### PR TITLE
Add keyvalue() to ArrayLib to copy array keys to values

### DIFF
--- a/core/ArrayLib.php
+++ b/core/ArrayLib.php
@@ -69,6 +69,17 @@ class ArrayLib {
 	public static function valuekey($arr) {
 		return array_combine($arr, $arr);
 	}
+
+	/**
+	 * Return an array where the values are all equal to the keys.
+	 *
+	 * @param $arr array
+	 * @return array
+	 */
+	public static function keyvalue($arr) {
+		$keys = array_keys($arr);
+		return array_combine($keys, $keys);
+	}
 	
 	/**
 	 * @todo Improve documentation

--- a/tests/core/ArrayLibTest.php
+++ b/tests/core/ArrayLibTest.php
@@ -47,6 +47,21 @@ class ArrayLibTest extends SapphireTest {
 			)
 		);
 	}
+
+	public function testKeyvalue() {
+		$this->assertEquals(
+			ArrayLib::keyvalue(
+				array(
+					'testkey1' => 'testvalue1',
+					'testkey2' => 'testvalue2'
+				)
+			),
+			array(
+				'testkey1' => 'testkey1',
+				'testkey2' => 'testkey2'
+			)
+		);
+	}
 	
 	public function testArrayMergeRecursive() {
 		$first = array(


### PR DESCRIPTION
Method is essentially the opposite of `ArrayLib::valuekey()`
