### PR TITLE
BUG: TreeDropdownField remove call to get value on search

### DIFF
--- a/javascript/TreeDropdownField.js
+++ b/javascript/TreeDropdownField.js
@@ -286,7 +286,7 @@
 					);
 
 				this.find('.treedropdownfield-panel').prepend(
-					$('<input type="text" class="search treedropdownfield-search" data-skip-autofocus="true" placeholder="' + title + '" value="' + this.getValue(title) + '" />')
+					$('<input type="text" class="search treedropdownfield-search" data-skip-autofocus="true" placeholder="' + title + '" value="" />')
 				);
 			},
 			search: function(str, callback) {


### PR DESCRIPTION
This call was placing the id of the currently selected record into the search box. Related to https://github.com/silverstripe/silverstripe-framework/commit/93ea066f53
d5d2b2a19cf0dd2e9479a3fc5796f7
