### PR TITLE
API Remove Content-Length setting from HTTPResponse (fixes #8010)

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -148,17 +148,6 @@ class Director implements TemplateGlobalProvider {
 						number_format(memory_get_peak_usage(),0)
 					));
 				} else {
-					// Set content length (according to RFC2616)
-					if(
-						!headers_sent()
-						&& $response->getBody() 
-						&& $req->httpMethod() != 'HEAD' 
-						&& $response->getStatusCode() >= 200
-						&& !in_array($response->getStatusCode(), array(204, 304))
-					) {
-						$response->fixContentLength();
-					}
-
 					$response->output();
 				}
 			} else {

--- a/control/HTTPResponse.php
+++ b/control/HTTPResponse.php
@@ -150,6 +150,9 @@ class SS_HTTPResponse {
 	
 	public function setBody($body) {
 		$this->body = $body;
+		
+		// Set content-length in bytes. Use mbstring to avoid problems with mb_internal_encoding() and mbstring.func_overload
+		$this->headers['Content-Length'] = mb_strlen($this->body,'8bit');
 	}
 	
 	public function getBody() {
@@ -245,14 +248,6 @@ class SS_HTTPResponse {
 	 */
 	public function isFinished() {
 		return in_array($this->statusCode, array(301, 302, 401, 403));
-	}
-
-	/**
-	 * Set content-length in bytes. Should be called right before {@link output()}.
-	 */
-	public function fixContentLength() {
-		// Use mbstring to avoid problems with mb_internal_encoding() and mbstring.func_overload
-		$this->headers['Content-Length'] = mb_strlen($this->body,'8bit');	
 	}
 	
 }

--- a/tests/control/HTTPResponseTest.php
+++ b/tests/control/HTTPResponseTest.php
@@ -15,7 +15,6 @@ class HTTPResponseTest extends SapphireTest {
 	
 	public function testContentLengthHeader() {
 		$r = new SS_HTTPResponse('123ü');
-		$r->fixContentLength();
 		$this->assertNotNull($r->getHeader('Content-Length'), 'Content-length header is added');
 		$this->assertEquals(
 			5, 
@@ -24,7 +23,6 @@ class HTTPResponseTest extends SapphireTest {
 		);
 		
 		$r->setBody('1234ü');
-		$r->fixContentLength();
 		$this->assertEquals(
 			6, 
 			$r->getHeader('Content-Length'),


### PR DESCRIPTION
This reverts commit 356a367eb5d05bea3dfa2edaeabc52a2496b93b2.
We can't use headers_sent() to determine an accurate
content length, since PHP defaults to buffering a couple of bytes
even without ob_start() (see "output_buffering" setting).
This makes the patch harmful, since it breaks any responses relying
on more structure data, like removing closing brackets from JSON.
Which in turn breaks the CMS in horrible ways (see http://open.silverstripe.org/ticket/8010).
See http://open.silverstripe.org/ticket/7574for context.

I'm proposing to fix this in 3.0. Its been a common source of frustration,
so a necessary API change - in reality, I don't think anybody's relying
on a PHP-generated Content-Length anyway, it was just a workaround
for some crazy proxy edge cases which should really be fixed in the proxy itself.
