### PR TITLE
FIX/minor fix the error in firefox were the toggle arrow on the drop down appears double

### DIFF
--- a/scss/TreeDropdownField.scss
+++ b/scss/TreeDropdownField.scss
@@ -52,7 +52,6 @@ div.TreeDropdownField {
 		margin: 0;
 		z-index: 0;
 		padding: 7px 3px;
-		float: right;
 		overflow: hidden;
 		-webkit-border-radius: 0 4px 4px 0;
 		-moz-border-radius: 0 4px 4px 0;


### PR DESCRIPTION
as the picture https://skitch.com/betterthangod/erb45/silverstripe-edit-page the change was tested on safari, chrome and firefox.
