### PR TITLE
BUGFIX: make sure the option is selected if value and label are 0

### DIFF
--- a/forms/DropdownField.php
+++ b/forms/DropdownField.php
@@ -163,8 +163,8 @@ class DropdownField extends FormField {
 				if($value === '' && ($this->value === '' || $this->value === null)) {
 					$selected = true;
 				} else {
-					// check against value, fallback to a type check comparison when !value
-					$selected = ($value) ? $value == $this->value : $value === $this->value;
+					// check against value, fallback to a type check comparison when !value; special case if value = 0 because 0 !== '0'
+					$selected = ($value) ? $value == $this->value : $value === $this->value || ($value === 0 && $this->value === '0');
 					$this->isSelected = $selected;
 				}
 				


### PR DESCRIPTION
$this->value is stored as string internally. In the special case that
the option value is 0, the type comparison fails to resolve 0 == '0',
see http://www.php.net/manual/en/types.comparisons.php
