### PR TITLE
Fixed formatting bug

### DIFF
--- a/forms/FieldGroup.php
+++ b/forms/FieldGroup.php
@@ -113,7 +113,7 @@ class FieldGroup extends CompositeField {
 			if($m = $subfield->Message()) $message[] = rtrim($m, ".");
 		}
 		
-		return (isset($message)) ? implode(",  ", $message) . ". " : "";
+		return (isset($message)) ? implode(",  ", $message) . "." : "";
 	}	
 	
 	/**


### PR DESCRIPTION
Set the FieldGroup to trim periods from the end of messages when concatenating them so that the messages get displayed nicely by default.

Before:
"{FieldName}" is required., "{FieldName}" is required.,"{FieldName}" is required..

After:
"{FieldName}" is required, "{FieldName}" is required,"{FieldName}" is required.
