### PR TITLE
Versioned not ignoring obsolete fields

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -569,7 +569,7 @@ class Versioned extends DataExtension {
 				// Add any extra, unchanged fields to the version record.
 				$data = DB::query("SELECT * FROM \"$table\" WHERE \"ID\" = $id")->record();
 				if($data) {
-					$fields = DataObject::database_fields($this->owner->class);
+					$fields = DataObject::database_fields($table);
 					if(is_array($fields)) {
 						$data=array_intersect_key($data,$fields);
 						foreach($data as $k => $v) {


### PR DESCRIPTION
Useful to prevent weird errors in development where fields have been renamed and in production where old databases have been updated and old fields made obsolete, and the Versioned extension has later been applied to the dataobject. In both these cases the obsolete fields present in the core table cause an error when writing Versioned records.
### To Reproduce:
1. Create a DataObject with at least one database field
2. Perform a build
3. Remove or rename a field from the dataobject, and apply the Versioned extension to the dataobject
4. Perform another build
5. Write a new or old but changed DataObject of this type
6. A database exception is thrown
### Resolution

The branch to pull fixes the problem by filtering the list of fields returned from the core table by those known to be present in the code via a call to _DataObject::database_fields()_
