### PR TITLE
FIX: Ensure HtmlEditorField loads correct MediaForm/LinkForm (fixes #3034)

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -581,6 +581,9 @@ class LeftAndMain extends Controller implements PermissionProvider {
 					'Content' => function() use(&$controller) {
 						return $controller->renderWith($controller->getTemplatesWithSuffix('_Content'));
 					},
+					'Toolbar' => function() use(&$controller) {
+						return $controller->EditorToolbar()->forTemplate();
+					},
 					'Breadcrumbs' => function() use (&$controller) {
 						return $controller->renderWith('CMSBreadcrumbs');
 					},

--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -307,7 +307,7 @@ jQuery.noConflict();
 				this.saveTabState();
 				
 				if(window.History.enabled) {
-					$.extend(data, {__forceReferer: forceReferer});
+					$.extend(data, {__forceReferer: forceReferer, pjax: 'Content,Toolbar'});
 					// Active menu item is set based on X-Controller ajax header,
 					// which matches one class on the menu
 					if(forceReload) {

--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -218,7 +218,8 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 
 	public function forTemplate() {
 		return sprintf(
-			'<div id="cms-editor-dialogs" data-url-linkform="%s" data-url-mediaform="%s"></div>',
+			'<div data-pjax-fragment="Toolbar" id="cms-editor-dialogs" 
+				data-url-linkform="%s" data-url-mediaform="%s"></div>',
 			Controller::join_links($this->controller->Link(), $this->name, 'LinkForm', 'forTemplate'),
 			Controller::join_links($this->controller->Link(), $this->name, 'MediaForm', 'forTemplate')
 		);

--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -384,20 +384,31 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 				var self = this, url = $('#cms-editor-dialogs').data('url' + capitalize(type) + 'form'),
 					dialog = $('.htmleditorfield-' + type + 'dialog');
 
-				if(dialog.length) {
+				// If we're re-opening a dialog that we've already loaded
+				if(dialog.length && dialog.data('url') == url) {
 					dialog.getForm().setElement(this);
 					dialog.open();
 				} else {
-					// Show a placeholder for instant feedback. Will be replaced with actual
-					// form dialog once its loaded.
-					dialog = $('<div class="htmleditorfield-dialog htmleditorfield-' + type + 'dialog loading">');
-					$('body').append(dialog);
+					// If there's a dialog present, but not the one we want, reset it and open it as 'loading'
+					if(dialog.length) {
+						dialog.getForm().setElement(this);
+						dialog.html('');
+						dialog.addClass('loading');
+						dialog.open();
+					// Otherwise construct a new dialog
+					} else {
+						// Show a placeholder for instant feedback. Will be replaced with actual form dialog once its loaded.
+						dialog = $('<div class="htmleditorfield-dialog htmleditorfield-' + type + 'dialog loading">');
+						$('body').append(dialog);
+					}
+
 					$.ajax({
 						url: url,
 						complete: function() {
 							dialog.removeClass('loading');
 						},
 						success: function(html) {
+							dialog.data('url', url);
 							dialog.html(html);
 							dialog.getForm().setElement(self);
 							dialog.trigger('ssdialogopen');


### PR DESCRIPTION
Proposed solution to #3034. Makes the `#cms-editor-dialogs` div a pjax fragment that’s updated each time a new LeftAndMain panel is loaded.

Changed the defaults for fragments set in `loadPanel`, I think this is an acceptable default (do we ever *not* want to update the media/link form links when switching `LeftAndMain` panels?).

The other issue is that when clearing/changing the dialog’s inner HTML, an error occurs:
> Error: cannot call methods on selectable prior to initialization; attempted to call method 'destroy'. 

Triggered [here](https://github.com/silverstripe/silverstripe-framework/blob/3.1/javascript/GridField.js#L268). The same error is triggered when picking existing files from an `UploadField` (try switching folders to trigger it).