### PR TITLE
FIX: Broken unit tests if framework/ has been renamed

### DIFF
--- a/tests/forms/RequirementsTest.php
+++ b/tests/forms/RequirementsTest.php
@@ -405,7 +405,6 @@ class RequirementsTest extends SapphireTest {
 	public function testSuffix() {
 		$template = '<html><head></head><body><header>My header</header><p>Body</p></body></html>';
 		$basePath = $this->getCurrentRelativePath();
-		$basePath = 'framework' . substr($basePath, strlen(FRAMEWORK_DIR));
 
 		$backend = new Requirements_Backend;
 


### PR DESCRIPTION
I couldn’t think of a way of getting round the issue with `SSViewerTest::testRequireCallInTemplateInclude()`, as you can’t do `<% require javascript($ModulePath(framework)...) %>`, so I added a substitute test that’ll hopefully suffice!
