### PR TITLE
checking for destroy

### DIFF
--- a/forms/gridfield/GridFieldExportButton.php
+++ b/forms/gridfield/GridFieldExportButton.php
@@ -155,7 +155,9 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 				$fileData .= "\n";
 			}
 
-			$item->destroy();
+			if ($item->hasMethod('destroy')) {
+				$item->destroy();
+			}
 		}
 
 		return $fileData;


### PR DESCRIPTION
Needed if grid field passed array data, rather than objects.