### PR TITLE
BUG Fixing incorrect error message on failed UploadField upload

### DIFF
--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -94,7 +94,11 @@
 		},
 		_onAlways: function (jqXHRorResult, textStatus, jqXHRorError, options) {
 			$.blueimpUI.fileupload.prototype._onAlways.call(this, jqXHRorResult, textStatus, jqXHRorError, options);
-			if (this._active === 0) {
+
+			if(typeof(jqXHRorError) === 'string') {
+				$('.fileOverview .uploadStatus .state').text(ss.i18n._t('AssetUploadField.UploadField.UPLOADFAIL', 'Sorry your upload failed'));
+				$('.fileOverview .uploadStatus').addClass("bad").removeClass("good").removeClass("notice");
+			} else if (jqXHRorError.status === 200) {
 				$('.fileOverview .uploadStatus .state').text(ss.i18n._t('AssetUploadField.FILEUPLOADCOMPLETED', 'File upload completed!'));//.hide();
 				$('.ss-uploadfield-item-edit-all').show();
 				$('.fileOverview .uploadStatus').addClass("good").removeClass("notice").removeClass("bad");


### PR DESCRIPTION
If applying custom Upload_Validator rules, uploads will fail POST with
a 403 to UploadField/upload as the upload was rejected, but UploadField
still shows that the upload was successful.

jqXHRorError returns either an error string, e.g. "Forbidden" or an
object. If it's a string, ensure that the upload summary shows an
error message. If it's an object and has a status of 200, show the
success message.
