### PR TITLE
BUGFIX: avoid calling updateCMSFields 2x in Member

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -1299,7 +1299,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		);
 		$timeFormatField->setValue($this->TimeFormat);
 
-		$this->extend('updateCMSFields', $fields);
+		$this->extend('updateMemberCMSFields', $fields);
 		
 		return $fields;
 	}


### PR DESCRIPTION
``` php
$this->extend('updateCMSFields', $fields); 
```

is called in DataObject::getCMSFields, but it is also called in Member::getCMSFields.  While it is important to have an extend in both, it is not so useful to call the same method twice.  Therefore, we call  updateMemberCMSFields in Member.

See https://github.com/silverstripe/silverstripe-framework/issues/2827
