### PR TITLE
[DO NOT MERGE] API Removed SS_ConfigStaticManifest in favour of Reflection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		}
 	},
 	"autoload": {
-		"classmap": ["tests/behat/features/bootstrap"]	
+		"classmap": ["tests/behat/features/bootstrap"]
 	},
 	"minimum-stability": "dev"
 }

--- a/control/Director.php
+++ b/control/Director.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Director is responsible for processing URLs, and providing environment information.
  *

--- a/core/Core.php
+++ b/core/Core.php
@@ -74,13 +74,13 @@ require_once 'filesystem/FileFinder.php';
 require_once 'core/manifest/ManifestCache.php';
 require_once 'core/manifest/ClassLoader.php';
 require_once 'core/manifest/ConfigManifest.php';
-require_once 'core/manifest/ConfigStaticManifest.php';
 require_once 'core/manifest/ClassManifest.php';
 require_once 'core/manifest/ManifestFileFinder.php';
 require_once 'core/manifest/TemplateLoader.php';
 require_once 'core/manifest/TemplateManifest.php';
 require_once 'core/manifest/TokenisedRegularExpression.php';
 require_once 'control/injector/Injector.php';
+
 
 // Initialise the dependency injector as soon as possible, as it is
 // subsequently used by some of the following code
@@ -110,10 +110,6 @@ $loader->pushManifest($manifest);
 if(file_exists(BASE_PATH . '/vendor/autoload.php')) {
 	require_once BASE_PATH . '/vendor/autoload.php';
 }
-
-// Now that the class manifest is up, load the static configuration
-$configManifest = new SS_ConfigStaticManifest(BASE_PATH, false, $flush);
-Config::inst()->pushConfigStaticManifest($configManifest);
 
 // And then the yaml configuration
 $configManifest = new SS_ConfigManifest(BASE_PATH, false, $flush);

--- a/core/Object.php
+++ b/core/Object.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * A base class for all SilverStripe objects to inherit from.
  *
@@ -588,6 +589,7 @@ abstract class Object {
 						"add_to_class deprecated on $extensionClass. Use get_extra_config instead");
 				}
 
+				// @todo Remove in 4.0
 				call_user_func(array($extensionClass, 'add_to_class'), $class, $extensionClass, $extensionArgs);
 
 				foreach(array_reverse(ClassInfo::ancestry($extensionClass)) as $extensionClassParent) {

--- a/model/DataList.php
+++ b/model/DataList.php
@@ -51,9 +51,8 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 	 * @param string $dataClass - The DataObject class to query.
 	 */
 	public function __construct($dataClass) {
-		$this->dataClass = $dataClass;
+		$this->dataClass = get_class(singleton($dataClass)); // avoid cast-sensitivity issues
 		$this->dataQuery = new DataQuery($this->dataClass);
-
 		parent::__construct();
 	}
 

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1927,7 +1927,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 						}
 					}
 				}
-
+				
 				$manyMany = $SNG_class->stat('belongs_many_many');
 				$candidate = (isset($manyMany[$component])) ? $manyMany[$component] : null;
 				if($candidate) {
@@ -1962,7 +1962,6 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 						);
 					}
 				}
-
 				return isset($items) ? array_merge($newItems, $items) : $newItems;
 			}
 		}
@@ -2995,6 +2994,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	 */
 	public static function get_one($callerClass, $filter = "", $cache = true, $orderby = "") {
 		$SNG = singleton($callerClass);
+		$callerClass = get_class($SNG); // avoid case-sensitivity issues
 
 		$cacheComponents = array($filter, $orderby, $SNG->extend('cacheKeyComponent'));
 		$cacheKey = md5(var_export($cacheComponents, true));

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -225,6 +225,18 @@ class DataObjectTest extends SapphireTest {
 		), true);
 		$this->assertNotEmpty($subteam1);
 		$this->assertEquals($subteam1->Title, "Subteam 1");
+
+		$subteam1 = DataObject::get('dataobjecttest_subteam')
+			->filter('Title', 'Subteam 1')
+			->first();
+		$this->assertNotEmpty($subteam1);
+		$this->assertEquals($subteam1->Title, "Subteam 1");
+
+		$subteam1 = dataobjecttest_subteam::get()
+			->filter('Title', 'Subteam 1')
+			->first();
+		$this->assertNotEmpty($subteam1);
+		$this->assertEquals($subteam1->Title, "Subteam 1");
 	}
 
 	public function testGetSubclassFields() {


### PR DESCRIPTION
Apologies for the "do not merge", but this is the best way to show a diff and include as many people as possible.

Anyway, i'm hoping that this PR is the start of a discussion to remove SS_ConfigStaticManifest and its flush process.

Instead of collecting private statics through parsing PHP files during the flush process, this PR uses Reflection to get private static config values at run-time when they're requested. This doesn't remove or affect YAML configuration in any way.

Initial performance tests show a small speed increase and ~0.6mb memory saving:

Before:

	Parameter			Min.		Max.		Avg.
	CPU Time			85.104 ms	180.61 ms	94.278 ms
	Memory Usage		9.97 M		10 M		9.98 M
	Peak Memory Usage	10.07 M		10.1 M		10.07 M
	Dataset Size		50

After:

	Parameter			Min.		Max.		Avg.
	CPU Time			85.052 ms	181.952 ms	92.791 ms
	Memory Usage		9.35 M		9.38 M		9.36 M
	Peak Memory Usage	9.34 M		9.49 M		9.46 M
	Dataset Size		50

These were ran using php 5.5.

This is only a proof of concept, but if nobody raises any issues with this method i'll turn this into a proper PR. Feedback welcome.