### PR TITLE
MINOR: Simplify build matrix for 3.x builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ addons:
     packages:
       - tidy
 
-php:
-  - 5.4
-
 env:
   global:
     - CORE_RELEASE=3.1
@@ -17,26 +14,19 @@ env:
     - "ARTIFACTS_S3_BUCKET=silverstripe-travis-artifacts"
     - secure: "DjwZKhY/c0wXppGmd8oEMiTV0ayfOXiCmi9Lg1aXoSXNnj+sjLmhYwhUWjehjR6IX0MRtzJG6v7V5Y+4nSGe+i+XIrBQnhPQ95Jrkm1gKofX2mznWTl9npQElNS1DXi58NLPbiB3qxHWGFBRAWmRQrsAouyZabkPnChnSa9ldOg="
     - secure: "UmbXCNLK0f2Dk+7qX8bOVcgIt4QhRvccoWvMUxaPtIU+95HCbG10eeCxvfOeBax+tHcRXmeCG4vM4tcuT/WoANkAma/VX74DylFjbWhks2tsKOcr2kjTrOwe6Q9CXOBjVAlcx0lnV/a+w83KARjXGnCrIbE7p7r4EDw31rkVufg="
-  matrix:
-    - DB=MYSQL
-    - DB=SQLITE
-    - DB=PGSQL
 
 matrix:
-  allow_failures:
-    - php: hhvm
-
   include:
-    - php: 5.5
-      env: DB=MYSQL
-    - php: 5.6
-      env: DB=MYSQL
-    - php: 5.4
-      env: DB=MYSQL BEHAT_TEST=1
     - php: 5.3
       env: DB=MYSQL
-    - php: hhvm
-      env: DB=MYSQL
+    - php: 5.4
+      env: DB=PGSQL
+    - php: 5.5
+      env: DB=SQLITE
+    - php: 5.6
+      env: DB=MYSQL PDO=1
+    - php: 5.6
+      env: DB=MYSQL BEHAT_TEST=1
 
 before_script:
  - composer self-update || true


### PR DESCRIPTION
This is a companion to https://github.com/silverstripe/silverstripe-framework/pull/4556
but targeted at the build needs of SilverStripe 3.x. Commit into 3.1 and
then the merge forward into 3.2 and 3.