### PR TITLE
BUG If config key doesn't exist, false config vals aren't set.

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -349,13 +349,14 @@ class Config {
 	 */
 	public static function merge_array_low_into_high(&$dest, $src) {
 		foreach ($src as $k => $v) {
-			if (!$v) {
-				continue;
-			}
-			else if (is_int($k)) {
+			if (is_int($k)) {
 				$dest[] = $v;
 			}
 			else if (isset($dest[$k])) {
+				if (!$v) {
+					continue;
+				}
+
 				$newType = self::get_value_type($v);
 				$currentType = self::get_value_type($dest[$k]);
 

--- a/tests/core/ConfigTest.php
+++ b/tests/core/ConfigTest.php
@@ -208,6 +208,20 @@ class ConfigTest extends SapphireTest {
 			array('test_3', 'test_1'));
 	}
 
+	public function testFalseValueMerges() {
+		$result = array('A' => true, 'B' => true);
+		Config::merge_array_low_into_high($result, array('A' => false, 'B' => true));
+		$this->assertEquals(array('A' => true, 'B' => true), $result);
+
+		$result = array();
+		Config::merge_array_low_into_high($result, array('A' => false));
+		$this->assertEquals(array('A' => false), $result);
+
+		$result = array('A' => array('A' => true));
+		Config::merge_array_low_into_high($result, array('A' => array('A' => false)));
+		$this->assertEquals(array('A' => array('A' => true)), $result);
+	}
+
 	public function testMerges() {
 		$result = array('A' => 1, 'B' => 2, 'C' => 3);
 		Config::merge_array_low_into_high($result, array('C' => 4, 'D' => 5));


### PR DESCRIPTION
Config::merge_array_low_into_high() will ignore false values that
don't exist in the config already. The expectation is that if the
key isn't set, you can still set a false value, just not overwrite
the true value with a false one when merging into an existing.

Added some tests to verify that merging still works as expected.
