### PR TITLE
FIX Handle empty URLs that are made absolute

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -425,7 +425,7 @@ class Director implements TemplateGlobalProvider {
 		}
 
 		if(substr($url,0,4) != "http") {
-			if($url[0] != "/") $url = Director::baseURL()  . $url;
+			if(strpos($url, '/') !== 0) $url = Director::baseURL()  . $url;
 			// Sometimes baseURL() can return a full URL instead of just a path
 			if(substr($url,0,4) != "http") $url = self::protocolAndHost() . $url;
 		}


### PR DESCRIPTION
When the email sender makes the links absolute, it can't handle empty `href` or `src` attributes as there's no expectation that the string length could be 0
