### PR TITLE
Using deprecated StringField::Upper() and StringField::Lower(). Calling ...

### DIFF
--- a/model/fieldtypes/Enum.php
+++ b/model/fieldtypes/Enum.php
@@ -87,10 +87,10 @@ class Enum extends DBField {
 	}
 	
 	function Lower() {
-		return StringField::Lower();
+		return StringField::LowerCase();
 	}
 	function Upper() {
-		return StringField::Upper();
+		return StringField::UpperCase();
 	}
 }
 


### PR DESCRIPTION
...$MyEnumField.Upper on the template returns an unresolvable deprecation error.
