### PR TITLE
Tidy up enum matching where classname is missing

### DIFF
--- a/model/fieldtypes/Enum.php
+++ b/model/fieldtypes/Enum.php
@@ -38,7 +38,7 @@ class Enum extends StringField {
 	public function __construct($name = null, $enum = NULL, $default = NULL) {
 		if($enum) {
 			if(!is_array($enum)) {
-				$enum = preg_split("/ *, */", trim($enum));
+				$enum = preg_split("/ *, */", trim(trim($enum, ',')));
 			}
 
 			$this->enum = $enum;

--- a/model/fieldtypes/MultiEnum.php
+++ b/model/fieldtypes/MultiEnum.php
@@ -18,7 +18,7 @@ class MultiEnum extends Enum {
 		// Validate and assign the default
 		$this->default = null;
 		if($default) {
-			$defaults = preg_split('/ *, */',trim($default));
+			$defaults = preg_split('/ *, */',trim(trim($default, ',')));
 			foreach($defaults as $thisDefault) {
 				if(!in_array($thisDefault, $this->enum)) {
 					user_error("Enum::__construct() The default value '$thisDefault' does not match "


### PR DESCRIPTION
This was causing a constant blue changed status for file since the enum matching differed (https://www.evernote.com/shard/s6/sh/7a28b633-e5d4-4b89-947b-19ebaf46084a/f0ff79c9e7aeca03e63dd9515447bd5e)
