### PR TITLE
API Handle uncaught ValidationException on controller execution

### DIFF
--- a/core/control/RequestHandler.php
+++ b/core/control/RequestHandler.php
@@ -143,6 +143,9 @@ class RequestHandler extends ViewableData {
 							$result = $this->$action($request);
 						} catch(SS_HTTPResponse_Exception $responseException) {
 							$result = $responseException->getResponse();
+						} catch(ValidationException $e) {
+							$msgs = implode('. ', $e->getResult()->messageList());
+							return $this->httpError(403, $msgs);
 						}
 					} else {
 						return $this->httpError(403, "Action '$action' isn't allowed on class $this->class");


### PR DESCRIPTION
This removes the need for a lot of boilerplate code
around DataObject->write() logic, and avoids generic 500 errors
on user-level failures which could show a slightly friendler and
more specific error. 

This should really be a per-project choice,
but at the moment request handling doesn't allow to configure
custom exception handling.

FYI, the case I'm trying to fix here is page saving in the CMS failing due to $allowed_children restrictions.
