### PR TITLE
Fixes Call to a member function setValue() on a non-object in ConfirmedPasswordField

### DIFF
--- a/forms/ConfirmedPasswordField.php
+++ b/forms/ConfirmedPasswordField.php
@@ -187,7 +187,7 @@ class ConfirmedPasswordField extends FormField {
 			if($value['_Password'] || (!$value['_Password'] && !$this->canBeEmpty)) {
 				$this->value = $value['_Password'];
 			}
-			if(isset($value['_PasswordFieldVisible'])){
+			if($this->showOnClick && isset($value['_PasswordFieldVisible'])){
 				$this->children->fieldByName($this->Name() . '[_PasswordFieldVisible]')->setValue($value['_PasswordFieldVisible']);
 			}
 		} else {


### PR DESCRIPTION
Only try setting the value on _PasswordFieldVisible if showOnClick is set to true (ie, the field actually exists)
