### PR TITLE
Fix autocompletion on ::create and ::strong_create

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -127,7 +127,7 @@ abstract class Object {
 	 *
 	 * @param string $class the class name
 	 * @param mixed $arguments,... arguments to pass to the constructor
-	 * @return Object
+	 * @return static
 	 */
 	public static function create() {
 		$args = func_get_args();
@@ -279,7 +279,7 @@ abstract class Object {
 	 *
 	 * @param string $class the class name
 	 * @param mixed $arguments,... arguments to pass to the constructor
-	 * @return Object
+	 * @return static
 	 */
 	public static function strong_create() {
 		$args  = func_get_args();


### PR DESCRIPTION
Currently `::create` and `::strong_create` are documented as returning `Object`. This breaks autocompletion for IDEs as they assume `Object` is being returned, when in actual fact a subclass is. `@return static` will make the IDE assume the LSB class is being returned. This will _greatly_ help working in IDEs and avoid having to use `/** @var SomeObject $obj */` all the time.

Obviously this won't always be the case due to `::useCustomClass`, however that's an exception to the rule and still doesn't break anything code-wise.
