### PR TITLE
MINOR Change error reporting level to explicitly exclude values rather t...

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -250,8 +250,8 @@ SS_TemplateLoader::instance()->pushManifest(new SS_TemplateManifest(
 // This is necessary to force developers to acknowledge and fix
 // notice level errors (you can override this directive in your _config.php)
 if (Director::isLive()) {
-	if(defined('E_DEPRECATED')) error_reporting((E_ALL ^ E_NOTICE) ^ E_DEPRECATED);
-	else error_reporting(E_ALL ^ E_NOTICE);
+	if(defined('E_DEPRECATED')) error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT | E_NOTICE));
+	else error_reporting(E_ALL & ~E_NOTICE);
 }
 ///////////////////////////////////////////////////////////////////////////////
 // POST-MANIFEST COMMANDS


### PR DESCRIPTION
...han using XOR.

E_STRICT is also excluded as it is included in E_ALL as of PHP 5.4.
