### PR TITLE
HTML error message in ChangePasswordForm

### DIFF
--- a/security/ChangePasswordForm.php
+++ b/security/ChangePasswordForm.php
@@ -131,7 +131,8 @@ class ChangePasswordForm extends Form {
 						"We couldn't accept that password: {password}",
 						array('password' => nl2br("\n".$isValid->starredList()))
 					),
-					"bad"
+					"bad",
+					false
 				);
 
 				// redirect back to the form, instead of using redirectBack() which could send the user elsewhere.


### PR DESCRIPTION
Use third argument in sessionMessage to avoid escaping br in the error message