### PR TITLE
Fix large foreign key dropdowns being changed to text fields

### DIFF
--- a/model/fieldtypes/ForeignKey.php
+++ b/model/fieldtypes/ForeignKey.php
@@ -41,11 +41,14 @@ class ForeignKey extends Int {
 			// Don't scaffold a dropdown for large tables, as making the list concrete
 			// might exceed the available PHP memory in creating too many DataObject instances
 			if($list->count() < 100) {
-				$field = new DropdownField($this->name, $title, $list->map('ID', $titleField));
-				$field->setEmptyString(' ');
+				$dropdownList = $list->map('ID', $titleField);
 			} else {
-				$field = new NumericField($this->name, $title);
+				// convert the datalist from a large memory hogging dataobject into
+				// a speedy and nimble hash
+				$dropdownList = $list->map('ID', $titleField)->toArray();
 			}
+			$field = new DropdownField($this->name, $title, $dropdownList);
+			$field->setEmptyString(' ');
 
 		}
 


### PR DESCRIPTION
The following commit disabled using datalists with over a 100 records due to php memory limits.
Would like to consider a different approach by using a hash instead of a object list.

4b8895c8
BUGFIX Don't scaffold has_one relations into a DropdownField in ForeignKey->scaffoldFormField() if more than 100 records would be created, to avoid exceeding PHP memory (fixes #6776)