### PR TITLE
BUG Fixed DateField date format error for IE8

### DIFF
--- a/forms/DateField.php
+++ b/forms/DateField.php
@@ -140,7 +140,7 @@ class DateField extends TextField {
 		$config = array(
 			'showcalendar' => $this->getConfig('showcalendar'),
 			'isoDateformat' => $this->getConfig('dateformat'),
-			'jqueryDateformat' => DateField_View_JQuery::convert_iso_to_jquery_format($this->getConfig('dateformat')),
+			'jquerydateformat' => DateField_View_JQuery::convert_iso_to_jquery_format($this->getConfig('dateformat')),
 			'min' => $this->getConfig('min'),
 			'max' => $this->getConfig('max')
 		);


### PR DESCRIPTION
On IE8, camel case element attributes are NOT included in the object returned
by $(elem).data(), meaning attrs defined in DateField.php (jqueryDateformat and
isoDateformat) are NOT seen by the code in DateField.js (ie the "config" var
doesn't have these set). Causing IE8 to fall back to using US date (mm/dd/yyyy)
formats. This can subsequently cause validation issues if the user's date
format is different.

DateField.js already explicitly checks for jquerydateformat (all lowercase)
so DateField.php has been modified to reflect the correct case for this
attribute name
