### PR TITLE
Remove GroupedDropdownField::validate() (regression)

### DIFF
--- a/forms/GroupedDropdownField.php
+++ b/forms/GroupedDropdownField.php
@@ -88,5 +88,12 @@ class GroupedDropdownField extends DropdownField {
 		return 'groupeddropdown dropdown';
 	}
 
+	/**
+	 * @todo Implement DropdownField::validate() with group validation support
+	 */
+	public function validate(Validator $validator) {
+		return true;
+	}
+
 }
 


### PR DESCRIPTION
Regression caused by 41ea83b,
which introduced field validation in the parent class without
also adapting this subclass.

Fixing the immediate issue (can't save this field type),
as a first step to the actual fix (implementing validate).

See silverstripe/silverstripe-translatable#179