### PR TITLE
Controller::redirect now returns the resulting SS_HTTPResponse

### DIFF
--- a/control/Controller.php
+++ b/control/Controller.php
@@ -458,6 +458,8 @@ class Controller extends RequestHandler implements TemplateGlobalProvider {
 	
 	/**
 	 * Redirect to the given URL.
+	 * 
+	 * @return SS_HTTPResponse
 	 */
 	public function redirect($url, $code=302) {
 		if(!$this->response) $this->response = new SS_HTTPResponse();
@@ -473,7 +475,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider {
 			$url = Director::baseURL() . $url;
 		}
 
-		$this->response->redirect($url, $code);
+		return $this->response->redirect($url, $code);
 	}
 	
 	/**


### PR DESCRIPTION
This is quite a minor code usability / style tweak.

Controller::redirect now returns the resulting SS_HTTPResponse.

The main argument for this is that the redirect functionality (Controller::redirect, SS_HTTPResponse::redirect, etc) are used across the codebase as though they return the SS_HTTPResponse object itself, although it doesn't in this case.

It's also odd that in many cases in Controller where `return $this->redirect($url)` is called, the redirect still works fine, giving the impression that it's returning the response back to the Director (it's not actually). If `return $this->redirect($url)` is called during routing (such as with a custom route handler) it doesn't work (this is how I found this).

Basically this just tightens up the visibility of what the code is doing vs what it's actually doing.

Test cases have been run on this btw!
