### PR TITLE
FIX: NumericField should work with numbers like 54,6

### DIFF
--- a/forms/NumericField.php
+++ b/forms/NumericField.php
@@ -1,19 +1,29 @@
 <?php
+
 /**
- * Text input field with validation for numeric values.
+ * Text input field with validation for numeric values. Supports validating
+ * the numeric value as to the {@link i18n::get_locale()} value.
  * 
  * @package forms
  * @subpackage fields-formattedinput
  */
-class NumericField extends TextField{
+class NumericField extends TextField {
 
 	public function Type() {
 		return 'numeric text';
 	}
 
-	/** PHP Validation **/
-	public function validate($validator){
-		if($this->value && !is_numeric(trim($this->value))){
+	public function validate($validator) {
+		if(!$this->value && !$validator->fieldIsRequired($this->name)) {
+			return true;
+		}
+
+		$valid = Zend_Locale_Format::isNumber(
+			trim($this->value), 
+			array('locale' => i18n::get_locale())
+		);
+
+		if(!$valid) {
 			$validator->validationError(
 				$this->name,
 				_t(
@@ -22,10 +32,11 @@ class NumericField extends TextField{
 				),
 				"validation"
 			);
+
 			return false;
-		} else{
-			return true;
 		}
+		
+		return true;
 	}
 	
 	public function dataValue() {

--- a/tests/forms/NumericFieldTest.php
+++ b/tests/forms/NumericFieldTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @package framework
+ * @subpackage tests
+ */
+class NumericFieldTest extends SapphireTest {
+	
+	protected $usesDatabase = false;
+
+	public function testValidator() {
+		i18n::set_locale('en_US');
+
+		$field = new NumericField('Number');
+		$field->setValue('12.00');
+
+		$validator = new RequiredFields('Number');
+		$this->assertTrue($field->validate($validator));
+
+		$field->setValue('12,00');
+		$this->assertFalse($field->validate($validator));
+
+		$field->setValue('0');
+		$this->assertTrue($field->validate($validator));
+
+		$field->setValue(false);
+		$this->assertFalse($field->validate($validator));
+
+		i18n::set_locale('de_DE');
+		$field->setValue('12,00');
+		$validator = new RequiredFields();
+		$this->assertTrue($field->validate($validator));
+
+		$field->setValue('12.00');
+		$this->assertFalse($field->validate($validator));
+	}
+}


### PR DESCRIPTION
Fixes http://open.silverstripe.org/ticket/5577.

Uses Zend_Locale_Format::isNumber(). Includes unit test for NumericField. Does not include testing work on DBField underlying NumericField to ensure that works consistently.
