### PR TITLE
BUG Accept $limit=0 in SQLQuery->setLimit()

### DIFF
--- a/model/SQLQuery.php
+++ b/model/SQLQuery.php
@@ -450,6 +450,7 @@ class SQLQuery {
 	 * Internally, limit will always be stored as a map containing the keys 'start' and 'limit'
 	 *
 	 * @param int|string|array $limit If passed as a string or array, assumes SQL escaped data.
+	 *                                Only applies for positive values, or if an $offset is set as well.
 	 * @param int $offset
 	 *
 	 * @throws InvalidArgumentException
@@ -461,7 +462,7 @@ class SQLQuery {
 			throw new InvalidArgumentException("SQLQuery::setLimit() only takes positive values");
 		}
 
-		if($limit && is_numeric($limit)) {
+		if(is_numeric($limit) && ($limit || $offset)) {
 			$this->limit = array(
 				'start' => $offset,
 				'limit' => $limit,

--- a/tests/model/SQLQueryTest.php
+++ b/tests/model/SQLQueryTest.php
@@ -138,6 +138,39 @@ class SQLQueryTest extends SapphireTest {
 			$query->sql());
 	}
 
+	public function testNullLimit() {
+		$query = new SQLQuery();
+		$query->setFrom("MyTable");
+		$query->setLimit(null);
+
+		$this->assertEquals(
+			'SELECT * FROM MyTable',
+			$query->sql()
+		);
+	}
+
+	public function testZeroLimit() {
+		$query = new SQLQuery();
+		$query->setFrom("MyTable");
+		$query->setLimit(0);
+
+		$this->assertEquals(
+			'SELECT * FROM MyTable',
+			$query->sql()
+		);
+	}
+
+	public function testZeroLimitWithOffset() {
+		$query = new SQLQuery();
+		$query->setFrom("MyTable");
+		$query->setLimit(0, 99);
+
+		$this->assertEquals(
+			'SELECT * FROM MyTable LIMIT 0 OFFSET 99',
+			$query->sql()
+		);
+	}
+
 	/**
 	 * @expectedException InvalidArgumentException
 	 */


### PR DESCRIPTION
SQLQuery->setLimit(0, 99) should result in "SELECT ... LIMIT 0 OFFSET 1".
In fact it does "SELECT ..." without a LIMIT clause at all,
which is unexpected. This is regardless of the $offset value.
