### PR TITLE
NEW: More helpful message for 'sake dev/build' on new envs.

### DIFF
--- a/admin/_config.php
+++ b/admin/_config.php
@@ -6,7 +6,7 @@ HtmlEditorConfig::get('cms')->setOptions(array(
 	'mode' => 'none', // initialized through LeftAndMain.EditFor.js logic
 
 	'body_class' => 'typography',
-	'document_base_url' => Director::absoluteBaseURL(),
+	'document_base_url' => isset($_SERVER['HTTP_HOST']) ? Director::absoluteBaseURL() : null,
 
 	'cleanup_callback' => "sapphiremce_cleanup",
 

--- a/cli-script.php
+++ b/cli-script.php
@@ -68,9 +68,42 @@ global $databaseConfig;
 // We don't have a session in cli-script, but this prevents errors
 $_SESSION = null;
 
-// Connect to database
 require_once("model/DB.php");
+
+
+// Connect to database
+if(!isset($databaseConfig) || !isset($databaseConfig['database']) || !$databaseConfig['database']) {
+	echo "\nPlease configure your database connection details.  You can do this by creating a file
+called _ss_environment.php in either of the following locations:\n\n";
+	echo " - " .  BASE_PATH  ."_ss_environment.php\n - " . dirname(BASE_PATH) . "_ss_environment.php\n\n";
+	echo <<<ENVCONTENT
+
+Put the following content into this file:
+--------------------------------------------------
+<?php
+
+/* Change this from 'dev' to 'live' for a production environment. */
+define('SS_ENVIRONMENT_TYPE', 'dev');
+ 
+/* This defines a default database user */
+define('SS_DATABASE_SERVER', 'localhost');
+define('SS_DATABASE_USERNAME', '<user>');
+define('SS_DATABASE_PASSWORD', '<password>');
+define('SS_DATABASE_NAME', '<database>');
+--------------------------------------------------
+
+Once you have done that, run 'composer install' or './framework/sake dev/build' to create 
+an empty database.
+
+For more information, please read this page in our docs:
+http://doc.silverstripe.org/framework/en/topics/environment-management
+
+
+ENVCONTENT;
+	exit(1);
+}
 DB::connect($databaseConfig);
+
 
 // Get the request URL from the querystring arguments
 $url = isset($_SERVER['argv'][1]) ? $_SERVER['argv'][1] : null;


### PR DESCRIPTION
This change alters the no-db message on cli execution to give a bit more of a helpful set-up instruction.

The main motivation for this is so that composer can be set to run dev/build on post-install and post-update.  With that feature added, this will ensure that users installing with composer create-project won't be left in the dark.

That change is suggested in https://github.com/silverstripe/silverstripe-installer/pull/42

An improvement on this would be a shell script that interactively asked for details to populate this file with, but one step at a time.
