### PR TITLE
FIX Remove check for existing BASE_PATH in ParameterConfirmationToken

### DIFF
--- a/core/startup/ParameterConfirmationToken.php
+++ b/core/startup/ParameterConfirmationToken.php
@@ -16,12 +16,7 @@ class ParameterConfirmationToken {
 	protected $token = null;
 
 	protected function pathForToken($token) {
-		if (defined('BASE_PATH')) {
-			$basepath = BASE_PATH;
-		}
-		else {
-			$basepath = rtrim(dirname(dirname(dirname(dirname(__FILE__)))), DIRECTORY_SEPARATOR);
-		}
+		$basepath = rtrim(dirname(dirname(dirname(dirname(__FILE__)))), DIRECTORY_SEPARATOR);
 
 		require_once(dirname(dirname(__FILE__)).'/TempPath.php');
 		$tempfolder = getTempFolder($basepath ? $basepath : DIRECTORY_SEPARATOR);


### PR DESCRIPTION
ParameterConfirmationToken#pathForToken would check for BASE_PATH being set
before trying to determine base path itself. However this just caused
problems, since there were several entry points to the method, some where
BASE_PATH might have been set, some where it wasnt
