### PR TITLE
FIX Prevent unnecessary call to config system which doesn't exist yet

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -85,8 +85,6 @@ require_once 'control/injector/Injector.php';
 // Initialise the dependency injector as soon as possible, as it is 
 // subsequently used by some of the following code
 $injector = new Injector(array('locator' => 'SilverStripeServiceConfigurationLocator'));
-$injector->registerService(Config::inst());
-
 Injector::set_inst($injector);
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
By passing the Config instantiation through the Injector and service configuration we're unnecessarily calling Config::inst()->get() on a config system which doesn't yet exist.

More specifically it calls Config::inst()->get('Config', 'dependencies') here: https://github.com/silverstripe/silverstripe-framework/blob/4ae0d90c5565b2245fe7b9ff96d89e4e386f018c/control/injector/Injector.php#L660 which in turn calls Config::inst()->get('Config', 'extensions').

This jumps through hoops trying to find the cached config for this class using the current Config_LRU class. When it doesn't find it, it then tries to look through the manifests which don't get created or brought from cache until later on in Core.php. Eventually this returns null for both Config::inst()->get() calls.

I ran a quick performance test before and after on an ec2 t2.micro box using siege (concurrency 5, 10 repetitions) and saved 400ms on average response times on a default installation - it would be awesome if somebody could confirm this is actually the case?