### PR TITLE
Lazy Loaded Fields break when initial query runs in default stage

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -167,8 +167,7 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 			$dataQuery->setQueryParam('Versioned.mode', 'archive');
 			$dataQuery->setQueryParam('Versioned.date', $parts[1]);
 
-		} else if($parts[0] == 'Stage' && $parts[1] != $this->defaultStage 
-				&& array_search($parts[1],$this->stages) !== false) {
+		} else if($parts[0] == 'Stage' && array_search($parts[1],$this->stages) !== false) {
 
 			$dataQuery->setQueryParam('Versioned.mode', 'stage');
 			$dataQuery->setQueryParam('Versioned.stage', $parts[1]);

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -590,7 +590,28 @@ class VersionedTest extends SapphireTest {
 		
 		Versioned::set_reading_mode($originalMode);
 	}
-	
+
+	public function testLazyLoadFieldsRetreival() {
+		// Set reading mode to Stage
+		Versioned::reading_stage('Stage');
+
+		// Create object only in reading stage
+		$original = new VersionedTest_Subclass();
+		$original->ExtraField = 'Foo';
+		$original->write();
+
+		// Query for object using base class
+		$query = VersionedTest_DataObject::get()->filter('ID', $original->ID);
+
+		// Set reading mode to Live
+		Versioned::reading_stage('Live');
+
+		$fetched = $query->first();
+		$this->assertTrue($fetched instanceof VersionedTest_Subclass);
+		$this->assertEquals($original->ID, $fetched->ID); // Eager loaded
+		$this->assertEquals($original->ExtraField, $fetched->ExtraField); // Lazy loaded
+	}
+
 	/**
 	 * Tests that reading mode persists between requests
 	 */


### PR DESCRIPTION
This pull request fixes issue #3182 and adds a test case for it.
