### PR TITLE
Corrected TotalItems() method to use Count(). (fixes #4646)

### DIFF
--- a/model/ListDecorator.php
+++ b/model/ListDecorator.php
@@ -81,7 +81,7 @@ abstract class SS_ListDecorator extends ViewableData implements SS_List, SS_Sort
 	}
 
 	public function TotalItems() {
-		return $this->list->TotalItems();
+		return $this->list->Count();
 	}
 
 	public function Count() {

--- a/tests/model/GroupedListTest.php
+++ b/tests/model/GroupedListTest.php
@@ -123,4 +123,31 @@ class GroupedListTest extends SapphireTest {
 		}
 	}
 
+	public function testTotalItems() {
+		$list = GroupedList::create(
+			ArrayList::create(
+				array(
+					ArrayData::create(array(
+						'Name' => 'AAA',
+						'Number' => '111',
+					)),
+					ArrayData::create(array(
+						'Name' => 'BBB',
+						'Number' => '111',
+					)),
+					ArrayData::create(array(
+						'Name'   => 'AAA',
+						'Number' => '222',
+					)),
+					ArrayData::create(array(
+						'Name'   => 'BBB',
+						'Number' => '111',
+					))
+				)
+			)
+		);
+
+		$this->assertEquals(4, $list->TotalItems());
+	}
+
 }


### PR DESCRIPTION
I have also added a test case to GroupedListTest to cover this particular method (the entire ListDecorator class should probably be covered by unit tests to avoid similar bugs in the future).