### PR TITLE
BUG Fix cookie errors when running in CLI

### DIFF
--- a/model/DB.php
+++ b/model/DB.php
@@ -73,6 +73,10 @@ class DB {
 	 * Set it to null to revert to the main database.
 	 */
 	public static function set_alternative_database_name($name = null) {
+		// Skip if CLI
+		if(Director::is_cli()) {
+			return;
+		}
 		if($name) {
 			if(!self::valid_alternative_database_name($name)) {
 				throw new InvalidArgumentException(sprintf(


### PR DESCRIPTION
This resolves an issue where errors during unit tests on CLI could result in a cookie write being attempted, which would often mask other errors in the output. 

`ERROR [User Warning]: Cookie 'alternativeDatabaseName' can't be set.`