### PR TITLE
FIX for #4417: Ensuring ->removeValidation() is defined on instances of Validator.

### DIFF
--- a/forms/Validator.php
+++ b/forms/Validator.php
@@ -4,7 +4,7 @@
  * This validation class handles all form and custom form validation through
  * the use of Required fields.
  *
- * Relies on javascript for client-side validation, and marking fields after serverside validation.
+ * Relies on javascript for client-side validation, and marking fields after server-side validation.
  *
  * Acts as a visitor to individual form fields.
  *
@@ -115,9 +115,19 @@ abstract class Validator extends Object {
 	}
 
 	/**
+	 * Performs actual validation. Data from the form is passed into this method.
+	 *
 	 * @param array $data
 	 *
 	 * @return mixed
 	 */
 	abstract public function php($data);
+
+	/**
+	 * Ensures your validator will not perform any validation at all, in case the current user doesn't have access to
+	 * edit any fields (for example).
+	 *
+	 * @return null
+	 */
+	abstract public function removeValidation();
 }


### PR DESCRIPTION
Quick fix for #4417. Went ahead and based this on `3.1`.

Might cause some issues for people who haven't defined this method and happen to also not actually need it, even though they're still technically at risk of a fatal error if that method is called in the future, should they ever have a validated form which is also not editable.
