### PR TITLE
FIX allVersions doesn't fetch all versions when class is changed

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -907,7 +907,8 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 		$oldMode = self::get_reading_mode();
 		self::reading_stage('Stage');
 
-		$list = DataObject::get(get_class($this->owner), $filter, $sort, $join, $limit);
+		$baseClass = ClassInfo::baseDataClass(get_class($this->owner));
+		$list = DataObject::get($baseClass, $filter, $sort, $join, $limit);
 		if($having) $having = $list->having($having);
 
 		$query = $list->dataQuery()->query();


### PR DESCRIPTION
Scenario:
* Create a new 'Page' and save.
* Change the page type to 'MyCustomPage' which extends 'Page'

When you call all versions it will only return MyCustomPage and its subclassed versions. It won't return 'Page' and any parent class versions.

This change sets the $baseClass and uses this instead.

I've made this change against 3.2 as whilst I believe it fixes a bug, its a behavioural change.

