### PR TITLE
FIX for #4502 Prevents JSON.parse() from scrambling sorted results from server-side.

### DIFF
--- a/forms/gridfield/GridFieldAddExistingAutocompleter.php
+++ b/forms/gridfield/GridFieldAddExistingAutocompleter.php
@@ -232,7 +232,12 @@ class GridFieldAddExistingAutocompleter
 		$originalSourceFileComments = Config::inst()->get('SSViewer', 'source_file_comments');
 		Config::inst()->update('SSViewer', 'source_file_comments', false);
 		foreach($results as $result) {
-			$json[$result->ID] = html_entity_decode(SSViewer::fromString($this->resultsFormat)->process($result));
+			$title = html_entity_decode(SSViewer::fromString($this->resultsFormat)->process($result));
+			$json[] = array(
+				"label" => $title,
+				"value" => $title,
+				"id" => $result->ID,
+			);
 		}
 		Config::inst()->update('SSViewer', 'source_file_comments', $originalSourceFileComments);
 		return Convert::array2json($json);

--- a/javascript/GridField.js
+++ b/javascript/GridField.js
@@ -371,9 +371,7 @@
 							url: $(searchField).data('searchUrl'),
 							data: encodeURIComponent(searchField.attr('name'))+'='+encodeURIComponent(searchField.val()), 
 							success: function(data) {
-								response( $.map(JSON.parse(data), function( name, id ) {
-									return { label: name, value: name, id: id };
-								}));
+								response(JSON.parse(data));
 							},
 							error: function(e) {
 								alert(ss.i18n._t('GRIDFIELD.ERRORINTRANSACTION', 'An error occured while fetching data from the server\n Please try again later.'));

--- a/tests/forms/gridfield/GridFieldAddExistingAutocompleterTest.php
+++ b/tests/forms/gridfield/GridFieldAddExistingAutocompleterTest.php
@@ -41,7 +41,11 @@ class GridFieldAddExistingAutocompleterTest extends FunctionalTest {
 		$this->assertFalse($response->isError());
 		$result = Convert::json2array($response->getBody());
 		$this->assertEquals(1, count($result));
-		$this->assertEquals(array($team2->ID => 'Team 2'), $result);
+		$this->assertEquals(array(array(
+			'label' => 'Team 2',
+			'value' => 'Team 2',
+			'id' => $team2->ID,
+		)), $result);
 								
 		$response = $this->post(
 			'GridFieldAddExistingAutocompleterTest_Controller/Form/field/testfield/'


### PR DESCRIPTION
This at least makes it possible to take results which were already sorted on the server and ensures they are displayed in the same order. See #4502 for a breakdown of what happens when JSON.parse() encounters an object which is 'unsorted' vs. an array, which is sorted.