### PR TITLE
Add parent to cached images

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -425,6 +425,8 @@ class Image extends File {
 			$cached = new Image_Cached($cacheFile);
 			// Pass through the title so the templates can use it
 			$cached->Title = $this->Title;
+			// Pass through the parent, to store cached images in correct folder.
+			$cached->ParentID = $this->ParentID;
 			return $cached;
 		}
 	}


### PR DESCRIPTION
if an image processing function is called on an already processed image the resulting cached image is stored in the assets/_resampled because the cached version of the image has no ParentID, which  cacheFilename needs to set the correct path.
