### PR TITLE
FIX 7862

### DIFF
--- a/javascript/TreeDropdownField.js
+++ b/javascript/TreeDropdownField.js
@@ -161,7 +161,7 @@
 							.jstree(self.getTreeConfig())
 							.bind('select_node.jstree', function(e, data) {
 								var node = data.rslt.obj, id = $(node).data('id');
-								if(!firstLoad && !self.getValue() == id) {
+								if(!firstLoad && !self.getValue() === id) {
 									// Value is already selected, unselect it (for lack of a better UI to do this)
 									self.data('metadata', null);
 									self.setTitle(null);


### PR DESCRIPTION
Strict equality check on previously selected item in the TreeDropdownField. If an item has an ID of 1, checking using '==' as opposed to '===' results in a false positive (because 1is seen as a boolean value set to true, instead of being seen as an integer) that prevents users to select this item, as this item is seen as previously selected already, but it's not the case.
