### PR TITLE
FIX TreeDropdownField doesnt change label on unselect

### DIFF
--- a/forms/TreeDropdownField.php
+++ b/forms/TreeDropdownField.php
@@ -215,16 +215,21 @@ class TreeDropdownField extends FormField {
 		
 		Requirements::css(FRAMEWORK_DIR . '/thirdparty/jquery-ui-themes/smoothness/jquery-ui.css');
 		Requirements::css(FRAMEWORK_DIR . '/css/TreeDropdownField.css');
-	
+
+		if($this->showSearch) {
+			$emptyTitle = _t('DropdownField.CHOOSESEARCH', '(Choose or Search)', 'start value of a dropdown');
+		} else {
+			$emptyTitle = _t('DropdownField.CHOOSE', '(Choose)', 'start value of a dropdown');
+		}
+
 		$record = $this->Value() ? $this->objectForKey($this->Value()) : null;
 		if($record instanceof ViewableData) {
 			$title = $record->obj($this->labelField)->forTemplate();
 		} elseif($record) {
 			$title = Convert::raw2xml($record->{$this->labelField});
-		} else if($this->showSearch) {
-			$title = _t('DropdownField.CHOOSESEARCH', '(Choose or Search)', 'start value of a dropdown');
-		} else {
-			$title = _t('DropdownField.CHOOSE', '(Choose)', 'start value of a dropdown');
+		}
+		else {
+			$title = $emptyTitle;
 		}
 
 		// TODO Implement for TreeMultiSelectField
@@ -237,6 +242,7 @@ class TreeDropdownField extends FormField {
 			$properties,
 			array(
 				'Title' => $title,
+				'EmptyTitle' => $emptyTitle,
 				'Metadata' => ($metadata) ? Convert::raw2json($metadata) : null,
 			)
 		);

--- a/javascript/TreeDropdownField.js
+++ b/javascript/TreeDropdownField.js
@@ -154,16 +154,20 @@
 				var updateFn = function() {
 					var val = self.getValue();
 					if(val) {
-						
+
 						var node = tree.find('*[data-id="' + val + '"]'),
 							title = node.children('a').find("span.jstree_pageicon")?node.children('a').find("span.item").html():null;
 						if(!title) title=(node.length > 0) ? tree.jstree('get_text', node[0]) : null;
-						
+
 						if(title) {
 							self.setTitle(title);
 							self.data('title', title);
 						}
 						if(node) tree.jstree('select_node', node);
+					}
+					else {
+						self.setTitle(self.data('empty-title'));
+						self.removeData('title');
 					}
 				};
 

--- a/templates/forms/TreeDropdownField.ss
+++ b/templates/forms/TreeDropdownField.ss
@@ -2,6 +2,7 @@
      class="TreeDropdownField <% if $extraClass %> $extraClass<% end_if %><% if $ShowSearch %> searchable<% end_if %>"
      data-url-tree="$Link('tree')"
      data-title="$Title.ATT"
+     data-empty-title="$EmptyTitle.ATT"
      <% if $Description %>title="$Description.ATT"<% end_if %>
      <% if $Metadata %>data-metadata="$Metadata.ATT"<% end_if %>>
 	<input id="$ID" type="hidden" name="$Name.ATT" value="$Value.ATT" />


### PR DESCRIPTION
This fixes a front-end regression in the CMS where changing a drop down to an unselected value appeared to make no difference:

Before:
![](https://dl.dropboxusercontent.com/u/3429338/Clippings/2015-06/2015-06-11_16-18-52-g128npZzec.gif)

After:
![](https://dl.dropboxusercontent.com/u/3429338/Clippings/2015-06/2015-06-11_16-16-26-Pn4tkhBd7I.gif)