### PR TITLE
FIX 7853 

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -457,7 +457,8 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 				/* NOP */
 			},
 			resetFields: function() {
-				/* NOP */
+				// Flush the tree drop down fields, as their content might get changed in other parts of the CMS, ie in Files and images
+				this.find('.tree-holder').empty();
 			}
 		});
 


### PR DESCRIPTION
Flush the content of drop down fields when closing html editor linker (links and images), so a reload of their content next time they are used will display the current state of the assets
