### PR TITLE
Fix for issue #3186

### DIFF
--- a/tests/model/VersionableExtensionsFixtures.yml
+++ b/tests/model/VersionableExtensionsFixtures.yml
@@ -1,0 +1,3 @@
+VersionableExtensionsTest_DataObject:
+  object:
+    Title: "Test"

--- a/tests/model/VersionableExtensionsTest.php
+++ b/tests/model/VersionableExtensionsTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @package framework
+ * @subpackage tests
+ */
+
+class VersionableExtensionsTest extends SapphireTest
+{
+	protected static $fixture_file = 'VersionableExtensionsFixtures.yml';
+
+	protected $requiredExtensions = array(
+		'VersionableExtensionsTest_Extension'  => array('Versioned'),
+	);
+	
+	protected $extraDataObjects = array(
+		'VersionableExtensionsTest_DataObject',
+	);
+
+
+	public function setUpOnce()
+	{
+		Config::nest();
+
+		VersionableExtensionsTest_DataObject::add_extension('Versioned');
+		VersionableExtensionsTest_DataObject::add_extension('VersionableExtensionsTest_Extension');
+		
+		$cfg = Config::inst();
+		
+		$cfg->update('VersionableExtensionsTest_DataObject', 'versionableExtensions', array(
+			'VersionableExtensionsTest_Extension' => array(
+				'test1',
+				'test2',
+				'test3'
+			)
+		));
+
+		parent::setUpOnce();
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+	public function testTablesAreCreated()
+	{
+		$tables = DB::tableList();		
+		$check = array(
+			'versionableextensionstest_dataobject_test1_live', 'versionableextensionstest_dataobject_test2_live', 'versionableextensionstest_dataobject_test3_live',
+			'versionableextensionstest_dataobject_test1_versions', 'versionableextensionstest_dataobject_test2_versions', 'versionableextensionstest_dataobject_test3_versions'
+		);
+
+		// Check that the right tables exist
+		foreach ($check as $tableName) {
+			$this->assertArrayHasKey($tableName, $tables);
+		}
+
+	}
+
+}
+
+class VersionableExtensionsTest_DataObject extends DataObject implements TestOnly {
+
+	private static $db = array(
+		'Title' => 'Varchar'
+	);
+	
+}
+
+
+class VersionableExtensionsTest_Extension extends DataExtension implements TestOnly {
+
+
+	public function isVersionedTable($table){
+		return true;
+	}
+
+
+	/**
+	 * fieldsInExtraTables function.
+	 * 
+	 * @access public
+	 * @param mixed $suffix
+	 * @return array
+	 */
+	public function fieldsInExtraTables($suffix){
+		$fields = array();
+		//$fields['db'] = DataObject::database_fields($this->owner->class);
+		$fields['indexes'] = $this->owner->databaseIndexes();
+
+		$fields['db'] = array_merge(
+			DataObject::database_fields($this->owner->class)
+		);
+		
+		return $fields;
+	}	
+}


### PR DESCRIPTION
Allow Versioned::$versionableExtensions to be manipulated with
Config::inst()->update() or from setting the values in a yml config
file. Also included a test that can be run at
/dev/tests/VersionableExtensionsTest
