### PR TITLE
Scaffolded Enum Search fields dont offer a null selection

### DIFF
--- a/model/fieldtypes/Enum.php
+++ b/model/fieldtypes/Enum.php
@@ -116,7 +116,7 @@ class Enum extends StringField {
 	 */
 	public function scaffoldSearchField($title = null) {
 		$anyText = _t('Enum.ANY', 'Any');
-		return $this->formField($title, null, false, '', null, "($anyText)");
+		return $this->formField($title, null, true, '', null, "($anyText)");
 	}
 	
 	/**


### PR DESCRIPTION
Enum search fields should default to having an empty string set
