### PR TITLE
Utilises name_to_label to make pretty unlabeled form fields

### DIFF
--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -125,7 +125,7 @@ class FormField extends RequestHandler {
 	 */
 	public function __construct($name, $title = null, $value = null) {
 		$this->name = $name;
-		$this->title = ($title === null) ? $name : $title;
+		$this->title = ($title === null) ? $this->name_to_label($name) : $title;
 
 		if($value !== NULL) $this->setValue($value);
 

--- a/tests/forms/FormTest.php
+++ b/tests/forms/FormTest.php
@@ -211,7 +211,7 @@ class FormTest extends FunctionalTest {
 		$this->assertPartialMatchBySelector(
 			'#SomeRequiredField span.required',
 			array(
-				'"SomeRequiredField" is required'
+				'"Some Required Field" is required'
 			),
 			'Required fields show a notification on field when left blank'
 		);


### PR DESCRIPTION
Not sure if it effects performance or not but as the
name_to_label function exists then it may as well be used
