### PR TITLE
BUG: Set visibility on login form methods to public.

### DIFF
--- a/security/Security.php
+++ b/security/Security.php
@@ -243,7 +243,7 @@ class Security extends Controller {
 	/**
 	 * Get the login form to process according to the submitted data
 	 */
-	protected function LoginForm() {
+	public function LoginForm() {
 		if(isset($this->requestParams['AuthenticationMethod'])) {
 			$authenticator = trim($_REQUEST['AuthenticationMethod']);
 
@@ -270,7 +270,7 @@ class Security extends Controller {
 	 *
 	 * @todo Check how to activate/deactivate authentication methods
 	 */
-	protected function GetLoginForms()
+	public function GetLoginForms()
 	{
 		$forms = array();
 


### PR DESCRIPTION
The visibility of the Security::LoginForm and Security::getLoginForms methods is current set to protected. There is no evident reason why this is, and it drastically interferes with the ability of a developer to place the login forms in places other than the login page (such as having a login form available in the header).

This patch sets the visibility of these methods to public.
