### PR TITLE
BUG 7735: TinyMCE not working if Requirements::set_suffix_requirements(false); set in config

### DIFF
--- a/view/Requirements.php
+++ b/view/Requirements.php
@@ -793,12 +793,16 @@ class Requirements_Backend {
 			$prefix = Director::baseURL();
 			$mtimesuffix = "";
 			$suffix = '';
-			if(strpos($fileOrUrl, '?') !== false) {
-				$suffix = '?' . substr($fileOrUrl, strpos($fileOrUrl, '?')+1);
-				$fileOrUrl = substr($fileOrUrl, 0, strpos($fileOrUrl, '?'));
-			}
 			if($this->suffix_requirements) {
 				$mtimesuffix = "?m=" . filemtime(Director::baseFolder() . '/' . $fileOrUrl);
+				$suffix = '&';
+			}
+			if(strpos($fileOrUrl, '?') !== false) {
+				if (strlen($suffix) == 0) {
+					$suffix = '?';
+				}
+				$suffix .= substr($fileOrUrl, strpos($fileOrUrl, '?')+1);
+				$fileOrUrl = substr($fileOrUrl, 0, strpos($fileOrUrl, '?'));
 			}
 			return "{$prefix}{$fileOrUrl}{$mtimesuffix}{$suffix}";
 		} else {


### PR DESCRIPTION
Fix to Requirements class where requesting files with query strings would fail. Code written by florian.thoma but submitted here as the issue is still unresolved and a fix has been written.
