### PR TITLE
BUG PaginatedList deprecated method was calling non-existent method

### DIFF
--- a/core/PaginatedList.php
+++ b/core/PaginatedList.php
@@ -438,7 +438,7 @@ class PaginatedList extends SS_ListDecorator {
 		Deprecation::notice('3.0', 'Use setPageStart, setPageLength, or setTotalItems instead.');
 		$this->setPageStart($pageStart);
 		$this->setPageLength($pageLength);
-		$this->setTotalSize($totalSize);
+		$this->setTotalItems($totalSize);
 		return $this;
 	}
 


### PR DESCRIPTION
Fixes a typo where PaginatedList's setPageLimits (a deprecated method) was calling a non-existent method.
