### PR TITLE
Update File.php

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -732,7 +732,7 @@ class File extends DataObject {
 	}
 
 	/**
-	 * Does not change the filesystem itself, please use {@link write()} for this.
+	 * Caution: this does not change the location of the file on the filesystem.
 	 */
 	public function setFilename($val) {
 		$this->setField('Filename', $val);


### PR DESCRIPTION
Updating wording to be less misleading, you can call write() after calling this function and it will still have no effect. 

The file does not get moved because of this line:
https://github.com/silverstripe/silverstripe-framework/blob/3.1/filesystem/File.php#L515

Maybe add to the method doc, telling people to set ParentId and Name instead if they want to change the location of a file (if that's the correct method).
