### PR TITLE
Observations about the Link() method application in framework only sites.

### DIFF
--- a/docs/en/topics/controller.md
+++ b/docs/en/topics/controller.md
@@ -54,6 +54,17 @@ making any code changes to your controller.
 	so a `MyController` class is accessible through `http://yourdomain.com/MyController`.
 </div>
 
+## Framework without the CMS Module and Link()
+
+The Link() method is applicable if you are using the Framework without the CMS Module.  If you are not using the CMS module, you may find it useful to have a method Link() on your Controller to return the URLSegment matching your custom route.
+
+  :::php
+  class FastFood_Controller extends Controller {
+    public function Link() {
+            return 'fastfood';
+        }
+      }
+      
 ## Access Control
 
 ### Through $allowed_actions


### PR DESCRIPTION
Inserted information about the Link() method below instructions for routing and description of automatic URL routing.
