### PR TITLE
FIX Clone Config_LRU incl. objects in array

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -623,6 +623,20 @@ class Config_LRU {
 		$this->indexing = array();
 	}
 
+	public function __clone() {
+		if (version_compare(PHP_VERSION, '5.3.7', '<')) {
+			// SplFixedArray causes seg faults before PHP 5.3.7
+			$cloned = array();
+		}
+		else {
+			$cloned = new SplFixedArray(self::SIZE);
+		}
+		for ($i = 0; $i < self::SIZE; $i++) {
+			$cloned[$i] = clone $this->cache[$i];
+		}
+		$this->cache = $cloned;
+	}
+
 	public function set($key, $val, $tags = array()) {
 		// Find an index to set at
 		$replacing = null;


### PR DESCRIPTION
@hafriedlander Caused key confusions when using Config::nest()/unnest().
I've tried the `unserialize(serialize())` deep clone trick first, but that doesn't
preserve array keys properly, and is also much slower.

This should fix the Travis builds for sapphire. Please merge 3.1 into master after merging this PR, since it has the same issue.
