### PR TITLE
FIX: wrong class name being returned

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -170,7 +170,7 @@ class GridFieldDetailForm implements GridField_URLHandler {
 		} else if(ClassInfo::exists(get_class($this) . "_ItemRequest")) {
 			return get_class($this) . "_ItemRequest";
 		} else {
-			return 'GridFieldItemRequest_ItemRequest';
+			return 'GridFieldDetailForm_ItemRequest';
 		}
 	}
 


### PR DESCRIPTION
This resulted in an error since the returned class name did not exist.
Note that this only happened when someone subclassed GridFieldDetailForm
and did not subclass GridFieldDetailForm_ItemRequest.
