### PR TITLE
Returning 404 on /Security, instead of Controller.ss template

### DIFF
--- a/security/Security.php
+++ b/security/Security.php
@@ -280,6 +280,9 @@ class Security extends Controller {
 		$this->response->addHeader('X-Frame-Options', 'SAMEORIGIN');
 	}
 
+	public function index() {
+		return $this->httpError(404); // no-op
+	}
 
 	/**
 	 * Get the login form to process according to the submitted data


### PR DESCRIPTION
We shouldn't expose unsolicited content on public URLs,
mainly because it impacts SEO.
