### PR TITLE
API Deprecated ScheduledTask and subclasses

### DIFF
--- a/docs/en/changelogs/3.1.0.md
+++ b/docs/en/changelogs/3.1.0.md
@@ -219,3 +219,6 @@ through the CMS controllers, providing a simple level of security.
    - `DataList#byIDs`
    - `DataList#reverse`
  * `DataList#dataQuery` has been changed to return a clone of the query, and so can't be used to modify the list's query directly. Use `DataList#alterDataQuery` instead to modify dataQuery in a safe manner.
+ * `ScheduledTask`, `QuarterHourlyTask`, `HourlyTask`, `DailyTask`, `MonthlyTask`, `WeeklyTask` and
+	 `YearlyTask` are deprecated, please extend from `BuildTask` or `CliController`,
+	 and invoke them in self-defined frequencies through Unix cronjobs etc.

--- a/tasks/DailyTask.php
+++ b/tasks/DailyTask.php
@@ -5,6 +5,8 @@
  * Please note: Subclasses of this task aren't extecuted automatically,
  * they need to be triggered by an external automation tool like unix cron.
  * See {@link ScheduledTask} for details.
+ *
+ * @deprecated 3.1
  * 
  * @todo Improve documentation
  * @package framework

--- a/tasks/HourlyTask.php
+++ b/tasks/HourlyTask.php
@@ -5,6 +5,8 @@
  * Please note: Subclasses of this task aren't extecuted automatically,
  * they need to be triggered by an external automation tool like unix cron.
  * See {@link ScheduledTask} for details.
+ *
+ * @deprecated 3.1
  * 
  * @package framework
  * @subpackage cron

--- a/tasks/MonthlyTask.php
+++ b/tasks/MonthlyTask.php
@@ -5,6 +5,8 @@
  * Please note: Subclasses of this task aren't extecuted automatically,
  * they need to be triggered by an external automation tool like unix cron.
  * See {@link ScheduledTask} for details.
+ *
+ * @deprecated 3.1
  * 
  * @package framework
  * @subpackage cron

--- a/tasks/QuarterHourlyTask.php
+++ b/tasks/QuarterHourlyTask.php
@@ -5,6 +5,8 @@
  * Please note: Subclasses of this task aren't extecuted automatically,
  * they need to be triggered by an external automation tool like unix cron.
  * See {@link ScheduledTask} for details.
+ *
+ * @deprecated 3.1
  * 
  * @package framework
  * @subpackage cron

--- a/tasks/ScheduledTask.php
+++ b/tasks/ScheduledTask.php
@@ -50,6 +50,8 @@
  * # WeelkyTask (every Monday at 6:25am)
  * 25 6 1 * *  www-data /webroot/framework/cli-script.php /WeeklyTask > /var/log/weeklytask.log
  * </code>
+ *
+ * @deprecated 3.1
  * 
  * @todo Improve documentation
  * @package framework
@@ -57,4 +59,15 @@
  */
 abstract class ScheduledTask extends CliController {
 	// this class exists as a logical extension
+
+	public function init() {
+		Deprecation::notice(
+			'3.1', 
+			'ScheduledTask, QuarterHourlyTask, HourlyTask, DailyTask, MonthlyTask, WeeklyTask and ' .
+			'YearlyTask are deprecated, please extend from BuildTask or CliController, ' .
+			'and invoke them in self-defined frequencies through Unix cronjobs etc.'
+		);
+
+		parent::init();
+	}
 }

--- a/tasks/WeeklyTask.php
+++ b/tasks/WeeklyTask.php
@@ -5,6 +5,8 @@
  * Please note: Subclasses of this task aren't extecuted automatically,
  * they need to be triggered by an external automation tool like unix cron.
  * See {@link ScheduledTask} for details.
+ *
+ * @deprecated 3.1
  * 
  * @package framework
  * @subpackage cron

--- a/tasks/YearlyTask.php
+++ b/tasks/YearlyTask.php
@@ -5,6 +5,8 @@
  * Please note: Subclasses of this task aren't extecuted automatically,
  * they need to be triggered by an external automation tool like unix cron.
  * See {@link ScheduledTask} for details.
+ *
+ * @deprecated 3.1
  * 
  * @package framework
  * @subpackage cron


### PR DESCRIPTION
These classes put configuration concerns in the inheritance hierarchy, making them very inflexible. For example, if the author of some task decides that "yearly" is an adequate frequency, you can't change that in your own project setup. The only advantage those classes have is the fact that you can set up one cron rule for all tasks, but in practice that saves little to no configuration effort.

Base CliController or BuildTask instead, with custom cron job intervals.
