### PR TITLE
Default UploadField to replace files

### DIFF
--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -1147,6 +1147,11 @@ class UploadField extends FileField {
 			$fileObject = Object::create($relationClass);
 		}
 
+		// Allow replacing files (rather than renaming a duplicate) when warning about overwrites
+		if($this->getConfig('overwriteWarning')) {
+			$this->upload->setReplaceFile(true);
+		}
+
 		// Get the uploaded file into a new file object.
 		try {
 			$this->upload->loadIntoFile($tmpFile, $fileObject, $this->getFolderName());


### PR DESCRIPTION
Honours the $overwriteWarning setting, rather than warning
about overwritten files, and when that warning is acknowledged by the user,
create a new file instead. We need to set this as close to
the Upload->load() call as possible, since it depends
on non-deterministic config state.

Tested via https://github.com/silverstripe/silverstripe-cms/pull/883
