### PR TITLE
Remove PHP version upgrade requirement for 3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.3",
+		"php": ">=5.3.2",
 		"composer/installers": "~1.0"
 	},
 	"require-dev": {

--- a/dev/install/install.php
+++ b/dev/install/install.php
@@ -4,17 +4,17 @@
  ************************************************************************************
  **                                                                                **
  **  If you can read this text in your browser then you don't have PHP installed.  **
- **  Please install PHP 5.3.3 or higher, preferably PHP 5.3.4+.                    **
+ **  Please install PHP 5.3.2 or higher, preferably PHP 5.3.4+.                    **
  **                                                                                **
  ************************************************************************************
  ************************************************************************************/
 
 /**
- * PHP version check. Make sure we've got at least PHP 5.3.3 in the most friendly way possible
+ * PHP version check. Make sure we've got at least PHP 5.3.2 in the most friendly way possible
  */
 define('FRAMEWORK_NAME', 'framework');
 
-if (version_compare(phpversion(), '5.3.3', '<')) {
+if (version_compare(phpversion(), '5.3.2', '<')) {
 	header("HTTP/1.1 500 Server Error");
 	echo str_replace(
 		array('$PHPVersion', 'sapphire'),

--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -4,7 +4,7 @@
  ************************************************************************************
  **                                                                                **
  **  If you can read this text in your browser then you don't have PHP installed.  **
- **  Please install PHP 5.3.3 or higher, preferably PHP 5.3.4+.                    **
+ **  Please install PHP 5.3.2 or higher, preferably PHP 5.3.4+.                    **
  **                                                                                **
  ************************************************************************************
  ************************************************************************************/
@@ -382,7 +382,7 @@ class InstallRequirements {
 		$isIIS = $this->isIIS();
 		$webserver = $this->findWebserver();
 
-		$this->requirePHPVersion('5.3.4', '5.3.3', array(
+		$this->requirePHPVersion('5.3.4', '5.3.2', array(
 			"PHP Configuration",
 			"PHP5 installed",
 			null,

--- a/dev/install/php5-required.html
+++ b/dev/install/php5-required.html
@@ -1,18 +1,18 @@
 <html>
 	<head>
-		<title>PHP 5.3.3 is required</title>
+		<title>PHP 5.3.2 is required</title>
 		<link rel="stylesheet" type="text/css" href="framework/dev/install/css/install.css">
 	</head>
 	<body>
 		<div id="BgContainer">
 			<div id="Container">
 				<div id="Header">
-					<h1>PHP 5.3.3 required</h1>
+					<h1>PHP 5.3.2 required</h1>
 					<div class="left">
-						<h3>To run SilverStripe, please install PHP 5.3.3 or greater.</h3>
+						<h3>To run SilverStripe, please install PHP 5.3.2 or greater.</h3>
 
 						<p>We have detected that you are running PHP version <b>$PHPVersion</b>. In order to run SilverStripe,
-						you must have PHP version 5.3.3 or greater, and for best results we recommend PHP 5.3.4 or greater.<p/>
+						you must have PHP version 5.3.2 or greater, and for best results we recommend PHP 5.3.4 or greater.<p/>
 
 						<p>If you are running on a shared host, you may need to ask your hosting provider how to do this.</p>
 					</div>

--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -8,7 +8,7 @@ Our web-based [PHP installer](installation/) can check if you meet the requireme
 
 ## Web server software requirements
 
- * PHP 5.3.3+
+ * PHP 5.3.2+
  * We recommend using a PHP accelerator or opcode cache, such as [xcache](http://xcache.lighttpd.net/) or [WinCache](http://www.iis.net/download/wincacheforphp).
  * Allocate at least 48MB of memory to each PHP process. (SilverStripe can be resource hungry for some intensive operations.)
  * Required modules: dom, gd2, fileinfo, hash, iconv, mbstring, mysqli (or other database driver), session, simplexml, tokenizer, xml.

--- a/main.php
+++ b/main.php
@@ -4,7 +4,7 @@
  ************************************************************************************
  **                                                                                **
  **  If you can read this text in your browser then you don't have PHP installed.  **
- **  Please install PHP 5.3.3 or higher, preferably PHP 5.3.4+.                    **
+ **  Please install PHP 5.3.2 or higher, preferably PHP 5.3.4+.                    **
  **                                                                                **
  ************************************************************************************
  ************************************************************************************/
@@ -14,7 +14,7 @@
  * @subpackage core
  */
 
-if (version_compare(phpversion(), '5.3.3', '<')) {
+if (version_compare(phpversion(), '5.3.2', '<')) {
 	header("HTTP/1.1 500 Server Error");
 	echo str_replace('$PHPVersion', phpversion(), file_get_contents("dev/install/php5-required.html"));
 	die();

--- a/model/Image.php
+++ b/model/Image.php
@@ -711,7 +711,7 @@ class Image extends File implements Flushable {
 		array_shift($args);
 		$folder = $this->ParentID ? $this->Parent()->Filename : ASSETS_DIR . "/";
 
-		$format = $format . base64_encode(json_encode($args, JSON_NUMERIC_CHECK));
+		$format = $format . base64_encode(json_encode(array_map('strval', $args)));
 		$filename = $format . "-" . $this->Name;
 		$patterns = $this->getFilenamePatterns($this->Name);
 		if (!preg_match($patterns['FullPattern'], $filename)) {

--- a/tests/forms/HtmlEditorFieldTest.php
+++ b/tests/forms/HtmlEditorFieldTest.php
@@ -88,8 +88,7 @@ class HtmlEditorFieldTest extends FunctionalTest {
 		$this->assertEquals(10, (int)$xml[0]['width'], 'Width tag of resized image is set.');
 		$this->assertEquals(20, (int)$xml[0]['height'], 'Height tag of resized image is set.');
 
-		$neededFilename = 'assets/_resampled/ResizedImage' . base64_encode(json_encode(array(10,20))) .
-			'-HTMLEditorFieldTest_example.jpg';
+		$neededFilename = $imageFile->cacheFilename('ResizedImage', 10, 20);
 
 		$this->assertEquals($neededFilename, (string)$xml[0]['src'], 'Correct URL of resized image is set.');
 		$this->assertTrue(file_exists(BASE_PATH.DIRECTORY_SEPARATOR.$neededFilename), 'File for resized image exists');

--- a/tests/model/ImageTest.php
+++ b/tests/model/ImageTest.php
@@ -287,8 +287,14 @@ class ImageTest extends SapphireTest {
 		$imageFirst = $image->Pad(200,200,'CCCCCC');
 		$imageFilename = $imageFirst->getFullPath();
 			// Encoding of the arguments is duplicated from cacheFilename
-		$neededPart = 'Pad' . base64_encode(json_encode(array(200,200,'CCCCCC')));
+		$args = array(200,200,'CCCCCC');
+		$neededPart = 'Pad' . base64_encode(json_encode(array_map('strval', $args)));
 		$this->assertContains($neededPart, $imageFilename, 'Filename for cached image is correctly generated');
+
+		$intImage = $image->SetWidth(200);
+		$strImage = $image->SetWidth('200');
+		$this->assertEquals($intImage->getFullPath(), $strImage->getFullPath(),
+			'Filenames for string/int arguments differ');
 	}
 
 	public function testMultipleGenerateManipulationCalls_Regeneration() {
@@ -309,8 +315,9 @@ class ImageTest extends SapphireTest {
 		$this->assertEquals($expected, $actual);
 
 		$imageThird = $imageSecond->Pad(600,600,'0F0F0F');
+
 		// Encoding of the arguments is duplicated from cacheFilename
-		$argumentString = base64_encode(json_encode(array(600,600,'0F0F0F')));
+		$argumentString = base64_encode(json_encode(array_map('strval', array(600,600,'0F0F0F'))));
 		$this->assertNotNull($imageThird);
 		$this->assertContains($argumentString, $imageThird->getFullPath(),
 			'Image contains background color for padded resizement');
@@ -352,8 +359,8 @@ class ImageTest extends SapphireTest {
 		$this->assertTrue(file_exists($p), 'Resized image exists after creation call');
 
 		// Encoding of the arguments is duplicated from cacheFilename
-		$oldArgumentString = base64_encode(json_encode(array(200)));
-		$newArgumentString = base64_encode(json_encode(array(300)));
+		$oldArgumentString = base64_encode(json_encode(array('200')));
+		$newArgumentString = base64_encode(json_encode(array('300')));
 
 		$newPath = str_replace($oldArgumentString, $newArgumentString, $p);
 		$newRelative = str_replace($oldArgumentString, $newArgumentString, $image_generated->getFileName());


### PR DESCRIPTION
#4359

I’ve added an assertion to `ImageTest` that covers the bug that #2577 was trying to fix... let’s see what Travis makes of adding 5.3.2 to the build matrix