### PR TITLE
HTML attr encoding for UploadField config

### DIFF
--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -1000,7 +1000,7 @@ class UploadField extends FileField {
 		
 		$mergedConfig = array_merge($config, $this->ufConfig);
 		return $this->customise(array(
-			'configString' => str_replace('"', "'", Convert::raw2json($mergedConfig)),
+			'configString' => str_replace('"', "&quot;", Convert::raw2json($mergedConfig)),
 			'config' => new ArrayData($mergedConfig),
 			'multiple' => $allowedMaxFileNumber !== 1
 		))->renderWith($this->getTemplates());

--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -151,9 +151,9 @@
 			
 				if(this.is('.readonly,.disabled')) return;
 
-				var fileInput = this.find('input[type=file]');
+				var fileInput = this.find('.ss-uploadfield-fromcomputer-fileinput');
 				var dropZone = this.find('.ss-uploadfield-dropzone');
-				var config = $.parseJSON(fileInput.data('config').replace(/'/g,'"'));				
+				var config = fileInput.data('config');
 				
 				/* Attach classes to dropzone when element can be dropped*/
 				$(document).unbind('dragover');
@@ -180,8 +180,6 @@
 				$(document).bind('drop dragover', function (e){					
 					e.preventDefault(); 
 				});
-
-
 
 				this.setConfig(config);
 				this.fileupload($.extend(true, 

--- a/templates/UploadField.ss
+++ b/templates/UploadField.ss
@@ -52,6 +52,8 @@
 					<% _t('UploadField.FROMCOMPUTER', 'From your computer') %>
 					<input id="$id" name="{$Name}[Uploads][]" class="$extraClass ss-uploadfield-fromcomputer-fileinput" data-config="$configString" type="file"<% if $multiple %> multiple="multiple"<% end_if %> />
 				</label>
+			<% else %>
+				<input id="$id" name="{$Name}[Uploads][]" class="$extraClass ss-uploadfield-fromcomputer-fileinput" data-config="$configString" type="hidden" />
 			<% end_if %>
 
 			<% if $canAttachExisting %>


### PR DESCRIPTION
Also fixed UploadField operation with canUpload=false, which broke the JS
because no config could be found, since the <input> field wasn't present. We
can't put the data-config attribute on the field holder, since fields can be
rendered without their field holder through FormField->SmalLFieldHolder().

Fixes https://github.com/silverstripe/silverstripe-cms/issues/874
