### PR TITLE
FIX: parent::init is not called first

### DIFF
--- a/docs/en/reference/rssfeed.md
+++ b/docs/en/reference/rssfeed.md
@@ -47,6 +47,7 @@ SilverStripe what values to include in the feed.
 	class Page_Controller extends ContentController {
 		private static $allowed_actions = array('rss');
 		public function init() {
+			parent::init();
 			// linkToFeed will add an appropriate HTML link tag to the website 
 			// <head> tag to notify web browsers that an RSS feed is available 
 			// for this page. You can include as many feeds on the page as you 
@@ -56,7 +57,6 @@ SilverStripe what values to include in the feed.
 			// In this example $this->Link("rss") refers to the *rss* function
 			// we define below.
 			RSSFeed::linkToFeed($this->Link("rss"), "RSS feed of this blog");
-			parent::init();
 		}
 		public function rss() {
 			// Creates a new RSS Feed list
@@ -87,8 +87,8 @@ updates. Update mysite/code/Page.php to something like this:
 		private static $allowed_actions = array('rss');
 		
 		public function init() {
-			RSSFeed::linkToFeed($this->Link() . "rss", "10 Most Recently Updated Pages");	
 			parent::init();
+			RSSFeed::linkToFeed($this->Link() . "rss", "10 Most Recently Updated Pages");	
 		}
 		
 		public function rss() {
@@ -130,8 +130,8 @@ for all the students as we've seen before.
 	class Page_Controller extends ContentController {
 		private static $allowed_actions = array('students');
 		public function init() {
-			RSSFeed::linkToFeed($this->Link("students"), "Students feed");
 			parent::init();
+			RSSFeed::linkToFeed($this->Link("students"), "Students feed");
 		}		
 		public function students() {
 			$rss = new RSSFeed(


### PR DESCRIPTION
In the controller's init function, parent::init() should be called before any other method calls.
