### PR TITLE
FIX Folder Title not being exactly the same as Name field 

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -625,19 +625,19 @@ class File extends DataObject {
 			}
 		}
 
-		// Update title
-		if(!$this->getField('Title')) {
-			$this->__set('Title', str_replace(array('-','_'),' ', preg_replace('/\.[^.]+$/', '', $name)));
-		}
-		
 		// Update actual field value
 		$this->setField('Name', $name);
 		
 		// Ensure that the filename is updated as well (only in-memory)
 		// Important: Circumvent the getter to avoid infinite loops
 		$this->setField('Filename', $this->getRelativePath());
-		
-		return $this->getField('Name');
+
+		// Update title
+		if(!$this->Title) {
+			$this->Title = str_replace(array('-','_'),' ', preg_replace('/\.[^.]+$/', '', $name));
+		}
+
+		return $name;
 	}
 
 	/**

--- a/filesystem/Folder.php
+++ b/filesystem/Folder.php
@@ -352,13 +352,16 @@ class Folder extends File {
 	 * Note that this is not appropriate for files, because someone might want to create a human-readable name
 	 * of a file that is different from its name on disk. But folders should always match their name on disk. */
 	public function setTitle($title) {
-		$this->setField('Title',$title);
-		parent::setName($title); //set the name and filename to match the title
+		$this->setName($title);
+	}
+
+	public function getTitle() {
+		return $this->Name;
 	}
 
 	public function setName($name) {
-		$this->setField('Title',$name);
 		parent::setName($name);
+		$this->setField('Title', $this->Name);
 	}
 
 	public function setFilename($filename) {

--- a/tests/filesystem/FolderTest.php
+++ b/tests/filesystem/FolderTest.php
@@ -354,5 +354,20 @@ class FolderTest extends SapphireTest {
 		$folder4 = Folder::find_or_make('/FolderTest/EN-US-Lang');
 		$this->assertEquals($folder->ID, $folder4->ID);
 	}
-	
+
+	public function testTitleTiedToName() {
+		$newFolder = new Folder();
+
+		$newFolder->Name = 'TestNameCopiedToTitle';
+		$this->assertEquals($newFolder->Name, $newFolder->Title);
+
+		$newFolder->Title = 'TestTitleCopiedToName';
+		$this->assertEquals($newFolder->Name, $newFolder->Title);
+
+		$newFolder->Name = 'TestNameWithIllegalCharactersCopiedToTitle <!BANG!>';
+		$this->assertEquals($newFolder->Name, $newFolder->Title);
+
+		$newFolder->Title = 'TestTitleWithIllegalCharactersCopiedToName <!BANG!>';
+		$this->assertEquals($newFolder->Name, $newFolder->Title);
+	}
 }


### PR DESCRIPTION
When setName modifies the value, Title would still be the old value.
(Fixes CWPBUG-155)
