### PR TITLE
BUG Fix DirectorTest failing when run with sake

### DIFF
--- a/tests/control/DirectorTest.php
+++ b/tests/control/DirectorTest.php
@@ -25,9 +25,11 @@ class DirectorTest extends SapphireTest {
 		if(!self::$originalRequestURI) {
 			self::$originalRequestURI = $_SERVER['REQUEST_URI'];
 		}
+		$_SERVER['REQUEST_URI'] = 'http://www.mysite.com';
 		
 		$this->originalGet = $_GET;
 		$this->originalSession = $_SESSION;
+		$_SESSION = array();
 		
 		Config::inst()->update('Director', 'rules', array(
 			'DirectorTestRule/$Action/$ID/$OtherID' => 'DirectorTestRequest_Controller',
@@ -136,26 +138,47 @@ class DirectorTest extends SapphireTest {
 	}
 
 	public function testAlternativeBaseURL() {
+		// Get original protocol and hostname
+		$rootURL = Director::protocolAndHost();
+		
 		// relative base URLs - you should end them in a /
 		Config::inst()->update('Director', 'alternate_base_url', '/relativebase/');
+		$_SERVER['REQUEST_URI'] = "$rootURL/relativebase/sub-page/";
+
 		$this->assertEquals('/relativebase/', Director::baseURL());
-		$this->assertEquals(Director::protocolAndHost() . '/relativebase/', Director::absoluteBaseURL());
-		$this->assertEquals(Director::protocolAndHost() . '/relativebase/subfolder/test',
-			Director::absoluteURL('subfolder/test'));
+		$this->assertEquals($rootURL . '/relativebase/', Director::absoluteBaseURL());
+		$this->assertEquals(
+			$rootURL . '/relativebase/subfolder/test',
+			Director::absoluteURL('subfolder/test')
+		);
 
 		// absolute base URLs - you should end them in a /
 		Config::inst()->update('Director', 'alternate_base_url', 'http://www.example.org/');
+		$_SERVER['REQUEST_URI'] = "http://www.example.org/sub-page/";
 		$this->assertEquals('http://www.example.org/', Director::baseURL());
 		$this->assertEquals('http://www.example.org/', Director::absoluteBaseURL());
-		$this->assertEquals('http://www.example.org/', Director::absoluteURL(''));
-		$this->assertEquals('http://www.example.org/subfolder/test', Director::absoluteURL('subfolder/test'));
+		$this->assertEquals('http://www.example.org/sub-page/', Director::absoluteURL(''));
+		$this->assertEquals('http://www.example.org/', Director::absoluteURL('', true));
+		/*
+		 * See Legacy behaviour in testAbsoluteURL - sub-pages with '/' in the string are not correctly evaluated
+		$this->assertEquals(
+			'http://www.example.org/sub-page/subfolder/test',
+			Director::absoluteURL('subfolder/test')
+		);*/
+		$this->assertEquals(
+			'http://www.example.org/subfolder/test',
+			Director::absoluteURL('subfolder/test', true)
+		);
 
 		// Setting it to false restores functionality
 		Config::inst()->update('Director', 'alternate_base_url', false);
+		$_SERVER['REQUEST_URI'] = $rootURL;
 		$this->assertEquals(BASE_URL.'/', Director::baseURL());
-		$this->assertEquals(Director::protocolAndHost().BASE_URL.'/', Director::absoluteBaseURL(BASE_URL));
-		$this->assertEquals(Director::protocolAndHost().BASE_URL . '/subfolder/test',
-			Director::absoluteURL('subfolder/test'));
+		$this->assertEquals($rootURL.BASE_URL.'/', Director::absoluteBaseURL(BASE_URL));
+		$this->assertEquals(
+			$rootURL.BASE_URL . '/subfolder/test',
+			Director::absoluteURL('subfolder/test')
+		);
 	}
 	
 	/**


### PR DESCRIPTION
The tests run fine with phpunit cli, but when run with sake dev/tests/all the `$_SERVER['REQUEST_URI']` ends up with the dev/tests/all in the url, which actually breaks some assumptions made in testAlternativeBaseURL about how absoluteURL works.

I've also added yet another note on absoluteURL behaving weird in 3.1, where url-segments such as parent/child are treated as absolute urls.