### PR TITLE
Check if remote class exists in DataObject->getRemoteJoinField()

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1528,6 +1528,11 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 		if(!$remoteClass) {
 			throw new Exception("Unknown $type component '$component' on class '$this->class'");
 		}
+		if(!ClassInfo::exists(strtok($remoteClass, '.'))) {
+			throw new Exception(
+				"Class '$remoteClass' not found, but used in $type component '$component' on class '$this->class'"
+			);
+		}
 		
 		if($fieldPos = strpos($remoteClass, '.')) {
 			return substr($remoteClass, $fieldPos + 1) . 'ID';
@@ -1546,8 +1551,9 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 
 		$message = "No has_one found on class '$remoteClass'";
 		if($type == 'has_many') {
-			// include a hint for missing has_many that is missing a has_one
-			$message .= ", the has_many relation from '$this->class' to '$remoteClass' requires a has_one on '$remoteClass'";
+			// include a hint for has_many that is missing a has_one
+			$message .= ", the has_many relation from '$this->class' to '$remoteClass'";
+			$message .= " requires a has_one on '$remoteClass'";
 		}
 		throw new Exception($message);
 	}


### PR DESCRIPTION
(also fixed comment mistake)

this will improve developer experience due to an error message that makes sense (previously the error message if the class is not found was `No has_one found on class '$remoteClass', the has_many relation from '$this->class' to '$remoteClass' requires a has_one on '$remoteClass'` since the field was not found, but this can be misleading if you have a typo in your relation or your class name.

but I can't speak to performance, I can imagine that this brings a slight performance penalty since every has_one or has_many relation will do a class exists check.
Maybe we should do this sort of check in `/dev/build` instead?
