### PR TITLE
BUG: Fixed bug in SS_HTTPRequest where a url ending in dots would cause match() and param() to return incorrect values

### DIFF
--- a/control/HTTPRequest.php
+++ b/control/HTTPRequest.php
@@ -132,7 +132,6 @@ class SS_HTTPRequest implements ArrayAccess {
 			$this->url = preg_replace(array('/\/+/','/^\//', '/\/$/'),array('/','',''), $this->url);
 		}
 		if(preg_match('/^(.*)\.([A-Za-z][A-Za-z0-9]*)$/', $this->url, $matches)) {
-			$this->url = $matches[1];
 			$this->extension = $matches[2];
 		}
 		if($this->url) $this->dirParts = preg_split('|/+|', $this->url);
@@ -313,7 +312,7 @@ class SS_HTTPRequest implements ArrayAccess {
 	 * @return string
 	 */
 	public function getURL($includeGetVars = false) {
-		$url = ($this->getExtension()) ? $this->url . '.' . $this->getExtension() : $this->url; 
+		$url = $this->url;
 
 		if ($includeGetVars) { 
 			// if we don't unset $vars['url'] we end up with /my/url?url=my/url&foo=bar etc 

--- a/tests/control/HTTPRequestTest.php
+++ b/tests/control/HTTPRequestTest.php
@@ -13,6 +13,18 @@ class HTTPRequestTest extends SapphireTest {
 		$this->assertEquals("add", $request->remaining());
 		
 		$this->assertEquals(array("_matched" => true), $request->match('add', true));
+
+		/* Test that match and param work when a url ends with a parameter with dots */
+		$request = new SS_HTTPRequest('GET', 'path/action/param.with.dots');
+		$this->assertEquals(
+			array(
+				'Action' => 'action',
+				'ID' => 'param.with.dots'
+			),
+			$request->match('path/$Action/$ID')
+		);
+
+		$this->assertEquals('param.with.dots', $request->param('ID'));
 	}
 	
 	public function testHttpMethodOverrides() {


### PR DESCRIPTION
There is a bug in HTTPRequest in how setUrl() and getUrl() work, which affects match() and param().

setUrl extracts any (probable) extension from a url that has one, except it then strangely *removes* the extension from the url.

getUrl resolves this by concatenating the extension back onto the split url.

This is not only unnecessary, it creates a bug in a specific case, where the url has dots after the last slash (and isn’t a file)

eg;

setUrl(‘path/action/test.param.fail’);

then:

$url = '’path/action/test.param’
$extension = ‘fail’

$dirParts = (
  [0] => ‘path’,
  [1] => ‘action’,
  [2] => ’test.param’
)

$dirParts is used in match(), therefore:

match(‘path/$Action/$ID’);

returns:

(
	[Action] => ‘action’,
	[ID] => ’test.param'
)

which is clearly wrong. $request->param(‘ID’) will return ’test.param’ rather than the expected ’test.param.fail’

SOLUTION:
I’ve included a unit test for match() and param() and a fix that simply removes the code that writes the split url in setUrl(), and the concatenation code in getUrl().

$url is protected so therefore not accessed elsewhere in the codebase.
