### PR TITLE
BUGFIX: absoluteURLs() rewrites URLs in list-style-image elements

### DIFF
--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -62,6 +62,7 @@ class HTTP {
 		}
 		$regExps[] = '/(background-image:[^;]*url *\()([^)]+)(\))/ie';
 		$regExps[] = '/(background:[^;]*url *\()([^)]+)(\))/ie';
+		$regExps[] = '/(list-style-image:[^;]*url *\()([^)]+)(\))/ie';
 
 		// Make
 		$code = 'stripslashes("$1") . (' . str_replace('$URL', 'stripslashes("$2")', $code) . ') . stripslashes("$3")';


### PR DESCRIPTION
This applies the patch from and resolves #6798: http://open.silverstripe.org/ticket/6798
