### PR TITLE
FIX Arguments to method calls reseting scope

### DIFF
--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -5,7 +5,7 @@ class SSViewerTest extends SapphireTest {
 		parent::setUp();
 		Config::inst()->update('SSViewer', 'source_file_comments', false);
 	}
-	
+
 	/**
 	 * Tests for {@link Config::inst()->get('SSViewer', 'theme')} for different behaviour
 	 * of user defined themes via {@link SiteConfig} and default theme
@@ -1074,7 +1074,7 @@ after')
 		$origEnv = Config::inst()->get('Director', 'environment_type');
 		Config::inst()->update('Director', 'environment_type', 'dev');
 		Config::inst()->update('SSViewer', 'source_file_comments', true);
-	   $f = FRAMEWORK_PATH . '/tests/templates/SSViewerTestComments';
+		$f = FRAMEWORK_PATH . '/tests/templates/SSViewerTestComments';
 		$templates = array(
 			array(
 				'name' => 'SSViewerTestCommentsFullSource',
@@ -1090,7 +1090,8 @@ after')
 			array(
 				'name' => 'SSViewerTestCommentsFullSourceHTML4Doctype',
 				'expected' => ""
-					. "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"\t\t\"http://www.w3.org/TR/html4/strict.dtd\">"
+					. "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML "
+					. "4.01//EN\"\t\t\"http://www.w3.org/TR/html4/strict.dtd\">"
 					. "<!-- template $f/SSViewerTestCommentsFullSourceHTML4Doctype.ss -->"
 					. "<html>"
 					. "\t<head></head>"
@@ -1208,6 +1209,46 @@ after')
 			$template->process(array()), 
 			"tests/forms/RequirementsTest_a.js"
 		));
+	}
+
+	public function testCallsWithArguments() {
+		$data = new ArrayData(array(
+			'Set' => new ArrayList(array(
+				new SSViewerTest_Object("1"),
+				new SSViewerTest_Object("2"),
+				new SSViewerTest_Object("3"),
+				new SSViewerTest_Object("4"),
+				new SSViewerTest_Object("5"),
+			)),
+			'Level' => new SSViewerTest_LevelTest(1),
+			'Nest' => array(
+				'Level' => new SSViewerTest_LevelTest(2),
+			),
+		));
+
+		$tests = array(
+			'$Level.output(1)' => '1-1',
+			'$Nest.Level.output($Set.First.Number)' => '2-1',
+			'<% with $Set %>$Up.Level.output($First.Number)<% end_with %>' => '1-1',
+			'<% with $Set %>$Top.Nest.Level.output($First.Number)<% end_with %>' => '2-1',
+			'<% loop $Set %>$Up.Nest.Level.output($Number)<% end_loop %>' => '2-12-22-32-42-5',
+			'<% loop $Set %>$Top.Level.output($Number)<% end_loop %>' => '1-11-21-31-41-5',
+			'<% with $Nest %>$Level.output($Top.Set.First.Number)<% end_with %>' => '2-1',
+			'<% with $Level %>$output($Up.Set.Last.Number)<% end_with %>' => '1-5',
+			'<% with $Level.forWith($Set.Last.Number) %>$output("hi")<% end_with %>' => '5-hi',
+			'<% loop $Level.forLoop($Set.First.Number) %>$Number<% end_loop %>' => '!0',
+			'<% with $Nest %>
+				<% with $Level.forWith($Up.Set.First.Number) %>$output("hi")<% end_with %>
+			<% end_with %>' => '1-hi',
+			'<% with $Nest %>
+				<% loop $Level.forLoop($Top.Set.Last.Number) %>$Number<% end_loop %>
+			<% end_with %>' => '!0!1!2!3!4',
+		);
+
+		foreach($tests as $template => $expected) {
+			print_r(SSTemplateParser::compileString($template));
+			$this->assertEquals($expected, trim($this->render($template, $data)));
+		}
 	}
 }
 
@@ -1347,3 +1388,28 @@ class SSViewerTest_GlobalProvider implements TemplateGlobalProvider, TestOnly {
 	}
 
 }
+
+class SSViewerTest_LevelTest extends ViewableData implements TestOnly {
+	protected $depth;
+
+	public function __construct($depth = 1) {
+		$this->depth = $depth;
+	}
+
+	public function output($val) {
+		return "$this->depth-$val";
+	}
+
+	public function forLoop($number) {
+		$ret = array();
+		for($i = 0; $i < (int)$number; ++$i) {
+			$ret[] = new SSViewerTest_Object("!$i");
+		}
+		return new ArrayList($ret);
+	}
+
+	public function forWith($number) {
+		return new self($number);
+	}
+}
+

--- a/view/SSTemplateParser.php.inc
+++ b/view/SSTemplateParser.php.inc
@@ -118,6 +118,9 @@ class SSTemplateParser extends Parser {
 	
 	/*!*
 	
+	# Values are bare words in templates, but strings in PHP. We rely on PHP's type conversion to back-convert
+	# strings to numbers when needed.
+
 	Word: / [A-Za-z_] [A-Za-z0-9_]* /
 	Number: / [0-9]+ /
 	Value: / [A-Za-z0-9_]+ /
@@ -128,15 +131,20 @@ class SSTemplateParser extends Parser {
 	CallArguments: :Argument ( < "," < :Argument )*
 	*/
 
