### PR TITLE
Fixed a markdown issue

### DIFF
--- a/docs/en/topics/testing/create-silverstripe-test.md
+++ b/docs/en/topics/testing/create-silverstripe-test.md
@@ -58,8 +58,8 @@ See [the PHPUnit manual](http://www.phpunit.de/manual/current/en/api.html#api.as
 for a listing of all PHPUnit's built-in assertions.
 
 The `[api:SapphireTest]` class comes with additional assertions which are more
-specific to the framework, e.g. `[assertEmailSent](api:SapphireTest->assertEmailSent())`
-which can simulate sending emails through the `Email->send()` API without actually
+specific to the framework, e.g. `[api:SapphireTest->assertEmailSent()]`
+which can simulate sending emails through the `[api:Email->send()]` API without actually
 using a mail server (see the [testing emails](email-sending)) guide.
 
 ## Fixtures


### PR DESCRIPTION
Maybe a bug in SS markdown?

The old code generated:

``` HTML
<a href="(faulty-link)">assertEmailSent</a>
<code>which can simulate sending emails through the</code>Email-&gt;send()` API
```

Instead of the expected:

``` HTML
<code><a href="(good-link)">assertEmailSent</a></code>
which can simulate sending emails through the <code>Email-&gt;send()</code> API
```

faulty-link = http://api.silverstripe.org/search/lookup/?q=SapphireTest->assertEmailSent(&version=trunk&module=framework)

good-link: http://api.silverstripe.org/search/lookup/?q=SapphireTest->assertEmailSent()&version=trunk&module=framework
