### PR TITLE
BUGFIX: removing reliance on Parent::getCMSFields

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -54,11 +54,11 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	);
 
 	private static $has_one = array();
-	
+
 	private static $has_many = array();
-	
+
 	private static $many_many = array();
-	
+
 	private static $many_many_extraFields = array();
 
 	private static $default_sort = '"Surname", "FirstName"';
@@ -66,7 +66,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	private static $indexes = array(
 		'Email' => true,
 		//Removed due to duplicate null values causing MSSQL problems
-		//'AutoLoginHash' => Array('type'=>'unique', 'value'=>'AutoLoginHash', 'ignoreNulls'=>true) 
+		//'AutoLoginHash' => Array('type'=>'unique', 'value'=>'AutoLoginHash', 'ignoreNulls'=>true)
 	);
 
 	/**
@@ -74,7 +74,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * @var boolean
 	 */
 	private static $notify_password_change = false;
-	
+
 	/**
 	 * All searchable database columns
 	 * in this object, currently queried
@@ -91,19 +91,19 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		'Surname',
 		'Email',
 	);
-	
+
 	private static $summary_fields = array(
 		'FirstName' => 'First Name',
 		'Surname' => 'Last Name',
 		'Email' => 'Email',
 	);
-	
+
 	/**
 	 * @config
 	 * @var Array See {@link set_title_columns()}
 	 */
 	private static $title_format = null;
-	
+
 	/**
 	 * The unique field used to identify this member.
 	 * By default, it's "Email", but another common
@@ -113,13 +113,13 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * @var string
 	 */
 	private static $unique_identifier_field = 'Email';
-	
+
 	/**
 	 * @config
 	 * {@link PasswordValidator} object for validating user's password
 	 */
 	private static $password_validator = null;
-	
+
 	/**
 	 * @config
 	 * The number of days that a password should be valid for.
@@ -130,8 +130,8 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	/**
 	 * @config
 	 * @var Int Number of incorrect logins after which
-	 * the user is blocked from further attempts for the timespan 
-	 * defined in {@link $lock_out_delay_mins}. 
+	 * the user is blocked from further attempts for the timespan
+	 * defined in {@link $lock_out_delay_mins}.
 	 */
 	private static $lock_out_after_incorrect_logins = null;
 
@@ -141,7 +141,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * Only applies if {@link $lock_out_after_incorrect_logins} greater than 0.
 	 */
 	private static $lock_out_delay_mins = 15;
-	
+
 	/**
 	 * @config
 	 * @var String If this is set, then a session cookie with the given name will be set on log-in,
@@ -152,7 +152,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	/**
 	 * Indicates that when a {@link Member} logs in, Member:session_regenerate_id()
 	 * should be called as a security precaution.
-	 * 
+	 *
 	 * This doesn't always work, especially if you're trying to set session cookies
 	 * across an entire site using the domain parameter to session_set_cookie_params()
 	 *
@@ -176,18 +176,18 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		parent::populateDefaults();
 		$this->Locale = i18n::get_closest_translation(i18n::get_locale());
 	}
-	
+
 	public function requireDefaultRecords() {
 		parent::requireDefaultRecords();
 		// Default groups should've been built by Group->requireDefaultRecords() already
-		
+
 		// Find or create ADMIN group
 		$adminGroup = Permission::get_groups_by_permission('ADMIN')->First();
 		if(!$adminGroup) {
 			singleton('Group')->requireDefaultRecords();
 			$adminGroup = Permission::get_groups_by_permission('ADMIN')->First();
 		}
-		
+
 		// Add a default administrator to the first ADMIN group found (most likely the default
 		// group created through Group->requireDefaultRecords()).
 		$admins = Permission::get_members_by_permission('ADMIN')->First();
@@ -205,13 +205,13 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * If this is called, then a session cookie will be set to "1" whenever a user
 	 * logs in.  This lets 3rd party tools, such as apache's mod_rewrite, detect
 	 * whether a user is logged in or not and alter behaviour accordingly.
-	 * 
+	 *
 	 * One known use of this is to bypass static caching for logged in users.  This is
 	 * done by putting this into _config.php
 	 * <pre>
 	 * Member::set_login_marker_cookie("SS_LOGGED_IN");
 	 * </pre>
-	 * 
+	 *
 	 * And then adding this condition to each of the rewrite rules that make use of
 	 * the static cache.
 	 * <pre>
@@ -224,7 +224,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	public static function set_login_marker_cookie($cookieName) {
 		Deprecation::notice('3.2', 'Use the "Member.login_marker_cookie" config setting instead');
 		self::config()->login_marker_cookie = $cookieName;
-	} 
+	}
 
 	/**
 	 * Check if the passed password matches the stored one (if the member is not locked out).
@@ -290,7 +290,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 
 	/**
 	 * Regenerate the session_id.
-	 * This wrapper is here to make it easier to disable calls to session_regenerate_id(), should you need to.  
+	 * This wrapper is here to make it easier to disable calls to session_regenerate_id(), should you need to.
 	 * They have caused problems in certain
 	 * quirky problems (such as using the Windmill 0.3.6 proxy).
 	 */
