### PR TITLE
Add thumbnails to the attach image dialog (Trac 7738).

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -15,6 +15,12 @@ class Image extends File {
 	static $casting = array(
 		'Tag' => 'HTMLText',
 	);
+	
+	public static $summary_fields = array(
+		'StripThumbnail' => 'Thumbnail',
+		'Name' => 'Name',
+		'Title' => 'Title',
+	);
 
 	/**
 	 * The width of an image thumbnail in a strip.


### PR DESCRIPTION
This is the change that I proposed in http://open.silverstripe.org/ticket/7738. The question is, if it would be smarter to add the summary_fields to File instead and include the information that AssetAdmin requires (see the trac ticket).
