### PR TITLE
BUG fix listview not working with IE9

### DIFF
--- a/javascript/GridField.js
+++ b/javascript/GridField.js
@@ -23,9 +23,12 @@
 					ajaxOpts.data = window.location.search.replace(/^\?/, '') + '&' + $.param(ajaxOpts.data);
 				}
 				
-				// IE9 and lower do not support html5 history, so they use hash-based history.
-				if(window.location.hash && !(window.history && window.history.pushState)){
-					ajaxOpts.data = window.location.hash.substring(window.location.hash.indexOf('?') + 1) + '&' + $.param(ajaxOpts.data);
+				// For browsers which do not support history.pushState like IE9, ss framework uses hash to track 
+				// the current location for PJAX, so for them we pass the query string stored in the hash instead
+				if(!window.history || !window.history.pushState){
+					if(window.location.hash && window.location.hash.indexOf('?') != -1){
+						ajaxOpts.data = window.location.hash.substring(window.location.hash.indexOf('?') + 1) + '&' + $.param(ajaxOpts.data);
+					}
 				}
 
 				form.addClass('loading');


### PR DESCRIPTION
To reproduce:
1. Using IE9, go to demo.silverstripe.com
2. login
3. go to Pages
4. switch to listview 
5. expand pages to get to one with pagination (e.g. Pages > Features > Listview)
6. go to next page

Expected: you go to the next page
Actual: it jumps you back to the home page

Fix: this fix passes parameters stored in the hash part of the url, which IE9 and below rely on for PJAX.
