### PR TITLE
BUGFIX Make StringFields more multibyte aware.

### DIFF
--- a/model/fieldtypes/HTMLText.php
+++ b/model/fieldtypes/HTMLText.php
@@ -24,18 +24,7 @@ class HTMLText extends Text {
 	 * @return string
 	 */
 	function LimitCharacters($limit = 20, $add = "...") {
-		$value = trim(strip_tags($this->value));
-		
-		// Content html text to plan text before sub string-ing
-		// to cutting off part of the html entity character
-		// For example, &amp; because &am
-		$value = html_entity_decode($value, ENT_COMPAT, 'UTF-8');
-		$value = (strlen($value) > $limit) ? substr($value, 0, $limit) . $add : $value;
-		
-		// Convert plan text back to html entities 
-		$value = htmlentities($value, ENT_COMPAT, 'UTF-8');
-		
-		return $value;
+		return $this->doLimitCharacters($limit, $add, true);
 	}
 
 	/**

--- a/model/fieldtypes/HTMLVarchar.php
+++ b/model/fieldtypes/HTMLVarchar.php
@@ -25,7 +25,11 @@ class HTMLVarchar extends Varchar {
 	public function scaffoldSearchField($title = null) {
 		return new TextField($this->name, $title);
 	}
-
+	
+	function LimitCharacters($limit = 20, $add = "...") {
+		return $this->doLimitCharacters($limit, $add, true);
+	}
+	
 }
 
 ?>

--- a/model/fieldtypes/StringField.php
+++ b/model/fieldtypes/StringField.php
@@ -73,20 +73,49 @@ abstract class StringField extends DBField {
 			return parent::prepValueForDB($value);
 		}
 	}
-
+	
+	protected function doLimitCharacters($limit, $add, $html) {
+		$value = trim($this->value);
+		if ($html) {
+			$value = strip_tags($value);
+			$value = html_entity_decode($value, ENT_COMPAT, 'UTF-8');
+			$value = (mb_strlen($value) > $limit) ?
+				mb_substr($value, 0, $limit) . $add : $value;
+			// Avoid encoding all multibyte characters as HTML entities by
+			// using htmlspecialchars().
+			$value = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
+		} else {
+			$value = (mb_strlen($value) > $limit) ?
+				mb_substr($value, 0, $limit) . $add : $value;
+		}
+		return $value;
+	}
+	
+	/**
+	 * Limit this field's content by a number of characters.
+	 * CAUTION: Does not take into account HTML tags, so it
+	 * has the potential to return malformed HTML.
+	 *
+	 * @param int $limit Number of characters to limit by
+	 * @param string $add Ellipsis to add to the end of truncated string
+	 * @return string
+	 */
+	function LimitCharacters($limit = 20, $add = "...") {
+		return $this->doLimitCharacters($limit, $add, false);
+	}
 	
 	/**
 	 * Return another DBField object with this value in lowercase.
 	 */
 	function Lower() {
-		return DBField::create(get_class($this), strtolower($this->value), $this->name);
+		return DBField::create(get_class($this), mb_strtolower($this->value), $this->name);
 	}
 
 	/**
 	 * Return another DBField object with this value in uppercase.
 	 */
 	function Upper() {
-		return DBField::create(get_class($this), strtoupper($this->value), $this->name);
+		return DBField::create(get_class($this), mb_strtoupper($this->value), $this->name);
 	}
 
 }

