### PR TITLE
Rewrote usages of error suppression operator (3.1 version)

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -245,7 +245,7 @@ class Director implements TemplateGlobalProvider {
 		Requirements::set_backend(new Requirements_Backend());
 
 		// Handle absolute URLs
-		if (@parse_url($url, PHP_URL_HOST) != '') {
+		if (parse_url($url, PHP_URL_HOST)) {
 			$bits = parse_url($url);
 			// If a port is mentioned in the absolute URL, be sure to add that into the 
 			// HTTP host

--- a/dev/Debug.php
+++ b/dev/Debug.php
@@ -401,7 +401,12 @@ class Debug {
 		$reporter = self::create_debug_view();
 		
 		// Coupling alert: This relies on knowledge of how the director gets its URL, it could be improved.
-		$httpRequest = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : @$_REQUEST['url'];
+		$httpRequest = null;
+		if(isset($_SERVER['REQUEST_URI'])) {
+			$httpRequest = $_SERVER['REQUEST_URI'];
+		} elseif(isset($_REQUEST['url'])) {
+			$httpRequest = $_REQUEST['url'];
+		}
 		if(isset($_SERVER['REQUEST_METHOD'])) $httpRequest = $_SERVER['REQUEST_METHOD'] . ' ' . $httpRequest;
 
 		$reporter->writeHeader($httpRequest);

--- a/dev/Log.php
+++ b/dev/Log.php
@@ -167,8 +167,8 @@ class SS_Log {
 			$message = array(
 				'errno' => '',
 				'errstr' => $message,
-				'errfile' => @$lastTrace['file'],
-				'errline' => @$lastTrace['line'],
+				'errfile' => isset($lastTrace['file']) ? $lastTrace['file'] : null,
+				'errline' => isset($lastTrace['line']) ? $lastTrace['line'] : null,
 				'errcontext' => $trace
 			);
 		}

--- a/dev/LogErrorEmailFormatter.php
+++ b/dev/LogErrorEmailFormatter.php
@@ -66,8 +66,8 @@ class SS_LogErrorEmailFormatter implements Zend_Log_Formatter_Interface {
 		$relfile = Director::makeRelative($errfile);
 		if($relfile && $relfile[0] == '/') $relfile = substr($relfile, 1);
 		
-		$host = @$_SERVER['HTTP_HOST'];
-		$uri = @$_SERVER['REQUEST_URI'];
+		$host = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : null;
+		$uri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : null;
 
 		$subject = "[$errorType] in $relfile:{$errline} (http://{$host}{$uri})";
 

--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -386,11 +386,15 @@ class InstallRequirements {
 	 */
 	function findWebserver() {
 		// Try finding from SERVER_SIGNATURE or SERVER_SOFTWARE
-		$webserver = @$_SERVER['SERVER_SIGNATURE'];
-		if(!$webserver) $webserver = @$_SERVER['SERVER_SOFTWARE'];
+		if(!empty($_SERVER['SERVER_SIGNATURE'])) {
+			$webserver = $_SERVER['SERVER_SIGNATURE'];
+		} elseif(!empty($_SERVER['SERVER_SOFTWARE'])) {
+			$webserver = $_SERVER['SERVER_SOFTWARE'];
+		} else {
+			return false;
+		}
 
-		if($webserver) return strip_tags(trim($webserver));
-		else return false;
+		return strip_tags(trim($webserver));
 	}
 
 	/**
@@ -1116,7 +1120,7 @@ class InstallRequirements {
 			$this->testing($testDetails);
 			return true;
 		} else {
-			if(!@$result['cannotCreate']) {
+			if(empty($result['cannotCreate'])) {
 				$testDetails[2] .= ". Please create the database manually.";
 			} else {
 				$testDetails[2] .= " (user '$databaseConfig[username]' doesn't have CREATE DATABASE permissions.)";
@@ -1194,7 +1198,7 @@ class InstallRequirements {
 		$section = $testDetails[0];
 		$test = $testDetails[1];
 
-		$this->tests[$section][$test] = array("error", @$testDetails[2]);
+		$this->tests[$section][$test] = array("error", isset($testDetails[2]) ? $testDetails[2] : null);
 		$this->errors[] = $testDetails;
 	}
 
@@ -1202,7 +1206,7 @@ class InstallRequirements {
 		$section = $testDetails[0];
 		$test = $testDetails[1];
 
-		$this->tests[$section][$test] = array("warning", @$testDetails[2]);
+		$this->tests[$section][$test] = array("warning", isset($testDetails[2]) ? $testDetails[2] : null);
 		$this->warnings[] = $testDetails;
 	}
 

--- a/docs/en/howto/phpunit-configuration.md
+++ b/docs/en/howto/phpunit-configuration.md
@@ -71,7 +71,7 @@ Example `mysite/_config.php`:
 	// Customized configuration for running with different database settings.
 	// Ensure this code comes after ConfigureFromEnv.php
 	if(Director::isDev()) {
-		if($db = @$_GET['db']) {
+		if(isset($_GET['db']) && ($db = $_GET['db'])) {
 			global $databaseConfig;
 			if($db == 'sqlite3') $databaseConfig['type'] = 'SQLite3Database';
 		}

--- a/forms/Form.php
+++ b/forms/Form.php
@@ -683,7 +683,7 @@ class Form extends RequestHandler {
 	 * @return String
 	 */
 	public function getAttribute($name) {
-		return @$this->attributes[$name];
+		if(isset($this->attributes[$name])) return $this->attributes[$name];
 	}
 
 	public function getAttributes() {

--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -358,7 +358,7 @@ class FormField extends RequestHandler {
 	 */
 	public function getAttribute($name) {
 		$attrs = $this->getAttributes();
-		return @$attrs[$name];
+		if(isset($attrs[$name])) return $attrs[$name];
 	}
 	
 	/**

--- a/forms/HtmlEditorSanitiser.php
+++ b/forms/HtmlEditorSanitiser.php
@@ -62,10 +62,10 @@ class HtmlEditorSanitiser {
 		foreach(explode(',', $validElements) as $validElement) {
 			if(preg_match($elementRuleRegExp, $validElement, $matches)) {
 
-				$prefix = @$matches[1];
-				$elementName = @$matches[2];
-				$outputName = @$matches[3];
-				$attrData = @$matches[4];
+				$prefix = isset($matches[1]) ? $matches[1] : null;
+				$elementName = isset($matches[2]) ? $matches[2] : null;
+				$outputName = isset($matches[3]) ? $matches[3] : null;
+				$attrData = isset($matches[4]) ? $matches[4] : null;
 
 				// Create the new element
 				$element = new stdClass();
@@ -91,10 +91,10 @@ class HtmlEditorSanitiser {
 						if(preg_match($attrRuleRegExp, $attr, $matches)) {
 							$attr = new stdClass();
 
-							$attrType = @$matches[1];
-							$attrName = str_replace('::', ':', @$matches[2]);
-							$prefix = @$matches[3];
-							$value = @$matches[4];
+							$attrType = isset($matches[1]) ? $matches[1] : null;
+							$attrName = isset($matches[2]) ? str_replace('::', ':', $matches[2]) : null;
+							$prefix = isset($matches[3]) ? $matches[3] : null;
+							$value = isset($matches[4]) ? $matches[4] : null;
 
 							// Required
 							if($attrType === '!') {

--- a/forms/gridfield/GridField.php
+++ b/forms/gridfield/GridField.php
@@ -615,7 +615,8 @@ class GridField extends FormField {
 	public function gridFieldAlterAction($data, $form, SS_HTTPRequest $request) {
 		$html = '';
 		$data = $request->requestVars();
-		$fieldData = @$data[$this->getName()];
+		$name = $this->getName();
+		$fieldData = isset($data[$name]) ? $data[$name] : null;
 
 		// Update state from client
 		$state = $this->getState(false);

--- a/model/Database.php
+++ b/model/Database.php
@@ -211,14 +211,16 @@ abstract class SS_Database {
 		foreach($this->schemaUpdateTransaction as $tableName => $changes) {
 			switch($changes['command']) {
 				case 'create':
-				$this->createTable($tableName, $changes['newFields'], $changes['newIndexes'], $changes['options'],
-					@$changes['advancedOptions']);
+					$this->createTable($tableName, $changes['newFields'], $changes['newIndexes'], $changes['options'],
+						isset($changes['advancedOptions']) ? $changes['advancedOptions'] : null
+					);
 					break;
 				
 				case 'alter':
 					$this->alterTable($tableName, $changes['newFields'], $changes['newIndexes'],
-					$changes['alteredFields'], $changes['alteredIndexes'], $changes['alteredOptions'],
-					@$changes['advancedOptions']);
+						$changes['alteredFields'], $changes['alteredIndexes'], $changes['alteredOptions'],
+						isset($changes['advancedOptions']) ? $changes['advancedOptions'] : null
+					);
 					break;
 			}
 		}

--- a/model/HTMLValue.php
+++ b/model/HTMLValue.php
@@ -163,9 +163,13 @@ class SS_HTML4Value extends SS_HTMLValue {
 		// Reset the document if we're in an invalid state for some reason
 		if (!$this->isValid()) $this->setDocument(null);
 
-		return @$this->getDocument()->loadHTML(
+		$errorState = libxml_use_internal_errors(true);
+		$result = $this->getDocument()->loadHTML(
 			'<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head>' .
 			"<body>$content</body></html>"
 		);
+		libxml_clear_errors();
+		libxml_use_internal_errors($errorState);
+		return $result;
 	}
 }

--- a/parsers/ShortcodeParser.php
+++ b/parsers/ShortcodeParser.php
@@ -229,8 +229,8 @@ class ShortcodeParser {
 					'text' => $match[0][0],
 					's' => $match[0][1],
 					'e' => $match[0][1] + strlen($match[0][0]),
-					'open' =>  @$match['open'][0],
-					'close' => @$match['close'][0],
+					'open' =>  isset($match['open'][0]) ? $match['open'][0] : null,
+					'close' => isset($match['close'][0]) ? $match['close'][0] : null,
 					'attrs' => $attrs,
 					'content' => '',
 					'escaped' => !empty($match['oesc'][0]) || !empty($match['cesc1'][0]) || !empty($match['cesc2'][0])

--- a/tests/security/BasicAuthTest.php
+++ b/tests/security/BasicAuthTest.php
@@ -26,8 +26,8 @@ class BasicAuthTest extends FunctionalTest {
 	}
 
 	public function testBasicAuthEnabledWithoutLogin() {
-		$origUser = @$_SERVER['PHP_AUTH_USER'];
-		$origPw = @$_SERVER['PHP_AUTH_PW'];
+		$origUser = isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : null;
+		$origPw = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : null;
 		
 		unset($_SERVER['PHP_AUTH_USER']);
 		unset($_SERVER['PHP_AUTH_PW']);
@@ -40,8 +40,8 @@ class BasicAuthTest extends FunctionalTest {
 	}
 	
 	public function testBasicAuthDoesntCallActionOrFurtherInitOnAuthFailure() {
-		$origUser = @$_SERVER['PHP_AUTH_USER'];
-		$origPw = @$_SERVER['PHP_AUTH_PW'];
+		$origUser = isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : null;
+		$origPw = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : null;
 		
 		unset($_SERVER['PHP_AUTH_USER']);
 		unset($_SERVER['PHP_AUTH_PW']);
@@ -60,8 +60,8 @@ class BasicAuthTest extends FunctionalTest {
 	}
 
 	public function testBasicAuthEnabledWithPermission() {
-		$origUser = @$_SERVER['PHP_AUTH_USER'];
-		$origPw = @$_SERVER['PHP_AUTH_PW'];
+		$origUser = isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : null;
+		$origPw = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : null;
 		
 		$_SERVER['PHP_AUTH_USER'] = 'user-in-mygroup@test.com';
 		$_SERVER['PHP_AUTH_PW'] = 'wrongpassword';
@@ -83,8 +83,8 @@ class BasicAuthTest extends FunctionalTest {
 	}
 	
 	public function testBasicAuthEnabledWithoutPermission() {
-		$origUser = @$_SERVER['PHP_AUTH_USER'];
-		$origPw = @$_SERVER['PHP_AUTH_PW'];
+		$origUser = isset($_SERVER['PHP_AUTH_USER']) ? $_SERVER['PHP_AUTH_USER'] : null;
+		$origPw = isset($_SERVER['PHP_AUTH_PW']) ? $_SERVER['PHP_AUTH_PW'] : null;
 		
 		$_SERVER['PHP_AUTH_USER'] = 'user-without-groups@test.com';
 		$_SERVER['PHP_AUTH_PW'] = 'wrongpassword';


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/pull/2924 for details.

I had to tweak this PR for 3.1 due to some extra classes and variances between the APIs.

I decided in the end that it wasn't critical to remove all of these from the test cases, since they aren't really run in the normal course of execution, although it would be wise to try avoiding their usage in the future.
