### PR TITLE
BUGFIX: Old version of SimpleTest does not recognise input fields of type 'email'.

### DIFF
--- a/thirdparty/simpletest/page.php
+++ b/thirdparty/simpletest/page.php
@@ -86,6 +86,7 @@ class SimpleTagBuilder {
                 'checkbox' => 'SimpleCheckboxTag',
                 'radio' => 'SimpleRadioButtonTag',
                 'text' => 'SimpleTextTag',
+                'email' => 'SimpleTextTag',
                 'hidden' => 'SimpleTextTag',
                 'password' => 'SimpleTextTag',
                 'file' => 'SimpleUploadTag');


### PR DESCRIPTION
Patch for SimpleTest which does not recognise input fields of type email so submitForm() was not populating EmailFields.
