### PR TITLE
BUG fix dependency injection stumbling over ViewableData's __isset

### DIFF
--- a/control/injector/Injector.php
+++ b/control/injector/Injector.php
@@ -654,10 +654,10 @@ class Injector {
 		// If the type defines some injections, set them here
 		if ($injections && count($injections)) {
 			foreach ($injections as $property => $value) {
-				// we're checking isset in case it already has a property at this name
+				// we're checking empty in case it already has a property at this name
 				// this doesn't catch privately set things, but they will only be set by a setter method, 
 				// which should be responsible for preventing further setting if it doesn't want it. 
-				if (!isset($object->$property)) {
+				if (empty($object->$property)) {
 					$value = $this->convertServiceProperty($value);
 					$this->setObjectProperty($object, $property, $value);
 				}

--- a/tests/injector/InjectorTest.php
+++ b/tests/injector/InjectorTest.php
@@ -457,6 +457,18 @@ class InjectorTest extends SapphireTest {
 		$si = $injector->get('TestStaticInjections');
 		$this->assertEquals('NewRequirementsBackend', get_class($si->backend));
 	}
+	
+	public function testSetterInjections() {
+		$injector = new Injector();
+		$config = array(
+			'NewRequirementsBackend',
+		);
+
+		$injector->load($config);
+
+		$si = $injector->get('TestSetterInjections');
+		$this->assertEquals('NewRequirementsBackend', get_class($si->getBackend()));
+	}
 
 	public function testCustomObjectCreator() {
 		$injector = new Injector();
@@ -750,6 +762,28 @@ class TestStaticInjections implements TestOnly {
 		'backend' => '%$NewRequirementsBackend'
 	);
 
+}
+
+/**
+ * Make sure DI works with ViewableData's implementation of __isset
+ */
+class TestSetterInjections extends ViewableData implements TestOnly {
+	
+	protected $backend;
+	
+	/** @config */
+	private static $dependencies = array(
+		'backend' => '%$NewRequirementsBackend'
+	);
+	
+	public function getBackend() {
+		return $this->backend;
+	}
+	
+	public function setBackend($backend) {
+		$this->backend = $backend;
+	}
+	
 }
 
 /**


### PR DESCRIPTION
This isn't normally an issue, but injecting objects that extend ViewableData run into issues with it's version of __isset mistakenly reporting null properties as not requiring dependency injection, when in fact they darn well do.
