### PR TITLE
#5467 $allowed_actions

### DIFF
--- a/tests/control/ControllerTest.php
+++ b/tests/control/ControllerTest.php
@@ -52,8 +52,8 @@ class ControllerTest extends FunctionalTest {
 		);
 		
 		$response = $this->get("ControllerTest_FullSecuredController/index");
-		$this->assertEquals(403, $response->getStatusCode(),
-			"Actions can be globally disallowed by using asterisk (*) for index method"
+		$this->assertEquals(200, $response->getStatusCode(),
+			"Index is always allowed"
 		);
 		
 		$response = $this->get("ControllerTest_FullSecuredController/adminonly");
@@ -122,8 +122,6 @@ class ControllerTest extends FunctionalTest {
 	public function testHasAction() {
 		$controller = new ControllerTest_HasAction();
 		
-		$this->assertFalse($controller->hasAction('1'), 'Numeric actions do not slip through.');
-		//$this->assertFalse($controller->hasAction('lowercase_permission'), 'Lowercase permission does not slip through.');
 		$this->assertFalse($controller->hasAction('undefined'), 'undefined actions do not exist');
 		$this->assertTrue($controller->hasAction('allowed_action'), 'allowed actions are recognised');
 		$this->assertTrue($controller->hasAction('template_action'), 'action-specific templates are recognised');
@@ -256,8 +254,7 @@ class ControllerTest_UnsecuredController extends ControllerTest_SecuredControlle
 class ControllerTest_HasAction extends Controller {
 	
 	public static $allowed_actions = array (
-		'allowed_action',
-		//'other_action' => 'lowercase_permission'
+		'allowed_action'
 	);
 	
 	protected $templates = array (

--- a/tests/control/RequestHandlingTest.yml
+++ b/tests/control/RequestHandlingTest.yml
@@ -1,0 +1,11 @@
+Permission:
+    admin:
+        Code: ADMIN
+Group:
+    admins:
+        Code: admins
+        Permissions: =>Permission.admin
+Member:
+    admin:
+        Email: admin@test.com
+        Groups: =>Group.admins


### PR DESCRIPTION
Two year old patch from @mateusz, ported to SS3: http://open.silverstripe.org/ticket/5467
From what I can tell, doesn't fix security issues as such, only clarifies misunderstandings on more complex $allowed_actions rules. It does raise a good point about dealing with private/protected actions, and adds UTs to verify the problem.

Needs peer review by at least one other core team member, given how central this code is to security.
From my perspective, we should hold off with this until 3.1 (= merge into master once we've branched off 3.0).
