### PR TITLE
BUG GridState_Data doesn't hold falsey values - Fixes #2813

### DIFF
--- a/forms/gridfield/GridState.php
+++ b/forms/gridfield/GridState.php
@@ -153,7 +153,7 @@ class GridState_Data {
 	 * @return mixed The value associated with this key, or the value specified by $default if not set
 	 */
 	public function getData($name, $default = null) {
-		if(empty($this->data[$name])) {
+		if(!isset($this->data[$name])) {
 			$this->data[$name] = $default;
 		} else if(is_array($this->data[$name])) {
 			$this->data[$name] = new GridState_Data($this->data[$name]);
@@ -168,6 +168,10 @@ class GridState_Data {
 	
 	public function __isset($name) {
 		return isset($this->data[$name]);
+	}
+	
+	public function __unset($name) {
+		unset($this->data[$name]);
 	}
 
 	public function __toString() {

--- a/tests/forms/GridFieldTest.php
+++ b/tests/forms/GridFieldTest.php
@@ -123,22 +123,22 @@ class GridFieldTest extends SapphireTest {
 		$obj->State->NoValue = 10;
 		$this->assertEquals(10, $obj->State->NoValue);
 		$this->assertEquals(10, $obj->State->NoValue(20));
+		
+		// Test that values can be set, unset, and inspected
+		$this->assertFalse(isset($obj->State->NotSet));
+		$obj->State->NotSet = false;
+		$this->assertTrue(isset($obj->State->NotSet));
+		unset($obj->State->NotSet);
+		$this->assertFalse(isset($obj->State->NotSet));
 
-		//Show that values returned by the assignment function don't
-		// actually return the value stored
+		// Test that false evaluating values are storable
 		$this->assertEquals(0, $obj->State->Falsey0(0)); // expect 0 back
 		$this->assertEquals(0, $obj->State->Falsey0(10)); // expect 0 back
 		$this->assertEquals(0, $obj->State->Falsey0); //expect 0 back
 		$obj->State->Falsey0 = 0; //manually assign 0
 		$this->assertEquals(0, $obj->State->Falsey0); //expect 0 back
 
-		//repeat for other falsey values
-		$this->assertEquals(array(), $obj->State->Falsey1(array()));
-		$this->assertEquals(array(), $obj->State->Falsey1(array('test')));
-		$this->assertEquals(array(), $obj->State->Falsey1);
-		$obj->State->Falsey1 = array(); //manually assign 0
-		$this->assertEquals(array(), $obj->State->Falsey1); //expect 0 back
-
+		// Test that false is storable
 		$this->assertFalse($obj->State->Falsey2(false));
 		$this->assertFalse($obj->State->Falsey2(true));
 		$this->assertFalse($obj->State->Falsey2);


### PR DESCRIPTION
Original test case left unsquashed for verbosity of history.

I have removed a portion of the test case dealing with array values; The convention within GridState_Data is that any array values are converted to a nested GridState_Data on retrieval; To change this would break backwards compatibility.

Hopefully resolves the issue noted by @dhensby at https://github.com/silverstripe/silverstripe-framework/pull/2813
