### PR TITLE
API Fixing id attribute on FieldHolder form templates

### DIFF
--- a/css/Security_login.css
+++ b/css/Security_login.css
@@ -1,8 +1,6 @@
-#Remember { margin: 0.5em 0 0.5em 11em !important; }
-
-p#Remember label { display: inline-block; margin: 0; }
-
-#Remember input { float: left; margin: 0 5px 0 0; }
+#MemberLoginForm_LoginForm_Remember_holder { margin: 0.5em 0 0.5em 11em !important; }
+#MemberLoginForm_LoginForm_Remember_holder label { display: inline-block; margin: 0; }
+#MemberLoginForm_LoginForm_Remember_holder input { float: left; margin: 0 5px 0 0; }
 
 #MemberLoginForm_LoginForm .Actions { padding-left: 12em; }
 

--- a/docs/en/changelogs/3.1.0.md
+++ b/docs/en/changelogs/3.1.0.md
@@ -4,6 +4,7 @@
 
 ## Upgrading
 
+ * FieldHolder templates now use $ID appended with "_holder" for the id attribute instead of $Name. Please check any custom JS/CSS selectors and update as necessary
  * Removed `SiteTree.MetaTitle` and `SiteTree.MetaKeywords` since they are irrelevant in terms of SEO ([1](http://www.seomoz.org/learn-seo/title-tag), [2](http://www.mattcutts.com/blog/keywords-meta-tag-in-web-search/)) and general page informancy
  * Deprecated `Profiler` class, use third-party solutions like [xhprof](https://github.com/facebook/xhprof/)
  * Removed defunct or unnecessary debug GET parameters: 

--- a/scss/Security_login.scss
+++ b/scss/Security_login.scss
@@ -1,14 +1,14 @@
-#Remember {
+#MemberLoginForm_LoginForm_Remember_holder {
 	margin: 0.5em 0 0.5em 11em !important;
-}
-	p#Remember label {
+	label {
 		display: inline-block;
 		margin: 0;
 	}
-	#Remember input {
+	input {
 		float: left;
 		margin: 0 5px 0 0;
 	}
+}
 #MemberLoginForm_LoginForm .Actions {
 	padding-left: 12em;
 }

--- a/templates/RightLabelledFieldHolder.ss
+++ b/templates/RightLabelledFieldHolder.ss
@@ -1,5 +1,5 @@
-<p id="$Name" class="field $Type">
+<p id="{$ID}_holder" class="field $Type">
 	$Field
-	<label class="right" for="$id">$Title</label>
+	<label class="right" for="$ID">$Title</label>
 	<% if Message %><span class="message $MessageType">$Message</span><% end_if %>
 </p>

--- a/templates/forms/CheckboxField_holder.ss
+++ b/templates/forms/CheckboxField_holder.ss
@@ -1,4 +1,4 @@
-<div id="$Name" class="field<% if extraClass %> $extraClass<% end_if %>">
+<div id="{$ID}_holder" class="field<% if extraClass %> $extraClass<% end_if %>">
 	$Field
 	<label class="right" for="$ID">$Title</label>
 	<% if Message %><span class="message $MessageType">$Message</span><% end_if %>

--- a/templates/forms/FieldGroup_DefaultFieldHolder.ss
+++ b/templates/forms/FieldGroup_DefaultFieldHolder.ss
@@ -1,4 +1,4 @@
-<div class="<% if extraClass %>$extraClass<% else %>fieldgroup<% end_if %><% if Zebra %> fieldgroup-zebra<% end_if %>" <% if ID %>id="$ID"<% end_if %>>
+<div<% if ID %> id="{$ID}_holder"<% end_if %> class="<% if extraClass %>$extraClass<% else %>fieldgroup<% end_if %><% if Zebra %> fieldgroup-zebra<% end_if %>">
 	<% loop FieldList %>
 		<div class="fieldgroup-field $FirstLast $EvenOdd">
 			$FieldHolder

--- a/templates/forms/FieldGroup_holder.ss
+++ b/templates/forms/FieldGroup_holder.ss
@@ -1,4 +1,4 @@
-<div <% if Name %>id="$Name"<% end_if %> class="field $Type $extraClass">
+<div<% if ID %> id="{$ID}_holder"<% end_if %> class="field $Type $extraClass">
 	<% if Title %><label class="left">$Title</label><% end_if %>
 	
 	<div class="middleColumn fieldgroup <% if Zebra %>fieldgroup-$Zebra<% end_if %>">

--- a/templates/forms/FormField_holder.ss
+++ b/templates/forms/FormField_holder.ss
@@ -1,4 +1,4 @@
-<div id="$Name" class="field<% if extraClass %> $extraClass<% end_if %>">
+<div id="{$ID}_holder" class="field<% if extraClass %> $extraClass<% end_if %>">
 	<% if Title %><label class="left" for="$ID">$Title</label><% end_if %>
 	<div class="middleColumn">
 		$Field

--- a/tests/forms/FormTest.php
+++ b/tests/forms/FormTest.php
@@ -202,20 +202,19 @@ class FormTest extends FunctionalTest {
 			)
 		);
 		$this->assertPartialMatchBySelector(
-			'#Email span.message',
+			'#Form_Form_Email_holder span.message',
 			array(
 				'Please enter an email address'
 			),
 			'Formfield validation shows note on field if invalid'
 		);
 		$this->assertPartialMatchBySelector(
-			'#SomeRequiredField span.required',
+			'#Form_Form_SomeRequiredField_holder span.required',
 			array(
 				'"Some Required Field" is required'
 			),
 			'Required fields show a notification on field when left blank'
 		);
-		
 	}
 	
 	public function testSessionSuccessMessage() {

--- a/tests/forms/uploadfield/UploadFieldTest.php
+++ b/tests/forms/uploadfield/UploadFieldTest.php
@@ -325,7 +325,7 @@
 		$this->assertFalse($response->isError());
 
 		$parser = new CSSContentParser($response->getBody());
-		$items = $parser->getBySelector('#ManyManyFiles .ss-uploadfield-files .ss-uploadfield-item');
+		$items = $parser->getBySelector('#Form_Form_ManyManyFiles_holder .ss-uploadfield-files .ss-uploadfield-item');
 		$ids = array();
 		foreach($items as $item) $ids[] = (int)$item['data-fileid'];
 		


### PR DESCRIPTION
Raised here: http://open.silverstripe.org/ticket/7868

Previously the id attribute was set to $Name, but this does not
clean up the value to satisfy HTML validation for an id attribute.
Additionally, the holder id would conflict with the field input id.

This fixes the FieldHolder templates to use "{$ID}_holder" for the
id attribute, which is namespaced to the form ID to avoid conflicts,
and any characters not allowed in the attribute are removed.

I've checked the core JavaScript and CSS, most of it is using classes
for selection, with a few exceptions that I found and fixed.

Because this is a big change, I've amended the upgrade notes for 3.1.0.
