### PR TITLE
BUG: Fixed an issue in the Config system regarding empty strings in arrays

### DIFF
--- a/core/Config.php
+++ b/core/Config.php
@@ -349,10 +349,7 @@ class Config {
 	 */
 	public static function merge_array_low_into_high(&$dest, $src) {
 		foreach ($src as $k => $v) {
-			if (!$v) {
-				continue;
-			}
-			else if (is_int($k)) {
+			if (is_int($k)) {
 				$dest[] = $v;
 			}
 			else if (isset($dest[$k])) {

--- a/tests/core/ConfigTest.php
+++ b/tests/core/ConfigTest.php
@@ -81,6 +81,10 @@ class ConfigTest_TestNest extends Object implements TestOnly {
 	private static $bar = 5;
 }
 
+class ConfigStaticTest_ArrayBlankValue extends Config implements TestOnly  {
+	public static $has_blank = array('', 'test_1', 'test_2');
+}
+
 class ConfigTest extends SapphireTest {
 	
 	public function testNest() {
@@ -133,6 +137,10 @@ class ConfigTest extends SapphireTest {
 		Config::inst()->update('ConfigStaticTest_Third', 'second', array('test_3_2'));
 		$this->assertEquals(Config::inst()->get('ConfigStaticTest_Third', 'second', Config::FIRST_SET),
 			array('test_3_2'));
+
+		Config::inst()->update('ConfigStaticTest_ArrayBlankValue', 'has_blank', array('test_3'));
+		$this->assertEquals(array('test_3', '', 'test_1', 'test_2'),
+			Config::inst()->get('ConfigStaticTest_ArrayBlankValue', 'has_blank'));
 	}
 
 	public function testUpdateWithFalsyValues() {


### PR DESCRIPTION
There is a bug in the config system - if a static non-associative array has a empty string value(s), and that array is updated via Config::inst()->update(), then any blank values will be incorrectly REMOVED.

The fix is to remove the conditional in Config.php merge_array_low_into_high that bails when the value is falsy. 

I've included a unit test which demonstrates this bug - to replicate, checkout the original core/Config.php and run ConfigTest

I actually discovered this bug when I added a new extension to $allowed_extensions in File via the Config system, because the default $allowed_extensions has a empty string (ie; a file with no extension), this effectively means that while my new extension gets added, files with no extensions can no longer be added to assets.

Cheers,
Dan