### PR TITLE
BUG GridFieldDeleteAction limited permissions cannot remove relation

### DIFF
--- a/docs/en/changelogs/3.1.6.md
+++ b/docs/en/changelogs/3.1.6.md
@@ -7,3 +7,9 @@
    follows the same process as the use of the 'flush' query string parameter, and will redirect
    requests containing this argument with a token in the querystring.
    Director::isDev, Director::isTest, and Director::isLive no longer have any parameters.
+
+ * GridFieldDeleteAction using the "removeRelation" option will now check the parent record `canEdit()` method
+   for permission, found via `Form->getRecord()` if available.
+   This will not affect most use cases, but if you're relying on `canEdit()` checks for non-ADMIN users,
+   this may not work as you'd expect it to. If a parent cannot be found, it falls back to the old behaviour.
+


### PR DESCRIPTION
GridFieldDeleteAction is checking the record canEdit() method, but
that's not appropriate, as it applies to _editing_ the record, not
unlinking the relation of the parent to the record.

Check if there's a parent and check canEdit() on that instead. If
there's no parent, fallback to record canEdit().
