### PR TITLE
FIX: Tag-less cache backends error on flush

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -101,7 +101,18 @@ class i18n extends Object implements TemplateGlobalProvider, Flushable {
 	 * Triggered early in the request when someone requests a flush.
 	 */
 	public static function flush() {
-		self::get_cache()->clean(Zend_Cache::CLEANING_MODE_MATCHING_TAG, array('Zend_Translate'));
+		$cache = self::get_cache();
+		$backend = $cache->getBackend();
+
+		if(
+			$backend instanceof Zend_Cache_Backend_ExtendedInterface
+			&& ($capabilities = $backend->getCapabilities())
+			&& $capabilities['tags']
+		) {
+			$cache->clean(Zend_Cache::CLEANING_MODE_MATCHING_TAG, $cache->getTags());
+		} else {
+			$cache->clean(Zend_Cache::CLEANING_MODE_ALL);
+		}
 	}
 
 	/**

--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -948,8 +948,19 @@ class SSViewer implements Flushable {
 	public static function flush_cacheblock_cache($force = false) {
 		if (!self::$cacheblock_cache_flushed || $force) {
 			$cache = SS_Cache::factory('cacheblock');
-			$tags = $cache->getTags();
-			$cache->clean(Zend_Cache::CLEANING_MODE_MATCHING_TAG, $tags);
+			$backend = $cache->getBackend();
+			
+			if(
+				$backend instanceof Zend_Cache_Backend_ExtendedInterface
+				&& ($capabilities = $backend->getCapabilities())
+				&& $capabilities['tags']
+			) {
+				$cache->clean(Zend_Cache::CLEANING_MODE_MATCHING_TAG, $cache->getTags());
+			} else {
+				$cache->clean(Zend_Cache::CLEANING_MODE_ALL);
+			}
+
+			
 			self::$cacheblock_cache_flushed = true;
 		}
 	}


### PR DESCRIPTION
[A little background info.](https://github.com/silverstripe/silverstripe-framework/commit/48eb0e67e62fe0304c300e45ba0076f09ed89c9d#commitcomment-8163092)

Checking if the backend is an instance of `Zend_Cache_Backend_ExtendedInterface` ensures that the `getCapabilities()` method exists.

I’ve rewritten more than I _need_ to here, here’s why:
- `i18n` didn’t error on flush, but if it tried to clear in tag mode on a tag-less backend, it’d silently fail (and [log the error](https://github.com/silverstripe/silverstripe-framework/blob/3.1/thirdparty/Zend/Cache/Backend/Apc.php#L154-L158))
- `Aggregate` wasn’t erroring at all. However, if you tried to specify a different backend for it that wasn’t an instance of `Zend_Cache_Backend_ExtendedInterface`, it’d result in an error as `getCapabilities()` may not exist. An extreme edge case, but at least we’ll now be consistently flushing caches across core code :)
