### PR TITLE
BUG Fix SapphireTestReporter erroring

### DIFF
--- a/dev/CliTestReporter.php
+++ b/dev/CliTestReporter.php
@@ -1,4 +1,9 @@
 <?php
+
+if(!class_exists('SapphireTestReporter')) {
+	return;
+}
+
 /**
  * Test reporter optimised for CLI (ie, plain-text) output
  *

--- a/dev/SapphireTestReporter.php
+++ b/dev/SapphireTestReporter.php
@@ -1,9 +1,7 @@
 <?php
-if(!class_exists('PHPUnit_Framework_TestResult', false)) {
-	require_once 'PHPUnit/Framework/TestResult.php';
-}
-if(!class_exists('PHPUnit_Framework_TestListener', false)) {
-	require_once 'PHPUnit/Framework/TestListener.php';
+
+if(!interface_exists('PHPUnit_Framework_TestListener')) {
+	return;
 }
 
 /**#@+


### PR DESCRIPTION
This class hasn't been updated much, so I've given it a general code quality bump.

There are some odd edge cases that occur if an error, failure, or notice is raised when there is no current suite or test being run, so rather than creating an invalid state, ensure that these are logged to a fallback store ($currentSession).

I suspect that these occur during setup / teardown methods when a test or suite may not be available, or during certain bootstrapping or exit conditions.