### PR TITLE
Make travis more resilient to composer self-update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
         - sudo apt-get install -y tidy
 
 before_script:
- - composer self-update
+ - composer self-update || true
  - phpenv rehash
  - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
  - "if [ \"$BEHAT_TEST\" = \"\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss; fi"


### PR DESCRIPTION
`composer self-update` has been failing regularly on travis recently.

As `composer` is already installed and it's not strictly essential to have the very latest version, this change allows the build to continue, even if composer can't self-update