@@ -299,15 +299,15 @@ class Member extends DataObject implements TemplateGlobalProvider {
 
 		// This can be called via CLI during testing.
 		if(Director::is_cli()) return;
-		
+
 		$file = '';
 		$line = '';
-		
+
 		// @ is to supress win32 warnings/notices when session wasn't cleaned up properly
 		// There's nothing we can do about this, because it's an operating system function!
 		if(!headers_sent($file, $line)) @session_regenerate_id(true);
 	}
-	
+
 	/**
 	 * Get the field used for uniquely identifying a member
 	 * in the database. {@see Member::$unique_identifier_field}
@@ -319,7 +319,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		Deprecation::notice('3.2', 'Use the "Member.unique_identifier_field" config setting instead');
 		return Member::config()->unique_identifier_field;
 	}
-	
+
 	/**
 	 * Set the field used for uniquely identifying a member
 	 * in the database. {@see Member::$unique_identifier_field}
@@ -331,14 +331,14 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		Deprecation::notice('3.2', 'Use the "Member.unique_identifier_field" config setting instead');
 		Member::config()->unique_identifier_field = $field;
 	}
-	
+
 	/**
 	 * Set a {@link PasswordValidator} object to use to validate member's passwords.
 	 */
 	public static function set_password_validator($pv) {
 		self::$password_validator = $pv;
 	}
-	
+
 	/**
 	 * Returns the current {@link PasswordValidator}
 	 */
@@ -356,7 +356,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		Deprecation::notice('3.2', 'Use the "Member.password_expiry_days" config setting instead');
 		self::config()->password_expiry_days = $days;
 	}
