### PR TITLE
API moved useTestTheme to base Sapphire test class so that it can be used elsewhere

### DIFF
--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -883,6 +883,37 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 	 * Cache for logInWithPermission()
 	 */
 	protected $cache_generatedMembers = array();
+
+
+	/**
+	 * Test against a theme.
+	 *
+	 * @param $themeBaseDir string - themes directory
+	 * @param $theme string - theme name
+	 * @param $callback Closure
+	 */
+	protected function useTestTheme($themeBaseDir, $theme, $callback) {
+		global $project;
+
+		$manifest = new SS_TemplateManifest($themeBaseDir, $project, true, true);
+
+		SS_TemplateLoader::instance()->pushManifest($manifest);
+
+		$origTheme = Config::inst()->get('SSViewer', 'theme');
+		Config::inst()->update('SSViewer', 'theme', $theme);
+
+		$e = null;
+
+		try { $callback(); }
+		catch (Exception $e) { /* NOP for now, just save $e */ }
+
+		// Remove all the test themes we created
+		SS_TemplateLoader::instance()->popManifest();
+		Config::inst()->update('SSViewer', 'theme', $origTheme);
+
+		if ($e) throw $e;
+	}
+
 }
 
 

--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -983,33 +983,10 @@ after')
 		);
 	}
 
-	protected function useTestTheme($theme, $callback) {
-		global $project;
-
-		$themeBaseDir = dirname(__FILE__);
-		$manifest = new SS_TemplateManifest($themeBaseDir, $project, true, true);
-
-		SS_TemplateLoader::instance()->pushManifest($manifest);
-
-		$origTheme = Config::inst()->get('SSViewer', 'theme');
-		Config::inst()->update('SSViewer', 'theme', $theme);
-
-		$e = null;
-
-		try { $callback(); }
-		catch (Exception $e) { /* NOP for now, just save $e */ }
-
-		// Remove all the test themes we created
-		SS_TemplateLoader::instance()->popManifest();
-		Config::inst()->update('SSViewer', 'theme', $origTheme);
-
-		if ($e) throw $e;
-	}
-
 	public function testLayout() {
 		$self = $this;
 
-		$this->useTestTheme('layouttest', function() use ($self) {
+		$this->useTestTheme(dirname(__FILE__), 'layouttest', function() use ($self) {
 			$template = new SSViewer(array('Page'));
 			$self->assertEquals('Foo', $template->process(new ArrayData(array())));
 
@@ -1023,7 +1000,7 @@ after')
 	 */
 	public function testGetTemplatesByClass() {
 		$self = $this;
-		$this->useTestTheme('layouttest', function() use ($self) {
+		$this->useTestTheme(dirname(__FILE__), 'layouttest', function() use ($self) {
 			// Test passing a string
 			$templates = SSViewer::get_templates_by_class('SSViewerTest_Controller', '', 'Controller');
 			$self->assertCount(2, $templates);


### PR DESCRIPTION
This is to allow other classes to use a test theme. More specifically, I need to use a custom theme in a CMS test to ensure the correct templates are chosen and the tests pass.

See https://github.com/silverstripe/silverstripe-cms/pull/914 for more.
