### PR TITLE
MINOR Removing weird filter argument on DataObject::get_one for Member

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -556,7 +556,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	static function currentUser() {
 		$id = Member::currentUserID();
 		if($id) {
-			return DataObject::get_one("Member", "\"Member\".\"ID\" = $id", true, 1);
+			return DataObject::get_one("Member", "\"Member\".\"ID\" = $id", true);
 		}
 	}
 


### PR DESCRIPTION
1) Remove the wierd filter argument on Member::get that results in a call without $filter=1 doesnt get cached. This only happens in the context of Member::currentUser()
