### PR TITLE
Bug: Page in SiteTree is incorrectly moved on reload in some cases

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -976,6 +976,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 			$data[$id] = array(
 				'html' => $html, 
 				'ParentID' => $record->ParentID,
+				'Sort' => $record->Sort,
 				'NextID' => $next ? $next->ID : null,
 				'PrevID' => $prev ? $prev->ID : null
 			);

--- a/admin/javascript/LeftAndMain.Tree.js
+++ b/admin/javascript/LeftAndMain.Tree.js
@@ -264,7 +264,7 @@
 				this.jstree(
 					'create_node', 
 					parentNode.length ? parentNode : -1, 
-					'last', 
+					data.Sort ? data.Sort : 'last',  
 					properties,
 					function(node) {
 						var origClasses = node.attr('class');


### PR DESCRIPTION
In some cases, the selected page in the site tree will not return to it's correct position when the page is reloaded/refreshed by the browser. If/when the subtree is loaded via ajax (I've identified about 5 subtree's deep), the javascript tells the selected page to be created in the "last" position (see LeftAndMain.Tree.js:267). This will only happen if the page is reloaded via the browser and the subtree has to load via ajax.

The fix is passing through the Sort field from the database via updatetreenodes and use that value to tell jstree create_node where to place the newly created "node"/page.