### PR TITLE
Remove redundant config logic from DataObject::setField()

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -2323,7 +2323,6 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 				user_error('DataObject::setField: passed an object that is not a DBField', E_USER_WARNING);
 			}
 		
-			$defaults = $this->stat('defaults');
 			// if a field is not existing or has strictly changed
 			if(!isset($this->record[$fieldName]) || $this->record[$fieldName] !== $val) {
 				// TODO Add check for php-level defaults which are not set in the db


### PR DESCRIPTION
Noticed during testing for #3934 that this is one of the top accessed config values, yet it’s never used here so is just wasting time and memory :)