### PR TITLE
MINOR Uses SS_Cache to cache RestfulService responses instead of filesys...

### DIFF
--- a/tests/api/RestfulServiceTest.php
+++ b/tests/api/RestfulServiceTest.php
@@ -135,38 +135,11 @@ class RestfulServiceTest extends SapphireTest {
 	public function testHttpErrorWithCache() {
 		$subUrl = 'RestfulServiceTest_Controller/httpErrorWithCache';
 		$connection = new RestfulServiceTest_MockErrorService(Director::absoluteBaseURL(), 0);
-		$this->createFakeCachedResponse($connection, $subUrl); 
 		$response = $connection->request($subUrl);
 		$this->assertEquals(400, $response->getStatusCode());
-		$this->assertEquals("Cache response body",$response->getCachedBody());
+		$this->assertEquals(false,$response->getCachedBody());
 		$this->assertContains("<error>HTTP Error</error>", $response->getBody());
 		
-	}
-	
-	/**
-	 * Simulate cached response file for testing error requests that are supposed to have cache files
-	 *
-	 * @todo Generate the cachepath without hardcoding the cache data
-	 */
-	private function createFakeCachedResponse($connection, $subUrl) {
-		$fullUrl = $connection->getAbsoluteRequestURL($subUrl);
-		//these are the defaul values that one would expect in the
-		$basicAuthStringMethod = new ReflectionMethod('RestfulServiceTest_MockErrorService', 'getBasicAuthString');
-		$basicAuthStringMethod->setAccessible(true);
-		$cachePathMethod = new ReflectionMethod('RestfulServiceTest_MockErrorService', 'getCachePath');
-		$cachePathMethod->setAccessible(true);
-		$cache_path = $cachePathMethod->invokeArgs($connection, array(array(
-			$fullUrl,
-			'GET',
-			null,
-			array(),
-			array(),
-			$basicAuthStringMethod->invoke($connection)
-		)));
-
-		$cacheResponse = new RestfulService_Response("Cache response body");
-		$store = serialize($cacheResponse);
-		file_put_contents($cache_path, $store);
 	}
 
 	public function testHttpHeaderParseing() {


### PR DESCRIPTION
...tem

xmlresponse_\* files are saved in the temp folder, are not garbage collected (they can fill up a disk if not actively monitored) and are not in line with the usual approach for managing cached objects in the framework. Using APC or similar other backend is then impossible for these files. This PR porposes to use SS_Cache for these files as well. Also the current code will use the cached object if available if the live call failed, the new code doesn't provide this fallback mechanism, but whether this fallback is a good thing is really debatable, as the returned cached object is stalled, and this error can be part of the spec for the API (ie 404 resource not found anymore)
