### PR TITLE
BUG: augmentSQL always extended on base data class on query finalization

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -227,7 +227,7 @@ class DataQuery {
 
 		// TODO: Versioned, Translatable, SiteTreeSubsites, etc, could probably be better implemented as subclasses of DataQuery
 
-		$obj = Injector::inst()->get(ClassInfo::baseDataClass($this->dataClass));
+		$obj = Injector::inst()->get($this->dataClass);
 		$obj->extend('augmentSQL', $query, $this);
 
 		$this->ensureSelectContainsOrderbyColumns($query);


### PR DESCRIPTION
The augmentSQL DataExtension method is always extended on the base data
class of data objects in DataQuery::getFinilisedQuery(). This results
in augmentSQL not being called for extensions that are applied to non-
base data classes when finalizing the query.

For example, if Versioned was applied to class B which extends class A,
which in turn extends DataObject, then augmentSQL would be extended for
class A in DataQuery::getFinilisedQuery(). Since class A doesn't have
the Versioned extension in this example, it would not work for class B.

Fixed this by extending augmentSQL on the actual data class and not
on the base class.
