### PR TITLE
ENHANCEMENT: Do not attempt to run abstract test classes

### DIFF
--- a/dev/TestRunner.php
+++ b/dev/TestRunner.php
@@ -286,8 +286,18 @@ class TestRunner extends Controller {
 			$skipTests = explode(',', $this->request->getVar('SkipTests'));
 		}
 
-		$classList = array_diff($classList, $skipTests);
+		$abstractClasses = array();
+		foreach($classList as $className) {
+			// Ensure that the autoloader pulls in the test class, as PHPUnit won't know how to do this.
+			class_exists($className);
+			$reflection = new ReflectionClass($className);
+			if ($reflection->isAbstract()) {
+				array_push($abstractClasses, $className);
+			}
+		}
 		
+		$classList = array_diff($classList, $skipTests, $abstractClasses);
+
 		// run tests before outputting anything to the client
 		$suite = new PHPUnit_Framework_TestSuite();
 		natcasesort($classList);


### PR DESCRIPTION
There is no reason to try to run test cases of a class that is abstract.  By
skipping them we allow developers to create abstract test case classes that
have test functions in them.  This is especially helpful when someone is
testing multiple implementations of the same service interface.  Most of their
tests can be in the abstract class, and then they can create concrete test
classes for each of their implementations and inherit all of the testing that
is built into the abstract class.
