### PR TITLE
Update GridFieldExportButton.php

### DIFF
--- a/forms/gridfield/GridFieldExportButton.php
+++ b/forms/gridfield/GridFieldExportButton.php
@@ -145,7 +145,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 				}
 
 				$value = str_replace(array("\r", "\n"), "\n", $value);
-				$columnData[] = '"' . str_replace('"', '\"', $value) . '"';
+				$columnData[] = '"' . str_replace('"', '""', $value) . '"';
 			}
 			$fileData .= implode($separator, $columnData);
 			$fileData .= "\n";

--- a/forms/gridfield/GridFieldExportButton.php
+++ b/forms/gridfield/GridFieldExportButton.php
@@ -21,6 +21,11 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 	protected $csvSeparator = ",";
 
 	/**
+	 * @var string
+	 */
+	protected $csvEnclosure = '"';
+
+	/**
 	 * @var boolean
 	 */
 	protected $csvHasHeader = true;
@@ -98,11 +103,10 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 	 * @return array
 	 */
 	public function generateExportFileData($gridField) {
-		$separator = $this->csvSeparator;
 		$csvColumns = ($this->exportColumns)
 			? $this->exportColumns
 			: singleton($gridField->getModelClass())->summaryFields();
-		$fileData = '';
+		$fileData = array();
 		$columnData = array();
 		$fieldItems = new ArrayList();
 
@@ -114,11 +118,10 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 			foreach($csvColumns as $columnSource => $columnHeader) {
 				$headers[] = (!is_string($columnHeader) && is_callable($columnHeader)) ? $columnSource : $columnHeader;
 			}
-
-			$fileData .= "\"" . implode("\"{$separator}\"", array_values($headers)) . "\"";
-			$fileData .= "\n";
+			
+			$fileData[] = $headers;
 		}
-
+		
 		$items = $gridField->getManipulatedList();
 
 		// @todo should GridFieldComponents change behaviour based on whether others are available in the config?
@@ -143,17 +146,23 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 				} else {
 					$value = $gridField->getDataFieldValue($item, $columnSource);
 				}
-
-				$value = str_replace(array("\r", "\n"), "\n", $value);
-				$columnData[] = '"' . str_replace('"', '""', $value) . '"';
+				
+				$columnData[] = $value;
 			}
-			$fileData .= implode($separator, $columnData);
-			$fileData .= "\n";
+			
+			$fileData[] = $columnData;
 
 			$item->destroy();
 		}
-
-		return $fileData;
+		
+		
+		ob_start();
+		$fp = fopen('php://output', 'w');
+		foreach($fileData as $line) {
+			fputcsv($fp, $line, $this->csvSeparator, $this->csvEnclosure);
+		}
+		fclose($fp);
+		return ob_get_clean();
 	}
 
 	/**

--- a/tests/forms/gridfield/GridFieldExportButtonTest.php
+++ b/tests/forms/gridfield/GridFieldExportButtonTest.php
@@ -27,7 +27,9 @@ class GridFieldExportButtonTest extends SapphireTest {
 		$button->setExportColumns(array('Name' => 'My Name'));
 
 		$this->assertEquals(
-			"\"My Name\"\n\"Test\"\n\"Test2\"\n",
+			'"My Name"'."\n".
+			'"Test"'."\n".
+			'"Test2"'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -42,7 +44,9 @@ class GridFieldExportButtonTest extends SapphireTest {
 		));
 
 		$this->assertEquals(
-			"\"Name\",\"City\"\n\"Test\",\"City city\"\n\"Test2\",\"City2 city\"\n",
+			'"Name","City"'."\n".
+			'"Test","City city"'."\n".
+			'"Test2","Quoted ""City"" 2 city"'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -55,7 +59,9 @@ class GridFieldExportButtonTest extends SapphireTest {
 		));
 
 		$this->assertEquals(
-			"\"Name\",\"strtolower\"\n\"Test\",\"City\"\n\"Test2\",\"City2\"\n",
+			'"Name","strtolower"'."\n".
+			'"Test","City"'."\n".
+			'"Test2","Quoted ""City"" 2"'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -69,7 +75,8 @@ class GridFieldExportButtonTest extends SapphireTest {
 		$button->setCsvHasHeader(false);
 
 		$this->assertEquals(
-			"\"Test\",\"City\"\n\"Test2\",\"City2\"\n",
+			'"Test","City"'."\n".
+			'"Test2","Quoted ""City"" 2"'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -87,4 +94,3 @@ class GridFieldExportButtonTest_Team extends DataObject implements TestOnly {
 	}
 
 }
-

--- a/tests/forms/gridfield/GridFieldExportButtonTest.php
+++ b/tests/forms/gridfield/GridFieldExportButtonTest.php
@@ -28,8 +28,8 @@ class GridFieldExportButtonTest extends SapphireTest {
 
 		$this->assertEquals(
 			'"My Name"'."\n".
-			'"Test"'."\n".
-			'"Test2"'."\n",
+			'Test'."\n".
+			'Test2'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -44,9 +44,9 @@ class GridFieldExportButtonTest extends SapphireTest {
 		));
 
 		$this->assertEquals(
-			'"Name","City"'."\n".
-			'"Test","City city"'."\n".
-			'"Test2","Quoted ""City"" 2 city"'."\n",
+			'Name,City'."\n".
+			'Test,"City city"'."\n".
+			'Test2,"Quoted ""City"" 2 city"'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -59,9 +59,9 @@ class GridFieldExportButtonTest extends SapphireTest {
 		));
 
 		$this->assertEquals(
-			'"Name","strtolower"'."\n".
-			'"Test","City"'."\n".
-			'"Test2","Quoted ""City"" 2"'."\n",
+			'Name,strtolower'."\n".
+			'Test,City'."\n".
+			'Test2,"Quoted ""City"" 2"'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -75,8 +75,8 @@ class GridFieldExportButtonTest extends SapphireTest {
 		$button->setCsvHasHeader(false);
 
 		$this->assertEquals(
-			'"Test","City"'."\n".
-			'"Test2","Quoted ""City"" 2"'."\n",
+			'Test,City'."\n".
+			'Test2,"Quoted ""City"" 2"'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}

--- a/tests/forms/gridfield/GridFieldExportButtonTest.yml
+++ b/tests/forms/gridfield/GridFieldExportButtonTest.yml
@@ -4,5 +4,4 @@ GridFieldExportButtonTest_Team:
         City: City
     test-team-2:
         Name: Test2
-        City: City2
-
+        City: 'Quoted "City" 2'


### PR DESCRIPTION
Quotes need to be escaped as "", not \".
http://tools.ietf.org/html/rfc4180#page-3 (point 7)

By the way, the `generateExportFileData` function can probably be simplified a lot by using [fputcsv](http://php.net/manual/en/function.fputcsv.php) (like [this](http://www.zyxware.com/articles/3527/how-to-create-csv-files-using-php)), but I didn't want to risk breaking any custom functionality for this simple change.