### PR TITLE
BUGFIX: Turn off filters on IE Nav icons

### DIFF
--- a/admin/css/ie7.css
+++ b/admin/css/ie7.css
@@ -32,6 +32,8 @@
 
 .cms .cms-content .cms-content-fields .aligned_right_label { margin-left: 0; }
 
+.cms-menu-list li a .icon { filter: none; }
+
 .ModelAdmin .cms-content-fields .cms-content-tools .cms-panel-content #Form_ImportForm div.file { margin: 0px; }
 .ModelAdmin .cms-content-fields .cms-content-tools .cms-panel-content #Form_ImportForm div.file input.file { margin-left: -132px; }
 .ModelAdmin .cms-content-fields .cms-content-tools .cms-panel-content #Form_ImportForm div.checkbox { padding: 0px; }

--- a/admin/css/ie8.css
+++ b/admin/css/ie8.css
@@ -32,6 +32,8 @@
 
 .cms .cms-content .cms-content-fields .aligned_right_label { margin-left: 0; }
 
+.cms-menu-list li a .icon { filter: none; }
+
 .ModelAdmin .cms-content-fields .cms-content-tools .cms-panel-content #Form_ImportForm div.file { margin: 0px; }
 .ModelAdmin .cms-content-fields .cms-content-tools .cms-panel-content #Form_ImportForm div.file input.file { margin-left: -132px; }
 .ModelAdmin .cms-content-fields .cms-content-tools .cms-panel-content #Form_ImportForm div.checkbox { padding: 0px; }

--- a/admin/scss/_ieShared.scss
+++ b/admin/scss/_ieShared.scss
@@ -97,6 +97,10 @@
 	}
 }
 
+.cms-menu-list li a .icon{
+ filter:none;
+}
+
 
 //fix for model admin filter styling 
 .ModelAdmin .cms-content-fields .cms-content-tools .cms-panel-content {


### PR DESCRIPTION
Set filter to none so that the main navigation icons appear correctly in IE7 and 8
