### PR TITLE
DOCS: Link to member custom code change is broken

### DIFF
--- a/docs/en/04_Changelogs/beta/3.2.0-beta1.md
+++ b/docs/en/04_Changelogs/beta/3.2.0-beta1.md
@@ -49,7 +49,7 @@
  Use `set*()` and `add*()` methods instead.
 * Template `<% control $MyList %>` syntax removed. Use `<% loop $MyList %>` instead.
 * Removed `Member.LastVisited` and `Member.NumVisits` properties, see
-  [Howto: Track Member Logins](/extending/how_tos/track_member_logins) to restore functionality as custom code
+  [Howto: Track Member Logins](/developer_guides/extending/how_tos/track_member_logins) to restore functionality as custom code
 
 ## New and changed API
 


### PR DESCRIPTION
I've found it as http://docs.silverstripe.org/en/3.2/developer_guides/extending/how_tos/track_member_logins/ but I guess the absolute URL is wrong, and I'm not sure if there are language / version url rewrites in place to use them.