### PR TITLE
API: Prevent large images from repeatedly crashing PHP on resize

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -44,6 +44,8 @@ if (!is_dir($aggregatecachedir)) mkdir($aggregatecachedir);
 SS_Cache::add_backend('aggregatestore', 'File', array('cache_dir' => $aggregatecachedir));
 SS_Cache::pick_backend('aggregatestore', 'aggregate', 1000);
 
+SS_Cache::set_cache_lifetime('GDBackend_Manipulations', null, 100);
+
 // If you don't want to see deprecation errors for the new APIs, change this to 3.2.0-dev.
 Deprecation::notification_version('3.2.0');
 

--- a/filesystem/ImagickBackend.php
+++ b/filesystem/ImagickBackend.php
@@ -97,6 +97,16 @@ class ImagickBackend extends Imagick implements Image_Backend {
 	}
 
 	/**
+	 * @todo Implement memory checking for Imagick? See {@link GD}
+	 * 
+	 * @param string $filename
+	 * @return boolean
+	 */
+	public function imageAvailable($filename) {
+		return true;
+	}
+
+	/**
 	 * resize
 	 *
 	 * @param int $width
@@ -263,6 +273,14 @@ class ImagickBackend extends Imagick implements Image_Backend {
 		}
 		$new->ThumbnailImage($width,$height,true);
 		return $new;
+	}
+
+	/**
+	 * @param Image $frontend
+	 * @return void
+	 */
+	public function onBeforeDelete($frontend) {
+		// Not in use
 	}
 }
 }

