### PR TITLE
Fixed typo in SS_List ->toArray() return type.

### DIFF
--- a/model/List.php
+++ b/model/List.php
@@ -10,7 +10,7 @@ interface SS_List extends ArrayAccess, Countable, IteratorAggregate {
 	/**
 	 * Returns all the items in the list in an array.
 	 *
-	 * @return arary
+	 * @return array
 	 */
 	public function toArray();
 


### PR DESCRIPTION
Found a typo that was throwing off my editor, since the type `arary` doesn't exist as far as I'm aware :)