### PR TITLE
NEW: Updating out of date URLs in the framework source code and docs

### DIFF
--- a/docs/en/installation/windows-pi.md
+++ b/docs/en/installation/windows-pi.md
@@ -5,7 +5,7 @@
 ## Installing SilverStripe
 
 *  Download and run Microsoft Web Platform Installer (WebPI):
-[![](http://www.silverstripe.org/assets/downloads/webpi/wpiBadgeGreen.jpg)](http://www.microsoft.com/web/gallery/install.aspx?appsxml=www.microsoft.com%2fweb%2fwebpi%2f2.0%2fWebApplicationList.xml&amp;appid=105)
+[![](http://www.silverstripe.org/assets/downloads/webpi/wpiBadgeGreen.png)](http://www.microsoft.com/web/gallery/install.aspx?appsxml=www.microsoft.com%2fweb%2fwebpi%2f2.0%2fWebApplicationList.xml&amp;appid=105)
 
 *  In WebPI, select 'SilverStripe' from the 'Content Management System' link
 *  Select install. It will install dependancies like MySQL and PHP if you don't have these installed already.

--- a/docs/en/misc/contributing/code.md
+++ b/docs/en/misc/contributing/code.md
@@ -68,7 +68,7 @@ there are any problems they will follow up with you, so please ensure they have 
 ### Quickfire Do's and Don't's
 
 If you aren't familiar with git and GitHub, try reading the ["GitHub bootcamp documentation"](http://help.github.com/). 
-We also found the [free online git book](http://progit.org/book/) and the [git crash course](http://gitref.org/) useful.
+We also found the [free online git book](http://git-scm.com/book/) and the [git crash course](http://gitref.org/) useful.
 If you're familiar with it, here's the short version of what you need to know. Once you fork and download the code:
 
   *  **Don't develop on the master branch.** Always create a development branch specific to "the issue" you're working on (mostly on our [bugtracker](/misc/contributing/issues)). Name it by issue number and description. For example, if you're working on Issue #100, a `DataObject::get_one()` bugfix, your development branch should be called 100-dataobject-get-one. If you decide to work on another issue mid-stream, create a new branch for that issue--don't work on both in one branch.
@@ -104,7 +104,7 @@ step.
 *  It's better to submit multiple patches with separate bits of functionality than a big patch containing lots of
 changes
 *  Document your code inline through [PHPDoc](http://en.wikipedia.org/wiki/PHPDoc) syntax. See our 
-[API documentation](http://api.silverstripe.org/trunk) for good examples.
+[API documentation](http://api.silverstripe.org/3.1/) for good examples.
 * Also check and update documentation on [doc.silverstripe.org](http://doc.silverstripe.org). Check for any references to functionality deprecated or extended through your patch. Documentation changes should be included in the patch.
 * We will attribute the change to you whereever possible (git does this automatically for pull requests)
 * If you get stuck, please post to the [forum](http://silverstripe.org/forum) or for deeper core problems, to the [core mailinglist](https://groups.google.com/forum/#!forum/silverstripe-dev)
@@ -260,7 +260,7 @@ It's as if you had just started your branch. One immediate advantage you get is 
 
 So when you're ready to send the new plugin upstream, you do one last rebase, test, and then merge (which is really no merge at all) and send out your pull request. Then in most cases, we have a simple fast-forward on our end (or at worst a very small rebase or merge) and over time that adds up to a simpler tree.
 
-More info on the ["Rebasing" chapter on progit.org](http://progit.org/book/ch3-6.html) and the [git rebase man page](http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html).
+More info on the ["Rebasing" chapter on git-scm.com](http://git-scm.com/book/ch3-6.html) and the [git rebase man page](http://www.kernel.org/pub/software/scm/git/docs/git-rebase.html).
 
 ## License
 

--- a/docs/en/reference/cms-architecture.md
+++ b/docs/en/reference/cms-architecture.md
@@ -30,7 +30,7 @@ and the [Compass framework](http://compass-style.org/), which helps
 us maintain expressive and concise style declarations. The files are located in `framework/admin/scss`
 (and if you have the `cms` module installed, in `cms/scss`), and are compiled to a `css` folder on the
 same directory path. Changes to the SCSS files can be automatically converted by installing
-the ["compass" module](http://www.silverstripe.org/compass-module/) for SilverStripe, 
+the ["compass" module](https://github.com/silverstripe-labs/silverstripe-compass) for SilverStripe, 
 although [installing the compass framework](http://compass-style.org/install/) directly works as well.
 Each file describes its purpose at the top of the declarations. Note that you can write
 plain CSS without SCSS for your custom CMS interfaces as well, we just mandate SCSS for core usage.

--- a/search/FulltextSearchable.php
+++ b/search/FulltextSearchable.php
@@ -9,7 +9,7 @@
  * CAUTION: Will make all files in your /assets folder searchable by file name
  * unless "File" is excluded from FulltextSearchable::enable().
  * 
- * @see http://doc.silverstripe.org/tutorial:4-site-search
+ * @see http://doc.silverstripe.org/framework/en/tutorials/4-site-search
  *
  * @package framework
  * @subpackage search

--- a/security/MemberAuthenticator.php
+++ b/security/MemberAuthenticator.php
@@ -11,7 +11,7 @@ class MemberAuthenticator extends Authenticator {
 	/**
 	 * @var Array Contains encryption algorithm identifiers.
 	 *  If set, will migrate to new precision-safe password hashing
-	 *  upon login. See http://open.silverstripe.org/ticket/3004.
+	 *  upon login. See http://open.silverstripe.org/ticket/3004
 	 */
 	private static $migrate_legacy_hashes = array(
 		'md5' => 'md5_v2.4', 


### PR DESCRIPTION
Ran the BrokenScriptsURL dev task from the check-source-urls module 

https://github.com/silverstripe-rebelalliance/check-source-urls

and found the following out of date and invalid URLS (the changelogs directory was ignored).

It did find a lot more but as they were mainly in the thirdparty directory I ignored them.
