### PR TITLE
GridField 'Add existing' action styling improvements (fixes #2567)

### DIFF
--- a/css/GridField.css
+++ b/css/GridField.css
@@ -30,10 +30,10 @@ Used in side panels and action tabs
 .cms .ss-gridfield .ss-gridfield-buttonrow { font-size: 14.4px; }
 .cms .ss-gridfield .grid-levelup { text-indent: -9999em; margin-bottom: 6px; }
 .cms .ss-gridfield .grid-levelup a.list-parent-link { background: transparent url(../images/gridfield-level-up.png) no-repeat 0 0; display: block; }
-.cms .ss-gridfield .add-existing-autocompleter { width: 500px; }
-.cms .ss-gridfield .add-existing-autocompleter span { display: -moz-inline-stack; display: inline-block; vertical-align: top; *vertical-align: auto; zoom: 1; *display: inline; }
-.cms .ss-gridfield .add-existing-autocompleter input.relation-search { width: 270px; margin-bottom: 12px; }
-.cms .ss-gridfield .grid-csv-button, .cms .ss-gridfield .grid-print-button { font-size: 12px; margin-bottom: 0; display: -moz-inline-stack; display: inline-block; vertical-align: middle; *vertical-align: auto; zoom: 1; *display: inline; }
+.cms .ss-gridfield .add-existing-autocompleter span { float: left; display: -moz-inline-stack; display: inline-block; vertical-align: top; *vertical-align: auto; zoom: 1; *display: inline; }
+.cms .ss-gridfield .add-existing-autocompleter input.relation-search { width: 270px; height: 32px; margin-bottom: 12px; border-top-right-radius: 0; border-bottom-right-radius: 0; }
+.cms .ss-gridfield .add-existing-autocompleter button#action_gridfield_relationadd { height: 32px; margin-left: 0; border-top-left-radius: 0; border-bottom-left-radius: 0; border-left: none; }
+.cms .ss-gridfield .grid-csv-button, .cms .ss-gridfield .grid-print-button { margin-bottom: 0; font-size: 12px; display: -moz-inline-stack; display: inline-block; vertical-align: middle; *vertical-align: auto; zoom: 1; *display: inline; }
 .cms table.ss-gridfield-table { display: table; -moz-box-shadow: none; -webkit-box-shadow: none; box-shadow: none; padding: 0; border-collapse: separate; border-bottom: 0 none; width: 100%; }
 .cms table.ss-gridfield-table thead { color: #323e46; background: transparent; }
 .cms table.ss-gridfield-table thead tr.filter-header .fieldgroup { max-width: 512px; }

--- a/forms/gridfield/GridFieldConfig.php
+++ b/forms/gridfield/GridFieldConfig.php
@@ -236,7 +236,7 @@ class GridFieldConfig_RelationEditor extends GridFieldConfig {
 		
 		$this->addComponent(new GridFieldButtonRow('before'));
 		$this->addComponent(new GridFieldAddNewButton('buttons-before-left'));
-		$this->addComponent(new GridFieldAddExistingAutocompleter('buttons-before-left'));
+		$this->addComponent(new GridFieldAddExistingAutocompleter('buttons-before-right'));
 		$this->addComponent(new GridFieldToolbarHeader());
 		$this->addComponent($sort = new GridFieldSortableHeader());
 		$this->addComponent($filter = new GridFieldFilterHeader());

--- a/scss/GridField.scss
+++ b/scss/GridField.scss
@@ -118,14 +118,23 @@ $gf_grid_x:	16px;
 			margin-bottom: 6px;
 		}
 		.add-existing-autocompleter {
-			span {															
+			span {
+				float: left;		
 				@include inline-block(top);
 			}
 			input.relation-search {
-				width: 270px;
+				width: 270px; height: 32px;
 				margin-bottom: $gf_grid_y;
+				border-top-right-radius: 0;
+				border-bottom-right-radius: 0;
 			}
-			width: 500px;
+			button#action_gridfield_relationadd {
+				height: 32px;
+				margin-left: 0; // Webkit needs this
+				border-top-left-radius: 0;
+				border-bottom-left-radius: 0;
+				border-left: none;
+			}
 		}
 		.grid-csv-button, .grid-print-button {
 			margin-bottom: 0;


### PR DESCRIPTION
https://github.com/silverstripe/silverstripe-framework/issues/2567

Tested in IE8, Win/Mac Chrome, Mac FF, Mac Safari. I don't have a copy of IE9 to test on unfortunately.

Before:
![screen shot 2013-10-22 at 16 02 06](https://f.cloud.github.com/assets/1655548/1382637/2b5ba320-3b31-11e3-8055-24409d435fa1.png)

After:
![screen shot 2013-10-22 at 16 40 42](https://f.cloud.github.com/assets/1655548/1382651/3e8c9fb2-3b31-11e3-8eae-152ac05aa5f8.png)
![screen shot 2013-10-22 at 16 40 50](https://f.cloud.github.com/assets/1655548/1382655/4486fa20-3b31-11e3-9cc5-f61ce684297d.png)

After in IE8:
![screen shot 2013-10-22 at 16 41 07](https://f.cloud.github.com/assets/1655548/1382657/4a44055c-3b31-11e3-87a2-9768c321b9f2.png)
![screen shot 2013-10-22 at 16 41 15](https://f.cloud.github.com/assets/1655548/1382659/53346e86-3b31-11e3-9fed-e58a51985db1.png)
