### PR TITLE
BUG Fixed incorrect variable usage in generation of PhoneNumberField form fields

### DIFF
--- a/forms/PhoneNumberField.php
+++ b/forms/PhoneNumberField.php
@@ -31,7 +31,6 @@ class PhoneNumberField extends FormField {
 		$fields = new FieldGroup( $this->name );
 		$fields->setID("{$this->name}_Holder");
 		list($countryCode, $areaCode, $phoneNumber, $extension) = $this->parseValue();
-		$hasTitle = false;
 
 		if ($this->value=="") {
 			$countryCode=$this->countryCode;
@@ -51,7 +50,7 @@ class PhoneNumberField extends FormField {
 		}
 		
 		if($this->ext !== null) {
-			$field->push(new NumericField( $this->name.'[Extension]', 'ext', $extension, 6));
+			$fields->push(new NumericField( $this->name.'[Extension]', 'ext', $extension, 6));
 		}
 
 		$description = $this->getDescription();
@@ -62,7 +61,7 @@ class PhoneNumberField extends FormField {
 			$field->setReadonly($this->isReadonly());
 		}
 			
-		return $field;
+		return $fields;
 	}
 	
 	public function setValue( $value ) {


### PR DESCRIPTION
I've fixed a pair of typos in the PhoneNumberField and removed an unused variable.

I'd appreciate it if you could please also merge down to 3.0 some time, as it's my 3.0 app that is breaking due to this.
