### PR TITLE
Making cacheToFile  key more resilient against mixed/nested types

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -1066,7 +1066,7 @@ abstract class Object {
 		if(!is_array($arguments)) $arguments = array($arguments);
 		
 		if($ID) $cacheName .= '_' . $ID;
-		if(count($arguments)) $cacheName .= '_' . implode('_', $arguments);
+		if(count($arguments)) $cacheName .= '_' . md5(serialize($arguments));
 		
 		if($data = $this->loadCache($cacheName, $lifetime)) {
 			return $data;
@@ -1085,7 +1085,7 @@ abstract class Object {
 		$cacheName = $this->class . '_' . $method;
 		if(!is_array($arguments)) $arguments = array($arguments);
 		if($ID) $cacheName .= '_' . $ID;
-		if(count($arguments)) $cacheName .= '_' . implode('_', $arguments);
+		if(count($arguments)) $cacheName .= '_' . md5(serialize($arguments));
 
 		$file = TEMP_FOLDER . '/' . $this->sanitiseCachename($cacheName);
 		if(file_exists($file)) unlink($file);


### PR DESCRIPTION
Previously if you passed in a nested array, or perhaps an array of objects, the implode call would throw an E_NOTICE error with an array to string conversion.

This method is more robust by giving a generally shorter file name length, and by ensuring we always get a string out of any kind of arguments passed in.
