### PR TITLE
API Disable discontinued Google Spellcheck in TinyMCE (#2213)

### DIFF
--- a/admin/_config.php
+++ b/admin/_config.php
@@ -26,8 +26,7 @@ HtmlEditorConfig::get('cms')->setOptions(array(
 		. "dd[id|class|title|dir],dl[id|class|title|dir],dt[id|class|title|dir],@[id,style,class]",
 	'extended_valid_elements' => "img[class|src|alt|title|hspace|vspace|width|height|align|onmouseover|onmouseout|name"
 		. "|usemap|data*],iframe[src|name|width|height|align|frameborder|marginwidth|marginheight|scrolling],"
-		. "object[width|height|data|type],param[name|value],map[class|name|id],area[shape|coords|href|target|alt]",
-	'spellchecker_rpc_url' => THIRDPARTY_DIR . '/tinymce-spellchecker/rpc.php'
+		. "object[width|height|data|type],param[name|value],map[class|name|id],area[shape|coords|href|target|alt]"
 ));
 
 HtmlEditorConfig::get('cms')->enablePlugins('media', 'fullscreen', 'inlinepopups');

--- a/docs/en/changelogs/3.0.6.md
+++ b/docs/en/changelogs/3.0.6.md
@@ -4,6 +4,7 @@
 
  * Security: Require ADMIN for `?flush=1` (stop denial of service attacks)
  ([#1692](https://github.com/silverstripe/silverstripe-framework/issues/1692))
+ * API: Disable discontinued Google Spellcheck in TinyMCE. Replaced by browser-based spellchecking if available (Chrome, Firefox)
 
 ## Details
 

--- a/docs/en/topics/rich-text-editing.md
+++ b/docs/en/topics/rich-text-editing.md
@@ -145,6 +145,29 @@ on your own editor wrapper. Note that the `[api:HtmlEditorConfig]` is currently 
 so its up to you to either convert existing configuration as applicable,
 or start your own configuration.
 
+### Integrating a Spellchecker for TinyMCE
+
+The TinyMCE editor uses spellchecking integrated into the browser if possible
+([docs](http://www.tinymce.com/wiki.php/Plugin3x:spellchecker)).
+Most modern browsers support it, although Internet Explorer only has limited
+support in IE10. Alternatively, you can use the PSpell PHP module for server side checks.
+Assuming you have the module installed, here's how you enable its use in `mysite/_config.php`:
+
+	:::php
+	HtmlEditorConfig::get('cms')->enablePlugins('spellchecker');
+	HtmlEditorConfig::get('cms')->addButtonsToLine(2, 'spellchecker');
+	HtmlEditorConfig::get('cms')->setOption(
+		'spellchecker_rpc_url', 
+		THIRDPARTY_DIR . '/tinymce-spellchecker/rpc.php'
+	);
+	HtmlEditorConfig::get('cms')->setOption('browser_spellcheck', false);
+
+Now change the default spellchecker in `framework/thirdparty/tinymce-spellchecker/config.php`:
+
+	:::php
+	// ...
+	$config['general.engine'] = 'PSpell';
+
 ## Related
 
  * [Howto: Extend the CMS Interface](../howto/extend-cms-interface)

--- a/forms/HtmlEditorConfig.php
+++ b/forms/HtmlEditorConfig.php
@@ -85,6 +85,7 @@ class HtmlEditorConfig {
 		'safari_warning' => false,
 		'relative_urls' => true,
 		'verify_html' => true,
+		'browser_spellcheck' => true,
 	);
 	
 	/**
@@ -95,7 +96,6 @@ class HtmlEditorConfig {
 		'table' => null, 
 		'emotions' => null, 
 		'paste' => null, 
-		'spellchecker' => null
 	);
 
 	/**
@@ -105,7 +105,7 @@ class HtmlEditorConfig {
 		1 => array('bold','italic','underline','strikethrough','separator',
 			'justifyleft','justifycenter','justifyright','justifyfull','formatselect','separator',
 			'bullist','numlist','outdent','indent','blockquote','hr','charmap'),
-		2 => array('undo','redo','separator','cut','copy','paste','pastetext','pasteword','spellchecker','separator',
+		2 => array('undo','redo','separator','cut','copy','paste','pastetext','pasteword','separator',
 			'advcode','search','replace','selectall','visualaid','separator','tablecontrols'),
 		3 => array()
 	);


### PR DESCRIPTION
Replaced by browser-based spellchecking if available (Chrome, Firefox),
with instructions on how to use PSpell as an alternative.

See https://github.com/silverstripe/silverstripe-framework/issues/2213 for background.
Submitting to 3.0 because it fixes broken behaviour (Google's intermittent service availability),
as well as better defaults concerning content privacy.
