### PR TITLE
BUG Delay HTMLEditorField showing (TinyMCE workaround)

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -266,14 +266,15 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 
 				ed.init(config);
 
-				// Avoid flicker (also set in CSS to apply as early as possible)
-				self.css('visibility', '');
-
 				// Create editor instance and render it.
 				// Similar logic to adapter/jquery/jquery.tinymce.js, but doesn't rely on monkey-patching
 				// jQuery methods, and avoids replicate the script lazyloading which is already in place with jQuery.ondemand.
 				ed.create(this.attr('id'), config, function() {
-					self.css('visibility', 'visible');
+					// Delayed show because TinyMCE calls hide() via setTimeout on removing an element,
+					// which is called in quick succession with adding a new editor after ajax loading new markup
+					setTimeout(function() {
+						$(ed.getContainer()).show();
+					}, 10);
 				});
 				
 				this._super();


### PR DESCRIPTION
Followup to https://github.com/silverstripe/sapphire/pull/847

Bug introduced by a recent upgrade from TinyMCE 3.5.3 to 3.5.6 in 758b4fd173127661646fc9123616d62a13d0177f

Delayed show because TinyMCE calls hide() via setTimeout on removing an element,
which is called in quick succession with adding a new editor after ajax loading new markup

Tested in Chrome, IE7/8/9

See https://github.com/tinymce/tinymce/commit/e0378ceb7792fb7949c3aca3487306a78668595e
