### PR TITLE
Re-instate CMS ping to ensure sessions are kept alive

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -74,6 +74,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		'getsubtree',
 		'printable',
 		'show',
+		'ping',
 		'EditorToolbar',
 		'EditForm',
 		'AddForm',
@@ -310,7 +311,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 			else if($version == 8) Requirements::css(FRAMEWORK_ADMIN_DIR . '/css/ie8.css');
 		}
 
-		// Custom requirements				
+		// Custom requirements
 		foreach (self::$extra_requirements['javascript'] as $file) {
 			Requirements::javascript($file[0]);
 		}
@@ -360,6 +361,13 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		return $this->getResponseNegotiator()->respond($request);
 	}
 
+	/**
+	 * admin/ping can be visited with ajax to keep a session alive.
+	 * This is used in the CMS.
+	 */
+	function ping() {
+		return 1;
+	}
 	
 	/**
 	 * If this is set to true, the "switchView" context in the

--- a/admin/javascript/LeftAndMain.Ping.js
+++ b/admin/javascript/LeftAndMain.Ping.js
@@ -1,28 +1,28 @@
 /**
- * File: LeftAndMain.EditForm.js
+ * File: LeftAndMain.Ping.js
  */
 (function($) {
-	$.entwine('ss', function($){
+	$.entwine('ss.ping', function($){
 
-		$('.cms-container').entwine(/** @lends ss.Form_EditForm */{	
+		$('.cms-container').entwine(/** @lends ss.Form_EditForm */{
 			/**
 			 * Variable: PingIntervalSeconds
 			 * (Number) Interval in which /Security/ping will be checked for a valid login session.
 			 */
 			PingIntervalSeconds: 5*60,
 			
-			// onmatch: function() {
-			// 	this._super();
-			// 	
-			// 	this._setupPinging();
-			// },
-			// onunmatch: function() {
-			//	this._super();
-			// }
+			onmatch: function() {
+				this._setupPinging();
+				this._super();
+			},
+
+			onunmatch: function() {
+				this._super();
+			},
 
 			/**
 			 * Function: _setupPinging
-			 * 
+			 *
 			 * This function is called by prototype when it receives notification that the user was logged out.
 			 * It uses /Security/ping for this purpose, which should return '1' if a valid user session exists.
 			 * It redirects back to the login form if the URL is either unreachable, or returns '0'.
@@ -32,17 +32,17 @@
 					if(xmlhttp.status > 400 || xmlhttp.responseText == 0) {
 						// TODO will pile up additional alerts when left unattended
 						if(window.open('Security/login')) {
-						    alert("Please log in and then try again");
+							alert('Please log in and then try again');
 						} else {
-						    alert("Please enable pop-ups for this site");
+							alert('Please enable pop-ups for this site');
 						}
 					}
 				};
 
 				// setup pinging for login expiry
 				setInterval(function() {
-					jQuery.ajax({
-						url: "Security/ping",
+					$.ajax({
+						url: 'admin/security/ping',
 						global: false,
 						complete: onSessionLost
 					});

--- a/security/Security.php
+++ b/security/Security.php
@@ -14,7 +14,6 @@ class Security extends Controller {
 	    'lostpassword', 
 	    'passwordsent', 
 	    'changepassword', 
-	    'ping',
 		'LoginForm',
 		'ChangePasswordForm',
 		'LostPasswordForm',
@@ -590,15 +589,6 @@ class Security extends Controller {
 		return $customisedController->renderWith(array('Security_changepassword', 'Security', $this->stat('template_main'), 'BlankPage'));
 	}
 	
-	/**
-	 * Security/ping can be visited with ajax to keep a session alive.
-	 * This is used in the CMS.
-	 */
-	function ping() {
-		return 1;
-	}
-
-
 	/**
 	 * Factory method for the lost password form
 	 *


### PR DESCRIPTION
Re-instate the CMS ping every 5 minutes so sessions are kept alive.

I've also moved `Security/ping` to `admin/security/ping`.

http://open.silverstripe.org/ticket/7381
