### PR TITLE
BUG Reapply fix for cms crashing due to History.js blindly appending slashes to end of url

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -374,7 +374,8 @@ jQuery.noConflict();
 				// Artificial HTTP referer, IE doesn't submit them via ajax. 
 				// Also rewrites anchors to their page counterparts, which is important
 				// as automatic browser ajax response redirects seem to discard the hash/fragment.
-				formData.push({name: 'BackURL', value:History.getPageUrl()});
+				// TODO Replaces trailing slashes added by History after locale (e.g. admin/?locale=en/)
+				formData.push({name: 'BackURL', value:History.getPageUrl().replace(/\/$/, '')});
 
 				// Save tab selections so we can restore them later
 				this.saveTabState();


### PR DESCRIPTION
The same fix has been applied to LeftAndMain.js in another part of the file at https://github.com/tractorcow/sapphire/blob/79c727661144d556971c05cee81152d7a13bd59e/admin/javascript/LeftAndMain.js#L86
