### PR TITLE
API Generated files API now requires callback as a mandatory parameter

### DIFF
--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -38,10 +38,8 @@
 
 ### ErrorPage
 
- * `ErrorPage::get_filepath_for_errorcode` has been removed
- * `ErrorPage::alternateFilepathForErrorcode` extension point has been removed
-
-See notes below on upgrading extensions to the ErrorPage class
+ * `ErrorPage::alternateFilepathForErrorcode` extension point has been removed. 
+   See notes below on upgrading extensions to the ErrorPage class
 
 ### Assets and Filesystem
 
@@ -412,35 +410,13 @@ After:
 
 ### Update code that modifies the behaviour of ErrorPage
 
-Since ErrorPage writes statically cached files for each dataobject, in order to integrate it with both the
-new asset backend, and ensure that .htaccess static references still works, these files are now cached
-potentially in two places:
+The extension point `ErrorPage::alternateFilepathForErrorcode` has been removed. Rather than allowing
+customisation of the full path for individual error pages, only the basename for each cached html file
+can be custoised. Instead, the path that these files are stored in can be customised via the
+`ErrorPage.static_filepath` config.
 
- * When an error is generated within the live environment, by default the error handler will query the 
-`GeneratedAssetHandler` for cached content, which is then served up in the same PHP request. This is the
-primary cache for error content, which does not involve database access, but is processed within the
-PHP process. Although, the file path for this cache is not predictable, as it uses the configured asset backend,
-and is not necessarily present on the same filesystem as the site code.
-
- * In order to ensure that the webserver has direct access an available cached error page, it can be necessary
-to ensure a physical file is present locally. By setting the `ErrorPage.enable_static_file` config,
-the generation of this file can be controlled. When this disabled, the static file will only be cached
-via the configured backend. When this is enabled (as it is by default) then the error page will be generated
-in the same location as it were in framework version 3.x. E.g. `/assets/error-404.html`
-
-If your webserver relies on static paths encoded in `.htaccess` to these files, then it's preferable to leave
-this option on. If using a non-local filesystem, and another mechanism for intercepting webserver errors,
-then it may be preferable to leave this off, meaning that the local assets folder is unnecessary.
-
-`ErrorPage::get_filepath_for_errorcode` has been removed, because the local path for a specific code is
-no longer assumed. Instead you should use `ErrorPage::get_content_for_errorcode` which retrieves the
-appropriate content for that error using one of the methods above.
-
-In order to retrieve the actual filename (which is used to identify an error page regardless of base
-path), you can use `ErrorPage::get_error_filename()` instead. Unlike the old `get_filepath_for_errorcode`
-method, there is no $locale parameter.
-
-In case that user code must customise this filename, such as for extensions which provide a locale value
+Additionally, the `$locale` parameter has been removed from these methods. In case that user code
+must customise this filename, such as for extensions which provide a locale value
 for any error page, the extension point `updateErrorFilename` can be used. This extension point should
 also be used to replace any `alternateFilepathForErrorcode` used.
 

--- a/filesystem/storage/CacheGeneratedAssetHandler.php
+++ b/filesystem/storage/CacheGeneratedAssetHandler.php
@@ -71,7 +71,7 @@ class CacheGeneratedAssetHandler implements GeneratedAssetHandler, Flushable {
 		self::get_cache()->clean();
 	}
 
-	public function getGeneratedURL($filename, $entropy = 0, $callback = null) {
+	public function getGeneratedURL($filename, $entropy, $callback) {
 		$result = $this->getGeneratedFile($filename, $entropy, $callback);
 		if($result) {
 			return $this
@@ -80,7 +80,7 @@ class CacheGeneratedAssetHandler implements GeneratedAssetHandler, Flushable {
 		}
 	}
 
-	public function getGeneratedContent($filename, $entropy = 0, $callback = null) {
+	public function getGeneratedContent($filename, $entropy, $callback) {
 		$result = $this->getGeneratedFile($filename, $entropy, $callback);
 		if($result) {
 			return $this
@@ -99,7 +99,7 @@ class CacheGeneratedAssetHandler implements GeneratedAssetHandler, Flushable {
 	 * @return array tuple array if available
 	 * @throws Exception If the file isn't available and $callback fails to regenerate content
 	 */
-	protected function getGeneratedFile($filename, $entropy = 0, $callback = null) {
+	protected function getGeneratedFile($filename, $entropy, $callback) {
 		// Check if there is an existing asset
 		$cache = self::get_cache();
 		$cacheID = $this->getCacheKey($filename, $entropy);
@@ -112,19 +112,8 @@ class CacheGeneratedAssetHandler implements GeneratedAssetHandler, Flushable {
 			}
 		}
 
-		// Regenerate
-		if($callback) {
-			// Invoke regeneration and save
-			$content = call_user_func($callback);
-			return $this->updateContent($filename, $entropy, $content);
-		}
-	}
-
-	public function updateContent($filename, $entropy, $content) {
-		$cache = self::get_cache();
-		$cacheID = $this->getCacheKey($filename, $entropy);
-
-		// Store content
+		// Invoke regeneration and save
+		$content = call_user_func($callback);
 		$result = $this
 			->getAssetStore()
 			->setFromString($content, $filename);
@@ -140,7 +129,6 @@ class CacheGeneratedAssetHandler implements GeneratedAssetHandler, Flushable {
 
 		throw new Exception("Error regenerating file \"{$filename}\"");
 	}
-
 
 	/**
 	 * Get cache key for the given generated asset

--- a/filesystem/storage/GeneratedAssetHandler.php
+++ b/filesystem/storage/GeneratedAssetHandler.php
@@ -22,7 +22,7 @@ interface GeneratedAssetHandler {
 	 * if there is valid content.
 	 * @return string URL to generated file
 	 */
-	public function getGeneratedURL($filename, $entropy = 0, $callback = null);
+	public function getGeneratedURL($filename, $entropy, $callback);
 
 	/**
 	 * Given a filename and entropy, determine if a pre-generated file is valid. If this file is invalid
@@ -34,14 +34,5 @@ interface GeneratedAssetHandler {
 	 * if there is valid content.
 	 * @return string Content for this generated file
 	 */
-	public function getGeneratedContent($filename, $entropy = 0, $callback = null);
-
-	/**
-	 * Update content with new value
-	 *
-	 * @param string $filename
-	 * @param mixed $entropy
-	 * @param string $content Content to write to the backend
-	 */
-	public function updateContent($filename, $entropy, $content);
+	public function getGeneratedContent($filename, $entropy, $callback);
 }


### PR DESCRIPTION
Revert changes to ErrorPage

updateContent has been removed as it was an architecturally flawed API; Caching mechanisms cannot be reliably retrieved from later on in the future, unless provide a regeneration callback in case of cache "miss". As error page is not able to reliably provide this, I've opted to revert the use of this handler to the old behaviour, which writes to a custom filesystem directory.

Merge with https://github.com/silverstripe/silverstripe-cms/pull/1308