### PR TITLE
FIX ImagickBackend backgroundColor

### DIFF
--- a/filesystem/ImagickBackend.php
+++ b/filesystem/ImagickBackend.php
@@ -184,7 +184,7 @@ class ImagickBackend extends Imagick implements Image_Backend {
 	 * @param int $height
 	 * @return Image_Backend
 	 */
-	public function paddedResize($width, $height, $backgroundColor = "#FFFFFF00") {
+	public function paddedResize($width, $height, $backgroundColor = "#FFFFFF") {
 		if(!$this->valid()) return;
 		
 		$width = round($width);
@@ -194,6 +194,10 @@ class ImagickBackend extends Imagick implements Image_Backend {
 		// Check that a resize is actually necessary.
 		if ($width == $geometry["width"] && $height == $geometry["height"]) {
 			return $this;
+		}
+		
+		if( strpos('#', $backgroundColor) === false ) {
+			$backgroundColor = '#'.$backgroundColor;
 		}
 		
 		$new = clone $this;
@@ -247,9 +251,7 @@ class ImagickBackend extends Imagick implements Image_Backend {
 			return $this;
 		}
 		
-		if(!$backgroundColor){
-			$backgroundColor = new ImagickPixel('transparent');
-		}
+		$backgroundColor = new ImagickPixel('transparent');
 		
 		$new = clone $this;
 		$new->setBackgroundColor($backgroundColor);


### PR DESCRIPTION
Bugs:
- `Undefined variable: backgroundColor` in ImagickBackend->croppedResize()
- `Unrecognized color string` in  ImagickBackend->paddedResize() - this is because we use a hex color code without a leading hash by default in Image->PaddedImage(). This fix simply prepends a hash char to the hex code if it's not there.

How to reproduce: Run ImagickImageTest
