### PR TITLE
BUGFIX: Don't have postgresql choke on bad data when an item is removed from an enum

### DIFF
--- a/model/fieldtypes/Enum.php
+++ b/model/fieldtypes/Enum.php
@@ -65,6 +65,14 @@ class Enum extends StringField {
 	 * @return void
 	 */
 	public function requireField() {
+		// Remove bad data from the enum before changing the field type
+		if(DB::getConn()->hasField($this->tableName, $this->name)) {
+			$SQL_default = Convert::raw2sql($this->default);
+			$SQL_enum = Convert::raw2sql($this->enum);
+
+			DB::query("UPDATE \"$this->tableName\" SET \"$this->name\" = '$SQL_default' WHERE \"$this->name\" NOT IN ('"  .implode("','", $SQL_enum)."')");
+		}
+
 		$parts = array(
 			'datatype' => 'enum', 
 			'enums' => Convert::raw2sql($this->enum), 


### PR DESCRIPTION
This fix ensures that there is no corrupt data stored in an enum when a column is removed from it.

An alternative fix would be to ensure that the enum always contained the values listed in the actual data.  The main issue with the approach included here is that would lead to data-loss if shuttling back & forth between different versions of an app.
