### PR TITLE
[3.2] FIX Prevent arguments passed to template methods from resetting the scope

### DIFF
--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -1062,7 +1062,7 @@ after')
 		$origEnv = Config::inst()->get('Director', 'environment_type');
 		Config::inst()->update('Director', 'environment_type', 'dev');
 		Config::inst()->update('SSViewer', 'source_file_comments', true);
-	   $f = FRAMEWORK_PATH . '/tests/templates/SSViewerTestComments';
+		$f = FRAMEWORK_PATH . '/tests/templates/SSViewerTestComments';
 		$templates = array(
 			array(
 				'name' => 'SSViewerTestCommentsFullSource',
@@ -1078,7 +1078,8 @@ after')
 			array(
 				'name' => 'SSViewerTestCommentsFullSourceHTML4Doctype',
 				'expected' => ""
-					. "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"\t\t\"http://www.w3.org/TR/html4/strict.dtd\">"
+					. "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML "
+					. "4.01//EN\"\t\t\"http://www.w3.org/TR/html4/strict.dtd\">"
 					. "<!-- template $f/SSViewerTestCommentsFullSourceHTML4Doctype.ss -->"
 					. "<html>"
 					. "\t<head></head>"
@@ -1196,6 +1197,45 @@ after')
 			$template->process(array()), 
 			"tests/forms/RequirementsTest_a.js"
 		));
+	}
+
+	public function testCallsWithArguments() {
+		$data = new ArrayData(array(
+			'Set' => new ArrayList(array(
+				new SSViewerTest_Object("1"),
+				new SSViewerTest_Object("2"),
+				new SSViewerTest_Object("3"),
+				new SSViewerTest_Object("4"),
+				new SSViewerTest_Object("5"),
+			)),
+			'Level' => new SSViewerTest_LevelTest(1),
+			'Nest' => array(
+				'Level' => new SSViewerTest_LevelTest(2),
+			),
+		));
+
+		$tests = array(
+			'$Level.output(1)' => '1-1',
+			'$Nest.Level.output($Set.First.Number)' => '2-1',
+			'<% with $Set %>$Up.Level.output($First.Number)<% end_with %>' => '1-1',
+			'<% with $Set %>$Top.Nest.Level.output($First.Number)<% end_with %>' => '2-1',
+			'<% loop $Set %>$Up.Nest.Level.output($Number)<% end_loop %>' => '2-12-22-32-42-5',
+			'<% loop $Set %>$Top.Level.output($Number)<% end_loop %>' => '1-11-21-31-41-5',
+			'<% with $Nest %>$Level.output($Top.Set.First.Number)<% end_with %>' => '2-1',
+			'<% with $Level %>$output($Up.Set.Last.Number)<% end_with %>' => '1-5',
+			'<% with $Level.forWith($Set.Last.Number) %>$output("hi")<% end_with %>' => '5-hi',
+			'<% loop $Level.forLoop($Set.First.Number) %>$Number<% end_loop %>' => '!0',
+			'<% with $Nest %>
+				<% with $Level.forWith($Up.Set.First.Number) %>$output("hi")<% end_with %>
+			<% end_with %>' => '1-hi',
+			'<% with $Nest %>
+				<% loop $Level.forLoop($Top.Set.Last.Number) %>$Number<% end_loop %>
+			<% end_with %>' => '!0!1!2!3!4',
+		);
+
+		foreach($tests as $template => $expected) {
+			$this->assertEquals($expected, trim($this->render($template, $data)));
+		}
 	}
 }
 
@@ -1326,3 +1366,28 @@ class SSViewerTest_GlobalProvider implements TemplateGlobalProvider, TestOnly {
 	}
 
 }
+
+class SSViewerTest_LevelTest extends ViewableData implements TestOnly {
+	protected $depth;
+
+	public function __construct($depth = 1) {
+		$this->depth = $depth;
+	}
+
+	public function output($val) {
+		return "$this->depth-$val";
+	}
+
+	public function forLoop($number) {
+		$ret = array();
+		for($i = 0; $i < (int)$number; ++$i) {
+			$ret[] = new SSViewerTest_Object("!$i");
+		}
+		return new ArrayList($ret);
+	}
+
+	public function forWith($number) {
+		return new self($number);
+	}
+}
+

