### PR TITLE
FIX: TestRunner was not cleaning up DB on failure

### DIFF
--- a/dev/TestRunner.php
+++ b/dev/TestRunner.php
@@ -325,6 +325,12 @@ class TestRunner extends Controller {
 		$phpunitwrapper->setSuite($suite);
 		$phpunitwrapper->setCoverageStatus($coverage);
 
+		// Make sure TearDown is called (even in the case of a fatal error)
+		$self = $this;
+		register_shutdown_function(function() use ($self) {
+			$self->tearDown();
+		});
+
 		$phpunitwrapper->runTests();
 
 		// get results of the PhpUnitWrapper class


### PR DESCRIPTION
When a unit test being run by PHPUnit encountered a fatal error,
TestRunner::tearDown was never being called. This resulted in tmpdb schemas
littering the database from failed test runs. This changeset fixes the issue
by registering TestRunner::tearDown as a shutdown function, so that it gets
called even in the event of a PHP Fatal Error.

NOTE: the date on this commit seems inconsistent because it is a commit we've had in our private repo for a long time, running on 2.4.x.  I simply pulled it to 3.1 branch and verified that it worked.  **In reality, I think this commit should be merged to all active branches of SilverStripe, including 2.4, 3.0, 3.1, and master.**
