### PR TITLE
FIX: searchable_fields inheritance from summary_fields includes methods called on fields (fixes #1429)

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -3179,16 +3179,25 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 		$fields = $this->stat('searchable_fields');
 		$labels = $this->fieldLabels();
 		
-		// fallback to summary fields
-		if(!$fields) {
+		// fallback to summary fields (unless empty array is explicitly specified)
+		if( ! $fields && ! is_array($fields)) {
 			$summaryFields = array_keys($this->summaryFields());
 			$fields = array();
 
-			// remove the custom getters as the search should not include.
+			// remove the custom getters as the search should not include them
 			if($summaryFields) {
 				foreach($summaryFields as $key => $name) {
-					if($this->hasDatabaseField($name) || $this->relObject($name)) {
+					$spec = $name;
+
+					// Extract field name in case this is a method called on a field (e.g. "Date.Nice")
+					if(($fieldPos = strpos($name, '.')) !== false) {
+						$name = substr($name, 0, $fieldPos);
+					}
+
+					if($this->hasDatabaseField($name)) {
 						$fields[] = $name;
+					} elseif($this->relObject($spec)) {
+						$fields[] = $spec;
 					}
 				}
 			}

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -645,6 +645,43 @@ class DataObjectTest extends SapphireTest {
 			'databaseFields() on subclass contains only fields defined on instance'
 		);
 	}
+
+	public function testSearchableFields() {
+		$player = $this->objFromFixture('DataObjectTest_Player', 'captain1');
+		$fields = $player->searchableFields();
+		$this->assertArrayHasKey(
+			'IsRetired',
+			$fields,
+			'Fields defined by $searchable_fields static are correctly detected'
+		);
+		$this->assertArrayHasKey(
+			'ShirtNumber',
+			$fields,
+			'Fields defined by $searchable_fields static are correctly detected'
+		);
+
+		$team = $this->objFromFixture('DataObjectTest_Team', 'team1');
+		$fields = $team->searchableFields();	
+		$this->assertArrayHasKey(
+			'Title',
+			$fields,
+			'Fields can be inherited from the $summary_fields static, including methods called on fields'
+		);
+		$this->assertArrayHasKey(
+			'Captain.ShirtNumber',
+			$fields,
+			'Fields on related objects can be inherited from the $summary_fields static'
+		);
+		$this->assertArrayHasKey(
+			'Captain.FavouriteTeam.Title',
+			$fields,
+			'Fields on related objects can be inherited from the $summary_fields static'
+		);
+
+		$testObj = new DataObjectTest_Fixture();
+		$fields = $testObj->searchableFields();
+		$this->assertEmpty($fields);
+	}
 	
 	public function testDataObjectUpdate() {
 		/* update() calls can use the dot syntax to reference has_one relations and other methods that return
@@ -1191,6 +1228,11 @@ class DataObjectTest_Player extends Member implements TestOnly {
 	private static $belongs_many_many = array(
 		'Teams' => 'DataObjectTest_Team'
 	);
+
+	private static $searchable_fields = array(
+		'IsRetired',
+		'ShirtNumber'
+	);
 }
 
 class DataObjectTest_Team extends DataObject implements TestOnly {
@@ -1218,6 +1260,12 @@ class DataObjectTest_Team extends DataObject implements TestOnly {
 		'Players' => array(
 			'Position' => 'Varchar(100)'
 		)
+	);
+
+	private static $summary_fields = array(
+		'Title.UpperCase' => 'Title',
+		'Captain.ShirtNumber' => 'Captain\'s shirt number',
+		'Captain.FavouriteTeam.Title' => 'Captain\'s favourite team'
 	);
 
 	private static $default_sort = '"Title"';
@@ -1250,6 +1298,13 @@ class DataObjectTest_Fixture extends DataObject implements TestOnly {
 	private static $defaults = array(
 		'MyFieldWithDefault' => 'Default Value',
 	);
+
+	private static $summary_fields = array(
+		'Data' => 'Data',
+		'DateField.Nice' => 'Date'
+	);
+
+	private static $searchable_fields = array();
 
 	public function populateDefaults() {
 		parent::populateDefaults();


### PR DESCRIPTION
Using the example:

``` php
private static $summary_fields = array(
    'Date.Nice' => 'Date'
);
```

Previously, `DataObject->searchableFields()` would call `$this->relObject('Date.Nice');`, resulting in an error as “Date” is a field, not a relation. After this patch, the field name (“Date”) is extracted and will be included in the array of searchable fields.

Patch also allows users to prevent searchable fields inheriting from summary fields by defining an empty array for their `$searchable_fields`.
