### PR TITLE
FIX: dev/build not flushing manifests if site is in a subfolder

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -96,7 +96,7 @@ Injector::set_inst($injector);
 // The coupling is a hack, but it removes an annoying bug where new classes
 // referenced in _config.php files can be referenced during the build process.
 $requestURL = isset($_REQUEST['url']) ? trim($_REQUEST['url'], '/') : false;
-$flush = (isset($_GET['flush']) || $requestURL == 'dev/build' || $requestURL == BASE_URL . '/dev/build');
+$flush = (isset($_GET['flush']) || $requestURL === trim(BASE_URL . '/dev/build', '/'));
 
 global $manifest;
 $manifest = new SS_ClassManifest(BASE_PATH, false, $flush);


### PR DESCRIPTION
For example: http://localhost/silverstripe/dev/build would result in `$requestURL` being `silverstripe/dev/build`, but `BASE_URL . '/dev/build'` would be `/silverstripe/dev/build` (note leading slash).