### PR TITLE
Specify fields to run dev/build on

### DIFF
--- a/model/DatabaseAdmin.php
+++ b/model/DatabaseAdmin.php
@@ -190,8 +190,8 @@ class DatabaseAdmin extends Controller {
 
 		// Build the database.  Most of the hard work is handled by DataObject
 		if(defined('DEV_BUILD_ONLY') && DEV_BUILD_ONLY != ''){
-        	$devBuildOnly = array_map('trim', explode(',', DEV_BUILD_ONLY));
-        	$dataClasses = array();
+        		$devBuildOnly = array_map('trim', explode(',', DEV_BUILD_ONLY));
+        		$dataClasses = array();
 			foreach($devBuildOnly as $class){
             			if(is_subclass_of($class, 'DataObject')) $dataClasses[$class] = $class;
         		}


### PR DESCRIPTION
Hi guys,
No sure if this is something you want in core or not, but it's a handy feature to be able to exclude certain fields from a dev/build if you operate a really large database like I do. For example, we have a few large location tables that contain static location data that very rarely requires updating, so these tables can really slow down the dev/build process.

I've added the option to exclude certain tables, and vice versa, only run on specified tables via DEV_BUILD_EXCLUDE and DEV_BUILD_ONLY constants respectively. These can be defined in the ss_environment like so:

define('DEV_BUILD_EXCLUDE', 'GeoBlocks, GeoLocation, SiteTree');

I could also add some $_GET exclude and include queries if you think that would be of use to people.
