### PR TITLE
BUG Fix data query not always joining necessary tables

### DIFF
--- a/tests/model/DataObjectLazyLoadingTest.php
+++ b/tests/model/DataObjectLazyLoadingTest.php
@@ -35,6 +35,7 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 			'"DataObjectTest_Team"."ClassName" IS NOT NULL THEN "DataObjectTest_Team"."ClassName" ELSE ' .
 			$db->prepStringForDB('DataObjectTest_Team').' END AS "RecordClassName", "DataObjectTest_Team"."Title" '.
 			'FROM "DataObjectTest_Team" ' .
+			'LEFT JOIN "DataObjectTest_SubTeam" ON "DataObjectTest_SubTeam"."ID" = "DataObjectTest_Team"."ID" ' .
 			'WHERE ("DataObjectTest_Team"."ClassName" IN ('.$db->prepStringForDB('DataObjectTest_SubTeam').'))' .
 			' ORDER BY "DataObjectTest_Team"."Title" ASC';
 		$this->assertEquals($expected, $playerList->sql());
@@ -62,7 +63,8 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 		$expected = 'SELECT DISTINCT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."Created", ' .
 			'"DataObjectTest_Team"."LastEdited", "DataObjectTest_Team"."Title", "DataObjectTest_Team"."ID", ' .
 			'CASE WHEN "DataObjectTest_Team"."ClassName" IS NOT NULL THEN "DataObjectTest_Team"."ClassName" ELSE ' .
-			$db->prepStringForDB('DataObjectTest_Team').' END AS "RecordClassName" FROM "DataObjectTest_Team" WHERE ' .
+			$db->prepStringForDB('DataObjectTest_Team').' END AS "RecordClassName" FROM "DataObjectTest_Team" ' . 
+			'LEFT JOIN "DataObjectTest_SubTeam" ON "DataObjectTest_SubTeam"."ID" = "DataObjectTest_Team"."ID" WHERE ' .
 			'("DataObjectTest_Team"."ClassName" IN ('.$db->prepStringForDB('DataObjectTest_SubTeam').')) ' .
 			'ORDER BY "DataObjectTest_Team"."Title" ASC';
 		$this->assertEquals($expected, $playerList->sql());

--- a/tests/model/DataQueryTest.php
+++ b/tests/model/DataQueryTest.php
@@ -1,11 +1,15 @@
 <?php
 
 class DataQueryTest extends SapphireTest {
+	
+	protected static $fixture_file = 'DataQueryTest.yml';
 
 	protected $extraDataObjects = array(
 		'DataQueryTest_A',
 		'DataQueryTest_B',
+		'DataQueryTest_C',
 		'DataQueryTest_D',
+		'DataQueryTest_E',
 	);
 
 	/**
@@ -124,6 +128,12 @@ class DataQueryTest extends SapphireTest {
 			$dq->sql()
 		);
 	}
+	
+	public function testDefaultSort() {
+		$query = new DataQuery('DataQueryTest_E');
+		$result = $query->column('Title');
+		$this->assertEquals(array('First', 'Second', 'Last'), $result);
+	}
 }
 
 
@@ -148,6 +158,10 @@ class DataQueryTest_B extends DataQueryTest_A {
 }
 
 class DataQueryTest_C extends DataObject implements TestOnly {
+	
+	private static $db = array(
+		'Title' => 'Varchar'
+	);
 
 	private static $has_one = array(
 		'TestA' => 'DataQueryTest_A',
@@ -170,4 +184,13 @@ class DataQueryTest_D extends DataObject implements TestOnly {
 	private static $has_one = array(
 		'Relation' => 'DataQueryTest_B',
 	);
+}
+
+class DataQueryTest_E extends DataQueryTest_C implements TestOnly {
+	
+	private static $db = array(
+		'SortOrder' => 'Int'
+	);
+	
+	private static $default_sort = '"DataQueryTest_E"."SortOrder" ASC';
 }

--- a/tests/model/DataQueryTest.yml
+++ b/tests/model/DataQueryTest.yml
@@ -1,0 +1,10 @@
+DataQueryTest_E:
+  query1:
+    Title: 'Last'
+    SortOrder: 3
+  query2:
+    Title: 'First'
+    SortOrder: 1
+  query3:
+    Title: 'Second'
+    SortOrder: 2


### PR DESCRIPTION
Fixes #2846

Previously, `DataQuery::getFinalisedQuery` would try to optimistically reduce the number of joined tables for certain queries. Sometimes it would be a bit over-ethusiastic, and omit tables that the query relied on later for sorting.

Since there's currently no robust way to accurately anticipate which tables can and can't be joined, it joins all tables vertically in the requested hierarchy (from `$baseClass` up until the queried class). If a table hierarchy is shallow (as it should be in practice) this will only be a slight performance hit, and only in cases where lots of limited-column queries would be done.
