### PR TITLE
BUG Fix bulk actions making sitetree unclickable

### DIFF
--- a/admin/javascript/LeftAndMain.BatchActions.js
+++ b/admin/javascript/LeftAndMain.BatchActions.js
@@ -170,6 +170,7 @@
 					st = this.getTree(),
 					ids = this.getIDs(),
 					allIds = [],
+					viewMode = $('.cms-content-batchactions-button'),
 					selectedAction = this.find(':input[name=Action]').val();
 			
 				// Default to refreshing the entire tree
@@ -180,7 +181,7 @@
 				}
 
 				// If no action is selected, enable all nodes
-				if(!selectedAction || selectedAction == -1) {
+				if(!selectedAction || selectedAction == -1 || !viewMode.hasClass('active')) {
 					$(rootNode).find('li').each(function() {
 						$(this).setEnabled(true);
 					});
@@ -354,11 +355,12 @@
 					tree.addClass('multiple');
 					tree.removeClass('draggable');
 					form.serializeFromTree();
-					$('#Form_BatchActionsForm').refreshSelected();
 				} else {
 					tree.removeClass('multiple');
 					tree.addClass('draggable');
 				}
+				
+				$('#Form_BatchActionsForm').refreshSelected();
 			}
 		});
 


### PR DESCRIPTION
If you select a bulk action with disabled items in it, disabling the action dropdown should make the whole sitetree clickable again. Before it would leave disabled items disabled.

3.3 version of https://github.com/silverstripe/silverstripe-framework/pull/4522