### PR TITLE
FIX 7936 Filters double escaped characters in gridfield table

### DIFF
--- a/admin/code/SecurityAdmin.php
+++ b/admin/code/SecurityAdmin.php
@@ -86,6 +86,9 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider {
 		$columns->setDisplayFields(array(
 			'Breadcrumbs' => singleton('Group')->fieldLabel('Title')
 		));
+		$columns->setFieldCasting(array(
+			'Breadcrumbs' => 'HTMLText->NoHTML'
+		));
 		
 		$fields = new FieldList(
 			$root = new TabSet(


### PR DESCRIPTION
Used on security tab for displaying groups. The approach for fixing the issue might seem unconventional but it does the job, and more importantly, it doesn't affect other parts of the CMS.
See http://open.silverstripe.org/ticket/7936
