### PR TITLE
BUG CSSContentParser fails if CLI tidy doesn't output anything.

### DIFF
--- a/dev/CSSContentParser.php
+++ b/dev/CSSContentParser.php
@@ -41,7 +41,7 @@ class CSSContentParser extends Object {
 		} elseif(@shell_exec('which tidy')) {
 			// using tiny through cli
 			$CLI_content = escapeshellarg($content);
-			$tidy = `echo $CLI_content | tidy -n -q -utf8 -asxhtml -w 0 2> /dev/null`;
+			$tidy = `echo $CLI_content | tidy --force-output 1 -n -q -utf8 -asxhtml -w 0 2> /dev/null`;
 			$tidy = str_replace('xmlns="http://www.w3.org/1999/xhtml"','',$tidy);
 			$tidy = str_replace('&#160;','',$tidy);
 		} else {


### PR DESCRIPTION
In cases where CLI tidy fails to recognise HTML with errors or
unknown HTML5 elements, it doesn't output any content and
CSSContentParser fails.

This adds the --force-output parameter so that it always outputs
the input content, even if it wasn't completely fixed by tidy.

It seems that tidy class in PHP already does this, so this just
fixes the CLI use of tidy in CSSContentParser to be consistent.

This fix can be observed on the HHVM travis builds, as tidy isn't
available compiled into HHVM as an extension.
