### PR TITLE
Disable DO validation for default admin writes

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -243,6 +243,9 @@ class Member extends DataObject implements TemplateGlobalProvider {
 			->filter('Email', Security::default_admin_username())
 			->first();
 		if(!$admin) {
+			//disable validation for DataObjects so we can force the write of the admin
+			Config::nest();
+			Config::inst()->update('DataObject', 'validation_enabled', false);
 			// 'Password' is not set to avoid creating
 			// persistent logins in the database. See Security::setDefaultAdmin().
 			// Set 'Email' to identify this as the default admin
@@ -250,6 +253,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 			$admin->FirstName = _t('Member.DefaultAdminFirstname', 'Default Admin');
 			$admin->Email = Security::default_admin_username();
 			$admin->write();
+			Config::unnest();
 		}
 
 		// Ensure this user is in the admin group

--- a/security/Security.php
+++ b/security/Security.php
@@ -770,11 +770,14 @@ class Security extends Controller {
 		}
 
 		if(!$member) {
+			Config::nest();
+			Config::inst()->update('DataObject', 'validation_enabled', false);
 			// Failover to a blank admin
 			$member = Member::create();
 			$member->FirstName = _t('Member.DefaultAdminFirstname', 'Default Admin');
 			$member->write();
 			$member->Groups()->add($adminGroup);
+			Config::unnest();
 		}
 
 		return $member;


### PR DESCRIPTION
Disable Validation on DOs when writing the default admin user.

This fixes build errors where exceptions are thrown if there's a custom validation function against the `Member` object.