### PR TITLE
Adding loading spinner to ui-autocomplete fields when making ajax reqests

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -140,6 +140,7 @@ body, html { font-size: 12px; line-height: 16px; font-family: Arial, sans-serif;
 .ui-accordion .ui-accordion-content { border: 1px solid #c0c0c2; border-top: none; }
 
 .ui-autocomplete { max-height: 240px; overflow-x: hidden; overflow-y: auto; }
+.ui-autocomplete-loading { background-image: url(../images/throbber.gif) !important; background-position: 97% center !important; background-repeat: no-repeat !important; background-size: auto !important; }
 
 /** This file defines common styles for form elements used throughout the CMS interface. It is an addition to the base styles defined in framework/css/Form.css.  @package framework @subpackage admin */
 /** ---------------------------------------------------- Basic form fields ---------------------------------------------------- */

--- a/admin/scss/_uitheme.scss
+++ b/admin/scss/_uitheme.scss
@@ -85,8 +85,16 @@
 	}
 }
 
-.ui-autocomplete{
+.ui-autocomplete {
 	max-height: 240px;
 	overflow-x: hidden;
 	overflow-y: auto;
+
+	/** sorry about the !important but the specificity of other selectors mandates it over writing out very specific selectors **/
+	&-loading {
+		background-image: url(../images/throbber.gif) !important;
+		background-position: 97% center !important;
+		background-repeat: no-repeat !important;
+		background-size: auto !important;
+	}
 }


### PR DESCRIPTION
This change now makes it apparent to the use when "work" is still being done and we are waiting for a response.

A nice bit of UI feedback.

![loader](https://dl.dropbox.com/u/3429338/Clippings/2015-04/2015-04-17_11-38-40_Zn7wT2QjcJ.png)