### PR TITLE
BUG Attempt to create log path before writing file

### DIFF
--- a/dev/LogFileWriter.php
+++ b/dev/LogFileWriter.php
@@ -58,6 +58,7 @@ class SS_LogFileWriter extends Zend_Log_Writer_Abstract {
 			$this->setFormatter($formatter);
 		}
 		$message = $this->_formatter->format($event);
+		if(!file_exists(dirname($this->path))) mkdir(dirname($this->path), 0755, true);
 		error_log($message, $this->messageType, $this->path, $this->extraHeaders);
 	}
 


### PR DESCRIPTION
Attempt to create the path a log file will be written to before blindly
attempting to write the file. This makes dynamically named log paths
(i.e. rotation by date) possible.
