### PR TITLE
BBUGFIX: jQueryUI configs broken because keys were all lowercase

### DIFF
--- a/forms/DateField.php
+++ b/forms/DateField.php
@@ -141,10 +141,12 @@ class DateField extends TextField {
 
 		// Add other jQuery UI specific, namespaced options (only serializable, no callbacks etc.)
 		// TODO Move to DateField_View_jQuery once we have a properly extensible HTML5 attribute system for FormField
+		$jqueryUIConfig = array();
 		foreach($this->getConfig() as $k => $v) {
-			if(preg_match('/^jQueryUI\.(.*)/', $k, $matches)) $config[$matches[1]] = $v;
+			if(preg_match('/^jQueryUI\.(.*)/', $k, $matches)) $jqueryUIConfig[$matches[1]] = $v;
 		}
-		
+		if ($jqueryUIConfig)
+			$config['jqueryuiconfig'] =  Convert::array2json(array_filter($jqueryUIConfig));
 		$config = array_filter($config);
 		foreach($config as $k => $v) $this->setAttribute('data-' . $k, $v);
 		

--- a/javascript/DateField.js
+++ b/javascript/DateField.js
@@ -8,7 +8,7 @@
 				$(this).siblings("button").addClass("ui-icon ui-icon-calendar");
 				
 				var holder = $(this).parents('.field.date:first'), 
-					config = $.extend(opts || {}, $(this).data(), {});
+					config = $.extend(opts || {}, $(this).data(), $(this).data('jqueryuiconfig'), {});
 				if(!config.showcalendar) return;
 	
 				if(config.locale && $.datepicker.regional[config.locale]) {


### PR DESCRIPTION
Text taken from: http://open.silverstripe.org/ticket/7834

The current version of DateField? now lets you set jQueryUI configs for the datepicker (in a hacky way, but at least it finally does).

When using $dateField->setConfig('jQueryUI.changeMonth', 'true'); this actually gets set, and is even picked up on javascript side.

Problem is, jQuery.data() returns all keys lower case, which turns {changeMonth: true} to {changemonth: true} But jQueryUI takes the config case sensetive

hmmm, I am not sure if its jquery or the browser, but eihter way, on JS end it comes up lowercase 
