### PR TITLE
match scaffoldFormField signature on Varchar to DBField

### DIFF
--- a/model/fieldtypes/Varchar.php
+++ b/model/fieldtypes/Varchar.php
@@ -93,7 +93,7 @@ class Varchar extends StringField {
 	 * (non-PHPdoc)
 	 * @see DBField::scaffoldFormField()
 	 */
-	public function scaffoldFormField($title = null, $params = null) {
+	public function scaffoldFormField($title = null) {
 		if(!$this->nullifyEmpty) {
 			// Allow the user to select if it's null instead of automatically assuming empty string is
 			return new NullableField(new TextField($this->name, $title));


### PR DESCRIPTION
The current code throws STRICT warnings when Varchar is extended. E.g. 

```php
class FlexiChoice extends Varchar
{

    // throws a STRICT warning because signature does not Match DBField
    public function scaffoldFormField($title = null) {
        $field = new FlexiChoiceField($this->name, $title);
        return $field;
    }

    ...
}
```