### PR TITLE
Discussion: Fluent DBField API

### DIFF
--- a/model/fieldtypes/Boolean.php
+++ b/model/fieldtypes/Boolean.php
@@ -14,31 +14,45 @@ class Boolean extends DBField {
 	}
 	
 	public function requireField() {
-		$parts=Array(
-			'datatype'=>'tinyint',
-			'precision'=>1,
-			'sign'=>'unsigned',
-			'null'=>'not null',
-			'default'=>$this->defaultVal,
-			'arrayValue'=>$this->arrayValue
+		$parts = array(
+			'datatype' => 'tinyint',
+			'precision' => 1,
+			'sign' => 'unsigned',
+			'null' => 'not null',
+			'default' => $this->defaultVal,
+			'arrayValue' => $this->arrayValue
 		);
-		$values=Array('type'=>'boolean', 'parts'=>$parts);
+
+		$values = array(
+			'type' => 'boolean', 
+			'parts' => $parts
+		);
+
 		DB::requireField($this->tableName, $this->name, $values);
 	}
 	
+	/**
+	 * @return string
+	 */
 	public function Nice() {
 		return ($this->value) ? _t('Boolean.YES', 'Yes') : _t('Boolean.NO', 'No');
 	}
 	
+	/**
+	 * @return string
+	 */
 	public function NiceAsBoolean() {
 		return ($this->value) ? 'true' : 'false';
 	}
 
 	/**
 	 * Saves this field to the given data object.
+	 *
+	 * @param DataObject
 	 */
 	public function saveInto($dataObject) {
 		$fieldName = $this->name;
+		
 		if($fieldName) {
 			$dataObject->$fieldName = ($this->value) ? 1 : 0;
 		} else {
@@ -46,10 +60,21 @@ class Boolean extends DBField {
 		}
 	}
 
+	/**
+	 * @param string $title
+	 * @param array $params
+	 *
+	 * @return CheckboxField
+	 */
 	public function scaffoldFormField($title = null, $params = null) {
 		return new CheckboxField($this->name, $title);
 	}
 	
+	/**
+	 * @param string $title
+	 *
+	 * @return DropdownField
+	 */
 	public function scaffoldSearchField($title = null) {
 		$anyText = _t('Boolean.ANY', 'Any');
 		$source = array(
@@ -59,29 +84,29 @@ class Boolean extends DBField {
 		
 		$field = new DropdownField($this->name, $title, $source);
 		$field->setEmptyString("($anyText)");
+
 		return $field;
 	}
 
 	/**
 	 * Return an encoding of the given value suitable for inclusion in a SQL statement.
+	 *
 	 * If necessary, this should include quotes.
+	 *
+	 * @return string
 	 */
 	public function prepValueForDB($value) {
-		if(strpos($value, '[')!==false)
+		if(strpos($value, '[') !== false) {
 			return Convert::raw2sql($value);
-		else {
-			if($value && strtolower($value) != 'f') {
-				return "'1'";
-			} else {
-				return "'0'";
-			}
+		} else {
+			return ($value && strtolower($value) != 'f') ? "'1'" : "'0'";
 		}
 	}
 
+	/**
+	 * @return string
+	 */
 	public function nullValue() {
 		return "'0'";
 	}
-	
 }
-
-

--- a/model/fieldtypes/CompositeDBField.php
+++ b/model/fieldtypes/CompositeDBField.php
@@ -160,6 +160,7 @@ interface CompositeDBField {
 	/**
 	 * Return array in the format of {@link $composite_db}.
 	 * Used by {@link DataObject->hasOwnDatabaseField()}.
+	 *
 	 * @return array
 	 */
 	public function compositeDatabaseFields();

--- a/model/fieldtypes/DBField.php
+++ b/model/fieldtypes/DBField.php
@@ -1,12 +1,15 @@
 <?php
 /**
  * Single field in the database.
+ *
  * Every field from the database is represented as a sub-class of DBField.
  * 
  * <b>Multi-value DBField objects</b>
  * 
- * Sometimes you will want to make DBField classes that don't have a 1-1 match to database fields.  To do this, there
- * are a number of fields for you to overload.
+ * Sometimes you will want to make DBField classes that don't have a 1-1 match 
+ * to database fields.  To do this, there are a number of fields for you to 
+ * overload.
+ *
  *  - Overload {@link writeToManipulation} to add the appropriate references to the INSERT or UPDATE command
  *  - Overload {@link addToQuery} to add the appropriate items to a SELECT query's field list
  *  - Add appropriate accessor methods 
@@ -60,6 +63,7 @@ abstract class DBField extends ViewableData {
 	 */
 	protected $defaultVal;
 	
+
 	public function __construct($name = null) {
 		$this->name = $name;
 		
@@ -68,29 +72,42 @@ abstract class DBField extends ViewableData {
 	
 	/**
 	 * Create a DBField object that's not bound to any particular field.
+	 *
 	 * Useful for accessing the classes behaviour for other parts of your code.
+	 *
+	 * @param string $className
+	 * @param mixed $value
+	 * @param string $name
+	 * @param mixed $object
 	 */
 	public static function create_field($className, $value, $name = null, $object = null) {
 		$dbField = Object::create($className, $name, $object);
 		$dbField->setValue($value, null, false);
+
 		return $dbField;
 	}
 	
 	/**
 	 * Set the name of this field.
-	 * The name should never be altered, but it if was never given a name in the first place you can set a name.
-	 * If you try an alter the name a warning will be thrown. 
+	 *
+	 * The name should never be altered, but it if was never given a name in 
+	 * the first place you can set a name. If you try an alter the name a 
+	 * warning will be thrown. 
+	 *
+	 * @return string
 	 */
 	public function setName($name) {
 		if($this->name) {
 			user_error("DBField::setName() shouldn't be called once a DBField already has a name."
 				. "It's partially immutable - it shouldn't be altered after it's given a value.", E_USER_WARNING);
 		}
+
 		$this->name = $name;
 	}
 	
 	/**
 	 * Returns the name of this field.
+	 *
 	 * @return string
 	 */
 	public function getName() {
@@ -99,6 +116,7 @@ abstract class DBField extends ViewableData {
 	
 	/**
 	 * Returns the value of this field.
+	 *
 	 * @return mixed
 	 */
 	public function getValue() {
@@ -135,6 +153,7 @@ abstract class DBField extends ViewableData {
 	 * this should include quotes.
 	 * 
 	 * @param $value mixed The value to check
+	 *
 	 * @return string The encoded value
 	 */
 	public function prepValueForDB($value) {
@@ -158,18 +177,19 @@ abstract class DBField extends ViewableData {
 	 * @param array $manipulation
 	 */
 	public function writeToManipulation(&$manipulation) {
-		$manipulation['fields'][$this->name] = $this->exists() 
-			? $this->prepValueForDB($this->value) : $this->nullValue();
+		if($this->exists()) {
+			$manipulation['fields'][$this->name] = $this->prepValueForDB($this->value);
+		} else { 
+			$manipulation['fields'][$this->name] = $this->nullValue();
+		}
 	}
 	
 	/**
-	 * Add custom query parameters for this field,
-	 * mostly SELECT statements for multi-value fields. 
+	 * Add custom query parameters for this field, mostly SELECT statements for 
+	 * multi-value fields. 
 	 * 
-	 * By default, the ORM layer does a
-	 * SELECT <tablename>.* which
-	 * gets you the default representations
-	 * of all columns.
+	 * By default, the ORM layer does a SELECT <tablename>.* which gets you the 
+	 * default representations of all columns.
 	 *
 	 * @param SS_Query $query
 	 */
@@ -223,6 +243,8 @@ abstract class DBField extends ViewableData {
 	/**
 	 * Returns the value to be set in the database to blank this field.
 	 * Usually it's a choice between null, 0, and ''
+	 *
+	 * @return mixed
 	 */
 	public function nullValue() {
 		return "null";
@@ -230,6 +252,8 @@ abstract class DBField extends ViewableData {
 
 	/**
 	 * Saves this field to the given data object.
+	 *
+	 * @param DataObject
 	 */
 	public function saveInto($dataObject) {
 		$fieldName = $this->name;
@@ -246,7 +270,8 @@ abstract class DBField extends ViewableData {
 	 *
 	 * Used by {@link SearchContext}, {@link ModelAdmin}, {@link DataObject::scaffoldFormFields()}
 	 * 
-	 * @param string $title Optional. Localized title of the generated instance
+	 * @param string $title Optional. Localized title of the generated instance.
+	 *
 	 * @return FormField
 	 */
 	public function scaffoldFormField($title = null) {
@@ -261,7 +286,8 @@ abstract class DBField extends ViewableData {
 	 *
 	 * Used by {@link SearchContext}, {@link ModelAdmin}, {@link DataObject::scaffoldFormFields()}.
 	 * 
-	 * @param string $title Optional. Localized title of the generated instance
+	 * @param string $title Optional. Localized title of the generated instance.
+	 *
 	 * @return FormField
 	 */
 	public function scaffoldSearchField($title = null) {
@@ -280,6 +306,7 @@ abstract class DBField extends ViewableData {
 	public function defaultSearchFilter($name = false) {
 		$name = ($name) ? $name : $this->name;
 		$filterClass = $this->stat('default_search_filter_class');
+
 		return new $filterClass($name);
 	}
 	
@@ -298,6 +325,9 @@ abstract class DBField extends ViewableData {
 DBG;
 	}
 
+	/**
+	 * @return string
+	 */
 	public function __toString() {
 		return $this->forTemplate();
 	}

--- a/model/fieldtypes/Date.php
+++ b/model/fieldtypes/Date.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Represents a date field.
+ *
  * The field currently supports New Zealand date format (DD/MM/YYYY),
  * or an ISO 8601 formatted date (YYYY-MM-DD).
  * Alternatively you can set a timestamp that is evaluated through
@@ -46,98 +47,124 @@ class Date extends DBField {
 
 		if(is_numeric($value)) {
 			$this->value = date('Y-m-d', $value);
-		} elseif(is_string($value)) {
-			try{
+		} else if(is_string($value)) {
+			try {
 				$date = new DateTime($value);
 				$this->value = $date->Format('Y-m-d');
+
 				return;
-			}catch(Exception $e){
+			} catch(Exception $e) {
 				$this->value = null;
+
 				return;
 			}
 		}
 	}
 
 	/**
-	 * Returns the date in the format dd/mm/yy 
+	 * Returns the date in the format dd/mm/yy.
+	 *
+	 * @return Text
 	 */	 
 	public function Nice() {
-		if($this->value) return $this->Format('d/m/Y');
+		return DBField::create_field('Text', $this->Format('d/m/Y'));
 	}
 	
 	/**
-	 * Returns the date in US format: “01/18/2006”
+	 * Returns the date in US format: “01/18/2006”.
+	 *
+	 * @return Text
 	 */
 	public function NiceUS() {
-		if($this->value) return $this->Format('m/d/Y');
+		return DBField::create_field('Text', $this->Format('m/d/Y'));
 	}
 	
 	/** 
-	 * Returns the year from the given date
+	 * Returns the year from the given date.
+	 *
+	 * @return Int
 	 */
 	public function Year() {
-		if($this->value) return $this->Format('Y');
+		return DBField::create_field('Int', $this->Format('Y'));
 	}
 	
 	/**
 	 * Returns the Full day, of the given date.
+	 *
+	 * @return Text
 	 */
 	public function Day(){
-		if($this->value) return $this->Format('l');
+		return DBField::create_fields('Text', $this->Format('l'));
 	}
 	
 	/**
 	 * Returns a full textual representation of a month, such as January.
+	 *
+	 * @return Text
 	 */
 	public function Month() {
-		if($this->value) return $this->Format('F');
+		return DBField::create_field('Text', $this->Format('F'));
 	}
 	
 	/**
-	 * Returns the short version of the month such as Jan
+	 * Returns the short version of the month such as Jan.
+	 *
+	 * @return Text
 	 */
 	public function ShortMonth() {
-		if($this->value) return $this->Format('M');
+		return DBField::create_field('Text', $this->Format('M'));
 	}
 
 	/**
 	 * Returns the day of the month.
+	 *
 	 * @param boolean $includeOrdinals Include ordinal suffix to day, e.g. "th" or "rd"
-	 * @return string
+	 *
+	 * @return Text
 	 */
 	public function DayOfMonth($includeOrdinal = false) {
-		if($this->value) {
-			$format = 'j';
-			if ($includeOrdinal) $format .= 'S';
-			return $this->Format($format);
+		$format = 'j';
+
+		if ($includeOrdinal) {
+			$format .= 'S';
 		}
+
+		return DBField::create_field('Text', $this->Format($format));
 	}
 	
 	/**
 	 * Returns the date in the format 24 December 2006
+	 *
+	 * @return Text
 	 */
 	public function Long() {
-		if($this->value) return $this->Format('j F Y');
+		return DBField::create_field('Text', $this->Format('j F Y'));
 	}
 	
 	/**
 	 * Returns the date in the format 24 Dec 2006
+	 *
+	 * @return Text
 	 */
 	public function Full() {
-		if($this->value) return $this->Format('j M Y');
+		return DBField::create_field('Text', $this->Format('j M Y'));
 	}
 	
 	/**
 	 * Return the date using a particular formatting string.
 	 * 
 	 * @param string $format Format code string. e.g. "d M Y" (see http://php.net/date)
-	 * @return string The date in the requested format
+	 *
+	 * @return Text The date in the requested format
 	 */
 	public function Format($format) {
-		if($this->value){
+		if($this->value) {
 			$date = new DateTime($this->value);
-			return $date->Format($format);
+
+			return DBField::create_field('Text', $date->Format($format));
 		}
+
+		return DBField::create_field('Text');
 	}
 	
 	/**
@@ -149,11 +176,14 @@ class Date extends DBField {
 	public function FormatI18N($formattingString) {
 		if($this->value) {
 			$fecfrm = strftime($formattingString, strtotime($this->value));
-			return utf8_encode($fecfrm);
+
+			return DBField::create_field('Text', utf8_encode($fecfrm));
 		}
+
+		return DBField::create_field('Text', null);
 	}
 	
-	/*
+	/**
 	 * Return a string in the form "12 - 16 Sept" or "12 Aug - 16 Sept"
 	 * @param Date $otherDateObj Another date object specifying the end of the range
 	 * @param boolean $includeOrdinals Include ordinal suffix to day, e.g. "th" or "rd"
@@ -302,13 +332,22 @@ class Date extends DBField {
 	}
 
 	public function requireField() {
-		$parts=Array('datatype'=>'date', 'arrayValue'=>$this->arrayValue);
-		$values=Array('type'=>'date', 'parts'=>$parts);
+		$parts = array(
+			'datatype' => 'date', 
+			'arrayValue' => $this->arrayValue
+		);
+		
+		$values = array(
+			'type' => 'date', 
+			'parts' => $parts
+		);
+
 		DB::requireField($this->tableName, $this->name, $values);
 	}
 	
 	/**
 	 * Returns true if date is in the past.
+	 *
 	 * @return boolean
 	 */
 	public function InPast() {
@@ -317,6 +356,7 @@ class Date extends DBField {
 	
 	/**
 	 * Returns true if date is in the future.
+	 *
 	 * @return boolean
 	 */
 	public function InFuture() {
@@ -325,6 +365,7 @@ class Date extends DBField {
 	
 	/**
 	 * Returns true if date is today.
+	 *
 	 * @return boolean
 	 */
 	public function IsToday() {
@@ -368,10 +409,14 @@ class Date extends DBField {
 	 * @param $fmonth int The number of the month (e.g. 3 is March, 4 is April)
 	 * @param $fday int The day of the month
 	 * @param $fyear int Determine historical value
+	 *
 	 * @return string Date in YYYY-MM-DD format
 	 */
 	public static function past_date($fmonth, $fday = 1, $fyear = null) {
-		if(!$fyear) $fyear = date('Y');
+		if(!$fyear) {
+			$fyear = date('Y');
+		}
+
 		$fday = (int) $fday;
 		$fmonth = (int) $fmonth;
 		$fyear = (int) $fyear;
@@ -386,6 +431,12 @@ class Date extends DBField {
 		}
 	}
 	
+	/**
+	 * @param string $title
+	 * @param array $params
+	 *
+	 * @return DateField
+	 */
 	public function scaffoldFormField($title = null, $params = null) {
 		return new DateField($this->name, $title);
 	}

--- a/model/fieldtypes/Double.php
+++ b/model/fieldtypes/Double.php
@@ -17,13 +17,19 @@ class Double extends DBField {
 		}
 	}
 	
+	/**
+	 * @return Text
+	 */
 	public function Nice() {
-		return number_format($this->value, 2);
+		return DBField::create_field('Text', number_format($this->value, 2));
 	}
 	
 	/**
 	 * Returns the value to be set in the database to blank this field.
+	 *
 	 * Usually it's a choice between null, 0, and ''
+	 *
+	 * @return mixed
 	 */
 	public function nullValue() {
 		return 0;
@@ -31,7 +37,12 @@ class Double extends DBField {
 
 	/**
 	 * Return an encoding of the given value suitable for inclusion in a SQL statement.
+	 *
 	 * If necessary, this should include quotes.
+	 *
+	 * @param mixed $value
+	 *
+	 * @return mixed
 	 */
 	public function prepValueForDB($value) {
 		if($value === true) {

--- a/model/fieldtypes/HTMLText.php
+++ b/model/fieldtypes/HTMLText.php
@@ -11,6 +11,7 @@
  * @subpackage model
  */
 class HTMLText extends Text {
+
 	private static $escape_type = 'xml';
 
 	private static $casting = array(
@@ -32,8 +33,14 @@ class HTMLText extends Text {
 		'NoHTML' => 'Text',
 	);
 
+	/**
+	 * @var boolean
+	 */
 	protected $processShortcodes = true;
 
+	/**
+	 * @param array $options
+	 */
 	public function setOptions(array $options = array()) {
 		parent::setOptions($options);
 
@@ -59,61 +66,86 @@ class HTMLText extends Text {
 	public function Summary($maxWords = 50, $flex = 15, $add = '...') {
 		$str = false;
 
-		/* First we need the text of the first paragraph, without tags. Try using SimpleXML first */
+		// First we need the text of the first paragraph, without tags. Try 
+		// using SimpleXML first 
 		if (class_exists('SimpleXMLElement')) {
 			$doc = new DOMDocument();
 			
-			// Catch warnings thrown by loadHTML and turn them into a failure boolean rather than a SilverStripe error
+			// Catch warnings thrown by loadHTML and turn them into a failure 
+			// boolean rather than a SilverStripe error
 			set_error_handler(create_function('$no, $str', 'throw new Exception("HTML Parse Error: ".$str);'), E_ALL);
+
 			//  Nonbreaking spaces get converted into weird characters, so strip them
 			$value = str_replace('&nbsp;', ' ', $this->value);
+
 			try {
 				$res = $doc->loadHTML('<meta content="text/html; charset=utf-8" http-equiv="Content-type"/>' . $value);
+			} catch (Exception $e) { 
+				$res = false; 
 			}
-			catch (Exception $e) { $res = false; }
+
 			restore_error_handler();
 			
 			if ($res) {
 				$xml = simplexml_import_dom($doc);
 				$res = $xml->xpath('//p');
-				if (!empty($res)) $str = strip_tags($res[0]->asXML());
+			
+				if (!empty($res)) {
+					$str = strip_tags($res[0]->asXML());
+				}
 			}
 		}
 		
-		/* If that failed, most likely the passed HTML is broken. use a simple regex + a custom more brutal strip_tags.
-		 * We don't use strip_tags because that does very badly on broken HTML */
+		// If that failed, most likely the passed HTML is broken. use a simple 
+		// regex + a custom more brutal strip_tags. We don't use strip_tags 
+		// because that does very badly on broken HTML.
 		if (!$str) {
-			/* See if we can pull a paragraph out*/
+			// See if we can pull a paragraph out
 
-			// Strip out any images in case there's one at the beginning. Not doing this will return a blank paragraph
+			// Strip out any images in case there's one at the beginning. Not 
+			// doing this will return a blank paragraph
 			$str = preg_replace('{^\s*(<.+?>)*<img[^>]*>}', '', $this->value);
-			if (preg_match('{<p(\s[^<>]*)?>(.*[A-Za-z]+.*)</p>}', $str, $matches)) $str = $matches[2];
 
-			/* If _that_ failed, just use the whole text */
-			if (!$str) $str = $this->value;
+			if (preg_match('{<p(\s[^<>]*)?>(.*[A-Za-z]+.*)</p>}', $str, $matches)) {
+				$str = $matches[2];
+			}
+
+			// If _that_ failed, just use the whole text
+			if (!$str) {
+				$str = $this->value;
+			}
 			
-			/* Now pull out all the html-alike stuff */
-			/* Take out anything that is obviously a tag */
+			// Now pull out all the html-alike stuff. Take out anything that 
+			// is obviously a tag.
 			$str = preg_replace('{</?[a-zA-Z]+[^<>]*>}', '', $str); 
-			/* Strip out any left over looking bits. Textual < or > should already be encoded to &lt; or &gt; */
+
+			// Strip out any left over looking bits. Textual < or > should 
+			// already be encoded to &lt; or &gt; 
 			$str = preg_replace('{</|<|>}', '', $str); 
 		}
 		
-		/* Now split into words. If we are under the maxWords limit, just return the whole string (re-implode for
-		 * whitespace normalization) */
+		// Now split into words. If we are under the maxWords limit, just 
+		// return the whole string (re-implode for whitespace normalization)
 		$words = preg_split('/\s+/', $str);
-		if ($maxWords == -1 || count($words) <= $maxWords) return implode(' ', $words);
 
-		/* Otherwise work backwards for a looking for a sentence ending (we try to avoid abbreviations, but aren't
-		 * very good at it) */
+		if ($maxWords == -1 || count($words) <= $maxWords) {
+			return implode(' ', $words);
+		}
+
+		// Otherwise work backwards for a looking for a sentence ending 
+		// (we try to avoid abbreviations, but aren't very good at it)
 		for ($i = $maxWords; $i >= $maxWords - $flex && $i >= 0; $i--) {
 			if (preg_match('/\.$/', $words[$i]) && !preg_match('/(Dr|Mr|Mrs|Ms|Miss|Sr|Jr|No)\.$/i', $words[$i])) {
 				return implode(' ', array_slice($words, 0, $i+1));
 			}
 		}
 		
-		// If we didn't find a sentence ending quickly enough, just cut at the maxWords point and add '...' to the end
-		return implode(' ', array_slice($words, 0, $maxWords)) . $add;
+		// If we didn't find a sentence ending quickly enough, just cut at the 
+		// maxWords point and add '...' to the end.	
+		$result = clone $this;
+		$result->setValue(implode(' ', array_slice($words, 0, $maxWords)) . $add);
+
+		return $result;
 	}
 	
 	/**
@@ -128,19 +160,28 @@ class HTMLText extends Text {
 		/* Use summary's html processing logic to get the first paragraph */
 		$paragraph = $this->Summary(-1);
 		
-		/* Then look for the first sentence ending. We could probably use a nice regex, but for now this will do */
 		$words = preg_split('/\s+/', $paragraph);
+		
 		foreach ($words as $i => $word) {
 			if (preg_match('/\.$/', $word) && !preg_match('/(Dr|Mr|Mrs|Ms|Miss|Sr|Jr|No)\.$/i', $word)) {
-				return implode(' ', array_slice($words, 0, $i+1));
+				$str = implode(' ', array_slice($words, 0, $i+1));
+
+				$sentence = clone $this;
+				$sentence->setValue($str);
+
+				return $sentence;
 			}
 		}
 		
-		/* If we didn't find a sentence ending, use the summary. We re-call rather than using paragraph so that
-		 * Summary will limit the result this time */
+		// If we didn't find a sentence ending, use the summary. We re-call 
+		// rather than using paragraph so that Summary will limit the result 
+		// this time.
 		return $this->Summary();
 	}	
 	
+	/**
+	 * @return string
+	 */
 	public function forTemplate() {
 		if ($this->processShortcodes) {
 			return ShortcodeParser::get_active()->parse($this->value);
@@ -152,6 +193,7 @@ class HTMLText extends Text {
 	
 	/**
 	 * Returns true if the field has meaningful content.
+	 *
 	 * Excludes null content like <h1></h1>, <p></p> ,etc
 	 * 
 	 * @return boolean
@@ -173,18 +215,27 @@ class HTMLText extends Text {
 			return false;
 		}
 
-		// Otherwise its content is genuine content
 		return true;
 	}
 	
+	/**
+	 * @param string $title
+	 * @param array $params
+	 *
+	 * @return HtmlEditorField
+	 */
 	public function scaffoldFormField($title = null, $params = null) {
 		return new HtmlEditorField($this->name, $title);
 	}
 	
+	/**
+	 * @param string $title
+	 * @param array $params
+	 *
+	 * @return TextField
+	 */
 	public function scaffoldSearchField($title = null, $params = null) {
 		return new TextField($this->name, $title);
 	}
-
 }
-
 

--- a/model/fieldtypes/Int.php
+++ b/model/fieldtypes/Int.php
@@ -15,46 +15,77 @@ class Int extends DBField {
 
 	/**
 	 * Returns the number, with commas added as appropriate, eg “1,000”.
+	 *
+	 * @return Text
 	 */
 	public function Formatted() {
-		return number_format($this->value);
+		return DBField::create_field('Text', number_format($this->value));
 	}
 
+	/**
+	 * @return string
+	 */
 	public function nullValue() {
 		return "0";
 	}
 
 	public function requireField() {
-		$parts=Array(
-			'datatype'=>'int',
-			'precision'=>11,
-			'null'=>'not null',
-			'default'=>$this->defaultVal,
-			'arrayValue'=>$this->arrayValue);
+		$parts = array(
+			'datatype' => 'int',
+			'precision' => 11,
+			'null' => 'not null',
+			'default' => $this->defaultVal,
+			'arrayValue' => $this->arrayValue
+		);
 		
-		$values=Array('type'=>'int', 'parts'=>$parts);
+		$values = array(
+			'type' => 'int', 
+			'parts' => $parts
+		);
+
 		DB::requireField($this->tableName, $this->name, $values);
 	}
 
+	/**
+	 * @return ArrayList
+	 */
 	public function Times() {
 		$output = new ArrayList();
-		for( $i = 0; $i < $this->value; $i++ )
-			$output->push( new ArrayData( array( 'Number' => $i + 1 ) ) );
+
+		for($i = 0; $i < $this->value; $i++) {
+			$output->push(new ArrayData(array(
+				'Number' => $i + 1 
+			)));
+		}
 
 		return $output;
 	}
 
+	/**
+	 * @return Text
+	 */
 	public function Nice() {
-		return sprintf( '%d', $this->value );
+		return DBField::create_field('Text', sprintf( '%d', $this->value));
 	}
 	
+	/**
+	 * @param string $title
+	 * @param array $params
+	 *
+	 * @return NumericField
+	 */
 	public function scaffoldFormField($title = null, $params = null) {
 		return new NumericField($this->name, $title);
 	}
 	
 	/**
 	 * Return an encoding of the given value suitable for inclusion in a SQL statement.
+	 *
 	 * If necessary, this should include quotes.
+	 *
+	 * @param mixed
+	 *
+	 * @return string
 	 */
 	public function prepValueForDB($value) {
 		if($value === true) {
@@ -70,4 +101,3 @@ class Int extends DBField {
 	}
 	
 }
-

--- a/model/fieldtypes/StringField.php
+++ b/model/fieldtypes/StringField.php
@@ -13,17 +13,6 @@ abstract class StringField extends DBField {
 	protected $nullifyEmpty = true;
 
 	/**
-	 * @var array
-	 */
-	private static $casting = array(
-		"LimitCharacters" => "Text",
-		'LimitWordCount' => 'Text',
-		'LimitWordCountXML' => 'HTMLText',
-		"LowerCase" => "Text",
-		"UpperCase" => "Text",
-	);
-
-	/**
 	 * Construct a string type field with a set of optional parameters.
 	 *
 	 * @param $name string The name of the field
@@ -31,8 +20,8 @@ abstract class StringField extends DBField {
 	 *                       {@link StringField::setOptions()} for information on the available options
 	 */
 	public function __construct($name = null, $options = array()) {
-		// Workaround: The singleton pattern calls this constructor with true/1 as the second parameter, so we
-		// must ignore it
+		// Workaround: The singleton pattern calls this constructor with true/1 
+		// as the second parameter, so we must ignore it
 		if(is_array($options)){
 			$this->setOptions($options);
 		}
@@ -42,6 +31,7 @@ abstract class StringField extends DBField {
 	
 	/**
 	 * Update the optional parameters for this field.
+	 *
 	 * @param $options array of options
 	 * The options allowed are:
 	 *   <ul><li>"nullifyEmpty"
@@ -49,7 +39,6 @@ abstract class StringField extends DBField {
 	 *       True (the default) means that empty strings are automatically converted to nulls to be stored in
 	 *       the database. Set it to false to ensure that nulls and empty strings are kept intact in the database.
 	 *   </li></ul>
-	 * @return unknown_type
 	 */
 	public function setOptions(array $options = array()) {
 		if(array_key_exists("nullifyEmpty", $options)) {
@@ -119,7 +108,7 @@ abstract class StringField extends DBField {
 			$value = (mb_strlen($value) > $limit) ? mb_substr($value, 0, $limit) . $add : $value;
 		}
 
-		return $value;
+		return DBField::create('Text', $value);
 	}
 
 
@@ -132,7 +121,7 @@ abstract class StringField extends DBField {
 	 * @param int $numWords Number of words to limit by.
 	 * @param string $add Ellipsis to add to the end of truncated string.
 	 *
-	 * @return string
+	 * @return Text
 	 */
 	public function LimitWordCount($numWords = 26, $add = '...') {
 		$this->value = trim(Convert::xml2raw($this->value));
@@ -145,7 +134,7 @@ abstract class StringField extends DBField {
 			$ret = implode(' ', $ret) . $add;
 		}
 
-		return $ret;
+		return DBField::create('Text', $ret);
 	}
 
 	/**
@@ -156,28 +145,44 @@ abstract class StringField extends DBField {
 	 * @param int $numWords Number of words to limit by.
 	 * @param string $add Ellipsis to add to the end of truncated string.
 	 *
-	 * @return string
+	 * @return HTMLText
 	 */
 	public function LimitWordCountXML($numWords = 26, $add = '...') {
 		$ret = $this->LimitWordCount($numWords, $add);
 
-		return Convert::raw2xml($ret);
+		return DBField::create('HTMLText', Convert::raw2xml($ret));
 	}
 
 	/**
 	 * Converts the current value for this StringField to lowercase.
 	 *
-	 * @return string
+	 * @return StringField
 	 */
 	public function LowerCase() {
-		return mb_strtolower($this->value);
+		$lower = clone $this;
+		$lower->setValue(mb_strtolower($lower->value));
+
+		return $lower;
 	}
 
 	/**
 	 * Converts the current value for this StringField to uppercase.
-	 * @return string 
+	 *
+	 * @return StringField 
 	 */ 
 	public function UpperCase() {
-		return mb_strtoupper($this->value);
+		$upper = clone $this;
+		$upper->setValue(mb_strtoupper($upper->value));
+
+		return $upper;
+	}
+
+	/**
+	 * Converts new lines to breaks.
+	 *
+	 * @return HTMLText
+	 */
+	public function Nl2Br() {
+		return DBField::create('HTMLText', nl2br($this->value));
 	}
 }

--- a/parsers/TextParser.php
+++ b/parsers/TextParser.php
@@ -22,6 +22,7 @@
  * Again, @see BBCodeParser for an example of the syntax
  * 
  * @todo Define a proper syntax for (or refactor) usable_tags that can be extended as needed.
+ *
  * @package framework
  * @subpackage misc
  */

--- a/tests/model/StringFieldTest.php
+++ b/tests/model/StringFieldTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package framework
  * @subpackage tests
@@ -23,6 +24,23 @@ class StringFieldTest extends SapphireTest {
 		$this->assertEquals(
 			'THIS IS A TEST!',
 			DBField::create_field('StringFieldTest_MyStringField', 'This is a TEST!')->UpperCase()
+		);
+	}
+
+	/**
+	 * @covers StringField->Nl2Br()
+	 */
+	public function testNl2Br() {
+		$this->assertEquals(
+			"String<br />line",
+			DBField::create_field('StringFieldTest_MyStringField', 'String\nLine')->Nl2Br()
+		);
+	}
+
+	public function testChainingCommands() {
+		$this->assertEquals(
+			'string<br />line"',
+			DBField::create_field('StringFieldTest_MyStringField', 'String\nLine')->Nl2Br()->Lower()
 		);
 	}
 


### PR DESCRIPTION
_Do not merge_

Before I continue with this, thought I would discuss the practically of it (@sminnee, @chillu).  

Idea being much like the DataList API that DBField functions that manipulate data return new DBField instances rather than strings. The benefit of this is a consistent API between the template and PHP (i.e $this->dbObject('Created')->Long()->UpperCase()). This pull request doesn't fix any of the tests that fail (roughly a dozen) after the change though if the idea has merit, happy to finish. 

If moved forward, would aim for 3.2 / 4.0 or something as it is a relatively API breaking change.

Sorry, pull request has code formatting fixes around it as well. Started tiding that up as well.
