### PR TITLE
ENH making /dev extendable

### DIFF
--- a/_config/dev.yml
+++ b/_config/dev.yml
@@ -1,0 +1,23 @@
+---
+Name: DevelopmentAdmin
+---
+DevelopmentAdmin:
+  registered_controllers:
+    build:
+      controller: 'DevBuildController'
+      links:
+        build: 'Build/rebuild this environment. Call this whenever you have updated your project sources'
+    tests:
+      controller: 'TestRunner'
+      links:
+        tests: 'See a list of unit tests to run'
+        'tests/all': 'Run all tests'
+    jstests:
+      controller: 'JSTestRunner'
+      links: 
+        jstests: 'See a list of JavaScript tests to run'
+        'jstests/all': 'Run all JavaScript tests'
+    tasks:
+      controller: 'TaskRunner'
+      links:
+        tasks: 'See a list of build tasks to run'

--- a/dev/DevBuildController.php
+++ b/dev/DevBuildController.php
@@ -1,0 +1,32 @@
+<?php 
+
+class DevBuildController extends Controller {
+	
+	private static $url_handlers = array(
+		'' => 'build'	
+	);
+	
+	private static $allowed_actions = array(
+		'build'
+	);
+	
+	
+	public function build($request) {
+		if(Director::is_cli()) {
+			$da = DatabaseAdmin::create();
+			return $da->handleRequest($request, $this->model);
+		} else {
+			$renderer = DebugView::create();
+			$renderer->writeHeader();
+			$renderer->writeInfo("Environment Builder", Director::absoluteBaseURL());
+			echo "<div class=\"build\">";
+	
+			$da = DatabaseAdmin::create();
+			return $da->handleRequest($request, $this->model);
+	
+			echo "</div>";
+			$renderer->writeFooter();
+		}
+	}
+	
+}

--- a/tests/dev/DevAdminControllerTest.php
+++ b/tests/dev/DevAdminControllerTest.php
@@ -1,0 +1,116 @@
+<?php 
+
+/**
+ * Note: the running of this test is handled by the thing it's testing (DevelopmentAdmin controller).
+ * 
+ * @package framework
+ * @package tests
+ */
+class DevAdminControllerTest extends FunctionalTest {
+	
+	public function setUp(){
+		parent::setUp();
+
+		Config::nest()->update('DevelopmentAdmin', 'registered_controllers', array(
+			'x1' => array(
+				'controller' => 'DevAdminControllerTest_Controller1',
+				'links' => array(
+					'x1' => 'x1 link description',
+					'x1/y1' => 'x1/y1 link description'
+				)
+			),
+			'x2' => array(
+				'controller' => 'DevAdminControllerTest_Controller2', // intentionally not a class that exists
+				'links' => array(
+					'x2' => 'x2 link description'
+				)
+			)
+		));
+	}
+	
+	public function tearDown(){
+		parent::tearDown();
+		Config::unnest();
+	}
+	
+	
+	public function testGoodRegisteredControllerOutput(){
+		// Check for the controller running from the registered url above 
+		// (we use contains rather than equals because sometimes you get Warning: You probably want to define an entry in $_FILE_TO_URL_MAPPING)
+		$this->assertContains(DevAdminControllerTest_Controller1::OK_MSG, $this->getCapture('/dev/x1'));
+		$this->assertContains(DevAdminControllerTest_Controller1::OK_MSG, $this->getCapture('/dev/x1/y1'));
+	}
+	
+	public function testGoodRegisteredControllerStatus(){
+		// Check response code is 200/OK
+		$this->assertEquals(false, $this->getAndCheckForError('/dev/x1'));
+		$this->assertEquals(false, $this->getAndCheckForError('/dev/x1/y1'));
+		
+		// Check response code is 500/ some sort of error
+		$this->assertEquals(true, $this->getAndCheckForError('/dev/x2'));
+	}
+	
+	
+	
+	protected function getCapture($url){
+		$this->logInWithPermission('ADMIN');
+		
+		ob_start();
+		$this->get($url);
+		$r = ob_get_contents();
+		ob_end_clean();
+		
+		return $r;
+	}
+	
+	protected function getAndCheckForError($url){
+		$this->logInWithPermission('ADMIN');
+		
+		if(Director::is_cli()){
+			// when in CLI the admin controller throws exceptions
+			ob_start();
+			try{
+				$this->get($url);
+			}catch(Exception $e){
+				ob_end_clean();
+				return true;
+			}
+			
+			ob_end_clean();
+			return false;
+			
+		}else{
+			// when in http the admin controller sets a response header
+			ob_start();
+			$resp = $this->get($url);
+			ob_end_clean();
+			return $resp->isError();
+		}
+	}
+	
+}
+
+class DevAdminControllerTest_Controller1 extends Controller {
+	
+	const OK_MSG = 'DevAdminControllerTest_Controller1 TEST OK';
+	
+	private static $url_handlers = array(
+		'' => 'index',
+		'y1' => 'y1Action'
+	);
+	
+	private static $allowed_actions = array(
+		'index',
+		'y1Action',
+	);
+	
+	
+	public function index(){
+		echo self::OK_MSG;
+	}
+	
+	public function y1Action(){
+		echo self::OK_MSG;
+	} 
+	
+}


### PR DESCRIPTION
Just a little refactoring, no behavioural changes made. I made /dev extendable so more stuff can be added to the list there. Currently if you want to add something it requires editing the DevelopmentAdmin.php file in the framework, not very modular.

I chose to go with an array rather than e.g. finding all subtypes of a DevController class to keep this simple and foolproof, and to prevent manifest cache issues, it's not something that needs to be fancy and is unlikely to need a lot of flexibility.

I kept the list the same, not adding build/defaults or generatesecuretoken as they are hidden currently, a decision to display it in the /dev list can be made by someone else.

When testing make sure you test CLI as well, e.g. /example/framework/sake dev/build

Thanks!
