### PR TITLE
BUGFIX: added many_many relationship hidden inupt

### DIFF
--- a/templates/UploadField.ss
+++ b/templates/UploadField.ss
@@ -37,6 +37,7 @@
 		</div>
 		<% end_if %>
 		<div class="ss-uploadfield-item-info">
+			<input type='hidden' value='$ID' name='{$Top.Name}[Files][]' />
 			<label class="ss-uploadfield-item-name">
 				<% if $multiple %>
 					<b><% _t('UploadField.ATTACHFILES', 'Attach files') %></b>


### PR DESCRIPTION
Without this hidden input the file uploading will not work for many_many relationship. File is uploaded, database record in table File is created, but the record in many_many join table is not created due to the lack of information about the file ID.
