### PR TITLE
BUG: Stop undefined error for $reEnableFilter being thrown

### DIFF
--- a/core/model/Translatable.php
+++ b/core/model/Translatable.php
@@ -1488,6 +1488,7 @@ class Translatable extends DataObjectDecorator implements PermissionProvider {
 	 * @return bool
      */
 	public function augmentValidURLSegment() {
+		$reEnableFilter = false;
 		if (self::locale_filter_enabled()) {
 			self::disable_locale_filter();
 			$reEnableFilter = true;


### PR DESCRIPTION
In the method augmentValidURLSegment a if (checking for locale_filter_enabled) statement declares a variable reEnableFilter, outside of the if statement but still inside the method the variable is accessed which can throw a undefined error if the locale filter was never enabled.

Added a isset check wrapper to stop the undefined error being thrown.
