### PR TITLE
Fix whitespace issues in NumericField/NumericFieldTest

### DIFF
--- a/forms/NumericField.php
+++ b/forms/NumericField.php
@@ -46,25 +46,24 @@ class NumericField extends TextField {
 	}
 	
 	/**
-     * Returns a readonly version of this field
-     */
-    public function performReadonlyTransformation() {
-        $field = new NumericField_Readonly($this->name, $this->title, $this->value);
-        $field->setForm($this->form);
-        return $field;
-    }
-    
+	 * Returns a readonly version of this field
+	 */
+	public function performReadonlyTransformation() {
+		$field = new NumericField_Readonly($this->name, $this->title, $this->value);
+		$field->setForm($this->form);
+		return $field;
+	}
+
 }
 
-class NumericField_Readonly extends ReadonlyField{
+class NumericField_Readonly extends ReadonlyField {
 
-    public function performReadonlyTransformation() {
-        return clone $this;
-    }
+	public function performReadonlyTransformation() {
+		return clone $this;
+	}
 
-    public function Value() {
-        return Convert::raw2xml($this->value ?
-            "$this->value" : "0");
-    }
+	public function Value() {
+		return Convert::raw2xml($this->value ? "$this->value" : "0");
+	}
 
 }

--- a/tests/forms/NumericFieldTest.php
+++ b/tests/forms/NumericFieldTest.php
@@ -37,4 +37,5 @@ class NumericFieldTest extends SapphireTest {
 		$field->setValue(0);
 		$this->assertRegExp("#<span[^>]+>\s*0\s*<\/span>#", "".$field->performReadonlyTransformation()->Field()."");
 	}
+
 }


### PR DESCRIPTION
A few minor corrections from 082c49c1b59ab162cdd36dbcbd3326c3f291354a:
- spaces vs tabs
- newline at EOF
