### PR TITLE
Removal of ereg_replace from ManifestBuilder

### DIFF
--- a/core/ManifestBuilder.php
+++ b/core/ManifestBuilder.php
@@ -307,7 +307,7 @@ class ManifestBuilder {
 			if(@is_dir("$folder/$item") && file_exists("$folder/$item/_manifest_exclude")) continue;
 
 			// i18n: ignore language files (loaded on demand)
-			if($item == 'lang' && @is_dir("$folder/$item") && ereg_replace("/[^/]+/\\.\\.","",$folder.'/..') == Director::baseFolder()) continue;
+            if ($item == 'lang' && @is_dir("$folder/lang") && rtrim(dirname($folder), DIRECTORY_SEPARATOR) == Director::baseFolder()) { continue; }
 
 			if(@is_dir("$folder/$item")) {
 				// Folder exclusion - used to skip over tests/ folders


### PR DESCRIPTION
Removed reference to ereg_replace to fix issue with 2.4 running on PHP 5.3.

The issue I had is that, when the warnings for this deprecated function are shown, the $_SESSION variable appears to be empty.  This stops you from being able to run things like dev/build, which need to access the current logged in user for authorization.
