### PR TITLE
fixing random changing of access tab radio buttons when refreshing the CMS

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -6,7 +6,18 @@
 	$.metadata.setType('html5');
 	
 	$.entwine('ss', function($){
-		
+
+		/**
+		 * Turn off autocomplete to fix the access tab randomly switching radio buttons in Firefox
+		 * when refresh the page with an anchor tag in the URL. E.g: /admin#Root_Access.
+		 * Autocomplete in the CMS also causes strangeness in other browsers,
+		 * filling out sections of the form that the user does not want to be filled out,
+		 * so this turns it off for all browsers.
+		 * See the following page for demo and explanation of the Firefox bug:
+		 *  http://www.ryancramer.com/journal/entries/radio_buttons_firefox/
+		 */
+		$("#Form_EditForm").attr("autocomplete", "off");
+
 		/**
 		 * Position the loading spinner animation below the ss logo
 		 */ 


### PR DESCRIPTION
BUGFIX: fixing random changing of access tab radio buttons when refreshing the CMS with a URL such as /admin/page/settings/show/1#Root_Access in Firefox
