### PR TITLE
API i18n::$common_languages and i18n::$common_locales converted to Confi...

### DIFF
--- a/docs/en/topics/i18n.md
+++ b/docs/en/topics/i18n.md
@@ -67,13 +67,34 @@ Formats can be set globally in the i18n class. These settings are currently only
 to write your own logic for any frontend output.
 
 	:::php
-	i18n::set_date_format('dd.MM.YYYY');
-	i18n::set_time_format('HH:mm');
+	Config::inst()->update('i18n', 'date_format', 'dd.MM.YYYY');
+	Config::inst()->update('i18n', 'time_format', 'HH:mm');
 
 Most localization routines in SilverStripe use the [Zend_Date API](http://framework.zend.com/manual/en/zend.date.html).
 This means all formats are defined in
 [ISO date format](http://framework.zend.com/manual/en/zend.date.constants.html#zend.date.constants.selfdefinedformats),
 not PHP's built-in [date()](http://nz.php.net/manual/en/function.date.php).
+
+### Language Names
+
+SilverStripe comes with a built-in list of common languages, listed by locale and region.
+They can be accessed via the `i18n.common_languages` and `i18n.common_locales` [config setting](/topics/configuratio).
+
+In order to add a value, add the following to your `config.yml`:
+
+	:::yml
+	i18n:
+	  common_languages:
+	    de_CGN:
+	      name: German (Cologne)
+	      native: Kölsch
+
+Similarly, to change an existing existing language label, you can overwrite one of these keys:
+	
+	i18n:
+	  common_languages:
+	    en_NZ:
+	      native: Niu Zillund
 
 ### i18n in URLs
 


### PR DESCRIPTION
...g API

They are now accessed via the Config API, and contain associative rather than indexed arrays.
Before: `array('de_DE' => array('German', 'Deutsch'))`, after: `array('de_DE' => array('name' => 'German', 'native' => 'Deutsch'))`.

Also fixed a i18n.js_i18n config accessor
