### PR TITLE
FulltextSearchableTest doesn't clean up after itself.

### DIFF
--- a/tests/search/FulltextSearchableTest.php
+++ b/tests/search/FulltextSearchableTest.php
@@ -8,35 +8,32 @@ class FulltextSearchableTest extends SapphireTest {
 
 	public function setUp() {
 		parent::setUp();
-		
-		$this->orig['File_searchable'] = File::has_extension('FulltextSearchable');
-		
-		// TODO This shouldn't need all arguments included
-		File::remove_extension('FulltextSearchable(\'"Filename","Title","Content"\')');
+
+		FulltextSearchable::enable('File');
 	}
-	
+
+	/**
+	 * FulltextSearchable::enable() leaves behind remains that don't get cleaned up
+	 * properly at the end of the test. This becomes apparent when a later test tries to
+	 * ALTER TABLE File and add fulltext indexes with the InnoDB table type.
+	 */
 	public function tearDown() {
-		// TODO This shouldn't need all arguments included
-		if($this->orig['File_searchable']) {
-			File::add_extension('FulltextSearchable(\'"Filename","Title","Content"\')');
-		}
-		
 		parent::tearDown();
+
+		File::remove_extension('FulltextSearchable');
+		Config::inst()->update('File', 'create_table_options', array('MySQLDatabase' => 'ENGINE=InnoDB'));
 	}
-	
+
 	public function testEnable() {
-		FulltextSearchable::enable();
 		$this->assertTrue(File::has_extension('FulltextSearchable'));
 	}
-	
+
 	public function testEnableWithCustomClasses() {
 		FulltextSearchable::enable(array('File'));
 		$this->assertTrue(File::has_extension('FulltextSearchable'));
 
-		// TODO This shouldn't need all arguments included
-		File::remove_extension('FulltextSearchable(\'"Filename","Title","Content"\')');
-		
+		File::remove_extension('FulltextSearchable');
 		$this->assertFalse(File::has_extension('FulltextSearchable'));
 	}
-	
+
 }


### PR DESCRIPTION
The extension doesn't get unloaded correctly at the end of the test,
resulting in tests afterwards sometimes failing because the table
type is reset back to InnoDB.

See silverstripe/silverstripe-cms ed8ee4e9b for a similar fix done
in the cms module.
