### PR TITLE
removing potentially invalid html in email

### DIFF
--- a/templates/email/GenericEmail.ss
+++ b/templates/email/GenericEmail.ss
@@ -5,9 +5,9 @@
 </head>
 <body>
 
-<p class="body">
+<div class="body">
 	$Body
-</p>
+</div>
 
 </body>
 </html>


### PR DESCRIPTION
The generic email template encapsulates the "body" content in a paragraph mark.  This is undesirable as it can lead to invalid HTML. Rather than using a paragraph, it is better to have a div encapsulating the content.

The underlying reason for this is that $Body is usually HTML and this can included block elements (div, p, etc...) that are not allowed within paragraphs (p).

It is important that the HTML is valid, because it will reduce the likelihood for it being marked as spam, because it is less likely to show up strange formatting and for use of tools like emogrifier.
