### PR TITLE
API Revert DataObject::validate to 3.1 method signature (protected)

### DIFF
--- a/docs/en/04_Changelogs/3.2.0.md
+++ b/docs/en/04_Changelogs/3.2.0.md
@@ -57,7 +57,7 @@
 * Refactor of database connectivity classes into separate components linked together through dependency injection
 * Refactor of `SQLQuery` into separate objects for each query type: `SQLQuery`, `SQLDelete`, `SQLUpdate` and `SQLInsert`
 * PDO is now a standard connector, and is available for all database interfaces
-* `DataObject::validate()` method visibility changed to public
+* `DataObject::doValidate()` method visibility added to access `DataObject::validate` externally
 * `NumericField` now uses HTML5 "number" type instead of "text"
 * `UploadField` "Select from files" shows files in all folders by default
 * `UploadField` won't display an overwrite warning unless `Upload::replaceFile` is true
@@ -195,24 +195,6 @@
   searching is enabled.
 
 ## Upgrading Notes
-
-### DataObject::validate() method visibility changed to public
-
-The visibility of `DataObject::validate()` has been changed from `protected` to `public`.
-
-Any existing classes that currently set this as `protected` should be changed like in
-this example:
-
-
-	::php
-	class MyDataClass extends DataObject {
-		...
-		public function validate() {
-			...
-		}
-		...
-	}
-
 
 ### UploadField "Select from files" shows files in all folders by default
 

--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -913,7 +913,7 @@ class File extends DataObject {
 		return $labels;
 	}
 
-	public function validate() {
+	protected function validate() {
 		if($this->config()->apply_restrictions_to_admin || !Permission::check('ADMIN')) {
 			// Extension validation
 			// TODO Merge this with Upload_Validator

--- a/filesystem/Folder.php
+++ b/filesystem/Folder.php
@@ -326,7 +326,7 @@ class Folder extends File {
 		}
 	}
 
-	public function validate() {
+	protected function validate() {
 		return new ValidationResult(true);
 	}
 

--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -919,7 +919,7 @@ class FormField extends RequestHandler {
 	 * Validation method each {@link FormField} subclass should implement,
 	 * determining whether the field is valid or not based on the value.
 	 *
-	 * @param Validator
+	 * @param Validator $validator
 	 * @return boolean
 	 */
 	public function validate($validator) {

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1063,10 +1063,20 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	 * @see {@link ValidationResult}
 	 * @return ValidationResult
 	 */
-	public function validate() {
+	protected function validate() {
 		$result = ValidationResult::create();
 		$this->extend('validate', $result);
 		return $result;
+	}
+
+	/**
+	 * Public accessor for {@see DataObject::validate()}
+	 * 
+	 * @return ValidationResult
+	 */
+	public function doValidate() {
+		// validate will be public in 4.0
+		return $this->validate();
 	}
 
 	/**

--- a/security/Group.php
+++ b/security/Group.php
@@ -336,7 +336,7 @@ class Group extends DataObject {
 		$this->setField("Code", Convert::raw2url($val));
 	}
 
-	public function validate() {
+	protected function validate() {
 		$result = parent::validate();
 
 		// Check if the new group hierarchy would add certain "privileged permissions",

--- a/security/Member.php
+++ b/security/Member.php
@@ -1487,7 +1487,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	/**
 	 * Validate this member object.
 	 */
-	public function validate() {
+	protected function validate() {
 		$valid = parent::validate();
 
 		if(!$this->ID || $this->isChanged('Password')) {

--- a/security/PermissionRoleCode.php
+++ b/security/PermissionRoleCode.php
@@ -20,7 +20,7 @@ class PermissionRoleCode extends DataObject {
 		"Role" => "PermissionRole",
 	);
 
-	public function validate() {
+	protected function validate() {
 		$result = parent::validate();
 
 		// Check that new code doesn't increase privileges, unless an admin is editing.

--- a/tests/filesystem/FileTest.php
+++ b/tests/filesystem/FileTest.php
@@ -103,18 +103,18 @@ class FileTest extends SapphireTest {
 
 		// Invalid ext
 		$file->Name = 'asdf.php';
-		$v = $file->validate();
+		$v = $file->doValidate();
 		$this->assertFalse($v->valid());
 		$this->assertContains('Extension is not allowed', $v->message());
 
 		// Valid ext
 		$file->Name = 'asdf.txt';
-		$v = $file->validate();
+		$v = $file->doValidate();
 		$this->assertTrue($v->valid());
 
 		// Capital extension is valid as well
 		$file->Name = 'asdf.TXT';
-		$v = $file->validate();
+		$v = $file->doValidate();
 		$this->assertTrue($v->valid());
 
 		Config::inst()->remove('File', 'allowed_extensions');

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -1811,7 +1811,7 @@ class DataObjectTest_ValidatedObject extends DataObject implements TestOnly {
 		'Name' => 'Varchar(50)'
 	);
 
-	public function validate() {
+	protected function validate() {
 		if(!empty($this->Name)) {
 			return new ValidationResult();
 		} else {


### PR DESCRIPTION
The changes made in https://github.com/silverstripe/silverstripe-framework/pull/2729 were not fully semver compliant, so make this accessible with a `doValidate` method for now (until 4.0 when we can make validate properly public).