### PR TITLE
API DateTime.Ago better infers significance of date units.

### DIFF
--- a/tests/model/DateTest.php
+++ b/tests/model/DateTest.php
@@ -164,7 +164,31 @@ class DateTest extends SapphireTest {
 		SS_Datetime::set_mock_now('2000-12-31 12:00:00');
 
 		$this->assertEquals(
-			'10 years ago',
+			'1 month ago', 
+			DBField::create_field('Date', '2000-11-26')->Ago(true, 1),
+			'Past match on days, less than two months, lowest significance'
+		);
+
+		$this->assertEquals(
+			'50 days ago', // Rounded from 49.5 days up
+			DBField::create_field('Date', '2000-11-12')->Ago(),
+			'Past match on days, less than two months'
+		);
+
+		$this->assertEquals(
+			'2 months ago', 
+			DBField::create_field('Date', '2000-10-27')->Ago(),
+			'Past match on days, over two months'
+		);
+
+		$this->assertEquals(
+			'66 days ago', // rounded from 65.5 days up
+			DBField::create_field('Date', '2000-10-27')->Ago(true, 3),
+			'Past match on days, over two months, significance of 3'
+		);
+
+		$this->assertEquals(
+			'10 years ago', 
 			DBField::create_field('Date', '1990-12-31')->Ago(),
 			'Exact past match on years'
 		);
@@ -176,7 +200,13 @@ class DateTest extends SapphireTest {
 		);
 
 		$this->assertEquals(
-			'1 year ago',
+			'1 year ago', 
+			DBField::create_field('Date', '1999-12-30')->Ago(true, 1),
+			'Approximate past match in singular, lowest significance'
+		);
+
+		$this->assertEquals(
+			'12 months ago', 
 			DBField::create_field('Date', '1999-12-30')->Ago(),
 			'Approximate past match in singular'
 		);
@@ -194,7 +224,13 @@ class DateTest extends SapphireTest {
 		);
 
 		$this->assertEquals(
-			'in 1 day',
+			'in 1 day', 
+			DBField::create_field('Date', '2001-01-01')->Ago(true, 1),
+			'Approximate past match on minutes'
+		);
+
+		$this->assertEquals(
+			'in 24 hours', 
 			DBField::create_field('Date', '2001-01-01')->Ago(),
 			'Approximate past match on minutes'
 		);

--- a/tests/model/DatetimeTest.php
+++ b/tests/model/DatetimeTest.php
@@ -105,7 +105,13 @@ class SS_DatetimeTest extends SapphireTest {
 		);
 
 		$this->assertEquals(
-			'1 year ago',
+			'1 year ago', 
+			DBField::create_field('SS_Datetime', '1999-12-30 12:00:12')->Ago(true, 1),
+			'Approximate past match in singular, significance=1'
+		);
+
+		$this->assertEquals(
+			'12 months ago', 
 			DBField::create_field('SS_Datetime', '1999-12-30 12:00:12')->Ago(),
 			'Approximate past match in singular'
 		);
@@ -127,6 +133,36 @@ class SS_DatetimeTest extends SapphireTest {
 			DBField::create_field('SS_Datetime', '2000-12-31 11:59:01')->Ago(false),
 			'Approximate past match on seconds with $includeSeconds=false'
 		);
+		
+		$this->assertEquals(
+			'1 min ago',
+			DBField::create_field('SS_Datetime', '2000-12-31 11:58:50')->Ago(false),
+			'Test between 1 and 2 minutes with includeSeconds=false'
+		);
+		
+		$this->assertEquals(
+			'70 secs ago',
+			DBField::create_field('SS_Datetime', '2000-12-31 11:58:50')->Ago(true),
+			'Test between 1 and 2 minutes with includeSeconds=true'
+		);
+
+		$this->assertEquals(
+			'4 mins ago', 
+			DBField::create_field('SS_Datetime', '2000-12-31 11:55:50')->Ago(),
+			'Past match on minutes'
+		);
+
+		$this->assertEquals(
+			'1 hour ago', 
+			DBField::create_field('SS_Datetime', '2000-12-31 10:50:58')->Ago(true, 1),
+			'Past match on hours, significance=1'
+		);
+
+		$this->assertEquals(
+			'3 hours ago', 
+			DBField::create_field('SS_Datetime', '2000-12-31 08:50:58')->Ago(),
+			'Past match on hours'
+		);
 
 		SS_Datetime::clear_mock_now();
 	}
@@ -141,7 +177,13 @@ class SS_DatetimeTest extends SapphireTest {
 		);
 
 		$this->assertEquals(
-			'in 1 hour',
+			'in 1 hour', 
+			DBField::create_field('SS_Datetime', '2000-12-31 1:01:05')->Ago(true, 1),
+			'Approximate past match on minutes, significance=1'
+		);
+
+		$this->assertEquals(
+			'in 61 mins', 
 			DBField::create_field('SS_Datetime', '2000-12-31 1:01:05')->Ago(),
 			'Approximate past match on minutes'
 		);


### PR DESCRIPTION
BUG Fixes missing i18n translation in Date::TimeDiffIn
BUG Fixes Date::TimeDiffIn not respecting mocked SS_Datetime::now

This fix provides more meaningful representations of time periods. E.g. "36 days" has a lot more relevant that "1 month". By default the minimum significant number of units is 2, but can be tweaked by customising the second parameter.

`Date::TimeDiffIn` has been cleaned up, with support for i18n strings included (which have been missing for ages), as well as cleanup of duplicate code.

Although this was raised as a usability issue in 3.1, this is an api change and can probably wait until 3.2. I can port back part of this as a bugfix to 3.1 if someone feels these issues deserve fixing there too.

There was a note in the prior code regarding translation strings having spaces in them, but I didn't notice any after a check of all current strings, so I think that issue has been safely resolved since then. :) I've thus removed the fix hack for this.

(ref: CWPBUG-141)
