### PR TITLE
Fix: avoid double utf8encoding in FormatI18N

### DIFF
--- a/model/fieldtypes/Date.php
+++ b/model/fieldtypes/Date.php
@@ -149,7 +149,12 @@ class Date extends DBField {
 	public function FormatI18N($formattingString) {
 		if($this->value) {
 			$fecfrm = strftime($formattingString, strtotime($this->value));
-			return utf8_encode($fecfrm);
+			if (ContentNegotiator::get_encoding() == 'utf-8' && !mb_check_encoding($fecfrm, 'utf-8')) {
+				return utf8_encode($fecfrm);
+			}
+			else {
+				return $fecfrm;
+			}
 		}
 	}
 	


### PR DESCRIPTION
fixes double utf8 encoding which can result in strange characters fe: MÃ¤rz

fix is taken from Beutlin in the forum:
http://www.silverstripe.org/all-other-modules/show/8641?start=8 
