### PR TITLE
BUG Fix tinymce errors crashing CMS

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -293,8 +293,15 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 			onremove: function() {
 				var ed = tinyMCE.get(this.attr('id'));
 				if (ed) {
-					ed.remove();
-					ed.destroy();
+					try {
+						ed.remove();
+					} catch(ex) {}
+					try {
+						ed.destroy();
+					} catch(ex) {}
+					
+					// Remove any residual tinyMCE editor element
+					this.next('.mceEditor').remove();
 
 					// TinyMCE leaves behind events. We should really fix TinyMCE, but lets brute force it for now
 					$.each(jQuery.cache, function(){


### PR DESCRIPTION
When removing a tinymce field, internal third party errors should be caught and ignored gracefully rather than breaking the whole CMS.

Fixes https://github.com/silverstripe-labs/silverstripe-content-widget/issues/2