### PR TITLE
DOCS Fixed code example for Requirements::set_write_js_to_body call

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/03_Requirements.md
+++ b/docs/en/02_Developer_Guides/01_Templates/03_Requirements.md
@@ -186,7 +186,7 @@ If the Javascript files are preferred to be placed in the `<head>` tag rather th
 `Requirements.write_js_to_body` should be set to false.
 
 	:::php
-	Requirements::set_force_js_to_bottom(true);
+	Requirements::set_write_js_to_body(false);
 
 
 ## API Documentation


### PR DESCRIPTION
Fixed code example for setting write_js_to_body value to false