### PR TITLE
Bugfix for DropdownField->validate (can't validate null)

### DIFF
--- a/forms/DropdownField.php
+++ b/forms/DropdownField.php
@@ -334,7 +334,7 @@ class DropdownField extends FormField {
 		$source = $this->getSourceAsArray();
 		$disabled = $this->getDisabledItems();
 
-		if (!array_key_exists($this->value, $source) || in_array($this->value, $disabled)) {
+		if (empty($this->value) || !array_key_exists($this->value, $source) || in_array($this->value, $disabled)) {
 			if ($this->getHasEmptyDefault() && !$this->value) {
 				return true;
 			}
@@ -343,7 +343,7 @@ class DropdownField extends FormField {
 				_t(
 					'DropdownField.SOURCE_VALIDATION',
 					"Please select a value within the list provided. {value} is not a valid option",
-					array('value' => $this->value)
+					array('value' => $this->value?:'')
 				),
 				"validation"
 			);


### PR DESCRIPTION
Blog 2.0 errored when I tried to add a blog item without tag or category (on SilverStripe 3.2). Perhaps that's a bug in the blog module, but why not make this validator be able to handle null values.