### PR TITLE
MINOR Enable the addition of a cache buster for assets, in a similar fas...

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,3 +6,6 @@ Upload:
   replaceFile: false
 MySQLDatabase:
   connection_charset: utf8
+File:
+  # Always append a cache buster parameter based on modification time
+  appendmtime: true

--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -235,7 +235,9 @@ class File extends DataObject {
 	}
 
 	public function RelativeLink() {
-		return $this->Filename;
+		return self::config()->appendmtime && file_exists($fullPath = $this->getFullPath()) ? 
+			Controller::join_links($this->Filename, '?m=' . filemtime($fullPath)) : 
+			$this->Filename;
 	}
 
 	/**
@@ -646,7 +648,11 @@ class File extends DataObject {
 	 * @return string
 	 */
 	public function getAbsoluteURL() {
-		return Director::absoluteBaseURL() . $this->getFilename();
+		$absUrl =  Director::absoluteBaseURL() . $this->getFilename();
+		if (self::config()->appendmtime && file_exists($fullPath = $this->getFullPath())){
+			$absUrl = Controller::join_links($absUrl, '?m=' . filemtime($fullPath));
+		}
+		return $absUrl;
 	}
 	
 	/**
@@ -656,7 +662,11 @@ class File extends DataObject {
 	 * @return string
 	 */
 	public function getURL() {
-		return Director::baseURL() . $this->getFilename();
+		$url = Director::baseURL() . $this->getFilename();
+		if (self::config()->appendmtime && file_exists($fullPath = $this->getFullPath())){
+			$url = Controller::join_links($url, '?m=' . filemtime($fullPath));
+		}
+		return $url;
 	}
 
 	/**

--- a/tests/filesystem/FileTest.php
+++ b/tests/filesystem/FileTest.php
@@ -188,9 +188,17 @@ class FileTest extends SapphireTest {
 	}
 	
 	public function testLinkAndRelativeLink() {
+		$appendmtime = Config::inst()->get('File', 'appendmtime');
+		Config::inst()->update('File','appendmtime', false);
 		$file = $this->objFromFixture('File', 'asdf');
 		$this->assertEquals(ASSETS_DIR . '/FileTest.txt', $file->RelativeLink());
 		$this->assertEquals(Director::baseURL() . ASSETS_DIR . '/FileTest.txt', $file->Link());
+		
+		Config::inst()->update('File','appendmtime', true);
+		$path = BASE_PATH . '/' . $file->Filename;
+		$this->assertEquals(ASSETS_DIR . '/FileTest.txt?m='.filemtime($path), $file->RelativeLink());
+		$this->assertEquals(Director::baseURL() . ASSETS_DIR . '/FileTest.txt?m='.filemtime($path), $file->Link());
+		Config::inst()->update('File','appendmtime', $appendmtime);
 	}
 	
 	public function testGetRelativePath() {
@@ -214,12 +222,28 @@ class FileTest extends SapphireTest {
 	
 	public function testGetURL() {
 		$rootfile = $this->objFromFixture('File', 'asdf');
+		
+		$appendmtime = Config::inst()->get('File', 'appendmtime');
+		Config::inst()->update('File','appendmtime', false);		
 		$this->assertEquals(Director::baseURL() . $rootfile->getFilename(), $rootfile->getURL());
+		
+		Config::inst()->update('File','appendmtime', true);
+		$path = BASE_PATH . '/' . $rootfile->Filename;
+		$this->assertEquals(Director::baseURL() . $rootfile->getFilename().'?m='.filemtime($path), $rootfile->getURL());
+		Config::inst()->update('File','appendmtime', $appendmtime);
 	}
 	
 	public function testGetAbsoluteURL() {
 		$rootfile = $this->objFromFixture('File', 'asdf');
+		
+		$appendmtime = Config::inst()->get('File', 'appendmtime');
+		Config::inst()->update('File','appendmtime', false);	
 		$this->assertEquals(Director::absoluteBaseURL() . $rootfile->getFilename(), $rootfile->getAbsoluteURL());
+		
+		Config::inst()->update('File','appendmtime', true);
+		$path = BASE_PATH . '/' . $rootfile->Filename;
+		$this->assertEquals(Director::absoluteBaseURL() . $rootfile->getFilename().'?m='.filemtime($path), $rootfile->getAbsoluteURL());
+		Config::inst()->update('File','appendmtime', $appendmtime);
 	}
 	
 	public function testNameAndTitleGeneration() {


### PR DESCRIPTION
...hion to the one for JS/Css files. This is mostly for enabling long etag headers on assets and therefore improve caching performance.
