### PR TITLE
BUG: update deprecated 'live' jquery to 'on'

### DIFF
--- a/javascript/DateField.js
+++ b/javascript/DateField.js
@@ -26,7 +26,7 @@
 		}
 	});
 
-	$('.field.date input.text').live('click', function() {
+	$(document).on("click", "field.date input.text,.fieldholder-small input.text.date", function() {
 		$(this).ssDatepicker();
 
 		if($(this).data('datepicker')) {


### PR DESCRIPTION
'live' has been deprecated since jquery v 1.7.0, and has been removed in the latest 2 versions of jquery. 

At the moment, using this javascript on the frontend means having to use an older version of jQuery.
