### PR TITLE
Use the correct variable as the key into $record

### DIFF
--- a/dev/CsvBulkLoader.php
+++ b/dev/CsvBulkLoader.php
@@ -152,11 +152,11 @@ class CsvBulkLoader extends BulkLoader {
 		foreach($this->duplicateChecks as $fieldName => $duplicateCheck) {
 			if(is_string($duplicateCheck)) {
 				$SQL_fieldName = Convert::raw2sql($duplicateCheck); 
-				if(!isset($record[$fieldName])) {
+				if(!isset($record[$SQL_fieldName])) {
 					return false;
 					//user_error("CsvBulkLoader:processRecord: Couldn't find duplicate identifier '{$fieldName}' in columns", E_USER_ERROR);
 				}
-				$SQL_fieldValue = Convert::raw2sql($record[$fieldName]);
+				$SQL_fieldValue = Convert::raw2sql($record[$SQL_fieldName]);
 				$existingRecord = DataObject::get_one($this->objectClass, "\"$SQL_fieldName\" = '{$SQL_fieldValue}'");
 				if($existingRecord) return $existingRecord;
 			} elseif(is_array($duplicateCheck) && isset($duplicateCheck['callback'])) {


### PR DESCRIPTION
It was using $fieldName, which is the CSV field name, not the database
field name. This prevents duplicate detection from working. It now
properly uses $SQL_fieldName
