### PR TITLE
(DO NOT MERGE) API Add FolderDropdownField to allow users to select the folder to upload into

### DIFF
--- a/css/UploadField.css
+++ b/css/UploadField.css
@@ -11,7 +11,7 @@
 Used in side panels and action tabs
 */
 .ss-uploadfield .clear { clear: both; }
-.ss-uploadfield .middleColumn { width: 510px; padding: 0; background: #fff; border: 1px solid #b3b3b3; -webkit-border-radius: 4px; -moz-border-radius: 4px; -ms-border-radius: 4px; -o-border-radius: 4px; border-radius: 4px; background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #efefef), color-stop(10%, #ffffff), color-stop(90%, #ffffff), color-stop(100%, #efefef)); background-image: -webkit-linear-gradient(#efefef, #ffffff 10%, #ffffff 90%, #efefef); background-image: -moz-linear-gradient(#efefef, #ffffff 10%, #ffffff 90%, #efefef); background-image: -o-linear-gradient(#efefef, #ffffff 10%, #ffffff 90%, #efefef); background-image: linear-gradient(#efefef, #ffffff 10%, #ffffff 90%, #efefef); }
+.ss-uploadfield .middleColumn .ss-uploadfield-filearea { width: 510px; padding: 0; background: #fff; border: 1px solid #b3b3b3; -webkit-border-radius: 4px; -moz-border-radius: 4px; -ms-border-radius: 4px; -o-border-radius: 4px; border-radius: 4px; background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #efefef), color-stop(10%, #ffffff), color-stop(90%, #ffffff), color-stop(100%, #efefef)); background-image: -webkit-linear-gradient(#efefef, #ffffff 10%, #ffffff 90%, #efefef); background-image: -moz-linear-gradient(#efefef, #ffffff 10%, #ffffff 90%, #efefef); background-image: -o-linear-gradient(#efefef, #ffffff 10%, #ffffff 90%, #efefef); background-image: linear-gradient(#efefef, #ffffff 10%, #ffffff 90%, #efefef); }
 .ss-uploadfield .ss-uploadfield-item { margin: 0; padding: 15px; overflow: auto; }
 .ss-uploadfield .ss-uploadfield-item .ss-uploadfield-item-preview { height: 60px; line-height: 60px; width: 80px; text-align: center; font-weight: bold; float: left; overflow: hidden; }
 .ss-uploadfield .ss-uploadfield-item .ss-uploadfield-item-preview.ss-uploadfield-dropzone { -webkit-box-shadow: gray 0 0 4px 0 inset; -moz-box-shadow: gray 0 0 4px 0 inset; box-shadow: gray 0 0 4px 0 inset; border: 2px dashed gray; background: #d0d3d5; display: none; margin-right: 15px; }
@@ -54,3 +54,4 @@ Used in side panels and action tabs
 .ss-upload .clear { clear: both; }
 .ss-upload .ss-uploadfield-fromcomputer input { /* since we can't really style the file input, we use this hack to make it as big as the button and hide it */ position: absolute; top: 0; right: 0; margin: 0; opacity: 0; filter: alpha(opacity=0); transform: translate(-300px, 0) scale(4); font-size: 23px; direction: ltr; cursor: pointer; height: 30px; line-height: 30px; }
 .ss-upload .loader { height: 94px; background: transparent url(../admin/images/spinner.gif) no-repeat 50% 50%; }
+.ss-upload.selectupload .FolderSelector label { font-style: italic; }

--- a/css/debug.css
+++ b/css/debug.css
@@ -1,24 +1,35 @@
 body { background: #eee !important; margin: 0; overflow-x: hidden; padding: 0; font-family: Helvetica,Arial,sans-serif; }
+
 .info { margin: 0 0 6px 0; padding: 18px; background-color: #003050; position: relative; line-height: 24px; color: #fff; background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #002137), color-stop(10%, #003050), color-stop(90%, #003050), color-stop(100%, #002137)); background-image: -webkit-linear-gradient(#002137, #003050 10%, #003050 90%, #002137); background-image: -moz-linear-gradient(#002137, #003050 10%, #003050 90%, #002137); background-image: -o-linear-gradient(#002137, #003050 10%, #003050 90%, #002137); background-image: linear-gradient(#002137, #003050 10%, #003050 90%, #002137); z-index: 9999; }
 .info h1 { margin: 0 0 6px 0; padding: 0 32px 0 0; color: #fff; font-size: 24px; text-shadow: 0 1px #002137; line-height: 30px; background: url(../admin/images/logo_small.png) no-repeat right 3px; }
 .info h3 { color: #7da4be; font-size: 16px; line-height: 18px; font-weight: normal; }
 .info p { margin: 0; font-size: 14px; color: #fff; }
 .info a { color: #fff; font-weight: bold; text-decoration: none; }
 .info a:hover, .info a:active { color: #fff; text-decoration: underline; }
+
 .header { margin: 0; border-bottom: 6px solid #ccdef3; height: 23px; background-color: #666673; padding: 4px 0 2px 6px; }
-.content {padding: 6px 12px;}
+
 .trace, .build, .options { padding: 6px 12px; background: #eee !important; position: relative; z-index: 9999; }
 .trace li, .build li, .options li { font-size: 14px; margin: 6px 0; }
+
 a { color: #666; }
 a:hover { color: #222; }
 a:active { color: #111; }
+
 p { margin-bottom: 6px; }
+
 pre { margin-bottom: 20px; background-color: #f5f5f5; border: 1px solid #eee; border: 1px solid rgba(0, 0, 0, 0.08); color: #333; padding: 11px; overflow: auto; -webkit-border-radius: 4px; -moz-border-radius: 4px; -ms-border-radius: 4px; -o-border-radius: 4px; border-radius: 4px; -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05); -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05); box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05); }
 pre span { color: #999; }
 pre .error { color: #f00; }
+
 h2 { margin: 0 0 12px 0; }
+
 h3 { margin: 0 0 6px 0; color: #333; font-size: 18px; line-height: 24px; }
+
 ul { margin: 0 0 18px 0; padding: 0 0 0 18px; }
-fieldset { border: 0; padding: 0;}
+
+fieldset { border: 1px solid #b2b2b2; margin-bottom: 18px; padding: 17px; }
+
 .pass { margin-top: 18px; padding: 2px 20px 2px 40px; color: #006600; background: #E2F9E3; border: 1px solid #8DD38D; border-radius: 4px; }
+
 .fail { margin-top: 18px; padding: 2px 20px 2px 40px; color: #C80700; background: #FFE9E9; border: 1px solid #C80700; border-radius: 4px; }

--- a/forms/FolderDropdownField.php
+++ b/forms/FolderDropdownField.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Represents a TreeDropdownField for folders which remembers the last folder selected
+ */
+class FolderDropdownField extends TreeDropdownField {
+
+	public function __construct($name, $title = null, $sourceObject = 'Folder', $keyField = 'ID', $labelField = 'TreeTitle', $showSearch = true) {
+		parent::__construct($name, $title, $sourceObject, $keyField, $labelField, $showSearch);
+		$this->setValue(self::get_last_folder());
+	}
+
+	/**
+	 * Set the last folder selected
+	 *
+	 * @param int|Folder $folder Folder instance or ID
+	 */
+	public static function set_last_folder($folder) {
+		if($folder instanceof Folder) {
+			$folder = $folder->ID;
+		}
+		Session::set(get_class().'.FolderID', $folder);
+	}
+
+	/**
+	 * Get the last folder selected
+	 *
+	 * @return int
+	 */
+	public static function get_last_folder() {
+		return Session::get(get_class().'.FolderID');
+	}
+}

--- a/forms/SelectUploadField.php
+++ b/forms/SelectUploadField.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * A composite form field which allows users to select a folder into which files may be uploaded
+ *
+ * @package framework
+ * @subpackage forms
+ */
+class SelectUploadField extends UploadField {
+
+	private static $url_handlers = array(
+		'folder/tree/$ID' => 'tree'
+	);
+
+	private static $allowed_actions = array(
+		'tree'
+	);
+
+	protected $selectField;
+
+	public function __construct($name, $title = null, \SS_List $items = null) {
+		parent::__construct($name, $title, $items);
+
+		$this->selectField = FolderDropdownField::create("{$name}/folder")
+			->addExtraClass('FolderSelector')
+			->setTitle('Select a folder to upload into');
+	}
+
+	public function FolderSelector() {
+		return $this->selectField;
+	}
+
+	public function tree($request) {
+		return $this->FolderSelector()->tree($request);
+	}
+
+	public function setForm($form) {
+		parent::setForm($form);
+		$this->selectField->setForm($form);
+	}
+
+	public function Type() {
+		return 'selectupload upload';
+	}
+
+	protected function updateFolderName($request) {
+		// Get path from upload
+		$folderID = $request->requestVar("{$this->Name}/folder");
+		if($folderID && ($folder = Folder::get()->byID($folderID))) {
+			$path = $folder->getFilename();
+			if(stripos($path, ASSETS_DIR) === 0) {
+				$path = substr($path, strlen(ASSETS_DIR) + 1);
+			}
+			$this->setFolderName($path);
+			FolderDropdownField::set_last_folder($folderID);
+		}
+	}
+
+	public function handleRequest(\SS_HTTPRequest $request, \DataModel $model) {
+		$this->updateFolderName($request);
+		return parent::handleRequest($request, $model);
+	}
+}

--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -61,9 +61,12 @@
 			var that = this;
 			var config = this.options;
 			if (config.overwriteWarning) {
+				var request = {'filename': data.files[0].name};
+				var folder = that.element.find(".FolderSelector input");
+				if(folder.length) request[folder.attr('name')] = folder.val();
 				$.get(
 					config['urlFileExists'],
-					{'filename': data.files[0].name},
+					request,
 					function(response, status, xhr) {
 						if(response.exists) {
 							//display the dialogs with the question to overwrite or not
@@ -191,14 +194,17 @@
 				$(document).bind('drop dragover', function (e){					
 					e.preventDefault(); 
 				});
-
+				
+				var self = this;
 				this.setConfig(config);
 				this.fileupload($.extend(true, 
 					{
 						formData: function(form) {
 							var idVal = $(form).find(':input[name=ID]').val();
+							var folder = self.find(".FolderSelector input");
 							var data = [{name: 'SecurityID', value: $(form).find(':input[name=SecurityID]').val()}];
 							if(idVal) data.push({name: 'ID', value: idVal});
+							if(folder.length) data.push({name: folder.attr('name'), value: folder.val()});
 							
 							return data;
 						},
@@ -219,22 +225,22 @@
 							emptyResult: ss.i18n._t('UploadField.EMPTYRESULT')
 						},
 						send: function(e, data) {
-								if (data.context && data.dataType && data.dataType.substr(0, 6) === 'iframe') {
-										// Iframe Transport does not support progress events.
-										// In lack of an indeterminate progress bar, we set
-										// the progress to 100%, showing the full animated bar:
-										data.total = 1;
-										data.loaded = 1;
-										$(this).data('fileupload').options.progress(e, data);
-								}
+							if (data.context && data.dataType && data.dataType.substr(0, 6) === 'iframe') {
+								// Iframe Transport does not support progress events.
+								// In lack of an indeterminate progress bar, we set
+								// the progress to 100%, showing the full animated bar:
+								data.total = 1;
+								data.loaded = 1;
+								$(this).data('fileupload').options.progress(e, data);
+							}
 						},
 						progress: function(e, data) {
-									if (data.context) {
-										var value = parseInt(data.loaded / data.total * 100, 10) + '%';
-										data.context.find('.ss-uploadfield-item-status').html((data.total == 1)?ss.i18n._t('UploadField.LOADING'):value);
-										data.context.find('.ss-uploadfield-item-progressbarvalue').css('width', value);
-									}
+							if (data.context) {
+								var value = parseInt(data.loaded / data.total * 100, 10) + '%';
+								data.context.find('.ss-uploadfield-item-status').html((data.total == 1)?ss.i18n._t('UploadField.LOADING'):value);
+								data.context.find('.ss-uploadfield-item-progressbarvalue').css('width', value);
 							}
+						}
 					}, 
 					config, 
 					{

--- a/scss/UploadField.scss
+++ b/scss/UploadField.scss
@@ -10,7 +10,7 @@
 		clear: both;
 	}
 
-	.middleColumn {
+	.middleColumn .ss-uploadfield-filearea {
 		// TODO .middleColumn styling should probably be theme specific (eg cms ui will look different than blackcandy)
 		// so we should move this style into the cms and black candy files
 		width: 510px;
@@ -287,5 +287,9 @@
 	.loader {
 		height: 94px; // Approxmiately matches the height of the field once a file is attached, avoids a 'jump' in size
 		background: transparent url(../admin/images/spinner.gif) no-repeat 50% 50%;
+	}
+
+	&.selectupload .FolderSelector label {
+		font-style: italic;
 	}
 }

--- a/templates/UploadField.ss
+++ b/templates/UploadField.ss
@@ -1,71 +1,79 @@
-<ul class="ss-uploadfield-files files">
-	<% if $CustomisedItems %>
-		<% loop $CustomisedItems %>
-			<li class="ss-uploadfield-item template-download" data-fileid="$ID">
-				<div class="ss-uploadfield-item-preview preview"><span>
-					<img alt="$hasRelation" src="$UploadFieldThumbnailURL" />
-				</span></div>
-				<div class="ss-uploadfield-item-info">
-					<input type='hidden' value='$ID' name='{$Top.Name}[Files][]' />
-					<label class="ss-uploadfield-item-name">
-						<span class="name">$Name.XML</span>
-						<span class="size">$Size</span>
-						<div class="clear"><!-- --></div>
-					</label>
-					<div class="ss-uploadfield-item-actions">
-						<% if $Top.isActive %>
-							$UploadFieldFileButtons
-						<% end_if %>
+<% if $FolderSelector %><% with FolderSelector %>
+	<div class="field $extraClass">
+		<% if $Title %><label for="$ID">$Title</label><% end_if %>
+		$Field
+	</div>
+<% end_with %><% end_if %>
+<div class="ss-uploadfield-filearea">
+	<ul class="ss-uploadfield-files files">
+		<% if $CustomisedItems %>
+			<% loop $CustomisedItems %>
+				<li class="ss-uploadfield-item template-download" data-fileid="$ID">
+					<div class="ss-uploadfield-item-preview preview"><span>
+						<img alt="$hasRelation" src="$UploadFieldThumbnailURL" />
+					</span></div>
+					<div class="ss-uploadfield-item-info">
+						<input type='hidden' value='$ID' name='{$Top.Name}[Files][]' />
+						<label class="ss-uploadfield-item-name">
+							<span class="name">$Name.XML</span>
+							<span class="size">$Size</span>
+							<div class="clear"><!-- --></div>
+						</label>
+						<div class="ss-uploadfield-item-actions">
+							<% if $Top.isActive %>
+								$UploadFieldFileButtons
+							<% end_if %>
+						</div>
 					</div>
-				</div>
-				<div class="ss-uploadfield-item-editform includeParent">
-					<iframe frameborder="0" data-src="$UploadFieldEditLink" src="about:blank"></iframe>
-				</div>
-			</li>
-		<% end_loop %>
-	<% end_if %>
-</ul>
-<% if $canUpload || $canAttachExisting %>
-	<div class="ss-uploadfield-item ss-uploadfield-addfile<% if $CustomisedItems %> borderTop<% end_if %>">
-		<% if canUpload %>
-		<div class="ss-uploadfield-item-preview ss-uploadfield-dropzone ui-corner-all">
-				<% if $multiple %>
-					<% _t('UploadField.DROPFILES', 'drop files') %>
-				<% else %>
-					<% _t('UploadField.DROPFILE', 'drop a file') %>
-				<% end_if %>
-		</div>
+					<div class="ss-uploadfield-item-editform includeParent">
+						<iframe frameborder="0" data-src="$UploadFieldEditLink" src="about:blank"></iframe>
+					</div>
+				</li>
+			<% end_loop %>
 		<% end_if %>
-		<div class="ss-uploadfield-item-info">
-			<label class="ss-uploadfield-item-name">
-				<% if $multiple %>
-					<b><% _t('UploadField.ATTACHFILES', 'Attach files') %></b>
-				<% else %>
-					<b><% _t('UploadField.ATTACHFILE', 'Attach a file') %></b>
-				<% end_if %>
-				<% if $canPreviewFolder %>
-					<small>(<%t UploadField.UPLOADSINTO 'saves into /{path}' path=$FolderName %>)</small>
-				<% end_if %>
-			</label>
-			<% if $canUpload %>
-				<label class="ss-uploadfield-fromcomputer ss-ui-button ui-corner-all" title="<% _t('UploadField.FROMCOMPUTERINFO', 'Upload from your computer') %>" data-icon="drive-upload">
-					<% _t('UploadField.FROMCOMPUTER', 'From your computer') %>
-					<input id="$id" name="{$Name}[Uploads][]" class="$extraClass ss-uploadfield-fromcomputer-fileinput" data-config="$configString" type="file"<% if $multiple %> multiple="multiple"<% end_if %> />
+	</ul>
+	<% if $canUpload || $canAttachExisting %>
+		<div class="ss-uploadfield-item ss-uploadfield-addfile<% if $CustomisedItems %> borderTop<% end_if %>">
+			<% if canUpload %>
+			<div class="ss-uploadfield-item-preview ss-uploadfield-dropzone ui-corner-all">
+					<% if $multiple %>
+						<% _t('UploadField.DROPFILES', 'drop files') %>
+					<% else %>
+						<% _t('UploadField.DROPFILE', 'drop a file') %>
+					<% end_if %>
+			</div>
+			<% end_if %>
+			<div class="ss-uploadfield-item-info">
+				<label class="ss-uploadfield-item-name">
+					<% if $multiple %>
+						<b><% _t('UploadField.ATTACHFILES', 'Attach files') %></b>
+					<% else %>
+						<b><% _t('UploadField.ATTACHFILE', 'Attach a file') %></b>
+					<% end_if %>
+					<% if $canPreviewFolder %>
+						<small>(<%t UploadField.UPLOADSINTO 'saves into /{path}' path=$FolderName %>)</small>
+					<% end_if %>
 				</label>
-			<% else %>
-				<input id="$id" name="{$Name}[Uploads][]" class="$extraClass ss-uploadfield-fromcomputer-fileinput" data-config="$configString" type="hidden" />
-			<% end_if %>
-
-			<% if $canAttachExisting %>
-				<button class="ss-uploadfield-fromfiles ss-ui-button ui-corner-all" title="<% _t('UploadField.FROMCOMPUTERINFO', 'Select from files') %>" data-icon="network-cloud"><% _t('UploadField.FROMFILES', 'From files') %></button>
-			<% end_if %>
-			<% if $canUpload %>
-				<% if not $autoUpload %>
-					<button class="ss-uploadfield-startall ss-ui-button ui-corner-all" data-icon="navigation"><% _t('UploadField.STARTALL', 'Start all') %></button>
+				<% if $canUpload %>
+					<label class="ss-uploadfield-fromcomputer ss-ui-button ui-corner-all" title="<% _t('UploadField.FROMCOMPUTERINFO', 'Upload from your computer') %>" data-icon="drive-upload">
+						<% _t('UploadField.FROMCOMPUTER', 'From your computer') %>
+						<input id="$id" name="{$Name}[Uploads][]" class="$extraClass ss-uploadfield-fromcomputer-fileinput" data-config="$configString" type="file"<% if $multiple %> multiple="multiple"<% end_if %> />
+					</label>
+				<% else %>
+					<input id="$id" name="{$Name}[Uploads][]" class="$extraClass ss-uploadfield-fromcomputer-fileinput" data-config="$configString" type="hidden" />
 				<% end_if %>
-			<% end_if %>
+
+				<% if $canAttachExisting %>
+					<button class="ss-uploadfield-fromfiles ss-ui-button ui-corner-all" title="<% _t('UploadField.FROMCOMPUTERINFO', 'Select from files') %>" data-icon="network-cloud"><% _t('UploadField.FROMFILES', 'From files') %></button>
+				<% end_if %>
+				<% if $canUpload %>
+					<% if not $autoUpload %>
+						<button class="ss-uploadfield-startall ss-ui-button ui-corner-all" data-icon="navigation"><% _t('UploadField.STARTALL', 'Start all') %></button>
+					<% end_if %>
+				<% end_if %>
+				<div class="clear"><!-- --></div>
+			</div>
 			<div class="clear"><!-- --></div>
 		</div>
-		<div class="clear"><!-- --></div>
-	</div>
-<% end_if %>
+	<% end_if %>
+</div>


### PR DESCRIPTION
This feature introduces a pair of new fields:
- SelectUploadField, which is a subclass of the UploadField control, but includes an additional selector allowing the user to choose the folder to upload to.
- FolderDropdownField: Which is a subclass of the TreeDropdownField, but rather than intended as a tool for saving to a database (which it can be used for) it's intended to act as a selector for folders. The selected value of this folder persists between each instance of the selector, within the user session, meaning that users are able to use a single upload destination when working on many parts of the website.

To be developed: Integration of this feature into the HTML Editor media uploader, so that users may manage their media uploads when working with the HTMLEditorField.

Currently the SelectUploadField looks like the below.

**Please do not merge**

This feature is pending internal review, tests, and additional documentation. This pull request is intended to support further review.

**Please do not merge**

![screen shot 2014-07-14 at 11 08 40 am](https://cloud.githubusercontent.com/assets/936064/3566058/ac5195da-0ae2-11e4-8a4d-563d69dd2867.png)

ref: PLAT-52
