### PR TITLE
API: Use HTMLText as default for RSS Description

### DIFF
--- a/api/RSSFeed.php
+++ b/api/RSSFeed.php
@@ -293,7 +293,7 @@ class RSSFeed_Entry extends ViewableData {
 	 * @return string Returns the description of the entry.
 	 */
 	public function Description() {
-		return $this->rssField($this->descriptionField, 'Text');
+		return $this->rssField($this->descriptionField, 'HTMLText');
 	}
 
 	/**


### PR DESCRIPTION
To allow for custom RSS descriptions (i.e. provided by a method rather than a DB field) and avoid double escaping a better default class for Description is 'HTMLText'. http://www.silverstripe.org/customising-the-cms/show/11606#post319519
