### PR TITLE
Fix to allow gridfield buttons to align inline & Fix button cell in gridfield

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -669,7 +669,6 @@ form.small .cms-file-info-data .field .middleColumn { margin-left: 120px; }
 
 /** -------------------------------------------- Users Members Admin -------------------------------------------- */
 .members_grid span button#action_gridfield_relationfind { display: none; }
-.members_grid p button#action_export { margin-top: 16px; }
 .members_grid p button#action_export span.btn-icon-download-csv { height: 17px; }
 .members_grid p button#action_export .ui-button-text { padding-left: 26px; }
 

--- a/admin/scss/_style.scss
+++ b/admin/scss/_style.scss
@@ -1575,7 +1575,6 @@ form.small {
  		display:none; //hides find button - redundant functionality
  	}
  	p button#action_export {
-		margin-top:$grid-y*2;
 		span.btn-icon-download-csv {
 			height:17px; //exact height of icon
 		}

--- a/css/GridField.css
+++ b/css/GridField.css
@@ -9,26 +9,24 @@
 /** ----------------------------------------------- Grid Units (px)  We have a vertical rhythm that the grid is based off both x (=horizontal) and y (=vertical). All internal padding and margins are scaled to this and accounting for paragraphs ------------------------------------------------ */
 /** ----------------------------------------------- Application Logo (CMS Logo) Must be 24px x 24px ------------------------------------------------ */
 .cms .ss-gridfield > div { margin-bottom: 36px; }
