### PR TITLE
Fix broken localised NumericField

### DIFF
--- a/forms/NumericField.php
+++ b/forms/NumericField.php
@@ -18,14 +18,7 @@ class NumericField extends TextField {
 			return true;
 		}
 		
-		require_once THIRDPARTY_PATH."/Zend/Locale/Format.php";
-
-		$valid = Zend_Locale_Format::isNumber(
-			trim($this->value), 
-			array('locale' => i18n::get_locale())
-		);
-
-		if(!$valid) {
+		if(!is_numeric($this->value)) {
 			$validator->validationError(
 				$this->name,
 				_t(
@@ -40,11 +33,67 @@ class NumericField extends TextField {
 		
 		return true;
 	}
-	
-	public function dataValue() {
-		return (is_numeric($this->value)) ? $this->value : 0;
+
+    
+	public function setValue($value, $context = null) {
+        // select the appropriate setter
+        // @todo: deprecate ignorant getters and setters and remove this terrible hack
+        if ($context instanceof DataObject) {
+            return $this->setDataValue($value);
+        } else {
+            $this->setViewValue($value);
+            return $this;
+        }
+    }
+
+	public function Value() {
+        // use the appropriate getter
+        return $this->getViewValue();
 	}
-	
+
+	public function dataValue() {
+        // use the appropriate getter
+        return $this->getDataValue();
+	}
+
+    /**
+     * @param $value (mixed) data representation of the value, e.g. (float)1.23
+    **/
+    public function setDataValue($value)
+    {
+        return parent::setValue($value);
+    }
+
+    /**
+     * @param $value (mixed) view representation of the value, e.g. (string)"1.200,00"
+    **/
+    public function setViewValue($value)
+    {
+        $this->value = $value || $value === 0 ? Zend_Locale_Format::getNumber(
+            trim($value),
+            array('locale' => i18n::get_locale())
+        ) : '';
+    }
+
+    /**
+     * @return (mixed) numeric data representation of the value, e.g. (float)1.23
+    **/
+    public function getDataValue()
+    {
+		return (is_numeric($this->value)) ? $this->value : 0;
+    }
+
+    /**
+     * @return (string) view representation of the value, e.g. "1.200,00"
+    **/
+    public function getViewValue()
+    {
+		return Zend_Locale_Format::toNumber(
+			trim($this->value), 
+			array('locale' => i18n::get_locale())
+		);
+    }
+
 	/**
 	 * Returns a readonly version of this field
 	 */
@@ -53,7 +102,6 @@ class NumericField extends TextField {
 		$field->setForm($this->form);
 		return $field;
 	}
-
 }
 
 class NumericField_Readonly extends ReadonlyField {


### PR DESCRIPTION
- Values stored in FormFields must not be localised but raw.
- A dedicated setter for localised values must be added to the FormField API and this setter has to be used throughout the framework when setting values on FormFields to user supplied input
- See #2161, #3354