### PR TITLE
Corrected example to work when copied and pasted.

### DIFF
--- a/docs/en/02_Developer_Guides/05_Extending/04_Shortcodes.md
+++ b/docs/en/02_Developer_Guides/05_Extending/04_Shortcodes.md
@@ -57,7 +57,7 @@ First we need to define a callback for the shortcode.
 		);
 
 		public function MyShortCodeMethod($arguments, $content = null, $parser = null, $tagName) {
-			return str_replace($content, "<em>$content</em>", $this->Content);
+			return "<em>" . $tagName . "</em> " . $content . "; " . count($arguments) . " arguments.";
 		}
 	}
 


### PR DESCRIPTION
Original example gives: Fatal error: Using $this when not in object context in E:\localhost\abscreensavers.com\mysite\code\Page.php on line 19