### PR TITLE
ENHANCEMENT: Allow programmers to set OwnerID for new files.

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -466,7 +466,9 @@ class File extends DataObject {
 		parent::onBeforeWrite();
 
 		// Set default owner
-		if(!$this->ID) $this->OwnerID = (Member::currentUser() ? Member::currentUser()->ID : 0);
+		if(!$this->ID && !$this->OwnerID) {
+			$this->OwnerID = (Member::currentUser() ? Member::currentUser()->ID : 0);
+		}
 
 		// Set default name
 		if(!$this->getField('Name')) $this->Name = "new-" . strtolower($this->class);


### PR DESCRIPTION
**NOTE:** This change should be reviewed to make sure it does not cause any side effects.

**Example use case:** An admin porting user images from an old website. 
The script would put the images in the assets folder, and then insert them into the database using Image::write() and data from the old database.

``` php
public function insertImage($data) {
    $image = new Image();
    $image->ParentID = $data->parentId;
    $image->Title = $data->title;
    $image->FileName = $data->filename;
    $image->OwnerID = $data->ownerId;
    $image->write();

    // In the current version, this results in all images
    // being owned by Member::currentUser() instead of 
    // the expected $data->ownerId;
}
```
