### PR TITLE
BUG: UploadField->isSaveable() was returning true with no underlying record

### DIFF
--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -627,7 +627,7 @@ class UploadField extends FileField {
 	public function isSaveable() {
 		$record = $this->getRecord();
 		// Don't allow upload or edit of a relation when the underlying record hasn't been persisted yet
-		return (!$record || !$this->managesRelation() || $record->exists());
+		return ($record && $record->exists()) || $this->managesRelation();
 	}
 }
 


### PR DESCRIPTION
If no underlying record or relation exists, the function should return false as the file can't be saveable. Message "Files can be attached once you have saved the record for the first time." should now be shown as intended.
