### PR TITLE
Fix tab index on textarea fields.

### DIFF
--- a/forms/TextareaField.php
+++ b/forms/TextareaField.php
@@ -52,7 +52,6 @@ class TextareaField extends FormField {
 				'id' => $this->id(),
 				'class' => 'readonly' . ($this->extraClass() ? $this->extraClass() : ''),
 				'name' => $this->name,
-				'tabindex' => $this->getTabIndex(),
 				'readonly' => 'readonly'
 			);
 


### PR DESCRIPTION
Fix tabindex being present on read-only textarea form fields instead of regular ones.
