### PR TITLE
NEW: Show loading indicator when attaching files to UploadField

### DIFF
--- a/css/UploadField.css
+++ b/css/UploadField.css
@@ -53,3 +53,4 @@ Used in side panels and action tabs
 
 .ss-upload .clear { clear: both; }
 .ss-upload .ss-uploadfield-fromcomputer input { /* since we can't really style the file input, we use this hack to make it as big as the button and hide it */ position: absolute; top: 0; right: 0; margin: 0; opacity: 0; filter: alpha(opacity=0); transform: translate(-300px, 0) scale(4); font-size: 23px; direction: ltr; cursor: pointer; height: 30px; line-height: 30px; }
+.ss-upload .loader { height: 94px; background: transparent url(../admin/images/spinner.gif) no-repeat 50% 50%; }

--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -295,18 +295,30 @@
 				dialog.ssdialog('open');
 			},
 			attachFiles: function(ids, uploadedFileId) {
-				var self = this, config = this.getConfig();
-				$.post(
-					config['urlAttach'], 
-					{'ids': ids},
-					function(data, status, xhr) {
+				var self = this,
+					config = this.getConfig(),
+					indicator = $('<div class="loader" />'),
+					target = (uploadedFileId) ? this.find(".ss-uploadfield-item[data-fileid='"+uploadedFileId+"']") : this.find('.ss-uploadfield-addfile');
+
+				target.children().hide();
+				target.append(indicator);
+
+				$.ajax({
+					type: "POST",
+					url: config['urlAttach'],
+					data: {'ids': ids},
+					complete: function(xhr, status) {
+						target.children().show();
+						indicator.remove();
+					},
+					success: function(data, status, xhr) {
 						self.fileupload('attach', {
 							files: data,
 							options: self.fileupload('option'),
 							replaceFileID: uploadedFileId
 						});
 					}
-				);
+				});
 			}
 		});
 		$('div.ss-upload *').entwine({

--- a/scss/UploadField.scss
+++ b/scss/UploadField.scss
@@ -284,4 +284,8 @@
 			line-height: 30px;
 		}
 	}
+	.loader {
+		height: 94px; // Approxmiately matches the height of the field once a file is attached, avoids a 'jump' in size
+		background: transparent url(../admin/images/spinner.gif) no-repeat 50% 50%;
+	}
 }


### PR DESCRIPTION
Currently, no indication is shown to the CMS user than anything is actually happening.

Is the attach functionality used anywhere outside a “standard” `UploadField` (e.g. `AssetUploadField`?) I can’t seem to find any usage of it anywhere else.

Attaching:
![screen shot 2014-03-03 at 21 13 54](https://f.cloud.github.com/assets/1655548/2314766/034b0edc-a31b-11e3-9b37-5183f67e4937.png)

Attaching a second file:
![screen shot 2014-03-03 at 21 14 15](https://f.cloud.github.com/assets/1655548/2314777/16384b0e-a31b-11e3-8a7f-ceb4abfd62c6.png)

Attaching via ‘choose another file’:
![screen shot 2014-03-03 at 21 14 44](https://f.cloud.github.com/assets/1655548/2314782/20786ac2-a31b-11e3-995e-e02a98cd249a.png)
