### PR TITLE
Fix localStorage for Windows 8.1 IE11 desktop mode

### DIFF
--- a/admin/javascript/LeftAndMain.Preview.js
+++ b/admin/javascript/LeftAndMain.Preview.js
@@ -179,18 +179,22 @@
 			 * Store the preview options for this page.
 			 */
 			saveState : function(name, value) {
-				if(!window.localStorage) return;
-				
-				window.localStorage.setItem('cms-preview-state-' + name, value);
+				try {
+					window.localStorage.setItem('cms-preview-state-' + name, value);
+				} catch (exception) {
+					return false;
+				}
 			},
 
 			/**
 			 * Load previously stored preferences
 			 */
 			loadState : function(name) {
-				if(!window.localStorage) return;
-				
-				return window.localStorage.getItem('cms-preview-state-' + name);
+				try {
+					window.localStorage.getItem('cms-preview-state-' + name);
+				} catch (exception) {
+					return false;
+				}
 			}, 
 
 			/**

--- a/admin/javascript/LeftAndMain.Preview.js
+++ b/admin/javascript/LeftAndMain.Preview.js
@@ -179,22 +179,14 @@
 			 * Store the preview options for this page.
 			 */
 			saveState : function(name, value) {
-				try {
-					window.localStorage.setItem('cms-preview-state-' + name, value);
-				} catch (exception) {
-					return false;
-				}
+				if(this._storage()) window.localStorage.setItem('cms-preview-state-' + name, value);
 			},
 
 			/**
 			 * Load previously stored preferences
 			 */
 			loadState : function(name) {
-				try {
-					window.localStorage.getItem('cms-preview-state-' + name);
-				} catch (exception) {
-					return false;
-				}
+				if(this._storage()) return window.localStorage.getItem('cms-preview-state-' + name);
 			}, 
 
 			/**
@@ -279,6 +271,24 @@
 				this.disablePreview();
 
 				this._super();
+			},
+			
+			/**
+			* Detect and use localStorage credit Mathias Bynens ref: https://mathiasbynens.be/notes/localstorage-pattern
+			* -------------------------------------------------------------------
+			*/
+			_storage: function() {
+				var uid = new Date;
+				var storage;
+				var result;
+				try {
+					(storage = window.localStorage).setItem(uid, uid);
+					result = storage.getItem(uid) == uid;
+					storage.removeItem(uid);
+					return result && storage;
+				} catch (exception) {
+					console.warn('localStorge is not available due to current browser / system settings.');
+				}
 			},
 
 			/**

--- a/admin/javascript/LeftAndMain.Preview.js
+++ b/admin/javascript/LeftAndMain.Preview.js
@@ -179,14 +179,14 @@
 			 * Store the preview options for this page.
 			 */
 			saveState : function(name, value) {
-				if(this._storage()) window.localStorage.setItem('cms-preview-state-' + name, value);
+				if(this._supportsLocalStorage()) window.localStorage.setItem('cms-preview-state-' + name, value);
 			},
 
 			/**
 			 * Load previously stored preferences
 			 */
 			loadState : function(name) {
-				if(this._storage()) return window.localStorage.getItem('cms-preview-state-' + name);
+				if(this._supportsLocalStorage()) return window.localStorage.getItem('cms-preview-state-' + name);
 			}, 
 
 			/**
@@ -274,10 +274,12 @@
 			},
 			
 			/**
-			* Detect and use localStorage credit Mathias Bynens ref: https://mathiasbynens.be/notes/localstorage-pattern
+			* Detect and use localStorage if available.
+			* In IE11 windows 8.1 call to window.localStorage was throwing out an access denied error in some cases.
+			* This was causing the preview window not to display correctly in the CMS admin area. 
 			* -------------------------------------------------------------------
 			*/
-			_storage: function() {
+			_supportsLocalStorage: function() {
 				var uid = new Date;
 				var storage;
 				var result;

--- a/admin/javascript/LeftAndMain.Preview.js
+++ b/admin/javascript/LeftAndMain.Preview.js
@@ -275,8 +275,8 @@
 			
 			/**
 			* Detect and use localStorage if available.
-			* In IE11 windows 8.1 call to window.localStorage was throwing out an access denied error in some cases.
-			* This was causing the preview window not to display correctly in the CMS admin area. 
+			* In IE11 windows 8.1 call to window.localStorage was throwing out an access denied error in some cases 
+			* which was causing the preview window not to display correctly in the CMS admin area. 
 			* -------------------------------------------------------------------
 			*/
 			_supportsLocalStorage: function() {

--- a/admin/javascript/LeftAndMain.Preview.js
+++ b/admin/javascript/LeftAndMain.Preview.js
@@ -274,10 +274,7 @@
 			},
 			
 			/**
-			* Detect and use localStorage if available.
-			* In IE11 windows 8.1 call to window.localStorage was throwing out an access denied error in some cases 
-			* which was causing the preview window not to display correctly in the CMS admin area. 
-			* -------------------------------------------------------------------
+			* Detect and use localStorage if available. In IE11 windows 8.1 call to window.localStorage was throwing out an access denied error in some cases which was causing the preview window not to display correctly in the CMS admin area.
 			*/
 			_supportsLocalStorage: function() {
 				var uid = new Date;


### PR DESCRIPTION
In IE11 windows 8.1 call to window.localStorage was throwing out an access denied error.  Using try and catch manages the issue and allows the script to execute in IE 11 in desktop mode.