### PR TITLE
Remove case sensitivity from sentence end

### DIFF
--- a/model/fieldtypes/HTMLText.php
+++ b/model/fieldtypes/HTMLText.php
@@ -141,7 +141,7 @@ class HTMLText extends Text {
 		/* Otherwise work backwards for a looking for a sentence ending (we try to avoid abbreviations, but aren't
 		 * very good at it) */
 		for ($i = $maxWords; $i >= $maxWords - $flex && $i >= 0; $i--) {
-			if (preg_match('/\.$/', $words[$i]) && !preg_match('/(Dr|Mr|Mrs|Ms|Miss|Sr|Jr|No)\.$/i', $words[$i])) {
+			if (parent::is_sentence_end($words[$i])) {
 				return implode(' ', array_slice($words, 0, $i+1));
 			}
 		}
@@ -165,7 +165,7 @@ class HTMLText extends Text {
 		/* Then look for the first sentence ending. We could probably use a nice regex, but for now this will do */
 		$words = preg_split('/\s+/', $paragraph);
 		foreach ($words as $i => $word) {
-			if (preg_match('/(!|\?|\.)$/', $word) && !preg_match('/(Dr|Mr|Mrs|Ms|Miss|Sr|Jr|No)\.$/i', $word)) {
+			if (parent::is_sentence_end($word)) {
 				return implode(' ', array_slice($words, 0, $i+1));
 			}
 		}

--- a/model/fieldtypes/Text.php
+++ b/model/fieldtypes/Text.php
@@ -96,7 +96,7 @@ class Text extends StringField {
 
 		$words = preg_split('/\s+/', $paragraph);
 		foreach ($words as $i => $word) {
-			if (preg_match('/(!|\?|\.)$/', $word) && !preg_match('/(Dr|Mr|Mrs|Ms|Miss|Sr|Jr|No)\.$/i', $word)) {
+			if (self::is_sentence_end($word)) {
 				return implode(' ', array_slice($words, 0, $i+1));
 			}
 		}
@@ -105,6 +105,13 @@ class Text extends StringField {
 		 * Summary will limit the result this time */
 		return $this->Summary(20);
 	}
+	
+    /**
+	 * Caution: Not XML/HTML-safe - does not respect closing tags.
+	 */
+	protected static function is_sentence_end($word) {
+	    return (preg_match('/(!|\?|\.)$/', $word) && !preg_match('/^(Dr|Mr|Mrs|Ms|Sr|Jr|No)\.$/i', $word));
+	} 
 
 	/**
 	 * Caution: Not XML/HTML-safe - does not respect closing tags.


### PR DESCRIPTION
Removed case sensitivity from FirstSentence() and Summary() end of
sentence exceptions.

Currently sentences aren't recognized if the last word ends in _mrs
_ms, etc. Removed case insensitive flag and specified cases to skip.
Removed "Miss" as this is not an abbreviation and is properly spelled
without a period.