### PR TITLE
Only redirect on logout if we're not already redirecting

### DIFF
--- a/security/Security.php
+++ b/security/Security.php
@@ -346,7 +346,9 @@ class Security extends Controller {
 		$member = Member::currentUser();
 		if($member) $member->logOut();
 
-		if($redirect) $this->redirectBack();
+		if($redirect && (!$this->response || !$this->response->isFinished())) {
+			$this->redirectBack();
+		}
 	}
 
 


### PR DESCRIPTION
Use case: An extension where the logout process has to go through another site. Allows using Controller#redirect, rather than header() and die().
