### PR TITLE
Set default encoding for compass

### DIFF
--- a/admin/config.rb
+++ b/admin/config.rb
@@ -18,3 +18,5 @@ relative_assets = true
 line_comments = false
 
 asset_cache_buster :none
+
+Encoding.default_external = "utf-8"

--- a/config.rb
+++ b/config.rb
@@ -18,3 +18,5 @@ relative_assets = true
 line_comments = false
 
 asset_cache_buster :none
+
+Encoding.default_external = "utf-8"


### PR DESCRIPTION
See https://github.com/haml/haml/issues/269 for a bit more info. Seems that OS X Mavericks causes this to occur, even when system default is set to `utf-8`.
