### PR TITLE
Update DataQuery.php

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -293,10 +293,22 @@ class DataQuery {
 					}
 				} else {
 					$qualCol = '"' . implode('"."', $parts) . '"';
+					$strTable = $parts[0];
+					$dbConn = DB::getConn();
+					$bAddInSelect = false;
+
+					$arrTables = $dbConn->tableList();
+					if(in_array($qualCol, $arrTables)){
+						$arrCols = $dbConn->fieldList($strTable);
+						if(in_array($qualCol, $arrCols)){
+							$bAddInSelect = true;
+						}
+					}
+					
 					
 					// To-do: Remove this if block once SQLQuery::$select has been refactored to store getSelect()
 					// format internally; then this check can be part of selectField()
-					if(!in_array($qualCol, $query->getSelect())) {
+					if(!in_array($qualCol, $query->getSelect()) && $bAddInSelect) {
 						$query->selectField($qualCol);
 					}
 				}


### PR DESCRIPTION
DataQuery::ensureSelectContainsOrderbyColumns wont add fields which are not in 
database tables FIXED

The goal was to add in a order by clues like the one below.

Product.CategoryID=10 DESC, Price ASC

where it should return the products price asc but return the products in category 10 first. 

the problem here is that the DataQuery adds in a Select to the query called,  Product.CategoryID=10

obviously there is no such column and the query fails. I've added a check to see whether that column is in the DB before adding it to the Select
