### PR TITLE
Don't add the class manifest with tests as an exclusive manifest

### DIFF
--- a/dev/TestRunner.php
+++ b/dev/TestRunner.php
@@ -82,7 +82,7 @@ class TestRunner extends Controller {
 			BASE_PATH, true, isset($_GET['flush'])
 		);
 		
-		SS_ClassLoader::instance()->pushManifest($classManifest);
+		SS_ClassLoader::instance()->pushManifest($classManifest, false);
 		SapphireTest::set_test_class_manifest($classManifest);
 
 		SS_TemplateLoader::instance()->pushManifest(new SS_TemplateManifest(


### PR DESCRIPTION
This allows for other class manifests (like the two I'm currently building) to still work when running tests (allowing them to be tested).

[ref:TRAITLOADER1]
