### PR TITLE
Fixed grammatical error for Form.FIELDISREQUIRED

### DIFF
--- a/lang/en_GB.yml
+++ b/lang/en_GB.yml
@@ -199,7 +199,7 @@ en_GB:
     TEXT2: 'password reset link'
     TEXT3: for
   Form:
-    FIELDISREQUIRED: '%s is required.'
+    FIELDISREQUIRED: '%s is required'
     SubmitBtnLabel: Go
     VALIDATIONCREDITNUMBER: 'Please ensure you have entered the {number} credit card number correctly'
     VALIDATIONNOTUNIQUE: 'The value entered is not unique'


### PR DESCRIPTION
Removed double full stop - it is already automatically added by the RequiredFields validator.
