### PR TITLE
Fix page reordering bug with ParentID

### DIFF
--- a/admin/javascript/LeftAndMain.Tree.js
+++ b/admin/javascript/LeftAndMain.Tree.js
@@ -105,7 +105,10 @@
 									SiblingIDs: siblingIDs
 								},
 								success: function() {
-									$('.cms-edit-form :input[name=ParentID]').val(newParentID);
+									// We only need to update the ParentID if the current page we're on is the page being moved
+									if ($('.cms-edit-form :input[name=ID]').val() == nodeID) {
+										$('.cms-edit-form :input[name=ParentID]').val(newParentID);
+									}
 									self.updateNodesFromServer([nodeID]);
 								},
 								statusCode: {


### PR DESCRIPTION
If you are viewing PageA in the CMS, but move PageB into PageC, the edit form will recieve an edit form ParentID of PageC.
This is incorrect, as only PageB had it's ParentID change.