### PR TITLE
SS_ListDecorator bad argument forwarding on wrapper methods

### DIFF
--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -50,8 +50,8 @@ class SSViewer_Scope {
 		array_splice($this->itemStack, $this->localIndex+1);
 	}
 	
-	function obj($name, $arguments = array()) {
-
+	function obj($name){
+		
 		switch ($name) {
 			case 'Up':
 				list($this->item, $this->itemIterator, $unused2, $this->upIndex, $this->currentIndex) = $this->itemStack[$this->upIndex];
@@ -63,9 +63,10 @@ class SSViewer_Scope {
 			
 			default:
 				$on = $this->itemIterator ? $this->itemIterator->current() : $this->item;
-
-				$this->item = call_user_func_array(array($on, 'obj'), (array) $arguments);
-
+				
+				$arguments = func_get_args();
+				$this->item = call_user_func_array(array($on, 'obj'), $arguments);
+				
 				$this->itemIterator = null;
 				$this->upIndex = $this->currentIndex ? $this->currentIndex : count($this->itemStack)-1;
 				$this->currentIndex = count($this->itemStack);


### PR DESCRIPTION
Currently `$myDecoratedList->filter('Bla', 2)` will call `$internalList->filter(array('Bla', 2))`

(Ignore commit 3a9ea42 and 82ef236. My first thought was that the problem is located at SSViewer_Scope :p)
