### PR TITLE
BUGFIX Supress mkdir() when attempting to create a temp folder, instead

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -324,14 +324,14 @@ function getTempFolder($base = null) {
 	$ssTmp = "$sysTmp/$cachefolder";
 
 	if(!@file_exists($ssTmp)) {
-		@$worked = mkdir($ssTmp);
+		$worked = @mkdir($ssTmp);
 	}
 
 	if(!$worked) {
 		$ssTmp = BASE_PATH . "/silverstripe-cache";
 		$worked = true;
 		if(!@file_exists($ssTmp)) {
-			@$worked = mkdir($ssTmp);
+			$worked = @mkdir($ssTmp);
 		}
 	}
 

--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -725,14 +725,14 @@ class InstallRequirements {
 		$ssTmp = "$sysTmp/silverstripe-cache";
 
 		if(!@file_exists($ssTmp)) {
-			@$worked = mkdir($ssTmp);
+			$worked = @mkdir($ssTmp);
 		}
 
 		if(!$worked) {
 			$ssTmp = dirname($_SERVER['SCRIPT_FILENAME']) . '/silverstripe-cache';
 			$worked = true;
 			if(!@file_exists($ssTmp)) {
-				@$worked = mkdir($ssTmp);
+				$worked = @mkdir($ssTmp);
 			}
 		}
 


### PR DESCRIPTION
of the variable. This gives a nicer error in the installer.
