### PR TITLE
BUG: Fixed use of DI in the Security controller

### DIFF
--- a/security/Security.php
+++ b/security/Security.php
@@ -341,7 +341,7 @@ class Security extends Controller {
 			// Disable ID-based caching  of the log-in page by making it a random number
 			$tmpPage->ID = -1 * rand(1,10000000);
 
-			$controller = new Page_Controller($tmpPage);
+			$controller = Page_Controller::create($tmpPage);
 			$controller->setDataModel($this->model);
 			$controller->init();
 			//Controller::$currentController = $controller;
@@ -436,7 +436,7 @@ class Security extends Controller {
 			$tmpPage->Title = _t('Security.LOSTPASSWORDHEADER', 'Lost Password');
 			$tmpPage->URLSegment = 'Security';
 			$tmpPage->ID = -1; // Set the page ID to -1 so we dont get the top level pages as its children
-			$controller = new Page_Controller($tmpPage);
+			$controller = Page_Controller::create($tmpPage);
 			$controller->init();
 		} else {
 			$controller = $this;
@@ -495,7 +495,7 @@ class Security extends Controller {
 			$tmpPage->Title = _t('Security.LOSTPASSWORDHEADER');
 			$tmpPage->URLSegment = 'Security';
 			$tmpPage->ID = -1; // Set the page ID to -1 so we dont get the top level pages as its children
-			$controller = new Page_Controller($tmpPage);
+			$controller = Page_Controller::create($tmpPage);
 			$controller->init();
 		} else {
 			$controller = $this;
@@ -553,7 +553,7 @@ class Security extends Controller {
 			$tmpPage->Title = _t('Security.CHANGEPASSWORDHEADER', 'Change your password');
 			$tmpPage->URLSegment = 'Security';
 			$tmpPage->ID = -1; // Set the page ID to -1 so we dont get the top level pages as its children
-			$controller = new Page_Controller($tmpPage);
+			$controller = Page_Controller::create($tmpPage);
 			$controller->init();
 		} else {
 			$controller = $this;


### PR DESCRIPTION
The security controller currently creates a nested Page_Controller instance, and populates it with a dummy Page object.

The issue is that by using "new Page_Controller" this process subverts dependency injection, and means that any Page_Controller with registered dependencies will not be properly initialised.

This fix replaces the object creation lines with Page_Controller::create() as per the convention.

I should probably have applied the same to the "new Page()" items, but I'm unsure whether or not it would be correct for DataObjects to have their own dependencies, so I opted for the simplest fix.
