### PR TITLE
API Disable unauthenticated get parameter access to site stage mode

### DIFF
--- a/control/VersionedRequestFilter.php
+++ b/control/VersionedRequestFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Initialises the versioned stage when a request is made.
  *
@@ -8,7 +9,37 @@
 class VersionedRequestFilter implements RequestFilter {
 
 	public function preRequest(SS_HTTPRequest $request, Session $session, DataModel $model) {
-		Versioned::choose_site_stage($session);
+		// Bootstrap session so that Session::get() accesses the right instance
+		$dummyController = new Controller();
+		$dummyController->setSession($session);
+		$dummyController->setRequest($request);
+		$dummyController->pushCurrent();
+
+		// Block non-authenticated users from setting the stage mode
+		if(!Versioned::can_choose_site_stage($request)) {
+			$permissionMessage = sprintf(
+				_t(
+					"ContentController.DRAFT_SITE_ACCESS_RESTRICTION",
+					'You must log in with your CMS password in order to view the draft or archived content. '.
+					'<a href="%s">Click here to go back to the published site.</a>'
+				),
+				Controller::join_links(Director::baseURL(), $request->getURL(), "?stage=Live")
+			);
+
+			// Force output since RequestFilter::preRequest doesn't support response overriding
+			$response = Security::permissionFailure($dummyController, $permissionMessage);
+			$session->inst_save();
+			$dummyController->popCurrent();
+			// Prevent output in testing
+			if(class_exists('SapphireTest', false) && SapphireTest::is_running_test()) {
+				return false;
+			}
+			$response->output();
+			die;
+		}
+
+		Versioned::choose_site_stage();
+		$dummyController->popCurrent();
 		return true;
 	}
 

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -597,6 +597,8 @@ class VersionedTest extends SapphireTest {
 	 */
 	public function testReadingPersistent() {
 		$session = Injector::inst()->create('Session', array());
+		$adminID = $this->logInWithPermission('ADMIN');
+		$session->inst_set('loggedInAs', $adminID);
 
 		// Set to stage
 		Director::test('/?stage=Stage', null, $session);
@@ -628,10 +630,11 @@ class VersionedTest extends SapphireTest {
 
 		// Test that session doesn't redundantly store the default stage if it doesn't need to
 		$session2 = Injector::inst()->create('Session', array());
+		$session2->inst_set('loggedInAs', $adminID);
 		Director::test('/', null, $session2);
-		$this->assertEmpty($session2->inst_changedData());
+		$this->assertArrayNotHasKey('readingMode', $session2->inst_changedData());
 		Director::test('/?stage=Live', null, $session2);
-		$this->assertEmpty($session2->inst_changedData());
+		$this->assertArrayNotHasKey('readingMode', $session2->inst_changedData());
 
 		// Test choose_site_stage
 		Session::set('readingMode', 'Stage.Stage');
@@ -643,6 +646,15 @@ class VersionedTest extends SapphireTest {
 		Session::clear('readingMode');
 		Versioned::choose_site_stage();
 		$this->assertEquals('Stage.Live', Versioned::get_reading_mode());
+	}
+
+	/**
+	 * Test that stage parameter is blocked by non-administrative users
+	 */
+	public function testReadingModeSecurity() {
+		$this->setExpectedException('SS_HTTPResponse_Exception', 'Invalid request');
+		$session = Injector::inst()->create('Session', array());
+		$result = Director::test('/?stage=Stage', null, $session);
 	}
 
 	/**


### PR DESCRIPTION
Also fixes a missing returned SS_HTTPResponse from Security::permissionFailure that this fix relies on.

This code involves an ugly work-around for session state that requires master changes.

Removing `$session` parameter from the `Versioned::choose_site_stage` method is not an api breakage.