### PR TITLE
FIX: Editing existing file links in HtmlEditorField was broken

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -823,9 +823,11 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 						} else if(el.is(':radio')) {
 							el.val([selected]).change();
 						} else if(fieldName == 'file') {
-							// Can't rely on fieldName, ad UploadFields have different naming convention
-							el = $('#' + fieldName);
-
+							// UploadField inputs have a slightly different naming convention
+							el = this.find(':input[name="' + fieldName + '[Uploads][]"]');
+							// We need the UploadField "field", not just the input
+							el = el.parents('.ss-uploadfield');
+							
 							// We have to wait for the UploadField to initialise
 							(function attach(el, selected) {
 								if( ! el.getConfig()) {


### PR DESCRIPTION
The old `el = $('#' + fieldName);` doesn’t work as the field IDs have changed. This uses the [input name](https://github.com/silverstripe/silverstripe-framework/blob/06d7bb77c08a54032f1d49f4c99d50f271ff9609/templates/UploadField.ss#L53) instead, which is `file[Uploads][]`, to get to the field.