### PR TITLE
Enable *_Readonly subclass on FormField

### DIFF
--- a/forms/CurrencyField.php
+++ b/forms/CurrencyField.php
@@ -36,13 +36,6 @@ class CurrencyField extends TextField {
 		return 'currency text';
 	}
 
-	/**
-	 * Create a new class for this field
-	 */
-	public function performReadonlyTransformation() {
-		return $this->castedCopy('CurrencyField_Readonly');
-	}
-
 	public function validate($validator) {
         $currencySymbol = preg_quote(Config::inst()->get('Currency','currency_symbol'));
         $regex = '/^\s*(\-?'.$currencySymbol.'?|'.$currencySymbol.'\-?)?(\d{1,3}(\,\d{3})*|(\d+))(\.\d{2})?\s*$/';

--- a/forms/DatetimeField.php
+++ b/forms/DatetimeField.php
@@ -339,7 +339,7 @@ class DatetimeField extends FormField {
 	}
 
 	public function performReadonlyTransformation() {
-		$field = $this->castedCopy('DatetimeField_Readonly');
+		$field = parent::performReadonlyTransformation();
 		$field->setValue($this->dataValue());
 
 		$dateFieldConfig = $this->getDateField()->getConfig();

--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -1039,10 +1039,16 @@ class FormField extends RequestHandler {
 	 * @return FormField
 	 */
 	public function performReadonlyTransformation() {
-		$readonlyClassName = $this->class . '_Readonly';
+		// Strip suffix so the transformation works on already transformed classes
+		$class = preg_replace('/(_readonly|_disabled)$/i', '', $this->class, 1);
 
+		$readonlyClassName = $class . '_Readonly';
+		$disabledClassName = $class . '_Disabled';
 		if(ClassInfo::exists($readonlyClassName)) {
 			$clone = $this->castedCopy($readonlyClassName);
+		} elseif(ClassInfo::exists($disabledClassName)) {
+			Deprecation::notice('3.5', "Using $disabledClassName as a fallback for $readOnlyClassName will be removed");
+			$clone = $this->castedCopy($disabledClassName);
 		} else {
 			$clone = $this->castedCopy('ReadonlyField');
 		}

--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -118,7 +118,7 @@ class HtmlEditorField extends TextareaField {
 	 * @return HtmlEditorField_Readonly
 	 */
 	public function performReadonlyTransformation() {
-		$field = $this->castedCopy('HtmlEditorField_Readonly');
+		$field = parent::performReadonlyTransformation();
 		$field->dontEscape = true;
 
 		return $field;

--- a/forms/InlineFormAction.php
+++ b/forms/InlineFormAction.php
@@ -23,10 +23,6 @@ class InlineFormAction extends FormField {
 		parent::__construct($action, $title);
 	}
 
-	public function performReadonlyTransformation() {
-		return $this->castedCopy('InlineFormAction_ReadOnly');
-	}
-
 	/**
 	 * @param array $properties
 	 * @return HTMLText

--- a/forms/TimeField.php
+++ b/forms/TimeField.php
@@ -221,13 +221,6 @@ class TimeField extends TextField {
 		}
 	}
 
-	/**
-	 * Creates a new readonly field specified below
-	 */
-	public function performReadonlyTransformation() {
-		return $this->castedCopy('TimeField_Readonly');
-	}
-
 	public function castedCopy($class) {
 		$copy = parent::castedCopy($class);
 		if($copy->hasMethod('setConfig')) {

--- a/forms/TreeDropdownField.php
+++ b/forms/TreeDropdownField.php
@@ -522,7 +522,7 @@ class TreeDropdownField extends FormField {
 	 * Changes this field to the readonly field.
 	 */
 	public function performReadonlyTransformation() {
-		$copy = $this->castedCopy('TreeDropdownField_Readonly');
+		$copy = parent::performReadonlyTransformation();
 		$copy->setKeyField($this->keyField);
 		$copy->setLabelField($this->labelField);
 		$copy->setSourceObject($this->sourceObject);

--- a/forms/TreeMultiselectField.php
+++ b/forms/TreeMultiselectField.php
@@ -176,7 +176,7 @@ class TreeMultiselectField extends TreeDropdownField {
 	 * Changes this field to the readonly field.
 	 */
 	public function performReadonlyTransformation() {
-		$copy = $this->castedCopy('TreeMultiselectField_Readonly');
+		$copy = parent::performReadonlyTransformation();
 		$copy->setKeyField($this->keyField);
 		$copy->setLabelField($this->labelField);
 		$copy->setSourceObject($this->sourceObject);

--- a/tests/forms/FormFieldTest.php
+++ b/tests/forms/FormFieldTest.php
@@ -159,6 +159,16 @@ class FormFieldTest extends SapphireTest {
 		$this->assertContains('readonly="readonly"', $field->getAttributesHTML());
 		$field->setReadonly(false);
 		$this->assertNotContains('readonly="readonly"', $field->getAttributesHTML());
+		$this->assertInstanceOf('ReadonlyField', $field->performReadonlyTransformation());
+
+		$field = new FormFieldTest_TestField('MyField');
+		$this->assertInstanceOf('FormFieldTest_TestField_Readonly', $field->performReadonlyTransformation());
+
+		$field = new FormFieldTest_TestField_Readonly('MyField');
+		$this->assertInstanceOf('FormFieldTest_TestField_Readonly', $field->performReadonlyTransformation());
+
+		$field = new FormFieldTest_TestField_Disabled('MyField');
+		$this->assertInstanceOf('FormFieldTest_TestField_Readonly', $field->performReadonlyTransformation());
 	}
 
 	public function testDisabled() {
@@ -253,4 +263,25 @@ class FormFieldTest_Extension extends Extension implements TestOnly {
 		$attrs['extended'] = true;
 	}
 
+}
+
+/**
+ * @package framework
+ * @subpackage tests
+ */
+class FormFieldTest_TestField extends FormField {
+}
+
+/**
+ * @package framework
+ * @subpackage tests
+ */
+class FormFieldTest_TestField_Readonly extends FormField {
+}
+
+/**
+ * @package framework
+ * @subpackage tests
+ */
+class FormFieldTest_TestField_Disabled extends FormField {
 }


### PR DESCRIPTION
When rendering read-only fields only the *_Disabled subclass was checked
for in FormField::performReadOnlyTransformation().

Added a *_Readonly check and kept the *_Disabled check for backward
compatibility.

Cleaned up all subclasses by using removing bogus overrides and using
parent::performReadOnlyTransformation() instead of
castedCopy('*_Readonly').
