### PR TITLE
Issue #2854: Permit ViewableData children to avoid caching 

### DIFF
--- a/tests/view/ViewableDataTest.php
+++ b/tests/view/ViewableDataTest.php
@@ -156,6 +156,25 @@ class ViewableDataTest extends SapphireTest {
 
 		$this->assertEquals($uncastedData, $castedData->getValue(), 'Casted and uncasted strings are not equal.');
 	}
+	
+	public function testCaching() {
+		$objCached = new ViewableDataTest_Cached();
+		$objNotCached = new ViewableDataTest_NotCached();
+		
+		$objCached->Test = 'AAA';
+		$objNotCached->Test = 'AAA';
+		
+		$this->assertEquals('AAA', $objCached->obj('Test', null, true, true));
+		$this->assertEquals('AAA', $objNotCached->obj('Test', null, true, true));
+		
+		$objCached->Test = 'BBB';
+		$objNotCached->Test = 'BBB';
+		
+		// Cached data must be always the same
+		$this->assertEquals('AAA', $objCached->obj('Test', null, true, true));
+		$this->assertEquals('BBB', $objNotCached->obj('Test', null, true, true));
+	}
+	
 }
 
 /**#@+
@@ -251,6 +270,16 @@ class ViewableDataTest_NoCastingInformation extends ViewableData {
 	public function noCastingInformation() {
 		return "No casting information";
 	}
+}
+	
+class ViewableDataTest_Cached extends ViewableData {
+	public $Test;
+	protected $cached = true;
+}
+
+class ViewableDataTest_NotCached extends ViewableData {
+	public $Test;
+	protected $cached = false;
 }
 
 /**#@-*/

--- a/view/ViewableData.php
+++ b/view/ViewableData.php
@@ -60,6 +60,13 @@ class ViewableData extends Object implements IteratorAggregate {
 	 */
 	private $objCache = array();
 	
+	/**
+	 * Avoid $objCache usage (useful when storing objects in Session)
+	 * 
+	 * @var boolean 
+	 */
+	protected $cached = true;
+	
 	// -----------------------------------------------------------------------------------------------------------------
 	
 	/**
@@ -354,7 +361,7 @@ class ViewableData extends Object implements IteratorAggregate {
 	public function obj($fieldName, $arguments = null, $forceReturnedObject = true, $cache = false, $cacheName = null) {
 		if(!$cacheName) $cacheName = $arguments ? $fieldName . implode(',', $arguments) : $fieldName;
 		
-		if(!isset($this->objCache[$cacheName])) {
+		if(!isset($this->objCache[$cacheName]) || !$this->cached) {
 			// HACK: Don't call the deprecated FormField::Name() method
 			$methodIsAllowed = true;
 			if($this instanceof FormField && $fieldName == 'Name') $methodIsAllowed = false;


### PR DESCRIPTION
Useful for frontend Session work. The issue: https://github.com/silverstripe/silverstripe-framework/issues/2854