### PR TITLE
MINOR: Fixed DateTest to work on Centos installation with another default

### DIFF
--- a/tests/model/DateTest.php
+++ b/tests/model/DateTest.php
@@ -10,14 +10,23 @@ class DateTest extends SapphireTest {
 	function setUp() {
 		// Set timezone to support timestamp->date conversion.
 		// We can't use date_default_timezone_set() as its not supported prior to PHP 5.2
-		$this->originalTZ = ini_get('date.timezone');
-		ini_set('date.timezone','Pacific/Auckland');
 		
+		if (version_compare(PHP_VERSION, '5.2.0', '<')) {
+			$this->originalTZ = ini_get('date.timezone');
+			ini_set('date.timezone', 'Pacific/Auckland');
+		} else {
+			$this->originalTZ = date_default_timezone_get();
+			date_default_timezone_set('Pacific/Auckland');
+		}
 		parent::setUp();
 	}
 	
 	function tearDown() {
-		ini_set('date.timezone',$this->originalTZ);
+        if(version_compare(PHP_VERSION, '5.2.0', '<') ){
+			ini_set('date.timezone',$this->originalTZ);
+        } else {
+            date_default_timezone_set($this->originalTZ);
+        }
 		
 		parent::tearDown();
 	}


### PR DESCRIPTION
MINOR: Fixed DateTest to work on Centos installation with another default date.timezone than Pacific/Auckland

Checking for PHP version and using the correct function for setting timezone

This could most likely be confirmed by running ./sapphire/sake dev/tests/all
