### PR TITLE
FIX MemberPassword history removed with with Members

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -59,7 +59,9 @@ class Member extends DataObject implements TemplateGlobalProvider {
 
 	private static $has_one = array();
 
-	private static $has_many = array();
+	private static $has_many = array(
+		'LoggedPasswords' => 'MemberPassword',
+	);
 
 	private static $many_many = array();
 
@@ -877,6 +879,26 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		if($this->isChanged('Password')) {
 			MemberPassword::log($this);
 		}
+	}
+
+	public function onAfterDelete() {
+		parent::onAfterDelete();
+
+		//prevent orphaned records remaining in the DB
+		$this->deletePasswordLogs();
+	}
+
+	/**
+	 * Delete the MemberPassword objects that are associated to this user
+	 *
+	 * @return self
+	 */
+	protected function deletePasswordLogs() {
+		foreach ($this->LoggedPasswords() as $password) {
+			$password->delete();
+			$password->destroy();
+		}
+		return $this;
 	}
 
 	/**

--- a/tests/security/MemberTest.php
+++ b/tests/security/MemberTest.php
@@ -172,6 +172,13 @@ class MemberTest extends FunctionalTest {
 		$this->assertInstanceOf('DataObject', $passwords->current());
 		$this->assertTrue($passwords->current()->checkPassword('1nitialPassword'),
 			"Password 1nitialPassword not found in MemberRecord");
+
+		//check we don't retain orphaned records when a member is deleted
+		$member->delete();
+
+		$passwords = MemberPassword::get()->filter('MemberID', $member->OldID);
+
+		$this->assertCount(0, $passwords);
 	}
 
 	/**


### PR DESCRIPTION
Currently Members that were deleted would still have their passwords stored in the DB even though they were deleted. This seems unnecessary and just increases data that could potentially be compromised later.