### PR TITLE
FIX: belongs_many_many back to the same class type

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1864,9 +1864,9 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 				$belongsManyMany = Config::inst()->get($class, 'belongs_many_many', Config::UNINHERITED);
 				$candidate = (isset($belongsManyMany[$component])) ? $belongsManyMany[$component] : null;
 				if($candidate) {
-                    
+
 					list($candidate,$varName) = explode('.',$candidate);
-                    
+
 					$childField = $candidate . "ID";
 
 					// We need to find the inverse component name
@@ -1880,7 +1880,8 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 							if($candidateClass == $class || is_subclass_of($class, $candidateClass)) {
 								$parentField = ($class == $candidate) ? "ChildID" : $candidateClass . "ID";
 
-								return array($class, $candidate, $parentField, $childField,"{$candidate}_$inverseComponentName");
+								return array($class, $candidate, $parentField,
+								$childField,"{$candidate}_$inverseComponentName");
 							}
 						}
 					} else {

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1785,17 +1785,29 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 				$manyMany = $SNG_class->stat('belongs_many_many');
 				$candidate = (isset($manyMany[$component])) ? $manyMany[$component] : null;
 				if($candidate) {
+					list($candidate,$varName) = explode('.',$candidate);
+
 					$SNG_candidate = singleton($candidate);
 					$candidateManyMany = $SNG_candidate->stat('many_many');
 					
-					// Find the relation given the class
-					if($candidateManyMany) foreach($candidateManyMany as $relation => $relatedClass) {
-						if($relatedClass == $class) {
-							$relationName = $relation;
-						}
+					if( empty($varName) ) {
+						// Find the relation given the class
+						if($candidateManyMany) {
+							foreach($candidateManyMany as $relation => $relatedClass) {
+								if($relatedClass == $class) {
+									$relationName = $relation;
+								}
+							}
+						}	
+					} else {
+						$relationName = $varName;
 					}
-					
-					$extraFields = $SNG_candidate->stat('many_many_extraFields');
+						
+					if( !isset($relationName) ) {
+						user_error("Inverse component of $candidate not found ({$this->class})", E_USER_ERROR);
+					}
+		
+						$extraFields = $SNG_candidate->stat('many_many_extraFields');
 					if(isset($extraFields[$relationName])) {
 						return $extraFields[$relationName];
 					}
@@ -1852,6 +1864,9 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 				$belongsManyMany = Config::inst()->get($class, 'belongs_many_many', Config::UNINHERITED);
 				$candidate = (isset($belongsManyMany[$component])) ? $belongsManyMany[$component] : null;
 				if($candidate) {
+                    
+					list($candidate,$varName) = explode('.',$candidate);
+                    
 					$childField = $candidate . "ID";
 
 					// We need to find the inverse component name
@@ -1860,12 +1875,19 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 						user_error("Inverse component of $candidate not found ({$this->class})", E_USER_ERROR);
 					}
 
-					foreach($otherManyMany as $inverseComponentName => $candidateClass) {
-						if($candidateClass == $class || is_subclass_of($class, $candidateClass)) {
-							$parentField = ($class == $candidate) ? "ChildID" : $candidateClass . "ID";
+					if( empty($varName) ) {
+						foreach($otherManyMany as $inverseComponentName => $candidateClass) {
+							if($candidateClass == $class || is_subclass_of($class, $candidateClass)) {
+								$parentField = ($class == $candidate) ? "ChildID" : $candidateClass . "ID";
 
-							return array($class, $candidate, $parentField, $childField,
-								"{$candidate}_$inverseComponentName");
+								return array($class, $candidate, $parentField, $childField,"{$candidate}_$inverseComponentName");
+							}
+						}
+					} else {
+						if( isset($otherManyMany[$varName]) ) {
+							$candidateClass = $otherManyMany[$varName];
+							$parentField = ($class == $candidate) ? "ChildID" : $candidateClass . "ID";
+							return array($class, $candidate, $parentField, $childField,"{$candidate}_$varName");
 						}
 					}
 					user_error("Orphaned \$belongs_many_many value for $this->class.$component", E_USER_ERROR);


### PR DESCRIPTION
Currently SS get's confused when referencing multiple of the same DataObject type in a belongs_many_many definition using the dot notation.  It doesn't recognize the dot notation at all, and leaving it off means it will just choose the first match in the many_many definition which isn't correct.  This adds in the dot check and reverse look-up functionality allowing for multiple definitions.

Updates from PULL Request #3409
* formatting fixed (spaces to tabs)
* restored summaryFields function to original format (couldn't figure out why I changed that, might have been going down a rabbit hole at the time)