### PR TITLE
DOCS Fixed dead link to image in tutorial 1

### DIFF
--- a/docs/en/01_Tutorials/01_Building_A_Basic_Site.md
+++ b/docs/en/01_Tutorials/01_Building_A_Basic_Site.md
@@ -383,7 +383,7 @@ We'll also replace the title text with an image. Find this line:
 
 	:::ss
 	<div id="Banner">
-	  <img src="http://www.silverstripe.org/themes/silverstripe/images/sslogo.png" alt="Homepage image" />
+	  <img src="http://www.silverstripe.org/assets/SilverStripe-200.png" alt="Homepage image" />
 	</div>
 
 


### PR DESCRIPTION
Found a dead link to the Silverstripe Logo, have changed this to an updated working link of the same image.