### PR TITLE
BUG onDemand plugin fixture

### DIFF
--- a/javascript/jquery-ondemand/jquery.ondemand.js
+++ b/javascript/jquery-ondemand/jquery.ondemand.js
@@ -16,7 +16,7 @@
 (function($){
 
 	var decodePath = function(str) {
-		return str.replace(/%2C/g,',').replace(/\&amp;/g, '&');
+		return str.replace(/%2C/g,',').replace(/\&amp;/g, '&').trim();
 	};
 
 	$.extend({


### PR DESCRIPTION
Added trim() to decodePath function. Headers X-Include-\* come with a space so some files are loaded few times. Looks like that depends on a webserver. Nginx has the space.

At the screenshoot you can see boolean values of console.log($.isItemLoaded(jsIncludePath)); and if it was false it displays path of a script to load. You can see that lib.js was loaded twice (actually 3 times cuz it's also in the HTML).

![screen shot 2013-10-27 at 8 08 22 am](https://f.cloud.github.com/assets/672794/1414754/aebcd23e-3ea6-11e3-97ef-ed076db5da38.png)
