### PR TITLE
BUGFIX: Uploads not working on DataObjects in Webkit browsers.

### DIFF
--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -102,13 +102,15 @@
 				this.fileupload($.extend(true, 
 					{
 						formData: function(form) {
-							
+							var idVal = $(form).find(':input[name=ID]').val();
+							if(!idVal) {
+								idVal = 0;
+							}
 							return [
 								{name: 'SecurityID', value: $(form).find(':input[name=SecurityID]').val()},
-								{name: 'ID', value: $(form).find(':input[name=ID]').val()}
+								{name: 'ID', value: idVal}
 							];
 						},
-						errorMessages: {
 							// errorMessages for all error codes suggested from the plugin author, some will be overwritten by the config comming from php
 							1: ss.i18n._t('UploadField.PHP_MAXFILESIZE'),
 							2: ss.i18n._t('UploadField.HTML_MAXFILESIZE'),


### PR DESCRIPTION
This resolves the "not found" bug that was occurring when Webkit browsers attempt to upload a file to a DataObject (e.g. GridField, ModelAdmin). If the ID parameter was not found, Webkit would pass a string of "undefined" to the upload handler, while Firefox would pass an int 0.

Consequently, the url handler /admin/pages/EditForm/ was failing because LeftAndMain::currentPageID() was believing that ID was in the request, because "undefined" as a string is (bool) true. The page was not found because of course SiteTree #undefined doesn't exist. All subsequent URL rules failed, and the request returned 404.

When a (int) 0 was passed, LeftAndMain::currentPageID() would return false for "ID" being in the request because 0 is falsy.
