### PR TITLE
BUG: javascript tree node updating fails when Translatable is used

### DIFF
--- a/admin/javascript/LeftAndMain.Tree.js
+++ b/admin/javascript/LeftAndMain.Tree.js
@@ -342,7 +342,7 @@
 				self.jstree('save_selected');
 
 				$.ajax({
-					url: this.data('urlUpdatetreenodes') + '?ids=' + ids.join(','),
+					url: $.path.addSearchParams(this.data('urlUpdatetreenodes'), 'ids=' + ids.join(',')),
 					dataType: 'json',
 					success: function(data, xhr) {
 						$.each(data, function(nodeId, nodeData) {


### PR DESCRIPTION
Automatic tree node updating fails when for example creating a new
translation, due to the update URL containing two question marks,
due to the locale get parameter.

Fixed by using the $.path.addSearchParams utility function, which properly
checks for existing query string parameters.
