### PR TITLE
BUG Content-Disposition header breaks in Firefox

### DIFF
--- a/control/HTTPRequest.php
+++ b/control/HTTPRequest.php
@@ -395,7 +395,7 @@ class SS_HTTPRequest implements ArrayAccess {
 		$response = new SS_HTTPResponse($fileData);
 		$response->addHeader("Content-Type", "$mimeType; name=\"" . addslashes($fileName) . "\"");
 		// Note a IE-only fix that inspects this header in HTTP::add_cache_headers().
-		$response->addHeader("Content-Disposition", "attachment; filename=" . addslashes($fileName));
+		$response->addHeader("Content-Disposition", "attachment; filename=\"" . addslashes($fileName) . "\"");
 		$response->addHeader("Content-Length", strlen($fileData));
 		
 		return $response;


### PR DESCRIPTION
There is an issue with ```SS_HTTPRequest::send_file()``` when the filename variable contains spaces and the client is using Firefox.

The issue is described in the links below:

http://kb.mozillazine.org/Filenames_with_spaces_are_truncated_upon_download
http://php.net/manual/en/function.header.php#87449
http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1

The fix is just to surround the filename in quotes.