### PR TITLE
Improve SQL Format information paragraph

### DIFF
--- a/docs/en/00_Getting_Started/05_Coding_Conventions.md
+++ b/docs/en/00_Getting_Started/05_Coding_Conventions.md
@@ -431,7 +431,7 @@ Put code into the classes in the following order (where applicable).
 
 ### SQL Format
 
-If you have to use raw SQL, make sure your code works across databases make sure you escape your queries like below, 
+If you have to use raw SQL, make sure your code works across databases. Make sure you escape your queries like below, 
 with the column or table name escaped with double quotes and values with single quotes.
 
 	:::php


### PR DESCRIPTION
Improve SQL Format information paragraph in the SilverStripe Coding Conventions. It just looked like some missing punctuation was missed when written.