### PR TITLE
Optimization: Manifest regen. optimizations

### DIFF
--- a/core/manifest/ConfigStaticManifest.php
+++ b/core/manifest/ConfigStaticManifest.php
@@ -183,17 +183,15 @@ class SS_ConfigStaticManifest_Parser {
 	}
 
 	/**
-	 * Get the next token to process, incrementing the pointer
+	 * Get the next token to process, incrementing the pointer, skips any whitespace tokens
 	 *
-	 * @param bool $ignoreWhitespace - if true will skip any whitespace tokens & only return non-whitespace ones
 	 * @return null | mixed - Either the next token or null if there isn't one
 	 */
-	protected function next($ignoreWhitespace = true) {
+	protected function next() {
 		do {
-			if($this->pos >= $this->length) return null;
-			$next = $this->tokens[$this->pos++];
+			$next = ($this->pos >= $this->length) ? null : $this->tokens[$this->pos++];
 		}
-		while($ignoreWhitespace && ($next === (array)$next) && $next[0] == T_WHITESPACE);
+		while(($next === (array)$next) && $next[0] == T_WHITESPACE);
 
 		return $next;
 	}
@@ -328,7 +326,7 @@ class SS_ConfigStaticManifest_Parser {
 		if($token == '=') {
 			$depth = 0;
 
-			while($token = $this->next(false)){
+			while($token = ($this->pos >= $this->length) ? null : $this->tokens[$this->pos++]) {
 				$type = ($token === (array)$token) ? $token[0] : $token;
 
 				// Track array nesting depth

--- a/core/manifest/ConfigStaticManifest.php
+++ b/core/manifest/ConfigStaticManifest.php
@@ -193,7 +193,7 @@ class SS_ConfigStaticManifest_Parser {
 			if($this->pos >= $this->length) return null;
 			$next = $this->tokens[$this->pos++];
 		}
-		while($ignoreWhitespace && is_array($next) && $next[0] == T_WHITESPACE);
+		while($ignoreWhitespace && ($next === (array)$next) && $next[0] == T_WHITESPACE);
 
 		return $next;
 	}
@@ -239,7 +239,7 @@ class SS_ConfigStaticManifest_Parser {
 		$depth = 0; $namespace = null; $class = null; $clsdepth = null; $access = 0;
 
 		while($token = $this->next()) {
-			$type = is_array($token) ? $token[0] : $token;
+			$type = ($token === (array)$token) ? $token[0] : $token;
 
 			if($type == T_CLASS) {
 				$next = $this->nextString();
@@ -302,7 +302,7 @@ class SS_ConfigStaticManifest_Parser {
 		$value = '';
 
 		while($token = $this->next()) {
-			$type = is_array($token) ? $token[0] : $token;
+			$type = ($token === (array)$token) ? $token[0] : $token;
 
 			if($type == T_PUBLIC || $type == T_PRIVATE || $type == T_PROTECTED) {
 				$access = $type;
@@ -329,7 +329,7 @@ class SS_ConfigStaticManifest_Parser {
 			$depth = 0;
 
 			while($token = $this->next(false)){
-				$type = is_array($token) ? $token[0] : $token;
+				$type = ($token === (array)$token) ? $token[0] : $token;
 
 				// Track array nesting depth
 				if($type == T_ARRAY || $type == '[') {
@@ -351,7 +351,7 @@ class SS_ConfigStaticManifest_Parser {
 					$value .= $class;
 				}
 				else {
-					$value .= is_array($token) ? $token[1] : $token;
+					$value .= ($token === (array)$token) ? $token[1] : $token;
 				}
 			}
 		}

--- a/filesystem/FileFinder.php
+++ b/filesystem/FileFinder.php
@@ -173,24 +173,28 @@ class SS_FileFinder {
 	 * @return bool
 	 */
 	protected function acceptDir($basename, $pathname, $depth) {
-		if ($this->getOption('ignore_vcs') && in_array($basename, self::$vcs_dirs)) {
+		if ($this->options['ignore_vcs'] && in_array($basename, self::$vcs_dirs)) {
 			return false;
 		}
 
-		if ($ignore = $this->getOption('ignore_dirs')) {
-			if (in_array($basename, $ignore)) return false;
+		$ignore = $this->options['ignore_dirs'];
+		if ($ignore && in_array($basename, $ignore)) {
+			return false;
 		}
 
-		if ($max = $this->getOption('max_depth')) {
-			if ($depth > $max) return false;
+		$max = $this->options['max_depth'];
+		if ($max && $depth > $max) {
+			return false;
 		}
 
-		if ($callback = $this->getOption('accept_callback')) {
-			if (!call_user_func($callback, $basename, $pathname, $depth)) return false;
+		$callback = $this->options['accept_callback'];
+		if ($callback && !call_user_func($callback, $basename, $pathname, $depth)) {
+			return false;
 		}
 
-		if ($callback = $this->getOption('accept_dir_callback')) {
-			if (!call_user_func($callback, $basename, $pathname, $depth)) return false;
+		$callback = $this->options['accept_dir_callback'];
+		if ($callback && !call_user_func($callback, $basename, $pathname, $depth)) {
+			return false;
 		}
 
 		return true;
@@ -203,24 +207,29 @@ class SS_FileFinder {
 	 * @return bool
 	 */
 	protected function acceptFile($basename, $pathname, $depth) {
-		if ($regex = $this->getOption('name_regex')) {
-			if (!preg_match($regex, $basename)) return false;
+		$regex = $this->options['name_regex'];
+		if ($regex && !preg_match($regex, $basename)) {
+			return false;
 		}
 
-		if ($ignore = $this->getOption('ignore_files')) {
-			if (in_array($basename, $ignore)) return false;
+		$ignore = $this->options['ignore_files'];
+		if ($ignore && in_array($basename, $ignore)) {
+			return false;
 		}
 
-		if ($minDepth = $this->getOption('min_depth')) {
-			if ($depth < $minDepth) return false;
+		$minDepth = $this->options['min_depth'];
+		if ($minDepth && $depth < $minDepth) {
+			return false;
 		}
 
-		if ($callback = $this->getOption('accept_callback')) {
-			if (!call_user_func($callback, $basename, $pathname, $depth)) return false;
+		$callback = $this->options['accept_callback'];
+		if ($callback && !call_user_func($callback, $basename, $pathname, $depth)) {
+			return false;
 		}
 
-		if ($callback = $this->getOption('accept_file_callback')) {
-			if (!call_user_func($callback, $basename, $pathname, $depth)) return false;
+		$callback = $this->options['accept_file_callback'];
+		if ($callback && !call_user_func($callback, $basename, $pathname, $depth)) {
+			return false;
 		}
 
 		return true;


### PR DESCRIPTION
Updated a few is_array() checks to use the ($var === (array)$var) method as it's much faster. On my 3.2ghz i5, I saw a 4 second speedup when regenerating the manifest on a clean SS build.