### PR TITLE
DOC: DropdownField __construct

### DIFF
--- a/forms/DropdownField.php
+++ b/forms/DropdownField.php
@@ -117,15 +117,15 @@ class DropdownField extends FormField {
 	protected $disabledItems = array();
 	
 	/**
-	 * Creates a new dropdown field.
-	 * @param $name The field name
-	 * @param $title The field title
-	 * @param $source An map of the dropdown items
-	 * @param $value The current value
-	 * @param $form The parent form
-	 * @param $emptyString mixed Add an empty selection on to of the {@link $source}-Array (can also be boolean, which
-	 *                           results in an empty string).  Argument is deprecated in 3.1, please use
-	 *                           {@link setEmptyString()} and/or {@link setHasEmptyDefault(true)} instead.
+	 * @param string $name The field name
+	 * @param string $title The field title
+	 * @param array $source An map of the dropdown items
+	 * @param string $value The current value
+	 * @param Form $form The parent form
+	 * @param string|bool $emptyString Add an empty selection on to of the {@link $source}-Array (can also be
+	 *					boolean, which  results in an empty string).  Argument is deprecated
+	 * 					in 3.1, please use{@link setEmptyString()} and/or
+	 * 					{@link setHasEmptyDefault(true)} instead.
 	 */
 	public function __construct($name, $title=null, $source=array(), $value='', $form=null, $emptyString=null) {
 		$this->setSource($source);


### PR DESCRIPTION
Current docs make PHPStorm spew errors about data types.

`new CheckboxSetField('Countries'...);`

Causes `Expected The, got string`.

Simple restructure.
