### PR TITLE
FIXED: Compatibility issues with the Translatable module

### DIFF
--- a/javascript/TreeDropdownField.js
+++ b/javascript/TreeDropdownField.js
@@ -193,11 +193,13 @@
 						'data': this.getPanel().find('.tree-holder').html(),
 						'ajax': {
 							'url': function(node) {
-								return self.data('urlTree') + '/' + ($(node).data("id") ? $(node).data("id") : 0);
+								var url = $.path.parseUrl(self.data('urlTree')).hrefNoSearch;
+								return url + '/' + ($(node).data("id") ? $(node).data("id") : 0);
 							},
 							'data': function(node) {
+								var query = $.query.load(self.data('urlTree')).keys;
 								var params = self.getRequestParams();
-								params = $.extend({}, params, {ajax: 1});
+								params = $.extend({}, query, params, {ajax: 1});
 								return params;
 							}
 						}


### PR DESCRIPTION
Follow up to fb9e997

Fixes issue in the CMS when using the TreeDropddownField alongside modules (such as Translatable) that add additional querystring arguments to page urls.

This fix resolves an issue where url generation wasn't robust enough to correctly respect querystring arguments in the data-url-tree attribute of tree nodes.

E.g. Ajax requests for sub-trees would be generated in the form /admin/pages/edit/EditForm/field/LinkedPageID/tree?locale=en_NZ/21&ajax=1. This fix correctly generates urls in the correct form. E.g. /admin/pages/edit/EditForm/field/LinkedPageID/tree/21?locale=en_NZ&ajax=1
