### PR TITLE
removed unnecessary write() from Member::logIn()

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -472,8 +472,6 @@ class Member extends DataObject implements TemplateGlobalProvider {
 
 		$this->regenerateTempID();
 
-		$this->write();
-
 		// Audit logging hook
 		$this->extend('memberLoggedIn');
 	}


### PR DESCRIPTION
$this->write() is already called in regenerateTempID()