### PR TITLE
BUG: Accordion widget doesn't actually accept 'true' for 'active'

### DIFF
--- a/javascript/ToggleCompositeField.js
+++ b/javascript/ToggleCompositeField.js
@@ -4,7 +4,7 @@
 			onadd: function() {
 				this.accordion({
 					collapsible: true,
-					active: !this.hasClass("ss-toggle-start-closed")
+					active: (this.hasClass("ss-toggle-start-closed")) ? false : 0
 				});
 
 				this._super();


### PR DESCRIPTION
The accordion widget was previously being passed true and false, whereas it either expects false or the integer of the panel to show [http://docs.jquery.com/UI/API/1.8/Accordion#option-active].

This fix sets it as either false or 0. I'm making the assumption that with the Silverstripe implementation with ToggleCompositeField, there would only ever be a single panel. If the field allows for more than one panel, then we would need to alter the `setStartClosed()` function to allow for an integer rather than just true/false.
