### PR TITLE
API Deprecate Aggregate and DataObject::getComponentsQuery

### DIFF
--- a/model/Aggregate.php
+++ b/model/Aggregate.php
@@ -29,6 +29,8 @@
  * NOTE: The cache logic uses tags, and so a backend that supports tags is required. Currently only the File
  * backend (and the two-level backend with the File backend as the slow store) meets this requirement
  * 
+ * @deprecated 3.1 Use DataList to aggregate data
+ * 
  * @author hfried
  * @package framework
  * @subpackage core
@@ -60,10 +62,15 @@ class Aggregate extends ViewableData {
 	/**
 	 * Constructor
 	 * 
+	 * @deprecated 3.1 Use DataList to aggregate data
+	 * 
 	 * @param string $type The DataObject type we are building an aggregate for
 	 * @param string $filter (optional) An SQL filter to apply to the selected rows before calculating the aggregate
 	 */
 	public function __construct($type, $filter = '') {
+		Deprecation::notice('3.1', 'Call aggregate methods on a DataList directly instead. In templates'
+			. ' an example of the new syntax is &lt% cached List(Member).max(LastEdited) %&gt instead'
+			. ' (check partial-caching.md documentation for more details.)');
 		$this->type = $type;
 		$this->filter = $filter;
 		parent::__construct();

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1468,39 +1468,11 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	}
 
 	/**
-	 * Get the query object for a $has_many Component.
-	 *
-	 * @param string $componentName
-	 * @param string $filter
-	 * @param string|array $sort
-	 * @param string $join Deprecated, use leftJoin($table, $joinClause) instead
-	 * @param string|array $limit
-	 * @return SQLQuery
+	 * @deprecated 3.1 Use getComponents to get a filtered DataList for an object's relation
 	 */
 	public function getComponentsQuery($componentName, $filter = "", $sort = "", $join = "", $limit = "") {
-		if(!$componentClass = $this->has_many($componentName)) {
-			user_error("DataObject::getComponentsQuery(): Unknown 1-to-many component '$componentName'"
-				. " on class '$this->class'", E_USER_ERROR);
-		}
-
-		if($join) {
-			throw new \InvalidArgumentException(
-				'The $join argument has been removed. Use leftJoin($table, $joinClause) instead.'
-			);
-		}
-
-		$joinField = $this->getRemoteJoinField($componentName, 'has_many');
-
-		$id = $this->getField("ID");
-			
-		// get filter
-		$combinedFilter = "\"$joinField\" = '$id'";
-		if(!empty($filter)) $combinedFilter .= " AND ({$filter})";
-			
-		return DataList::create($componentClass)
-			->where($combinedFilter)
-			->canSortBy($sort)
-			->limit($limit);
+		Deprecation::notice('3.1', "Use getComponents to get a filtered DataList for an object's relation");
+		return $this->getComponents($componentName, $filter, $sort, $join, $limit);
 	}
 
 	/**


### PR DESCRIPTION
https://github.com/silverstripe/silverstripe-framework/blob/3.1/model/Aggregate.php seems like it could be a bit of a relic of 2.4. It references DataObject::getManyManyComponentsQuery (which no longer exists), and it seems that most of its functionality is superceded by DataList, other than the caching behaviour.

In addition, this seems to be the only place where `DataObject::getComponentsQuery` is used. Is there any situation where this function is useful where `DataList` or `DataObject::getComponents` can't do the job?

Can we deprecate these, or am I missing a valid reason for their still existing?

I couldn't find any test case coverage or documentation for these, so I didn't bother to attempt 'fixing' `Aggregate`.
