### PR TITLE
Fix: Enable delete button for users with canDelete() but no canEdit() permissions

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -381,6 +381,10 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 		if($this->record->ID && !$canEdit) {
 			// Restrict editing of existing records
 			$form->makeReadonly();
+			// Hack to re-enable delete button if user can delete
+			if ($canDelete) {
+				$form->Actions()->fieldByName('action_doDelete')->setReadonly(false);
+			}
 		} elseif(!$this->record->ID && !$canCreate) {
 			// Restrict creation of new records
 			$form->makeReadonly();


### PR DESCRIPTION
If a user has `canDelete()` permissions, but doesn't have `canEdit()` permissions, the 'Delete' button is disabled on the ItemEditForm, despite being enabled in the main GridField.

Cause: `$form->makeReadonly()` iterates over all fields/actions, disabling the 'delete' button even when the user has permission. 
