### PR TITLE
Behat: Ignore native dropdowns if they're not visible

### DIFF
--- a/tests/behat/features/bootstrap/SilverStripe/Framework/Test/Behaviour/CmsUiContext.php
+++ b/tests/behat/features/bootstrap/SilverStripe/Framework/Test/Behaviour/CmsUiContext.php
@@ -418,7 +418,7 @@ class CmsUiContext extends BehatContext {
 			'named', 
 			array('select', $this->getSession()->getSelectorsHandler()->xpathLiteral($field))
 		);
-		if($nativeField) {
+		if($nativeField && $nativeField->isVisible()) {
 			$nativeField->selectOption($value);
 			return;
 		}


### PR DESCRIPTION
The CmsUiContext->theIFillInTheDropdownWith() method was written
primarily for TreeDropdownField, which don't have a select tag (only an input tag).
The method currently fails for CMS dropdowns (Dropdown form field class),
since they have a hidden select tag.

I've checked through core feature files and confirmed that every use
of the method relates to TreeDropdownField, which is why this bug hasn't ocurred earlier.