### PR TITLE
BUG Prevent clickjacking in CMS and Security controllers (fixes #2215)

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -449,6 +449,9 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		$title = $this->Title();
 		if(!$response->getHeader('X-Controller')) $response->addHeader('X-Controller', $this->class);
 		if(!$response->getHeader('X-Title')) $response->addHeader('X-Title', urlencode($title));
+
+		// Prevent clickjacking, see https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
+		$this->response->addHeader('X-Frame-Options', 'SAMEORIGIN');
 		
 		return $response;
 	}

--- a/docs/en/topics/security.md
+++ b/docs/en/topics/security.md
@@ -407,6 +407,8 @@ configuration and test fixtures).
 You should therefore block access to all yaml files (extension .yml) by default, and white list only yaml files
 you need to serve directly.
 
+See [Apache](/installation/webserver) and [Nginx](/installation/nginx) installation documentation for details 
+specific to your web server
 See [Apache](/installation/webserver) and [Nginx](/installation/nginx) installation documentation for details  specific to your web server
 
 ## Passwords
@@ -436,6 +438,31 @@ In addition, you can tighten password security with the following configuration 
     the user is blocked from further attempts for the timespan defined in `$lock_out_delay_mins`
  * `Member.lock_out_delay_mins`: Minutes of enforced lockout after incorrect password attempts.
  		Only applies if `lock_out_after_incorrect_logins` is greater than 0.
+
+## Clickjacking: Prevent iframe Inclusion
+
+"[Clickjacking](http://en.wikipedia.org/wiki/Clickjacking)"  is a malicious technique
+where a web user is tricked into clicking on hidden interface elements, which can
+lead to the attacker gaining access to user data or taking control of the website behaviour.
+
+You can signal to browsers that the current response isn't allowed to be 
+included in HTML "frame" or "iframe" elements, and thereby prevent the most common
+attack vector. This is done through a HTTP header, which is usually added in your
+controller's `init()` method:
+
+	:::php
+	class MyController extends Controller {
+		public function init() {
+			parent::init();
+
+			$this->response->addHeader('X-Frame-Options', 'SAMEORIGIN');
+		}
+	}
+	
+
+This is a recommended option to secure any controller which displays
+or submits sensitive user input, and is enabled by default in all CMS controllers,
+as well as the login form.
 
 ##  Related
 

--- a/security/Security.php
+++ b/security/Security.php
@@ -270,6 +270,13 @@ class Security extends Controller {
 		return;
 	}
 
+	public function init() {
+		parent::init();
+
+		// Prevent clickjacking, see https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
+		$this->response->addHeader('X-Frame-Options', 'SAMEORIGIN');
+	}
+
 
 	/**
 	 * Get the login form to process according to the submitted data


### PR DESCRIPTION
Haven't added a test, since its kind of straightforward, right? We don't check for correct `Content-Type` headers etc in CMS responses either.
