### PR TITLE
FIX No longer caching has_one after ID change

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -2316,6 +2316,10 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	 * @return DataObject $this
 	 */
 	public function setField($fieldName, $val) {
+		//if it's a has_one component, destroy the cache
+		if (substr($fieldName, -2) == 'ID') {
+			unset($this->components[substr($fieldName, 0, -2)]);
+		}
 		// Situation 1: Passing an DBField
 		if($val instanceof DBField) {
 			$val->Name = $fieldName;

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -311,6 +311,7 @@ class DataObjectTest extends SapphireTest {
 	public function testHasOneRelationship() {
 		$team1 = $this->objFromFixture('DataObjectTest_Team', 'team1');
 		$player1 = $this->objFromFixture('DataObjectTest_Player', 'player1');
+		$player2 = $this->objFromFixture('DataObjectTest_Player', 'player2');
 
 		// Add a captain to team 1
 		$team1->setField('CaptainID', $player1->ID);
@@ -325,6 +326,14 @@ class DataObjectTest extends SapphireTest {
 			'Player 1 is the captain');
 		$this->assertEquals($team1->getComponent('Captain')->FirstName, 'Player 1',
 			'Player 1 is the captain');
+
+		$team1->CaptainID = $player2->ID;
+		$team1->write();
+
+		$this->assertEquals($player2->ID, $team1->Captain()->ID);
+		$this->assertEquals($player2->ID, $team1->getComponent('Captain')->ID);
+		$this->assertEquals('Player 2', $team1->Captain()->FirstName);
+		$this->assertEquals('Player 2', $team1->getComponent('Captain')->FirstName);
 	}
 	
 	/**


### PR DESCRIPTION
Bug where the cache for has_one relations doesn't expire when an relation ID is changed.

eg:

```php
$do = MyDataObject::get()->byID(1);
$do->HasOneRelation()->ID; // 1
$do->HasOneRelationID = 2;
$do->write();
$do->HasOneRelation()->ID; //still 1
```