### PR TITLE
Allow https YouTube oEmbed URLs

### DIFF
--- a/_config/Oembed.yml
+++ b/_config/Oembed.yml
@@ -4,6 +4,8 @@ Oembed:
   providers:
     'http://*.youtube.com/watch*':
       'http://www.youtube.com/oembed/'
+    'https://*.youtube.com/watch*':
+      'https://www.youtube.com/oembed/?scheme=https'
     'http://*.flickr.com/*':
       'http://www.flickr.com/services/oembed/'
     'http://*.viddler.com/*':


### PR DESCRIPTION
YouTube's oEmbed service supports a ?scheme=https parameter for https URLs. Currently, any embedded YouTube videos result in content policy errors as they're returned from oEmbed as http. See https://groups.google.com/forum/?fromgroups#!topic/youtube-api-gdata/S9Fa-Zw2Ma8
