### PR TITLE
NEW: Form action handlers can now do custom validation by throwing ValidationExceptions.

### DIFF
--- a/admin/code/CMSForm.php
+++ b/admin/code/CMSForm.php
@@ -3,19 +3,28 @@
  * Deals with special form handling in CMS, mainly around {@link PjaxResponseNegotiator}
  */
 class CMSForm extends Form {
+
+	protected $responseNegotiator;
 	
 	/**
 	 * Route validation error responses through response negotiator,
 	 * so they return the correct markup as expected by the requesting client.
 	 */
-	protected function getValidationErrorResponse() {
+	protected function getValidationErrorResponse(ValidationResult $result) {
 		$request = $this->getRequest();
 		$negotiator = $this->getResponseNegotiator();
+
 		if($request->isAjax() && $negotiator) {
+			// Load form errors from the result into the form
+			// Also save them to session, in case the negotation returns a 302
+			$this->setupFormErrors($result, $this->getData());
+			$this->saveFormErrorsToSession($result, $this->getData());
+
 			$negotiator->setResponse(new SS_HTTPResponse($this));
 			return $negotiator->respond($request);
+
 		} else {
-			return parent::getValidationErrorResponse();
+			return parent::getValidationErrorResponse($result);
 		}
 	}
 

--- a/docs/en/changelogs/3.1.0.md
+++ b/docs/en/changelogs/3.1.0.md
@@ -36,6 +36,7 @@
  * Support for PHP 5.4's built-in webserver
  * Support for [Composer](http://getcomposer.org) dependency manager (also works with 3.0)
  * Added support for filtering incoming HTML from TinyMCE (disabled by default, see [security](/topics/security))
+ * ValidationExceptions are now handled by Form, simplifying the use of model validation.
 
 ## Upgrading
 

--- a/docs/en/topics/datamodel.md
+++ b/docs/en/topics/datamodel.md
@@ -682,6 +682,7 @@ model. SilverStripe provides the `[api:DataObject->validate()]` method for this
 purpose.
 
 By default, there is no validation - objects are always valid!  
+
 However, you can overload this method in your
 DataObject sub-classes to specify custom validation, 
 or use the hook through `[api:DataExtension]`.
@@ -689,11 +690,14 @@ or use the hook through `[api:DataExtension]`.
 Invalid objects won't be able to be written - a [api:ValidationException]` will
 be thrown and no write will occur.
 
-It is expected that you call validate() in your own application to test that an
-object is valid before attempting a write, and respond appropriately if it isn't.
+Alternatively, you can throw a ValidationException yourself anywhere in code that gets called by
+DataObject::write(), such as onBeforeWrite().
 
-The return value of `validate()` is a `[api:ValidationResult]` object.
-You can append your own errors in there.
+It is expected that the code in your application will put the write call in a try { } block, and catch any
+`ValidationException` that are thrown to handle them appropriately.  Note, however, that any Form actions already
+have this built in: the users will be sent back to the form with validaiton errors dispalyed.
+
+The return value of `validate()` is a `[api:ValidationResult]` object.  You can append your own errors in there.
 
 Example: Validate postcodes based on the selected country
 

--- a/forms/gridfield/GridFieldDeleteAction.php
+++ b/forms/gridfield/GridFieldDeleteAction.php
@@ -144,14 +144,14 @@ class GridFieldDeleteAction implements GridField_ColumnProvider, GridField_Actio
 			if($actionName == 'deleterecord') {
 				if(!$item->canDelete()) {
 					throw new ValidationException(
-						_t('GridFieldAction_Delete.DeletePermissionsFailure',"No delete permissions"),0);
+						_t('GridFieldAction_Delete.DeletePermissionsFailure',"No delete permissions"));
 				}
 
 				$item->delete();
 			} else {
 				if(!$item->canEdit()) {
 				throw new ValidationException(
-					_t('GridFieldAction_Delete.EditPermissionsFailure',"No permission to unlink record"),0);
+					_t('GridFieldAction_Delete.EditPermissionsFailure',"No permission to unlink record"));
 			}
 
 				$gridField->getList()->remove($item);

--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -542,7 +542,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 		try {
 			if (!$this->record->canDelete()) {
 				throw new ValidationException(
-					_t('GridFieldDetailForm.DeletePermissionsFailure',"No delete permissions"),0);
+					_t('GridFieldDetailForm.DeletePermissionsFailure',"No delete permissions"));
 			}
 
 			$this->record->delete();

--- a/model/ValidationException.php
+++ b/model/ValidationException.php
@@ -47,11 +47,25 @@ class ValidationException extends Exception {
 			$this->result = new ValidationResult(false, _t("ValdiationExcetpion.DEFAULT_ERROR", "Validation error"));
 
 		} else {
-			throw new InvalidArgumentException("ValidationExceptions must be passed a ValdiationResult, a string, or nothing at all");
+			throw new InvalidArgumentException(
+				"ValidationExceptions must be passed a ValdiationResult, a string, or nothing at all");
 		}
 		
 		// Construct
 		parent::__construct($exceptionMessage ? $exceptionMessage : $this->result->message(), $code);
+	}
+
+	/**
+	 * Create a ValidationException with a message for a single field-specific error message.
+	 * 
+	 * @param  string $field   The field name
+	 * @param  string $message The error message
+	 * @return ValidationException
+	 */
+	static function create_for_field($field, $message) {
+		$result = new ValidationResult;
+		$result->error($message, null, $field);
+		return new ValidationException($result);
 	}
 	
 	/**

--- a/model/ValidationException.php
+++ b/model/ValidationException.php
@@ -27,26 +27,31 @@ class ValidationException extends Exception {
 	 * the error code number.
 	 * @param integer $code The error code number, if not given in the second parameter
 	 */
-	public function __construct($result = null, $message = null, $code = 0) {
-		
-		// Check arguments
-		if(!($result instanceof ValidationResult)) {
-			
-			// Shift parameters if no ValidationResult is given
-			$code = $message;
-			$message = $result;
-			
-			// Infer ValidationResult from parameters
-			$result = new ValidationResult(false, $message);
-		} elseif(empty($message)) {
-			
-			// Infer message if not given
-			$message = $result->message();
+	public function __construct($result = null, $code = 0, $dummy = null) {
+		$exceptionMessage = null;
+
+		// Backwards compatibiliy failover.  The 2nd argument used to be $message, and $code the 3rd.
+		// For callers using that, we ditch the message
+		if(!is_numeric($code)) {
+			$exceptionMessage = $code;
+			if($dummy) $code = $dummy;
+		}
+
+		if($result instanceof ValidationResult) {
+			$this->result = $result;
+
+		} else if(is_string($result)) {
+			$this->result = new ValidationResult(false, $result);
+
+		} else if(!$result) {
+			$this->result = new ValidationResult(false, _t("ValdiationExcetpion.DEFAULT_ERROR", "Validation error"));
+
+		} else {
+			throw new InvalidArgumentException("ValidationExceptions must be passed a ValdiationResult, a string, or nothing at all");
 		}
 		
 		// Construct
-		$this->result = $result;
-		parent::__construct($message, $code);
+		parent::__construct($exceptionMessage ? $exceptionMessage : $this->result->message(), $code);
 	}
 	
 	/**

--- a/model/ValidationResult.php
+++ b/model/ValidationResult.php
@@ -36,7 +36,9 @@ class ValidationResult extends Object {
 	}
 	
 	/**
-	 * Record an error against this validation result,
+	 * Record an error against this validation result.
+	 * 
+	 * It's better to use addError, addFeildError, addMessage, or addFieldMessage instead.
 	 * 
 	 * @param string $message     The message string.
 	 * @param string $code        A codename for this error. Only one message per codename will be added.
@@ -44,24 +46,70 @@ class ValidationResult extends Object {
 	 * @param string $fieldName   The field to link the message to.  If omitted; a form-wide message is assumed.
 	 * @param string $messageType The type of message: e.g. "bad", "warning", "good", or "required". Passed as a CSS
 	 *                            class to the form, so other values can be used if desired.
+	 *
+	 * @deprecated 3.2
 	 */
 	public function error($message, $code = null, $fieldName = null, $messageType = "bad") {
+		Deprecation::notice('3.2', 'Use addError or addFieldError instead.');
+
+		return $this->addFieldError($fieldName, $message, $messageType, $code);
+	}
+
+	/**
+	 * Record an error against this validation result,
+	 * 
+	 * @param string $message     The message string.
+	 * @param string $messageType The type of message: e.g. "bad", "warning", "good", or "required". Passed as a CSS
+	 *                            class to the form, so other values can be used if desired.
+	 * @param string $code        A codename for this error. Only one message per codename will be added.
+	 *                            This can be usedful for ensuring no duplicate messages
+	 */
+	public function addError($message, $messageType = "bad", $code = null) {
 		$this->isValid = false;
 		
-		return $this->addMessage($message, $code, $fieldName, $messageType);
+		return $this->addFieldMessage(null, $message, $messageType, $code);
+	}
+
+	/**
+	 * Record an error against this validation result,
+	 * 
+	 * @param string $fieldName   The field to link the message to.  If omitted; a form-wide message is assumed.
+	 * @param string $message     The message string.
+	 * @param string $messageType The type of message: e.g. "bad", "warning", "good", or "required". Passed as a CSS
+	 *                            class to the form, so other values can be used if desired.
+	 * @param string $code        A codename for this error. Only one message per codename will be added.
+	 *                            This can be usedful for ensuring no duplicate messages
+	 */
+	public function addFieldError($fieldName = null, $message, $messageType = "bad", $code = null) {
+		$this->isValid = false;
+		
+		return $this->addFieldMessage($fieldName, $message, $messageType, $code);
 	}
 
 	/**
 	 * Add a message to this ValidationResult without necessarily marking it as an error
 	 *  
 	 * @param string $message     The message string.
-	 * @param string $code        A codename for this error. Only one message per codename will be added.
-	 *                            This can be usedful for ensuring no duplicate messages
-	 * @param string $fieldName   The field to link the message to.  If omitted; a form-wide message is assumed.
 	 * @param string $messageType The type of message: e.g. "bad", "warning", "good", or "required". Passed as a CSS
 	 *                            class to the form, so other values can be used if desired.
+	 * @param string $code        A codename for this error. Only one message per codename will be added.
+	 *                            This can be usedful for ensuring no duplicate messages
 	 */
-	public function addMessage($message, $code = null, $fieldName = null, $messageType = "bad") {
+	public function addMessage($message, $messageType = "bad", $code = null) {
+		return $this->addFieldMessage(null, $message, $messageType, $code);
+	}
+
+	/**
+	 * Add a message to this ValidationResult without necessarily marking it as an error
+	 *  
+	 * @param string $fieldName   The field to link the message to.  If omitted; a form-wide message is assumed.
+	 * @param string $message     The message string.
+	 * @param string $messageType The type of message: e.g. "bad", "warning", "good", or "required". Passed as a CSS
+	 *                            class to the form, so other values can be used if desired.
+	 * @param string $code        A codename for this error. Only one message per codename will be added.
+	 *                            This can be usedful for ensuring no duplicate messages
+	 */
+	public function addFieldMessage($fieldName, $message, $messageType = "bad", $code = null) {
 		$metadata = array(
 			'message' => $message,
 			'fieldName' => $fieldName,
@@ -72,7 +120,8 @@ class ValidationResult extends Object {
 			if(!is_numeric($code)) {
 				$this->errorList[$code] = $metadata;
 			} else {
-				throw new InvalidArgumentException("ValidationResult::error() - Don't use a numeric code '$code'.  Use a string.");
+				throw new InvalidArgumentException(
+					"ValidationResult::error() - Don't use a numeric code '$code'.  Use a string.");
 				$this->errorList[$code] = $metadata;
 			}
 		} else {
@@ -107,7 +156,10 @@ class ValidationResult extends Object {
 		$output = array();
 		foreach($this->errorList as $key => $item) {
 			if($item['fieldName']) {
-				$output[$item['fieldName']] = array('message' => $item['message'], 'messageType' => $item['messageType']);
+				$output[$item['fieldName']] = array(
+					'message' => $item['message'],
+					'messageType' => $item['messageType']
+				);
 			}
 		}
 		return $output;

--- a/model/ValidationResult.php
+++ b/model/ValidationResult.php
@@ -24,28 +24,59 @@ class ValidationResult extends Object {
 	 */
 	public function __construct($valid = true, $message = null) {
 		$this->isValid = $valid;
-		if($message) $this->errorList[] = $message;
+		if($message) $this->error($message);
 		parent::__construct();
 	}
 	
 	/**
-	 * Record an error against this validation result,
-	 * @param $message The validation error message
-	 * @param $code An optional error code string, that can be accessed with {@link $this->codeList()}.
+	 * Return the full error meta-data, suitable for combining with another ValidationResult.
 	 */
-	public function error($message, $code = null) {
+	function getErrorMetaData() {
+		return $this->errorList;
+	}
+	
+	/**
+	 * Record an error against this validation result,
+	 * 
+	 * @param string $message     The message string.
+	 * @param string $code        A codename for this error. Only one message per codename will be added.
+	 *                            This can be usedful for ensuring no duplicate messages
+	 * @param string $fieldName   The field to link the message to.  If omitted; a form-wide message is assumed.
+	 * @param string $messageType The type of message: e.g. "bad", "warning", "good", or "required". Passed as a CSS
+	 *                            class to the form, so other values can be used if desired.
+	 */
+	public function error($message, $code = null, $fieldName = null, $messageType = "bad") {
 		$this->isValid = false;
+		
+		return $this->addMessage($message, $code, $fieldName, $messageType);
+	}
+
+	/**
+	 * Add a message to this ValidationResult without necessarily marking it as an error
+	 *  
+	 * @param string $message     The message string.
+	 * @param string $code        A codename for this error. Only one message per codename will be added.
+	 *                            This can be usedful for ensuring no duplicate messages
+	 * @param string $fieldName   The field to link the message to.  If omitted; a form-wide message is assumed.
+	 * @param string $messageType The type of message: e.g. "bad", "warning", "good", or "required". Passed as a CSS
+	 *                            class to the form, so other values can be used if desired.
+	 */
+	public function addMessage($message, $code = null, $fieldName = null, $messageType = "bad") {
+		$metadata = array(
+			'message' => $message,
+			'fieldName' => $fieldName,
+			'messageType' => $messageType,
+		);
 		
 		if($code) {
 			if(!is_numeric($code)) {
-				$this->errorList[$code] = $message;
+				$this->errorList[$code] = $metadata;
 			} else {
-				user_error("ValidationResult::error() - Don't use a numeric code '$code'.  Use a string."
-					. "I'm going to ignore it.", E_USER_WARNING);
-				$this->errorList[$code] = $message;
+				throw new InvalidArgumentException("ValidationResult::error() - Don't use a numeric code '$code'.  Use a string.");
+				$this->errorList[$code] = $metadata;
 			}
 		} else {
-			$this->errorList[] = $message;
+			$this->errorList[] = $metadata;
 		}
 	}
 	
@@ -60,9 +91,28 @@ class ValidationResult extends Object {
 	 * Get an array of errors
 	 */
 	public function messageList() {
-		return $this->errorList;
+		$list = array();
+		foreach($this->errorList as $key => $item) {
+			if(is_numeric($key)) $list[] = $item['message'];
+			else $list[$key] = $item['message'];
+		}
+		return $list;
 	}
-
+	
+	/**
+	 * Get the field-specific messages as a map.
+	 * Keys will be field names, and values will be a 2 element map with keys 'messsage', and 'messageType'
+	 */
+	public function fieldErrors() {
+		$output = array();
+		foreach($this->errorList as $key => $item) {
+			if($item['fieldName']) {
+				$output[$item['fieldName']] = array('message' => $item['message'], 'messageType' => $item['messageType']);
+			}
+		}
+		return $output;
+	}
+	
 	/**
 	 * Get an array of error codes
 	 */
@@ -76,14 +126,25 @@ class ValidationResult extends Object {
 	 * Get the error message as a string.
 	 */
 	public function message() {
-		return implode("; ", $this->errorList);
+		return implode("; ", $this->messageList());
+	}
+	
+	/**
+	 * The the error message that's not related to a field as a string
+	 */
+	public function overallMessage() {
+		$messages = array();
+		foreach($this->errorList as $item) {
+			if(!$item['fieldName']) $messages[] = $item['message'];
+		}
+		return implode("; ", $messages);
 	}
 	
 	/**
 	 * Get a starred list of all messages
 	 */
 	public function starredList() {
-		return " * " . implode("\n * ", $this->errorList);
+		return " * " . implode("\n * ", $this->messageList());
 	}
 	
 	/**
@@ -93,8 +154,6 @@ class ValidationResult extends Object {
 	 */
 	public function combineAnd(ValidationResult $other) {
 		$this->isValid = $this->isValid && $other->valid();
-		$this->errorList = array_merge($this->errorList, $other->messageList());
+		$this->errorList = array_merge($this->errorList, $other->getErrorMetaData());
 	}
-	
-	
 }

--- a/security/Member.php
+++ b/security/Member.php
@@ -682,7 +682,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 				)
 			);
 			if($existingRecord) {
-				throw new ValidationException(new ValidationResult(false, _t(
+				throw new ValidationException(_t(
 					'Member.ValidationIdentifierFailed', 
 					'Can\'t overwrite existing member #{id} with identical identifier ({name} = {value}))', 
 					'Values in brackets show "fieldname = value", usually denoting an existing email address',
@@ -691,7 +691,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 						'name' => $identifierField,
 						'value' => $this->$identifierField
 					)
-				)));
+				));
 			}
 		}
 

--- a/security/Member.php
+++ b/security/Member.php
@@ -429,7 +429,9 @@ class Member extends DataObject implements TemplateGlobalProvider {
 				self::session_regenerate_id();
 				Session::set("loggedInAs", $member->ID);
 				// This lets apache rules detect whether the user has logged in
-				if(Member::config()->login_marker_cookie) Cookie::set(Member::config()->login_marker_cookie, 1, 0, null, null, false, true);
+				if(Member::config()->login_marker_cookie) {
+					Cookie::set(Member::config()->login_marker_cookie, 1, 0, null, null, false, true);
+				}
 				
 				$generator = new RandomGenerator();
 				$token = $generator->randomToken('sha1');
@@ -713,11 +715,14 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		// Note that this only works with cleartext passwords, as we can't rehash
 		// existing passwords.
 		if((!$this->ID && $this->Password) || $this->isChanged('Password')) {
+			if($this->PasswordEncryption) $encryption = $this->PasswordEncryption;
+			else $encryption = Security::config()->password_encryption_algorithm;
+
 			// Password was changed: encrypt the password according the settings
 			$encryption_details = Security::encrypt_password(
 				$this->Password, // this is assumed to be cleartext
 				$this->Salt,
-				($this->PasswordEncryption) ? $this->PasswordEncryption : Security::config()->password_encryption_algorithm,
+				$encryption,
 				$this
 			);
 

--- a/tests/model/ValidationExceptionTest.php
+++ b/tests/model/ValidationExceptionTest.php
@@ -72,13 +72,13 @@ class ValidationExceptionTest extends SapphireTest
 	public function testCreateWithComplexValidationResultAndMessage() {
 		$result = new ValidationResult();
 		$result->error('A spork is not a knife');
-		$result->error('A knife is not a back scratcher');
+		$result->error('A knife is not a scratcher');
 		$exception = new ValidationException($result, 'An error has occurred', E_USER_WARNING);
 		
 		$this->assertEquals(E_USER_WARNING, $exception->getCode());
 		$this->assertEquals('An error has occurred', $exception->getMessage());
 		$this->assertEquals(false, $exception->getResult()->valid());
-		$this->assertEquals('A spork is not a knife; A knife is not a back scratcher', $exception->getResult()->message());
+		$this->assertEquals('A spork is not a knife; A knife is not a scratcher', $exception->getResult()->message());
 	}
 
 	/**

--- a/tests/model/ValidationExceptionTest.php
+++ b/tests/model/ValidationExceptionTest.php
@@ -80,4 +80,51 @@ class ValidationExceptionTest extends SapphireTest
 		$this->assertEquals(false, $exception->getResult()->valid());
 		$this->assertEquals('A spork is not a knife; A knife is not a back scratcher', $exception->getResult()->message());
 	}
+
+	/**
+	 * Test that a ValidationException created with no contained ValidationResult
+	 * will correctly populate itself with an inferred version
+	 */
+	public function testCreateForField() {
+		$exception = ValidationException::create_for_field('Content', 'Content is required');
+
+		$this->assertEquals('Content is required', $exception->getMessage());
+		$this->assertEquals(false, $exception->getResult()->valid());
+
+		$this->assertEquals(array(
+			'Content' => array(
+				'message' => 'Content is required',
+				'messageType' => 'bad',
+			),
+		), $exception->getResult()->fieldErrors());
+	}
+
+	/**
+	 * Test that a ValidationException created with no contained ValidationResult
+	 * will correctly populate itself with an inferred version
+	 */
+	public function testValidationResultAddMethods() {
+		$result = new ValidationResult();
+		$result->addMessage('A spork is not a knife', 'bad');
+		$result->addError('A knife is not a back scratcher');
+		$result->addFieldMessage('Title', 'Title is good', 'good');
+		$result->addFieldError('Content', 'Content is bad');
+		
+
+		$this->assertEquals(array(
+			'Title' => array(
+				'message' => 'Title is good',
+				'messageType' => 'good'
+			),
+			'Content' => array(
+				'message' => 'Content is bad',
+				'messageType' => 'bad'
+			)
+		), $result->fieldErrors());
+
+		$this->assertEquals('A spork is not a knife; A knife is not a back scratcher', $result->overallMessage());
+
+		$exception = ValidationException::create_for_field('Content', 'Content is required');
+	}
+
 }

--- a/tests/security/SecurityTest.php
+++ b/tests/security/SecurityTest.php
@@ -260,7 +260,7 @@ class SecurityTest extends FunctionalTest {
 			/* THE FIRST 4 TIMES, THE MEMBER SHOULDN'T BE LOCKED OUT */
 			if($i < 5) {
 				$this->assertNull($member->LockedOutUntil);
-				$this->assertContains($this->loginErrorMessage(), _t('Member.ERRORWRONGCRED'));
+				$this->assertContains(_t('Member.ERRORWRONGCRED'), $this->loginErrorMessage());
 			}
 			
 			/* AFTER THAT THE USER IS LOCKED OUT FOR 15 MINUTES */
@@ -433,7 +433,8 @@ class SecurityTest extends FunctionalTest {
 	 * Get the error message on the login form
 	 */
 	public function loginErrorMessage() {
-		return $this->session()->inst_get('FormInfo.MemberLoginForm_LoginForm.formError.message');
+		$result = $this->session()->inst_get('FormInfo.MemberLoginForm_LoginForm.result');
+		return $result->message();
 	}	
 	
 }


### PR DESCRIPTION
NEW: ValidationResult can now store field-specific errors.
NEW: You can pass a string error message to the ValidationException constructor.
API: The session variables that Form uses to keep track of messages/validation have changed.

This is a fairly significant improvement in the flexibility with which you can define Form validation, and it shouldn't introduce too many backwards compatibility issues.  My hope is that we can get away with it for 3.1, because it's not breaking any APIs, it's only adding them.

I have deprecated a couple of things marked at 3.2, to given an indication that we should drop them.

The one thing I did deprecate was Form::messageForForm, which is a static method that just seems horrible.  I don't know if anyone is using it.