### PR TITLE
Impossible to unselect TreeDropdownField

### DIFF
--- a/javascript/TreeDropdownField.js
+++ b/javascript/TreeDropdownField.js
@@ -148,7 +148,7 @@
 							.jstree(self.getTreeConfig())
 							.bind('select_node.jstree', function(e, data) {
 								var node = data.rslt.obj, id = $(node).data('id');
-								if(!firstLoad && !self.getValue() === id) {
+								if(!firstLoad && self.getValue() == id) {
 									// Value is already selected, unselect it (for lack of a better UI to do this)
 									self.data('metadata', null);
 									self.setTitle(null);


### PR DESCRIPTION
It was impossible to unselect TreeDropdownField.
'!' operator should not be used at all and identical comparison (===) was too "strict" (self.getValue() returns string but $(node).data('id') returns number).
