### PR TITLE
BUGFIX: ContextSummary should be cast as HTMLText

### DIFF
--- a/model/fieldtypes/Text.php
+++ b/model/fieldtypes/Text.php
@@ -21,7 +21,7 @@ class Text extends StringField {
 	static $casting = array(
 		"AbsoluteLinks" => "Text",
 		"BigSummary" => "Text",
-		"ContextSummary" => "Text",
+		"ContextSummary" => "HTMLText",
 		"FirstParagraph" => "Text",
 		"FirstSentence" => "Text",
 		"LimitCharacters" => "Text",


### PR DESCRIPTION
Otherwise, the <span class="highlight"> renders as escaped HTML.
