### PR TITLE
BUGFIX: Added double quotes to column names in automatically generated i...

### DIFF
--- a/model/Database.php
+++ b/model/Database.php
@@ -391,7 +391,7 @@ abstract class SS_Database {
 		
 		//DB Abstraction: remove this ===true option as a possibility?
 		if($spec === true) {
-			$spec = "($index)";
+			$spec = "(\"$index\")";
 		}
 		
 		//Indexes specified as arrays cannot be checked with this line: (it flattens out the array)


### PR DESCRIPTION
...ndexes for many_many relationships (this time in the right place, should not interfere with index name - all tests pass)
