### PR TITLE
BUGFIX: multiple HTMLEditorFields would disappear on save

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -272,8 +272,9 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 				ed.create(this.attr('id'), config, function() {
 					// Delayed show because TinyMCE calls hide() via setTimeout on removing an element,
 					// which is called in quick succession with adding a new editor after ajax loading new markup
+					var rteobj = $(ed.getInstance().getContainer());
 					setTimeout(function() {
-						$(ed.getContainer()).show();
+						rteobj.show();
 					}, 10);
 				});
 				


### PR DESCRIPTION
IDs were being overwritten by something while setTimeout was running.
Storing the instance in an object before setting timeout seems to fix it
