### PR TITLE
Update Controller to allow extension in handleAction()

### DIFF
--- a/control/Controller.php
+++ b/control/Controller.php
@@ -183,6 +183,8 @@ class Controller extends RequestHandler implements TemplateGlobalProvider {
 	 * If $Action isn't given, it will use "index" as a default.
 	 */
 	protected function handleAction($request, $action) {
+		$this->extend('beforeCallActionHandler', $request, $action);
+		
 		foreach($request->latestParams() as $k => $v) {
 			if($v || !isset($this->urlParams[$k])) $this->urlParams[$k] = $v;
 		}


### PR DESCRIPTION
Controller's parent class (RequestHandler) has two extensions in its handleAction() method that are obscured by Controller's implementation.

There are many reasons to hook into action, custom logging being the most obvious.