### PR TITLE
API: Support inequalities in templates, fixes #1518

### DIFF
--- a/docs/en/changelogs/3.1.0.md
+++ b/docs/en/changelogs/3.1.0.md
@@ -435,3 +435,12 @@ you can enable those warnings and future-proof your code already.
    formatting hints as placeholders and description text below the field itself.
    If you change the date/time format of those fields, you need to adjust the hints.
    To remove the hints, use `setDescription(null)` and `setAttribute('placeholder', null)`.
+ * Changed the way FreeStrings in `SSTemplateParser` are recognized, they will now also break on inequality operators (`<`, `>`). If you use inequality operators in free strings in comparisions like 
+ 
+   `<% if Some<String == Some>Other>String %>...<% end_if %>`
+
+   you have to replace them with explicitly markes strings like
+
+   `<% if "Some<String" == "Some>Other>String" %>...<% end_if %>`
+
+   This change was necessary in order to support inequality operators in comparisons in templates

--- a/docs/en/reference/templates.md
+++ b/docs/en/reference/templates.md
@@ -202,6 +202,13 @@ You can combine two or more conditions with `&&` ("and"). The markup is used if
 		Lets swap dinners
 	<% end_if %>
 
+You can use inequalities like `<`, `<=`, `>`, `>=` to compare numbers.
+
+	:::ss
+	<% if $Number>="5" && $Number<="10" %>
+		Number between 5 and 10
+	<% end_if %>
+
 ## Looping Over Lists
 
 The `<% loop %>...<% end_loop %>` tag is used to **iterate** or loop over a 

--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -432,6 +432,22 @@ after')
 		$this->assertEquals('AD',
 			$this->render('A<% if Right == Wrong %>B<% else_if RawVal != RawVal %>C<% end_if %>D'));
 
+		// test inequalities with simple numbers
+		$this->assertEquals('ABD', $this->render('A<% if 5 > 3 %>B<% else %>C<% end_if %>D'));
+		$this->assertEquals('ABD', $this->render('A<% if 5 >= 3 %>B<% else %>C<% end_if %>D'));
+		$this->assertEquals('ACD', $this->render('A<% if 3 > 5 %>B<% else %>C<% end_if %>D'));
+		$this->assertEquals('ACD', $this->render('A<% if 3 >= 5 %>B<% else %>C<% end_if %>D'));
+
+		$this->assertEquals('ABD', $this->render('A<% if 3 < 5 %>B<% else %>C<% end_if %>D'));
+		$this->assertEquals('ABD', $this->render('A<% if 3 <= 5 %>B<% else %>C<% end_if %>D'));
+		$this->assertEquals('ACD', $this->render('A<% if 5 < 3 %>B<% else %>C<% end_if %>D'));
+		$this->assertEquals('ACD', $this->render('A<% if 5 <= 3 %>B<% else %>C<% end_if %>D'));
+
+		$this->assertEquals('ABD', $this->render('A<% if 4 <= 4 %>B<% else %>C<% end_if %>D'));
+		$this->assertEquals('ABD', $this->render('A<% if 4 >= 4 %>B<% else %>C<% end_if %>D'));
+		$this->assertEquals('ACD', $this->render('A<% if 4 > 4 %>B<% else %>C<% end_if %>D'));
+		$this->assertEquals('ACD', $this->render('A<% if 4 < 4 %>B<% else %>C<% end_if %>D'));
+
 		// Bare words with ending space
 		$this->assertEquals('ABC',
 			$this->render('A<% if "RawVal" == RawVal %>B<% end_if %>C'));

--- a/view/SSTemplateParser.php
+++ b/view/SSTemplateParser.php
@@ -999,11 +999,11 @@ class SSTemplateParser extends Parser {
 	}
 
 
-	/* FreeString: /[^,)%!=|&]+/ */
+	/* FreeString: /[^,)%!=><|&]+/ */
 	protected $match_FreeString_typestack = array('FreeString');
 	function match_FreeString ($stack = array()) {
 		$matchrule = "FreeString"; $result = $this->construct($matchrule, $matchrule, null);
-		if (( $subres = $this->rx( '/[^,)%!=|&]+/' ) ) !== FALSE) {
+		if (( $subres = $this->rx( '/[^,)%!=><|&]+/' ) ) !== FALSE) {
 			$result["text"] .= $subres;
 			return $this->finalise($result);
 		}
@@ -1155,48 +1155,114 @@ class SSTemplateParser extends Parser {
 		$res['php'] = "'" . str_replace("'", "\\'", trim($sub['text'])) . "'";
 	}
 	
-	/* ComparisonOperator: "==" | "!=" | "=" */
+	/* ComparisonOperator: "!=" | "==" | ">=" | ">" | "<=" | "<" | "=" */
 	protected $match_ComparisonOperator_typestack = array('ComparisonOperator');
 	function match_ComparisonOperator ($stack = array()) {
 		$matchrule = "ComparisonOperator"; $result = $this->construct($matchrule, $matchrule, null);
-		$_171 = NULL;
+		$_187 = NULL;
 		do {
 			$res_164 = $result;
 			$pos_164 = $this->pos;
-			if (( $subres = $this->literal( '==' ) ) !== FALSE) {
+			if (( $subres = $this->literal( '!=' ) ) !== FALSE) {
 				$result["text"] .= $subres;
-				$_171 = TRUE; break;
+				$_187 = TRUE; break;
 			}
 			$result = $res_164;
 			$this->pos = $pos_164;
-			$_169 = NULL;
+			$_185 = NULL;
 			do {
 				$res_166 = $result;
 				$pos_166 = $this->pos;
-				if (( $subres = $this->literal( '!=' ) ) !== FALSE) {
+				if (( $subres = $this->literal( '==' ) ) !== FALSE) {
 					$result["text"] .= $subres;
-					$_169 = TRUE; break;
+					$_185 = TRUE; break;
 				}
 				$result = $res_166;
 				$this->pos = $pos_166;
-				if (substr($this->string,$this->pos,1) == '=') {
-					$this->pos += 1;
-					$result["text"] .= '=';
-					$_169 = TRUE; break;
+				$_183 = NULL;
+				do {
+					$res_168 = $result;
+					$pos_168 = $this->pos;
+					if (( $subres = $this->literal( '>=' ) ) !== FALSE) {
+						$result["text"] .= $subres;
+						$_183 = TRUE; break;
+					}
+					$result = $res_168;
+					$this->pos = $pos_168;
+					$_181 = NULL;
+					do {
+						$res_170 = $result;
+						$pos_170 = $this->pos;
+						if (substr($this->string,$this->pos,1) == '>') {
+							$this->pos += 1;
+							$result["text"] .= '>';
+							$_181 = TRUE; break;
+						}
+						$result = $res_170;
+						$this->pos = $pos_170;
+						$_179 = NULL;
+						do {
+							$res_172 = $result;
+							$pos_172 = $this->pos;
+							if (( $subres = $this->literal( '<=' ) ) !== FALSE) {
+								$result["text"] .= $subres;
+								$_179 = TRUE; break;
+							}
+							$result = $res_172;
+							$this->pos = $pos_172;
+							$_177 = NULL;
+							do {
+								$res_174 = $result;
+								$pos_174 = $this->pos;
+								if (substr($this->string,$this->pos,1) == '<') {
+									$this->pos += 1;
+									$result["text"] .= '<';
+									$_177 = TRUE; break;
+								}
+								$result = $res_174;
+								$this->pos = $pos_174;
+								if (substr($this->string,$this->pos,1) == '=') {
+									$this->pos += 1;
+									$result["text"] .= '=';
+									$_177 = TRUE; break;
+								}
+								$result = $res_174;
+								$this->pos = $pos_174;
+								$_177 = FALSE; break;
+							}
+							while(0);
+							if( $_177 === TRUE ) { $_179 = TRUE; break; }
+							$result = $res_172;
+							$this->pos = $pos_172;
+							$_179 = FALSE; break;
+						}
+						while(0);
+						if( $_179 === TRUE ) { $_181 = TRUE; break; }
+						$result = $res_170;
+						$this->pos = $pos_170;
+						$_181 = FALSE; break;
+					}
+					while(0);
+					if( $_181 === TRUE ) { $_183 = TRUE; break; }
+					$result = $res_168;
+					$this->pos = $pos_168;
+					$_183 = FALSE; break;
 				}
+				while(0);
+				if( $_183 === TRUE ) { $_185 = TRUE; break; }
 				$result = $res_166;
 				$this->pos = $pos_166;
-				$_169 = FALSE; break;
+				$_185 = FALSE; break;
 			}
 			while(0);
-			if( $_169 === TRUE ) { $_171 = TRUE; break; }
+			if( $_185 === TRUE ) { $_187 = TRUE; break; }
 			$result = $res_164;
 			$this->pos = $pos_164;
-			$_171 = FALSE; break;
+			$_187 = FALSE; break;
 		}
 		while(0);
-		if( $_171 === TRUE ) { return $this->finalise($result); }
-		if( $_171 === FALSE) { return FALSE; }
+		if( $_187 === TRUE ) { return $this->finalise($result); }
+		if( $_187 === FALSE) { return FALSE; }
 	}
 
 
@@ -1204,27 +1270,27 @@ class SSTemplateParser extends Parser {
 	protected $match_Comparison_typestack = array('Comparison');
 	function match_Comparison ($stack = array()) {
 		$matchrule = "Comparison"; $result = $this->construct($matchrule, $matchrule, null);
-		$_178 = NULL;
+		$_194 = NULL;
 		do {
 			$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_178 = FALSE; break; }
+			else { $_194 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			$matcher = 'match_'.'ComparisonOperator'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_178 = FALSE; break; }
+			else { $_194 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_178 = FALSE; break; }
-			$_178 = TRUE; break;
+			else { $_194 = FALSE; break; }
+			$_194 = TRUE; break;
 		}
 		while(0);
-		if( $_178 === TRUE ) { return $this->finalise($result); }
-		if( $_178 === FALSE) { return FALSE; }
+		if( $_194 === TRUE ) { return $this->finalise($result); }
+		if( $_194 === FALSE) { return FALSE; }
 	}
 
 
@@ -1247,11 +1313,11 @@ class SSTemplateParser extends Parser {
 	protected $match_PresenceCheck_typestack = array('PresenceCheck');
 	function match_PresenceCheck ($stack = array()) {
 		$matchrule = "PresenceCheck"; $result = $this->construct($matchrule, $matchrule, null);
-		$_185 = NULL;
+		$_201 = NULL;
 		do {
-			$res_183 = $result;
-			$pos_183 = $this->pos;
-			$_182 = NULL;
+			$res_199 = $result;
+			$pos_199 = $this->pos;
+			$_198 = NULL;
 			do {
 				$stack[] = $result; $result = $this->construct( $matchrule, "Not" ); 
 				if (( $subres = $this->literal( 'not' ) ) !== FALSE) {
@@ -1261,27 +1327,27 @@ class SSTemplateParser extends Parser {
 				}
 				else {
 					$result = array_pop($stack);
-					$_182 = FALSE; break;
+					$_198 = FALSE; break;
 				}
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-				$_182 = TRUE; break;
+				$_198 = TRUE; break;
 			}
 			while(0);
-			if( $_182 === FALSE) {
-				$result = $res_183;
-				$this->pos = $pos_183;
-				unset( $res_183 );
-				unset( $pos_183 );
+			if( $_198 === FALSE) {
+				$result = $res_199;
+				$this->pos = $pos_199;
+				unset( $res_199 );
+				unset( $pos_199 );
 			}
 			$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_185 = FALSE; break; }
-			$_185 = TRUE; break;
+			else { $_201 = FALSE; break; }
+			$_201 = TRUE; break;
 		}
 		while(0);
-		if( $_185 === TRUE ) { return $this->finalise($result); }
-		if( $_185 === FALSE) { return FALSE; }
+		if( $_201 === TRUE ) { return $this->finalise($result); }
+		if( $_201 === FALSE) { return FALSE; }
 	}
 
 
@@ -1306,31 +1372,31 @@ class SSTemplateParser extends Parser {
 	protected $match_IfArgumentPortion_typestack = array('IfArgumentPortion');
 	function match_IfArgumentPortion ($stack = array()) {
 		$matchrule = "IfArgumentPortion"; $result = $this->construct($matchrule, $matchrule, null);
-		$_190 = NULL;
+		$_206 = NULL;
 		do {
-			$res_187 = $result;
-			$pos_187 = $this->pos;
+			$res_203 = $result;
+			$pos_203 = $this->pos;
 			$matcher = 'match_'.'Comparison'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres );
-				$_190 = TRUE; break;
+				$_206 = TRUE; break;
 			}
-			$result = $res_187;
-			$this->pos = $pos_187;
+			$result = $res_203;
+			$this->pos = $pos_203;
 			$matcher = 'match_'.'PresenceCheck'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres );
-				$_190 = TRUE; break;
+				$_206 = TRUE; break;
 			}
-			$result = $res_187;
-			$this->pos = $pos_187;
-			$_190 = FALSE; break;
+			$result = $res_203;
+			$this->pos = $pos_203;
+			$_206 = FALSE; break;
 		}
 		while(0);
-		if( $_190 === TRUE ) { return $this->finalise($result); }
-		if( $_190 === FALSE) { return FALSE; }
+		if( $_206 === TRUE ) { return $this->finalise($result); }
+		if( $_206 === FALSE) { return FALSE; }
 	}
 
 
@@ -1343,27 +1409,27 @@ class SSTemplateParser extends Parser {
 	protected $match_BooleanOperator_typestack = array('BooleanOperator');
 	function match_BooleanOperator ($stack = array()) {
 		$matchrule = "BooleanOperator"; $result = $this->construct($matchrule, $matchrule, null);
-		$_195 = NULL;
+		$_211 = NULL;
 		do {
-			$res_192 = $result;
-			$pos_192 = $this->pos;
+			$res_208 = $result;
+			$pos_208 = $this->pos;
 			if (( $subres = $this->literal( '||' ) ) !== FALSE) {
 				$result["text"] .= $subres;
-				$_195 = TRUE; break;
+				$_211 = TRUE; break;
 			}
-			$result = $res_192;
-			$this->pos = $pos_192;
+			$result = $res_208;
+			$this->pos = $pos_208;
 			if (( $subres = $this->literal( '&&' ) ) !== FALSE) {
 				$result["text"] .= $subres;
-				$_195 = TRUE; break;
+				$_211 = TRUE; break;
 			}
-			$result = $res_192;
-			$this->pos = $pos_192;
-			$_195 = FALSE; break;
+			$result = $res_208;
+			$this->pos = $pos_208;
+			$_211 = FALSE; break;
 		}
 		while(0);
-		if( $_195 === TRUE ) { return $this->finalise($result); }
-		if( $_195 === FALSE) { return FALSE; }
+		if( $_211 === TRUE ) { return $this->finalise($result); }
+		if( $_211 === FALSE) { return FALSE; }
 	}
 
 
@@ -1371,18 +1437,18 @@ class SSTemplateParser extends Parser {
 	protected $match_IfArgument_typestack = array('IfArgument');
 	function match_IfArgument ($stack = array()) {
 		$matchrule = "IfArgument"; $result = $this->construct($matchrule, $matchrule, null);
-		$_204 = NULL;
+		$_220 = NULL;
 		do {
 			$matcher = 'match_'.'IfArgumentPortion'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "IfArgumentPortion" );
 			}
-			else { $_204 = FALSE; break; }
+			else { $_220 = FALSE; break; }
 			while (true) {
-				$res_203 = $result;
-				$pos_203 = $this->pos;
-				$_202 = NULL;
+				$res_219 = $result;
+				$pos_219 = $this->pos;
+				$_218 = NULL;
 				do {
 					if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 					$matcher = 'match_'.'BooleanOperator'; $key = $matcher; $pos = $this->pos;
@@ -1390,30 +1456,30 @@ class SSTemplateParser extends Parser {
 					if ($subres !== FALSE) {
 						$this->store( $result, $subres, "BooleanOperator" );
 					}
-					else { $_202 = FALSE; break; }
+					else { $_218 = FALSE; break; }
 					if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 					$matcher = 'match_'.'IfArgumentPortion'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 					if ($subres !== FALSE) {
 						$this->store( $result, $subres, "IfArgumentPortion" );
 					}
-					else { $_202 = FALSE; break; }
-					$_202 = TRUE; break;
+					else { $_218 = FALSE; break; }
+					$_218 = TRUE; break;
 				}
 				while(0);
-				if( $_202 === FALSE) {
-					$result = $res_203;
-					$this->pos = $pos_203;
-					unset( $res_203 );
-					unset( $pos_203 );
+				if( $_218 === FALSE) {
+					$result = $res_219;
+					$this->pos = $pos_219;
+					unset( $res_219 );
+					unset( $pos_219 );
 					break;
 				}
 			}
-			$_204 = TRUE; break;
+			$_220 = TRUE; break;
 		}
 		while(0);
-		if( $_204 === TRUE ) { return $this->finalise($result); }
-		if( $_204 === FALSE) { return FALSE; }
+		if( $_220 === TRUE ) { return $this->finalise($result); }
+		if( $_220 === FALSE) { return FALSE; }
 	}
 
 
@@ -1430,42 +1496,42 @@ class SSTemplateParser extends Parser {
 	protected $match_IfPart_typestack = array('IfPart');
 	function match_IfPart ($stack = array()) {
 		$matchrule = "IfPart"; $result = $this->construct($matchrule, $matchrule, null);
-		$_214 = NULL;
+		$_230 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_214 = FALSE; break; }
+			else { $_230 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( 'if' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_214 = FALSE; break; }
+			else { $_230 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_214 = FALSE; break; }
+			else { $_230 = FALSE; break; }
 			$matcher = 'match_'.'IfArgument'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "IfArgument" );
 			}
-			else { $_214 = FALSE; break; }
+			else { $_230 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_214 = FALSE; break; }
-			$res_213 = $result;
-			$pos_213 = $this->pos;
+			else { $_230 = FALSE; break; }
+			$res_229 = $result;
+			$pos_229 = $this->pos;
 			$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "Template" );
 			}
 			else {
-				$result = $res_213;
-				$this->pos = $pos_213;
-				unset( $res_213 );
-				unset( $pos_213 );
+				$result = $res_229;
+				$this->pos = $pos_229;
+				unset( $res_229 );
+				unset( $pos_229 );
 			}
-			$_214 = TRUE; break;
+			$_230 = TRUE; break;
 		}
 		while(0);
-		if( $_214 === TRUE ) { return $this->finalise($result); }
-		if( $_214 === FALSE) { return FALSE; }
+		if( $_230 === TRUE ) { return $this->finalise($result); }
+		if( $_230 === FALSE) { return FALSE; }
 	}
 
 
@@ -1473,35 +1539,35 @@ class SSTemplateParser extends Parser {
 	protected $match_ElseIfPart_typestack = array('ElseIfPart');
 	function match_ElseIfPart ($stack = array()) {
 		$matchrule = "ElseIfPart"; $result = $this->construct($matchrule, $matchrule, null);
-		$_224 = NULL;
+		$_240 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_224 = FALSE; break; }
+			else { $_240 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( 'else_if' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_224 = FALSE; break; }
+			else { $_240 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_224 = FALSE; break; }
+			else { $_240 = FALSE; break; }
 			$matcher = 'match_'.'IfArgument'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "IfArgument" );
 			}
-			else { $_224 = FALSE; break; }
+			else { $_240 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_224 = FALSE; break; }
+			else { $_240 = FALSE; break; }
 			$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "Template" );
 			}
