### PR TITLE
Changes to use injector for creating some classes to ensure injection of dependencies

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -283,7 +283,7 @@ Debug::loadErrorHandlers();
 
 // initialise the dependency injector
 $default_options = array('locator' => 'SilverStripeServiceConfigurationLocator');
-Injector::inst($default_options)->addAutoProperty('injector', Injector::inst()); 
+Injector::inst($default_options); 
 
 ///////////////////////////////////////////////////////////////////////////////
 // HELPER FUNCTIONS

--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -829,17 +829,17 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 	 */
 	function logInWithPermission($permCode = "ADMIN") {
 		if(!isset($this->cache_generatedMembers[$permCode])) {
-			$group = new Group();
+			$group = Injector::inst()->create('Group');
 			$group->Title = "$permCode group";
 			$group->write();
 
-			$permission = new Permission();
+			$permission = Injector::inst()->create('Permission');
 			$permission->Code = $permCode;
 			$permission->write();
 			$group->Permissions()->add($permission);
 			
 			$member = DataObject::get_one('Member', sprintf('"Email" = \'%s\'', "$permCode@example.org"));
-			if(!$member) $member = new Member();
+			if(!$member) $member = Injector::inst()->create('Member');
 			
 			$member->FirstName = $permCode;
 			$member->Surname = "User";

--- a/model/DataList.php
+++ b/model/DataList.php
@@ -454,9 +454,9 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 		
 		// Instantiate the class mentioned in RecordClassName only if it exists, otherwise default to $this->dataClass
 		if(class_exists($row['RecordClassName'])) {
-			$item = new $row['RecordClassName']($row, false, $this->model);
+			$item = Injector::inst()->create($row['RecordClassName'], $row, false, $this->model);
 		} else {
-			$item = new $defaultClass($row, false, $this->model);
+			$item = Injector::inst()->create($defaultClass, $row, false, $this->model);
 		}
 		
 		return $item;
@@ -765,7 +765,7 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 	 */
 	public function newObject($initialFields = null) {
 		$class = $this->dataClass;
- 		return new $class($initialFields, false, $this->model);
+ 		return Injector::inst()->create($class, $initialFields, false, $this->model);
 	}
 	
 	/**

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1447,7 +1447,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	public function getManyManyComponents($componentName, $filter = "", $sort = "", $join = "", $limit = "") {
 		list($parentClass, $componentClass, $parentField, $componentField, $table) = $this->many_many($componentName);
 		
-		$result = new ManyManyList($componentClass, $table, $componentField, $parentField,
+		$result = Injector::inst()->create('ManyManyList', $componentClass, $table, $componentField, $parentField,
 			$this->many_many_extraFields($componentName));
 		if($this->model) $result->setDataModel($this->model);
 

--- a/security/Member.php
+++ b/security/Member.php
@@ -934,7 +934,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * @todo Push all this logic into Member_GroupSet's getIterator()?
 	 */
 	public function Groups() {
-		$groups = new Member_GroupSet('Group', 'Group_Members', 'GroupID', 'MemberID');
+		$groups = Injector::inst()->create('Member_GroupSet', 'Group', 'Group_Members', 'GroupID', 'MemberID');
 		$groups->setForeignID($this->ID);
 		
 		$this->extend('updateGroups', $groups);


### PR DESCRIPTION
MINOR Use injector for creating Member_GroupSet object

MINOR Use Injector::inst() for creating objects; cannot rely on this->injector being present due to many classes being created with 'new', so use inst() directly. Will re

MINOR Remove injector autoset property for now; automatically setting it breaks a few test cases that don't know about it. As it's not required just yet, will remove from setting it. 

MINOR Use injector for creating many many list objects

MINOR Use injector for creating objects from within the DataList
