### PR TITLE
FIX: Prevent UploadField folder selection from being too tall for the iframe (fixes #2188)

### DIFF
--- a/css/UploadField.css
+++ b/css/UploadField.css
@@ -44,3 +44,5 @@ Used in side panels and action tabs
 
 .ss-upload .clear { clear: both; }
 .ss-upload .ss-uploadfield-fromcomputer input { /* since we can't really style the file input, we use this hack to make it as big as the button and hide it */ position: absolute; top: 0; right: 0; margin: 0; opacity: 0; filter: alpha(opacity=0); transform: translate(-300px, 0) scale(4); font-size: 23px; direction: ltr; cursor: pointer; height: 30px; line-height: 30px; }
+
+.ss-uploadfield-edit-iframe #ParentID .treedropdownfield-panel { /* prevents the 'Folder' dropdown from being too tall and flowing out of the iframe - 80px works universally */ max-height: 80px; }

--- a/scss/UploadField.scss
+++ b/scss/UploadField.scss
@@ -228,3 +228,12 @@
 		}
 	}
 }
+
+.ss-uploadfield-edit-iframe {
+	#ParentID {
+		.treedropdownfield-panel {
+			/* prevents 'Folder' dropdown being too tall and flowing out of view - 80px fits universally & has room for box-shadows */
+			max-height: 80px;
+		}
+	}
+}


### PR DESCRIPTION
This does make the dropdown menu fairly short (and can result in a large amount of scrolling if lots of folders are present), but is an improvement on not being able to select them at all.

Most of the asset management should be done in the files section anyway.

See before/after below:

![screen shot 2013-07-11 at 15 25 29](https://f.cloud.github.com/assets/1655548/782135/ca092f08-ea35-11e2-9cef-028062440884.png)
![screen shot 2013-07-11 at 15 24 58](https://f.cloud.github.com/assets/1655548/782137/ccb24b04-ea35-11e2-803c-6c5372df3a06.png)
