### PR TITLE
Fix: remove all leading dashes from URLSegments

### DIFF
--- a/model/URLSegmentFilter.php
+++ b/model/URLSegmentFilter.php
@@ -33,7 +33,7 @@ class URLSegmentFilter extends Object {
 		'/[_.]+/u' => '-', // underscores and dots to dashes
 		'/[^A-Za-z0-9\-]+/u' => '', // remove non-ASCII chars, only allow alphanumeric and dashes
 		'/[\-]{2,}/u' => '-', // remove duplicate dashes
-		'/^[\-_]/u' => '', // Remove all leading dashes or underscores
+		'/^[\-]+/u' => '' // Remove all leading dashes
 	);
 	
 	/**

--- a/tests/model/URLSegmentFilterTest.php
+++ b/tests/model/URLSegmentFilterTest.php
@@ -77,4 +77,9 @@ class URLSegmentFilterTest extends SapphireTest {
 		$this->assertEquals('url-contains-dot', $filter->filter('url-contains.dot'));
 	}
 
+	public function testRemoveLeadingDashes() {
+		$filter = new URLSegmentFilter();
+		$this->assertEquals('url-has-leading-dashes', $filter->filter('---url-has-leading-dashes'));
+	}
+
 }


### PR DESCRIPTION
Changed behaviour to remove all leading dashes and not just one. Removed redundant check for underscore as this is already handled with [underscores and dots to dashes](https://github.com/silverstripe/silverstripe-framework/blob/3.1/model/URLSegmentFilter.php#L33).
