### PR TITLE
Disallow increasing the execution time if it's already 0

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -261,8 +261,8 @@ function increase_time_limit_to($timeLimit = null) {
 			return true;
 		} else {
 			$currTimeLimit = ini_get('max_execution_time');
-			// Only increase if its smaller
-			if($currTimeLimit && $currTimeLimit < $timeLimit) {
+			// Only increase if its smaller (and we're not at 0)
+			if($currTimeLimit && ($currTimeLimit < $timeLimit) && ($currTimeLimit != 0)) {
 				set_time_limit($timeLimit);
 			} 
 			return true;


### PR DESCRIPTION
This comes into play mainly on the CLI, where if we have a time limit of 0, we don't want to be able to increase it further.
