### PR TITLE
Refactored CSV export functionality to sit in it's own class.

### DIFF
--- a/exporters/CSVListExporter.php
+++ b/exporters/CSVListExporter.php
@@ -1,47 +1,112 @@
 <?php
-
+/**
+ * Converts a SS_List to a CSV string
+ *
+ * @package exporters
+ */
 class CSVListExporter implements SS_ListExporter{
 	
+	/**
+	 * List to extract data from
+	 * 
+	 * @var SS_List
+	 */
 	protected $list;
 
+	/**
+	 * List of columns to export
+	 * 
+	 * @var array
+	 */
 	protected $exportColumns;
 
+	/**
+	 * CSV seperator
+	 * 
+	 * @var string
+	 */
 	protected $csvSeparator = ",";
 
+	/**
+	 * Include header in export
+	 * 
+	 * @var boolean
+	 */
 	protected $csvHasHeader = true;
 
+	/**
+	 * Function that gets values from a record
+	 * 
+	 * @var Closure
+	 */
 	protected $callback;
 
-	function __construct(SS_List $list) {
+	public function __construct(SS_List $list) {
 		$this->list = $list;
 	}
 
-	public function setHasHeader(boolean $hasheader) {
+	/**
+	 * Determine if exports contain a CSV header.
+	 * 
+	 * @param boolean $hasHeader
+	 */
+	public function setHasHeader($hasheader) {
 		$this->csvHasHeader = $hasheader;
 		return $this;
 	}
 
-	public function setSeperator(string $seperator) {
+	/**
+	 * Set the character(s) that should be used to seperate
+	 * CSV data values.
+	 * @param string $seperator
+	 */
+	public function setSeperator($seperator) {
 		$this->csvSeparator = $seperator;
 		return $this;
 	}
 
+	/**
+	 * Set the columns that should be included in export.
+	 * @param array $columns
+	 */
 	public function setColumns(array $columns) {
 		$this->exportColumns = $columns;
 		return $this;
 	}
 
+	/**
+	 * Get the columns that will be included in exports.
+	 * @return array
+	 * @todo fall back to work out automatically from list model class
+	 */
 	public function getColumns() {
-		return $this->exportColumns;
-		//TODO: fall back to work out automatically from list model class
+		return $this->exportColumns;	
 	}
 
+	/**
+	 * Get value from a record in a customised way
+	 * The callbake takes two arguments: $record and $field
+	 *
+	 * Eg:
+	 * <code>
+	 * $writer->setDataCallback(function($item, $field) use ($gridField) {
+	 *		return $gridField->getDataFieldValue($item, $field);
+	 * });
+	 * </code>
+	 * 
+	 * @see export()
+	 * @param Closure $callback [description]
+	 */
 	public function setDataCallback(Closure $callback) {
 		$this->callback = $callback;
 		return $this;
 	}
 
-	function export() {
+	/**
+	 * Export the list to a string
+	 * @return string
+	 */
+	public function export() {
 		$fileData = '';
 		if($this->csvHasHeader) {
 			$headers = array();
@@ -79,6 +144,12 @@ class CSVListExporter implements SS_ListExporter{
 		return $fileData;
 	}
 
+	/**
+	 * Get a field from a list record in various ways.
+	 * @param  mixed $record
+	 * @param  string $fieldName
+	 * @return mixed
+	 */
 	protected function getFieldValue($record, $fieldName) {
 		if($record->hasMethod('relField')) {
 			return $record->relField($fieldName);

--- a/exporters/CSVListExporter.php
+++ b/exporters/CSVListExporter.php
@@ -1,0 +1,91 @@
+<?php
+
+class CSVListExporter implements SS_ListExporter{
+	
+	protected $list;
+
+	protected $exportColumns;
+
+	protected $csvSeparator = ",";
+
+	protected $csvHasHeader = true;
+
+	protected $callback;
+
+	function __construct(SS_List $list) {
+		$this->list = $list;
+	}
+
+	public function setHasHeader(bool $hasheader) {
+		$this->csvHasHeader = $hasheader;
+		return $this;
+	}
+
+	public function setSeperator(string $seperator) {
+		$this->csvSeparator = $seperator;
+		return $this;
+	}
+
+	public function setColumns(array $columns) {
+		$this->exportColumns = $columns;
+		return $this;
+	}
+
+	public function getColumns() {
+		return $this->exportColumns;
+		//TODO: fall back to work out automatically from list model class
+	}
+
+	public function setDataCallback(Closure $callback) {
+		$this->callback = $callback;
+		return $this;
+	}
+
+	function export() {
+		$fileData = '';
+		if($this->csvHasHeader) {
+			$headers = array();
+			// determine the CSV headers. If a field is callable (e.g. anonymous function) then use the
+			// source name as the header instead
+			foreach($this->exportColumns as $columnSource => $columnHeader) {
+				$headers[] = (!is_string($columnHeader) && is_callable($columnHeader)) ? $columnSource : $columnHeader;
+			}
+			$fileData .= "\"" . implode("\"{$this->csvSeparator}\"", array_values($headers)) . "\"";
+			$fileData .= "\n";
+		}
+		foreach($this->list->limit(null) as $item) {
+			$columnData = array();
+			foreach($this->exportColumns as $columnSource => $columnHeader) {
+				if(!is_string($columnHeader) && is_callable($columnHeader)) {
+					if($item->hasMethod($columnSource)) {
+						$relObj = $item->{$columnSource}();
+					} else {
+						$relObj = $item->relObject($columnSource);
+					}
+					$value = $columnHeader($relObj);
+				} elseif($callback = $this->callback) {
+					$value = $callback($item, $columnSource);
+				}else{
+					$value = $this->getFieldValue($item, $columnSource);
+				}
+				$value = str_replace(array("\r", "\n"), "\n", $value);
+				$columnData[] = '"' . str_replace('"', '\"', $value) . '"';
+			}
+			$fileData .= implode($this->csvSeparator, $columnData);
+			$fileData .= "\n";
+			$item->destroy();
+		}
+
+		return $fileData;
+	}
+
+	protected function getFieldValue($record, $fieldName) {
+		if($record->hasMethod('relField')) {
+			return $record->relField($fieldName);
+		} elseif($record->hasMethod($fieldName)) {
+			return $record->$fieldName();
+		}
+		return $record->$fieldName;
+	}
+
+}

--- a/exporters/CSVListExporter.php
+++ b/exporters/CSVListExporter.php
@@ -16,7 +16,7 @@ class CSVListExporter implements SS_ListExporter{
 		$this->list = $list;
 	}
 
-	public function setHasHeader(bool $hasheader) {
+	public function setHasHeader(boolean $hasheader) {
 		$this->csvHasHeader = $hasheader;
 		return $this;
 	}

--- a/exporters/ListExporter.php
+++ b/exporters/ListExporter.php
@@ -1,7 +1,16 @@
 <?php
 
+/**
+ * Interface for conferting SS_List into various formats
+ * 
+ * @package exporters
+ */
 interface SS_ListExporter{
 	
+	/**
+	 * Convert a SS_List into a particular format
+	 * @return string
+	 */
 	public function export();
 
 }

--- a/exporters/ListExporter.php
+++ b/exporters/ListExporter.php
@@ -1,0 +1,7 @@
+<?php
+
+interface SS_ListExporter{
+	
+	public function export();
+
+}

--- a/exporters/ListExporter.php
+++ b/exporters/ListExporter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Interface for conferting SS_List into various formats
+ * Interface for converting SS_List into various formats
  * 
  * @package exporters
  */

--- a/forms/gridfield/GridFieldExportButton.php
+++ b/forms/gridfield/GridFieldExportButton.php
@@ -24,6 +24,11 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 	 * @var boolean
 	 */
 	protected $csvHasHeader = true;
+
+	/**
+	 * @var boolean
+	 */
+	protected $exportFullList = false;
 	
 	/**
 	 * Fragment to write the button to
@@ -98,28 +103,11 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 	 * @return array
 	 */
 	public function generateExportFileData($gridField) {
-		$separator = $this->csvSeparator;
 		$csvColumns = ($this->exportColumns)
 			? $this->exportColumns
 			: singleton($gridField->getModelClass())->summaryFields();
-		$fileData = '';
-		$columnData = array();
-		$fieldItems = new ArrayList();
 
-		if($this->csvHasHeader) {
-			$headers = array();
-
-			// determine the CSV headers. If a field is callable (e.g. anonymous function) then use the
-			// source name as the header instead
-			foreach($csvColumns as $columnSource => $columnHeader) {
-				$headers[] = (!is_string($columnHeader) && is_callable($columnHeader)) ? $columnSource : $columnHeader;
-			}
-
-			$fileData .= "\"" . implode("\"{$separator}\"", array_values($headers)) . "\"";
-			$fileData .= "\n";
-		}
-
-		$items = $gridField->getManipulatedList();
+		$items = $this->exportFullList ? $gridField->getList() : $gridField->getManipulatedList();
 
 		// @todo should GridFieldComponents change behaviour based on whether others are available in the config?
 		foreach($gridField->getConfig()->getComponents() as $component){
@@ -127,31 +115,15 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 				$items = $component->getManipulatedData($gridField, $items);
 			}
 		}
-
-		foreach($items->limit(null) as $item) {
-			$columnData = array();
-
-			foreach($csvColumns as $columnSource => $columnHeader) {
-				if(!is_string($columnHeader) && is_callable($columnHeader)) {
-					if($item->hasMethod($columnSource)) {
-						$relObj = $item->{$columnSource}();
-					} else {
-						$relObj = $item->relObject($columnSource);
-					}
-
-					$value = $columnHeader($relObj);
-				} else {
-					$value = $gridField->getDataFieldValue($item, $columnSource);
-				}
-
-				$value = str_replace(array("\r", "\n"), "\n", $value);
-				$columnData[] = '"' . str_replace('"', '\"', $value) . '"';
-			}
-			$fileData .= implode($separator, $columnData);
-			$fileData .= "\n";
-
-			$item->destroy();
-		}
+		
+		$writer = new CSVListExporter($items);
+		$writer->setHasHeader($this->csvHasHeader)
+				->setSeperator($this->csvSeparator)
+				->setColumns($csvColumns)
+				->setDataCallback(function($item, $field) use ($gridField) {
+					return $gridField->getDataFieldValue($item, $field);
+				});
+		$fileData = $writer->export();
 
 		return $fileData;
 	}
@@ -198,6 +170,21 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 	 */
 	public function setCsvHasHeader($bool) {
 		$this->csvHasHeader = $bool;
+		return $this;
+	}
+
+	/**
+	 * @return boolean
+	 */
+	public function getExportFullList() {
+		return $this->exportFullList;
+	}
+
+	/**
+	 * @param boolean
+	 */
+	public function setExportFullList($dofullexport) {
+		$this->exportFullList = $dofullexport;
 		return $this;
 	}
 

--- a/forms/gridfield/GridFieldExportButton.php
+++ b/forms/gridfield/GridFieldExportButton.php
@@ -116,7 +116,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 			}
 		}
 		
-		$writer = new CSVListExporter($items);
+		$writer = Injector::inst()->create('CSVListExporter', $items);
 		$writer->setHasHeader($this->csvHasHeader)
 				->setSeperator($this->csvSeparator)
 				->setColumns($csvColumns)


### PR DESCRIPTION
I have split out CSV exporting functionality into it's own class.

Note the folder structure and interface I've created. What are your thoughts on these?

Yes this probably needs unit tests. I just wanted to get this work out for people to review for now.

Relates to (but doesn't fix) #2802 #2431 #3408

Also resolves this: http://stackoverflow.com/questions/17502299/how-to-export-all-rows-as-csv-in-modeladmin-silverstripe-3-1