### PR TITLE
Fixed syntax error in Form.php (missing })

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -1105,6 +1105,7 @@ class Form extends RequestHandler {
 
 			return $this->message;
 		}
+	}
 
 	/**
 	 * Set a status message for the form.


### PR DESCRIPTION
the syntax error was introduced by this merge: 0e0597f8cd5bd9eec0033cf13e58916e3a1f52f0
