### PR TITLE
NEW: Add support for ‘%%remove%%’ market in Yaml Config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,6 @@ matrix:
       env: DB=MYSQL
     - php: 5.4
       env: DB=MYSQL BEHAT_TEST=1
-    - php: 5.3
-      env: DB=MYSQL
     - php: 7.0
       env: DB=MYSQL
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.3",
+		"php": ">=5.4.0",
 		"composer/installers": "~1.0"
 	},
 	"require-dev": {

--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -8,7 +8,7 @@ Our web-based [PHP installer](installation/) can check if you meet the requireme
 
 ## Web server software requirements
 
- * PHP 5.3.3+
+ * PHP 5.4+
  * We recommend using a PHP accelerator or opcode cache, such as [xcache](http://xcache.lighttpd.net/) or [WinCache](http://www.iis.net/download/wincacheforphp).
  * Allocate at least 48MB of memory to each PHP process. (SilverStripe can be resource hungry for some intensive operations.)
  * Required modules: dom, gd2, fileinfo, hash, iconv, mbstring, mysqli (or other database driver), session, simplexml, tokenizer, xml.

--- a/docs/en/02_Developer_Guides/04_Configuration/00_Configuration.md
+++ b/docs/en/02_Developer_Guides/04_Configuration/00_Configuration.md
@@ -311,6 +311,19 @@ Due to YAML limitations, having multiple conditions of the same kind (say, two `
 will result in only the latter coming through.
 </div>
 
+## Removing values set in another config file
+
+Sometimes you will want to create a configuration file that removes configuration set by anotehr file. For example,
+you may wish to remove configuration provided by default by the framework or a module.
+
+To do this, you can set a configuration option to the special value, `%%remove%%`. For example, this will remove the
+routing rule for admin/ URLs:
+
+	Director:
+	  rules:
+	    admin: %%remove%%
+
+Note that this is case-sensitive - `%%REMOVE%%` won't work.
 
 ## API Documentation
 

--- a/tests/core/ConfigTest.php
+++ b/tests/core/ConfigTest.php
@@ -248,6 +248,39 @@ class ConfigTest extends SapphireTest {
 			array('A' => 1, 'B' => 2, 'C' => array('Foo' => 1, 'Bar' => 3, 'Baz' => 4), 'D' => 3));
 	}
 
+	public function testRemoveKey() {
+		// 4 copies of our test array
+		$oneA = $oneB = $oneC = $oneD = [
+			'arr' => [
+				'A' => 'eh',
+				'B' => 'bee',
+				'C' => [ 'see', 'sea' ]
+			],
+		];
+		$two = [
+			'arr' => [
+				'B' => '%%remove%%',
+				'C' => '%%remove%%',
+				'D' => 'dee',
+			]
+		];
+		$three = [
+			'arr' => '%%remove%%',
+		];
+
+		Config::merge_array_high_into_low($oneA, $two);
+		$this->assertEquals($oneA, [ 'arr' => [ 'A' => 'eh', 'D' => 'dee' ] ]);
+
+		Config::merge_array_low_into_high($oneB, $two);
+		$this->assertEquals($oneB, [ 'arr' => [ 'A' => 'eh', 'B' => 'bee', 'C' => [ 'see', 'sea' ], 'D' => 'dee' ] ]);
+
+		Config::merge_array_high_into_low($oneC, $three);
+		$this->assertEquals($oneC, []);
+
+		Config::merge_array_low_into_high($oneD, $three);
+		$this->assertEquals($oneD, [ 'arr' => [ 'A' => 'eh', 'B' => 'bee', 'C' => [ 'see', 'sea' ] ] ]);
+	}
+
 	public function testStaticLookup() {
 		$this->assertEquals(Object::static_lookup('ConfigTest_DefinesFoo', 'foo'), 1);
 		$this->assertEquals(Object::static_lookup('ConfigTest_DefinesFoo', 'bar'), null);


### PR DESCRIPTION
Sometimes, it’s not enough to set a config option to null. For example,
you may configure a list of items as a constructor property setter and
it won’t expect empty items in the string.

This change introduces a special string that you can use to mark config
options that you would like to have removed with unset().

Note that this means we can’t set a configuration option to the string
“%%remove%%”; hence the reason for using a slightly convoluted string.

@camspiers @nyeholt @stevie-mayhew @tractorcow, this flows on pretty
directly from my work on Injector, so I'd be keen to get your views.

@hafriedlander I'm nervous about making any changes to Config without
a thumbs-up from you. ;-) I don't think this will have too much performance
impact.
