### PR TITLE
Flush should be off by default - consistant

### DIFF
--- a/dev/TestRunner.php
+++ b/dev/TestRunner.php
@@ -78,9 +78,9 @@ class TestRunner extends Controller {
 	 * top of the loader stacks.
 	 */
 	public static function use_test_manifest() {
-		$flush = true;
-		if(isset($_GET['flush']) && $_GET['flush'] === '0') {
-			$flush = false;
+		$flush = false;
+		if(isset($_GET['flush']) && ($_GET['flush'] === '1' || $_GET['flush'] == 'all')) {
+			$flush = true;
 		}
 
 		$classManifest = new SS_ClassManifest(


### PR DESCRIPTION
Flushing should be off by default, just like it is when you are on the site normally.

It's not obvious that tests always flush when they run and you have to pass flush=0 to turn them off. People expect to have to flush to clear the cache, and the documentation already covers mentions about flushing.

Flushing all the time is slow. It adds 5-6 seconds for the tests even with sqlite. When your doing them a couple of times a minute it's pretty painful.

-> http://doc.silverstripe.org/en/developer_guides/testing/unit_testing/
*phpunit framework/tests '' flush=all *
*Run tests with optional `$_GET` parameters (you need an empty second argument)*