### PR TITLE
FIX: DataObject::db returned fields in incorrect order, with incorrect data types

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1666,9 +1666,14 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	 */
 	public function db($fieldName = null) {
 		$classes = ClassInfo::ancestry($this, true);
-		$items = array();
 
-		foreach(array_reverse($classes) as $class) {
+		// If we're looking for a specific field, we want to hit subclasses first as they may override field types
+		if($fieldName) {
+			$classes = array_reverse($classes);
+		}
+
+		$items = array();
+		foreach($classes as $class) {
 			if(isset(self::$_cache_db[$class])) {
 				$dbItems = self::$_cache_db[$class];
 			} else {

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -38,9 +38,19 @@ class DataObjectTest extends SapphireTest {
 		$this->assertEquals('Text', $obj->db('Comment'));
 
 		$obj = new DataObjectTest_ExtendedTeamComment();
+		$dbFields = $obj->db();
 
 		// Assert overloaded fields have correct data type
 		$this->assertEquals('HTMLText', $obj->db('Comment'));
+		$this->assertEquals('HTMLText', $dbFields['Comment'],
+			'Calls to DataObject::db without a field specified return correct data types');
+
+		// assertEquals doesn't verify the order of array elements, so access keys manually to check order:
+		// expected: array('Name' => 'Varchar', 'Comment' => 'HTMLText')
+		reset($dbFields);
+		$this->assertEquals('Name', key($dbFields), 'DataObject::db returns fields in correct order');
+		next($dbFields);
+		$this->assertEquals('Comment', key($dbFields), 'DataObject::db returns fields in correct order');
 	}
 
 	public function testValidObjectsForBaseFields() {


### PR DESCRIPTION
fixes #3802