### PR TITLE
BUG 3.2 Fixed cross-platform issues with test cases and file utility

### DIFF
--- a/core/TempPath.php
+++ b/core/TempPath.php
@@ -46,7 +46,7 @@ function getTempParentFolder($base = null) {
 	$worked = true;
 
 	// first, try finding a silverstripe-cache dir built off the base path
-	$tempPath = $base . '/silverstripe-cache';
+	$tempPath = $base . DIRECTORY_SEPARATOR . 'silverstripe-cache';
 	if(@file_exists($tempPath)) {
 		if((fileperms($tempPath) & 0777) != 0777) {
 			@chmod($tempPath, 0777);
@@ -55,7 +55,7 @@ function getTempParentFolder($base = null) {
 	}
 
 	// failing the above, try finding a namespaced silverstripe-cache dir in the system temp
-	$cacheFolder = '/silverstripe-cache' . str_replace(array(' ', '/', ':', '\\'), '-', $base);
+	$cacheFolder = DIRECTORY_SEPARATOR . 'silverstripe-cache' . str_replace(array(' ', '/', ':', '\\'), '-', $base);
 	$tempPath = sys_get_temp_dir() . $cacheFolder;
 	if(!@file_exists($tempPath)) {
 		$oldUMask = umask(0);
@@ -72,7 +72,7 @@ function getTempParentFolder($base = null) {
 	// failing to use the system path, attempt to create a local silverstripe-cache dir
 	if(!$worked) {
 		$worked = true;
-		$tempPath = $base . '/silverstripe-cache';
+		$tempPath = $base . DIRECTORY_SEPARATOR . 'silverstripe-cache';
 		if(!@file_exists($tempPath)) {
 			$oldUMask = umask(0);
 			$worked = @mkdir($tempPath, 0777);

--- a/tests/core/CoreTest.php
+++ b/tests/core/CoreTest.php
@@ -12,29 +12,30 @@ class CoreTest extends SapphireTest {
 
 	public function setUp() {
 		parent::setUp();
-		$this->tempPath = Director::baseFolder() . '/silverstripe-cache';
+		$this->tempPath = Director::baseFolder() . DIRECTORY_SEPARATOR . 'silverstripe-cache';
 	}
 
 	public function testGetTempPathInProject() {
 		$user = getTempFolderUsername();
 
 		if(file_exists($this->tempPath)) {
-			$this->assertEquals(getTempFolder(BASE_PATH), $this->tempPath . '/' . $user);
+			$this->assertEquals(getTempFolder(BASE_PATH), $this->tempPath . DIRECTORY_SEPARATOR . $user);
 		} else {
 			$user = getTempFolderUsername();
 
 			// A typical Windows location for where sites are stored on IIS
-			$this->assertEquals(sys_get_temp_dir() . 
-				'/silverstripe-cacheC--inetpub-wwwroot-silverstripe-test-project/' . $user,
+			$this->assertEquals(sys_get_temp_dir() . DIRECTORY_SEPARATOR .
+				'silverstripe-cacheC--inetpub-wwwroot-silverstripe-test-project' . DIRECTORY_SEPARATOR . $user,
 				getTempFolder('C:\\inetpub\\wwwroot\\silverstripe-test-project'));
 
 			// A typical Mac OS X location for where sites are stored
-			$this->assertEquals(sys_get_temp_dir() . 
-				'/silverstripe-cache-Users-joebloggs-Sites-silverstripe-test-project/' . $user,
+			$this->assertEquals(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 
+				'silverstripe-cache-Users-joebloggs-Sites-silverstripe-test-project' . DIRECTORY_SEPARATOR . $user,
 				getTempFolder('/Users/joebloggs/Sites/silverstripe-test-project'));
 
 			// A typical Linux location for where sites are stored
-			$this->assertEquals(sys_get_temp_dir() . '/silverstripe-cache-var-www-silverstripe-test-project/' . $user,
+			$this->assertEquals(sys_get_temp_dir() . DIRECTORY_SEPARATOR .
+				'silverstripe-cache-var-www-silverstripe-test-project' . DIRECTORY_SEPARATOR . $user,
 				getTempFolder('/var/www/silverstripe-test-project'));
 		}
 	}
@@ -42,17 +43,16 @@ class CoreTest extends SapphireTest {
 	public function tearDown() {
 		parent::tearDown();
 		$user = getTempFolderUsername();
-		if(file_exists(sys_get_temp_dir() . '/silverstripe-cacheC--inetpub-wwwroot-silverstripe-test-project')) {
-			rmdir(sys_get_temp_dir() . '/silverstripe-cacheC--inetpub-wwwroot-silverstripe-test-project/' . $user);
-			rmdir(sys_get_temp_dir() . '/silverstripe-cacheC--inetpub-wwwroot-silverstripe-test-project');
-		}
-		if(file_exists(sys_get_temp_dir() . '/silverstripe-cache-Users-joebloggs-Sites-silverstripe-test-project')) {
-			rmdir(sys_get_temp_dir() . '/silverstripe-cache-Users-joebloggs-Sites-silverstripe-test-project/' . $user);
-			rmdir(sys_get_temp_dir() . '/silverstripe-cache-Users-joebloggs-Sites-silverstripe-test-project');
-		}
-		if(file_exists(sys_get_temp_dir() . '/silverstripe-cache-var-www-silverstripe-test-project')) {
-			rmdir(sys_get_temp_dir() . '/silverstripe-cache-var-www-silverstripe-test-project/' . $user);
-			rmdir(sys_get_temp_dir() . '/silverstripe-cache-var-www-silverstripe-test-project');
+		foreach(array(
+			'silverstripe-cacheC--inetpub-wwwroot-silverstripe-test-project',
+			'silverstripe-cache-Users-joebloggs-Sites-silverstripe-test-project',
+			'silverstripe-cache-var-www-silverstripe-test-project'
+		) as $dir) {
+			$path = sys_get_temp_dir().DIRECTORY_SEPARATOR.$dir;
+			if(file_exists($path)) {
+				rmdir($path . DIRECTORY_SEPARATOR . $user);
+				rmdir($path);
+			}
 		}
 	}
 

--- a/tests/forms/HtmlEditorFieldTest.php
+++ b/tests/forms/HtmlEditorFieldTest.php
@@ -88,10 +88,11 @@ class HtmlEditorFieldTest extends FunctionalTest {
 		$this->assertEquals(10, (int)$xml[0]['width'], 'Width tag of resized image is set.');
 		$this->assertEquals(20, (int)$xml[0]['height'], 'Height tag of resized image is set.');
 		
-		$neededFilename = 'assets/_resampled/ResizedImage' . base64_encode(json_encode(array(10,20))) . '-HTMLEditorFieldTest_example.jpg';
+		$neededFilename = 'assets/_resampled/ResizedImage' . base64_encode(json_encode(array(10,20))) .
+			'-HTMLEditorFieldTest_example.jpg';
 		
 		$this->assertEquals($neededFilename, (string)$xml[0]['src'], 'Correct URL of resized image is set.');
-		$this->assertTrue(file_exists($neededFilename), 'File for resized image exists');
+		$this->assertTrue(file_exists(BASE_PATH.DIRECTORY_SEPARATOR.$neededFilename), 'File for resized image exists');
 		$this->assertEquals(false, $obj->HasBrokenFile, 'Referenced image file exists.');
 	}	
 	

--- a/tests/i18n/i18nTest.php
+++ b/tests/i18n/i18nTest.php
@@ -28,8 +28,8 @@ class i18nTest extends SapphireTest {
 	public function setUp() {
 		parent::setUp();
 		
-		$this->alternateBasePath = $this->getCurrentAbsolutePath() . "/_fakewebroot";
-		$this->alternateBaseSavePath = TEMP_FOLDER . '/i18nTextCollectorTest_webroot';
+		$this->alternateBasePath = $this->getCurrentAbsolutePath() . DIRECTORY_SEPARATOR . "_fakewebroot";
+		$this->alternateBaseSavePath = TEMP_FOLDER . DIRECTORY_SEPARATOR . 'i18nTextCollectorTest_webroot';
 		FileSystem::makeFolder($this->alternateBaseSavePath);
 		Config::inst()->update('Director', 'alternate_base_folder', $this->alternateBasePath);
 
@@ -182,13 +182,13 @@ class i18nTest extends SapphireTest {
 		), 'en_US');
 		
 		$viewer = new SSViewer('i18nTestModule');
-		$parsedHtml = $viewer->process(new ArrayData(array('TestProperty' => 'TestPropertyValue')));
+		$parsedHtml = Convert::nl2os($viewer->process(new ArrayData(array('TestProperty' => 'TestPropertyValue'))));
 		$this->assertContains(
-			"Layout Template\n",
+			Convert::nl2os("Layout Template\n"),
 			$parsedHtml
 		);
 		$this->assertContains(
-			"Layout Template no namespace\n",
+			Convert::nl2os("Layout Template no namespace\n"),
 			$parsedHtml
 		);
 		
@@ -206,37 +206,37 @@ class i18nTest extends SapphireTest {
 		), 'de_DE');
 
 		$viewer = new SSViewer('i18nTestModule');
-		$parsedHtml = $viewer->process(new ArrayData(array('TestProperty' => 'TestPropertyValue')));
+		$parsedHtml = Convert::nl2os($viewer->process(new ArrayData(array('TestProperty' => 'TestPropertyValue'))));
 		$this->assertContains(
-			"TRANS Main Template\n",
+			Convert::nl2os("TRANS Main Template\n"),
 			$parsedHtml
 		);
 		$this->assertContains(
-			"TRANS Layout Template\n",
+			Convert::nl2os("TRANS Layout Template\n"),
 			$parsedHtml
 		);
 		$this->assertContains(
-			"TRANS Layout Template no namespace",
+			Convert::nl2os("TRANS Layout Template no namespace\n"),
 			$parsedHtml
 		);
 		$this->assertContains(
-			"TRANS My replacement: TestPropertyValue",
+			Convert::nl2os("TRANS My replacement: TestPropertyValue\n"),
 			$parsedHtml
 		);
 		$this->assertContains(
-			"TRANS Include Entity with Namespace",
+			Convert::nl2os("TRANS Include Entity with Namespace\n"),
 			$parsedHtml
 		);
 		$this->assertContains(
-			"TRANS Include Entity without Namespace",
+			Convert::nl2os("TRANS Include Entity without Namespace\n"),
 			$parsedHtml
 		);
 		$this->assertContains(
-			"TRANS My include replacement: TestPropertyValue",
+			Convert::nl2os("TRANS My include replacement: TestPropertyValue\n"),
 			$parsedHtml
 		);
 		$this->assertContains(
-			"TRANS My include replacement no namespace: TestPropertyValue",
+			Convert::nl2os("TRANS My include replacement no namespace: TestPropertyValue\n"),
 			$parsedHtml
 		);
 		
@@ -335,25 +335,27 @@ class i18nTest extends SapphireTest {
 		),'en_US');
 
 		$viewer = new SSViewer('i18nTestModule');
-		$parsedHtml = $viewer->process(new ArrayData(array('TestProperty' => 'TestPropertyValue')));
+		$parsedHtml = Convert::nl2os($viewer->process(new ArrayData(array('TestProperty' => 'TestPropertyValue'))));
 		$this->assertContains(
-			"Hello Mark welcome. But it is late, bye\n",
+			Convert::nl2os("Hello Mark welcome. But it is late, bye\n"),
 			$parsedHtml, "Testing fallback to the translation default (but using the injection array)"
 		);
 
 		$this->assertContains(
-			"TRANS Hello Paul good you are here. But it is late, see you\n",
+			Convert::nl2os("TRANS Hello Paul good you are here. But it is late, see you\n"),
 			$parsedHtml, "Testing entity, default string and injection array"
 		);
 
 		$this->assertContains(
-			"TRANS Hello Cat meow. But it is late, meow\n",
+			Convert::nl2os("TRANS Hello Cat meow. But it is late, meow\n"),
 			$parsedHtml, "Testing a translation with just entity and injection array"
 		);
 
 		//test injected calls
 		$this->assertContains(
-			"TRANS Hello ".Director::absoluteBaseURL()." ".i18n::get_locale().". But it is late, global calls\n",
+			Convert::nl2os(
+				"TRANS Hello ".Director::absoluteBaseURL()." ".i18n::get_locale().". But it is late, global calls\n"
+			),
 			$parsedHtml,
 			"Testing a translation with just entity and injection array, but with global variables injected in"
 		);


### PR DESCRIPTION
This bug fixes issues in test cases where:
- Path comparison where '/' and '\' would distinguish otherwise equivalent paths
- Various line delimiters would break string comparison
- Issues where test cases would fail if the execution directory did not match the site root.

This also applies this consistent logic in TempPath.php to ensure that generated directory filenames are consistent with the underlying operating system.

Extracted from https://github.com/silverstripe/silverstripe-framework/pull/1360
