### PR TITLE
BUG Fix change detection on browser back button

### DIFF
--- a/admin/javascript/LeftAndMain.EditForm.js
+++ b/admin/javascript/LeftAndMain.EditForm.js
@@ -129,13 +129,23 @@
 			 * Doesn't cancel any unload or form removal events, you'll need to implement this based on the return
 			 * value of this message.
 			 * 
+			 * If changes are confirmed for discard, the 'changed' flag is reset.
+			 * 
 			 * Returns:
 			 *  (Boolean) FALSE if the user wants to abort with changes present, TRUE if no changes are detected 
 			 *  or the user wants to discard them.
 			 */
 			confirmUnsavedChanges: function() {
 				this.trigger('beforesubmitform');
-				return (this.is('.changed')) ? confirm(ss.i18n._t('LeftAndMain.CONFIRMUNSAVED')) : true;
+				if(!this.is('.changed')) {
+					return true;
+				}
+				var confirmed = confirm(ss.i18n._t('LeftAndMain.CONFIRMUNSAVED'));
+				if(confirmed) {
+					// confirm discard changes
+					this.removeClass('changed');
+				}
+				return confirmed;
 			},
 
 			/**


### PR DESCRIPTION
FIxes #4419

Tested in ie8, ie11, safari, chrome.

Only noticeable oddities are where, if you press the back button, the URL of the "back" page is displayed while the confirm dialog is open. If you press "cancel" it restores the current url.

In ie8 I wasn't able to restore the current url properly, but the change detection is safe.

Another limitation is that the "next" browser history reset is overwritten by the restored url, so you can't press back and then forwards. :P Only if you click "no" to losing changes though.