### PR TITLE
FIX Avoid infinite loops on ?isDev=1 and Deprecation class

### DIFF
--- a/dev/Deprecation.php
+++ b/dev/Deprecation.php
@@ -129,7 +129,7 @@ class Deprecation {
 	 */
 	public static function notice($atVersion, $string = '', $scope = Deprecation::SCOPE_METHOD) {
 		// Never raise deprecation notices in a live environment
-		if(Director::isLive()) return;
+		if(Director::isLive(true)) return;
 
 		// If you pass #.#, assume #.#.0
 		if(preg_match('/^[0-9]+\.[0-9]+$/', $atVersion)) $atVersion .= '.0';


### PR DESCRIPTION
If any of the functionality triggered by Director::isDev()
was causing deprecation errors, the system would go into
an infinite loop. Since the only way to cause this is the DB
checking functionality, we disable that for Deprecation.
Side effect of this change: You can't show deprecation notices
on a live site by forcing the session into dev mode.
