### PR TITLE
FIX #4392: Ensure headers are checked first before being clobbered by globally maintained state.

### DIFF
--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -448,8 +448,14 @@ class HTTP {
 
 		// Now that we've generated them, either output them or attach them to the SS_HTTPResponse as appropriate
 		foreach($responseHeaders as $k => $v) {
-			if($body) $body->addHeader($k, $v);
-			else if(!headers_sent()) header("$k: $v");
+			if($body) {
+				// Set the header now if it's not already set.
+				if ($body->getHeader($k) === null) {
+					$body->addHeader($k, $v);
+				}
+			} elseif(!headers_sent()) {
+				header("$k: $v");
+			}
 		}
 	}
 


### PR DESCRIPTION
Proposed fix for #4392. Unit tests are coming soon.

**Note:** This is a duplicate of the old PR #4393 to bring it up to date with the `3.2` branch.



