### PR TITLE
$i18nLocaleDirection template placeholder

### DIFF
--- a/docs/en/topics/i18n.md
+++ b/docs/en/topics/i18n.md
@@ -61,6 +61,13 @@ To let browsers know which language they're displaying a document in, you can de
 Setting the '<html>' attribute is the most commonly used technique. There are other ways to specify content languages
 (meta tags, HTTP headers), explained in this [w3.org article](http://www.w3.org/International/tutorials/language-decl/).
 
+You can also set the [script direction](http://www.w3.org/International/questions/qa-scripts), 
+which is determined by the current locale, in order to indicate the preferred flow of characters
+and default alignment of paragraphs and tables to browsers.
+
+	:::html
+	<html lang="$ContentLocale" dir="$i18nScriptDirection">
+
 ### Date and time formats
 
 Formats can be set globally in the i18n class. These settings are currently only picked up by the CMS, you'll need 

--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -2468,6 +2468,21 @@ class i18n extends Object implements TemplateGlobalProvider {
 	public static function set_default_locale($locale) {
 		self::$default_locale = $locale;
 	}
+
+	/**
+	 * Returns the script direction in format compatible with the HTML "dir" attribute.
+	 *
+	 * @see http://www.w3.org/International/tutorials/bidi-xhtml/
+	 * @param String $locale Optional locale incl. region (underscored)
+	 * @return String "rtl" or "ltr"
+	 */
+	public static function get_script_direction($locale = null) {
+		require_once 'Zend/Locale/Data.php';
+		if(!$locale) $locale = i18n::get_locale();
+		$dir = Zend_Locale_Data::getList($locale, 'layout');
+		
+		return ($dir && $dir['characters'] == 'right-to-left') ? 'rtl' : 'ltr';
+	}
 	
 	/**
 	 * Includes all available language files for a certain defined locale.
@@ -2588,6 +2603,7 @@ class i18n extends Object implements TemplateGlobalProvider {
 		return array(
 			'i18nLocale' => 'get_locale',
 			'get_locale',
+			'i18nScriptDirection' => 'get_script_direction',
 		);
 	}
 	


### PR DESCRIPTION
Optional RTL support based on Zend_Locale data.
Not set in CMS by default because it breaks the layout
quite badly without deep CSS modifications.
