### PR TITLE
FIX: pass controller as reference inside closure.

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -830,7 +830,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		// match the filter criteria until they're queried (and matched up with previously marked nodes).
 		$nodeThresholdLeaf = Config::inst()->get('Hierarchy', 'node_threshold_leaf');
 		if($nodeThresholdLeaf && !$filterFunction) {
-			$nodeCountCallback = function($parent, $numChildren) use($controller, $className, $nodeThresholdLeaf) {
+			$nodeCountCallback = function($parent, $numChildren) use(&$controller, $className, $nodeThresholdLeaf) {
 				if($className == 'SiteTree' && $parent->ID && $numChildren > $nodeThresholdLeaf) {
 					return sprintf(
 						'<ul><li class="readonly"><span class="item">'


### PR DESCRIPTION
Non referenced causes segfaults on PHP <= 5.3.8 environments when opening subtrees in the CMS. Likely the cause of silverstripe-cms/issues/803.
