### PR TITLE
BUGFIX i18n module load order in i18n::include_by_locale()

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -2506,7 +2506,8 @@ class i18n extends Object implements TemplateGlobalProvider {
 		$sortedModules = array();
 		foreach ($order as $module) {
 			if (isset($modules[$module])) $sortedModules[$module] = $modules[$module];
-			}
+		}
+		$sortedModules = array_reverse($sortedModules, true);
 
 		// Loop in reverse order, meaning the translator with the highest priority goes first
 		$translators = array_reverse(self::get_translators(), true);

--- a/tests/i18n/_fakewebroot/i18ntestmodule/code/subfolder/lang/de.yml
+++ b/tests/i18n/_fakewebroot/i18ntestmodule/code/subfolder/lang/de.yml
@@ -1,3 +1,4 @@
 de:
   i18nTestModule: 
+    PRIORITYNOTICE: High Module Priority (de)
     OTHERENTITY: Other Entity (de)

--- a/tests/i18n/_fakewebroot/i18ntestmodule/lang/de.yml
+++ b/tests/i18n/_fakewebroot/i18ntestmodule/lang/de.yml
@@ -11,5 +11,6 @@ de:
     WITHNAMESPACE: Include Entity with Namespace (de)
     LAYOUTTEMPLATE: Layout Template (de)
     SPRINTFNAMESPACE: My replacement: %s (de)
+    PRIORITYNOTICE: Low Module Priority (de)
   i18nTestModuleInclude.ss:
     SPRINTFINCLUDENAMESPACE: My include replacement: %s (de)

--- a/tests/i18n/i18nTest.php
+++ b/tests/i18n/i18nTest.php
@@ -435,6 +435,9 @@ class i18nTest extends SapphireTest {
 		$this->assertFalse($adapter->isTranslated('i18nTestModule.ENTITY', 'af'), 
 			'Non-existing unloaded entity not available before call'
 		);
+		
+		// set _fakewebroot module priority
+		Config::inst()->update('i18n', 'module_priority', array('subfolder','i18ntestmodule'));
 
 		i18n::include_by_locale('de');
 		
@@ -443,6 +446,11 @@ class i18nTest extends SapphireTest {
 		$this->assertTrue($adapter->isTranslated('i18nTestModule.ENTITY', null, 'de'), 'Includes module files');
 		$this->assertTrue($adapter->isTranslated('i18nTestTheme1.LAYOUTTEMPLATE', null, 'de'), 'Includes theme files');
 		$this->assertTrue($adapter->isTranslated('i18nTestModule.OTHERENTITY', null, 'de'), 'Includes submodule files');
+		
+		// check module priority
+		$this->assertEquals($adapter->translate('i18nTestModule.PRIORITYNOTICE', 'de'), 
+			'High Module Priority (de)'
+		);
 		
 		SS_ClassLoader::instance()->popManifest();
 	}


### PR DESCRIPTION
The "project" module (normally mysite) is considered with the highest priority. Yet, the project's i18n is loaded first and cannot overwrite existing translations. I've added a array_reverse(), so the iteration keeps the translation of the module with the highest priority.

Old $sortedModules: mysite, (other_modules,) cms, admin, framework.
New $sortedModules: framework, admin, cms, (other_modules,) mysite.
