### PR TITLE
Cache the merged config to a persistent cache

### DIFF
--- a/core/ConfigCacheInterface.php
+++ b/core/ConfigCacheInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+interface ConfigCacheInterface {
+
+	/**
+	 * @param string $key
+	 * @param mixed $val
+	 * @param array $tags
+	 */
+	public function set($key, $val, $tags = array());
+
+	/**
+	 * @param string $key
+	 */
+	public function get($key);
+
+	/**
+	 * @param string|null $tag
+	 */
+	public function clean($tag = null); 
+
+	/**
+	 * Cache hit/miss stats
+	 *
+	 * @return int|float
+	 */
+	public function stats();
+
+}
+

--- a/core/Core.php
+++ b/core/Core.php
@@ -61,6 +61,7 @@ gc_enable();
 
 // Include the files needed the initial manifest building, as well as any files
 // that are needed for the boostrap process on every request.
+require_once 'core/ConfigCacheInterface.php';
 require_once 'cache/Cache.php';
 require_once 'core/Object.php';
 require_once 'core/ClassInfo.php';

--- a/core/Core.php
+++ b/core/Core.php
@@ -62,6 +62,7 @@ gc_enable();
 // Include the files needed the initial manifest building, as well as any files
 // that are needed for the boostrap process on every request.
 require_once 'core/ConfigCacheInterface.php';
+require_once 'core/Flushable.php';
 require_once 'cache/Cache.php';
 require_once 'core/Object.php';
 require_once 'core/ClassInfo.php';

--- a/docs/en/00_Getting_Started/03_Environment_Management.md
+++ b/docs/en/00_Getting_Started/03_Environment_Management.md
@@ -125,3 +125,4 @@ This is my `_ss_environment.php` file. I have it placed in `/var`, as each of th
 | `SS_SEND_ALL_EMAILS_TO`| If you define this constant, all emails will be redirected to this address.|
 | `SS_SEND_ALL_EMAILS_FROM`| If you define this constant, all emails will be sent from this address.|
 | `SS_ERROR_LOG` | Relative path to the log file. |
+| `SS_PERSISTENTCONFIGCACHE` | Define the persistent config class to use. This must implement the ConfigCacheInterface. |

