### PR TITLE
Allow scheme-relative URLs in requirements

### DIFF
--- a/tests/forms/RequirementsTest.php
+++ b/tests/forms/RequirementsTest.php
@@ -18,8 +18,10 @@ class RequirementsTest extends SapphireTest {
 
 		$backend->javascript('http://www.mydomain.com/test.js');
 		$backend->javascript('https://www.mysecuredomain.com/test.js');
+		$backend->javascript('//scheme-relative.example.com/test.js');
 		$backend->css('http://www.mydomain.com/test.css');
 		$backend->css('https://www.mysecuredomain.com/test.css');
+		$backend->css('//scheme-relative.example.com/test.css');
 		
 		$html = $backend->includeInHTML(false, self::$html_template);
 		
@@ -32,12 +34,20 @@ class RequirementsTest extends SapphireTest {
 			'Load external secure javascript URL'
 		);
 		$this->assertTrue(
+			(strpos($html, '//scheme-relative.example.com/test.js') !== false), 
+			'Load external scheme-relative javascript URL'
+		);
+		$this->assertTrue(
 			(strpos($html, 'http://www.mydomain.com/test.css') !== false), 
 			'Load external CSS URL'
 		);
 		$this->assertTrue(
 			(strpos($html, 'https://www.mysecuredomain.com/test.css') !== false), 
 			'Load external secure CSS URL'
+		);
+		$this->assertTrue(
+			(strpos($html, '//scheme-relative.example.com/test.css') !== false), 
+			'Load scheme-relative CSS URL'
 		);
 	}
 

--- a/view/Requirements.php
+++ b/view/Requirements.php
@@ -784,7 +784,7 @@ class Requirements_Backend {
 	 * @return string|boolean 
 	 */
 	protected function path_for_file($fileOrUrl) {
-		if(preg_match('/^http[s]?/', $fileOrUrl)) {
+		if(preg_match('{^//|http[s]?}', $fileOrUrl)) {
 			return $fileOrUrl;
 		} elseif(Director::fileExists($fileOrUrl)) {
 			$prefix = Director::baseURL();


### PR DESCRIPTION
The Requirements class currently treats only absolute URLs as URLs, and
tries to interpret anything else as a filesystem path. This prevents
using scheme-relative URLs for requirements.

Example:
<% require javascript(//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js) %>

This forces the unfortunate choice of not using a CDN for common
scripts, always using an https absolute URL, or accepting that some
browsers will throw a security warning when viewing the site in https.

This change allows scheme-relative URLs & updates RequirementsTest.
