### PR TITLE
MINOR: Drop wasteful 'allow-failures' builds; simplify build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,6 @@ env:
     - DB=PGSQL
 
 matrix:
-  allow_failures:
-    - php: hhvm
-    - php: 7.0
-    - php: nightly
-
   include:
     - php: 5.4
       env: DB=MYSQL PDO=1
@@ -37,12 +32,6 @@ matrix:
       env: DB=MYSQL
     - php: 5.4
       env: DB=MYSQL BEHAT_TEST=1
-    - php: 7.0
-      env: DB=MYSQL
-    - php: nightly
-      env: DB=MYSQL
-    - php: hhvm
-      env: DB=MYSQL
 
 before_script:
  - composer self-update || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ addons:
     packages:
       - tidy
 
-php:
-  - 5.4
-
 env:
   global:
     - CORE_RELEASE=master
@@ -17,20 +14,16 @@ env:
     - "ARTIFACTS_S3_BUCKET=silverstripe-travis-artifacts"
     - secure: "DjwZKhY/c0wXppGmd8oEMiTV0ayfOXiCmi9Lg1aXoSXNnj+sjLmhYwhUWjehjR6IX0MRtzJG6v7V5Y+4nSGe+i+XIrBQnhPQ95Jrkm1gKofX2mznWTl9npQElNS1DXi58NLPbiB3qxHWGFBRAWmRQrsAouyZabkPnChnSa9ldOg="
     - secure: "UmbXCNLK0f2Dk+7qX8bOVcgIt4QhRvccoWvMUxaPtIU+95HCbG10eeCxvfOeBax+tHcRXmeCG4vM4tcuT/WoANkAma/VX74DylFjbWhks2tsKOcr2kjTrOwe6Q9CXOBjVAlcx0lnV/a+w83KARjXGnCrIbE7p7r4EDw31rkVufg="
-  matrix:
-    - DB=MYSQL
-    - DB=SQLITE
-    - DB=PGSQL
 
 matrix:
   include:
     - php: 5.4
-      env: DB=MYSQL PDO=1
+      env: DB=PGSQL
     - php: 5.5
-      env: DB=MYSQL
+      env: DB=SQLITE
     - php: 5.6
-      env: DB=MYSQL
-    - php: 5.4
+      env: DB=MYSQL PDO=1
+    - php: 5.6
       env: DB=MYSQL BEHAT_TEST=1
 
 before_script:


### PR DESCRIPTION
Our build time is an impediment: frequently we're slowed down waiting for
test runs to complete. In this context, running allowed-failure builds
that everyone ignores is just a waste.

I'd love to see HHVM work, but that's going to require that someone
actually gets the build to pass. At that point, we can add it back into
the build matrix.

I'm working on a PHP7 branch that will hopefully also fix our nightly
builds. Once I get that going, I'll add those two back, but not have
'allow failures'

Even if we decide, at some point in the future, that supporting nightly
doesn't make sense, I see the *only* value of Travis is maintaining our
green tick. We either care about builds or we don't: I've never seen a
'grey area' build result in anything other than embarrassment and
technical debt.

Let's decide what matters to us and treat it like it matters to us:
it's part of the build or not.