### PR TITLE
Allow different homepage url

### DIFF
--- a/core/control/RootURLController.php
+++ b/core/control/RootURLController.php
@@ -54,6 +54,16 @@ class RootURLController extends Controller {
 	}
 	
 	/**
+	 * Set the URL Segment used for your homepage when it is created by dev/build.
+	 * This allows you to use home page URLs other than the default "home".
+	 *
+	 * @param string $urlsegment the URL segment for your home page
+	 */
+	public static function set_default_homepage_link($urlsegment = "home") {
+		self::$default_homepage_link = $urlsegment;
+	}
+
+	/**
 	 * Gets the link that denotes the homepage if there is not one explicitly defined for this HTTP_HOST value.
 	 *
 	 * @return string

--- a/core/model/SiteTree.php
+++ b/core/model/SiteTree.php
@@ -180,9 +180,9 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	
 	/**
 	 * @see SiteTree::set_create_defaultpages()
-	*/
+	 */
 	private static $create_default_pages = true;
-	
+
 	/**
 	 * This controls whether of not extendCMSFields() is called by getCMSFields.
 	 */
@@ -231,7 +231,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public static function set_create_default_pages($option = true) {
 		self::$create_default_pages = $option;
 	}
-	
+
 	/**
 	 * Fetches the {@link SiteTree} object that maps to a link.
 	 *
@@ -618,8 +618,8 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
  			&& (!$maxDepth || sizeof($parts) < $maxDepth) 
  			&& (!$stopAtPageType || $page->ClassName != $stopAtPageType)
  		) {
-			if($showHidden || $page->ShowInMenus || ($page->ID == $this->ID)) { 
-				if($page->URLSegment == 'home') $hasHome = true;
+			if($showHidden || $page->ShowInMenus || ($page->ID == $this->ID)) {
+				$title = $this->getBreadcrumbTitle($page);
 				if(($page->ID == $this->ID) || $unlinked) {
 				 	$parts[] = Convert::raw2xml($page->Title);
 				} else {
@@ -1287,11 +1287,11 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		
 		// default pages
 		if($this->class == 'SiteTree' && self::$create_default_pages) {
-			if(!SiteTree::get_by_link('home')) {
+			if(!SiteTree::get_by_link(RootURLController::get_default_homepage_link())) {
 				$homepage = new Page();
 				$homepage->Title = _t('SiteTree.DEFAULTHOMETITLE', 'Home');
 				$homepage->Content = _t('SiteTree.DEFAULTHOMECONTENT', '<p>Welcome to SilverStripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>. You can now access the <a href="http://doc.silverstripe.org">developer documentation</a>, or begin <a href="http://doc.silverstripe.org/doku.php?id=tutorials">the tutorials.</a></p>');
-				$homepage->URLSegment = 'home';
+				$homepage->URLSegment = RootURLController::get_default_homepage_link();
 				$homepage->Status = 'Published';
 				$homepage->Sort = 1;
 				$homepage->write();


### PR DESCRIPTION
If you changed the URL segment for your homepage to anything other than 'home'
a new homepage would be created every time you ran a dev/build.  This commit
allows you to call RootURLController::set_default_homepage_link('something');
to change the URL segment for your homepage to 'something'.  After doing this
the dev/build process will no longer create a homepage if you already have a
page with 'something' as the URL segment.

There was a discussion of needing this at
http://www.silverstripe.org/general-questions/show/12253
