### PR TITLE
Change to how environment file is found

### DIFF
--- a/docs/en/topics/environment-management.md
+++ b/docs/en/topics/environment-management.md
@@ -56,10 +56,8 @@ of `$databaseConfig` and `Director::set_dev_servers`, and instead make sure that
 The mechanism by which the `_ss_environment.php` files work is quite simple.  Here's how it works:
 
 *  At the beginning of SilverStripe's execution, the `_ss_environment.php` file is searched for, and if it is found, it's
-included.  SilverStripe looks in 3 places for the file:
-    * The site's base folder (ie, a sibling of framework, jsparty, and cms)
-    * The parent of the base folder
-    * The grandparent of the base folder
+included.  SilverStripe looks in all the parent folders of framework up to the server root (using the REAL location of
+the dir - see PHP realpath()):
 *  The `_ss_environment.php` file sets a number of "define()".
 *  "conf/ConfigureFromEnv.php" is included from within your `mysite/_config.php`.  This file has a number of regular
 configuration commands that use those defines as their arguments.  If you are curious, open up


### PR DESCRIPTION
The _ss_environment.php file can now be in any parent folder of the framework (according to realpath())

Removing the description of '3 levels deep' and replaced with explanation of infinite depth.
