### PR TITLE
Added check for "convert_urls" in TinyMCE config.

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -213,11 +213,12 @@ ss.editorWrappers.tinyMCE = (function() {
 		 *  {DOMElement}
 		 */
 		cleanLink: function(href, node) {
-			var cb = tinyMCE.settings['urlconverter_callback'];
+			var cb = tinyMCE.settings['urlconverter_callback'],
+			    cu = tinyMCE.settings['convert_urls'];
 			if(cb) href = eval(cb + "(href, node, true);");
 
-			// Turn into relative
-			if(href.match(new RegExp('^' + tinyMCE.settings['document_base_url'] + '(.*)$'))) {
+			// Turn into relative, if set in TinyMCE config
+			if(cu && href.match(new RegExp('^' + tinyMCE.settings['document_base_url'] + '(.*)$'))) {
 				href = RegExp.$1;
 			}
 			

--- a/model/DataList.php
+++ b/model/DataList.php
@@ -709,7 +709,7 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 	 * @return int
 	 */
 	public function count() {
-		return $this->dataQuery->count();
+		return (int)$this->dataQuery->count();
 	}
 	
 	/**


### PR DESCRIPTION
Found this as a part of Subsite/TinyMCE issue earlier today. Even when you set "convert_urls" to false in TinyMCE config, SS still converts them to relative links. This piece of code prevents that.
