### PR TITLE
Issue #503: Persist the filter for model admins, and pages list view

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -407,14 +407,14 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 		// Thanks to this however, we are able to nest GridFields, and also access the initial Controller by
 		// dereferencing GridFieldDetailForm_ItemRequest->getController() multiple times. See getToplevelController
 		// below.
-		$form = new Form(
+		$form = new GridFieldItemEditForm(
 			$this,
 			'ItemEditForm',
 			$fields,
 			$actions,
 			$this->component->getValidator()
 		);
-		
+
 		$form->loadDataFrom($this->record, $this->record->ID == 0 ? Form::MERGE_IGNORE_FALSEISH : Form::MERGE_DEFAULT);
 
 		if($this->record->ID && !$canEdit) {
@@ -490,8 +490,9 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 			} 
 		}
 		if(!$backlink) $backlink = $toplevelController->Link();
-		
-		return $backlink;
+		//Persist the state of the model admin filter by adding the 'q' get variables if present.
+		$filterVars = $toplevelController->getRequest()->getVar('q');
+		return $backlink . (!empty($filterVars) && !strpos($backlink, '?') ? '?' . http_build_query(array('q' => $filterVars)) : '');
 	}
 
 	

--- a/forms/gridfield/GridFieldItemEditForm.php
+++ b/forms/gridfield/GridFieldItemEditForm.php
@@ -1,0 +1,25 @@
+<?php
+
+class GridFieldItemEditForm extends Form
+{
+	/**
+	 * Return the form's action attribute.
+	 * This is build by adding an executeForm get variable to the parent controller's Link() value
+	 *
+	 * If the form action hasn't been otherwise customised then it will also add the query variables from the ModelAdmin
+	 * if present. This is so that filtering on the model admin is preserved through multiple requests
+	 *
+	 * @return string
+	 */
+	public function FormAction()
+	{
+		if ($this->formActionPath) {
+			return $this->formActionPath;
+		} elseif ($this->controller->hasMethod("FormObjectLink")) {
+			return $this->controller->FormObjectLink($this->name);
+		} else {
+			$filterVars = $this->controller->getRequest()->getVar('q');
+			return Controller::join_links($this->controller->Link(), $this->name) . (!empty($filterVars) ? '?' . http_build_query(array('q' => $filterVars)) : '');
+		}
+	}
+} 


### PR DESCRIPTION
Append the 'q' get variable to the GridField ItemEditForm action, and back link to persist the filter for the model admin, and pages list view.
