### PR TITLE
Enforce 'dev' environment for test runs

### DIFF
--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -287,6 +287,10 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 	public function setUpOnce() {
 		$isAltered = false;
 
+		if(!Director::isDev()) {
+			user_error('Tests can only run in "dev" mode', E_USER_ERROR);
+		}
+
 		// Remove any illegal extensions that are present
 		foreach($this->illegalExtensions as $class => $extensions) {
 			foreach($extensions as $extension) {


### PR DESCRIPTION
Otherwise tests like ControllerTest will fail because Deprecation
notices aren't thrown (limited to only 'dev' environments).

We _could_ limit this setting to the specific ControllerTest method,
but it seems like a good default.
