### PR TITLE
Deprecate DropdownField $emptyString argument properly

### DIFF
--- a/forms/DropdownField.php
+++ b/forms/DropdownField.php
@@ -14,7 +14,6 @@
  * 	public function getCMSFields() {
  * 		$fields = parent::getCMSFields();
  * 		$field = new DropdownField('GalleryID', 'Gallery', DataList::create('Gallery')->map('ID', 'Title'));
- * 		$field->setHasEmptyDefault(true);
  * 		$field->setEmptyString('(Select one)');
  * 		$fields->addFieldToTab('Root.Content', $field, 'Content');
  * </code>
@@ -29,10 +28,10 @@
  *   static $db = array(
  *     'Country' => "Varchar(100)"
  *   );
- * }			
+ * }
  * </code>
  * 
- * Exampe instantiation:
+ * Example instantiation:
  * <code>
  * new DropdownField(
  *   'Country',
@@ -55,7 +54,7 @@
  *   static $db = array(
  *     'Country' => "Enum('New Zealand,United States,Germany','New Zealand')"
  *   );
- * }			
+ * }
  * </code>
  * 
  * Field construction:
@@ -113,14 +112,21 @@ class DropdownField extends FormField {
 	 * @param $form The parent form
 	 * @param $emptyString mixed Add an empty selection on to of the {@link $source}-Array 
 	 * 	(can also be boolean, which results in an empty string)
-	 *  Argument is deprecated in 2.3, please use {@link setHasEmptyDefault()} and {@link setEmptyString()} instead.
+	 *  Argument is deprecated in 3.1, please use {@link setEmptyString()} and/or {@link setHasEmptyDefault(true)} instead.
 	 */
-	function __construct($name, $title = null, $source = array(), $value = "", $form = null, $emptyString = null) {
+	function __construct($name, $title = null, $source = array(), $value = '', $form = null, $emptyString = null) {
 		$this->setSource($source);
-		
+
+		if($emptyString === true) {
+			Deprecation::notice('3.1', 'Please use setHasEmptyDefault(true) instead of passing a boolean true $emptyString argument');
+		}
+		if(is_string($emptyString)) {
+			Deprecation::notice('3.1', 'Please use setEmptyString() instead of passing a string $emptyString argument.');
+		}
+
 		if($emptyString) $this->setHasEmptyDefault(true);
 		if(is_string($emptyString)) $this->setEmptyString($emptyString);
-	
+
 		parent::__construct($name, ($title===null) ? $name : $title, $value, $form);
 	}
 	
@@ -172,7 +178,7 @@ class DropdownField extends FormField {
 	function isSelected() {
 		return $this->isSelected;
 	}
-  
+
 	/**
 	 * Gets the source array including any empty default values.
 	 * 
@@ -180,12 +186,12 @@ class DropdownField extends FormField {
 	 */
 	function getSource() {
 		if(is_array($this->source) && $this->getHasEmptyDefault()) {
-			return array(""=>$this->emptyString) + (array)$this->source;
+			return array('' => $this->emptyString) + (array) $this->source;
 		} else {
 			return $this->source;
 		}
 	}
-  
+
 	/**
 	 * @param array $source
 	 */
@@ -213,7 +219,7 @@ class DropdownField extends FormField {
 	 * Set the default selection label, e.g. "select...".
 	 * Defaults to an empty string. Automatically sets
 	 * {@link $hasEmptyDefault} to true.
-	 * 
+	 *
 	 * @param string $str
 	 */
 	function setEmptyString($str) {

--- a/model/fieldtypes/Boolean.php
+++ b/model/fieldtypes/Boolean.php
@@ -50,7 +50,8 @@ class Boolean extends DBField {
 			0 => _t('Boolean.NO', 'No')
 		);
 		
-		return new DropdownField($this->name, $title, $source, '', null, "($anyText)");
+		$field = new DropdownField($this->name, $title, $source);
+		$field->setEmptyString("($anyText)");
 	}
 
 	/**
@@ -60,7 +61,7 @@ class Boolean extends DBField {
 	function prepValueForDB($value) {
 		if(strpos($value, '[')!==false)
 			return Convert::raw2sql($value);
-		else {		
+		else {
 			if($value && strtolower($value) != 'f') {
 				return "'1'";
 			} else {

--- a/model/fieldtypes/Enum.php
+++ b/model/fieldtypes/Enum.php
@@ -65,15 +65,16 @@ class Enum extends DBField {
 		if(!$title) $title = $this->name;
 		if(!$name) $name = $this->name;
 
-		$field = new DropdownField($name, $title, $this->enumValues($hasEmpty), $value, $form, $emptyString);
-			
-		return $field;		
+		$field = new DropdownField($name, $title, $this->enumValues($hasEmpty), $value, $form);
+		$field->setEmptyString($emptyString);
+
+		return $field;
 	}
 
 	public function scaffoldFormField($title = null, $params = null) {
 		return $this->formField($title);
 	}
-	
+
 	function scaffoldSearchField($title = null) {
 		$anyText = _t('Enum.ANY', 'Any');
 		return $this->formField($title, null, false, '', null, "($anyText)");

--- a/model/fieldtypes/ForeignKey.php
+++ b/model/fieldtypes/ForeignKey.php
@@ -41,9 +41,10 @@ class ForeignKey extends Int {
 			// Don't scaffold a dropdown for large tables, as making the list concrete
 			// might exceed the available PHP memory in creating too many DataObject instances
 			if($list->count() < 100) {
-				$field = new DropdownField($this->name, $title, $list->map("ID", $titleField), null, null, ' ');	
+				$field = new DropdownField($this->name, $title, $list->map('ID', $titleField));
+				$field->setEmptyString(' ');
 			} else {
-				$field = new NumericField($this->name, $title);	
+				$field = new NumericField($this->name, $title);
 			}
 			
 		}

--- a/model/fieldtypes/PrimaryKey.php
+++ b/model/fieldtypes/PrimaryKey.php
@@ -25,9 +25,11 @@ class PrimaryKey extends Int {
 	}
 	
 	public function scaffoldFormField($title = null, $params = null) {
-		$titleField = ($this->object->hasField('Title')) ? "Title" : "Name";
-		$map = DataList::create(get_class($this->object))->map("ID", $titleField);
-		return new DropdownField($this->name, $title, $map, null, null, ' ');
+		$titleField = ($this->object->hasField('Title')) ? 'Title' : 'Name';
+		$map = DataList::create(get_class($this->object))->map('ID', $titleField);
+		$field = new DropdownField($this->name, $title, $map);
+		$field->setEmptyString(' ');
+		return $field;
 	}
 }
 

--- a/security/Group.php
+++ b/security/Group.php
@@ -123,8 +123,8 @@ class Group extends DataObject {
 		if(count($editorConfigMap) > 1) {
 			$fields->addFieldToTab('Root.Permissions',
 				new DropdownField(
-					'HtmlEditorConfig', 
-					'HTML Editor Configuration', 
+					'HtmlEditorConfig',
+					'HTML Editor Configuration',
 					$editorConfigMap
 				),
 				'Permissions'

--- a/tests/forms/DropdownFieldTest.php
+++ b/tests/forms/DropdownFieldTest.php
@@ -17,39 +17,29 @@ class DropdownFieldTest extends SapphireTest {
 	}
 	
 	function testReadonlyField() {
-		$dropdownField = new DropdownField('FeelingOk', 'Are you feeling ok?', array(0 => 'No', 1 => 'Yes'), '', null, '(Select one)');
-		$dropdownField->setValue(1);
-		$readonlyDropdownField = $dropdownField->performReadonlyTransformation();
-		preg_match('/Yes/', $dropdownField->Field(), $matches);
+		$field = new DropdownField('FeelingOk', 'Are you feeling ok?', array(0 => 'No', 1 => 'Yes'));
+		$field->setEmptyString('(Select one)');
+		$field->setValue(1);
+		$readonlyField = $field->performReadonlyTransformation();
+		preg_match('/Yes/', $field->Field(), $matches);
 		$this->assertEquals($matches[0], 'Yes');
 	}
-	
-	function testEmptyStringAsBooleanConstructorArgument() {
-		$source = array(1=>'one');
-		$field = new DropdownField('Field', null, $source, null, null, true);
-		$this->assertEquals(
-			$field->getSource(),
-			array(
-				'' => '',
-				1 => 'one'
-			)
-		);
-	}
-	
+
 	function testEmptyStringAsLiteralConstructorArgument() {
-		$source = array(1=>'one');
-		$field = new DropdownField('Field', null, $source, null, null, 'select...');
+		$source = array(1 => 'one');
+		$field = new DropdownField('Field', null, $source);
+		$field->setEmptyString('select...');
 		$this->assertEquals(
 			$field->getSource(),
 			array(
-				"" => 'select...',
+				'' => 'select...',
 				1 => 'one'
 			)
 		);
 	}
-	
+
 	function testHasEmptyDefault() {
-		$source = array(1=>'one');
+		$source = array(1 => 'one');
 		$field = new DropdownField('Field', null, $source);
 		$field->setHasEmptyDefault(true);
 		$this->assertEquals(
@@ -60,7 +50,7 @@ class DropdownFieldTest extends SapphireTest {
 			)
 		);
 	}
-	
+
 	function testEmptyDefaultStringThroughSetter() {
 		$source = array(1=>'one');
 		$field = new DropdownField('Field', null, $source);
@@ -76,7 +66,7 @@ class DropdownFieldTest extends SapphireTest {
 			$field->getHasEmptyDefault()
 		);
 	}
-	
+
 	function testZeroArraySourceNotOverwrittenByEmptyString() {
 		$source = array(0=>'zero');
 		$field = new DropdownField('Field', null, $source);
@@ -171,7 +161,10 @@ class DropdownFieldTest extends SapphireTest {
 			1 => 'Yes'
 		);
 		
-		return new DropdownField('Field', null, $source, $value, null, $emptyString);
+		$field = new DropdownField('Field', null, $source, $value);
+		$field->setEmptyString($emptyString);
+
+		return $field;
 	}
 
 	/**


### PR DESCRIPTION
The `$emptyString` argument to `DropdownField` has been deprecated since 2.3, but hasn't been properly reported for people upgrading. `setEmptyString()` is now the correct way to set an empty string.

If you pass in the argument, a deprecation notice is now issued.

All core code has been updated to use `setEmptyString()` on DropdownField instances instead.
