### PR TITLE
Set the stage reading mode in `LeftAndMain`

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -436,6 +436,9 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		// The user's theme shouldn't affect the CMS, if, for example, they have 
 		// replaced TableListField.ss or Form.ss.
 		Config::inst()->update('SSViewer', 'theme_enabled', false);
+
+		//set the reading mode for the admin to stage
+		Versioned::set_reading_mode('Stage');
 	}
 	
 	public function handleRequest(SS_HTTPRequest $request, DataModel $model = null) {


### PR DESCRIPTION
`LeftAndMain` is used as the foundation of the CMS.

All edits in the CMS should really be against the stage version of a `DataObject` otherwise there becomes inconsistencies (see https://github.com/silverstripe/silverstripe-cms/issues/1094)