### PR TITLE
Adding a background to the UploadField preview

### DIFF
--- a/css/UploadField.css
+++ b/css/UploadField.css
@@ -16,6 +16,7 @@ Used in side panels and action tabs
 .ss-uploadfield .ss-uploadfield-item { margin: 0; padding: 15px; overflow: auto; }
 .ss-uploadfield .ss-uploadfield-item .ss-uploadfield-item-preview { height: 60px; line-height: 60px; width: 80px; text-align: center; font-weight: bold; float: left; overflow: hidden; }
 .ss-uploadfield .ss-uploadfield-item .ss-uploadfield-item-preview.ss-uploadfield-dropzone { -moz-box-shadow: #808080 0 0 4px 0 inset; -webkit-box-shadow: #808080 0 0 4px 0 inset; box-shadow: #808080 0 0 4px 0 inset; border: 2px dashed #808080; background: #d0d3d5; display: none; margin-right: 15px; }
+.ss-uploadfield .ss-uploadfield-item .ss-uploadfield-item-preview img { background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAJElEQVQYV2O8dOnSfwYkoKenx4jMZ6SDAmT7QGx0K1EcRBsFAJfOHd3Le79RAAAAAElFTkSuQmCC') repeat; }
 .ss-uploadfield .ss-uploadfield-item .ss-uploadfield-item-info { margin-left: 95px; }
 .ss-uploadfield .ss-uploadfield-item .ss-uploadfield-item-info .ss-uploadfield-item-name { display: block; line-height: 13px; height: 26px; margin: 0; text-align: left; }
 .ss-uploadfield .ss-uploadfield-item .ss-uploadfield-item-info .ss-uploadfield-item-name .name { max-width: 240px; font-weight: bold; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; -o-text-overflow: ellipsis; display: inline; float: left; }

--- a/scss/UploadField.scss
+++ b/scss/UploadField.scss
@@ -48,6 +48,9 @@
 				display: none;
 				margin-right: 15px;
 			}
+			img {
+				background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAJElEQVQYV2O8dOnSfwYkoKenx4jMZ6SDAmT7QGx0K1EcRBsFAJfOHd3Le79RAAAAAElFTkSuQmCC) repeat;
+			}
 		}
 		.ss-uploadfield-item-info {
 			margin-left: 95px;


### PR DESCRIPTION
I could not see a preview of a white image with background transparency in the preview area. Adding a background to this area helps make it more visible, at the very least you can tell them image has transparency. 

**Before**
![before](https://cloud.githubusercontent.com/assets/5096172/11291309/be96de9a-8f92-11e5-8e30-e49e159e7812.jpg)

**After:**
![after](https://cloud.githubusercontent.com/assets/5096172/11291311/c1a38778-8f92-11e5-859d-dc27725cfc51.jpg)
