### PR TITLE
BUGFIX BASE_PATH was trimming trailing whitespace in paths rather than t...

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -139,7 +139,7 @@ if(!isset($_SERVER['HTTP_HOST'])) {
  */
 if(!defined('BASE_PATH')) {
 	// Assuming that this file is sapphire/core/Core.php we can then determine the base path
-	define('BASE_PATH', rtrim(dirname(dirname(dirname(__FILE__)))), DIRECTORY_SEPARATOR);
+	define('BASE_PATH', rtrim(dirname(dirname(dirname(__FILE__))), DIRECTORY_SEPARATOR));
 }
 if(!defined('BASE_URL')) {
 	// Determine the base URL by comparing SCRIPT_NAME to SCRIPT_FILENAME and getting common elements


### PR DESCRIPTION
...railing DIRECTORY_SEPARATORs.

The parentheses were off by one, so DIRECTORY_SEPARATOR was being passed as the case-sensitive parameter to define() rather than the charlist to rtrim(), so really weird edge cases where someone had whitespace at the end of their path mean the include path was set to non-existent folders, so nothing was included.
