### PR TITLE
Fix misleading documentation about Children.max in partial caching

### DIFF
--- a/docs/en/reference/partial-caching.md
+++ b/docs/en/reference/partial-caching.md
@@ -227,7 +227,7 @@ Can be re-written as:
 	:::ss
 	<% cached LastEdited %>
 	
-	  <% cached Children.max(LastEdited) %>
+	  <% cached AllChildren.max(LastEdited) %>
 	    <% loop $Children %>
 	      $Name
 	    <% end_loop %>


### PR DESCRIPTION
Currently, the documentation implies that doing a `Children.max(LastEdited)` will work, which isn't the case.
This change uses `AllChildren.max(LastEdited)` instead, which while slightly more inefficient, will actually work consistently.
