### PR TITLE
ENH: moving hardcoded nice date/time formats to config

### DIFF
--- a/model/fieldtypes/Date.php
+++ b/model/fieldtypes/Date.php
@@ -19,7 +19,15 @@
  * @subpackage model
  */
 class Date extends DBField {
-
+	
+	/**
+	 * @config
+	 * @see also SS_DateTime::niceDatetimeFormat
+	 * @see also Time::niceFormat
+	 */
+	private static $niceFormat = 'd/m/Y';
+	
+	
 	public function setValue($value, $record = null) {
 		if($value === false || $value === null || (is_string($value) && !strlen($value))) {
 			// don't try to evaluate empty values with strtotime() below, as it returns "1970-01-01" when it should be
@@ -59,16 +67,18 @@ class Date extends DBField {
 	}
 
 	/**
-	 * Returns the date in the format dd/mm/yy
-	 */
+	 * Returns the date in the format specified by the config value niceFormat, or dd/mm/yy by default
+	 */	 
 	public function Nice() {
-		if($this->value) return $this->Format('d/m/Y');
+		if($this->value) return $this->Format(Config::inst()->get(__CLASS__, 'niceFormat'));
 	}
-
+	
 	/**
 	 * Returns the date in US format: “01/18/2006”
+	 * @deprecated 3.2 Use Nice() with config setting Date::niceFormat instead
 	 */
 	public function NiceUS() {
+		Deprecation::notice('3.2', 'Use Nice() with config setting '.__CLASS__.'::niceFormat instead');
 		if($this->value) return $this->Format('m/d/Y');
 	}
 

--- a/model/fieldtypes/Datetime.php
+++ b/model/fieldtypes/Datetime.php
@@ -24,7 +24,15 @@
  * @subpackage model
  */
 class SS_Datetime extends Date implements TemplateGlobalProvider {
-
+	
+	/**
+	 * @config
+	 * @see also Date::niceFormat
+	 * @see also Time::niceFormat
+	 */
+	private static $niceFormat = 'd/m/Y g:ia';
+	
+	
 	public function setValue($value, $record = null) {
 		if($value === false || $value === null || (is_string($value) && !strlen($value))) {
 			// don't try to evaluate empty values with strtotime() below, as it returns "1970-01-01" when it should be
@@ -54,18 +62,21 @@ class SS_Datetime extends Date implements TemplateGlobalProvider {
 	}
 
 	/**
-	 * Returns the date and time (in 12-hour format) using the format string 'd/m/Y g:ia' e.g. '31/01/2014 2:23pm'.
+	 * Returns the date and time in the format specified by the config value niceFormat, or 
+	 * 'd/m/Y g:ia' by default (e.g. '31/01/2014 2:23pm').
 	 * @return string Formatted date and time.
 	 */
 	public function Nice() {
-		if($this->value) return $this->Format('d/m/Y g:ia');
+		if($this->value) return $this->Format(Config::inst()->get(__CLASS__, 'niceFormat'));
 	}
 
 	/**
 	 * Returns the date and time (in 24-hour format) using the format string 'd/m/Y H:i' e.g. '28/02/2014 13:32'.
 	 * @return string Formatted date and time.
+	 * @deprecated 3.2 Use Nice() with config setting niceFormat instead
 	 */
 	public function Nice24() {
+		Deprecation::notice('3.2', 'Use Nice() with config setting '.__CLASS__.'::niceFormat instead');
 		if($this->value) return $this->Format('d/m/Y H:i');
 	}
 

--- a/model/fieldtypes/Time.php
+++ b/model/fieldtypes/Time.php
@@ -15,7 +15,15 @@
  * @subpackage model
  */
 class Time extends DBField {
-
+	
+	/**
+	 * @config
+	 * @see also Date::niceFormat
+	 * @see also SS_DateTime::niceFormat
+	 */
+	private static $niceFormat = 'g:ia';
+	
+	
 	public function setValue($value, $record = null) {
 		if($value) {
 			if(preg_match( '/(\d{1,2})[:.](\d{2})([a|A|p|P|][m|M])/', $value, $match )) $this->TwelveHour( $match );
@@ -26,22 +34,25 @@ class Time extends DBField {
 	}
 
 	/**
-	 * Return a user friendly format for time
-	 * in a 12 hour format.
-	 *
-	 * @return string Time in 12 hour format
+	 * Returns the time in the format specified by the config value niceFormat, or 12 hour format by default 
+	 * e.g. "3:15pm"
+	 * 
+	 * @return string
 	 */
 	public function Nice() {
-		if($this->value) return date('g:ia', strtotime($this->value));
+		if($this->value) return $this->Format(Config::inst()->get(__CLASS__, 'niceFormat'));
+		
 	}
 
 	/**
 	 * Return a user friendly format for time
 	 * in a 24 hour format.
-	 *
+	 * 
 	 * @return string Time in 24 hour format
+	 * @deprecated 3.2 Use Nice() with config setting niceFormat instead
 	 */
 	public function Nice24() {
+		Deprecation::notice('3.2', 'Use Nice() with config setting '.__CLASS__.'::niceFormat instead');
 		if($this->value) return date('H:i', strtotime($this->value));
 	}
 


### PR DESCRIPTION
I was using Date.Nice() in my template today, and wanted it to have an even nicer format, but soon found that it was hardcoded, and I could only use Date.Format('...'), copy-pasting it across my template files.

It's generally good practice to move the default date format out to a config somewhere, so I have done so in this commit. The default stays the same, but if you want to change it, you just pop into your site's config.yml and do:

Date:
  niceFormat: '...'
Datetime:
  niceFormat: '...'
Time:
  niceFormat: '...'

Below is some code that might be handy for the people reading this if they want to play around with this. Thanks,
Igor

--------------------------------------------------------------
// mysite/code/TestDateFormat.php
<?php 

class TestDateFormat extends Controller {
	
	public function index(){
		echo '<pre>';
		
		$objs = array(
			'Date'        => new Date(),
			'SS_Datetime' => new SS_Datetime(),
			'Time'        => new Time(),
		);
		$objs['Date']->setValue('2015-07-29');
		$objs['SS_Datetime']->setValue('2015-07-29 17:15:55');
		$objs['Time']->setValue('17:15:55');
		
		$newNiceFormats = array(
			'Date'        => 'd F Y',
			'SS_Datetime' => 'd F Y, H:i:s',
			'Time'        => 'H:i:s',	
		);
		
		foreach($objs as $class => $obj){
			echo PHP_EOL.PHP_EOL.'CLASS: '.$class.PHP_EOL;
			
			$defaultNiceFormat = Config::inst()->get($class, 'niceFormat');
			echo 'Default niceFormat is: "'.$defaultNiceFormat.'"'.PHP_EOL;
			echo 'getValue() = "'.$obj->getValue().'"'.PHP_EOL;
			echo 'Nice()     = "'.$obj->Nice().'"'.PHP_EOL.PHP_EOL;
			
			$newNiceFormat = $newNiceFormats[$class];
			Config::inst()->update($class, 'niceFormat', $newNiceFormat);
			echo 'New niceFormat is: "'.$newNiceFormat.'"'.PHP_EOL;
			echo 'Nice()     = "'.$obj->Nice().'"'.PHP_EOL.PHP_EOL;
		}
		
		
		die;
		
	}
	
}

// mysite/_config.php
Config::inst()->update('Director', 'rules', array('testdateformat' => 'TestDateFormat')); // now go to http://localhost/testdateformat
