### PR TITLE
FIX Arguments to method calls reseting scope

### DIFF
--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -1074,7 +1074,7 @@ after')
 		$origEnv = Config::inst()->get('Director', 'environment_type');
 		Config::inst()->update('Director', 'environment_type', 'dev');
 		Config::inst()->update('SSViewer', 'source_file_comments', true);
-	   $f = FRAMEWORK_PATH . '/tests/templates/SSViewerTestComments';
+		$f = FRAMEWORK_PATH . '/tests/templates/SSViewerTestComments';
 		$templates = array(
 			array(
 				'name' => 'SSViewerTestCommentsFullSource',
@@ -1090,7 +1090,8 @@ after')
 			array(
 				'name' => 'SSViewerTestCommentsFullSourceHTML4Doctype',
 				'expected' => ""
-					. "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"\t\t\"http://www.w3.org/TR/html4/strict.dtd\">"
+					. "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML "
+					. "4.01//EN\"\t\t\"http://www.w3.org/TR/html4/strict.dtd\">"
 					. "<!-- template $f/SSViewerTestCommentsFullSourceHTML4Doctype.ss -->"
 					. "<html>"
 					. "\t<head></head>"
@@ -1208,6 +1209,45 @@ after')
 			$template->process(array()), 
 			"tests/forms/RequirementsTest_a.js"
 		));
+	}
+
+	public function testCallsWithArguments() {
+		$data = new ArrayData(array(
+			'Set' => new ArrayList(array(
+				new SSViewerTest_Object("1"),
+				new SSViewerTest_Object("2"),
+				new SSViewerTest_Object("3"),
+				new SSViewerTest_Object("4"),
+				new SSViewerTest_Object("5"),
+			)),
+			'Level' => new SSViewerTest_LevelTest(1),
+			'Nest' => array(
+				'Level' => new SSViewerTest_LevelTest(2),
+			),
+		));
+
+		$tests = array(
+			'$Level.output(1)' => '1-1',
+			'$Nest.Level.output($Set.First.Number)' => '2-1',
+			'<% with $Set %>$Up.Level.output($First.Number)<% end_with %>' => '1-1',
+			'<% with $Set %>$Top.Nest.Level.output($First.Number)<% end_with %>' => '2-1',
+			'<% loop $Set %>$Up.Nest.Level.output($Number)<% end_loop %>' => '2-12-22-32-42-5',
+			'<% loop $Set %>$Top.Level.output($Number)<% end_loop %>' => '1-11-21-31-41-5',
+			'<% with $Nest %>$Level.output($Top.Set.First.Number)<% end_with %>' => '2-1',
+			'<% with $Level %>$output($Up.Set.Last.Number)<% end_with %>' => '1-5',
+			'<% with $Level.forWith($Set.Last.Number) %>$output("hi")<% end_with %>' => '5-hi',
+			'<% loop $Level.forLoop($Set.First.Number) %>$Number<% end_loop %>' => '!0',
+			'<% with $Nest %>
+				<% with $Level.forWith($Up.Set.First.Number) %>$output("hi")<% end_with %>
+			<% end_with %>' => '1-hi',
+			'<% with $Nest %>
+				<% loop $Level.forLoop($Top.Set.Last.Number) %>$Number<% end_loop %>
+			<% end_with %>' => '!0!1!2!3!4',
+		);
+
+		foreach($tests as $template => $expected) {
+			$this->assertEquals($expected, trim($this->render($template, $data)));
+		}
 	}
 }
 
@@ -1347,3 +1387,28 @@ class SSViewerTest_GlobalProvider implements TemplateGlobalProvider, TestOnly {
 	}
 
 }
+
+class SSViewerTest_LevelTest extends ViewableData implements TestOnly {
+	protected $depth;
+
+	public function __construct($depth = 1) {
+		$this->depth = $depth;
+	}
+
+	public function output($val) {
+		return "$this->depth-$val";
+	}
+
+	public function forLoop($number) {
+		$ret = array();
+		for($i = 0; $i < (int)$number; ++$i) {
+			$ret[] = new SSViewerTest_Object("!$i");
+		}
+		return new ArrayList($ret);
+	}
+
+	public function forWith($number) {
+		return new self($number);
+	}
+}
+

--- a/view/SSTemplateParser.php
+++ b/view/SSTemplateParser.php
@@ -615,7 +615,7 @@ class SSTemplateParser extends Parser {
 
 	
 	function Lookup__construct(&$res) {
-		$res['php'] = '$scope';
+		$res['php'] = '$scope->locally()';
 		$res['LookupSteps'] = array();
 	}
 	

--- a/view/SSTemplateParser.php.inc
+++ b/view/SSTemplateParser.php.inc
@@ -157,7 +157,7 @@ class SSTemplateParser extends Parser {
 	*/
 	
 	function Lookup__construct(&$res) {
-		$res['php'] = '$scope';
+		$res['php'] = '$scope->locally()';
 		$res['LookupSteps'] = array();
 	}
 	


### PR DESCRIPTION
Better fix than https://github.com/silverstripe/silverstripe-framework/pull/2028 or https://github.com/silverstripe/silverstripe-framework/pull/2149

Adds a new method to scope, `locally`, which resets the scope to the current local base, but remembers the current deviation from local base. When XML_val or equivalent lookup chain end-mark resets the scope via `resetLocalScope`, if there was a pre-existing deviation from local base we restore to that rather than local.
