### PR TITLE
BUG Flush editors on form submission (os#8222)

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -290,6 +290,16 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 				this._super();
 			},
 
+			/**
+			 * Make sure the editor has flushed all it's buffers before the form is submitted.
+			 */
+			'from .cms-edit-form': {
+				onbeforesubmitform: function(e) {
+					this.getEditor().save();
+					this._super();
+				}
+			},
+
 			oneditorinit: function() {
 				// Delayed show because TinyMCE calls hide() via setTimeout on removing an element,
 				// which is called in quick succession with adding a new editor after ajax loading new markup


### PR DESCRIPTION
Otherwise some non-textual changes such as moving images and resizing
them could be missed when saving.

This is because TinyMCE does not treat the image move/resize as an
undolevel and does not register this via regular "onChange" event.

http://open.silverstripe.org/ticket/8222
