### PR TITLE
ENHANCEMENT: LeftAndMain breadcrumbs to use MenuTitle

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -645,13 +645,13 @@ class LeftAndMain extends Controller implements PermissionProvider {
 				$ancestors->push($record);
 				foreach($ancestors as $ancestor) {
 					$items->push(new ArrayData(array(
-						'Title' => $ancestor->Title,
+						'Title' => ($ancestor->MenuTitle) ? $ancestor->MenuTitle : $ancestor->Title,
 						'Link' => ($unlinked) ? false : Controller::join_links($this->Link('show'), $ancestor->ID)
 					)));		
 				}
 			} else {
 				$items->push(new ArrayData(array(
-					'Title' => $record->Title,
+					'Title' => ($record->MenuTitle) ? $record->MenuTitle : $record->Title,
 					'Link' => ($unlinked) ? false : Controller::join_links($this->Link('show'), $record->ID)
 				)));	
 			}


### PR DESCRIPTION
Breadcrumbs in the CMS currently only use 'Title', when 'MenuTitle' is probably more appropriate (if/when it is set).
