### PR TITLE
Update javascript/GridField.js

### DIFF
--- a/javascript/GridField.js
+++ b/javascript/GridField.js
@@ -302,7 +302,7 @@
 							},
 							type: "GET",
 							url: suggestionUrl,
-							data: escape(searchField.attr('name'))+'='+escape(searchField.val()), 
+							data: encodeURIComponent(searchField.attr('name'))+'='+encodeURIComponent(searchField.val()), 
 							success: function(data) {
 								response( $.map(JSON.parse(data), function( name, id ) {
 									return { label: name, value: name, id: id };


### PR DESCRIPTION
The escape and unescape functions do not work properly for non-ASCII characters and have been deprecated. In JavaScript 1.5 and later, use encodeURI, decodeURI, encodeURIComponent, and decodeURIComponent.
I have problem with cyrillic http://www.silverstripe.org/general-questions/show/21433
