### PR TITLE
Use preg_replace_callback over preg_replace with e modifier

### DIFF
--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -60,20 +60,25 @@ class HTTP {
 			if(!is_numeric($tag)) $tagPrefix = "$tag ";
 			else $tagPrefix = "";
 
-			$regExps[] = "/(<{$tagPrefix}[^>]*$attrib *= *\")([^\"]*)(\")/ie";
-			$regExps[] = "/(<{$tagPrefix}[^>]*$attrib *= *')([^']*)(')/ie";
-			$regExps[] = "/(<{$tagPrefix}[^>]*$attrib *= *)([^\"' ]*)( )/ie";
+			$regExps[] = "/(<{$tagPrefix}[^>]*$attrib *= *\")([^\"]*)(\")/i";
+			$regExps[] = "/(<{$tagPrefix}[^>]*$attrib *= *')([^']*)(')/i";
+			$regExps[] = "/(<{$tagPrefix}[^>]*$attrib *= *)([^\"' ]*)( )/i";
 		}
-		$regExps[] = '/(background-image:[^;]*url *\()([^)]+)(\))/ie';
-		$regExps[] = '/(background:[^;]*url *\()([^)]+)(\))/ie';
-		$regExps[] = '/(list-style-image:[^;]*url *\()([^)]+)(\))/ie';
-		$regExps[] = '/(list-style:[^;]*url *\()([^)]+)(\))/ie';
+		$regExps[] = '/(background-image:[^;]*url *\()([^)]+)(\))/i';
+		$regExps[] = '/(background:[^;]*url *\()([^)]+)(\))/i';
+		$regExps[] = '/(list-style-image:[^;]*url *\()([^)]+)(\))/i';
+		$regExps[] = '/(list-style:[^;]*url *\()([^)]+)(\))/i';
 
 		// Make
-		$code = 'stripslashes("$1") . (' . str_replace('$URL', 'stripslashes("$2")', $code) . ') . stripslashes("$3")';
-
+		$callback = function($matches) use($code) {
+			return
+				stripslashes($matches[1]) .
+				str_replace('$URL', stripslashes($matches[2]), $code) .
+				stripslashes($matches[3]);
+		};
+		
 		foreach($regExps as $regExp) {
-			$content = preg_replace($regExp, $code, $content);
+			$content = preg_replace_callback($regExp, $callback, $content);
 		}
 
 		return $content;

--- a/core/Convert.php
+++ b/core/Convert.php
@@ -244,9 +244,12 @@ class Convert {
 		
 		// Expand hyperlinks
 		if(!$preserveLinks && !$config['PreserveLinks']) {
-			$data = preg_replace('/<a[^>]*href\s*=\s*"([^"]*)">(.*?)<\/a>/ie', "Convert::html2raw('\\2').'[\\1]'",
-				$data);
-			$data = preg_replace('/<a[^>]*href\s*=\s*([^ ]*)>(.*?)<\/a>/ie', "Convert::html2raw('\\2').'[\\1]'", $data);
+			$data = preg_replace_callback('/<a[^>]*href\s*=\s*"([^"]*)">(.*?)<\/a>/i', function($matches) {
+				return Convert::html2raw($matches[2]) . "[$matches[1]]";
+			}, $data);
+			$data = preg_replace_callback('/<a[^>]*href\s*=\s*([^ ]*)>(.*?)<\/a>/i', function($matches) {
+				return Convert::html2raw($matches[2]) . "[$matches[1]]";
+			}, $data);
 		}
 	
 		// Replace images with their alt tags

--- a/email/Mailer.php
+++ b/email/Mailer.php
@@ -368,7 +368,9 @@ function encodeFileForEmail($file, $destFileName = false, $disposition = NULL, $
 function QuotedPrintable_encode($quotprint) {
 		$quotprint = (string)str_replace('\r\n',chr(13).chr(10),$quotprint);
 		$quotprint = (string)str_replace('\n',  chr(13).chr(10),$quotprint);
-		$quotprint = (string)preg_replace("~([\x01-\x1F\x3D\x7F-\xFF])~e", "sprintf('=%02X', ord('\\1'))", $quotprint);
+		$quotprint = (string)preg_replace_callback("~([\x01-\x1F\x3D\x7F-\xFF])~e", function($matches) {
+			return sprintf('=%02X', ord($matches[1]));
+		}, $quotprint);
 		//$quotprint = (string)str_replace('\=0D=0A',"=0D=0A",$quotprint);
 		$quotprint = (string)str_replace('=0D=0A',"\n",$quotprint);	
 		$quotprint = (string)str_replace('=0A=0D',"\n",$quotprint);	


### PR DESCRIPTION
The e modifier is deprecated in PHP 5.5. The tinymce-spellchecker module, specifically the GoogleSpell tie-in, still uses it, so that'll need to be updated once the vendor has updated it.
