### PR TITLE
FIX: Class names referenced in Config should be case-insensitive

### DIFF
--- a/core/manifest/ConfigManifest.php
+++ b/core/manifest/ConfigManifest.php
@@ -147,8 +147,8 @@ class SS_ConfigManifest {
 	/**
 	 * Gets the (merged) config value for the given class and config property name
 	 *
-	 * @param string $class - The class to get the config property value for
-	 * @param string $name - The config property to get the value for
+	 * @param string $class - The class to get the config property value for; lowercase
+	 * @param string $name - The config property to get the value for; case sensitive
 	 * @param any $default - What to return if no value was contained in any YAML file for the passed $class and $name
 	 * @return any - The merged set of all values contained in all the YAML configuration files for the passed
 	 * $class and $name, or $default if there are none
@@ -647,13 +647,14 @@ class SS_ConfigManifest {
 
 	/**
 	 * Recursively merge a yaml fragment's configuration array into the primary merged configuration array.
+	 * Also makes the top-level keys lowercase, so that class comparisons can be case-insensitive
 	 * @param  $into
 	 * @param  $fragment
 	 * @return void
 	 */
 	public function mergeInYamlFragment(&$into, $fragment) {
 		foreach ($fragment as $k => $v) {
-			Config::merge_high_into_low($into[$k], $v);
+			Config::merge_high_into_low($into[strtolower($k)], $v);
 		}
 	}
 

--- a/core/manifest/ConfigStaticManifest.php
+++ b/core/manifest/ConfigStaticManifest.php
@@ -21,10 +21,15 @@ class SS_ConfigStaticManifest {
 	protected $key;
 
 	protected $index;
+
+	/**
+	 * Stores the values of statics as a nested map of classname -> keyname -> data
+	 * classnames are lowercase; keynames are case-sensitive
+	 */
 	protected $statics;
 
 	static protected $initial_classes = array(
-		'Object', 'ViewableData', 'Injector', 'Director'
+		'object', 'viewabledata', 'injector', 'director'
 	);
 
 	/**
@@ -57,6 +62,14 @@ class SS_ConfigStaticManifest {
 		}
 	}
 
+	/**
+	 * Gets the config value for the given class and config property name as specified by the relevant static
+	 *
+	 * @param string $class - The class to get the config property value for; lowercase
+	 * @param string $name - The config property to get the value for; case sensitive
+	 * @param any $default - What to return if no value was contained in any YAML file for the passed $class and $name
+	 * @return any - The configuration value defined in the static
+	 */
 	public function get($class, $name, $default) {
 		if (!isset($this->statics[$class])) {
 			if (isset($this->index[$class])) {
@@ -136,6 +149,8 @@ class SS_ConfigStaticManifest {
 		$parser->parse();
 
 		$this->index = array_merge($this->index, $parser->getInfo());
+
+		// Turn keys to lowercase so that classes are case-insensitive
 		$this->statics = array_merge($this->statics, $parser->getStatics());
 	}
 
@@ -298,6 +313,8 @@ class SS_ConfigStaticManifest_Parser {
 	 * being declared in a comma seperated list
 	 */
 	function parseStatic($access, $class) {
+		$class = strtolower($class);
+
 		$variable = null;
 		$value = '';
 

--- a/tests/core/ConfigTest.php
+++ b/tests/core/ConfigTest.php
@@ -250,6 +250,23 @@ class ConfigTest extends SapphireTest {
 		$this->assertEquals(Object::static_lookup('ConfigTest_DefinesFooDoesntExtendObject', 'bar'), null);
 	}
 
+	public function testCaseInsensitive() {
+		// Class is case-insensitive
+		$this->assertEquals(Object::static_lookup('configtest_DEFINESFOO', 'foo'), 1);
+
+		$this->assertEquals(3, Config::inst()->get('ConfigTest_TESTNEST', 'foo'));
+
+		Config::inst()->remove('ConfigStaticTest_THIRD', 'second');
+		$this->assertEquals(array(), Config::inst()->get('ConfigSTATICTest_Third', 'second'));
+
+		Config::inst()->update('ConfigStaticTest_FIRST', 'int', 42);
+		$this->assertEquals(42, Config::inst()->get('ConfigSTATICTest_First', 'int'));
+
+		// Variable name is not
+		$this->assertEquals(Object::static_lookup('configtest_DEFINESFOO', 'FOO'), null);
+
+	}
+
 	public function testFragmentOrder() {
 		$this->markTestIncomplete();
 	}

--- a/tests/core/manifest/ConfigManifestTest.php
+++ b/tests/core/manifest/ConfigManifestTest.php
@@ -15,7 +15,7 @@ class ConfigManifestTest extends SapphireTest {
 	 */
 	protected function getConfigFixtureValue($name) {
 		$manifest = new SS_ConfigManifest(dirname(__FILE__).'/fixtures/configmanifest', true, true);
-		return $manifest->get('ConfigManifestTest', $name);
+		return $manifest->get('configmanifesttest', $name);
 	}
 
 	/**

--- a/tests/core/manifest/ConfigStaticManifestTest.php
+++ b/tests/core/manifest/ConfigStaticManifestTest.php
@@ -106,7 +106,7 @@ DOC;
 		foreach($levels as $var => $level) {
 			$this->assertEquals(
 				$level,
-				$statics[__CLASS__][$var]['access'],
+				$statics[strtolower(__CLASS__)][$var]['access'],
 				'Variable '.$var.' has '.($level ? token_name($level) : 'no').' access level'
 			);
 		}
@@ -139,7 +139,7 @@ DOC;
 
 				$this->assertEquals(
 					self::$$var,
-					$statics[__CLASS__][$var]['value'],
+					$statics[strtolower(__CLASS__)][$var]['value'],
 					'Variable '.$var.' value is extracted properly'
 				);
 			}
@@ -149,21 +149,21 @@ DOC;
 	public function testIgnoreComments() {
 		$statics = $this->parseSelf()->getStatics();
 
-		$this->assertEquals(self::$commented_int, $statics[__CLASS__]['commented_int']['value']);
-		$this->assertEquals(self::$commented_string, $statics[__CLASS__]['commented_string']['value']);
+		$this->assertEquals(self::$commented_int, $statics[strtolower(__CLASS__)]['commented_int']['value']);
+		$this->assertEquals(self::$commented_string, $statics[strtolower(__CLASS__)]['commented_string']['value']);
 
-		$this->assertEquals(self::$docblocked_int, $statics[__CLASS__]['docblocked_int']['value']);
-		$this->assertEquals(self::$docblocked_string, $statics[__CLASS__]['docblocked_string']['value']);
+		$this->assertEquals(self::$docblocked_int, $statics[strtolower(__CLASS__)]['docblocked_int']['value']);
+		$this->assertEquals(self::$docblocked_string, $statics[strtolower(__CLASS__)]['docblocked_string']['value']);
 	}
 
 	public function testIgnoresMethodStatics() {
 		$statics = $this->parseSelf()->getStatics();
-		$this->assertNull(@$statics[__CLASS__]['method_static']);
+		$this->assertNull(@$statics[strtolower(__CLASS__)]['method_static']);
 	}
 
 	public function testIgnoresStaticMethods() {
 		$statics = $this->parseSelf()->getStatics();
-		$this->assertNull(@$statics[__CLASS__]['static_method']);
+		$this->assertNull(@$statics[strtolower(__CLASS__)]['static_method']);
 	}
 
 	public function testParsingShortArray() {
@@ -183,7 +183,7 @@ DOC;
 			'Description' => 'Text',
 		);
 
-		$this->assertEquals($expectedValue, $statics['ConfigStaticManifestTestMyObject']['db']['value']);
+		$this->assertEquals($expectedValue, $statics['configstaticmanifesttestmyobject']['db']['value']);
 	}
 
 	public function testParsingNamespacesclass() {
@@ -198,7 +198,7 @@ DOC;
 			'Description' => 'Text',
 		);
 
-		$this->assertEquals($expectedValue, $statics['config\staticmanifest\NamespaceTest']['db']['value']);
+		$this->assertEquals($expectedValue, $statics['config\staticmanifest\namespacetest']['db']['value']);
 	}
 
 	public function testParsingMultyStringClass() {


### PR DESCRIPTION
The config system maps top-level key name to a PHP class. PHP classes are case-insensitive,
but without this patch, the Config system was case-sensitive on this variable. I think this
should be considered a bug.

The following patch makes the "class" key case-insensitive, but leave the "name" key, as
case-sensitive, mirroring the semantics of PHP classes and static variables, respectively.

Arguably, the entire config system could be case-insensitive, but I haven't done that in
this patch.
