### PR TITLE
BUGFIX: add capability of redirecting form actions.

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -106,7 +106,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 	);
 
 	/**
-	 * @var PJAXResponseNegotiator
+	 * @var PjaxResponseNegotiator
 	 */
 	protected $responseNegotiator;
 	
@@ -416,12 +416,12 @@ class LeftAndMain extends Controller implements PermissionProvider {
 	/**
 	 * Caution: Volatile API.
 	 *  
-	 * @return PJAXResponseNegotiator
+	 * @return PjaxResponseNegotiator
 	 */
 	public function getResponseNegotiator() {
 		if(!$this->responseNegotiator) {
 			$controller = $this;
-			$this->responseNegotiator = new PJAXResponseNegotiator(array(
+			$this->responseNegotiator = new PjaxResponseNegotiator(array(
 				'CurrentForm' => function() use(&$controller) {
 					return $controller->getEditForm()->forTemplate();
 				},

--- a/admin/javascript/LeftAndMain.Content.js
+++ b/admin/javascript/LeftAndMain.Content.js
@@ -80,10 +80,18 @@
 				// as automatic browser ajax response redirects seem to discard the hash/fragment.
 				formData.push({name: 'BackURL', value:History.getPageUrl()});
 
+				// Some action buttons are redirecting to content areas as oposed to reloading the form.
+				// They will have pjax-content class on them.
+				var pjaxType = 'CurrentForm', pjaxSelector = '.cms-edit-form';
+				if ($(button).hasClass('pjax-content')) {
+					pjaxType = 'Content';
+					pjaxSelector = '.cms-content';
+				}
+
 				jQuery.ajax(jQuery.extend({
 					headers: {
-						"X-Pjax" : "CurrentForm",
-						'X-Pjax-Selector': '.cms-edit-form'
+						"X-Pjax" : pjaxType,
+						'X-Pjax-Selector': pjaxSelector
 					},
 					url: form.attr('action'), 
 					data: formData,

--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -291,8 +291,9 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 		if($this->record->ID !== 0) {
 			$actions->push(FormAction::create('doSave', _t('GridFieldDetailForm.Save', 'Save'))
 				->setUseButtonTag(true)->addExtraClass('ss-ui-action-constructive')->setAttribute('data-icon', 'accept'));
+			// The delete action will redirect, hence pjax-content class.
 			$actions->push(FormAction::create('doDelete', _t('GridFieldDetailForm.Delete', 'Delete'))
-				->addExtraClass('ss-ui-action-destructive'));
+				->addExtraClass('ss-ui-action-destructive')->addExtraClass('pjax-content'));
 		}else{ // adding new record
 			//Change the Save label to 'Create'
 			$actions->push(FormAction::create('doSave', _t('GridFieldDetailForm.Create', 'Create'))


### PR DESCRIPTION
Form actions assume that they are reloading the form afterwards. But
this is not always the case - for example "delete" action will redirect
back to the panel, so we need to be able to set the X-Pjax headers
accordingly.
