### PR TITLE
RequestHandler::handleAction() declared incorrectly

### DIFF
--- a/control/RequestHandler.php
+++ b/control/RequestHandler.php
@@ -264,7 +264,7 @@ class RequestHandler extends ViewableData {
 	 * @param $action
 	 * @return SS_HTTPResponse
 	 */
-	protected function handleAction($request, $action) {
+	public function handleAction($request, $action) {
 		$className = get_class($this);
 
 		if(!$this->hasMethod($action)) {


### PR DESCRIPTION
Controller::handleAction() is declared as public, as well as a lot
of other places in the framework. RequestHandler::handleAction()
is declared as protected which isn't correct.
