### PR TITLE
MINOR Redundant code removal

### DIFF
--- a/api/RestfulService.php
+++ b/api/RestfulService.php
@@ -298,8 +298,6 @@ class RestfulService extends ViewableData {
 	protected function extractResponse($ch, $rawResponse) {
 		//get the status code
 		$statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		//get a curl error if there is one
-		$curlError = curl_error($ch);
 		//normalise the status code
 		if(curl_error($ch) !== '' || $statusCode == 0) $statusCode = 500;
 		//calculate the length of the header and extract it


### PR DESCRIPTION
Oh Ingo, what is wrong with me. Looks like my last patch actually fixed an undefined var error I was getting on my code that had fragmented a bit from the real 3.1 branch so this var declaration is useless IRL.
Removed redundant code. I'm going to bed before you shout at me.
