### PR TITLE
Check that method 'hasMethod' exists in GridFieldSortableHeader

### DIFF
--- a/forms/gridfield/GridFieldSortableHeader.php
+++ b/forms/gridfield/GridFieldSortableHeader.php
@@ -111,7 +111,7 @@ class GridFieldSortableHeader implements GridField_HTMLProvider, GridField_DataM
 					if($tmpItem instanceof SS_List) {
 						// It's impossible to sort on a HasManyList/ManyManyList
 						break;
-					} elseif($tmpItem->hasMethod($methodName)) {
+					} elseif(method_exists($tmpItem, 'hasMethod') && $tmpItem->hasMethod($methodName)) {
 						// The part is a relation name, so get the object/list from it
 						$tmpItem = $tmpItem->$methodName();
 					} elseif($tmpItem instanceof DataObject && $tmpItem->hasField($methodName)) {


### PR DESCRIPTION
In some specific cases, this can cause a fatal error (`Call to a member function hasMethod() on a non-object`) which is hard to diagnose (this came up on IRC).

Example code is:
```php
private static $has_one = array
    'Image' => 'Image'
);
private static $summary_fields = array(
		'Image.CMSThumbnail.Tag' => 'Image'
);
```

This code won’t present the tag anyway (just escaped HTML for it), but before this change it gives the fatal error that a beginner wouldn’t be able to understand.