### PR TITLE
Do not set Content-Length header if debug_profile is set

### DIFF
--- a/control/HTTPResponse.php
+++ b/control/HTTPResponse.php
@@ -151,8 +151,10 @@ class SS_HTTPResponse {
 	public function setBody($body) {
 		$this->body = $body;
 		
-		// Set content-length in bytes. Use mbstring to avoid problems with mb_internal_encoding() and mbstring.func_overload
-		$this->headers['Content-Length'] = mb_strlen($this->body,'8bit');
+		if (Director::isLive() || !isset($_GET['debug_profile'])) {
+			// Set content-length in bytes. Use mbstring to avoid problems with mb_internal_encoding() and mbstring.func_overload
+			$this->headers['Content-Length'] = mb_strlen($this->body,'8bit');
+		}
 	}
 	
 	public function getBody() {


### PR DESCRIPTION
Do not set Content-Length header if debug_profile is set, because $this->body doesn't contain output from Profiler.
Browser will not read more bytes than the Content-Length value and we won't get Profiler debug information.
