### PR TITLE
Move iframe load handler to separate method

### DIFF
--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -416,7 +416,7 @@
 				return false;
 			} 
 		});
-		$( 'div.ss-upload:not(.disabled):not(.readonly) .ss-uploadfield-item-edit').entwine({
+		$( 'div.ss-upload:not(.disabled):not(.readonly) .ss-uploadfield-item-edit, .ss-assetuploadfield .ss-uploadfield-item-edit').entwine({
 			onclick: function(e) {
 				var self = this,
 					editform = self.closest('.ss-uploadfield-item').find('.ss-uploadfield-item-editform'),
@@ -426,8 +426,19 @@
 				// Ignore clicks while the iframe is loading
 				if (iframe.parent().hasClass('loading')) {
 					e.preventDefault();
+
 					return false;
 				}
+
+				this._loadIframe();
+
+				e.preventDefault(); // Avoid a form submit
+			},
+			_loadIframe: function() {
+				var self = this,
+					editform = self.closest('.ss-uploadfield-item').find('.ss-uploadfield-item-editform'),
+					itemInfo = editform.prev('.ss-uploadfield-item-info'),
+					iframe = editform.find('iframe');
 
 				if (iframe.attr('src') == 'about:blank') {
 					// Lazy-load the iframe on editform toggle
@@ -439,7 +450,6 @@
 					disabled=this.siblings();
 					disabled.addClass('ui-state-disabled');
 					disabled.attr('disabled', 'disabled');
-
 					iframe.on('load', function() {
 						iframe.parent().removeClass('loading');
 
@@ -454,7 +464,6 @@
 					self._prepareIframe(iframe, editform, itemInfo);
 				}
 
-				e.preventDefault(); // Avoid a form submit
 				return false;
 			},
 			_prepareIframe: function(iframe, editform, itemInfo) {

--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -416,7 +416,7 @@
 				return false;
 			} 
 		});
-		$( 'div.ss-upload:not(.disabled):not(.readonly) .ss-uploadfield-item-edit, .ss-assetuploadfield .ss-uploadfield-item-edit').entwine({
+		$( 'div.ss-upload:not(.disabled):not(.readonly) .ss-uploadfield-item-edit, .ss-assetuploadfield:not(.disabled):not(.readonly) .ss-uploadfield-item-edit').entwine({
 			onclick: function(e) {
 				var self = this,
 					editform = self.closest('.ss-uploadfield-item').find('.ss-uploadfield-item-editform'),
@@ -452,7 +452,8 @@
 					disabled.attr('disabled', 'disabled');
 					iframe.on('load', function() {
 						iframe.parent().removeClass('loading');
-
+						editform.fitHeight();
+						
 						// This ensures we only call _prepareIframe() on load once - otherwise it'll
 						// be superfluously called after clicking 'save' in the editform
 						if (iframe.data('src')) {
@@ -504,7 +505,7 @@
 
 
 
-		$('div.ss-upload .ss-uploadfield-item-editform').entwine({
+		$('.ss-uploadfield-item-editform').entwine({
 			fitHeight: function() {
 				var iframe = this.find('iframe'),
 					contents = iframe.contents().find('body'),


### PR DESCRIPTION
When using the DMS module linking to an existing document the edit iframe would fail to remove the loading icon. This change makes it possible for DMS javascript to manually call the iframe load logic.
