### PR TITLE
API CHANGE: By default add trailing slashes on URLs that should have them

### DIFF
--- a/_config/controller.yml
+++ b/_config/controller.yml
@@ -1,0 +1,6 @@
+---
+name: corecontroller
+---
+Controller:
+  links_have_trailing_slash:
+    true

--- a/control/Controller.php
+++ b/control/Controller.php
@@ -558,12 +558,41 @@ class Controller extends RequestHandler implements TemplateGlobalProvider {
 			}
 		}
 		
+		$result = self::handle_trailing_slash_on_link($result);
+		
 		if($querystrings) $result .= '?' . implode('&', $querystrings);
 		if($fragmentIdentifier) $result .= "#$fragmentIdentifier";
 		
 		return $result;
 	}
+	
+	/**
+	 * Add or removes a trailing slash from the passed in URL depending on the URL and configuration
+	 * 
+	 * @param $url string
+	 * @return string - the modiefied url
+	 */
+	public static function handle_trailing_slash_on_link($url) {
 
+		// Remove any current trailing slashes 
+		$url = rtrim($url, '/');
+
+		// If this looks like file name, always skip adding a trailing slash
+		if((strpos(basename($url), '.') !== false)) {
+			return $url;
+		}
+
+		if(!Config::inst()->get('Controller', 'links_have_trailing_slash')) {
+			return $url;
+		}
+
+		return $url . '/';
+	}
+	
+	/**
+	 *
+	 * @return array
+	 */
 	public static function get_template_global_variables() {
 		return array(
 			'CurrentPage' => 'curr',

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -51,6 +51,7 @@ Please read our [guide to contributing documentation](misc/contributing/document
 *  [Testing Guide](topics/testing/): Framework for automated testing like Unittests
 *  [Execution Pipeline](reference/execution-pipeline): Tracking a request from director to template-rendering
 *  [Recipes/Howtos](howto/)
+*  [Search engine optimisation](topics/search-engine-optimisation.md): Information on how SilverStripe helps with SEO improvements.
 
 ### Level 4: Contributing to the SilverStripe core
 

--- a/docs/en/topics/index.md
+++ b/docs/en/topics/index.md
@@ -25,6 +25,7 @@ It is where most documentation should live, and is the natural "second step" aft
  * [Modules](modules): Introduction, how to download and install a module (e.g. with blog or forum functionality)
  * [Page Types](page-types): What is a "page type" and how do you create one?
  * [Search](search): Searching for properties in the database as well as other documents
+ * [Search Engine Optimisation (SEO)](search-engine-optimisation.md): Information on how SilverStripe handles URLs and meta tags for SEO.
  * [Security](security): How to develop secure SilverStripe applications with good code examples
  * [Templates](templates): SilverStripe template syntax: Variables, loops, includes and much more
  * [Testing](testing): Functional and Unit Testing with PHPUnit and SilverStripe's testing framework

--- a/docs/en/topics/search-engine-optimisation.md
+++ b/docs/en/topics/search-engine-optimisation.md
@@ -1,0 +1,62 @@
+# Search Engine Optimisation (SEO)
+
+Ranking high in a search engine is one of the key factors of your sites awerness on the web today. 
+The SilverStripe platform have a default set of features that will help you provide a structure that
+helps search engines to index and rank your site.
+
+ > Search engine optimization (SEO) is the process of improving the visibility of a website or a web 
+ > page in a search engine's "natural" or un-paid ("organic" or "algorithmic") search results.
+ Source: [wikipedia](http://en.wikipedia.org/wiki/Search_engine_optimization)
+
+## Page title
+
+## URLs
+
+### Nested URLs
+
+By adding a the following line in your mysite/_config.php
+
+	:::php
+	if(class_exists('SiteTree')) SiteTree::enable_nested_urls();
+
+Will make the url for any page 'inherit' the parent folders url. Site tree example:
+
+    - Category (url: category/)
+        - SubCategory (URL: subcategory/) 
+
+The SubCategory page URL will then be `category/subcategory/`
+
+If you disable the nested URL functionality, 
+
+	:::php
+	SiteTree::disable_nested_urls()
+
+the SubCategory page URL will then be `subcategory/`
+
+### Trailing slash
+
+By the default SilverStripe adds trailing slashes on all URLs that are passed through the internal 
+framework (see `Controller::join_links()`).
+
+This automatic functionlity can be disabled by adding 
+the following configuration in a `mysite/_config/controller.yml` file.
+
+	---
+	Name: mysitecontroller
+	After: '#corecontroller'
+	---
+	Controller:
+	  links_have_trailing_slash:
+	    false
+
+*Note:* URLs that looks like files, ie have a dot (.) in them will never have trailing slash on 
+them.
+
+## Meta tags
+
+## Sitemap
+
+## Reports
+
+## Modified since
+


### PR DESCRIPTION
This changes the default behavior of the Controller::join_links() to add a trailing slash on all urls that doesn't contains a dot (crude filename detection).

This can be disabled / enabled via the Config system and an example of how to do that is provided in a first cut of a SEO topic documentation.
