### PR TITLE
Strip duplicate querystrings from the url before adding document.location.search

### DIFF
--- a/admin/javascript/LeftAndMain.Content.js
+++ b/admin/javascript/LeftAndMain.Content.js
@@ -60,6 +60,9 @@
 
 					var url = $(node).find('a:first').attr('href');
 					if(url && url != '#') {
+						// strip possible querystrings from the url to avoid duplicateing document.location.search
+						url = url.split('?')[0];
+						
 						// Deselect all nodes (will be reselected after load according to form state)
 						self.jstree('deselect_all');
 						self.jstree('uncheck_all');


### PR DESCRIPTION
When a querystring is passed with the url (for example the Translatable locale) it is duplicated by adding document.location.search each time the content panel is reloaded, and so it should be stripped from the url first in the function doAdd().
