### PR TITLE
Minor PHP5.4 fixes

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -240,8 +240,8 @@ if(isset($_GET['debugmanifest'])) Debug::show(file_get_contents(MANIFEST_FILE));
 // This is necessary to force developers to acknowledge and fix
 // notice level errors (you can override this directive in your _config.php)
 if (Director::isLive()) {
-	if(defined('E_DEPRECATED')) error_reporting((E_ALL ^ E_NOTICE) ^ E_DEPRECATED);
-	else error_reporting(E_ALL ^ E_NOTICE);
+	if(defined('E_DEPRECATED')) error_reporting(E_ALL & ~(E_NOTICE | E_DEPRECATED | E_STRICT));
+	else error_reporting(E_ALL & ~E_NOTICE);
 }
 ///////////////////////////////////////////////////////////////////////////////
 // POST-MANIFEST COMMANDS

--- a/dev/Backtrace.php
+++ b/dev/Backtrace.php
@@ -130,7 +130,9 @@ class SS_Backtrace {
 		if($showArgs && isset($item['args'])) {
 			$args = array();
 			foreach($item['args'] as $arg) {
-				if(!is_object($arg) || method_exists($arg, '__toString')) {
+				if(is_array($arg)) {
+					$args[] = 'Array';
+				} elseif(!is_object($arg) || method_exists($arg, '__toString')) {
 					$args[] = (string) $arg;
 				} else {
 					$args[] = get_class($arg);


### PR DESCRIPTION
Explictly excludes E_STRICT from live error level and handle arrays in a backtrace
output, rather than trying to convert to string.

These are the only differences I could see relating to PHP5.4 stuff when comparing PocketRent's sapphire to the 2.4.8-rc1 release.
