### PR TITLE
BUG Exclude framework/dev from text collection (fixes #4754)

### DIFF
--- a/i18n/i18nTextCollector.php
+++ b/i18n/i18nTextCollector.php
@@ -170,7 +170,7 @@ class i18nTextCollector extends Object {
 			$fileList = $this->getFilesRecursive("$this->basePath/$module/code");
 		} else if($module == FRAMEWORK_DIR || substr($module, 0, 7) == 'themes/') {
 			// framework doesn't have the usual module structure, so we'll scan all subfolders
-			$fileList = $this->getFilesRecursive("$this->basePath/$module");
+			$fileList = $this->getFilesRecursive("$this->basePath/$module", null, null, '/\/(tests|dev)$/');
 		}
 		foreach($fileList as $filePath) {
 			// exclude ss-templates, they're scanned separately
@@ -183,8 +183,7 @@ class i18nTextCollector extends Object {
 		
 		// Search for calls in template files if these exists
 		if(is_dir("$this->basePath/$module/")) {
-			$dummy = array();
-			$fileList = $this->getFilesRecursive("$this->basePath/$module/", $dummy, 'ss');
+			$fileList = $this->getFilesRecursive("$this->basePath/$module/", null, 'ss');
 			foreach($fileList as $index => $filePath) {
 				$content = file_get_contents($filePath);
 				// templates use their filename as a namespace
@@ -400,25 +399,30 @@ class i18nTextCollector extends Object {
 	 * @param string $folder base directory to scan (will scan recursively)
 	 * @param array $fileList Array to which potential files will be appended
 	 * @param string $type Optional, "php" or "ss"
+	 * @param  string $folderExclude Regular expression matching folder names to exclude
 	 * @return array $fileList An array of files
 	 */
-	protected function getFilesRecursive($folder, &$fileList = null, $type = null) {
+	protected function getFilesRecursive($folder, $fileList = null, $type = null, $folderExclude = null) {
+		if(!$folderExclude) $folderExclude = '/\/(tests)$/';
 		if(!$fileList) $fileList = array();
 		$items = scandir($folder);
 		$isValidFolder = (
 			!in_array('_manifest_exclude', $items)
-			&& !preg_match('/\/tests$/', $folder)
+			&& !preg_match($folderExclude, $folder)
 		);
 
 		if($items && $isValidFolder) foreach($items as $item) {
 			if(substr($item,0,1) == '.') continue;
 			if(substr($item,-4) == '.php' && (!$type || $type == 'php')) {
 				$fileList[substr($item,0,-4)] = "$folder/$item";
-			}
-			else if(substr($item,-3) == '.ss' && (!$type || $type == 'ss')) {
+			} else if(substr($item,-3) == '.ss' && (!$type || $type == 'ss')) {
 				$fileList[$item] = "$folder/$item";
+			} else if(is_dir("$folder/$item")) {
+				$fileList = array_merge(
+					$fileList, 
+					$this->getFilesRecursive("$folder/$item", $fileList, $type, $folderExclude)
+				);
 			}
-			else if(is_dir("$folder/$item")) $this->getFilesRecursive("$folder/$item", $fileList, $type);
 		}
 		return $fileList;
 	}


### PR DESCRIPTION
Avoids breaking execution if PHPUnit is not installed,
since classes in framework/dev/ extend PHPUnit,
and get autoloaded when we inspect the ancestry and implementors
of every class defined on the filesystem.
Not an ideal, since it removes i18n support for dev classes,
but in practice this only impacts a single entity definition.

See discussion at https://groups.google.com/forum/?fromgroups=#!topic/silverstripe-dev/5hMXL1zeh1o
