### PR TITLE
NEW DataList->filterAny()

### DIFF
--- a/docs/en/topics/datamodel.md
+++ b/docs/en/topics/datamodel.md
@@ -161,12 +161,30 @@ Then there is the most complex task when you want to find Sam and Sig that has e
 		'FirstName' => array('Sam', 'Sig'),
 		'Age' => array(17, 74)
 	));
+	// SQL: WHERE ("FirstName" IN ('Sam', 'Sig) AND "Age" IN ('17', '74))
 
-This would be equivalent to a SQL query of
+In case you want to match multiple criteria non-exclusively (with an "OR" disjunctive),
+use the `filterAny()` method instead:
 
-	:::
-	... WHERE ("FirstName" IN ('Sam', 'Sig) AND "Age" IN ('17', '74));
+	:::php
+	$members = Member::get()->filterAny(array(
+		'FirstName' => 'Sam',
+		'Age' => 17,
+	));
+	// SQL: WHERE ("FirstName" = 'Sam' OR "Age" = '17')
 
+You can also combine both conjunctive ("AND") and disjunctive ("OR") statements.
+
+	:::php
+	$members = Member::get()
+		->filter(array(
+			'LastName' => 'Minnée'
+		))
+		->filterAny(array(
+			'FirstName' => 'Sam',
+			'Age' => 17,
+		));
+	// SQL: WHERE ("LastName" = 'Minnée' AND ("FirstName" = 'Sam' OR "Age" = '17'))
 
 ### Exclude
 


### PR DESCRIPTION
A user-friendly way to get "OR" conditions working.
Uses the new disjunctive capabilities which Simon added recently.
See discussion at http://logs.simon.geek.nz/index.php?date=2012-10-12#22_38

On a related note, Simon suggested to change exclude() to be conjunctive, and add excludeAny() with disjunctive to make the API consistent. That'd be an API change to exclude(), so needs discussion (on the mailinglist).

We need this to get highlevel ORM filtering working in a GridField component, see  https://github.com/silverstripe/sapphire/pull/871
