### PR TITLE
FIX 7742 Properly escape tree dropdown field title

### DIFF
--- a/forms/TreeDropdownField.php
+++ b/forms/TreeDropdownField.php
@@ -188,7 +188,7 @@ class TreeDropdownField extends FormField {
 			$properties,
 			array(
 				'Title' => $title,
-				'TitleURLEncoded' => rawurlencode($title),
+				'TitleURLEncoded' => Convert::raw2att($title),
 				'Metadata' => ($metadata) ? Convert::raw2att(Convert::raw2json($metadata)) : null
 			)
 		);


### PR DESCRIPTION
See http://open.silverstripe.org/ticket/7742

Also if someone could explain to me why github is showing 4 commits for a branch that only contains 1 commit (and 1 file change), I'd appreciate. Cheers