--- a/tests/core/ConfigTest.php
+++ b/tests/core/ConfigTest.php
@@ -267,105 +267,72 @@ class ConfigTest extends SapphireTest {
 	}
 
 	public function testCacheCleaning() {
-		$cache = new ConfigTest_Config_MemCache();
+		$cache = new Config_MemCache();
+		$cacheProp = new ReflectionProperty('Config_MemCache', 'cache');
+		$cacheProp->setAccessible(true);
+
+		$tagProp = new ReflectionProperty('Config_MemCache', 'tags');
+		$tagProp->setAccessible(true);
 
 		for ($i = 0; $i < 1000; $i++) $cache->set($i, $i);
-		$this->assertEquals(1000, count($cache->persistentCacheData));
-
-		// Attempt to completely empty the cache.
-		// This should empty the entire cache
+		$this->assertEquals(1000, count($cacheProp->getValue($cache)));
 		$cache->clean();
-		$this->assertEmpty($cache->tags, 'Clean clears all items');
-		$this->assertEmpty($cache->disabledPersistentCache, 'Clean clears all items');
-		$this->assertEmpty($cache->persistentCacheData, 'Clean clears all items');
-		$this->assertEmpty($cache->cache, 'Clean clears all items');
-		$this->assertFalse($cache->get('MyKey'), 'Clean clears all items');
-
-		// This should be added to persistent cache
-		$cache->set('MyKey', 1, array('Foo'));
-		$this->assertCount(1, $cache->tags);
-		$this->assertEmpty($cache->disabledPersistentCache, 'Nothing should be disabled');
-		$this->assertCount(1, $cache->persistentCacheData);
-		$this->assertEmpty($cache->cache);
-		$this->assertEquals($cache->get('MyKey'), 1);
-
-		// This should be removed from persistent cache and disable persistent cache for
-		// the key 'MyKey' in future set calls
+		$this->assertEquals(0, count($cacheProp->getValue($cache)), 'Clean clears all items');
+		$this->assertFalse($cache->get(1), 'Clean clears all items');
+		$cache->set(1, 1, array('Foo'));
+		$this->assertEquals(1, count($cacheProp->getValue($cache)));
+		$this->assertEquals(1, count($tagProp->getValue($cache)));
 		$cache->clean('Foo');
-		$this->assertCount(0, $cache->tags, 'Clean items with matching tag');
-		$this->assertCount(1, $cache->disabledPersistentCache, 'Cache should be empty');
-		$this->assertCount(0, $cache->persistentCacheData, 'Cache should be empty');
-		$this->assertCount(0, $cache->cache, 'Cache should be empty');
-		$this->assertFalse($cache->get('MyKey'), 'Clean items with matching tag');
-
-		// We're setting 1 again, so this should go into the runtime cache ($cache->cache);
-		$cache->set('MyKey', 1, array('Foo', 'Bar'));
-		$this->assertCount(2, $cache->tags);
-		$this->assertCount(1, $cache->disabledPersistentCache);
-		$this->assertCount(0, $cache->persistentCacheData);
-		$this->assertCount(1, $cache->cache);
-		$this->assertEquals(1, $cache->get('MyKey'));
-
-		// Bar is the last tagged item so everything should be empty
+		$this->assertEquals(0, count($tagProp->getValue($cache)), 'Clean items with matching tag');
+		$this->assertFalse($cache->get(1), 'Clean items with matching tag');
+		$cache->set(1, 1, array('Foo', 'Bar'));
+		$this->assertEquals(2, count($tagProp->getValue($cache)));
+		$this->assertEquals(1, count($cacheProp->getValue($cache)));
 		$cache->clean('Bar');
-		$this->assertCount(1, $cache->tags);
-		$this->assertCount(1, $cache->disabledPersistentCache);
-		$this->assertCount(0, $cache->persistentCacheData, 'Clean items with any single matching tag');
-		$this->assertCount(0, $cache->cache);
-		$this->assertFalse($cache->get('MyKey'), 'Clean items with any single matching tag');
+		$this->assertEquals(1, count($tagProp->getValue($cache)));
+		$this->assertEquals(0, count($cacheProp->getValue($cache)), 'Clean items with any single matching tag');
+		$this->assertFalse($cache->get(1), 'Clean items with any single matching tag');
 	}
 
 	public function testLRUDiscarding() {
-		$cache = new ConfigTest_Config_LRU();
+		$indexing = new ReflectionProperty('Config_LRU', 'indexing');
+		$indexing->setAccessible(true);
+
+		$cache = new Config_LRU();
 		for ($i = 0; $i < Config_LRU::SIZE*2; $i++) $cache->set($i, $i);
 		$this->assertEquals(
-			Config_LRU::SIZE, count($cache->indexing),
+			Config_LRU::SIZE, count($indexing->getValue($cache)),
 			'Homogenous usage gives exact discarding'
 		);
-		$cache = new ConfigTest_Config_LRU();
+		$cache = new Config_LRU();
 		for ($i = 0; $i < Config_LRU::SIZE; $i++) $cache->set($i, $i);
 		for ($i = 0; $i < Config_LRU::SIZE; $i++) $cache->set(-1, -1);
 		$this->assertLessThan(
-			Config_LRU::SIZE, count($cache->indexing),
+			Config_LRU::SIZE, count($indexing->getValue($cache)),
 			'Heterogenous usage gives sufficient discarding'
 		);
 	}
 
 	public function testLRUCleaning() {
-		$cache = new ConfigTest_Config_LRU();
+		$indexing = new ReflectionProperty('Config_LRU', 'indexing');
+		$indexing->setAccessible(true);
+
+		$cache = new Config_LRU();
 		for ($i = 0; $i < Config_LRU::SIZE; $i++) $cache->set($i, $i);
-		$this->assertEquals(Config_LRU::SIZE, count($cache->indexing));
+		$this->assertEquals(Config_LRU::SIZE, count($indexing->getValue($cache)));
 		$cache->clean();
-		$this->assertEquals(0, count($cache->indexing), 'Clean clears all items');
+		$this->assertEquals(0, count($indexing->getValue($cache)), 'Clean clears all items');
 		$this->assertFalse($cache->get(1), 'Clean clears all items');
 		$cache->set(1, 1, array('Foo'));
-		$this->assertEquals(1, count($cache->indexing));
+		$this->assertEquals(1, count($indexing->getValue($cache)));
 		$cache->clean('Foo');
-		$this->assertEquals(0, count($cache->indexing), 'Clean items with matching tag');
+		$this->assertEquals(0, count($indexing->getValue($cache)), 'Clean items with matching tag');
 		$this->assertFalse($cache->get(1), 'Clean items with matching tag');
 		$cache->set(1, 1, array('Foo', 'Bar'));
-		$this->assertEquals(1, count($cache->indexing));
+		$this->assertEquals(1, count($indexing->getValue($cache)));
 		$cache->clean('Bar');
-		$this->assertEquals(0, count($cache->indexing), 'Clean items with any single matching tag');
+		$this->assertEquals(0, count($indexing->getValue($cache)), 'Clean items with any single matching tag');
 		$this->assertFalse($cache->get(1), 'Clean items with any single matching tag');
 	}
 }
 
-class ConfigTest_Config_LRU extends Config_LRU implements TestOnly {
-	public $cache;
-	public $indexing;
-}
-
-class ConfigTest_Config_MemCache extends Config_MemCache implements TestOnly {
-	
-	public $cache;
-	public $persistentCacheData;
-	public $disabledPersistentCache;
-	public $tags;
-
-	public function __construct() {
-		parent::__construct();
-		$this->persistentCacheData = array();
-	}
-
-}


### PR DESCRIPTION
This caches merged config to a persistent cache so that it doesn't have to merge on each request.

Initial tests show page load times on a base installation drop from ~~2 seconds to 0.35 seconds~~ (edit: not properly performance tested).

I'll provide more data shortly.

**Key**
localhost:8181 - **master**
vagrant:8181 - **pre-merge-config**