### PR TITLE
BUGFIX: Without casting TreeTitle as HTMLText, unescape HTML appears in ...

### DIFF
--- a/filesystem/Folder.php
+++ b/filesystem/Folder.php
@@ -24,6 +24,10 @@ class Folder extends File {
 	private static $plural_name = "Folders";
 
 	private static $default_sort = "\"Name\"";
+
+	private static $casting = array (
+		'TreeTitle' => 'HTMLText'
+	);
 	
 	/**
 	 * 


### PR DESCRIPTION
...TreeDropdownField
