### PR TITLE
Update Travis to test against PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 php: 
  - 5.3
- - 5.4
+ - 5.5
 
 env:
  - DB=MYSQL CORE_RELEASE=3.0
@@ -11,9 +11,9 @@ env:
 
 matrix:
   exclude:
-    - php: 5.4
+    - php: 5.5
       env: DB=PGSQL CORE_RELEASE=3.0
-    - php: 5.4
+    - php: 5.5
       env: DB=SQLITE3 CORE_RELEASE=3.0
   allow_failures:
     - env: DB=PGSQL CORE_RELEASE=3.0


### PR DESCRIPTION
Switch out PHP 5.4 for 5.5. Other option is to add 5.5 as another version to test against and leave 5.4. Went this way so tests don't take longer to run and we're testing against the minimum supported version (kinda, it's 5.3 latest) and the latest version.
