### PR TITLE
BUG Workaround for issues in testing versioned

### DIFF
--- a/control/VersionedRequestFilter.php
+++ b/control/VersionedRequestFilter.php
@@ -32,7 +32,7 @@ class VersionedRequestFilter implements RequestFilter {
 			$dummyController->popCurrent();
 			// Prevent output in testing
 			if(class_exists('SapphireTest', false) && SapphireTest::is_running_test()) {
-				return false;
+				throw new SS_HTTPResponse_Exception($response);
 			}
 			$response->output();
 			die;

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -654,7 +654,7 @@ class VersionedTest extends SapphireTest {
 	 * Test that stage parameter is blocked by non-administrative users
 	 */
 	public function testReadingModeSecurity() {
-		$this->setExpectedException('SS_HTTPResponse_Exception', 'Invalid request');
+		$this->setExpectedException('SS_HTTPResponse_Exception');
 		$session = Injector::inst()->create('Session', array());
 		$result = Director::test('/?stage=Stage', null, $session);
 	}


### PR DESCRIPTION
Using `return false` meant that cms tests couldn't test that the returned response couldn't be examined, so adjusted the behaviour slightly for tests.