### PR TITLE
FIX: Relates to silverstripe/silverstripe-cms#981

### DIFF
--- a/admin/code/SecurityAdmin.php
+++ b/admin/code/SecurityAdmin.php
@@ -69,7 +69,7 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider {
 		
 		$memberList = GridField::create(
 			'Members',
-			false,
+			_t("SecurityAdmin.Users", 'Users'),
 			Member::get(),
 			$memberListConfig = GridFieldConfig_RecordEditor::create()
 				->addComponent(new GridFieldButtonRow('after'))
@@ -88,7 +88,7 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider {
 
 		$groupList = GridField::create(
 			'Groups',
-			false,
+			_t("SecurityAdmin.GROUPS", 'Groups'),
 			Group::get(),
 			GridFieldConfig_RecordEditor::create()
 		);
@@ -157,7 +157,7 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider {
 		// Add roles editing interface
 		if(Permission::check('APPLY_ROLES')) {
 			$rolesField = GridField::create('Roles',
-				false,
+				_t("SecurityAdmin.ROLES", 'Roles'),
 				PermissionRole::get(),
 				GridFieldConfig_RecordEditor::create()
 			);

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -514,6 +514,7 @@ en:
     NEWGROUP: 'New Group'
     PERMISSIONS: Permissions
     ROLES: Roles
+    GROUPS: Groups
     ROLESDESCRIPTION: 'Roles are predefined sets of permissions, and can be assigned to groups.<br />They are inherited from parent groups if required.'
     TABROLES: Roles
     Users: Users


### PR DESCRIPTION
This patches SecurityAdmin so that all out of the box CMS admins will have a `GridFieldToolbarHeader` and appropriate title.
