### PR TITLE
API File->canEdit() returns TRUE by default (not checking CMS perms)

### DIFF
--- a/docs/en/changelogs/3.1.0.md
+++ b/docs/en/changelogs/3.1.0.md
@@ -10,3 +10,4 @@
    `debug_profile`, `debug_memory`, `profile_trace`, `debug_javascript`, `debug_behaviour`
  * Removed `Member_ProfileForm`, use `CMSProfileController` instead
  * `SiteTree::$nested_urls` enabled by default. To disable, call `SiteTree::disable_nested_urls()`.
+ * Removed CMS permission checks from `File->canEdit()` and `File->canDelete()`. If you have unsecured controllers relying on these permissions, please override them through a `DataExtension`.

--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -293,7 +293,7 @@ class File extends DataObject {
 		$result = $this->extendedCan('canEdit', $member);
 		if($result !== null) return $result;
 		
-		return Permission::checkMember($member, 'CMS_ACCESS_AssetAdmin');
+		return true;
 	}
 	
 	/**


### PR DESCRIPTION
This is a measure to support form fields and controllers
interacting with files in different contexts,
for example an UploadField used in a ModelAdmin,
or a website frontend. The check for 'CMS_ACCESS_AssetAdmin'
was too restricting. This wasn't a problem in 2.x simply because
the old FileField/Upload classes didn't respect File->can*() permissions.

This doesn't create a security issue as we're still securing core upload
fields by their controllers. The only field present in core is located
in CMSFileAddController, and indirectly through HTMLEditorField->MediaForm().

See discussion at https://groups.google.com/forum/?fromgroups=#!topic/silverstripe-dev/30CXT9csKFQ
