### PR TITLE
No <label for> on OptionsetField/CheckboxSetField holder

### DIFF
--- a/templates/forms/OptionsetField_holder.ss
+++ b/templates/forms/OptionsetField_holder.ss
@@ -1,0 +1,9 @@
+<div id="$Name" class="field<% if $extraClass %> $extraClass<% end_if %>">
+	<% if $Title %><label class="left">$Title</label><% end_if %>
+	<div class="middleColumn">
+		$Field
+	</div>
+	<% if $RightTitle %><label class="right">$RightTitle</label><% end_if %>
+	<% if $Message %><span class="message $MessageType">$Message</span><% end_if %>
+	<% if $Description %><span class="description">$Description</span><% end_if %>
+</div>


### PR DESCRIPTION
It produces invalid HTML since the "for" attribute doesn't
map to any HTML input field. Each individual checkbox or radio button
input element has its own <label for>
