### PR TITLE
NEW Money field now uses eight digits of precision after the decimal.

### DIFF
--- a/model/fieldtypes/Money.php
+++ b/model/fieldtypes/Money.php
@@ -60,7 +60,7 @@ class Money extends DBField implements CompositeDBField {
 	 */
 	private static $composite_db = array(
 		"Currency" => "Varchar(3)",
-		"Amount" => 'Decimal(19,4)'
+		"Amount" => 'Decimal(19,8)'
 	);
 	
 	public function __construct($name = null) {


### PR DESCRIPTION
Digital currencies require at least eight digits of precision after the decimal to be used effectively. The current class only uses four digits of precision, which limits price granularity to approximately $0.06 USD at Bitcoin prices. This change will work well with the existing dependency on the Zend currency library, which allows precision of up to 30 digits. There is no impact on existing unit tests.
