### PR TITLE
BUG Fixes an issue where batch actions dropdown doesn't show up after ajax request back to the cms Pages section

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -33,7 +33,11 @@ jQuery.noConflict();
 					el.siblings('.chzn-container').prop('title', title);
 				}
 			} else {
-				setTimeout(function() { applyChosen(el); }, 500);
+				setTimeout(function() {
+					// Make sure it's visible before applying the ui
+					el.show();
+					applyChosen(el); }, 
+				500);
 			}
 		};
 


### PR DESCRIPTION
Steps to produce:
1. Log in the CMS 
2. Click any page, for example "Home" page 
3. Now you go back to the Pages section by "Pages" button on the left-hand side menu
4. The batch dropdown field doesn't show up

Screenshot: http://www.evernote.com/shard/s3/sh/ef1b9be6-be28-4e35-932e-42440d211720/35fa69c8684b2635d2270635eb0128bd
