### PR TITLE
UPDATE: Add support for user defined charset and collation

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,7 +6,8 @@ Upload:
   replaceFile: false
 MySQLDatabase:
   connection_charset: utf8
-  connection_collation: utf8_general_ci
+  charset: utf8
+  collation: utf8_general_ci
 HTTP:
   cache_control:
     max-age: 0

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -5,6 +5,8 @@ Upload:
   # Replace an existing file rather than renaming the new one.
   replaceFile: false
 MySQLDatabase:
+  # You are advised to backup your tables if changing settings on an existing database
+  # `connection_charset` and `charset` should be equal, similarly so should `connection_collation` and `collation`
   connection_charset: utf8
   connection_collation: utf8_general_ci
   charset: utf8

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,6 +6,7 @@ Upload:
   replaceFile: false
 MySQLDatabase:
   connection_charset: utf8
+  connection_collation: utf8_unicode_ci
 HTTP:
   cache_control:
     max-age: 0

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,6 +6,7 @@ Upload:
   replaceFile: false
 MySQLDatabase:
   connection_charset: utf8
+  connection_collation: utf8_general_ci
   charset: utf8
   collation: utf8_general_ci
 HTTP:

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,7 +6,7 @@ Upload:
   replaceFile: false
 MySQLDatabase:
   connection_charset: utf8
-  connection_collation: utf8_unicode_ci
+  connection_collation: utf8_general_ci
 HTTP:
   cache_control:
     max-age: 0

--- a/model/connect/MySQLDatabase.php
+++ b/model/connect/MySQLDatabase.php
@@ -159,7 +159,7 @@ class MySQLDatabase extends SS_Database {
 			$baseClasses[$class] = '"' . $class . '"';
 		}
 
