### PR TITLE
BUG Fix DataObject / Versioned publishing issues

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -2166,6 +2166,11 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 		}
 
 		$dataQuery = new DataQuery($tableClass);
+		
+		// Reset query parameter context to that of this DataObject
+		if($params = $this->getSourceQueryParams()) {
+			foreach($params as $key => $value) $dataQuery->setQueryParam($key, $value);
+		}
 
 		// TableField sets the record ID to "new" on new row data, so don't try doing anything in that case
 		if(!is_numeric($this->record['ID'])) return false;

--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -1184,6 +1184,7 @@ class Versioned extends DataExtension {
 		$oldMode = Versioned::get_reading_mode();
 		Versioned::reading_stage($stage);
 
+		$this->owner->forceChange();
 		$result = $this->owner->write(false, $forceInsert);
 		Versioned::set_reading_mode($oldMode);
 


### PR DESCRIPTION
This issue was initially raised at and fixes https://github.com/silverstripe/silverstripe-blog/issues/105.

After investigation I found the following issues.

If a DataObject was queried under a certain stage or reading mode, and then this mode changes, lazy-loading of fields would fail since it will always attempt to use the current mode. This is fixed in `DataObject::loadLazyFields` so that any `DataObject` will maintain it's own query parameters internally, propegating this context from initial load all the way to lazy loading of fields.

This fix was made in `DataObject` rather than in `Versioned::augmentLoadLazyFields` because (in my humble opinion) it's the role of the DataObject to maintain its own query context, and it should only be touched by extensions to modify this explicitly. This is easier than updating each dataobject extension across the board.

Secondly, `Versioned::writeToStage` was failing if no fields were modified, meaning simply loading a record from one stage and writing it to another would result in no write performed.

Test cases were included in `VersionedTest` rather than `DataObjectLazyLoadingTest` becuase I feel that this is more a test of the Versioned extension (and DataObject's support for extensions) than the lazy loading process itself. I could just as easy have put it there though. :)

I've marked this as "don't merge" because I'd like to get a few developer opinions before I'm confident this is the correct solution.
