### PR TITLE
remove deprecated message for ereg_replace

### DIFF
--- a/core/control/Director.php
+++ b/core/control/Director.php
@@ -492,7 +492,7 @@ class Director {
 	 */
 	static function makeRelative($url) {
 		// Allow for the accidental inclusion of a // in the URL
-		$url = ereg_replace('([^:])//','\\1/',$url);
+		$url = preg_replace('/([^:])\/\//','\\1/',$url);
 		$url = trim($url);
 
 		// Only bother comparing the URL to the absolute version if $url looks like a URL.


### PR DESCRIPTION
removed deprecated message for ereg_replace in PHP 5.3, which drives your logfile or services like New Relic crazy
