### PR TITLE
Post-2.4 bugfix: Bulkloader relation

### DIFF
--- a/QI-notes.txt
+++ b/QI-notes.txt
@@ -1,0 +1,11 @@
+Gitflow stanzas for git config:
+
+[gitflow "branch"]
+	master = qi-production
+	develop = post-2.4
+[gitflow "prefix"]
+	feature = feature/
+	release = release/
+	hotfix = hotfix/
+	support = support/
+	versiontag = 

--- a/dev/BulkLoader.php
+++ b/dev/BulkLoader.php
@@ -142,11 +142,9 @@ abstract class BulkLoader extends ViewableData {
 		if ($this->deleteExistingRecords) {
 			$q = singleton($this->objectClass)->buildSQL();
 			if (!empty($this->objectClass)) {
-
 				$idSelector = $this->objectClass . '."ID"';
 			}
 			else {
-
 				$idSelector = '"ID"';
 			}
 			$q->select = array($idSelector);


### PR DESCRIPTION
This is a nicely formatted version of the fix given at http://open.silverstripe.org/ticket/6472

It fixes an ambiguity in the name of the ID field when importing a class that has a relationship.
