### PR TITLE
Fix edge case in sessionStorage detection for FireFox.

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -441,7 +441,7 @@ jQuery.noConflict();
 			 * Requires HTML5 sessionStorage support.
 			 */
 			saveTabState: function() {
-				if(typeof(window.sessionStorage)=="undefined") return;
+				if(typeof(window.sessionStorage)=="undefined" || window.sessionStorage == null) return;
 
 				var selectedTabs = [], url = this._tabStateUrl();
 				this.find('.cms-tabset,.ss-tabset').each(function(i, el) {
@@ -459,7 +459,7 @@ jQuery.noConflict();
 			 * Requires HTML5 sessionStorage support.
 			 */
 			restoreTabState: function() {
-				if(typeof(window.sessionStorage)=="undefined") return;
+				if(typeof(window.sessionStorage)=="undefined" || window.sessionStorage == null) return;
 
 				var self = this, url = this._tabStateUrl(),
 					data = window.sessionStorage.getItem('tabs-' + url),


### PR DESCRIPTION
If sessionStorage is disabled using about:config, typeof will be object, but the value will be null. See http://open.silverstripe.org/ticket/7617.
