### PR TITLE
FIX: Fixes #2382

### DIFF
--- a/parsers/ShortcodeParser.php
+++ b/parsers/ShortcodeParser.php
@@ -218,9 +218,9 @@ class ShortcodeParser {
 					preg_match_all(self::attrrx(), $match['attrs'][0], $attrmatches, PREG_SET_ORDER);
 
 					foreach ($attrmatches as $attr) {
-						list($whole, $name, $value) = array_values(array_filter($attr));
+						list($whole, $name, $value) = array_values(array_filter($attr, 'strlen'));
 						$attrs[$name] = $value;
-				}
+					}
 				}
 				
 				// And store the indexes, tag details, etc

--- a/tests/parsers/ShortcodeParserTest.php
+++ b/tests/parsers/ShortcodeParserTest.php
@@ -88,6 +88,18 @@ class ShortcodeParserTest extends SapphireTest {
 		}
 	}
 	
+	public function testOneFalseishArgumentWhereIsZero() {
+		$tests = array (
+			'[test_shortcode foo="0"]', "[test_shortcode foo='0']",
+			'[test_shortcode foo=0]'
+		);
+		
+		foreach($tests as $test) {
+			$this->parser->parse($test);
+			$this->assertEquals(array('foo' => 0), $this->arguments, $test);
+		}
+	}
+	
 	public function testMultipleArguments() {
 		$this->parser->parse('[test_shortcode foo = "bar",bar=\'foo\', baz="buz"]');
 		


### PR DESCRIPTION
- Errors are thrown in front-end should the shortcode parser encounter a shortcode with a value of '0'
- Added test
