### PR TITLE
adding extension hook in GridFieldDetailForm.php

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -348,7 +348,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 
 		$cb = $this->component->getItemEditFormCallback();
 		if($cb) $cb($form, $this);
-
+		$this->extend("updateItemEditForm", $form);
 		return $form;
 	}
 


### PR DESCRIPTION
This hook is useful so that you can add additional fields / actions in a gridfield form that are not available in other settings (e.g. additional actions: previous / next / save and publish / unpublish / etc)
