### PR TITLE
Update versioning.md

### DIFF
--- a/docs/en/topics/versioning.md
+++ b/docs/en/topics/versioning.md
@@ -196,6 +196,5 @@ whenever a blog entry has been published.
 	  // ...
 	  public function onAfterPublish() {
 	    mail("sam@silverstripe.com", "Blog published", "The blog has been published");
-	    parent::onAfterPublish();
 	  }
 	}


### PR DESCRIPTION
Removed parent::onAfterPublish(); because Page parents does not implement it. The old code generate this error:

Error at framework/core/Object.php line 761: Uncaught Exception: Object->__call(): the method 'onafterpublish' does not exist on 'MyPage' (http://ssdev-master.zk/admin/pages/edit/EditForm)
