### PR TITLE
Increase minimum required PHP version to 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ env:
 
 matrix:
   include:
-    - php: 5.4
+    - php: 5.5
       env: DB=MYSQL
-    - php: 5.4
+    - php: 5.5
       env: DB=PGSQL
     - php: 5.5
       env: DB=SQLITE

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.4.0",
+		"php": ">=5.5.0",
 		"composer/installers": "~1.0",
 		"monolog/monolog": "~1.11",
 		"league/flysystem": "~1.0.12",

--- a/dev/install/install.php
+++ b/dev/install/install.php
@@ -4,17 +4,17 @@
  ************************************************************************************
  **                                                                                **
  **  If you can read this text in your browser then you don't have PHP installed.  **
- **  Please install PHP 5.3.3 or higher, preferably PHP 5.3.4+.                    **
+ **  Please install PHP 5.5.0 or higher.                                           **
  **                                                                                **
  ************************************************************************************
  ************************************************************************************/
 
 /**
- * PHP version check. Make sure we've got at least PHP 5.3.3 in the most friendly way possible
+ * PHP version check. Make sure we've got at least PHP 5.5.0 in the most friendly way possible
  */
 define('FRAMEWORK_NAME', 'framework');
 
-if (version_compare(phpversion(), '5.3.3', '<')) {
+if (version_compare(phpversion(), '5.5.0', '<')) {
 	header("HTTP/1.1 500 Server Error");
 	echo str_replace(
 		array('$PHPVersion', 'sapphire'),

--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -4,7 +4,7 @@
  ************************************************************************************
  **                                                                                **
  **  If you can read this text in your browser then you don't have PHP installed.  **
- **  Please install PHP 5.3.3 or higher, preferably PHP 5.3.4+.                    **
+ **  Please install PHP 5.5.0 or higher.                                           **
  **                                                                                **
  ************************************************************************************
  ************************************************************************************/
@@ -382,7 +382,7 @@ class InstallRequirements {
 		$isIIS = $this->isIIS();
 		$webserver = $this->findWebserver();
 
-		$this->requirePHPVersion('5.3.4', '5.3.3', array(
+		$this->requirePHPVersion('5.5.0', '5.5.0', array(
 			"PHP Configuration",
 			"PHP5 installed",
 			null,

--- a/dev/install/php5-required.html
+++ b/dev/install/php5-required.html
@@ -1,18 +1,18 @@
 <html>
 	<head>
-		<title>PHP 5.3.3 is required</title>
+		<title>PHP 5.5.0 is required</title>
 		<link rel="stylesheet" type="text/css" href="framework/dev/install/css/install.css">
 	</head>
 	<body>
 		<div id="BgContainer">
 			<div id="Container">
 				<div id="Header">
-					<h1>PHP 5.3.3 required</h1>
+					<h1>PHP 5.5.0 required</h1>
 					<div class="left">
-						<h3>To run SilverStripe, please install PHP 5.3.3 or greater.</h3>
+						<h3>To run SilverStripe, please install PHP 5.5.0 or greater.</h3>
 
 						<p>We have detected that you are running PHP version <b>$PHPVersion</b>. In order to run SilverStripe,
-						you must have PHP version 5.3.3 or greater, and for best results we recommend PHP 5.3.4 or greater.<p/>
+						you must have PHP version 5.5.0 or higher.<p/>
 
 						<p>If you are running on a shared host, you may need to ask your hosting provider how to do this.</p>
 					</div>

--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -8,7 +8,7 @@ Our web-based [PHP installer](installation/) can check if you meet the requireme
 
 ## Web server software requirements
 
- * PHP 5.4+
+ * PHP 5.5 or newer
  * We recommend using a PHP accelerator or opcode cache, such as [xcache](http://xcache.lighttpd.net/) or [WinCache](http://www.iis.net/download/wincacheforphp).
  * Allocate at least 48MB of memory to each PHP process. (SilverStripe can be resource hungry for some intensive operations.)
  * Required modules: dom, gd2, fileinfo, hash, iconv, mbstring, mysqli (or other database driver), session, simplexml, tokenizer, xml.

--- a/docs/en/00_Getting_Started/01_Installation/04_Other_installation_Options/Windows_IIS7.md
+++ b/docs/en/00_Getting_Started/01_Installation/04_Other_installation_Options/Windows_IIS7.md
@@ -27,8 +27,8 @@ We'll also install SQL Server 2008 R2, and support for connecting to it in PHP.
 
   * Internet Information Services (IIS) 7.x
   * SQL Server 2008 R2
-  * PHP 5.4 (PHP 5.3.2+ also works, but we'll install with the latest PHP stable)
-  * SilverStripe 3
+  * PHP 5.5 or newer
+  * SilverStripe 4
   * [Microsoft URL Rewrite Module 2.0](http://www.iis.net/download/URLRewrite)
   * [IIS 7 Administration Pack](http://www.iis.net/download/AdministrationPack) (ONLY required for Windows Vista or Server 2008)
   * [PHP Manager](http://phpmanager.codeplex.com/releases/view/69115)
@@ -94,7 +94,7 @@ Installing SQL Server should be relatively straightforward. Keep a note of the p
 ### Install PHP
 
  * Install PHP Manager from http://phpmanager.codeplex.com/releases/view/69115 (choose x86 or x64 depending on your Windows architecture)
- * Download the latest stable PHP 5.4 (VC9, x86) zip from http://windows.php.net/download
+ * Download the latest stable PHP 5.5 (VC9, x86) zip from http://windows.php.net/download
  * Extract zip contents to **C:\php**
  * Open PHP Manager in IIS and register **C:\php\php-cgi.exe** to enable PHP for IIS
 
@@ -113,7 +113,7 @@ This is the PHP extension allowing it to connect to SQL Server databases.
 
 This is an op-code cacher which speeds up PHP execution on Windows.
 
- * Download the latest wincache (for PHP 5.4, x86) from http://www.iis.net/download/wincacheforphp
+ * Download the latest wincache (for PHP 5.5, x86) from http://www.iis.net/download/wincacheforphp
  * Extract zip contents to a temporary location, such as C:\wincache
  * Copy php_wincache.dll to C:\php\ext
  * Open PHP Manager and go to **Eanble or disable an extension**
@@ -291,7 +291,6 @@ If this still doesn't help, enable Failed Request Tracing in IIS. You could also
 **A:** A non-thread safe of PHP is recommended for use with IIS. Thread safety checks are not required, and you'll get a performance boost by not using a thread safe version. If possible, use a version compiled in VC9 instead of VC6. VC9 versions require you to have the [Microsoft 2008 C++ Runtime (x86)](http://www.microsoft.com/downloads/details.aspx?FamilyID=9B2DA534-3E03-4391-8A4D-074B9F2BC1BF) or the [Microsoft 2008 C++ Runtime (x64)](http://www.microsoft.com/downloads/details.aspx?familyid=bd2a6171-e2d6-4230-b809-9a8d7548c1b6&displaylang=en) installed
 
 You should also ensure you are using the latest version of the [Microsoft Drivers for PHP for SQL Server](http://www.microsoft.com/downloads/en/details.aspx?FamilyID=80E44913-24B4-4113-8807-CAAE6CF2CA05&displaylang=en) driver.
-If possible, you should also use PHP 5.4 which provides performance improvements over 5.2 and 5.3.
 
 Try increasing the IIS **MaxInstances** in IIS Manager > FastCGI from 4 to a higher value. For quad core CPUs, a higher value such as **32** should prove to provide a performance enhancement.
 

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -4,6 +4,7 @@
 
 ### Framework
 
+ * Minimum PHP version raised to 5.5.0
  * Deprecate `SQLQuery` in favour `SQLSelect`
  * `DataList::filter` by null now internally generates "IS NULL" or "IS NOT NULL" conditions appropriately on queries
  * `DataObject::database_fields` now returns all fields on that table.

--- a/main.php
+++ b/main.php
@@ -4,7 +4,7 @@
  ************************************************************************************
  **                                                                                **
  **  If you can read this text in your browser then you don't have PHP installed.  **
- **  Please install PHP 5.3.3 or higher, preferably PHP 5.3.4+.                    **
+ **  Please install PHP 5.5.0 or higher                       .                    **
  **                                                                                **
  ************************************************************************************
  ************************************************************************************/
@@ -14,7 +14,7 @@
  * @subpackage core
  */
 
-if (version_compare(phpversion(), '5.3.3', '<')) {
+if (version_compare(phpversion(), '5.5.0', '<')) {
 	header("HTTP/1.1 500 Server Error");
 	echo str_replace('$PHPVersion', phpversion(), file_get_contents("dev/install/php5-required.html"));
 	die();


### PR DESCRIPTION
See mailinglist discussion at https://groups.google.com/forum/#!topic/silverstripe-dev/7mVvhNNeNps.
Please merge together with https://github.com/silverstripe/silverstripe-cms/pull/1303.
I haven't tested that the IIS setup still works with PHP 5.5, but I'm sure it doesn't with the PHP 5.3 and PHP 5.4 versions mentioned before (at least once https://github.com/open-sausages/silverstripe-framework/commits/features/dbfile-uploadfield is merged, which uses PHP 5.5 only syntax).