### PR TITLE
API: add api for setting a custom template on  RSS feed.

### DIFF
--- a/api/RSSFeed.php
+++ b/api/RSSFeed.php
@@ -8,6 +8,7 @@
  * @subpackage integration
  */
 class RSSFeed extends ViewableData {
+
 	/**
 	 * Casting information for this object's methods.
 	 * Let's us use $Title.XML in templates
@@ -79,6 +80,11 @@ class RSSFeed extends ViewableData {
 	 * @var string The value for the HTTP ETag header.
 	 */
 	protected $etag;
+
+	/**
+	 * @var string
+	 */
+	protected $template = 'RSSFeed';
 
 	/**
 	 * Constructor
@@ -203,9 +209,28 @@ class RSSFeed extends ViewableData {
 	function feedContent() {
 		$prevState = SSViewer::get_source_file_comments();
 		SSViewer::set_source_file_comments(false);
-		$content = str_replace('&nbsp;', '&#160;', $this->renderWith('RSSFeed'));
+		$content = str_replace('&nbsp;', '&#160;', $this->renderWith($this->getTemplate()));
 		SSViewer::set_source_file_comments($prevState);
 		return $content;
+	}
+
+	/**
+	 * Set the name of the template to use. Actual template will be resolved
+	 * via the standard template inclusion process.
+	 *
+	 * @param string
+	 */
+	public function setTemplate($template) {
+		$this->template = $template;
+	}
+
+	/**
+	 * Returns the name of the template to use.
+	 *
+	 * @return string
+	 */
+	public function getTemplate() {
+		return $this->template;
 	}
 }
 

--- a/tests/api/RSSFeedTest.php
+++ b/tests/api/RSSFeedTest.php
@@ -43,6 +43,20 @@ class RSSFeedTest extends SapphireTest {
 		$this->assertContains('<description>ItemC AltContent</description>', $content);
 	}
 
+	public function testRenderWithTemplate() {
+		$rssFeed = new RSSFeed(new ArrayList(), "", "", "");
+		$rssFeed->setTemplate('RSSFeedTest');
+
+		$content = $rssFeed->feedContent();
+
+		$this->assertContains('<title>Test Custom Template</title>', $content);
+
+		$rssFeed->setTemplate('RSSFeed');
+		$content = $rssFeed->feedContent();
+		
+		$this->assertNotContains('<title>Test Custom Template</title>', $content);
+	}
+
 	public function setUp() {
 		parent::setUp();
 		Director::setBaseURL('/');

--- a/tests/templates/RSSFeedTest.ss
+++ b/tests/templates/RSSFeedTest.ss
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom">
+	<channel>
+		<title>Test Custom Template</title>
+	</channel>
+</rss>


### PR DESCRIPTION
See initial idea at http://open.silverstripe.org/ticket/6441. Added $template property and corresponding getters / setters for customizing the template used. Added relevant unit test.
