### PR TITLE
FIX Escape the redirect URL before outputting (alternate implementation)

### DIFF
--- a/control/HTTPResponse.php
+++ b/control/HTTPResponse.php
@@ -213,12 +213,14 @@ class SS_HTTPResponse {
 		}
 
 		if(in_array($this->statusCode, self::$redirect_codes) && headers_sent($file, $line)) {
-			$url = Convert::raw2htmlatt($this->headers['Location']);
+			$url = (string)$this->headers['Location'];
+			$urlATT = Convert::raw2htmlatt($url);
+			$urlJS = Convert::raw2js($url);
 			echo
-			"<p>Redirecting to <a href=\"$url\" title=\"Click this link if your browser does not redirect you\">"
-				. "$url... (output started on $file, line $line)</a></p>
-			<meta http-equiv=\"refresh\" content=\"1; url=$url\" />
-			<script type=\"text/javascript\">setTimeout('window.location.href = \"$url\"', 50);</script>";
+			"<p>Redirecting to <a href=\"$urlATT\" title=\"Click this link if your browser does not redirect you\">"
+				. "$urlATT... (output started on $file, line $line)</a></p>
+			<meta http-equiv=\"refresh\" content=\"1; url=$urlATT\" />
+			<script type=\"text/javascript\">setTimeout(function(){ window.location.href = \"$urlJS\"; }, 50);</script>";
 		} else {
 			$line = $file = null;
 			if(!headers_sent($file, $line)) {


### PR DESCRIPTION
Slightly more rigorous implementation of #2981.

This PR would do well with a behat test, if someone has capacity to build one.

A manual test resulted in the following output.

``` html
<p>Redirecting to <a href="http://www.google.com/#hello"
title="Click this link if your browser does not redirect you">
http://www.google.com/#hello... (output started on /sitedir/mysite/code/Page.php, line 47)</a></p>
<meta http-equiv="refresh" content="1; url=http://www.google.com/#hello" />
<script type="text/javascript">setTimeout(function(){ window.location.href = "http:\/\/www.google.com\/#hello"; }, 50);</script>
```
