### PR TITLE
BUG Fix grid field showing search without search component added

### DIFF
--- a/javascript/GridField.js
+++ b/javascript/GridField.js
@@ -40,16 +40,19 @@
 						// multiple relationships via keyboard.
 						if(focusedElName) self.find(':input[name="' + focusedElName + '"]').focus();
 
-						var content;
-						if(ajaxOpts.data[0].filter=="show"){	
-							content = '<span class="non-sortable"></span>';
-							self.addClass('show-filter').find('.filter-header').show();														
-						}else{
-							content = '<button name="showFilter" class="ss-gridfield-button-filter trigger"></button>';
-							self.removeClass('show-filter').find('.filter-header').hide();	
-						}
+						// Update filter 
+						if(self.find('.filter-header').length) {
+							var content;
+							if(ajaxOpts.data[0].filter=="show") {
+								content = '<span class="non-sortable"></span>';
+								self.addClass('show-filter').find('.filter-header').show();														
+							} else {
+								content = '<button name="showFilter" class="ss-gridfield-button-filter trigger"></button>';
+								self.removeClass('show-filter').find('.filter-header').hide();	
+							}
 
-						self.find('.sortable-header th:last').html(content);
+							self.find('.sortable-header th:last').html(content);
+						}
 
 						form.removeClass('loading');
 						if(successCallback) successCallback.apply(this, arguments);


### PR DESCRIPTION
Previously, a gridfield with a GridFieldSortableHeader but NOT a GridFieldFilterHeader would incorrectly replace the header with a search box, breaking the sorting. This should only activate if a search header is available.

ref: CWPBUG-133
