### PR TITLE
BUG Convert::raw2xml() not converting new lines to break tags

### DIFF
--- a/core/Convert.php
+++ b/core/Convert.php
@@ -74,7 +74,7 @@ class Convert {
 			foreach($val as $k => $v) $val[$k] = self::raw2xml($v);
 			return $val;
 		} else {
-			return htmlspecialchars($val, ENT_QUOTES, 'UTF-8');
+			return nl2br(htmlspecialchars($val, ENT_QUOTES, 'UTF-8'));
 		}
 	}
 	


### PR DESCRIPTION
This bug came in in 3.0 - where the new `raw2xml()` function did everything that it did in 2.4, except for converting new lines to break tags.

This commit fixes that.
