### PR TITLE
BUGFIX: Issue #2375

### DIFF
--- a/templates/UploadField.ss
+++ b/templates/UploadField.ss
@@ -67,4 +67,3 @@
 		<div class="clear"><!-- --></div>
 	</div>
 <% end_if %>
-<% if Description %><span class="description">$Description</span><% end_if %>


### PR DESCRIPTION
In terms of architecture, I'm unsure why there was ever a need to add a template ref to $Description _specifically_ for \UploadField..
- UploadField showed 2 descriptions in CMS with one call to setDescription().
- Removed UploadField-specific template ref to $Description, in favour of using the "default" in FormField_holder.ss
