### PR TITLE
MINOR Testing extended dates (very far in the past and future) in DateTest

### DIFF
--- a/tests/model/DateTest.php
+++ b/tests/model/DateTest.php
@@ -112,4 +112,16 @@ class DateTest extends SapphireTest {
 		$range = $date->RangeString(DBField::create_field('Date', '2000-10-20'), true);
 		$this->assertEquals('10th - 20th Oct 2000', $range);
 	}
+
+	function testExtendedDates() {
+		$date = DBField::create_field('Date', '1800-10-10');
+		$this->assertEquals('10 Oct 1800', $date->Format('d M Y'));
+
+		$date = DBField::create_field('Date', '1500-10-10');
+		$this->assertEquals('10 Oct 1500', $date->Format('d M Y'));
+
+		$date = DBField::create_field('Date', '3000-4-3');
+		$this->assertEquals('03 Apr 3000', $date->Format('d M Y'));
+	}
+
 }


### PR DESCRIPTION
Tests very old dates and also very far future dates can be parsed with the Date field type.

Ticket was raised here 3 years ago: http://open.silverstripe.org/ticket/3804
