### PR TITLE
Improved site tree tooltips

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -1958,8 +1958,9 @@ class LeftAndMain_TreeNode extends ViewableData {
 		$obj = $this->obj;
 		return "<li id=\"record-$obj->ID\" data-id=\"$obj->ID\" data-pagetype=\"$obj->ClassName\" class=\""
 			. $this->getClasses() . "\">" . "<ins class=\"jstree-icon\">&nbsp;</ins>"
-			. "<a href=\"" . $this->getLink() . "\" title=\"" . _t('LeftAndMain.PAGETYPE','Page type: ')
-			. "$obj->class\" ><ins class=\"jstree-icon\">&nbsp;</ins><span class=\"text\">" . ($obj->TreeTitle)
+			. "<a href=\"" . $this->getLink() . "\" title=\"("
+			. trim(_t('LeftAndMain.PAGETYPE','Page type'), " :") // account for inconsistencies in translations
+			. ": " . $obj->i18n_singular_name() . ") $obj->Title\" ><ins class=\"jstree-icon\">&nbsp;</ins><span class=\"text\">" . ($obj->TreeTitle)
 			. "</span></a>";
 	}
 


### PR DESCRIPTION
Included full title and friendly singular name for page type. Also standardised white space and use of colon character in translations.

![screen shot 2015-07-07 at 2 21 24 pm](https://cloud.githubusercontent.com/assets/1079425/8557980/fa639172-24b5-11e5-800c-4c4a2292a71e.png)
