### PR TITLE
Minor fix for note about lack of news-file icon

### DIFF
--- a/docs/en/tutorials/2-extending-a-basic-site.md
+++ b/docs/en/tutorials/2-extending-a-basic-site.md
@@ -351,7 +351,7 @@ This will change the icons for the pages in the CMS.
 ![](_images/tutorial2_icons2.jpg)
 
 <div class="hint" markdown="1">
-Note: The `news-file` icon may not exist in a default SilverStripe install. Try adding your own image, or choosing a different one from the `tree-icons` collection.
+Note: The `news-file` icon may not exist in a default SilverStripe installation. Try adding your own image or choosing a different one from the `treeicons` collection.
 </div>
 
 ## Showing the latest news on the homepage


### PR DESCRIPTION
Minor fix for note about the lack of a news-file icon to improve clarity. Wasn't 100% happy with the wording of the note before, and treeicons had incorrectly been given a hyphen.
