### PR TITLE
BUG More specific i18n include paths to avoid Zend_Loader problems

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -1,7 +1,9 @@
 <?php
 require_once 'Zend/Translate.php';
-require_once 'i18nRailsYamlAdapter.php';
-require_once 'i18nSSLegacyAdapter.php';
+
+// Overrule Zend_Loader
+require_once FRAMEWORK_PATH . DIRECTORY_SEPARATOR . 'i18n' . DIRECTORY_SEPARATOR . 'i18nRailsYamlAdapter.php';
+require_once FRAMEWORK_PATH . DIRECTORY_SEPARATOR . 'i18n' . DIRECTORY_SEPARATOR . 'i18nSSLegacyAdapter.php';
 
 /**
  * Base-class for storage and retrieval of translated entities.


### PR DESCRIPTION
The problem surfaced for configurations where include_path
didn't include the current directory.
See http://www.silverstripe.org/installing-silverstripe/show/20224
for details.
