### PR TITLE
BUG Non-object error attempting to upload file to assets root

### DIFF
--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -425,9 +425,14 @@ class UploadField extends FileField {
 		//get all the existing files in the current folder
 		if ($this->getConfig('overwriteWarning')) {
 			$folder = Folder::find_or_make($this->getFolderName());
-			$files = glob( $folder->getFullPath() . '/*' );
-			$config['existingFiles'] = array_map("basename", $files);;
-
+			if($folder && $folder->exists()) {
+				$path = $folder->getFullPath();
+			} else {
+				// we're overwriting a file in the assets root
+				$path = ASSETS_PATH;
+			}
+			$files = glob($path . '/*');
+			$config['existingFiles'] = array_map("basename", $files);
 			//add overwrite warning error message to the config object sent to Javascript
 			$config['errorMessages']['overwriteWarning'] =
 				_t('UploadField.OVERWRITEWARNING','File with the same name already exists');


### PR DESCRIPTION
This fixes a regression in UploadField caused by 22c7bbfcd42a8785da4d443d5573981b2ee1d220

UploadField assumes a Folder record exists, but if you're
uploading a file to the assets root, a non-object error is
thrown instead.

Use ASSETS_PATH as the upload path when a Folder->getFullPath()
isn't available.
