### PR TITLE
BUG Fix gridfield generating invalid session keys

### DIFF
--- a/forms/gridfield/GridField.php
+++ b/forms/gridfield/GridField.php
@@ -840,7 +840,8 @@ class GridField_FormAction extends FormAction {
 			'args' => $this->args,
 		);
 
-		$id = substr(md5(serialize($state)), 0, 8);
+		// Ensure $id doesn't contain only numeric characters
+		$id = 'gf_'.substr(md5(serialize($state)), 0, 8);
 		Session::set($id, $state);
 		$actionData['StateID'] = $id;
 		


### PR DESCRIPTION
The issue is that md5 could occasionally generate all-numeric keys which would fail on assignment. `$_SESSION` may not have numeric keys.