### PR TITLE
Strict type check for null cache values

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -1077,10 +1077,12 @@ abstract class Object {
 		if($ID) $cacheName .= '_' . $ID;
 		if(count($arguments)) $cacheName .= '_' . md5(serialize($arguments));
 		
-		if($data = $this->loadCache($cacheName, $lifetime)) {
+		$data = $this->loadCache($cacheName, $lifetime);
+
+		if($data !== false) {
 			return $data;
 		}
-		
+
 		$data = call_user_func_array(array($this, $method), $arguments);
 		$this->saveCache($cacheName, $data);
 		


### PR DESCRIPTION
Previously, generated cache results that returned 0, '', array() etc
were being ignored. This change narrows it down to just false.

Ideally we would use a EmptyCacheHit object to be very specific for
these cases, but perhaps this approach is a bit overkill.
