### PR TITLE
API Security better respects BackURL on login

### DIFF
--- a/tests/security/MemberTest.yml
+++ b/tests/security/MemberTest.yml
@@ -1,78 +1,78 @@
 Permission:
-   admin:
-      Code: ADMIN
-   security-admin:
-      Code: CMS_ACCESS_SecurityAdmin
+  admin:
+    Code: ADMIN
+  security-admin:
+    Code: CMS_ACCESS_SecurityAdmin
 Group:
-   admingroup:
-      Title: Admin
-      Code: admin
-      Permissions: =>Permission.admin
-   securityadminsgroup:
-      Title: securityadminsgroup
-      Code: securityadminsgroup
-      Permissions: =>Permission.security-admin
-   staffgroup:
-      Title: staffgroup
-      Code: staffgroup
-   managementgroup:
-      Title: managementgroup
-      Code: managementgroup
-      Parent: =>Group.staffgroup
-   accountinggroup:
-      Title: accountinggroup
-      Code: accountinggroup
-      Parent: =>Group.staffgroup
-   ceogroup:
-      Title: ceogroup
-      Code: ceogroup
-      Parent: =>Group.managementgroup 
-   memberlessgroup:
-      Title: Memberless Group
-      code: memberless
+  admingroup:
+    Title: Admin
+    Code: admin
+    Permissions: =>Permission.admin
+  securityadminsgroup:
+    Title: securityadminsgroup
+    Code: securityadminsgroup
+    Permissions: =>Permission.security-admin
+  staffgroup:
+    Title: staffgroup
+    Code: staffgroup
+  managementgroup:
+    Title: managementgroup
+    Code: managementgroup
+    Parent: =>Group.staffgroup
+  accountinggroup:
+    Title: accountinggroup
+    Code: accountinggroup
+    Parent: =>Group.staffgroup
+  ceogroup:
+    Title: ceogroup
+    Code: ceogroup
+    Parent: =>Group.managementgroup 
+  memberlessgroup:
+    Title: Memberless Group
+    code: memberless
 Member:
-   admin:
-     FirstName: Admin
-     Email: admin@silverstripe.com
-     Groups: =>Group.admingroup
-   other-admin:
-     FirstName: OtherAdmin
-     Email: other-admin@silverstripe.com
-     Groups: =>Group.admingroup
-   test:
-      FirstName: Test
-      Surname: User
-      Email: sam@silverstripe.com
-      Password: 1nitialPassword
-      PasswordExpiry: 2030-01-01
-      Groups: =>Group.securityadminsgroup
-   expiredpassword:
-      FirstName: Test
-      Surname: User
-      Email: expired@silverstripe.com
-      Password: 1nitialPassword
-      PasswordExpiry: 2006-01-01
-   noexpiry:
-      FirstName: Test
-      Surname: User
-      Email: noexpiry@silverstripe.com
-      Password: 1nitialPassword
-   staffmember:
-      Email: staffmember@test.com
-      Groups: =>Group.staffgroup
-   managementmember:
-      Email: managementmember@test.com
-      Groups: =>Group.managementgroup
-   accountingmember:
-      Email: accountingmember@test.com
-      Groups: =>Group.accountinggroup
-   ceomember:
-      Email: ceomember@test.com
-      Groups: =>Group.ceogroup
-   grouplessmember: 
-      FirstName: Groupless Member
-   noformatmember:
-      Email: noformat@test.com
-   delocalemember:
-      Email: delocalemember@test.com
-      Locale: de_DE
+  admin:
+    FirstName: Admin
+    Email: admin@silverstripe.com
+    Groups: =>Group.admingroup
+  other-admin:
+    FirstName: OtherAdmin
+    Email: other-admin@silverstripe.com
+    Groups: =>Group.admingroup
+  test:
+    FirstName: Test
+    Surname: User
+    Email: sam@silverstripe.com
+    Password: 1nitialPassword
+    PasswordExpiry: 2030-01-01
+    Groups: =>Group.securityadminsgroup
+  expiredpassword:
+    FirstName: Test
+    Surname: User
+    Email: expired@silverstripe.com
+    Password: 1nitialPassword
+    PasswordExpiry: 2006-01-01
+  noexpiry:
+    FirstName: Test
+    Surname: User
+    Email: noexpiry@silverstripe.com
+    Password: 1nitialPassword
+  staffmember:
+    Email: staffmember@test.com
+    Groups: =>Group.staffgroup
+  managementmember:
+    Email: managementmember@test.com
+    Groups: =>Group.managementgroup
+  accountingmember:
+    Email: accountingmember@test.com
+    Groups: =>Group.accountinggroup
+  ceomember:
+    Email: ceomember@test.com
+    Groups: =>Group.ceogroup
+  grouplessmember: 
+    FirstName: Groupless Member
+  noformatmember:
+    Email: noformat@test.com
+  delocalemember:
+    Email: delocalemember@test.com
+    Locale: de_DE


### PR DESCRIPTION
Also restore missing authentication message not appearing in the login form $Content area (regression from #1807)