### PR TITLE
Update 04_GridField.md docs for typo

### DIFF
--- a/docs/en/02_Developer_Guides/03_Forms/Field_types/04_GridField.md
+++ b/docs/en/02_Developer_Guides/03_Forms/Field_types/04_GridField.md
@@ -71,7 +71,7 @@ the `getConfig()` method on `GridField`.
 			);
 
 			// GridField configuration
-			$config = $gridField->getConfig();
+			$config = $grid->getConfig();
 
 			//
 			// Modification of existing components can be done by fetching that component.


### PR DESCRIPTION
Variable name should be $grid, as defined when creating the GridField just above.  Thanks.