### PR TITLE
FIX undefined method should be fatal error

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -758,7 +758,8 @@ abstract class Object {
 					);
 			}
 		} else {
-			// Please do not change the exception code number below.
+			// Please do not change the exception code number below as it effects VirtualPage in the cms.
+			// If anybody knows what 2175 means please update this comment. Thanks.
 			$class = get_class($this);
 			throw new Exception("Object->__call(): the method '$method' does not exist on '$class'", 2175);
 		}

--- a/dev/Debug.php
+++ b/dev/Debug.php
@@ -531,7 +531,8 @@ function exceptionHandler($exception) {
 	$file = $exception->getFile();
 	$line = $exception->getLine();
 	$context = $exception->getTrace();
-	return Debug::fatalHandler($errno, $message, $file, $line, $context);
+	Debug::fatalHandler($errno, $message, $file, $line, $context);
+	exit(1);
 }
 
 /**


### PR DESCRIPTION
There's currently no solid way to detect that a build has failed on CLI. At the moment if you call $class->undefinedMethod() it will throw an exception and end execution but it returns with exit code 0 meaning the script has ended successfully.

This fix passes handling through SilverStripe and back to PHP to throw the default exit code (255).

Ideally, this would all be handled within SilverStripe but that requires an API change so something for the future.

To replicate the issue:

On any DataObject subclass add:

    public function requireDefaultRecords() {
        parent::requireDefaultRecords();
        $this->undefinedMethod();
    }

Then on the CLI run:
    `php framework/cli-script.php dev/build > /dev/null && echo $?`

Expected: Fatal Error
Actual: 0