### PR TITLE
MINOR: fix Email class modifying SSViewer.source_file_comments config val

### DIFF
--- a/email/Email.php
+++ b/email/Email.php
@@ -349,8 +349,9 @@ class Email extends ViewableData {
 	 * and it won't be plain email :) 
 	 */
 	protected function parseVariables($isPlain = false) {
+		$origState = Config::inst()->get('SSViewer', 'source_file_comments');
 		Config::inst()->update('SSViewer', 'source_file_comments', false);
-		
+
 		if(!$this->parseVariables_done) {
 			$this->parseVariables_done = true;
 
@@ -373,6 +374,7 @@ class Email extends ViewableData {
 			// Rewrite relative URLs
 			$this->body = HTTP::absoluteURLs($fullBody);
 		}
+		Config::inst()->update('SSViewer', 'source_file_comments', $origState);
 	}
 	
 	/**

--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -1062,7 +1062,7 @@ after')
 		$origEnv = Config::inst()->get('Director', 'environment_type');
 		Config::inst()->update('Director', 'environment_type', 'dev');
 		Config::inst()->update('SSViewer', 'source_file_comments', true);
-	   $f = FRAMEWORK_PATH . '/tests/templates/SSViewerTestComments';
+		$f = FRAMEWORK_PATH . '/tests/templates/SSViewerTestComments';
 		$templates = array(
 			array(
 				'name' => 'SSViewerTestCommentsFullSource',


### PR DESCRIPTION
The Email class was updating the SSViewer.source_file_comments value and not
resetting it. If someone had this value set to true in their system and then
used the Email class, it seems there would be an unintended side-effect of
having the source file comments turned off.
