### PR TITLE
Varchar(50) for "Code" is much too short.

### DIFF
--- a/security/Permission.php
+++ b/security/Permission.php
@@ -17,7 +17,7 @@ class Permission extends DataObject implements TemplateGlobalProvider {
 	// the (1) after Type specifies the DB default value which is needed for
 	// upgrades from older SilverStripe versions
 	private static $db = array(
-		"Code" => "Varchar",
+		"Code" => "Varchar(255)",
 		"Arg" => "Int",
 		"Type" => "Int(1)"
 	);


### PR DESCRIPTION
I had problems because I came to the 50 character limit with automatically generated permission codes.
I think a longer Varchar should be in the framework, instead of overwriting it in .yml files all the time.