### PR TITLE
BUG Make RequestProcessor->filters settable as a property too

### DIFF
--- a/control/RequestProcessor.php
+++ b/control/RequestProcessor.php
@@ -14,6 +14,10 @@ class RequestProcessor {
 		$this->filters = $filters;
 	}
 
+	public function setFilters($filters) {
+		$this->filters = $filters;
+	}
+
 	public function preRequest(SS_HTTPRequest $request, Session $session, DataModel $model) {
 		foreach ($this->filters as $filter) {
 			$res = $filter->preRequest($request, $session, $model);


### PR DESCRIPTION
filters was a DI property that could only be set via constructor. This meant that modules couldnt add a
filter without interfering with other modules. With this change you can now add a config block like:

Injector:
  RequestProcessor:
    properties:
      filters:
        - "%$MyFilter"

Which will add a filter to RequestProcessors list of filters