-	/** 
-	 * Values are bare words in templates, but strings in PHP. We rely on PHP's type conversion to back-convert
-	 * strings to numbers when needed.
-	 */
+	function CallArguments__construct(&$res) {
+		$res['args'] = array();
+	}
+
 	function CallArguments_Argument(&$res, $sub) {
+		$arg = ($sub['ArgumentMode'] == 'default' ?
+			$sub['string_php'] :
+			str_replace('$$FINAL', 'XML_val', $sub['php'])
+		);
+
+		$res['args'][] = $arg;
+
 		if (!empty($res['php'])) $res['php'] .= ', ';
-		
-		$res['php'] .= ($sub['ArgumentMode'] == 'default') ? $sub['string_php'] : 
-			str_replace('$$FINAL', 'XML_val', $sub['php']);
+		$res['php'] .= $arg;
 	}
 
 	/*!*
@@ -155,24 +163,58 @@ class SSTemplateParser extends Parser {
 
 	Lookup: LookupStep ("." LookupStep)* "." LastLookupStep | LastLookupStep
 	*/
-	
+
 	function Lookup__construct(&$res) {
+		$res['args'] = array();
 		$res['php'] = '$scope';
 		$res['LookupSteps'] = array();
 	}
-	
-	/** 
+
+	/** @var int Counter to make sure variables don't overwrite each other. TODO: Be better about recycling these */
+	static $ctr = 0;
+
+	/**
 	 * The basic generated PHP of LookupStep and LastLookupStep is the same, except that LookupStep calls 'obj' to 
 	 * get the next ViewableData in the sequence, and LastLookupStep calls different methods (XML_val, hasValue, obj)
 	 * depending on the context the lookup is used in.
+	 *
+	 * Note the special handling of arguments to avoid breaking scope chaining part way through.
+	 *
+	 *   $A.B($C.D($E.F, $G.H))
+	 *
+	 * becomes effectively
+	 *
+	 *   $v1 = $E.F; $v2 = $G.H; $v3 = $C.D($v1, $v2); return $A.B($v3);
+	 *
+	 * The caveat is that the output php fragment needs to be an expression, not a set of statements, so we have to
+	 * do a bit of trickery to be able to do both the variable assignment & the call within the same expression.
+	 *
+	 *   (($v1 = $E.F) || true)  // always true - either from $v1, or from true if $v1 gets assigned false
+	 *   &&                      // && so that short-circuit doesn't skip next assignments
+	 *   (($v2 = $G.H) || true)
+	 *   &&
+	 *   (($v3 = $C.D($v1, $v2)) || true)
+	 *   ? $A.B($v3)
+	 *   : 0
+	 *
+	 * Actually it's a bit uglier than that, as the list is built up by recursion.
 	 */
 	function Lookup_AddLookupStep(&$res, $sub, $method) {
 		$res['LookupSteps'][] = $sub;
 		
 		$property = $sub['Call']['Method']['text'];
 		
-		if (isset($sub['Call']['CallArguments']) && $arguments = $sub['Call']['CallArguments']['php']) {
-			$res['php'] .= "->$method('$property', array($arguments), true)";
+		if (!empty($sub['Call']['CallArguments']['args'])) {
+			$vars = array();
+
+			foreach($sub['Call']['CallArguments']['args'] as $arg) {
+				$varname = '$var'.(++self::$ctr);
+
+				$res['args'][] = "(($varname = $arg) || true)";
+				$vars[] = $varname;
+			}
+
+			$res['php'] .= "->$method('$property', array(".implode(',',$vars)."), true)";
 		}
 		else {
 			$res['php'] .= "->$method('$property', null, true)";
@@ -185,8 +227,9 @@ class SSTemplateParser extends Parser {
 
 	function Lookup_LastLookupStep(&$res, $sub) {
 		$this->Lookup_AddLookupStep($res, $sub, '$$FINAL');
-	}
 
+		if (!empty($res['args'])) $res['php'] = '(('.implode('&&',$res['args']).') ? '.$res['php'].' : 0)';
+	}
 
 	/*!*
 


### PR DESCRIPTION
Alternative method of fixing https://github.com/silverstripe/silverstripe-framework/pull/2028 which doesn't involve cloning scope.

Works by rewriting Lookup elements to extract elements first. That is,

```
$A.B($C.D($E.F, $G.H))
```

becomes effectively

```
$v1 = $E.F; $v2 = $G.H; $v3 = $C.D($v1, $v2); return $A.B($v3);
```

Although this should work with short circuiting I need to add more tests to make sure - although no method called in a template should have a side effect anyway.
