### PR TITLE
Datetime test fix

### DIFF
--- a/tests/model/DatetimeTest.php
+++ b/tests/model/DatetimeTest.php
@@ -35,6 +35,8 @@ class SS_DatetimeTest extends SapphireTest {
 	}
 
 	function testSetNullAndZeroValues() {
+		date_default_timezone_set('UTC');
+
 		$date = DBField::create('SS_Datetime', '');
 		$this->assertNull($date->getValue(), 'Empty string evaluates to NULL');
 
@@ -45,10 +47,10 @@ class SS_DatetimeTest extends SapphireTest {
 		$this->assertNull($date->getValue(), 'Boolean FALSE evaluates to NULL');
 
 		$date = DBField::create('SS_Datetime', '0');
-		$this->assertEquals('1970-01-01 12:00:00', $date->getValue(), 'String zero is UNIX epoch time');
+		$this->assertEquals('1970-01-01 00:00:00', $date->getValue(), 'String zero is UNIX epoch time');
 
 		$date = DBField::create('SS_Datetime', 0);
-		$this->assertEquals('1970-01-01 12:00:00', $date->getValue(), 'Numeric zero is UNIX epoch time');
+		$this->assertEquals('1970-01-01 00:00:00', $date->getValue(), 'Numeric zero is UNIX epoch time');
 	}
 
 }


### PR DESCRIPTION
Corrects timezone ambiguity in DatetimeTest so that all tests pass again. Changes expected timezone from NZT to UTC. Clarifies error messages so that you can tell numeric from string zero.
