### PR TITLE
Don't show next for anything above TotalPages

### DIFF
--- a/core/PaginatedList.php
+++ b/core/PaginatedList.php
@@ -353,7 +353,7 @@ class PaginatedList extends SS_ListDecorator {
 	 * @return bool
 	 */
 	public function NotLastPage() {
-		return $this->CurrentPage() != $this->TotalPages();
+		return $this->CurrentPage() < $this->TotalPages();
 	}
 
 	/**


### PR DESCRIPTION
Bots often have the habit of trying a next page, even if there isn't one.
Thus, using CurrentPage < TotalPages, prevents from unwanted next-links being shown.
