### PR TITLE
BUG: Fixes #2808 fixed  case type in documentation

### DIFF
--- a/docs/en/topics/datamodel.md
+++ b/docs/en/topics/datamodel.md
@@ -290,7 +290,7 @@ start with S, who has logged in  since 1/1/2011.
 
 	:::php
 	$members = Member::get()->filter(array(
-		'FirstName:StartsWith:Not' => 'S'
+		'FirstName:StartsWith:not' => 'S'
 		'LastVisited:GreaterThan' => '2011-01-01'
 	));
 


### PR DESCRIPTION
Amended the documentation to have the correct case as trying to use something like

```
$members = Member::get()->filter(array(
    'FirstName:StartsWith:Not' => 'D'
));
```

does result in the following error

[User Error] Uncaught InvalidArgumentException: StartsWithFilter does not accept Not as modifiers

On a side note if you do find errors or typos in the SilverStripe documentation please feel free to amend this yourself as SilverStripe is open source we welcome contributions from our community.
The documentation is built from MD files which are included in the framework repository so they can be amended and then a pull request can be raised on GitHub to make these changes.

See the links below for more information

http://www.silverstripe.org/contributing-to-silverstripe
http://www.silverstripe.org/advanced-developers
