### PR TITLE
BUG: variables and functions are precedence over subtemplates in SSViewe...

### DIFF
--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -837,7 +837,7 @@ class SSViewer {
 				$subtemplateViewer = new SSViewer($this->chosenTemplates[$subtemplate]);
 				$subtemplateViewer->setPartialCacheStore($this->getPartialCacheStore());
 
-				$underlay[$subtemplate] = $subtemplateViewer->process($item, $arguments);
+				$arguments[$subtemplate] = $subtemplateViewer->process($item, $arguments);
 			}
 		}
 


### PR DESCRIPTION
The use of templates/Content/ subtemplates has been restricted, and virtually prevented by the DataObject db field or functions taking precedence.

Trac ticket: http://open.silverstripe.org/ticket/7692
