### PR TITLE
doRollback was setting new version number on draft

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -1199,7 +1199,7 @@ class Versioned extends DataExtension {
 	 */
 	public function doRollbackTo($version) {
 		$this->owner->extend('onBeforeRollback', $version);
-		$this->publish($version, "Stage", true);
+		$this->publish($version, "Stage", false);
 
 		$this->owner->writeWithoutVersion();
 


### PR DESCRIPTION
This is problematic for DataObjects with Versioning enabled. When you roll back, your draft gets a NEW version number, so while the data remains in sync with Live, your version number is ahead of the most recently published version that is Live.
