### PR TITLE
Update uploadfield.md

### DIFF
--- a/docs/en/reference/uploadfield.md
+++ b/docs/en/reference/uploadfield.md
@@ -341,6 +341,7 @@ gallery the below code could be used:
 	// In GalleryPage.php
 	class GalleryPage extends Page {}
 	class GalleryPage_Controller extends Page_Controller {
+		private static $allowed_actions = array('Form');
 		public function Form() {
 			$fields = new FieldList(
 				new TextField('Title', 'Title', null, 255),


### PR DESCRIPTION
added:    private static $allowed_actions = array('Form'); to sample code to fix 403 forbidden error: Action 'Form' isn't allowed on class GalleryPage_Controller on clean SS3.1.5 install.
