### PR TITLE
NEW Changed `DataObject::write()` to return `$this`

### DIFF
--- a/dev/CsvBulkLoader.php
+++ b/dev/CsvBulkLoader.php
@@ -171,7 +171,7 @@ class CsvBulkLoader extends BulkLoader {
 		}
 
 		// write record
-		$id = ($preview) ? 0 : $obj->write();
+		$id = ($preview) ? 0 : $obj->write()->ID;
 		
 		// @todo better message support
 		$message = '';

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -643,6 +643,13 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	}
 
 	/**
+	 * @return string the class name
+	 */
+	public function __toString() {
+		return parent::__toString() . ' #' . $this->ID;
+	}
+
+	/**
 	 * Returns TRUE if all values (other than "ID") are
 	 * considered empty (by weak boolean comparison).
 	 * Only checks for fields listed in {@link custom_database_fields()}
@@ -1296,7 +1303,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 		if($writeComponents) {
 			$this->writeComponents(true);
 		}
-		return $this->record['ID'];
+		return $this;
 	}
 
 	/**

--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -644,7 +644,7 @@ class Versioned extends DataExtension {
 	 * Perform a write without affecting the version table.
 	 * On objects without versioning.
 	 *
-	 * @return int The ID of the record
+	 * @return DataObject The dataobject that has been written
 	 */
 	public function writeWithoutVersion() {
 		$this->_nextWriteWithoutVersion = true;

--- a/tests/model/DataObjectLazyLoadingTest.php
+++ b/tests/model/DataObjectLazyLoadingTest.php
@@ -304,7 +304,7 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 		$obj1 = new VersionedLazySub_DataObject();
 		$obj1->PageName = "old-value";
 		$obj1->ExtraField = "old-value";
-		$obj1ID = $obj1->write();
+		$obj1ID = $obj1->write()->ID;
 		$obj1->publish('Stage', 'Live');
 
 		$obj1 = VersionedLazySub_DataObject::get()->byID($obj1ID);

--- a/tests/model/MoneyTest.php
+++ b/tests/model/MoneyTest.php
@@ -90,7 +90,7 @@ class MoneyTest extends SapphireTest {
 			"Money field not added to data object properly when read prior to first writing the record."
 		);
 		
-		$objID = $obj->write();
+		$objID = $obj->write()->ID;
 
 		$moneyTest = DataObject::get_by_id('MoneyTest_DataObject',$objID);
 		$this->assertTrue($moneyTest instanceof MoneyTest_DataObject);

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -426,13 +426,13 @@ class VersionedTest extends SapphireTest {
 
 		$relatedData = new VersionedTest_RelatedWithoutVersion();
 		$relatedData->Name = 'Related Data';
-		$relatedDataId = $relatedData->write();
+		$relatedDataId = $relatedData->write()->ID;
 
 		$testData = new VersionedTest_DataObject();
 		$testData->Title = 'Test';
 		$testData->Content = 'Before Content';
 		$testData->Related()->add($relatedData);
-		$id = $testData->write();
+		$id = $testData->write()->ID;
 
 		SS_Datetime::set_mock_now('2010-01-01 00:00:00');
 		$testData->Content = 'After Content';


### PR DESCRIPTION
Changed `DataObject::write()` to return `$this` as per new SS 3 convention

Fix for #1843
