### PR TITLE
vendor folder is blocked only if outside themes

### DIFF
--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -1277,16 +1277,15 @@ HTML;
 ErrorDocument 404 /assets/error-404.html
 ErrorDocument 500 /assets/error-500.html
 
-<IfModule mod_alias.c>
-	RedirectMatch 403 /silverstripe-cache(/|$)
-	RedirectMatch 403 /vendor(/|$)
-	RedirectMatch 403 /composer\.(json|lock)
-</IfModule>
-
 <IfModule mod_rewrite.c>
 	SetEnv HTTP_MOD_REWRITE On
 	RewriteEngine On
 	$baseClause
+
+	RewriteRule ^vendor(/|$) - [F,L,NC]
+	RewriteRule silverstripe-cache(/|$) - [F,L,NC]
+	RewriteRule composer\.(json|lock) - [F,L,NC]
+	
 	RewriteCond %{REQUEST_URI} ^(.*)$
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteCond %{REQUEST_URI} !\.php$


### PR DESCRIPTION
Update in line with this Installer issue: https://github.com/silverstripe/silverstripe-installer/issues/34
Vendor folders are now blocked only if outside themes.
