### PR TITLE
BUG Unable to return to site tree admin from Preview mode trac 8063

### DIFF
--- a/admin/javascript/LeftAndMain.Preview.js
+++ b/admin/javascript/LeftAndMain.Preview.js
@@ -73,6 +73,7 @@
 					this.unblock();
 				} else {
 					this.block();
+					this.toggle();
 				}
 			},
 


### PR DESCRIPTION
added a call to toggle to reload the page when going from preview back to the current admin section via the left hand menu
