### PR TITLE
BUG ErrorControlChain now supports exception handling

### DIFF
--- a/docs/en/changelogs/3.2.0.md
+++ b/docs/en/changelogs/3.2.0.md
@@ -15,6 +15,7 @@
  * `SS_Filterable`, `SS_Limitable` and `SS_Sortable` now explicitly extend `SS_List`
  * `Convert::html2raw` no longer wraps text by default and can decode single quotes.
  * `Mailer` no longer calls `xml2raw` on all email subject line, and now must be passed in via plain text.
+ * `ErrorControlChain` now supports reload on exceptions
 
 #### Deprecated classes/methods removed
 

--- a/tests/core/startup/ErrorControlChainTest.php
+++ b/tests/core/startup/ErrorControlChainTest.php
@@ -140,6 +140,21 @@ class ErrorControlChainTest extends SapphireTest {
 			->executeInSubprocess();
 
 		$this->assertEquals('Done', $out);
+
+		// Exceptions
+
+		$chain = new ErrorControlChainTest_Chain();
+
+		list($out, $code) = $chain
+			->then(function(){
+				throw new Exception("bob");
+			})
+			->thenIfErrored(function(){
+				echo "Done";
+			})
+			->executeInSubprocess();
+
+		$this->assertEquals('Done', $out);
 	}
 
 	function testExceptionSuppression() {


### PR DESCRIPTION
For instance, Injector can throw exceptions if new classes haven't been detected. It's necessary to allow flushing in these cases.
