### PR TITLE
Fix the order of params

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -358,8 +358,8 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 			if(!is_string($fieldClass)) continue;
 
 			// Strip off any parameters
-			$bPos = strpos('(', $fieldClass);
-			if($bPos !== FALSE) $fieldClass = substr(0,$bPos, $fieldClass);
+			$bPos = strpos($fieldClass, '(');
+			if($bPos !== FALSE) $fieldClass = substr($fieldClass, 0, $bPos);
 			
 			// Test to see if it implements CompositeDBField
 			if(ClassInfo::classImplements($fieldClass, 'CompositeDBField')) {


### PR DESCRIPTION
The parameters for the strpos and substr functions were wrong. strpos always failed so never triggered the substr.

This would mean $fieldClass would be left with 'Varchar(255)'

Fixing this had no noticeable speed or memory effect.