### PR TITLE
Only notify users about PDO native mode once

### DIFF
--- a/model/connect/MySQLSchemaManager.php
+++ b/model/connect/MySQLSchemaManager.php
@@ -125,9 +125,16 @@ class MySQLSchemaManager extends DBSchemaManager {
 	}
 
 	public function checkAndRepairTable($tableName) {
+		// Flag to ensure we only send the warning about PDO + native mode once
+		static $pdo_warning_sent = false;
+
 		// If running PDO and not in emulated mode, check table will fail
 		if($this->database->getConnector() instanceof PDOConnector && !PDOConnector::is_emulate_prepare()) {
-			$this->alterationMessage('CHECK TABLE command disabled for PDO in native mode', 'notice');
+			if (!$pdo_warning_sent) {
+				$this->alterationMessage('CHECK TABLE command disabled for PDO in native mode', 'notice');
+				$pdo_warning_sent = true;
+			}
+
 			return true;
 		}
 


### PR DESCRIPTION
Users don’t need to be notified about this for every table! I’ll await others’ input on whether this is a bug and should be fixed against 3.2.

Before:
![screen shot 2015-10-12 at 16 45 49](https://cloud.githubusercontent.com/assets/1655548/10432063/c071b20e-7100-11e5-82b5-dfc13d7281cf.png)

After:
![screen shot 2015-10-12 at 16 48 10](https://cloud.githubusercontent.com/assets/1655548/10432109/0bca3276-7101-11e5-9aef-f13373445201.png)
