### PR TITLE
DataObject accept arrays or stdClass

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -399,6 +399,9 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 				E_USER_WARNING);
 			$record = null;
 		}
+		if (is_a($record, "stdClass")){
+			$record = (array)$record;
+		}
 
 		// Set $this->record to $record, but ignore NULLs
 		$this->record = array();


### PR DESCRIPTION
The constructor of DataObject can take an array or stdClass for $record.
However, it is access as an array [here](https://github.com/silverstripe/silverstripe-framework/blob/3.1/model/DataObject.php#L416) and [here](https://github.com/silverstripe/silverstripe-framework/blob/3.1/model/DataObject.php#L431)

This pull request ensures $record is an array after validation