### PR TITLE
BUGFIX: Removed regression introduced in 9741d1. 

### DIFF
--- a/admin/code/CMSBatchAction.php
+++ b/admin/code/CMSBatchAction.php
@@ -82,13 +82,9 @@ abstract class CMSBatchAction extends Object {
 		
 		foreach($objs as $obj) {
 			
-			// Don't run doPublish() if $obj isn't in a fit state be published
-			// @todo Implementation logic _is_ better in CMSBatchAction_Publish#run() but at least objects not matching, still get the batchaction run over them
-			if ($helperMethod == 'isPublish' && !$obj->getIsDeletedFromStage()) {
-				// Perform the action
-				if (!call_user_func_array(array($obj, $helperMethod), $arguments)) {
-					$status['error'][$obj->ID] = '';
-				}
+			// Perform the action
+			if (!call_user_func_array(array($obj, $helperMethod), $arguments)) {
+				$status['error'][$obj->ID] = '';
 			}
 			
 			// Now make sure the tree title is appropriately updated


### PR DESCRIPTION
With the former fix in place, CMS authors are no longer perform batch publish actions, period. This fix, simply reverts 9741d1.

A better solution is therefore required.
