### PR TITLE
BUG Fix semver violation in create_table_options

### DIFF
--- a/model/connect/MySQLSchemaManager.php
+++ b/model/connect/MySQLSchemaManager.php
@@ -12,25 +12,13 @@ class MySQLSchemaManager extends DBSchemaManager {
 	 * Identifier for this schema, used for configuring schema-specific table
 	 * creation options
 	 */
-	const ID = 'MySQL';
+	const ID = 'MySQLDatabase';
 
 	public function createTable($table, $fields = null, $indexes = null, $options = null, $advancedOptions = null) {
 		$fieldSchemas = $indexSchemas = "";
 
 		if (!empty($options[self::ID])) {
 			$addOptions = $options[self::ID];
-		} elseif (!empty($options[get_class($this)])) {
-			Deprecation::notice(
-				'3.2',
-				'Use MySQLSchemaManager::ID for referencing mysql-specific table creation options'
-			);
-			$addOptions = $options[get_class($this)];
-		} elseif (!empty($options[get_parent_class($this)])) {
-			Deprecation::notice(
-				'3.2',
-				'Use MySQLSchemaManager::ID for referencing mysql-specific table creation options'
-			);
-			$addOptions = $options[get_parent_class($this)];
 		} else {
 			$addOptions = "ENGINE=InnoDB";
 		}


### PR DESCRIPTION
In the ORM rewrite the change made was to use a const `<schemaclass>::ID` instead of literals such as `MySQLDatabase` for create_table_options.

In order to make this semver, we should use the same string value to prevent breakages where old code uses this value as a literal. Fortunately this means we don't need to deprecate anything and it can continue working as is. :D