### PR TITLE
A resubmission of a previous pull request. Contains a couple of bugfixes (including ticket #7448) and minor usage enhancements

### DIFF
--- a/control/injector/Injector.php
+++ b/control/injector/Injector.php
@@ -231,6 +231,30 @@ class Injector {
 	}
 	
 	/**
+	 * Accessor (for testing purposes)
+	 * @return InjectionCreator
+	 */
+	public function getObjectCreator() {
+		return $this->objectCreator;
+	}
+	
+	/**
+	 * Set the configuration locator 
+	 * @param ServiceConfigurationLocator $configLocator 
+	 */
+	public function setConfigLocator($configLocator) {
+		$this->configLocator = $configLocator;
+	}
+	
+	/**
+	 * Retrieve the configuration locator 
+	 * @return ServiceConfigurationLocator 
+	 */
+	public function getConfigLocator() {
+		return $this->configLocator;
+	}
+	
+	/**
 	 * Add in a specific mapping that should be catered for on a type. 
 	 * This allows configuration of what should occur when an object
 	 * of a particular type is injected, and what items should be injected

--- a/core/Core.php
+++ b/core/Core.php
@@ -249,6 +249,12 @@ require_once 'core/manifest/ManifestFileFinder.php';
 require_once 'core/manifest/TemplateLoader.php';
 require_once 'core/manifest/TemplateManifest.php';
 require_once 'core/manifest/TokenisedRegularExpression.php';
+require_once 'control/injector/Injector.php';
+
+// Initialise the dependency injector as soon as possible, as it is 
+// subsequently used by some of the following code
+$default_options = array('locator' => 'SilverStripeServiceConfigurationLocator');
+Injector::inst($default_options); 
 
 ///////////////////////////////////////////////////////////////////////////////
 // MANIFEST
@@ -286,9 +292,6 @@ if(Director::isLive()) {
  */
 Debug::loadErrorHandlers();
 
-// initialise the dependency injector
-$default_options = array('locator' => 'SilverStripeServiceConfigurationLocator');
-Injector::inst($default_options); 
 
 ///////////////////////////////////////////////////////////////////////////////
 // HELPER FUNCTIONS

--- a/tests/injector/InjectorTest.php
+++ b/tests/injector/InjectorTest.php
@@ -12,6 +12,12 @@ define('TEST_SERVICES', dirname(__FILE__) . '/testservices');
  */
 class InjectorTest extends SapphireTest {
 	
+	public function testCorrectlyInitialised() {
+		$injector = Injector::inst();
+		$this->assertTrue($injector->getConfigLocator() instanceof SilverStripeServiceConfigurationLocator,
+				'If this fails, it is likely because the injector has been referenced BEFORE being initialised in Core.php');
+	}
+	
 	public function testBasicInjector() {
 		$injector = new Injector();
 		$injector->setAutoScanProperties(true);


### PR DESCRIPTION
BUGFIX Make sure to only construct args for prototype object creation if there are actually args passed through to prevent overwriting with null args if they're passed

MINOR Added __get alias to remove need for explicit ->get() call

MINOR Added the injector instance as an object that can be injected into other classes

BUGFIX Fixed issue described in http://open.silverstripe.org/ticket/7448 whereby using the injector to create an object of a type already registered as a singleton would actually overwrite the stored singleton object
