### PR TITLE
Cookie::forceExpiry() do not delete the cookie

### DIFF
--- a/control/Cookie.php
+++ b/control/Cookie.php
@@ -43,7 +43,8 @@ class Cookie {
 	
 	static function forceExpiry( $name ) {
 		if(!headers_sent($file, $line)) {
-			setcookie( $name, null, time() - 86400 );
+			//setcookie( $name, null, time() - 86400 );
+			self::set($name, null, -20);
 		}
 	}
 	


### PR DESCRIPTION
Cookie is not deleted because the cookie path and domain differ if you use the Cookie::forceExpiry() method.
