### PR TITLE
FIX use config for Security::$login_url

### DIFF
--- a/security/Security.php
+++ b/security/Security.php
@@ -1047,7 +1047,8 @@ class Security extends Controller {
 	 * Set a custom log-in URL if you have built your own log-in page.
 	 */
 	public static function set_login_url($loginUrl) {
-		self::$login_url = $loginUrl;
+		Deprecation::notice('3.1', 'Use the "Security.login_url" config setting instead');
+		static::config()->update('login_url', $loginUrl);
 	}
 
 	/**
@@ -1055,7 +1056,7 @@ class Security extends Controller {
 	 * Defaults to Security/login but can be re-set with {@link set_login_url()}
 	 */
 	public static function login_url() {
-		return self::$login_url;
+		return static::config()->get('login_url');
 	}
 
 }


### PR DESCRIPTION
Currently the config settings are ingnored wen setting the `login_url` on `Security`, this fixes that problem