### PR TITLE
FIX #1866 Environment file finder logic

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -44,24 +44,46 @@
 error_reporting(E_ALL | E_STRICT);
 
 /**
- * Include _ss_environment.php files
+ * Include _ss_environment.php file
  */
 //define the name of the environment file
 $envFile = '_ss_environment.php';
-//define the dir to start scanning from (have to add the trailing slash)
-$dir = '.';
-//check this dir and every parent dir (until we hit the base of the drive)
-do {
-	$dir = realpath($dir) . '/';
-	//if the file exists, then we include it, set relevant vars and break out
-	if (file_exists($dir . $envFile)) {
-		define('SS_ENVIRONMENT_FILE', $dir . $envFile);
-		include_once(SS_ENVIRONMENT_FILE);
-		break;
-	}
-//here we need to check that the real path of the last dir and the next one are
-// not the same, if they are, we have hit the root of the drive
-} while (realpath($dir) != realpath($dir .= '../'));
+//define the dirs to start scanning from (have to add the trailing slash)
+// we're going to check the realpath AND the path as the script sees it
+$dirsToCheck = array(
+	realpath('.'),
+	dirname($_SERVER['SCRIPT_FILENAME'])
+);
+//if they are the same, remove one of them
+if ($dirsToCheck[0] == $dirsToCheck[1]) {
+	unset($dirsToCheck[1]);
+}
+foreach ($dirsToCheck as $dir) {
+	//check this dir and every parent dir (until we hit the base of the drive)
+	// or until we hit a dir we can't read
+	do {
+		//add the trailing slash we need to concatenate properly
+		$dir .= DIRECTORY_SEPARATOR;
+		//if it's readable, go ahead
+		if (@is_readable($dir)) {
+			//if the file exists, then we include it, set relevant vars and break out
+			if (file_exists($dir . $envFile)) {
+				define('SS_ENVIRONMENT_FILE', $dir . $envFile);
+				include_once(SS_ENVIRONMENT_FILE);
+				//break out of BOTH loops because we found the $envFile
+				break(2);
+			}
+		}
+		else {
+			//break out of the while loop, we can't read the dir
+			break;
+		}
+		//go up a directory
+		$dir = dirname($dir);
+	//here we need to check that the path of the last dir and the next one are
+	// not the same, if they are, we have hit the root of the drive
+	} while (dirname($dir) != $dir);
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // GLOBALS AND DEFINE SETTING

--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -28,27 +28,47 @@ if (function_exists('session_start')) {
 	session_start();
 }
 
-// Include environment files
-$usingEnv = false;
-$envFileExists = false;
+/**
+ * Include _ss_environment.php file
+ */
 //define the name of the environment file
 $envFile = '_ss_environment.php';
-//define the dir to start scanning from
-$dir = '.';
-//check this dir and every parent dir (until we hit the base of the drive)
-do {
-	$dir = realpath($dir) . '/';
-	//if the file exists, then we include it, set relevant vars and break out
-	if (file_exists($dir . $envFile)) {
-		include_once($dir . $envFile);
-		$envFileExists = true;
-		//legacy variable assignment
-		$usingEnv = true;
-		break;
-	}
-//here we need to check that the real path of the last dir and the next one are
-// not the same, if they are, we have hit the root of the drive
-} while (realpath($dir) != realpath($dir .= '../'));
+//define the dirs to start scanning from (have to add the trailing slash)
+// we're going to check the realpath AND the path as the script sees it
+$dirsToCheck = array(
+	realpath('.'),
+	dirname($_SERVER['SCRIPT_FILENAME'])
+);
+//if they are the same, remove one of them
+if ($dirsToCheck[0] == $dirsToCheck[1]) {
+	unset($dirsToCheck[1]);
+}
+foreach ($dirsToCheck as $dir) {
+	//check this dir and every parent dir (until we hit the base of the drive)
+	// or until we hit a dir we can't read
+	do {
+		//add the trailing slash we need to concatenate properly
+		$dir .= DIRECTORY_SEPARATOR;
+		//if it's readable, go ahead
+		if (@is_readable($dir)) {
+			//if the file exists, then we include it, set relevant vars and break out
+			if (file_exists($dir . $envFile)) {
+				define('SS_ENVIRONMENT_FILE', $dir . $envFile);
+				include_once(SS_ENVIRONMENT_FILE);
+				//break out of BOTH loops because we found the $envFile
+				break(2);
+			}
+		}
+		else {
+			//break out of the while loop, we can't read the dir
+			break;
+		}
+		//go up a directory
+		$dir = dirname($dir);
+	//here we need to check that the path of the last dir and the next one are
+	// not the same, if they are, we have hit the root of the drive
+	} while (dirname($dir) != $dir);
+}
 
 if($envFileExists) {
 	if(!empty($_REQUEST['useEnv'])) {


### PR DESCRIPTION
Fixing the logic that searches for environment files so that warnings
due to open_basedir are suppressed and both the 'realdir' and the server
path are spidered for the environment file.

Fixing issue #1866
