### PR TITLE
FEATURE allow force resampling on images

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -65,6 +65,12 @@ class Image extends File {
 	 * @var int The height of an image preview in the Asset section.
 	 */
 	private static $asset_preview_height = 200;
+
+	/**
+	 * @config
+	 * @var bool Force all images to resample in all cases
+	 */
+	private static $force_resample = false;
 	
 	public static function set_backend($backend) {
 		self::$backend = $backend;
@@ -214,10 +220,10 @@ class Image extends File {
 		$heightRatio = $height / $this->height;
 		if( $widthRatio < $heightRatio ) {
 			// Target is higher aspect ratio than image, so check width
-			if($this->isWidth($width)) return $this;
+			if($this->isWidth($width) && !Config::inst()->get('Image', 'force_resample')) return $this;
 		} else {
 			// Target is wider aspect ratio than image, so check height
-			if($this->isHeight($height)) return $this;
+			if($this->isHeight($height) && !Config::inst()->get('Image', 'force_resample')) return $this;
 		}
 		
 		// Item must be regenerated
@@ -244,7 +250,7 @@ class Image extends File {
 	 * @return Image
 	 */
 	public function SetWidth($width) {
-		return $this->isWidth($width) 
+		return $this->isWidth($width) && !Config::inst()->get('Image', 'force_resample')
 			? $this
 			: $this->getFormattedImage('SetWidth', $width);
 	}
@@ -267,7 +273,7 @@ class Image extends File {
 	 * @return Image
 	 */
 	public function SetHeight($height) {
-		return $this->isHeight($height)
+		return $this->isHeight($height) && !Config::inst()->get('Image', 'force_resample')
 			? $this 
 			: $this->getFormattedImage('SetHeight', $height);
 	}
@@ -292,7 +298,7 @@ class Image extends File {
 	 * @return Image
 	 */
 	public function SetSize($width, $height) {
-		return $this->isSize($width, $height)
+		return $this->isSize($width, $height) && !Config::inst()->get('Image', 'force_resample')
 			? $this 
 			: $this->getFormattedImage('SetSize', $width, $height);
 	}
@@ -354,7 +360,7 @@ class Image extends File {
 	 * @return Image
 	 */
 	public function PaddedImage($width, $height, $backgroundColor='FFFFFF') {
-		return $this->isSize($width, $height)
+		return $this->isSize($width, $height) && !Config::inst()->get('Image', 'force_resample')
 			? $this 
 			: $this->getFormattedImage('PaddedImage', $width, $height, $backgroundColor);
 	}
@@ -490,7 +496,7 @@ class Image extends File {
 	 * @return Image
 	 */
 	public function ResizedImage($width, $height) {
-		return $this->isSize($width, $height)
+		return $this->isSize($width, $height) && !Config::inst()->get('Image', 'force_resample')
 			? $this 
 			: $this->getFormattedImage('ResizedImage', $width, $height);
 	}
@@ -522,7 +528,7 @@ class Image extends File {
 	 * @return Image
 	 */
 	public function CroppedImage($width, $height) {
-		return $this->isSize($width, $height)
+		return $this->isSize($width, $height) && !Config::inst()->get('Image', 'force_resample')
 			? $this 
 			: $this->getFormattedImage('CroppedImage', $width, $height);
 	}

--- a/tests/model/ImageTest.php
+++ b/tests/model/ImageTest.php
@@ -109,7 +109,7 @@ class ImageTest extends SapphireTest {
 		$image = $this->objFromFixture('Image', 'imageWithoutTitle');
 		$this->assertTrue($image->isSize(300, 300));
 		
-		// Set width to 50 pixels
+		// Set width to 300 pixels
 		$imageSetWidth = $image->SetWidth(300);
 		$this->assertEquals($imageSetWidth->getWidth(), 300);
 		$this->assertEquals($image->Filename, $imageSetWidth->Filename);
@@ -149,6 +149,61 @@ class ImageTest extends SapphireTest {
 		$imageSetRatioSize = $image->SetRatioSize(300, 300);
 		$this->assertTrue($imageSetRatioSize->isSize(300, 300));
 		$this->assertEquals($image->Filename, $imageSetRatioSize->Filename);
+	}
+
+	/**
+	 * Tests that image manipulations that do not affect the resulting dimensions
+	 * of the output image resample the file when force_resample is set to true.
+	 */
+	public function testForceResample() {
+
+		$image = $this->objFromFixture('Image', 'imageWithoutTitle');
+		$this->assertTrue($image->isSize(300, 300));
+
+		$origForceResample = Config::inst()->get('Image', 'force_resample');
+		Config::inst()->update('Image', 'force_resample', true);
+
+		// Set width to 300 pixels
+		$imageSetWidth = $image->SetWidth(300);
+		$this->assertEquals($imageSetWidth->getWidth(), 300);
+		$this->assertNotEquals($image->Filename, $imageSetWidth->Filename);
+
+		// Set height to 300 pixels
+		$imageSetHeight = $image->SetHeight(300);
+		$this->assertEquals($imageSetHeight->getHeight(), 300);
+		$this->assertNotEquals($image->Filename, $imageSetHeight->Filename);
+
+		// Crop image to 300 x 300
+		$imageCropped = $image->CroppedImage(300, 300);
+		$this->assertTrue($imageCropped->isSize(300, 300));
+		$this->assertNotEquals($image->Filename, $imageCropped->Filename);
+
+		// Resize (padded) to 300 x 300
+		$imageSized = $image->SetSize(300, 300);
+		$this->assertTrue($imageSized->isSize(300, 300));
+		$this->assertNotEquals($image->Filename, $imageSized->Filename);
+
+		// Padded image 300 x 300 (same as above)
+		$imagePadded = $image->PaddedImage(300, 300);
+		$this->assertTrue($imagePadded->isSize(300, 300));
+		$this->assertNotEquals($image->Filename, $imagePadded->Filename);
+
+		// Resized (stretched) to 300 x 300
+		$imageStretched = $image->ResizedImage(300, 300);
+		$this->assertTrue($imageStretched->isSize(300, 300));
+		$this->assertNotEquals($image->Filename, $imageStretched->Filename);
+
+		// SetRatioSize (various options)
+		$imageSetRatioSize = $image->SetRatioSize(300, 600);
+		$this->assertTrue($imageSetRatioSize->isSize(300, 300));
+		$this->assertNotEquals($image->Filename, $imageSetRatioSize->Filename);
+		$imageSetRatioSize = $image->SetRatioSize(600, 300);
+		$this->assertTrue($imageSetRatioSize->isSize(300, 300));
+		$this->assertNotEquals($image->Filename, $imageSetRatioSize->Filename);
+		$imageSetRatioSize = $image->SetRatioSize(300, 300);
+		$this->assertTrue($imageSetRatioSize->isSize(300, 300));
+		$this->assertNotEquals($image->Filename, $imageSetRatioSize->Filename);
+		Config::inst()->update('Image', 'force_resample', $origForceResample);
 	}
 	
 	public function testImageResize() {


### PR DESCRIPTION
This change allows users to set a flag via configuration to force resampling of images even if they are the correct dimensions.
