### PR TITLE
FIX: Recursion errors when sorting customised ViewableData objects (fixes #4464)

### DIFF
--- a/tests/model/ArrayListTest.php
+++ b/tests/model/ArrayListTest.php
@@ -426,6 +426,25 @@ class ArrayListTest extends SapphireTest {
 	}
 
 	/**
+	 * Check that we don't cause recursion errors with array_multisort() and customised ViewableData objects
+	 */
+	public function testSortWithRecursiveReferences() {
+		$items = ArrayList::create();
+
+		// Objects need the same sort value so that their properties are compared by array_multisort
+		$items->add(DataObject::create(array('Order' => 1)));
+		$items->add(DataObject::create(array('Order' => 1)));
+
+		// Customising the object adds recursive dependencies (between the object and its customised instance)
+		foreach ($items as $item) {
+			$item->customise(array());
+		}
+
+		// This call will trigger a fatal error if there are recursion issues
+		$items->sort('Order');
+	}
+
+	/**
 	 * $list->filter('Name', 'bob'); // only bob in the list
 	 */
 	public function testSimpleFilter() {


### PR DESCRIPTION
Basically, if the sort values are the same then PHP will try to inspect the object’s properties, which will completely break if there are recursive dependencies: https://3v4l.org/s9UZM. This issue was highlighted by https://github.com/bummzack/sortablefile/pull/41. I don’t think we need to worry about people passing in their own object types with recursive dependencies (we can’t fix PHP after all), but I think we should fix it for `ViewableData`.

`spl_object_hash()` seems to be good enough. If the objects being compared are identical (i.e. the same instance of the object) then the hashes are the same, but `array_multisort()` is already able to handle that anyway.

This is an issue in 3.1 too, but we don’t have an easy way of telling whether an object is customised (`ViewableData::getCustomisedObj()` doesn’t exist in 3.1). I’m happy to resubmit this to 3.1 if anyone can think of a workaround for that.