-			else { $_224 = FALSE; break; }
-			$_224 = TRUE; break;
+			else { $_240 = FALSE; break; }
+			$_240 = TRUE; break;
 		}
 		while(0);
-		if( $_224 === TRUE ) { return $this->finalise($result); }
-		if( $_224 === FALSE) { return FALSE; }
+		if( $_240 === TRUE ) { return $this->finalise($result); }
+		if( $_240 === FALSE) { return FALSE; }
 	}
 
 
@@ -1509,27 +1575,27 @@ class SSTemplateParser extends Parser {
 	protected $match_ElsePart_typestack = array('ElsePart');
 	function match_ElsePart ($stack = array()) {
 		$matchrule = "ElsePart"; $result = $this->construct($matchrule, $matchrule, null);
-		$_232 = NULL;
+		$_248 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_232 = FALSE; break; }
+			else { $_248 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( 'else' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_232 = FALSE; break; }
+			else { $_248 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_232 = FALSE; break; }
+			else { $_248 = FALSE; break; }
 			$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "Template" );
 			}
-			else { $_232 = FALSE; break; }
-			$_232 = TRUE; break;
+			else { $_248 = FALSE; break; }
+			$_248 = TRUE; break;
 		}
 		while(0);
-		if( $_232 === TRUE ) { return $this->finalise($result); }
-		if( $_232 === FALSE) { return FALSE; }
+		if( $_248 === TRUE ) { return $this->finalise($result); }
+		if( $_248 === FALSE) { return FALSE; }
 	}
 
 
@@ -1537,50 +1603,50 @@ class SSTemplateParser extends Parser {
 	protected $match_If_typestack = array('If');
 	function match_If ($stack = array()) {
 		$matchrule = "If"; $result = $this->construct($matchrule, $matchrule, null);
-		$_242 = NULL;
+		$_258 = NULL;
 		do {
 			$matcher = 'match_'.'IfPart'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_242 = FALSE; break; }
+			else { $_258 = FALSE; break; }
 			while (true) {
-				$res_235 = $result;
-				$pos_235 = $this->pos;
+				$res_251 = $result;
+				$pos_251 = $this->pos;
 				$matcher = 'match_'.'ElseIfPart'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 				if ($subres !== FALSE) { $this->store( $result, $subres ); }
 				else {
-					$result = $res_235;
-					$this->pos = $pos_235;
-					unset( $res_235 );
-					unset( $pos_235 );
+					$result = $res_251;
+					$this->pos = $pos_251;
+					unset( $res_251 );
+					unset( $pos_251 );
 					break;
 				}
 			}
-			$res_236 = $result;
-			$pos_236 = $this->pos;
+			$res_252 = $result;
+			$pos_252 = $this->pos;
 			$matcher = 'match_'.'ElsePart'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
 			else {
-				$result = $res_236;
-				$this->pos = $pos_236;
-				unset( $res_236 );
-				unset( $pos_236 );
+				$result = $res_252;
+				$this->pos = $pos_252;
+				unset( $res_252 );
+				unset( $pos_252 );
 			}
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_242 = FALSE; break; }
+			else { $_258 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( 'end_if' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_242 = FALSE; break; }
+			else { $_258 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_242 = FALSE; break; }
-			$_242 = TRUE; break;
+			else { $_258 = FALSE; break; }
+			$_258 = TRUE; break;
 		}
 		while(0);
-		if( $_242 === TRUE ) { return $this->finalise($result); }
-		if( $_242 === FALSE) { return FALSE; }
+		if( $_258 === TRUE ) { return $this->finalise($result); }
+		if( $_258 === FALSE) { return FALSE; }
 	}
 
 
