### PR TITLE
BUGFIX: Prevent 500 error when a HEAD request is sent to its action URL.

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -192,6 +192,7 @@ class Form extends RequestHandler {
 		'$Action!' => 'handleAction',
 		'POST ' => 'httpSubmission',
 		'GET ' => 'httpSubmission',
+		'HEAD ' => 'httpSubmission',
 	);
 	
 	/**


### PR DESCRIPTION
It's a bit of an edge-case, but this came up on a project in production.  It's relatively benign, but causes issues if you're monitoring 500 errors.
