### PR TITLE
MINOR: Trim ModelAdmin SearchForm values

### DIFF
--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -210,6 +210,11 @@ abstract class ModelAdmin extends LeftAndMain {
 	public function getList() {
 		$context = $this->getSearchContext();
 		$params = $this->request->requestVar('q');
+		
+		if(is_array($params)) {
++        		$params = array_map('trim', $params);
++        	}
+
 		$list = $context->getResults($params);
 
 		$this->extend('updateList', $list);

--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -212,8 +212,8 @@ abstract class ModelAdmin extends LeftAndMain {
 		$params = $this->request->requestVar('q');
 		
 		if(is_array($params)) {
-+        		$params = array_map('trim', $params);
-+        	}
+	       		$params = array_map('trim', $params);
+        	}
 
 		$list = $context->getResults($params);
 


### PR DESCRIPTION
Entering "R868 WWL " in a field within the ModelAdmin SearchForm will now return items with the title "R868 WWL"

Amended version of https://github.com/silverstripe/silverstripe-framework/pull/3719