### PR TITLE
BUGFIX #7298 Fixed incorrect message in GridFieldDetailForm from en.yml

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -266,13 +266,13 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 
 		$actions = new FieldList();
 		if($this->record->ID !== 0) {
-			$actions->push(FormAction::create('doSave', _t('GridFieldDetailsForm.Save', 'Save'))
+			$actions->push(FormAction::create('doSave', _t('GridFieldDetailForm.Save', 'Save'))
 				->setUseButtonTag(true)->addExtraClass('ss-ui-action-constructive')->setAttribute('data-icon', 'accept'));
-			$actions->push(FormAction::create('doDelete', _t('GridFieldDetailsForm.Delete', 'Delete'))
+			$actions->push(FormAction::create('doDelete', _t('GridFieldDetailForm.Delete', 'Delete'))
 				->addExtraClass('ss-ui-action-destructive'));
 		}else{ // adding new record
 			//Change the Save label to 'Create'
-			$actions->push(FormAction::create('doSave', _t('GridFieldDetailsForm.Create', 'Create'))
+			$actions->push(FormAction::create('doSave', _t('GridFieldDetailForm.Create', 'Create'))
 				->setUseButtonTag(true)->addExtraClass('ss-ui-action-constructive')->setAttribute('data-icon', 'add'));
 				
 			// Add a Cancel link which is a button-like link and link back to one level up.
@@ -347,7 +347,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 		// TODO Save this item into the given relationship
 
 		$message = sprintf(
-			_t('ComplexTableField.SUCCESSEDIT2', 'Saved %s %s'),
+			_t('GridFieldDetailForm.Saved', 'Saved %s %s'),
 			$this->record->singular_name(),
 			'<a href="' . $this->Link('edit') . '">"' . htmlspecialchars($this->record->Title, ENT_QUOTES) . '"</a>'
 		);
@@ -361,7 +361,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 		try {
 			$toDelete = $this->record;
 			if (!$toDelete->canDelete()) {
-				throw new ValidationException(_t('GridFieldDetailsForm.DeletePermissionsFailure',"No delete permissions"),0);
+				throw new ValidationException(_t('GridFieldDetailForm.DeletePermissionsFailure',"No delete permissions"),0);
 			}
 
 			$toDelete->delete();
@@ -371,7 +371,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 		}
 
 		$message = sprintf(
-			_t('ComplexTableField.SUCCESSEDIT2', 'Deleted %s %s'),
+			_t('GridFieldDetailForm.Deleted', 'Deleted %s %s'),
 			$this->record->singular_name(),
 			'<a href="' . $this->Link('edit') . '">"' . htmlspecialchars($this->record->Title, ENT_QUOTES) . '"</a>'
 		);

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -188,11 +188,13 @@ en:
     ResetFilter: Reset
   GridFieldAction_Delete:
     DeletePermissionsFailure: 'No delete permissions'
-  GridFieldDetailsForm:
+  GridFieldDetailForm:
     Create: Create
     Delete: Delete
     DeletePermissionsFailure: 'No delete permissions'
     Save: Save
+    Saved: 'Saved %s %s'
+    Deleted: 'Deleted %s %s'
   GridFieldItemEditView.ss:
     'Go back': 'Go back'
   Group:


### PR DESCRIPTION
1) Use `GridDetailForm` in the language files, not "GridDetailsForm" to be consistent with the class name.

2) Use the correct language, leave the ComplexTableField ones as-is, create new `GridFieldDetailForm.Saved` and `GridFieldDetailForm.Deleted` entities.

See http://open.silverstripe.org/ticket/7298
