### PR TITLE
Fixed support for single stage in Versioned

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -616,7 +616,11 @@ class Versioned extends DataExtension {
 			}
 			
 			// If we're editing Live, then use (table)_Live instead of (table)
-			if(Versioned::current_stage() && Versioned::current_stage() != $this->defaultStage) {
+			if(
+				Versioned::current_stage() 
+				&& Versioned::current_stage() != $this->defaultStage
+				&& in_array(Versioned::current_stage(), $this->stages)
+			) {
 				// If the record has already been inserted in the (table), get rid of it. 
 				if($manipulation[$table]['command']=='insert') {
 					DB::query("DELETE FROM \"{$table}\" WHERE \"ID\"='$id'");


### PR DESCRIPTION
This used to work in 2.4, so is considered a regression. To test, simply add a
Versioned("Stage") extension to some record in 2.4 vs. 3.1.

/cc @nathanbrauer
