### PR TITLE
Semantic existing upload renaming

### DIFF
--- a/filesystem/Upload.php
+++ b/filesystem/Upload.php
@@ -157,7 +157,7 @@ class Upload extends Controller {
 			}
 		}
 
-		// if filename already exists, version the filename (e.g. test.gif to test2.gif, test2.gif to test3.gif)
+		// if filename already exists, version the filename (e.g. test.gif to test-2.gif, test-2.gif to test-3.gif)
 		if(!$this->replaceFile) {
 			$fileSuffixArray = explode('.', $fileName);
 			$fileTitle = array_shift($fileSuffixArray);
@@ -175,11 +175,11 @@ class Upload extends Controller {
 				$i = isset($i) ? ($i+1) : 2;
 				$oldFilePath = $relativeFilePath;
 
-				$pattern = '/([0-9]+$)/';
-				if(preg_match($pattern, $fileTitle)) {
-					$fileTitle = preg_replace($pattern, $i, $fileTitle);
+				$pattern = '/-v([0-9]+$)/';
+				if(preg_match($pattern, $fileTitle, $matches)) {
+					$fileTitle = preg_replace($pattern, '-v' . ($matches[1] + 1), $fileTitle);
 				} else {
-					$fileTitle .= $i;
+					$fileTitle .= '-v' . $i;
 				}
 				$relativeFilePath = $relativeFolderPath . $fileTitle . $fileSuffix;
 

--- a/tests/filesystem/UploadTest.php
+++ b/tests/filesystem/UploadTest.php
@@ -684,21 +684,21 @@ class UploadTest extends SapphireTest {
 
 		$file2 = $upload('UploadTest-testUpload.jpg');
 		$this->assertEquals(
-			'UploadTest-testUpload2.jpg',
+			'UploadTest-testUpload-v2.jpg',
 			$file2->Name,
 			'File does receive new name'
 		);
 
 		$file3 = $upload('UploadTest-testUpload.jpg');
 		$this->assertEquals(
-			'UploadTest-testUpload3.jpg',
+			'UploadTest-testUpload-v3.jpg',
 			$file3->Name,
 			'File does receive new name'
 		);
 
-		$file4 = $upload('UploadTest-testUpload3.jpg');
+		$file4 = $upload('UploadTest-testUpload-v3.jpg');
 		$this->assertEquals(
-			'UploadTest-testUpload4.jpg',
+			'UploadTest-testUpload-v4.jpg',
 			$file4->Name,
 			'File does receive new name'
 		);


### PR DESCRIPTION
Filename          | Old result     | New result
------------------|----------------|-----------
image.jpg         | image2.jpg     | image-v2.jpg
55.jpg            | 56.jpg         | 55-v2.jpg
Image-2402.jpg    | Image-2403.jpg | Image-2402-v2.jpg
Image-2402-v2.jpg | -NA-           | Image-2402-v3.jpg

Numbers are often used at the end of file names in image sequences (e.g. digital photos) and the current renaming scheme can disrupt this, creating a confusing situation for the user. Presence of '-v' flag should help reduce this.