### PR TITLE
BUG Calling extraStatics() with args (regression from fa37c448)

### DIFF
--- a/model/DataExtension.php
+++ b/model/DataExtension.php
@@ -38,7 +38,7 @@ abstract class DataExtension extends Extension {
 			$extraStaticsMethod = 'extraStatics';
 		}
 
-		$statics = Injector::inst()->get($extension, true, $args)->$extraStaticsMethod();
+		$statics = Injector::inst()->get($extension, true, $args)->$extraStaticsMethod($class, $extension);
 
 		if ($statics) {
 			Deprecation::notice('3.1.0', "$extraStaticsMethod deprecated. Just define statics on your extension, or use get_extra_config", Deprecation::SCOPE_GLOBAL);


### PR DESCRIPTION
I've noticed this because the comments module stopped working (since it uses those args).
Even if we're deprecating extraStatics() for 3.1, presumably fa37c448 was supposed to be an internal refactoring (= no API changes), correct?
