### PR TITLE
BUG Fix BasicAuth not resetting failed login counts on authentication

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -463,9 +463,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		}
 		
 		// Clear the incorrect log-in count
-		if(self::config()->lock_out_after_incorrect_logins) {
-			$this->FailedLoginCount = 0;
-		}
+		$this->registerSuccessfulLogin();
 		
 		// Don't set column if its not built yet (the login might be precursor to a /dev/build...)
 		if(array_key_exists('LockedOutUntil', DB::fieldList('Member'))) {
@@ -1558,6 +1556,17 @@ class Member extends DataObject implements TemplateGlobalProvider {
 				$this->LockedOutUntil = date('Y-m-d H:i:s', time() + $lockoutMins*60);
 				$this->write();
 			}
+		}
+	}
+
+	/**
+	 * Tell this member that a successful login has been made
+	 */
+	public function registerSuccessfulLogin() {
+		if(self::config()->lock_out_after_incorrect_logins) {
+			// Forgive all past login failures
+			$this->FailedLoginCount = 0;
+			$this->write();
 		}
 	}
 	

--- a/security/MemberAuthenticator.php
+++ b/security/MemberAuthenticator.php
@@ -73,6 +73,8 @@ class MemberAuthenticator extends Authenticator {
 		if(!$success) {
 			if($member) $member->registerFailedLogin();
 			if($form) $form->sessionMessage($result->message(), 'bad');
+		} else {
+			if($member) $member->registerSuccessfulLogin();
 		}
 
 		return $member;

--- a/tests/security/BasicAuthTest.yml
+++ b/tests/security/BasicAuthTest.yml
@@ -1,15 +1,19 @@
 Group:
-   mygroup:
-      Code: mygroup
+  mygroup:
+    Code: mygroup
 Member:
-   user-in-mygroup:
-      Email: user-in-mygroup@test.com
-      Password: test
-      Groups: =>Group.mygroup
-   user-without-groups:
-      Email: user-without-groups@test.com
-      Password: test
+  user-in-mygroup:
+    Email: user-in-mygroup@test.com
+    Password: test
+    Groups: =>Group.mygroup
+  user-without-groups:
+    Email: user-without-groups@test.com
+    Password: test
+  failed-login:
+    Email: failedlogin@test.com
+    Password: Password
+    FailedLoginCount: 0
 Permission:
-   mycode:
-      Code: MYCODE
-      Group: =>Group.mygroup
+  mycode:
+    Code: MYCODE
+    Group: =>Group.mygroup


### PR DESCRIPTION
FailedLoginCount would always be incremented whenever an authentication failed, but not reset on success. The actual reset of this counter would normally be done in `Member::logIn`, but this means that if we are merely authenticating the given credentials (i.e. proving these are correct, and not wishing to log them in) then the reset would never occur.

I've resolved this issue in the MemberAuthenticator by ensuring that the registerFailedLogin method is paired by registerSuccessfulLogin.

@simonwelsh do you see any risk in this fix from a BC perspective?

Also cc @wilr who originally reported this issue. Are you satisfied that this fixes the problem?