### PR TITLE
Further small injector tweaks that I'm finding as I'm using it heavily in a PoC project at the moment

### DIFF
--- a/tests/injector/InjectorTest.php
+++ b/tests/injector/InjectorTest.php
@@ -209,6 +209,42 @@ class InjectorTest extends SapphireTest {
 		$sample = $injector->get('SampleService');
 		$this->assertEquals($sample->constructorVarOne, 'val1');
 		$this->assertEquals(get_class($sample->constructorVarTwo), 'AnotherService');
+		
+		$injector = new Injector();
+		$config = array(array(
+				'src' => TEST_SERVICES . '/SampleService.php',
+				'constructor' => array(
+					'val1',
+					'val2',
+				)
+				));
+
+		$injector->load($config);
+		$sample = $injector->get('SampleService');
+		$this->assertEquals($sample->constructorVarOne, 'val1');
+		$this->assertEquals($sample->constructorVarTwo, 'val2');
+		
+		// test constructors on prototype
+		$injector = new Injector();
+		$config = array(array(
+			'type'	=> 'prototype',
+			'src' => TEST_SERVICES . '/SampleService.php',
+			'constructor' => array(
+				'val1',
+				'val2',
+			)
+		));
+
+		$injector->load($config);
+		$sample = $injector->get('SampleService');
+		$this->assertEquals($sample->constructorVarOne, 'val1');
+		$this->assertEquals($sample->constructorVarTwo, 'val2');
+		
+		$again = $injector->get('SampleService');
+		$this->assertFalse($sample === $again);
+		
+		$this->assertEquals($sample->constructorVarOne, 'val1');
+		$this->assertEquals($sample->constructorVarTwo, 'val2');
 	}
 
 	public function testInjectUsingSetter() {
@@ -595,3 +631,4 @@ class SSObjectCreator extends InjectionCreator {
 		return array($class, $args);
 	}
 }
+


### PR DESCRIPTION
MINOR Add the injector as a registered object so that it other classes can 
reference it as a dependency directly

BUGFIX Make sure to only construct args for prototype object creation if
there are actually args passed through to prevent overwriting with null
args if they're passed

MINOR Added __get alias to remove need for explicit ->get() call

TESTS Updated injector tests to catch null constructor args bug
