### PR TITLE
BUG Safari Navigation bug fix open ticket 8039

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -509,13 +509,13 @@ jQuery.noConflict();
 						var tabsUrl = 'tabs-' + url;
 						window.sessionStorage.setItem(tabsUrl, JSON.stringify(activeTabs));
 					}
-					if(activeTabs) window.sessionStorage.setItem('tabs-' + url, JSON.stringify(activeTabs));
 				} catch(err) {
 					// if this fails we ignore the error as the only issue is that it does not
 					// remember the tab state
 					// This is a Safari bug which happens when private browsing is set to on
 					// It should be caught by checking window.sessionStorage but in Safari
 					// window.sessionStorage returns true when private browsing is on
+					return;
 				}
 			},
 


### PR DESCRIPTION
Safari has a bug where window.sessionStorage returns true when private browsing is on.

This stops the CMS navigation menu from working as later on as it tries to use setItem on sessionStorage.

The fix catches the exception it does not do anything with the exception as this is a edge case and any interaction with the user would be intrusive in this situation
