### PR TITLE
FIX: Fixed regression from ClassInfo case-sensitivity fix.

### DIFF
--- a/core/ClassInfo.php
+++ b/core/ClassInfo.php
@@ -61,6 +61,8 @@ class ClassInfo {
 	 * @return array List of subclasses
 	 */
 	public static function getValidSubClasses($class = 'SiteTree', $includeUnbacked = false) {
+		if(is_string($class) && !class_exists($class)) return null;
+
 		$class = self::class_name($class);
 		$classes = DB::get_schema()->enumValuesForField($class, 'ClassName');
 		if (!$includeUnbacked) $classes = array_filter($classes, array('ClassInfo', 'exists'));
@@ -76,6 +78,8 @@ class ClassInfo {
 	 * @return array
 	 */
 	public static function dataClassesFor($class) {
+		if(is_string($class) && !class_exists($class)) return null;
+
 		$result = array();
 
 		$class = self::class_name($class);
@@ -100,6 +104,8 @@ class ClassInfo {
 	 * @return string
 	 */
 	public static function baseDataClass($class) {
+		if(is_string($class) && !class_exists($class)) return null;
+
 		$class = self::class_name($class);
 
 		if (!is_subclass_of($class, 'DataObject')) {
@@ -134,6 +140,8 @@ class ClassInfo {
 	 * @return array Names of all subclasses as an associative array.
 	 */
 	public static function subclassesFor($class) {
+		if(is_string($class) && !class_exists($class)) return null;
+
 		//normalise class case
 		$className = self::class_name($class);
 		$descendants = SS_ClassLoader::instance()->getManifest()->getDescendantsOf($class);
@@ -159,6 +167,7 @@ class ClassInfo {
 		if (is_object($nameOrObject)) {
 			return get_class($nameOrObject);
 		}
+
 		$reflection = new ReflectionClass($nameOrObject);
 		return $reflection->getName();
 	}
@@ -172,6 +181,8 @@ class ClassInfo {
 	 * @return array
 	 */
 	public static function ancestry($class, $tablesOnly = false) {
+		if(is_string($class) && !class_exists($class)) return null;
+
 		$class = self::class_name($class);
 
 		$lClass = strtolower($class);

--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -232,10 +232,12 @@ class DataQuery {
 				foreach($collisions as $collision) {
 					if(preg_match('/^"([^"]+)"/', $collision, $matches)) {
 						$collisionBase = $matches[1];
-						$collisionClasses = ClassInfo::subclassesFor($collisionBase);
-						$collisionClasses = Convert::raw2sql($collisionClasses, true);
-						$caseClauses[] = "WHEN \"$baseClass\".\"ClassName\" IN ("
-							. implode(", ", $collisionClasses) . ") THEN $collision";
+						if(class_exists($collisionBase)) {
+							$collisionClasses = ClassInfo::subclassesFor($collisionBase);
+							$collisionClasses = Convert::raw2sql($collisionClasses, true);
+							$caseClauses[] = "WHEN \"$baseClass\".\"ClassName\" IN ("
+								. implode(", ", $collisionClasses) . ") THEN $collision";
+						}
 					} else {
 						user_error("Bad collision item '$collision'", E_USER_WARNING);
 					}


### PR DESCRIPTION
This fixes a bug introduced by ffbeac6b7d3ed1a6e02a150573ee4b2f9251cf9c.
ClassInfo::subclassesFor() didn't previously throw an Exception if passed
an invalid class; it just returned no values. This will annoy minor-release
upgrades, and so I've made it return null instead in these situation.