### PR TITLE
API Removed permission checks from XML/JSON data formatters

### DIFF
--- a/api/XMLDataFormatter.php
+++ b/api/XMLDataFormatter.php
@@ -139,7 +139,7 @@ class XMLDataFormatter extends DataFormatter {
 		$xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
 		$xml .= (is_numeric($this->totalSize)) ? "<$className totalSize=\"{$this->totalSize}\">\n" : "<$className>\n";
 		foreach($set as $item) {
-			if($item->canView()) $xml .= $this->convertDataObjectWithoutHeader($item, $fields);
+			$xml .= $this->convertDataObjectWithoutHeader($item, $fields);
 		}
 		$xml .= "</$className>";
 	


### PR DESCRIPTION
Handle those checks in the logic using the formatters
instead. Applied permission checks to its primary use case, the "restfulserver" module.
Not removed from JSONDataFormatter because that was already accidentally removed
during the ORM refactoring (separate fix for 3.0 forthcoming with 3.0.3).

See https://github.com/silverstripe/silverstripe-restfulserver/commit/9732ec8932e3046bb394ebd5a2840c871bfe60bb
