### PR TITLE
FIX issue with Injector::create not passing args

### DIFF
--- a/control/injector/Injector.php
+++ b/control/injector/Injector.php
@@ -773,6 +773,9 @@ class Injector {
 			if (isset($this->specs[$name])) {
 				$spec = $this->specs[$name];
 				$this->updateSpecConstructor($spec);
+				if ($constructorArgs) {
+					$spec['constructor'] = $constructorArgs;
+				}
 				return $this->instantiate($spec, $name);
 			}
 		}

--- a/tests/injector/InjectorTest.php
+++ b/tests/injector/InjectorTest.php
@@ -523,12 +523,25 @@ class InjectorTest extends SapphireTest {
 		
 		$this->assertInstanceOf('OtherTestObject', $item->property->property);
 	}
+	
+	public function testCreateConfiggedObjectWithCustomConstructorArgs() {
+		// need to make sure that even if the config defines some constructor params, 
+		// that we take our passed in constructor args instead
+		$injector = new Injector(array('locator' => 'InjectorTestConfigLocator'));
+		
+		$item = $injector->create('ConfigConstructor', 'othervalue');
+		$this->assertEquals($item->property, 'othervalue');
+	}
 }
 
 class InjectorTestConfigLocator extends SilverStripeServiceConfigurationLocator implements TestOnly {
 	public function locateConfigFor($name) {
 		if ($name == 'TestObject') {
 			return array('class' => 'ConstructableObject', 'constructor' => array('%$OtherTestObject'));
+		}
+
+		if ($name == 'ConfigConstructor') {
+			return array('class' => 'ConstructableObject', 'constructor' => array('value'));
 		}
 
 		return parent::locateConfigFor($name);


### PR DESCRIPTION
If creating an object using Injector::create() and constructor arguments
are passed through, in some cases where the object being created had a yml
configuration set for it, the passed in constructor arguments weren't being
passed through to the instantiation of the object.
