### PR TITLE
Update 00_Issues_and_Bugs.md

### DIFF
--- a/docs/en/05_Contributing/00_Issues_and_Bugs.md
+++ b/docs/en/05_Contributing/00_Issues_and_Bugs.md
@@ -14,7 +14,7 @@ well written bug reports can be half of the solution already!
  * Search on [http://silverstripe.org/modules](http://silverstripe.org/modules) for module-specific bugtrackers
  * Request features: [UserVoice](http://silverstripe.uservoice.com).
 
-Before submitting a bug:
+Before submitting a bug: 
 
  * Ask for assistance on the [forums](http://www.silverstripe.org/community/forums/), [core mailinglist](http://groups.google.com/group/silverstripe-dev) or on [IRC](http://irc.silverstripe.org/) if you're unsure if its really a bug.
  * Search for similar, existing tickets


### PR DESCRIPTION
Line 13: is there a separate bug tracker for docs ? I couldn't find it easily. At the moment, users are referred to the framework bug tracker to record doc bugs. 
Line 65: should this be a link to documentation group (which looks full of "cobwebs") or translators ? Probably the former.