### PR TITLE
BUG Remove html5 number field due to insufficient localisation support

### DIFF
--- a/forms/NumericField.php
+++ b/forms/NumericField.php
@@ -82,13 +82,6 @@ class NumericField extends TextField {
 		return 'numeric text';
 	}
 
-	public function getAttributes() {
-		return array_merge(parent::getAttributes(), array(
-			'type' => 'number',
-			'step' => 'any' // allows entering float/decimal numbers like "1.2" instead of just integers
-		));
-	}
-
 	/**
 	 * Validate this field
 	 *

--- a/tests/forms/NumericFieldTest.php
+++ b/tests/forms/NumericFieldTest.php
@@ -187,8 +187,10 @@ class NumericFieldTest extends SapphireTest {
 		$field = new NumericField('Number');
 
 		$html = $field->Field();
-		$this->assertContains('type="number"', $html, 'number type set');
-		$this->assertContains('step="any"', $html, 'step value set to any');
+		
+		// @todo - Revert to number one day when html5 number supports proper localisation
+		// See https://github.com/silverstripe/silverstripe-framework/pull/4565
+		$this->assertContains('type="text"', $html, 'number type not set');
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/4550

It looks as though drupal encountered this same issue. See https://www.drupal.org/node/2290029 for the discussion. We may as well save the discussion and concur with them on the current solution.

I feel that accurate localisation is more important to silverstripe than conforming to standards for the sake of standardisation (although we prefer it where these align with one another).

One day when html5 number supports thousands separators, as per proper numeric localisation, we can re-enable this.

An alternative solution (which I'm going to reject) is to strip thousands separators. If there's a nice locale-safe way to do so, then we could do this, but since there are at least three different thousands separator formats (space, comma, period, and maybe more) I don't feel like it's wise to expose to so many edge cases. It would also reduce the localisation quality of the resulting string.