### PR TITLE
BUG Add missing CMSSecurity route

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -15,6 +15,7 @@ After:
 Director:
   rules:
     'Security//$Action/$ID/$OtherID': 'Security'
+    'CMSSecurity//$Action/$ID/$OtherID': 'CMSSecurity'
     'dev': 'DevelopmentAdmin'
     'interactive': 'SapphireREPL'
     'InstallerTest//$Action/$ID/$OtherID': 'InstallerTest'


### PR DESCRIPTION
It appears that this broke when controller routes were made to require manual registration.