### PR TITLE
Total Items of a Paginated List

### DIFF
--- a/core/PaginatedList.php
+++ b/core/PaginatedList.php
@@ -435,6 +435,13 @@ class PaginatedList extends SS_ListDecorator {
 	}
 
 	/**
+	 * Returns the total number of items in the list
+	 */
+	public function TotalItems() {
+		return $this->getTotalItems();
+	}
+
+	/**
 	 * Set the request object for this list
 	 *
 	 * @param SS_HTTPRequest


### PR DESCRIPTION
Just added support for displaying the number of total items contained in a Paginated List across templates