### PR TITLE
FIX: Missing dotfiles matched as root URL

### DIFF
--- a/control/HTTPRequest.php
+++ b/control/HTTPRequest.php
@@ -131,7 +131,7 @@ class SS_HTTPRequest implements ArrayAccess {
 		if(Director::is_relative_url($url) || preg_match('/^\//', $url)) {
 			$this->url = preg_replace(array('/\/+/','/^\//', '/\/$/'),array('/','',''), $this->url);
 		}
-		if(preg_match('/^(.*)\.([A-Za-z][A-Za-z0-9]*)$/', $this->url, $matches)) {
+		if(preg_match('/^(.+)\.([A-Za-z][A-Za-z0-9]*)$/', $this->url, $matches)) {
 			$this->url = $matches[1];
 			$this->extension = $matches[2];
 		}

--- a/tests/control/HTTPRequestTest.php
+++ b/tests/control/HTTPRequestTest.php
@@ -253,5 +253,11 @@ class HTTPRequestTest extends SapphireTest {
 		$req = new SS_HTTPRequest('GET', '/home?test=1');
 		$this->assertEquals('home?test=1', $req->getURL(true));
 		$this->assertEquals('home', $req->getURL());
+
+		$req = new SS_HTTPRequest('GET', 'somefile.gif');
+		$this->assertEquals('gif', $req->getExtension());
+
+		$req = new SS_HTTPRequest('GET', '.passwd');
+		$this->assertEquals(null, $req->getExtension());
 	}
 }


### PR DESCRIPTION
Missing dotfiles for example `.passwd` are matched as files and split by the dot to retrieve the extension. However this means `$this->url` is set to empty which in turn means `$this->dirParts` is empty which is then matched as the root URL instead of returning a 404.

This regex modification only matches files with names. I thought this was the least intrusive way to fix this issue.
