### PR TITLE
MINOR: change the ugly user-facing CSRF message to more friendly

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -240,7 +240,7 @@ class Form extends RequestHandler {
 		// Protection against CSRF attacks
 		$token = $this->getSecurityToken();
 		if(!$token->checkRequest($request)) {
-			$this->httpError(400, "Security token doesn't match, possible CSRF attack.");
+			$this->httpError(400, "Sorry, your session has timed out.");
 		}
 		
 		// Determine the action button clicked


### PR DESCRIPTION
User does not necessarily knows what CSRF is, and tends to get scared by
this, thinking he has abused something. On the other hand users tend to
know what session expiry means.
