### PR TITLE
FIX gridfield delete alert selector specificity

### DIFF
--- a/javascript/GridField.js
+++ b/javascript/GridField.js
@@ -136,7 +136,7 @@
 		});
 
 		// Covers both tabular delete button, and the button on the detail form 
-		$('.ss-gridfield .Actions .action.gridfield-button-delete, .cms-edit-form .Actions button.action.action-delete').entwine({
+		$('.ss-gridfield .col-buttons .action.gridfield-button-delete, .cms-edit-form .Actions button.action.action-delete').entwine({
 			onclick: function(e){
 				if(!confirm(ss.i18n._t('TABLEFIELD.DELETECONFIRMMESSAGE'))) {
 					e.preventDefault();


### PR DESCRIPTION
JS alerts when deleting items in GridFields were gone with this commit 02cc662aaf0603d925c0188d420588332b061adc this uses `.col-buttons` class instead to fix it.
