### PR TITLE
BUG: Correct semantic error regarding cURL options in RestfulService

### DIFF
--- a/api/RestfulService.php
+++ b/api/RestfulService.php
@@ -140,7 +140,7 @@ class RestfulService extends ViewableData {
 			$method,
 			$data,
 			array_merge((array)$this->customHeaders, (array)$headers),
-			array_merge(self::$default_curl_options,$curlOptions),
+			$curlOptions + self::$default_curl_options,
 			$this->getBasicAuthString()
 		));
 		
@@ -196,7 +196,7 @@ class RestfulService extends ViewableData {
 		$timeout   = 5;
 		$sapphireInfo = new SapphireInfo(); 
 		$useragent = 'SilverStripe/' . $sapphireInfo->Version();
-		$curlOptions = array_merge(self::$default_curl_options, $curlOptions);
+		$curlOptions = $curlOptions + self::$default_curl_options;
 
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);


### PR DESCRIPTION
cURL options are numeric, and array_merge is destructive of numeric
keys. Replace array_merge calls with array union operator, with defaults
on right-hand side so that passed options override defaults.
