### PR TITLE
Allow customising the HTTP Cache-Control defaults.

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,3 +6,8 @@ Upload:
   replaceFile: false
 MySQLDatabase:
   connection_charset: utf8
+HTTP:
+  CacheControl:
+    max-age: 0
+    must-revalidate: true
+    no-transform: true


### PR DESCRIPTION
This is my proposed fix for #3501. It allows the default `Cache-Control` header to be customised using a yaml config array. You can choose true/false to enable or disable control settings, or you can set values.
For example:
```yaml
HTTP:
  CacheControl:
    max-age: 0
    must-revalidate: true
    no-transform: false
```
Would produce `Cache-Control: max-age=0, must-revalidate`

**EDIT: I've noticed that this would actually produce:**  `Cache-Control: must-revalidate`, because `0` is treated as false. Keen to hear thoughts before attempting to fix.