### PR TITLE
Auto Relation Setting on GridField

### DIFF
--- a/forms/gridfield/GridField.php
+++ b/forms/gridfield/GridField.php
@@ -1,25 +1,25 @@
 <?php
 /**
  * Displays a {@link SS_List} in a grid format.
- * 
- * GridField is a field that takes an SS_List and displays it in an table with rows 
- * and columns. It reminds of the old TableFields but works with SS_List types 
+ *
+ * GridField is a field that takes an SS_List and displays it in an table with rows
+ * and columns. It reminds of the old TableFields but works with SS_List types
  * and only loads the necessary rows from the list.
- * 
- * The minimum configuration is to pass in name and title of the field and a 
+ *
+ * The minimum configuration is to pass in name and title of the field and a
  * SS_List.
- * 
+ *
  * <code>
  * $gridField = new GridField('ExampleGrid', 'Example grid', new DataList('Page'));
  * </code>
- * 
+ *
  * @see SS_List
- * 
+ *
  * @package framework
  * @subpackage fields-relational
  */
 class GridField extends FormField {
-	
+
 	/**
 	 *
 	 * @var array
@@ -28,7 +28,7 @@ class GridField extends FormField {
 		'index',
 		'gridFieldAlterAction'
 	);
-	
+
 	/** @var SS_List - the datasource */
 	protected $list = null;
 
@@ -37,26 +37,26 @@ class GridField extends FormField {
 
 	/** @var GridState - the current state of the GridField */
 	protected $state = null;
-	
+
 	/**
 	 *
 	 * @var GridFieldConfig
 	 */
 	protected $config = null;
-	
+
 	/**
-	 * The components list 
+	 * The components list
 	 */
 	protected $components = array();
-	
+
 	/**
 	 * Internal dispatcher for column handlers.
 	 * Keys are column names and values are GridField_ColumnProvider objects
-	 * 
+	 *
 	 * @var array
 	 */
 	protected $columnDispatch = null;
-	
+
 	/**
 	 * Map of callbacks for custom data fields
 	 */
@@ -79,28 +79,28 @@ class GridField extends FormField {
 		if($dataList) {
 			$this->setList($dataList);
 		}
-		
+
 		if(!$config) {
 			$this->config = GridFieldConfig_Base::create();
 		} else {
 			$this->config = $config;
 		}
-		
+
 		$this->config->addComponent(new GridState_Component());
-		$this->state = new GridState($this);		
-		
+		$this->state = new GridState($this);
+
 		$this->addExtraClass('ss-gridfield');
 	}
 
 	function index($request) {
 		return $this->gridFieldAlterAction(array(), $this->getForm(), $request);
 	}
-	
+
 	/**
 	 * Set the modelClass (dataobject) that this field will get it column headers from.
 	 * If no $displayFields has been set, the displayfields will be fetched from
 	 * this modelclass $summary_fields
-	 * 
+	 *
 	 * @param string $modelClassName
 	 * @see GridFieldDataColumns::getDisplayFields()
 	 */
@@ -108,10 +108,10 @@ class GridField extends FormField {
 		$this->modelClassName = $modelClassName;
 		return $this;
 	}
-	
+
 	/**
 	 * Returns a dataclass that is a DataObject type that this GridField should look like.
-	 * 
+	 *
 	 * @throws Exception
 	 * @return string
 	 */
@@ -133,15 +133,15 @@ class GridField extends FormField {
 	public function getConfig() {
 		return $this->config;
 	}
-	
+
 	public function getComponents() {
 		return $this->config->getComponents();
 	}
-	
+
 	/**
 	 * Cast a arbitrary value with the help of a castingDefintion
-	 * 
-	 * @param $value 
+	 *
+	 * @param $value
 	 * @param $castingDefinition
 	 * @todo refactor this into GridFieldComponent
 	 */
@@ -153,21 +153,21 @@ class GridField extends FormField {
 		} else {
 			$castingParams = array();
 		}
-		
+
 		if(strpos($castingDefinition,'->') === false) {
 			$castingFieldType = $castingDefinition;
 			$castingField = DBField::create_field($castingFieldType, $value);
 			$value = call_user_func_array(array($castingField,'XML'),$castingParams);
 		} else {
 			$fieldTypeParts = explode('->', $castingDefinition);
-			$castingFieldType = $fieldTypeParts[0];	
+			$castingFieldType = $fieldTypeParts[0];
 			$castingMethod = $fieldTypeParts[1];
 			$castingField = DBField::create_field($castingFieldType, $value);
 			$value = call_user_func_array(array($castingField,$castingMethod),$castingParams);
 		}
-		
+
 		return $value;
-	}	 
+	}
 
 	/**
 	 * Set the datasource
@@ -187,7 +187,7 @@ class GridField extends FormField {
 	public function getList() {
 		return $this->list;
 	}
-	
+
 	/**
 	 * Get the current GridState_Data or the GridState
 	 *
@@ -228,7 +228,7 @@ class GridField extends FormField {
 				$list = $item->getManipulatedData($this, $list);
 			}
 		}
-		
+
 		// Render headers, footers, etc
 		$content = array(
 			"before" => "",
@@ -237,7 +237,7 @@ class GridField extends FormField {
 			"footer" => "",
 		);
 
-		foreach($this->getComponents() as $item) {			
+		foreach($this->getComponents() as $item) {
 			if($item instanceof GridField_HTMLProvider) {
 				$fragments = $item->getHTMLFragments($this);
 				if($fragments) foreach($fragments as $k => $v) {
@@ -253,10 +253,10 @@ class GridField extends FormField {
 		}
 
 		// Replace custom fragments and check which fragments are defined
-		// Nested dependencies are handled by deferring the rendering of any content item that 
+		// Nested dependencies are handled by deferring the rendering of any content item that
 		// Circular dependencies are detected by disallowing any item to be deferred more than 5 times
 		// It's a fairly crude algorithm but it works
-		
+
 		$fragmentDefined = array('header' => true, 'footer' => true, 'before' => true, 'after' => true);
 		reset($content);
 		while(list($k,$v) = each($content)) {
@@ -270,10 +270,10 @@ class GridField extends FormField {
 					if(preg_match('/\$DefineFragment\(([a-z0-9\-_]+)\)/i', $fragment, $matches)) {
 						// If we've already deferred this fragment, then we have a circular dependency
 						if(isset($fragmentDeferred[$k]) && $fragmentDeferred[$k] > 5) {
-							throw new LogicException("GridField HTML fragment '$fragmentName' and '$matches[1]' " . 
+							throw new LogicException("GridField HTML fragment '$fragmentName' and '$matches[1]' " .
 								"appear to have a circular dependency.");
 						}
-						
+
 						// Otherwise we can push to the end of the content array
 						unset($content[$k]);
 						$content[$k] = $v;
@@ -329,10 +329,10 @@ class GridField extends FormField {
 				$rows[] = $row;
 			}
 			$content['body'] = implode("\n", $rows);
-		} 
-		
+		}
+
 		// Display a message when the grid field is empty
-		if(!(isset($content['body']) && $content['body'])) {    
+		if(!(isset($content['body']) && $content['body'])) {
 			$content['body'] = $this->createTag(
 				'tr',
 				array("class" => 'ss-gridfield-item ss-gridfield-no-items'),
@@ -347,7 +347,7 @@ class GridField extends FormField {
 
 		$this->addExtraClass('ss-gridfield field');
 		$attrs = array_diff_key(
-			$this->getAttributes(), 
+			$this->getAttributes(),
 			array('value' => false, 'type' => false, 'name' => false)
 		);
 		$attrs['data-name'] = $this->getName();
@@ -355,18 +355,18 @@ class GridField extends FormField {
 			'id' => isset($this->id) ? $this->id : null,
 			'class' => 'ss-gridfield-table',
 			'cellpadding' => '0',
-			'cellspacing' => '0'	
+			'cellspacing' => '0'
 		);
 
 
 		return
-			$this->createTag('fieldset', $attrs, 
+			$this->createTag('fieldset', $attrs,
 				$content['before'] .
 				$this->createTag('table', $tableAttrs, $head."\n".$foot."\n".$body) .
 				$content['after']
 			);
 	}
-	
+
 	public function Field($properties = array()) {
 		return $this->FieldHolder($properties);
 	}
@@ -405,7 +405,7 @@ class GridField extends FormField {
 		if(!$this->columnDispatch) {
 			$this->buildColumnDispatch();
 		}
-		
+
 		if(!empty($this->columnDispatch[$column])) {
 			$content = "";
 			foreach($this->columnDispatch[$column] as $handler) {
@@ -416,16 +416,16 @@ class GridField extends FormField {
 			throw new InvalidArgumentException("Bad column '$column'");
 		}
 	}
-	
+
 	/**
 	 * Add additional calculated data fields to be used on this GridField
 	 * @param array $fields a map of fieldname to callback.  The callback will bed passed the record as an argument.
 	 */
 	public function addDataFields($fields) {
 		if($this->customDataFields) $this->customDataFields = array_merge($this->customDataFields, $fields);
-		else $this->customDataFields = $fields;		
+		else $this->customDataFields = $fields;
 	}
-	
+
 	/**
 	 * Get the value of a named field  on the given record.
 	 * Use of this method ensures that any special rules around the data for this gridfield are followed.
@@ -436,7 +436,7 @@ class GridField extends FormField {
 			$callback = $this->customDataFields[$fieldName];
 			return $callback($record);
 		}
-		
+
 		// Default implementation
 		if($record->hasMethod('relField')) {
 			return $record->relField($fieldName);
@@ -461,7 +461,7 @@ class GridField extends FormField {
 		if(!$this->columnDispatch) {
 			$this->buildColumnDispatch();
 		}
-		
+
 		if(!empty($this->columnDispatch[$column])) {
 			$attrs = array();
 
@@ -493,20 +493,20 @@ class GridField extends FormField {
 		if(!$this->columnDispatch) {
 			$this->buildColumnDispatch();
 		}
-		
+
 		if(!empty($this->columnDispatch[$column])) {
 			$metadata = array();
 
 			foreach($this->columnDispatch[$column] as $handler) {
 				$column_metadata = $handler->getColumnMetadata($this, $column);
-				
+
 				if(is_array($column_metadata))
 					$metadata = array_merge($metadata, $column_metadata);
 				else
 					throw new LogicException("Non-array response from " . get_class($handler) . "::getColumnMetadata()");
-				
+
 			}
-			
+
 			return $metadata;
 		}
 		throw new InvalidArgumentException("Bad column '$column'");
@@ -520,13 +520,13 @@ class GridField extends FormField {
 	public function getColumnCount() {
 		// Build the column dispatch
 		if(!$this->columnDispatch) $this->buildColumnDispatch();
-		return count($this->columnDispatch);	
+		return count($this->columnDispatch);
 	}
 
 	/**
 	 * Build an columnDispatch that maps a GridField_ColumnProvider to a column
 	 * for reference later
-	 * 
+	 *
 	 */
 	protected function buildColumnDispatch() {
 		$this->columnDispatch = array();
@@ -544,7 +544,7 @@ class GridField extends FormField {
 	 * This is the action that gets executed when a GridField_AlterAction gets clicked.
 	 *
 	 * @param array $data
-	 * @return string 
+	 * @return string
 	 */
 	public function gridFieldAlterAction($data, $form, SS_HTTPRequest $request) {
 		$html = '';
@@ -567,7 +567,7 @@ class GridField extends FormField {
 				if($html) return $html;
 			}
 		}
-		
+
 		switch($request->getHeader('X-Pjax')) {
 			case 'CurrentField':
 				return $this->FieldHolder();
@@ -598,17 +598,17 @@ class GridField extends FormField {
 			if(!($component instanceof GridField_ActionProvider)) {
 				continue;
 			}
-			
+
 			if(in_array($actionName, array_map('strtolower', (array)$component->getActions($this)))) {
 				return $component->handleAction($this, $actionName, $args, $data);
 			}
 		}
 		throw new InvalidArgumentException("Can't handle action '$actionName'");
 	}
-	
+
 	/**
 	 * Custom request handler that will check component handlers before proceeding to the default implementation.
-	 * 
+	 *
 	 * @todo There is too much code copied from RequestHandler here.
 	 */
 	function handleRequest(SS_HTTPRequest $request, DataModel $model) {
@@ -621,14 +621,14 @@ class GridField extends FormField {
 
 		$fieldData = $this->request->requestVar($this->getName());
 		if($fieldData && $fieldData['GridState']) $this->getState(false)->setValue($fieldData['GridState']);
-		
+
 		foreach($this->getComponents() as $component) {
 			if(!($component instanceof GridField_URLHandler)) {
 				continue;
 			}
-			
+
 			$urlHandlers = $component->getURLHandlers($this);
-			
+
 			if($urlHandlers) foreach($urlHandlers as $rule => $action) {
 				if($params = $request->match($rule, true)) {
 					// Actions can reference URL parameters, eg, '$Action/$ID/$OtherID' => '$Action',
@@ -671,7 +671,7 @@ class GridField extends FormField {
 				}
 			}
 		}
-		
+
 		return parent::handleRequest($request, $model);
 	}
 }
@@ -679,11 +679,11 @@ class GridField extends FormField {
 
 /**
  * This class is the base class when you want to have an action that alters the state of the gridfield,
- * rendered as a button element. 
- * 
+ * rendered as a button element.
+ *
  * @package framework
  * @subpackage forms
- * 
+ *
  */
 class GridField_FormAction extends FormAction {
 
@@ -692,19 +692,19 @@ class GridField_FormAction extends FormAction {
 	 * @var GridField
 	 */
 	protected $gridField;
-	
+
 	/**
 	 *
-	 * @var array 
+	 * @var array
 	 */
 	protected $stateValues;
-	
+
 	/**
 	 *
 	 * @var array
 	 */
 	//protected $stateFields = array();
-	
+
 	protected $actionName;
 
 	protected $args = array();
@@ -717,7 +717,7 @@ class GridField_FormAction extends FormAction {
 	 * @param type $name
 	 * @param type $label
 	 * @param type $actionName
-	 * @param type $args 
+	 * @param type $args
 	 */
 	public function __construct(GridField $gridField, $name, $title, $actionName, $args) {
 		$this->gridField = $gridField;
@@ -728,7 +728,7 @@ class GridField_FormAction extends FormAction {
 
 	/**
 	 * urlencode encodes less characters in percent form than we need - we need everything that isn't a \w
-	 * 
+	 *
 	 * @param string $val
 	 */
 	public function nameEncode($val) {
@@ -737,7 +737,7 @@ class GridField_FormAction extends FormAction {
 
 	/**
 	 * The callback for nameEncode
-	 * 
+	 *
 	 * @param string $val
 	 */
 	public function _nameEncode($match) {
@@ -754,12 +754,12 @@ class GridField_FormAction extends FormAction {
 		$id = preg_replace('/[^\w]+/', '_', uniqid('', true));
 		Session::set($id, $state);
 		$actionData['StateID'] = $id;
-		
+
 		return array_merge(
 			parent::getAttributes(),
 			array(
-				// Note:  This field needs to be less than 65 chars, otherwise Suhosin security patch 
-				// will strip it from the requests 
+				// Note:  This field needs to be less than 65 chars, otherwise Suhosin security patch
+				// will strip it from the requests
 				'name' => 'action_gridFieldAlterAction'. '?' . http_build_query($actionData),
 				'data-url' => $this->gridField->Link(),
 			)

--- a/forms/gridfield/GridFieldConfig.php
+++ b/forms/gridfield/GridFieldConfig.php
@@ -3,10 +3,10 @@
  * Encapsulates a collection of components following the {@link GridFieldComponent} interface.
  * While the {@link GridField} itself has some configuration in the form of setters,
  * most of the details are dealt with through components.
- * 
+ *
  * For example, you would add a {@link GridFieldPaginator} component to enable
  * pagination on the listed records, and configure it through {@link GridFieldPaginator->setItemsPerPage()}.
- * 
+ *
  * In order to reduce the amount of custom code required, the framework provides
  * some default configurations for common use cases:
  * - {@link GridFieldConfig_Base} (added by default to GridField)
@@ -14,30 +14,30 @@
  * - {@link GridFieldConfig_RelationEditor}
  */
 class GridFieldConfig {
-	
+
 	/**
 	 *
-	 * @return GridFieldConfig 
+	 * @return GridFieldConfig
 	 */
 	public static function create(){
 		return new GridFieldConfig();
 	}
-	
+
 	/**
 	 *
 	 * @var ArrayList
 	 */
 	protected $components = null;
-	
+
 	/**
-	 * 
+	 *
 	 */
 	public function __construct() {
 		$this->components = new ArrayList();
 	}
-	
+
 	/**
-	 * @param GridFieldComponent $component 
+	 * @param GridFieldComponent $component
 	 * @param string $insertBefore The class of the component to insert this one before
 	 */
 	public function addComponent(GridFieldComponent $component, $insertBefore = null) {
@@ -67,16 +67,16 @@ class GridFieldConfig {
 		foreach($components as $component) $this->addComponent($component);
 		return $this;
 	}
-	
+
 	/**
-	 * @param GridFieldComponent $component 
+	 * @param GridFieldComponent $component
 	 * @return GridFieldConfig $this
 	 */
 	public function removeComponent(GridFieldComponent $component) {
 		$this->getComponents()->remove($component);
-		return $this;	
+		return $this;
 	}
-	
+
 	/**
 	 * @param String Class name or interface
 	 * @return GridFieldConfig $this
@@ -88,7 +88,7 @@ class GridFieldConfig {
 		}
 		return $this;
 	}
-	
+
 	/**
 	 * @return ArrayList Of GridFieldComponent
 	 */
@@ -101,7 +101,7 @@ class GridFieldConfig {
 
 	/**
 	 * Returns all components extending a certain class, or implementing a certain interface.
-	 * 
+	 *
 	 * @param String Class name or interface
 	 * @return ArrayList Of GridFieldComponent
 	 */
@@ -115,7 +115,7 @@ class GridFieldConfig {
 
 	/**
 	 * Returns the first available component with the given class or interface.
-	 * 
+	 *
 	 * @param String ClassName
 	 * @return GridFieldComponent
 	 */
@@ -173,7 +173,7 @@ class GridFieldConfig_RecordViewer extends GridFieldConfig_Base {
 }
 
 /**
- * 
+ *
  */
 class GridFieldConfig_RecordEditor extends GridFieldConfig {
 
@@ -191,7 +191,7 @@ class GridFieldConfig_RecordEditor extends GridFieldConfig {
 	 * @param int $itemsPerPage - How many items per page should show up
 	 */
 	public function __construct($itemsPerPage=null) {
-		
+
 		$this->addComponent(new GridFieldButtonRow('before'));
 		$this->addComponent(new GridFieldAddNewButton('buttons-before-left'));
 		$this->addComponent(new GridFieldToolbarHeader());
@@ -212,11 +212,11 @@ class GridFieldConfig_RecordEditor extends GridFieldConfig {
 
 /**
  * Similar to {@link GridFieldConfig_RecordEditor}, but adds features
- * to work on has-many or many-many relationships. 
+ * to work on has-many or many-many relationships.
  * Allows to search for existing records to add to the relationship,
  * detach listed records from the relationship (rather than removing them from the database),
  * and automatically add newly created records to it.
- * 
+ *
  * To further configure the field, use {@link getComponentByType()},
  * for example to change the field to search.
  * <code>
@@ -231,16 +231,16 @@ class GridFieldConfig_RelationEditor extends GridFieldConfig {
 	 * @param int $itemsPerPage - How many items per page should show up
 	 * @return GridFieldConfig_RelationEditor
 	 */
-	public static function create($itemsPerPage=null){
-		return new GridFieldConfig_RelationEditor($itemsPerPage);
+	public static function create($itemsPerPage = null,$relationAutoSetting = true){
+		return new GridFieldConfig_RelationEditor($itemsPerPage, $relationAutoSetting);
 	}
 
 	/**
 	 *
 	 * @param int $itemsPerPage - How many items per page should show up
 	 */
-	public function __construct($itemsPerPage=null) {
-		
+	public function __construct($itemsPerPage = null, $relationAutoSetting = true) {
+
 		$this->addComponent(new GridFieldButtonRow('before'));
 		$this->addComponent(new GridFieldAddNewButton('buttons-before-left'));
 		$this->addComponent(new GridFieldAddExistingAutocompleter('buttons-before-left'));
@@ -251,7 +251,9 @@ class GridFieldConfig_RelationEditor extends GridFieldConfig {
 		$this->addComponent(new GridFieldEditButton());
 		$this->addComponent(new GridFieldDeleteAction());
 		$this->addComponent($pagination = new GridFieldPaginator($itemsPerPage));
-		$this->addComponent(new GridFieldDetailForm());
+		$this->addComponent($detailForm = new GridFieldDetailForm());
+
+		$detailForm->setRelationAutoSetting($relationAutoSetting);
 
 		$sort->setThrowExceptionOnBadDataType(false);
 		$filter->setThrowExceptionOnBadDataType(false);

--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Provides view and edit forms at GridField-specific URLs.  
+ * Provides view and edit forms at GridField-specific URLs.
  * These can be placed into pop-ups by an appropriate front-end.
  * Usually added to a grid field alongside of {@link GridFieldEditButton}
  * which takes care of linking the individual rows to their edit view.
- * 
+ *
  * The URLs provided will be off the following form:
  *  - <FormURL>/field/<GridFieldName>/item/<RecordID>
  *  - <FormURL>/field/<GridFieldName>/item/<RecordID>/edit
@@ -38,13 +38,27 @@ class GridFieldDetailForm implements GridField_URLHandler {
 	 */
 	protected $itemEditFormCallback;
 
+	/**
+	 * @var bool Allow the CMS to guess the relation field
+	 */
+	protected $relationAutoSetting = true;
+
 	function getURLHandlers($gridField) {
 		return array(
 			'item/$ID' => 'handleItem',
 			'autocomplete' => 'handleAutocomplete',
 		);
 	}
-	
+
+	function setRelationAutoSetting($bool) {
+		$this->relationAutoSetting = $bool;
+		return $this;
+	}
+
+	function getRelationAutoSetting() {
+		return $this->relationAutoSetting;
+	}
+
 	/**
 	 * Create a popup component. The two arguments will specify how the popup form's HTML and
 	 * behaviour is created.  The given controller will be customised, putting the edit form into the
@@ -52,18 +66,18 @@ class GridFieldDetailForm implements GridField_URLHandler {
 	 *
 	 * The arguments are experimental API's to support partial content to be passed back to whatever
 	 * controller who wants to display the getCMSFields
-	 * 
+	 *
 	 * @param string $name The name of the edit form to place into the pop-up form
 	 */
 	public function __construct($name = 'DetailForm') {
 		$this->name = $name;
 	}
-	
+
 	/**
 	 *
 	 * @param type $gridField
 	 * @param type $request
-	 * @return GridFieldDetailForm_ItemRequest 
+	 * @return GridFieldDetailForm_ItemRequest
 	 */
 	public function handleItem($gridField, $request) {
 		$controller = $gridField->getForm()->Controller();
@@ -71,7 +85,7 @@ class GridFieldDetailForm implements GridField_URLHandler {
 		if(is_numeric($request->param('ID'))) {
 			$record = $gridField->getList()->byId($request->param("ID"));
 		} else {
-			$record = Object::create($gridField->getModelClass());	
+			$record = Object::create($gridField->getModelClass());
 		}
 
 		$class = $this->getItemRequestClass();
@@ -164,19 +178,19 @@ class GridFieldDetailForm implements GridField_URLHandler {
 }
 
 class GridFieldDetailForm_ItemRequest extends RequestHandler {
-	
+
 	/**
 	 *
-	 * @var GridField 
+	 * @var GridField
 	 */
 	protected $gridField;
-	
+
 	/**
 	 *
 	 * @var GridField_URLHandler
 	 */
 	protected $component;
-	
+
 	/**
 	 *
 	 * @var DataObject
@@ -188,13 +202,13 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 	 * @var Controller
 	 */
 	protected $popupController;
-	
+
 	/**
 	 *
 	 * @var string
 	 */
 	protected $popupFormName;
-	
+
 	/**
 	 * @var String
 	 */
@@ -204,14 +218,14 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 		'$Action!' => '$Action',
 		'' => 'edit',
 	);
-	
+
 	/**
 	 *
 	 * @param GridFIeld $gridField
 	 * @param GridField_URLHandler $component
 	 * @param DataObject $record
 	 * @param Controller $popupController
-	 * @param string $popupFormName 
+	 * @param string $popupFormName
 	 */
 	public function __construct($gridField, $component, $record, $popupController, $popupFormName) {
 		$this->gridField = $gridField;
@@ -253,31 +267,38 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 		$controller = $this->getToplevelController();
 		$form = $this->ItemEditForm($this->gridField, $request);
 
+		if ($this->component->getRelationAutoSetting()) {
+			//@todo Determine if these vars/functions are always available
+			// or what we want
+			$list = $this->gridField->getList();
+			$form->Fields()->push(new HiddenField($list->foreignKey,'tetr',$list->foreignID));
+		}
+
 		$return = $this->customise(array(
 			'Backlink' => $controller->hasMethod('Backlink') ? $controller->Backlink() : $controller->Link(),
 			'ItemEditForm' => $form,
 		))->renderWith($this->template);
 
 		if($request->isAjax()) {
-			return $return;	
+			return $return;
 		} else {
 			// If not requested by ajax, we need to render it within the controller context+template
 			return $controller->customise(array(
 				// TODO CMS coupling
 				'Content' => $return,
-			));	
+			));
 		}
 	}
 
 	/**
 	 * Builds an item edit form.  The arguments to getCMSFields() are the popupController and
 	 * popupFormName, however this is an experimental API and may change.
-	 * 
+	 *
 	 * @todo In the future, we will probably need to come up with a tigher object representing a partially
 	 * complete controller with gaps for extra functionality.  This, for example, would be a better way
 	 * of letting Security/login put its log-in form inside a UI specified elsewhere.
-	 * 
-	 * @return Form 
+	 *
+	 * @return Form
 	 */
 	function ItemEditForm() {
 		if (empty($this->record)) {
@@ -297,7 +318,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 			//Change the Save label to 'Create'
 			$actions->push(FormAction::create('doSave', _t('GridFieldDetailForm.Create', 'Create'))
 				->setUseButtonTag(true)->addExtraClass('ss-ui-action-constructive')->setAttribute('data-icon', 'add'));
-				
+
 			// Add a Cancel link which is a button-like link and link back to one level up.
 			$curmbs = $this->Breadcrumbs();
 			if($curmbs && $curmbs->count()>=2){
@@ -321,7 +342,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 		// TODO Coupling with CMS
 		$toplevelController = $this->getToplevelController();
 		if($toplevelController && $toplevelController instanceof LeftAndMain) {
-			// Always show with base template (full width, no other panels), 
+			// Always show with base template (full width, no other panels),
 			// regardless of overloaded CMS controller templates.
 			// TODO Allow customization, e.g. to display an edit form alongside a search form from the CMS controller
 			$form->setTemplate('LeftAndMain_EditForm');
@@ -330,7 +351,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 			if($form->Fields()->hasTabset()) $form->Fields()->findOrMakeTab('Root')->setTemplate('CMSTabSet');
 			// TODO Link back to controller action (and edited root record) rather than index,
 			// which requires more URL knowledge than the current link to this field gives us.
-			// The current root record is held in session only, 
+			// The current root record is held in session only,
 			// e.g. page/edit/show/6/ vs. page/edit/EditForm/field/MyGridField/....
 			$form->Backlink = $toplevelController->hasMethod('Backlink') ? $toplevelController->Backlink() : $toplevelController->Link();
 		}
@@ -345,7 +366,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 	 * Traverse up nested requests until we reach the first that's not a GridFieldDetailForm_ItemRequest.
 	 * The opposite of {@link Controller::curr()}, required because
 	 * Controller::$controller_stack is not directly accessible.
-	 * 
+	 *
 	 * @return Controller
 	 */
 	protected function getToplevelController() {
@@ -375,7 +396,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 			$this->record->singular_name(),
 			'<a href="' . $this->Link('edit') . '">"' . htmlspecialchars($this->record->Title, ENT_QUOTES) . '"</a>'
 		);
-		
+
 		$form->sessionMessage($message, 'good');
 
 		return Controller::curr()->redirect($this->Link());
@@ -443,8 +464,8 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 	 * CMS-specific functionality: Passes through navigation breadcrumbs
 	 * to the template, and includes the currently edited record (if any).
 	 * see {@link LeftAndMain->Breadcrumbs()} for details.
-	 * 
-	 * @param boolean $unlinked 
+	 *
+	 * @param boolean $unlinked
 	 * @return ArrayData
 	 */
 	function Breadcrumbs($unlinked = false) {
@@ -455,14 +476,14 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 			$items->push(new ArrayData(array(
 				'Title' => $this->record->Title,
 				'Link' => $this->Link()
-			)));	
+			)));
 		} else {
 			$items->push(new ArrayData(array(
 				'Title' => sprintf(_t('GridField.NewRecord', 'New %s'), $this->record->singular_name()),
 				'Link' => false
-			)));	
+			)));
 		}
-		
+
 		return $items;
 	}
 }

--- a/forms/gridfield/GridFieldLevelup.php
+++ b/forms/gridfield/GridFieldLevelup.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * Adds a "level up" link to a GridField table, which is useful
- * when viewing hierarchical data. Requires the managed record 
+ * when viewing hierarchical data. Requires the managed record
  * to have a "getParent()" method or has_one relationship called "Parent".
  */
 class GridFieldLevelup extends Object implements GridField_HTMLProvider{
-	
+
 	/**
 	 * @var integer - the record id of the level up to
 	 */
@@ -30,13 +30,12 @@ class GridFieldLevelup extends Object implements GridField_HTMLProvider{
 	public function __construct($currentID) {
 		if($currentID && is_numeric($currentID)) $this->currentID = $currentID;
 	}
-	
+
 	public function getHTMLFragments($gridField) {
 		$modelClass = $gridField->getModelClass();
 		$parentID = 0;
 
-		if($this->currentID) {
-			$modelObj = DataObject::get_by_id($modelClass, $this->currentID);
+		if($this->currentID && $modelObj = DataObject::get_by_id($modelClass, $this->currentID)) {
 
 			if($modelObj->hasMethod('getParent')) {
 				$parent = $modelObj->getParent();
@@ -45,7 +44,7 @@ class GridFieldLevelup extends Object implements GridField_HTMLProvider{
 			}
 
 			if($parent) $parentID = $parent->ID;
-			
+
 			// Attributes
 			$attrs = array_merge($this->attributes, array(
 				'href' => sprintf($this->linkSpec, $parentID),
@@ -81,4 +80,4 @@ class GridFieldLevelup extends Object implements GridField_HTMLProvider{
 	public function getLinkSpec() {
 		return $this->linkSpec;
 	}
-} 
+}


### PR DESCRIPTION
Auto relation setting is now working on grid field when used like so:

GridField::create(
    'Name',
    'Label',
    $this->Relation(),
    GridFieldConfig_RelationEditor::create()
)

To turn off relation auto setting:
GridFieldConfig_RelationEditor::create($itemsPerPage,false)
