### PR TITLE
API Enhanced the overwriteWarning behaviour to work independently of the replaceFile setting

### DIFF
--- a/_config/uploadfield.yml
+++ b/_config/uploadfield.yml
@@ -1,4 +1,5 @@
-name: uploadfield
+---
+Name: uploadfield
 ---
 UploadField:
   defaultConfig:
@@ -11,4 +12,8 @@ UploadField:
     previewMaxHeight: 60
     uploadTemplateName: 'ss-uploadfield-uploadtemplate'
     downloadTemplateName: 'ss-uploadfield-downloadtemplate'
-    overwriteWarning: true # Warning before overwriting existing file (only relevant when Upload: replaceFile is true)
+    # Warning before overwriting existing file. Behaviour depends on replaceFile.
+    overwriteWarning: true
+    # replaceFile determines if uploads replace existing files of the same name.
+    # if false an auto-rename is performed instead.
+    replaceFile: true

--- a/docs/en/reference/uploadfield.md
+++ b/docs/en/reference/uploadfield.md
@@ -146,6 +146,19 @@ to known file categories.
 	// 'doc','docx','txt','rtf','xls','xlsx','pages', 'ppt','pptx','pps','csv', 'html','htm','xhtml', 'xml','pdf'
 	$uploadField->setAllowedFileCategories('image', 'doc');
 
+### Customise file-exists behaviour
+
+When uploading files that may already exist there are two behaviours that must be configured.
+These are `overwriteWarning`, which determines whether a user should be prompted if
+any file exists, and `replaceFile`, which determines whether a file should be replaced or 
+automatically renamed. These both default to true, but can be customised if necessary (especially
+if used on the frontend).
+
+	:::php
+	// Disable notifications, and prevent file-overwriting
+	$uploadField
+		->setOverwriteWarning(false) // Don't notify or prompt user
+		->setReplaceFile(false); // Never replace files, only rename
 
 ### Limit the maximum file size
 
@@ -289,7 +302,10 @@ editform, or 'fileEditValidator' to determine the validator (eg RequiredFields).
    (of a method on File to provide a actions) for the EditForm (Example: 'getCMSActions')
  - `setFileEditValidator`: (string) Validator (eg RequiredFields) or string $name 
    (of a method on File to provide a Validator) for the EditForm (Example: 'getCMSValidator')
- - `setOverwriteWarning`: (boolean) Show a warning when overwriting a file.
+ - `setOverwriteWarning`: (boolean) Show a warning when overwriting a file. The warning message will
+   depend on the value of `replaceFile`.
+ - `setReplaceFile`: (boolean) Determine if existing files should be replaced. If false a rename
+    is performed instead.
  - `setPreviewMaxWidth`: (int)
  - `setPreviewMaxHeight`: (int)
  - `setTemplateFileButtons`: (string) Template name to use for the file buttons
@@ -313,16 +329,21 @@ Certain default values for the above can be configured using the YAML config sys
 		previewMaxHeight: 60
 		uploadTemplateName: 'ss-uploadfield-uploadtemplate'
 		downloadTemplateName: 'ss-uploadfield-downloadtemplate'
-		overwriteWarning: true # Warning before overwriting existing file (only relevant when Upload: replaceFile is true)
+		# Warning before overwriting existing file. Behaviour depends on replaceFile
+		overwriteWarning: true
+		# replaceFile determines if uploads replace existing files of the same name.
+		# if false an auto-rename is performed instead.
+		replaceFile: true
 
 The above settings can also be set on a per-instance basis by using `setConfig` with the appropriate key.
 
-You can also configure the underlying `[api:Upload]` class, by using the YAML config system.
+You can also configure the underlying `[api:Upload]` class, by using the YAML config system. Note that
+the value of `UploadField.replaceFile` will override the value of `Upload.replaceFile` when an
+`[api:UploadField]` is used.
 
 	:::yaml
 	Upload:
-	  # Globally disables automatic renaming of files and displays a warning before overwriting an existing file
-	  replaceFile: true
+	  replaceFile: false # Same as above, but only affects Upload when used as stand-alone field
 	  uploads_folder: 'Uploads'
   
 ## Using the UploadField in a frontend form
@@ -346,6 +367,8 @@ gallery the below code could be used:
 				new TextField('Title', 'Title', null, 255),
 				$field = new UploadField('Images', 'Upload Images')
 			); 
