### PR TITLE
Making Mailer ready for 3.2 and adding preflight hook

### DIFF
--- a/docs/en/topics/email.md
+++ b/docs/en/topics/email.md
@@ -25,6 +25,30 @@ by stripping HTML markup, or transforming it where possible
 
 The default HTML template is located in `framework/templates/email/GenericEmail.ss`.
 
+#### Preflight HTML hook
+
+Typically with HTML emails there is a need to run a "preflight" script, this can be a CSS inliner or other similar manipulation
+to the html content.
+
+To make use of the preflight hook you can add a data extension to the Mailer and add a `preflightHTML` function. Notice the html
+is passed by reference.
+
+```php
+
+class PreflightMailer extends Extension {
+
+	/**
+	 * Remove all tab chars from the HTML
+	 */
+	public function preflightHTML(&$html) {
+		//manipulate html
+		$html = str_replace("\t", '', $html);
+	}
+
+}
+
+```
+
 ### Sending Plaintext only
 
 	:::php

--- a/email/Mailer.php
+++ b/email/Mailer.php
@@ -144,6 +144,8 @@ class Mailer extends Object {
 				"</HTML>";
 		}
 
+		$this->extend('preflightHTML', $htmlContent);
+
 		$headers["Content-Transfer-Encoding"] = "quoted-printable";
 		$htmlPart = $this->processHeaders($headers, wordwrap($this->QuotedPrintable_encode($htmlContent),75));
 	


### PR DESCRIPTION
Making some changes that were documented for 3.2 and added a preflight hook for HTML emails.

It's very common for HTML emails to run through a preflight process before going out, we usually run emails through a CSS inliner so our templates are clean but are compatible with webmail clients.

This allows developers to hook into the HTML just before it's manipulated for sending
