### PR TITLE
Issue with empty CheckboxSetField value

### DIFF
--- a/forms/CheckboxSetField.php
+++ b/forms/CheckboxSetField.php
@@ -96,8 +96,12 @@ class CheckboxSetField extends OptionsetField {
 						}
 					}
 				} elseif($values && is_string($values)) {
-					$items = explode(',', $values);
-					$items = str_replace('{comma}', ',', $items);
+					if(!empty($values)) {
+						$items = explode(',', $values);
+						$items = str_replace('{comma}', ',', $items);
+					} else {
+						$items = array();
+					}
 				}
 			}
 		} else {
@@ -109,8 +113,12 @@ class CheckboxSetField extends OptionsetField {
 					$items = array();
 				}
 				else {
-					$items = explode(',', $values);
-					$items = str_replace('{comma}', ',', $items);
+					if(!empty($values)) {
+						$items = explode(',', $values);
+						$items = str_replace('{comma}', ',', $items);
+					} else {
+						$items = array();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
If the source of CheckboxSetField contains an empty string (i.e, nothing selected) and you have an option with the key value of 0, it will be selected. Explode returns an array of key 0/value empty with an empty input. Therefore, check that the value is not null or empty before exploding, otherwise, return an empty array.