### PR TITLE
MINOR: Raise deprecation errors in the same way as notice-level errors.

### DIFF
--- a/dev/Debug.php
+++ b/dev/Debug.php
@@ -697,6 +697,7 @@ function errorHandler($errno, $errstr, $errfile, $errline) {
 
 		case E_NOTICE:
 		case E_USER_NOTICE:
+		case E_USER_DEPRECATED:
 			Debug::noticeHandler($errno, $errstr, $errfile, $errline, null);
 			break;
 	}

--- a/dev/DebugView.php
+++ b/dev/DebugView.php
@@ -30,6 +30,10 @@ class DebugView extends Object {
 			'title' => 'User Notice',
 			'class' => 'notice'
 		),
+		E_USER_DEPRECATED => array(
+			'title' => 'Deprecation',
+			'class' => 'notice'
+		),
 		E_CORE_ERROR => array(
 			'title' => 'Core Error',
 			'class' => 'error'


### PR DESCRIPTION
I'm not sure what the intention of deprecation errors was with regards display, but right now they don't show up at all.  This shows them as a notice-level error.
