### PR TITLE
BUGFIX Even if there are zero items there is always at least one page.

### DIFF
--- a/core/PaginatedList.php
+++ b/core/PaginatedList.php
@@ -328,7 +328,7 @@ class PaginatedList extends SS_ListDecorator {
 	 * @return int
 	 */
 	public function TotalPages() {
-		return ceil($this->getTotalItems() / $this->pageLength);
+		return max(array(ceil($this->getTotalItems() / $this->pageLength), 1));
 	}
 
 	/**


### PR DESCRIPTION
Either TotalPages needs to return 1 even if there are zero items or CurrentPage needs to return 0 if there are zero items. Always having at least one page will be easier to deal with and introduces fewer changes.
