### PR TITLE
BUG Fix the password reset message to be shown consistently.

### DIFF
--- a/security/Security.php
+++ b/security/Security.php
@@ -658,9 +658,8 @@ class Security extends Controller {
 				'Form' => $this->ChangePasswordForm()));
 
 		} else {
-			// show an error message if the auto login token is invalid and the
-			// user is not logged in
-			if(!isset($_REQUEST['t']) || !$member) {
+			// Show friendly message if it seems like the user arrived here via password reset feature.
+			if(isset($_REQUEST['m']) || isset($_REQUEST['t'])) {
 				$customisedController = $controller->customise(
 					array('Content' =>
 						_t(


### PR DESCRIPTION
If we detect any of the password reset GET params, it's safe to assume
that someone intended a password reset, regardless of other conditions.
