### PR TITLE
Added link colors to the tree

### DIFF
--- a/admin/scss/_tree.scss
+++ b/admin/scss/_tree.scss
@@ -43,6 +43,15 @@
 			& > .jstree-icon {
 				cursor: pointer;
 			}
+			&.status-modified > a {
+				color: #FF8000 !important;
+			}
+			&.status-addedtodraft > a {
+				color: #238C00 !important;
+			}
+			&.status-deletedonlive > a {
+				color: #cc0000 !important;
+			}
 		}
 		ins {
 			display: inline-block;


### PR DESCRIPTION
Just like 2.4 had, added colors for new/modified/deleted tree links to improve usability. The new flags that appear at the end of the links are generally hidden unless the div is scrolled - especially for long titles.
Colors are probably not the same as they used to be, but you can adjust them.
PS Apologies for the !important but I see they are used elsewhere in the file...
