### PR TITLE
Fix ModelAdmin When Managed Models Is Array

### DIFF
--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -96,14 +96,18 @@ abstract class ModelAdmin extends LeftAndMain {
 		
 	/**
 	 * Initialize the model admin interface. Sets up embedded jquery libraries and requisite plugins.
-	 * 
-	 * @todo remove reliance on urlParams
 	 */
 	public function init() {
 		parent::init();
 
 		$models = $this->getManagedModels();
-		$this->modelClass = (isset($this->urlParams['ModelClass'])) ? $this->urlParams['ModelClass'] : key($models);
+
+		if($this->request->param('ModelClass')) {
+			$this->modelClass = $this->request->param('ModelClass');
+		} else {
+			reset($models);
+			$this->modelClass = key($models);
+		}
 
 		// security check for valid models
 		if(!array_key_exists($this->modelClass, $models)) {


### PR DESCRIPTION
If the managed models is an array, ModelAdmin::init() uses key() to determine the default managed model to use. In some circumstances the array has already been iterated, so key() returns NULL, so the security check always fails.

This fixes it by reset'ing the array first. Also removed deprecated url params usage.
