### PR TITLE
MINOR Use composer @stable for PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"composer/installers": "*"
 	},
 	"require-dev": {
-		"phpunit/PHPUnit": "~3.7"
+		"phpunit/PHPUnit": "~3.7@stable"
 	},
 	"autoload": {
 		"classmap": ["tests/behat/features/bootstrap"]	


### PR DESCRIPTION
Using stable will allow some packages to be downloaded as zips instead of clones all the time.

Here's my output of `composer require phpunit/phpunit ~3.7@stable`:

```
[vagrant@localhost html]$ composer require phpunit/phpunit ~3.7@stable
Warning: This development build of composer is over 30 days old. It is recommended to update it by running "/usr/bin/composer self-update" to get the latest version.
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Installing symfony/yaml (dev-master e9525fc)
    Cloning e9525fc511a51e7bfa214c6c420515c580fda35a

  - Installing phpunit/php-text-template (1.2.0)
    Downloading: 100%

  - Installing phpunit/phpunit-mock-objects (1.2.x-dev c39c451)
    Cloning c39c4511c3b007539eb170c32cbc2af49a07351a

  - Installing phpunit/php-timer (1.0.5)
    Downloading: 100%

  - Installing phpunit/php-token-stream (dev-master ad4e1e2)
    Cloning ad4e1e23ae01b483c16f600ff1bebec184588e32

  - Installing phpunit/php-file-iterator (1.3.4)
    Downloading: 100%

  - Installing phpunit/php-code-coverage (1.2.x-dev 6ef2bf3)
    Cloning 6ef2bf3a1c47eca07ea95f0d8a902a6340390b34

  - Installing phpunit/phpunit (3.7.37)
    Downloading: 100%

phpunit/phpunit-mock-objects suggests installing ext-soap (*)
phpunit/phpunit suggests installing phpunit/php-invoker (~1.1)
Writing lock file
Generating autoload files
```
