### PR TITLE
BUGFIX: Pages set as 'deletedindraft' were allowed to be published throu...

### DIFF
--- a/admin/code/CMSBatchAction.php
+++ b/admin/code/CMSBatchAction.php
@@ -82,9 +82,13 @@ abstract class CMSBatchAction extends Object {
 		
 		foreach($objs as $obj) {
 			
-			// Perform the action
-			if (!call_user_func_array(array($obj, $helperMethod), $arguments)) {
-				$status['error'][$obj->ID] = '';
+			// Don't run doPublish() if $obj isn't in a fit state be published
+			// @todo Implementation logic _is_ better in CMSBatchAction_Publish#run() but at least objects not matching, still get the batchaction run over them
+			if ($helperMethod == 'isPublish' && !$obj->getIsDeletedFromStage()) {
+				// Perform the action
+				if (!call_user_func_array(array($obj, $helperMethod), $arguments)) {
+					$status['error'][$obj->ID] = '';
+				}
 			}
 			
 			// Now make sure the tree title is appropriately updated


### PR DESCRIPTION
BUGFIX: Pages set as 'deletedindraft' were allowed to be published through CMS batch-actions leaving an empty title in the SiteTree.
