### PR TITLE
API Removed user_error  UploadField::setConfig

### DIFF
--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -502,14 +502,13 @@ class UploadField extends FileField {
 	/**
 	 * Assign a front-end config variable for the upload field
 	 * 
+	 * @see https://github.com/blueimp/jQuery-File-Upload/wiki/Options for the list of front end options available
+	 * 
 	 * @param string $key
 	 * @param mixed $val
 	 * @return UploadField self reference
 	 */
 	public function setConfig($key, $val) {
-		if(!array_key_exists($key, $this->ufConfig)) {
-			user_error("UploadField->setConfig called with invalid option: '$key'", E_USER_ERROR);
-		}
 		$this->ufConfig[$key] = $val;
 		return $this;
 	}
@@ -517,13 +516,13 @@ class UploadField extends FileField {
 	/**
 	 * Gets a front-end config variable for the upload field
 	 * 
+	 * @see https://github.com/blueimp/jQuery-File-Upload/wiki/Options for the list of front end options available
+	 * 
 	 * @param string $key
 	 * @return mixed
 	 */
 	public function getConfig($key) {
-		if(!array_key_exists($key, $this->ufConfig)) {
-			user_error("UploadField->getConfig called with invalid option: '$key'", E_USER_ERROR);
-		}
+		if(!isset($this->ufConfig[$key])) return null;
 		return $this->ufConfig[$key];
 	}
 


### PR DESCRIPTION
API Removed user_error when setting missing option on UploadField via setConfig. Added documentation to this function as a replacement for the check.

Resolves https://github.com/silverstripe/silverstripe-framework/issues/2045
