### PR TITLE
BUG Fix old patch for IE no-cache https downloads.

### DIFF
--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -343,7 +343,19 @@ class HTTP {
 			$responseHeaders['Vary'] = 'Cookie, X-Forwarded-Protocol, User-Agent, Accept';
 		}
 		else {
-			$responseHeaders["Cache-Control"] = "no-cache, max-age=0, must-revalidate, no-transform";
+			if(
+				strstr($_SERVER["HTTP_USER_AGENT"], 'MSIE')==true &&
+				($contentDisposition = $body->getHeader('Content-disposition')) &&
+				strstr($contentDisposition, 'attachment;')==true
+			) {
+				// IE6-IE8 have problems saving files when https and no-cache are used
+				// (http://support.microsoft.com/kb/323308)
+				// Note: this is also fixable by ticking "Do not save encrypted pages to disk" in advanced options.
+				$responseHeaders["Cache-Control"] = "max-age=3, must-revalidate, no-transform";
+				$responseHeaders["Pragma"] = "";
+			} else {
+				$responseHeaders["Cache-Control"] = "no-cache, max-age=0, must-revalidate, no-transform";
+			}
 		}
 
 		if(self::$modification_date && self::$cache_age > 0) {

--- a/control/HTTPRequest.php
+++ b/control/HTTPRequest.php
@@ -393,11 +393,6 @@ class SS_HTTPRequest implements ArrayAccess {
 		$response->addHeader("Content-Type", "$mimeType; name=\"" . addslashes($fileName) . "\"");
 		$response->addHeader("Content-disposition", "attachment; filename=" . addslashes($fileName));
 		$response->addHeader("Content-Length", strlen($fileData));
-		$response->addHeader("Pragma", ""); // Necessary because IE has issues sending files over SSL
-		
-		if(strstr($_SERVER["HTTP_USER_AGENT"],"MSIE") == true) {
-			$response->addHeader('Cache-Control', 'max-age=3, must-revalidate'); // Workaround for IE6 and 7
-		}
 		
 		return $response;
 	}


### PR DESCRIPTION
Currently the HTTP::add_cache_headers competely overrides Cache-Control
headers on each request, so there is no way to inject custom headers
from the API-consuning methods.

Also of note: adding no-store header also fixes the issue but will
prevent proxies from caching the request body (which they do when using
no-cache). So the setting max-age to some low number is a better choice
here.
