### PR TITLE
Allow GridFields without titles to be found.

### DIFF
--- a/tests/behat/features/bootstrap/SilverStripe/Framework/Test/Behaviour/CmsUiContext.php
+++ b/tests/behat/features/bootstrap/SilverStripe/Framework/Test/Behaviour/CmsUiContext.php
@@ -114,11 +114,20 @@ class CmsUiContext extends BehatContext {
 		$table_element = null;
 		foreach ($table_elements as $table) {
 			$table_title_element = $table->find('css', '.title');
-			if ($table_title_element->getText() === $title) {
+			if ($table_title_element && $table_title_element->getText() === $title) {
 				$table_element = $table;
 				break;
 			}
 		}
+
+		// Some {@link GridField} tables don't have a visible title, so look for a fieldset with data-name instead
+		if(!$table_element) {
+			$fieldset = $page->findAll('xpath', "//fieldset[@data-name='$title']");
+			if(is_array($fieldset) && isset($fieldset[0])) {
+				$table_element = $fieldset[0]->find('css', '.ss-gridfield-table');
+			}
+		}
+
 		assertNotNull($table_element, sprintf('Table `%s` not found', $title));
 
 		return $table_element;


### PR DESCRIPTION
This fixes an issue with a silverstripe-cms behat test (insert-an-image.feature). In some cases, a GridField won't have a title element, which means that getGridFieldTable() won't be able to find it. This uses the data-name attribute, which is added to the fieldset element that surrounds a GridField.

It doesn't appear that we can just use one method over another, as data-name won't exist unless there is no visible title.
