### PR TITLE
Allow the paddedresize to take another hex value to specify a transparency on the padded color

### DIFF
--- a/docs/en/02_Developer_Guides/14_Files/01_Image.md
+++ b/docs/en/02_Developer_Guides/14_Files/01_Image.md
@@ -109,8 +109,15 @@ For output of an image tag with the image automatically resized to 80px width, y
 The paddedResize (PHP) and PaddedImage (template) methods allow you to resize an image with existing ratio and will
 pad any surplus space. You can specify the color of the padding using a hex code such as FFFFFF or 000000.
 
-You can also specify another hex value on the end to adjust the transparency. If you want the padding to be fully
-transparent then use E7 on the end (eg FFFFFFE7), if you want it 50% transparent then use 3C. Only works with png files.
+You can also specify a level of transparency to apply to the padding color in a fourth param. This will only effect
+png images.
+
+	:::php
+	$Image.PaddedImage(80, 80, FFFFFF, 50) // white padding with 50% transparency
+	$Image.PaddedImage(80, 80, FFFFFF, 100) // white padding with 100% transparency
+	$Image.PaddedImage(80, 80, FFFFFF, true) // white padding with 100% transparency
+	$Image.PaddedImage(80, 80, FFFFFF) // white padding with no transparency
+
 
 ### Form Upload
 

--- a/docs/en/02_Developer_Guides/14_Files/01_Image.md
+++ b/docs/en/02_Developer_Guides/14_Files/01_Image.md
@@ -115,7 +115,6 @@ png images.
 	:::php
 	$Image.PaddedImage(80, 80, FFFFFF, 50) // white padding with 50% transparency
 	$Image.PaddedImage(80, 80, FFFFFF, 100) // white padding with 100% transparency
-	$Image.PaddedImage(80, 80, FFFFFF, true) // white padding with 100% transparency
 	$Image.PaddedImage(80, 80, FFFFFF) // white padding with no transparency
 
 

--- a/docs/en/02_Developer_Guides/14_Files/01_Image.md
+++ b/docs/en/02_Developer_Guides/14_Files/01_Image.md
@@ -65,7 +65,7 @@ You can also create your own functions by extending the image class, for example
 			return $this->getWidth() < $this->getHeight();
 		}
 		
