### PR TITLE
FIX: improve Director::makeRelative() to ignore  SSL changes.

### DIFF
--- a/tests/control/DirectorTest.php
+++ b/tests/control/DirectorTest.php
@@ -122,16 +122,22 @@ class DirectorTest extends SapphireTest {
 	public function testMakeRelative() {
 		$siteUrl = Director::absoluteBaseURL();
 		$siteUrlNoProtocol = preg_replace('/https?:\/\//', '', $siteUrl);
+		
 		$this->assertEquals(Director::makeRelative("$siteUrl"), '');
-		//$this->assertEquals(Director::makeRelative("https://$siteUrlNoProtocol"), '');
+		$this->assertEquals(Director::makeRelative("https://$siteUrlNoProtocol"), '');
+		$this->assertEquals(Director::makeRelative("http://$siteUrlNoProtocol"), '');
+
 		$this->assertEquals(Director::makeRelative("   $siteUrl/testpage   "), 'testpage');
-		//$this->assertEquals(Director::makeRelative("$siteUrlNoProtocol/testpage"), 'testpage');
+		$this->assertEquals(Director::makeRelative("$siteUrlNoProtocol/testpage"), 'testpage');
+		
 		$this->assertEquals(Director::makeRelative('ftp://test.com'), 'ftp://test.com');
 		$this->assertEquals(Director::makeRelative('http://test.com'), 'http://test.com');
-		// the below is not a relative URL, test makes no sense
-		// $this->assertEquals(Director::makeRelative('/relative'), '/relative');
+
 		$this->assertEquals(Director::makeRelative('relative'), 'relative');
 		$this->assertEquals(Director::makeRelative("$siteUrl/?url=http://test.com"), '?url=http://test.com');
+
+		$this->assertEquals("test", Director::makeRelative("https://".$siteUrlNoProtocol."/test"));
+		$this->assertEquals("test", Director::makeRelative("http://".$siteUrlNoProtocol."/test"));
 	}
 	
 	/**


### PR DESCRIPTION
See http://open.silverstripe.org/ticket/6672. Expanded on initial patch with test coverage. Fixes another one of the commented out cases in the test by picking up URL's which do not include a protocol.
