### PR TITLE
Fixed Interfaces Which Extend Multiple Interfaces Not Being Loaded

### DIFF
--- a/core/manifest/ClassManifest.php
+++ b/core/manifest/ClassManifest.php
@@ -60,13 +60,7 @@ class SS_ClassManifest {
 		return new TokenisedRegularExpression(array(
 			0 => T_INTERFACE,
 			1 => T_WHITESPACE,
-			2 => array(T_STRING, 'can_jump_to' => 7, 'save_to' => 'interfaceName'),
-			3 => T_WHITESPACE,
-			4 => T_EXTENDS,
-			5 => T_WHITESPACE,
-			6 => array(T_STRING, 'save_to' => 'extends'),
-			7 => array(T_WHITESPACE, 'optional' => true),
-			8 => '{',
+			2 => array(T_STRING, 'save_to' => 'interfaceName')
 		));
 	}
 

--- a/tests/core/manifest/TokenisedRegularExpressionTest.php
+++ b/tests/core/manifest/TokenisedRegularExpressionTest.php
@@ -43,6 +43,10 @@ implements InterfaceA, InterfaceB {
 	
 }
 
+interface InterfaceC extends InterfaceA, InterfaceB {
+}
+interface InterfaceD extends InterfaceA, InterfaceB, InterfaceC {
+}
 ?>
 PHP
 );
@@ -88,8 +92,8 @@ PHP
 		if($matches) foreach($matches as $match) $interfaces[$match['interfaceName']] = $match;
 
 		$this->assertArrayHasKey('InterfaceA', $interfaces);
-
 		$this->assertArrayHasKey('InterfaceB', $interfaces);
-		$this->assertEquals('Something', $interfaces['InterfaceB']['extends']);
+		$this->assertArrayHasKey('InterfaceC', $interfaces);
+		$this->assertArrayHasKey('InterfaceD', $interfaces);
 	}
 }


### PR DESCRIPTION
The tokenised regular expression used to parse interface definitions only expects there to be a single interface it extends from. This means that interfaces which extend from multiple interfaces won't be matched or autoloaded, which is a pretty big issue.

This fix just removes the matching of the parent information - it's not used anywhere. I've included a test.
