### PR TITLE
API CHANGE Changed PasswordEncryptor to use ReflectionClass instead of eval()

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -64,10 +64,10 @@ if(!defined('EMAIL_BOUNCEHANDLER_KEY')) {
 }
 
 PasswordEncryptor::register('none', 'PasswordEncryptor_None');
-PasswordEncryptor::register('md5', 'PasswordEncryptor_LegacyPHPHash("md5")');
-PasswordEncryptor::register('sha1','PasswordEncryptor_LegacyPHPHash("sha1")');
-PasswordEncryptor::register('md5_v2.4', 'PasswordEncryptor_PHPHash("md5")');
-PasswordEncryptor::register('sha1_v2.4','PasswordEncryptor_PHPHash("sha1")');
+PasswordEncryptor::register('md5', 'PasswordEncryptor_LegacyPHPHash', array("md5"));
+PasswordEncryptor::register('sha1','PasswordEncryptor_LegacyPHPHash', array("sha1"));
+PasswordEncryptor::register('md5_v2.4', 'PasswordEncryptor_PHPHash', array("md5"));
+PasswordEncryptor::register('sha1_v2.4','PasswordEncryptor_PHPHash', array("sha1"));
 
 // Zend_Cache temp directory setting
 $_ENV['TMPDIR'] = TEMP_FOLDER; // for *nix

--- a/tests/security/PasswordEncryptorTest.php
+++ b/tests/security/PasswordEncryptorTest.php
@@ -29,13 +29,13 @@ class PasswordEncryptorTest extends SapphireTest {
 	}
 	
 	function testEncrytorPHPHashWithArguments() {
-		PasswordEncryptor::register('test_md5', 'PasswordEncryptor_PHPHash("md5")');
+		PasswordEncryptor::register('test_md5', 'PasswordEncryptor_PHPHash', array("md5"));
 		$e = PasswordEncryptor::create_for_algorithm('test_md5');
 		$this->assertEquals('md5', $e->getAlgorithm());
 	}
 	
 	function testEncrytorPHPHash() {
-		PasswordEncryptor::register('test_sha1', 'PasswordEncryptor_PHPHash("sha1")');
+		PasswordEncryptor::register('test_sha1', 'PasswordEncryptor_PHPHash', array("sha1"));
 		$e = PasswordEncryptor::create_for_algorithm('test_sha1');
 		$password = 'mypassword';
 		$salt = 'mysalt';
@@ -46,7 +46,7 @@ class PasswordEncryptorTest extends SapphireTest {
 	}
 	
 	function testEncrytorPHPHashCompare() {
-		PasswordEncryptor::register('test_sha1', 'PasswordEncryptor_PHPHash("sha1")');
+		PasswordEncryptor::register('test_sha1', 'PasswordEncryptor_PHPHash', array("sha1"));
 		$e = PasswordEncryptor::create_for_algorithm('test_sha1');
 		$this->assertTrue($e->compare(sha1('mypassword'), sha1('mypassword')));
 		$this->assertFalse($e->compare(sha1('mypassword'), sha1('mywrongpassword')));
@@ -59,7 +59,7 @@ class PasswordEncryptorTest extends SapphireTest {
 	 * 	php -r "echo(base_convert(sha1('mypassword'), 16, 36));"
 	 */
 	function testEncrytorLegacyPHPHashCompare() {
-		PasswordEncryptor::register('test_sha1legacy', 'PasswordEncryptor_LegacyPHPHash("sha1")');
+		PasswordEncryptor::register('test_sha1legacy', 'PasswordEncryptor_LegacyPHPHash', array("sha1"));
 		$e = PasswordEncryptor::create_for_algorithm('test_sha1legacy');
 		// precomputed hashes for 'mypassword' from different architectures
 		$amdHash = 'h1fj0a6m4o6k0sosks88oo08ko4gc4s';


### PR DESCRIPTION
As the use of eval() is discouraged (see:
http://de.php.net/manual/en/function.eval.php ), I've changed the
PasswordEncryptor to use ReflectionClass instead to instantiate its
subclasses. Note that the registering process now treats the class
names and instantiation parameters separately. Updated UnitTest is
included.
