### PR TITLE
Form errors in LeftAndMain response negotiation

### DIFF
--- a/admin/code/CMSForm.php
+++ b/admin/code/CMSForm.php
@@ -37,4 +37,9 @@ class CMSForm extends Form {
 		return $this->responseNegotiator;
 	}
 
+	public function FormName() {
+		if($this->htmlID) return $this->htmlID;
+		else return 'Form_' . str_replace(array('.', '/'), '', $this->name);
+	}
+
 }

--- a/forms/Form.php
+++ b/forms/Form.php
@@ -241,6 +241,8 @@ class Form extends RequestHandler {
 		if(isset($errorInfo['message']) && isset($errorInfo['type'])) {
 			$this->setMessage($errorInfo['message'], $errorInfo['type']);
 		}
+
+		return $this;
 	}
 	
 	/**


### PR DESCRIPTION
The session key for form errors changed from "Form_EditForm" to "CMSForm_EditForm",
causing a mismatch. See https://github.com/silverstripe/silverstripe-framework/pull/2084/files#r6338249 for discussion
