### PR TITLE
FIX: Enable $forceWrite argument of DataObject#write()

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1123,7 +1123,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 		}
 
 		// No changes made
-		if($this->changed) {
+		if($this->changed || $forceWrite) {
 			foreach($this->getClassAncestry() as $ancestor) {
 				if(self::has_own_table($ancestor))
 				$ancestry[] = $ancestor;
@@ -1133,13 +1133,14 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 			if(!$forceInsert) unset($this->changed['ID']);
 
 			$hasChanges = false;
-			foreach($this->changed as $fieldName => $changed) {
-				if($changed) {
-					$hasChanges = true;
-					break;
+			if (!$forceWrite) {
+				foreach ($this->changed as $fieldName => $changed) {
+					if ($changed) {
+						$hasChanges = true;
+						break;
+					}
 				}
 			}
-
 			if($hasChanges || $forceWrite || !$this->record['ID']) {
 					
 				// New records have their insert into the base data table done first, so that they can pass the


### PR DESCRIPTION
$forceWrite was being ignored because it was tested in a part of the
code that is reachable if and only if there are changes to the object.
This patch adds an additional test to correct that logic error.

Also, refrain from needlessly checking for changes when $forceWrite is
true.

Fixes #1687
