### PR TITLE
BUG: Implode url GET var to deal with array input

### DIFF
--- a/core/Core.php
+++ b/core/Core.php
@@ -96,7 +96,7 @@ Injector::set_inst($injector);
 // Regenerate the manifest if ?flush is set, or if the database is being built.
 // The coupling is a hack, but it removes an annoying bug where new classes
 // referenced in _config.php files can be referenced during the build process.
-$requestURL = isset($_REQUEST['url']) ? trim($_REQUEST['url'], '/') : false;
+$requestURL = isset($_REQUEST['url']) ? trim(is_array($_REQUEST['url']) ? implode($_REQUEST['url']) : $_REQUEST['url'], '/') : false;
 $flush = (isset($_GET['flush']) || $requestURL === trim(BASE_URL . '/dev/build', '/'));
 
 global $manifest;

--- a/main.php
+++ b/main.php
@@ -84,7 +84,7 @@ if (isset($_GET['url']) && php_sapi_name() !== 'cli-server') {
 		$parseQuery($queryString);
 	}
 
-	$url = $_GET['url'];
+	$url = is_array($_REQUEST['url']) ? implode($_GET['url']) : $_GET['url'];
 
 	// IIS includes get variables in url
 	$i = strpos($url, '?');

--- a/main.php
+++ b/main.php
@@ -84,7 +84,7 @@ if (isset($_GET['url']) && php_sapi_name() !== 'cli-server') {
 		$parseQuery($queryString);
 	}
 
-	$url = is_array($_REQUEST['url']) ? implode($_GET['url']) : $_GET['url'];
+	$url = is_array($_GET['url']) ? implode($_GET['url']) : $_GET['url'];
 
 	// IIS includes get variables in url
 	$i = strpos($url, '?');


### PR DESCRIPTION
Silverstripe expects the url var to be a string and functions like trim() will fail if it is an array. Also possible security concern as errors are shown to the end user.

http://www.silverstripe.org/?url[]=test
