### PR TITLE
ENHANCEMENT: automatic link child class (has_one parent) in addNewForm

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -381,7 +381,18 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 			$actions,
 			$this->component->getValidator()
 		);
-		
+
+		//lock-in parent ID for HasMany List.  
+		//We do this before the loading of the data into the form
+		//so that the user can see the parent has been set.
+		$list = $this->gridField->getList();
+		if($list && $list instanceof HasManyList) {
+			$foreignKey = $list->getForeignKey();
+			$fields->makeFieldReadonly($foreignKey);
+			$this->record->$foreignKey = $list->getForeignID();
+		}
+
+
 		$form->loadDataFrom($this->record, $this->record->ID == 0 ? Form::MERGE_IGNORE_FALSEISH : Form::MERGE_DEFAULT);
 
 		if($this->record->ID && !$canEdit) {


### PR DESCRIPTION
Presets and locks-in the parent HasOne relationship value for a child record (e.g. if we add a city to a country then the user can see that the country is preset and that the country can not be changed (as on save it will be overridden to the parent country anyway).

For a full description and discussion, see https://github.com/silverstripe/silverstripe-framework/pull/2637 and https://github.com/silverstripe/silverstripe-framework/pull/2651
