### PR TITLE
API DB-specific comparisators in SearchFilter and DataList

### DIFF
--- a/model/Database.php
+++ b/model/Database.php
@@ -884,6 +884,18 @@ abstract class SS_Database {
 	}
 
 	/**
+	 * Generate a WHERE clause for text matching.
+	 * 
+	 * @param String $field Quoted field name
+	 * @param String $value Escaped search. Can include percentage wildcards.
+	 * @param boolean $exact Exact matches or wildcard support.
+	 * @param boolean $negate Negate the clause.
+	 * @param boolean $caseSensitive Perform case sensitive search.
+	 * @return String SQL
+	 */
+	abstract public function comparisonClause($field, $value, $exact = false, $negate = false, $caseSensitive = false);
+
+	/**
 	 * function to return an SQL datetime expression that can be used with the adapter in use
 	 * used for querying a datetime in a certain format
 	 * @param string $date to be formated, can be either 'now', literal datetime like '1973-10-14 10:30:00' or

--- a/model/MySQLDatabase.php
+++ b/model/MySQLDatabase.php
@@ -1057,6 +1057,28 @@ class MySQLDatabase extends SS_Database {
 	}
 
 	/**
+	 * Generate a WHERE clause for text matching.
+	 * 
+	 * @param String $field Quoted field name
+	 * @param String $value Escaped search. Can include percentage wildcards.
+	 * @param boolean $exact Exact matches or wildcard support.
+	 * @param boolean $negate Negate the clause.
+	 * @param boolean $caseSensitive Enforce case sensitivity if TRUE or FALSE.
+	 *                               Stick with default collation if set to NULL.
+	 * @return String SQL
+	 */
+	public function comparisonClause($field, $value, $exact = false, $negate = false, $caseSensitive = null) {
+		if($exact && $caseSensitive === null) {
+			$comp = ($negate) ? '!=' : '=';
+		} else {
+			$comp = ($caseSensitive) ? 'LIKE BINARY' : 'LIKE';
+			if($negate) $comp = 'NOT ' . $comp;
+		}
+		
+		return sprintf("%s %s '%s'", $field, $comp, $value);
+	}
+
+	/**
 	 * function to return an SQL datetime expression that can be used with MySQL
 	 * used for querying a datetime in a certain format
 	 * @param string $date to be formated, can be either 'now', literal datetime like '1973-10-14 10:30:00' or

--- a/search/filters/EndsWithFilter.php
+++ b/search/filters/EndsWithFilter.php
@@ -17,27 +17,14 @@
  * @subpackage search
  */
 class EndsWithFilter extends SearchFilter {
-	protected function comparison($exclude = false) {
-		$modifiers = $this->getModifiers();
+
+	public function setModifiers(array $modifiers) {
 		if(($extras = array_diff($modifiers, array('not', 'nocase', 'case'))) != array()) {
 			throw new InvalidArgumentException(
 				get_class($this) . ' does not accept ' . implode(', ', $extras) . ' as modifiers');
 		}
-		if(DB::getConn() instanceof PostgreSQLDatabase) {
-			if(in_array('case', $modifiers)) {
-				$comparison = 'LIKE';
-			} else {
-				$comparison = 'ILIKE';
-			}
-		} elseif(in_array('case', $modifiers)) {
-			$comparison = 'LIKE BINARY';
-		} else {
-			$comparison = 'LIKE';
-		}
-		if($exclude) {
-			$comparison = 'NOT ' . $comparison;
-		}
-		return $comparison;
+
+		parent::setModifiers($modifiers);
 	}
 	
 	/**
@@ -47,12 +34,15 @@ class EndsWithFilter extends SearchFilter {
 	 */
 	protected function applyOne(DataQuery $query) {
 		$this->model = $query->applyRelation($this->relation);
-		return $query->where(sprintf(
-			"%s %s '%%%s'",
+		$modifiers = $this->getModifiers();
+		$where = DB::getConn()->comparisonClause(
 			$this->getDbName(),
-			$this->comparison(false),
-			Convert::raw2sql($this->getValue())
-		));
+			'%' . Convert::raw2sql($this->getValue()),
+			false, // exact?
+			false, // negate?
+			$this->getCaseSensitive()
+		);
+		return $query->where($where);
 	}
 
 	/**
@@ -63,13 +53,15 @@ class EndsWithFilter extends SearchFilter {
 	 */
 	protected function applyMany(DataQuery $query) {
 		$this->model = $query->applyRelation($this->relation);
+		$modifiers = $this->getModifiers();
 		$connectives = array();
 		foreach($this->getValue() as $value) {
-			$connectives[] = sprintf(
-				"%s %s '%%%s'",
+			$connectives[] = DB::getConn()->comparisonClause(
 				$this->getDbName(),
-				$this->comparison(false),
-				Convert::raw2sql($value)
+				'%' . Convert::raw2sql($value),
+				false, // exact?
+				false, // negate?
+				$this->getCaseSensitive()
 			);
 		}
 		$whereClause = implode(' OR ', $connectives);
@@ -83,12 +75,15 @@ class EndsWithFilter extends SearchFilter {
 	 */
 	protected function excludeOne(DataQuery $query) {
 		$this->model = $query->applyRelation($this->relation);
-		return $query->where(sprintf(
-			"%s NOT %s '%%%s'",
+		$modifiers = $this->getModifiers();
+		$where = DB::getConn()->comparisonClause(
 			$this->getDbName(),
-			$this->comparison(true),
-			Convert::raw2sql($this->getValue())
-		));
+			'%' . Convert::raw2sql($this->getValue()),
+			false, // exact?
+			true, // negate?
+			$this->getCaseSensitive()
+		);
+		return $query->where($where);
 	}
 
 	/**
@@ -99,13 +94,15 @@ class EndsWithFilter extends SearchFilter {
 	 */
 	protected function excludeMany(DataQuery $query) {
 		$this->model = $query->applyRelation($this->relation);
+		$modifiers = $this->getModifiers();
 		$connectives = array();
 		foreach($this->getValue() as $value) {
-			$connectives[] = sprintf(
-				"%s NOT %s '%%%s'",
+			$connectives[] = DB::getConn()->comparisonClause(
 				$this->getDbName(),
-				$this->comparison(true),
-				Convert::raw2sql($value)
+				'%' . Convert::raw2sql($value),
+				false, // exact?
+				true, // negate?
+				$this->getCaseSensitive()
 			);
 		}
 		$whereClause = implode(' AND ', $connectives);

--- a/search/filters/SearchFilter.php
+++ b/search/filters/SearchFilter.php
@@ -55,7 +55,7 @@ abstract class SearchFilter extends Object {
 		// sets $this->name and $this->relation
 		$this->addRelation($fullName);
 		$this->value = $value;
-		$this->modifiers = array_map('strtolower', $modifiers);
+		$this->setModifiers(array_map('strtolower', $modifiers));
 	}
 	
 	/**
@@ -278,5 +278,17 @@ abstract class SearchFilter extends Object {
 	public function isEmpty() {
 		return false;
 	}
-	
+
+	/**
+	 * Determines case sensitivity based on {@link getModifiers()}.
+	 * 
+	 * @return Mixed TRUE or FALSE to enforce sensitivity, NULL to use field collation.
+	 */
+	protected function getCaseSensitive() {
+		$modifiers = $this->getModifiers();
+		if(in_array('case', $modifiers)) return true;
+		else if(in_array('nocase', $modifiers)) return false;
+		else return null;
+	}
+
 }


### PR DESCRIPTION
New approach for #1011.

Too many edge cases to leave this up to datalists,
particularly now that we introduced enforced
case sensitivity/insensitivity in the ORM APIs.

Do you think we need to deprecate a protected SearchFilter->comparison() method?
Its kinda incompatible with what we're doing.

I've made the method abstract in the base Database class,
which means you'll need to use the latest master drivers from the repo.
Necessary evil, right?

I'm not 100% sure that the case IN-sensitivity ('nocase') is enforced correctly,
but the DataListTest UTs pass on the various drivers.
Will do a full run on all drivers tomorrow.

Postgres: https://gist.github.com/4254736
Sqlite3: https://gist.github.com/4254782
MSSQL: https://gist.github.com/4254787
