### PR TITLE
BUG Disable cache to prevent caching of build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ addons:
     packages:
       - tidy
 
-cache:
-  directories:
-    - $HOME/.composer/cache
-
 php:
   - 5.4
 


### PR DESCRIPTION
The addition of the cache did solve the issue of composer stalling, but introduced a new issue of caching of the current target build. Without an effective cache-buster mechanism, pushing up changes to a pull request would simply result in the cached result being re-run.

See https://github.com/silverstripe/silverstripe-cms/pull/1248 and https://github.com/silverstripe-labs/silverstripe-travis-support/issues/18