### PR TITLE
Fix datefield to work with other form markup

### DIFF
--- a/javascript/DateField.js
+++ b/javascript/DateField.js
@@ -26,7 +26,7 @@
 		}
 	});
 
-	$(document).on("click", ".field.date input.text,.fieldholder-small input.text.date", function() {
+	$(document).on("click", "input.text.date", function() {
 		$(this).ssDatepicker();
 
 		if($(this).data('datepicker')) {

--- a/javascript/DateField.js
+++ b/javascript/DateField.js
@@ -26,7 +26,7 @@
 		}
 	});
 
-	$(document).on("click", "input.text.date", function() {
+	$(document).on("click", ".field.date input.text,input.text.date", function() {
 		$(this).ssDatepicker();
 
 		if($(this).data('datepicker')) {


### PR DESCRIPTION
Changed onClick selector to catch any date field, so it will work with "nonstandard" form markups like adding new lines from https://github.com/silverstripe-australia/silverstripe-gridfieldextensions