### PR TITLE
API Restfulservice improvements

### DIFF
--- a/tests/api/RestfulServiceTest.php
+++ b/tests/api/RestfulServiceTest.php
@@ -184,7 +184,7 @@ class RestfulServiceTest extends SapphireTest {
 				'bar=foo'
 			)
 		);
-		$headerFunction = new ReflectionMethod('RestfulService', 'parse_raw_headers');
+		$headerFunction = new ReflectionMethod('RestfulService', 'parseRawHeaders');
 		$headerFunction->setAccessible(true);
 		$this->assertEquals(
 			$expected,


### PR DESCRIPTION
Changed the RestfulService so that it:
- Now parses and stores headers from the responses
- Cached responses on errors now store the whole response, not just the body
- Ability to store default curl options
- Cache key generation now takes account of all params, rather than just the URL

see https://github.com/silverstripe/sapphire/pull/1148
