### PR TITLE
Tidy up of the panels for consistency, filter message styles, position of edit tree button

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -145,7 +145,7 @@ form.nostyle label.left { float: none; display: inherit; width: auto; padding: 0
 form.nostyle .middleColumn { margin-left: 0; }
 form.nostyle input.text, form.nostyle textarea, form.nostyle select, form.nostyle .TreeDropdownField { width: auto; max-width: auto; }
 
-.field { display: block; border-bottom: 1px solid #d0d3d5; -webkit-box-shadow: 0 1px 0 rgba(245, 245, 245, 0.8); -moz-box-shadow: 0 1px 0 rgba(245, 245, 245, 0.8); box-shadow: 0 1px 0 rgba(245, 245, 245, 0.8); padding: 0 0 7px 0; margin: 0 0 8px 0; *zoom: 1; }
+.field { display: block; border-bottom: 1px solid #d0d3d5; -webkit-box-shadow: 0 1px 0 rgba(245, 245, 245, 0.8); -moz-box-shadow: 0 1px 0 rgba(245, 245, 245, 0.8); box-shadow: 0 1px 0 rgba(245, 245, 245, 0.8); padding: 0 0 7px 0; margin: 8px 0; *zoom: 1; }
 .field:last-child { border-bottom: none; -webkit-box-shadow: none; -moz-box-shadow: none; box-shadow: none; }
 .field:after { content: "\0020"; display: block; height: 0; clear: both; overflow: hidden; visibility: hidden; }
 .field.nolabel .middleColumn { margin-left: 0; }
@@ -394,9 +394,9 @@ body.cms { overflow: hidden; }
 .ui-tabs .cms-edit-form .ui-tabs-nav, .ui-tabs .cms-content-fields .ui-tabs-nav { margin: 10px 12px 0; padding: 0 8px 0 0; /* second set of tabs */ }
 .ui-tabs .cms-edit-form #tree_actions .ui-tabs-nav, .ui-tabs .cms-content-fields #tree_actions .ui-tabs-nav { margin: 0; }
 .ui-tabs .cms-panel-padded h3 { margin-left: 12px; /* reports headers, probably too specific */ }
-.ui-tabs .cms-panel-padded .ui-tabs-panel { margin: 0; padding: 12px 12px 12px; }
+.ui-tabs .cms-panel-padded .ui-tabs-panel { margin: 0; padding: 8px 12px 0 12px; }
 .ui-tabs .cms-panel-padded .ui-tabs-panel .ui-tabs-panel { padding: 8px 0 0 0; }
-.ui-tabs .ui-tabs .ui-tabs-panel { /* second level tabs */ padding-top: 8px; }
+.ui-tabs .ui-tabs .ui-tabs-panel { /* second level tabs */ padding-top: 12px; }
 .ui-tabs.ss-tabset-tabshidden .ui-tabs-panel { border-top: none; }
 
 /** Primary styles which sit on top of screen, with different tab colors. TODO Only use one "primary" selector and fix HTMLEditorField TabSet addExtraClass() */
@@ -426,7 +426,7 @@ body.cms { overflow: hidden; }
 .cms-content-actions, .cms-preview-controls { margin: 0; padding: 12px 12px; z-index: 0; border-top: 1px solid #cacacc; -webkit-box-shadow: 1px 0 0 #eceff1, rgba(248, 248, 248, 0.9) 0 1px 0px inset, rgba(201, 205, 206, 0.8) 0 0 1px; -moz-box-shadow: 1px 0 0 #eceff1, rgba(248, 248, 248, 0.9) 0 1px 0px inset, rgba(201, 205, 206, 0.8) 0 0 1px; box-shadow: 1px 0 0 #eceff1, rgba(248, 248, 248, 0.9) 0 1px 0px inset, rgba(201, 205, 206, 0.8) 0 0 1px; height: 28px; background-color: #eceff1; }
 
 /** -------------------------------------------- Messages -------------------------------------------- */
-.message { display: block; clear: both; margin: 8px 0; padding: 10px 12px; font-weight: normal; border: 1px #ccc solid; background: #fff; background: rgba(255, 255, 255, 0.5); text-shadow: none; -webkit-border-radius: 3px 3px 3px 3px; -moz-border-radius: 3px 3px 3px 3px; -ms-border-radius: 3px 3px 3px 3px; -o-border-radius: 3px 3px 3px 3px; border-radius: 3px 3px 3px 3px; }
+.message { display: block; clear: both; margin: 0 0 8px; padding: 10px 12px; font-weight: normal; border: 1px #ccc solid; background: #fff; background: rgba(255, 255, 255, 0.5); text-shadow: none; -webkit-border-radius: 3px 3px 3px 3px; -moz-border-radius: 3px 3px 3px 3px; -ms-border-radius: 3px 3px 3px 3px; -o-border-radius: 3px 3px 3px 3px; border-radius: 3px 3px 3px 3px; }
 .message.notice { background-color: #f0f8fc; border-color: #93cde8; }
 .message.warning { background-color: #fefbde; border-color: #e9d104; }
 .message.error, .message.bad, .message.required, .message.validation { background-color: #fae8e9; border-color: #e68288; }
@@ -466,7 +466,7 @@ p.message { margin-bottom: 12px; }
 #PageType ul li .description { font-style: italic; }
 
 /** -------------------------------------------- Content toolbar -------------------------------------------- */
-.cms-content-toolbar { min-height: 29px; display: block; margin: 0 0 15px 0; border-bottom: 1px solid #d0d3d5; -webkit-box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); -moz-box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); -o-box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); *zoom: 1; /* smaller treedropdown */ }
+.cms-content-toolbar { min-height: 29px; display: block; margin: 0 0 12px 0; padding-bottom: 0; border-bottom: 1px solid #d0d3d5; -webkit-box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); -moz-box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); -o-box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); *zoom: 1; /* smaller treedropdown */ }
 .cms-content-toolbar:after { content: "\0020"; display: block; height: 0; clear: both; overflow: hidden; visibility: hidden; }
 .cms-content-toolbar .cms-tree-view-modes { float: right; padding-top: 5px; }
 .cms-content-toolbar .cms-tree-view-modes * { display: inline-block; }
@@ -482,7 +482,7 @@ p.message { margin-bottom: 12px; }
 /* -------------------------------------------------------- Content Tools is the sidebar on the left of the main content panel */
 .cms-content-tools { background: #eceff1; width: 192px; overflow-y: auto; overflow-x: hidden; z-index: 70; border-right: 1px solid #c0c0c2; -webkit-box-shadow: rgba(248, 248, 248, 0.9) -1px 0 0 inset, 0 0 1px rgba(201, 205, 206, 0.8); -moz-box-shadow: rgba(248, 248, 248, 0.9) -1px 0 0 inset, 0 0 1px rgba(201, 205, 206, 0.8); box-shadow: rgba(248, 248, 248, 0.9) -1px 0 0 inset, 0 0 1px rgba(201, 205, 206, 0.8); float: left; position: relative; }
 .cms-content-tools.filter { padding: 0 !important; }
-.cms-content-tools .cms-panel-header { clear: both; margin: 0 0 7px; line-height: 24px; border-bottom: 1px solid #d0d3d5; -webkit-box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); -moz-box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); -o-box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); }
+.cms-content-tools .cms-panel-header { clear: both; margin: 10px 0 7px; padding-bottom: 2px; line-height: 24px; border-bottom: 1px solid #d0d3d5; -webkit-box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); -moz-box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); -o-box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); box-shadow: 0 1px 0 rgba(248, 248, 248, 0.9); }
 .cms-content-tools .cms-panel-content { width: 176px; padding: 8px 8px 0; overflow: auto; height: 100%; }
 .cms-content-tools .cms-panel-content .Actions .ss-ui-action-constructive { margin-right: 5px; }
 .cms-content-tools .cms-content-header { background-color: #748d9d; background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjUwJSIgeTE9IjAlIiB4Mj0iNTAlIiB5Mj0iMTAwJSI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2IwYmVjNyIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzc0OGQ5ZCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA=='); background-size: 100%; background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #b0bec7), color-stop(100%, #748d9d)); background-image: -webkit-linear-gradient(#b0bec7, #748d9d); background-image: -moz-linear-gradient(#b0bec7, #748d9d); background-image: -o-linear-gradient(#b0bec7, #748d9d); background-image: linear-gradient(#b0bec7, #748d9d); }
@@ -507,11 +507,15 @@ p.message { margin-bottom: 12px; }
 .cms-content-tools table td { padding: 4px; line-height: 16px; vertical-align: top; }
 .cms-content-tools td { border-bottom: 1px solid #ced7dc; padding: 7px 2px; font-size: 11px; }
 
+/** ------------------------------------------------------------------ Filter message - should be generic and not nesacerly just for tree ----------------------------------------------------------------- */
+.cms-tree-filtered { display: block; margin: 0 0 8px; padding: 10px 12px; font-weight: normal; border: 1px #d0d3d5 solid; background: #fff; background: rgba(255, 255, 255, 0.5); text-shadow: none; -webkit-border-radius: 3px; -moz-border-radius: 3px; -ms-border-radius: 3px; -o-border-radius: 3px; border-radius: 3px; }
+
 /**  CMS Batch actions */
 .cms-content-batchactions { float: left; position: relative; display: block; margin-left: 8px; }
 .cms-content-batchactions .view-mode-batchactions-wrapper { float: left; padding: 4px 6px; border: 1px solid #aaa; margin-bottom: 8px; background-color: #D9D9D9; background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjUwJSIgeTE9IjAlIiB4Mj0iNTAlIiB5Mj0iMTAwJSI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2ZmZmZmZiIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iI2Q5ZDlkOSIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA=='); background-size: 100%; background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #ffffff), color-stop(100%, #d9d9d9)); background-image: -webkit-linear-gradient(top, #ffffff, #d9d9d9); background-image: -moz-linear-gradient(top, #ffffff, #d9d9d9); background-image: -o-linear-gradient(top, #ffffff, #d9d9d9); background-image: linear-gradient(top, #ffffff, #d9d9d9); border-top-left-radius: 4px; border-bottom-left-radius: 4px; }
 .cms-content-batchactions .view-mode-batchactions-wrapper label { display: none; }
 .cms-content-batchactions .view-mode-batchactions-wrapper fieldset, .cms-content-batchactions .view-mode-batchactions-wrapper .Actions { display: inline-block; }
+.cms-content-batchactions .view-mode-batchactions-wrapper #view-mode-batchactions { margin-top: 2px; }
 .cms-content-batchactions.inactive .view-mode-batchactions-wrapper { border-radius: 4px; }
 .cms-content-batchactions.inactive .view-mode-batchactions-wrapper label { display: inline; }
 .cms-content-batchactions form > * { display: block; float: left; }

--- a/admin/scss/_forms.scss
+++ b/admin/scss/_forms.scss
@@ -26,7 +26,7 @@ form.nostyle {
 	// margin with a postive padding to ensure the bottom border extends
 	// over the edges
 	padding: 0 0 $grid-y - 1 0;
-	margin: 0 0 $grid-y 0;
+	margin: $grid-y 0;
 
 	&:last-child {
 		border-bottom: none;

--- a/admin/scss/_style.scss
+++ b/admin/scss/_style.scss
@@ -275,15 +275,15 @@ body.cms {
 		}
 		.ui-tabs-panel {
 			margin: 0;
-			padding: 12px 12px 12px;
+			padding: $grid-y $grid-x*1.5 0 $grid-x*1.5;
 
 			.ui-tabs-panel {
-				padding: $grid-x 0 0 0;
+				padding: $grid-y 0 0 0;
 			}
 		}
 	}
 	.ui-tabs .ui-tabs-panel {						/* second level tabs */
-		padding-top: 8px;
+		padding-top: $grid-y*1.5;
 	}
 
 	&.ss-tabset-tabshidden .ui-tabs-panel {
@@ -449,7 +449,7 @@ body.cms {
 .message {												// White
 	display: block;
 	clear: both;
-	margin: $grid-y 0;
+	margin: 0 0 $grid-y;
 	padding: $grid-y + $grid-x/4 $grid-x + $grid-x/2;
 	font-weight: normal;	
 	border: 1px #ccc solid;
@@ -605,7 +605,8 @@ p.message {
 .cms-content-toolbar {
 	min-height: 29px;
 	display: block;
-	margin: 0 0 15px 0;
+	margin: 0 0 $grid-y*1.5 0;
+	padding-bottom: 0;
 	
 	@include doubleborder(bottom, $color-light-separator, $box-shadow-shine);
 	@include legacy-pie-clearfix();
@@ -691,7 +692,8 @@ p.message {
 	
 	.cms-panel-header {
 		clear: both;
-		margin: 0 0 $grid-y - 1;
+		margin: 10px 0 $grid-y - 1;
+		padding-bottom: 2px;
 		line-height: $grid-y * 3;
 		
 		@include doubleborder(bottom, $color-light-separator, $box-shadow-shine);
@@ -824,6 +826,23 @@ p.message {
 	}
 }
 
+/** ------------------------------------------------------------------
+ * Filter message - should be generic and not nesacerly just for tree
+ * ----------------------------------------------------------------- */
+
+.cms-tree-filtered {
+	display: block;
+	margin: 0 0 8px;
+	padding: 10px 12px;
+	font-weight: normal;	
+	border: 1px $color-light-separator solid;
+	background: #fff;									// for browsers that don't understand rgba
+	background: rgba(#fff,0.5);
+	text-shadow: none;
+	@include border-radius(3px);
+}
+
+
 /** 
  * CMS Batch actions
  */
@@ -850,6 +869,9 @@ p.message {
 
 		fieldset, .Actions {
 			display: inline-block;
+		}
+		#view-mode-batchactions {
+			margin-top: 2px;
 		}
 	}
 


### PR DESCRIPTION
General tidy up of the tab panels so that spacing is more consistent

Improved filter message styles but is not a complete fix and I suggest that filter messages should be available in other areas of framework like in the files area, more discussion here (fixes #7884).

Position of "edit tree" button has been allowed to align with the "add new" button in the sitetree collapsed panel toolbar. The button will probably push out to the next line in some browsers as the buttons are still quite large (the edit tree button will potentially be getting replaced soon anyway).
