### PR TITLE
Change default message to be credential agnostic.

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -348,7 +348,7 @@ en:
     ERRORLOCKEDOUT2: 'Your account has been temporarily disabled because of too many failed attempts at logging in. Please try again in {count} minutes.'
     ERRORNEWPASSWORD: 'You have entered your new password differently, try again'
     ERRORPASSWORDNOTMATCH: 'Your current password does not match, please try again'
-    ERRORWRONGCRED: 'That doesn''t seem to be the right e-mail address or password. Please try again.'
+    ERRORWRONGCRED: 'The provided details don''t seem to be correct. Please try again.'
     FIRSTNAME: 'First Name'
     INTERFACELANG: 'Interface Language'
     INVALIDNEWPASSWORD: 'We couldn''t accept that password: {password}'

--- a/security/Member.php
+++ b/security/Member.php
@@ -229,9 +229,10 @@ class Member extends DataObject implements TemplateGlobalProvider {
 
 		$e = PasswordEncryptor::create_for_algorithm($this->PasswordEncryption);
 		if(!$e->check($this->Password, $password, $this->Salt, $this)) {
+			$iidentifierField = 
 			$result->error(_t (
-				'Member.ERRORWRONGCRED',
-				'That doesn\'t seem to be the right e-mail address or password. Please try again.'
+				'Member.ERRORWRONGCREDS',
+				'The provided details don\'t seem to be correct. Please try again.'
 			));
 		}
 


### PR DESCRIPTION
Member.unique_identifier_field allows you to set the login option to other fields from email. In this case we're using store ID reference number and code. This updates the error message to be agnostic to the login fields.

I considered using sprintf + nested translatable unique identifier fields but figured follow the simple is best
