### PR TITLE
Fix behaviour of panels

### DIFF
--- a/admin/javascript/LeftAndMain.Panel.js
+++ b/admin/javascript/LeftAndMain.Panel.js
@@ -138,7 +138,7 @@
 		$('.cms-content-tools.collapsed').entwine({
 			// Expand CMS' centre pane, when the pane itself is clicked somewhere
 			onclick: function(e) {
-				$('.cms-panel .toggle-expand').trigger('click');
+				this.expandPanel();
 			}
 		});
 	});


### PR DESCRIPTION
The current behaviour causes a bug when more than one panel is present.

In **screenshot 1**, clicking the 'Post Options' panel results in both panels being expanded, see **screenshot 2**.

This happens because a click event is triggered on all panels, which is incorrect, only the panel that has been clicked should have behaviour triggered.

**Screenshot 1:**
![framework-bug-01](https://cloud.githubusercontent.com/assets/878176/7601160/d6d86374-f966-11e4-9cc8-7e64c764d942.png)

**Screenshot 2:**
![framework-bug-02](https://cloud.githubusercontent.com/assets/878176/7601165/db16e8b6-f966-11e4-94e9-2192c0d8773c.png)
