### PR TITLE
Update Director.php

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -892,11 +892,11 @@ class Director implements TemplateGlobalProvider {
 	 */
 	public static function get_template_global_variables() {
 		return array(
-			'absoluteBaseURL',
-			'baseURL',
+			'absoluteBaseURL' => array('method' => 'absoluteBaseURL', 'casting' => 'Text'),
+			'baseURL'  => array('method' => 'baseURL', 'casting' => 'Text'),
 			'is_ajax',
 			'isAjax' => 'is_ajax',
-			'BaseHref' => 'absoluteBaseURL',    //@deprecated 3.0
+			'BaseHref' => array('method' => 'absoluteBaseURL', 'casting' => 'Text'),    //@deprecated 3.0
 		);
 	}
 }


### PR DESCRIPTION
The template variables $AbsoluteBaseURL $BaseURL and the deprecated $BaseHref are cast as HTMLText by default in SSViewer. As a result they are appended with a newline character.

When trying to build custom links with these variables this newline breaks the links and makes the html unreadable. Casting as Text fixes this problem.
