### PR TITLE
MINOR: fixed opera vendor prefix for @mixin hide-text-overflow

### DIFF
--- a/admin/scss/_mixins.scss
+++ b/admin/scss/_mixins.scss
@@ -19,7 +19,7 @@
 	// could optionally use the compass mixin but that
 	// would require a 3rd party plugin
 	text-overflow: ellipsis;
-	o-text-overflow: ellipsis;
+	-o-text-overflow: ellipsis;
 }
 
 //** ----------------------------------------------------


### PR DESCRIPTION
https://developer.mozilla.org/en/CSS/text-overflow#Opera_notes
