### PR TITLE
Fix sqlquery joined table aliases

### DIFF
--- a/core/model/SQLQuery.php
+++ b/core/model/SQLQuery.php
@@ -23,6 +23,12 @@ class SQLQuery {
 	 * @var array
 	 */
 	public $from = array();
+
+	/**
+	 * An array of actual table names without their alias.
+	 * @var array
+	 */
+	public $tables = array();
 	
 	/**
 	 * An array of filters.
@@ -138,7 +144,9 @@ class SQLQuery {
 	 * @return SQLQuery This instance
 	 */
 	public function from($table) {
-		$this->from[str_replace(array('"','`'),'',$table)] = $table;
+		$tableName = str_replace(array('"','`'),'',$table);
+		$this->from[$tableName] = $table;
+		$this->tables[] = $tableName;
 		
 		return $this;
 	}
@@ -157,6 +165,7 @@ class SQLQuery {
 			$tableAlias = $table;
 		}
 		$this->from[$tableAlias] = "LEFT JOIN \"$table\" AS \"$tableAlias\" ON $onPredicate";
+		$this->tables[] = $table;
 		return $this;
 	}
 	
@@ -174,7 +183,17 @@ class SQLQuery {
 			$tableAlias = $table;
 		}
 		$this->from[$tableAlias] = "INNER JOIN \"$table\" AS \"$tableAlias\" ON $onPredicate";
+		$this->tables[] = $table;
 		return $this;
+	}
+
+	/**
+	 * Returns the array of unique table names used in this query (not aliases).
+	 *
+	 * @return array unique table names (actual table - not aliases) used by this query
+	 */
+	public function getTables() {
+		return array_unique($this->tables);
 	}
 	
 	/**

--- a/core/model/Versioned.php
+++ b/core/model/Versioned.php
@@ -144,7 +144,7 @@ class Versioned extends DataObjectDecorator {
 		// Get a specific stage
 		} else if(Versioned::current_stage() && Versioned::current_stage() != $this->defaultStage 
 					&& array_search(Versioned::current_stage(), $this->stages) !== false) {
-			foreach($query->from as $table => $dummy) {
+			foreach($query->getTables() as $table) {
 				$query->renameTable($table, $table . '_' . Versioned::current_stage());
 			}
 		}


### PR DESCRIPTION
If you used SQLQuery join functions with aliases for the table names it caused
Versioned->augmentSQL to create invalid table names.  For instance, if you did:

$query = new SQLQuery('"SiteTree".ID, "SiteTree".Title');
$query->from('"SiteTree"');
$query->where('"SiteTree".Locale', 'en');
$query->innerJoin('SiteTree', '"SiteTree"."ParentID" = pa1.ID AND pa1.URLSegment = \'some-page\'', 'pa1');
singleton('Versioned')->augmentSQL(&$query);
$query->execute();

This previously resulted in Versioned->augmentSQL renaming "pa1" to "pa1_Live"
which is not a table or table alias in the resulting SQL query.

The fix in this commit is to track table names separately from the aliases used
for tables.  This allows Versioned->augmentSQL to iterate over these actual
table names regardless of what (if any) aliases are used for them.
