### PR TITLE
Fix return the member ID for logInWithPermission

### DIFF
--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -855,6 +855,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 		}
 		
 		$this->cache_generatedMembers[$permCode]->logIn();
+		return $this->cache_generatedMembers[$permCode]->id;
 	}
 	
 	/**


### PR DESCRIPTION
Will now return the ID, as per the doc-block comment
