### PR TITLE
Only use iconv.internal_encoding in PHP<5.6

### DIFF
--- a/thirdparty/Zend/Locale/Format.php
+++ b/thirdparty/Zend/Locale/Format.php
@@ -309,8 +309,13 @@ class Zend_Locale_Format
 
         // Get correct signs for this locale
         $symbols = Zend_Locale_Data::getList($options['locale'], 'symbols');
-        $oenc = iconv_get_encoding('internal_encoding');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if (version_compare(PHP_VERSION, '5.6', '<')) {
+            $oenc = iconv_get_encoding('internal_encoding');
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        } else {
+            $oenc = ini_get('php.internal_encoding');
+            ini_set('php.internal_encoding', 'UTF-8');
+        }
 
         // Get format
         $format = $options['number_format'];
@@ -345,7 +350,11 @@ class Zend_Locale_Format
         }
 
         if (iconv_strpos($format, '0') === false) {
-            iconv_set_encoding('internal_encoding', $oenc);
+            if (version_compare(PHP_VERSION, '5.6', '<')) {
+                iconv_set_encoding('internal_encoding', $oenc);
+            } else {
+                ini_set('php.internal_encoding', $oenc);
+            }
             require_once 'Zend/Locale/Exception.php';
             throw new Zend_Locale_Exception('Wrong format... missing 0');
         }
@@ -471,7 +480,11 @@ class Zend_Locale_Format
             }
         }
 
-        iconv_set_encoding('internal_encoding', $oenc);
+        if (version_compare(PHP_VERSION, '5.6', '<')) {
+            iconv_set_encoding('internal_encoding', $oenc);
+        } else {
+            ini_set('php.internal_encoding', $oenc);
+        }
         return (string) $format;
     }
 
@@ -780,8 +793,13 @@ class Zend_Locale_Format
         $result['date_format'] = $format; // save the format used to normalize $number (convenience)
         $result['locale'] = $options['locale']; // save the locale used to normalize $number (convenience)
 
-        $oenc = iconv_get_encoding('internal_encoding');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if (version_compare(PHP_VERSION, '5.6', '<')) {
+            $oenc = iconv_get_encoding('internal_encoding');
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        } else {
+            $oenc = ini_get('php.internal_encoding');
+            ini_set('php.internal_encoding', 'UTF-8');
+        }
         $day   = iconv_strpos($format, 'd');
         $month = iconv_strpos($format, 'M');
         $year  = iconv_strpos($format, 'y');
@@ -846,7 +864,11 @@ class Zend_Locale_Format
         }
 
         if (empty($parse)) {
-            iconv_set_encoding('internal_encoding', $oenc);
+            if (version_compare(PHP_VERSION, '5.6', '<')) {
+                iconv_set_encoding('internal_encoding', $oenc);
+            } else {
+                ini_set('php.internal_encoding', $oenc);
+            }
             require_once 'Zend/Locale/Exception.php';
             throw new Zend_Locale_Exception("Unknown date format, neither date nor time in '" . $format . "' found");
         }
@@ -866,7 +888,11 @@ class Zend_Locale_Format
         preg_match_all('/\d+/u', $number, $splitted);
 
         if (count($splitted[0]) == 0) {
-            iconv_set_encoding('internal_encoding', $oenc);
+            if (version_compare(PHP_VERSION, '5.6', '<')) {
+                iconv_set_encoding('internal_encoding', $oenc);
+            } else {
+                ini_set('php.internal_encoding', $oenc);
+            }
             require_once 'Zend/Locale/Exception.php';
             throw new Zend_Locale_Exception("No date part in '$date' found.");
         }
@@ -972,7 +998,11 @@ class Zend_Locale_Format
                 if (($position !== false) and ((iconv_strpos($date, $result['day']) === false) or
                                                (isset($result['year']) and (iconv_strpos($date, $result['year']) === false)))) {
                     if ($options['fix_date'] !== true) {
-                        iconv_set_encoding('internal_encoding', $oenc);
+                        if (version_compare(PHP_VERSION, '5.6', '<')) {
+                            iconv_set_encoding('internal_encoding', $oenc);
+                        } else {
+                            ini_set('php.internal_encoding', $oenc);
+                        }
                         require_once 'Zend/Locale/Exception.php';
                         throw new Zend_Locale_Exception("Unable to parse date '$date' using '" . $format
                             . "' (false month, $position, $month)");
@@ -988,7 +1018,11 @@ class Zend_Locale_Format
             if (isset($result['day']) and isset($result['year'])) {
                 if ($result['day'] > 31) {
                     if ($options['fix_date'] !== true) {
-                        iconv_set_encoding('internal_encoding', $oenc);
+                        if (version_compare(PHP_VERSION, '5.6', '<')) {
+                            iconv_set_encoding('internal_encoding', $oenc);
+                        } else {
+                            ini_set('php.internal_encoding', $oenc);
+                        }
                         require_once 'Zend/Locale/Exception.php';
                         throw new Zend_Locale_Exception("Unable to parse date '$date' using '"
                                                       . $format . "' (d <> y)");
@@ -1004,7 +1038,11 @@ class Zend_Locale_Format
             if (isset($result['month']) and isset($result['year'])) {
                 if ($result['month'] > 31) {
                     if ($options['fix_date'] !== true) {
-                        iconv_set_encoding('internal_encoding', $oenc);
+                        if (version_compare(PHP_VERSION, '5.6', '<')) {
+                            iconv_set_encoding('internal_encoding', $oenc);
+                        } else {
+                            ini_set('php.internal_encoding', $oenc);
+                        }
                         require_once 'Zend/Locale/Exception.php';
                         throw new Zend_Locale_Exception("Unable to parse date '$date' using '"
                                                       . $format . "' (M <> y)");
@@ -1020,7 +1058,11 @@ class Zend_Locale_Format
             if (isset($result['month']) and isset($result['day'])) {
                 if ($result['month'] > 12) {
                     if ($options['fix_date'] !== true || $result['month'] > 31) {
-                        iconv_set_encoding('internal_encoding', $oenc);
+                        if (version_compare(PHP_VERSION, '5.6', '<')) {
+                            iconv_set_encoding('internal_encoding', $oenc);
+                        } else {
+                            ini_set('php.internal_encoding', $oenc);
+                        }
                         require_once 'Zend/Locale/Exception.php';
                         throw new Zend_Locale_Exception("Unable to parse date '$date' using '"
                                                       . $format . "' (M <> d)");
@@ -1047,7 +1089,11 @@ class Zend_Locale_Format
             }
         }
 
-        iconv_set_encoding('internal_encoding', $oenc);
+        if (version_compare(PHP_VERSION, '5.6', '<')) {
+            iconv_set_encoding('internal_encoding', $oenc);
+        } else {
+            ini_set('php.internal_encoding', $oenc);
+        }
         return $result;
     }
 


### PR DESCRIPTION
`iconv.internal_encoding` has been deprecated in favour of `php.internal_encoding` in PHP5.6. This updates `Zend_Locale_Format` to the latest version from `ZF1` then changes it to conditionally use `php.internal_encoding` in 5.6.
