### PR TITLE
Fixing formatting errors

### DIFF
--- a/docs/en/tutorials/2-extending-a-basic-site.md
+++ b/docs/en/tutorials/2-extending-a-basic-site.md
@@ -201,9 +201,9 @@ the date field will have the date format defined by your locale.
 		$fields = parent::getCMSFields();
 		
 		$fields->addFieldToTab('Root.Main', $dateField = new DateField('Date','Article Date (for example: 20/12/2010)'), 'Content');
-        $dateField->setConfig('showcalendar', true);
-        $fields->addFieldToTab('Root.Main', $dateField, 'Content');
-        $fields->addFieldToTab('Root.Main', new TextField('Author'), 'Content');
+		$dateField->setConfig('showcalendar', true);
+		$fields->addFieldToTab('Root.Main', $dateField, 'Content');
+		$fields->addFieldToTab('Root.Main', new TextField('Author'), 'Content');
 
 		return $fields;
 	}


### PR DESCRIPTION
The usage of spaces instead of tabs causes the highlighting to display incorrectly on the docs.silverstripe.org site. I replaced them with tabs as they should be
