### PR TITLE
For png images with transparency, the imagesaveaplpha() needs to be set ...

### DIFF
--- a/filesystem/GD.php
+++ b/filesystem/GD.php
@@ -30,7 +30,12 @@ class GD extends Object {
 			switch($type) {
 				case 1: if(function_exists('imagecreatefromgif')) $this->setGD(imagecreatefromgif($filename)); break;
 				case 2: if(function_exists('imagecreatefromjpeg')) $this->setGD(imagecreatefromjpeg($filename)); break;
-				case 3: if(function_exists('imagecreatefrompng')) $this->setGD(imagecreatefrompng($filename)); break;
+				case 3: if(function_exists('imagecreatefrompng')) {
+					$img = imagecreatefrompng($filename);
+					imagesavealpha($img, true); // save alphablending setting (important)
+					$this->setGD($img);
+					break;
+				}
 			}
 		}
 		


### PR DESCRIPTION
...to true on the source image in order for the alpha to be preserved when using the modifier methods.
