### PR TITLE
Patch for create translation language dropdown

### DIFF
--- a/core/model/Translatable.php
+++ b/core/model/Translatable.php
@@ -938,6 +938,7 @@ class Translatable extends DataObjectDecorator implements PermissionProvider {
 		// This action is possible both when showing the "default language"
 		// and a translation. Include the current locale (record might not be saved yet).
 		$alreadyTranslatedLocales = $this->getTranslatedLocales();
+		$alreadyTranslatedLocales = array_combine($alreadyTranslatedLocales, $alreadyTranslatedLocales);
 		$alreadyTranslatedLocales[$this->owner->Locale] = $this->owner->Locale;
 
 		if($originalRecord && $isTranslationMode) {
@@ -1003,7 +1004,7 @@ class Translatable extends DataObjectDecorator implements PermissionProvider {
 				new HeaderField('ExistingTransHeader', _t('Translatable.EXISTING', 'Existing translations:'), 3)
 			);
 			$existingTransHTML = '<ul>';
-			foreach($alreadyTranslatedLocales as $i => $langCode) {		
+			foreach($alreadyTranslatedLocales as $langCode) {		
 				$existingTranslation = $this->owner->getTranslation($langCode);
 				if($existingTranslation) {
 					$existingTransHTML .= sprintf('<li><a href="%s">%s</a></li>',


### PR DESCRIPTION
Copy values to keys in updateCMSFields' $alreadyTranslatedLocales since it's later used by LanguageDropdownField to exclude languages for which a translation already exists and LanguageDropdownField operates on array keys.
Also removed unused index/key variable $i from foreach loop that displays the existing translations.
