### PR TITLE
MINOR Remove extraneous call to preg_match

### DIFF
--- a/model/Database.php
+++ b/model/Database.php
@@ -763,8 +763,11 @@ abstract class SS_Database {
 
 		foreach($select as $alias => $field) {
 			// Don't include redundant aliases.
-			if($alias === $field || preg_match('/"' . preg_quote($alias) . '"$/', $field)) $clauses[] = $field;
-			else $clauses[] = "$field AS \"$alias\"";
+			if ($alias == $field) {
+				$clauses[] = $field;
+			} else {
+				$clauses[] = "$field AS \"$alias\"";
+			}
 		}
 
 		$text = 'SELECT ';


### PR DESCRIPTION
preg_match/preg_quote isn't useful here as far as I can see, and is expensive enough to be worth removing it.

I wasn't sure about the change from === to ==, but I believe it should be fine since it's an array key, meaning integer or string anyway.
As far I can tell, the preg_match did the same thing as the === anyway.
