### PR TITLE
BUG count breaks when having clause defined

### DIFF
--- a/model/SQLQuery.php
+++ b/model/SQLQuery.php
@@ -1038,8 +1038,13 @@ class SQLQuery {
 	 * @return int
 	 */
 	public function count( $column = null) {
+		// we can't clear the select if we're relying on its output by a HAVING clause
+		if(!empty($this->having)) {
+			$records = $this->execute();
+			return $records->numRecords();
+		}
 		// Choose a default column
-		if($column == null) {
+		elseif($column == null) {
 			if($this->groupby) {
 				$column = 'DISTINCT ' . implode(", ", $this->groupby);
 			} else {


### PR DESCRIPTION
`unlimitedRowCount` acknowledges this edge case but it isn't dealt with in `count`

This will prevent SQL errors when executing DataList::exists() when a `having` clause has been defined