### PR TITLE
BUG Fix bulk actions making sitetree unclickable

### DIFF
--- a/admin/javascript/LeftAndMain.BatchActions.js
+++ b/admin/javascript/LeftAndMain.BatchActions.js
@@ -174,6 +174,9 @@
 					// the native dropdown
 					setTimeout(function() { batchactions.addClass('inactive'); }, 100);
 				}
+				
+				// Refresh selected / enabled nodes
+				$('#Form_BatchActionsForm').refreshSelected();
 			},
 
 			/**
@@ -236,6 +239,7 @@
 					st = this.getTree(),
 					ids = this.getIDs(),
 					allIds = [],
+					viewMode = $('.cms-content-batchactions :input[name=view-mode-batchactions]'),
 					selectedAction = this.find(':input[name=Action]').val();
 			
 				// Default to refreshing the entire tree
@@ -246,7 +250,7 @@
 				}
 
 				// If no action is selected, enable all nodes
-				if(selectedAction == -1) {
+				if(!selectedAction || selectedAction == -1 || !viewMode.is(":checked")) {
 					$(rootNode).find('li').each(function() {
 						$(this).setEnabled(true);
 					});


### PR DESCRIPTION
If you select a bulk action with disabled items in it, disabling the action dropdown should make the whole sitetree clickable again. Before it would leave disabled items disabled.

3.2 version of https://github.com/silverstripe/silverstripe-framework/pull/4524