### PR TITLE
add .yml indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,8 @@ insert_final_newline = true
 indent_style = tab
 charset = utf-8
 trim_trailing_whitespace = true
+
+# indentation for YAML config files
+[_config/*.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
added some extra rules for any _config/*.yml files so that they use 2 space indents.
