### PR TITLE
Don't try to unbind events from inside top-level iframes

### DIFF
--- a/admin/javascript/LeftAndMain.ActionTabSet.js
+++ b/admin/javascript/LeftAndMain.ActionTabSet.js
@@ -28,7 +28,7 @@
 				// Remove all bound events.
 				// This guards against an edge case where the click handlers are not unbound
 				// because the panel is still open when the ajax edit form reloads.
-				var frame = $('.cms').find('iframe');
+				var frame = $('.cms-container').find('iframe');
 				frame.each(function(index, iframe){
 					$(iframe).contents().off('click.ss-ui-action-tabset');
 				});
@@ -58,7 +58,7 @@
 			 * Note: Should be called by a click event attached to 'this'
 			 */
 			attachCloseHandler: function(event, ui) {
-				var that = this, frame = $('.cms').find('iframe'), closeHandler;
+				var that = this, frame = $('.cms-container').find('iframe'), closeHandler;
 
 				// Create a handler for the click event so we can close tabs
 				// and easily remove the event once done
@@ -74,7 +74,7 @@
 						that.tabs('option', 'active', false); // close tabs
 
 						// remove click event from objects it is bound to (iframe's and document)
-						frame = $('.cms').find('iframe');
+						frame = $('.cms-container').find('iframe');
 						frame.each(function(index, iframe){
 							$(iframe).contents().off('click.ss-ui-action-tabset', closeHandler);
 						});


### PR DESCRIPTION
Some JavaScript APIs (notably all Google APIs) rely on inserting a hidden iframe within the body.

`LeftAndMain.ActionTabSet.js` has functionality to find all iframes and unbind all JS events within the interior pages. This ends up trying to access the contents of an iframe on Google's domain resulting in CORS errors and halting further JavaScript execution in the Admin.

There should perhaps be a wider discussion here around trying to check whether an iframe is internal or external before attempting to access the contents, but in the meantime this will unblock iframes that are direct children of `body`/`.cms` which will cover most iframes that are inserted by third-party JavaScript.

As far as I can tell the iframes we are trying to target for this unbinding operation will always be within `.cms-container`.