### PR TITLE
FIX Disallow group removal when member is edited in groups view

### DIFF
--- a/security/Group.php
+++ b/security/Group.php
@@ -102,12 +102,18 @@ class Group extends DataObject {
 			$config->getComponentByType('GridFieldDetailForm')
 				->setValidator(new Member_Validator())
 				->setItemEditFormCallback(function($form, $component) use($group) {
-					// If new records are created in a group context,
-					// set this group by default.
 					$record = $form->getRecord();
-					if($record && !$record->ID) {
-						$groupsField = $form->Fields()->dataFieldByName('DirectGroups');
-						if($groupsField) $groupsField->setValue($group->ID);
+					$groupsField = $form->Fields()->dataFieldByName('DirectGroups');
+					if($groupsField) {
+						// If new records are created in a group context,
+						// set this group by default.
+						if($record && !$record->ID) {
+							$groupsField->setValue($group->ID);
+						} elseif($record && $record->ID) {
+							// TODO Mark disabled once chosen.js supports it
+							// $groupsField->setDisabledItems(array($group->ID));
+							$form->Fields()->replaceField('DirectGroups', $groupsField->performReadonlyTransformation());
+						}
 					}
 				});
 			$memberList = GridField::create('Members',false, $this->Members(), $config)->addExtraClass('members_grid');


### PR DESCRIPTION
It would invalidate this view. Only allow group editing
for new members added to this group (with a group default),
and for members edited through the "root" view.
