### PR TITLE
Bug 8056: Add Page parent page selection does not display page titles

### DIFF
--- a/forms/SelectionGroup.php
+++ b/forms/SelectionGroup.php
@@ -9,6 +9,8 @@
  * @subpackage fields-structural
  */
 class SelectionGroup extends CompositeField {
+
+	protected $labels = array();
 	
 	/**
 	 * Create a new selection group.
@@ -22,6 +24,7 @@ class SelectionGroup extends CompositeField {
 	 */
 	public function __construct($name, $items) {
 		$this->name = $name;
+		$this->labels = array_keys($items);
 		
 		parent::__construct($items);
 		
@@ -40,12 +43,13 @@ class SelectionGroup extends CompositeField {
 		$newItems = array();
 		
 		foreach($items as $key => $item) {
-			if(strpos($key,'//') !== false) {
-				list($key,$title) = explode('//', $key,2);
+			$label = $this->labels[$key];
+			if(strpos($label,'//') !== false) {
+				list($label,$title) = explode('//', $label,2);
 			} else {
-				$title = $key;
+				$title = $label;
 			}
-			if($this->value == $key) {
+			if($this->value == $label) {
 				$firstSelected = " class=\"selected\"";
 				$checked = " checked=\"checked\"";
 			}
@@ -53,7 +57,7 @@ class SelectionGroup extends CompositeField {
 			$itemID = $this->ID() . '_' . (++$count);
 			$extra = array(
 				"RadioButton" => "<input class=\"selector\" type=\"radio\" id=\"$itemID\" name=\"$this->name\""
-					. " value=\"$key\"$checked />",
+					. " value=\"$label\"$checked />",
 				"RadioLabel" => "<label for=\"$itemID\">$title</label>",
 				"Selected" => $firstSelected,
 			);


### PR DESCRIPTION
Since commit b6017a7c9, ToArray() has taken to stripping out key values, leaving
only the numeric indices.  This means that SelectionGroups can no longer label their
fields directly in the $items array; the $key value will always be the numeric index,
and thus so will the $title.  The result in the CMS is the "Choose where to create this page"
section of Add Page not showing the correct labels of "Top level" and "Under another page",
but rather "0" and "1" (respectively).

This patch adds a new protected array to the SelectionGroup object to store the labels
of incoming items before they're passed to ToArray(), which will strip them out.

To confirm bug:

```
1. Install SilverStripe 3.0.3 and login to the administration area
2. Go to Add Page
3. You will see "0" and "1" as labels under "Choose where to create this page" instead of
"Top level" and "Under another page"
```

To Test:

```
1. Apply this patch
2. Reload Add Page page with ?flush=all
3. You should now see the correct labels under "Choose where to create this page"
4. Using the radio buttons and actually creating the page should work as before
```

fixes #8056
