### PR TITLE
Save resampled images into a folder structure indicating transformations

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -229,7 +229,7 @@ class File extends DataObject {
 	 */
 	public static function find($filename) {
 		// Get the base file if $filename points to a resampled file
-		$filename = preg_replace('/_resampled\/[^-]+-/', '', $filename);
+		$filename = preg_replace('/_resampled\/(.+\/|[^-]+-)/', '', $filename);
 
 		// Split to folders and the actual filename, and traverse the structure.
 		$parts = explode("/", $filename);

--- a/filesystem/Filesystem.php
+++ b/filesystem/Filesystem.php
@@ -79,6 +79,29 @@ class Filesystem extends Object {
 	}
 
 	/**
+	 * Remove a directory, but only if it is empty.
+	 *
+	 * @param String $folder Absolute folder path
+	 * @param Boolean $recursive Remove contained empty folders before attempting to remove this one
+	 * @return Boolean True on success, false on failure. 
+	 */
+	public static function removeFolderIfEmpty($folder, $recursive = true) {
+		if (!is_readable($folder)) return false;
+		$handle = opendir($folder);
+		while (false !== ($entry = readdir($handle))) {
+			if ($entry != "." && $entry != "..") {
+				// if an empty folder is detected, remove that one first and move on
+				if($recursive && is_dir($entry) && self::removeFolderIfEmpty($entry)) continue;
+				// if a file was encountered, or a subdirectory was not empty, return false.
+				return false;
+			}
+		}
+		// if we are still here, the folder is empty. 
+		rmdir($folder);
+		return true;
+	}
+
+	/**
 	 * Cleanup function to reset all the Filename fields.  Visit File/fixfiles to call.
 	 */
 	public function fixfiles() {

--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -461,7 +461,7 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 				));
 			} else {
 				$url = Director::makeRelative($request->getVar('FileURL'));
-				$url = preg_replace('/_resampled\/[^-]+-/', '', $url);
+				$url = preg_replace('/_resampled\/(.+\/|[^-]+-)/', '', $url);
 				$file = File::get()->filter('Filename', $url)->first();
 				if(!$file) $file = new File(array(
 					'Title' => basename($url),

--- a/tests/forms/HtmlEditorFieldTest.php
+++ b/tests/forms/HtmlEditorFieldTest.php
@@ -88,8 +88,8 @@ class HtmlEditorFieldTest extends FunctionalTest {
 		$this->assertEquals(10, (int)$xml[0]['width'], 'Width tag of resized image is set.');
 		$this->assertEquals(20, (int)$xml[0]['height'], 'Height tag of resized image is set.');
 
-		$neededFilename = 'assets/_resampled/ResizedImage' . base64_encode(json_encode(array(10,20))) .
-			'-HTMLEditorFieldTest_example.jpg';
+		$neededFilename = 'assets/_resampled/ResizedImage' . base64url_encode(json_encode(array(10,20))) .
+			'/HTMLEditorFieldTest_example.jpg';
 
 		$this->assertEquals($neededFilename, (string)$xml[0]['src'], 'Correct URL of resized image is set.');
 		$this->assertTrue(file_exists(BASE_PATH.DIRECTORY_SEPARATOR.$neededFilename), 'File for resized image exists');


### PR DESCRIPTION
This is a solution for issue #4295. 

Resampled images are now saved into a folder structure that indicates the image transformations that have happened, rather than creating a long filename prefix. 

This change should be transparent to users, so I'm hoping this may make it into 3.2. I have tracked down all implications I could find, but will be happy to create additional patches if any issues come up during beta testing. 

(Note that `Image::getGeneratedImages` uses the SPL function `RecursiveIteratorIterator`. SPL is included and compiled by default since PHP 5.0, and can no longer be disabled since PHP 5.3.)