### PR TITLE
BUG Fix issues with uploading to /assets

### DIFF
--- a/filesystem/Upload.php
+++ b/filesystem/Upload.php
@@ -134,7 +134,9 @@ class Upload extends Controller {
 		$file = $nameFilter->filter($tmpFile['name']);
 		$fileName = basename($file);
 
-		$relativeFilePath = $parentFolder ? $parentFolder->getRelativePath() . "$fileName" : $fileName;		
+		$relativeFilePath = $parentFolder
+			? $parentFolder->getRelativePath() . "$fileName" 
+			: ASSETS_DIR . "/" . $fileName;
 		
 		// Create a new file record (or try to retrieve an existing one)
 		if(!$this->file) {

--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -1276,7 +1276,9 @@ class UploadField extends FileField {
 		// Resolve expected folder name
 		$folderName = $this->getFolderName();
 		$folder = Folder::find_or_make($folderName);
-		$parentPath = BASE_PATH."/".$folder->getFilename();
+		$parentPath = $folder
+			? BASE_PATH."/".$folder->getFilename()
+			: ASSETS_PATH."/";
 		
 		// check if either file exists
 		$exists = false;


### PR DESCRIPTION
If you have an uploadfield with ->setFolderName('/') then various parts of the system fail to respond correctly.
- `UploadField::fileexists` crashes with an error from calling getFilename on a null $folder variable.
- `Upload::load` mistakenly interprets `/` as the site root, rather than the assets root, and attemps to save the file outside of the assets folder.

This provides an alternative solution to https://github.com/silverstripe/silverstripe-framework/pull/2902 which encountered a similar problem.
