### PR TITLE
Performance fix: Don't set distinct in DataQuery::initialiseQuery()

### DIFF
--- a/model/DataList.php
+++ b/model/DataList.php
@@ -212,6 +212,16 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 	}
 
 	/**
+	 * Return a new DataList instance with the query selecting as distinct.
+	 * @param bool $value
+	 */
+	public function distinct($value) {
+		return $this->alterDataQuery(function($query) use ($value){
+			$query->distinct($value);
+		});
+	}
+
+	/**
 	 * Return a new DataList instance with the records returned in this query
 	 * restricted by a limit clause.
 	 * 

--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -121,8 +121,7 @@ class DataQuery {
 
 		// Build our intial query
 		$this->query = new SQLQuery(array());
-		$this->query->setDistinct(true);
-		
+
 		if($sort = singleton($this->dataClass)->stat('default_sort')) {
 			$this->sort($sort);
 		}
@@ -537,7 +536,18 @@ class DataQuery {
 		$this->query->reverseOrderBy();
 		return $this;
 	}
-	
+
+
+	/**
+	 * Set whether the query should add DISTINCT or not.
+	 * @param bool $value
+	 * @return DataQuery
+	 */
+	public function distinct($value) {
+		$this->query->setDistinct($value);
+		return $this;
+	}
+
 	/**
 	 * Set the limit of this query.
 	 * 
@@ -558,6 +568,7 @@ class DataQuery {
 	 */
 	public function innerJoin($table, $onClause, $alias = null) {
 		if($table) {
+			$this->query->setDistinct(true);
 			$this->query->addInnerJoin($table, $onClause, $alias);
 		}
 		return $this;
@@ -572,6 +583,7 @@ class DataQuery {
 	 */
 	public function leftJoin($table, $onClause, $alias = null) {
 		if($table) {
+			$this->query->setDistinct(true);
 			$this->query->addLeftJoin($table, $onClause, $alias);
 		}
 		return $this;

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -135,7 +135,7 @@ class DataListTest extends SapphireTest {
 	public function testSql() {
 		$db = DB::getConn();
 		$list = DataObjectTest_TeamComment::get();
-		$expected = 'SELECT DISTINCT "DataObjectTest_TeamComment"."ClassName", "DataObjectTest_TeamComment"."Created",'
+		$expected = 'SELECT "DataObjectTest_TeamComment"."ClassName", "DataObjectTest_TeamComment"."Created",'
 			. ' "DataObjectTest_TeamComment"."LastEdited", "DataObjectTest_TeamComment"."Name",'
 			. ' "DataObjectTest_TeamComment"."Comment", "DataObjectTest_TeamComment"."TeamID",'
 			. ' "DataObjectTest_TeamComment"."ID", CASE WHEN "DataObjectTest_TeamComment"."ClassName" IS NOT NULL'

--- a/tests/model/DataObjectLazyLoadingTest.php
+++ b/tests/model/DataObjectLazyLoadingTest.php
@@ -30,7 +30,7 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 		$db = DB::getConn();
 		$playerList = new DataList('DataObjectTest_SubTeam');
 		$playerList = $playerList->setQueriedColumns(array('ID'));
-		$expected = 'SELECT DISTINCT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."Created", ' .
+		$expected = 'SELECT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."Created", ' .
 			'"DataObjectTest_Team"."LastEdited", "DataObjectTest_Team"."ID", CASE WHEN '.
 			'"DataObjectTest_Team"."ClassName" IS NOT NULL THEN "DataObjectTest_Team"."ClassName" ELSE ' .
 			$db->prepStringForDB('DataObjectTest_Team').' END AS "RecordClassName", "DataObjectTest_Team"."Title" '.
@@ -45,7 +45,7 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 		$db = DB::getConn();
 		$playerList = new DataList('DataObjectTest_SubTeam');
 		$playerList = $playerList->setQueriedColumns(array('Title', 'SubclassDatabaseField'));
-		$expected = 'SELECT DISTINCT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."Created", ' .
+		$expected = 'SELECT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."Created", ' .
 			'"DataObjectTest_Team"."LastEdited", "DataObjectTest_Team"."Title", ' .
 			'"DataObjectTest_SubTeam"."SubclassDatabaseField", "DataObjectTest_Team"."ID", CASE WHEN ' .
 			'"DataObjectTest_Team"."ClassName" IS NOT NULL THEN "DataObjectTest_Team"."ClassName" ELSE ' .
@@ -60,7 +60,7 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 		$db = DB::getConn();
 		$playerList = new DataList('DataObjectTest_SubTeam');
 		$playerList = $playerList->setQueriedColumns(array('Title'));
-		$expected = 'SELECT DISTINCT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."Created", ' .
+		$expected = 'SELECT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."Created", ' .
 			'"DataObjectTest_Team"."LastEdited", "DataObjectTest_Team"."Title", "DataObjectTest_Team"."ID", ' .
 			'CASE WHEN "DataObjectTest_Team"."ClassName" IS NOT NULL THEN "DataObjectTest_Team"."ClassName" ELSE ' .
 			$db->prepStringForDB('DataObjectTest_Team').' END AS "RecordClassName" FROM "DataObjectTest_Team" ' . 
@@ -74,7 +74,7 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 		$db = DB::getConn();
 		$playerList = new DataList('DataObjectTest_SubTeam');
 		$playerList = $playerList->setQueriedColumns(array('SubclassDatabaseField'));
-		$expected = 'SELECT DISTINCT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."Created", ' .
+		$expected = 'SELECT "DataObjectTest_Team"."ClassName", "DataObjectTest_Team"."Created", ' .
 			'"DataObjectTest_Team"."LastEdited", "DataObjectTest_SubTeam"."SubclassDatabaseField", ' .
 			'"DataObjectTest_Team"."ID", CASE WHEN "DataObjectTest_Team"."ClassName" IS NOT NULL THEN ' .
 			'"DataObjectTest_Team"."ClassName" ELSE '.$db->prepStringForDB('DataObjectTest_Team').' END ' .
@@ -91,7 +91,7 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 		$playerList = new DataList('DataObjectTest_Team');
 		// Shouldn't be a left join in here.
 		$this->assertEquals(0, 
-			preg_match('/SELECT DISTINCT "DataObjectTest_Team"."ID" .* LEFT JOIN .* FROM "DataObjectTest_Team"/',
+			preg_match('/SELECT "DataObjectTest_Team"."ID" .* LEFT JOIN .* FROM "DataObjectTest_Team"/',
 			$playerList->sql()));
 	}
 
@@ -99,7 +99,7 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 		// This queries all columns from base table and subtable
 		$playerList = new DataList('DataObjectTest_SubTeam');
 		// Should be a left join.
-		$this->assertEquals(1, preg_match('/SELECT DISTINCT .* LEFT JOIN .* /', $playerList->sql()));
+		$this->assertEquals(1, preg_match('/SELECT .* LEFT JOIN .* /', $playerList->sql()));
 	}
 
 	public function testLazyLoadedFieldsHasField() {


### PR DESCRIPTION
Currently _all_ ORM queries are marked as DISTINCT. This has the effect
of slowing down queries on tables with lots of records dramatically.
