### PR TITLE
FIX: Make CreditCardField use template

### DIFF
--- a/forms/CreditCardField.php
+++ b/forms/CreditCardField.php
@@ -16,16 +16,16 @@ class CreditCardField extends TextField {
 		$parts = array_pad($parts, 4, "");
 
 		// TODO Mark as disabled/readonly
-		$field = "<span id=\"{$this->name}_Holder\" class=\"creditCardField\">"
-			. "<input autocomplete=\"off\" name=\"{$this->name}[0]\" value=\"$parts[0]\" maxlength=\"4\""
-			. $this->getTabIndexHTML(0) . " /> - "
-			. "<input autocomplete=\"off\" name=\"{$this->name}[1]\" value=\"$parts[1]\" maxlength=\"4\"" 
-			. $this->getTabIndexHTML(1) . " /> - "
-			. "<input autocomplete=\"off\" name=\"{$this->name}[2]\" value=\"$parts[2]\" maxlength=\"4\"" 
-			. $this->getTabIndexHTML(2) . " /> - "
-			. "<input autocomplete=\"off\" name=\"{$this->name}[3]\" value=\"$parts[3]\" maxlength=\"4\"" 
-			. $this->getTabIndexHTML(3) . " /></span>";
-		return $field;
+		$properties['ValueOne'] = $parts[0];
+		$properties['ValueTwo'] = $parts[1];
+		$properties['ValueThree'] = $parts[2];
+		$properties['ValueFour'] = $parts[3];
+		$properties['TabIndexOne'] = $this->getTabIndexHTML(0);
+		$properties['TabIndexTwo'] = $this->getTabIndexHTML(1);
+		$properties['TabIndexThree'] = $this->getTabIndexHTML(2);
+		$properties['TabIndexFour'] = $this->getTabIndexHTML(3);
+
+		return parent::Field($properties);
 	}
 
 	/**

--- a/templates/forms/CreditCardField.ss
+++ b/templates/forms/CreditCardField.ss
@@ -1,0 +1,6 @@
+<span id="{$Name}_Holder" class="creditCardField">
+	<input autocomplete="off" name="{$Name}[0]" value="{$ValueOne}" maxlength="4" $TabIndexOne/> -
+	<input autocomplete="off" name="{$Name}[1]" value="{$ValueTwo}" maxlength="4" $TabIndexTwo/> -
+	<input autocomplete="off" name="{$Name}[2]" value="{$ValueThree}" maxlength="4" $TabIndexThree/> -
+	<input autocomplete="off" name="{$Name}[3]" value="{$ValueFour}" maxlength="4" $TabIndexFour/>
+</span>


### PR DESCRIPTION
Changed the `CreditCardField` to use a template to generate the HTML so that it's easier to customise.

I'm planning on making a few more PR's to improve the way the `$parts` and `getTabIndexHTML` get parsed to the template, as well as to implement disabled/readonly attributes. But I just wanted to get the initial change approved/merged first.
