### PR TITLE
API: Added 'onBeforeHTTPError' and 'onBeforeHTTPError<code>' extension p...

### DIFF
--- a/control/RequestHandler.php
+++ b/control/RequestHandler.php
@@ -332,12 +332,14 @@ class RequestHandler extends ViewableData {
 	 * @uses SS_HTTPResponse_Exception
 	 */
 	public function httpError($errorCode, $errorMessage = null) {
-		$e = new SS_HTTPResponse_Exception($errorMessage, $errorCode);
+		// Call a handler method such as onBeforeHTTPError404
+		$this->extend('onBeforeHTTPError' . $errorCode, $this->request);
 
-		// Error responses should always be considered plaintext, for security reasons
-		$e->getResponse()->addHeader('Content-Type', 'text/plain');
+		// Call a handler method such as onBeforeHTTPError, passing 404 as the first arg
+		$this->extend('onBeforeHTTPError', $errorCode, $this->request);
 
-		throw $e;
+		// Throw a new exception
+		throw new SS_HTTPResponse_Exception($errorMessage, $errorCode);
 	}
 
 	/**

--- a/tests/control/HTTPResponseTest.php
+++ b/tests/control/HTTPResponseTest.php
@@ -30,4 +30,35 @@ class HTTPResponseTest extends SapphireTest {
 		);
 	}
 	
+	public function testHTTPResponseException() {
+		$response = new SS_HTTPResponse("Test", 200, 'OK');
+
+		// Confirm that the exception's statusCode and statusDescription take precedence
+		try {
+			throw new SS_HTTPResponse_Exception($response, 404, 'not even found');
+
+		} catch(SS_HTTPResponse_Exception $e) {
+			$this->assertEquals(404, $e->getResponse()->getStatusCode());
+			$this->assertEquals('not even found', $e->getResponse()->getStatusDescription());
+			return;
+		}
+		// Fail if we get to here
+		$this->assertFalse(true, 'Something went wrong with our test exception');
+
+	}
+
+	public function testExceptionContentPlainByDefault() {
+
+		// Confirm that the exception's statusCode and statusDescription take precedence
+		try {
+			throw new SS_HTTPResponse_Exception("Some content that may be from a hacker", 404, 'not even found');
+
+		} catch(SS_HTTPResponse_Exception $e) {
+			$this->assertEquals("text/plain", $e->getResponse()->getHeader("Content-Type"));
+			return;
+		}
+		// Fail if we get to here
+		$this->assertFalse(true, 'Something went wrong with our test exception');
+
+	}
 }

--- a/tests/control/RequestHandlingTest.php
+++ b/tests/control/RequestHandlingTest.php
@@ -146,9 +146,17 @@ class RequestHandlingTest extends FunctionalTest {
 	}
 	
 	public function testHTTPError() {
+		RequestHandlingTest_ControllerExtension::$called_error = false;
+		RequestHandlingTest_ControllerExtension::$called_404_error = false;
+
 		$response = Director::test('RequestHandlingTest_Controller/throwhttperror');
 		$this->assertEquals(404, $response->getStatusCode());
 		$this->assertEquals('This page does not exist.', $response->getBody());
+
+		// Confirm that RequestHandlingTest_ControllerExtension::onBeforeHTTPError() called
+		$this->assertTrue(RequestHandlingTest_ControllerExtension::$called_error);
+		// Confirm that RequestHandlingTest_ControllerExtension::onBeforeHTTPError404() called
+		$this->assertTrue(RequestHandlingTest_ControllerExtension::$called_404_error);
 	}
 	
 	public function testMethodsOnParentClassesOfRequestHandlerDeclined() {
@@ -401,9 +409,27 @@ class RequestHandlingTest_FormActionController extends Controller {
  * Simple extension for the test controller
  */
 class RequestHandlingTest_ControllerExtension extends Extension {
+	public static $called_error = false;
+	public static $called_404_error = false;
+
 	public function extendedMethod() {
 		return "extendedMethod";
 	}
+
+	/**
+	 * Called whenever there is an HTTP error
+	 */
+	public function onBeforeHTTPError() {
+		self::$called_error = true;
+	}
+
+	/**
+	 * Called whenever there is an 404 error
+	 */
+	public function onBeforeHTTPError404() {
+		self::$called_404_error = true;
+	}
+
 }
 
 /**


### PR DESCRIPTION
...oints to RequestHandler::httpError().

These APIs are primarily intended to let developers write custom 404 handlers.  They can define an onBeforeHTTPError404() method on an Extension that gets added to Controller or RequestHandler.

The SS_HTTPResponse_Exception object has also been tidied up to override the status info of any SS_HTTPResponse object that might get passed.  This is mainly to make it easier for callers (such as ContentController and ModelAsController) to use RequestHandler::httpError() more consistently.
