### PR TITLE
Adding SVG to allowed file types

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -129,7 +129,7 @@ class File extends DataObject {
 		'','ace','arc','arj','asf','au','avi','bmp','bz2','cab','cda','css','csv','dmg','doc','docx','dotx','dotm',
 		'flv','gif','gpx','gz','hqx','ico','jar','jpeg','jpg','js','kml', 'm4a','m4v',
 		'mid','midi','mkv','mov','mp3','mp4','mpa','mpeg','mpg','ogg','ogv','pages','pcx','pdf','pkg',
-		'png','pps','ppt','pptx','potx','potm','ra','ram','rm','rtf','sit','sitx','tar','tgz','tif','tiff',
+		'png','pps','ppt','pptx','potx','potm','ra','ram','rm','rtf','sit','sitx', 'svg', 'tar','tgz','tif','tiff',
 		'txt','wav','webm','wma','wmv','xls','xlsx','xltx','xltm','zip','zipx',
 	);
 


### PR DESCRIPTION
Adding svg to allowed extensions array, this should be merged in conjunction with a change I am making to the htaccess file in the silverstripe-installer repo (also on 3 branch). I will link to this when I have completed the PR.