### PR TITLE
fixes to Image->deleteFormattedImages() [corrected]

### DIFF
--- a/core/model/Image.php
+++ b/core/model/Image.php
@@ -335,7 +335,7 @@ class Image extends File {
 		if(!$this->Filename) return 0;
 		
 		$numDeleted = 0;
-		$methodNames = $this->allMethodNames();
+		$methodNames = $this->allMethodNames(true);
 		$cachedFiles = array();
 		
 		$folder = $this->ParentID ? $this->Parent()->Filename : ASSETS_DIR . '/';


### PR DESCRIPTION
Resubmitting to correct branch (was master; is 2.4).

This fixes 2 issues with Image->deleteFormattedImages():
1. The name inserted into a pattern for preg_match needs to be preg_quoted.
2. The search for image-generating methods does not take extensions/decorators into account.
