### PR TITLE
FIX 5284: Prevent crash for lager images.

### DIFF
--- a/filesystem/GD.php
+++ b/filesystem/GD.php
@@ -27,7 +27,31 @@ class GDBackend extends Object implements Image_Backend {
 		}
 	}
 
+	/**
+	 * @param filename string The filename of the image
+	 * @param height int The height of the image
+	 * @return boolean true if the image might fit in memory, false otherwise
+	 */
+	private static function image_fits_available_memory($filename) {
+		$imageInfo = getimagesize($filename);
+		$memory_limit = translate_memstring(ini_get('memory_limit'));
+		//bytes per channel (round up, default 1) * channels (default 4 rgba).
+		$bytes_per_pixel = (isset($imageInfo['bits']) ? ($imageInfo['bits']+7)/8 : 1)
+			* (isset($imageInfo['channels']) ? $imageInfo['channels'] : 4);
+		//number of pixels (width * height) * bytes per pixel
+		$memory_required = $imageInfo[0]*$imageInfo[1]*$bytes_per_pixel;
+		return $memory_needed + memory_get_usage() < $memory_limit;
+	}
+	
+	private static function get_lockfile_name($filename) {
+		$pathInfo = pathinfo($filename);
+		return $pathInfo['dirname'] . '.lock.' . $pathInfo['filename'];
+	}
+
 	public function __construct($filename = null) {
+		// Check for _lock file, if it exists we crashed while opening this file --> do not try again 
+		if(file_exists(self::get_lockfile_name($filename)) || !self::image_fits_available_memory($filename)) return;
+		fclose(fopen(self::get_lockfile_name($filename), 'w')); //create .lock file
 		// If we're working with image resampling, things could take a while.  Bump up the time-limit
 		increase_time_limit_to(300);
 
@@ -53,6 +77,7 @@ class GDBackend extends Object implements Image_Backend {
 			}
 		}
 		
+		unlink(self::get_lockfile_name($filename)); //opening the file was successfull --> delete the _lock file. 
 		parent::__construct();
 
 		$this->quality = $this->config()->default_quality;

--- a/model/Image.php
+++ b/model/Image.php
@@ -644,6 +644,9 @@ class Image extends File {
 	protected function onBeforeDelete() {
 		parent::onBeforeDelete(); 
 
+		$pathInfo = pathinfo($this->getFullPath());
+		$lockfile = $pathInfo['dirname'] . '.lock.' . $pathInfo['filename'];
+		if(file_exists($lockfile)) unlink($lockfile);
 		$this->deleteFormattedImages();
 	}
 }

--- a/tests/model/ImageTest.php
+++ b/tests/model/ImageTest.php
@@ -214,4 +214,14 @@ class ImageTest extends SapphireTest {
 		$secondImagePath = $secondImage->getRelativePath();
 		$this->assertEquals($secondImagePath, $secondImage->Filename);
 	}
+
+	public function testLockfileRemovalOnImageDelete() {
+		$testFile = $this->objFromFixture('Image', 'deletion_test_image');
+		$pathInfo = pathinfo($testFile->getFullPath());
+		$lockfile = $pathInfo['dirname'] . '.lock.' . $pathInfo['filename'];
+		fclose(fopen($lockfile, 'w')); //create .lock file
+		$this->assertTrue(file_exists($lockfile));
+		$testFile->delete();
+		$this->assertFalse(file_exists($lockfile));
+	}
 }

--- a/tests/model/ImageTest.yml
+++ b/tests/model/ImageTest.yml
@@ -16,3 +16,7 @@ Image:
         Title: This is a/an image Title
         Filename: assets/ImageTest/test_image).png
         Parent: =>Folder.folder1
+    deletion_test_image:
+        Title: This is a/an image Title
+        Filename: assets/ImageTest/test_image.png
+        Parent: =>Folder.folder1


### PR DESCRIPTION
Implemented check in GD that estimates the memory required to load the image and rejects larger images. Created lock files that remains after a large image has previously crashed GD.
