### PR TITLE
NEW Forcefully write javascripts to the end of the HTML if wished

### DIFF
--- a/tests/forms/RequirementsTest.php
+++ b/tests/forms/RequirementsTest.php
@@ -357,36 +357,46 @@ class RequirementsTest extends SapphireTest {
 		// Test matching with HTML5 <header> tags as well
 		$template = '<html><head></head><body><header>My header</header><p>Body<script></script></p></body></html>';
 
-		// Test if the script is before the first <script> tag, not before the body.
+		// The expected outputs
+		$JsInHead = "<html><head><script type=\"text/javascript\" src=\"http://www.mydomain.com/test.js\"></script>\n</head><body><header>My header</header><p>Body<script></script></p></body></html>";
+		$JsInBody = "<html><head></head><body><header>My header</header><p>Body<script type=\"text/javascript\" src=\"http://www.mydomain.com/test.js\"></script><script></script></p></body></html>";
+		$JsAtEnd  = "<html><head></head><body><header>My header</header><p>Body<script></script></p><script type=\"text/javascript\" src=\"http://www.mydomain.com/test.js\"></script></body></html>";
+
+		
+		// Test if the script is before the head tag, not before the body.
+		// Expected: $JsInHead
 		$backend->set_write_js_to_body(false);
 		$backend->set_force_js_to_bottom(false);
 		$html = $backend->includeInHTML(false, $template);
-		$this->assertNotContains('</script></body>', $html);
-		$this->assertNotContains('</script><script', $html);
-		$this->assertContains('<head><script', $html);
+		$this->assertNotEquals($JsInBody, $html);
+		$this->assertNotEquals($JsAtEnd, $html);
+		$this->assertEquals($JsInHead, $html);
 
 		// Test if the script is before the first <script> tag, not before the body.
+		// Expected: $JsInBody
 		$backend->set_write_js_to_body(true);
 		$backend->set_force_js_to_bottom(false);
 		$html = $backend->includeInHTML(false, $template);
-		$this->assertNotContains('</script></body>', $html);
-		$this->assertContains('</script><script', $html);
+		$this->assertNotEquals($JsAtEnd, $html);
+		$this->assertEquals($JsInBody, $html);
 
 		// Test if the script is placed just before the closing bodytag, with write-to-body false.
+		// Expected: $JsAtEnd
 		$backend->set_write_js_to_body(false);
 		$backend->set_force_js_to_bottom(true);
 		$html = $backend->includeInHTML(false, $template);
-		$this->assertNotContains('<head><script', $html);
-		$this->assertNotContains('</script><script', $html);
-		$this->assertContains('</script></body>', $html);
-
+		$this->assertNotEquals($JsInHead, $html);
+		$this->assertNotEquals($JsInBody, $html);
+		$this->assertEquals($JsAtEnd, $html);
+		
 		// Test if the script is placed just before the closing bodytag, with write-to-body true.
+		// Expected: $JsAtEnd
 		$backend->set_write_js_to_body(true);
 		$backend->set_force_js_to_bottom(true);
 		$html = $backend->includeInHTML(false, $template);
-		$this->assertNotContains('<head><script', $html);
-		$this->assertNotContains('</script><script', $html);
-		$this->assertContains('</script></body>', $html);
+		$this->assertNotEquals($JsInHead, $html);
+		$this->assertNotEquals($JsInBody, $html);
+		$this->assertEquals($JsAtEnd, $html);
 	}
 
 	public function testSuffix() {

--- a/view/Requirements.php
+++ b/view/Requirements.php
@@ -733,8 +733,8 @@ class Requirements_Backend {
 				$jsRequirements = preg_replace('/>\n*/', '>', $jsRequirements);
 
 				// We put script tags into the body, for performance.
-				// If your template already has script tags in the body, then we put our script
-				// tags just before those. Otherwise, we put it at the bottom.
+				// We forcefully put it at the bottom instead of before
+				// the first script-tag occurence
 				$content = preg_replace("/(<\/body[^>]*>)/i", $jsRequirements . "\\1", $content);
 				
 				// Put CSS at the bottom of the head


### PR DESCRIPTION
It's defaulted to false. But when set to true, the JS is written to the end of the HTML, even though there are earlier scripts.
This results in faster page-loading if the JS isn't needed earlier-on.

Sorry, no tests, since there aren't any "Requirements tests" yet it seems (or did I look wrong?)

As other Requirements settings, it can be set in page or _config. Manual testing shows this works as expected and are not harmful for the framework's operational flow (unless, ofcourse it should be loaded before inline scripts, but then again, it shouldn't have been set to true).

*
I'll be updating soon. Overlooked the RequirementsTest file appearantly.
