### PR TITLE
PHP Fatal // member function called on boolean // added is_object()

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -3010,7 +3010,11 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 				}
 			}
 
-			$object = $component->dbObject($fieldName);
+			if (is_object($component)){
+				$object = $component->dbObject($fieldName);
+			}else{
+				user_error('component is not an object on field '.$fieldName, E_USER_WARNING);
+			}
 
 		} else {
 			$object = $this->dbObject($fieldPath);


### PR DESCRIPTION
PHP Fatal error: Call to a member function dbObject() on boolean in /var/www/ [...] /public/framework/model/DataObject.php on line 3016

Not quite sure if I just messed up the relation definitions on my DataObject or this is a real bug.
Anyway it might be an improvement to check if $component is an object.