--- a/model/fieldtypes/Text.php
+++ b/model/fieldtypes/Text.php
@@ -78,20 +78,6 @@ class Text extends StringField {
 	}
 	
 	/**
-	 * Limit this field's content by a number of characters.
-	 * CAUTION: Does not take into account HTML tags, so it
-	 * has the potential to return malformed HTML.
-	 *
-	 * @param int $limit Number of characters to limit by
-	 * @param string $add Ellipsis to add to the end of truncated string
-	 * @return string
-	 */
-	function LimitCharacters($limit = 20, $add = "...") {
-		$value = trim($this->value);
-		return (strlen($value) > $limit) ? substr($value, 0, $limit) . $add : $value;
-	}
-	
-	/**
 	 * Limit the number of words of the current field's
 	 * content. This is XML safe, so characters like &
 	 * are converted to &amp;
@@ -159,9 +145,10 @@ class Text extends StringField {
 			return "";
 		
 		// grab the first paragraph, or, failing that, the whole content
-		if( strpos( $data, "\n\n" ) )
-			$data = substr( $data, 0, strpos( $data, "\n\n" ) );
-			
+		$pos = strpos( $data, "\n\n" );
+		if( $pos )
+			$data = substr( $data, 0, $pos );
+		
 		$sentences = explode( '.', $data );	
 		
 		$count = count( explode( ' ', $sentences[0] ) );
@@ -241,8 +228,9 @@ class Text extends StringField {
 			if( !$data ) return "";
 		
 			// grab the first paragraph, or, failing that, the whole content
-			if( strpos( $data, "\n\n" ) )
-				$data = substr( $data, 0, strpos( $data, "\n\n" ) );
+			$pos = strpos( $data, "\n\n" );
+			if( $pos )
+				$data = substr( $data, 0, $pos );
 
 			return $data;
 		

--- a/model/fieldtypes/Varchar.php
+++ b/model/fieldtypes/Varchar.php
@@ -69,18 +69,7 @@ class Varchar extends StringField {
 	function RTF() {
 		return str_replace("\n", '\par ', $this->value);
 	}
-
-	/**
-	 * Returns the value of the string, limited to the specified number of characters
-	 * @param $limit int Character limit
-	 * @param $add string Extra string to add to the end of the limited string
-	 * @return string
-	 */
-	function LimitCharacters($limit = 20, $add = "...") {
-		$value = trim($this->value);
-		return (strlen($value) > $limit) ? substr($value, 0, $limit) . $add : $value;
-	}
-
+	
 	/**
 	 * (non-PHPdoc)
 	 * @see DBField::scaffoldFormField()

--- a/tests/model/DBFieldTest.php
+++ b/tests/model/DBFieldTest.php
@@ -192,6 +192,31 @@ class DBFieldTest extends SapphireTest {
 		$textField->setValue(null);
 		$this->assertFalse($textField->hasValue());
 	}
+	
+	function testStringFieldsWithMultibyteData() {
+		$plainFields = array('Varchar', 'Text');
+		$htmlFields = array('HTMLVarchar', 'HTMLText');
+		$allFields = array_merge($plainFields, $htmlFields);
+		
+		$value = 'üåäöÜÅÄÖ';
+		foreach ($allFields as $stringField) {
+			$stringField = DBField::create($stringField, $value);
+			for ($i = 1; $i < mb_strlen($value); $i++) {
+				$expected = mb_substr($value, 0, $i) . '...';
+				$this->assertEquals($expected, $stringField->LimitCharacters($i));
+			}
+		}
+		
+		$value = '<p>üåäö&amp;ÜÅÄÖ</p>';
+		foreach ($htmlFields as $stringField) {
+			$stringField = DBField::create($stringField, $value);
+			$this->assertEquals('üåäö&amp;ÜÅÄ...', $stringField->LimitCharacters(8));
+		}
+		
+		$this->assertEquals('ÅÄÖ', DBField::create('Text', 'åäö')->Upper()->getValue());
+		$this->assertEquals('åäö', DBField::create('Text', 'ÅÄÖ')->Lower()->getValue());
+	}
+	
 }
 
 ?>


### PR DESCRIPTION
These are fixes for problems I have encountered when using StringFields with multibyte data. I have also tried to clean up the API slightly by moving the implementation of LimitCharacters to StringField and have its subclasses use it instead of re-implementing the functionality.
