### PR TITLE
Upgrade template translation syntax

### DIFF
--- a/admin/templates/Includes/BackLink_Button.ss
+++ b/admin/templates/Includes/BackLink_Button.ss
@@ -1,7 +1,7 @@
 <% if $Backlink %>
 	<div class="cms_backlink">
 		<a class="backlink ss-ui-button cms-panel-link" data-icon="back" href="$Backlink">
-			<% _t('BackLink_Button_ss.Back', 'Back') %>
+			<%t BackLink_Button_ss.Back 'Back' %>
 		</a>
 	</div>
 <% end_if %>	

--- a/admin/templates/Includes/CMSLoadingScreen.ss
+++ b/admin/templates/Includes/CMSLoadingScreen.ss
@@ -1,6 +1,6 @@
 <div class="ss-loading-screen">
 	<div class="loading-logo">
-		<img class="loading-animation" src="$ModulePath(frameworkadmin)/images/spinner.gif" alt="<% _t('CMSLoadingScreen_ss.LOADING','Loading...') %>" />
-		<noscript><p class="nojs-warning"><span class="message notice"><% _t('CMSLoadingScreen_ss.REQUIREJS','The CMS requires that you have JavaScript enabled.') %></span></p></noscript>
+		<img class="loading-animation" src="$ModulePath(frameworkadmin)/images/spinner.gif" alt="<%t CMSLoadingScreen_ss.LOADING 'Loading...' %>" />
+		<noscript><p class="nojs-warning"><span class="message notice"><%t CMSLoadingScreen_ss.REQUIREJS 'The CMS requires that you have JavaScript enabled.' %></span></p></noscript>
 	</div>
 </div>

--- a/admin/templates/Includes/CMSSettingsController_SilverStripeNavigator.ss
+++ b/admin/templates/Includes/CMSSettingsController_SilverStripeNavigator.ss
@@ -1,5 +1,5 @@
 <div class="cms-navigator">
 	<a href="#" class="ss-ui-button cms-preview-toggle-link" data-icon="preview">
-		&laquo; <% _t('SilverStripeNavigator.Edit', 'Edit') %>
+		&laquo; <%t SilverStripeNavigator.Edit 'Edit' %>
 	</a>
 </div>

--- a/admin/templates/Includes/LeftAndMain_EditForm.ss
+++ b/admin/templates/Includes/LeftAndMain_EditForm.ss
@@ -50,7 +50,7 @@
 			<% end_loop %>
 			<% if $Controller.LinkPreview %>
 			<a href="$Controller.LinkPreview" class="cms-preview-toggle-link ss-ui-button" data-icon="preview">
-				<% _t('LeftAndMain.PreviewButton', 'Preview') %> &raquo;
+				<%t LeftAndMain.PreviewButton 'Preview' %> &raquo;
 			</a>
 			<% end_if %>
 		</div>

--- a/admin/templates/Includes/LeftAndMain_Menu.ss
+++ b/admin/templates/Includes/LeftAndMain_Menu.ss
@@ -8,10 +8,10 @@
 		</div>
 	
 		<div class="cms-login-status">
-			<a href="$LogoutURL" class="logout-link" title="<% _t('LeftAndMain_Menu_ss.LOGOUT','Log out') %>"><% _t('LeftAndMain_Menu_ss.LOGOUT','Log out') %></a>
+			<a href="$LogoutURL" class="logout-link" title="<%t LeftAndMain_Menu_ss.LOGOUT 'Log out' %>"><%t LeftAndMain_Menu_ss.LOGOUT 'Log out' %></a>
 			<% with $CurrentMember %>
 				<span>
-					<% _t('LeftAndMain_Menu_ss.Hello','Hi') %>
+					<%t LeftAndMain_Menu_ss.Hello 'Hi' %>
 					<a href="{$AbsoluteBaseURL}admin/myprofile" class="profile-link">
 						<% if $FirstName && $Surname %>$FirstName $Surname<% else_if $FirstName %>$FirstName<% else %>$Email<% end_if %>
 					</a>

--- a/admin/templates/Includes/LeftAndMain_SilverStripeNavigator.ss
+++ b/admin/templates/Includes/LeftAndMain_SilverStripeNavigator.ss
@@ -3,18 +3,18 @@
 	<% include LeftAndMain_ViewModeSelector SelectID="preview-mode-dropdown-in-preview" %>
 	
     <span id="preview-size-dropdown" class="preview-size-selector preview-selector field dropdown">
-		<select title="<% _t('SilverStripeNavigator.ViewDeviceWidth', 'Select a preview width') %>" id="preview-size-dropdown-select" class="preview-dropdown dropdown nolabel" autocomplete="off" name="Action">
-			<option data-icon="icon-auto" data-description="<% _t('SilverStripeNavigator.Responsive', 'Responsive') %>" class="icon-auto icon-view first" value="auto">
-				<% _t('SilverStripeNavigator.Auto', 'Auto') %>
+		<select title="<%t SilverStripeNavigator.ViewDeviceWidth 'Select a preview width' %>" id="preview-size-dropdown-select" class="preview-dropdown dropdown nolabel" autocomplete="off" name="Action">
+			<option data-icon="icon-auto" data-description="<%t SilverStripeNavigator.Responsive 'Responsive' %>" class="icon-auto icon-view first" value="auto">
+				<%t SilverStripeNavigator.Auto 'Auto' %>
 			</option>
