### PR TITLE
GroupedList: Enable grouping by a function result. Example: Want to grou...

### DIFF
--- a/model/GroupedList.php
+++ b/model/GroupedList.php
@@ -16,7 +16,9 @@ class GroupedList extends SS_ListDecorator {
 		$result = array();
 
 		foreach ($this->list as $item) {
-			$key = is_object($item) ? ($item->$index)?$item->$index:$item->$index() : $item[$index];
+      /* if $item is an Object, $index can be a method or a value,
+       * if $item is an array, $index is used as the index */
+			$key = is_object($item) ? ($item->hasMethod($index) ? $item->$index() : $item->$index) : $item[$index];
 
 			if (array_key_exists($key, $result)) {
 				$result[$key]->push($item);


### PR DESCRIPTION
GroupedList: 

Enable a functionality that worked in SIlverstripe 2.4:
Grouping by a function result. 

Example: Want to group by the Year part of a Date field, build a function Year() that extracts the year from the date, then use GroupedBy(Year) in the template.

(Maybe my fix is a bit dirty, but it works well in my projects)
