### PR TITLE
BUG Default Sort table not always joined

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -303,6 +303,21 @@ class DataQuery {
 						$query->selectField($qualCol);
 					}
 				}
+				//we need to ensure that we're joined onto the table that has
+				// the sort column
+				$sortCol = array_pop($parts);
+				foreach ($tableClasses as $class) {
+					if (
+						singleton($class)->hasOwnTableDatabaseField($sortCol)
+						&& !$this->query->isJoinedTo($class)
+					) {
+						$this->query->addLeftJoin(
+							$class,
+							"\"$baseClass\".\"ID\" = \"$class\".\"ID\""
+						);
+						break;
+					}
+				}
 			}
 
 			$query->setOrderBy($orderby);


### PR DESCRIPTION
I encountered a bug when doing:

CustomPage::get()->map()->toArray();

where CustomPage has public static $default_sort = "Date"; with a column called Date in that class's $db static.

An SQL error was thrown unkown column 'Date'. This was because the table for CustomPage was not included in the query as a join or from.

This is a rather inelegant fix and I'd love some guidence on how to select the join field more appropriately, as sometimes it should be ID and sometimes RecordID.

This seems to fix the issue for me, but I'm sure it's not very robust (with things like versioning and so on)
