### PR TITLE
parse the string to be converted to group codes.

### DIFF
--- a/security/MemberCsvBulkLoader.php
+++ b/security/MemberCsvBulkLoader.php
@@ -40,6 +40,7 @@ class MemberCsvBulkLoader extends CsvBulkLoader {
 		if(isset($record['Groups']) && $record['Groups']) {
 			$groupCodes = explode(',', $record['Groups']);
 			foreach($groupCodes as $groupCode) {
+				$groupCode = Convert::raw2url($groupCode);
 				if(!isset($_cache_groupByCode[$groupCode])) {
 					$group = Group::get()->filter('Code', $groupCode)->first();
 					if(!$group) {
@@ -49,8 +50,8 @@ class MemberCsvBulkLoader extends CsvBulkLoader {
 						$group->write();
 					}
 					$member->Groups()->add($group);
+					$_cache_groupByCode[$groupCode] = $group;
 				}
-				$_cache_groupByCode[$groupCode] = $group;
 			}
 		}
 


### PR DESCRIPTION
Two fixes.
1. parse the group code by using Convert::raw2url() as it creates duplicate records if the group code is given in upper case letters, spaces etc. 
2. assigning to the $_cache_groupByCode has to be really done in the if condition rather than out of it.