### PR TITLE
FIXED: Issue where messages attached to checkbox fields would not be displayed

### DIFF
--- a/templates/forms/CheckboxField_holder.ss
+++ b/templates/forms/CheckboxField_holder.ss
@@ -1,5 +1,5 @@
 <div id="$Name" class="field<% if extraClass %> $extraClass<% end_if %>">
 	$Field
 	<label class="right" for="$ID">$Title</label>
-	<% if Message %><span class="message $MessageType">$messageBlock</span><% end_if %>
+	<% if Message %><span class="message $MessageType">$Message</span><% end_if %>
 </div>


### PR DESCRIPTION
I'm not sure what the old template was referencing, but any checkbox with an error would attempt to use $messageBlock as the error message instead of $Message. This would always come up with a blank error message instead of the correct one.

I couldn't find any reference to this in the code, so I replaced it. Voila!
