### PR TITLE
BUG Fix issue with GridFieldSortableHeader incorrectly walking database schema

### DIFF
--- a/tests/forms/gridfield/GridFieldSortableHeaderTest.php
+++ b/tests/forms/gridfield/GridFieldSortableHeaderTest.php
@@ -10,8 +10,10 @@ class GridFieldSortableHeaderTest extends SapphireTest {
 
 	protected $extraDataObjects = array(
 		'GridFieldSortableHeaderTest_Team',
+		'GridFieldSortableHeaderTest_TeamGroup',
 		'GridFieldSortableHeaderTest_Cheerleader',
-		'GridFieldSortableHeaderTest_CheerleaderHat'
+		'GridFieldSortableHeaderTest_CheerleaderHat',
+		'GridFieldSortableHeaderTest_Mom'
 	);
 	
 	/**
@@ -103,6 +105,92 @@ class GridFieldSortableHeaderTest extends SapphireTest {
 		);
 	}
 
+	/**
+	 * Test getManipulatedData on subclassed dataobjects
+	 */
+	public function testInheritedGetManiplatedData() {
+		$list = GridFieldSortableHeaderTest_TeamGroup::get();
+		$config = new GridFieldConfig_RecordEditor();
+		$gridField = new GridField('testfield', 'testfield', $list, $config);
+		$state = $gridField->State->GridFieldSortableHeader;
+		$compontent = $gridField->getConfig()->getComponentByType('GridFieldSortableHeader');
+
+		// Test that inherited dataobjects will work correctly
+		$state->SortColumn = 'Cheerleader.Hat.Colour';
+		$state->SortDirection = 'asc';
+		$relationListA = $compontent->getManipulatedData($gridField, $list);
+		$relationListAsql = Convert::nl2os($relationListA->sql(), ' ');
+
+		// Assert that all tables are joined properly
+		$this->assertContains('FROM "GridFieldSortableHeaderTest_Team"', $relationListAsql);
+		$this->assertContains(
+			'LEFT JOIN "GridFieldSortableHeaderTest_TeamGroup" '
+			. 'ON "GridFieldSortableHeaderTest_TeamGroup"."ID" = "GridFieldSortableHeaderTest_Team"."ID"',
+			$relationListAsql
+		);
+		$this->assertContains(
+			'LEFT JOIN "GridFieldSortableHeaderTest_Cheerleader" AS "Cheerleader" '
+			. 'ON "Cheerleader"."ID" = "GridFieldSortableHeaderTest_Team"."CheerleaderID"',
+			$relationListAsql
+		);
+		$this->assertContains(
+			'LEFT JOIN "GridFieldSortableHeaderTest_CheerleaderHat" AS "Hat" '
+			. 'ON "Hat"."ID" = "Cheerleader"."HatID"', $relationListAsql);
+
+		// Test sorting is correct
+		$this->assertEquals(
+			array('Cologne', 'Auckland', 'Wellington', 'Melbourne'),
+			$relationListA->column('City')
+		);
+		$state->SortDirection = 'desc';
+		$relationListAdesc = $compontent->getManipulatedData($gridField, $list);
+		$this->assertEquals(
+			array('Melbourne', 'Wellington', 'Auckland', 'Cologne'),
+			$relationListAdesc->column('City')
+		);
+		
+		// Test subclasses of tables
+		$state->SortColumn = 'CheerleadersMom.Hat.Colour';
+		$state->SortDirection = 'asc';
+		$relationListB = $compontent->getManipulatedData($gridField, $list);
+		$relationListBsql = $relationListB->sql();
+
+		// Assert that subclasses are included in the query
+		$this->assertContains('FROM "GridFieldSortableHeaderTest_Team"', $relationListBsql);
+		$this->assertContains(
+			'LEFT JOIN "GridFieldSortableHeaderTest_TeamGroup" '
+			. 'ON "GridFieldSortableHeaderTest_TeamGroup"."ID" = "GridFieldSortableHeaderTest_Team"."ID"',
+			$relationListBsql
+		);
+		$this->assertContains(
+			'LEFT JOIN "GridFieldSortableHeaderTest_Mom" AS "CheerleadersMom" '
+			. 'ON "CheerleadersMom"."ID" = "GridFieldSortableHeaderTest_Team"."CheerleadersMomID"',
+			$relationListBsql
+		);
+		// Note that cheerleader is no longer aliased, as it is an implicit join
+		$this->assertContains(
+			'LEFT JOIN "GridFieldSortableHeaderTest_Cheerleader" '
+			. 'ON "GridFieldSortableHeaderTest_Cheerleader"."ID" = "CheerleadersMom"."ID"',
+			$relationListBsql
+		);
+		$this->assertContains(
+			'LEFT JOIN "GridFieldSortableHeaderTest_CheerleaderHat" AS "Hat" '
+			. 'ON "Hat"."ID" = "GridFieldSortableHeaderTest_Cheerleader"."HatID"', $relationListBsql);
+
+
+		// Test sorting is correct
+		$this->assertEquals(
+			array('Cologne', 'Auckland', 'Wellington', 'Melbourne'),
+			$relationListB->column('City')
+		);
+		$state->SortDirection = 'desc';
+		$relationListBdesc = $compontent->getManipulatedData($gridField, $list);
+		$this->assertEquals(
+			array('Melbourne', 'Wellington', 'Auckland', 'Cologne'),
+			$relationListBdesc->column('City')
+		);
+	}
+
 }
 
 class GridFieldSortableHeaderTest_Team extends DataObject implements TestOnly {
@@ -119,9 +207,16 @@ class GridFieldSortableHeaderTest_Team extends DataObject implements TestOnly {
 	);
 
 	private static $has_one = array(
-		'Cheerleader' => 'GridFieldSortableHeaderTest_Cheerleader'
+		'Cheerleader' => 'GridFieldSortableHeaderTest_Cheerleader',
+		'CheerleadersMom' => 'GridFieldSortableHeaderTest_Mom'
 	);
 
+}
+
+class GridFieldSortableHeaderTest_TeamGroup extends GridFieldSortableHeaderTest_Team implements TestOnly {
+	private static $db = array(
+		'GroupName' => 'Varchar'
+	);
 }
 
 class GridFieldSortableHeaderTest_Cheerleader extends DataObject implements TestOnly {
@@ -135,6 +230,15 @@ class GridFieldSortableHeaderTest_Cheerleader extends DataObject implements Test
 		'Hat' => 'GridFieldSortableHeaderTest_CheerleaderHat'
 	);
 
