### PR TITLE
DatetimeField returns wrong year

### DIFF
--- a/forms/DatetimeField.php
+++ b/forms/DatetimeField.php
@@ -15,7 +15,7 @@
  * Example:
  * <code>
  * $field = new DatetimeField('Name', 'Label');
- * $field->setConfig('datavalueformat', 'YYYY-MM-dd HH:mm'); // global setting
+ * $field->setConfig('datavalueformat', 'yyyy-MM-dd HH:mm'); // global setting
  * $field->getDateField()->setConfig('showcalendar', 1); // field-specific setting
  * </code>
  * 
@@ -46,7 +46,7 @@ class DatetimeField extends FormField {
 	 * @var array
 	 */
 	private static $default_config = array(
-		'datavalueformat' => 'YYYY-MM-dd HH:mm:ss',
+		'datavalueformat' => 'yyyy-MM-dd HH:mm:ss',
 		'usertimezone' => null,
 		'datetimeorder' => '%s %s',
 	);


### PR DESCRIPTION
This is related to how Zend_Date returns year for YYYY & yyyy format. Detailed explanation is here http://framework.zend.com/issues/browse/ZF-5297

Sample code (adapted the Datetimefield setValue() method) to highlight the problem:

include 'framework/thirdparty/Zend/Date.php';

$userValueObj = new Zend_Date(null, null, 'en_US');
$userValueObj->setTimezone('GMT');
$userValueObj->setDate('2012-01-01', 'YYYY-MM-dd');
$userValueObj->setTime('00:00:00', 'HH:mm:ss');
echo $userValueObj->get('YYYY-MM-dd HH:mm:ss', 'en_US'), "\n"; // returns 2011-01-01 00:00:00
echo $userValueObj->get('yyyy-MM-dd HH:mm:ss', 'en_US'), "\n"; // returns 2012-01-01 00:00:00
