### PR TITLE
FIX 7832 Lang files for ss macron plugin - correct path to "langs", not "lang"

### DIFF
--- a/thirdparty/tinymce_ssmacron/editor_plugin_src.js
+++ b/thirdparty/tinymce_ssmacron/editor_plugin_src.js
@@ -40,7 +40,7 @@
 	
 			// Register buttons
 			ed.addButton('ssmacron', {
-				title : t.editor.translate('insertmacron'),
+				title : ed.getLang('tinymce_ssmacron.insertmacron'),
 				cmd : 'mceInsertMacron',
 				image : url + '/img/macron.png'
 			});

--- a/thirdparty/tinymce_ssmacron/lang/en.js
+++ b/thirdparty/tinymce_ssmacron/lang/en.js
@@ -1,1 +1,0 @@
-tinyMCE.addI18n('en.ssmacron',{'insertmacron': 'Insert a Macron'});

--- a/thirdparty/tinymce_ssmacron/lang/mi_NZ.js
+++ b/thirdparty/tinymce_ssmacron/lang/mi_NZ.js
@@ -1,1 +1,0 @@
-tinyMCE.addI18n('mi_NZ.ssmacron',{'insertmacron': 'T\u0101urua he tohut\u014D'});

--- a/thirdparty/tinymce_ssmacron/langs/en.js
+++ b/thirdparty/tinymce_ssmacron/langs/en.js
@@ -1,0 +1,3 @@
+tinyMCE.addI18n('en.tinymce_ssmacron', {
+	insertmacron: 'Insert a macron'
+});

--- a/thirdparty/tinymce_ssmacron/langs/mi_NZ.js
+++ b/thirdparty/tinymce_ssmacron/langs/mi_NZ.js
@@ -1,0 +1,3 @@
+tinyMCE.addI18n('mi_NZ.tinymce_ssmacron', {
+	insertmacron: 'T\u0101urua he tohut\u014D'
+});


### PR DESCRIPTION
MINOR Consistently use ed.getLang method
