### PR TITLE
remove a useless line from HTTP::absoluteURLs

### DIFF
--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -40,7 +40,6 @@ class HTTP {
 	 * Turn all relative URLs in the content to absolute URLs
 	 */
 	public static function absoluteURLs($html) {
-		$html = str_replace('$CurrentPageURL', $_SERVER['REQUEST_URI'], $html);
 		return HTTP::urlRewriter($html, function($url) {
 			return Director::absoluteURL($url, true);
 		});


### PR DESCRIPTION
removed 
$html = str_replace('$CurrentPageURL', $_SERVER['REQUEST_URI'], $html);
CurrentPageURL is not defined anywhere, so this line will not do anything (i.e. the currentPageURL can not be found - it is an empty string)
