### PR TITLE
BUG Fix duplicate primary key crash on duplicate

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -1395,6 +1395,16 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 		$fields->removeByName('Version');
 	}
 
+	/**
+	 * Ensure version ID is reset to 0 on duplicate
+	 *
+	 * @param DataObject $source Record this was duplicated from
+	 * @param bool $doWrite
+	 */
+	public function onBeforeDuplicate($source, $doWrite) {
+		$this->owner->Version = 0;
+	}
+
 	public function flushCache() {
 		self::$cache_versionnumber = array();
 	}

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -100,6 +100,23 @@ class VersionedTest extends SapphireTest {
 		$this->assertEquals($count, $count2);
 	}
 
+	public function testDuplicate() {
+		$obj1 = new VersionedTest_Subclass();
+		$obj1->ExtraField = 'Foo';
+		$obj1->write(); // version 1
+		$obj1->publish('Stage', 'Live');
+		$obj1->ExtraField = 'Foo2';
+		$obj1->write(); // version 2
+
+		// Make duplicate
+		$obj2 = $obj1->duplicate();
+
+		// Check records differ
+		$this->assertNotEquals($obj1->ID, $obj2->ID);
+		$this->assertEquals(2, $obj1->Version);
+		$this->assertEquals(1, $obj2->Version);
+	}
+
 	public function testForceChangeUpdatesVersion() {
 		$obj = new VersionedTest_DataObject();
 		$obj->Name = "test";


### PR DESCRIPTION
Duplicating objects should clear the version ID