### PR TITLE
BUG Fix periodic tinymce layout refresh

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -92,7 +92,12 @@ ss.editorWrappers.tinyMCE = (function() {
 				var interval;
 				jQuery(ed.getBody()).on('focus', function() {
 					interval = setInterval(function() {
-						ed.save();
+						// Update underlying element as necessary
+						var element = jQuery(ed.getElement());
+						if(ed.isDirty()) {
+							// Set content without triggering editor content cleanup
+							element.val(ed.getContent({format : 'raw', no_events : 1}));
+						}
 					}, 5000);
 				});
 				jQuery(ed.getBody()).on('blur', function() {


### PR DESCRIPTION
Refactor of bugfix which was a part of https://github.com/silverstripe/silverstripe-framework/pull/3322

After each 5 second interval the underlying textarea field is saved from the tinymce editor window. The issue with the existing implementation is that it was done in such a way that it triggered the refresh of the content window, interfering with plugins which interact with the content (e.g. the spellcheck plugin).

This fixes the method so that it saves the raw content without triggering any content update, and only when necessary.
