### PR TITLE
FIX: Flush was clearing all file-based caches

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -109,7 +109,7 @@ class i18n extends Object implements TemplateGlobalProvider, Flushable {
 			&& ($capabilities = $backend->getCapabilities())
 			&& $capabilities['tags']
 		) {
-			$cache->clean(Zend_Cache::CLEANING_MODE_MATCHING_TAG, $cache->getTags());
+			$cache->clean(Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG, $cache->getTags());
 		} else {
 			$cache->clean(Zend_Cache::CLEANING_MODE_ALL);
 		}

--- a/tests/cache/CacheTest.php
+++ b/tests/cache/CacheTest.php
@@ -64,5 +64,19 @@ class CacheTest extends SapphireTest {
 		$this->assertEquals(1200, $cache->getOption('lifetime'));
 	}
 
+	/**
+	 * Test that flushing does not clear caches that aren't deliberately being
+	 * cleared (e.g. with Flushable)
+	 */
+	public function testFlushDoesNotClearAllCaches() {
+		$cache = SS_Cache::factory('test');
+		$cache->save('Foo', 'cachekey');
+		$this->assertEquals('Foo', $cache->load('cachekey'));
+
+		Director::test('/?flush=1');
+
+		$this->assertEquals('Foo', $cache->load('cachekey'));
+	}
+
 }
 	

--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -955,7 +955,7 @@ class SSViewer implements Flushable {
 				&& ($capabilities = $backend->getCapabilities())
 				&& $capabilities['tags']
 			) {
-				$cache->clean(Zend_Cache::CLEANING_MODE_MATCHING_TAG, $cache->getTags());
+				$cache->clean(Zend_Cache::CLEANING_MODE_MATCHING_ANY_TAG, $cache->getTags());
 			} else {
 				$cache->clean(Zend_Cache::CLEANING_MODE_ALL);
 			}


### PR DESCRIPTION
[This problem](https://github.com/silverstripe/silverstripe-framework/issues/3122) just won’t seem to go away :(

The issue is [here](https://github.com/silverstripe/silverstripe-framework/blob/3.1/thirdparty/Zend/Cache/Backend/File.php#L682). As the template partial cache data isn’t tagged, an empty array is passed for the tags when cleaning [here](https://github.com/silverstripe/silverstripe-framework/blob/3.1/view/SSViewer.php#L958). This means that every bit of data stored in a file-based cache will be matched, so data from all caches will be cleared.

I’ve captured the issue in a test now, so hopefully we’ve seen the last of this :)
