### PR TITLE
MINOR: changed cache folder location

### DIFF
--- a/thirdparty/simplepie/simplepie.inc
+++ b/thirdparty/simplepie/simplepie.inc
@@ -439,7 +439,7 @@ class SimplePie
 	 * @see SimplePie::set_cache_location()
 	 * @access private
 	 */
-	var $cache_location = './cache';
+	var $cache_location = TEMP_FOLDER;
 
 	/**
 	 * @var string Function that creates the cache filename


### PR DESCRIPTION
Set SimplePie's cache location to remove the files from the root causing permission issues.
