### PR TITLE
MINOR LeftAndMain::getRecord check $ClassName before use

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -627,9 +627,9 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		$className = $this->stat('tree_class');
 		if($className && $id instanceof $className) {
 			return $id;
-		} else if($id == 'root') {
+		} else if($className && $id == 'root') {
 			return singleton($className);
-		} else if(is_numeric($id)) {
+		} else if($className && is_numeric($id)) {
 			return DataObject::get_by_id($className, $id);
 		} else {
 			return false;


### PR DESCRIPTION
While the check for `$classname` was done in the first conditional, it was left out of the other two, leading to potential issues when an invalid ID was given, instead of the expected `false`.
