### PR TITLE
BUGFIX: Handle consecutive shortcodes.

### DIFF
--- a/tests/parsers/ShortcodeParserTest.php
+++ b/tests/parsers/ShortcodeParserTest.php
@@ -100,6 +100,10 @@ class ShortcodeParserTest extends SapphireTest {
 		
 		$this->assertEquals(2, $this->arguments['id']);
 	}
+
+	public function testConsecutiveTags() {
+		$this->assertEquals('', $this->parser->parse('[test_shortcode][test_shortcode]'));
+	}
 	
 	// -----------------------------------------------------------------------------------------------------------------
 	


### PR DESCRIPTION
Had to change the logic so that the prefix/suffix characters didn't cause problems with matches. Tests all pass.
