### PR TITLE
Spelling correction in sapphire documentation

### DIFF
--- a/api/RestfulService.php
+++ b/api/RestfulService.php
@@ -297,7 +297,7 @@ class RestfulService extends ViewableData {
 	
 	/**
  	* Gets set of node values as an array. 
- 	* When you get to the depth in the hierachchy use node_child_subchild syntax to get the value.
+ 	* When you get to the depth in the hierarchy use node_child_subchild syntax to get the value.
  	* @param string $xml The the source xml to parse, this could be the original response received.
  	* @param string $collection The name of parent node which wraps the elements, if available
  	* @param string $element The element we need to extract the node values.

--- a/core/Object.php
+++ b/core/Object.php
@@ -22,7 +22,7 @@ abstract class Object {
 	 * Example:
 	 * <code>
 	 * public static $extensions = array (
-	 *   'Hierachy',
+	 *   'Hierarchy',
 	 *   "Version('Stage', 'Live')"
 	 * );
 	 * </code>

--- a/docs/en/changelogs/2.2.0.md
+++ b/docs/en/changelogs/2.2.0.md
@@ -195,8 +195,8 @@ Sitemap.php
           * Added crop()
           * Added getWidth()
           * Added getHeight()
-      * Hierachy
-          * Versioned now automatically add suffixes, so Hierachy no longer needs to
+      * Hierarchy
+          * Versioned now automatically add suffixes, so Hierarchy no longer needs to
       * HTTP
           * Added register_modification_timestamp()
           * Added register_etag()

--- a/docs/en/changelogs/2.3.0.md
+++ b/docs/en/changelogs/2.3.0.md
@@ -602,7 +602,7 @@ See http://open.silverstripe.com/changeset/69688
  * ![rev:67299] Changed Director::test($this->URLSegment) to Director::test($this->Link()) in ErrorPage->publish() to be more robust
  * ![rev:67290] Added parent::setUp() and parent::tearDown() calls to various tests, in preparation for push/pop a mock controller the controller-stack
  * ![rev:67271] dev/build should function even when new classes are referenced in _config.php
- * ![rev:67268] Filter on the baseclassid in Hierachy, not the class id, in case the class doesnt have a table (aoneil)
+ * ![rev:67268] Filter on the baseclassid in Hierarchy, not the class id, in case the class doesnt have a table (aoneil)
  * ![rev:67221] Save default locale for new members, so the profile form doesn't show first available locale in dropdown because its defaults are overwritten by Member->Locale = NULL (see #3159)
  * ![rev:67201] Declared behaviour.js variables as local for better recursive functionality
  * ![rev:67199] Fixed incorrect permission checking when the current member isn't being used

--- a/docs/en/changelogs/alpha/2.4.0-alpha1.md
+++ b/docs/en/changelogs/alpha/2.4.0-alpha1.md
@@ -309,9 +309,9 @@
  * [rev:88499] Refactored ModelAsController to only grab the first page of a request, then pass control on to it. From: Andrew Short
  * [rev:88491] #3279: Updated the link inserter to insert a shortcode rather than a plain HTML link. From: Andrew Short
  * [rev:88489] Updated the SiteTree link and section code to derive data from the current page, rather than relying on its own cache.
- * [rev:88488] Added Hierachy->getAncestors() to return all the parent objects of the class in a DataObjectSet. From: Andrew Short
+ * [rev:88488] Added Hierarchy->getAncestors() to return all the parent objects of the class in a DataObjectSet. From: Andrew Short
  * [rev:88487] Update ContentController to manually set the current Director page in handleRequest().
- * [rev:88482] Refactored TreeDropdownField to generate and manage the tree using Hierachy's ParentID data, rather than relying on the client. From: Andrew Short
+ * [rev:88482] Refactored TreeDropdownField to generate and manage the tree using Hierarchy's ParentID data, rather than relying on the client. From: Andrew Short
  * [rev:88480] Added ErrorPage::response_for() to get a response for a HTTP error code and request.
  * [rev:88479] Added ModelAsController::controller_for() to link a SiteTree object to its controller. From: Andrew Short
  * [rev:88478] Added HTTPRequest->isMedia() to check if a request is for a common media type. From: Andrew Short

--- a/model/Hierarchy.php
+++ b/model/Hierarchy.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * DataObjects that use the Hierachy extension can be be organised as a hierachy, with children and parents.
+ * DataObjects that use the Hierarchy extension can be be organised as a hierarchy, with children and parents.
  * The most obvious example of this is SiteTree.
  * @package sapphire
  * @subpackage model


### PR DESCRIPTION
Found and fixed all misspellings of "[Hh]ierarchy"
