### PR TITLE
BUG Fixed DataList filtering and excluding by ID.

### DIFF
--- a/model/DataList.php
+++ b/model/DataList.php
@@ -253,7 +253,13 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 					$comparisor = $this->applyFilterContext($field, $fieldArg, $value);
 				}
 			} else {
-				$SQL_Statements[] = '"'.Convert::raw2sql($field).'" '.$customQuery;
+				if($field == 'ID') {
+					$field = sprintf('"%s"."ID"', ClassInfo::baseDataClass($this->dataClass));
+				} else {
+					$field = '"' . Convert::raw2sql($field) . '"';
+				}
+
+				$SQL_Statements[] = $field . ' ' . $customQuery;
 			}
 		}
 		if(count($SQL_Statements)) {
@@ -350,10 +356,16 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 
 		$SQL_Statements = array();
 		foreach($whereArguments as $fieldName => $value) {
-			if(is_array($value)){
-				$SQL_Statements[] = ('"'.$fieldName.'" NOT IN (\''.implode('\',\'', Convert::raw2sql($value)).'\')');
+			if($fieldName == 'ID') {
+				$fieldName = sprintf('"%s"."ID"', ClassInfo::baseDataClass($this->dataClass));
 			} else {
-				$SQL_Statements[] = ('"'.$fieldName.'" != \''.Convert::raw2sql($value).'\'');
+				$fieldName = '"' . Convert::raw2sql($fieldName) . '"';
+			}
+
+			if(is_array($value)){
+				$SQL_Statements[] = ($fieldName . ' NOT IN (\''.implode('\',\'', Convert::raw2sql($value)).'\')');
+			} else {
+				$SQL_Statements[] = ($fieldName . ' != \''.Convert::raw2sql($value).'\'');
 			}
 		}
 		$this->dataQuery->whereAny($SQL_Statements);

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -397,7 +397,17 @@ class DataListTest extends SapphireTest {
 		$this->assertEquals(1, $list->count(), 'There should be one comments');
 		$this->assertEquals('Bob', $list->first()->Name, 'Only comment should be from Bob');
 	}
-	
+
+	public function testFilterAndExcludeById() {
+		$id = $this->idFromFixture('DataObjectTest_SubTeam', 'subteam1');
+		$list = DataObjectTest_SubTeam::get()->filter('ID', $id);
+		$this->assertEquals($id, $list->first()->ID);
+
+		$list = DataObjectTest_SubTeam::get();
+		$this->assertEquals(3, count($list));
+		$this->assertEquals(2, count($list->exclude('ID', $id)));
+	}
+
 	/**
 	 * $list->exclude('Name', 'bob'); // exclude bob from list
 	 */


### PR DESCRIPTION
If a filter or exclude by ID was applied across more than one table it
would throw an ambiguous column error as the table name was not specified.
