### PR TITLE
BUG 3.2 Issues with CMSForm not consistently respecting new form naming scheme

### DIFF
--- a/admin/code/CMSForm.php
+++ b/admin/code/CMSForm.php
@@ -86,9 +86,4 @@ class CMSForm extends Form {
 		return $this->responseNegotiator;
 	}
 
-	public function FormName() {
-		if($this->htmlID) return $this->htmlID;
-		else return 'Form_' . str_replace(array('.', '/'), '', $this->name);
-	}
-
 }

--- a/admin/tests/CMSFormTest.php
+++ b/admin/tests/CMSFormTest.php
@@ -10,7 +10,7 @@ class CMSFormTest extends FunctionalTest {
 		$response = $this->get('CMSFormTest_Controller');
 
 		$response = $this->submitForm(
-			'Form_Form',
+			'CMSForm_Form',
 			'action_doSubmit',
 			array(
 				'Email' => 'test@test.com'
@@ -19,7 +19,7 @@ class CMSFormTest extends FunctionalTest {
 			
 		// Firstly, assert that required fields still work when not using an exempt action
 		$this->assertPartialMatchBySelector(
-			'#SomeRequiredField span.required',
+			'#CMSForm_Form_SomeRequiredField_Holder span.required',
 			array(
 				'"Some Required Field" is required'
 			),
@@ -28,7 +28,7 @@ class CMSFormTest extends FunctionalTest {
 
 		// Re-submit the form using validation-exempt button
 		$response = $this->submitForm(
-			'Form_Form',
+			'CMSForm_Form',
 			'action_doSubmitValidationExempt',
 			array(
 				'Email' => 'test@test.com'
@@ -36,12 +36,12 @@ class CMSFormTest extends FunctionalTest {
 		);
 
 		// The required message should be empty if validation was skipped
-		$items = $this->cssParser()->getBySelector('#SomeRequiredField span.required');
+		$items = $this->cssParser()->getBySelector('#CMSForm_Form_SomeRequiredField_Holder span.required');
 		$this->assertEmpty($items);
 
 		// And the session message should show up is submitted successfully
 		$this->assertPartialMatchBySelector(
-			'#Form_Form_error',
+			'#CMSForm_Form_error',
 			array(
 				'Validation skipped'
 			),

--- a/forms/Form.php
+++ b/forms/Form.php
@@ -693,7 +693,7 @@ class Form extends RequestHandler {
 
 	public function getAttributes() {
 		$attrs = array(
-			'id' => $this->getTemplateHelper()->generateFormID($this),
+			'id' => $this->FormName(),
 			'action' => $this->FormAction(),
 			'method' => $this->FormMethod(),
 			'enctype' => $this->getEncType(),


### PR DESCRIPTION
This fix resolves issues first of all with `CMSFormTest` failing, but also consolidates the form ID / Name used by `CMSForm`. The default `Form::FormName` implementation already respects the set htmlID, and `CMSForm` was using the old methodology for generating form IDs, which was not even being used consistently. The `Form::getAttributes` method already generates the form ID ignoring the behaviour of `Form::FormName`, so it wouldn't have had much effect to override that method in `CMSForm` anyway. 

The result is that now `CMSFormTest` passes, `CMSForm` uses the new correct naming convention, and `FormName` is respected a little more in Form classes that might override it in the future.

All test cases were run and passed.
