### PR TITLE
BUG: notify PaginatedList the full-text results are already limited.

### DIFF
--- a/model/MySQLDatabase.php
+++ b/model/MySQLDatabase.php
@@ -880,6 +880,9 @@ class MySQLDatabase extends SS_Database {
 		$list->setPageLEngth($pageLength);
 		$list->setTotalItems($totalCount);
 
+		// The list has already been limited by the query above
+		$list->setLimitItems(false);
+
 		return $list;
 	}
 


### PR DESCRIPTION
PaginatedList needs to be notified about this, otherwise it will
errorneously try to further limit the already limited set, making the
subsequent pages empty.