+}
+
+/**
+ * Should have access to same properties as cheerleader
+ */
+class GridFieldSortableHeaderTest_Mom extends GridFieldSortableHeaderTest_Cheerleader implements TestOnly {
+	private static $db = array(
+		'NumberOfCookiesBaked' => 'Int'
+	);
 }
 
 class GridFieldSortableHeaderTest_CheerleaderHat extends DataObject implements TestOnly {

--- a/tests/forms/gridfield/GridFieldSortableHeaderTest.yml
+++ b/tests/forms/gridfield/GridFieldSortableHeaderTest.yml
@@ -1,39 +1,76 @@
 GridFieldSortableHeaderTest_CheerleaderHat:
-	hat1:
-		Colour: Blue
-	hat2:
-		Colour: Red
-	hat3:
-		Colour: Green
-	hat4:
-		Colour: Pink
+  hat1:
+    Colour: Blue
+  hat2:
+    Colour: Red
+  hat3:
+    Colour: Green
+  hat4:
+    Colour: Pink
 GridFieldSortableHeaderTest_Cheerleader:
-	cheerleader1:
-		Name: Heather
-		Hat: =>GridFieldSortableHeaderTest_CheerleaderHat.hat2
-	cheerleader2:
-		Name: Bob
-		Hat: =>GridFieldSortableHeaderTest_CheerleaderHat.hat4
-	cheerleader3:
-		Name: Jenny
-		Hat: =>GridFieldSortableHeaderTest_CheerleaderHat.hat1
-	cheerleader4:
-		Name: Sam
-		Hat: =>GridFieldSortableHeaderTest_CheerleaderHat.hat3
+  cheerleader1:
+    Name: Heather
+    Hat: =>GridFieldSortableHeaderTest_CheerleaderHat.hat2
+  cheerleader2:
+    Name: Bob
+    Hat: =>GridFieldSortableHeaderTest_CheerleaderHat.hat4
+  cheerleader3:
+    Name: Jenny
+    Hat: =>GridFieldSortableHeaderTest_CheerleaderHat.hat1
+  cheerleader4:
+    Name: Sam
+    Hat: =>GridFieldSortableHeaderTest_CheerleaderHat.hat3
+
+GridFieldSortableHeaderTest_Mom:
+  mom1:
+    Name: Ethel
+    Hat: =>GridFieldSortableHeaderTest_CheerleaderHat.hat2
+  mom2:
+    Name: Eileene
+    Hat: =>GridFieldSortableHeaderTest_CheerleaderHat.hat4
+  mom3:
+    Name: Gertrude
+    Hat: =>GridFieldSortableHeaderTest_CheerleaderHat.hat1
+  mom4:
+    Name: Andrew
+    Hat: =>GridFieldSortableHeaderTest_CheerleaderHat.hat3
+    
 GridFieldSortableHeaderTest_Team:
-	team1:
-		Name: Team 1
-		City: Cologne
-		Cheerleader: =>GridFieldSortableHeaderTest_Cheerleader.cheerleader3
-	team2:
-		Name: Team 2
-		City: Wellington
-		Cheerleader: =>GridFieldSortableHeaderTest_Cheerleader.cheerleader2
-	team3:
-		Name: Team 3
-		City: Auckland
-		Cheerleader: =>GridFieldSortableHeaderTest_Cheerleader.cheerleader4
-	team4:
-		Name: Team 4
-		City: Melbourne
-		Cheerleader: =>GridFieldSortableHeaderTest_Cheerleader.cheerleader1
+  team1:
+    Name: Team 1
+    City: Cologne
+    Cheerleader: =>GridFieldSortableHeaderTest_Cheerleader.cheerleader3
+  team2:
+    Name: Team 2
+    City: Wellington
+    Cheerleader: =>GridFieldSortableHeaderTest_Cheerleader.cheerleader2
+  team3:
+    Name: Team 3
+    City: Auckland
+    Cheerleader: =>GridFieldSortableHeaderTest_Cheerleader.cheerleader4
+  team4:
+    Name: Team 4
+    City: Melbourne
+    Cheerleader: =>GridFieldSortableHeaderTest_Cheerleader.cheerleader1
+
+GridFieldSortableHeaderTest_TeamGroup:
+  group1:
+    Name: Group 1
+    City: Cologne
+    Cheerleader: =>GridFieldSortableHeaderTest_Cheerleader.cheerleader3
+    CheerleadersMom: =>GridFieldSortableHeaderTest_Mom.mom3
+  group2:
+    Name: Group 2
+    City: Wellington
+    Cheerleader: =>GridFieldSortableHeaderTest_Cheerleader.cheerleader2
+    CheerleadersMom: =>GridFieldSortableHeaderTest_Mom.mom2
+  group3:
+    Name: Group 3
+    City: Auckland
+    Cheerleader: =>GridFieldSortableHeaderTest_Cheerleader.cheerleader4
+    CheerleadersMom: =>GridFieldSortableHeaderTest_Mom.mom4
+  group4:
+    Name: Group 4
+    City: Melbourne
+    Cheerleader: =>GridFieldSortableHeaderTest_Cheerleader.cheerleader1
+    CheerleadersMom: =>GridFieldSortableHeaderTest_Mom.mom1


### PR DESCRIPTION
This seems to be an issue exposed by, but not caused by, the recent ClassInfo improvements.

The incorrect behaviour is `ClassInfo::table_for_object_field(` being passed in aliases rather than actual classnames, meaning that the fallback would occur more often than it should, and would not correctly include the table.

The fix to this issue is to distinguish between tables joined via aliases (as per the SortColumn parameter) and those tables joined implicitly (through db schema reflection).

Variables named `$tmpItem` did not help solve this issue..........