### PR TITLE
Folder::findOrMake() - Fallback to the assets folder

### DIFF
--- a/filesystem/Folder.php
+++ b/filesystem/Folder.php
@@ -82,6 +82,15 @@ class Folder extends File {
 			}
 			$parentID = $item->ID;
 		}
+		
+		// Fallback to the assets/ folder
+		if(!$item) {
+			$item = new Folder();
+			$item->ParentID = null;
+			$item->Name = 'assets';
+			$item->Title = null;
+			$item->Filename = null;
+		}
 
 		return $item;
 	}

--- a/tests/filesystem/FolderTest.php
+++ b/tests/filesystem/FolderTest.php
@@ -54,6 +54,15 @@ class FolderTest extends SapphireTest {
 		$this->assertEquals(ASSETS_DIR . $path,$folder->getRelativePath(),
 			'A folder named "assets/" within "assets/" is allowed'
 		);
+		
+		$path = '/'; // relative to "assets/" folder, should produce "assets/"
+		$folder = Folder::find_or_make($path);
+		$this->assertEquals(ASSETS_DIR . $path,$folder->getRelativePath(),
+			'The folder "assets/"'
+		);
+		$this->assertEquals(ASSETS_PATH . $path,$folder->getFullPath(),
+			'The folder "assets/"'
+		);
 	}
 	
 	/**


### PR DESCRIPTION
Fallback to the assets folder if no Folder (DataObject) is found.

See:
CMSFileAddController->getEditForm()
$uploadField->setFolderName('/'); // root of the assets
#2878
- PHP Fatal error: Call to a member function getFilename() on a non-object in UploadField.php on line 1279
