### PR TITLE
BUG #3282: Added ability to subselect with in left or inner join

### DIFF
--- a/model/SQLQuery.php
+++ b/model/SQLQuery.php
@@ -903,9 +903,11 @@ class SQLQuery {
 				else if(sizeof($join['filter']) == 1) $filter = $join['filter'][0];
 				else $filter = "(" . implode(") AND (", $join['filter']) . ")";
 
+				$table = strpos(strtoupper($join['table']), 'SELECT') ? $join['table'] : "\"" 
+					. $join['table'] . "\"";
 				$aliasClause = ($alias != $join['table']) ? " AS \"" . Convert::raw2sql($alias) . "\"" : "";
-				$this->from[$alias] = strtoupper($join['type']) . " JOIN \"" 
-					. $join['table'] . "\"$aliasClause ON $filter";
+				$this->from[$alias] = strtoupper($join['type']) . " JOIN " 
+					. $table . "$aliasClause ON $filter";
 			}
 		}
 

--- a/tests/model/SQLQueryTest.php
+++ b/tests/model/SQLQueryTest.php
@@ -342,6 +342,27 @@ class SQLQueryTest extends SapphireTest {
 		);
 	}
 	
+	public function testJoinSubSelect() {
+
+		$query = new SQLQuery();
+		$query->setFrom('MyTable');
+		$query->addInnerJoin('(SELECT * FROM MyOtherTable)', 
+			'Mot.MyTableID = MyTable.ID', 'Mot');
+		$query->addLeftJoin('(SELECT MyLastTable.MyOtherTableID, COUNT(1) as MyLastTableCount FROM MyLastTable '
+			. 'GROUP BY MyOtherTableID)', 
+			'Mlt.MyOtherTableID = Mot.ID', 'Mlt');
+		$query->setOrderBy('COALESCE(Mlt.MyLastTableCount, 0) DESC');
+
+		$this->assertEquals('SELECT *, COALESCE(Mlt.MyLastTableCount, 0) AS "_SortColumn0" FROM MyTable '.
+			'INNER JOIN (SELECT * FROM MyOtherTable) AS "Mot" ON Mot.MyTableID = MyTable.ID ' .
+			'LEFT JOIN (SELECT MyLastTable.MyOtherTableID, COUNT(1) as MyLastTableCount FROM MyLastTable '
+			. 'GROUP BY MyOtherTableID) AS "Mlt" ON Mlt.MyOtherTableID = Mot.ID ' .
+			'ORDER BY "_SortColumn0" DESC',
+			$query->sql()
+		);
+
+	}
+	
 	public function testSetWhereAny() {
 		$query = new SQLQuery();
 		$query->setFrom('MyTable');


### PR DESCRIPTION
Remove string that by default wraps a join table in quotes causing an issue if you need to sub-select as a join table.

Raised issue in forum, as here is PR - http://www.silverstripe.org/data-model-questions/show/66002
