### PR TITLE
AjaxUniqueTextField is flagging a unique value when editing.

### DIFF
--- a/forms/AjaxUniqueTextField.php
+++ b/forms/AjaxUniqueTextField.php
@@ -21,6 +21,8 @@ class AjaxUniqueTextField extends TextField {
 		
 		$this->restrictedTable = $restrictedTable;
 
+
+                // We kinda need the ID of the page or DataObject, to exclude it in the validator function. Haven't found a better method yet.
                 $this->id = $id;
 		
 		$this->validateURL = $validationURL;
@@ -110,7 +112,9 @@ JS;
 	}
 
 function validate( $validator ) {
-
+                // Excluding the ID of the DataObject from the query, so the AjaxUnique is actually unique on this DataObject.
+                // Without excluding the ID itself, the count will always return 1 if the field itself hasn't changed. This means a "Not unique", even though it is.
+                // First thought was to make the result > 1, but that won't work sadly.
                 $result = DB::query(sprintf(
 			"SELECT COUNT(*) FROM \"%s\" WHERE \"%s\" = '%s' AND ID != '%d'",
 			$this->restrictedTable,


### PR DESCRIPTION
Fix for the currennt (Unique) value being flagged as false. The current ID is at position 5, for calling the AjaxUniqueTextField(), at position 5 aff $this->ID, so it's properly escaped in the validator.
A problem mentioned a few times in IRC as wel.
