### PR TITLE
FIX: Follow internal redirections for cli operations.

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -147,11 +147,22 @@ class Director implements TemplateGlobalProvider {
 
 		// Return code for a redirection request
 		if(is_string($result) && substr($result,0,9) == 'redirect:') {
-			$response = new SS_HTTPResponse();
-			$response->redirect(substr($result, 9));
-			$res = Injector::inst()->get('RequestProcessor')->postRequest($req, $response, $model);
-			if ($res !== false) {
-				$response->output();
+			$url = substr($result, 9);
+
+			if(Director::is_cli()) {
+				// on cli, follow SilverStripe redirects automatically
+				return Director::direct(
+					str_replace(Director::absoluteBaseURL(), '', $url), 
+					DataModel::inst()
+				);
+			} else {
+				$response = new SS_HTTPResponse();
+				$response->redirect($url);
+				$res = Injector::inst()->get('RequestProcessor')->postRequest($req, $response, $model);
+
+				if ($res !== false) {
+					$response->output();
+				}
 			}
 		// Handle a controller
 		} else if($result) {


### PR DESCRIPTION
Raised as part of https://github.com/silverstripe-labs/silverstripe-staticpublisher/issues/23. 

Previously any redirection operations when called via sake returned a blank result. This patch alters the behaviour to automatically follow redirects. Alternatively we could output a warning to the user that the page has moved, however this approach would be favoured since it won't break any cron jobs or other scripted operations which is the highest risk.
