### PR TITLE
Fix edge case in which uninitialized buttons are being destroyed.

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -575,7 +575,7 @@ jQuery.noConflict();
 				this._super();
 			},
 			onremove: function() {
-				this.button('destroy');
+				if(this.data('button')) this.button('destroy');
 				this._super();
 			}
 		});


### PR DESCRIPTION
In certain cases, the button may not yet be initialized or may no longer have button properties at the time of removal from the DOM. Without this check, an uncaught exception is thrown.
