### PR TITLE
Fix issues with tests and "subfolder" URLs

### DIFF
--- a/tests/control/ControllerTest.php
+++ b/tests/control/ControllerTest.php
@@ -328,7 +328,7 @@ class ControllerTest extends FunctionalTest {
 	*/
 
 	public function testRedirectBackByReferer() {
-		$internalRelativeUrl = '/some-url';
+		$internalRelativeUrl = Controller::join_links(Director::baseURL(), '/some-url');
 		$internalAbsoluteUrl = Controller::join_links(Director::absoluteBaseURL(), '/some-url');
 		
 		$response = $this->get('ControllerTest_Controller/redirectbacktest', null,
@@ -354,7 +354,7 @@ class ControllerTest extends FunctionalTest {
 	}
 
 	public function testRedirectBackByBackUrl() {
-		$internalRelativeUrl = '/some-url';
+		$internalRelativeUrl = Controller::join_links(Director::baseURL(), '/some-url');
 		$internalAbsoluteUrl = Controller::join_links(Director::absoluteBaseURL(), '/some-url');
 		
 		$response = $this->get('ControllerTest_Controller/redirectbacktest?BackURL=' . urlencode($internalRelativeUrl));

--- a/tests/forms/RequirementsTest.php
+++ b/tests/forms/RequirementsTest.php
@@ -366,10 +366,11 @@ class RequirementsTest extends SapphireTest {
 		$backend = new Requirements_Backend();
 		$backend->set_suffix_requirements(false);
 		$src = $this->getCurrentRelativePath() . '/RequirementsTest_a.js';
+		$urlSrc = Controller::join_links(Director::baseURL(), $src);
 		$backend->javascript($src);
 		$html = $backend->includeInHTML(false, $template);
 		$this->assertEquals('<html><head></head><body><!--<script>alert("commented out");</script>-->'
-			. '<h1>more content</h1><script type="text/javascript" src="/' . $src . '"></script></body></html>', $html);
+			. '<h1>more content</h1><script type="text/javascript" src="' . $urlSrc . '"></script></body></html>', $html);
 	}
 
 	public function testForceJsToBottom() {


### PR DESCRIPTION
These assertions currently fail if `$_FILE_TO_URL_MAPPING` is set to include a directory, e.g:

```php
$_FILE_TO_URL_MAPPING['/var/www/html'] = 'http://mysite.com/subdir/';
```