### PR TITLE
BUG: HiddenFields and VisibleFields should always return extraFields

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -556,7 +556,7 @@ class Form extends RequestHandler {
 	 * @return FieldList
 	 */
 	public function HiddenFields() {
-		return $this->fields->HiddenFields();
+		return $this->Fields()->HiddenFields();
 	}
 
 	/**
@@ -564,7 +564,7 @@ class Form extends RequestHandler {
 	 * Useful when making your own simplified form layouts.
 	 */
 	public function VisibleFields() {
-		return $this->fields->VisibleFields();
+		return $this->Fields()->VisibleFields();
 	}
 	
 	/**


### PR DESCRIPTION
HiddenFields() and VisibleFields() should always return extraFields, e.g. HiddenFields doesn't return SecurityID if it is called before Fields().
