### PR TITLE
Fixes #6578

### DIFF
--- a/admin/javascript/LeftAndMain.Tree.js
+++ b/admin/javascript/LeftAndMain.Tree.js
@@ -293,7 +293,7 @@
 		 */
 		getSelectedIDs: function() {
 			return $.map($(this).jstree('get_checked'), function(el, i) {return $(el).data('id');});
-		},
+		}
 	});
 	
 	$('#sitetree_ul li').entwine({


### PR DESCRIPTION
Fixes #6578. Checks if movedNode is in allowedChildren of newParent node before moving in tree.
Assumes that all nodes can have root node as parent.

[Ticket](http://open.silverstripe.org/ticket/6578)
