### PR TITLE
Currently, the time format does not allow differentiate the AM/PM hours ...

### DIFF
--- a/dev/LogErrorFileFormatter.php
+++ b/dev/LogErrorFileFormatter.php
@@ -35,7 +35,7 @@ class SS_LogErrorFileFormatter implements Zend_Log_Formatter_Interface {
 			$urlSuffix = " (http://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI])";
 		}
 
-		return '[' . date('d-M-Y h:i:s') . "] $errtype at $relfile line $errline: $errstr$urlSuffix" . PHP_EOL;
+		return '[' . date('d-M-Y H:i:s') . "] $errtype at $relfile line $errline: $errstr$urlSuffix" . PHP_EOL;
 	}
 
 }


### PR DESCRIPTION
...since the format choosen is 12h and no AM/PM label is added to each log line. So, my suggestion is to convert to 24h format (using a H instead of h) to fix this issue.

More details, see PHP date function doc - http://php.net/manual/en/function.date.php
