### PR TITLE
Admin removal warning

### DIFF
--- a/admin/code/SecurityAdmin.php
+++ b/admin/code/SecurityAdmin.php
@@ -32,6 +32,7 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider {
 	public function init() {
 		parent::init();
 		Requirements::javascript(FRAMEWORK_ADMIN_DIR . '/javascript/SecurityAdmin.js');
+		Requirements::javascript(FRAMEWORK_DIR . '/javascript/i18n.js');
 	}
 
 	/**

--- a/admin/javascript/SecurityAdmin.js
+++ b/admin/javascript/SecurityAdmin.js
@@ -74,6 +74,28 @@
 				}
 			}
 		});
+		$("[name='DirectGroups[]']").entwine({
+			onchange: function(event) {
+				// warn any admin users if they are trying to remove their own admin permissions
+				if ($("[name='removeAdminWarning']").length == 0) {
+					return;
+				}
+				var adminGroupIDs = $("[name='removeAdminWarning']").val().split(',');
+				var adminCount = 0;
+				$("[id$='DirectGroups'] option:selected'").each(function() {
+					if (jQuery.inArray($(this).val(), adminGroupIDs) != -1) {
+						// increment if a selected group is a admin group
+						adminCount++;
+					}
+				});
+				// show warning if adminCount does not equal the number of admin groups member started with
+				if (adminCount != adminGroupIDs.length) {
+					// only want to show the popup once so remove the hidden field
+					$("[name='removeAdminWarning']").remove();
+					alert(ss.i18n._t('SecurityAdmin.REMOVING_OWN_ADMIN','Warning you are removing ADMIN permissions from your own member profile'));
+				}
+			}
+		});
 	});
 	
 }(jQuery));

--- a/javascript/lang/en.js
+++ b/javascript/lang/en.js
@@ -42,7 +42,8 @@ if(typeof(ss) == 'undefined' || typeof(ss.i18n) == 'undefined') {
 	"TreeDropdownField.ENTERTOSEARCH": "Press enter to search",
 	"TreeDropdownField.OpenLink": "Open",
 	"TreeDropdownField.FieldTitle": "Choose",
-	"TreeDropdownField.SearchFieldTitle": "Choose or Search"
+	"TreeDropdownField.SearchFieldTitle": "Choose or Search",
+    	"SecurityAdmin.REMOVING_OWN_ADMIN": "Warning you are removing ADMIN permissions from your own member profile"
 }
 );
 }

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -498,6 +498,7 @@ en:
     MemberListCaution: 'Caution: Removing members from this list will remove them from all groups and the database'
     NEWGROUP: 'New Group'
     PERMISSIONS: Permissions
+    REMOVING_OWN_ADMIN: 'Warning you are removing ADMIN permissions from your own member profile'
     ROLES: Roles
     ROLESDESCRIPTION: 'Roles are predefined sets of permissions, and can be assigned to groups.<br />They are inherited from parent groups if required.'
     TABROLES: Roles

--- a/security/Member.php
+++ b/security/Member.php
@@ -1253,6 +1253,25 @@ class Member extends DataObject implements TemplateGlobalProvider {
 				}
 			}
 
+			// warn a admin user to if they are removing their own admin permission
+			if ($self->ID == Member::CurrentUserID()) {
+				$adminGroups = Permission::get_groups_by_permission('ADMIN');
+				
+				foreach ($adminGroups as $group) {
+					if ($self->inGroup($group->ID, true)) {
+						$adminPermissions = (isset($adminPermissions)) ? 
+							$adminPermission = ',' . $group->ID : $group->ID;
+					}
+				}
+				if (isset($adminPermissions)) {
+					$fields->push(
+						new HiddenField(
+							'removeAdminWarning', 'removeAdminWarning', $adminPermissions
+						)
+					);
+				}
+			}
+
 			$permissionsTab = $fields->fieldByName("Root")->fieldByName('Permissions');
 			if($permissionsTab) $permissionsTab->addExtraClass('readonly');
 			

--- a/tests/behat/features/manage-users.feature
+++ b/tests/behat/features/manage-users.feature
@@ -54,3 +54,8 @@ Feature: Manage users
     And I press the "Delete" button, confirming the dialog
     Then I should see "admin@test.com"
     And I should not see "staffmember@test.com"
+
+  Scenario: I receive a warning when trying to remove my own admin permissions
+    When I click the "Users" CMS tab
+    And I click "ADMIN@example.org" in the "#Root_Users" element
+    And I click on the element with css selector ".search-choice-close", confirming the dialog


### PR DESCRIPTION
This pull request is to resolve CMS Issue 730

silverstripe/silverstripe-cms#730

It works by adding a warning popup when a admin removes the admin option from the DirectGroups listbox on their own profile.
Member::getCMSField has had a check added where if a admin is modifying there own profile a hidden field called removeAdminWarning is added containing there admin groups.
SecurityAdmin.js has been modified so if if any changes are made to DirectGroups it checks the field removeAdminWarning to see if the admin permissions are being removed and if they are a warning is produced.

A unit test has been included for this however this relies on a pull request for the SilverStripe Behat extension which adds 2 new steps.

silverstripe-labs/silverstripe-behat-extension#21

It may be worth considering dropping the unit test or refactoring it to use existing behat functions however I did look into this and could not find a way to achieve this with existing functionality however the following pull request does seem to suggest it could be done differently

https://github.com/silverstripe-labs/silverstripe-behat-extension/pull/27