-			<option data-icon="icon-desktop" data-description="1024px <% _t('SilverStripeNavigator.Width', 'width') %>" class="icon-desktop icon-view" value="desktop">
-				<% _t('SilverStripeNavigator.Desktop', 'Desktop') %>
+			<option data-icon="icon-desktop" data-description="1024px <%t SilverStripeNavigator.Width 'width' %>" class="icon-desktop icon-view" value="desktop">
+				<%t SilverStripeNavigator.Desktop 'Desktop' %>
 			</option>
-			<option data-icon="icon-tablet" data-description="800px <% _t('SilverStripeNavigator.Width', 'width') %>" class="icon-tablet icon-view" value="tablet">
-				<% _t('SilverStripeNavigator.Tablet', 'Tablet') %>
+			<option data-icon="icon-tablet" data-description="800px <%t SilverStripeNavigator.Width 'width' %>" class="icon-tablet icon-view" value="tablet">
+				<%t SilverStripeNavigator.Tablet 'Tablet' %>
 			</option>
-			<option data-icon="icon-mobile" data-description="400px <% _t('SilverStripeNavigator.Width', 'width') %>" class="icon-mobile icon-view last" value="mobile">
-				<% _t('SilverStripeNavigator.Mobile', 'Mobile') %>
+			<option data-icon="icon-mobile" data-description="400px <%t SilverStripeNavigator.Width 'width' %>" class="icon-mobile icon-view last" value="mobile">
+				<%t SilverStripeNavigator.Mobile 'Mobile' %>
 			</option>
 		</select>
 	</span>
@@ -32,7 +32,7 @@
 			</fieldset>
 		<% else %>
 			<span id="preview-state-dropdown" class="cms-preview-states field dropdown">
-				<select title="<% _t('SilverStripeNavigator.PreviewState', 'Preview State') %>" id="preview-states" class="preview-state dropdown nolabel" autocomplete="off" name="preview-state">
+				<select title="<%t SilverStripeNavigator.PreviewState 'Preview State' %>" id="preview-states" class="preview-state dropdown nolabel" autocomplete="off" name="preview-state">
 					<% loop $Items %>	
 					<option name="$Name" data-name="$Name" data-link="$Link" class="state-name $FirstLast" value="$Link" <% if $isActive %>selected<% end_if %>>
 						$Title

--- a/admin/templates/Includes/ModelAdmin_Content.ss
+++ b/admin/templates/Includes/ModelAdmin_Content.ss
@@ -8,7 +8,7 @@
 						<% if $SectionTitle %>
 							$SectionTitle
 						<% else %>
-							<% _t('ModelAdmin.Title', 'Data Models') %>
+							<%t ModelAdmin.Title 'Data Models' %>
 						<% end_if %>
 					</span>
 				</h2>
@@ -16,7 +16,7 @@
 		</div>
 
 		<div class="cms-content-header-tabs cms-tabset-nav-primary ss-ui-tabs-nav">
-			<button id="filters-button" class="icon-button font-icon-search" title="<% _t('CMSPagesController_Tools_ss.FILTER', 'Filter') %>"></button>
+			<button id="filters-button" class="icon-button font-icon-search" title="<%t CMSPagesController_Tools_ss.FILTER 'Filter' %>"></button>
 			<ul class="cms-tabset-nav-primary">
 				<% loop $ManagedModelTabs %>
 				<li class="tab-$ClassName $LinkOrCurrent<% if $LinkOrCurrent == 'current' %> ui-tabs-active<% end_if %>">

--- a/admin/templates/Includes/ModelAdmin_ImportSpec.ss
+++ b/admin/templates/Includes/ModelAdmin_ImportSpec.ss
@@ -1,8 +1,8 @@
 <div class="importSpec" id="SpecFor{$ModelName}">
-	<a href="#SpecDetailsFor{$ModelName}" class="detailsLink"><% sprintf(_t('ModelAdmin_ImportSpec_ss.IMPORTSPECLINK', 'Show Specification for %s'),$ModelName) %></a>
+	<a href="#SpecDetailsFor{$ModelName}" class="detailsLink"><%t ModelAdmin_ImportSpec_ss.IMPORTSPECLINK 'Show Specification for %s' s=$ModelName %></a>
 	<div class="details" id="SpecDetailsFor{$ModelName}">
