### PR TITLE
Don't clear BackURL after MemberAuthenticator::authenticate()

### DIFF
--- a/security/MemberAuthenticator.php
+++ b/security/MemberAuthenticator.php
@@ -115,10 +115,8 @@ class MemberAuthenticator extends Authenticator {
 			$member->write();
 		}
 
-		if($member) {
-			Session::clear('BackURL');
-		} else {
-			if($form && $result) $form->sessionMessage($result->message(), 'bad');
+		if(!$member && $form && $result) {
+			$form->sessionMessage($result->message(), 'bad');
 		}
 
 		return $member;


### PR DESCRIPTION
It breaks logic flow, e.g. when

Its called by BasicAuth:requireLogin() when basic auth is enabled, before any
controller logic kicks in (on every HTTP request). This means you can't use
session-based BackURLs with basic auth enabled, breaking flows like
redirection after Facebook logins.

I can't see why a clear() was necessary here, looks like a overly cautious way
to prevent infinite loops? Can't see how those would be caused by
requireLogin() though.

Been there since all the way back in 2007:
a377a67e540a33941e4a5436d169e4cfa93af58a

Followup from https://github.com/silverstripe/silverstripe-framework/pull/3089