-		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
+		$charset = Config::inst()->get('MySQLDatabase', 'charset');
 
 		// Make column selection lists
 		$select = array(

--- a/model/connect/MySQLDatabase.php
+++ b/model/connect/MySQLDatabase.php
@@ -31,6 +31,13 @@ class MySQLDatabase extends SS_Database {
 			$parameters['charset'] = $charset;
 		}
 
+		// Set collation
+		if( empty($parameters['collation'])
+			&& ($collation = Config::inst()->get('MySQLDatabase', 'connection_collation'))
+		) {
+			$parameters['collation'] = $collation;
+		}
+
 		// Notify connector of parameters
 		$this->connector->connect($parameters);
 

--- a/model/connect/MySQLDatabase.php
+++ b/model/connect/MySQLDatabase.php
@@ -159,18 +159,20 @@ class MySQLDatabase extends SS_Database {
 			$baseClasses[$class] = '"' . $class . '"';
 		}
 
+		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
+
 		// Make column selection lists
 		$select = array(
 			'SiteTree' => array(
 				"ClassName", "$baseClasses[SiteTree].\"ID\"", "ParentID",
 				"Title", "MenuTitle", "URLSegment", "Content",
 				"LastEdited", "Created",
-				"Filename" => "_utf8''", "Name" => "_utf8''",
+				"Filename" => "_{$charset}''", "Name" => "_{$charset}''",
 				"Relevance" => $relevance['SiteTree'], "CanViewType"
 			),
 			'File' => array(
-				"ClassName", "$baseClasses[File].\"ID\"", "ParentID" => "_utf8''",
-				"Title", "MenuTitle" => "_utf8''", "URLSegment" => "_utf8''", "Content",
+				"ClassName", "$baseClasses[File].\"ID\"", "ParentID" => "_{$charset}''",
+				"Title", "MenuTitle" => "_{$charset}''", "URLSegment" => "_{$charset}''", "Content",
 				"LastEdited", "Created",
 				"Filename", "Name",
 				"Relevance" => $relevance['File'], "CanViewType" => "NULL"

--- a/model/connect/MySQLSchemaManager.php
+++ b/model/connect/MySQLSchemaManager.php
@@ -194,8 +194,8 @@ class MySQLSchemaManager extends DBSchemaManager {
 	}
 
 	public function createDatabase($name) {
-		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
-		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		$charset = Config::inst()->get('MySQLDatabase', 'charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'collation');
 		$this->query("CREATE DATABASE \"$name\" DEFAULT CHARACTER SET {$charset} DEFAULT COLLATE {$collation}");
 	}
 
@@ -435,8 +435,8 @@ class MySQLSchemaManager extends DBSchemaManager {
 		//DB::requireField($this->tableName, $this->name, "enum('" . implode("','", $this->enum) . "') character set
 		// utf8 collate utf8_general_ci default '{$this->default}'");
 		$valuesString = implode(",", Convert::raw2sql($values['enums'], true));
-		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
-		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		$charset = Config::inst()->get('MySQLDatabase', 'charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'collation');
 		return "enum($valuesString) character set {$charset} collate {$collation}" . $this->defaultClause($values);
 	}
 
@@ -453,8 +453,8 @@ class MySQLSchemaManager extends DBSchemaManager {
 		//DB::requireField($this->tableName, $this->name, "enum('" . implode("','", $this->enum) . "') character set
 		//utf8 collate utf8_general_ci default '{$this->default}'");
 		$valuesString = implode(",", Convert::raw2sql($values['enums'], true));
-		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
-		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		$charset = Config::inst()->get('MySQLDatabase', 'charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'collation');
 		return "set($valuesString) character set {$charset} collate {$collation}" . $this->defaultClause($values);
 	}
 
@@ -509,8 +509,8 @@ class MySQLSchemaManager extends DBSchemaManager {
 		//For reference, this is what typically gets passed to this function:
 		//$parts=Array('datatype'=>'mediumtext', 'character set'=>'utf8', 'collate'=>'utf8_general_ci');
 		//DB::requireField($this->tableName, $this->name, "mediumtext character set utf8 collate utf8_general_ci");
-		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
-		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		$charset = Config::inst()->get('MySQLDatabase', 'charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'collation');
 		return 'mediumtext character set ' . $charset . ' collate ' . $collation . $this->defaultClause($values);
 	}
 
@@ -541,8 +541,8 @@ class MySQLSchemaManager extends DBSchemaManager {
 		//DB::requireField($this->tableName, $this->name, "varchar($this->size) character set utf8 collate
 		// utf8_general_ci");
 		$default = $this->defaultClause($values);
-		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
-		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		$charset = Config::inst()->get('MySQLDatabase', 'charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'collation');
 		return "varchar({$values['precision']}) character set {$charset} collate {$collation}{$default}";
 	}
 

--- a/model/connect/MySQLSchemaManager.php
+++ b/model/connect/MySQLSchemaManager.php
@@ -194,7 +194,9 @@ class MySQLSchemaManager extends DBSchemaManager {
 	}
 
 	public function createDatabase($name) {
-		$this->query("CREATE DATABASE \"$name\" DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci");
+		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		$this->query("CREATE DATABASE \"$name\" DEFAULT CHARACTER SET {$charset} DEFAULT COLLATE {$collation}");
 	}
 
 	public function dropDatabase($name) {
@@ -433,7 +435,9 @@ class MySQLSchemaManager extends DBSchemaManager {
 		//DB::requireField($this->tableName, $this->name, "enum('" . implode("','", $this->enum) . "') character set
 		// utf8 collate utf8_general_ci default '{$this->default}'");
 		$valuesString = implode(",", Convert::raw2sql($values['enums'], true));
-		return "enum($valuesString) character set utf8 collate utf8_general_ci" . $this->defaultClause($values);
+		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		return "enum($valuesString) character set {$charset} collate {$collation}" . $this->defaultClause($values);
 	}
 
 	/**
@@ -449,7 +453,9 @@ class MySQLSchemaManager extends DBSchemaManager {
 		//DB::requireField($this->tableName, $this->name, "enum('" . implode("','", $this->enum) . "') character set
 		//utf8 collate utf8_general_ci default '{$this->default}'");
 		$valuesString = implode(",", Convert::raw2sql($values['enums'], true));
-		return "set($valuesString) character set utf8 collate utf8_general_ci" . $this->defaultClause($values);
+		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		return "set($valuesString) character set {$charset} collate {$collation}" . $this->defaultClause($values);
 	}
 
 	/**
@@ -503,7 +509,9 @@ class MySQLSchemaManager extends DBSchemaManager {
 		//For reference, this is what typically gets passed to this function:
 		//$parts=Array('datatype'=>'mediumtext', 'character set'=>'utf8', 'collate'=>'utf8_general_ci');
 		//DB::requireField($this->tableName, $this->name, "mediumtext character set utf8 collate utf8_general_ci");
-		return 'mediumtext character set utf8 collate utf8_general_ci' . $this->defaultClause($values);
+		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		return 'mediumtext character set ' . $charset . ' collate ' . $collation . $this->defaultClause($values);
 	}
 
 	/**
@@ -533,7 +541,9 @@ class MySQLSchemaManager extends DBSchemaManager {
 		//DB::requireField($this->tableName, $this->name, "varchar($this->size) character set utf8 collate
 		// utf8_general_ci");
 		$default = $this->defaultClause($values);
-		return "varchar({$values['precision']}) character set utf8 collate utf8_general_ci$default";
+		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		return "varchar({$values['precision']}) character set {$charset} collate {$collation}{$default}";
 	}
 
 	/*

--- a/model/connect/MySQLiConnector.php
+++ b/model/connect/MySQLiConnector.php
@@ -56,6 +56,10 @@ class MySQLiConnector extends DBConnector {
 		// Normally $selectDB is set to false by the MySQLDatabase controller, as per convention
 		$selectedDB = ($selectDB && !empty($parameters['database'])) ? $parameters['database'] : null;
 
+		// Connection charset and collation
+		$connCharset = Config::inst()->get('MySQLDatabase', 'connection_charset');
+		$connCollation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+
 		if(!empty($parameters['port'])) {
 			$this->dbConn = new MySQLi(
 				$parameters['server'],
@@ -77,11 +81,18 @@ class MySQLiConnector extends DBConnector {
 			$this->databaseError("Couldn't connect to MySQL database | " . $this->dbConn->connect_error);
 		}
 
-		// Set charset if given and not null. Can explicitly set to empty string to omit
+		// Set charset and collation if given and not null. Can explicitly set to empty string to omit
 		$charset = isset($parameters['charset'])
 				? $parameters['charset']
-				: 'utf8';
+				: $connCharset;
+
 		if (!empty($charset)) $this->dbConn->set_charset($charset);
+
+		$collation = isset($parameters['collation'])
+			? $parameters['collation']
+			: $connCollation;
+
+		if (!empty($collation)) $this->dbConn->query("SET collation_connection = {$collation}");
 	}
 
 	public function __destruct() {

--- a/model/connect/PDOConnector.php
+++ b/model/connect/PDOConnector.php
@@ -134,20 +134,24 @@ class PDOConnector extends DBConnector {
 			}
 		}
 
+		// Connection charset and collation
+		$connCharset = Config::inst()->get('MySQLDatabase', 'connection_charset');
+		$connCollation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+
 		// Set charset if given and not null. Can explicitly set to empty string to omit
 		if($parameters['driver'] !== 'sqlsrv') {
 			$charset = isset($parameters['charset'])
 					? $parameters['charset']
-					: 'utf8';
+					: $connCharset;
 			if (!empty($charset)) $dsn[] = "charset=$charset";
 		}
 
 		// Connection commands to be run on every re-connection
 		if(!isset($charset)) {
-			$charset = 'utf8';
+			$charset = $connCharset;
 		}
 		$options = array(
-			PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES ' . $charset
+			PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES ' . $charset . ' COLLATE ' . $connCollation
 		);
 		if(self::is_emulate_prepare()) {
 			$options[PDO::ATTR_EMULATE_PREPARES] = true;

--- a/model/connect/PDOConnector.php
+++ b/model/connect/PDOConnector.php
@@ -143,8 +143,11 @@ class PDOConnector extends DBConnector {
 		}
 
 		// Connection commands to be run on every re-connection
+		if(!isset($charset)) {
+			$charset = 'utf8';
+		}
 		$options = array(
-			PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8'
+			PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES ' . $charset
 		);
 		if(self::is_emulate_prepare()) {
 			$options[PDO::ATTR_EMULATE_PREPARES] = true;

--- a/model/fieldtypes/Enum.php
+++ b/model/fieldtypes/Enum.php
@@ -65,8 +65,8 @@ class Enum extends StringField {
 	 * @return void
 	 */
 	public function requireField() {
-		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
-		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		$charset = Config::inst()->get('MySQLDatabase', 'charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'collation');
 
 		$parts = array(
 			'datatype' => 'enum',

--- a/model/fieldtypes/Enum.php
+++ b/model/fieldtypes/Enum.php
@@ -65,11 +65,14 @@ class Enum extends StringField {
 	 * @return void
 	 */
 	public function requireField() {
+		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+
 		$parts = array(
 			'datatype' => 'enum',
 			'enums' => $this->enum,
-			'character set' => 'utf8',
-			'collate' => 'utf8_general_ci',
+			'character set' => $charset,
+			'collate' => $collation,
 			'default' => $this->default,
 			'table' => $this->tableName,
 			'arrayValue' => $this->arrayValue

--- a/model/fieldtypes/MultiEnum.php
+++ b/model/fieldtypes/MultiEnum.php
@@ -31,8 +31,8 @@ class MultiEnum extends Enum {
 	}
 
 	public function requireField(){
-		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
-		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		$charset = Config::inst()->get('MySQLDatabase', 'charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'collation');
 		$values=array(
 			'type'=>'set',
 			'parts'=>array(

--- a/model/fieldtypes/MultiEnum.php
+++ b/model/fieldtypes/MultiEnum.php
@@ -31,13 +31,14 @@ class MultiEnum extends Enum {
 	}
 
 	public function requireField(){
-
+		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
 		$values=array(
 			'type'=>'set',
 			'parts'=>array(
 				'enums'=>$this->enum,
-				'character set'=>'utf8',
-				'collate'=> 'utf8_general_ci',
+				'character set'=> $charset,
+				'collate'=> $collation,
 				'default'=> $this->default,
 				'table'=>$this->tableName,
 				'arrayValue'=>$this->arrayValue

--- a/model/fieldtypes/Text.php
+++ b/model/fieldtypes/Text.php
@@ -37,10 +37,13 @@ class Text extends StringField {
  	 * @see DBField::requireField()
  	 */
 	public function requireField() {
+		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+
 		$parts = array(
 			'datatype' => 'mediumtext',
-			'character set' => 'utf8',
-			'collate' => 'utf8_general_ci',
+			'character set' => $charset,
+			'collate' => $collation,
 			'arrayValue' => $this->arrayValue
 		);
 

--- a/model/fieldtypes/Text.php
+++ b/model/fieldtypes/Text.php
@@ -37,8 +37,8 @@ class Text extends StringField {
  	 * @see DBField::requireField()
  	 */
 	public function requireField() {
-		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
-		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		$charset = Config::inst()->get('MySQLDatabase', 'charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'collation');
 
 		$parts = array(
 			'datatype' => 'mediumtext',

--- a/model/fieldtypes/Varchar.php
+++ b/model/fieldtypes/Varchar.php
@@ -50,11 +50,14 @@ class Varchar extends StringField {
  	 * @see DBField::requireField()
  	 */
 	public function requireField() {
+		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+
 		$parts = array(
 			'datatype'=>'varchar',
 			'precision'=>$this->size,
-			'character set'=>'utf8',
-			'collate'=>'utf8_general_ci',
+			'character set'=> $charset,
+			'collate'=> $collation,
 			'arrayValue'=>$this->arrayValue
 		);
 

--- a/model/fieldtypes/Varchar.php
+++ b/model/fieldtypes/Varchar.php
@@ -50,8 +50,8 @@ class Varchar extends StringField {
  	 * @see DBField::requireField()
  	 */
 	public function requireField() {
-		$charset = Config::inst()->get('MySQLDatabase', 'connection_charset');
-		$collation = Config::inst()->get('MySQLDatabase', 'connection_collation');
+		$charset = Config::inst()->get('MySQLDatabase', 'charset');
+		$collation = Config::inst()->get('MySQLDatabase', 'collation');
 
 		$parts = array(
 			'datatype'=>'varchar',


### PR DESCRIPTION
Support for user defined charset and collation. In my case I need to support emoji's as I'm writing the backend of a mobile app with SilverStripe. Therefore I need my columns set to `charset utf8mb4` and `collate utf8mb4_unicode_ci`. 

I've set the default collation `MySQLDatabase connection_collation` to utf8_unicode_ci. 

I didn't understand why there was a config option `connection_charset` if it had no effect on the database columns. Took a look and found that utf8 is defined statically everywhere. 

Fixes https://github.com/silverstripe/silverstripe-framework/issues/1913