### PR TITLE
FIX: Update SapphireTest to match phpunit 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"composer/installers": "*"
 	},
 	"require-dev": {
-		"phpunit/PHPUnit": "~3.7@stable"
+		"phpunit/PHPUnit": "4.*@stable"
 	},
 	"autoload": {
 		"classmap": ["tests/behat/features/bootstrap"]	

--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -507,8 +507,9 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 		$needle,
 		$haystack,
 		$message = '',
-		$ignoreCase = FALSE,
-		$checkForObjectIdentity = TRUE
+		$ignoreCase = false,
+		$checkForObjectIdentity = true,
+		$checkForNonObjectIdentity = false
 	) {
 		if ($haystack instanceof DBField) $haystack = (string)$haystack;
 		parent::assertContains($needle, $haystack, $message, $ignoreCase, $checkForObjectIdentity);
@@ -518,8 +519,9 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 		$needle,
 		$haystack,
 		$message = '',
-		$ignoreCase = FALSE,
-		$checkForObjectIdentity = TRUE
+		$ignoreCase = false,
+		$checkForObjectIdentity = true,
+		$checkForNonObjectIdentity = false
 	) {
 		if ($haystack instanceof DBField) $haystack = (string)$haystack;
 		parent::assertNotContains($needle, $haystack, $message, $ignoreCase, $checkForObjectIdentity);


### PR DESCRIPTION
This appears to be the only change necessary to get the tests building on phpunit 4.  We'll see if the pull requests fails build on another phpunit...
