### PR TITLE
API GridState_Data values can have default values specified during retrieval.

### DIFF
--- a/docs/en/reference/grid-field.md
+++ b/docs/en/reference/grid-field.md
@@ -345,6 +345,23 @@ transfered between page requests by being inserted as a hidden field in the form
 
 A GridFieldComponent sets and gets data from the GridState.
 
+Data within this object can be nested, allowing for organisation of information in a logical fashion. Additionally,
+default values can be specified for any data field by invoking that field as a method, passing the default value
+as the first parameter. If no default is specified then a nested `GridState_Data` is returned, which may be chained
+to subsequently nest data values.
+
+Example:
+
+	:::php
+	
+	public function getManipulatedData(GridField $gridField, SS_List $dataList) {
+		// Accesses the GridState, returns a nested GridState_Data, and retrieve a single field with a default of null
+		$objectID = $gridField->State->MyComponent->RecordID(null);
+		if($objectID) $dataList = $dataList->filter('ParentID', $objectID);
+		return $dataList;
+	}
+
+
 ## Permissions
 
 Since GridField is mostly used in the CMS, the controller managing a GridField instance

--- a/forms/gridfield/GridField.php
+++ b/forms/gridfield/GridField.php
@@ -17,6 +17,7 @@
  * 
  * @package framework
  * @subpackage fields-gridfield
