### PR TITLE
Add installation steps for Composer

### DIFF
--- a/docs/en/00_Getting_Started/01_Installation/02_Mac_OSX.md
+++ b/docs/en/00_Getting_Started/01_Installation/02_Mac_OSX.md
@@ -1,9 +1,9 @@
 # Mac OSX
 
-This topic covers setting up your Mac as a Web Server and installing SilverStripe. 
+This topic covers setting up your Mac as a Web Server and installing SilverStripe.
 
 While OSX Comes bundled with PHP and Apache (Thanks Apple!) Its not quite ideal for SilverStripe so for setting up a
-webserver on OSX we suggest using [MAMP](http://www.mamp.info/en/index.php) or using [MacPorts](http://www.macports.org/) 
+webserver on OSX we suggest using [MAMP](http://www.mamp.info/en/index.php) or using [MacPorts](http://www.macports.org/)
 to manage your packages.
 
 If you want to use the default OSX PHP version then you will need to recompile your own versions of PHP with GD. Providing instructions
@@ -25,31 +25,51 @@ Servers - this is so our changes to the php.ini take effect.
 
 ## Installing SilverStripe
 
-###Composer
-[Composer (a dependancy manager for PHP)](http://getcomposer.org) is the prefered way to install SilverStripe and ensure you get the correct set of files for your project.
+### Composer
+[Composer (a dependancy manager for PHP)](http://getcomposer.org) is the preferred way to install SilverStripe and ensure you get the correct set of files for your project.
 
-Composer uses your MAMP PHP executible to run and also requires [git](http://git-scm.com) (so it can automatically download the required files from GitHub).
+Composer uses your MAMP PHP executable to run and also requires [git](http://git-scm.com) (so it can automatically download the required files from GitHub).
 
-Process to install is as follows:
+#### Install composer using MAMP
+ 1. First create an alias for our bash profile, using your preferred terminal text editor (nano, vim, etc) open `~/.bash_profile`.
 
- 1. Install [git for mac](http://git-scm.com/download/mac).
- 2. Install composer using the instructions at https://gist.github.com/kkirsche/5710272
- 3. Run the following command to get a fresh copy of SilverStripe via composer:
-  
-        composer create-project silverstripe/installer /Applications/MAMP/htdocs/silverstripe/
+ 2. Add the following line (adjusting the version number of PHP to your installation of MAMP): `alias phpmamp='/Applications/MAMP/bin/php/php5.4.10/bin/php'`.
 
- 4. You can now [use composer](http://doc.silverstripe.org/framework/en/installation/composer) to manage future SilverStripe updates and adding modules with a few easy commands.
+ 3. The run `. ~/.bash_profile` to reload the bash profile and make it accessible.
 
-###Package Download
+ 4. This will create an alias, `phpmamp`, allowing you to use the MAMP installation of PHP. Please take note of the PHP version, in this case 5.4.10, as with different versions of MAMP this may be different. Check your installation and see what version you have, and replace the number accordingly (this was written with MAMP version 2.1.2).
 
-[Download](http://silverstripe.org/download) the latest SilverStripe installer package. Copy the tar.gz file to the 'Document Root' for MAMP - By Default its `/Applications/MAMP/htdocs`.
-Don't know what your Document Root is? Open MAMP Click `Preferences -> Apache`. 
+ 5. With that setup, we are ready to install `composer`. This is a two step process if we would like this to be installed globally (only do the first step if you would like `composer` installed to the local working directory only).
+    - First, run the following command in the terminal: `curl -sS https://getcomposer.org/installer | phpmamp`
+
+	We are using `phpmamp` so that we correctly use the MAMP installation of PHP from above.
+
+	- Second, if you want to make composer available globally, we need to move the file to '/usr/local/bin/composer'. To do this, run the following command:
+	`sudo mv composer.phar /usr/local/bin/composer`
+
+	Terminal will ask you for your root password, after entering it and pressing the 'return' (or enter) key, you'll have a working global installation of composer on your mac that uses MAMP.
+
+ 6. You can verify your installation worked by typing the following command:
+	`composer`
+	It'll show you the current version and a list of commands you can use.
+
+ 7. Run the following command to get a fresh copy of SilverStripe via composer:
+
+        `composer create-project silverstripe/installer /Applications/MAMP/htdocs/silverstripe/`
+
+ 8. You can now [use composer](http://doc.silverstripe.org/framework/en/getting_started/composer/) to manage future SilverStripe updates and adding modules with a few easy commands.
+
+
+### Package Download
+
+[Download](http://silverstripe.org/software/download/) the latest SilverStripe installer package. Copy the tar.gz or zip file to the 'Document Root' for MAMP - By Default its `/Applications/MAMP/htdocs`.
+Don't know what your Document Root is? Open MAMP Click `Preferences -> Apache`.
 
 Extract the tar.gz file to a folder, e.g. `silverstripe/` (you always move the tar.gz file first and not the other way
 around as SilverStripe uses a '.htaccess' file which is hidden from OSX so if you move SilverStripe the .htaccess file
 won't come along.
 
-###Run the installation wizard
+### Run the installation wizard
 Once you have a copy of the required code (by either of the above methods), open your web browser and go to `http://localhost:8888/silverstripe/`. Enter your database details - by default with MAMP its user `root` and password  `root` and select your account details. Click "Check Details".
 
-Once everything is sorted hit "Install!" and Voila,  you have SilverStripe installed 
+Once everything is sorted hit "Install!" and Voila,  you have SilverStripe installed


### PR DESCRIPTION
(Cherry picked pull request from fork by @kkirsche)

Added installation steps for Composer using the global installation of PHP and the MAMP installation of PHP.

Note that the use of HTML instead of standard Markdown was due to Markdown incorrectly handling nested ordered lists. This wasn't my preference, but I felt having consistent and clear styling of sub menus overrode ease of use as plain-text.