### PR TITLE
BUGFIX: Use Object->hasMethod() instead of method_exists()

### DIFF
--- a/forms/gridfield/GridField.php
+++ b/forms/gridfield/GridField.php
@@ -149,7 +149,7 @@ class GridField extends FormField {
 			return $this->modelClassName;
 		}
 
-		if($this->list && method_exists($this->list, 'dataClass')) {
+		if($this->list && $this->list->hasMethod('dataClass')) {
 			$class = $this->list->dataClass();
 
 			if($class) {


### PR DESCRIPTION
BUGFIX: Use `Object->hasMethod()` instead of `method_exists()`

This fixes an issue when you pass a `PaginatedList` back from `ModelAdmin::getList()`. The original issue can be replicated with the following:
```php
<?php
class AdminTest extends ModelAdmin {
    private static $managed_models = array('SiteTree');
    private static $url_segment = 'test';
    private static $menu_title = 'Test';

    public function getList() {
        return new PaginatedList(parent::getList(), $this->request);
}
```