### PR TITLE
BUG removeRequiredField() should use array_splice() instead of unset()

### DIFF
--- a/forms/RequiredFields.php
+++ b/forms/RequiredFields.php
@@ -112,9 +112,9 @@ class RequiredFields extends Validator {
 	}
 
 	public function removeRequiredField($field) {
-		for($i=0; $i<count($this->required); $i++) {
-			if($field == $this->required[$i]) {
-				unset($this->required[$i]);
+		foreach ($this->required as $i => $required) {
+			if ($field == $required) {
+				array_splice($this->required, $i);
 			}
 		}
 	}


### PR DESCRIPTION
Function unset() preserves numeric keys and method removeRequiredField() will give a PHP notice about nonexistent array key and loop won't iterate throughout all elements in array on second method call (and all subsequent).
So it's better to use foreach loop and array_splice() function (it doesn't preserve numeric keys).
