### PR TITLE
API: Prevent large images from repeatedly crashing PHP on resize

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -44,6 +44,8 @@ if (!is_dir($aggregatecachedir)) mkdir($aggregatecachedir);
 SS_Cache::add_backend('aggregatestore', 'File', array('cache_dir' => $aggregatecachedir));
 SS_Cache::pick_backend('aggregatestore', 'aggregate', 1000);
 
+SS_Cache::set_cache_lifetime('GDBackend_Manipulations', null, 100);
+
 // If you don't want to see deprecation errors for the new APIs, change this to 3.0.0-dev.
 Deprecation::notification_version('3.1.0');
 

--- a/filesystem/GD.php
+++ b/filesystem/GD.php
@@ -8,6 +8,8 @@ class GDBackend extends Object implements Image_Backend {
 	protected $gd, $width, $height;
 	protected $quality;
 	protected $interlace;
+	protected $lockFile;
+	protected $cache, $cacheKey, $manipulation;
 	
 	/**
 	 * @config
@@ -34,29 +36,42 @@ class GDBackend extends Object implements Image_Backend {
 		}
 	}
 
-	public function __construct($filename = null) {
+	public function __construct($filename = null, $args = array()) {
 		// If we're working with image resampling, things could take a while.  Bump up the time-limit
 		increase_time_limit_to(300);
 
+		$this->cache = SS_Cache::factory('GDBackend_Manipulations');
+
 		if($filename) {
-			// We use getimagesize instead of extension checking, because sometimes extensions are wrong.
-			list($width, $height, $type, $attr) = getimagesize($filename);
-			switch($type) {
-				case 1:
-					if(function_exists('imagecreatefromgif'))
-						$this->setImageResource(imagecreatefromgif($filename));
-					break;
-				case 2:
-					if(function_exists('imagecreatefromjpeg'))
-						$this->setImageResource(imagecreatefromjpeg($filename));
-					break;
-				case 3:
-					if(function_exists('imagecreatefrompng')) {
-						$img = imagecreatefrompng($filename);
-						imagesavealpha($img, true); // save alphablending setting (important)
-						$this->setImageResource($img);
-					}
-					break;
+			$this->cacheKey = md5(implode('_', array($filename, filemtime($filename))));
+			$this->manipulation = implode('|', $args);
+
+			$cacheData = unserialize($this->cache->load($this->cacheKey));
+			$cacheData = ($cacheData !== false) ? $cacheData : array();
+
+			if ($this->imageAvailable($filename, $this->manipulation)) {
+				$cacheData[$this->manipulation] = true;
+				$this->cache->save(serialize($cacheData), $this->cacheKey);
+
+				// We use getimagesize instead of extension checking, because sometimes extensions are wrong.
+				list($width, $height, $type, $attr) = getimagesize($filename);
+				switch($type) {
+					case 1:
+						if(function_exists('imagecreatefromgif'))
+							$this->setImageResource(imagecreatefromgif($filename));
+						break;
+					case 2:
+						if(function_exists('imagecreatefromjpeg'))
+							$this->setImageResource(imagecreatefromjpeg($filename));
+						break;
+					case 3:
+						if(function_exists('imagecreatefrompng')) {
+							$img = imagecreatefrompng($filename);
+							imagesavealpha($img, true); // save alphablending setting (important)
+							$this->setImageResource($img);
+						}
+						break;
+				}
 			}
 		}
 		
@@ -64,6 +79,14 @@ class GDBackend extends Object implements Image_Backend {
 
 		$this->quality = $this->config()->default_quality;
 		$this->interlace = $this->config()->image_interlace;
+	}
+
+	public function __destruct() {
+		if ($this->hasImageResource()) { 
+			$cacheData = unserialize($this->cache->load($this->cacheKey));
+			unset($cacheData[$this->manipulation]);
+			$this->cache->save(serialize($cacheData), $this->cacheKey);
+		}
 	}
 	
 	public function setImageResource($resource) {
@@ -84,6 +107,67 @@ class GDBackend extends Object implements Image_Backend {
 	public function getGD() {
 		Deprecation::notice('3.1', 'GD::getImageResource instead');
 		return $this->getImageResource();
+	}
+
+	/**
+	 * @param string $filename
+	 * @return boolean
+	 */
+	public function imageAvailable($filename, $manipulation) {
+		return ($this->checkAvailableMemory($filename) && ! $this->failedResample($filename, $manipulation));
+	}
+
+	/**
+	 * Check if we've got enough memory available for resampling this image. This check is rough,
+	 * so it will not catch all images that are too large - it also won't work accurately on large,
+	 * animated GIFs as bits per pixel can't be calculated for an animated GIF with a global color
+	 * table.
+	 * 
+	 * @param string $filename
+	 * @return boolean
+	 */
+	public function checkAvailableMemory($filename) {
+		$limit = translate_memstring(ini_get('memory_limit'));
+
+		if ($limit < 0) return true; // memory_limit == -1
+
+		$imageInfo = getimagesize($filename);
+
+		// bits per channel (rounded up, default to 1)
+		$bits = isset($imageInfo['bits']) ? ($imageInfo['bits'] + 7) / 8 : 1;
+
+		// channels (default 4 rgba)
+		$channels = isset($imageInfo['channels']) ? $imageInfo['channels'] : 4;
+
+		$bytesPerPixel = $bits * $channels;
+
+		// width * height * bytes per pixel
+		$memoryRequired = $imageInfo[0] * $imageInfo[1] * $bytesPerPixel;
+
+		return $memoryRequired + memory_get_usage() < $limit;
+	}
+
+	/**
+	 * Check if this image has previously crashed GD when attempting to open it - if it's opened
+	 * successfully, the 'lock' file is deleted.
+	 * 
+	 * @param string $filename
+	 * @return boolean
+	 */
+	public function failedResample($filename, $manipulation) {
+		$cacheData = unserialize($this->cache->load($this->cacheKey));
+		return ($cacheData && array_key_exists($manipulation, $cacheData));
+	}
+
+	/**
+	 * Get the 'lock' file name, e.g. .lock.my-image.jpg
+	 * 
+	 * @param string $filename
+	 * @return boolean
+	 */
+	public function getLockfileName($filename) {
+		$pathInfo = pathinfo($filename);
+		return $pathInfo['dirname'] . '/.lock.' . $pathInfo['filename'] . '.' . $pathInfo['extension'];
 	}
 
 	/**
@@ -480,6 +564,18 @@ class GDBackend extends Object implements Image_Backend {
 					imagepng($this->gd, $filename); break;
 			}
 			if(file_exists($filename)) @chmod($filename,0664);
+		}
+	}
+
+	public function onBeforeDelete($frontend) {
+		$file = Director::baseFolder() . "/" . $frontend->Filename;
+
+		if (file_exists($file)) {
+			$key = md5(implode('_', array($file, filemtime($file))));
+
+			if (unserialize($this->cache->load($key))) {
+				$this->cache->remove($key);
+			}
 		}
 	}
 	

--- a/filesystem/ImagickBackend.php
+++ b/filesystem/ImagickBackend.php
@@ -97,6 +97,16 @@ class ImagickBackend extends Imagick implements Image_Backend {
 	}
 
 	/**
+	 * @todo Implement memory checking/lock file for Imagick?
+	 * 
+	 * @param string $filename
+	 * @return boolean
+	 */
+	public function imageAvailable($filename) {
+		return true;
+	}
+
+	/**
 	 * resize
 	 *
 	 * @param int $width
@@ -263,6 +273,14 @@ class ImagickBackend extends Imagick implements Image_Backend {
 		}
 		$new->ThumbnailImage($width,$height,true);
 		return $new;
+	}
+
+	/**
+	 * @param Image $frontend
+	 * @return void
+	 */
+	public function onBeforeDelete($frontend) {
+		// Not in use
 	}
 }
 }

