### PR TITLE
FIX: Ensuring GridFieldDetailForm validator uses Object->hasMethod() to respect e...

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -95,7 +95,7 @@ class GridFieldDetailForm implements GridField_URLHandler {
 
 		// if no validator has been set on the GridField and the record has a
 		// CMS validator, use that.
-		if(!$this->getValidator() && method_exists($record, 'getCMSValidator')) {
+		if(!$this->getValidator() && (method_exists($record, 'getCMSValidator') || $record instanceof Object && $record->hasMethod('getCMSValidator'))) {
 			$this->setValidator($record->getCMSValidator());
 		}
 


### PR DESCRIPTION
I noticed that while SilverStripe utilizes a decorator pattern with it's extensions, it didn't appear to respect (or see) my custom `->getCMSValidator()` method on one of my extensions. I'm not sure if this was by accident or design, but it appears to have been due to using the native `method_exists()` function instead of calling the `->hasMethod()` object descended from the `Object` parent. 

Now for my particular use case **specifically** with `getCMSValidator()`, I'm fine if that method gets defined on the target object and overrides my decorator method (a workaround would probably be simple within the method itself). What I'm wondering is this: There are many other instances here in the framework that I'm seeing where `method_exists()` is being used where potentially `Object->hasMethod()` could be getting called instead (to help prevent that frustrating hit-or-miss end result that caused me to almost pull my hair out). 

**So:** Would it make sense to drop a `hasMethod($object, $method)` function somewhere into the framework and then use that in place of `method_exists()` and within that function simply rely on `->hasMethod()` (if the object is an `instanceof Object` or otherwise falling back to `method_exists()`? To me it would make sense to centralize and utilize this as much as possible, so that's why I wanted to open this pull request; to open a discussion about that as well.