### PR TITLE
FIX: UnsavedRelationList did not call its constructor

### DIFF
--- a/model/UnsavedRelationList.php
+++ b/model/UnsavedRelationList.php
@@ -51,6 +51,7 @@ class UnsavedRelationList extends ArrayList {
 		$this->baseClass = $baseClass;
 		$this->relationName = $relationName;
 		$this->dataClass = $dataClass;
+		parent::__construct();
 	}
 
 	/**


### PR DESCRIPTION
This resulted in Object extensions not working for it, and methods not existing
where they should have.  It also resulted in poor error messages appearing when
thrown from Object since $this->class was empty since the constructor was never
called in Object.
