### PR TITLE
BUG Issue with ValidationException having blank ValidationResult

### DIFF
--- a/model/ValidationException.php
+++ b/model/ValidationException.php
@@ -10,22 +10,50 @@
 class ValidationException extends Exception {
 
 	/**
-	 * @var {@link ValidationResult} or string
+	 * The contained ValidationResult related to this error
+	 * 
+	 * @var ValidationResult
 	 */
 	protected $result;
 
+	/**
+	 * Construct a new ValidationException with an optional ValidationResult object
+	 * 
+	 * @param ValidationResult|string $result The ValidationResult containing the
+	 * failed result. Can be substituted with an error message instead if no
+	 * ValidationResult exists.
+	 * @param string|integer $message The error message. If $result was given the 
+	 * message string rather than a ValidationResult object then this will have 
+	 * the error code number.
+	 * @param integer $code The error code number, if not given in the second parameter
+	 */
 	public function __construct($result = null, $message = null, $code = 0) {
-		if($result instanceof ValidationResult) {
-			$this->result = $result;
-			$message = $result->message();
-		} else {
+		
+		// Check arguments
+		if(!($result instanceof ValidationResult)) {
+			
+			// Shift parameters if no ValidationResult is given
 			$code = $message;
 			$message = $result;
+			
+			// Infer ValidationResult from parameters
+			$result = new ValidationResult(false, $message);
+		} elseif(empty($message)) {
+			
+			// Infer message if not given
+			$message = $result->message();
 		}
 		
+		// Construct
+		$this->result = $result;
 		parent::__construct($message, $code);
 	}
 	
+	/**
+	 * Retrieves the ValidationResult related to this error
+	 * 
+	 * @return ValidationResult
+	 */
 	public function getResult() {
 		return $this->result;	
 	}

--- a/tests/model/ValidationExceptionTest.php
+++ b/tests/model/ValidationExceptionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @package framework
+ * @subpackage Testing
+ */
+class ValidationExceptionTest extends SapphireTest 
+{
+	/**
+	 * Test that ValidationResult object can correctly populate a ValidationException
+	 */
+	public function testCreateFromValidationResult() {
+		
+		$result = new ValidationResult(false, 'Not a valid result');
+		$exception = new ValidationException($result);
+		
+		$this->assertEquals(0, $exception->getCode());
+		$this->assertEquals('Not a valid result', $exception->getMessage());
+		$this->assertEquals(false, $exception->getResult()->valid());
+		$this->assertEquals('Not a valid result', $exception->getResult()->message());
+		
+	}
+	
+	/**
+	 * Test that ValidationResult object with multiple errors can correctly 
+	 * populate a ValidationException
+	 */
+	public function testCreateFromComplexValidationResult() {
+		$result = new ValidationResult();
+		$result->error('Invalid type');
+		$result->error('Out of kiwis');
+		$exception = new ValidationException($result);
+		
+		$this->assertEquals(0, $exception->getCode());
+		$this->assertEquals('Invalid type; Out of kiwis', $exception->getMessage());
+		$this->assertEquals(false, $exception->getResult()->valid());
+		$this->assertEquals('Invalid type; Out of kiwis', $exception->getResult()->message());
+	}
+	
+	/**
+	 * Test that a ValidationException created with no contained ValidationResult
+	 * will correctly populate itself with an inferred version
+	 */
+	public function testCreateFromMessage() {
+		$exception = new ValidationException('Error inferred from message', E_USER_ERROR);
+		
+		$this->assertEquals(E_USER_ERROR, $exception->getCode());
+		$this->assertEquals('Error inferred from message', $exception->getMessage());
+		$this->assertEquals(false, $exception->getResult()->valid());
+		$this->assertEquals('Error inferred from message', $exception->getResult()->message());
+	}
+	
+	/**
+	 * Test that ValidationException can be created with both a ValidationResult
+	 * and a custom message
+	 */
+	public function testCreateWithValidationResultAndMessage() {
+		$result = new ValidationResult(false, 'Incorrect placement of cutlery');
+		$exception = new ValidationException($result, 'An error has occurred', E_USER_WARNING);
+		
+		$this->assertEquals(E_USER_WARNING, $exception->getCode());
+		$this->assertEquals('An error has occurred', $exception->getMessage());
+		$this->assertEquals(false, $exception->getResult()->valid());
+		$this->assertEquals('Incorrect placement of cutlery', $exception->getResult()->message());
+	}
+	
+	
+	/**
+	 * Test that ValidationException can be created with both a ValidationResult
+	 * and a custom message
+	 */
+	public function testCreateWithComplexValidationResultAndMessage() {
+		$result = new ValidationResult();
+		$result->error('A spork is not a knife');
+		$result->error('A knife is not a back scratcher');
+		$exception = new ValidationException($result, 'An error has occurred', E_USER_WARNING);
+		
+		$this->assertEquals(E_USER_WARNING, $exception->getCode());
+		$this->assertEquals('An error has occurred', $exception->getMessage());
+		$this->assertEquals(false, $exception->getResult()->valid());
+		$this->assertEquals('A spork is not a knife; A knife is not a back scratcher', $exception->getResult()->message());
+	}
+}


### PR DESCRIPTION
This pull request fixes some issues with the behaviour of ValidationException.

Code such as https://github.com/silverstripe/sapphire/blob/3.1/forms/gridfield/GridFieldDetailForm.php#L520 expects that any caught ValidationException has a contained ValidationResult object. Across the code base there seem to be a few inconsistent ways in which this object is created:
- Sometimes with a single ValidationError parameter
- Sometimes with only a message (and maybe an error code)
- Sometimes both of the above

I've attempted to fill in the missing PHPDoc of ValidationException to identify that each of these is correct, and updated the code to more robustly handle each of these situations.

As an effect of this, ValidationException will always have a contained ValidationError object, meaning that user (or other core) code that relies on this behaviour will no longer get null exceptions when calling $e->getResult()->message().

This was tracked down from a CMS bug where an error in DataObject was thrown from https://github.com/silverstripe/sapphire/blob/3.1/model/DataObject.php#L1064 but not being handled correctly.

Thorough test cases included.
