### PR TITLE
Fix Session::set_cookie_domain

### DIFF
--- a/control/Session.php
+++ b/control/Session.php
@@ -169,7 +169,7 @@ class Session {
 	 */
 	public static function set_cookie_domain($domain) {
 		Deprecation::notice('3.2', 'Use the "Session.cookie_domain" config setting instead');
-		Config::inst()->update('Session', 'cookie_domain', $age);
+		Config::inst()->update('Session', 'cookie_domain', $domain);
 	}
 
 	/**


### PR DESCRIPTION
The variabel name is currently $age which does not exist in that context. Changed the variable name to $domain as in the function definition.
