### PR TITLE
BUG Text::BigSummary() fails with undefined $data when $plain = false

### DIFF
--- a/model/fieldtypes/Text.php
+++ b/model/fieldtypes/Text.php
@@ -159,14 +159,14 @@ class Text extends StringField {
 	* Performs the same function as the big summary, but doesn't trim new paragraphs off data.
 	* Caution: Not XML/HTML-safe - does not respect closing tags.
 	*/
-	public function BigSummary($maxWords = 50, $plain = 1) {
-		$result = "";
-		
+	public function BigSummary($maxWords = 50, $plain = true) {
+		$result = '';
+
 		// get first sentence?
 		// this needs to be more robust
-		if($plain) $data = Convert::xml2raw($this->value, true);
-		
-		if(!$data) return "";
+		$data = $plain ? Convert::xml2raw($this->value, true) : $this->value;
+
+		if(!$data) return '';
 			
 		$sentences = explode('.', $data);	
 		$count = count(explode(' ', $sentences[0]));

--- a/tests/model/TextTest.php
+++ b/tests/model/TextTest.php
@@ -112,21 +112,39 @@ class TextTest extends SapphireTest {
 	/**
 	 * Test {@link Text->BigSummary()}
 	 */
-	public function testBigSummary() {
+	public function testBigSummaryPlain() {
 		$cases = array(
-			'This text has multiple sentences. Big Summary uses this to split sentences up.'
+			'<p>This text has multiple sentences. Big Summary uses this to split sentences up.</p>'
 				=> 'This text has multiple...',
 			'This text does not have multiple sentences' => 'This text does not...',
 			'Very short' => 'Very short',
 			'' => ''
 		);
-		
+
 		foreach($cases as $originalValue => $expectedValue) {
 			$textObj = DBField::create_field('Text', $originalValue);
-			$this->assertEquals($expectedValue, $textObj->BigSummary(4));
+			$this->assertEquals($expectedValue, $textObj->BigSummary(4, true));
 		}
 	}
-	
+
+	/**
+	 * Test {@link Text->BigSummary()}
+	 */
+	public function testBigSummary() {
+		$cases = array(
+			'<strong>This</strong> text has multiple sentences. Big Summary uses this to split sentences up.</p>'
+				=> '<strong>This</strong> text has multiple...',
+			'This text does not have multiple sentences' => 'This text does not...',
+			'Very short' => 'Very short',
+			'' => ''
+		);
+
+		foreach($cases as $originalValue => $expectedValue) {
+			$textObj = DBField::create_field('Text', $originalValue);
+			$this->assertEquals($expectedValue, $textObj->BigSummary(4, false));
+		}
+	}
+
 	public function testContextSummary() {
 		$testString1 = '<p>This is some text. It is a test</p>';
 		$testKeywords1 = 'test';


### PR DESCRIPTION
Fix for #3515
