### PR TITLE
BUG Fixed major issue with testing dataobjects that implement TestOnly

### DIFF
--- a/dev/TestRunner.php
+++ b/dev/TestRunner.php
@@ -92,6 +92,10 @@ class TestRunner extends Controller {
 		Config::inst()->pushConfigStaticManifest(new SS_ConfigStaticManifest(
 			BASE_PATH, true, isset($_GET['flush'])
 		));
+		
+		// Invalidate classname spec since the test manifest will now pull out new subclasses for each internal class
+		// (e.g. Member will now have various subclasses of DataObjects that implement TestOnly)
+		DataObject::clear_classname_spec_cache();
 	}
 
 	public function init() {

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -192,6 +192,14 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	 * @var [string] - class => ClassName field definition cache for self::database_fields
 	 */
 	private static $classname_spec_cache = array();
+	
+	/**
+	 * Clear all cached classname specs. It's necessary to clear all cached subclassed names
+	 * for any classes if a new class manifest is generated.
+	 */
+	public static function clear_classname_spec_cache() {
+		self::$classname_spec_cache = array();
+	}
 
 	/**
 	 * Return the complete map of fields on this object, including "Created", "LastEdited" and "ClassName".
@@ -202,7 +210,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	 */
 	public static function database_fields($class) {
 		if(get_parent_class($class) == 'DataObject') {
-			if(!isset(self::$classname_spec_cache[$class])) {
+			if(empty(self::$classname_spec_cache[$class])) {
 				$classNames = ClassInfo::subclassesFor($class);
 
 				$db = DB::getConn();


### PR DESCRIPTION
Fixed major issue with testing dataobjects that implement TestOnly and extend non-TestOnly dataobjects. Database regeneration would incorrectly populate the ClassName column.

For some reason without this code the "ClassName" DB field generation was very temperamental. The problem is that this value is cached before the test SS_ClassManifest is initiated, meaning that it contained invalid data.

The fix to this is to clear this cache in the test initialisation phase just after adding the new manifest.

@kmayo-ss - This is the cause of that issue that wasted 1 of each of our hours at hackfest!
