### PR TITLE
BUG: Fix for Cookie expiry timeout being passed as a large number on 64 ...

### DIFF
--- a/control/Session.php
+++ b/control/Session.php
@@ -523,9 +523,11 @@ class Session {
 
 		if(!session_id() && !headers_sent()) {
 			if($domain) {
-				session_set_cookie_params($timeout, $path, $domain, $secure /* secure */, true /* httponly */);
+				session_set_cookie_params($timeout, $path, $domain,
+					$secure /* secure */, true /* httponly */);
 			} else {
-				session_set_cookie_params($timeout, $path, null, $secure /* secure */, true /* httponly */);
+				session_set_cookie_params($timeout, $path, null,
+					$secure /* secure */, true /* httponly */);
 			}
 
 			// Allow storing the session in a non standard location
@@ -541,7 +543,8 @@ class Session {
 		// Modify the timeout behaviour so it's the *inactive* time before the session expires.
 		// By default it's the total session lifetime
 		if($timeout && !headers_sent()) {
-			Cookie::set(session_name(), session_id(), time()+$timeout, $path, $domain ? $domain : null, $secure, true);
+			Cookie::set(session_name(), session_id(), $timeout/86400, $path, $domain ? $domain
+				: null, $secure, true);
 		}
 	}
 


### PR DESCRIPTION
Pull request to fix a bug on 64 bit machines where the cookie expiry timeout can cause a error due to being a large number.
Have tested this on my local machine by setting the cookie timeout to a large number by adding the following line to _config.php

Config::inst()->update('Session', 'timeout', time());

Below is some history from some comments on commit 4ef83a2895bd05a943d13a590680264a2f7f262b

May be a bug but I am running into issue on a 64 bit machine where the timestamp for the expiry date in cookie is becoming quite large white in turns produces a date way past 2038 or 9999.

Which in turn produces the following warning

[Warning] Expiry date cannot have a year greater then 9999

The link below gives a better description of this.

http://stackoverflow.com/questions/10070673/http-cookie-expire-time-average-maximum

Below if a rough patch I have done which adds a check on the expiry timestamp and changes it if it is greater then the maximum date.

--- a/control/Cookie.php
+++ b/control/Cookie.php
@@ -107,7 +107,14 @@ class Cookie {
$domain = null, $secure = false, $httpOnly = false
) {
if(!headers_sent($file, $line)) {
$expiry = $expiry > 0 ? time()+(86400*$expiry) : $expiry;

// check that the expiry is not greater then 9999
//echo gmdate("Y-m-d\TH:i:s\Z", $expiry); exit;
$maxTimestamp = strtotime('31-12-9998');
if ($expiry >= $maxTimestamp) {
$expiry = time()+(3600 \* 24 \* 7);
} $path = ($path) ? $path : Director::baseURL(); setcookie($name, $value, $expiry, $path, $domain, $secure, $httpOnly); $_COOKIE[$name] = $value;
