### PR TITLE
BUGFIX Throwing an InvalidArgumentException without the new keyword results in a Fatal error

### DIFF
--- a/view/GenericTemplateGlobalProvider.php
+++ b/view/GenericTemplateGlobalProvider.php
@@ -26,7 +26,7 @@ class GenericTemplateGlobalProvider implements TemplateGlobalProvider {
 		if(isset(self::$modules[$name])) {
 			return self::$modules[$name];
 		} else {
-			throw InvalidArgumentException(sprintf('%s is not a supported argument. Possible values: %s', $name, implode(', ', self::$modules)));
+			throw new InvalidArgumentException(sprintf('%s is not a supported argument. Possible values: %s', $name, implode(', ', self::$modules)));
 		}
 	}
 


### PR DESCRIPTION
..
