### PR TITLE
Added --no-update hint to composer docs

### DIFF
--- a/docs/en/installation/composer.md
+++ b/docs/en/installation/composer.md
@@ -66,7 +66,16 @@ Composer isn't only used to download SilverStripe CMS, it can also be used to ma
 
 	composer require silverstripe/forum:*
 
-This command has two parts.  First is `silverstripe/forum`. This is the name of the package.  You can find other packages with the following command:
+This will install the forum module in the latest compatible version.
+By default, Composer updates other existing modules (like `framework` and `cms`),
+and installs "dev" dependencies like PHPUnit. In case you don't need those dependencies,
+use the following command instead:
+
+	composer require --no-update silverstripe/forum:*
+	composer update --no-dev
+
+The `require` command has two parts. First is `silverstripe/forum`. This is the name of the package. 
+You can find other packages with the following command:
 
 	composer search silverstripe
 
@@ -84,7 +93,7 @@ Except for the control code of the Voyager space probe, every piece of code in t
 
 To get the latest updates of the modules in your project, run this command:
 
-	composer update
+	composer update --no-dev
 
 Updates to the required modules will be installed, and the `composer.lock` file will get updated with the specific commits of each of those.
 


### PR DESCRIPTION
Composer has recently changed their default behaviour. See https://github.com/composer/composer/issues/1005 and https://github.com/composer/composer/pull/1644 for context.

It installs dev dependencies by default on any `composer update`. By extension, this also includes calls to `composer require`, since those update existing dependencies first. Not the best default behaviour for us, particularly because we have quite a chain of dev dependencies through phpunit and behat. 

This greatly reduces the usefulness of `composer require` to us, because it takes module installation from a few seconds to 2+ minutes (at least the first time). Plus it adds all kinds of cruft which is probably not required for most of our devs using `composer require`.

I've updated the docs to reflect this, but its ugly/confusing. I'm actually tempted to remove the `require--dev` sections from our composer declarations, or at least move them to `suggests`. If you want to contribute to SS (e.g. run tests), you can achieve the same project state with two or three calls like `composer require phpunit/phpunit`.

@simonwelsh I know you voiced your frustration with this on github - would this be a feasible solution?

@sminnee What do you think?
