### PR TITLE
Update i18n.js

### DIFF
--- a/javascript/i18n.js
+++ b/javascript/i18n.js
@@ -67,12 +67,16 @@ ss.i18n = {
 			this.init();
 
 			var langName = this.getLocale().replace(/_[\w]+/i, '');
+			var defaultlangName = this.defaultLocale.replace(/_[\w]+/i, '');
+			
 			if (this.lang && this.lang[this.getLocale()] && this.lang[this.getLocale()][entity]) {
 				return this.lang[this.getLocale()][entity];
 			} else if (this.lang && this.lang[langName] && this.lang[langName][entity]) {
 				return this.lang[langName][entity];
 			} else if (this.lang && this.lang[this.defaultLocale] && this.lang[this.defaultLocale][entity]) {
 				return this.lang[this.defaultLocale][entity];
+			} else if (this.lang && this.lang[defaultlangName] && this.lang[defaultlangName][entity]) {
+				return this.lang[defaultlangName][entity]; 
 			} else if(fallbackString) {
 				return fallbackString;
 			} else {


### PR DESCRIPTION
When looking for a translation, the fallback solution (CurrentLocale -> defaultLocale -> fallbackString) does not work for cms/javascript/CMSMain.Tree.js as localization for this part was changed to short locale names (e.g. de_DE -> de). (Don't know why...)

The original fallback solution will not find a translation for e.g. "Tree.ShowAsList" in the de-language file. For this entry there is also no fallbackString defined, so the menu in the CMS (right click on a page) is broken for each language that does not have the translation included.

I added another fallback level where the short version of the default language (en_US -> us) is searched before falling back to the fallbackstring and then finally giving up...
