### PR TITLE
Reformat .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,34 @@
 language: php 
 
 php:
-  - 5.3
   - 5.4
-  - 5.5
-  - 5.6
 
 env:
   global:
+    - CORE_RELEASE=3.1
     - "ARTIFACTS_AWS_REGION=us-east-1"
     - "ARTIFACTS_S3_BUCKET=silverstripe-travis-artifacts"
     - secure: "DjwZKhY/c0wXppGmd8oEMiTV0ayfOXiCmi9Lg1aXoSXNnj+sjLmhYwhUWjehjR6IX0MRtzJG6v7V5Y+4nSGe+i+XIrBQnhPQ95Jrkm1gKofX2mznWTl9npQElNS1DXi58NLPbiB3qxHWGFBRAWmRQrsAouyZabkPnChnSa9ldOg="
     - secure: "UmbXCNLK0f2Dk+7qX8bOVcgIt4QhRvccoWvMUxaPtIU+95HCbG10eeCxvfOeBax+tHcRXmeCG4vM4tcuT/WoANkAma/VX74DylFjbWhks2tsKOcr2kjTrOwe6Q9CXOBjVAlcx0lnV/a+w83KARjXGnCrIbE7p7r4EDw31rkVufg="
   matrix:
-    - DB=MYSQL CORE_RELEASE=3.1
+    - DB=MYSQL
+    - DB=SQLITE
+    - DB=PGSQL 
 
 matrix:
   allow_failures:
     - php: hhvm-nightly
   include:
-    - php: 5.3
-      env: DB=PGSQL CORE_RELEASE=3.1
-    - php: 5.3
-      env: DB=SQLITE CORE_RELEASE=3.1
-    - php: 5.4
-      env: DB=MYSQL CORE_RELEASE=3.1
     - php: 5.5
-      env: DB=MYSQL CORE_RELEASE=3.1
+      env: DB=MYSQL
     - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.1
+      env: DB=MYSQL
     - php: 5.4
-      env: DB=MYSQL CORE_RELEASE=3.1 BEHAT_TEST=1
+      env: DB=MYSQL BEHAT_TEST=1
+    - php: 5.3
+      env: DB=MYSQL
     - php: hhvm-nightly
-      env: DB=MYSQL CORE_RELEASE=3.1
+      env: DB=MYSQL
       before_install:
         - sudo apt-get update -qq
         - sudo apt-get install -y tidy


### PR DESCRIPTION
Duplicate configurations were introduced at https://github.com/silverstripe/silverstripe-framework/commit/9476b22409706666bd6f24db41cc249bca3ab14e

Moved CORE_RELEASE to a global env since it is the same for every configuration.
