### PR TITLE
2.4

### DIFF
--- a/core/control/RequestHandler.php
+++ b/core/control/RequestHandler.php
@@ -196,10 +196,7 @@ class RequestHandler extends ViewableData {
 		
 		foreach($this->extension_instances as $extension) {
 			if($extensionActions = Object::get_static(get_class($extension), 'allowed_actions')) {
-				if(!$actions)
-				{
-					$actions = array();
-				}
+				if(!$actions) $actions = array();
 				$actions = array_merge($actions, $extensionActions);
 			}
 		}


### PR DESCRIPTION
A fix to prevent allowedActions() from failing with a warning when the main class doesn't have an allowed_actions array, but one or more of its extensions does.

Background:
I created a DataObjectDecorator for a form object that added an action. However, it refused to execute the action, giving an "action not allowed" error. Adding an allowed_actions array to the decorator was the only option, but caused RequestHandler::allowedActions() to fail with the following error: "Argument #1 is not an array". This small patch eliminates the error.

NOTES: 
- The reason why the new code is where it is, is so that the function still returns nothing (not even an empty array) if no actions are found
- The master branch appears to also have the same defect, so it's worth checking that too, and fixing it if necessaryBackground:
  I created a DataObjectDecorator for a form object that added an action. However, it refused to execute the action, giving an "action not allowed" error. Adding an allowed_actions array to the decorator was the only option, but caused RequestHandler::allowedActions() to fail with the following error: "Argument #1 is not an array". This small patch eliminates the error.

NOTES: 
- The reason why the new code is where it is, is so that the function still returns nothing (not even an empty array) if no actions are found
- The master branch appears to also have the same defect, so it's worth checking that too, and fixing it if necessary
