### PR TITLE
NEW Cookie names with dots are now handled more gracefully

### DIFF
--- a/control/CookieJar.php
+++ b/control/CookieJar.php
@@ -3,7 +3,7 @@
 /**
  * A default backend for the setting and getting of cookies
  *
- * This backend allows one to better test Cookie setting and seperate cookie
+ * This backend allows one to better test Cookie setting and separate cookie
  * handling from the core
  *
  * @todo Create a config array for defaults (eg: httpOnly, secure, path, domain, expiry)
@@ -14,7 +14,7 @@
 class CookieJar implements Cookie_Backend {
 
 	/**
-	 * Hold the cookies that were existing at time of instatiation (ie: The ones
+	 * Hold the cookies that were existing at time of instantiation (ie: The ones
 	 * sent to PHP by the browser)
 	 *
 	 * @var array Existing cookies sent by the browser
@@ -30,7 +30,7 @@ class CookieJar implements Cookie_Backend {
 	protected $current = array();
 
 	/**
-	 * Hold any NEW cookies that were set by the appliation and will be sent
+	 * Hold any NEW cookies that were set by the application and will be sent
 	 * in the next response
 	 *
 	 * @var array New cookies set by the application
@@ -39,7 +39,7 @@ class CookieJar implements Cookie_Backend {
 
 	/**
 	 * When creating the backend we want to store the existing cookies in our
-	 * "existing" array. This allows us to distinguish between cookies we recieved
+	 * "existing" array. This allows us to distinguish between cookies we received
 	 * or we set ourselves (and didn't get from the browser)
 	 *
 	 * @param array $cookies The existing cookies to load into the cookie jar.
@@ -92,6 +92,8 @@ class CookieJar implements Cookie_Backend {
 	/**
 	 * Get the cookie value by name
 	 *
+	 * Cookie names are normalised to work around PHP's behaviour of replacing incoming variable name . with _
+	 *
 	 * @param string $name The name of the cookie to get
 	 * @param boolean $includeUnsent Include cookies we've yet to send when fetching values
 	 *
@@ -101,6 +103,12 @@ class CookieJar implements Cookie_Backend {
 		$cookies = $includeUnsent ? $this->current : $this->existing;
 		if (isset($cookies[$name])) {
 			return $cookies[$name];
+		}
+
+		//Normalise cookie names by replacing '.' with '_'
+		$safeName = str_replace('.', '_', $name);
+		if (isset($cookies[$safeName])) {
+			return $cookies[$safeName];
 		}
 	}
 

--- a/tests/control/CookieJarTest.php
+++ b/tests/control/CookieJarTest.php
@@ -53,8 +53,20 @@ class CookieJarTest extends SapphireTest {
 		//make sure it was set
 		$this->assertEquals('testVal', $cookieJar->get('testCookie'));
 
-		//make sure we can distinguise it from ones that were "existing"
+		//make sure we can distinguish it from ones that were "existing"
 		$this->assertEmpty($cookieJar->get('testCookie', false));
+
+		//PHP will replace an incoming COOKIE called 'var.with.dots' to 'var_with_dots'
+		$cookieJar = new CookieJar(array(
+			'var_with_dots' => 'value',
+		));
+
+		$cookieJar->set('test.dots', 'dots');
+
+		//check we can access with '.' and with '_'
+		$this->assertEquals('value', $cookieJar->get('var.with.dots'));
+		$this->assertEquals('value', $cookieJar->get('var_with_dots'));
+		$this->assertEquals('dots', $cookieJar->get('test.dots'));
 	}
 
 	/**
@@ -120,14 +132,14 @@ class CookieJarTest extends SapphireTest {
 		//check we can add a new cookie and remove it and it doesn't leave any phantom values
 		$cookieJar->set('newCookie', 'i am new');
 
-		//check it's set by not recieved
+		//check it's set by not received
 		$this->assertEquals('i am new', $cookieJar->get('newCookie'));
 		$this->assertEmpty($cookieJar->get('newCookie', false));
 
 		//remove it
 		$cookieJar->forceExpiry('newCookie');
 
-		//check it's neither set nor reveived
+		//check it's neither set nor received
 		$this->assertEmpty($cookieJar->get('newCookie'));
 		$this->assertEmpty($cookieJar->get('newCookie', false));
 	}

--- a/tests/control/CookieTest.php
+++ b/tests/control/CookieTest.php
@@ -28,6 +28,7 @@ class CookieTest extends SapphireTest {
 			'cookie1' => 1,
 			'cookie2' => 'cookies',
 			'cookie3' => 'test',
+			'cookie_4' => 'value',
 		);
 
 		Injector::inst()->unregisterNamedObject('Cookie_Backend');
@@ -35,6 +36,8 @@ class CookieTest extends SapphireTest {
 		$this->assertEquals($_COOKIE['cookie1'], Cookie::get('cookie1'));
 		$this->assertEquals($_COOKIE['cookie2'], Cookie::get('cookie2'));
 		$this->assertEquals($_COOKIE['cookie3'], Cookie::get('cookie3'));
+		$this->assertEquals($_COOKIE['cookie_4'], Cookie::get('cookie.4'));
+		$this->assertEquals($_COOKIE['cookie_4'], Cookie::get('cookie_4'));
 
 		//for good measure check the CookieJar hasn't stored anything extra
 		$this->assertEquals($_COOKIE, Cookie::get_inst()->getAll(false));


### PR DESCRIPTION
For legacy reasons, PHP converts `.` in cookie names to `_`. This is somewhat unexpected behaviour and the kind of behaviour a framework should aim to mitigate.

This change allows programmers to set and get cookies with `.` in the name without having to worry about PHP's conversions of incoming variable names.

Any code that took this PHP behaviour into account will still work.

reference: http://php.net/manual/en/language.variables.external.php#language.variables.external.dot-in-names