### PR TITLE
BUG Fixes a regexp that could never be matched and was wrong anyway.

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -158,8 +158,7 @@ class DataQuery {
 
 			foreach ($query->getWhere() as $where) {
 				// Check for just the column, in the form '"Column" = ?' and the form '"Table"."Column"' = ?
-				if (preg_match('/^"([^"]+)"/', $where, $matches) ||
-					preg_match('/^"([^"]+)"\."[^"]+"/', $where, $matches)) {
+				if (preg_match('/^(?:"[^"]+"\.)?"([^"]+)"/', $where, $matches)){
 					if (!in_array($matches[1], $queriedColumns)) $queriedColumns[] = $matches[1];
 				}
 			}


### PR DESCRIPTION
Regex in getFinalisedQuery() would not match "column" in ' "table".'column" ' as it's supposed to.

I blew this PR the other day - but I think it's fine now.
