### PR TITLE
Allow module directories to be named with more valid characters ensuring that module names in fragment meta-data are correct

### DIFF
--- a/core/manifest/ConfigManifest.php
+++ b/core/manifest/ConfigManifest.php
@@ -291,7 +291,7 @@ class SS_ConfigManifest {
 						// For each, parse out into module/file#name, and set any missing to "*"
 						$header[$order] = array();
 						foreach($orderparts as $part) {
-							preg_match('! (?P<module>\*|\w+)? (\/ (?P<file>\*|\w+))? (\# (?P<fragment>\*|\w+))? !x',
+							preg_match('! (?P<module>\*|[^\/#]+)? (\/ (?P<file>\*|\w+))? (\# (?P<fragment>\*|\w+))? !x',
 								$part, $match);
 
 							$header[$order][] = array(

--- a/tests/core/manifest/fixtures/configmanifest/mysite/_config/addyamlconfigfile.yml
+++ b/tests/core/manifest/fixtures/configmanifest/mysite/_config/addyamlconfigfile.yml
@@ -1,0 +1,59 @@
+---
+After: 'mysite/testfile#fragment'
+---
+ClassManifestTest:
+    testParam: false
+
+---
+After: 'test-module/testfile#fragment'
+---
+ClassManifestTest:
+    testParam: false
+
+---
+After: '*'
+---
+ClassManifestTest:
+    testParam: false
+
+---
+After: '*/testfile'
+---
+ClassManifestTest:
+    testParam: false
+
+---
+After: '*/*#fragment'
+---
+ClassManifestTest:
+    testParam: false
+
+---
+After: '#fragment'
+---
+ClassManifestTest:
+    testParam: false
+
+---
+After: 'test-module#fragment'
+---
+ClassManifestTest:
+    testParam: false
+
+---
+After: 'test-module'
+---
+ClassManifestTest:
+    testParam: false
+
+---
+After: 'test-module/*'
+---
+ClassManifestTest:
+    testParam: false
+
+---
+After: 'test-module/*#*'
+---
+ClassManifestTest:
+    testParam: false


### PR DESCRIPTION
When modules are named "silverstripe-something" the regex fails to pickup the correct module name. I couldn't find unit tests for this part of the ConfigManifest, there appears to be no testing of the parsing of the yml files (addYAMLConfigFile). It would be more effort than I have time for to write tests covering this part of the system, apologies.
