### PR TITLE
Support PHPUnit 3.8+ compatibility

### DIFF
--- a/dev/SapphireTestReporter.php
+++ b/dev/SapphireTestReporter.php
@@ -300,6 +300,18 @@ class SapphireTestReporter implements PHPUnit_Framework_TestListener {
 		}
 	}
 	
+        /**
+         * Risky test.
+         *
+         * @param PHPUnit_Framework_Test $test
+         * @param Exception              $e
+         * @param float                  $time
+         * @since  Method available since Release 3.8.0
+         */
+        public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
+    	        // Stub out to support PHPUnit 3.8
+        }
+
 	/**
 	 * Trys to get the original exception thrown by the test on failure/error 
 	 * to enable us to give a bit more detail about the failure/error

--- a/dev/SilverStripeListener.php
+++ b/dev/SilverStripeListener.php
@@ -46,4 +46,16 @@ class SilverStripeListener implements PHPUnit_Framework_TestListener {
 
 	public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
 	}
+
+        /**
+         * Risky test.
+         *
+         * @param PHPUnit_Framework_Test $test
+         * @param Exception              $e
+         * @param float                  $time
+         * @since  Method available since Release 3.8.0
+         */
+        public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
+    	         // Stub out to support PHPUnit 3.8
+        }       
 } 

--- a/dev/TeamCityListener.php
+++ b/dev/TeamCityListener.php
@@ -61,4 +61,16 @@ class TeamCityListener implements PHPUnit_Framework_TestListener {
 		$message = $this->escape($e->getMessage());
 		echo "##teamcity[testIgnored name='{$class}.{$test->getName()}' message='$message']\n";
 	}
+
+        /**
+         * Risky test.
+         *
+         * @param PHPUnit_Framework_Test $test
+         * @param Exception              $e
+         * @param float                  $time
+         * @since  Method available since Release 3.8.0
+         */
+        public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
+    	         // Stub out to support PHPUnit 3.8
+        }
 }

--- a/dev/TestListener.php
+++ b/dev/TestListener.php
@@ -38,6 +38,18 @@ class SS_TestListener implements PHPUnit_Framework_TestListener {
 		$this->class->tearDownOnce();
 	}
 	
+        /**
+         * Risky test.
+         *
+         * @param PHPUnit_Framework_Test $test
+         * @param Exception              $e
+         * @param float                  $time
+         * @since  Method available since Release 3.8.0
+         */
+        public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time) {
+    	         // Stub out to support PHPUnit 3.8
+        }
+
 	/**
 	 * @param String Classname
 	 * @return boolean


### PR DESCRIPTION
PHPUnit 3.8+ adds a method to its PHPUnit_Framework_TestListener called addRiskyTest(). Need to stub it out to avoid "must implement this interface method" fatals when using 3.8+
