### PR TITLE
Corrected parameters in model relations example

### DIFF
--- a/docs/en/topics/testing/fixtures.md
+++ b/docs/en/topics/testing/fixtures.md
@@ -158,7 +158,7 @@ Model relations can be expressed through the same notation as in the YAML fixtur
 described earlier, through the `=>` prefix on data values.
 
 	:::php
-	$obj = $factory->createObject('MyObject', array(
+	$obj = $factory->createObject('MyObject', 'myobj1', array(
 		'MyHasManyRelation' => '=>MyOtherObject.obj1,=>MyOtherObject.obj2'
 	));
 


### PR DESCRIPTION
An identifier needs to be specified when creating an object with relations, but the example had omitted that.
