### PR TITLE
FIX (partial) for #3181 where non-submit buttons are being activated on "enter" key press.

### DIFF
--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -352,7 +352,7 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 				'<h4>' . sprintf($numericLabelTmpl, '1', _t('HtmlEditorField.ADDURL', 'Add URL')) . '</h4>'),
 			$remoteURL = new TextField('RemoteURL', 'http://'),
 			new LiteralField('addURLImage',
-				'<button class="action ui-action-constructive ui-button field add-url" data-icon="addMedia">' .
+				'<button type="button" class="action ui-action-constructive ui-button field add-url" data-icon="addMedia">' .
 				_t('HtmlEditorField.BUTTONADDURL', 'Add url').'</button>')
 		);
 

--- a/forms/gridfield/GridFieldSortableHeader.php
+++ b/forms/gridfield/GridFieldSortableHeader.php
@@ -150,7 +150,7 @@ class GridFieldSortableHeader implements GridField_HTMLProvider, GridField_DataM
 						&& $gridField->getConfig()->getComponentByType('GridFieldFilterHeader')){
 
 					$field = new LiteralField($fieldName,
-						'<button name="showFilter" class="ss-gridfield-button-filter trigger"></button>');
+						'<button type="button" name="showFilter" class="ss-gridfield-button-filter trigger"></button>');
 				} else {
 					$field = new LiteralField($fieldName, '<span class="non-sortable">' . $title . '</span>');
 				}

--- a/javascript/GridField.js
+++ b/javascript/GridField.js
@@ -55,7 +55,7 @@
 								content = '<span class="non-sortable"></span>';
 								self.addClass('show-filter').find('.filter-header').show();
 							} else {
-								content = '<button name="showFilter" class="ss-gridfield-button-filter trigger"></button>';
+								content = '<button type="button" name="showFilter" class="ss-gridfield-button-filter trigger"></button>';
 								self.removeClass('show-filter').find('.filter-header').hide();
 							}
 

