### PR TITLE
fixed and tested object has_extension

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -475,9 +475,10 @@ abstract class Object {
 	 * and new format ($object->has_extension($class, $requiredExtension))
 	 * @param string $classOrExtension if 1 argument supplied, the class name of the extension to
 	 *                                 check for; if 2 supplied, the class name to test
-	 * @param string $requiredExtension used only if 2 arguments supplied 
+	 * @param string $requiredExtension used only if 2 arguments supplied
+	 * @param boolean $strict if the extension has to match the required extension and not be a subclass
 	 */
-	public static function has_extension($classOrExtension, $requiredExtension = null) {
+	public static function has_extension($classOrExtension, $requiredExtension = null, $strict = false) {
 		//BC support
 		if(func_num_args() > 1){
 			$class = $classOrExtension;
@@ -495,6 +496,7 @@ abstract class Object {
 			$left = strtolower(Extension::get_classname_without_arguments($extension));
 			$right = strtolower(Extension::get_classname_without_arguments($requiredExtension));
 			if($left == $right) return true;
+			if (!$strict && is_subclass_of($left, $right)) return true;
 		}
 		
 		return false;

--- a/tests/core/ObjectTest.php
+++ b/tests/core/ObjectTest.php
@@ -233,6 +233,25 @@ class ObjectTest extends SapphireTest {
 			ObjectTest_ExtensionTest::has_extension('ObjectTest_ExtendTest3'),
 			"Extensions are detected with static has_extension() when added through add_extension()"
 		);
+		// ObjectTest_ExtendTest4 is added manually
+		ObjectTest_ExtensionTest3::add_extension('ObjectTest_ExtendTest4("Param")');
+		// test against ObjectTest_ExtendTest3, not ObjectTest_ExtendTest3
+		$this->assertTrue(
+			ObjectTest_ExtensionTest3::has_extension('ObjectTest_ExtendTest4'),
+			"Extensions are detected with static has_extension() when added through add_extension()"
+		);
+		// test against ObjectTest_ExtendTest3, not ObjectTest_ExtendTest4 to test if it picks up
+		// the sub classes of ObjectTest_ExtendTest3
+		$this->assertTrue(
+			ObjectTest_ExtensionTest3::has_extension('ObjectTest_ExtendTest3'),
+			"Sub-Extensions are detected with static has_extension() when added through add_extension()"
+		);
+		// strictly test against ObjectTest_ExtendTest3, not ObjectTest_ExtendTest4 to test if it picks up
+		// the sub classes of ObjectTest_ExtendTest3
+		$this->assertFalse(
+			ObjectTest_ExtensionTest3::has_extension('ObjectTest_ExtendTest3', null, true),
+			"Sub-Extensions are detected with static has_extension() when added through add_extension()"
+		);
 		// a singleton() wouldn't work as its already initialized
 		$objectTest_ExtensionTest = new ObjectTest_ExtensionTest();
 		$this->assertTrue(
@@ -518,6 +537,10 @@ class ObjectTest_ExtensionTest2 extends Object {
 	private static $extensions = array('ObjectTest_Extension');
 }
 
+
+class ObjectTest_ExtensionTest3 extends Object {
+}
+
 class ObjectTest_ExtensionRemoveTest extends Object {
 	
 	private static $extensions = array (
@@ -561,6 +584,10 @@ class ObjectTest_ExtendTest2 extends Extension {
 
 class ObjectTest_ExtendTest3 extends Extension {
 	public function extendableMethod($argument = null) { return "ExtendTest3($argument)"; }
+}
+
+class ObjectTest_ExtendTest4 extends ObjectTest_ExtendTest3 {
+	public function extendableMethod($argument = null) { return "ExtendTest4($argument)"; }
 }
 
 /**#@-*/


### PR DESCRIPTION
If you extend an extension and apply it to a class, then thest if the class has the base extension it currently returns false.

Extension2 extends Extension1
Page::add_extension('Extension2');
Page::has_extension('Extension1') should return true, before this patch does not.
