### PR TITLE
BUGFIX: Put all php file inclusions/exclusions into a single file

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,7 +1,7 @@
 <FilesMatch "\.(php|php3|php4|php5|phtml|inc)$">
 	Deny from all
 </FilesMatch>
-<FilesMatch "(main|static-main|rpc)\.php$">
+<FilesMatch "(main|static-main|rpc|tiny_mce_gzip)\.php$">
 	Allow from all
 </FilesMatch>
 <FilesMatch "silverstripe_version$">

--- a/thirdparty/tinymce/.htaccess
+++ b/thirdparty/tinymce/.htaccess
@@ -1,3 +1,0 @@
-<FilesMatch "\.(php)$">
-	Allow from all
-</FilesMatch>


### PR DESCRIPTION
Some servers don't seem to allow reenabling of file access in a subdirection .htaccess file.

See http://www.silverstripe.org/installing-silverstripe/show/19784

I'm not really sure what's different about gakenny's server, but the fact of the matter is, the current configuration is brittle.  I suspect it's a minor behavioural change between Apache versions, something resulting from a plugin such as mod_security, or a difference introduced in one of those commercial Apache forks.

I don't see any other htaccess files in framework with a similar issue, nor any other PHP files we need to give access to, and the amended configuration works fine on my Apache, so I think this changes should be safe.
