### PR TITLE
BUG Fixed isue with SQLQuery->lastRow()

### DIFF
--- a/model/SQLQuery.php
+++ b/model/SQLQuery.php
@@ -1080,7 +1080,10 @@ class SQLQuery {
 	public function lastRow() {
 		$query = clone $this;
 		$offset = $this->limit ? $this->limit['start'] : 0;
-		$query->setLimit(1, $this->count() + $offset - 1);
+		
+		// Limit index to start in case of empty results
+		$index = max($this->count() + $offset - 1, 0);
+		$query->setLimit(1, $index);
 		return $query;
 	}
 

--- a/tests/model/SQLQueryTest.php
+++ b/tests/model/SQLQueryTest.php
@@ -2,7 +2,7 @@
 
 class SQLQueryTest extends SapphireTest {
 	
-	static $fixture_file = null;
+	public static $fixture_file = 'SQLQueryTest.yml';
 
 	protected $extraDataObjects = array(
 		'SQLQueryTest_DO',
@@ -299,6 +299,72 @@ class SQLQueryTest extends SapphireTest {
 
 		$query->setWhereAny(array("Monkey = 'Chimp'", "Color = 'Brown'"));
 		$this->assertEquals("SELECT * FROM MyTable WHERE (Monkey = 'Chimp' OR Color = 'Brown')",$query->sql());
+	}
+	
+	public function testSelectFirst() {
+		
+		// Test first from sequence
+		$query = new SQLQuery();
+		$query->setFrom('"SQLQueryTest_DO"');
+		$query->setOrderBy('"Name"');
+		$result = $query->firstRow()->execute();
+		
+		$this->assertCount(1, $result);
+		foreach($result as $row) {
+			$this->assertEquals('Object 1', $row['Name']);
+		}
+		
+		// Test first from empty sequence
+		$query = new SQLQuery();
+		$query->setFrom('"SQLQueryTest_DO"');
+		$query->setOrderBy('"Name"');
+		$query->setWhere(array("\"Name\" = 'Nonexistent Object'"));
+		$result = $query->firstRow()->execute();
+		$this->assertCount(0, $result);
+		
+		// Test that given the last item, the 'first' in this list matches the last
+		$query = new SQLQuery();
+		$query->setFrom('"SQLQueryTest_DO"');
+		$query->setOrderBy('"Name"');
+		$query->setLimit(1, 1);
+		$result = $query->firstRow()->execute();
+		$this->assertCount(1, $result);
+		foreach($result as $row) {
+			$this->assertEquals('Object 2', $row['Name']);
+		}
+	}
+	
+	public function testSelectLast() {
+		
+		// Test last in sequence
+		$query = new SQLQuery();
+		$query->setFrom('"SQLQueryTest_DO"');
+		$query->setOrderBy('"Name"');
+		$result = $query->lastRow()->execute();
+		
+		$this->assertCount(1, $result);
+		foreach($result as $row) {
+			$this->assertEquals('Object 2', $row['Name']);
+		}
+		
+		// Test last from empty sequence
+		$query = new SQLQuery();
+		$query->setFrom('"SQLQueryTest_DO"');
+		$query->setOrderBy('"Name"');
+		$query->setWhere(array("\"Name\" = 'Nonexistent Object'"));
+		$result = $query->lastRow()->execute();
+		$this->assertCount(0, $result);
+		
+		// Test that given the first item, the 'last' in this list matches the first
+		$query = new SQLQuery();
+		$query->setFrom('"SQLQueryTest_DO"');
+		$query->setOrderBy('"Name"');
+		$query->setLimit(1);
+		$result = $query->lastRow()->execute();
+		$this->assertCount(1, $result);
+		foreach($result as $row) {
+			$this->assertEquals('Object 1', $row['Name']);
+		}
 	}
 
 }

--- a/tests/model/SQLQueryTest.yml
+++ b/tests/model/SQLQueryTest.yml
@@ -1,0 +1,7 @@
+SQLQueryTest_DO:
+  test1:
+    Name: 'Object 1'
+    Meta: 'Details 1'
+  test2:
+    Name: 'Object 2'
+    Meta: 'Details 2'


### PR DESCRIPTION
SQLQuery->lastRow() would crash on an empty result set; The code would try to call $this->setLimit(1, -1) which of course will fail.

This has been fixed in code and added test cases to check for correct behaviour of both firstRow() and lastRow().
