### PR TITLE
FIX Join table names were escaped 

### DIFF
--- a/model/SQLQuery.php
+++ b/model/SQLQuery.php
@@ -874,7 +874,7 @@ class SQLQuery {
 				else $filter = "(" . implode(") AND (", $join['filter']) . ")";
 
 				$aliasClause = ($alias != $join['table']) ? " AS \"" . Convert::raw2sql($alias) . "\"" : "";
-				$this->from[$alias] = strtoupper($join['type']) . " JOIN \"" . Convert::raw2sql($join['table']) . "\"$aliasClause ON $filter";
+				$this->from[$alias] = strtoupper($join['type']) . " JOIN \"" . $join['table'] . "\"$aliasClause ON $filter";
 			}
 		}
 


### PR DESCRIPTION
The table name in the join was being escaped, though table
names aren't escaped anywhere else.
