### PR TITLE
BUGFIX: Fixed incorrect variables breaking form submission.

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -241,7 +241,7 @@ jQuery.noConflict();
 					},
 					success: function(data, status, xhr) {
 						form.removeClass('changed'); // TODO This should be using the plugin API
-						if(callback) callback(xmlhttp, status);
+						if(callback) callback(data, status, xhr);
 
 						var newContentEls = self.handleAjaxResponse(data, status, xhr);
 						if(!newContentEls) return;


### PR DESCRIPTION
- Fixed undefined arg to the submitForm callback. This caused the add page form to break, and is a pretty
  major issue. I changed the args to match the jquery default, but they aren't actually used anywhere
