### PR TITLE
Minor bug fix to show link description field 

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -547,6 +547,7 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 					this.find('.field#AnchorSelector').show();
 					this.find('.field#AnchorRefresh').show();
 				}
+				this.find('.field#Description').show();
 			},
 			/**
 			 * @return Object Keys: 'href', 'target', 'title'


### PR DESCRIPTION
When adding a link in the html editor field, the description field was present, but hidden. Adjusted javascript to show the description field. 
