### PR TITLE
Allow PHPUnit installations with composer (and drop PEAR dependency)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
 		"php": ">=5.3.3",
 		"composer/installers": "*"
 	},
+	"require-dev": {
+		"phpunit/PHPUnit": "~3.7"
+	},
 	"extra": {
 		"branch-alias": {
 			"dev-master": "3.2.x-dev"

--- a/dev/phpunit/PhpUnitWrapper.php
+++ b/dev/phpunit/PhpUnitWrapper.php
@@ -138,12 +138,20 @@ class PhpUnitWrapper implements IPhpUnitWrapper {
 	public static function inst() {
 		
 		if (self::$phpunit_wrapper == null) {
-			if (fileExistsInIncludePath("/PHPUnit/Autoload.php")) {
+			// Loaded via autoloader, composer or other generic
+			if (class_exists('PHPUnit_Runner_Version')) {
+				self::$phpunit_wrapper = new PhpUnitWrapper_Generic();
+			}
+			// 3.5 detection
+			else if (fileExistsInIncludePath("/PHPUnit/Autoload.php")) {
 				self::$phpunit_wrapper = new PhpUnitWrapper_3_5();
-			} else 
-			if (fileExistsInIncludePath("/PHPUnit/Framework.php")) {
+			}
+			// 3.4 detection
+			else if (fileExistsInIncludePath("/PHPUnit/Framework.php")) {
 				self::$phpunit_wrapper = new PhpUnitWrapper_3_4();
-			} else {
+			}
+			// No version found - will lead to an error
+			else {
 				self::$phpunit_wrapper = new PhpUnitWrapper();
 			} 
 			self::$phpunit_wrapper->init();

--- a/dev/phpunit/PhpUnitWrapper_3_4.php
+++ b/dev/phpunit/PhpUnitWrapper_3_4.php
@@ -46,10 +46,10 @@ class PhpUnitWrapper_3_4 extends PhpUnitWrapper {
 	}
 
 	/**
-	 * Overwrites aferRunTests. Creates coverage report and clover report 
+	 * Overwrites afterRunTests. Creates coverage report and clover report
 	 * if required.
 	 */
-	protected function aferRunTests() {
+	protected function afterRunTests() {
 
 		if($this->getCoverageStatus()) {
 

--- a/dev/phpunit/PhpUnitWrapper_3_5.php
+++ b/dev/phpunit/PhpUnitWrapper_3_5.php
@@ -13,7 +13,7 @@ class PhpUnitWrapper_3_5 extends PhpUnitWrapper {
 	protected static $test_name = 'SapphireTest';
 
 	public static function get_test_name() {
-		return self::$test_name;
+		return static::$test_name;
 	}
 
 	/** 
@@ -61,10 +61,10 @@ class PhpUnitWrapper_3_5 extends PhpUnitWrapper {
 	}
 
 	/**
-	 * Overwrites aferRunTests. Creates coverage report and clover report 
+	 * Overwrites afterRunTests. Creates coverage report and clover report
 	 * if required.
 	 */
-	protected function aferRunTests() {
+	protected function afterRunTests() {
 
 		if($this->getCoverageStatus()) {
 			$coverage = $this->coverage;

--- a/dev/phpunit/PhpUnitWrapper_Generic.php
+++ b/dev/phpunit/PhpUnitWrapper_Generic.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Generic PhpUnitWrapper.
+ * Originally intended for use with Composer based installations, but will work
+ * with any fully functional autoloader.
+ * Extends PhpUnitWrapper_3_5 to inherit useful (and compatible) functionality
+ * for before/after test hooks.
+ */
+class PhpUnitWrapper_Generic extends PhpUnitWrapper_3_5 {
+
+	protected $version = null;
+
+	/**
+	 * Returns a version string, like 3.7.34 or 4.2-dev.
+	 * @return string
+	 */
+	public function getVersion() {
+		return PHPUnit_Runner_Version::id();
+	}
+
+	/**
+	 * No work is needed as the autoloader takes care of initialising classes.
+	 */
+	public function init() {
+	}
+
+}


### PR DESCRIPTION
This basically lets you install PHPUnit with composer and completely remove pear as a dependency.

@dhensby also mentioned that you could also change the composer.json file to list PHPUnit as a dev dependency, so no more fragmented installs.

I also fixed a few misc typos which would otherwise throw exceptions.
