### PR TITLE
HtmlEditorConfig default TinyMCE mode is now none

### DIFF
--- a/admin/_config.php
+++ b/admin/_config.php
@@ -3,7 +3,6 @@
 HtmlEditorConfig::get('cms')->setOptions(array(
 	'friendly_name' => 'Default CMS',
 	'priority' => '50',
-	'mode' => 'none', // initialized through LeftAndMain.EditFor.js logic
 
 	'body_class' => 'typography',
 	'document_base_url' => isset($_SERVER['HTTP_HOST']) ? Director::absoluteBaseURL() : null,

--- a/forms/HtmlEditorConfig.php
+++ b/forms/HtmlEditorConfig.php
@@ -69,7 +69,7 @@ class HtmlEditorConfig {
 	protected $settings = array(
 		'friendly_name' => '(Please set a friendly name for this config)',
 		'priority' => 0,
-		'mode' => "specific_textareas",
+		'mode' => "none", // initialized through HtmlEditorField.js redraw() logic
 		'editor_selector' => "htmleditor",
 		'width' => "100%",
 		'auto_resize' => false,


### PR DESCRIPTION
When creating custom `HtmlEditorConfig` the default `mode` would be `specific_textareas` making TinyMCE to convert the textareas automatically while this init will also be called in JavaScript making TinyMCE to be rendered twice.

Seemed unnecessary to have to explicitly have to set `mode` to none. Updated 'cms' config to reflect this too.

A short talk about it here: https://groups.google.com/forum/#!topic/silverstripe-dev/_de_55ggSmI
Also, issue #1650 seem to talk about a similar problem, but I can't be sure it is 100% related or wheither this happened with custom config. could be closed?
