### PR TITLE
BUG Fixing session keep alive for non-ADMIN users

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -80,7 +80,6 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		'updatetreenodes',
 		'printable',
 		'show',
-		'ping',
 		'EditorToolbar',
 		'EditForm',
 		'AddForm',
@@ -398,15 +397,6 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		return $this->getResponseNegotiator()->respond($request);
 	}
 
-	/**
-	 * admin/ping can be visited with ajax to keep a session alive.
-	 * This is used in the CMS.
-	 */
-	public function ping() {
-		Requirements::clear();
-		return 1;
-	}
-	
 	/**
 	 * If this is set to true, the "switchView" context in the
 	 * template is shown, with links to the staging and publish site.

--- a/admin/javascript/LeftAndMain.Ping.js
+++ b/admin/javascript/LeftAndMain.Ping.js
@@ -38,7 +38,7 @@
 				// setup pinging for login expiry
 				setInterval(function() {
 					$.ajax({
-						url: 'admin/security/ping',
+						url: 'Security/ping',
 						global: false,
 						type: 'POST',
 						complete: onSessionLost

--- a/security/Security.php
+++ b/security/Security.php
@@ -14,6 +14,7 @@ class Security extends Controller {
 	    'lostpassword', 
 	    'passwordsent', 
 	    'changepassword', 
+		'ping',
 		'LoginForm',
 		'ChangePasswordForm',
 		'LostPasswordForm',
@@ -294,6 +295,13 @@ class Security extends Controller {
 		return "Security/$action";
 	}
 
+	/**
+	 * This action is available as a keep alive, so user
+	 * sessions don't timeout. A common use is in the admin.
+	 */
+	public function ping() {
+		return 1;
+	}
 
 	/**
 	 * Log the currently logged in user out


### PR DESCRIPTION
SecurityAdmin isn't always available for CMS users, as they might
not have permission to view that section. This fixes the problem
with session keep alive by moving the ping to Security/ping, which
is available for all users.
