### PR TITLE
BUG: ampersand escaping

### DIFF
--- a/tests/forms/RequirementsTest.php
+++ b/tests/forms/RequirementsTest.php
@@ -254,13 +254,13 @@ class RequirementsTest extends SapphireTest {
 		$backend->delete_combined_files('RequirementsTest_bc.js');
 
 		$html = $backend->includeInHTML(false, self::$html_template);
-
+		
 		/* Javascript has correct path */
-		$this->assertTrue((bool)preg_match('/src=".*\/RequirementsTest_a\.js\?m=\d\d+&test=1&test=2&test=3/', $html),
+		$this->assertTrue((bool)preg_match('/src=".*\/RequirementsTest_a\.js\?m=\d\d+&amp;test=1&amp;test=2&amp;test=3/', $html),
 			'javascript has correct path'); 
 
 		/* CSS has correct path */
-		$this->assertTrue((bool)preg_match('/href=".*\/RequirementsTest_a\.css\?m=\d\d+&test=1&test=2&test=3/',$html),
+		$this->assertTrue((bool)preg_match('/href=".*\/RequirementsTest_a\.css\?m=\d\d+&amp;test=1&amp;test=2&amp;test=3/',$html),
 			'css has correct path'); 
 	}
 	
@@ -363,17 +363,17 @@ class RequirementsTest extends SapphireTest {
 		$backend->set_suffix_requirements(true);
 		$html = $backend->includeInHTML(false, $template);
 		$this->assertRegexp('/RequirementsTest_a\.js\?m=[\d]*/', $html);
-		$this->assertRegexp('/RequirementsTest_b\.js\?m=[\d]*&foo=bar&bla=blubb/', $html);
+		$this->assertRegexp('/RequirementsTest_b\.js\?m=[\d]*&amp;foo=bar&amp;bla=blubb/', $html);
 		$this->assertRegexp('/RequirementsTest_a\.css\?m=[\d]*/', $html);
-		$this->assertRegexp('/RequirementsTest_b\.css\?m=[\d]*&foo=bar&bla=blubb/', $html);
+		$this->assertRegexp('/RequirementsTest_b\.css\?m=[\d]*&amp;foo=bar&amp;bla=blubb/', $html);
 
 		$backend->set_suffix_requirements(false);
 		$html = $backend->includeInHTML(false, $template);
 		$this->assertNotContains('RequirementsTest_a.js=', $html);
 		$this->assertNotRegexp('/RequirementsTest_a\.js\?m=[\d]*/', $html);
-		$this->assertNotRegexp('/RequirementsTest_b\.js\?m=[\d]*&foo=bar&bla=blubb/', $html);
+		$this->assertNotRegexp('/RequirementsTest_b\.js\?m=[\d]*&amp;foo=bar&amp;bla=blubb/', $html);
 		$this->assertNotRegexp('/RequirementsTest_a\.css\?m=[\d]*/', $html);
-		$this->assertNotRegexp('/RequirementsTest_b\.css\?m=[\d]*&foo=bar&bla=blubb/', $html);
+		$this->assertNotRegexp('/RequirementsTest_b\.css\?m=[\d]*&amp;foo=bar&amp;bla=blubb/', $html);
 	}
 
 	public function assertFileIncluded($backend, $type, $files) {

--- a/view/Requirements.php
+++ b/view/Requirements.php
@@ -660,7 +660,7 @@ class Requirements_Backend {
 			$this->process_combined_files();
 
 			foreach(array_diff_key($this->javascript,$this->blocked) as $file => $dummy) {
-				$path = $this->path_for_file($file);
+				$path = Convert::raw2xml($this->path_for_file($file));
 				if($path) {
 					$jsRequirements .= "<script type=\"text/javascript\" src=\"$path\"></script>\n";
 				}
@@ -677,7 +677,7 @@ class Requirements_Backend {
 			}
 
 			foreach(array_diff_key($this->css,$this->blocked) as $file => $params) {
-				$path = $this->path_for_file($file);
+				$path = Convert::raw2xml($this->path_for_file($file));
 				if($path) {
 					$media = (isset($params['media']) && !empty($params['media']))
 						? " media=\"{$params['media']}\"" : "";


### PR DESCRIPTION
I followed chillu hint on https://github.com/silverstripe/sapphire/pull/1264

I used Convert::raw2xml() in Requirements->includeInHTML(), and tested it on SS with both XHTML and HTML5 templates. I also modified the test suite in order to validate with it. Here you are W3C a validation POC (just html files, no SS):
- HTML5: http://lab.zirak.it/html5.html
- XHTML 1.0 strict: http://lab.zirak.it/xhtml.html
- XHTML 1.1: http://lab.zirak.it/xhtml11.html
