### PR TITLE
API refactor LeftAndMain_Menu.ss into individually overridable components

### DIFF
--- a/admin/templates/Includes/LeftAndMain_Menu.ss
+++ b/admin/templates/Includes/LeftAndMain_Menu.ss
@@ -1,42 +1,13 @@
 <div class="cms-menu cms-panel cms-panel-layout west" id="cms-menu" data-layout-type="border">
 	<div class="cms-logo-header north">
-		<div class="cms-logo">
-			<a href="$ApplicationLink" target="_blank" title="$ApplicationName (Version - $CMSVersion)">
-				$ApplicationName <% if $CMSVersion %><abbr class="version">$CMSVersion</abbr><% end_if %>
-			</a>
-			<span><% if $SiteConfig %>$SiteConfig.Title<% else %>$ApplicationName<% end_if %></span>
-		</div>
-
-		<div class="cms-login-status">
-			<a href="$LogoutURL" class="logout-link font-icon-logout" title="<%t LeftAndMain_Menu_ss.LOGOUT 'Log out' %>"></a>
-			<% with $CurrentMember %>
-				<span>
-					<%t LeftAndMain_Menu_ss.Hello 'Hi' %>
-					<a href="{$AbsoluteBaseURL}admin/myprofile" class="profile-link">
-						<% if $FirstName && $Surname %>$FirstName $Surname<% else_if $FirstName %>$FirstName<% else %>$Email<% end_if %>
-					</a>
-				</span>
-			<% end_with %>
-		</div>
+		<% include LeftAndMain_MenuStatus %>
 	</div>
 
 	<div class="cms-panel-content center">
-		<ul class="cms-menu-list">
-		<% loop $MainMenu %>
-			<li class="$LinkingMode $FirstLast <% if $LinkingMode == 'link' %><% else %>opened<% end_if %>" id="Menu-$Code" title="$Title.ATT">
-				<a href="$Link" $AttributesHTML>
-					<span class="icon icon-16 icon-{$Code.LowerCase}">&nbsp;</span>
-					<span class="text">$Title</span>
-				</a>
-			</li>
-		<% end_loop %>
-		</ul>
+		<% include LeftAndMain_MenuList %>
 	</div>
 
 	<div class="cms-panel-toggle south">
-		<button class="sticky-toggle" type="button" title="Sticky nav">Sticky nav</button>
-		<span class="sticky-status-indicator">auto</span>
-		<a class="toggle-expand" href="#"><span>&raquo;</span></a>
-		<a class="toggle-collapse" href="#"><span>&laquo;</span></a>
+		<% include LeftAndMain_MenuToggle %>
 	</div>
 </div>

--- a/admin/templates/Includes/LeftAndMain_MenuList.ss
+++ b/admin/templates/Includes/LeftAndMain_MenuList.ss
@@ -1,0 +1,10 @@
+<ul class="cms-menu-list">
+	<% loop $MainMenu %>
+		<li class="$LinkingMode $FirstLast <% if $LinkingMode == 'link' %><% else %>opened<% end_if %>" id="Menu-$Code" title="$Title.ATT">
+			<a href="$Link" $AttributesHTML>
+				<span class="icon icon-16 icon-{$Code.LowerCase}">&nbsp;</span>
+				<span class="text">$Title</span>
+			</a>
+		</li>
+	<% end_loop %>
+</ul>

--- a/admin/templates/Includes/LeftAndMain_MenuStatus.ss
+++ b/admin/templates/Includes/LeftAndMain_MenuStatus.ss
@@ -1,0 +1,17 @@
+<div class="cms-logo">
+    <a href="$ApplicationLink" target="_blank" title="$ApplicationName (Version - $CMSVersion)">
+		$ApplicationName <% if $CMSVersion %><abbr class="version">$CMSVersion</abbr><% end_if %>
+    </a>
+    <span><% if $SiteConfig %>$SiteConfig.Title<% else %>$ApplicationName<% end_if %></span>
+</div>
+<div class="cms-login-status">
+	<a href="$LogoutURL" class="logout-link font-icon-logout" title="<%t LeftAndMain_Menu_ss.LOGOUT 'Log out' %>"></a>
+	<% with $CurrentMember %>
+		<span>
+			<%t LeftAndMain_Menu_ss.Hello 'Hi' %>
+			<a href="{$AbsoluteBaseURL}admin/myprofile" class="profile-link">
+				<% if $FirstName && $Surname %>$FirstName $Surname<% else_if $FirstName %>$FirstName<% else %>$Email<% end_if %>
+			</a>
+		</span>
+	<% end_with %>
+</div>

--- a/admin/templates/Includes/LeftAndMain_MenuToggle.ss
+++ b/admin/templates/Includes/LeftAndMain_MenuToggle.ss
@@ -1,0 +1,4 @@
+<button class="sticky-toggle" type="button" title="Sticky nav">Sticky nav</button>
+<span class="sticky-status-indicator">auto</span>
+<a class="toggle-expand" href="#"><span>&raquo;</span></a>
+<a class="toggle-collapse" href="#"><span>&laquo;</span></a>


### PR DESCRIPTION
Since many modules override the main menu, it makes sense to cut down on code duplication (and maintenance) by splitting out re-usable components.

Fluent, translatable, and subsites, for instance, each add custom left hand menus.