### PR TITLE
BUG Database config values aren't escaped

### DIFF
--- a/dev/install/config-form.html
+++ b/dev/install/config-form.html
@@ -157,7 +157,7 @@
 														$attrs['class'] .= ' configured-by-env';
 													}
 													$attrHTML = '';
-													foreach($attrs as $attrName => $attrValue) $attrHTML .= "$attrName=\"$attrValue\" ";
+													foreach($attrs as $attrName => $attrValue) $attrHTML .= "$attrName=\"" . htmlspecialchars($attrValue) . '"';
 													if(isset($fieldSpec['attributes'])) $attrs = array_merge($attrs, $fieldSpec['attributes']);
 													
 													// html


### PR DESCRIPTION
Causes minor UI issues if you try use database configuration values that happen to have " or other values in them.
