### PR TITLE
BUG: Border at top of tabs when no subtabs

### DIFF
--- a/admin/scss/_style.scss
+++ b/admin/scss/_style.scss
@@ -187,50 +187,6 @@ body.cms {
 			}
 		}
 	}
-
-	.cms-content-fields .ui-tabs-nav {
-		border-bottom: none;
-		float: right;
-		margin: $grid-y 0 -1px 0;
-		padding: 0 $grid-x*3 0 0;
-
-		li {
-			float: left;
-
-			a {
-				font-weight: bold;
-				line-height: $grid-y * 2;
-				padding: $grid-y $grid-x*2.5 $grid-y;
-			}
-		}
-		.ui-state-default,
-		.ui-widget-content .ui-state-default,
-		.ui-widget-header .ui-state-default {
-			border:1px solid $color-button-generic-border;
-		}
-		.ui-state-active,
-		.ui-widget-content .ui-state-active,
-		.ui-widget-header .ui-state-active {
-			padding-bottom:1px;
-			background: $tab-panel-texture-background;
-			border:1px solid $color-button-generic-border;
-		}
-	}
-
-	.ss-tabset {
-		.ss-tabset {
-			position: static;
-		}
-
-		.ui-tabs-panel {
-			border-top:1px solid $color-button-generic-border;
-			clear: both;
-		}
-
-		&.ss-tabset-tabshidden .ui-tabs-panel {
-			border-top: none;
-		}
-	}
 }
 
 /** --------------------------------------------


### PR DESCRIPTION
This bug reappeared when branches were merged because the 3.0 version of _style.scss had tabsets defined in different places.

This scss was inserted, but there was no idication that it was new to master (except in the resulting css file). As these styles are declared differently elsewhere in _style.scss, I think this declaration must have been refactored in an earlier commit in master.
