### PR TITLE
API: Hierachy class cleanup

### DIFF
--- a/model/Hierarchy.php
+++ b/model/Hierarchy.php
@@ -6,22 +6,22 @@
  * @subpackage model
  */
 class Hierarchy extends DataExtension {
-	
+
 	protected $markedNodes;
-	
+
 	protected $markingFilter;
-	
+
 	/**
 	 * @var Int
 	 */
 	protected $_cache_numChildren;
-	
+
 	public function augmentSQL(SQLQuery &$query) {
 	}
 
 	public function augmentDatabase() {
 	}
-	
+
 	public function augmentWrite(&$manipulation) {
 	}
 
@@ -36,11 +36,11 @@ class Hierarchy extends DataExtension {
 	 */
 	public function validate(ValidationResult $validationResult) {
 		// The object is new, won't be looping.
-		if (!$this->owner->ID) return; 
+		if (!$this->owner->ID) return;
 		// The object has no parent, won't be looping.
-		if (!$this->owner->ParentID) return; 
+		if (!$this->owner->ParentID) return;
 		// The parent has not changed, skip the check for performance reasons.
-		if (!$this->owner->isChanged('ParentID')) return; 
+		if (!$this->owner->isChanged('ParentID')) return;
 
 		// Walk the hierarchy upwards until we reach the top, or until we reach the originating node again.
 		$node = $this->owner;
@@ -77,18 +77,18 @@ class Hierarchy extends DataExtension {
 	 * @param int $minNodeCount
 	 * @return string
 	 */
-	public function getChildrenAsUL($attributes = "", $titleEval = '"<li>" . $child->Title', $extraArg = null, 
-			$limitToMarked = false, $childrenMethod = "AllChildrenIncludingDeleted", 
+	public function getChildrenAsUL($attributes = "", $titleEval = '"<li>" . $child->Title', $extraArg = null,
+			$limitToMarked = false, $childrenMethod = "AllChildrenIncludingDeleted",
 			$numChildrenMethod = "numChildren", $rootCall = true, $minNodeCount = 30) {
 
 		if($limitToMarked && $rootCall) {
 			$this->markingFinished($numChildrenMethod);
 		}
-		
+
 		if($this->owner->hasMethod($childrenMethod)) {
 			$children = $this->owner->$childrenMethod($extraArg);
 		} else {
-			user_error(sprintf("Can't find the method '%s' on class '%s' for getting tree children", 
+			user_error(sprintf("Can't find the method '%s' on class '%s' for getting tree children",
 				$childrenMethod, get_class($this->owner)), E_USER_ERROR);
 		}
 
@@ -96,35 +96,35 @@ class Hierarchy extends DataExtension {
 			if($attributes) {
 				$attributes = " $attributes";
 			}
-			
+
 			$output = "<ul$attributes>\n";
-		
+
 			foreach($children as $child) {
 				if(!$limitToMarked || $child->isMarked()) {
 					$foundAChild = true;
 					$output .= (is_callable($titleEval)) ? $titleEval($child) : eval("return $titleEval;");
-					$output .= "\n" . 
+					$output .= "\n" .
 					$child->getChildrenAsUL("", $titleEval, $extraArg, $limitToMarked, $childrenMethod,
 						$numChildrenMethod, false, $minNodeCount) . "</li>\n";
 				}
 			}
-			
+
 			$output .= "</ul>\n";
 		}
-		
+
 		if(isset($foundAChild) && $foundAChild) {
 			return $output;
 		}
 	}
-	
+
 	/**
 	 * Mark a segment of the tree, by calling mark().
 	 * The method performs a breadth-first traversal until the number of nodes is more than minCount.
 	 * This is used to get a limited number of tree nodes to show in the CMS initially.
-	 * 
-	 * This method returns the number of nodes marked.  After this method is called other methods 
+	 *
+	 * This method returns the number of nodes marked.  After this method is called other methods
 	 * can check isExpanded() and isMarked() on individual nodes.
-	 * 
+	 *
 	 * @param int $minNodeCount The minimum amount of nodes to mark.
 	 * @return int The actual number of nodes marked.
 	 */
@@ -142,10 +142,10 @@ class Hierarchy extends DataExtension {
 			if($minNodeCount && sizeof($this->markedNodes) >= $minNodeCount) {
 				break;
 			}
-		}		
+		}
 		return sizeof($this->markedNodes);
 	}
-	
+
 	/**
 	 * Filter the marking to only those object with $node->$parameterName = $parameterValue
 	 * @param string $parameterName The parameter on each node to check when marking.
@@ -188,7 +188,7 @@ class Hierarchy extends DataExtension {
 						break;
 					}
 				}
-				return $ret;		
+				return $ret;
 			} else {
 				return ($node->$parameterName == $this->markingFilter['value']);
 			}
@@ -196,7 +196,7 @@ class Hierarchy extends DataExtension {
 			return call_user_func($func, $node);
 		}
 	}
-	
+
 	/**
 	 * Mark all children of the given node that match the marking filter.
 	 * @param DataObject $node Parent node.
@@ -206,10 +206,10 @@ class Hierarchy extends DataExtension {
 		if($node->hasMethod($childrenMethod)) {
 			$children = $node->$childrenMethod($context);
 		} else {
-			user_error(sprintf("Can't find the method '%s' on class '%s' for getting tree children", 
+			user_error(sprintf("Can't find the method '%s' on class '%s' for getting tree children",
 				$childrenMethod, get_class($node)), E_USER_ERROR);
 		}
-		
+
 		$node->markExpanded();
 		if($children) {
 			foreach($children as $child) {
@@ -224,7 +224,7 @@ class Hierarchy extends DataExtension {
 			}
 		}
 	}
-	
+
 	/**
 	 * Ensure marked nodes that have children are also marked expanded.
 	 * Call this after marking but before iterating over the tree.
@@ -239,7 +239,7 @@ class Hierarchy extends DataExtension {
 			}
 		}
 	}
-	
+
 	/**
 	 * Return CSS classes of 'unexpanded', 'closed', both, or neither, depending on
 	 * the marking of this DataObject.
@@ -256,7 +256,7 @@ class Hierarchy extends DataExtension {
 		}
 		return $classes;
 	}
-	
+
 	/**
 	 * Mark the children of the DataObject with the given ID.
 	 * @param int $id ID of parent node.
@@ -276,7 +276,7 @@ class Hierarchy extends DataExtension {
 
 	/**
 	 * Expose the given object in the tree, by marking this page and all it ancestors.
-	 * @param DataObject $childObj 
+	 * @param DataObject $childObj
 	 */
 	public function markToExpose($childObj) {
 		if(is_object($childObj)){
@@ -286,7 +286,7 @@ class Hierarchy extends DataExtension {
 			}
 		}
 	}
-	
+
 	/**
 	 * Return the IDs of all the marked nodes
 	 */
@@ -300,33 +300,33 @@ class Hierarchy extends DataExtension {
 	 */
 	public function parentStack() {
 		$p = $this->owner;
-		
+
 		while($p) {
 			$stack[] = $p;
 			$p = $p->ParentID ? $p->Parent() : null;
 		}
-		
+
 		return $stack;
 	}
-	
+
 	/**
 	 * True if this DataObject is marked.
 	 * @var boolean
 	 */
 	protected static $marked = array();
-	
+
 	/**
 	 * True if this DataObject is expanded.
 	 * @var boolean
 	 */
 	protected static $expanded = array();
-	
+
 	/**
 	 * True if this DataObject is opened.
 	 * @var boolean
 	 */
 	protected static $treeOpened = array();
-	
+
 	/**
 	 * Mark this DataObject as expanded.
 	 */
@@ -334,7 +334,7 @@ class Hierarchy extends DataExtension {
 		self::$marked[ClassInfo::baseDataClass($this->owner->class)][$this->owner->ID] = true;
 		self::$expanded[ClassInfo::baseDataClass($this->owner->class)][$this->owner->ID] = true;
 	}
-	
+
 	/**
 	 * Mark this DataObject as unexpanded.
 	 */
@@ -342,7 +342,7 @@ class Hierarchy extends DataExtension {
 		self::$marked[ClassInfo::baseDataClass($this->owner->class)][$this->owner->ID] = true;
 		self::$expanded[ClassInfo::baseDataClass($this->owner->class)][$this->owner->ID] = false;
 	}
-	
+
 	/**
 	 * Mark this DataObject's tree as opened.
 	 */
@@ -350,7 +350,7 @@ class Hierarchy extends DataExtension {
 		self::$marked[ClassInfo::baseDataClass($this->owner->class)][$this->owner->ID] = true;
 		self::$treeOpened[ClassInfo::baseDataClass($this->owner->class)][$this->owner->ID] = true;
 	}
-	
+
 	/**
 	 * Check if this DataObject is marked.
 	 * @return boolean
@@ -360,7 +360,7 @@ class Hierarchy extends DataExtension {
 		$id = $this->owner->ID;
 		return isset(self::$marked[$baseClass][$id]) ? self::$marked[$baseClass][$id] : false;
 	}
-	
+
 	/**
 	 * Check if this DataObject is expanded.
 	 * @return boolean
@@ -370,7 +370,7 @@ class Hierarchy extends DataExtension {
 		$id = $this->owner->ID;
 		return isset(self::$expanded[$baseClass][$id]) ? self::$expanded[$baseClass][$id] : false;
 	}
-	
+
 	/**
 	 * Check if this DataObject's tree is opened.
 	 */
@@ -381,24 +381,6 @@ class Hierarchy extends DataExtension {
 	}
 
 	/**
-	 * Return a partial tree as an HTML UL.
-	 */
-	public function partialTreeAsUL($minCount = 50) {
-		$children = $this->owner->AllChildren();
-		if($children) {
-			if($attributes) $attributes = " $attributes";
-			$output = "<ul$attributes>\n";
-		
-			foreach($children as $child) {
-				$output .= eval("return $titleEval;") . "\n" . 
-					$child->getChildrenAsUL("", $titleEval, $extraArg) . "</li>\n";
-			}
-			$output .= "</ul>\n";
-		}
-		return $output;
-	}
-	
-	/**
 	 * Get a list of this DataObject's and all it's descendants IDs.
 	 * @return int
 	 */
@@ -407,7 +389,7 @@ class Hierarchy extends DataExtension {
 		$this->loadDescendantIDListInto($idList);
 		return $idList;
 	}
-	
+
 	/**
 	 * Get a list of this DataObject's and all it's descendants ID, and put it in $idList.
 	 * @var array $idList Array to put results in.
@@ -426,23 +408,18 @@ class Hierarchy extends DataExtension {
 			}
 		}
 	}
-	
+
 	/**
 	 * Get the children for this DataObject.
-	 * @return SS_List
+	 * @return ArrayList
 	 */
 	public function Children() {
-		if(!(isset($this->_cache_children) && $this->_cache_children)) { 
-			$result = $this->owner->stageChildren(false); 
-			if(isset($result)) { 
-				$this->_cache_children = new ArrayList(); 
-				foreach($result as $child) { 
-					if($child->canView()) { 
-						$this->_cache_children->push($child); 
-					} 
-				} 
-			} 
-		} 
+		if(!(isset($this->_cache_children) && $this->_cache_children)) {
+			$result = $this->owner->stageChildren(false);
+			$this->_cache_children = $result->filterByCallback(function($item) {
+				return $item->canView();
+			});
+		}
 		return $this->_cache_children;
 	}
 
@@ -465,7 +442,7 @@ class Hierarchy extends DataExtension {
 	public function AllChildrenIncludingDeleted($context = null) {
 		return $this->doAllChildrenIncludingDeleted($context);
 	}
-	
+
 	/**
 	 * @see AllChildrenIncludingDeleted
 	 *
@@ -474,14 +451,11 @@ class Hierarchy extends DataExtension {
 	 */
 	public function doAllChildrenIncludingDeleted($context = null) {
 		if(!$this->owner) user_error('Hierarchy::doAllChildrenIncludingDeleted() called without $this->owner');
-		
-		$idxStageChildren = array();
-		$idxLiveChildren = array();
-		
+
 		$baseClass = ClassInfo::baseDataClass($this->owner->class);
 		if($baseClass) {
 			$stageChildren = $this->owner->stageChildren(true);
-			
+
 			// Add live site content that doesn't exist on the stage site, if required.
 			if($this->owner->hasExtension('Versioned')) {
 				// Next, go through the live children.  Only some of these will be listed					
@@ -494,16 +468,16 @@ class Hierarchy extends DataExtension {
 				}
 			}
 
-			$this->owner->extend("augmentAllChildrenIncludingDeleted", $stageChildren, $context); 
-			
+			$this->owner->extend("augmentAllChildrenIncludingDeleted", $stageChildren, $context);
+
 		} else {
 			user_error("Hierarchy::AllChildren() Couldn't determine base class for '{$this->owner->class}'",
 				E_USER_ERROR);
 		}
-		
+
 		return $stageChildren;
 	}
-	
+
 	/**
 	 * Return all the children that this page had, including pages that were deleted
 	 * from both stage & live.
@@ -512,12 +486,12 @@ class Hierarchy extends DataExtension {
 		if(!$this->owner->hasExtension('Versioned')) {
 			throw new Exception('Hierarchy->AllHistoricalChildren() only works with Versioned extension applied');
 		}
-		
+
 		$baseClass=ClassInfo::baseDataClass($this->owner->class);
-		return Versioned::get_including_deleted($baseClass, 
+		return Versioned::get_including_deleted($baseClass,
 			"\"ParentID\" = " . (int)$this->owner->ID, "\"$baseClass\".\"ID\" ASC");
 	}
-	
+
 	/**
 	 * Return the number of children that this page ever had, including pages that were deleted
 	 */
@@ -526,7 +500,7 @@ class Hierarchy extends DataExtension {
 			throw new Exception('Hierarchy->AllHistoricalChildren() only works with Versioned extension applied');
 		}
 
-		return Versioned::get_including_deleted(ClassInfo::baseDataClass($this->owner->class), 
+		return Versioned::get_including_deleted(ClassInfo::baseDataClass($this->owner->class),
 			"\"ParentID\" = " . (int)$this->owner->ID)->count();
 	}
 
@@ -534,74 +508,65 @@ class Hierarchy extends DataExtension {
 	 * Return the number of direct children.
 	 * By default, values are cached after the first invocation.
 	 * Can be augumented by {@link augmentNumChildrenCountQuery()}.
-	 * 
+	 *
 	 * @param Boolean $cache
 	 * @return int
 	 */
 	public function numChildren($cache = true) {
 		// Build the cache for this class if it doesn't exist.
-		if(!$cache || !is_numeric($this->_cache_numChildren)) {
-			// Hey, this is efficient now!
+		if (!$cache || !is_numeric($this->_cache_numChildren)) {
 			// We call stageChildren(), because Children() has canView() filtering
 			$this->_cache_numChildren = (int)$this->owner->stageChildren(true)->Count();
 		}
-
 		// If theres no value in the cache, it just means that it doesn't have any children.
 		return $this->_cache_numChildren;
 	}
 
 	/**
 	 * Return children from the stage site
-	 * 
+	 *
 	 * @param showAll Inlcude all of the elements, even those not shown in the menus.
 	 *   (only applicable when extension is applied to {@link SiteTree}).
-	 * @return SS_List
+	 * @return DataList
 	 */
 	public function stageChildren($showAll = false) {
-		if($this->owner->db('ShowInMenus')) {
-			$extraFilter = ($showAll) ? '' : " AND \"ShowInMenus\"=1";
-		} else {
-			$extraFilter = '';
-		}
-		
 		$baseClass = ClassInfo::baseDataClass($this->owner->class);
-		
-		$staged = DataObject::get($baseClass, "\"{$baseClass}\".\"ParentID\" = " 
-			. (int)$this->owner->ID . " AND \"{$baseClass}\".\"ID\" != " . (int)$this->owner->ID
-			. $extraFilter, "");
-			
+		$staged = $baseClass::get()
+			->filter('ParentID', (int)$this->owner->ID)
+			->exclude('ID', (int)$this->owner->ID);
+		if (!$showAll && $this->owner->db('ShowInMenus')) {
+			$staged = $staged->filter('ShowInMenus', 1);
+		}
 		$this->owner->extend("augmentStageChildren", $staged, $showAll);
 		return $staged;
 	}
 
 	/**
 	 * Return children from the live site, if it exists.
-	 * 
+	 *
 	 * @param boolean $showAll Include all of the elements, even those not shown in the menus.
 	 *   (only applicable when extension is applied to {@link SiteTree}).
 	 * @param boolean $onlyDeletedFromStage Only return items that have been deleted from stage
 	 * @return SS_List
 	 */
 	public function liveChildren($showAll = false, $onlyDeletedFromStage = false) {
-		if(!$this->owner->hasExtension('Versioned')) {
+		if (!$this->owner->hasExtension('Versioned')) {
 			throw new Exception('Hierarchy->liveChildren() only works with Versioned extension applied');
 		}
-
 		$baseClass = ClassInfo::baseDataClass($this->owner->class);
-		$id = $this->owner->ID;
-		
-		$children = DataObject::get($baseClass)
-			->where("\"{$baseClass}\".\"ParentID\" = $id AND \"{$baseClass}\".\"ID\" != $id")
+		$children = $baseClass::get()
+			->filter('ParentID', (int)$this->owner->ID)
+			->exclude('ID', (int)$this->owner->ID)
 			->setDataQueryParam(array(
 				'Versioned.mode' => $onlyDeletedFromStage ? 'stage_unique' : 'stage',
 				'Versioned.stage' => 'Live'
 			));
-
-		if(!$showAll) $children = $children->where('"ShowInMenus" = 1');
-
+		if (!$showAll) {
+			$children = $children->filter('ShowInMenus', 1);
+		}
 		return $children;
 	}
-	
+
 	/**
 	 * Get the parent of this class.
 	 * @return DataObject
@@ -614,7 +579,7 @@ class Hierarchy extends DataExtension {
 			return DataObject::get_one($this->owner->class, $filter);
 		}
 	}
-	
+
 	/**
 	 * Return all the parents of this class in a set ordered from the lowest to highest parent.
 	 *
@@ -623,18 +588,18 @@ class Hierarchy extends DataExtension {
 	public function getAncestors() {
 		$ancestors = new ArrayList();
 		$object    = $this->owner;
-		
+
 		while($object = $object->getParent()) {
 			$ancestors->push($object);
 		}
-		
+
 		return $ancestors;
 	}
 
 	/**
 	 * Returns a human-readable, flattened representation of the path to the object,
 	 * using its {@link Title()} attribute.
-	 * 
+	 *
 	 * @param String
 	 * @return String
 	 */
@@ -645,14 +610,14 @@ class Hierarchy extends DataExtension {
 		$crumbs[] = $this->owner->Title;
 		return implode($separator, $crumbs);
 	}
-	
+
 	/**
 	 * Get the next node in the tree of the type. If there is no instance of the className descended from this node,
 	 * then search the parents.
-	 * 
+	 *
 	 * @todo Write!
 	 */
-	public function naturalPrev( $className, $afterNode = null ) {
+	public function naturalPrev($className, $afterNode = null) {
 		return null;
 	}
 
@@ -664,7 +629,7 @@ class Hierarchy extends DataExtension {
 	 * @param DataObject afterNode Used for recursive calls to this function
 	 * @return DataObject
 	 */
-	public function naturalNext( $className = null, $root = 0, $afterNode = null ) {
+	public function naturalNext($className = null, $root = 0, $afterNode = null) {
 		// If this node is not the node we are searching from, then we can possibly return this
 		// node as a solution
 		if($afterNode && $afterNode->ID != $this->owner->ID) {
@@ -672,41 +637,43 @@ class Hierarchy extends DataExtension {
 				return $this->owner;
 			}
 		}
-			
+
 		$nextNode = null;
 		$baseClass = ClassInfo::baseDataClass($this->owner->class);
-		
-		$children = DataObject::get(ClassInfo::baseDataClass($this->owner->class),
-			"\"$baseClass\".\"ParentID\"={$this->owner->ID}" . ( ( $afterNode ) ? " AND \"Sort\" > "
-			. sprintf( '%d', $afterNode->Sort ) : "" ), '"Sort" ASC');
-		
+		$children = $baseClass::get()
+			->filter('ParentID', (int)$this->owner->ID)
+			->sort('Sort', 'ASC');
+		if ($afterNode) {
+			$children = $children->where(sprintf('"Sort" > %d', $afterNode->Sort));
+		}
+
 		// Try all the siblings of this node after the given node
 		/*if( $siblings = DataObject::get( ClassInfo::baseDataClass($this->owner->class), 
 		"\"ParentID\"={$this->owner->ParentID}" . ( $afterNode ) ? "\"Sort\" 
 		> {$afterNode->Sort}" : "" , '\"Sort\" ASC' ) ) $searchNodes->merge( $siblings );*/
-		
+
 		if($children) {
 			foreach($children as $node) {
 				if($nextNode = $node->naturalNext($className, $node->ID, $this->owner)) {
 					break;
 				}
 			}
-			
+
 			if($nextNode) {
 				return $nextNode;
 			}
 		}
-		
+
 		// if this is not an instance of the root class or has the root id, search the parent
 		if(!(is_numeric($root) && $root == $this->owner->ID || $root == $this->owner->class)
 				&& ($parent = $this->owner->Parent())) {
-			
+
 			return $parent->naturalNext( $className, $root, $this->owner );
 		}
-		
+
 		return null;
 	}
-	
+
 	public function flushCache() {
 		$this->_cache_children = null;
 		$this->_cache_numChildren = null;


### PR DESCRIPTION
API: refactored Hierachy class to use new DataObject::get() syntax
API: removed broken & unused method Hierachy->partialTreeAsUL()
