### PR TITLE
FIX memory exhaustion in MySQLStatement->bind()

### DIFF
--- a/model/connect/MySQLStatement.php
+++ b/model/connect/MySQLStatement.php
@@ -58,12 +58,13 @@ class MySQLStatement extends SS_Query {
 			$variables[] = &$this->boundValues[$field->name];
 		}
 
-		call_user_func_array(array($this->statement, 'bind_result'), $variables);
 		$this->bound = true;
 		$this->metadata->free();
 
 		// Buffer all results
 		$this->statement->store_result();
+
+		call_user_func_array(array($this->statement, 'bind_result'), $variables);
 	}
 
 	/**


### PR DESCRIPTION
This is an attempt to fix #4322. It definitely fixed my problem but I'm not sure what side-effects there may be.

I basically done what was advised here: http://php.net/manual/en/mysqli-stmt.bind-result.php#57564

cc: @tractorcow 