### PR TITLE
Fixing expanding/collapse CMS menu targeting wrong element

### DIFF
--- a/admin/javascript/LeftAndMain.Panel.js
+++ b/admin/javascript/LeftAndMain.Panel.js
@@ -111,7 +111,7 @@
 			}
 		});
 
-		$('.cms-panel.collapsed').entwine({
+		$('.cms-panel.collapsed .cms-panel-toggle').entwine({
 			onclick: function(e) {
 				this.expandPanel();
 				e.preventDefault();


### PR DESCRIPTION
If a user clicks the log out button (for example) and the menu is
collapsed, the menu expands and then you have to press log out
again