-	
+
 	/**
 	 * Configure the security system to lock users out after this many incorrect logins
 	 *
@@ -366,8 +366,8 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		Deprecation::notice('3.2', 'Use the "Member.lock_out_after_incorrect_logins" config setting instead');
 		self::config()->lock_out_after_incorrect_logins = $numLogins;
 	}
-	
-	
+
+
 	public function isPasswordExpired() {
 		if(!$this->PasswordExpiry) return false;
 		return strtotime(date('Y-m-d')) >= strtotime($this->PasswordExpiry);
@@ -399,19 +399,19 @@ class Member extends DataObject implements TemplateGlobalProvider {
 			Cookie::set('alc_enc', null);
 			Cookie::force_expiry('alc_enc');
 		}
-		
+
 		// Clear the incorrect log-in count
 		if(self::config()->lock_out_after_incorrect_logins) {
 			$this->FailedLoginCount = 0;
 		}
-		
+
 		// Don't set column if its not built yet (the login might be precursor to a /dev/build...)
 		if(array_key_exists('LockedOutUntil', DB::fieldList('Member'))) {
 			$this->LockedOutUntil = null;
 		}
 
 		$this->write();
-		
+
 		// Audit logging hook
 		$this->extend('memberLoggedIn');
 	}
@@ -420,7 +420,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * Check if the member ID logged in session actually
 	 * has a database record of the same ID. If there is
 	 * no logged in user, FALSE is returned anyway.
-	 * 
+	 *
 	 * @return boolean TRUE record found FALSE no record found
 	 */
 	public static function logged_in_session_exists() {
@@ -429,10 +429,10 @@ class Member extends DataObject implements TemplateGlobalProvider {
 				if($member->exists()) return true;
 			}
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Log the user in if the "remember login" cookie is set
 	 *
@@ -442,7 +442,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	public static function autoLogin() {
 		// Don't bother trying this multiple times
 		self::$_already_tried_to_auto_log_in = true;
-		
+
 		if(strpos(Cookie::get('alc_enc'), ':') && !Session::get("loggedInAs")) {
 			list($uid, $token) = explode(':', Cookie::get('alc_enc'), 2);
 			$SQL_uid = Convert::raw2sql($uid);
@@ -464,14 +464,14 @@ class Member extends DataObject implements TemplateGlobalProvider {
 				if(Member::config()->login_marker_cookie) {
 					Cookie::set(Member::config()->login_marker_cookie, 1, 0, null, null, false, true);
 				}
-				
+
 				$generator = new RandomGenerator();
 				$token = $generator->randomToken('sha1');
 				$hash = $member->encryptWithUserSettings($token);
 				$member->RememberLoginToken = $hash;
 				Cookie::set('alc_enc', $member->ID . ':' . $token, 90, null, null, false, true);
 				$member->write();
-				
+
 				// Audit logging hook
 				$member->extend('memberAutoLoggedIn');
 			}
@@ -495,12 +495,12 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		Cookie::set('alc_enc', null); // // Clear the Remember Me cookie
 		Cookie::force_expiry('alc_enc');
 
-		// Switch back to live in order to avoid infinite loops when 
+		// Switch back to live in order to avoid infinite loops when
 		// redirecting to the login screen (if this login screen is versioned)
 		Session::clear('readingMode');
 
 		$this->write();
-		
+
 		// Audit logging hook
 		$this->extend('memberLoggedOut');
 	}
@@ -587,7 +587,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 
 	/**
 	 * Returns the fields for the member form - used in the registration/profile module.
-	 * It should return fields that are editable by the admin and the logged-in user. 
+	 * It should return fields that are editable by the admin and the logged-in user.
 	 *
 	 * @return FieldList Returns a {@link FieldList} containing the fields for
 	 *                   the member form.
@@ -704,14 +704,14 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		if($this->SetPassword) $this->Password = $this->SetPassword;
 
 		// If a member with the same "unique identifier" already exists with a different ID, don't allow merging.
-		// Note: This does not a full replacement for safeguards in the controller layer (e.g. in a registration form), 
+		// Note: This does not a full replacement for safeguards in the controller layer (e.g. in a registration form),
 		// but rather a last line of defense against data inconsistencies.
 		$identifierField = Member::config()->unique_identifier_field;
 		if($this->$identifierField) {
 			// Note: Same logic as Member_Validator class
 			$idClause = ($this->ID) ? sprintf(" AND \"Member\".\"ID\" <> %d", (int)$this->ID) : '';
 			$existingRecord = DataObject::get_one(
-				'Member', 
+				'Member',
 				sprintf(
 					"\"%s\" = '%s' %s",
 					$identifierField,
@@ -721,8 +721,8 @@ class Member extends DataObject implements TemplateGlobalProvider {
 			);
 			if($existingRecord) {
 				throw new ValidationException(ValidationResult::create(false, _t(
-					'Member.ValidationIdentifierFailed', 
-					'Can\'t overwrite existing member #{id} with identical identifier ({name} = {value}))', 
+					'Member.ValidationIdentifierFailed',
+					'Can\'t overwrite existing member #{id} with identical identifier ({name} = {value}))',
 					'Values in brackets show "fieldname = value", usually denoting an existing email address',
 					array(
 						'id' => $existingRecord->ID,
@@ -736,9 +736,9 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		// We don't send emails out on dev/tests sites to prevent accidentally spamming users.
 		// However, if TestMailer is in use this isn't a risk.
 		if(
-			(Director::isLive() || Email::mailer() instanceof TestMailer) 
+			(Director::isLive() || Email::mailer() instanceof TestMailer)
 			&& $this->isChanged('Password')
-			&& $this->record['Password'] 
+			&& $this->record['Password']
 			&& $this->config()->notify_password_change
 		) {
 			$e = Member_ChangePasswordEmail::create();
@@ -780,10 +780,10 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		if(!$this->Locale) {
 			$this->Locale = i18n::get_locale();
 		}
-		
+
 		parent::onBeforeWrite();
 	}
-	
+
 	public function onAfterWrite() {
 		parent::onAfterWrite();
 
@@ -791,10 +791,10 @@ class Member extends DataObject implements TemplateGlobalProvider {
 			MemberPassword::log($this);
 		}
 	}
-	
+
 	/**
 	 * If any admin groups are requested, deny the whole save operation.
-	 * 
+	 *
 	 * @param Array $ids Database IDs of Group records
 	 * @return boolean
 	 */
@@ -822,7 +822,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		if($groups) foreach($groups as $group) {
 			if($this->inGroup($group, $strict)) return true;
 		}
-		
+
 		return false;
 	}
 
@@ -845,9 +845,9 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		} else {
 			user_error('Member::inGroup(): Wrong format for $group parameter', E_USER_ERROR);
 		}
