### PR TITLE
API Storing alternative DB name in cookie rather than session

### DIFF
--- a/dev/DevelopmentAdmin.php
+++ b/dev/DevelopmentAdmin.php
@@ -25,7 +25,8 @@ class DevelopmentAdmin extends Controller {
         'viewmodel', 
         'build', 
         'reset', 
-        'viewcode' 
+        'viewcode',
+        'generatesecuretoken',
  	);
 	
 	public function init() {
@@ -170,6 +171,25 @@ class DevelopmentAdmin extends Controller {
 			echo "</div>";
 			$renderer->writeFooter();
 		}
+	}
+
+	/**
+	 * Generate a secure token which can be used as a crypto key.
+	 * Returns the token and suggests PHP configuration to set it.
+	 */
+	public function generatesecuretoken() {
+		$generator = Injector::inst()->create('RandomGenerator');
+		$token = $generator->randomToken('sha1');
+
+		echo <<<TXT
+
+Token: $token
+
+Please add this to your mysite/_config.php with the following code:
+Config::inst()->update('Security', 'token', '$token');
+
+
+TXT;
 	}
 
 	public function reset() {

--- a/dev/TestRunner.php
+++ b/dev/TestRunner.php
@@ -349,6 +349,9 @@ class TestRunner extends Controller {
 	 * See {@link setdb()} for an alternative approach which just sets a database
 	 * name, and is used for more advanced use cases like interacting with test databases
 	 * directly during functional tests.
+	 *
+	 * Requires PHP's mycrypt extension in order to set the database name
+	 * as an encrypted cookie.
 	 */
 	public function startsession() {
 		if(!Director::isLive()) {
@@ -420,7 +423,7 @@ HTML;
 	}
 
 	/**
-	 * Set an alternative database name in the current browser session.
+	 * Set an alternative database name in the current browser session as a cookie.
 	 * Useful for functional testing libraries like behat to create a "clean slate". 
 	 * Does not actually create the database, that's usually handled
 	 * by {@link SapphireTest::create_temp_db()}.
@@ -432,33 +435,33 @@ HTML;
 	 *
 	 * See {@link startsession()} for a different approach which actually creates
 	 * the DB and loads a fixture file instead.
+	 *
+	 * Requires PHP's mycrypt extension in order to set the database name
+	 * as an encrypted cookie.
 	 */
 	public function setdb() {
 		if(Director::isLive()) {
 			return $this->permissionFailure("dev/tests/setdb can only be used on dev and test sites");
 		}
-		
 		if(!isset($_GET['database'])) {
 			return $this->permissionFailure("dev/tests/setdb must be used with a 'database' parameter");
 		}
 		
-		$database_name = $_GET['database'];
+		$name = $_GET['database'];
 		$prefix = defined('SS_DATABASE_PREFIX') ? SS_DATABASE_PREFIX : 'ss_';
 		$pattern = strtolower(sprintf('#^%stmpdb\d{7}#', $prefix));
-		if(!preg_match($pattern, $database_name)) {
+		if($name && !preg_match($pattern, $name)) {
 			return $this->permissionFailure("Invalid database name format");
 		}
 
-		DB::set_alternative_database_name($database_name);
+		DB::set_alternative_database_name($name);
 
-		return "<p>Set database session to '$database_name'.  Time to start testing; where would you like to start?</p>
-			<ul>
-				<li><a id=\"home-link\" href=\"" .Director::baseURL() . "\">Homepage - published site</a></li>
-				<li><a id=\"draft-link\" href=\"" .Director::baseURL() . "?stage=Stage\">Homepage - draft site</a></li>
-				<li><a id=\"admin-link\" href=\"" .Director::baseURL() . "admin/\">CMS Admin</a></li>
-				<li><a id=\"endsession-link\" href=\"" .Director::baseURL() . "dev/tests/endsession\">
-					End your test session</a></li>
-			</ul>";
+		if($name) {
+			return "<p>Set database session to '$name'.</p>";
+		} else {
+			return "<p>Unset database session.</p>";
+		}
+		
 	}
 	
 	public function emptydb() {

--- a/docs/en/changelogs/3.0.4.md
+++ b/docs/en/changelogs/3.0.4.md
@@ -1,0 +1,12 @@
+# 3.0.4
+
+## Overview
+
+ * Changed `dev/tests/setdb` and `dev/tests/startsession` from session to cookie storage.
+
+## Upgrading
+
+ * If you are using `dev/tests/setdb` and `dev/tests/startsession`,
+   you'll need to configure a secure token in order to encrypt the cookie value:
+   Simply run `sake dev/generatesecuretoken` and add the resulting code to your `mysite/_config.php`.
+   Note that this functionality now requires the PHP `mcrypt` extension.

--- a/security/Security.php
+++ b/security/Security.php
@@ -82,6 +82,14 @@ class Security extends Controller {
 	 * @var array|string
 	 */
 	protected static $default_message_set = '';
+
+	/**
+	 * Random secure token, can be used as a crypto key internally.
+	 * Generate one through 'sake dev/generatesecuretoken'.
+	 * 
+	 * @var String
+	 */
+	public static $token;
 	
 	/**
 	 * Get location of word list file

--- a/tests/model/DBTest.php
+++ b/tests/model/DBTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @package framework
+ * @subpackage tests
+ */
+class DBTest extends SapphireTest {
+
+	protected $origEnvType;
+
+	function setUp() {
+		$this->origEnvType = Director::get_environment_type();
+		Director::set_environment_type('dev');
+
+		parent::setUp();
+	}
+
+	function tearDown() {
+		Director::set_environment_type($this->origEnvType);
+
+		parent::tearDown();
+	}
+
+	function testValidAlternativeDatabaseName() {
+		$this->assertTrue(DB::valid_alternative_database_name('ss_tmpdb1234567'));
+		$this->assertFalse(DB::valid_alternative_database_name('ss_tmpdb12345678'));
+		$this->assertFalse(DB::valid_alternative_database_name('tmpdb1234567'));
+		$this->assertFalse(DB::valid_alternative_database_name('random'));
+		$this->assertFalse(DB::valid_alternative_database_name(''));
+
+		$origEnvType = Director::get_environment_type();
+		Director::set_environment_type('live');		
+		$this->assertFalse(DB::valid_alternative_database_name('ss_tmpdb1234567'));
+		Director::set_environment_type($origEnvType);		
+	}
+
+}


### PR DESCRIPTION
Session is not initialized by the time we need to use
the setting in DB::connect(). Cookie values get initialized
automatically for each request.

See discussion at https://groups.google.com/forum/?fromgroups=#!topic/silverstripe-dev/WxfC-VlBiFs

Tightened name format validation to ensure it can only
be used for temporary databases, rather than switching
the browser session to a different production database.

~~Doesn't implement any kind of "signed cookie" mechanism,
because I can't think of a good way to retain whatever secure token
we would base this cookie on. If we set an encrypted (not hashed)
cookie, the decryption passphrase needs to be stored on the server.
We could of course set a global one on the filesystem,
but that sounds like a bit of overkill to me.~~

On the long run, I would like to extract this whole "alternative DB" stuff
into module which hooks into the `DB` class. Its fairly security sensitive code,
there's no good reason it should even exist on production sites.
This would also make securing cookies less relevant.
