### PR TITLE
NEW add logout url to Security

### DIFF
--- a/admin/templates/Includes/LeftAndMain_Menu.ss
+++ b/admin/templates/Includes/LeftAndMain_Menu.ss
@@ -8,7 +8,7 @@
 		</div>
 	
 		<div class="cms-login-status">
-			<a href="Security/logout" class="logout-link" title="<% _t('LeftAndMain_Menu_ss.LOGOUT','Log out') %>"><% _t('LeftAndMain_Menu_ss.LOGOUT','Log out') %></a>
+			<a href="$LogoutURL" class="logout-link" title="<% _t('LeftAndMain_Menu_ss.LOGOUT','Log out') %>"><% _t('LeftAndMain_Menu_ss.LOGOUT','Log out') %></a>
 			<% with $CurrentMember %>
 				<span>
 					<% _t('LeftAndMain_Menu_ss.Hello','Hi') %>

--- a/security/Security.php
+++ b/security/Security.php
@@ -4,7 +4,7 @@
  * @package framework
  * @subpackage security
  */
-class Security extends Controller {
+class Security extends Controller implements TemplateGlobalProvider {
 	
 	private static $allowed_actions = array( 
 		'index', 
@@ -96,7 +96,25 @@ class Security extends Controller {
 	 * @var String
 	 */
 	private static $token;
-	
+
+	/**
+	 * The default login URL
+	 *
+	 * @config
+	 *
+	 * @var string
+	 */
+	private static $login_url = "Security/login";
+
+	/**
+	 * The default logout URL
+	 *
+	 * @config
+	 *
+	 * @var string
+	 */
+	private static $logout_url = "Security/logout";
+
 	/**
 	 * Get location of word list file
 	 *
@@ -989,22 +1007,52 @@ class Security extends Controller {
 		return self::$ignore_disallowed_actions;
 	}
 
-	/** @config */
-	private static $login_url = "Security/login";
 
 	/**
 	 * Set a custom log-in URL if you have built your own log-in page.
+	 *
+	 * @deprecated 3.2 Use the "Security.login_url" config setting instead.
 	 */
 	public static function set_login_url($loginUrl) {
-		self::$login_url = $loginUrl;
+		Deprecation::notice('3.2', 'Use the "Security.login_url" config setting instead');
+		self::config()->update("login_url", $loginUrl);
 	}
+
 
 	/**
 	 * Get the URL of the log-in page.
-	 * Defaults to Security/login but can be re-set with {@link set_login_url()}
+	 * 
+	 * To update the login url use the "Security.login_url" config setting.
+	 *
+	 * @return string
 	 */
 	public static function login_url() {
-		return self::$login_url;
+		return self::config()->login_url;
+	}
+
+
+	/**
+	 * Get the URL of the logout page.
+	 * 
+	 * To update the logout url use the "Security.logout_url" config setting.
+	 *
+	 * @return string
+	 */
+	public static function logout_url() {
+		return self::config()->logout_url;
+	}
+
+
+	/**
+	 * Defines global accesible templates variables.
+	 *
+	 * @return array
+	 */
+	public static function get_template_global_variables() {
+		return array(
+			"LoginURL" => "login_url",
+			"LogoutURL" => "logout_url",
+		);
 	}
 
 }

--- a/tests/security/SecurityTest.php
+++ b/tests/security/SecurityTest.php
@@ -414,7 +414,7 @@ class SecurityTest extends FunctionalTest {
 	 * Helper method for the tests above
 	 */
 	public function doTestLoginForm($email, $password, $backURL = 'test/link') {
-		$this->get('Security/logout');
+		$this->get(Config::inst()->get('Security', 'logout_url'));
 		$this->session()->inst_set('BackURL', $backURL);
 		$this->get(Config::inst()->get('Security', 'login_url'));
 		


### PR DESCRIPTION
Added logout_url config setting to Security and global template variables $LogoutURL and $LoginURL.

I've also deprecated the use of Security::set_login_url() in favour of the config api.
