### PR TITLE
FIX Sanitize SS_HTTPResponse_Exception body (fixes #2597)

### DIFF
--- a/core/control/HTTPResponse.php
+++ b/core/control/HTTPResponse.php
@@ -292,17 +292,27 @@ class SS_HTTPResponse_Exception extends Exception {
 	protected $response;
 	
 	/**
-	 * @see SS_HTTPResponse::__construct();
+	 * @param String $body Plaintext message (exposed to the user agent)
+	 * @param int $statusCode
+	 * @param String $statusDescription Plaintext HTTP status description
 	 */
-	 public function __construct($body = null, $statusCode = null, $statusDescription = null) {
-	 	if($body instanceof SS_HTTPResponse) {
-	 		$this->setResponse($body);
-	 	} else {
-	 		$this->setResponse(new SS_HTTPResponse($body, $statusCode, $statusDescription));
-	 	}
-	 	
-	 	parent::__construct($this->getResponse()->getBody(), $this->getResponse()->getStatusCode());
-	 }
+	public function __construct($body = null, $statusCode = null, $statusDescription = null) {
+		// Sanitize body text. Sets plaintext content-type further down,
+		// but further prevent XSS through servers modifying the HTTP response,
+		// as well as user agents doing content sniffing.
+		if($body instanceof SS_HTTPResponse) {
+			$body->setBody(strip_tags($body->getBody()));
+			$this->setResponse($body);
+		} else {
+			$body = strip_tags($body);
+			$this->setResponse(new SS_HTTPResponse($body, $statusCode, $statusDescription));
+		}
+
+		// Error responses should always be considered plaintext, for security reasons
+		$this->getResponse()->addHeader('Content-Type', 'text/plain');
+		
+		parent::__construct($this->getResponse()->getBody(), $this->getResponse()->getStatusCode());
+	}
 	 
 	 /**
 	  * @return SS_HTTPResponse

--- a/core/control/RequestHandler.php
+++ b/core/control/RequestHandler.php
@@ -323,10 +323,6 @@ class RequestHandler extends ViewableData {
 	 */
 	public function httpError($errorCode, $errorMessage = null) {
 		$e = new SS_HTTPResponse_Exception($errorMessage, $errorCode);
-
-		// Error responses should always be considered plaintext, for security reasons
-		$e->getResponse()->addHeader('Content-Type', 'text/plain');
-
 		throw $e;
 	}
 
@@ -338,4 +334,4 @@ class RequestHandler extends ViewableData {
 	function getRequest() {
 		return $this->request;
 	}
-	}
+}


### PR DESCRIPTION
(can be merged upwards to 3.0 and 3.1 as well)

Edge case XSS prevention: The body is forced to a text/plain content type,
but proxies modifying the HTTP response or content sniffing user agents
might cause the body to be interpreted as HTML anyway.

Moved text/plain header setting into the SS_HTTPResponse_Exception constructor
in order to ensure its consistently applied.

Note: SS_HTTPResponse_Exception is mainly used through RequestHandler->httpError()

Thanks to Nathan Brauer for reporting.
