### PR TITLE
FIX Load _config.php's after static config manifest

### DIFF
--- a/core/manifest/ClassLoader.php
+++ b/core/manifest/ClassLoader.php
@@ -43,8 +43,7 @@ class SS_ClassLoader {
 	}
 
 	/**
-	 * Pushes a class manifest instance onto the top of the stack. This will
-	 * also include any module configuration files at the same time.
+	 * Pushes a class manifest instance onto the top of the stack.
 	 *
 	 * @param SS_ClassManifest $manifest
 	 * @param Boolean Marks the manifest as exclusive. If set to FALSE, will
@@ -52,10 +51,6 @@ class SS_ClassLoader {
 	 */
 	public function pushManifest(SS_ClassManifest $manifest, $exclusive = true) {
 		$this->manifests[] = array('exclusive' => $exclusive, 'instance' => $manifest);
-
-		foreach ($manifest->getConfigs() as $config) {
-			require_once $config;
-		}
 	}
 
 	/**

--- a/docs/en/changelogs/3.1.0.md
+++ b/docs/en/changelogs/3.1.0.md
@@ -42,13 +42,15 @@ of defining the default value.
 In SilverStripe 3.0, it was possible to edit this value at run-time and have the change propagate into the
 configuration system.  This is no longer the case, for performance reasons.
 
-Many of the configuration variables have been change to "private" so that attempts to change them throw an
+Many of the configuration variables have been changed to "private" so that attempts to change them throw an
 error, but if you do have a configuration static that is able to be changed, and you change it, then the
 configuration system will silently ignore it.
 
 Please change all run-time manipulation of configuration to use `Config::inst()->update()` or
-`$this->config()->update()`.  For more information about how to use the config system, see the 
-["Configuration" topic](/topic/configuration).
+`$this->config()->update()`. This mostly applies to changes in `_config.php`, which is
+processed after the YAML and PHP statics configuration are compiled.
+
+For more information about how to use the config system, see the  ["Configuration" topic](/topic/configuration).
 
 ### default_cast is now Text
 

--- a/docs/en/topics/configuration.md
+++ b/docs/en/topics/configuration.md
@@ -14,9 +14,10 @@ SilverStripe system due to three properties:
   - Configuration is normally set by a knowledgeable technical user, such as a developer, not the end user
 
 In SilverStripe 3, each class has it's configuration specified as set of named properties and associated values. The
-values at any given time are calculated by merging several sources using rules explained below. These sources are:
+values at any given time are calculated by merging several sources using rules explained below. 
+These sources are as follows (in highest -> lowest priority order):
 
-  - Values set via a call to Config#update
+  - Values set via a call to Config#update (e.g. in `_config.php`)
 
   - Values taken from YAML files in specially named directories
 
@@ -69,9 +70,9 @@ the result will be the higher priority false-ish value.
 
 The locations that configuration values are taken from in highest -> lowest priority order are:
 
-- Any values set via a call to Config#update
+- Any values set via a call to Config#update (e.g. via `_config.php`)
 
-- The configuration values taken from the YAML files in _config directories (internally sorted in before / after order, where
+- The configuration values taken from the YAML files in `_config/` directories (internally sorted in before / after order, where
   the item that is latest is highest priority)
 
 - Any static set on an "additional static source" class (such as an extension) named the same as the name of the property


### PR DESCRIPTION
This allows more sophisticated handling of config alterations
in _config.php, e.g. additions to DataObject::$db
based on configuration which requires some processing.

See https://github.com/unclecheese/TranslatableDataObject/blob/master/TranslatableDataObject.php for an example use (3.0 compatible code, but have a look at the register() and extraStatics() logic. It adds a decorator plus marks fields as "translatable", and then adds them to MyClass->db() _before_ dev/build runs. Since those field names are dynamic based on the configured locales, we can't move it to the YAML config as such.
