### PR TITLE
FIX: Undefined variable in TreeDropdownField.php

### DIFF
--- a/forms/TreeDropdownField.php
+++ b/forms/TreeDropdownField.php
@@ -434,7 +434,7 @@ class TreeDropdownField extends FormField {
 			$sourceObject = $this->sourceObject;
 			$wheres = array();
 			if(singleton($sourceObject)->hasDatabaseField($this->labelField)) {
-				$wheres[] = "\"$searchField\" LIKE '%$this->search%'";
+				$wheres[] = "\"$this->labelField\" LIKE '%$this->search%'";
 			} else {
 				if(singleton($sourceObject)->hasDatabaseField('Title')) {
 					$wheres[] = "\"Title\" LIKE '%$this->search%'";


### PR DESCRIPTION
I'm guessing this was just a simple typo. Checked this by searching on SiteTree, behaves as expected after this change.
