### PR TITLE
API Debug::dump in CLI no longer generates HTML. Uses colours.

### DIFF
--- a/dev/CliDebugView.php
+++ b/dev/CliDebugView.php
@@ -41,7 +41,7 @@ class CliDebugView extends DebugView {
 		foreach($lines as $offset => $line) {
 			echo ($offset == $errline) ? "* " : "  ";
 			echo str_pad("$offset:",5);
-			echo wordwrap($line, 100, "\n       ");
+			echo wordwrap($line, self::config()->columns, "\n       ");
 		}
 		echo "\n";
 	}
@@ -61,11 +61,25 @@ class CliDebugView extends DebugView {
 	 * @param string $title
 	 */
 	public function writeInfo($title, $subtitle, $description=false) {
-		echo wordwrap(strtoupper($title),100) . "\n";
-		echo wordwrap($subtitle,100) . "\n";
-		echo str_repeat('-',min(100,max(strlen($title),strlen($subtitle)))) . "\n";
-		echo wordwrap($description,100) . "\n\n";
+		echo wordwrap(strtoupper($title),self::config()->columns) . "\n";
+		echo wordwrap($subtitle,self::config()->columns) . "\n";
+		echo str_repeat('-',min(self::config()->columns,max(strlen($title),strlen($subtitle)))) . "\n";
+		echo wordwrap($description,self::config()->columns) . "\n\n";
 	}
 	
+	public function writeVariable($val, $caller) {
+		echo PHP_EOL;
+		echo SS_Cli::text(str_repeat('=', self::config()->columns), 'green');
+		echo PHP_EOL;
+		echo SS_Cli::text($this->formatCaller($caller), 'blue', null, true);
+		echo PHP_EOL.PHP_EOL;
+		if (is_string($val)) {
+			print_r(wordwrap($val, self::config()->columns));
+		} else {
+			print_r($val);
+		}
+		echo PHP_EOL;
+		echo SS_Cli::text(str_repeat('=', self::config()->columns), 'green');
+		echo PHP_EOL;
+	}
 }
-

--- a/dev/Debug.php
+++ b/dev/Debug.php
@@ -71,6 +71,11 @@ class Debug {
 
 	}
 
+	/**
+	 * Returns the caller for a specific method
+	 * 
+	 * @return array
+	 */
 	public static function caller() {
 		$bt = debug_backtrace();
 		$caller = $bt[2];
@@ -102,12 +107,7 @@ class Debug {
 	 * @param mixed $val
 	 */
 	public static function dump($val) {
-		echo '<pre style="background-color:#ccc;padding:5px;font-size:14px;line-height:18px;">';
-		$caller = Debug::caller();
-		echo "<span style=\"font-size: 12px;color:#666;\">" . basename($caller['file']) . ":$caller[line] - </span>\n";
-		if (is_string($val)) print_r(wordwrap($val, 100));
-		else print_r($val);
-		echo '</pre>';
+		self::create_debug_view()->writeVariable($val, self::caller());
 	}
 
 	/**
@@ -366,13 +366,17 @@ class Debug {
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Create an instance of an appropriate DebugView object.
+	 * 
+	 * @return DebugView
 	 */
 	public static function create_debug_view() {
-		if(Director::is_cli() || Director::is_ajax()) return new CliDebugView();
-		else return new DebugView();
+		$service = Director::is_cli() || Director::is_ajax()
+			? 'CliDebugView'
+			: 'DebugView';
+		return Injector::inst()->get($service);
 	}
 
 	/**

--- a/dev/DebugView.php
+++ b/dev/DebugView.php
@@ -12,6 +12,14 @@
  * @subpackage dev
  */
 class DebugView extends Object {
+	
+	/**
+	 * Column size to wrap long strings to
+	 *
+	 * @var int
+	 * @config
+	 */
+	private static $columns = 100;
 
 	protected static $error_types = array(
 		E_USER_ERROR => array(
@@ -180,5 +188,32 @@ class DebugView extends Object {
 	public function writeParagraph($text) {
 		echo '<p class="info">' . $text . '</p>';
 	}
+	
+	/**
+	 * Formats the caller of a method
+	 * 
+	 * @param array $caller
+	 * @return string
+	 */
+	protected function formatCaller($caller) {
+		$return = basename($caller['file']) . ":" . $caller['line'];
+		if(!empty($caller['class']) && !empty($caller['function'])) {
+			$return .= " - {$caller['class']}::{$caller['function']}()";
+		}
+		return $return;
+	}
+	
+	/**
+	 * Outputs a variable in a user presentable way
+	 * 
+	 * @param object $val
+	 * @param array $caller Caller information
+	 */
+	public function writeVariable($val, $caller) {
+		echo '<pre style="background-color:#ccc;padding:5px;font-size:14px;line-height:18px;">';
+		echo "<span style=\"font-size: 12px;color:#666;\">" . $this->formatCaller($caller). " - </span>\n";
+		if (is_string($val)) print_r(wordwrap($val, self::config()->columns));
+		else print_r($val);
+		echo '</pre>';
+	}
 }
-


### PR DESCRIPTION
API Column size is configurable in DebugView

After a long love-hate relationship with Debug::dump I've finally made it pretty in CLI.
