### PR TITLE
MINOR Check for display_errors=Off during installation (fixes #5779)

### DIFF
--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -398,6 +398,7 @@ class InstallRequirements {
 
 		$this->suggestPHPSetting('asp_tags', array(''), array('PHP Configuration', 'asp_tags option turned off', 'This should be turned off as it can cause issues with SilverStripe'));
 		$this->suggestPHPSetting('magic_quotes_gpc', array(''), array('PHP Configuration', 'magic_quotes_gpc option turned off', 'This should be turned off, as it can cause issues with cookies. More specifically, unserializing data stored in cookies.'));
+		$this->suggestPHPSetting('display_errors', array(''), array('PHP Configuration', 'display_errors option turned off', 'This should be turned off, as it can expose sensitive data to website users.'));
 
 		// Check memory allocation
 		$this->requireMemory(32*1024*1024, 64*1024*1024, array("PHP Configuration", "Memory allocated (PHP config option 'memory_limit')", "SilverStripe needs a minimum of 32M allocated to PHP, but recommends 64M.", ini_get("memory_limit")));


### PR DESCRIPTION
This came up here: http://open.silverstripe.org/ticket/5779
It might be a little over cautious (as devs will install on their dev environments where the setting is useful). I'm happy for the pull request to be rejected if you think its unnecessary :)
