### PR TITLE
MINOR added onBeforeRender extension hook to FormField

### DIFF
--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -583,7 +583,7 @@ class FormField extends RequestHandler {
 	 */
 	public function Field($properties = array()) {
 		$obj = ($properties) ? $this->customise($properties) : $this;
-
+		$this->extend('onBeforeRender', $this);
 		return $obj->renderWith($this->getTemplates());
 	}
 


### PR DESCRIPTION
An extension hook to modify a form field right before it is rendered. Generally useful for modules like ZenValidator and DisplayLogic that build up a set of attributes that should only be applied once all the display/validation logic is complete.
