### PR TITLE
FIX: Creating styles for admin notice popup (Growl style)

### DIFF
--- a/admin/scss/_style.scss
+++ b/admin/scss/_style.scss
@@ -479,6 +479,26 @@ body.cms {
 	}
 }
 
+
+.notice-item {
+	border: 0;   
+	@include border-radius(3px);
+	font-family: inherit; 
+	font-size: inherit; 
+	padding: 8px 10px 8px 10px; 
+}
+
+.notice-item-close {
+	color: #333333; 
+	background: url(../images/filter-icons.png) no-repeat 0 -20px; 
+	width: 1px; 
+	height: 1px; 
+	overflow: hidden; 
+	padding: 0px 0 20px 15px;
+}
+
+
+
 /** --------------------------------------------
  * Page icons
  * -------------------------------------------- */


### PR DESCRIPTION
When a page/object is modified/created in the CMS admin, a black popup appears in the top right. Currently this incorporates crude built-in styles. I have prettied this popup to create a more visually appealing style.

See screenshot below of before vs after:

![silverstripe_framework_fix](https://f.cloud.github.com/assets/1711444/858601/c5065e00-f56a-11e2-9ab3-0770785cf1a1.png)
