### PR TITLE
When loading data into a form, make sure its using ALL fields

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -1280,7 +1280,7 @@ class Form extends RequestHandler {
 		if(is_object($data)) $this->record = $data;
 
 		// dont include fields without data
-		$dataFields = $this->fields->dataFields();
+		$dataFields = $this->Fields()->dataFields();
 		if($dataFields) foreach($dataFields as $field) {
 			$name = $field->getName();
 

--- a/forms/Form.php
+++ b/forms/Form.php
@@ -657,8 +657,10 @@ class Form extends RequestHandler {
 		$extraFields = new FieldList();
 
 		$token = $this->getSecurityToken();
-		$tokenField = $token->updateFieldSet($this->fields);
-		if($tokenField) $tokenField->setForm($this);
+		if ($token) {
+			$tokenField = $token->updateFieldSet($this->fields);
+			if($tokenField) $tokenField->setForm($this);
+		}
 		$this->securityTokenAdded = true;
 
 		// add the "real" HTTP method if necessary (for PUT, DELETE and HEAD)

--- a/tests/forms/FormTest.php
+++ b/tests/forms/FormTest.php
@@ -544,6 +544,26 @@ class FormTest extends FunctionalTest {
 			$messageEls[0]->asXML()
 		);
 	}
+
+    public function testGetExtraFields()
+    {
+        $form = new FormTest_ExtraFieldsForm(
+            new FormTest_Controller(),
+            'Form',
+            new FieldList(new TextField('key1')),
+            new FieldList()
+        );
+
+        $data = array(
+            'key1' => 'test',
+            'ExtraFieldCheckbox' => false,
+        );
+
+        $form->loadDataFrom($data);
+
+        $formData = $form->getData();
+        $this->assertEmpty($formData['ExtraFieldCheckbox']);
+    }
 	
 	protected function getStubForm() {
 		return new Form(
@@ -673,41 +693,57 @@ class FormTest_ControllerWithSecurityToken extends Controller implements TestOnl
 
 }
 
-class FormTest_ControllerWithStrictPostCheck extends Controller implements TestOnly {
+class FormTest_ControllerWithStrictPostCheck extends Controller implements TestOnly
+{
 
-	private static $allowed_actions = array('Form');
-	
-	protected $template = 'BlankPage';
-	
-	public function Link($action = null) {
-		return Controller::join_links(
-			'FormTest_ControllerWithStrictPostCheck', 
-			$this->request->latestParam('Action'),
-			$this->request->latestParam('ID'), 
-			$action
-		);
-	}
-	
-	public function Form() {
-		$form = new Form(
-			$this,
-			'Form',
-			new FieldList(
-				new EmailField('Email')
-			),
-			new FieldList(
-				new FormAction('doSubmit')
-			)
-		);
-		$form->setFormMethod('POST');
-		$form->setStrictFormMethodCheck(true);
-		$form->disableSecurityToken(); // Disable CSRF protection for easier form submission handling
+    private static $allowed_actions = array('Form');
 
-		return $form;
-	}
-	
-	public function doSubmit($data, $form, $request) {
-		$form->sessionMessage('Test save was successful', 'good');
-		return $this->redirectBack();
-	}
+    protected $template = 'BlankPage';
+
+    public function Link($action = null)
+    {
+        return Controller::join_links(
+            'FormTest_ControllerWithStrictPostCheck',
+            $this->request->latestParam('Action'),
+            $this->request->latestParam('ID'),
+            $action
+        );
+    }
+
+    public function Form()
+    {
+        $form = new Form(
+            $this,
+            'Form',
+            new FieldList(
+                new EmailField('Email')
+            ),
+            new FieldList(
+                new FormAction('doSubmit')
+            )
+        );
+        $form->setFormMethod('POST');
+        $form->setStrictFormMethodCheck(true);
+        $form->disableSecurityToken(); // Disable CSRF protection for easier form submission handling
+
+        return $form;
+    }
+
+    public function doSubmit($data, $form, $request)
+    {
+        $form->sessionMessage('Test save was successful', 'good');
+        return $this->redirectBack();
+    }
+}
+
+class FormTest_ExtraFieldsForm extends Form implements TestOnly {
+
+    public function getExtraFields() {
+        $fields = parent::getExtraFields();
+
+        $fields->push(new CheckboxField('ExtraFieldCheckbox', 'Extra Field Checkbox', 1));
+
+        return $fields;
+    }
+
 }


### PR DESCRIPTION
Fixes issue where loading data into a form doesn't take into account fields that could have been added by `getExtraFields`.