### PR TITLE
MINOR Fixing use of deprecated getAllFields(), mark field as deprecated ...

### DIFF
--- a/model/DataDifferencer.php
+++ b/model/DataDifferencer.php
@@ -70,10 +70,10 @@ class DataDifferencer extends ViewableData {
 	function diffedData() {
 		if($this->fromRecord) {
 			$diffed = clone $this->fromRecord;
-			$fields = array_keys($diffed->getAllFields() + $this->toRecord->getAllFields());
+			$fields = array_keys($diffed->toMap() + $this->toRecord->toMap());
 		} else {
 			$diffed = clone $this->toRecord;
-			$fields = array_keys($this->toRecord->getAllFields());
+			$fields = array_keys($this->toRecord->toMap());
 		}
 		
 		$hasOnes = $this->fromRecord->has_one();
@@ -144,10 +144,10 @@ class DataDifferencer extends ViewableData {
 
 		if($this->fromRecord) {
 			$base = $this->fromRecord;
-			$fields = array_keys($this->fromRecord->getAllFields());
+			$fields = array_keys($this->fromRecord->toMap());
 		} else {
 			$base = $this->toRecord;
-			$fields = array_keys($this->toRecord->getAllFields());
+			$fields = array_keys($this->toRecord->toMap());
 		}
 		
 		foreach($fields as $field) {
@@ -190,13 +190,13 @@ class DataDifferencer extends ViewableData {
 	 */
 	function changedFieldNames() {
 		$diffed = clone $this->fromRecord;
-		$fields = array_keys($diffed->getAllFields());
+		$fields = array_keys($diffed->toMap());
 		
 		$changedFields = array();
 		
 		foreach($fields as $field) {
 			if(in_array($field, $this->ignoredFields)) continue;
-			if($this->fromRecord->$field != $this->toRecord->$field) {			
+			if($this->fromRecord->$field != $this->toRecord->$field) {
 				$changedFields[] = $field;
 			}
 		}

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1982,6 +1982,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	 * @return array A map of field names to field values.
 	 */
 	public function getAllFields() {
+		Deprecation::notice('3.0', 'Use toMap() instead.');
 		return $this->toMap();
 	}
 

--- a/tests/model/DataObjectLazyLoadingTest.php
+++ b/tests/model/DataObjectLazyLoadingTest.php
@@ -228,7 +228,7 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 		$parentTeam = $this->objFromFixture('DataObjectTest_Team', 'team1');
 		$teams = DataObject::get('DataObjectTest_Team'); // query parent class
 		$subteam1Lazy = $teams->find('ID', $subteam1->ID);
-		$this->assertArrayNotHasKey('SubclassDatabaseField_Lazy', $subteam1Lazy->getAllFields());
-		$this->assertArrayHasKey('SubclassDatabaseField', $subteam1Lazy->getAllFields());
+		$this->assertArrayNotHasKey('SubclassDatabaseField_Lazy', $subteam1Lazy->toMap());
+		$this->assertArrayHasKey('SubclassDatabaseField', $subteam1Lazy->toMap());
 	}
 }

--- a/view/ViewableData.php
+++ b/view/ViewableData.php
@@ -374,7 +374,7 @@ class ViewableData extends Object implements IteratorAggregate {
 				}
 				
 				$valueObject = Object::create_from_string($castConstructor, $fieldName);
-				$valueObject->setValue($value, ($this->hasMethod('getAllFields') ? $this->getAllFields() : null));
+				$valueObject->setValue($value, ($this->hasMethod('toMap') ? $this->toMap() : null));
 				
 				$value = $valueObject;
 			}
@@ -704,10 +704,10 @@ class ViewableData_Debugger extends ViewableData {
 		
 		$debug .= '</ul>';
 		
-		if($this->object->hasMethod('getAllFields')) {
+		if($this->object->hasMethod('toMap')) {
 			$debug .= "<b>Debugging Information: all fields available in '{$this->object->class}'</b><br/><ul>";
 			
-			foreach($this->object->getAllFields() as $field => $value) {
+			foreach($this->object->toMap() as $field => $value) {
 				$debug .= "<li>\$$field</li>";
 			}
 			


### PR DESCRIPTION
`getAllFields()` on `DataObject` is marked as deprecated in phpdoc, but not set with `Deprecation::notice()`. Let's mark it as deprecated correctly, and replace all internal use of the method with `toMap()` instead with the new API.
