### PR TITLE
Silverstripe.com is not this version

### DIFF
--- a/docs/en/topics/shortcodes.md
+++ b/docs/en/topics/shortcodes.md
@@ -97,6 +97,7 @@ CMS users still need to remember the specific syntax, but these shortcodes can f
 for more advanced editing interfaces (with visual placeholders). See the built-in `[embed]` shortcode as an example
 for coupling shortcodes with a form to create and edit placeholders.
 
+
 ## Built-in Shortcodes
 
 SilverStripe comes with several shortcode parsers already.


### PR DESCRIPTION
On Silverstripe.com(http://doc.silverstripe.com/framework/en/3.0/topics/shortcodes) is an older version of this file.
From the "Built-in Shortcodes"-heading down to the bottom the page is marked as code.

Cheers
K
