### PR TITLE
BUG Fix insert media form inserting images from other UploadFields (#8051)

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -874,7 +874,7 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 					//get the uploaded file ID when this event triggers, signaling the upload has compeleted successfully
 					editFieldIDs.push($(this).data('id'));
 				});
-				var uploadedFiles = $('.ss-uploadfield-files').children('.ss-uploadfield-item');
+				var uploadedFiles = form.find('.ss-uploadfield-files').children('.ss-uploadfield-item');
 				uploadedFiles.each(function(){
 					var uploadedID = $(this).data('fileid');
 					if ($.inArray(uploadedID, editFieldIDs) == -1) {


### PR DESCRIPTION
The insert media form would pick up unwanted images from other UploadFields. Limiting where it is looking to only the closest form fixes this. Fixes #8051
