### PR TITLE
FIX: ensure date input has a date picker to trigger open (#7504).

### DIFF
--- a/javascript/DateField.js
+++ b/javascript/DateField.js
@@ -28,6 +28,9 @@
 
 	$('.field.date input.text').live('click', function() {
 		$(this).ssDatepicker();
-		$(this).datepicker('show');
+
+		if($(this).data('datepicker')) {
+			$(this).datepicker('show');
+		}
 	});
 }(jQuery));


### PR DESCRIPTION
$.fn. ssDatepicker() can skip applying the datepicker configuration to the input, if so in that case, don't trigger the date picker.
