### PR TITLE
API Deprecated Profiler class, removed related debug GET params

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -134,15 +134,7 @@ class Director implements TemplateGlobalProvider {
 			
 			$res = Injector::inst()->get('RequestProcessor')->postRequest($req, $response, $model);
 			if ($res !== false) {
-				// ?debug_memory=1 will output the number of bytes of memory used for this request
-				if(isset($_REQUEST['debug_memory']) && $_REQUEST['debug_memory']) {
-					Debug::message(sprintf(
-						"Peak memory usage in bytes: %s", 
-						number_format(memory_get_peak_usage(),0)
-					));
-				} else {
-					$response->output();
-				}
+				$response->output();
 			} else {
 				// @TODO Proper response here.
 				throw new SS_HTTPResponse_Exception("Invalid response");

--- a/dev/Profiler.php
+++ b/dev/Profiler.php
@@ -9,6 +9,8 @@
 
 /**
  * Execution time profiler.
+ *
+ * @deprecated 3.1 The Profiler class is deprecated, use third party tools like XHProf instead
  * 
  * @package framework
  * @subpackage misc
@@ -51,6 +53,7 @@ class Profiler {
     // Public Methods
     
     static function init() {
+        Deprecation::notice('3.1', 'The Profiler class is deprecated, use third party tools like XHProf instead');
     	if(!self::$inst) self::$inst = new Profiler(true,true);
     }
     	

--- a/docs/en/changelogs/3.1.0.md
+++ b/docs/en/changelogs/3.1.0.md
@@ -1,0 +1,9 @@
+# 3.1.0 (unreleased)
+
+## Overview ##
+
+## Upgrading
+
+ * Deprecated `Profiler` class, use third-party solutions like [xhprof](https://github.com/facebook/xhprof/)
+ * Removed defunct or unnecessary debug GET parameters: 
+   `debug_profile`, `debug_memory`, `profile_trace`, `debug_javascript`, `debug_behaviour`

--- a/docs/en/reference/urlvariabletools.md
+++ b/docs/en/reference/urlvariabletools.md
@@ -45,15 +45,6 @@ Append the option and corresponding value to your URL in your browser's address 
  | showqueries  | | 1      | | List all SQL queries executed                                                                | 
  | previewwrite | | 1      | | List all insert / update SQL queries, and **don't** execute them.  Useful for previewing writes to the database. | 
 
-## Profiling
-
- | URL Variable     | | Values | | Description                                                                                      | 
- | ------------     | | ------ | | -----------                                                                                      | 
- | debug_memory     | | 1      | | Output the number of bytes of memory used for this 
- | debug_memory     | | 1      | | Output the number of bytes of memory used for this request                                       | 
- | debug_profile    | | 1      | | Enable the [profiler](/topics/debugging) for the duration of the request                         | 
- | profile_trace    | | 1      | | Includes full stack traces, must be used with **debug_profile**                                  | 
-
 ## Security Redirects
 
 You can set an URL to redirect back to after a [Security](/topics/security) action.  See the section on [URL

--- a/main.php
+++ b/main.php
@@ -36,9 +36,6 @@ if (version_compare(phpversion(), '5.3.2', '<')) {
  * After that, it calls {@link Director::direct()}, which is responsible for doing most of the 
  * real work.
  *
- * Finally, main.php will use {@link Profiler} to show a profile if the querystring variable 
- * "debug_profile" is set.
- *
  * CONFIGURING THE WEBSERVER
  *
  * To use SilverStripe, every request that doesn't point directly to a file should be rewritten to
@@ -89,12 +86,6 @@ if (isset($_GET['url'])) {
 // Remove base folders from the URL if webroot is hosted in a subfolder
 if (substr(strtolower($url), 0, strlen(BASE_URL)) == strtolower(BASE_URL)) $url = substr($url, strlen(BASE_URL));
 
-if (isset($_GET['debug_profile'])) {
-	Profiler::init();
-	Profiler::mark('all_execution');
-	Profiler::mark('main.php init');
-}
-
 // Connect to database
 require_once('model/DB.php');
 
@@ -114,20 +105,8 @@ if(!isset($databaseConfig) || !isset($databaseConfig['database']) || !$databaseC
 	die();
 }
 
-if (isset($_GET['debug_profile'])) Profiler::mark('DB::connect');
 DB::connect($databaseConfig);
-if (isset($_GET['debug_profile'])) Profiler::unmark('DB::connect');
-
-if (isset($_GET['debug_profile'])) Profiler::unmark('main.php init');
-
 
 // Direct away - this is the "main" function, that hands control to the appropriate controller
 DataModel::set_inst(new DataModel());
 Director::direct($url, DataModel::inst());
-
-if (isset($_GET['debug_profile'])) {
-	Profiler::unmark('all_execution');
-	if(!Director::isLive()) {
-		Profiler::show(isset($_GET['profile_trace']));
-	}
-}

--- a/model/Database.php
+++ b/model/Database.php
@@ -455,8 +455,6 @@ abstract class SS_Database {
 		$fieldValue = null;
 		$newTable = false;
 		
-		Profiler::mark('requireField');
-		
 		// backwards compatibility patch for pre 2.4 requireField() calls
 		$spec_orig=$spec;
 		
@@ -507,10 +505,7 @@ abstract class SS_Database {
 		}
 		
 		if($newTable || $fieldValue=='') {
-			Profiler::mark('createField');
-			
 			$this->transCreateField($table, $field, $spec_orig);
-			Profiler::unmark('createField');
 			$this->alterationMessage("Field $table.$field: created as $spec_orig","created");
 		} else if($fieldValue != $specValue) {
 			// If enums/sets are being modified, then we need to fix existing data in the table.
@@ -545,12 +540,9 @@ abstract class SS_Database {
 					}
 				}
 			}
-			Profiler::mark('alterField');
 			$this->transAlterField($table, $field, $spec_orig);
-			Profiler::unmark('alterField');
 			$this->alterationMessage("Field $table.$field: changed to $specValue <i style=\"color: #AAA\">(from {$fieldValue})</i>","changed");
 		}
-		Profiler::unmark('requireField');
 	}
 	
 	/**

--- a/view/Requirements.php
+++ b/view/Requirements.php
@@ -646,8 +646,6 @@ class Requirements_Backend {
 	 * @return string HTML content thats augumented with the requirements before the closing <head> tag.
 	 */
 	function includeInHTML($templateFile, $content) {
-		if(isset($_GET['debug_profile'])) Profiler::mark("Requirements::includeInHTML");
-		
 		if((strpos($content, '</head>') !== false || strpos($content, '</head ') !== false) && ($this->css || $this->javascript || $this->customCSS || $this->customScript || $this->customHeadTags)) {
 			$requirements = '';
 			$jsRequirements = '';
@@ -710,8 +708,6 @@ class Requirements_Backend {
 				$content = preg_replace("/(<\/head>)/i", $jsRequirements . "\\1", $content);
 			}
 		} 
-		
-		if(isset($_GET['debug_profile'])) Profiler::unmark("Requirements::includeInHTML");
 		
 		return $content;
 	}

--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -810,22 +810,16 @@ class SSViewer {
 			$template = $this->chosenTemplates[$key];
 		}
 		
-		if(isset($_GET['debug_profile'])) Profiler::mark("SSViewer::process", " for $template");
 		$cacheFile = TEMP_FOLDER . "/.cache" . str_replace(array('\\','/',':'), '.', Director::makeRelative(realpath($template)));
-
 		$lastEdited = filemtime($template);
 
 		if(!file_exists($cacheFile) || filemtime($cacheFile) < $lastEdited || isset($_GET['flush'])) {
-			if(isset($_GET['debug_profile'])) Profiler::mark("SSViewer::process - compile", " for $template");
-			
 			$content = file_get_contents($template);
 			$content = SSViewer::parseTemplateContent($content, $template);
 			
 			$fh = fopen($cacheFile,'w');
 			fwrite($fh, $content);
 			fclose($fh);
-
-			if(isset($_GET['debug_profile'])) Profiler::unmark("SSViewer::process - compile", " for $template");
 		}
 
 		$underlay = array('I18NNamespace' => basename($template));
@@ -846,8 +840,6 @@ class SSViewer {
 		
 		array_pop(SSViewer::$topLevel);
 
-		if(isset($_GET['debug_profile'])) Profiler::unmark("SSViewer::process", " for $template");
-		
 		// If we have our crazy base tag, then fix # links referencing the current page.
 		if($this->rewriteHashlinks && self::$options['rewriteHashlinks']) {
 			if(strpos($output, '<base') !== false) {

--- a/view/ViewableData.php
+++ b/view/ViewableData.php
@@ -351,10 +351,6 @@ class ViewableData extends Object implements IteratorAggregate {
 	 * @param string $cacheName a custom cache name
 	 */
 	public function obj($fieldName, $arguments = null, $forceReturnedObject = true, $cache = false, $cacheName = null) {
-		if(isset($_REQUEST['debug_profile'])) {
-			Profiler::mark("obj.$fieldName", "on a $this->class object");
-		}
-		
 		if(!$cacheName) $cacheName = $arguments ? $fieldName . implode(',', $arguments) : $fieldName;
 		
 		if(!isset($this->objCache[$cacheName])) {
@@ -382,10 +378,6 @@ class ViewableData extends Object implements IteratorAggregate {
 			if($cache) $this->objCache[$cacheName] = $value;
 		} else {
 			$value = $this->objCache[$cacheName];
-		}
-		
-		if(isset($_REQUEST['debug_profile'])) {
-			Profiler::unmark("obj.$fieldName", "on a $this->class object");
 		}
 		
 		if(!is_object($value) && $forceReturnedObject) {


### PR DESCRIPTION
Use third party tools like XHProf instead.
Removed defunct or unnecessary debug GET parameters:
debug_profile, debug_memory, profile_trace, debug_javascript, debug_behaviour

Rationale: Its been created in a time where third party profilers
weren't as useful as they are today. It clutters the core code,
adds unnecessary global dependencies. And its very selective
in what it profiles (just happens to be the stuff we thought would
have the biggest performance impact).

Sending pull request against master, as it shouldn't go into the 3.0 branch (and the 3.0.1 release)
