### PR TITLE
Bugfix: fixed inheritance breaks filtering if relations are included

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -610,8 +610,9 @@ class DataQuery {
 				if(!$this->query->isJoinedTo($component)) {
 					$has_one = array_flip($model->has_one());
 					$foreignKey = $has_one[$component];
+					$realModelClass = ClassInfo::table_for_object_field($modelClass, "{$foreignKey}ID");
 					$this->query->addLeftJoin($component,
-						"\"$component\".\"ID\" = \"{$modelClass}\".\"{$foreignKey}ID\"");
+						"\"$component\".\"ID\" = \"{$realModelClass}\".\"{$foreignKey}ID\"");
 				
 					/**
 					 * add join clause to the component's ancestry classes so that the search filter could search on

--- a/tests/model/DataQueryTest.php
+++ b/tests/model/DataQueryTest.php
@@ -49,6 +49,14 @@ class DataQueryTest extends SapphireTest {
 			$dq->sql());
 	}
 
+	public function testApplyReplationDeepInheretence() {
+		$newDQ = new DataQuery('DataQueryTest_E');
+		//apply a relation to a relation from an ancestor class
+		$newDQ->applyRelation('TestA');
+		$this->assertTrue($newDQ->query()->isJoinedTo('DataQueryTest_C'));
+		$this->assertContains('"DataQueryTest_A"."ID" = "DataQueryTest_C"."TestAID"', $newDQ->sql());
+	}
+
 	public function testRelationReturn() {
 		$dq = new DataQuery('DataQueryTest_C');
 		$this->assertEquals('DataQueryTest_A', $dq->applyRelation('TestA'),
@@ -63,6 +71,9 @@ class DataQueryTest extends SapphireTest {
 		$this->assertEquals('DataQueryTest_B', $dq->applyRelation('TestBs'),
 			'DataQuery::applyRelation should return the name of the related object.');
 		$this->assertEquals('DataQueryTest_B', $dq->applyRelation('ManyTestBs'),
+			'DataQuery::applyRelation should return the name of the related object.');
+		$newDQ = new DataQuery('DataQueryTest_E');
+		$this->assertEquals('DataQueryTest_A', $newDQ->applyRelation('TestA'),
 			'DataQuery::applyRelation should return the name of the related object.');
 	}
 


### PR DESCRIPTION
The problem was a missing check in DataQuery::applyRelation()
Fix #3610 and probably #3528 and #3556
