### PR TITLE
NEW Enforce max node counts to avoid excessive resource usage

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -765,15 +765,53 @@ class LeftAndMain extends Controller implements PermissionProvider {
 			$link = Controller::join_links($recordController->Link("show"), $child->ID);
 			return LeftAndMain_TreeNode::create($child, $link, $controller->isCurrentPage($child))->forTemplate();
 		};
-		$html = $obj->getChildrenAsUL(
-			"",
-			$titleFn,
-			singleton('CMSPagesController'),
-			true, 
-			$childrenMethod,
-			$numChildrenMethod,
-			$nodeCountThreshold
-		);
+		
+		// Limit the amount of nodes shown for performance reasons.
+		// Skip the check if we're filtering the tree, since its not clear how many children will
+		// match the filter criteria until they're queried (and matched up with previously marked nodes).
+		$nodeThresholdLeaf = Config::inst()->get('Hierarchy', 'node_threshold_leaf');
+		if($nodeThresholdLeaf && !$filterFunction) {
+			$nodeCountCallback = function($parent, $numChildren) use($controller, $className, $nodeThresholdLeaf) {
+				if($className == 'SiteTree' && $parent->ID && $numChildren > $nodeThresholdLeaf) {
+					return sprintf(
+						'<ul><li class="readonly"><span class="item">'
+							. '%s (<a href="%s" class="cms-panel-link" data-pjax-target="Content">%s</a>)'
+							. '</span></li></ul>',
+						_t('LeftAndMain.TooManyPages', 'Too many pages'),
+						Controller::join_links(
+							$controller->LinkWithSearch($controller->Link()), '
+							?view=list&ParentID=' . $parent->ID
+						), 
+						_t(
+							'LeftAndMain.ShowAsList', 
+							'show as list', 
+							'Show large amount of pages in list instead of tree view'
+						)
+					);
+				}
+			};	
+		} else {
+			$nodeCountCallback = null;
+		}
+		
+		// If the amount of pages exceeds the node thresholds set, use the callback
+		if($obj->ParentID && $nodeCountCallback) {
+			$html = $nodeCountCallback($obj, $obj->$numChildrenMethod());
+		} 
+
+		// Otherwise return the actual tree (which might still filter leaf thresholds on children)
+		if(!$html) {
+			$html = $obj->getChildrenAsUL(
+				"",
+				$titleFn,
+				singleton('CMSPagesController'),
+				true, 
+				$childrenMethod,
+				$numChildrenMethod,
+				$nodeCountThreshold,
+				$nodeCountCallback
+			);
+		}
 
 		// Wrap the root if needs be.
 		if(!$rootID) {

--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -783,6 +783,9 @@ form.import-form label.left { width: 250px; }
 .tree-holder.jstree-apple li.Root > a .jstree-icon, .cms-tree.jstree-apple li.Root > a .jstree-icon { background-position: -56px -36px; }
 .tree-holder.jstree-apple li.deletedonlive .text, .cms-tree.jstree-apple li.deletedonlive .text { text-decoration: line-through; }
 .tree-holder.jstree-apple li.jstree-checked > a, .tree-holder.jstree-apple li.jstree-checked > a:link, .cms-tree.jstree-apple li.jstree-checked > a, .cms-tree.jstree-apple li.jstree-checked > a:link { background-color: #efe999; }
+.tree-holder.jstree-apple li.readonly, .cms-tree.jstree-apple li.readonly { color: #aaaaaa; padding-left: 18px; }
+.tree-holder.jstree-apple li.readonly a, .tree-holder.jstree-apple li.readonly a:link, .cms-tree.jstree-apple li.readonly a, .cms-tree.jstree-apple li.readonly a:link { margin: 0; padding: 0; }
+.tree-holder.jstree-apple li.readonly .jstree-icon, .cms-tree.jstree-apple li.readonly .jstree-icon { display: none; }
 .tree-holder.jstree-apple a, .tree-holder.jstree-apple a:link, .cms-tree.jstree-apple a, .cms-tree.jstree-apple a:link { color: #0073c1; padding: 3px 6px 3px 3px; border: none; display: inline-block; margin-right: 5px; }
 .tree-holder.jstree-apple ins, .cms-tree.jstree-apple ins { background-color: transparent; background-image: url(../images/sitetree_ss_default_icons.png); }
 .tree-holder.jstree-apple span.badge, .cms-tree.jstree-apple span.badge { clear: both; text-transform: uppercase; display: inline-block; padding: 0px 3px; font-size: 0.75em; line-height: 1em; margin-left: 3px; margin-right: 6px; margin-top: -1px; -webkit-border-radius: 2px 2px; -moz-border-radius: 2px / 2px; border-radius: 2px / 2px; }

--- a/admin/scss/_tree.scss
+++ b/admin/scss/_tree.scss
@@ -418,6 +418,19 @@
 					background-color: $color-cms-batchactions-menu-selected-background;
 				}
 			} 
+			&.readonly {
+				color: $color-text-disabled;
+				padding-left: 18px;
+
+				// Don't show drag icons or required spacing
+				a, a:link {
+					margin: 0;
+					padding: 0;
+				}
+				.jstree-icon {
+					display: none;
+				}
+			}
 		}	
 		a, a:link {
 			color:  $color-text-blue-link;
@@ -441,6 +454,7 @@
 			margin-right: 6px;
 			margin-top:  -1px;
 			@include border-radius(2px, 2px);
+	
 			&.modified, &.addedtodraft  {
 				color:  #7E7470;
 				border: 1px solid #C9B800;

--- a/docs/en/changelogs/3.1.0.md
+++ b/docs/en/changelogs/3.1.0.md
@@ -426,3 +426,6 @@ you can enable those warnings and future-proof your code already.
  * `ScheduledTask`, `QuarterHourlyTask`, `HourlyTask`, `DailyTask`, `MonthlyTask`, `WeeklyTask` and
 	 `YearlyTask` are deprecated, please extend from `BuildTask` or `CliController`,
 	 and invoke them in self-defined frequencies through Unix cronjobs etc.
+ * Hard limit displayed pages in the CMS tree to `500`, to avoid excessive resource usage. 
+   Configure through `Hierarchy.node_threshold_total` and `Hierarchy.node_threshold_leaf`.
+   Set to `0` to show tree unrestricted.

--- a/docs/en/reference/sitetree.md
+++ b/docs/en/reference/sitetree.md
@@ -74,7 +74,7 @@ Hierarchy operations (defined on `[api:Hierarchy]`:
  * `$page->AllHistoricalChildren()`: Return all the children this page had, including pages that were deleted from both stage & live.
  * `$page->AllChildrenIncludingDeleted()`: Return all children, including those that have been deleted but are still in live.
 
-## Limiting Hierarchy
+## Allowed Children, Default Child and Root-Level 
 
 By default, any page type can be the child of any other page type.  
 However, there are static properties that can be
@@ -115,9 +115,20 @@ level.
 
 Note that there is no allowed_parents` control.  To set this, you will need to specify the `allowed_children` of all other page types to exclude the page type in question.
 
-## Permission Control
+## Tree Limitations
 
+SilverStripe limits the amount of initially rendered nodes in order to avoid
+processing delays, usually to a couple of dozen. The value can be configured
+through `[api:Hierarchy::$node_threshold_total]`.
 
+If a website has thousands of pages, the tree UI metaphor can become an inefficient way
+to manage them. The CMS has an alternative "list view" for this purpose, which allows
+sorting and paging through large numbers of pages in a tabular view.
+
+To avoid exceeding performance constraints of both the server and browser,
+SilverStripe places hard limits on the amount of rendered pages in
+a specific tree leaf, typically a couple of hundred pages.
+The value can be configured through `[api:Hierarchy::$node_threshold_leaf]`.
 
 ## Tree Display (Description, Icons and Badges)
 

--- a/tests/model/HierarchyTest.php
+++ b/tests/model/HierarchyTest.php
@@ -60,11 +60,11 @@ class HierarchyTest extends SapphireTest {
 		$obj3 = Versioned::get_including_deleted("HierarchyTest_Object", "\"Title\" = 'Obj 3'")->First();
 	
 		// Check that both obj 3 children are returned
-		$this->assertEquals(array("Obj 3a", "Obj 3b"), 
+		$this->assertEquals(array("Obj 3a", "Obj 3b", "Obj 3c"), 
 			$obj3->AllHistoricalChildren()->column('Title'));
 			
 		// Check numHistoricalChildren
-		$this->assertEquals(2, $obj3->numHistoricalChildren());
+		$this->assertEquals(3, $obj3->numHistoricalChildren());
 		
 	}
 	
@@ -94,7 +94,7 @@ class HierarchyTest extends SapphireTest {
 	public function testNumChildren() {
 		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj1')->numChildren(), 0);
 		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj2')->numChildren(), 2);
-		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj3')->numChildren(), 2);
+		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj3')->numChildren(), 3);
 		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj2a')->numChildren(), 2);
 		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj2b')->numChildren(), 0);
 		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj3a')->numChildren(), 2);
@@ -200,29 +200,13 @@ class HierarchyTest extends SapphireTest {
 			true,  // rootCall
 			$nodeCountThreshold
 		);
-		$parser = new CSSContentParser($html);
-		$node2 = $parser->getByXpath(
-			'//ul/li[@id="' . $obj2->ID . '"]'
-		);
-		$this->assertTrue(
-			(bool)$node2,
+		$this->assertTreeContains($html, array($obj2),
 			'Contains root elements'
 		);
-		$node2a = $parser->getByXpath(
-			'//ul/li[@id="' . $obj2->ID . '"]' .
-				'/ul/li[@id="' . $obj2a->ID . '"]'
-		);
-		$this->assertTrue(
-			(bool)$node2a,
+		$this->assertTreeContains($html, array($obj2, $obj2a),
 			'Contains child elements (in correct nesting)'
 		);
-		$node2aa = $parser->getByXpath(
-			'//ul/li[@id="' . $obj2->ID . '"]' .
-				'/ul/li[@id="' . $obj2a->ID . '"]' .
-				'/ul/li[@id="' . $obj2aa->ID . '"]'
-		);
-		$this->assertTrue(
-			(bool)$node2aa,
+		$this->assertTreeContains($html, array($obj2, $obj2a, $obj2aa),
 			'Contains grandchild elements (in correct nesting)'
 		);
 	}
@@ -247,27 +231,13 @@ class HierarchyTest extends SapphireTest {
 			true, 
 			$nodeCountThreshold
 		);
-		$parser = new CSSContentParser($html);
-		$node1 = $parser->getByXpath(
-			'//ul/li[@id="' . $obj1->ID . '"]'
-		);
-		$this->assertTrue(
-			(bool)$node1,
+		$this->assertTreeContains($html, array($obj1),
 			'Contains root elements'
 		);
-		$node2 = $parser->getByXpath(
-			'//ul/li[@id="' . $obj2->ID . '"]'
-		);
-		$this->assertTrue(
-			(bool)$node2,
+		$this->assertTreeContains($html, array($obj2),
 			'Contains root elements'
 		);
-		$node2a = $parser->getByXpath(
-			'//ul/li[@id="' . $obj2->ID . '"]' .
-				'/ul/li[@id="' . $obj2a->ID . '"]'
-		);
-		$this->assertFalse(
-			(bool)$node2a,
+		$this->assertTreeNotContains($html, array($obj2, $obj2a),
 			'Does not contains child elements because they exceed minNodeCount'
 		);
 	}
@@ -296,20 +266,12 @@ class HierarchyTest extends SapphireTest {
 			true, 
 			$nodeCountThreshold
 		);
-		$parser = new CSSContentParser($html);
-		$node2 = $parser->getByXpath(
-			'//ul/li[@id="' . $obj2->ID . '"]'
-		);
-		$this->assertTrue(
-			(bool)$node2,
+		$this->assertTreeContains($html, array($obj2),
 			'Contains root elements'
 		);
-		$node2aa = $parser->getByXpath(
-			'//ul/li[@id="' . $obj2->ID . '"]' .
-				'/ul/li[@id="' . $obj2a->ID . '"]' .
-				'/ul/li[@id="' . $obj2aa->ID . '"]'
+		$this->assertTreeContains($html, array($obj2, $obj2a, $obj2aa),
+			'Does contain marked children nodes regardless of configured threshold'
 		);
-		$this->assertTrue((bool)$node2aa);
 	}
 
 	public function testGetChildrenAsULMinNodeCountWithFilters() {
@@ -343,21 +305,10 @@ class HierarchyTest extends SapphireTest {
 			true, 
 			$nodeCountThreshold
 		);
-		$parser = new CSSContentParser($html);
-		$node1 = $parser->getByXpath(
-			'//ul/li[@id="' . $obj1->ID . '"]'
-		);
-		$this->assertFalse(
-			(bool)$node1,
+		$this->assertTreeNotContains($html, array($obj1),
 			'Does not contain root elements which dont match the filter'
 		);
-		$node2aa = $parser->getByXpath(
-			'//ul/li[@id="' . $obj2->ID . '"]' .
-				'/ul/li[@id="' . $obj2a->ID . '"]' .
-				'/ul/li[@id="' . $obj2aa->ID . '"]'
-		);
-		$this->assertTrue(
-			(bool)$node2aa,
+		$this->assertTreeContains($html, array($obj2, $obj2a, $obj2aa),
 			'Contains non-root elements which match the filter'
 		);
 	}
@@ -377,8 +328,6 @@ class HierarchyTest extends SapphireTest {
 		$root->setMarkingFilterFunction(function($record) use($obj2, $obj2a, $obj2aa) {
 			// Results need to include parent hierarchy, even if we just want to
 			// match the innermost node.
-			// var_dump($record->Title);
-			// var_dump(in_array($record->ID, array($obj2->ID, $obj2a->ID, $obj2aa->ID)));
 			return in_array($record->ID, array($obj2->ID, $obj2a->ID, $obj2aa->ID));
 		});
 		$root->markPartialTree($nodeCountThreshold);
@@ -393,23 +342,81 @@ class HierarchyTest extends SapphireTest {
 			true, 
 			$nodeCountThreshold
 		);
-		$parser = new CSSContentParser($html);
-		$node1 = $parser->getByXpath(
-			'//ul/li[@id="' . $obj1->ID . '"]'
-		);
-		$this->assertFalse(
-			(bool)$node1,
+		$this->assertTreeNotContains($html, array($obj1),
 			'Does not contain root elements which dont match the filter'
 		);
-		$node2aa = $parser->getByXpath(
-			'//ul/li[@id="' . $obj2->ID . '"]' .
-				'/ul/li[@id="' . $obj2a->ID . '"]' .
-				'/ul/li[@id="' . $obj2aa->ID . '"]'
-		);
-		$this->assertTrue(
-			(bool)$node2aa,
+		$this->assertTreeContains($html, array($obj2, $obj2a, $obj2aa),
 			'Contains non-root elements which match the filter'
 		);
+	}
+
+	public function testGetChildrenAsULNodeThresholdLeaf() {
+		$obj1 = $this->objFromFixture('HierarchyTest_Object', 'obj1');
+		$obj2 = $this->objFromFixture('HierarchyTest_Object', 'obj2');
+		$obj2a = $this->objFromFixture('HierarchyTest_Object', 'obj2a');
+		$obj3 = $this->objFromFixture('HierarchyTest_Object', 'obj3');
+		$obj3a = $this->objFromFixture('HierarchyTest_Object', 'obj3a');
+
+		$nodeCountThreshold = 99;
+
+		$root = new HierarchyTest_Object();
+		$root->markPartialTree($nodeCountThreshold);
+		$nodeCountCallback = function($parent, $numChildren) {
+			// Set low enough that it the fixture structure should exceed it
+			if($parent->ID && $numChildren > 2) {
+				return '<span class="exceeded">Exceeded!</span>';
+			}
+		};	
+
+		$html = $root->getChildrenAsUL(
+			"", 
+			'"<li id=\"" . $child->ID . "\">" . $child->Title', 
+			null, 
+			true, // limit to marked
+			"AllChildrenIncludingDeleted", 
+			"numChildren", 
+			true, 
+			$nodeCountThreshold,
+			$nodeCountCallback
+		);
+		$this->assertTreeContains($html, array($obj1),
+			'Does contain root elements regardless of count'
+		);
+		$this->assertTreeContains($html, array($obj3),
+			'Does contain root elements regardless of count'
+		);
+		$this->assertTreeContains($html, array($obj2, $obj2a),
+			'Contains children which do not exceed threshold'
+		);
+		$this->assertTreeNotContains($html, array($obj3, $obj3a),
+			'Does not contain children which exceed threshold'
+		);
+	}
+
+	/**
+	 * @param String $html  [description]
+	 * @param array $nodes Breadcrumb path as array
+	 * @param String $message
+	 */
+	protected function assertTreeContains($html, $nodes, $message = null) {
+		$parser = new CSSContentParser($html);
+		$xpath = '/';
+		foreach($nodes as $node) $xpath .= '/ul/li[@id="' . $node->ID . '"]';
+		$match = $parser->getByXpath($xpath);
+		self::assertThat((bool)$match, self::isTrue(), $message);
+	}
+
+	/**
+	 * @param String $html  [description]
+	 * @param array $nodes Breadcrumb path as array
+	 * @param String $message
+	 */
+	protected function assertTreeNotContains($html, $nodes, $message = null) {
+		$parser = new CSSContentParser($html);
+		$xpath = '/';
+		foreach($nodes as $node) $xpath .= '/ul/li[@id="' . $node->ID . '"]';
+		$match = $parser->getByXpath($xpath);
+		self::assertThat((bool)$match, self::isFalse(), $message);	
 	}
 
 }

--- a/tests/model/HierarchyTest.yml
+++ b/tests/model/HierarchyTest.yml
@@ -17,6 +17,9 @@ HierarchyTest_Object:
    obj3b:
       Parent: =>HierarchyTest_Object.obj3
       Title: Obj 3b
+   obj3c:
+      Parent: =>HierarchyTest_Object.obj3
+      Title: Obj 3c
    obj2aa:
       Parent: =>HierarchyTest_Object.obj2a
       Title: Obj 2aa


### PR DESCRIPTION
Rendering potentially 1000s of nodes can exceed the CPU and memory constraints
of a normal PHP process, as well as the rendering capabilities of browsers.
Set a hard maximum for the renderable nodes, deferring to a "show as list" action
in the main CMS tree. For TreeDropdownField, we don't have the list fallback option,
so ask the user to search for the node title instead.

Also makes both the "node_threshold_total" and "node_threshold_leaf" values configurable

Small tree view: http://monosnap.com/image/Qmk0prU3G6V34vcI2EqQ9uml1
Large tree view: http://monosnap.com/image/siymlxkhSzFv9aFkBCODfuH4o
Treedropdown view: http://monosnap.com/image/ixVFUzx5LlOAoFnbkrh6l39Ej

I'm aware that this change adds the umpteenth argument to getChildrenAsUL(), but at this point it doesn't really matter too much. The API needs a major overhaul (with some tree support in the ORM, and potentially JSON-based views). For now, the pull request doesn't weaken the API much more than it already is.

In terms of UI/UX, I've talked it through with @clarkepaul and he agrees that while the tree is still not a good metaphor for this amount of data, the "too many children" approach is a good solution for the immediate problem
