### PR TITLE
allow themed renderWith even if theme is disabled

### DIFF
--- a/view/ViewableData.php
+++ b/view/ViewableData.php
@@ -320,15 +320,15 @@ class ViewableData extends Object implements IteratorAggregate {
 	 *
 	 * @param string|array|SSViewer $template the template to render into
 	 * @param array $customFields fields to customise() the object with before rendering
-	 * @param boolean $enableTheme - makes sure that the site's theme is used, 
+	 * @param boolean $forceTheme - makes sure that the site's theme is used, 
 	 *   even if is turned off (e.g. when editing in the CMS)
 	 * @return HTMLText
 	 */
-	public function renderWith($template, $customFields = null, $enableTheme = false) {
+	public function renderWith($template, $customFields = null, $forceTheme = false) {
 		if(!is_object($template)) {
 			$template = new SSViewer($template);
 		}
-		if($enableTheme) {
+		if($forceTheme) {
 			$isThemeEnabled = Config::inst()->get('SSViewer', 'theme_enabled', true);
 			if(!$isThemeEnabled) {
 				Config::inst()->update('SSViewer', 'theme_enabled', true);
@@ -340,7 +340,7 @@ class ViewableData extends Object implements IteratorAggregate {
 		}
 		if($template instanceof SSViewer) {
 			$outcome = $template->process($data, is_array($customFields) ? $customFields : null);
-			if($enableTheme && !$isThemeEnabled) {			
+			if($forceTheme && !$isThemeEnabled) {			
 					Config::inst()->update('SSViewer', 'theme_enabled', false);
 			}
 			return $outcome;

--- a/view/ViewableData.php
+++ b/view/ViewableData.php
@@ -320,22 +320,31 @@ class ViewableData extends Object implements IteratorAggregate {
 	 *
 	 * @param string|array|SSViewer $template the template to render into
 	 * @param array $customFields fields to customise() the object with before rendering
+	 * @param boolean $enableTheme - makes sure that the site's theme is used, 
+	 *   even if is turned off (e.g. when editing in the CMS)
 	 * @return HTMLText
 	 */
-	public function renderWith($template, $customFields = null) {
+	public function renderWith($template, $customFields = null, $enableTheme = false) {
 		if(!is_object($template)) {
 			$template = new SSViewer($template);
 		}
-		
+		if($enableTheme) {
+			$isThemeEnabled = Config::inst()->get('SSViewer', 'theme_enabled', true);
+			if(!$isThemeEnabled) {
+				Config::inst()->update('SSViewer', 'theme_enabled', true);
+			}
+		}
 		$data = ($this->customisedObject) ? $this->customisedObject : $this;
-		
 		if($customFields instanceof ViewableData) {
 			$data = $data->customise($customFields);
 		}
 		if($template instanceof SSViewer) {
-			return $template->process($data, is_array($customFields) ? $customFields : null);
+			$outcome = $template->process($data, is_array($customFields) ? $customFields : null);
+			if($enableTheme && !$isThemeEnabled) {			
+					Config::inst()->update('SSViewer', 'theme_enabled', false);
+			}
+			return $outcome;
 		}
-		
 		throw new UnexpectedValueException (
 			"ViewableData::renderWith(): unexpected $template->class object, expected an SSViewer instance"
 		);


### PR DESCRIPTION
```php
$this->renderWith(foo)
```
called while the user is editing the CMS (e.g. when creating a newsletter) often leads to unexpected results: the theme of the site is not being used and therefore no themed templates can be found because the CMS turns of the site's theme (for good reasons).  

This proposed addition to the renderwith method allows devs to render in theme style even if called from within the CMS (of other situations where the theme is disabled).

Maybe it will be better to allow it to work both ways - so that you can choose with or without theme. I am happy to resubmit of course.

Nicolaas