### PR TITLE
BUG: Allow empty else- and else_if-blocks

### DIFF
--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -448,6 +448,14 @@ after')
 		$this->assertEquals('ACD', $this->render('A<% if 4 > 4 %>B<% else %>C<% end_if %>D'));
 		$this->assertEquals('ACD', $this->render('A<% if 4 < 4 %>B<% else %>C<% end_if %>D'));
 
+		// empty else_if and else tags, if this would not be supported,
+		// the output would stop after A, thereby failing the assert
+		$this->assertEquals('AD', $this->render('A<% if IsSet %><% else %><% end_if %>D'));
+		$this->assertEquals('AD', 
+			$this->render('A<% if NotSet %><% else_if IsSet %><% else %><% end_if %>D'));
+		$this->assertEquals('AD', 
+			$this->render('A<% if NotSet %><% else_if AlsoNotSet %><% else %><% end_if %>D'));
+
 		// Bare words with ending space
 		$this->assertEquals('ABC',
 			$this->render('A<% if "RawVal" == RawVal %>B<% end_if %>C'));

--- a/view/SSTemplateParser.php
+++ b/view/SSTemplateParser.php
@@ -1535,7 +1535,7 @@ class SSTemplateParser extends Parser {
 	}
 
 
-	/* ElseIfPart: '<%' < 'else_if' [ :IfArgument > '%>' Template:$TemplateMatcher */
+	/* ElseIfPart: '<%' < 'else_if' [ :IfArgument > '%>' Template:$TemplateMatcher? */
 	protected $match_ElseIfPart_typestack = array('ElseIfPart');
 	function match_ElseIfPart ($stack = array()) {
 		$matchrule = "ElseIfPart"; $result = $this->construct($matchrule, $matchrule, null);
@@ -1557,12 +1557,19 @@ class SSTemplateParser extends Parser {
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
 			else { $_240 = FALSE; break; }
+			$res_239 = $result;
+			$pos_239 = $this->pos;
 			$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "Template" );
 			}
-			else { $_240 = FALSE; break; }
+			else {
+				$result = $res_239;
+				$this->pos = $pos_239;
+				unset( $res_239 );
+				unset( $pos_239 );
+			}
 			$_240 = TRUE; break;
 		}
 		while(0);
@@ -1571,7 +1578,7 @@ class SSTemplateParser extends Parser {
 	}
 
 
-	/* ElsePart: '<%' < 'else' > '%>' Template:$TemplateMatcher */
+	/* ElsePart: '<%' < 'else' > '%>' Template:$TemplateMatcher? */
 	protected $match_ElsePart_typestack = array('ElsePart');
 	function match_ElsePart ($stack = array()) {
 		$matchrule = "ElsePart"; $result = $this->construct($matchrule, $matchrule, null);
@@ -1585,12 +1592,19 @@ class SSTemplateParser extends Parser {
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) { $result["text"] .= $subres; }
 			else { $_248 = FALSE; break; }
+			$res_247 = $result;
+			$pos_247 = $this->pos;
 			$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
 			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
 			if ($subres !== FALSE) {
 				$this->store( $result, $subres, "Template" );
 			}
-			else { $_248 = FALSE; break; }
+			else {
+				$result = $res_247;
+				$this->pos = $pos_247;
+				unset( $res_247 );
+				unset( $pos_247 );
+			}
 			$_248 = TRUE; break;
 		}
 		while(0);
@@ -1661,14 +1675,14 @@ class SSTemplateParser extends Parser {
 	function If_ElseIfPart(&$res, $sub) {
 		$res['php'] .= 
 			'else if (' . $sub['IfArgument']['php'] . ') { ' . PHP_EOL .
-				$sub['Template']['php'] . PHP_EOL . 
+            (isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
 			'}';
 	}
 
 	function If_ElsePart(&$res, $sub) {
 		$res['php'] .= 
 			'else { ' . PHP_EOL . 
-				$sub['Template']['php'] . PHP_EOL . 
+            (isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
 			'}';
 	}
 

--- a/view/SSTemplateParser.php.inc
+++ b/view/SSTemplateParser.php.inc
@@ -417,8 +417,8 @@ class SSTemplateParser extends Parser {
 	# argument structure to every other block 
 	 
 	IfPart: '<%' < 'if' [ :IfArgument > '%>' Template:$TemplateMatcher?
-	ElseIfPart: '<%' < 'else_if' [ :IfArgument > '%>' Template:$TemplateMatcher
-	ElsePart: '<%' < 'else' > '%>' Template:$TemplateMatcher
+	ElseIfPart: '<%' < 'else_if' [ :IfArgument > '%>' Template:$TemplateMatcher?
+	ElsePart: '<%' < 'else' > '%>' Template:$TemplateMatcher?
 
 	If: IfPart ElseIfPart* ElsePart? '<%' < 'end_if' > '%>'
 	*/
@@ -432,14 +432,14 @@ class SSTemplateParser extends Parser {
 	function If_ElseIfPart(&$res, $sub) {
 		$res['php'] .= 
 			'else if (' . $sub['IfArgument']['php'] . ') { ' . PHP_EOL .
-				$sub['Template']['php'] . PHP_EOL . 
+				(isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
 			'}';
 	}
 
 	function If_ElsePart(&$res, $sub) {
 		$res['php'] .= 
 			'else { ' . PHP_EOL . 
-				$sub['Template']['php'] . PHP_EOL . 
+				(isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
 			'}';
 	}
 


### PR DESCRIPTION
This fix allows empty else and else-if-blocks to be processed, fixes #1660.

This fix makes the matching of a template inside else_if and else-blocks optional and thereby allows empty else and else-if-blocks. 
To facilitate this, the processing of these blocks has to include an `isset($sub['Template'])` check, just like the if-block.

This includes some test cases that would fail without this fix as the parser would just stop processing the template...

Best regards,
s-m
