### PR TITLE
Fix/Performance: Combine multiple queries into one for ManyManyList::getExtraData

### DIFF
--- a/model/ManyManyList.php
+++ b/model/ManyManyList.php
@@ -362,17 +362,21 @@ class ManyManyList extends RelationList {
 			user_error('ComponentSet::getExtraData() passed a non-numeric child ID', E_USER_ERROR);
 		}
 
-		// @todo Optimize into a single query instead of one per extra field
 		if($this->extraFields) {
-			foreach($this->extraFields as $fieldName => $dbFieldSpec) {
-				$query = new SQLQuery("\"{$fieldName}\"", "\"{$this->joinTable}\"");
-				if($filter = $this->foreignIDWriteFilter($this->getForeignID())) {
-					$query->setWhere($filter);
-				} else {
-					user_error("Can't call ManyManyList::getExtraData() until a foreign ID is set", E_USER_WARNING);
-				}
-				$query->addWhere("\"{$this->localKey}\" = {$itemID}");
-				$result[$fieldName] = $query->execute()->value();
+			$cleanExtraFields = array();
+			foreach ($this->extraFields as $fieldName => $dbFieldSpec) {
+				$cleanExtraFields[] = "\"{$fieldName}\"";
+			}
+			$query = new SQLQuery($cleanExtraFields, "\"{$this->joinTable}\"");
+			if($filter = $this->foreignIDWriteFilter($this->getForeignID())) {
+				$query->setWhere($filter);
+			} else {
+				user_error("Can't call ManyManyList::getExtraData() until a foreign ID is set", E_USER_WARNING);
+			}
+			$query->addWhere("\"{$this->localKey}\" = {$itemID}");
+			$queryResult = $query->execute()->current();
+			foreach ($queryResult as $fieldName => $value) {
+				$result[$fieldName] = $value;
 			}
 		}
 


### PR DESCRIPTION
Previously when calling `getExtraData`, it would take an individual query per extra field to get the data. This PR adjusts that to combine each field into the single query. Beyond passing an array to the `SQLQuery` and looping over the columns in the result, the functionality hasn't changed.

`GridFieldDetailForm_ItemRequest` is the only reference in Framework or CMS that actually uses the `getExtraData` function.