### PR TITLE
API UploadField: move replaceFile to the front end config

### DIFF
--- a/docs/en/changelogs/3.2.0.md
+++ b/docs/en/changelogs/3.2.0.md
@@ -5,6 +5,7 @@
  * Minimum PHP version raised to 5.3.3
  * DataObject::validate() method visibility changed to public
  * UploadField "Select from files" shows files in all folders by default
+ * UploadField won't display an overwrite warning unless Upload:replaceFile is true
  * HtmlEditorField no longer substitutes `<blockquote />` for indented text
 
 ## Changelog
@@ -31,6 +32,29 @@ In order to list files in a single folder by default (previous default behaviour
 use `setDisplayFolderName()` with a folder path relative to `assets/`:
 
 	UploadField::create('MyField')->setDisplayFolderName('Uploads');
+
+### UploadField won't display an overwrite warning unless Upload:replaceFile is true
+
+The configuration setting `UploadField:overwriteWarning` is dependent on `Upload:replaceFile` 
+which is set to false by default.
+
+To display a warning before overwriting a file:
+
+Via config:
+
+	::yaml
+	Upload:
+	  # Replace an existing file rather than renaming the new one.
+	  replaceFile: true
+	UploadField:
+	  # Warning before overwriting existing file (only relevant when Upload: replaceFile is true)
+	  overwriteWarning: true
+
+Or per instance:
+
+	::php
+	$uploadField->getUpload()->setReplaceFile(true);
+	$uploadField->setOverwriteWarning(true);
 
 ### File.allowed_extensions restrictions
 

--- a/docs/en/reference/uploadfield.md
+++ b/docs/en/reference/uploadfield.md
@@ -165,6 +165,26 @@ NOTE: this only sets the configuration for your UploadField, this does NOT chang
 	$size = $sizeMB * 1024 * 1024; // 2 MB in bytes
 	$this->getValidator()->setAllowedMaxFileSize($size);
 
+### Overwrite warning
+
+In order to display a warning before overwriting an existing file, `Upload:replaceFile` must be set to true.
+
+Via config:
+
+	:::yaml
+	Upload:
+	  # Replace an existing file rather than renaming the new one.
+	  replaceFile: true
+	UploadField:
+	  # Warning before overwriting existing file (only relevant when Upload: replaceFile is true)
+	  overwriteWarning: true
+
+Or per instance:
+
+	:::php
+	$uploadField->getUpload()->setReplaceFile(true);
+	$uploadField->setOverwriteWarning(true);
+
 ### Preview dimensions
 
 Set the dimensions of the image preview. By default the max width is set to 80 

--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -154,8 +154,7 @@ class UploadField extends FileField {
 		/**
 		 * Show a warning when overwriting a file.
 		 * This requires Upload->replaceFile config to be set to true, otherwise
-		 * files will be renamed instead of overwritten (although the warning will
-		 * still be displayed)
+		 * files will be renamed instead of overwritten
 		 * 
 		 * @see Upload
 		 * @var boolean
@@ -984,7 +983,8 @@ class UploadField extends FileField {
 			'urlFileExists' => $this->link('fileexists'),
 			'acceptFileTypes' => '.+$',
 			// Fileupload treats maxNumberOfFiles as the max number of _additional_ items allowed
-			'maxNumberOfFiles' => $allowedMaxFileNumber ? ($allowedMaxFileNumber - count($this->getItemIDs())) : null
+			'maxNumberOfFiles' => $allowedMaxFileNumber ? ($allowedMaxFileNumber - count($this->getItemIDs())) : null,
+			'replaceFile' => $this->getUpload()->getReplaceFile(),
 		);
 		
 		// Validation: File extensions
@@ -1022,9 +1022,8 @@ class UploadField extends FileField {
 			}
 		}
 
-		//get all the existing files in the current folder
+		// add overwrite warning error message to the config object sent to Javascript
 		if ($this->getOverwriteWarning()) {
-			//add overwrite warning error message to the config object sent to Javascript
 			$config['errorMessages']['overwriteWarning'] =
 				_t('UploadField.OVERWRITEWARNING', 'File with the same name already exists');
 		}
@@ -1176,11 +1175,6 @@ class UploadField extends FileField {
 		if ($relationClass = $this->getRelationAutosetClass(null)) {
 			// Create new object explicitly. Otherwise rely on Upload::load to choose the class.
 			$fileObject = Object::create($relationClass);
-		}
-
-		// Allow replacing files (rather than renaming a duplicate) when warning about overwrites
-		if($this->getConfig('overwriteWarning')) {
-			$this->upload->setReplaceFile(true);
 		}
 
 		// Get the uploaded file into a new file object.

--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -60,7 +60,7 @@
 			//check the array of existing files to see if we are trying to upload a file that already exists
 			var that = this;
 			var config = this.options;
-			if (config.overwriteWarning) {
+			if (config.overwriteWarning && config.replaceFile) {
 				$.get(
 					config['urlFileExists'],
 					{'filename': data.files[0].name},

--- a/tests/forms/uploadfield/UploadFieldTest.php
+++ b/tests/forms/uploadfield/UploadFieldTest.php
@@ -694,6 +694,45 @@ class UploadFieldTest extends FunctionalTest {
 	}
 
 	/**
+	 * Test that UploadField:overwriteWarning cannot overwrite Upload:replaceFile
+	 */
+	public function testConfigOverwriteWarningCannotRelaceFiles() {
+		$this->loginWithPermission('ADMIN');
+
+		Upload::config()->replaceFile = false;
+		UploadField::config()->defaultConfig = array_merge(
+			UploadField::config()->defaultConfig, array('overwriteWarning' => true)
+		);
+
+		$tmpFileName = 'testUploadBasic.txt';
+		$response = $this->mockFileUpload('NoRelationField', $tmpFileName);
+		$this->assertFalse($response->isError());
+		$responseData = Convert::json2array($response->getBody());
+		$this->assertFileExists(ASSETS_PATH . '/UploadFieldTest/' . $responseData[0]['name']);
+		$uploadedFile = DataObject::get_by_id('File', (int) $responseData[0]['id']);
+		$this->assertTrue(is_object($uploadedFile), 'The file object is created');
+
+		$tmpFileName = 'testUploadBasic.txt';
+		$response = $this->mockFileUpload('NoRelationField', $tmpFileName);
+		$this->assertFalse($response->isError());
+		$responseData = Convert::json2array($response->getBody());
+		$this->assertFileExists(ASSETS_PATH . '/UploadFieldTest/' . $responseData[0]['name']);
+		$uploadedFile2 = DataObject::get_by_id('File', (int) $responseData[0]['id']);
+		$this->assertTrue(is_object($uploadedFile2), 'The file object is created');
+		$this->assertTrue(
+			$uploadedFile->Filename !== $uploadedFile2->Filename,
+			'Filename is not the same'
+		);
+		$this->assertTrue(
+			$uploadedFile->ID !== $uploadedFile2->ID,
+			'File database record is not the same'
+		);
+
+		$uploadedFile->delete();
+		$uploadedFile2->delete();
+	}
+
+	/**
 	 * Tests that UploadField::fileexist works
 	 */
 	public function testFileExists() {


### PR DESCRIPTION
Bug: A warning should not overwrite the config it wants to warn about.

See #2920
