### PR TITLE
BUGFIX Versioned_Version->relField()

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -1210,4 +1210,32 @@ class Versioned_Version extends ViewableData {
 	public function Published() {
 		return !empty( $this->record['WasPublished'] );
 	}
+
+	/**
+	 * Copied from DataObject to allow access via dot notation.
+	 */
+	public function relField($fieldName) {
+		$component = $this;
+
+		if(strpos($fieldName, '.') !== false) {
+			$parts = explode('.', $fieldName);
+			$fieldName = array_pop($parts);
+
+			// Traverse dot syntax
+			foreach($parts as $relation) {
+				if($component instanceof SS_List) {
+					if(method_exists($component,$relation)) $component = $component->$relation();
+					else $component = $component->relation($relation);
+				} else {
+					$component = $component->$relation();
+				}
+			}
+		}
+
+		// Unlike has-one's, these "relations" can return false
+		if($component) {
+			if ($component->hasMethod($fieldName)) return $component->$fieldName();
+			return $component->$fieldName;
+		}
+	}
 }


### PR DESCRIPTION
Copied from DataObject, since we can't use the $fallback opion in this case
(will try to retrieve from wrong class). Specifically, this was needed
to generate a GridField view which lists Versioned_Version records with the Author.Email field.
Since I can't (easily) overload Versioned_Version (its instanciated within Versioned),
I don't see an easy way to access this relationship otherwise. Ideally Versioned_Version would extend DataObject (or behave as one), but without requiring a table, but that's a much larger refactoring.
