### PR TITLE
FIX: Fix DataObject::get_one() when the classname is passed with imprope...

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -2850,12 +2850,10 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 				&& DataObject::$_cache_get_one[$callerClass][$cacheKey] instanceof DataObject 
 				&& DataObject::$_cache_get_one[$callerClass][$cacheKey]->destroyed) {
 
-			DataObject::$_cache_get_one[$callerClass][$cacheKey
-			] = false;
+			DataObject::$_cache_get_one[$callerClass][$cacheKey] = false;
 		}
 		if(!$cache || !isset(DataObject::$_cache_get_one[$callerClass][$cacheKey])) {
-			$dl = DataList::create($callerClass)->where($filter)->sort($orderby);
-			$dl->setDataModel(DataModel::inst());
+			$dl = $callerClass::get()->where($filter)->sort($orderby);
 			$item = $dl->First();
 
 			if($cache) {

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -171,6 +171,10 @@ class DataObjectTest extends SapphireTest {
 		$this->assertEquals('Bob', $comment->Name);
 		$comment = DataObject::get_one('DataObjectTest_TeamComment', '', true, '"Name" DESC');
 		$this->assertEquals('Phil', $comment->Name);
+
+		// Test get_one() with bad case on the classname
+		$subteam1 = DataObject::get_one('dataobjecttest_subteam', "\"Title\" = 'Subteam 1'", true);
+		$this->assertEquals($subteam1->Title, "Subteam 1");
 	}
 
 	public function testGetSubclassFields() {


### PR DESCRIPTION
...r casing.
