### PR TITLE
API DataObject::validate() visibility changed to public (issue #1659)

### DIFF
--- a/docs/en/changelogs/3.2.0.md
+++ b/docs/en/changelogs/3.2.0.md
@@ -3,7 +3,24 @@
 ## Overview
 
  * Minimum PHP version raised to 5.3.3
+ * DataObject::validate() method visibility changed to public
 
 ## Changelog
+
+### DataObject::validate() method visibility changed to public
+
+The visibility of `DataObject::validate()` has been changed from `protected` to `public`.
+
+Any existing classes that currently set this as `protected` should be changed like in
+this example:
+
+	::php
+	class MyDataClass extends DataObject {
+		...
+		public function validate() {
+			...
+		}
+		...
+	}
 
 ### Bugfixes

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1015,7 +1015,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	 * 
 	 * @return A {@link ValidationResult} object
 	 */
-	protected function validate() {
+	public function validate() {
 		$result = ValidationResult::create();
 		$this->extend('validate', $result);
 		return $result;

--- a/security/PermissionRoleCode.php
+++ b/security/PermissionRoleCode.php
@@ -14,7 +14,7 @@ class PermissionRoleCode extends DataObject {
 		"Role" => "PermissionRole",
 	);
 
-	protected function validate() {
+	public function validate() {
 		$result = parent::validate();
 
 		// Check that new code doesn't increase privileges, unless an admin is editing.

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -1304,7 +1304,7 @@ class DataObjectTest_ValidatedObject extends DataObject implements TestOnly {
 		'Name' => 'Varchar(50)'
 	);
 	
-	protected function validate() {
+	public function validate() {
 		if(!empty($this->Name)) {
 			return new ValidationResult();
 		} else {


### PR DESCRIPTION
DataObject::validate() is currently set to protected, but this means
you can't call validate() from outside the context of itself unless
you overload the method to use a public visibility and then call
parent::validate()

As it would turn out, most classes that overload this method already
set the visibility to public, so it would make sense the parent matches
that as well.

Probably shouldn't go in 3.1, so this pull request has been made against master (to be 3.2)
