### PR TITLE
Default browser actions on right click in GridField

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -1048,12 +1048,16 @@ jQuery.noConflict();
 		 * with the CMS-specific ajax loading.
 		 */
 		$('.cms .ss-gridfield').entwine({
-			showDetailView: function(url) {
+			showDetailView: function(url, newWindow) {
 				// Include any GET parameters from the current URL, as the view state might depend on it.
 				// For example, a list prefiltered through external search criteria might be passed to GridField.
 				var params = window.location.search.replace(/^\?/, '');
 				if(params) url = $.path.addSearchParams(url, params);
-				$('.cms-container').loadPanel(url);
+				if(newWindow) {
+					window.open(url);
+				} else {
+					$('.cms-container').loadPanel(url);
+				}
 			}
 		});
 

--- a/javascript/GridField.js
+++ b/javascript/GridField.js
@@ -61,8 +61,16 @@
 					}
 				}, ajaxOpts));
 			},
-			showDetailView: function(url) {
-				window.location.href = url;
+			/**
+			 * @param String url
+			 * @param Boolean newWindow
+			 */
+			showDetailView: function(url, newWindow) {
+				if(newWindow) {
+					window.open(url);
+				} else {
+					window.location.href = url;
+				}
 			},
 			getItems: function() {
 				return this.find('.ss-gridfield-item');
@@ -111,8 +119,16 @@
 					return false;
 				}
 
+				// Use default behaviour on right click
+				if(e.which == 3) return false;
+
 				var editLink = this.find('.edit-link');
-				if(editLink.length) this.getGridField().showDetailView(editLink.prop('href'));
+				if(editLink.length) {
+					this.getGridField().showDetailView(
+						editLink.prop('href'), 
+						(e.which == 2 || e.metaKey)
+					);
+				}
 			},
 			onmouseover: function() {
 				if(this.find('.edit-link').length) this.css('cursor', 'pointer');
@@ -233,7 +249,13 @@
 
 		$('.ss-gridfield .action-detail').entwine({
 			onclick: function() {
-				this.getGridField().showDetailView($(this).prop('href'));
+				// Use default behaviour on right click
+				if(e.which == 3) return false;
+
+				this.getGridField().showDetailView(
+					$(this).prop('href'), 
+					(e.which == 2 || e.metaKey)
+				);
 				return false;
 			}
 		});


### PR DESCRIPTION
Allows opening into a new tab from "edit" buttons, and in the case of Firefox
allows right clicks on the row without causing an action (e.g. to inspect the
element).

Fixes https://github.com/silverstripe/silverstripe-cms/issues/953
