### PR TITLE
Sync template-parser files

### DIFF
--- a/view/SSTemplateParser.php
+++ b/view/SSTemplateParser.php
@@ -3913,7 +3913,7 @@ class SSTemplateParser extends Parser {
 
 
 
-	/* Comment: "<%--" (!"--%>" /./)+ "--%>" */
+	/* Comment: "<%--" (!"--%>" /(?s)./)+ "--%>" */
 	protected $match_Comment_typestack = array('Comment');
 	function match_Comment ($stack = array()) {
 		$matchrule = "Comment"; $result = $this->construct($matchrule, $matchrule, null);

--- a/view/SSTemplateParser.php.inc
+++ b/view/SSTemplateParser.php.inc
@@ -804,7 +804,7 @@ class SSTemplateParser extends Parser {
 	 * @deprecated
 	 */
 	function ClosedBlock_Handle_Control(&$res) {
-		Deprecation::notice('3.1', 'Use <% with %> or <% loop %> instead.');
+		Deprecation::notice('3.1', '<% control %> is deprecated. Use <% with %> or <% loop %> instead.');
 		return $this->ClosedBlock_Handle_Loop($res);
 	}
 	
@@ -1002,7 +1002,7 @@ class SSTemplateParser extends Parser {
 		// non-dynamically calculated
 		$text = preg_replace(
 			'/href\s*\=\s*\"\#/', 
-			'href="\' . (SSViewer::$options[\'rewriteHashlinks\'] ? strip_tags( $_SERVER[\'REQUEST_URI\'] ) : "") . 
+			'href="\' . (Config::inst()->get(\'SSViewer\', \'rewrite_hash_links\') ? strip_tags( $_SERVER[\'REQUEST_URI\'] ) : "") . 
 				\'#',
 			$text
 		);


### PR DESCRIPTION
The template-parser files were not in sync, there were some lines added in SSTemplateParser.php from 3334eafcb1c42b917dcafe46d87ea32f2b1014b8 and 0a9f3b75a9195092ff7c42265ec066339d8f8aa3 , I readded those parts into the SSTemplateParser-include-file and recreated the SSTemplateParser.php to get to a synced and stable state...

Best regards,
s-m
