### PR TITLE
BUG Using GLOB for case sensitive matches in SQLite3

### DIFF
--- a/search/filters/ExactMatchFilter.php
+++ b/search/filters/ExactMatchFilter.php
@@ -20,23 +20,30 @@ class ExactMatchFilter extends SearchFilter {
 			throw new InvalidArgumentException(
 				get_class($this) . ' does not accept ' . implode(', ', $extras) . ' as modifiers');
 		}
+
+		if(DB::getConn() instanceof PostgreSQLDatabase) {
+			$nocaseComp = 'ILIKE';
+			$caseComp = 'LIKE';
+		} elseif(DB::getConn() instanceof SQLite3Database) {
+			$nocaseComp = 'LIKE';
+			$caseComp = 'GLOB';
+		} else {
+			$nocaseComp = 'LIKE';
+			$caseComp = 'LIKE BINARY';
+		}
+
 		if(!in_array('case', $modifiers) && !in_array('nocase', $modifiers)) {
 			if($exclude) {
 				return '!=';
 			} else {
 				return '=';
 			}
-		} elseif(DB::getConn() instanceof PostgreSQLDatabase) {
-			if(in_array('case', $modifiers)) {
-				$comparison = 'LIKE';
-			} else {
-				$comparison = 'ILIKE';
-			}
 		} elseif(in_array('case', $modifiers)) {
-			$comparison = 'LIKE BINARY';
+			$comparison = $caseComp;
 		} else {
-			$comparison = 'LIKE';
+			$comparison = $nocaseComp;
 		}
+
 		if($exclude) {
 			$comparison = 'NOT ' . $comparison;
 		}

--- a/search/filters/SearchFilter.php
+++ b/search/filters/SearchFilter.php
@@ -278,5 +278,21 @@ abstract class SearchFilter extends Object {
 	public function isEmpty() {
 		return false;
 	}
+
+	/**
+	 * Return wildcard for partial searches. Depends on modifier state
+	 * and used database driver.
+	 * 
+	 * @return String
+	 */
+	protected function getWildcard() {
+		$modifiers = $this->getModifiers();
+		if(in_array('case', $modifiers) && DB::getConn() instanceof SQLite3Database) {
+			$wildcard = '*';
+		} else {
+			$wildcard = '%';
+		}
+		return $wildcard;
+	}
 	
 }


### PR DESCRIPTION
As opposed to LIKE, the GLOB operator is case sensitive by default
in SQlite3. It uses "*" instead of "%" for wildcards,
which necessitated a new SearchFilter->getWildcard() method.

SQlite3 doesn't support per-term modifiers,
COLLATE BINARY LIKE is case insensitive by default
unless the field collation is set up accordingly.
There's connection-level modifiers (PRAGMA case_sensitive_like = true),
but that would affect all comparisators in the executed query.

Note that this doesn't escape asterisk wildcards in the searched string in any way.
That's no different from existing logic though, percent wildcards aren't escaped either.
Is this a bug, or a feature? It might be handy to pass in further
wildcards in the searched term through the highlevel APIs.
If its a feature, we need to convert any percents to asterisks.

This code should be contained in the DB driver instead,
but needs more refactoring, there's a _lot_ of duplication
in there already. For now it fixes this
aspect of the SQlite3 builds, which enables us
to work with a more responsive test suite again.

Smoke tested DataListTest in Sqlite3, Postgres, MSSQL and Mysql.
