### PR TITLE
fixed RemoteURL css for CMS issue 1086

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -652,10 +652,10 @@ body.cms-dialog { overflow: auto; background: url("../images/textures/bg_cms_mai
 .htmleditorfield-dialog .htmleditorfield-from-web #RemoteURL { border: none; -moz-box-shadow: none; -webkit-box-shadow: none; box-shadow: none; width: 55%; max-width: 512px; float: left; position: relative; }
 .htmleditorfield-dialog .htmleditorfield-from-web #RemoteURL label { position: absolute; left: 8px; top: 13px; font-weight: normal; color: #888; }
 .htmleditorfield-dialog .htmleditorfield-from-web #RemoteURL .middleColumn { margin-left: 0; }
-.htmleditorfield-dialog .htmleditorfield-from-web #RemoteURL input.remoteurl { padding-left: 40px; }
-.htmleditorfield-dialog .htmleditorfield-from-web button.add-url { margin-top: 5px; padding-top: 15px; overflow: hidden; *zoom: 1; border: none; background: none; opacity: 0.8; cursor: hand; }
+.htmleditorfield-dialog .htmleditorfield-from-web #RemoteURL input.remoteurl { padding-left: 40px; max-width: 350px; }
+.htmleditorfield-dialog .htmleditorfield-from-web button.add-url { margin-top: 20px; overflow: hidden; *zoom: 1; border: none; background: none; opacity: 0.8; cursor: hand; }
 .htmleditorfield-dialog .htmleditorfield-from-web button.add-url .btn-icon-addMedia { width: 20px; height: 20px; }
-.htmleditorfield-dialog .htmleditorfield-from-web button.add-url .ui-button-text { margin-left: 10px; margin-top: -5px; line-height: 20px; float: left; }
+.htmleditorfield-dialog .htmleditorfield-from-web button.add-url .ui-button-text { margin-left: 10px; padding-top: 10px; }
 .htmleditorfield-dialog .htmleditorfield-from-web button.add-url:hover, .htmleditorfield-dialog .htmleditorfield-from-web button.add-url:active { border: none; -moz-box-shadow: none; -webkit-box-shadow: none; box-shadow: none; opacity: 1; }
 .htmleditorfield-dialog .htmleditorfield-from-web button.add-url.ui-state-disabled, .htmleditorfield-dialog .htmleditorfield-from-web button.add-url.ui-state-disabled:hover, .htmleditorfield-dialog .htmleditorfield-from-web button.add-url.ui-state-disabled:active { opacity: 0.35; filter: Alpha(Opacity=35); }
 .htmleditorfield-dialog .htmleditorfield-from-web .loading button.add-url .ui-icon { background-image: url(../images/throbber.gif); background-position: 50% 50%; background-repeat: no-repeat; }

--- a/admin/scss/_style.scss
+++ b/admin/scss/_style.scss
@@ -1427,11 +1427,11 @@ body.cms-dialog {
 
 			input.remoteurl {
 				padding-left: 40px;
+				max-width: 350px;
 			}
 		}
 		button.add-url{
-			margin-top:5px;
-			padding-top:15px;
+			margin-top:20px;
 			@include clearfix;
 			border:none;
 			background:none;
@@ -1443,9 +1443,7 @@ body.cms-dialog {
 			}
 			.ui-button-text{
 				margin-left:10px;
-				margin-top:-5px;
-				line-height:20px;
-				float:left;
+				padding-top:10px;
 			}
 			&:hover, &:active{
 				border:none;


### PR DESCRIPTION
Fixed CSS issue with RemoteURL extending past the "Add URL" button text. 

https://github.com/silverstripe/silverstripe-cms/issues/1086

Compiled Compass version 1.0.1

Original Issue example:
![issue1086_original](https://cloud.githubusercontent.com/assets/2508506/4729911/5da012b6-5990-11e4-8e35-7881616e9917.png)

Fixed:
Windows - IE8
![issue1086_fix_win_ie8](https://cloud.githubusercontent.com/assets/2508506/4729912/5da1d3d0-5990-11e4-92b6-690366350006.jpg)

Windows - IE11
![issue1086_fix_win_ie11](https://cloud.githubusercontent.com/assets/2508506/4729908/5d999fd0-5990-11e4-9d54-454a770291e3.jpg)

OSX - Chrome
![issue1086_fix_osx_chrome](https://cloud.githubusercontent.com/assets/2508506/4729910/5d9e4170-5990-11e4-9ca6-8086cd79df65.png)

OSX - Firefox
![issue1086_fix_osx_firefox](https://cloud.githubusercontent.com/assets/2508506/4729913/5da39148-5990-11e4-8631-4c893e745d2b.png)

OSX - Safari
![issue1086_fix_osx_safari](https://cloud.githubusercontent.com/assets/2508506/4729909/5d9cff40-5990-11e4-84ce-21826cb0b454.png)
