### PR TITLE
Trac ticket #6438

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -679,7 +679,7 @@ abstract class Object {
 	public function __call($method, $arguments) {
 		// If the method cache was cleared by an an Object::add_extension() / Object::remove_extension()
 		// call, then we should rebuild it.
-		if(empty(self::$cached_statics[get_class($this)])) {
+		if(empty(self::$extra_methods[get_class($this)])) {
 			$this->defineMethods();
 		}
 		


### PR DESCRIPTION
This changes the check in Object::__call() that checks if the extra methods have been defined from checking against the cached statics to checking against the extra methods. I've only noticed this occurring when unserializing an object with extensions before that object is instigated normally.