-	<h4><% sprintf(_t('ModelAdmin_ImportSpec_ss.IMPORTSPECTITLE', 'Specification for %s'),$ModelName) %></h4>
-		<h5><% _t('ModelAdmin_ImportSpec_ss.IMPORTSPECFIELDS', 'Database columns') %></h5>
+	<h4><%t ModelAdmin_ImportSpec_ss.IMPORTSPECTITLE 'Specification for %s' s=$ModelName %></h4>
+		<h5><%t ModelAdmin_ImportSpec_ss.IMPORTSPECFIELDS 'Database columns' %></h5>
 		<% loop $Fields %>
 		<dl>
 			<dt><em>$Name</em></dt>
@@ -10,7 +10,7 @@
 		</dl>
 		<% end_loop %>
 
-		<h5><% _t('ModelAdmin_ImportSpec_ss.IMPORTSPECRELATIONS', 'Relations') %></h5>
+		<h5><%t ModelAdmin_ImportSpec_ss.IMPORTSPECRELATIONS 'Relations' %></h5>
 		<% loop $Relations %>
 		<dl>
 			<dt><em>$Name</em></dt>

--- a/admin/templates/Includes/ModelAdmin_Tools.ss
+++ b/admin/templates/Includes/ModelAdmin_Tools.ss
@@ -1,11 +1,11 @@
 <div id="cms-content-tools-ModelAdmin" class="cms-content-filters">
 	<% if $SearchForm %>
-	<h3 class="cms-panel-header"><% _t('ModelAdmin_Tools_ss.FILTER', 'Filter') %></h3>
+	<h3 class="cms-panel-header"><%t ModelAdmin_Tools_ss.FILTER 'Filter' %></h3>
 	$SearchForm
 	<% end_if %>
 
 	<% if $ImportForm %>
-	<h3 class="cms-panel-header"><% _t('ModelAdmin_Tools_ss.IMPORT', 'Import') %></h3>
+	<h3 class="cms-panel-header"><%t ModelAdmin_Tools_ss.IMPORT 'Import' %></h3>
 	$ImportForm
 	<% end_if %>
 </div>

--- a/admin/templates/LeftAndMain.ss
+++ b/admin/templates/LeftAndMain.ss
@@ -16,7 +16,7 @@
 		$Content
 
 		<div class="cms-preview east" data-layout-type="border">
-			<div class="preview-note"><span><!-- --></span><% _t('CMSPageHistoryController_versions_ss.PREVIEW','Website preview') %></div>
+			<div class="preview-note"><span><!-- --></span><%t CMSPageHistoryController_versions_ss.PREVIEW 'Website preview' %></div>
 			<div class="preview-scroll center">
 				<div class="preview-device-outer">
 					<div class="preview-device-inner">

--- a/admin/templates/ModelSidebar.ss
+++ b/admin/templates/ModelSidebar.ss
@@ -1,7 +1,7 @@
-<h3><% _t('ModelSidebar_ss.SEARCHLISTINGS','Search') %></h3>
+<h3><%t ModelSidebar_ss.SEARCHLISTINGS 'Search' %></h3>
 $SearchForm
 
 <% if $ImportForm %>
-	<h3><% _t('ModelSidebar_ss.IMPORT_TAB_HEADER', 'Import') %></h3>
+	<h3><%t ModelSidebar_ss.IMPORT_TAB_HEADER 'Import' %></h3>
 	$ImportForm
 <% end_if %>

--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -19,8 +19,9 @@ require_once 'i18nSSLegacyAdapter.php';
  *
  * Templates:
  * <code>
- * <% _t('MyNamespace.MYENTITY', 'My default natural language value') %>
- * <% sprintf(_t('MyNamespace.MYENTITY','Counting %s things'),$ThingsCount) %>
+ * <%t MyNamespace.MYENTITY 'My default natural language value' %>
+ * <%t MyNamespace.MYENTITY 'Counting %s things' s=$ThingsCount %>
+ * <%t MyNamespace.MYENTITY 'Counting {count} things' count=$ThingsCount %>
  * </code>
  *
  * Javascript (see framework/javascript/i18n.js):

--- a/templates/AssetUploadField.ss
+++ b/templates/AssetUploadField.ss
@@ -3,34 +3,34 @@
 	<h3>
 		<span class="step-label">
 			<span class="flyout">1</span><span class="arrow"></span>
-			<span class="title"><% _t('AssetUploadField.ChooseFiles', 'Choose files') %></span>
+			<span class="title"><%t AssetUploadField.ChooseFiles 'Choose files' %></span>
 		</span>
 	</h3>
 
 
 
 	<div class="ss-uploadfield-item-info">
