### PR TITLE
BUG Fixing plural_name messing up singular words ending in "e" (#3251)

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -713,9 +713,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 			return $name;
 		} else {
 			$name = $this->singular_name();
-			if(substr($name,-1) == 'e') $name = substr($name,0,-1);
-			else if(substr($name,-1) == 'y') $name = substr($name,0,-1) . 'ie';
-
+			if(substr($name,-1) == 'y') $name = substr($name,0,-1) . 'ie';
 			return ucfirst($name . 's');
 		}
 	}

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -949,21 +949,40 @@ class DataObjectTest extends SapphireTest {
 	 * Tests that singular_name() generates sensible defaults.
 	 */
 	public function testSingularName() {
-		$assertions = array (
+		$assertions = array(
 			'DataObjectTest_Player'       => 'Data Object Test Player',
 			'DataObjectTest_Team'         => 'Data Object Test Team',
 			'DataObjectTest_Fixture'      => 'Data Object Test Fixture'
 		);
 		
 		foreach($assertions as $class => $expectedSingularName) {
-			$this->assertEquals (
+			$this->assertEquals(
 				$expectedSingularName,
 				singleton($class)->singular_name(),
 				"Assert that the singular_name for '$class' is correct."
 			);
 		}
 	}
-	
+
+	/**
+	 * Tests that plural_name() generates sensible defaults.
+	 */
+	public function testPluralName() {
+		$assertions = array(
+			'DataObjectTest_Player'       => 'Data Object Test Players',
+			'DataObjectTest_Team'         => 'Data Object Test Teams',
+			'DataObjectTest_Fixture'      => 'Data Object Test Fixtures'
+		);
+
+		foreach($assertions as $class => $expectedPluralName) {
+			$this->assertEquals(
+				$expectedPluralName,
+				singleton($class)->plural_name(),
+				"Assert that the plural_name for '$class' is correct."
+			);
+		}
+	}
+
 	public function testHasDatabaseField() {
 		$team = singleton('DataObjectTest_Team');
 		$subteam = singleton('DataObjectTest_SubTeam');


### PR DESCRIPTION
This would ideally be fixed with the ability to use an external library
like gettext, but that's an API change. This for now fixes the issue
where a singular like "Page" returns "Pags" for the plural name.

I've also added a test, as there wasn't one before.
