### PR TITLE
BUGFIX: Removed XHTML XML declaration requirement

### DIFF
--- a/control/ContentNegotiator.php
+++ b/control/ContentNegotiator.php
@@ -134,25 +134,19 @@ class ContentNegotiator {
 	 */
 	public function xhtml(SS_HTTPResponse $response) {
 		$content = $response->getBody();
-		
-		// Only serve "pure" XHTML if the XML header is present
-		if(substr($content,0,5) == '<' . '?xml' ) {
-			$response->addHeader("Content-Type", "application/xhtml+xml; charset=" . self::$encoding);
-			$response->addHeader("Vary" , "Accept");
 
-			// Fix base tag
-			$content = preg_replace('/<base href="([^"]*)"><!--\[if[[^\]*]\] \/><!\[endif\]-->/', 
-				'<base href="$1" />', $content);
-			
-			$content = str_replace('&nbsp;','&#160;', $content);
-			$content = str_replace('<br>','<br />', $content);
-			$content = preg_replace('#(<img[^>]*[^/>])>#i', '\\1/>', $content);
-			
-			$response->setBody($content);
+		$response->addHeader("Content-Type", "application/xhtml+xml; charset=" . self::$encoding);
+		$response->addHeader("Vary" , "Accept");
 
-		} else {
-			return $this->html($response);
-		}
+		// Fix base tag
+		$content = preg_replace('/<base href="([^"]*)"><!--\[if[[^\]*]\] \/><!\[endif\]-->/', 
+			'<base href="$1" />', $content);
+
+		$content = str_replace('&nbsp;','&#160;', $content);
+		$content = str_replace('<br>','<br />', $content);
+		$content = preg_replace('#(<img[^>]*[^/>])>#i', '\\1/>', $content);
+
+		$response->setBody($content);
 	}
 	
 	/*


### PR DESCRIPTION
An XML declaration is not required in all XML documents; however XHTML document authors are strongly encouraged to use XML declarations in all their documents. Such a declaration is required when the character encoding of the document is other than the default UTF-8 or UTF-16 and no encoding was determined by a higher-level protocol.

Discussion here: https://groups.google.com/forum/?fromgroups=#!topic/silverstripe-dev/akRYY5ev6w0
