### PR TITLE
FIX issue with cyclic configs when framework called sapphire

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -9,8 +9,8 @@ Director:
 Name: coreroutes
 Before: '*'
 After:
-  - framework/routes#rootroutes
-  - cms/routes#modelascontrollerroutes
+  - '#rootroutes'
+  - '#modelascontrollerroutes'
 ---
 Director:
   rules:
@@ -25,9 +25,9 @@ Director:
 Name: adminroutes
 Before: '*'
 After:
-  - framework/routes#rootroutes
-  - framework/routes#coreroutes
-  - cms/routes#modelascontrollerroutes
+  - '#rootroutes'
+  - '#coreroutes'
+  - '#modelascontrollerroutes'
 ---
 Director:
   rules:

--- a/core/manifest/ConfigManifest.php
+++ b/core/manifest/ConfigManifest.php
@@ -223,11 +223,12 @@ class SS_ConfigManifest {
 						// For each, parse out into module/file#name, and set any missing to "*"
 						$header[$order] = array();
 						foreach($orderparts as $part) {
-							preg_match('! (\*|\w+) (?:\/(\*|\w+) (?:\*|\#(\w+))? )? !x', $part, $match);
+							preg_match('! (?P<module>\*|\w+)? (\/ (?P<file>\*|\w+))? (\# (?P<fragment>\*|\w+))? !x', $part, $match);
+
 							$header[$order][] = array(
-								'module' => $match[1],
-								'file' => isset($match[2]) ? $match[2] : '*',
-								'name' => isset($match[3]) ? $match[3] : '*'
+								'module' => isset($match['module']) && $match['module'] ? $match['module'] : '*',
+								'file' => isset($match['file']) && $match['file'] ? $match['file'] : '*',
+								'name' => isset($match['fragment'])  && $match['fragment'] ? $match['fragment'] : '*'
 							);
 						}
 					}


### PR DESCRIPTION
The _config/route rules explicitly mentioned framework by module name,
so if you installed framework in the older sapphire directory youd
always end up with cyclic config requirement errors
