### PR TITLE
API: Support for multiple HTMLEditorConfig per page

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -337,8 +337,6 @@ class LeftAndMain extends Controller implements PermissionProvider {
 
 		if (Director::isDev()) Requirements::javascript(FRAMEWORK_ADMIN_DIR . '/javascript/leaktools.js');
 
-		HTMLEditorField::include_js();
-
 		$leftAndMainIncludes = array_unique(array_merge(
 			array(
 				FRAMEWORK_ADMIN_DIR . '/javascript/LeftAndMain.Layout.js',

--- a/docs/en/topics/rich-text-editing.md
+++ b/docs/en/topics/rich-text-editing.md
@@ -23,6 +23,34 @@ functionality. It is usually added through the `[api:DataObject->getCMSFields()]
 		}
 	}
 
+### Specify which configuration to use
+
+By default, a config named 'cms' is used in any new `[api:HTMLEditorField]`.
+
+If you have created your own `[api:HtmlEditorConfig]` and would like to use it,
+you can call `HtmlEditorConfig::set_active('myConfig')` and all subsequently created `[api:HTMLEditorField]`
+will use the configuration with the name 'myConfig'.
+
+You can also specify which `[api:HtmlEditorConfig]` to use on a per field basis via the construct argument.
+This is particularly useful if you need different configurations for multiple `[api:HTMLEditorField]` on the same page or form.
+
+	:::php
+	class MyObject extends DataObject {
+		private static $db = array(
+			'Content' => 'HTMLText',
+			'OtherContent' => 'HTMLText'
+		);
+		
+		public function getCMSFields() {
+			return new FieldList(array(
+				new HTMLEditorField('Content'),
+				new HTMLEditorField('OtherContent', 'Other content', $this->OtherContent, 'myConfig')
+			));
+		}
+	}
+
+In the above example, the 'Content' field will use the default 'cms' config while 'OtherContent' will be using 'myConfig'.
+
 ## Configuration
 
 To keep the JavaScript editor configuration manageable and extensible,
@@ -30,8 +58,6 @@ we've wrapped it in a PHP class called `[api:HtmlEditorConfig]`.
 The class comes with its own defaults, which are extended through [configuration files](/topics/configuration)
 in the framework (and the `cms` module in case you've got that installed).
 There can be multiple configs, which should always be created / accessed using `[api:HtmlEditorConfig::get]`.
-You can then set  the currently active config using `set_active()`.
-By default, a config named 'cms' is used in any field created throughout the CMS interface.
 
 <div class="notice" markdown='1'>
 Caveat: currently the order in which the `_config.php` files are executed depends on the module directory

--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -315,8 +315,8 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 			},
 
 			redraw: function() {
-				// Using a global config (generated through HTMLEditorConfig PHP logic)
-				var config = ssTinyMceConfig, self = this, ed = this.getEditor();
+				// Using textarea config ID from global config object (generated through HTMLEditorConfig PHP logic)
+				var config = ssTinyMceConfig[this.data('config')], self = this, ed = this.getEditor();
 
 				ed.init(config);
 

--- a/tests/forms/HtmlEditorConfigTest.php
+++ b/tests/forms/HtmlEditorConfigTest.php
@@ -66,13 +66,27 @@ class HtmlEditorConfigTest extends SapphireTest {
 		$this->assertNotContains('plugin1', array_keys($plugins));
 		$this->assertNotContains('plugin2', array_keys($plugins));
 	}
-	
-	public function testGenerateJSWritesPlugins() {
-		$c = new HtmlEditorConfig();
-		$c->enablePlugins(array('plugin1'));
+
+	public function testRequireJSIncludesAllExternalPlugins() {
+		$c = HtmlEditorConfig::get('config');
+		$c->enablePlugins(array('plugin1' => '/mypath/plugin1'));
 		$c->enablePlugins(array('plugin2' => '/mypath/plugin2'));
 
-		$this->assertContains('plugin1', $c->generateJS());
-		$this->assertContains('tinymce.PluginManager.load("plugin2", "/mypath/plugin2");', $c->generateJS());
+		HtmlEditorConfig::require_js();
+		$js = Requirements::get_custom_scripts();
+
+		$this->assertContains('tinymce.PluginManager.load("plugin1", "/mypath/plugin1");', $js);
+		$this->assertContains('tinymce.PluginManager.load("plugin2", "/mypath/plugin2");', $js);
+	}
+
+	public function testRequireJSIncludesAllConfigs() {
+		$c = HtmlEditorConfig::get('configA');
+		$c = HtmlEditorConfig::get('configB');
+
+		HtmlEditorConfig::require_js();
+		$js = Requirements::get_custom_scripts();
+
+		$this->assertContains('"configA":{', $js);
+		$this->assertContains('"configB":{', $js);
 	}
 }


### PR DESCRIPTION
This allows to specify a `HTMLEditorConfig` on a per field basis.

`HtmlEditorField` now takes an optional 4th argument with the identifier of the EditorConfig. This falls back to the active EditorConfig identifier, so this should be backward compatible.

`HTMLEditorConfig` now output `ssTinyMceConfig` as an object with key:value pairs of Identifier and Config. Also takes care of loading all external plugins (maybe this could be done on a per field init basis rather than load them all at the bottom?).

This is similar to https://github.com/silverstripe/silverstripe-framework/issues/2940 but with a different approach. Using *identifiers* rather than *inline* as a parameter might be more intuitive?
This PR requires https://github.com/silverstripe/silverstripe-framework/pull/2297 to solve multi TinyMCE inits.

Pulled against master for now, but may be better against 3.1? This is maybe more a NEW features rather than API change?
This is up for review and comments.