### PR TITLE
BUG Fix regression introduced in #2356 (method call on non-object)

### DIFF
--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -343,11 +343,14 @@ class HTTP {
 			$responseHeaders['Vary'] = 'Cookie, X-Forwarded-Protocol, User-Agent, Accept';
 		}
 		else {
-			// Grab header for checking. Unfortunately HTTPRequest uses a mistyped variant.
-			$contentDisposition = $body->getHeader('Content-disposition');
-			if (!$contentDisposition) $contentDisposition = $body->getHeader('Content-Disposition');
+			if($body) {
+				// Grab header for checking. Unfortunately HTTPRequest uses a mistyped variant.
+				$contentDisposition = $body->getHeader('Content-disposition');
+				if (!$contentDisposition) $contentDisposition = $body->getHeader('Content-Disposition');
+			}
 
 			if(
+				$body &&
 				Director::is_https() &&
 				strstr($_SERVER["HTTP_USER_AGENT"], 'MSIE')==true &&
 				strstr($contentDisposition, 'attachment;')==true


### PR DESCRIPTION
#2356 introduced a slight regression where calling `HTTP::add_cache_headers();` with no arguments caused the following error.

`Fatal error: Call to a member function getHeader() on a non-object`

See https://github.com/silverstripe/silverstripe-framework/blob/3.1.0/api/RSSFeed.php#L203 for an example of such a method call.
