### PR TITLE
MINOR: Fix tests on PHPUnit 3.4

### DIFF
--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -680,6 +680,22 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 
       self::assertThat($actual, $constraint, $message);
   }
+
+  	/**
+  	 * Provide assertEmpty() in PHPUnit <3.5.
+  	 * We want to support PHPUnit 3.4, as this is the most recent release available
+  	 * to environments running PHP <=5.2.6, such as Debian Lenny.
+  	 */
+	public static function assertEmpty($item, $message = '') {
+		if(class_exists('PHPUnit_Framework_Constraint_IsEmpty')) {
+			parent::assertEmpty($item, $message);
+		} else {
+			if(!empty($item)) {
+				$message = $message ? $message : "Failed asserting that " . var_export($item, true) . " is empty.";
+				throw new PHPUnit_Framework_AssertionFailedError($message);
+			}
+		}
+	}
 	
 	/**
 	 * Helper function for the DOS matchers

--- a/tests/dev/DeprecationTest.php
+++ b/tests/dev/DeprecationTest.php
@@ -29,7 +29,7 @@ class DeprecationTest extends SapphireTest {
 	}
 
 	/**
-     * @expectedException PHPUnit_Framework_Error_Notice
+     * @expectedException PHPUnit_Framework_Error
 	 */
 	function testEqualVersionTriggersNotice() {
 		Deprecation::notification_version('2.0.0');
@@ -43,7 +43,7 @@ class DeprecationTest extends SapphireTest {
 	}
 
 	/**
-    * @expectedException PHPUnit_Framework_Error_Notice
+    * @expectedException PHPUnit_Framework_Error
 	 */
 	function testGreaterVersionTriggersNotice() {
 		Deprecation::notification_version('3.0.0');
@@ -57,7 +57,7 @@ class DeprecationTest extends SapphireTest {
 	}
 
 	/**
-    * @expectedException PHPUnit_Framework_Error_Notice
+    * @expectedException PHPUnit_Framework_Error
 	 */
 	function testMatchingModuleNotifcationVersionAffectsNotice() {
 		Deprecation::notification_version('1.0.0');


### PR DESCRIPTION
Fixes unit tests on PHPUnit3.4 (the latest that can be installed with PHP 2.2.6 on Debian Lenny.)
