### PR TITLE
API Removed "PastMember" cookie and template getter

### DIFF
--- a/control/Controller.php
+++ b/control/Controller.php
@@ -75,7 +75,6 @@ class Controller extends RequestHandler implements TemplateGlobalProvider {
 		if(Session::get('loggedInAs') && Security::database_is_ready()) {
 			$member = Member::currentUser();
 			if($member) {
-				if(!headers_sent()) Cookie::set("PastMember", true, 90, null, null, false, true);
 				DB::query("UPDATE \"Member\" SET \"LastVisited\" = " . DB::getConn()->now()
 					. " WHERE \"ID\" = $member->ID", null);
 			}

--- a/security/Member.php
+++ b/security/Member.php
@@ -627,13 +627,6 @@ class Member extends DataObject implements TemplateGlobalProvider {
 			return DataObject::get_one("Member", "\"Member\".\"ID\" = $id", true, 1);
 		}
 	}
-	
-	/**
-	 * Returns true if the current member is a repeat visitor who has logged in more than once.
-	 */
-	public static function is_repeat_member() {
-		return Cookie::get("PastMember") ? true : false;
-	}
 
 	/**
 	 * Get the ID of the current logged in user
@@ -1463,8 +1456,6 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		return array(
 			'CurrentMember' => 'currentUser',
 			'currentUser',
-			'PastMember' => 'is_repeat_member',
-			'IsRepeatMember' => 'is_repeat_member',
 		);
 	}
 }

--- a/tests/control/DirectorTest.php
+++ b/tests/control/DirectorTest.php
@@ -277,7 +277,7 @@ class DirectorTest extends SapphireTest {
 			'HTTP_USER_AGENT'      => 'User Agent',
 			'HTTP_ACCEPT'          => 'text/html',
 			'HTTP_ACCEPT_LANGUAGE' => 'en-us',
-			'HTTP_COOKIE'          => 'PastMember=1',
+			'HTTP_COOKIE'          => 'MyCookie=1',
 			'SERVER_PROTOCOL'      => 'HTTP/1.1',
 			'REQUEST_METHOD'       => 'GET',
 			'REQUEST_URI'          => '/',
@@ -291,7 +291,7 @@ class DirectorTest extends SapphireTest {
 			'User-Agent'      => 'User Agent',
 			'Accept'          => 'text/html',
 			'Accept-Language' => 'en-us',
-			'Cookie'          => 'PastMember=1',
+			'Cookie'          => 'MyCookie=1',
 			'Content-Type'    => 'text/xml',
 			'Content-Length'  => '10'
 		);


### PR DESCRIPTION
The functionality is easy to replicate in custom controllers,
and is too rarely used to be placed in core.

This also removes the `Member::is_repeat_member()` getter
and the `PastMember`/`IsRepeatMember` template globals.

See https://groups.google.com/forum/#!topic/silverstripe-dev/b8K3wU64TXg
