### PR TITLE
BUGFIX: Width of Chosen dropdowns is wrong on hidden CMS tabs

### DIFF
--- a/admin/thirdparty/chosen/chosen/chosen.jquery.js
+++ b/admin/thirdparty/chosen/chosen/chosen.jquery.js
@@ -325,6 +325,7 @@ Copyright (c) 2011 by Harvest
       this.container_id = this.form_field.id.length ? this.form_field.id.replace(/(:|\.)/g, '_') : this.generate_field_id();
       this.container_id += "_chzn";
       this.f_width = this.form_field_jq.outerWidth();
+      if (this.f_width==0) this.f_width = this.form_field_jq.css("width");
       this.default_text = this.form_field_jq.data('placeholder') ? this.form_field_jq.data('placeholder') : this.default_text_default;
       container_div = $("<div />", {
         id: this.container_id,


### PR DESCRIPTION
When Chosen dropdowns are instantiated on hidden tabs, the width is rendered very small and they are unreadable. This is a known bug in Chosen. A change has been proposed at the Chosen page here: https://github.com/harvesthq/chosen/issues/92 but no pull request has been executed.
