### PR TITLE
Changed comparison from truthy to explicit

### DIFF
--- a/forms/OptionsetField.php
+++ b/forms/OptionsetField.php
@@ -68,14 +68,18 @@ class OptionsetField extends DropdownField {
 				$odd = ($odd + 1) % 2;
 				$extraClass = $odd ? 'odd' : 'even';
 				$extraClass .= ' val' . preg_replace('/[^a-zA-Z0-9\-\_]/', '_', $value);
-				
+                if($value) {
+                    $checked = ($value == $this->value);
+                } else {
+                    $checked = ($value === $this->value) || (((string) $value) === ((string) $this->value));
+                }
 				$options[] = new ArrayData(array(
 					'ID' => $itemID,
 					'Class' => $extraClass,
 					'Name' => $this->name,
 					'Value' => $value,
 					'Title' => $title,
-					'isChecked' => $value === $this->value,
+					'isChecked' => $checked,
 					'isDisabled' => $this->disabled || in_array($value, $this->disabledItems),
 				));
 			}

--- a/forms/OptionsetField.php
+++ b/forms/OptionsetField.php
@@ -75,7 +75,7 @@ class OptionsetField extends DropdownField {
 					'Name' => $this->name,
 					'Value' => $value,
 					'Title' => $title,
-					'isChecked' => $value == $this->value,
+					'isChecked' => $value === $this->value,
 					'isDisabled' => $this->disabled || in_array($value, $this->disabledItems),
 				));
 			}


### PR DESCRIPTION
Changed comparison from truthy (==) to explicit (===) to avoid cases of `null == false`