### PR TITLE
Implove GridFieldAddExistingAutocompleter->doSearch() html output

### DIFF
--- a/forms/gridfield/GridFieldAddExistingAutocompleter.php
+++ b/forms/gridfield/GridFieldAddExistingAutocompleter.php
@@ -229,9 +229,12 @@ class GridFieldAddExistingAutocompleter
 			->limit($this->getResultsLimit());
 
 		$json = array();
+		$originalSourceFileComments = Config::inst()->get('SSViewer', 'source_file_comments');
+		Config::inst()->update('SSViewer', 'source_file_comments', false);
 		foreach($results as $result) {
 			$json[$result->ID] = html_entity_decode(SSViewer::fromString($this->resultsFormat)->process($result));
 		}
+		Config::inst()->update('SSViewer', 'source_file_comments', $originalSourceFileComments);
 		return Convert::array2json($json);
 	}
 


### PR DESCRIPTION
- Replace HTML entities in GridFieldAddExistingAutocompleter->doSearch()  with actual charaters as the DropDown does not play nicely with HTML entities
-  disable source_file_comments in GridFieldAddExistingAutocompleter->doSearch() because they would be displayed as plaintext in the dropdown

this is what it looks like before this change:
![before](https://f.cloud.github.com/assets/186158/1499001/a2a81c34-484b-11e3-9ab7-63f70f0b3c01.png)

after first commit with source_file_comments on:
![before2](https://f.cloud.github.com/assets/186158/1499158/cf4fd2c2-4850-11e3-9f16-05a5c8128401.png)

and after:
![after](https://f.cloud.github.com/assets/186158/1499002/a752c41e-484b-11e3-8c8b-0213d38a326d.png)
