### PR TITLE
fixed wrong ID output for many_many and has_many relations

### DIFF
--- a/api/JSONDataFormatter.php
+++ b/api/JSONDataFormatter.php
@@ -97,7 +97,7 @@ class JSONDataFormatter extends DataFormatter {
 					$innerParts[] = ArrayData::array_to_object(array(
 						"className" => $relClass,
 						"href" => "$href.json",
-						"id" => $item->$fieldName
+						"id" => $item->ID
 					));
 				}
 				$serobj->$relName = $innerParts;
@@ -118,7 +118,7 @@ class JSONDataFormatter extends DataFormatter {
 					$innerParts[] = ArrayData::array_to_object(array(
 						"className" => $relClass,
 						"href" => "$href.json",
-						"id" => $item->$fieldName
+						"id" => $item->ID
 					));
 				}
 				$serobj->$relName = $innerParts;


### PR DESCRIPTION
JSONDataFormatter spits out the wrong ID for `has_many` and `many_many` relations.

This is a confusing bug, since the `$fieldName` is set before, when looping through the `->has_one()` relations and leaves a "random" value left for the `->has_many()` and `->many_many()` loops.
