### PR TITLE
BUG: exclude() clears previously selected filters() (Trac #7529)

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -461,7 +461,7 @@ function max($field) {
 	function whereAny($filter) {
 		if($filter) {
 			$clone = $this;
-			$clone->query->whereAny($filter);
+			$clone->query->addWhereAny($filter);
 			return $clone;
 		} else {
 			return $this;

--- a/model/SQLQuery.php
+++ b/model/SQLQuery.php
@@ -738,13 +738,27 @@ class SQLQuery {
 		return $this->setWhere($where);
 	}
 
+	public function whereAny($where) {
+		Deprecation::notice('3.0', 'Please use setWhereAny() or setWhereAny() instead!');
+		return $this->setWhereAny($where);
+	}
+
 	/**
 	 * @param String|array $filters Predicate(s) to set, as escaped SQL statements.
 	 */
-	function whereAny($filters) {
+	function setWhereAny($filters) {
 		if(is_string($filters)) $filters = func_get_args();
 		$clause = implode(" OR ", $filters);
 		return $this->setWhere($clause);
+	}
+
+	/**
+	 * @param String|array $filters Predicate(s) to set, as escaped SQL statements.
+	 */
+	function addWhereAny($filters) {
+		if(is_string($filters)) $filters = func_get_args();
+		$clause = implode(" OR ", $filters);
+		return $this->addWhere($clause);
 	}
 		
 	/**

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -437,6 +437,17 @@ class DataListTest extends SapphireTest {
 		$list->exclude(array('Name'=>'Bob', 'Comment'=>'This is a team comment by Bob'));
 		$this->assertEquals(2, $list->count());
 	}
+
+	/**
+	 * Test that if an exclude() is applied to a filter(), the filter() is still preserved.
+	 */
+	public function testExcludeOnFilter() {
+		$list = DataObjectTest_TeamComment::get();
+ 		$list = $list->filter('Comment', 'Phil is a unique guy, and comments on team2');
+		$list = $list->exclude('Name', 'Bob');
+		
+		$this->assertContains('WHERE ("Comment" = \'Phil is a unique guy, and comments on team2\') AND ("Name" != \'Bob\')', $list->sql());
+	}
 	
 	/**
 	 * $list->exclude(array('Name'=>'bob, 'Age'=>array(21, 43))); // exclude bob with Age 21 or 43

--- a/tests/model/SQLQueryTest.php
+++ b/tests/model/SQLQueryTest.php
@@ -258,11 +258,11 @@ class SQLQueryTest extends SapphireTest {
 		);
 	}
 
-	public function testWhereAny() {
+	public function testSetWhereAny() {
 		$query = new SQLQuery();
 		$query->setFrom('MyTable');
 
-		$query->whereAny(array("Monkey = 'Chimp'", "Color = 'Brown'"));
+		$query->setWhereAny(array("Monkey = 'Chimp'", "Color = 'Brown'"));
 		$this->assertEquals("SELECT * FROM MyTable WHERE (Monkey = 'Chimp' OR Color = 'Brown')",$query->sql());
 	}
 


### PR DESCRIPTION
This bug was caused by the fact that SQLQuery::whereAny() removed existing filters.  In line with addWhere() and setWhere(), I split this into addWhereAny() and setWhereAny().  Strictly speaking, this drops the method SQLQuery::whereAny(), but it was really just an internal function for exclude, and so I think that's acceptable.
