### PR TITLE
BUGFIX: GridField delete icon now correctly deletes, rather than always ...

### DIFF
--- a/forms/gridfield/GridFieldDeleteAction.php
+++ b/forms/gridfield/GridFieldDeleteAction.php
@@ -133,7 +133,11 @@ class GridFieldDeleteAction implements GridField_ColumnProvider, GridField_Actio
 			if($actionName == 'deleterecord' && !$item->canDelete()) {
 				throw new ValidationException(_t('GridFieldAction_Delete.DeletePermissionsFailure',"No delete permissions"),0);
 			}
-			$gridField->getList()->remove($item);
+			if($actionName == 'deleterecord') {
+				$item->delete();
+			} else {
+				$gridField->getList()->remove($item);
+			}
 		} 
 	}
 }


### PR DESCRIPTION
...just unlinking (Fixes 7801)

Fixes the handleAction function of GridFieldDeleteAction which wasn't differentiating between a 'deleterecord' action and an 'unlinkrelation' action.

Fixes http://open.silverstripe.org/ticket/7801
