### PR TITLE
API: Update Requirements to use Injector and Config

### DIFF
--- a/_config/requirements.yml
+++ b/_config/requirements.yml
@@ -1,0 +1,5 @@
+---
+Name: requirements
+---
+Injector:
+  Requirements_Backend: RequirementsHandler

--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -426,7 +426,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 					$config = array();
 				}
 
-				Requirements::themedCSS($file, isset($config['media']) ? $config['media'] : null);
+				Requirements::themed_css($file, isset($config['media']) ? $config['media'] : null);
 			}
 		}
 
@@ -679,7 +679,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 					)));
 				}
 			}
-			if ($menuIconStyling) Requirements::customCSS($menuIconStyling);
+			if ($menuIconStyling) Requirements::custom_css($menuIconStyling);
 
 			$this->_cache_MainMenu = $menu;
 		}

--- a/admin/tests/LeftAndMainTest.php
+++ b/admin/tests/LeftAndMainTest.php
@@ -21,7 +21,7 @@ class LeftAndMainTest extends FunctionalTest {
 
 		$this->backupCss = Config::inst()->get('LeftAndMain', 'extra_requirements_css');
 		$this->backupJs = Config::inst()->get('LeftAndMain', 'extra_requirements_javascript');
-		$this->backupCombined = Requirements::get_combined_files_enabled();
+		$this->backupCombined = Config::inst()->get('Requirements', 'combined_files_enabled');
 
 		Config::inst()->update('LeftAndMain', 'extra_requirements_css', array(
 			FRAMEWORK_DIR . '/tests/assets/LeftAndMainTest.css'
@@ -31,7 +31,7 @@ class LeftAndMainTest extends FunctionalTest {
 			FRAMEWORK_DIR . '/tests/assets/LeftAndMainTest.js'
 		));
 
-		Requirements::set_combined_files_enabled(false);
+		Config::inst()->update('Requirements', 'combined_files_enabled', false);
 	}
 
 	public function tearDown() {
@@ -39,8 +39,7 @@ class LeftAndMainTest extends FunctionalTest {
 
 		Config::inst()->update('LeftAndMain', 'extra_requirements_css', $this->backupCss);
 		Config::inst()->update('LeftAndMain', 'extra_requirements_javascript', $this->backupJs);
-
-		Requirements::set_combined_files_enabled($this->backupCombined);
+		Config::inst()->update('Requirements', 'combined_files_enabled', $this->backupCombined);
 	}
 
 

--- a/api/RSSFeed.php
+++ b/api/RSSFeed.php
@@ -132,7 +132,7 @@ class RSSFeed extends ViewableData {
 	 */
 	public static function linkToFeed($url, $title = null) {
 		$title = Convert::raw2xml($title);
-		Requirements::insertHeadTags(
+		Requirements::insert_head_tags(
 			'<link rel="alternate" type="application/rss+xml" title="' . $title .
 			'" href="' . $url . '" />');
 	}

--- a/control/Director.php
+++ b/control/Director.php
@@ -240,15 +240,13 @@ class Director implements TemplateGlobalProvider {
 		$existingCookies = isset($_COOKIE) ? $_COOKIE : array();
 		$existingServer	= isset($_SERVER) ? $_SERVER : array();
 
-		$existingRequirementsBackend = Requirements::backend();
-
 		Config::inst()->update('Cookie', 'report_errors', false);
-		Requirements::set_backend(new Requirements_Backend());
+		Injector::inst()->unregisterNamedObject('Requirements_Backend');
 
 		// Set callback to invoke prior to return
 		$onCleanup = function() use(
 			$existingRequestVars, $existingGetVars, $existingPostVars, $existingSessionVars,
-			$existingCookies, $existingServer, $existingRequirementsBackend, $oldStage
+			$existingCookies, $existingServer, $oldStage
 		) {
 			// Restore the superglobals
 			$_REQUEST = $existingRequestVars;
@@ -258,13 +256,11 @@ class Director implements TemplateGlobalProvider {
 			$_COOKIE = $existingCookies;
 			$_SERVER = $existingServer;
 
-			Requirements::set_backend($existingRequirementsBackend);
-
 			// These are needed so that calling Director::test() doesnt muck with whoever is calling it.
 			// Really, it's some inappropriate coupling and should be resolved by making less use of statics
 			Versioned::reading_stage($oldStage);
 
-			Injector::unnest(); // Restore old CookieJar, etc
+			Injector::unnest(); // Restore old CookieJar, RequirementsHandler etc
 			Config::unnest();
 		};
 

--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -160,6 +160,9 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 	protected $model;
 
 	public function setUp() {
+		Injector::nest();
+		Config::nest();
+
 		// We cannot run the tests on this abstract class.
 		if(get_class($this) == "SapphireTest") $this->skipTest = true;
 		
@@ -481,7 +484,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 		
 		// Restore requirements
 		if($this->originalRequirements) {
-			Requirements::set_backend($this->originalRequirements);	
+			Injector::inst()->registerService($this->originalRequirements, 'Requirements_Backend');
 		}
 
 		// Mark test as no longer being run - we use originalIsRunningTest to allow for nested SapphireTest calls
@@ -499,6 +502,9 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 			$controller->response->setStatusCode(200);
 			$controller->response->removeHeader('Location');
 		}
+
+		Injector::unnest();
+		Config::unnest();
 	}
 
 	public static function assertContains(

--- a/docs/en/02_Developer_Guides/01_Templates/03_Requirements.md
+++ b/docs/en/02_Developer_Guides/01_Templates/03_Requirements.md
@@ -62,7 +62,7 @@ JavaScript in a separate file and instead load, via search and replace, several 
 	    "EditorCSS" => "cms/css/editor.css",
 	);
 
-	Requirements::javascriptTemplate("cms/javascript/editor.template.js", $vars);
+	Requirements::javascript_emplate("cms/javascript/editor.template.js", $vars);
 
 In this example, `editor.template.js` is expected to contain a replaceable variable expressed as `$EditorCSS`.
 
@@ -74,12 +74,12 @@ this is generally speaking the best way to do these things - it clearly marks th
 language.
 
 	:::php
-	Requirements::customScript(<<<JS
+	Requirements::custom_script(<<<JS
 	  alert("hi there");
 	JS
 	);
 
-	Requirements::customCSS(<<<CSS
+	Requirements::custom_css(<<<CSS
 	  .tree li.$className {
 	    background-image: url($icon);
 	  }
@@ -176,8 +176,12 @@ careful when messing with the order of requirements.
 By default, SilverStripe includes all Javascript files at the bottom of the page body, unless there's another script 
 already loaded, then, it's inserted before the first `<script>` tag. If this causes problems, it can be configured.
 
-	:::php
-	Requirements::set_force_js_to_bottom(true);
+	**mysite/_config/app.yml**
+
+	:::yml
+	Requirements:
+	  write_js_to_body: true
+	  force_js_to_bottom: true
 
 `Requirements.force_js_to_bottom`, will force SilverStripe to write the Javascript to the bottom of the page body, even 
 if there is an earlier script tag.
@@ -185,9 +189,13 @@ if there is an earlier script tag.
 If the Javascript files are preferred to be placed in the `<head>` tag rather than in the `<body>` tag,
 `Requirements.write_js_to_body` should be set to false.
 
-	:::php
-	Requirements::set_force_js_to_bottom(true);
+## Extending / Customising
 
+The `Requirements` class is essentially a convenience “front end” for a class named `RequirementsHandler`, which handles the actual tracking and output of files and scripts. If you need to override the `RequirementsHandler` backend, you can specify your own class (that implements `Requirements_Backend`) using the following configuration setting:
+
+	:::yml
+	Injector:
+	  Requirements_Backend: MyRequirementsHandler
 
 ## API Documentation
 

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -1,0 +1,30 @@
+# 4.0.0 (unreleased)
+
+## Overview
+
+### Framework
+
+ * `SapphireTest` now nests `Injector` and `Config` before each test and unnests them after
+
+### Other
+
+ * The `Requirements` class has been updated to make use of the `Injector` and `Config` APIs, the
+   following methods/settings are marked as deprecated and will be removed in 5.0:
+	* Requirements_Backend configuration:
+		- `Requirements_Backend` has been renamed to `RequirementsHandler`, with `Requirements_Backend` becoming an interface
+		- `Requirements::set_backend()` has been replaced with `Injector` configuration, see the [requirements developer guide](/developer_guides/templates/requirements#extending--customising) for more information
+	* Renamed methods:
+		- `Requirements::customScript()` has been replaced with `Requirements::custom_script()`
+		- `Requirements::customCSS()` has been replaced with `Requirements::custom_css()`
+		- `Requirements::insertHeadTags()` has been replaced with `Requirements::insert_head_tags()`
+		- `Requirements::javascriptTemplate()` has been replaced with `Requirements::javascript_template()`
+		- `Requirements::themedCSS()` has been replaced with `Requirements::themed_css()`
+		- `Requirements::includeInHTML()` has been replaced with `Requirements::include_in_html()`
+	* Configuration:
+		- `Requirements::set_combined_files_enabled()` has been replaced with the `Requirements.combined_files_enabled` config setting
+		- `Requirements::set_combined_files_folder()` has been replaced with the `Requirements.combined_files_folder` config setting
+		- `Requirements::set_suffix_requirements()` has been replaced with the `Requirements.suffix_requirements` config setting
+		- `Requirements::set_write_js_to_body()` has been replaced with the `Requirements.write_js_to_body` config setting
+		- `Requirements::set_force_js_to_bottom()` has been replaced with the `Requirements.force_js_to_bottom` config setting
+		- Setting `Requirements::backend()->write_header_comment` has been replaced with the `Requirements.write_header_comment` config setting
+		- Setting `Requirements::backend()->combine_js_with_jsmin` has been replaced with the `Requirements.combine_js_with_jsmin` config setting

--- a/email/Email.php
+++ b/email/Email.php
@@ -650,7 +650,7 @@ class Email extends ViewableData {
 	public static function obfuscate($email, $method = 'visible') {
 		switch($method) {
 			case 'direction' :
-				Requirements::customCSS(
+				Requirements::custom_css(
 					'span.codedirection { unicode-bidi: bidi-override; direction: rtl; }',
 					'codedirectionCSS'
 				);

--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -52,7 +52,7 @@ class HtmlEditorField extends TextareaField {
 			Requirements::javascript(MCE_ROOT . 'tiny_mce_src.js');
 		}
 
-		Requirements::customScript($configObj->generateJS(), 'htmlEditorConfig');
+		Requirements::custom_script($configObj->generateJS(), 'htmlEditorConfig');
 	}
 
 	/**

--- a/forms/InlineFormAction.php
+++ b/forms/InlineFormAction.php
@@ -29,7 +29,7 @@ class InlineFormAction extends FormField {
 
 	public function Field($properties = array()) {
 		if($this->includeDefaultJS) {
-			Requirements::javascriptTemplate(FRAMEWORK_DIR . '/javascript/InlineFormAction.js',
+			Requirements::javascript_template(FRAMEWORK_DIR . '/javascript/InlineFormAction.js',
 				array('ID'=>$this->id()));
 		}
 

--- a/security/MemberLoginForm.php
+++ b/security/MemberLoginForm.php
@@ -127,7 +127,7 @@ class MemberLoginForm extends LoginForm {
 				if(el && el.focus && (typeof jQuery == 'undefined' || jQuery(el).is(':visible'))) el.focus();
 			})();
 JS;
-		Requirements::customScript($js, 'MemberLoginFormFieldFocus');
+		Requirements::custom_script($js, 'MemberLoginFormFieldFocus');
 	}
 
 	/**

--- a/tests/core/ConfigTest.php
+++ b/tests/core/ConfigTest.php
@@ -189,8 +189,7 @@ class ConfigTest extends SapphireTest {
 		// But it won't affect subclasses - this is *uninherited* static
 		$this->assertNotContains('test_2b',
 			Config::inst()->get('ConfigStaticTest_Third', 'first', Config::UNINHERITED));
-		$this->assertNotContains('test_2b',
-			Config::inst()->get('ConfigStaticTest_Fourth', 'first', Config::UNINHERITED));
+		$this->assertNull(Config::inst()->get('ConfigStaticTest_Fourth', 'first', Config::UNINHERITED));
 
 		// Subclasses that don't have the static explicitly defined should allow definition, also
 		// This also checks that set can be called after the first uninherited get()

--- a/view/Requirements.php
+++ b/view/Requirements.php
@@ -1,451 +1,55 @@
 <?php
-
 /**
- * Requirements tracker, for javascript and css.
- * @todo Document the requirements tracker, and discuss it with the others.
- *
+ * Front-end for requirements handler for JavaScript and CSS files.
  * @package framework
  * @subpackage view
  */
-class Requirements implements Flushable {
-
-	/**
-	 * Triggered early in the request when someone requests a flush.
-	 */
-	public static function flush() {
-		self::delete_all_combined_files();
-	}
-
-	/**
-	 * Enable combining of css/javascript files.
-	 * @param boolean $enable
-	 */
-	public static function set_combined_files_enabled($enable) {
-		self::backend()->set_combined_files_enabled($enable);
-	}
-
-	/**
-	 * Checks whether combining of css/javascript files is enabled.
-	 * @return boolean
-	 */
-	public static function get_combined_files_enabled() {
-		return self::backend()->get_combined_files_enabled();
-	}
-
-	/**
-	 * Set the relative folder e.g. "assets" for where to store combined files
-	 * @param string $folder Path to folder
-	 */
-	public static function set_combined_files_folder($folder) {
-		self::backend()->setCombinedFilesFolder($folder);
-	}
-
-	/**
-	 * Set whether we want to suffix requirements with the time /
-	 * location on to the requirements
-	 *
-	 * @param bool
-	 */
-	public static function set_suffix_requirements($var) {
-		self::backend()->set_suffix_requirements($var);
-	}
-
-	/**
-	 * Return whether we want to suffix requirements
-	 *
-	 * @return bool
-	 */
-	public static function get_suffix_requirements() {
-		return self::backend()->get_suffix_requirements();
-	}
-
-	/**
-	 * Instance of requirements for storage
-	 *
-	 * @var Requirements
-	 */
-	private static $backend = null;
-
-	public static function backend() {
-		if(!self::$backend) {
-			self::$backend = new Requirements_Backend();
-		}
-		return self::$backend;
-	}
-
-	/**
-	 * Setter method for changing the Requirements backend
-	 *
-	 * @param Requirements $backend
-	 */
-	public static function set_backend(Requirements_Backend $backend) {
-		self::$backend = $backend;
-	}
-
-	/**
-	 * Register the given javascript file as required.
-	 *
-	 * See {@link Requirements_Backend::javascript()} for more info
-	 *
-	 */
-	public static function javascript($file) {
-		self::backend()->javascript($file);
-	}
-
-	/**
-	 * Add the javascript code to the header of the page
-	 *
-	 * See {@link Requirements_Backend::customScript()} for more info
-	 * @param script The script content
-	 * @param uniquenessID Use this to ensure that pieces of code only get added once.
-	 */
-	public static function customScript($script, $uniquenessID = null) {
-		self::backend()->customScript($script, $uniquenessID);
-	}
-
-	/**
-	 * Include custom CSS styling to the header of the page.
-	 *
-	 * See {@link Requirements_Backend::customCSS()}
-	 *
-	 * @param string $script CSS selectors as a string (without <style> tag enclosing selectors).
-	 * @param int $uniquenessID Group CSS by a unique ID as to avoid duplicate custom CSS in header
-	 */
-	public static function customCSS($script, $uniquenessID = null) {
-		self::backend()->customCSS($script, $uniquenessID);
-	}
-
-	/**
-	 * Add the following custom code to the <head> section of the page.
-	 * See {@link Requirements_Backend::insertHeadTags()}
-	 *
-	 * @param string $html
-	 * @param string $uniquenessID
-	 */
-	public static function insertHeadTags($html, $uniquenessID = null) {
-		self::backend()->insertHeadTags($html, $uniquenessID);
-	}
-
-	/**
-	 * Load the given javascript template with the page.
-	 * See {@link Requirements_Backend::javascriptTemplate()}
-	 *
-	 * @param file The template file to load.
-	 * @param vars The array of variables to load.  These variables are loaded via string search & replace.
-	 */
-	public static function javascriptTemplate($file, $vars, $uniquenessID = null) {
-		self::backend()->javascriptTemplate($file, $vars, $uniquenessID);
-	}
-
-	/**
-	 * Register the given stylesheet file as required.
-	 * See {@link Requirements_Backend::css()}
-	 *
-	 * @param $file String Filenames should be relative to the base, eg, 'framework/javascript/tree/tree.css'
-	 * @param $media String Comma-separated list of media-types (e.g. "screen,projector")
-	 * @see http://www.w3.org/TR/REC-CSS2/media.html
-	 */
-	public static function css($file, $media = null) {
-		self::backend()->css($file, $media);
-	}
-
-	/**
-	 * Registers the given themeable stylesheet as required.
-	 *
-	 * A CSS file in the current theme path name "themename/css/$name.css" is
-	 * first searched for, and it that doesn't exist and the module parameter is
-	 * set then a CSS file with that name in the module is used.
-	 *
-	 * NOTE: This API is experimental and may change in the future.
-	 *
-	 * @param string $name The name of the file - e.g. "/css/File.css" would have
-	 *        the name "File".
-	 * @param string $module The module to fall back to if the css file does not
-	 *        exist in the current theme.
-	 * @param string $media The CSS media attribute.
-	 */
-	public static function themedCSS($name, $module = null, $media = null) {
-		return self::backend()->themedCSS($name, $module, $media);
-	}
-
-	/**
-	 * Clear either a single or all requirements.
-	 * Caution: Clearing single rules works only with customCSS and customScript if you specified a {@uniquenessID}.
-	 *
-	 * See {@link Requirements_Backend::clear()}
-	 *
-	 * @param $file String
-	 */
-	public static function clear($fileOrID = null) {
-		self::backend()->clear($fileOrID);
-	}
-
-	/**
-	 * Blocks inclusion of a specific file
-	 * See {@link Requirements_Backend::block()}
-	 *
-	 * @param unknown_type $fileOrID
-	 */
-	public static function block($fileOrID) {
-		self::backend()->block($fileOrID);
-	}
-
-	/**
-	 * Removes an item from the blocking-list.
-	 * See {@link Requirements_Backend::unblock()}
-	 *
-	 * @param string $fileOrID
-	 */
-	public static function unblock($fileOrID) {
-		self::backend()->unblock($fileOrID);
-	}
-
-	/**
-	 * Removes all items from the blocking-list.
-	 * See {@link Requirements_Backend::unblock_all()}
-	 */
-	public static function unblock_all() {
-		self::backend()->unblock_all();
-	}
-
-	/**
-	 * Restore requirements cleared by call to Requirements::clear
-	 * See {@link Requirements_Backend::restore()}
-	 */
-	public static function restore() {
-		self::backend()->restore();
-	}
-
-	/**
-	 * Update the given HTML content with the appropriate include tags for the registered
-	 * requirements.
-	 * See {@link Requirements_Backend::includeInHTML()} for more information.
-	 *
-	 * @param string $templateFilePath Absolute path for the *.ss template file
-	 * @param string $content HTML content that has already been parsed from the $templateFilePath
-	 * through {@link SSViewer}.
-	 * @return string HTML content thats augumented with the requirements before the closing <head> tag.
-	 */
-	public static function includeInHTML($templateFile, $content) {
-		return self::backend()->includeInHTML($templateFile, $content);
-	}
-
-	public static function include_in_response(SS_HTTPResponse $response) {
-		return self::backend()->include_in_response($response);
-	}
-
-	/**
-	 * Add i18n files from the given javascript directory.
-	 *
-	 * @param String
-	 * @param Boolean
-	 * @param Boolean
-	 *
-	 * See {@link Requirements_Backend::add_i18n_javascript()} for more information.
-	 */
-	public static function add_i18n_javascript($langDir, $return = false, $langOnly = false) {
-		return self::backend()->add_i18n_javascript($langDir, $return, $langOnly);
-	}
-
-	/**
-	 * Concatenate several css or javascript files into a single dynamically generated file.
-	 * See {@link Requirements_Backend::combine_files()} for more info.
-	 *
-	 * @param string $combinedFileName
-	 * @param array $files
-	 * @param string $media
-	 */
-	public static function combine_files($combinedFileName, $files, $media = null) {
-		self::backend()->combine_files($combinedFileName, $files, $media);
-	}
-
-	/**
-	 * Returns all combined files.
-	 * See {@link Requirements_Backend::get_combine_files()}
-	 *
-	 * @return array
-	 */
-	public static function get_combine_files() {
-		return self::backend()->get_combine_files();
-	}
-
-	/**
-	 * Deletes all dynamically generated combined files from the filesystem.
-	 * See {@link Requirements_Backend::delete_combine_files()}
-	 *
-	 * @param string $combinedFileName If left blank, all combined files are deleted.
-	 */
-	public static function delete_combined_files($combinedFileName = null) {
-		return self::backend()->delete_combined_files($combinedFileName);
-	}
-
-	/**
-	 * Deletes all generated combined files in the configured combined files directory,
-	 * but doesn't delete the directory itself.
-	 */
-	public static function delete_all_combined_files() {
-		return self::backend()->delete_all_combined_files();
-	}
-
-	/**
-	 * Re-sets the combined files definition. See {@link Requirements_Backend::clear_combined_files()}
-	 */
-	public static function clear_combined_files() {
-		self::backend()->clear_combined_files();
-	}
-
-	/**
-	 * See {@link combine_files()}.
- 	 */
-	public static function process_combined_files() {
-		return self::backend()->process_combined_files();
-	}
-
-	/**
-	 * Returns all custom scripts
-	 * See {@link Requirements_Backend::get_custom_scripts()}
-	 *
-	 * @return array
-	 */
-	public static function get_custom_scripts() {
-		return self::backend()->get_custom_scripts();
-	}
-
-	/**
-	 * Set whether you want to write the JS to the body of the page or
-	 * in the head section
-	 *
-	 * @see Requirements_Backend::set_write_js_to_body()
-	 * @param boolean
-	 */
-	public static function set_write_js_to_body($var) {
-		self::backend()->set_write_js_to_body($var);
-	}
-
-	/**
-	 * Set the javascript to be forced to end of the HTML, or use the default.
-	 * Useful if you use inline <script> tags, that don't need the javascripts
-	 * included via Requirements::require();
-	 *
-	 * @param boolean $var If true, force the javascripts to be included at the bottom.
-	 */
-	public static function set_force_js_to_bottom($var) {
-		self::backend()->set_force_js_to_bottom($var);
-	}
-
-	public static function debug() {
-		return self::backend()->debug();
-	}
-
-}
-
-/**
- * @package framework
- * @subpackage view
- */
-class Requirements_Backend {
-
-	/**
-	 * Do we want requirements to suffix onto the requirement link
-	 * tags for caching or is it disabled. Getter / Setter available
-	 * through {@link Requirements::set_suffix_requirements()}
-	 *
-	 * @var bool
-	 */
-	protected $suffix_requirements = true;
-
-	/**
-	 * Enable combining of css/javascript files.
-	 *
-	 * @var boolean
-	 */
-	protected $combined_files_enabled = true;
-
-	/**
-	 * Paths to all required .js files relative to the webroot.
-	 *
-	 * @var array $javascript
-	 */
-	protected $javascript = array();
-
-	/**
-	 * Paths to all required .css files relative to the webroot.
-	 *
-	 * @var array $css
-	 */
-	protected $css = array();
-
-	/**
-	 * All custom javascript code that is inserted
-	 * directly at the bottom of the HTML <head> tag.
-	 *
-	 * @var array $customScript
-	 */
-	protected $customScript = array();
-
-	/**
-	 * All custom CSS rules which are inserted
-	 * directly at the bottom of the HTML <head> tag.
-	 *
-	 * @var array $customCSS
-	 */
-	protected $customCSS = array();
-
-	/**
-	 * All custom HTML markup which is added before
-	 * the closing <head> tag, e.g. additional metatags.
-	 * This is preferred to entering tags directly into
-	 */
-	protected $customHeadTags = array();
-
-	/**
-	 * Remembers the filepaths of all cleared Requirements
-	 * through {@link clear()}.
-	 *
-	 * @var array $disabled
-	 */
-	protected $disabled = array();
-
-	/**
-	 * The filepaths (relative to webroot) or
-	 * uniquenessIDs of any included requirements
-	 * which should be blocked when executing {@link inlcudeInHTML()}.
-	 * This is useful to e.g. prevent core classes to modifying
-	 * Requirements without subclassing the entire functionality.
-	 * Use {@link unblock()} or {@link unblock_all()} to revert changes.
-	 *
-	 * @var array $blocked
-	 */
-	protected $blocked = array();
-
-	/**
-	 * See {@link combine_files()}.
-	 *
-	 * @var array $combine_files
-	 */
-	public $combine_files = array();
+class Requirements implements Flushable, TemplateGlobalProvider {
 
 	/**
 	 * Using the JSMin library to minify any
 	 * javascript file passed to {@link combine_files()}.
-	 *
+	 * @config
 	 * @var boolean
 	 */
-	public $combine_js_with_jsmin = true;
+	private static $combine_js_with_jsmin = true;
+
+	/**
+	 * Enable combining of css/javascript files
+	 * @config
+	 * @var boolean
+	 */
+	private static $combined_files_enabled = true;
+
+	/**
+	 * The folder that combined files are stored in
+	 * @config
+	 * @var string
+	 */
+	private static $combined_files_folder = '$AssetsDir/_combinedfiles';
+
+	/**
+	 * Force the javascripts to the bottom of the page, even if there's a
+	 * <script> tag in the body already
+	 * @config
+	 * @var boolean
+	 */
+	private static $force_js_to_bottom = false;
+
+	/**
+	 * Enable adding query string suffix to requirements for caching
+	 * @config
+	 * @var bool
+	 */
+	private static $suffix_requirements = true;
 
 	/**
 	 * Setting for whether or not a file header should be written when
 	 * combining files.
-	 *
+	 * @config
 	 * @var boolean
 	 */
-	public $write_header_comment = true;
-
-	/**
-	 * @var string By default, combined files are stored in assets/_combinedfiles.
-	 * Set this by calling Requirements::set_combined_files_folder()
-	 */
-	protected $combinedFilesFolder = null;
+	private static $write_header_comment = true;
 
 	/**
 	 * Put all javascript includes at the bottom of the template
@@ -455,792 +59,414 @@ class Requirements_Backend {
 	 * Caution: Doesn't work when modifying the DOM from those external
 	 * scripts without listening to window.onload/document.ready
 	 * (e.g. toplevel document.write() calls).
-	 *
 	 * @see http://developer.yahoo.com/performance/rules.html#js_bottom
-	 *
+	 * @config
 	 * @var boolean
 	 */
-	public $write_js_to_body = true;
-	
+	private static $write_js_to_body = true;
+
 	/**
-	 * Force the javascripts to the bottom of the page, even if there's a
-	 * <script> tag in the body already
-	 *  
-	 * @var boolean
+	 * Triggered early in the request when someone requests a flush.
 	 */
-	protected $force_js_to_bottom = false;
-
-	public function set_combined_files_enabled($enable) {
-		$this->combined_files_enabled = (bool) $enable;
-	}
-
-	public function get_combined_files_enabled() {
-		return $this->combined_files_enabled;
+	public static function flush() {
+		self::delete_all_combined_files();
 	}
 
 	/**
-	 * @param String $folder
-	 */
-	public function setCombinedFilesFolder($folder) {
-		$this->combinedFilesFolder = $folder;
-	}
-
-	/**
-	 * @return String Folder relative to the webroot
-	 */
-	public function getCombinedFilesFolder() {
-		return ($this->combinedFilesFolder) ? $this->combinedFilesFolder : ASSETS_DIR . '/_combinedfiles';
-	}
-
-	/**
-	 * Set whether we want to suffix requirements with the time /
-	 * location on to the requirements
-	 *
-	 * @param bool
-	 */
-	public function set_suffix_requirements($var) {
-		$this->suffix_requirements = $var;
-	}
-
-	/**
-	 * Return whether we want to suffix requirements
-	 *
-	 * @return bool
-	 */
-	public function get_suffix_requirements() {
-		return $this->suffix_requirements;
-	}
-
-	/**
-	 * Set whether you want the files written to the head or the body. It
-	 * writes to the body by default which can break some scripts
-	 *
-	 * @param boolean
-	 */
-	public function set_write_js_to_body($var) {
-		$this->write_js_to_body = $var;
-	}
-	/**
-	 * Forces the javascript to the end of the body, just before the closing body-tag.
-	 *
-	 * @param boolean
-	 */
-	public function set_force_js_to_bottom($var) {
-		$this->force_js_to_bottom = $var;
-	}
-	/**
-	 * Register the given javascript file as required.
-	 * Filenames should be relative to the base, eg, 'framework/javascript/loader.js'
-	 */
-
-	public function javascript($file) {
-		$this->javascript[$file] = true;
-	}
-
-	/**
-	 * Returns an array of all included javascript
-	 *
 	 * @return array
 	 */
-	public function get_javascript() {
-		return array_keys(array_diff_key($this->javascript,$this->blocked));
+	public static function get_template_global_variables() {
+		return array(
+			'javascript',
+			'css',
+			'customScript' => 'custom_script',
+			'customCSS' => 'custom_css',
+			'themedCSS' => 'themed_css',
+			'insertHeadTags' => 'insert_head_tags',
+			'javascriptTemplate' => 'javascript_template',
+			'clear',
+			'block',
+			'unblock'
+		);
 	}
 
 	/**
-	 * Add the javascript code to the header of the page
-	 * @todo Make Requirements automatically put this into a separate file :-)
-	 * @param script The script content
-	 * @param uniquenessID Use this to ensure that pieces of code only get added once.
+	 * Returns an instance of Requirements_Backend
+	 * @return Requirements_Backend
 	 */
-	public function customScript($script, $uniquenessID = null) {
-		if($uniquenessID) $this->customScript[$uniquenessID] = $script;
-		else $this->customScript[] = $script;
-
-		$script .= "\n";
+	public static function backend() {
+		return Injector::inst()->get('Requirements_Backend');
 	}
 
 	/**
-	 * Include custom CSS styling to the header of the page.
-	 *
-	 * @param string $script CSS selectors as a string (without <style> tag enclosing selectors).
-	 * @param int $uniquenessID Group CSS by a unique ID as to avoid duplicate custom CSS in header
+	 * Requirements_Backend should now be set using the Injector api, e.g:
+	 * Injector.Requirements_Backend: MyRequirementsHandler
+	 * {@link Injector::registerService()} can be used to manually set
+	 * an instance
+	 * @deprecated 4.0 Use Config system to set backend instead
+	 * @param Requirements $backend
 	 */
-	public function customCSS($script, $uniquenessID = null) {
-		if($uniquenessID) $this->customCSS[$uniquenessID] = $script;
-		else $this->customCSS[] = $script;
+	public static function set_backend(Requirements_Backend $backend) {
+		Deprecation::notice('4.0', 'Use Config system to set backend instead');
+		Injector::inst()->registerService($backend, 'Requirements_Backend');
 	}
 
 	/**
-	 * Add the following custom code to the <head> section of the page.
-	 *
-	 * @param string $html
-	 * @param string $uniquenessID
+	 * Register the given javascript file as required.
+	 * See {@link RequirementsHandler::javascript()} for more info
+	 * @param string $file
 	 */
-	public function insertHeadTags($html, $uniquenessID = null) {
-		if($uniquenessID) $this->customHeadTags[$uniquenessID] = $html;
-		else $this->customHeadTags[] = $html;
-	}
-
-	/**
-	 * Load the given javascript template with the page.
-	 * @param file The template file to load.
-	 * @param vars The array of variables to load.  These variables are loaded via string search & replace.
-	 */
-	public function javascriptTemplate($file, $vars, $uniquenessID = null) {
-		$script = file_get_contents(Director::getAbsFile($file));
-		$search = array();
-		$replace = array();
-
-		if($vars) foreach($vars as $k => $v) {
-			$search[] = '$' . $k;
-			$replace[] = str_replace("\\'","'", Convert::raw2js($v));
-		}
-
-		$script = str_replace($search, $replace, $script);
-		$this->customScript($script, $uniquenessID);
+	public static function javascript($file) {
+		self::backend()->javascript($file);
 	}
 
 	/**
 	 * Register the given stylesheet file as required.
-	 *
-	 * @param $file String Filenames should be relative to the base, eg, 'framework/javascript/tree/tree.css'
-	 * @param $media String Comma-separated list of media-types (e.g. "screen,projector")
+	 * See {@link RequirementsHandler::css()}
+	 * @param string $file Filenames should be relative to the base, eg, 'framework/javascript/tree/tree.css'
+	 * @param string $media Comma-separated list of media-types (e.g. "screen,projector")
 	 * @see http://www.w3.org/TR/REC-CSS2/media.html
 	 */
-	public function css($file, $media = null) {
-		$this->css[$file] = array(
-			"media" => $media
-		);
-	}
-
-	public function get_css() {
-		return array_diff_key($this->css, $this->blocked);
+	public static function css($file, $media = null) {
+		self::backend()->css($file, $media);
 	}
 
 	/**
-	 * Needed to actively prevent the inclusion of a file,
-	 * e.g. when using your own jQuery version.
-	 * Blocking should only be used as an exception, because
-	 * it is hard to trace back. You can just block items with an
-	 * ID, so make sure you add an unique identifier to customCSS() and customScript().
-	 *
-	 * @param string $fileOrID
+	 * Add the javascript code to the header of the page
+	 * See {@link RequirementsHandler::customScript()} for more info
+	 * @param $script The script content
+	 * @param $uniquenessID Use this to ensure that pieces of code only get added once.
 	 */
-	public function block($fileOrID) {
-		$this->blocked[$fileOrID] = $fileOrID;
+	public static function custom_script($script, $uniquenessID = null) {
+		self::backend()->customScript($script, $uniquenessID);
+	}
+
+	/**
+	 * Include custom CSS styling to the header of the page.
+	 * See {@link RequirementsHandler::customCSS()}
+	 * @param string $script CSS selectors as a string (without <style> tag enclosing selectors).
+	 * @param int $uniquenessID Group CSS by a unique ID as to avoid duplicate custom CSS in header
+	 */
+	public static function custom_css($script, $uniquenessID = null) {
+		self::backend()->customCSS($script, $uniquenessID);
+	}
+
+	/**
+	 * Add the following custom code to the <head> section of the page.
+	 * See {@link RequirementsHandler::insertHeadTags()}
+	 * @param string $html
+	 * @param string $uniquenessID
+	 */
+	public static function insert_head_tags($html, $uniquenessID = null) {
+		self::backend()->insertHeadTags($html, $uniquenessID);
+	}
+
+	/**
+	 * Load the given javascript template with the page.
+	 * See {@link RequirementsHandler::javascriptTemplate()}
+	 * @param $file The template file to load.
+	 * @param $vars The array of variables to load. These variables are loaded via string search & replace.
+	 */
+	public static function javascript_template($file, $vars, $uniquenessID = null) {
+		self::backend()->javascriptTemplate($file, $vars, $uniquenessID);
+	}
+
+	/**
+	 * Registers the given themeable stylesheet as required.
+	 * A CSS file in the current theme path name "themename/css/$name.css" is
+	 * first searched for, and it that doesn't exist and the module parameter is
+	 * set then a CSS file with that name in the module is used.
+	 * @param string $name The name of the file - e.g. "/css/File.css" would have the name "File".
+	 * @param string $module The module to fall back to if the css file does not exist in the current theme.
+	 * @param string $media The CSS media attribute.
+	 */
+	public static function themed_css($name, $module = null, $media = null) {
+		self::backend()->themedCSS($name, $module, $media);
 	}
 
 	/**
 	 * Clear either a single or all requirements.
-	 * Caution: Clearing single rules works only with customCSS and customScript if you specified a {@uniquenessID}.
-	 *
+	 * Caution: Clearing single rules works only with customCSS and customScript if you
+	 * specified a {@uniquenessID}.
+	 * See {@link RequirementsHandler::clear()}
 	 * @param $file String
 	 */
-	public function clear($fileOrID = null) {
-		if($fileOrID) {
-			foreach(array('javascript','css', 'customScript', 'customCSS', 'customHeadTags') as $type) {
-				if(isset($this->{$type}[$fileOrID])) {
-					$this->disabled[$type][$fileOrID] = $this->{$type}[$fileOrID];
-					unset($this->{$type}[$fileOrID]);
-				}
-			}
-		} else {
-			$this->disabled['javascript'] = $this->javascript;
-			$this->disabled['css'] = $this->css;
-			$this->disabled['customScript'] = $this->customScript;
-			$this->disabled['customCSS'] = $this->customCSS;
-			$this->disabled['customHeadTags'] = $this->customHeadTags;
+	public static function clear($fileOrID = null) {
+		self::backend()->clear($fileOrID);
+	}
 
-			$this->javascript = array();
-			$this->css = array();
-			$this->customScript = array();
-			$this->customCSS = array();
-			$this->customHeadTags = array();
-		}
+	/**
+	 * Blocks inclusion of a specific file
+	 * See {@link RequirementsHandler::block()}
+	 * @param string $fileOrID
+	 */
+	public static function block($fileOrID) {
+		self::backend()->block($fileOrID);
 	}
 
 	/**
 	 * Removes an item from the blocking-list.
-	 * CAUTION: Does not "re-add" any previously blocked elements.
+	 * See {@link RequirementsHandler::unblock()}
 	 * @param string $fileOrID
 	 */
-	public function unblock($fileOrID) {
-		if(isset($this->blocked[$fileOrID])) unset($this->blocked[$fileOrID]);
+	public static function unblock($fileOrID) {
+		self::backend()->unblock($fileOrID);
 	}
+
 	/**
 	 * Removes all items from the blocking-list.
+	 * See {@link RequirementsHandler::unblockAll()}
 	 */
-	public function unblock_all() {
-		$this->blocked = array();
+	public static function unblock_all() {
+		self::backend()->unblockAll();
 	}
 
 	/**
 	 * Restore requirements cleared by call to Requirements::clear
+	 * See {@link RequirementsHandler::restore()}
 	 */
-	public function restore() {
-		$this->javascript = $this->disabled['javascript'];
-		$this->css = $this->disabled['css'];
-		$this->customScript = $this->disabled['customScript'];
-		$this->customCSS = $this->disabled['customCSS'];
-		$this->customHeadTags = $this->disabled['customHeadTags'];
+	public static function restore() {
+		self::backend()->restore();
 	}
 
 	/**
 	 * Update the given HTML content with the appropriate include tags for the registered
-	 * requirements. Needs to receive a valid HTML/XHTML template in the $content parameter,
-	 * including a <head> tag. The requirements will insert before the closing <head> tag automatically.
-	 *
-	 * @todo Calculate $prefix properly
-	 *
+	 * requirements.
+	 * See {@link RequirementsHandler::includeInHTML()} for more information.
 	 * @param string $templateFilePath Absolute path for the *.ss template file
 	 * @param string $content HTML content that has already been parsed from the $templateFilePath
-	 *                        through {@link SSViewer}.
+	 * through {@link SSViewer}.
 	 * @return string HTML content thats augumented with the requirements before the closing <head> tag.
 	 */
-	public function includeInHTML($templateFile, $content) {
-		if(
-			(strpos($content, '</head>') !== false || strpos($content, '</head ') !== false)
-			&& ($this->css || $this->javascript || $this->customCSS || $this->customScript || $this->customHeadTags)
-		) {
-			$requirements = '';
-			$jsRequirements = '';
-
-			// Combine files - updates $this->javascript and $this->css
-			$this->process_combined_files();
-
-			foreach(array_diff_key($this->javascript,$this->blocked) as $file => $dummy) {
-				$path = Convert::raw2xml($this->path_for_file($file));
-				if($path) {
-					$jsRequirements .= "<script type=\"text/javascript\" src=\"$path\"></script>\n";
-				}
-			}
-
-			// add all inline javascript *after* including external files which
-			// they might rely on
-			if($this->customScript) {
-				foreach(array_diff_key($this->customScript,$this->blocked) as $script) {
-					$jsRequirements .= "<script type=\"text/javascript\">\n//<![CDATA[\n";
-					$jsRequirements .= "$script\n";
-					$jsRequirements .= "\n//]]>\n</script>\n";
-				}
-			}
-
-			foreach(array_diff_key($this->css,$this->blocked) as $file => $params) {
-				$path = Convert::raw2xml($this->path_for_file($file));
-				if($path) {
-					$media = (isset($params['media']) && !empty($params['media']))
-						? " media=\"{$params['media']}\"" : "";
-					$requirements .= "<link rel=\"stylesheet\" type=\"text/css\"{$media} href=\"$path\" />\n";
-				}
-			}
-
-			foreach(array_diff_key($this->customCSS, $this->blocked) as $css) {
-				$requirements .= "<style type=\"text/css\">\n$css\n</style>\n";
-			}
-
-			foreach(array_diff_key($this->customHeadTags,$this->blocked) as $customHeadTag) {
-				$requirements .= "$customHeadTag\n";
-			}
-
-			if ($this->force_js_to_bottom) {
-				// Remove all newlines from code to preserve layout
-				$jsRequirements = preg_replace('/>\n*/', '>', $jsRequirements);
-
-				// We put script tags into the body, for performance.
-				// We forcefully put it at the bottom instead of before
-				// the first script-tag occurence
-				$content = preg_replace("/(<\/body[^>]*>)/i", $jsRequirements . "\\1", $content);
-				
-				// Put CSS at the bottom of the head
-				$content = preg_replace("/(<\/head>)/i", $requirements . "\\1", $content);				
-			} elseif($this->write_js_to_body) {
-				// Remove all newlines from code to preserve layout
-				$jsRequirements = preg_replace('/>\n*/', '>', $jsRequirements);
-
-				// We put script tags into the body, for performance.
-				// If your template already has script tags in the body, then we try to put our script
-				// tags just before those. Otherwise, we put it at the bottom.
-				$p2 = stripos($content, '<body');
-				$p1 = stripos($content, '<script', $p2);
-				
-				$commentTags = array();
-				$canWriteToBody = ($p1 !== false)
-					&&
-					//check that the script tag is not inside a html comment tag
-					!(
-						preg_match('/.*(?|(<!--)|(-->))/U', $content, $commentTags, 0, $p1)
-						&& 
-						$commentTags[1] == '-->'
-					);
-
-				if($canWriteToBody) {
-					$content = substr($content,0,$p1) . $jsRequirements . substr($content,$p1);
-				} else {
-					$content = preg_replace("/(<\/body[^>]*>)/i", $jsRequirements . "\\1", $content);
-				}
-
-				// Put CSS at the bottom of the head
-				$content = preg_replace("/(<\/head>)/i", $requirements . "\\1", $content);
-			} else {
-				$content = preg_replace("/(<\/head>)/i", $requirements . "\\1", $content);
-				$content = preg_replace("/(<\/head>)/i", $jsRequirements . "\\1", $content);
-			}
-		}
-
-		return $content;
+	public static function include_in_html($templateFile, $content) {
+		return self::backend()->includeInHTML($templateFile, $content);
 	}
 
 	/**
-	 * Attach requirements inclusion to X-Include-JS and X-Include-CSS headers on the HTTP response
+	 * Attach requirements inclusion to X-Include-JS and X-Include-CSS headers on the HTTP response.
+	 * @param SS_HTTPResponse $response
 	 */
-	public function include_in_response(SS_HTTPResponse $response) {
-		$this->process_combined_files();
-		$jsRequirements = array();
-		$cssRequirements = array();
-
-		foreach(array_diff_key($this->javascript, $this->blocked) as $file => $dummy) {
-			$path = $this->path_for_file($file);
-			if($path) {
-				$jsRequirements[] = str_replace(',', '%2C', $path);
-			}
-		}
-
-		$response->addHeader('X-Include-JS', implode(',', $jsRequirements));
-
-		foreach(array_diff_key($this->css,$this->blocked) as $file => $params) {
-			$path = $this->path_for_file($file);
-			if($path) {
-				$path = str_replace(',', '%2C', $path);
-				$cssRequirements[] = isset($params['media']) ? "$path:##:$params[media]" : $path;
-			}
-		}
-
-		$response->addHeader('X-Include-CSS', implode(',', $cssRequirements));
+	public static function include_in_response(SS_HTTPResponse $response) {
+		self::backend()->includeInResponse($response);
 	}
 
 	/**
-	 * Add i18n files from the given javascript directory.  SilverStripe expects that the given directory
-	 * will contain a number of java script files named by language: en_US.js, de_DE.js, etc.
-	 *
-	 * @param String The javascript lang directory, relative to the site root, e.g., 'framework/javascript/lang'
-	 * @param Boolean Return all relative file paths rather than including them in requirements
-	 * @param Boolean Only include language files, not the base libraries
+	 * Add i18n files from the given javascript directory.
+	 * See {@link RequirementsHandler::addI18nJavaScript()} for more information.
+	 * @param string
+	 * @param boolean
+	 * @param boolean
+	 * @return array|null
 	 */
-	public function add_i18n_javascript($langDir, $return = false, $langOnly = false) {
-		$files = array();
-		$base = Director::baseFolder() . '/';
-		if(i18n::config()->js_i18n) {
-			// Include i18n.js even if no languages are found.  The fact that
-			// add_i18n_javascript() was called indicates that the methods in
-			// here are needed.
-			if(!$langOnly) $files[] = FRAMEWORK_DIR . '/javascript/i18n.js';
-
-			if(substr($langDir,-1) != '/') $langDir .= '/';
-
-			$candidates = array(
-				'en.js',
-				'en_US.js',
-				i18n::get_lang_from_locale(i18n::default_locale()) . '.js',
-				i18n::default_locale() . '.js',
-				i18n::get_lang_from_locale(i18n::get_locale()) . '.js',
-				i18n::get_locale() . '.js',
-			);
-			foreach($candidates as $candidate) {
-				if(file_exists($base . DIRECTORY_SEPARATOR . $langDir . $candidate)) {
-					$files[] = $langDir . $candidate;
-				}
-			}
-		} else {
-			// Stub i18n implementation for when i18n is disabled.
-			if(!$langOnly) $files[] = FRAMEWORK_DIR . '/javascript/i18nx.js';
-		}
-
-		if($return) {
-			return $files;
-		} else {
-			foreach($files as $file) $this->javascript($file);
-		}
+	public static function add_i18n_javascript($langDir, $return = false, $langOnly = false) {
+		return self::backend()->addI18nJavaScript($langDir, $return, $langOnly);
 	}
 
 	/**
-	 * Finds the path for specified file.
-	 *
-	 * @param string $fileOrUrl
-	 * @return string|boolean
+	 * Concatenate several css or javascript files into a single dynamically generated file.
+	 * See {@link RequirementsHandler::combineFiles()} for more info.
+	 * @param string $combinedFileName
+	 * @param array $files
+	 * @param string $media
 	 */
-	protected function path_for_file($fileOrUrl) {
-		if(preg_match('{^//|http[s]?}', $fileOrUrl)) {
-			return $fileOrUrl;
-		} elseif(Director::fileExists($fileOrUrl)) {
-			$filePath = preg_replace('/\?.*/', '', Director::baseFolder() . '/' . $fileOrUrl);
-			$prefix = Director::baseURL();
-			$mtimesuffix = "";
-			$suffix = '';
-			if($this->suffix_requirements) {
-				$mtimesuffix = "?m=" . filemtime($filePath);
-				$suffix = '&';
-			}
-			if(strpos($fileOrUrl, '?') !== false) {
-				if (strlen($suffix) == 0) {
-					$suffix = '?';
-				}
-				$suffix .= substr($fileOrUrl, strpos($fileOrUrl, '?')+1);
-				$fileOrUrl = substr($fileOrUrl, 0, strpos($fileOrUrl, '?'));
-			} else {
-				$suffix = '';
-			}
-			return "{$prefix}{$fileOrUrl}{$mtimesuffix}{$suffix}";
-		} else {
-			return false;
-		}
+	public static function combine_files($combinedFileName, $files, $media = null) {
+		self::backend()->combineFiles($combinedFileName, $files, $media);
 	}
 
 	/**
-	 * Concatenate several css or javascript files into a single dynamically generated
-	 * file (stored in {@link Director::baseFolder()}). This increases performance
-	 * by fewer HTTP requests.
-	 *
-	 * The combined file is regenerated
-	 * based on every file modification time. Optionally a rebuild can be triggered
-	 * by appending ?flush=1 to the URL.
-	 * If all files to be combined are javascript, we use the external JSMin library
-	 * to minify the javascript. This can be controlled by {@link $combine_js_with_jsmin}.
-	 *
-	 * All combined files will have a comment on the start of each concatenated file
-	 * denoting their original position. For easier debugging, we recommend to only
-	 * minify javascript if not in development mode ({@link Director::isDev()}).
-	 *
-	 * CAUTION: You're responsible for ensuring that the load order for combined files
-	 * is retained - otherwise combining javascript files can lead to functional errors
-	 * in the javascript logic, and combining css can lead to wrong styling inheritance.
-	 * Depending on the javascript logic, you also have to ensure that files are not included
-	 * in more than one combine_files() call.
-	 * Best practice is to include every javascript file in exactly *one* combine_files()
-	 * directive to avoid the issues mentioned above - this is enforced by this function.
-	 *
-	 * CAUTION: Combining CSS Files discards any "media" information.
-	 *
-	 * Example for combined JavaScript:
-	 * <code>
-	 * Requirements::combine_files(
-	 *  'foobar.js',
-	 *  array(
-	 * 		'mysite/javascript/foo.js',
-	 * 		'mysite/javascript/bar.js',
-	 * 	)
-	 * );
-	 * </code>
-	 *
-	 * Example for combined CSS:
-	 * <code>
-	 * Requirements::combine_files(
-	 *  'foobar.css',
-	 * 	array(
-	 * 		'mysite/javascript/foo.css',
-	 * 		'mysite/javascript/bar.css',
-	 * 	)
-	 * );
-	 * </code>
-	 *
-	 * @see http://code.google.com/p/jsmin-php/
-	 *
-	 * @todo Should we enforce unique inclusion of files, or leave it to the developer? Can auto-detection cause
-	 *       breaks?
-	 *
-	 * @param string $combinedFileName Filename of the combined file (will be stored in {@link Director::baseFolder()}
-	 *                                 by default)
-	 * @param array $files Array of filenames relative to the webroot
-	 * @param string $media Comma-separated list of media-types (e.g. "screen,projector").
-	 */
-	public function combine_files($combinedFileName, $files, $media = null) {
-		// duplicate check
-		foreach($this->combine_files as $_combinedFileName => $_files) {
-			$duplicates = array_intersect($_files, $files);
-			if($duplicates && $combinedFileName != $_combinedFileName) {
-				user_error("Requirements_Backend::combine_files(): Already included files " . implode(',', $duplicates)
-					. " in combined file '{$_combinedFileName}'", E_USER_NOTICE);
-				return false;
-			}
-		}
-		foreach($files as $index=>$file) {
-			if(is_array($file)) {
-				// Either associative array path=>path type=>type or numeric 0=>path 1=>type
-				// Otherwise, assume path is the first item
-				if (isset($file['type']) && in_array($file['type'], array('css', 'javascript', 'js'))) {
-					switch ($file['type']) {
-						case 'css':
-							$this->css($file['path'], $media);
-							break;
-						default:
-							$this->javascript($file['path']);
-							break;
-					}
-					$files[$index] = $file['path'];
-				} elseif (isset($file[1]) && in_array($file[1], array('css', 'javascript', 'js'))) {
-					switch ($file[1]) {
-						case 'css':
-							$this->css($file[0], $media);
-							break;
-						default:
-							$this->javascript($file[0]);
-							break;
-					}
-					$files[$index] = $file[0];
-				} else {
-					$file = array_shift($file);
-				}
-			}
-			if (!is_array($file)) {
-				if(substr($file, -2) == 'js') {
-					$this->javascript($file);
-				} elseif(substr($file, -3) == 'css') {
-					$this->css($file, $media);
-				} else {
-					user_error("Requirements_Backend::combine_files(): Couldn't guess file type for file '$file', "
-						. "please specify by passing using an array instead.", E_USER_NOTICE);
-				}
-			}
-		}
-		$this->combine_files[$combinedFileName] = $files;
-	}
-
-		/**
 	 * Returns all combined files.
+	 * See {@link RequirementsHandler::getCombineFiles()}
 	 * @return array
 	 */
-	public function get_combine_files() {
-		return $this->combine_files;
+	public static function get_combine_files() {
+		return self::backend()->getCombineFiles();
 	}
 
 	/**
 	 * Deletes all dynamically generated combined files from the filesystem.
-	 *
+	 * See {@link RequirementsHandler::deleteCombineFiles()}
 	 * @param string $combinedFileName If left blank, all combined files are deleted.
 	 */
-	public function delete_combined_files($combinedFileName = null) {
-		$combinedFiles = ($combinedFileName) ? array($combinedFileName => null) : $this->combine_files;
-		$combinedFolder = ($this->getCombinedFilesFolder()) ?
-			(Director::baseFolder() . '/' . $this->combinedFilesFolder) : Director::baseFolder();
-		foreach($combinedFiles as $combinedFile => $sourceItems) {
-			$filePath = $combinedFolder . '/' . $combinedFile;
-			if(file_exists($filePath)) {
-				unlink($filePath);
-			}
-		}
+	public static function delete_combined_files($combinedFileName = null) {
+		self::backend()->deleteCombinedFiles($combinedFileName);
 	}
 
 	/**
 	 * Deletes all generated combined files in the configured combined files directory,
 	 * but doesn't delete the directory itself.
 	 */
-	public function delete_all_combined_files() {
-		$combinedFolder = $this->getCombinedFilesFolder();
-		if(!$combinedFolder) return false;
-
-		$path = Director::baseFolder() . '/' . $combinedFolder;
-		if(file_exists($path)) {
-			Filesystem::removeFolder($path, true);
-		}
-	}
-
-	public function clear_combined_files() {
-		$this->combine_files = array();
+	public static function delete_all_combined_files() {
+		return self::backend()->deleteAllCombinedFiles();
 	}
 
 	/**
-	 * See {@link combine_files()}
-	 *
+	 * Re-sets the combined files definition.
+	 * See {@link RequirementsHandler::clearCombinedFiles()}
 	 */
-	public function process_combined_files() {
-		// The class_exists call prevents us from loading SapphireTest.php (slow) just to know that
-		// SapphireTest isn't running :-)
-		if(class_exists('SapphireTest', false)) $runningTest = SapphireTest::is_running_test();
-		else $runningTest = false;
-
-		if((Director::isDev() && !$runningTest && !isset($_REQUEST['combine'])) || !$this->combined_files_enabled) {
-			return;
-		}
-
-		// Make a map of files that could be potentially combined
-		$combinerCheck = array();
-		foreach($this->combine_files as $combinedFile => $sourceItems) {
-			foreach($sourceItems as $sourceItem) {
-				if(isset($combinerCheck[$sourceItem]) && $combinerCheck[$sourceItem] != $combinedFile){
-					user_error("Requirements_Backend::process_combined_files - file '$sourceItem' appears in two " .
-						"combined files:" .	" '{$combinerCheck[$sourceItem]}' and '$combinedFile'", E_USER_WARNING);
-				}
-				$combinerCheck[$sourceItem] = $combinedFile;
-
-			}
-		}
-
-		// Work out the relative URL for the combined files from the base folder
-		$combinedFilesFolder = ($this->getCombinedFilesFolder()) ? ($this->getCombinedFilesFolder() . '/') : '';
-
-		// Figure out which ones apply to this pageview
-		$combinedFiles = array();
-		$newJSRequirements = array();
-		$newCSSRequirements = array();
-		foreach($this->javascript as $file => $dummy) {
-			if(isset($combinerCheck[$file])) {
-				$newJSRequirements[$combinedFilesFolder . $combinerCheck[$file]] = true;
-				$combinedFiles[$combinerCheck[$file]] = true;
-			} else {
-				$newJSRequirements[$file] = true;
-			}
-		}
-
-		foreach($this->css as $file => $params) {
-			if(isset($combinerCheck[$file])) {
-				// Inherit the parameters from the last file in the combine set.
-				$newCSSRequirements[$combinedFilesFolder . $combinerCheck[$file]] = $params;
-				$combinedFiles[$combinerCheck[$file]] = true;
-			} else {
-				$newCSSRequirements[$file] = $params;
-			}
-		}
-
-		// Process the combined files
-		$base = Director::baseFolder() . '/';
-		foreach(array_diff_key($combinedFiles, $this->blocked) as $combinedFile => $dummy) {
-			$fileList = $this->combine_files[$combinedFile];
-			$combinedFilePath = $base . $combinedFilesFolder . '/' . $combinedFile;
-
-
-			// Make the folder if necessary
-			if(!file_exists(dirname($combinedFilePath))) {
-				Filesystem::makeFolder(dirname($combinedFilePath));
-			}
-
-			// If the file isn't writeable, don't even bother trying to make the combined file and return (falls back
-			//  to uncombined).  Complex test because is_writable fails if the file doesn't exist yet.
-			if((file_exists($combinedFilePath) && !is_writable($combinedFilePath))
-				|| (!file_exists($combinedFilePath) && !is_writable(dirname($combinedFilePath)))
-			) {
-				user_error("Requirements_Backend::process_combined_files(): Couldn't create '$combinedFilePath'",
-					E_USER_WARNING);
-				return false;
-			}
-
-			// Determine if we need to build the combined include
-			if(file_exists($combinedFilePath)) {
-				// file exists, check modification date of every contained file
-				$srcLastMod = 0;
-				foreach($fileList as $file) {
-					if(file_exists($base . $file)) {
-						$srcLastMod = max(filemtime($base . $file), $srcLastMod);
-					}
-				}
-				$refresh = $srcLastMod > filemtime($combinedFilePath);
-			} else {
-				// file doesn't exist, or refresh was explicitly required
-				$refresh = true;
-			}
-
-			if(!$refresh) continue;
-
-			$failedToMinify = false;
-			$combinedData = "";
-			foreach(array_diff($fileList, $this->blocked) as $file) {
-				$fileContent = file_get_contents($base . $file);
-				
-				try{
-					$fileContent = $this->minifyFile($file, $fileContent);
-				}catch(Exception $e){
-					$failedToMinify = true;
-				}
-
-				if ($this->write_header_comment) {
-					// write a header comment for each file for easier identification and debugging
-					// also the semicolon between each file is required for jQuery to be combinable properly
-					$combinedData .= "/****** FILE: $file *****/\n";
-				}
-
-				$combinedData .= $fileContent . "\n";
-			}
-
-			$successfulWrite = false;
-			$fh = fopen($combinedFilePath, 'wb');
-			if($fh) {
-				if(fwrite($fh, $combinedData) == strlen($combinedData)) $successfulWrite = true;
-				fclose($fh);
-				unset($fh);
-			}
-			
-			if($failedToMinify){
-				// Failed to minify, use unminified. This warning is raised at the end to allow code execution
-				// to complete in case this warning is caught inside a try-catch block. 
-				user_error('Failed to minify '.$file.', exception: '.$e->getMessage(), E_USER_WARNING);
-			}
-
-			// Unsuccessful write - just include the regular JS files, rather than the combined one
-			if(!$successfulWrite) {
-				user_error("Requirements_Backend::process_combined_files(): Couldn't create '$combinedFilePath'",
-					E_USER_WARNING);
-				continue;
-			}
-		}
-
-		// @todo Alters the original information, which means you can't call this
-		// method repeatedly - it will behave different on the second call!
-		$this->javascript = $newJSRequirements;
-		$this->css = $newCSSRequirements;
-	}
-
-	protected function minifyFile($filename, $content) {
-		// if we have a javascript file and jsmin is enabled, minify the content
-		$isJS = stripos($filename, '.js');
-		if($isJS && $this->combine_js_with_jsmin) {
-			require_once('thirdparty/jsmin/jsmin.php');
-
-			increase_time_limit_to();
-			$content = JSMin::minify($content);
-		}
-		$content .= ($isJS ? ';' : '') . "\n";
-		return $content;
-	}
-
-	public function get_custom_scripts() {
-		$requirements = "";
-
-		if($this->customScript) {
-			foreach($this->customScript as $script) {
-				$requirements .= "$script\n";
-			}
-		}
-
-		return $requirements;
+	public static function clear_combined_files() {
+		self::backend()->clearCombinedFiles();
 	}
 
 	/**
-	 * @see Requirements::themedCSS()
+	 * Trigger processing of combined files
+	 * See {@link Requirements::combine_files()}.
 	 */
-	public function themedCSS($name, $module = null, $media = null) {
-		$theme = SSViewer::get_theme_folder();
-		$project = project();
-		$absbase = BASE_PATH . DIRECTORY_SEPARATOR;
-		$abstheme = $absbase . $theme;
-		$absproject = $absbase . $project;
-		$css = "/css/$name.css";
-		
-		if(file_exists($absproject . $css)) {
-			$this->css($project . $css, $media);
-		} elseif($module && file_exists($abstheme . '_' . $module.$css)) {
-			$this->css($theme . '_' . $module . $css, $media);
-		} elseif(file_exists($abstheme . $css)) {
-			$this->css($theme . $css, $media);
-		} elseif($module) {
-			$this->css($module . $css, $media);
-		}
+	public static function process_combined_files() {
+		return self::backend()->processCombinedFiles();
 	}
 
-	public function debug() {
-		Debug::show($this->javascript);
-		Debug::show($this->css);
-		Debug::show($this->customCSS);
-		Debug::show($this->customScript);
-		Debug::show($this->customHeadTags);
-		Debug::show($this->combine_files);
+	/**
+	 * Returns all custom scripts
+	 * See {@link RequirementsHandler::getCustomScripts()}
+	 * @return array
+	 */
+	public static function get_custom_scripts() {
+		return self::backend()->getCustomScripts();
+	}
+
+	/**
+	 * @deprecated 4.0 Use Requirements::custom_script() instead
+	 * @param $script The script content
+	 * @param $uniquenessID Use this to ensure that pieces of code only get added once.
+	 */
+	public static function customScript($script, $uniquenessID = null) {
+		Deprecation::notice('4.0', 'Use Requirements::custom_script() instead');
+		self::custom_script($script, $uniquenessID);
+	}
+
+	/**
+	 * @deprecated 4.0 Use Requirements::custom_css() instead
+	 * @param string $script CSS selectors as a string (without <style> tag enclosing selectors).
+	 * @param int $uniquenessID Group CSS by a unique ID as to avoid duplicate custom CSS in header
+	 */
+	public static function customCSS($script, $uniquenessID = null) {
+		Deprecation::notice('4.0', 'Use Requirements::custom_css() instead');
+		self::custom_css($script, $uniquenessID);
+	}
+
+	/**
+	 * @deprecated 4.0 Use Requirements::insert_head_tags() instead
+	 * @param string $html
+	 * @param string $uniquenessID
+	 */
+	public static function insertHeadTags($html, $uniquenessID = null) {
+		Deprecation::notice('4.0', 'Use Requirements::insert_head_tags() instead');
+		self::insert_head_tags($html, $uniquenessID);
+	}
+
+	/**
+	 * @deprecated 4.0 Use Requirements::javascript_template() instead
+	 * @param file The template file to load.
+	 * @param vars The array of variables to load.  These variables are loaded via string search & replace.
+	 */
+	public static function javascriptTemplate($file, $vars, $uniquenessID = null) {
+		Deprecation::notice('4.0', 'Use Requirements::javascript_template() instead');
+		self::javascript_template($file, $vars, $uniquenessID);
+	}
+
+	/**
+	 * @deprecated 4.0 Use Requirements::themed_css() instead
+	 * @param string $name The name of the file - e.g. "/css/File.css" would have the name "File".
+	 * @param string $module The module to fall back to if the css file does not exist in the current theme.
+	 * @param string $media The CSS media attribute.
+	 */
+	public static function themedCSS($name, $module = null, $media = null) {
+		Deprecation::notice('4.0', 'Use Requirements::themed_css() instead');
+		self::themed_css($name, $module, $media);
+	}
+
+	/**
+	 * @deprecated 4.0 Use Requirements::include_in_html() instead
+	 * @param string $templateFilePath Absolute path for the *.ss template file
+	 * @param string $content HTML content that has already been parsed from the $templateFilePath
+	 * through {@link SSViewer}.
+	 * @return string HTML content thats augumented with the requirements before the closing <head> tag.
+	 */
+	public static function includeInHTML($templateFile, $content) {
+		Deprecation::notice('4.0', 'Use Requirements::include_in_html() instead');
+		return self::include_in_html($templateFile, $content);
+	}
+
+	/**
+	 * Enable combining of css/javascript files.
+	 * @deprecated 4.0 Use the "Requirements.combined_files_enabled" config setting instead
+	 * @param boolean $enable
+	 */
+	public static function set_combined_files_enabled($enable) {
+		Deprecation::notice('4.0', 'Use the "Requirements.combined_files_enabled" config setting instead');
+		Config::inst()->update('Requirements', 'combined_files_enabled', (bool) $enable);
+	}
+
+	/**
+	 * Checks whether combining of css/javascript files is enabled.
+	 * @deprecated 4.0 Use the "Requirements.combined_files_enabled" config setting instead
+	 * @return boolean
+	 */
+	public static function get_combined_files_enabled() {
+		Deprecation::notice('4.0', 'Use the "Requirements.combined_files_enabled" config setting instead');
+		return Config::inst()->get('Requirements', 'combined_files_enabled');
+	}
+
+	/**
+	 * Set the relative folder e.g. "assets" for where to store combined files
+	 * @deprecated 4.0 Use the "Requirements.combined_files_folder" config setting instead
+	 * @param string $folder Path to folder
+	 */
+	public static function set_combined_files_folder($folder) {
+		Deprecation::notice('4.0', 'Use the "Requirements.combined_files_folder" config setting instead');
+		Config::inst()->update('Requirements', 'combined_files_folder', $folder);
+	}
+
+	/**
+	 * Set whether we want to suffix requirements with the time /
+	 * location on to the requirements
+	 * @deprecated 4.0 Use the "Requirements.suffix_requirements" config setting instead
+	 * @param bool
+	 */
+	public static function set_suffix_requirements($var) {
+		Deprecation::notice('4.0', 'Use the "Requirements.suffix_requirements" config setting instead');
+		Config::inst()->update('Requirements', 'suffix_requirements', (bool) $var);
+	}
+
+	/**
+	 * Return whether we want to suffix requirements
+	 * @deprecated 4.0 Use the "Requirements.suffix_requirements" config setting instead
+	 * @return bool
+	 */
+	public static function get_suffix_requirements() {
+		Deprecation::notice('4.0', 'Use the "Requirements.suffix_requirements" config setting instead');
+		return Config::inst()->get('Requirements', 'suffix_requirements');
+	}
+
+	/**
+	 * Set whether you want to write the JS to the body of the page or
+	 * in the head section
+	 * @deprecated 4.0 Use the "Requirements.write_js_to_body" config setting instead
+	 * @param boolean
+	 */
+	public static function set_write_js_to_body($var) {
+		Deprecation::notice('4.0', 'Use the "Requirements.write_js_to_body" config setting instead');
+		Config::inst()->update('Requirements', 'write_js_to_body', (bool) $var);
+	}
+
+	/**
+	 * Set the javascript to be forced to end of the HTML, or use the default.
+	 * Useful if you use inline <script> tags, that don't need the javascripts
+	 * included via Requirements::require();
+	 * @deprecated 4.0 Use the "Requirements.force_js_to_bottom" config setting instead
+	 * @param boolean
+	 */
+	public static function set_force_js_to_bottom($var) {
+		Deprecation::notice('4.0', 'Use the "Requirements.force_js_to_bottom" config setting instead');
+		Config::inst()->update('Requirements', 'force_js_to_bottom', (bool) $var);
+	}
+
+	/**
+	 * Show a list of all current requirements
+	 * @return mixed
+	 */
+	public static function debug() {
+		return self::backend()->debug();
 	}
 
 }

--- a/view/RequirementsHandler.php
+++ b/view/RequirementsHandler.php
@@ -1,0 +1,817 @@
+<?php
+/**
+ * Requirements handler for JavaScript and CSS files - does the actual
+ * work of calculating what to include and where.
+ * @package framework
+ * @subpackage view
+ */
+class RequirementsHandler implements Requirements_Backend {
+
+	/**
+	 * Paths to all required .js files relative to the webroot.
+	 *
+	 * @var array $javascript
+	 */
+	protected $javascript = array();
+
+	/**
+	 * Paths to all required .css files relative to the webroot.
+	 *
+	 * @var array $css
+	 */
+	protected $css = array();
+
+	/**
+	 * All custom javascript code that is inserted
+	 * directly at the bottom of the HTML <head> tag.
+	 *
+	 * @var array $customScript
+	 */
+	protected $customScript = array();
+
+	/**
+	 * All custom CSS rules which are inserted
+	 * directly at the bottom of the HTML <head> tag.
+	 *
+	 * @var array $customCSS
+	 */
+	protected $customCSS = array();
+
+	/**
+	 * All custom HTML markup which is added before
+	 * the closing <head> tag, e.g. additional metatags.
+	 * This is preferred to entering tags directly into
+	 */
+	protected $customHeadTags = array();
+
+	/**
+	 * Remembers the filepaths of all cleared Requirements
+	 * through {@link clear()}.
+	 *
+	 * @var array $disabled
+	 */
+	protected $disabled = array();
+
+	/**
+	 * The filepaths (relative to webroot) or
+	 * uniquenessIDs of any included requirements
+	 * which should be blocked when executing {@link inlcudeInHTML()}.
+	 * This is useful to e.g. prevent core classes to modifying
+	 * Requirements without subclassing the entire functionality.
+	 * Use {@link unblock()} or {@link unblock_all()} to revert changes.
+	 *
+	 * @var array $blocked
+	 */
+	protected $blocked = array();
+
+	/**
+	 * See {@link combine_files()}.
+	 *
+	 * @var array $combine_files
+	 */
+	public $combine_files = array();
+
+	/**
+	 * Magic setter used for deprecating previously public properties
+	 */
+	public function __set($name, $value) {
+		if($name == 'write_header_comment' || $name == 'combine_js_with_jsmin') {
+			Deprecation::notice('4.0', "Use the Requirements.{$name} config setting instead", false);
+			Config::inst()->update("Requirements", $name, $value);
+		}
+	}
+
+	/**
+	 * Get the folder that combined files will be stored in. The default Config
+	 * value for Requirements.combined_files_folder includes a placeholder which
+	 * this method will replace
+	 * @return string
+	 */
+	public function getCombinedFilesFolder() {
+		$folder = Config::inst()->get('Requirements', 'combined_files_folder');
+		return str_replace('$AssetsDir', ASSETS_DIR, $folder);
+	}
+
+	/**
+	 * Register the given javascript file as required.
+	 * Filenames should be relative to the base, eg, 'framework/javascript/loader.js'
+	 */
+	public function javascript($file) {
+		$this->javascript[$file] = true;
+	}
+
+	/**
+	 * Returns an array of all included javascript
+	 * @todo Deprecate this method?
+	 * @return array
+	 */
+	public function get_javascript() {
+		return array_keys(array_diff_key($this->javascript,$this->blocked));
+	}
+
+	/**
+	 * Add the javascript code to the header of the page
+	 * @todo Make Requirements automatically put this into a separate file :-)
+	 * @param script The script content
+	 * @param uniquenessID Use this to ensure that pieces of code only get added once.
+	 */
+	public function customScript($script, $uniquenessID = null) {
+		if($uniquenessID) $this->customScript[$uniquenessID] = $script;
+		else $this->customScript[] = $script;
+
+		$script .= "\n";
+	}
+
+	/**
+	 * Include custom CSS styling to the header of the page.
+	 *
+	 * @param string $script CSS selectors as a string (without <style> tag enclosing selectors).
+	 * @param int $uniquenessID Group CSS by a unique ID as to avoid duplicate custom CSS in header
+	 */
+	public function customCSS($script, $uniquenessID = null) {
+		if($uniquenessID) $this->customCSS[$uniquenessID] = $script;
+		else $this->customCSS[] = $script;
+	}
+
+	/**
+	 * Add the following custom code to the <head> section of the page.
+	 *
+	 * @param string $html
+	 * @param string $uniquenessID
+	 */
+	public function insertHeadTags($html, $uniquenessID = null) {
+		if($uniquenessID) $this->customHeadTags[$uniquenessID] = $html;
+		else $this->customHeadTags[] = $html;
+	}
+
+	/**
+	 * Load the given javascript template with the page.
+	 * @param file The template file to load.
+	 * @param vars The array of variables to load.  These variables are loaded via string search & replace.
+	 */
+	public function javascriptTemplate($file, $vars, $uniquenessID = null) {
+		$script = file_get_contents(Director::getAbsFile($file));
+		$search = array();
+		$replace = array();
+
+		if($vars) foreach($vars as $k => $v) {
+			$search[] = '$' . $k;
+			$replace[] = str_replace("\\'","'", Convert::raw2js($v));
+		}
+
+		$script = str_replace($search, $replace, $script);
+		$this->customScript($script, $uniquenessID);
+	}
+
+	/**
+	 * Register the given stylesheet file as required.
+	 *
+	 * @param $file String Filenames should be relative to the base, eg, 'framework/javascript/tree/tree.css'
+	 * @param $media String Comma-separated list of media-types (e.g. "screen,projector")
+	 * @see http://www.w3.org/TR/REC-CSS2/media.html
+	 */
+	public function css($file, $media = null) {
+		$this->css[$file] = array(
+			"media" => $media
+		);
+	}
+
+	/**
+	 * @todo Deprecate this method?
+	 */
+	public function get_css() {
+		return array_diff_key($this->css, $this->blocked);
+	}
+
+	/**
+	 * Needed to actively prevent the inclusion of a file,
+	 * e.g. when using your own jQuery version.
+	 * Blocking should only be used as an exception, because
+	 * it is hard to trace back. You can just block items with an
+	 * ID, so make sure you add an unique identifier to customCSS() and customScript().
+	 *
+	 * @param string $fileOrID
+	 */
+	public function block($fileOrID) {
+		$this->blocked[$fileOrID] = $fileOrID;
+	}
+
+	/**
+	 * Clear either a single or all requirements.
+	 * Caution: Clearing single rules works only with customCSS and customScript if you specified a {@uniquenessID}.
+	 *
+	 * @param $file String
+	 */
+	public function clear($fileOrID = null) {
+		if($fileOrID) {
+			foreach(array('javascript','css', 'customScript', 'customCSS', 'customHeadTags') as $type) {
+				if(isset($this->{$type}[$fileOrID])) {
+					$this->disabled[$type][$fileOrID] = $this->{$type}[$fileOrID];
+					unset($this->{$type}[$fileOrID]);
+				}
+			}
+		} else {
+			$this->disabled['javascript'] = $this->javascript;
+			$this->disabled['css'] = $this->css;
+			$this->disabled['customScript'] = $this->customScript;
+			$this->disabled['customCSS'] = $this->customCSS;
+			$this->disabled['customHeadTags'] = $this->customHeadTags;
+
+			$this->javascript = array();
+			$this->css = array();
+			$this->customScript = array();
+			$this->customCSS = array();
+			$this->customHeadTags = array();
+		}
+	}
+
+	/**
+	 * Removes an item from the blocking-list.
+	 * CAUTION: Does not "re-add" any previously blocked elements.
+	 * @param string $fileOrID
+	 */
+	public function unblock($fileOrID) {
+		if(isset($this->blocked[$fileOrID])) unset($this->blocked[$fileOrID]);
+	}
+
+	/**
+	 * Removes all items from the blocking-list.
+	 */
+	public function unblockAll() {
+		$this->blocked = array();
+	}
+
+	/**
+	 * Restore requirements cleared by call to Requirements::clear
+	 */
+	public function restore() {
+		$this->javascript = $this->disabled['javascript'];
+		$this->css = $this->disabled['css'];
+		$this->customScript = $this->disabled['customScript'];
+		$this->customCSS = $this->disabled['customCSS'];
+		$this->customHeadTags = $this->disabled['customHeadTags'];
+	}
+
+	/**
+	 * Update the given HTML content with the appropriate include tags for the registered
+	 * requirements. Needs to receive a valid HTML/XHTML template in the $content parameter,
+	 * including a <head> tag. The requirements will insert before the closing <head> tag automatically.
+	 *
+	 * @todo Calculate $prefix properly
+	 *
+	 * @param string $templateFilePath Absolute path for the *.ss template file
+	 * @param string $content HTML content that has already been parsed from the $templateFilePath
+	 *                        through {@link SSViewer}.
+	 * @return string HTML content thats augumented with the requirements before the closing <head> tag.
+	 */
+	public function includeInHTML($templateFile, $content) {
+		if(
+			(strpos($content, '</head>') !== false || strpos($content, '</head ') !== false)
+			&& ($this->css || $this->javascript || $this->customCSS || $this->customScript || $this->customHeadTags)
+		) {
+			$requirements = '';
+			$jsRequirements = '';
+
+			// Combine files - updates $this->javascript and $this->css
+			$this->processCombinedFiles();
+
+			foreach(array_diff_key($this->javascript, $this->blocked) as $file => $dummy) {
+				$path = Convert::raw2xml($this->pathForFile($file));
+				if($path) {
+					$jsRequirements .= "<script type=\"text/javascript\" src=\"$path\"></script>\n";
+				}
+			}
+
+			// add all inline javascript *after* including external files which
+			// they might rely on
+			if($this->customScript) {
+				foreach(array_diff_key($this->customScript, $this->blocked) as $script) {
+					$jsRequirements .= "<script type=\"text/javascript\">\n//<![CDATA[\n";
+					$jsRequirements .= "$script\n";
+					$jsRequirements .= "\n//]]>\n</script>\n";
+				}
+			}
+
+			foreach(array_diff_key($this->css, $this->blocked) as $file => $params) {
+				$path = Convert::raw2xml($this->pathForFile($file));
+				if($path) {
+					$media = (isset($params['media']) && !empty($params['media']))
+						? " media=\"{$params['media']}\"" : "";
+					$requirements .= "<link rel=\"stylesheet\" type=\"text/css\"{$media} href=\"$path\" />\n";
+				}
+			}
+
+			foreach(array_diff_key($this->customCSS, $this->blocked) as $css) {
+				$requirements .= "<style type=\"text/css\">\n$css\n</style>\n";
+			}
+
+			foreach(array_diff_key($this->customHeadTags, $this->blocked) as $customHeadTag) {
+				$requirements .= "$customHeadTag\n";
+			}
+
+			if (Config::inst()->get('Requirements', 'force_js_to_bottom')) {
+				// Remove all newlines from code to preserve layout
+				$jsRequirements = preg_replace('/>\n*/', '>', $jsRequirements);
+
+				// We put script tags into the body, for performance.
+				// We forcefully put it at the bottom instead of before
+				// the first script-tag occurence
+				$content = preg_replace("/(<\/body[^>]*>)/i", $jsRequirements . "\\1", $content);
+				
+				// Put CSS at the bottom of the head
+				$content = preg_replace("/(<\/head>)/i", $requirements . "\\1", $content);				
+			} elseif(Config::inst()->get('Requirements', 'write_js_to_body')) {
+				// Remove all newlines from code to preserve layout
+				$jsRequirements = preg_replace('/>\n*/', '>', $jsRequirements);
+
+				// We put script tags into the body, for performance.
+				// If your template already has script tags in the body, then we try to put our script
+				// tags just before those. Otherwise, we put it at the bottom.
+				$p2 = stripos($content, '<body');
+				$p1 = stripos($content, '<script', $p2);
+
+				$commentTags = array();
+				$canWriteToBody = ($p1 !== false)
+					&&
+					//check that the script tag is not inside a html comment tag
+					!(
+						preg_match('/.*(?|(<!--)|(-->))/U', $content, $commentTags, 0, $p1)
+						&& 
+						$commentTags[1] == '-->'
+					);
+				if($canWriteToBody) {
+					$content = substr($content,0,$p1) . $jsRequirements . substr($content,$p1);
+				} else {
+					$content = preg_replace("/(<\/body[^>]*>)/i", $jsRequirements . "\\1", $content);
+				}
+
+				// Put CSS at the bottom of the head
+				$content = preg_replace("/(<\/head>)/i", $requirements . "\\1", $content);
+			} else {
+				$content = preg_replace("/(<\/head>)/i", $requirements . "\\1", $content);
+				$content = preg_replace("/(<\/head>)/i", $jsRequirements . "\\1", $content);
+			}
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Attach requirements inclusion to X-Include-JS and X-Include-CSS headers on the HTTP response
+	 */
+	public function includeInResponse(SS_HTTPResponse $response) {
+		$this->processCombinedFiles();
+		$jsRequirements = array();
+		$cssRequirements = array();
+
+		foreach(array_diff_key($this->javascript, $this->blocked) as $file => $dummy) {
+			$path = $this->pathForFile($file);
+			if($path) {
+				$jsRequirements[] = str_replace(',', '%2C', $path);
+			}
+		}
+
+		$response->addHeader('X-Include-JS', implode(',', $jsRequirements));
+
+		foreach(array_diff_key($this->css, $this->blocked) as $file => $params) {
+			$path = $this->pathForFile($file);
+			if($path) {
+				$path = str_replace(',', '%2C', $path);
+				$cssRequirements[] = isset($params['media']) ? "$path:##:$params[media]" : $path;
+			}
+		}
+
+		$response->addHeader('X-Include-CSS', implode(',', $cssRequirements));
+	}
+
+	/**
+	 * Add i18n files from the given javascript directory.  SilverStripe expects that the given directory
+	 * will contain a number of java script files named by language: en_US.js, de_DE.js, etc.
+	 *
+	 * @param String The javascript lang directory, relative to the site root, e.g., 'framework/javascript/lang'
+	 * @param Boolean Return all relative file paths rather than including them in requirements
+	 * @param Boolean Only include language files, not the base libraries
+	 */
+	public function addI18nJavaScript($langDir, $return = false, $langOnly = false) {
+		$files = array();
+		$base = Director::baseFolder() . '/';
+		if(i18n::config()->js_i18n) {
+			// Include i18n.js even if no languages are found.  The fact that
+			// add_i18n_javascript() was called indicates that the methods in
+			// here are needed.
+			if(!$langOnly) $files[] = FRAMEWORK_DIR . '/javascript/i18n.js';
+
+			if(substr($langDir,-1) != '/') $langDir .= '/';
+
+			$candidates = array(
+				'en.js',
+				'en_US.js',
+				i18n::get_lang_from_locale(i18n::default_locale()) . '.js',
+				i18n::default_locale() . '.js',
+				i18n::get_lang_from_locale(i18n::get_locale()) . '.js',
+				i18n::get_locale() . '.js',
+			);
+			foreach($candidates as $candidate) {
+				if(file_exists($base . DIRECTORY_SEPARATOR . $langDir . $candidate)) {
+					$files[] = $langDir . $candidate;
+				}
+			}
+		} else {
+			// Stub i18n implementation for when i18n is disabled.
+			if(!$langOnly) $files[] = FRAMEWORK_DIR . '/javascript/i18nx.js';
+		}
+
+		if($return) {
+			return $files;
+		} else {
+			foreach($files as $file) $this->javascript($file);
+		}
+	}
+
+	/**
+	 * Finds the path for specified file.
+	 *
+	 * @param string $fileOrUrl
+	 * @return string|boolean
+	 */
+	protected function pathForFile($fileOrUrl) {
+		if(preg_match('{^//|http[s]?}', $fileOrUrl)) {
+			return $fileOrUrl;
+		} elseif(Director::fileExists($fileOrUrl)) {
+			$filePath = preg_replace('/\?.*/', '', Director::baseFolder() . '/' . $fileOrUrl);
+			$prefix = Director::baseURL();
+			$mtimesuffix = "";
+			$suffix = '';
+			if(Config::inst()->get('Requirements', 'suffix_requirements')) {
+				$mtimesuffix = "?m=" . filemtime($filePath);
+				$suffix = '&';
+			}
+			if(strpos($fileOrUrl, '?') !== false) {
+				if (strlen($suffix) == 0) {
+					$suffix = '?';
+				}
+				$suffix .= substr($fileOrUrl, strpos($fileOrUrl, '?')+1);
+				$fileOrUrl = substr($fileOrUrl, 0, strpos($fileOrUrl, '?'));
+			} else {
+				$suffix = '';
+			}
+			return "{$prefix}{$fileOrUrl}{$mtimesuffix}{$suffix}";
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Concatenate several css or javascript files into a single dynamically generated
+	 * file (stored in {@link Director::baseFolder()}). This increases performance
+	 * by fewer HTTP requests.
+	 *
+	 * The combined file is regenerated
+	 * based on every file modification time. Optionally a rebuild can be triggered
+	 * by appending ?flush=1 to the URL.
+	 * If all files to be combined are javascript, we use the external JSMin library
+	 * to minify the javascript. This can be controlled by {@link $combine_js_with_jsmin}.
+	 *
+	 * All combined files will have a comment on the start of each concatenated file
+	 * denoting their original position. For easier debugging, we recommend to only
+	 * minify javascript if not in development mode ({@link Director::isDev()}).
+	 *
+	 * CAUTION: You're responsible for ensuring that the load order for combined files
+	 * is retained - otherwise combining javascript files can lead to functional errors
+	 * in the javascript logic, and combining css can lead to wrong styling inheritance.
+	 * Depending on the javascript logic, you also have to ensure that files are not included
+	 * in more than one combine_files() call.
+	 * Best practice is to include every javascript file in exactly *one* combine_files()
+	 * directive to avoid the issues mentioned above - this is enforced by this function.
+	 *
+	 * CAUTION: Combining CSS Files discards any "media" information.
+	 *
+	 * Example for combined JavaScript:
+	 * <code>
+	 * Requirements::combine_files(
+	 *  'foobar.js',
+	 *  array(
+	 * 		'mysite/javascript/foo.js',
+	 * 		'mysite/javascript/bar.js',
+	 * 	)
+	 * );
+	 * </code>
+	 *
+	 * Example for combined CSS:
+	 * <code>
+	 * Requirements::combine_files(
+	 *  'foobar.css',
+	 * 	array(
+	 * 		'mysite/javascript/foo.css',
+	 * 		'mysite/javascript/bar.css',
+	 * 	)
+	 * );
+	 * </code>
+	 *
+	 * @see http://code.google.com/p/jsmin-php/
+	 *
+	 * @todo Should we enforce unique inclusion of files, or leave it to the developer? Can auto-detection cause
+	 *       breaks?
+	 *
+	 * @param string $combinedFileName Filename of the combined file (will be stored in {@link Director::baseFolder()}
+	 *                                 by default)
+	 * @param array $files Array of filenames relative to the webroot
+	 * @param string $media Comma-separated list of media-types (e.g. "screen,projector").
+	 */
+	public function combineFiles($combinedFileName, $files, $media = null) {
+		// duplicate check
+		foreach($this->combine_files as $_combinedFileName => $_files) {
+			$duplicates = array_intersect($_files, $files);
+			if($duplicates && $combinedFileName != $_combinedFileName) {
+				user_error("RequirementsHandler::combineFiles(): Already included files " . implode(',', $duplicates)
+					. " in combined file '{$_combinedFileName}'", E_USER_NOTICE);
+				return false;
+			}
+		}
+		foreach($files as $index=>$file) {
+			if(is_array($file)) {
+				// Either associative array path=>path type=>type or numeric 0=>path 1=>type
+				// Otherwise, assume path is the first item
+				if (isset($file['type']) && in_array($file['type'], array('css', 'javascript', 'js'))) {
+					switch ($file['type']) {
+						case 'css':
+							$this->css($file['path'], $media);
+							break;
+						default:
+							$this->javascript($file['path']);
+							break;
+					}
+					$files[$index] = $file['path'];
+				} elseif (isset($file[1]) && in_array($file[1], array('css', 'javascript', 'js'))) {
+					switch ($file[1]) {
+						case 'css':
+							$this->css($file[0], $media);
+							break;
+						default:
+							$this->javascript($file[0]);
+							break;
+					}
+					$files[$index] = $file[0];
+				} else {
+					$file = array_shift($file);
+				}
+			}
+			if (!is_array($file)) {
+				if(substr($file, -2) == 'js') {
+					$this->javascript($file);
+				} elseif(substr($file, -3) == 'css') {
+					$this->css($file, $media);
+				} else {
+					user_error("RequirementsHandler::combineFiles(): Couldn't guess file type for file '$file', "
+						. "please specify by passing using an array instead.", E_USER_NOTICE);
+				}
+			}
+		}
+		$this->combine_files[$combinedFileName] = $files;
+	}
+
+	/**
+	 * Returns all combined files.
+	 * @return array
+	 */
+	public function getCombineFiles() {
+		return $this->combine_files;
+	}
+
+	/**
+	 * Deletes all dynamically generated combined files from the filesystem.
+	 *
+	 * @param string $combinedFileName If left blank, all combined files are deleted.
+	 */
+	public function deleteCombinedFiles($combinedFileName = null) {
+		$combinedFiles = ($combinedFileName) ? array($combinedFileName => null) : $this->combine_files;
+		$folderName = $this->getCombinedFilesFolder();
+		$combinedFolder = ($folderName) ? Director::baseFolder() . '/' . $folderName : Director::baseFolder();
+		foreach($combinedFiles as $combinedFile => $sourceItems) {
+			$filePath = $combinedFolder . '/' . $combinedFile;
+			if(file_exists($filePath)) {
+				unlink($filePath);
+			}
+		}
+	}
+
+	/**
+	 * Deletes all generated combined files in the configured combined files directory,
+	 * but doesn't delete the directory itself.
+	 */
+	public function deleteAllCombinedFiles() {
+		$combinedFolder = $this->getCombinedFilesFolder();
+		if(!$combinedFolder) return false;
+
+		$path = Director::baseFolder() . '/' . $combinedFolder;
+		if(file_exists($path)) {
+			Filesystem::removeFolder($path, true);
+		}
+	}
+
+	public function clearCombinedFiles() {
+		$this->combine_files = array();
+	}
+
+	/**
+	 * See {@link combine_files()}
+	 */
+	public function processCombinedFiles() {
+		// The class_exists call prevents us from loading SapphireTest.php (slow) just to know that
+		// SapphireTest isn't running :-)
+		if(class_exists('SapphireTest', false)) $runningTest = SapphireTest::is_running_test();
+		else $runningTest = false;
+
+		if(
+			(Director::isDev() && ! $runningTest && ! isset($_REQUEST['combine']))
+			|| ( ! Config::inst()->get('Requirements', 'combined_files_enabled'))
+		) {
+			return;
+		}
+
+		// Make a map of files that could be potentially combined
+		$combinerCheck = array();
+		foreach($this->combine_files as $combinedFile => $sourceItems) {
+			foreach($sourceItems as $sourceItem) {
+				if(isset($combinerCheck[$sourceItem]) && $combinerCheck[$sourceItem] != $combinedFile){
+					user_error("RequirementsHandler::process_combined_files - file '$sourceItem' appears in two " .
+						"combined files:" .	" '{$combinerCheck[$sourceItem]}' and '$combinedFile'", E_USER_WARNING);
+				}
+				$combinerCheck[$sourceItem] = $combinedFile;
+
+			}
+		}
+
+		// Work out the relative URL for the combined files from the base folder
+		$combinedFilesFolder = $this->getCombinedFilesFolder();
+		$combinedFilesFolder = ($combinedFilesFolder) ? $combinedFilesFolder . '/' : '';
+
+		// Figure out which ones apply to this pageview
+		$combinedFiles = array();
+		$newJSRequirements = array();
+		$newCSSRequirements = array();
+		foreach($this->javascript as $file => $dummy) {
+			if(isset($combinerCheck[$file])) {
+				$newJSRequirements[$combinedFilesFolder . $combinerCheck[$file]] = true;
+				$combinedFiles[$combinerCheck[$file]] = true;
+			} else {
+				$newJSRequirements[$file] = true;
+			}
+		}
+
+		foreach($this->css as $file => $params) {
+			if(isset($combinerCheck[$file])) {
+				// Inherit the parameters from the last file in the combine set.
+				$newCSSRequirements[$combinedFilesFolder . $combinerCheck[$file]] = $params;
+				$combinedFiles[$combinerCheck[$file]] = true;
+			} else {
+				$newCSSRequirements[$file] = $params;
+			}
+		}
+
+		// Process the combined files
+		$base = Director::baseFolder() . '/';
+		foreach(array_diff_key($combinedFiles, $this->blocked) as $combinedFile => $dummy) {
+			$fileList = $this->combine_files[$combinedFile];
+			$combinedFilePath = $base . $combinedFilesFolder . '/' . $combinedFile;
+
+
+			// Make the folder if necessary
+			if(!file_exists(dirname($combinedFilePath))) {
+				Filesystem::makeFolder(dirname($combinedFilePath));
+			}
+
+			// If the file isn't writeable, don't even bother trying to make the combined file and return (falls back
+			//  to uncombined).  Complex test because is_writable fails if the file doesn't exist yet.
+			if((file_exists($combinedFilePath) && !is_writable($combinedFilePath))
+				|| (!file_exists($combinedFilePath) && !is_writable(dirname($combinedFilePath)))
+			) {
+				user_error("RequirementsHandler::process_combined_files(): Couldn't create '$combinedFilePath'",
+					E_USER_WARNING);
+				return false;
+			}
+
+			// Determine if we need to build the combined include
+			if(file_exists($combinedFilePath)) {
+				// file exists, check modification date of every contained file
+				$srcLastMod = 0;
+				foreach($fileList as $file) {
+					if(file_exists($base . $file)) {
+						$srcLastMod = max(filemtime($base . $file), $srcLastMod);
+					}
+				}
+				$refresh = $srcLastMod > filemtime($combinedFilePath);
+			} else {
+				// file doesn't exist, or refresh was explicitly required
+				$refresh = true;
+			}
+
+			if(!$refresh) continue;
+
+			$combinedData = "";
+			$failedToMinify = false;
+			foreach(array_diff($fileList, $this->blocked) as $file) {
+				$fileContent = file_get_contents($base . $file);
+				
+				$fileContent = file_get_contents($base . $file);
+				
+				try {
+					$fileContent = $this->minifyFile($file, $fileContent);
+				} catch(Exception $e) {
+					$failedToMinify = true;
+				}
+
+				if (Config::inst()->get('Requirements', 'write_header_comment')) {
+					// write a header comment for each file for easier identification and debugging
+					// also the semicolon between each file is required for jQuery to be combinable properly
+					$combinedData .= "/****** FILE: $file *****/\n";
+				}
+
+				$combinedData .= $fileContent . "\n";
+			}
+
+			$successfulWrite = false;
+			$fh = fopen($combinedFilePath, 'wb');
+			if($fh) {
+				if(fwrite($fh, $combinedData) == strlen($combinedData)) $successfulWrite = true;
+				fclose($fh);
+				unset($fh);
+			}
+
+			if($failedToMinify) {
+				// Failed to minify, use unminified. This warning is raised at the end to allow code execution
+				// to complete in case this warning is caught inside a try-catch block. 
+				user_error('Failed to minify '.$file.', exception: '.$e->getMessage(), E_USER_WARNING);
+			}
+
+			// Unsuccessful write - just include the regular JS files, rather than the combined one
+			if(!$successfulWrite) {
+				user_error("RequirementsHandler::process_combined_files(): Couldn't create '$combinedFilePath'",
+					E_USER_WARNING);
+				continue;
+			}
+		}
+
+		// @todo Alters the original information, which means you can't call this
+		// method repeatedly - it will behave different on the second call!
+		$this->javascript = $newJSRequirements;
+		$this->css = $newCSSRequirements;
+	}
+
+	protected function minifyFile($filename, $content) {
+		// if we have a javascript file and jsmin is enabled, minify the content
+		$isJS = stripos($filename, '.js');
+		if($isJS && Config::inst()->get('Requirements', 'combine_js_with_jsmin')) {
+			require_once('thirdparty/jsmin/jsmin.php');
+
+			increase_time_limit_to();
+			$content = JSMin::minify($content);
+		}
+		$content .= ($isJS ? ';' : '') . "\n";
+		return $content;
+	}
+
+	public function getCustomScripts() {
+		$requirements = "";
+
+		if($this->customScript) {
+			foreach($this->customScript as $script) {
+				$requirements .= "$script\n";
+			}
+		}
+
+		return $requirements;
+	}
+
+	/**
+	 * @see Requirements::themedCSS()
+	 */
+	public function themedCSS($name, $module = null, $media = null) {
+		$theme = SSViewer::get_theme_folder();
+		$project = project();
+		$absbase = BASE_PATH . DIRECTORY_SEPARATOR;
+		$abstheme = $absbase . $theme;
+		$absproject = $absbase . $project;
+		$css = "/css/$name.css";
+		
+		if(file_exists($absproject . $css)) {
+			$this->css($project . $css, $media);
+		} elseif($module && file_exists($abstheme . '_' . $module.$css)) {
+			$this->css($theme . '_' . $module . $css, $media);
+		} elseif(file_exists($abstheme . $css)) {
+			$this->css($theme . $css, $media);
+		} elseif($module) {
+			$this->css($module . $css, $media);
+		}
+	}
+
+	public function debug() {
+		Debug::show($this->javascript);
+		Debug::show($this->css);
+		Debug::show($this->customCSS);
+		Debug::show($this->customScript);
+		Debug::show($this->customHeadTags);
+		Debug::show($this->combine_files);
+	}
+
+}

--- a/view/Requirements_Backend.php
+++ b/view/Requirements_Backend.php
@@ -1,0 +1,149 @@
+<?php
+
+interface Requirements_Backend {
+
+	/**
+	 * Register the given javascript file as required.
+	 * @param string $file
+	 */
+	public function javascript($file);
+
+	/**
+	 * Add the javascript code to the document
+	 * @param string $script The script content (without <script> tags).
+	 * @param int|string $uniquenessID Use this to ensure that pieces of code only get added once.
+	 */
+	public function customScript($script, $uniquenessID = null);
+
+	/**
+	 * Add custom CSS to the <head> section of the document.
+	 * @param string $script CSS as a string (without <style> tags).
+	 * @param int|string $uniquenessID Use this to ensure that pieces of code only get added once.
+	 */
+	public function customCSS($script, $uniquenessID = null);
+
+	/**
+	 * Add the following custom code to the <head> section of the document.
+	 * @param string $html The HTML to be inserted.
+	 * @param int|string $uniquenessID Use this to ensure that pieces of code only get added once.
+	 */
+	public function insertHeadTags($html, $uniquenessID = null);
+
+	/**
+	 * Load the given javascript template with the page.
+	 * @param string $file The template file to load.
+	 * @param array $vars The array of variables to load. These variables are loaded via string search & replace.
+	 * @param int|string $uniquenessID Use this to ensure that pieces of code only get added once.
+	 */
+	public function javascriptTemplate($file, $vars, $uniquenessID = null);
+
+	/**
+	 * Register the given stylesheet file as required.
+	 * @param string $file The CSS file to load.
+	 * @param string $media Comma-separated list of media-types (e.g. "screen,projector").
+	 */
+	public function css($file, $media = null);
+
+	/**
+	 * Registers the given themeable stylesheet as required.
+	 * @param string $name The name of the file - e.g. "/css/File.css" would have the name "File".
+	 * @param string $module The module to fall back to if the css file does not exist in the current theme.
+	 * @param string $media Comma-separated list of media-types (e.g. "screen,projector").
+	 */
+	public function themedCSS($name, $module = null, $media = null);
+
+	/**
+	 * Clear either a single or all requirements.
+	 * @param string $file If given, only this requirement will be cleared.
+	 */
+	public function clear($fileOrID = null);
+
+	/**
+	 * Prevent inclusion of a previously registered requirement
+	 * @param string $fileOrID The filename (or unique ID) of the file to be blocked.
+	 */
+	public function block($fileOrID);
+
+	/**
+	 * Removes an item from the blocking-list.
+	 * @param string $fileOrID The filename (or unique ID) of the file to be unblocked.
+	 */
+	public function unblock($fileOrID);
+
+	/**
+	 * Removes all items from the blocking-list.
+	 */
+	public function unblockAll();
+
+	/**
+	 * Restore requirements cleared by call to Requirements::clear
+	 */
+	public function restore();
+
+	/**
+	 * Update the given HTML content with the appropriate include tags for the registered
+	 * requirements.
+	 * @param string $templateFilePath Absolute path for the *.ss template file
+	 * @param string $content HTML content that has already been parsed from the $templateFilePath
+	 *                        through {@link SSViewer}.
+	 * @return string HTML content that's augumented with the requirements.
+	 */
+	public function includeInHTML($templateFile, $content);
+
+	/**
+	 * Attach requirements the HTTP response.
+	 * @param SS_HTTPResponse $response
+	 */
+	public function includeInResponse(SS_HTTPResponse $response);
+
+	/**
+	 * Add i18n files from the given javascript directory.
+	 * @param string $langDir The javascript lang directory
+	 * @param boolean $return Return all files rather than including them in requirements.
+	 * @param boolean $langOnly Only include language files, not the base libraries.
+	 * @return array|void Will return an array of files if the $return parameter is truthy.
+	 */
+	public function addI18nJavaScript($langDir, $return = false, $langOnly = false);
+
+	/**
+	 * Concatenate several css or javascript files into a single dynamically generated file.
+	 * @param string $combinedFileName The filename of the file to save the generated content as.
+	 * @param array $files An array of files to be combined.
+	 * @param string $media Comma-separated list of media-types (e.g. "screen,projector").
+	 */
+	public function combineFiles($combinedFileName, $files, $media = null);
+
+	/**
+	 * Returns all combined files.
+	 * @return array
+	 */
+	public function getCombineFiles();
+
+	/**
+	 * Deletes one or all dynamically generated combined files from the filesystem.
+	 * @param string $combinedFileName If left blank, all combined files are deleted.
+	 */
+	public function deleteCombinedFiles($combinedFileName = null);
+
+	/**
+	 * Prevent all combined files from being included.
+	 */
+	public function clearCombinedFiles();
+
+	/**
+	 * Process the list of files to be combined and write the generated files to the filesystem.
+	 */
+	public function processCombinedFiles();
+
+	/**
+	 * Return the content of all custom scripts contatenated.
+	 * @return string
+	 */
+	public function getCustomScripts();
+
+	/**
+	 * Show debug information for the registered requirements.
+	 */
+	public function debug();
+
+}

--- a/view/SSTemplateParser.php
+++ b/view/SSTemplateParser.php
@@ -1864,7 +1864,17 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 
 	function Require_Call(&$res, $sub) {
-		$res['php'] = "Requirements::".$sub['Method']['text'].'('.$sub['CallArguments']['php'].');';
+		$target = $sub['Method']['text'];
+		$methods = Requirements::get_template_global_variables();
+
+		if(array_key_exists($target, $methods)) {
+			$target = $methods[$target];
+		} elseif( ! in_array($target, $methods)) {
+			throw new SSTemplateParseException('Unable to call "Requirements::' . $target . '()". Perhaps the method '
+				. 'doesn’t exist or you have mis-spelled it.', $this);
+		}
+
+		$res['php'] = "Requirements::".$target.'('.$sub['CallArguments']['php'].');';
 	}
 
 	

--- a/view/SSTemplateParser.php.inc
+++ b/view/SSTemplateParser.php.inc
@@ -565,7 +565,17 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	Require: '<%' < 'require' [ Call:(Method:Word "(" < :CallArguments  > ")") > '%>'
 	*/
 	function Require_Call(&$res, $sub) {
-		$res['php'] = "Requirements::".$sub['Method']['text'].'('.$sub['CallArguments']['php'].');';
+		$target = $sub['Method']['text'];
+		$methods = Requirements::get_template_global_variables();
+
+		if(array_key_exists($target, $methods)) {
+			$target = $methods[$target];
+		} elseif( ! in_array($target, $methods)) {
+			throw new SSTemplateParseException('Unable to call "Requirements::' . $target . '()". Perhaps the method '
+				. 'doesn’t exist or you have mis-spelled it.', $this);
+		}
+
+		$res['php'] = "Requirements::".$target.'('.$sub['CallArguments']['php'].');';
 	}
 
 	

--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -1053,7 +1053,7 @@ class SSViewer implements Flushable {
 	 * replacing the special "$Content" and "$Layout" placeholders with their 
 	 * respective subtemplates.
 	 *
-	 * The method injects extra HTML in the header via {@link Requirements::includeInHTML()}.
+	 * The method injects extra HTML in the header via {@link Requirements::include_in_html()}.
 	 * 
 	 * Note: You can call this method indirectly by {@link ViewableData->renderWith()}.
 	 * 
@@ -1104,7 +1104,7 @@ class SSViewer implements Flushable {
 		$output = $this->includeGeneratedTemplate($cacheFile, $item, $arguments, $underlay, $inheritedScope);
 		
 		if($this->includeRequirements) {
-			$output = Requirements::includeInHTML($template, $output);
+			$output = Requirements::include_in_html($template, $output);
 		}
 		
 		array_pop(SSViewer::$topLevel);


### PR DESCRIPTION
- Rename `Requirements_Backend` to `RequirementsHandler` - `Requirements_Backend` is now an interface for the required methods
- Switch to the `Config` API for setting various static properties
- Move `Requirements_Backend->combine_js_with_jsmin` and `write_header_comment` to `Config`, use `__set()` to deprecate them
- Update names of static methods to be more consistent with coding conventions (existing template syntax preserved with `TemplateGlobalProvider`)
- Update unit tests and existing uses of `Requirements` in core

All comments are welcome :)