### PR TITLE
Add getter/setter functions for FormField's dontEscape

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -406,17 +406,16 @@ class File extends DataObject {
 			)->setName("FilePreviewImage")->addExtraClass('cms-file-info-preview'),
 			CompositeField::create(
 				CompositeField::create(
-					new ReadonlyField("FileType", _t('AssetTableField.TYPE','File type') . ':'),
-					new ReadonlyField("Size", _t('AssetTableField.SIZE','File size') . ':', $this->getSize()),
-					$urlField = new ReadonlyField('ClickableURL', _t('AssetTableField.URL','URL'),
+					ReadonlyField::create("FileType", _t('AssetTableField.TYPE','File type') . ':'),
+					ReadonlyField::create("Size", _t('AssetTableField.SIZE','File size') . ':', $this->getSize()),
+					ReadonlyField::create('ClickableURL', _t('AssetTableField.URL','URL'),
 						sprintf('<a href="%s" target="_blank">%s</a>', $this->Link(), $this->RelativeLink())
-					),
+					)->setDontEscape(true),
 					new DateField_Disabled("Created", _t('AssetTableField.CREATED','First uploaded') . ':'),
 					new DateField_Disabled("LastEdited", _t('AssetTableField.LASTEDIT','Last changed') . ':')
 				)
 			)->setName("FilePreviewData")->addExtraClass('cms-file-info-data')
 		)->setName("FilePreview")->addExtraClass('cms-file-info');
-		$urlField->dontEscape = true;
 
 		//get a tree listing with only folder, no files
 		$folderTree = new TreeDropdownField("ParentID", _t('AssetTableField.FOLDER','Folder'), 'Folder');

