### PR TITLE
Allow grouped list to group by related objects

### DIFF
--- a/model/GroupedList.php
+++ b/model/GroupedList.php
@@ -1,12 +1,19 @@
 <?php
 /**
- * A list decorator that allows a list to be grouped into sub-lists by common
- * values of a field.
+ * A list decorator that allows a list to be grouped into sub-lists
+ * by a given field, or related object.
  *
  * @package framework
  * @subpackage model
  */
 class GroupedList extends SS_ListDecorator {
+
+	/**
+	 * Store references to has_one object groupings,
+	 * if present.
+	 * @var array
+	 */
+	protected $groupobjects = array();
 
 	/**
 	 * @param  string $index
@@ -19,6 +26,12 @@ class GroupedList extends SS_ListDecorator {
 			// if $item is an Object, $index can be a method or a value,
 			// if $item is an array, $index is used as the index
 			$key = is_object($item) ? ($item->hasMethod($index) ? $item->$index() : $item->$index) : $item[$index];
+
+			//convert index relation object into ID
+			if($key instanceof DataObject){
+				$this->groupobjects[$key->ID] = $key;
+				$key = $key->ID;
+			}
 
 			if (array_key_exists($key, $result)) {
 				$result[$key]->push($item);
@@ -41,9 +54,12 @@ class GroupedList extends SS_ListDecorator {
 	public function GroupedBy($index, $children = 'Children') {
 		$grouped = $this->groupBy($index);
 		$result  = new ArrayList();
-
 		foreach ($grouped as $indVal => $list) {
 			$list = GroupedList::create($list);
+			//convert indVal from ID to DataObject, if appropriate
+			if(!empty($this->groupobjects) && isset($this->groupobjects[$indVal])){
+				$indVal = $this->groupobjects[$indVal];
+			}
 			$result->push(new ArrayData(array(
 				$index    => $indVal,
 				$children => $list


### PR DESCRIPTION
Provides access in template for displaying group object data.

Allows for usage such as:
```
<% loop GroupableList.GroupedBy(RelatedGroup) %>
   <h4>$RelatedGroup.Title</h4>
   <% loop Children %>
     ...
   <% end_loop %>
<% end_loop %>
```