### PR TITLE
API Add the ability to query if the schema update is in progress.

### DIFF
--- a/model/Database.php
+++ b/model/Database.php
@@ -180,8 +180,12 @@ abstract class SS_Database {
 	 * @var array
 	 */
 	protected $indexList;
-	
-	
+
+	/**
+	 * Keeps track whether we are currently updating the schema.
+	 */
+	protected $schemaIsUpdating = false;
+
 	/**
 	 * Large array structure that represents a schema update transaction
 	 */
@@ -193,6 +197,7 @@ abstract class SS_Database {
 	 * Once	
 	 */
 	public function beginSchemaUpdate() {
+		$this->schemaIsUpdating = true;
 		$this->tableList = array();
 		$tables = $this->tableList();
 		foreach($tables as $table) $this->tableList[strtolower($table)] = $table;
@@ -221,6 +226,7 @@ abstract class SS_Database {
 			}
 		}
 		$this->schemaUpdateTransaction = null;
+		$this->schemaIsUpdating = false;
 	}
 
 	/**
@@ -228,6 +234,14 @@ abstract class SS_Database {
 	 */
 	public function cancelSchemaUpdate() {
 		$this->schemaUpdateTransaction = null;
+		$this->schemaIsUpdating = false;
+	}
+
+	/**
+	 * Returns true if we are during a schema update.
+	 */
+	function isSchemaUpdating() {
+		return $this->schemaIsUpdating;
 	}
 
 	/**

--- a/tests/model/DatabaseTest.php
+++ b/tests/model/DatabaseTest.php
@@ -62,6 +62,22 @@ class DatabaseTest extends SapphireTest {
 		}
 	}
 
+	function testIsSchemaUpdating() {
+		$db = DB::getConn();
+
+		$this->assertFalse($db->isSchemaUpdating(), 'Before the transaction the flag is false.');
+
+		$db->beginSchemaUpdate();
+		$this->assertTrue($db->isSchemaUpdating(), 'During the transaction the flag is true.');
+
+		$db->endSchemaUpdate();
+		$this->assertFalse($db->isSchemaUpdating(), 'After the transaction the flag is false.');
+
+		$db->beginSchemaUpdate();
+		$db->cancelSchemaUpdate();
+		$this->assertFalse($db->doesSchemaNeedUpdating(), 'After cancelling the transaction the flag is false');
+	}
+
 	public function testSchemaUpdateChecking() {
 		$db = DB::getConn();
 


### PR DESCRIPTION
The specific situation where this is useful is where populateDefaults on
DataObjects needs to query the database. This will break the dev/build
when it tries to create the object via singleton - the query will not be
able to be executed if the table is not there or its schema has changed.

For an example of such use case see Translatable::populateDefaults.
