### PR TITLE
Explicit cast return of DBField->exists()

### DIFF
--- a/model/fieldtypes/DBField.php
+++ b/model/fieldtypes/DBField.php
@@ -144,7 +144,7 @@ abstract class DBField extends ViewableData {
 	 * @return boolean
 	 */
 	public function exists() {
-		return ($this->value);
+		return (bool)$this->value;
 	}
 	
 	/**


### PR DESCRIPTION
Possibly all it's needed to fix [Issue #1494](https://github.com/silverstripe/silverstripe-framework/issues/1494)
