### PR TITLE
API Adding default_classes config option for Form and FormField

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -142,6 +142,12 @@ class Form extends RequestHandler {
 	protected $extraClasses = array();
 
 	/**
+	 * @config
+	 * @var array $default_classes The default classes to apply to the Form
+	 */
+	private static $default_classes = array();
+
+	/**
 	 * @var string
 	 */
 	protected $encType;
@@ -224,6 +230,8 @@ class Form extends RequestHandler {
 		}
 
 		$this->securityToken = ($securityEnabled) ? new SecurityToken() : new NullSecurityToken();
+
+		$this->setupDefaultClasses();
 	}
 
 	private static $url_handlers = array(
@@ -261,6 +269,19 @@ class Form extends RequestHandler {
 		}
 
 		return $this;
+	}
+
+	/**
+	 * set up the default classes for the form. This is done on construct so that the default classes can be removed
+	 * after instantiation
+	 */
+	protected function setupDefaultClasses() {
+		$defaultClasses = self::config()->get('default_classes');
+		if ($defaultClasses) {
+			foreach ($defaultClasses as $class) {
+				$this->addExtraClass($class);
+			}
+		}
 	}
 
 	/**

--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -41,6 +41,12 @@ class FormField extends RequestHandler {
 	 */
 	protected $extraClasses;
 
+	/**
+	 * @config
+	 * @var array $default_classes The default classes to apply to the FormField
+	 */
+	private static $default_classes = array();
+
 	public $dontEscape;
 
 	/**
@@ -164,6 +170,21 @@ class FormField extends RequestHandler {
 		if($value !== NULL) $this->setValue($value);
 
 		parent::__construct();
+
+		$this->setupDefaultClasses();
+	}
+
+	/**
+	 * set up the default classes for the form. This is done on construct so that the default classes can be removed
+	 * after instantiation
+	 */
+	protected function setupDefaultClasses() {
+		$defaultClasses = self::config()->get('default_classes');
+		if ($defaultClasses) {
+			foreach ($defaultClasses as $class) {
+				$this->addExtraClass($class);
+			}
+		}
 	}
 
 	/**

--- a/tests/forms/FormFieldTest.php
+++ b/tests/forms/FormFieldTest.php
@@ -3,7 +3,52 @@
  * @package framework
  * @subpackage tests
  */
-class FormFieldTest extends SapphireTest implements TestOnly {
+class FormFieldTest extends SapphireTest {
+
+	public function testDefaultClasses() {
+		Config::nest();
+
+		Config::inst()->update('FormField', 'default_classes', array(
+			'class1',
+		));
+
+		$field = new FormField('MyField');
+
+		$this->assertContains('class1', $field->extraClass(), 'Class list does not contain expected class');
+
+		Config::inst()->update('FormField', 'default_classes', array(
+			'class1',
+			'class2',
+		));
+
+		$field = new FormField('MyField');
+
+		$this->assertContains('class1 class2', $field->extraClass(), 'Class list does not contain expected class');
+
+		Config::inst()->update('FormField', 'default_classes', array(
+			'class3',
+		));
+
+		$field = new FormField('MyField');
+
+		$this->assertContains('class3', $field->extraClass(), 'Class list does not contain expected class');
+
+		$field->removeExtraClass('class3');
+
+		$this->assertNotContains('class3', $field->extraClass(), 'Class list contains unexpected class');
+
+		Config::inst()->update('TextField', 'default_classes', array(
+			'textfield-class',
+		));
+
+		$field = new TextField('MyField');
+
+		//check default classes inherit
+		$this->assertContains('class3', $field->extraClass(), 'Class list does not contain inherited class');
+		$this->assertContains('textfield-class', $field->extraClass(), 'Class list does not contain expected class');
+
+		Config::unnest();
+	}
 
 	public function testAddExtraClass() {
 		$field = new FormField('MyField');

--- a/tests/forms/FormTest.php
+++ b/tests/forms/FormTest.php
@@ -478,6 +478,40 @@ class FormTest extends FunctionalTest {
 		);
 	}
 
+	public function testDefaultClasses() {
+		Config::nest();
+
+		Config::inst()->update('Form', 'default_classes', array(
+			'class1',
+		));
+
+		$form = $this->getStubForm();
+
+		$this->assertContains('class1', $form->extraClass(), 'Class list does not contain expected class');
+
+		Config::inst()->update('Form', 'default_classes', array(
+			'class1',
+			'class2',
+		));
+
+		$form = $this->getStubForm();
+
+		$this->assertContains('class1 class2', $form->extraClass(), 'Class list does not contain expected class');
+
+		Config::inst()->update('Form', 'default_classes', array(
+			'class3',
+		));
+
+		$form = $this->getStubForm();
+
+		$this->assertContains('class3', $form->extraClass(), 'Class list does not contain expected class');
+
+		$form->removeExtraClass('class3');
+
+		$this->assertNotContains('class3', $form->extraClass(), 'Class list contains unexpected class');
+
+		Config::unnest();
+	}
 
 	public function testAttributes() {
 		$form = $this->getStubForm();


### PR DESCRIPTION
This adds the ability to add default classes to `Form` and `FormField` which is useful for CSS frameworks to ensure fields and forms can have classes which are relevant.

Fixes #3688