### PR TITLE
NEW: Add Config::moduleExists()

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -339,6 +339,22 @@ class Config {
 	}
 
 	/**
+	 * Check whether the given module exists in any of the manifests
+	 * 
+	 * @param string $module
+	 * @return boolean
+	 */
+	public function moduleExists($module) {
+		foreach($this->manifests as $manifest) {
+			if($manifest->moduleExists($module)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Merge a lower priority associative array into an existing higher priority associative array, as per the class
 	 * docblock rules
 	 *

--- a/core/manifest/ConfigManifest.php
+++ b/core/manifest/ConfigManifest.php
@@ -96,6 +96,8 @@ class SS_ConfigManifest {
 			$this->phpConfigSources = $this->cache->load($this->key.'php_config_sources');
 			// Get the variant key spec
 			$this->variantKeySpec = $this->cache->load($this->key.'variant_key_spec');
+			// Get the list of modules
+			$this->modules = $this->cache->load($this->key.'modules');
 		}
 
 		// If we don't have a variantKeySpec (because we're forcing regen, or it just wasn't in the cache), generate it
@@ -222,6 +224,7 @@ class SS_ConfigManifest {
 			$this->cache->save($this->phpConfigSources, $this->key.'php_config_sources');
 			$this->cache->save($this->yamlConfigFragments, $this->key.'yaml_config_fragments');
 			$this->cache->save($this->variantKeySpec, $this->key.'variant_key_spec');
+			$this->cache->save($this->modules, $this->key.'modules');
 		}
 	}
 

--- a/tests/core/ConfigTest.php
+++ b/tests/core/ConfigTest.php
@@ -254,6 +254,18 @@ class ConfigTest extends SapphireTest {
 		$this->markTestIncomplete();
 	}
 
+	public function testModuleExists() {
+		Config::nest();
+
+		$manifest = new SS_ConfigManifest(dirname(__FILE__).'/fixtures', true, true);
+		Config::inst()->pushConfigYamlManifest($manifest);
+
+		$this->assertTrue(Config::inst()->moduleExists('configtestmodule'));
+		$this->assertFalse(Config::inst()->moduleExists('nonexistant'));
+
+		Config::unnest();
+	}
+
 	public function testLRUDiscarding() {
 		$cache = new ConfigTest_Config_LRU();
 

--- a/tests/core/manifest/ConfigManifestTest.php
+++ b/tests/core/manifest/ConfigManifestTest.php
@@ -104,9 +104,9 @@ class ConfigManifestTest extends SapphireTest {
 		// Test that load is called
 		$manifest = $this->getManifestMock(array('getCache', 'regenerate', 'buildYamlConfigVariant'));
 
-		// Load should be called twice
+		// Load should be called three times
 		$cache = $this->getCacheMock();
-		$cache->expects($this->exactly(2))
+		$cache->expects($this->exactly(3))
 			->method('load');
 
 		$manifest->expects($this->any())
@@ -120,7 +120,7 @@ class ConfigManifestTest extends SapphireTest {
 		$manifest = $this->getManifestMock(array('getCache', 'regenerate', 'buildYamlConfigVariant'));
 
 		$cache = $this->getCacheMock();
-		$cache->expects($this->exactly(2))
+		$cache->expects($this->exactly(3))
 			->method('load')
 			->will($this->onConsecutiveCalls(false, false));
 
@@ -138,7 +138,7 @@ class ConfigManifestTest extends SapphireTest {
 		$manifest = $this->getManifestMock(array('getCache', 'regenerate', 'buildYamlConfigVariant'));
 
 		$cache = $this->getCacheMock();
-		$cache->expects($this->exactly(2))
+		$cache->expects($this->exactly(3))
 			->method('load')
 			->will($this->onConsecutiveCalls(array(), array()));
 


### PR DESCRIPTION
Directory-based check for whether a module exists in the manifest. Uses the same method of checking that the YAML `moduleexists: foo` does, just caches it and adds a way of accessing it through `Config`.

Usage:

```php
Config::inst()->moduleExists('sqlite3'); // boolean
```

Thinking: `class_exists()` is obviously the best way of doing this, but classes can be (and are) added/removed from some modules, so this can sometimes be a more robust check. Plus, the functionality to check already exists - it just can’t be accessed currently.