### PR TITLE
API Allow parameterised joins / subselects

### DIFF
--- a/docs/en/changelogs/3.2.0.md
+++ b/docs/en/changelogs/3.2.0.md
@@ -305,10 +305,10 @@ Examples of areas where queries should be upgraded are below:
 			'"Title" = ?', $title
 		);
 
-4. #### Interaction with the `DataList::sql()`, `DataQuery::sql()` or `SQLSelect::sql()` methods
+4. #### Interaction with `DataList::sql()`, `DataQuery::sql()`, `SQLSelect::sql()`, or `SQLSelect::getJoins()` methods
 
 	The place where legacy code would almost certainly fail is any code that calls
-	`SQLQuery::sql`, `DataList::sql` or `DataQuery::sql`, as the api requires that user
+	`SQLQuery::sql`, `DataList::sql`, `DataQuery::sql` or `SQLSelect::getJoins()`, as the api requires that user
 	code passes in an argument here to retrieve SQL parameters by value.
 
 	User code that assumes parameterless queries will likely fail, and need to be

--- a/docs/en/topics/datamodel.md
+++ b/docs/en/topics/datamodel.md
@@ -485,6 +485,8 @@ methods have the same arguments:
  * The name of the table to join to
  * The filter clause for the join
  * An optional alias
+ * Priority (to allow you to later sort joins)
+ * An optional list of parameters (in case you wish to use a parameterised subselect).
 
 For example:
 
@@ -495,6 +497,17 @@ For example:
 
 	$members = Member::get()
 		->innerJoin("Group_Members", "\"Rel\".\"MemberID\" = \"Member\".\"ID\"", "Rel");
+
+	// With a subselect
+	$members = Member::get()
+		->innerJoin(
+			'(SELECT "MemberID", COUNT("ID") AS "Count" FROM "Member_Likes" GROUP BY "MemberID" HAVING "Count" >= ?)',
+			'"Likes"."MemberID" = "Member"."ID"',
+			"Likes",
+			20,
+			array($threshold)
+		);
+
 	
 Passing a *$join* statement to DataObject::get will filter results further by
 the JOINs performed against the foreign table. **It will NOT return the

--- a/model/DataList.php
+++ b/model/DataList.php
@@ -599,11 +599,15 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 	 * @param string $table Table name (unquoted and as escaped SQL)
 	 * @param string $onClause Escaped SQL statement, e.g. '"Table1"."ID" = "Table2"."ID"'
 	 * @param string $alias - if you want this table to be aliased under another name
+	 * @param int $order A numerical index to control the order that joins are added to the query; lower order values
+	 * will cause the query to appear first. The default is 20, and joins created automatically by the
+	 * ORM have a value of 10.
+	 * @param array $parameters Any additional parameters if the join is a parameterised subquery
 	 * @return DataList
 	 */
