### PR TITLE
ENHANCEMENT: Add ability to change URL for SS logo in LeftAndMain Menu

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -1387,14 +1387,6 @@ class LeftAndMain extends Controller implements PermissionProvider {
 	static $menu_link = 'http://www.silverstripe.org/';
 	
 	/**
-	 * The title for the anchor on the Silverstripe logo
-	 * Set by calling LeftAndMain::set_menu_link_title()
-	 *
-	 * @var String
-	 */
-	static $menu_link_title = null;
-	
-	/**
 	 * Sets the href for the anchor on the Silverstripe logo in the menu
 	 *
 	 * @param String $link
@@ -1408,26 +1400,6 @@ class LeftAndMain extends Controller implements PermissionProvider {
 	 */
 	public function MenuLink() {
 		return self::$menu_link;
-	}
-	
-	/**
-	 * Sets the title for the anchor on the Silverstripe logo in the menu
-	 *
-	 * @param String $link
-	 */
-	public static function set_menu_link_title($title) {
-		self::$menu_link_title = $title;
-	}
-	
-	/**
-	 * @return String
-	 */
-	public function MenuLinkTitle() {
-		if (self::$menu_link_title) {
-			return self::$menu_link_title;
-		} else {
-			return 'SilverStripe (Version - ' . $this->CMSVersion() . ')';
-		}
 	}
 
 	/**

--- a/admin/templates/Includes/LeftAndMain_Menu.ss
+++ b/admin/templates/Includes/LeftAndMain_Menu.ss
@@ -1,7 +1,7 @@
 <div class="cms-menu cms-panel cms-panel-layout west" id="cms-menu" data-layout-type="border">
 	<div class="cms-logo-header north">
 		<div class="cms-logo">
-			<a href="$MenuLink" target="_blank" title="$MenuLinkTitle">
+			<a href="$MenuLink" target="_blank" title="SilverStripe (Version - $CMSVersion)">
 				SilverStripe <% if CMSVersion %><abbr class="version">$CMSVersion</abbr><% end_if %>
 			</a>
 			<span><% if SiteConfig %>$SiteConfig.Title<% else %>$ApplicationName<% end_if %></span>


### PR DESCRIPTION
Used to set a custom URL for the SilverStripe logo in the top left of the CMS:

``` php
LeftAndMain::set_menu_link(Director::baseURL()); // Sets the href to the site base URL
LeftAndMain::set_menu_link('http://www.example.com/'); // Sets the href to be a custom URL
```
