### PR TITLE
BUGFIX: Fix SecurityAdmin checkboxes not being properly unchecked

### DIFF
--- a/admin/javascript/SecurityAdmin.js
+++ b/admin/javascript/SecurityAdmin.js
@@ -60,15 +60,15 @@
 				
 				if(this.is(':checked')) {
 					checkboxes.each(function() {
-						$(this).data('SecurityAdmin.oldChecked', $(this).attr('checked'));
-						$(this).data('SecurityAdmin.oldDisabled', $(this).attr('disabled'));
-						$(this).attr('disabled', 'disabled');
-						$(this).attr('checked', 'checked');
+						$(this).data('SecurityAdmin.oldChecked', $(this).is(':checked'));
+						$(this).data('SecurityAdmin.oldDisabled', $(this).is(':disabled'));
+						$(this).prop('disabled', true);
+						$(this).prop('checked', true);
 					});
 				} else {
 					checkboxes.each(function() {
-						$(this).attr('checked', $(this).data('SecurityAdmin.oldChecked') === 'checked');
-						$(this).attr('disabled', $(this).data('SecurityAdmin.oldDisabled') === 'disabled');
+						$(this).prop('checked', $(this).data('SecurityAdmin.oldChecked'));
+						$(this).prop('disabled', $(this).data('SecurityAdmin.oldDisabled'));
 					});
 				}
 			}

--- a/javascript/PermissionCheckboxSetField.js
+++ b/javascript/PermissionCheckboxSetField.js
@@ -72,15 +72,15 @@
 				var checkboxes = this.getCheckboxesExceptThisOne();
 				if($(this).is(':checked')) {
 					checkboxes.each(function() {
-						$(this).data('PermissionCheckboxSetField.oldChecked', $(this).attr('checked'));
-						$(this).data('PermissionCheckboxSetField.oldDisabled', $(this).attr('disabled'));
-						$(this).attr('disabled', 'disabled');
-						$(this).attr('checked', 'checked');
+						$(this).data('PermissionCheckboxSetField.oldChecked', $(this).is(':checked'));
+						$(this).data('PermissionCheckboxSetField.oldDisabled', $(this).is(':disabled'));
+						$(this).prop('disabled', 'disabled');
+						$(this).prop('checked', 'checked');
 					});
 				} else {
 					checkboxes.each(function() {
-						$(this).attr('checked', $(this).data('PermissionCheckboxSetField.oldChecked') === 'checked');
-						$(this).attr('disabled', $(this).data('PermissionCheckboxSetField.oldDisabled') === 'disabled');
+						$(this).prop('checked', $(this).data('PermissionCheckboxSetField.oldChecked'));
+						$(this).prop('disabled', $(this).data('PermissionCheckboxSetField.oldDisabled'));
 					});
 				}
 			}


### PR DESCRIPTION
This fixes a bug where while editing a group in SecurityAdmin, if you went to the Permissions tab, and selected the 'Full administrative rights' checkbox, then if you unchecked the same checkbox, all the other checkboxes were still disabled and checked, meaning you couldn't change them. This led to inconsistent UX - they were checked, but didn't submit so the permissions didn't change.

This fixes both the 'Full administrative rights' and 'Access to all CMS sections' checkboxes. The CMS will remember which checkboxes were checked prior to turning them all on, and restore those choices when you uncheck one of those two checkboxes.

This works in latest Chrome, latest Firefox for Mac, and IE9. I haven't extensively tested other browsers.
