### PR TITLE
FIX for #4710: Use INTERNAL dialogs instead of old alert() popups on server connection errors during ping.

### DIFF
--- a/admin/javascript/LeftAndMain.Ping.js
+++ b/admin/javascript/LeftAndMain.Ping.js
@@ -2,6 +2,13 @@
  * File: LeftAndMain.Ping.js
  */
 (function($) {
+	// TODO: Coping with an apparent bug in entwine namespacing! Normally $('.cms-container').entwine('ss') would still work even from within the 'ss.ping' namespace.
+	// TODO: Best solution for now at least may be to tweak the 'ss' namespace to just 'ss'.
+	var containerScope;
+	$.entwine('ss', function($){
+		containerScope = $('.cms-container');
+	});
+
 	$.entwine('ss.ping', function($){
 
 		$('.cms-container').entwine(/** @lends ss.Form_EditForm */{
@@ -21,16 +28,67 @@
 			 *
 			 * This function is called by prototype when it receives notification that the user was logged out.
 			 * It uses /Security/ping for this purpose, which should return '1' if a valid user session exists.
-			 * It redirects back to the login form if the URL is either unreachable, or returns '0'.
+			 * It opens the login form in a new window if the URL is either unreachable (doesn't return HTTP 200) or doesn't return the expected '1'.
 			 */
 			_setupPinging: function() {
+				var loginWindow;	// Reference to pop-up window generated if/when ping fails.
+				var dialog;			// Reference to message dialog, if one is ever opened.
+
 				var onSessionLost = function(xmlhttp, status) {
-					if(xmlhttp.status > 400 || xmlhttp.responseText == 0) {
-						// TODO will pile up additional alerts when left unattended
-						if(window.open('Security/login')) {
-							alert('Please log in and then try again');
-						} else {
-							alert('Please enable pop-ups for this site');
+					// See if we're getting a response that contains a request to re-authenticate. If so, do that now.
+					if (xmlhttp.getResponseHeader('X-Reauthenticate')) {
+						//TODO: Change to the following line when entwine bug is found/fixed.
+						// $('.cms-container').entwine('ss').showLoginDialog();
+						containerScope.showLoginDialog();
+
+					} else if(xmlhttp.responseText !== "1") {
+						// In this case, the server may not have even responded at all. To be safe, open a new window and
+						// show a default message requesting user to login, in case the login window is already open or
+						// opens successfully. This is necessary so we don't attempt to load a login iframe to a down
+						// server (better to do that in a new window instead).
+						var message = 'Please log in and then try again.';
+
+						if (!loginWindow || (loginWindow && loginWindow.closed)) {
+							// Window hasn't yet been opened (or has been closed but must be reopened again).
+							loginWindow = window.open('Security/login');
+							if(!loginWindow) message = 'Please enable pop-ups for this site.';
+						}
+
+						// Render message dialog now.
+						// TODO: This generic dialog code should be abstracted so it can be reused throughout the system in place of 90's style alert() dialogs.
+						dialog = $("#message-dialog");
+						window.testDialog = dialog;
+						if (dialog.length == 0) {
+							dialog = $('<div id="message-dialog" align="center"></div>');
+							$('body').append(dialog);
+						}
+						dialog.html('<h4>' + message + '</h4>');
+
+						dialog.ssdialog({
+							autoOpen: true,
+							minWidth: 450,
+							maxWidth: 450,
+							minHeight: 0,
+							maxHeight: 0,
+							closeOnEscape: true
+						});
+
+					} else {
+						if (loginWindow || dialog) {
+							// Close login window and warning dialog now that they are no longer necessary.
+							if (loginWindow) loginWindow.close();
+							if (dialog) dialog.remove();
+							loginWindow = dialog = null;
+
+							// However, we still want to confirm that the user still has a valid session (in case it timed
+							// out server-side). If this fails, we'll detect the presence of X-Reauthenticate and trigger
+							// the display of the standard login prompt within the page.
+							$.ajax({
+								url: 'Security/ping',
+								global: false,
+								type: 'POST',
+								complete: onSessionLost
+							});
 						}
 					}
 				};

--- a/admin/javascript/ssui.core.js
+++ b/admin/javascript/ssui.core.js
@@ -149,20 +149,22 @@
 			var self = this;
 
 			// Create iframe
-			var iframe = $('<iframe marginWidth="0" marginHeight="0" frameBorder="0" scrolling="auto"></iframe>');
-			iframe.bind('load', function(e) {
-				if($(this).attr('src') == 'about:blank') return;
+			if (this.options.iframeUrl) {
+				var iframe = $('<iframe marginWidth="0" marginHeight="0" frameBorder="0" scrolling="auto"></iframe>');
+				iframe.bind('load', function(e) {
+					if($(this).attr('src') == 'about:blank') return;
 
-				iframe.addClass('loaded').show(); // more reliable than 'src' attr check (in IE)
-				self._resizeIframe();
-				self.uiDialog.removeClass('loading');
-			}).hide();
+					iframe.addClass('loaded').show(); // more reliable than 'src' attr check (in IE)
+					self._resizeIframe();
+					self.uiDialog.removeClass('loading');
+				}).hide();
 
-			if(this.options.dialogExtraClass) this.uiDialog.addClass(this.options.dialogExtraClass);
-			this.element.append(iframe);
+				if(this.options.dialogExtraClass) this.uiDialog.addClass(this.options.dialogExtraClass);
+				this.element.append(iframe);
 
-			// Let the iframe handle its scrolling
-			if(this.options.iframeUrl) this.element.css('overflow', 'hidden');
+				// Let the iframe handle its scrolling
+				if(this.options.iframeUrl) this.element.css('overflow', 'hidden');
+			}
 		},
 		open: function() {
 			$.ui.dialog.prototype.open.call(this);

--- a/security/Security.php
+++ b/security/Security.php
@@ -376,7 +376,8 @@ class Security extends Controller implements TemplateGlobalProvider {
 	 * sessions don't timeout. A common use is in the admin.
 	 */
 	public function ping() {
-		return 1;
+		if (Member::currentUserID()) return 1;
+		return Security::permissionFailure($this);
 	}
 
 	/**


### PR DESCRIPTION
Fix to address #4710. Also adding login prompt, in case server connectivity issues last long enough to timeout session due to failed pings.

**Goals:**
- Use internal dialog instead of `alert()`, mainly to prevent window from stealing focus and for a less interrupted experience.
- Provide the opportunity for the user to log back in via more fail-safe method on server access errors, i.e. new window instead in case server is down and `<iframe>` is not able to load inline within page.
- Close the internal message dialog if everything is back to normal (at least in terms of server response).
- In case user ends up locked out of server long enough (due to downtime) and then their **session** times out, provide opportunity once server is back online to log back into session.

**What I had to change**
- Ping code, added more in-depth and specific checking on server response with more intelligent handling. Preventing display of multiple message over and over by checking for existing messages first.
- Minor tweak to `ssui.ssdialog` in `ssui.core.js` to not require an `<iframe>` by simply checking to see if a URL was passed. That way you can still toggle/style modal dialogs without having to load a URL. This is important here, given the server could be down!
- Performing an actual security check on `ping` (in the `Security` controller, no less) to facilitate more specific response checking client-side, which I think makes sense here.

**What is still needed**
- Fix the entwine namespacing issues (see below).
- Abstract that simple message code that I wrote to something reusable, maybe. I can see this being useful elsewhere; after modifying `ssui.ssdialog` in `ssui.core.js`, you no longer MUST have an `<iframe>` in order to display a nicely formatted SilverStripe dialog that just contains arbitrary HTML. I don't believe that you should have to create a tag; I think you should be able to call some sort of function (namespaced itself) and just give it the HTML or message you want to render. e.g. `$.ss.simpleModal("My message here.")`.

---

**IMPORTANT (unrelated to original PR):** Originally I was able to work with calling the following in older `3.1` code, but ended up having to perform a hack/workaround to deal with a potential bug (or change?) in entwine namespacing. That is, calling this would work from within the `ss.ping` entwine namespace:

``` js
$('.cms-container').entwine('ss').showLoginDialog();
```

Now, I have to resort to something more like this in order to steal from the _working_ scope of `ss` on its own, since this no longer works inside of the `ss.ping` scope:

``` js
var containerScope;
$.entwine('ss', function($){
    containerScope = $('.cms-container');
    window.containerScope = containerScope;
});

$.entwine('ss.ping', function($){
    $('.cms-container').entwine({
        _setupPinging: function () {
            containerScope.showLoginDialog();
        }
    });
});
```
