### PR TITLE
Only start session when necessary

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -94,6 +94,8 @@ class Director implements TemplateGlobalProvider {
 		}
 
 		// Load the session into the controller
+		if(!isset($_SESSION) && (isset($_COOKIE[session_name()]) || isset($_REQUEST[session_name()]))) Session::start();
+
 		$session = new Session(isset($_SESSION) ? $_SESSION : null);
 		
 		$result = Director::handleRequest($req, $session, $model);

--- a/main.php
+++ b/main.php
@@ -59,9 +59,7 @@ if (version_compare(phpversion(), '5.3.2', '<')) {
 /**
  * Include SilverStripe's core code
  */
-require_once("core/Core.php");
-
-Session::start();
+require_once('core/Core.php');
 
 // IIS will sometimes generate this.
 if(!empty($_SERVER['HTTP_X_ORIGINAL_URL'])) {

--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -791,9 +791,17 @@ class Versioned extends DataExtension {
 
 		if(!headers_sent() && !Director::is_cli()) {
 			if(Versioned::current_stage() == 'Live') {
-				Cookie::set('bypassStaticCache', null, 0, null, null, false, true /* httponly */);
+				// clear the cookie if it's set
+				if(!empty($_COOKIE['bypassStaticCache'])) {
+					Cookie::set('bypassStaticCache', null, 0, null, null, false, true /* httponly */);
+					unset($_COOKIE['bypassStaticCache']);
+				}
 			} else {
-				Cookie::set('bypassStaticCache', '1', 0, null, null, false, true /* httponly */);
+				// set the cookie if it's cleared
+				if(empty($_COOKIE['bypassStaticCache'])) {
+					Cookie::set('bypassStaticCache', '1', 0, null, null, false, true /* httponly */);
+					$_COOKIE['bypassStaticCache'] = 1;
+				}
 			}
 		}
 	}

--- a/security/SecurityToken.php
+++ b/security/SecurityToken.php
@@ -55,9 +55,6 @@ class SecurityToken extends Object implements TemplateGlobalProvider {
 	 */
 	function __construct($name = null) {
 		$this->name = ($name) ? $name : self::get_default_name();
-		// only regenerate if the token isn't already set in the session
-		if(!$this->getValue()) $this->setValue($this->generate());
-		
 		parent::__construct();
 	}
 	
@@ -132,7 +129,15 @@ class SecurityToken extends Object implements TemplateGlobalProvider {
 	 * @return String
 	 */
 	function getValue() {
-		return Session::get($this->getName());
+		$value = Session::get($this->getName());
+
+		// only regenerate if the token isn't already set in the session
+		if(!$value) {
+			$value = $this->generate();
+			$this->setValue($value);
+		}
+
+		return $value;
 	}
 	
 	/**

--- a/tests/control/SessionTest.php
+++ b/tests/control/SessionTest.php
@@ -45,6 +45,30 @@ class SessionTest extends SapphireTest {
 		$this->assertEquals($session, array('Test' => 'Test', 'Test-2' => 'Test-2'));
 	}
 
+	/**
+	 * Check that changedData isn't populated with junk when clearing non-existent entries.
+	 */
+	function testClearElementThatDoesntExist() {
+		$s = new Session(array('something' => array('does' => 'exist')));
+
+		$s->inst_clear('something.doesnt.exist');
+		$this->assertEquals(array(), $s->inst_changedData());
+
+		$s->inst_set('something-else', 'val');
+		$s->inst_clear('something-new');
+		$this->assertEquals(array('something-else' => 'val'), $s->inst_changedData());
+	}
+
+	/**
+	 * Check that changedData is populated with clearing data.
+	 */
+	function testClearElementThatDoesExist() {
+		$s = new Session(array('something' => array('does' => 'exist')));
+
+		$s->inst_clear('something.does');
+		$this->assertEquals(array('something' => array('does' => null)), $s->inst_changedData());
+	}
+
 	function testNonStandardPath(){
 		Session::set_session_store_path(realpath(dirname($_SERVER['DOCUMENT_ROOT']) . '/../session'));
 		Session::start();


### PR DESCRIPTION
Don't start the session until it's actually necessary, which is to say there is a cookie available with the current PHP session name (or a request variable with the session_name() - typically PHPSESSID.) The latter allows for passing session ID through as an alternative to cookies.
