### PR TITLE
more meaningful error message in ConfigStaticManifest.php (depth < 0)

### DIFF
--- a/core/manifest/ConfigStaticManifest.php
+++ b/core/manifest/ConfigStaticManifest.php
@@ -237,7 +237,7 @@ class SS_ConfigStaticManifest_Parser {
 			else if($type == '}') {
 				$depth -= 1;
 				if($depth < $clsdepth) $class = $clsdepth = null;
-				if($depth < 0) user_error("Hmm - depth calc wrong, hit negatives", E_USER_ERROR);
+				if($depth < 0) user_error("Hmm - depth calc wrong, hit negatives, see: ".$this->path, E_USER_ERROR);
 			}
 			else if($type == T_PUBLIC || $type == T_PRIVATE || $type == T_PROTECTED) {
 				$access = $type;


### PR DESCRIPTION
Changed error from: Fatal error: Hmm - depth calc wrong, hit negatives in /var/www/mysite.maori.nz/framework/core/manifest/ConfigStaticManifest.php on line 242 

... to .... 

Fatal error: Hmm - depth calc wrong, hit negatives, see: /var/www/mysite.maori.nz/mymodule/code/MyClass.php in /var/www/mysite.maori.nz/framework/core/manifest/ConfigStaticManifest.php on line 240

The first error is completely meaningless and impossible to debug...
