### PR TITLE
FIX: Fixed Versioned::get_version() to query the correct table which was...

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -1074,14 +1074,14 @@ class Versioned extends DataExtension {
 	 * 
 	 * @return DataObject
 	 */
-	public static function get_version($class, $id, $version) {
-		$baseClass = ClassInfo::baseDataClass($class);
-		$list = DataList::create($baseClass)
-			->where("\"$baseClass\".\"RecordID\" = $id")
-			->where("\"$baseClass\".\"Version\" = " . (int)$version);
-		$list->dataQuery()->setQueryParam('Versioned.mode', 'all_versions');
-		return $list->First();
-	}
+    public static function get_version($class, $id, $version) {
+        $baseClass = ClassInfo::baseDataClass($class);
+        $list = DataList::create($class)
+            ->where("\"$baseClass\".\"RecordID\" = $id")
+            ->where("\"{$baseClass}_versions\".\"Version\" = " . (int)$version);
+        $list->dataQuery()->setQueryParam('Versioned.mode', 'all_versions');
+        return $list->First();
+    }
 
 	/**
 	 * Return a list of all versions for a given id

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -392,6 +392,32 @@ class VersionedTest extends SapphireTest {
 			'Additional version fields returned');
 		$this->assertEquals($extraFields, array('2005', '2007', '2009'), 'Additional version fields returned');
 	}
+    
+    public function testLazyLoadedField() {
+        // Creat the first version of our object
+        $testPage = new VersionedTest_Subclass();
+        $testPage->Title = "First Version";
+        $testPage->ExtraField = "First Version";
+        $testPage->write();
+
+        // Now update the fields for our second version
+        $testPage->Title = "Second Version";
+        $testPage->ExtraField = "Second Version";
+        $testPage->write();
+
+        $versions = Versioned::get_all_versions('VersionedTest_Subclass', $testPage->ID);
+        $this->assertEquals($versions->count(), 2, "2 version have been created.");
+
+        // Check our second (staged) version
+        $stage = VersionedTest_Subclass::get()->first();
+        $this->assertEquals($stage->Title, "Second Version", "Stage title correct.");
+        $this->assertEquals($stage->ExtraField, "Second Version", "Stage content correct.");
+
+        // Now go back and check our first version values
+        $version = Versioned::get_version($testPage->ClassName, $testPage->ID, 1);
+        $this->assertEquals($version->Title, "First Version", "First version title correct.");
+        $this->assertEquals($version->ExtraField, "First Version", "First version ExtraField correct."); // This is the real test.
+    }
 }
 
 class VersionedTest_DataObject extends DataObject implements TestOnly {


### PR DESCRIPTION
... affecting lazy loaded fields

Cleaned up version of this pull request: https://github.com/silverstripe/sapphire/pull/1284

I looked at the 3.1 fix that was linked to [fbfff8d](https://github.com/silverstripe/sapphire/commit/fbfff8d) but I'm not convinced its the same fix. Whilst they may both have the same end result, this fix addresses the issue that Versioned::get_version() queries the wrong table (which in turn fixes the lazy loading issue).
