### PR TITLE
FIX Words ending ay/ey/iy/oy/uy are not pluralised correctly

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -781,7 +781,10 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 			return $name;
 		} else {
 			$name = $this->singular_name();
-			if(substr($name,-1) == 'y') $name = substr($name,0,-1) . 'ie';
+			//if the penultimate character is not a vowel, replace "y" with "ies"
+			if (preg_match('/[^aeiou]y$/i', $name)) {
+				$name = substr($name,0,-1) . 'ie';
+			}
 			return ucfirst($name . 's');
 		}
 	}

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -26,6 +26,9 @@ class DataObjectTest extends SapphireTest {
 		'DataObjectTest_Staff',
 		'DataObjectTest_CEO',
 		'DataObjectTest_Fan',
+		'DataObjectTest_Play',
+		'DataObjectTest_Ploy',
+		'DataObjectTest_Bogey',
 	);
 
 	public function testDb() {
@@ -1341,7 +1344,10 @@ class DataObjectTest extends SapphireTest {
 		$assertions = array(
 			'DataObjectTest_Player'       => 'Data Object Test Players',
 			'DataObjectTest_Team'         => 'Data Object Test Teams',
-			'DataObjectTest_Fixture'      => 'Data Object Test Fixtures'
+			'DataObjectTest_Fixture'      => 'Data Object Test Fixtures',
+			'DataObjectTest_Play'         => 'Data Object Test Plays',
+			'DataObjectTest_Bogey'        => 'Data Object Test Bogeys',
+			'DataObjectTest_Ploy'         => 'Data Object Test Ploys',
 		);
 
 		foreach($assertions as $class => $expectedPluralName) {
@@ -1936,6 +1942,10 @@ class DataObjectTest_ExtendedTeamComment extends DataObjectTest_TeamComment {
 		'Comment' => 'HTMLText'
 	);
 }
+
+class DataObjectTest_Play extends DataObject implements TestOnly {}
+class DataObjectTest_Ploy extends DataObject implements TestOnly {}
+class DataObjectTest_Bogey extends DataObject implements TestOnly {}
 
 DataObjectTest_Team::add_extension('DataObjectTest_Team_Extension');
 


### PR DESCRIPTION
Words that end in a vowel and then a "y" should have an "s" added to the end, not  have the "y" replaced with "ies".

play -> plays