### PR TITLE
FIX: include ImagickBackend only when Imagick installed

### DIFF
--- a/filesystem/ImagickBackend.php
+++ b/filesystem/ImagickBackend.php
@@ -1,5 +1,16 @@
 <?php
+
+/**
+ * @package framework
+ * @subpackage filesystem
+ */
+
+if(class_exists('Imagick')) {
 class ImagickBackend extends Imagick implements Image_Backend {
+	
+	/**
+	 * @var int
+	 */
 	protected static $default_quality = 75;
 	
 	/**
@@ -263,4 +274,5 @@ class ImagickBackend extends Imagick implements Image_Backend {
 		
 		return $new;
 	}
+}
 }


### PR DESCRIPTION
Test is marked as skipped when the extension isn't loaded but the class is not.
