### PR TITLE
Correct Memcached config in example

### DIFF
--- a/docs/en/02_Developer_Guides/08_Performance/01_Caching.md
+++ b/docs/en/02_Developer_Guides/08_Performance/01_Caching.md
@@ -117,14 +117,16 @@ To use this backend, you need a memcached daemon and the memcache PECL extension
 		'primary_memcached', 
 		'Memcached',
 		array(
-			'host' => 'localhost', 
-			'port' => 11211, 
-			'persistent' => true, 
-			'weight' => 1, 
-			'timeout' => 5,
-			'retry_interval' => 15, 
-			'status' => true, 
-			'failure_callback' => '' 
+			'servers' => array(
+				'host' => 'localhost', 
+				'port' => 11211, 
+				'persistent' => true, 
+				'weight' => 1, 
+				'timeout' => 5,
+				'retry_interval' => 15, 
+				'status' => true, 
+				'failure_callback' => ''
+			)
 		)
 	);
 	SS_Cache::pick_backend('primary_memcached', 'any', 10);


### PR DESCRIPTION
Unlike Libmemcached, the Memcached backend server config must be nested inside an array() with a single key 'servers' - otherwise the default host of 127.0.0.1 is used.

array(
	'servers' => array(
		'host' => 'localhost', 
		'port' => 11211, 
		'persistent' => true, 
		'weight' => 1, 
		'timeout' => 1,
		'retry_interval' => 15, 
		'status' => true, 
		'failure_callback' => ''
	)
)