### PR TITLE
BUG - Critical - Fixed missing allowed_actions on UploadField_SelectHandler

### DIFF
--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -1490,6 +1490,11 @@ class UploadField_SelectHandler extends RequestHandler {
 		'' => 'index',
 	);
 
+	private static $allowed_actions = array(
+		'doAttach',
+		'Form'
+	);
+
 	public function __construct($parent, $folderName = null) {
 		$this->parent = $parent;
 		$this->folderName = $folderName;


### PR DESCRIPTION
Following up to fb784af7380a06b6ae078f7af17e61acb0b3a2f6 UploadField_SelectHandler now requires explicit specification of all actions.

At the moment trying to change the folder from the attach dialogue throws a 403 error.
