### PR TITLE
Fixing absolute URLs for empty urls

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -422,13 +422,22 @@ class Director implements TemplateGlobalProvider {
 	 */
 	public static function absoluteURL($url, $relativeToSiteBase = false) {
 		if(!isset($_SERVER['REQUEST_URI'])) return false;
+
+		//a url of . or ./ is the same as an empty url
+		if ($url == '.' || $url == './') {
+			$url = '';
+		}
 		
 		if(strpos($url,'/') === false && !$relativeToSiteBase) {
-			$url = dirname($_SERVER['REQUEST_URI'] . 'x') . '/' . $url;
+			//if there's no URL we want to force a trailing slash on the link
+			if (!$url) {
+				$url = '/';
+			}
+			$url = Controller::join_links(dirname($_SERVER['REQUEST_URI'] . 'x'), $url);
 		}
 
 		if(substr($url,0,4) != "http") {
-			if($url[0] != "/") $url = Director::baseURL()  . $url;
+			if(strpos($url, '/') !== 0) $url = Director::baseURL()  . $url;
 			// Sometimes baseURL() can return a full URL instead of just a path
 			if(substr($url,0,4) != "http") $url = self::protocolAndHost() . $url;
 		}

--- a/tests/control/DirectorTest.php
+++ b/tests/control/DirectorTest.php
@@ -97,6 +97,16 @@ class DirectorTest extends SapphireTest {
 		$_SERVER['REQUEST_URI'] = "$rootURL/mysite/sub-page/";
 		Config::inst()->update('Director', 'alternate_base_url', '/mysite/');
 
+		//test empty URL
+		$this->assertEquals("$rootURL/mysite/sub-page/", Director::absoluteURL(''));
+
+		//test absolute - /
+		$this->assertEquals("$rootURL/", Director::absoluteURL('/'));
+
+		//test relative
+		$this->assertEquals("$rootURL/mysite/sub-page/", Director::absoluteURL('./'));
+		$this->assertEquals("$rootURL/mysite/sub-page/", Director::absoluteURL('.'));
+
 		// Test already absolute url
 		$this->assertEquals($rootURL, Director::absoluteURL($rootURL));
 		$this->assertEquals($rootURL, Director::absoluteURL($rootURL, true));
@@ -137,6 +147,7 @@ class DirectorTest extends SapphireTest {
 		Config::inst()->update('Director', 'alternate_base_url', 'http://www.example.org/');
 		$this->assertEquals('http://www.example.org/', Director::baseURL());
 		$this->assertEquals('http://www.example.org/', Director::absoluteBaseURL());
+		$this->assertEquals('http://www.example.org/', Director::absoluteURL(''));
 		$this->assertEquals('http://www.example.org/subfolder/test', Director::absoluteURL('subfolder/test'));
 
 		// Setting it to false restores functionality

--- a/tests/control/HTTPTest.php
+++ b/tests/control/HTTPTest.php
@@ -161,6 +161,27 @@ class HTTPTest extends FunctionalTest {
 	public function testAbsoluteURLsAttributes() {
 		$this->withBaseURL('http://www.silverstripe.org/', function($test){
 			
+			//empty links
+			$test->assertEquals(
+				'<a href="http://www.silverstripe.org/">test</a>',
+				HTTP::absoluteURLs('<a href="">test</a>')
+			);
+
+			$test->assertEquals(
+				'<a href="http://www.silverstripe.org/">test</a>',
+				HTTP::absoluteURLs('<a href="/">test</a>')
+			);
+
+			//relative
+			$test->assertEquals(
+				'<a href="http://www.silverstripe.org/">test</a>',
+				HTTP::absoluteURLs('<a href="./">test</a>')
+			);
+			$test->assertEquals(
+				'<a href="http://www.silverstripe.org/">test</a>',
+				HTTP::absoluteURLs('<a href=".">test</a>')
+			);
+
 			// links
 			$test->assertEquals(
 				'<a href=\'http://www.silverstripe.org/blog/\'>SS Blog</a>',


### PR DESCRIPTION
Empty urls are now handled properly as well as relative "./" or "." urls

@tractorcow

re #3323 and #3345