### PR TITLE
BUG: Confirmed Password Field now copies attributes to child fields.

### DIFF
--- a/forms/ConfirmedPasswordField.php
+++ b/forms/ConfirmedPasswordField.php
@@ -122,6 +122,11 @@ class ConfirmedPasswordField extends FormField {
 		foreach($this->children as $field) {
 			$field->setDisabled($this->isDisabled()); 
 			$field->setReadonly($this->isReadonly());
+			if(count($this->attributes)) {
+				foreach($this->attributes as $name => $value) {
+					$field->setAttribute($name, $value);
+				}
+			}
 			$content .= $field->FieldHolder();
 		}
 


### PR DESCRIPTION
As is already done with the readonly and disabled settings, the attributes of a ConfirmedPasswordField are now copied into the child fields, so that ConfirmedPasswordField::setAttribute() is effective.
