### PR TITLE
FIX: Year.php getDefaultOptions now fixed, sets key as year. Also added YearTest unit test.

### DIFF
--- a/model/fieldtypes/Year.php
+++ b/model/fieldtypes/Year.php
@@ -39,7 +39,7 @@ class Year extends DBField {
 		if (!$end) $end = 1900;
 		$years = array();
 		for($i=$start;$i>=$end;$i--) {
-			$years[] = $i;
+			$years[$i] = $i;
 		}
 		return $years;
 	}

--- a/tests/model/YearTest.php
+++ b/tests/model/YearTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @package framework
+ * @subpackage tests
+ */
+class YearTest extends SapphireTest {
+
+	/**
+	 * Test that the scaffolding form field works
+	 */
+	public function testScaffoldFormFieldFirst() {
+		$year = new Year();
+		$field = $year->scaffoldFormField("YearTest");
+		$this->assertEquals("DropdownField", get_class($field));
+
+		//This should be a list of years from the current one, counting down to 1900
+		$source = $field->getSource();
+
+		$lastValue = end($source);
+		$lastKey = key($source);
+
+		//Keys and values should be the same - and the last one should be 1900
+		$this->assertEquals(1900, $lastValue);
+		$this->assertEquals(1900, $lastKey);
+	}
+
+	public function testScaffoldFormFieldLast() {
+		$year = new Year();
+		$field = $year->scaffoldFormField("YearTest");
+		$source = $field->getSource();
+
+		//The first one should be the current year
+		$currentYear = (int)date('Y');
+		$firstValue = reset($source);
+		$firstKey = key($source);
+
+		$this->assertEquals($currentYear, $firstValue);
+		$this->assertEquals($currentYear, $firstKey);
+
+	}
+}


### PR DESCRIPTION
The default scaffolding for the Year type was failing, as getDefaultOptions was returning the following:

[0] => 2013
[1] => 2012
[2] => 2011
...

When it should have been returning:

[2013] => 2013
[2012] => 2012
[2011] => 2011

This merge fixes that, and adds a unit test as well.
