### PR TITLE
BUGFIX: Handling of classes with namespaces in database

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1131,7 +1131,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 							if($dbCommand == 'insert') {
 								$manipulation[$class]['fields']["Created"] = "'".SS_Datetime::now()->Rfc2822()."'";
 								//echo "<li>$this->class - " .get_class($this);
-								$manipulation[$class]['fields']["ClassName"] = "'$this->class'";
+								$manipulation[$class]['fields']["ClassName"] = DB::getConn()->prepStringForDB($this->class);
 							}
 						}
 
@@ -2942,8 +2942,8 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 
 				// Build index list
 				$manymanyIndexes = array(
-					"{$this->class}ID" => true,
-				(($this->class == $childClass) ? "ChildID" : "{$childClass}ID") => true,
+					"\"{$this->class}ID\"" => true,
+				(($this->class == $childClass) ? "ChildID" : "\"{$childClass}ID\"") => true,
 				);
 				
 				DB::requireTable("{$this->class}_$relationship", $manymanyFields, $manymanyIndexes, true, null, $extensions);

--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -198,6 +198,7 @@ class DataQuery {
 					if(preg_match('/^"([^"]+)"/', $collision, $matches)) {
 						$collisionBase = $matches[1];
 						$collisionClasses = ClassInfo::subclassesFor($collisionBase);
+						$collisionClasses = array_map(array(DB::getConn(), 'prepStringForDB'), $collisionClasses);
 						$caseClauses[] = "WHEN \"$baseClass\".\"ClassName\" IN ('"
 							. implode("', '", $collisionClasses) . "') THEN $collision";
 					} else {
@@ -215,6 +216,7 @@ class DataQuery {
 				// Get the ClassName values to filter to
 				$classNames = ClassInfo::subclassesFor($this->dataClass);
 				if(!$classNames) user_error("DataList::create() Can't find data sub-classes for '$callerClass'");
+				$classNames = array_map(array(DB::getConn(), 'prepStringForDB'), $classNames);
 				$query->addWhere("\"$baseClass\".\"ClassName\" IN ('" . implode("','", $classNames) . "')");
 			}
 		}

--- a/model/MySQLDatabase.php
+++ b/model/MySQLDatabase.php
@@ -776,7 +776,7 @@ class MySQLDatabase extends SS_Database {
 
 		$classes = array();
 		foreach($matches[0] as $value) {
-			$classes[] = trim($value, "'");
+			$classes[] = stripslashes(trim($value, "'"));
 		}
 		return $classes;
 	}


### PR DESCRIPTION
MySQLDatabase::enumValuesForField() - Added stripslashes because backslashes are escaped in the type description

DataObject::requireTable() - Added double quotes to column names in automatically generated indexes for many_many relationships

DataObject::write() - Escaped class name for DB query

DataQuery::getFinalisedQuery() - Escaped class names for DB query
