### PR TITLE
FIX: only insert JS script includes before other JS file references

### DIFF
--- a/view/Requirements.php
+++ b/view/Requirements.php
@@ -708,11 +708,15 @@ class Requirements_Backend {
 				// We put script tags into the body, for performance.
 				// If your template already has script tags in the body, then we put our script
 				// tags just before those. Otherwise, we put it at the bottom.
+				$p1 = false;
+				preg_match('/<script\s+type=[\'"]text\/javascript[\'"]/', $content, $match);
+				if (!empty($match)) {
+					$p1 = strripos($content, $match[0]);
+				}
 				$p2 = stripos($content, '<body');
-				$p1 = stripos($content, '<script', $p2);
 
-				if($p1 !== false) {
-					$content = substr($content,0,$p1) . $jsRequirements . substr($content,$p1);
+				if($p1 !== false && $p1 > $p2) {
+					$content = substr($content, 0, $p1) . $jsRequirements . substr($content, $p1);
 				} else {
 					$content = preg_replace("/(<\/body[^>]*>)/i", $jsRequirements . "\\1", $content);
 				}


### PR DESCRIPTION
If you had a script tag somewhere in your body that was for a JS template or JSON data
(for example `<script type='application/json' id='something'>{ ... }</script>`), then
the backend was inserting your included JS files before that script tag when it really
should have been putting them at the end of the body.
