### PR TITLE
BUG: RestfulService shouldn't cache POST and PUT responses.

### DIFF
--- a/api/RestfulService.php
+++ b/api/RestfulService.php
@@ -103,8 +103,8 @@ class RestfulService extends ViewableData {
 	
 	/**
 	 * Makes a request to the RESTful server, and return a {@link RestfulService_Response} object for parsing of the result.
+	 *
 	 * @todo Better POST, PUT, DELETE, and HEAD support
-	 * @todo Caching of requests - probably only GET and HEAD requestst
 	 * @todo JSON support in RestfulService_Response
 	 * @todo Pass the response headers to RestfulService_Response
 	 *
@@ -124,10 +124,9 @@ class RestfulService extends ViewableData {
 		$cache_path = $cachedir."/xmlresponse_$cache_file";
 		
 		// Check for unexpired cached feed (unless flush is set)
-		if(!isset($_GET['flush']) && @file_exists($cache_path) && @filemtime($cache_path) + $this->cache_expire > time()) {
+		if(in_array($method, array('GET', 'HEAD', 'OPTIONS')) && !isset($_GET['flush']) && @file_exists($cache_path) && @filemtime($cache_path) + $this->cache_expire > time()) {
 			$store = file_get_contents($cache_path);
-			$response = unserialize($store);
-			
+			$response = unserialize($store);	
 		} else {
 			$ch = curl_init();
 			$timeout = 5;


### PR DESCRIPTION
Avoid caching POST and PUT responses from RestfulService. Avoids an unsecure situation where RestfulService is used for secure data.
