### PR TITLE
FIX: Image resizing breaks when one of the resized image dimensions is between 0 and 1

### DIFF
--- a/filesystem/GD.php
+++ b/filesystem/GD.php
@@ -175,18 +175,20 @@ class GDBackend extends Object implements Image_Backend {
 	 */
 	public function resize($width, $height) {
 		if(!$this->gd) return;
+		
+		if($width < 0 || $height < 0) throw new InvalidArgumentException("Image resizing dimensions cannot be negative");
+		if(!$width && !$height) throw new InvalidArgumentException("No dimensions given when resizing image");
+		if(!$width) throw new InvalidArgumentException("Width not given when resizing image");
+		if(!$height) throw new InvalidArgumentException("Height not given when resizing image");
 
-		$width = round($width);
-		$height = round($height);
+		//use whole numbers, ensuring that size is at least 1x1
+		$width = max(1, round($width));
+		$height = max(1, round($height));
 		
 		// Check that a resize is actually necessary.
 		if ($width == $this->width && $height == $this->height) {
 			return $this;
 		}
-		
-		if(!$width && !$height) user_error("No dimensions given", E_USER_ERROR);
-		if(!$width) user_error("Width not given", E_USER_ERROR);
-		if(!$height) user_error("Height not given", E_USER_ERROR);
 
 		$newGD = imagecreatetruecolor($width, $height);
 		

--- a/filesystem/ImagickBackend.php
+++ b/filesystem/ImagickBackend.php
@@ -104,9 +104,15 @@ class ImagickBackend extends Imagick implements Image_Backend {
 	 */
 	public function resize($width, $height) {
 		if(!$this->valid()) return;
-	
-		$width = round($width);
-		$height = round($height);
+		
+		if($width < 0 || $height < 0) throw new InvalidArgumentException("Image resizing dimensions cannot be negative");
+		if(!$width && !$height) throw new InvalidArgumentException("No dimensions given when resizing image");
+		if(!$width) throw new InvalidArgumentException("Width not given when resizing image");
+		if(!$height) throw new InvalidArgumentException("Height not given when resizing image");
+		
+		//use whole numbers, ensuring that size is at least 1x1
+		$width = max(1, round($width));
+		$height = max(1, round($height));
 		
 		$geometry = $this->getImageGeometry();
 		
@@ -114,10 +120,6 @@ class ImagickBackend extends Imagick implements Image_Backend {
 		if ($width == $geometry["width"] && $height == $geometry["height"]) {
 			return $this;
 		}
-		
-		if(!$width && !$height) user_error("No dimensions given", E_USER_ERROR);
-		if(!$width) user_error("Width not given", E_USER_ERROR);
-		if(!$height) user_error("Height not given", E_USER_ERROR);
 		
 		$new = clone $this;
 		$new->resizeImage($width, $height, self::FILTER_LANCZOS, 1);


### PR DESCRIPTION
Solution: Round up to 1 instead of down to 0.
