### PR TITLE
 File validate should have extend hook  

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -890,7 +890,9 @@ class File extends DataObject {
 		// We aren't validating for an existing "Filename" on the filesystem.
 		// A record should still be saveable even if the underlying record has been removed.
 		
-		return new ValidationResult(true);
+		$result = new ValidationResult(true);
+		$this->extend('validate', $result);
+		return $result;
 	}
 	
 	/**


### PR DESCRIPTION
Currently you can't add validation rules to File thru a DataExtension. This fixes this issue.
