### PR TITLE
FIX GridFieldDetailForm::setItemEditFormCalback broke chaining

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -188,6 +188,7 @@ class GridFieldDetailForm implements GridField_URLHandler {
 	 */
 	public function setItemEditFormCallback(Closure $cb) {
 		$this->itemEditFormCallback = $cb;
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
This is an inconsistent API!

This is a bug as `set` methods should return `$this`