### PR TITLE
BUG Fixing tabindex added to CreditCardField when tabindex is NULL

### DIFF
--- a/forms/CreditCardField.php
+++ b/forms/CreditCardField.php
@@ -35,6 +35,9 @@ class CreditCardField extends TextField {
 	 * @return string
 	 */
 	protected function getTabIndexHTML($increment = 0) {
+		// we can't add a tabindex if there hasn't been one set yet.
+		if($this->getAttribute('tabindex') === null) return false;
+
 		$tabIndex = (int)$this->getAttribute('tabindex') + (int)$increment;
 		return (is_numeric($tabIndex)) ? ' tabindex = "' . $tabIndex . '"' : '';
 	}


### PR DESCRIPTION
The tabindex increment _should_ only be done if there is a tabindex
that has been set on a CreditCardField already, otherwise it breaks
the tab ordering.
