### PR TITLE
Update templates.md

### DIFF
--- a/docs/en/reference/templates.md
+++ b/docs/en/reference/templates.md
@@ -641,9 +641,9 @@ default if it exists and there is no action in the url parameters.
 		}
 	}
 
-## Fragment Link rewriting
+## Anchor Link rewriting
 
-Fragment links are links with a "#" in them.  A frequent use-case is to use fragment links to point to different
+Anchor links are links with a "#" in them.  A frequent use-case is to use anchor links to point to different
 sections of the current page.  For example, we might have this in our template.
 
 For, example, we might have this on http://www.example.com/my-long-page/
@@ -659,8 +659,8 @@ So far, so obvious.  However, things get tricky because of we have set our `<bas
 site.  So, when you click the first link you will be sent to http://www.example.com/#section1 instead of
 http://www.example.com/my-long-page/#section1
 
-In order to prevent this situation, the SSViewer template renderer will automatically rewrite any fragment link that
-doesn't specify a URL before the fragment, prefixing the URL of the current page.  For our example above, the following
+In order to prevent this situation, the SSViewer template renderer will automatically rewrite any anchor link that
+doesn't specify a URL before the anchor, prefixing the URL of the current page.  For our example above, the following
 would be created:
 
 	:::ss
@@ -670,8 +670,8 @@ would be created:
 	</ul>
 
 
-There are cases where this can be unhelpful.  HTML fragments created from Ajax responses are the most common.  In these
-situations, you can disable fragment link rewriting by setting the
+There are cases where this can be unhelpful.  HTML anchors created from Ajax responses are the most common.  In these
+situations, you can disable anchor link rewriting by setting the
 `SSViewer.rewrite_hash_links` configuration value to `false`.
 
 ### More Advanced Controls


### PR DESCRIPTION
Changed Fragment links to Anchor links, however it's is slighty confusing what the right name for the thing is.
According to w3.org: "Some URIs refer to a location within a resource. This kind of URI ends with "#" followed by an anchor identifier (called the fragment identifier)." - http://www.w3.org/TR/html401/intro/intro.html#fragment-uri

After doing some research in the most common used name for the #some-link identifier I came to the conclusion that most of the time (about 70% on StackOverflow/BlogArticles/Interwebz) Anchor-link was the term used to describe the identifier. Imho, Anchor is the prefered term for the identifier.

Is it acceptable to change fragment to anchor, since it seems more used?
