### PR TITLE
The MAX_FILE_SIZE field must precede the file input field.

### DIFF
--- a/templates/forms/FileField.ss
+++ b/templates/forms/FileField.ss
@@ -1,2 +1,2 @@
-<input $AttributesHTML />
 <input type="hidden" name="MAX_FILE_SIZE" value="$MaxFileSize" />
+<input $AttributesHTML />


### PR DESCRIPTION
More here: http://php.net/manual/en/features.file-upload.post-method.php
