### PR TITLE
FIX text/html type for Debug::friendlyError() in live mode

### DIFF
--- a/dev/Debug.php
+++ b/dev/Debug.php
@@ -347,6 +347,7 @@ class Debug {
 				);
 				if(file_exists($errorFilePath)) {
 					$content = file_get_contents(ASSETS_PATH . "/error-$statusCode.html");
+					if(!headers_sent()) header('Content-Type: text/html');
 					// $BaseURL is left dynamic in error-###.html, so that multi-domain sites don't get broken
 					echo str_replace('$BaseURL', Director::absoluteBaseURL(), $content);
 				}


### PR DESCRIPTION
Avoid unparsed HTML responses in case of httpError(4xx) or httpError(5xx) in
live mode. The SS_HTTPResponse_Exception constructor automatically set
"text/plain" a content type, which conflicts with the later choice of
Debug::friendlyError() to return HTML.

This is a hotfix, needs more work to properly separate logic flow from
presentation concerns (e.g. through request processors).

This doesn't affect 3.0 since the commit causing the regression was 3.1 only: 39952f4a5ca313491984f9ef7d4d00ee4a41b23a
