### PR TITLE
FIX Allow Director::$rules like //$Action

### DIFF
--- a/control/HTTPRequest.php
+++ b/control/HTTPRequest.php
@@ -449,6 +449,9 @@ class SS_HTTPRequest implements ArrayAccess {
 			$shiftCount = sizeof($patternParts);
 		}
 
+		// Filter out any "empty" matching parts - either from an initial / or a trailing /
+		$patternParts = array_values(array_filter($patternParts));
+
 		$arguments = array();
 		foreach($patternParts as $i => $part) {
 			$part = trim($part);


### PR DESCRIPTION
In 3.0, doing $Action => SomeController would redirect all requests with an action
to that controller. In 3.1, you'd need to do //$Action => SomeController
but it didnt work - those initial slashes broke matching
