### PR TITLE
Making Director::test() ignore URL Anchors

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -244,6 +244,10 @@ class Director implements TemplateGlobalProvider {
 		Config::inst()->update('Cookie', 'report_errors', false);
 		Requirements::set_backend(new Requirements_Backend());
 
+		if (strpos($url, '#') !== false) {
+			$url = substr($url, 0, strpos($url, '#'));
+		}
+
 		// Handle absolute URLs
 		if (@parse_url($url, PHP_URL_HOST) != '') {
 			$bits = parse_url($url);

--- a/tests/control/DirectorTest.php
+++ b/tests/control/DirectorTest.php
@@ -344,6 +344,23 @@ class DirectorTest extends SapphireTest {
 
 		$_SERVER = $origServer;
 	}
+
+	public function testTestIgnoresHashes() {
+		//test that hashes are ignored
+		$url = "DirectorTestRequest_Controller/returnGetValue?somekey=key";
+		$hash = "#test";
+		$response = Director::test($url . $hash, null, null, null, null, null, null, $request);
+		$this->assertFalse($response->isError());
+		$this->assertEquals('key', $response->getBody());
+		$this->assertEquals($request->getURL(true), $url);
+
+		//test encoded hashes are accepted
+		$url = "DirectorTestRequest_Controller/returnGetValue?somekey=test%23key";
+		$response = Director::test($url, null, null, null, null, null, null, $request);
+		$this->assertFalse($response->isError());
+		$this->assertEquals('test#key', $response->getBody());
+		$this->assertEquals($request->getURL(true), $url);
+	}
 	
 	public function testRequestFilterInDirectorTest() {
 		$filter = new TestRequestFilter;


### PR DESCRIPTION
Anchors should never make it to the server when they are in the browser URL bar, however tests are slightly different and some `Link()` functions may return a URL anchor. Instead of every test checking a link and stripping the anchor, I feel the Director::test() function should strip them off.
