### PR TITLE
Fix example code for DataObject advanced indexes

### DIFF
--- a/docs/en/reference/dataobject.md
+++ b/docs/en/reference/dataobject.md
@@ -265,7 +265,7 @@ arrays that represent each index. There's several supported notations:
 
 	# Advanced
 	private static $indexes = array(
-		'<index-name>' => array('type' => '<type>', 'value' => '"<column-name>"')
+		'<index-name>' => array('type' => '<type>', 'value' => '<column-name>')
 	);
 
 	# SQL


### PR DESCRIPTION
Removed quotes around the field name as this causes the builder to fail. Removing them makes it work again.
