### PR TITLE
Store current page before marking tree nodes (fixes #4137, fixes silverstripe/silverstripe-cms#1135)

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -811,6 +811,12 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		// Get the tree root
 		$record = ($rootID) ? $this->getRecord($rootID) : null;
 		$obj = $record ? $record : singleton($className);
+
+		// Get the current page
+		// NOTE: This *must* be fetched before markPartialTree() is called, as this
+		// causes the Hierarchy::$marked cache to be flushed (@see CMSMain::getRecord)
+		// which means that deleted pages stored in the marked tree would be removed
+		$currentPage = $this->currentPage();
 		
 		// Mark the nodes of the tree to return
 		if ($filterFunction) $obj->setMarkingFilterFunction($filterFunction);
@@ -818,10 +824,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		$obj->markPartialTree($nodeCountThreshold, $this, $childrenMethod, $numChildrenMethod);
 		
 		// Ensure current page is exposed
-		// This call flushes the Hierarchy::$marked cache when the current node is deleted
-		// @see CMSMain::getRecord()
-		// This will make it impossible to show children under a deleted parent page
-		// if($p = $this->currentPage()) $obj->markToExpose($p);
+		if($currentPage) $obj->markToExpose($currentPage);
 		
 		// NOTE: SiteTree/CMSMain coupling :-(
 		if(class_exists('SiteTree')) {


### PR DESCRIPTION
Well, this was an easier solution than I expected!

Code docs should explain this well enough, but basically:

- Without `$obj->markToExpose()`, the tree view fails to load with the current page highlighted under the conditions described in [this issue](https://github.com/silverstripe/silverstripe-cms/issues/1135). It then tries to load `getsubtree?ID=0&ajax=1` before collapsing _fully_ (all the way down to the root “your site name” node), making it very difficult to then find the current page;
- With `$obj->markToExpose()` uncommented where it was, [this issue](https://github.com/silverstripe/silverstripe-cms/issues/1049) re-occurs;
- By moving `$this->currentPage()` before `$obj->markToExpose()`, the deleted pages in `Hierarchy::$marked` aren’t wiped, fixing both issues