-	public function innerJoin($table, $onClause, $alias = null) {
-		return $this->alterDataQuery(function($query) use ($table, $onClause, $alias){
-			$query->innerJoin($table, $onClause, $alias);
+	public function innerJoin($table, $onClause, $alias = null, $order = 20, $parameters = array()) {
+		return $this->alterDataQuery(function($query) use ($table, $onClause, $alias, $order, $parameters){
+			$query->innerJoin($table, $onClause, $alias, $order, $parameters);
 		});
 	}
 
@@ -613,11 +617,15 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 	 * @param string $table Table name (unquoted and as escaped SQL)
 	 * @param string $onClause Escaped SQL statement, e.g. '"Table1"."ID" = "Table2"."ID"'
 	 * @param string $alias - if you want this table to be aliased under another name
+	 * @param int $order A numerical index to control the order that joins are added to the query; lower order values
+	 * will cause the query to appear first. The default is 20, and joins created automatically by the
+	 * ORM have a value of 10.
+	 * @param array $parameters Any additional parameters if the join is a parameterised subquery
 	 * @return DataList
 	 */
-	public function leftJoin($table, $onClause, $alias = null) {
-		return $this->alterDataQuery(function($query) use ($table, $onClause, $alias){
-			$query->leftJoin($table, $onClause, $alias);
+	public function leftJoin($table, $onClause, $alias = null, $order = 20, $parameters = array()) {
+		return $this->alterDataQuery(function($query) use ($table, $onClause, $alias, $order, $parameters){
+			$query->leftJoin($table, $onClause, $alias, $order, $parameters);
 		});
 	}
 

--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -583,10 +583,14 @@ class DataQuery {
 	 * @param String $table The unquoted table name to join to.
 	 * @param String $onClause The filter for the join (escaped SQL statement)
 	 * @param String $alias An optional alias name (unquoted)
+	 * @param int $order A numerical index to control the order that joins are added to the query; lower order values
+	 * will cause the query to appear first. The default is 20, and joins created automatically by the
+	 * ORM have a value of 10.
+	 * @param array $parameters Any additional parameters if the join is a parameterised subquery
 	 */
-	public function innerJoin($table, $onClause, $alias = null) {
+	public function innerJoin($table, $onClause, $alias = null, $order = 20, $parameters = array()) {
 		if($table) {
-			$this->query->addInnerJoin($table, $onClause, $alias);
+			$this->query->addInnerJoin($table, $onClause, $alias, $order, $parameters);
 		}
 		return $this;
 	}
@@ -594,13 +598,17 @@ class DataQuery {
 	/**
 	 * Add a LEFT JOIN clause to this query.
 	 *
-	 * @param String $table The unquoted table to join to.
-	 * @param String $onClause The filter for the join (escaped SQL statement).
-	 * @param String $alias An optional alias name (unquoted)
+	 * @param string $table The unquoted table to join to.
+	 * @param string $onClause The filter for the join (escaped SQL statement).
+	 * @param string $alias An optional alias name (unquoted)
+	 * @param int $order A numerical index to control the order that joins are added to the query; lower order values
+	 * will cause the query to appear first. The default is 20, and joins created automatically by the
+	 * ORM have a value of 10.
+	 * @param array $parameters Any additional parameters if the join is a parameterised subquery
 	 */
-	public function leftJoin($table, $onClause, $alias = null) {
+	public function leftJoin($table, $onClause, $alias = null, $order = 20, $parameters = array()) {
 		if($table) {
-			$this->query->addLeftJoin($table, $onClause, $alias);
+			$this->query->addLeftJoin($table, $onClause, $alias, $order, $parameters);
 		}
 		return $this;
 	}

--- a/model/connect/DBQueryBuilder.php
+++ b/model/connect/DBQueryBuilder.php
@@ -216,8 +216,9 @@ class DBQueryBuilder {
 	 * @param array $parameters Out parameter for the resulting query parameters
 	 * @return string Completed from part of statement
 	 */
-	public function buildFromFragment(SQLExpression $query, array &$parameters) {
-		$from = $query->getJoins();
+	public function buildFromFragment(SQLConditionalExpression $query, array &$parameters) {
+		$from = $query->getJoins($joinParameters);
+		$parameters = array_merge($parameters, $joinParameters);
 		$nl = $this->getSeparator();
 		return  "{$nl}FROM " . implode(' ', $from);
 	}
@@ -229,8 +230,7 @@ class DBQueryBuilder {
 	 * @param array $parameters Out parameter for the resulting query parameters
 	 * @return string Completed where condition
 	 */
-	public function buildWhereFragment(SQLExpression $query, array &$parameters) {
-
+	public function buildWhereFragment(SQLConditionalExpression $query, array &$parameters) {
 		// Get parameterised elements
 		$where = $query->getWhereParameterised($whereParameters);
 		if(empty($where)) return '';

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -168,6 +168,36 @@ class DataListTest extends SapphireTest {
 			. '"DataObjectTest_TeamComment"."TeamID"';
 
 		$this->assertSQLEquals($expected, $list->sql($parameters));
+		$this->assertEmpty($parameters);
+	}
+
+	public function testInnerJoinParameterised() {
+		$db = DB::get_conn();
+		
+		$list = DataObjectTest_TeamComment::get();
+		$list = $list->innerJoin(
+			'DataObjectTest_Team',
+			'"DataObjectTest_Team"."ID" = "DataObjectTest_TeamComment"."TeamID" '
+			. 'AND "DataObjectTest_Team"."Title" LIKE ?',
+			'Team',
+			20,
+			array('Team%')
+		);
+
+		$expected = 'SELECT DISTINCT "DataObjectTest_TeamComment"."ClassName", '
+			. '"DataObjectTest_TeamComment"."LastEdited", "DataObjectTest_TeamComment"."Created", '
+			. '"DataObjectTest_TeamComment"."Name", "DataObjectTest_TeamComment"."Comment", '
+			. '"DataObjectTest_TeamComment"."TeamID", "DataObjectTest_TeamComment"."ID", '
+			. 'CASE WHEN "DataObjectTest_TeamComment"."ClassName" IS NOT NULL'
+			. ' THEN "DataObjectTest_TeamComment"."ClassName" ELSE '
+			. $db->quoteString('DataObjectTest_TeamComment')
+			. ' END AS "RecordClassName" FROM "DataObjectTest_TeamComment" INNER JOIN '
+			. '"DataObjectTest_Team" AS "Team" ON "DataObjectTest_Team"."ID" = '
+			. '"DataObjectTest_TeamComment"."TeamID" '
+			. 'AND "DataObjectTest_Team"."Title" LIKE ?';
+
+		$this->assertSQLEquals($expected, $list->sql($parameters));
+		$this->assertEquals(array('Team%'), $parameters);
 	}
 
 	public function testLeftJoin() {
@@ -191,6 +221,7 @@ class DataListTest extends SapphireTest {
 			. 'AS "Team" ON "DataObjectTest_Team"."ID" = "DataObjectTest_TeamComment"."TeamID"';
 
 		$this->assertSQLEquals($expected, $list->sql($parameters));
+		$this->assertEmpty($parameters);
 
 		// Test with namespaces (with non-sensical join, but good enough for testing)
 		$list = DataObjectTest_TeamComment::get();
@@ -213,7 +244,37 @@ class DataListTest extends SapphireTest {
 			. 'LEFT JOIN "DataObjectTest\NamespacedClass" ON '
 			. '"DataObjectTest\NamespacedClass"."ID" = "DataObjectTest_TeamComment"."ID"';
 		$this->assertSQLEquals($expected, $list->sql($parameters), 'Retains backslashes in namespaced classes');
+		$this->assertEmpty($parameters);
 
+	}
+
+	public function testLeftJoinParameterised() {
+		$db = DB::get_conn();
+
+		$list = DataObjectTest_TeamComment::get();
+		$list = $list->leftJoin(
+			'DataObjectTest_Team',
+			'"DataObjectTest_Team"."ID" = "DataObjectTest_TeamComment"."TeamID" '
+			. 'AND "DataObjectTest_Team"."Title" LIKE ?',
+			'Team',
+			20,
+			array('Team%')
+		);
+
+		$expected = 'SELECT DISTINCT "DataObjectTest_TeamComment"."ClassName", '
+			. '"DataObjectTest_TeamComment"."LastEdited", "DataObjectTest_TeamComment"."Created", '
+			. '"DataObjectTest_TeamComment"."Name", "DataObjectTest_TeamComment"."Comment", '
+			. '"DataObjectTest_TeamComment"."TeamID", "DataObjectTest_TeamComment"."ID", '
+			. 'CASE WHEN "DataObjectTest_TeamComment"."ClassName" IS NOT NULL'
+			. ' THEN "DataObjectTest_TeamComment"."ClassName" ELSE '
+			. $db->quoteString('DataObjectTest_TeamComment')
+			. ' END AS "RecordClassName" FROM "DataObjectTest_TeamComment" LEFT JOIN '
+			. '"DataObjectTest_Team" AS "Team" ON "DataObjectTest_Team"."ID" = '
+			. '"DataObjectTest_TeamComment"."TeamID" '
+			. 'AND "DataObjectTest_Team"."Title" LIKE ?';
+
+		$this->assertSQLEquals($expected, $list->sql($parameters));
+		$this->assertEquals(array('Team%'), $parameters);
 	}
 
 	public function testToNestedArray() {


### PR DESCRIPTION
Until now only where conditions supported parameters.

In some cases, however, it can be more SQL efficient to join against subselects (e.g. when joining a table against a grouped subselect), and it may be necessary to allow parameterised conditions there.

This is necessary for migration of a certain part of the forum module to the new framework. (see https://github.com/silverstripe/silverstripe-forum/blob/0.6/code/pagetypes/Forum.php#L410)
