### PR TITLE
Allowed the fixture to overwrite the LastEdited field on an object

### DIFF
--- a/dev/YamlFixture.php
+++ b/dev/YamlFixture.php
@@ -228,6 +228,12 @@ class YamlFixture extends Object {
 				}
 			}
 			$obj->write();
+            //If LastEdited was set in the fixture, set it here
+            if (array_key_exists('LastEdited', $fields)) {
+                $manip = array($dataClass => array("command" => "update", "id" => $obj->id,
+                    "fields" => array("LastEdited" => $this->parseFixtureVal($fields['LastEdited']))));
+                DB::manipulate($manip);
+            }
 		}
 	}
 	


### PR DESCRIPTION
Ran into this problem while doing tests.
This patch works on 2.4, so it should work on the current HEAD.
