### PR TITLE
Fix for issue #3186

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -123,12 +123,29 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 	 * 		'Extension2' => array('suffix2', 'suffix3'),
 	 * 	);
 	 * 
+	 * This can also be manipulated by updating the current loaded config
+	 * 
+	 * SiteTree:
+	 *   versionableExtensions:
+	 *     - Extension1:
+	 *       - suffix1
+	 *       - suffix2
+	 *     - Extension2:
+	 *       - suffix1
+	 *       - suffix2
+	 *
+	 * or programaticall:
+	 * 
+	 *  Config::inst()->update($this->owner->class, 'versionableExtensions',
+	 *  array('Extension1' => 'suffix1', 'Extension2' => array('suffix2', 'suffix3')));
+	 * 
+	 *
 	 * Make sure your extension has a static $enabled-property that determines if it is
 	 * processed by Versioned.
 	 *
 	 * @var array
 	 */
-	protected static $versionableExtensions = array('Translatable' => 'lang');
+	private static $versionableExtensions = array('Translatable' => 'lang');
 
 	/**
 	 * Reset static configuration variables to their default values.
@@ -379,11 +396,15 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 
 		// Build a list of suffixes whose tables need versioning
 		$allSuffixes = array();
-		foreach (Versioned::$versionableExtensions as $versionableExtension => $suffixes) {
-			if ($this->owner->hasExtension($versionableExtension)) {
-				$allSuffixes = array_merge($allSuffixes, (array)$suffixes);
-				foreach ((array)$suffixes as $suffix) {
-					$allSuffixes[$suffix] = $versionableExtension;
+		$versionableExtensions = $this->owner->config()->versionableExtensions;
+		if(count($versionableExtensions)){
+		
+			foreach ($versionableExtensions as $versionableExtension => $suffixes) {
+				if ($this->owner->hasExtension($versionableExtension)) {
+					$allSuffixes = array_merge($allSuffixes, (array)$suffixes);
+					foreach ((array)$suffixes as $suffix) {
+						$allSuffixes[$suffix] = $versionableExtension;
+					}
 				}
 			}
 		}
@@ -715,12 +736,16 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 	 * @return string
 	 */
 	public function extendWithSuffix($table) {
-		foreach (Versioned::$versionableExtensions as $versionableExtension => $suffixes) {
-			if ($this->owner->hasExtension($versionableExtension)) {
-				$ext = $this->owner->getExtensionInstance($versionableExtension);
-				$ext->setOwner($this->owner);
-				$table = $ext->extendWithSuffix($table);
-				$ext->clearOwner();
+		$versionableExtensions = $this->owner->config()->versionableExtensions;
+		
+		if(count($versionableExtensions)){
+			foreach ($versionableExtensions as $versionableExtension => $suffixes) {
+				if ($this->owner->hasExtension($versionableExtension)) {
+					$ext = $this->owner->getExtensionInstance($versionableExtension);
+					$ext->setOwner($this->owner);
+					$table = $ext->extendWithSuffix($table);
+					$ext->clearOwner();
+				}
 			}
 		}
 

--- a/tests/model/VersionableExtensionsFixtures.yml
+++ b/tests/model/VersionableExtensionsFixtures.yml
@@ -1,0 +1,3 @@
+VersionableExtensionsTest_DataObject:
+  object:
+    Title: "Test"

--- a/tests/model/VersionableExtensionsTest.php
+++ b/tests/model/VersionableExtensionsTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @package framework
+ * @subpackage tests
+ */
+
+
+
+
+class VersionableExtensionsTest extends SapphireTest
+{
+	protected static $fixture_file = 'VersionableExtensionsFixtures.yml';
+
+	protected $requiredExtensions = array(
+		'SiteTree'  => array('Versioned'),
+	);
+	
+	protected $extraDataObjects = array(
+		'VersionableExtensionsTest_DataObject',
+	);
+
+
+	public function setUpOnce()
+	{
+		Config::nest();
+
+		VersionableExtensionsTest_DataObject::add_extension('Versioned');
+		VersionableExtensionsTest_DataObject::add_extension('VersionableExtensionsTest_Extension');
+		
+		$cfg = Config::inst();
+		
+		$cfg->update('VersionableExtensionsTest_DataObject', 'versionableExtensions', array(
+			'VersionableExtensionsTest_Extension' => array(
+				'test1',
+				'test2',
+				'test3'
+			)
+		));
+
+		parent::setUpOnce();
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+	public function testTablesAreCreated()
+	{
+		$tables = DB::tableList();		
+		$check = array(
+			'versionableextensionstest_dataobject_test1_live', 'versionableextensionstest_dataobject_test2_live', 'versionableextensionstest_dataobject_test3_live',
+			'versionableextensionstest_dataobject_test1_versions', 'versionableextensionstest_dataobject_test2_versions', 'versionableextensionstest_dataobject_test3_versions'
+		);
+
+		// Check that the right tables exist
+		foreach ($check as $tableName) {
+			$this->assertArrayHasKey($tableName, $tables);
+		}
+
+	}
+
+}
+
+class VersionableExtensionsTest_DataObject extends DataObject implements TestOnly {
+
+	private static $db = array(
+		'Title' => 'Varchar'
+	);
+	
+}
+
+
+class VersionableExtensionsTest_Extension extends DataExtension implements TestOnly {
+
+
+	public function isVersionedTable($table){
+		return true;
+	}
+
+
+	/**
+	 * fieldsInExtraTables function.
+	 * 
+	 * @access public
+	 * @param mixed $suffix
+	 * @return array
+	 */
+	public function fieldsInExtraTables($suffix){
+		$fields = array();
+		//$fields['db'] = DataObject::database_fields($this->owner->class);
+		$fields['indexes'] = $this->owner->databaseIndexes();
+
+		$fields['db'] = array_merge(
+			DataObject::database_fields($this->owner->class)
+		);
+		
+		return $fields;
+	}	
+}


### PR DESCRIPTION
Allow Versioned::$versionableExtensions to be manipulated with
Config::inst()->update() or from setting the values in a yml config
file. Also included a test that can be run at
/dev/tests/VersionableExtensionsTest
