### PR TITLE
FIX Log out current member when forgotten password

### DIFF
--- a/security/Security.php
+++ b/security/Security.php
@@ -634,6 +634,11 @@ class Security extends Controller implements TemplateGlobalProvider {
 		if(isset($_REQUEST['t']) && $member && $member->validateAutoLoginToken($_REQUEST['t'])) {
 			// On first valid password reset request redirect to the same URL without hash to avoid referrer leakage.
 
+			// if there is a current member, they should be logged out
+			if ($curMember = Member::currentUser()) {
+				$curMember->logOut();
+			}
+			
 			// Store the hash for the change password form. Will be unset after reload within the ChangePasswordForm.
 			Session::set('AutoLoginHash', $member->encryptWithUserSettings($_REQUEST['t']));
 			


### PR DESCRIPTION
At the moment, if a user is logged in on a device (say, their phone) but has forgotten their password.

If they attempt to reset their password on their desktop, then open the email on their phone they then see the reset password form _with_ the CurrentPassword field. I'm not entirely sure what happens if a DIFFERENT user is currently logged in, but I think they remain logged in and you're effectively trying to change their password.

Both scenarios are not ideal and (in fact) this happens a lot in the real world as it's a legitimate complaint we're receiving from a visitors of one of our client's websites.
