### PR TITLE
Remove PHP 5.3 from Travis suite, updating minimum version requirement.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,6 @@ matrix:
       env: DB=MYSQL
     - php: 5.4
       env: DB=MYSQL BEHAT_TEST=1
-    - php: 5.3
-      env: DB=MYSQL
     - php: 7.0
       env: DB=MYSQL
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.3",
+		"php": ">=5.4.0",
 		"composer/installers": "~1.0"
 	},
 	"require-dev": {

--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -8,7 +8,7 @@ Our web-based [PHP installer](installation/) can check if you meet the requireme
 
 ## Web server software requirements
 
- * PHP 5.3.3+
+ * PHP 5.4+
  * We recommend using a PHP accelerator or opcode cache, such as [xcache](http://xcache.lighttpd.net/) or [WinCache](http://www.iis.net/download/wincacheforphp).
  * Allocate at least 48MB of memory to each PHP process. (SilverStripe can be resource hungry for some intensive operations.)
  * Required modules: dom, gd2, fileinfo, hash, iconv, mbstring, mysqli (or other database driver), session, simplexml, tokenizer, xml.


### PR DESCRIPTION
This PR is intended to be the official removal of PHP 5.3 support from master (which will become SilverStripe 4).

Assuming that we don't have any objections on https://groups.google.com/forum/#!topic/silverstripe-dev/FR_d5QVjXe4 by 7 August, it should be good to merge.

If we get objections, we should probably discuss whether we listen to them. We'd need a pretty darn good reason to retain 5.3 support in ss4.

Thanks,
Sam

PS: There's a lot more discussion about this in #4463