### PR TITLE
FIX: Documentation for Silverstripe Test

### DIFF
--- a/docs/en/topics/testing/creating-a-silverstripe-test.md
+++ b/docs/en/topics/testing/creating-a-silverstripe-test.md
@@ -16,7 +16,7 @@ Here is an example of a test which extends SapphireTest:
 	class SiteTreeTest extends SapphireTest {
 
 		// Define the fixture file to use for this test class
-		private static $fixture_file = 'SiteTreeTest.yml';
+		protected static $fixture_file = 'SiteTreeTest.yml';
 
 		/**
 		 * Test generation of the URLSegment values.


### PR DESCRIPTION
Change the access level of the `static $fixture_file` property in the example code.
