### PR TITLE
FIX: using ->subtract breaks Translatable

### DIFF
--- a/forms/gridfield/GridFieldAddExistingAutocompleter.php
+++ b/forms/gridfield/GridFieldAddExistingAutocompleter.php
@@ -223,8 +223,11 @@ class GridFieldAddExistingAutocompleter
 			$name = (strpos($searchField, ':') !== FALSE) ? $searchField : "$searchField:StartsWith";
 			$params[$name] = $request->getVar('gridfield_relationsearch');
 		}
+		$existing = $gridField->getList()->column('ID');
+		if ($existing) {
+			$allList = $allList->where(sprintf('"%s"."ID" NOT IN (%s)', $dataClass, implode(',', $existing)));
+		}
 		$results = $allList
-			->subtract($gridField->getList())
 			->filterAny($params)
 			->sort(strtok($searchFields[0], ':'), 'ASC')
 			->limit($this->getResultsLimit());


### PR DESCRIPTION
Using $allList->subtract($gridField->getList()) breaks Translatable->augmentSQL because
it finds the Locale filter in the subquery and assumes it does not need to augment the
actual search query.  When you have a very large table with many records not in the
locale that you are searching, this can affect the search time by several orders of
magnitude.
