### PR TITLE
Bug fix: File->setName()

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -609,7 +609,7 @@ class File extends DataObject {
 
 		// If it's changed, check for duplicates
 		if($oldName && $oldName != $name) {
-			$base = pathinfo($name, PATHINFO_BASENAME);
+			$base = pathinfo($name, PATHINFO_FILENAME);
 			$ext = self::get_file_extension($name);
 			$suffix = 1;
 
@@ -621,7 +621,7 @@ class File extends DataObject {
 				))->first()
 			) {
 				$suffix++;
-				$name = "$base-$suffix$ext";
+				$name = "$base-$suffix.$ext";
 			}
 		}
 


### PR DESCRIPTION
Logical error. $base should use PATHINFO_FILENAME instead of
PATHINFO_BASENAME in order to exclude extension; final $name should
include a period before $ext as $ext uses PATHINFO_EXTENSION which
excludes the period.

Reference issue: https://github.com/silverstripe/silverstripe-framework/issues/4187