### PR TITLE
Bug:ListBoxField and DropdownField does not respect getSource in all Places

### DIFF
--- a/forms/DropdownField.php
+++ b/forms/DropdownField.php
@@ -236,7 +236,7 @@ class DropdownField extends FormField {
 	}
 
 	function performReadonlyTransformation() {
-		$field = new LookupField($this->name, $this->title, $this->source);
+		$field = new LookupField($this->name, $this->title, $this->getSource());
 		$field->setValue($this->value);
 		$field->setForm($this->form);
 		$field->setReadonly(true);

--- a/forms/ListboxField.php
+++ b/forms/ListboxField.php
@@ -224,7 +224,7 @@ class ListboxField extends DropdownField {
 				// They're silently ignored and overwritten the next time the field is saved.
 				parent::setValue($parts);
 			} else {
-				if(!in_array($val, array_keys($this->source))) {
+				if(!in_array($val, array_keys($this->getSource()))) {
 					throw new InvalidArgumentException(sprintf(
 						'Invalid value "%s" for multiple=false', 
 						Convert::raw2xml($val)


### PR DESCRIPTION
In some places source is referenced directly and assumed to be array, while in some places the getSource() method is used instead.
By changing this you have more freedom when extending these classes
