### PR TITLE
Adding appropriate nginx fastcgi buffer config required for admin

### DIFF
--- a/docs/en/installation/nginx.md
+++ b/docs/en/installation/nginx.md
@@ -81,11 +81,14 @@ But enough of the disclaimer, on to the actual configuration — typically in `n
 		}
 	
 		location ~ \.php$ {
-	                fastcgi_keep_conn on;
-	                fastcgi_pass   127.0.0.1:9000;
-	                fastcgi_index  index.php;
-	                fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;
-	                include        fastcgi_params;
+			fastcgi_keep_conn on;
+			fastcgi_pass   127.0.0.1:9000;
+			fastcgi_index  index.php;
+			fastcgi_param  SCRIPT_FILENAME $document_root$fastcgi_script_name;
+			include        fastcgi_params;
+			fastcgi_buffer_size 32k;
+			fastcgi_busy_buffers_size 64k;
+			fastcgi_buffers 4 32k;
 		}
 	}
 


### PR DESCRIPTION
Fix for existing nginx docs, spun out from the conversation in https://github.com/silverstripe/silverstripe-framework/pull/3588

These are the same ones used in nginx+HHVM docs here: http://doc.silverstripe.org/framework/en/installation/nginx-hhvm
