### PR TITLE
FIX: Minor CSS issues on DatetimeField (fixes #1872)

### DIFF
--- a/css/DatetimeField.css
+++ b/css/DatetimeField.css
@@ -1,1 +1,2 @@
 .datetime .middleColumn .middleColumn { margin: 0; padding: 0; clear: none; float: left; }
+.datetime .middleColumn .field { margin: 0; border-bottom: none; box-shadow: none; }

--- a/scss/DatetimeField.scss
+++ b/scss/DatetimeField.scss
@@ -4,3 +4,8 @@
 	clear: none;
 	float: left;
 }
+.datetime .middleColumn .field {
+	margin: 0;
+	border-bottom: none;
+	box-shadow: none;
+}


### PR DESCRIPTION
The two 'child' field divs with a `.field` class were adding additional margin and borders
