### PR TITLE
BUG Using Session::set() for DB::set_alternative_database_name()

### DIFF
--- a/model/DB.php
+++ b/model/DB.php
@@ -65,14 +65,14 @@ class DB {
 	 * Set it to null to revert to the main database.
 	 */
 	public static function set_alternative_database_name($dbname) {
-		$_SESSION["alternativeDatabaseName"] = $dbname;
+		Session::set("alternativeDatabaseName", $dbname);
 	}
 	
 	/**
 	 * Get the name of the database in use
 	 */
 	public static function get_alternative_database_name() {
-		return $_SESSION["alternativeDatabaseName"];	
+		return Session::get("alternativeDatabaseName");	
 	}
 
 	/**
@@ -84,8 +84,8 @@ class DB {
 	 */
 	public static function connect($databaseConfig) {
 		// This is used by TestRunner::startsession() to test up a test session using an alt
-		if(isset($_SESSION) && !empty($_SESSION['alternativeDatabaseName'])) {
-			$databaseConfig['database'] = $_SESSION['alternativeDatabaseName'];
+		if($name = Session::get('alternativeDatabaseName')) {
+			$databaseConfig['database'] = $name;
 		}
 
 		if(!isset($databaseConfig['type']) || empty($databaseConfig['type'])) {


### PR DESCRIPTION
Setting session directly through $_SESSION relies on
session_autostart which might not be set on every environment,
and isn't consistent with other framework use.

This is required to get Behat going on our TeamCity instance, which doesn't autostart sessions
unless you go through Session::set(). At first I thought this was using $_SESSION directly because the Session instance was pointing to an in-memory mock, but it doesn't in any existing use of set_alternative_database_name().
