### PR TITLE
 Ensure Cookie::get() will immediately return results.

### DIFF
--- a/control/Cookie.php
+++ b/control/Cookie.php
@@ -110,6 +110,7 @@ class Cookie {
 			$expiry = $expiry > 0 ? time()+(86400*$expiry) : $expiry;
 			$path = ($path) ? $path : Director::baseURL();
 			setcookie($name, $value, $expiry, $path, $domain, $secure, $httpOnly);
+			$_COOKIE[$name] = $value;
 		} else {
 			if(Config::inst()->get('Cookie', 'report_errors')) {
 				user_error("Cookie '$name' can't be set. The site started outputting content at line $line in $file",


### PR DESCRIPTION
Without this change, a call to Cookie::get() immediately after Cookie::set()
won't return the value provided.  This creates some unintuitive edge-cases,
although to date it looks like they have been worked around.

The patch doesn't have a test because our testing framework doesn't deal
with cookies well.
