### PR TITLE
BUG Fix ClassInfo::table_for_object_field

### DIFF
--- a/core/ClassInfo.php
+++ b/core/ClassInfo.php
@@ -291,7 +291,11 @@ class ClassInfo {
 	 * @return string
 	 */
 	public static function table_for_object_field($candidateClass, $fieldName) {
-		if(!$candidateClass || !$fieldName || !is_subclass_of($candidateClass, 'DataObject')) {
+		if(!$candidateClass
+			|| !$fieldName
+			|| !class_exists($candidateClass)
+			|| !is_subclass_of($candidateClass, 'DataObject')
+		) {
 			return null;
 		}
 


### PR DESCRIPTION
Substitute fix for https://github.com/silverstripe/silverstripe-framework/pull/4608

Apparently on < 5.3.7 this silent issue is a non-silent one, so class_exists must be called before checking is_subclass_of.

The actual issue in gridfieldsortableheader still exists, but we've decided to focus efforts on fixing this in the 3.x branch.