### PR TITLE
Remove TinyMCE change detection on insert (breaks IE8)

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -1402,16 +1402,5 @@ function sapphiremce_cleanup(type, value) {
 		});
 	}
 
-	// if we are inserting from a popup back into the editor
-	// add the changed class and update the Content value
-	if(type == 'insert_to_editor' && typeof tinyMCE.selectedInstance.editorId !== 'undefined') {
-		var field = jQuery('#' + tinyMCE.selectedInstance.editorId);
-		var original = field.val();
-		if (original != value) {
-			field.val(value).addClass('changed');
-			field.closest('form').addClass('changed');
-		}
-	}
-
 	return value;
 }


### PR DESCRIPTION
The detection is triggered on first load, and in IE8 the inserted value
doesn't equal the value already in the textarea field. That's possibly due to
whitespace or encoding differences, but they have the same character length.

Tried fixing this by whitespace removal, didn't work: if((original ||
'').replace(/[\s\t\n\r]/g, '') != (value || '').replace(/[\s\t\n\r]/g, '')) {

In the end, we're already detecting changes through a 5s interval triggering
the save() method on the editor if the field is focused. The impact of this
removal is that after inserting an image, it'll take a few seconds for the
change detection to kick in
(and thus highlight the "save" button and ask for confirmation when navigating
away without saving).

See d12ae82f70038ef08f444e7e6e0157491228319b and https://silverstripe.atlassian.net/browse/CWPBUG-26 (internal link) for context.
