### PR TITLE
API: Refactor the authentication plugin system to make it easier to crea...

### DIFF
--- a/security/ChangePasswordForm.php
+++ b/security/ChangePasswordForm.php
@@ -5,7 +5,8 @@
  * @subpackage security
  */
 class ChangePasswordForm extends Form {
-	
+	protected $authenticator;
+
 	/**
 	 * Constructor
 	 *
@@ -19,31 +20,30 @@ class ChangePasswordForm extends Form {
 	 * @param FieldList|FormAction $actions All of the action buttons in the
 	 *                                     form - a {@link FieldList} of
 	 */
-	public function __construct($controller, $name, $fields = null, $actions = null) {
+	function __construct($controller, $name, Authenticator $authenticator) {
+		$this->authenticator = $authenticator;
+
 		if(isset($_REQUEST['BackURL'])) {
 			$backURL = $_REQUEST['BackURL'];
 		} else {
 			$backURL = Session::get('BackURL');
 		}
 		
-		if(!$fields) {
-			$fields = new FieldList();
-			
-			// Security/changepassword?h=XXX redirects to Security/changepassword
-			// without GET parameter to avoid potential HTTP referer leakage.
-			// In this case, a user is not logged in, and no 'old password' should be necessary.
-			if(Member::currentUser()) {
-				$fields->push(new PasswordField("OldPassword",_t('Member.YOUROLDPASSWORD', "Your old password")));
-			}
+		$fields = new FieldList();
 
-			$fields->push(new PasswordField("NewPassword1", _t('Member.NEWPASSWORD', "New Password")));
-			$fields->push(new PasswordField("NewPassword2", _t('Member.CONFIRMNEWPASSWORD', "Confirm New Password")));
+		// Security/changepassword?h=XXX redirects to Security/changepassword
+		// without GET parameter to avoid potential HTTP referer leakage.
+		// In this case, a user is not logged in, and no 'old password' should be necessary.
+		if(Member::currentUser()) {
+			$fields->push(new PasswordField("OldPassword",_t('Member.YOUROLDPASSWORD', "Your old password")));
 		}
-		if(!$actions) {
-			$actions = new FieldList(
-				new FormAction("doChangePassword", _t('Member.BUTTONCHANGEPASSWORD', "Change Password"))
-			);
-		}
+
+		$fields->push(new PasswordField("NewPassword1", _t('Member.NEWPASSWORD', "New Password")));
+		$fields->push(new PasswordField("NewPassword2", _t('Member.CONFIRMNEWPASSWORD', "Confirm New Password")));
+
+		$actions = new FieldList(
+			new FormAction("doChangePassword", _t('Member.BUTTONCHANGEPASSWORD', "Change Password"))
+		);
 
 		if(isset($backURL)) {
 			$fields->push(new HiddenField('BackURL', 'BackURL', $backURL));
@@ -52,6 +52,13 @@ class ChangePasswordForm extends Form {
 		parent::__construct($controller, $name, $fields, $actions);
 	}
 
+	function getAuthenticator() {
+		return $this->authenticator;
+	}
+
+	function setAuthenticator(Authenticator $authenticator) {
+		$this->authenticator = $authenticator;
+	}
 
 	/**
 	 * Change the password
@@ -61,7 +68,7 @@ class ChangePasswordForm extends Form {
 	public function doChangePassword(array $data) {
 		if($member = Member::currentUser()) {
 			// The user was logged in, check the current password
-			if(empty($data['OldPassword']) || !$member->checkPassword($data['OldPassword'])->valid()) {
+			if(empty($data['OldPassword']) || !$this->authenticator->checkPassword($member, $data['OldPassword'])) {
 				$this->clearMessage();
 				$this->sessionMessage(
 					_t('Member.ERRORPASSWORDNOTMATCH', "Your current password does not match, please try again"), 
@@ -95,7 +102,7 @@ class ChangePasswordForm extends Form {
 			return;
 		}
 		else if($data['NewPassword1'] == $data['NewPassword2']) {
-			$isValid = $member->changePassword($data['NewPassword1']);
+			$isValid = $this->authenticator->changePassword($member, $data['NewPassword1']);
 			if($isValid->valid()) {
 				$member->logIn();
 				
@@ -113,7 +120,7 @@ class ChangePasswordForm extends Form {
 					// Redirect to default location - the login form saying "You are logged in as..."
 					$redirectURL = HTTP::setGetVar(
 						'BackURL',
-						Director::absoluteBaseURL(), $this->controller->Link('login')
+						Director::absoluteBaseURL(), Security::Link('login')
 					);
 					$this->controller->redirect($redirectURL);
 				}

--- a/security/LoginForm.php
+++ b/security/LoginForm.php
@@ -1,3 +1,4 @@
+
 <?php
 /**
  * Abstract base class for a login form
@@ -9,11 +10,148 @@
  * @package framework
  * @subpackage security
  */
-abstract class LoginForm extends Form {
-	public function __construct($controller, $name, $fields, $actions) {
-		parent::__construct($controller, $name, $fields, $actions);
+class LoginForm extends Form {
+	public function __construct($controller, $name, Authenticator $authenticator) {
+
+		$this->authenticator = $authenticator;
 		
 		$this->disableSecurityToken();	
+
+		$customCSS = project() . '/css/member_login.css';
+		if(Director::fileExists($customCSS)) {
+			Requirements::css($customCSS);
+		}
+
+		$fields = $this->authenticator->getLoginFields();
+
+		$backURL = null;
+		if(isset($_REQUEST['BackURL'])) {
+			$backURL = $_REQUEST['BackURL'];
+		} else {
+			$backURL = Session::get('BackURL');
+		}
+		if($backURL) {
+			$fields->push(new HiddenField('BackURL', 'BackURL', $backURL));
+		}
+
+		$fields->push(new HiddenField("AuthenticationMethod", null, get_class($this->authenticator)));
+
+		// Log in as someone else
+		if(Member::currentUser() && Member::logged_in_session_exists()) {
+			$fields = new FieldList(
+			);
+			$actions = new FieldList(
+				new FormAction("doLogout", _t('Member.BUTTONLOGINOTHER', "Log in as someone else"))
+			);
+
+		//  Regular log-in
+		} else {
+			if(Security::config()->autologin_enabled) {
+				$fields->push(new CheckboxField(
+					"Remember",
+					_t('Member.REMEMBERME', "Remember me next time?")
+				));
+			}
+		}
+
+		$actions = new FieldList(
+			new FormAction('doLogin', _t('Member.BUTTONLOGIN', "Log in"))
+		);
+
+		if($this->authenticator->supportsPasswordReset()) {
+			$actions->push(new LiteralField(
+				'forgotPassword',
+				'<p id="ForgotPassword"><a href="Security/lostpassword">' . _t('Member.BUTTONLOSTPASSWORD', "I've lost my password") . '</a></p>'
+			));
+		}
+
+		// Reduce attack surface by enforcing POST requests
+		$this->setFormMethod('POST', true);
+
+		parent::__construct($controller, $name, $fields, $actions);
+	}
+
+	public function doLogin($data, $form) {
+		$member = null;
+		try {
+			$member = $this->authenticator->authenticate($data, $form);
+		} catch(SS_UserException $e) {
+			$this->sessionMessage($e->getMessage(), "error");
+		}
+
+		if($member) {
+			$member->LogIn(!empty($data['Remember']));
+
+			Session::clear('SessionForms.MemberLoginForm.Email');
+			Session::clear('SessionForms.MemberLoginForm.Remember');
+			if(
+				isset($_REQUEST['BackURL'])
+				&& $_REQUEST['BackURL']
+				// absolute redirection URLs may cause spoofing
+				&& Director::is_site_url($_REQUEST['BackURL'])
+			) {
+				$this->controller->redirect($_REQUEST['BackURL']);
+			} elseif (Security::config()->default_login_dest) {
+				$this->controller->redirect(Director::absoluteBaseURL() . Security::default_login_dest());
+			} else {
+				$member = Member::currentUser();
+				if($member) {
+					$firstname = Convert::raw2xml($member->FirstName);
+
+					if(!empty($data['Remember'])) {
+						Session::set('SessionForms.MemberLoginForm.Remember', '1');
+						$member->logIn(true);
+					} else {
+						$member->logIn();
+					}
+
+					Session::set('Security.Message.message',
+						sprintf(_t('Member.WELCOMEBACK', "Welcome Back, %s"), $firstname)
+					);
+					Session::set("Security.Message.type", "good");
+				}
+				$this->controller->redirectBack();
+			}
+		} else {
+			foreach(array('Email','Username','Remember') as $field) {
+				if(isset($data[$field])) {
+					Session::set('SessionForms.MemberLoginForm.' . $field, $data[$field]);
+				}
+			}
+
+			if(isset($_REQUEST['BackURL'])) $backURL = $_REQUEST['BackURL'];
+			else $backURL = null;
+
+			if($backURL) Session::set('BackURL', $backURL);
+
+			// Show the right tab on failed login
+			$loginLink = Director::absoluteURL($this->controller->Link('login'));
+			if($backURL) $loginLink .= '?BackURL=' . urlencode($backURL);
+			$this->controller->redirect($loginLink . '#' . $this->FormName() .'_tab');
+		}
+	}
+
+
+	/**
+	 * This field is used in the "You are logged in as %s" message
+	 * @var string
+	 */
+	public $loggedInAsField = 'FirstName';
+
+	protected $authenticator_class = 'MemberAuthenticator';
+
+	/**
+	 * Log out form handler method
+	 *
+	 * This method is called when the user clicks on "logout" on the form
+	 * created when the parameter <i>$checkCurrentUser</i> of the
+	 * {@link __construct constructor} was set to TRUE and the user was
+	 * currently logged in.
+	 */
+	public function doLogout() {
+		$s = new Security();
+		$s->logout();
+		$this->controller->redirectBack();
 	}
 
 	/**
@@ -24,21 +162,19 @@ abstract class LoginForm extends Form {
 	 * @var string
 	 */
 	
-	protected $authenticator_class;
+	protected $authenticator;
+
+
+	public function setAuthenticator(Authenticator $authenticator) {
+		$this->authenticator = $authenticator;
+	}
 
 	/**
 	 * Get the authenticator class
 	 * @return Authenticator Returns the authenticator class for this login form.
 	 */
-	
 	public function getAuthenticator() {
-		if(!class_exists($this->authenticator_class) || !is_subclass_of($this->authenticator_class, 'Authenticator')) {
-			user_error("The form uses an invalid authenticator class! '{$this->authenticator_class}'"
-				. " is not a subclass of 'Authenticator'", E_USER_ERROR);
-			return;
-		}
-		
-		return new $this->authenticator_class;
+		return $this->authenticator;
 	}
 }
 

--- a/security/Member.php
+++ b/security/Member.php
@@ -530,19 +530,19 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	/**
 	 * Return the member for the auto login hash
 	 *
+	 * @param string RAW_hash The hash component of the auto-login token
 	 * @param bool $login Should the member be logged in?
 	 */
 	public static function member_from_autologinhash($RAW_hash, $login = false) {
 		$SQL_hash = Convert::raw2sql($RAW_hash);
-
+ 
 		$member = DataObject::get_one(
 			'Member',
 			"\"AutoLoginHash\"='" . $SQL_hash . "' AND \"AutoLoginExpired\" > " . DB::getConn()->now()
 		);
-
-		if($login && $member)
-			$member->logIn();
-
+ 
+		if($login && $member) $member->logIn();
+ 
 		return $member;
 	}
 

--- a/security/MemberAuthenticator.php
+++ b/security/MemberAuthenticator.php
@@ -29,7 +29,7 @@ class MemberAuthenticator extends Authenticator {
 	 *                     the member object
 	 * @see Security::setDefaultAdmin()
 	 */
-	public static function authenticate($RAW_data, Form $form = null) {
+	public function authenticate($RAW_data, Form $form = null) {
 		if(array_key_exists('Email', $RAW_data) && $RAW_data['Email']){
 			$SQL_user = Convert::raw2sql($RAW_data['Email']);
 		} else {
@@ -41,90 +41,133 @@ class MemberAuthenticator extends Authenticator {
 
 		// Default login (see Security::setDefaultAdmin())
 		if(Security::check_default_admin($RAW_data['Email'], $RAW_data['Password'])) {
-			$member = Security::findAnAdministrator();
+			return Security::findAnAdministrator();
+
 		} else {
 			$member = DataObject::get_one(
 				"Member", 
-				"\"" . Member::config()->unique_identifier_field . "\" = '$SQL_user' AND \"Password\" IS NOT NULL"
+				"\"" . Member::get_unique_identifier_field() . "\" = '$SQL_user' AND \"Password\" IS NOT NULL"
 			);
 
 			if($member) {
 				$result = $member->checkPassword($RAW_data['Password']);
 			} else {
-				$result = new ValidationResult(false, _t('Member.ERRORWRONGCRED'));
-			}
-
-			if($member && !$result->valid()) { 
-				$member->registerFailedLogin();
-				$member = false;
-			}
-		}
-		
-		// Optionally record every login attempt as a {@link LoginAttempt} object
-		/**
-		 * TODO We could handle this with an extension
-		 */
-		if(Security::config()->login_recording) {
-			$attempt = new LoginAttempt();
-			if($member) {
-				// successful login (member is existing with matching password)
-				$attempt->MemberID = $member->ID;
-				$attempt->Status = 'Success';
-				
-				// Audit logging hook
-				$member->extend('authenticated');
-			} else {
-				// failed login - we're trying to see if a user exists with this email (disregarding wrong passwords)
-				$existingMember = DataObject::get_one(
-					"Member",
-					"\"" . Member::config()->unique_identifier_field . "\" = '$SQL_user'"
-				);
-				if($existingMember) {
-					$attempt->MemberID = $existingMember->ID;
-					
-					// Audit logging hook
-					$existingMember->extend('authenticationFailed');
-				} else {
-					
-					// Audit logging hook
-					singleton('Member')->extend('authenticationFailedUnknownUser', $RAW_data);
-				}
-				$attempt->Status = 'Failure';
-			}
-			if(is_array($RAW_data['Email'])) {
-				user_error("Bad email passed to MemberAuthenticator::authenticate(): $RAW_data[Email]", E_USER_WARNING);
 				return false;
 			}
+
+			$isLockedOut = false;
+			$result = null;
+
+			// Default login (see Security::setDefaultAdmin())
+			if(Security::check_default_admin($RAW_data['Email'], $RAW_data['Password'])) {
+				$member = Security::findAnAdministrator();
+			} else {
+				$member = DataObject::get_one(
+					"Member", 
+					"\"" . Member::config()->unique_identifier_field . "\" = '$SQL_user' AND \"Password\" IS NOT NULL"
+				);
+
+				if($member) {
+					$result = $member->checkPassword($RAW_data['Password']);
+				} else {
+					$result = new ValidationResult(false, _t('Member.ERRORWRONGCRED'));
+				}
+
+				if($member && !$result->valid()) { 
+					$member->registerFailedLogin();
+					$member = false;
+				}
+			}
 			
-			$attempt->Email = $RAW_data['Email'];
-			$attempt->IP = Controller::curr()->getRequest()->getIP();
-			$attempt->write();
-		}
-		
-		// Legacy migration to precision-safe password hashes.
-		// A login-event with cleartext passwords is the only time
-		// when we can rehash passwords to a different hashing algorithm,
-		// bulk-migration doesn't work due to the nature of hashing.
-		// See PasswordEncryptor_LegacyPHPHash class.
-		if(
-			$member // only migrate after successful login
-			&& self::$migrate_legacy_hashes
-			&& array_key_exists($member->PasswordEncryption, self::$migrate_legacy_hashes)
-		) {
-			$member->Password = $RAW_data['Password'];
-			$member->PasswordEncryption = self::$migrate_legacy_hashes[$member->PasswordEncryption];
-			$member->write();
-		}
+			// Optionally record every login attempt as a {@link LoginAttempt} object
+			/**
+			 * TODO We could handle this with an extension
+			 */
+			if(Security::config()->login_recording) {
+				$attempt = new LoginAttempt();
+				if($member) {
+					// successful login (member is existing with matching password)
+					$attempt->MemberID = $member->ID;
+					$attempt->Status = 'Success';
+					
+					// Audit logging hook
+					$member->extend('authenticated');
+				} else {
+					// failed login - we're trying to see if a user exists with this email (disregarding wrong passwords)
+					$existingMember = DataObject::get_one(
+						"Member",
+						"\"" . Member::config()->unique_identifier_field . "\" = '$SQL_user'"
+					);
+					if($existingMember) {
+						$attempt->MemberID = $existingMember->ID;
+						
+						// Audit logging hook
+						$existingMember->extend('authenticationFailed');
+					} else {
+						
+						// Audit logging hook
+						singleton('Member')->extend('authenticationFailedUnknownUser', $RAW_data);
+					}
+					$attempt->Status = 'Failure';
+				}
+				if(is_array($RAW_data['Email'])) {
+					user_error("Bad email passed to MemberAuthenticator::authenticate(): $RAW_data[Email]", E_USER_WARNING);
+			} else {
+					return false;
+				}
+				
+				$attempt->Email = $RAW_data['Email'];
+				$attempt->IP = Controller::curr()->getRequest()->getIP();
+				$attempt->write();
+			}
+			
+			// Legacy migration to precision-safe password hashes.
+			// A login-event with cleartext passwords is the only time
+			// when we can rehash passwords to a different hashing algorithm,
+			// bulk-migration doesn't work due to the nature of hashing.
+			// See PasswordEncryptor_LegacyPHPHash class.
+			if(
+				$member // only migrate after successful login
+				&& self::$migrate_legacy_hashes
+				&& array_key_exists($member->PasswordEncryption, self::$migrate_legacy_hashes)
+			) {
+				$member->Password = $RAW_data['Password'];
+				$member->PasswordEncryption = self::$migrate_legacy_hashes[$member->PasswordEncryption];
+				$member->write();
+			}
 
-		if($member) {
-			Session::clear('BackURL');
-		} else {
-			if($form && $result) $form->sessionMessage($result->message(), 'bad');
-		}
+			if($member) {
+				Session::clear('BackURL');
+			} else {
+				if($form && $result) $form->sessionMessage($result->message(), 'bad');
+			}
 
-		return $member;
+			return $member;
+		}
 	}
 
+
+	/**
+	 * Returns true to indicate that this authenticator supports password reset
+	 */
+	public function supportsPasswordReset() {
+		return true;
+	}
+
+
+	/**
+	 * Check this member's password
+	 */
+	public function checkPassword(Member $member, $password) {
+		return $member->checkPassword($password)->valid();
+	}
+
+	/**
+	 * Change this member's password
+	 */
+	public function changePassword(Member $member, $password) {
+		return $member->changePassword($password);
+	}
 
 	/**
 	 * Method that creates the login form for this authentication method
@@ -134,17 +177,29 @@ class MemberAuthenticator extends Authenticator {
 	 * @return Form Returns the login form to use with this authentication
 	 *              method
 	 */
-	public static function get_login_form(Controller $controller) {
-		return Object::create("MemberLoginForm", $controller, "LoginForm");
+	public function getLoginForm(Controller $controller, $name) {
+		return Object::create("LoginForm", $controller, $name, $this);
 	}
 
+	/**
+	 * Return the fields for the login form.
+	 * Used by the default LoginForm class
+	 */
+	public function getLoginFields() {
+		$label=singleton('Member')->fieldLabel(Member::config()->unique_identifier_field);
+		return new FieldList(
+			// Regardless of what the unique identifer field is (usually 'Email'), it will be held in the 'Email' value, below:
+			new TextField("Email", $label, Session::get('SessionForms.MemberLoginForm.Email'), null, $this),
+			new PasswordField("Password", _t('Member.PASSWORD', 'Password'))
+		);
+	}
 
 	/**
 	 * Get the name of the authentication method
 	 *
 	 * @return string Returns the name of the authentication method.
 	 */
-	public static function get_name() {
+	public function getName() {
 		return _t('MemberAuthenticator.TITLE', "E-mail &amp; Password");
 	}
 }

--- a/security/MemberLoginForm.php
+++ b/security/MemberLoginForm.php
@@ -7,129 +7,16 @@
 class MemberLoginForm extends LoginForm {
 
 	/**
-	 * This field is used in the "You are logged in as %s" message
-	 * @var string
-	 */
-	public $loggedInAsField = 'FirstName';
-
-	protected $authenticator_class = 'MemberAuthenticator';
-	
-	/**
-	 * Constructor
-	 *
-	 * @param Controller $controller The parent controller, necessary to
-	 *                               create the appropriate form action tag.
-	 * @param string $name The method on the controller that will return this
-	 *                     form object.
-	 * @param FieldList|FormField $fields All of the fields in the form - a
-	 *                                   {@link FieldList} of {@link FormField}
-	 *                                   objects.
-	 * @param FieldList|FormAction $actions All of the action buttons in the
-	 *                                     form - a {@link FieldList} of
-	 *                                     {@link FormAction} objects
-	 * @param bool $checkCurrentUser If set to TRUE, it will be checked if a
-	 *                               the user is currently logged in, and if
-	 *                               so, only a logout button will be rendered
-	 * @param string $authenticatorClassName Name of the authenticator class that this form uses.
-	 */
-	public function __construct($controller, $name, $fields = null, $actions = null,
-								$checkCurrentUser = true) {
-
-		// This is now set on the class directly to make it easier to create subclasses
-		// $this->authenticator_class = $authenticatorClassName;
-
-		$customCSS = project() . '/css/member_login.css';
-		if(Director::fileExists($customCSS)) {
-			Requirements::css($customCSS);
-		}
-		
-		if(isset($_REQUEST['BackURL'])) {
-			$backURL = $_REQUEST['BackURL'];
-		} else {
-			$backURL = Session::get('BackURL');
-		}
-
-		if($checkCurrentUser && Member::currentUser() && Member::logged_in_session_exists()) {
-			$fields = new FieldList(
-				new HiddenField("AuthenticationMethod", null, $this->authenticator_class, $this)
-			);
-			$actions = new FieldList(
-				new FormAction("logout", _t('Member.BUTTONLOGINOTHER', "Log in as someone else"))
-			);
-		} else {
-			if(!$fields) {
-				$label=singleton('Member')->fieldLabel(Member::config()->unique_identifier_field);
-				$fields = new FieldList(
-					new HiddenField("AuthenticationMethod", null, $this->authenticator_class, $this),
-					// Regardless of what the unique identifer field is (usually 'Email'), it will be held in the
-					// 'Email' value, below:
-					new TextField("Email", $label, Session::get('SessionForms.MemberLoginForm.Email'), null, $this),
-					new PasswordField("Password", _t('Member.PASSWORD', 'Password'))
-				);
-				if(Security::config()->autologin_enabled) {
-					$fields->push(new CheckboxField(
-						"Remember", 
-						_t('Member.REMEMBERME', "Remember me next time?")
-					));
-				}
-			}
-			if(!$actions) {
-				$actions = new FieldList(
-					new FormAction('dologin', _t('Member.BUTTONLOGIN', "Log in")),
-					new LiteralField(
-						'forgotPassword',
-						'<p id="ForgotPassword"><a href="Security/lostpassword">'
-						. _t('Member.BUTTONLOSTPASSWORD', "I've lost my password") . '</a></p>'
-					)
-				);
-			}
-		}
-
-		if(isset($backURL)) {
-			$fields->push(new HiddenField('BackURL', 'BackURL', $backURL));
-		}
-
-		// Reduce attack surface by enforcing POST requests
-		$this->setFormMethod('POST', true);
-
-		parent::__construct($controller, $name, $fields, $actions);
-
-		// Focus on the email input when the page is loaded
-		Requirements::customScript(<<<JS
-			(function() {
-				var el = document.getElementById("MemberLoginForm_LoginForm_Email");
-				if(el && el.focus) el.focus();
-			})();
-JS
-		);
-	}
-
-	/**
-	 * Get message from session
-	 */
-	protected function getMessageFromSession() {
-		parent::getMessageFromSession();
-		if(($member = Member::currentUser()) && !Session::get('MemberLoginForm.force_message')) {
-			$this->message = _t(
-				'Member.LOGGEDINAS', 
-				"You're logged in as {name}.", 
-				array('name' => $member->{$this->loggedInAsField})
-			);
-		}
-		Session::set('MemberLoginForm.force_message', false);
-	}
-
-
-	/**
 	 * Login form handler method
 	 *
-	 * This method is called when the user clicks on "Log in"
+	 * This method is called when the user clicks on "Log in".
 	 *
 	 * @param array $data Submitted data
 	 */
 	public function dologin($data) {
 		if($this->performLogin($data)) {
 			$this->logInUserAndRedirect($data);
+
 		} else {
 			if(array_key_exists('Email', $data)){
 				Session::set('SessionForms.MemberLoginForm.Email', $data['Email']);
@@ -171,7 +58,7 @@ JS
 			if(isset($_REQUEST['BackURL']) && $backURL = $_REQUEST['BackURL']) {
 				Session::set('BackURL', $backURL);
 			}
-			$cp = new ChangePasswordForm($this->controller, 'ChangePasswordForm');
+			$cp = new ChangePasswordForm($this->controller, 'ChangePasswordForm', $this->authenticator);
 			$cp->sessionMessage('Your password has expired. Please choose a new one.', 'good');
 			return $this->controller->redirect('Security/changepassword');
 		}
@@ -233,7 +120,7 @@ JS
 	 *                or NULL on failure.
 	 */
 	public function performLogin($data) {
-		$member = call_user_func_array(array($this->authenticator_class, 'authenticate'), array($data, $this));
+		$member = $this->authenticator->authenticate($data, $this);
 		if($member) {
 			$member->LogIn(isset($data['Remember']));
 			return $member;


### PR DESCRIPTION
The current Authenticator system, although ostensibly extensible, had design flaws that meant that actually making a new Authentication backend necessitated the copy & paste of a large amount of code.

This patch, which has been used in production for a couple of years now on a 2.4 site, addresses this in the following ways:
- Authenticators have instance, rather than static, methods to make it easier to call overriden values.
- As well getLoginForm() (which replaces get_login_form), we add getChangePasswordForm() and getLostPasswordForm(), so auxiliary authentication services can also be overridden.
- Most of MemberLoginForm has been pushed into LoginForm, which is no longer abstract.  It relies on a few methods in the authenticator to fill in the gaps: getLoginFields(), supportsPasswordReset(), and authenticate(), meaning that creating a custom login form within some common constraints can be done more easily.
- Similarly, ChangePasswordForm makes use of changePassword() and checkPassword() on authenticator.

In addition, there is a tweak to the change password functionality such that, if the password reset link has an expired autologin cookie, you can regenerate one with a single click.

I don't really expect this to be 100% ready for merge as-is, but I'd appreciate some code review.
