### PR TITLE
FIX Allow comments in static var declarations

### DIFF
--- a/core/manifest/ConfigStaticManifest.php
+++ b/core/manifest/ConfigStaticManifest.php
@@ -268,6 +268,9 @@ class SS_ConfigStaticManifest_Parser {
 			else if($type == ';' || $type == ',' || $type == '=') {
 				break;
 			}
+			else if ($type == T_DOC_COMMENT || $type == T_COMMENT) {
+				continue;
+			}
 			else {
 				user_error('Unexpected token when building static manifest: '.print_r($token, true), E_USER_ERROR);
 			}


### PR DESCRIPTION
At the moment, comments inside the declaration of static vars are
causing an error.

eg:

``` php
protected static
/**
* The URL to access the service
*/
$endpoint = '',
/**
* Our username to access the service
*/
$username = '',
/**
* Our secret key to access the service
*/
$secret = '';
```

Throws an error. This patch fixes that.

It's realistic that this could happen too:

``` php
public static /* comment */ $var = '';
```

Though I haven't tested that with this patch.

There is still an issue with this declaration:

``` php
public static $var = <<<VAR
Some value
VAR;
```

I'm not certain this is the best solution, so happy to hear thoughts.
