### PR TITLE
BUG Fix illegalExtensions breaking tests.

### DIFF
--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -342,6 +342,27 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 	 * tearDown method that's called once per test class rather once per test method.
 	 */
 	public function tearDownOnce() {
+		// If we have made changes to the extensions present, then migrate the database schema.
+		if($this->extensionsToReapply || $this->extensionsToRemove) {
+			// @todo: This isn't strictly necessary to restore extensions, but only to ensure that
+			// Object::$extra_methods is properly flushed. This should be replaced with a simple
+			// flush mechanism for each $class.
+			//
+			// Remove extensions added for testing
+			foreach($this->extensionsToRemove as $class => $extensions) {
+				foreach($extensions as $extension) {
+					$class::remove_extension($extension);
+				}
+			}
+
+			// Reapply ones removed
+			foreach($this->extensionsToReapply as $class => $extensions) {
+				foreach($extensions as $extension) {
+					$class::add_extension($extension);
+				}
+			}
+		}
+		
 		//unnest injector / config now that the test suite is over
 		// this will reset all the extensions on the object too (see setUpOnce)
 		Injector::unnest();


### PR DESCRIPTION
Revert #3979 

Before fixing (running subsites test with translatable):

```
Time: 1.01 minutes, Memory: 122.50Mb

There were 25 errors:

1) SubsiteAdminFunctionalTest::testAnonymousIsForbiddenAdminAccess
Exception: Object->__call(): the method 'hastranslation' does not exist on 'Page'

/Users/dmooyman/Sites/cwp111test/framework/core/Object.php:763
/Users/dmooyman/Sites/cwp111test/translatable/code/model/Translatable.php:906
/Users/dmooyman/Sites/cwp111test/translatable/code/model/Translatable.php:906
/Users/dmooyman/Sites/cwp111test/framework/core/Object.php:1002
/Users/dmooyman/Sites/cwp111test/framework/model/DataObject.php:1037
/Users/dmooyman/Sites/cwp111test/cms/code/model/SiteTree.php:1488
/Users/dmooyman/Sites/cwp111test/framework/model/DataObject.php:1161
/Users/dmooyman/Sites/cwp111test/framework/dev/FixtureBlueprint.php:120
/Users/dmooyman/Sites/cwp111test/framework/dev/FixtureFactory.php:71
/Users/dmooyman/Sites/cwp111test/framework/dev/YamlFixture.php:206
/Users/dmooyman/Sites/cwp111test/framework/dev/SapphireTest.php:262
/Users/dmooyman/Sites/cwp111test/framework/dev/FunctionalTest.php:81
/Users/dmooyman/Sites/cwp111test/vendor/phpunit/phpunit/composer/bin/phpunit:63
```

After fixing:

```
MacBook-Pro:cwp111test dmooyman$ vendor/bin/phpunit subsites/tests/
PHPUnit 3.7.38 by Sebastian Bergmann.

Configuration read from /Users/dmooyman/Sites/cwp111test/phpunit.xml.dist

..............................................

Time: 1.45 minutes, Memory: 137.00Mb

OK (46 tests, 193 assertions)
```