### PR TITLE
Load tree parent nodes if non-existant

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -847,6 +847,7 @@ li.class-ErrorPage > a .jstree-pageicon { background-position: 0 -112px; }
 .cms-tree.multiple li > a > .jstree-icon { display: none; }
 .cms-tree.multiple li > a > .jstree-icon.jstree-checkbox { display: inline-block; }
 .cms-tree.multiple li#record-0 > a .jstree-checkbox { display: none; }
+.cms-tree.jstree-loading li#record-0 > .jstree-icon { background: url(../images/throbber.gif) top left no-repeat; }
 .cms-tree a.jstree-loading .jstree-icon { background-image: none !important; }
 .cms-tree a.jstree-loading .jstree-pageicon { background: url(../images/throbber.gif) top left no-repeat; }
 

--- a/admin/scss/_tree.scss
+++ b/admin/scss/_tree.scss
@@ -596,6 +596,12 @@ a .jstree-pageicon {
 		}
 	}
 
+	&.jstree-loading {
+		li#record-0 > .jstree-icon {
+			background: url(../images/throbber.gif) top left no-repeat;
+		}
+	}
+
 	// Show the loading indicator on the page icon rather than the default
 	// jstree icon (which is only used for its dragging handles)
 	a.jstree-loading{


### PR DESCRIPTION
This edge case can occur when a large tree is cached in HTML already,
without any nodes expanded via ajax. If a new node is added with
a parent that's not existant, it was simply placed on the root node.
This is a display bug, a full CMS refresh fixes it.

Fixes a related bug where tree causes (view) duplicates,
where the same node is rendered twice. This was due to the whole
subtree being refreshed (including the new node) through jstree's
built-in "open"/"select" events, while at the same time
creating a new node through updateNodesFromServer() callbacks.

Also added a global tree loading indication to make it clear
that the tree is still processing.

See https://github.com/silverstripe/silverstripe-cms/issues/872
