### PR TITLE
Better visibility of key phrasing

### DIFF
--- a/docs/en/installation/composer.md
+++ b/docs/en/installation/composer.md
@@ -41,7 +41,7 @@ Composer updates regularly, so you should run this command fairly often. These i
 
 ## Create a new site
 
-Composer can create a new site for you, using the installer as a template:
+Composer can create a new site for you, using the installer as a template (by default composer will download the latest stable version):
 
 	composer create-project silverstripe/installer ./my/website/folder
 
@@ -50,8 +50,7 @@ For example, on OS X, you might use a subdirectory of `~/Sites`.
 As long as your web server is up and running, this will get all the code that you need. 
 Now visit the site in your web browser, and the installation process will be completed.
 
-By default composer will download the latest stable version. You can also specify
-a version to download that version explicitly, i.e. this will download the older `3.0.3` release:
+You can also specify a version to download that version explicitly, i.e. this will download the older `3.0.3` release:
 
 	composer create-project silverstripe/installer ./my/website/folder 3.0.3
 	


### PR DESCRIPTION
Because the phrasing wasn't near the installation command I didn't see it.