--- a/forms/CurrencyField.php
+++ b/forms/CurrencyField.php
@@ -67,7 +67,7 @@ class CurrencyField_Readonly extends ReadonlyField{
 	 */
 	public function Field($properties = array()) {
 		if($this->value){
-			$val = $this->dontEscape ? $this->value : Convert::raw2xml($this->value);
+			$val = $this->getDontEscape() ? $this->value : Convert::raw2xml($this->value);
 			$val = _t('CurrencyField.CURRENCYSYMBOL', '$') . number_format(preg_replace('/[^0-9.]/',"",$val), 2);
 		} else {
 			$val = '<i>'._t('CurrencyField.CURRENCYSYMBOL', '$').'0.00</i>';
@@ -100,7 +100,7 @@ class CurrencyField_Disabled extends CurrencyField{
 	 */
 	public function Field($properties = array()) {
 		if($this->value){
-			$val = $this->dontEscape ? $this->value : Convert::raw2xml($this->value);
+			$val = $this->getDontEscape() ? $this->value : Convert::raw2xml($this->value);
 			$val = _t('CurrencyField.CURRENCYSYMBOL', '$') . number_format(preg_replace('/[^0-9.]/',"",$val), 2);
 		} else {
 			$val = '<i>'._t('CurrencyField.CURRENCYSYMBOL', '$').'0.00</i>';

--- a/forms/FormField.php
+++ b/forms/FormField.php
@@ -1146,6 +1146,26 @@ class FormField extends RequestHandler {
 	}
 
 	/**
+	 * Flag whether this field's content should be escaped.
+	 *
+	 * @param string $dontEscape
+	 *
+	 * @return $this
+	 */
+	public function setDontEscape($dontEscape) {
+		$this->dontEscape = $dontEscape;
+
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDontEscape() {
+		return $this->description;
+	}
+
+	/**
 	 * @return string
 	 */
 	public function debug() {
@@ -1247,15 +1267,14 @@ class FormField extends RequestHandler {
 			->setLeftTitle($this->LeftTitle())
 			->setRightTitle($this->RightTitle())
 			->addExtraClass($this->extraClass())
-			->setDescription($this->getDescription());
+            ->setDescription($this->getDescription())
+            ->setDontEscape($this->getDontEscape());
 
 		// Only include built-in attributes, ignore anything set through getAttributes().
 		// Those might change important characteristics of the field, e.g. its "type" attribute.
 		foreach($this->attributes as $attributeKey => $attributeValue) {
 			$field->setAttribute($attributeKey, $attributeValue);
 		}
-
-		$field->dontEscape = $this->dontEscape;
 
 		return $field;
 	}

--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -119,7 +119,7 @@ class HtmlEditorField extends TextareaField {
 	 */
 	public function performReadonlyTransformation() {
 		$field = $this->castedCopy('HtmlEditorField_Readonly');
-		$field->dontEscape = true;
+		$field->setDontEscape(true);
 
 		return $field;
 	}
@@ -584,7 +584,7 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 				CompositeField::create(
 					CompositeField::create(
 						new ReadonlyField("FileType", _t('AssetTableField.TYPE','File type') . ':', $file->Type),
-						$urlField = ReadonlyField::create(
+						ReadonlyField::create(
 							'ClickableURL',
 							_t('AssetTableField.URL','URL'),
 							sprintf(
@@ -592,7 +592,7 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 								Convert::raw2att($url),
 								Convert::raw2att($url)
 							)
-						)->addExtraClass('text-wrap')
+						)->addExtraClass('text-wrap')->setDontEscape(true)
 					)
 				)->setName("FilePreviewData")->addExtraClass('cms-file-info-data')
 			)->setName("FilePreview")->addExtraClass('cms-file-info'),
@@ -626,7 +626,6 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 				)->addExtraClass('dimensions last')
 			);
 		}
-		$urlField->dontEscape = true;
 
 		if($file->Type == 'photo') {
 			$fields->insertBefore('CaptionText', new TextField(
@@ -698,7 +697,7 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 					CompositeField::create(
 						new ReadonlyField("FileType", _t('AssetTableField.TYPE','File type'), $file->FileType),
 						new ReadonlyField("Size", _t('AssetTableField.SIZE','File size'), $file->getSize()),
-						$urlField = new ReadonlyField(
+						ReadonlyField::create(
 							'ClickableURL',
 							_t('AssetTableField.URL','URL'),
 							sprintf(
@@ -707,7 +706,7 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 								Convert::raw2att($file->Link()),
 								Convert::raw2att($file->RelativeLink())
 							)
-						),
+						)->setDontEscape(true),
 						new DateField_Disabled("Created", _t('AssetTableField.CREATED','First uploaded'),
 							$file->Created),
 						new DateField_Disabled("LastEdited", _t('AssetTableField.LASTEDIT','Last changed'),
@@ -759,7 +758,6 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 				)->addExtraClass('dimensions last')
 			);
 		}
-		$urlField->dontEscape = true;
 
 		$this->extend('updateFieldsForImage', $fields, $url, $file);
 

--- a/forms/LookupField.php
+++ b/forms/LookupField.php
@@ -61,7 +61,7 @@ class LookupField extends DropdownField {
 		if($mapped) {
 			$attrValue = implode(', ', array_values($mapped));
 
-			if(!$this->dontEscape) {
+			if(!$this->getDontEscape()) {
 				$attrValue = Convert::raw2xml($attrValue);
 			}
 

--- a/forms/ReadonlyField.php
+++ b/forms/ReadonlyField.php
@@ -53,7 +53,7 @@ class ReadonlyField extends FormField {
 	}
 
 	public function Value() {
-		if($this->value) return $this->dontEscape ? $this->value : Convert::raw2xml($this->value);
+		if($this->value) return $this->getDontEscape() ? $this->value : Convert::raw2xml($this->value);
 		else return '<i>(' . _t('FormField.NONE', 'none') . ')</i>';
 	}
 

--- a/forms/ToggleField.php
+++ b/forms/ToggleField.php
@@ -78,7 +78,7 @@ class ToggleField extends ReadonlyField {
 			<input type="hidden" name="$this->name" value="$valforInput" />
 HTML;
 		} else {
-			$this->dontEscape = true;
+			$this->setDontEscape(true);
 			$content = parent::Field();
 		}
 		

--- a/forms/TreeDropdownField.php
+++ b/forms/TreeDropdownField.php
@@ -555,7 +555,7 @@ class TreeDropdownField_Readonly extends TreeDropdownField {
 		$field = new LookupField($this->name, $this->title, $source);
 		$field->setValue($this->value);
 		$field->setForm($this->form);
-		$field->dontEscape = true;
+		$field->setDontEscape(true);
 		return $field->Field();
 	}
 }

--- a/tests/forms/LookupFieldTest.php
+++ b/tests/forms/LookupFieldTest.php
@@ -34,7 +34,7 @@ class LookupFieldTest extends SapphireTest {
 		$source = array(1 => 'one', 2 => 'two', 3 => 'three');
 		$f = new LookupField('test', 'test', $source);
 		$f->setValue('<ins>w00t</ins>');
-		$f->dontEscape = true; // simulates CMSMain->compareversions()
+		$f->setDontEscape(true); // simulates CMSMain->compareversions()
 		$this->assertEquals(
 			'<span class="readonly" id="test"><ins>w00t</ins></span><input type="hidden" name="test" value="" />',
 			$f->Field()->getValue()


### PR DESCRIPTION
I've got a couple areas in the CMS on a project I'm working on where it makes sense to include a link to another record in amongst the form fields, and it's a pain to have to create an extra holder variable when everything else can be accessed by setters through `ReadOnlyField::create`.

Maybe it'd make more sense in the long term to make some kind of ClickableLinkReadOnlyField? But this at least brings $dontEscape inline with the other properties.