-		<label class="ss-uploadfield-fromcomputer ss-ui-button ss-ui-action-constructive" title="<% _t('AssetUploadField.FROMCOMPUTERINFO', 'Upload from your computer') %>" data-icon="drive-upload-large">
-			<% _t('AssetUploadField.TOUPLOAD', 'Choose files to upload...') %>
-			<input id="$id" name="$getName" class="$extraClass ss-uploadfield-fromcomputer-fileinput" data-config="$configString" type="file"<% if $multiple %> multiple="multiple"<% end_if %> title="<% _t('AssetUploadField.FROMCOMPUTER', 'Choose files from your computer') %>" />
+		<label class="ss-uploadfield-fromcomputer ss-ui-button ss-ui-action-constructive" title="<%t AssetUploadField.FROMCOMPUTERINFO 'Upload from your computer' %>" data-icon="drive-upload-large">
+			<%t AssetUploadField.TOUPLOAD 'Choose files to upload...' %>
+			<input id="$id" name="$getName" class="$extraClass ss-uploadfield-fromcomputer-fileinput" data-config="$configString" type="file"<% if $multiple %> multiple="multiple"<% end_if %> title="<%t AssetUploadField.FROMCOMPUTER 'Choose files from your computer' %>" />
 		</label>
 		
 		<div class="clear"><!-- --></div>
 	</div>
 	<div class="ss-uploadfield-item-uploador">
-		<% _t('AssetUploadField.UPLOADOR', 'OR') %>
+		<%t AssetUploadField.UPLOADOR 'OR' %>
 	</div>
 	<div class="ss-uploadfield-item-preview ss-uploadfield-dropzone">
 		<div>
-			<% _t('AssetUploadField.DROPAREA', 'Drop Area') %>
-			<span><% _t('AssetUploadField.DRAGFILESHERE', 'Drag files here') %></span>
+			<%t AssetUploadField.DROPAREA 'Drop Area' %>
+			<span><%t AssetUploadField.DRAGFILESHERE 'Drag files here' %></span>
 		</div>
 	</div>
 	
 	<span class="ss-uploadfield-view-allowed-extensions"> 
 		<span class="description">
 
-			<a href="#" class="toggle"><% _t('AssetAdmin.SHOWALLOWEDEXTS', 'Show allowed extensions') %></a>
+			<a href="#" class="toggle"><%t AssetAdmin.SHOWALLOWEDEXTS 'Show allowed extensions' %></a>
 			<p class="toggle-content">$Extensions</p>
 		</span>	
 	</span>	
@@ -42,13 +42,13 @@
 	<h3>
 		<span class="step-label">
 			<span class="flyout">2</span><span class="arrow"></span>
-			<span class="title"><% _t('AssetUploadField.EDITANDORGANIZE', 'Edit & organize') %></span>
+			<span class="title"><%t AssetUploadField.EDITANDORGANIZE 'Edit & organize' %></span>
 		</span>
 	</h3>			
 
 		<div class="ss-uploadfield-item-actions edit-all">
-		<button class="ss-uploadfield-item-edit-all ss-ui-button ui-corner-all" title="<% _t('AssetUploadField.EDITINFO', 'Edit files') %>" style="display:none;">
-			<% _t('AssetUploadField.EDITALL', 'Edit all') %>
+		<button class="ss-uploadfield-item-edit-all ss-ui-button ui-corner-all" title="<%t AssetUploadField.EDITINFO 'Edit files' %>" style="display:none;">
+			<%t AssetUploadField.EDITALL 'Edit all' %>
 				<span class="toggle-details-icon"></span>
 		</button>
 	</div>
@@ -56,9 +56,9 @@
 	<ul class="ss-uploadfield-files files"></ul>
 	<div class="fileOverview">
 		<div class="uploadStatus message notice">
-			<div class="state"><% _t('AssetUploadField.UPLOADINPROGRESS', 'Please wait… upload in progress') %></div>
-			<div class="details"><% _t('AssetUploadField.TOTAL', 'Total') %>: 
-				<span class="total"></span> <% _t('AssetUploadField.FILES', 'Files') %> 
+			<div class="state"><%t AssetUploadField.UPLOADINPROGRESS 'Please wait… upload in progress' %></div>
+			<div class="details"><%t AssetUploadField.TOTAL 'Total' %>: 
+				<span class="total"></span> <%t AssetUploadField.FILES 'Files' %> 
 				<span class="fileSize"></span> 
 			</div>
 		</div>		

--- a/templates/HtmlEditorField_UploadField.ss
+++ b/templates/HtmlEditorField_UploadField.ss
@@ -3,24 +3,24 @@
 	<h4>
 		<span class="step-label">
 			<span class="flyout">1</span><span class="arrow"></span>
-			<span class="title"><% _t('AssetUploadField.ChooseFiles', 'Choose files') %></span>
+			<span class="title"><%t AssetUploadField.ChooseFiles 'Choose files' %></span>
 		</span>
 	</h4>
 
 	<div class="ss-uploadfield-item-info">
