### PR TITLE
Editing the /sapphire/email/mime.types file to allow Microsoft Office 2010 doc types

### DIFF
--- a/email/mime.types
+++ b/email/mime.types
@@ -10,7 +10,7 @@ application/mac-binhex40			hqx
 application/mac-compactpro			cpt
 application/mathematica				nb
 application/msaccess				mdb
-application/msword				doc dot
+application/msword				doc dot docx docm dotx dotm
 application/octet-stream			bin
 application/oda					oda
 application/ogg					ogg
@@ -29,10 +29,10 @@ application/xhtml+xml				xhtml xht
 application/xml					xml xsl
 application/zip					zip
 application/vnd.mozilla.xul+xml			xul
-application/vnd.ms-excel			xls xlb xlt
+application/vnd.ms-excel			xls xlb xlt xlsx xlsm xltx xltm xlsb xlam
 application/vnd.ms-pki.seccat			cat
 application/vnd.ms-pki.stl			stl
-application/vnd.ms-powerpoint			ppt pps
+application/vnd.ms-powerpoint			ppt pps pptx pptm potx potm ppam ppsx ppsm sldx sldm thmx
 application/vnd.oasis.opendocument.chart	odc
 application/vnd.oasis.opendocument.database	odb
 application/vnd.oasis.opendocument.formula	odf


### PR DESCRIPTION
Editing the /sapphire/email/mime.types file to allow Microsoft Office 2010 file extensions which were not previously in this file. This prevented these files from being sent as attachments on emails. I have added in the basic extensions of .docx, .pptx, .xlsx but also the additional extensions that Office 2010 have from this page - http://office.microsoft.com/en-us/help/introduction-to-new-file-name-extensions-HA010006935.aspx#BM1

I have no idea if the macro enabled file extensions like .xltm or .docm pose a security threat, but thought that if I was adding the basic types in I should add the others as well. I'll let someone else decide this as I have no idea :)

This is the first time I have done this so hope I have done it okay.

Cheers,
Colin
@ccburns
