### PR TITLE
Add hook to updatetreenodes for customisation of tree

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -977,6 +977,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 				'PrevID' => $prev ? $prev->ID : null
 			);
 		}
+		$this->extend('updateUpdatedTreeNodes', $data, $request);
 		$this->response->addHeader('Content-Type', 'text/json');
 		return Convert::raw2json($data);
 	}


### PR DESCRIPTION
Somewhat related to #3835

This adds a hook to updatetreenodes to allow plugs like https://github.com/micmania1/silverstripe-lumberjack and https://github.com/micschk/silverstripe-excludechildren to enforce hidden children from the tree even through AJAX requests.

Currently, a page being edited will appear in the sitetree as the response to the ajax request can't be customised to stop pages being shown.