### PR TITLE
Member::onChangeGroups() should allow ADMIN permission grant if logged in user is admin

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -702,9 +702,9 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * @return boolean
 	 */
 	function onChangeGroups($ids) {
-		// Filter out admin groups to avoid privilege escalation, 
-		// unless the current user is an admin already
-		if(!Permission::checkMember($this, 'ADMIN')) {
+		// Filter out admin groups to avoid privilege escalation,
+		// unless the current user is an admin already OR the logged in user is an admin
+		if(!(Permission::check('ADMIN') || Permission::checkMember($this, 'ADMIN'))) {
 			$adminGroups = Permission::get_groups_by_permission('ADMIN');
 			$adminGroupIDs = ($adminGroups) ? $adminGroups->column('ID') : array();
 			return count(array_intersect($ids, $adminGroupIDs)) == 0;

--- a/tests/security/MemberTest.php
+++ b/tests/security/MemberTest.php
@@ -551,6 +551,14 @@ class MemberTest extends FunctionalTest {
 			$staffMember->onChangeGroups(array($newAdminGroup->ID)),
 			'Adding new admin group relation is not allowed for non-admin members'
 		);
+
+		$this->session()->inst_set('loggedInAs', $adminMember->ID);
+		$this->assertTrue(
+			$staffMember->onChangeGroups(array($newAdminGroup->ID)),
+			'Adding new admin group relation is allowed for normal users, when granter is logged in as admin'
+		);
+		$this->session()->inst_set('loggedInAs', null);
+
 		$this->assertTrue(
 			$adminMember->onChangeGroups(array($newAdminGroup->ID)),
 			'Adding new admin group relation is allowed for admin members'


### PR DESCRIPTION
`Member::onChangeGroups()` now checks for current _logged in_ member as admin, so if the logged in user is has `ADMIN` permissions, they can grant `ADMIN` permissions to non-admin members.

I found this bug when on SS 2.4, a logged in admin couldn't grant a new member with admin permissions.
