### PR TITLE
FIX Missing thumbnails and inconsistencies

### DIFF
--- a/admin/css/screen.css
+++ b/admin/css/screen.css
@@ -691,9 +691,6 @@ body.cms-dialog { overflow: auto; background: url("../images/textures/bg_cms_mai
 .htmleditorfield-linkform .ss-uploadfield .middleColumn { width: auto; }
 
 .htmleditorfield-mediaform .ss-gridfield .gridfield-button-delete { display: none; }
-.htmleditorfield-mediaform .ss-gridfield table.ss-gridfield-table tbody td:first-child { padding: 0; text-align: center; }
-.htmleditorfield-mediaform .ss-gridfield table.ss-gridfield-table tbody td:first-child img { max-height: 30px; }
-.htmleditorfield-mediaform .ss-gridfield table.ss-gridfield-table tr td { padding: 4px; }
 .htmleditorfield-mediaform .htmleditorfield-from-web .ss-uploadfield .middleColumn, .htmleditorfield-mediaform .htmleditorfield-from-cms .ss-uploadfield .middleColumn { width: auto; background: none; border: none; margin-top: 13px; }
 .htmleditorfield-mediaform .htmleditorfield-from-cms .ss-uploadfield h4 { float: left; margin-top: 4px; margin-bottom: 0; }
 .htmleditorfield-mediaform .htmleditorfield-from-cms .ss-uploadfield .middleColumn { margin-top: 16px; margin-left: 184px; min-width: 0; clear: none; }

--- a/admin/scss/_style.scss
+++ b/admin/scss/_style.scss
@@ -1533,18 +1533,6 @@ body.cms-dialog {
 			// TODO Remove from PHP instead of hiding
 			display: none; // delete action shouldn't be allowed here
 		}
-		table.ss-gridfield-table {
-			tbody td:first-child {
-				padding: 0;
-				text-align: center;
-				img {
-					max-height: 30px; // same thumbnail size as uploadfield rows
-				}
-			}
-			tr td {
-				padding: $grid-x/2; // more compressed space
-			}	
-		}
 	}
 
 	.htmleditorfield-from-web, .htmleditorfield-from-cms {

--- a/css/GridField.css
+++ b/css/GridField.css
@@ -134,3 +134,5 @@ Used in side panels and action tabs
 .cms table.ss-gridfield-table tr.last td { border-bottom: 0 none; }
 .cms table.ss-gridfield-table td:first-child { border-left: 1px solid rgba(0, 0, 0, 0.1); }
 .cms table.ss-gridfield-table td:last-child { border-right: 1px solid rgba(0, 0, 0, 0.1); }
+.cms table.ss-gridfield-table td.col-StripThumbnail { padding: 2px 4px; width: 32px; height: 32px; }
+.cms table.ss-gridfield-table td.col-StripThumbnail img { width: 32px; height: 32px; display: block; }

--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -311,7 +311,7 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 			new GridFieldFilterHeader(),
 			new GridFieldSortableHeader(),
 			new GridFieldDataColumns(),
-			new GridFieldPaginator(5),
+			new GridFieldPaginator(7),
 			// TODO Shouldn't allow delete here, its too confusing with a "remove from editor view" action.
 			// Remove once we can fit the search button in the last actual title column
 			new GridFieldDeleteAction(),
@@ -323,8 +323,12 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 		$fileField->setAttribute('data-multiselect', true);
 		$columns = $fileField->getConfig()->getComponentByType('GridFieldDataColumns');
 		$columns->setDisplayFields(array(
-			'CMSThumbnail' => false,
-			'Name' => _t('File.Name'),
+			'StripThumbnail' => false,
+			'Title' => _t('File.Title'),
+			'Created' => singleton('File')->fieldLabel('Created'),
+		));
+		$columns->setFieldCasting(array(
+			'Created' => 'SS_Datetime->Nice'
 		));
 
 		$numericLabelTmpl = '<span class="step-label"><span class="flyout">%d</span><span class="arrow"></span>'

--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -1566,16 +1566,21 @@ class UploadField_SelectHandler extends RequestHandler {
 		$config->addComponent(new GridFieldFilterHeader());
 		$config->addComponent($colsComponent = new GridFieldDataColumns());
 		$colsComponent->setDisplayFields(array(
-			'Title' => singleton('File')->fieldLabel('Name'),
-			'Filename' => singleton('File')->fieldLabel('Filename'),
+			'StripThumbnail' => '',
+			'Title' => singleton('File')->fieldLabel('Title'),
+			'Created' => singleton('File')->fieldLabel('Created'),
 			'Size' => singleton('File')->fieldLabel('Size')
 		));
+		$colsComponent->setFieldCasting(array(
+			'Created' => 'SS_Datetime->Nice'
+		));
+		$config->addComponent(new GridFieldPaginator(11));
 
 		// If relation is to be autoset, we need to make sure we only list compatible objects.
 		$baseClass = $this->parent->getRelationAutosetClass();
 
 		// Create the data source for the list of files within the current directory.
-		$files = DataList::create($baseClass);
+		$files = DataList::create($baseClass)->exclude('ClassName', 'Folder');
 		if($folderID) $files = $files->filter('ParentID', $folderID);
 
 		$fileField = new GridField('Files', false, $files, $config);

--- a/scss/GridField.scss
+++ b/scss/GridField.scss
@@ -674,5 +674,18 @@ $gf_grid_x:	16px;
 		td:last-child{
 			border-right: 1px solid $gf_colour_border;
 		}
+		
+		// Thumbnails e.g. in File admin, UploadField and HtmlEditorField file selection
+		td.col-StripThumbnail {
+			padding: 2px 4px;
+			width: 32px;
+			height: 32px;
+	
+			img {
+				width: 32px;
+				height: 32px;
+				display: block;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Some quick fixes for consistency when selecting files. Companion fix for CMS at https://github.com/silverstripe/silverstripe-cms/pull/1250

* Standardised thumbnail presentation
* Allow sort by created date for accessing recently uploaded files
* Appropriate pagination limits to make use of space without hiding form action buttons
* Display Title instead of Filename

**Before:**
![silverstripe_-_edit_page](https://cloud.githubusercontent.com/assets/1079425/8947863/391c1e48-3555-11e5-9474-b77260be4c54.png)

**After:**
![silverstripe_-_edit_page](https://cloud.githubusercontent.com/assets/1079425/8947867/45e2921a-3555-11e5-9f71-c1c106ea9204.png)

**Before:**
![silverstripe_-_edit_page](https://cloud.githubusercontent.com/assets/1079425/8947875/620165c0-3555-11e5-9064-377906ffbe7d.png)
**After:**
![silverstripe_-_edit_page](https://cloud.githubusercontent.com/assets/1079425/8947879/67be7ed0-3555-11e5-90c2-aa578eab0508.png)

**Before:**
![silverstripe_-_files](https://cloud.githubusercontent.com/assets/1079425/8947882/76f6da0a-3555-11e5-91e0-0b9e3426f631.png)

**After:**
![silverstripe_-_files](https://cloud.githubusercontent.com/assets/1079425/8947884/7eb5a8c0-3555-11e5-9871-52aeb0f46fc0.png)