### PR TITLE
BUGFIX: Show a correct growl message when ajax returns a JS error rather than HTTP error.

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -23,7 +23,11 @@ jQuery.noConflict();
 		// global ajax error handlers
 		$.ajaxSetup({
 			error: function(xmlhttp, status, error) {
-				var msg = (xmlhttp.getResponseHeader('X-Status')) ? xmlhttp.getResponseHeader('X-Status') : xmlhttp.statusText;
+				if(xmlhttp.status < 200 || xmlhttp.status > 399) {
+					var msg = (xmlhttp.getResponseHeader('X-Status')) ? xmlhttp.getResponseHeader('X-Status') : xmlhttp.statusText;
+				} else {
+					msg = error;
+				}
 				statusMessage(msg, 'bad');
 			}
 		});


### PR DESCRIPTION
This was making it difficult to debug the blog module - I got "error: OK" messages :-P
