### PR TITLE
Set link description field to show on all but email link type

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -547,6 +547,8 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 					this.find('.field#AnchorSelector').show();
 					this.find('.field#AnchorRefresh').show();
 				}
+				if(linkType == 'internal' || linkType == 'external' || linkType == 'anchor') this.find('.field#Description').show();
+
 			},
 			/**
 			 * @return Object Keys: 'href', 'target', 'title'


### PR DESCRIPTION
Set the Link Description field to show for internal, external, and anchor link types.  The field was already there so figured unhiding it for use made sense.  :)
