### PR TITLE
IMPROVEMENT Media Dialog extra data

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -1185,7 +1185,7 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 			getExtraData: function() {
 				var width = this.find(':input[name=Width]').val(),
 					height = this.find(':input[name=Height]').val();
-				return {
+				var data = {
 					'CaptionText': this.find(':input[name=CaptionText]').val(),
 					'Url': this.find(':input[name=URL]').val(),
 					'thumbnail': this.find('.thumbnail-preview').attr('src'),
@@ -1193,6 +1193,12 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 					'height' : height ? parseInt(height, 10) : null,
 					'cssclass': this.find(':input[name=CSSClass]').val()
 				};
+				this.find(':input').each(function(){
+					if($(this).hasClass('extra-data')){
+						data[$(this).attr('name')] = $(this).val();
+					}
+				});
+				return data;
 			},
 			getHTML: function() {
 				var el,


### PR DESCRIPTION
HtmlEditorField_Toolbar class allows you to extend media fields for an
instance this way:

``` php
HtmlEditorField_Toolbar::add_extension('HtmlEditorField_ToolbarEx');
class HtmlEditorField_ToolbarEx extends Extension {
    public function updateFieldsForImage($fields, $url, $file){
        if(is_a($file,'HtmlEditorField_Embed')){
            $fields->push(
                DropdownField::create('lightbox','Showing Type',array('0'=>'In text window','1'=>'Popup Window'))
                    ->addExtraClass('extra-data')
            );
        }
    }
}
```

But there's no use in such exteding when u can't pass this attributes
to content field so every field that has class "extra-data" will be
added to media as data-_field_name_ attribute as u can see in my
exmaple data-lightbox="1" attribute will be added to an image. The same
way we can add a hidden field with full size image url and it will be
possible to open this image in lightbox window
