### PR TITLE
fixing strict notice by declaring static method Email::is_valid_address() as static

### DIFF
--- a/email/Email.php
+++ b/email/Email.php
@@ -556,7 +556,7 @@ class Email extends ViewableData {
 	 * 	This code is licensed under a Creative Commons Attribution-ShareAlike 2.5 License 
 	 * 	http://creativecommons.org/licenses/by-sa/2.5/
 	 */
-	function is_valid_address($email){
+	public static function is_valid_address($email){
 		$qtext = '[^\\x0d\\x22\\x5c\\x80-\\xff]';
 		$dtext = '[^\\x0d\\x5b-\\x5d\\x80-\\xff]';
 		$atom = '[^\\x00-\\x20\\x22\\x28\\x29\\x2c\\x2e\\x3a-\\x3c'.


### PR DESCRIPTION
("Non-static method Email::is_valid_address() should not be called statically, assuming $this from incompatible context")
