### PR TITLE
BUGFIX: fix response regression in initiation of request handler

### DIFF
--- a/control/Controller.php
+++ b/control/Controller.php
@@ -133,6 +133,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider {
 		$this->pushCurrent();
 		$this->urlParams = $request->allParams();
 		$this->setRequest($request);
+		$this->getResponse();
 		$this->setDataModel($model);
 
 		$this->extend('onBeforeInit');


### PR DESCRIPTION
`$this->response` might be called in user land code during the `init` cycle and a previous PR would have caused a regression here