### PR TITLE
Don't run forceSSL() on CLI

### DIFF
--- a/control/Director.php
+++ b/control/Director.php
@@ -854,14 +854,17 @@ class Director implements TemplateGlobalProvider {
 	 * @return boolean|string String of URL when unit tests running, boolean FALSE if patterns don't match request URI
 	 */
 	public static function forceSSL($patterns = null, $secureDomain = null) {
-		if(!isset($_SERVER['REQUEST_URI'])) return false;
+		if(!isset($_SERVER['REQUEST_URI'])) {
+			return false;
+		}
+
+		if(Director::is_cli()) {
+			return false;
+		}
 
 		$matched = false;
 
 		if($patterns) {
-			// Calling from the command-line?
-			if(!isset($_SERVER['REQUEST_URI'])) return;
-
 			$relativeURL = self::makeRelative(Director::absoluteURL($_SERVER['REQUEST_URI']));
 
 			// protect portions of the site based on the pattern


### PR DESCRIPTION
Was performing an inefficient check for this previously.
REQUEST_URI is set through cli-script.php, hence it's not
an accurate way to determine CLI operation.

The effect of this bug is that command line tasks will fail to
run since they'll return a HTTP redirect which a CLI client can't interpret.

Note: I don't know how to unit test this, since `Director::is_cli()` is called statically and uses `php_sapi_name()` which I can't mock.