### PR TITLE
ENHANCEMENT Allow multiline comments in SS3 templates

### DIFF
--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -59,11 +59,23 @@ class SSViewerTest extends SapphireTest {
 	public function testComments() {
 		$output = $this->render(<<<SS
 This is my template<%-- this is a comment --%>This is some content<%-- this is another comment --%>Final content
+<%-- Alone multi
+	line comment --%>
+Some more content
+Mixing content and <%-- multi
+	line comment --%> Final final 
+content
 SS
 );
+		$shouldbe = <<<SS
+This is my templateThis is some contentFinal content
+
+Some more content
+Mixing content and  Final final 
+content
+SS;
 		
-		$this->assertEquals("This is my templateThis is some contentFinal content", 
-			preg_replace("/\n?<!--.*-->\n?/U",'',$output));
+		$this->assertEquals($shouldbe, $output);
 	}
 	
 	public function testBasicText() {

--- a/view/SSTemplateParser.php
+++ b/view/SSTemplateParser.php
@@ -3923,7 +3923,7 @@ class SSTemplateParser extends Parser {
 						$result = $res_671;
 						$this->pos = $pos_671;
 					}
-					if (( $subres = $this->rx( '/./' ) ) !== FALSE) { $result["text"] .= $subres; }
+					if (( $subres = $this->rx( '/(?s)./' ) ) !== FALSE) { $result["text"] .= $subres; }
 					else { $_673 = FALSE; break; }
 					$_673 = TRUE; break;
 				}

--- a/view/SSTemplateParser.php.inc
+++ b/view/SSTemplateParser.php.inc
@@ -936,7 +936,7 @@ class SSTemplateParser extends Parser {
 	 
 	# This is used to remove template comments
 	 
-	Comment: "<%--" (!"--%>" /./)+ "--%>"
+	Comment: "<%--" (!"--%>" /(?s)./)+ "--%>"
 	*/
 	function Comment__construct(&$res) {
 		$res['php'] = '';


### PR DESCRIPTION
Allowing multi line comments in SS3 templates. Unit test fixed accordingly.
