### PR TITLE
FIX: Manifest flushing

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -95,9 +95,9 @@ Injector::set_inst($injector);
 // Regenerate the manifest if ?flush is set, or if the database is being built.
 // The coupling is a hack, but it removes an annoying bug where new classes
 // referenced in _config.php files can be referenced during the build process.
-$flush = (isset($_GET['flush']) || isset($_REQUEST['url']) && (
-	$_REQUEST['url'] == 'dev/build' || $_REQUEST['url'] == BASE_URL . '/dev/build'
-));
+$requestURL = isset($_REQUEST['url']) ? trim($_REQUEST['url'], '/') : false;
+$flush = (isset($_GET['flush']) || $requestURL == 'dev/build' || $requestURL == BASE_URL . '/dev/build');
+
 global $manifest;
 $manifest = new SS_ClassManifest(BASE_PATH, false, $flush);
 
@@ -111,16 +111,17 @@ if(file_exists(BASE_PATH . '/vendor/autoload.php')) {
 	require_once BASE_PATH . '/vendor/autoload.php';
 }
 
-// Now that the class manifest is up, load the configuration
+// Now that the class manifest is up, load the static configuration
 $configManifest = new SS_ConfigStaticManifest(BASE_PATH, false, $flush);
 Config::inst()->pushConfigStaticManifest($configManifest);
 
-// Now that the class manifest is up, load the configuration
+// And then the yaml configuration
 $configManifest = new SS_ConfigManifest(BASE_PATH, false, $flush);
 Config::inst()->pushConfigYamlManifest($configManifest);
 
+// Load template manifest
 SS_TemplateLoader::instance()->pushManifest(new SS_TemplateManifest(
-	BASE_PATH, project(), false, isset($_GET['flush'])
+	BASE_PATH, project(), false, $flush
 ));
 
 // If in live mode, ensure deprecation, strict and notices are not reported

--- a/core/manifest/TemplateManifest.php
+++ b/core/manifest/TemplateManifest.php
@@ -16,7 +16,6 @@ class SS_TemplateManifest {
 	protected $cacheKey;
 	protected $project;
 	protected $inited;
-	protected $forceRegen;
 	protected $templates = array();
 
 	/**
@@ -39,8 +38,10 @@ class SS_TemplateManifest {
 
 		$this->cache = new $cacheClass('templatemanifest'.($includeTests ? '_tests' : ''));
 		$this->cacheKey = $this->getCacheKey($includeTests);
-
-		$this->forceRegen = $forceRegen;
+		
+		if ($forceRegen) {
+			$this->regenerate();
+		}
 	}
 
 	/**
@@ -208,7 +209,7 @@ class SS_TemplateManifest {
 	}
 
 	protected function init() {
-		if (!$this->forceRegen && $data = $this->cache->load($this->cacheKey)) {
+		if ($data = $this->cache->load($this->cacheKey)) {
 			$this->templates = $data;
 			$this->inited    = true;
 		} else {


### PR DESCRIPTION
Fixes silverstripe/silverstripe-framework#2325
Fixes silverstripe/silverstripe-framework#3093

Static manifest was not being flushed during a dev/build on some environments (without ?flush in URL) and template manifest was never being flushed during a dev/build.
