### PR TITLE
BUGFIX Fix to prevent unintended results from getComponentsQuery(...)

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1359,7 +1359,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 			
 		// get filter
 		$combinedFilter = "\"$joinField\" = '$id'";
-		if($filter) $combinedFilter .= " AND {$filter}";
+		if(!empty($filter)) $combinedFilter .= " AND ({$filter})";
 			
 		return singleton($componentClass)->extendedSQL($combinedFilter, $sort, $limit, $join);
 	}


### PR DESCRIPTION
Wrapped $filter inside parentheses to prevent unintended results if $filter contains "OR".
