### PR TITLE
BUG Fixed DateTimeField where time value was being parsed incorrectly.

### DIFF
--- a/tests/forms/TimeFieldTest.php
+++ b/tests/forms/TimeFieldTest.php
@@ -100,4 +100,36 @@ class TimeFieldTest extends SapphireTest {
 		$field->setValue('');
 		$this->assertEquals($field->dataValue(), '');
 	}
+	
+	/**
+	 * Test that AM/PM is preserved correctly in various situations
+	 */
+	public function testPreserveAMPM() {
+		
+		// Test with timeformat that includes hour
+		
+		// Check pm
+		$f = new TimeField('Time', 'Time');
+		$f->setConfig('timeformat', 'h:mm:ss a');
+		$f->setValue('3:59 pm');
+		$this->assertEquals($f->dataValue(), '15:59:00');
+		
+		// Check am
+		$f = new TimeField('Time', 'Time');
+		$f->setConfig('timeformat', 'h:mm:ss a');
+		$f->setValue('3:59 am');
+		$this->assertEquals($f->dataValue(), '03:59:00');
+		
+		// Check with ISO date/time
+		$f = new TimeField('Time', 'Time');
+		$f->setConfig('timeformat', 'h:mm:ss a');
+		$f->setValue('15:59:00');
+		$this->assertEquals($f->dataValue(), '15:59:00');
+		
+		// ISO am
+		$f = new TimeField('Time', 'Time');
+		$f->setConfig('timeformat', 'h:mm:ss a');
+		$f->setValue('03:59:00');
+		$this->assertEquals($f->dataValue(), '03:59:00');
+	}
 }


### PR DESCRIPTION
When the current user's locale has AM/PM included, the time field would attempt to parse this value, but before using the same locale parse string, it would run it past the ISO time format string (which ommits the AM/PM). Since the matching was a bit slack, it would think these times were actually ISO, and would parse this in. Of course, the AM/PM would get lost.

This fix changes the parsing mechanism to still do these checks in the correct order, but will only match the ISO format against the presented value if it matches exactly (which is tested by writing the parsed value out and comparing this to the input).

Issue first noted at http://www.silverstripe.org/content-editor-discussions/show/24005
