### PR TITLE
NEW Many-many relation data editing in GridFieldDetailForm

### DIFF
--- a/docs/en/reference/grid-field.md
+++ b/docs/en/reference/grid-field.md
@@ -78,7 +78,7 @@ We will now move onto what the `GridFieldConfig`s are and how to use them.
 
 ----
 
-## GridFieldConfig
+## Configuration
 
 A gridfields's behaviour and look all depends on what config we're giving it. In the above example 
 we did not specify one, so it picked a default config called `GridFieldConfig_Base`.
@@ -98,7 +98,7 @@ A config object can be either injected as the fourth argument of the GridField c
 
 The framework comes shipped with some base GridFieldConfigs:
 
-### GridFieldConfig_Base
+### Table listing with GridFieldConfig_Base
 
 A simple read-only and paginated view of records with sortable and searchable headers.
 
@@ -107,7 +107,7 @@ A simple read-only and paginated view of records with sortable and searchable he
 
 The fields displayed are from `DataObject::getSummaryFields()`
 
-### GridFieldConfig_RecordViewer
+### Viewing records with GridFieldConfig_RecordViewer
 
 Similar to `GridFieldConfig_Base` with the addition support of:
 
@@ -118,7 +118,7 @@ The fields displayed in the read-only view is from `DataObject::getCMSFields()`
 	:::php
 	$gridField = new GridField('pages', 'All pages', SiteTree::get(), GridFieldConfig_RecordViewer::create());
 
-### GridFieldConfig_RecordEditor
+### Editing records with GridFieldConfig_RecordEditor
 
 Similar to `GridFieldConfig_RecordViewer` with the addition support of:
 
@@ -130,7 +130,7 @@ Similar to `GridFieldConfig_RecordViewer` with the addition support of:
 
 The fields displayed in the edit form are from `DataObject::getCMSFields()`
  
-### GridFieldConfig_RelationEditor
+### Editing relations with GridFieldConfig_RelationEditor
 
 Similar to `GridFieldConfig_RecordEditor`, but adds features to work on a record's has-many or 
 many-many relationships. As such, it expects the list used with the `GridField` to be a
@@ -147,9 +147,61 @@ The relations can be:
 
 The fields displayed in the edit form are from `DataObject::getCMSFields()`
 
+## Customizing Detail Forms
+
+The `GridFieldDetailForm` component drives the record editing form which is usually configured
+through the configs `GridFieldConfig_RecordEditor` and `GridFieldConfig_RelationEditor`
+described above. It takes its fields from `DataObject->getCMSFields()`,
+but can be customized to accept different fields via its `[api:GridFieldDetailForm->setFields()](api:setFields())` method.
+
+The component also has the ability to load and save data stored on join tables
+when two records are related via a "many_many" relationship, as defined through
+`[api:DataObject::$many_many_extraFields]`. While loading and saving works transparently,
+you need to add the necessary fields manually, they're not included in the `getCMSFields()` scaffolding.
+
+These extra fields act like usual form fields, but need to be "namespaced"
+in order for the gridfield logic to detect them as fields for relation extradata,
+and to avoid clashes with the other form fields.
+The namespace notation is `ManyMany[<extradata-field-name>]`, so for example
+`ManyMany[MyExtraField]`.
+
+Example:
+
+	:::php
+	class Player extends DataObject {
+		public static $db = array('Name' => 'Text');
+		public static $many_many = array('Teams' => 'Team');
+		public static $many_many_extraFields = array(
+			'Teams' => array('Position' => 'Text')
+		);
+		public function getCMSFields() {
+			$fields = parent::getCMSFields();
+
+			if($this->ID) {
+				$teamFields = singleton('Team')->getCMSFields();
+				$teamFields->addFieldToTab(
+					'Root.Main',
+					// Please follow the "ManyMany[<extradata-name>]" convention
+					new TextField('ManyMany[Position]', 'Current Position')
+				);
+				$config = GridFieldConfig_RelationEditor::create();
+				$config->getComponentByType('GridFieldDetailForm')->setFields($teamFields);
+				$gridField = new GridField('Teams', 'Teams', $this->Teams(), $config);
+				$fields->findOrMakeTab('Root.Teams')->replaceField('Teams', $gridField);
+			}
+
+			return $fields;
+		}
+	}
+
+	class Team extends DataObject {
+		public static $db = array('Name' => 'Text');
+		public static $many_many = array('Players' => 'Player');
+	}
+
 ## GridFieldComponents
 
-GridFieldComponents the actual workers in a gridfield. They can be responsible for:
+The `GridFieldComponent` classes are the actual workers in a gridfield. They can be responsible for:
 
  - Output some HTML to be rendered
  - Manipulate data

--- a/docs/en/reference/modeladmin.md
+++ b/docs/en/reference/modeladmin.md
@@ -152,6 +152,8 @@ Consider replacing it with a more powerful interface in case you have many recor
 Has-many and many-many relationships are usually handled via the `[GridField](/reference/grid-field)` class,
 more specifically the `[api:GridFieldAddExistingAutocompleter]` and `[api:GridFieldRelationDelete]` components.
 They provide a list/detail interface within a single record edited in your ModelAdmin.
+The `[GridField](/reference/grid-field)` docs also explain how to manage 
+extra relation fields on join tables through its detail forms.
 
 ## Permissions
 


### PR DESCRIPTION
Also adds GridFieldDetailForm->setFields() for customizing
the displayed form fields (required for adding relational fields).

Discussed API with Stig beforehand, we both agree that implicit namespacing isn't really the best API design, but also couldn't come up with a better way, given the limitations of the form API underneath.

The setup required by a dev is a bit of work at the moment, although its at least well documented.
In general, we could automatically scaffold in extra fields by reusing parts of FormScaffolder.
What do people think of this default? Might be confusing to have non-record fields show up in there, with pretty random field names like "ManyMany[MyRelationField]"?

Note that setFields() was a necessary addition, we can't simply add those extra fields to the record's own getCMSFields() implementation, since it might be used in other contexts as well. For example, a record might be edited as part of a ManyManyList in a GridFieldDetailForm, but elsewhere in a ModelAdmin as part of a standard DataList.

BTW, need this for a client project, implementing publication flags for manymany relationships.
