### PR TITLE
BUG Fixed critical issue with Folder::find_or_make failing to handle invalid filename characters

### DIFF
--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -1273,11 +1273,15 @@ class UploadField extends FileField {
 		$nameFilter = FileNameFilter::create();
 		$filteredFile = basename($nameFilter->filter($originalFile));
 		
+		// Resolve expected folder name
+		$folderName = $this->getFolderName();
+		$folder = Folder::find_or_make($folderName);
+		$parentPath = BASE_PATH."/".$folder->getFilename();
+		
 		// check if either file exists
-		$folder = $this->getFolderName();
 		$exists = false;
 		foreach(array($originalFile, $filteredFile) as $file) {
-			if(file_exists(ASSETS_PATH."/$folder/$file")) {
+			if(file_exists($parentPath.$file)) {
 				$exists = true;
 				break;
 			}

--- a/tests/filesystem/FolderTest.php
+++ b/tests/filesystem/FolderTest.php
@@ -338,4 +338,21 @@ class FolderTest extends SapphireTest {
 		))->count());
 	}
 	
+	public function testIllegalFilenames() {
+		
+		// Test that generating a filename with invalid characters generates a correctly named folder.
+		$folder = Folder::find_or_make('/FolderTest/EN_US Lang');
+		$this->assertEquals(ASSETS_DIR.'/FolderTest/EN-US-Lang/', $folder->getRelativePath());
+		
+		// Test repeatitions of folder
+		$folder2 = Folder::find_or_make('/FolderTest/EN_US Lang');
+		$this->assertEquals($folder->ID, $folder2->ID);
+		
+		$folder3 = Folder::find_or_make('/FolderTest/EN--US_L!ang');
+		$this->assertEquals($folder->ID, $folder3->ID);
+		
+		$folder4 = Folder::find_or_make('/FolderTest/EN-US-Lang');
+		$this->assertEquals($folder->ID, $folder4->ID);
+	}
+	
 }


### PR DESCRIPTION
Fixes #2868

There are cases where legacy filenames may still exist in the filesystem, despite not following the rules set by FileNameFilter, so folder matching attempts to be as forgiving as possible to avoid duplication of folders.
