### PR TITLE
Versioned not ignoring obsolete fields 2

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -568,9 +568,15 @@ class Versioned extends DataExtension {
 			if(!isset($manipulation[$table]['fields']['Version'])) {
 				// Add any extra, unchanged fields to the version record.
 				$data = DB::query("SELECT * FROM \"$table\" WHERE \"ID\" = $id")->record();
-				if($data) foreach($data as $k => $v) {
-					if (!isset($newManipulation['fields'][$k])) {
-						$newManipulation['fields'][$k] = "'" . Convert::raw2sql($v) . "'";
+				if ($data) {
+					$fields = DataObject::database_fields($table);
+					if (is_array($fields)) {
+						$data = array_intersect_key($data, $fields);
+						foreach ($data as $k => $v) {
+							if (!isset($newManipulation['fields'][$k])) {
+								$newManipulation['fields'][$k] = "'" . Convert::raw2sql($v) . "'";
+							}
+						}
 					}
 				}
 

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -452,6 +452,17 @@ class VersionedTest extends SapphireTest {
 		);
 	}
 
+	public function testVersionedHandlesRenamedDataObjectFields(){
+		Config::inst()->remove('VersionedTest_RelatedWithoutVersion','db','Name','Varchar');
+		Config::inst()->update('VersionedTest_RelatedWithoutVersion','db',array(
+			"NewField" => "Varchar",
+		));
+		VersionedTest_RelatedWithoutVersion::add_extension("Versioned('Stage', 'Live')");
+		$this->resetDBSchema(true);
+		$testData = new VersionedTest_RelatedWithoutVersion();
+		$testData->NewField = 'Test';
+		$testData->write();
+	}
 }
 
 


### PR DESCRIPTION
Copy of #2163 from updated branch - as requested have squashed all commits to affected code into one and added a unit test that fails prior to the fix suggested.

Useful to prevent weird errors in development where fields have been renamed and in production where old databases have been updated and old fields made obsolete, and the Versioned extension has later been applied to the dataobject. In both these cases the obsolete fields present in the core table cause an error when writing Versioned records.

### To Reproduce:

1. Create a DataObject with at least one database field
2. Perform a build
3. Remove or rename a field from the dataobject, and apply the Versioned extension to the dataobject
4. Perform another build
5. Write a new or old but changed DataObject of this type
6. A database exception is thrown

### Resolution

The branch to pull fixes the problem by filtering the list of fields returned from the core table by those known to be present in the code via a call to *DataObject::database_fields()*
