### PR TITLE
BUG: 8337 - scaffolding of SS_Datetime is not working with Default DateTime settings

### DIFF
--- a/forms/TimeField.php
+++ b/forms/TimeField.php
@@ -98,8 +98,8 @@ class TimeField extends TextField {
 			$this->valueObj = null;
 		}
 		// load ISO time from database (usually through Form->loadDataForm())
-		else if(Zend_Date::isDate($val, $this->getConfig('datavalueformat')) && $this->getConfig('timeformat') != "h:mm:ss a") {
-			$this->valueObj = new Zend_Date($val, $this->getConfig('datavalueformat'));
+		else if(Zend_Date::isDate($val, $this->getConfig('datavalueformat'))) {
+			$this->valueObj = new Zend_Date(date('H:i:s', strtotime($val)), $this->getConfig('datavalueformat'));
 			$this->value = $this->valueObj->get($this->getConfig('timeformat'));
 		}
 		// Set in current locale (as string)


### PR DESCRIPTION
When a US user has AM/PM settings which is default on SIlverStripe install scaffolding is failing when you have anything in the AM and is automatically converted to PM.  This should prevent the convert to ISO time and use the default convert to local time frame in that case.
