### PR TITLE
Persist the filter for model admins, and pages list view

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -324,8 +324,8 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 	 * @todo In the future, we will probably need to come up with a tigher object representing a partially
 	 * complete controller with gaps for extra functionality.  This, for example, would be a better way
 	 * of letting Security/login put its log-in form inside a UI specified elsewhere.
-	 * 
-	 * @return Form 
+	 *
+	 * @return GridFieldItemEditForm
 	 */
 	public function ItemEditForm() {
 		$list = $this->gridField->getList();
@@ -407,7 +407,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 		// Thanks to this however, we are able to nest GridFields, and also access the initial Controller by
 		// dereferencing GridFieldDetailForm_ItemRequest->getController() multiple times. See getToplevelController
 		// below.
-		$form = new Form(
+		$form = new GridFieldItemEditForm(
 			$this,
 			'ItemEditForm',
 			$fields,
@@ -490,8 +490,13 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 			} 
 		}
 		if(!$backlink) $backlink = $toplevelController->Link();
-		
-		return $backlink;
+		//Persist the state of the model admin/page list view filter by adding the 'q' get variables if present.
+		$filterVars = $toplevelController->getRequest()->getVar('q');
+		return $backlink .
+		(!empty($filterVars) && !strpos($backlink, '?')
+			? '?' . http_build_query(array('q' => $filterVars))
+			: ''
+		);
 	}
 
 	

--- a/forms/gridfield/GridFieldItemEditForm.php
+++ b/forms/gridfield/GridFieldItemEditForm.php
@@ -1,0 +1,29 @@
+<?php
+
+class GridFieldItemEditForm extends Form
+{
+	/**
+	 * Return the form's action attribute.
+	 * This is build by adding an executeForm get variable to the parent controller's Link() value
+	 *
+	 * If the form action hasn't been otherwise customised then it will also add the query variables from the ModelAdmin
+	 * if present. This is so that filtering on the model admin is preserved through multiple requests
+	 *
+	 * @return string
+	 */
+	public function FormAction()
+	{
+		if ($this->formActionPath) {
+			return $this->formActionPath;
+		} elseif ($this->controller->hasMethod("FormObjectLink")) {
+			return $this->controller->FormObjectLink($this->name);
+		} else {
+			$gridFieldGetVars = $this->controller->getRequest()->getVar('q');
+			return Controller::join_links($this->controller->Link(), $this->name) .
+			(!empty($gridFieldGetVars)
+				? '?' . http_build_query(array('q' => $gridFieldGetVars))
+				: ''
+			);
+		}
+	}
+}

--- a/tests/forms/gridfield/GridFieldDetailFormTest.php
+++ b/tests/forms/gridfield/GridFieldDetailFormTest.php
@@ -27,7 +27,7 @@ class GridFieldDetailFormTest extends FunctionalTest {
 		$this->assertFalse($response->isError());
 
 		$parser = new CSSContentParser($response->getBody());
-		$addform = $parser->getBySelector('#Form_ItemEditForm');
+		$addform = $parser->getBySelector('#GridFieldItemEditForm_ItemEditForm');
 		$addformurl = (string) $addform[0]['action'];
 
 		$response = $this->post(
@@ -74,7 +74,7 @@ class GridFieldDetailFormTest extends FunctionalTest {
 		$this->assertFalse($response->isError());
 
 		$parser = new CSSContentParser($response->getBody());
-		$addform = $parser->getBySelector('#Form_ItemEditForm');
+		$addform = $parser->getBySelector('#GridFieldItemEditForm_ItemEditForm');
 		$addformurl = (string) $addform[0]['action'];
 
 		$response = $this->post(
@@ -106,8 +106,8 @@ class GridFieldDetailFormTest extends FunctionalTest {
 		$response = $this->get($viewLink);
 		$parser   = new CSSContentParser($response->getBody());
 
-		$firstName = $parser->getBySelector('#Form_ItemEditForm_FirstName');
-		$surname   = $parser->getBySelector('#Form_ItemEditForm_Surname');
+		$firstName = $parser->getBySelector('#GridFieldItemEditForm_ItemEditForm_FirstName');
+		$surname   = $parser->getBySelector('#GridFieldItemEditForm_ItemEditForm_Surname');
 
 		$this->assertFalse($response->isError());
 		$this->assertEquals('Jane', (string) $firstName[0]);
@@ -133,7 +133,7 @@ class GridFieldDetailFormTest extends FunctionalTest {
 		$this->assertFalse($response->isError());
 
 		$parser = new CSSContentParser($response->getBody());
-		$editform = $parser->getBySelector('#Form_ItemEditForm');
+		$editform = $parser->getBySelector('#GridFieldItemEditForm_ItemEditForm');
 		$editformurl = (string) $editform[0]['action'];
 		
 		$response = $this->post(
@@ -168,10 +168,12 @@ class GridFieldDetailFormTest extends FunctionalTest {
 		$response = $this->get($editlink);
 		$this->assertFalse($response->isError());
 		$parser = new CSSContentParser($response->getBody());
-		$editform = $parser->getBySelector('#Form_ItemEditForm');
+		$editform = $parser->getBySelector('#GridFieldItemEditForm_ItemEditForm');
 		$editformurl = (string) $editform[0]['action'];
 
-		$manyManyField = $parser->getByXpath('//*[@id="Form_ItemEditForm"]//input[@name="ManyMany[IsPublished]"]');
+		$manyManyField = $parser->getByXpath(
+			'//*[@id="GridFieldItemEditForm_ItemEditForm"]//input[@name="ManyMany[IsPublished]"]'
+		);
 		$this->assertTrue((bool)$manyManyField);
 		
 		$response = $this->post(
@@ -215,7 +217,7 @@ class GridFieldDetailFormTest extends FunctionalTest {
 		$response = $this->get((string)$groupEditLink[0]['href']);
 		$this->assertFalse($response->isError());
 		$parser = new CSSContentParser($response->getBody());
-		$personEditLink = $parser->getByXpath('//fieldset[@id="Form_ItemEditForm_People"]' .
+		$personEditLink = $parser->getByXpath('//fieldset[@id="GridFieldItemEditForm_ItemEditForm_People"]' .
 			'//tr[contains(@class, "ss-gridfield-item") and contains(@data-id, "' . $person->ID . '")]//a');		
 		$this->assertEquals(
 			sprintf('GridFieldDetailFormTest_GroupController/Form/field/testfield/item/%d/ItemEditForm/field/People'
@@ -227,7 +229,7 @@ class GridFieldDetailFormTest extends FunctionalTest {
 		$response = $this->get((string)$personEditLink[0]['href']);
 		$this->assertFalse($response->isError());
 		$parser = new CSSContentParser($response->getBody());
-		$categoryEditLink = $parser->getByXpath('//fieldset[@id="Form_ItemEditForm_Categories"]'
+		$categoryEditLink = $parser->getByXpath('//fieldset[@id="GridFieldItemEditForm_ItemEditForm_Categories"]'
 			. '//tr[contains(@class, "ss-gridfield-item") and contains(@data-id, "' . $category->ID . '")]//a');	
 		$this->assertEquals(
 			sprintf('GridFieldDetailFormTest_GroupController/Form/field/testfield/item/%d/ItemEditForm/field/People'


### PR DESCRIPTION
Fix: Append the 'q' get variable to the GridField ItemEditForm action, and back link to persist the filter for the model admin, and pages list view.

Found the issue here: https://github.com/silverstripe/silverstripe-cms/issues/503
