### PR TITLE
admin/myprofile layout after validation (fixes #2644)

### DIFF
--- a/admin/code/CMSProfileController.php
+++ b/admin/code/CMSProfileController.php
@@ -14,15 +14,6 @@ class CMSProfileController extends LeftAndMain {
 
 	private static $tree_class = 'Member';
 
-	public function getResponseNegotiator() {
-		$neg = parent::getResponseNegotiator();
-		$controller = $this;
-		$neg->setCallback('CurrentForm', function() use(&$controller) {
-			return $controller->renderWith($controller->getTemplatesWithSuffix('_Content'));
-		});
-		return $neg;
-	}
-
 	public function getEditForm($id = null, $fields = null) {
 		$this->setCurrentPageID(Member::currentUserID());
 
@@ -42,8 +33,6 @@ class CMSProfileController extends LeftAndMain {
 		);
 
 		$form->Actions()->removeByName('action_delete');
-		$form->setTemplate('Form');
-		$form->setAttribute('data-pjax-fragment', null);
 
 		if($member = Member::currentUser()) {
 			$form->setValidator($member->getValidator());
@@ -55,7 +44,7 @@ class CMSProfileController extends LeftAndMain {
 			$form->Fields()->findOrMakeTab('Root')->setTemplate('CMSTabSet');
 		}
 
-		$form->addExtraClass('member-profile-form root-form cms-edit-form cms-panel-padded center');
+		$form->addExtraClass('member-profile-form root-form cms-edit-form center');
 		
 		return $form;
 	}

--- a/admin/templates/CMSProfileController_Content.ss
+++ b/admin/templates/CMSProfileController_Content.ss
@@ -1,4 +1,4 @@
-<div id="settings-controller-cms-content" class="cms-content center cms-tabset $BaseCSSClasses" data-layout-type="border" data-pjax-fragment="Content CurrentForm">
+<div id="settings-controller-cms-content" class="cms-content center cms-tabset $BaseCSSClasses" data-layout-type="border" data-pjax-fragment="Content">
 
 	<div class="cms-content-header north">
 		<% with $EditForm %>
@@ -21,10 +21,6 @@
 		<% end_with %>
 	</div>
 
-	<div class="cms-content-fields center ui-widget-content" data-layout-type="border">
-
-		$EditForm
-
-	</div>
+	$EditForm
 
 </div>

--- a/admin/templates/Includes/CMSProfileController_EditForm.ss
+++ b/admin/templates/Includes/CMSProfileController_EditForm.ss
@@ -1,0 +1,28 @@
+<form $FormAttributes data-layout-type="border">
+
+	<div class="cms-content-fields center">
+		<% if $Message %>
+		<p id="{$FormName}_error" class="message $MessageType">$Message</p>
+		<% else %>
+		<p id="{$FormName}_error" class="message $MessageType" style="display: none"></p>
+		<% end_if %>
+
+		<fieldset>
+			<% if $Legend %><legend>$Legend</legend><% end_if %>
+			<% loop $Fields %>
+				$FieldHolder
+			<% end_loop %>
+			<div class="clear"><!-- --></div>
+		</fieldset>
+	</div>
+
+	<div class="cms-content-actions cms-content-controls south">
+		<% if $Actions %>
+		<div class="Actions">
+			<% loop $Actions %>
+				$Field
+			<% end_loop %>
+		</div>
+		<% end_if %>
+	</div>
+</form>


### PR DESCRIPTION
Broke because the `<form>` tag was returned, while the client logic was
expecting the whole `<div>` including the `<form>`. Fixed to display the button
bar at the bottom, and tested with validation errors as well as switching
from/to the panel via ajax.

Tested in latest Chrome, IE8 and IE9
