### PR TITLE
fixed error property $ of object is not a function

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -1051,7 +1051,7 @@ jQuery.noConflict();
 }(jQuery));
 
 var statusMessage = function(text, type) {
-	text = $('<div/>').text(text).html(); // Escape HTML entities in text
+	text = jQuery('<div/>').text(text).html(); // Escape HTML entities in text
 	jQuery.noticeAdd({text: text, type: type});
 };
 


### PR DESCRIPTION
changed $ to jQuery, because without it the system would generate the following error:

Uncaught TypeError: Property '$' of object [object Window] is not a function 
