### PR TITLE
Don't update CMS preview on a CMS redirect

### DIFF
--- a/admin/javascript/LeftAndMain.Preview.js
+++ b/admin/javascript/LeftAndMain.Preview.js
@@ -326,7 +326,10 @@
 			 * Update preview whenever any panels are reloaded.
 			 */
 			'from .cms-container': {
-				onafterstatechange: function(){
+				onafterstatechange: function(e, data) {
+					// Don't update preview if we're dealing with a custom redirect
+					if(data.xhr.getResponseHeader('X-ControllerURL')) return;
+
 					this._initialiseFromContent();
 				}
 			},


### PR DESCRIPTION
The CMS preview causes unnecessary browser processing by loading a URL which
should be considered "in transit" when a CMS redirect is set through the
X-ControllerURL HTTP header. The CMS history processing will load this new
URL, and cause a new preview URL to be loaded.

Fixes https://github.com/silverstripe/silverstripe-translatable/issues/158