### PR TITLE
BUGFIX: TreeMultiselectField causes issues in combination with translatable module.

### DIFF
--- a/forms/TreeMultiselectField.php
+++ b/forms/TreeMultiselectField.php
@@ -119,7 +119,11 @@ class TreeMultiselectField extends TreeDropdownField {
 		if ($this->form){
 			$dataUrlTree = $this->Link('tree');
 			if (isset($idArray) && count($idArray)){
-				$dataUrlTree .= '?forceValue='.implode(',',$idArray);
+				if(strpos($dataUrlTree, '?') === false){
+					$dataUrlTree .= '?forceValue='.implode(',',$idArray);
+				} else {
+					$dataUrlTree .= '&forceValue='.implode(',',$idArray);
+				}
 			}
 		}
 		return FormField::create_tag(


### PR DESCRIPTION
The translatable module adds query-strings containing the locale to the URL. The `TreeMultiselectField` assumes that there's no query-string with the URL which in turn causes errors.
This bugfix addresses this problem.
