### PR TITLE
Adding defaults for unhandled event priorities in log formatters.

### DIFF
--- a/dev/LogErrorEmailFormatter.php
+++ b/dev/LogErrorEmailFormatter.php
@@ -23,6 +23,9 @@ class SS_LogErrorEmailFormatter implements Zend_Log_Formatter_Interface {
 				$errorType = 'Notice';
 				$colour = 'grey';
 				break;
+			default:
+				$errorType = $event['priorityName'];
+				$colour = 'grey';
 		}
 
 		if(!is_array($event['message'])) {

--- a/dev/LogErrorFileFormatter.php
+++ b/dev/LogErrorFileFormatter.php
@@ -15,7 +15,7 @@ class SS_LogErrorFileFormatter implements Zend_Log_Formatter_Interface {
 		$errfile = $event['message']['errfile'];
 		$errline = $event['message']['errline'];
 		$errcontext = $event['message']['errcontext'];
-		
+
 		switch($event['priorityName']) {
 			case 'ERR':
 				$errtype = 'Error';
@@ -26,6 +26,8 @@ class SS_LogErrorFileFormatter implements Zend_Log_Formatter_Interface {
 			case 'NOTICE':
 				$errtype = 'Notice';
 				break;
+			default:
+				$errtype = $event['priorityName'];
 		}
 
 		$urlSuffix = '';


### PR DESCRIPTION
Unhandled types wouldn't show up in the error format message, and a
notice "undefined $errtype" is displayed on these cases.
