### PR TITLE
NEW Configurable file version prefix

### DIFF
--- a/filesystem/Upload.php
+++ b/filesystem/Upload.php
@@ -72,6 +72,17 @@ class Upload extends Controller {
 	 */
 	private static $uploads_folder = "Uploads";
 
+	/**
+	 * A prefix for the version number added to an uploaded file
+	 * when a file with the same name already exists.
+	 * Example using no prefix: IMG001.jpg becomes IMG2.jpg
+	 * Example using '-v' prefix: IMG001.jpg becomes IMG001-v2.jpg
+	 *
+	 * @config
+	 * @var string
+	 */
+	private static $version_prefix = '-v';
+
 	public function __construct() {
 		parent::__construct();
 		$this->validator = Injector::inst()->create('Upload_Validator');
@@ -157,7 +168,7 @@ class Upload extends Controller {
 			}
 		}
 
-		// if filename already exists, version the filename (e.g. test.gif to test2.gif, test2.gif to test3.gif)
+		// if filename already exists, version the filename (e.g. test.gif to test-v2.gif, test-v2.gif to test-v3.gif)
 		if(!$this->replaceFile) {
 			$fileSuffixArray = explode('.', $fileName);
 			$fileTitle = array_shift($fileSuffixArray);
@@ -175,11 +186,12 @@ class Upload extends Controller {
 				$i = isset($i) ? ($i+1) : 2;
 				$oldFilePath = $relativeFilePath;
 
-				$pattern = '/([0-9]+$)/';
-				if(preg_match($pattern, $fileTitle)) {
-					$fileTitle = preg_replace($pattern, $i, $fileTitle);
+				$prefix = $this->config()->version_prefix;
+				$pattern = '/' . preg_quote($prefix) . '([0-9]+$)/';
+				if(preg_match($pattern, $fileTitle, $matches)) {
+					$fileTitle = preg_replace($pattern, $prefix . ($matches[1] + 1), $fileTitle);
 				} else {
-					$fileTitle .= $i;
+					$fileTitle .= $prefix . $i;
 				}
 				$relativeFilePath = $relativeFolderPath . $fileTitle . $fileSuffix;
 

--- a/tests/filesystem/UploadTest.php
+++ b/tests/filesystem/UploadTest.php
@@ -352,7 +352,7 @@ class UploadTest extends SapphireTest {
 		$u->load($tmpFile);
 		$file2 = $u->getFile();
 		$this->assertEquals(
-			'UploadTest-testUpload2.tar.gz',
+			'UploadTest-testUpload-v2.tar.gz',
 			$file2->Name,
 			'File receives a number attached to the end before the extension'
 		);
@@ -370,7 +370,7 @@ class UploadTest extends SapphireTest {
 		$u->load($tmpFile);
 		$file3 = $u->getFile();
 		$this->assertEquals(
-			'UploadTest-testUpload3.tar.gz',
+			'UploadTest-testUpload-v3.tar.gz',
 			$file3->Name,
 			'File receives a number attached to the end before the extension'
 		);
@@ -434,7 +434,7 @@ class UploadTest extends SapphireTest {
 		$u->load($tmpFile);
 		$file2 = $u->getFile();
 		$this->assertEquals(
-			'UploadTest-testUpload2',
+			'UploadTest-testUpload-v2',
 			$file2->Name,
 			'File receives a number attached to the end'
 		);
@@ -584,7 +584,7 @@ class UploadTest extends SapphireTest {
 		$u->loadIntoFile($tmpFile, new File());
 		$file3 = $u->getFile();
 		$this->assertEquals(
-				'UploadTest-testUpload2.txt',
+				'UploadTest-testUpload-v2.txt',
 				$file3->Name,
 				'File does receive new name'
 		);
@@ -674,31 +674,35 @@ class UploadTest extends SapphireTest {
 			$u->load($tmpFile);
 			return $u->getFile();
 		};
+		
+		// test empty file version prefix
+		$originalVersionPrefix = Config::inst()->get('Upload', 'version_prefix');
+		Config::inst()->update('Upload', 'version_prefix', '');
 
-		$file1 = $upload('UploadTest-testUpload.jpg');
+		$file1 = $upload('UploadTest-IMG001.jpg');
 		$this->assertEquals(
-			'UploadTest-testUpload.jpg',
+			'UploadTest-IMG001.jpg',
 			$file1->Name,
 			'File does not receive new name'
 		);
 
-		$file2 = $upload('UploadTest-testUpload.jpg');
+		$file2 = $upload('UploadTest-IMG001.jpg');
 		$this->assertEquals(
-			'UploadTest-testUpload2.jpg',
+			'UploadTest-IMG2.jpg',
 			$file2->Name,
 			'File does receive new name'
 		);
 
-		$file3 = $upload('UploadTest-testUpload.jpg');
+		$file3 = $upload('UploadTest-IMG001.jpg');
 		$this->assertEquals(
-			'UploadTest-testUpload3.jpg',
+			'UploadTest-IMG3.jpg',
 			$file3->Name,
 			'File does receive new name'
 		);
 
-		$file4 = $upload('UploadTest-testUpload3.jpg');
+		$file4 = $upload('UploadTest-IMG3.jpg');
 		$this->assertEquals(
-			'UploadTest-testUpload4.jpg',
+			'UploadTest-IMG4.jpg',
 			$file4->Name,
 			'File does receive new name'
 		);
@@ -707,6 +711,44 @@ class UploadTest extends SapphireTest {
 		$file2->delete();
 		$file3->delete();
 		$file4->delete();
+		
+		// test '-v' file version prefix
+		Config::inst()->update('Upload', 'version_prefix', '-v');
+
+		$file1 = $upload('UploadTest2-IMG001.jpg');
+		$this->assertEquals(
+			'UploadTest2-IMG001.jpg',
+			$file1->Name,
+			'File does not receive new name'
+		);
+
+		$file2 = $upload('UploadTest2-IMG001.jpg');
+		$this->assertEquals(
+			'UploadTest2-IMG001-v2.jpg',
+			$file2->Name,
+			'File does receive new name'
+		);
+
+		$file3 = $upload('UploadTest2-IMG001.jpg');
+		$this->assertEquals(
+			'UploadTest2-IMG001-v3.jpg',
+			$file3->Name,
+			'File does receive new name'
+		);
+
+		$file4 = $upload('UploadTest2-IMG001-v3.jpg');
+		$this->assertEquals(
+			'UploadTest2-IMG001-v4.jpg',
+			$file4->Name,
+			'File does receive new name'
+		);
+
+		$file1->delete();
+		$file2->delete();
+		$file3->delete();
+		$file4->delete();
+		
+		Config::inst()->update('Upload', 'version_prefix', $originalVersionPrefix);
 	}
 
 }


### PR DESCRIPTION
Numbers are often used at the end of file names in image sequences (e.g. digital photos) and the current renaming scheme can disrupt this, creating a confusing situation for the user. A configurable file version prefix should help prevent this.

Filename   | Old result | New result
-----------|------------|--------------
IMG001.jpg | IMG2.jpg   | IMG001-v2.jpg

Note: this is a version of #4241 for master which introduces a default value of '-v'.