### PR TITLE
DOCS Code of conduct draft

### DIFF
--- a/docs/en/05_Contributing/07_Code_of_conduct.md
+++ b/docs/en/05_Contributing/07_Code_of_conduct.md
@@ -1,0 +1,61 @@
+# SilverStripe community code of conduct
+
+These guidelines aim to be an aspirational ideal for how we should behave when interacting in the SilverStripe developer community and to aid in building great open source software.
+
+This code of conduct should be applied to all discussions and interactions involving SilverStripe and its related resources. 
+
+Honour the code of conduct whenever you participate formally and informally in our community and follow it in spirit as much as in letter.
+
+## **Be open, collaborative and curious**
+
+ * Experiment with your code and share the results.
+ * Ask questions if you get stuck.
+ * If you can answer questions be responsive and help guide others towards solutions
+ * Share code and knowledge that might help others.
+ * The community is first and foremost about people sharing their knowledge to build something great together.
+
+## Be empathetic, friendly and considerate.
+ * Welcome and encourage participation from everyone that wishes to join our community.
+ * Remember growing the community socially is as important as code related matters.
+ * Be respectful and honour diversity in our community. Sexist, racist, and other exclusionary jokes can offend those around you and are not appropriate.
+ * Keep your actions lawful, non-discriminatory, and unthreatening towards others.
+
+## Respect the reader’s time.
+ * Be concise and read over things before you post.
+ * Mind your words, you write something once that will be read by many - being abusive, mean spirited and swearing at others does nothing to help get points across and drive constructive contributions to open source.
+ * Be clear when responding who you are representing, are you speaking on behalf of another business or acting in your capacity as an individual community member? Either is fine and encouraged and you should aim to make it clear to the reader.
+
+## Respect different levels of participation.
+ * Welcome newcomers, spend a little time helping orientate them in our community.
+ * All contributors and core committers, module maintainers and knowledge sharers are participating in the community in  a voluntary nature. Have respect for them and their time when making requests. You may need to exercise some patience.
+ * Whenever possible reference your comments to others with example code or links to documentation.This helps people learn and become more experienced community members and developers.
+ * If you manage to solve your own problem, tell others how you solved it. This will help people in the future that find they have the same problem as you.
+ * If you are reducing your input and potentially stepping away from the community please remember others might rely on your contributions. Be prepared to ensure these are kept open and available, spend some time handing over to another community member or core contributor to help continuity of SilverStripe open source.
+
+## Resolve conflicts directly
+ * Conflict may eventuate from time to time, we should view it as a constructive process. Understanding others positions without descending into ad hominem attacks is valuable.
+ * Involve a 3rd party or if necessary inform a core committer if conflicts continue to escalate.
+ * Breaches of the code of conduct by community members may first result in a reminder about the code of conduct (we realise we're all human and sometimes we have bad days).
+ * Repeated and deliberate breaching after this will be referred to the core committers team and may result in members being asked to leave the community channels.
+ * While we have a policy of not removing postings and comments from our digital channels, there may be times in which items are removed if deemed blatantly discriminatory towards individuals, groups or cultures.
+ * Call others on their behaviour within the community and remind them of this code where necessary.
+ * Refer to [these helpful guides on conflict resolution](http://www.crnhq.org/pages.php?pID=10) to aid you.
+
+
+## A living document
+ * This is a living document, as core committers we don't have all the answers and we attempt to make the community an innovative and valuable space for everyone that wishes to participate.
+
+ * If you would like to improve the wording, add additional items or simply fix typos each contribution to the code of conduct will be considered on it's merit and if agreed unanimously by the core committers it will be included in future revisions of the SilverStripe code of conduct.
+
+## Core committers house rules
+Core committers are also bound by their [own set of house rules](core_committers#house_rules_for_the_core_committer_team).
+
+_The SilverStripe code of conduct has been adapted from the following sources:_
+
+http://www.apache.org/foundation/policies/conduct.html
+
+https://www.djangoproject.com/conduct/
+
+http://speakup.io/coc.html
+
+http://www.crnhq.org/pages.php?pID=10


### PR DESCRIPTION
This is a draft code of conduct created on behalf of the SilverStripe core committers. It aims to bring us into line with other open source projects (e.g. Apache, Django etc), which have clear conduct codes without being overbearing.

The raising of this draft was discussed at the [SilverStripe core committer hangout #1 (2015)](http://youtu.be/wVFMCgyDixc?t=24m33s) and this draft is submitted for consultation in the community before we consider adopting it. As @sminnee mentioned in the hangout, this is meant to be an aspirational ideal of what good behaviour and outcomes in the community looks like rather than hard and fast rules.

Any discussions, comments or queries can be made on this pull request.

If you would like to improve the draft wording (with an aim to make it shorter), typos or grammatical faux pas please [submit your pull request to my fork](https://github.com/camfindlay/silverstripe-framework/blob/codeofconduct/docs/en/05_Contributing/07_Code_of_conduct.md) (so I can merge in and update this pull request). Once merged into the docs direct pull requests can be made against the framework as standard with our documentation.