### PR TITLE
API Adding chaining to i18nTextCollector::write()

### DIFF
--- a/i18n/i18nTextCollector.php
+++ b/i18n/i18nTextCollector.php
@@ -193,6 +193,7 @@ class i18nTextCollector extends Object {
 
 	public function write($module, $entities) {
 		$this->getWriter()->write($entities, $this->defaultLocale, $this->baseSavePath . '/' . $module);
+		return $this;
 	}
 	
 	/**


### PR DESCRIPTION
Allowing chaining off of the i18nTextCollector::write() function so it's
inline with DataObject::write() (see #2786)
