### PR TITLE
FIX: Strict error warnings on DataExtension

### DIFF
--- a/model/DataExtension.php
+++ b/model/DataExtension.php
@@ -58,7 +58,7 @@ abstract class DataExtension extends Extension {
 	 * @param $validationResult Local validation result
 	 * @throws ValidationException
 	 */
-	public function validate(ValidationResult &$validationResult) {
+	public function validate(ValidationResult $validationResult) {
 	}
 	
 	/**


### PR DESCRIPTION
PHP is throwing strict error warnings when overriding the updateCMSFields and other functions in custom DataExtensions due to the fact that the abstract class doesn't declare  that the variables should be passed by reference
