### PR TITLE
Show HTMLEditorField in full width by default

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -265,6 +265,9 @@ input.radio { margin-left: 0; }
 .optionset.field { padding-top: 0; }
 
 /** ---------------------------------------------------- HTML Text  ---------------------------------------------------- */
+.htmleditor label { display: block; float: none; padding-bottom: 10px; }
+.htmleditor .middleColumn { margin-left: 0px; clear: left; }
+.htmleditor .description { margin-left: 0px; }
 .htmleditor textarea { visibility: hidden; }
 .htmleditor .mceEditor input, .htmleditor .mceEditor select { width: auto; }
 .htmleditor label.left { padding-bottom: 4px; }

--- a/admin/scss/_forms.scss
+++ b/admin/scss/_forms.scss
@@ -153,20 +153,7 @@ form.nostyle {
 }
 
 form.stacked .field, .field.stacked {
-	label {
-		display: block;
-		float: none;
-		padding-bottom: 10px;
-	}
-	
-	.middleColumn {
-		margin-left: 0px;
-		clear: left;
-	}
-
-	.description {
-		margin-left: 0px;
-	}
+	@include form-field-stacked;
 }
 
 form.small .field, .field.small {
@@ -648,6 +635,8 @@ input.radio {
  * ---------------------------------------------------- */
 
 .htmleditor {
+
+	@include form-field-stacked;
 	
 	textarea {
 		visibility: hidden; // enabled by JS

--- a/admin/scss/_mixins.scss
+++ b/admin/scss/_mixins.scss
@@ -117,6 +117,26 @@
   transition-duration: $time; 
 }
 
+//** ----------------------------------------------------
+// * Show label and field content in their own lines,
+// * to maximize the available horizontal space.
+// * ----------------------------------------------------- */
+@mixin form-field-stacked {
+	label {
+		display: block;
+		float: none;
+		padding-bottom: 10px;
+	}
+	
+	.middleColumn {
+		margin-left: 0px;
+		clear: left;
+	}
+
+	.description {
+		margin-left: 0px;
+	}
+}
 
 /*Mixin used to generate slightly smaller text and forms
 Used in side panels and action tabs


### PR DESCRIPTION
We've implemented this as a one-off for the "Content" field,
but in practice its useful everywhere. Or to say it another way:
It wastes a lot of valueable space due to the label indentation
without it, and using $myField->addExtraClass('stacked') everywhere
is clumsy.
