### PR TITLE
API tinymce editor no longer transforms paragraphs with margin-left into blockquotes

### DIFF
--- a/docs/en/changelogs/3.2.0.md
+++ b/docs/en/changelogs/3.2.0.md
@@ -5,6 +5,7 @@
  * Minimum PHP version raised to 5.3.3
  * DataObject::validate() method visibility changed to public
  * UploadField "Select from files" shows files in all folders by default
+ * HtmlEditorField no longer substitutes `<blockquote />` for indented text
 
 ## Changelog
 

--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -1400,8 +1400,6 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
  */
 function sapphiremce_cleanup(type, value) {
 	if(type == 'get_from_editor') {
-		// replace indented text with a <blockquote>
-		value = value.replace(/<p [^>]*margin-left[^>]*>([^\n|\n\015|\015\n]*)<\/p>/ig,"<blockquote><p>$1</p></blockquote>");
 	
 		// replace VML pixel image references with image tags - experimental
 		value = value.replace(/<[a-z0-9]+:imagedata[^>]+src="?([^> "]+)"?[^>]*>/ig,"<img src=\"$1\">");


### PR DESCRIPTION
This is legacy behaviour which does not often reflect the expected behaviour of the current editor. indent and outdent can (in some situations) prefer to use margin instead of padding. sapphiremce_cleanup faultily assumes that such indented text should be block quoted, and replaces this with a block quote element. This is not necessary, since the blockquote element can be placed explicitly by the user when necessary.

To replicate the incorrect indentation behaviour, configure tinymce to use the 'lists' plugin (via admin/_config.php) and attempt to indent some text. Indented text will be unexpectedly replaced with blockquotes.

[ref: CWPBUG-102]
