### PR TITLE
BUG: Fixes #2547 a undefined error for $originalDisplayErrorsValue

### DIFF
--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -19,17 +19,17 @@ ini_set('mysql.connect_timeout', 5);
 // Don't die half was through installation; that does more harm than good
 ini_set('max_execution_time', 0);
 
-// set display_errors php setting to on to force installer to avoid blank screen of death.
-// get the original value so it can be used in PHP requirement checks later in this script.
-$originalDisplayErrorsValue = ini_get('display_errors');
-ini_set('display_errors', '1');
-
 error_reporting(E_ALL | E_STRICT);
 
 // Attempt to start a session so that the username and password can be sent back to the user.
 if (function_exists('session_start') && !session_id()) {
 	session_start();
+	// get the original value so it can be used in PHP requirement checks later in this script.
+	$_SESSION['originalDisplayErrorsValue'] = ini_get('display_errors');
 }
+// set display_errors php setting to on to force installer to avoid blank screen of death.
+ini_set('display_errors', '1');
+
 
 /**
  * Include _ss_environment.php file
@@ -507,8 +507,8 @@ class InstallRequirements {
 
 		// special case for display_errors, check the original value before
 		// it was changed at the start of this script.
-		if($settingName = 'display_errors') {
-			$val = $originalDisplayErrorsValue;
+		if($settingName = 'display_errors' && isset($_SESSION['originalDisplayErrorsValue'])) {
+			$val = $_SESSION['originalDisplayErrorsValue'];
 		} else {
 			$val = ini_get($settingName);
 		}


### PR DESCRIPTION
The changes made in commit dd49834 to install.php5 make use of the variable $originalDisplayErrorsValue in the function suggestPHPSetting
However as this variable will be out of scope in the function the following undefined error is being displayed on the install page

Notice: Undefined variable: originalDisplayErrorsValue in /opt/local/apache2/htdocs/campaignmonitor/framework/dev/install/install.php5 on line 511

This pull request which will store this value in a session could use a global variable but I would prefer not too even for a install script which is only used once then deleted, but I am open to suggestions and comments if anyone has a better suggestion.
