### PR TITLE
BUGFIX: Members with access to the security admin can create other members.

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -1375,6 +1375,32 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		return $this->canEdit($member);
 	}
 
+	/**
+	 * Members can create others if they have access to the security admin.
+	 *
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canCreate($member = null) {
+
+		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) $member = Member::currentUser();
+		
+		// extended access checks
+		$results = $this->extend('canView', $member);
+		if($results && is_array($results)) {
+			if(!min($results)) return false;
+			else return true;
+		}
+		
+		if(
+			Permission::checkMember($member, 'ADMIN')
+			|| Permission::checkMember($member, 'CMS_ACCESS_SecurityAdmin')
+		) {
+			return true;
+		}
+		
+		return false;
+	}
 
 	/**
 	 * Validate this member object.

--- a/tests/security/SecurityTest.php
+++ b/tests/security/SecurityTest.php
@@ -451,6 +451,17 @@ class SecurityTest extends FunctionalTest {
 		return $this->session()->inst_get('FormInfo.MemberLoginForm_LoginForm.formError.message');
 	}	
 	
+	/**
+	 * Members with access to the security admin area can create other members.
+	 */
+	public function testCreateMemberPermissions() {
+		$member = $this->objFromFixture('Member', 'test');
+		$this->session()->inst_set('loggedInAs', $member->ID);
+
+		$this->assertEquals(Permission::checkMember($member, 'ADMIN'), false);
+		$this->assertTrue(Permission::checkMember($member, "CMS_ACCESS_SecurityAdmin"));
+		$this->assertTrue($member->canCreate());
+	}
 }
 
 class SecurityTest_SecuredController extends Controller implements TestOnly {


### PR DESCRIPTION
Fixes silverstripe/silverstripe-framework#2232. Members will still need EDIT_PERMISSIONS permission in order to place newly created members in groups etc.
