### PR TITLE
Many many permission fix

### DIFF
--- a/forms/gridfield/GridFieldDeleteAction.php
+++ b/forms/gridfield/GridFieldDeleteAction.php
@@ -105,7 +105,9 @@ class GridFieldDeleteAction implements GridField_ColumnProvider, GridField_Actio
 	 */
 	public function getColumnContent($gridField, $record, $columnName) {
 		if($this->removeRelation) {
-			if(!$record->canEdit()) return;
+			$list = $gridField->getList();
+			if (is_a($list, 'ManyManyList') && !$record->canView()) return;
+			if(!is_a($list, 'ManyManyList') && !$record->canEdit()) return;
 
 			$field = GridField_FormAction::create($gridField, 'UnlinkRelation'.$record->ID, false,
 					"unlinkrelation", array('RecordID' => $record->ID))

--- a/forms/gridfield/GridFieldDeleteAction.php
+++ b/forms/gridfield/GridFieldDeleteAction.php
@@ -151,10 +151,11 @@ class GridFieldDeleteAction implements GridField_ColumnProvider, GridField_Actio
 
 				$item->delete();
 			} else {
-				if(!$item->canEdit()) {
-				throw new ValidationException(
-					_t('GridFieldAction_Delete.EditPermissionsFailure',"No permission to unlink record"),0);
-			}
+				$list = $gridField->getList();
+				if ((is_a($list, 'ManyManyList') && !$item->canView()) || (!is_a($list, 'ManyManyList') && !$item->canEdit()))  {
+					throw new ValidationException(
+						_t('GridFieldAction_Delete.EditPermissionsFailure',"No permission to unlink record"),0);
+				}
 
 				$gridField->getList()->remove($item);
 			}


### PR DESCRIPTION
The use case is 
Object 1: can edit 
Object 2: can't edit, can view 
Object 1 many to many Object 2. 

There is currently no way to specify permission on the relationship object other than creating a new DataObject from scratch, which complicates the relationship, UI etc. 

If you can edit the Object 1 you will get a grid field for Object 2. You will not see the relationships, until you have canView on Object 2. This gives you a AutoCompleteExisting, which allows you to create the relationship between Object 1 and 2. 

However since you can create relationships, you should also be able to delete relationships. 

If you stop users being able to create relationships for Object 2, even though they can view Object 2 (and creating a relationship is not directly editing the model), then we would have to introduce either: 
a) Some way to specify permissions on many-to-many relationship intermediate object 
b) Force people to create a separate model which defines the 'can' permissions 

The second option seems over the top since we can assume the user has permissions to edit at least one end of the relationship and can view the other end. Also means the UI gets more complicated for users. 

John