### PR TITLE
FIX Empty Datefield with defined min or max has non-object error thrown

### DIFF
--- a/forms/DateField.php
+++ b/forms/DateField.php
@@ -367,7 +367,7 @@ class DateField extends TextField {
 			} else {
 				$minDate = new Zend_Date(strftime('%Y-%m-%d', strtotime($min)), $this->getConfig('datavalueformat'));
 			}
-			if(!$this->valueObj->isLater($minDate) && !$this->valueObj->equals($minDate)) {
+			if(!$this->valueObj || (!$this->valueObj->isLater($minDate) && !$this->valueObj->equals($minDate))) {
 				$validator->validationError(
 					$this->name, 
 					_t(
@@ -388,7 +388,7 @@ class DateField extends TextField {
 			} else {
 				$maxDate = new Zend_Date(strftime('%Y-%m-%d', strtotime($max)), $this->getConfig('datavalueformat'));
 			}
-			if(!$this->valueObj->isEarlier($maxDate) && !$this->valueObj->equals($maxDate)) {
+			if(!$this->valueObj || (!$this->valueObj->isEarlier($maxDate) && !$this->valueObj->equals($maxDate))) {
 				$validator->validationError(
 					$this->name, 
 					_t('DateField.VALIDDATEMAXDATE',


### PR DESCRIPTION
When submitting a Datefield with no value but with a min / max config date, the validate() function attempts to access a function on $this->valueObj (which is a non-object)
