### PR TITLE
BUG Fixing encoding issue with non-ASCII characters

### DIFF
--- a/javascript/GridField.js
+++ b/javascript/GridField.js
@@ -302,7 +302,7 @@
 							},
 							type: "GET",
 							url: suggestionUrl,
-							data: escape(searchField.attr('name'))+'='+escape(searchField.val()), 
+							data: encodeURIComponent(searchField.attr('name')) + '=' + encodeURIComponent(searchField.val()), 
 							success: function(data) {
 								response( $.map(JSON.parse(data), function( name, id ) {
 									return { label: name, value: name, id: id };


### PR DESCRIPTION
GridFieldAddExistingAutocompleter messes up non-ASCII characters
because GridField.js uses escape() to encode URI paramters.
This is known to be broken, and encodeURIComponent() is a better
alternative.

See http://stackoverflow.com/questions/75980/best-practice-escape-or-encodeuri-encodeuricomponent
for more information

Raised on this forum post: http://www.silverstripe.org/general-questions/show/21433#post318162
