### PR TITLE
BUGFIX: Fix correct input type for ImageFormAction replaces.

### DIFF
--- a/forms/FormAction.php
+++ b/forms/FormAction.php
@@ -80,7 +80,7 @@ class FormAction extends FormField {
 	}
 
 	function getAttributes() {
-		$type = ($this->hasAttribute('src')) ? 'image' : 'submit';
+		$type = (isset($this->attributes['src'])) ? 'image' : 'submit';
 		$type = ($this->useButtonTag) ? null : $type;
 		
 		return array_merge(

--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -359,16 +359,6 @@ class FormField extends RequestHandler {
 	}
 	
 	/**
-	 * Returns whether the {@link FormField} has a given attribute set. Avoids
-	 * use of getAttribute to avoid recursion.
-	 *
-	 * @return boolean
-	 */
-	public function hasAttribute($name) {
-		return (isset($this->attributes[$name]));
-	}
-	
-	/**
 	 * @return array
 	 */
 	function getAttributes() {

--- a/tests/forms/FormFieldTest.php
+++ b/tests/forms/FormFieldTest.php
@@ -12,9 +12,6 @@ class FormFieldTest extends SapphireTest {
 		$attrs = $field->getAttributes();
 		$this->assertArrayHasKey('foo', $attrs);
 		$this->assertEquals('bar', $attrs['foo']);
-		
-		$this->assertTrue($field->hasAttribute('foo'));
-		$this->assertFalse($field->hasAttribute('loremipsum'));
 	}
 
 	function testAttributesHTML() {


### PR DESCRIPTION
ImageFormAction is deprecated, using the new API results in a submit input rather than an image input being generated. Added hasAttribute helper to FormField as well as test coverage.
