### PR TITLE
BUGFIX Don't filter out attributes that are '0'

### DIFF
--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -374,7 +374,9 @@ class FormField extends RequestHandler {
 		if(!$attrs || is_string($attrs)) $attrs = $this->getAttributes();
 
 		// Remove empty
-		$attrs = array_filter((array)$attrs, create_function('$v', 'return ($v || $v === 0);')); ; 
+		$attrs = array_filter((array)$attrs, function($v) {
+			return ($v || $v === 0 || $v === '0');
+		}); 
 
 		// Remove excluded
 		if($exclude) $attrs = array_diff_key($attrs, array_flip($exclude));


### PR DESCRIPTION
This is causing a value of 0 in the database to be ignored.
