### PR TITLE
Fix CheckboxSetField's getOptions() $items creation

### DIFF
--- a/forms/CheckboxSetField.php
+++ b/forms/CheckboxSetField.php
@@ -83,35 +83,24 @@ class CheckboxSetField extends OptionsetField {
 			}
 		}
 		
-		// Source is not an array
-		if(!is_array($source) && !is_a($source, 'SQLMap')) {
-			if(is_array($values)) {
+		// Generate $items array from $values, if set
+		if ($values) {
+			// If $values is an array, we can directly use it
+			if (is_array($values)) {
 				$items = $values;
-			} else {
-				// Source and values are DataObject sets.
-				if($values && is_a($values, 'SS_List')) {
-					foreach($values as $object) {
-						if(is_a($object, 'DataObject')) {
-							$items[] = $object->ID;
-						}
+			}
+			// If it is a list, append each object's ID to $items
+			elseif ($values instanceof SS_List) {
+				foreach($values as $object) {
+					if(is_a($object, 'DataObject')) {
+						$items[] = $object->ID;
 					}
-				} elseif($values && is_string($values)) {
-					$items = explode(',', $values);
-					$items = str_replace('{comma}', ',', $items);
 				}
 			}
-		} else {
-			// Sometimes we pass a singluar default value thats ! an array && !SS_List
-			if($values instanceof SS_List || is_array($values)) {
-				$items = $values;
-			} else {
-				if($values === null) {
-					$items = array();
-				}
-				else {
-					$items = explode(',', $values);
-					$items = str_replace('{comma}', ',', $items);
-				}
+			// If it is a string, generate $items by splitting by comma
+			elseif (is_string($values)) {
+				$items = explode(',', $values);
+				$items = str_replace('{comma}', ',', $items);
 			}
 		}
 


### PR DESCRIPTION
This change fixes a bug in framework/forms/CheckboxSetField.php's
getOptions() method that triggered warnings such as the following:

  Warning at framework/forms/CheckboxSetField.php line 167: in_array()
  expects parameter 2 to be array, object given (http://foo/admin/
  pages/edit/EditForm/field/Dishes/item/416/edit)

This was due to $items being expected to always be an array, which didn't
hold true for the combination of $source being an Array and $values being
an instanceof SS_List object.
