### PR TITLE
minor debug text

### DIFF
--- a/model/MySQLDatabase.php
+++ b/model/MySQLDatabase.php
@@ -143,7 +143,7 @@ class MySQLDatabase extends SS_Database {
 
 		if(isset($_REQUEST['showqueries']) && Director::isDev(true)) {
 			$endtime = round(microtime(true) - $starttime,4);
-			Debug::message("\n$sql\n{$endtime}ms\n", false);
+			Debug::message("\n$sql\n{$endtime}s\n", false);
 		}
 
 		if(!$handle && $errorLevel) {


### PR DESCRIPTION
Seconds, not milliseconds. 

microtime(true) returns "a float, which represents the current time in seconds since the Unix epoch accurate to the nearest microsecond" as per php docs.