@@ -1610,61 +1676,61 @@ class SSTemplateParser extends Parser {
 	protected $match_Require_typestack = array('Require');
 	function match_Require ($stack = array()) {
 		$matchrule = "Require"; $result = $this->construct($matchrule, $matchrule, null);
-		$_258 = NULL;
+		$_274 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_258 = FALSE; break; }
+			else { $_274 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( 'require' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_258 = FALSE; break; }
+			else { $_274 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_258 = FALSE; break; }
+			else { $_274 = FALSE; break; }
 			$stack[] = $result; $result = $this->construct( $matchrule, "Call" ); 
-			$_254 = NULL;
+			$_270 = NULL;
 			do {
 				$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 				if ($subres !== FALSE) {
 					$this->store( $result, $subres, "Method" );
 				}
-				else { $_254 = FALSE; break; }
+				else { $_270 = FALSE; break; }
 				if (substr($this->string,$this->pos,1) == '(') {
 					$this->pos += 1;
 					$result["text"] .= '(';
 				}
-				else { $_254 = FALSE; break; }
+				else { $_270 = FALSE; break; }
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 				$matcher = 'match_'.'CallArguments'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 				if ($subres !== FALSE) {
 					$this->store( $result, $subres, "CallArguments" );
 				}
-				else { $_254 = FALSE; break; }
+				else { $_270 = FALSE; break; }
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 				if (substr($this->string,$this->pos,1) == ')') {
 					$this->pos += 1;
 					$result["text"] .= ')';
 				}
-				else { $_254 = FALSE; break; }
-				$_254 = TRUE; break;
+				else { $_270 = FALSE; break; }
+				$_270 = TRUE; break;
 			}
 			while(0);
-			if( $_254 === TRUE ) {
+			if( $_270 === TRUE ) {
 				$subres = $result; $result = array_pop($stack);
 				$this->store( $result, $subres, 'Call' );
 			}
-			if( $_254 === FALSE) {
+			if( $_270 === FALSE) {
 				$result = array_pop($stack);
-				$_258 = FALSE; break;
+				$_274 = FALSE; break;
 			}
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_258 = FALSE; break; }
-			$_258 = TRUE; break;
+			else { $_274 = FALSE; break; }
+			$_274 = TRUE; break;
 		}
 		while(0);
-		if( $_258 === TRUE ) { return $this->finalise($result); }
-		if( $_258 === FALSE) { return FALSE; }
+		if( $_274 === TRUE ) { return $this->finalise($result); }
+		if( $_274 === FALSE) { return FALSE; }
 	}
 
 
@@ -1684,97 +1750,97 @@ class SSTemplateParser extends Parser {
 	protected $match_CacheBlockArgument_typestack = array('CacheBlockArgument');
 	function match_CacheBlockArgument ($stack = array()) {
 		$matchrule = "CacheBlockArgument"; $result = $this->construct($matchrule, $matchrule, null);
-		$_278 = NULL;
+		$_294 = NULL;
 		do {
-			$res_266 = $result;
-			$pos_266 = $this->pos;
-			$_265 = NULL;
+			$res_282 = $result;
+			$pos_282 = $this->pos;
+			$_281 = NULL;
 			do {
-				$_263 = NULL;
+				$_279 = NULL;
 				do {
-					$res_260 = $result;
-					$pos_260 = $this->pos;
+					$res_276 = $result;
+					$pos_276 = $this->pos;
 					if (( $subres = $this->literal( 'if ' ) ) !== FALSE) {
 						$result["text"] .= $subres;
-						$_263 = TRUE; break;
+						$_279 = TRUE; break;
 					}
-					$result = $res_260;
-					$this->pos = $pos_260;
+					$result = $res_276;
+					$this->pos = $pos_276;
 					if (( $subres = $this->literal( 'unless ' ) ) !== FALSE) {
 						$result["text"] .= $subres;
-						$_263 = TRUE; break;
+						$_279 = TRUE; break;
 					}
-					$result = $res_260;
-					$this->pos = $pos_260;
-					$_263 = FALSE; break;
+					$result = $res_276;
+					$this->pos = $pos_276;
+					$_279 = FALSE; break;
 				}
 				while(0);
-				if( $_263 === FALSE) { $_265 = FALSE; break; }
-				$_265 = TRUE; break;
+				if( $_279 === FALSE) { $_281 = FALSE; break; }
+				$_281 = TRUE; break;
 			}
 			while(0);
-			if( $_265 === TRUE ) {
-				$result = $res_266;
-				$this->pos = $pos_266;
-				$_278 = FALSE; break;
+			if( $_281 === TRUE ) {
+				$result = $res_282;
+				$this->pos = $pos_282;
+				$_294 = FALSE; break;
 			}
-			if( $_265 === FALSE) {
-				$result = $res_266;
-				$this->pos = $pos_266;
+			if( $_281 === FALSE) {
+				$result = $res_282;
+				$this->pos = $pos_282;
 			}
-			$_276 = NULL;
+			$_292 = NULL;
 			do {
-				$_274 = NULL;
+				$_290 = NULL;
 				do {
-					$res_267 = $result;
-					$pos_267 = $this->pos;
+					$res_283 = $result;
+					$pos_283 = $this->pos;
 					$matcher = 'match_'.'DollarMarkedLookup'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 					if ($subres !== FALSE) {
 						$this->store( $result, $subres, "DollarMarkedLookup" );
-						$_274 = TRUE; break;
+						$_290 = TRUE; break;
 					}
-					$result = $res_267;
-					$this->pos = $pos_267;
-					$_272 = NULL;
+					$result = $res_283;
+					$this->pos = $pos_283;
+					$_288 = NULL;
 					do {
-						$res_269 = $result;
-						$pos_269 = $this->pos;
+						$res_285 = $result;
+						$pos_285 = $this->pos;
 						$matcher = 'match_'.'QuotedString'; $key = $matcher; $pos = $this->pos;
 						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 						if ($subres !== FALSE) {
 							$this->store( $result, $subres, "QuotedString" );
-							$_272 = TRUE; break;
+							$_288 = TRUE; break;
 						}
-						$result = $res_269;
-						$this->pos = $pos_269;
+						$result = $res_285;
+						$this->pos = $pos_285;
 						$matcher = 'match_'.'Lookup'; $key = $matcher; $pos = $this->pos;
 						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 						if ($subres !== FALSE) {
 							$this->store( $result, $subres, "Lookup" );
-							$_272 = TRUE; break;
+							$_288 = TRUE; break;
 						}
-						$result = $res_269;
-						$this->pos = $pos_269;
-						$_272 = FALSE; break;
+						$result = $res_285;
+						$this->pos = $pos_285;
+						$_288 = FALSE; break;
 					}
 					while(0);
-					if( $_272 === TRUE ) { $_274 = TRUE; break; }
-					$result = $res_267;
-					$this->pos = $pos_267;
-					$_274 = FALSE; break;
+					if( $_288 === TRUE ) { $_290 = TRUE; break; }
+					$result = $res_283;
+					$this->pos = $pos_283;
+					$_290 = FALSE; break;
 				}
 				while(0);
-				if( $_274 === FALSE) { $_276 = FALSE; break; }
-				$_276 = TRUE; break;
+				if( $_290 === FALSE) { $_292 = FALSE; break; }
+				$_292 = TRUE; break;
 			}
 			while(0);
-			if( $_276 === FALSE) { $_278 = FALSE; break; }
-			$_278 = TRUE; break;
+			if( $_292 === FALSE) { $_294 = FALSE; break; }
+			$_294 = TRUE; break;
 		}
 		while(0);
-		if( $_278 === TRUE ) { return $this->finalise($result); }
-		if( $_278 === FALSE) { return FALSE; }
+		if( $_294 === TRUE ) { return $this->finalise($result); }
+		if( $_294 === FALSE) { return FALSE; }
 	}
 
 
@@ -1795,44 +1861,44 @@ class SSTemplateParser extends Parser {
 	protected $match_CacheBlockArguments_typestack = array('CacheBlockArguments');
 	function match_CacheBlockArguments ($stack = array()) {
 		$matchrule = "CacheBlockArguments"; $result = $this->construct($matchrule, $matchrule, null);
-		$_287 = NULL;
+		$_303 = NULL;
 		do {
 			$matcher = 'match_'.'CacheBlockArgument'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_287 = FALSE; break; }
+			else { $_303 = FALSE; break; }
 			while (true) {
-				$res_286 = $result;
-				$pos_286 = $this->pos;
-				$_285 = NULL;
+				$res_302 = $result;
+				$pos_302 = $this->pos;
+				$_301 = NULL;
 				do {
 					if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 					if (substr($this->string,$this->pos,1) == ',') {
 						$this->pos += 1;
 						$result["text"] .= ',';
 					}
-					else { $_285 = FALSE; break; }
+					else { $_301 = FALSE; break; }
 					if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 					$matcher = 'match_'.'CacheBlockArgument'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 					if ($subres !== FALSE) { $this->store( $result, $subres ); }
-					else { $_285 = FALSE; break; }
-					$_285 = TRUE; break;
+					else { $_301 = FALSE; break; }
+					$_301 = TRUE; break;
 				}
 				while(0);
-				if( $_285 === FALSE) {
-					$result = $res_286;
-					$this->pos = $pos_286;
-					unset( $res_286 );
-					unset( $pos_286 );
+				if( $_301 === FALSE) {
+					$result = $res_302;
+					$this->pos = $pos_302;
+					unset( $res_302 );
+					unset( $pos_302 );
 					break;
 				}
 			}
-			$_287 = TRUE; break;
+			$_303 = TRUE; break;
 		}
 		while(0);
-		if( $_287 === TRUE ) { return $this->finalise($result); }
-		if( $_287 === FALSE) { return FALSE; }
+		if( $_303 === TRUE ) { return $this->finalise($result); }
+		if( $_303 === FALSE) { return FALSE; }
 	}
 
 
@@ -1851,204 +1917,204 @@ class SSTemplateParser extends Parser {
 		$matchrule = "CacheBlockTemplate"; $result = $this->construct($matchrule, $matchrule, array('TemplateMatcher' => 'CacheRestrictedTemplate'));
 		$count = 0;
 		while (true) {
-			$res_331 = $result;
-			$pos_331 = $this->pos;
-			$_330 = NULL;
+			$res_347 = $result;
+			$pos_347 = $this->pos;
+			$_346 = NULL;
 			do {
-				$_328 = NULL;
+				$_344 = NULL;
 				do {
-					$res_289 = $result;
-					$pos_289 = $this->pos;
+					$res_305 = $result;
+					$pos_305 = $this->pos;
 					$matcher = 'match_'.'Comment'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 					if ($subres !== FALSE) {
 						$this->store( $result, $subres );
-						$_328 = TRUE; break;
+						$_344 = TRUE; break;
 					}
-					$result = $res_289;
-					$this->pos = $pos_289;
-					$_326 = NULL;
+					$result = $res_305;
+					$this->pos = $pos_305;
+					$_342 = NULL;
 					do {
-						$res_291 = $result;
-						$pos_291 = $this->pos;
+						$res_307 = $result;
+						$pos_307 = $this->pos;
 						$matcher = 'match_'.'Translate'; $key = $matcher; $pos = $this->pos;
 						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 						if ($subres !== FALSE) {
 							$this->store( $result, $subres );
-							$_326 = TRUE; break;
+							$_342 = TRUE; break;
 						}
-						$result = $res_291;
-						$this->pos = $pos_291;
-						$_324 = NULL;
+						$result = $res_307;
+						$this->pos = $pos_307;
+						$_340 = NULL;
 						do {
-							$res_293 = $result;
-							$pos_293 = $this->pos;
+							$res_309 = $result;
+							$pos_309 = $this->pos;
 							$matcher = 'match_'.'If'; $key = $matcher; $pos = $this->pos;
 							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 							if ($subres !== FALSE) {
 								$this->store( $result, $subres );
-								$_324 = TRUE; break;
+								$_340 = TRUE; break;
 							}
-							$result = $res_293;
-							$this->pos = $pos_293;
-							$_322 = NULL;
+							$result = $res_309;
+							$this->pos = $pos_309;
+							$_338 = NULL;
 							do {
-								$res_295 = $result;
-								$pos_295 = $this->pos;
+								$res_311 = $result;
+								$pos_311 = $this->pos;
 								$matcher = 'match_'.'Require'; $key = $matcher; $pos = $this->pos;
 								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 								if ($subres !== FALSE) {
 									$this->store( $result, $subres );
-									$_322 = TRUE; break;
+									$_338 = TRUE; break;
 								}
-								$result = $res_295;
-								$this->pos = $pos_295;
-								$_320 = NULL;
+								$result = $res_311;
+								$this->pos = $pos_311;
+								$_336 = NULL;
 								do {
-									$res_297 = $result;
-									$pos_297 = $this->pos;
+									$res_313 = $result;
+									$pos_313 = $this->pos;
 									$matcher = 'match_'.'OldI18NTag'; $key = $matcher; $pos = $this->pos;
 									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 									if ($subres !== FALSE) {
 										$this->store( $result, $subres );
-										$_320 = TRUE; break;
+										$_336 = TRUE; break;
 									}
-									$result = $res_297;
-									$this->pos = $pos_297;
-									$_318 = NULL;
+									$result = $res_313;
+									$this->pos = $pos_313;
+									$_334 = NULL;
 									do {
-										$res_299 = $result;
-										$pos_299 = $this->pos;
+										$res_315 = $result;
+										$pos_315 = $this->pos;
 										$matcher = 'match_'.'Include'; $key = $matcher; $pos = $this->pos;
 										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 										if ($subres !== FALSE) {
 											$this->store( $result, $subres );
-											$_318 = TRUE; break;
+											$_334 = TRUE; break;
 										}
-										$result = $res_299;
-										$this->pos = $pos_299;
-										$_316 = NULL;
+										$result = $res_315;
+										$this->pos = $pos_315;
+										$_332 = NULL;
 										do {
-											$res_301 = $result;
-											$pos_301 = $this->pos;
+											$res_317 = $result;
+											$pos_317 = $this->pos;
 											$matcher = 'match_'.'ClosedBlock'; $key = $matcher; $pos = $this->pos;
 											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 											if ($subres !== FALSE) {
 												$this->store( $result, $subres );
-												$_316 = TRUE; break;
+												$_332 = TRUE; break;
 											}
-											$result = $res_301;
-											$this->pos = $pos_301;
-											$_314 = NULL;
+											$result = $res_317;
+											$this->pos = $pos_317;
+											$_330 = NULL;
 											do {
-												$res_303 = $result;
-												$pos_303 = $this->pos;
+												$res_319 = $result;
+												$pos_319 = $this->pos;
 												$matcher = 'match_'.'OpenBlock'; $key = $matcher; $pos = $this->pos;
 												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 												if ($subres !== FALSE) {
 													$this->store( $result, $subres );
-													$_314 = TRUE; break;
+													$_330 = TRUE; break;
 												}
-												$result = $res_303;
-												$this->pos = $pos_303;
-												$_312 = NULL;
+												$result = $res_319;
+												$this->pos = $pos_319;
+												$_328 = NULL;
 												do {
-													$res_305 = $result;
-													$pos_305 = $this->pos;
+													$res_321 = $result;
+													$pos_321 = $this->pos;
 													$matcher = 'match_'.'MalformedBlock'; $key = $matcher; $pos = $this->pos;
 													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 													if ($subres !== FALSE) {
 														$this->store( $result, $subres );
-														$_312 = TRUE; break;
+														$_328 = TRUE; break;
 													}
-													$result = $res_305;
-													$this->pos = $pos_305;
-													$_310 = NULL;
+													$result = $res_321;
+													$this->pos = $pos_321;
+													$_326 = NULL;
 													do {
-														$res_307 = $result;
-														$pos_307 = $this->pos;
+														$res_323 = $result;
+														$pos_323 = $this->pos;
 														$matcher = 'match_'.'Injection'; $key = $matcher; $pos = $this->pos;
 														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 														if ($subres !== FALSE) {
 															$this->store( $result, $subres );
-															$_310 = TRUE; break;
+															$_326 = TRUE; break;
 														}
-														$result = $res_307;
-														$this->pos = $pos_307;
+														$result = $res_323;
+														$this->pos = $pos_323;
 														$matcher = 'match_'.'Text'; $key = $matcher; $pos = $this->pos;
 														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 														if ($subres !== FALSE) {
 															$this->store( $result, $subres );
-															$_310 = TRUE; break;
+															$_326 = TRUE; break;
 														}
-														$result = $res_307;
-														$this->pos = $pos_307;
-														$_310 = FALSE; break;
+														$result = $res_323;
+														$this->pos = $pos_323;
+														$_326 = FALSE; break;
 													}
 													while(0);
-													if( $_310 === TRUE ) { $_312 = TRUE; break; }
-													$result = $res_305;
-													$this->pos = $pos_305;
-													$_312 = FALSE; break;
+													if( $_326 === TRUE ) { $_328 = TRUE; break; }
+													$result = $res_321;
+													$this->pos = $pos_321;
+													$_328 = FALSE; break;
 												}
 												while(0);
-												if( $_312 === TRUE ) { $_314 = TRUE; break; }
-												$result = $res_303;
-												$this->pos = $pos_303;
-												$_314 = FALSE; break;
+												if( $_328 === TRUE ) { $_330 = TRUE; break; }
+												$result = $res_319;
+												$this->pos = $pos_319;
+												$_330 = FALSE; break;
 											}
 											while(0);
-											if( $_314 === TRUE ) { $_316 = TRUE; break; }
-											$result = $res_301;
-											$this->pos = $pos_301;
-											$_316 = FALSE; break;
+											if( $_330 === TRUE ) { $_332 = TRUE; break; }
+											$result = $res_317;
+											$this->pos = $pos_317;
+											$_332 = FALSE; break;
 										}
 										while(0);
-										if( $_316 === TRUE ) { $_318 = TRUE; break; }
-										$result = $res_299;
-										$this->pos = $pos_299;
-										$_318 = FALSE; break;
+										if( $_332 === TRUE ) { $_334 = TRUE; break; }
+										$result = $res_315;
+										$this->pos = $pos_315;
+										$_334 = FALSE; break;
 									}
 									while(0);
-									if( $_318 === TRUE ) { $_320 = TRUE; break; }
-									$result = $res_297;
-									$this->pos = $pos_297;
-									$_320 = FALSE; break;
+									if( $_334 === TRUE ) { $_336 = TRUE; break; }
+									$result = $res_313;
+									$this->pos = $pos_313;
+									$_336 = FALSE; break;
 								}
 								while(0);
-								if( $_320 === TRUE ) { $_322 = TRUE; break; }
-								$result = $res_295;
-								$this->pos = $pos_295;
-								$_322 = FALSE; break;
+								if( $_336 === TRUE ) { $_338 = TRUE; break; }
+								$result = $res_311;
+								$this->pos = $pos_311;
+								$_338 = FALSE; break;
 							}
 							while(0);
-							if( $_322 === TRUE ) { $_324 = TRUE; break; }
-							$result = $res_293;
-							$this->pos = $pos_293;
-							$_324 = FALSE; break;
+							if( $_338 === TRUE ) { $_340 = TRUE; break; }
+							$result = $res_309;
+							$this->pos = $pos_309;
+							$_340 = FALSE; break;
 						}
 						while(0);
-						if( $_324 === TRUE ) { $_326 = TRUE; break; }
-						$result = $res_291;
-						$this->pos = $pos_291;
-						$_326 = FALSE; break;
+						if( $_340 === TRUE ) { $_342 = TRUE; break; }
+						$result = $res_307;
+						$this->pos = $pos_307;
+						$_342 = FALSE; break;
 					}
 					while(0);
-					if( $_326 === TRUE ) { $_328 = TRUE; break; }
-					$result = $res_289;
-					$this->pos = $pos_289;
-					$_328 = FALSE; break;
+					if( $_342 === TRUE ) { $_344 = TRUE; break; }
+					$result = $res_305;
+					$this->pos = $pos_305;
+					$_344 = FALSE; break;
 				}
 				while(0);
-				if( $_328 === FALSE) { $_330 = FALSE; break; }
-				$_330 = TRUE; break;
+				if( $_344 === FALSE) { $_346 = FALSE; break; }
+				$_346 = TRUE; break;
 			}
 			while(0);
-			if( $_330 === FALSE) {
-				$result = $res_331;
-				$this->pos = $pos_331;
-				unset( $res_331 );
-				unset( $pos_331 );
+			if( $_346 === FALSE) {
+				$result = $res_347;
+				$this->pos = $pos_347;
+				unset( $res_347 );
+				unset( $pos_347 );
 				break;
 			}
 			$count += 1;
@@ -2067,63 +2133,63 @@ class SSTemplateParser extends Parser {
 	protected $match_UncachedBlock_typestack = array('UncachedBlock');
 	function match_UncachedBlock ($stack = array()) {
 		$matchrule = "UncachedBlock"; $result = $this->construct($matchrule, $matchrule, null);
-		$_368 = NULL;
+		$_384 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_368 = FALSE; break; }
+			else { $_384 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( 'uncached' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_368 = FALSE; break; }
+			else { $_384 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-			$res_336 = $result;
-			$pos_336 = $this->pos;
+			$res_352 = $result;
+			$pos_352 = $this->pos;
 			$matcher = 'match_'.'CacheBlockArguments'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
 			else {
-				$result = $res_336;
-				$this->pos = $pos_336;
-				unset( $res_336 );
-				unset( $pos_336 );
+				$result = $res_352;
+				$this->pos = $pos_352;
+				unset( $res_352 );
+				unset( $pos_352 );
 			}
-			$res_348 = $result;
-			$pos_348 = $this->pos;
-			$_347 = NULL;
+			$res_364 = $result;
+			$pos_364 = $this->pos;
+			$_363 = NULL;
 			do {
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 				$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" ); 
-				$_343 = NULL;
+				$_359 = NULL;
 				do {
-					$_341 = NULL;
+					$_357 = NULL;
 					do {
-						$res_338 = $result;
-						$pos_338 = $this->pos;
+						$res_354 = $result;
+						$pos_354 = $this->pos;
 						if (( $subres = $this->literal( 'if' ) ) !== FALSE) {
 							$result["text"] .= $subres;
-							$_341 = TRUE; break;
+							$_357 = TRUE; break;
 						}
-						$result = $res_338;
-						$this->pos = $pos_338;
+						$result = $res_354;
+						$this->pos = $pos_354;
 						if (( $subres = $this->literal( 'unless' ) ) !== FALSE) {
 							$result["text"] .= $subres;
-							$_341 = TRUE; break;
+							$_357 = TRUE; break;
 						}
-						$result = $res_338;
-						$this->pos = $pos_338;
-						$_341 = FALSE; break;
+						$result = $res_354;
+						$this->pos = $pos_354;
+						$_357 = FALSE; break;
 					}
 					while(0);
-					if( $_341 === FALSE) { $_343 = FALSE; break; }
-					$_343 = TRUE; break;
+					if( $_357 === FALSE) { $_359 = FALSE; break; }
+					$_359 = TRUE; break;
 				}
 				while(0);
-				if( $_343 === TRUE ) {
+				if( $_359 === TRUE ) {
 					$subres = $result; $result = array_pop($stack);
 					$this->store( $result, $subres, 'Conditional' );
 				}
-				if( $_343 === FALSE) {
+				if( $_359 === FALSE) {
 					$result = array_pop($stack);
-					$_347 = FALSE; break;
+					$_363 = FALSE; break;
 				}
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 				$matcher = 'match_'.'IfArgument'; $key = $matcher; $pos = $this->pos;
@@ -2131,87 +2197,87 @@ class SSTemplateParser extends Parser {
 				if ($subres !== FALSE) {
 					$this->store( $result, $subres, "Condition" );
 				}
-				else { $_347 = FALSE; break; }
-				$_347 = TRUE; break;
+				else { $_363 = FALSE; break; }
+				$_363 = TRUE; break;
 			}
 			while(0);
-			if( $_347 === FALSE) {
-				$result = $res_348;
-				$this->pos = $pos_348;
-				unset( $res_348 );
-				unset( $pos_348 );
+			if( $_363 === FALSE) {
+				$result = $res_364;
+				$this->pos = $pos_364;
+				unset( $res_364 );
+				unset( $pos_364 );
 			}
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_368 = FALSE; break; }
-			$res_351 = $result;
-			$pos_351 = $this->pos;
+			else { $_384 = FALSE; break; }
+			$res_367 = $result;
+			$pos_367 = $this->pos;
 			$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "Template" );
 			}
 			else {
-				$result = $res_351;
-				$this->pos = $pos_351;
-				unset( $res_351 );
-				unset( $pos_351 );
+				$result = $res_367;
+				$this->pos = $pos_367;
+				unset( $res_367 );
+				unset( $pos_367 );
 			}
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_368 = FALSE; break; }
+			else { $_384 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( 'end_' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_368 = FALSE; break; }
-			$_364 = NULL;
+			else { $_384 = FALSE; break; }
+			$_380 = NULL;
 			do {
-				$_362 = NULL;
+				$_378 = NULL;
 				do {
-					$res_355 = $result;
-					$pos_355 = $this->pos;
+					$res_371 = $result;
+					$pos_371 = $this->pos;
 					if (( $subres = $this->literal( 'uncached' ) ) !== FALSE) {
 						$result["text"] .= $subres;
-						$_362 = TRUE; break;
+						$_378 = TRUE; break;
 					}
-					$result = $res_355;
-					$this->pos = $pos_355;
-					$_360 = NULL;
+					$result = $res_371;
+					$this->pos = $pos_371;
+					$_376 = NULL;
 					do {
-						$res_357 = $result;
-						$pos_357 = $this->pos;
+						$res_373 = $result;
+						$pos_373 = $this->pos;
 						if (( $subres = $this->literal( 'cached' ) ) !== FALSE) {
 							$result["text"] .= $subres;
-							$_360 = TRUE; break;
+							$_376 = TRUE; break;
 						}
-						$result = $res_357;
-						$this->pos = $pos_357;
+						$result = $res_373;
+						$this->pos = $pos_373;
 						if (( $subres = $this->literal( 'cacheblock' ) ) !== FALSE) {
 							$result["text"] .= $subres;
-							$_360 = TRUE; break;
+							$_376 = TRUE; break;
 						}
-						$result = $res_357;
-						$this->pos = $pos_357;
-						$_360 = FALSE; break;
+						$result = $res_373;
+						$this->pos = $pos_373;
+						$_376 = FALSE; break;
 					}
 					while(0);
-					if( $_360 === TRUE ) { $_362 = TRUE; break; }
-					$result = $res_355;
-					$this->pos = $pos_355;
-					$_362 = FALSE; break;
+					if( $_376 === TRUE ) { $_378 = TRUE; break; }
+					$result = $res_371;
+					$this->pos = $pos_371;
+					$_378 = FALSE; break;
 				}
 				while(0);
-				if( $_362 === FALSE) { $_364 = FALSE; break; }
-				$_364 = TRUE; break;
+				if( $_378 === FALSE) { $_380 = FALSE; break; }
+				$_380 = TRUE; break;
 			}
 			while(0);
-			if( $_364 === FALSE) { $_368 = FALSE; break; }
+			if( $_380 === FALSE) { $_384 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_368 = FALSE; break; }
-			$_368 = TRUE; break;
+			else { $_384 = FALSE; break; }
+			$_384 = TRUE; break;
 		}
 		while(0);
-		if( $_368 === TRUE ) { return $this->finalise($result); }
-		if( $_368 === FALSE) { return FALSE; }
+		if( $_384 === TRUE ) { return $this->finalise($result); }
+		if( $_384 === FALSE) { return FALSE; }
 	}
 
 
@@ -2227,240 +2293,240 @@ class SSTemplateParser extends Parser {
 		$matchrule = "CacheRestrictedTemplate"; $result = $this->construct($matchrule, $matchrule, null);
 		$count = 0;
 		while (true) {
-			$res_420 = $result;
-			$pos_420 = $this->pos;
-			$_419 = NULL;
+			$res_436 = $result;
+			$pos_436 = $this->pos;
+			$_435 = NULL;
 			do {
-				$_417 = NULL;
+				$_433 = NULL;
 				do {
-					$res_370 = $result;
-					$pos_370 = $this->pos;
+					$res_386 = $result;
+					$pos_386 = $this->pos;
 					$matcher = 'match_'.'Comment'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 					if ($subres !== FALSE) {
 						$this->store( $result, $subres );
-						$_417 = TRUE; break;
+						$_433 = TRUE; break;
 					}
-					$result = $res_370;
-					$this->pos = $pos_370;
-					$_415 = NULL;
+					$result = $res_386;
+					$this->pos = $pos_386;
+					$_431 = NULL;
 					do {
-						$res_372 = $result;
-						$pos_372 = $this->pos;
+						$res_388 = $result;
+						$pos_388 = $this->pos;
 						$matcher = 'match_'.'Translate'; $key = $matcher; $pos = $this->pos;
 						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 						if ($subres !== FALSE) {
 							$this->store( $result, $subres );
-							$_415 = TRUE; break;
+							$_431 = TRUE; break;
 						}
-						$result = $res_372;
-						$this->pos = $pos_372;
-						$_413 = NULL;
+						$result = $res_388;
+						$this->pos = $pos_388;
+						$_429 = NULL;
 						do {
-							$res_374 = $result;
-							$pos_374 = $this->pos;
+							$res_390 = $result;
+							$pos_390 = $this->pos;
 							$matcher = 'match_'.'If'; $key = $matcher; $pos = $this->pos;
 							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 							if ($subres !== FALSE) {
 								$this->store( $result, $subres );
-								$_413 = TRUE; break;
+								$_429 = TRUE; break;
 							}
-							$result = $res_374;
-							$this->pos = $pos_374;
-							$_411 = NULL;
+							$result = $res_390;
+							$this->pos = $pos_390;
+							$_427 = NULL;
 							do {
-								$res_376 = $result;
-								$pos_376 = $this->pos;
+								$res_392 = $result;
+								$pos_392 = $this->pos;
 								$matcher = 'match_'.'Require'; $key = $matcher; $pos = $this->pos;
 								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 								if ($subres !== FALSE) {
 									$this->store( $result, $subres );
-									$_411 = TRUE; break;
+									$_427 = TRUE; break;
 								}
-								$result = $res_376;
-								$this->pos = $pos_376;
-								$_409 = NULL;
+								$result = $res_392;
+								$this->pos = $pos_392;
+								$_425 = NULL;
 								do {
-									$res_378 = $result;
-									$pos_378 = $this->pos;
+									$res_394 = $result;
+									$pos_394 = $this->pos;
 									$matcher = 'match_'.'CacheBlock'; $key = $matcher; $pos = $this->pos;
 									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 									if ($subres !== FALSE) {
 										$this->store( $result, $subres );
-										$_409 = TRUE; break;
+										$_425 = TRUE; break;
 									}
-									$result = $res_378;
-									$this->pos = $pos_378;
-									$_407 = NULL;
+									$result = $res_394;
+									$this->pos = $pos_394;
+									$_423 = NULL;
 									do {
-										$res_380 = $result;
-										$pos_380 = $this->pos;
+										$res_396 = $result;
+										$pos_396 = $this->pos;
 										$matcher = 'match_'.'UncachedBlock'; $key = $matcher; $pos = $this->pos;
 										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 										if ($subres !== FALSE) {
 											$this->store( $result, $subres );
-											$_407 = TRUE; break;
+											$_423 = TRUE; break;
 										}
-										$result = $res_380;
-										$this->pos = $pos_380;
-										$_405 = NULL;
+										$result = $res_396;
+										$this->pos = $pos_396;
+										$_421 = NULL;
 										do {
-											$res_382 = $result;
-											$pos_382 = $this->pos;
+											$res_398 = $result;
+											$pos_398 = $this->pos;
 											$matcher = 'match_'.'OldI18NTag'; $key = $matcher; $pos = $this->pos;
 											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 											if ($subres !== FALSE) {
 												$this->store( $result, $subres );
-												$_405 = TRUE; break;
+												$_421 = TRUE; break;
 											}
-											$result = $res_382;
-											$this->pos = $pos_382;
-											$_403 = NULL;
+											$result = $res_398;
+											$this->pos = $pos_398;
+											$_419 = NULL;
 											do {
-												$res_384 = $result;
-												$pos_384 = $this->pos;
+												$res_400 = $result;
+												$pos_400 = $this->pos;
 												$matcher = 'match_'.'Include'; $key = $matcher; $pos = $this->pos;
 												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 												if ($subres !== FALSE) {
 													$this->store( $result, $subres );
-													$_403 = TRUE; break;
+													$_419 = TRUE; break;
 												}
-												$result = $res_384;
-												$this->pos = $pos_384;
-												$_401 = NULL;
+												$result = $res_400;
+												$this->pos = $pos_400;
+												$_417 = NULL;
 												do {
-													$res_386 = $result;
-													$pos_386 = $this->pos;
+													$res_402 = $result;
+													$pos_402 = $this->pos;
 													$matcher = 'match_'.'ClosedBlock'; $key = $matcher; $pos = $this->pos;
 													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 													if ($subres !== FALSE) {
 														$this->store( $result, $subres );
-														$_401 = TRUE; break;
+														$_417 = TRUE; break;
 													}
-													$result = $res_386;
-													$this->pos = $pos_386;
-													$_399 = NULL;
+													$result = $res_402;
+													$this->pos = $pos_402;
+													$_415 = NULL;
 													do {
-														$res_388 = $result;
-														$pos_388 = $this->pos;
+														$res_404 = $result;
+														$pos_404 = $this->pos;
 														$matcher = 'match_'.'OpenBlock'; $key = $matcher; $pos = $this->pos;
 														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 														if ($subres !== FALSE) {
 															$this->store( $result, $subres );
-															$_399 = TRUE; break;
+															$_415 = TRUE; break;
 														}
-														$result = $res_388;
-														$this->pos = $pos_388;
-														$_397 = NULL;
+														$result = $res_404;
+														$this->pos = $pos_404;
+														$_413 = NULL;
 														do {
-															$res_390 = $result;
-															$pos_390 = $this->pos;
+															$res_406 = $result;
+															$pos_406 = $this->pos;
 															$matcher = 'match_'.'MalformedBlock'; $key = $matcher; $pos = $this->pos;
 															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 															if ($subres !== FALSE) {
 																$this->store( $result, $subres );
-																$_397 = TRUE; break;
+																$_413 = TRUE; break;
 															}
-															$result = $res_390;
-															$this->pos = $pos_390;
-															$_395 = NULL;
+															$result = $res_406;
+															$this->pos = $pos_406;
+															$_411 = NULL;
 															do {
-																$res_392 = $result;
-																$pos_392 = $this->pos;
+																$res_408 = $result;
+																$pos_408 = $this->pos;
 																$matcher = 'match_'.'Injection'; $key = $matcher; $pos = $this->pos;
 																$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 																if ($subres !== FALSE) {
 																	$this->store( $result, $subres );
-																	$_395 = TRUE; break;
+																	$_411 = TRUE; break;
 																}
-																$result = $res_392;
-																$this->pos = $pos_392;
+																$result = $res_408;
+																$this->pos = $pos_408;
 																$matcher = 'match_'.'Text'; $key = $matcher; $pos = $this->pos;
 																$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 																if ($subres !== FALSE) {
 																	$this->store( $result, $subres );
-																	$_395 = TRUE; break;
+																	$_411 = TRUE; break;
 																}
-																$result = $res_392;
-																$this->pos = $pos_392;
-																$_395 = FALSE; break;
+																$result = $res_408;
+																$this->pos = $pos_408;
+																$_411 = FALSE; break;
 															}
 															while(0);
-															if( $_395 === TRUE ) { $_397 = TRUE; break; }
-															$result = $res_390;
-															$this->pos = $pos_390;
-															$_397 = FALSE; break;
+															if( $_411 === TRUE ) { $_413 = TRUE; break; }
+															$result = $res_406;
+															$this->pos = $pos_406;
+															$_413 = FALSE; break;
 														}
 														while(0);
-														if( $_397 === TRUE ) { $_399 = TRUE; break; }
-														$result = $res_388;
-														$this->pos = $pos_388;
-														$_399 = FALSE; break;
+														if( $_413 === TRUE ) { $_415 = TRUE; break; }
+														$result = $res_404;
+														$this->pos = $pos_404;
+														$_415 = FALSE; break;
 													}
 													while(0);
-													if( $_399 === TRUE ) { $_401 = TRUE; break; }
-													$result = $res_386;
-													$this->pos = $pos_386;
-													$_401 = FALSE; break;
+													if( $_415 === TRUE ) { $_417 = TRUE; break; }
+													$result = $res_402;
+													$this->pos = $pos_402;
+													$_417 = FALSE; break;
 												}
 												while(0);
-												if( $_401 === TRUE ) { $_403 = TRUE; break; }
-												$result = $res_384;
-												$this->pos = $pos_384;
-												$_403 = FALSE; break;
+												if( $_417 === TRUE ) { $_419 = TRUE; break; }
+												$result = $res_400;
+												$this->pos = $pos_400;
+												$_419 = FALSE; break;
 											}
 											while(0);
-											if( $_403 === TRUE ) { $_405 = TRUE; break; }
-											$result = $res_382;
-											$this->pos = $pos_382;
-											$_405 = FALSE; break;
+											if( $_419 === TRUE ) { $_421 = TRUE; break; }
+											$result = $res_398;
+											$this->pos = $pos_398;
+											$_421 = FALSE; break;
 										}
 										while(0);
-										if( $_405 === TRUE ) { $_407 = TRUE; break; }
-										$result = $res_380;
-										$this->pos = $pos_380;
-										$_407 = FALSE; break;
+										if( $_421 === TRUE ) { $_423 = TRUE; break; }
+										$result = $res_396;
+										$this->pos = $pos_396;
+										$_423 = FALSE; break;
 									}
 									while(0);
-									if( $_407 === TRUE ) { $_409 = TRUE; break; }
-									$result = $res_378;
-									$this->pos = $pos_378;
-									$_409 = FALSE; break;
+									if( $_423 === TRUE ) { $_425 = TRUE; break; }
+									$result = $res_394;
+									$this->pos = $pos_394;
+									$_425 = FALSE; break;
 								}
 								while(0);
-								if( $_409 === TRUE ) { $_411 = TRUE; break; }
-								$result = $res_376;
-								$this->pos = $pos_376;
-								$_411 = FALSE; break;
+								if( $_425 === TRUE ) { $_427 = TRUE; break; }
+								$result = $res_392;
+								$this->pos = $pos_392;
+								$_427 = FALSE; break;
 							}
 							while(0);
-							if( $_411 === TRUE ) { $_413 = TRUE; break; }
-							$result = $res_374;
-							$this->pos = $pos_374;
-							$_413 = FALSE; break;
+							if( $_427 === TRUE ) { $_429 = TRUE; break; }
+							$result = $res_390;
+							$this->pos = $pos_390;
+							$_429 = FALSE; break;
 						}
 						while(0);
-						if( $_413 === TRUE ) { $_415 = TRUE; break; }
-						$result = $res_372;
-						$this->pos = $pos_372;
-						$_415 = FALSE; break;
+						if( $_429 === TRUE ) { $_431 = TRUE; break; }
+						$result = $res_388;
+						$this->pos = $pos_388;
+						$_431 = FALSE; break;
 					}
 					while(0);
-					if( $_415 === TRUE ) { $_417 = TRUE; break; }
-					$result = $res_370;
-					$this->pos = $pos_370;
-					$_417 = FALSE; break;
+					if( $_431 === TRUE ) { $_433 = TRUE; break; }
+					$result = $res_386;
+					$this->pos = $pos_386;
+					$_433 = FALSE; break;
 				}
 				while(0);
-				if( $_417 === FALSE) { $_419 = FALSE; break; }
-				$_419 = TRUE; break;
+				if( $_433 === FALSE) { $_435 = FALSE; break; }
+				$_435 = TRUE; break;
 			}
 			while(0);
-			if( $_419 === FALSE) {
-				$result = $res_420;
-				$this->pos = $pos_420;
-				unset( $res_420 );
-				unset( $pos_420 );
+			if( $_435 === FALSE) {
+				$result = $res_436;
+				$this->pos = $pos_436;
+				unset( $res_436 );
+				unset( $pos_436 );
 				break;
 			}
 			$count += 1;
@@ -2489,101 +2555,101 @@ class SSTemplateParser extends Parser {
 	protected $match_CacheBlock_typestack = array('CacheBlock');
 	function match_CacheBlock ($stack = array()) {
 		$matchrule = "CacheBlock"; $result = $this->construct($matchrule, $matchrule, null);
-		$_475 = NULL;
+		$_491 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_475 = FALSE; break; }
+			else { $_491 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			$stack[] = $result; $result = $this->construct( $matchrule, "CacheTag" ); 
-			$_428 = NULL;
+			$_444 = NULL;
 			do {
-				$_426 = NULL;
+				$_442 = NULL;
 				do {
-					$res_423 = $result;
-					$pos_423 = $this->pos;
+					$res_439 = $result;
+					$pos_439 = $this->pos;
 					if (( $subres = $this->literal( 'cached' ) ) !== FALSE) {
 						$result["text"] .= $subres;
-						$_426 = TRUE; break;
+						$_442 = TRUE; break;
 					}
-					$result = $res_423;
-					$this->pos = $pos_423;
+					$result = $res_439;
+					$this->pos = $pos_439;
 					if (( $subres = $this->literal( 'cacheblock' ) ) !== FALSE) {
 						$result["text"] .= $subres;
-						$_426 = TRUE; break;
+						$_442 = TRUE; break;
 					}
-					$result = $res_423;
-					$this->pos = $pos_423;
-					$_426 = FALSE; break;
+					$result = $res_439;
+					$this->pos = $pos_439;
+					$_442 = FALSE; break;
 				}
 				while(0);
-				if( $_426 === FALSE) { $_428 = FALSE; break; }
-				$_428 = TRUE; break;
+				if( $_442 === FALSE) { $_444 = FALSE; break; }
+				$_444 = TRUE; break;
 			}
 			while(0);
-			if( $_428 === TRUE ) {
+			if( $_444 === TRUE ) {
 				$subres = $result; $result = array_pop($stack);
 				$this->store( $result, $subres, 'CacheTag' );
 			}
-			if( $_428 === FALSE) {
+			if( $_444 === FALSE) {
 				$result = array_pop($stack);
-				$_475 = FALSE; break;
+				$_491 = FALSE; break;
 			}
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-			$res_433 = $result;
-			$pos_433 = $this->pos;
-			$_432 = NULL;
+			$res_449 = $result;
+			$pos_449 = $this->pos;
+			$_448 = NULL;
 			do {
 				$matcher = 'match_'.'CacheBlockArguments'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 				if ($subres !== FALSE) { $this->store( $result, $subres ); }
-				else { $_432 = FALSE; break; }
-				$_432 = TRUE; break;
+				else { $_448 = FALSE; break; }
+				$_448 = TRUE; break;
 			}
 			while(0);
-			if( $_432 === FALSE) {
-				$result = $res_433;
-				$this->pos = $pos_433;
-				unset( $res_433 );
-				unset( $pos_433 );
+			if( $_448 === FALSE) {
+				$result = $res_449;
+				$this->pos = $pos_449;
+				unset( $res_449 );
+				unset( $pos_449 );
 			}
-			$res_445 = $result;
-			$pos_445 = $this->pos;
-			$_444 = NULL;
+			$res_461 = $result;
+			$pos_461 = $this->pos;
+			$_460 = NULL;
 			do {
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 				$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" ); 
-				$_440 = NULL;
+				$_456 = NULL;
 				do {
-					$_438 = NULL;
+					$_454 = NULL;
 					do {
-						$res_435 = $result;
-						$pos_435 = $this->pos;
+						$res_451 = $result;
+						$pos_451 = $this->pos;
 						if (( $subres = $this->literal( 'if' ) ) !== FALSE) {
 							$result["text"] .= $subres;
-							$_438 = TRUE; break;
+							$_454 = TRUE; break;
 						}
-						$result = $res_435;
-						$this->pos = $pos_435;
+						$result = $res_451;
+						$this->pos = $pos_451;
 						if (( $subres = $this->literal( 'unless' ) ) !== FALSE) {
 							$result["text"] .= $subres;
-							$_438 = TRUE; break;
+							$_454 = TRUE; break;
 						}
-						$result = $res_435;
-						$this->pos = $pos_435;
-						$_438 = FALSE; break;
+						$result = $res_451;
+						$this->pos = $pos_451;
+						$_454 = FALSE; break;
 					}
 					while(0);
-					if( $_438 === FALSE) { $_440 = FALSE; break; }
-					$_440 = TRUE; break;
+					if( $_454 === FALSE) { $_456 = FALSE; break; }
+					$_456 = TRUE; break;
 				}
 				while(0);
-				if( $_440 === TRUE ) {
+				if( $_456 === TRUE ) {
 					$subres = $result; $result = array_pop($stack);
 					$this->store( $result, $subres, 'Conditional' );
 				}
-				if( $_440 === FALSE) {
+				if( $_456 === FALSE) {
 					$result = array_pop($stack);
-					$_444 = FALSE; break;
+					$_460 = FALSE; break;
 				}
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 				$matcher = 'match_'.'IfArgument'; $key = $matcher; $pos = $this->pos;
@@ -2591,132 +2657,132 @@ class SSTemplateParser extends Parser {
 				if ($subres !== FALSE) {
 					$this->store( $result, $subres, "Condition" );
 				}
-				else { $_444 = FALSE; break; }
-				$_444 = TRUE; break;
+				else { $_460 = FALSE; break; }
+				$_460 = TRUE; break;
 			}
 			while(0);
-			if( $_444 === FALSE) {
-				$result = $res_445;
-				$this->pos = $pos_445;
-				unset( $res_445 );
-				unset( $pos_445 );
+			if( $_460 === FALSE) {
+				$result = $res_461;
+				$this->pos = $pos_461;
+				unset( $res_461 );
+				unset( $pos_461 );
 			}
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_475 = FALSE; break; }
+			else { $_491 = FALSE; break; }
 			while (true) {
-				$res_458 = $result;
-				$pos_458 = $this->pos;
-				$_457 = NULL;
+				$res_474 = $result;
+				$pos_474 = $this->pos;
+				$_473 = NULL;
 				do {
-					$_455 = NULL;
+					$_471 = NULL;
 					do {
-						$res_448 = $result;
-						$pos_448 = $this->pos;
+						$res_464 = $result;
+						$pos_464 = $this->pos;
 						$matcher = 'match_'.'CacheBlock'; $key = $matcher; $pos = $this->pos;
 						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 						if ($subres !== FALSE) {
 							$this->store( $result, $subres );
-							$_455 = TRUE; break;
+							$_471 = TRUE; break;
 						}
-						$result = $res_448;
-						$this->pos = $pos_448;
-						$_453 = NULL;
+						$result = $res_464;
+						$this->pos = $pos_464;
+						$_469 = NULL;
 						do {
-							$res_450 = $result;
-							$pos_450 = $this->pos;
+							$res_466 = $result;
+							$pos_466 = $this->pos;
 							$matcher = 'match_'.'UncachedBlock'; $key = $matcher; $pos = $this->pos;
 							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 							if ($subres !== FALSE) {
 								$this->store( $result, $subres );
-								$_453 = TRUE; break;
+								$_469 = TRUE; break;
 							}
-							$result = $res_450;
-							$this->pos = $pos_450;
+							$result = $res_466;
+							$this->pos = $pos_466;
 							$matcher = 'match_'.'CacheBlockTemplate'; $key = $matcher; $pos = $this->pos;
 							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 							if ($subres !== FALSE) {
 								$this->store( $result, $subres );
-								$_453 = TRUE; break;
+								$_469 = TRUE; break;
 							}
-							$result = $res_450;
-							$this->pos = $pos_450;
-							$_453 = FALSE; break;
+							$result = $res_466;
+							$this->pos = $pos_466;
+							$_469 = FALSE; break;
 						}
 						while(0);
-						if( $_453 === TRUE ) { $_455 = TRUE; break; }
-						$result = $res_448;
-						$this->pos = $pos_448;
-						$_455 = FALSE; break;
+						if( $_469 === TRUE ) { $_471 = TRUE; break; }
+						$result = $res_464;
+						$this->pos = $pos_464;
+						$_471 = FALSE; break;
 					}
 					while(0);
-					if( $_455 === FALSE) { $_457 = FALSE; break; }
-					$_457 = TRUE; break;
+					if( $_471 === FALSE) { $_473 = FALSE; break; }
+					$_473 = TRUE; break;
 				}
 				while(0);
-				if( $_457 === FALSE) {
-					$result = $res_458;
-					$this->pos = $pos_458;
-					unset( $res_458 );
-					unset( $pos_458 );
+				if( $_473 === FALSE) {
+					$result = $res_474;
+					$this->pos = $pos_474;
+					unset( $res_474 );
+					unset( $pos_474 );
 					break;
 				}
 			}
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_475 = FALSE; break; }
+			else { $_491 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( 'end_' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_475 = FALSE; break; }
-			$_471 = NULL;
+			else { $_491 = FALSE; break; }
+			$_487 = NULL;
 			do {
-				$_469 = NULL;
+				$_485 = NULL;
 				do {
-					$res_462 = $result;
-					$pos_462 = $this->pos;
+					$res_478 = $result;
+					$pos_478 = $this->pos;
 					if (( $subres = $this->literal( 'cached' ) ) !== FALSE) {
 						$result["text"] .= $subres;
-						$_469 = TRUE; break;
+						$_485 = TRUE; break;
 					}
-					$result = $res_462;
-					$this->pos = $pos_462;
-					$_467 = NULL;
+					$result = $res_478;
+					$this->pos = $pos_478;
+					$_483 = NULL;
 					do {
-						$res_464 = $result;
-						$pos_464 = $this->pos;
+						$res_480 = $result;
+						$pos_480 = $this->pos;
 						if (( $subres = $this->literal( 'uncached' ) ) !== FALSE) {
 							$result["text"] .= $subres;
-							$_467 = TRUE; break;
+							$_483 = TRUE; break;
 						}
-						$result = $res_464;
-						$this->pos = $pos_464;
+						$result = $res_480;
+						$this->pos = $pos_480;
 						if (( $subres = $this->literal( 'cacheblock' ) ) !== FALSE) {
 							$result["text"] .= $subres;
-							$_467 = TRUE; break;
+							$_483 = TRUE; break;
 						}
-						$result = $res_464;
-						$this->pos = $pos_464;
-						$_467 = FALSE; break;
+						$result = $res_480;
+						$this->pos = $pos_480;
+						$_483 = FALSE; break;
 					}
 					while(0);
-					if( $_467 === TRUE ) { $_469 = TRUE; break; }
-					$result = $res_462;
-					$this->pos = $pos_462;
-					$_469 = FALSE; break;
+					if( $_483 === TRUE ) { $_485 = TRUE; break; }
+					$result = $res_478;
+					$this->pos = $pos_478;
+					$_485 = FALSE; break;
 				}
 				while(0);
-				if( $_469 === FALSE) { $_471 = FALSE; break; }
-				$_471 = TRUE; break;
+				if( $_485 === FALSE) { $_487 = FALSE; break; }
+				$_487 = TRUE; break;
 			}
 			while(0);
-			if( $_471 === FALSE) { $_475 = FALSE; break; }
+			if( $_487 === FALSE) { $_491 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_475 = FALSE; break; }
-			$_475 = TRUE; break;
+			else { $_491 = FALSE; break; }
+			$_491 = TRUE; break;
 		}
 		while(0);
-		if( $_475 === TRUE ) { return $this->finalise($result); }
-		if( $_475 === FALSE) { return FALSE; }
+		if( $_491 === TRUE ) { return $this->finalise($result); }
+		if( $_491 === FALSE) { return FALSE; }
 	}
 
 
@@ -2762,93 +2828,93 @@ class SSTemplateParser extends Parser {
 	protected $match_OldTPart_typestack = array('OldTPart');
 	function match_OldTPart ($stack = array()) {
 		$matchrule = "OldTPart"; $result = $this->construct($matchrule, $matchrule, null);
-		$_494 = NULL;
+		$_510 = NULL;
 		do {
 			if (( $subres = $this->literal( '_t' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_494 = FALSE; break; }
+			else { $_510 = FALSE; break; }
 			$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_494 = FALSE; break; }
+			else { $_510 = FALSE; break; }
 			if (substr($this->string,$this->pos,1) == '(') {
 				$this->pos += 1;
 				$result["text"] .= '(';
 			}
-			else { $_494 = FALSE; break; }
+			else { $_510 = FALSE; break; }
 			$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_494 = FALSE; break; }
+			else { $_510 = FALSE; break; }
 			$matcher = 'match_'.'QuotedString'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_494 = FALSE; break; }
-			$res_487 = $result;
-			$pos_487 = $this->pos;
-			$_486 = NULL;
+			else { $_510 = FALSE; break; }
+			$res_503 = $result;
+			$pos_503 = $this->pos;
+			$_502 = NULL;
 			do {
 				$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 				if ($subres !== FALSE) { $this->store( $result, $subres ); }
-				else { $_486 = FALSE; break; }
+				else { $_502 = FALSE; break; }
 				if (substr($this->string,$this->pos,1) == ',') {
 					$this->pos += 1;
 					$result["text"] .= ',';
 				}
-				else { $_486 = FALSE; break; }
+				else { $_502 = FALSE; break; }
 				$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 				if ($subres !== FALSE) { $this->store( $result, $subres ); }
-				else { $_486 = FALSE; break; }
+				else { $_502 = FALSE; break; }
 				$matcher = 'match_'.'CallArguments'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 				if ($subres !== FALSE) { $this->store( $result, $subres ); }
-				else { $_486 = FALSE; break; }
-				$_486 = TRUE; break;
+				else { $_502 = FALSE; break; }
+				$_502 = TRUE; break;
 			}
 			while(0);
-			if( $_486 === FALSE) {
-				$result = $res_487;
-				$this->pos = $pos_487;
-				unset( $res_487 );
-				unset( $pos_487 );
+			if( $_502 === FALSE) {
+				$result = $res_503;
+				$this->pos = $pos_503;
+				unset( $res_503 );
+				unset( $pos_503 );
 			}
 			$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_494 = FALSE; break; }
+			else { $_510 = FALSE; break; }
 			if (substr($this->string,$this->pos,1) == ')') {
 				$this->pos += 1;
 				$result["text"] .= ')';
 			}
-			else { $_494 = FALSE; break; }
+			else { $_510 = FALSE; break; }
 			$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_494 = FALSE; break; }
-			$res_493 = $result;
-			$pos_493 = $this->pos;
-			$_492 = NULL;
+			else { $_510 = FALSE; break; }
+			$res_509 = $result;
+			$pos_509 = $this->pos;
+			$_508 = NULL;
 			do {
 				if (substr($this->string,$this->pos,1) == ';') {
 					$this->pos += 1;
 					$result["text"] .= ';';
 				}
-				else { $_492 = FALSE; break; }
-				$_492 = TRUE; break;
+				else { $_508 = FALSE; break; }
+				$_508 = TRUE; break;
 			}
 			while(0);
-			if( $_492 === FALSE) {
-				$result = $res_493;
-				$this->pos = $pos_493;
-				unset( $res_493 );
-				unset( $pos_493 );
+			if( $_508 === FALSE) {
+				$result = $res_509;
+				$this->pos = $pos_509;
+				unset( $res_509 );
+				unset( $pos_509 );
 			}
-			$_494 = TRUE; break;
+			$_510 = TRUE; break;
 		}
 		while(0);
-		if( $_494 === TRUE ) { return $this->finalise($result); }
-		if( $_494 === FALSE) { return FALSE; }
+		if( $_510 === TRUE ) { return $this->finalise($result); }
+		if( $_510 === FALSE) { return FALSE; }
 	}
 
 
@@ -2891,23 +2957,23 @@ class SSTemplateParser extends Parser {
 	protected $match_OldTTag_typestack = array('OldTTag');
 	function match_OldTTag ($stack = array()) {
 		$matchrule = "OldTTag"; $result = $this->construct($matchrule, $matchrule, null);
-		$_502 = NULL;
+		$_518 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_502 = FALSE; break; }
+			else { $_518 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			$matcher = 'match_'.'OldTPart'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_502 = FALSE; break; }
+			else { $_518 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_502 = FALSE; break; }
-			$_502 = TRUE; break;
+			else { $_518 = FALSE; break; }
+			$_518 = TRUE; break;
 		}
 		while(0);
-		if( $_502 === TRUE ) { return $this->finalise($result); }
-		if( $_502 === FALSE) { return FALSE; }
+		if( $_518 === TRUE ) { return $this->finalise($result); }
+		if( $_518 === FALSE) { return FALSE; }
 	}
 
 
@@ -2920,49 +2986,49 @@ class SSTemplateParser extends Parser {
 	protected $match_OldSprintfTag_typestack = array('OldSprintfTag');
 	function match_OldSprintfTag ($stack = array()) {
 		$matchrule = "OldSprintfTag"; $result = $this->construct($matchrule, $matchrule, null);
-		$_519 = NULL;
+		$_535 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_519 = FALSE; break; }
+			else { $_535 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( 'sprintf' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_519 = FALSE; break; }
+			else { $_535 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (substr($this->string,$this->pos,1) == '(') {
 				$this->pos += 1;
 				$result["text"] .= '(';
 			}
-			else { $_519 = FALSE; break; }
+			else { $_535 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			$matcher = 'match_'.'OldTPart'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_519 = FALSE; break; }
+			else { $_535 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (substr($this->string,$this->pos,1) == ',') {
 				$this->pos += 1;
 				$result["text"] .= ',';
 			}
-			else { $_519 = FALSE; break; }
+			else { $_535 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			$matcher = 'match_'.'CallArguments'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) { $this->store( $result, $subres ); }
-			else { $_519 = FALSE; break; }
+			else { $_535 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (substr($this->string,$this->pos,1) == ')') {
 				$this->pos += 1;
 				$result["text"] .= ')';
 			}
-			else { $_519 = FALSE; break; }
+			else { $_535 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_519 = FALSE; break; }
-			$_519 = TRUE; break;
+			else { $_535 = FALSE; break; }
+			$_535 = TRUE; break;
 		}
 		while(0);
-		if( $_519 === TRUE ) { return $this->finalise($result); }
-		if( $_519 === FALSE) { return FALSE; }
+		if( $_535 === TRUE ) { return $this->finalise($result); }
+		if( $_535 === FALSE) { return FALSE; }
 	}
 
 
@@ -2983,31 +3049,31 @@ class SSTemplateParser extends Parser {
 	protected $match_OldI18NTag_typestack = array('OldI18NTag');
 	function match_OldI18NTag ($stack = array()) {
 		$matchrule = "OldI18NTag"; $result = $this->construct($matchrule, $matchrule, null);
-		$_524 = NULL;
+		$_540 = NULL;
 		do {
-			$res_521 = $result;
-			$pos_521 = $this->pos;
+			$res_537 = $result;
+			$pos_537 = $this->pos;
 			$matcher = 'match_'.'OldSprintfTag'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres );
-				$_524 = TRUE; break;
+				$_540 = TRUE; break;
 			}
-			$result = $res_521;
-			$this->pos = $pos_521;
+			$result = $res_537;
+			$this->pos = $pos_537;
 			$matcher = 'match_'.'OldTTag'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres );
-				$_524 = TRUE; break;
+				$_540 = TRUE; break;
 			}
-			$result = $res_521;
-			$this->pos = $pos_521;
-			$_524 = FALSE; break;
+			$result = $res_537;
+			$this->pos = $pos_537;
+			$_540 = FALSE; break;
 		}
 		while(0);
-		if( $_524 === TRUE ) { return $this->finalise($result); }
-		if( $_524 === FALSE) { return FALSE; }
+		if( $_540 === TRUE ) { return $this->finalise($result); }
+		if( $_540 === FALSE) { return FALSE; }
 	}
 
 
@@ -3020,30 +3086,30 @@ class SSTemplateParser extends Parser {
 	protected $match_NamedArgument_typestack = array('NamedArgument');
 	function match_NamedArgument ($stack = array()) {
 		$matchrule = "NamedArgument"; $result = $this->construct($matchrule, $matchrule, null);
-		$_529 = NULL;
+		$_545 = NULL;
 		do {
 			$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "Name" );
 			}
-			else { $_529 = FALSE; break; }
+			else { $_545 = FALSE; break; }
 			if (substr($this->string,$this->pos,1) == '=') {
 				$this->pos += 1;
 				$result["text"] .= '=';
 			}
-			else { $_529 = FALSE; break; }
+			else { $_545 = FALSE; break; }
 			$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "Value" );
 			}
-			else { $_529 = FALSE; break; }
-			$_529 = TRUE; break;
+			else { $_545 = FALSE; break; }
+			$_545 = TRUE; break;
 		}
 		while(0);
-		if( $_529 === TRUE ) { return $this->finalise($result); }
-		if( $_529 === FALSE) { return FALSE; }
+		if( $_545 === TRUE ) { return $this->finalise($result); }
+		if( $_545 === FALSE) { return FALSE; }
 	}
 
 
@@ -3072,75 +3138,75 @@ class SSTemplateParser extends Parser {
 	protected $match_Include_typestack = array('Include');
 	function match_Include ($stack = array()) {
 		$matchrule = "Include"; $result = $this->construct($matchrule, $matchrule, null);
-		$_548 = NULL;
+		$_564 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_548 = FALSE; break; }
+			else { $_564 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( 'include' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_548 = FALSE; break; }
+			else { $_564 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "Template" );
 			}
-			else { $_548 = FALSE; break; }
+			else { $_564 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-			$res_545 = $result;
-			$pos_545 = $this->pos;
-			$_544 = NULL;
+			$res_561 = $result;
+			$pos_561 = $this->pos;
+			$_560 = NULL;
 			do {
 				$matcher = 'match_'.'NamedArgument'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 				if ($subres !== FALSE) { $this->store( $result, $subres ); }
-				else { $_544 = FALSE; break; }
+				else { $_560 = FALSE; break; }
 				while (true) {
-					$res_543 = $result;
-					$pos_543 = $this->pos;
-					$_542 = NULL;
+					$res_559 = $result;
+					$pos_559 = $this->pos;
+					$_558 = NULL;
 					do {
 						if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 						if (substr($this->string,$this->pos,1) == ',') {
 							$this->pos += 1;
 							$result["text"] .= ',';
 						}
-						else { $_542 = FALSE; break; }
+						else { $_558 = FALSE; break; }
 						if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 						$matcher = 'match_'.'NamedArgument'; $key = $matcher; $pos = $this->pos;
 						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 						if ($subres !== FALSE) {
 							$this->store( $result, $subres );
 						}
-						else { $_542 = FALSE; break; }
-						$_542 = TRUE; break;
+						else { $_558 = FALSE; break; }
+						$_558 = TRUE; break;
 					}
 					while(0);
-					if( $_542 === FALSE) {
-						$result = $res_543;
-						$this->pos = $pos_543;
-						unset( $res_543 );
-						unset( $pos_543 );
+					if( $_558 === FALSE) {
+						$result = $res_559;
+						$this->pos = $pos_559;
+						unset( $res_559 );
+						unset( $pos_559 );
 						break;
 					}
 				}
-				$_544 = TRUE; break;
+				$_560 = TRUE; break;
 			}
 			while(0);
-			if( $_544 === FALSE) {
-				$result = $res_545;
-				$this->pos = $pos_545;
-				unset( $res_545 );
-				unset( $pos_545 );
+			if( $_560 === FALSE) {
+				$result = $res_561;
+				$this->pos = $pos_561;
+				unset( $res_561 );
+				unset( $pos_561 );
 			}
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_548 = FALSE; break; }
-			$_548 = TRUE; break;
+			else { $_564 = FALSE; break; }
+			$_564 = TRUE; break;
 		}
 		while(0);
-		if( $_548 === TRUE ) { return $this->finalise($result); }
-		if( $_548 === FALSE) { return FALSE; }
+		if( $_564 === TRUE ) { return $this->finalise($result); }
+		if( $_564 === FALSE) { return FALSE; }
 	}
 
 
@@ -3176,48 +3242,48 @@ class SSTemplateParser extends Parser {
 	protected $match_BlockArguments_typestack = array('BlockArguments');
 	function match_BlockArguments ($stack = array()) {
 		$matchrule = "BlockArguments"; $result = $this->construct($matchrule, $matchrule, null);
-		$_557 = NULL;
+		$_573 = NULL;
 		do {
 			$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "Argument" );
 			}
-			else { $_557 = FALSE; break; }
+			else { $_573 = FALSE; break; }
 			while (true) {
-				$res_556 = $result;
-				$pos_556 = $this->pos;
-				$_555 = NULL;
+				$res_572 = $result;
+				$pos_572 = $this->pos;
+				$_571 = NULL;
 				do {
 					if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 					if (substr($this->string,$this->pos,1) == ',') {
 						$this->pos += 1;
 						$result["text"] .= ',';
 					}
-					else { $_555 = FALSE; break; }
+					else { $_571 = FALSE; break; }
 					if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 					$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 					if ($subres !== FALSE) {
 						$this->store( $result, $subres, "Argument" );
 					}
-					else { $_555 = FALSE; break; }
-					$_555 = TRUE; break;
+					else { $_571 = FALSE; break; }
+					$_571 = TRUE; break;
 				}
 				while(0);
-				if( $_555 === FALSE) {
-					$result = $res_556;
-					$this->pos = $pos_556;
-					unset( $res_556 );
-					unset( $pos_556 );
+				if( $_571 === FALSE) {
+					$result = $res_572;
+					$this->pos = $pos_572;
+					unset( $res_572 );
+					unset( $pos_572 );
 					break;
 				}
 			}
-			$_557 = TRUE; break;
+			$_573 = TRUE; break;
 		}
 		while(0);
-		if( $_557 === TRUE ) { return $this->finalise($result); }
-		if( $_557 === FALSE) { return FALSE; }
+		if( $_573 === TRUE ) { return $this->finalise($result); }
+		if( $_573 === FALSE) { return FALSE; }
 	}
 
 
@@ -3225,153 +3291,153 @@ class SSTemplateParser extends Parser {
 	protected $match_NotBlockTag_typestack = array('NotBlockTag');
 	function match_NotBlockTag ($stack = array()) {
 		$matchrule = "NotBlockTag"; $result = $this->construct($matchrule, $matchrule, null);
-		$_595 = NULL;
+		$_611 = NULL;
 		do {
-			$res_559 = $result;
-			$pos_559 = $this->pos;
+			$res_575 = $result;
+			$pos_575 = $this->pos;
 			if (( $subres = $this->literal( 'end_' ) ) !== FALSE) {
 				$result["text"] .= $subres;
-				$_595 = TRUE; break;
+				$_611 = TRUE; break;
 			}
-			$result = $res_559;
-			$this->pos = $pos_559;
-			$_593 = NULL;
+			$result = $res_575;
+			$this->pos = $pos_575;
+			$_609 = NULL;
 			do {
-				$_590 = NULL;
+				$_606 = NULL;
 				do {
-					$_588 = NULL;
+					$_604 = NULL;
 					do {
-						$res_561 = $result;
-						$pos_561 = $this->pos;
+						$res_577 = $result;
+						$pos_577 = $this->pos;
 						if (( $subres = $this->literal( 'if' ) ) !== FALSE) {
 							$result["text"] .= $subres;
-							$_588 = TRUE; break;
+							$_604 = TRUE; break;
 						}
-						$result = $res_561;
-						$this->pos = $pos_561;
-						$_586 = NULL;
+						$result = $res_577;
+						$this->pos = $pos_577;
+						$_602 = NULL;
 						do {
-							$res_563 = $result;
-							$pos_563 = $this->pos;
+							$res_579 = $result;
+							$pos_579 = $this->pos;
 							if (( $subres = $this->literal( 'else_if' ) ) !== FALSE) {
 								$result["text"] .= $subres;
-								$_586 = TRUE; break;
+								$_602 = TRUE; break;
 							}
-							$result = $res_563;
-							$this->pos = $pos_563;
-							$_584 = NULL;
+							$result = $res_579;
+							$this->pos = $pos_579;
+							$_600 = NULL;
 							do {
-								$res_565 = $result;
-								$pos_565 = $this->pos;
+								$res_581 = $result;
+								$pos_581 = $this->pos;
 								if (( $subres = $this->literal( 'else' ) ) !== FALSE) {
 									$result["text"] .= $subres;
-									$_584 = TRUE; break;
+									$_600 = TRUE; break;
 								}
-								$result = $res_565;
-								$this->pos = $pos_565;
-								$_582 = NULL;
+								$result = $res_581;
+								$this->pos = $pos_581;
+								$_598 = NULL;
 								do {
-									$res_567 = $result;
-									$pos_567 = $this->pos;
+									$res_583 = $result;
+									$pos_583 = $this->pos;
 									if (( $subres = $this->literal( 'require' ) ) !== FALSE) {
 										$result["text"] .= $subres;
-										$_582 = TRUE; break;
+										$_598 = TRUE; break;
 									}
-									$result = $res_567;
-									$this->pos = $pos_567;
-									$_580 = NULL;
+									$result = $res_583;
+									$this->pos = $pos_583;
+									$_596 = NULL;
 									do {
-										$res_569 = $result;
-										$pos_569 = $this->pos;
+										$res_585 = $result;
+										$pos_585 = $this->pos;
 										if (( $subres = $this->literal( 'cached' ) ) !== FALSE) {
 											$result["text"] .= $subres;
-											$_580 = TRUE; break;
+											$_596 = TRUE; break;
 										}
-										$result = $res_569;
-										$this->pos = $pos_569;
-										$_578 = NULL;
+										$result = $res_585;
+										$this->pos = $pos_585;
+										$_594 = NULL;
 										do {
-											$res_571 = $result;
-											$pos_571 = $this->pos;
+											$res_587 = $result;
+											$pos_587 = $this->pos;
 											if (( $subres = $this->literal( 'uncached' ) ) !== FALSE) {
 												$result["text"] .= $subres;
-												$_578 = TRUE; break;
+												$_594 = TRUE; break;
 											}
-											$result = $res_571;
-											$this->pos = $pos_571;
-											$_576 = NULL;
+											$result = $res_587;
+											$this->pos = $pos_587;
+											$_592 = NULL;
 											do {
-												$res_573 = $result;
-												$pos_573 = $this->pos;
+												$res_589 = $result;
+												$pos_589 = $this->pos;
 												if (( $subres = $this->literal( 'cacheblock' ) ) !== FALSE) {
 													$result["text"] .= $subres;
-													$_576 = TRUE; break;
+													$_592 = TRUE; break;
 												}
-												$result = $res_573;
-												$this->pos = $pos_573;
+												$result = $res_589;
+												$this->pos = $pos_589;
 												if (( $subres = $this->literal( 'include' ) ) !== FALSE) {
 													$result["text"] .= $subres;
-													$_576 = TRUE; break;
+													$_592 = TRUE; break;
 												}
-												$result = $res_573;
-												$this->pos = $pos_573;
-												$_576 = FALSE; break;
+												$result = $res_589;
+												$this->pos = $pos_589;
+												$_592 = FALSE; break;
 											}
 											while(0);
-											if( $_576 === TRUE ) { $_578 = TRUE; break; }
-											$result = $res_571;
-											$this->pos = $pos_571;
-											$_578 = FALSE; break;
+											if( $_592 === TRUE ) { $_594 = TRUE; break; }
+											$result = $res_587;
+											$this->pos = $pos_587;
+											$_594 = FALSE; break;
 										}
 										while(0);
-										if( $_578 === TRUE ) { $_580 = TRUE; break; }
-										$result = $res_569;
-										$this->pos = $pos_569;
-										$_580 = FALSE; break;
+										if( $_594 === TRUE ) { $_596 = TRUE; break; }
+										$result = $res_585;
+										$this->pos = $pos_585;
+										$_596 = FALSE; break;
 									}
 									while(0);
-									if( $_580 === TRUE ) { $_582 = TRUE; break; }
-									$result = $res_567;
-									$this->pos = $pos_567;
-									$_582 = FALSE; break;
+									if( $_596 === TRUE ) { $_598 = TRUE; break; }
+									$result = $res_583;
+									$this->pos = $pos_583;
+									$_598 = FALSE; break;
 								}
 								while(0);
-								if( $_582 === TRUE ) { $_584 = TRUE; break; }
-								$result = $res_565;
-								$this->pos = $pos_565;
-								$_584 = FALSE; break;
+								if( $_598 === TRUE ) { $_600 = TRUE; break; }
+								$result = $res_581;
+								$this->pos = $pos_581;
+								$_600 = FALSE; break;
 							}
 							while(0);
-							if( $_584 === TRUE ) { $_586 = TRUE; break; }
-							$result = $res_563;
-							$this->pos = $pos_563;
-							$_586 = FALSE; break;
+							if( $_600 === TRUE ) { $_602 = TRUE; break; }
+							$result = $res_579;
+							$this->pos = $pos_579;
+							$_602 = FALSE; break;
 						}
 						while(0);
-						if( $_586 === TRUE ) { $_588 = TRUE; break; }
-						$result = $res_561;
-						$this->pos = $pos_561;
-						$_588 = FALSE; break;
+						if( $_602 === TRUE ) { $_604 = TRUE; break; }
+						$result = $res_577;
+						$this->pos = $pos_577;
+						$_604 = FALSE; break;
 					}
 					while(0);
-					if( $_588 === FALSE) { $_590 = FALSE; break; }
-					$_590 = TRUE; break;
+					if( $_604 === FALSE) { $_606 = FALSE; break; }
+					$_606 = TRUE; break;
 				}
 				while(0);
-				if( $_590 === FALSE) { $_593 = FALSE; break; }
+				if( $_606 === FALSE) { $_609 = FALSE; break; }
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-				else { $_593 = FALSE; break; }
-				$_593 = TRUE; break;
+				else { $_609 = FALSE; break; }
+				$_609 = TRUE; break;
 			}
 			while(0);
-			if( $_593 === TRUE ) { $_595 = TRUE; break; }
-			$result = $res_559;
-			$this->pos = $pos_559;
-			$_595 = FALSE; break;
+			if( $_609 === TRUE ) { $_611 = TRUE; break; }
+			$result = $res_575;
+			$this->pos = $pos_575;
+			$_611 = FALSE; break;
 		}
 		while(0);
-		if( $_595 === TRUE ) { return $this->finalise($result); }
-		if( $_595 === FALSE) { return FALSE; }
+		if( $_611 === TRUE ) { return $this->finalise($result); }
+		if( $_611 === FALSE) { return FALSE; }
 	}
 
 
@@ -3380,53 +3446,53 @@ class SSTemplateParser extends Parser {
 	protected $match_ClosedBlock_typestack = array('ClosedBlock');
 	function match_ClosedBlock ($stack = array()) {
 		$matchrule = "ClosedBlock"; $result = $this->construct($matchrule, $matchrule, null);
-		$_615 = NULL;
+		$_631 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_615 = FALSE; break; }
+			else { $_631 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-			$res_599 = $result;
-			$pos_599 = $this->pos;
+			$res_615 = $result;
+			$pos_615 = $this->pos;
 			$matcher = 'match_'.'NotBlockTag'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres );
-				$result = $res_599;
-				$this->pos = $pos_599;
-				$_615 = FALSE; break;
+				$result = $res_615;
+				$this->pos = $pos_615;
+				$_631 = FALSE; break;
 			}
 			else {
-				$result = $res_599;
-				$this->pos = $pos_599;
+				$result = $res_615;
+				$this->pos = $pos_615;
 			}
 			$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "BlockName" );
 			}
-			else { $_615 = FALSE; break; }
-			$res_605 = $result;
-			$pos_605 = $this->pos;
-			$_604 = NULL;
+			else { $_631 = FALSE; break; }
+			$res_621 = $result;
+			$pos_621 = $this->pos;
+			$_620 = NULL;
 			do {
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-				else { $_604 = FALSE; break; }
+				else { $_620 = FALSE; break; }
 				$matcher = 'match_'.'BlockArguments'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 				if ($subres !== FALSE) {
 					$this->store( $result, $subres, "BlockArguments" );
 				}
-				else { $_604 = FALSE; break; }
+				else { $_620 = FALSE; break; }
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-				else { $_604 = FALSE; break; }
-				$_604 = TRUE; break;
+				else { $_620 = FALSE; break; }
+				$_620 = TRUE; break;
 			}
 			while(0);
-			if( $_604 === FALSE) {
-				$result = $res_605;
-				$this->pos = $pos_605;
-				unset( $res_605 );
-				unset( $pos_605 );
+			if( $_620 === FALSE) {
+				$result = $res_621;
+				$this->pos = $pos_621;
+				unset( $res_621 );
+				unset( $pos_621 );
 			}
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			$stack[] = $result; $result = $this->construct( $matchrule, "Zap" ); 
@@ -3437,36 +3503,36 @@ class SSTemplateParser extends Parser {
 			}
 			else {
 				$result = array_pop($stack);
-				$_615 = FALSE; break;
+				$_631 = FALSE; break;
 			}
-			$res_608 = $result;
-			$pos_608 = $this->pos;
+			$res_624 = $result;
+			$pos_624 = $this->pos;
 			$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "Template" );
 			}
 			else {
-				$result = $res_608;
-				$this->pos = $pos_608;
-				unset( $res_608 );
-				unset( $pos_608 );
+				$result = $res_624;
+				$this->pos = $pos_624;
+				unset( $res_624 );
+				unset( $pos_624 );
 			}
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_615 = FALSE; break; }
+			else { $_631 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( 'end_' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_615 = FALSE; break; }
+			else { $_631 = FALSE; break; }
 			if (( $subres = $this->literal( ''.$this->expression($result, $stack, 'BlockName').'' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_615 = FALSE; break; }
+			else { $_631 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_615 = FALSE; break; }
-			$_615 = TRUE; break;
+			else { $_631 = FALSE; break; }
+			$_631 = TRUE; break;
 		}
 		while(0);
-		if( $_615 === TRUE ) { return $this->finalise($result); }
-		if( $_615 === FALSE) { return FALSE; }
+		if( $_631 === TRUE ) { return $this->finalise($result); }
+		if( $_631 === FALSE) { return FALSE; }
 	}
 
 
@@ -3573,62 +3639,62 @@ class SSTemplateParser extends Parser {
 	protected $match_OpenBlock_typestack = array('OpenBlock');
 	function match_OpenBlock ($stack = array()) {
 		$matchrule = "OpenBlock"; $result = $this->construct($matchrule, $matchrule, null);
-		$_628 = NULL;
+		$_644 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_628 = FALSE; break; }
+			else { $_644 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-			$res_619 = $result;
-			$pos_619 = $this->pos;
+			$res_635 = $result;
+			$pos_635 = $this->pos;
 			$matcher = 'match_'.'NotBlockTag'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres );
-				$result = $res_619;
-				$this->pos = $pos_619;
-				$_628 = FALSE; break;
+				$result = $res_635;
+				$this->pos = $pos_635;
+				$_644 = FALSE; break;
 			}
 			else {
-				$result = $res_619;
-				$this->pos = $pos_619;
+				$result = $res_635;
+				$this->pos = $pos_635;
 			}
 			$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "BlockName" );
 			}
-			else { $_628 = FALSE; break; }
-			$res_625 = $result;
-			$pos_625 = $this->pos;
-			$_624 = NULL;
+			else { $_644 = FALSE; break; }
+			$res_641 = $result;
+			$pos_641 = $this->pos;
+			$_640 = NULL;
 			do {
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-				else { $_624 = FALSE; break; }
+				else { $_640 = FALSE; break; }
 				$matcher = 'match_'.'BlockArguments'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 				if ($subres !== FALSE) {
 					$this->store( $result, $subres, "BlockArguments" );
 				}
-				else { $_624 = FALSE; break; }
+				else { $_640 = FALSE; break; }
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-				else { $_624 = FALSE; break; }
-				$_624 = TRUE; break;
+				else { $_640 = FALSE; break; }
+				$_640 = TRUE; break;
 			}
 			while(0);
-			if( $_624 === FALSE) {
-				$result = $res_625;
-				$this->pos = $pos_625;
-				unset( $res_625 );
-				unset( $pos_625 );
+			if( $_640 === FALSE) {
+				$result = $res_641;
+				$this->pos = $pos_641;
+				unset( $res_641 );
+				unset( $pos_641 );
 			}
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_628 = FALSE; break; }
-			$_628 = TRUE; break;
+			else { $_644 = FALSE; break; }
+			$_644 = TRUE; break;
 		}
 		while(0);
-		if( $_628 === TRUE ) { return $this->finalise($result); }
-		if( $_628 === FALSE) { return FALSE; }
+		if( $_644 === TRUE ) { return $this->finalise($result); }
+		if( $_644 === FALSE) { return FALSE; }
 	}
 
 
@@ -3697,27 +3763,27 @@ class SSTemplateParser extends Parser {
 	protected $match_MismatchedEndBlock_typestack = array('MismatchedEndBlock');
 	function match_MismatchedEndBlock ($stack = array()) {
 		$matchrule = "MismatchedEndBlock"; $result = $this->construct($matchrule, $matchrule, null);
-		$_636 = NULL;
+		$_652 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_636 = FALSE; break; }
+			else { $_652 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( 'end_' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_636 = FALSE; break; }
+			else { $_652 = FALSE; break; }
 			$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "Word" );
 			}
-			else { $_636 = FALSE; break; }
+			else { $_652 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_636 = FALSE; break; }
-			$_636 = TRUE; break;
+			else { $_652 = FALSE; break; }
+			$_652 = TRUE; break;
 		}
 		while(0);
-		if( $_636 === TRUE ) { return $this->finalise($result); }
-		if( $_636 === FALSE) { return FALSE; }
+		if( $_652 === TRUE ) { return $this->finalise($result); }
+		if( $_652 === FALSE) { return FALSE; }
 	}
 
 
@@ -3732,78 +3798,78 @@ class SSTemplateParser extends Parser {
 	protected $match_MalformedOpenTag_typestack = array('MalformedOpenTag');
 	function match_MalformedOpenTag ($stack = array()) {
 		$matchrule = "MalformedOpenTag"; $result = $this->construct($matchrule, $matchrule, null);
-		$_651 = NULL;
+		$_667 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_651 = FALSE; break; }
+			else { $_667 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-			$res_640 = $result;
-			$pos_640 = $this->pos;
+			$res_656 = $result;
+			$pos_656 = $this->pos;
 			$matcher = 'match_'.'NotBlockTag'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres );
-				$result = $res_640;
-				$this->pos = $pos_640;
-				$_651 = FALSE; break;
+				$result = $res_656;
+				$this->pos = $pos_656;
+				$_667 = FALSE; break;
 			}
 			else {
-				$result = $res_640;
-				$this->pos = $pos_640;
+				$result = $res_656;
+				$this->pos = $pos_656;
 			}
 			$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "Tag" );
 			}
-			else { $_651 = FALSE; break; }
-			$res_650 = $result;
-			$pos_650 = $this->pos;
-			$_649 = NULL;
+			else { $_667 = FALSE; break; }
+			$res_666 = $result;
+			$pos_666 = $this->pos;
+			$_665 = NULL;
 			do {
-				$res_646 = $result;
-				$pos_646 = $this->pos;
-				$_645 = NULL;
+				$res_662 = $result;
+				$pos_662 = $this->pos;
+				$_661 = NULL;
 				do {
 					if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-					else { $_645 = FALSE; break; }
+					else { $_661 = FALSE; break; }
 					$matcher = 'match_'.'BlockArguments'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 					if ($subres !== FALSE) {
 						$this->store( $result, $subres, "BlockArguments" );
 					}
-					else { $_645 = FALSE; break; }
+					else { $_661 = FALSE; break; }
 					if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-					else { $_645 = FALSE; break; }
-					$_645 = TRUE; break;
+					else { $_661 = FALSE; break; }
+					$_661 = TRUE; break;
 				}
 				while(0);
-				if( $_645 === FALSE) {
-					$result = $res_646;
-					$this->pos = $pos_646;
-					unset( $res_646 );
-					unset( $pos_646 );
+				if( $_661 === FALSE) {
+					$result = $res_662;
+					$this->pos = $pos_662;
+					unset( $res_662 );
+					unset( $pos_662 );
 				}
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 				if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-				else { $_649 = FALSE; break; }
-				$_649 = TRUE; break;
+				else { $_665 = FALSE; break; }
+				$_665 = TRUE; break;
 			}
 			while(0);
-			if( $_649 === TRUE ) {
-				$result = $res_650;
-				$this->pos = $pos_650;
-				$_651 = FALSE; break;
+			if( $_665 === TRUE ) {
+				$result = $res_666;
+				$this->pos = $pos_666;
+				$_667 = FALSE; break;
 			}
-			if( $_649 === FALSE) {
-				$result = $res_650;
-				$this->pos = $pos_650;
+			if( $_665 === FALSE) {
+				$result = $res_666;
+				$this->pos = $pos_666;
 			}
-			$_651 = TRUE; break;
+			$_667 = TRUE; break;
 		}
 		while(0);
-		if( $_651 === TRUE ) { return $this->finalise($result); }
-		if( $_651 === FALSE) { return FALSE; }
+		if( $_667 === TRUE ) { return $this->finalise($result); }
+		if( $_667 === FALSE) { return FALSE; }
 	}
 
 
@@ -3818,57 +3884,57 @@ class SSTemplateParser extends Parser {
 	protected $match_MalformedCloseTag_typestack = array('MalformedCloseTag');
 	function match_MalformedCloseTag ($stack = array()) {
 		$matchrule = "MalformedCloseTag"; $result = $this->construct($matchrule, $matchrule, null);
-		$_663 = NULL;
+		$_679 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_663 = FALSE; break; }
+			else { $_679 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			$stack[] = $result; $result = $this->construct( $matchrule, "Tag" ); 
-			$_657 = NULL;
+			$_673 = NULL;
 			do {
 				if (( $subres = $this->literal( 'end_' ) ) !== FALSE) { $result["text"] .= $subres; }
-				else { $_657 = FALSE; break; }
+				else { $_673 = FALSE; break; }
 				$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
 				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 				if ($subres !== FALSE) {
 					$this->store( $result, $subres, "Word" );
 				}
-				else { $_657 = FALSE; break; }
-				$_657 = TRUE; break;
+				else { $_673 = FALSE; break; }
+				$_673 = TRUE; break;
 			}
 			while(0);
-			if( $_657 === TRUE ) {
+			if( $_673 === TRUE ) {
 				$subres = $result; $result = array_pop($stack);
 				$this->store( $result, $subres, 'Tag' );
 			}
-			if( $_657 === FALSE) {
+			if( $_673 === FALSE) {
 				$result = array_pop($stack);
-				$_663 = FALSE; break;
+				$_679 = FALSE; break;
 			}
-			$res_662 = $result;
-			$pos_662 = $this->pos;
-			$_661 = NULL;
+			$res_678 = $result;
+			$pos_678 = $this->pos;
+			$_677 = NULL;
 			do {
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 				if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-				else { $_661 = FALSE; break; }
-				$_661 = TRUE; break;
+				else { $_677 = FALSE; break; }
+				$_677 = TRUE; break;
 			}
 			while(0);
-			if( $_661 === TRUE ) {
-				$result = $res_662;
-				$this->pos = $pos_662;
-				$_663 = FALSE; break;
+			if( $_677 === TRUE ) {
+				$result = $res_678;
+				$this->pos = $pos_678;
+				$_679 = FALSE; break;
 			}
-			if( $_661 === FALSE) {
-				$result = $res_662;
-				$this->pos = $pos_662;
+			if( $_677 === FALSE) {
+				$result = $res_678;
+				$this->pos = $pos_678;
 			}
-			$_663 = TRUE; break;
+			$_679 = TRUE; break;
 		}
 		while(0);
-		if( $_663 === TRUE ) { return $this->finalise($result); }
-		if( $_663 === FALSE) { return FALSE; }
+		if( $_679 === TRUE ) { return $this->finalise($result); }
+		if( $_679 === FALSE) { return FALSE; }
 	}
 
 
@@ -3883,31 +3949,31 @@ class SSTemplateParser extends Parser {
 	protected $match_MalformedBlock_typestack = array('MalformedBlock');
 	function match_MalformedBlock ($stack = array()) {
 		$matchrule = "MalformedBlock"; $result = $this->construct($matchrule, $matchrule, null);
-		$_668 = NULL;
+		$_684 = NULL;
 		do {
-			$res_665 = $result;
-			$pos_665 = $this->pos;
+			$res_681 = $result;
+			$pos_681 = $this->pos;
 			$matcher = 'match_'.'MalformedOpenTag'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres );
-				$_668 = TRUE; break;
+				$_684 = TRUE; break;
 			}
-			$result = $res_665;
-			$this->pos = $pos_665;
+			$result = $res_681;
+			$this->pos = $pos_681;
 			$matcher = 'match_'.'MalformedCloseTag'; $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres );
-				$_668 = TRUE; break;
+				$_684 = TRUE; break;
 			}
-			$result = $res_665;
-			$this->pos = $pos_665;
-			$_668 = FALSE; break;
+			$result = $res_681;
+			$this->pos = $pos_681;
+			$_684 = FALSE; break;
 		}
 		while(0);
-		if( $_668 === TRUE ) { return $this->finalise($result); }
-		if( $_668 === FALSE) { return FALSE; }
+		if( $_684 === TRUE ) { return $this->finalise($result); }
+		if( $_684 === FALSE) { return FALSE; }
 	}
 
 
@@ -3917,51 +3983,51 @@ class SSTemplateParser extends Parser {
 	protected $match_Comment_typestack = array('Comment');
 	function match_Comment ($stack = array()) {
 		$matchrule = "Comment"; $result = $this->construct($matchrule, $matchrule, null);
-		$_676 = NULL;
+		$_692 = NULL;
 		do {
 			if (( $subres = $this->literal( '<%--' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_676 = FALSE; break; }
+			else { $_692 = FALSE; break; }
 			$count = 0;
 			while (true) {
-				$res_674 = $result;
-				$pos_674 = $this->pos;
-				$_673 = NULL;
+				$res_690 = $result;
+				$pos_690 = $this->pos;
+				$_689 = NULL;
 				do {
-					$res_671 = $result;
-					$pos_671 = $this->pos;
+					$res_687 = $result;
+					$pos_687 = $this->pos;
 					if (( $subres = $this->literal( '--%>' ) ) !== FALSE) {
 						$result["text"] .= $subres;
-						$result = $res_671;
-						$this->pos = $pos_671;
-						$_673 = FALSE; break;
+						$result = $res_687;
+						$this->pos = $pos_687;
+						$_689 = FALSE; break;
 					}
 					else {
-						$result = $res_671;
-						$this->pos = $pos_671;
+						$result = $res_687;
+						$this->pos = $pos_687;
 					}
 					if (( $subres = $this->rx( '/(?s)./' ) ) !== FALSE) { $result["text"] .= $subres; }
-					else { $_673 = FALSE; break; }
-					$_673 = TRUE; break;
+					else { $_689 = FALSE; break; }
+					$_689 = TRUE; break;
 				}
 				while(0);
-				if( $_673 === FALSE) {
-					$result = $res_674;
-					$this->pos = $pos_674;
-					unset( $res_674 );
-					unset( $pos_674 );
+				if( $_689 === FALSE) {
+					$result = $res_690;
+					$this->pos = $pos_690;
+					unset( $res_690 );
+					unset( $pos_690 );
 					break;
 				}
 				$count += 1;
 			}
 			if ($count > 0) {  }
-			else { $_676 = FALSE; break; }
+			else { $_692 = FALSE; break; }
 			if (( $subres = $this->literal( '--%>' ) ) !== FALSE) { $result["text"] .= $subres; }
-			else { $_676 = FALSE; break; }
-			$_676 = TRUE; break;
+			else { $_692 = FALSE; break; }
+			$_692 = TRUE; break;
 		}
 		while(0);
-		if( $_676 === TRUE ) { return $this->finalise($result); }
-		if( $_676 === FALSE) { return FALSE; }
+		if( $_692 === TRUE ) { return $this->finalise($result); }
+		if( $_692 === FALSE) { return FALSE; }
 	}
 
 
@@ -3977,258 +4043,258 @@ class SSTemplateParser extends Parser {
 		$matchrule = "TopTemplate"; $result = $this->construct($matchrule, $matchrule, array('TemplateMatcher' => 'Template'));
 		$count = 0;
 		while (true) {
-			$res_732 = $result;
-			$pos_732 = $this->pos;
-			$_731 = NULL;
+			$res_748 = $result;
+			$pos_748 = $this->pos;
+			$_747 = NULL;
 			do {
-				$_729 = NULL;
+				$_745 = NULL;
 				do {
-					$res_678 = $result;
-					$pos_678 = $this->pos;
+					$res_694 = $result;
+					$pos_694 = $this->pos;
 					$matcher = 'match_'.'Comment'; $key = $matcher; $pos = $this->pos;
 					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 					if ($subres !== FALSE) {
 						$this->store( $result, $subres );
-						$_729 = TRUE; break;
+						$_745 = TRUE; break;
 					}
-					$result = $res_678;
-					$this->pos = $pos_678;
-					$_727 = NULL;
+					$result = $res_694;
+					$this->pos = $pos_694;
+					$_743 = NULL;
 					do {
-						$res_680 = $result;
-						$pos_680 = $this->pos;
+						$res_696 = $result;
+						$pos_696 = $this->pos;
 						$matcher = 'match_'.'Translate'; $key = $matcher; $pos = $this->pos;
 						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 						if ($subres !== FALSE) {
 							$this->store( $result, $subres );
-							$_727 = TRUE; break;
+							$_743 = TRUE; break;
 						}
-						$result = $res_680;
-						$this->pos = $pos_680;
-						$_725 = NULL;
+						$result = $res_696;
+						$this->pos = $pos_696;
+						$_741 = NULL;
 						do {
-							$res_682 = $result;
-							$pos_682 = $this->pos;
+							$res_698 = $result;
+							$pos_698 = $this->pos;
 							$matcher = 'match_'.'If'; $key = $matcher; $pos = $this->pos;
 							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 							if ($subres !== FALSE) {
 								$this->store( $result, $subres );
-								$_725 = TRUE; break;
+								$_741 = TRUE; break;
 							}
-							$result = $res_682;
-							$this->pos = $pos_682;
-							$_723 = NULL;
+							$result = $res_698;
+							$this->pos = $pos_698;
+							$_739 = NULL;
 							do {
-								$res_684 = $result;
-								$pos_684 = $this->pos;
+								$res_700 = $result;
+								$pos_700 = $this->pos;
 								$matcher = 'match_'.'Require'; $key = $matcher; $pos = $this->pos;
 								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 								if ($subres !== FALSE) {
 									$this->store( $result, $subres );
-									$_723 = TRUE; break;
+									$_739 = TRUE; break;
 								}
-								$result = $res_684;
-								$this->pos = $pos_684;
-								$_721 = NULL;
+								$result = $res_700;
+								$this->pos = $pos_700;
+								$_737 = NULL;
 								do {
-									$res_686 = $result;
-									$pos_686 = $this->pos;
+									$res_702 = $result;
+									$pos_702 = $this->pos;
 									$matcher = 'match_'.'CacheBlock'; $key = $matcher; $pos = $this->pos;
 									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 									if ($subres !== FALSE) {
 										$this->store( $result, $subres );
-										$_721 = TRUE; break;
+										$_737 = TRUE; break;
 									}
-									$result = $res_686;
-									$this->pos = $pos_686;
-									$_719 = NULL;
+									$result = $res_702;
+									$this->pos = $pos_702;
+									$_735 = NULL;
 									do {
-										$res_688 = $result;
-										$pos_688 = $this->pos;
+										$res_704 = $result;
+										$pos_704 = $this->pos;
 										$matcher = 'match_'.'UncachedBlock'; $key = $matcher; $pos = $this->pos;
 										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 										if ($subres !== FALSE) {
 											$this->store( $result, $subres );
-											$_719 = TRUE; break;
+											$_735 = TRUE; break;
 										}
-										$result = $res_688;
-										$this->pos = $pos_688;
-										$_717 = NULL;
+										$result = $res_704;
+										$this->pos = $pos_704;
+										$_733 = NULL;
 										do {
-											$res_690 = $result;
-											$pos_690 = $this->pos;
+											$res_706 = $result;
+											$pos_706 = $this->pos;
 											$matcher = 'match_'.'OldI18NTag'; $key = $matcher; $pos = $this->pos;
 											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 											if ($subres !== FALSE) {
 												$this->store( $result, $subres );
-												$_717 = TRUE; break;
+												$_733 = TRUE; break;
 											}
-											$result = $res_690;
-											$this->pos = $pos_690;
-											$_715 = NULL;
+											$result = $res_706;
+											$this->pos = $pos_706;
+											$_731 = NULL;
 											do {
-												$res_692 = $result;
-												$pos_692 = $this->pos;
+												$res_708 = $result;
+												$pos_708 = $this->pos;
 												$matcher = 'match_'.'Include'; $key = $matcher; $pos = $this->pos;
 												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 												if ($subres !== FALSE) {
 													$this->store( $result, $subres );
-													$_715 = TRUE; break;
+													$_731 = TRUE; break;
 												}
-												$result = $res_692;
-												$this->pos = $pos_692;
-												$_713 = NULL;
+												$result = $res_708;
+												$this->pos = $pos_708;
+												$_729 = NULL;
 												do {
-													$res_694 = $result;
-													$pos_694 = $this->pos;
+													$res_710 = $result;
+													$pos_710 = $this->pos;
 													$matcher = 'match_'.'ClosedBlock'; $key = $matcher; $pos = $this->pos;
 													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 													if ($subres !== FALSE) {
 														$this->store( $result, $subres );
-														$_713 = TRUE; break;
+														$_729 = TRUE; break;
 													}
-													$result = $res_694;
-													$this->pos = $pos_694;
-													$_711 = NULL;
+													$result = $res_710;
+													$this->pos = $pos_710;
+													$_727 = NULL;
 													do {
-														$res_696 = $result;
-														$pos_696 = $this->pos;
+														$res_712 = $result;
+														$pos_712 = $this->pos;
 														$matcher = 'match_'.'OpenBlock'; $key = $matcher; $pos = $this->pos;
 														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 														if ($subres !== FALSE) {
 															$this->store( $result, $subres );
-															$_711 = TRUE; break;
+															$_727 = TRUE; break;
 														}
-														$result = $res_696;
-														$this->pos = $pos_696;
-														$_709 = NULL;
+														$result = $res_712;
+														$this->pos = $pos_712;
+														$_725 = NULL;
 														do {
-															$res_698 = $result;
-															$pos_698 = $this->pos;
+															$res_714 = $result;
+															$pos_714 = $this->pos;
 															$matcher = 'match_'.'MalformedBlock'; $key = $matcher; $pos = $this->pos;
 															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 															if ($subres !== FALSE) {
 																$this->store( $result, $subres );
-																$_709 = TRUE; break;
+																$_725 = TRUE; break;
 															}
-															$result = $res_698;
-															$this->pos = $pos_698;
-															$_707 = NULL;
+															$result = $res_714;
+															$this->pos = $pos_714;
+															$_723 = NULL;
 															do {
-																$res_700 = $result;
-																$pos_700 = $this->pos;
+																$res_716 = $result;
+																$pos_716 = $this->pos;
 																$matcher = 'match_'.'MismatchedEndBlock'; $key = $matcher; $pos = $this->pos;
 																$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 																if ($subres !== FALSE) {
 																	$this->store( $result, $subres );
-																	$_707 = TRUE; break;
+																	$_723 = TRUE; break;
 																}
-																$result = $res_700;
-																$this->pos = $pos_700;
-																$_705 = NULL;
+																$result = $res_716;
+																$this->pos = $pos_716;
+																$_721 = NULL;
 																do {
-																	$res_702 = $result;
-																	$pos_702 = $this->pos;
+																	$res_718 = $result;
+																	$pos_718 = $this->pos;
 																	$matcher = 'match_'.'Injection'; $key = $matcher; $pos = $this->pos;
 																	$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 																	if ($subres !== FALSE) {
 																		$this->store( $result, $subres );
-																		$_705 = TRUE; break;
+																		$_721 = TRUE; break;
 																	}
-																	$result = $res_702;
-																	$this->pos = $pos_702;
+																	$result = $res_718;
+																	$this->pos = $pos_718;
 																	$matcher = 'match_'.'Text'; $key = $matcher; $pos = $this->pos;
 																	$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 																	if ($subres !== FALSE) {
 																		$this->store( $result, $subres );
-																		$_705 = TRUE; break;
+																		$_721 = TRUE; break;
 																	}
-																	$result = $res_702;
-																	$this->pos = $pos_702;
-																	$_705 = FALSE; break;
+																	$result = $res_718;
+																	$this->pos = $pos_718;
+																	$_721 = FALSE; break;
 																}
 																while(0);
-																if( $_705 === TRUE ) { $_707 = TRUE; break; }
-																$result = $res_700;
-																$this->pos = $pos_700;
-																$_707 = FALSE; break;
+																if( $_721 === TRUE ) { $_723 = TRUE; break; }
+																$result = $res_716;
+																$this->pos = $pos_716;
+																$_723 = FALSE; break;
 															}
 															while(0);
-															if( $_707 === TRUE ) { $_709 = TRUE; break; }
-															$result = $res_698;
-															$this->pos = $pos_698;
-															$_709 = FALSE; break;
+															if( $_723 === TRUE ) { $_725 = TRUE; break; }
+															$result = $res_714;
+															$this->pos = $pos_714;
+															$_725 = FALSE; break;
 														}
 														while(0);
-														if( $_709 === TRUE ) { $_711 = TRUE; break; }
-														$result = $res_696;
-														$this->pos = $pos_696;
-														$_711 = FALSE; break;
+														if( $_725 === TRUE ) { $_727 = TRUE; break; }
+														$result = $res_712;
+														$this->pos = $pos_712;
+														$_727 = FALSE; break;
 													}
 													while(0);
-													if( $_711 === TRUE ) { $_713 = TRUE; break; }
-													$result = $res_694;
-													$this->pos = $pos_694;
-													$_713 = FALSE; break;
+													if( $_727 === TRUE ) { $_729 = TRUE; break; }
+													$result = $res_710;
+													$this->pos = $pos_710;
+													$_729 = FALSE; break;
 												}
 												while(0);
-												if( $_713 === TRUE ) { $_715 = TRUE; break; }
-												$result = $res_692;
-												$this->pos = $pos_692;
-												$_715 = FALSE; break;
+												if( $_729 === TRUE ) { $_731 = TRUE; break; }
+												$result = $res_708;
+												$this->pos = $pos_708;
+												$_731 = FALSE; break;
 											}
 											while(0);
-											if( $_715 === TRUE ) { $_717 = TRUE; break; }
-											$result = $res_690;
-											$this->pos = $pos_690;
-											$_717 = FALSE; break;
+											if( $_731 === TRUE ) { $_733 = TRUE; break; }
+											$result = $res_706;
+											$this->pos = $pos_706;
+											$_733 = FALSE; break;
 										}
 										while(0);
-										if( $_717 === TRUE ) { $_719 = TRUE; break; }
-										$result = $res_688;
-										$this->pos = $pos_688;
-										$_719 = FALSE; break;
+										if( $_733 === TRUE ) { $_735 = TRUE; break; }
+										$result = $res_704;
+										$this->pos = $pos_704;
+										$_735 = FALSE; break;
 									}
 									while(0);
-									if( $_719 === TRUE ) { $_721 = TRUE; break; }
-									$result = $res_686;
-									$this->pos = $pos_686;
-									$_721 = FALSE; break;
+									if( $_735 === TRUE ) { $_737 = TRUE; break; }
+									$result = $res_702;
+									$this->pos = $pos_702;
+									$_737 = FALSE; break;
 								}
 								while(0);
-								if( $_721 === TRUE ) { $_723 = TRUE; break; }
-								$result = $res_684;
-								$this->pos = $pos_684;
-								$_723 = FALSE; break;
+								if( $_737 === TRUE ) { $_739 = TRUE; break; }
+								$result = $res_700;
+								$this->pos = $pos_700;
+								$_739 = FALSE; break;
 							}
 							while(0);
-							if( $_723 === TRUE ) { $_725 = TRUE; break; }
-							$result = $res_682;
-							$this->pos = $pos_682;
-							$_725 = FALSE; break;
+							if( $_739 === TRUE ) { $_741 = TRUE; break; }
+							$result = $res_698;
+							$this->pos = $pos_698;
+							$_741 = FALSE; break;
 						}
 						while(0);
-						if( $_725 === TRUE ) { $_727 = TRUE; break; }
-						$result = $res_680;
-						$this->pos = $pos_680;
-						$_727 = FALSE; break;
+						if( $_741 === TRUE ) { $_743 = TRUE; break; }
+						$result = $res_696;
+						$this->pos = $pos_696;
+						$_743 = FALSE; break;
 					}
 					while(0);
-					if( $_727 === TRUE ) { $_729 = TRUE; break; }
-					$result = $res_678;
-					$this->pos = $pos_678;
-					$_729 = FALSE; break;
+					if( $_743 === TRUE ) { $_745 = TRUE; break; }
+					$result = $res_694;
+					$this->pos = $pos_694;
+					$_745 = FALSE; break;
 				}
 				while(0);
-				if( $_729 === FALSE) { $_731 = FALSE; break; }
-				$_731 = TRUE; break;
+				if( $_745 === FALSE) { $_747 = FALSE; break; }
+				$_747 = TRUE; break;
 			}
 			while(0);
-			if( $_731 === FALSE) {
-				$result = $res_732;
-				$this->pos = $pos_732;
-				unset( $res_732 );
-				unset( $pos_732 );
+			if( $_747 === FALSE) {
+				$result = $res_748;
+				$this->pos = $pos_748;
+				unset( $res_748 );
+				unset( $pos_748 );
 				break;
 			}
 			$count += 1;
@@ -4260,189 +4326,189 @@ class SSTemplateParser extends Parser {
 		$matchrule = "Text"; $result = $this->construct($matchrule, $matchrule, null);
 		$count = 0;
 		while (true) {
-			$res_771 = $result;
-			$pos_771 = $this->pos;
-			$_770 = NULL;
+			$res_787 = $result;
+			$pos_787 = $this->pos;
+			$_786 = NULL;
 			do {
-				$_768 = NULL;
+				$_784 = NULL;
 				do {
-					$res_733 = $result;
-					$pos_733 = $this->pos;
+					$res_749 = $result;
+					$pos_749 = $this->pos;
 					if (( $subres = $this->rx( '/ [^<${\\\\]+ /' ) ) !== FALSE) {
 						$result["text"] .= $subres;
-						$_768 = TRUE; break;
+						$_784 = TRUE; break;
 					}
-					$result = $res_733;
-					$this->pos = $pos_733;
-					$_766 = NULL;
+					$result = $res_749;
+					$this->pos = $pos_749;
+					$_782 = NULL;
 					do {
-						$res_735 = $result;
-						$pos_735 = $this->pos;
+						$res_751 = $result;
+						$pos_751 = $this->pos;
 						if (( $subres = $this->rx( '/ (\\\\.) /' ) ) !== FALSE) {
 							$result["text"] .= $subres;
-							$_766 = TRUE; break;
+							$_782 = TRUE; break;
 						}
-						$result = $res_735;
-						$this->pos = $pos_735;
-						$_764 = NULL;
+						$result = $res_751;
+						$this->pos = $pos_751;
+						$_780 = NULL;
 						do {
-							$res_737 = $result;
-							$pos_737 = $this->pos;
-							$_740 = NULL;
+							$res_753 = $result;
+							$pos_753 = $this->pos;
+							$_756 = NULL;
 							do {
 								if (substr($this->string,$this->pos,1) == '<') {
 									$this->pos += 1;
 									$result["text"] .= '<';
 								}
-								else { $_740 = FALSE; break; }
-								$res_739 = $result;
-								$pos_739 = $this->pos;
+								else { $_756 = FALSE; break; }
+								$res_755 = $result;
+								$pos_755 = $this->pos;
 								if (substr($this->string,$this->pos,1) == '%') {
 									$this->pos += 1;
 									$result["text"] .= '%';
-									$result = $res_739;
-									$this->pos = $pos_739;
-									$_740 = FALSE; break;
+									$result = $res_755;
+									$this->pos = $pos_755;
+									$_756 = FALSE; break;
 								}
 								else {
-									$result = $res_739;
-									$this->pos = $pos_739;
+									$result = $res_755;
+									$this->pos = $pos_755;
 								}
-								$_740 = TRUE; break;
+								$_756 = TRUE; break;
 							}
 							while(0);
-							if( $_740 === TRUE ) { $_764 = TRUE; break; }
-							$result = $res_737;
-							$this->pos = $pos_737;
-							$_762 = NULL;
+							if( $_756 === TRUE ) { $_780 = TRUE; break; }
+							$result = $res_753;
+							$this->pos = $pos_753;
+							$_778 = NULL;
 							do {
-								$res_742 = $result;
-								$pos_742 = $this->pos;
-								$_747 = NULL;
+								$res_758 = $result;
+								$pos_758 = $this->pos;
+								$_763 = NULL;
 								do {
 									if (substr($this->string,$this->pos,1) == '$') {
 										$this->pos += 1;
 										$result["text"] .= '$';
 									}
-									else { $_747 = FALSE; break; }
-									$res_746 = $result;
-									$pos_746 = $this->pos;
-									$_745 = NULL;
+									else { $_763 = FALSE; break; }
+									$res_762 = $result;
+									$pos_762 = $this->pos;
+									$_761 = NULL;
 									do {
 										if (( $subres = $this->rx( '/[A-Za-z_]/' ) ) !== FALSE) { $result["text"] .= $subres; }
-										else { $_745 = FALSE; break; }
-										$_745 = TRUE; break;
+										else { $_761 = FALSE; break; }
+										$_761 = TRUE; break;
 									}
 									while(0);
-									if( $_745 === TRUE ) {
-										$result = $res_746;
-										$this->pos = $pos_746;
-										$_747 = FALSE; break;
+									if( $_761 === TRUE ) {
+										$result = $res_762;
+										$this->pos = $pos_762;
+										$_763 = FALSE; break;
 									}
-									if( $_745 === FALSE) {
-										$result = $res_746;
-										$this->pos = $pos_746;
+									if( $_761 === FALSE) {
+										$result = $res_762;
+										$this->pos = $pos_762;
 									}
-									$_747 = TRUE; break;
+									$_763 = TRUE; break;
 								}
 								while(0);
-								if( $_747 === TRUE ) { $_762 = TRUE; break; }
-								$result = $res_742;
-								$this->pos = $pos_742;
-								$_760 = NULL;
+								if( $_763 === TRUE ) { $_778 = TRUE; break; }
+								$result = $res_758;
+								$this->pos = $pos_758;
+								$_776 = NULL;
 								do {
-									$res_749 = $result;
-									$pos_749 = $this->pos;
-									$_752 = NULL;
+									$res_765 = $result;
+									$pos_765 = $this->pos;
+									$_768 = NULL;
 									do {
 										if (substr($this->string,$this->pos,1) == '{') {
 											$this->pos += 1;
 											$result["text"] .= '{';
 										}
-										else { $_752 = FALSE; break; }
-										$res_751 = $result;
-										$pos_751 = $this->pos;
+										else { $_768 = FALSE; break; }
+										$res_767 = $result;
+										$pos_767 = $this->pos;
 										if (substr($this->string,$this->pos,1) == '$') {
 											$this->pos += 1;
 											$result["text"] .= '$';
-											$result = $res_751;
-											$this->pos = $pos_751;
-											$_752 = FALSE; break;
+											$result = $res_767;
+											$this->pos = $pos_767;
+											$_768 = FALSE; break;
 										}
 										else {
-											$result = $res_751;
-											$this->pos = $pos_751;
+											$result = $res_767;
+											$this->pos = $pos_767;
 										}
-										$_752 = TRUE; break;
+										$_768 = TRUE; break;
 									}
 									while(0);
-									if( $_752 === TRUE ) { $_760 = TRUE; break; }
-									$result = $res_749;
-									$this->pos = $pos_749;
-									$_758 = NULL;
+									if( $_768 === TRUE ) { $_776 = TRUE; break; }
+									$result = $res_765;
+									$this->pos = $pos_765;
+									$_774 = NULL;
 									do {
 										if (( $subres = $this->literal( '{$' ) ) !== FALSE) { $result["text"] .= $subres; }
-										else { $_758 = FALSE; break; }
-										$res_757 = $result;
-										$pos_757 = $this->pos;
-										$_756 = NULL;
+										else { $_774 = FALSE; break; }
+										$res_773 = $result;
+										$pos_773 = $this->pos;
+										$_772 = NULL;
 										do {
 											if (( $subres = $this->rx( '/[A-Za-z_]/' ) ) !== FALSE) { $result["text"] .= $subres; }
-											else { $_756 = FALSE; break; }
-											$_756 = TRUE; break;
+											else { $_772 = FALSE; break; }
+											$_772 = TRUE; break;
 										}
 										while(0);
-										if( $_756 === TRUE ) {
-											$result = $res_757;
-											$this->pos = $pos_757;
-											$_758 = FALSE; break;
+										if( $_772 === TRUE ) {
+											$result = $res_773;
+											$this->pos = $pos_773;
+											$_774 = FALSE; break;
 										}
-										if( $_756 === FALSE) {
-											$result = $res_757;
-											$this->pos = $pos_757;
+										if( $_772 === FALSE) {
+											$result = $res_773;
+											$this->pos = $pos_773;
 										}
-										$_758 = TRUE; break;
+										$_774 = TRUE; break;
 									}
 									while(0);
-									if( $_758 === TRUE ) { $_760 = TRUE; break; }
-									$result = $res_749;
-									$this->pos = $pos_749;
-									$_760 = FALSE; break;
+									if( $_774 === TRUE ) { $_776 = TRUE; break; }
+									$result = $res_765;
+									$this->pos = $pos_765;
+									$_776 = FALSE; break;
 								}
 								while(0);
-								if( $_760 === TRUE ) { $_762 = TRUE; break; }
-								$result = $res_742;
-								$this->pos = $pos_742;
-								$_762 = FALSE; break;
+								if( $_776 === TRUE ) { $_778 = TRUE; break; }
+								$result = $res_758;
+								$this->pos = $pos_758;
+								$_778 = FALSE; break;
 							}
 							while(0);
-							if( $_762 === TRUE ) { $_764 = TRUE; break; }
-							$result = $res_737;
-							$this->pos = $pos_737;
-							$_764 = FALSE; break;
+							if( $_778 === TRUE ) { $_780 = TRUE; break; }
+							$result = $res_753;
+							$this->pos = $pos_753;
+							$_780 = FALSE; break;
 						}
 						while(0);
-						if( $_764 === TRUE ) { $_766 = TRUE; break; }
-						$result = $res_735;
-						$this->pos = $pos_735;
-						$_766 = FALSE; break;
+						if( $_780 === TRUE ) { $_782 = TRUE; break; }
+						$result = $res_751;
+						$this->pos = $pos_751;
+						$_782 = FALSE; break;
 					}
 					while(0);
-					if( $_766 === TRUE ) { $_768 = TRUE; break; }
-					$result = $res_733;
-					$this->pos = $pos_733;
-					$_768 = FALSE; break;
+					if( $_782 === TRUE ) { $_784 = TRUE; break; }
+					$result = $res_749;
+					$this->pos = $pos_749;
+					$_784 = FALSE; break;
 				}
 				while(0);
-				if( $_768 === FALSE) { $_770 = FALSE; break; }
-				$_770 = TRUE; break;
+				if( $_784 === FALSE) { $_786 = FALSE; break; }
+				$_786 = TRUE; break;
 			}
 			while(0);
-			if( $_770 === FALSE) {
-				$result = $res_771;
-				$this->pos = $pos_771;
-				unset( $res_771 );
-				unset( $pos_771 );
+			if( $_786 === FALSE) {
+				$result = $res_787;
+				$this->pos = $pos_787;
+				unset( $res_787 );
+				unset( $pos_787 );
 				break;
 			}
 			$count += 1;

--- a/view/SSTemplateParser.php.inc
+++ b/view/SSTemplateParser.php.inc
@@ -281,7 +281,7 @@ class SSTemplateParser extends Parser {
 	# character which, in some context, would indicate the end of a free string, regardless of if we're actually in
 	# that context or not 
 	 
-	FreeString: /[^,)%!=|&]+/
+	FreeString: /[^,)%!=><|&]+/
 	
 	# An argument - either a marked value, or a bare value, prefering lookup matching on the bare value over
 	# freestring matching as long as that would give a successful parse 
@@ -338,7 +338,7 @@ class SSTemplateParser extends Parser {
 	 
 	# if and else_if blocks allow basic comparisons between arguments
 	 
-	ComparisonOperator: "==" | "!=" | "="
+	ComparisonOperator: "!=" | "==" | ">=" | ">" | "<=" | "<" | "="
 
 	Comparison: Argument < ComparisonOperator > Argument
 	*/


### PR DESCRIPTION
This adds support for `<`, `<=`, `>`, `>=` in templates (see #1518 for original ticket).

This required a change to the FreeString, as this now has to be bounded by a `<` or a `>`-sign, otherwise for the following example the free string would be `5 >`

```
<% if 5 > 3 %>...<% end_if %>
```

This includes some test cases for all inequalities and their equal-counterparts as well as a little doc-item about these operators...

Best regards,
s-m
