### PR TITLE
fixed mediaform urls in modeladmin

### DIFF
--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -278,8 +278,8 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 	public function forTemplate() {
 		return sprintf(
 			'<div id="cms-editor-dialogs" data-url-linkform="%s" data-url-mediaform="%s"></div>',
-			Controller::join_links($this->controller->Link($this->name), 'LinkForm', 'forTemplate'),
-			Controller::join_links($this->controller->Link($this->name), 'MediaForm', 'forTemplate')
+			Controller::join_links($this->controller->Link(), $this->name, 'LinkForm', 'forTemplate'),
+			Controller::join_links($this->controller->Link(), $this->name, 'MediaForm', 'forTemplate')
 		);
 	}
 


### PR DESCRIPTION
" The problem is, that the 'action' parameter in ModelAdmin::Link() in fact is the currently handled model, rather than the action. By appending the action to the returned link, we get the currently managed model returned from Modeladmin and can append our action.

I have confirmed this working in model admin as well as CMS. "

see http://open.silverstripe.org/ticket/8013
