### PR TITLE
Improve memory performance when generating config static and class caches

### DIFF
--- a/core/manifest/ClassManifest.php
+++ b/core/manifest/ClassManifest.php
@@ -274,6 +274,15 @@ class SS_ClassManifest {
 	}
 
 	/**
+	 * Used to set up files that we want to exclude from parsing for performance reasons.
+	 */
+	protected function setDefaults()
+	{
+		$this->classes['sstemplateparser'] = FRAMEWORK_PATH.'/view/SSTemplateParser.php';
+		$this->classes['sstemplateparseexception'] = FRAMEWORK_PATH.'/view/SSTemplateParser.php';
+	}
+
+	/**
 	 * Completely regenerates the manifest file.
 	 *
 	 * @param bool $cache Cache the result.
@@ -289,10 +298,12 @@ class SS_ClassManifest {
 			$this->$reset = array();
 		}
 
+		$this->setDefaults();
+
 		$finder = new ManifestFileFinder();
 		$finder->setOptions(array(
 			'name_regex'    => '/^(_config.php|[^_].*\.php)$/',
-			'ignore_files'  => array('index.php', 'main.php', 'cli-script.php'),
+			'ignore_files'  => array('index.php', 'main.php', 'cli-script.php', 'SSTemplateParser.php'),
 			'ignore_tests'  => !$this->tests,
 			'file_callback' => array($this, 'handleFile'),
 			'dir_callback' => array($this, 'handleDir')

--- a/core/manifest/ConfigStaticManifest.php
+++ b/core/manifest/ConfigStaticManifest.php
@@ -100,7 +100,7 @@ class SS_ConfigStaticManifest {
 		$finder = new ManifestFileFinder();
 		$finder->setOptions(array(
 			'name_regex'    => '/^([^_].*\.php)$/',
-			'ignore_files'  => array('index.php', 'main.php', 'cli-script.php'),
+			'ignore_files'  => array('index.php', 'main.php', 'cli-script.php', 'SSTemplateParser.php'),
 			'ignore_tests'  => !$this->tests,
 			'file_callback' => array($this, 'handleFile')
 		));

--- a/tests/core/manifest/ClassManifestTest.php
+++ b/tests/core/manifest/ClassManifestTest.php
@@ -36,17 +36,20 @@ class ClassManifestTest extends SapphireTest {
 
 	public function testGetClasses() {
 		$expect = array(
-			'classa' => "{$this->base}/module/classes/ClassA.php",
-			'classb' => "{$this->base}/module/classes/ClassB.php",
-			'classc' => "{$this->base}/module/classes/ClassC.php",
-			'classd' => "{$this->base}/module/classes/ClassD.php"
+			'classb'                   => "{$this->base}/module/classes/ClassB.php",
+			'classa'                   => "{$this->base}/module/classes/ClassA.php",
+			'classb'                   => "{$this->base}/module/classes/ClassB.php",
+			'classc'                   => "{$this->base}/module/classes/ClassC.php",
+			'classd'                   => "{$this->base}/module/classes/ClassD.php",
+			'sstemplateparser'         => FRAMEWORK_PATH."/view/SSTemplateParser.php",
+			'sstemplateparseexception' => FRAMEWORK_PATH."/view/SSTemplateParser.php"
 		);
 		$this->assertEquals($expect, $this->manifest->getClasses());
 	}
 
 	public function testGetClassNames() {
 		$this->assertEquals(
-			array('classa', 'classb', 'classc', 'classd'),
+			array('sstemplateparser', 'sstemplateparseexception', 'classa', 'classb', 'classc', 'classd'),
 			$this->manifest->getClassNames());
 	}
 

--- a/tests/core/manifest/NamespacedClassManifestTest.php
+++ b/tests/core/manifest/NamespacedClassManifestTest.php
@@ -12,7 +12,7 @@ class NamespacedClassManifestTest extends SapphireTest {
 
 	public function setUp() {
 		parent::setUp();
-		
+
 		$this->base = dirname(__FILE__) . '/fixtures/namespaced_classmanifest';
 		$this->manifest      = new SS_ClassManifest($this->base, false, true, false);
 	}
@@ -41,17 +41,20 @@ class NamespacedClassManifestTest extends SapphireTest {
 			'silverstripe\test\classe' => "{$this->base}/module/classes/ClassE.php",
 			'silverstripe\test\classf' => "{$this->base}/module/classes/ClassF.php",
 			'silverstripe\test\classg' => "{$this->base}/module/classes/ClassG.php",
-			'silverstripe\test\classh' => "{$this->base}/module/classes/ClassH.php"
+			'silverstripe\test\classh' => "{$this->base}/module/classes/ClassH.php",
+			'sstemplateparser'         => FRAMEWORK_PATH."/view/SSTemplateParser.php",
+			'sstemplateparseexception' => FRAMEWORK_PATH."/view/SSTemplateParser.php"
 		);
-		
+
 		$this->assertEquals($expect, $this->manifest->getClasses());
 	}
 
 	public function testGetClassNames() {
 		$this->assertEquals(
-			array('silverstripe\test\classa', 'silverstripe\test\classb', 'silverstripe\test\classc',
-				'silverstripe\test\classd', 'silverstripe\test\classe', 'silverstripe\test\classf',
-				'silverstripe\test\classg', 'silverstripe\test\classh'),
+			array('sstemplateparser', 'sstemplateparseexception', 'silverstripe\test\classa',
+				'silverstripe\test\classb', 'silverstripe\test\classc', 'silverstripe\test\classd',
+				'silverstripe\test\classe', 'silverstripe\test\classf', 'silverstripe\test\classg',
+				'silverstripe\test\classh'),
 			$this->manifest->getClassNames());
 	}
 
@@ -59,7 +62,7 @@ class NamespacedClassManifestTest extends SapphireTest {
 		$expect = array(
 			'silverstripe\test\classa' => array('silverstripe\test\ClassB', 'silverstripe\test\ClassH'),
 		);
-		
+
 		$this->assertEquals($expect, $this->manifest->getDescendants());
 	}
 
@@ -109,7 +112,7 @@ class NamespacedClassManifestTest extends SapphireTest {
 		$expect = array("{$this->base}/module/_config.php");
 		$this->assertEquals($expect, $this->manifest->getConfigs());
 	}
-	
+
 	public function testGetModules() {
 		$expect = array(
 			"module" => "{$this->base}/module",


### PR DESCRIPTION
Improves #1705 

Final xhprof benchmarking:

<table >
<tr><th></th><th>Run #51da7bfa0e9b0</th><th>Run #51da7be07d1a1</th><th>Diff</th><th>Diff%</th></tr><tr><td>Number of Function Calls</td><td>3,418,925</td>
<td>3,126,772</td>
<td>-292,153</td>
<td>-8.5%</td>
</tr><tr><td>Incl. Wall Time (microsec)</td><td>9,809,302</td>
<td>8,829,096</td>
<td>-980,206</td>
<td>-10.0%</td>
</tr><tr></tr><tr><td>Incl. CPU (microsecs)</td><td>9,794,225</td>
<td>8,732,070</td>
<td>-1,062,155</td>
<td>-10.8%</td>
</tr><tr></tr><tr><td>Incl. MemUse (bytes)</td><td>25,068,840</td>
<td>25,057,480</td>
<td>-11,360</td>
<td>-0.0%</td>
</tr><tr></tr><tr><td>Incl.  PeakMemUse (bytes)</td><td>57,953,040</td>
<td>25,264,256</td>
<td>-32,688,784</td>
<td>-56.4%</td>
</tr></table>
