### PR TITLE
clear_all returns void (and not the result of inst_clearAll() invocation)

### DIFF
--- a/control/Session.php
+++ b/control/Session.php
@@ -257,12 +257,12 @@ class Session {
 	
 	/**
 	 * Clear all the values
+	 *
+	 * @return void
 	 */
 	public static function clear_all() {
-		$ret = self::current_session()->inst_clearAll();
-		self::$default_session = null;
-		
-		return $ret;
+		self::current_session()->inst_clearAll();
+		self::$default_session = null;			
 	}
 		
 	/**


### PR DESCRIPTION
The inst_clearAll method is not returning any value so it does not make sense that clear_all mehod returns the value of inst_clearAll inocartion. 

So, I suggest remove the return instruction and change the clear_all method documentation to be cleear that the method returns void
