### PR TITLE
Correct return statements in SS_HTTPResponse

### DIFF
--- a/control/HTTPResponse.php
+++ b/control/HTTPResponse.php
@@ -161,6 +161,7 @@ class SS_HTTPResponse {
 	 */
 	public function setBody($body) {
 		$this->body = $body ? (string)$body : $body; // Don't type-cast false-ish values, eg null is null not ''
+		return $this;
 	}
 	
 	/**
@@ -191,7 +192,6 @@ class SS_HTTPResponse {
 	public function getHeader($header) {
 		if(isset($this->headers[$header]))
 			return $this->headers[$header];			
-			return null;
 		}
 	
 	/**


### PR DESCRIPTION
- setBody failed to return a value; it now returns $this as related methods do
- getHeader had an extra, unreachable return statement; removed