### PR TITLE
Defining $children as a public variable

### DIFF
--- a/forms/ConfirmedPasswordField.php
+++ b/forms/ConfirmedPasswordField.php
@@ -60,6 +60,13 @@ class ConfirmedPasswordField extends FormField {
 	public $showOnClickTitle;
 	
 	/**
+	 * Child fields (_Password, _ConfirmPassword)
+	 * 
+	 * @var FieldList
+	 */
+	 public $children;
+	
+	/**
 	 * @param string $name
 	 * @param string $title
 	 * @param mixed $value


### PR DESCRIPTION
Defining $children as a public variable (it was previously defined on-the-fly)
