### PR TITLE
API Text - Limit characters to closest word

### DIFF
--- a/model/fieldtypes/StringField.php
+++ b/model/fieldtypes/StringField.php
@@ -17,6 +17,7 @@ abstract class StringField extends DBField {
 	 */
 	private static $casting = array(
 		"LimitCharacters" => "Text",
+		"LimitCharactersToClosestWord" => "Text",
 		'LimitWordCount' => 'Text',
 		'LimitWordCountXML' => 'HTMLText',
 		"LowerCase" => "Text",
@@ -103,7 +104,7 @@ abstract class StringField extends DBField {
 	public function forTemplate() {
 		return nl2br($this->XML());
 	}
-	
+
 	/**
 	 * Limit this field's content by a number of characters.
 	 * This makes use of strip_tags() to avoid malforming the
@@ -111,40 +112,48 @@ abstract class StringField extends DBField {
 	 *
 	 * @param int $limit Number of characters to limit by
 	 * @param string $add Ellipsis to add to the end of truncated string
-	 * @param string $completeWord Truncate the string to the last complete 
-	 * word. This will strip all HTML tags in the string if any.
 	 * @return string
 	 */
-	public function LimitCharacters($limit = 20, $add = '...', $completeWord = false) {
-		$value = $completeWord ? Convert::xml2raw(trim($this->value)) : trim($this->value);
-
-		$exceedsLimit = mb_strlen($value) > $limit;
-
+	public function LimitCharacters($limit = 20, $add = '...') {
+		$value = trim($this->value);
 		if($this->stat('escape_type') == 'xml') {
 			$value = strip_tags($value);
 			$value = html_entity_decode($value, ENT_COMPAT, 'UTF-8');
-
-			$exceedsLimit = mb_strlen($value) > $limit;
-
-			// If string exceeds character limit, substring to character limit
-			// Add ellipsis if not limiting to last complete word
-			if($exceedsLimit) {
-				$value = $completeWord ? mb_substr($value, 0, $limit) : mb_substr($value, 0, $limit) . $add;
-			}
-
+			$value = (mb_strlen($value) > $limit) ? mb_substr($value, 0, $limit) . $add : $value;
 			// Avoid encoding all multibyte characters as HTML entities by using htmlspecialchars().
 			$value = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
 		} else {
-			// If string exceeds character limit, substring to character limit
-			// Add ellipsis if not limiting to last complete word
-			if($exceedsLimit) {
-				$value = $completeWord ? mb_substr($value, 0, $limit) : mb_substr($value, 0, $limit) . $add;
-			}
+			$value = (mb_strlen($value) > $limit) ? mb_substr($value, 0, $limit) . $add : $value;
 		}
+		return $value;
+	}
+    
+	/**
+	 * Limit this field's content by a number of characters and truncate
+	 * the field to the closest complete word. All HTML tags are stripped 
+	 * from the field.
+	 *
+	 * @param int $limit Number of characters to limit by
+	 * @param string $add Ellipsis to add to the end of truncated string
+	 * @return string
+	 */
+	public function LimitCharactersToClosestWord($limit = 20, $add = '...') {
+		// Strip HTML tags if they exist in the field
+		$this->value = strip_tags($this->value);
 
-		// Find last complete word, trim whitespace/punctuation and add ellipsis
-		if($completeWord && $exceedsLimit) {
+		// Determine if value exceeds limit before limiting characters
+		$exceedsLimit = mb_strlen($this->value) > $limit;
+
+		// Limit to character limit
+		$value = $this->LimitCharacters($limit, '');
+
+		// If value exceeds limit, strip punctuation off the end to the last space and apply ellipsis
+		if($exceedsLimit) {
+			$value = html_entity_decode($value, ENT_COMPAT, 'UTF-8');
+
 			$value = rtrim(mb_substr($value, 0, mb_strrpos($value, " ")), "/[\.,-\/#!$%\^&\*;:{}=\-_`~()]\s") . $add;
+
+			$value = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
 		}
 
 		return $value;

--- a/tests/model/TextTest.php
+++ b/tests/model/TextTest.php
@@ -9,18 +9,23 @@ class TextTest extends SapphireTest {
 	 * Test {@link Text->LimitCharacters()}
 	 */
 	public function testLimitCharacters() {
-		$cases1 = array(
+		$cases = array(
 			'The little brown fox jumped over the lazy cow.' => 'The little brown fox...',
 			'<p>This is some text in a paragraph.</p>' => '<p>This is some text...'
 		);
 		
-		foreach($cases1 as $originalValue => $expectedValue) {
+		foreach($cases as $originalValue => $expectedValue) {
 			$textObj = new Text('Test');
 			$textObj->setValue($originalValue);
 			$this->assertEquals($expectedValue, $textObj->LimitCharacters());
 		}
-
-		$cases2 = array(
+	}
+    
+	/**
+	 * Test {@link Text->LimitCharactersToClosestWord()}
+	 */
+	public function testLimitCharactersToClosestWord() {
+		$cases = array(
 			/* Standard words limited, ellipsis added if truncated */
 			'Lorem ipsum dolor sit amet' => 'Lorem ipsum dolor sit...',
 
@@ -32,13 +37,16 @@ class TextTest extends SapphireTest {
 			/* HTML tags get stripped out, leaving the raw text */
 			'<p>Lorem ipsum dolor sit amet</p>' => 'Lorem ipsum dolor sit...',
 			'<p><span>Lorem ipsum dolor sit amet</span></p>' => 'Lorem ipsum dolor sit...',
-			'<p>Lorem ipsum</p>' => 'Lorem ipsum'
+			'<p>Lorem ipsum</p>' => 'Lorem ipsum',
+            
+			/* HTML entities are treated as a single character */
+			'Lorem &amp; ipsum dolor sit amet' => 'Lorem &amp; ipsum dolor...'
 		);
 
-		foreach($cases2 as $originalValue => $expectedValue) {
+		foreach($cases as $originalValue => $expectedValue) {
 			$textObj = new Text('Test');
 			$textObj->setValue($originalValue);
-			$this->assertEquals($expectedValue, $textObj->LimitCharacters(24, '...', true));
+			$this->assertEquals($expectedValue, $textObj->LimitCharactersToClosestWord(24));
 		}
 	}
 

--- a/tests/model/TextTest.php
+++ b/tests/model/TextTest.php
@@ -9,18 +9,39 @@ class TextTest extends SapphireTest {
 	 * Test {@link Text->LimitCharacters()}
 	 */
 	public function testLimitCharacters() {
-		$cases = array(
+		$cases1 = array(
 			'The little brown fox jumped over the lazy cow.' => 'The little brown fox...',
 			'<p>This is some text in a paragraph.</p>' => '<p>This is some text...'
 		);
 		
-		foreach($cases as $originalValue => $expectedValue) {
+		foreach($cases1 as $originalValue => $expectedValue) {
 			$textObj = new Text('Test');
 			$textObj->setValue($originalValue);
 			$this->assertEquals($expectedValue, $textObj->LimitCharacters());
 		}
+
+		$cases2 = array(
+			/* Standard words limited, ellipsis added if truncated */
+			'Lorem ipsum dolor sit amet' => 'Lorem ipsum dolor sit...',
+
+			/* Complete words less than the character limit don't get truncated, ellipsis not added */
+			'Lorem ipsum' => 'Lorem ipsum',
+			'Lorem' => 'Lorem',
+			'' => '',	// No words produces nothing!
+
+			/* HTML tags get stripped out, leaving the raw text */
+			'<p>Lorem ipsum dolor sit amet</p>' => 'Lorem ipsum dolor sit...',
+			'<p><span>Lorem ipsum dolor sit amet</span></p>' => 'Lorem ipsum dolor sit...',
+			'<p>Lorem ipsum</p>' => 'Lorem ipsum'
+		);
+
+		foreach($cases2 as $originalValue => $expectedValue) {
+			$textObj = new Text('Test');
+			$textObj->setValue($originalValue);
+			$this->assertEquals($expectedValue, $textObj->LimitCharacters(24, '...', true));
+		}
 	}
-	
+
 	/**
 	 * Test {@link Text->LimitWordCount()}
 	 */


### PR DESCRIPTION
This new function builds on top of the functionality in Text->LimitCharacters(), but it truncates the value to the closest complete word.

There are several advantages to this over Text->LimitCharacters eg. the ellipsis (...) is always added after a complete word as sometimes in Text->LimitCharacters it can add the ellipsis in the middle of a word, or worse, at the end of a space or other punctuation. This function also trims any whitespace/punctuation on the end before adding the ellipsis.

It gives more control especially when using a tile frontend like Isotope, where the tile height is fixed and cannot adjust to the content length.

The limitation of the function is that it strips all HTML tags out of the value, but then its only intended for showing a small snippet of the text in a restrictive layout.