### PR TITLE
FIX make augmentSQL API consistent for strict PHP

### DIFF
--- a/model/DataExtension.php
+++ b/model/DataExtension.php
@@ -42,7 +42,7 @@ abstract class DataExtension extends Extension {
 	 *
 	 * @param SQLQuery $query Query to augment.
 	 */
-	public function augmentSQL(SQLQuery &$query) {
+	public function augmentSQL(SQLQuery &$query, DataQuery &$dataQuery = null) {
 	}
 
 	/**

--- a/model/Hierarchy.php
+++ b/model/Hierarchy.php
@@ -38,7 +38,7 @@ class Hierarchy extends DataExtension {
 	 */
 	private static $node_threshold_leaf = 250;
 	
-	public function augmentSQL(SQLQuery &$query) {
+	public function augmentSQL(SQLQuery &$query, DataQuery &$dataQuery = null) {
 	}
 
 	public function augmentDatabase() {


### PR DESCRIPTION
This references silverstripe/silverstripe-translatable#113
For that issue, we needed to have the DataQuery as the second parameter to
DataQuery's augmentSQL call.  Fortunately, DataQuery was already passing this
argument.  However, where the function was defined in DataExtension, the
argument was not present.  Thus, subclasses of DataExtension could not add the
parameter to their function signature if they were running in PHP strict mode
because PHP will complain that the signatures don't match.
