### PR TITLE
Added a class check when comparing ID's in `GridFieldAddExistingAutocompleter`

### DIFF
--- a/forms/gridfield/GridFieldAddExistingAutocompleter.php
+++ b/forms/gridfield/GridFieldAddExistingAutocompleter.php
@@ -230,14 +230,17 @@ class GridFieldAddExistingAutocompleter
 			->limit($this->getResultsLimit());
 
 		$json = array();
+		$formRecord = $gridField->getForm()->getRecord();
 		foreach($results as $result) {
 			// Prevent a circular reference and associated error in CMS/admin
-			$hideFromSearch = ($gridField->getForm()->getRecord() && ($result->ID == $gridField->getForm()->getRecord()->ID));
+			$hideFromSearch = ($formRecord && ($result->ClassName == $formRecord->ClassName && $result->ID == $formRecord->ID));
+
 			if($hideFromSearch) {
 				continue;
 			}
 			$json[$result->ID] = SSViewer::fromString($this->resultsFormat)->process($result);
 		}
+		
 		return Convert::array2json($json);
 	}
 


### PR DESCRIPTION
Added check for classes when comparing ID's in `GridFieldAddExistingAutocompleter` - if objects are of different type, ID's are going to clash.
