### PR TITLE
FIX: Ensure GridFieldExportButton only has padding added when placed 'after'

### DIFF
--- a/forms/gridfield/GridFieldExportButton.php
+++ b/forms/gridfield/GridFieldExportButton.php
@@ -52,8 +52,9 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 		);
 		$button->setAttribute('data-icon', 'download-csv');
 		$button->addExtraClass('no-ajax');
+		$cssClass = ($this->targetFragment == 'after') ? 'grid-bottom-button grid-csv-button' : 'grid-csv-button';
 		return array(
-			$this->targetFragment => '<p class="grid-bottom-button grid-csv-button">' . $button->Field() . '</p>',
+			$this->targetFragment => '<p class="' . $cssClass . '">' . $button->Field() . '</p>',
 		);
 	}
 


### PR DESCRIPTION
Currently the `.grid-bottom-button` class is causing the button to be out of alignment with other buttons.

![screen shot 2013-06-20 at 12 13 56](https://f.cloud.github.com/assets/842280/686375/c656c0c6-da56-11e2-9da0-e8340e598fdc.png)

This is a simple fix to ensure that the class only gets added if the component is placed 'after' the GridField.
