### PR TITLE
BUG Fix incorrect parsing of HTML content

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -585,11 +585,14 @@ jQuery.noConflict();
 
 				var newFragments = {}, newContentEls;
 				// If content type is text/json (ignoring charset and other parameters)
-				if(xhr.getResponseHeader('Content-Type').match(/^text\/json[ \t]*;?/i)) {
+				if(xhr.getResponseHeader('Content-Type').match(/^((text)|(application))\/json[ \t]*;?/i)) {
 					newFragments = data;
 				} else {
+					
 					// Fall back to replacing the content fragment if HTML is returned
-					$data = $(data);
+					var fragment = document.createDocumentFragment();
+					jQuery.clean( [ data ], document, fragment, [] );
+					$data = $(jQuery.merge( [], fragment.childNodes ));
 
 					// Try and guess the fragment if none is provided
 					// TODO: data-pjax-fragment might actually give us the fragment. For now we just check most common case


### PR DESCRIPTION
In jquery 1.8 there is a `jQuery.parseHTML` method. See http://api.jquery.com/jQuery.parseHTML/ for details. Unfortunately, in 1.7 there is no such method, so I've taken an extremely simplified version of the necessary part of that method and backported it for use in 1.7.

The old code uses `$(content)` to encapsulate raw HTML inside a jquery container, but this behaviour is not reliable.

The issue as it stands is that if the content does not include the `<` character at the start of the string then the value can be misinterpreted as a jQuery selector and throws up the error seen at https://travis-ci.org/tractorcow/silverstripe-cms/builds/32177340.

```
Error: Syntax error, unrecognized expression:       } in http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:4267:1
STACKTRACE:
Sizzle.error@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:4267:2
Sizzle.filter@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:4253:5
Sizzle@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:4043:1
Sizzle@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:5175:4
.find@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:5431:4
jQuery</jQuery.prototype.init@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:187:5
init@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:910:4
jQuerySub@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:898:4
.handleAjaxResponse@http://localhost:8000/framework/admin/javascript/LeftAndMain.js?m=1407542257:592:6
$.entwine.Namespace<.one/one@http://localhost:8000/framework/thirdparty/jquery-entwine/dist/jquery.entwine-dist.js?m=1407542257:1011:13
$.entwine.Namespace<.build_proxy/prxy@http://localhost:8000/framework/thirdparty/jquery-entwine/dist/jquery.entwine-dist.js?m=1407542257:1036:17
.submitForm/<.success@http://localhost:8000/framework/admin/javascript/LeftAndMain.js?m=1407542257:398:11
jQuery.Callbacks/fire@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:1075:1
jQuery.Callbacks/self.fireWith@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:1193:7
.beforeSend/</<@http://localhost:8000/framework/javascript/jquery-ondemand/jquery.ondemand.js?m=1407542257:150:63
jQuery.Callbacks/fire@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:1075:1
jQuery.Callbacks/self.add@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:1110:7
.beforeSend/<@http://localhost:8000/framework/javascript/jquery-ondemand/jquery.ondemand.js?m=1407542257:149:5
jQuery.Callbacks/fire@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:1075:1
jQuery.Callbacks/self.fireWith@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:1193:7
done@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:7538:67
.send/callback@http://localhost:8000/framework/thirdparty/jquery/jquery.js?m=1407542257:8324:8
```

This fix enhances the behaviour to capture non-ajax content a little more elegantly, and also considers application/json as a content type.
