### PR TITLE
NEW: Add new method "each" to SS_List

### DIFF
--- a/model/ArrayList.php
+++ b/model/ArrayList.php
@@ -66,6 +66,18 @@ class ArrayList extends ViewableData implements SS_List, SS_Filterable, SS_Sorta
 	public function toArray() {
 		return $this->items;
 	}
+	
+	/**
+	 * Walks the list using the specified callback
+	 *
+	 * @param callable $callback
+	 * @return DataList
+	 */
+	public function each($callback) {
+		foreach($this as $item) {
+			$callback($item);
+		}
+	}
 
 	public function debug() {
 		$val = "<h2>" . $this->class . "</h2><ul>";

--- a/model/DataList.php
+++ b/model/DataList.php
@@ -588,6 +588,20 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 
 		return $result;
 	}
+	
+	/**
+	 * Walks the list using the specified callback
+	 *
+	 * @param callable $callback
+	 * @return DataList
+	 */
+	public function each($callback) {
+		foreach($this as $row) {
+			$callback($row);
+		}
+		
+		return $this;
+	}
 
 	public function debug() {
 		$val = "<h2>" . $this->class . "</h2><ul>";

--- a/model/List.php
+++ b/model/List.php
@@ -77,4 +77,12 @@ interface SS_List extends ArrayAccess, Countable, IteratorAggregate {
 	 * @return array
 	 */
 	public function column($colName = "ID");
+	
+	/**
+	 * Walks the list using the specified callback
+	 *
+	 * @param callable $callback
+	 * @return mixed
+	 */
+	public function each($callback);
 }

--- a/model/ListDecorator.php
+++ b/model/ListDecorator.php
@@ -103,6 +103,10 @@ abstract class SS_ListDecorator extends ViewableData implements SS_List, SS_Sort
 	public function column($value = 'ID') {
 		return $this->list->column($value);
 	}
+	
+	public function each($callback) {
+		return $this->list->each($callback);
+	}
 
 	public function canSortBy($by) {
 		return $this->list->canSortBy($by);

--- a/tests/model/ArrayListTest.php
+++ b/tests/model/ArrayListTest.php
@@ -60,6 +60,21 @@ class ArrayListTest extends SapphireTest {
 			array('First' => 'ThirdFirst', 'Second' => 'ThirdSecond')
 		));
 	}
+	
+	public function testEach() {
+		$list = new ArrayList(array(1, 2, 3));
+		
+		$count = 0;
+		$test = $this;
+		
+		$list->each(function($item) use (&$count, $test) {
+			$count++;
+			
+			$test->assertTrue(is_int($item));
+		});
+		
+		$this->assertEquals($list->Count(), $count);
+	}
 
 	public function testLimit() {
 		$list = new ArrayList(array(

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -179,6 +179,21 @@ class DataListTest extends SapphireTest {
 		$this->assertEquals($otherExpected, $otherMap);
 	}
 	
+	public function testEach() {
+		$list = DataObjectTest_TeamComment::get();
+		
+		$count = 0;
+		$test = $this;
+		
+		$list->each(function($item) use (&$count, $test) {
+			$count++;
+			
+			$test->assertTrue(is_a($item, "DataObjectTest_TeamComment"));
+		});
+		
+		$this->assertEquals($list->Count(), $count);
+	}
+	
 	public function testFilter() {
 		// coming soon!
 		}


### PR DESCRIPTION
Adds a new SS_List::each method, which accepts a callable parameter. This callable is passed each item for the list.

Example usage would be:

SomeObject::get()->filter("ParentID", 0)->each(function($item) {
    $item->delete();
});
