### PR TITLE
FIX Files should only report as "existing" if the file actually exists

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -222,8 +222,17 @@ class File extends DataObject {
 	}
 
 	/**
-	 * Find a File object by the given filename.
+	 * A file only exists if the file_exists() and is in the DB as a record
 	 * 
+	 * @return bool
+	 */
+	public function exists() {
+		return parent::exists() && file_exists($this->getFullPath());
+	}
+
+	/**
+	 * Find a File object by the given filename.
+	 *
 	 * @param String $filename Matched against the "Name" property.
 	 * @return mixed null if not found, File object of found file
 	 */
@@ -272,7 +281,7 @@ class File extends DataObject {
 		// ensure that the record is synced with the filesystem before deleting
 		$this->updateFilesystem();
 
-		if($this->Filename && $this->Name && file_exists($this->getFullPath()) && !is_dir($this->getFullPath())) {
+		if($this->exists() && !is_dir($this->getFullPath())) {
 			unlink($this->getFullPath());
 		}
 	}

--- a/model/Image.php
+++ b/model/Image.php
@@ -123,25 +123,13 @@ class Image extends File implements Flushable {
 	}
 
 	/**
-	 * An image exists if it has a filename.
-	 * Does not do any filesystem checks.
-	 * 
-	 * @return boolean
-	 */
-	public function exists() {
-		if(isset($this->record["Filename"])) {
-			return true;
-		}		
-	}
-	
-	/**
 	 * Return an XHTML img tag for this Image,
 	 * or NULL if the image file doesn't exist on the filesystem.
 	 * 
 	 * @return string
 	 */
 	public function getTag() {
-		if(file_exists(Director::baseFolder() . '/' . $this->Filename)) {
+		if($this->exists()) {
 			$url = $this->getURL();
 			$title = ($this->Title) ? $this->Title : $this->Filename;
 			if($this->Title) {
@@ -618,8 +606,8 @@ class Image extends File implements Flushable {
 	public function getDimensions($dim = "string") {
 		if($this->getField('Filename')) {
 
-			$imagefile = Director::baseFolder() . '/' . $this->getField('Filename');
-			if(file_exists($imagefile)) {
+			$imagefile = $this->getFullPath();
+			if($this->exists()) {
 				$size = getimagesize($imagefile);
 				return ($dim === "string") ? "$size[0]x$size[1]" : $size[$dim];
 			} else {


### PR DESCRIPTION
This fixes an issue where images and files that have models in the DB but no actual file on the filesystem still report as existing.

Fixes this case where there would be no output:

```html
<% if $Image %>
    $image
<% else %>
   <img src="holder.jpg"/>
<% end_if %>
```