### PR TITLE
fix email template

### DIFF
--- a/templates/email/GenericEmail.ss
+++ b/templates/email/GenericEmail.ss
@@ -5,9 +5,9 @@
 </head>
 <body>
 
-<p class="body">
+<div class="body">
 	$Body
-</p>
+</div>
 
 </body>
 </html>


### PR DESCRIPTION
having a paragraph encapsulating generic html is not correct... therefore it is replaced by a div.
