### PR TITLE
Amending composer.json constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,12 @@
 	],
 	"require": {
 		"php": ">=5.3.3",
-		"composer/installers": "*"
+		"composer/installers": "~1.0"
 	},
 	"require-dev": {
-		"phpunit/PHPUnit": "~3.7@stable"
+		"phpunit/PHPUnit": "~3.7"
 	},
 	"autoload": {
 		"classmap": ["tests/behat/features/bootstrap"]	
-	},
-	"minimum-stability": "dev"
+	}
 }


### PR DESCRIPTION
see https://github.com/silverstripe/silverstripe-installer/issues/100

- Moves composer installers to be locked onto v1
- Removed minimum-stability as it is root-only setting (https://getcomposer.org/doc/04-schema.md#minimum-stability)