### PR TITLE
BUGFIX: Use Object->hasMethod() instead of method_exists()

### DIFF
--- a/forms/gridfield/GridField.php
+++ b/forms/gridfield/GridField.php
@@ -148,7 +148,7 @@ class GridField extends FormField {
 			return $this->modelClassName;
 		}
 
-		if($this->list && method_exists($this->list, 'dataClass')) {
+		if($this->list && $this->list->hasMethod('dataClass')) {
 			$class = $this->list->dataClass();
 
 			if($class) {


### PR DESCRIPTION
This allows you to for example return a `PaginatedList` object from `ModelAdmin::getList()` without `GridField` failing when trying to render that list in certain circumstances.

I can't see a downside to this, a slight performance hit as it now checks for extension methods as well as the standard `method_exists()`, but it's only executed once per rendered `GridField`.

Wasn't sure if I should raise this against 3.1 or 3.2?