+ * @property GridState_Data $State The gridstate of this object
  */
 class GridField extends FormField {
 	

--- a/forms/gridfield/GridFieldFilterHeader.php
+++ b/forms/gridfield/GridFieldFilterHeader.php
@@ -87,12 +87,12 @@ class GridFieldFilterHeader implements GridField_HTMLProvider, GridField_DataMan
 	public function getManipulatedData(GridField $gridField, SS_List $dataList) {
 		if(!$this->checkDataType($dataList)) return $dataList;
 		
-		$state = $gridField->State->GridFieldFilterHeader;
-		if(!isset($state->Columns)) {
+		$columns = $gridField->State->GridFieldFilterHeader->Columns(null);
+		if(empty($columns)) {
 			return $dataList;
-		} 
+		}
 		
-		$filterArguments = $state->Columns->toArray();
+		$filterArguments = $columns->toArray();
 		$dataListClone = clone($dataList);
 		foreach($filterArguments as $columnName => $value ) {
 			if($dataList->canFilterBy($columnName) && $value) {

--- a/forms/gridfield/GridFieldPaginator.php
+++ b/forms/gridfield/GridFieldPaginator.php
@@ -110,7 +110,7 @@ class GridFieldPaginator implements GridField_HTMLProvider, GridField_DataManipu
 		$state = $gridField->State->GridFieldPaginator;
 		
 		// Force the state to the initial page if none is set
-		if(empty($state->currentPage)) $state->currentPage = 1;
+		$state->currentPage(1);
 		
 		return $state;
 	}

--- a/forms/gridfield/GridFieldSortableHeader.php
+++ b/forms/gridfield/GridFieldSortableHeader.php
@@ -98,7 +98,7 @@ class GridFieldSortableHeader implements GridField_HTMLProvider, GridField_DataM
 			}
 			if($title && $gridField->getList()->canSortBy($columnField)) {
 				$dir = 'asc';
-				if($state->SortColumn == $columnField && $state->SortDirection == 'asc') {
+				if($state->SortColumn(null) == $columnField && $state->SortDirection('asc') == 'asc') {
 					$dir = 'desc';
 				}
 				
@@ -107,10 +107,10 @@ class GridFieldSortableHeader implements GridField_HTMLProvider, GridField_DataM
 					"sort$dir", array('SortColumn' => $columnField)
 				)->addExtraClass('ss-gridfield-sort');
 
-				if($state->SortColumn == $columnField){
+				if($state->SortColumn(null) == $columnField){
 					$field->addExtraClass('ss-gridfield-sorted');
 
-					if($state->SortDirection == 'asc')
+					if($state->SortDirection('asc') == 'asc')
 						$field->addExtraClass('ss-gridfield-sorted-asc');
 					else
 						$field->addExtraClass('ss-gridfield-sorted-desc');
@@ -165,9 +165,10 @@ class GridFieldSortableHeader implements GridField_HTMLProvider, GridField_DataM
 		if(!$this->checkDataType($dataList)) return $dataList;
 
 		$state = $gridField->State->GridFieldSortableHeader;
-		if ($state->SortColumn == "") {
+		$sortColumn = $state->SortColumn();
+		if (empty($sortcolumn)) {
 			return $dataList;
 		}
-		return $dataList->sort($state->SortColumn, $state->SortDirection);
+		return $dataList->sort($sortColumn, $state->SortDirection('asc'));
 	}
 }

--- a/forms/gridfield/GridState.php
+++ b/forms/gridfield/GridState.php
@@ -59,7 +59,7 @@ class GridState extends HiddenField {
 	}
 	
 	/**
-	 * @var GridState_Data
+	 * @return GridState_Data
 	 */
 	public function getData() {
 		if(!$this->data) {
@@ -136,8 +136,25 @@ class GridState_Data {
 	}
 	
 	public function __get($name) {
-		if(!isset($this->data[$name])) {
-			$this->data[$name] = new GridState_Data();
+		return $this->getData($name, new GridState_Data());
+	}
+	
+	public function __call($name, $arguments) {
+		// Assume first parameter is default value
+		$default = empty($arguments) ? new GridState_Data() : $arguments[0];
+		return $this->getData($name, $default);
+	}
+	
+	/**
+	 * Retrieve the value for the given key
+	 * 
+	 * @param string $name The name of the value to retrieve
+	 * @param mixed $default Default value to assign if not set
+	 * @return mixed The value associated with this key, or the value specified by $default if not set
+	 */
+	public function getData($name, $default = null) {
+		if(empty($this->data[$name])) {
+			$this->data[$name] = $default;
 		} else if(is_array($this->data[$name])) {
 			$this->data[$name] = new GridState_Data($this->data[$name]);
 		}

--- a/tests/forms/GridFieldTest.php
+++ b/tests/forms/GridFieldTest.php
@@ -106,6 +106,30 @@ class GridFieldTest extends SapphireTest {
 		$this->assertTrue($obj->getState() instanceof GridState_Data);
 		$this->assertTrue($obj->getState(false) instanceof GridState);
 	}
+	
+	/**
+	 * Tests usage of nested GridState values
+	 * 
+	 * @covers GridState_Data::__get
+	 * @covers GridState_Data::__call
+	 * @covers GridState_Data::getData
+	 */
+	public function testGetStateData() {
+		$obj = new GridField('testfield', 'testfield');
+		
+		// Check value persistance
+		$this->assertEquals(15, $obj->State->NoValue(15));
+		$this->assertEquals(15, $obj->State->NoValue(-1));
+		$obj->State->NoValue = 10;
+		$this->assertEquals(10, $obj->State->NoValue);
+		$this->assertEquals(10, $obj->State->NoValue(20));
+		
+		// Check nested values
+		$this->assertInstanceOf('GridState_Data', $obj->State->Nested);
+		$this->assertInstanceOf('GridState_Data', $obj->State->Nested->DeeperNested());
+		$this->assertEquals(3, $obj->State->Nested->DataValue(3));
+		$this->assertEquals(10, $obj->State->Nested->DeeperNested->DataValue(10));
+	}
 
 	/**
 	 * @covers GridField::getColumns


### PR DESCRIPTION
With this fix it's now possible to define a default value for any `GridState` keys. Currently, attempting to retrieve a key from the `GridState` for the first time returns a `GridState_Data` object; Not very useful if you are expecting a `DataObject` ID or string value.

This fix also adds value by allowing keys to be retrieved using the `__call` magic function, meaning that the `$state->Sort` field could also be accessed with `$state->Sort()`, optionally being passed a parameter to specify a reasonable default value (e.g. `$state->Sort('asc')`). If Sort isn't yet defined you'll get `'asc'` as a returned value instead of a `GridState_Data` object, which would make no sense in this context. This will remain the default default if nothing is specified (so that calling it as a field or a parameterless method are symmetrical).

https://github.com/silverstripe/silverstripe-framework/pull/1360 depends on this fix, because up until now `DataObject::get_by_id` has been sent lots of `GridState_Data` values as IDs, and it's not really pragmatic to have to check for empty and non-value type IDs being sent into the parametrised query interface (especially since at times these could be valid parameters, such as when a BLOB or a `SQLConditionGroup` object are used).

I've also trimmed some dead code from `GridFieldAddExistingAutocompleter` which wasn't doing (or able to do) anything.

I've added the phpdoc for $State to GridField for better IDE auto-completion.
