### PR TITLE
FIX: ensure permissions_for_member() accounts for denied permissions

### DIFF
--- a/tests/security/PermissionTest.php
+++ b/tests/security/PermissionTest.php
@@ -1,6 +1,11 @@
 <?php
 
+/**
+ * @package framework
+ * @subpackage tests
+ */
 class PermissionTest extends SapphireTest {
+
 	static $fixture_file = 'PermissionTest.yml';
 	
 	function testGetCodesGrouped() {
@@ -32,6 +37,23 @@ class PermissionTest extends SapphireTest {
 		$this->assertTrue(Permission::checkMember($member, "CMS_ACCESS_SecurityAdmin"));
 		$this->assertTrue(Permission::checkMember($member, "EDIT_PERMISSIONS"));
 		$this->assertFalse(Permission::checkMember($member, "SITETREE_VIEW_ALL"));
+	}
+
+	function testPermissionsForMember() {
+		$member = $this->objFromFixture('Member', 'access');
+		$permissions = Permission::permissions_for_member($member->ID);
+		$this->assertEquals(4, count($permissions));
+		$this->assertTrue(in_array('CMS_ACCESS_MyAdmin', $permissions));
+		$this->assertTrue(in_array('CMS_ACCESS_AssetAdmin', $permissions));
+		$this->assertTrue(in_array('CMS_ACCESS_SecurityAdmin', $permissions));
+		$this->assertTrue(in_array('EDIT_PERMISSIONS', $permissions));
+
+		$group = $this->objFromFixture("Group", "access");
+
+		Permission::deny($group->ID, "CMS_ACCESS_MyAdmin");
+		$permissions = Permission::permissions_for_member($member->ID);
+		$this->assertEquals(3, count($permissions));
+		$this->assertFalse(in_array('CMS_ACCESS_MyAdmin', $permissions));
 	}
 	
 	function testRolesAndPermissionsFromParentGroupsAreInherited() {
@@ -76,5 +98,5 @@ class PermissionTest extends SapphireTest {
 		
 		Permission::remove_from_hidden_permissions('CMS_ACCESS_LeftAndMain');
 		$this->assertContains('CMS_ACCESS_LeftAndMain', $permissionCheckboxSet->Field());
-	}	
+	}
 }

--- a/tests/security/PermissionTest.yml
+++ b/tests/security/PermissionTest.yml
@@ -3,7 +3,7 @@ PermissionRole:
       Title: Author
    access:
       Title: Access Administrator
-   
+
 PermissionRoleCode:
    author1:
       Role: =>PermissionRole.author
@@ -28,7 +28,7 @@ Member:
    globalauthor:
       FirstName: Test
       Surname: Global Author
-      
+
 Group:
    author:
       Title: Authors


### PR DESCRIPTION
Taken from http://open.silverstripe.org/ticket/7296. PermissionTest extended to validate that permissions_for_member() includes permissions denied pre applying patch. PermissionTest passes post patch.
