### PR TITLE
Conditionally send "ID" val in UploadField

### DIFF
--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -186,13 +186,10 @@
 					{
 						formData: function(form) {
 							var idVal = $(form).find(':input[name=ID]').val();
-							if(!idVal) {
-								idVal = 0;
-							}
-							return [
-								{name: 'SecurityID', value: $(form).find(':input[name=SecurityID]').val()},
-								{name: 'ID', value: idVal}
-							];
+							var data = [{name: 'SecurityID', value: $(form).find(':input[name=SecurityID]').val()}];
+							if(idVal) data.push({name: 'ID', value: idVal});
+							
+							return data;
 						},
 						errorMessages: {
 							// errorMessages for all error codes suggested from the plugin author, some will be overwritten by the config coming from php


### PR DESCRIPTION
The "ID" form field is not always defined, for example in the "Replace" tab of
the "versionedfiles" module
(which uses GridFieldDetailForm). Since the path to that detail form relies on
the "ID" in AssetAdmin->currentPageID(), and does an is_numeric() check to
support the "root" folder, we need to leave the "ID" param out completely.

Checked this without versionedfiles module in admin/assets as well as a custom
UploadField in CMSMain.
