### PR TITLE
Use corrected function name from silverstripe-cms project

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -540,7 +540,7 @@ class LeftAndMain extends Controller {
 		
 		// NOTE: SiteTree/CMSMain coupling :-(
 		if(class_exists('SiteTree')) {
-			SiteTree::prepopuplate_permission_cache('CanEditType', $obj->markedNodeIDs(), 'SiteTree::can_edit_multiple');
+			SiteTree::prepopulate_permission_cache('CanEditType', $obj->markedNodeIDs(), 'SiteTree::can_edit_multiple');
 		}
 
 		// getChildrenAsUL is a flexible and complex way of traversing the tree


### PR DESCRIPTION
The CMS project had a function named "SiteTree::prepopuplate_permission_cache" which
should be "SiteTree::prepopulate_permission_cache".  Since another commit corrected
the function name in that project, this project needs to use the new name.

See https://github.com/silverstripe/silverstripe-cms/pull/51 for the master pull request where the function was actually renamed.
