### PR TITLE
FIX: Ensure GridFieldDetailForm has the current record validator.

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -90,6 +90,12 @@ class GridFieldDetailForm implements GridField_URLHandler {
 		$handler = Object::create($class, $gridField, $this, $record, $controller, $this->name);
 		$handler->setTemplate($this->template);
 
+		// if no validator has been set on the GridField and the record has a
+		// CMS validator, use that.
+		if(!$this->getValidator() && method_exists($record, 'getCMSValidator')) {
+			$this->setValidator($record->getCMSValidator());
+		}
+
 		return $handler->handleRequest($request, DataModel::inst());
 	}
 

--- a/tests/forms/gridfield/GridFieldDetailFormTest.php
+++ b/tests/forms/gridfield/GridFieldDetailFormTest.php
@@ -1,6 +1,11 @@
 <?php
 
+/**
+ * @package framework
+ * @subpackage tests
+ */
 class GridFieldDetailFormTest extends FunctionalTest {
+
 	protected static $fixture_file = 'GridFieldDetailFormTest.yml';
 
 	protected $extraDataObjects = array(
@@ -8,6 +13,48 @@ class GridFieldDetailFormTest extends FunctionalTest {
 		'GridFieldDetailFormTest_PeopleGroup',
 		'GridFieldDetailFormTest_Category',
 	);
+
+	public function testValidator() {
+		$this->logInWithPermission('ADMIN');
+
+		$response = $this->get('GridFieldDetailFormTest_Controller');
+		$this->assertFalse($response->isError());
+		$parser = new CSSContentParser($response->getBody());
+		$addlinkitem = $parser->getBySelector('.ss-gridfield .new-link');
+		$addlink = (string) $addlinkitem[0]['href'];
+
+		$response = $this->get($addlink);
+		$this->assertFalse($response->isError());
+
+		$parser = new CSSContentParser($response->getBody());
+		$addform = $parser->getBySelector('#Form_ItemEditForm');
+		$addformurl = (string) $addform[0]['action'];
+
+		$response = $this->post(
+			$addformurl,
+			array(
+				'FirstName' => 'Jeremiah',
+				'ajax' => 1,
+				'action_doSave' => 1
+			)
+		);
+
+		$parser = new CSSContentParser($response->getBody());
+		$errors = $parser->getBySelector('span.required');
+		$this->assertEquals(1, count($errors));
+
+		$response = $this->post(
+			$addformurl,
+			array(
+				'ajax' => 1,
+				'action_doSave' => 1
+			)
+		);
+
+		$parser = new CSSContentParser($response->getBody());
+		$errors = $parser->getBySelector('span.required');
+		$this->assertEquals(2, count($errors));
+	}
 
 	public function testAddForm() {
 		$this->logInWithPermission('ADMIN');
@@ -247,7 +294,13 @@ class GridFieldDetailFormTest extends FunctionalTest {
 
 }
 
+/**
+ * @package framework
+ * @subpackage tests
+ */
+
 class GridFieldDetailFormTest_Person extends DataObject implements TestOnly {
+
 	private static $db = array(
 		'FirstName' => 'Varchar',
 		'Surname' => 'Varchar'
@@ -280,7 +333,18 @@ class GridFieldDetailFormTest_Person extends DataObject implements TestOnly {
 		);
 		return $fields;
 	}
+
+	public function getCMSValidator() {
+		return new RequiredFields(array(
+			'FirstName', 'Surname'
+		));
+	}
 }
+
+/**
+ * @package framework
+ * @subpackage tests
+ */
 
 class GridFieldDetailFormTest_PeopleGroup extends DataObject implements TestOnly {
 	private static $db = array(
@@ -305,6 +369,11 @@ class GridFieldDetailFormTest_PeopleGroup extends DataObject implements TestOnly
 		return $fields;
 	}
 }
+
+/**
+ * @package framework
+ * @subpackage tests
+ */
 
 class GridFieldDetailFormTest_Category extends DataObject implements TestOnly {
 	
@@ -331,6 +400,11 @@ class GridFieldDetailFormTest_Category extends DataObject implements TestOnly {
 	}
 }
 
+/**
+ * @package framework
+ * @subpackage tests
+ */
+
 class GridFieldDetailFormTest_Controller extends Controller implements TestOnly {
 	
 	private static $allowed_actions = array('Form');
@@ -354,6 +428,11 @@ class GridFieldDetailFormTest_Controller extends Controller implements TestOnly 
 	}
 }
 
+/**
+ * @package framework
+ * @subpackage tests
+ */
+
 class GridFieldDetailFormTest_GroupController extends Controller implements TestOnly {
 
 	private static $allowed_actions = array('Form');
@@ -369,6 +448,11 @@ class GridFieldDetailFormTest_GroupController extends Controller implements Test
 		return new Form($this, 'Form', new FieldList($field), new FieldList());
 	}
 }
+
+/**
+ * @package framework
+ * @subpackage tests
+ */
 
 class GridFieldDetailFormTest_CategoryController extends Controller implements TestOnly {
 
@@ -391,5 +475,8 @@ class GridFieldDetailFormTest_CategoryController extends Controller implements T
 	}
 }
 
-class GridFieldDetailFormTest_ItemRequest extends GridFieldDetailForm_ItemRequest implements TestOnly {
-}
+/**
+ * @package framework
+ * @subpackage tests
+ */
+class GridFieldDetailFormTest_ItemRequest extends GridFieldDetailForm_ItemRequest implements TestOnly { }


### PR DESCRIPTION
Currently the validator is only set through
ModelAdmin and not through GridField
directly. This will set the validator based on the
record unless a custom validator has been
provided.

http://www.silverstripe.org/data-model-questions/show/34650?start=8#post331958
