### PR TITLE
Enable use of image backends from config.

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -458,7 +458,7 @@ class Image extends File {
 		
 		$cacheFile = call_user_func_array(array($this, "cacheFilename"), $args);
 		
-		$backend = Injector::inst()->createWithArgs(self::$backend, array(
+		$backend = Injector::inst()->createWithArgs($this->config()->backend, array(
 			Director::baseFolder()."/" . $this->Filename
 		));
 		


### PR DESCRIPTION
Currently, Silverstripe doesn't allow the backend of Image to be set through config (either PHP or YAML-based).

This fixes that problem.
