### PR TITLE
Enhanced DBTest to respect SS_DATABASE_PREFIX if set

### DIFF
--- a/tests/model/DBTest.php
+++ b/tests/model/DBTest.php
@@ -6,15 +6,18 @@
 class DBTest extends SapphireTest {
 
 	function testValidAlternativeDatabaseName() {
+		
+		$prefix = defined('SS_DATABASE_PREFIX') ? SS_DATABASE_PREFIX : 'ss_';
+		
 		Config::inst()->update('Director', 'environment_type', 'dev');
-		$this->assertTrue(DB::valid_alternative_database_name('ss_tmpdb1234567'));
-		$this->assertFalse(DB::valid_alternative_database_name('ss_tmpdb12345678'));
+		$this->assertTrue(DB::valid_alternative_database_name($prefix.'tmpdb1234567'));
+		$this->assertFalse(DB::valid_alternative_database_name($prefix.'tmpdb12345678'));
 		$this->assertFalse(DB::valid_alternative_database_name('tmpdb1234567'));
 		$this->assertFalse(DB::valid_alternative_database_name('random'));
 		$this->assertFalse(DB::valid_alternative_database_name(''));
 
 		Config::inst()->update('Director', 'environment_type', 'live');
-		$this->assertFalse(DB::valid_alternative_database_name('ss_tmpdb1234567'));
+		$this->assertFalse(DB::valid_alternative_database_name($prefix.'tmpdb1234567'));
 
 		Config::inst()->update('Director', 'environment_type', 'dev');
 	}


### PR DESCRIPTION
The testcase in `DBTest` fails, if `SS_DATABASE_PREFIX` is set, as it does not respect the prefix when calling `DB::valid_alternative_database_name`.
