### PR TITLE
FIX: docs not included in composer package installs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/ export-ignore


### PR DESCRIPTION
This change will improve the performance of package-download-based installs of composer packages, by excluding docs. It does this by excluding them from the output of the "git archive" command.

It uses the export-ignore git attribute to do this.

The suggestion came from https://github.com/composer/composer/issues/1750