-		
+
 		if(!$groupCheckObj) return false;
-		
+
 		$groupCandidateObjs = ($strict) ? $this->getManyManyComponents("Groups") : $this->Groups();
 		if($groupCandidateObjs) foreach($groupCandidateObjs as $groupCandidateObj) {
 			if($groupCandidateObj->ID == $groupCheckObj->ID) return true;
@@ -855,32 +855,32 @@ class Member extends DataObject implements TemplateGlobalProvider {
 
 		return false;
 	}
-	
+
 	/**
-	 * Adds the member to a group. This will create the group if the given 
-	 * group code does not return a valid group object. 
+	 * Adds the member to a group. This will create the group if the given
+	 * group code does not return a valid group object.
 	 *
 	 * @param string $groupcode
 	 * @param string Title of the group
 	 */
 	public function addToGroupByCode($groupcode, $title = "") {
 		$group = DataObject::get_one('Group', "\"Code\" = '" . Convert::raw2sql($groupcode). "'");
-		
+
 		if($group) {
 			$this->Groups()->add($group);
 		}
 		else {
 			if(!$title) $title = $groupcode;
-			
+
 			$group = new Group();
 			$group->Code = $groupcode;
 			$group->Title = $title;
 			$group->write();
-			
+
 			$this->Groups()->add($group);
 		}
 	}
-	
+
 	/**
 	 * Removes a member from a group.
 	 *
@@ -888,12 +888,12 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 */
 	public function removeFromGroupByCode($groupcode) {
 		$group = Group::get()->filter(array('Code' => $groupcode))->first();
-		
+
 		if($group) {
 			$this->Groups()->remove($group);
 		}
 	}
-	
+
 	/**
 	 * @param Array $columns Column names on the Member record to show in {@link getTitle()}.
 	 * @param String $sep Separator
@@ -908,7 +908,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	/**
 	 * Get the complete name of the member, by default in the format "<Surname>, <FirstName>".
 	 * Falls back to showing either field on its own.
-	 * 
+	 *
 	 * You can overload this getter with {@link set_title_format()}
 	 * and {@link set_title_sql()}.
 	 *
@@ -942,7 +942,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	/**
 	 * Return a SQL CONCAT() fragment suitable for a SELECT statement.
 	 * Useful for custom queries which assume a certain member title format.
-	 * 
+	 *
 	 * @param String $tableName
 	 * @return String SQL
 	 */
@@ -956,7 +956,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 			foreach($format['columns'] as $column) {
 				$columnsWithTablename[] = "\"$tableName\".\"$column\"";
 			}
-		
+
 			return "(".join(" $op '".$format['sep']."' $op ", $columnsWithTablename).")";
 		} else {
 			return "(\"$tableName\".\"Surname\" $op ' ' $op \"$tableName\".\"FirstName\")";
@@ -1003,7 +1003,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * Override the default getter for DateFormat so the
 	 * default format for the user's locale is used
 	 * if the user has not defined their own.
-	 * 
+	 *
 	 * @return string ISO date format
 	 */
 	public function getDateFormat() {
@@ -1018,7 +1018,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * Override the default getter for TimeFormat so the
 	 * default format for the user's locale is used
 	 * if the user has not defined their own.
-	 * 
+	 *
 	 * @return string ISO date format
 	 */
 	public function getTimeFormat() {
@@ -1042,7 +1042,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	public function Groups() {
 		$groups = Member_GroupSet::create('Group', 'Group_Members', 'GroupID', 'MemberID');
 		$groups = $groups->forForeignID($this->ID);
-		
+
 		$this->extend('updateGroups', $groups);
 
 		return $groups;
@@ -1054,19 +1054,19 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	public function DirectGroups() {
 		return $this->getManyManyComponents('Groups');
 	}
-	
+
 	/**
 	 * Get a member SQLMap of members in specific groups
-	 * 
+	 *
 	 * If no $groups is passed, all members will be returned
-	 * 
+	 *
 	 * @param mixed $groups - takes a SS_List, an array or a single Group.ID
 	 * @return SQLMap Returns an SQLMap that returns all Member data.
 	 * @see map()
 	 */
 	public static function map_in_groups($groups = null) {
 		$groupIDList = array();
-		
+
 		if($groups instanceof SS_List) {
 			foreach( $groups as $group ) {
 				$groupIDList[] = $group->ID;
@@ -1076,18 +1076,18 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		} elseif($groups) {
 			$groupIDList[] = $groups;
 		}
-		
+
 		// No groups, return all Members
 		if(!$groupIDList) {
 			return Member::get()->sort(array('Surname'=>'ASC', 'FirstName'=>'ASC'))->map();
 		}
-		
+
 		$membersList = new ArrayList();
 		// This is a bit ineffective, but follow the ORM style
 		foreach(Group::get()->byIDs($groupIDList) as $group) {
 			$membersList->merge($group->Members());
 		}
-		
+
 		$membersList->removeDuplicates('ID');
 		return $membersList->map();
 	}
@@ -1106,19 +1106,19 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	public static function mapInCMSGroups($groups = null) {
 		if(!$groups || $groups->Count() == 0) {
 			$perms = array('ADMIN', 'CMS_ACCESS_AssetAdmin');
-			
+
 			if(class_exists('CMSMain')) {
 				$cmsPerms = singleton('CMSMain')->providePermissions();
 			} else {
 				$cmsPerms = singleton('LeftAndMain')->providePermissions();
 			}
-			
+
 			if(!empty($cmsPerms)) {
 				$perms = array_unique(array_merge($perms, array_keys($cmsPerms)));
 			}
-			
+
 			$SQL_perms = "'" . implode("', '", Convert::raw2sql($perms)) . "'";
-			
+
 			$groups = DataObject::get('Group')
 				->innerJoin(
 					"Permission",
@@ -1139,7 +1139,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		$filterClause = ($groupIDList)
 			? "\"GroupID\" IN (" . implode( ',', $groupIDList ) . ")"
 			: "";
-			
+
 		return Member::get()->where($filterClause)->sort("\"Surname\", \"FirstName\"")
 			->innerJoin("Group_Members", "\"MemberID\"=\"Member\".\"ID\"")
 			->innerJoin("Group", "\"Group\".\"ID\"=\"GroupID\"")
@@ -1167,7 +1167,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 				unset($groupList[$index]);
 			}
 		}
-		
+
 		return $groupList;
 	}
 
@@ -1181,47 +1181,58 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 */
 	public function getCMSFields() {
 		require_once('Zend/Date.php');
-		
-		$fields = parent::getCMSFields();
 
-		$mainFields = $fields->fieldByName("Root")->fieldByName("Main")->Children;
 
-		$password = new ConfirmedPasswordField(
-			'Password', 
-			null, 
-			null, 
-			null, 
+		//build basic tabset
+		$fields = new FieldList(
+			$root = new TabSet(
+				'Root',
+				$mainTab = new Tab(
+					'Main',
+					singleton('Member')->i18n_singular_name()
+				),
+				$permissionsTab = new Tab(
+					'Permissions',
+					singleton('Permission')->i18n_plural_name()
+				),
+				$settingsTab = new Tab(
+					'LocaleSettings',
+					_t('Member.db_Locale', "Interface Locale", 'Language and formatting settings for member')
+				)
+			)
+		);
+
+
+		//add main fields including password
+		$passwordField = new ConfirmedPasswordField(
+			'Password',
+			null,
+			null,
+			null,
 			true // showOnClick
 		);
-		$password->setCanBeEmpty(true);
-		if(!$this->ID) $password->showOnClick = false;
-		$mainFields->replaceField('Password', $password);
-
-		$mainFields->replaceField('Locale', new DropdownField(
-			"Locale", 
-			_t('Member.INTERFACELANG', "Interface Language", 'Language of the CMS'), 
-			i18n::get_existing_translations()
-		));
-
-		$mainFields->removeByName('RememberLoginToken');
-		$mainFields->removeByName('AutoLoginHash');
-		$mainFields->removeByName('AutoLoginExpired');
-		$mainFields->removeByName('PasswordEncryption');
-		$mainFields->removeByName('PasswordExpiry');
-		$mainFields->removeByName('LockedOutUntil');
-		
-		if(!self::config()->lock_out_after_incorrect_logins) {
-			$mainFields->removeByName('FailedLoginCount');
+		$passwordField->setCanBeEmpty(true);
+		if(!$this->ID) {
+			$passwordField->showOnClick = false;
 		}
-		
-		$mainFields->removeByName('Salt');
+		$fields->addFieldsToTab(
+			"Root.Main",
+			array(
+				new TextField("FirstName", _t('Member.FIRSTNAME', "First Name", 'First Name of Member') ),
+				new TextField("Surname", _t('Member.SURNAME', "Surname", 'Surname of Member')),
+				new EmailField("Email", _t('Member.EMAIL', "Email", 'Email of Member')),
+				$passwordField
+			)
+		);
 
-		$fields->removeByName('Subscriptions');
 
+		// add permission fields
+		if(self::config()->lock_out_after_incorrect_logins) {
+			$fields->addFieldToTab('Root.Permissions', new NumericField('FailedLoginCount'));
+			$fields->addFieldToTab('Root.Permissions', new ReadonlyField('MaximumCount', "Maximum failures: ".self::config()->lock_out_after_incorrect_logins));
+		}
 		// Groups relation will get us into logical conflicts because
 		// Members are displayed within  group edit form in SecurityAdmin
-		$fields->removeByName('Groups');
-
 		if(Permission::check('EDIT_PERMISSIONS')) {
 			$groupsMap = array();
 			foreach(Group::get() as $group) {
@@ -1229,16 +1240,16 @@ class Member extends DataObject implements TemplateGlobalProvider {
 				$groupsMap[$group->ID] = $group->getBreadcrumbs(' > ');
 			}
 			asort($groupsMap);
-			$fields->addFieldToTab('Root.Main',
+			$fields->addFieldToTab(
+				'Root.Permissions',
 				ListboxField::create('DirectGroups', singleton('Group')->i18n_plural_name())
 					->setMultiple(true)
 					->setSource($groupsMap)
 					->setAttribute(
-						'data-placeholder', 
+						'data-placeholder',
 						_t('Member.ADDGROUP', 'Add group', 'Placeholder text for a dropdown')
 					)
 			);
-
 			// Add permission field (readonly to avoid complicated group assignment logic).
 			// This should only be available for existing records, as new records start
 			// with no permissions until they have a group assignment anyway.
@@ -1251,14 +1262,18 @@ class Member extends DataObject implements TemplateGlobalProvider {
 					// we don't want parent relationships, they're automatically resolved in the field
 					$this->getManyManyComponents('Groups')
 				);
-				$fields->findOrMakeTab('Root.Permissions', singleton('Permission')->i18n_plural_name());
 				$fields->addFieldToTab('Root.Permissions', $permissionsField);
 			}
 		}
+		$permissionsTab->addExtraClass('readonly');
 
-		$permissionsTab = $fields->fieldByName("Root")->fieldByName('Permissions');
-		if($permissionsTab) $permissionsTab->addExtraClass('readonly');
-		
+
+		//add local settings fields
+		$localeField = new DropdownField(
+			"Locale",
+			_t('Member.INTERFACELANG', "Interface Language", 'Language of the CMS'),
+			i18n::get_existing_translations()
+		);
 		$localDateFormat = Zend_Locale_Data::getContent(new Zend_Locale($this->Locale), 'date', 'short');
 		// Ensure short dates always use four digit dates to avoid confusion
 		$localDateFormat = preg_replace('/(^|[^y])yy($|[^y])/', '$1yyyy$2', $localDateFormat);
@@ -1269,44 +1284,48 @@ class Member extends DataObject implements TemplateGlobalProvider {
 			'MM/dd/yyyy' => Zend_Date::now()->toString('MM/dd/yyyy'),
 			'dd/MM/yyyy' => Zend_Date::now()->toString('dd/MM/yyyy'),
 		);
-		$mainFields->push(
-			$dateFormatField = new MemberDatetimeOptionsetField(
-				'DateFormat',
-				$this->fieldLabel('DateFormat'),
-				$dateFormatMap
-			)
+		$dateFormatField = new MemberDatetimeOptionsetField(
+			'DateFormat',
+			$this->fieldLabel('DateFormat'),
+			$dateFormatMap
 		);
 		$dateFormatField->setValue($this->DateFormat);
-		
+		//time
 		$localTimeFormat = Zend_Locale_Format::getTimeFormat(new Zend_Locale($this->Locale));
 		$timeFormatMap = array(
-			$this->TimeFormat => Zend_Date::now()->toString($this->TimeFormat), 
+			$this->TimeFormat => Zend_Date::now()->toString($this->TimeFormat),
 			$localTimeFormat => Zend_Date::now()->toString($localTimeFormat),
 			'h:mm a' => Zend_Date::now()->toString('h:mm a'),
 			'H:mm' => Zend_Date::now()->toString('H:mm'),
 		);
-		$mainFields->push(
-			$timeFormatField = new MemberDatetimeOptionsetField(
-				'TimeFormat',
-				$this->fieldLabel('TimeFormat'),
-				$timeFormatMap
-			)
+		$timeFormatField = new MemberDatetimeOptionsetField(
+			'TimeFormat',
+			$this->fieldLabel('TimeFormat'),
+			$timeFormatMap
 		);
 		$timeFormatField->setValue($this->TimeFormat);
+		$fields->addFieldsToTab(
+			'Root.LocaleSettings',
+			array(
+				$localeField,
+				$dateFormatField,
+				$timeFormatField
+			)
+		);
 
+		//add hook
 		$this->extend('updateCMSFields', $fields);
-		
 		return $fields;
 	}
-	
+
 	/**
 	 *
 	 * @param boolean $includerelations a boolean value to indicate if the labels returned include relation fields
-	 * 
+	 *
 	 */
 	public function fieldLabels($includerelations = true) {
 		$labels = parent::fieldLabels($includerelations);
-		
+
 		$labels['FirstName'] = _t('Member.FIRSTNAME', 'First Name');
 		$labels['Surname'] = _t('Member.SURNAME', 'Surname');
 		$labels['Email'] = _t('Member.EMAIL', 'Email');
@@ -1322,7 +1341,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		}
 		return $labels;
 	}
-	
+
 	/**
 	 * Users can view their own record.
 	 * Otherwise they'll need ADMIN or CMS_ACCESS_SecurityAdmin permissions.
@@ -1330,54 +1349,54 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 */
 	public function canView($member = null) {
 		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) $member = Member::currentUser();
-		
+
 		// extended access checks
 		$results = $this->extend('canView', $member);
 		if($results && is_array($results)) {
 			if(!min($results)) return false;
 			else return true;
 		}
-		
+
 		// members can usually edit their own record
 		if($member && $this->ID == $member->ID) return true;
-		
+
 		if(
 			Permission::checkMember($member, 'ADMIN')
 			|| Permission::checkMember($member, 'CMS_ACCESS_SecurityAdmin')
 		) {
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Users can edit their own record.
 	 * Otherwise they'll need ADMIN or CMS_ACCESS_SecurityAdmin permissions
 	 */
 	public function canEdit($member = null) {
 		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) $member = Member::currentUser();
-		
+
 		// extended access checks
 		$results = $this->extend('canEdit', $member);
 		if($results && is_array($results)) {
 			if(!min($results)) return false;
 			else return true;
 		}
-		
+
 		// No member found
 		if(!($member && $member->exists())) return false;
-		
+
 		// If the requesting member is not an admin, but has access to manage members,
 		// he still can't edit other members with ADMIN permission.
 		// This is a bit weak, strictly speaking he shouldn't be allowed to
 		// perform any action that could change the password on a member
-		// with "higher" permissions than himself, but thats hard to determine.		
+		// with "higher" permissions than himself, but thats hard to determine.
 		if(!Permission::checkMember($member, 'ADMIN') && Permission::checkMember($this, 'ADMIN')) return false;
 
 		return $this->canView($member);
 	}
-	
+
 	/**
 	 * Users can edit their own record.
 	 * Otherwise they'll need ADMIN or CMS_ACCESS_SecurityAdmin permissions
@@ -1398,7 +1417,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		// Members are not allowed to remove themselves,
 		// since it would create inconsistencies in the admin UIs.
 		if($this->ID && $member->ID == $this->ID) return false;
-		
+
 		return $this->canEdit($member);
 	}
 
@@ -1408,7 +1427,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 */
 	public function validate() {
 		$valid = parent::validate();
-		
+
 		if(!$this->ID || $this->isChanged('Password')) {
 			if($this->Password && self::$password_validator) {
 				$valid->combineAnd(self::$password_validator->validate($this->Password, $this));
@@ -1422,26 +1441,26 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		}
 
 		return $valid;
-	}	
-	
+	}
+
 	/**
 	 * Change password. This will cause rehashing according to
 	 * the `PasswordEncryption` property.
-	 * 
+	 *
 	 * @param String $password Cleartext password
 	 */
 	public function changePassword($password) {
 		$this->Password = $password;
 		$valid = $this->validate();
-		
+
 		if($valid->valid()) {
 			$this->AutoLoginHash = null;
 			$this->write();
 		}
-		
+
 		return $valid;
 	}
-	
+
 	/**
 	 * Tell this member that someone made a failed attempt at logging in as them.
 	 * This can be used to lock the user out temporarily if too many failed attempts are made.
@@ -1450,7 +1469,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		if(self::config()->lock_out_after_incorrect_logins) {
 			// Keep a tally of the number of failed log-ins so that we can lock people out
 			$this->FailedLoginCount = $this->FailedLoginCount + 1;
-	
+
 			if($this->FailedLoginCount >= self::config()->lock_out_after_incorrect_logins) {
 				$lockoutMins = self::config()->lock_out_delay_mins;
 				$this->LockedOutUntil = date('Y-m-d H:i:s', time() + $lockoutMins*60);
@@ -1460,18 +1479,18 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		$this->extend('registerFailedLogin');
 		$this->write();
 	}
-	
+
 	/**
 	 * Get the HtmlEditorConfig for this user to be used in the CMS.
 	 * This is set by the group. If multiple configurations are set,
 	 * the one with the highest priority wins.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function getHtmlEditorConfigForCMS() {
 		$currentName = '';
 		$currentPriority = 0;
-		
+
 		foreach($this->Groups() as $group) {
 			$configName = $group->HtmlEditorConfig;
 			if($configName) {
@@ -1482,7 +1501,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 				}
 			}
 		}
-		
+
 		// If can't find a suitable editor, just default to cms
 		return $currentName ? $currentName : 'cms';
 	}
@@ -1511,7 +1530,7 @@ class Member_GroupSet extends ManyManyList {
 		$this->foreignKey = $foreignKey;
 		$this->extraFields = $extraFields;
 	}
-	
+
 	/**
 	 * Link this group set to a specific member.
 	 */
@@ -1529,7 +1548,7 @@ class Member_GroupSet extends ManyManyList {
 			$groupIDs = DataObject::get("Group")->byIDs($groupIDs)->column("ParentID");
 			$groupIDs = array_filter($groupIDs);
 		}
-		
+
 		// Add a filter to this DataList
 		if($allGroupIDs) {
 			return "\"Group\".\"ID\" IN (" . implode(',', $allGroupIDs) .")";
@@ -1556,7 +1575,7 @@ class Member_ChangePasswordEmail extends Email {
 	protected $from = '';   // setting a blank from address uses the site's default administrator email
 	protected $subject = '';
 	protected $ss_template = 'ChangePasswordEmail';
-	
+
 	public function __construct() {
 		parent::__construct();
 
@@ -1576,7 +1595,7 @@ class Member_ForgotPasswordEmail extends Email {
 	protected $from = '';  // setting a blank from address uses the site's default administrator email
 	protected $subject = '';
 	protected $ss_template = 'ForgotPasswordEmail';
-	
+
 	public function __construct() {
 		parent::__construct();
 
@@ -1631,7 +1650,7 @@ class Member_Validator extends RequiredFields {
 	 */
 	public function php($data) {
 		$valid = parent::php($data);
-		
+
 		$identifierField = Member::config()->unique_identifier_field;
 		$SQL_identifierField = Convert::raw2sql($data[$identifierField]);
 		$member = DataObject::get_one('Member', "\"$identifierField\" = '{$SQL_identifierField}'");


### PR DESCRIPTION
Removing reliance on the parent::getCMSFields within the getCMSFields method for the following reason:
- in line with the way CMS Fields are added by Folder, File, Group, SiteTree and other core classes
- faster (no need to add a whole bunch of fields and then remove them again)
- updateCMSFields only called once
- better organisation of fields with less relevant fields out of the way in separate tabs (locale settings), making the member CMS fields less intimidating and messy.
