### PR TITLE
BUG Prevent dev/build continually regenerating Number field type

### DIFF
--- a/model/connect/MySQLSchemaManager.php
+++ b/model/connect/MySQLSchemaManager.php
@@ -407,15 +407,17 @@ class MySQLSchemaManager extends DBSchemaManager {
 			$precision = $values['precision'];
 		}
 
-		$defaultValue = '';
+		// Fix format of default value to match precision
 		if (isset($values['default']) && is_numeric($values['default'])) {
 			$decs = strpos($precision, ',') !== false
 					? (int) substr($precision, strpos($precision, ',') + 1)
 					: 0;
-			$defaultValue = ' default ' . number_format($values['default'], $decs, '.', '');
+			$values['default'] = number_format($values['default'], $decs, '.', '');
+		} else {
+			unset($values['default']);
 		}
 
-		return "decimal($precision) not null $defaultValue";
+		return "decimal($precision) not null" . $this->defaultClause($values);
 	}
 
 	/**

--- a/tests/model/DataObjectSchemaGenerationTest.php
+++ b/tests/model/DataObjectSchemaGenerationTest.php
@@ -178,6 +178,11 @@ class DataObjectSchemaGenerationTest_DO extends DataObject implements TestOnly {
 	private static $db = array(
 		'Enum1' => 'Enum("A, B, C, D","")',
 		'Enum2' => 'Enum("A, B, C, D","A")',
+		'NumberField' => 'Decimal',
+		'FloatingField' => 'Decimal(10,3,1.1)',
+		'TextValue' => 'Varchar',
+		'Date' => 'SS_Datetime',
+		'MyNumber' => 'Int'
 	);
 }
 


### PR DESCRIPTION
This is because the default value thinks `0.00` and `'0.00'` are different values, and continually attempts to rebuild the database.