### PR TITLE
DataQuery::count() doesn't use SQLQuery::setDistinct() API

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -329,7 +329,9 @@ class DataQuery {
 	 */
 	public function count() {
 		$baseClass = ClassInfo::baseDataClass($this->dataClass);
-		return $this->getFinalisedQuery()->count("DISTINCT \"$baseClass\".\"ID\"");
+		$query = $this->getFinalisedQuery();
+		$query->setDistinct(true);
+		return $query->count("\"$baseClass\".\"ID\"");
 	}
 
 	/**


### PR DESCRIPTION
Remove hardcoded "DISTINCT" in SQL and use `setDistinct(true)` on SQLQuery instead which does the same thing, but using the API correctly.
