### PR TITLE
FIXED: Issue where route table arguments would not be accessible without using non deprecated API

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -252,13 +252,13 @@ class Director implements TemplateGlobalProvider {
 
 		foreach($rules as $pattern => $controllerOptions) {
 			if(is_string($controllerOptions)) {
-				if(substr($controllerOptions,0,2) == '->') $controllerOptions = array('Redirect' => substr($controllerOptions,2));
-				else $controllerOptions = array('Controller' => $controllerOptions);
+				if(substr($controllerOptions,0,2) == '->')
+					$controllerOptions = array('Redirect' => substr($controllerOptions,2));
+				else 
+					$controllerOptions = array('Controller' => $controllerOptions);
 			}
 
-			if(($arguments = $request->match($pattern, true)) !== false) {
-				// controllerOptions provide some default arguments
-				$arguments = array_merge($controllerOptions, $arguments);
+			if(($arguments = $request->match($pattern, true, $controllerOptions)) !== false) {
 
 				// Find the controller name
 				if(isset($arguments['Controller'])) $controller = $arguments['Controller'];

--- a/control/HTTPRequest.php
+++ b/control/HTTPRequest.php
@@ -335,8 +335,15 @@ class SS_HTTPRequest implements ArrayAccess {
 	 * 
 	 * The pattern can optionally start with an HTTP method and a space.  For example, "POST $Controller/$Action".
 	 * This is used to define a rule that only matches on a specific HTTP method.
+	 * 
+	 * @param string $pattern The URL pattern to match against
+	 * @param boolean $shiftOnSuccess
+	 * @param array $routeArguments Any additional arguments specified in the routing table entry for the 
+	 * specified pattern
+	 * @return array The resulting map of request arguments to values, as specified in the routing entry for this
+	 * pattern, as well as any evaluated URL arguments
 	 */
-	function match($pattern, $shiftOnSuccess = false) {
+	function match($pattern, $shiftOnSuccess = false, $routeArguments = array()) {
 		// Check if a specific method is required
 		if(preg_match('/^([A-Za-z]+) +(.*)$/', $pattern, $matches)) {
 			$requiredMethod = $matches[1];
@@ -348,7 +355,9 @@ class SS_HTTPRequest implements ArrayAccess {
 		
 		// Special case for the root URL controller
 		if(!$pattern) {
-			return ($this->dirParts == array()) ? array('Matched' => true) : false;
+			return ($this->dirParts == array()) 
+				? array_merge($routeArguments, array('Matched' => true)) 
+				: false;
 		}
 
 		// Check for the '//' marker that represents the "shifting point"
@@ -364,8 +373,7 @@ class SS_HTTPRequest implements ArrayAccess {
 			$shiftCount = sizeof($patternParts);
 		}
 
-		$matched = true;
-		$arguments = array();
+		$arguments = $routeArguments;
 		foreach($patternParts as $i => $part) {
 			$part = trim($part);
 


### PR DESCRIPTION
This pull request is for a "fix" for a gap in the api.

Previously any arguments specified on the routing table would be saved in Director::urlParams() and could be retrieved by the controller. For example, my routes.yml file looks like the below:

``` yml

---
Name: translatedroutes
After: framework/routes#rootroutes

---
Director:
  rules:
    'en_NZ/$URLSegment!//$Action/$ID/$OtherID':
      Controller: 'ModelAsController'
      Locale: 'en_NZ'
```

In 2.4 the "Locale" parameter would be available, but trying to access this in SS 3.0 via Director::urlParams() gives a deprecation error, noting that SS_HTTPRequest->latestParams() should be used instead. Since only arguments in the url pattern (URLSegment, Action, etc) are actually stored in the request object, this actually represents a degradation in functionality.

My fix is to ensure that during routing these additional parameters are correctly passed to the request object and stored, so that they may be retrieved via $this->request->latestParams().

Note: A previous pull request to fix this issue caused a test case (ContentControllerTest) to fail. This pull request resolves this issue.
