### PR TITLE
Add 0 Based Position tip.

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/01_Syntax.md
+++ b/docs/en/02_Developer_Guides/01_Templates/01_Syntax.md
@@ -298,6 +298,7 @@ iteration.
  * `$First`, `$Last`, `$Middle`: Booleans about the position in the list.
  * `$FirstLast`: Returns a string, "first", "last", or "". Useful for CSS classes.
  * `$Pos`: The current position in the list (integer). Will start at 1.
+ * `$Pos(0)`: The current position in the list (integer). Will start at 0.
  * `$TotalItems`: Number of items in the list (integer).
 
 	:::ss


### PR DESCRIPTION
Sometimes you need a zero based index, unless you read the api there is no information that $Pos is actually a method that takes a starting position rather than just a property.