### PR TITLE
API CHANGE Deprecated internal access to SQLQuery properties

### DIFF
--- a/core/PaginatedList.php
+++ b/core/PaginatedList.php
@@ -137,9 +137,9 @@ class PaginatedList extends SS_ListDecorator {
 	 * @param SQLQuery $query
 	 */
 	public function setPaginationFromQuery(SQLQuery $query) {
-		if ($query->limit) {
-			$this->setPageLength($query->limit['limit']);
-			$this->setPageStart($query->limit['start']);
+		if ($limit = $query->getLimit()) {
+			$this->setPageLength($limit['limit']);
+			$this->setPageStart($limit['start']);
 			$this->setTotalItems($query->unlimitedRowCount());
 		}
 	}

--- a/docs/en/changelogs/3.0.0.md
+++ b/docs/en/changelogs/3.0.0.md
@@ -182,6 +182,27 @@ The abstract `RelationList` class and its implementations `ManyManyList` and `Ha
 are replacing the `ComponentSet` API, which is only relevant if you have instanciated these manually.
 Relations are retrieved through the same way (e.g. `$myMember->Groups()`).
 
+### `SQLQuery` changes ###
+
+`SQLQuery` has been changed so direct access to internal properties `$from`, `$select`, `$orderby` is
+now deprecated.
+
+Instead, there are now methods you can call which allow you to get and set SQL clauses instead.
+
+ * `$from` getter is `getFrom()` and setters `setFrom()` and `addFrom()`
+ * `$select` getter is `getSelect()` and setters `setSelect()` and `addSelect()`
+ * `$where` getter is `getWhere()` and setter `setWhere()` and `addWhere()`
+ * `$orderby` getter is `getOrderBy()` and setter `setOrderBy()` and `addOrderBy()`
+ * `$groupby` getter is `getGroupBy()` and setter `getGroupBy()` and `addGroupBy()`
+ * `$having` getter is `getHaving()` and setter `setHaving()` and `addHaving()`
+ * `$limit` getter is `getLimit()` and setter `setLimit()`
+ * `$distinct` getter is `getDistinct()` and setter `setDistinct()`
+ * `$delete` getter is `getDelete()` and setter `setDelete()`
+ * `$connective` getter is `getConnective()` and settter `setConnective()`
+
+ * `innerJoin()` has been renamed to `addInnerJoin()`
+ * `leftJoin()` has been renamed to `addLeftJoin()`
+
 ### InnoDB driver for existing and new tables on MySQL (instead of MyISAM) [innodb]###
 
 SilverStripe has traditionally created all MySQL tables with the MyISAM storage driver,

--- a/model/DataList.php
+++ b/model/DataList.php
@@ -201,7 +201,7 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 		
 		return $this;
 	}
-	
+
 	/**
 	 * Filter the list to include items with these charactaristics
 	 *

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1216,9 +1216,9 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 		//    obviously, that means getting requireTable() to configure cascading deletes ;-)
 		$srcQuery = DataList::create($this->class, $this->model)->where("ID = $this->ID")->dataQuery()->query();
 		foreach($srcQuery->queriedTables() as $table) {
-			$query = new SQLQuery("*", array('"'.$table.'"'));
-			$query->where("\"ID\" = $this->ID");
-			$query->delete = true;
+			$query = new SQLQuery("*", array('"' . $table . '"'));
+			$query->setWhere("\"ID\" = $this->ID");
+			$query->setDelete(true);
 			$query->execute();
 		}
 		// Remove this item out of any caches

--- a/model/ManyManyList.php
+++ b/model/ManyManyList.php
@@ -115,15 +115,15 @@ class ManyManyList extends RelationList {
 	    if(!is_numeric($itemID)) throw new InvalidArgumentException("ManyManyList::removeById() expecting an ID");
 
 		$query = new SQLQuery("*", array("\"$this->joinTable\""));
-		$query->delete = true;
+		$query->setDelete(true);
 		
 		if($filter = $this->foreignIDFilter()) {
-			$query->where($filter);
+			$query->setWhere($filter);
 		} else {
 			user_error("Can't call ManyManyList::remove() until a foreign ID is set", E_USER_WARNING);
 		}
 		
-		$query->where("\"$this->localKey\" = {$itemID}");
+		$query->addWhere("\"$this->localKey\" = {$itemID}");
 		$query->execute();
 	}
 
@@ -132,10 +132,9 @@ class ManyManyList extends RelationList {
      */
     function removeAll() {
 		$query = $this->dataQuery()->query();
-		$query->delete = true;
-		$query->select(array('*'));
-		$query->from = array("\"$this->joinTable\"");
-		$query->orderby = null;
+		$query->setDelete(true);
+		$query->setSelect(array('*'));
+		$query->setFrom("\"$this->joinTable\"");
 		$query->execute();
     }
 

--- a/model/MySQLDatabase.php
+++ b/model/MySQLDatabase.php
@@ -855,9 +855,9 @@ class MySQLDatabase extends SS_Database {
 			$query = $list->dataQuery()->query();
 
 			// There's no need to do all that joining
-			$query->from = array(str_replace(array('"','`'),'',$baseClasses[$class]) => $baseClasses[$class]);
-			$query->select($select[$class]);
-			$query->orderby = null;
+			$query->setFrom(array(str_replace(array('"','`'), '', $baseClasses[$class]) => $baseClasses[$class]));
+			$query->setSelect($select[$class]);
+			$query->setOrderBy(array());
 			
 			$querySQLs[] = $query->sql();
 			$totalCount += $query->unlimitedRowCount();

--- a/tests/model/DbDatetimeTest.php
+++ b/tests/model/DbDatetimeTest.php
@@ -91,9 +91,9 @@ class DbDatetimeTest extends FunctionalTest {
 			$this->matchesRoughly($result, date('Y-m-d H:i:s', strtotime('+1 Day', $this->getDbNow())), 'tomorrow');
 
 			$query = new SQLQuery();
-			$query->select(array("test" => $this->adapter->datetimeIntervalClause('"Created"', '-15 Minutes')))
-			 	->from('"DbDateTimeTest_Team"')
-				->limit(1);
+			$query->setSelect(array("test" => $this->adapter->datetimeIntervalClause('"Created"', '-15 Minutes')))
+			 	->setFrom('"DbDateTimeTest_Team"')
+				->setLimit(1);
 			$result = $query->execute()->value();
 			$this->matchesRoughly($result, date('Y-m-d H:i:s', strtotime(Dataobject::get_one('DbDateTimeTest_Team')->Created) - 900), '15 Minutes before creating fixture');
 
@@ -116,9 +116,9 @@ class DbDatetimeTest extends FunctionalTest {
 			$this->matchesRoughly($result, -45 * 60, 'now - 45 minutes ahead');
 
 			$query = new SQLQuery();
-			$query->select(array("test" => $this->adapter->datetimeDifferenceClause('"LastEdited"', '"Created"')))
-				->from('"DbDateTimeTest_Team"')
-				->limit(1);
+			$query->setSelect(array("test" => $this->adapter->datetimeDifferenceClause('"LastEdited"', '"Created"')))
+				->setFrom('"DbDateTimeTest_Team"')
+				->setLimit(1);
 				
 			$result = $query->execute()->value();
 			$lastedited = Dataobject::get_one('DbDateTimeTest_Team')->LastEdited;

--- a/tests/model/PaginatedListTest.php
+++ b/tests/model/PaginatedListTest.php
@@ -34,10 +34,12 @@ class PaginatedListTest extends SapphireTest {
 
 	public function testSetPaginationFromQuery() {
 		$query = $this->getMock('SQLQuery');
-		$query->limit = array('limit' => 15, 'start' => 30);
+		$query->expects($this->once())
+		      ->method('getLimit')
+			  ->will($this->returnValue(array('limit' => 15, 'start' => 30)));
 		$query->expects($this->once())
 		      ->method('unlimitedRowCount')
-		      ->will($this->returnValue(100));
+			  ->will($this->returnValue(100));
 
 		$list = new PaginatedList(new ArrayList());
 		$list->setPaginationFromQuery($query);

--- a/tests/model/SQLQueryTest.php
+++ b/tests/model/SQLQueryTest.php
@@ -15,25 +15,25 @@ class SQLQueryTest extends SapphireTest {
 	
 	function testSelectFromBasicTable() {
 		$query = new SQLQuery();
-		$query->from[] = "MyTable";
+		$query->setFrom('MyTable');
 		$this->assertEquals("SELECT * FROM MyTable", $query->sql());
-		$query->from[] = "MyJoin";
+		$query->addFrom('MyJoin');
 		$this->assertEquals("SELECT * FROM MyTable MyJoin", $query->sql());
 	}
 	
 	function testSelectFromUserSpecifiedFields() {
 		$query = new SQLQuery();
-		$query->select(array("Name", "Title", "Description"));
-		$query->from[] = "MyTable";
+		$query->setSelect(array("Name", "Title", "Description"));
+		$query->setFrom("MyTable");
 		$this->assertEquals("SELECT Name, Title, Description FROM MyTable", $query->sql());
 	}
 	
 	function testSelectWithWhereClauseFilter() {
 		$query = new SQLQuery();
-		$query->select(array("Name","Meta"));
-		$query->from[] = "MyTable";
-		$query->where[] = "Name = 'Name'";
-		$query->where[] = "Meta = 'Test'";
+		$query->setSelect(array("Name","Meta"));
+		$query->setFrom("MyTable");
+		$query->setWhere("Name = 'Name'");
+		$query->addWhere("Meta = 'Test'");
 		$this->assertEquals("SELECT Name, Meta FROM MyTable WHERE (Name = 'Name') AND (Meta = 'Test')", $query->sql());
 	}
 	
@@ -46,132 +46,115 @@ class SQLQueryTest extends SapphireTest {
 	
 	function testSelectWithChainedMethods() {
 		$query = new SQLQuery();
-		$query->select("Name","Meta")->from("MyTable")->where("Name", "Name")->where("Meta", "Test");
+		$query->setSelect("Name","Meta")->setFrom("MyTable")->setWhere("Name = 'Name'")->addWhere("Meta = 'Test'");
 		$this->assertEquals("SELECT Name, Meta FROM MyTable WHERE (Name = 'Name') AND (Meta = 'Test')", $query->sql());
 	}
 	
 	function testCanSortBy() {
 		$query = new SQLQuery();
-		$query->select("Name","Meta")->from("MyTable")->where("Name", "Name")->where("Meta", "Test");
+		$query->setSelect("Name","Meta")->setFrom("MyTable")->setWhere("Name = 'Name'")->addWhere("Meta = 'Test'");
 		$this->assertTrue($query->canSortBy('Name ASC'));
 		$this->assertTrue($query->canSortBy('Name'));
 	}
 	
 	function testSelectWithChainedFilterParameters() {
 		$query = new SQLQuery();
-		$query->select(array("Name","Meta"))->from("MyTable");
-		$query->where("Name = 'Name'")->where("Meta","Test")->where("Beta", "!=", "Gamma");
-		$this->assertEquals("SELECT Name, Meta FROM MyTable WHERE (Name = 'Name') AND (Meta = 'Test') AND (Beta != 'Gamma')", $query->sql());		
-	}
-	
-	function testSelectWithPredicateFilters() {
-	    /* this is no longer part of this
-		$query = new SQLQuery();
-		$query->select(array("Name"))->from("SQLQueryTest_DO");
-
-		$match = new ExactMatchFilter("Name", "Value");
-		$match->setModel('SQLQueryTest_DO');
-		$match->apply($query);
-
-		$match = new PartialMatchFilter("Meta", "Value");
-		$match->setModel('SQLQueryTest_DO');
-		$match->apply($query);
-
-		$this->assertEquals("SELECT Name FROM SQLQueryTest_DO WHERE (\"SQLQueryTest_DO\".\"Name\" = 'Value') AND (\"SQLQueryTest_DO\".\"Meta\" LIKE '%Value%')", $query->sql());
-		*/
+		$query->setSelect(array("Name","Meta"))->setFrom("MyTable");
+		$query->setWhere("Name = 'Name'")->addWhere("Meta = 'Test'")->addWhere("Beta != 'Gamma'");
+		$this->assertEquals("SELECT Name, Meta FROM MyTable WHERE (Name = 'Name') AND (Meta = 'Test') AND (Beta != 'Gamma')", $query->sql());
 	}
 	
 	function testSelectWithLimitClause() {
-		// These are MySQL specific :-S
-		if(DB::getConn() instanceof MySQLDatabase) {
-			// numeric limit
-			$query = new SQLQuery();
-			$query->from[] = "MyTable";
-			$query->limit(99);
-			$this->assertEquals("SELECT * FROM MyTable LIMIT 99", $query->sql());
-		
-			// array limit with start (MySQL specific)
-			$query = new SQLQuery();
-			$query->from[] = "MyTable";
-			$query->limit(99, 97);
-			$this->assertEquals("SELECT * FROM MyTable LIMIT 99 OFFSET 97", $query->sql());
+		if(!(DB::getConn() instanceof MySQLDatabase || DB::getConn() instanceof SQLite3Database || DB::getConn() instanceof PostgreSQLDatabase)) {
+			$this->markTestIncomplete();
 		}
+
+		$query = new SQLQuery();
+		$query->setFrom("MyTable");
+		$query->setLimit(99);
+		$this->assertEquals("SELECT * FROM MyTable LIMIT 99", $query->sql());
+	
+		// array limit with start (MySQL specific)
+		$query = new SQLQuery();
+		$query->setFrom("MyTable");
+		$query->setLimit(99, 97);
+		$this->assertEquals("SELECT * FROM MyTable LIMIT 99 OFFSET 97", $query->sql());
 	}
 	
 	function testSelectWithOrderbyClause() {
 		$query = new SQLQuery();
-		$query->from[] = "MyTable";
-		$query->orderby('MyName');
+		$query->setFrom("MyTable");
+		$query->setOrderBy('MyName');
 		$this->assertEquals('SELECT * FROM MyTable ORDER BY MyName ASC', $query->sql());
 		
 		$query = new SQLQuery();
-		$query->from[] = "MyTable";
-		$query->orderby('MyName desc');
+		$query->setFrom("MyTable");
+		$query->setOrderBy('MyName desc');
 		$this->assertEquals('SELECT * FROM MyTable ORDER BY MyName DESC', $query->sql());
 		
 		$query = new SQLQuery();
-		$query->from[] = "MyTable";
-		$query->orderby('MyName ASC, Color DESC');
+		$query->setFrom("MyTable");
+		$query->setOrderBy('MyName ASC, Color DESC');
 		$this->assertEquals('SELECT * FROM MyTable ORDER BY MyName ASC, Color DESC', $query->sql());
 		
 		$query = new SQLQuery();
-		$query->from[] = "MyTable";
-		$query->orderby('MyName ASC, Color');
+		$query->setFrom("MyTable");
+		$query->setOrderBy('MyName ASC, Color');
 		$this->assertEquals('SELECT * FROM MyTable ORDER BY MyName ASC, Color ASC', $query->sql());
 
 		$query = new SQLQuery();
-		$query->from[] = "MyTable";
-		$query->orderby(array('MyName' => 'desc'));
+		$query->setFrom("MyTable");
+		$query->setOrderBy(array('MyName' => 'desc'));
 		$this->assertEquals('SELECT * FROM MyTable ORDER BY MyName DESC', $query->sql());
 		
 		$query = new SQLQuery();
-		$query->from[] = "MyTable";
-		$query->orderby(array('MyName' => 'desc', 'Color'));
+		$query->setFrom("MyTable");
+		$query->setOrderBy(array('MyName' => 'desc', 'Color'));
 		$this->assertEquals('SELECT * FROM MyTable ORDER BY MyName DESC, Color ASC', $query->sql());
 		
 		$query = new SQLQuery();
-		$query->from[] = "MyTable";
-		$query->orderby('implode("MyName","Color")');
+		$query->setFrom("MyTable");
+		$query->setOrderBy('implode("MyName","Color")');
 		$this->assertEquals('SELECT *, implode("MyName","Color") AS "_SortColumn0" FROM MyTable ORDER BY "_SortColumn0" ASC', $query->sql());
 		
 		$query = new SQLQuery();
-		$query->from[] = "MyTable";
-		$query->orderby('implode("MyName","Color") DESC');
+		$query->setFrom("MyTable");
+		$query->setOrderBy('implode("MyName","Color") DESC');
 		$this->assertEquals('SELECT *, implode("MyName","Color") AS "_SortColumn0" FROM MyTable ORDER BY "_SortColumn0" DESC', $query->sql());
 		
 		$query = new SQLQuery();
-		$query->from[] = "MyTable";
-		$query->orderby('RAND()');
+		$query->setFrom("MyTable");
+		$query->setOrderBy('RAND()');
 		
 		$this->assertEquals('SELECT *, RAND() AS "_SortColumn0" FROM MyTable ORDER BY "_SortColumn0" ASC', $query->sql());
 	}
 	
 	public function testReverseOrderBy() {
 		$query = new SQLQuery();
-		$query->from('MyTable');
+		$query->setFrom('MyTable');
 		
 		// default is ASC
-		$query->orderby("Name");
+		$query->setOrderBy("Name");
 		$query->reverseOrderBy();
 
 		$this->assertEquals('SELECT * FROM MyTable ORDER BY Name DESC',$query->sql());	
 		
-		$query->orderby("Name DESC");
+		$query->setOrderBy("Name DESC");
 		$query->reverseOrderBy();
 
 		$this->assertEquals('SELECT * FROM MyTable ORDER BY Name ASC',$query->sql());
 		
-		$query->orderby(array("Name" => "ASC"));
+		$query->setOrderBy(array("Name" => "ASC"));
 		$query->reverseOrderBy();
 		
 		$this->assertEquals('SELECT * FROM MyTable ORDER BY Name DESC',$query->sql());
 		
-		$query->orderby(array("Name" => 'DESC', 'Color' => 'asc'));
+		$query->setOrderBy(array("Name" => 'DESC', 'Color' => 'asc'));
 		$query->reverseOrderBy();
 		
 		$this->assertEquals('SELECT * FROM MyTable ORDER BY Name ASC, Color DESC',$query->sql());
 		
-		$query->orderby('implode("MyName","Color") DESC');
+		$query->setOrderBy('implode("MyName","Color") DESC');
 		$query->reverseOrderBy();
 		
 		$this->assertEquals('SELECT *, implode("MyName","Color") AS "_SortColumn0" FROM MyTable ORDER BY "_SortColumn0" ASC',$query->sql());
@@ -179,50 +162,42 @@ class SQLQueryTest extends SapphireTest {
 
 	function testFiltersOnID() {
 		$query = new SQLQuery();
-		$query->where[] = "ID = 5";
+		$query->setWhere("ID = 5");
 		$this->assertTrue(
 			$query->filtersOnID(),
 			"filtersOnID() is true with simple unquoted column name"
 		);
 		
 		$query = new SQLQuery();
-		$query->where[] = "ID=5";
+		$query->setWhere("ID=5");
 		$this->assertTrue(
 			$query->filtersOnID(),
 			"filtersOnID() is true with simple unquoted column name and no spaces in equals sign"
 		);
-		/*
+
 		$query = new SQLQuery();
-		$query->where[] = "Foo='Bar' AND ID=5";
-		$this->assertTrue(
-			$query->filtersOnID(),
-			"filtersOnID() is true with combined SQL statements"
-		);
-		*/
-		
-		$query = new SQLQuery();
-		$query->where[] = "Identifier = 5";
+		$query->setWhere("Identifier = 5");
 		$this->assertFalse(
 			$query->filtersOnID(),
 			"filtersOnID() is false with custom column name (starting with 'id')"
 		);
 		
 		$query = new SQLQuery();
-		$query->where[] = "ParentID = 5";
+		$query->setWhere("ParentID = 5");
 		$this->assertFalse(
 			$query->filtersOnID(),
 			"filtersOnID() is false with column name ending in 'ID'"
 		);
 		
 		$query = new SQLQuery();
-		$query->where[] = "MyTable.ID = 5";
+		$query->setWhere("MyTable.ID = 5");
 		$this->assertTrue(
 			$query->filtersOnID(),
 			"filtersOnID() is true with table and column name"
 		);
 		
 		$query = new SQLQuery();
-		$query->where[] = "MyTable.ID= 5";
+		$query->setWhere("MyTable.ID = 5");
 		$this->assertTrue(
 			$query->filtersOnID(),
 			"filtersOnID() is true with table and quoted column name "
@@ -231,28 +206,28 @@ class SQLQueryTest extends SapphireTest {
 	
 	function testFiltersOnFK() {
 		$query = new SQLQuery();
-		$query->where[] = "ID = 5";
+		$query->setWhere("ID = 5");
 		$this->assertFalse(
 			$query->filtersOnFK(),
 			"filtersOnFK() is true with simple unquoted column name"
 		);
 		
 		$query = new SQLQuery();
-		$query->where[] = "Identifier = 5";
+		$query->setWhere("Identifier = 5");
 		$this->assertFalse(
 			$query->filtersOnFK(),
 			"filtersOnFK() is false with custom column name (starting with 'id')"
 		);
 		
 		$query = new SQLQuery();
-		$query->where[] = "MyTable.ParentID = 5";
+		$query->setWhere("MyTable.ParentID = 5");
 		$this->assertTrue(
 			$query->filtersOnFK(),
 			"filtersOnFK() is true with table and column name"
 		);
 		
 		$query = new SQLQuery();
-		$query->where[] = "MyTable.`ParentID`= 5";
+		$query->setWhere("MyTable.`ParentID`= 5");
 		$this->assertTrue(
 			$query->filtersOnFK(),
 			"filtersOnFK() is true with table and quoted column name "
@@ -261,36 +236,36 @@ class SQLQueryTest extends SapphireTest {
 
 	public function testInnerJoin() {
 		$query = new SQLQuery();
-		$query->from( 'MyTable' );
-		$query->innerJoin( 'MyOtherTable', 'MyOtherTable.ID = 2' );
-		$query->leftJoin( 'MyLastTable', 'MyOtherTable.ID = MyLastTable.ID' );
+		$query->setFrom('MyTable');
+		$query->addInnerJoin('MyOtherTable', 'MyOtherTable.ID = 2');
+		$query->addLeftJoin('MyLastTable', 'MyOtherTable.ID = MyLastTable.ID');
 
-		$this->assertEquals( 'SELECT * FROM MyTable '.
+		$this->assertEquals('SELECT * FROM MyTable '.
 			'INNER JOIN "MyOtherTable" ON MyOtherTable.ID = 2 '.
 			'LEFT JOIN "MyLastTable" ON MyOtherTable.ID = MyLastTable.ID',
 			$query->sql()
 		);
 
 		$query = new SQLQuery();
-		$query->from( 'MyTable' );
-		$query->innerJoin( 'MyOtherTable', 'MyOtherTable.ID = 2', 'table1' );
-		$query->leftJoin( 'MyLastTable', 'MyOtherTable.ID = MyLastTable.ID', 'table2' );
+		$query->setFrom('MyTable');
+		$query->addInnerJoin('MyOtherTable', 'MyOtherTable.ID = 2', 'table1');
+		$query->addLeftJoin('MyLastTable', 'MyOtherTable.ID = MyLastTable.ID', 'table2');
 
-		$this->assertEquals( 'SELECT * FROM MyTable '.
+		$this->assertEquals('SELECT * FROM MyTable '.
 			'INNER JOIN "MyOtherTable" AS "table1" ON MyOtherTable.ID = 2 '.
 			'LEFT JOIN "MyLastTable" AS "table2" ON MyOtherTable.ID = MyLastTable.ID',
 			$query->sql()
 		);
 	}
 
-
 	public function testWhereAny() {
 		$query = new SQLQuery();
-		$query->from( 'MyTable' );
+		$query->setFrom('MyTable');
 
 		$query->whereAny(array("Monkey = 'Chimp'", "Color = 'Brown'"));
 		$this->assertEquals("SELECT * FROM MyTable WHERE (Monkey = 'Chimp' OR Color = 'Brown')",$query->sql());
 	}
+
 }
 
 class SQLQueryTest_DO extends DataObject implements TestOnly {


### PR DESCRIPTION
Modified `SQLQuery` to deprecate access to internal properties. Bit of an API cleanup.

Added getters and setters for the internal properties.
Deprecation notice is thrown if attempting to get or set an internal property on SQLQuery.

In addition, I've documented the change in the upgrading notes.
