### PR TITLE
BUGFIX Ensure the form inside htmleditorfield-dialog element is redrawn ...

### DIFF
--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -313,8 +313,9 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 							'external' => _t('HtmlEditorField.LINKEXTERNAL', 'Another website'),
 							'anchor' => _t('HtmlEditorField.LINKANCHOR', 'Anchor on this page'),
 							'email' => _t('HtmlEditorField.LINKEMAIL', 'Email address'),
-							'file' => _t('HtmlEditorField.LINKFILE', 'Download a file'),			
-						)
+							'file' => _t('HtmlEditorField.LINKFILE', 'Download a file'),
+						),
+						'internal'
 					),
 					new LiteralField('Step2',
 						'<div class="step2">' . sprintf($numericLabelTmpl, '2', _t('HtmlEditorField.DETAILS', 'Details')) . '</div>'

--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -295,6 +295,7 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 						url: url,
 						success: function(html) {
 							dialog.html(html);
+							dialog.getForm().redraw();
 						}
 					});
 				}
@@ -330,7 +331,7 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 			},
 			ondialogopen: function(e) {
 				this.getForm().updateFromEditor();
-				this.redraw();
+				this.getForm().redraw();
 			},
 			ondialogclose: function(e) {
 				this.getForm().resetFields();


### PR DESCRIPTION
Ensure the lazy loaded form inside htmleditorfield-dialog is redrawn when lazy loaded. This fixes the initial state for the insert link dialog form.

Also ensure the link form uses "internal" as the default, so the initial state doesn't show all fields, just those associated with the first radio option "internal".

This also fixes http://open.silverstripe.org/ticket/7273.
