### PR TITLE
Suppress warnings when constructing a Zend_Translate object

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -1588,7 +1588,7 @@ class i18n extends Object implements TemplateGlobalProvider {
 		if(!self::$translators) {
 			$defaultPriority = 10;
 			self::$translators[$defaultPriority] = array(
-				'core' => new Zend_Translate(array(
+				'core' => @new Zend_Translate(array(
 					'adapter' => 'i18nRailsYamlAdapter',
 					'locale' => self::$default_locale,
 					'disableNotices' => true,


### PR DESCRIPTION
This hides problems where a host is set up with an include_path that has paths not in the open_basedir value. Zend_Loader always gets called, and always enumerates every part of the include_path.
