### PR TITLE
Tidy up of Member class querying (embargoed until query cache is implemented)

### DIFF
--- a/model/DataList.php
+++ b/model/DataList.php
@@ -225,7 +225,7 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 		} elseif($numberFuncArgs == 2) {
 			$whereArguments[func_get_arg(0)] = func_get_arg(1);
 		} else {
-			throw new InvalidArgumentException('Arguments passed to filter() is wrong');
+			throw new InvalidArgumentException('Incorrect number of arguments passed to filter()');
 		}
 
 		$SQL_Statements = array();


### PR DESCRIPTION
Removing use of `DataObject::get()`, `DataObject::get_by_id()` and using `Member::get()` instead. Mostly just tidying things up to use the new ORM.
