### PR TITLE
mysqli::real_escape_string only accepts strings.

### DIFF
--- a/model/MySQLDatabase.php
+++ b/model/MySQLDatabase.php
@@ -973,7 +973,7 @@ class MySQLDatabase extends SS_Database {
 	 * This will return text which has been escaped in a database-friendly manner.
 	 */
 	public function addslashes($value){
-		return $this->dbConn->real_escape_string($value);
+		return $this->dbConn->real_escape_string((string)$value);
 	}
 
 	/*


### PR DESCRIPTION
Should cast all input to strings (+ HHVM is very strict about this for now... needs to be a string for unit tests to pass)