-.cms .ss-gridfield > div.addNewGridFieldButton { margin-bottom: 12px; }
-.cms .ss-gridfield > div.addNewGridFieldButton:after { content: "."; display: block; height: 0; clear: both; visibility: hidden; }
-*:first-child .cms .ss-gridfield > div.addNewGridFieldButton { zoom: 1; }
+.cms .ss-gridfield > div.addNewGridFieldButton { /*margin-bottom:$gf_grid_y;
+@include clearfix;*/ /* stops multiple buttons appearing inline*/ margin-bottom: 0; }
+.cms .ss-gridfield > div.addNewGridFieldButton .action { margin-bottom: 12px; }
 .cms .ss-gridfield[data-selectable] tr.ui-selected, .cms .ss-gridfield[data-selectable] tr.ui-selecting { background: #FFFAD6 !important; }
 .cms .ss-gridfield[data-selectable] td { cursor: pointer; }
 .cms .ss-gridfield span button#action_gridfield_relationfind { display: none; }
-.cms .ss-gridfield p button#action_export { margin-top: 12px; }
 .cms .ss-gridfield p button#action_export span.btn-icon-download-csv { height: 17px; }
 .cms .ss-gridfield p button#action_export .ui-button-text { padding-left: 26px; }
 .cms .ss-gridfield .right { float: right; }
-.cms .ss-gridfield .right > * { float: right; margin-left: 5px; font-size: 14.4px; }
+.cms .ss-gridfield .right > * { float: right; margin-left: 5px; font-size: 14.4px; /* This should be removed and use default button sizes, don't see what it effects though */ }
 .cms .ss-gridfield .right .pagination-records-number { font-size: 1.0em; padding: 6px 3px 6px 0; color: white; text-shadow: 0px -1px 0 rgba(0, 0, 0, 0.2); font-weight: normal; }
 .cms .ss-gridfield .left { float: left; }
-.cms .ss-gridfield .left > * { margin-right: 5px; float: left; font-size: 14.4px; }
+.cms .ss-gridfield .left > * { margin-right: 5px; float: left; }
 .cms .ss-gridfield .grid-levelup { text-indent: -9999em; margin-bottom: 6px; }
 .cms .ss-gridfield .grid-levelup a.list-parent-link { background: transparent url(../images/gridfield-level-up.png) no-repeat 0 0; display: block; }
-.cms .ss-gridfield .add-existing-autocompleter { width: 500px; }
-.cms .ss-gridfield .add-existing-autocompleter input.relation-search { width: 380px; }
-.cms .ss-gridfield .grid-print-button { display: inline-block; }
-.cms .ss-gridfield .grid-csv-button { display: inline-block; }
+.cms .ss-gridfield .add-existing-autocompleter span { display: inline-block; }
+.cms .ss-gridfield .add-existing-autocompleter input.relation-search { width: 270px; }
+.cms .ss-gridfield .grid-csv-button, .cms .ss-gridfield .grid-print-button { margin-bottom: 12px; display: inline-block; }
 .cms table.ss-gridfield-table { display: table; -moz-box-shadow: none; -webkit-box-shadow: none; box-shadow: none; padding: 0; border-collapse: separate; border-bottom: 0 none; width: 100%; margin-bottom: 12px; }
 .cms table.ss-gridfield-table thead { color: #323e46; background: transparent; }
 .cms table.ss-gridfield-table thead tr.filter-header .fieldgroup { max-width: 512px; }
@@ -38,10 +36,10 @@
 .cms table.ss-gridfield-table tbody { background: #FFF; }
 .cms table.ss-gridfield-table tbody tr { cursor: pointer; }
 .cms table.ss-gridfield-table tbody td { width: auto; max-width: 500px; word-wrap: break-word; }
-.cms table.ss-gridfield-table tbody td.col-buttons { width: auto; padding: 0 8px; text-align: right; white-space: nowrap; }
+.cms table.ss-gridfield-table tbody td.col-buttons { /* width: auto; this doesnt shrink to fit */ width: 40px; padding: 0 8px; text-align: right; white-space: nowrap; }
 .cms table.ss-gridfield-table tbody td.col-listChildrenLink { width: 16px; border-right: none; text-indent: -9999em; padding: 0; }
 .cms table.ss-gridfield-table tbody td.col-listChildrenLink .list-children-link { background: transparent url(../images/sitetree_ss_default_icons.png) no-repeat 3px -4px; display: block; }
-.cms table.ss-gridfield-table tbody td.col-getTreeTitle span.item { color: #1556b2; }
+.cms table.ss-gridfield-table tbody td.col-getTreeTitle span.item { color: #0073c1; }
 .cms table.ss-gridfield-table tbody td.col-getTreeTitle span.badge { clear: both; text-transform: uppercase; display: inline-block; padding: 0px 3px; font-size: 0.75em; line-height: 1em; margin-left: 10px; margin-right: 6px; margin-top: -1px; -webkit-border-radius: 2px 2px; -moz-border-radius: 2px / 2px; border-radius: 2px / 2px; }
 .cms table.ss-gridfield-table tbody td.col-getTreeTitle span.badge.modified { color: #7E7470; border: 1px solid #C9B800; background-color: #FFF0BC; }
 .cms table.ss-gridfield-table tbody td.col-getTreeTitle span.badge.addedtodraft { color: #7E7470; border: 1px solid #C9B800; background-color: #FFF0BC; }

--- a/scss/GridField.scss
+++ b/scss/GridField.scss
@@ -41,8 +41,12 @@ $gf_grid_x:	16px;
 		& > div {
 			margin-bottom: $gf_grid_y*3;
 			&.addNewGridFieldButton{
-				margin-bottom:$gf_grid_y;
-				@include clearfix;
+				/*margin-bottom:$gf_grid_y;
+				@include clearfix;*/ /* stops multiple buttons appearing inline*/
+				margin-bottom: 0;
+				.action {
+					margin-bottom: $gf_grid_y;
+				}
 			}
 		}
 
@@ -61,7 +65,6 @@ $gf_grid_x:	16px;
 	 	}
 
 	 	p button#action_export {
-			margin-top:$gf_grid_y;
 			span.btn-icon-download-csv {
 				height:17px; //exact height of icon
 			}
@@ -74,11 +77,10 @@ $gf_grid_x:	16px;
 			& > * {
 				float: right;
 				margin-left:5px;			
-				font-size: $gf_grid_y*1.2;
+				font-size: $gf_grid_y*1.2; /* This should be removed and use default button sizes, don't see what it effects though */
 			}
 
-			.pagination-records-number
-			{
+			.pagination-records-number {
 				font-size: 1.0em;
 				padding: 6px 3px 6px 0;
 				color: $color-text-light;
@@ -91,7 +93,6 @@ $gf_grid_x:	16px;
 			& > * {
 				margin-right:5px;
 				float: left;
-				font-size: $gf_grid_y*1.2;
 			}
 		}
 	}
@@ -106,15 +107,15 @@ $gf_grid_x:	16px;
 			margin-bottom: 6px;
 		}
 		.add-existing-autocompleter {
-			input.relation-search {
-				width: 380px;
+			span {															
+				display: inline-block;
 			}
-			width: 500px;
+			input.relation-search {
+				width: 270px;
+			}
 		}
-		.grid-print-button{
-			display: inline-block;
-		}
-		.grid-csv-button{
+		.grid-csv-button, .grid-print-button {
+			margin-bottom: 12px;
 			display: inline-block;
 		}
 	}
@@ -160,10 +161,11 @@ $gf_grid_x:	16px;
 				max-width: 500px; //This number is semi-arbitary. It is acting as a percentage limit, rather than actually constricting the width to 500px.
 				word-wrap:break-word;
 				// Give browser some hints on which cols take priority:
-				// The last column (buttons) should always shrink to fit.
+				// The last column (buttons) should always shrink to fit. REPLY: does not shrink to fit
 				// Overwritten for IE7, which doesnt support this.			
 				&.col-buttons {
-					width: auto;
+					/* width: auto; this doesnt shrink to fit */
+					width: 40px;
 					padding:0 $gf_grid_x/2;
 					text-align: right;
 					white-space: nowrap;


### PR DESCRIPTION
- Trac ticket #8099
- Someone removed the width on the last cell of gridfield for buttons probably so it can hold more or less items but making the width auto will not solve this issue, put back the 40px width (https://www.evernote.com/shard/s24/sh/cadb0f40-03c7-4511-a43a-3e6ba8d2c3e4/d9e8f80713876dd8809c89be07ac364b)
- Also removed some custom button sizes so gridfield buttons get their sizes from form styles instead.
