### PR TITLE
NEW: Add ViewableData::setFailover() to refresh detected methods when changing failover

### DIFF
--- a/tests/view/ViewableDataTest.php
+++ b/tests/view/ViewableDataTest.php
@@ -20,7 +20,8 @@ class ViewableDataTest extends SapphireTest {
 
 	public function testFailoverRequiresCasting() {
 		$caster = new ViewableDataTest_Castable();
-		$container = new ViewableDataTest_Container($caster);
+		$container = new ViewableDataTest_Container();
+		$container->setFailover($caster);
 
 		$this->assertTrue($container->obj('alwaysCasted') instanceof ViewableDataTest_RequiresCasting);
 		$this->assertTrue($caster->obj('alwaysCasted', null, false) instanceof ViewableDataTest_RequiresCasting);
@@ -175,6 +176,19 @@ class ViewableDataTest extends SapphireTest {
 		$this->assertEquals('BBB', $objNotCached->obj('Test', null, true, true));
 	}
 
+	public function testSetFailover() {
+		$failover = new ViewableData();
+		$container = new ViewableDataTest_Container();
+		$container->setFailover($failover);
+
+		$this->assertSame($failover, $container->getFailover(), 'getFailover() returned a different object');
+		$this->assertFalse($container->hasMethod('testMethod'), 'testMethod() is already defined when it shouldn’t be');
+
+		// Ensure that defined methods detected from the failover aren't cached when setting a new failover
+		$container->setFailover(new ViewableDataTest_Failover);
+		$this->assertTrue($container->hasMethod('testMethod'));
+	}
+
 }
 
 /**#@+
@@ -252,10 +266,6 @@ class ViewableData_Caster extends ViewableData {
 
 class ViewableDataTest_Container extends ViewableData {
 
-	public function __construct($failover) {
-		$this->failover = $failover;
-		parent::__construct();
-	}
 }
 
 class ViewableDataTest_CastingClass extends ViewableData {
@@ -285,4 +295,6 @@ class ViewableDataTest_NotCached extends ViewableData {
 	}
 }
 
-/**#@-*/
+class ViewableDataTest_Failover extends ViewableData {
+	public function testMethod() {}
+}

--- a/view/ViewableData.php
+++ b/view/ViewableData.php
@@ -127,6 +127,25 @@ class ViewableData extends Object implements IteratorAggregate {
 			$this->setField($property, $value);
 		}
 	}
+
+	/**
+	 * Set a failover object to attempt to get data from if it is not present on this object.
+	 * 
+	 * @param ViewableData $failover
+	 */
+	public function setFailover(ViewableData $failover) {
+		$this->failover = $failover;
+		$this->defineMethods();
+	}
+
+	/**
+	 * Get the current failover object if set
+	 * 
+	 * @return ViewableData|null
+	 */
+	public function getFailover() {
+		return $this->failover;
+	}
 	
 	/**
 	 * Check if a field exists on this object. This should be overloaded in child classes.
@@ -137,7 +156,7 @@ class ViewableData extends Object implements IteratorAggregate {
 	public function hasField($field) {
 		return property_exists($this, $field);
 	}
-	
+
 	/**
 	 * Get the value of a field on this object. This should be overloaded in child classes.
 	 *


### PR DESCRIPTION
Hopefully the tests explain this better than my bug ticket did...

This is the only workaround I could think up for this issue. We don’t have a setter like `ViewableData::setFailover()` to hook into, and even if we added one we have no guarantee that people would use it (especially because setting `$this->failover = $foo;` has been an undocumented convention for a while now).