### PR TITLE
FIX Use array_intersect() with expected values so that the order matches

### DIFF
--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -863,7 +863,7 @@ class DataObjectTest extends SapphireTest {
 		// Check that the values of those fields are properly read from the database
 		$values = DataObject::get("DataObjectTest_Team", "\"DataObjectTest_Team\".\"ID\" IN 
 			($obj1->ID, $obj2->ID)")->column("SubclassDatabaseField");
-		$this->assertEquals(array('obj1', 'obj2'), $values);
+		$this->assertEquals(array_intersect($values, array('obj1', 'obj2')), $values);
 	}
 	
 	function testClassNameSetForNewObjects() {


### PR DESCRIPTION
The values in $values aren't returned in any order, so this test can randomly fail. This
changes the check from expected = $values to $values \cap expected = $value. PHP's array_intersect
maintains the keys of the first array, so order is preserved. The intersect also guarentees that the
only accepted values are the expected ones.
