### PR TITLE
[FIX] Custom page icons

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -344,7 +344,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		foreach (self::$extra_requirements['themedcss'] as $file) {
 			Requirements::themedCSS($file[0], $file[1]);
 		}
-
+		Requirements::customCSS(CMSMain::generatePageIconsCss());
 		$dummy = null;
 		$this->extend('init', $dummy);
 


### PR DESCRIPTION
SilverStripe has a feature to set custom icons for page types for an
instance:
public static $icon =
'background-image:url(zz-basic/backend/images/treeicons/page-file.png);'
;

When you open /admin/pages/ url it works ok, but if you will go to
settings, then refresh the page and click to pages icons won't be shown
cuz custom css generated to display custom icons won't be included by
ajax response.
