### PR TITLE
MINOR: fix places where IDE interprets ?> as end of PHP file

### DIFF
--- a/control/ContentNegotiator.php
+++ b/control/ContentNegotiator.php
@@ -214,7 +214,7 @@ class ContentNegotiator extends Object {
 		$content = preg_replace('/<base href="([^"]*)" \/>/', 
 			'<base href="$1"><!--[if lte IE 6]></base><![endif]-->', $content);
 
-		$content = preg_replace("#<\\?xml[^>]+\\?>\n?#", '', $content);
+		$content = preg_replace("#<\\?xml[^>]+\\?" . ">\n?#", '', $content);
 		$content = str_replace(array('/>','xml:lang','application/xhtml+xml'),array('>','lang','text/html'), $content);
 		
 		// Only replace the doctype in templates with the xml header

--- a/core/Convert.php
+++ b/core/Convert.php
@@ -235,11 +235,11 @@ class Convert {
 			$config = $defaultConfig;
 		}
 
-		$data = preg_replace("/<style([^A-Za-z0-9>][^>]*)?>.*?<\/style[^>]*>/is","", $data);
-		$data = preg_replace("/<script([^A-Za-z0-9>][^>]*)?>.*?<\/script[^>]*>/is","", $data);
+		$data = preg_replace("/<style([^A-Za-z0-9>][^>]*)?" . ">.*?<\/style[^>]*>/is","", $data);
+		$data = preg_replace("/<script([^A-Za-z0-9>][^>]*)?" . ">.*?<\/script[^>]*>/is","", $data);
 
 		if($config['ReplaceBoldAsterisk']) {
-			$data = preg_replace('%<(strong|b)( [^>]*)?>|</(strong|b)>%i','*',$data);
+			$data = preg_replace('%<(strong|b)( [^>]*)?' . '>|</(strong|b)>%i','*',$data);
 		}
 		
 		// Expand hyperlinks
@@ -264,14 +264,14 @@ class Convert {
 		}
 		
 		// Parse newline tags
-		$data = preg_replace("/\s*<[Hh][1-6]([^A-Za-z0-9>][^>]*)?> */", "\n\n", $data);
-		$data = preg_replace("/\s*<[Pp]([^A-Za-z0-9>][^>]*)?> */", "\n\n", $data);
-		$data = preg_replace("/\s*<[Dd][Ii][Vv]([^A-Za-z0-9>][^>]*)?> */", "\n\n", $data);
+		$data = preg_replace("/\s*<[Hh][1-6]([^A-Za-z0-9>][^>]*)?" . "> */", "\n\n", $data);
+		$data = preg_replace("/\s*<[Pp]([^A-Za-z0-9>][^>]*)?" . "> */", "\n\n", $data);
+		$data = preg_replace("/\s*<[Dd][Ii][Vv]([^A-Za-z0-9>][^>]*)?" . "> */", "\n\n", $data);
 		$data = preg_replace("/\n\n\n+/", "\n\n", $data);
 
-		$data = preg_replace("/<[Bb][Rr]([^A-Za-z0-9>][^>]*)?> */", "\n", $data);
-		$data = preg_replace("/<[Tt][Rr]([^A-Za-z0-9>][^>]*)?> */", "\n", $data);
-		$data = preg_replace("/<\/[Tt][Dd]([^A-Za-z0-9>][^>]*)?> */", "    ", $data);
+		$data = preg_replace("/<[Bb][Rr]([^A-Za-z0-9>][^>]*)?" . "> */", "\n", $data);
+		$data = preg_replace("/<[Tt][Rr]([^A-Za-z0-9>][^>]*)?" . "> */", "\n", $data);
+		$data = preg_replace("/<\/[Tt][Dd]([^A-Za-z0-9>][^>]*)?" . "> */", "    ", $data);
 		$data = preg_replace('/<\/p>/i', "\n\n", $data );
 	
 		// Replace HTML entities

--- a/model/fieldtypes/HTMLText.php
+++ b/model/fieldtypes/HTMLText.php
@@ -86,8 +86,8 @@ class HTMLText extends Text {
 			/* See if we can pull a paragraph out*/
 
 			// Strip out any images in case there's one at the beginning. Not doing this will return a blank paragraph
-			$str = preg_replace('{^\s*(<.+?>)*<img[^>]*>}', '', $this->value);
-			if (preg_match('{<p(\s[^<>]*)?>(.*[A-Za-z]+.*)</p>}', $str, $matches)) $str = $matches[2];
+			$str = preg_replace('{^\s*(<.+?' . '>)*<img[^>]*>}', '', $this->value);
+			if (preg_match('{<p(\s[^<>]*)?' . '>(.*[A-Za-z]+.*)</p>}', $str, $matches)) $str = $matches[2];
 
 			/* If _that_ failed, just use the whole text */
 			if (!$str) $str = $this->value;

--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -471,7 +471,7 @@ after')
 
 	public function testBaseTagGeneration() {
 		// XHTML wil have a closed base tag
-		$tmpl1 = '<?xml version="1.0" encoding="UTF-8"?>
+		$tmpl1 = '<?xml version="1.0" encoding="UTF-8"?' . '>
 			<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"'
 				. ' "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 			<html>

--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -977,7 +977,7 @@ class SSViewer {
 		if($this->rewriteHashlinks && $rewrite) {
 			if(strpos($output, '<base') !== false) {
 				if($rewrite === 'php') { 
-					$thisURLRelativeToBase = "<?php echo strip_tags(\$_SERVER['REQUEST_URI']); ?>"; 
+					$thisURLRelativeToBase = "<?php echo strip_tags(\$_SERVER['REQUEST_URI']); ?" . ">";
 				} else { 
 					$thisURLRelativeToBase = strip_tags($_SERVER['REQUEST_URI']); 
 				}


### PR DESCRIPTION
Not sure if this annoys others (or if your particular IDE does it in each of these places), but some editors interpret ?> in some locations as the end of the PHP file and it royally messes up syntax highlighting / formatting for the rest of the file after the ?> appears.  This simply breaks the strings that contain ?> so that the IDE will not interpret it as the end of the file.

I found all places in framework that had ?> (excluding thirdparty folders) and then replaced those that my IDE (vim) had problems with.  Others (like the ones in a <<EOF or comment block) did not cause formatting issues, so I didn't modify those.