--- a/model/Image.php
+++ b/model/Image.php
@@ -459,7 +459,8 @@ class Image extends File {
 		$cacheFile = call_user_func_array(array($this, "cacheFilename"), $args);
 		
 		$backend = Injector::inst()->createWithArgs(self::$backend, array(
-			Director::baseFolder()."/" . $this->Filename
+			Director::baseFolder()."/" . $this->Filename,
+			$args
 		));
 		
 		if($backend->hasImageResource()) {
@@ -642,9 +643,12 @@ class Image extends File {
 	}
 	
 	protected function onBeforeDelete() {
-		parent::onBeforeDelete(); 
+		$backend = Injector::inst()->create(self::$backend);
+		$backend->onBeforeDelete($this);
 
 		$this->deleteFormattedImages();
+
+		parent::onBeforeDelete();
 	}
 }
 

--- a/model/Image_Backend.php
+++ b/model/Image_Backend.php
@@ -110,4 +110,21 @@ interface Image_Backend {
 	 * @return Image_Backend
 	 */
 	public function croppedResize($width, $height);
+
+	/**
+	 * imageAvailable
+	 * 
+	 * @param string $filename
+	 * @return boolean
+	 */
+	public function imageAvailable($filename, $manipulation);
+
+	/**
+	 * onBeforeDelete
+	 * 
+	 * @param Image $frontend
+	 * @return void
+	 */
+	public function onBeforeDelete($frontend);
+
 }

--- a/tasks/CleanImageManipulationCache.php
+++ b/tasks/CleanImageManipulationCache.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Wipe the cache of failed image manipulations. When {@link GDBackend} attempts to resample an image, it will write
+ * the attempted manipulation to the cache and remove it from the cache if the resample is successful. The objective
+ * of the cache is to prevent fatal errors (for example from exceeded memory limits) from occurring more than once.
+ *
+ * @package framework
+ * @subpackage filesystem
+ */
+class CleanImageManipulationCache extends BuildTask {
+	
+	protected $title = 'Clean Image Manipulation Cache';
+	
+	protected $description = 'Clean the failed image manipulation cache. Use this to allow SilverStripe to attempt
+		to resample images that have previously failed to resample (for example if memory limits were exceeded).';
+	
+	/**
+	 * Check that the user has appropriate permissions to execute this task
+	 */
+	public function init() {
+		if(!Director::is_cli() && !Director::isDev() && !Permission::check('ADMIN')) {
+			return Security::permissionFailure();
+		}
+		
+		parent::init();
+	}
+	
+	/**
+	 * Clear out the image manipulation cache
+	 * @param SS_HTTPRequest $request
+	 */
+	public function run($request) {
+		$failedManipulations = 0;
+		$processedImages = 0;
+		$images = DataObject::get('Image');
+		
+		if($images && Image::get_backend() == "GDBackend") {
+			$cache = SS_Cache::factory('GDBackend_Manipulations');
+
+			foreach($images as $image) {
+				$path = $image->getFullPath();
+
+				if (file_exists($path)) {
+					$key = md5(implode('_', array($path, filemtime($path))));
+
+					if ($manipulations = unserialize($cache->load($key))) {
+						$failedManipulations += count($manipulations);
+						$processedImages++;
+						$cache->remove($key);
+					}
+				}
+			}
+		}
+		
+		echo "Cleared $failedManipulations failed manipulations from 
+			$processedImages Image objects stored in the Database.";
+	}
+	
+}

--- a/tests/filesystem/GDTest.php
+++ b/tests/filesystem/GDTest.php
@@ -15,6 +15,11 @@ class GDTest extends SapphireTest {
 		'png32' => 'test_png32.png'
 	);
 	
+	public function tearDown() {
+		$cache = SS_Cache::factory('GDBackend_Manipulations');
+		$cache->clean(Zend_Cache::CLEANING_MODE_ALL);
+	}
+	
 	/**
 	 * Loads all images into an associative array of GD objects.
 	 * Optionally applies an operation to each GD
@@ -135,4 +140,70 @@ class GDTest extends SapphireTest {
 		$samplesPNG32 = $this->sampleAreas($images['png32']);
 		$this->assertGreyscale($samplesPNG32, 8);
 	}
+
+	/**
+	 * Tests that GD doesn't attempt to load images when they're deemed unavailable
+	 * @return void
+	 */
+	public function testImageSkippedWhenUnavailable() {
+		$fullPath = realpath(dirname(__FILE__) . '/gdtest/test_jpg.jpg');
+		$gd = new GDBackend_ImageUnavailable($fullPath);
+
+		/* Ensure no image resource is created if the image is unavailable */
+		$this->assertNull($gd->getImageResource());
+	}
+
+	/**
+	 * Tests the integrity of the manipulation cache when an error occurs
+	 * @return void
+	 */
+	public function testCacheIntegrity() {
+		$fullPath = realpath(dirname(__FILE__) . '/gdtest/test_jpg.jpg');
+
+		try {
+			$gdFailure = new GDBackend_Failure($fullPath, array('SetWidth', 123));
+		} catch (Exception $e) {
+			$cache = SS_Cache::factory('GDBackend_Manipulations');
+			$key = md5(implode('_', array($fullPath, filemtime($fullPath))));
+
+			$data = unserialize($cache->load($key));
+
+			$this->assertArrayHasKey('SetWidth|123', $data);
+			$this->assertTrue($data['SetWidth|123']);
+		}
+	}
+
+	/**
+	 * Test that GD::failedResample() returns true for the current image
+	 * manipulation only if it previously failed
+	 * @return void
+	 */
+	public function testFailedResample() {
+		$fullPath = realpath(dirname(__FILE__) . '/gdtest/test_jpg.jpg');
+
+		try {
+			$gdFailure = new GDBackend_Failure($fullPath, array('SetWidth-failed', 123));
+		} catch (Exception $e) {
+			$gd = new GDBackend($fullPath, array('SetWidth', 123));
+			$this->assertTrue($gd->failedResample($fullPath, 'SetWidth-failed|123'));
+			$this->assertFalse($gd->failedResample($fullPath, 'SetWidth-not-failed|123'));
+		}
+	}
+
+}
+
+class GDBackend_ImageUnavailable extends GDBackend implements TestOnly {
+
+	public function imageAvailable($filename, $manipulation) {
+		return false;
+	}
+
+}
+
+class GDBackend_Failure extends GDBackend implements TestOnly {
+
+	public function setImageResource($resource) {
+		throw new Exception('GD failed to load image');
+	}
+
 }

