### PR TITLE
Bugfix: Added private static $defaultFormat...

### DIFF
--- a/control/ContentNegotiator.php
+++ b/control/ContentNegotiator.php
@@ -45,6 +45,12 @@ class ContentNegotiator extends Object {
 	 * @var boolean
 	 */
 	private static $enabled = false;
+	
+	/**
+	 * @config
+	 * @var string
+	 */
+	private static $default_format = 'html';
 
 	/**
 	 * Set the character set encoding for this page.  By default it's utf-8, but you could change it to, say,
@@ -114,7 +120,7 @@ class ContentNegotiator extends Object {
 		);
 		$q = array();
 		if(headers_sent()) {
-			$chosenFormat = "html";
+			$chosenFormat = Config::inst()->get('ContentNegotiator', 'default_format');
 
 		} else if(isset($_GET['forceFormat'])) {
 			$chosenFormat = $_GET['forceFormat'];
@@ -139,7 +145,7 @@ class ContentNegotiator extends Object {
 					krsort($q);
 					$chosenFormat = reset($q);
 				} else {
-					$chosenFormat = "html";
+					$chosenFormat = Config::inst()->get('ContentNegotiator', 'default_format');
 				}
 			}
 		}


### PR DESCRIPTION
... in order to choose default via config. Permit WCAG validation of XHTML (http://achecker.ca/checker/index.php).

Achecker validator's request are really basic:

```
GET / HTTP/1.0
Host: cmondovi31.zirak.it
```

We can't check user agent like we do for W3C validator, so we need to define a customizable default.
