### PR TITLE
Fixed BC break (ancestry) in Mailer

### DIFF
--- a/email/Mailer.php
+++ b/email/Mailer.php
@@ -7,7 +7,7 @@
  * @package framework
  * @subpackage email
  */
-class Mailer {
+class Mailer extends Object {
 	
 	/**
 	 * Send a plain-text email.


### PR DESCRIPTION
fb076c039647980f197705cbcf5fd3c00abe2b67 broke BC on Mailer by removing its Object ancestry. This commit reintroduces the Object ancestry in Mailer.
