### PR TITLE
DOCS Update i18n language customisation docs

### DIFF
--- a/docs/en/02_Developer_Guides/13_i18n/index.md
+++ b/docs/en/02_Developer_Guides/13_i18n/index.md
@@ -95,7 +95,7 @@ Similarly, to change an existing language label, you can overwrite one of these 
 
 	:::yml
 	i18n:
-	  common_locales:
+	  common_languages:
 	    en_NZ:
 	      native: Niu Zillund
 


### PR DESCRIPTION
I could be wrong, but pretty sure it's meant to be common_languages instead of common_locales