### PR TITLE
BUG Fix wrong date conversion from PHP format 'y' to jquery date and back

### DIFF
--- a/forms/DateField.php
+++ b/forms/DateField.php
@@ -591,7 +591,7 @@ class DateField_View_JQuery extends Object {
 		  '/l/' => '',
 		  '/YYYY/' => 'yy',
 		  '/yyyy/' => 'yy',
-		  '/[^y]yy[^y]/' => 'y',
+		  '/y{1,3}/' => 'yy',
 		  '/a/' => '',
 		  '/B/' => '',
 		  '/hh/' => '',


### PR DESCRIPTION
While 'y' in PHP means 4 digits year (e.g. 2012), jquery date picker means 2 digits (e.g. 12). That's all fine until then but when you pass the 2 digit year value back to PHP it all goes awry.
For exmple, defatult date format in en_US is 'MMM d, y' so in jquery date picker it's something like this 'Aug 22, 12' and eventually PHP will convert that value to '0012-08-22' which completely wrong.
