### PR TITLE
PHP 5.4 Compatibility (Array To String Conversion Notice)

### DIFF
--- a/core/control/Controller.php
+++ b/core/control/Controller.php
@@ -381,8 +381,12 @@ class Controller extends RequestHandler {
 	 * in user.
 	 * @return boolean
 	 */
-	function can($perm, $member = null) {
+	public function can($perm, $member = null) {
 		if(!$member) $member = Member::currentUser();
+		if(is_array($perm)) {
+			$perm = array_map(array($this, 'can'), $perm, array_fill(0, count($perm), $member));
+			return min($perm);
+		}
 		if($this->hasMethod($methodName = 'can' . $perm)) {
 			return $this->$methodName($member);
 		} else {


### PR DESCRIPTION
Merged code from SS3.0 branch to get rid of an instance of the "Array
To String Conversion Notice".
