### PR TITLE
Model admin tabs should use plural instead of singular title

### DIFF
--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -280,7 +280,7 @@ abstract class ModelAdmin extends LeftAndMain {
 		// Normalize models to have their model class in array key
 		foreach($models as $k => $v) {
 			if(is_numeric($k)) {
-				$models[$v] = array('title' => singleton($v)->i18n_singular_name());
+				$models[$v] = array('title' => singleton($v)->i18n_plural_name());
 				unset($models[$k]);
 			}
 		}


### PR DESCRIPTION
It seems more logical to use plurals for tab titles in modeladmin. ie. Customers, Orders, Products instead of the currently implemented singular name.
