### PR TITLE
Update CTF to enforce per-item permissions

### DIFF
--- a/forms/ComplexTableField.php
+++ b/forms/ComplexTableField.php
@@ -743,6 +743,7 @@ class ComplexTableField_ItemRequest extends TableListField_ItemRequest {
 		if($this->ctf->Can('edit') !== true) {
 			return false;
 		}
+		if(!$this->dataObj()->canEdit()) { return Security::permissionFailure(); }
 
 		$this->methodName = "edit";
 
@@ -758,7 +759,10 @@ class ComplexTableField_ItemRequest extends TableListField_ItemRequest {
 			return false;
 		}
 
-		$this->dataObj()->delete();
+		$dataObj = $this->dataObj();
+		if(!$dataObj->canDelete()) { return Security::permissionFailure(); }
+
+		$dataObj->delete();
 	}
 
 	///////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
ComplexTableField_Item's edit() and delete() functions currently only check global permissions before executing either action. This patch calls the item's own canEdit()/canDelete() methods, to make sure that any fine-grained permissions are respected. 

An example use case is assets management with per-file access permissions and with the DataObjectManager class installed (so that CTF is used).
