### PR TITLE
BUG If a nested page editable but parent not, user can't expand tree

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -649,7 +649,7 @@ form.import-form label.left { width: 250px; }
 .cms .jstree a > .jstree-icon, .TreeDropdownField .treedropdownfield-panel .jstree a > .jstree-icon { margin-right: 3px; }
 .cms .jstree li.jstree-open > ul, .TreeDropdownField .treedropdownfield-panel .jstree li.jstree-open > ul { display: block; }
 .cms .jstree li.jstree-closed > ul, .TreeDropdownField .treedropdownfield-panel .jstree li.jstree-closed > ul { display: none; }
-.cms .jstree li.disabled a, .TreeDropdownField .treedropdownfield-panel .jstree li.disabled a { color: #aaaaaa; }
+.cms .jstree li.disabled > a, .TreeDropdownField .treedropdownfield-panel .jstree li.disabled > a { color: #aaaaaa; }
 .cms .jstree-rtl a > .jstree-icon, .TreeDropdownField .treedropdownfield-panel .jstree-rtl a > .jstree-icon { margin-left: 3px; margin-right: 0; }
 .cms .jstree-rtl li, .TreeDropdownField .treedropdownfield-panel .jstree-rtl li { margin-left: 0; margin-right: 18px; }
 .cms .jstree-rtl > ul > li, .TreeDropdownField .treedropdownfield-panel .jstree-rtl > ul > li { margin-right: 0px; }

--- a/admin/javascript/LeftAndMain.Tree.js
+++ b/admin/javascript/LeftAndMain.Tree.js
@@ -75,9 +75,12 @@
 							}
 							
 							if($.inArray(data.func, ['check_node', 'uncheck_node'])) {
-								//Don't allow check and uncheck if parent is disabled
+								// don't allow check and uncheck if parent is disabled
 								var node = $(data.args[0]).parents('li:first');
-								if(node.hasClass('disabled')) {
+								var allowedChildren = node.find('li:not(.disabled)');
+
+								// if there are child nodes that aren't disabled, allow expanding the tree
+								if(node.hasClass('disabled') && allowedChildren == 0) {
 									e.stopImmediatePropagation();
 									return false;
 								}

--- a/admin/scss/_tree.scss
+++ b/admin/scss/_tree.scss
@@ -75,7 +75,7 @@
 			}
 
 		}
-		li.disabled a {
+		li.disabled > a {
 			color: #aaaaaa;
 		}
 


### PR DESCRIPTION
If you're logged in as a specific user in a group who has view/edit
permissions of a page that has a parent page which doesn't have
permissions, you can't expand the tree node to get access to that
nested page.

This fixes LeftAndMain.Tree.js to allow expanding if there are
immediate children tree nodes that are not disabled. Also fixes
styling so that only immediate children nodes are greyed out.

Fixes this ticket: http://open.silverstripe.org/ticket/7913
