### PR TITLE
Disable ID based partial caching for all security actions

### DIFF
--- a/security/Security.php
+++ b/security/Security.php
@@ -468,7 +468,8 @@ class Security extends Controller {
 			$tmpPage = new Page();
 			$tmpPage->Title = _t('Security.LOSTPASSWORDHEADER', 'Lost Password');
 			$tmpPage->URLSegment = 'Security';
-			$tmpPage->ID = -1; // Set the page ID to -1 so we dont get the top level pages as its children
+			// Disable ID-based caching  of the log-in page by making it a random number
+			$tmpPage->ID = -1 * rand(1,10000000);
 			$controller = Page_Controller::create($tmpPage);
 			$controller->init();
 		} else {
@@ -530,7 +531,8 @@ class Security extends Controller {
 			$tmpPage = new Page();
 			$tmpPage->Title = _t('Security.LOSTPASSWORDHEADER');
 			$tmpPage->URLSegment = 'Security';
-			$tmpPage->ID = -1; // Set the page ID to -1 so we dont get the top level pages as its children
+			// Disable ID-based caching  of the log-in page by making it a random number
+			$tmpPage->ID = -1 * rand(1,10000000);
 			$controller = Page_Controller::create($tmpPage);
 			$controller->init();
 		} else {
@@ -596,7 +598,8 @@ class Security extends Controller {
 			$tmpPage = new Page();
 			$tmpPage->Title = _t('Security.CHANGEPASSWORDHEADER', 'Change your password');
 			$tmpPage->URLSegment = 'Security';
-			$tmpPage->ID = -1; // Set the page ID to -1 so we dont get the top level pages as its children
+			// Disable ID-based caching  of the log-in page by making it a random number
+			$tmpPage->ID = -1 * rand(1,10000000);
 			$controller = Page_Controller::create($tmpPage);
 			$controller->init();
 		} else {


### PR DESCRIPTION
Disables ID based partial caching for all security actions so that actions such as Security/lostpassword and Security/passwordsent work properly even if partial caching is used.
