### PR TITLE
FIX: Fixes CMS errors when viewing history on "Deleted" pages.

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -1249,8 +1249,11 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 	 */
 	public function isLatestVersion() {
 		$version = self::get_latest_version($this->owner->class, $this->owner->ID);
+		if($version) {
+			return ($version->Version == $this->owner->Version);
+		}
 		
-		return ($version->Version == $this->owner->Version);
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Fixes undocumented error when viewing history tab of deleted pages with no history.
Related to silverstripe/silverstripe/cms#1054 (See
silverstripe/silverstripe-cms/pull/1149).