### PR TITLE
BUGFIX, API CHANGE: Enable setting the DB timezone from the environment.

### DIFF
--- a/conf/ConfigureFromEnv.php
+++ b/conf/ConfigureFromEnv.php
@@ -15,6 +15,7 @@
  *  - SS_DATABASE_PASSWORD: The database password (mandatory)
  *  - SS_DATABASE_SUFFIX:   A suffix to add to the database name.
  *  - SS_DATABASE_PREFIX:   A prefix to add to the database name.
+ *  - SS_DATABASE_TIMEZONE: Set the database timezone to something other than the system timezone.
  * 
  * There is one more setting that is intended to be used by people who work on SilverStripe.
  *  - SS_DATABASE_CHOOSE_NAME: Boolean/Int.  If set, then the system will choose a default database name for you if one isn't give
@@ -83,7 +84,12 @@ if(defined('SS_DATABASE_USERNAME') && defined('SS_DATABASE_PASSWORD')) {
 			. $database 
 			. (defined('SS_DATABASE_SUFFIX') ? SS_DATABASE_SUFFIX : ''),
 	);
-	
+
+	// Set the timezone if called for
+	if (defined('SS_DATABASE_TIMEZONE')) {
+		$databaseConfig['timezone'] = SS_DATABASE_TIMEZONE;
+	}
+
 	// For schema enabled drivers: 
  	if(defined('SS_DATABASE_SCHEMA')) 
  		$databaseConfig["schema"] = SS_DATABASE_SCHEMA; 


### PR DESCRIPTION
- It was possible to set the database time zone from $databaseConfig, but not if you were using ConfigureFromEnv.
- Introduces a new constant, SS_DATABASE_TIMEZONE
