### PR TITLE
BUG: #2766 Corrects MoneyField::performReadonlyTransformation()

### DIFF
--- a/forms/MoneyField.php
+++ b/forms/MoneyField.php
@@ -120,6 +120,8 @@ class MoneyField extends FormField {
 	 */
 	public function performReadonlyTransformation() {
 		$clone = clone $this;
+		$clone->fieldAmount = $clone->fieldAmount->performReadonlyTransformation();
+        $clone->fieldCurrency = $clone->fieldCurrency->performReadonlyTransformation();
 		$clone->setReadonly(true);
 		return $clone;
 	}
@@ -131,8 +133,8 @@ class MoneyField extends FormField {
 	public function setReadonly($bool) {
 		parent::setReadonly($bool);
 		
-		$this->fieldAmount = $this->fieldAmount->performReadonlyTransformation();
-        $this->fieldCurrency = $this->fieldCurrency->performReadonlyTransformation();
+		$this->fieldAmount->setReadonly($bool);
+        $this->fieldCurrency->setReadonly($bool);
 
 		return $this;
 	}


### PR DESCRIPTION
MoneyField::performReadonlyTransformation() only performs setReadonly() on the two child fields (currency and amount). Their field types need to be changed to ReadonlyField.

This fix causes our cloned MoneyField to actually contain two ReadonlyFields for currency and amount.
