### PR TITLE
If a DataObject has a many_many to a SiteTree subclass...

### DIFF
--- a/search/filters/SearchFilter.php
+++ b/search/filters/SearchFilter.php
@@ -142,7 +142,7 @@ abstract class SearchFilter extends Object {
 		// Todo: move to somewhere more appropriate, such as DataMapper, the magical class-to-be?
 		$candidateClass = $this->model;
 		while($candidateClass != 'DataObject') {
-			if(singleton($candidateClass)->hasOwnTableDatabaseField($this->name)) break;
+			if(DataObject::has_own_table($candidateClass) && singleton($candidateClass)->hasOwnTableDatabaseField($this->name)) break;
 			$candidateClass = get_parent_class($candidateClass);
 		}
 		if($candidateClass == 'DataObject') user_error("Couldn't find field $this->name in any of $this->model's tables.", E_USER_ERROR);


### PR DESCRIPTION
and that subclass has no database fields defined, and $this->name is "ID", this function will errantly return "SiteTreeSubClass.ID", which can never exist in a search query, since there is no such table as SiteTreeSubClass. The problem is that DataObject::hasOwnTableDatabaseField() is a little eager when passed an argument of "ID." It doesn't check to see if the object has its own table first.
