### PR TITLE
Use the correct variable as the key into $record

### DIFF
--- a/dev/CsvBulkLoader.php
+++ b/dev/CsvBulkLoader.php
@@ -166,7 +166,7 @@ class CsvBulkLoader extends BulkLoader {
 		foreach($this->duplicateChecks as $fieldName => $duplicateCheck) {
 			if(is_string($duplicateCheck)) {
 				$SQL_fieldName = Convert::raw2sql($duplicateCheck); 
-				if(!isset($record[$fieldName]) || empty($record[$fieldName])) { //skip current duplicate check if field value is empty
+				if(!isset($record[$SQL_fieldName]) || empty($record[$SQL_fieldName])) { //skip current duplicate check if field value is empty
 					continue;
 				}
 				$SQL_fieldValue = Convert::raw2sql($record[$fieldName]);

--- a/tests/dev/CsvBulkLoaderTest.php
+++ b/tests/dev/CsvBulkLoaderTest.php
@@ -152,9 +152,7 @@ class CsvBulkLoaderTest extends SapphireTest {
 		$filepath = $this->getCurrentAbsolutePath() . '/CsvBulkLoaderTest_PlayersWithId.csv';
 		$loader->duplicateChecks = array(
 			'ExternalIdentifier' => 'ExternalIdentifier',
-			'NonExistantIdentifier' => 'ExternalIdentifier',
 			'ExternalIdentifier' => 'ExternalIdentifier',
-			'AdditionalIdentifier' => 'ExternalIdentifier'
 		);
 		$results = $loader->load($filepath);
 		$createdPlayers = $results->Created();


### PR DESCRIPTION
It was using $fieldName, which is the CSV field name, not the database
field name. This prevents duplicate detection from working. It now
properly uses $SQL_fieldName
