### PR TITLE
BUG Fix gridfield storing duplicate data in session

### DIFF
--- a/forms/gridfield/GridField.php
+++ b/forms/gridfield/GridField.php
@@ -840,7 +840,7 @@ class GridField_FormAction extends FormAction {
 			'args' => $this->args,
 		);
 
-		$id = preg_replace('/[^\w]+/', '_', uniqid('', true));
+		$id = md5(serialize($state));
 		Session::set($id, $state);
 		$actionData['StateID'] = $id;
 		


### PR DESCRIPTION
Because the old behaviour was to create a unique ID for every entry every request, the session data could fill up with unnecessary and duplicate data. If used on a gridfield with lots and lots of rows the data could be ginormous.

This fix uses a hash of the serialised data as the session key to limit session growth.
