### PR TITLE
Fix: WYSIWYG now returns valid HTML in tables

### DIFF
--- a/admin/_config.php
+++ b/admin/_config.php
@@ -14,7 +14,7 @@ HtmlEditorConfig::get('cms')->setOptions(array(
 		. "|class],-strong/-b[class],-em/-i[class],-strike[class],-u[class],#p[id|dir|class|align|style],-ol[class],"
 		. "-ul[class],-li[class],br,img[id|dir|longdesc|usemap|class|src|border|alt=|title|width|height|align|data*],"
 		. "-sub[class],-sup[class],-blockquote[dir|class],-cite[dir|class|id|title],"
-		. "-table[border=0|cellspacing|cellpadding|width|height|class|align|summary|dir|id|style],"
+		. "-table[cellspacing|cellpadding|width|height|class|align|summary|dir|id|style],"
 		. "-tr[id|dir|class|rowspan|width|height|align|valign|bgcolor|background|bordercolor|style],"
 		. "tbody[id|class|style],thead[id|class|style],tfoot[id|class|style],"
 		. "#td[id|dir|class|colspan|rowspan|width|height|align|valign|scope|style],"


### PR DESCRIPTION
The WYSIWYG by default creates invalid HTML5. Creating a table and running it through W3C validator returns the following error: The border attribute on the table element is obsolete. Use CSS instead.
