### PR TITLE
FIX DataDifferencer was trying to compare fields, even if the fields did...

### DIFF
--- a/model/DataDifferencer.php
+++ b/model/DataDifferencer.php
@@ -77,28 +77,33 @@ class DataDifferencer extends ViewableData {
 			$diffed = clone $this->toRecord;
 			$fields = array_keys($this->toRecord->toMap());
 		}
-		
-		$hasOnes = $this->fromRecord->has_one();
-		
+
+		$hasOnes = array_merge($this->fromRecord->has_one(), $this->toRecord->has_one());
+
 		// Loop through properties
 		foreach($fields as $field) {
 			if(in_array($field, $this->ignoredFields)) continue;
 			if(in_array($field, array_keys($hasOnes))) continue;
-			
+
 			if(!$this->fromRecord) {
 				$diffed->setField($field, "<ins>" . $this->toRecord->$field . "</ins>");
-			} else if($this->fromRecord->$field != $this->toRecord->$field) {			
+			} else if($this->fromRecord->$field != $this->toRecord->$field) {
 				$diffed->setField($field, Diff::compareHTML($this->fromRecord->$field, $this->toRecord->$field));
 			}
 		}
-		
+
 		// Loop through has_one
 		foreach($hasOnes as $relName => $relSpec) {
 			if(in_array($relName, $this->ignoredFields)) continue;
-			
+
+			// Create the actual column name
 			$relField = "{$relName}ID";
-			$relObjTo = $this->toRecord->$relName();
-			
+			$toTitle = '';
+			if($this->toRecord->hasMethod($relName)) {
+				$relObjTo = $this->toRecord->$relName();
+				$toTitle = $relObjTo->hasMethod('Title') || $relObjTo->hasField('Title') ? $relObjTo->Title : '';
+			}
+
 			if(!$this->fromRecord) {
 				if($relObjTo) {
 					if($relObjTo instanceof Image) {
@@ -107,28 +112,32 @@ class DataDifferencer extends ViewableData {
 						// not playing nice with mocked images
 						$diffed->setField($relName, "<ins>" . $relObjTo->getTag() . "</ins>");
 					} else {
-						$diffed->setField($relField, "<ins>" . $relObjTo->Title() . "</ins>");
+						$diffed->setField($relField, "<ins>" . $toTitle . "</ins>");
 					}
 				}
 			} else if($this->fromRecord->$relField != $this->toRecord->$relField) {
-				$relObjFrom = $this->fromRecord->$relName();
-				if($relObjFrom instanceof Image) {
+				$fromTitle = '';
+				if($this->fromRecord->hasMethod($relName)) {
+					$relObjFrom = $this->fromRecord->$relName();
+					$fromTitle = $relObjFrom->hasMethod('Title') || $relObjFrom->hasField('Title') ? $relObjFrom->Title : '';
+				}
+				if(isset($relObjFrom) && $relObjFrom instanceof Image) {
 					// TODO Use CMSThumbnail (see above)
 					$diffed->setField(
-						// Using relation name instead of database column name, because of FileField etc.
-						$relName, 
+					// Using relation name instead of database column name, because of FileField etc.
+						$relName,
 						Diff::compareHTML($relObjFrom->getTag(), $relObjTo->getTag())
 					);
 				} else {
+					// Set the field.
 					$diffed->setField(
-						$relField, 
-						Diff::compareHTML($relObjFrom->getTitle(), $relObjTo->getTitle())
+						$relField,
+						Diff::compareHTML($fromTitle, $toTitle)
 					);
 				}
-				
 			}
 		}
-		
+
 		return $diffed;
 	}
 	


### PR DESCRIPTION
...n't exist causing an error.

Scenario: (save & publish after each step).
- Create a 'Page' in the CMS.
- Change the type to 'MyCustomPage' which has a has_one relation.
- Set the has_one.
- Change the page type back to 'Page'

Now when you compare the 'Page' version to the 'MyCustomPage' version it will try to compare $obj->MyHasOne() on both classes which causes an error on 'Page' where it doesn't exist.

This fix addresses this issue by checking that the method exists before calling it.

It also fixes an issue where $obj->Title() is blindly called - this assumes that the has_one relation has a 'Title' method which also causes an error where this isn't the case. This is fixed by checking for a field or method on the DataObject then calling $obj->Title if it exists. This maps to Title(), getTitle() or db['Title'].
