### PR TITLE
Members with no ID have no permissions

### DIFF
--- a/security/Permission.php
+++ b/security/Permission.php
@@ -160,7 +160,11 @@ class Permission extends DataObject implements TemplateGlobalProvider {
 		if(!$member) {
 			$memberID = $member = Member::currentUserID();
 		} else {
-			$memberID = (is_object($member)) ? $member->ID : $member; 
+			$memberID = (is_object($member)) ? $member->ID : $member;
+		}
+
+		if (!$memberID) {
+			return false;
 		}
 
 		// Turn the code into an array as we may need to add other permsissions to the set we check

--- a/tests/security/PermissionTest.php
+++ b/tests/security/PermissionTest.php
@@ -124,4 +124,14 @@ class PermissionTest extends SapphireTest {
 		Config::inst()->remove('Permission', 'hidden_permissions');		
 		$this->assertContains('CMS_ACCESS_LeftAndMain', $permissionCheckboxSet->Field());
 	}
+
+	public function testEmptyMemberFails() {
+		$member = new Member();
+		$this->assertFalse($member->exists());
+
+		$this->logInWithPermission('ADMIN');
+
+		$this->assertFalse(Permission::checkMember($member, 'ADMIN'));
+		$this->assertFalse(Permission::checkMember($member, 'CMS_ACCESS_LeftAndMain'));
+	}
 }


### PR DESCRIPTION
This fixes an issue where empty objects (or indeed IDs of 0) being passed in to a permission::check fall back to the permission set of the currently logged in user.