### PR TITLE
FIX: Modifications to GridFieldExportButton to allow ArrayList use in SS_Report

### DIFF
--- a/forms/gridfield/GridFieldExportButton.php
+++ b/forms/gridfield/GridFieldExportButton.php
@@ -132,7 +132,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 		}
 
 		foreach($items->limit(null) as $item) {
-			if($item->hasMethod('canView') && $item->canView()) {
+			if(!$item->hasMethod('canView') || $item->canView()) {
 				$columnData = array();
 
 				foreach($csvColumns as $columnSource => $columnHeader) {
@@ -146,16 +146,23 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 						$value = $columnHeader($relObj);
 					} else {
 						$value = $gridField->getDataFieldValue($item, $columnSource);
+
+						if(!$value) {
+							$value = $gridField->getDataFieldValue($item, $columnHeader);
+						}
 					}
 
 					$value = str_replace(array("\r", "\n"), "\n", $value);
 					$columnData[] = '"' . str_replace('"', '""', $value) . '"';
 				}
+
 				$fileData .= implode($separator, $columnData);
 				$fileData .= "\n";
 			}
 
-			$item->destroy();
+			if($item->hasMethod('destroy')) {
+				$item->destroy();
+			}
 		}
 
 		return $fileData;


### PR DESCRIPTION
- canView is not defined, so if method doesn't exist assume that the user can view it (what GridField does).

- check destroy method exists

- Get value by source number returned null on arraylist, this will fetch by column name


