### PR TITLE
BUG ChangePasswordForm validation message should render HTML correctly.

### DIFF
--- a/security/ChangePasswordForm.php
+++ b/security/ChangePasswordForm.php
@@ -133,7 +133,8 @@ class ChangePasswordForm extends Form {
 						"We couldn't accept that password: {password}",
 						array('password' => nl2br("\n".$isValid->starredList()))
 					), 
-					"bad"
+					"bad",
+					false
 				);
 
 				// redirect back to the form, instead of using redirectBack() which could send the user elsewhere.


### PR DESCRIPTION
HTML shows up in the form message escaped, but it shouldn't be, otherwise the list of password strength problems will look a bit broken. :)
