### PR TITLE
API CHANGE Renames Transliterator to SS_Transliterator

### DIFF
--- a/filesystem/FileNameFilter.php
+++ b/filesystem/FileNameFilter.php
@@ -91,22 +91,22 @@ class FileNameFilter extends Object {
 	}
 		
 	/**
-	 * @var Transliterator
+	 * @var SS_Transliterator
 	 */
 	protected $transliterator;
 	
 	/**
-	 * @return Transliterator|NULL
+	 * @return SS_Transliterator|NULL
 	 */
 	function getTransliterator() {
 		if($this->transliterator === null && self::$default_use_transliterator) {
-			$this->transliterator = Transliterator::create();
+			$this->transliterator = SS_Transliterator::create();
 		} 
 		return $this->transliterator;
 	}
 	
 	/**
-	 * @param Transliterator|FALSE
+	 * @param SS_Transliterator|FALSE
 	 */
 	function setTransliterator($t) {
 		$this->transliterator = $t;

--- a/model/Transliterator.php
+++ b/model/Transliterator.php
@@ -6,14 +6,14 @@
  * Usage:
  * 
  * <code>
- * $tr = new Transliterator();
+ * $tr = new SS_Transliterator();
  * $ascii = $tr->toASCII($unicode);
  * </code>
  * 
  * @package framework
  * @subpackage model
  */
-class Transliterator extends Object {
+class SS_Transliterator extends Object {
 	/**
 	 * Allow the use of iconv() to perform transliteration.  Set to false to disable.
 	 * Even if this variable is true, iconv() won't be used if it's not installed.

--- a/model/URLSegmentFilter.php
+++ b/model/URLSegmentFilter.php
@@ -6,7 +6,7 @@
 
 /**
  * Filter certain characters from "URL segments" (also called "slugs"), for nicer (more SEO-friendly) URLs.
- * Uses {@link Transliterator} to convert non-ASCII characters to meaningful ASCII representations.
+ * Uses {@link SS_Transliterator} to convert non-ASCII characters to meaningful ASCII representations.
  * Use {@link $default_allow_multibyte} to allow a broader range of characters without transliteration.
  * 
  * Caution: Should not be used on full URIs with domains or query parameters.
@@ -94,22 +94,22 @@ class URLSegmentFilter extends Object {
 	}
 		
 	/**
-	 * @var Transliterator
+	 * @var SS_Transliterator
 	 */
 	protected $transliterator;
 	
 	/**
-	 * @return Transliterator|NULL
+	 * @return SS_Transliterator|NULL
 	 */
 	function getTransliterator() {
 		if($this->transliterator === null && self::$default_use_transliterator) {
-			$this->transliterator = Transliterator::create();
+			$this->transliterator = SS_Transliterator::create();
 		} 
 		return $this->transliterator;
 	}
 	
 	/**
-	 * @param Transliterator|FALSE
+	 * @param SS_Transliterator|FALSE
 	 */
 	function setTransliterator($t) {
 		$this->transliterator = $t;

--- a/tests/filesystem/FileNameFilterTest.php
+++ b/tests/filesystem/FileNameFilterTest.php
@@ -18,7 +18,7 @@ class FileNameFilterTest extends SapphireTest {
 	function testFilterWithTransliterator() {
 		$name = 'Brötchen  für allë-mit_Unterstrich!.jpg';
 		$filter = new FileNameFilter();
-		$filter->setTransliterator(new Transliterator());
+		$filter->setTransliterator(new SS_Transliterator());
 		$this->assertEquals(
 			'Broetchen-fuer-alle-mit-Unterstrich.jpg', 
 			$filter->filter($name)
@@ -39,7 +39,7 @@ class FileNameFilterTest extends SapphireTest {
 	function testFilterWithEmptyString() {
 		$name = 'ö ö ö.jpg';
 		$filter = new FileNameFilter();
-		$filter->setTransliterator(new Transliterator());
+		$filter->setTransliterator(new SS_Transliterator());
 		$result = $filter->filter($name);
 		$this->assertFalse(
 			empty($result)


### PR DESCRIPTION
The intl extension in PHP 5.4 provides a Transliterator class, which
conflicts with the SilverStripe one. This leads to some really weird
ReflectionExceptions about Transliterator's constructor being
private.
