### PR TITLE
FIX only use sethasemptydefault if exists.

### DIFF
--- a/forms/DropdownField.php
+++ b/forms/DropdownField.php
@@ -362,7 +362,9 @@ class DropdownField extends FormField {
 	 */
 	public function castedCopy($classOrCopy) {
 		$field = parent::castedCopy($classOrCopy);
-		$field->setHasEmptyDefault($this->getHasEmptyDefault());
+		if($field->hasMethod('setHasEmptyDefault')) {
+			$field->setHasEmptyDefault($this->getHasEmptyDefault());
+		}
 		return $field;
 	}
 }


### PR DESCRIPTION
Backport of #4672 with a slight rewrite incase of subclasses of the field.