### PR TITLE
API: Support string descriptors for unique indexes

### DIFF
--- a/docs/en/reference/dataobject.md
+++ b/docs/en/reference/dataobject.md
@@ -250,6 +250,35 @@ The CMS default sections as well as custom interfaces like
 `[ModelAdmin](/reference/modeladmin)` or `[GridField](/reference/gridfield)`
 already enforce these permissions.
 
+## Indexes
+
+It is sometimes desirable to add indexes to your data model, whether to
+optimize queries or add a uniqueness constraint to a field. This is done
+through the `DataObject::$indexes` map, which maps index names to descriptor
+arrays that represent each index.
+
+The general pattern for the descriptor arrays is
+
+	:::php
+	array('type' => 'index|unique|fulltext', 'value' => '"FieldA","FieldB"')
+
+You can also express the descriptor as a string.
+
+	:::php
+	'unique ("Name")'
+
+
+Note that some databases support more keywords for 'type' than shown above.
+
+Example: a unique index on a field
+
+	:::php
+	private static $db = array('SEOName' => 'Varchar(255)',);
+	private static $indexes = array(
+		'Name_IDX' => array('type' => 'unique', 'value' => '"Name"'),
+		'OtherField_IDX' => 'unique ("OtherField")',
+	);
+
 ## API Documentation
 
 `[api:DataObject]`

--- a/docs/en/topics/datamodel.md
+++ b/docs/en/topics/datamodel.md
@@ -762,6 +762,11 @@ Example: Validate postcodes based on the selected country
 		}
 	}
 
+<div class="hint" markdown='1'>
+**Tip:** If you decide to add unique or other indexes to your model via
+`static $indexes`, see [DataObject](/reference/dataobject) for details.
+</div>
+
 ## Maps
 
 A map is an array where the array indexes contain data as well as the values.


### PR DESCRIPTION
- Documents the format for descriptor arrays
- Implements the behaviour that developers have come to expect for
  string descriptors of indexes
- Resolves #2403

Versioned needs to convert unique indexes to non-unique for its suffixed tables, such as Foo_Live and Foo_versions. Because DataObject accepts string descriptors such as array('UniqIDX' => 'unique (Uniq)') as well as array-based descriptors, Versioned needs to recognize string descriptors. This patch accomplishes that. Before, Versioned would fail to convert string-described indexes to non-unique, resulting in run-time errors when creating a new version of an object.
