### PR TITLE
BUG Restore GD class to avoid breaking GD::set_default_quality() calls

### DIFF
--- a/filesystem/GD.php
+++ b/filesystem/GD.php
@@ -459,4 +459,17 @@ class GDBackend extends Object implements Image_Backend {
 	}
 	
 }
-class_alias("GDBackend", "GD");
+
+/**
+ * Backwards compatibility
+ */
+class GD extends GDBackend {
+	public static function set_default_quality($quality) {
+		Deprecation::notice(
+			'3.1', 
+			'GDBackend::set_default_quality instead',
+			Deprecation::SCOPE_CLASS
+		);
+		GDBackend::set_default_quality($quality);
+	}	
+}


### PR DESCRIPTION
Regression from d24b586. It used `class_alias` for backwards compat, but that doesn't work because its never picked up by our Manifest autoloader.
