### PR TITLE
NEW Upload->replaceFile setting

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,0 +1,6 @@
+---
+Name: coreconfig
+---
+Upload:
+  # Replace an existing file rather than renaming the new one.
+  replaceFile: false

--- a/docs/en/reference/uploadfield.md
+++ b/docs/en/reference/uploadfield.md
@@ -219,6 +219,13 @@ editform, or 'fileEditValidator' to determine the validator (eg RequiredFields).
    (of a method on File to provide a actions) for the EditForm (Example: 'getCMSActions')
  - `fileEditValidator`: (string) Validator (eg RequiredFields) or string $name 
    (of a method on File to provide a Validator) for the EditForm (Example: 'getCMSValidator')
+
+You can also configure the underlying `[api:Upload]` class, by using the YAML config system.
+
+	:::yaml
+	Upload:
+	  # Globally disables automatic renaming of files
+	  replaceFile: true
   
 ## TODO: Using the UploadField in a frontend form
 

--- a/forms/FileField.php
+++ b/forms/FileField.php
@@ -78,7 +78,7 @@ class FileField extends FormField {
 	 * @param int $value The value of the field.
 	 */
 	public function __construct($name, $title = null, $value = null) {
-		$this->upload = new Upload();
+		$this->upload = Upload::create();
 	
 		parent::__construct($name, $title, $value);
 	}

--- a/tests/filesystem/UploadTest.php
+++ b/tests/filesystem/UploadTest.php
@@ -316,6 +316,62 @@ class UploadTest extends SapphireTest {
 		$file2->delete();
 	}
 
+	public function testReplaceFile() {
+		// create tmp file
+		$tmpFileName = 'UploadTest-testUpload';
+		$tmpFilePath = TEMP_FOLDER . '/' . $tmpFileName;
+		$tmpFileContent = '';
+		for($i=0; $i<10000; $i++) $tmpFileContent .= '0';
+		file_put_contents($tmpFilePath, $tmpFileContent);
+		
+		// emulates the $_FILES array
+		$tmpFile = array(
+			'name' => $tmpFileName,
+			'type' => 'text/plaintext',
+			'size' => filesize($tmpFilePath),
+			'tmp_name' => $tmpFilePath,
+			'extension' => 'txt',
+			'error' => UPLOAD_ERR_OK,
+		);
+		
+		// Make sure there are none here, otherwise they get renamed incorrectly for the test.
+		$this->deleteTestUploadFiles("/UploadTest-testUpload.*/");
+
+		$v = new UploadTest_Validator();
+		$v->setAllowedExtensions(array(''));
+
+		// test upload into default folder
+		$u = new Upload();
+		$u->setValidator($v);
+		$u->load($tmpFile);
+		$file = $u->getFile();
+
+		$this->assertEquals(
+			'UploadTest-testUpload',
+			$file->Name,
+			'File is uploaded without extension'
+		);
+		
+		$u = new Upload();
+		$u->setValidator($v);
+		$u->setReplaceFile(true);
+		$u->load($tmpFile);
+		$file2 = $u->getFile();
+		$this->assertEquals(
+			'UploadTest-testUpload',
+			$file2->Name,
+			'File does not receive new name'
+		);
+		$this->assertEquals(
+			$file->ID,
+			$file2->ID,
+			'File database record is the same'
+		);
+		
+		$file->delete();
+		$file2->delete();
+	}
+
 }
 class UploadTest_Validator extends Upload_Validator implements TestOnly {
 


### PR DESCRIPTION
This was required for a client who wants to manage files a bit more tightly, and replace existing files with the same name by default rather than appending numbers and creating a new file.

Aside: I've used _config/config.yml because I think one config file per class is getting ridiculous. Sure, they should have names so we can override specific config aspects, but we should also give devs a realistic chance of understanding the existing config values available. Since we have zero introspection there at the moment (http://open.silverstripe.org/ticket/7827), I think fewer files are better.