-		<label class="ss-uploadfield-fromcomputer ss-ui-button ss-ui-action-constructive" title="<% _t('AssetUploadField.FROMCOMPUTERINFO', 'Upload from your computer') %>" data-icon="drive-upload-large">
-			<% _t('AssetUploadField.TOUPLOAD', 'Choose files to upload...') %>
-			<input id="$id" name="$getName" class="$extraClass ss-uploadfield-fromcomputer-fileinput" data-config="$configString" type="file"<% if $multiple %> multiple="multiple"<% end_if %> title="<% _t('AssetUploadField.FROMCOMPUTER', 'Choose files from your computer') %>" />
+		<label class="ss-uploadfield-fromcomputer ss-ui-button ss-ui-action-constructive" title="<%t AssetUploadField.FROMCOMPUTERINFO 'Upload from your computer' %>" data-icon="drive-upload-large">
+			<%t AssetUploadField.TOUPLOAD 'Choose files to upload...' %>
+			<input id="$id" name="$getName" class="$extraClass ss-uploadfield-fromcomputer-fileinput" data-config="$configString" type="file"<% if $multiple %> multiple="multiple"<% end_if %> title="<%t AssetUploadField.FROMCOMPUTER 'Choose files from your computer' %>" />
 		</label>
 
 		<div class="clear"><!-- --></div>
 	</div>
 	<div class="ss-uploadfield-item-uploador">
-		<% _t('AssetUploadField.UPLOADOR', 'OR') %>
+		<%t AssetUploadField.UPLOADOR 'OR' %>
 	</div>
 	<div class="ss-uploadfield-item-preview ss-uploadfield-dropzone">
 		<div>
-			<span><% _t('AssetUploadField.DRAGFILESHERE', 'Drag files here') %></span>
+			<span><%t AssetUploadField.DRAGFILESHERE 'Drag files here' %></span>
 		</div>
 	</div>
 	<div class="clear"><!-- --></div>

--- a/templates/Image_iframe.ss
+++ b/templates/Image_iframe.ss
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" >
 	<head>
 		<% base_tag %>
-		<title><% _t('Image_iframe_ss.TITLE', 'Image Uploading Iframe') %></title>
+		<title><%t Image_iframe_ss.TITLE 'Image Uploading Iframe' %></title>
 		<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7">
 	</head>
 

--- a/templates/Includes/GridFieldEditButton.ss
+++ b/templates/Includes/GridFieldEditButton.ss
@@ -1,1 +1,1 @@
-<a class="action action-detail edit-link" href="$Link" title="<% _t('GridFieldEditButton_ss.EDIT', 'Edit') %>"><% _t('GridFieldEditButton_ss.EDIT', 'Edit') %></a>
+<a class="action action-detail edit-link" href="$Link" title="<%t GridFieldEditButton_ss.EDIT 'Edit' %>"><%t GridFieldEditButton_ss.EDIT 'Edit' %></a>

--- a/templates/Includes/GridFieldFooter.ss
+++ b/templates/Includes/GridFieldFooter.ss
@@ -4,7 +4,7 @@
 			<span class="pagination-records-number">
 				$FirstShownRecord - 
 				$LastShownRecord
-				<% _t('TableListField_PageControls_ss.OF', 'of', 'Example: View 1 of 2') %>
+				<%t TableListField_PageControls_ss.OF 'of' is 'Example: View 1 of 2' %>
 				$NumRecords
 			</span>
 		<% end_if %>

--- a/templates/Includes/GridFieldItemEditView.ss
+++ b/templates/Includes/GridFieldItemEditView.ss
@@ -1,5 +1,5 @@
 <% if Backlink %>
-	<a href="$Backlink"><% _t('GridFieldItemEditView.Go_back', 'Go back' ) %></a>
+	<a href="$Backlink"><%t GridFieldItemEditView.Go_back 'Go back' %></a>
 <% end_if %>
 
 $ItemEditForm

--- a/templates/Includes/GridFieldPageCount.ss
+++ b/templates/Includes/GridFieldPageCount.ss
@@ -1,6 +1,6 @@
 <span class="pagination-records-number">
-	<% _t('Pagination.View', 'View', 'Verb. Example: View 1 of 2') %>
+	<%t Pagination.View 'View' is 'Verb. Example: View 1 of 2' %>
 	{$FirstShownRecord}&ndash;{$LastShownRecord}
-	<% _t('TableListField_PageControls_ss.OF', 'of', 'Example: View 1 of 2') %> 
+	<%t TableListField_PageControls_ss.OF 'of' is 'Example: View 1 of 2' %> 
 	$NumRecords
 </span>

--- a/templates/Includes/GridFieldPaginator_Row.ss
+++ b/templates/Includes/GridFieldPaginator_Row.ss
@@ -5,18 +5,18 @@
 			<div class="datagrid-pagination">
 				$FirstPage $PreviousPage 
 				<span class="pagination-page-number">
-					<% _t('Pagination.Page', 'Page') %> 
+					<%t Pagination.Page 'Page' %> 
 					<input class="text" value="$CurrentPageNum" data-skip-autofocus="true" /> 
