### PR TITLE
BUG Calling DataObject::relField() on a object with an empty relation list

### DIFF
--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -1091,6 +1091,9 @@ class DataObjectTest extends SapphireTest {
 		$player = $this->objFromFixture('DataObjectTest_Player', 'player2');
 		// Test that we can traverse more than once, and that arbitrary methods are okay
 		$this->assertEquals("Team 1", $player->relField('Teams.First.Title'));
+		
+		$newPlayer = new DataObjectTest_Player();
+		$this->assertNull($newPlayer->relField('Teams.First.Title'));
 	}
 
 	public function testRelObject() {


### PR DESCRIPTION
This causes a 'Fatal error: Call to a member function hasMethod() on a non-object'.

This can happen when displaying a field in a gridfield on a belongs_to relationship.
