### PR TITLE
updating comments for HTTPRequest - immutability

### DIFF
--- a/control/HTTPRequest.php
+++ b/control/HTTPRequest.php
@@ -4,6 +4,9 @@
  * Represents a HTTP-request, including a URL that is tokenised for parsing, and a request method
  * (GET/POST/PUT/DELETE). This is used by {@link RequestHandler} objects to decide what to do.
  * 
+ * Caution: objects of this class are immutable, e.g. echo $request['a']; works as expected, 
+ * but $request['a'] = '1'; has no effect.
+ * 
  * The intention is that a single SS_HTTPRequest object can be passed from one object to another, each object calling
  * match() to get the information that they need out of the URL.  This is generally handled by 
  * {@link RequestHandler::handleRequest()}.


### PR DESCRIPTION
SS_HTTPRequest can be read like an array, e.g. echo $request['a'], but cannot be written like an array, e.g. $request['a'] = 5; Added comment to caution people.
# See line 375:

```
/**
 * @ignore
 */
public function offsetSet($offset, $value) {}

/**
 * @ignore
 */
public function offsetUnset($offset) {}
```
# 

Might be good to write something about how you are supposed to modify a request, or what you are supposed to do instead (a redirect?).
