### PR TITLE
Hardcoded http:// cause browser warnings in admin panel 

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -76,7 +76,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 	 * @config
 	 * @var string
 	 */
-	private static $help_link = 'http://userhelp.silverstripe.org/framework/en/3.1';
+	private static $help_link = '//userhelp.silverstripe.org/framework/en/3.1';
 
 	/**
 	 * @var array
@@ -1595,7 +1595,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 	 * @config
 	 * @var String
 	 */
-	private static $application_link = 'http://www.silverstripe.org/';
+	private static $application_link = '//www.silverstripe.org/';
 	
 	/**
 	 * Sets the href for the anchor on the Silverstripe logo in the menu


### PR DESCRIPTION
Two links Help button (http://userhelp.silverstripe.org/framework/en/3.1) and logo (http://www.silverstripe.org/) are hardcoded with protcol defined in admin/code/LeftAndMain.php
private static $application_link = 'http://www.silverstripe.org/';
private static $help_link = 'http://userhelp.silverstripe.org/framework/en/3.1';
Many use https for the admin panel and some browsers (Internet explorer all versions) popup and say connection is not secure. 
In fact, it is nothing but it scares people. 
Changed http:// to //: in both links. 
