### PR TITLE
Fix issue where Access All CMS Sections doesnt work

### DIFF
--- a/security/Permission.php
+++ b/security/Permission.php
@@ -162,16 +162,23 @@ class Permission extends DataObject implements TemplateGlobalProvider {
 		} else {
 			$memberID = (is_object($member)) ? $member->ID : $member; 
 		}
-		
+
+		// If $admin_implies_all was false then this would be inefficient, but that's an edge
+		// case and this keeps the code simpler
+		if(!is_array($code)) $code = array($code);
+
 		if($arg == 'any') {
 			// Cache the permissions in memory
 			if(!isset(self::$cache_permissions[$memberID])) {
 				self::$cache_permissions[$memberID] = self::permissions_for_member($memberID);
 			}
-			
-			// If $admin_implies_all was false then this would be inefficient, but that's an edge
-			// case and this keeps the code simpler
-			if(!is_array($code)) $code = array($code);
+			foreach ($code as $permCode) {
+				if (substr($permCode, 0, 11) == 'CMS_ACCESS_') {
+					//cms_access_leftandmain means access to all CMS areas
+					$code[] = 'CMS_ACCESS_LeftAndMain';
+					break;
+				}
+			}
 			if(Config::inst()->get('Permission', 'admin_implies_all')) $code[] = "ADMIN";
 
 			// Multiple $code values - return true if at least one matches, ie, intersection exists

--- a/tests/security/PermissionTest.php
+++ b/tests/security/PermissionTest.php
@@ -22,6 +22,26 @@ class PermissionTest extends SapphireTest {
 		$member = $this->objFromFixture('Member', 'author');
 		$this->assertTrue(Permission::checkMember($member, "SITETREE_VIEW_ALL"));
 	}
+
+	public function testLeftAndMainAccessAll() {
+		//add user and group
+		$member = Member::create()->update(array(
+			'FirstName' => 'Left',
+			'Surname' => 'Main',
+			'Email' => 'leftandmain@example.com',
+		));
+		$member->write();
+		$group = Group::create()->update(array(
+			'Title' => 'LeftAndMain',
+		));
+		$group->write();
+		Permission::grant($group->ID, 'CMS_ACCESS_LeftAndMain');
+		$group->DirectMembers()->add($member);
+
+		$this->assertTrue(Permission::checkMember($member, "CMS_ACCESS_MyAdmin"));
+		$this->assertTrue(Permission::checkMember($member, "CMS_ACCESS_AssetAdmin"));
+		$this->assertTrue(Permission::checkMember($member, "CMS_ACCESS_SecurityAdmin"));
+	}
 	
 	public function testPermissionAreInheritedFromOneRole() {
 		$member = $this->objFromFixture('Member', 'author');
@@ -39,7 +59,7 @@ class PermissionTest extends SapphireTest {
 		$this->assertFalse(Permission::checkMember($member, "SITETREE_VIEW_ALL"));
 	}
 
-	function testPermissionsForMember() {
+	public function testPermissionsForMember() {
 		$member = $this->objFromFixture('Member', 'access');
 		$permissions = Permission::permissions_for_member($member->ID);
 		$this->assertEquals(4, count($permissions));


### PR DESCRIPTION
At the moment, if you select "Access to all CMS sections" in the Permissions for a group, a user belonging to the group can't access the Members.

Member canView requires the CMS_ACCESS_Security (which is a sub section of CMS_ACCESS_Security).

This patch automatically adds CMS_ACCESS_LeftAndMain to the permissions codes we check against if any CMS_ACCESS_* code is supplied.