### PR TITLE
FIX: Hierarchy markOpened incorrectly applying

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -869,6 +869,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 				true, 
 				$childrenMethod,
 				$numChildrenMethod,
+				true,
 				$nodeCountThreshold,
 				$nodeCountCallback
 			);


### PR DESCRIPTION
Resubmit of #3234

Moved call to `markingClasses()` to after resolution of the nodes children has happened. This fixes the jstree-open applying before the tree has been checked.

Previously nodes with children would get `jstree-open` applied before checking for if the tree is open or not has completed.

Also changed `$node_threshold_total` from 50 to 30, as it's changed to 30 multiple times in the file. This should should be refactored to be more consistently calling the `$node_threshold_total`.

LeftAndMain was missing an argument with it's call to `getChildrenAsUL()`, this has been added though it shouldn't be affecting the `markOpened()` call.