### PR TITLE
FIX for #4663 ensuring TabSet return values are retained from parent.

### DIFF
--- a/forms/CompositeField.php
+++ b/forms/CompositeField.php
@@ -222,6 +222,9 @@ class CompositeField extends FormField {
 		return $ret;
 	}
 
+	/**
+	 * @uses FieldList->insertAfter()
+	 */
 	public function insertAfter($insertAfter, $field) {
 		$ret = $this->children->insertAfter($insertAfter, $field);
 		$this->sequentialSet = null;

--- a/forms/FieldList.php
+++ b/forms/FieldList.php
@@ -312,7 +312,7 @@ class FieldList extends ArrayList {
 	 * Returns a named field.
 	 * You can use dot syntax to get fields from child composite fields
 	 *
-	 * @todo Implement similiarly to dataFieldByName() to support nested sets - or merge with dataFields()
+	 * @todo Implement similarly to dataFieldByName() to support nested sets - or merge with dataFields()
 	 */
 	public function fieldByName($name) {
 		$name = $this->rewriteTabPath($name);
@@ -356,6 +356,7 @@ class FieldList extends ArrayList {
 	 *
 	 * @param string $name Name of the field to insert before
 	 * @param FormField $item The form field to insert
+	 * @return FormField|false
 	 */
 	public function insertBefore($name, $item) {
 		// Backwards compatibility for order of arguments
@@ -385,6 +386,7 @@ class FieldList extends ArrayList {
 	 *
 	 * @param string $name Name of the field to insert after
 	 * @param FormField $item The form field to insert
+	 * @return FormField|false
 	 */
 	public function insertAfter($name, $item) {
 		// Backwards compatibility for order of arguments

--- a/forms/TabSet.php
+++ b/forms/TabSet.php
@@ -114,7 +114,10 @@ class TabSet extends CompositeField {
 	}
 
 	/**
-	 * Returns the named tab
+	 * Returns a named field.
+	 *
+	 * @param string $name Name of the field you want to find. Allows for dot notation.
+	 * @return FormField|null
 	 */
 	public function fieldByName($name) {
 		if(strpos($name,'.') !== false)	list($name, $remainder) = explode('.',$name,2);
@@ -135,6 +138,8 @@ class TabSet extends CompositeField {
 				}
 			}
 		}
+
+		return null;
 	}
 
 	/**
@@ -148,22 +153,24 @@ class TabSet extends CompositeField {
 	/**
 	 * Inserts a field before a particular field in a FieldList.
 	 *
-	 * @param FormField $item The form field to insert
-	 * @param string $name Name of the field to insert before
+	 * @param string $insertBefore Name of the field to insert before
+	 * @param FormField $field The form field to insert
+	 * @return	FormField|null
 	 */
 	public function insertBefore($insertBefore, $field) {
-		parent::insertBefore($insertBefore, $field);
 		if($field instanceof Tab) $field->setTabSet($this);
-		$this->sequentialSet = null;
+		return parent::insertBefore($insertBefore, $field);
 	}
 
+	/**
+	 * Inserts a field after a particular field in a FieldList.
+	 *
+	 * @param string $insertAfter Name of the field to insert after
+	 * @param FormField $field The form field to insert
+	 * @return FormField|null
+	 */
 	public function insertAfter($insertAfter, $field) {
-		parent::insertAfter($insertAfter, $field);
 		if($field instanceof Tab) $field->setTabSet($this);
-		$this->sequentialSet = null;
-	}
-
-	public function removeByName( $tabName, $dataFieldOnly = false ) {
-		parent::removeByName( $tabName, $dataFieldOnly );
+		return parent::insertAfter($insertAfter, $field);
 	}
 }


### PR DESCRIPTION
Proposed solution to address #4663. 

Please also see note about the unrelated (but redundant) override of `removeByName` method. Why is that even there?