### PR TITLE
PaginatedList::getIterator() mutates the original list

### DIFF
--- a/core/PaginatedList.php
+++ b/core/PaginatedList.php
@@ -172,8 +172,9 @@ class PaginatedList extends SS_ListDecorator {
 	 */
 	public function getIterator() {
 		if($this->limitItems) {
+			$tmptList = clone $this->list;
 			return new IteratorIterator(
-				$this->list->limit($this->pageLength, $this->getPageStart())
+				$tmptList->limit($this->pageLength, $this->getPageStart())
 			);
 		} else {
 			return new IteratorIterator($this->list);

--- a/tests/model/PaginatedListTest.php
+++ b/tests/model/PaginatedListTest.php
@@ -7,6 +7,14 @@
  */
 class PaginatedListTest extends SapphireTest {
 
+	static $fixture_file = 'DataObjectTest.yml';
+
+	protected $extraDataObjects = array(
+		'DataObjectTest_Team',		
+		'DataObjectTest_SubTeam',
+		'DataObjectTest_Player'
+	);
+
 	public function testPageStart() {
 		$list = new PaginatedList(new ArrayList());
 		$this->assertEquals(0, $list->getPageStart(), 'The start defaults to 0.');
@@ -84,6 +92,12 @@ class PaginatedListTest extends SapphireTest {
 
 		$list->setCurrentPage(999);
 		$this->assertDOSEquals(array(), $list->getIterator());
+
+		$players = DataObjectTest_Player::get();
+		$list = new PaginatedList($players);
+		$list->setPageLength(1);
+		$list->getIterator();
+		$this->assertEquals(4, $list->getTotalItems(), 'Getting an iterator should not trim the list to the page length.');
 	}
 
 	public function testPages() {


### PR DESCRIPTION
Fix an issue where PaginatedList::getIterator() trims the original list to the page length when the source list is DataList. This bug, for example, affects the blog pagination. It appears that blog always have just one page since the total number of entries is equal to the set page length.
