### PR TITLE
BUGFIX: Correct date calculation failure in GridFieldTest.

### DIFF
--- a/tests/forms/GridFieldTest.php
+++ b/tests/forms/GridFieldTest.php
@@ -319,6 +319,7 @@ class GridFieldTest extends SapphireTest {
 	 * @covers GridField::getCastedValue
 	 */
 	public function testGetCastedValueObject() {
+		date_default_timezone_set('UTC');
 		$obj = new GridField('testfield', 'testfield');
 		$value = $obj->getCastedValue('This is a sentance. This ia another.', 'Date');
 		$this->assertEquals('1970-01-01', $value);


### PR DESCRIPTION
- PHP now requires a default timezone to be set, so tests cannot assume they are running in UTC
- Explicitly set UTC default time zone for testGetCastedValueObject()
