### PR TITLE
harden addFilter method

### DIFF
--- a/model/DataList.php
+++ b/model/DataList.php
@@ -372,8 +372,10 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 
 	/**
 	 * Return a new instance of the list with an added filter
+	 *
+	 * @param  array $filterArray
 	 */
-	public function addFilter($filterArray) {
+	public function addFilter(array $filterArray) {
 		$list = $this;
 
 		foreach($filterArray as $field => $value) {

--- a/model/DataList.php
+++ b/model/DataList.php
@@ -373,9 +373,9 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 	/**
 	 * Return a new instance of the list with an added filter
 	 *
-	 * @param  array $filterArray
+	 * @param array $filterArray
 	 */
-	public function addFilter(array $filterArray) {
+	public function addFilter($filterArray) {
 		$list = $this;
 
 		foreach($filterArray as $field => $value) {


### PR DESCRIPTION
currently anything could be given to the method - causing the foreach to fatal fail if the given param is not iterable.