### PR TITLE
API Rename Transliterator to SS_Transliterator to remove conflict with Intl extension

### DIFF
--- a/core/model/SiteTree.php
+++ b/core/model/SiteTree.php
@@ -1517,7 +1517,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 */
 	function generateURLSegment($title){
 		$t = (function_exists('mb_strtolower')) ? mb_strtolower($title) : strtolower($title);
-		$t = Object::create('Transliterator')->toASCII($t);
+		$t = Object::create('SS_Transliterator')->toASCII($t);
 		$t = str_replace('&amp;','-and-',$t);
 		$t = str_replace('&','-and-',$t);
 		$t = ereg_replace('[^A-Za-z0-9]+','-',$t);

--- a/core/model/Transliterator.php
+++ b/core/model/Transliterator.php
@@ -6,14 +6,14 @@
  * Usage:
  * 
  * <code>
- * $tr = new Transliterator();
+ * $tr = new SS_Transliterator();
  * $ascii = $tr->toASCII($unicode);
  * </code>
  * 
  * @package sapphire
  * @subpackage model
  */
-class Transliterator {
+class SS_Transliterator {
 	/**
 	 * Allow the use of iconv() to perform transliteration.  Set to false to disable.
 	 * Even if this variable is true, iconv() won't be used if it's not installed.
@@ -58,4 +58,8 @@ class Transliterator {
 	protected function useIconv($source) {
  		return iconv("utf-8", "us-ascii//IGNORE//TRANSLIT", $source);
 	}
+}
+
+if(!class_exists('Transliterator')) {
+	class Transliterator extends SS_Transliterator {}
 }


### PR DESCRIPTION
With PHP 5.4 and the Intl extension 2.0, a [Transliterator class](http://nz1.php.net/manual/en/class.transliterator.php) already exists, which causes the Object::create() call in SiteTree to throw a [ReflectionException](http://www.silverstripe.org/hosting-requirements/show/19949?start=8#post318411) due to a non-public constructor.

I'm posting this incase there's reason for a 2.4.9 and so that there's something to reference when explaining to people that run into this error how to fix it.
