### PR TITLE
BUG Unable to use 'Created', 'LastUpdated' or 'ClassName' in $searchable_fields

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1677,6 +1677,11 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 			}
 
 			if($fieldName) {
+				$dbItems = array_merge(
+					self::database_fields($class),
+					$dbItems
+				);
+				
 				if(isset($dbItems[$fieldName])) {
 					return $dbItems[$fieldName];
 				}


### PR DESCRIPTION
DO NOT MERGE: needs reviewing

If you define 'Created', 'LastUpdated' or 'ClassName' in a model's `$searchable_fields`, an error occurs: "Call to a member function scaffoldSearchField() on a non-object in .../DataObject.php on line 1973".

This is because `relObject()`, and in turn `dbObject()` return null for any of those fields. The reason for this is that `DataObject->db()` gets its array of database fields from the Config manifest with:

`Config::inst()->get($class, 'db', Config::INHERITED);`.

This doesn't include those fields in the returned data.

Changing the above line to instead use `self::database_fields($class);` fixes the issue, but adds 'Created', 'LastUpdated' and 'ClassName' to the scaffolded form fields.

Proposed solution is attached, but will need reviewing by someone with a better understanding of the implications of this change. `database_fields()` calls `custom_database_fields()` which appears to add has_one relationships to the array using dot notation, so that's an extra consideration.
