### PR TITLE
Unable to migrate down

### DIFF
--- a/dev/MigrationTask.php
+++ b/dev/MigrationTask.php
@@ -16,7 +16,7 @@
  * 	protected $description = "Description"; // description of what it does
  *
  * 	public function run($request) {
- * 		if ($request->param('Direction') == 'down') {
+ * 		if ($request->getVar('Direction') == 'down') {
  * 			$this->down();
  * 		} else {
  * 			$this->up();


### PR DESCRIPTION
Possible bug? Running PHP 5.6.3 
I had to override this method in MyMigrationTask.
I was running it like so 
http://localhost/dev/tasks/MyMigrationTask?Direction=down&isDevtoken=1f77ac503d80182e49fe100d651b5e1a&isDev=1