### PR TITLE
BUG Removed php5.2 incompatible syntax

### DIFF
--- a/dev/phpunit/PhpUnitWrapper_Generic.php
+++ b/dev/phpunit/PhpUnitWrapper_Generic.php
@@ -20,7 +20,7 @@ class PhpUnitWrapper_Generic extends PhpUnitWrapper {
 	protected static $test_name = 'SapphireTest';
 
 	public static function get_test_name() {
-		return static::$test_name;
+		return self::$test_name;
 	}
 	
 	/**


### PR DESCRIPTION
Regression from https://github.com/silverstripe/silverstripe-framework/commit/c5d4d7daf363001912dd9838023da47e4c728fcf
