### PR TITLE
Update ImagickBackend.php

### DIFF
--- a/filesystem/ImagickBackend.php
+++ b/filesystem/ImagickBackend.php
@@ -184,7 +184,7 @@ class ImagickBackend extends Imagick implements Image_Backend {
 	 * @param int $height
 	 * @return Image_Backend
 	 */
-	public function paddedResize($width, $height, $backgroundColor = "FFFFFF") {
+	public function paddedResize($width, $height, $backgroundColor = "#FFFFFF00") {
 		if(!$this->valid()) return;
 		
 		$width = round($width);


### PR DESCRIPTION
ImagickBackend fails when creating thumbnails without this change. This is in an issue I have already raised.

As a side note the error which is binary also crashes the htmlentities() on Backtrace.php

I have also added a transparent alpha for future compatibility
