### PR TITLE
BUG DataQuery::getFinalizedQuery misses left joins

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -158,10 +158,9 @@ class DataQuery {
 
 			foreach ($query->getWhere() as $where) {
 				// Check for just the column, in the form '"Column" = ?' and the form '"Table"."Column"' = ?
-				if (preg_match('/^"([^"]+)"/', $where, $matches) ||
-					preg_match('/^"([^"]+)"\."[^"]+"/', $where, $matches)) {
-					if (!in_array($matches[1], $queriedColumns)) $queriedColumns[] = $matches[1];
-				}
+				if (preg_match('/^"[^"]+"\."([^"]+)"|^"([^"]+)"/', $where, $matches)){
+				if (!in_array($matches[1], $queriedColumns)) $queriedColumns[] = $matches[1];
+			    }
 			}
 		}
 		else $tableClasses = ClassInfo::ancestry($this->dataClass, true);


### PR DESCRIPTION
Fixes a regexp that could never be matched and was wrong anyway.

Comment and code in GetFinalizedQuery() do not match.
This PR solves an issue in our project where the Query would not contain left joins for addtional tables needed.
