### PR TITLE
Add HTMLText::EscapeXML() so that shortcode output is also escaped.

### DIFF
--- a/core/model/fieldtypes/HTMLText.php
+++ b/core/model/fieldtypes/HTMLText.php
@@ -149,6 +149,15 @@ class HTMLText extends Text {
 	public function scaffoldSearchField($title = null) {
 		return new TextField($this->name, $title);
 	}
+	
+	/**
+	 * Return the value of the field with XML tags escaped.
+	 * @return string
+	 */
+	function EscapeXML() {
+		$value = ShortcodeParser::get_active()->parse($this->value);
+		return str_replace(array('&','<','>','"'), array('&amp;','&lt;','&gt;','&quot;'), $value);
+	}
 
 }
 


### PR DESCRIPTION
My blog's RSS feed had raw HTML tags in the description that were generated by shortcodes. This commit processes shortcodes before escaping.

NOTE: This also requires pull request #1797 in order to get the blog RSS feed bahaving properly.
