### PR TITLE
API: Allow setting a test as only needing the database build once

### DIFF
--- a/tests/MemoryLimitTest.php
+++ b/tests/MemoryLimitTest.php
@@ -5,6 +5,8 @@
  */
 
 class MemoryLimitTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testIncreaseMemoryLimitTo() {
 		if(!$this->canChangeMemory()) return;

--- a/tests/PhpSyntaxTest.php
+++ b/tests/PhpSyntaxTest.php
@@ -8,6 +8,8 @@
  * Test the syntax of the PHP files with various settings
  */
 class PhpSyntaxTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	public function setUp() {
 		parent::setUp();
 		$this->markTestSkipped('This needs to be written to include only core php files, not test/thirdparty files');

--- a/tests/api/RSSFeedTest.php
+++ b/tests/api/RSSFeedTest.php
@@ -7,6 +7,8 @@ class RSSFeedTest extends SapphireTest {
 
 	protected static $original_host;
 
+	protected static $build_db_each_test = false;
+
 	public function testRSSFeed() {
 		$list = new ArrayList();
 		$list->push(new RSSFeedTest_ItemA());

--- a/tests/api/RestfulServiceTest.php
+++ b/tests/api/RestfulServiceTest.php
@@ -6,7 +6,9 @@
  */
 class RestfulServiceTest extends SapphireTest {
 	
-	protected $member_unique_identifier_field = ''; 
+	protected $member_unique_identifier_field = '';
+
+	protected static $build_db_each_test = false;
 	
 	public function setUp() {
 		// backup the project unique identifier field

--- a/tests/api/XMLDataFormatterTest.php
+++ b/tests/api/XMLDataFormatterTest.php
@@ -4,6 +4,8 @@ class XMLDataFormatterTest extends SapphireTest {
 
 	public static $fixture_file = 'XMLDataFormatterTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	public function setUp() {
 		ShortcodeParser::get_active()->register('test_shortcode', array($this, 'shortcodeSaver'));
 

--- a/tests/cache/CacheTest.php
+++ b/tests/cache/CacheTest.php
@@ -2,6 +2,8 @@
 
 class CacheTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function testCacheBasics() {
 		$cache = SS_Cache::factory('test');
 		

--- a/tests/control/ControllerTest.php
+++ b/tests/control/ControllerTest.php
@@ -4,6 +4,8 @@ class ControllerTest extends FunctionalTest {
 	
 	static $fixture_file = 'ControllerTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	protected $autoFollowRedirection = false;
 	
 	public function testDefaultAction() {

--- a/tests/control/DirectorTest.php
+++ b/tests/control/DirectorTest.php
@@ -9,6 +9,8 @@ class DirectorTest extends SapphireTest {
 
 	protected static $originalRequestURI;
 
+	protected static $build_db_each_test = false;
+
 	public function setUp() {
 		parent::setUp();
 

--- a/tests/control/HTTPRequestTest.php
+++ b/tests/control/HTTPRequestTest.php
@@ -2,6 +2,8 @@
 
 class HTTPRequestTest extends SapphireTest {
 	static $fixture_file = null;
+
+	protected static $build_db_each_test = false;
 	
 	public function testMatch() {
 		$request = new SS_HTTPRequest("GET", "admin/crm/add");

--- a/tests/control/HTTPResponseTest.php
+++ b/tests/control/HTTPResponseTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class HTTPResponseTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testStatusDescriptionStripsNewlines() {
 		$r = new SS_HTTPResponse('my body', 200, "my description \nwith newlines \rand carriage returns");

--- a/tests/control/HTTPTest.php
+++ b/tests/control/HTTPTest.php
@@ -6,6 +6,8 @@
  * @subpackage tests
  */
 class HTTPTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	/**
 	 * Tests {@link HTTP::getLinksIn()}

--- a/tests/control/NullHTTPRequestTest.php
+++ b/tests/control/NullHTTPRequestTest.php
@@ -5,6 +5,8 @@
  */
 class NullHTTPRequestTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function testAllHttpVerbsAreFalse() {
 		$r = new NullHTTPRequest();
 		$this->assertFalse($r->isGET());

--- a/tests/control/PjaxResponseNegotiatorTest.php
+++ b/tests/control/PjaxResponseNegotiatorTest.php
@@ -1,5 +1,7 @@
 <?php
 class PjaxResponseNegotiatorTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testDefaultCallbacks() {
 		$negotiator = new PjaxResponseNegotiator(array(

--- a/tests/control/RequestHandlingTest.php
+++ b/tests/control/RequestHandlingTest.php
@@ -6,6 +6,8 @@
  */
 class RequestHandlingTest extends FunctionalTest {
 	static $fixture_file = null;
+
+	protected static $build_db_each_test = false;
 	
 	// public function testRequestHandlerChainingLatestParams() {
 	// 	$c = new RequestHandlingTest_Controller();

--- a/tests/control/SessionTest.php
+++ b/tests/control/SessionTest.php
@@ -8,6 +8,8 @@
  */
 
 class SessionTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testGetSetBasics() {
 		Session::set('Test', 'Test');

--- a/tests/core/ArrayDataTest.php
+++ b/tests/core/ArrayDataTest.php
@@ -2,6 +2,8 @@
 
 class ArrayDataTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function testViewabledataItemsInsideArraydataArePreserved() {
 		/* ViewableData objects will be preserved, but other objects will be converted */
 		$arrayData = new ArrayData(array(

--- a/tests/core/ArrayLibTest.php
+++ b/tests/core/ArrayLibTest.php
@@ -4,6 +4,9 @@
  * @subpackage tests
  */
 class ArrayLibTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
+	
 	public function testInvert() {
 		$arr = array(
 			'row1' => array(

--- a/tests/core/ClassInfoTest.php
+++ b/tests/core/ClassInfoTest.php
@@ -5,6 +5,8 @@
  */
 class ClassInfoTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function testExists() {
 		$this->assertTrue(ClassInfo::exists('Object'));
 		$this->assertTrue(ClassInfo::exists('ClassInfoTest'));

--- a/tests/core/ConfigTest.php
+++ b/tests/core/ConfigTest.php
@@ -54,6 +54,8 @@ class ConfigStaticTest_Combined3 extends ConfigStaticTest_Combined2 {
 
 class ConfigTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function testUpdateStatic() {
 		$this->assertEquals(Config::inst()->get('ConfigStaticTest_First', 'first', Config::FIRST_SET),
 			array('test_1'));

--- a/tests/core/ConvertTest.php
+++ b/tests/core/ConvertTest.php
@@ -6,6 +6,8 @@
  */
 class ConvertTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	/**
 	 * Tests {@link Convert::raw2att()}
 	 */

--- a/tests/core/CoreTest.php
+++ b/tests/core/CoreTest.php
@@ -8,6 +8,8 @@
  */
 class CoreTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	protected $tempPath;
 
 	public function setUp() {

--- a/tests/core/DiffTest.php
+++ b/tests/core/DiffTest.php
@@ -5,6 +5,8 @@
  */
 
 class DiffTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	/**
 	 * @see https://groups.google.com/forum/#!topic/silverstripe-dev/yHcluCvuszo

--- a/tests/core/HTMLCleanerTest.php
+++ b/tests/core/HTMLCleanerTest.php
@@ -5,6 +5,8 @@
  */
 
 class HTMLCleanerTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testHTMLClean() {
 		$cleaner = HTMLCleaner::inst();

--- a/tests/core/ObjectTest.php
+++ b/tests/core/ObjectTest.php
@@ -8,6 +8,8 @@
  * @todo tests for setting statics through extensions (#2387)
  */
 class ObjectTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function setUp() {
 		parent::setUp();

--- a/tests/dev/BacktraceTest.php
+++ b/tests/dev/BacktraceTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class BacktraceTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testFullFuncNameWithArgsAndCustomCharLimit() {
 		$func = array(

--- a/tests/dev/CSVParserTest.php
+++ b/tests/dev/CSVParserTest.php
@@ -1,6 +1,9 @@
 <?php
 
 class CSVParserTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
+	
 	public function testParsingWithHeaders() {
 		/* By default, a CSV file will be interpreted as having headers */
 		$csv = new CSVParser($this->getCurrentRelativePath() . '/CsvBulkLoaderTest_PlayersWithHeader.csv');

--- a/tests/dev/DeprecationTest.php
+++ b/tests/dev/DeprecationTest.php
@@ -12,6 +12,8 @@ class DeprecationTest_Deprecation extends Deprecation {
 
 class DeprecationTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	static $originalVersionInfo;
 
 	public function setUp() {

--- a/tests/dev/LogTest.php
+++ b/tests/dev/LogTest.php
@@ -5,6 +5,8 @@
  */
 class SS_LogTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	protected $testEmailWriter;
 
 	public function setUp() {

--- a/tests/filesystem/FileFinderTest.php
+++ b/tests/filesystem/FileFinderTest.php
@@ -9,6 +9,8 @@ class FileFinderTest extends SapphireTest {
 
 	protected $base;
 
+	protected static $build_db_each_test = false;
+
 	public function __construct() {
 		$this->base = dirname(__FILE__) . '/fixtures/filefinder';
 		parent::__construct();

--- a/tests/filesystem/FileNameFilterTest.php
+++ b/tests/filesystem/FileNameFilterTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class FileNameFilterTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testFilter() {
 		$name = 'Brötchen  für allë-mit_Unterstrich!.jpg';

--- a/tests/forms/CompositeFieldTest.php
+++ b/tests/forms/CompositeFieldTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class CompositeFieldTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testFieldPosition() {
 		$compositeOuter = new CompositeField(

--- a/tests/forms/ConfirmedPasswordFieldTest.php
+++ b/tests/forms/ConfirmedPasswordFieldTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class ConfirmedPasswordFieldTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	public function testSetValue() {
 		$field = new ConfirmedPasswordField('Test', 'Testing', 'valueA');
 		$this->assertEquals('valueA', $field->Value());

--- a/tests/forms/CurrencyFieldTest.php
+++ b/tests/forms/CurrencyFieldTest.php
@@ -6,6 +6,8 @@
  */
 class CurrencyFieldTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function testValidate() {
 		$f = new CurrencyField('TestField');
 		

--- a/tests/forms/DateFieldTest.php
+++ b/tests/forms/DateFieldTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class DateFieldTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function setUp() {
 		parent::setUp();

--- a/tests/forms/DatefieldViewJQueryTest.php
+++ b/tests/forms/DatefieldViewJQueryTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class DateFieldViewJQueryTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testConvert() {
 		$this->assertEquals(

--- a/tests/forms/DatetimeFieldTest.php
+++ b/tests/forms/DatetimeFieldTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class DatetimeFieldTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function setUp() {
 		parent::setUp();

--- a/tests/forms/DropdownFieldTest.php
+++ b/tests/forms/DropdownFieldTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class DropdownFieldTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testGetSource() {
 		$source = array(1=>'one');

--- a/tests/forms/EmailFieldTest.php
+++ b/tests/forms/EmailFieldTest.php
@@ -2,6 +2,8 @@
 
 class EmailFieldTest extends FunctionalTest {
 
+	protected static $build_db_each_test = false;
+
 	/**
 	 * Check the php validator for email addresses. We should be checking against RFC 5322 which defines email address
 	 * syntax.

--- a/tests/forms/FieldListTest.php
+++ b/tests/forms/FieldListTest.php
@@ -20,6 +20,8 @@
  */
 class FieldListTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	/**
 	 * Test adding a field to a tab in a set.
 	 */

--- a/tests/forms/FileFieldTest.php
+++ b/tests/forms/FileFieldTest.php
@@ -5,6 +5,8 @@
  */
 class FileFieldTest extends FunctionalTest {
 
+	protected static $build_db_each_test = false;
+
 	/** 
 	 * Test a valid upload of a required file in a form. Error is set to 0, as the upload went well 
 	 */

--- a/tests/forms/FormActionTest.php
+++ b/tests/forms/FormActionTest.php
@@ -5,6 +5,8 @@
  * @subpackage tests
  */
 class FormActionTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testGetField() {
 		$formAction = new FormAction('test');

--- a/tests/forms/FormFieldTest.php
+++ b/tests/forms/FormFieldTest.php
@@ -5,6 +5,8 @@
  */
 class FormFieldTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function testAddExtraClass() {
 		$field = new FormField('MyField');
 		$field->addExtraClass('class1');

--- a/tests/forms/FormScaffolderTest.php
+++ b/tests/forms/FormScaffolderTest.php
@@ -11,6 +11,8 @@ class FormScaffolderTest extends SapphireTest {
 	
 	static $fixture_file = 'FormScaffolderTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	protected $extraDataObjects = array(
 		'FormScaffolderTest_Article',
 		'FormScaffolderTest_Tag',

--- a/tests/forms/FormTest.php
+++ b/tests/forms/FormTest.php
@@ -7,6 +7,8 @@ class FormTest extends FunctionalTest {
 	
 	static $fixture_file = 'FormTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	protected $extraDataObjects = array(
 		'FormTest_Player',
 		'FormTest_Team',

--- a/tests/forms/GridFieldTest.php
+++ b/tests/forms/GridFieldTest.php
@@ -1,6 +1,8 @@
 <?php
 class GridFieldTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	/**
 	 * @covers GridField::__construct
 	 */

--- a/tests/forms/HtmlEditorConfigTest.php
+++ b/tests/forms/HtmlEditorConfigTest.php
@@ -5,6 +5,8 @@
  */
 class HtmlEditorConfigTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function testEnablePluginsByString() {
 		$c = new HtmlEditorConfig();
 		$c->enablePlugins('plugin1');

--- a/tests/forms/HtmlEditorFieldTest.php
+++ b/tests/forms/HtmlEditorFieldTest.php
@@ -6,6 +6,8 @@
 class HtmlEditorFieldTest extends FunctionalTest {
 	
 	public static $fixture_file = 'HtmlEditorFieldTest.yml';
+
+	protected static $build_db_each_test = false;
 	
 	public static $use_draft_site = true;
 	

--- a/tests/forms/ListboxFieldTest.php
+++ b/tests/forms/ListboxFieldTest.php
@@ -7,6 +7,8 @@
 class ListboxFieldTest extends SapphireTest {
 
 	static $fixture_file = 'ListboxFieldTest.yml';
+
+	protected static $build_db_each_test = false;
 	
 	protected $extraDataObjects = array('ListboxFieldTest_DataObject', 'ListboxFieldTest_Article',
 		'ListboxFieldTest_Tag');

--- a/tests/forms/LookupFieldTest.php
+++ b/tests/forms/LookupFieldTest.php
@@ -8,6 +8,8 @@ class LookupFieldTest extends SapphireTest {
 	
 	static $fixture_file = 'LookupFieldTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	public function testNullValueWithNumericArraySource() {
 		$source = array(1 => 'one', 2 => 'two', 3 => 'three');
 		$f = new LookupField('test', 'test', $source);

--- a/tests/forms/MemberDatetimeOptionsetFieldTest.php
+++ b/tests/forms/MemberDatetimeOptionsetFieldTest.php
@@ -7,6 +7,8 @@ class MemberDatetimeOptionsetFieldTest extends SapphireTest {
 
 	public static $fixture_file = 'MemberDatetimeOptionsetFieldTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	protected function createDateFormatFieldForMember($member) {
 		require_once 'Zend/Date.php';
 		$defaultDateFormat = Zend_Locale_Format::getDateFormat($member->Locale);

--- a/tests/forms/MoneyFieldTest.php
+++ b/tests/forms/MoneyFieldTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class MoneyFieldTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	protected $extraDataObjects = array(
 		'MoneyFieldTest_Object',

--- a/tests/forms/NullableFieldTests.php
+++ b/tests/forms/NullableFieldTests.php
@@ -7,6 +7,8 @@
  *
  */
 class NullableFieldTests extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	/**
 	 * Test that the NullableField works when it wraps a TextField containing actual content

--- a/tests/forms/OptionsetFieldTest.php
+++ b/tests/forms/OptionsetFieldTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class OptionsetFieldTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	public function testSetDisabledItems() {
 		$f = new OptionsetField(
 			'Test', 

--- a/tests/forms/RequirementsTest.php
+++ b/tests/forms/RequirementsTest.php
@@ -7,6 +7,8 @@
  * @todo Figure out how to clear the modified state of Requirements class - might affect other tests.
  */
 class RequirementsTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	static $html_template = '<html><head></head><body></body></html>';
 	

--- a/tests/forms/TextareaFieldTest.php
+++ b/tests/forms/TextareaFieldTest.php
@@ -2,6 +2,8 @@
 
 class TextareaFieldTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	/**
 	 * Quick smoke test to ensure that text is being encoded properly.
 	 */

--- a/tests/forms/TimeFieldTest.php
+++ b/tests/forms/TimeFieldTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class TimeFieldTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function setUp() {
 		parent::setUp();

--- a/tests/forms/gridfield/GridFieldAddExistingAutocompleterTest.php
+++ b/tests/forms/gridfield/GridFieldAddExistingAutocompleterTest.php
@@ -3,6 +3,8 @@ class GridFieldAddExistingAutocompleterTest extends FunctionalTest {
 
 	static $fixture_file = 'GridFieldTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	protected $extraDataObjects = array('GridFieldTest_Team', 'GridFieldTest_Player');
 	
 	public function testSearch() {

--- a/tests/forms/gridfield/GridFieldConfigTest.php
+++ b/tests/forms/gridfield/GridFieldConfigTest.php
@@ -6,6 +6,8 @@
 
 class GridFieldConfigTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function testGetComponents() {
 		$config = GridFieldConfig::create();
 		$this->assertInstanceOf('ArrayList', $config->getComponents());

--- a/tests/forms/gridfield/GridFieldDataColumnsTest.php
+++ b/tests/forms/gridfield/GridFieldDataColumnsTest.php
@@ -1,6 +1,8 @@
 <?php
 class GridFieldDataColumnsTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	/**
 	 * @covers GridFieldDataColumns::getDisplayFields
 	 */

--- a/tests/forms/gridfield/GridFieldDetailFormTest.php
+++ b/tests/forms/gridfield/GridFieldDetailFormTest.php
@@ -3,6 +3,8 @@
 class GridFieldDetailFormTest extends FunctionalTest {
 	static $fixture_file = 'GridFieldDetailFormTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	protected $extraDataObjects = array(
 		'GridFieldDetailFormTest_Person',
 		'GridFieldDetailFormTest_PeopleGroup',
@@ -65,45 +67,6 @@ class GridFieldDetailFormTest extends FunctionalTest {
 		$this->assertFalse($response->isError());
 		$this->assertEquals('Jane', (string) $firstName[0]);
 		$this->assertEquals('Doe', (string) $surname[0]);
-	}
-
-	public function testEditForm() {
-		$this->logInWithPermission('ADMIN');
-		$group = GridFieldDetailFormTest_PeopleGroup::get()
-			->filter('Name', 'My Group')
-			->sort('Name')
-			->First();
-		$firstperson = $group->People()->First();
-		$this->assertTrue($firstperson->Surname != 'Baggins');
-
-		$response = $this->get('GridFieldDetailFormTest_Controller');
-		$this->assertFalse($response->isError());
-		$parser = new CSSContentParser($response->getBody());
-		$editlinkitem = $parser->getBySelector('.ss-gridfield-items .first .edit-link');
-		$editlink = (string) $editlinkitem[0]['href'];
-
-		$response = $this->get($editlink);
-		$this->assertFalse($response->isError());
-
-		$parser = new CSSContentParser($response->getBody());
-		$editform = $parser->getBySelector('#Form_ItemEditForm');
-		$editformurl = (string) $editform[0]['action'];
-		
-		$response = $this->post(
-			$editformurl,
-			array(
-				'FirstName' => 'Bilbo',
-				'Surname' => 'Baggins',
-				'action_doSave' => 1
-			)
-		);
-		$this->assertFalse($response->isError());
-
-		$group = GridFieldDetailFormTest_PeopleGroup::get()
-			->filter('Name', 'My Group')
-			->sort('Name')
-			->First();
-		$this->assertDOSContains(array(array('Surname' => 'Baggins')), $group->People());
 	}
 
 	public function testNestedEditForm() {
@@ -176,6 +139,45 @@ class GridFieldDetailFormTest extends FunctionalTest {
 		);
 		$form = $request->ItemEditForm();
 		$this->assertNotNull($form->Fields()->fieldByName('Callback'));
+	}
+
+	public function testEditForm() {
+		$this->logInWithPermission('ADMIN');
+		$group = GridFieldDetailFormTest_PeopleGroup::get()
+			->filter('Name', 'My Group')
+			->sort('Name')
+			->First();
+		$firstperson = $group->People()->First();
+		$this->assertTrue($firstperson->Surname != 'Baggins');
+
+		$response = $this->get('GridFieldDetailFormTest_Controller');
+		$this->assertFalse($response->isError());
+		$parser = new CSSContentParser($response->getBody());
+		$editlinkitem = $parser->getBySelector('.ss-gridfield-items .first .edit-link');
+		$editlink = (string) $editlinkitem[0]['href'];
+
+		$response = $this->get($editlink);
+		$this->assertFalse($response->isError());
+
+		$parser = new CSSContentParser($response->getBody());
+		$editform = $parser->getBySelector('#Form_ItemEditForm');
+		$editformurl = (string) $editform[0]['action'];
+		
+		$response = $this->post(
+			$editformurl,
+			array(
+				'FirstName' => 'Bilbo',
+				'Surname' => 'Baggins',
+				'action_doSave' => 1
+			)
+		);
+		$this->assertFalse($response->isError());
+
+		$group = GridFieldDetailFormTest_PeopleGroup::get()
+			->filter('Name', 'My Group')
+			->sort('Name')
+			->First();
+		$this->assertDOSContains(array(array('Surname' => 'Baggins')), $group->People());
 	}
 }
 

--- a/tests/forms/gridfield/GridFieldEditButtonTest.php
+++ b/tests/forms/gridfield/GridFieldEditButtonTest.php
@@ -14,6 +14,8 @@ class GridFieldEditButtonTest extends SapphireTest {
 	/** @var string */
 	public static $fixture_file = 'GridFieldActionTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	/** @var array */
 	protected $extraDataObjects = array('GridFieldAction_Delete_Team', 'GridFieldAction_Edit_Team');
 	

--- a/tests/forms/gridfield/GridFieldExportButtonTest.php
+++ b/tests/forms/gridfield/GridFieldExportButtonTest.php
@@ -9,6 +9,8 @@ class GridFieldExportButtonTest extends SapphireTest {
 
 	public static $fixture_file = 'GridFieldExportButtonTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	protected $extraDataObjects = array(
 		'GridFieldExportButtonTest_Team'
 	);

--- a/tests/forms/gridfield/GridFieldPaginatorTest.php
+++ b/tests/forms/gridfield/GridFieldPaginatorTest.php
@@ -8,6 +8,8 @@ class GridFieldPaginatorTest extends FunctionalTest {
 	
 	/** @var string */
 	static $fixture_file = 'GridFieldTest.yml';
+
+	protected static $build_db_each_test = false;
 	
 	/** @var Form */
 	protected $form;

--- a/tests/forms/gridfield/GridField_URLHandlerTest.php
+++ b/tests/forms/gridfield/GridField_URLHandlerTest.php
@@ -4,6 +4,8 @@
  * Test the API for creating GridField_URLHandler compeonnts
  */
 class GridField_URLHandlerTest extends FunctionalTest {
+
+	protected static $build_db_each_test = false;
 	public function testFormSubmission() {
 		$result = $this->get("GridField_URLHandlerTest_Controller/Form/field/Grid/showform");
 		$formResult = $this->submitForm('Form_Form', 'action_doAction', array('Test' => 'foo bar') );

--- a/tests/i18n/i18nSSLegacyAdapterTest.php
+++ b/tests/i18n/i18nSSLegacyAdapterTest.php
@@ -6,6 +6,8 @@
 
 class i18nSSLegacyAdapterTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function setUp() {
 		parent::setUp();
 		

--- a/tests/i18n/i18nTest.php
+++ b/tests/i18n/i18nTest.php
@@ -6,6 +6,8 @@ require_once 'Zend/Translate.php';
  * @subpackage tests
  */
 class i18nTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	/**
 	 * @var string $tmpBasePath Used to write language files.

--- a/tests/i18n/i18nTextCollectorTest.php
+++ b/tests/i18n/i18nTextCollectorTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class i18nTextCollectorTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	/**
 	 * @var string $tmpBasePath Used to write language files.

--- a/tests/injector/InjectorTest.php
+++ b/tests/injector/InjectorTest.php
@@ -11,6 +11,8 @@ define('TEST_SERVICES', dirname(__FILE__) . '/testservices');
  * @license BSD License http://silverstripe.org/bsd-license/
  */
 class InjectorTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testCorrectlyInitialised() {
 		$injector = Injector::inst();

--- a/tests/integration/HTMLValueTest.php
+++ b/tests/integration/HTMLValueTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class SS_HTMLValueTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testInvalidHTMLSaving() {
 		$value = new SS_HTMLValue();

--- a/tests/model/AggregateTest.php
+++ b/tests/model/AggregateTest.php
@@ -52,6 +52,8 @@ class AggregateTest_Baz extends DataObject implements TestOnly {
 
 class AggregateTest extends SapphireTest {
 	static $fixture_file = 'AggregateTest.yml';
+
+	protected static $build_db_each_test = false;
 	
 	protected $extraDataObjects = array(
 		'AggregateTest_Foo',
@@ -89,7 +91,6 @@ class AggregateTest extends SapphireTest {
 		$this->assertEquals($foo->Aggregate('AggregateTest_Foo')->Max('Foo'), 9);
 		$this->assertEquals($foo->Aggregate('AggregateTest_Fab')->Max('Fab'), 3);
 	}
-	/* */
 	
 	/**
 	 * Test basic aggregation on a given dataobject
@@ -107,7 +108,6 @@ class AggregateTest extends SapphireTest {
 		$this->assertEquals($foo->Aggregate()->Max('Foo'), 9);
 		$this->assertEquals($fab->Aggregate()->Max('Fab'), 3);
 	}
-	/* */
 	
 	/**
 	 * Test base-level field access - was failing due to use of custom_database_fields, not just database_fields
@@ -126,7 +126,6 @@ class AggregateTest extends SapphireTest {
 			$this->formatDate(DataObject::get_one('AggregateTest_Foo', '', '', '"Created" DESC')->Created)
 		);
 	}
-	/* */
 
 	/**
 	 * Test aggregation takes place on the passed type & it's children only
@@ -142,7 +141,6 @@ class AggregateTest extends SapphireTest {
 		$this->assertEquals($foo->Aggregate('AggregateTest_Fac')->Max('Foo'), 6);
 		
 	}
-	/* */
 
 	/**
 	 * Test aggregates are cached properly
@@ -150,7 +148,17 @@ class AggregateTest extends SapphireTest {
 	public function testCache() {
 		
 	}
-	/* */
+	
+	/**
+	 * Test basic relationship aggregation
+	 */
+	public function testRelationshipAggregate() {
+		$bar1 = $this->objFromFixture('AggregateTest_Bar', 'bar1');
+		$this->assertEquals($bar1->RelationshipAggregate('Foos')->Max('Foo'), 8);
+
+		$baz1 = $this->objFromFixture('AggregateTest_Baz', 'baz1');
+		$this->assertEquals($baz1->RelationshipAggregate('Foos')->Max('Foo'), 8);
+	}
 	
 	/**
 	 * Test cache is correctly flushed on write
@@ -186,19 +194,6 @@ class AggregateTest extends SapphireTest {
 		$this->assertEquals($fab->Aggregate('AggregateTest_Fab')->Max('Foo'), 15);
 		$this->assertEquals($fab->Aggregate('AggregateTest_Fac')->Max('Foo'), 6);
 	}
-	/* */
-	
-	/**
-	 * Test basic relationship aggregation
-	 */
-	public function testRelationshipAggregate() {
-		$bar1 = $this->objFromFixture('AggregateTest_Bar', 'bar1');
-		$this->assertEquals($bar1->RelationshipAggregate('Foos')->Max('Foo'), 8);
-
-		$baz1 = $this->objFromFixture('AggregateTest_Baz', 'baz1');
-		$this->assertEquals($baz1->RelationshipAggregate('Foos')->Max('Foo'), 8);
-	}
-	/* */
 	
 	/**
 	 * Copied from DataObject::__construct(), special case for MSSQLDatabase.

--- a/tests/model/ArrayListTest.php
+++ b/tests/model/ArrayListTest.php
@@ -5,6 +5,8 @@
  */
 class ArrayListTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function testArrayAccessExists() {
 		$list = new ArrayList(array(
 			$one = new DataObject(array('Title' => 'one')),

--- a/tests/model/ComponentSetTest.php
+++ b/tests/model/ComponentSetTest.php
@@ -6,6 +6,8 @@
 class ComponentSetTest extends SapphireTest {
 	
 	static $fixture_file = 'ComponentSetTest.yml';
+
+	protected static $build_db_each_test = false;
 	
 	protected $extraDataObjects = array(
 		'ComponentSetTest_Player',

--- a/tests/model/CompositeDBFieldTest.php
+++ b/tests/model/CompositeDBFieldTest.php
@@ -5,6 +5,8 @@
  */
 class CompositeDBFieldTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	protected $extraDataObjects = array(
 		'CompositeDBFieldTest_DataObject',
 		'SubclassedDBFieldObject',

--- a/tests/model/CurrencyTest.php
+++ b/tests/model/CurrencyTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class CurrencyTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	public function testNiceFormatting() {
 		// Test a bunch of different data values and results in Nice() and Whole()
 		$tests = array(

--- a/tests/model/DBFieldTest.php
+++ b/tests/model/DBFieldTest.php
@@ -8,6 +8,8 @@
  *
  */
 class DBFieldTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	/**
 	 * Test the nullValue() method on DBField.

--- a/tests/model/DBLocaleTest.php
+++ b/tests/model/DBLocaleTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class DBLocaleTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	public function testNice() {
 		$l = DBField::create_field('DBLocale', 'de_DE');
 		$this->assertEquals($l->Nice(), 'German');

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -557,25 +557,6 @@ class DataListTest extends SapphireTest {
 		);
 	}
 
-	public function testFilterAndExcludeById() {
-		$id = $this->idFromFixture('DataObjectTest_SubTeam', 'subteam1');
-		$list = DataObjectTest_SubTeam::get()->filter('ID', $id);
-		$this->assertEquals($id, $list->first()->ID);
-
-		$list = DataObjectTest_SubTeam::get();
-		$this->assertEquals(3, count($list));
-		$this->assertEquals(2, count($list->exclude('ID', $id)));
-
-		// Check that classes with namespaces work.
-		$obj = new DataObjectTest\NamespacedClass();
-		$obj->Name = "Test";
-		$obj->write();
-
-		$list = DataObjectTest\NamespacedClass::get()->filter('ID', $obj->ID);
-		$this->assertEquals('Test', $list->First()->Name);
-		$this->assertEquals(0, $list->exclude('ID', $obj->ID)->count());
-	}
-
 	/**
 	 * $list->exclude('Name', 'bob'); // exclude bob from list
 	 */
@@ -734,5 +715,24 @@ class DataListTest extends SapphireTest {
 			'Team 2',
 			'Team 1',
 		), $list->column("Title"));
+	}
+
+	public function testFilterAndExcludeById() {
+		$id = $this->idFromFixture('DataObjectTest_SubTeam', 'subteam1');
+		$list = DataObjectTest_SubTeam::get()->filter('ID', $id);
+		$this->assertEquals($id, $list->first()->ID);
+
+		$list = DataObjectTest_SubTeam::get();
+		$this->assertEquals(3, count($list));
+		$this->assertEquals(2, count($list->exclude('ID', $id)));
+
+		// Check that classes with namespaces work.
+		$obj = new DataObjectTest\NamespacedClass();
+		$obj->Name = "Test";
+		$obj->write();
+
+		$list = DataObjectTest\NamespacedClass::get()->filter('ID', $obj->ID);
+		$this->assertEquals('Test', $list->First()->Name);
+		$this->assertEquals(0, $list->exclude('ID', $obj->ID)->count());
 	}
 }

--- a/tests/model/DataQueryTest.php
+++ b/tests/model/DataQueryTest.php
@@ -1,6 +1,8 @@
 <?php
 
 class DataQueryTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	/**
 	 * Test the leftJoin() and innerJoin method of the DataQuery object
 	 */

--- a/tests/model/DateTest.php
+++ b/tests/model/DateTest.php
@@ -7,6 +7,8 @@ class DateTest extends SapphireTest {
 	
 	protected $originalTZ;
 
+	protected static $build_db_each_test = false;
+
 	public function setUp() {
 		// Set timezone to support timestamp->date conversion.
 		$this->originalTZ = date_default_timezone_get();

--- a/tests/model/DatetimeTest.php
+++ b/tests/model/DatetimeTest.php
@@ -11,6 +11,8 @@
  * @subpackage tests
  */
 class SS_DatetimeTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	public function testNowWithSystemDate() {
 		$systemDatetime = DBField::create_field('SS_Datetime', date('Y-m-d H:i:s'));
 		$nowDatetime = SS_Datetime::now();

--- a/tests/model/DbDatetimeTest.php
+++ b/tests/model/DbDatetimeTest.php
@@ -3,6 +3,8 @@
 class DbDatetimeTest extends FunctionalTest {
 
 	static $fixture_file = 'DbDatetimeTest.yml';
+
+	protected static $build_db_each_test = false;
 	
 	protected $extraDataObjects = array('DbDatetimeTest_Team');
 

--- a/tests/model/DecimalTest.php
+++ b/tests/model/DecimalTest.php
@@ -7,6 +7,8 @@ class DecimalTest extends SapphireTest {
 
 	public static $fixture_file = 'DecimalTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	protected $testDataObject;
 	
 	protected $extraDataObjects = array(

--- a/tests/model/GDImageTest.php
+++ b/tests/model/GDImageTest.php
@@ -9,6 +9,14 @@ class GDImageTest extends ImageTest {
 		}
 	
 		parent::setUp();
+	}
+
+	public function setUpOnce() {
+		parent::setUpOnce();
+
+		if(!extension_loaded("gd")) {
+			return;
+		}
 		
 		Image::set_backend("GDBackend");
 		

--- a/tests/model/GroupedListTest.php
+++ b/tests/model/GroupedListTest.php
@@ -7,6 +7,8 @@
  */
 class GroupedListTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function testGroupBy() {
 		$list = new GroupedList(new ArrayList(array(
 			array('Name' => 'AAA'),

--- a/tests/model/HTMLTextTest.php
+++ b/tests/model/HTMLTextTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class HTMLTextTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	/**
 	 * Test {@link HTMLText->LimitCharacters()}

--- a/tests/model/HasManyListTest.php
+++ b/tests/model/HasManyListTest.php
@@ -1,6 +1,8 @@
 <?php
 
 class HasManyListTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	// Borrow the model from DataObjectTest
 	public static $fixture_file = 'DataObjectTest.yml';

--- a/tests/model/ImageTest.php
+++ b/tests/model/ImageTest.php
@@ -7,14 +7,16 @@
 class ImageTest extends SapphireTest {
 	
 	static $fixture_file = 'ImageTest.yml';
+
+	protected static $build_db_each_test = false;
 	
 	protected $origBackend;
 	
-	public function setUp() {
+	public function setUpOnce() {
 		if(get_class($this) == "ImageTest")
 			$this->skipTest = true;
 	
-		parent::setUp();
+		parent::setUpOnce();
 		
 		if($this->skipTest)
 			return;
@@ -33,26 +35,20 @@ class ImageTest extends SapphireTest {
 		}
 	}
 	
-	public function tearDown() {
+	public function tearDownOnce() {
 		Image::set_backend($this->origBackend);
 	
 		/* Remove the test files that we've created */
 		$fileIDs = $this->allFixtureIDs('Image');
 		foreach($fileIDs as $fileID) {
 			$file = DataObject::get_by_id('Image', $fileID);
-			if($file && file_exists(BASE_PATH."/$file->Filename")) unlink(BASE_PATH."/$file->Filename");
-		}
-
-		/* Remove the test folders that we've crated */
-		$folderIDs = $this->allFixtureIDs('Folder');
-		foreach($folderIDs as $folderID) {
-			$folder = DataObject::get_by_id('Folder', $folderID);
-			if($folder && file_exists(BASE_PATH."/$folder->Filename")) {
-				Filesystem::removeFolder(BASE_PATH."/$folder->Filename");
-			}
+			$image = imagecreatetruecolor(300,300);
+		
+			imagepng($image, BASE_PATH."/$file->Filename");
+			imagedestroy($image);
 		}
 		
-		parent::tearDown();
+		parent::tearDownOnce();
 	}
 	
 	public function testGetTagWithTitle() {

--- a/tests/model/ImagickImageTest.php
+++ b/tests/model/ImagickImageTest.php
@@ -9,6 +9,14 @@ class ImagickImageTest extends ImageTest {
 		}
 		
 		parent::setUp();
+	}
+
+	public function setUpOnce() {
+		parent::setUpOnce();
+
+		if(!extension_loaded("imagick")) {
+			return;
+		}
 		
 		Image::set_backend("ImagickBackend");
 		

--- a/tests/model/LabelFieldTest.php
+++ b/tests/model/LabelFieldTest.php
@@ -6,6 +6,8 @@
 
 class LabelFieldTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function testFieldHasNoNameAttribute() {
 		$field = new LabelField('MyName', 'MyTitle');
 		$this->assertEquals($field->Field(), '<label id="MyName" class="readonly">MyTitle</label>');

--- a/tests/model/MapTest.php
+++ b/tests/model/MapTest.php
@@ -4,6 +4,8 @@ class SS_MapTest extends SapphireTest {
 	// Borrow the model from DataObjectTest
 	static $fixture_file = 'DataObjectTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	protected $extraDataObjects = array(
 		'DataObjectTest_Team',
 		'DataObjectTest_Fixture',

--- a/tests/model/PaginatedListTest.php
+++ b/tests/model/PaginatedListTest.php
@@ -9,6 +9,8 @@ class PaginatedListTest extends SapphireTest {
 
 	static $fixture_file = 'DataObjectTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	protected $extraDataObjects = array(
 		'DataObjectTest_Team',		
 		'DataObjectTest_SubTeam',

--- a/tests/model/PercentageTest.php
+++ b/tests/model/PercentageTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class PercentageTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testNice() {
 		/* Test the default Nice() output of Percentage */

--- a/tests/model/SQLQueryTest.php
+++ b/tests/model/SQLQueryTest.php
@@ -4,6 +4,8 @@ class SQLQueryTest extends SapphireTest {
 	
 	static $fixture_file = null;
 
+	protected static $build_db_each_test = false;
+
 	protected $extraDataObjects = array(
 		'SQLQueryTest_DO',
 	);

--- a/tests/model/StringFieldTest.php
+++ b/tests/model/StringFieldTest.php
@@ -5,6 +5,8 @@
  */
 
 class StringFieldTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	/**
 	 * @covers StringField->LowerCase()

--- a/tests/model/TextTest.php
+++ b/tests/model/TextTest.php
@@ -5,6 +5,8 @@
  */
 class TextTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	/**
 	 * Test {@link Text->LimitCharacters()}
 	 */

--- a/tests/model/URLSegmentFilterTest.php
+++ b/tests/model/URLSegmentFilterTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class URLSegmentFilterTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testReplacesCommonEnglishSymbols() {
 		$f = new URLSegmentFilter();

--- a/tests/oembed/OembedTest.php
+++ b/tests/oembed/OembedTest.php
@@ -1,6 +1,8 @@
 <?php
 
 class OembedTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	public function testGetOembedFromUrl() {
 		Config::inst()->update('Oembed', 'providers', array(
 			'http://*.silverstripe.com/watch*'=>'http://www.silverstripe.com/oembed/'

--- a/tests/parsers/SQLFormatterTest.php
+++ b/tests/parsers/SQLFormatterTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class SQLFormatterTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testNewlineHanding() {
 		$formatter = new SQLFormatter();

--- a/tests/parsers/ShortcodeParserTest.php
+++ b/tests/parsers/ShortcodeParserTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class ShortcodeParserTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	protected $arguments, $contents, $tagName, $parser;
 	

--- a/tests/search/FulltextSearchableTest.php
+++ b/tests/search/FulltextSearchableTest.php
@@ -6,6 +6,8 @@
 
 class FulltextSearchableTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function setUp() {
 		parent::setUp();
 		

--- a/tests/search/SearchContextTest.php
+++ b/tests/search/SearchContextTest.php
@@ -4,6 +4,8 @@ class SearchContextTest extends SapphireTest {
 	
 	static $fixture_file = 'SearchContextTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	protected $extraDataObjects = array(
 		'SearchContextTest_Person',
 		'SearchContextTest_Book',

--- a/tests/search/SearchFilterApplyRelationTest.php
+++ b/tests/search/SearchFilterApplyRelationTest.php
@@ -10,6 +10,8 @@
  */
 class SearchFilterApplyRelationTest extends SapphireTest{
 	static $fixture_file = 'SearchFilterApplyRelationTest.yml';
+
+	protected static $build_db_each_test = false;
 	
 	protected $extraDataObjects = array(
 		'SearchFilterApplyRelationTest_DO',

--- a/tests/security/BasicAuthTest.php
+++ b/tests/security/BasicAuthTest.php
@@ -10,6 +10,8 @@ class BasicAuthTest extends FunctionalTest {
 
 	static $fixture_file = 'BasicAuthTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	public function setUp() {
 		parent::setUp();
 

--- a/tests/security/PasswordEncryptorTest.php
+++ b/tests/security/PasswordEncryptorTest.php
@@ -1,6 +1,8 @@
 <?php
 class PasswordEncryptorTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	/**
 	 *
 	 * @var Config

--- a/tests/security/PasswordValidatorTest.php
+++ b/tests/security/PasswordValidatorTest.php
@@ -5,6 +5,8 @@
  */
 
 class PasswordValidatorTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testValidate() {
 		$v = new PasswordValidator();

--- a/tests/security/PermissionCheckboxSetFieldTest.php
+++ b/tests/security/PermissionCheckboxSetFieldTest.php
@@ -5,6 +5,8 @@
  */
 class PermissionCheckboxSetFieldTest extends SapphireTest {
 	static $fixture_file = 'PermissionCheckboxSetFieldTest.yml';
+
+	protected static $build_db_each_test = false;
 	
 	public function testHiddenPermissions() {
 		$f = new PermissionCheckboxSetField(

--- a/tests/security/PermissionRoleTest.php
+++ b/tests/security/PermissionRoleTest.php
@@ -5,6 +5,8 @@
  */
 class PermissionRoleTest extends FunctionalTest {
 	static $fixture_file = 'PermissionRoleTest.yml';
+
+	protected static $build_db_each_test = false;
 	
 	public function testDelete() {
 		$role = $this->objFromFixture('PermissionRole', 'role');

--- a/tests/security/PermissionTest.php
+++ b/tests/security/PermissionTest.php
@@ -7,6 +7,8 @@
 class PermissionTest extends SapphireTest {
 
 	static $fixture_file = 'PermissionTest.yml';
+
+	protected static $build_db_each_test = false;
 	
 	public function testGetCodesGrouped() {
 		$codes = Permission::get_codes();

--- a/tests/security/RandomGeneratorTest.php
+++ b/tests/security/RandomGeneratorTest.php
@@ -6,6 +6,8 @@
  */
 class RandomGeneratorTest extends SapphireTest {
 
+	protected static $build_db_each_test = false;
+
 	public function testGenerateEntropy() {
 		$r = new RandomGenerator();
 		$this->assertNotNull($r->generateEntropy());

--- a/tests/security/SecurityDefaultAdminTest.php
+++ b/tests/security/SecurityDefaultAdminTest.php
@@ -1,5 +1,7 @@
 <?php
 class SecurityDefaultAdminTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function setUp() {
 		parent::setUp();

--- a/tests/security/SecurityTokenTest.php
+++ b/tests/security/SecurityTokenTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class SecurityTokenTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testIsEnabled() {
 		$inst1 = SecurityToken::inst();

--- a/tests/testing/CSSContentParserTest.php
+++ b/tests/testing/CSSContentParserTest.php
@@ -4,6 +4,8 @@
  * @subpackage tests
  */
 class CSSContentParserTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	public function testSelector2xpath() {
 		$parser = new CSSContentParser("<html><head><title>test</title></head><body><p>test</p></body></html>");
 

--- a/tests/testing/YamlFixtureTest.php
+++ b/tests/testing/YamlFixtureTest.php
@@ -4,6 +4,8 @@ class YamlFixtureTest extends SapphireTest {
 
 	static $fixture_file = 'YamlFixtureTest.yml';
 
+	protected static $build_db_each_test = false;
+
 	protected $extraDataObjects = array(
 		'YamlFixtureTest_DataObject',
 		'YamlFixtureTest_DataObjectRelation',

--- a/tests/view/SSViewerCacheBlockTest.php
+++ b/tests/view/SSViewerCacheBlockTest.php
@@ -21,6 +21,8 @@ class SSViewerCacheBlockTest_Model extends DataObject implements TestOnly {
 }
 
 class SSViewerCacheBlockTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	protected $extraDataObjects = array('SSViewerCacheBlockTest_Model');
 	

--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -1,6 +1,8 @@
 <?php
 
 class SSViewerTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	public function setUp() {
 		parent::setUp();
 		SSViewer::set_source_file_comments(false);

--- a/tests/view/ViewableDataTest.php
+++ b/tests/view/ViewableDataTest.php
@@ -7,6 +7,8 @@
  * @subpackage tests
  */
 class ViewableDataTest extends SapphireTest {
+
+	protected static $build_db_each_test = false;
 	
 	public function testRequiresCasting() {
 		$caster = new ViewableDataTest_Castable();


### PR DESCRIPTION
This adds the static $build_db_each_test to SapphireTest. When set to true,
the database is built for every test method. This is the default and current
behaviour. When set to false, the database is built once for the entire test
class.
