### PR TITLE
Fixed FulltextSearchable non-object error and remove deprecated Object::add_static_var() usage

### DIFF
--- a/search/FulltextSearchable.php
+++ b/search/FulltextSearchable.php
@@ -52,9 +52,7 @@ class FulltextSearchable extends DataExtension {
 			if(!class_exists($class)) continue;
 			
 			if(isset($defaultColumns[$class])) {
-				if(DB::getConn()->getDatabaseServer() == 'mysql') {
-					Object::add_static_var($class, 'create_table_options', array('MySQLDatabase' => 'ENGINE=MyISAM'), true);
-				}
+				Config::inst()->update($class, 'create_table_options', array('MySQLDatabase' => 'ENGINE=MyISAM'));
 				Object::add_extension($class, "FulltextSearchable('{$defaultColumns[$class]}')");
 			} else {
 				throw new Exception("FulltextSearchable::enable() I don't know the default search columns for class '$class'");


### PR DESCRIPTION
Fixed FulltextSearchable checking `DB::getConn()` unnecessarily for MySQL, as `Database::requireTable()` will only apply create_table_options to the database adapter they're set for anyway.

Replace `Object::add_static_var()` usage (deprecated) with the new config system instead.
