### PR TITLE
BUG Check for existence of HTTP_USER_AGENT to avoid E_NOTICE error.

### DIFF
--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -361,7 +361,8 @@ class HTTP {
 			if(
 				$body &&
 				Director::is_https() &&
-				strstr($_SERVER["HTTP_USER_AGENT"], 'MSIE')==true &&
+				isset($_SERVER['HTTP_USER_AGENT']) &&
+				strstr($_SERVER['HTTP_USER_AGENT'], 'MSIE')==true &&
 				strstr($contentDisposition, 'attachment;')==true
 			) {
 				// IE6-IE8 have problems saving files when https and no-cache are used


### PR DESCRIPTION
In some cases, a request may not have an HTTP_USER_AGENT. This should
check the variable exists before attempting to check it. The specific
case where it failed for me was Active Directory Federation Services
sending a web request to a SilverStripe site, but failing because it
doesn't have an agent string.