### PR TITLE
Rewrite documentation of Breadcrumbs to conform to actual behaviour

### DIFF
--- a/docs/en/reference/built-in-page-controls.md
+++ b/docs/en/reference/built-in-page-controls.md
@@ -93,7 +93,7 @@ limit the number of items in the breadcrumbs, as well as whether the breadcrumb 
 
 ####  $Breadcrumbs(3)
 
-This returns a maximum of 3 pages in the breadcrumb list, which can be handy if you wanting to limit the size of your
+This returns a maximum of 3 pages in the breadcrumb list, which can be handy if you want to limit the size of your
 breadcrumbs to conform to your page design.
 
 ####  <% control Breadcrumbs(3, true) %>


### PR DESCRIPTION
MINOR: Rewrite documentation of Breadcrumbs to conform to actual behaviour of SiteTree

The documentation referred to <% control Breadcrumbs %>, but the actual Breadcrumbs method returns a string.
