### PR TITLE
BUG Fix regression from #4396 in test fixtures

### DIFF
--- a/dev/FixtureBlueprint.php
+++ b/dev/FixtureBlueprint.php
@@ -192,6 +192,11 @@ class FixtureBlueprint {
 			if($data && array_key_exists('LastEdited', $data)) {
 				$this->overrideField($obj, 'LastEdited', $data['LastEdited'], $fixtures);
 			}
+
+			// Ensure Folder objects exist physically, as otherwise future File fixtures can't detect them
+			if($obj instanceof Folder) {
+				Filesystem::makeFolder($obj->getFullPath());
+			}
 		} catch(Exception $e) {
 			Config::inst()->update('DataObject', 'validation_enabled', $validationenabled);
 			throw $e;


### PR DESCRIPTION
During test initialisation, if a Folder is created it doesn't "exist" until the physical filesystem folder is created.

This means that if a File fixture has a folder as a parent, it will fail to attach during creation, and will end up being set to the root directory.

E.g. this fixture:


```yaml
Folder:
  folder1:
    Name: UploadFieldTest
File:
  file1:
    Title: File1
    Filename: assets/UploadFieldTest/file1.txt
    Parent: =>Folder.folder1
```

Will end up with a file in assets/file1.txt

The only way to ensure a created directory is valid is to create the underlying filesystem directory on the fly, immediately after saving it to the database (but before being assigned children).