### PR TITLE
ENHANCEMENT: allow disabling of Versioned prepopulate_versionnumber_cache

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -80,6 +80,14 @@ class Versioned extends DataExtension {
 	);
 
 	/**
+	 * Used to enable or disable the prepopulation of the version number cache.
+	 * Defaults to true.
+	 *
+	 * @var boolean
+	 */
+	private static $prepopulate_versionnumber_cache = true;
+
+	/**
 	 * Keep track of the archive tables that have been created.
 	 *
 	 * @var array
@@ -1095,6 +1103,9 @@ class Versioned extends DataExtension {
 	 * @param array $idList
 	 */
 	public static function prepopulate_versionnumber_cache($class, $stage, $idList = null) {
+		if (!Config::inst()->get('Versioned', 'prepopulate_versionnumber_cache')) {
+			return;
+		}
 		$filter = "";
 
 		if($idList) {


### PR DESCRIPTION
In large sites this can take a very long time, drastically slowing down the CMS
admin.  Even though the versions will then need to be queried individually,
this is still significantly faster than loading hundreds of thousands of
version numbers in one query and populating the cache array.
