### PR TITLE
API Better detection and prevention of image resampling

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -188,21 +188,11 @@ class Image extends File {
 	}
 	
 	public function SetWidth($width) {
-		return $this->getWidth() == $width ? $this : $this->getFormattedImage('SetWidth', $width);
+		return $this->getWidth() == $width ? $this : $this->getFormattedImage('SetWidth', $width, null, false);
 	}
 	
 	public function SetHeight($height) {
-		return $this->getHeight() == $height ? $this : $this->getFormattedImage('SetHeight', $height);
-	}
-	
-	public function SetSize($width, $height) {
-		return (($this->getWidth() == $width) &&  ($this->getHeight() == $height)) 
-			? $this 
-			: $this->getFormattedImage('SetSize', $width, $height);
-	}
-	
-	public function SetRatioSize($width, $height) {
-		return $this->getFormattedImage('SetRatioSize', $width, $height);
+		return $this->getHeight() == $height ? $this : $this->getFormattedImage('SetHeight', $height, null, false);
 	}
 	
 	public function generateSetRatioSize(Image_Backend $backend, $width, $height) {
@@ -272,6 +262,19 @@ class Image extends File {
 	public function generatePaddedImage(Image_Backend $backend, $width, $height) {
 		return $backend->paddedResize($width, $height);
 	}
+	
+	/**
+	 * Determine if this image is of the specified size
+	 * 
+	 * @param integer $width
+	 * @param integer $height
+	 * @return boolean
+	 */
+	public function isSize($width, $height) {
+		if(empty($width) || empty($height)) return false;
+		
+		return $this->getWidth() == $width && $this->getHeight() == $height;
+	}
 
 	/**
 	 * Return an image object representing the image in the given format.
@@ -280,10 +283,20 @@ class Image extends File {
 	 * @param string $format The name of the format.
 	 * @param string $arg1 An argument to pass to the generate function.
 	 * @param string $arg2 A second argument to pass to the generate function.
+	 * @param boolean $compareDimensions Determine if the $arg1 and $arg2 should
+	 * be compared to the current width and height of the image in order to
+	 * prevent unnecessary image resampling.
 	 * @return Image_Cached
 	 */
-	public function getFormattedImage($format, $arg1 = null, $arg2 = null) {
+	public function getFormattedImage($format, $arg1 = null, $arg2 = null, $compareDimensions = true) {
 		if($this->ID && $this->Filename && Director::fileExists($this->Filename)) {
+			
+			// Determine if the image itself is already of the requested dimensions
+			if($compareDimensions && $this->isSize($arg1, $arg2)) {
+				return $this;
+			}
+			
+			// Regenerate image in the requested format
 			$cacheFile = $this->cacheFilename($format, $arg1, $arg2);
 
 			if(!file_exists(Director::baseFolder()."/".$cacheFile) || isset($_GET['flush'])) {

--- a/tests/model/ImageTest.php
+++ b/tests/model/ImageTest.php
@@ -81,6 +81,9 @@ class ImageTest extends SapphireTest {
 		$this->assertEquals($expected, $actual);
 	}
 	
+	/**
+	 * Tests that multiple image manipulations may be performed on a single Image
+	 */
 	public function testMultipleGenerateManipulationCalls() {
 		$image = $this->objFromFixture('Image', 'imageWithoutTitle');
 		
@@ -96,6 +99,61 @@ class ImageTest extends SapphireTest {
 		$expected = 100;
 		$actual = $imageSecond->getHeight();
 		$this->assertEquals($expected, $actual);
+	}
+	
+	/**
+	 * Tests that image manipulations that do not affect the resulting dimensions
+	 * of the output image do not resample the file.
+	 */
+	public function testReluctanceToResampling() {
+		$image = $this->objFromFixture('Image', 'imageWithoutTitle');
+		$this->assertTrue($image->isSize(300, 300));
+		
+		// Set width to 50 pixels
+		$imageSetWidth = $image->SetWidth(300);
+		$this->assertEquals($imageSetWidth->getWidth(), 300);
+		$this->assertEquals($image->Filename, $imageSetWidth->Filename);
+		
+		// Set height to 300 pixels
+		$imageSetHeight = $image->SetHeight(300);
+		$this->assertEquals($imageSetHeight->getHeight(), 300);
+		$this->assertEquals($image->Filename, $imageSetHeight->Filename);
+		
+		// Crop image to 300 x 300
+		$imageCropped = $image->CroppedImage(300, 300);
+		$this->assertTrue($imageCropped->isSize(300, 300));
+		$this->assertEquals($image->Filename, $imageCropped->Filename);
+		
+		// Resize (padded) to 300 x 300
+		$imagePadded = $image->SetSize(300, 300);
+		$this->assertTrue($imagePadded->isSize(300, 300));
+		$this->assertEquals($image->Filename, $imagePadded->Filename);
+		
+		// SetRatioSize
+		$imageSetRatioSize = $image->SetRatioSize(300, 300);
+		$this->assertTrue($imageSetRatioSize->isSize(300, 300));
+		$this->assertEquals($image->Filename, $imageSetRatioSize->Filename);
+	}
+	
+	public function testImageResize() {
+		$image = $this->objFromFixture('Image', 'imageWithoutTitle');
+		$this->assertTrue($image->isSize(300, 300));
+		
+		// Test normal resize
+		$resized = $image->SetSize(150, 100);
+		$this->assertTrue($resized->isSize(150, 100));
+		
+		// Test cropped resize
+		$cropped = $image->CroppedImage(100, 200);
+		$this->assertTrue($cropped->isSize(100, 200));
+		
+		// Test padded resize
+		$padded = $image->PaddedImage(200, 100);
+		$this->assertTrue($padded->isSize(200, 100));
+		
+		// Test SetRatioSize
+		$ratio = $image->SetRatioSize(80, 160);
+		$this->assertTrue($ratio->isSize(80, 80));
 	}
 	
 	public function testGeneratedImageDeletion() {


### PR DESCRIPTION
An earlier fix to the Image class https://github.com/silverstripe/sapphire/commit/627a2916f48af24d399ad6e06fe97cde117fc776 allowed the SetWidth, SetHeight, and SetSize functions detect whether a resize is necessary.

There are other functions in the class that would benefit from having a similar approach. Rather than implement a new function for each of the generation methods (CroppedImage, etc) I propose changing the convention to check for image dimension changes in getFormattedImage, unless a specific method (such as setHeight) explicitly opts out of it.

Personally I feel a bit conflicted about the solution I've found, as the new behaviour is enabled by default (and thus for all internal methods that use both $arg1 and $arg2). This means any existing user code that adds generation methods where $arg1 and $arg2 are used as values other than width and height (skewing?) will require a custom function calling getFormattedImage with the fourth parameter set to false.

If this is a problem then I could simple make false the default (thus preserving true backwards compatibility) but then I'd add a new method for each of the generation functions (thus bloating code).

Thorough test cases included.
