### PR TITLE
API enable PaginatedList to be disabled by setting page length to 0

### DIFF
--- a/core/PaginatedList.php
+++ b/core/PaginatedList.php
@@ -65,9 +65,10 @@ class PaginatedList extends SS_ListDecorator {
 	}
 
 	/**
-	 * Set the number of items displayed per page.
+	 * Set the number of items displayed per page. Set to zero to disable paging.
 	 *
 	 * @param int $length
+	 * @return $this
 	 */
 	public function setPageLength($length) {
 		$this->pageLength = $length;
@@ -77,7 +78,8 @@ class PaginatedList extends SS_ListDecorator {
 	/**
 	 * Sets the current page.
 	 *
-	 * @param int $page
+	 * @param int $page Page index beginning with 1
+	 * @return $this
 	 */
 	public function setCurrentPage($page) {
 		$this->pageStart = ($page - 1) * $this->getPageLength();
@@ -182,10 +184,11 @@ class PaginatedList extends SS_ListDecorator {
 	 * @return IteratorIterator
 	 */
 	public function getIterator() {
-		if($this->limitItems) {
+		$pageLength = $this->getPageLength();
+		if($this->limitItems && $pageLength) {
 			$tmptList = clone $this->list;
 			return new IteratorIterator(
-				$tmptList->limit($this->getPageLength(), $this->getPageStart())
+				$tmptList->limit($pageLength, $this->getPageStart())
 			);
 		} else {
 			return new IteratorIterator($this->list);
@@ -325,14 +328,20 @@ class PaginatedList extends SS_ListDecorator {
 	 * @return int
 	 */
 	public function CurrentPage() {
-		return floor($this->getPageStart() / $this->getPageLength()) + 1;
+		$pageLength = $this->getPageLength();
+		return $pageLength
+			? floor($this->getPageStart() / $pageLength) + 1
+			: 1;
 	}
 
 	/**
 	 * @return int
 	 */
 	public function TotalPages() {
-		return ceil($this->getTotalItems() / $this->getPageLength());
+		$pageLength = $this->getPageLength();
+		return $pageLength
+			? ceil($this->getTotalItems() / $pageLength)
+			: min($this->getTotalItems(), 1);
 	}
 
 	/**
@@ -372,10 +381,13 @@ class PaginatedList extends SS_ListDecorator {
 	 * @return int
 	 */
 	public function LastItem() {
-		if ($start = $this->getPageStart()) {
-			return min($start + $this->getPageLength(), $this->getTotalItems());
+		$pageLength = $this->getPageLength();
+		if(!$pageLength) {
+			return $this->getTotalItems();
+		} elseif ($start = $this->getPageStart()) {
+			return min($start + $pageLength, $this->getTotalItems());
 		} else {
-			return min($this->getPageLength(), $this->getTotalItems());
+			return min($pageLength, $this->getTotalItems());
 		}
 	}
 

--- a/docs/en/02_Developer_Guides/01_Templates/How_Tos/02_Pagination.md
+++ b/docs/en/02_Developer_Guides/01_Templates/How_Tos/02_Pagination.md
@@ -88,6 +88,9 @@ when using custom lists.
 	$pages = new PaginatedList(Page::get(), $this->request);
 	$pages->setPageLength(25);
 
+If you set this limit to 0 it will disable paging entirely, effectively causing it to appear as a single page
+list.
+
 ## Template Variables
 
 | Variable | Description |

--- a/tests/model/PaginatedListTest.php
+++ b/tests/model/PaginatedListTest.php
@@ -64,6 +64,10 @@ class PaginatedListTest extends SapphireTest {
 
 		$this->assertEquals(10, $list->CurrentPage());
 		$this->assertEquals(90, $list->getPageStart());
+
+		// Test disabled paging
+		$list->setPageLength(0);
+		$this->assertEquals(1, $list->CurrentPage());
 	}
 
 	public function testGetIterator() {
@@ -93,6 +97,20 @@ class PaginatedListTest extends SapphireTest {
 		$list->setCurrentPage(999);
 		$this->assertDOSEquals(array(), $list->getIterator());
 
+		// Test disabled paging
+		$list->setPageLength(0);
+		$list->setCurrentPage(1);
+		$this->assertDOSEquals(
+			array(
+				array('Num' => 1),
+				array('Num' => 2),
+				array('Num' => 3),
+				array('Num' => 4),
+				array('Num' => 5)
+			), $list->getIterator()
+		);
+
+		// Test with dataobjectset
 		$players = DataObjectTest_Player::get();
 		$list = new PaginatedList($players);
 		$list->setPageLength(1);
@@ -127,6 +145,13 @@ class PaginatedListTest extends SapphireTest {
 			array('PageNum' => 4),
 		);
 		$this->assertDOSEquals($expectLimited, $list->Pages(3));
+
+		// Disable paging
+		$list->setPageLength(0);
+		$expectAll = array(
+			array('PageNum' => 1, 'CurrentBool' => true),
+		);
+		$this->assertDOSEquals($expectAll, $list->Pages());
 	}
 
 	public function testPaginationSummary() {
@@ -146,6 +171,13 @@ class PaginatedListTest extends SapphireTest {
 			array('PageNum' => 8),
 			array('PageNum' => null),
 			array('PageNum' => 25),
+		);
+		$this->assertDOSEquals($expect, $list->PaginationSummary(4));
+
+		// Disable paging
+		$list->setPageLength(0);
+		$expect = array(
+			array('PageNum' => 1, 'CurrentBool' => true)
 		);
 		$this->assertDOSEquals($expect, $list->PaginationSummary(4));
 	}
@@ -170,6 +202,10 @@ class PaginatedListTest extends SapphireTest {
 		$this->assertEquals(2, $list->CurrentPage());
 		$list->setPageStart(40);
 		$this->assertEquals(5, $list->CurrentPage());
+
+		// Disable paging
+		$list->setPageLength(0);
+		$this->assertEquals(1, $list->CurrentPage());
 	}
 
 	public function testTotalPages() {
@@ -183,6 +219,13 @@ class PaginatedListTest extends SapphireTest {
 
 		$list->setTotalItems(5);
 		$this->assertEquals(5, $list->TotalPages());
+
+		// Disable paging
+		$list->setPageLength(0);
+		$this->assertEquals(1, $list->TotalPages());
+
+		$list->setTotalItems(0);
+		$this->assertEquals(0, $list->TotalPages());
 	}
 
 	public function testMoreThanOnePage() {
@@ -194,6 +237,10 @@ class PaginatedListTest extends SapphireTest {
 
 		$list->setTotalItems(2);
 		$this->assertTrue($list->MoreThanOnePage());
+
+		// Disable paging
+		$list->setPageLength(0);
+		$this->assertFalse($list->MoreThanOnePage());
 	}
 
 	public function testNotFirstPage() {
@@ -230,6 +277,10 @@ class PaginatedListTest extends SapphireTest {
 		$this->assertEquals(20, $list->LastItem());
 		$list->setCurrentPage(3);
 		$this->assertEquals(25, $list->LastItem());
+
+		// Disable paging
+		$list->setPageLength(0);
+		$this->assertEquals(25, $list->LastItem());
 	}
 
 	public function testFirstLink() {
@@ -242,6 +293,10 @@ class PaginatedListTest extends SapphireTest {
 		$list->setPageLength(10);
 		$list->setTotalItems(100);
 		$this->assertContains('start=90', $list->LastLink());
+
+		// Disable paging
+		$list->setPageLength(0);
+		$this->assertContains('start=0', $list->LastLink());
 	}
 
 	public function testNextLink() {
@@ -257,6 +312,11 @@ class PaginatedListTest extends SapphireTest {
 		$this->assertContains('start=40', $list->NextLink());
 		$list->setCurrentPage(5);
 		$this->assertNull($list->NextLink());
+
+		// Disable paging
+		$list->setCurrentPage(1);
+		$list->setPageLength(0);
+		$this->assertNull($list->NextLink());
 	}
 
 	public function testPrevLink() {
@@ -270,6 +330,10 @@ class PaginatedListTest extends SapphireTest {
 		$this->assertContains('start=10', $list->PrevLink());
 		$list->setCurrentPage(5);
 		$this->assertContains('start=30', $list->PrevLink());
+
+		// Disable paging
+		$list->setPageLength(0);
+		$this->assertNull($list->PrevLink());
 	}
 
 }


### PR DESCRIPTION
Useful for cases where paging size could be set / disabled via CMS settings