### PR TITLE
FIX #527 : Add Thumbnails to 'Choose another file' dialogue

### DIFF
--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -1548,8 +1548,13 @@ class UploadField_SelectHandler extends RequestHandler {
 		$config = GridFieldConfig::create();
 		$config->addComponent(new GridFieldSortableHeader());
 		$config->addComponent(new GridFieldFilterHeader());
-		$config->addComponent(new GridFieldDataColumns());
-		$config->addComponent(new GridFieldPaginator(10));
+		$config->addComponent($columns = new GridFieldDataColumns());
+		$columns->setDisplayFields(array(
+			'StripThumbnail' => '',
+			'Name' => 'Name',
+			'Title' => 'Title'
+		));
+		$config->addComponent(new GridFieldPaginator(8));
 
 		// If relation is to be autoset, we need to make sure we only list compatible objects.
 		$baseClass = $this->parent->getRelationAutosetClass();


### PR DESCRIPTION
Very difficult to choose an image based on file name alone. Added thumbnail and reduced rows from 10 to 8 to compensate for increased height of rows with thumbnail included.

Will send a separate pull request to the CMS project to deal with styling the gridfield like Asset Admin.

This fixes https://github.com/silverstripe/silverstripe-cms/issues/527
