### PR TITLE
UTF8 defaults for MySQLDatabase->createDatabase()

### DIFF
--- a/model/MySQLDatabase.php
+++ b/model/MySQLDatabase.php
@@ -155,7 +155,7 @@ class MySQLDatabase extends SS_Database {
 	}
 
 	public function createDatabase() {
-		$this->query("CREATE DATABASE \"$this->database\"");
+		$this->query("CREATE DATABASE \"$this->database\" DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci");
 		$this->query("USE \"$this->database\"");
 
 		$this->tableList = $this->fieldList = $this->indexList = null;


### PR DESCRIPTION
Doesn't have much effect in practice, because charset and collation
are already hardcoded on an ALTER TABLE level (field definitions),
which take priority. Since most MySQL installs will still default
to a latin1 encoding, this propagates to the table though,
confusing devs and in some cases causing wrong data.

Example: A MSSQL->MySQL DB migration tool used the table metadata
to determine the charset, creating encoding issues.

In terms of hardcoding, we don't really support anything other than UTF8,
and the field-level settings are already hardcoded.

This commit should be fit for 3.1.1, but if anybody has concerns about its
side effects we can merge into master as well.

We should probably remove the field-specific settings and rely
on the DB defaults, but that's a sensitive API change
(need to set on existing DBs during upgrade).
