### PR TITLE
ENHANCEMENT Sort menu items according to priority descending, then title ascending

### DIFF
--- a/admin/code/CMSMenu.php
+++ b/admin/code/CMSMenu.php
@@ -150,15 +150,14 @@ class CMSMenu extends Object implements IteratorAggregate, i18nEntityProvider
 			}
 		}
 		
-		// Sort menu items according to priority
+		// Sort menu items according to priority, then title asc
 		$menuPriority = array();
-		$i = 0;
+		$menuTitle    = array();
 		foreach($menuItems as $key => $menuItem) {
-			$i++;
-			// This funny litle formula ensures that the first item added with the same priority will be left-most.
-			$menuPriority[$key] = $menuItem->priority*100 - $i;
+			$menuPriority[$key] = $menuItem->priority;
+			$menuTitle[$key]    = $menuItem->title;
 		}
-		array_multisort($menuPriority, SORT_DESC, $menuItems);
+		array_multisort($menuPriority, SORT_DESC, $menuTitle, SORT_ASC, $menuItems);
 		
 		return $menuItems;
 	}

--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -54,6 +54,13 @@ abstract class ModelAdmin extends LeftAndMain {
 	 * @var array|string
 	 */
 	public static $managed_models = null;
+
+	/**
+	 * Override menu_priority so that ModelAdmin CMSMenu objects
+	 * are grouped together directly above the Help menu item.
+	 * @var float
+	 */
+	public static $menu_priority = -0.5;
 	
 	public static $allowed_actions = array(
 		'ImportForm',


### PR DESCRIPTION
CMS menu items are currently sorted by priority, then first come first serve (index of the foreach loop). This has the unintended result that multiple Model Admins are sorted by filename rather than menu_title, when no priority is provided by default.

This pull request creates a fairer sort by sorting by priority, then menu_title. As other menu items had an identical priority to ModelAdmin items (0), I have changed the default priority for ModelAdmins to -0.5, so that they are grouped together without intermixing with system CMS menu items.
