### PR TITLE
BUG: DataObject::write overwrites Created on first write

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1147,7 +1147,13 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 						if($idx == 0) {
 							$manipulation[$class]['fields']["LastEdited"] = "'".SS_Datetime::now()->Rfc2822()."'";
 							if($dbCommand == 'insert') {
-								$manipulation[$class]['fields']["Created"] = "'".SS_Datetime::now()->Rfc2822()."'";
+								if(!empty($this->record["Created"])) {
+									$manipulation[$class]['fields']["Created"]
+										= DB::getConn()->prepStringForDB($this->record["Created"]);
+								} else {
+									$manipulation[$class]['fields']["Created"]
+										= DB::getConn()->prepStringForDB(SS_Datetime::now()->Rfc2822());
+								}
 								//echo "<li>$this->class - " .get_class($this);
 								$manipulation[$class]['fields']["ClassName"]
 									= DB::getConn()->prepStringForDB($this->class);

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -1127,7 +1127,24 @@ class DataObjectTest extends SapphireTest {
 		
 	}
 	
-
+	public function testWriteOverwritesCreated() {
+		// Previously, if you set DataObject::$Created before the object was first written, it would be overwritten
+		$pastdate = new SS_DateTime();
+		$pastdate->setValue(Date::past_date(1));
+		
+		$obj = new DataObjectTest_Player();
+		$obj->Created = $pastdate->Value;
+		$obj->write();
+		
+		$objID = $obj->ID;
+		
+		unset($obj);
+		DataObject::reset();
+		
+		$obj = DataObjectTest_Player::get()->byID($objID);
+		
+		$this->assertEquals($pastdate->Value, $obj->Created);
+	}
 }
 
 class DataObjectTest_Player extends Member implements TestOnly {


### PR DESCRIPTION
DataObject::write currently ignores (and overwrites) the Created field if it's set before the first write of the DataObject to the database. This patch fixes it so that the Created field is used in place of "now", if it's set and non-empty.
