### PR TITLE
Fixed static usage in Form::messageForForm()

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -1053,8 +1053,11 @@ class Form extends RequestHandler {
 		Session::set("FormInfo.{$this->FormName()}.formError.type", $type);
 	}
 
-	public static function messageForForm( $formName, $message, $type ) {
-		Session::set("FormInfo.{$formName}.formError.message", $message);
+	public static function messageForForm( $formName, $message, $type, $escapeHtml = true) {
+		Session::set(
+			"FormInfo.{$formName}.formError.message", 
+			$escapeHtml ? Convert::raw2xml($message) : $message
+		);
 		Session::set("FormInfo.{$formName}.formError.type", $type);
 	}
 


### PR DESCRIPTION
This implements a fix here: https://github.com/micmania1/silverstripe-framework/commit/13371d910f1bd0e17a1827b6994f66e6aac3132a

It also fixes the usage of $FormName where it should be $formName (case-sensitive).
