### PR TITLE
DOCS Permanent link to speakup.io added in Code of Conduct

### DIFF
--- a/docs/en/05_Contributing/07_Code_of_conduct.md
+++ b/docs/en/05_Contributing/07_Code_of_conduct.md
@@ -56,6 +56,6 @@ http://www.apache.org/foundation/policies/conduct.html
 
 https://www.djangoproject.com/conduct/
 
-http://speakup.io/coc.html
+http://web.archive.org/web/20141109123859/http://speakup.io/coc.html
 
 http://www.crnhq.org/pages.php?pID=10


### PR DESCRIPTION
As this is hosted on github pages and the custom domain setup was depricated (We may reinstate the original link later).