### PR TITLE
BUG Ensure tests have relative urls not site-root urls

### DIFF
--- a/tests/control/ControllerTest.php
+++ b/tests/control/ControllerTest.php
@@ -328,7 +328,7 @@ class ControllerTest extends FunctionalTest {
 	*/
 
 	public function testRedirectBackByReferer() {
-		$internalRelativeUrl = '/some-url';
+		$internalRelativeUrl = 'some-url';
 		$internalAbsoluteUrl = Controller::join_links(Director::absoluteBaseURL(), '/some-url');
 		
 		$response = $this->get('ControllerTest_Controller/redirectbacktest', null,
@@ -354,7 +354,7 @@ class ControllerTest extends FunctionalTest {
 	}
 
 	public function testRedirectBackByBackUrl() {
-		$internalRelativeUrl = '/some-url';
+		$internalRelativeUrl = 'some-url';
 		$internalAbsoluteUrl = Controller::join_links(Director::absoluteBaseURL(), '/some-url');
 		
 		$response = $this->get('ControllerTest_Controller/redirectbacktest?BackURL=' . urlencode($internalRelativeUrl));
@@ -363,7 +363,6 @@ class ControllerTest extends FunctionalTest {
 			"Redirects on internal relative URLs"
 		);
 
-		$internalAbsoluteUrl = Director::absoluteBaseURL() . '/some-url';
 		$response = $this->get('ControllerTest_Controller/redirectbacktest?BackURL=' . urlencode($internalAbsoluteUrl));
 		$this->assertEquals($internalAbsoluteUrl, $response->getHeader('Location'));
 		$this->assertEquals(302, $response->getStatusCode(),


### PR DESCRIPTION
Symptoms come up in testing environments where the baseurl has a subdirectory.

![image](https://cloud.githubusercontent.com/assets/936064/9431568/2b8cb738-4a68-11e5-89e0-70198588cf78.png)

The fault is on the code assuming that `/some-url` is the root relative url when it's not always the case.