### PR TITLE
API: Lazy load template parser

### DIFF
--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -785,7 +785,9 @@ class SSViewer implements Flushable {
 	 *  </code>
 	 */
 	public function __construct($templateList, TemplateParser $parser = null) {
-		$this->setParser($parser ?: Injector::inst()->get('SSTemplateParser'));
+		if ($parser) {
+			$this->setParser($parser);
+		}
 
 		if(!is_array($templateList) && substr((string) $templateList,-3) == '.ss') {
 			$this->chosenTemplates['main'] = $templateList;
@@ -829,6 +831,9 @@ class SSViewer implements Flushable {
 	 */
 	public function getParser()
 	{
+		if (!$this->parser) {
+			$this->parser = Injector::inst()->get('SSTemplateParser');
+		}
 		return $this->parser;
 	}
 
@@ -1105,6 +1110,8 @@ class SSViewer implements Flushable {
 		// through $Content and $Layout placeholders.
 		foreach(array('Content', 'Layout') as $subtemplate) {
 			if(isset($this->chosenTemplates[$subtemplate])) {
+				// NB: We intentionally avoid using ->getParser() here as it may trigger expensive 
+				// template parser instantiation that may not be necessary
 				$subtemplateViewer = new SSViewer($this->chosenTemplates[$subtemplate], $this->parser);
 				$subtemplateViewer->includeRequirements(false);
 				$subtemplateViewer->setPartialCacheStore($this->getPartialCacheStore());
@@ -1173,7 +1180,7 @@ class SSViewer implements Flushable {
 	}
 
 	public function parseTemplateContent($content, $template="") {
-		return $this->parser->compileString(
+		return $this->getParser()->compileString(
 			$content,
 			$template,
 			Director::isDev() && Config::inst()->get('SSViewer', 'source_file_comments')
@@ -1242,7 +1249,10 @@ class SSViewer_FromString extends SSViewer {
 	protected $cacheTemplate;
 	
 	public function __construct($content, TemplateParser $parser = null) {
-		$this->setParser($parser ?: Injector::inst()->get('SSTemplateParser'));
+		if ($parser) {
+			$this->setParser($parser);
+		}
+
 		$this->content = $content;
 	}
 


### PR DESCRIPTION
Rationale: loading `SSTemplateParser.php` is one of the most CPU and memory intensive operations that we do, yet we cache the template files that it generates - so for most requests, it’s not required _at all_.

Benchmarked on PHP 5.5.24:
<img width="535" alt="screen shot 2015-07-20 at 21 02 16" src="https://cloud.githubusercontent.com/assets/1655548/8785869/a2d2e954-2f22-11e5-822d-7caad88809b6.png">
<img width="649" alt="screen shot 2015-07-20 at 21 06 57" src="https://cloud.githubusercontent.com/assets/1655548/8785962/47b8fff8-2f23-11e5-8260-ba19ce07c6dd.png">

Yes, that memory saving is just from not loading one file!

Marked as API and PR-ed against master as a precaution really, but I guess this could possibly be a candidate for 3 if accepted?