### PR TITLE
FIX Unquoted shortcodes weren't parsed (fixes #680)

### DIFF
--- a/parsers/ShortcodeParser.php
+++ b/parsers/ShortcodeParser.php
@@ -151,7 +151,7 @@ class ShortcodeParser {
 		(?:
 			(?:\'([^\']+)\') | # Value surrounded by \'
 			(?:"([^"]+)")    | # Value surrounded by "
-			(\w+)              # Bare value
+			([^\s,\]]+)          # Bare value
 		)
 ';
 	

--- a/tests/parsers/ShortcodeParserTest.php
+++ b/tests/parsers/ShortcodeParserTest.php
@@ -150,13 +150,13 @@ class ShortcodeParserTest extends SapphireTest {
 	}
 
 	public function testUnquotedArguments() {
-		$this->assertEquals('', $this->parser->parse('[test_shortcode,foo=bar,baz = buz]'));
-		$this->assertEquals(array('foo' => 'bar', 'baz' => 'buz'), $this->arguments);
+		$this->assertEquals('', $this->parser->parse('[test_shortcode,foo=bar!,baz = buz123]'));
+		$this->assertEquals(array('foo' => 'bar!', 'baz' => 'buz123'), $this->arguments);
 	}
 	
 	public function testSpacesForDelimiter() {
-		$this->assertEquals('', $this->parser->parse('[test_shortcode foo=bar baz = buz]'));
-		$this->assertEquals(array('foo' => 'bar', 'baz' => 'buz'), $this->arguments);
+		$this->assertEquals('', $this->parser->parse('[test_shortcode foo=bar! baz = buz123]'));
+		$this->assertEquals(array('foo' => 'bar!', 'baz' => 'buz123'), $this->arguments);
 	}
 
 	public function testSelfClosingTag() {

--- a/thirdparty/tinymce_ssbuttons/editor_plugin_src.js
+++ b/thirdparty/tinymce_ssbuttons/editor_plugin_src.js
@@ -62,10 +62,10 @@
 				var content = jQuery(o.content);
 				content.find('.ss-htmleditorfield-file.embed').each(function() {
 					var el = jQuery(this);
-					var shortCode = '[embed width=' + el.data('width')
-										+ ' height=' + el.data('height')
-										+ ' class=' + el.data('cssclass')
-										+ ' thumbnail=' + el.data('thumbnail')
+					var shortCode = '[embed width="' + el.data('width') + '"'
+										+ ' height="' + el.data('height') + '"'
+										+ ' class="' + el.data('cssclass') + '"'
+										+ ' thumbnail="' + el.data('thumbnail') + '"'
 										+ ']' + el.data('url')
 										+ '[/embed]';
 					el.replaceWith(shortCode);


### PR DESCRIPTION
Since that used to be the default shortcode notation
for our core "insert media" functionality, its important
to have this fixed and keep supporting "legacy" content created with 3.0.

@hafriedlander Could you check that the attributes regex doesn't mess things up? It has pretty good test coverage, but ... its a complicated regex ;)
