### PR TITLE
MINOR: Fix style according to style guidelines, and add a comment about ...

### DIFF
--- a/security/PasswordEncryptor.php
+++ b/security/PasswordEncryptor.php
@@ -134,12 +134,18 @@ class PasswordEncryptor_Blowfish extends PasswordEncryptor {
 	protected static $cost = 10;
 
 	function encrypt($password, $salt = null, $member = null) {
+		// We use $2y$ here instead of $2a$ - in PHP < 5.3.7, passwords
+		// with non-ascii characters will use a flawed version of the blowfish
+		// algorithm when specified with $2a$. $2y$ specifies non-flawed version
+		// in all cases.
+		// See https://bugs.php.net/bug.php?id=55477&edit=1
 		$method_and_salt = '$2y$' . $salt;
 		$encrypted_password = crypt($password, $method_and_salt);
 		// We *never* want to generate blank passwords. If something
 		// goes wrong, throw an exception.
-		if(strpos($encrypted_password, $method_and_salt) === false)
+		if(strpos($encrypted_password, $method_and_salt) === false) {
 			throw new PasswordEncryptor_EncryptionFailed('Blowfish password encryption failed.');
+		}
 
 		// Remove the method and salt from the password, as the salt
 		// is stored in a separate column.


### PR DESCRIPTION
...use of "$2y" instead of "$2a"
