### PR TITLE
FIX: corrected link to CMS Alternating Button Page

### DIFF
--- a/docs/en/howto/extend-cms-interface.md
+++ b/docs/en/howto/extend-cms-interface.md
@@ -210,4 +210,4 @@ blocks and concepts for more complex extensions as well.
  * [Reference: CMS Architecture](../reference/cms-architecture)
  * [Reference: Layout](../reference/layout)
  * [Topics: Rich Text Editing](../topics/rich-text-editing)
- * [CMS Alternating Button](../reference/cms-alternating-button)
+ * [CMS Alternating Button](../howto/cms-alternating-button)


### PR DESCRIPTION
Minor update to replace the link for the CMS Alternating Button link at the bottom of the page.
