### PR TITLE
Removed case insensitivity on First Sentence

### DIFF
--- a/model/fieldtypes/HTMLText.php
+++ b/model/fieldtypes/HTMLText.php
@@ -165,7 +165,7 @@ class HTMLText extends Text {
 		/* Then look for the first sentence ending. We could probably use a nice regex, but for now this will do */
 		$words = preg_split('/\s+/', $paragraph);
 		foreach ($words as $i => $word) {
-			if (preg_match('/(!|\?|\.)$/', $word) && !preg_match('/(Dr|Mr|Mrs|Ms|Miss|Sr|Jr|No)\.$/i', $word)) {
+			if (preg_match('/(!|\?|\.)$/', $word) && !preg_match('/(Dr|DR|Mr|MR|Mrs|MRS|Ms|MS|Sr|Jr|No)\.$/', $word)) {
 				return implode(' ', array_slice($words, 0, $i+1));
 			}
 		}

--- a/model/fieldtypes/Text.php
+++ b/model/fieldtypes/Text.php
@@ -96,7 +96,7 @@ class Text extends StringField {
 
 		$words = preg_split('/\s+/', $paragraph);
 		foreach ($words as $i => $word) {
-			if (preg_match('/(!|\?|\.)$/', $word) && !preg_match('/(Dr|Mr|Mrs|Ms|Miss|Sr|Jr|No)\.$/i', $word)) {
+			if (preg_match('/(!|\?|\.)$/', $word) && !preg_match('/(Dr|DR|Mr|MR|Mrs|MRS|Ms|MS|Sr|Jr|No)\.$/', $word)) {
 				return implode(' ', array_slice($words, 0, $i+1));
 			}
 		}


### PR DESCRIPTION
Sentences aren't found if the last word ends in _mrs _ms. Removed case insensitive flag and specified specific cases to skip. Removed "Miss" as this is not an abbreviation and is properly spelled without a .