### PR TITLE
Apply a default filter for a relation if none was specified

### DIFF
--- a/model/DataList.php
+++ b/model/DataList.php
@@ -379,8 +379,11 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 				$fieldArgs = explode(':',$field);
 				$field = array_shift($fieldArgs);
 				foreach($fieldArgs as $fieldArg){
-					$comparisor = $this->applyFilterContext($field, $fieldArg, $value);
+					$this->applyFilterContext($field, $fieldArg, $value);
 				}
+			} elseif (strstr($field,'.') !== false) {
+				//Relation without a filter, use default filter (ExactMatch).
+				$this->applyFilterContext($field, 'ExactMatch', $value);
 			} else {
 				if($field == 'ID') {
 					$field = sprintf('"%s"."ID"', ClassInfo::baseDataClass($this->dataClass));

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -140,7 +140,9 @@ class DataListTest extends SapphireTest {
 	
 	function testFilter() {
 		// coming soon!
-		}
+		//TODO be sure to test all cases in addFilter(), including adding a relation
+		// without a filter (e.g. DataObjectTest_SubTeam.ParentTeam)
+	}
 		
 	function testWhere() {
 		// We can use raw SQL queries with where.  This is only recommended for advanced uses;


### PR DESCRIPTION
Follow up to pull #693.

If addFilter() is called for a relation without specifying a default filter (e.g. Groups.Permissions.Code vs. Groups.Permissions.Code:ExactMatch) this patch will apply a default filter.
This default filter is currently hard coded to `search/filter/ExactMatchFilter`, introducing a dependency on that filter.

Willr proposed that the default should be a case insensitive exact match. ExactMatch contains a todo for a case sensitivity switch. So this switch should be set as soon as it is available. Maybe a TODO for that should be added to addFilter.
