### PR TITLE
Fixes #4424

### DIFF
--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -366,7 +366,7 @@ abstract class ModelAdmin extends LeftAndMain {
 			$specRelations->push(new ArrayData(array('Name' => $name, 'Description' => $desc)));
 		}
 		$specHTML = $this->customise(array(
-			'attrModelName' => str_replace(' ', '',$modelName),
+			'ClassName' => str_replace('\\', '_', $className),
 			'ModelName' => Convert::raw2att($modelName),
 			'Fields' => $specFields,
 			'Relations' => $specRelations, 

--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -366,6 +366,7 @@ abstract class ModelAdmin extends LeftAndMain {
 			$specRelations->push(new ArrayData(array('Name' => $name, 'Description' => $desc)));
 		}
 		$specHTML = $this->customise(array(
+			'attrModelName' => str_replace(' ', '',$modelName),
 			'ModelName' => Convert::raw2att($modelName),
 			'Fields' => $specFields,
 			'Relations' => $specRelations, 

--- a/admin/templates/Includes/ModelAdmin_ImportSpec.ss
+++ b/admin/templates/Includes/ModelAdmin_ImportSpec.ss
@@ -1,6 +1,6 @@
-<div class="importSpec" id="SpecFor{$attrModelName}">
-	<a href="#SpecDetailsFor{$attrModelName}" class="detailsLink"><% sprintf(_t('ModelAdmin_ImportSpec_ss.IMPORTSPECLINK', 'Show Specification for %s'),$ModelName) %></a>
-	<div class="details" id="SpecDetailsFor{$attrModelName}">
+<div class="importSpec" id="SpecFor{$ClassName}">
+	<a href="#SpecDetailsFor{$ClassName}" class="detailsLink"><% sprintf(_t('ModelAdmin_ImportSpec_ss.IMPORTSPECLINK', 'Show Specification for %s'),$ModelName) %></a>
+	<div class="details" id="SpecDetailsFor{$ClassName}">
 	<h4><% sprintf(_t('ModelAdmin_ImportSpec_ss.IMPORTSPECTITLE', 'Specification for %s'),$ModelName) %></h4>
 		<h5><% _t('ModelAdmin_ImportSpec_ss.IMPORTSPECFIELDS', 'Database columns') %></h5>
 		<% loop $Fields %>

--- a/admin/templates/Includes/ModelAdmin_ImportSpec.ss
+++ b/admin/templates/Includes/ModelAdmin_ImportSpec.ss
@@ -1,6 +1,6 @@
-<div class="importSpec" id="SpecFor{$ModelName}">
-	<a href="#SpecDetailsFor{$ModelName}" class="detailsLink"><% sprintf(_t('ModelAdmin_ImportSpec_ss.IMPORTSPECLINK', 'Show Specification for %s'),$ModelName) %></a>
-	<div class="details" id="SpecDetailsFor{$ModelName}">
+<div class="importSpec" id="SpecFor{$attrModelName}">
+	<a href="#SpecDetailsFor{$attrModelName}" class="detailsLink"><% sprintf(_t('ModelAdmin_ImportSpec_ss.IMPORTSPECLINK', 'Show Specification for %s'),$ModelName) %></a>
+	<div class="details" id="SpecDetailsFor{$attrModelName}">
 	<h4><% sprintf(_t('ModelAdmin_ImportSpec_ss.IMPORTSPECTITLE', 'Specification for %s'),$ModelName) %></h4>
 		<h5><% _t('ModelAdmin_ImportSpec_ss.IMPORTSPECFIELDS', 'Database columns') %></h5>
 		<% loop $Fields %>


### PR DESCRIPTION
Model Admin : 'Show Specification for' toggle link breaks if Title contains spaces #4424