### PR TITLE
FIX: $Layout should not be executed if inside cached block

### DIFF
--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -968,6 +968,29 @@ after')
 		});
 	}
 
+	public function testLayoutInCachedBlock() {
+		$self = $this;
+
+		$this->useTestTheme('layoutcachedblocktest', function() use ($self) {
+			$template = new SSViewer(array('LayoutInCachedBlock'));
+			$page = new SSViewerTest_TitleCallCountingPage();
+			$page->ID = 11;
+			$firstResponse = $template->process($page);
+			$self->assertEquals(1, $page->getCount());
+			$self->assertEquals(1, preg_match('/Line 1 - 11/', $firstResponse->forTemplate()));
+			$self->assertEquals(1, preg_match('/Layout line - test page/', $firstResponse->forTemplate()));
+			$self->assertEquals(1, preg_match('/Last line - 11/', $firstResponse->forTemplate()));
+
+			// create a new page to simulate loading a page from the database so that
+			// cached calls aren't still stored, affecting the title call count
+			$page = new SSViewerTest_TitleCallCountingPage();
+			$page->ID = 11;
+			$secondResponse = $template->process($page);
+			$self->assertEquals(0, $page->getCount());
+			$self->assertEquals($firstResponse->forTemplate(), $secondResponse->forTemplate());
+		});
+	}
+
 	/**
 	 * @covers SSViewer::get_themes()
 	 */
@@ -1412,3 +1435,22 @@ class SSViewerTest_LevelTest extends ViewableData implements TestOnly {
 	}
 }
 
+class SSViewerTest_TitleCallCountingPage extends DataObject {
+
+	private $count = 0;
+	private $title = 'test page';
+
+	public function getTitle() {
+		$this->count++;
+		return $this->title;
+	}
+
+	public function resetCount() {
+		$this->count = 0;
+	}
+
+	public function getCount() {
+		return $this->count;
+	}
+
+}

--- a/tests/view/themes/layoutcachedblocktest/Layout/LayoutInCachedBlock.ss
+++ b/tests/view/themes/layoutcachedblocktest/Layout/LayoutInCachedBlock.ss
@@ -1,0 +1,1 @@
+Layout line - $Title

--- a/tests/view/themes/layoutcachedblocktest/LayoutInCachedBlock.ss
+++ b/tests/view/themes/layoutcachedblocktest/LayoutInCachedBlock.ss
@@ -1,0 +1,5 @@
+Line 1 - $ID
+<% cached 'page', ID %>
+  $Layout
+<% end_cached %>
+Last line - $ID

--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -420,7 +420,8 @@ class SSViewer_DataPresenter extends SSViewer_Scope {
 
 		// Check for a presenter-specific override
 		if (array_key_exists($property, $this->overlay)) {
-			$source = array('value' => $this->overlay[$property]);
+			$key = $this->overlay[$property] instanceof Closure ? 'callable' : 'value';
+			$source = array($key => $this->overlay[$property]);
 		}
 		// Check if the method to-be-called exists on the target object - if so, don't check any further
 		// injection locations
@@ -429,7 +430,8 @@ class SSViewer_DataPresenter extends SSViewer_Scope {
 		}
 		// Check for a presenter-specific override
 		else if (array_key_exists($property, $this->underlay)) {
-			$source = array('value' => $this->underlay[$property]);
+			$key = $this->underlay[$property] instanceof Closure ? 'callable' : 'value';
+			$source = array($key => $this->underlay[$property]);
 		}
 		// Then for iterator-specific overrides
 		else if (array_key_exists($property, self::$iteratorProperties)) {
@@ -452,10 +454,14 @@ class SSViewer_DataPresenter extends SSViewer_Scope {
 			$res = array();
 
 			// Look up the value - either from a callable, or from a directly provided value
-			if (isset($source['callable'])) $res['value'] = call_user_func_array($source['callable'], $params);
-			elseif (isset($source['value'])) $res['value'] = $source['value'];
-			else throw new InvalidArgumentException("Injected property $property does't have a value or callable " .
+			if (isset($source['callable'])) {
+				$res['value'] = call_user_func_array($source['callable'], $params);
+			} else if (isset($source['value'])) {
+				$res['value'] = $source['value'];
+			} else {
+				throw new InvalidArgumentException("Injected property $property does't have a value or callable " .
 				"value source provided");
+			}
 
 			// If we want to provide a casted object, look up what type object to use
 			if ($cast) {
@@ -971,11 +977,14 @@ class SSViewer {
 		// through $Content and $Layout placeholders.
 		foreach(array('Content', 'Layout') as $subtemplate) {
 			if(isset($this->chosenTemplates[$subtemplate])) {
-				$subtemplateViewer = new SSViewer($this->chosenTemplates[$subtemplate]);
-				$subtemplateViewer->includeRequirements(false);
-				$subtemplateViewer->setPartialCacheStore($this->getPartialCacheStore());
-
-				$underlay[$subtemplate] = $subtemplateViewer->process($item, $arguments);
+				$chosenTemplate = $this->chosenTemplates[$subtemplate];
+				$self = $this;
+				$underlay[$subtemplate] = function() use ($item, $arguments, $chosenTemplate, $self) {
+					$subtemplateViewer = new SSViewer($chosenTemplate);
+					$subtemplateViewer->includeRequirements(false);
+					$subtemplateViewer->setPartialCacheStore($self->getPartialCacheStore());
+					return $subtemplateViewer->process($item, $arguments);
+				};
 			}
 		}
 


### PR DESCRIPTION
This is a fix and test case for Jonathan Menz' assertion in the silverstripe-dev discussion below.  It shows that $Layout is processed (which means all method calls, etc, are processed - causing performance problems) even if it does not need to be since it is only referenced within a <% cached %> block.

The problem with the code was in SSViewer->process where the Layout and Content templates were executed and made into an underlay before $this->includeGeneratedTemplate is called.  They were executed even though they may not be needed.  This PR changes that behavior to turn them into a closure to allow late-binding of variables within the underlay.  It also adds the same functionality for the overlay for the sake of consistency even though that is not currently used.  This was needed because the overlay and underlay before were treated only as arrays of values rather than objects that could have methods like the actual data object that SSViewer_DataPresenter is wrapping.

See https://groups.google.com/d/msg/silverstripe-dev/itYU50HoH50/aR6grcPIBSYJ
