### PR TITLE
BUG prevent UploadField edit form generation for Folders

### DIFF
--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -1432,6 +1432,10 @@ class UploadField_ItemHandler extends RequestHandler {
 	 */
 	public function EditForm() {
 		$file = $this->getItem();
+		if(!$file) return $this->httpError(404);
+		if($file instanceof Folder) return $this->httpError(403);
+		if(!$file->canEdit()) return $this->httpError(403);
+		
 		// Get form components
 		$fields = $this->parent->getFileEditFields($file);
 		$actions = $this->parent->getFileEditActions($file);


### PR DESCRIPTION
This is actually a tiny minor issue, and only really manifests itself in edge-case testing.

If you attempt to resolve the edit form for a Folder DataObject it should fail. However, in some situations the edit form will be generated, but fail with a validation error on submission, resulting in an obscure `Exception: Object->__call(): the method 'redirectback' does not exist on 'UploadField_ItemHandler'` error.

This moves the error up to before the form is generated.