### PR TITLE
FIX: fixed flush url redirect which was causing two forward slashes in the url

### DIFF
--- a/core/startup/ParameterConfirmationToken.php
+++ b/core/startup/ParameterConfirmationToken.php
@@ -91,7 +91,16 @@ class ParameterConfirmationToken {
 		unset($params['url']);
 
 		// Join them all together into the original URL
-		$location = "$proto://" . $host . '/' . ltrim(BASE_URL, '/') . $url . ($params ? '?'.http_build_query($params) : '');
+		$urlParts = array(
+			$host,
+			BASE_URL,
+			$url,
+			($params ? '?'.http_build_query($params) : '')
+		);
+		array_walk($urlParts, function(&$val) {
+			$val = trim($val, '/');
+		});
+		$location = "$proto://" . implode('/', array_filter($urlParts));
 
 		// And redirect
 		if (headers_sent()) {


### PR DESCRIPTION
See: https://github.com/silverstripe/silverstripe-framework/pull/2333
