### PR TITLE
Adding ability to change query distinct on DataList and DataQuery

### DIFF
--- a/model/DataList.php
+++ b/model/DataList.php
@@ -223,7 +223,18 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 			$query->limit($limit, $offset);
 		});
 	}
-	
+
+	/**
+	 * Return a new DataList instance with distinct records or not
+	 *
+	 * @param bool $value
+	 */
+	public function distinct($value) {
+		return $this->alterDataQuery(function($query) use ($value){
+			$query->distinct($value);
+		});
+	}
+
 	/**
 	 * Return a new DataList instance as a copy of this data list with the sort
 	 * order set.

--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -550,6 +550,17 @@ class DataQuery {
 	}
 
 	/**
+	 * Set whether this query should be distinct or not.
+	 *
+	 * @param bool $value
+	 * @return DataQuery
+	 */
+	public function distinct($value) {
+		$this->query->setDistinct($value);
+		return $this;
+	}
+
+	/**
 	 * Add an INNER JOIN clause to this query.
 	 * 
 	 * @param String $table The unquoted table name to join to.

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -121,7 +121,18 @@ class DataListTest extends SapphireTest {
 		// $check = $list->limit(null, 2);
 		// $this->assertEquals(1, $check->count());
 	}
-	
+
+	public function testDistinct() {
+		$list = DataObjectTest_TeamComment::get();
+		$this->assertContains('SELECT DISTINCT', $list->dataQuery()->sql(), 'Query is set as distinct by default');
+
+		$list = $list->distinct(false);
+		$this->assertNotContains('SELECT DISTINCT', $list->dataQuery()->sql(), 'Query does not contain distinct');
+
+		$list = $list->distinct(true);
+		$this->assertContains('SELECT DISTINCT', $list->dataQuery()->sql(), 'Query contains distinct');
+	}
+
 	public function testDataClass() {
 		$list = DataObjectTest_TeamComment::get();
 		$this->assertEquals('DataObjectTest_TeamComment',$list->dataClass());

--- a/tests/model/DataQueryTest.php
+++ b/tests/model/DataQueryTest.php
@@ -155,6 +155,18 @@ class DataQueryTest extends SapphireTest {
 		$result = $query->column('Title');
 		$this->assertEquals(array('First', 'Second', 'Last'), $result);
 	}
+
+	public function testDistinct() {
+		$query = new DataQuery('DataQueryTest_E');
+		$this->assertContains('SELECT DISTINCT', $query->sql(), 'Query is set as distinct by default');
+
+		$query = $query->distinct(false);
+		$this->assertNotContains('SELECT DISTINCT', $query->sql(), 'Query does not contain distinct');
+
+		$query = $query->distinct(true);
+		$this->assertContains('SELECT DISTINCT', $query->sql(), 'Query contains distinct');
+	}
+
 }
 
 


### PR DESCRIPTION
Since `setDistinct(true)` is being called on every use of `DataList` via `DataQuery::initialiseQuery()`, this change gives the ability to call `distinct(false)` on a `DataList` (or `DataQuery` directly) to turn that off. This is especially useful in cases where you're dealing with queries to tables with loads of data, as the use of distinct can slow things down considerably.

We can consider removing distinct from being the default, but probably something for master, not 3.1. If we decided to do that, this change would let you enable distinct on-demand.
