### PR TITLE
Allow setting cache lifetime for SS_Configuration and i18n caches

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -47,5 +47,8 @@ SS_Cache::pick_backend('aggregatestore', 'aggregate', 1000);
 // If you don't want to see deprecation errors for the new APIs, change this to 3.0.0-dev.
 Deprecation::notification_version('3.1.0');
 
+SS_Cache::set_cache_lifetime('SS_Configuration', null);
+SS_Cache::set_cache_lifetime('i18n', null);
+
 // TODO Remove once new ManifestBuilder with submodule support is in place
 require_once('admin/_config.php');

--- a/core/manifest/ConfigManifest.php
+++ b/core/manifest/ConfigManifest.php
@@ -111,11 +111,9 @@ class SS_ConfigManifest {
 	 * Provides a hook for mock unit tests despite no DI
 	 * @return Zend_Cache_Frontend
 	 */
-	protected function getCache()
-	{
+	protected function getCache() {
 		return SS_Cache::factory('SS_Configuration', 'Core', array(
-			'automatic_serialization' => true,
-			'lifetime' => null
+			'automatic_serialization' => true
 		));
 	}
 

--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -109,7 +109,9 @@ class i18n extends Object implements TemplateGlobalProvider, Flushable {
 	 * @return Zend_Cache
 	 */
 	public static function get_cache() {
-		return SS_Cache::factory('i18n', 'Output', array('lifetime' => null, 'automatic_serialization' => true));
+		return SS_Cache::factory('i18n', 'Output', array(
+			'automatic_serialization' => true
+		));
 	}
 
 	/**


### PR DESCRIPTION
This currently hardcodes the lifetimes to null. Doing so will make the
cache last indefinitely. However, this means we can't override the
lifetime from custom code, like this:

```
SS_Cache::set_cache_lifetime('any', 3600);
```

This change sets the cache lifetime configuration from
framework/_config.php so there's the potential to override it with
a higher priority from custom code.
