### PR TITLE
BUG Fix tutorial index page for the new doc site

### DIFF
--- a/docs/en/tutorials/index.md
+++ b/docs/en/tutorials/index.md
@@ -1,12 +1,12 @@
 # Written Tutorials
 
- * [Tutorial 1: Building a basic site](1-building-a-basic-site): An introduction to building a site with
+ * [Tutorial 1: Building a basic site](building-a-basic-site): An introduction to building a site with
 SilverStripe
- * [Tutorial 2: Extending a basic site](2-extending-a-basic-site): A tutorial that builds on "Building a basic
+ * [Tutorial 2: Extending a basic site](extending-a-basic-site): A tutorial that builds on "Building a basic
 site"
- * [Tutorial 3: Forms](3-forms): An introduction to forms in SilverStripe.
- * [Tutorial 4: Site Search](4-site-search): Learn how to add search to your site.
- * [Tutorial 5: Dataobject Relationship Management](5-dataobject-relationship-management): Learn how to create
+ * [Tutorial 3: Forms](forms): An introduction to forms in SilverStripe.
+ * [Tutorial 4: Site Search](site-search): Learn how to add search to your site.
+ * [Tutorial 5: Dataobject Relationship Management](dataobject-relationship-management): Learn how to create
 a simple data relationships
 
 #  Video tutorials
@@ -19,5 +19,5 @@ a simple data relationships
 # Help: If you get stuck
 
  * [Common Problems](/installation/common-problems): Review some existing solutions to common problems.
- * [SilverStripe Forums](http://www.silverstripe.com/silverstripe-forum/): Head over to the forums and ask the community
+ * [SilverStripe Forums](http://www.silverstripe.org/community/forums/): Head over to the forums and ask the community
 for help


### PR DESCRIPTION
This fixes broken tutorial links in 2.4 version of docs for the new documentation website.