### PR TITLE
BUGFIX #6817: FieldList.php: findOrMakeTab () fails for nested TabSets

### DIFF
--- a/forms/FieldList.php
+++ b/forms/FieldList.php
@@ -267,10 +267,7 @@ class FieldList extends ArrayList {
 				if(is_a($parentPointer, 'TabSet')) {
 					// use $title on the innermost tab only
 					if ($k == $last_idx) {
-						if (!isset($title)) {
-							$title = $part;
-						}
-						$currentPointer = new Tab($part, $title);
+						$currentPointer = isset($title) ? new Tab($part, $title) : new Tab($part);
 					}
 					else {
 						$currentPointer = new TabSet($part);


### PR DESCRIPTION
- Implements recommended solution from bug report.
- Calculates last index only once instead of at each loop iteration.
- There was no existing test for this method, so if someone can implement a test, that would be great.
