### PR TITLE
DatetimeField and TimeField generate invalid HTML

### DIFF
--- a/forms/DatetimeField.php
+++ b/forms/DatetimeField.php
@@ -84,7 +84,7 @@ class DatetimeField extends FormField {
 		);
 		$config = array_filter($config);
 		$this->addExtraClass('fieldgroup');
-		$this->addExtraClass(Convert::raw2json($config));
+		$this->setAttribute('data-datetime-config', Convert::raw2json($config));
 
 		return parent::FieldHolder($properties);
 	}

--- a/forms/TimeField.php
+++ b/forms/TimeField.php
@@ -69,7 +69,7 @@ class TimeField extends TextField {
 			'timeformat' => $this->getConfig('timeformat')
 		);
 		$config = array_filter($config);
-		$this->addExtraClass(Convert::raw2json($config));
+		$this->setAttribute('data-time-config', Convert::raw2json($config));
 		return parent::Field($properties);
 	}
 	


### PR DESCRIPTION
 DatetimeField and TimeField generate invalid HTML due to JSON being rendered in the class attribute.

This pull request removes the json from the class attributes and adds it to a data- attribute instead