### PR TITLE
fix speling error in plural_name var description

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -81,7 +81,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	private static $singular_name = null;
 	
 	/**
-	 * Human-readable pluaral name
+	 * Human-readable plural name
 	 * @var string
 	 * @config
 	 */


### PR DESCRIPTION
The comment description for plural_name variable had a spelling error
