### PR TITLE
FIX Resampled images inherit source properties

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -691,11 +691,7 @@ class Image extends File implements Flushable {
 				call_user_func_array(array($this, "generateFormattedImage"), $args);
 			}
 
-			$cached = new Image_Cached($cacheFile);
-			// Pass through the title so the templates can use it
-			$cached->Title = $this->Title;
-			// Pass through the parent, to store cached images in correct folder.
-			$cached->ParentID = $this->ParentID;
+			$cached = new Image_Cached($cacheFile, false, $this);
 			return $cached;
 		}
 	}
@@ -1037,8 +1033,9 @@ class Image_Cached extends Image {
 	 * @param boolean $isSingleton This this to true if this is a singleton() object, a stub for calling methods.
 	 *                             Singletons don't have their defaults set.
 	 */
-	public function __construct($filename = null, $isSingleton = false) {
+	public function __construct($filename = null, $isSingleton = false, Image $sourceImage = null) {
 		parent::__construct(array(), $isSingleton);
+		if ($sourceImage) $this->update($sourceImage->toMap());
 		$this->ID = -1;
 		$this->Filename = $filename;
 	}

--- a/tests/model/ImageTest.php
+++ b/tests/model/ImageTest.php
@@ -341,6 +341,19 @@ class ImageTest extends SapphireTest {
 	}
 
 	/**
+	 * Test that propertes from the source Image are inherited by resampled images 
+	 */
+	public function testPropertyInheritance() {
+		$testString = 'This is a test';
+		$origImage = $this->objFromFixture('Image', 'imageWithTitle');
+		$origImage->TestProperty = $testString;
+		$resampled = $origImage->ScaleWidth(10);
+		$this->assertEquals($resampled->TestProperty, $testString);
+		$resampled2 = $resampled->ScaleWidth(5);
+		$this->assertEquals($resampled2->TestProperty, $testString);
+	}
+
+	/**
 	 * Tests that cached images are regenerated properly after a cached file is renamed with new arguments
 	 * ToDo: This doesn't seem like something that is worth testing - what is the point of this?
 	 */


### PR DESCRIPTION
Ensure Image_Cached objects can access all the properties of the source image (fixes #4569)