### PR TITLE
BUG: GridFieldFilterHeader only filters on last filter

### DIFF
--- a/forms/gridfield/GridFieldFilterHeader.php
+++ b/forms/gridfield/GridFieldFilterHeader.php
@@ -92,13 +92,13 @@ class GridFieldFilterHeader implements GridField_HTMLProvider, GridField_DataMan
 		} 
 		
 		$filterArguments = $state->Columns->toArray();
-		$dataListClone = null;
+		$dataListClone = clone($dataList);
 		foreach($filterArguments as $columnName => $value ) {
 			if($dataList->canFilterBy($columnName) && $value) {
-				$dataListClone = $dataList->filter($columnName.':PartialMatch', $value);
+				$dataListClone = $dataListClone->filter($columnName.':PartialMatch', $value);
 			}
 		}
-		return ($dataListClone) ? $dataListClone : $dataList;
+		return $dataListClone;
 	}
 
 	public function getHTMLFragments($gridField) {


### PR DESCRIPTION
GridFieldFilterHeader only filters on the last filter argument because it keeps recloning the original datalist
