### PR TITLE
Update install.php5 - error handling on getDatabaseConfigurationHelper

### DIFF
--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -48,7 +48,7 @@ $dirsToCheck = array(
 if($dirsToCheck[0] == $dirsToCheck[1]) {
 	unset($dirsToCheck[1]);
 }
-foreach($dirsToCheck as $dir) {
+foreach($dirsToCheck as $dir) {
 //check this dir and every parent dir (until we hit the base of the drive)
 	// or until we hit a dir we can't read
 	do {
@@ -1048,12 +1048,16 @@ class InstallRequirements {
 			$helperPath = $adapters[$databaseClass]['helperPath'];
 			$class = str_replace('.php', '', basename($helperPath));
 		}
-		return (class_exists($class)) ? new $class() : new MySQLDatabaseConfigurationHelper();
+		return (class_exists($class)) ? new $class() : false;
 	}
 
 	function requireDatabaseFunctions($databaseConfig, $testDetails) {
 		$this->testing($testDetails);
 		$helper = $this->getDatabaseConfigurationHelper($databaseConfig['type']);
+		if (!$helper) {
+			$this->error("Couldn't load database helper code for ". $databaseConfig['type']);
+			return false;
+		}
 		$result = $helper->requireDatabaseFunctions($databaseConfig);
 		if($result) {
 			return true;


### PR DESCRIPTION
Defaulting to MySQL here is really dumb. There is an explicit type as an argument so falling back to mysql could result in "I couldn't write to path ....db" despite the real error that the include of the sqlite3/code/SQLiteDatabaseConfigurationHelper.php failed for some reason.

Other uses of getDatabaseConfigurationHelper also need a similar error handler.
