### PR TITLE
BUG Fix undefined index ID

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -639,7 +639,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	 * @return boolean true if this object exists
 	 */
 	public function exists() {
-		return ($this->record && $this->record['ID'] > 0);
+		return (isset($this->record['ID']) && $this->record['ID'] > 0);
 	}
 
 	/**


### PR DESCRIPTION
I have had a few odd cases where a record without a set ID would throw up PHP notices. This is a slightly more robust check.
