### PR TITLE
Proving bug with Deep nested many_many relations

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -673,7 +673,7 @@ class DataQuery {
 					);
 					$this->lastAlias = $alias;
 				}
-				if(ClassInfo::hasTable($componentClass)) {
+				if(ClassInfo::hasTable($componentClass)	&& !$this->query->isJoinedTo($componentClass)) {
 					$this->query->addLeftJoin($componentClass,
 						"\"$relationTable\".\"$componentField\" = \"$componentClass\".\"ID\"");
 				}

--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -13,6 +13,8 @@
  */
 class DataQuery {
 
+	public $lastAlias;
+
 	/**
 	 * @var string
 	 */
@@ -597,6 +599,7 @@ class DataQuery {
 	 * @return The model class of the related item
 	 */
 	public function applyRelation($relation) {
+		$this->lastAlias = '';
 		// NO-OP
 		if(!$relation) return $this->dataClass;
 
@@ -660,6 +663,15 @@ class DataQuery {
 				if (!$this->query->isJoinedTo($componentBaseClass)) {
 					$this->query->addLeftJoin($componentBaseClass,
 						"\"$relationTable\".\"$componentField\" = \"$componentBaseClass\".\"ID\"");
+				}
+				else {
+					$alias = uniqid($componentBaseClass);
+					$this->query->addLeftJoin(
+						$componentBaseClass,
+						"\"$relationTable\".\"$componentField\" = \"$alias\".\"ID\"",
+						$alias
+					);
+					$this->lastAlias = $alias;
 				}
 				if(ClassInfo::hasTable($componentClass)) {
 					$this->query->addLeftJoin($componentClass,

--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -657,8 +657,10 @@ class DataQuery {
 				$componentBaseClass = ClassInfo::baseDataClass($componentClass);
 				$this->query->addInnerJoin($relationTable,
 					"\"$relationTable\".\"$parentField\" = \"$parentBaseClass\".\"ID\"");
-				$this->query->addLeftJoin($componentBaseClass,
-					"\"$relationTable\".\"$componentField\" = \"$componentBaseClass\".\"ID\"");
+				if (!$this->query->isJoinedTo($componentBaseClass)) {
+					$this->query->addLeftJoin($componentBaseClass,
+						"\"$relationTable\".\"$componentField\" = \"$componentBaseClass\".\"ID\"");
+				}
 				if(ClassInfo::hasTable($componentClass)) {
 					$this->query->addLeftJoin($componentClass,
 						"\"$relationTable\".\"$componentField\" = \"$componentClass\".\"ID\"");

--- a/search/filters/ExactMatchFilter.php
+++ b/search/filters/ExactMatchFilter.php
@@ -50,6 +50,7 @@ class ExactMatchFilter extends SearchFilter {
 	 */
 	protected function applyMany(DataQuery $query) {
 		$this->model = $query->applyRelation($this->relation);
+		$column = $query->lastAlias ? sprintf('"%s"."%s"', $query->lastAlias, $this->name) : $this->getDbName();
 		$modifiers = $this->getModifiers();
 		$values = array();
 		foreach($this->getValue() as $value) {
@@ -59,13 +60,13 @@ class ExactMatchFilter extends SearchFilter {
 			$valueStr = "'" . implode("', '", $values) . "'";
 			return $query->where(sprintf(
 				'%s IN (%s)',
-				$this->getDbName(),
+				$column,
 				$valueStr
 			));
 		} else {
 			foreach($values as &$v) {
 				$v = DB::getConn()->comparisonClause(
-					$this->getDbName(),
+					$column,
 					$v,
 					true, // exact?
 					false, // negate?

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -20,6 +20,9 @@ class DataListTest extends SapphireTest {
 		'DataObjectTest_Player',
 		'DataObjectTest_TeamComment',
 		'DataObjectTest\NamespacedClass',
+		'DataObjectTest_A',
+		'DataObjectTest_B',
+		'DataObjectTest_C',
 	);
 
 	public function testFilterDataObjectByCreatedDate() {
@@ -709,6 +712,19 @@ class DataListTest extends SapphireTest {
 
 		$this->assertEquals(1, $list->count());
 		$this->assertEquals('007', $list->first()->ShirtNumber);
+	}
+
+	public function testFilterOnImplicitJoinWithSharedInheritance() {
+		$list = DataObjectTest_B::get()->filter(array(
+			'ManyCs.ID' => array(
+				$this->idFromFixture('DataObjectTest_C', 'test1'),
+				$this->idFromFixture('DataObjectTest_C', 'test2'),
+			),
+		));
+		$this->assertEquals(2, $list->count());
+		$ids = $list->column('ID');
+		$this->assertContains($this->idFromFixture('DataObjectTest_B', 'test1'), $ids);
+		$this->assertContains($this->idFromFixture('DataObjectTest_B', 'test2'), $ids);
 	}
 
 	public function testFilterAndExcludeById() {

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -17,7 +17,12 @@ class DataObjectTest extends SapphireTest {
 		'DataObjectTest_ValidatedObject',
 		'DataObjectTest_Player',
 		'DataObjectTest_TeamComment',
-		'DataObjectTest_ExtendedTeamComment'
+		'DataObjectTest_ExtendedTeamComment',
+		'DataObjectTest_Company',
+		'DataObjectTest_Staff',
+		'DataObjectTest_A',
+		'DataObjectTest_B',
+		'DataObjectTest_C',
 	);
 
 	public function testDb() {
@@ -1375,6 +1380,10 @@ class DataObjectTest_Team extends DataObject implements TestOnly {
 		'Captain.FavouriteTeam.Title' => 'Captain\'s favourite team'
 	);
 
+	private static $extensions = array(
+		'DataObjectTest_Team_Extension',
+	);
+
 	private static $default_sort = '"Title"';
 
 	public function MyTitle() {
@@ -1485,19 +1494,19 @@ class DataObjectTest_ValidatedObject extends DataObject implements TestOnly {
 	}
 }
 
-class DataObjectTest_Company extends DataObject {
+class DataObjectTest_Company extends DataObject implements TestOnly {
 	private static $has_one = array (
 		'CEO'         => 'DataObjectTest_CEO',
 		'PreviousCEO' => 'DataObjectTest_CEO'
 	);
-	
+
 	private static $has_many = array (
 		'CurrentStaff'     => 'DataObjectTest_Staff.CurrentCompany',
 		'PreviousStaff'    => 'DataObjectTest_Staff.PreviousCompany'
 	);
 }
 
-class DataObjectTest_Staff extends DataObject {
+class DataObjectTest_Staff extends DataObject implements TestOnly {
 	private static $has_one = array (
 		'CurrentCompany'  => 'DataObjectTest_Company',
 		'PreviousCompany' => 'DataObjectTest_Company'
@@ -1511,7 +1520,7 @@ class DataObjectTest_CEO extends DataObjectTest_Staff {
 	);
 }
 
-class DataObjectTest_TeamComment extends DataObject {
+class DataObjectTest_TeamComment extends DataObject implements TestOnly {
 	private static $db = array(
 		'Name' => 'Varchar',
 		'Comment' => 'Text'
@@ -1530,5 +1539,23 @@ class DataObjectTest_ExtendedTeamComment extends DataObjectTest_TeamComment {
 	);
 }
 
-DataObjectTest_Team::add_extension('DataObjectTest_Team_Extension');
+class DataObjectTest_A extends DataObject implements TestOnly {
+
+	private static $db = array(
+		'Title' => 'Varchar(255)',
+	);
+
+}
+
+class DataObjectTest_B extends DataObjectTest_A {
+	private static $many_many = array(
+		'ManyCs' => 'DataObjectTest_C',
+	);
+}
+
+class DataObjectTest_C extends DataObjectTest_A {
+	private static $belongs_many_many = array(
+		'ManyBs' => 'DataObjectTest_C',
+	);
+}
 

--- a/tests/model/DataObjectTest.yml
+++ b/tests/model/DataObjectTest.yml
@@ -1,47 +1,61 @@
 DataObjectTest_Team:
-	team1:
-		Title: Team 1
-	team2:
-		Title: Team 2
-	team3:
-		Title: Team 3
+  team1:
+    Title: Team 1
+  team2:
+    Title: Team 2
+  team3:
+    Title: Team 3
 DataObjectTest_Player:
-	captain1:
-		FirstName: Captain
-		ShirtNumber: 007
-		FavouriteTeam: =>DataObjectTest_Team.team1
-		Teams: =>DataObjectTest_Team.team1
-		IsRetired: 1
-	captain2:
-		FirstName: Captain 2
-		Teams: =>DataObjectTest_Team.team2
-	player1:
-		FirstName: Player 1
-	player2:
-		FirstName: Player 2
-		Teams: =>DataObjectTest_Team.team1,=>DataObjectTest_Team.team2
+  captain1:
+    FirstName: Captain
+    ShirtNumber: 007
+    FavouriteTeam: =>DataObjectTest_Team.team1
+    Teams: =>DataObjectTest_Team.team1
+    IsRetired: 1
+  captain2:
+    FirstName: Captain 2
+    Teams: =>DataObjectTest_Team.team2
+  player1:
+    FirstName: Player 1
+  player2:
+    FirstName: Player 2
+    Teams: =>DataObjectTest_Team.team1,=>DataObjectTest_Team.team2
 DataObjectTest_SubTeam:
-	subteam1:
-		Title: Subteam 1
-		SubclassDatabaseField: Subclassed 1
-		ExtendedDatabaseField: Extended 1
-		ParentTeam: =>DataObjectTest_Team.team1
-	subteam2_with_player_relation:
-		Title: Subteam 2
-		SubclassDatabaseField: Subclassed 2
-		ExtendedHasOneRelationship: =>DataObjectTest_Player.player1
-	subteam3_with_empty_fields:
-		Title: Subteam 3
+  subteam1:
+    Title: Subteam 1
+    SubclassDatabaseField: Subclassed 1
+    ExtendedDatabaseField: Extended 1
+    ParentTeam: =>DataObjectTest_Team.team1
+  subteam2_with_player_relation:
+    Title: Subteam 2
+    SubclassDatabaseField: Subclassed 2
+    ExtendedHasOneRelationship: =>DataObjectTest_Player.player1
+  subteam3_with_empty_fields:
+    Title: Subteam 3
 DataObjectTest_TeamComment:
-	comment1:
-		Name: Joe
-		Comment: This is a team comment by Joe
-		Team: =>DataObjectTest_Team.team1
-	comment2:
-		Name: Bob
-		Comment: This is a team comment by Bob
-		Team: =>DataObjectTest_Team.team1
-	comment3:
-		Name: Phil
-		Comment: Phil is a unique guy, and comments on team2
-		Team: =>DataObjectTest_Team.team2
+  comment1:
+    Name: Joe
+    Comment: This is a team comment by Joe
+    Team: =>DataObjectTest_Team.team1
+  comment2:
+    Name: Bob
+    Comment: This is a team comment by Bob
+    Team: =>DataObjectTest_Team.team1
+  comment3:
+    Name: Phil
+    Comment: Phil is a unique guy, and comments on team2
+    Team: =>DataObjectTest_Team.team2
+DataObjectTest_C:
+  test1:
+    Title: 'Test 1'
+  test2:
+    Title: 'Test 2'
+  test3:
+    Title: 'Test 3'
+DataObjectTest_B:
+  test1:
+    Title: 'Test1'
+    ManyCs: =>DataObjectTest_C.test1,=>DataObjectTest_C.test2
+  test2:
+    Title: 'Test2'
+    ManyCs: =>DataObjectTest_C.test1,=>DataObjectTest_C.test3

--- a/tests/model/DataObjectTest.yml
+++ b/tests/model/DataObjectTest.yml
@@ -59,3 +59,13 @@ DataObjectTest_B:
   test2:
     Title: 'Test2'
     ManyCs: =>DataObjectTest_C.test1,=>DataObjectTest_C.test3
+ManyManyListTest_Product:
+  producta:
+    Title: 'Product A'
+  productb:
+    Title: 'Product B'
+    RelatedProducts: =>ManyManyListTest_Product.producta
+ManyManyListTest_Category:
+  categorya:
+    Title: 'Category A'
+    Products: =>ManyManyListTest_Product.producta,=>ManyManyListTest_Product.productb

--- a/tests/model/DataQueryTest.php
+++ b/tests/model/DataQueryTest.php
@@ -11,6 +11,7 @@ class DataQueryTest extends SapphireTest {
 		'DataQueryTest_D',
 		'DataQueryTest_E',
 		'DataQueryTest_F',
+		'DataQueryTest_G',
 	);
 
 
@@ -63,11 +64,39 @@ class DataQueryTest extends SapphireTest {
 	}
 
 	public function testApplyReplationDeepInheretence() {
+		//test has_one relation
 		$newDQ = new DataQuery('DataQueryTest_E');
 		//apply a relation to a relation from an ancestor class
 		$newDQ->applyRelation('TestA');
 		$this->assertTrue($newDQ->query()->isJoinedTo('DataQueryTest_C'));
 		$this->assertContains('"DataQueryTest_A"."ID" = "DataQueryTest_C"."TestAID"', $newDQ->sql());
+
+		//test many_many relation
+
+		//test many_many with separate inheritance
+		$newDQ = new DataQuery('DataQueryTest_C');
+		$baseDBTable = ClassInfo::baseDataClass('DataQueryTest_C');
+		$newDQ->applyRelation('ManyTestAs');
+		//check we are "joined" to the DataObject's table (there is no distinction between FROM or JOIN clauses)
+		$this->assertTrue($newDQ->query()->isJoinedTo($baseDBTable));
+		//check we are explicitly selecting "FROM" the DO's table
+		$this->assertContains("FROM \"$baseDBTable\"", $newDQ->sql());
+
+		//test many_many with shared inheritance
+		$newDQ = new DataQuery('DataQueryTest_E');
+		$baseDBTable = ClassInfo::baseDataClass('DataQueryTest_E');
+		//check we are "joined" to the DataObject's table (there is no distinction between FROM or JOIN clauses)
+		$this->assertTrue($newDQ->query()->isJoinedTo($baseDBTable));
+		//check we are explicitly selecting "FROM" the DO's table
+		$this->assertContains("FROM \"$baseDBTable\"", $newDQ->sql(), 'The FROM clause is missing from the query');
+		$newDQ->applyRelation('ManyTestGs');
+		//confirm we are still joined to the base table
+		$this->assertTrue($newDQ->query()->isJoinedTo($baseDBTable));
+		//double check it is the "FROM" clause
+		$this->assertContains("FROM \"$baseDBTable\"", $newDQ->sql(), 'The FROM clause has been removed from the query');
+		//another (potentially less crude check) for checking "FROM" clause
+		$fromTables = $newDQ->query()->getFrom();
+		$this->assertEquals($baseDBTable, $fromTables[$baseDBTable]);
 	}
 
 	public function testRelationReturn() {
@@ -305,7 +334,11 @@ class DataQueryTest_E extends DataQueryTest_C implements TestOnly {
 	private static $db = array(
 		'SortOrder' => 'Int'
 	);
-	
+
+	private static $many_many = array(
+		'ManyTestGs' => 'DataQueryTest_G',
+	);
+
 	private static $default_sort = '"DataQueryTest_E"."SortOrder" ASC';
 }
 
@@ -316,4 +349,12 @@ class DataQueryTest_F extends DataObject implements TestOnly {
 		'MyDate' => 'SS_Datetime',
 		'MyString' => 'Text'
 	);
+}
+
+class DataQueryTest_G extends DataQueryTest_C implements TestOnly {
+
+	private static $belongs_many_many = array(
+		'ManyTestEs' => 'DataQueryTest_E',
+	);
+
 }

--- a/tests/model/DataQueryTest.php
+++ b/tests/model/DataQueryTest.php
@@ -96,7 +96,7 @@ class DataQueryTest extends SapphireTest {
 		$this->assertContains("FROM \"$baseDBTable\"", $newDQ->sql(), 'The FROM clause has been removed from the query');
 		//another (potentially less crude check) for checking "FROM" clause
 		$fromTables = $newDQ->query()->getFrom();
-		$this->assertEquals($baseDBTable, $fromTables[$baseDBTable]);
+		$this->assertEquals('"' . $baseDBTable . '"', $fromTables[$baseDBTable]);
 	}
 
 	public function testRelationReturn() {

--- a/tests/model/ManyManyListTest.php
+++ b/tests/model/ManyManyListTest.php
@@ -18,6 +18,8 @@ class ManyManyListTest extends SapphireTest {
 		'DataObjectTest_B',
 		'DataObjectTest_C',
 		'ManyManyListTest_ExtraFields',
+		'ManyManyListTest_Product',
+		'ManyManyListTest_Category',
 	);
 
 
@@ -270,6 +272,17 @@ class ManyManyListTest extends SapphireTest {
 		$this->assertEquals($expected, $list->sql());
 	}
 
+	public function testFilteringOnPreviouslyJoinedTable() {
+
+		/** @var ManyManyListTest_Category $category */
+		$category = $this->objFromFixture('ManyManyListTest_Category', 'categorya');
+
+		/** @var ManyManyList $productsRelatedToProductB */
+		$productsRelatedToProductB = $category->Products()->filter('RelatedProducts.Title', 'Product B');
+
+		$this->assertEquals(1, $productsRelatedToProductB->count());
+	}
+
 
 }
 
@@ -294,3 +307,33 @@ class ManyManyListTest_ExtraFields extends DataObject implements TestOnly {
 		)
 	);
 }
+
+class ManyManyListTest_Product extends DataObject implements TestOnly {
+
+	private static $db = array(
+		'Title' => 'Varchar'
+	);
+
+	private static $many_many = array(
+		'RelatedProducts' => 'ManyManyListTest_Product'
+	);
+
+	private static $belongs_many_many = array(
+		'RelatedTo' => 'ManyManyListTest_Product',
+		'Categories' => 'ManyManyListTest_Category'
+	);
+
+}
+
+class ManyManyListTest_Category extends DataObject implements TestOnly {
+
+	private static $db = array(
+		'Title' => 'Varchar'
+	);
+
+	private static $many_many = array(
+		'Products' => 'ManyManyListTest_Product'
+	);
+
+}
+

--- a/tests/model/ManyManyListTest.php
+++ b/tests/model/ManyManyListTest.php
@@ -14,6 +14,9 @@ class ManyManyListTest extends SapphireTest {
 		'DataObjectTest_Player',
 		'DataObjectTest_Company',
 		'DataObjectTest_TeamComment',
+		'DataObjectTest_A',
+		'DataObjectTest_B',
+		'DataObjectTest_C',
 		'ManyManyListTest_ExtraFields',
 	);
 


### PR DESCRIPTION
When adding a filter to a many_many with a shared inheritance, the FROM table is removed and added as a LEFT JOIN which causes a syntax error.

This means `$dataList->filter('ManyManyRel.ID', array(1,2))` doesn't work.