### PR TITLE
BUGFIX: Removes duplicate create_table_options that caused preg_match() t

### DIFF
--- a/search/FulltextSearchable.php
+++ b/search/FulltextSearchable.php
@@ -53,7 +53,6 @@ class FulltextSearchable extends DataExtension {
 					Object::add_static_var($class, 'create_table_options', array('MySQLDatabase' => 'ENGINE=MyISAM'), true);
 				}
 				Object::add_extension($class, "FulltextSearchable('{$defaultColumns[$class]}')");
-				Object::add_static_var($class, 'create_table_options', array('MySQLDatabase' => 'ENGINE=MyISAM'));
 			} else {
 				throw new Exception("FulltextSearchable::enable() I don't know the default search columns for class '$class'");
 			}


### PR DESCRIPTION
BUGFIX: Removes duplicate create_table_options that caused preg_match() to fail in PHP 5.2.
