### PR TITLE
BUG Added _config as valid module folder in TextCollector

### DIFF
--- a/i18n/i18nTextCollector.php
+++ b/i18n/i18nTextCollector.php
@@ -120,10 +120,12 @@ class i18nTextCollector extends Object {
 			// Only search for calls in folder with a _config.php file or _config folder
 			// (which means they are modules, including themes folder)  
 			$isValidModuleFolder = (
-				is_dir("$this->basePath/$module") 
-				&& is_file("$this->basePath/$module/_config.php")
-				&& is_dir("$this->basePath/$module/_config")
+				is_dir("$this->basePath/$module")
 				&& substr($module,0,1) != '.'
+				&& (
+					is_file("$this->basePath/$module/_config.php")
+					|| is_dir("$this->basePath/$module/_config")
+				)
 			) || (
 				substr($module,0,7) == 'themes/'
 				&& is_dir("$this->basePath/$module")


### PR DESCRIPTION
Needed to add _config.php otherwise TextCollector wouldn't find my modules. With this fix _config.php is no longer needed.
