### PR TITLE
setSelect was calling deprecated addSelect

### DIFF
--- a/model/SQLQuery.php
+++ b/model/SQLQuery.php
@@ -159,13 +159,21 @@ class SQLQuery {
 	 * @return SQLQuery
 	 */
 	public function setSelect($fields) {
-		$this->select = array();
 		if (func_num_args() > 1) {
 			$fields = func_get_args();
 		} else if(!is_array($fields)) {
 			$fields = array($fields);
 		}
-		return $this->addSelect($fields);
+		
+		foreach($fields as $idx => $field) {
+			if(preg_match('/^(.*) +AS +"?([^"]*)"?/i', $field, $matches)) {
+				$this->selectField($matches[1], $matches[2]);
+			} else {
+				$this->selectField($field, is_numeric($idx) ? null : $idx);
+			}
+		}
+		
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
When I call SQLQuery->setSelect() I get a user deprecated error:

`[User Deprecated] SQLQuery->addSelect is deprecated. Use selectField() to specify column aliases. Called from SQLQuery->setSelect.`

As far as I know, setSelect isn't deprecated (it'd be a pain to use selectField() multiple times rather than just passing an array of select clauses). The problem is that setSelect itself calls the deprecated addSelect function.

So I guess setSelect should do something like below, where it recreates the behaviour of addSelect without actually calling it and minus the deprecation message.
