### PR TITLE
FIXED: Issue with duplicate help tips appearing on select fields in CMS

### DIFF
--- a/admin/javascript/LeftAndMain.FieldHelp.js
+++ b/admin/javascript/LeftAndMain.FieldHelp.js
@@ -6,15 +6,17 @@
 		 */
 		$(".cms form .field .middleColumn > [title]").entwine({
 			onmatch: function() {
+				
 				var title = this.prop("title");
+				var field = this.closest(".field");
 
-				if(title && title.length) {
+				if(title && title.length && field.has('.help').length == 0) {
 					var span = $("<span></span>", {
 						"class": "help",
 						"text":  title
 					});
 
-					this.closest(".field").append(span);
+					field.append(span);
 					this.removeProp("title");
 				}
 


### PR DESCRIPTION
This pull request fixes description fields appearing duplicated on some form fields.

This can be seen currently on the Security / Edit Group form.
