### PR TITLE
FIX: i18n support in LookupField

### DIFF
--- a/forms/LookupField.php
+++ b/forms/LookupField.php
@@ -67,7 +67,7 @@ class LookupField extends DropdownField {
 
 			$inputValue = implode(', ', array_values($values)); 
 		} else {
-			$attrValue = "<i>(none)</i>";
+			$attrValue = '<i>('._t('FormField.NONE', 'none').')</i>';
 			$inputValue = '';
 		}
 


### PR DESCRIPTION
Fixed i18n support in LookupField when value is empty (read-only complement of DropdownField)
