### PR TITLE
BUGFIX: CMS permissions checkbox won't untoggle once selected

### DIFF
--- a/javascript/PermissionCheckboxSetField.js
+++ b/javascript/PermissionCheckboxSetField.js
@@ -77,8 +77,8 @@
 					});
 				} else {
 					checkboxes.each(function() {
-						$(this).attr('checked', '');
-						$(this).attr('disabled', '');
+						$(this).prop('checked', false);
+						$(this).prop('disabled', false);
 					});
 				}
 			}


### PR DESCRIPTION
- Fixes issue with CMS permissions checkbox, which won't un-toggle checked-checkboxes, after being clicked a 2nd time
