### PR TITLE
BUG: Right click on LeftAndMain menu caused CMS preview pane to open

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -168,7 +168,8 @@ jQuery.noConflict();
 			 * Ensure the user can see the requested section - restore the default view.
 			 */
 			'from .cms-menu-list li a': {
-				onclick: function() {
+				onclick: function(e) {
+					if(e.which > 1) return;
 					this.splitViewMode();
 				}
 			},


### PR DESCRIPTION
The onclick event for LeftAndMain menu links didn't check if the click
was left or right, meaning that right click events could trigger the
function for loading split view mode in some browser/os combinations.
