### PR TITLE
FIX: Prevent JSON response showing when re-opening closed tab (fixes silverstripe/silverstripe-cms#1121)

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -457,6 +457,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 
 		// Prevent clickjacking, see https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
 		$this->response->addHeader('X-Frame-Options', 'SAMEORIGIN');
+		$this->response->addHeader('Vary', 'X-Requested-With');
 		
 		return $response;
 	}


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-cms/issues/1121. This fixes the issue in Chrome, I can’t recreate the original issue in other browsers.
