### PR TITLE
Fixes issue #3763; added findTab method to FieldList class

### DIFF
--- a/forms/FieldList.php
+++ b/forms/FieldList.php
@@ -270,12 +270,9 @@ class FieldList extends ArrayList {
 	 * @param string $tabName The tab to return, in the form "Tab.Subtab.Subsubtab".
 	 *   Caution: Does not recursively create TabSet instances, you need to make sure everything
 	 *   up until the last tab in the chain exists.
-	 * @param string $title Natural language title of the tab. If {@link $tabName} is passed in dot notation,
-	 *   the title parameter will only apply to the innermost referenced tab.
-	 *   The title is only changed if the tab doesn't exist already.
 	 * @return Tab The found or false if none found
 	 */
-	public function findTab($tabName, $title = null) {
+	public function findTab($tabName) {
 		// Backwards compatibility measure: Allow rewriting of outdated tab paths
 		$tabName = $this->rewriteTabPath($tabName);
 

--- a/forms/FieldList.php
+++ b/forms/FieldList.php
@@ -150,8 +150,9 @@ class FieldList extends ArrayList {
 
 		// Find the tab
 		$tab = $this->findTab($tabName);
-		if ($tab)
+		if ($tab) {
 			$tab->removeByName($fieldName);
+		}
 	}
 	
 	/**
@@ -166,11 +167,10 @@ class FieldList extends ArrayList {
 		// Find the tab
 		$tab = $this->findTab($tabName);
 		
-		if (!$tab)
-			return false;
-		
-		// Add the fields to the end of this set
-		foreach($fields as $field) $tab->removeByName($field);
+		// Remove the fields from the tab, if any found
+		if ($tab) {
+			foreach($fields as $field) $tab->removeByName($field);
+		}
 	}
 	
 	/**
@@ -279,7 +279,7 @@ class FieldList extends ArrayList {
 		// Backwards compatibility measure: Allow rewriting of outdated tab paths
 		$tabName = $this->rewriteTabPath($tabName);
 
-		$parts = explode('.',$tabName);
+		$parts = explode('.', $tabName);
 		$last_idx = count($parts) - 1;
 		// We could have made this recursive, but I've chosen to keep all the logic code within FieldList rather than
 		// add it to TabSet and Tab too.


### PR DESCRIPTION
When calling removeFieldFromTab() or removeFieldsFromTab() on FieldList class
if the tab did not exists it was created; as reported on issue#3763.