### PR TITLE
FIX Incorrect env setting in 3.1.13

### DIFF
--- a/core/Constants.php
+++ b/core/Constants.php
@@ -94,7 +94,10 @@ function stripslashes_recursively(&$array) {
 if(!defined('TRUSTED_PROXY')) {
 	$trusted = true; // will be false by default in a future release
 
-	if(getenv('BlockUntrustedIPs') || defined('SS_TRUSTED_PROXY_IPS')) {
+	if(getenv('BlockUntrustedProxyHeaders') // Official published flag
+		|| getenv('BlockUntrustedIPs') // Legacy setting
+		|| defined('SS_TRUSTED_PROXY_IPS')
+	) {
 		$trusted = false;
 
 		if(defined('SS_TRUSTED_PROXY_IPS') && SS_TRUSTED_PROXY_IPS !== 'none') {


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-installer/pull/91

This is why we shouldn't do same-day releases for security fixes or changes.