### PR TITLE
FIX Imported namespaces now correctly used to determine class inheritance

### DIFF
--- a/tests/core/manifest/fixtures/namespaced_classmanifest/module/classes/ClassI.php
+++ b/tests/core/manifest/fixtures/namespaced_classmanifest/module/classes/ClassI.php
@@ -1,0 +1,12 @@
+<?php
+namespace SilverStripe\Framework\Tests;
+
+//whitespace here is important for tests, please don't change it
+use  ModelAdmin;
+use Controller  as  Cont ;
+use SS_HTTPRequest as Request,SS_HTTPResponse AS Response, PermissionProvider AS P;
+use silverstripe\test\ClassA;
+use \DataObject;
+
+class ClassI extends ModelAdmin implements P {
+}


### PR DESCRIPTION
Fixes #3707

This fix allows the manifest builder to recognise Classes and Interfaces that have been used within namespaced classes or where namespaced classes have been imported with a `use` keyword.

Previously a classname or interface in the global scope explicitly needed to have a `\` prepended to the name in the `extends` or `implements` declarations for the manifest builder to recognise it.

Some examples of previously failing declarations that now pass are correctly recognised

```php
<?php
namespace SilverStripe\Test\Space;

use ModelAdmin as Admin;
use PermissionProvider, TestOnly as Test,HiddenClass;
use OtherInterface;
use \InterfaceName;

class MyExample extends Admin implements PermissionProvider, Test, HiddenClass, OtherInterface, InterfaceName {

    ...

}
```

This class would now (correctly) be picked up as a `ModelAdmin` subclass and an implementor of `PermissionProvider`;

Other declarations that were correctly interpreted remain so:

```php
<?php
namespace SilverStripe\Test\Space;

class MyClass extends \ModelAdmin {
    ...
}
```