### PR TITLE
BUGFIX Allow PartialMatchFilter to use an array as search term

### DIFF
--- a/search/filters/PartialMatchFilter.php
+++ b/search/filters/PartialMatchFilter.php
@@ -14,11 +14,17 @@ class PartialMatchFilter extends SearchFilter {
 	
 	public function apply(DataQuery $query) {
 		$this->model = $query->applyRelation($this->relation);
-		return $query->where(sprintf(
-			"%s LIKE '%%%s%%'",
-			$this->getDbName(),
-			Convert::raw2sql($this->getValue())
-		));
+		$where = array();
+		if(is_array($this->getValue())) {
+			foreach($this->getValue() as $value) {
+				$where[]= sprintf("%s LIKE '%%%s%%'", $this->getDbName(), Convert::raw2sql($value));
+			}
+
+		} else {
+			$where[] = sprintf("%s LIKE '%%%s%%'", $this->getDbName(), Convert::raw2sql($this->getValue()));
+		}
+
+		return $query->where(implode(' OR ', $where));
 	}
 	
 	public function isEmpty() {


### PR DESCRIPTION
This will fix issues when using DataList::filter() like these:

```
$list->filter('Title:PartialMatch', array('Stig', 'Claus'));
```

The previous result was a query that looked like this:

```
... WHERE ("Title" LIKE "%Array%")
```

Now it looks like this:

```
... WHERE ("Title" LIKE "%Stig%" OR "Title" LIKE "%Claus%") ..
```
