### PR TITLE
FIX Image: deleteFormattedImages() regex

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -582,7 +582,7 @@ class Image extends File {
 		}
 		// All generate functions may appear any number of times in the image cache name.
 		$generateFuncs = implode('|', $generateFuncs);
-		$pattern = "/^(({$generateFuncs})\d+\-)+" . preg_quote($this->Name) . "$/i";
+		$pattern = "/^(({$generateFuncs}).*\-)+" . preg_quote($this->Name) . "$/i";
 
 		foreach($cachedFiles as $cfile) {
 			if(preg_match($pattern, $cfile)) {


### PR DESCRIPTION
Resampled images could include names without a size argument, such as CMSThumbnail-test_image.png.
And also could include names with a size and a hex color code, such as PaddedImage200100FFFFFF-test_image.png.

This makes arguments after the function name optional.
