### PR TITLE
BUG: magic getter in ViewableData behaves differently than direct calls

### DIFF
--- a/tests/view/ViewableDataTest.php
+++ b/tests/view/ViewableDataTest.php
@@ -8,6 +8,22 @@
  */
 class ViewableDataTest extends SapphireTest {
 
+	/**
+	 * This test checks that getting a value by `PropertyName(property)` and `getPropertyName(property)`
+	 * returns the same value when there is a PropertyName() method in this object
+	 */
+	public function testMagicGetterMethod() {
+		$obj = new ViewableDataTest_MethodLookup();
+		$funcCall = $obj->obj('getMyMethod', array('fibbonacci'));
+		$getValue = $obj->obj('MyMethod', array('fibbonacci'));
+		$this->assertEquals($funcCall->value, $getValue->value);
+		// double check that the default value still works
+		$defaultFuncCall = $obj->obj('getMyMethod');
+		$this->assertEquals('default', $defaultFuncCall->value);
+		$defaultValueGet = $obj->obj('MyMethod');
+		$this->assertEquals('default', $defaultValueGet->value);
+	}
+
 	public function testRequiresCasting() {
 		$caster = new ViewableDataTest_Castable();
 
@@ -282,6 +298,13 @@ class ViewableDataTest_NotCached extends ViewableData {
 	protected function objCacheGet($key) {
 		// Disable caching
 		return null;
+	}
+}
+
+class ViewableDataTest_MethodLookup extends ViewableData {
+
+	public function getMyMethod($argument = 'default') {
+		return $argument;
 	}
 }
 

--- a/view/ViewableData.php
+++ b/view/ViewableData.php
@@ -416,9 +416,12 @@ class ViewableData extends Object implements IteratorAggregate {
 			// HACK: Don't call the deprecated FormField::Name() method
 			$methodIsAllowed = true;
 			if($this instanceof FormField && $fieldName == 'Name') $methodIsAllowed = false;
-			
+
 			if($methodIsAllowed && $this->hasMethod($fieldName)) {
 				$value = $arguments ? call_user_func_array(array($this, $fieldName), $arguments) : $this->$fieldName();
+			} else if($this->hasMethod($method = "get$fieldName")) {
+				$methodName = "get$fieldName";
+				$value = $arguments ? call_user_func_array(array($this, $methodName), $arguments) : $this->$methodName();
 			} else {
 				$value = $this->$fieldName;
 			}


### PR DESCRIPTION
There is my opinion a bug when calling a ViewableData method with an argument and using either the `getMethod('argument')` (true method name) and `Method('argument')` (magic function lookup).

This PR will do the method lookup in ViewableData::obj() instead of in ViewableData::__get() where the arguments are lost.

This often gets confusing in SilverStripe templates.