### PR TITLE
API CHANGE: Public visibility on DataQuery::selectField

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -789,7 +789,7 @@ class DataQuery {
 	 * @param $fieldExpression String The field to select (escaped SQL statement)
 	 * @param $alias String The alias of that field (escaped SQL statement)
 	 */
-	protected function selectField($fieldExpression, $alias = null) {
+	public function selectField($fieldExpression, $alias = null) {
 		$this->query->selectField($fieldExpression, $alias);
 	}
 


### PR DESCRIPTION
It doesn't seem appropriate to hide this method from the public space. It precludes the user from customising queries in a DataList.

```php
$mylist->alterDataquery(function($query) {
    $query->selectField("225,300,000km", "DistanceToMars");
});
```