### PR TITLE
BUG Temporarily disable overwrite warning on HtmlEditorField "insert media".

### DIFF
--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -426,6 +426,8 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 		$computerUploadField->removeExtraClass('ss-uploadfield');
 		$computerUploadField->setTemplate('HtmlEditorField_UploadField');
 		$computerUploadField->setFolderName(Config::inst()->get('Upload', 'uploads_folder'));
+		// @todo - Remove this once this field supports display and recovery of file upload validation errors
+		$computerUploadField->setOverwriteWarning(false);
 
 		$tabSet = new TabSet(
 			"MediaFormInsertMediaTabs",


### PR DESCRIPTION
Temporarily disable overwrite warning on HtmlEditorField "insert media" dialogue until this feature properly supports validation error recovery.

This fix mitigates the immediate issue raised in https://github.com/silverstripe/silverstripe-framework/issues/2079 that prevents the dialogue from working once a file overwrite notification occurs.

The major issue remains however, as this dialogue does not gracefully handle errors during upload of any sort. This is a more serious issue that will need to be resolved in the future.
