### PR TITLE
Added onBeforeRender to HtmlEditorField Field()

### DIFF
--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -91,7 +91,7 @@ class HtmlEditorField extends TextareaField {
 
 		$properties['Value'] = htmlentities($value->getContent(), ENT_COMPAT, 'UTF-8');
 		$obj = $this->customise($properties);
-
+		$this->extend('onBeforeRender', $this);
 		return $obj->renderWith($this->getTemplates());
 	}
 


### PR DESCRIPTION
I had a need to use onBeforeRender on a DataExtension of HtmlEditorField and noticed it wasn't there. I wasn't sure if this was intentional, or just never added.
