### PR TITLE
Add code-sniffs other than line length to scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,5 @@
+tools:
+    custom_commands:
+        -
+            scope: file
+            command: php tests/phpcs_runner.php %pathname%

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
  - DB=MYSQL CORE_RELEASE=3.0
  - DB=PGSQL CORE_RELEASE=3.0
  - DB=SQLITE3 CORE_RELEASE=3.0
- - PHPCS=1 CORE_RELEASE=3.0
 
 matrix:
   exclude:
@@ -16,22 +15,18 @@ matrix:
       env: DB=PGSQL CORE_RELEASE=3.0
     - php: 5.4
       env: DB=SQLITE3 CORE_RELEASE=3.0
-    - php: 5.4
-      env: PHPCS=1 CORE_RELEASE=3.0
   allow_failures:
     - env: DB=PGSQL CORE_RELEASE=3.0
     - env: DB=SQLITE3 CORE_RELEASE=3.0
-    - env: PHPCS=1 CORE_RELEASE=3.0
 
 before_script:
- - pear install pear/PHP_CodeSniffer
  - phpenv rehash
  - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
  - cd ~/builds/ss
 
 script: 
- - sh -c "if [ '$PHPCS' != '1' ]; then phpunit framework/tests; else phpcs --encoding=utf-8 --tab-width=4 --standard=framework/tests/phpcs/ruleset.xml -np framework && phpcs --encoding=utf-8 --standard=framework/tests/phpcs/tabs.xml -np framework; fi"
+ - phpunit framework/tests
 
 branches:
   except:

--- a/tests/phpcs/ruleset.xml
+++ b/tests/phpcs/ruleset.xml
@@ -14,14 +14,6 @@
 	<!-- PHP-PEG generated file not intended for human consumption -->
 	<exclude-pattern>*/SSTemplateParser.php$</exclude-pattern>
 	
-	<rule ref="Generic.Files.LineEndings.InvalidEOLChar">
-		<severity>8</severity>
-	</rule>
-	<rule ref="Generic.Files.LineEndings">
-		<properties>
-			<property name="eolChar" value="\n" />
-		</properties>
-	</rule>
 	<rule ref="Generic.Files.LineLength.TooLong">
 		<severity>7</severity>
 	</rule>

--- a/tests/phpcs/tabs.xml
+++ b/tests/phpcs/tabs.xml
@@ -14,5 +14,13 @@
 	<!-- PHP-PEG generated file not intended for human consumption -->
 	<exclude-pattern>*/SSTemplateParser.php$</exclude-pattern>
 	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
+        <rule ref="Generic.Files.LineEndings.InvalidEOLChar">
+                <severity>8</severity>
+        </rule>
+        <rule ref="Generic.Files.LineEndings">
+                <properties>
+                        <property name="eolChar" value="\n" />
+                </properties>
+        </rule>
 </ruleset>
 

--- a/tests/phpcs_runner.php
+++ b/tests/phpcs_runner.php
@@ -1,0 +1,48 @@
+<?php
+
+if(php_sapi_name() != 'cli') {
+	die("This script must be called from the command line\n");
+}
+
+if(!empty($_SERVER['argv'][1])) {
+	$path = $_SERVER['argv'][1];
+} else {
+	die("Usage: php {$_SERVER['argv'][0]} <file>\n");
+}
+
+$result = array('comments' => array());
+
+// Run each sniff
+
+// phpcs --encoding=utf-8 --standard=framework/tests/phpcs/tabs.xml
+run_sniff('tabs.xml', $path, $result);
+
+// phpcs --encoding=utf-8 --tab-width=4 --standard=framework/tests/phpcs/ruleset.xml
+run_sniff('ruleset.xml', $path, $result, '--tab-width=4');
+
+echo json_encode($result);
+
+function run_sniff($standard, $path, array &$result, $extraFlags = '') {
+	$sniffPath = escapeshellarg(__DIR__ . '/phpcs/' . $standard);
+	$checkPath = escapeshellarg($path);
+
+	exec("phpcs --encoding=utf-8 $extraFlags --standard=$sniffPath --report=xml $checkPath", $output);
+
+	// We can't check the return code as it's non-zero if the sniff finds an error
+	if($output) {
+		$xml = implode("\n", $output);
+		$xml = simplexml_load_string($xml);
+		$errors = $xml->xpath('/phpcs/file/error');
+		if($errors) {
+			$sanePath = str_replace('/', '_', $path);
+			foreach($errors as $error) {
+				$attributes = $error->attributes();
+				$result['comments'][] = array(
+					'line' => (int)strval($attributes->line),
+					'id' => $standard . '-' . $sanePath . '-' . $attributes->line . '-' . $attributes->column,
+					'message' => strval($error)
+				);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This requires turnings scrutiniser on (https://scrutinizer-ci.com) and then runs the tabs and end of line character sniffs. The line-length is still done through travis since we can’t have multiple configs for scrutiniser and it should be a soft-fail anyway.
