### PR TITLE
Performance improvements to ClassInfo::ancestry()

### DIFF
--- a/core/ClassInfo.php
+++ b/core/ClassInfo.php
@@ -157,15 +157,20 @@ class ClassInfo {
 		if (!is_string($class)) $class = get_class($class);
 
 		$cacheKey = $class . '_' . (string)$tablesOnly;
-		$parent = $class;
 		if(!isset(self::$_cache_ancestry[$cacheKey])) {
-			$ancestry = array();
-			do {
-				if (!$tablesOnly || DataObject::has_own_table($parent)) {
-					$ancestry[$parent] = $parent;
+			// Create an array containing this class and all parent classes
+			$ancestry = array($class => $class) + class_parents($class);
+			
+			// If we only want classes with a table in the db, filter out those that don't have one
+			if($tablesOnly) {
+				foreach($ancestry as $parent) {
+					if(!DataObject::has_own_table($parent)) {
+						unset($ancestry[$parent]);
+					}
 				}
-			} while ($parent = get_parent_class($parent));
-			self::$_cache_ancestry[$cacheKey] = array_reverse($ancestry);
+			}
+			
+			self::$_cache_ancestry[$cacheKey] = array_reverse($ancestry);	
 		}
 
 		return self::$_cache_ancestry[$cacheKey];


### PR DESCRIPTION
Basically just switching from `get_parent_class()` in a loop to using `class_parents()` instead. Not a massive performance increase, but every little helps :)

Benchmarks on PHP 5.5.18, completely blank install of CMS + Framework only, loading home page. Aggregate of 10 runs each:

Before:
![screen shot 2015-03-10 at 13 45 37](https://cloud.githubusercontent.com/assets/1655548/6576016/ca905efe-c72b-11e4-8af3-16a79bfcfb24.png)

After:
![screen shot 2015-03-10 at 13 45 44](https://cloud.githubusercontent.com/assets/1655548/6576020/cdfa32a4-c72b-11e4-83e2-c6d977583b34.png)
