### PR TITLE
BUG HTTP incorrectly converts mailto links to absolute urls

### DIFF
--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -42,6 +42,7 @@ class HTTP {
 	public static function absoluteURLs($html) {
 		$html = str_replace('$CurrentPageURL', $_SERVER['REQUEST_URI'], $html);
 		return HTTP::urlRewriter($html, function($url) {
+			if(stripos($url, 'mailto:') === 0) return $url;
 			return Director::absoluteURL($url, true);
 		});
 	}

--- a/tests/control/HTTPTest.php
+++ b/tests/control/HTTPTest.php
@@ -187,6 +187,18 @@ class HTTPTest extends SapphireTest {
 		});
 	}
 	
+	public function testEmailLinks() {
+		$this->withBaseURL('http://www.silverstripe.org/', function($test){
+			
+			// links
+			$test->assertEquals(
+				'<a href=\'mailto:admin@silverstripe.org\'>Email Us</a>',
+				HTTP::absoluteURLs('<a href=\'mailto:admin@silverstripe.org\'>Email Us</a>')
+			);
+		});
+		
+	}
+	
 	/**
 	 * Run a test while mocking the base url with the provided value
 	 * @param string $url The base URL to use for this test


### PR DESCRIPTION
HTTP will now correctly pass over mailto: links when converting relative links to absolute (e.g. in Emails)
