### PR TITLE
FIX 2644

### DIFF
--- a/dev/Debug.php
+++ b/dev/Debug.php
@@ -416,7 +416,6 @@ class Debug {
 		}
 		$reporter->writeTrace(($errcontext ? $errcontext : debug_backtrace()));
 		$reporter->writeFooter();
-		exit(1);
 	}
 	
 	/**


### PR DESCRIPTION
Remove exit() from showError to continue execution after an user_error of warning (warningHandler) or notice (noticeHandler) level.
