### PR TITLE
BUGFIX: remove form auto-detection from the generic JS state handler.

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -213,9 +213,6 @@ jQuery.noConflict();
 				var headers = {};
 				if(state.data.pjax) {
 					headers['X-Pjax'] = state.data.pjax;
-				} else if(contentEl[0] != null && contentEl.is('form')) {
-					// Replace a form
-					headers["X-Pjax"] = 'CurrentForm';
 				} else {
 					// Replace full RHS content area
 					headers["X-Pjax"] = 'Content';


### PR DESCRIPTION
Forms take care of PJAX state on their own in the submit and load functions (os-7126)
