### PR TITLE
API CHANGE Childclasses to SS_List matches the same signature on abstract

### DIFF
--- a/model/ArrayList.php
+++ b/model/ArrayList.php
@@ -155,7 +155,7 @@ class ArrayList extends ViewableData implements SS_List {
 		return end($this->items);
 	}
 
-	public function map($keyfield, $titlefield) {
+	public function map($keyfield = 'ID', $titlefield = 'Title') {
 		$map = array();
 		foreach ($this->items as $item) {
 			$map[$this->extractValue($item, $keyfield)] = $this->extractValue($item, $titlefield);

--- a/model/List.php
+++ b/model/List.php
@@ -67,7 +67,7 @@ interface SS_List extends ArrayAccess, Countable, IteratorAggregate {
 	 * @param  string $titlefield
 	 * @return array
 	 */
-	public function map($keyfield, $titlefield);
+	public function map($keyfield = 'ID', $titlefield = 'Title');
 
 	/**
 	 * Returns the first item in the list where the key field is equal to the
@@ -85,7 +85,7 @@ interface SS_List extends ArrayAccess, Countable, IteratorAggregate {
 	 * @param  string $field
 	 * @return array
 	 */
-	public function column($field);
+	public function column($colName = "ID");
 
 	/**
 	 * Returns TRUE if the list can be sorted by a field.


### PR DESCRIPTION
API CHANGE Childclasses to SS_List matches the same signature on abstract methods column and map.

This was failing with PHP 5.2

Either we change the DataList to not have default values in the signature, or we change the abstract method in SS_List.. 
