### PR TITLE
Issue #7818: Making UploadField work after page refresh or direct access

### DIFF
--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -149,6 +149,7 @@
 					{
 						fileInput: fileInput,
 						dropZone: dropZone,
+						form: $(fileInput).closest('form'),
 						previewAsCanvas: false,
 						acceptFileTypes: new RegExp(config.acceptFileTypes, 'i')
 					}


### PR DESCRIPTION
It could only find and send the SecurityID if the page was loaded via AJAX (see http://open.silverstripe.org/ticket/7818).  

I've added a line passing

form: $(fileInput).closest('form')

to fileupload which helps it find the form and it's SecurityID field every time.

To test you can go to the upload screen in asset admin (eg admin/assets/add/?ID=1) or edit any page with an UploadField, refresh the browser then try to upload something.  It should now work as expected instead of returning a 400 error.
