### PR TITLE
BUG: Fix invalid code with source-file-comments, fixes #1487

### DIFF
--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -1068,10 +1068,10 @@ after')
 		
 		$result = $view->process($data);
 		$expected = '<!doctype html>
-<html><!-- template ' . FRAMEWORK_PATH . '/tests/templates/SSViewerTestCommentsFullSource.ss -->
+<!-- template ' . FRAMEWORK_PATH . '/tests/templates/SSViewerTestCommentsFullSource.ss --><html>
 	<head></head>
 	<body></body>
-<!-- end template ' . FRAMEWORK_PATH . '/tests/templates/SSViewerTestCommentsFullSource.ss --></html>
+</html><!-- end template ' . FRAMEWORK_PATH . '/tests/templates/SSViewerTestCommentsFullSource.ss -->
 ';
 		$this->assertEquals($result, $expected);
 		

--- a/view/SSTemplateParser.php
+++ b/view/SSTemplateParser.php
@@ -1675,14 +1675,14 @@ class SSTemplateParser extends Parser {
 	function If_ElseIfPart(&$res, $sub) {
 		$res['php'] .= 
 			'else if (' . $sub['IfArgument']['php'] . ') { ' . PHP_EOL .
-            (isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
+				(isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
 			'}';
 	}
 
 	function If_ElsePart(&$res, $sub) {
 		$res['php'] .= 
 			'else { ' . PHP_EOL . 
-            (isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
+				(isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
 			'}';
 	}
 
@@ -4593,11 +4593,11 @@ class SSTemplateParser extends Parser {
 		
 		// Include top level debugging comments if desired
 		if($includeDebuggingComments && $templateName && stripos($code, "<?xml") === false) {
-			// If this template is a full HTML page, then put the comments just inside the HTML tag to prevent any IE 
-			// glitches
+			// If this template is a full HTML page, then put the comments just outside the HTML tag, 
+			// this is still no problem for IE as long as the DOCTYPE-declaration is done before this comment
 			if(stripos($code, "<html") !== false) {
-				$code = preg_replace('/(<html[^>]*>)/i', "\\1<!-- template $templateName -->", $code);
-				$code = preg_replace('/(<\/html[^>]*>)/i', "<!-- end template $templateName -->\\1", $code);
+				$code = preg_replace('/(<html[^>]*>)/i', "<!-- template $templateName -->\\1", $code);
+				$code = preg_replace('/(<\/html[^>]*>)/i', "\\1<!-- end template $templateName -->", $code);
 			} else {
 				$code = str_replace('<?php' . PHP_EOL, '<?php' . PHP_EOL . '$val .= \'<!-- template ' . $templateName .
 					' -->\';' . "\n", $code);

--- a/view/SSTemplateParser.php.inc
+++ b/view/SSTemplateParser.php.inc
@@ -1047,11 +1047,11 @@ class SSTemplateParser extends Parser {
 		
 		// Include top level debugging comments if desired
 		if($includeDebuggingComments && $templateName && stripos($code, "<?xml") === false) {
-			// If this template is a full HTML page, then put the comments just inside the HTML tag to prevent any IE 
-			// glitches
+			// If this template is a full HTML page, then put the comments just outside the HTML tag, 
+			// this is still no problem for IE as long as the DOCTYPE-declaration is done before this comment
 			if(stripos($code, "<html") !== false) {
-				$code = preg_replace('/(<html[^>]*>)/i', "\\1<!-- template $templateName -->", $code);
-				$code = preg_replace('/(<\/html[^>]*>)/i', "<!-- end template $templateName -->\\1", $code);
+				$code = preg_replace('/(<html[^>]*>)/i', "<!-- template $templateName -->\\1", $code);
+				$code = preg_replace('/(<\/html[^>]*>)/i', "\\1<!-- end template $templateName -->", $code);
 			} else {
 				$code = str_replace('<?php' . PHP_EOL, '<?php' . PHP_EOL . '$val .= \'<!-- template ' . $templateName .
 					' -->\';' . "\n", $code);


### PR DESCRIPTION
The parser could sometimes generate invalid code if the source-file-comments were enabled, this moves the comments outside the html-tag to circumvent these problems, see #1487 for details, this includes a change to the test-case for the template comments...

Best regards,
s-m
