### PR TITLE
Include AllPages() form method to $allowed_actions

### DIFF
--- a/docs/en/reference/grid-field.md
+++ b/docs/en/reference/grid-field.md
@@ -42,7 +42,7 @@ Here is an example where we display a basic gridfield with the default settings:
 	:::php
 	class GridController extends Page_Controller {
 
-		static $allowed_actions = array('index');
+		static $allowed_actions = array('index', 'AllPages');
 		
 		public function index(SS_HTTPRequest $request) {
 			$this->Content = $this->AllPages();


### PR DESCRIPTION
Using the previous snippet resulted in a 404. Including the AllPages() method in the $allowed_actions array avoids this.
