### PR TITLE
FIX Hierarchy#liveChildren couldnt handle lots of pages

### DIFF
--- a/model/Hierarchy.php
+++ b/model/Hierarchy.php
@@ -575,22 +575,9 @@ class Hierarchy extends DataExtension {
 		if(!$showAll) $children = $children->where('"ShowInMenus" = 1');
 
 		// Query the live site
-		$children->dataQuery()->setQueryParam('Versioned.mode', 'stage');
+		$children->dataQuery()->setQueryParam('Versioned.mode', $onlyDeletedFromStage ? 'stage_unique' : 'stage');
 		$children->dataQuery()->setQueryParam('Versioned.stage', 'Live');
-		
-		if($onlyDeletedFromStage) {
-			// Note that this makes a second query, and could be optimised to be a join
-			$stageChildren = DataObject::get($baseClass)
-				->where("\"{$baseClass}\".\"ID\" != $id");
-			$stageChildren->dataQuery()->setQueryParam('Versioned.mode', 'stage');
-			$stageChildren->dataQuery()->setQueryParam('Versioned.stage', '');
-			
-			$ids = $stageChildren->column("ID");
-			if($ids) {
-				$children = $children->where("\"$baseClass\".\"ID\" NOT IN (" . implode(',',$ids) . ")");
-			}
-		}
-		
+
 		return $children;
 	}
 	


### PR DESCRIPTION
Hierarchy#liveChildren was generating a list of all IDs of all pages
on staging. When a site had lots of pages, this basically killed the
tree.

Fix by adding new versioned mode, stage_unique, which uses a
subselect to only return items from a stage that are in no
other stage.
