### PR TITLE
BUG backtrace now filters MySQLi arguments

### DIFF
--- a/dev/Backtrace.php
+++ b/dev/Backtrace.php
@@ -16,6 +16,8 @@ class SS_Backtrace {
 		'mysql_connect',
 		'mssql_connect',
 		'pg_connect',
+		array('mysqli', 'mysqli'),
+		array('mysqli', 'select_db'),
 		array('DB', 'connect'),
 		array('Security', 'check_default_admin'),
 		array('Security', 'encrypt_password'),


### PR DESCRIPTION
Add MySQLi functions mysqli() and select_db() to the list of filtered
function arguments to avoid exposing sensitive data
