### PR TITLE
BUG UploadField: overwriteWarning overwrites replaceFile=false

### DIFF
--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -154,8 +154,7 @@ class UploadField extends FileField {
 		/**
 		 * Show a warning when overwriting a file.
 		 * This requires Upload->replaceFile config to be set to true, otherwise
-		 * files will be renamed instead of overwritten (although the warning will
-		 * still be displayed)
+		 * files will be renamed instead of overwritten.
 		 * 
 		 * @see Upload
 		 * @var boolean
@@ -998,11 +997,12 @@ class UploadField extends FileField {
 			}
 		}
 
-		//get all the existing files in the current folder
-		if ($this->getOverwriteWarning()) {
-			//add overwrite warning error message to the config object sent to Javascript
+		// add overwrite warning error message to the config object sent to Javascript
+		if ($this->getUpload()->getReplaceFile() && $this->getOverwriteWarning()) {
 			$config['errorMessages']['overwriteWarning'] =
 				_t('UploadField.OVERWRITEWARNING', 'File with the same name already exists');
+		} else {
+			$this->setOverwriteWarning(false);
 		}
 		
 		$mergedConfig = array_merge($config, $this->ufConfig);
@@ -1152,11 +1152,6 @@ class UploadField extends FileField {
 		if ($relationClass = $this->getRelationAutosetClass(null)) {
 			// Create new object explicitly. Otherwise rely on Upload::load to choose the class.
 			$fileObject = Object::create($relationClass);
-		}
-
-		// Allow replacing files (rather than renaming a duplicate) when warning about overwrites
-		if($this->getConfig('overwriteWarning')) {
-			$this->upload->setReplaceFile(true);
 		}
 
 		// Get the uploaded file into a new file object.

--- a/tests/forms/uploadfield/UploadFieldTest.php
+++ b/tests/forms/uploadfield/UploadFieldTest.php
@@ -642,6 +642,41 @@ class UploadFieldTest extends FunctionalTest {
 		$this->assertContains($file4->ID, $itemIDs, 'Contains file in assigned folder');
 		$this->assertNotContains($fileSubfolder->ID, $itemIDs, 'Does not contain file in subfolder');
 	}
+	
+	/**
+	 * Test that UploadField:overwriteWarning cannot overwrite Upload:replaceFile
+	 */
+	public function testConfigOverwriteWarningCannotRelaceFiles() {
+		$this->loginWithPermission('ADMIN');
+
+		$tmpFileName = 'testUploadBasic.txt';
+		$response = $this->mockFileUpload('NoRelationField', $tmpFileName);
+		$this->assertFalse($response->isError());
+		$responseData = Convert::json2array($response->getBody());
+		$this->assertFileExists(ASSETS_PATH . '/UploadFieldTest/' . $responseData[0]['name']);
+		$uploadedFile = DataObject::get_by_id('File', (int) $responseData[0]['id']);
+		$this->assertTrue(is_object($uploadedFile), 'The file object is created');
+
+		Upload::config()->replaceFile = false;
+		UploadField::config()->defaultConfig = array_merge(
+				UploadField::config()->defaultConfig, array('overwriteWarning' => true)
+		);
+
+		$tmpFileName = 'testUploadBasic.txt';
+		$response = $this->mockFileUpload('NoRelationField', $tmpFileName);
+		$this->assertFalse($response->isError());
+		$responseData = Convert::json2array($response->getBody());
+		$this->assertFileExists(ASSETS_PATH . '/UploadFieldTest/' . $responseData[0]['name']);
+		$uploadedFile2 = DataObject::get_by_id('File', (int) $responseData[0]['id']);
+		$this->assertTrue(is_object($uploadedFile2), 'The file object is created');
+		$this->assertTrue(
+				$uploadedFile->Filename !== $uploadedFile2->Filename, 'Filename is not the same'
+		);
+		$this->assertGreaterThan(
+				$uploadedFile->ID, $uploadedFile2->ID, 'File database record is not the same'
+		);
+		$uploadedFile2->delete();
+	}
 
 	protected function getMockForm() {
 		return new Form(new Controller(), 'Form', new FieldList(), new FieldList());


### PR DESCRIPTION
A warning should not overwrite the config it wants to warn about.

If somebody likes to see replaceFile=true by default, please do it in config.yml
#2904
