### PR TITLE
Making ConfigStaticManifest::parseStatic error more meaningful

### DIFF
--- a/core/manifest/ConfigStaticManifest.php
+++ b/core/manifest/ConfigStaticManifest.php
@@ -282,7 +282,7 @@ class SS_ConfigStaticManifest_Parser {
 				// NOP
 			}
 			else {
-				user_error('Unexpected token when building static manifest: '.print_r($token, true), E_USER_ERROR);
+				user_error('Unexpected token ("' . token_name($type) . '") when building static manifest in class "' . $class . '": '.print_r($token, true), E_USER_ERROR);
 			}
 		}
 


### PR DESCRIPTION
The error thrown by `parseStatic` when there's an unexpected token is now more meaningful as it states the type of token that was encountered as well as the class that it was found in.
