### PR TITLE
Removed SiteTree.MetaTitle and MetaKeywords usage

### DIFF
--- a/docs/en/changelogs/3.1.0.md
+++ b/docs/en/changelogs/3.1.0.md
@@ -4,6 +4,7 @@
 
 ## Upgrading
 
+ * Removed `SiteTree.MetaTitle` and `SiteTree.MetaKeywords` since they are irrelevant in terms of SEO ([1](http://www.seomoz.org/learn-seo/title-tag), [2](http://www.mattcutts.com/blog/keywords-meta-tag-in-web-search/)) and general page informancy
  * Deprecated `Profiler` class, use third-party solutions like [xhprof](https://github.com/facebook/xhprof/)
  * Removed defunct or unnecessary debug GET parameters: 
    `debug_profile`, `debug_memory`, `profile_trace`, `debug_javascript`, `debug_behaviour`

--- a/model/MySQLDatabase.php
+++ b/model/MySQLDatabase.php
@@ -825,15 +825,15 @@ class MySQLDatabase extends SS_Database {
 		$notMatch = $invertedMatch ? "NOT " : "";
 		if($keywords) {
 			$match['SiteTree'] = "
-				MATCH (Title, MenuTitle, Content, MetaTitle, MetaDescription, MetaKeywords) AGAINST ('$keywords' $boolean)
-				+ MATCH (Title, MenuTitle, Content, MetaTitle, MetaDescription, MetaKeywords) AGAINST ('$htmlEntityKeywords' $boolean)
+				MATCH (Title, MenuTitle, Content, MetaDescription) AGAINST ('$keywords' $boolean)
+				+ MATCH (Title, MenuTitle, Content, MetaDescription) AGAINST ('$htmlEntityKeywords' $boolean)
 			";
 			$match['File'] = "MATCH (Filename, Title, Content) AGAINST ('$keywords' $boolean) AND ClassName = 'File'";
 
 			// We make the relevance search by converting a boolean mode search into a normal one
 			$relevanceKeywords = str_replace(array('*','+','-'),'',$keywords);
 			$htmlEntityRelevanceKeywords = str_replace(array('*','+','-'),'',$htmlEntityKeywords);
-			$relevance['SiteTree'] = "MATCH (Title, MenuTitle, Content, MetaTitle, MetaDescription, MetaKeywords) AGAINST ('$relevanceKeywords') + MATCH (Title, MenuTitle, Content, MetaTitle, MetaDescription, MetaKeywords) AGAINST ('$htmlEntityRelevanceKeywords')";
+			$relevance['SiteTree'] = "MATCH (Title, MenuTitle, Content, MetaDescription) AGAINST ('$relevanceKeywords') + MATCH (Title, MenuTitle, Content, MetaDescription) AGAINST ('$htmlEntityRelevanceKeywords')";
 			$relevance['File'] = "MATCH (Filename, Title, Content) AGAINST ('$relevanceKeywords')";
 		} else {
 			$relevance['SiteTree'] = $relevance['File'] = 1;

--- a/search/FulltextSearchable.php
+++ b/search/FulltextSearchable.php
@@ -43,7 +43,7 @@ class FulltextSearchable extends DataExtension {
 	 */
 	public static function enable($searchableClasses = array('SiteTree', 'File')) {
 		$defaultColumns = array(
-			'SiteTree' => '"Title","MenuTitle","Content","MetaTitle","MetaDescription","MetaKeywords"',
+			'SiteTree' => '"Title","MenuTitle","Content","MetaDescription"',
 			'File' => '"Filename","Title","Content"'
 		);
 


### PR DESCRIPTION
Followup to https://github.com/silverstripe/sapphire/pull/805/ and https://github.com/silverstripe/silverstripe-cms/pull/205/

See related CMS request: https://github.com/silverstripe/silverstripe-cms/pull/210
