### PR TITLE
Fixing header case in `send_file`

### DIFF
--- a/control/HTTPRequest.php
+++ b/control/HTTPRequest.php
@@ -395,7 +395,7 @@ class SS_HTTPRequest implements ArrayAccess {
 		$response = new SS_HTTPResponse($fileData);
 		$response->addHeader("Content-Type", "$mimeType; name=\"" . addslashes($fileName) . "\"");
 		// Note a IE-only fix that inspects this header in HTTP::add_cache_headers().
-		$response->addHeader("Content-disposition", "attachment; filename=" . addslashes($fileName));
+		$response->addHeader("Content-Disposition", "attachment; filename=" . addslashes($fileName));
 		$response->addHeader("Content-Length", strlen($fileData));
 		
 		return $response;


### PR DESCRIPTION
`SS_HTTPRequest::send_file()` currently uses the wrong case for the `Content-Disposition` header.
