### PR TITLE
BUG: fixing previews for old pages in side by side editing ticket 8089

### DIFF
--- a/admin/javascript/LeftAndMain.Preview.js
+++ b/admin/javascript/LeftAndMain.Preview.js
@@ -228,6 +228,11 @@
 			 * Change the URL of the preview iframe.
 			 */
 			_loadUrl: function(url) {
+				// do we need to be showing a older version of the preview
+				var archive = $('#cms-page-history-versions').find('tr.active td.last-edited').attr('value');
+				if (archive) {
+					url += ((url.match(/\?/)) ? '&' : '?') + 'archiveDate=' + archive.replace(/\/s/g, "%20");
+				}
 				this.find('iframe').addClass('loading').attr('src', url);
 				return this;
 			},


### PR DESCRIPTION
Fix for previewing old pages in history with side by side editing check for a archive date value and append that to the iframe url if it exists.

The following pull request has been raised for CMS
https://github.com/silverstripe/silverstripe-cms/pull/278
