### PR TITLE
Add ability to add custom actions to GridField record

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -318,17 +318,19 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 			return $controller->redirect($noActionURL, 302);
 		}
 
-		$actions = $this->getFormActions();
+		$actions = new FieldList();
 		if($this->record->ID !== 0) {
                     // Add check to see if record is providing its own actions.
                     // If not, fall back to default.
                     // Currently custom methods for manipulating data need to be
                     // added to this class via Object::add_extension();
-                    if($this->formActions->count() == 0) {
+                    if(!$this->getFormActions()->exists()) {
                         $actions->push(FormAction::create('doSave', _t('GridFieldDetailForm.Save', 'Save'))
                                 ->setUseButtonTag(true)->addExtraClass('ss-ui-action-constructive')->setAttribute('data-icon', 'accept'));
                         $actions->push(FormAction::create('doDelete', _t('GridFieldDetailForm.Delete', 'Delete'))
                                 ->addExtraClass('ss-ui-action-destructive'));
+                    } else {
+                        $actions->merge($this->getFormActions());
                     }
 		}else{ // adding new record
 			//Change the Save label to 'Create'


### PR DESCRIPTION
Mainly I see this as useful for ModelAdmin, but could be useful elsewhere as well.

Currently GridField only adds Create/Cancel or Save/Delete buttons when editing an object. The record controller now checks if the Model class provides a getCMSActions() method, and if so, uses that.

Also added some extra methods for Publishing and UnPublishing content.

Still rudimentary, but think it would be quite a useful feature.
