### PR TITLE
BUG Correct behaviour for empty filter array (as per 3.1)

### DIFF
--- a/search/filters/ExactMatchFilter.php
+++ b/search/filters/ExactMatchFilter.php
@@ -56,6 +56,10 @@ class ExactMatchFilter extends SearchFilter {
 			// For queries using the default collation (no explicit case) we can use the WHERE .. IN .. syntax,
 			// providing simpler SQL than many WHERE .. OR .. fragments.
 			$column = $this->getDbName();
+			// If values is an empty array, fall back to 3.1 behaviour and use empty string comparison
+			if(empty($values)) {
+				$values = array('');
+			}
 			$placeholders = DB::placeholders($values);
 			return $query->where(array(
 				"$column IN ($placeholders)" => $values
@@ -109,6 +113,10 @@ class ExactMatchFilter extends SearchFilter {
 			// For queries using the default collation (no explicit case) we can use the WHERE .. NOT IN .. syntax,
 			// providing simpler SQL than many WHERE .. AND .. fragments.
 			$column = $this->getDbName();
+			// If values is an empty array, fall back to 3.1 behaviour and use empty string comparison
+			if(empty($values)) {
+				$values = array('');
+			}
 			$placeholders = DB::placeholders($values);
 			return $query->where(array(
 				"$column NOT IN ($placeholders)" => $values

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -898,6 +898,26 @@ class DataListTest extends SapphireTest {
 	}
 
 	/**
+	 * Test exact match filter with empty array items
+	 */
+	public function testEmptyFilter() {
+		$list = DataObjectTest_TeamComment::get();
+		$list = $list->exclude('Name', array());
+
+		$sql = $list->sql($parameters);
+		$this->assertSQLContains('WHERE (("DataObjectTest_TeamComment"."Name" NOT IN (?)))', $sql);
+		$this->assertEquals(array(''), $parameters);
+
+
+		$list = DataObjectTest_TeamComment::get();
+		$list = $list->filter('Name', array());
+
+		$sql = $list->sql($parameters);
+		$this->assertSQLContains('WHERE ("DataObjectTest_TeamComment"."Name" IN (?))', $sql);
+		$this->assertEquals(array(''), $parameters);
+	}
+
+	/**
 	 * $list->exclude(array('Name'=>'bob, 'Age'=>array(21, 43))); // exclude bob with Age 21 or 43
 	 */
 	public function testMultipleExcludeWithMultipleThatCheersEitherTeam() {


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/4758

This isn't strictly correct, but it does bring the 3.2 behaviour in line with 3.1, which was to map filters against empty arrays to empty string comparison.