### PR TITLE
FIX Image backend ignoring config.

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -732,7 +732,7 @@ class Image extends File {
 	}
 
 	protected function onBeforeDelete() {
-		$backend = Injector::inst()->create(self::$backend);
+		$backend = Injector::inst()->create(self::get_backend());
 		$backend->onBeforeDelete($this);
 
 		$this->deleteFormattedImages();


### PR DESCRIPTION
The method directly calls the static property instead of the config value.
