### PR TITLE
FIX: Add missing 'groupby' method

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -419,14 +419,22 @@ class DataQuery {
 	}
 	
 	/**
+	 * Set the GROUP BY clause of this query.
+	 * 
+	 * @param String $groupby Escaped SQL statement
+	 */
+	public function groupby($groupby) {
+		$this->query->addGroupBy($groupby);
+		return $this;
+	}
+	
+	/**
 	 * Set the HAVING clause of this query.
 	 * 
 	 * @param String $having Escaped SQL statement
 	 */
 	public function having($having) {
-		if($having) {
-			$this->query->addHaving($having);
-		}
+		$this->query->addHaving($having);
 		return $this;
 	}
 


### PR DESCRIPTION
This is a simple fix to allow the setting of SQL 'GROUP BY' from a DataQuery context.

I realise that there is a lot of work going on with regard to database abstraction aimed at 3.2 but I think this would be a really useful addition in the mean time.
