### PR TITLE
bugfix for 6856, isDev=1&showqueries going into infinite loop

### DIFF
--- a/model/MySQLDatabase.php
+++ b/model/MySQLDatabase.php
@@ -109,13 +109,13 @@ class MySQLDatabase extends SS_Database {
 			return;
 		}
 
-		if(isset($_REQUEST['showqueries'])) {
+		if(isset($_REQUEST['showqueries']) && Director::isDev(true)) {
 			$starttime = microtime(true);
 		}
 
 		$handle = $this->dbConn->query($sql);
 
-		if(isset($_REQUEST['showqueries'])) {
+		if(isset($_REQUEST['showqueries']) && Director::isDev(true)) {
 			$endtime = round(microtime(true) - $starttime,4);
 			Debug::message("\n$sql\n{$endtime}ms\n", false);
 		}


### PR DESCRIPTION
BUGFIX: add Director::isDev parameter so we can test if we know we're dev mode already without touching the database. Used in showqueries on MySQL, so that errors are avoided when showing queries on initial switch to dev move (#6856)
