### PR TITLE
Fix CSSContentParser's use of CLI 'Tidy'

### DIFF
--- a/dev/CSSContentParser.php
+++ b/dev/CSSContentParser.php
@@ -30,7 +30,7 @@ class CSSContentParser extends Object {
 				array(
 					'output-xhtml' => true,
 					'numeric-entities' => true,
-					'wrap' => 99999, // We need this to be consistent for functional test string comparisons
+					'wrap' => 0, // We need this to be consistent for functional test string comparisons
 				), 
 				'utf8'
 			);
@@ -41,7 +41,7 @@ class CSSContentParser extends Object {
 		} elseif(@shell_exec('which tidy')) {
 			// using tiny through cli
 			$CLI_content = escapeshellarg($content);
-			$tidy = `echo $CLI_content | tidy -n -q -utf8 -asxhtml 2> /dev/null`;
+			$tidy = `echo $CLI_content | tidy -n -q -utf8 -asxhtml -w 0 2> /dev/null`;
 			$tidy = str_replace('xmlns="http://www.w3.org/1999/xhtml"','',$tidy);
 			$tidy = str_replace('&#160;','',$tidy);
 		} else {


### PR DESCRIPTION
This came up with failing framework unit tests locally:

```
1) CompositeFieldTest::testLegend
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'My legend'
+'My
+legend'
```

The -w option sets which column `tidy` should wrap at ([see man page](http://tidy.sourceforge.net/docs/tidy_man.html)). Without setting this, it’ll supposedly wrap at column 68 by default. The manual says that 0 is assumed if it’s omitted, but this doesn’t seem to always be the case (I’m on OS X 10.9.4 and that’s definitely not the case for me).

Marked as don’t merge as I wanted a second opinion before anyone clicks the green button - `CSSContentParser` isn’t exclusively used for unit tests, I’d hate to break something for someone (though I can’t see how/why someone would rely on wrapping at column 68!).

---

**Edit:** Just spotted that the use of php-tidy just above sets the word wrap to 99999, so seems the CLI wrapper was just overlooked.
