### PR TITLE
FIX: Automatically select appropriate tab based on URL hash (fixes #1964)

### DIFF
--- a/javascript/TabSet.js
+++ b/javascript/TabSet.js
@@ -9,6 +9,11 @@
 			onadd: function() {
 				// Can't name redraw() as it clashes with other CMS entwine classes
 				this.redrawTabs();
+				if(document.location.hash!='') {
+					//get the index from URL hash
+					tabSelect = document.location.hash.substr(1,document.location.hash.length);
+					this.tabs('select', tabSelect);
+				}
 				this._super();
 			},
 			onremove: function() {


### PR DESCRIPTION
DO NOT MERGE. Need to confirm this doesn't alter behaviour elsewhere.

This will automatically open tabs based upon the hash present in the URL. As this is to address an issue with `SecurityAdmin` (I've not seen this issue raised for any other reason), perhaps this would be better placed in a `SecurityAdmin.js` file?
