### PR TITLE
Prevent this.toggleCheckboxes() from firing on refresh.

### DIFF
--- a/admin/javascript/SecurityAdmin.js
+++ b/admin/javascript/SecurityAdmin.js
@@ -39,8 +39,6 @@
 		 */
 		$('#Permissions .checkbox[value=ADMIN]').entwine({
 			onmatch: function() {
-				this.toggleCheckboxes();
-
 				this._super();
 			},
 			onunmatch: function() {


### PR DESCRIPTION
Further bug fix to silverstripe/silverstripe-framework#2760.

This fixes an issue with JS firing the onclick event twice when the page is first rendered (e.g. after a 'Save')
