### PR TITLE
FIX: error message doesn't always include class name

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -746,8 +746,8 @@ abstract class Object {
 			}
 		} else {
 			// Please do not change the exception code number below.
-			
-			throw new Exception("Object->__call(): the method '$method' does not exist on '$this->class'", 2175);
+			$class = (empty($this->class) ? get_class($this) : $this->class);
+			throw new Exception("Object->__call(): the method '$method' does not exist on '$class'", 2175);
 		}
 	}
 	


### PR DESCRIPTION
When a method was not found on UnsavedRelationList I was getting the following error:
Object->__call(): the method 'nameOfMethod' does not exist on ''
(nameOfMethod has been replaced here since it was a method I added via an extension)
