### PR TITLE
FIX: Deliberately clear partial cache blocks on flush (fixes #1383)

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -101,7 +101,7 @@ class i18n extends Object implements TemplateGlobalProvider, Flushable {
 	 * Triggered early in the request when someone requests a flush.
 	 */
 	public static function flush() {
-		self::get_cache()->clean(Zend_Cache::CLEANING_MODE_ALL);
+		self::get_cache()->clean(Zend_Cache::CLEANING_MODE_MATCHING_TAG, array('Zend_Translate'));
 	}
 
 	/**

--- a/tests/view/SSViewerCacheBlockTest.php
+++ b/tests/view/SSViewerCacheBlockTest.php
@@ -123,6 +123,18 @@ class SSViewerCacheBlockTest extends SapphireTest {
 		$this->assertEquals($this->_runtemplate('<% cached %>$Foo<% end_cached %>', array('Foo' => 1)), '1');
 		$this->assertEquals($this->_runtemplate('<% cached %>$Foo<% end_cached %>', array('Foo' => 2)), '1');
 	}
+
+	/**
+	 * Test that the cacheblocks invalidate when a flush occurs.
+	 */
+	public function testBlocksInvalidateOnFlush() {
+		Director::test('/');
+		$this->_reset(true);
+		$this->assertEquals($this->_runtemplate('<% cached %>$Foo<% end_cached %>', array('Foo' => 1)), '1');
+
+		Director::test('/?flush=1');
+		$this->assertEquals($this->_runtemplate('<% cached %>$Foo<% end_cached %>', array('Foo' => 2)), '2');
+	}
 	
 	public function testVersionedCache() {
 				

--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -572,6 +572,16 @@ class SSViewer implements Flushable {
 	private static $source_file_comments = false;
 
 	/**
+	 * @ignore
+	 */
+	private static $template_cache_flushed = false;
+
+	/**
+	 * @ignore
+	 */
+	private static $cacheblock_cache_flushed = false;
+
+	/**
 	 * Set whether HTML comments indicating the source .SS file used to render this page should be
 	 * included in the output.  This is enabled by default
 	 *
@@ -643,6 +653,7 @@ class SSViewer implements Flushable {
 	 */
 	public static function flush() {
 		self::flush_template_cache();
+		self::flush_cacheblock_cache();
 	}
 
 	/**
@@ -907,11 +918,6 @@ class SSViewer implements Flushable {
 			return $founds[0];
 		}
 	}
-
-	/**
-	 * @ignore
-	 */
-	static private $flushed = false;
 	
 	/**
 	 * Clears all parsed template files in the cache folder.
@@ -919,12 +925,26 @@ class SSViewer implements Flushable {
 	 * Can only be called once per request (there may be multiple SSViewer instances).
 	 */
 	public static function flush_template_cache() {
-		if (!self::$flushed) {
+		if (!self::$template_cache_flushed) {
 			$dir = dir(TEMP_FOLDER);
 			while (false !== ($file = $dir->read())) {
 				if (strstr($file, '.cache')) unlink(TEMP_FOLDER . '/' . $file);
 			}
-			self::$flushed = true;
+			self::$template_cache_flushed = true;
+		}
+	}
+
+	/**
+	 * Clears all partial cache blocks.
+	 *
+	 * Can only be called once per request (there may be multiple SSViewer instances).
+	 */
+	public static function flush_cacheblock_cache() {
+		if (!self::$cacheblock_cache_flushed) {
+			$cache = SS_Cache::factory('cacheblock');
+			$tags = $cache->getTags();
+			$cache->clean(Zend_Cache::CLEANING_MODE_MATCHING_TAG, $tags);
+			self::$cacheblock_cache_flushed = true;
 		}
 	}
 


### PR DESCRIPTION
The new `Flushable` stuff reintroduced a bug where `i18n::flush()` would clear partial cache blocks from templates, instead of just clearing translations. Obviously, this bug is desirable and has actually been in-place since d3b63dae0c7913689124a760ecbcbf136bd64d2a (excluding 3.1.6, where [I “fixed” it](https://github.com/silverstripe/silverstripe-framework/commit/d012b79cf0fbedcb8ad483d63d0be7c4c051c8a5) - sorry about that).

So now, `i18n` only clears its own tag (if you’re curious, the tag name `Zend_Translate` comes from [here](https://github.com/silverstripe/silverstripe-framework/blob/3.1.6/thirdparty/Zend/Translate/Adapter.php#L965)) and `SSViewer` clears its own cache too.

Ideally, `SSViewer::getPartialCacheStore()` would use some DI or Injector magic, so we wouldn’t have to hardcode which cache we clear, but that’d presumably be an API change. We’d need to ensure the partial cache store was registered before `SSViewer::flush()` was called.

I appreciate the unit test is a bit... odd... but I wanted to be explicit in ensuring that visiting a url with `flush=1` definitely clears the cache. Now that I look back at it, I’m not sure that’s a good idea after all. Will await feedback on that.
