### PR TITLE
BUGFIX: Min-width on html dialog box (fixes #7541)

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -516,6 +516,8 @@ form.member-profile-form .ui-tabs-nav .ui-corner-all, form.member-profile-form .
 
 .cms .ui-widget-overlay { background-color: #000; background-image: none; }
 
+.cms .ui-dialog { min-width: 570px; }
+.cms .ui-dialog .htmleditorfield-dialog { min-width: 570px; }
 .cms .ui-dialog .ss-ui-dialog.ui-dialog-content { padding-top: 0px; }
 
 .ui-dialog { background: url("../images/textures/bg_cms_main_content.png") repeat left top #f0f3f4; border: 3px solid #000 !important; border-radius: 8px; overflow: visible; padding: 0; }

--- a/admin/scss/_style.scss
+++ b/admin/scss/_style.scss
@@ -1280,8 +1280,14 @@ form.member-profile-form {
 	background-image: none;
 }
 
-.cms .ui-dialog .ss-ui-dialog.ui-dialog-content {
-	padding-top: 0px; //removes padding so that tabs are flush with header
+.cms .ui-dialog{
+	min-width:570px;
+	.htmleditorfield-dialog{
+		min-width:570px;
+	}
+	.ss-ui-dialog.ui-dialog-content {
+		padding-top: 0px; //removes padding so that tabs are flush with header
+	}
 }
 
 // Elements with this class can either frame inline markup or an iframe,


### PR DESCRIPTION
Put a minimum width on htmleditor dialog boxes so that the box can not be resized beyond a point where the layout works.
