### PR TITLE
Allow empty has_one returns in DataDifferencer

### DIFF
--- a/model/DataDifferencer.php
+++ b/model/DataDifferencer.php
@@ -116,7 +116,11 @@ class DataDifferencer extends ViewableData {
 			$toTitle = '';
 			if($this->toRecord->hasMethod($relName)) {
 				$relObjTo = $this->toRecord->$relName();
-				$toTitle = $relObjTo->hasMethod('Title') || $relObjTo->hasField('Title') ? $relObjTo->Title : '';
+				if($relObjTo) {
+					$toTitle = ($relObjTo->hasMethod('Title') || $relObjTo->hasField('Title')) ? $relObjTo->Title : '';
+				} else {
+					$toTitle = '';
+				}
 			}
 
 			if(!$this->fromRecord) {
@@ -134,7 +138,12 @@ class DataDifferencer extends ViewableData {
 				$fromTitle = '';
 				if($this->fromRecord->hasMethod($relName)) {
 					$relObjFrom = $this->fromRecord->$relName();
-					$fromTitle = $relObjFrom->hasMethod('Title') || $relObjFrom->hasField('Title') ? $relObjFrom->Title : '';
+					if($relObjFrom) {
+						$fromTitle = ($relObjFrom->hasMethod('Title') || $relObjFrom->hasField('Title')) ? $relObjFrom->Title : '';	
+					} else {
+						$fromTitle = '';
+					}
+					
 				}
 				if(isset($relObjFrom) && $relObjFrom instanceof Image) {
 					// TODO Use CMSThumbnail (see above)


### PR DESCRIPTION
Sometimes the has_one getter is incorrectly implemented,
resulting in an empty return object. While that's technically
a core API validation, there's no checks around it (i.e. no PHP class interface).
DataDifferencer has the option to continue here, so we should
program it defensively rather than resulting in a fatal error.