### PR TITLE
BUGFIX Deprecation class throws notice on PHP 5.2

### DIFF
--- a/dev/Deprecation.php
+++ b/dev/Deprecation.php
@@ -26,11 +26,22 @@
  * When set per-module, only direct calls to deprecated methods from those modules are considered - if the module
  * calls a non-module method which then calls a deprecated method, that call will use the global check version, not
  * the module specific check version.
+ *
+ * @package sapphire
+ * @subpackage dev
  */
 class Deprecation {
 
+	/**
+	 *
+	 * @var string
+	 */
 	protected static $version;
 
+	/**
+	 *
+	 * @var array
+	 */
 	protected static $module_version_overrides = array();
 
 	/**
@@ -92,7 +103,7 @@ class Deprecation {
 		$level = (int)$level;
 		if(!$level) $level = 1;
 		$called = $backtrace[$level];
-		
+
 		if (isset($called['class'])) {
 			return $called['class'] . $called['type'] . $called['function'];
 		}
@@ -104,7 +115,7 @@ class Deprecation {
 	/**
 	 * Raise a notice indicating the method is deprecated if the version passed as the second argument is greater
 	 * than or equal to the check version set via ::notification_version
-	 * 
+	 *
 	 * @static
 	 * @param $string - The notice to raise
 	 * @param $atVersion - The version at which this notice should start being raised
@@ -167,5 +178,4 @@ class Deprecation {
 		self::$version = $settings['version'];
 		self::$module_version_overrides = $settings['moduleVersions'];
 	}
-
 }


### PR DESCRIPTION
Checks on constants must be within quotes.
