### PR TITLE
RECOMMIT This is a recommit of a previously merged, but reverted, commit...

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -118,7 +118,7 @@ class Config {
 	 * @return Config
 	 */
 	static public function inst() {
-		if (!self::$instance) self::$instance = singleton('Config');
+		if (!self::$instance) self::$instance = new Config();
 		return self::$instance;
 	}
 

--- a/core/Core.php
+++ b/core/Core.php
@@ -356,8 +356,6 @@ function getClassFile($className) {
  * way to access instance methods which don't rely on instance
  * data (e.g. the custom SilverStripe static handling).
  *
- * @uses Object::strong_create()
- *
  * @param string $className
  * @return Object
  */
@@ -367,7 +365,7 @@ function singleton($className) {
 	if(!is_string($className)) user_error("singleton() passed bad class_name: " . var_export($className,true), E_USER_ERROR);
 	if(!isset($_SINGLETONS[$className])) {
 		if(!class_exists($className)) user_error("Bad class to singleton() - $className", E_USER_ERROR);
-		$_SINGLETONS[$className] = Object::strong_create($className,null, true);
+		$_SINGLETONS[$className] = Injector::inst()->get($className);
 		if(!$_SINGLETONS[$className]) user_error("singleton() Unknown class '$className'", E_USER_ERROR);
 	}
 	return $_SINGLETONS[$className];

--- a/core/Object.php
+++ b/core/Object.php
@@ -234,8 +234,7 @@ abstract class Object {
 			$class = self::$strong_classes[$class];
 		}
 		
-		$reflector = new ReflectionClass($class);
-		return $reflector->newInstanceArgs($args);
+		return Injector::inst()->createWithArgs($class, $args);
 	}
 	
 	/**

--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -92,7 +92,7 @@ class Versioned extends DataExtension {
 	 * The first stage is consiedered the 'default' stage, the last stage is
 	 * considered the 'live' stage.
 	 */
-	function __construct($stages) {
+	function __construct($stages=array('Stage','Live')) {
 		parent::__construct();
 
 		if(!is_array($stages)) {


### PR DESCRIPTION
.... The initial commit had problems when running "tests/all flush=all" when dev/build would re-analyse a bunch of stuff; fixes to address this went into https://github.com/silverstripe/sapphire/pull/487, but for some reason the actual base changes didn't, so I'm re-submitting them in a separate pull.

BUGFIX Versioned's constructor doesn't provide suitable defaults. Previously a bug/feature in singleton, where it would pass null,true as params to strong_create, which would then get passed through as params to Versioned's constructor, meant that the code still executed fine (as was set to something that wasn't an array, so the null and true were instead taken as args). The fact that the usage of singleton(Versioned) never really used the classes code, purely for value lookup, meant that this never propagated errors. I've now switched singleton() to use the injector for retrieving values, which means these dud values are no longer passed through

CHANGE Given that Config::inst is an implementation of the singleton pattern itself, I've removed the extra call to singleton(). A side effect of this is that it gets around a possibly nasty circular reference with the dependency injector (which relies on the config object); in future, this dependency structure should really be structured from the DI directly.

MINOR Change singleton and strong_create to use dependency injector
