### PR TITLE
BUGFIX: Allow Versioned::get_latest_version() and Version::get_version()to return results if the classname has changed.

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -991,7 +991,7 @@ class Versioned extends DataExtension {
 	 */
 	static function get_latest_version($class, $id) {
 		$baseClass = ClassInfo::baseDataClass($class);
-		$list = DataList::create($class)->where("\"$baseClass\".\"RecordID\" = $id");
+		$list = DataList::create($baseClass)->where("\"$baseClass\".\"RecordID\" = $id");
 		$list->dataQuery()->setQueryParam("Versioned.mode", "latest_versions");
 		return $list->First();
 	}
@@ -1033,7 +1033,7 @@ class Versioned extends DataExtension {
 	 */
 	static function get_version($class, $id, $version) {
 		$baseClass = ClassInfo::baseDataClass($class);
-		$list = DataList::create($class)->where("\"$baseClass\".\"RecordID\" = $id")->where("\"$baseClass\".\"Version\" = " . (int)$version);
+		$list = DataList::create($baseClass)->where("\"$baseClass\".\"RecordID\" = $id")->where("\"$baseClass\".\"Version\" = " . (int)$version);
 		$list->dataQuery()->setQueryParam('Versioned.mode', 'all_versions');
 		return $list->First();
 	}

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -242,6 +242,30 @@ class VersionedTest extends SapphireTest {
 	        'VersionedTest_Subclass_Live',
 	    ), DataObject::get('VersionedTest_Subclass')->dataQuery()->query()->queriedTables());
 	}
+	
+	public function testGetVersionWhenClassnameChanged() {
+		$obj = new VersionedTest_DataObject;
+		$obj->Name = "test";
+		$obj->write();
+		$obj->Name = "test2";
+		$obj->ClassName = "VersionedTest_Subclass";
+		$obj->write();
+		$subclassVersion = $obj->Version;
+		
+		$obj->Name = "test3";
+		$obj->ClassName = "VersionedTest_DataObject";
+		$obj->write();
+		
+		// We should be able to pass the subclass and still get the correct class back
+		$obj2 = Versioned::get_version("VersionedTest_Subclass", $obj->ID, $subclassVersion);
+		$this->assertInstanceOf("VersionedTest_Subclass", $obj2);
+		$this->assertEquals("test2", $obj2->Name);
+
+		$obj3 = Versioned::get_latest_version("VersionedTest_Subclass", $obj->ID);
+		$this->assertEquals("test3", $obj3->Name);
+		$this->assertInstanceOf("VersionedTest_DataObject", $obj3);
+
+	}
 }
 
 class VersionedTest_DataObject extends DataObject implements TestOnly {


### PR DESCRIPTION
Without this bugfix, if you had a Page that used to be a SiteTree, and you tried to use Versiond::get_version() or Versioned::get_latest_version() to return the older SiteTree version, nothing would be returned, because the results were being filtered by ClassName.  This caused bugs in the history panel for certain combinbations of page classname alteration.
