### PR TITLE
NEW: Make the record count in GridFieldFooter optional

### DIFF
--- a/forms/gridfield/GridFieldFooter.php
+++ b/forms/gridfield/GridFieldFooter.php
@@ -21,15 +21,17 @@ class GridFieldFooter implements GridField_HTMLProvider {
 	 * @var string - a message to display in the footer
 	 */
 	protected $message = null;
+	protected $showrecordcount;
 
 	/**
 	 *
 	 * @param string $message - a message to display in the footer
 	 */
-	public function __construct($message = null) {
+	public function __construct($message = null, $showrecordcount = true) {
 		if($message) {
 			$this->message = $message;
 		}
+		$this->showrecordcount = $showrecordcount;
 	}
 
 
@@ -37,6 +39,7 @@ class GridFieldFooter implements GridField_HTMLProvider {
 		$count = $gridField->getList()->count();
 
 		$forTemplate = new ArrayData(array(
+			'ShowRecordCount' => $this->showrecordcount,
 			'Message' => $this->message,
 			'FirstShownRecord' => 1,
 			'LastShownRecord' => $count,

--- a/templates/Includes/GridFieldFooter.ss
+++ b/templates/Includes/GridFieldFooter.ss
@@ -1,12 +1,13 @@
 <tr>
 	<td class="bottom-all" colspan="$Colspan">
-		<span class="pagination-records-number">
-			$FirstShownRecord - 
-			$LastShownRecord
-			<% _t('TableListField_PageControls_ss.OF', 'of', 'Example: View 1 of 2') %>
-			$NumRecords
-		</span>
-
+		<% if $ShowRecordCount %>
+			<span class="pagination-records-number">
+				$FirstShownRecord - 
+				$LastShownRecord
+				<% _t('TableListField_PageControls_ss.OF', 'of', 'Example: View 1 of 2') %>
+				$NumRecords
+			</span>
+		<% end_if %>
 		<% if $Message %>
 		<div class="datagrid-footer-message">$Message</div>
 		<% end_if %>


### PR DESCRIPTION
This is particularly useful when you only have a couple of records in a grid field, and you don't want to display record counts.
