### PR TITLE
Have tiny_mce_gzip.php use local silverstripe-cache folder if available

### DIFF
--- a/core/TempPath.php
+++ b/core/TempPath.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Returns the temporary folder path that silverstripe should use for its cache files.
+ *
+ * @param $base The base path to use for determining the temporary path
+ * @return string Path to temp
+ */
+function getTempFolder($base = null) {
+	if(!$base && defined('BASE_PATH')) $base = BASE_PATH;
+
+	$tempPath = '';
+	$worked = true;
+
+	// first, try finding a silverstripe-cache dir built off the base path
+	$tempPath = $base . '/silverstripe-cache';
+	if(@file_exists($tempPath)) {
+		return $tempPath;
+	}
+
+	// failing the above, try finding a namespaced silverstripe-cache dir in the system temp
+	$cacheFolder = '/silverstripe-cache' . str_replace(array(' ', '/', ':', '\\'), '-', $base);
+	$tempPath = sys_get_temp_dir() . $cacheFolder;
+	if(!@file_exists($tempPath)) {
+		$worked = @mkdir($tempPath);
+	}
+
+	// failing to use the system path, attempt to create a local silverstripe-cache dir
+	if(!$worked) {
+		$worked = true;
+		$tempPath = $base . '/silverstripe-cache';
+		if(!@file_exists($tempPath)) {
+			$worked = @mkdir($tempPath);
+		}
+	}
+
+	if(!$worked) {
+		throw new Exception(
+			'Permission problem gaining access to a temp folder. ' .
+			'Please create a folder named silverstripe-cache in the base folder ' .
+			'of the installation and ensure it has the correct permissions'
+		);
+	}
+
+	return $tempPath;
+}
+

--- a/tests/core/CoreTest.php
+++ b/tests/core/CoreTest.php
@@ -17,7 +17,7 @@ class CoreTest extends SapphireTest {
 
 	public function testGetTempPathInProject() {
 		if(file_exists($this->tempPath)) {
-			$this->assertEquals(getTempFolder(), $this->tempPath);
+			$this->assertEquals(getTempFolder(BASE_PATH), $this->tempPath);
 		} else {
 			// A typical Windows location for where sites are stored on IIS
 			$this->assertEquals(getTempFolder('C:\\inetpub\\wwwroot\\silverstripe-test-project'), sys_get_temp_dir() . '/silverstripe-cacheC--inetpub-wwwroot-silverstripe-test-project');

--- a/thirdparty/tinymce/tiny_mce_gzip.php
+++ b/thirdparty/tinymce/tiny_mce_gzip.php
@@ -9,12 +9,17 @@
  * Contributing: http://tinymce.moxiecode.com/contributing
  */
 
+$frameworkPath = rtrim(dirname(dirname(dirname(__FILE__))), DIRECTORY_SEPARATOR);
+$basePath = rtrim(dirname($frameworkPath), DIRECTORY_SEPARATOR);
+
+require_once $frameworkPath . '/core/TempPath.php';
+
 // Handle incoming request if it's a script call
 if (TinyMCE_Compressor::getParam("js")) {
 	// Default settings
 	$tinyMCECompressor = new TinyMCE_Compressor(array(
 		// CUSTOM SilverStripe
-		'cache_dir' => sys_get_temp_dir()
+		'cache_dir' => getTempFolder($basePath)
 		// CUSTOM END
 	));
 


### PR DESCRIPTION
This is a fix for ticket #7670 - http://open.silverstripe.org/ticket/7670.

Some hosting situations don't allow write access to the system temp path. tiny_mce_gzip.php is currently using sys_get_temp_dir() by default, and not using a local silverstripe-cache folder that may exist in the SilverStripe project.

This change moves the getTempFolder() function into a common file, and includes that in core/Core.php, as well as thirdparty/tinymce/tiny_mce_gzip.php so both locations share the same code to work out the temp path.

Not sure about the naming of the TempPath.php file, if anyone has any recommendations or alternative approaches, please comment.
