### PR TITLE
BUGFIX: If ->loadDataFrom is given an array, allow multiples for namespaced keys

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -1416,10 +1416,13 @@ class Form extends RequestHandler {
 					// First encode data using PHP's method of converting nested arrays to form data
 					$flatData = urldecode(http_build_query($data));
 					// Then pull the value out from that flattened string
-					preg_match('/' . addcslashes($name,'[]') . '=([^&]*)/', $flatData, $matches);
+					preg_match_all('/' . addcslashes($name,'[]') . '[^=]*=([^&]*)/', $flatData, $matches);
 
-					if (isset($matches[1])) {
+					if (isset($matches[1]) && sizeof($matches[1]) == 1) {
 						$exists = true;
+						$val = $matches[1][0];
+					} elseif(isset($matches[1])) {
+						$exists	= true;
 						$val = $matches[1];
 					}
 				}

--- a/tests/forms/FormTest.php
+++ b/tests/forms/FormTest.php
@@ -32,12 +32,21 @@ class FormTest extends FunctionalTest {
 				new TextField('key1'),
 				new TextField('namespace[key2]'),
 				new TextField('namespace[key3][key4]'),
-				new TextField('othernamespace[key5][key6][key7]')
+				new TextField('othernamespace[key5][key6][key7]'),
+				new CheckboxsetField('namespace2[Key1][Key2]', 'CheckboxsetField', array(
+					1 => "Monday",
+					2 => "Tuesday",
+					3 => "Wednesday",
+					4 => "Thursday",
+					5 => "Friday",
+					6 => "Saturday",
+					7 => "Sunday"
+				))
 			),
 			new FieldList()
 		);
 
-		// url would be ?key1=val1&namespace[key2]=val2&namespace[key3][key4]=val4&othernamespace[key5][key6][key7]=val7
+		// url would be ?key1=val1&namespace[key2]=val2&namespace[key3][key4]=val4&othernamespace[key5][key6][key7]=val7&namespace2[Key1][Key2][1]=1&namespace2[Key1][Key2][4]=4
 		$requestData = array(
 			'key1' => 'val1',
 			'namespace' => array(
@@ -52,6 +61,14 @@ class FormTest extends FunctionalTest {
 						'key7' => 'val7'
 					)
 				)
+			),
+			'namespace2' => array(
+				'Key1' => array(
+					'Key2' => array(
+						1 => '1',
+						4 => '4'
+					)
+				)
 			)
 		);
 
@@ -62,6 +79,7 @@ class FormTest extends FunctionalTest {
 		$this->assertEquals($fields->fieldByName('namespace[key2]')->Value(), 'val2');
 		$this->assertEquals($fields->fieldByName('namespace[key3][key4]')->Value(), 'val4');
 		$this->assertEquals($fields->fieldByName('othernamespace[key5][key6][key7]')->Value(), 'val7');
+		$this->assertEquals($fields->fieldByName('namespace2[Key1][Key2]')->Value(), array('1', '4'));
 	}
 
 	public function testLoadDataFromUnchangedHandling() {


### PR DESCRIPTION
When `Form->loadDataFrom()` is passed an array for `$data` (e.g. what selecting
multiple values for a `CheckboxsetField` would do), this allows those values to
be correctly set by `loadDataFrom`.

I can probably provide a reproducible test case if required, for me it
manifested in a `GridField` inside a `ModelAdmin` `GridField` on a
`CheckboxsetField` which has a field name something like `Schedule[Daily][Days]`,
which means e.g. the first value would be `Schedule[Daily][Days][1] = 1`.