### PR TITLE
Gridfield Action Button's not lined out correctly

### DIFF
--- a/scss/GridField.scss
+++ b/scss/GridField.scss
@@ -254,7 +254,7 @@ $gf_grid_x:	16px;
 					display:inline-block;
 					width:20px;
 					height:20px; //min height to fit the edit icon
-					text-indent:9999em;
+					text-indent:-9999em;
 					overflow: hidden;
 					vertical-align: middle;
 				}


### PR DESCRIPTION
**Gridfield Action buttons:**
Col is not width enough, and text-indent isn't working properly.

_Before:_
http://i.imgur.com/VWxST.png

_After:_
http://i.imgur.com/0U4E2.png

Problem occurs with all browsers and latest 3.0 branch. Col seems width enough in admin/security, but text-indent isn't doesn't its job the rightway.

_Update_
The reason the widthness is oke in admin/security, is because of "GridFieldFilterHeader".

I couldn't get it compiled, I am using the Windows version of it, and it doesn't have the same output as you are using right now, so I don't want to mess up the .scss files.
