### PR TITLE
Allow non-action buttons to pass through validation (fixes #2527)

### DIFF
--- a/admin/code/CMSForm.php
+++ b/admin/code/CMSForm.php
@@ -15,8 +15,9 @@ class CMSForm extends Form {
 	 * @return boolean
 	 */
 	public function validate() {
+		$buttonClicked = $this->buttonClicked();
 		return (
-			in_array($this->buttonClicked()->actionName(), $this->getValidationExemptActions())
+			($buttonClicked && in_array($buttonClicked->actionName(), $this->getValidationExemptActions()))
 			|| parent::validate()
 		);
 	}


### PR DESCRIPTION
The specific example for this issue is usage of `InlineFormField` in translatable - results in `call to actionName() on non-object` error. See #2527 for context.

This fixes #2527, but that issue brought up a wider issue that you can't use `setValidationExemptActions()` on `InlineFormAction` or any `FormAction`s that aren't passed into the main 'actions' `FieldList` when constructing the form.
