### PR TITLE
Bugfix NumericField shows (none) for 0 on readonly

### DIFF
--- a/forms/NumericField.php
+++ b/forms/NumericField.php
@@ -44,4 +44,27 @@ class NumericField extends TextField {
 	public function dataValue() {
 		return (is_numeric($this->value)) ? $this->value : 0;
 	}
+	
+	/**
+     * Returns a readonly version of this field
+     */
+    public function performReadonlyTransformation() {
+        $field = new NumericField_Readonly($this->name, $this->title, $this->value);
+        $field->setForm($this->form);
+        return $field;
+    }
+    
+}
+
+class NumericField_Readonly extends ReadonlyField{
+
+    public function performReadonlyTransformation() {
+        return clone $this;
+    }
+
+    public function Value() {
+        return Convert::raw2xml($this->value ?
+            "$this->value" : "0");
+    }
+
 }

--- a/tests/forms/NumericFieldTest.php
+++ b/tests/forms/NumericFieldTest.php
@@ -33,5 +33,8 @@ class NumericFieldTest extends SapphireTest {
 
 		$field->setValue('12.00');
 		$this->assertFalse($field->validate($validator));
+		
+		$field->setValue(0);
+		$this->assertRegExp("#<span[^>]+>\s*0\s*<\/span>#", "".$field->performReadonlyTransformation()->Field()."");
 	}
 }


### PR DESCRIPTION
When using a `NumericField` and calling `performReadonlyTransformation()` it will show (none) for a zero value. I've essentially brought over what the `CheckboxField` does on the readonly transformation.
