### PR TITLE
Delete formatted images after image upload

### DIFF
--- a/filesystem/Upload.php
+++ b/filesystem/Upload.php
@@ -186,6 +186,7 @@ class Upload extends Controller {
 			// This is to prevent it from trying to rename the file
 			$this->file->Name = basename($relativeFilePath);
 			$this->file->write();
+			$this->file->onAfterUpload();
 			$this->extend('onAfterLoad', $this->file);   //to allow extensions to e.g. create a version after an upload
 			return true;
 		} else {

--- a/model/Image.php
+++ b/model/Image.php
@@ -640,6 +640,11 @@ class Image extends File {
 			return self::ORIENTATION_SQUARE;
 		}
 	}
+
+	public function onAfterUpload() {
+		$this->deleteFormattedImages();
+		parent::onAfterUpload();
+	}
 	
 	protected function onBeforeDelete() {
 		parent::onBeforeDelete(); 


### PR DESCRIPTION
This change fixes an issue where old/existing formatted images are used
when a filename is reused (by overwrite or by coincidence), regardless
of if the file contents have changed. To users this mainly manifests
as a file overwrite appearing not to work; the thumbnails in the CMS
show the original image until regeneration is forced.

Calling `Image::deleteFormattedImages()` after image upload ensures that
no stagnant formatted images will be used.
