### PR TITLE
NEW UploadField lists all files, shows path info

### DIFF
--- a/docs/en/changelogs/3.2.0.md
+++ b/docs/en/changelogs/3.2.0.md
@@ -4,6 +4,7 @@
 
  * Minimum PHP version raised to 5.3.3
  * DataObject::validate() method visibility changed to public
+ * UploadField "Select from files" shows files in all folders by default
 
 ## Changelog
 
@@ -22,5 +23,12 @@ this example:
 		}
 		...
 	}
+
+### UploadField "Select from files" shows files in all folders by default
+
+In order to list files in a single folder by default (previous default behaviour), 
+use `setDisplayFolderName()` with a folder path relative to `assets/`:
+
+	UploadField::create('MyField')->setDisplayFolderName('Uploads');
 
 ### Bugfixes

--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -164,6 +164,15 @@ class UploadField extends FileField {
 	);
 
 	/**
+	 * @var String Folder to display in "Select files" list.
+	 * Defaults to listing all files regardless of folder. 
+	 * The folder path should be relative to the webroot.
+	 * See {@link FileField->folderName} to set the upload target instead.
+	 * @example admin/folder/subfolder
+	 */
+	protected $displayFolderName;
+
+	/**
 	 * FieldList $fields or string $name (of a method on File to provide a fields) for the EditForm
 	 * @example 'getCMSFields'
 	 * 
@@ -299,6 +308,21 @@ class UploadField extends FileField {
 	 */
 	public function setOverwriteWarning($overwriteWarning) {
 		return $this->setConfig('overwriteWarning', $overwriteWarning);
+	}
+
+	/**
+	 * @param String
+	 */
+	public function setDisplayFolderName($name) {
+		$this->displayFolderName = $name;
+		return $this;
+	}
+
+	/**
+	 * @return String
+	 */
+	public function getDisplayFolderName() {
+		return $this->displayFolderName;
 	}
 
 	/**
@@ -1537,8 +1561,8 @@ class UploadField_SelectHandler extends RequestHandler {
 	public function Form() {
 		// Find out the requested folder ID.
 		$folderID = $this->parent->getRequest()->requestVar('ParentID');
-		if (!isset($folderID)) {
-			$folder = Folder::find_or_make($this->folderName);
+		if ($folderID === null && $this->parent->getDisplayFolderName()) {
+			$folder = Folder::find_or_make($this->parent->getDisplayFolderName());
 			$folderID = $folder ? $folder->ID : 0;
 		}
 
@@ -1571,19 +1595,19 @@ class UploadField_SelectHandler extends RequestHandler {
 		$config = GridFieldConfig::create();
 		$config->addComponent(new GridFieldSortableHeader());
 		$config->addComponent(new GridFieldFilterHeader());
-		$config->addComponent($columns = new GridFieldDataColumns());
-		$columns->setDisplayFields(array(
-			'StripThumbnail' => '',
-			'Name' => 'Name',
-			'Title' => 'Title'
+		$config->addComponent($colsComponent = new GridFieldDataColumns());
+		$colsComponent->setDisplayFields(array(
+			'Title' => singleton('File')->fieldLabel('Name'),
+			'Filename' => singleton('File')->fieldLabel('Filename'),
+			'Size' => singleton('File')->fieldLabel('Size')
 		));
-		$config->addComponent(new GridFieldPaginator(8));
 
 		// If relation is to be autoset, we need to make sure we only list compatible objects.
 		$baseClass = $this->parent->getRelationAutosetClass();
 
 		// Create the data source for the list of files within the current directory.
-		$files = DataList::create($baseClass)->filter('ParentID', $folderID);
+		$files = DataList::create($baseClass);
+		if($folderID) $files = $files->filter('ParentID', $folderID);
 
 		$fileField = new GridField('Files', false, $files, $config);
 		$fileField->setAttribute('data-selectable', true);

--- a/tests/forms/uploadfield/UploadFieldTest.php
+++ b/tests/forms/uploadfield/UploadFieldTest.php
@@ -646,11 +646,27 @@ class UploadFieldTest extends FunctionalTest {
 
 		$record = $this->objFromFixture('UploadFieldTest_Record', 'record1');
 		$file4 = $this->objFromFixture('File', 'file4');
-		$file5 = $this->objFromFixture('File', 'file5');
 		$fileSubfolder = $this->objFromFixture('File', 'file-subfolder');
-		$fileNoEdit = $this->objFromFixture('File', 'file-noedit');
 
 		$response = $this->get('UploadFieldTest_Controller/Form/field/ManyManyFiles/select/');
+		$this->assertFalse($response->isError());
+
+		// A bit too much coupling with GridField, but a full template overload would make things too complex
+		$parser = new CSSContentParser($response->getBody());
+		$items = $parser->getBySelector('.ss-gridfield-item');
+		$itemIDs = array_map(create_function('$el', 'return (int)$el["data-id"];'), $items);
+		$this->assertContains($file4->ID, $itemIDs, 'Contains file in assigned folder');
+		$this->assertContains($fileSubfolder->ID, $itemIDs, 'Contains file in subfolder');
+	}
+
+	public function testSelectWithDisplayFolderName() {
+		$this->loginWithPermission('ADMIN');
+
+		$record = $this->objFromFixture('UploadFieldTest_Record', 'record1');
+		$file4 = $this->objFromFixture('File', 'file4');
+		$fileSubfolder = $this->objFromFixture('File', 'file-subfolder');
+
+		$response = $this->get('UploadFieldTest_Controller/Form/field/HasManyDisplayFolder/select/');
 		$this->assertFalse($response->isError());
 
 		// A bit too much coupling with GridField, but a full template overload would make things too complex
@@ -907,6 +923,10 @@ class UploadFieldTestForm extends Form implements TestOnly {
 		
 		$fieldHasManyNoView = UploadField::create('HasManyNoViewFiles')
 			->setFolderName('UploadFieldTest');
+
+		$fieldHasManyDisplayFolder = UploadField::create('HasManyDisplayFolder')
+			->setFolderName('UploadFieldTest')
+			->setDisplayFolderName('UploadFieldTest');
 		
 		$fieldReadonly = UploadField::create('ReadonlyField')
 			->setFolderName('UploadFieldTest')
@@ -938,6 +958,7 @@ class UploadFieldTestForm extends Form implements TestOnly {
 			$fieldHasManyMaxTwo,
 			$fieldManyMany,
 			$fieldHasManyNoView,
+			$fieldHasManyDisplayFolder,
 			$fieldReadonly,
 			$fieldDisabled,
 			$fieldSubfolder,


### PR DESCRIPTION
It doesn't make a lot of sense to limit the listing to assets/Uploads/, which
is the default set through FileField->folderName. Showing all files regardless
of folder makes them easier to find, users can still opt-in to filtering by
folder through the TreeDropdownField.
