### PR TITLE
FIX: Hidden errors for composite fields nested inside FieldGroups (fixes #4773)

### DIFF
--- a/forms/FieldGroup.php
+++ b/forms/FieldGroup.php
@@ -118,7 +118,8 @@ class FieldGroup extends CompositeField {
 	 * @return string
 	 */
 	public function Message() {
-		$fs = $this->FieldList();
+		$fs = array();
+		$this->collateDataFields($fs);
 
 		foreach($fs as $subfield) {
 			if($m = $subfield->Message()) $message[] = rtrim($m, ".");
@@ -131,7 +132,8 @@ class FieldGroup extends CompositeField {
 	 * @return string
 	 */
 	public function MessageType() {
-		$fs = $this->FieldList();
+		$fs = array();
+		$this->collateDataFields($fs);
 
 		foreach($fs as $subfield) {
 			if($m = $subfield->MessageType()) $MessageType[] = $m;

--- a/tests/forms/FieldGroupTest.php
+++ b/tests/forms/FieldGroupTest.php
@@ -1,0 +1,20 @@
+<?php
+
+class FieldGroupTest extends SapphireTest {
+
+	public function testMessagesInsideNestedCompositeFields() {
+		$fieldGroup = new FieldGroup(
+			new CompositeField(
+				$textField = new TextField('TestField', 'Test Field'),
+				$emailField = new EmailField('TestEmailField', 'Test Email Field')
+			)
+		);
+
+		$textField->setError('Test error message', 'warning');
+		$emailField->setError('Test error message', 'error');
+
+		$this->assertEquals('Test error message,  Test error message.', $fieldGroup->Message());
+		$this->assertEquals('warning.  error', $fieldGroup->MessageType());
+	}
+
+}


### PR DESCRIPTION
Tests highlighted the weird formatting on message “types”. Given that these are output as `class="warning.  error"` they should probably be fixed/improved in future, didn’t do that as part of this PR.