### PR TITLE
BUG Fixed possible reference to null string

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -945,8 +945,8 @@ jQuery.noConflict();
 			 */
 			rewriteHashlinks: function() {
 				$(this).find('ul a').each(function() {
-					var href = $(this).attr('href').replace(/.*(#.*)/, '$1');
-					if(href) $(this).attr('href', href);
+					var href = $(this).attr('href');
+					if(href) $(this).attr('href', href.replace(/.*(#.*)/, '$1'));
 				});
 			}
 		});


### PR DESCRIPTION
rewriteHashlink for tabs in the backend didn't check the existence of
the href value before trying to .replace it.
