### PR TITLE
Improved label clipping in site tree

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -862,8 +862,8 @@ form.import-form label.left { width: 250px; }
 .jstree-apple a { border-radius: 3px; }
 
 /* ensure status is visible in sidebar */
-.cms-content-tools .cms-tree.jstree li { min-width: 159px; }
-.cms-content-tools .cms-tree.jstree a { overflow: hidden; display: block; position: relative; }
+.cms-content-tools .cms-tree.jstree li { min-width: 187px; }
+.cms-content-tools .cms-tree.jstree a { overflow: hidden; text-overflow: ellipsis; display: block; position: relative; }
 .cms-content-tools .cms-tree.jstree span.badge { position: absolute; top: 0; right: 0; padding: 7px 9px 6px 5px; margin: 0; max-width: 40%; -moz-transition: max-width 0.75s linear; -o-transition: max-width 0.75s linear; -webkit-transition: max-width 0.75s linear; transition: max-width 0.75s linear; }
 .cms-content-tools .cms-tree.jstree span.badge:hover { max-width: 150px; }
 

--- a/admin/scss/_tree.scss
+++ b/admin/scss/_tree.scss
@@ -610,10 +610,11 @@
 /* ensure status is visible in sidebar */
 .cms-content-tools .cms-tree.jstree {
 	li {
-		min-width: 159px;
+		min-width: 187px;
 	}
 	a {
 		overflow: hidden;
+		text-overflow: ellipsis;
 		display: block;
 		position: relative;
 	}


### PR DESCRIPTION
Deeply nested site tree nodes show a few more characters and any clipped text in labels is marked as such (thanks @clarkepaul) (fixes https://github.com/silverstripe/silverstripe-cms/issues/1235)

![labels](https://cloud.githubusercontent.com/assets/1079425/8550703/0adc91e0-2487-11e5-9790-5c279d91328c.gif)
