### PR TITLE
FIX Image::deleteFormattedImages() has too restricted regex

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -576,7 +576,7 @@ class Image extends File {
 		}
 		// All generate functions may appear any number of times in the image cache name.
 		$generateFuncs = implode('|', $generateFuncs);
-		$pattern = "/^(({$generateFuncs})\d+\-)+" . preg_quote($this->Name) . "$/i";
+		$pattern = "/^(({$generateFuncs})\d*\-)+" . preg_quote($this->Name) . "$/i";
 
 		foreach($cachedFiles as $cfile) {
 			if(preg_match($pattern, $cfile)) {


### PR DESCRIPTION
Image resamples could also include names without a size argument, such as CMSThumbnail-fan-how-we-work. This makes the digits after the function name optional.
