### PR TITLE
FIX PHPUnit latest not working with composer installed builds

### DIFF
--- a/dev/phpunit/PhpUnitWrapper_3_5.php
+++ b/dev/phpunit/PhpUnitWrapper_3_5.php
@@ -20,12 +20,14 @@ class PhpUnitWrapper_3_5 extends PhpUnitWrapper {
 	 * Initialise the wrapper class.
 	 */
 	public function init() {
-		require_once 'PHP/CodeCoverage.php';
-		require_once 'PHP/CodeCoverage/Report/HTML.php';
+		if(!class_exists('PHPUnit_Framework_TestCase')) {
+			require_once 'PHP/CodeCoverage.php';
+			require_once 'PHP/CodeCoverage/Report/HTML.php';
 
-		require_once 'PHPUnit/Autoload.php';
+			require_once 'PHPUnit/Autoload.php';
 
-		require_once 'PHP/CodeCoverage/Filter.php';
+			require_once 'PHP/CodeCoverage/Filter.php';
+		}
 	}
 	
 	/**


### PR DESCRIPTION
When using composer, we must rely on the composer autoloader to
load in PHPUnit and not try do to so ourselves, as the old
PHPUnit\Autoload.php file doesnt understand how to find things
in vendor
