### PR TITLE
FIX: prevent use cache on browser back button

### DIFF
--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -384,7 +384,7 @@ class HTTP {
 				// prefer the caching information indicated through the "Cache-Control" header.
 				$responseHeaders["Pragma"] = "";
 			} else {
-				$responseHeaders["Cache-Control"] = "no-cache, max-age=0, must-revalidate, no-transform";
+				$responseHeaders["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate, no-transform";
 			}
 		}
 


### PR DESCRIPTION
Header "Cache-Control: no-store" prevents browsers from using cache when going back in browser history.

To replicate: 
1. login to /admin
2. go to a page in the admin
3. hit logout button
4. (depending on browser) right click on back button and select the page you were just on

Expected: authentication error.
Actual: page content is shown, and you can read it. Authentication error shows over top.

See: http://stackoverflow.com/questions/866822/why-both-no-cache-and-no-store-should-be-used-in-http-response