### PR TITLE
FIX #3458 iframe transport multi file upload FIX #3343, FIX #3148

### DIFF
--- a/filesystem/Upload.php
+++ b/filesystem/Upload.php
@@ -270,9 +270,11 @@ class Upload extends Controller {
 	
 	/**
 	 * Clear out all errors (mostly set by {loadUploaded()})
+	 * including the validator's errors
 	 */
 	public function clearErrors() {
 		$this->errors = array();
+		$this->validator->clearErrors();
 	}
 	
 	/**
@@ -340,6 +342,13 @@ class Upload_Validator {
 	 */
 	public function getErrors() {
 		return $this->errors;		
+	}
+
+	/**
+	 * Clear out all errors
+	 */
+	public function clearErrors() {
+		$this->errors = array();
 	}
 
 	/**

--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -1222,20 +1222,25 @@ class UploadField extends FileField {
 		$name = $this->getName();
 		$postVars = $request->postVar($name);
 
-		// Save the temporary file into a File object
+		// Extract uploaded files from Form data
 		$uploadedFiles = $this->extractUploadedFileData($postVars);
-		$firstFile = reset($uploadedFiles);
-		$file = $this->saveTemporaryFile($firstFile, $error);
-		if(empty($file)) {
-			$return = array('error' => $error);
-		} else {
-			$return = $this->encodeFileAttributes($file);
+		$return = array();
+
+		// Save the temporary files into a File objects
+		// and save data/error on a per file basis
+		foreach ($uploadedFiles as $tempFile) {
+			$file = $this->saveTemporaryFile($tempFile, $error);
+			if(empty($file)) {
+				array_push($return, array('error' => $error));
+			} else {
+				array_push($return, $this->encodeFileAttributes($file));
+			}
+			$this->upload->clearErrors();
 		}
-		
+
 		// Format response with json
-		$response = new SS_HTTPResponse(Convert::raw2json(array($return)));
+		$response = new SS_HTTPResponse(Convert::raw2json($return));
 		$response->addHeader('Content-Type', 'text/plain');
-		if (!empty($return['error'])) $response->setStatusCode(403);
 		return $response;
 	}
 

--- a/tests/forms/uploadfield/UploadFieldTest.php
+++ b/tests/forms/uploadfield/UploadFieldTest.php
@@ -167,8 +167,9 @@ class UploadFieldTest extends FunctionalTest {
 			'UploadFieldTest_Controller/Form/field/AllowedExtensionsField/upload',
 			array('AllowedExtensionsField' => $this->getUploadFile($invalidFile))
 		);
-		$this->assertTrue($response->isError());
-		$this->assertContains('Extension is not allowed', $response->getBody());
+		$response = json_decode($response->getBody(), true);
+		$this->assertTrue(array_key_exists('error', $response[0]));
+		$this->assertContains('Extension is not allowed', $response[0]['error']);
 
 		$validFile = 'valid.txt';
 		$_FILES = array('AllowedExtensionsField' => $this->getUploadFile($validFile));
@@ -176,8 +177,8 @@ class UploadFieldTest extends FunctionalTest {
 			'UploadFieldTest_Controller/Form/field/AllowedExtensionsField/upload',
 			array('AllowedExtensionsField' => $this->getUploadFile($validFile))
 		);
-		$this->assertFalse($response->isError());
-		$this->assertNotContains('Extension is not allowed', $response->getBody());
+		$response = json_decode($response->getBody(), true);
+		$this->assertFalse(array_key_exists('error', $response[0]));
 	}
 
 	/**


### PR DESCRIPTION
UploadField now handles multiple file upload through iframe transport
correctly (mainly for IE) as well as upload errors on a per file basis.