### PR TITLE
BUG: Removed !important attribute of #Remember margin

### DIFF
--- a/css/Security_login.css
+++ b/css/Security_login.css
@@ -1,4 +1,4 @@
-#Remember { margin: 0.5em 0 0.5em 11em !important; }
+#Remember { margin: 0.5em 0 0.5em 11em; }
 
 p#Remember label { display: inline-block; margin: 0; }
 


### PR DESCRIPTION
The Security_login.css file, which is included in the front-end Security_login action, includes an !important modifier in the margin attribute of the #Remember field of the login form.
This is highly disruptive during styling of the login form, as it requires additional usage of !important in user CSS, and furthermore requires that the user's CSS be included after Security_login.css, which is usually the case but not always.

I don't foresee any side-effects in removing this !important modifier, except in cases where bad CSS has been written against the login form.
