### PR TITLE
BUG Fix serialised stateid exceeding request length

### DIFF
--- a/forms/gridfield/GridField.php
+++ b/forms/gridfield/GridField.php
@@ -840,7 +840,7 @@ class GridField_FormAction extends FormAction {
 			'args' => $this->args,
 		);
 
-		$id = md5(serialize($state));
+		$id = substr(md5(serialize($state)), 0, 8);
 		Session::set($id, $state);
 		$actionData['StateID'] = $id;
 		


### PR DESCRIPTION
cc @chillu 

For some reason it didn't work with `substr($str, 0,7)` but it's fine with 8 for some reason. :)