### PR TITLE
MINOR Empty YAML config causes invalid argument error

### DIFF
--- a/core/manifest/ConfigManifest.php
+++ b/core/manifest/ConfigManifest.php
@@ -652,8 +652,10 @@ class SS_ConfigManifest {
 	 * @return void
 	 */
 	public function mergeInYamlFragment(&$into, $fragment) {
-		foreach ($fragment as $k => $v) {
-			Config::merge_high_into_low($into[$k], $v);
+		if ($fragment) {
+			foreach ($fragment as $k => $v) {
+				Config::merge_high_into_low($into[$k], $v);
+			}
 		}
 	}
 

--- a/tests/core/manifest/fixtures/configmanifest/mysite/_config/namedempty.yml
+++ b/tests/core/manifest/fixtures/configmanifest/mysite/_config/namedempty.yml
@@ -1,0 +1,3 @@
+---
+Name: emptyconfig
+---


### PR DESCRIPTION
This fixes an issue where an empty yml config file causes the `ConfigManifest` to throw an invalid argument error for the foreach.