### PR TITLE
Allow Form->forTemplate() URL access (fixes #788)

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -149,7 +149,11 @@ class Form extends RequestHandler {
 	 */
 	protected $attributes = array();
 
-	private static $allowed_actions = array('handleField', 'httpSubmission');
+	private static $allowed_actions = array(
+		'handleField', 
+		'httpSubmission',
+		'forTemplate',
+	);
 
 	/**
 	 * Create a new form, with the given fields an action buttons.
@@ -210,7 +214,7 @@ class Form extends RequestHandler {
 		'GET ' => 'httpSubmission',
 		'HEAD ' => 'httpSubmission',
 	);
-	
+
 	/**
 	 * Set up current form errors in session to
 	 * the current form if appropriate.


### PR DESCRIPTION
Need to specifically whitelist URL-accessible actions now.
Used in "Insert Link" form in HtmlEditorField.
Regression from 1edf45fbedd1431f7b0105403b628deda2b61bdc

It would be nicer to make this an `index()` method,
and allow access via `mycontroller/MyForm` rather than `mycontroller/myForm/forTemplate`,
but that doesn't work because actions fall back to `Form->httpSubmission()` at the moment.
