### PR TITLE
FIX: Remove limit on GridField export

### DIFF
--- a/forms/gridfield/GridFieldExportButton.php
+++ b/forms/gridfield/GridFieldExportButton.php
@@ -128,8 +128,9 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 			}
 		}
 
-		foreach($items as $item) {
+		foreach($items->limit(null) as $item) {
 			$columnData = array();
+
 			foreach($csvColumns as $columnSource => $columnHeader) {
 				if(!is_string($columnHeader) && is_callable($columnHeader)) {
 					if($item->hasMethod($columnSource)) {

--- a/model/ArrayList.php
+++ b/model/ArrayList.php
@@ -133,8 +133,13 @@ class ArrayList extends ViewableData implements SS_List, SS_Filterable, SS_Sorta
 	 * @return ArrayList 
 	 */
 	public function limit($length, $offset = 0) {
+		if(!$length) {
+			$length = count($this->items);
+		}
+
 		$list = clone $this;
 		$list->items = array_slice($this->items, $offset, $length);
+
 		return $list;
 	}
 

--- a/model/DataList.php
+++ b/model/DataList.php
@@ -212,22 +212,21 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 	}
 
 	/**
-	 * Return a new DataList instance with the records returned in this query restricted by a limit clause
+	 * Return a new DataList instance with the records returned in this query
+	 * restricted by a limit clause.
 	 * 
 	 * @param int $limit
 	 * @param int $offset
 	 */
 	public function limit($limit, $offset = 0) {
-		if(!$limit && !$offset) {
-			return $this;
-		}
 		return $this->alterDataQuery(function($query) use ($limit, $offset){
 			$query->limit($limit, $offset);
 		});
 	}
 	
 	/**
-	 * Return a new DataList instance as a copy of this data list with the sort order set
+	 * Return a new DataList instance as a copy of this data list with the sort
+	 * order set.
 	 *
 	 * @see SS_List::sort()
 	 * @see SQLQuery::orderby

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -98,6 +98,29 @@ class DataListTest extends SapphireTest {
 		// We can also restrict the output to a range
 		$this->assertEquals(array('Joe', 'Phil'), $list->limit(2, 1)->column('Name'));
 	}
+
+	public function testLimitAndOffset() {
+		$list = DataObjectTest_TeamComment::get();
+		$check = $list->limit(3);
+
+		$this->assertEquals(3, $check->count());
+
+		$check = $list->limit(1);
+		$this->assertEquals(1, $check->count());
+
+		$check = $list->limit(1, 1);
+		$this->assertEquals(1, $check->count());
+
+		$check = $list->limit(false);
+		$this->assertEquals(3, $check->count());
+
+		$check = $list->limit(null);
+		$this->assertEquals(3, $check->count());
+
+		// no limit with an offset is currently not supported by the orm
+		// $check = $list->limit(null, 2);
+		// $this->assertEquals(1, $check->count());
+	}
 	
 	public function testDataClass() {
 		$list = DataObjectTest_TeamComment::get();


### PR DESCRIPTION
Allow DataList::limit() to take a null value to remove the limit.

Added tests for limit(). Note the one failure, currently the ORM doesn't support unlimited values with an offset.

Raised for 3.1 but I expect this is a 3.1.1
