### PR TITLE
API Use unbuffered MySQL Prepared statements by default

### DIFF
--- a/model/connect/MySQLQuery.php
+++ b/model/connect/MySQLQuery.php
@@ -9,13 +9,6 @@
 class MySQLQuery extends SS_Query {
 
 	/**
-	 * The MySQLiConnector object that created this result set.
-	 *
-	 * @var MySQLiConnector
-	 */
-	protected $database;
-
-	/**
 	 * The internal MySQL handle that points to the result set.
 	 *
 	 * @var mysqli_result
@@ -23,28 +16,16 @@ class MySQLQuery extends SS_Query {
 	protected $handle;
 
 	/**
-	 * The related mysqli statement object if generated using a prepared query
-	 *
-	 * @var mysqli_stmt
-	 */
-	protected $statement;
-
-	/**
 	 * Hook the result-set given into a Query class, suitable for use by SilverStripe.
-	 * @param MySQLDatabase $database The database object that created this query.
+	 * 
 	 * @param mysqli_result $handle the internal mysql handle that is points to the resultset.
-	 * @param mysqli_stmt $statement The related statement, if present
 	 */
-	public function __construct(MySQLiConnector $database, $handle = null, $statement = null) {
-		$this->database = $database;
+	public function __construct($handle = null) {
 		$this->handle = $handle;
-		$this->statement = $statement;
 	}
 
 	public function __destruct() {
 		if (is_object($this->handle)) $this->handle->free();
-		// Don't close statement as these may be re-used across the life of this request
-		// if (is_object($this->statement)) $this->statement->close();
 	}
 
 	public function seek($row) {

--- a/model/connect/MySQLStatement.php
+++ b/model/connect/MySQLStatement.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * Provides a record-view for mysqli statements
+ *
+ * By default streams unbuffered data, but seek(), rewind(), or numRecords() will force the statement to
+ * buffer itself and sacrifice any potential performance benefit.
+ */
+class MySQLStatement extends SS_Query {
+
+	/**
+	 * The related mysqli statement object if generated using a prepared query
+	 *
+	 * @var mysqli_stmt
+	 */
+	protected $statement;
+
+	/**
+	 * Metadata result for this statement
+	 *
+	 * @var mysqli_result
+	 */
+	protected $metadata;
+
+	/**
+	 * Is the statement bound to the current resultset?
+	 *
+	 * @var bool
+	 */
+	protected $bound = false;
+
+	/**
+	 * List of column names
+	 *
+	 * @var array
+	 */
+	protected $columns = array();
+
+	/**
+	 * List of bound variables in the current row
+	 *
+	 * @var array
+	 */
+	protected $boundValues = array();
+
+	/**
+	 * Array buffer of all rows in this result set
+	 *
+	 * @var array
+	 */
+	protected $rows = array();
+
+	/**
+	 * If the statement has been closed.
+	 * The statement will automatically close once all rows have been buffered.
+	 *
+	 * @var bool
+	 */
+	protected $closed = false;
+
+	/**
+	 * Force all remaining unbuffered rows to be buffered and close the statement
+	 */
+	public function buffer() {
+		// Force internal pointer to iterate to the end
+		while($this->bufferNext()) {}
+	}
+
+	/**
+	 * Release all resources held by this object
+	 */
+	protected function close() {
+		if($this->isClosed()) {
+			return;
+		}
+		$this->metadata->free();
+		$this->statement->close();
+		$this->closed = true;
+		$this->currentRecord = false;
+	}
+
+	/**
+	 * Have resources been released?
+	 *
+	 * @return boolean
+	 */
+	public function isClosed() {
+		return $this->closed;
+	}
+
+	/**
+	 * Is this result bound?
+	 *
+	 * @return boolean
+	 */
+	public function isBound() {
+		return $this->bound;
+	}
+
+	/**
+	 * Binds this statement to the variables
+	 */
+	protected function bind() {
+		if($this->isBound() || $this->isClosed()) {
+			return;
+		}
+
+		$variables = array();
+
+		// Bind each field
+		while($field = $this->metadata->fetch_field()) {
+			$this->columns[] = $field->name;
+			$variables[] = &$this->boundValues[$field->name];
+		}
+
+		call_user_func_array(array($this->statement, 'bind_result'), $variables);
+		$this->bound = true;
+	}
+
+	/**
+	 * Hook the result-set given into a Query class, suitable for use by SilverStripe.
+	 * @param mysqli_stmt $statement The related statement, if present
+	 * @param mysqli_result $metadata The metadata for this statement
+	 */
+	public function __construct($statement, $metadata) {
+		$this->statement = $statement;
+		$this->metadata = $metadata;
+	}
+
+	public function __destruct() {
+		$this->close();
+	}
+
+	public function seek($row) {
+		$this->rowNum = $row - 1;
+		return $this->next();
+	}
+
+	/**
+	 * Fetch the next row from the internal statement and buffer it.
+	 * If fetchRow() reaches the end of the resultset it will close any held resources.
+	 *
+	 * @return array|false The result fetched, or false if end of set
+	 */
+	protected function bufferNext() {
+		if($this->isClosed()) {
+			return false;
+		}
+
+		// Detect end of results
+		$this->bind();
+		if (!$this->statement->fetch()) {
+			$this->close();
+			return false;
+		}
+
+		// Buffer dereferenced row
+		$row = array();
+		foreach($this->boundValues as $value) {
+			$row[] = $value;
+		}
+		$this->rows[] = $row;
+		return array_combine($this->columns, $row);
+	}
+
+	public function numRecords() {
+		// Try not to do this on large datasets if performance is critical
+		$this->buffer();
+		return count($this->rows);
+	}
+
+	public function nextRecord() {
+		// Index of next row (given rowNum is current now)
+		$rowNum = $this->rowNum + 1;
+		
+		// Buffer up to $rowNum
+		while(count($this->rows) <= $rowNum) {
+			if(!$this->bufferNext()) {
+				return false;
+			}
+		}
+		return array_combine($this->columns, $this->rows[$rowNum]);
+	}
+
+	public function rewind() {
+		// Don't count records in rewind as it forces a full buffer
+		return $this->seek(0);
+	}
+
+}

--- a/tests/model/MySQLDatabaseTest.php
+++ b/tests/model/MySQLDatabaseTest.php
@@ -5,46 +5,67 @@
  */
 
 class MySQLDatabaseTest extends SapphireTest {
+	
+	protected static $fixture_file = 'MySQLDatabaseTest.yml';
+
 	protected $extraDataObjects = array(
-		'MySQLDatabaseTest_DO',
+		'MySQLDatabaseTest_Data'
 	);
 
-	public function setUp() {
-		if(DB::get_conn() instanceof MySQLDatabase) {
-			MySQLDatabaseTest_DO::config()->db = array(
-				'MultiEnum1' => 'MultiEnum("A, B, C, D","")',
-				'MultiEnum2' => 'MultiEnum("A, B, C, D","A")',
-				'MultiEnum3' => 'MultiEnum("A, B, C, D","A, B")',
-			);
+
+	public function testPreparedStatements() {
+		if(!(DB::get_connector() instanceof MySQLiConnector)) {
+			$this->markTestSkipped('This test requires the current DB connector is MySQLi');
 		}
-		$this->markTestSkipped('This test requires the Config API to be immutable');
-		parent::setUp();
-	}
 
-	/**
-	 * Check that once a schema has been generated, then it doesn't need any more updating
-	 */
-	public function testFieldsDontRerequestChanges() {
-		// These are MySQL specific :-S
-		if(DB::get_conn() instanceof MySQLDatabase) {
-			$schema = DB::get_schema();
-			$test = $this;
-			DB::quiet();
+		// The latest result should not be buffered immediately
+		$result1 = DB::get_connector()->preparedQuery(
+			'SELECT "Sort", "Title" FROM "MySQLDatabaseTest_Data" WHERE "Sort" > ? ORDER BY "Sort"',
+			array(0)
+		);
+		$this->assertInstanceOf('MySQLStatement', $result1);
+		$this->assertFalse($result1->isClosed());
 
-			// Verify that it doesn't need to be recreated
-			$schema->schemaUpdate(function() use ($test, $schema) {
-				$obj = new MySQLDatabaseTest_DO();
-				$obj->requireTable();
-				$needsUpdating = $schema->doesSchemaNeedUpdating();
-				$schema->cancelSchemaUpdate();
+		// Any following query should force prior queries to buffer themselves
+		$result2 = DB::get_connector()->preparedQuery(
+			'SELECT "Sort", "Title" FROM "MySQLDatabaseTest_Data" WHERE "Sort" > ? ORDER BY "Sort"',
+			array(2)
+		);
+		$this->assertInstanceOf('MySQLStatement', $result2);
+		$this->assertTrue($result1->isClosed());
+		$this->assertFalse($result2->isClosed());
 
-				$test->assertFalse($needsUpdating);
-			});
-		}
+		// Non-prepared statements should also force buffering
+		$result3 = DB::get_connector()->query('SELECT "Sort", "Title" FROM "MySQLDatabaseTest_Data" ORDER BY "Sort"');
+		$this->assertInstanceOf('MySQLQuery', $result3);
+		$this->assertTrue($result1->isClosed());
+		$this->assertTrue($result2->isClosed());
+
+		// Iterating one level should not buffer, but return the right result
+		$this->assertEquals(
+			array(
+				'Sort' => 1,
+				'Title' => 'First Item'
+			),
+			$result1->next()
+		);
+		$this->assertEquals(
+			array(
+				'Sort' => 2,
+				'Title' => 'Second Item'
+			),
+			$result1->next()
+		);
 	}
 }
 
-class MySQLDatabaseTest_DO extends DataObject implements TestOnly {
-	private static $db = array();
+class MySQLDatabaseTest_Data extends DataObject implements TestOnly {
+	private static $db = array(
+		'Title' => 'Varchar',
+		'Description' => 'Text',
+		'Enabled' => 'Boolean',
+		'Sort' => 'Int'
+	);
 
+	private static $default_sort = '"Sort" ASC';
 }

--- a/tests/model/MySQLDatabaseTest.yml
+++ b/tests/model/MySQLDatabaseTest.yml
@@ -1,0 +1,17 @@
+MySQLDatabaseTest_Data:
+  data1:
+    Title: 'First Item'
+    Description: 'The content'
+    Sort: 1
+  data2:
+    Title: 'Second Item'
+    Description: 'More Content'
+    Sort: 2
+  data3:
+    Title: 'Third Item'
+    Description: ''
+    Sort: 3
+  data4:
+    Title: 'Last Item'
+    Description: 'Testing'
+    Sort: 4


### PR DESCRIPTION
This solution avoids the usage of any MySQL Native Driver specific API, so it should work with libmysql. 

Using unbuffered SQL Statements should give a general performance increase, but we still use an internal buffer to support seek operations, or in cases where subsequent statements need to be prepared and require existing statements to release resources.

The non-prepared DB::query will still use the existing MySQLQuery object, but it has been stripped down a bit.

Fixes #3426