-		public function generatePaddedImageByWidth(GD $gd,$width=600,$color="fff"){
+		public function generatePaddedImageByWidth(GD $gd,$width=600,$color="ffffff"){
 			return $gd->paddedResize($width, round($gd->getHeight()/($gd->getWidth()/$width),0),$color);
 		}
 		
@@ -104,6 +104,13 @@ For output of an image tag with the image automatically resized to 80px width, y
 	$Image.Filename // returns filename
 	$Image.URL // returns filename
 
+### Padded Image Resize
+
+The paddedResize (PHP) and PaddedImage (template) methods allow you to resize an image with existing ratio and will
+pad any surplus space. You can specify the color of the padding using a hex code such as FFFFFF or 000000.
+
+You can also specify another hex value on the end to adjust the transparency. If you want the padding to be fully
+transparent then use E7 on the end (eg FFFFFFE7), if you want it 50% transparent then use 3C. Only works with png files.
 
 ### Form Upload
 

--- a/filesystem/GD.php
+++ b/filesystem/GD.php
@@ -347,9 +347,11 @@ class GDBackend extends Object implements Image_Backend {
 		$r = hexdec(substr($webColor,0,2));
 		$g = hexdec(substr($webColor,2,2));
 		$b = hexdec(substr($webColor,4,2));
-		
+		if(strlen($webColor) == 8) {
+			$a = hexdec(substr($webColor,6,2));
+			return imagecolorallocatealpha($image, $r, $g, $b, $a);
+		}
 		return imagecolorallocate($image, $r, $g, $b);
-		
 	}
 
 	/**

--- a/filesystem/GD.php
+++ b/filesystem/GD.php
@@ -342,13 +342,17 @@ class GDBackend extends Object implements Image_Backend {
 			return $useAsMinimum ? $this->resizeByWidth( $maxWidth ) : $this->resizeByHeight( $maxHeight );
 	}
 	
-	public static function color_web2gd($image, $webColor) {
+	public static function color_web2gd($image, $webColor, $transparencyPercent=0) {
 		if(substr($webColor,0,1) == "#") $webColor = substr($webColor,1);
 		$r = hexdec(substr($webColor,0,2));
 		$g = hexdec(substr($webColor,2,2));
 		$b = hexdec(substr($webColor,4,2));
-		if(strlen($webColor) == 8) {
-			$a = hexdec(substr($webColor,6,2));
+
+		if($transparencyPercent) {
+			if($transparencyPercent > 100 || $transparencyPercent === 'true') {
+				$transparencyPercent = 100;
+			}
+			$a = 127 * bcdiv($transparencyPercent, 100, 2);
 			return imagecolorallocatealpha($image, $r, $g, $b, $a);
 		}
 		return imagecolorallocate($image, $r, $g, $b);
@@ -360,8 +364,9 @@ class GDBackend extends Object implements Image_Backend {
 	 * @param width
 	 * @param height
 	 * @param backgroundColour
+	 * @param transparencyPercent
 	 */
-	public function paddedResize($width, $height, $backgroundColor = "FFFFFF") {
+	public function paddedResize($width, $height, $backgroundColor = "FFFFFF", $transparencyPercent=0) {
 		if(!$this->gd) return;
 		$width = round($width);
 		$height = round($height);
@@ -377,7 +382,7 @@ class GDBackend extends Object implements Image_Backend {
 		imagealphablending($newGD, false);
 		imagesavealpha($newGD, true);
 		
-		$bg = GD::color_web2gd($newGD, $backgroundColor);
+		$bg = GD::color_web2gd($newGD, $backgroundColor, $transparencyPercent);
 		imagefilledrectangle($newGD, 0, 0, $width, $height, $bg);
 		
 		$destAR = $width / $height;

--- a/filesystem/GD.php
+++ b/filesystem/GD.php
@@ -342,14 +342,14 @@ class GDBackend extends Object implements Image_Backend {
 			return $useAsMinimum ? $this->resizeByWidth( $maxWidth ) : $this->resizeByHeight( $maxHeight );
 	}
 	
-	public static function color_web2gd($image, $webColor, $transparencyPercent=0) {
+	public static function color_web2gd($image, $webColor, $transparencyPercent = 0) {
 		if(substr($webColor,0,1) == "#") $webColor = substr($webColor,1);
 		$r = hexdec(substr($webColor,0,2));
 		$g = hexdec(substr($webColor,2,2));
 		$b = hexdec(substr($webColor,4,2));
 
 		if($transparencyPercent) {
-			if($transparencyPercent > 100 || $transparencyPercent === 'true') {
+			if($transparencyPercent > 100) {
 				$transparencyPercent = 100;
 			}
 			$a = 127 * bcdiv($transparencyPercent, 100, 2);
@@ -366,7 +366,7 @@ class GDBackend extends Object implements Image_Backend {
 	 * @param backgroundColour
 	 * @param transparencyPercent
 	 */
-	public function paddedResize($width, $height, $backgroundColor = "FFFFFF", $transparencyPercent=0) {
+	public function paddedResize($width, $height, $backgroundColor = "FFFFFF", $transparencyPercent = 0) {
 		if(!$this->gd) return;
 		$width = round($width);
 		$height = round($height);

--- a/filesystem/ImagickBackend.php
+++ b/filesystem/ImagickBackend.php
@@ -183,17 +183,42 @@ class ImagickBackend extends Imagick implements Image_Backend {
 	 *
 	 * @param int $width
 	 * @param int $height
+	 * @param int $transparencyPercent
 	 * @return Image_Backend
 	 */
-	public function paddedResize($width, $height, $backgroundColor = "FFFFFF") {
+	public function paddedResize($width, $height, $backgroundColor = "FFFFFF", $transparencyPercent=0) {
 		$new = $this->resizeRatio($width, $height);
-		$new->setImageBackgroundColor("#".$backgroundColor);
+		if($transparencyPercent) {
+			$alphaHex = $this->calculateAlphaHex($transparencyPercent);
+			$new->setImageBackgroundColor("#{$backgroundColor}{$alphaHex}");
+		} else {
+			$new->setImageBackgroundColor("#{$backgroundColor}");
+		}
 		$w = $new->getImageWidth();
 		$h = $new->getImageHeight();
 		$new->extentImage($width,$height,($w-$width)/2,($h-$height)/2);
 		
 		return $new;
 	}
+
+	/**
+	 * Convert a percentage (or 'true') to a two char hex code to signifiy the level of an alpha channel
+	 *
+	 * @param $percent
+	 * @return string
+	 */
+	public function calculateAlphaHex($percent) {
+		if($percent > 100 || $percent == 'true') {
+			$percent = 100;
+		}
+		// unlike GD, this uses 255 instead of 127, and is reversed. Lower = more transparent
+		$alphaHex = dechex(255 - floor(255 * bcdiv($percent, 100, 2)));
+		if(strlen($alphaHex) == 1) {
+			$alphaHex =  '0' .$alphaHex;
+		}
+		return $alphaHex;
+	}
+
 	
 	/**
 	 * croppedResize

--- a/filesystem/ImagickBackend.php
+++ b/filesystem/ImagickBackend.php
@@ -186,7 +186,7 @@ class ImagickBackend extends Imagick implements Image_Backend {
 	 * @param int $transparencyPercent
 	 * @return Image_Backend
 	 */
-	public function paddedResize($width, $height, $backgroundColor = "FFFFFF", $transparencyPercent=0) {
+	public function paddedResize($width, $height, $backgroundColor = "FFFFFF", $transparencyPercent = 0) {
 		$new = $this->resizeRatio($width, $height);
 		if($transparencyPercent) {
 			$alphaHex = $this->calculateAlphaHex($transparencyPercent);
@@ -208,7 +208,7 @@ class ImagickBackend extends Imagick implements Image_Backend {
 	 * @return string
 	 */
 	public function calculateAlphaHex($percent) {
-		if($percent > 100 || $percent == 'true') {
+		if($percent > 100) {
 			$percent = 100;
 		}
 		// unlike GD, this uses 255 instead of 127, and is reversed. Lower = more transparent

--- a/model/Image.php
+++ b/model/Image.php
@@ -373,7 +373,7 @@ class Image extends File implements Flushable {
 	 * @param integer $transparencyPercent Level of transparency
 	 * @return Image
 	 */
-	public function PaddedImage($width, $height, $backgroundColor='FFFFFF', $transparencyPercent=0) {
+	public function PaddedImage($width, $height, $backgroundColor = 'FFFFFF', $transparencyPercent = 0) {
 		return $this->isSize($width, $height) && !Config::inst()->get('Image', 'force_resample')
 			? $this 
 			: $this->getFormattedImage('PaddedImage', $width, $height, $backgroundColor, $transparencyPercent);
@@ -388,7 +388,7 @@ class Image extends File implements Flushable {
 	 * @param integer $transparencyPercent Level of transparency
 	 * @return Image_Backend
 	 */
-	public function generatePaddedImage(Image_Backend $backend, $width, $height, $backgroundColor='FFFFFF', $transparencyPercent=0) {
+	public function generatePaddedImage(Image_Backend $backend, $width, $height, $backgroundColor = 'FFFFFF', $transparencyPercent = 0) {
 		return $backend->paddedResize($width, $height, $backgroundColor, $transparencyPercent);
 	}
 	

--- a/model/Image.php
+++ b/model/Image.php
@@ -370,12 +370,13 @@ class Image extends File implements Flushable {
 	 * 
 	 * @param integer $width The width to size to
 	 * @param integer $height The height to size to
+	 * @param integer $transparencyPercent Level of transparency
 	 * @return Image
 	 */
-	public function PaddedImage($width, $height, $backgroundColor='FFFFFF') {
+	public function PaddedImage($width, $height, $backgroundColor='FFFFFF', $transparencyPercent=0) {
 		return $this->isSize($width, $height) && !Config::inst()->get('Image', 'force_resample')
 			? $this 
-			: $this->getFormattedImage('PaddedImage', $width, $height, $backgroundColor);
+			: $this->getFormattedImage('PaddedImage', $width, $height, $backgroundColor, $transparencyPercent);
 	}
 	
 	/**
@@ -384,10 +385,11 @@ class Image extends File implements Flushable {
 	 * @param Image_Backend $backend
 	 * @param integer $width The width to size to
 	 * @param integer $height The height to size to
+	 * @param integer $transparencyPercent Level of transparency
 	 * @return Image_Backend
 	 */
-	public function generatePaddedImage(Image_Backend $backend, $width, $height, $backgroundColor='FFFFFF') {
-		return $backend->paddedResize($width, $height, $backgroundColor);
+	public function generatePaddedImage(Image_Backend $backend, $width, $height, $backgroundColor='FFFFFF', $transparencyPercent=0) {
+		return $backend->paddedResize($width, $height, $backgroundColor, $transparencyPercent);
 	}
 	
 	/**


### PR DESCRIPTION
When using the paddedresize sometimes it'd be useful to have the padding transparent as the color behind the image can change.

This pull allows you to add another hex value to the color. Using E7 on the end you can make it fully transparent, or use a hex value for an integer between 0 or 127 for a different level.

Also fixed the doc where it used a shortcode color which doesn't work.

Update the doc to explain about the padded image color a little.