### PR TITLE
Conditionally reset MemberLoginForm.force_message

### DIFF
--- a/security/MemberLoginForm.php
+++ b/security/MemberLoginForm.php
@@ -135,14 +135,20 @@ JS;
 	 */
 	protected function getMessageFromSession() {
 		parent::getMessageFromSession();
-		if(($member = Member::currentUser()) && !Session::get('MemberLoginForm.force_message')) {
+
+		$forceMessage = Session::get('MemberLoginForm.force_message');
+		if(($member = Member::currentUser()) && !$forceMessage) {
 			$this->message = _t(
 				'Member.LOGGEDINAS',
 				"You're logged in as {name}.",
 				array('name' => $member->{$this->loggedInAsField})
 			);
 		}
-		Session::set('MemberLoginForm.force_message', false);
+
+		// Reset forced message
+		if($forceMessage) {
+			Session::set('MemberLoginForm.force_message', false);
+		}
 	}
 
 


### PR DESCRIPTION
Avoid starting a session just because the login form is rendered,
which adds overhead to requests and makes them harder to cache.
