### PR TITLE
FIX: Image_Backend -> croppedResize function doesn't include a backgroundColor

### DIFF
--- a/filesystem/ImagickBackend.php
+++ b/filesystem/ImagickBackend.php
@@ -247,12 +247,8 @@ class ImagickBackend extends Imagick implements Image_Backend {
 			return $this;
 		}
 		
-		if(!$backgroundColor){
-			$backgroundColor = new ImagickPixel('transparent');
-		}
-		
 		$new = clone $this;
-		$new->setBackgroundColor($backgroundColor);
+		$new->setBackgroundColor(new ImagickPixel('transparent'));
 		
 		if(($geo['width']/$width) < ($geo['height']/$height)){
 			$new->cropImage($geo['width'], floor($height*$geo['width']/$width),


### PR DESCRIPTION
The code was throwing a notice because `$backgroundColor` was never defined. This PR removed unused code.
