### PR TITLE
API Default to "yyyy-MM-dd" for date format

### DIFF
--- a/docs/en/changelogs/3.2.0.md
+++ b/docs/en/changelogs/3.2.0.md
@@ -31,4 +31,15 @@ use `setDisplayFolderName()` with a folder path relative to `assets/`:
 
 	UploadField::create('MyField')->setDisplayFolderName('Uploads');
 
+### Removed format detection in i18n::$date_format and i18n::$time_format
+
+Localized dates cause inconsistencies in client-side vs. server-side formatting
+and validation, particularly in abbreviated month names. The default date
+format has been changed to "yyyy-MM-dd" (e.g. 2014-12-31). 
+New users will continue to have the option for a localized date
+format in their profile (based on their chosen locale).
+If you have existing users with `Member.DateFormat` set to a format
+including "MMM" or "MMMM", consider deleting those formats to fall back to
+the global (and more stable) default.
+
 ### Bugfixes

--- a/docs/en/reference/datefield.md
+++ b/docs/en/reference/datefield.md
@@ -37,6 +37,12 @@ You can define a custom dateformat for your Datefield based on [Zend_Date consta
 	// will display a date in the following format: 31-06-2012
 	DateField::create('MyDate')->setConfig('dateformat', 'dd-MM-yyyy'); 
  
+Caution: If you're using natural language date formats like abbreviated month names
+alongside the "showcalendar" option, you'll need to ensure the formats
+between the calendar widget and the SilverStripe validation are consistent.
+As an example for the 'de' locale, check `framework/thirdparty/jquery-ui/datepicker/i18n/jquery.ui.datepicker-de.js` 
+and compare it to `framework/thirdparty/Zend/Locale/Data/de.xml`
+(see `<calendar type="gregorian">` in the XML data).
 
 ## Min and Max Dates
 

--- a/forms/DateField.php
+++ b/forms/DateField.php
@@ -97,7 +97,7 @@ class DateField extends TextField {
 		
 		$this->config = $this->config()->default_config;
 		if(!$this->getConfig('dateformat')) {
-			$this->setConfig('dateformat', i18n::get_date_format());
+			$this->setConfig('dateformat', Config::inst()->get('i18n', 'date_format'));
 		}
 		
 		foreach ($this->config()->default_config AS $defaultK => $defaultV) {

--- a/forms/TimeField.php
+++ b/forms/TimeField.php
@@ -58,7 +58,7 @@ class TimeField extends TextField {
 		$this->config = $this->config()->default_config;
 		
 		if(!$this->getConfig('timeformat')) {
-			$this->setConfig('timeformat', i18n::get_time_format());
+			$this->setConfig('timeformat', Config::inst()->get('i18n', 'time_format'));
 		}
 		
 		parent::__construct($name,$title,$value);

--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -84,13 +84,13 @@ class i18n extends Object implements TemplateGlobalProvider {
 	 * @config
 	 * @var string
 	 */
-	private static $date_format;
+	private static $date_format = 'yyyy-MM-dd';
 	
 	/**
 	 * @config
 	 * @var string
 	 */
-	private static $time_format;
+	private static $time_format = 'H:mm';
 	
 	/**
 	 * @var array Array of priority keys to instances of Zend_Translate, mapped by name.
@@ -141,9 +141,8 @@ class i18n extends Object implements TemplateGlobalProvider {
 	 * @return string ISO date format
 	 */
 	public static function get_date_format() {
-		require_once 'Zend/Date.php';
-		$dateFormat = Config::inst()->get('i18n', 'date_format');
-		return ($dateFormat) ? $dateFormat : Zend_Locale_Format::getDateFormat(self::get_locale());
+		Deprecation::notice('3.2', 'Use the "i18n.date_format" config setting instead');
+		return Config::inst()->get('i18n', 'date_format');
 	}
 	
 	/**
@@ -159,9 +158,8 @@ class i18n extends Object implements TemplateGlobalProvider {
 	 * @return string ISO time format
 	 */
 	public static function get_time_format() {
-		require_once 'Zend/Date.php';
-		$timeFormat = Config::inst()->get('i18n', 'time_format');
-		return ($timeFormat) ? $timeFormat : Zend_Locale_Format::getTimeFormat(self::get_locale());
+		Deprecation::notice('3.2', 'Use the "i18n.time_format" config setting instead');
+		return Config::inst()->get('i18n', 'time_format');
 	}
 	
 	/**

--- a/tests/forms/MemberDatetimeOptionsetFieldTest.php
+++ b/tests/forms/MemberDatetimeOptionsetFieldTest.php
@@ -11,7 +11,7 @@ class MemberDatetimeOptionsetFieldTest extends SapphireTest {
 		require_once 'Zend/Date.php';
 		$defaultDateFormat = Zend_Locale_Format::getDateFormat($member->Locale);
 		$dateFormatMap = array(
-			'MMM d, yyyy' => Zend_Date::now()->toString('MMM d, yyyy'),
+			'yyyy-MM-dd' => Zend_Date::now()->toString('yyyy-MM-dd'),
 			'yyyy/MM/dd' => Zend_Date::now()->toString('yyyy/MM/dd'),
 			'MM/dd/yyyy' => Zend_Date::now()->toString('MM/dd/yyyy'),
 			'dd/MM/yyyy' => Zend_Date::now()->toString('dd/MM/yyyy'),
@@ -44,15 +44,17 @@ class MemberDatetimeOptionsetFieldTest extends SapphireTest {
 	}
 
 	public function testDateFormatDefaultCheckedInFormField() {
+		Config::inst()->update('i18n', 'date_format', 'yyyy-MM-dd');
 		$field = $this->createDateFormatFieldForMember($this->objFromFixture('Member', 'noformatmember'));
 		$field->setForm(new Form(new MemberDatetimeOptionsetFieldTest_Controller(), 'Form', new FieldList(),
 			new FieldList())); // fake form
 		$parser = new CSSContentParser($field->Field());
-		$xmlArr = $parser->getBySelector('#Form_Form_DateFormat_MMM_d__y');
+		$xmlArr = $parser->getBySelector('#Form_Form_DateFormat_yyyy-MM-dd');
 		$this->assertEquals('checked', (string) $xmlArr[0]['checked']);
 	}
 
 	public function testTimeFormatDefaultCheckedInFormField() {
+		Config::inst()->update('i18n', 'time_format', 'h:mm:ss a');
 		$field = $this->createTimeFormatFieldForMember($this->objFromFixture('Member', 'noformatmember'));
 		$field->setForm(new Form(new MemberDatetimeOptionsetFieldTest_Controller(), 'Form', new FieldList(),
 			new FieldList())); // fake form

--- a/tests/i18n/i18nTest.php
+++ b/tests/i18n/i18nTest.php
@@ -65,36 +65,6 @@ class i18nTest extends SapphireTest {
 		parent::tearDown();
 	}
 	
-	public function testDateFormatFromLocale() {
-		i18n::set_locale('en_US');
-		$this->assertEquals('MMM d, y', i18n::get_date_format());
-		i18n::set_locale('en_NZ');
-		$this->assertEquals('d/MM/yyyy', i18n::get_date_format());
-		i18n::set_locale('en_US');
-	}
-	
-	public function testTimeFormatFromLocale() {
-		i18n::set_locale('en_US');
-		$this->assertEquals('h:mm:ss a', i18n::get_time_format());
-		i18n::set_locale('de_DE');
-		$this->assertEquals('HH:mm:ss', i18n::get_time_format());
-		i18n::set_locale('en_US');
-	}
-	
-	public function testDateFormatCustom() {
-		i18n::set_locale('en_US');
-		$this->assertEquals('MMM d, y', i18n::get_date_format());
-		i18n::config()->date_format = 'd/MM/yyyy';
-		$this->assertEquals('d/MM/yyyy', i18n::get_date_format());
-	}
-	
-	public function testTimeFormatCustom() {
-		i18n::set_locale('en_US');
-		$this->assertEquals('h:mm:ss a', i18n::get_time_format());
-		i18n::config()->time_format = 'HH:mm:ss';
-		$this->assertEquals('HH:mm:ss', i18n::get_time_format());
-	}
-	
 	public function testGetExistingTranslations() {
 		$translations = i18n::get_existing_translations();
 		$this->assertTrue(isset($translations['en_US']), 'Checking for en translation');

--- a/tests/security/MemberTest.php
+++ b/tests/security/MemberTest.php
@@ -320,17 +320,13 @@ class MemberTest extends FunctionalTest {
 	}
 	
 	public function testMemberWithNoDateFormatFallsbackToGlobalLocaleDefaultFormat() {
+		Config::inst()->update('i18n', 'date_format', 'yyyy-MM-dd');
+		Config::inst()->update('i18n', 'time_format', 'H:mm');
 		$member = $this->objFromFixture('Member', 'noformatmember');
-		$this->assertEquals('MMM d, y', $member->DateFormat);
-		$this->assertEquals('h:mm:ss a', $member->TimeFormat);
+		$this->assertEquals('yyyy-MM-dd', $member->DateFormat);
+		$this->assertEquals('H:mm', $member->TimeFormat);
 	}
-	
-	public function testMemberWithNoDateFormatFallsbackToTheirLocaleDefaultFormat() {
-		$member = $this->objFromFixture('Member', 'delocalemember');
-		$this->assertEquals('dd.MM.yyyy', $member->DateFormat);
-		$this->assertEquals('HH:mm:ss', $member->TimeFormat);
-	}
-	
+		
 	public function testInGroups() {
 		$staffmember = $this->objFromFixture('Member', 'staffmember');
 		$managementmember = $this->objFromFixture('Member', 'managementmember');


### PR DESCRIPTION
The motivation for this was to avoid using "MMM" in particular, since it causes inconsistencies in month
names between jQuery UI and Zend_Locale_Format.
One example of that was "mar." (jQuery UI( vs. "mars" (Zend_Locale) as a danish short month name.

This means if you set a default locale of `de_DE` for example,
the date format will still be `yyyy-MM-dd` (rather than `dd.MM.yyyy`).
You still get that one as a suggestion in the member profile,
and can set it as a global default through `i18n.date_format` config API,
its just not auto detected any longer. This also makes `i18n::get_date_format()`
obsolete, since we can now simply use the Config API without any dynamic calls.

I've implemented the same changes for consistency in `time_format` as well.

Fixes https://github.com/silverstripe/silverstripe-cms/issues/544
