### PR TITLE
Fix left nav styling.

### DIFF
--- a/admin/javascript/LeftAndMain.Menu.js
+++ b/admin/javascript/LeftAndMain.Menu.js
@@ -139,6 +139,14 @@
 			onadd: function () {
 				var self = this;
 
+				setTimeout(function () {
+					// Use a timeout so this happens after the redraw.
+					// Triggering a toggle before redraw will result in an incorrect
+					// menu 'expanded width' being calculated when then menu
+					// is added in a collapsed state.
+					self.togglePanel(!self.getEvaluatedCollapsedState(), false, false);
+				}, 0);
+
 				// Setup automatic expand / collapse behaviour.
 				$(window).on('ajaxComplete', function (e) {
 					setTimeout(function () { // Use a timeout so this happens after the redraw

--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -221,7 +221,7 @@ jQuery.noConflict();
 			 * See LeftAndMain.Layout.js for description of these options.
 			 */
 			LayoutOptions: {
-				minContentWidth: 820,
+				minContentWidth: 940,
 				minPreviewWidth: 400,
 				mode: 'content'
 			},


### PR DESCRIPTION
- Fixes incorrect collapsed state on reload. This happens when the 'flush' param is not present and you try to reload the page with the menu collapsed. A flush causes the 'ajaxComplete' to trigger, which toggles the panel corrently. Omitting flush, 'ajaxComplete' doesn't trigger, and the panel ends up in expanded when it should be collapsed.

- The content area had a horizontal scroll in split-mode.