### PR TITLE
RSSTemplate modified to pass feed validation

### DIFF
--- a/templates/RSSFeed.ss
+++ b/templates/RSSFeed.ss
@@ -3,7 +3,7 @@
 	<channel>
 		<title>$Title</title>
 		<link>$Link</link>
-		<atom:link href="$Link" rel="self" type="application/rss+xml" />
+		<atom:link href="$Link" rel="self" type="application/rss+xml"></atom:link>
 		<description>$Description.XML</description>
 
 		<% loop Entries %>


### PR DESCRIPTION
correctly closing the atom:link tag so that feeds now pass validation. 

W3C validator throws an error on the closing </channel> tag. Using the validator at http://www.validome.org/rss-atom/validate it identifies an incorrect closing statement for the atom:link tag, as fixed in this commit. 
