### PR TITLE
FEATURE: <% include %> inherits scope of parent template

### DIFF
--- a/tests/templates/SSViewerTestIncludeScopeInheritance.ss
+++ b/tests/templates/SSViewerTestIncludeScopeInheritance.ss
@@ -1,0 +1,3 @@
+<% loop Items %>
+	<% include SSViewerTestIncludeScopeInheritanceInclude %>
+<% end_loop %>

--- a/tests/templates/SSViewerTestIncludeScopeInheritanceInclude.ss
+++ b/tests/templates/SSViewerTestIncludeScopeInheritanceInclude.ss
@@ -1,0 +1,1 @@
+$Title <% if ArgA %>- $ArgA <% end_if %>- <%if First %>First-<% end_if %><% if Last %>Last-<% end_if %><%if MultipleOf(2) %>EVEN<% else %>ODD<% end_if %> top:$Top.Title

--- a/tests/templates/SSViewerTestIncludeScopeInheritanceWithArgs.ss
+++ b/tests/templates/SSViewerTestIncludeScopeInheritanceWithArgs.ss
@@ -1,0 +1,3 @@
+<% loop Items %>
+	<% include SSViewerTestIncludeScopeInheritanceInclude ArgA=$Title %>
+<% end_loop %>

--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -29,7 +29,57 @@ class SSViewerTest extends SapphireTest {
 		$result = $data->renderWith("SSViewerTestPartialTemplate");
 		$this->assertEquals('Test partial template: var value', trim(preg_replace("/<!--.*-->/U",'',$result)));
 	}
-	
+
+	public function testIncludeScopeInheritance() {
+		$data = $this->getScopeInheritanceTestData();
+		$expected = array(
+			'Item 1 - First-ODD top:Item 1',
+			'Item 2 - EVEN top:Item 2',
+			'Item 3 - ODD top:Item 3',
+			'Item 4 - EVEN top:Item 4',
+			'Item 5 - ODD top:Item 5',
+			'Item 6 - Last-EVEN top:Item 6',
+		);
+
+		$result = $data->renderWith('SSViewerTestIncludeScopeInheritance');
+		$this->assertExpectedStrings($result, $expected);
+
+		// reset results for the tests that include arguments (the title is passed as an arg)
+		$expected = array(
+			'Item 1 - Item 1 - First-ODD top:Item 1',
+			'Item 2 - Item 2 - EVEN top:Item 2',
+			'Item 3 - Item 3 - ODD top:Item 3',
+			'Item 4 - Item 4 - EVEN top:Item 4',
+			'Item 5 - Item 5 - ODD top:Item 5',
+			'Item 6 - Item 6 - Last-EVEN top:Item 6',
+		);
+
+		$result = $data->renderWith('SSViewerTestIncludeScopeInheritanceWithArgs');
+		$this->assertExpectedStrings($result, $expected);
+	}
+
+	private function getScopeInheritanceTestData() {
+		return new ArrayData(array(
+			'Title' => 'TopTitleValue',
+			'Items' => new ArrayList(array(
+				new ArrayData(array('Title' => 'Item 1')),
+				new ArrayData(array('Title' => 'Item 2')),
+				new ArrayData(array('Title' => 'Item 3')),
+				new ArrayData(array('Title' => 'Item 4')),
+				new ArrayData(array('Title' => 'Item 5')),
+				new ArrayData(array('Title' => 'Item 6'))
+			))
+		));
+	}
+
+	private function assertExpectedStrings($result, $expected) {
+		foreach ($expected as $expectedStr) {
+			$this->assertTrue(
+				(boolean) preg_match("/{$expectedStr}/", $result),
+				"Didn't find '{$expectedStr}' in:\n{$result}"
+			);
+		}
+	}
 	
 	/**
 	 * Small helper to render templates from strings

--- a/view/SSTemplateParser.php
+++ b/view/SSTemplateParser.php
@@ -3242,7 +3242,7 @@ class SSTemplateParser extends Parser {
 		$arguments = $res['arguments'];
 
 		$res['php'] = '$val .= SSViewer::execute_template('.$template.', $scope->getItem(), array(' . 
-			implode(',', $arguments)."));\n";
+			implode(',', $arguments)."), \$scope);\n";
 
 		if($this->includeDebuggingComments) { // Add include filename comments on dev sites
 			$res['php'] =

--- a/view/SSTemplateParser.php.inc
+++ b/view/SSTemplateParser.php.inc
@@ -701,7 +701,7 @@ class SSTemplateParser extends Parser {
 		$arguments = $res['arguments'];
 
 		$res['php'] = '$val .= SSViewer::execute_template('.$template.', $scope->getItem(), array(' . 
-			implode(',', $arguments)."));\n";
+			implode(',', $arguments)."), \$scope);\n";
 
 		if($this->includeDebuggingComments) { // Add include filename comments on dev sites
 			$res['php'] =


### PR DESCRIPTION
NOTE: the unit tests for this will fail until #2137 or #2113 are merged since it uses a code branch that currently has a bug on 3.1 (and either of those pull requests will fix the bug).

This pull request represents a debated topic - whether or not the <% include %> tag should inherit the scope of the caller.  For the discussion, see https://groups.google.com/d/msg/silverstripe-dev/ymCg3m5LBxE/Ccn-8Gzk-3gJ

Since there is debate on this topic, the code is structured so that you can turn this feature on globally or on a per-include basis.  By default it is off - behaving exactly like 3.0 where scope is not inherited inside an include.

I am open to other suggestion on how this should be accomplished - for instance, I don't 100% like the "inheritScope=true" arg you can pass to an include.  But I wanted to get this prototype out here to aid with the discussion referenced above.

Final note: when I first implemented this, I did not have the configurable options.  It was just by default on - every include inherited scope.  None of the unit tests in the suite failed.  Meaning that it does not seem to break anything that we are currently testing in our suites.  Since it does change what $Top and $Up would do as compared to 3.0.x, I assume that someone could be using those in their 3.0.x templates and may encounter an issue if they switched to using this - which is part of the reason I added the configurability.  But if users are coming from 2.4.x to 3.1.x, they will definitely benefit from having the ability to turn this feature on.  Without that ability, many users' templates will break in a 2.4.x->3.1.x migration.
