### PR TITLE
ENHANCEMENT EmailField now uses type="email"

### DIFF
--- a/forms/EmailField.php
+++ b/forms/EmailField.php
@@ -11,11 +11,12 @@ class EmailField extends TextField {
 	}
 
 	function getAttributes() {
-		$attrs = array(
-			'type' => 'email',
+		return array_merge(
+			parent::getAttributes(),
+			array(
+				'type' => 'email'
+			)
 		);
-
-		return array_merge($attrs, $this->attributes);
 	}
 
 	/**


### PR DESCRIPTION
This has the benefit of allowing email validation in the browser, when using the required="required" attribute.
If using an old browser, the "email" type will fallback to "text" so it degrades gracefully in old browsers.
