### PR TITLE
added CroppedImage

### DIFF
--- a/docs/en/reference/image.md
+++ b/docs/en/reference/image.md
@@ -96,6 +96,7 @@ For output of an image tag with the image automatically resized to 80px width, y
 	$Image.SetHeight(80) // returns a image 80px tall, ration kept the same
 	$Image.SetSize(80,80) // returns a 80x80px padded image
 	$Image.SetRatioSize(80,80) // Returns an image scaled proportional, with its greatest diameter scaled to 80px
+	$Image.CroppedImage(80,80) // Returns an 80x80 image cropped from the center.
 	$Image.PaddedImage(80, 80) // Returns an 80x80 image. Unused space is padded white. No crop. No stretching
 	$Image.Width // returns width of image
 	$Image.Height // returns height of image


### PR DESCRIPTION
The `CroppedImage` method was not listed even though it works in the templates (just tested on 3.0.2)
