### PR TITLE
Adjusted wording in DebugView for E_DEPRECATED and E_USER_DEPRECATED error levels

### DIFF
--- a/dev/DebugView.php
+++ b/dev/DebugView.php
@@ -31,11 +31,11 @@ class DebugView extends Object {
 			'class' => 'notice'
 		),
 		E_DEPRECATED => array(
-			'title' => 'Deprecation',
+			'title' => 'Deprecated',
 			'class' => 'notice'
 		),
 		E_USER_DEPRECATED => array(
-			'title' => 'Deprecation',
+			'title' => 'User Deprecated',
 			'class' => 'notice'
 		),
 		E_CORE_ERROR => array(


### PR DESCRIPTION
Tidied up the wording to be consistent with the other error levels, and adding a different message to distinguish E_USER_DEPRECATED from E_DEPRECATED now that E_DEPRECATED is no longer supressed in Core.php.