-					<% _t('TableListField_PageControls_ss.OF', 'of', 'Example: View 1 of 2') %> 
+					<%t TableListField_PageControls_ss.OF 'of' is 'Example: View 1 of 2' %> 
 					$NumPages
 				</span> 
 				$NextPage $LastPage 
 			</div>
 		<% end_if %>
 		<span class="pagination-records-number">
-			<% _t('Pagination.View', 'View', 'Verb. Example: View 1 of 2') %>
+			<%t Pagination.View 'View' is 'Verb. Example: View 1 of 2' %>
 			{$FirstShownRecord}&ndash;{$LastShownRecord}
-			<% _t('TableListField_PageControls_ss.OF', 'of', 'Example: View 1 of 2') %> 
+			<%t TableListField_PageControls_ss.OF 'of' is 'Example: View 1 of 2' %> 
 			$NumRecords
 		</span>
 	</td>

--- a/templates/Includes/GridField_print.ss
+++ b/templates/Includes/GridField_print.ss
@@ -16,15 +16,15 @@
 				<% end_loop %>
 				<% else %>
 					<tr>
-						<td colspan="$Header.Count"><p><% _t('GridField.NoItemsFound', 'No items found') %></p></td>
+						<td colspan="$Header.Count"><p><%t GridField.NoItemsFound 'No items found' %></p></td>
 					</tr>
 				<% end_if %>
 			</tbody>
 		</table>
 		<p>
-			<% _t('GridField.PRINTEDAT', 'Printed at') %> $Datetime.Time, $Datetime.Date
+			<%t GridField.PRINTEDAT 'Printed at' %> $Datetime.Time, $Datetime.Date
 			<br />
-			<% _t('GridField.PRINTEDBY', 'Printed by') %> $Member.Name
+			<%t GridField.PRINTEDBY 'Printed by' %> $Member.Name
 		</p>
 	</body>
 

--- a/templates/Includes/HtmlEditorField_viewfile.ss
+++ b/templates/Includes/HtmlEditorField_viewfile.ss
@@ -15,7 +15,7 @@
 				$Name
 			</span>
 			<% if $Width %>
-			<div class="ss-uploadfield-item-status ui-state-success-text" title="<% _t('UploadField.Dimensions', 'Dimensions') %>">
+			<div class="ss-uploadfield-item-status ui-state-success-text" title="<%t UploadField.Dimensions 'Dimensions' %>">
 				{$Width} x {$Height} (px)
 			</div>
 			<% end_if %>
@@ -23,13 +23,13 @@
 			<div class="clear"><!-- --></div> 
 		</label>
 		<div class="ss-uploadfield-item-actions">	
-			<button data-icon="deleteLight" class="ss-uploadfield-item-cancel ss-uploadfield-item-remove" title="<% _t('UploadField.REMOVE', 'Remove') %>">
-				<% _t('UploadField.REMOVE', 'Remove') %>
+			<button data-icon="deleteLight" class="ss-uploadfield-item-cancel ss-uploadfield-item-remove" title="<%t UploadField.REMOVE 'Remove' %>">
+				<%t UploadField.REMOVE 'Remove' %>
 			</button>
 			
 			<div class="ss-uploadfield-item-edit edit">
-				<button class="ss-uploadfield-item-edit ss-ui-button ui-corner-all" title="<% _t('UploadField.EDITINFO', 'Edit this file') %>" data-icon="pencil">
-					<% _t('UploadField.EDIT', 'Edit') %>
+				<button class="ss-uploadfield-item-edit ss-ui-button ui-corner-all" title="<%t UploadField.EDITINFO 'Edit this file' %>" data-icon="pencil">
+					<%t UploadField.EDIT 'Edit' %>
 					<span class="toggle-details">
 						<span class="toggle-details-icon"></span>
 					</span>

--- a/templates/Includes/LeftAndMain_ViewModeSelector.ss
+++ b/templates/Includes/LeftAndMain_ViewModeSelector.ss
@@ -1,12 +1,12 @@
 <span id="$SelectID" class="preview-mode-selector preview-selector field dropdown">
-	<select title="<% _t('SilverStripeNavigator.ChangeViewMode', 'Change view mode') %>" id="$SelectID-select" class="preview-dropdown dropdown nolabel no-change-track" autocomplete="off" name="Action">
+	<select title="<%t SilverStripeNavigator.ChangeViewMode 'Change view mode' %>" id="$SelectID-select" class="preview-dropdown dropdown nolabel no-change-track" autocomplete="off" name="Action">
 
-		<option data-icon="icon-split" class="icon-split icon-view first" value="split"><% _t('SilverStripeNavigator.SplitView', 'Split mode') %></option>
-		<option data-icon="icon-preview" class="icon-preview icon-view" value="preview"><% _t('SilverStripeNavigator.PreviewView', 'Preview mode') %></option>
-		<option data-icon="icon-edit" class="icon-edit icon-view last" value="content"><% _t('SilverStripeNavigator.EditView', 'Edit mode') %></option>
+		<option data-icon="icon-split" class="icon-split icon-view first" value="split"><%t SilverStripeNavigator.SplitView 'Split mode' %></option>
+		<option data-icon="icon-preview" class="icon-preview icon-view" value="preview"><%t SilverStripeNavigator.PreviewView 'Preview mode' %></option>
+		<option data-icon="icon-edit" class="icon-edit icon-view last" value="content"><%t SilverStripeNavigator.EditView 'Edit mode' %></option>
 		<!-- Dual window not implemented yet -->
 		<!--
