### PR TITLE
BUGFIX: Remove stray scrolling and zooming glitches on iPad.

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -231,7 +231,7 @@ input.radio { margin-left: 0; }
 * (see _tree.scss and _menu.scss).
 */
 /** ---------------------------------------------------- Core Styles. ---------------------------------------------------- */
-html, body { width: 100%; height: 100%; }
+html, body { width: 100%; height: 100%; /* Removes RHS whitespace on iPad */ overflow-x: hidden; }
 
 body.cms { overflow: hidden; }
 

--- a/admin/scss/_style.scss
+++ b/admin/scss/_style.scss
@@ -21,6 +21,8 @@
 html,body {
 	width: 100%;
 	height: 100%;
+	/* Removes RHS whitespace on iPad */
+	overflow-x: hidden;
 }
 
 body.cms {

--- a/admin/templates/LeftAndMain.ss
+++ b/admin/templates/LeftAndMain.ss
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 <% base_tag %>
+<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+<meta name="viewport" content="width=720, maximum-scale=1.0" />
 <title>$Title</title>
 </head>
 


### PR DESCRIPTION
Ingo - one for you to review.  The most invasive change is the viewport one, which won't affect non-iPads, and I'd expect the overflow-x change not to cause issue.  Tested fine on Chrome, FF, IE8.

The result of this fix is that the interface is much less buggy feeling on the iPad, although it is still sluggish, but I understand that there are fixes in the pipeline already around that.

If nothing else, iPad performance provides a nice clientside-performance-stress-test in 2012. ;-)
