### PR TITLE
Update conventions

### DIFF
--- a/docs/en/misc/coding-conventions.md
+++ b/docs/en/misc/coding-conventions.md
@@ -282,7 +282,7 @@ apart from the last argument.
 #### if/else/elseif
 
 No control structure is allowed to have spaces directly
-before or after the opening parathesis, as well as no space before the closing parenthesis.
+before or after the opening parenthesis, as well as no space before the closing parenthesis.
 
 The opening brace and closing brace are written on the same line as the conditional statement. 
 Any content within the braces must be indented using a tab.


### PR DESCRIPTION
Changes are:
- Close method header on same line as last argument
- Require new lines at the end of files
  
  This mostly fixes the problem with an empty _config.php with just "<?php" (no newline) outputting the <?php
- Use successive capitals for acronyms in classnames
- Use columns for line length over characters
  
  This removes the confusion over a tab (one character) taking up four spaces.

This makes the conventions copied from Zend more closely match the current code.
