### PR TITLE
BUG Fix users with all cms section access not able to edit files

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -305,7 +305,7 @@ class File extends DataObject {
 		$result = $this->extendedCan('canEdit', $member);
 		if($result !== null) return $result;
 		
-		return Permission::checkMember($member, 'CMS_ACCESS_AssetAdmin');
+		return Permission::checkMember($member, array('CMS_ACCESS_AssetAdmin', 'CMS_ACCESS_LeftAndMain'));
 	}
 	
 	/**

--- a/tests/filesystem/FileTest.php
+++ b/tests/filesystem/FileTest.php
@@ -393,9 +393,13 @@ class FileTest extends SapphireTest {
 		$this->objFromFixture('Member', 'frontend')->logIn();
 		$this->assertFalse($file->canEdit(), "Permissionless users can't edit files");
 
-		// Test cms non-asset user
+		// Test global CMS section users
 		$this->objFromFixture('Member', 'cms')->logIn();
-		$this->assertFalse($file->canEdit(), "Basic CMS users can't edit files");
+		$this->assertTrue($file->canEdit(), "Users with all CMS section access can edit files");
+
+		// Test cms access users without file access
+		$this->objFromFixture('Member', 'security')->logIn();
+		$this->assertFalse($file->canEdit(), "Security CMS users can't edit files");
 
 		// Test asset-admin user
 		$this->objFromFixture('Member', 'assetadmin')->logIn();

--- a/tests/filesystem/FileTest.yml
+++ b/tests/filesystem/FileTest.yml
@@ -35,6 +35,8 @@ Permission:
     Code: CMS_ACCESS_LeftAndMain
   assetadmin:
     Code: CMS_ACCESS_AssetAdmin
+  securityadmin:
+    Code: CMS_ACCESS_SecurityAdmin
 Group:
   admins:
     Title: Administrators
@@ -42,9 +44,12 @@ Group:
   cmsusers:
     Title: 'CMS Users'
     Permissions: =>Permission.cmsmain
+  securityusers:
+    Title: 'Security Users'
+    Permissions: =>Permission.securityadmin
   assetusers:
     Title: 'Asset Users'
-    Permissions: =>Permission.cmsmain, =>Permission.assetadmin
+    Permissions: =>Permission.assetadmin
 Member:
   frontend:
     Email: frontend@example.com
@@ -57,3 +62,6 @@ Member:
   assetadmin:
     Email: assetadmin@silverstripe.com
     Groups: =>Group.assetusers
+  security:
+    Email: security@silverstripe.com
+    Groups: =>Group.securityusers


### PR DESCRIPTION
Fixes #4078 

If a user has "all cms section" access they should be able to edit files.