### PR TITLE
FIX xml links in SVG not being re-written

### DIFF
--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -1176,7 +1176,6 @@ after')
 	}
 
 	public function testRewriteHashlinks() {
-		$orig = Config::inst()->get('SSViewer', 'rewrite_hash_links'); 
 		Config::inst()->update('SSViewer', 'rewrite_hash_links', true);
 
 		$_SERVER['HTTP_HOST'] = 'www.mysite.com';
@@ -1199,6 +1198,7 @@ after')
 				<a class="inline" href="#anchor">InlineLink</a>
 				$InsertedLink
 				<svg><use xlink:href="#sprite"></use></svg>
+				<a class="wrong-href" href="#test" data-href="#test">wronghreflink</a>
 				<body>
 			</html>');
 		$tmpl = new SSViewer($tmplFile);
@@ -1219,6 +1219,10 @@ after')
 			$result
 		);
 		$this->assertContains(
+			'<a class="wrong-href" href="' . $base . '#test" data-href="#test">wronghreflink</a>',
+			$result
+		);
+		$this->assertContains(
 			'<a class="external-inline" href="http://google.com#anchor">ExternalInlineLink</a>',
 			$result
 		);
@@ -1229,8 +1233,6 @@ after')
 		);
 
 		unlink($tmplFile);
-
-		Config::inst()->update('SSViewer', 'rewrite_hash_links', $orig); 
 	}
 	
 	public function testRewriteHashlinksInPhpMode() {

--- a/view/SSViewer.php
+++ b/view/SSViewer.php
@@ -1116,7 +1116,7 @@ class SSViewer implements Flushable {
 					$thisURLRelativeToBase = Convert::raw2att(preg_replace("/^(\\/)+/", "/", $_SERVER['REQUEST_URI']));
 				}
 
-				$output = preg_replace('/(<a[^>]+href *= *)"#/i', '\\1"' . $thisURLRelativeToBase . '#', $output);
+				$output = preg_replace('/(<[a-z][^>]+\s*href\s*=\s*)[\'"]?#/i', '\\1"' . $thisURLRelativeToBase . '#', $output);
 			}
 		}
 


### PR DESCRIPTION
With SVG sprites you can do the following:

```xml
<svg class="icon">
    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-blah"></use>
</svg>
```

However, the xlink:href is not picked up because it is not an `<a>`.

This patch allows `href`s on any tag being re-written.