### PR TITLE
NEW: Add ‘calls’ section to Injector configs.

### DIFF
--- a/control/injector/Injector.php
+++ b/control/injector/Injector.php
@@ -585,12 +585,49 @@ class Injector {
 		$objtype = $asType ? $asType : get_class($object);
 		$mapping = isset($this->injectMap[$objtype]) ? $this->injectMap[$objtype] : null;
 
+		$spec = empty($this->specs[$objtype]) ? array() : $this->specs[$objtype];
+
 		// first off, set any properties defined in the service specification for this
 		// object type
-		if (isset($this->specs[$objtype]) && isset($this->specs[$objtype]['properties'])) {
+		if(!empty($spec['properties']) && is_array($spec['properties'])) {
 			foreach ($this->specs[$objtype]['properties'] as $key => $value) {
 				$val = $this->convertServiceProperty($value);
 				$this->setObjectProperty($object, $key, $val);
+			}
+		}
+
+		// Populate named methods
+		if (!empty($spec['calls']) && is_array($spec['calls'])) {
+			foreach ($spec['calls'] as $method) {
+				// Ignore any blank entries from the array; these may be left in due to config system limitations
+				if(!$method) continue;
+
+				// Format validation
+				if(!is_array($method) || !isset($method[0]) || isset($method[2])) {
+					throw new \InvalidArgumentException(
+						"'calls' entries in service definition should be 1 or 2 element arrays."
+					);
+				}
+				if(!is_string($method[0])) {
+					throw new \InvalidArgumentException("1st element of a 'calls' entry should be a string");
+				}
+				if(isset($method[1]) && !is_array($method[1])) {
+					throw new \InvalidArgumentException("2nd element of a 'calls' entry should an arguments array");
+				}
+
+				// Check that the method exists and is callable
+				$objectMethod = array($object, $method[0]);
+				if (!is_callable($objectMethod)) {
+					throw new \InvalidArgumentException("'$method[0]' in 'calls' entry is not a public method");
+				}
+
+				// Call it
+				call_user_func_array(
+					$objectMethod,
+					$this->convertServiceProperty(
+						isset($method[1]) ? $method[1] : array()
+					)
+				);
 			}
 		}
 

--- a/docs/en/02_Developer_Guides/05_Extending/05_Injector.md
+++ b/docs/en/02_Developer_Guides/05_Extending/05_Injector.md
@@ -111,6 +111,16 @@ Now the dependencies will be replaced with our configuration.
 	echo ($object->textProperty == 'My Text Value');
 	// returns true;
 
+As well as properties, method calls can also be specified:
+
+	:::yml
+	Injector:
+	  Logger:
+	    class: Monolog\Logger
+	    calls:
+	      - [ pushHandler, [ %$DefaultHandler ] ]
+
+
 ## Factories
 
 Some services require non-trivial construction which means they must be created by a factory class. To do this, create


### PR DESCRIPTION
As well as properties, you can now configure a series of method calls in your service definitions.

I started tinkering with Injector in response to #4442, and I ended up deciding that this was a less invasive change to start with for now.