### PR TITLE
FIX Use config for determining Vary header

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -11,3 +11,4 @@ HTTP:
     max-age: 0
     must-revalidate: "true"
     no-transform: "true"
+  vary: "Cookie, X-Forwarded-Protocol, User-Agent, Accept"

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -358,7 +358,10 @@ class HTTP {
 
 			// To do: User-Agent should only be added in situations where you *are* actually
 			// varying according to user-agent.
-			$responseHeaders['Vary'] = 'Cookie, X-Forwarded-Protocol, User-Agent, Accept';
+            $vary = $config->get('HTTP', 'vary');
+            if ($vary && strlen($vary)) {
+                $responseHeaders['Vary'] = $vary;
+            }
 		}
 		else {
 			if($body) {

--- a/docs/en/02_Developer_Guides/08_Performance/02_HTTP_Cache_Headers.md
+++ b/docs/en/02_Developer_Guides/08_Performance/02_HTTP_Cache_Headers.md
@@ -31,3 +31,23 @@ clause in `Cache-Control` and `Pragma` will be included.
 
 Used to set the modification date to something more recent than the default. [api:DataObject::__construct] calls 
 [api:HTTP::register_modification_date(] whenever a record comes from the database ensuring the newest date is present.
+
+### Vary: cache header
+
+By default, SilverStripe will output a `Vary` header (used by upstream caches for determining uniqueness) 
+that looks like
+
+```
+Cookie, X-Forwarded-Protocol, User-Agent, Accept
+```
+
+To change the value of the `Vary` header, you can change this value by specifying the header in configuration
+
+```yml
+HTTP:
+  vary: ""
+```
+
+
+
+

--- a/tests/control/HTTPTest.php
+++ b/tests/control/HTTPTest.php
@@ -46,6 +46,31 @@ class HTTPTest extends FunctionalTest {
 		}
 	}
 
+
+    public function testConfigVary() {
+        $body = "<html><head></head><body><h1>Mysite</h1></body></html>";
+		$response = new SS_HTTPResponse($body, 200);
+        Config::inst()->update('Director', 'environment_type', 'live');
+        HTTP::set_cache_age(30);
+		HTTP::add_cache_headers($response);
+
+        $v = $response->getHeader('Vary');
+		$this->assertNotEmpty($v);
+
+        $this->assertContains("Cookie", $v);
+        $this->assertContains("X-Forwarded-Protocol", $v);
+        $this->assertContains("User-Agent", $v);
+        $this->assertContains("Accept", $v);
+
+        Config::inst()->update('HTTP', 'vary', '');
+
+        $response = new SS_HTTPResponse($body, 200);
+        HTTP::add_cache_headers($response);
+
+        $v = $response->getHeader('Vary');
+		$this->assertEmpty($v);
+    }
+
 	/**
 	 * Tests {@link HTTP::getLinksIn()}
 	 */


### PR DESCRIPTION
Existing implementation hardcodes the Vary header; swap to using Config layer
instead

(Now, the philosophical argument - is this a fix to eliminate a hardcoded, untested string, or a new, backwards compatible public API? :D) 