### PR TITLE
Update thirdparty/prototype/prototype.js

### DIFF
--- a/thirdparty/prototype/prototype.js
+++ b/thirdparty/prototype/prototype.js
@@ -780,10 +780,10 @@ Ajax.Request.prototype = Object.extend(new Ajax.Base(), {
 
       /* Force "Connection: close" for Mozilla browsers to work around
        * a bug where XMLHttpReqeuest sends an incorrect Content-length
-       * header. See Mozilla Bugzilla #246651.
+       * header. See Mozilla Bugzilla #246651. update: causes "connection refused" error in chrome.  246651 is now fixed.
        */
-      if (this.transport.overrideMimeType)
-        requestHeaders.push('Connection', 'close');
+      //if (this.transport.overrideMimeType)
+      //  requestHeaders.push('Connection', 'close');
     }
 
     if (this.options.requestHeaders)


### PR DESCRIPTION
This fix for old firefox is causing error "Connection refused" in chrome.  sugest removing it.  JS errrors scare users and its not clear if it's contributing to other bugs. 
