### PR TITLE
BUG Non-breaking space added automatically by TinyMCE on anchors

### DIFF
--- a/admin/_config.php
+++ b/admin/_config.php
@@ -11,7 +11,7 @@ HtmlEditorConfig::get('cms')->setOptions(array(
 	'cleanup_callback' => "sapphiremce_cleanup",
 
 	'use_native_selects' => true, // fancy selects are bug as of SS 2.3.0
-	'valid_elements' => "@[id|class|style|title],#a[id|rel|rev|dir|tabindex|accesskey|type|name|href|target|title"
+	'valid_elements' => "@[id|class|style|title],a[id|rel|rev|dir|tabindex|accesskey|type|name|href|target|title"
 		. "|class],-strong/-b[class],-em/-i[class],-strike[class],-u[class],#p[id|dir|class|align|style],-ol[class],"
 		. "-ul[class],-li[class],br,img[id|dir|longdesc|usemap|class|src|border|alt=|title|width|height|align],"
 		. "-sub[class],-sup[class],-blockquote[dir|class],"


### PR DESCRIPTION
Everytime TinyMCE is saved, it adds &nbsp; characters immediately
after anchors, e.g. `<a name="test"></a>&nbsp;`\- this fix stops
TinyMCE from adding those extraneous non-breaking spaces
after the anchors.