-			<option data-icon="icon-window" class="icon-window icon-view last" value="window"><% _t('SilverStripeNavigator.DualWindowView', 'Dual Window') %></option>
+			<option data-icon="icon-window" class="icon-window icon-view last" value="window"><%t SilverStripeNavigator.DualWindowView 'Dual Window' %></option>
 		-->
 	</select>
 </span>

--- a/templates/Includes/UploadField_FileButtons.ss
+++ b/templates/Includes/UploadField_FileButtons.ss
@@ -1,17 +1,17 @@
 <% if $canEdit %>
-	<button class="ss-uploadfield-item-edit ss-ui-button ui-corner-all" title="<% _t('UploadField.EDITINFO', 'Edit this file') %>" data-icon="pencil">
-	<% _t('UploadField.EDIT', 'Edit') %>
+	<button class="ss-uploadfield-item-edit ss-ui-button ui-corner-all" title="<%t UploadField.EDITINFO 'Edit this file' %>" data-icon="pencil">
+	<%t UploadField.EDIT 'Edit' %>
 	<span class="toggle-details">
 		<span class="toggle-details-icon"></span>
 	</span>
 	</button>
 <% end_if %>
-<button class="ss-uploadfield-item-remove ss-ui-button ui-corner-all" title="<% _t('UploadField.REMOVEINFO', 'Remove this file from here, but do not delete it from the file store') %>" data-icon="plug-disconnect-prohibition">
-<% _t('UploadField.REMOVE', 'Remove') %></button>
+<button class="ss-uploadfield-item-remove ss-ui-button ui-corner-all" title="<%t UploadField.REMOVEINFO 'Remove this file from here, but do not delete it from the file store' %>" data-icon="plug-disconnect-prohibition">
+<%t UploadField.REMOVE 'Remove' %></button>
 <% if $canDelete %>
-	<button data-href="$UploadFieldDeleteLink" class="ss-uploadfield-item-delete ss-ui-button ui-corner-all" title="<% _t('UploadField.DELETEINFO', 'Permanently delete this file from the file store') %>" data-icon="minus-circle"><% _t('UploadField.DELETE', 'Delete from files') %></button>
+	<button data-href="$UploadFieldDeleteLink" class="ss-uploadfield-item-delete ss-ui-button ui-corner-all" title="<%t UploadField.DELETEINFO 'Permanently delete this file from the file store' %>" data-icon="minus-circle"><%t UploadField.DELETE 'Delete from files' %></button>
 <% end_if %>
 <% if $UploadField.canAttachExisting %>
-	<button class="ss-uploadfield-item-choose-another ss-uploadfield-fromfiles ss-ui-button ui-corner-all" title="<% _t('UploadField.CHOOSEANOTHERINFO', 'Replace this file with another one from the file store') %>" data-icon="network-cloud">
-	<% _t('UploadField.CHOOSEANOTHERFILE', 'Choose another file') %></button>
+	<button class="ss-uploadfield-item-choose-another ss-uploadfield-fromfiles ss-ui-button ui-corner-all" title="<%t UploadField.CHOOSEANOTHERINFO' 'Replace this file with another one from the file store' %>" data-icon="network-cloud">
+	<%t UploadField.CHOOSEANOTHERFILE 'Choose another file' %></button>
 <% end_if %>

--- a/templates/UploadField.ss
+++ b/templates/UploadField.ss
@@ -30,26 +30,26 @@
 		<% if canUpload %>
 		<div class="ss-uploadfield-item-preview ss-uploadfield-dropzone ui-corner-all">
 				<% if $multiple %>
-					<% _t('UploadField.DROPFILES', 'drop files') %>
+					<%t UploadField.DROPFILES 'drop files' %>
 				<% else %>
-					<% _t('UploadField.DROPFILE', 'drop a file') %>
+					<%t UploadField.DROPFILE 'drop a file' %>
 				<% end_if %>
 		</div>
 		<% end_if %>
 		<div class="ss-uploadfield-item-info">
 			<label class="ss-uploadfield-item-name">
 				<% if $multiple %>
-					<b><% _t('UploadField.ATTACHFILES', 'Attach files') %></b>
+					<b><%t UploadField.ATTACHFILES 'Attach files' %></b>
 				<% else %>
-					<b><% _t('UploadField.ATTACHFILE', 'Attach a file') %></b>
+					<b><%t UploadField.ATTACHFILE 'Attach a file' %></b>
 				<% end_if %>
 				<% if $canPreviewFolder %>
 					<small>(<%t UploadField.UPLOADSINTO 'saves into /{path}' path=$FolderName %>)</small>
 				<% end_if %>
 			</label>
 			<% if $canUpload %>
