### PR TITLE
Leave original ValidationException intact in write()

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1125,7 +1125,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 			if (!$valid->valid()) {
 				$writeException = new ValidationException(
 					$valid,
-					"Validation error writing a $this->class object: " . $valid->message() . ".  Object not written.",
+					$valid->message(),
 					E_USER_WARNING
 				);
 			}


### PR DESCRIPTION
If we want DataObject->validate() to be used instead of the form layer, we
should allow for validation errors to be passed through unchanged to the
controller layer so we can present them to the user. The context of which
class is written should be apparent from the stacktrace of the exception.
