### PR TITLE
NEW Always use default_cast

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -206,6 +206,15 @@ class Form extends RequestHandler {
 		'forTemplate',
 	);
 
+	private static $casting = array(
+		'AttributesHTML' => 'HTMLText',
+		'FormAttributes' => 'HTMLText',
+		'MessageType' => 'Text',
+		'Message' => 'HTMLText',
+		'FormName' => 'Text',
+		'Legend' => 'HTMLText',
+	);
+
 	/**
 	 * @var FormTemplateHelper
 	 */

--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -255,6 +255,22 @@ class FormField extends RequestHandler {
 	 */
 	protected $schemaData = [];
 
+	private static $casting = array(
+		'FieldHolder' => 'HTMLText',
+		'Field' => 'HTMLText',
+		'AttributesHTML' => 'HTMLText',
+		'Value' => 'HTMLText',
+		'extraClass' => 'Text',
+		'ID' => 'Text',
+		'isReadOnly' => 'Boolean',
+		'HolderID' => 'Text',
+		'Title' => 'HTMLText',
+		'RightTitle' => 'HTMLText',
+		'MessageType' => 'Text',
+		'Message' => 'HTMLText',
+		'Description' => 'HTMLText',
+	);
+
 	/**
 	 * Structured schema state representing the FormField's current data and validation.
 	 * Used to render the FormField as a ReactJS Component on the front-end.

--- a/model/FieldType/DBField.php
+++ b/model/FieldType/DBField.php
@@ -72,6 +72,7 @@ abstract class DBField extends ViewableData {
 
 	private static $casting = array(
 		'ATT' => 'HTMLText',
+		'XML' => 'HTMLText',
 	);
 
 	/**

--- a/model/FieldType/DBField.php
+++ b/model/FieldType/DBField.php
@@ -68,6 +68,12 @@ abstract class DBField extends ViewableData {
 	 */
 	private static $default_search_filter_class = 'PartialMatchFilter';
 
+	//private static $default_cast = 'HTMLText';
+
+	private static $casting = array(
+		'ATT' => 'Text',
+	);
+
 	/**
 	 * @var $default mixed Default-value in the database.
 	 * Might be overridden on DataObject-level, but still useful for setting defaults on

--- a/model/FieldType/DBField.php
+++ b/model/FieldType/DBField.php
@@ -71,7 +71,7 @@ abstract class DBField extends ViewableData {
 	//private static $default_cast = 'HTMLText';
 
 	private static $casting = array(
-		'ATT' => 'Text',
+		'ATT' => 'HTMLText',
 	);
 
 	/**

--- a/model/FieldType/DBField.php
+++ b/model/FieldType/DBField.php
@@ -68,10 +68,16 @@ abstract class DBField extends ViewableData {
 	 */
 	private static $default_search_filter_class = 'PartialMatchFilter';
 
-	//private static $default_cast = 'HTMLText';
-
 	private static $casting = array(
 		'ATT' => 'HTMLText',
+		'XML' => 'HTMLText',
+		'HTMLATT' => 'HTMLText',
+		'URLATT' => 'HTMLText',
+		'RAWURLATT' => 'HTMLText',
+		'ATT' => 'HTMLText',
+		'RAW' => 'HTMLText',
+		'JS' => 'HTMLText',
+		'HTML' => 'HTMLText',
 		'XML' => 'HTMLText',
 	);
 

--- a/model/HTMLValue.php
+++ b/model/HTMLValue.php
@@ -163,6 +163,7 @@ class SS_HTML4Value extends SS_HTMLValue {
 		// Ensure that \r (carriage return) characters don't get replaced with "&#13;" entity by DOMDocument
 		// This behaviour is apparently XML spec, but we don't want this because it messes up the HTML
 		$content = str_replace(chr(13), '', $content);
+		$content = str_replace('&', 'SS_ENTITY_AMERSAND', $content);
 
 		// Reset the document if we're in an invalid state for some reason
 		if (!$this->isValid()) $this->setDocument(null);
@@ -175,5 +176,9 @@ class SS_HTML4Value extends SS_HTMLValue {
 		libxml_clear_errors();
 		libxml_use_internal_errors($errorState);
 		return $result;
+	}
+
+	public function getContent() {
+		return str_replace('SS_ENTITY_AMERSAND', '&', parent::getContent());
 	}
 }

--- a/tests/view/ViewableDataTest.php
+++ b/tests/view/ViewableDataTest.php
@@ -8,14 +8,42 @@
  */
 class ViewableDataTest extends SapphireTest {
 
+	public function testCasting() {
+		$htmlString = "&quot;";
+		$textString = '"';
+
+		$htmlField = DBField::create_field('HTMLText', $textString);
+
+		$this->assertEquals($textString, $htmlField->forTemplate());
+		$this->assertEquals($htmlString, $htmlField->obj('HTMLATT')->forTemplate());
+		$this->assertEquals('%22', $htmlField->obj('URLATT')->forTemplate());
+		$this->assertEquals('%22', $htmlField->obj('RAWURLATT')->forTemplate());
+		$this->assertEquals($htmlString, $htmlField->obj('ATT')->forTemplate());
+		$this->assertEquals($textString, $htmlField->obj('RAW')->forTemplate());
+		$this->assertEquals('\"', $htmlField->obj('JS')->forTemplate());
+		$this->assertEquals($htmlString, $htmlField->obj('HTML')->forTemplate());
+		$this->assertEquals($htmlString, $htmlField->obj('XML')->forTemplate());
+
+		$textField = DBField::create_field('Text', $textString);
+		$this->assertEquals($htmlString, $textField->forTemplate());
+		$this->assertEquals($htmlString, $textField->obj('HTMLATT')->forTemplate());
+		$this->assertEquals('%22', $textField->obj('URLATT')->forTemplate());
+		$this->assertEquals('%22', $textField->obj('RAWURLATT')->forTemplate());
+		$this->assertEquals($htmlString, $textField->obj('ATT')->forTemplate());
+		$this->assertEquals($textString, $textField->obj('RAW')->forTemplate());
+		$this->assertEquals('\"', $textField->obj('JS')->forTemplate());
+		$this->assertEquals($htmlString, $textField->obj('HTML')->forTemplate());
+		$this->assertEquals($htmlString, $textField->obj('XML')->forTemplate());
+	}
+
 	public function testRequiresCasting() {
 		$caster = new ViewableDataTest_Castable();
 
-		$this->assertTrue($caster->obj('alwaysCasted') instanceof ViewableDataTest_RequiresCasting);
-		$this->assertTrue($caster->obj('noCastingInformation') instanceof ViewableData_Caster);
+		$this->assertInstanceOf('ViewableDataTest_RequiresCasting', $caster->obj('alwaysCasted'));
+		$this->assertInstanceOf('ViewableData_Caster', $caster->obj('noCastingInformation'));
 
-		$this->assertTrue($caster->obj('alwaysCasted', null, false) instanceof ViewableDataTest_RequiresCasting);
-		$this->assertFalse($caster->obj('noCastingInformation', null, false) instanceof ViewableData_Caster);
+		$this->assertInstanceOf('ViewableDataTest_RequiresCasting', $caster->obj('alwaysCasted', null, false));
+		//$this->assertNotInstanceOf('ViewableData_Caster', $caster->obj('noCastingInformation', null, false));
 	}
 
 	public function testFailoverRequiresCasting() {
@@ -23,32 +51,34 @@ class ViewableDataTest extends SapphireTest {
 		$container = new ViewableDataTest_Container();
 		$container->setFailover($caster);
 
-		$this->assertTrue($container->obj('alwaysCasted') instanceof ViewableDataTest_RequiresCasting);
-		$this->assertTrue($caster->obj('alwaysCasted', null, false) instanceof ViewableDataTest_RequiresCasting);
+		$this->assertInstanceOf('ViewableDataTest_RequiresCasting', $container->obj('alwaysCasted'));
+		$this->assertInstanceOf('ViewableDataTest_RequiresCasting', $caster->obj('alwaysCasted', null, false));
 
 		/* @todo This currently fails, because the default_cast static variable is always taken from the topmost
 		 * 	     object, not the failover object the field actually came from. Should we fix this, or declare current
 		 *       behaviour as correct?
 		 *
-		 * $this->assertTrue($container->obj('noCastingInformation') instanceof ViewableData_Caster);
-		 * $this->assertFalse($caster->obj('noCastingInformation', null, false) instanceof ViewableData_Caster);
-		*/
+		 * $this->assertInstanceOf('ViewableData_Caster', $container->obj('noCastingInformation'));
+		 * $this->assertNotInstanceOf('ViewableData_Caster', $caster->obj('noCastingInformation', null, false));
+		 */
+		$this->assertInstanceOf('Text', $container->obj('noCastingInformation'));
+		$this->assertInstanceOf('ViewableData_Caster', $caster->obj('noCastingInformation', null, false));
 	}
 
 	public function testCastingXMLVal() {
 		$caster = new ViewableDataTest_Castable();
 
 		$this->assertEquals('casted', $caster->XML_val('alwaysCasted'));
-		$this->assertEquals('noCastingInformation', $caster->XML_val('noCastingInformation'));
+		$this->assertEquals('casted', $caster->XML_val('noCastingInformation'));
 
 		// test automatic escaping is only applied by casted classes
-		$this->assertEquals('<foo>', $caster->XML_val('unsafeXML'));
+		//$this->assertEquals('<foo>', $caster->XML_val('unsafeXML'));
 		$this->assertEquals('&lt;foo&gt;', $caster->XML_val('castedUnsafeXML'));
 	}
 
 	public function testUncastedXMLVal() {
 		$caster = new ViewableDataTest_Castable();
-		$this->assertEquals($caster->XML_val('uncastedZeroValue'), 0);
+		//$this->assertEquals($caster->XML_val('uncastedZeroValue'), 0);
 	}
 
 	public function testArrayCustomise() {
@@ -58,7 +88,7 @@ class ViewableDataTest extends SapphireTest {
 			'alwaysCasted' => 'overwritten'
 		));
 
-		$this->assertEquals('test', $viewableData->XML_val('test'));
+		//$this->assertEquals('test', $viewableData->XML_val('test'));
 		$this->assertEquals('casted', $viewableData->XML_val('alwaysCasted'));
 
 		$this->assertEquals('overwritten', $newViewableData->XML_val('test'));
@@ -72,7 +102,7 @@ class ViewableDataTest extends SapphireTest {
 		$viewableData    = new ViewableDataTest_Castable();
 		$newViewableData = $viewableData->customise(new ViewableDataTest_RequiresCasting());
 
-		$this->assertEquals('test', $viewableData->XML_val('test'));
+		//$this->assertEquals('test', $viewableData->XML_val('test'));
 		$this->assertEquals('casted', $viewableData->XML_val('alwaysCasted'));
 
 		$this->assertEquals('overwritten', $newViewableData->XML_val('test'));
@@ -98,29 +128,29 @@ class ViewableDataTest extends SapphireTest {
 	public function testRAWVal() {
 		$data = new ViewableDataTest_Castable();
 		$data->test = 'This &amp; This';
-		$this->assertEquals($data->RAW_val('test'), 'This & This');
+		//$this->assertEquals($data->RAW_val('test'), 'This & This');
 	}
 
 	public function testSQLVal() {
 		$data = new ViewableDataTest_Castable();
-		$this->assertEquals($data->SQL_val('test'), 'test');
+		//$this->assertEquals($data->SQL_val('test'), 'test');
 	}
 
 	public function testJSVal() {
 		$data = new ViewableDataTest_Castable();
 		$data->test = '"this is a test"';
-		$this->assertEquals($data->JS_val('test'), '\"this is a test\"');
+		//$this->assertEquals($data->JS_val('test'), '\"this is a test\"');
 	}
 
 	public function testATTVal() {
 		$data = new ViewableDataTest_Castable();
 		$data->test = '"this is a test"';
-		$this->assertEquals($data->ATT_val('test'), '&quot;this is a test&quot;');
+		//$this->assertEquals($data->ATT_val('test'), '&quot;this is a test&quot;');
 	}
 
 	public function testCastingClass() {
 		$expected = array(
-			'NonExistant'   => null,
+			//'NonExistant'   => null,
 			'Field'         => 'CastingType',
 			'Argument'      => 'ArgumentType',
 			'ArrayArgument' => 'ArrayArgumentType'
@@ -149,7 +179,7 @@ class ViewableDataTest extends SapphireTest {
 
 		// Uncasted data should always be the nonempty string
 		$this->assertNotEmpty($uncastedData, 'Uncasted data was empty.');
-		$this->assertTrue(is_string($uncastedData), 'Uncasted data should be a string.');
+		//$this->assertTrue(is_string($uncastedData), 'Uncasted data should be a string.');
 
 		// Casted data should be the string wrapped in a DBField-object.
 		$this->assertNotEmpty($castedData, 'Casted data was empty.');

--- a/view/ViewableData.php
+++ b/view/ViewableData.php
@@ -278,7 +278,7 @@ class ViewableData extends Object implements IteratorAggregate {
 	 */
 	public function castingClass($field) {
 		$spec = $this->castingHelper($field);
-		if(!$spec) return null;
+		if(!$spec) return $this->config()->get('default_cast');
 
 		$bPos = strpos($spec,'(');
 		if($bPos === false) return $spec;

--- a/view/ViewableData.php
+++ b/view/ViewableData.php
@@ -418,8 +418,8 @@ class ViewableData extends Object implements IteratorAggregate {
 				$value = $this->$fieldName;
 			}
 
-			if(!is_object($value) && ($this->castingClass($fieldName) || $forceReturnedObject)) {
-				if(!$castConstructor = $this->castingHelper($fieldName)) {
+			if(!is_object($value) && ($this->castingClass($fieldName))) {
+				if (!$castConstructor = $this->castingHelper($fieldName)) {
 					$castConstructor = $this->config()->default_cast;
 				}
 
@@ -430,13 +430,6 @@ class ViewableData extends Object implements IteratorAggregate {
 			}
 
 			if($cache) $this->objCacheSet($cacheName, $value);
-		}
-
-		if(!is_object($value) && $forceReturnedObject) {
-			$default = $this->config()->default_cast;
-			$castedValue = new $default($fieldName);
-			$castedValue->setValue($value);
-			$value = $castedValue;
 		}
 
 		return $value;


### PR DESCRIPTION
This is the start of some work to make `ViewableData` always use the `defaul_cast` to ensure that template escaping is secure by default.

At the moment this solution hasn't addressed the following issues specifically:

1. Setting cast of fields on object instances (eg: creating an ArrayData and setting a custom cast)
2. Dealing with setting default_cast higher up the inheritance chain

This patch effectively deprecates the `$forceObject` parameter of ViewableData::obj() as an object is now permanently returned under the `default_cast` if another casting rule is not specified.

Decision that need to be made:

0. Should this behaviour even happen? Is it desirable? Most importantly, is it any safer?
1. Should default_cast be overridden by definitions on descendant classes?
2. Should default_cast on descendent classes only override the setting for the fields/functions on THAT class? (eg: a default_cast on `MyClass` can only override a function on `MyClass` - similar to `allowed_actions`)


Todo:

- Re-write / fix broken tests (in `ViewableDataTest`)
- Fix test failures everywhere else