### PR TITLE
HTMLText AbsoluteLink parse placeholders

### DIFF
--- a/model/fieldtypes/HTMLText.php
+++ b/model/fieldtypes/HTMLText.php
@@ -172,8 +172,16 @@ class HTMLText extends Text {
 		/* If we didn't find a sentence ending, use the summary. We re-call rather than using paragraph so that
 		 * Summary will limit the result this time */
 		return $this->Summary();
-	}	
-	
+	}
+
+	/**
+	 * Return the value of the field with relative links converted to absolute urls (with placeholders parsed).
+	 * @return string
+	 */
+	public function AbsoluteLinks() {
+		return HTTP::absoluteURLs($this->forTemplate());
+	}
+
 	public function forTemplate() {
 		if ($this->processShortcodes) {
 			return ShortcodeParser::get_active()->parse($this->value);


### PR DESCRIPTION
Fixes #1910

Left AbsoluteLinks method in Text and overrode it in HTMLText so that original tests continue to pass, removing the AbsoluteLinks method in Text would have resulted in many more changes being required and could have resulted in unexpected behaviour for users.

The AbsoluteLinks method in HTMLText now parses shortcodes before passing the value to HTTP::absoluteLinks.

Added to the RSSFeedTest to ensure that things continue working as expected.
