### PR TITLE
BUGFIX Ensure that enum values with a single quote are escaped correctly for MySQL

### DIFF
--- a/model/MySQLDatabase.php
+++ b/model/MySQLDatabase.php
@@ -367,7 +367,9 @@ class MySQLDatabase extends SS_Database {
 	public function fieldList($table) {
 		$fields = DB::query("SHOW FULL FIELDS IN \"$table\"");
 		foreach($fields as $field) {
-			$fieldSpec = $field['Type'];
+
+			// ensure that '' is converted to \' in field specification (mostly for the benefit of ENUM values)
+			$fieldSpec = str_replace('\'\'', '\\\'', $field['Type']);
 			if(!$field['Null'] || $field['Null'] == 'NO') {
 				$fieldSpec .= ' not null';
 			}


### PR DESCRIPTION
In the example, if you have an enum of 'Enum("Something,Don\'t know")' in your `DataObject::$db` array, then dev/build will _always_ say this field has changed, because `MySQLDatabase::showFields()` returns the escaped string specification of the field with '' instead of \'.

This converts the field spec so that '' is escaped to \' correctly so the change detection in `Database` is correct.
