### PR TITLE
Deprecate Director::set_dev_servers() and Director::set_test_servers()

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -773,9 +773,11 @@ class Director {
 	 * we recommend to set this mode via {@link Director::set_environment_type()}
 	 * or an _ss_environment.php instead.
 	 * 
+	 * @deprecated 3.0 Use Director::set_environment_type() or an _ss_environment.php instead.
 	 * @param $servers array An array of HTTP_HOST values that should be treated as development environments.
 	 */
 	static function set_dev_servers($servers) {
+		Deprecation::notice('3.0', 'Use Director::set_environment_type() or an _ss_environment.php instead.');
 		Director::$dev_servers = $servers;
 	}
 	
@@ -787,9 +789,11 @@ class Director {
 	 * we recommend to set this mode via {@link Director::set_environment_type()}
 	 * or an _ss_environment.php instead.
 	 * 
+	 * @deprecated 3.0 Use Director::set_environment_type() or an _ss_environment.php instead.
 	 * @param $servers array An array of HTTP_HOST values that should be treated as test environments.
 	 */
 	static function set_test_servers($servers) {
+		Deprecation::notice('3.0', 'Use Director::set_environment_type() or an _ss_environment.php instead.');
 		Director::$test_servers = $servers;
 	}
 


### PR DESCRIPTION
As there's already a big CAUTION in the docblock for the methods, and setting the environment based on HTTP_HOST is a rather bad idea, I move that these methods be formally deprecated in favour of Director::set_environment_type() or an _ss_environment.php file.
