### PR TITLE
NEW Tree node updates after save (fixes #7450, #7389, #7658)

### DIFF
--- a/admin/javascript/LeftAndMain.Tree.js
+++ b/admin/javascript/LeftAndMain.Tree.js
@@ -271,8 +271,11 @@
 			 *  (Object) Map of additional data, e.g. ParentID
 			 */
 			updateNode: function(node, html, data) {
-				var self = this, newNode = $(html), origClasses = node.attr('class'),
-					parentNode = data.ParentID ? this.find('li[data-id='+data.ParentID+']') : false;
+				var self = this, newNode = $(html), origClasses = node.attr('class');
+
+				var nextNode = data.NextID ? this.find('li[data-id='+data.NextID+']') : false;
+				var prevNode = data.PrevID ? this.find('li[data-id='+data.PrevID+']') : false;
+				var parentNode = data.ParentID ? this.find('li[data-id='+data.ParentID+']') : false;
 
 				// Copy attributes. We can't replace the node completely
 				// without removing or detaching its children nodes.
@@ -284,8 +287,15 @@
 				// Replace inner content
 				node.addClass(origClasses).html(newNode.html());
 
-				// Set correct parent
-				this.jstree('move_node', node, parentNode.length ? parentNode : -1, data.Sort);
+				if (nextNode && nextNode.length) {
+					this.jstree('move_node', node, nextNode, 'before');
+				}
+				else if (prevNode && prevNode.length) {
+					this.jstree('move_node', node, prevNode, 'after');
+				}
+				else {
+					this.jstree('move_node', node, parentNode.length ? parentNode : -1);
+				}
 			},
 			
 			/**


### PR DESCRIPTION
Rebased branch with some fixes from https://github.com/silverstripe/sapphire/pull/650
- Updates icon, badges, title, and position in hierarchy
- New LeftAndMain_TreeNode API to allow rendering of single tree nodes
  without their hierarchy, extracted from LeftAndMain->getSiteTreeFor()
- New LeftAndMain->updatetreenodes() endpoint to request updated state
  for one or more nodes. Triggered on demand by form refreshes.
