### PR TITLE
BUG Hardcoded project name in include_by_locale()

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -1956,7 +1956,7 @@ class i18n extends Object implements TemplateGlobalProvider {
 		
 		// Sort modules by inclusion priority, then alphabetically
 		// TODO Should be handled by priority flags within modules
-		$prios = array('sapphire' => 10, 'framework' => 10, 'admin' => 11, 'cms' => 12, 'mysite' => 90);
+		$prios = array('sapphire' => 10, 'framework' => 10, 'admin' => 11, 'cms' => 12, project() => 90);
 		$modules = SS_ClassLoader::instance()->getManifest()->getModules();
 		ksort($modules);
 		uksort(


### PR DESCRIPTION
include_by_locale() should not use hardcoded default project name 'mysite' (fixes #7969).
