### PR TITLE
BUG Fixing queries on non-existent table breaking archive site

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -147,6 +147,10 @@ class Versioned extends DataExtension {
 		case 'archive':
 			$date = $dataQuery->getQueryParam('Versioned.date');
 			foreach($query->getFrom() as $table => $dummy) {
+				if(!DB::getConn()->hasTable($table . '_versions')) {
+					continue;
+				}
+
 				$query->renameTable($table, $table . '_versions');
 				$query->replaceText("\"{$table}_versions\".\"ID\"", "\"{$table}_versions\".\"RecordID\"");
 				$query->replaceText("`{$table}_versions`.`ID`", "`{$table}_versions`.`RecordID`");
@@ -161,7 +165,6 @@ class Versioned extends DataExtension {
 					$query->addWhere("\"{$table}_versions\".\"Version\" = \"{$baseTable}_versions\".\"Version\"");
 				}
 			}
-
 			// Link to the version archived on that date
 			$safeDate = Convert::raw2sql($date);
 			$query->addWhere(


### PR DESCRIPTION
With a many to many relation, e.g. SiteTree_MyRelation, and listing
them in your template then adding ?archiveDate=x in the URL, a SQL
error is shown because Versioned::augmentSQL() tries to query the
non-existent table "SiteTree_MyRelation_versions" assuming there's
versioning setup, but there isn't.

I've added a test to expose this scenario, and the fix is to simply check
the table exists before augmenting the SQL in Versioned.
