### PR TITLE
Update the deprecation notification version to 3.1

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -45,7 +45,7 @@ SS_Cache::add_backend('aggregatestore', 'File', array('cache_dir' => $aggregatec
 SS_Cache::pick_backend('aggregatestore', 'aggregate', 1000);
 
 // If you don't want to see deprecation errors for the new APIs, change this to 3.0.0-dev.
-Deprecation::notification_version('3.0.0');
+Deprecation::notification_version('3.1.0');
 
 // TODO Remove once new ManifestBuilder with submodule support is in place
 require_once('admin/_config.php');


### PR DESCRIPTION
This will throw a lot of errors, but these need to be fixed before 3.1 is released.
