### PR TITLE
MINOR: GridFieldDetailForm::doSave() returns unescaped HTML in success m...

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -508,15 +508,12 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 
 		// TODO Save this item into the given relationship
 
-		$link = '<a href="' . $this->Link('edit') . '">"' 
-			. htmlspecialchars($this->record->Title, ENT_QUOTES) 
-			. '"</a>';
 		$message = _t(
-			'GridFieldDetailForm.Saved', 
+			'GridFieldDetailForm.Saved',
 			'Saved {name} {link}',
 			array(
 				'name' => $this->record->i18n_singular_name(),
-				'link' => $link
+				'link' => $this->record->Title
 			)
 		);
 		


### PR DESCRIPTION
...essage

Due to the new default casting of Text, the HTML is unescaped. Citing that the anchor tag in the success message is of little utility to the user, this change removes the HTML and leaves a plain success message. Note that the {link} key in the translation no longer has any semantic meaning. Consider updating the lang files.
