### PR TITLE
Oembed warning if GD function is missing

### DIFF
--- a/oembed/Oembed.php
+++ b/oembed/Oembed.php
@@ -267,7 +267,10 @@ class Oembed_Result extends ViewableData {
 		if(!$data) {
 			// if the response is no valid JSON we might have received a binary stream to an image
 			$data = array();
-			$image = @imagecreatefromstring($body);
+			if (!function_exists('imagecreatefromstring')) {
+				throw new LogicException('imagecreatefromstring function does not exist - Please make sure GD is installed');
+			}
+			$image = imagecreatefromstring($body);
 			if($image !== FALSE) {
 				preg_match("/^(http:\/\/)?([^\/]+)/i", $this->url, $matches);
 				$protocoll = $matches[1];


### PR DESCRIPTION
I lost about 2 hours of my life debugging why a page was throwing a completely silent 500 error. Nothing in the logs and nothing on screen. It was because GD wasn't installed (yay me).

I've made changes so that there is a helpful error message if the GD function isn't available and removed the silencing of the errors from the function call (from the [PHP docs](http://www.php.net/manual/en/function.imagecreatefromstring.php)) I don't see any notice of errors/warnings/notices being thrown, so there is no point in silencing it - it simply makes debugging impossible.
