### PR TITLE
BUG All tabs are in open state when changing the name of a folder.

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -643,6 +643,10 @@ jQuery.noConflict();
 
 					if(!tabset.data('tabs')) return; // don't act on uninit'ed controls
 
+					// The tabs may have changed, notify the widget that it should update its internal state.
+					tabset.tabs('refresh');
+
+					// Make sure the intended tab is selected.
 					if(forcedTab.length) {
 						index = forcedTab.index();
 					} else if(overrideStates && overrideStates[tabsetId]) {


### PR DESCRIPTION
Submitting the form via AJAX changes the DOM controlled by the tabs
widget, it needs to be notified about the change.

Refresh seems to be the right method to use: http://api.jqueryui.com/1.9/tabs/#method-refresh
