### PR TITLE
Allow HHVM tests to run on new travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: php
 
 sudo: false
 
+addons:
+  apt:
+    packages:
+      - tidy
+
 cache:
   directories:
     - $HOME/.composer/cache
@@ -42,9 +47,6 @@ matrix:
       env: DB=MYSQL
     - php: hhvm
       env: DB=MYSQL
-      before_install:
-        - sudo apt-get update -qq
-        - sudo apt-get install -y tidy
 
 before_script:
  - composer self-update || true


### PR DESCRIPTION
Related: #4365 

This fixes the HHVM tests that fail due to sudo being used to install tidy.

Unfortunately, we need to have this addon for all environments as you can't do targeted addons for specific builds