### PR TITLE
BUGFIX: URL '/' ending up beeing redirected to '//'

### DIFF
--- a/core/startup/ParameterConfirmationToken.php
+++ b/core/startup/ParameterConfirmationToken.php
@@ -91,7 +91,7 @@ class ParameterConfirmationToken {
 		unset($params['url']);
 
 		// Join them all together into the original URL
-		$location = "$proto://" . $host . '/' . ltrim(BASE_URL, '/') . $url . ($params ? '?'.http_build_query($params) : '');
+		$location = "$proto://" . $host . (strlen(trim(BASE_URL, '/')) > 0 ? '/' . trim(BASE_URL, '/') : '' ) . (strlen(trim($url, '/')) > 0 ? '/' . trim($url, '/') : '' ) . ($params ? '?'.http_build_query($params) : '');
 
 		// And redirect
 		if (headers_sent()) {


### PR DESCRIPTION
With the introduction of the fix '/' after the host name, if the $url is '/' as well, the user ends up being redirected to '//', which causes an error on litespeed.
