### PR TITLE
FIX: TreeDropdownField Folder expansion

### DIFF
--- a/admin/javascript/LeftAndMain.Content.js
+++ b/admin/javascript/LeftAndMain.Content.js
@@ -46,9 +46,6 @@
 					// when JSTree auto-selects elements on first load.
 					if(!origEvent) {
 						return false;
-					}else if($(origEvent.target).hasClass('jstree-icon') || $(origEvent.target).hasClass('jstree-pageicon')){
-						// in case the click is not on the node title, ie on pageicon or dragicon, 
-						return false;
 					}
 					
 					// Don't allow checking disabled nodes

--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -390,7 +390,6 @@ class File extends DataObject {
 
 		//get a tree listing with only folder, no files
 		$folderTree = new TreeDropdownField("ParentID", _t('AssetTableField.FOLDER','Folder'), 'Folder');
-		$folderTree->setChildrenMethod('ChildFolders');
 
 		$fields = new FieldList(
 			new TabSet('Root',

--- a/filesystem/Folder.php
+++ b/filesystem/Folder.php
@@ -466,6 +466,13 @@ class Folder extends File {
 	public function ChildFolders() {
 		return Folder::get()->filter('ParentID', $this->ID);
 	}
+
+	/**
+	 * Get the number of children of this folder that are also folders.
+	 */
+	public function numChildFolders() {
+		return $this->ChildFolders()->count();
+	}
 	
 	/**
 	 * @return String
@@ -479,7 +486,7 @@ class Folder extends File {
 		if(!$this->canEdit()) 
 			$classes .= " disabled";
 			
-		$classes .= $this->markingClasses();
+		$classes .= $this->markingClasses('numChildFolders');
 
 		return $classes;
 	}

--- a/forms/TreeDropdownField.php
+++ b/forms/TreeDropdownField.php
@@ -56,9 +56,13 @@ class TreeDropdownField extends FormField {
 	protected $sourceObject, $keyField, $labelField, $filterCallback,
 		$disableCallback, $searchCallback, $baseID = 0;
 	/**
-	 * @var string default child method in Hierarcy->getChildrenAsUL
+	 * @var string default child method in Hierarchy->getChildrenAsUL
 	 */
 	protected $childrenMethod = 'AllChildrenIncludingDeleted';
+	/**
+	 * @var string default child counting method in Hierarchy->getChildrenAsUL
+	 */
+	protected $numChildrenMethod = 'numChildren';
 	
 	/**
 	 * Used by field search to leave only the relevant entries
@@ -96,6 +100,12 @@ class TreeDropdownField extends FormField {
 		$this->keyField     = $keyField;
 		$this->labelField   = $labelField;
 		$this->showSearch	= $showSearch;
+		
+		//Extra settings for Folders
+		if ($sourceObject == 'Folder') {
+			$this->childrenMethod = 'ChildFolders';
+			$this->numChildrenMethod = 'numChildFolders';
+		}
 
 		$this->addExtraClass('single');
 
@@ -171,14 +181,24 @@ class TreeDropdownField extends FormField {
 
 	/**
 	 * @param $method The parameter to ChildrenMethod to use when calling Hierarchy->getChildrenAsUL in
-	 * {@link Hierarchy}. The method specified determined the structure of the returned list. Use "ChildFolders"
+	 * {@link Hierarchy}. The method specified determines the structure of the returned list. Use "ChildFolders"
 	 * in place of the default to get a drop-down listing with only folders, i.e. not including the child elements in
-	 * the currently selected folder.
+	 * the currently selected folder. setNumChildrenMethod() should be used as well for proper functioning.
 	 * 
 	 * See {@link Hierarchy} for a complete list of possible methods.
 	 */
 	public function setChildrenMethod($method) {
 		$this->childrenMethod = $method;
+		return $this;
+	}
+	
+	/**
+	 * @param $method The parameter to numChildrenMethod to use when calling Hierarchy->getChildrenAsUL in
+	 * {@link Hierarchy}. Should be used in conjunction with setChildrenMethod().
+	 * 
+	 */
+	public function setNumChildrenMethod($method) {
+		$this->numChildrenMethod = $method;
 		return $this;
 	}
 
@@ -273,10 +293,11 @@ class TreeDropdownField extends FormField {
 		if ( $this->search != "" )
 			$this->populateIDs();
 		
-		if ($this->filterCallback || $this->sourceObject == 'Folder' || $this->search != "" )
+		if ($this->filterCallback || $this->search != "" )
 			$obj->setMarkingFilterFunction(array($this, "filterMarking"));
 		
-		$obj->markPartialTree();
+		$obj->markPartialTree($nodeCountThreshold = 30, $context = null,
+			$this->childrenMethod, $this->numChildrenMethod);
 		
 		// allow to pass values to be selected within the ajax request
 		if( isset($_REQUEST['forceValue']) || $this->value ) {
@@ -298,7 +319,7 @@ class TreeDropdownField extends FormField {
 				Convert::raw2xml($child->$keyField),
 				Convert::raw2xml($child->$keyField),
 				Convert::raw2xml($child->class),
-				Convert::raw2xml($child->markingClasses()),
+				Convert::raw2xml($child->markingClasses($self->numChildrenMethod)),
 				($self->nodeIsDisabled($child)) ? 'disabled' : '',
 				(int)$child->ID,
 				$child->obj($labelField)->forTemplate()
@@ -330,7 +351,7 @@ class TreeDropdownField extends FormField {
 				null,
 				true, 
 				$this->childrenMethod,
-				'numChildren',
+				$this->numChildrenMethod,
 				true, // root call
 				null,
 				$nodeCountCallback
@@ -343,7 +364,7 @@ class TreeDropdownField extends FormField {
 				null,
 				true, 
 				$this->childrenMethod,
-				'numChildren',
+				$this->numChildrenMethod,
 				true, // root call
 				null,
 				$nodeCountCallback
@@ -353,15 +374,14 @@ class TreeDropdownField extends FormField {
 	}
 
 	/**
-	 * Marking public function for the tree, which combines different filters sensibly. If a filter function has been
-	 * set, that will be called. If the source is a folder, automatically filter folder. And if search text is set,
+	 * Marking public function for the tree, which combines different filters sensibly.
+	 * If a filter function has been set, that will be called. And if search text is set,
 	 * filter on that too. Return true if all applicable conditions are true, false otherwise.
 	 * @param $node
 	 * @return unknown_type
 	 */
 	public function filterMarking($node) {
 		if ($this->filterCallback && !call_user_func($this->filterCallback, $node)) return false;
-		if ($this->sourceObject == "Folder" && $node->ClassName != 'Folder') return false;
 		if ($this->search != "") {
 			return isset($this->searchIds[$node->ID]) && $this->searchIds[$node->ID] ? true : false;
 		}

--- a/model/Hierarchy.php
+++ b/model/Hierarchy.php
@@ -324,7 +324,7 @@ class Hierarchy extends DataExtension {
 		}
 		
 		// Set jstree open state, or mark it as a leaf (closed) if there are no children
-		if(!$this->$numChildrenMethod()) {
+		if(!$this->owner->$numChildrenMethod()) {
 			$classes .= " jstree-leaf closed";
 		} elseif($this->isTreeOpened()) {
 			$classes .= " jstree-open";


### PR DESCRIPTION
When viewing a Folder tree, an expansion icon was shown if the Folder had *any* children, but it should be restricted to children that are Folders. This has annoyed me for a long time :)

The `Hierarchy::getChildrenAsUL()` function requires a separate method for counting children, but this hasn't been accommodated in TreeDropdownField so numChildren calculations were wrong. I'm guessing the requirement for the separate counting function predates lazy-loading as now it should be quite efficient to just do `$SomeListMethod()->count()`.

Propose that for SS4.0 the `$numChildrenMethod` argument in `Hierarchy::getChildrenAsUL()` is deprecated, and the total can then be simply calculated using `$childrenMethod()->count()`. Or maybe we could even sneak this in to 3.2?

Companion fix for CMS at https://github.com/silverstripe/silverstripe-cms/pull/1205