### PR TITLE
BUG / API Fixes to test cases requiring code for consolidating newlines

### DIFF
--- a/core/Convert.php
+++ b/core/Convert.php
@@ -317,4 +317,15 @@ class Convert {
 		$f = URLSegmentFilter::create();
 		return $f->filter($title);
 	}
+	
+	/**
+	 * Normalises newline sequences to conform to (an) OS specific format.
+	 * @param string $data Text containing potentially mixed formats of newline
+	 * sequences including \r, \r\n, \n, or unicode newline characters
+	 * @param string $nl The newline sequence to normalise to. Defaults to that
+	 * specified by the current OS
+	 */
+	public static function nl2os($data, $nl = PHP_EOL) {
+		return preg_replace('~\R~u', $nl, $data);
+	}
 }

--- a/core/HTMLCleaner.php
+++ b/core/HTMLCleaner.php
@@ -93,6 +93,8 @@ class TidyHTMLCleaner extends HTMLCleaner {
 	public function cleanHTML($content) {
 		$tidy = new tidy();
 		$output = $tidy->repairString($content, $this->config);
-		return $output;
+		
+		// Clean leading/trailing whitespace
+		return preg_replace('/(^\s+)|(\s+$)/', '', $output);
 	}
 }

--- a/dev/Deprecation.php
+++ b/dev/Deprecation.php
@@ -86,11 +86,11 @@ class Deprecation {
 	protected static function get_calling_module_from_trace($backtrace) {
 		if (!isset($backtrace[1]['file'])) return;
 
-		$callingfile = $backtrace[1]['file'];
+		$callingfile = realpath($backtrace[1]['file']);
 
 		global $manifest;
 		foreach ($manifest->getModules() as $name => $path) {
-			if (strpos($callingfile, $path) === 0) {
+			if (strpos($callingfile, realpath($path)) === 0) {
 				return $name;
 			}
 		}

--- a/i18n/i18nTextCollector.php
+++ b/i18n/i18nTextCollector.php
@@ -522,7 +522,8 @@ class i18nTextCollector_Writer_Php implements i18nTextCollector_Writer {
 		$php .= (count($entitySpec) == 1) ? var_export($entitySpec[0], true) : var_export($entitySpec, true);
 		$php .= ";$eol";
 		
-		return $php;
+		// Normalise linebreaks due to fix var_export output
+		return Convert::nl2os($php, $eol);
 	}
 }
 

--- a/tests/core/ConvertTest.php
+++ b/tests/core/ConvertTest.php
@@ -139,5 +139,51 @@ class ConvertTest extends SapphireTest {
 		$this->assertEquals('foos-bar-2', Convert::raw2url('foo\'s [bar] (2)'));
 		URLSegmentFilter::$default_allow_multibyte = $orig;
 	}
-
+	
+	/**
+	 * Helper function for comparing characters with significant whitespaces
+	 * @param type $expected
+	 * @param type $actual 
+	 */
+	protected function assertEqualsQuoted($expected, $actual) {
+		$message = sprintf(
+			"Expected \"%s\" but given \"%s\"", 
+			addcslashes($expected, "\r\n"), 
+			addcslashes($actual, "\r\n")
+		);
+		$this->assertEquals($expected, $actual, $message);
+	}
+	
+	public function testNL2OS() {
+		
+		foreach(array("\r\n", "\r", "\n") as $nl) {
+			
+			// Base case: no action
+			$this->assertEqualsQuoted(
+				"Base case",
+				Convert::nl2os("Base case", $nl)
+			);
+			
+			// Mixed formats
+			$this->assertEqualsQuoted(
+				"Test{$nl}Text{$nl}Is{$nl}{$nl}Here{$nl}.",
+				Convert::nl2os("Test\rText\r\nIs\n\rHere\r\n.", $nl)
+			);
+			
+			// Test that multiple runs are non-destructive
+			$expected = "Test{$nl}Text{$nl}Is{$nl}{$nl}Here{$nl}.";
+			$this->assertEqualsQuoted(
+				$expected,
+				Convert::nl2os($expected, $nl)
+			);
+			
+			// Check repeated sequence behaves correctly
+			$expected = "{$nl}{$nl}{$nl}{$nl}{$nl}{$nl}{$nl}{$nl}";
+			$input = "\r\r\n\r\r\n\n\n\n\r";
+			$this->assertEqualsQuoted(
+				$expected,
+				Convert::nl2os($input, $nl)
+			);
+		}
+	}
 }

--- a/tests/core/HTMLCleanerTest.php
+++ b/tests/core/HTMLCleanerTest.php
@@ -11,13 +11,13 @@ class HTMLCleanerTest extends SapphireTest {
 
 		if ($cleaner) {
 			$this->assertEquals(
-				$cleaner->cleanHTML('<p>wrong <b>nesting</i></p>' . "\n"),
-				'<p>wrong <b>nesting</b></p>' . "\n",
+				$cleaner->cleanHTML('<p>wrong <b>nesting</i></p>'),
+				'<p>wrong <b>nesting</b></p>',
 				"HTML cleaned properly"
 			);
 			$this->assertEquals(
-				$cleaner->cleanHTML('<p>unclosed paragraph' . "\n"),
-				'<p>unclosed paragraph</p>' . "\n",
+				$cleaner->cleanHTML('<p>unclosed paragraph'),
+				'<p>unclosed paragraph</p>',
 				"HTML cleaned properly"
 			);
 		} else {

--- a/tests/i18n/i18nTextCollectorTest.php
+++ b/tests/i18n/i18nTextCollectorTest.php
@@ -413,7 +413,7 @@ de:
     OtherEntityName: 'Other Text'
 
 YAML;
-		$this->assertEquals($yaml, $writer->getYaml($entities, 'de'));
+		$this->assertEquals($yaml, Convert::nl2os($writer->getYaml($entities, 'de')));
 	}
 	
 	public function testCollectFromIncludedTemplates() {


### PR DESCRIPTION
Throughout the test cases there are many cases where string comparison is highly dependent upon environment.

In order to alleviate some of these issues this code introduces a new Convert::nl2os function which allows newline characters to be normalised across environments. This function may be called on its own to convert any newline sequences within a string to match those used by the current operating system, or a sequence may be specified in order to convert to a foreign system.

Test cases are included to test the correctness of this function.

Various test cases have been updated in order to remove the variability of line endings from string comparison in cases where this is not critical. This should now allow test cases to run identically across any environment.

Some test cases also had issues with system depedant path separators, so realpath() has been used to normalise these.

I also noticed some issues with the tidy library appending an odd \r\n\r to any tidied string. This may be an odd glitch in that library, but I considered it safe to trim trailing and leading whitespace characters from any cleaned string. This could just be a windows thing. Please correct me if this is an incorrect consideration.

I also managed to somehow correctly squash and rebase these commits, for the first time ever. Thanks Sam for the tutorial. :)
