### PR TITLE
Fix nesting of config in tests to prevent iterative nesting

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -315,8 +315,12 @@ class Director implements TemplateGlobalProvider {
 			throw new SS_HTTPResponse_Exception(_t('Director.INVALID_REQUEST', 'Invalid request'), 400);
 		}
 
-		// TODO: Pass in the DataModel
-		$result = Director::handleRequest($request, $session, $model);
+		try {
+			$result = Director::handleRequest($request, $session, $model);
+		} catch(Exception $ex) {
+			$onCleanup();
+			throw $ex;
+		}
 
 		// Ensure that the result is an SS_HTTPResponse object
 		if(is_string($result)) {

--- a/core/Config.php
+++ b/core/Config.php
@@ -237,11 +237,12 @@ class Config {
 	 * @return Config Reference to new active Config instance
 	 */
 	public static function unnest() {
+		self::$instance->cache->clean();
 		return self::set_instance(self::$instance->nestedFrom);
 	}
 
 	/**
-	 * @var array
+	 * @var Config_Cache
 	 */
 	protected $cache;
 
@@ -681,9 +682,47 @@ class Config {
 /**
  * @package framework
  * @subpackage core
+ */
+interface Config_Cache {
+
+	/**
+	 * Set a config value
+	 * 
+	 * @param string $key
+	 * @param mixed $val
+	 * @param array $tags
+	 */
+	public function set($key, $val, $tags = array());
+	
+	/**
+	 * Get stats on this cache
+	 * 
+	 * @return array
+	 */
+	public function stats();
+	
+	/**
+	 * Get the value for a key
+	 * 
+	 * @param string $key
+	 * @return mixed
+	 */
+	public function get($key);
+	
+	/**
+	 * Clean values
+	 * 
+	 * @param string $tag Optional tag to limit cleaning to
+	 */
+	public function clean($tag = null);
+}
+
+/**
+ * @package framework
+ * @subpackage core
  * @deprecated 3.2
  */
-class Config_LRU {
+class Config_LRU implements Config_Cache {
 	const SIZE = 1000;
 
 	protected $cache;
@@ -793,7 +832,7 @@ class Config_LRU {
  * @package framework
  * @subpackage core
  */
-class Config_MemCache {
+class Config_MemCache implements Config_Cache {
 	protected $cache;
 
 	protected $i = 0;

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -27,6 +27,16 @@ class DataObjectTest extends SapphireTest {
 		'DataObjectTest_CEO',
 		'DataObjectTest_Fan',
 	);
+	
+	public function setUp() {
+		parent::setUp();
+		Config::nest();
+	}
+	
+	public function tearDown() {
+		Config::unnest();
+		parent::tearDown();
+	}
 
 	public function testDb() {
 		$obj = new DataObjectTest_TeamComment();
@@ -1069,62 +1079,35 @@ class DataObjectTest extends SapphireTest {
 	}
 
 	public function testValidateModelDefinitionsFailsWithArray() {
-		Config::nest();
-		
 		$object = new DataObjectTest_Team;
 		$method = $this->makeAccessible($object, 'validateModelDefinitions');
 
 		Config::inst()->update('DataObjectTest_Team', 'has_one', array('NotValid' => array('NoArraysAllowed')));
 		$this->setExpectedException('LogicException');
 
-		try {
-			$method->invoke($object);
-		} catch(Exception $e) {
-			Config::unnest(); // Catch the exception so we can unnest config before failing the test
-			throw $e;
-		}
+		$method->invoke($object);
 	}
 
 	public function testValidateModelDefinitionsFailsWithIntKey() {
-		Config::nest();
-		
 		$object = new DataObjectTest_Team;
 		$method = $this->makeAccessible($object, 'validateModelDefinitions');
-
 		Config::inst()->update('DataObjectTest_Team', 'has_many', array(12 => 'DataObjectTest_Player'));
 		$this->setExpectedException('LogicException');
-
-		try {
-			$method->invoke($object);
-		} catch(Exception $e) {
-			Config::unnest(); // Catch the exception so we can unnest config before failing the test
-			throw $e;
-		}
+		$method->invoke($object);
 	}
 
 	public function testValidateModelDefinitionsFailsWithIntValue() {
-		Config::nest();
-		
 		$object = new DataObjectTest_Team;
 		$method = $this->makeAccessible($object, 'validateModelDefinitions');
-
 		Config::inst()->update('DataObjectTest_Team', 'many_many', array('Players' => 12));
 		$this->setExpectedException('LogicException');
-
-		try {
-			$method->invoke($object);
-		} catch(Exception $e) {
-			Config::unnest(); // Catch the exception so we can unnest config before failing the test
-			throw $e;
-		}
+		$method->invoke($object);
 	}
 
 	/**
 	 * many_many_extraFields is allowed to have an array value, so shouldn't throw an exception
 	 */
 	public function testValidateModelDefinitionsPassesWithExtraFields() {
-		Config::nest();
-		
 		$object = new DataObjectTest_Team;
 		$method = $this->makeAccessible($object, 'validateModelDefinitions');
 
@@ -1134,12 +1117,9 @@ class DataObjectTest extends SapphireTest {
 		try {
 			$method->invoke($object);
 		} catch(Exception $e) {
-			Config::unnest();
 			$this->fail('Exception should not be thrown');
 			throw $e;
 		}
-
-		Config::unnest();
 	}
 
 	public function testNewClassInstance() {


### PR DESCRIPTION
Director::test was sometimes not unnesting config, meaning that config wasn't being cleaned up / collected properly.

Also fixed the custom nesting in DataObjectTest