### PR TITLE
BUGFIX: Ampersands in Form data cut off

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -1415,9 +1415,10 @@ class Form extends RequestHandler {
 				// If field is in array-notation we need to access nested data
 				else if(strpos($name,'[')) {
 					// First encode data using PHP's method of converting nested arrays to form data
-					$flatData = urldecode(http_build_query($data));
+					$flatData    = http_build_query($data);
+					$encodedName = urlencode($name);
 					// Then pull the value out from that flattened string
-					preg_match('/' . addcslashes($name,'[]') . '=([^&]*)/', $flatData, $matches);
+					preg_match('/' . $encodedName . '=([^&]*)/', $flatData, $matches);
 
 					if (isset($matches[1])) {
 						$exists = true;


### PR DESCRIPTION
When ampersands are entered in the form data, all data after the ampersand is cut off.
Here's the scenario:

With a site I'm working on, a form is created which later saves its data to several different objects.

The fields are created along these lines:

``` php
        $smokerField = OptionsetField::create('Customer[Smoke]', _t('Quote.SmokerLabel', 'Êtes-vous fumeur(ese)'), array(
            'no'  => _t('Quote.db_Smoke_No', 'Non'),
            'yes' => _t('Quote.db_Smoke_Yes', 'Oui')
        ));
```

Now, when the data is submitted, various things are processed and the data is saved roughly like this:

``` php
        $form->saveInto($customer, array_keys($data['Customer']));
```

In this situation the bug occurs due to the handling of square brackets by `saveInto`.

``` php
// framework/forms/Form.php
 . . .
                // If field is in array-notation we need to access nested data
                else if(strpos($name,'[')) {
                    // First encode data using PHP's method of converting nested arrays to form data
                    $flatData = urldecode(http_build_query($data));
                    // Then pull the value out from that flattened string
                    preg_match('/' . addcslashes($name,'[]') . '=([^&]*)/', $flatData, $matches);

                    if (isset($matches[1])) {
                        $exists = true;
                        $val = $matches[1];
                    }
. . .
```

This is because `urldecode` is being called, which is decoding not only `&s` between fields, but also within them.
