### PR TITLE
BUGFIX Don't try setting the value attribute on DropdownField or its sub...

### DIFF
--- a/forms/DropdownField.php
+++ b/forms/DropdownField.php
@@ -165,7 +165,7 @@ class DropdownField extends FormField {
 	function getAttributes() {
 		return array_merge(
 			parent::getAttributes(),
-			array('type' => null)
+			array('type' => null, 'value' => null)
 		);
 	}
 


### PR DESCRIPTION
...classes.

The reason for this is the E_NOTICE on array to string conversion in PHP 5.4. ListboxField's value is an array, so rendering one would generate the error.

value is also not a valid attribute on a select element.
