### PR TITLE
Fix: display correct icon in the GridFieldDetailForm's breadcrumbs

### DIFF
--- a/admin/templates/CMSBreadcrumbs.ss
+++ b/admin/templates/CMSBreadcrumbs.ss
@@ -1,22 +1,19 @@
 <div class="breadcrumbs-wrapper" data-pjax-fragment="Breadcrumbs">
-	<% loop Breadcrumbs %>
-	
-		<% if First %>
-			<% if ToplevelController %>
-				<span class="section-icon icon icon-16 icon-{$ToplevelController.MenuCurrentItem.Code.LowerCase}"></span>
-			<% else_if Controller %>
-				<span class="section-icon icon icon-16 icon-{$Controller.MenuCurrentItem.Code.LowerCase}"></span>
-			<% else %>
-				<span class="section-icon icon icon-16 icon-{$MenuCurrentItem.Code.LowerCase}"></span>
-			<% end_if %>
-		<% end_if %>
 
+	<% if ToplevelController %>
+		<span class="section-icon icon icon-16 icon-{$ToplevelController.MenuCurrentItem.Code.LowerCase}"></span>
+	<% else_if Controller %>
+		<span class="section-icon icon icon-16 icon-{$Controller.MenuCurrentItem.Code.LowerCase}"></span>
+	<% else %>
+		<span class="section-icon icon icon-16 icon-{$MenuCurrentItem.Code.LowerCase}"></span>
+	<% end_if %>
+
+	<% loop Breadcrumbs %>
 		<% if Last %>
 			<span class="cms-panel-link crumb last">$Title.XML</span>
 		<% else %>
 			<a class="cms-panel-link crumb" href="$Link">$Title.XML</a>
 			<span class="sep">/</span>
 		<% end_if %>
-
 	<% end_loop %>
 </div>


### PR DESCRIPTION
In CMSBreadcrumbs.ss the (TopLevel)Controller is not recognized within
the Breadcrumbs loop, so the class that is used in css to style the
icon cannot be created. Moving the construction outside the loop will
remedy this. As far as I can see this works within the CMS.
