### PR TITLE
FIX Sanitize SS_HTTPResponse_Exception body (fixes #2597)

### DIFF
--- a/control/RequestHandler.php
+++ b/control/RequestHandler.php
@@ -365,10 +365,6 @@ class RequestHandler extends ViewableData {
 	 */
 	public function httpError($errorCode, $errorMessage = null) {
 		$e = new SS_HTTPResponse_Exception($errorMessage, $errorCode);
-
-		// Error responses should always be considered plaintext, for security reasons
-		$e->getResponse()->addHeader('Content-Type', 'text/plain');
-
 		throw $e;
 	}
 


### PR DESCRIPTION
Edge case XSS prevention: The body is forced to a text/plain content type, but
proxies modifying the HTTP response or content sniffing user agents might
cause the body to be interpreted as HTML anyway.

Moved text/plain header setting into the SS_HTTPResponse_Exception constructor 
in order to ensure its consistently applied.

Note: SS_HTTPResponse_Exception is mainly used through
RequestHandler->httpError()

Thanks to Nathan Brauer for reporting.
