### PR TITLE
API: Check that form submission HTTP method matches form

### DIFF
--- a/docs/en/topics/forms.md
+++ b/docs/en/topics/forms.md
@@ -7,18 +7,18 @@ and handle the actions and data from a form.
 
 A fully implemented form in SilverStripe includes a couple of classes that individually have separate concerns.
 
- * Controller - Takes care of assemble the form and recieving data from it.
+ * Controller - Takes care of assemble the form and receiving data from it.
  * Form - Holds sets of fields, actions and validators.
- * FormField  - Fields that recieves data or displays them, e.g input fields.
+ * FormField  - Fields that receive data or displays them, e.g input fields.
  * FormActions - Often submit buttons that executes actions.
- * Validators - Validates the whole form, see [Form validation](form-validation.md) topic for more information.
+ * Validators - Validate the whole form, see [Form validation](form-validation.md) topic for more information.
 
 Depending on your needs you can customize and override any of the above classes, however the defaults are often 
 sufficient.
 
 ## The Controller
 
-Forms start at the controller. Here is an simple example on how to set up a form in a controller.
+Forms start at the controller. Here is a simple example on how to set up a form in a controller.
 
 **Page.php**
 
@@ -363,6 +363,13 @@ Adds a new text field called FavouriteColour next to the Content field in the CM
 
 	:::php
 	$this->Fields()->addFieldToTab('Root.Content', new TextField('FavouriteColour'), 'Content');
+
+## Security
+
+The form must be submitted with the correct HTTP method (POST, unless
+you change it by calling `$this->setFormMethod()`). If the submission is
+with a mismatched method, the submission is rejected with status code
+405 (method not allowed).
 
 ## Related
 

--- a/forms/Form.php
+++ b/forms/Form.php
@@ -64,7 +64,7 @@ class Form extends RequestHandler {
 
 	protected $validator;
 	
-	protected $formMethod = "post";
+	protected $formMethod = "POST";
 	
 	protected static $current_action;
 	
@@ -239,6 +239,12 @@ class Form extends RequestHandler {
 	 * if the form is valid.
 	 */
 	public function httpSubmission($request) {
+		// Check that submission has arrived by the correct HTTP method
+		if ($this->formMethod != $this->request->httpMethod()) {
+			$response = Controller::curr()->getResponse();
+			$response->addHeader('Allow', $this->formMethod);
+			$this->httpError(405, _t("Form.METHOD_NOT_ALLOWED", "You must submit the form by method specified in the form."));
+		}
 		$vars = $request->requestVars();
 		if(isset($funcName)) {
 			Form::set_current_action($funcName);
@@ -526,7 +532,7 @@ class Form extends RequestHandler {
 		$this->securityTokenAdded = true;
 		
 		// add the "real" HTTP method if necessary (for PUT, DELETE and HEAD)
-		if($this->FormMethod() != $this->FormHttpMethod()) {
+		if (strtoupper($this->FormMethod()) != $this->FormHttpMethod()) {
 			$methodField = new HiddenField('_method', '', $this->FormHttpMethod());
 			$methodField->setForm($this);
 			$extraFields->push($methodField);
@@ -656,7 +662,7 @@ class Form extends RequestHandler {
 		// - forms with security tokens shouldn't be cached because security tokens expire
 		$needsCacheDisabled = false;
 		if ($this->getSecurityToken()->isEnabled()) $needsCacheDisabled = true;
-		if ($this->FormMethod() != 'get') $needsCacheDisabled = true;
+		if ($this->FormMethod() != 'GET') $needsCacheDisabled = true;
 		if (!($this->validator instanceof RequiredFields) || count($this->validator->getRequired())) {
 			$needsCacheDisabled = true;
 		}
@@ -783,8 +789,8 @@ class Form extends RequestHandler {
 	 * @return string Form tag compatbile HTTP method: 'get' or 'post'
 	 */
 	public function FormMethod() {
-		if(in_array($this->formMethod,array('get','post'))) {
-			return $this->formMethod;
+		if(in_array($this->formMethod,array('GET','POST'))) {
+			return strtolower($this->formMethod);
 		} else {
 			return 'post';
 		}
@@ -796,7 +802,7 @@ class Form extends RequestHandler {
 	 * @param $method string
 	 */
 	public function setFormMethod($method) {
-		$this->formMethod = strtolower($method);
+		$this->formMethod = strtoupper($method);
 		return $this;
 	}
 	

--- a/tests/forms/FormTest.php
+++ b/tests/forms/FormTest.php
@@ -202,7 +202,7 @@ class FormTest extends FunctionalTest {
 		
 		$form = $this->getStubForm();
 		$form->setFormMethod('PUT');
-		$this->assertEquals($form->Fields()->dataFieldByName('_method')->Value(), 'put',
+		$this->assertEquals($form->Fields()->dataFieldByName('_method')->Value(), 'PUT',
 			'PUT override in forms has PUT in hiddenfield'
 		);
 		$this->assertEquals($form->FormMethod(), 'post',
@@ -211,7 +211,7 @@ class FormTest extends FunctionalTest {
 		
 		$form = $this->getStubForm();
 		$form->setFormMethod('DELETE');
-		$this->assertEquals($form->Fields()->dataFieldByName('_method')->Value(), 'delete',
+		$this->assertEquals($form->Fields()->dataFieldByName('_method')->Value(), 'DELETE',
 			'PUT override in forms has PUT in hiddenfield'
 		);
 		$this->assertEquals($form->FormMethod(), 'post',


### PR DESCRIPTION
- Add test to Form#httpSubmission()
- Send HTTP 405 response & Allow header on mismatch (per RFC 2616 10.4.6)
- Because HTTP methods are upper case, change the representation of methods to upper case
- Retain lower case for Form#FormMethod(), because that is intended for X/HTML
- Update FormTest to accommodate the case changes
- Update documentation

Fixes #1672
