### PR TITLE
Cleaning up Controller::handleRequest

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -355,7 +355,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 	 * @uses LeftAndMainExtension->accessedCMS()
 	 * @uses CMSMenu
 	 */
-	public function init() {
+	protected function init() {
 		parent::init();
 
 		Config::inst()->update('SSViewer', 'rewrite_hash_links', false);

--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -93,7 +93,7 @@ abstract class ModelAdmin extends LeftAndMain {
 	/**
 	 * Initialize the model admin interface. Sets up embedded jquery libraries and requisite plugins.
 	 */
-	public function init() {
+	protected function init() {
 		parent::init();
 
 		$models = $this->getManagedModels();

--- a/admin/code/SecurityAdmin.php
+++ b/admin/code/SecurityAdmin.php
@@ -29,7 +29,7 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider {
 		'roles'
 	);
 
-	public function init() {
+	protected function init() {
 		parent::init();
 		Requirements::javascript(FRAMEWORK_ADMIN_DIR . '/client/dist/js/SecurityAdmin.js');
 	}

--- a/cli/CliController.php
+++ b/cli/CliController.php
@@ -15,7 +15,7 @@ abstract class CliController extends Controller {
 		'index'
 	);
 
-	public function init() {
+	protected function init() {
 		parent::init();
 		// Unless called from the command line, all CliControllers need ADMIN privileges
 		if(!Director::is_cli() && !Permission::check("ADMIN")) {
@@ -27,7 +27,7 @@ abstract class CliController extends Controller {
 		foreach(ClassInfo::subclassesFor($this->class) as $subclass) {
 			echo $subclass . "\n";
 			$task = new $subclass();
-			$task->init();
+			$task->doInit();
 			$task->process();
 		}
 	}

--- a/control/RequestHandler.php
+++ b/control/RequestHandler.php
@@ -194,7 +194,7 @@ class RequestHandler extends ViewableData {
 			if(!$this->hasAction($action)) {
 				return $this->httpError(404, "Action '$action' isn't available $classMessage.");
 			}
-			if(!$this->checkAccessAction($action) || in_array(strtolower($action), array('run', 'init'))) {
+			if(!$this->checkAccessAction($action) || in_array(strtolower($action), array('run', 'doInit'))) {
 				return $this->httpError(403, "Action '$action' isn't allowed $classMessage.");
 			}
 			$result = $this->handleAction($request, $action);
@@ -376,7 +376,7 @@ class RequestHandler extends ViewableData {
 			Config::UNINHERITED | Config::EXCLUDE_EXTRA_SOURCES
 		);
 		if(!is_array($actions) || !$actionsWithoutExtra) {
-			if($action != 'init' && $action != 'run' && method_exists($this, $action)) return true;
+			if($action != 'doInit' && $action != 'run' && method_exists($this, $action)) return true;
 		}
 
 		return false;
@@ -493,8 +493,10 @@ class RequestHandler extends ViewableData {
 	 * or {@link handleRequest()}, but in some based we want to set it manually.
 	 *
 	 * @param SS_HTTPRequest
+	 * @return $this
 	 */
 	public function setRequest($request) {
 		$this->request = $request;
+		return $this;
 	}
 }

--- a/dev/DevelopmentAdmin.php
+++ b/dev/DevelopmentAdmin.php
@@ -29,7 +29,7 @@ class DevelopmentAdmin extends Controller {
 		'generatesecuretoken',
 	);
 
-	public function init() {
+	protected function init() {
 		parent::init();
 
 		// Special case for dev/build: Defer permission checks to DatabaseAdmin->init() (see #4957)

--- a/dev/SapphireInfo.php
+++ b/dev/SapphireInfo.php
@@ -11,7 +11,7 @@ class SapphireInfo extends Controller {
 		'environmenttype',
 	);
 
-	public function init() {
+	protected function init() {
 		parent::init();
 		if(!Director::is_cli() && !Permission::check('ADMIN')) return Security::permissionFailure();
 	}

--- a/dev/TaskRunner.php
+++ b/dev/TaskRunner.php
@@ -15,7 +15,7 @@ class TaskRunner extends Controller {
 		'runTask',
 	);
 
-	public function init() {
+	protected function init() {
 		parent::init();
 
 		$isRunningTests = (class_exists('SapphireTest', false) && SapphireTest::is_running_test());

--- a/docs/en/changelogs/4.0.0.md
+++ b/docs/en/changelogs/4.0.0.md
@@ -1,0 +1,98 @@
+# 4.0.0 (unreleased)
+
+## Overview
+
+### Framework
+
+ * Deprecate `SQLQuery` in favour `SQLSelect`
+ * `DataList::filter` by null now internally generates "IS NULL" or "IS NOT NULL" conditions appropriately on queries
+ * `Controller::init` visibility changed to protected
+ * Initialising controllers now the responsibility of `Controller::doInit()`
+ * `handleRequest`
+
+## Upgrading
+
+### Update code that uses SQLQuery
+
+SQLQuery is still implemented, but now extends the new SQLSelect class and has some methods
+deprecated. Previously this class was used for both selecting and deleting, but these
+have been superceded by the specialised SQLSelect and SQLDelete classes.
+
+Take care for any code or functions which expect an object of type `SQLQuery`, as
+these references should be replaced with `SQLSelect`. Legacy code which generates
+`SQLQuery` can still communicate with new code that expects `SQLSelect` as it is a
+subclass of `SQLSelect`, but the inverse is not true.
+
+### Update implementations of augmentSQL
+
+Since this method now takes a `SQLSelect` as a first parameter, existing code referencing the deprecated `SQLQuery`
+type will raise a PHP error.
+
+E.g.
+
+Before:
+
+	:::php
+	function augmentSQL(SQLQuery &$query, DataQuery &$dataQuery = null) {
+		$locale = Translatable::get_current_locale();
+		if(!preg_match('/("|\'|`)Locale("|\'|`)/', implode(' ', $query->getWhere())))  {
+			$qry = sprintf('"Locale" = \'%s\'', Convert::raw2sql($locale));
+			$query->addWhere($qry); 
+		}
+	}
+
+After:
+
+	:::php
+	function augmentSQL(SQLSelect $query, DataQuery $dataQuery = null) {
+		$locale = Translatable::get_current_locale();
+		if(!preg_match('/("|\'|`)Locale("|\'|`)/', implode(' ', $query->getWhereParameterised($parameters))))  {
+			$query->addWhere(array(
+				'"Locale"' => $locale
+			));
+		}
+	}
+
+
+### Update to Controller initialisation
+
+`Controller::init` is now protected, so any overloaded instances of this method need to have their visibility changed to
+`protected`
+
+Before:
+
+	:::php
+	public function init() {
+		parent::init();
+		
+		if (!Member::currentMemberID()) {
+			Security::permissionFailure($this);
+		}
+	}
+
+After:
+
+	:::php
+	protected function init() {
+		parent::init();
+		
+		if (!Member::currentMemberID()) {
+			Security::permissionFailure($this);
+		}
+	}
+
+Initialising controllers now need to be done with the `doInit` method.
+
+Before:
+
+	:::php
+	
+	$controller = ModelAsController::controller_for(Page::get()->first());
+	$controller->init();
+
+After:
+
+	:::php
+	
+	$controller = ModelAsController::controller_for(Page::get()->first());
+	$controller->doInit();

--- a/model/DatabaseAdmin.php
+++ b/model/DatabaseAdmin.php
@@ -21,7 +21,7 @@ class DatabaseAdmin extends Controller {
 		'import'
 	);
 
-	public function init() {
+	protected function init() {
 		parent::init();
 
 		// We allow access to this controller regardless of live-status or ADMIN permission only

--- a/security/CMSSecurity.php
+++ b/security/CMSSecurity.php
@@ -24,7 +24,7 @@ class CMSSecurity extends Security {
 	 */
 	private static $reauth_enabled = true;
 
-	public function init() {
+	protected function init() {
 		parent::init();
 
 		// Include CMS styles and js

--- a/security/Security.php
+++ b/security/Security.php
@@ -304,7 +304,7 @@ class Security extends Controller implements TemplateGlobalProvider {
 		);
 	}
 
-	public function init() {
+	protected function init() {
 		parent::init();
 
 		// Prevent clickjacking, see https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
@@ -450,7 +450,7 @@ class Security extends Controller implements TemplateGlobalProvider {
 
 		$controller = Page_Controller::create($tmpPage);
 		$controller->setDataModel($this->model);
-		$controller->init();
+		$controller->doInit();
 		return $controller;
 	}
 

--- a/tests/FakeController.php
+++ b/tests/FakeController.php
@@ -20,6 +20,6 @@ class FakeController extends Controller {
 
 		$this->setResponse(new SS_HTTPResponse());
 
-		$this->init();
+		$this->doInit();
 	}
 }

--- a/tests/security/BasicAuthTest.php
+++ b/tests/security/BasicAuthTest.php
@@ -133,7 +133,7 @@ class BasicAuthTest_ControllerSecuredWithPermission extends Controller implement
 
 	protected $template = 'BlankPage';
 
-	public function init() {
+	protected function init() {
 		self::$post_init_called = false;
 		self::$index_called = false;
 
@@ -155,7 +155,7 @@ class BasicAuthTest_ControllerSecuredWithoutPermission extends Controller implem
 
 	protected $template = 'BlankPage';
 
-	public function init() {
+	protected function init() {
 		BasicAuth::protect_entire_site(true, null);
 		parent::init();
 	}


### PR DESCRIPTION
This PR reduced the amount of responsiblity taken on by `Controller::handleRequest`. In turn this reduces the code complexity as well.

The handleRequest function has been split into component parts (setup and teardown - the functions that prepare and cleanup the controller before and after the request is _actually_ handled).

The init function has had a similar treatment. The init function is now split into the logic that should actually be happening when init is run and the logic preparing to run the init and enforcing that base init has been run at all.

init is still defined on controllers and executed as expected but instantiators of controllers should be calling `doInit` from now on when preparing their controllers.

Further, I've removed all direct manipulations of class properties and used their accessors where appropriate (and created them where missing).

---

1. Separated responsibility of handleAction so that it no longer bootstraps the controller and cleans up after the request is handled.
2. NEW beforeHandleRequest to take responsibility of bootstrapping the controller
3. NEW afterHandleRequest to take responsibility of cleanup for the controller
4. NEW calling init on controllers removed in favour of doInit() which takes responsibility of enforcing that "base init" is called and the before and after hooks. init() is now protected visibility
5. NEW Added prepareResponse to Controller for dealing with responses from controllers
6. NEW setResponse added to controller for setting response objects on the controller