### PR TITLE
FIX: Misleading error message in SSViewer

### DIFF
--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -778,12 +778,14 @@ class SSViewer implements Flushable {
 		if(!$this->chosenTemplates) {
 			$templateList = (is_array($templateList)) ? $templateList : array($templateList);
 
-			user_error(
-				"None of these templates can be found in theme '"
-				. Config::inst()->get('SSViewer', 'theme') . "': "
-				. implode(".ss, ", $templateList) . ".ss", 
-				E_USER_WARNING
-			);
+			$message = 'None of the following templates could be found';
+			if(!$theme) {
+				$message .= ' (no theme in use)';
+			} else {
+				$message .= ' in theme "' . $theme . '"';
+			}
+
+			user_error($message . ': ' . implode(".ss, ", $templateList) . ".ss", E_USER_WARNING);
 		}
 	}
 


### PR DESCRIPTION
If `SSViewer.theme` is set, this error message implies that it’s searching in the theme even when `SSViewer.theme_enabled` is set to false. I’ve also made it more clear in the error message that the theme is disabled.