### PR TITLE
FIX: broken link in docs to how_tos/extend_cms_interface

### DIFF
--- a/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/05_CMS_Architecture.md
+++ b/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/05_CMS_Architecture.md
@@ -13,7 +13,7 @@ feel familiar to you. This is just a quick run down to get you started
 with some special conventions.
 
 For a more practical-oriented approach to CMS customizations, refer to the
-[Howto: Extend the CMS Interface](../how_tos/extend_cms_interface) which builds
+[Howto: Extend the CMS Interface](how_tos/extend_cms_interface) which builds
 
 
 ## Markup and Style Conventions


### PR DESCRIPTION
I'm not certain this fixes the issue, as I haven't tested it. It at least points it out.