### PR TITLE
BUG Removed unnecessary escaping of DataObject properties in JSONDataFor...

### DIFF
--- a/api/JSONDataFormatter.php
+++ b/api/JSONDataFormatter.php
@@ -57,7 +57,7 @@ class JSONDataFormatter extends DataFormatter {
 			// Field filtering
 			if($fields && !in_array($fieldName, $fields)) continue;
 
-			$fieldValue = $obj->obj($fieldName)->forTemplate();
+			$fieldValue = $obj->obj($fieldName)->RAW();
 			$serobj->$fieldName = $fieldValue;
 		}
 

--- a/tests/api/JSONDataFormatterTest.php
+++ b/tests/api/JSONDataFormatterTest.php
@@ -1,0 +1,26 @@
+<?php
+class JSONDataFormatterTest extends SapphireTest {
+	
+	public function testConvertDataObjectWithSpecialCharacters() {
+		$formatter = new JSONDataFormatter();
+		$formatter->setCustomAddFields(array('Content'));
+		
+		$obj = new JSONDataFormatterTest_DataObject();
+		// Content: <p>a 'test' "case" </p>
+		$obj->Content = "<p>a 'test' \"case\" </p>";
+
+		$encoded = $formatter->convertDataObject($obj, array('Content'));
+
+		// converted JSON: {"Content":"<p>a 'test' \"case\" <\/p>"}
+		$this->assertEquals('{"Content":"<p>a \'test\' \\"case\\" <\/p>"}', $encoded);
+	}
+
+}
+
+class JSONDataFormatterTest_DataObject extends DataObject implements TestOnly {
+
+	private static $db = array(
+		'Content' => 'Varchar(50)'
+	);
+
+}


### PR DESCRIPTION
Removed call to forTemplate when serializing a DataObject (fixes #3055).
Added simple testcase for JSONDataFormatter#convertDataObjectToJSONObject.
