### PR TITLE
DateField::setValue() with dmyfields sets erroneous date in valueObj

### DIFF
--- a/forms/DateField.php
+++ b/forms/DateField.php
@@ -196,8 +196,13 @@ class DateField extends TextField {
 				// Setting in correct locale
 				if(is_array($val) && $this->validateArrayValue($val)) {
 					// set() gets confused with custom date formats when using array notation
-					$this->valueObj = new Zend_Date($val, null, $this->locale);
-					$this->value = $this->valueObj->toArray();
+					if(!(empty($val['day']) || empty($val['month']) || empty($val['year']))) {
+						$this->valueObj = new Zend_Date($val, null, $this->locale);
+						$this->value = $this->valueObj->toArray();
+					} else {
+						$this->value = $val;
+						$this->valueObj = null;
+					}
 				}
 				// load ISO date from database (usually through Form->loadDataForm())
 				else if(!empty($val) && Zend_Date::isDate($val, $this->getConfig('datavalueformat'), $this->locale)) {

--- a/tests/forms/DateFieldTest.php
+++ b/tests/forms/DateFieldTest.php
@@ -135,7 +135,18 @@ class DateFieldTest extends SapphireTest {
 		// $f = new DateField('Date', 'Date', array('day' => 9999, 'month' => 9999, 'year' => 9999));
 		// $this->assertFalse($f->validate(new RequiredFields()));
 	}
-	
+
+	function testValidateEmptyArrayValuesSetsNullForValueObject() {
+		$f = new DateField('Date', 'Date');
+		$f->setConfig('dmyfields', true);
+
+		$f->setValue(array('day' => '', 'month' => '', 'year' => ''));
+		$this->assertNull($f->dataValue());
+
+		$f->setValue(array('day' => null, 'month' => null, 'year' => null));
+		$this->assertNull($f->dataValue());
+	}
+
 	function testValidateArrayValue() {
 		$f = new DateField('Date', 'Date');
 		$this->assertTrue($f->validateArrayValue(array('day' => 29, 'month' => 03, 'year' => 2003)));


### PR DESCRIPTION
If you call setValue(array('day' => '', 'month' => '', 'year' => '')) on a DateField, the valueObj property gets set with Zend_Date data that is erroneous. valueObj should be NULL in this case. Presently, this bug stops you from submitting a form with empty day, month and year values, as Zend_Date will give back 2000-11-1 (?) and set this date which is erroneous.

I've written a test to confirm that dataValue() is null if you submit empty day, month and year values in the value array, and fixed the appropriate place which attempts to use Zend_Date on the value set on DateField.

Note that we can't check for these in validateArrayValue(), as it's valid to submit a DateField with empty values.
