### PR TITLE
Deprecate ViewableData magic caching logic

### DIFF
--- a/view/ViewableData.php
+++ b/view/ViewableData.php
@@ -177,12 +177,31 @@ class ViewableData extends Object implements IteratorAggregate {
 		foreach($this->allMethodNames() as $method) {
 			if($method[0] == '_' && $method[1] != '_') {
 				$this->createMethod(
-					substr($method, 1), "return \$obj->cachedCall('$method', \$args, '" . substr($method, 1) . "');"
+					substr($method, 1),
+					"return \$obj->deprecatedCachedCall('$method', \$args, '" . substr($method, 1) . "');"
 				);
 			}
 		}
 		
 		parent::defineMethods();
+	}
+
+	/**
+	 * Method to facilitate deprecation of underscore-prefixed methods automatically being cached.
+	 * 
+	 * @param string $field
+	 * @param array $arguments
+	 * @param string $identifier an optional custom cache identifier
+	 * @return unknown
+	 */
+	public function deprecatedCachedCall($method, $args = null, $identifier = null) {
+		Deprecation::notice(
+			'4.0',
+			'You are calling an underscore-prefixed method (e.g. _mymethod()) without the underscore. This behaviour,
+				and the caching logic behind it, has been deprecated.',
+			Deprecation::SCOPE_GLOBAL
+		);
+		return $this->cachedCall($method, $args, $identifier);
 	}
 	
 	/**


### PR DESCRIPTION
Proposed method of deprecating the unnecessary caching logic that `ViewableData::defineMethods()` adds. See #4063 for more info, but basically:

- It’s not documented anywhere.
- It wastes memory - it will loop over *every* method in `ViewableData` (and *every* method of *every* subclass of `ViewableData`) looking for methods that begin with an underscore and magically caching them.

It’s a bit confusing at a glance, this is roughly how it works:

```php
<?php

class MyController extends Controller {
	public function index() {
		// Will only echo 'Magic!' once
		$this->magic();
		$this->magic();
	}

	public function _magic() {
		echo 'Magic!';
	}
}
```

The notice text is a bit verbose, but it’s confusing behaviour and I didn’t know how else to describe it. Plus the notice tells you it was called from `__lambda_func`, which isn’t very helpful.

Given that this isn’t documented at all, it doesn’t technically form part of our public API so it might be worth considering introducing this change earlier? I’d say it’s _very_ unlikely that anyone is actually using this behaviour, but I guess it’s possible which is why I was cautious and decided to open this against master.