### PR TITLE
FIX TemplateManifest prevent cache collision

### DIFF
--- a/core/manifest/TemplateManifest.php
+++ b/core/manifest/TemplateManifest.php
@@ -38,9 +38,33 @@ class SS_TemplateManifest {
 		$cacheClass = defined('SS_MANIFESTCACHE') ? SS_MANIFESTCACHE : 'ManifestCache_File';
 
 		$this->cache = new $cacheClass('templatemanifest'.($includeTests ? '_tests' : ''));
-		$this->cacheKey = 'manifest';
+		$this->cacheKey = $this->getCacheKey($includeTests);
 
 		$this->forceRegen = $forceRegen;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getBase() {
+		return $this->base;
+	}
+
+	/**
+	 * Generate a unique cache key to avoid manifest cache collisions.
+	 * We compartmentalise based on the base path, the given project, and whether
+	 * or not we intend to include tests.
+	 * @param boolean $includeTests
+	 * @return string
+	 */
+	public function getCacheKey($includeTests = false) {
+		return sha1(sprintf(
+			"manifest-%s-%s-%s",
+				$this->base,
+				$this->project,
+				(int) $includeTests // cast true to 1, false to 0
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
The `cacheKey` was always `manifest`. Need I say more?
