### PR TITLE
BUG Less misuse of error control operator (@)

### DIFF
--- a/dev/Backtrace.php
+++ b/dev/Backtrace.php
@@ -90,7 +90,7 @@ class SS_Backtrace {
 		// Filter out arguments
 		foreach($bt as $i => $frame) {
 			$match = false;
-			if(@$bt[$i]['class']) {
+			if(!empty($bt[$i]['class'])) {
 				foreach($ignoredArgs as $fnSpec) {
 					if(is_array($fnSpec) && $bt[$i]['class'] == $fnSpec[0] && $bt[$i]['function'] == $fnSpec[1]) {
 						$match = true;

--- a/dev/Log.php
+++ b/dev/Log.php
@@ -94,7 +94,7 @@ class SS_Log {
 			// Add default context (shouldn't change until the actual log event happens)
 			foreach(static::$log_globals as $globalName => $keys) {
 				foreach($keys as $key) {
-					$val = @$GLOBALS[$globalName][$key];
+					$val = isset($GLOBALS[$globalName][$key]) ? $GLOBALS[$globalName][$key] : null;
 					static::$logger->setEventItem(sprintf('$%s[\'%s\']', $globalName, $key), $val);
 				}
 			}


### PR DESCRIPTION
This is necessary to prevent get_last_error() from returning suppressed errors when retrieving values from nested arrays.

I would not expect this would be the case, but it came up surprisingly while I was writing some error handling code.
