### PR TITLE
BUG Issue with login form failing to login in certain situations. Fixes ...

### DIFF
--- a/security/MemberLoginForm.php
+++ b/security/MemberLoginForm.php
@@ -15,6 +15,15 @@ class MemberLoginForm extends LoginForm {
 	protected $authenticator_class = 'MemberAuthenticator';
 	
 	/**
+	 * Since the logout and dologin actions may be conditionally removed, it's necessary to ensure these
+	 * remain valid actions regardless of the member login state.
+	 *
+	 * @var array
+	 * @config 
+	 */
+	private static $allowed_actions = array('dologin', 'logout');
+	
+	/**
 	 * Constructor
 	 *
 	 * @param Controller $controller The parent controller, necessary to


### PR DESCRIPTION
Fixes issue #2424.

This PR needs some review. I realise that form actions should not necessarily require inclusion in allowed_actions, but since the form action fields are conditionally added to the form (depending on the login status of the member, whether in progress, or persistent) it's necessary in this case to force these fields to be allowed.

Have I evaluated the issue and is this fix appropriate?
