### PR TITLE
E_DEPRECATED fixes - split() replaced with preg_split()

### DIFF
--- a/admin/code/CMSBatchActionHandler.php
+++ b/admin/code/CMSBatchActionHandler.php
@@ -81,7 +81,7 @@ class CMSBatchActionHandler extends RequestHandler {
 		$actionHandler = new $actionClass();
 		
 		// Sanitise ID list and query the database for apges
-		$ids = split(' *, *', trim($request->requestVar('csvIDs')));
+		$ids = preg_split('/ *, */', trim($request->requestVar('csvIDs')));
 		foreach($ids as $k => $v) if(!is_numeric($v)) unset($ids[$k]);
 		
 		if($ids) {
@@ -135,7 +135,7 @@ class CMSBatchActionHandler extends RequestHandler {
 		$actionHandler = new $actionClass['class']();
 
 		// Sanitise ID list and query the database for apges
-		$ids = split(' *, *', trim($request->requestVar('csvIDs')));
+		$ids = preg_split('/ *, */', trim($request->requestVar('csvIDs')));
 		foreach($ids as $k => $id) $ids[$k] = (int)$id;
 		$ids = array_filter($ids);
 		
@@ -157,7 +157,7 @@ class CMSBatchActionHandler extends RequestHandler {
 		$actionHandler = new $actionClass();
 
 		// Sanitise ID list and query the database for apges
-		$ids = split(' *, *', trim($request->requestVar('csvIDs')));
+		$ids = preg_split('/ *, */', trim($request->requestVar('csvIDs')));
 		foreach($ids as $k => $id) $ids[$k] = (int)$id;
 		$ids = array_filter($ids);
 		

--- a/core/Core.php
+++ b/core/Core.php
@@ -38,7 +38,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // ENVIRONMENT CONFIG
 
-if(defined('E_DEPRECATED')) error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
+if(defined('E_DEPRECATED')) error_reporting(E_ALL & ~(E_STRICT));
 else error_reporting(E_ALL);
 
 /**

--- a/core/Diff.php
+++ b/core/Diff.php
@@ -800,7 +800,7 @@ class Diff
 		if(is_array($content)) $content = implode(',', $content);
 		
 		$content = str_replace(array("&nbsp;","<", ">"),array(" "," <", "> "),$content);
-		$candidateChunks = split("[\t\r\n ]+", $content);
+		$candidateChunks = preg_split("/[\t\r\n ]+/", $content);
 		while(list($i,$item) = each($candidateChunks)) {
 			if(isset($item[0]) && $item[0] == "<") {
 				$newChunk = $item;

--- a/dev/Debug.php
+++ b/dev/Debug.php
@@ -697,6 +697,7 @@ function errorHandler($errno, $errstr, $errfile, $errline) {
 
 		case E_NOTICE:
 		case E_USER_NOTICE:
+		case E_DEPRECATED:
 		case E_USER_DEPRECATED:
 			Debug::noticeHandler($errno, $errstr, $errfile, $errline, null);
 			break;

--- a/dev/DebugView.php
+++ b/dev/DebugView.php
@@ -30,6 +30,10 @@ class DebugView extends Object {
 			'title' => 'User Notice',
 			'class' => 'notice'
 		),
+		E_DEPRECATED => array(
+			'title' => 'Deprecation',
+			'class' => 'notice'
+		),
 		E_USER_DEPRECATED => array(
 			'title' => 'Deprecation',
 			'class' => 'notice'

--- a/thirdparty/simpletest/form.php
+++ b/thirdparty/simpletest/form.php
@@ -172,7 +172,7 @@ class SimpleForm {
      */
     function _addRadioButton(&$tag) {
         if (! isset($this->_radios[$tag->getName()])) {
-            $this->_widgets[] = &new SimpleRadioGroup();
+            $this->_widgets[] = new SimpleRadioGroup();
             $this->_radios[$tag->getName()] = count($this->_widgets) - 1;
         }
         $this->_widgets[$this->_radios[$tag->getName()]]->addWidget($tag);
@@ -191,7 +191,7 @@ class SimpleForm {
             $index = $this->_checkboxes[$tag->getName()];
             if (! SimpleTestCompatibility::isA($this->_widgets[$index], 'SimpleCheckboxGroup')) {
                 $previous = &$this->_widgets[$index];
-                $this->_widgets[$index] = &new SimpleCheckboxGroup();
+                $this->_widgets[$index] = new SimpleCheckboxGroup();
                 $this->_widgets[$index]->addWidget($previous);
             }
             $this->_widgets[$index]->addWidget($tag);

--- a/thirdparty/simpletest/http.php
+++ b/thirdparty/simpletest/http.php
@@ -98,9 +98,9 @@ class SimpleRoute {
      */
     function &_createSocket($scheme, $host, $port, $timeout) {
         if (in_array($scheme, array('https'))) {
-            $socket = &new SimpleSecureSocket($host, $port, $timeout);
+            $socket = new SimpleSecureSocket($host, $port, $timeout);
         } else {
-            $socket = &new SimpleSocket($host, $port, $timeout);
+            $socket = new SimpleSocket($host, $port, $timeout);
         }
         return $socket;
     }
@@ -279,7 +279,7 @@ class SimpleHttpRequest {
      *    @access protected
      */
     function &_createResponse(&$socket) {
-        $response = &new SimpleHttpResponse(
+        $response = new SimpleHttpResponse(
                 $socket,
                 $this->_route->getUrl(),
                 $this->_encoding);
@@ -516,13 +516,13 @@ class SimpleHttpResponse extends SimpleStickyError {
     function _parse($raw) {
         if (! $raw) {
             $this->_setError('Nothing fetched');
-            $this->_headers = &new SimpleHttpHeaders('');
+            $this->_headers = new SimpleHttpHeaders('');
         } elseif (! strstr($raw, "\r\n\r\n")) {
             $this->_setError('Could not split headers from content');
-            $this->_headers = &new SimpleHttpHeaders($raw);
+            $this->_headers = new SimpleHttpHeaders($raw);
         } else {
             list($headers, $this->_content) = split("\r\n\r\n", $raw, 2);
-            $this->_headers = &new SimpleHttpHeaders($headers);
+            $this->_headers = new SimpleHttpHeaders($headers);
         }
     }
     

--- a/thirdparty/simpletest/page.php
+++ b/thirdparty/simpletest/page.php
@@ -163,7 +163,7 @@ class SimplePageBuilder extends SimpleSaxListener {
      *    @access protected
      */
     function &_createPage($response) {
-        $page = &new SimplePage($response);
+        $page = new SimplePage($response);
         return $page;
     }
 
@@ -175,7 +175,7 @@ class SimplePageBuilder extends SimpleSaxListener {
      *    @access protected
      */
     function &_createParser(&$listener) {
-        $parser = &new SimpleHtmlSaxParser($listener);
+        $parser = new SimpleHtmlSaxParser($listener);
         return $parser;
     }
     
@@ -188,7 +188,7 @@ class SimplePageBuilder extends SimpleSaxListener {
      *    @access public
      */
     function startElement($name, $attributes) {
-        $factory = &new SimpleTagBuilder();
+        $factory = new SimpleTagBuilder();
         $tag = $factory->createTag($name, $attributes);
         if (! $tag) {
             return true;
@@ -641,7 +641,7 @@ class SimplePage {
      *    @access public
      */
     function acceptFormStart(&$tag) {
-        $this->_open_forms[] = &new SimpleForm($tag, $this);
+        $this->_open_forms[] = new SimpleForm($tag, $this);
     }
 
     /**

--- a/thirdparty/simpletest/parser.php
+++ b/thirdparty/simpletest/parser.php
@@ -197,7 +197,7 @@ class SimpleLexer {
         $this->_case = $case;
         $this->_regexes = array();
         $this->_parser = &$parser;
-        $this->_mode = &new SimpleStateStack($start);
+        $this->_mode = new SimpleStateStack($start);
         $this->_mode_handlers = array($start => $start);
     }
     
@@ -579,7 +579,7 @@ class SimpleHtmlSaxParser {
      *    @static
      */
     function &createLexer(&$parser) {
-        $lexer = &new SimpleHtmlLexer($parser);
+        $lexer = new SimpleHtmlLexer($parser);
         return $lexer;
     }
     

--- a/thirdparty/simpletest/url.php
+++ b/thirdparty/simpletest/url.php
@@ -106,7 +106,7 @@ class SimpleUrl {
         }
         if (preg_match('/^([^\/]*)@(.*)/', $url, $matches)) {
             $url = $prefix . $matches[2];
-            $parts = split(":", $matches[1]);
+            $parts = preg_split('/:/', $matches[1]);
             return array(
                     urldecode($parts[0]),
                     isset($parts[1]) ? urldecode($parts[1]) : false);
@@ -184,7 +184,7 @@ class SimpleUrl {
     function _parseRequest($raw) {
         $this->_raw = $raw;
         $request = new SimpleGetEncoding();
-        foreach (split("&", $raw) as $pair) {
+        foreach (preg_split('/&/', $raw) as $pair) {
             if (preg_match('/(.*?)=(.*)/', $pair, $matches)) {
                 $request->add($matches[1], urldecode($matches[2]));
             } elseif ($pair) {
@@ -379,7 +379,7 @@ class SimpleUrl {
      */
     function clearRequest() {
         $this->_raw = false;
-        $this->_request = &new SimpleGetEncoding();
+        $this->_request = new SimpleGetEncoding();
     }
     
     /**


### PR DESCRIPTION
Fixed all the E_DEPRECATED things I could find, split() replaced with preg_split() and usage of "&new Class()". Tests all seem to pass now, even with E_DEPRECATED enabled in error reporting level. There's a companion pull request for silverstripe-cms which replaces a usage of ereg_replace() with preg_replace().

Debug now handles E_DEPRECATED and E_USER_DEPRECATED as notice level errors, so these get revealed in unit tests.

Next step is E_STRICT compliance!
