### PR TITLE
FIX: Don’t reuse DBConnector (fixes #4735)

### DIFF
--- a/_config/database.yml
+++ b/_config/database.yml
@@ -14,3 +14,9 @@ Injector:
       connector: %$MySQLiConnector
       schemaManager: %$MySQLSchemaManager
       queryBuilder: %$MySQLQueryBuilder
+  MySQLiConnector:
+    class: 'MySQLiConnector'
+    type: prototype
+  PDOConnector:
+    class: 'PDOConnector'
+    type: prototype


### PR DESCRIPTION
Without this fix, multiple Database objects will use the same
DBConnector object, meaning that SilverStripe can’t connect to multiple
databases.

This fix ensures that the service cache generates new DBConnector
subclasses each time it is called.