### PR TITLE
Retain script tags in editor if allowed (fixes #3611)

### DIFF
--- a/thirdparty/tinymce_ssbuttons/editor_plugin_src.js
+++ b/thirdparty/tinymce_ssbuttons/editor_plugin_src.js
@@ -70,7 +70,16 @@
 										+ '[/embed]';
 					el.replaceWith(shortCode);
 				});
-				o.content = jQuery('<div />').append(content).html(); // Little hack to get outerHTML string
+
+				// Insert outerHTML in order to retain all nodes incl. <script>
+				// tags which would've been filtered out with jQuery.html().
+				// Note that <script> tags might be sanitized separately based on editor config.
+				o.content = '';
+				content.each(function() {
+					if(this.outerHTML !== undefined) {
+						o.content += this.outerHTML;
+					}
+				});
 			});
 
 			var shortTagRegex = /(.?)\[embed(.*?)\](.+?)\[\/\s*embed\s*\](.?)/gi;


### PR DESCRIPTION
TinyMCE strips them by default, but if they're specifically added to the allowed elements we should respect that setting.

Example PHP config:

```php
$validEls = HtmlEditorConfig::get('cms')->getOption('extended_valid_elements');
$validEls .= ',script[src|type]';
HtmlEditorConfig::get('cms')->setOption('extended_valid_elements', $validEls);
```

Tested in IE8, Chrome, Firefox. IE8 wraps the `<script>` tag in `<p>` tags, but that's not a problem of this logic, it also ocurs when completely skipping the callback.