### PR TITLE
Rewrote usages of error suppression operator (3.0 version)

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -208,9 +208,8 @@ class Director implements TemplateGlobalProvider {
 		Requirements::set_backend(new Requirements_Backend());
 
 		// Handle absolute URLs
-		if (@parse_url($url, PHP_URL_HOST) != '') {
-			$bits = parse_url($url);
-			$_SERVER['HTTP_HOST'] = $bits['host'];
+		if ($host = parse_url($url, PHP_URL_HOST)) {
+			$_SERVER['HTTP_HOST'] = $host;
 			$url = Director::makeRelative($url);
 		}
 

--- a/dev/Backtrace.php
+++ b/dev/Backtrace.php
@@ -90,7 +90,7 @@ class SS_Backtrace {
 		// Filter out arguments
 		foreach($bt as $i => $frame) {
 			$match = false;
-			if(@$bt[$i]['class']) {
+			if(!empty($bt[$i]['class'])) {
 				foreach(self::$ignore_function_args as $fnSpec) {
 					if(is_array($fnSpec) && $bt[$i]['class'] == $fnSpec[0] && $bt[$i]['function'] == $fnSpec[1]) {
 						$match = true;

--- a/dev/Debug.php
+++ b/dev/Debug.php
@@ -419,7 +419,12 @@ class Debug {
 		$reporter = self::create_debug_view();
 		
 		// Coupling alert: This relies on knowledge of how the director gets its URL, it could be improved.
-		$httpRequest = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : @$_REQUEST['url'];
+		$httpRequest = null;
+		if(isset($_SERVER['REQUEST_URI'])) {
+			$httpRequest = $_SERVER['REQUEST_URI'];
+		} elseif(isset($_REQUEST['url'])) {
+			$httpRequest = $_REQUEST['url'];
+		}
 		if(isset($_SERVER['REQUEST_METHOD'])) $httpRequest = $_SERVER['REQUEST_METHOD'] . ' ' . $httpRequest;
 
 		$reporter->writeHeader($httpRequest);

--- a/dev/Log.php
+++ b/dev/Log.php
@@ -94,7 +94,7 @@ class SS_Log {
 			// Add default context (shouldn't change until the actual log event happens)
 			foreach(static::$log_globals as $globalName => $keys) {
 				foreach($keys as $key) {
-					$val = @$GLOBALS[$globalName][$key];
+					$val = isset($GLOBALS[$globalName][$key]) ? $GLOBALS[$globalName][$key] : null;
 					static::$logger->setEventItem(sprintf('$%s[\'%s\']', $globalName, $key), $val);
 				}
 			}
@@ -167,8 +167,8 @@ class SS_Log {
 			$message = array(
 				'errno' => '',
 				'errstr' => $message,
-				'errfile' => @$lastTrace['file'],
-				'errline' => @$lastTrace['line'],
+				'errfile' => isset($lastTrace['file']) ? $lastTrace['file'] : null,
+				'errline' => isset($lastTrace['line']) ? $lastTrace['line'] : null,
 				'errcontext' => $trace
 			);
 		}

--- a/dev/LogErrorEmailFormatter.php
+++ b/dev/LogErrorEmailFormatter.php
@@ -63,8 +63,8 @@ class SS_LogErrorEmailFormatter implements Zend_Log_Formatter_Interface {
 		$relfile = Director::makeRelative($errfile);
 		if($relfile && $relfile[0] == '/') $relfile = substr($relfile, 1);
 		
-		$host = @$_SERVER['HTTP_HOST'];
-		$uri = @$_SERVER['REQUEST_URI'];
+		$host = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : null;
+		$uri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : null;
 
 		$subject = "[$errorType] in $relfile:{$errline} (http://{$host}{$uri})";
 

--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -362,11 +362,15 @@ class InstallRequirements {
 	 */
 	function findWebserver() {
 		// Try finding from SERVER_SIGNATURE or SERVER_SOFTWARE
-		$webserver = @$_SERVER['SERVER_SIGNATURE'];
-		if(!$webserver) $webserver = @$_SERVER['SERVER_SOFTWARE'];
+		if(!empty($_SERVER['SERVER_SIGNATURE'])) {
+			$webserver = $_SERVER['SERVER_SIGNATURE'];
+		} elseif(!empty($_SERVER['SERVER_SOFTWARE'])) {
+			$webserver = $_SERVER['SERVER_SOFTWARE'];
+		} else {
+			return false;
+		}
 
-		if($webserver) return strip_tags(trim($webserver));
-		else return false;
+		return strip_tags(trim($webserver));
 	}
 
 	/**
@@ -913,7 +917,7 @@ class InstallRequirements {
 			$this->testing($testDetails);
 			return true;
 		} else {
-			if(!@$result['cannotCreate']) {
+			if(empty($result['cannotCreate'])) {
 				$testDetails[2] .= ". Please create the database manually.";
 			} else {
 				$testDetails[2] .= " (user '$databaseConfig[username]' doesn't have CREATE DATABASE permissions.)";
@@ -972,7 +976,7 @@ class InstallRequirements {
 		$section = $testDetails[0];
 		$test = $testDetails[1];
 
-		$this->tests[$section][$test] = array("error", @$testDetails[2]);
+		$this->tests[$section][$test] = array("error", isset($testDetails[2]) ? $testDetails[2] : null);
 		$this->errors[] = $testDetails;
 	}
 
@@ -980,7 +984,7 @@ class InstallRequirements {
 		$section = $testDetails[0];
 		$test = $testDetails[1];
 
-		$this->tests[$section][$test] = array("warning", @$testDetails[2]);
+		$this->tests[$section][$test] = array("warning", isset($testDetails[2]) ? $testDetails[2] : null);
 		$this->warnings[] = $testDetails;
 	}
 

--- a/docs/en/howto/phpunit-configuration.md
+++ b/docs/en/howto/phpunit-configuration.md
@@ -71,7 +71,7 @@ Example `mysite/_config.php`:
 	// Customized configuration for running with different database settings.
 	// Ensure this code comes after ConfigureFromEnv.php
 	if(Director::isDev()) {
-		if($db = @$_GET['db']) {
+		if(isset($_GET['db']) && ($db = $_GET['db'])) {
 			global $databaseConfig;
 			if($db == 'sqlite3') $databaseConfig['type'] = 'SQLite3Database';
 		}

--- a/forms/Form.php
+++ b/forms/Form.php
@@ -651,7 +651,7 @@ class Form extends RequestHandler {
 	 * @return String
 	 */
 	public function getAttribute($name) {
-		return @$this->attributes[$name];
+		if(isset($this->attributes[$name])) return $this->attributes[$name];
 	}
 
 	public function getAttributes() {

--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -361,7 +361,7 @@ class FormField extends RequestHandler {
 	 */
 	public function getAttribute($name) {
 		$attrs = $this->getAttributes();
-		return @$attrs[$name];
+		if(isset($attrs[$name])) return $attrs[$name];
 	}
 	
 	/**

--- a/forms/gridfield/GridField.php
+++ b/forms/gridfield/GridField.php
@@ -591,7 +591,8 @@ class GridField extends FormField {
 	public function gridFieldAlterAction($data, $form, SS_HTTPRequest $request) {
 		$html = '';
 		$data = $request->requestVars();
-		$fieldData = @$data[$this->getName()];
+		$name = $this->getName();
+		$fieldData = isset($data[$name]) ? $data[$name] : null;
 
 		// Update state from client
 		$state = $this->getState(false);

--- a/model/Database.php
+++ b/model/Database.php
@@ -214,14 +214,16 @@ abstract class SS_Database {
 		foreach($this->schemaUpdateTransaction as $tableName => $changes) {
 			switch($changes['command']) {
 				case 'create':
-				$this->createTable($tableName, $changes['newFields'], $changes['newIndexes'], $changes['options'],
-					@$changes['advancedOptions']);
+					$this->createTable($tableName, $changes['newFields'], $changes['newIndexes'], $changes['options'],
+						isset($changes['advancedOptions']) ? $changes['advancedOptions'] : null
+					);
 					break;
 				
 				case 'alter':
 					$this->alterTable($tableName, $changes['newFields'], $changes['newIndexes'],
-					$changes['alteredFields'], $changes['alteredIndexes'], $changes['alteredOptions'],
-					@$changes['advancedOptions']);
+						$changes['alteredFields'], $changes['alteredIndexes'], $changes['alteredOptions'],
+						isset($changes['advancedOptions']) ? $changes['advancedOptions'] : null
+					);
 					break;
 			}
 		}

--- a/model/HTMLValue.php
+++ b/model/HTMLValue.php
@@ -73,10 +73,14 @@ class SS_HTMLValue extends ViewableData {
 		// This behaviour is apparently XML spec, but we don't want this because it messes up the HTML
 		$content = str_replace(chr(13), '', $content);
 
-		return @$this->getDocument()->loadHTML(
+		$errorState = libxml_use_internal_errors(true);
+		$result = $this->getDocument()->loadHTML(
 			'<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head>' .
 			"<body>$content</body></html>"
 		);
+		libxml_clear_errors();
+		libxml_use_internal_errors($errorState);
+		return $result;
 	}
 
 	/**

--- a/tests/security/BasicAuthTest.php
+++ b/tests/security/BasicAuthTest.php
@@ -26,8 +26,8 @@ class BasicAuthTest extends FunctionalTest {
 	}
 
 	public function testBasicAuthEnabledWithoutLogin() {
-		$origUser = @$_SERVER['PHP_AUTH_USER'];
-		$origPw = @$_SERVER['PHP_AUTH_PW'];
+		$origUser = isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : null;
+		$origPw = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : null;
 		
 		unset($_SERVER['PHP_AUTH_USER']);
 		unset($_SERVER['PHP_AUTH_PW']);
@@ -40,8 +40,8 @@ class BasicAuthTest extends FunctionalTest {
 	}
 	
 	public function testBasicAuthDoesntCallActionOrFurtherInitOnAuthFailure() {
-		$origUser = @$_SERVER['PHP_AUTH_USER'];
-		$origPw = @$_SERVER['PHP_AUTH_PW'];
+		$origUser = isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : null;
+		$origPw = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : null;
 		
 		unset($_SERVER['PHP_AUTH_USER']);
 		unset($_SERVER['PHP_AUTH_PW']);
@@ -60,8 +60,8 @@ class BasicAuthTest extends FunctionalTest {
 	}
 
 	public function testBasicAuthEnabledWithPermission() {
-		$origUser = @$_SERVER['PHP_AUTH_USER'];
-		$origPw = @$_SERVER['PHP_AUTH_PW'];
+		$origUser = isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : null;
+		$origPw = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : null;
 		
 		$_SERVER['PHP_AUTH_USER'] = 'user-in-mygroup@test.com';
 		$_SERVER['PHP_AUTH_PW'] = 'wrongpassword';
@@ -83,8 +83,8 @@ class BasicAuthTest extends FunctionalTest {
 	}
 	
 	public function testBasicAuthEnabledWithoutPermission() {
-		$origUser = @$_SERVER['PHP_AUTH_USER'];
-		$origPw = @$_SERVER['PHP_AUTH_PW'];
+		$origUser = isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : null;
+		$origPw = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : null;
 		
 		$_SERVER['PHP_AUTH_USER'] = 'user-without-groups@test.com';
 		$_SERVER['PHP_AUTH_PW'] = 'wrongpassword';


### PR DESCRIPTION
There are several places in the code where the error suppression operator has been used, mostly unnecessarily, especially to provide a shortcut for safely accessing array-indexed elements that may not be set.

The problem with this approach is that, even though errors aren't reported immediately, they are still raised behind the scenes. Not only is this a performance issue, but it also pollutes the result of `error_get_last` with messages where no error has actually occurred. This is actually where I found these to be an issue, as I was writing an application that had to detect and respond to errors in the error control loop.

In most cases isset and empty was sufficient to safely determine array accessed values. `HTMLValue::setContent` was rewritten using some information I found at http://stackoverflow.com/questions/7082401/avoid-domdocument-xml-warnings-in-php

There are still places that the operator is used, specifically in third party modules (which are mostly not covered by test cases) and file access methods, which were troublesome to rewrite safely without the error suppression.

This will be ported up to 3.1 in a separate PR, since some of the API has changed in 3.1.
