### PR TITLE
API Require ADMIN for ?showtemplate=1 (2.4)

### DIFF
--- a/core/SSViewer.php
+++ b/core/SSViewer.php
@@ -401,7 +401,7 @@ class SSViewer {
 		}
 	
 		
-		if(isset($_GET['showtemplate']) && !Director::isLive()) {
+		if(isset($_GET['showtemplate']) && $_GET['showtemplate'] && Permission::check('ADMIN')) {
 			$lines = file($cacheFile);
 			echo "<h2>Template: $cacheFile</h2>";
 			echo "<pre>";
@@ -680,7 +680,7 @@ class SSViewer_FromString extends SSViewer {
 		fwrite($fh, $template);
 		fclose($fh);
 
-		if(isset($_GET['showtemplate']) && $_GET['showtemplate']) {
+		if(isset($_GET['showtemplate']) && $_GET['showtemplate'] && Permission::check('ADMIN')) {
 			$lines = file($tmpFile);
 			echo "<h2>Template: $tmpFile</h2>";
 			echo "<pre>";


### PR DESCRIPTION
Doesn't expose sensitive data (to my knowledge), but still an information leak, so low-priority security issue. 
Also raised a PR for 3.0 with https://github.com/silverstripe/sapphire/pull/1182
