### PR TITLE
FIX UploadField server validation error display

### DIFF
--- a/css/UploadField.css
+++ b/css/UploadField.css
@@ -23,6 +23,13 @@ Used in side panels and action tabs
 .ss-uploadfield .ss-uploadfield-item .ss-uploadfield-item-info .ss-uploadfield-item-name .ss-uploadfield-item-status.ui-state-error-text { color: red; font-weight: bold; width: 150px; }
 .ss-uploadfield .ss-uploadfield-item .ss-uploadfield-item-info .ss-uploadfield-item-name .ss-uploadfield-item-status.ui-state-warning-text { color: #b7a403; }
 .ss-uploadfield .ss-uploadfield-item .ss-uploadfield-item-info .ss-uploadfield-item-name .ss-uploadfield-item-status.ui-state-success-text { color: #1f9433; }
+.ss-uploadfield .ss-uploadfield-item.ui-state-error .ss-uploadfield-item-preview { width: auto; height: auto; margin-right: 15px; }
+.ss-uploadfield .ss-uploadfield-item.ui-state-error .ss-uploadfield-item-info { margin-left: 0; }
+.ss-uploadfield .ss-uploadfield-item.ui-state-error .ss-uploadfield-item-info .ss-uploadfield-item-name { float: left; width: 70%; height: auto; }
+.ss-uploadfield .ss-uploadfield-item.ui-state-error .ss-uploadfield-item-info .ss-uploadfield-item-name .name { float: left; width: 100%; margin-bottom: 5px; }
+.ss-uploadfield .ss-uploadfield-item.ui-state-error .ss-uploadfield-item-info .ss-uploadfield-item-name .ss-uploadfield-item-status { float: left; width: 100%; padding: 0; text-align: left; }
+.ss-uploadfield .ss-uploadfield-item.ui-state-error .ss-uploadfield-item-info .ss-uploadfield-item-actions { float: right; width: 5%; min-height: 0; margin: 0; }
+.ss-uploadfield .ss-uploadfield-item.ui-state-error .ss-uploadfield-item-info .ss-uploadfield-item-actions .ss-uploadfield-item-cancel { position: relative; top: auto; }
 .ss-uploadfield .ss-ui-button { display: block; float: left; margin: 0 10px 6px 0; }
 .ss-uploadfield .ss-ui-button.ss-uploadfield-fromcomputer { position: relative; overflow: hidden; }
 .ss-uploadfield .ss-uploadfield-files { margin: 0; padding: 0; overflow: auto; position: relative; }

--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -1235,7 +1235,6 @@ class UploadField extends FileField {
 		// Format response with json
 		$response = new SS_HTTPResponse(Convert::raw2json(array($return)));
 		$response->addHeader('Content-Type', 'text/plain');
-		if(!empty($return['error'])) $response->setStatusCode(403);
 		return $response;
 	}
 

--- a/javascript/UploadField_downloadtemplate.js
+++ b/javascript/UploadField_downloadtemplate.js
@@ -1,9 +1,11 @@
 window.tmpl.cache['ss-uploadfield-downloadtemplate'] = tmpl(
 	'{% for (var i=0, files=o.files, l=files.length, file=files[0]; i<l; file=files[++i]) { %}' +
 		'<li class="ss-uploadfield-item template-download{% if (file.error) { %} ui-state-error{% } %}" data-fileid="{%=file.id%}">' + 
-			'<div class="ss-uploadfield-item-preview preview"><span>' +
-				'<img src="{%=file.thumbnail_url%}" alt="" />' +
-			'</span></div>' +
+			'{% if (file.thumbnail_url) { %}' +
+				'<div class="ss-uploadfield-item-preview preview"><span>' +
+					'<img src="{%=file.thumbnail_url%}" alt="" />' +
+				'</span></div>' +
+			'{% } %}' +
 			'<div class="ss-uploadfield-item-info">' +
 				'{% if (!file.error) { %}' +
 					'<input type="hidden" name="{%=file.fieldname%}[Files][]" value="{%=file.id%}" />' + 

--- a/scss/UploadField.scss
+++ b/scss/UploadField.scss
@@ -85,6 +85,52 @@
 				}
 			}			
 		}
+
+		//Upload/Validation error
+		&.ui-state-error
+		{
+			.ss-uploadfield-item-preview {
+				width: auto;
+				height: auto;
+				margin-right: 15px;
+			}
+
+			.ss-uploadfield-item-info {
+				margin-left: 0;
+
+				.ss-uploadfield-item-name {
+					float: left;
+					width: 70%;
+					height: auto;
+
+					.name
+					{
+						float: left;
+						width: 100%;
+						margin-bottom: 5px;
+					}
+
+					.ss-uploadfield-item-status {
+						float: left;
+						width: 100%;
+						padding: 0;
+						text-align: left;
+					}
+				}
+
+				.ss-uploadfield-item-actions {
+					float: right;
+					width: 5%;
+					min-height: 0;
+					margin: 0;
+
+					.ss-uploadfield-item-cancel {
+						position: relative;
+						top: auto;
+					}			
+				}
+			}			
+		}
 	}
 	.ss-ui-button {
 		display: block;


### PR DESCRIPTION
While working on a solution for a StackOverflow question about custom Upload validation (http://stackoverflow.com/questions/18242663/silverstripe-custom-validator-on-uploadfield/18249650) came across a bug where UploadField would not display the validation error message but Forbidden instead.

Removed the `$response->setStatusCode(403)` in the upload response so error messages are now displayed.

Updated the download template and the CSS so the error messages look a bit better.
Before:
![image](https://f.cloud.github.com/assets/978040/996360/804330e0-09ce-11e3-9b9a-cb719b6b62be.png)
![image](https://f.cloud.github.com/assets/978040/996362/88957f46-09ce-11e3-9724-38561305dc0b.png)
![image](https://f.cloud.github.com/assets/978040/996365/8defaf20-09ce-11e3-84b9-b484bc9e295a.png)

After:
![image](https://f.cloud.github.com/assets/978040/996368/967f794a-09ce-11e3-9121-3813bd1247b1.png)
![image](https://f.cloud.github.com/assets/978040/996369/9c38e948-09ce-11e3-88fa-d7d77028b077.png)
![image](https://f.cloud.github.com/assets/978040/996373/a3e6d088-09ce-11e3-8d11-93fd514c5646.png)

This is open for review and discussion and more tests. And all commits can be squashed before/if merging.
