### PR TITLE
ENHANCEMENT CurrencyField to use Currency.currency_symbol

### DIFF
--- a/forms/CurrencyField.php
+++ b/forms/CurrencyField.php
@@ -17,7 +17,7 @@ class CurrencyField extends TextField {
 	 */
 	public function setValue($val) {
 		if(!$val) $val = 0.00;
-		$this->value = '$' . number_format((double)preg_replace('/[^0-9.\-]/', '', $val), 2);
+		$this->value = Config::inst()->get('Currency','currency_symbol') . number_format((double)preg_replace('/[^0-9.\-]/', '', $val), 2);
 		return $this;
 	}
 	/**
@@ -44,8 +44,10 @@ class CurrencyField extends TextField {
 	}
 
 	public function validate($validator) {
+        $currencySymbol = preg_quote(Config::inst()->get('Currency','currency_symbol'));
+        $regex = '/^\s*(\-?'.$currencySymbol.'?|'.$currencySymbol.'\-?)?(\d{1,3}(\,\d{3})*|(\d+))(\.\d{2})?\s*$/';
 		if(!empty ($this->value)
-				&& !preg_match('/^\s*(\-?\$?|\$\-?)?(\d{1,3}(\,\d{3})*|(\d+))(\.\d{2})?\s*$/', $this->value)) {
+				&& !preg_match($regex, $this->value)) {
 
 			$validator->validationError($this->name, _t('Form.VALIDCURRENCY', "Please enter a valid currency"),
 				"validation", false);

--- a/tests/forms/CurrencyFieldTest.php
+++ b/tests/forms/CurrencyFieldTest.php
@@ -10,6 +10,7 @@ class CurrencyFieldTest extends SapphireTest {
 		$f = new CurrencyField('TestField');
 		$validator = new RequiredFields();
 
+        //tests with default currency symbol setting
 		$f->setValue('123.45');
 		$this->assertTrue(
 			$f->validate($validator),
@@ -57,11 +58,63 @@ class CurrencyFieldTest extends SapphireTest {
 			$f->validate($validator),
 			'Words are valid'
 		);
+
+        //tests with updated currency symbol setting
+        Config::inst()->update('Currency', 'currency_symbol', '€');
+
+        $f->setValue('123.45');
+        $this->assertTrue(
+            $f->validate($validator),
+            'Validates positive decimals'
+        );
+
+        $f->setValue('-123.45');
+        $this->assertTrue(
+            $f->validate($validator),
+            'Validates negative decimals'
+        );
+
+        $f->setValue('€123.45');
+        $this->assertTrue(
+            $f->validate($validator),
+            'Validates positive decimals with sign'
+        );
+
+        $f->setValue('-€123.45');
+        $this->assertTrue(
+            $f->validate($validator),
+            'Validates negative decimals with sign'
+        );
+
+        $f->setValue('€-123.45');
+        $this->assertTrue(
+            $f->validate($validator),
+            'Validates negative decimals with sign'
+        );
+
+        $f->setValue('324511434634');
+        $this->assertTrue(
+            $f->validate($validator),
+            'Validates large integers'
+        );
+
+        $f->setValue('test€1.23test');
+        $this->assertTrue(
+            $f->validate($validator),
+            'Alphanumeric is valid'
+        );
+
+        $f->setValue('€test');
+        $this->assertTrue(
+            $f->validate($validator),
+            'Words are valid'
+        );
 	}
 
 	public function testSetValue() {
 		$f = new CurrencyField('TestField');
 
+        //tests with default currency symbol setting
 		$f->setValue('123.45');
 		$this->assertEquals(
 			$f->value, '$123.45',
@@ -109,11 +162,63 @@ class CurrencyFieldTest extends SapphireTest {
 			$f->value, '$0.00',
 			'Does not set alpha values'
 		);
-	}
+
+        //update currency symbol via config
+        Config::inst()->update('Currency', 'currency_symbol', '€');
+
+        $f->setValue('123.45');
+        $this->assertEquals(
+            $f->value, '€123.45',
+            'Prepends dollar sign to positive decimal'
+        );
+
+        $f->setValue('-123.45');
+        $this->assertEquals(
+            $f->value, '€-123.45',
+            'Prepends dollar sign to negative decimal'
+        );
+
+        $f->setValue('€1');
+        $this->assertEquals(
+            $f->value, '€1.00',
+            'Formats small value'
+        );
+
+        $f->setValue('€2.5');
+        $this->assertEquals(
+            $f->value, '€2.50',
+            'Formats small value'
+        );
+
+        $f->setValue('€2500000.13');
+        $this->assertEquals(
+            $f->value, '€2,500,000.13',
+            'Formats large value'
+        );
+
+        $f->setValue('€2.50000013');
+        $this->assertEquals(
+            $f->value, '€2.50',
+            'Truncates long decimal portions'
+        );
+
+        $f->setValue('test123.00test');
+        $this->assertEquals(
+            $f->value, '€123.00',
+            'Strips alpha values'
+        );
+
+        $f->setValue('test');
+        $this->assertEquals(
+            $f->value, '€0.00',
+            'Does not set alpha values'
+        );
+    }
 
 	public function testDataValue() {
 		$f = new CurrencyField('TestField');
 
+        //tests with default currency symbol settings
 		$f->setValue('$123.45');
 		$this->assertEquals(
 			$f->dataValue(), 123.45
@@ -128,5 +233,23 @@ class CurrencyFieldTest extends SapphireTest {
 		$this->assertEquals(
 			$f->dataValue(), -123.45
 		);
+
+        //tests with updated currency symbol setting
+        Config::inst()->update('Currency', 'currency_symbol', '€');
+
+        $f->setValue('€123.45');
+        $this->assertEquals(
+            $f->dataValue(), 123.45
+        );
+
+        $f->setValue('-€123.45');
+        $this->assertEquals(
+            $f->dataValue(), -123.45
+        );
+
+        $f->setValue('€-123.45');
+        $this->assertEquals(
+            $f->dataValue(), -123.45
+        );
 	}
 }


### PR DESCRIPTION
fixes #4035

I have limited experience with regex, so I hope I did it correctly. I was able to save/save & publish with the curent regex and the values look good.