### PR TITLE
BUG: GridField add existing auto complete has no max height (fixes #7965)

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -135,6 +135,7 @@ body, html { font-size: 12px; line-height: 16px; font-family: Arial, sans-serif;
 .cms .ui-widget input, .cms .ui-widget select, .cms .ui-widget textarea, .cms .ui-widget button { color: #444444; font-size: 12px; font-family: Arial, sans-serif; }
 .cms .ui-accordion .ui-accordion-header { border-color: #c0c0c2; margin-bottom: 0; }
 .cms .ui-accordion .ui-accordion-content { border: 1px solid #c0c0c2; border-top: none; }
+.cms .ui-autocomplete { max-height: 240px; overflow-x: hidden; overflow-y: auto; }
 
 /** This file defines common styles for form elements used throughout the CMS interface. It is an addition to the base styles defined in framework/css/Form.css.  @package framework @subpackage admin */
 /** ---------------------------------------------------- Basic form fields ---------------------------------------------------- */

--- a/admin/scss/_uitheme.scss
+++ b/admin/scss/_uitheme.scss
@@ -51,8 +51,7 @@
 		font-size: $font-base-size;
 		font-family: $font-family;
 		border: 0;
-	}
-	
+	}	
 
 	.ui-widget-header {			
 		background-color: darken($color-widget-bg, 20%);
@@ -68,9 +67,7 @@
 		& .ui-dialog-title {
 			padding: 6px 0;
 			text-shadow: lighten($color-base, 10%) 1px 1px 0;
-		}
-		
-		
+		}		
 		
 		& a.ui-dialog-titlebar-close {
 			position:  absolute;
@@ -119,5 +116,11 @@
 			border: 1px solid $color-button-generic-border;
 			border-top: none;
 		}
+	}
+
+	.ui-autocomplete{
+		max-height: 240px;
+		overflow-x: hidden;
+		overflow-y: auto;
 	}
 }

--- a/scss/GridField.scss
+++ b/scss/GridField.scss
@@ -118,7 +118,6 @@ $gf_grid_x:	16px;
 			display: inline-block;
 		}
 	}
-
 	table.ss-gridfield-table {
 		display: table; 
 		@include box-shadow-none;		


### PR DESCRIPTION
Added a maxheight to the ui-autocompleter, as used in gridfield, and specified what to do with overflow.
