### PR TITLE
6782: Button overflow contained to max 100%

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -570,6 +570,7 @@ li.class-ErrorPage > a .jstree-pageicon { background-position: 0 -112px; }
 .ModelAdmin .cms-content-tools #SearchForm_holder div.tab h3 { margin-top: 16px; margin-bottom: 10px; border-bottom: 1px solid rgba(201, 205, 206, 0.8); -webkit-box-shadow: 0 1px 0 rgba(228, 230, 230, 0.8); -moz-box-shadow: 0 1px 0 rgba(228, 230, 230, 0.8); -o-box-shadow: 0 1px 0 rgba(228, 230, 230, 0.8); box-shadow: 0 1px 0 rgba(228, 230, 230, 0.8); }
 .ModelAdmin .cms-content-tools #SearchForm_holder div.tab form input { margin: 0px; }
 .ModelAdmin .cms-content-tools #SearchForm_holder div.tab form .field { border-bottom: 0px; margin-bottom: 6px; }
+.ModelAdmin .cms-content-tools #SearchForm_holder div.tab form .Actions { max-width: 100%; overflow: hidden; }
 .ModelAdmin .cms-content-tools #SearchForm_holder div.tab form .Actions button.ss-ui-action-minor { display: none; }
 
 .SecurityAdmin .cms-edit-form .cms-content-header h2 { display: none; }

--- a/admin/scss/_ModelAdmin.scss
+++ b/admin/scss/_ModelAdmin.scss
@@ -53,9 +53,22 @@
 						margin-bottom:6px;
 					}
 					.Actions {
+						max-width:100%;
+						overflow:hidden;
 						button.ss-ui-action-minor {
 							//removing the "clear search" button
 							display:none;
+						}
+						input.action {
+							//experimenting with text-overlow:ellipsis on action buttons
+							//currently disabled as this ignores padding-left on the buttons in Firefox
+							//and makes the text appear in front of the icon in Firefox 10
+							//See a screenshot here: http://db.tt/iBi39rRt 
+						  
+						  //white-space: nowrap;
+							//overflow: hidden;
+							//text-overflow:ellipsis;
+							//max-width:100%;
 						}
 					}
 				}


### PR DESCRIPTION
additionally, outcommented instructions on how button styling can be increased for Webkit & IE9

See http://open.silverstripe.org/ticket/6782
