### PR TITLE
FIX Respect tree node limits, fix search result node display

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -691,7 +691,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 	 * @return String Nested unordered list with links to each page
 	 */
 	public function getSiteTreeFor($className, $rootID = null, $childrenMethod = null, $numChildrenMethod = null,
-			$filterFunction = null, $minNodeCount = 30) {
+			$filterFunction = null, $nodeCountThreshold = 30) {
 
 		// Filter criteria
 		$params = $this->request->getVar('q');
@@ -719,7 +719,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		// Mark the nodes of the tree to return
 		if ($filterFunction) $obj->setMarkingFilterFunction($filterFunction);
 
-		$obj->markPartialTree($minNodeCount, $this, $childrenMethod, $numChildrenMethod);
+		$obj->markPartialTree($nodeCountThreshold, $this, $childrenMethod, $numChildrenMethod);
 		
 		// Ensure current page is exposed
 		if($p = $this->currentPage()) $obj->markToExpose($p);
@@ -744,7 +744,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 			true, 
 			$childrenMethod,
 			$numChildrenMethod,
-			$minNodeCount
+			$nodeCountThreshold
 		);
 
 		// Wrap the root if needs be.


### PR DESCRIPTION
The $minNodeCount attribute wasn't properly respected
during actual querying, so SilverStripe would always traverse
the entire tree (and load all objects into memory),
before then marking nodes as "unexpanded", which prevents
them from actually being rendered.

Fixes nodes on search results to be expanded by default, and nodes on search results to correctly ajax-expand.

I'm sending a PR for 3.0, since I think this is an important performance regression fix.
I've benchmarked on a standard install with 2000 sample pages created through `FTPageMakerTask` in the `frameworktest` module. The `admin/pages/treeview` URL went from 1.6s to 1.1s.
