### PR TITLE
API: Change getAttributesHTML to AttributesHTML

### DIFF
--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -385,7 +385,7 @@ class FormField extends RequestHandler {
 	 * If at least one argument is passed as a string, all arguments act as excludes by name.
 	 * @return string HTML attributes, ready for insertion into an HTML tag
 	 */
-	public function getAttributesHTML($attrs = null) {
+	public function AttributesHTML($attrs = null) {
 		$exclude = (is_string($attrs)) ? func_get_args() : null;
 
 		if(!$attrs || is_string($attrs)) $attrs = $this->getAttributes();
@@ -405,6 +405,13 @@ class FormField extends RequestHandler {
 		}
 
 		return implode(' ', $parts);
+	}
+
+	/**
+	 * @deprecated 3.2 Use AttributesHTML() instead
+	 */
+	public function getAttributesHTML($attrs = null) {
+		return $this->AttributesHTML($attrs);
 	}
 
 	/**

--- a/tests/forms/FormActionTest.php
+++ b/tests/forms/FormActionTest.php
@@ -8,9 +8,9 @@ class FormActionTest extends SapphireTest {
 	
 	public function testGetField() {
 		$formAction = new FormAction('test');
-		$this->assertContains('type="submit"',  $formAction->getAttributesHTML());
+		$this->assertContains('type="submit"',  $formAction->AttributesHTML());
 
 		$formAction->setAttribute('src', 'file.png');
-		$this->assertContains('type="image"', $formAction->getAttributesHTML());
+		$this->assertContains('type="image"', $formAction->AttributesHTML());
 	}
 }

--- a/tests/forms/FormFieldTest.php
+++ b/tests/forms/FormFieldTest.php
@@ -73,35 +73,35 @@ class FormFieldTest extends SapphireTest {
 		$field = new FormField('MyField');
 
 		$field->setAttribute('foo', 'bar');
-		$this->assertContains('foo="bar"', $field->getAttributesHTML());
+		$this->assertContains('foo="bar"', $field->AttributesHTML());
 
 		$field->setAttribute('foo', null);
-		$this->assertNotContains('foo=', $field->getAttributesHTML());
+		$this->assertNotContains('foo=', $field->AttributesHTML());
 
 		$field->setAttribute('foo', '');
-		$this->assertNotContains('foo=', $field->getAttributesHTML());
+		$this->assertNotContains('foo=', $field->AttributesHTML());
 
 		$field->setAttribute('foo', false);
-		$this->assertNotContains('foo=', $field->getAttributesHTML());
+		$this->assertNotContains('foo=', $field->AttributesHTML());
 
 		$field->setAttribute('foo', true);
-		$this->assertContains('foo="foo"', $field->getAttributesHTML());
+		$this->assertContains('foo="foo"', $field->AttributesHTML());
 
 		$field->setAttribute('foo', 'false');
-		$this->assertContains('foo="false"', $field->getAttributesHTML());
+		$this->assertContains('foo="false"', $field->AttributesHTML());
 
 		$field->setAttribute('foo', 'true');
-		$this->assertContains('foo="true"', $field->getAttributesHTML());
+		$this->assertContains('foo="true"', $field->AttributesHTML());
 
 		$field->setAttribute('foo', 0);
-		$this->assertContains('foo="0"', $field->getAttributesHTML());
+		$this->assertContains('foo="0"', $field->AttributesHTML());
 
 		$field->setAttribute('one', 1);
 		$field->setAttribute('two', 2);
 		$field->setAttribute('three', 3);
-		$this->assertNotContains('one="1"', $field->getAttributesHTML('one', 'two'));
-		$this->assertNotContains('two="2"', $field->getAttributesHTML('one', 'two'));
-		$this->assertContains('three="3"', $field->getAttributesHTML('one', 'two'));
+		$this->assertNotContains('one="1"', $field->AttributesHTML('one', 'two'));
+		$this->assertNotContains('two="2"', $field->AttributesHTML('one', 'two'));
+		$this->assertContains('three="3"', $field->AttributesHTML('one', 'two'));
 	}
 
 	public function testEveryFieldTransformsReadonlyAsClone() {


### PR DESCRIPTION
Currently it is impossible to use `$AttributesHTML('class')` in your template to output all attributes except 'class'. Instead you are forced to use `$getAttributesHTML('class')` this seems inconsistent. So I have replaced `getAttributesHTML` with `AttributesHTML`.

This is because when using `__get()` the method is always called with no parameters which causes `$AttributesHTML('class')` to currently not work.

Also sorry for the duplicate PR #2481
