### PR TITLE
FIX: <% if Link %> wasn't working

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -2643,8 +2643,8 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 		} else if($fieldName == 'ID') {
 			return new PrimaryKey($fieldName, $this);
 			
-		// General casting information for items in $db or $casting
-		} else if($helper = $this->castingHelper($fieldName)) {
+		// General casting information for items in $db
+		} else if($helper = $this->db($fieldName)) {
 			$obj = Object::create_from_string($helper, $fieldName);
 			$obj->setValue($this->$fieldName, $this->record, false);
 			return $obj;

--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -165,6 +165,18 @@ SS;
 			'Permissions template functions result correct result');
 	}
 
+	public function testNonFieldCastingHelpersNotUsedInHasValue() {
+		// check if Link without $ in front of variable
+		$result = $this->render(
+			'A<% if Link %>$Link<% end_if %>B', new SSViewerTest_Object());
+		$this->assertEquals('Asome/url.htmlB', $result, 'casting helper not used for <% if Link %>');
+
+		// check if Link with $ in front of variable
+		$result = $this->render(
+			'A<% if $Link %>$Link<% end_if %>B', new SSViewerTest_Object());
+		$this->assertEquals('Asome/url.htmlB', $result, 'casting helper not used for <% if $Link %>');
+	}
+
 	public function testLocalFunctionsTakePriorityOverGlobals() {
 		$data = new ArrayData(array(
 			'Page' => new SSViewerTest_Object()
@@ -1274,6 +1286,11 @@ class SSViewerTest_Object extends DataObject {
 
 	public $number = null;
 
+	private static $casting = array(
+		'Link' => 'Text',
+	);
+
+
 	public function __construct($number = null) {
 		parent::__construct();
 		$this->number = $number;
@@ -1289,6 +1306,10 @@ class SSViewerTest_Object extends DataObject {
 
 	public function lotsOfArguments11($a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k) {
 		return $a. $b. $c. $d. $e. $f. $g. $h. $i. $j. $k;
+	}
+
+	public function Link() {
+		return 'some/url.html';
 	}
 }
 


### PR DESCRIPTION
Since ViewableData was returning a casting helper for Link, but DataObject was
only using $this->$fieldname to set values on that casting helper, you could
not use <% if Link %> (or <% if $Link %>) in your templates because Link is not
a field, and thus had no value to be set on the casting helper, causing
hasValue to think that there was no value.  Since DataObject->dbOject says that
"it only matches fields and not methods", it seems safe to have it pass an
argument to ViewableData->castingHelper requiring it to do the same - only
return casting helpers for actual DB fields and not other things in the casting
config.
