### PR TITLE
ENHANCEMENT Remove use of deprecated extraStatics in core files

### DIFF
--- a/core/Extension.php
+++ b/core/Extension.php
@@ -52,7 +52,7 @@ abstract class Extension {
 	 * @static
 	 * @param $class
 	 */
-	static function add_to_class($class, $extensionClass, $args) {
+	static function add_to_class($class, $extensionClass, $args = null) {
 		Config::add_static_source($class, $extensionClass);
 	}
 

--- a/model/DataExtension.php
+++ b/model/DataExtension.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * An extension that adds additional functionality to a {@link DataObject}.
+  An extension that adds additional functionality to a {@link DataObject}.
  *
  * @package framework
  * @subpackage model
@@ -18,19 +18,18 @@ abstract class DataExtension extends Extension {
 	 * @var array
 	 */
 	protected static $extendable_statics = array(
-		'db' => true, 
+		'db' => true,
 		'has_one' => true,
 		'belongs_to' => true,
-		'indexes' => true, 
-		'defaults' => true, 
-		'has_many' => true, 
-		'many_many' => true, 
-		'belongs_many_many' => true, 
+		'indexes' => true,
+		'defaults' => true,
+		'has_many' => true,
+		'many_many' => true,
+		'belongs_many_many' => true,
 		'many_many_extraFields' => true,
 		'searchable_fields' => true,
 		'api_access' => false,
 	);
-
 
 	static function add_to_class($class, $extensionClass, $args = null) {
 		if(method_exists($class, 'extraDBFields')) {
@@ -185,12 +184,12 @@ abstract class DataExtension extends Extension {
 	 * by the extension
 	 * By default, the summaryField() of its owner will merge more fields defined in the extension's
 	 * $extra_fields['summary_fields']
+	 *
+	 * @param array $fields Array of field names
 	 */
-	function updateSummaryFields(&$fields){
-		$extra_fields = $this->extraStatics();
-		if(isset($extra_fields['summary_fields'])){
-			$summary_fields = $extra_fields['summary_fields'];
-			
+	function updateSummaryFields(&$fields) {
+		$summary_fields = Config::inst()->get($this->class, 'summary_fields');
+		if($summary_fields) {
 			// if summary_fields were passed in numeric array,
 			// convert to an associative array
 			if($summary_fields && array_key_exists(0, $summary_fields)) {
@@ -199,25 +198,20 @@ abstract class DataExtension extends Extension {
 			if($summary_fields) $fields = array_merge($fields, $summary_fields);
 		}
 	}
-	
+
 	/**
 	 * this function is used to provide modifications to the fields labels in CMS
 	 * by the extension
 	 * By default, the fieldLabels() of its owner will merge more fields defined in the extension's
 	 * $extra_fields['field_labels']
+	 *
+	 * @param array $labels Array of field labels
 	 */
-	function updateFieldLabels(&$lables){
-		$extra_fields = $this->extraStatics();
-		if(isset($extra_fields['field_labels'])){
-			$field_labels = $extra_fields['field_labels'];
-			if($field_labels) $lables = array_merge($lables, $field_labels);
+	function updateFieldLabels(&$labels) {
+		$field_labels = Config::inst()->get($this->class, 'field_labels');
+		if($field_labels) {
+			$labels = array_merge($labels, $field_labels);
 		}
-	}
-	
-	/**
-	 * Clear any internal caches.
-	 */
-	function flushCache() {
 	}
 
 }

--- a/tests/forms/uploadfield/UploadFieldTest.php
+++ b/tests/forms/uploadfield/UploadFieldTest.php
@@ -612,34 +612,32 @@
 
 class UploadFieldTest_Record extends DataObject implements TestOnly {
 
-static $db = array(
-	'Title' => 'Text',
-);
+	static $db = array(
+		'Title' => 'Text',
+	);
 
-static $has_one = array(
-	'HasOneFile' => 'File',
-	'HasOneFileMaxOne' => 'File',
-	'HasOneFileMaxTwo' => 'File',
-);
+	static $has_one = array(
+		'HasOneFile' => 'File',
+		'HasOneFileMaxOne' => 'File',
+		'HasOneFileMaxTwo' => 'File',
+	);
 
-static $has_many = array(
-	'HasManyFiles' => 'File',
-	'HasManyFilesMaxTwo' => 'File',
-);
+	static $has_many = array(
+		'HasManyFiles' => 'File',
+		'HasManyFilesMaxTwo' => 'File',
+	);
 
-static $many_many = array(
-	'ManyManyFiles' => 'File',
-);
+	static $many_many = array(
+		'ManyManyFiles' => 'File',
+	);
 
 }
 
 class UploadFieldTest_FileExtension extends DataExtension implements TestOnly {
 
-	function extraStatics($class = null, $extension = null) {
-		return array(
-			'has_one' => array('Record' => 'UploadFieldTest_Record')
-		);
-	}
+	public static $has_one = array(
+		'Record' => 'UploadFieldTest_Record'
+	);
 
 	function canDelete($member = null) {
 		if($this->owner->Name == 'nodelete.txt') return false;

--- a/tests/i18n/_fakewebroot/i18nothermodule/code/i18nTestModuleDecorator.php
+++ b/tests/i18n/_fakewebroot/i18nothermodule/code/i18nTestModuleDecorator.php
@@ -1,10 +1,8 @@
 <?php
 class i18nTestModuleExtension extends DataExtension {
-	function extraStatics($class=null, $extension=null) {
-		return array(
-			'db' => array(
-				'MyExtraField' => 'Varchar'
-			)
-		);
-	}
+
+	public static $db = array(
+		'MyExtraField' => 'Varchar'
+	);
+
 }

--- a/tests/model/DataExtensionTest.php
+++ b/tests/model/DataExtensionTest.php
@@ -177,7 +177,7 @@ class DataExtensionTest_Player extends DataObject implements TestOnly {
 
 class DataExtensionTest_PlayerExtension extends DataExtension implements TestOnly {
 	
-	function extraStatics($class=null, $extension=null) {
+	public static function add_to_class($class = null, $extensionClass = null, $args = null) {
 		// Only add these extensions if the $class is set to DataExtensionTest_Player, to
 		// test that the argument works.
 		if($class == 'DataExtensionTest_Player') {
@@ -197,23 +197,21 @@ class DataExtensionTest_PlayerExtension extends DataExtension implements TestOnl
 }
 
 class DataExtensionTest_ContactRole extends DataExtension implements TestOnly {
-	
-	function extraStatics($class=null, $extension=null) {
-		return array(
-			'db' => array(
-				'Website' => 'Varchar',
-				'Phone' => 'Varchar(255)',
-			),
-			'has_many' => array(
-				'RelatedObjects' => 'DataExtensionTest_RelatedObject'
-			),
-			'defaults' => array(
-				'Phone' => '123'
-			),
-			'api_access' => true,
-		);
-	}
-	
+
+	public static $db =array(
+		'db' => array(
+			'Website' => 'Varchar',
+			'Phone' => 'Varchar(255)',
+		),
+		'has_many' => array(
+			'RelatedObjects' => 'DataExtensionTest_RelatedObject'
+		),
+		'defaults' => array(
+			'Phone' => '123'
+		),
+		'api_access' => true,
+	);
+
 }
 
 class DataExtensionTest_RelatedObject extends DataObject implements TestOnly {
@@ -293,19 +291,19 @@ class DataExtensionTest_Ext2 extends DataExtension implements TestOnly {
 }
 
 class DataExtensionTest_Faves extends DataExtension implements TestOnly {
-	public function extraStatics($class=null, $extension=null) {
-		return array(
-			'many_many' => array(
-				'Faves' => 'DataExtensionTest_RelatedObject'
-			)
-		);
-	}
+
+	public static $many_many = array(
+		'Faves' => 'DataExtensionTest_RelatedObject'
+	);
+
 }
 
 class DataExtensionTest_AppliedToDO extends DataExtension implements TestOnly {
+
 	public function testMethodApplied() {
 		return "hello world";
 	}
+
 }
 
 DataObject::add_extension('DataExtensionTest_MyObject', 'DataExtensionTest_Ext1');


### PR DESCRIPTION
Remove use of `extraStatics` in core files and just define the statics directly on the extensions instead, or use `add_to_class()` if that's not possible. This brings it up to date with the new config system.
