### PR TITLE
FIX DataQuery::applyRelation was returning the base class.

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -581,7 +581,7 @@ function max($field) {
 	    if(!$relation) return $this->dataClass;
 	    
 	    if(is_string($relation)) $relation = explode(".", $relation);
-	    
+	   
 	    $modelClass = $this->dataClass;
 	    
     	foreach($relation as $rel) {
@@ -601,7 +601,6 @@ function max($field) {
     					foreach($ancestry as $ancestor){
     						if($ancestor != $component){
     							$this->query->addInnerJoin($ancestor, "\"$component\".\"ID\" = \"$ancestor\".\"ID\"");
-    							$component=$ancestor;
     						}
     					}
     				}
@@ -623,7 +622,6 @@ function max($field) {
     					foreach($ancestry as $ancestor){
     						if($ancestor != $component){
     							$this->query->addInnerJoin($ancestor, "\"$component\".\"ID\" = \"$ancestor\".\"ID\"");
-    							$component=$ancestor;
     						}
     					}
     				}

--- a/tests/model/DataQueryTest.php
+++ b/tests/model/DataQueryTest.php
@@ -13,5 +13,53 @@ class DataQueryTest extends SapphireTest {
 		$dq->leftJoin("Group_Members", "\"Group_Members\".\"MemberID\" = \"Member\".\"ID\"");
 		$this->assertContains("LEFT JOIN \"Group_Members\" ON \"Group_Members\".\"MemberID\" = \"Member\".\"ID\"", $dq->sql());
 	}
+
+	function testRelationReturn() {
+		$dq = new DataQuery('DataQueryTest_C');
+		$this->assertEquals('DataQueryTest_A', $dq->applyRelation('TestA'), 'DataQuery::applyRelation should return the name of the related object.');
+		$this->assertEquals('DataQueryTest_A', $dq->applyRelation('TestAs'), 'DataQuery::applyRelation should return the name of the related object.');
+		$this->assertEquals('DataQueryTest_A', $dq->applyRelation('ManyTestAs'), 'DataQuery::applyRelation should return the name of the related object.');
+
+		$this->assertEquals('DataQueryTest_B', $dq->applyRelation('TestB'), 'DataQuery::applyRelation should return the name of the related object.');
+		$this->assertEquals('DataQueryTest_B', $dq->applyRelation('TestBs'), 'DataQuery::applyRelation should return the name of the related object.');
+		$this->assertEquals('DataQueryTest_B', $dq->applyRelation('ManyTestBs'), 'DataQuery::applyRelation should return the name of the related object.');
+	}
 }
 
+
+class DataQueryTest_A extends DataObject implements TestOnly {
+	public static $db = array(
+		'Name' => 'Varchar',
+	);
+
+	public static $has_one = array(
+		'TestC' => 'DataQueryTest_C',
+	);
+}
+
+class DataQueryTest_B extends DataQueryTest_A {
+	public static $db = array(
+		'Title' => 'Varchar',
+	);
+
+	public static $has_one = array(
+		'TestC' => 'DataQueryTest_C',
+	);
+}
+
+class DataQueryTest_C extends DataObject implements TestOnly {
+	public static $has_one = array(
+		'TestA' => 'DataQueryTest_A',
+		'TestB' => 'DataQueryTest_B',
+	);
+
+	public static $has_many = array(
+		'TestAs' => 'DataQueryTest_A',
+		'TestBs' => 'DataQueryTest_B',
+	);
+
+	public static $many_many = array(
+		'ManyTestAs' => 'DataQueryTest_A',
+		'ManyTestBs' => 'DataQueryTest_B',
+	);
+}


### PR DESCRIPTION
If the applyRelation() was passed a relation that went to a class with a parent
class with a database table, applyRelation would return the name of the parent
class, rather than the class the relation was actually too.
