### PR TITLE
BUG Debug error handler breaks error_get_last

### DIFF
--- a/dev/Debug.php
+++ b/dev/Debug.php
@@ -429,6 +429,7 @@ class Debug {
 		}
 		$reporter->writeTrace(($errcontext ? $errcontext : debug_backtrace()));
 		$reporter->writeFooter();
+		return false;
 	}
 	
 	/**


### PR DESCRIPTION
I've tracked down a critical issue in Debug which makes error recovery impossible in CLI.

In certain situations it's necessary to have error recovery behaviour (through either `register_shutdown_function` or detecting errors with `error_get_last`). This is also critical to the successful recovery for `ErrorControlChain`, which relies on both to correctly respond to errors.

The problem is that `error_get_last` is documented as returning null if the error handler (set by `set_error_handler`, as the `Debug` class does) does not return false.

Checking `Debug.php` I find that `fatalHandler` does not return false in cli_mode. See https://github.com/silverstripe/silverstripe-framework/blob/3.1/dev/Debug.php#L338 and https://github.com/silverstripe/silverstripe-framework/blob/3.1/dev/Debug.php#L426.

`Debug::showError` doesn't return anything; which is not the same as returning false. This means that the error is printed out to the screen (which is great, thanks) but then `error_get_last` lies about there not being an error. That bastard!

I think this is a serious issue with 3.1 as this currently means that error recover is difficult without completely disabling the Debug error handler and rolling your own.

This fix adds a `return false;` to the end of `Debug::showError`, meaning that all error handling paths return false explicitly.

Can someone please explain if the current behaviour is in place intentionally? If so, can it please be explained how an error handled by fatalError in CLI be detected?