### PR TITLE
Added backticks to column names in automatically generated indexes for ...

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -2942,8 +2942,8 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 
 				// Build index list
 				$manymanyIndexes = array(
-					"{$this->class}ID" => true,
-				(($this->class == $childClass) ? "ChildID" : "{$childClass}ID") => true,
+					"`{$this->class}ID`" => true,
+				(($this->class == $childClass) ? "ChildID" : "`{$childClass}ID`") => true,
 				);
 				
 				DB::requireTable("{$this->class}_$relationship", $manymanyFields, $manymanyIndexes, true, null, $extensions);


### PR DESCRIPTION
...many_many relationships to avoid problems with namespaced classes
