### PR TITLE
Fix "cms-description-tooltip" reference in code

### DIFF
--- a/docs/en/howto/cms-formfield-help-text.md
+++ b/docs/en/howto/cms-formfield-help-text.md
@@ -19,7 +19,7 @@ add a `.cms-description-tooltip` class.
 	:::php
 	TextField::create('MyText', 'My Text Label')
 		->setDescription('More <strong>detailed</strong> help')
-		->addExtraClass('cms-help-tooltip');
+		->addExtraClass('cms-description-tooltip');
 
 Tooltips are only supported
 for native, focusable input elements, which excludes


### PR DESCRIPTION
The instruction said to put "cms-description-tooltip" in the addExtraClass but in the sample code it is using "cms-help-tooltip"
