### PR TITLE
BUG Cached images stored in wrong folder

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -425,6 +425,8 @@ class Image extends File {
 			$cached = new Image_Cached($cacheFile);
 			// Pass through the title so the templates can use it
 			$cached->Title = $this->Title;
+			// Pass through the parent, to store cached images in correct folder.
+			$cached->ParentID = $this->ParentID;
 			return $cached;
 		}
 	}

--- a/tests/model/ImageTest.php
+++ b/tests/model/ImageTest.php
@@ -181,4 +181,37 @@ class ImageTest extends SapphireTest {
 		$image->deleteFormattedImages();
 		$this->assertFalse(file_exists($p));
 	}
+
+	/**
+	 * Tests that generated images with multiple image manipulations are all deleted
+	 */
+	public function testMultipleGenerateManipulationCallsImageDeletion() {
+		$image = $this->objFromFixture('Image', 'imageWithMetacharacters');
+
+		$firstImage = $image->SetWidth(200);
+		$firstImagePath = $firstImage->getFullPath();
+		$this->assertTrue(file_exists($firstImagePath));
+
+		$secondImage = $firstImage->SetHeight(100);
+		$secondImagePath = $secondImage->getFullPath();
+		$this->assertTrue(file_exists($secondImagePath));
+
+		$image->deleteFormattedImages();
+		$this->assertFalse(file_exists($firstImagePath));
+		$this->assertFalse(file_exists($secondImagePath));
+	}
+
+	/**
+	 * Tests path properties of cached images with multiple image manipulations
+	 */
+	public function testPathPropertiesCachedImage() {
+		$image = $this->objFromFixture('Image', 'imageWithMetacharacters');
+		$firstImage = $image->SetWidth(200);
+		$firstImagePath = $firstImage->getRelativePath();
+		$this->assertEquals($firstImagePath, $firstImage->Filename);
+
+		$secondImage = $firstImage->SetHeight(100);
+		$secondImagePath = $secondImage->getRelativePath();
+		$this->assertEquals($secondImagePath, $secondImage->Filename);
+	}
 }


### PR DESCRIPTION
If multiple image manipulations are performend the resulting cached image is stored in assets/_resampled because the cached version of the image has no ParentID, which cacheFilename needs to set the correct path.
