### PR TITLE
FIX: Disable autocomplete on ConfirmedPasswordField instances.

### DIFF
--- a/forms/ConfirmedPasswordField.php
+++ b/forms/ConfirmedPasswordField.php
@@ -95,6 +95,12 @@ class ConfirmedPasswordField extends FormField {
 		if($showOnClick) {
 			$this->children->push(new HiddenField("{$name}[_PasswordFieldVisible]"));
 		}
+
+		// disable auto complete
+		foreach($this->children as $child) {
+			$child->setAttribute('autocomplete', 'off');
+		}
+
 		$this->showOnClick = $showOnClick;
 		
 		// we have labels for the subfields
@@ -136,11 +142,13 @@ class ConfirmedPasswordField extends FormField {
 		foreach($this->children as $field) {
 			$field->setDisabled($this->isDisabled()); 
 			$field->setReadonly($this->isReadonly());
+
 			if(count($this->attributes)) {
 				foreach($this->attributes as $name => $value) {
 					$field->setAttribute($name, $value);
 				}
 			}
+
 			$content .= $field->FieldHolder();
 		}
 

--- a/javascript/ConfirmedPasswordField.js
+++ b/javascript/ConfirmedPasswordField.js
@@ -1,5 +1,5 @@
 (function ($) {
-	$('.confirmedpassword .showOnClick a').live('click', function () {
+	$(document).on('click', '.confirmedpassword .showOnClick a', function () {
 		var $container = $('.showOnClickContainer', $(this).parent());
 
 		$container.toggle('fast', function() {


### PR DESCRIPTION
From http://open.silverstripe.org/ticket/6245.

According to my manual test and the documentation (https://developer.mozilla.org/en-US/docs/Mozilla/How_to_Turn_Off_Form_Autocompletion) the javascript clear is no longer required. 
