### PR TITLE
BUGFIX: make sure option with value 0 is selected

### DIFF
--- a/forms/DropdownField.php
+++ b/forms/DropdownField.php
@@ -164,7 +164,7 @@ class DropdownField extends FormField {
 					$selected = true;
 				} else {
 					// check against value, fallback to a type check comparison when !value
-					$selected = ($value) ? $value == $this->value : $value === $this->value;
+					$selected = ($value !== null) ? $value == $this->value : $value === $this->value;
 					$this->isSelected = $selected;
 				}
 				


### PR DESCRIPTION
I had the problem that if the options have numerical values of which one
is 0 (zero), the option is not selected because the check for the value
(which is zero) is false.
