### PR TITLE
Revert "Tidy up enum matching where classname is missing"

### DIFF
--- a/model/fieldtypes/Enum.php
+++ b/model/fieldtypes/Enum.php
@@ -38,7 +38,7 @@ class Enum extends StringField {
 	public function __construct($name = null, $enum = NULL, $default = NULL) {
 		if($enum) {
 			if(!is_array($enum)) {
-				$enum = preg_split("/ *, */", trim(trim($enum, ',')));
+				$enum = preg_split("/ *, */", trim($enum));
 			}
 
 			$this->enum = $enum;

--- a/model/fieldtypes/MultiEnum.php
+++ b/model/fieldtypes/MultiEnum.php
@@ -18,7 +18,7 @@ class MultiEnum extends Enum {
 		// Validate and assign the default
 		$this->default = null;
 		if($default) {
-			$defaults = preg_split('/ *, */',trim(trim($default, ',')));
+			$defaults = preg_split('/ *, */',trim($default));
 			foreach($defaults as $thisDefault) {
 				if(!in_array($thisDefault, $this->enum)) {
 					user_error("Enum::__construct() The default value '$thisDefault' does not match "


### PR DESCRIPTION
This reverts commit 20e082d00e6390eeb1d2f4e00f6850127d9a1882.
Resolves #2935
