### PR TITLE
API TinyMCE contextmenu is disabled by default

### DIFF
--- a/admin/_config.php
+++ b/admin/_config.php
@@ -29,6 +29,8 @@ HtmlEditorConfig::get('cms')->setOptions(array(
 		. "object[width|height|data|type],param[name|value],map[class|name|id],area[shape|coords|href|target|alt]"
 ));
 
+HtmlEditorConfig::get('cms')->disablePlugins('contextmenu');
+
 HtmlEditorConfig::get('cms')->enablePlugins('media', 'fullscreen', 'inlinepopups');
 HtmlEditorConfig::get('cms')->enablePlugins(array(
 	'ssbuttons' => sprintf('../../../%s/tinymce_ssbuttons/editor_plugin_src.js', THIRDPARTY_DIR)


### PR DESCRIPTION
Allows for built-in browser spell-check to be used via right click menu. Makes sense since #2288 was merged, otherwise browser would highlight spell error but nothing could be done about it.
