### PR TITLE
FIX CMS-445 Avoid collision of status flags in tree items when updating ...

### DIFF
--- a/admin/javascript/LeftAndMain.Tree.js
+++ b/admin/javascript/LeftAndMain.Tree.js
@@ -291,6 +291,15 @@
 					node.attr(attrName, newNode.attr(attrName));
 				});
 
+				// To avoid conflicting classes when the node gets its content replaced (see below)
+				// Filter out all previous status flags if they are not in the class property of the new node
+				var statusFlags = ['removedfromdraft', 'deletedonlive', 'addedtodraft', 'modified'];
+				for(var i=0; i<statusFlags.length; i++){
+					if (node.attr('class').indexOf(statusFlags[i]) === -1){
+						origClasses = origClasses.replace(statusFlags[i], '');
+					}
+				}
+
 				// Replace inner content
 				var origChildren = node.children('ul').detach();
 				node.addClass(origClasses).html(newNode.html()).append(origChildren);


### PR DESCRIPTION
...tree nodes. This is to avoid tree items still being striked through after a restore. Issue is that when the node gets its classes repopulated, so that js-leaf is preserved, the old status flag is kept, and the new status flag is merged. As a result, conflicting classes are both in the class attributes. This patch ensures old status are not merged if they are not present in the returned html. This fix is related to https://github.com/silverstripe/silverstripe-cms/issues/445
On a side note, I noticed another issue where the message when restoring is the escaped version of the html for the tree node, not the page title. I ensured my patch is not responsible for that regression.
