### PR TITLE
BUGFIX: UploadField does not work on DataObjects

### DIFF
--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -102,10 +102,13 @@
 				this.fileupload($.extend(true, 
 					{
 						formData: function(form) {
-							
+							var idVal = $(form).find(':input[name=ID]').val();
+							if(!idVal) {
+								idVal = 0;
+							}
 							return [
 								{name: 'SecurityID', value: $(form).find(':input[name=SecurityID]').val()},
-								{name: 'ID', value: $(form).find(':input[name=ID]').val()}
+								{name: 'ID', value: idVal}
 							];
 						},
 						errorMessages: {


### PR DESCRIPTION
This patch fixes UploadFields throwing a 404 "not found" error with DataObjects (e.g. GridField, ModelAdmin) in Webkit browsers. These browsers were passing an ID parameter into the request with a value of (string) "undefined", while Firefox was passing (int) 0.

This had the effect of confusing LeftAndMain::currentPageID(). A string value of "undefined" was causing the function to behave as if the ID parameter was present in the request, and subsequently attempting to retrieve SiteTree #undefined, which didn't exist, and therefore all subsequent URL handlers were failing, resulting in a 404.

Because Firefox passed a value of (int) 0, the function did not evaluate the ID parameter as being present in the request, because (int) 0 is falsy, and it went on to retrieve the currentPageID() from the session.

The patch forces a value of (int) 0 into the request when the form element containing ID is not found.
