### PR TITLE
NEW 7838 Support for document as a category in File class

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -138,6 +138,9 @@ class File extends DataObject {
 		),
 		'flash' => array(
 			'swf', 'fla'
+		),
+		'doc' => array(
+			'doc','docx','txt','rtf','xls','xlsx','pages', 'ppt','pptx','pps','csv', 'html','htm','xhtml', 'xml','pdf'
 		)
 	);
 


### PR DESCRIPTION
Support for the following extensions : 'doc','docx','txt','rtf','xls','xlsx','pages', 'ppt','pptx','pps','csv', 'html','htm','xhtml', 'xml','pdf', in a new category called 'doc'
