### PR TITLE
Fixed link and added branch direction

### DIFF
--- a/docs/en/misc/contributing/documentation.md
+++ b/docs/en/misc/contributing/documentation.md
@@ -12,9 +12,9 @@ and a GitHub user account.
 
 ## Editing online
 
-The easiest way of making a change the the documentation is to find the appropriate .md 
-file in the [github.com/silverstripe/sapphire](https://github.com/silverstripe/sapphire/edit/3.0/docs/) repository
-and press the "edit" button.  You will need a GitHub account to do this.
+The easiest way of making a change to the documentation is to find the appropriate .md 
+file in the [github.com/silverstripe/sapphire](https://github.com/silverstripe/sapphire/tree/3.0/docs/) repository
+and press the "edit" button.  You will need a GitHub account to do this.  You should make the changes in the lowest branch they apply to.
 
  * After you have made your change, describe it in the "commit summary" and "extended description" fields below, and press "Commit Changes".
  * After that you will see form to submit a Pull Request.  You should just be able to submit the form, and your changes will be sent to the core team for approval.


### PR DESCRIPTION
Broken link to edit docs, perhaps should link to repo instead of directory to avoid having a branch in the URL.  Also added blurb to clarify what branch doc edits should occur in.
