### PR TITLE
BUG Set javascript i18n locale from lang attribute in body tag

### DIFF
--- a/javascript/i18n.js
+++ b/javascript/i18n.js
@@ -174,6 +174,13 @@ ss.i18n = {
 				}
 			}
 
+			if(!rawLocale) {
+				// get by lang attribute on the body tag
+				if (document.getElementsByTagName('body')[0].attributes['lang']) {
+					rawLocale = document.getElementsByTagName('body')[0].attributes['lang'].nodeValue;
+				}
+			}
+			
 			// fallback to default locale
 			if(!rawLocale) rawLocale = this.defaultLocale;
 			


### PR DESCRIPTION
Set current i18n locale for javascript based on the lang attribute in
the body tag (if present) if no matching locale is found from meta tags.
This fixes javascript i18n switching in the cms (where the lang
attribute on the body tag is used).
