### PR TITLE
API HTTP 429 Allowed for use with rate limiting methods

### DIFF
--- a/control/HTTPResponse.php
+++ b/control/HTTPResponse.php
@@ -44,6 +44,7 @@ class SS_HTTPResponse {
 		416 => 'Request Range Not Satisfiable',
 		417 => 'Expectation Failed',
 		422 => 'Unprocessable Entity',
+		429 => 'Too Many Requests',
 		500 => 'Internal Server Error',
 		501 => 'Not Implemented',
 		502 => 'Bad Gateway',


### PR DESCRIPTION
See http://en.wikipedia.org/wiki/List_of_HTTP_status_codes#429 for context

This will be used for rate limiting of certain content.

ref: CWPBUG-29
