### PR TITLE
Deprecate magic_quotes and fix bad install opts

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -142,6 +142,9 @@ if(!isset($_SERVER['HTTP_HOST'])) {
 		if($_GET) stripslashes_recursively($_GET);
 		if($_POST) stripslashes_recursively($_POST);
 		if($_COOKIE) stripslashes_recursively($_COOKIE);
+		// No more magic_quotes!
+		trigger_error('get_magic_quotes_gpc support is being removed from Silverstripe. Please set this to off in ' .
+			' your php.ini and see http://php.net/manual/en/security.magicquotes.php', E_USER_WARNING);
 	}
 	
 	/**

--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -488,9 +488,9 @@ class InstallRequirements {
 
 		$this->suggestClass('tidy', array('PHP Configuration', 'tidy support', 'Tidy provides a library of code to clean up your html. SilverStripe will operate fine without tidy but HTMLCleaner will not be effective.'));
 
-		$this->suggestPHPSetting('asp_tags', array(false,0,''), array('PHP Configuration', 'asp_tags option', 'This should be turned off as it can cause issues with SilverStripe'));
-		$this->suggestPHPSetting('magic_quotes_gpc', array(false,0,''), array('PHP Configuration', 'magic_quotes_gpc option', 'This should be turned off, as it can cause issues with cookies. More specifically, unserializing data stored in cookies.'));
-		$this->suggestPHPSetting('display_errors', array(false,0,''), array('PHP Configuration', 'display_errors option', 'Unless you\'re in a development environment, this should be turned off, as it can expose sensitive data to website users.'));
+		$this->suggestPHPSetting('asp_tags', array(false), array('PHP Configuration', 'asp_tags option', 'This should be turned off as it can cause issues with SilverStripe'));
+		$this->requirePHPSetting('magic_quotes_gpc', array(false), array('PHP Configuration', 'magic_quotes_gpc option', 'This should be turned off, as it can cause issues with cookies. More specifically, unserializing data stored in cookies.'));
+		$this->suggestPHPSetting('display_errors', array(false), array('PHP Configuration', 'display_errors option', 'Unless you\'re in a development environment, this should be turned off, as it can expose sensitive data to website users.'));
 
 		// Check memory allocation
 		$this->requireMemory(32*1024*1024, 64*1024*1024, array("PHP Configuration", "Memory allocation (PHP config option 'memory_limit')", "SilverStripe needs a minimum of 32M allocated to PHP, but recommends 64M.", ini_get("memory_limit")));
@@ -505,6 +505,16 @@ class InstallRequirements {
 		if(!in_array($val, $settingValues) && $val != $settingValues) {
 			$testDetails[2] = "$settingName is set to '$val' in php.ini.  $testDetails[2]";
 			$this->warning($testDetails);
+		}
+	}
+
+	function requirePHPSetting($settingName, $settingValues, $testDetails) {
+		$this->testing($testDetails);
+
+		$val = ini_get($settingName);
+		if(!in_array($val, $settingValues) && $val != $settingValues) {
+			$testDetails[2] = "$settingName is set to '$val' in php.ini.  $testDetails[2]";
+			$this->error($testDetails);
 		}
 	}
 


### PR DESCRIPTION
Change the in_array call to not do bad things with strict casting off
Add a deprecated message if you run with magic_quotes on
Change the requirement for magic_quotes to an error
