### PR TITLE
Install - Check if mysite/_config/config.yml is writeable

### DIFF
--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -415,6 +415,13 @@ class InstallRequirements {
 			"Is the mysite/_config.php file writeable?",
 			null
 		));
+
+		$this->requireWriteable('mysite/_config/config.yml', array(
+			"File permissions",
+			"Is the mysite/_config/config.yml file writeable?",
+			null
+		));
+
 		if(!$this->checkModuleExists('cms')) {
 			$this->requireWriteable('mysite/code/RootURLController.php', array(
 				"File permissions",


### PR DESCRIPTION
In 3.2b1, the installer likes to write changes to mysite/_config/config.yml. We should check if this file is writeable first.

Bug:
- `Couldn't write to file /silverstripe-dev-3.2/mysite/_config/config.yml`
- breaks install process