### PR TITLE
FIX. Summary fields can't be translated

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -99,9 +99,9 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	);
 	
 	private static $summary_fields = array(
-		'FirstName' => 'First Name',
-		'Surname' => 'Last Name',
-		'Email' => 'Email',
+		'FirstName',
+		'Surname',
+		'Email',
 	);
 
 	/**


### PR DESCRIPTION
fieldLabels() now can find these fields and translate them.