### PR TITLE
BUG Upload: File versioning with existing files

### DIFF
--- a/filesystem/Upload.php
+++ b/filesystem/Upload.php
@@ -173,6 +173,8 @@ class Upload extends Controller {
 			}
 			while(file_exists("$base/$relativeFilePath")) {
 				$i = isset($i) ? ($i+1) : 2;
+				$oldFilePath = $relativeFilePath;
+
 				$pattern = '/([0-9]+$)/';
 				if(preg_match($pattern, $fileTitle)) {
 					$fileTitle = preg_replace($pattern, $i, $fileTitle);
@@ -180,6 +182,7 @@ class Upload extends Controller {
 					$fileTitle .= $i;
 				}
 				$relativeFilePath = $relativeFolderPath . $fileTitle . $fileSuffix;
+
 				if($oldFilePath == $relativeFilePath && $i > 2) {
 					user_error("Couldn't fix $relativeFilePath with $i tries", E_USER_ERROR);
 				}

--- a/tests/filesystem/UploadTest.php
+++ b/tests/filesystem/UploadTest.php
@@ -560,6 +560,70 @@ class UploadTest extends SapphireTest {
 		$image->delete();
 	}
 
+	public function testFileVersioningWithAnExistingFile() {
+		$upload = function($tmpFileName) {
+			// create tmp file
+			$tmpFilePath = TEMP_FOLDER . '/' . $tmpFileName;
+			$tmpFileContent = '';
+			for ($i = 0; $i < 10000; $i++) {
+				$tmpFileContent .= '0';
+			}
+			file_put_contents($tmpFilePath, $tmpFileContent);
+
+			// emulates the $_FILES array
+			$tmpFile = array(
+				'name' => $tmpFileName,
+				'type' => 'text/plaintext',
+				'size' => filesize($tmpFilePath),
+				'tmp_name' => $tmpFilePath,
+				'extension' => 'jpg',
+				'error' => UPLOAD_ERR_OK,
+			);
+
+			$v = new UploadTest_Validator();
+
+			// test upload into default folder
+			$u = new Upload();
+			$u->setReplaceFile(false);
+			$u->setValidator($v);
+			$u->load($tmpFile);
+			return $u->getFile();
+		};
+
+		$file1 = $upload('UploadTest-testUpload.jpg');
+		$this->assertEquals(
+			'UploadTest-testUpload.jpg',
+			$file1->Name,
+			'File does not receive new name'
+		);
+
+		$file2 = $upload('UploadTest-testUpload.jpg');
+		$this->assertEquals(
+			'UploadTest-testUpload2.jpg',
+			$file2->Name,
+			'File does receive new name'
+		);
+
+		$file3 = $upload('UploadTest-testUpload.jpg');
+		$this->assertEquals(
+			'UploadTest-testUpload3.jpg',
+			$file3->Name,
+			'File does receive new name'
+		);
+
+		$file4 = $upload('UploadTest-testUpload3.jpg');
+		$this->assertEquals(
+			'UploadTest-testUpload4.jpg',
+			$file4->Name,
+			'File does receive new name'
+		);
+
+		$file1->delete();
+		$file2->delete();
+		$file3->delete();
+		$file4->delete();
+	}
+
 }
 class UploadTest_Validator extends Upload_Validator implements TestOnly {
 


### PR DESCRIPTION
I introduced a bug in #2921 where an uploaded file with a digit in the filename can not be versioned if a file with the same filename already exists.

Bug:
- upload test.jpg
- upload test.jpg again - versioned to test2.jpg
- upload test.jpg again - versioned to test3.jpg
- upload test3.jpg - should be test4.jpg but ...

`[User Error] Couldn't fix assets/Uploads/test3.jpg with 3 tries
Line 184 in framework/filesystem/Upload.php`

Bugfix for #3565
