### PR TITLE
ENHANCEMENT: Allow Object::create() to be called with late static binding.

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -467,7 +467,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 				$menu->push(new ArrayData(array(
 					"MenuItem" => $menuItem,
 					"Title" => Convert::raw2xml($title),
-					"Code" => DBField::create('Text', $code),
+					"Code" => DBField::create_field('Text', $code),
 					"Link" => $menuItem->url,
 					"LinkingMode" => $linkingmode
 				)));
@@ -1256,7 +1256,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 	 * @return String
 	 */
 	function Locale() {
-		return DBField::create('DBLocale', i18n::get_locale());
+		return DBField::create_field('DBLocale', i18n::get_locale());
 	}
 
 	function providePermissions() {

--- a/core/Object.php
+++ b/core/Object.php
@@ -83,13 +83,27 @@ abstract class Object {
 	 * overload is found, an instance of this is returned rather than the original class. To overload a class, use
 	 * {@link Object::useCustomClass()}
 	 *
+	 * This can be called in one of two ways - either calling via the class directly,
+	 * or calling on Object and passing the class name as the first parameter. The following
+	 * are equivalent:
+	 *    $list = DataList::create('SiteTree');
+	 *    $list = Object::create('DataList', 'SiteTree');
+	 *
 	 * @param string $class the class name
 	 * @param mixed $arguments,... arguments to pass to the constructor
 	 * @return Object
 	 */
 	public static function create() {
 		$args  = func_get_args();
-		$class = self::getCustomClass(array_shift($args));
+
+		// Class to create should be the calling class if not Object,
+		// otherwise the first parameter
+		$class = get_called_class();
+		if($class == 'Object')
+			$class = array_shift($args);
+		
+		$class = self::getCustomClass($class);
+		
 		$reflector = new ReflectionClass($class);
 		if($reflector->getConstructor()) {
 			return $reflector->newInstanceArgs($args);

--- a/forms/FormAction.php
+++ b/forms/FormAction.php
@@ -45,10 +45,6 @@ class FormAction extends FormField {
 		parent::__construct($this->action, $title, null, $form);
 	}
 
-	static function create($action, $title = "") {
-		return new FormAction($action, $title);
-	}
-
 	function actionName() {
 		return substr($this->name, 7);
 	}

--- a/forms/HiddenField.php
+++ b/forms/HiddenField.php
@@ -28,9 +28,4 @@ class HiddenField extends FormField {
 			array('type' => 'hidden')
 		);
 	}
-
-	static function create($name) {
-		return new HiddenField($name);
-	}
-
 }

--- a/forms/MoneyField.php
+++ b/forms/MoneyField.php
@@ -103,7 +103,7 @@ class MoneyField extends FormField {
 	function saveInto($dataObject) {
 		$fieldName = $this->name;
 		if($dataObject->hasMethod("set$fieldName")) {
-			$dataObject->$fieldName = DBField::create('Money', array(
+			$dataObject->$fieldName = DBField::create_field('Money', array(
 				"Currency" => $this->fieldCurrency->Value(),
 				"Amount" => $this->fieldAmount->Value()
 			));

--- a/forms/TableListField.php
+++ b/forms/TableListField.php
@@ -637,8 +637,8 @@ JS
 			$summaryFields[] = new ArrayData(array(
 				'Function' => $function,
 				'SummaryValue' => $summaryValue,
-				'Name' => DBField::create('Varchar', $fieldName),
-				'Title' => DBField::create('Varchar', $fieldTitle),
+				'Name' => DBField::create_field('Varchar', $fieldName),
+				'Title' => DBField::create_field('Varchar', $fieldTitle),
 			));
 		}
 		return new ArrayList($summaryFields);
@@ -1234,13 +1234,13 @@ JS
 		}
 		if(strpos($castingDefinition,'->') === false) {
 			$castingFieldType = $castingDefinition;
-			$castingField = DBField::create($castingFieldType, $value);
+			$castingField = DBField::create_field($castingFieldType, $value);
 			$value = call_user_func_array(array($castingField,'XML'),$castingParams);
 		} else {
 			$fieldTypeParts = explode('->', $castingDefinition);
 			$castingFieldType = $fieldTypeParts[0];	
 			$castingMethod = $fieldTypeParts[1];
-			$castingField = DBField::create($castingFieldType, $value);
+			$castingField = DBField::create_field($castingFieldType, $value);
 			$value = call_user_func_array(array($castingField,$castingMethod),$castingParams);
 		}
 		

--- a/forms/ToggleField.php
+++ b/forms/ToggleField.php
@@ -59,7 +59,7 @@ class ToggleField extends ReadonlyField {
 		$rawInput = Convert::html2raw($valforInput);
 		
 		if($this->charNum) $reducedVal = substr($rawInput,0,$this->charNum);
-		else $reducedVal = DBField::create('Text',$rawInput)->{$this->truncateMethod}();
+		else $reducedVal = DBField::create_field('Text',$rawInput)->{$this->truncateMethod}();
 		
 		// only create togglefield if the truncated content is shorter
 		if(strlen($reducedVal) < strlen($rawInput)) {

--- a/forms/gridfield/GridField.php
+++ b/forms/gridfield/GridField.php
@@ -239,13 +239,13 @@ class GridField extends FormField {
 		
 		if(strpos($castingDefinition,'->') === false) {
 			$castingFieldType = $castingDefinition;
-			$castingField = DBField::create($castingFieldType, $value);
+			$castingField = DBField::create_field($castingFieldType, $value);
 			$value = call_user_func_array(array($castingField,'XML'),$castingParams);
 		} else {
 			$fieldTypeParts = explode('->', $castingDefinition);
 			$castingFieldType = $fieldTypeParts[0];	
 			$castingMethod = $fieldTypeParts[1];
-			$castingField = DBField::create($castingFieldType, $value);
+			$castingField = DBField::create_field($castingFieldType, $value);
 			$value = call_user_func_array(array($castingField,$castingMethod),$castingParams);
 		}
 		

--- a/model/ArrayList.php
+++ b/model/ArrayList.php
@@ -14,18 +14,6 @@ class ArrayList extends ViewableData implements SS_List, SS_Filterable, SS_Sorta
 	 */
 	protected $items;
 	
-	
-	/**
-	 * Synonym of the constructor. Can be chained with literate methods.
-	 * ArrayList::create("SiteTree")->sort("Title") is legal, but
-	 * new ArrayList("SiteTree")->sort("Title") is not.
-	 * 
-	 * @param array $items - an initial array to fill this object with
-	 */
-	public static function create(array $items = array()) {
-		return new ArrayList($items);
-	}
-	
 	/**
 	 *
 	 * @param array $items - an initial array to fill this object with

--- a/model/DataList.php
+++ b/model/DataList.php
@@ -27,17 +27,6 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 	 * @var DataModel
 	 */
 	protected $model;
-	
-	/**
-	 * Synonym of the constructor.  Can be chained with literate methods.
-	 * DataList::create("SiteTree")->sort("Title") is legal, but
-	 * new DataList("SiteTree")->sort("Title") is not.
-	 * 
-	 * @param string $dataClass - The DataObject class to query.
-	 */
-	public static function create($dataClass) {
-		return new DataList($dataClass);
-	}
 
 	/**
 	 * Create a new DataList.

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1092,7 +1092,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 
 								// if database column doesn't correlate to a DBField instance...
 								if(!$fieldObj) {
-									$fieldObj = DBField::create('Varchar', $this->record[$fieldName], $fieldName);
+									$fieldObj = DBField::create_field('Varchar', $this->record[$fieldName], $fieldName);
 								}
 
 								// Both CompositeDBFields and regular fields need to be repopulated
@@ -2380,12 +2380,12 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 		// Special case for has_one relationships
 		} else if(preg_match('/ID$/', $fieldName) && $this->has_one(substr($fieldName,0,-2))) {
 			$val = (isset($this->record[$fieldName])) ? $this->record[$fieldName] : null;
-			return DBField::create('ForeignKey', $val, $fieldName, $this);
+			return DBField::create_field('ForeignKey', $val, $fieldName, $this);
 			
 		// Special case for ClassName
 		} else if($fieldName == 'ClassName') {
 			$val = get_class($this);
-			return DBField::create('Varchar', $val, $fieldName, $this);
+			return DBField::create_field('Varchar', $val, $fieldName, $this);
 		}
 	}
 

--- a/model/ManyManyList.php
+++ b/model/ManyManyList.php
@@ -12,24 +12,6 @@ class ManyManyList extends RelationList {
 	protected $foreignKey, $foreignID;
 
 	protected $extraFields;
-	
-	/**
-	 * Synonym of the constructor.  Can be chained with literate methods.
-	 * ManyManyList::create("Group","Member","ID", "GroupID")->sort("Title") is legal, but
-	 * new ManyManyList("Group","Member","ID", "GroupID")->sort("Title") is not.
-	 * 
-	 * @param string $dataClass The class of the DataObjects that this will list.
-	 * @param string $joinTable The name of the table whose entries define the content of this many_many relation.
-	 * @param string $localKey The key in the join table that maps to the dataClass' PK.
-	 * @param string $foreignKey The key in the join table that maps to joined class' PK.
-	 * @param string $extraFields A map of field => fieldtype of extra fields on the join table.
-	 * 
-	 * @see ManyManyList::__construct();
-	 * @example ManyManyList::create('Group','Group_Members', 'GroupID', 'MemberID');
-	 */
-	public static function create($dataClass, $joinTable, $localKey, $foreignKey, $extraFields = array()) {
-		return new ManyManyList($dataClass, $joinTable, $localKey, $foreignKey, $extraFields = array());
-	}
 
 	/**
 	 * Create a new ManyManyList object.

--- a/model/fieldtypes/CompositeDBField.php
+++ b/model/fieldtypes/CompositeDBField.php
@@ -25,13 +25,13 @@
 * 		if($this->getStreetName()) {
 * 			$manipulation['fields']["{$this->name}Name"] = $this->prepValueForDB($this->getStreetName());
 * 		} else {
-* 			$manipulation['fields']["{$this->name}Name"] = DBField::create('Varchar', $this->getStreetName())->nullValue();
+* 			$manipulation['fields']["{$this->name}Name"] = DBField::create_field('Varchar', $this->getStreetName())->nullValue();
 * 		}
 * 		
 * 		if($this->getStreetNumber()) {
 * 			$manipulation['fields']["{$this->name}Number"] = $this->prepValueForDB($this->getStreetNumber());
 * 		} else {
-* 			$manipulation['fields']["{$this->name}Number"] = DBField::create('Int', $this->getStreetNumber())->nullValue();
+* 			$manipulation['fields']["{$this->name}Number"] = DBField::create_field('Int', $this->getStreetNumber())->nullValue();
 * 		}
 * 	}
 * 	

--- a/model/fieldtypes/DBField.php
+++ b/model/fieldtypes/DBField.php
@@ -63,11 +63,18 @@ abstract class DBField extends ViewableData {
 		parent::__construct();
 	}
 	
+
+	static function create() {
+		Deprecation::notice('3.0', 'DBField::create_field() is deprecated as it clashes with Object::create(). Use DBField::create_field() instead.');
+
+		return call_user_func_array(array('DBField', 'create_field'), func_get_args());
+	}
+
 	/**
 	 * Create a DBField object that's not bound to any particular field.
 	 * Useful for accessing the classes behaviour for other parts of your code.
 	 */
-	static function create($className, $value, $name = null, $object = null) {
+	static function create_field($className, $value, $name = null, $object = null) {
 		$dbField = Object::create($className, $name, $object);
 		$dbField->setValue($value, null, false);
 		return $dbField;

--- a/model/fieldtypes/Datetime.php
+++ b/model/fieldtypes/Datetime.php
@@ -96,7 +96,7 @@ class SS_Datetime extends Date {
 		if(self::$mock_now) {
 			return self::$mock_now;
 		} else {
-			return DBField::create('SS_Datetime', date('Y-m-d H:i:s'));
+			return DBField::create_field('SS_Datetime', date('Y-m-d H:i:s'));
 		}
 	}
 	
@@ -111,7 +111,7 @@ class SS_Datetime extends Date {
 		if($datetime instanceof SS_Datetime) {
 			self::$mock_now = $datetime;
 		} elseif(is_string($datetime)) {
-			self::$mock_now = DBField::create('SS_Datetime', $datetime);
+			self::$mock_now = DBField::create_field('SS_Datetime', $datetime);
 		} else {
 			throw new Exception('SS_Datetime::set_mock_now(): Wrong format: ' . $datetime);
 		}

--- a/model/fieldtypes/Money.php
+++ b/model/fieldtypes/Money.php
@@ -84,13 +84,13 @@ class Money extends DBField implements CompositeDBField {
 		if($this->getCurrency()) {
 			$manipulation['fields'][$this->name.'Currency'] = $this->prepValueForDB($this->getCurrency());
 		} else {
-			$manipulation['fields'][$this->name.'Currency'] = DBField::create('Varchar', $this->getCurrency())->nullValue();
+			$manipulation['fields'][$this->name.'Currency'] = DBField::create_field('Varchar', $this->getCurrency())->nullValue();
 		}
 		
 		if($this->getAmount()) {
 			$manipulation['fields'][$this->name.'Amount'] = $this->getAmount();
 		} else {
-			$manipulation['fields'][$this->name.'Amount'] = DBField::create('Decimal', $this->getAmount())->nullValue();
+			$manipulation['fields'][$this->name.'Amount'] = DBField::create_field('Decimal', $this->getAmount())->nullValue();
 		}
 	}
 	

--- a/tests/api/RestfulServerTest.php
+++ b/tests/api/RestfulServerTest.php
@@ -544,7 +544,7 @@ class RestfulServerTest_AuthorRating extends DataObject implements TestOnly {
 	static $db = array(
 		'Rating' => 'Int',
 		'SecretField' => 'Text',
-		'WriteProtectedField' => 'Text'
+		'WriteProtectedField' => 'Text',
 	);
 	
 	static $has_one = array(

--- a/tests/core/ObjectTest.php
+++ b/tests/core/ObjectTest.php
@@ -119,6 +119,11 @@ class ObjectTest extends SapphireTest {
 		$strongObj = Object::strong_create('ObjectTest_CreateTest', 'arg1', 'arg2', array(), null, 'arg5');
 		$this->assertEquals($strongObj->constructArguments, array('arg1', 'arg2', array(), null, 'arg5'));
 	}
+
+	public function testCreateLateStaticBinding() {
+		$createdObj = ObjectTest_CreateTest::create('arg1', 'arg2', array(), null, 'arg5');
+		$this->assertEquals($createdObj->constructArguments, array('arg1', 'arg2', array(), null, 'arg5'));
+	}
 	
 	/**
 	 * Tests that {@link Object::useCustomClass()} correnctly replaces normal and strong objects

--- a/tests/dev/CsvBulkLoaderTest.php
+++ b/tests/dev/CsvBulkLoaderTest.php
@@ -131,7 +131,7 @@ class CsvBulkLoaderTest extends SapphireTest {
 		$this->assertEquals($testPlayer->ContractID, $testContract->ID, 'Creating new has_one relation works');
 		
 		// Test nested setting of relation properties
-		$contractAmount = DBField::create('Currency', $compareRow[5])->RAW();
+		$contractAmount = DBField::create_field('Currency', $compareRow[5])->RAW();
 		$this->assertEquals($testPlayer->Contract()->Amount, $contractAmount, 'Setting nested values in a relation works');
 		
 		fclose($file);

--- a/tests/model/DBFieldTest.php
+++ b/tests/model/DBFieldTest.php
@@ -202,7 +202,7 @@ class DBFieldTest extends SapphireTest {
 		
 		$value = 'üåäöÜÅÄÖ';
 		foreach ($allFields as $stringField) {
-			$stringField = DBField::create($stringField, $value);
+			$stringField = DBField::create_field($stringField, $value);
 			for ($i = 1; $i < mb_strlen($value); $i++) {
 				$expected = mb_substr($value, 0, $i) . '...';
 				$this->assertEquals($expected, $stringField->LimitCharacters($i));
@@ -211,12 +211,12 @@ class DBFieldTest extends SapphireTest {
 		
 		$value = '<p>üåäö&amp;ÜÅÄÖ</p>';
 		foreach ($htmlFields as $stringField) {
-			$stringField = DBField::create($stringField, $value);
+			$stringField = DBField::create_field($stringField, $value);
 			$this->assertEquals('üåäö&amp;ÜÅÄ...', $stringField->LimitCharacters(8));
 		}
 		
-		$this->assertEquals('ÅÄÖ', DBField::create('Text', 'åäö')->UpperCase());
-		$this->assertEquals('åäö', DBField::create('Text', 'ÅÄÖ')->LowerCase());
+		$this->assertEquals('ÅÄÖ', DBField::create_field('Text', 'åäö')->UpperCase());
+		$this->assertEquals('åäö', DBField::create_field('Text', 'ÅÄÖ')->LowerCase());
 	}
 	
 }

--- a/tests/model/DBLocaleTest.php
+++ b/tests/model/DBLocaleTest.php
@@ -5,17 +5,17 @@
  */
 class DBLocaleTest extends SapphireTest {
 	function testNice() {
-		$l = DBField::create('DBLocale', 'de_DE');
+		$l = DBField::create_field('DBLocale', 'de_DE');
 		$this->assertEquals($l->Nice(), 'German');
 	}
 	
 	function testNiceNative() {
-		$l = DBField::create('DBLocale', 'de_DE');
+		$l = DBField::create_field('DBLocale', 'de_DE');
 		$this->assertEquals($l->Nice(true), 'Deutsch');
 	}
 	
 	function testNativeName() {
-		$l = DBField::create('DBLocale', 'de_DE');
+		$l = DBField::create_field('DBLocale', 'de_DE');
 		$this->assertEquals($l->getNativeName(), 'Deutsch');
 	}
 }

--- a/tests/model/DateTest.php
+++ b/tests/model/DateTest.php
@@ -32,96 +32,96 @@ class DateTest extends SapphireTest {
 	}
 	
 	function testNiceDate() {
-		$this->assertEquals('01/04/2008', DBField::create('Date', 1206968400)->Nice(),
+		$this->assertEquals('01/04/2008', DBField::create_field('Date', 1206968400)->Nice(),
 			"Date->Nice() works with timestamp integers"
 		);
-		$this->assertEquals('31/03/2008', DBField::create('Date', 1206882000)->Nice(),
+		$this->assertEquals('31/03/2008', DBField::create_field('Date', 1206882000)->Nice(),
 			"Date->Nice() works with timestamp integers"
 		);
-		$this->assertEquals('01/04/2008', DBField::create('Date', '1206968400')->Nice(),
+		$this->assertEquals('01/04/2008', DBField::create_field('Date', '1206968400')->Nice(),
 			"Date->Nice() works with timestamp strings"
 		);
-		$this->assertEquals('31/03/2008', DBField::create('Date', '1206882000')->Nice(),
+		$this->assertEquals('31/03/2008', DBField::create_field('Date', '1206882000')->Nice(),
 			"Date->Nice() works with timestamp strings"
 		);
-		$this->assertEquals('04/03/2003', DBField::create('Date', '4/3/03')->Nice(),
+		$this->assertEquals('04/03/2003', DBField::create_field('Date', '4/3/03')->Nice(),
 			"Date->Nice() works with D/M/YY format"
 		);
-		$this->assertEquals('04/03/2003', DBField::create('Date', '04/03/03')->Nice(),
+		$this->assertEquals('04/03/2003', DBField::create_field('Date', '04/03/03')->Nice(),
 			"Date->Nice() works with DD/MM/YY format"
 		);
-		$this->assertEquals('04/03/2003', DBField::create('Date', '4/3/03')->Nice(),
+		$this->assertEquals('04/03/2003', DBField::create_field('Date', '4/3/03')->Nice(),
 			"Date->Nice() works with D/M/YY format"
 		);
-		$this->assertEquals('04/03/2003', DBField::create('Date', '4/03/03')->Nice(),
+		$this->assertEquals('04/03/2003', DBField::create_field('Date', '4/03/03')->Nice(),
 			"Date->Nice() works with D/M/YY format"
 		);
-		$this->assertEquals('04/03/2003', DBField::create('Date', '4/3/2003')->Nice(),
+		$this->assertEquals('04/03/2003', DBField::create_field('Date', '4/3/2003')->Nice(),
 			"Date->Nice() works with D/M/YYYY format"
 		);
-		$this->assertEquals('04/03/2003', DBField::create('Date', '4-3-2003')->Nice(),
+		$this->assertEquals('04/03/2003', DBField::create_field('Date', '4-3-2003')->Nice(),
 			"Date->Nice() works with D-M-YYYY format"
 		);
-		$this->assertEquals('04/03/2003', DBField::create('Date', '2003-03-04')->Nice(),
+		$this->assertEquals('04/03/2003', DBField::create_field('Date', '2003-03-04')->Nice(),
 			"Date->Nice() works with YYYY-MM-DD format"
 		);
-		$this->assertEquals('04/03/2003', DBField::create('Date', '04/03/2003')->Nice(),
+		$this->assertEquals('04/03/2003', DBField::create_field('Date', '04/03/2003')->Nice(),
 			"Date->Nice() works with DD/MM/YYYY format"
 		);
-		$this->assertEquals('04/03/2003', DBField::create('Date', '04-03-2003')->Nice(),
+		$this->assertEquals('04/03/2003', DBField::create_field('Date', '04-03-2003')->Nice(),
 			"Date->Nice() works with DD/MM/YYYY format"
 		);
 	}
 	
 	function testLongDate() {
-		$this->assertEquals('1 April 2008', DBField::create('Date', 1206968400)->Long(),
+		$this->assertEquals('1 April 2008', DBField::create_field('Date', 1206968400)->Long(),
 			"Date->Long() works with numeric timestamp"
 		);
-		$this->assertEquals('1 April 2008', DBField::create('Date', '1206968400')->Long(),
+		$this->assertEquals('1 April 2008', DBField::create_field('Date', '1206968400')->Long(),
 			"Date->Long() works with string timestamp"
 		);
-		$this->assertEquals('31 March 2008', DBField::create('Date', 1206882000)->Long(),
+		$this->assertEquals('31 March 2008', DBField::create_field('Date', 1206882000)->Long(),
 			"Date->Long() works with numeric timestamp"
 		);
-		$this->assertEquals('31 March 2008', DBField::create('Date', '1206882000')->Long(),
+		$this->assertEquals('31 March 2008', DBField::create_field('Date', '1206882000')->Long(),
 			"Date->Long() works with numeric timestamp"
 		);
-		$this->assertEquals('3 April 2003', DBField::create('Date', '2003-4-3')->Long(),
+		$this->assertEquals('3 April 2003', DBField::create_field('Date', '2003-4-3')->Long(),
 			"Date->Long() works with YYYY-M-D"
 		);
-		$this->assertEquals('3 April 2003', DBField::create('Date', '3/4/2003')->Long(),
+		$this->assertEquals('3 April 2003', DBField::create_field('Date', '3/4/2003')->Long(),
 			"Date->Long() works with D/M/YYYY"
 		);
 	}
 
 	function testSetNullAndZeroValues() {
-		$date = DBField::create('Date', '');
+		$date = DBField::create_field('Date', '');
 		$this->assertNull($date->getValue(), 'Empty string evaluates to NULL');
 
-		$date = DBField::create('Date', null);
+		$date = DBField::create_field('Date', null);
 		$this->assertNull($date->getValue(), 'NULL is set as NULL');
 
-		$date = DBField::create('Date', false);
+		$date = DBField::create_field('Date', false);
 		$this->assertNull($date->getValue(), 'Boolean FALSE evaluates to NULL');
 
-		$date = DBField::create('Date', array());
+		$date = DBField::create_field('Date', array());
 		$this->assertNull($date->getValue(), 'Empty array evaluates to NULL');
 
-		$date = DBField::create('Date', '0');
+		$date = DBField::create_field('Date', '0');
 		$this->assertEquals('1970-01-01', $date->getValue(), 'Zero is UNIX epoch date');
 
-		$date = DBField::create('Date', 0);
+		$date = DBField::create_field('Date', 0);
 		$this->assertEquals('1970-01-01', $date->getValue(), 'Zero is UNIX epoch date');
 	}
 
 	function testDayOfMonth() {
-		$date = DBField::create('Date', '2000-10-10');
+		$date = DBField::create_field('Date', '2000-10-10');
 		$this->assertEquals('10', $date->DayOfMonth());
 		$this->assertEquals('10th', $date->DayOfMonth(true));
 
-		$range = $date->RangeString(DBField::create('Date', '2000-10-20'));
+		$range = $date->RangeString(DBField::create_field('Date', '2000-10-20'));
 		$this->assertEquals('10 - 20 Oct 2000', $range);
-		$range = $date->RangeString(DBField::create('Date', '2000-10-20'), true);
+		$range = $date->RangeString(DBField::create_field('Date', '2000-10-20'), true);
 		$this->assertEquals('10th - 20th Oct 2000', $range);
 	}
 }

--- a/tests/model/DatetimeTest.php
+++ b/tests/model/DatetimeTest.php
@@ -12,7 +12,7 @@
  */
 class SS_DatetimeTest extends SapphireTest {
 	function testNowWithSystemDate() {
-		$systemDatetime = DBField::create('SS_Datetime', date('Y-m-d H:i:s'));
+		$systemDatetime = DBField::create_field('SS_Datetime', date('Y-m-d H:i:s'));
 		$nowDatetime = SS_Datetime::now();
 		
 		$this->assertEquals($systemDatetime->Date(), $nowDatetime->Date());
@@ -22,14 +22,14 @@ class SS_DatetimeTest extends SapphireTest {
 		// Test setting
 		$mockDate = '2001-12-31 22:10:59';
 		SS_Datetime::set_mock_now($mockDate);
-		$systemDatetime = DBField::create('SS_Datetime', date('Y-m-d H:i:s'));
+		$systemDatetime = DBField::create_field('SS_Datetime', date('Y-m-d H:i:s'));
 		$nowDatetime = SS_Datetime::now();
 		$this->assertNotEquals($systemDatetime->Date(), $nowDatetime->Date());
 		$this->assertEquals($nowDatetime->getValue(), $mockDate);
 		
 		// Test clearing
 		SS_Datetime::clear_mock_now();
-		$systemDatetime = DBField::create('SS_Datetime', date('Y-m-d H:i:s'));
+		$systemDatetime = DBField::create_field('SS_Datetime', date('Y-m-d H:i:s'));
 		$nowDatetime = SS_Datetime::now();
 		$this->assertEquals($systemDatetime->Date(), $nowDatetime->Date());
 	}
@@ -37,19 +37,19 @@ class SS_DatetimeTest extends SapphireTest {
 	function testSetNullAndZeroValues() {
 		date_default_timezone_set('UTC');
 
-		$date = DBField::create('SS_Datetime', '');
+		$date = DBField::create_field('SS_Datetime', '');
 		$this->assertNull($date->getValue(), 'Empty string evaluates to NULL');
 
-		$date = DBField::create('SS_Datetime', null);
+		$date = DBField::create_field('SS_Datetime', null);
 		$this->assertNull($date->getValue(), 'NULL is set as NULL');
 
-		$date = DBField::create('SS_Datetime', false);
+		$date = DBField::create_field('SS_Datetime', false);
 		$this->assertNull($date->getValue(), 'Boolean FALSE evaluates to NULL');
 
-		$date = DBField::create('SS_Datetime', '0');
+		$date = DBField::create_field('SS_Datetime', '0');
 		$this->assertEquals('1970-01-01 00:00:00', $date->getValue(), 'String zero is UNIX epoch time');
 
-		$date = DBField::create('SS_Datetime', 0);
+		$date = DBField::create_field('SS_Datetime', 0);
 		$this->assertEquals('1970-01-01 00:00:00', $date->getValue(), 'Numeric zero is UNIX epoch time');
 	}
 

--- a/tests/model/HTMLTextTest.php
+++ b/tests/model/HTMLTextTest.php
@@ -108,30 +108,30 @@ class HTMLTextTest extends SapphireTest {
 	}	
 
 	public function testRAW() {
-		$data = DBField::create('HTMLText', 'This &amp; This');
+		$data = DBField::create_field('HTMLText', 'This &amp; This');
 		$this->assertEquals($data->RAW(), 'This &amp; This');
 
-		$data = DBField::create('HTMLText', 'This & This');
+		$data = DBField::create_field('HTMLText', 'This & This');
 		$this->assertEquals($data->RAW(), 'This & This');
 	}
 	
 	public function testXML() {
-		$data = DBField::create('HTMLText', 'This & This');
+		$data = DBField::create_field('HTMLText', 'This & This');
 		$this->assertEquals($data->XML(), 'This &amp; This');
 	}
 
 	public function testHTML() {
-		$data = DBField::create('HTMLText', 'This & This');
+		$data = DBField::create_field('HTMLText', 'This & This');
 		$this->assertEquals($data->HTML(), 'This &amp; This');
 	}
 
 	public function testJS() {
-		$data = DBField::create('HTMLText', '"this is a test"');
+		$data = DBField::create_field('HTMLText', '"this is a test"');
 		$this->assertEquals($data->JS(), '\"this is a test\"');
 	}
 
 	public function testATT() {
-		$data = DBField::create('HTMLText', '"this is a test"');
+		$data = DBField::create_field('HTMLText', '"this is a test"');
 		$this->assertEquals($data->ATT(), '&quot;this is a test&quot;');
 	}
 }

--- a/tests/model/StringFieldTest.php
+++ b/tests/model/StringFieldTest.php
@@ -12,7 +12,7 @@ class StringFieldTest extends SapphireTest {
 	function testLowerCase() {
 		$this->assertEquals(
 			'this is a test!',
-			DBField::create('StringFieldTest_MyStringField', 'This is a TEST!')->LowerCase()
+			DBField::create_field('StringFieldTest_MyStringField', 'This is a TEST!')->LowerCase()
 		);
 	}
 
@@ -22,7 +22,7 @@ class StringFieldTest extends SapphireTest {
 	function testUpperCase() {
 		$this->assertEquals(
 			'THIS IS A TEST!',
-			DBField::create('StringFieldTest_MyStringField', 'This is a TEST!')->UpperCase()
+			DBField::create_field('StringFieldTest_MyStringField', 'This is a TEST!')->UpperCase()
 		);
 	}
 

--- a/tests/model/TextTest.php
+++ b/tests/model/TextTest.php
@@ -99,7 +99,7 @@ class TextTest extends SapphireTest {
 		);
 		
 		foreach($cases as $originalValue => $expectedValue) {
-			$textObj = DBField::create('Text', $originalValue);
+			$textObj = DBField::create_field('Text', $originalValue);
 			$this->assertEquals($expectedValue, $textObj->BigSummary(4));
 		}
 	}
@@ -115,7 +115,7 @@ class TextTest extends SapphireTest {
 		$testKeyword3 = 'a';
 		$testKeyword3a = 'ate';
 
-		$textObj = DBField::create('Text', $testString1, 'Text');
+		$textObj = DBField::create_field('Text', $testString1, 'Text');
 		
 		$this->assertEquals(
 			'... text. It is a <span class="highlight">test</span>...',
@@ -145,27 +145,27 @@ class TextTest extends SapphireTest {
 	}	
 
 	public function testRAW() {
-		$data = DBField::create('Text', 'This &amp; This');
+		$data = DBField::create_field('Text', 'This &amp; This');
 		$this->assertEquals($data->RAW(), 'This &amp; This');
 	}
 	
 	public function testXML() {
-		$data = DBField::create('Text', 'This & This');
+		$data = DBField::create_field('Text', 'This & This');
 		$this->assertEquals($data->XML(), 'This &amp; This');
 	}
 
 	public function testHTML() {
-		$data = DBField::create('Text', 'This & This');
+		$data = DBField::create_field('Text', 'This & This');
 		$this->assertEquals($data->HTML(), 'This &amp; This');
 	}
 
 	public function testJS() {
-		$data = DBField::create('Text', '"this is a test"');
+		$data = DBField::create_field('Text', '"this is a test"');
 		$this->assertEquals($data->JS(), '\"this is a test\"');
 	}
 
 	public function testATT() {
-		$data = DBField::create('Text', '"this is a test"');
+		$data = DBField::create_field('Text', '"this is a test"');
 		$this->assertEquals($data->ATT(), '&quot;this is a test&quot;');
 	}
 }


### PR DESCRIPTION
This allows DataList::create('SiteTree') as equivalent to Object::create('DataList', 'SiteTree'), without
having to have a create() function on DataList.

Required for E_STRICT compliance, as child classes can't override create() if they change the arguments.

DBField::create() is also renamed to DBField::create_field(), as this does not just call the constructor, which all other cases of create() do.
