### PR TITLE
BUGFIX: Media in IE9 (fixes #4 of #7497)

### DIFF
--- a/javascript/jquery-ondemand/jquery.ondemand.js
+++ b/javascript/jquery-ondemand/jquery.ondemand.js
@@ -44,7 +44,7 @@
 		},
 
 		requireCss : function(styleUrl, media){
-			if(media === null) media = 'all';
+			if(!media) media = 'all';
 
 			// Don't double up on loading scripts
 			if($.isItemLoaded(styleUrl)) return;


### PR DESCRIPTION
IE9 appears to evaluate "if(media === null)" as false, because media === undefined. 
media == null, is true, but the change in the commit (22de5c65979355752f2dbd9ca5b7f70265474742) was done to fix memory leaks that may have been occurring because of the double equals?
