### PR TITLE
FIX: remove_extension should work on parameterized extensions

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -492,6 +492,7 @@ abstract class Object {
 
 	/**
 	 * Remove an extension from a class.
+	 *
 	 * Keep in mind that this won't revert any datamodel additions
 	 * of the extension at runtime, unless its used before the
 	 * schema building kicks in (in your _config.php).
@@ -509,6 +510,20 @@ abstract class Object {
 		$class = get_called_class();
 
 		Config::inst()->remove($class, 'extensions', Config::anything(), $extension);
+
+		// remove any instances of the extension with parameters
+		$config = Config::inst()->get($class, 'extensions');
+
+		if($config) {
+			foreach($config as $k => $v) {
+				// extensions with parameters will be stored in config as
+				// ExtensionName("Param").
+				if(preg_match(sprintf("/^(%s)\(/", preg_quote($extension, '/')), $v)) {
+					Config::inst()->remove($class, 'extensions', Config::anything(), $v);
+				}
+			}
+		}
+
 		Config::inst()->extraConfigSourcesChanged($class);
 
 		// unset singletons to avoid side-effects

--- a/tests/core/ObjectTest.php
+++ b/tests/core/ObjectTest.php
@@ -265,10 +265,12 @@ class ObjectTest extends SapphireTest {
 
 		// ObjectTest_ExtendTest1 is already present in $extensions
 		ObjectTest_ExtensionRemoveTest::remove_extension('ObjectTest_ExtendTest1');
+
 		$this->assertFalse(
 			ObjectTest_ExtensionRemoveTest::has_extension('ObjectTest_ExtendTest1'),
 			"Extension added through \$extensions are detected as removed in has_extension()"
 		);
+
 		$objectTest_ExtensionRemoveTest = new ObjectTest_ExtensionRemoveTest();
 		$this->assertFalse(
 			$objectTest_ExtensionRemoveTest->hasExtension('ObjectTest_ExtendTest1'),
@@ -276,6 +278,27 @@ class ObjectTest extends SapphireTest {
 		);
 	}
 	
+	public function testRemoveExtensionWithParameters() {
+		ObjectTest_ExtensionRemoveTest::add_extension('ObjectTest_ExtendTest2("MyParam")');
+
+		$this->assertTrue(
+			ObjectTest_ExtensionRemoveTest::has_extension('ObjectTest_ExtendTest2'),
+			"Extension added through \$add_extension() are added correctly"
+		);
+
+		ObjectTest_ExtensionRemoveTest::remove_extension('ObjectTest_ExtendTest2');
+		$this->assertFalse(
+			Object::has_extension('ObjectTest_ExtensionRemoveTest', 'ObjectTest_ExtendTest2'),
+			"Extension added through \$add_extension() are detected as removed in has_extension()"
+		);
+
+		$objectTest_ExtensionRemoveTest = new ObjectTest_ExtensionRemoveTest();
+		$this->assertFalse(
+			$objectTest_ExtensionRemoveTest->hasExtension('ObjectTest_ExtendTest2'),
+			"Extensions added through \$extensions are detected as removed in instances through hasExtension()"
+		);
+	}
+
 	public function testParentClass() {
 		$this->assertEquals(ObjectTest_MyObject::create()->parentClass(), 'Object');
 	}


### PR DESCRIPTION
From http://open.silverstripe.org/ticket/6079. Includes unit test.
