### PR TITLE
BUG: fixes #2194 tree dropdown title being reset when loosing focus

### DIFF
--- a/javascript/TreeDropdownField.js
+++ b/javascript/TreeDropdownField.js
@@ -109,6 +109,8 @@
 				this[this.getPanel().is(':visible') ? 'closePanel' : 'openPanel']();
 			},
 			setTitle: function(title) {
+				// need to consider if a title has been set previously
+				title = (title) ? title : this.find('.treedropdownfield-title').html();
 				if(!title) title = strings.fieldTitle;
 					
 				this.find('.treedropdownfield-title').html(title);


### PR DESCRIPTION
The title in TreeDropdown is being reset to the default string when focus is being lost as per issue #2194.

I have replicated this via the Add page form in the CMS system and this is where I tested the fix as well.

I have tested this on FireFox and Chrome on a Mac and I have used VirtualBox to test on IE8.
