### PR TITLE
DOCS Suggesting a convention for CMS user documentation so CMS users …

### DIFF
--- a/docs/en/02_Developer_Guides/05_Extending/00_Modules.md
+++ b/docs/en/02_Developer_Guides/05_Extending/00_Modules.md
@@ -137,6 +137,7 @@ Documentation will use the following format:
  * A changelog CHANGELOG.md (may link to other more detailed docs or GitHub releases if you want).
  * Has a licence (LICENSE.md file) - for SilverStripe supported this needs to be BSD.
  * Detailed documentation in /docs/en as a nested set of GitHub-compatible Markdown files.
+ * It is suggested to use a documentation page named `userguide.md` in `docs/en/` that includes documentation of module features that have CMS user functionality (if applicable). For modules with large userguides, this should be in a directory named `userguide` with an `index.md` linking to any other userguide pages.
  * Links and image references are relative, and are able to be followed in viewers such as GitHub.
  * Markdown may include non-visible comments or meta-data.
 


### PR DESCRIPTION
…don't get lost in dev docs.