### PR TITLE
API Handle uncaught ValidationException on CMS controller execution

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -354,7 +354,18 @@ class LeftAndMain extends Controller implements PermissionProvider {
 	}
 	
 	public function handleRequest(SS_HTTPRequest $request, DataModel $model = null) {
-		$response = parent::handleRequest($request, $model);
+		try {
+			$response = parent::handleRequest($request, $model);
+		} catch(ValidationException $e) {
+			// Nicer presentation of model-level validation errors
+			$msgs = _t('LeftAndMain.ValidationError', 'Validation error') . ': ' 
+				. $e->getResult()->message();
+			$e = new SS_HTTPResponse_Exception($msgs, 403);
+			$e->getResponse()->addHeader('Content-Type', 'text/plain');
+			$e->getResponse()->addHeader('X-Status', rawurlencode($msgs));
+			throw $e;
+		}
+
 		$title = $this->Title();
 		if(!$response->getHeader('X-Controller')) $response->addHeader('X-Controller', $this->class);
 		if(!$response->getHeader('X-Title')) $response->addHeader('X-Title', $title);


### PR DESCRIPTION
This removes the need for a lot of boilerplate code
around DataObject->write() logic, and avoids generic 500 errors
on user-level failures. This should really be a per-project choice,
but at the moment request handling doesn't allow to configure
custom exception handling.

Ported https://github.com/silverstripe/silverstripe-cms/pull/296 from post-2.4 to 3.0.
Same idea, but with a "validation error" wording addition, since the default
overlays in the CMS don't visually distinguish between errors and success messages
(which is out of scope to fix here).
