### PR TITLE
Change singleton and strong_create to use dependency injector, with additional fixes to existing classes to behave correctly

### DIFF
--- a/control/injector/Injector.php
+++ b/control/injector/Injector.php
@@ -642,6 +642,24 @@ class Injector {
 	}
 	
 	/**
+	 * Removes a named object from the cached list of objects managed
+	 * by the inject
+	 * 
+	 * @param type $name 
+	 *				The name to unregister
+	 */
+	public function unregisterNamedObject($name) {
+		unset($this->serviceCache[$name]);
+	}
+
+	/**
+	 * Clear out all objects that are managed by the injetor. 
+	 */
+	public function unregisterAllObjects() {
+		$this->serviceCache = array();
+	}
+	
+	/**
 	 * Get a named managed object
 	 * 
 	 * Will first check to see if the item has been registered as a configured service/bean

--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -766,6 +766,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 		if(self::using_temp_db()) {
 			// clear singletons, they're caching old extension info which is used in DatabaseAdmin->doBuild()
 			global $_SINGLETONS;
+			Injector::inst()->unregisterAllObjects();
 			$_SINGLETONS = array();
 
 			$dataClasses = ClassInfo::subclassesFor('DataObject');

--- a/model/fieldtypes/Boolean.php
+++ b/model/fieldtypes/Boolean.php
@@ -7,7 +7,7 @@
  */
 class Boolean extends DBField {
 	
-	function __construct($name, $defaultVal = 0) {
+	function __construct($name = null, $defaultVal = 0) {
 		$this->defaultVal = ($defaultVal) ? 1 : 0;
 		
 		parent::__construct($name);

--- a/model/fieldtypes/Currency.php
+++ b/model/fieldtypes/Currency.php
@@ -18,7 +18,7 @@
 class Currency extends Decimal {
 	protected static $currencySymbol = '$';
 	
-	function __construct($name, $wholeSize = 9, $decimalSize = 2, $defaultValue = 0) {
+	function __construct($name = null, $wholeSize = 9, $decimalSize = 2, $defaultValue = 0) {
 		parent::__construct($name, $wholeSize, $decimalSize, $defaultValue);
 	}
 	

--- a/model/fieldtypes/Decimal.php
+++ b/model/fieldtypes/Decimal.php
@@ -10,7 +10,7 @@ class Decimal extends DBField {
 	/**
 	 * Create a new Decimal field.
 	 */
-	function __construct($name, $wholeSize = 9, $decimalSize = 2, $defaultValue = 0) {
+	function __construct($name = null, $wholeSize = 9, $decimalSize = 2, $defaultValue = 0) {
 		$this->wholeSize = isset($wholeSize) ? $wholeSize : 9;
 		$this->decimalSize = isset($decimalSize) ? $decimalSize : 2;
 		$this->defaultValue = $defaultValue;

--- a/model/fieldtypes/Enum.php
+++ b/model/fieldtypes/Enum.php
@@ -28,7 +28,7 @@ class Enum extends DBField {
 	 * @param enum: A string containing a comma separated list of options or an array of Vals.
 	 * @param default The default option, which is either NULL or one of the items in the enumeration.
 	 */
-	function __construct($name, $enum = NULL, $default = NULL) {
+	function __construct($name = null, $enum = NULL, $default = NULL) {
 		if($enum) {
 			if(!is_array($enum)){
 				$enum = preg_split("/ *, */", trim($enum));

--- a/model/fieldtypes/Float.php
+++ b/model/fieldtypes/Float.php
@@ -7,7 +7,7 @@
  */
 class Float extends DBField {
 
-	function __construct($name, $defaultVal = 0) {
+	function __construct($name = null, $defaultVal = 0) {
 		$this->defaultVal = is_float($defaultVal) ? $defaultVal : (float) 0;
 		
 		parent::__construct($name);

--- a/model/fieldtypes/Int.php
+++ b/model/fieldtypes/Int.php
@@ -7,7 +7,7 @@
  */
 class Int extends DBField {
 
-	function __construct($name, $defaultVal = 0) {
+	function __construct($name = null, $defaultVal = 0) {
 		$this->defaultVal = is_int($defaultVal) ? $defaultVal : 0;
 		
 		parent::__construct($name);

--- a/model/fieldtypes/Percentage.php
+++ b/model/fieldtypes/Percentage.php
@@ -18,7 +18,7 @@ class Percentage extends Decimal {
 	/**
 	 * Create a new Decimal field.
 	 */
-	function __construct($name, $precision = 4) {
+	function __construct($name = null, $precision = 4) {
 		if(!$precision) $precision = 4;
 	
 		parent::__construct($name, $precision + 1, $precision);

--- a/model/fieldtypes/PrimaryKey.php
+++ b/model/fieldtypes/PrimaryKey.php
@@ -19,7 +19,7 @@ class PrimaryKey extends Int {
 	 * @param string $name
 	 * @param DataOject $object The object that this is primary key for (should have a relation with $name)
 	 */
-	function __construct($name, $object) {
+	function __construct($name = null, $object) {
 		$this->object = $object;
 		parent::__construct($name);
 	}

--- a/model/fieldtypes/Varchar.php
+++ b/model/fieldtypes/Varchar.php
@@ -26,7 +26,7 @@ class Varchar extends StringField {
  	 * @param $options array Optional parameters, e.g. array("nullifyEmpty"=>false). See {@link StringField::setOptions()} for information on the available options
  	 * @return unknown_type
  	 */
- 	function __construct($name, $size = 50, $options = array()) {
+ 	function __construct($name = null, $size = 50, $options = array()) {
 		$this->size = $size ? $size : 50;
 		parent::__construct($name, $options);
 	}

--- a/search/FulltextSearchable.php
+++ b/search/FulltextSearchable.php
@@ -68,7 +68,7 @@ class FulltextSearchable extends DataExtension {
 	 * @param Array|String $searchFields Comma-separated list (or array) of database column names
 	 *  that can be searched on. Used for generation of the database index defintions.
 	 */
-	function __construct($searchFields) {
+	function __construct($searchFields = array()) {
 		if(is_array($searchFields)) $this->searchFields = implode(',', $searchFields);
 		else $this->searchFields = $searchFields;
 		


### PR DESCRIPTION
This is a followup to the previous pull request with additional default constructor values added; seems that running the tests in a slightly different config weren't executing the same code paths (running an individual test case will pass on its own, but as part of /all it'll fail - something to do with the build bootstrapping process - go figure). I have seen a couple of failures running tests/all (to do with grid field I think it was) but these are failing before I applied the below patch, so I'm assuming those errors are exclusive of this code. 

BUGFIX Versioned's constructor doesn't provide suitable defaults. Previously a bug/feature in singleton, where it would pass null,true as params to strong_create, which would then get passed through as params to Versioned's constructor, meant that the code still executed fine (as  was set to something that wasn't an array, so the null and true were instead taken as args). The fact that the usage of singleton(Versioned) never really used the classes code, purely for value lookup, meant that this never propagated errors. I've now switched singleton() to use the injector for retrieving values, which means these dud values are no longer passed through

CHANGE Given that Config::inst is an implementation of the singleton pattern itself, I've removed the extra call to singleton(). A side effect of this is that it gets around a possibly nasty circular reference with the dependency injector (which relies on the config object); in future, this dependency structure should really be structured from the DI directly.

MINOR Change singleton and strong_create to use dependency injector

BUGFIX: Provide default constructor values for classes (fixes issues when used in 'singleton' scenario during dev/build in particular)

MINOR Clear out injector state when resetting db schema during tests (a follow on from changing singleton() calls to use the injector underneath)
