### PR TITLE
BUG: Preserve alpha channel when cropping

### DIFF
--- a/filesystem/GD.php
+++ b/filesystem/GD.php
@@ -264,6 +264,11 @@ class GDBackend extends Object implements Image_Backend {
 	
 	public function crop($top, $left, $width, $height) {
 		$newGD = imagecreatetruecolor($width, $height);
+
+		// Preserve alpha channel between images
+		imagealphablending($newGD, false);
+		imagesavealpha($newGD, true);
+
 		imagecopyresampled($newGD, $this->gd, 0, 0, $left, $top, $width, $height, $width, $height);
 		
 		$output = clone $this;


### PR DESCRIPTION
This keeps the alpha channel from turning black.

Submitted on behalf of @phil-quinn
