### PR TITLE
API Refactor CompositeDBField into an abstract class

### DIFF
--- a/forms/MoneyField.php
+++ b/forms/MoneyField.php
@@ -106,15 +106,18 @@ class MoneyField extends FormField {
 	 * (see @link MoneyFieldTest_CustomSetter_Object for more information)
 	 */
 	public function saveInto(DataObjectInterface $dataObject) {
-		$fieldName = $this->name;
+		$fieldName = $this->getName();
 		if($dataObject->hasMethod("set$fieldName")) {
 			$dataObject->$fieldName = DBField::create_field('Money', array(
 				"Currency" => $this->fieldCurrency->dataValue(),
 				"Amount" => $this->fieldAmount->dataValue()
 			));
 		} else {
-			$dataObject->$fieldName->setCurrency($this->fieldCurrency->dataValue());
-			$dataObject->$fieldName->setAmount($this->fieldAmount->dataValue());
+			$currencyField = "{$fieldName}Currency";
+			$amountField = "{$fieldName}Amount";
+
+			$dataObject->$currencyField = $this->fieldCurrency->dataValue();
+			$dataObject->$amountField = $this->fieldAmount->dataValue();
 		}
 	}
 

--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -462,6 +462,7 @@ class DataQuery {
 		if($compositeFields) foreach($compositeFields as $k => $v) {
 			if((is_null($columns) || in_array($k, $columns)) && $v) {
 				$dbO = Object::create_from_string($v, $k);
+				$dbO->setTable($tableClass);
 				$dbO->addToQuery($query);
 			}
 		}

--- a/model/ManyManyList.php
+++ b/model/ManyManyList.php
@@ -122,18 +122,17 @@ class ManyManyList extends RelationList {
 				// convert joined extra fields into their composite field types.
 				$value = array();
 
-				foreach($composed as $subField => $subSpec) {
-					if(isset($row[$fieldName . $subSpec])) {
-						$value[$subSpec] = $row[$fieldName . $subSpec];
+				foreach($composed as $subField) {
+					if(isset($row[$fieldName . $subField])) {
+						$value[$subField] = $row[$fieldName . $subField];
 
 						// don't duplicate data in the record
-						unset($row[$fieldName . $subSpec]);
+						unset($row[$fieldName . $subField]);
 					}
 				}
 
 				$obj = Object::create_from_string($this->extraFields[$fieldName], $fieldName);
 				$obj->setValue($value, null, false);
-
 				$add[$fieldName] = $obj;
 			}
 		}

--- a/model/fieldtypes/CompositeDBField.php
+++ b/model/fieldtypes/CompositeDBField.php
@@ -7,96 +7,18 @@
  *
  * Example with a combined street name and number:
  * <code>
-* class Street extends DBField implements CompositeDBField {
-* 	protected $streetNumber;
-* 	protected $streetName;
-* 	protected $isChanged = false;
-* 	static $composite_db = return array(
+* class Street extends CompositeDBField {
+* 	private static $composite_db = return array(
 * 		"Number" => "Int",
 * 		"Name" => "Text"
 * 	);
-*
-* 	function requireField() {
-* 		DB::requireField($this->tableName, "{$this->name}Number", 'Int');
-* 		DB::requireField($this->tableName, "{$this->name}Name", 'Text');
-* 	}
-*
-* 	function writeToManipulation(&$manipulation) {
-* 		if($this->getStreetName()) {
-* 			$manipulation['fields']["{$this->name}Name"] = $this->prepValueForDB($this->getStreetName());
-* 		} else {
-* 			$manipulation['fields']["{$this->name}Name"] = DBField::create_field('Varchar', $this->getStreetName())
-* 				->nullValue();
-* 		}
-*
-* 		if($this->getStreetNumber()) {
-* 			$manipulation['fields']["{$this->name}Number"] = $this->prepValueForDB($this->getStreetNumber());
-* 		} else {
-* 			$manipulation['fields']["{$this->name}Number"] = DBField::create_field('Int', $this->getStreetNumber())
-* 				->nullValue();
-* 		}
-* 	}
-*
-* 	function addToQuery(&$query) {
-* 		parent::addToQuery($query);
-* 		$query->setSelect("{$this->name}Number");
-* 		$query->setSelect("{$this->name}Name");
-* 	}
-*
-* 	function setValue($value, $record = null, $markChanged=true) {
-* 		if ($value instanceof Street && $value->exists()) {
-* 			$this->setStreetName($value->getStreetName(), $markChanged);
-* 			$this->setStreetNumber($value->getStreetNumber(), $markChanged);
-* 			if($markChanged) $this->isChanged = true;
-* 		} else if($record && isset($record[$this->name . 'Name']) && isset($record[$this->name . 'Number'])) {
-* 			if($record[$this->name . 'Name'] && $record[$this->name . 'Number']) {
-* 				$this->setStreetName($record[$this->name . 'Name'], $markChanged);
-* 				$this->setStreetNumber($record[$this->name . 'Number'], $markChanged);
-* 			}
-* 			if($markChanged) $this->isChanged = true;
-* 		} else if (is_array($value)) {
-* 			if (array_key_exists('Name', $value)) {
-* 				$this->setStreetName($value['Name'], $markChanged);
-* 			}
-* 			if (array_key_exists('Number', $value)) {
-* 				$this->setStreetNumber($value['Number'], $markChanged);
-* 			}
-* 			if($markChanged) $this->isChanged = true;
-* 		}
-* 	}
-*
-* 	function setStreetNumber($val, $markChanged=true) {
-* 		$this->streetNumber = $val;
-* 		if($markChanged) $this->isChanged = true;
-* 	}
-*
-* 	function setStreetName($val, $markChanged=true) {
-* 		$this->streetName = $val;
-* 		if($markChanged) $this->isChanged = true;
-* 	}
-*
-* 	function getStreetNumber() {
-* 		return $this->streetNumber;
-* 	}
-*
-* 	function getStreetName() {
-* 		return $this->streetName;
-* 	}
-*
-* 	function isChanged() {
-* 		return $this->isChanged;
-* 	}
-*
-* 	function exists() {
-* 		return ($this->getStreetName() || $this->getStreetNumber());
-* 	}
 * }
  * </code>
  *
  * @package framework
  * @subpackage model
  */
-interface CompositeDBField {
+abstract class CompositeDBField extends DBField {
 
 	/**
 	 * Similiar to {@link DataObject::$db},
@@ -104,48 +26,30 @@ interface CompositeDBField {
 	 * Don't include the fields "main name",
 	 * it will be prefixed in {@link requireField()}.
 	 *
-	 * @var array $composite_db
+	 * @config
+	 * @var array
 	 */
-	//static $composite_db;
+	private static $composite_db = array();
 
 	/**
-	 * Set the value of this field in various formats.
-	 * Used by {@link DataObject->getField()}, {@link DataObject->setCastedField()}
-	 * {@link DataObject->dbObject()} and {@link DataObject->write()}.
-	 *
-	 * As this method is used both for initializing the field after construction,
-	 * and actually changing its values, it needs a {@link $markChanged}
-	 * parameter.
-	 *
-	 * @param DBField|array $value
-	 * @param DataObject|array $record An array or object that this field is part of
-	 * @param boolean $markChanged Indicate wether this field should be marked changed.
-	 *  Set to FALSE if you are initializing this field after construction, rather
-	 *  than setting a new value.
+	 * Either the parent dataobject link, or a record of saved values for each field
+	 * 
+	 * @var array|DataObject
 	 */
-	public function setValue($value, $record = null, $markChanged = true);
+	protected $record = array();
 
 	/**
-	 * Used in constructing the database schema.
-	 * Add any custom properties defined in {@link $composite_db}.
-	 * Should make one or more calls to {@link DB::requireField()}.
-	 */
-	//abstract public function requireField();
-
-	/**
-	 * Add the custom internal values to an INSERT or UPDATE
-	 * request passed through the ORM with {@link DataObject->write()}.
-	 * Fields are added in $manipulation['fields']. Please ensure
-	 * these fields are escaped for database insertion, as no
-	 * further processing happens before running the query.
-	 * Use {@link DBField->prepValueForDB()}.
-	 * Ensure to write NULL or empty values as well to allow
-	 * unsetting a previously set field. Use {@link DBField->nullValue()}
-	 * for the appropriate type.
+	 * Write all nested fields into a manipulation
 	 *
 	 * @param array $manipulation
 	 */
-	public function writeToManipulation(&$manipulation);
+	public function writeToManipulation(&$manipulation) {
+		foreach($this->compositeDatabaseFields() as $field => $spec) {
+			// Write sub-manipulation
+			$fieldObject = $this->dbObject($field);
+			$fieldObject->writeToManipulation($manipulation);
+		}
+	}
 
 	/**
 	 * Add all columns which are defined through {@link requireField()}
@@ -155,30 +59,199 @@ interface CompositeDBField {
 	 *
 	 * @param SQLSelect $query
 	 */
-	public function addToQuery(&$query);
+	public function addToQuery(&$query) {
+		parent::addToQuery($query);
+		
+		foreach($this->compositeDatabaseFields() as $field => $spec) {
+			$table = $this->tableName;
+			$key = $this->getName() . $field;
+			if($table) {
+				$query->selectField("\"{$table}\".\"{$key}\"");
+			} else {
+				$query->selectField("\"{$key}\"");
+			}
+		}
+	}
 
 	/**
 	 * Return array in the format of {@link $composite_db}.
 	 * Used by {@link DataObject->hasOwnDatabaseField()}.
+	 * 
 	 * @return array
 	 */
-	public function compositeDatabaseFields();
+	public function compositeDatabaseFields() {
+		return $this->config()->composite_db;
+	}
+
+
+	public function isChanged() {
+		// When unbound, use the local changed flag
+		if(! ($this->record instanceof DataObject) ) {
+			return $this->isChanged;
+		}
+
+		// Defer to parent record
+		foreach($this->compositeDatabaseFields() as $field => $spec) {
+			$key = $this->getName() . $field;
+			if($this->record->isChanged($key)) {
+				return true;
+			}
+		}
+		return false;
+	}
 
 	/**
-	 * Determines if the field has been changed since its initialization.
-	 * Most likely relies on an internal flag thats changed when calling
-	 * {@link setValue()} or any other custom setters on the object.
+	 * Composite field defaults to exists only if all fields have values
 	 *
 	 * @return boolean
 	 */
-	public function isChanged();
+	public function exists() {
+		// By default all fields
+		foreach($this->compositeDatabaseFields() as $field => $spec) {
+			$fieldObject = $this->dbObject($field);
+			if(!$fieldObject->exists()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public function requireField() {
+		foreach($this->compositeDatabaseFields() as $field => $spec){
+			$key = $this->getName() . $field;
+			DB::requireField($this->tableName, $key, $spec);
+		}
+	}
 
 	/**
-	 * Determines if any of the properties in this field have a value,
-	 * meaning at least one of them is not NULL.
+	 * Assign the given value.
+	 * If $record is assigned to a dataobject, this field becomes a loose wrapper over
+	 * the records on that object instead.
 	 *
-	 * @return boolean
+	 * @param type $value
+	 * @param DataObject $record
+	 * @param type $markChanged
+	 * @return type
 	 */
-	public function exists();
+	public function setValue($value, $record = null, $markChanged = true) {
+		$this->isChanged = $markChanged;
+		
+		// When given a dataobject, bind this field to that
+		if($record instanceof DataObject) {
+			$this->bindTo($record);
+			$record = null;
+		}
+
+		foreach($this->compositeDatabaseFields() as $field => $spec) {
+			// Check value
+			if($value instanceof CompositeDBField) {
+				// Check if saving from another composite field
+				$this->setField($field, $value->getField($field));
+
+			} elseif(isset($value[$field])) {
+				// Check if saving from an array
+				$this->setField($field, $value[$field]);
+			}
+
+			// Load from $record
+			$key = $this->getName() . $field;
+			if(isset($record[$key])) {
+				$this->setField($field, $record[$key]);
+			}
+		}
+	}
+
+	/**
+	 * Bind this field to the dataobject, and set the underlying table to that of the owner
+	 *
+	 * @param DataObject $dataObject
+	 */
+	public function bindTo($dataObject) {
+		$this->record = $dataObject;
+		$this->setTable(get_class($dataObject));
+	}
+
+	public function saveInto($dataObject) {
+		foreach($this->compositeDatabaseFields() as $field => $spec) {
+			// Save into record
+			$key = $this->getName() . $field;
+			$dataObject->setField($key, $this->getField($field));
+		}
+	}
+
+	/**
+	 * get value of a single composite field
+	 *
+	 * @param string $field
+	 * @return mixed
+	 */
+	public function getField($field) {
+		// Skip invalid fields
+		$fields = $this->compositeDatabaseFields();
+		if(!isset($fields[$field])) {
+			return null;
+		}
+
+		// Check bound object
+		if($this->record instanceof DataObject) {
+			$key = $this->getName().$field;
+			return $this->record->getField($key);
+		}
+
+		// Check local record
+		if(isset($this->record[$field])) {
+			return $this->record[$field];
+		}
+		return null;
+	}
+
+	/**
+	 * Set value of a single composite field
+	 *
+	 * @param string $field
+	 * @param mixed $value
+	 * @param bool $markChanged
+	 */
+	public function setField($field, $value, $markChanged = true) {
+		// Skip invalid fields
+		$fields = $this->compositeDatabaseFields();
+		if(!isset($fields[$field])) {
+			return;
+		}
+
+		// Set changed
+		if($markChanged) {
+			$this->isChanged = true;
+		}
+
+		// Set bound object
+		if($this->record instanceof DataObject) {
+			$key = $this->getName() . $field;
+			return $this->record->setField($key, $value);
+		}
+
+		// Set local record
+		$this->record[$field] = $value;
+	}
+
+	/**
+	 * Get a db object for the named field
+	 *
+	 * @param string $field Field name
+	 * @return DBField|null
+	 */
+	public function dbObject($field) {
+		$fields = $this->compositeDatabaseFields();
+		if(!isset($fields[$field])) {
+			return null;
+		}
+
+		// Build nested field
+		$key = $this->getName() . $field;
+		$spec = $fields[$field];
+		$fieldObject = Object::create_from_string($spec, $key);
+		$fieldObject->setValue($this->getField($field), null, false);
+		return $fieldObject;
+	}
 
 }

--- a/model/fieldtypes/Currency.php
+++ b/model/fieldtypes/Currency.php
@@ -46,7 +46,7 @@ class Currency extends Decimal {
 		else return $val;
 	}
 
-	public function setValue($value, $record = null) {
+	public function setValue($value, $record = null, $markChanged = true) {
 		$matches = null;
 		if(is_numeric($value)) {
 			$this->value = $value;

--- a/model/fieldtypes/DBField.php
+++ b/model/fieldtypes/DBField.php
@@ -131,15 +131,27 @@ abstract class DBField extends ViewableData {
 	}
 
 	/**
-	 * Set the value on the field.
+	 * Set the value of this field in various formats.
+	 * Used by {@link DataObject->getField()}, {@link DataObject->setCastedField()}
+	 * {@link DataObject->dbObject()} and {@link DataObject->write()}.
 	 *
-	 * Optionally takes the whole record as an argument, to pick other values.
+	 * As this method is used both for initializing the field after construction,
+	 * and actually changing its values, it needs a {@link $markChanged}
+	 * parameter.
 	 *
 	 * @param mixed $value
-	 * @param array $record
+	 * @param DataObject|array $record An array or object that this field is part of
+	 * @param boolean $markChanged Indicate wether this field should be marked changed.
+	 *  Set to FALSE if you are initializing this field after construction, rather
+	 *  than setting a new value.
 	 */
-	public function setValue($value, $record = null) {
+	public function setValue($value, $record = null, $markChanged = true) {
 		$this->value = $value;
+
+		// Remember table
+		if($record instanceof DataObject) {
+			$this->setTable(get_class($record));
+		}
 	}
 
 

--- a/model/fieldtypes/Date.php
+++ b/model/fieldtypes/Date.php
@@ -20,7 +20,7 @@
  */
 class Date extends DBField {
 
-	public function setValue($value, $record = null) {
+	public function setValue($value, $record = null, $markChanged = true) {
 		if($value === false || $value === null || (is_string($value) && !strlen($value))) {
 			// don't try to evaluate empty values with strtotime() below, as it returns "1970-01-01" when it should be
 			// saved as NULL in database

--- a/model/fieldtypes/Datetime.php
+++ b/model/fieldtypes/Datetime.php
@@ -25,7 +25,7 @@
  */
 class SS_Datetime extends Date implements TemplateGlobalProvider {
 
-	public function setValue($value, $record = null) {
+	public function setValue($value, $record = null, $markChanged = true) {
 		if($value === false || $value === null || (is_string($value) && !strlen($value))) {
 			// don't try to evaluate empty values with strtotime() below, as it returns "1970-01-01" when it should be
 			// saved as NULL in database

--- a/model/fieldtypes/PolymorphicForeignKey.php
+++ b/model/fieldtypes/PolymorphicForeignKey.php
@@ -6,34 +6,12 @@
  * @package framework
  * @subpackage model
  */
-class PolymorphicForeignKey extends ForeignKey implements CompositeDBField {
+class PolymorphicForeignKey extends CompositeDBField {
 
-	/**
-	 * @var boolean $isChanged
-	 */
-	protected $isChanged = false;
-
-	/**
-	 * Value of relation class
-	 *
-	 * @var string
-	 */
-	protected $classValue = null;
-
-	/**
-	 * Field definition cache for compositeDatabaseFields
-	 *
-	 * @var string
-	 */
-	protected static $classname_spec_cache = array();
-
-	/**
-	 * Clear all cached classname specs. It's necessary to clear all cached subclassed names
-	 * for any classes if a new class manifest is generated.
-	 */
-	public static function clear_classname_spec_cache() {
-		self::$classname_spec_cache = array();
-	}
+	private static $composite_db = array(
+		'ID' => 'Int',
+		'Class' => 'Varchar'
+	);
 
 	public function scaffoldFormField($title = null, $params = null) {
 		// Opt-out of form field generation - Scaffolding should be performed on
@@ -42,55 +20,23 @@ class PolymorphicForeignKey extends ForeignKey implements CompositeDBField {
 		return null;
 	}
 
-	public function requireField() {
-		$fields = $this->compositeDatabaseFields();
-		if($fields) foreach($fields as $name => $type){
-			DB::requireField($this->tableName, $this->name.$name, $type);
-		}
-	}
-
-	public function writeToManipulation(&$manipulation) {
-
-		// Write ID, checking that the value is valid
-		$manipulation['fields'][$this->name . 'ID'] = $this->exists()
-			? $this->prepValueForDB($this->getIDValue())
-			: $this->nullValue();
-
-		// Write class
-		$classObject = DBField::create_field('Enum', $this->getClassValue(), $this->name . 'Class');
-		$classObject->writeToManipulation($manipulation);
-	}
-
-	public function addToQuery(&$query) {
-		parent::addToQuery($query);
-		$query->selectField(
-			"\"{$this->tableName}\".\"{$this->name}ID\"",
-			"{$this->name}ID"
-		);
-		$query->selectField(
-			"\"{$this->tableName}\".\"{$this->name}Class\"",
-			"{$this->name}Class"
-		);
-	}
-
 	/**
 	 * Get the value of the "Class" this key points to
 	 *
 	 * @return string Name of a subclass of DataObject
 	 */
 	public function getClassValue() {
-		return $this->classValue;
+		return $this->getField('Class');
 	}
 
 	/**
 	 * Set the value of the "Class" this key points to
 	 *
-	 * @param string $class Name of a subclass of DataObject
+	 * @param string $value Name of a subclass of DataObject
 	 * @param boolean $markChanged Mark this field as changed?
 	 */
-	public function setClassValue($class, $markChanged = true) {
-		$this->classValue = $class;
-		if($markChanged) $this->isChanged = true;
+	public function setClassValue($value, $markChanged = true) {
+		$this->setField('Class', $value, $markChanged);
 	}
 
 	/**
@@ -99,95 +45,36 @@ class PolymorphicForeignKey extends ForeignKey implements CompositeDBField {
 	 * @return integer
 	 */
 	public function getIDValue() {
-		return parent::getValue();
+		return $this->getField('ID');
 	}
 
 	/**
 	 * Sets the value of the "ID" this key points to
 	 *
-	 * @param integer $id
+	 * @param integer $value
 	 * @param boolean $markChanged Mark this field as changed?
 	 */
-	public function setIDValue($id, $markChanged = true) {
-		parent::setValue($id);
-		if($markChanged) $this->isChanged = true;
+	public function setIDValue($value, $markChanged = true) {
+		$this->setField('ID', $value, $markChanged);
 	}
 
 	public function setValue($value, $record = null, $markChanged = true) {
-		$idField = "{$this->name}ID";
-		$classField = "{$this->name}Class";
-
-		// Check if an object is assigned directly
+		// Map dataobject value to array
 		if($value instanceof DataObject) {
-			$record = array(
-				$idField => $value->ID,
-				$classField => $value->class
+			$value = array(
+				'ID' => $value->ID,
+				'Class' => $value->class
 			);
 		}
-
-		// Convert an object to an array
-		if($record instanceof DataObject) {
-			$record = $record->getQueriedDatabaseFields();
-		}
-
-		// Use $value array if record is missing
-		if(empty($record) && is_array($value)) {
-			$record = $value;
-		}
-
-		// Inspect presented values
-		if(isset($record[$idField]) && isset($record[$classField])) {
-			if(empty($record[$idField]) || empty($record[$classField])) {
-				$this->setIDValue($this->nullValue(), $markChanged);
-				$this->setClassValue('', $markChanged);
-			} else {
-				$this->setClassValue($record[$classField], $markChanged);
-				$this->setIDValue($record[$idField], $markChanged);
-			}
-		}
+		
+		parent::setValue($value, $record, $markChanged);
 	}
 
 	public function getValue() {
-		if($this->exists()) {
-			return DataObject::get_by_id($this->getClassValue(), $this->getIDValue());
+		$id = $this->getIDValue();
+		$class = $this->getClassValue();
+		if($id && $class && is_subclass_of($class, 'DataObject')) {
+			return DataObject::get_by_id($class, $id);
 		}
-	}
-
-	public function compositeDatabaseFields() {
-
-		// Ensure the table level cache exists
-		if(empty(self::$classname_spec_cache[$this->tableName])) {
-			self::$classname_spec_cache[$this->tableName] = array();
-		}
-
-		// Ensure the field level cache exists
-		if(empty(self::$classname_spec_cache[$this->tableName][$this->name])) {
-
-			// Get all class names
-			$classNames = ClassInfo::subclassesFor('DataObject');
-			unset($classNames['DataObject']);
-
-			$schema = DB::get_schema();
-			if($schema->hasField($this->tableName, "{$this->name}Class")) {
-				$existing = DB::query("SELECT DISTINCT \"{$this->name}Class\" FROM \"{$this->tableName}\"")->column();
-				$classNames = array_unique(array_merge($classNames, $existing));
-			}
-
-			self::$classname_spec_cache[$this->tableName][$this->name]
-				= "Enum(array('" . implode("', '", array_filter($classNames)) . "'))";
-		}
-
-		return array(
-			'ID' => 'Int',
-			'Class' => self::$classname_spec_cache[$this->tableName][$this->name]
-		);
-	}
-
-	public function isChanged() {
-		return $this->isChanged;
-	}
-
-	public function exists() {
-		return $this->getClassValue() && $this->getIDValue();
 	}
 }

--- a/model/fieldtypes/PrimaryKey.php
+++ b/model/fieldtypes/PrimaryKey.php
@@ -19,7 +19,7 @@ class PrimaryKey extends Int {
 	 * @param string $name
 	 * @param DataOject $object The object that this is primary key for (should have a relation with $name)
 	 */
-	public function __construct($name = null, $object) {
+	public function __construct($name, $object = null) {
 		$this->object = $object;
 		parent::__construct($name);
 	}
@@ -31,5 +31,12 @@ class PrimaryKey extends Int {
 		$field->setEmptyString(' ');
 		return $field;
 	}
-}
 
+	public function setValue($value, $record = null, $markChanged = true) {
+		parent::setValue($value, $record, $markChanged);
+
+		if($record instanceof DataObject) {
+			$this->object = $record;
+		}
+	}
+}

--- a/model/fieldtypes/Time.php
+++ b/model/fieldtypes/Time.php
@@ -16,7 +16,7 @@
  */
 class Time extends DBField {
 
-	public function setValue($value, $record = null) {
+	public function setValue($value, $record = null, $markChanged = true) {
 		if($value) {
 			if(preg_match( '/(\d{1,2})[:.](\d{2})([a|A|p|P|][m|M])/', $value, $match )) $this->TwelveHour( $match );
 			else $this->value = date('H:i:s', strtotime($value));

--- a/tests/model/CompositeDBFieldTest.php
+++ b/tests/model/CompositeDBFieldTest.php
@@ -35,6 +35,29 @@ class CompositeDBFieldTest extends SapphireTest {
 				$this->assertEquals(array('MyMoney' => 'Money', 'OtherMoney' => 'Money'),
 			DataObject::composite_fields('SubclassedDBFieldObject'));
 	}
+
+	/**
+	 * Tests that changes to the fields affect the underlying dataobject, and vice versa
+	 */
+	public function testFieldBinding() {
+		$object = new CompositeDBFieldTest_DataObject();
+		$object->MyMoney->Currency = 'NZD';
+		$object->MyMoney->Amount = 100.0;
+		$this->assertEquals('NZD', $object->MyMoneyCurrency);
+		$this->assertEquals(100.0, $object->MyMoneyAmount);
+		$object->write();
+
+		$object2 = CompositeDBFieldTest_DataObject::get()->byID($object->ID);
+		$this->assertEquals('NZD', $object2->MyMoney->Currency);
+		$this->assertEquals(100.0, $object2->MyMoney->Amount);
+
+		$object2->MyMoneyCurrency = 'USD';
+		$this->assertEquals('USD', $object2->MyMoney->Currency);
+
+		$object2->MyMoney->setValue(array('Currency' => 'EUR', 'Amount' => 200.0));
+		$this->assertEquals('EUR', $object2->MyMoneyCurrency);
+		$this->assertEquals(200.0, $object2->MyMoneyAmount);
+	}
 }
 
 class CompositeDBFieldTest_DataObject extends DataObject implements TestOnly {

--- a/tests/model/ManyManyListTest.php
+++ b/tests/model/ManyManyListTest.php
@@ -10,8 +10,23 @@ class ManyManyListTest extends SapphireTest {
 
 	protected $extraDataObjects = array(
 		'DataObjectTest_Team',
+		'DataObjectTest_Fixture',
 		'DataObjectTest_SubTeam',
+		'OtherSubclassWithSameField',
+		'DataObjectTest_FieldlessTable',
+		'DataObjectTest_FieldlessSubTable',
+		'DataObjectTest_ValidatedObject',
 		'DataObjectTest_Player',
+		'DataObjectTest_TeamComment',
+		'DataObjectTest_EquipmentCompany',
+		'DataObjectTest_SubEquipmentCompany',
+		'DataObjectTest\NamespacedClass',
+		'DataObjectTest\RelationClass',
+		'DataObjectTest_ExtendedTeamComment',
+		'DataObjectTest_Company',
+		'DataObjectTest_Staff',
+		'DataObjectTest_CEO',
+		'DataObjectTest_Fan',
 		'ManyManyListTest_ExtraFields'
 	);
 

--- a/tests/model/MoneyTest.php
+++ b/tests/model/MoneyTest.php
@@ -145,11 +145,11 @@ class MoneyTest extends SapphireTest {
 		));
 		$m->setLocale('ar_EG');
 
-		$this->assertSame('Estnische Krone', $m->getName('EEK','de_AT'));
-		$this->assertSame('يورو', $m->getName());
+		$this->assertSame('Estnische Krone', $m->getCurrencyName('EEK','de_AT'));
+		$this->assertSame('يورو', $m->getCurrencyName());
 
 		try {
-			$m->getName('EGP', 'xy_XY');
+			$m->getCurrencyName('EGP', 'xy_XY');
 			$this->setExpectedException("Exception");
 		} catch(Exception $e) {
 		}

--- a/tests/model/MoneyTest.yml
+++ b/tests/model/MoneyTest.yml
@@ -1,8 +1,8 @@
 MoneyTest_DataObject:
-   test1:
-      MyMoneyCurrency: EUR
-      MyMoneyAmount: 1.23
+ test1:
+  MyMoneyCurrency: EUR
+  MyMoneyAmount: 1.23
 MoneyTest_SubClass:
-   test2:
-      MyOtherMoneyCurrency: GBP
-      MyOtherMoneyAmount: 2.46
+ test2:
+  MyOtherMoneyCurrency: GBP
+  MyOtherMoneyAmount: 2.46

--- a/view/ViewableData.php
+++ b/view/ViewableData.php
@@ -263,17 +263,15 @@ class ViewableData extends Object implements IteratorAggregate {
 	 * on this object.
 	 *
 	 * @param string $field
-	 * @return string
+	 * @return string Casting helper
 	 */
 	public function castingHelper($field) {
-		if($this->hasMethod('db') && $fieldSpec = $this->db($field)) {
-			return $fieldSpec;
+		$specs = $this->config()->casting;
+		if(isset($specs[$field])) {
+			return $specs[$field];
+		} elseif($this->failover) {
+			return $this->failover->castingHelper($field);
 		}
-
-		$specs = Config::inst()->get(get_class($this), 'casting');
-		if(isset($specs[$field])) return $specs[$field];
-
-		if($this->failover) return $this->failover->castingHelper($field);
 	}
 
 	/**


### PR DESCRIPTION
CompositeDBField is now an interface to nested fields on an underlying dataobject, allowing field manipulation to be performed at the field and dataobject level without having to synchronise them manually.

Cleanup and rationalisation of changes:

* ViewableData::castingHelper is overridden in DataObject rather than it trying to do magic reflection on its subclasses. Better to override than try to build in too much logic into a base class.
* Money::getName Renamed to getCurrencyName, since it conflicted with DBField::getName which had a different purpose.
* markChanged parameter added to DBField::setValue in order to make the API consistent between CompositeDBField and DBField.
* DBField::setValue has been updated in a few instances in order to better interact with any parent dataobject. PrimaryKey will use the $record parameter for generating a default formfield, and DBField objects will record which tables they should use for augmenting dataqueries (so better SQL is generated).
* All existing compositeDBFields were re-written to support this being an abstract base class, instead of an interface.
* CompositeDBField now works closer as an interface on top of an underlying DataObject, with get/setField and dbObject to support casting and modification of its sub-field data. As with DBField, setValue is used to bind it to a parent object with which it uses as a data source. Check CompositeDBFieldTest::testFieldBinding for an example of how this works in practice.
* As a result of some of this API change, special cases in DataObject::dbObject have been consolidated together. $fixed_fields['ID'] has been changed from type 'Int' to 'PrimaryKey' (because that's what it is).
* DataObject::get/setField changed to resolve regressions in assigning values as DBField instances.
* DataObject::getChangedFields had to be changed to fix an infinite loop in CompositeDBField::isChanged.
* DataObject::composite_fields now includes polymorphic foreign key fields.
* PolymorphicForeignKey has been changed from Int/Enum to Int/Varchar due to it performing excessive schema queries. Possibly worth looking into again in the future (if we can force it to only query during dev/build).