### PR TITLE
Rewrite old file + sitetree links to new shortcode format in HtmlEditorF...

### DIFF
--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -112,33 +112,23 @@ class HtmlEditorField extends TextareaField {
 				$href = Director::makeRelative($link->getAttribute('href'));
 
 				if($href) {
-					if(preg_match('/\[sitetree_link(?|(,)|( ))id=([0-9]+)\]/i', $href, $matches)) {
-						$ID = $matches[2];
-						if($matches[1]==' ') {	// rewrite old links to new syntax
+					if(preg_match('/\[(?|(sitetree)|(file))_link(?|(,)|( ))id=([0-9]+)\]/i', $href, $matches)) {
+						$ID = $matches[3];
+						if($matches[2]==' ') {	// rewrite old links to new syntax
 							$link->removeAttribute('href');
-							$link->setAttribute('href', '[sitetree_link,id=' . $ID . ']');
+							$link->setAttribute('href', '[' . $matches[1] . '_link,id=' . $ID . ']');
 						}
 						// clear out any broken link classes
 						if($class = $link->getAttribute('class')) {
 							$link->setAttribute('class',
 									preg_replace('/(^ss-broken|ss-broken$| ss-broken )/', null, $class));
 						}
-
-						$linkedPages[] = $ID;
-						if(!DataObject::get_by_id('SiteTree', $ID))  $record->HasBrokenLink = true;
-
-					} else if(preg_match('/\[file_link,id=([0-9]+)\]/i', $href, $matches)) {
-						$ID = $matches[1];
-
-						// clear out any broken link classes
-						if($class = $link->getAttribute('class')) {
-							$link->setAttribute('class',
-									preg_replace('/(^ss-broken|ss-broken$| ss-broken )/', null, $class));
+						if($matches[1]=='sitetree') {
+							$linkedPages[] = $ID;
+						}else {
+							$linkedFiles[] = $ID;
 						}
-
-						$linkedFiles[] = $ID;
 						if(!DataObject::get_by_id('SiteTree', $ID))  $record->HasBrokenLink = true;
-						
 					} else if(substr($href, 0, strlen(ASSETS_DIR) + 1) == ASSETS_DIR.'/') {
 						$candidateFile = File::find(Convert::raw2sql(urldecode($href)));
 						if($candidateFile) {


### PR DESCRIPTION
...ield.php

The file and sitetree links shortcode formats have changed and old url based file links are no longer taken care of by HtmlEditorField.

This proposed change will rewrite those links into the form that is expected by the component.
A migration task might be better suited for this, but this is what I came up with.