--- a/model/Image.php
+++ b/model/Image.php
@@ -466,7 +466,8 @@ class Image extends File {
 		$cacheFile = call_user_func_array(array($this, "cacheFilename"), $args);
 		
 		$backend = Injector::inst()->createWithArgs(self::$backend, array(
-			Director::baseFolder()."/" . $this->Filename
+			Director::baseFolder()."/" . $this->Filename,
+			$args
 		));
 		
 		if($backend->hasImageResource()) {
@@ -725,9 +726,12 @@ class Image extends File {
 	}
 	
 	protected function onBeforeDelete() {
-		parent::onBeforeDelete(); 
+		$backend = Injector::inst()->create(self::$backend);
+		$backend->onBeforeDelete($this);
 
 		$this->deleteFormattedImages();
+
+		parent::onBeforeDelete();
 	}
 }
 

--- a/model/Image_Backend.php
+++ b/model/Image_Backend.php
@@ -110,4 +110,21 @@ interface Image_Backend {
 	 * @return Image_Backend
 	 */
 	public function croppedResize($width, $height);
+
+	/**
+	 * imageAvailable
+	 * 
+	 * @param string $filename
+	 * @return boolean
+	 */
+	public function imageAvailable($filename, $manipulation);
+
+	/**
+	 * onBeforeDelete
+	 * 
+	 * @param Image $frontend
+	 * @return void
+	 */
+	public function onBeforeDelete($frontend);
+
 }

--- a/tasks/CleanImageManipulationCache.php
+++ b/tasks/CleanImageManipulationCache.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Wipe the cache of failed image manipulations. When {@link GDBackend} attempts to resample an image, it will write
+ * the attempted manipulation to the cache and remove it from the cache if the resample is successful. The objective
+ * of the cache is to prevent fatal errors (for example from exceeded memory limits) from occurring more than once.
+ *
+ * @package framework
+ * @subpackage filesystem
+ */
+class CleanImageManipulationCache extends BuildTask {
+	
+	protected $title = 'Clean Image Manipulation Cache';
+	
+	protected $description = 'Clean the failed image manipulation cache. Use this to allow SilverStripe to attempt
+		to resample images that have previously failed to resample (for example if memory limits were exceeded).';
+	
+	/**
+	 * Check that the user has appropriate permissions to execute this task
+	 */
+	public function init() {
+		if(!Director::is_cli() && !Director::isDev() && !Permission::check('ADMIN')) {
+			return Security::permissionFailure();
+		}
+		
+		parent::init();
+	}
+	
+	/**
+	 * Clear out the image manipulation cache
+	 * @param SS_HTTPRequest $request
+	 */
+	public function run($request) {
+		$failedManipulations = 0;
+		$processedImages = 0;
+		$images = DataObject::get('Image');
+		
+		if($images && Image::get_backend() == "GDBackend") {
+			$cache = SS_Cache::factory('GDBackend_Manipulations');
+
+			foreach($images as $image) {
+				$path = $image->getFullPath();
+
+				if (file_exists($path)) {
+					$key = md5(implode('_', array($path, filemtime($path))));
+
+					if ($manipulations = unserialize($cache->load($key))) {
+						$failedManipulations += count($manipulations);
+						$processedImages++;
+						$cache->remove($key);
+					}
+				}
+			}
+		}
+		
+		echo "Cleared $failedManipulations failed manipulations from 
+			$processedImages Image objects stored in the Database.";
+	}
+	
+}

--- a/tests/model/GDImageTest.php
+++ b/tests/model/GDImageTest.php
@@ -1,5 +1,7 @@
 <?php
+
 class GDImageTest extends ImageTest {
+
 	public function setUp() {
 		if(!extension_loaded("gd")) {
 			$this->markTestSkipped("The GD extension is required");
@@ -25,4 +27,41 @@ class GDImageTest extends ImageTest {
 			$file->write();
 		}
 	}
+
+	public function tearDown() {
+		$cache = SS_Cache::factory('GDBackend_Manipulations');
+		$cache->clean(Zend_Cache::CLEANING_MODE_ALL);
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the cache of manipulation failures is cleared when deleting
+	 * the image object
+	 * @return void
+	 */
+	public function testCacheCleaningOnDelete() {
+		$image = $this->objFromFixture('Image', 'imageWithTitle');
+		$cache = SS_Cache::factory('GDBackend_Manipulations');
+		$fullPath = $image->getFullPath();
+		$key = md5(implode('_', array($fullPath, filemtime($fullPath))));
+
+		try {
+			// Simluate a failed manipulation
+			$gdFailure = new GDBackend_Failure($fullPath, array('SetWidth', 123));
+			$this->fail('GDBackend_Failure should throw an exception when setting image resource');
+		} catch (GDBackend_Failure_Exception $e) {
+			// Check that the cache has stored the manipulation failure
+			$data = unserialize($cache->load($key));
+			$this->assertArrayHasKey('SetWidth|123', $data);
+			$this->assertTrue($data['SetWidth|123']);
+
+			// Delete the image object
+			$image->delete();
+
+			// Check that the cache has been removed
+			$data = unserialize($cache->load($key));
+			$this->assertFalse($data);
+		}
+	}
+
 }


### PR DESCRIPTION
See #2753 for more discussion.

This is a (late) follow up to the discussion [here](https://groups.google.com/forum/#!searchin/silverstripe-dev/image/silverstripe-dev/B57a3KYeAVQ/fUjsQQnfEPAJ) about GD crashing when attempting to open large or high DPI images.

The Google Group discussion involved ideas around “image unavailable” icons in the CMS, this setup (by storing which manipulation failed) will hopefully pave the way for that functionality to be added later, while addressing the immediate issue of completely crashing entire sections of websites.

Implements the same method for checking available memory as #2569, though it’s different to the [method Ingo suggested](http://php.net/manual/en/function.imagecreatefromjpeg.php#64155). I’m not really sure which is more robust, the method in the php.net comments doesn’t take into account that bits and channels aren’t always present in the image info.

Marked as an API change as I’ve added a few methods to the `Image_Backend` interface.

Doesn’t cause any issues with the CMS, the images just don’t appear for now:

![screen shot 2014-01-02 at 16 15 27](https://f.cloud.github.com/assets/1655548/1833671/53841ff0-73ce-11e3-8daa-840aa19ddcdd.png)
![screen shot 2014-01-02 at 16 17 23](https://f.cloud.github.com/assets/1655548/1833673/55a842ca-73ce-11e3-8d17-a1820c5bd4bf.png)

All comments welcome.
