### PR TITLE
Cleaning up Test DataObjects to ensure TestOnly is implemented

### DIFF
--- a/tests/core/ClassInfoTest.php
+++ b/tests/core/ClassInfoTest.php
@@ -6,6 +6,14 @@
  */
 class ClassInfoTest extends SapphireTest {
 
+	protected $extraDataObjects = array(
+		'ClassInfoTest_BaseClass',
+		'ClassInfoTest_ChildClass',
+		'ClassInfoTest_GrandChildClass',
+		'ClassInfoTest_BaseDataClass',
+		'ClassInfoTest_NoFields',
+	);
+
 	public function testExists() {
 		$this->assertTrue(ClassInfo::exists('Object'));
 		$this->assertTrue(ClassInfo::exists('ClassInfoTest'));
@@ -146,7 +154,7 @@ class ClassInfoTest extends SapphireTest {
  * @subpackage tests
  */
 
-class ClassInfoTest_BaseClass extends DataObject {
+class ClassInfoTest_BaseClass extends DataObject implements TestOnly {
 
 }
 
@@ -173,7 +181,7 @@ class ClassInfoTest_GrandChildClass extends ClassInfoTest_ChildClass {
  * @subpackage tests
  */
 
-class ClassInfoTest_BaseDataClass extends DataObject {
+class ClassInfoTest_BaseDataClass extends DataObject implements TestOnly {
 
 	private static $db = array(
 		'Title' => 'Varchar'

--- a/tests/model/CompositeDBFieldTest.php
+++ b/tests/model/CompositeDBFieldTest.php
@@ -37,7 +37,7 @@ class CompositeDBFieldTest extends SapphireTest {
 	}
 }
 
-class CompositeDBFieldTest_DataObject extends DataObject {
+class CompositeDBFieldTest_DataObject extends DataObject implements TestOnly {
 	private static $db = array(
 		'Title' => 'Text',
 		'MyMoney' => 'Money',

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -19,7 +19,10 @@ class DataListTest extends SapphireTest {
 		'DataObjectTest_ValidatedObject',
 		'DataObjectTest_Player',
 		'DataObjectTest_TeamComment',
+		'DataObjectTest_ExtendedTeamComment',
 		'DataObjectTest\NamespacedClass',
+		'DataObjectTest_Company',
+		'DataObjectTest_Fan',
 	);
 
 	public function testFilterDataObjectByCreatedDate() {

--- a/tests/model/DataObjectLazyLoadingTest.php
+++ b/tests/model/DataObjectLazyLoadingTest.php
@@ -21,9 +21,10 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 		'DataObjectTest_FieldlessSubTable',
 		'DataObjectTest_ValidatedObject',
 		'DataObjectTest_Player',
-		'DataObjectTest_TeamComment',
 		'VersionedTest_DataObject',
-		'VersionedTest_Subclass'
+		'VersionedTest_Subclass',
+		'VersionedLazy_DataObject',
+		'VersionedLazySub_DataObject',
 	);
 
 	public function testQueriedColumnsID() {
@@ -403,7 +404,7 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 
 
 /** Additional classes for versioned lazy loading testing */
-class VersionedLazy_DataObject extends DataObject {
+class VersionedLazy_DataObject extends DataObject implements TestOnly {
 	private static $db = array(
 		"PageName" => "Varchar"
 	);

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -19,7 +19,11 @@ class DataObjectTest extends SapphireTest {
 		'DataObjectTest_TeamComment',
 		'DataObjectTest\NamespacedClass',
 		'DataObjectTest\RelationClass',
-		'DataObjectTest_ExtendedTeamComment'
+		'DataObjectTest_ExtendedTeamComment',
+		'DataObjectTest_Company',
+		'DataObjectTest_Staff',
+		'DataObjectTest_CEO',
+		'DataObjectTest_Fan',
 	);
 
 	public function testDb() {
@@ -1642,7 +1646,7 @@ class DataObjectTest_ValidatedObject extends DataObject implements TestOnly {
 	}
 }
 
-class DataObjectTest_Company extends DataObject {
+class DataObjectTest_Company extends DataObject implements TestOnly {
 
 	private static $db = array(
 		'Name' => 'Varchar'
@@ -1660,7 +1664,7 @@ class DataObjectTest_Company extends DataObject {
 	);
 }
 
-class DataObjectTest_Staff extends DataObject {
+class DataObjectTest_Staff extends DataObject implements TestOnly {
 	private static $has_one = array (
 		'CurrentCompany'  => 'DataObjectTest_Company',
 		'PreviousCompany' => 'DataObjectTest_Company'
@@ -1675,7 +1679,7 @@ class DataObjectTest_CEO extends DataObjectTest_Staff {
 	);
 }
 
-class DataObjectTest_TeamComment extends DataObject {
+class DataObjectTest_TeamComment extends DataObject implements TestOnly {
 	private static $db = array(
 		'Name' => 'Varchar',
 		'Comment' => 'Text'
@@ -1687,7 +1691,7 @@ class DataObjectTest_TeamComment extends DataObject {
 
 }
 
-class DataObjectTest_Fan extends DataObject {
+class DataObjectTest_Fan extends DataObject implements TestOnly {
 
 	private static $db = array(
 		'Name' => 'Varchar(255)'

--- a/tests/model/HasManyListTest.php
+++ b/tests/model/HasManyListTest.php
@@ -9,6 +9,7 @@ class HasManyListTest extends SapphireTest {
 		'DataObjectTest_Team',
 		'DataObjectTest_SubTeam',
 		'DataObjectTest_Player',
+		'DataObjectTest_TeamComment',
 	);
 
 	public function testRelationshipEmptyOnNewRecords() {

--- a/tests/model/PolymorphicHasManyListTest.php
+++ b/tests/model/PolymorphicHasManyListTest.php
@@ -19,7 +19,7 @@ class PolymorphicHasManyListTest extends SapphireTest {
 		'DataObjectTest_Team',
 		'DataObjectTest_SubTeam',
 		'DataObjectTest_Player',
-		'DataObjectTest_Fan'
+		'DataObjectTest_Fan',
 	);
 
 	public function testRelationshipEmptyOnNewRecords() {

--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -1,6 +1,11 @@
 <?php
 
 class SSViewerTest extends SapphireTest {
+
+	protected $extraDataObjects = array(
+		'SSViewerTest_Object',
+	);
+
 	public function setUp() {
 		parent::setUp();
 		Config::inst()->update('SSViewer', 'source_file_comments', false);
@@ -1461,7 +1466,7 @@ class SSViewerTest_Controller extends Controller {
 
 }
 
-class SSViewerTest_Object extends DataObject {
+class SSViewerTest_Object extends DataObject implements TestOnly {
 
 	public $number = null;
 


### PR DESCRIPTION
Pretty self-explanatory.

Enforcing that the framework implements TestOnly on DataObjects defined for test purposes only and adds them to `$extraDataObjects` on tests that need them where they haven't been included.