### PR TITLE
API CHANGE Enable E_STRICT, but include DebugView, Log classes as these ...

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -40,7 +40,7 @@
 
 // ALL errors are reported, including E_STRICT by default *unless* the site is in
 // live mode, where reporting is limited to fatal errors and warnings (see later in this file)
-error_reporting(E_ALL & ~(E_STRICT));
+error_reporting(E_ALL | E_STRICT);
 
 /**
  * Include _ss_environment.php files
@@ -223,6 +223,10 @@ require_once 'core/ClassInfo.php';
 require_once 'view/TemplateGlobalProvider.php';
 require_once 'control/Director.php';
 require_once 'dev/Debug.php';
+require_once 'dev/DebugView.php';
+require_once 'dev/Backtrace.php';
+require_once 'dev/ZendLog.php';
+require_once 'dev/Log.php';
 require_once 'filesystem/FileFinder.php';
 require_once 'core/manifest/ClassLoader.php';
 require_once 'core/manifest/ClassManifest.php';


### PR DESCRIPTION
Re-enable E_STRICT after it was temporarily turned off.

Additionally, this fixes "class SS_Log not found" errors by explicitly requiring the required debugging classes in Core.php bootstrap code, because `SS_ClassLoader::registerAutoloader()` can't always guarantee that at the time the strict error was issued the Debug/Log classes were loaded yet.

This should be pulled _after_ this issue is fixed: http://open.silverstripe.org/ticket/7135 which allieviates the problem of changing every `getCMSFields` method when upgrading because of the parameter differences.
