### PR TITLE
BUGFIX: Show text for collapsed side panel in IE8 and 9 (fixes #7469)

### DIFF
--- a/admin/css/ie7.css
+++ b/admin/css/ie7.css
@@ -91,3 +91,6 @@ table.ss-gridfield-table tr.ss-gridfield-item.even { background: #F0F4F7; }
 .cms-content-header h2 { float: left; }
 .cms-content-header h2 .section-icon { display: none; }
 .cms-content-header .cms-content-header-tabs { position: absolute; right: 0; }
+
+.cms-panel-content-collapsed { position: relative; width: 40px; }
+.cms-panel-content-collapsed h2.cms-panel-header, .cms-panel-content-collapsed h3.cms-panel-header { zoom: 1; position: absolute; top: 10px; right: 10px; writing-mode: tb-rl; float: right; z-index: 5000; }

--- a/admin/css/ie8.css
+++ b/admin/css/ie8.css
@@ -36,8 +36,8 @@
 .ModelAdmin .cms-content-fields .cms-content-tools .cms-panel-content #Form_ImportForm div.file input.file { margin-left: -132px; }
 .ModelAdmin .cms-content-fields .cms-content-tools .cms-panel-content #Form_ImportForm div.checkbox { padding: 0px; }
 
-.cms-panel .cms-panel-content-collapsed { width: 40px; }
-.cms-panel .cms-panel-content-collapsed h2, .cms-panel .cms-panel-content-collapsed h3 { display: none; }
+.cms-panel .cms-panel-content-collapsed { position: relative; width: 40px; }
+.cms-panel .cms-panel-content-collapsed h2.cms-panel-header, .cms-panel .cms-panel-content-collapsed h3.cms-panel-header { zoom: 1; position: absolute; top: 10px; right: 10px; writing-mode: tb-rl; float: right; z-index: 5000; }
 
 .cms-content-toolbar .cms-tree-view-modes .checkboxAboveTree { margin-right: 1px; }
 

--- a/admin/scss/_ieShared.scss
+++ b/admin/scss/_ieShared.scss
@@ -1,3 +1,23 @@
+//Mixin to adjust text in collapsed side panel and display vertically
+@mixin IEVerticalPanelText{
+	.cms-panel-content-collapsed {
+		position:relative;
+		width: 40px;		
+		h2, h3 {
+			&.cms-panel-header {
+				zoom: 1;
+				position:absolute;
+				top:10px;
+				right:10px;
+				writing-mode: tb-rl;  
+				float:right;
+				z-index:5000;
+			}
+		}	
+	}
+}
+
+
 //fix for background colors on buttons
 .cms .ss-ui-button {
 	background-color: $color-button-generic;
@@ -96,7 +116,6 @@
 		margin-left:0;
 	}
 }
-
 
 //fix for model admin filter styling 
 .ModelAdmin .cms-content-fields .cms-content-tools .cms-panel-content {

--- a/admin/scss/ie7.scss
+++ b/admin/scss/ie7.scss
@@ -199,3 +199,5 @@ table.ss-gridfield-table {
 	}	
 }
 		
+
+@include IEVerticalPanelText; //IE7 needs this defined outside .cms-panel

--- a/admin/scss/ie8.scss
+++ b/admin/scss/ie8.scss
@@ -1,14 +1,9 @@
 @import 'themes/default';
 @import 'ieShared';
 
-
+//IE8 needs this defined inside .cms-panel
 .cms-panel {
-	.cms-panel-content-collapsed {
-		width: 40px;
-		h2, h3 {
-			display: none;
-		}
-	}
+	@include IEVerticalPanelText;
 }
 
 //fix for overlapping of tree view mode checkboxes


### PR DESCRIPTION
Altered IE CSS for CMS-panel to allow the text to display from top to
bottom.
