### PR TITLE
Use fputcsv in GridFieldExportButton

### DIFF
--- a/forms/gridfield/GridFieldExportButton.php
+++ b/forms/gridfield/GridFieldExportButton.php
@@ -21,6 +21,11 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 	protected $csvSeparator = ",";
 
 	/**
+	 * @var string
+	 */
+	protected $csvEnclosure = '"';
+
+	/**
 	 * @var boolean
 	 */
 	protected $csvHasHeader = true;
@@ -98,13 +103,10 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 	 * @return array
 	 */
 	public function generateExportFileData($gridField) {
-		$separator = $this->csvSeparator;
 		$csvColumns = ($this->exportColumns)
 			? $this->exportColumns
 			: singleton($gridField->getModelClass())->summaryFields();
-		$fileData = '';
-		$columnData = array();
-		$fieldItems = new ArrayList();
+		$fileData = array();
 
 		if($this->csvHasHeader) {
 			$headers = array();
@@ -115,8 +117,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 				$headers[] = (!is_string($columnHeader) && is_callable($columnHeader)) ? $columnSource : $columnHeader;
 			}
 
-			$fileData .= "\"" . implode("\"{$separator}\"", array_values($headers)) . "\"";
-			$fileData .= "\n";
+			$fileData[] = $headers;
 		}
 		
 		//Remove GridFieldPaginator as we're going to export the entire list.
@@ -152,12 +153,10 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 						}
 					}
 
-					$value = str_replace(array("\r", "\n"), "\n", $value);
-					$columnData[] = '"' . str_replace('"', '""', $value) . '"';
+					$columnData[] = $value;
 				}
 
-				$fileData .= implode($separator, $columnData);
-				$fileData .= "\n";
+				$fileData[] = $columnData;
 			}
 
 			if($item->hasMethod('destroy')) {
@@ -165,7 +164,13 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 			}
 		}
 
-		return $fileData;
+		// Convert the $fileData array into csv by capturing fputcsv's output
+		$csv = fopen('php://temp', 'r+');
+		foreach($fileData as $line) {
+			fputcsv($csv, $line, $this->csvSeparator, $this->csvEnclosure);
+		}
+		rewind($csv);
+		return stream_get_contents($csv);
 	}
 
 	/**
@@ -195,6 +200,21 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 	 */
 	public function setCsvSeparator($separator) {
 		$this->csvSeparator = $separator;
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getCsvEnclosure() {
+		return $this->csvEnclosure;
+	}
+
+	/**
+	 * @param string
+	 */
+	public function setCsvEnclosure($enclosure) {
+		$this->csvEnclosure = $enclosure;
 		return $this;
 	}
 

--- a/tests/forms/gridfield/GridFieldExportButtonTest.php
+++ b/tests/forms/gridfield/GridFieldExportButtonTest.php
@@ -48,7 +48,9 @@ class GridFieldExportButtonTest extends SapphireTest {
 		$button->setExportColumns(array('Name' => 'My Name'));
 
 		$this->assertEquals(
-			"\"My Name\"\n\"Test\"\n\"Test2\"\n",
+			'"My Name"'."\n".
+			'Test'."\n".
+			'Test2'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -63,7 +65,9 @@ class GridFieldExportButtonTest extends SapphireTest {
 		));
 
 		$this->assertEquals(
-			"\"Name\",\"City\"\n\"Test\",\"City city\"\n\"Test2\",\"City2 city\"\n",
+			'Name,City'."\n".
+			'Test,"City city"'."\n".
+			'Test2,"Quoted ""City"" 2 city"'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -76,7 +80,9 @@ class GridFieldExportButtonTest extends SapphireTest {
 		));
 
 		$this->assertEquals(
-			"\"Name\",\"strtolower\"\n\"Test\",\"City\"\n\"Test2\",\"City2\"\n",
+			'Name,strtolower'."\n".
+			'Test,City'."\n".
+			'Test2,"Quoted ""City"" 2"'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -90,7 +96,8 @@ class GridFieldExportButtonTest extends SapphireTest {
 		$button->setCsvHasHeader(false);
 
 		$this->assertEquals(
-			"\"Test\",\"City\"\n\"Test2\",\"City2\"\n",
+			'Test,City'."\n".
+			'Test2,"Quoted ""City"" 2"'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -110,8 +117,23 @@ class GridFieldExportButtonTest extends SapphireTest {
 		$this->gridField->setList($arrayList);
 		
 		$this->assertEquals(
-			"\"ID\"\n\"1\"\n\"2\"\n\"3\"\n\"4\"\n\"5\"\n\"6\"\n\"7\"\n\"8\"\n"
-			."\"9\"\n\"10\"\n\"11\"\n\"12\"\n\"13\"\n\"14\"\n\"15\"\n\"16\"\n",
+			"ID\n".
+			"1\n".
+			"2\n".
+			"3\n".
+			"4\n".
+			"5\n".
+			"6\n".
+			"7\n".
+			"8\n".
+			"9\n".
+			"10\n".
+			"11\n".
+			"12\n".
+			"13\n".
+			"14\n".
+			"15\n".
+			"16\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}

--- a/tests/forms/gridfield/GridFieldExportButtonTest.yml
+++ b/tests/forms/gridfield/GridFieldExportButtonTest.yml
@@ -4,7 +4,7 @@ GridFieldExportButtonTest_Team:
         City: City
     test-team-2:
         Name: Test2
-        City: City2
+        City: 'Quoted "City" 2'
 
 GridFieldExportButtonTest_NoView:
 	item1:


### PR DESCRIPTION
This is a (slightly improved) rebase of #3411. 

Uses php's built-in `fputcsv` in order to generate csv in the standard format. This includes the ability to specify the enclosure, which defaults to ". 

CSV output will change very slightly with this, because values that do not need enclosing, no longer get enclosing. In other words, the method previously wrapped every single value in quotes, while `fputcsv` only does that when that is required (due to a linebreak or a character that needs escaping). 

(I can make these changes against 3.2 instead, if that is desired)