### PR TITLE
Only compare array notations in SQLQuery->getOrderedJoins()

### DIFF
--- a/model/SQLQuery.php
+++ b/model/SQLQuery.php
@@ -1127,10 +1127,15 @@ class SQLQuery {
 		// shift the first FROM table out from so we only deal with the JOINs
 		$baseFrom = array_shift($from);
 		$this->mergesort($from, function($firstJoin, $secondJoin) {
-			if($firstJoin['order'] == $secondJoin['order']) {
+			if(
+				!is_array($firstJoin) 
+				|| !is_array($secondJoin)
+				|| $firstJoin['order'] == $secondJoin['order']
+			) {
 				return 0;
+			} else {
+				return ($firstJoin['order'] < $secondJoin['order']) ?  -1 : 1;
 			}
-			return ($firstJoin['order'] < $secondJoin['order']) ?  -1 : 1;
 		});
 		
 		// Put the first FROM table back into the results 

--- a/tests/model/SQLQueryTest.php
+++ b/tests/model/SQLQueryTest.php
@@ -132,9 +132,20 @@ class SQLQueryTest extends SapphireTest {
 		$query = new SQLQuery();
 		$query->setFrom("MyTable");
 		$query->setOrderBy('RAND()');
-		
 		$this->assertEquals(
 			'SELECT *, RAND() AS "_SortColumn0" FROM MyTable ORDER BY "_SortColumn0" ASC',
+			$query->sql());
+
+		$query = new SQLQuery();
+		$query->setFrom("MyTable");
+		$query->addFrom('INNER JOIN SecondTable USING (ID)');
+		$query->addFrom('INNER JOIN ThirdTable USING (ID)');
+		$query->setOrderBy('MyName');
+		$this->assertEquals(
+			'SELECT * FROM MyTable '
+			. 'INNER JOIN SecondTable USING (ID) '
+			. 'INNER JOIN ThirdTable USING (ID) '
+			. 'ORDER BY MyName ASC',
 			$query->sql());
 	}
 


### PR DESCRIPTION
If more than two $from were added through SQLQuery->addFrom(),
the getOrderedJoins() comparison kicks in. It assumes all $from
parts are in array notation, which isn't always the case.
For legacy reasons, and because we don't have full API support,
you can still add literal joins through addFrom('INNER JOIN ...').
On PHP 5.3, the ordering comparison still works because it
allows array access in strings, with string rather than numeric indexes.
Thankfully that's no longer supported in PHP 5.4.

The tables in the SQLQuery test don't exist, but that doesn't really matter since the query is never executed.
