### PR TITLE
RSS feed description encoding fix

### DIFF
--- a/api/RSSFeed.php
+++ b/api/RSSFeed.php
@@ -275,7 +275,7 @@ class RSSFeed_Entry extends ViewableData {
 	 * @return string Returns the description of the entry.
 	 */
 	function Description() {
-		return $this->rssField($this->descriptionField, 'Text');
+		return $this->rssField($this->descriptionField, 'HTMLText');
 	}
 
 	/**


### PR DESCRIPTION
Stops the RSS feed's description from being double XML encoded. The double-encoding started happening after a change to Text.php in commit 029f77f5a414ec806d89311690281398a4898285.
