### PR TITLE
FIX: Recursion errors when sorting objects with circular dependencies (fixes #4464)

### DIFF
--- a/model/ArrayList.php
+++ b/model/ArrayList.php
@@ -422,10 +422,15 @@ class ArrayList extends ViewableData implements SS_List, SS_Filterable, SS_Sorta
 			throw new InvalidArgumentException("Bad arguments passed to sort()");
 		}
 
+		// Store the original keys of the items as a sort fallback, so we can preserve the original order in the event
+		// that array_multisort is unable to work out a sort order for them. This also prevents array_multisort trying
+		// to inspect object properties which can result in errors with circular dependencies
+		$originalKeys = array_keys($this->items);
+
 		// This the main sorting algorithm that supports infinite sorting params
 		$multisortArgs = array();
 		$values = array();
-		foreach($columnsToSort as $column => $direction ) {
+		foreach($columnsToSort as $column => $direction) {
 			// The reason these are added to columns is of the references, otherwise when the foreach
 			// is done, all $values and $direction look the same
 			$values[$column] = array();
@@ -442,6 +447,8 @@ class ArrayList extends ViewableData implements SS_List, SS_Filterable, SS_Sorta
 			$multisortArgs[] = &$sortDirection[$column];
 		}
 
+		$multisortArgs[] = &$originalKeys;
+		
 		$list = clone $this;
 		// As the last argument we pass in a reference to the items that all the sorting will be applied upon
 		$multisortArgs[] = &$list->items;

--- a/tests/model/ArrayListTest.php
+++ b/tests/model/ArrayListTest.php
@@ -424,6 +424,30 @@ class ArrayListTest extends SapphireTest {
 		$this->assertEquals($list->first()->ID, 1, 'Aron.2 should be first in the list');
 		$this->assertEquals($list->last()->ID, 3, 'Bert.3 should be last in the list');
 	}
+
+	/**
+	 * Check that we don't cause recursion errors with array_multisort() and circular dependencies
+	 */
+	public function testSortWithCircularDependencies() {
+		$itemA = new stdClass;
+		$childA = new stdClass;
+		$itemA->child = $childA;
+		$childA->parent = $itemA;
+		$itemA->Sort = 1;
+
+		$itemB = new stdClass;
+		$childB = new stdClass;
+		$itemB->child = $childB;
+		$childB->parent = $itemB;
+		$itemB->Sort = 1;
+
+		$items = new ArrayList;
+		$items->add($itemA);
+		$items->add($itemB);
+
+		// This call will trigger a fatal error if there are issues with circular dependencies
+		$items->sort('Sort');
+	}
 	
 	/**
 	 * $list->filter('Name', 'bob'); // only bob in the list


### PR DESCRIPTION
Another attempt at #4544.

This doesn’t use `spl_object_hash()` as it can mess with the sort order itself. If all the values being sorted on are the same, then it will sort by the hashes which can result in objects coming back in a different order each time you attempt the sort.

This is simpler - we just store an array (1, 2, 3 etc) that’s passed as the penultimate argument to `array_multisort()`. This way if the sort values are the same, then the items come back in the same order that they were passed in.