### PR TITLE
FIXED: Minor adjustment to order of file fulltext search fields.

### DIFF
--- a/search/FulltextSearchable.php
+++ b/search/FulltextSearchable.php
@@ -44,7 +44,7 @@ class FulltextSearchable extends DataExtension {
 	public static function enable($searchableClasses = array('SiteTree', 'File')) {
 		$defaultColumns = array(
 			'SiteTree' => '"Title","MenuTitle","Content","MetaTitle","MetaDescription","MetaKeywords"',
-			'File' => '"Filename","Title","Content"'
+			'File' => '"Title","Filename","Content"'
 		);
 
 		if(!is_array($searchableClasses)) $searchableClasses = array($searchableClasses);


### PR DESCRIPTION
By matching the order of these index columns to the same as the fields on the table itself, this will prevent the unnecessary regeneration of fulltext indexes on some database connectors each dev/build, notably MS SQL Server.
