### PR TITLE
Content-Length Fix

### DIFF
--- a/control/HTTPResponse.php
+++ b/control/HTTPResponse.php
@@ -153,7 +153,7 @@ class SS_HTTPResponse {
 		
 		// Set content-length in bytes. Use mbstring to avoid problems with 
 		// mb_internal_encoding() and mbstring.func_overload
-		$this->headers['Content-Length'] = mb_strlen($this->body,'8bit');
+		if($this->body) $this->headers['Content-Length'] = mb_strlen($this->body,'8bit');
 	}
 	
 	public function getBody() {


### PR DESCRIPTION
Currently when doing a dev/build there is no "body" and cannot determine a Content-Length.

This fix first determines whether there is content in $this->body before appending the header.
