### PR TITLE
BUGFIX: Change requirement rubrics to remove confusion

### DIFF
--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -308,7 +308,7 @@ class InstallRequirements {
 					$databaseConfig,
 					array(
 						"Database Configuration",
-						"Database access credentials correct",
+						"Database access credentials",
 						"That username/password doesn't work"
 					)
 				)) {
@@ -316,7 +316,7 @@ class InstallRequirements {
 						$databaseConfig,
 						array(
 							"Database Configuration",
-							"Database server meets required version",
+							"Database server version requirement",
 							'',
 							'Version ' . $this->getDatabaseConfigurationHelper($databaseConfig['type'])->getDatabaseVersion($databaseConfig)
 						)
@@ -461,14 +461,14 @@ class InstallRequirements {
 		// Check for Standard PHP Library (SPL) support
 		$this->requireFunction('spl_classes', array('PHP Configuration', 'SPL support', 'Standard PHP Library (SPL) not included in PHP.'));
 
-		$this->requireDateTimezone(array('PHP Configuration', 'date.timezone set and valid', 'date.timezone option in php.ini must be set correctly.', ini_get('date.timezone')));
+		$this->requireDateTimezone(array('PHP Configuration', 'date.timezone setting and validity', 'date.timezone option in php.ini must be set correctly.', ini_get('date.timezone')));
 
-		$this->suggestPHPSetting('asp_tags', array(false,0,''), array('PHP Configuration', 'asp_tags option turned off', 'This should be turned off as it can cause issues with SilverStripe'));
-		$this->suggestPHPSetting('magic_quotes_gpc', array(false,0,''), array('PHP Configuration', 'magic_quotes_gpc option turned off', 'This should be turned off, as it can cause issues with cookies. More specifically, unserializing data stored in cookies.'));
-		$this->suggestPHPSetting('display_errors', array(false,0,''), array('PHP Configuration', 'display_errors option turned off', 'Unless you\'re in a development environment, this should be turned off, as it can expose sensitive data to website users.'));
+		$this->suggestPHPSetting('asp_tags', array(false,0,''), array('PHP Configuration', 'asp_tags option', 'This should be turned off as it can cause issues with SilverStripe'));
+		$this->suggestPHPSetting('magic_quotes_gpc', array(false,0,''), array('PHP Configuration', 'magic_quotes_gpc option', 'This should be turned off, as it can cause issues with cookies. More specifically, unserializing data stored in cookies.'));
+		$this->suggestPHPSetting('display_errors', array(false,0,''), array('PHP Configuration', 'display_errors option', 'Unless you\'re in a development environment, this should be turned off, as it can expose sensitive data to website users.'));
 
 		// Check memory allocation
-		$this->requireMemory(32*1024*1024, 64*1024*1024, array("PHP Configuration", "Memory allocated (PHP config option 'memory_limit')", "SilverStripe needs a minimum of 32M allocated to PHP, but recommends 64M.", ini_get("memory_limit")));
+		$this->requireMemory(32*1024*1024, 64*1024*1024, array("PHP Configuration", "Memory allocation (PHP config option 'memory_limit')", "SilverStripe needs a minimum of 32M allocated to PHP, but recommends 64M.", ini_get("memory_limit")));
 
 		return $this->errors;
 	}


### PR DESCRIPTION
Resolves #7199

Change all the rubrics to be nouns or questions, rather than a statement of
the desired setting. If the setting is correct, we get a nice green OK; if
not, it was confusing for the rubric to state the opposite of the failure
mode, which is described in the long message.
