### PR TITLE
BUG: Treedropdowns broken inside togglecomposite fields (fixes #1945)

### DIFF
--- a/css/TreeDropdownField.css
+++ b/css/TreeDropdownField.css
@@ -1,4 +1,4 @@
-div.TreeDropdownField { width: 400px; background: #fff; border: 1px solid #aaa; cursor: pointer; overflow: hidden; }
+div.TreeDropdownField { width: 400px; background: #fff; border: 1px solid #aaa; cursor: pointer; overflow: visible; position: relative; }
 div.TreeDropdownField input { border: none; background: none; padding: 0; margin: 0; }
 div.TreeDropdownField .treedropdownfield-title { float: left; padding: 7px; width: 90%; line-height: 16px; overflow: hidden; outline: none; }
 div.TreeDropdownField .treedropdownfield-panel { clear: left; position: absolute; overflow: auto; display: none; cursor: default; border: 1px solid #aaa; border-top: none; margin: 1px 0 0 -1px; /* account for border on container div */ max-height: 200px; background-color: #fff; z-index: 50; -webkit-box-shadow: 0 4px 5px rgba(0, 0, 0, 0.15); -moz-box-shadow: 0 4px 5px rgba(0, 0, 0, 0.15); -o-box-shadow: 0 4px 5px rgba(0, 0, 0, 0.15); box-shadow: 0 4px 5px rgba(0, 0, 0, 0.15); }

--- a/javascript/TreeDropdownField.js
+++ b/javascript/TreeDropdownField.js
@@ -58,9 +58,7 @@
 				$('body').bind('click', _clickTestFn);
 				
 				var panel = this.getPanel(), tree = this.find('.tree-holder');
-				var top = this.position().top + this.height();
-				
-				panel.css('top', top);
+
 				panel.css('width', this.width());
 				
 				panel.show();

--- a/scss/TreeDropdownField.scss
+++ b/scss/TreeDropdownField.scss
@@ -3,7 +3,8 @@ div.TreeDropdownField {
 	background: #fff;
 	border: 1px solid #aaa;
 	cursor: pointer;
-	overflow: hidden;
+	overflow: visible;
+	position:relative;
 
 	input {
 		border: none;


### PR DESCRIPTION
- Removed positioning javascript from treedropdownfield
- Set parent to be relatively positioned and overflow to visible

I have tested with large and small sitetrees, inside a gridfield, in the files area, inside a toggle composite, and at the very bottom of a tab (after scrolling: n.b. it was originally broken here too). 

Browsers tested:
- Firefox
- Chrome
- IE9
- IE8 (this browser does have a slight issues, as it doesn't resize the toggle composite field to fit the treedropdown field. This fix doesn't change anything on that front. )
