### PR TITLE
Image Magick PaddedResize fix

### DIFF
--- a/filesystem/ImagickBackend.php
+++ b/filesystem/ImagickBackend.php
@@ -23,9 +23,8 @@ class ImagickBackend extends Imagick implements Image_Backend {
 	public function __construct($filename = null) {
 		if(is_string($filename)) {
 			parent::__construct($filename);
-		} else {
-			self::setImageCompressionQuality($this->config()->default_quality);
 		}
+		$this->setQuality(Config::inst()->get('ImagickBackend','default_quality'));
 	}
 
 	/**
@@ -185,45 +184,11 @@ class ImagickBackend extends Imagick implements Image_Backend {
 	 * @return Image_Backend
 	 */
 	public function paddedResize($width, $height, $backgroundColor = "FFFFFF") {
-		if(!$this->valid()) return;
-		
-		$width = round($width);
-		$height = round($height);
-		$geometry = $this->getImageGeometry();
-		
-		// Check that a resize is actually necessary.
-		if ($width == $geometry["width"] && $height == $geometry["height"]) {
-			return $this;
-		}
-		
-		$new = clone $this;
-		$new->setBackgroundColor("#".$backgroundColor);
-		
-		$destAR = $width / $height;
-		if ($geometry["width"] > 0 && $geometry["height"] > 0) {
-			// We can't divide by zero theres something wrong.
-			
-			$srcAR = $geometry["width"] / $geometry["height"];
-		
-			// Destination narrower than the source
-			if($destAR > $srcAR) {
-				$destY = 0;
-				$destHeight = $height;
-				
-				$destWidth = round( $height * $srcAR );
-				$destX = round( ($width - $destWidth) / 2 );
-			
-			// Destination shorter than the source
-			} else {
-				$destX = 0;
-				$destWidth = $width;
-				
-				$destHeight = round( $width / $srcAR );
-				$destY = round( ($height - $destHeight) / 2 );
-			}
-		
-			$new->extentImage($width, $height, $destX, $destY);
-		}
+		$new = $this->resizeRatio($width, $height);
+		$new->setImageBackgroundColor("#".$backgroundColor);
+		$w = $new->getImageWidth();
+		$h = $new->getImageHeight();
+		$new->extentImage($width,$height,($w-$width)/2,($h-$height)/2);
 		
 		return $new;
 	}


### PR DESCRIPTION
This fixes the padded resize problem mentioned in #3333

Note that Image_Backend doesn't have any cross-backend unit tests.

In this answer, someone suggests stripping out image metadata, and doing a MD5 checksum on the bits.
http://stackoverflow.com/questions/7149747/need-help-understanding-difference-in-raw-image-binary-data-for-phpunit-test
Not sure how well this will work, as there are surely slight differences with image quality etc across backends.
