### PR TITLE
Removed DataObject::$allowed_actions

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -3634,11 +3634,6 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	private static $summary_fields = null;
 	
 	/**
-	 * Provides a list of allowed methods that can be called via RESTful api.
-	 */
-	public static $allowed_actions = null;
-	
-	/**
 	 * Collect all static properties on the object
 	 * which contain natural language, and need to be translated.
 	 * The full entity name is composed from the class name and a custom identifier.


### PR DESCRIPTION
 As per "DataObject $allowed_actions property is public not private in version 3+ - Issue #3200"