### PR TITLE
BUG: Permission::checkMember() use of undefined variable $codes

### DIFF
--- a/security/Permission.php
+++ b/security/Permission.php
@@ -199,7 +199,7 @@ class Permission extends DataObject implements TemplateGlobalProvider {
 
 		// Code filters
 		$codeParams = is_array($code) ? $code : array($code);
-		$codeClause = DB::placeholders($codes);
+		$codeClause = DB::placeholders($codeParams);
 		$adminParams = (self::$admin_implies_all) ? array('ADMIN') : array();
 		$adminClause = (self::$admin_implies_all) ?  ", ?" : '';
 


### PR DESCRIPTION
An undefined variable in the method `checkMember()` was used to generate an SQL `codeClause`.
This resulted in a logical incomplete permission query, which may cause security issues.