### PR TITLE
API Make default gridfield paging configurable

### DIFF
--- a/docs/en/reference/grid-field.md
+++ b/docs/en/reference/grid-field.md
@@ -98,6 +98,24 @@ A config object can be either injected as the fourth argument of the GridField c
 	$gridField = new GridField('pages', 'All pages', SiteTree::get());
 	$gridField->setConfig(GridFieldConfig_Base::create());
 
+By default the `[api:GridFieldConfig_Base]` constructor takes a single parameter to specify the number
+of items displayed on each page.
+
+	:::php
+	// I have lots of items, so increase the page size
+	$myConfig = GridFieldConfig_Base::create(40);
+
+The default page size can also be tweaked via the config. (put in your mysite/_config/config.yml)
+
+	:::yaml
+	// For updating all gridfield defaults system wide
+	GridFieldPaginator:
+		default_items_per_page: 40
+
+Note that for [/reference/modeladmin](ModelAdmin) sections the default 30 number of pages can be
+controlled either by setting the base `ModelAdmin.page_length` config to the desired number, or
+by overriding this value in a custom subclass.
+
 The framework comes shipped with some base GridFieldConfigs:
 
 ### Table listing with GridFieldConfig_Base
@@ -246,6 +264,8 @@ Here is a list of components for generic use:
  - `[api:GridFieldDeleteAction]`
  - `[api:GridFieldViewButton]`
  - `[api:GridFieldEditButton]`
+ - `[api:GridFieldExportButton]`
+ - `[api:GridFieldPrintButton]`
  - `[api:GridFieldPaginator]`
  - `[api:GridFieldDetailForm]`
 

--- a/forms/gridfield/GridFieldPaginator.php
+++ b/forms/gridfield/GridFieldPaginator.php
@@ -9,9 +9,17 @@
 class GridFieldPaginator implements GridField_HTMLProvider, GridField_DataManipulator, GridField_ActionProvider {
 	
 	/**
+	 * Specifies default items per page
+	 * 
+	 * @config
 	 * @var int
 	 */
-	protected $itemsPerPage = 15;
+	private static $default_items_per_page = 15;
+	
+	/**
+	 * @var int
+	 */
+	protected $itemsPerPage;
 
 	/**
 	 * Which template to use for rendering
@@ -30,7 +38,8 @@ class GridFieldPaginator implements GridField_HTMLProvider, GridField_DataManipu
 	 * @param int $itemsPerPage - How many items should be displayed per page
 	 */
 	public function __construct($itemsPerPage=null) {
-		if($itemsPerPage) $this->itemsPerPage = $itemsPerPage;
+		$this->itemsPerPage = $itemsPerPage
+			?: Config::inst()->get('GridFieldPaginator', 'default_items_per_page');
 	}
 	
 	/**


### PR DESCRIPTION
This un-hard codes the '15' in the default gridfield pagination. While this can be specified on a per-instance basis, it's not always practical to manually change this for each instance.

This seems to be quite a common question for those using gridfield for the first time, so docs have been updated to demonstrate how to configure this.

ref: CWPBUG-143
