### PR TITLE
GridFieldDeleteAction minor tidy up

### DIFF
--- a/forms/gridfield/GridFieldDeleteAction.php
+++ b/forms/gridfield/GridFieldDeleteAction.php
@@ -2,8 +2,8 @@
 /**
  * This class is a {@link GridField} component that adds a delete action for objects.
  *
- * This will also supports unlinking a relation instead of deleting the object. Use the {@link $removeRelation}
- * property set in the constructor.
+ * This component also supports unlinking a relation instead of deleting the object.
+ * Use the {@link $removeRelation} property set in the constructor.
  *
  * <code>
  * $action = new GridFieldDeleteAction(); // delete objects permanently


### PR DESCRIPTION
The class documentation for GridFieldDeleteAction is quite confusing, as it refers to a separate GridFieldRemoveButton which doesn't exist. The argument for GridFieldDeleteAction::__construct(), however, does allow you to remove the relation instead.

Tidied up the class documentation a bit, and improved the code syntax to our standards.
