### PR TITLE
FIX: Repeated template lookups were not cached (fixes #4626)

### DIFF
--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -1434,6 +1434,34 @@ after')
 		}
 	}
 
+	public function testRepeatedCallsAreCached() {
+		$data = new SSViewerTest_CacheTestData();
+		$template = '
+			<% if $TestWithCall %>
+				<% with $TestWithCall %>
+					{$Message}
+				<% end_with %>
+
+				{$TestWithCall.Message}
+			<% end_if %>';
+
+		$this->assertEquals('HiHi', preg_replace('/\s+/', '', $this->render($template, $data)));
+		$this->assertEquals(1, $data->testWithCalls,
+			'SSViewerTest_CacheTestData::TestWithCall() should only be called once. Subsequent calls should be cached');
+
+		$data = new SSViewerTest_CacheTestData();
+		$template = '
+			<% if $TestLoopCall %>
+				<% loop $TestLoopCall %>
+					{$Message}
+				<% end_loop %>
+			<% end_if %>';
+
+		$this->assertEquals('OneTwo', preg_replace('/\s+/', '', $this->render($template, $data)));
+		$this->assertEquals(1, $data->testLoopCalls,
+			'SSViewerTest_CacheTestData::TestLoopCall() should only be called once. Subsequent calls should be cached');
+	}
+
 	public function testClosedBlockExtension() {
 		$count = 0;
 		$parser = new SSTemplateParser();
@@ -1561,6 +1589,25 @@ class SSViewerTest_ViewableData extends ViewableData implements TestOnly {
 	}
 }
 
+class SSViewerTest_CacheTestData extends ViewableData implements TestOnly {
+
+	public $testWithCalls = 0;
+	public $testLoopCalls = 0;
+
+	public function TestWithCall() {
+		$this->testWithCalls++;
+		return ArrayData::create(array('Message' => 'Hi'));
+	}
+
+	public function TestLoopCall() {
+		$this->testLoopCalls++;
+		return ArrayList::create(array(
+			ArrayData::create(array('Message' => 'One')),
+			ArrayData::create(array('Message' => 'Two'))
+		));
+	}
+
+}
 
 class SSViewerTest_Controller extends Controller {
 

--- a/view/SSTemplateParser.php
+++ b/view/SSTemplateParser.php
@@ -742,12 +742,16 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		$res['LookupSteps'][] = $sub;
 		
 		$property = $sub['Call']['Method']['text'];
-		
+		$callArgs = "null";
 		if (isset($sub['Call']['CallArguments']) && $arguments = $sub['Call']['CallArguments']['php']) {
-			$res['php'] .= "->$method('$property', array($arguments), true)";
+			$callArgs = "array($arguments)";
 		}
-		else {
-			$res['php'] .= "->$method('$property', null, true)";
+
+		if ($method === 'obj') {
+			// obj() has an extra parameter for caching
+			$res['php'] .= "->$method('$property', $callArgs, true, true)";
+		} else {
+			$res['php'] .= "->$method('$property', $callArgs, true)";
 		}
 	}
 
@@ -3741,8 +3745,9 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			if ($arg['ArgumentMode'] == 'string') {
 				throw new SSTemplateParseException('Control block cant take string as argument.', $this);
 			}
-			$on = str_replace('$$FINAL', 'obj', 
-				($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
+			$on = str_replace('$$FINAL', 'obj', ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
+			// obj() has a fourth argument to enable caching, so add that to the end of the call
+			$on = preg_replace('/(\))$/', ', true)', $on);
 		}
 
 		return
@@ -3775,6 +3780,8 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		}
 		
 		$on = str_replace('$$FINAL', 'obj', ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
+		// obj() has a fourth argument to enable caching, so add that to the end of the call
+		$on = preg_replace('/(\))$/', ', true)', $on);
 		return 
 			$on . '; $scope->pushScope();' . PHP_EOL .
 				$res['Template']['php'] . PHP_EOL .

--- a/view/SSTemplateParser.php.inc
+++ b/view/SSTemplateParser.php.inc
@@ -284,12 +284,16 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		$res['LookupSteps'][] = $sub;
 		
 		$property = $sub['Call']['Method']['text'];
-		
+		$callArgs = "null";
 		if (isset($sub['Call']['CallArguments']) && $arguments = $sub['Call']['CallArguments']['php']) {
-			$res['php'] .= "->$method('$property', array($arguments), true)";
+			$callArgs = "array($arguments)";
 		}
-		else {
-			$res['php'] .= "->$method('$property', null, true)";
+
+		if ($method === 'obj') {
+			// obj() has an extra parameter for caching
+			$res['php'] .= "->$method('$property', $callArgs, true, true)";
+		} else {
+			$res['php'] .= "->$method('$property', $callArgs, true)";
 		}
 	}
 
@@ -921,8 +925,9 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			if ($arg['ArgumentMode'] == 'string') {
 				throw new SSTemplateParseException('Control block cant take string as argument.', $this);
 			}
-			$on = str_replace('$$FINAL', 'obj', 
-				($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
+			$on = str_replace('$$FINAL', 'obj', ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
+			// obj() has a fourth argument to enable caching, so add that to the end of the call
+			$on = preg_replace('/(\))$/', ', true)', $on);
 		}
 
 		return
@@ -955,6 +960,8 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		}
 		
 		$on = str_replace('$$FINAL', 'obj', ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
+		// obj() has a fourth argument to enable caching, so add that to the end of the call
+		$on = preg_replace('/(\))$/', ', true)', $on);
 		return 
 			$on . '; $scope->pushScope();' . PHP_EOL .
 				$res['Template']['php'] . PHP_EOL .


### PR DESCRIPTION
Hopefully the test makes a bit more sense than my wall of text in #4626. Basically, `<% with $Foo %>`, `<% loop $Foo %>` and `{$Foo.Bar}` are not cached.

As far as I can see in git history, they never have been explicitly cached. However, they were somewhat _accidentally_ cached in 3.1. This is what happened in 3.1:

- `<% if $Foo %>` looks up `Foo` and then caches the result
- `<% with $Foo %>` would _not_ be cached, but as the result was already in the cache from the `<% if %>` it would be pulled out anyway

#3985 changed this behaviour, meaning that now if `$cache` is set to false, it avoids the cache - even if `Foo` is already present in the cache.

I don’t like using regular expressions to add a fourth parameter to `obj()` calls, but I can’t see any way to avoid it. Its method signature is different to `XML_val()` and `hasValue()`, yet it looks like the template parser expects it to be identical.

cc @hafriedlander 