### PR TITLE
BUG: DataObject::__construct() now accepts stdClass for $record

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -323,7 +323,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 			);
 		}
 
-		if(!is_array($record)) {
+		if(!is_array($record) && !is_a($record, "stdClass")) {
 			if(is_object($record)) $passed = "an object of type '$record->class'";
 			else $passed = "The value '$record'";
 


### PR DESCRIPTION
DataObject::__construct() currently only accepts an array. This works fine the majority of the time, but a minor enhancement is to allow stdClass to be accepted as well.

The reason for this is that PDO results are often fetched as objects when doing database migrations, so being able to create new DataObjects directly from the results of a PDO statement fetch is very useful.

There should be no side-effects from this, as the additional acceptance is limited to stdClass, which is only produced in cases where an anonymous object is constructed, usually from a typecast to an object, but in certain other cases as well, such as PDOStatement::fetch(PDO::FETCH_OBJ).