+			$field->setOverwriteWarning(false); // Don't use front-end file exists notifications
+			$field->setReplaceFile(false); // Prevent users replacing each others' files
 			$field->setCanAttachExisting(false); // Block access to Silverstripe assets library
 			$field->setCanPreviewFolder(false); // Don't show target filesystem folder on upload field
 			$field->relationAutoSetting = false; // Prevents the form thinking the GalleryPage is the underlying object

--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -71,10 +71,13 @@
 								.text(config.errorMessages.overwriteWarning)
 								.addClass('ui-state-warning-text');
 							data.context.find('.ss-uploadfield-item-progress').hide();
-							data.context.find('.ss-uploadfield-item-overwrite').show();
-							data.context.find('.ss-uploadfield-item-overwrite-warning').on('click', function(e){
+							var action = config.replaceFile
+								? data.context.find('.ss-uploadfield-item-overwrite')
+								: data.context.find('.ss-uploadfield-item-rename');
+							action.show();
+							action.find('.ss-uploadfield-item-warning').on('click', function(e){
 								data.context.find('.ss-uploadfield-item-progress').show();
-								data.context.find('.ss-uploadfield-item-overwrite').hide();
+								action.hide();
 								data.context.find('.ss-uploadfield-item-status')
 									.removeClass('ui-state-warning-text');
 								//upload only if the "overwrite" button is clicked

--- a/javascript/UploadField_uploadtemplate.js
+++ b/javascript/UploadField_uploadtemplate.js
@@ -24,7 +24,10 @@ window.tmpl.cache['ss-uploadfield-uploadtemplate'] = tmpl(
 						'<button class="icon icon-16" data-icon="minus-circle" title="' + ss.i18n._t('UploadField.CANCELREMOVE', 'Cancel/Remove') + '">' + ss.i18n._t('UploadField.CANCELREMOVE', 'Cancel/Remove') + '</button>' +
 					'</div>' +
 					'<div class="ss-uploadfield-item-overwrite hide ">'+
-						'<button data-icon="drive-upload" class="ss-uploadfield-item-overwrite-warning" title="' + ss.i18n._t('UploadField.OVERWRITE', 'Overwrite') + '">' + ss.i18n._t('UploadField.OVERWRITE', 'Overwrite') + '</button>' +
+						'<button data-icon="drive-upload" class="ss-uploadfield-item-warning" title="' + ss.i18n._t('UploadField.OVERWRITE', 'Overwrite') + '">' + ss.i18n._t('UploadField.OVERWRITE', 'Overwrite') + '</button>' +
+					'</div>' +
+					'<div class="ss-uploadfield-item-rename hide ">'+
+						'<button data-icon="drive-upload" class="ss-uploadfield-item-warning" title="' + ss.i18n._t('UploadField.AUTORENAME', 'Auto-Rename') + '">' + ss.i18n._t('UploadField.AUTORENAME', 'Auto-Rename') + '</button>' +
 					'</div>' +
 				'</div>' +
 			'</div>' +


### PR DESCRIPTION
This should hopefully provide a solution to the issue raised at https://github.com/silverstripe/silverstripe-framework/pull/2920

When we introduced the overwriteWarning option, this field would force replaceFile to true in any situation, even if the default value is set to false (or set to false in user-code).

To acommodate more flexibility in configuration I've enhanced the notification message slightly, so that the message displayed to users when they upload an already existing file differs slightly, depending on whether they have replaceFile set to true or false.

with replaceFile set to true:

![clipboard-1](https://f.cloud.github.com/assets/936064/2341079/b00da556-a4d0-11e3-8276-232bd46c9b77.jpg)

with replaceFile set to false:

![clipboard-2](https://f.cloud.github.com/assets/936064/2341089/de821692-a4d0-11e3-8abd-5d1facf4ced0.jpg)

I've updated the documentation to hopefully better explain how these field options should be configured, and updated the front end usage guidelines.

Unfortunately, in order to maintain backwards compatibility, I've had to introduce an `UploadField.replaceFile` default config. The reason for this introduction is that according to the current behaviour, overwriteWarning is true, and this forces replaceFile to be true on the instance. If I let it inherit the default value from `Upload.replaceFile`, then this would effectively change the current behaviour so that renaming was the default option, instead of replacing. Hopefully, this at least means that there is no behaviour change for those simply upgrading from the previous version.

`Upload.replaceFile` is still in place, but is only useful in cases where the `Upload` class is used as a stand-alone uploader.

Now the default behaviour for UploadField can be easily configured by updating the overwriteWarning and replaceFile configuration keys on UploadField, and also customised on a per-instance basis.
