### PR TITLE
Remove "Filter" title if no search form is present

### DIFF
--- a/admin/templates/Includes/ModelAdmin_Tools.ss
+++ b/admin/templates/Includes/ModelAdmin_Tools.ss
@@ -1,7 +1,9 @@
 <div class="cms-content-tools west cms-panel cms-panel-layout" id="cms-content-tools-ModelAdmin" data-expandOnClick="true" data-layout-type="border">
 	<div class="cms-panel-content center">
-		<h3 class="cms-panel-header"><% _t('ModelAdmin_Tools_ss.FILTER', 'Filter') %></h3>
-		$SearchForm
+		<% if $SearchForm %>
+			<h3 class="cms-panel-header"><% _t('ModelAdmin_Tools_ss.FILTER', 'Filter') %></h3>
+			$SearchForm
+		<% end_if %>
 
 		<% if $ImportForm %>
 			<h3 class="cms-panel-header"><% _t('ModelAdmin_Tools_ss.IMPORT', 'Import') %></h3>


### PR DESCRIPTION
Same as with the import form - you can overload the public function `SearchForm` in your model admin subclass to not return a form and the title currently remains there which makes no sense.