### PR TITLE
BUG: Fix incorrect common_languages config

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -704,7 +704,8 @@ class i18n extends Object implements TemplateGlobalProvider {
 			'native' => 'Hrvatski'
 		),
 		'zh' => array(
-			'name' => 'Chinese','中国的'
+			'name' => 'Chinese',
+			'native' => '&#20013;&#22269;&#30340;'
 		),
 		'cs' => array(
 			'name' => 'Czech', 


### PR DESCRIPTION
The missing 'native' tag broke the encoding.

Pasting below to demonstrate how it would appear in normal view.

&#20013;&#22269;&#30340;
