### PR TITLE
i18nSSLegacyAdapterTest setting wrong arguments for manifest.

### DIFF
--- a/tests/i18n/i18nSSLegacyAdapterTest.php
+++ b/tests/i18n/i18nSSLegacyAdapterTest.php
@@ -21,7 +21,7 @@ class i18nSSLegacyAdapterTest extends SapphireTest {
 		$this->_oldTheme = Config::inst()->get('SSViewer', 'theme');
 		Config::inst()->update('SSViewer', 'theme', 'testtheme1');
 		
-		$classManifest = new SS_ClassManifest($this->alternateBasePath, null, true, true, false);
+		$classManifest = new SS_ClassManifest($this->alternateBasePath, false, true, false);
 		SS_ClassLoader::instance()->pushManifest($classManifest);
 
 		$this->originalLocale = i18n::get_locale();


### PR DESCRIPTION
Currently if you run i18nSSLegacyAdapterTest twice in a row you
get errors about classes not existing, because the class manifest
doesn't get set correctly during the test setUp() method.
