### PR TITLE
FIX Incorrect parsing of T_STRING values in class spec parsing

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -194,11 +194,13 @@ abstract class Object {
 			
 				case T_STRING:
 					switch($token[1]) {
-						case 'true': $args[] = true; break;
-						case 'false': $args[] = false; break;
+						case 'true': $bucket[] = true; break;
+						case 'false': $bucket[] = false; break;
+						case 'null': $bucket[] = null; break;
 						default: throw new Exception("Bad T_STRING arg '{$token[1]}'");
 					}
-				
+					break;
+
 				case T_ARRAY:
 					// Add an empty array to the bucket
 					$bucket[] = array();

--- a/tests/core/ObjectTest.php
+++ b/tests/core/ObjectTest.php
@@ -349,6 +349,17 @@ class ObjectTest extends SapphireTest {
 			array('Versioned',array('Stage\'Stage,Live\'Live', 'Live')),
 			Object::parse_class_spec("Versioned('Stage\'Stage,Live\'Live','Live')")
 		);
+
+		// True, false and null values
+		$this->assertEquals(
+			array('ClassName', array('string', true, array('string', false))),
+			Object::parse_class_spec('ClassName("string", true, array("string", false))')
+		);
+		$this->assertEquals(
+			array('ClassName', array(true, false, null)),
+			Object::parse_class_spec('ClassName(true, false, null)')
+		);
+
 		// Array
 		$this->assertEquals(
 			array('Enum',array(array('Accepted', 'Pending', 'Declined', 'Unsubmitted'), 'Unsubmitted')),


### PR DESCRIPTION
- Due to missing break, the T_STRING case would fall through to array.
- The values were being added to the wrong variable.
- Added missing support for missing null values.
