### PR TITLE
FIX remove redundant DB name switch in TestRunner

### DIFF
--- a/dev/TestRunner.php
+++ b/dev/TestRunner.php
@@ -365,6 +365,5 @@ class TestRunner extends Controller {
 	
 	public function tearDown() {
 		SapphireTest::kill_temp_db();
-		DB::set_alternative_database_name(null);
 	}
 }


### PR DESCRIPTION
Another ~controversial~ test suite related commit.

From what I can see, this doesn't actually do anything, except cause an error with cookie setting after HTTP body is sent when tests fail. This is an issue on both the `sake` runner and web runner.
