### PR TITLE
NEW: Sanitise task name in runTask

### DIFF
--- a/dev/TaskRunner.php
+++ b/dev/TaskRunner.php
@@ -86,7 +86,7 @@ class TaskRunner extends Controller {
 			}
 		}
 
-		$message(sprintf('The build task "%s" could not be found', $name));
+		$message(sprintf('The build task "%s" could not be found', Convert::raw2xml($name)));
 	}
 
 	/**


### PR DESCRIPTION
The task name is not sanitised so if you submit something like 

```
<your_site>/dev/tasks/<img+src=aa+onerror=alert(1)>
```

it will be output to the browser