-				<label class="ss-uploadfield-fromcomputer ss-ui-button ui-corner-all" title="<% _t('UploadField.FROMCOMPUTERINFO', 'Upload from your computer') %>" data-icon="drive-upload">
-					<% _t('UploadField.FROMCOMPUTER', 'From your computer') %>
+				<label class="ss-uploadfield-fromcomputer ss-ui-button ui-corner-all" title="<%t UploadField.FROMCOMPUTERINFO 'Upload from your computer' %>" data-icon="drive-upload">
+					<%t UploadField.FROMCOMPUTER 'From your computer' %>
 					<input id="$id" name="{$Name}[Uploads][]" class="$extraClass ss-uploadfield-fromcomputer-fileinput" data-config="$configString" type="file"<% if $multiple %> multiple="multiple"<% end_if %> />
 				</label>
 			<% else %>
@@ -57,11 +57,11 @@
 			<% end_if %>
 
 			<% if $canAttachExisting %>
-				<button class="ss-uploadfield-fromfiles ss-ui-button ui-corner-all" title="<% _t('UploadField.FROMCOMPUTERINFO', 'Select from files') %>" data-icon="network-cloud"><% _t('UploadField.FROMFILES', 'From files') %></button>
+				<button class="ss-uploadfield-fromfiles ss-ui-button ui-corner-all" title="<%t UploadField.FROMCOMPUTERINFO 'Select from files' %>" data-icon="network-cloud"><%t UploadField.FROMFILES 'From files' %></button>
 			<% end_if %>
 			<% if $canUpload %>
 				<% if not $autoUpload %>
-					<button class="ss-uploadfield-startall ss-ui-button ui-corner-all" data-icon="navigation"><% _t('UploadField.STARTALL', 'Start all') %></button>
+					<button class="ss-uploadfield-startall ss-ui-button ui-corner-all" data-icon="navigation"><%t UploadField.STARTALL 'Start all' %></button>
 				<% end_if %>
 			<% end_if %>
 			<div class="clear"><!-- --></div>

--- a/templates/email/ChangePasswordEmail.ss
+++ b/templates/email/ChangePasswordEmail.ss
@@ -1,11 +1,11 @@
-<p><% _t('ChangePasswordEmail_ss.HELLO', 'Hi') %> $FirstName,</p>
+<p><%t ChangePasswordEmail_ss.HELLO 'Hi' %> $FirstName,</p>
 
 <p>
-	<% _t('ChangePasswordEmail_ss.CHANGEPASSWORDTEXT1', 'You changed your password for', 'for a url') %> $AbsoluteBaseURL.<br />
-	<% _t('ChangePasswordEmail_ss.CHANGEPASSWORDTEXT2', 'You can now use the following credentials to log in:') %>
+	<%t ChangePasswordEmail_ss.CHANGEPASSWORDTEXT1 'You changed your password for' is 'for a url' %> $AbsoluteBaseURL.<br />
+	<%t ChangePasswordEmail_ss.CHANGEPASSWORDTEXT2 'You can now use the following credentials to log in:' %>
 </p>
 
 <p>
-	<% _t('ChangePasswordEmail_ss.EMAIL', 'Email') %>: $Email<br />
-	<% _t('ChangePasswordEmail_ss.PASSWORD', 'Password') %>: $CleartextPassword
+	<%t ChangePasswordEmail_ss.EMAIL 'Email' %>: $Email<br />
+	<%t ChangePasswordEmail_ss.PASSWORD 'Password' %>: $CleartextPassword
 </p>

--- a/templates/email/ForgotPasswordEmail.ss
+++ b/templates/email/ForgotPasswordEmail.ss
@@ -1,4 +1,4 @@
-<p><% _t('ForgotPasswordEmail_ss.HELLO', 'Hi') %> $FirstName,</p>
+<p><%t ForgotPasswordEmail_ss.HELLO 'Hi' %> $FirstName,</p>
 
-<p><% _t('ForgotPasswordEmail_ss.TEXT1', 'Here is your') %> <a href="$PasswordResetLink"><% _t('ForgotPasswordEmail_ss.TEXT2', 'password reset link') %></a> <% _t('ForgotPasswordEmail_ss.TEXT3', 'for') %> $AbsoluteBaseURL.</p>
+<p><%t ForgotPasswordEmail_ss.TEXT1 'Here is your' %> <a href="$PasswordResetLink"><%t ForgotPasswordEmail_ss.TEXT2 'password reset link' %></a> <%t ForgotPasswordEmail_ss.TEXT3 'for' %> $AbsoluteBaseURL.</p>
 


### PR DESCRIPTION
Given that this “new” syntax has been in place [since 2012](https://github.com/silverstripe/silverstripe-framework/pull/342), I think it’s probably time we upgraded core templates to use it :)