### PR TITLE
API Allow $summary_fields to support methods on DBFields

### DIFF
--- a/docs/en/reference/dataobject.md
+++ b/docs/en/reference/dataobject.md
@@ -167,13 +167,13 @@ Example: Simple Definition
 	    'ProductCode' => 'Int',
 	  ); 
 	  private static $summary_fields = array(
-	      'Name',
-	      'ProductCode'
-	   );
+	    'Name',
+	    'ProductCode'
+	  );
 	}
 
 
-To include relations in your summaries, you can use a dot-notation.
+To include relations or field manipulations in your summaries, you can use a dot-notation.
 
 	:::php
 	class OtherObject extends DataObject {
@@ -183,16 +183,36 @@ To include relations in your summaries, you can use a dot-notation.
 	}
 	class MyDataObject extends DataObject {
 	  private static $db = array(
-	    'Name' => 'Text'
+	    'Name' => 'Text',
+	    'Description' => 'HTMLText'
 	  );
 	  private static $has_one = array(
 	    'OtherObject' => 'OtherObject'
 	  );
-	   private static $summary_fields = array(
-	      'Name',
-	      'OtherObject.Title'
-	   );
+	  private static $summary_fields = array(
+	    'Name' => 'Name',
+	    'Description.Summary' => 'Description (summary)',
+	    'OtherObject.Title' => 'Other Object Title'
+	  );
 	}
+
+
+Non-textual elements (such as images and their manipulations) can also be used in summaries.
+
+	:::php
+	class MyDataObject extends DataObject {
+	  private static $db = array(
+	    'Name' => 'Text'
+	  );
+	  private static $has_one = array(
+	    'HeroImage' => 'Image'
+	  );
+	  private static $summary_fields = array(
+	    'Name' => 'Name,
+	    'HeroImage.CMSThumbnail' => 'Hero Image'
+	  );
+	}
+
 
 ## Permissions
 

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -1103,6 +1103,10 @@ class DataObjectTest extends SapphireTest {
 		
 		$newPlayer = new DataObjectTest_Player();
 		$this->assertNull($newPlayer->relField('Teams.First.Title'));
+		
+		// Test that relField works on db field manipulations
+		$comment = $this->objFromFixture('DataObjectTest_TeamComment', 'comment3');
+		$this->assertEquals("PHIL IS A UNIQUE GUY, AND COMMENTS ON TEAM2" , $comment->relField('Comment.UpperCase'));
 	}
 
 	public function testRelObject() {

--- a/tests/model/DataObjectTest.yml
+++ b/tests/model/DataObjectTest.yml
@@ -20,7 +20,6 @@ DataObjectTest_Player:
 	player2:
 		FirstName: Player 2
 		Teams: =>DataObjectTest_Team.team1,=>DataObjectTest_Team.team2
-      
 DataObjectTest_SubTeam:
 	subteam1:
 		Title: Subteam 1
@@ -33,12 +32,11 @@ DataObjectTest_SubTeam:
 		ExtendedHasOneRelationship: =>DataObjectTest_Player.player1
 	subteam3_with_empty_fields:
 		Title: Subteam 3
-      
 DataObjectTest_TeamComment:
 	comment1:
-    	Name: Joe
-    	Comment: This is a team comment by Joe
-    	Team: =>DataObjectTest_Team.team1
+		Name: Joe
+		Comment: This is a team comment by Joe
+		Team: =>DataObjectTest_Team.team1
 	comment2:
 		Name: Bob
 		Comment: This is a team comment by Bob


### PR DESCRIPTION
This minor tweak allows summary methods to be called on DBField objects.

E.g.

``` php
private static $summary_fields = array(
    'Description.Summary' => 'Description (summary)',
);
```

Documentation has been updated to reflect this and other summary mechanisms (such as image resize methods).

Test case updated.
