### PR TITLE
Gridfield Paginator counting only viewable items

### DIFF
--- a/forms/gridfield/GridFieldPaginator.php
+++ b/forms/gridfield/GridFieldPaginator.php
@@ -136,8 +136,12 @@ class GridFieldPaginator implements GridField_HTMLProvider, GridField_DataManipu
 
 		$state = $this->getGridPagerState($gridField);
 
-		// Update item count prior to filter. GridFieldPageCount will rely on this value
-		$this->totalItems = $dataList->count();
+		// Update item count prior to filter. Just the count the viewable items.
+		// GridFieldPageCount will rely on this value.
+		$this->totalItems = 0;
+		foreach ($dataList as $item) {
+			if (method_exists($item, 'canView') && $item->canView()) $this->totalItems++;
+		}
 
 		if(!($dataList instanceof SS_Limitable) || ($dataList instanceof UnsavedRelationList)) {
 			return $dataList;


### PR DESCRIPTION
When displaying any list which contains objects which aren't viewable for the current user the count isn't equal with the number of viewed elements. I tried it with a ArrayList containing DataObjects which use _canView() to determine if it should be displayed. The DataObjects which weren't allowed to display didn't show up but still were counted.
