### PR TITLE
Don't use Zend_Cache in manifests

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -254,6 +254,7 @@ require_once 'dev/Backtrace.php';
 require_once 'dev/ZendLog.php';
 require_once 'dev/Log.php';
 require_once 'filesystem/FileFinder.php';
+require_once 'core/manifest/ManifestCache.php';
 require_once 'core/manifest/ClassLoader.php';
 require_once 'core/manifest/ClassManifest.php';
 require_once 'core/manifest/ManifestFileFinder.php';

--- a/core/manifest/ClassManifest.php
+++ b/core/manifest/ClassManifest.php
@@ -117,11 +117,10 @@ class SS_ClassManifest {
 		$this->base  = $base;
 		$this->tests = $includeTests;
 
-		$this->cache = SS_Cache::factory('SS_ClassManifest', 'Core', array(
-			'automatic_serialization' => true,
-			'lifetime' => null
-		));
-		$this->cacheKey = $this->tests ? 'manifest_tests' : 'manifest';
+		$cacheClass = defined('SS_MANIFESTCACHE') ? SS_MANIFESTCACHE : 'ManifestCache_File';
+
+		$this->cache = new $cacheClass('classmanifest'.($includeTests ? '_tests' : ''));
+		$this->cacheKey = 'manifest';
 
 		if (!$forceRegen && $data = $this->cache->load($this->cacheKey)) {
 			$this->classes      = $data['classes'];
@@ -343,7 +342,7 @@ class SS_ClassManifest {
 			$interfaces = self::get_interface_parser()->findAll($tokens);
 
 			$cache = array('classes' => $classes, 'interfaces' => $interfaces, 'namespace' => $namespace);
-			$this->cache->save($cache, $key, array('fileparse'));
+			$this->cache->save($cache, $key);
 		}
 
 		foreach ($classes as $class) {

--- a/core/manifest/ConfigStaticManifest.php
+++ b/core/manifest/ConfigStaticManifest.php
@@ -39,12 +39,10 @@ class SS_ConfigStaticManifest {
 		$this->base  = $base;
 		$this->tests = $includeTests;
 
-		$this->cache = SS_Cache::factory('SS_ConfigStatics', 'Core', array(
-			'automatic_serialization' => true,
-			'lifetime' => null
-		));
+		$cacheClass = defined('SS_MANIFESTCACHE') ? SS_MANIFESTCACHE : 'ManifestCache_File';
 
-		$this->key = 'sc_'.sha1($base . ($includeTests ? '!tests' : ''));
+		$this->cache = new $cacheClass('staticmanifest'.($includeTests ? '_tests' : ''));
+		$this->key = sha1($base);
 
 		if(!$forceRegen) {
 			$this->index = $this->cache->load($this->key);

--- a/core/manifest/ManifestCache.php
+++ b/core/manifest/ManifestCache.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * A basic caching interface that manifests use to store data.
+ */
+interface ManifestCache {
+	public function __construct($name);
+	public function load($key);
+	public function save($data, $key);
+	public function clear();
+}
+
+/**
+ * Stores manifest data in files in TEMP_DIR dir on filesystem
+ */
+class ManifestCache_File implements ManifestCache {
+	function __construct($name) {
+		$this->folder = TEMP_FOLDER.'/'.$name;
+		if (!is_dir($this->folder)) mkdir($this->folder);
+	}
+
+	function load($key) {
+		$file = $this->folder.'/cache_'.$key;
+		return file_exists($file) ? unserialize(file_get_contents($file)) : null;
+	}
+
+	function save($data, $key) {
+		$file = $this->folder.'/cache_'.$key;
+		file_put_contents($file, serialize($data));
+	}
+
+	function clear() {
+		array_map('unlink', glob($this->folder.'/cache_*'));
+	}
+}
+
+/**
+ * Same as ManifestCache_File, but stores the data as valid PHP which gets included to load
+ * This is a bit faster if you have an opcode cache installed, but slower otherwise
+ */
+class ManifestCache_File_PHP extends ManifestCache_File {
+	function load($key) {
+		global $loaded_manifest;
+		$loaded_manifest = null;
+
+		$file = $this->folder.'/cache_'.$key;
+		if (file_exists($file)) include $file;
+
+		return $loaded_manifest;
+	}
+
+	function save($data, $key) {
+		$file = $this->folder.'/cache_'.$key;
+		file_put_contents($file, '<?php $loaded_manifest = '.var_export($data, true).';');
+	}
+}
+
+/**
+ * Stores manifest data in APC.
+ * Note: benchmarks seem to indicate this is not particularly faster than _File
+ */
+class ManifestCache_APC implements ManifestCache {
+	protected $pre;
+
+	function __construct($name) {
+		$this->pre = $name;
+	}
+
+	function load($key) {
+		return apc_fetch($this->pre.$key);
+	}
+
+	function save($data, $key) {
+		apc_store($this->pre.$key, $data);
+	}
+
+	function clear() {
+	}
+}

--- a/core/manifest/TemplateManifest.php
+++ b/core/manifest/TemplateManifest.php
@@ -35,13 +35,12 @@ class SS_TemplateManifest {
 
 		$this->project = $project;
 
-		$this->cacheKey   = $this->tests ? 'manifest_tests' : 'manifest';
-		$this->forceRegen = $forceRegen;
+		$cacheClass = defined('SS_MANIFESTCACHE') ? SS_MANIFESTCACHE : 'ManifestCache_File';
 
-		$this->cache = SS_Cache::factory('SS_TemplateManifest', 'Core', array(
-			'automatic_serialization' => true,
-			'lifetime' => null
-		));
+		$this->cache = new $cacheClass('templatemanifest'.($includeTests ? '_tests' : ''));
+		$this->cacheKey = 'manifest';
+
+		$this->forceRegen = $forceRegen;
 	}
 
 	/**


### PR DESCRIPTION
The overhead of Zend_Cache in manifests is too high - we don't
need LRU or tags, just somewhere to dump a bunch of data that
persists

You can replace the class used by defining SS_MANIFESTCACHE
to be a class that implements the ManifestCache interface
(we can't use the Config system to set this, as it isn't
initialised yet).
