### PR TITLE
DOCFIX: small typo causing linking error

### DIFF
--- a/docs/en/reference/grid-field.md
+++ b/docs/en/reference/grid-field.md
@@ -154,7 +154,7 @@ The fields displayed in the edit form are from `DataObject::getCMSFields()`
 The `GridFieldDetailForm` component drives the record editing form which is usually configured
 through the configs `GridFieldConfig_RecordEditor` and `GridFieldConfig_RelationEditor`
 described above. It takes its fields from `DataObject->getCMSFields()`,
-but can be customized to accept different fields via its `[api:GridFieldDetailForm->setFields()](api:setFields())` method.
+but can be customized to accept different fields via its `[api:GridFieldDetailForm->setFields()]` method.
 
 The component also has the ability to load and save data stored on join tables
 when two records are related via a "many_many" relationship, as defined through


### PR DESCRIPTION
http://doc.silverstripe.org/framework/en/3.1/reference/grid-field#customizing-detail-forms had a small error in the first paragraph. I'm not sure how to build these docs, but based my change on the links that appear correctly in /howto/pagination
