### PR TITLE
FIX: Object::parse_class_spec failed to parse associative arrays

### DIFF
--- a/tests/core/ObjectTest.php
+++ b/tests/core/ObjectTest.php
@@ -417,7 +417,7 @@ class ObjectTest extends SapphireTest {
 		// 5.4 Shorthand Array
 		$this->assertEquals(
 			array('Enum',array(array('Accepted', 'Pending', 'Declined', 'Unsubmitted'), 'Unsubmitted')),
-			Object::parse_class_spec("Enum(['Accepted', 'Pending', 'Declined', 'Unsubmitted'), 'Unsubmitted']")
+			Object::parse_class_spec("Enum(['Accepted', 'Pending', 'Declined', 'Unsubmitted'], 'Unsubmitted')")
 		);
 		// 5.4 Nested shorthand array
 		$this->assertEquals(
@@ -426,6 +426,13 @@ class ObjectTest extends SapphireTest {
 			Object::parse_class_spec(
 				"Enum(['Accepted', 'Pending', 'Declined', ['UnsubmittedA','UnsubmittedB']], 'Unsubmitted')")
 		);
+
+		// Associative array
+		$this->assertEquals(
+			array('Varchar', array(255, array('nullifyEmpty' => false))),
+			Object::parse_class_spec("Varchar(255, array('nullifyEmpty' => false))")
+		);
+
 		// Namespaced class
 		$this->assertEquals(
 			array('Test\MyClass', array()),


### PR DESCRIPTION
Submitted to 3.1 as this enables a documented ability of the framework - [configuring database field options](https://github.com/silverstripe/silverstripe-framework/blob/d5361dedecee991e37b6563918de0aa32c6d0f21/model/fieldtypes/StringField.php#L31). I.e:

```php
private static $db = array(
	'MyField' => 'Varchar(255, array("nullifyEmpty" => false))'
);
```