### PR TITLE
BUG FormField->removeExtraClass() works on indexed arrays

### DIFF
--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -321,9 +321,9 @@ class FormField extends RequestHandler {
 	 * @param $class String
 	 */
 	public function removeExtraClass($class) {
-		if(isset($this->extraClasses) && array_key_exists($class, $this->extraClasses)) {
-			unset($this->extraClasses[$class]);
-		}
+		$pos = array_search($class, $this->extraClasses);
+		if($pos !== false) unset($this->extraClasses[$pos]);
+
 		return $this;
 	}
 

--- a/tests/forms/FormFieldTest.php
+++ b/tests/forms/FormFieldTest.php
@@ -5,6 +5,22 @@
  */
 class FormFieldTest extends SapphireTest {
 
+	public function testAddExtraClass() {
+		$field = new FormField('MyField');
+		$field->addExtraClass('class1');
+		$field->addExtraClass('class2');
+		$this->assertStringEndsWith('class1 class2', $field->extraClass());
+	}
+
+	public function testRemoveExtraClass() {
+		$field = new FormField('MyField');
+		$field->addExtraClass('class1');
+		$field->addExtraClass('class2');
+		$this->assertStringEndsWith('class1 class2', $field->extraClass());
+		$field->removeExtraClass('class1');
+		$this->assertStringEndsWith('class2', $field->extraClass());
+	}
+
 	public function testAttributes() {
 		$field = new FormField('MyField');
 		$field->setAttribute('foo', 'bar');


### PR DESCRIPTION
Was assuming an associative map, which isn't the case in the current implementations.
