### PR TITLE
BUG: Fixed issue where FormField::getAttributesHTML() params from template are ignored

### DIFF
--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -405,6 +405,14 @@ class FormField extends RequestHandler {
 
 		return implode(' ', $parts);
 	}
+	
+	/**
+	 * Alias of getAttributesHTML() for template use
+	 * @see FormField::getAttributesHTML()
+	 */
+	public function AttributesHTML() {
+		return call_user_func_array(array($this, 'getAttributesHTML'), func_get_args());
+	}
 
 	/**
 	 * Returns a version of a title suitable for insertion into an HTML attribute


### PR DESCRIPTION
Because of how the template parser works attributes passed into FormField::getAttributesHTML() from templates were ignored. This causes form fields like CreditCardField to have duplicate html attributes, in the case of the name attribute this causes a php error when the field is validated.

I'm not sure I like this fix but its the only way I know of to get around the compatibility issue if FormField::getAttributesHTML() is renamed to FormField::AttributesHTML(). If you simply call FormField::getAttributesHTML() from the added method passing in an array it breaks the attributes so using call_user_func_array() seems to be the only way short of duplicating code.