### PR TITLE
BUG Fix issue with inheritance of Injector service configuration

### DIFF
--- a/control/injector/Injector.php
+++ b/control/injector/Injector.php
@@ -180,6 +180,13 @@ class Injector {
 	 * @var Factory
 	 */
 	protected $objectCreator;
+	
+	/**
+	 * Locator for determining Config properties for services
+	 * 
+	 * @var ServiceConfigurationLocator 
+	 */
+	protected $configLocator;
 
 	/**
 	 * Create a new injector. 

--- a/control/injector/ServiceConfigurationLocator.php
+++ b/control/injector/ServiceConfigurationLocator.php
@@ -9,7 +9,13 @@
  * @subpackage injector
  */
 class ServiceConfigurationLocator {
-	public function locateConfigFor($name) {
-		
-	}
+	
+	
+	/**
+	 * Finds the Injector config for a named service.
+	 * 
+	 * @param string $name
+	 * @return mixed
+	 */
+	public function locateConfigFor($name) {}
 }

--- a/control/injector/SilverStripeServiceConfigurationLocator.php
+++ b/control/injector/SilverStripeServiceConfigurationLocator.php
@@ -7,43 +7,65 @@
  * @package framework
  * @subpackage injector
  */
-class SilverStripeServiceConfigurationLocator {
+class SilverStripeServiceConfigurationLocator extends ServiceConfigurationLocator {
 	
-	private $configs = array();
+	/**
+	 * List of Injector configurations cached from Config in class => config format.
+	 * If any config is false, this denotes that this class and all its parents 
+	 * have no configuration specified.
+	 * 
+	 * @var array
+	 */
+	protected $configs = array();
 	
 	public function locateConfigFor($name) {
 		
+		// Check direct or cached result
+		$config = $this->configFor($name);
+		if($config !== null) return $config;
+		
+		// do parent lookup if it's a class
+		if (class_exists($name)) {
+			$parents = array_reverse(array_keys(ClassInfo::ancestry($name)));
+			array_shift($parents);
+
+			foreach ($parents as $parent) {
+				// have we already got for this? 
+				$config = $this->configFor($parent);
+				if($config !== null) {
+					// Cache this result
+					$this->configs[$name] = $config;
+					return $config;
+				}
+			}
+		}
+		
+		// there is no parent config, so we'll record that as false so we don't do the expensive
+		// lookup through parents again
+		$this->configs[$name] = false;
+	}
+	
+	/**
+	 * Retrieves the config for a named service without performing a hierarchy walk
+	 * 
+	 * @param string $name Name of service
+	 * @return mixed Returns either the configuration data, if there is any. A missing config is denoted 
+	 * by a value of either null (there is no direct config assigned and a hierarchy walk is necessary)
+	 * or false (there is no config for this class, nor within the hierarchy for this class). 
+	 */
+	protected function configFor($name) {
+		
+		// Return cached result
 		if (isset($this->configs[$name])) {
-			return $this->configs[$name];
+			return $this->configs[$name]; // Potentially false
 		}
 		
 		$config = Config::inst()->get('Injector', $name);
 		if ($config) {
 			$this->configs[$name] = $config;
 			return $config;
-		}
-		
-		// do parent lookup if it's a class
-		if (class_exists($name)) {
-			$parents = array_reverse(array_keys(ClassInfo::ancestry($name)));
-			array_shift($parents);
-			foreach ($parents as $parent) {
-				// have we already got for this? 
-				if (isset($this->configs[$parent])) {
-					return $this->configs[$parent];
-				}
-				$config = Config::inst()->get('Injector', $parent);
-				if ($config) {
-					$this->configs[$name] = $config;
-					return $config;
-				} else {
-					$this->configs[$parent] = false;
-				}
-			}
-			
-			// there is no parent config, so we'll record that as false so we don't do the expensive
-			// lookup through parents again
-			$this->configs[$name] = false;
+		} else {
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
This issue came up in a case where a parent class had a particular set of dependencies specified, and while direct subclasses of this would work fine with Injector, attempts to instantiate sub-subclasses of this would result in missing dependencies.

E.g. A extends B extends C, where only C has dependencies specified, and attempts to create an instance of A would break future calls to `B::create()`.

The `SilverStripeServiceConfigurationLocator` would walk from A to C finding dependencies, and during this process "B" would be marked with a config of `false`, meaning future calls to `B::create()` (or sometimes `A::create()`) would incorrectly ignore all dependencies.

This fix no longer marks a class as having a `false` config unless its parent has a `false` config, or if there are no other parents above this.

`SilverStripeServiceConfigurationLocator` was also refactored to be a bit more test-case friendly and better documentation given.

This was a fun afternoon trying to debug...
