### PR TITLE
BUGFIX double requirements

### DIFF
--- a/core/Requirements.php
+++ b/core/Requirements.php
@@ -636,7 +636,7 @@ class Requirements_Backend {
 	function includeInHTML($templateFile, $content) {
 		if(isset($_GET['debug_profile'])) Profiler::mark("Requirements::includeInHTML");
 		
-		if(strpos($content, '</head') !== false && ($this->css || $this->javascript || $this->customCSS || $this->customScript || $this->customHeadTags)) {
+		if((strpos($content, '</head>') !== false || strpos($content, '</head ') !== false) && ($this->css || $this->javascript || $this->customCSS || $this->customScript || $this->customHeadTags)) {
 			$requirements = '';
 			$jsRequirements = '';
 			


### PR DESCRIPTION
BUGFIX Having <header tag in HTML causes requirements to double. See http://www.silverstripe.org/general-questions/show/17524
