### PR TITLE
Fixing deselect failing to change field title

### DIFF
--- a/forms/TreeMultiselectField.php
+++ b/forms/TreeMultiselectField.php
@@ -103,6 +103,7 @@ class TreeMultiselectField extends TreeDropdownField {
 		$titleArray = array();
 		$idArray = array();
 		$items = $this->getItems();
+		$emptyTitle = _t('DropdownField.CHOOSE', '(Choose)', 'start value of a dropdown');
 
 		if($items && count($items)) {
 			foreach($items as $item) {
@@ -115,7 +116,7 @@ class TreeMultiselectField extends TreeDropdownField {
 			$title = implode(", ", $titleArray);
 			$value = implode(",", $idArray);
 		} else {
-			$title = _t('DropdownField.CHOOSE', '(Choose)', 'start value of a dropdown');
+			$title = $emptyTitle;
 		} 
 		
 		$dataUrlTree = '';
@@ -129,6 +130,7 @@ class TreeMultiselectField extends TreeDropdownField {
 			$properties,
 			array(
 				'Title' => $title,
+				'EmptyTitle' => $emptyTitle,
 				'Link' => $dataUrlTree,
 				'Value' => $value
 			)

--- a/javascript/TreeDropdownField.js
+++ b/javascript/TreeDropdownField.js
@@ -138,7 +138,7 @@
 				this[this.getPanel().is(':visible') ? 'closePanel' : 'openPanel']();
 			},
 			setTitle: function(title) {
-				title = title || this.data('title') || strings.fieldTitle;
+				title = title || this.data('empty-title') || strings.fieldTitle;
 				
 				this.find('.treedropdownfield-title').html(title);
 				this.data('title', title); // separate view from storage (important for search cancellation)


### PR DESCRIPTION
fixes #4240

- Fixes missing empty title value for `TreeMultiselectField`
- Uses empty value when no value is passed to the field