### PR TITLE
Fix: scaffolded Enum dropdown field always returning empty string

### DIFF
--- a/model/fieldtypes/Enum.php
+++ b/model/fieldtypes/Enum.php
@@ -95,7 +95,9 @@ class Enum extends StringField {
 		if(!$name) $name = $this->name;
 
 		$field = new DropdownField($name, $title, $this->enumValues($hasEmpty), $value, $form);
-		$field->setEmptyString($emptyString);
+		if($hasEmpty) {
+			$field->setEmptyString($emptyString);
+		}
 
 		return $field;
 	}


### PR DESCRIPTION
when scaffolding an enum field from a Dataobject in the CMS. It always has an empty string option, due to a bug fixed here.
