### PR TITLE
Refactor ViewableData::obj caching

### DIFF
--- a/tests/view/ViewableDataTest.php
+++ b/tests/view/ViewableDataTest.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * See {@link SSViewerTest->testCastingHelpers()} for more tests related to casting and ViewableData behaviour, 
+ * See {@link SSViewerTest->testCastingHelpers()} for more tests related to casting and ViewableData behaviour,
  * from a template-parsing perspective.
- * 
+ *
  * @package framework
  * @subpackage tests
  */
 class ViewableDataTest extends SapphireTest {
-	
+
 	public function testRequiresCasting() {
 		$caster = new ViewableDataTest_Castable();
-		
+
 		$this->assertTrue($caster->obj('alwaysCasted') instanceof ViewableDataTest_RequiresCasting);
 		$this->assertTrue($caster->obj('noCastingInformation') instanceof ViewableData_Caster);
-		
+
 		$this->assertTrue($caster->obj('alwaysCasted', null, false) instanceof ViewableDataTest_RequiresCasting);
 		$this->assertFalse($caster->obj('noCastingInformation', null, false) instanceof ViewableData_Caster);
 	}
@@ -28,7 +28,7 @@ class ViewableDataTest extends SapphireTest {
 		/* @todo This currently fails, because the default_cast static variable is always taken from the topmost
 		 * 	     object, not the failover object the field actually came from. Should we fix this, or declare current
 		 *       behaviour as correct?
-		 * 
+		 *
 		 * $this->assertTrue($container->obj('noCastingInformation') instanceof ViewableData_Caster);
 		 * $this->assertFalse($caster->obj('noCastingInformation', null, false) instanceof ViewableData_Caster);
 		*/
@@ -36,27 +36,27 @@ class ViewableDataTest extends SapphireTest {
 
 	public function testCastingXMLVal() {
 		$caster = new ViewableDataTest_Castable();
-		
+
 		$this->assertEquals('casted', $caster->XML_val('alwaysCasted'));
 		$this->assertEquals('noCastingInformation', $caster->XML_val('noCastingInformation'));
-		
+
 		// test automatic escaping is only applied by casted classes
 		$this->assertEquals('<foo>', $caster->XML_val('unsafeXML'));
 		$this->assertEquals('&lt;foo&gt;', $caster->XML_val('castedUnsafeXML'));
 	}
-	
+
 	public function testUncastedXMLVal() {
 		$caster = new ViewableDataTest_Castable();
 		$this->assertEquals($caster->XML_val('uncastedZeroValue'), 0);
 	}
-	
+
 	public function testArrayCustomise() {
 		$viewableData    = new ViewableDataTest_Castable();
 		$newViewableData = $viewableData->customise(array (
 			'test'         => 'overwritten',
 			'alwaysCasted' => 'overwritten'
 		));
-		
+
 		$this->assertEquals('test', $viewableData->XML_val('test'));
 		$this->assertEquals('casted', $viewableData->XML_val('alwaysCasted'));
 
@@ -99,7 +99,7 @@ class ViewableDataTest extends SapphireTest {
 		$data->test = 'This &amp; This';
 		$this->assertEquals($data->RAW_val('test'), 'This & This');
 	}
-	
+
 	public function testSQLVal() {
 		$data = new ViewableDataTest_Castable();
 		$this->assertEquals($data->SQL_val('test'), 'test');
@@ -156,36 +156,55 @@ class ViewableDataTest extends SapphireTest {
 
 		$this->assertEquals($uncastedData, $castedData->getValue(), 'Casted and uncasted strings are not equal.');
 	}
+
+	public function testCaching() {
+		$objCached = new ViewableDataTest_Cached();
+		$objNotCached = new ViewableDataTest_NotCached();
+
+		$objCached->Test = 'AAA';
+		$objNotCached->Test = 'AAA';
+
+		$this->assertEquals('AAA', $objCached->obj('Test', null, true, true));
+		$this->assertEquals('AAA', $objNotCached->obj('Test', null, true, true));
+
+		$objCached->Test = 'BBB';
+		$objNotCached->Test = 'BBB';
+
+		// Cached data must be always the same
+		$this->assertEquals('AAA', $objCached->obj('Test', null, true, true));
+		$this->assertEquals('BBB', $objNotCached->obj('Test', null, true, true));
+	}
+
 }
 
 /**#@+
  * @ignore
  */
 class ViewableDataTest_Castable extends ViewableData {
-	
+
 	private static $default_cast = 'ViewableData_Caster';
-	
+
 	private static $casting = array (
 		'alwaysCasted'    => 'ViewableDataTest_RequiresCasting',
 		'castedUnsafeXML' => 'ViewableData_UnescaptedCaster'
 	);
-	
+
 	public $test = 'test';
-	
+
 	public $uncastedZeroValue = 0;
-	
+
 	public function alwaysCasted() {
 		return 'alwaysCasted';
 	}
-	
+
 	public function noCastingInformation() {
 		return 'noCastingInformation';
 	}
-	
+
 	public function unsafeXML() {
 		return '<foo>';
 	}
-	
+
 	public function castedUnsafeXML() {
 		return $this->unsafeXML();
 	}
@@ -196,39 +215,39 @@ class ViewableDataTest_Castable extends ViewableData {
 }
 
 class ViewableDataTest_RequiresCasting extends ViewableData {
-	
+
 	public $test = 'overwritten';
-	
+
 	public function forTemplate() {
 		return 'casted';
 	}
-	
+
 	public function setValue() {}
-	
+
 }
 
 class ViewableData_UnescaptedCaster extends ViewableData {
-	
+
 	protected $value;
-	
+
 	public function setValue($value) {
 		$this->value = $value;
 	}
-	
+
 	public function forTemplate() {
 		return Convert::raw2xml($this->value);
 	}
-	
+
 }
 
 class ViewableData_Caster extends ViewableData {
-	
+
 	public function forTemplate() {
 		return 'casted';
 	}
-	
+
 	public function setValue() {}
-	
+
 }
 
 class ViewableDataTest_Container extends ViewableData {
@@ -250,6 +269,19 @@ class ViewableDataTest_CastingClass extends ViewableData {
 class ViewableDataTest_NoCastingInformation extends ViewableData {
 	public function noCastingInformation() {
 		return "No casting information";
+	}
+}
+
+class ViewableDataTest_Cached extends ViewableData {
+	public $Test;
+}
+
+class ViewableDataTest_NotCached extends ViewableData {
+	public $Test;
+
+	protected function objCacheGet($key) {
+		// Disable caching
+		return null;
 	}
 }
 


### PR DESCRIPTION
To demonstrate alternative solution to #2855

Without introducing any new external api, this refactor allows user code to customise, disable, or enhance the viewable data obj caching.