### PR TITLE
BUG FIX: Improve translation efficiency for missing locales

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -1833,8 +1833,11 @@ class i18n extends Object implements TemplateGlobalProvider {
 			}
 		}
 
-		// Finally, load any translations from registered plugins
+		// Load any translations from registered plugins
 		if ($load_plugins) self::plugins_load($locale);
+		
+		// Make sure this is only done once. We don't want to attempt it hundreds of times for missing locals
+		if(!isset($lang[$locale])) $lang[$locale] = array();
 	}
 
 	/**


### PR DESCRIPTION
Make sure the translation function doesn't try to include missing locale files over and over again.

Currently the translation function tries to include a locale file every time it's called if the locale hasn't already been loaded. This leads to super duper inefficiency for missing locale files (like en_AU).
