### PR TITLE
Define function as static (line 59)

### DIFF
--- a/docs/en/02_Developer_Guides/05_Extending/04_Shortcodes.md
+++ b/docs/en/02_Developer_Guides/05_Extending/04_Shortcodes.md
@@ -56,7 +56,7 @@ First we need to define a callback for the shortcode.
 			'MyShortCodeMethod' => 'HTMLText'
 		);
 
-		public function MyShortCodeMethod($arguments, $content = null, $parser = null, $tagName) {
+		public static function MyShortCodeMethod($arguments, $content = null, $parser = null, $tagName) {
 			return "<em>" . $tagName . "</em> " . $content . "; " . count($arguments) . " arguments.";
 		}
 	}


### PR DESCRIPTION
Not defining function on line 59 as static triggers php error: [Strict Notice] call_user_func() expects parameter 1 to be a valid callback, non-static method Page::MyShortCodeMethod() should not be called statically

Note: PHP 5.5.12