### PR TITLE
BUG: #2503 Fixes performReadonlyTransformation for OptionSetField

### DIFF
--- a/forms/OptionsetField.php
+++ b/forms/OptionsetField.php
@@ -93,7 +93,7 @@ class OptionsetField extends DropdownField {
 	public function performReadonlyTransformation() {
 		// Source and values are DataObject sets.
 		$field = $this->castedCopy('LookupField');
-		$field->setValue($this->getSource());
+		$field->setSource($this->getSource());
 		$field->setReadonly(true);
 		
 		return $field;

--- a/tests/forms/OptionsetFieldTest.php
+++ b/tests/forms/OptionsetFieldTest.php
@@ -24,4 +24,14 @@ class OptionsetFieldTest extends SapphireTest {
 			''
 		);
 	}
+
+	public function testReadonlyField() {
+		$sourceArray = array(0 => 'No', 1 => 'Yes');
+		$field = new OptionsetField('FeelingOk', 'are you feeling ok?', $sourceArray, 1);
+		$field->setEmptyString('(Select one)');
+		$field->setValue(1);
+		$readonlyField = $field->performReadonlyTransformation();
+		preg_match('/Yes/', $field->Field(), $matches);
+		$this->assertEquals($matches[0], 'Yes');
+	}
 }


### PR DESCRIPTION
OptionSetField is using setValue in the method performReadonlyTransformation, which does not set the option values changed to use setSource to match DropdownField which it inherits from

See the following issue for more information

https://github.com/silverstripe/silverstripe-framework/issues/2503
