### PR TITLE
Updating @package and @subpackage doc tags

### DIFF
--- a/control/RequestFilter.php
+++ b/control/RequestFilter.php
@@ -7,6 +7,8 @@
  *
  * @author marcus@silverstripe.com.au
  * @license BSD License http://silverstripe.org/bsd-license/
+ * @package framework
+ * @subpackage control
  */
 interface RequestFilter {
 	/**

--- a/core/DAG.php
+++ b/core/DAG.php
@@ -3,6 +3,9 @@
 /**
  * A Directed Acyclic Graph - used for doing topological sorts on dependencies, such as the before/after conditions
  * in config yaml fragments
+ *
+ * @package framework
+ * @subpackage manifest
  */
 class SS_DAG implements IteratorAggregate {
 	/**
@@ -88,10 +91,20 @@ class SS_DAG implements IteratorAggregate {
 	}
 }
 
+/**
+ * Exception thrown when the {@link SS_DAG} class is unable to resolve sorting the DAG due to cyclic dependencies.
+ *
+ * @package framework
+ * @subpackage manifest
+ */
 class SS_DAG_CyclicException extends Exception {
 
 	public $dag;
 
+	/**
+	 * @param string $message The Exception message
+	 * @param SS_DAG $dag The remainder of the Directed Acyclic Graph (DAG) after the last successful sort
+	 */
 	public function __construct($message, $dag) {
 		$this->dag = $dag;
 		parent::__construct($message);
@@ -99,6 +112,10 @@ class SS_DAG_CyclicException extends Exception {
 
 }
 
+/**
+ * @package framework
+ * @subpackage manifest
+ */
 class SS_DAG_Iterator implements Iterator {
 
 	protected $data;

--- a/core/TempPath.php
+++ b/core/TempPath.php
@@ -2,6 +2,9 @@
 /**
  * Returns the temporary folder path that silverstripe should use for its cache files.
  *
+ * @package framework
+ * @subpackage core
+ *
  * @param $base The base path to use for determining the temporary path
  * @return string Path to temp
  */
@@ -20,6 +23,9 @@ function getTempFolder($base = null) {
 
 /**
  * Returns as best a representation of the current username as we can glean.
+ *
+ * @package framework
+ * @subpackage core
  */
 function getTempFolderUsername() {
 	$user = getenv('APACHE_RUN_USER');
@@ -38,6 +44,9 @@ function getTempFolderUsername() {
  * Return the parent folder of the temp folder.
  * The temp folder will be a subfolder of this, named by username.
  * This structure prevents permission problems.
+ *
+ * @package framework
+ * @subpackage core
  */
 function getTempParentFolder($base = null) {
 	if(!$base && defined('BASE_PATH')) $base = BASE_PATH;

--- a/core/manifest/ConfigStaticManifest.php
+++ b/core/manifest/ConfigStaticManifest.php
@@ -9,6 +9,7 @@
  * optionally catch attempts to modify the config statics (otherwise the modification will appear
  * to work, but won't actually have any effect - the equvilent of failing silently)
  *
+ * @package framework
  * @subpackage manifest
  */
 class SS_ConfigStaticManifest {
@@ -150,6 +151,9 @@ class SS_ConfigStaticManifest {
  * We can't do this using TokenisedRegularExpression because we need to keep track of state
  * as we process the token list (when we enter and leave a namespace or class, when we see
  * an access level keyword, etc)
+ *
+ * @package framework
+ * @subpackage manifest
  */
 class SS_ConfigStaticManifest_Parser {
 

--- a/core/manifest/ManifestCache.php
+++ b/core/manifest/ManifestCache.php
@@ -2,6 +2,9 @@
 
 /**
  * A basic caching interface that manifests use to store data.
+ *
+ * @package framework
+ * @subpackage manifest
  */
 interface ManifestCache {
 	public function __construct($name);
@@ -12,6 +15,9 @@ interface ManifestCache {
 
 /**
  * Stores manifest data in files in TEMP_DIR dir on filesystem
+ *
+ * @package framework
+ * @subpackage manifest
  */
 class ManifestCache_File implements ManifestCache {
 	function __construct($name) {
@@ -37,6 +43,9 @@ class ManifestCache_File implements ManifestCache {
 /**
  * Same as ManifestCache_File, but stores the data as valid PHP which gets included to load
  * This is a bit faster if you have an opcode cache installed, but slower otherwise
+ *
+ * @package framework
+ * @subpackage manifest
  */
 class ManifestCache_File_PHP extends ManifestCache_File {
 	function load($key) {
@@ -58,6 +67,9 @@ class ManifestCache_File_PHP extends ManifestCache_File {
 /**
  * Stores manifest data in APC.
  * Note: benchmarks seem to indicate this is not particularly faster than _File
+ *
+ * @package framework
+ * @subpackage manifest
  */
 class ManifestCache_APC implements ManifestCache {
 	protected $pre;

--- a/dev/SilverStripeListener.php
+++ b/dev/SilverStripeListener.php
@@ -1,8 +1,12 @@
 <?php
-
-// Inject SilverStripe 'setUpOnce' and 'tearDownOnce' unittest extension methods into phpunit
-// This is already in later SilverStripe 2.4 versions, but having it here extends compatibility to older versions
-
+/**
+ * Inject SilverStripe 'setUpOnce' and 'tearDownOnce' unittest extension methods into PHPUnit.
+ *
+ * This is already in later SilverStripe 2.4 versions, but having it here extends compatibility to older versions.
+ *
+ * @package framework
+ * @subpackage testing
+ */
 class SilverStripeListener implements PHPUnit_Framework_TestListener {
 	
 	protected function isValidClass($name) {

--- a/dev/TeamCityListener.php
+++ b/dev/TeamCityListener.php
@@ -1,7 +1,10 @@
 <?php
-
-// Bind TeamCity test listener. Echos messages to stdout that TeamCity interprets into the test results
-
+/**
+ * Bind TeamCity test listener. Echos messages to stdout that TeamCity interprets into the test results
+ *
+ * @package framework
+ * @subpackage testing
+ */
 class TeamCityListener implements PHPUnit_Framework_TestListener {
 	
 	private function escape($str) {

--- a/email/Mailer.php
+++ b/email/Mailer.php
@@ -437,6 +437,8 @@ class Mailer extends Object {
 }
 
 /**
+ * @package framework
+ * @subpackage email
  * @deprecated 3.1
  */
 function htmlEmail($to, $from, $subject, $htmlContent, $attachedFiles = false, $customheaders = false,
@@ -449,6 +451,8 @@ function htmlEmail($to, $from, $subject, $htmlContent, $attachedFiles = false, $
 }
 
 /**
+ * @package framework
+ * @subpackage email
  * @deprecated 3.1
  */
 function plaintextEmail($to, $from, $subject, $plainContent, $attachedFiles, $customheaders = false) {
@@ -459,6 +463,8 @@ function plaintextEmail($to, $from, $subject, $plainContent, $attachedFiles, $cu
 }
 
 /**
+ * @package framework
+ * @subpackage email
  * @deprecated 3.1
  */
 function encodeMultipart($parts, $contentType, $headers = false) {
@@ -469,6 +475,8 @@ function encodeMultipart($parts, $contentType, $headers = false) {
 }
 
 /**
+ * @package framework
+ * @subpackage email
  * @deprecated 3.1
  */
 function wrapImagesInline($htmlContent) {
@@ -479,6 +487,8 @@ function wrapImagesInline($htmlContent) {
 }
 
 /**
+ * @package framework
+ * @subpackage email
  * @deprecated 3.1
  */
 function wrapImagesInline_rewriter($url) {
@@ -490,6 +500,8 @@ function wrapImagesInline_rewriter($url) {
 }
 
 /**
+ * @package framework
+ * @subpackage email
  * @deprecated 3.1
  */
 function processHeaders($headers, $body = false) {
@@ -500,6 +512,8 @@ function processHeaders($headers, $body = false) {
 }
 
 /**
+ * @package framework
+ * @subpackage email
  * @deprecated 3.1
  */
 function encodeFileForEmail($file, $destFileName = false, $disposition = NULL, $extraHeaders = "") {
@@ -510,6 +524,8 @@ function encodeFileForEmail($file, $destFileName = false, $disposition = NULL, $
 }
 
 /**
+ * @package framework
+ * @subpackage email
  * @deprecated 3.1
  */
 function QuotedPrintable_encode($quotprint) {
@@ -520,6 +536,8 @@ function QuotedPrintable_encode($quotprint) {
 }
 
 /**
+ * @package framework
+ * @subpackage email
  * @deprecated 3.1
  */
 function validEmailAddr($emailAddress) {

--- a/filesystem/GD.php
+++ b/filesystem/GD.php
@@ -475,7 +475,10 @@ class GDBackend extends Object implements Image_Backend {
 }
 
 /**
- * Backwards compatibility
+ * This class is maintained for backwards-compatibility only. Please use the {@link GDBackend} class instead.
+ *
+ * @package framework
+ * @subpackage filesystem
  */
 class GD extends GDBackend {
 

--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -828,6 +828,8 @@ class HtmlEditorField_Toolbar extends RequestHandler {
  * such as file name or the URL.
  *
  * @todo Remove once core has support for remote files
+ * @package forms
+ * @subpackage fields-formattedinput
  */
 class HtmlEditorField_File extends ViewableData {
 
@@ -896,6 +898,13 @@ class HtmlEditorField_File extends ViewableData {
 
 }
 
+/**
+ * Encapsulation of an oembed tag, linking to an external media source.
+ *
+ * @see Oembed
+ * @package forms
+ * @subpackage fields-formattedinput
+ */
 class HtmlEditorField_Embed extends HtmlEditorField_File {
 	protected $oembed;
 
@@ -979,6 +988,12 @@ class HtmlEditorField_Embed extends HtmlEditorField_File {
 	}
 }
 
+/**
+ * Encapsulation of an image tag, linking to an image either internal or external to the site.
+ *
+ * @package forms
+ * @subpackage fields-formattedinput
+ */
 class HtmlEditorField_Image extends HtmlEditorField_File {
 
 	protected $width;

--- a/forms/HtmlEditorSanitiser.php
+++ b/forms/HtmlEditorSanitiser.php
@@ -7,7 +7,8 @@
  * See www.tinymce.com/wiki.php/configuration:valid_elements for details on the spec of TinyMCE's
  * whitelist configuration
  *
- * Class HtmlEditorSanitiser
+ * @package forms
+ * @subpackage fields-formattedinput
  */
 class HtmlEditorSanitiser {
 

--- a/forms/MoneyField.php
+++ b/forms/MoneyField.php
@@ -6,7 +6,7 @@
  * 
  * @author Ingo Schommer, SilverStripe Ltd. (<firstname>@silverstripe.com)
  * 
- * @package framework
+ * @package forms
  * @subpackage fields-formattedinput
  */
 class MoneyField extends FormField {

--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -22,8 +22,8 @@
  * </code>
  * 
  * @author Zauberfisch
- * @package framework
- * @subpackage forms
+ * @package forms
+ * @subpackages fields-files
  */
 class UploadField extends FileField {
 
@@ -1311,8 +1311,8 @@ class UploadField extends FileField {
  * RequestHandler for actions (edit, remove, delete) on a single item (File) of the UploadField
  * 
  * @author Zauberfisch
- * @package framework
- * @subpackage forms
+ * @package forms
+ * @subpackages fields-files
  */
 class UploadField_ItemHandler extends RequestHandler {
 
@@ -1472,6 +1472,9 @@ class UploadField_ItemHandler extends RequestHandler {
 
 /**
  * File selection popup for attaching existing files.
+ *
+ * @package forms
+ * @subpackages fields-files
  */
 class UploadField_SelectHandler extends RequestHandler {
 

--- a/forms/gridfield/GridField.php
+++ b/forms/gridfield/GridField.php
@@ -15,7 +15,7 @@
  * 
  * @see SS_List
  * 
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridField extends FormField {
@@ -764,7 +764,7 @@ class GridField extends FormField {
  * This class is the base class when you want to have an action that alters 
  * the state of the {@link GridField}, rendered as a button element. 
  * 
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridField_FormAction extends FormAction {

--- a/forms/gridfield/GridFieldAddExistingAutocompleter.php
+++ b/forms/gridfield/GridFieldAddExistingAutocompleter.php
@@ -15,7 +15,7 @@
  * For easier setup, have a look at a sample configuration in 
  * {@link GridFieldConfig_RelationEditor}.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldAddExistingAutocompleter 

--- a/forms/gridfield/GridFieldAddNewButton.php
+++ b/forms/gridfield/GridFieldAddNewButton.php
@@ -6,7 +6,7 @@
  * Only returns a button if {@link DataObject->canCreate()} for this record 
  * returns true.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldAddNewButton implements GridField_HTMLProvider {

--- a/forms/gridfield/GridFieldButtonRow.php
+++ b/forms/gridfield/GridFieldButtonRow.php
@@ -8,7 +8,7 @@
  * This row provides two new HTML fragment spaces: 'toolbar-header-left' and 
  * 'toolbar-header-right'.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldButtonRow implements GridField_HTMLProvider {

--- a/forms/gridfield/GridFieldComponent.php
+++ b/forms/gridfield/GridFieldComponent.php
@@ -3,7 +3,7 @@
 /**
  * Base interface for all components that can be added to GridField.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 interface GridFieldComponent {	
@@ -13,7 +13,7 @@ interface GridFieldComponent {
  * A GridField manipulator that provides HTML for the header/footer rows, or f
  * or before/after the template.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 interface GridField_HTMLProvider extends GridFieldComponent {
@@ -43,7 +43,7 @@ interface GridField_HTMLProvider extends GridFieldComponent {
  *
  * Used once per record/row.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 interface GridField_ColumnProvider extends GridFieldComponent {
@@ -110,7 +110,7 @@ interface GridField_ColumnProvider extends GridFieldComponent {
  *
  * @see {@link GridField_FormAction}.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 interface GridField_ActionProvider extends GridFieldComponent {
@@ -151,7 +151,7 @@ interface GridField_ActionProvider extends GridFieldComponent {
  * Generally, the data manipulator will make use of to {@link GridState} 
  * variables to decide how to modify the {@link DataList}.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 interface GridField_DataManipulator extends GridFieldComponent {
@@ -177,7 +177,7 @@ interface GridField_DataManipulator extends GridFieldComponent {
  * For example a URL that will return JSON-formatted data for a javascript 
  * grid control.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 interface GridField_URLHandler extends GridFieldComponent {
@@ -196,7 +196,7 @@ interface GridField_URLHandler extends GridFieldComponent {
  * A component which is used to handle when a {@link GridField} is saved into 
  * a record.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 interface GridField_SaveHandler extends GridFieldComponent {

--- a/forms/gridfield/GridFieldConfig.php
+++ b/forms/gridfield/GridFieldConfig.php
@@ -16,7 +16,7 @@
  * - {@link GridFieldConfig_RecordEditor}
  * - {@link GridFieldConfig_RelationEditor}
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldConfig {
@@ -138,7 +138,7 @@ class GridFieldConfig {
  * A simple readonly, paginated view of records, with sortable and searchable 
  * headers.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldConfig_Base extends GridFieldConfig {
@@ -163,7 +163,7 @@ class GridFieldConfig_Base extends GridFieldConfig {
 /**
  * Allows viewing readonly details of individual records.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldConfig_RecordViewer extends GridFieldConfig_Base {
@@ -178,7 +178,10 @@ class GridFieldConfig_RecordViewer extends GridFieldConfig_Base {
 }
 
 /**
- * @package framework
+ * Allows editing of records contained within the GridField, instead of only allowing the ability to view records in
+ * the GridField.
+ *
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldConfig_RecordEditor extends GridFieldConfig {
@@ -224,7 +227,7 @@ class GridFieldConfig_RecordEditor extends GridFieldConfig {
  * 	->setSearchFields('MyField');
  * </code>
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldConfig_RelationEditor extends GridFieldConfig {

--- a/forms/gridfield/GridFieldDataColumns.php
+++ b/forms/gridfield/GridFieldDataColumns.php
@@ -2,7 +2,7 @@
 /**
  * @see GridField
  * 
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldDataColumns implements GridField_ColumnProvider {

--- a/forms/gridfield/GridFieldDeleteAction.php
+++ b/forms/gridfield/GridFieldDeleteAction.php
@@ -15,7 +15,7 @@
  * $action = new GridFieldDeleteAction(true); 
  * </code>
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldDeleteAction implements GridField_ColumnProvider, GridField_ActionProvider {

--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -13,7 +13,7 @@
  *  - <FormURL>/field/<GridFieldName>/item/<RecordID>
  *  - <FormURL>/field/<GridFieldName>/item/<RecordID>/edit
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldDetailForm implements GridField_URLHandler {
@@ -190,7 +190,7 @@ class GridFieldDetailForm implements GridField_URLHandler {
 }
 
 /**
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldDetailForm_ItemRequest extends RequestHandler {

--- a/forms/gridfield/GridFieldEditButton.php
+++ b/forms/gridfield/GridFieldEditButton.php
@@ -10,7 +10,7 @@
  * The default routing applies to the {@link GridFieldDetailForm} component, 
  * which has to be added separately to the {@link GridField} configuration.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldEditButton implements GridField_ColumnProvider {

--- a/forms/gridfield/GridFieldExportButton.php
+++ b/forms/gridfield/GridFieldExportButton.php
@@ -3,7 +3,7 @@
 /**
  * Adds an "Export list" button to the bottom of a {@link GridField}.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 

--- a/forms/gridfield/GridFieldFilterHeader.php
+++ b/forms/gridfield/GridFieldFilterHeader.php
@@ -5,7 +5,7 @@
  * 
  * @see GridField
  * 
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldFilterHeader implements GridField_HTMLProvider, GridField_DataManipulator, GridField_ActionProvider {

--- a/forms/gridfield/GridFieldFooter.php
+++ b/forms/gridfield/GridFieldFooter.php
@@ -12,7 +12,7 @@
  * The purpose of this class is to have a footer that can round off 
  * {@link GridField} without having to use pagination.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldFooter implements GridField_HTMLProvider {

--- a/forms/gridfield/GridFieldLevelup.php
+++ b/forms/gridfield/GridFieldLevelup.php
@@ -4,7 +4,7 @@
  * hierarchical data. Requires the managed record to have a "getParent()" 
  * method or has_one relationship called "Parent".
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldLevelup extends Object implements GridField_HTMLProvider {

--- a/forms/gridfield/GridFieldPageCount.php
+++ b/forms/gridfield/GridFieldPageCount.php
@@ -6,7 +6,7 @@
  * 
  * Depends on {@link GridFieldPaginator} being added to the {@link GridField}.
  * 
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldPageCount implements GridField_HTMLProvider {

--- a/forms/gridfield/GridFieldPaginator.php
+++ b/forms/gridfield/GridFieldPaginator.php
@@ -3,7 +3,7 @@
  * GridFieldPaginator paginates the {@link GridField} list and adds controls 
  * to the bottom of the {@link GridField}.
  * 
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldPaginator implements GridField_HTMLProvider, GridField_DataManipulator, GridField_ActionProvider {

--- a/forms/gridfield/GridFieldPrintButton.php
+++ b/forms/gridfield/GridFieldPrintButton.php
@@ -3,7 +3,7 @@
 /**
  * Adds an "Print" button to the bottom or top of a GridField.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldPrintButton implements GridField_HTMLProvider, GridField_ActionProvider, GridField_URLHandler {

--- a/forms/gridfield/GridFieldSortableHeader.php
+++ b/forms/gridfield/GridFieldSortableHeader.php
@@ -6,7 +6,7 @@
  * 
  * @see GridField
  * 
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldSortableHeader implements GridField_HTMLProvider, GridField_DataManipulator, GridField_ActionProvider {

--- a/forms/gridfield/GridFieldToolbarHeader.php
+++ b/forms/gridfield/GridFieldToolbarHeader.php
@@ -6,7 +6,7 @@
  *
  * The header serves to display the name of the data the GridField is showing.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldToolbarHeader implements GridField_HTMLProvider {

--- a/forms/gridfield/GridFieldViewButton.php
+++ b/forms/gridfield/GridFieldViewButton.php
@@ -4,7 +4,7 @@
  * disabled by default and intended for use in readonly {@link GridField}
  * instances.
  *
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridFieldViewButton implements GridField_ColumnProvider {

--- a/forms/gridfield/GridState.php
+++ b/forms/gridfield/GridState.php
@@ -7,7 +7,7 @@
  * 
  * @see GridField
  * 
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridState extends HiddenField {
@@ -121,7 +121,7 @@ class GridState extends HiddenField {
  *
  * @see GridState
  * 
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridState_Data {
@@ -175,7 +175,7 @@ class GridState_Data {
 /**
  * @see GridState
  * 
- * @package framework
+ * @package forms
  * @subpackage fields-gridfield
  */
 class GridState_Component implements GridField_HTMLProvider {

--- a/i18n/i18nSSLegacyAdapter.php
+++ b/i18n/i18nSSLegacyAdapter.php
@@ -6,7 +6,6 @@ require_once 'Zend/Translate/Adapter.php';
  * @package framework
  * @subpackage i18n
  */
-
 class i18nSSLegacyAdapter extends Zend_Translate_Adapter implements i18nTranslateAdapterInterface {
 	
 	/**
@@ -65,6 +64,10 @@ class i18nSSLegacyAdapter extends Zend_Translate_Adapter implements i18nTranslat
 	
 }
 
+/**
+ * @package framework
+ * @subpackage i18n
+ */
 class i18nSSLegacyAdapter_Iterator extends RecursiveIteratorIterator {
 
 	protected $keyStack = array();

--- a/i18n/i18nTextCollector.php
+++ b/i18n/i18nTextCollector.php
@@ -476,6 +476,9 @@ class i18nTextCollector extends Object {
 /**
  * Allows serialization of entity definitions collected through {@link i18nTextCollector}
  * into a persistent format, usually on the filesystem.
+ *
+ * @package framework
+ * @subpackage i18n
  */
 interface i18nTextCollector_Writer {
 	/**
@@ -492,6 +495,9 @@ interface i18nTextCollector_Writer {
 
 /**
  * Legacy writer for 2.x style persistence.
+ *
+ * @package framework
+ * @subpackage i18n
  */
 class i18nTextCollector_Writer_Php implements i18nTextCollector_Writer {
 
@@ -570,6 +576,9 @@ class i18nTextCollector_Writer_Php implements i18nTextCollector_Writer {
 
 /**
  * Writes files compatible with {@link i18nRailsYamlAdapter}.
+ *
+ * @package framework
+ * @subpackage i18n
  */
 class i18nTextCollector_Writer_RailsYaml implements i18nTextCollector_Writer {
 
@@ -624,6 +633,9 @@ class i18nTextCollector_Writer_RailsYaml implements i18nTextCollector_Writer {
 
 /**
  * Parser that scans through a template and extracts the parameters to the _t and <%t calls
+ *
+ * @package framework
+ * @subpackage i18n
  */
 class i18nTextCollector_Parser extends SSTemplateParser {
 

--- a/model/Filterable.php
+++ b/model/Filterable.php
@@ -7,6 +7,8 @@
  * applied, rather than applying the filter in place
  *
  * @see SS_List, SS_Sortable, SS_Limitable
+ * @package framework
+ * @subpackage model
  */
 interface SS_Filterable {
 

--- a/model/Limitable.php
+++ b/model/Limitable.php
@@ -7,6 +7,8 @@
  * applied, rather than applying the limit in place
  *
  * @see SS_List, SS_Sortable, SS_Filterable
+ * @package framework
+ * @subpackage model
  */
 interface SS_Limitable {
 

--- a/model/Sortable.php
+++ b/model/Sortable.php
@@ -7,6 +7,8 @@
  * applied, rather than applying the sort in place
  *
  * @see SS_List, SS_Filterable, SS_Limitable
+ * @package framework
+ * @subpackage model
  */
 interface SS_Sortable {
 

--- a/security/PermissionFailureException.php
+++ b/security/PermissionFailureException.php
@@ -1,9 +1,11 @@
 <?php
-
 /**
  * Throw this exception to register that a user doesn't have permission to do the given action
  * and potentially redirect them to the log-in page.  The exception message may be presented to the
  * user, so it shouldn't be in nerd-speak.
+ *
+ * @package framework
+ * @subpackage security
  */
 class PermissionFailureException extends Exception {
 

--- a/view/SSTemplateParser.php
+++ b/view/SSTemplateParser.php
@@ -20,6 +20,9 @@ else {
  * This is the exception raised when failing to parse a template. Note that we don't currently do any static analysis,
  * so we can't know if the template will run, just if it's malformed. It also won't catch mistakes that still look
  * valid.
+ *
+ * @package framework
+ * @subpackage view
  */
 class SSTemplateParseException extends Exception {
 	
@@ -35,36 +38,39 @@ class SSTemplateParseException extends Exception {
 }
 
 /**
-  * This is the parser for the SilverStripe template language. It gets called on a string and uses a php-peg parser
-  * to match that string against the language structure, building up the PHP code to execute that structure as it
-  * parses
-  * 
-  * The $result array that is built up as part of the parsing (see thirdparty/php-peg/README.md for more on how
-  * parsers build results) has one special member, 'php', which contains the php equivalent of that part of the
-  * template tree.
-  * 
-  * Some match rules generate alternate php, or other variations, so check the per-match documentation too.
-  * 
-  * Terms used:
-  * 
-  * Marked: A string or lookup in the template that has been explictly marked as such - lookups by prepending with
-  * "$" (like $Foo.Bar), strings by wrapping with single or double quotes ('Foo' or "Foo")
-  * 
-  * Bare: The opposite of marked. An argument that has to has it's type inferred by usage and 2.4 defaults.
-  * 
-  * Example of using a bare argument for a loop block: <% loop Foo %>
-  * 
-  * Block: One of two SS template structures. The special characters "<%" and "%>" are used to wrap the opening and
-  * (required or forbidden depending on which block exactly) closing block marks.
-  * 
-  * Open Block: An SS template block that doesn't wrap any content or have a closing end tag (in fact, a closing end
-  * tag is forbidden)
-  * 
-  * Closed Block: An SS template block that wraps content, and requires a counterpart <% end_blockname %> tag
-  * 
-  * Angle Bracket: angle brackets "<" and ">" are used to eat whitespace between template elements
-  * N: eats white space including newlines (using in legacy _t support)
-  */
+ * This is the parser for the SilverStripe template language. It gets called on a string and uses a php-peg parser
+ * to match that string against the language structure, building up the PHP code to execute that structure as it
+ * parses
+ *
+ * The $result array that is built up as part of the parsing (see thirdparty/php-peg/README.md for more on how
+ * parsers build results) has one special member, 'php', which contains the php equivalent of that part of the
+ * template tree.
+ *
+ * Some match rules generate alternate php, or other variations, so check the per-match documentation too.
+ *
+ * Terms used:
+ *
+ * Marked: A string or lookup in the template that has been explictly marked as such - lookups by prepending with
+ * "$" (like $Foo.Bar), strings by wrapping with single or double quotes ('Foo' or "Foo")
+ *
+ * Bare: The opposite of marked. An argument that has to has it's type inferred by usage and 2.4 defaults.
+ *
+ * Example of using a bare argument for a loop block: <% loop Foo %>
+ *
+ * Block: One of two SS template structures. The special characters "<%" and "%>" are used to wrap the opening and
+ * (required or forbidden depending on which block exactly) closing block marks.
+ *
+ * Open Block: An SS template block that doesn't wrap any content or have a closing end tag (in fact, a closing end
+ * tag is forbidden)
+ *
+ * Closed Block: An SS template block that wraps content, and requires a counterpart <% end_blockname %> tag
+ *
+ * Angle Bracket: angle brackets "<" and ">" are used to eat whitespace between template elements
+ * N: eats white space including newlines (using in legacy _t support)
+ *
+ * @package framework
+ * @subpackage view
+ */
 class SSTemplateParser extends Parser {
 
 	/**

--- a/view/SSTemplateParser.php.inc
+++ b/view/SSTemplateParser.php.inc
@@ -41,6 +41,9 @@ else {
  * This is the exception raised when failing to parse a template. Note that we don't currently do any static analysis,
  * so we can't know if the template will run, just if it's malformed. It also won't catch mistakes that still look
  * valid.
+ *
+ * @package framework
+ * @subpackage view
  */
 class SSTemplateParseException extends Exception {
 	
@@ -56,36 +59,39 @@ class SSTemplateParseException extends Exception {
 }
 
 /**
-  * This is the parser for the SilverStripe template language. It gets called on a string and uses a php-peg parser
-  * to match that string against the language structure, building up the PHP code to execute that structure as it
-  * parses
-  * 
-  * The $result array that is built up as part of the parsing (see thirdparty/php-peg/README.md for more on how
-  * parsers build results) has one special member, 'php', which contains the php equivalent of that part of the
-  * template tree.
-  * 
-  * Some match rules generate alternate php, or other variations, so check the per-match documentation too.
-  * 
-  * Terms used:
-  * 
-  * Marked: A string or lookup in the template that has been explictly marked as such - lookups by prepending with
-  * "$" (like $Foo.Bar), strings by wrapping with single or double quotes ('Foo' or "Foo")
-  * 
-  * Bare: The opposite of marked. An argument that has to has it's type inferred by usage and 2.4 defaults.
-  * 
-  * Example of using a bare argument for a loop block: <% loop Foo %>
-  * 
-  * Block: One of two SS template structures. The special characters "<%" and "%>" are used to wrap the opening and
-  * (required or forbidden depending on which block exactly) closing block marks.
-  * 
-  * Open Block: An SS template block that doesn't wrap any content or have a closing end tag (in fact, a closing end
-  * tag is forbidden)
-  * 
-  * Closed Block: An SS template block that wraps content, and requires a counterpart <% end_blockname %> tag
-  * 
-  * Angle Bracket: angle brackets "<" and ">" are used to eat whitespace between template elements
-  * N: eats white space including newlines (using in legacy _t support)
-  */
+ * This is the parser for the SilverStripe template language. It gets called on a string and uses a php-peg parser
+ * to match that string against the language structure, building up the PHP code to execute that structure as it
+ * parses
+ *
+ * The $result array that is built up as part of the parsing (see thirdparty/php-peg/README.md for more on how
+ * parsers build results) has one special member, 'php', which contains the php equivalent of that part of the
+ * template tree.
+ *
+ * Some match rules generate alternate php, or other variations, so check the per-match documentation too.
+ *
+ * Terms used:
+ *
+ * Marked: A string or lookup in the template that has been explictly marked as such - lookups by prepending with
+ * "$" (like $Foo.Bar), strings by wrapping with single or double quotes ('Foo' or "Foo")
+ *
+ * Bare: The opposite of marked. An argument that has to has it's type inferred by usage and 2.4 defaults.
+ *
+ * Example of using a bare argument for a loop block: <% loop Foo %>
+ *
+ * Block: One of two SS template structures. The special characters "<%" and "%>" are used to wrap the opening and
+ * (required or forbidden depending on which block exactly) closing block marks.
+ *
+ * Open Block: An SS template block that doesn't wrap any content or have a closing end tag (in fact, a closing end
+ * tag is forbidden)
+ *
+ * Closed Block: An SS template block that wraps content, and requires a counterpart <% end_blockname %> tag
+ *
+ * Angle Bracket: angle brackets "<" and ">" are used to eat whitespace between template elements
+ * N: eats white space including newlines (using in legacy _t support)
+ *
+ * @package framework
+ * @subpackage view
+ */
 class SSTemplateParser extends Parser {
 
 	/**

--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -18,7 +18,9 @@
  * We also keep the index of the current starting point for lookups. A lookup is a sequence of obj calls -
  * when in a loop or with tag the end result becomes the new scope, but for injections, we throw away the lookup
  * and revert back to the original scope once we've got the value we're after
- * 
+ *
+ * @package framework
+ * @subpackage view
  */
 class SSViewer_Scope {
 	
@@ -182,6 +184,13 @@ class SSViewer_Scope {
 	}
 }
 
+/**
+ * Defines an extra set of basic methods that can be used in templates
+ * that are not defined on sub-classes of {@link ViewableData}.
+ *
+ * @package framework
+ * @subpackage view
+ */
 class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider {
 
 	protected $iteratorPos;
@@ -345,6 +354,9 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider {
  * (like $FirstLast etc).
  * 
  * It's separate from SSViewer_Scope to keep that fairly complex code as clean as possible.
+ *
+ * @package framework
+ * @subpackage view
  */
 class SSViewer_DataPresenter extends SSViewer_Scope {
 	


### PR DESCRIPTION
I got annoyed with the fact that this page exists: http://api.silverstripe.org/3.1/package-None.html

So the next time docs are updated, it should disappear :)

There are no actual code changes in here, and the biggest change (to SSTemplateParser.php and SSTemplateParser.php.inc) is only to fix the comment spacing, the actual wording doesn't change.
