### PR TITLE
Prevent IE 9/10 errors

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -277,7 +277,10 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 						if (!source) return;
 
 						var parent = source;
-						while (parent && parent.nodeType == 1) parent = parent.parentNode;
+						try {
+							while (parent && parent.nodeType == 1) parent = parent.parentNode;
+						}
+						catch(err) {}
 
 						if (!parent) $(source).unbind().remove();
 					});


### PR DESCRIPTION
Both IE 9 & 10 generate a "SCRIPT70: Permission denied" when looping through the parents in the CMS. This happens after data has been edited in a UploadField iframe (eg: submitted Title change), followed by a click on any SiteTree link.