### PR TITLE
Validate 'archiveDate' user data in Versioned 

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -841,7 +841,7 @@ class Versioned extends DataExtension {
 
 			Session::set('readingMode', 'Stage.' . $stage);
 		}
-		if(isset($_GET['archiveDate'])) {
+		if(isset($_GET['archiveDate']) && strtotime($_GET['archiveDate'])) {
 			Session::set('readingMode', 'Archive.' . $_GET['archiveDate']);
 		}
 		


### PR DESCRIPTION
Not a security issue as such, since the user input is sanitized
before being used in Versioned->augmentSQL(). But it shouldn't
reach the session state either, since that's commonly assumed
to be sanitized data, and it leaves unnecessary room for error.

strtotime() has fairly loose validation rules around dates,
but its a good "first line of defence".
