### PR TITLE
Updated HtmlEditorField Field()

### DIFF
--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -90,9 +90,8 @@ class HtmlEditorField extends TextareaField {
 		}
 
 		$properties['Value'] = htmlentities($value->getContent(), ENT_COMPAT, 'UTF-8');
-		$obj = $this->customise($properties);
 
-		return $obj->renderWith($this->getTemplates());
+		return parent::Field($properties);
 	}
 
 	public function getAttributes() {


### PR DESCRIPTION
I had a need to use onBeforeRender on a DataExtension of
HtmlEditorField and noticed it wasn't there. Added return
parent::Field($properties) use FormField::Field which utilizes
onBeforeRender.
