### PR TITLE
Use Injector to create default Upload_Validator instance

### DIFF
--- a/filesystem/Upload.php
+++ b/filesystem/Upload.php
@@ -74,7 +74,7 @@ class Upload extends Controller {
 	
 	public function __construct() {
 		parent::__construct();
-		$this->validator = new Upload_Validator();
+		$this->validator = Injector::inst()->create('Upload_Validator');
 		$this->replaceFile = self::config()->replaceFile;
 	}
 	


### PR DESCRIPTION
Allows this class to be swapped out with a custom Upload_Validator
globally, without having to call Upload::setValidator() everywhere.
