### PR TITLE
Improve IIS security

### DIFF
--- a/web.config
+++ b/web.config
@@ -1,11 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-	<system.webServer>
-		<security>
-			<requestFiltering>
-				<hiddenSegments>
-					<add segment="silverstripe_version" />
-				</hiddenSegments>
-			</requestFiltering>
-		</security>
-	</system.webServer>
+   <system.webServer>
+       <rewrite>
+           <rules>
+               <rule name="Block Scripts" stopProcessing="true">
+                   <match url="([^\\/]+)\.(php|php3|php4|php5|phtml|inc)$" />
+                   <conditions trackAllCaptures="true">
+                       <add input="{REQUEST_FILENAME}" pattern="\b(main|rpc|tiny_mce_gzip)\.php$" negate="true" />
+                   </conditions>
+                   <action type="AbortRequest" />
+               </rule>
+               <rule name="Block Version" stopProcessing="true">
+                   <match url="\bsilverstripe_version$" />
+                   <action type="AbortRequest" />
+               </rule>
+           </rules>
+       </rewrite>
+   </system.webServer>
 </configuration>


### PR DESCRIPTION
This config should mirror the rules defined in `.htaccess`:

```
<FilesMatch "\.(php|php3|php4|php5|phtml|inc)$">
	Deny from all
</FilesMatch>
<FilesMatch "(main|rpc|tiny_mce_gzip)\.php$">
	Allow from all
</FilesMatch>
<FilesMatch "silverstripe_version$">
	Deny from all
</FilesMatch>
```