### PR TITLE
ENHANCEMENT: rafactor the redirecting form submit to be more explicit

### DIFF
--- a/admin/javascript/LeftAndMain.Content.js
+++ b/admin/javascript/LeftAndMain.Content.js
@@ -80,10 +80,9 @@
 				// as automatic browser ajax response redirects seem to discard the hash/fragment.
 				formData.push({name: 'BackURL', value:History.getPageUrl()});
 
-				// Some action buttons are redirecting to content areas as oposed to reloading the form.
-				// They will have pjax-content class on them.
+				// Some action buttons are redirecting to content areas as oposed to reloading the form by default.
 				var pjaxType = 'CurrentForm', pjaxSelector = '.cms-edit-form';
-				if ($(button).hasClass('pjax-content')) {
+				if ($(button).hasClass('redirecting-to-content')) {
 					pjaxType = 'Content';
 					pjaxSelector = '.cms-content';
 				}

--- a/forms/FormAction.php
+++ b/forms/FormAction.php
@@ -107,6 +107,24 @@ class FormAction extends FormField {
 	}
 
 	/**
+	 * Set the button as redirecting to content, where the default
+	 * behaviour is to reload the same for in place.
+	 *
+	 * It is up to JS to set the headers properly to reflect this.
+	 *
+	 * @param $redirecting bool Should the button redirect to content?
+	 */
+	function setRedirectingToContent($redirecting = true) {
+		if ($redirecting) {
+			$this->addExtraClass('redirecting-to-content');
+		}
+		else {
+			$this->removeExtraClass('redirecting-to-content');
+		}
+		return $this;
+	}
+
+	/**
 	 * @param Boolean
 	 */
 	public function setUseButtonTag($bool) {

--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -291,9 +291,8 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 		if($this->record->ID !== 0) {
 			$actions->push(FormAction::create('doSave', _t('GridFieldDetailForm.Save', 'Save'))
 				->setUseButtonTag(true)->addExtraClass('ss-ui-action-constructive')->setAttribute('data-icon', 'accept'));
-			// The delete action will redirect, hence pjax-content class.
 			$actions->push(FormAction::create('doDelete', _t('GridFieldDetailForm.Delete', 'Delete'))
-				->addExtraClass('ss-ui-action-destructive')->addExtraClass('pjax-content'));
+				->addExtraClass('ss-ui-action-destructive')->setRedirectingToContent());
 		}else{ // adding new record
 			//Change the Save label to 'Create'
 			$actions->push(FormAction::create('doSave', _t('GridFieldDetailForm.Create', 'Create'))
@@ -402,11 +401,8 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 
 		$form->sessionMessage($message, 'good');
 
-		//when an item is deleted, redirect to the revelant admin section without the action parameter
-		$controller = Controller::curr();
-		$noActionURL = $controller->removeAction($data['url']);
-
-		return Director::redirect($noActionURL, 302); //redirect back to admin section
+		$controller = $this->getToplevelController();
+		return $controller->getResponseNegotiator()->respond($controller->request);
 	}
 
 	/**


### PR DESCRIPTION
Follow up to https://github.com/silverstripe/sapphire/pull/464

This is just an enhancement, but I'd like to discuss this a bit further.

@Ingo or anyone who knows how PJAX stuff works, can you have a look here? I'm not sure what is the best way to do it - this solution seems right from the logical standpoint - we are explicitly requesting what we need. But the expected behaviour is configured on FormAction::create, which means it's quite hidden, and we can't react to user input by branching out to serving different things.

From the programmer's perspective, it would be easier to be able to specify what is served more like with a Director::redirect, where the decision is made at the end of the control flow. Like here: https://github.com/mateusz/sapphire/compare/os7299bis

What do you think?
