### PR TITLE
Check the extraStatics method exists before running it.

### DIFF
--- a/model/DataExtension.php
+++ b/model/DataExtension.php
@@ -61,6 +61,9 @@ abstract class DataExtension extends Extension {
 		
 		// If the extension has been manually applied to a subclass, we should ignore that.
 		if(Object::has_extension(get_parent_class($class), $extensionClass)) return;
+
+		// If there aren't any extraStatics we shouldn't try to load them.
+		if ( ! method_exists($extensionClass, $extraStaticsMethod) ) return;
 		
 		$statics = call_user_func(array($extensionClass, $extraStaticsMethod), $class, $extension);
 		


### PR DESCRIPTION
This class attempts to run the extraStatics method without first checking it exists. There's no reason why a data object decorator would necessarily add extra statics.
