### PR TITLE
Update i18n.md

### DIFF
--- a/docs/en/topics/i18n.md
+++ b/docs/en/topics/i18n.md
@@ -91,15 +91,16 @@ In order to add a value, add the following to your `config.yml`:
 
 	:::yml
 	i18n:
-	  common_languages:
+	  common_locales:
 	    de_CGN:
 	      name: German (Cologne)
 	      native: Kölsch
 
-Similarly, to change an existing existing language label, you can overwrite one of these keys:
+Similarly, to change an existing language label, you can overwrite one of these keys:
 	
+	:::yml
 	i18n:
-	  common_languages:
+	  common_locales:
 	    en_NZ:
 	      native: Niu Zillund
 


### PR DESCRIPTION
Corrected a mistake: to make a new locale available (in particular for use with silverstripe/translatable), i18n:common_locales needs to be updated, not i18n:common_languages.
