### PR TITLE
FIX Deprecation $manifest not in global scope

### DIFF
--- a/dev/Deprecation.php
+++ b/dev/Deprecation.php
@@ -88,7 +88,7 @@ class Deprecation {
 
 		$callingfile = realpath($backtrace[1]['file']);
 
-		global $manifest;
+		$manifest = SS_ClassLoader::instance()->getManifest();
 		foreach ($manifest->getModules() as $name => $path) {
 			if (strpos($callingfile, realpath($path)) === 0) {
 				return $name;


### PR DESCRIPTION
$manifest is not in the global scope, patched it to use SS_ClassLoader to get the manifest instead.
