### PR TITLE
FIX for #4417: Ensuring ->removeValidation() is defined on instances of Validator. Setup new API for enabling/disabling validation. Documentation and better type handling.

### DIFF
--- a/src/Forms/RequiredFields.php
+++ b/src/Forms/RequiredFields.php
@@ -48,6 +48,7 @@ class RequiredFields extends Validator
      */
     public function removeValidation()
     {
+        parent::removeValidation();
         $this->required = array();
 
         return $this;

--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -30,6 +30,11 @@ abstract class Validator extends Object
     protected $result;
 
     /**
+     * @var bool
+     */
+    private $enabled = true;
+
+    /**
      * @param Form $form
      * @return $this
      */
@@ -47,7 +52,9 @@ abstract class Validator extends Object
     public function validate()
     {
         $this->resetResult();
-        $this->php($this->form->getData());
+        if ($this->getEnabled()) {
+            $this->php($this->form->getData());
+        }
         return $this->result;
     }
 
@@ -128,6 +135,34 @@ abstract class Validator extends Object
      * @return mixed
      */
     abstract public function php($data);
+
+    /**
+     * @param bool $enabled
+     * @return $this
+     */
+    public function setEnabled($enabled)
+    {
+        $this->enabled = (bool)$enabled;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @return $this
+     */
+    public function removeValidation()
+    {
+        $this->setEnabled(false);
+        $this->resetResult();
+        return $this;
+    }
 
     /**
      * Clear current result

--- a/tests/php/Forms/ValidatorTest.php
+++ b/tests/php/Forms/ValidatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SilverStripe\Forms\Tests;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\Tests\ValidatorTest\TestValidator;
+use SilverStripe\Forms\TextField;
+
+/**
+ * @package framework
+ * @subpackage tests
+ */
+class ValidatorTest extends SapphireTest
+{
+
+    /**
+     * Common method for setting up form, since that will always be a dependency for the validator.
+     *
+     * @param    array $fieldNames
+     * @return    Form
+     */
+    protected function getForm(array $fieldNames = array())
+    {
+        // Setup field list now. We're only worried about names right now.
+        $fieldList = new FieldList();
+        foreach ($fieldNames as $name) {
+            $fieldList->add(new TextField($name));
+        }
+
+        return new Form(new Controller(), "testForm", $fieldList, new FieldList([/* no actions */]));
+    }
+
+
+    public function testRemoveValidation()
+    {
+        $validator = new TestValidator();
+
+        // Setup a form with the fields/data we're testing (a form is a dependency for validation right now).
+        $data = array("foobar" => "");
+        $form = $this->getForm(array_keys($data)); // We only care right now about the fields we've got setup in this array.
+        $form->disableSecurityToken();
+        $form->setValidator($validator); // Setup validator now that we've got our form.
+        $form->loadDataFrom($data); // Put data into the form so the validator can pull it back out again.
+
+        $result = $form->validationResult();
+        $this->assertFalse($result->isValid());
+        $this->assertCount(1, $result->getMessages());
+
+        // Make sure it doesn't fail after removing validation AND has no errors (since calling validate should reset errors).
+        $validator->removeValidation();
+        $result = $form->validationResult();
+        $this->assertTrue($result->isValid());
+        $this->assertEmpty($result->getMessages());
+    }
+}

--- a/tests/php/Forms/ValidatorTest/TestValidator.php
+++ b/tests/php/Forms/ValidatorTest/TestValidator.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\ValidatorTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\Validator;
+
+class TestValidator extends Validator implements TestOnly
+{
+
+    /**
+     * Requires a specific field for test purposes.
+     *
+     * @param array $data
+     * @return null
+     */
+    public function php($data)
+    {
+        foreach ($data as $field => $data) {
+            $this->validationError($field, 'error');
+        }
+    }
+}


### PR DESCRIPTION
Replying to original PR here: #4418

@dhensby @tractorcow 

**Firstly:** I was in the process of setting this up in master, however I realized that maybe it'd make more sense to go ahead and rethink this and take a different approach (since we're going against master and we can be _a little_ more flexible with the API). That is -- since there must not be very many implementations of this which are already broken by the lack of `->removeValidation()` method, maybe it will make more sense to update the API take the "enable" vs "disable" approach. I think if you need the ability remove validation, you should also then have the ability to enable it again. So, I'd suggest having a new method like `->setEnabled($enabled)` which `->validate()` will check first before actually doing anything useful.

**Secondly:** Since needed to have `->removeValidation()` available by default (due to it's calling/usage elsewhere), it makes sense for it to do something. In light of the above API (`->setEnabled()`) we can have it just be an alias for `->setEnabled(false)` and, in order to make it functional, it can maintain state for the `->validate()` method, which (if I'm correct) is the goal. That is, to be able to allow regular execution of the `->validate()` method without triggering errors (to effectively disable/remove validation, but **temporarily** if desired).

**Thirdly:** This PR contains that along with a cleanup of `->errors` to be consistent with `->getErrors()` documentation (that is, it's expected to always be an array). An empty array loosely validates to false just as well as null does, plus we're being more explicit here and, in my opinion, it's simpler to just return the same type all of the time. 
