### PR TITLE
Revert "FIX: allow CURLOPT_CONNECTTIMEOUT to be configured."

### DIFF
--- a/api/RestfulService.php
+++ b/api/RestfulService.php
@@ -1,21 +1,17 @@
 <?php
 /**
  * RestfulService class allows you to consume various RESTful APIs.
- *
  * Through this you could connect and aggregate data of various web services.
- *
- * @see http://doc.silverstripe.org/framework/en/reference/restfulservice
+ * For more info visit wiki documentation - http://doc.silverstripe.org/doku.php?id=restfulservice  
  * 
  * @package framework
  * @subpackage integration
  */
 class RestfulService extends ViewableData {
-
 	protected $baseURL;
 	protected $queryString;
 	protected $errorTag;
 	protected $checkErrors;
-	protected $connectTimeout = 5;
 	protected $cache_expire;
 	protected $authUsername, $authPassword;
 	protected $customHeaders = array();
@@ -217,6 +213,7 @@ class RestfulService extends ViewableData {
 	 */
 	public function curlRequest($url, $method, $data = null, $headers = null, $curlOptions = array()) {
 		$ch        = curl_init();
+		$timeout   = 5;
 		$sapphireInfo = new SapphireInfo(); 
 		$useragent = 'SilverStripe/' . $sapphireInfo->Version();
 		$curlOptions = $curlOptions + (array)$this->config()->default_curl_options;
@@ -224,7 +221,7 @@ class RestfulService extends ViewableData {
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_USERAGENT, $useragent);
-		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->getConnectTimeout());
+		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
 		if(!ini_get('open_basedir')) curl_setopt($ch, CURLOPT_FOLLOWLOCATION,1);
 		curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
 
@@ -556,31 +553,6 @@ class RestfulService extends ViewableData {
 		
 		return $output;
 	}
-
-	/**
-	 * Set the connection timeout for the curl request in seconds.
-	 *
-	 * @see http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTCONNECTTIMEOUT
-	 *
-	 * @param int
-	 *
-	 * @return RestfulService
-	 */
-	public function setConnectTimeout($timeout) {
-		$this->connectTimeout = $timeout;
-
-		return $this;
-	}
-
-	/**
-	 * Return the connection timeout value.
-	 *
-	 * @return int
-	 */
-	public function getConnectTimeout() {
-		return $this->connectTimeout;
-	}
-
 }
 
 /**


### PR DESCRIPTION
Basically, we shouldn't be creating individual setters and getters for each curl option. Instead they should be set using the curlOptions array or default config.

``` php
Config::inst()->update('RestfulService', 'default_curl_options', array(
    CURLOPT_CONNECTTIMEOUT => 10
));
```

This reverts commit 0d493d4effb8994480976dee7042c498f2057df9.

See https://github.com/silverstripe/silverstripe-framework/pull/2699#issuecomment-41789220

cc @chillu
