### PR TITLE
Prevent IE errors on hidden login forms

### DIFF
--- a/security/MemberLoginForm.php
+++ b/security/MemberLoginForm.php
@@ -114,13 +114,13 @@ class MemberLoginForm extends LoginForm {
 		$this->setValidator(new RequiredFields('Email', 'Password'));
 
 		// Focus on the email input when the page is loaded
-		Requirements::customScript(<<<JS
+		$js = <<<JS
 			(function() {
 				var el = document.getElementById("MemberLoginForm_LoginForm_Email");
-				if(el && el.focus) el.focus();
+				if(el && el.focus && (!jQuery || jQuery(el).is(':visible'))) el.focus();
 			})();
-JS
-		);
+JS;
+		Requirements::customScript($js, 'MemberLoginFormFieldFocus');
 	}
 
 	/**


### PR DESCRIPTION
In order to focus a field, it needs to be visible,
which can't be guaranteed on a core level by the login form JavaScript.
Optionally check for visibility via jQuery if it exists,
and allow explicit disabling of this behaviour via a unique identifier.
