### PR TITLE
Make themedCSS use {theme}_{module}/css/{name}.css files if they exist

### DIFF
--- a/view/Requirements.php
+++ b/view/Requirements.php
@@ -1074,16 +1074,18 @@ class Requirements_Backend {
 	 * @see Requirements::themedCSS()
 	 */
 	public function themedCSS($name, $module = null, $media = null) {
-		$theme = SSViewer::current_theme();
-		$path  = SSViewer::get_theme_folder() . "/css/$name.css";
+		$path = SSViewer::get_theme_folder();
+		$abspath = BASE_PATH . DIRECTORY_SEPARATOR . $path;
+		$css = "/css/$name.css";
 
-		if (file_exists(BASE_PATH . '/' . $path)) {
-			$this->css($path, $media);
-			return;
+		if ($module && file_exists($abspath.'_'.$module.$css)) {
+			$this->css($path.'_'.$module.$css, $media);
 		}
-
-		if ($module) {
-			$this->css("$module/css/$name.css");
+		else if (file_exists($abspath.$css)) {
+			$this->css($path.$css, $media);
+		}
+		else if ($module) {
+			$this->css($module.$css);
 		}
 	}
 	


### PR DESCRIPTION
2.4 used to use a manifest to find css. One side-effect of that is that even without explicit support,
css files in module-specific themes (/themes/{theme}_{module}/) would get picked up. This broke in 3.

This fix does still require the module name to be explicitly passed as a parameter to themedCSS, but if
you do, and a css file of that name exists in the module-specific themes css directory, that will
be included in preference to the theme or module provided css
