### PR TITLE
FIX make class loader classExists check interface_exists as per docs

### DIFF
--- a/core/manifest/ClassLoader.php
+++ b/core/manifest/ClassLoader.php
@@ -95,13 +95,13 @@ class SS_ClassLoader {
 	}
 
 	/**
-	 * Returns true if a class name exists in the manifest.
+	 * Returns true if a class or interface name exists in the manifest.
 	 *
 	 * @param  string $class
 	 * @return bool
 	 */
 	public function classExists($class) {
-		return class_exists($class, false) || $this->getItemPath($class);
+		return class_exists($class, false) || interface_exists($class, false) || $this->getItemPath($class);
 	}
 
 }


### PR DESCRIPTION
The PHP comment says that it checks for classes and interfaces.

If that's the case, we should use the built in `interface_exists` function with the `class_exists` one for speed.

Should this method be renamed?

Should this method even use the php functions at all? Currently it doesn't depend on the manifest being used - though removing those checks would miss PHP classes/interfaces. Though the PHPDoc says "... in the manifest"

Should we have functions to check existence of classes/interfaces separately?