### PR TITLE
ENHANCEMENT: added ellipsis to breadcrumbs when text overflows - added t...

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -262,7 +262,9 @@ body.cms { overflow: hidden; }
 .cms-content-header .backlink span.btn-icon-back { height: 16px; }
 .cms-content-header h2 { padding: 8px 8px 0 8px; font-size: 14px; line-height: 24px; font-weight: bold; text-shadow: #bfcad2 1px 1px 0; margin: 0; display: table-cell; vertical-align: top; width: 100%; }
 .cms-content-header h2 .breadcrumbs-wrapper { display: table-row; }
-.cms-content-header h2 .breadcrumbs-wrapper .crumb { display: table-cell; line-height: 26px; }
+.cms-content-header h2 .breadcrumbs-wrapper .crumb { display: table-cell; line-height: 26px; position: relative; }
+.cms-content-header h2 .breadcrumbs-wrapper .crumb .show-ellipsis { position: absolute; top: 0; right: 0; display: none; padding-right: 5px; }
+.cms-content-header h2 .breadcrumbs-wrapper .crumb.extra-padding { padding-right: 15px; }
 .cms-content-header div { display: table-row; }
 .cms-content-header div .cms_backlink { display: table-cell; vertical-align: middle; width: auto; }
 .cms-content-header .cms-content-header-tabs { display: table-cell; white-space: nowrap; width: 100%; }

--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -559,6 +559,34 @@ jQuery.noConflict();
 			e.preventDefault();
 		}
 	});
+
+	/**
+	 * CMS Breadcrumbs - when breadcrumbs overflow (due to window size), adds ellipsis. 
+	 */
+
+	$('.breadcrumbs-wrapper').entwine({
+		updateEllipsis: function() {
+			this.find('.crumb').each(function() {
+				//checks for height of breadcrumb. If it is greater than 26px then the text is wrapping and so ellipsis are shown.
+				if ($(this).height() > 26) {
+					$(this).find('.show-ellipsis').show();
+					$(this).addClass('extra-padding');
+				} else {
+					$(this).find('.show-ellipsis').hide();
+					$(this).removeClass('extra-padding');
+				}
+			});
+		},
+	});
+	//if window size causes text wrapping in breadcrumbs then updateEllipsis is triggered on page load
+	//otherwise the updateEllipsis function is triggered every time the window is resized.
+	$(document).ready(function(){
+		var breadcrumbs = $('.breadcrumbs-wrapper');
+		$(window).bind('resize', function() {
+			breadcrumbs.updateEllipsis();
+		});
+		breadcrumbs.updateEllipsis();
+	});
 	
 }(jQuery));
 

--- a/admin/scss/_style.scss
+++ b/admin/scss/_style.scss
@@ -122,6 +122,17 @@ body.cms {
 			.crumb {
 				display:table-cell;
 				line-height:26px;
+				position:relative;
+				.show-ellipsis {
+					position:absolute;
+					top:0;
+					right:0;
+					display:none;
+					padding-right:5px;
+				}
+			}
+			.crumb.extra-padding {
+				padding-right:15px;
 			}
 		}
 	}

--- a/admin/templates/CMSBreadcrumbs.ss
+++ b/admin/templates/CMSBreadcrumbs.ss
@@ -1,9 +1,9 @@
 <div class="breadcrumbs-wrapper">
 	<% control Breadcrumbs %>
 		<% if Last %>
-			<span class="cms-panel-link crumb">$Title.XML</span>
+			<span class="cms-panel-link crumb">$Title.XML<span class="show-ellipsis">...</span></span>
 		<% else %>
-			<a class="cms-panel-link crumb" href="$Link">$Title.XML</a>/
+			<a class="cms-panel-link crumb" href="$Link" title="$Title.XML">$Title.XML<span class="show-ellipsis">...</span></a>/
 		<% end_if %>
 	<% end_control %>
 </div>

--- a/css/UnitTesting.css
+++ b/css/UnitTesting.css
@@ -8,17 +8,17 @@ table.details tr { background: #eeeee0; }
 
 p { line-height: 1.5em; margin-top: 0.5em; margin-bottom: 1.0em; }
 
-h1 { margin: 0px 0px 5px; font: 165% verdana,arial,helvetica; }
+h1 { margin: 0px 0px 5px; font: 165% verdana, arial, helvetica; }
 
-h2 { margin-top: 1em; margin-bottom: 0.5em; font: bold 125% verdana,arial,helvetica; }
+h2 { margin-top: 1em; margin-bottom: 0.5em; font: bold 125% verdana, arial, helvetica; }
 
-h3 { margin-bottom: 0.5em; font: bold 115% verdana,arial,helvetica; }
+h3 { margin-bottom: 0.5em; font: bold 115% verdana, arial, helvetica; }
 
-h4 { margin-bottom: 0.5em; font: bold 100% verdana,arial,helvetica; }
+h4 { margin-bottom: 0.5em; font: bold 100% verdana, arial, helvetica; }
 
-h5 { margin-bottom: 0.5em; font: bold 100% verdana,arial,helvetica; }
+h5 { margin-bottom: 0.5em; font: bold 100% verdana, arial, helvetica; }
 
-h6 { margin-bottom: 0.5em; font: bold 100% verdana,arial,helvetica; }
+h6 { margin-bottom: 0.5em; font: bold 100% verdana, arial, helvetica; }
 
 .Error { font-weight: bold; color: red; }
 


### PR DESCRIPTION
...ool tips on hover so that the whole breadcrumb can be seen.

Ok so I have come up with a solution to the breadcrumbs overflow. We now have ellipsis working when each breadcrumb overflows. I wasn't able to come up with a good solution for showing the whole breadcrumb on click of the ellipsis though, the only thing that I thought would be useful was to put a 'tooltip' on hover so that the user could see the full link of the breadcrumb. Unfortunately there is a small issue of when the text wraps the width of the breadcrumb is set to the longest line of text, this means that if the first of the breadcrumb is short it then is left with a gap after it. eg: Mr. Johnston would end up looking like Mr       ... /  I can't see a work around for this at this stage.
