### PR TITLE
Removing redundant DatabaseAdmin::testinstall()

### DIFF
--- a/model/DatabaseAdmin.php
+++ b/model/DatabaseAdmin.php
@@ -18,7 +18,6 @@ class DatabaseAdmin extends Controller {
 		'index',
 		'build',
 		'cleanup',
-		'testinstall',
 		'import'
 	);
 	
@@ -263,15 +262,6 @@ class DatabaseAdmin extends Controller {
 			else DB::query("TRUNCATE \"$table\"");
 		}
 	}
-
-
-	/**
-	 * Method used to check mod_rewrite is working correctly in the installer.
-	 */
-	public function testinstall() {
-		echo "OK";
-	}
-
 
 	/**
 	 * Remove invalid records from tables - that is, records that don't have


### PR DESCRIPTION
The original intention of this method was to be a rewrite
check by the installer, but it doesn't belong in
DatabaseAdmin, nor is it used by the installer anymore,
since the rewrite test is done by the installer directly.
