### PR TITLE
BUG Add a synthetic event to workaround IE8 issues.

### DIFF
--- a/javascript/TreeDropdownField.js
+++ b/javascript/TreeDropdownField.js
@@ -173,7 +173,11 @@
 			},
 			setValue: function(val) {
 				this.data('metadata', $.extend(this.data('metadata'), {id: val}));
-				this.find(':input:hidden').val(val).trigger('change');
+				this.find(':input:hidden').val(val)
+					// Trigger synthetic event so subscribers can workaround the IE8 problem with 'change' events
+					// not propagating on hidden inputs. 'change' is still triggered for backwards compatiblity.
+					.trigger('valueupdated')
+					.trigger('change');
 			},
 			getValue: function() {
 				return this.find(':input:hidden').val();


### PR DESCRIPTION
Without this event it's not possible to hook into the value change in a
reliable way (panelhide event is called too many times to rely on it).
