### PR TITLE
GenericTemplateGlobalProvider::getDataList() shouldn't sort by default

### DIFF
--- a/view/GenericTemplateGlobalProvider.php
+++ b/view/GenericTemplateGlobalProvider.php
@@ -48,7 +48,7 @@ class GenericTemplateGlobalProvider implements TemplateGlobalProvider {
 	public static function getDataList($className) {
 		$list = new DataList($className);
 		$list->setDataModel(DataModel::inst());
-		return $list;
+		return $list->sort(array());
 	}
 
 }


### PR DESCRIPTION
The common use of this method is to fetch a single aggregate value
for use in partial caches within templates. Sorting aggregates in this
scenario will break MSSQL and PostgreSQL and `DataQuery::initialiseQuery()`
will add `$default_sort` as the sort automatically, which never happened before
the merge of e53280c6500e82a28b5ffec1ec3c24d2df9aad87.

The proposed fix is to just not sort any of the aggregates at all in this context.
