### PR TITLE
Fix CMSMenuItem CSS references for namespaced controllers

### DIFF
--- a/admin/code/CMSMenu.php
+++ b/admin/code/CMSMenu.php
@@ -142,7 +142,7 @@ class CMSMenu extends Object implements IteratorAggregate, i18nEntityProvider {
 			$cmsClasses = self::get_cms_classes();
 			foreach($cmsClasses as $cmsClass) {
 				$menuItem = self::menuitem_for_controller($cmsClass);
-				if($menuItem) $menuItems[$cmsClass] = $menuItem;
+				if($menuItem) $menuItems[Convert::raw2htmlname(str_replace('\\', '-', $cmsClass))] = $menuItem;
 			}
 		}
 		

--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -556,7 +556,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 	public static function menu_icon_for_class($class) {
 		$icon = Config::inst()->get($class, 'menu_icon', Config::FIRST_SET);
 		if (!empty($icon)) {
-			$class = strtolower($class);
+			$class = strtolower(Convert::raw2htmlname(str_replace('\\', '-', $class)));
 			return ".icon.icon-16.icon-{$class} { background: url('{$icon}'); } ";
 		}
 		return '';

--- a/admin/javascript/LeftAndMain.Menu.js
+++ b/admin/javascript/LeftAndMain.Menu.js
@@ -92,7 +92,7 @@
 			updateMenuFromResponse: function(xhr) {
 				var controller = xhr.getResponseHeader('X-Controller');
 				if(controller) {
-					var item = this.find('li#Menu-' + controller);
+					var item = this.find('li#Menu-' + controller.replace(/\\/g, '-').replace(/[^a-zA-Z0-9\-_:.]+/, ''));
 					if(!item.hasClass('current')) item.select();
 				}
 				this.updateItems();


### PR DESCRIPTION
The controller class name including namespace is used to create CSS class names for `CMSMenuItem` (specifically for the icon).

Currently this is done without escaping the class name resulting in CSS classes with backslashes (`\`) which are invalid characters for CSS class names.

This PR simply uses the existing `Convert::raw2htmlname()` method to escape the class name before use in `CMSMenuItem`.