### PR TITLE
Filter heading being processed as part of code

### DIFF
--- a/docs/en/topics/datamodel.md
+++ b/docs/en/topics/datamodel.md
@@ -138,7 +138,7 @@ You can also sort randomly
 
 	:::php
 	$member = Member::get()->sort('RAND()')
-	
+
 ### Filter
 
 As you might expect, the `filter()` method filters the list of objects that gets


### PR DESCRIPTION
Whitespace issue causing the filter header to become part of the sorting example above - fixed whitespace.
