### PR TITLE
NEW Added Youtube's short URL.

### DIFF
--- a/_config/Oembed.yml
+++ b/_config/Oembed.yml
@@ -8,6 +8,12 @@ Oembed:
     'https://*.youtube.com/watch*':
       http: 'http://www.youtube.com/oembed/',
       https: 'https://www.youtube.com/oembed/?scheme=https'
+    'http://*.youtu.be/*':
+      http: 'http://www.youtube.com/oembed/',
+      https: 'https://www.youtube.com/oembed/?scheme=https'
+    'https://youtu.be/*':
+      http: 'http://www.youtube.com/oembed/',
+      https: 'https://www.youtube.com/oembed/?scheme=https'
     'http://*.flickr.com/*':
       'http://www.flickr.com/services/oembed/'
     'http://*.viddler.com/*':


### PR DESCRIPTION
At the moment using the short URL (eg. https://youtu.be/qA0T8WumxT4) defaults to http. This introduces issue when running over https.