### PR TITLE
Check for id attributes for anchor targets and prevent partial matches

### DIFF
--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -519,7 +519,7 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 			}
 
 			// Similar to the regex found in HtmlEditorField.js / getAnchors method.
-			if (preg_match_all("/name=\"([^\"]+?)\"|name='([^']+?)'/im", $page->Content, $matches)) {
+			if (preg_match_all("/\s(name|id)=\"([^\"]+?)\"|\s(name|id)='([^']+?)'/im", $page->Content, $matches)) {
 				$anchors = $matches[1];
 			}
 

--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -716,10 +716,11 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 						// http://www.w3.org/TR/1999/REC-html401-19991224/struct/links.html#h-12.2
 
 						if(ed) {
-							var raw = ed.getContent().match(/name="([^"]+?)"|name='([^']+?)'/gim);
+							var raw = ed.getContent().match(/\s(name|id)="([^"]+?)"|\s(name|id)='([^']+?)'/gim);
 							if (raw && raw.length) {
 								for(var i = 0; i < raw.length; i++) {
-									collectedAnchors.push(raw[i].substr(6).replace(/"$/, ''));
+									var indexStart = (raw[i].indexOf('id=') == -1) ? 7 : 5;
+									collectedAnchors.push(raw[i].substr(indexStart).replace(/"$/, ''));
 								}
 							}
 						}


### PR DESCRIPTION
Detects id attributes as well as names when looking for anchor targets.
Prevents partial matches e.g. `<a data-myname="foo">` will no longer match.