### PR TITLE
Removing redundant function

### DIFF
--- a/forms/FormAction.php
+++ b/forms/FormAction.php
@@ -121,10 +121,6 @@ class FormAction extends FormField {
 		return $this->useButtonTag;
 	}
 
-	public function extraClass() {
-		return 'action ' . parent::extraClass();
-	}
-
 	/**
 	 * Does not transform to readonly by purpose.
 	 * Globally disabled buttons would break the CMS.


### PR DESCRIPTION
At the moment form actions (buttons) have the classes 'action action' as default. This is because the extraClass function adds 'action' and then calls the parent method. The parent then includes the $this->Type() ('action') again.

So I've remove this overloading of extraClass
