### PR TITLE
NEW: Files can be uploaded directly in the 'Insert Link' form

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -671,6 +671,7 @@ body.cms-dialog { overflow: auto; background: url("../images/textures/bg_cms_mai
 .htmleditorfield-dialog .CompositeField .text select { margin: 5px 0 0 0; }
 
 .htmleditorfield-linkform .step2 { margin-bottom: 16px; }
+.htmleditorfield-linkform .ss-uploadfield .middleColumn { width: auto; }
 
 .htmleditorfield-mediaform .ss-gridfield .gridfield-button-delete { display: none; }
 .htmleditorfield-mediaform .ss-gridfield table.ss-gridfield-table tbody td:first-child { padding: 0; text-align: center; }

--- a/admin/scss/_style.scss
+++ b/admin/scss/_style.scss
@@ -1518,6 +1518,11 @@ body.cms-dialog {
 	.step2 {
 		margin-bottom: $grid-x*2;
 	}
+	.ss-uploadfield {
+		.middleColumn {
+			width: auto;
+		}
+	}
 }
 
 .htmleditorfield-mediaform {

--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -278,7 +278,7 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 					$siteTree,
 					new TextField('external', _t('HtmlEditorField.URL', 'URL'), 'http://'),
 					new EmailField('email', _t('HtmlEditorField.EMAIL', 'Email address')),
-					new TreeDropdownField('file', _t('HtmlEditorField.FILE', 'File'), 'File', 'ID', 'Title', true),
+					$fileField = new UploadField('file', _t('HtmlEditorField.FILE', 'File')),
 					new TextField('Anchor', _t('HtmlEditorField.ANCHORVALUE', 'Anchor')),
 					new TextField('Description', _t('HtmlEditorField.LINKDESCR', 'Link description')),
 					new CheckboxField('TargetBlank',
@@ -300,7 +300,8 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 
 		$headerWrap->addExtraClass('CompositeField composite cms-content-header nolabel ');		
 		$contentComposite->addExtraClass('ss-insert-link content');
-		
+		$fileField->setAllowedMaxFileNumber(1);
+
 		$form->unsetValidator();
 		$form->loadDataFrom($this);
 		$form->addExtraClass('htmleditorfield-form htmleditorfield-linkform cms-dialog-content');


### PR DESCRIPTION
This seems like it was far too easy... but everything in my initial testing works. Uploading works, “From files” works, editing an inserted link works, the UploadField edit form works.

Still need to do some more cross-browser testing, but wanted to get this on here now in case I’ve missed something glaringly obvious which would explain why it’s almost _too_ simple :wink:.

Sorry for the stupidly large screenshots.

![screen shot 2014-02-28 at 22 26 32](https://f.cloud.github.com/assets/1655548/2299162/4dbfe80c-a0c8-11e3-81aa-671a5be8a296.png)
![screen shot 2014-02-28 at 22 27 07](https://f.cloud.github.com/assets/1655548/2299163/4dc246b0-a0c8-11e3-8707-439fe6f00c61.png)