--- a/javascript/UploadField_downloadtemplate.js
+++ b/javascript/UploadField_downloadtemplate.js
@@ -22,7 +22,7 @@ window.tmpl.cache['ss-uploadfield-downloadtemplate'] = tmpl(
 				'</label>' +
 				'{% if (file.error) { %}' +
 					'<div class="ss-uploadfield-item-actions">' + 
-						'<div class="ss-uploadfield-item-cancel ss-uploadfield-item-cancelfailed delete"><button class="icon icon-16" data-icon="delete" title="' + ss.i18n._t('UploadField.CANCELREMOVE', 'Cancel/Remove') + '">' + ss.i18n._t('UploadField.CANCELREMOVE', 'Cancel/Remove') + '</button></div>' +
+						'<div class="ss-uploadfield-item-cancel ss-uploadfield-item-cancelfailed delete"><button type="button" class="icon icon-16" data-icon="delete" title="' + ss.i18n._t('UploadField.CANCELREMOVE', 'Cancel/Remove') + '">' + ss.i18n._t('UploadField.CANCELREMOVE', 'Cancel/Remove') + '</button></div>' +
 					'</div>' +
 				'{% } else { %}' +
 					'<div class="ss-uploadfield-item-actions">{% print(file.buttons, true); %}</div>' +

--- a/javascript/UploadField_uploadtemplate.js
+++ b/javascript/UploadField_uploadtemplate.js
@@ -17,14 +17,14 @@ window.tmpl.cache['ss-uploadfield-uploadtemplate'] = tmpl(
 					'{% if (!file.error) { %}' +						
 						'<div class="ss-uploadfield-item-progress"><div class="ss-uploadfield-item-progressbar"><div class="ss-uploadfield-item-progressbarvalue"></div></div></div>' +
 						'{% if (!o.options.autoUpload) { %}' + 
-							'<div class="ss-uploadfield-item-start start"><button class="icon icon-16" data-icon="navigation">' + ss.i18n._t('UploadField.START', 'Start') + '</button></div>' + 
+							'<div class="ss-uploadfield-item-start start"><button type="button" class="icon icon-16" data-icon="navigation">' + ss.i18n._t('UploadField.START', 'Start') + '</button></div>' +
 						'{% } %}' +
 					'{% } %}' + 	
 					'<div class="ss-uploadfield-item-cancel cancel">' +
-						'<button class="icon icon-16" data-icon="minus-circle" title="' + ss.i18n._t('UploadField.CANCELREMOVE', 'Cancel/Remove') + '">' + ss.i18n._t('UploadField.CANCELREMOVE', 'Cancel/Remove') + '</button>' +
+						'<button type="button" class="icon icon-16" data-icon="minus-circle" title="' + ss.i18n._t('UploadField.CANCELREMOVE', 'Cancel/Remove') + '">' + ss.i18n._t('UploadField.CANCELREMOVE', 'Cancel/Remove') + '</button>' +
 					'</div>' +
 					'<div class="ss-uploadfield-item-overwrite hide ">'+
-						'<button data-icon="drive-upload" class="ss-uploadfield-item-overwrite-warning" title="' + ss.i18n._t('UploadField.OVERWRITE', 'Overwrite') + '">' + ss.i18n._t('UploadField.OVERWRITE', 'Overwrite') + '</button>' +
+						'<button type="button" data-icon="drive-upload" class="ss-uploadfield-item-overwrite-warning" title="' + ss.i18n._t('UploadField.OVERWRITE', 'Overwrite') + '">' + ss.i18n._t('UploadField.OVERWRITE', 'Overwrite') + '</button>' +
 					'</div>' +
 				'</div>' +
 			'</div>' +

--- a/templates/AssetUploadField.ss
+++ b/templates/AssetUploadField.ss
@@ -47,7 +47,7 @@
 	</h3>			
 
 		<div class="ss-uploadfield-item-actions edit-all">
-		<button class="ss-uploadfield-item-edit-all ss-ui-button ui-corner-all" title="<%t AssetUploadField.EDITINFO 'Edit files' %>" style="display:none;">
+		<button type="button" class="ss-uploadfield-item-edit-all ss-ui-button ui-corner-all" title="<%t AssetUploadField.EDITINFO 'Edit files' %>" style="display:none;">
 			<%t AssetUploadField.EDITALL 'Edit all' %>
 				<span class="toggle-details-icon"></span>
 		</button>

--- a/templates/Includes/HtmlEditorField_viewfile.ss
+++ b/templates/Includes/HtmlEditorField_viewfile.ss
@@ -23,12 +23,12 @@
 			<div class="clear"><!-- --></div> 
 		</label>
 		<div class="ss-uploadfield-item-actions">	
-			<button data-icon="deleteLight" class="ss-uploadfield-item-cancel ss-uploadfield-item-remove" title="<%t UploadField.REMOVE 'Remove' %>">
+			<button type="button" data-icon="deleteLight" class="ss-uploadfield-item-cancel ss-uploadfield-item-remove" title="<%t UploadField.REMOVE 'Remove' %>">
 				<%t UploadField.REMOVE 'Remove' %>
 			</button>
 			
 			<div class="ss-uploadfield-item-edit edit">
-				<button class="ss-uploadfield-item-edit ss-ui-button ui-corner-all" title="<%t UploadField.EDITINFO 'Edit this file' %>" data-icon="pencil">
+				<button type="button" class="ss-uploadfield-item-edit ss-ui-button ui-corner-all" title="<%t UploadField.EDITINFO 'Edit this file' %>" data-icon="pencil">
 					<%t UploadField.EDIT 'Edit' %>
 					<span class="toggle-details">
 						<span class="toggle-details-icon"></span>

--- a/templates/Includes/UploadField_FileButtons.ss
+++ b/templates/Includes/UploadField_FileButtons.ss
@@ -1,17 +1,17 @@
 <% if $canEdit %>
-	<button class="ss-uploadfield-item-edit ss-ui-button ui-corner-all" title="<%t UploadField.EDITINFO 'Edit this file' %>" data-icon="pencil">
+	<button type="button" class="ss-uploadfield-item-edit ss-ui-button ui-corner-all" title="<%t UploadField.EDITINFO 'Edit this file' %>" data-icon="pencil">
 	<%t UploadField.EDIT 'Edit' %>
 	<span class="toggle-details">
 		<span class="toggle-details-icon"></span>
 	</span>
 	</button>
 <% end_if %>
-<button class="ss-uploadfield-item-remove ss-ui-button ui-corner-all" title="<%t UploadField.REMOVEINFO 'Remove this file from here, but do not delete it from the file store' %>" data-icon="plug-disconnect-prohibition">
+<button type="button" class="ss-uploadfield-item-remove ss-ui-button ui-corner-all" title="<%t UploadField.REMOVEINFO 'Remove this file from here, but do not delete it from the file store' %>" data-icon="plug-disconnect-prohibition">
 <%t UploadField.REMOVE 'Remove' %></button>
 <% if $canDelete %>
-	<button data-href="$UploadFieldDeleteLink" class="ss-uploadfield-item-delete ss-ui-button ui-corner-all" title="<%t UploadField.DELETEINFO 'Permanently delete this file from the file store' %>" data-icon="minus-circle"><%t UploadField.DELETE 'Delete from files' %></button>
+	<button type="button" data-href="$UploadFieldDeleteLink" class="ss-uploadfield-item-delete ss-ui-button ui-corner-all" title="<%t UploadField.DELETEINFO 'Permanently delete this file from the file store' %>" data-icon="minus-circle"><%t UploadField.DELETE 'Delete from files' %></button>
 <% end_if %>
 <% if $UploadField.canAttachExisting %>
-	<button class="ss-uploadfield-item-choose-another ss-uploadfield-fromfiles ss-ui-button ui-corner-all" title="<%t UploadField.CHOOSEANOTHERINFO 'Replace this file with another one from the file store' %>" data-icon="network-cloud">
+	<button type="button" class="ss-uploadfield-item-choose-another ss-uploadfield-fromfiles ss-ui-button ui-corner-all" title="<%t UploadField.CHOOSEANOTHERINFO 'Replace this file with another one from the file store' %>" data-icon="network-cloud">
 	<%t UploadField.CHOOSEANOTHERFILE 'Choose another file' %></button>
 <% end_if %>

--- a/templates/UploadField.ss
+++ b/templates/UploadField.ss
@@ -57,11 +57,11 @@
 			<% end_if %>
 
 			<% if $canAttachExisting %>
-				<button class="ss-uploadfield-fromfiles ss-ui-button ui-corner-all" title="<%t UploadField.FROMCOMPUTERINFO 'Select from files' %>" data-icon="network-cloud"><%t UploadField.FROMFILES 'From files' %></button>
+				<button type="button" class="ss-uploadfield-fromfiles ss-ui-button ui-corner-all" title="<%t UploadField.FROMCOMPUTERINFO 'Select from files' %>" data-icon="network-cloud"><%t UploadField.FROMFILES 'From files' %></button>
 			<% end_if %>
 			<% if $canUpload %>
 				<% if not $autoUpload %>
-					<button class="ss-uploadfield-startall ss-ui-button ui-corner-all" data-icon="navigation"><%t UploadField.STARTALL 'Start all' %></button>
+					<button type="button" class="ss-uploadfield-startall ss-ui-button ui-corner-all" data-icon="navigation"><%t UploadField.STARTALL 'Start all' %></button>
 				<% end_if %>
 			<% end_if %>
 			<div class="clear"><!-- --></div>


### PR DESCRIPTION
Now based on `3` branch. Copied from (and supersedes) previous PR https://github.com/silverstripe/silverstripe-framework/pull/465 which was based on `3.1`

---

This issue (and fix for  #3181) relates to CMS issue at https://github.com/silverstripe/silverstripe-cms/issues/1288 and associated pull request: https://github.com/silverstripe/silverstripe-cms/pull/1292

**PLEASE NOTE:** This is a combined fix across both repositories and ensures that all non-submit buttons are defined explicitly as type `button` to ensure browsers will not automatically register the first occurrence after someone presses the enter key.

* **CMS:**
  * Issue: https://github.com/silverstripe/silverstripe-cms/issues/1288 
  * PR: https://github.com/silverstripe/silverstripe-cms/pull/1290
* **Framework:**
  * Issue: https://github.com/silverstripe/silverstripe-framework/issues/3181
  * PR: https://github.com/silverstripe/silverstripe-framework/pull/4662 (you are here)