### PR TITLE
PHP 5.3.2 recommended configuration

### DIFF
--- a/docs/en/installation/server-requirements.md
+++ b/docs/en/installation/server-requirements.md
@@ -14,8 +14,6 @@ Our web-based [PHP installer](/installation) can check if you meet the requireme
  * Required modules: dom, gd2, fileinfo, hash, iconv, mbstring, mysql (or other database driver), session, simplexml, tokenizer, xml.
  * Recommended configuration
 
-		safe_mode = Off
-		magic_quotes_gpc = Off
 		memory_limit = 48M
 
  * See [phpinfo()](http://php.net/manual/en/function.phpinfo.php) for more information about your environment


### PR DESCRIPTION
I was checking the requirements, I wanted to know more about the following and I came across the php website where the following functions are deprecated in PHP 5.3. Since we use PHP 5.3, there is no need to have them being recomended in the doc?

Source: php.net

Safe mode:
This feature has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.

magic_quotes_gpc
This feature has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
