### PR TITLE
Update Debug.php

### DIFF
--- a/dev/Debug.php
+++ b/dev/Debug.php
@@ -346,7 +346,7 @@ class Debug {
 					class_exists('Translatable') ? Translatable::get_current_locale() : null
 				);
 				if(file_exists($errorFilePath)) {
-					$content = file_get_contents(ASSETS_PATH . "/error-$statusCode.html");
+					$content = file_get_contents($errorFilePath);
 					if(!headers_sent()) header('Content-Type: text/html');
 					// $BaseURL is left dynamic in error-###.html, so that multi-domain sites don't get broken
 					echo str_replace('$BaseURL', Director::absoluteBaseURL(), $content);


### PR DESCRIPTION
The above change allows you to actually override the path. As is, the whole call to `ErrorPage::get_filepath_for_errorcode` is pointless. Would it be possible to port this to the 3.1 branch too?
