### PR TITLE
BUGFIX PHP 5.2 doesn't allow calling a static method like $className::$staticMethod()

### DIFF
--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -328,7 +328,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope {
 			if ($createObject) $implementer = new $implementer();
 
 			// Get the exposed variables
-			$exposedVariables = $implementer::$variableMethod();
+			$exposedVariables = call_user_func(array($implementer, $variableMethod));
 
 			foreach($exposedVariables as $varName => $details) {
 				if (!is_array($details)) $details = array('method' => $details, 'casting' => Object::get_static('ViewableData', 'default_cast'));


### PR DESCRIPTION
This has not been checked on php 5.2, but this is how I've solved this before. Still works on php 5.3
