### PR TITLE
Update datamodel.md to use an array argument to Enum instead of the more...

### DIFF
--- a/docs/en/topics/datamodel.md
+++ b/docs/en/topics/datamodel.md
@@ -375,7 +375,7 @@ Data is defined in the static variable $db on each class, in the format:
 	    "FirstName" => "Varchar",
 	    "Surname" => "Varchar",
 	    "Description" => "Text",
-	    "Status" => "Enum('Active, Injured, Retired')",
+	    "Status" => "Enum(array('Active', 'Injured', 'Retired'))",
 	    "Birthday" => "Date"
 	  );
 	}
@@ -393,7 +393,7 @@ the default behavior by making a function called "get`<fieldname>`" or
 	:::php
 	class Player extends DataObject {
 	  private static $db = array(
-	    "Status" => "Enum('Active, Injured, Retired')"
+	    "Status" => "Enum(array('Active', 'Injured', 'Retired'))"
 	  );
 	
 	  // access through $myPlayer->Status


### PR DESCRIPTION
... error-prone string

The previous argument to the Enum was: 
"Status" => "Enum('Active, Injured, Retired')"

This would cause issues where the 'Injured' and 'Retired' statuses would actually be stored in the database as ' Injured' and ' Retired' respectively, at least in 3.0.

Using an array() to specify the enum, and using normal array syntax (albeit within a string) is less likely to cause errors.
