### PR TITLE
Better support for overloading start and destroy methods in Session

### DIFF
--- a/control/Controller.php
+++ b/control/Controller.php
@@ -439,7 +439,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider {
 			if(isset(self::$controller_stack[1])) {
 				$this->session = self::$controller_stack[1]->getSession();
 			} else {
-				$this->session = new Session(null);
+				$this->session = Injector::inst()->create('Session', array());
 			}
 		}
 	}

--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -201,7 +201,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 		DataObject::reset();
 		if(class_exists('SiteTree')) SiteTree::reset();
 		Hierarchy::reset();
-		if(Controller::has_curr()) Controller::curr()->setSession(new Session(array()));
+		if(Controller::has_curr()) Controller::curr()->setSession(Injector::inst()->create('Session', array()));
 		Security::$database_is_ready = null;
 		
 		$fixtureFile = static::get_fixture_file();

--- a/dev/TestSession.php
+++ b/dev/TestSession.php
@@ -23,7 +23,7 @@ class TestSession {
 	private $lastUrl;
 
 	public function __construct() {
-		$this->session = new Session(array());
+		$this->session = Injector::inst()->create('Session', array());
 		$this->controller = new Controller();
 		$this->controller->setSession($this->session);
 		$this->controller->pushCurrent();

--- a/docs/en/topics/testing/creating-a-functional-test.md
+++ b/docs/en/topics/testing/creating-a-functional-test.md
@@ -18,7 +18,7 @@ URLs.  Here is an example from the subsites module:
 		 * Return a session that has a user logged in as an administrator
 		 */
 		public function adminLoggedInSession() {
-			return new Session(array(
+			return Injector::inst()->create('Session', array(
 				'loggedInAs' => $this->idFromFixture('Member', 'admin')
 			));
 		}

--- a/tests/FakeController.php
+++ b/tests/FakeController.php
@@ -5,7 +5,7 @@ class FakeController extends Controller {
 	public function __construct() {
 		parent::__construct();
 
-		$session = new Session(isset($_SESSION) ? $_SESSION : null);
+		$session = Injector::inst()->create('Session', isset($_SESSION) ? $_SESSION : array());
 		$this->setSession($session);
 		
 		$this->pushCurrent();

--- a/tests/api/RestfulServiceTest.php
+++ b/tests/api/RestfulServiceTest.php
@@ -362,7 +362,7 @@ class RestfulServiceTest_MockRestfulService extends RestfulService {
 	public function request($subURL = '', $method = "GET", $data = null, $headers = null, $curlOptions = array()) {
 		
 		if(!$this->session) {
-			$this->session = new Session(array());
+			$this->session = Injector::inst()->create('Session', array());
 		}
 		
 		$url = $this->baseURL . $subURL; // Url for the request

--- a/tests/control/SessionTest.php
+++ b/tests/control/SessionTest.php
@@ -47,7 +47,7 @@ class SessionTest extends SapphireTest {
 	}
 
 	public function testSettingExistingDoesntClear() {
-		$s = new Session(array('something' => array('does' => 'exist')));
+		$s = Injector::inst()->create('Session', array('something' => array('does' => 'exist')));
 
 		$s->inst_set('something.does', 'exist');
 		$result = $s->inst_changedData();
@@ -59,7 +59,7 @@ class SessionTest extends SapphireTest {
 	 * Check that changedData isn't populated with junk when clearing non-existent entries.
 	 */
 	public function testClearElementThatDoesntExist() {
-		$s = new Session(array('something' => array('does' => 'exist')));
+		$s = Injector::inst()->create('Session', array('something' => array('does' => 'exist')));
 
 		$s->inst_clear('something.doesnt.exist');
 		$result = $s->inst_changedData();
@@ -77,7 +77,7 @@ class SessionTest extends SapphireTest {
 	 * Check that changedData is populated with clearing data.
 	 */
 	public function testClearElementThatDoesExist() {
-		$s = new Session(array('something' => array('does' => 'exist')));
+		$s = Injector::inst()->create('Session', array('something' => array('does' => 'exist')));
 
 		$s->inst_clear('something.does');
 		$result = $s->inst_changedData();
@@ -97,7 +97,7 @@ class SessionTest extends SapphireTest {
 		$_SERVER['HTTP_USER_AGENT'] = 'Test Agent';
 
 		// Generate our session
-		$s = new Session(array());
+		$s = Injector::inst()->create('Session', array());
 		$s->inst_set('val', 123);
 		$s->inst_finalize();
 
@@ -105,7 +105,7 @@ class SessionTest extends SapphireTest {
 		$_SERVER['HTTP_USER_AGENT'] = 'Fake Agent';
 		
 		// Verify the new session reset our values
-		$s2 = new Session($s);
+		$s2 = Injector::inst()->create('Session', $s);
 		$this->assertNotEquals($s2->inst_get('val'), 123);
 	}
 }

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -537,7 +537,7 @@ class VersionedTest extends SapphireTest {
 	 * Tests that reading mode persists between requests
 	 */
 	public function testReadingPersistent() {
-		$session = new Session(array());
+		$session = Injector::inst()->create('Session', array());
 		
 		// Set to stage
 		Director::test('/?stage=Stage', null, $session);
@@ -568,7 +568,7 @@ class VersionedTest extends SapphireTest {
 		);
 		
 		// Test that session doesn't redundantly store the default stage if it doesn't need to
-		$session2 = new Session(array());
+		$session2 = Injector::inst()->create('Session', array());
 		Director::test('/', null, $session2);
 		$this->assertEmpty($session2->inst_changedData());
 		Director::test('/?stage=Live', null, $session2);


### PR DESCRIPTION
Move functionality from static start and destroy functions into instance
methods, allowing these to be overloaded. This works the same way as
calling Session::set() which then in turn calls inst_set()

Additionally use Injector to create the default Session instance to
allow the class to be swapped out.
