### PR TITLE
More fluent API

### DIFF
--- a/model/Map.php
+++ b/model/Map.php
@@ -77,6 +77,8 @@ class SS_Map implements ArrayAccess, Countable, IteratorAggregate {
 		$oldItems = $this->firstItems;
 		$this->firstItems = array($key => $value);
 		if($oldItems) $this->firstItems = $this->firstItems + $oldItems;
+		
+		return $this;
 	}
 
 	// ArrayAccess


### PR DESCRIPTION
return $this, for do things like this: new DropdownField('XPTOName', 'XPTO Label', XPTOModel::get()->map("ID", "Name")->unshift(0,'- Select -'))

This does not break anything and makes things more natural
