### PR TITLE
API CHANGE Removed Member_SignupEmail and deprecate sendInfo() on Member

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -478,6 +478,8 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * @param array $data Additional data to pass to the email (can be used in the template)
 	 */
 	function sendInfo($type = 'signup', $data = null) {
+		Deprecation::notice('3.0', 'Please use Member_ChangePasswordEmail or Member_ForgotPasswordEmail directly instead');
+
 		switch($type) {
 			case "changePassword":
 				$e = Member_ChangePasswordEmail::create();
@@ -644,7 +646,10 @@ class Member extends DataObject implements TemplateGlobalProvider {
 			&& $this->record['Password'] 
 			&& Member::$notify_password_change
 		) {
-			$this->sendInfo('changePassword');
+			$e = Member_ChangePasswordEmail::create();
+			$e->populateTemplate($this);
+			$e->setTo($this->Email);
+			$e->send();
 		}
 
 		// The test on $this->ID is used for when records are initially created.

--- a/security/MemberLoginForm.php
+++ b/security/MemberLoginForm.php
@@ -258,12 +258,13 @@ JS
 		if($member) {
 			$member->generateAutologinHash();
 
-			$member->sendInfo(
-				'forgotPassword',
-				array(
-					'PasswordResetLink' => Security::getPasswordResetLink($member->AutoLoginHash)
-				)
-			);
+			$e = Member_ForgotPasswordEmail::create();
+			$e->populateTemplate($member);
+			$e->populateTemplate(array(
+				'PasswordResetLink' => Security::getPasswordResetLink($member->AutoLoginHash)
+			));
+			$e->setTo($member->Email);
+			$e->send();
 
 			$this->controller->redirect('Security/passwordsent/' . urlencode($data['Email']));
 		} elseif($data['Email']) {


### PR DESCRIPTION
`Member_SignupEmail` is very specific, including it's own custom template and referencing custom fields like "Phone". This is unused code that's been lying around the core for years now, much like `AdvancedSearchForm` and `Email_Template` was, and got subsequently removed.

We don't need a built-in signup email, as they're going to vary on pretty much every custom implementation of a registration system, and we don't use it in core code, so let's get rid of it.

Also, `sendInfo()` uses a switch statement which isn't extensible. It's not needed, as everyone will use custom email logic anyway, so let's deprecate that.
