### PR TITLE
tree loads when nodes are loaded

### DIFF
--- a/admin/javascript/LeftAndMain.Tree.js
+++ b/admin/javascript/LeftAndMain.Tree.js
@@ -406,7 +406,12 @@
 										newNode = self.find('li[data-id='+nodeId+']');
 										correctStateFn(newNode);
 									});
-								} else {
+								} else if(self.find('li[data-id='+nodeId+']').length){
+                                    					self.jstree('load_node', -1, function() {
+                                        					newNode = self.find('li[data-id='+nodeId+']');
+                                        					correctStateFn(newNode);
+                                    					});
+                                				} else {
 									self.createNode(nodeData.html, nodeData, function(newNode) {
 										correctStateFn(newNode);
 									});


### PR DESCRIPTION
when a page is loaded in the CMS and if that page is already there in the site tree node which is opened, the tree.js reloads it again and add that page into the bottom of the branch. 

this fixes it from trying to load the tree again. 