### PR TITLE
NEW Added beforeExtending, afterExtending, and beforeUpdateCMSFields

### DIFF
--- a/docs/en/changelogs/3.1.0.md
+++ b/docs/en/changelogs/3.1.0.md
@@ -455,3 +455,6 @@ you can enable those warnings and future-proof your code already.
  * Hard limit displayed pages in the CMS tree to `500`, and the number of direct children to `250`,
    to avoid excessive resource usage. Configure through `Hierarchy.node_threshold_total` and `
    Hierarchy.node_threshold_leaf`.  Set to `0` to show tree unrestricted.
+ * `Object` now has `beforeExtending` and `afterExtending` to inject behaviour around method extension.
+  `DataObject` also has `beforeUpdateCMSFields` to insert fields between automatic scaffolding and extension
+  by `updateCMSFields`. See the [DataExtension Reference](/reference/dataextension) for more information.

--- a/docs/en/reference/dataextension.md
+++ b/docs/en/reference/dataextension.md
@@ -78,6 +78,57 @@ The `$`fields parameter is passed by reference, as it is an object.
 	  $fields->push(new UploadField('Image', 'Profile Image'));
 	}
 
+### Adding/modifying fields prior to extensions
+
+User code can intervene in the process of extending cms fields by using `beforeUpdateCMSFields`
+in its implementation of `getCMSFields`. This can be useful in cases where user code will add
+fields to a dataobject that should be present in the `$fields` parameter when passed to
+`updateCMSFields` in extensions.
+
+This method is preferred to disabling, enabling, and calling cms field extensions manually.
+
+	:::php
+	function getCMSFields() {
+		$this->beforeUpdateCMSFields(function($fields) {
+			// Include field which must be present when updateCMSFields is called on extensions
+			$fields->addFieldToTab("Root.Main", new TextField('Detail', 'Details', null, 255));
+		});
+
+		$fields = parent::getCMSFields();
+		// ... additional fields here
+		return $fields;
+	}
+
+### Object extension injection points
+
+`Object` now has two additional methods, `beforeExtending` and `afterExtending`, each of which takes a
+method name and a callback to be executed immediately before and after `Object::extend()` is called on
+extensions.
+
+This is useful in many cases where working with modules such as `Translatable` which operate on
+`DataObject` fields that must exist in the `FieldList` at the time that `$this->extend('UpdateCMSFields')`
+is called.
+
+<div class="notice" markdown='1'>
+Please note that each callback is only ever called once, and then cleared, so multiple extensions
+to the same function require that a callback is registered each time, if necessary.
+</div>
+
+Example: A class that wants to control default values during object initialisation. The code
+needs to assign a value if not specified in self::$defaults, but before extensions have been called:
+
+	:::php
+	function __construct() {
+		$self = $this;
+		$this->beforeExtending('populateDefaults', function() uses ($self) {
+			if(empty($self->MyField)) {
+				$self->MyField = 'Value we want as a default if not specified in $defaults, but set before extensions';
+			}
+		});
+		parent::__construct();
+	}
+
+
 ### Custom database generation
 
 Some extensions are designed to transparently add more sophisticated data-collection capabilities to your data object.

--- a/docs/en/reference/dataobject.md
+++ b/docs/en/reference/dataobject.md
@@ -63,6 +63,8 @@ data management interfaces with very little custom coding.
 
 You can also alter the fields of built-in and module `DataObject` classes through
 your own `[DataExtension](/reference/dataextension)`, and a call to `[api:DataExtension->updateCMSFields()]`.
+`[api::DataObject->beforeUpdateCMSFields()]` can also be used to interact with and add to automatically
+scaffolded fields prior to being passed to extensions (See `[DataExtension](/reference/dataextension)`).
 
 ### Searchable Fields
 

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -2000,6 +2000,16 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	}
 	
 	/**
+	 * Allows user code to hook into DataObject::getCMSFields prior to updateCMSFields
+	 * being called on extensions
+	 * 
+	 * @param callable $callback The callback to execute
+	 */
+	protected function beforeUpdateCMSFields($callback) {
+		$this->beforeExtending('updateCMSFields', $callback);
+	}
+	
+	/**
 	 * Centerpiece of every data administration interface in Silverstripe,
 	 * which returns a {@link FieldList} suitable for a {@link Form} object.
 	 * If not overloaded, we're using {@link scaffoldFormFields()} to automatically


### PR DESCRIPTION
Added beforeExtending, afterExtending, and beforeUpdateCMSFields to provide a finer degree of control over how classes interact with their own extensions.

Please see https://github.com/silverstripe/silverstripe-cms/pull/692 for the first implementation of this method, and subsequent discussion, followed by https://github.com/silverstripe/silverstripe-cms/pull/694 for the second implementation. This third implementation supersedes these.

Modules such as Blog use disableCMSFieldsExtensions / enableCMSFieldsExtensions around field manipulation code in order to delay extension of CMS fields. See https://github.com/silverstripe/silverstripe-blog/blob/master/code/BlogEntry.php#L62

This code simply formalises it, adds test cases, and documentation. Hopefully this will make user code that performs such manipulation a bit more explicit and readable.

E.g.

``` php

public function getCMSFields() {

    // Before updateCMSFields we want to add some text fields, perhaps 
    // to be later interacted with with modules such as Translatable
    $this->beforeUpdateCMSFields(function(FieldList $fields) {
        $fields->addFieldToTab('Root.Main', new TextField('Details'));
    });

    // after extending updateCMSFields we may want to interact with fields added by extensions
    $fields = parent::getCMSFields();
    $fields->removeByName('GoogleAnalytics');
    return $fields;
}
```

Resolves ticket at https://github.com/silverstripe/sapphire/issues/1362
