### PR TITLE
BUGFIX: Check if class exists before attempting to open file

### DIFF
--- a/parsers/HTML/HTMLBBCodeParser.php
+++ b/parsers/HTML/HTMLBBCodeParser.php
@@ -212,12 +212,13 @@ class SSHTMLBBCodeParser
 		$filter = ucfirst($filter);
 		if (!array_key_exists($filter, $this->_filters)) {
 			$class = 'SSHTMLBBCodeParser_Filter_'.$filter;
-			if (fopen('BBCodeParser/Filter/'.$filter.'.php','r',true)) { 
-				include_once 'BBCodeParser/Filter/'.$filter.'.php'; 
-			}
 			if (!class_exists($class)) {
-
-				//PEAR::raiseError("Failed to load filter $filter", null, PEAR_ERROR_DIE);
+				if (fopen('BBCodeParser/Filter/'.$filter.'.php','r',true)) { 
+					include_once 'BBCodeParser/Filter/'.$filter.'.php'; 
+				}
+				else {
+					//PEAR::raiseError("Failed to load filter $filter", null, PEAR_ERROR_DIE);
+				}
 			}
 			else {
 				$this->_filters[$filter] = new $class; 


### PR DESCRIPTION
If the user has provided his own filter class, i.e. in the mysite/ directory, that should be checked before trying to open the file in the core
