### PR TITLE
FIX #8188 Properly show link for showing and hiding class spec in model admin

### DIFF
--- a/admin/javascript/ModelAdmin.js
+++ b/admin/javascript/ModelAdmin.js
@@ -19,9 +19,9 @@
 		 */
 		$('.importSpec').entwine({
 			onmatch: function() {
-				this.hide();
+				this.find('div.details').hide();
 				this.find('a.detailsLink').click(function() {
-					$('#' + $(this).attr('href').replace(/.*#/,'')).toggle();
+					$('#' + $(this).attr('href').replace(/.*#/,'')).slideToggle();
 					return false;
 				});
 				


### PR DESCRIPTION
On a side note, I had to use slideToggle as opposed to the usual toggle method, which is not available in that scope. I don't understand why but it seems related to a jquery sub definition of the $ variable (using jQuery.('#bla).toggle works, but not $('#bla).toggle();) If someone has a clue, I'd like to understand why, but that's optional, as slideToggle is way more cool B-)
