### PR TITLE
FIX check for suite existence in endCurrentTest

### DIFF
--- a/dev/SapphireTestReporter.php
+++ b/dev/SapphireTestReporter.php
@@ -242,7 +242,7 @@ class SapphireTestReporter implements PHPUnit_Framework_TestListener {
 	 * Cleanly end the current test
 	 */
 	protected function endCurrentTest() {
-		if(!$this->currentTest) return;
+		if(!$this->currentTest || !$this->currentSuite) return;
 
 		// Time the current test
 		$testDuration = microtime(true) - $this->startTestTime;


### PR DESCRIPTION
When using data providers with tests, the reporter appears to get confused and run callbacks in a weird order. This checks that the current suite before adding more details.