### PR TITLE
BUG Fix access to protected Session::current_session()

### DIFF
--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -439,7 +439,6 @@ class VersionedTest extends SapphireTest {
 		$testData->Content = 'After Content';
 		$testData->write();
 
-		$_GET['archiveDate'] = '2009-01-01 19:00:00';
 		Versioned::reading_archived_date('2009-01-01 19:00:00');
 
 		$fetchedData = VersionedTest_DataObject::get()->byId($id);
@@ -568,6 +567,16 @@ class VersionedTest extends SapphireTest {
 			'Check that subsequent requests in the same session remain in Live mode'
 		);
 		
+		// Test choose_site_stage
+		Session::set('readingMode', 'Stage.Stage');
+		Versioned::choose_site_stage();
+		$this->assertEquals('Stage.Stage', Versioned::get_reading_mode());
+		Session::set('readingMode', 'Archive.2014-01-01');
+		Versioned::choose_site_stage();
+		$this->assertEquals('Archive.2014-01-01', Versioned::get_reading_mode());
+		Session::clear('readingMode');
+		Versioned::choose_site_stage();
+		$this->assertEquals('Stage.Live', Versioned::get_reading_mode());
 	}
 
 }


### PR DESCRIPTION
Fortunately this issue would not come up in a clean install, since the framework only ever calls `Versioned::choose_site_stage` with a parameter. Rather than determining the session to pass the state to, we determine the state before conditionally assigning it to the given session, or the static session::set

Fixes #3144
