### PR TITLE
FIX: Using undefined var in ModelAdmin

### DIFF
--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -366,7 +366,7 @@ abstract class ModelAdmin extends LeftAndMain {
 			$specRelations->push(new ArrayData(array('Name' => $name, 'Description' => $desc)));
 		}
 		$specHTML = $this->customise(array(
-			'ClassName' => str_replace('\\', '_', $className),
+			'ClassName' => $this->sanitiseClassName($this->modelClass),
 			'ModelName' => Convert::raw2att($modelName),
 			'Fields' => $specFields,
 			'Relations' => $specRelations, 


### PR DESCRIPTION
See #4477. `$className` is undefined. Figured we may as well use `sanitiseClassName()` too as that’s what the method was added for.

ping @dhensby as you’ve been merging upstream lately. Looks like this is an issue across 3.1, 3.2, 3 and master. Good luck! :stuck_out_tongue_winking_eye: 