### PR TITLE
API Fix HTTPS proxy header detection (Same as #3152)

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -414,11 +414,22 @@ class Director implements TemplateGlobalProvider {
 	 * @return String
 	 */
 	public static function protocol() {
-		if(isset($_SERVER['HTTP_X_FORWARDED_PROTOCOL'])&&strtolower($_SERVER['HTTP_X_FORWARDED_PROTOCOL'])=='https') {
-			return "https://";
+		if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https') {
+			// Convention for (non-standard) proxy signaling a HTTPS forward,
+			// see https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
+			return 'https://';
+		} else if (isset($_SERVER['HTTP_X_FORWARDED_PROTOCOL']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTOCOL']) == 'https') {
+			// Less conventional proxy header
+			return 'https://';
+		} else if (isset($_SERVER['HTTP_FRONT_END_HTTPS']) && strtolower($_SERVER['HTTP_FRONT_END_HTTPS']) == 'on') {
+			// Microsoft proxy convention: https://support.microsoft.com/?kbID=307347
+			return 'https://';
+		} else if((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')) {
+			return 'https://';
+		} else if (isset($_SERVER['SSL'])) {
+			return 'https://';
 		}
-		return (isset($_SERVER['SSL']) || (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')) 
-			? 'https://' : 'http://';
+		return 'http://';
 	}
 
 	/**

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -343,7 +343,7 @@ class HTTP {
 			// By also using and etag that includes both the modification date and all the varies 
 			// values which we also check against we can catch this and not return a 304
 			$etagParts = array(self::$modification_date, serialize($_COOKIE));
-			if (isset($_SERVER['HTTP_X_FORWARDED_PROTOCOL'])) $etagParts[] = $_SERVER['HTTP_X_FORWARDED_PROTOCOL'];
+			$etagParts[] = Director::protocol();
 			if (isset($_SERVER['HTTP_USER_AGENT'])) $etagParts[] = $_SERVER['HTTP_USER_AGENT'];
 			if (isset($_SERVER['HTTP_ACCEPT'])) $etagParts[] = $_SERVER['HTTP_ACCEPT'];
 

--- a/core/startup/ParameterConfirmationToken.php
+++ b/core/startup/ParameterConfirmationToken.php
@@ -76,15 +76,23 @@ class ParameterConfirmationToken {
 	protected function currentAbsoluteURL() {
 		global $url;
 
-		// Are we http or https?
-		$proto = 'http';
-
-		if(isset($_SERVER['HTTP_X_FORWARDED_PROTOCOL'])) {
-			if(strtolower($_SERVER['HTTP_X_FORWARDED_PROTOCOL']) == 'https') $proto = 'https';
+		if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https') {
+			// Convention for (non-standard) proxy signaling a HTTPS forward,
+			// see https://en.wikipedia.org/wiki/List_of_HTTP_header_fields
+			$proto = 'https';
+		} else if (isset($_SERVER['HTTP_X_FORWARDED_PROTOCOL']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTOCOL']) == 'https') {
+			// Less conventional proxy header
+			$proto = 'https';
+		} else if (isset($_SERVER['HTTP_FRONT_END_HTTPS']) && strtolower($_SERVER['HTTP_FRONT_END_HTTPS']) == 'on') {
+			// Microsoft proxy convention: https://support.microsoft.com/?kbID=307347
+			$proto = 'https';
+		} else if((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')) {
+			$proto = 'https';
+		} else if (isset($_SERVER['SSL'])) {
+			$proto = 'https';
+		} else {
+			$proto = 'http';
 		}
-
-		if((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off')) $proto = 'https';
-		if(isset($_SERVER['SSL'])) $proto = 'https';
 
 		$parts = array_filter(array(
 			// What's our host


### PR DESCRIPTION
Didn't use the de facto standard HTTP_X_FORWARDED_PROTO or the less standard HTTP_FRONT_END_HTTPS.
Removed the 'X-Forwarded-Proto', since PHP should prefix/underscore all HTTP headers before it hits $_SERVER.

References:
- https://docs.djangoproject.com/en/1.4/ref/settings/#secure-proxy-ssl-header
- https://drupal.org/node/1859252
- https://drupal.org/node/313145
- http://scottwb.com/blog/2013/02/06/always-on-https-with-rails-behind-an-elb/
