### PR TITLE
Fix Monolog constant use

### DIFF
--- a/conf/ConfigureFromEnv.php
+++ b/conf/ConfigureFromEnv.php
@@ -144,7 +144,7 @@ if(defined('SS_USE_BASIC_AUTH') && SS_USE_BASIC_AUTH) {
 if(defined('SS_ERROR_LOG')) {
 	$logger = Injector::inst()->get('Logger');
 	if($logger instanceof Logger) {
-		$logger->pushHandler(new StreamHandler(BASE_PATH . '/' . SS_ERROR_LOG, Logger::WARN));
+		$logger->pushHandler(new StreamHandler(BASE_PATH . '/' . SS_ERROR_LOG, Logger::WARNING));
 	} else {
 		user_error("SS_ERROR_LOG setting only works with Monolog, you are using another logger", E_USER_WARNING);
 	}


### PR DESCRIPTION
Changed from WARN to WARNING in 1.0
https://github.com/Seldaek/monolog/commit/594ed9cdcb4b376289c65478ec201555130f0577,
looks like it was just a typo on our part (given the change happened in 2011)