### PR TITLE
FulltextSearch to switch to MyISAM

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -97,10 +97,6 @@ class File extends DataObject {
 		"Hierarchy",
 	);
 	
-	static $create_table_options = array(
-		'MySQLDatabase' => 'ENGINE=MyISAM'
-	);
-	
 	/**
 	 * @var array List of allowed file extensions, enforced through {@link validate()}.
 	 * 

--- a/search/FulltextSearchable.php
+++ b/search/FulltextSearchable.php
@@ -50,6 +50,7 @@ class FulltextSearchable extends DataExtension {
 			
 			if(isset($defaultColumns[$class])) {
 				Object::add_extension($class, "FulltextSearchable('{$defaultColumns[$class]}')");
+				Object::add_static_var($class, 'create_table_options', array('MySQLDatabase' => 'ENGINE=MyISAM'));
 			} else {
 				throw new Exception("FulltextSearchable::enable() I don't know the default search columns for class '$class'");
 			}


### PR DESCRIPTION
FulltextSearch::enable() now sets create_table_options on each search class, rather than having it always enabled.
