### PR TITLE
Display descriptive help labels for checkbox fields.

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -224,6 +224,7 @@ form.small .field input.text, form.small .field textarea, form.small .field sele
 /** ---------------------------------------------------- Checkbox Field ---------------------------------------------------- */
 .field.checkbox { padding-left: 184px; margin-bottom: 8px; }
 .field.checkbox input { margin-left: 0; }
+.field.checkbox .help { margin-left: 0; }
 
 input.checkbox { margin-left: 0; }
 

--- a/admin/javascript/LeftAndMain.FieldHelp.js
+++ b/admin/javascript/LeftAndMain.FieldHelp.js
@@ -4,7 +4,7 @@
 		 * Takes form fields with a title attribute, extracts it, and displays
 		 * it as inline help text below the field.
 		 */
-		$(".cms form .field .middleColumn > [title]").entwine({
+		$(".cms form .field .middleColumn > [title], .cms form .field.checkbox input[type='checkbox'][title]").entwine({
 			onmatch: function() {
 				
 				var title = this.prop("title");

--- a/admin/scss/_forms.scss
+++ b/admin/scss/_forms.scss
@@ -508,6 +508,10 @@ form.small .field, .field.small {
 	input {
 		margin-left: 0;
 	}
+	
+	.help {
+		margin-left: 0;
+	}
 }
 input.checkbox {
 	margin-left: 0


### PR DESCRIPTION
Previously this would only be displayed for fields containing a div with the middleColumn class. ->setDescription could be called on a CheckboxField, but the message would not be displayed in a fashion consistent with other fields (for example, TextField).
