### PR TITLE
BUG Video embed from Add Media Feature no longer works (open #8033)

### DIFF
--- a/admin/_config.php
+++ b/admin/_config.php
@@ -13,7 +13,7 @@ HtmlEditorConfig::get('cms')->setOptions(array(
 	'use_native_selects' => false,
 	'valid_elements' => "@[id|class|style|title],a[id|rel|rev|dir|tabindex|accesskey|type|name|href|target|title"
 		. "|class],-strong/-b[class],-em/-i[class],-strike[class],-u[class],#p[id|dir|class|align|style],-ol[class],"
-		. "-ul[class],-li[class],br,img[id|dir|longdesc|usemap|class|src|border|alt=|title|width|height|align],"
+		. "-ul[class],-li[class],br,img[id|dir|longdesc|usemap|class|src|border|alt=|title|width|height|align|data*],"
 		. "-sub[class],-sup[class],-blockquote[dir|class],"
 		. "-table[border=0|cellspacing|cellpadding|width|height|class|align|summary|dir|id|style],"
 		. "-tr[id|dir|class|rowspan|width|height|align|valign|bgcolor|background|bordercolor|style],"
@@ -25,7 +25,7 @@ HtmlEditorConfig::get('cms')->setOptions(array(
 		. "-h4[id|dir|class|align|style],-h5[id|dir|class|align|style],-h6[id|dir|class|align|style],hr[class],"
 		. "dd[id|class|title|dir],dl[id|class|title|dir],dt[id|class|title|dir],@[id,style,class]",
 	'extended_valid_elements' => "img[class|src|alt|title|hspace|vspace|width|height|align|onmouseover|onmouseout|name"
-		. "|usemap],iframe[src|name|width|height|align|frameborder|marginwidth|marginheight|scrolling],"
+		. "|usemap|data*],iframe[src|name|width|height|align|frameborder|marginwidth|marginheight|scrolling],"
 		. "object[width|height|data|type],param[name|value],map[class|name|id],area[shape|coords|href|target|alt]",
 	'spellchecker_rpc_url' => THIRDPARTY_DIR . '/tinymce-spellchecker/rpc.php'
 ));


### PR DESCRIPTION
Since the tinymce upgrade from 3.5.6 to 3.5.7 it seems like data attributes are forbidden on tags.
This fix tells tinymce to allow data\* properties on img tags
