### PR TITLE
FIX Image_Cached record class name

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -1040,7 +1040,12 @@ class Image_Cached extends Image {
 	 */
 	public function __construct($filename = null, $isSingleton = false, Image $sourceImage = null) {
 		parent::__construct(array(), $isSingleton);
-		if ($sourceImage) $this->update($sourceImage->toMap());
+		if ($sourceImage) {
+			// Copy properties from source image, except unsafe ones
+			$properties = $sourceImage->toMap();
+			unset($properties['RecordClassName'], $properties['ClassName']);
+			$this->update($properties);
+		}
 		$this->ID = -1;
 		$this->Filename = $filename;
 	}


### PR DESCRIPTION
This prevents Image_Cached objects having their `ClassName` and `RecordClassName` properties set to 'Image' instead of 'Image_Cached'.

I don't know what those properties are used for but if I try to replace the Image class with the injector I run in to problems without this fix.