### PR TITLE
NEW: Allow specifying custom factories for services.

### DIFF
--- a/control/injector/InjectionCreator.php
+++ b/control/injector/InjectionCreator.php
@@ -1,26 +1,20 @@
 <?php
-
 /**
  * A class for creating new objects by the injector.
  *
  * @package framework
  * @subpackage injector
  */
-class InjectionCreator {
+class InjectionCreator implements InjectorFactory {
 
-	/**
-	 * @param string $object
-	 *					A string representation of the class to create
-	 * @param array $params
-	 *					An array of parameters to be passed to the constructor
-	 */
 	public function create($class, $params = array()) {
 		$reflector = new ReflectionClass($class);
 
 		if (count($params)) {
 			return $reflector->newInstanceArgs($params); 
 		}
-		
+
 		return $reflector->newInstance();
 	}
+
 }

--- a/control/injector/InjectorFactory.php
+++ b/control/injector/InjectorFactory.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * A factory which is used by the {@link Injector} to create new instances.
+ *
+ * Each injector has a default factory, but services can also specify a custom
+ * factory using the `factory` parameter.
+ *
+ * @package framework
+ * @subpackage injector
+ */
+interface InjectorFactory {
+
+	/**
+	 * Creates a new instance of a component and returns it.
+	 *
+	 * @param string $component The component name to create, usually a class name.
+	 * @param array $parameters The parameters to use to create the object.
+	 * @return object
+	 */
+	public function create($component, $parameters = array());
+
+}

--- a/control/injector/SilverStripeInjectionCreator.php
+++ b/control/injector/SilverStripeInjectionCreator.php
@@ -5,7 +5,7 @@
  * @subpackage injector
  */
 
-class SilverStripeInjectionCreator {
+class SilverStripeInjectionCreator implements InjectorFactory {
 	/**
 	 *
 	 * @param string $object

--- a/docs/en/reference/injector.md
+++ b/docs/en/reference/injector.md
@@ -168,6 +168,21 @@ would
 * Create a MySQLDatabase class, passing dbusername and dbpassword as the 
   parameters to the constructor
 
+### Service Factories
+
+For services which require non-trivial construction, it is necessary to use
+a factory object to create new instances of the service. To do this, you must
+create a factory class, which should implement [api:InjectorFactory].
+
+When creating the service definition, you then specify a `factory` key with
+the service definition. When the service is created, the injector will get an
+instance of the factory service class, and then use it to create the new service.
+
+```yaml
+Injector:
+  Service:
+    factory: ServiceFactory
+```
 
 ### What are Services?
 

--- a/tests/injector/InjectorTest.php
+++ b/tests/injector/InjectorTest.php
@@ -455,6 +455,32 @@ class InjectorTest extends SapphireTest {
 		$this->assertEquals('OriginalRequirementsBackend', get_class($requirements->backend));
 	}
 
+	/**
+	 * Tests that object creation with a custom factory service operates as
+	 * expected.
+	 */
+	public function testCustomFactory() {
+		$injector = new Injector();
+		$service = new TestObject();
+
+		$injector->load(array(
+			'TestService' => array(
+				'factory' => 'TestFactory',
+				'constructor' => array('parameter')
+			)
+		));
+
+		$factory = $this->getMock('InjectorFactory');
+		$factory->expects($this->once())
+			->method('create')
+			->with($this->equalTo('TestService'), $this->equalTo(array('parameter')))
+			->will($this->returnValue($service));
+
+		$injector->registerService($factory, 'TestFactory');
+
+		$this->assertEquals($service, $injector->get('TestService'));
+	}
+
 	public function testInheritedConfig() {
 		$injector = new Injector(array('locator' => 'SilverStripeServiceConfigurationLocator'));
 		Config::inst()->update('Injector', 'MyParentClass', array('properties' => array('one' => 'the one')));


### PR DESCRIPTION
If you specify a `factory` key with a service definition, a service
with that name will be used to create instances of the service.

The factory should implement the `InjectorFactory` interface.
