### PR TITLE
Fix empty $messageBlock on CheckboxField

### DIFF
--- a/forms/CheckboxField.php
+++ b/forms/CheckboxField.php
@@ -47,7 +47,7 @@ class CheckboxField extends FormField {
 		} else {
 			extract($this->getXMLValues(array( 'Name', 'Field', 'Title', 'Message', 'MessageType' )),
 				EXTR_SKIP);
-			$messageBlock = isset($Message) ? "<span class=\"message $MessageType\">$Message</span>" : '';
+			$messageBlock = empty($Message) ? '' : "<span class=\"message $MessageType\">$Message</span>";
 			$Type = $this->XML_val('Type');
 			$extraClass = $this->XML_val('extraClass'); 
 			return <<<HTML


### PR DESCRIPTION
From 2.4.13 the FormField Message attribute is Text, so every checkbox now show an empty $messageBlock.

See https://github.com/silverstripe/silverstripe-framework/issues/2489 
or http://www.silverstripe.org/general-questions/show/25254
