### PR TITLE
Revert #3358

### DIFF
--- a/templates/forms/CheckboxSetField.ss
+++ b/templates/forms/CheckboxSetField.ss
@@ -2,8 +2,8 @@
 	<% if $Options.Count %>
 		<% loop $Options %>
 			<li class="$Class">
-				<input id="$ID" class="checkbox" name="$Name.ATT" type="checkbox" value="$Value.ATT"<% if $isChecked %> checked="checked"<% end_if %><% if $isDisabled %> disabled="disabled"<% end_if %> />
-				<label for="$ID">$Title.XML</label>
+				<input id="$ID" class="checkbox" name="$Name" type="checkbox" value="$Value"<% if $isChecked %> checked="checked"<% end_if %><% if $isDisabled %> disabled="disabled"<% end_if %> />
+				<label for="$ID">$Title</label>
 			</li> 
 		<% end_loop %>
 	<% else %>

--- a/templates/forms/DropdownField.ss
+++ b/templates/forms/DropdownField.ss
@@ -1,5 +1,5 @@
 <select $AttributesHTML>
 <% loop $Options %>
-	<option value="$Value.ATT"<% if $Selected %> selected="selected"<% end_if %><% if $Disabled %> disabled="disabled"<% end_if %>>$Title.XML</option>
+	<option value="$Value.XML"<% if $Selected %> selected="selected"<% end_if %><% if $Disabled %> disabled="disabled"<% end_if %>>$Title.XML</option>
 <% end_loop %>
 </select>

--- a/templates/forms/OptionsetField.ss
+++ b/templates/forms/OptionsetField.ss
@@ -1,8 +1,8 @@
 <ul id="$ID" class="$extraClass">
 	<% loop $Options %>
 		<li class="$Class">
-			<input id="$ID" class="radio" name="$Name.ATT" type="radio" value="$Value.ATT"<% if $isChecked %> checked<% end_if %><% if $isDisabled %> disabled<% end_if %> />
-			<label for="$ID">$Title.XML</label>
+			<input id="$ID" class="radio" name="$Name" type="radio" value="$Value"<% if $isChecked %> checked<% end_if %><% if $isDisabled %> disabled<% end_if %> />
+			<label for="$ID">$Title</label>
 		</li>
 	<% end_loop %>
 </ul>

--- a/tests/forms/CheckboxSetFieldTest.php
+++ b/tests/forms/CheckboxSetFieldTest.php
@@ -144,17 +144,6 @@ class CheckboxSetFieldTest extends SapphireTest {
 		$this->assertEquals('Test,Another', $dbValue);
 	}
 
-	public function testEscapedOptions() {
-		$field = new CheckboxSetField('Content', 'Content', array(
-			'Test' => 'Test',
-			'Another<weirdvalue>' => 'Another',
-		));
-
-		$html = $field->Field();
-		$this->assertContains('Content[Another&lt;weirdvalue&gt;]', $html, 'Option name is escaped');
-		$this->assertContains('value="Another&lt;weirdvalue&gt;', $html, 'Option value is escaped');
-	}
-
 }
 
 /**

--- a/tests/forms/DropdownFieldTest.php
+++ b/tests/forms/DropdownFieldTest.php
@@ -208,17 +208,7 @@ class DropdownFieldTest extends SapphireTest {
 		$disabledOptions = $this->findDisabledOptionElements($field->Field());
 		$this->assertEquals(count($disabledOptions), 0, 'There are no disabled options');
 	}
-
-	public function testEscapedOptions() {
-		$field = new DropdownField('Content', 'Content', array(
-			'Test' => 'Test',
-			'Another<weirdvalue>' => 'Another',
-		));
-
-		$html = $field->Field();
-		$this->assertContains('value="Another&lt;weirdvalue&gt;', $html, 'Option value is escaped');
-	}
-
+	
 	/**
 	 * Create a test dropdown field, with the option to
 	 * set what source and blank value it should contain

--- a/tests/forms/OptionsetFieldTest.php
+++ b/tests/forms/OptionsetFieldTest.php
@@ -34,15 +34,4 @@ class OptionsetFieldTest extends SapphireTest {
 		preg_match('/Yes/', $field->Field(), $matches);
 		$this->assertEquals($matches[0], 'Yes');
 	}
-
-	public function testEscapedOptions() {
-		$field = new OptionsetField('Content', 'Content', array(
-			'Test' => 'Test',
-			'Another<weirdvalue>' => 'Another',
-		));
-
-		$html = $field->Field();
-		$this->assertContains('value="Another&lt;weirdvalue&gt;', $html, 'Option value is escaped');
-	}
-
 }


### PR DESCRIPTION
Reverts #3358 

Sorry @halkyon, some elements of the CMS rely on encoding HTML in checkboxes manually (see add new page).
