### PR TITLE
BUG fix missing permission for dev/build/defaults

### DIFF
--- a/dev/DevelopmentAdmin.php
+++ b/dev/DevelopmentAdmin.php
@@ -27,6 +27,7 @@ class DevelopmentAdmin extends Controller {
 		'reset', 
 		'viewcode',
 		'generatesecuretoken',
+		'buildDefaults',
 	);
 	
 	public function init() {


### PR DESCRIPTION
the `buildDefaults` action is available via `dev/build/defaults` but doesn't have the necessary `allowed_actions` entry to permit it to run.

Running `dev/build/defaults` prior to this causes `Action 'buildDefaults' isn't available on class DatabaseAdmin.`
