### PR TITLE
MINOR Security::database_is_ready() check are doing duplicate DB queries...

### DIFF
--- a/security/Security.php
+++ b/security/Security.php
@@ -105,6 +105,14 @@ class Security extends Controller {
 	static $force_database_is_ready = null;
 	
 	/**
+	 * When the database has once been verified as ready, it will not do the
+	 * checks again.
+	 *
+	 * @var bool
+	 */
+	protected static $database_is_ready = false;
+
+	/**
 	 * Set location of word list file
 	 * 
 	 * @param string $wordListFile Location of word list file
@@ -800,6 +808,8 @@ class Security extends Controller {
 	public static function database_is_ready() {
 		// Used for unit tests
 		if(self::$force_database_is_ready !== NULL) return self::$force_database_is_ready;
+
+		if(self::$database_is_ready) return self::$database_is_ready;
 		
 		$requiredTables = ClassInfo::dataClassesFor('Member');
 		$requiredTables[] = 'Group';
@@ -822,6 +832,7 @@ class Security extends Controller {
 			
 			if($missingFields) return false;
 		}
+		self::$database_is_ready = true;
 		
 		return true;
 	}


### PR DESCRIPTION
... for Members.

The will make sure that if the database has been ready once, it is ready for the rest of the request

If a member is logged in the following happens:

For the homepage three calls are made to Controller::init()
- RootURLController::handleRequest
- ModelAsController::handleRequest
- ContentController::init()

For typical non root pages it will only be two.

Every call to database_is_ready() will trigger the following queries:

```
SHOW FULL FIELDS IN "Member"
SHOW FULL FIELDS IN "Group"
SHOW FULL FIELDS IN "Permission"
```

My change is to assume that no db schema structures are made during runtime.
