### PR TITLE
FIX: UploadField error when attempting to attach non-existent file IDs

### DIFF
--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -316,6 +316,8 @@
 						indicator.remove();
 					},
 					success: function(data, status, xhr) {
+						if (!data || $.isEmptyObject(data)) return;
+
 						self.fileupload('attach', {
 							files: data,
 							options: self.fileupload('option'),


### PR DESCRIPTION
See https://github.com/kinglozzer/htmleditoruploadfield/issues/2. As that behaviour was merged into 3, this will need merging up: editing a broken file link will result in JS errors as `UploadField` attempts to attach files that don’t exist.

`UploadField::attach()` just returns an empty array if the files don’t exist, so we check for that. I did consider making `UploadField::attach()` 404 error if no files were found, but that’s an unnecessary behavioural change and it results in a “404 not found” popup in the CMS that we don’t want.