### PR TITLE
Explicitly don't support PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ env:
 matrix:
   allow_failures:
     - php: hhvm
-    - php: 7.0
     - php: nightly
 
   include:
@@ -36,8 +35,6 @@ matrix:
     - php: 5.4
       env: DB=MYSQL BEHAT_TEST=1
     - php: 5.3
-      env: DB=MYSQL
-    - php: 7.0
       env: DB=MYSQL
     - php: nightly
       env: DB=MYSQL

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.2",
+		"php": ">=5.3.2,<7",
 		"composer/installers": "*"
 	},
 	"require-dev": {


### PR DESCRIPTION
SilverStripe doesn't work in PHP7 (see #4271 at least), so have composer reflect that.

Should probably be merged up to master as well.