### PR TITLE
Fix TreeDropdownField title on deselect

### DIFF
--- a/javascript/TreeDropdownField.js
+++ b/javascript/TreeDropdownField.js
@@ -165,6 +165,9 @@
 						}
 						if(node) tree.jstree('select_node', node);
 					}
+					else {
+						self.setTitle(' ');
+					}
 				};
 
 				// Load the tree if its not already present


### PR DESCRIPTION
When deselecting the currently selected item in a TreeDropdownField component, the select list title displays '()'. This is confusing user feedback as it does not convey the reset action that was intended by deselecting the item. If the title is set to an empty string, then '()' is still displayed, my solution is to set the title to a single space.
