### PR TITLE
BUG / API - Change tracking for UploadField

### DIFF
--- a/admin/javascript/jquery-changetracker/lib/jquery.changetracker.js
+++ b/admin/javascript/jquery-changetracker/lib/jquery.changetracker.js
@@ -55,6 +55,9 @@
 			// optional metadata plugin support
 			if ($.meta) options = $.extend({}, options, this.data());
 
+			// Flag indicating this form was dirtied by an external component
+			var dirty = false;
+
 			var onchange = function(e) {
 				var $field = $(e.target);
 				var origVal = $field.data('changetracker.origVal'), newVal;
@@ -76,8 +79,8 @@
 					if($field.is(':radio')) {
 						self.find(':radio[name=' + $field.attr('name') + ']').removeClass(options.changedCssClass);
 					}
-					// Only unset form state if no other fields are changed as well
-					if(!self.getFields().filter('.' + options.changedCssClass).length) {
+					// Only unset form state if no other fields are changed as well and the form isn't explicitly dirty
+					if(!dirty && !self.getFields().filter('.' + options.changedCssClass).length) {
 						self.removeClass(options.changedCssClass);
 					}
 				}
@@ -95,6 +98,11 @@
 				}
 				$(this).data('changetracker.origVal', origVal);
 			});
+			
+			self.bind('dirty.changetracker', function() {
+				dirty = true;
+				self.addClass(options.changedCssClass);
+			});
 
 			this.data('changetracker', true);
 		};
@@ -104,7 +112,8 @@
 				.unbind('.changetracker')
 				.removeClass(options.changedCssClass)
 				.removeData('changetracker.origVal');
-			this.removeData('changetracker');
+			this.unbind('.changetracker')
+				.removeData('changetracker');
 		};
 			
 		/**
@@ -137,13 +146,13 @@
 
 		// Support invoking "public" methods as string arguments
 		if (typeof arguments[0] === 'string') {  
-      var property = arguments[1];  
-      var args = Array.prototype.slice.call(arguments);  
-      args.splice(0, 1);  
-      return this[arguments[0]].apply(this, args);  
-  	} else {
-    	return this.initialize();
-    }
+			var property = arguments[1];  
+			var args = Array.prototype.slice.call(arguments);  
+			args.splice(0, 1);  
+			return this[arguments[0]].apply(this, args);  
+		} else {
+			return this.initialize();
+		}
 		
 	};
 }(jQuery));

--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -48,6 +48,11 @@
 
 			return result;
 		},
+		_onDone: function (result, textStatus, jqXHR, options) {
+			// Mark form as dirty on completion of successful upload
+			this.element.closest('form').trigger('dirty');
+			$.blueimpUI.fileupload.prototype._onDone.call(this, result, textStatus, jqXHR, options);
+		},
 		_onSend: function (e, data) {
 			//check the array of existing files to see if we are trying to upload a file that already exists
 			var that = this;
@@ -98,6 +103,7 @@
 			this._adjustMaxNumberOfFiles(0);
 		},
 		attach: function(data) {
+			this.element.closest('form').trigger('dirty');
 
 			// Handles attachment of already uploaded files, similar to add
 			var self = this,
@@ -340,6 +346,7 @@
 				
 				if(this.is('.ss-uploadfield-item-delete')) {
 					if(confirm(ss.i18n._t('UploadField.ConfirmDelete'))) {
+						this.closest('form').trigger('dirty');
 						fileupload._trigger('destroy', e, {
 							context: item,
 							url: this.data('href'),
@@ -349,6 +356,7 @@
 					}
 				} else {
 					// Removed files will be applied to object on save
+					this.closest('form').trigger('dirty');
 					fileupload._trigger('destroy', e, {context: item});	
 				}
 				


### PR DESCRIPTION
This fix builds on top of the kind work done by @TomSpeak at https://github.com/silverstripe/silverstripe-framework/pull/2305

I've extended the jquery change tracker plugin to allow the form to be set to dirty. This means it can be told to stay dirty, even if it detects it's original fields haven't changed. This is necessary because some fields can be added to the form after initialisation. Another approach would be to detect changes to the form, but this would require a massive rewrite of jquery.changetracker. This approach does not allow for any un-dirtying of the form, so it's a one way only.

UploadField now communicates with the form by sending the 'dirty' event rather than adding the changed class. This is necessary because otherwise further form updates would remove the change class if a field is typed in, but then reverted to the original.

The logic in UploadField also attempts to avoid unnecessary changes (such as uploading a file that already exists, and the user cancels the upload after the file exists notification).
