### PR TITLE
BUG: Director::test() don't respect port settings in $_FILE_TO_URL_MAPPING

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -247,7 +247,13 @@ class Director implements TemplateGlobalProvider {
 		// Handle absolute URLs
 		if (@parse_url($url, PHP_URL_HOST) != '') {
 			$bits = parse_url($url);
-			$_SERVER['HTTP_HOST'] = $bits['host'];
+			// If a port is mentioned in the absolute URL, be sure to add that into the 
+			// HTTP host
+			if(isset($bits['port'])) {
+				$_SERVER['HTTP_HOST'] = $bits['host'].':'.$bits['port'];
+			} else {
+				$_SERVER['HTTP_HOST'] = $bits['host'];
+			}
 			$url = Director::makeRelative($url);
 		}
 


### PR DESCRIPTION
Director::test() don't set the HTTP_HOST with the port number if that has been set.
Later call to Director::makeRelative() will return wrong value because of the strict string matching
(http://localhost/ != http://localhost:8000)

This bug affects all modules that are using Director::test in CLI where the $_FILE_TO_URL_MAPPING
have been set to use a domain with a port in it, i.e. static publishers.
