### PR TITLE
Remove forward slash in URLs in multibyte mode

### DIFF
--- a/model/URLSegmentFilter.php
+++ b/model/URLSegmentFilter.php
@@ -32,6 +32,7 @@ class URLSegmentFilter extends Object {
 		'/\s|\+/u' => '-', // remove whitespace/plus
 		'/[_.]+/u' => '-', // underscores and dots to dashes
 		'/[^A-Za-z0-9\-]+/u' => '', // remove non-ASCII chars, only allow alphanumeric and dashes
+		'/\/+/u' => '-', // remove forward slashes in case multibyte is allowed (and ASCII chars aren't removed)
 		'/[\-]{2,}/u' => '-', // remove duplicate dashes
 		'/^[\-]+/u' => '', // Remove all leading dashes
 		'/[\-]+$/u' => '' // Remove all trailing dashes

--- a/tests/model/URLSegmentFilterTest.php
+++ b/tests/model/URLSegmentFilterTest.php
@@ -55,6 +55,15 @@ class URLSegmentFilterTest extends SapphireTest {
 		);
 	}
 
+	public function testReplacesForwardSlashesWithAllowMultiByteOption() {
+		$f = new URLSegmentFilter();
+		$f->setAllowMultibyte(true);
+		$this->assertEquals(
+			urlencode('this-that'),
+			$f->filter('this/that')
+		);
+	}
+
 	public function testReplacements() {
 		$f = new URLSegmentFilter();
 		$this->assertEquals(


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-cms/issues/1262.

This change only affects projects which have `URLSegmentFilter.default_allow_multibyte` set to `true` (defaults to `false`). In that case, the removal of non-ASCII chars is disabled, but certain characters with semantic meaning in the URI context still need to be removed. I don't think any projects would've relied on this faulty behaviour, since it causes the page not to be found. Hence 3 as the target branch.