### PR TITLE
Fixed "Image_Backend interface constructor needs updating (master) #3477"

### DIFF
--- a/filesystem/GD.php
+++ b/filesystem/GD.php
@@ -35,6 +35,13 @@ class GDBackend extends Object implements Image_Backend {
 		}
 	}
 
+	/**
+	 * __construct
+	 *
+	 * @param string $filename = null
+	 * @param array $args = array()
+	 * @return void
+	 */
 	public function __construct($filename = null, $args = array()) {
 		// If we're working with image resampling, things could take a while.  Bump up the time-limit
 		increase_time_limit_to(300);

--- a/filesystem/ImagickBackend.php
+++ b/filesystem/ImagickBackend.php
@@ -18,9 +18,10 @@ class ImagickBackend extends Imagick implements Image_Backend {
 	 * __construct
 	 *
 	 * @param string $filename = null
+	 * @param array $args = array()
 	 * @return void
 	 */
-	public function __construct($filename = null) {
+	public function __construct($filename = null, $args = array()) {
 		if(is_string($filename)) {
 			parent::__construct($filename);
 		}

--- a/model/Image_Backend.php
+++ b/model/Image_Backend.php
@@ -13,9 +13,10 @@ interface Image_Backend {
 	 * __construct
 	 *
 	 * @param string $filename = null
+	 * @param array $args = array()
 	 * @return void
 	 */
-	public function __construct($filename = null);
+	public function __construct($filename = null, $args = array());
 
 	/**
 	 * writeTo


### PR DESCRIPTION
For both the Image_Backend Model and Imagick_Backend filesystem class, as well as updated / added Docblocks for the aforementioned classes and also GDBackend.