### PR TITLE
BUG Groups can't be listed in TreeDropdownField without SecurityAdmin access

### DIFF
--- a/security/Group.php
+++ b/security/Group.php
@@ -436,22 +436,30 @@ class Group extends DataObject {
 	/**
 	 * Checks for permission-code CMS_ACCESS_SecurityAdmin.
 	 * 
-	 * @param $member Member
+	 * @param Member $member
 	 * @return boolean
 	 */
 	public function canView($member = null) {
-		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) $member = Member::currentUser();
-		
-		// extended access checks
+		if(!$member) {
+			$member = Member::currentUser();
+		}
+
 		$results = $this->extend('canView', $member);
-		if($results && is_array($results)) if(!min($results)) return false;
-		
-		// user needs access to CMS_ACCESS_SecurityAdmin
-		if(Permission::checkMember($member, "CMS_ACCESS_SecurityAdmin")) return true;
-		
-		return false;
+		if($results && is_array($results) && !min($results)) {
+			return false;
+		}
+
+		if(!$member) {
+			return false;
+		}
+
+		return true;
 	}
-	
+
+	/**
+	 * @param Member $member
+	 * @return bool
+	 */
 	public function canDelete($member = null) {
 		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) $member = Member::currentUser();
 		

--- a/tests/security/GroupTest.php
+++ b/tests/security/GroupTest.php
@@ -6,7 +6,18 @@
 class GroupTest extends FunctionalTest {
 
 	protected static $fixture_file = 'GroupTest.yml';
-	
+
+	public function testMemberCanViewFalseByDefault() {
+		$group = new Group();
+		$this->assertFalse($group->canView(), 'Groups are by default not viewable.');
+	}
+
+	public function testMemberCanViewTrueByLoggedInUsers() {
+		$this->logInAs($this->idFromFixture('GroupTest_Member', 'parentgroupuser'));
+		$group = new Group();
+		$this->assertTrue($group->canView(), 'Groups should be viewable by logged in users.');
+	}
+
 	public function testGroupCodeDefaultsToTitle() {
 		$g1 = new Group();
 		$g1->Title = "My Title";


### PR DESCRIPTION
Example use case:
As a content editor I want to be able to select from a list of groups for a specific page so that they can be notified on updates.

Also see https://github.com/silverstripe-australia/advancedworkflow/issues/170