### PR TITLE
FIX: Fixed regression in ContentController template selection.

### DIFF
--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -721,6 +721,13 @@ class SSViewer {
 		foreach($classes as $class) {
 			$template = $class . $suffix;
 			if(SSViewer::hasTemplate($template)) $templates[] = $template;
+
+			// If the class is "Page_Controller", look for Page.ss
+			if(stripos($class,'_controller') !== false) {
+				$template = str_ireplace('_controller','',$class) . $suffix;
+				if(SSViewer::hasTemplate($template)) $templates[] = $template;
+			}
+
 			if($baseClass && $class == $baseClass) break;
 		}
 		return $templates;


### PR DESCRIPTION
https://github.com/silverstripe/silverstripe-cms/commit/47582b3e3c7cad2957087d50b368fddedeeccdfe improved
template selection, but has introduced a regression.  Specifically, it applies to contorllers that are
created by making a direct subclass of Page_Controller (a pattern used in a few modules to make a page
that looks like a CMS page but doesn't appear in the sitetree).  Previously Page.ss would be used as a
template, because when Page_Controller was interrogated in the template stack, the strtok(Page_Controller,_)
was called before looking up the template.

The code was refactored to use SSViewer::get_templates_by_class(), which doesn't do this.  This function
is used by LeftAndMain as well, so rather than re-add the strtok() call, which might cause unintended
side-effects, I've instead just have it ignore _controller in a classname.  Strictly speaking, this is
an API change, but as long as people have followed page type class naming conventions, it will still
work in the relevant cases.
