### PR TITLE
FIX ConfigManifest regenerating every request if variantKeySpec is an empty array()

### DIFF
--- a/core/manifest/ConfigManifest.php
+++ b/core/manifest/ConfigManifest.php
@@ -23,7 +23,7 @@ class SS_ConfigManifest {
 	  * the current environment.
 	  * @var array
 	  */
-	protected $variantKeySpec = array();
+	protected $variantKeySpec = false;
 
 	/**
 	 * All the _config.php files. Need to be included every request & can't be cached. Not variant specific.
@@ -88,10 +88,7 @@ class SS_ConfigManifest {
 		$this->includeTests = $includeTests;
 
 		// Get the Zend Cache to load/store cache into
-		$this->cache = SS_Cache::factory('SS_Configuration', 'Core', array(
-			'automatic_serialization' => true,
-			'lifetime' => null
-		));
+		$this->cache = $this->getCache();
 
 		// Unless we're forcing regen, try loading from cache
 		if (!$forceRegen) {
@@ -102,12 +99,24 @@ class SS_ConfigManifest {
 		}
 
 		// If we don't have a variantKeySpec (because we're forcing regen, or it just wasn't in the cache), generate it
-		if (!$this->variantKeySpec) {
+		if (false === $this->variantKeySpec) {
 			$this->regenerate($includeTests);
 		}
 
 		// At this point $this->variantKeySpec will always contain something valid, so we can build the variant
 		$this->buildYamlConfigVariant();
+	}
+
+	/**
+	 * Provides a hook for mock unit tests despite no DI
+	 * @return Zend_Cache_Frontend
+	 */
+	protected function getCache()
+	{
+		return SS_Cache::factory('SS_Configuration', 'Core', array(
+			'automatic_serialization' => true,
+			'lifetime' => null
+		));
 	}
 
 	/**


### PR DESCRIPTION
@chillu This is what I talked about last night. It turns out that `regenerate` was being called on `SS_ConfigManifest` whenever `variantKeySpec` was equal to `array()`.

Essentially unless you had a module installed that caused `variantKeySpec` to be non-empty the Config would regenerate on each request.

Before and after xhprof against a vanilla SilverStripe install that has a fully primed cache:

<table>
<tr><th></th><th>Run #51dca138cc06c</th><th>Run #51dca11fd851a</th><th>Diff</th><th>Diff%</th></tr><tr><td>Number of Function Calls</td><td>142,247</td>
<td>18,238</td>
<td>-124,009</td>
<td>-87.2%</td>
</tr><tr><td>Incl. Wall Time (microsec)</td><td>433,458</td>
<td>133,542</td>
<td>-299,916</td>
<td>-69.2%</td>
</tr><tr></tr><tr><td>Incl. CPU (microsecs)</td><td>426,059</td>
<td>126,969</td>
<td>-299,090</td>
<td>-70.2%</td>
</tr><tr></tr><tr><td>Incl. MemUse (bytes)</td><td>21,550,856</td>
<td>21,278,064</td>
<td>-272,792</td>
<td>-1.3%</td>
</tr><tr></tr><tr><td>Incl.  PeakMemUse (bytes)</td><td>21,669,480</td>
<td>21,395,448</td>
<td>-274,032</td>
<td>-1.3%</td>
</tr></table>
