### PR TITLE
Ensure ClassInfo is backwards compatible with non-existant classes

### DIFF
--- a/core/ClassInfo.php
+++ b/core/ClassInfo.php
@@ -159,6 +159,13 @@ class ClassInfo {
 	public static function class_name($nameOrObject) {
 		if (is_object($nameOrObject)) {
 			return get_class($nameOrObject);
+		} elseif (!self::exists($nameOrObject)) {
+			Deprecation::notice(
+				'4.0',
+				"ClassInfo::class_name() passed a class that doesn't exist. Support for this will be removed in 4.0",
+				Deprecation::SCOPE_GLOBAL
+			);
+			return $nameOrObject;
 		}
 		$reflection = new ReflectionClass($nameOrObject);
 		return $reflection->getName();

--- a/tests/core/ClassInfoTest.php
+++ b/tests/core/ClassInfoTest.php
@@ -42,6 +42,15 @@ class ClassInfoTest extends SapphireTest {
 		);
 	}
 
+	public function testClassName() {
+		$this->assertEquals('ClassInfoTest', ClassInfo::class_name($this));
+		$this->assertEquals('ClassInfoTest', ClassInfo::class_name('ClassInfoTest'));
+		$this->assertEquals('ClassInfoTest', ClassInfo::class_name('CLaSsInfOTEsT'));
+
+		// This is for backwards compatiblity and will be removed in 4.0
+		$this->assertEquals('IAmAClassThatDoesNotExist', ClassInfo::class_name('IAmAClassThatDoesNotExist'));
+	}
+
 	public function testClassesForFolder() {
 		//$baseFolder = Director::baseFolder() . '/' . FRAMEWORK_DIR . '/tests/_ClassInfoTest';
 		//$manifestInfo = ManifestBuilder::get_manifest_info($baseFolder);


### PR DESCRIPTION
See [this comment](https://github.com/silverstripe/silverstripe-framework/pull/3949#issuecomment-127300189) and #4474 for context.

Of course it doesn’t make any sense to pass non-existant classes to `ClassInfo`, but we have supported it so unfortunately we probably need to until 4.0. The example from #4474 is that `ClassInfo::subclassesFor('IDontExist')` used to return `array('IDontExist'=>'IDontExist')` but now triggers a fatal error.

Not marked as a fix for #4474 because it will need to be fixed another way.