--- a/view/SSTemplateParser.php
+++ b/view/SSTemplateParser.php
@@ -941,7 +941,9 @@ class SSTemplateParser extends Parser {
 
 
 	function Injection_STR(&$res, $sub) {
-		$res['php'] = '$val .= '. str_replace('$$FINAL', 'XML_val', $sub['Lookup']['php']) . ';';
+		list($clones, $call) = $this->cloneArgumentScopes($sub['Lookup']['php']);
+		$res['php'] .= $clones;
+		$res['php'] .= '$val .= '. str_replace('$$FINAL', 'XML_val', $call) . ';';
 	}
 
 	/* DollarMarkedLookup: SimpleInjection */
@@ -3613,6 +3615,9 @@ class SSTemplateParser extends Parser {
 				($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
 		}
 
+		list($clones, $on) = $this->cloneArgumentScopes($on);
+		$on = $clones . $on;
+
 		return
 			$on . '; $scope->pushScope(); while (($key = $scope->next()) !== false) {' . PHP_EOL .
 				$res['Template']['php'] . PHP_EOL .
@@ -3641,8 +3646,12 @@ class SSTemplateParser extends Parser {
 		if ($arg['ArgumentMode'] == 'string') {
 			throw new SSTemplateParseException('Control block cant take string as argument.', $this);
 		}
-		
+	
 		$on = str_replace('$$FINAL', 'obj', ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
+
+		list($clones, $on) = $this->cloneArgumentScopes($on);
+		$on = $clones . $on;
+
 		return 
 			$on . '; $scope->pushScope();' . PHP_EOL .
 				$res['Template']['php'] . PHP_EOL .
@@ -4548,7 +4557,8 @@ class SSTemplateParser extends Parser {
 		// non-dynamically calculated
 		$text = preg_replace(
 			'/href\s*\=\s*\"\#/', 
-			'href="\' . (Config::inst()->get(\'SSViewer\', \'rewrite_hash_links\') ? strip_tags( $_SERVER[\'REQUEST_URI\'] ) : "") . 
+			'href="\' . (Config::inst()->get(\'SSViewer\', \'rewrite_hash_links\') ?
+				strip_tags( $_SERVER[\'REQUEST_URI\'] ) : "") . 
 				\'#',
 			$text
 		);
@@ -4630,6 +4640,51 @@ class SSTemplateParser extends Parser {
 			$code .= "\r\n" . '$val .= \'<!-- end template ' . $templateName . ' -->\';';
 		}
 		return $code;
+	}
+
+	/**
+	 * Parses a line of PHP and clones all variables after the first one.
+	 *
+	 * @param string $code The line of generated to PHP
+	 * @return array A two element array containing the clone calls as the first element and the updated code line
+	 *               as the second element.
+	 */
+	protected function cloneArgumentScopes($code) {
+		$clones = '';
+		$tokens = token_get_all('<?php ' . $code);
+		array_shift($tokens);
+		$i = 0;
+		foreach($tokens as &$token) {
+			// We only care about variables
+			if(!is_array($token) || $token[0] != T_VARIABLE) {
+				continue;
+			}
+			// Skip the '$FINAL' variable
+			if($token[1] == '$FINAL') {
+				continue;
+			}
+			// We don't want to rename the very first one
+			if(!$i) {
+				$i++;
+				continue;
+			}
+			$name = "{$token[1]}_{$i}_clone";
+			$clones .= "$name = clone $token[1];\n";
+			$token[1] = $name;
+			$i++;
+		}
+
+		// Build the string up again
+		$code = '';
+		foreach($tokens as $t) {
+			if(is_array($t)) {
+				$code .= $t[1];
+			} else {
+				$code .= $t;
+			}
+		}
+
+		return array($clones, $code);
 	}
 	
 	/**

--- a/view/SSTemplateParser.php.inc
+++ b/view/SSTemplateParser.php.inc
@@ -252,7 +252,9 @@ class SSTemplateParser extends Parser {
 	Injection: BracketInjection | SimpleInjection
 	*/
 	function Injection_STR(&$res, $sub) {
-		$res['php'] = '$val .= '. str_replace('$$FINAL', 'XML_val', $sub['Lookup']['php']) . ';';
+		list($clones, $call) = $this->cloneArgumentScopes($sub['Lookup']['php']);
+		$res['php'] .= $clones;
+		$res['php'] .= '$val .= '. str_replace('$$FINAL', 'XML_val', $call) . ';';
 	}
 
 	/*!*
@@ -793,6 +795,9 @@ class SSTemplateParser extends Parser {
 				($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
 		}
 
+		list($clones, $on) = $this->cloneArgumentScopes($on);
+		$on = $clones . $on;
+
 		return
 			$on . '; $scope->pushScope(); while (($key = $scope->next()) !== false) {' . PHP_EOL .
 				$res['Template']['php'] . PHP_EOL .
@@ -821,8 +826,12 @@ class SSTemplateParser extends Parser {
 		if ($arg['ArgumentMode'] == 'string') {
 			throw new SSTemplateParseException('Control block cant take string as argument.', $this);
 		}
-		
+	
 		$on = str_replace('$$FINAL', 'obj', ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
+
+		list($clones, $on) = $this->cloneArgumentScopes($on);
+		$on = $clones . $on;
+
 		return 
 			$on . '; $scope->pushScope();' . PHP_EOL .
 				$res['Template']['php'] . PHP_EOL .
@@ -1002,7 +1011,8 @@ class SSTemplateParser extends Parser {
 		// non-dynamically calculated
 		$text = preg_replace(
 			'/href\s*\=\s*\"\#/', 
-			'href="\' . (Config::inst()->get(\'SSViewer\', \'rewrite_hash_links\') ? strip_tags( $_SERVER[\'REQUEST_URI\'] ) : "") . 
+			'href="\' . (Config::inst()->get(\'SSViewer\', \'rewrite_hash_links\') ?
+				strip_tags( $_SERVER[\'REQUEST_URI\'] ) : "") . 
 				\'#',
 			$text
 		);
@@ -1084,6 +1094,51 @@ class SSTemplateParser extends Parser {
 			$code .= "\r\n" . '$val .= \'<!-- end template ' . $templateName . ' -->\';';
 		}
 		return $code;
+	}
+
+	/**
+	 * Parses a line of PHP and clones all variables after the first one.
+	 *
+	 * @param string $code The line of generated to PHP
+	 * @return array A two element array containing the clone calls as the first element and the updated code line
+	 *               as the second element.
+	 */
+	protected function cloneArgumentScopes($code) {
+		$clones = '';
+		$tokens = token_get_all('<?php ' . $code);
+		array_shift($tokens);
+		$i = 0;
+		foreach($tokens as &$token) {
+			// We only care about variables
+			if(!is_array($token) || $token[0] != T_VARIABLE) {
+				continue;
+			}
+			// Skip the '$FINAL' variable
+			if($token[1] == '$FINAL') {
+				continue;
+			}
+			// We don't want to rename the very first one
+			if(!$i) {
+				$i++;
+				continue;
+			}
+			$name = "{$token[1]}_{$i}_clone";
+			$clones .= "$name = clone $token[1];\n";
+			$token[1] = $name;
+			$i++;
+		}
+
+		// Build the string up again
+		$code = '';
+		foreach($tokens as $t) {
+			if(is_array($t)) {
+				$code .= $t[1];
+			} else {
+				$code .= $t;
+			}
+		}
+
+		return array($clones, $code);
 	}
 	
 	/**


### PR DESCRIPTION
The problem here is that `$Blah.Foo($Baz)` first calculates `$Blah`, then `$Baz` and finally `.Foo()` (due to the way PHP executes calls). So the scope is changed (by `obj`), reset (by `XML_Val`) then in the wrong place to call `Foo`.

My solution is to clone the current scope for any arguments in the call, as well as in a with/loop opening block. This means the scope is correctly set for any chained calls as well as after the calls are executed (in the case of `->pushScope()`).

I’m going to be moving the code that adds the clones into its own method (it’s duplicated in three places, just with a different variable) and add tests. Hopefully going to get it done tomorrow or Friday, which should hopefully be in time for RC1.
