### PR TITLE
.ico incorrect mimetype set - doesn't match finfo

### DIFF
--- a/_config/mimetypes.yml
+++ b/_config/mimetypes.yml
@@ -321,7 +321,7 @@ HTTP:
       icc: application/vnd.iccprofile
       ice: x-conference/x-cooltalk
       icm: application/vnd.iccprofile
-      ico: image/x-icon
+      ico: image/x-ico
       ics: text/calendar
       ief: image/ief
       ifb: text/calendar


### PR DESCRIPTION
The .ico mimetype doesn't match the fileinfo PHP extension meaning validation can incorrectly fail. It should be image/x-ico instead of image/x-icon.
