### PR TITLE
 Fixed " search button for groups is meaningless... #3420 " 

### DIFF
--- a/admin/code/SecurityAdmin.php
+++ b/admin/code/SecurityAdmin.php
@@ -94,10 +94,10 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider {
 		);
 		$columns = $groupList->getConfig()->getComponentByType('GridFieldDataColumns');
 		$columns->setDisplayFields(array(
-			'Breadcrumbs' => singleton('Group')->fieldLabel('Title')
+			'Title' => singleton('Group')->fieldLabel('Title')
 		));
 		$columns->setFieldFormatting(array(
-			'Breadcrumbs' => function($val, $item) {
+			'Title' => function($val, $item) {
 				return Convert::raw2xml($item->getBreadcrumbs(' > '));
 			}
 		));

--- a/admin/javascript/lib.js
+++ b/admin/javascript/lib.js
@@ -244,7 +244,7 @@
 			//could be mailto, etc
 			isExternal: function( url ) {
 				var u = path.parseUrl( url );
-				return u.protocol && u.domain !== documentUrl.domain ? true : false;
+				return u.protocol && u.domain !== document.domain ? true : false;
 			},
 
 			hasProtocol: function( url ) {


### PR DESCRIPTION
Using the changes mentioned in the issue which results in the ability to search through groups by group name