### PR TITLE
Allow explicitly setting environment file location

### DIFF
--- a/core/Constants.php
+++ b/core/Constants.php
@@ -36,43 +36,50 @@
 /**
  * Include _ss_environment.php file
  */
-//define the name of the environment file
-$envFile = '_ss_environment.php';
-//define the dirs to start scanning from (have to add the trailing slash)
-// we're going to check the realpath AND the path as the script sees it
-$dirsToCheck = array(
-	realpath('.'),
-	dirname($_SERVER['SCRIPT_FILENAME'])
-);
-//if they are the same, remove one of them
-if ($dirsToCheck[0] == $dirsToCheck[1]) {
-	unset($dirsToCheck[1]);
-}
-foreach ($dirsToCheck as $dir) {
-	//check this dir and every parent dir (until we hit the base of the drive)
-	// or until we hit a dir we can't read
-	while(true) {
-		//if it's readable, go ahead
-		if (@is_readable($dir)) {
-			//if the file exists, then we include it, set relevant vars and break out
-			if (file_exists($dir . DIRECTORY_SEPARATOR . $envFile)) {
-				define('SS_ENVIRONMENT_FILE', $dir . DIRECTORY_SEPARATOR . $envFile);
-				include_once(SS_ENVIRONMENT_FILE);
-				//break out of BOTH loops because we found the $envFile
-				break(2);
+if (!defined('SS_ENVIRONMENT_FILE')) {
+	if (getenv('SS_ENVIRONMENT_FILE')) {
+		define('SS_ENVIRONMENT_FILE', getenv('SS_ENVIRONMENT_FILE'));
+	}
+	else {
+		//define the name of the environment file
+		$envFile = '_ss_environment.php';
+		//define the dirs to start scanning from (have to add the trailing slash)
+		// we're going to check the realpath AND the path as the script sees it
+		$dirsToCheck = array(
+			realpath('.'),
+			dirname($_SERVER['SCRIPT_FILENAME'])
+		);
+		//if they are the same, remove one of them
+		if ($dirsToCheck[0] == $dirsToCheck[1]) {
+			unset($dirsToCheck[1]);
+		}
+		foreach ($dirsToCheck as $dir) {
+			//check this dir and every parent dir (until we hit the base of the drive)
+			// or until we hit a dir we can't read
+			while(true) {
+				//if it's readable, go ahead
+				if (@is_readable($dir)) {
+					//if the file exists, then we include it, set relevant vars and break out
+					if (file_exists($dir . DIRECTORY_SEPARATOR . $envFile)) {
+						define('SS_ENVIRONMENT_FILE', $dir . DIRECTORY_SEPARATOR . $envFile);
+						include_once(SS_ENVIRONMENT_FILE);
+						//break out of BOTH loops because we found the $envFile
+						break(2);
+					}
+				}
+				else {
+					//break out of the while loop, we can't read the dir
+					break;
+				}
+				if (dirname($dir) == $dir) {
+					// here we need to check that the path of the last dir and the next one are
+					// not the same, if they are, we have hit the root of the drive
+					break;
+				}
+				//go up a directory
+				$dir = dirname($dir);
 			}
 		}
-		else {
-			//break out of the while loop, we can't read the dir
-			break;
-		}
-		if (dirname($dir) == $dir) {
-			// here we need to check that the path of the last dir and the next one are
-			// not the same, if they are, we have hit the root of the drive
-			break;
-		}
-		//go up a directory
-		$dir = dirname($dir);
 	}
 }
 
@@ -178,7 +185,7 @@ if(!isset($_SERVER['HTTP_HOST'])) {
 	 * Fix HTTP_HOST from reverse proxies
 	 */
 	if (TRUSTED_PROXY && isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
-		
+
 		// Get the first host, in case there's multiple separated through commas
 		$_SERVER['HTTP_HOST'] = strtok($_SERVER['HTTP_X_FORWARDED_HOST'], ',');
 	}

--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -1482,7 +1482,7 @@ ErrorDocument 500 /assets/error-500.html
 	RewriteRule ^vendor(/|$) - [F,L,NC]
 	RewriteRule silverstripe-cache(/|$) - [F,L,NC]
 	RewriteRule composer\.(json|lock) - [F,L,NC]
-	
+
 	# Process through SilverStripe if no file with the requested name exists.
 	# Pass through the original path as a query parameter, and retain the existing parameters.
 	RewriteCond %{REQUEST_URI} ^(.*)$

--- a/docs/en/00_Getting_Started/03_Environment_Management.md
+++ b/docs/en/00_Getting_Started/03_Environment_Management.md
@@ -57,7 +57,7 @@ The mechanism by which the `_ss_environment.php` files work is quite simple.  He
 
 *  At the beginning of SilverStripe's execution, the `_ss_environment.php` file is searched for, and if it is found, it's
 included.  SilverStripe looks in all the parent folders of framework up to the server root (using the REAL location of
-the dir - see PHP realpath()):
+the dir - see PHP realpath() - AND the path used for execution):
 *  The `_ss_environment.php` file sets a number of "define()".
 *  "conf/ConfigureFromEnv.php" is included from within your `mysite/_config.php`.  This file has a number of regular
 configuration commands that use those defines as their arguments.  If you are curious, open up
@@ -100,6 +100,37 @@ This is my `_ss_environment.php` file. I have it placed in `/var`, as each of th
 	// This is used by sake to know which directory points to which URL
 	global $_FILE_TO_URL_MAPPING;
 	$_FILE_TO_URL_MAPPING['/var/www'] = 'http://simon.geek.nz';
+
+## Defining the environment file location
+
+If there is no `SS_ENVIRONMENT_FILE` constant defined, SilverStripe will search up the directory tree looking for a file.
+
+However, sometimes this default behaviour is not desired as can be the case when running through CLI or on hosting providers
+where you can't access outside the webroot (and you want a seperate config for live/dev).
+
+There are two ways to define the `SS_ENVIRONMENT_PATH` and prevent the default behaviour:
+
+#### 1. Define an environment variable
+
+This can be done in the .htaccess:
+
+```
+SetEnv SS_ENVIRONMENT_FILE "/path/to/_ss_environment.php"
+```
+
+Or via CLI with the server
+
+```bash
+export SS_ENVIRONMENT_FILE="/path/to/_ss_environment.php"
+```
+
+Note: this environment variable will need to be set for the user that executes your PHP files
+
+#### 2. Pass an argument to sake (CLI for SilverStripe)
+
+```shell
+framework/sake home --environment-file=/path/to/_ss_environment.php
+```
 
 ## Available Constants
 


### PR DESCRIPTION
This is a possible solution to #3315

`SS_ENVIRONMENT_FILE` can now be defined via an environment variable with the same name OR via a CLI option

```
framework/sake url --environment-file=/path/to/_ss_environment.php
```

This also BREAKS the CLI behaviour where `--` prefixed options would be parsed as a URL query string:

```
framework/sake url --flush=all&something=somethingelse
```

Instead, we'd have to use the current behaviour:

```
framework/sake url flush=all something=somethingelse
```