### PR TITLE
added space after class name in InvalidArgumentException for applyMany +...

### DIFF
--- a/search/filters/SearchFilter.php
+++ b/search/filters/SearchFilter.php
@@ -229,7 +229,7 @@ abstract class SearchFilter extends Object {
 	 * @return DataQuery
 	 */
 	protected function applyMany(DataQuery $query) {
-		throw new InvalidArgumentException(get_class($this) . "can't be used to filter by a list of items.");
+		throw new InvalidArgumentException(get_class($this) . " can't be used to filter by a list of items.");
 	}
 
 	/**
@@ -265,7 +265,7 @@ abstract class SearchFilter extends Object {
 	 * @return DataQuery
 	 */
 	protected function excludeMany(DataQuery $query) {
-		throw new InvalidArgumentException(get_class($this) . "can't be used to filter by a list of items.");
+		throw new InvalidArgumentException(get_class($this) . " can't be used to filter by a list of items.");
 	}
 	
 	/**


### PR DESCRIPTION
... excludeMany

"ClassNamecan't be used to filter by a list of items." => "ClassName can't be used to filter by a list of items."