--- a/tests/model/GDImageTest.php
+++ b/tests/model/GDImageTest.php
@@ -1,5 +1,7 @@
 <?php
+
 class GDImageTest extends ImageTest {
+
 	public function setUp() {
 		if(!extension_loaded("gd")) {
 			$this->markTestSkipped("The GD extension is required");
@@ -25,4 +27,39 @@ class GDImageTest extends ImageTest {
 			$file->write();
 		}
 	}
+
+	public function tearDown() {
+		$cache = SS_Cache::factory('GDBackend_Manipulations');
+		$cache->clean(Zend_Cache::CLEANING_MODE_ALL);
+	}
+
+	/**
+	 * Test that the cache of manipulation failures is cleared when deleting
+	 * the image object
+	 * @return void
+	 */
+	public function testCacheCleaningOnDelete() {
+		$image = $this->objFromFixture('Image', 'imageWithTitle');
+		$cache = SS_Cache::factory('GDBackend_Manipulations');
+		$fullPath = $image->getFullPath();
+		$key = md5(implode('_', array($fullPath, filemtime($fullPath))));
+
+		try {
+			// Simluate a failed manipulation
+			$gdFailure = new GDBackend_Failure($fullPath, array('SetWidth', 123));
+		} catch (Exception $e) {
+			// Check that the cache has stored the manipulation failure
+			$data = unserialize($cache->load($key));
+			$this->assertArrayHasKey('SetWidth|123', $data);
+			$this->assertTrue($data['SetWidth|123']);
+
+			// Delete the image object
+			$image->delete();
+
+			// Check that the cache has been removed
+			$data = unserialize($cache->load($key));
+			$this->assertFalse($data);
+		}
+	}
+
 }


### PR DESCRIPTION
This is a (late) follow up to the discussion [here](https://groups.google.com/forum/#!searchin/silverstripe-dev/image/silverstripe-dev/B57a3KYeAVQ/fUjsQQnfEPAJ) about GD crashing when attempting to open large or high DPI images.

The Google Group discussion involved ideas around “image unavailable” icons in the CMS, this setup (by storing which manipulation failed) will hopefully pave the way for that functionality to be added later, while addressing the immediate issue of completely crashing entire sections of websites.

Implements the same method for checking available memory as #2569, though it’s different to the [method Ingo suggested](http://php.net/manual/en/function.imagecreatefromjpeg.php#64155). I’m not really sure which is more robust, the method in the php.net comments doesn’t take into account that bits and channels aren’t always present in the image info.

Marked as an API change as I’ve added a few methods to the `Image_Backend` interface. Have only tested the basic functionality so far, unit tests etc are still todo. Perhaps this would be better opened against master and delayed until 3.2?

Doesn’t cause any issues with the CMS, the images just don’t appear for now:

![screen shot 2014-01-02 at 16 15 27](https://f.cloud.github.com/assets/1655548/1833671/53841ff0-73ce-11e3-8daa-840aa19ddcdd.png)
![screen shot 2014-01-02 at 16 17 23](https://f.cloud.github.com/assets/1655548/1833673/55a842ca-73ce-11e3-8d17-a1820c5bd4bf.png)

All comments welcome.
