### PR TITLE
BUG Fix missing Description element on FieldGroup_holder.ss

### DIFF
--- a/templates/forms/FieldGroup_holder.ss
+++ b/templates/forms/FieldGroup_holder.ss
@@ -10,4 +10,5 @@
 	</div>
 	<% if $RightTitle %><label class="right">$RightTitle</label><% end_if %>
 	<% if $Message %><span class="message $MessageType">$Message</span><% end_if %>
+	<% if $Description %><span class="description">$Description</span><% end_if %>
 </div>


### PR DESCRIPTION
Keeping in line with `FormField_holder.ss`, this introduces the missing (apparently by mistake) description field to the template.

I'm not certain if FieldGroup_holder_small can support this field robustly, but the main holder template seems to work fine with this. This can be introduced later if necessary.
