### PR TITLE
Remove @ suppression operator on session_start()

### DIFF
--- a/control/Session.php
+++ b/control/Session.php
@@ -376,10 +376,8 @@ class Session {
 			// seperate (less secure) session for non-HTTPS requests
 			if($secure) session_name('SECSESSID');
 
-			// @ is to supress win32 warnings/notices when session wasn't cleaned up properly
-			// There's nothing we can do about this, because it's an operating system function!
 			if($sid) session_id($sid);
-			@session_start();
+			session_start();
 
 			$this->data = isset($_SESSION) ? $_SESSION : array();
 		}


### PR DESCRIPTION
This was originally added to stop PHP on Windows complaining that it
couldn't garbage collect old sessions, but that was for an old version
of PHP years ago and doesn't seem to be an issue any longer. We
really shouldn't be suppressing this. If session_start() threw a
warning that it couldn't write to the filesystem, then we wouldn't
know about it at all.
