### PR TITLE
API Reverse config extra statics control flow

### DIFF
--- a/core/ClassInfo.php
+++ b/core/ClassInfo.php
@@ -231,6 +231,25 @@ class ClassInfo {
 
 		return $matchedClasses;
 	}
+
+	private static $method_from_cache = array();
+
+	static function has_method_from($class, $method, $compclass) {
+		if (!isset(self::$method_from_cache[$class])) self::$method_from_cache[$class] = array();
+
+		if (!array_key_exists($method, self::$method_from_cache[$class])) {
+			self::$method_from_cache[$class][$method] = false;
+
+			$classRef = new ReflectionClass($class);
+
+			if ($classRef->hasMethod($method)) {
+				$methodRef = $classRef->getMethod($method);
+				self::$method_from_cache[$class][$method] = $methodRef->getDeclaringClass()->getName();
+			}
+		}
+
+		return self::$method_from_cache[$class][$method] == $compclass;
+	}
 	
 }
 

--- a/core/Extension.php
+++ b/core/Extension.php
@@ -46,14 +46,11 @@ abstract class Extension {
 	/**
 	 * Called when this extension is added to a particular class
 	 *
-	 * TODO: This is likely to be replaced by event sytem before 3.0 final, so be aware
-	 * this API is fairly unstable.
-	 *
 	 * @static
 	 * @param $class
 	 */
 	static function add_to_class($class, $extensionClass, $args = null) {
-		Config::add_static_source($class, $extensionClass);
+		// NOP
 	}
 
 	/**

--- a/model/DataExtension.php
+++ b/model/DataExtension.php
@@ -31,34 +31,21 @@ abstract class DataExtension extends Extension {
 		'api_access' => false,
 	);
 
-	static function add_to_class($class, $extensionClass, $args = null) {
-		if(method_exists($class, 'extraDBFields')) {
+	static function get_extra_config($class, $extension, $args) {
+		if(method_exists($extension, 'extraDBFields')) {
 			$extraStaticsMethod = 'extraDBFields';
 		} else {
 			$extraStaticsMethod = 'extraStatics';
 		}
 
-		$statics = Injector::inst()->get($extensionClass, true, $args)->$extraStaticsMethod($class, $extensionClass);
+		$statics = Injector::inst()->get($extension, true, $args)->$extraStaticsMethod();
 
 		if ($statics) {
-			Deprecation::notice('3.1.0', "$extraStaticsMethod deprecated. Just define statics on your extension, or use add_to_class", Deprecation::SCOPE_GLOBAL);
-
-			// TODO: This currently makes extraStatics the MOST IMPORTANT config layer, not the least
-			foreach (self::$extendable_statics as $key => $merge) {
-				if (isset($statics[$key])) {
-					if (!$merge) Config::inst()->remove($class, $key);
-					Config::inst()->update($class, $key, $statics[$key]);
-				}
-			}
-
-			// TODO - remove this
-			DataObject::$cache_has_own_table[$class]       = null;
-			DataObject::$cache_has_own_table_field[$class] = null;
+			Deprecation::notice('3.1.0', "$extraStaticsMethod deprecated. Just define statics on your extension, or use get_extra_config", Deprecation::SCOPE_GLOBAL);
+			return $statics;
 		}
-
-		parent::add_to_class($class, $extensionClass, $args);
 	}
-	
+
 	public static function unload_extra_statics($class, $extension) {
 		throw new Exception('unload_extra_statics gone');
 	}

--- a/model/Hierarchy.php
+++ b/model/Hierarchy.php
@@ -25,9 +25,10 @@ class Hierarchy extends DataExtension {
 	function augmentWrite(&$manipulation) {
 	}
 
-	static function add_to_class($class, $extensionClass, $args = null) {
-		Config::inst()->update($class, 'has_one', array('Parent' => $class));
-		parent::add_to_class($class, $extensionClass, $args);
+	static function get_extra_config($class, $extension, $args) {
+		return array(
+			'has_one' => array('Parent' => $class)
+		);
 	}
 
 	/**

--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -107,9 +107,10 @@ class Versioned extends DataExtension {
 		'Version' => 'Int'
 	);
 
-	static function add_to_class($class, $extensionClass, $args = null) {
-		Config::inst()->update($class, 'has_many', array('Versions' => $class));
-		parent::add_to_class($class, $extensionClass, $args);
+	static function get_extra_config($class, $extension, $args) {
+		array(
+			'has_many' => array('Versions' => $class)
+		);
 	}
 	
 	/**

--- a/search/FulltextSearchable.php
+++ b/search/FulltextSearchable.php
@@ -75,14 +75,16 @@ class FulltextSearchable extends DataExtension {
 		parent::__construct();
 	}
 
-	static function add_to_class($class, $extensionClass, $args = null) {
-		Config::inst()->update($class, 'indexes', array('SearchFields' => array(
-			'type' => 'fulltext',
-			'name' => 'SearchFields',
-			'value' => $args[0]
-		)));
-
-		parent::add_to_class($class, $extensionClass, $args);
+	static function get_extra_config($class, $extensionClass, $args) {
+		return array(
+			'indexes' => array(
+				'SearchFields' => array(
+					'type' => 'fulltext',
+					'name' => 'SearchFields',
+					'value' => $args[0]
+				)
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Config system used to provide an add_static_source method, which was intended for
use by Extensions to add statics. But extensions for a class arent initialised
until at least one instance of that class is created, so before that the
Config system didnt include values from extensions

This patch reverses the control flow, so that the Config system explictly asks
each Object for its additional config sources via the new method
get_extra_config_sources. This method returns an array that can contain
string names of classes and also raw associative arrays.

The developer visible change is that Extension#add_to_class has been
deprecated. Instead there is a new method, get_extra_config, which has
the same method signature but needs to guarantee that it doesnt
cause side effects. Additionally there is no need to call
parent::get_extra_config - this is handled automatically.
