### PR TITLE
BUGFIX: Director::protocol() was returning https when $_SERVER['HTTPS'] ...

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -375,7 +375,7 @@ class Director implements TemplateGlobalProvider {
 	 */
 	static function protocol() {
 		if(isset($_SERVER['HTTP_X_FORWARDED_PROTOCOL']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTOCOL']) == 'https') return "https://";
-		return (isset($_SERVER['SSL']) || (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')) ? 'https://' : 'http://';
+		return (isset($_SERVER['SSL']) || (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')) ? 'https://' : 'http://';
 	}
 
 	/**


### PR DESCRIPTION
...was an empty value.

From http://www.php.net/manual/en/reserved.variables.server.php:

'HTTPS'
Set to a non-empty value if the script was queried through the HTTPS protocol.

The isset() check would return true if $_SERVER['HTTPS'] were an empty string (say, due to using fastcgi_param HTTPS $https), whereas, going by the description from php.net, an empty string shows it was not queried using HTTPS.
