### PR TITLE
Change the LRU cache to a simple in-memory mode

### DIFF
--- a/tests/core/ConfigTest.php
+++ b/tests/core/ConfigTest.php
@@ -225,47 +225,31 @@ class ConfigTest extends SapphireTest {
 		$this->markTestIncomplete();
 	}
 
-	public function testLRUDiscarding() {
-		$cache = new ConfigTest_Config_LRU();
-
-		for ($i = 0; $i < Config_LRU::SIZE*2; $i++) $cache->set($i, $i);
-		$this->assertEquals(
-			Config_LRU::SIZE, count($cache->indexing),
-			'Homogenous usage gives exact discarding'
-		);
-
-		$cache = new ConfigTest_Config_LRU();
-
-		for ($i = 0; $i < Config_LRU::SIZE; $i++) $cache->set($i, $i);
-		for ($i = 0; $i < Config_LRU::SIZE; $i++) $cache->set(-1, -1);
-		$this->assertLessThan(
-			Config_LRU::SIZE, count($cache->indexing),
-			'Heterogenous usage gives sufficient discarding'
-		);
-	}
-
 	public function testLRUCleaning() {
 		$cache = new ConfigTest_Config_LRU();
 
-		for ($i = 0; $i < Config_LRU::SIZE; $i++) $cache->set($i, $i);
-		$this->assertEquals(Config_LRU::SIZE, count($cache->indexing));
+		for ($i = 0; $i < 1000; $i++) $cache->set($i, $i);
+		$this->assertEquals(1000, count($cache->cache));
 
 		$cache->clean();
-		$this->assertEquals(0, count($cache->indexing), 'Clean clears all items');
+		$this->assertEquals(0, count($cache->cache), 'Clean clears all items');
 		$this->assertFalse($cache->get(1), 'Clean clears all items');
 
 		$cache->set(1, 1, array('Foo'));
-		$this->assertEquals(1, count($cache->indexing));
+		$this->assertEquals(1, count($cache->cache));
+		$this->assertEquals(1, count($cache->tags));
 
 		$cache->clean('Foo');
-		$this->assertEquals(0, count($cache->indexing), 'Clean items with matching tag');
+		$this->assertEquals(0, count($cache->tags), 'Clean items with matching tag');
 		$this->assertFalse($cache->get(1), 'Clean items with matching tag');
 
 		$cache->set(1, 1, array('Foo', 'Bar'));
-		$this->assertEquals(1, count($cache->indexing));
+		$this->assertEquals(2, count($cache->tags));
+		$this->assertEquals(1, count($cache->cache));
 
 		$cache->clean('Bar');
-		$this->assertEquals(0, count($cache->indexing), 'Clean items with any single matching tag');
+		$this->assertEquals(1, count($cache->tags));
+		$this->assertEquals(0, count($cache->cache), 'Clean items with any single matching tag');
 		$this->assertFalse($cache->get(1), 'Clean items with any single matching tag');
 	}
 }
@@ -273,6 +257,6 @@ class ConfigTest extends SapphireTest {
 class ConfigTest_Config_LRU extends Config_LRU {
 
 	public $cache;
-	public $indexing;
+	public $tags;
 
 }


### PR DESCRIPTION
This dramatically decreases the complexity and overhead of the Config_LRU cache with only a slight increase in memory usage when the cache hits about 2000 items.

As an aside, Config_LRU should probably get renamed now that it's not a LRU cache.
