### PR TITLE
BUG Fix regression in canViewStage

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -815,7 +815,7 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 		$oldMode = Versioned::get_reading_mode();
 		Versioned::reading_stage($stage);
 
-		$versionFromStage = DataObject::get($this->class)->byID($this->ID);
+		$versionFromStage = DataObject::get($this->owner->class)->byID($this->owner->ID);
 
 		Versioned::set_reading_mode($oldMode);
 		return $versionFromStage ? $versionFromStage->canView($member) : false;


### PR DESCRIPTION
In refactoring this code from SiteTree, I should have also refactored the unit tests. These are now included.

Fixes test failures in https://github.com/silverstripe/silverstripe-cms/pull/1341