### PR TITLE
NOT FOR MERGE: W.I.P. Add <% withif %> template block

### DIFF
--- a/view/SSTemplateParser.php
+++ b/view/SSTemplateParser.php
@@ -25,46 +25,46 @@ else {
  * @subpackage view
  */
 class SSTemplateParseException extends Exception {
-	
+
 	function __construct($message, $parser) {
 		$prior = substr($parser->string, 0, $parser->pos);
-		
+
 		preg_match_all('/\r\n|\r|\n/', $prior, $matches);
 		$line = count($matches[0])+1;
-		
+
 		parent::__construct("Parse error in template on line $line. Error was: $message");
 	}
-	
+
 }
 
 /**
   * This is the parser for the SilverStripe template language. It gets called on a string and uses a php-peg parser
   * to match that string against the language structure, building up the PHP code to execute that structure as it
   * parses
-  * 
+  *
   * The $result array that is built up as part of the parsing (see thirdparty/php-peg/README.md for more on how
   * parsers build results) has one special member, 'php', which contains the php equivalent of that part of the
   * template tree.
-  * 
+  *
   * Some match rules generate alternate php, or other variations, so check the per-match documentation too.
-  * 
+  *
   * Terms used:
-  * 
+  *
   * Marked: A string or lookup in the template that has been explictly marked as such - lookups by prepending with
   * "$" (like $Foo.Bar), strings by wrapping with single or double quotes ('Foo' or "Foo")
-  * 
+  *
   * Bare: The opposite of marked. An argument that has to has it's type inferred by usage and 2.4 defaults.
-  * 
+  *
   * Example of using a bare argument for a loop block: <% loop Foo %>
-  * 
+  *
   * Block: One of two SS template structures. The special characters "<%" and "%>" are used to wrap the opening and
   * (required or forbidden depending on which block exactly) closing block marks.
-  * 
+  *
   * Open Block: An SS template block that doesn't wrap any content or have a closing end tag (in fact, a closing end
   * tag is forbidden)
-  * 
+  *
   * Closed Block: An SS template block that wraps content, and requires a counterpart <% end_blockname %> tag
-  * 
+  *
   * Angle Bracket: angle brackets "<" and ">" are used to eat whitespace between template elements
   * N: eats white space including newlines (using in legacy _t support)
   *
@@ -120,7 +120,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 	/**
 	 * Set the closed blocks that the template parser should use
-	 * 
+	 *
 	 * This method will delete any existing closed blocks, please use addClosedBlock if you don't
 	 * want to overwrite
 	 * @param array $closedBlocks
@@ -195,7 +195,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			);
 		}
 	}
-	
+
 	/* Template: (Comment | Translate | If | Require | CacheBlock | UncachedBlock | OldI18NTag | Include | ClosedBlock |
 	OpenBlock | MalformedBlock | Injection | Text)+ */
 	protected $match_Template_typestack = array('Template');
@@ -450,7 +450,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function Template_STR(&$res, $sub) {
 		$res['php'] .= $sub['php'] . PHP_EOL ;
 	}
-	
+
 	/* Word: / [A-Za-z_] [A-Za-z0-9_]* / */
 	protected $match_Word_typestack = array('Word');
 	function match_Word ($stack = array()) {
@@ -538,14 +538,14 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 
 
-	/** 
+	/**
 	 * Values are bare words in templates, but strings in PHP. We rely on PHP's type conversion to back-convert
 	 * strings to numbers when needed.
 	 */
 	function CallArguments_Argument(&$res, $sub) {
 		if (!empty($res['php'])) $res['php'] .= ', ';
-		
-		$res['php'] .= ($sub['ArgumentMode'] == 'default') ? $sub['string_php'] : 
+
+		$res['php'] .= ($sub['ArgumentMode'] == 'default') ? $sub['string_php'] :
 			str_replace('$$FINAL', 'XML_val', $sub['php']);
 	}
 
@@ -727,22 +727,22 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 
 
-	
+
 	function Lookup__construct(&$res) {
 		$res['php'] = '$scope->locally()';
 		$res['LookupSteps'] = array();
 	}
-	
-	/** 
-	 * The basic generated PHP of LookupStep and LastLookupStep is the same, except that LookupStep calls 'obj' to 
+
+	/**
+	 * The basic generated PHP of LookupStep and LastLookupStep is the same, except that LookupStep calls 'obj' to
 	 * get the next ViewableData in the sequence, and LastLookupStep calls different methods (XML_val, hasValue, obj)
 	 * depending on the context the lookup is used in.
 	 */
 	function Lookup_AddLookupStep(&$res, $sub, $method) {
 		$res['LookupSteps'][] = $sub;
-		
+
 		$property = $sub['Call']['Method']['text'];
-		
+
 		if (isset($sub['Call']['CallArguments']) && $arguments = $sub['Call']['CallArguments']['php']) {
 			$res['php'] .= "->$method('$property', array($arguments), true)";
 		}
@@ -1083,7 +1083,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		$matchrule = "QuotedString"; $result = $this->construct($matchrule, $matchrule, null);
 		$_142 = NULL;
 		do {
-			$stack[] = $result; $result = $this->construct( $matchrule, "q" ); 
+			$stack[] = $result; $result = $this->construct( $matchrule, "q" );
 			if (( $subres = $this->rx( '/[\'"]/' ) ) !== FALSE) {
 				$result["text"] .= $subres;
 				$subres = $result; $result = array_pop($stack);
@@ -1093,7 +1093,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 				$result = array_pop($stack);
 				$_142 = FALSE; break;
 			}
-			$stack[] = $result; $result = $this->construct( $matchrule, "String" ); 
+			$stack[] = $result; $result = $this->construct( $matchrule, "String" );
 			if (( $subres = $this->rx( '/ (\\\\\\\\ | \\\\. | [^'.$this->expression($result, $stack, 'q').'\\\\])* /' ) ) !== FALSE) {
 				$result["text"] .= $subres;
 				$subres = $result; $result = array_pop($stack);
@@ -1227,21 +1227,21 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 
 
-	
+
 	/**
 	 * If we get a bare value, we don't know enough to determine exactly what php would be the translation, because
 	 * we don't know if the position of use indicates a lookup or a string argument.
-	 * 
+	 *
 	 * Instead, we record 'ArgumentMode' as a member of this matches results node, which can be:
 	 *   - lookup if this argument was unambiguously a lookup (marked as such)
 	 *   - string is this argument was unambiguously a string (marked as such, or impossible to parse as lookup)
 	 *   - default if this argument needs to be handled as per 2.4
-	 * 
+	 *
 	 * In the case of 'default', there is no php member of the results node, but instead 'lookup_php', which
 	 * should be used by the parent if the context indicates a lookup, and 'string_php' which should be used
 	 * if the context indicates a string
 	 */
-	
+
 	function Argument_DollarMarkedLookup(&$res, $sub) {
 		$res['ArgumentMode'] = 'lookup';
 		$res['php'] = $sub['Lookup']['php'];
@@ -1263,12 +1263,12 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			$res['php'] = $sub['php'];
 		}
 	}
-	
+
 	function Argument_FreeString(&$res, $sub) {
 		$res['ArgumentMode'] = 'string';
 		$res['php'] = "'" . str_replace("'", "\\'", trim($sub['text'])) . "'";
 	}
-	
+
 	/* ComparisonOperator: "!=" | "==" | ">=" | ">" | "<=" | "<" | "=" */
 	protected $match_ComparisonOperator_typestack = array('ComparisonOperator');
 	function match_ComparisonOperator ($stack = array()) {
@@ -1413,7 +1413,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		if ($sub['ArgumentMode'] == 'default') {
 			if (!empty($res['php'])) $res['php'] .= $sub['string_php'];
 			else $res['php'] = str_replace('$$FINAL', 'XML_val', $sub['lookup_php']);
-		}	
+		}
 		else {
 			$res['php'] .= str_replace('$$FINAL', 'XML_val', $sub['php']);
 		}
@@ -1433,7 +1433,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			$pos_199 = $this->pos;
 			$_198 = NULL;
 			do {
-				$stack[] = $result; $result = $this->construct( $matchrule, "Not" ); 
+				$stack[] = $result; $result = $this->construct( $matchrule, "Not" );
 				if (( $subres = $this->literal( 'not' ) ) !== FALSE) {
 					$result["text"] .= $subres;
 					$subres = $result; $result = array_pop($stack);
@@ -1469,7 +1469,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function PresenceCheck_Not(&$res, $sub) {
 		$res['php'] = '!';
 	}
-	
+
 	function PresenceCheck_Argument(&$res, $sub) {
 		if ($sub['ArgumentMode'] == 'string') {
 			$res['php'] .= '((bool)'.$sub['php'].')';
@@ -1780,22 +1780,22 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 
 	function If_IfPart(&$res, $sub) {
-		$res['php'] = 
+		$res['php'] =
 			'if (' . $sub['IfArgument']['php'] . ') { ' . PHP_EOL .
 				(isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
 			'}';
-	} 
+	}
 
 	function If_ElseIfPart(&$res, $sub) {
-		$res['php'] .= 
+		$res['php'] .=
 			'else if (' . $sub['IfArgument']['php'] . ') { ' . PHP_EOL .
 				(isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
 			'}';
 	}
 
 	function If_ElsePart(&$res, $sub) {
-		$res['php'] .= 
-			'else { ' . PHP_EOL . 
+		$res['php'] .=
+			'else { ' . PHP_EOL .
 				(isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
 			'}';
 	}
@@ -1813,7 +1813,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			else { $_274 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
 			else { $_274 = FALSE; break; }
-			$stack[] = $result; $result = $this->construct( $matchrule, "Call" ); 
+			$stack[] = $result; $result = $this->construct( $matchrule, "Call" );
 			$_270 = NULL;
 			do {
 				$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
@@ -1867,10 +1867,10 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		$res['php'] = "Requirements::".$sub['Method']['text'].'('.$sub['CallArguments']['php'].');';
 	}
 
-	
+
 	/* CacheBlockArgument:
    !( "if " | "unless " )
-	( 
+	(
 		:DollarMarkedLookup |
 		:QuotedString |
 		:Lookup
@@ -1976,15 +1976,15 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function CacheBlockArgument_DollarMarkedLookup(&$res, $sub) {
 		$res['php'] = $sub['Lookup']['php'];
 	}
-	
+
 	function CacheBlockArgument_QuotedString(&$res, $sub) {
 		$res['php'] = "'" . str_replace("'", "\\'", $sub['String']['text']) . "'";
 	}
-	
+
 	function CacheBlockArgument_Lookup(&$res, $sub) {
 		$res['php'] = $sub['php'];
 	}
-		
+
 	/* CacheBlockArguments: CacheBlockArgument ( < "," < CacheBlockArgument )* */
 	protected $match_CacheBlockArguments_typestack = array('CacheBlockArguments');
 	function match_CacheBlockArguments ($stack = array()) {
@@ -2034,10 +2034,10 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function CacheBlockArguments_CacheBlockArgument(&$res, $sub) {
 		if (!empty($res['php'])) $res['php'] .= ".'_'.";
 		else $res['php'] = '';
-		
+
 		$res['php'] .= str_replace('$$FINAL', 'XML_val', $sub['php']);
 	}
-	
+
 	/* CacheBlockTemplate: (Comment | Translate | If | Require |    OldI18NTag | Include | ClosedBlock |
 	OpenBlock | MalformedBlock | Injection | Text)+ */
 	protected $match_CacheBlockTemplate_typestack = array('CacheBlockTemplate','Template');
@@ -2253,8 +2253,8 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 
 
-		
-	/* UncachedBlock: 
+
+	/* UncachedBlock:
 	'<%' < "uncached" < CacheBlockArguments? ( < Conditional:("if"|"unless") > Condition:IfArgument )? > '%>'
 		Template:$TemplateMatcher?
 		'<%' < 'end_' ("uncached"|"cached"|"cacheblock") > '%>' */
@@ -2285,7 +2285,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			$_363 = NULL;
 			do {
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-				$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" ); 
+				$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" );
 				$_359 = NULL;
 				do {
 					$_357 = NULL;
@@ -2413,7 +2413,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function UncachedBlock_Template(&$res, $sub){
 		$res['php'] = $sub['php'];
 	}
-	
+
 	/* CacheRestrictedTemplate: (Comment | Translate | If | Require | CacheBlock | UncachedBlock | OldI18NTag | Include | ClosedBlock |
 	OpenBlock | MalformedBlock | Injection | Text)+ */
 	protected $match_CacheRestrictedTemplate_typestack = array('CacheRestrictedTemplate','Template');
@@ -2665,17 +2665,17 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 
 
-	function CacheRestrictedTemplate_CacheBlock(&$res, $sub) { 
+	function CacheRestrictedTemplate_CacheBlock(&$res, $sub) {
 		throw new SSTemplateParseException('You cant have cache blocks nested within with, loop or control blocks ' .
 			'that are within cache blocks', $this);
 	}
-	
-	function CacheRestrictedTemplate_UncachedBlock(&$res, $sub) { 
+
+	function CacheRestrictedTemplate_UncachedBlock(&$res, $sub) {
 		throw new SSTemplateParseException('You cant have uncache blocks nested within with, loop or control blocks ' .
 			'that are within cache blocks', $this);
 	}
-	
-	/* CacheBlock: 
+
+	/* CacheBlock:
 	'<%' < CacheTag:("cached"|"cacheblock") < (CacheBlockArguments)? ( < Conditional:("if"|"unless") >
 	Condition:IfArgument )? > '%>'
 		(CacheBlock | UncachedBlock | CacheBlockTemplate)*
@@ -2688,7 +2688,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
 			else { $_491 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-			$stack[] = $result; $result = $this->construct( $matchrule, "CacheTag" ); 
+			$stack[] = $result; $result = $this->construct( $matchrule, "CacheTag" );
 			$_444 = NULL;
 			do {
 				$_442 = NULL;
@@ -2745,7 +2745,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			$_460 = NULL;
 			do {
 				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-				$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" ); 
+				$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" );
 				$_456 = NULL;
 				do {
 					$_454 = NULL;
@@ -2918,23 +2918,23 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function CacheBlock__construct(&$res){
 		$res['subblocks'] = 0;
 	}
-	
+
 	function CacheBlock_CacheBlockArguments(&$res, $sub){
 		$res['key'] = !empty($sub['php']) ? $sub['php'] : '';
 	}
-	
+
 	function CacheBlock_Condition(&$res, $sub){
 		$res['condition'] = ($res['Conditional']['text'] == 'if' ? '(' : '!(') . $sub['php'] . ') && ';
 	}
-	
+
 	function CacheBlock_CacheBlock(&$res, $sub){
 		$res['php'] .= $sub['php'];
 	}
-	
+
 	function CacheBlock_UncachedBlock(&$res, $sub){
 		$res['php'] .= $sub['php'];
 	}
-	
+
 	function CacheBlock_CacheBlockTemplate(&$res, $sub){
 		// Get the block counter
 		$block = ++$res['subblocks'];
@@ -2959,14 +2959,14 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			. ".'_$block'"; // block index
 		// Get any condition
 		$condition = isset($res['condition']) ? $res['condition'] : '';
-		
+
 		$res['php'] .= 'if ('.$condition.'($partial = $cache->load('.$key.'))) $val .= $partial;' . PHP_EOL;
 		$res['php'] .= 'else { $oldval = $val; $val = "";' . PHP_EOL;
 		$res['php'] .= $sub['php'] . PHP_EOL;
 		$res['php'] .= $condition . ' $cache->save($val); $val = $oldval . $val;' . PHP_EOL;
 		$res['php'] .= '}';
 	}
-	
+
 	/* OldTPart: "_t" N "(" N QuotedString (N "," N CallArguments)? N ")" N (";")? */
 	protected $match_OldTPart_typestack = array('OldTPart');
 	function match_OldTPart ($stack = array()) {
@@ -3077,7 +3077,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function OldTPart__construct(&$res) {
 		$res['php'] = "_t(";
 	}
-	
+
 	function OldTPart_QuotedString(&$res, $sub) {
 		$entity = $sub['String']['text'];
 		if (strpos($entity, '.') === false) {
@@ -3087,7 +3087,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			$res['php'] .= "'$entity'";
 		}
 	}
-	
+
 	function OldTPart_CallArguments(&$res, $sub) {
 		$res['php'] .= ',' . $sub['php'];
 	}
@@ -3095,7 +3095,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function OldTPart__finalise(&$res) {
 		$res['php'] .= ')';
 	}
-	
+
 	/* OldTTag: "<%" < OldTPart > "%>" */
 	protected $match_OldTTag_typestack = array('OldTTag');
 	function match_OldTTag ($stack = array()) {
@@ -3125,7 +3125,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		$res['php'] = $sub['php'];
 	}
 
-	/* OldSprintfTag: "<%" < "sprintf" < "(" < OldTPart < "," < CallArguments > ")" > "%>"  */
+	/* OldSprintfTag: "<%" < "sprintf" < "(" < OldTPart < "," < CallArguments > ")" > "%>" */
 	protected $match_OldSprintfTag_typestack = array('OldSprintfTag');
 	function match_OldSprintfTag ($stack = array()) {
 		$matchrule = "OldSprintfTag"; $result = $this->construct($matchrule, $matchrule, null);
@@ -3179,7 +3179,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function OldSprintfTag__construct(&$res) {
 		$res['php'] = "sprintf(";
 	}
-	
+
 	function OldSprintfTag_OldTPart(&$res, $sub) {
 		$res['php'] .= $sub['php'];
 	}
@@ -3187,7 +3187,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function OldSprintfTag_CallArguments(&$res, $sub) {
 		$res['php'] .= ',' . $sub['php'] . ')';
 	}
-	
+
 	/* OldI18NTag: OldSprintfTag | OldTTag */
 	protected $match_OldI18NTag_typestack = array('OldI18NTag');
 	function match_OldI18NTag ($stack = array()) {
@@ -3370,7 +3370,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		$template = $res['template'];
 		$arguments = $res['arguments'];
 
-		$res['php'] = '$val .= SSViewer::execute_template('.$template.', $scope->getItem(), array(' . 
+		$res['php'] = '$val .= SSViewer::execute_template('.$template.', $scope->getItem(), array(' .
 			implode(',', $arguments)."), \$scope);\n";
 
 		if($this->includeDebuggingComments) { // Add include filename comments on dev sites
@@ -3381,7 +3381,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		}
 	}
 
-	/* BlockArguments: :Argument ( < "," < :Argument)*  */
+	/* BlockArguments: :Argument ( < "," < :Argument)* */
 	protected $match_BlockArguments_typestack = array('BlockArguments');
 	function match_BlockArguments ($stack = array()) {
 		$matchrule = "BlockArguments"; $result = $this->construct($matchrule, $matchrule, null);
@@ -3584,7 +3584,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	}
 
 
-	/* ClosedBlock: '<%' < !NotBlockTag BlockName:Word ( [ :BlockArguments ] )? > Zap:'%>' Template:$TemplateMatcher? 
+	/* ClosedBlock: '<%' < !NotBlockTag BlockName:Word ( [ :BlockArguments ] )? > Zap:'%>' Template:$TemplateMatcher?
 	'<%' < 'end_' '$BlockName' > '%>' */
 	protected $match_ClosedBlock_typestack = array('ClosedBlock');
 	function match_ClosedBlock ($stack = array()) {
@@ -3638,7 +3638,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 				unset( $pos_621 );
 			}
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-			$stack[] = $result; $result = $this->construct( $matchrule, "Zap" ); 
+			$stack[] = $result; $result = $this->construct( $matchrule, "Zap" );
 			if (( $subres = $this->literal( '%>' ) ) !== FALSE) {
 				$result["text"] .= $subres;
 				$subres = $result; $result = array_pop($stack);
@@ -3680,7 +3680,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 
 
-	
+
 	/**
 	 * As mentioned in the parser comment, block handling is kept fairly generic for extensibility. The match rule
 	 * builds up two important elements in the match result array:
@@ -3690,15 +3690,15 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	 * Once a block has successfully been matched against, it will then look for the actual handler, which should
 	 * be on this class (either defined or extended on) as ClosedBlock_Handler_Name(&$res), where Name is the
 	 * tag name, first letter captialized (i.e Control, Loop, With, etc).
-	 * 
+	 *
 	 * This function will be called with the match rule result array as it's first argument. It should return
 	 * the php result of this block as it's return value, or throw an error if incorrect arguments were passed.
 	 */
-	
+
 	function ClosedBlock__construct(&$res) {
 		$res['ArgumentCount'] = 0;
 	}
-	
+
 	function ClosedBlock_BlockArguments(&$res, $sub) {
 		if (isset($sub['Argument']['ArgumentMode'])) {
 			$res['Arguments'] = array($sub['Argument']);
@@ -3741,7 +3741,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			if ($arg['ArgumentMode'] == 'string') {
 				throw new SSTemplateParseException('Control block cant take string as argument.', $this);
 			}
-			$on = str_replace('$$FINAL', 'obj', 
+			$on = str_replace('$$FINAL', 'obj',
 				($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
 		}
 
@@ -3759,7 +3759,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		Deprecation::notice('4.0', '<% control %> is deprecated. Use <% with %> or <% loop %> instead.');
 		return $this->ClosedBlock_Handle_Loop($res);
 	}
-	
+
 	/**
 	 * The closed block handler for with blocks
 	 */
@@ -3768,19 +3768,42 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			throw new SSTemplateParseException('Either no or too many arguments in with block. Must be one ' .
 				'argument only.', $this);
 		}
-		
+
 		$arg = $res['Arguments'][0];
 		if ($arg['ArgumentMode'] == 'string') {
 			throw new SSTemplateParseException('Control block cant take string as argument.', $this);
 		}
-		
+
 		$on = str_replace('$$FINAL', 'obj', ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
-		return 
+		return
 			$on . '; $scope->pushScope();' . PHP_EOL .
 				$res['Template']['php'] . PHP_EOL .
 			'; $scope->popScope(); ';
 	}
-	
+
+	/**
+	 * The closed block handler for withif blocks
+	 */
+	function ClosedBlock_Handle_Withif(&$res) {
+		if ($res['ArgumentCount'] != 1) {
+			throw new SSTemplateParseException('Either no or too many arguments in withif block. Must be one ' .
+				'argument only.', $this);
+		}
+
+		$arg = $res['Arguments'][0];
+		if ($arg['ArgumentMode'] == 'string') {
+			throw new SSTemplateParseException('Control block cant take string as argument.', $this);
+		}
+
+		$if = str_replace('$$FINAL', 'hasValue', ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
+		$on = str_replace('$$FINAL', 'obj', ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
+		return
+			'if (' . $if . ') {'.
+			$on . '; $scope->pushScope();' . PHP_EOL .
+				$res['Template']['php'] . PHP_EOL .
+			'; $scope->popScope(); }';
+	}
+
 	/* OpenBlock: '<%' < !NotBlockTag BlockName:Word ( [ :BlockArguments ] )? > '%>' */
 	protected $match_OpenBlock_typestack = array('OpenBlock');
 	function match_OpenBlock ($stack = array()) {
@@ -3848,7 +3871,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function OpenBlock__construct(&$res) {
 		$res['ArgumentCount'] = 0;
 	}
-	
+
 	function OpenBlock_BlockArguments(&$res, $sub) {
 		if (isset($sub['Argument']['ArgumentMode'])) {
 			$res['Arguments'] = array($sub['Argument']);
@@ -3881,9 +3904,9 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		if ($res['ArgumentCount'] == 0) return '$scope->debug();';
 		else if ($res['ArgumentCount'] == 1) {
 			$arg = $res['Arguments'][0];
-			
+
 			if ($arg['ArgumentMode'] == 'string') return 'Debug::show('.$arg['php'].');';
-			
+
 			$php = ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php'];
 			return '$val .= Debug::show('.str_replace('FINALGET!', 'cachedCall', $php).');';
 		}
@@ -3907,7 +3930,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		if ($res['ArgumentCount'] != 0) throw new SSTemplateParseException('Current_page takes no arguments', $this);
 		return '$val .= $_SERVER[SCRIPT_URL];';
 	}
-	
+
 	/* MismatchedEndBlock: '<%' < 'end_' :Word > '%>' */
 	protected $match_MismatchedEndBlock_typestack = array('MismatchedEndBlock');
 	function match_MismatchedEndBlock ($stack = array()) {
@@ -3939,7 +3962,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 	function MismatchedEndBlock__finalise(&$res) {
 		$blockname = $res['Word']['text'];
-		throw new SSTemplateParseException('Unexpected close tag end_' . $blockname . 
+		throw new SSTemplateParseException('Unexpected close tag end_' . $blockname .
 			' encountered. Perhaps you have mis-nested blocks, or have mis-spelled a tag?', $this);
 	}
 
@@ -4028,7 +4051,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		throw new SSTemplateParseException("Malformed opening block tag $tag. Perhaps you have tried to use operators?"
 			, $this);
 	}
-	
+
 	/* MalformedCloseTag: '<%' < Tag:('end_' :Word ) !( > '%>' ) */
 	protected $match_MalformedCloseTag_typestack = array('MalformedCloseTag');
 	function match_MalformedCloseTag ($stack = array()) {
@@ -4038,7 +4061,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
 			else { $_679 = FALSE; break; }
 			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-			$stack[] = $result; $result = $this->construct( $matchrule, "Tag" ); 
+			$stack[] = $result; $result = $this->construct( $matchrule, "Tag" );
 			$_673 = NULL;
 			do {
 				if (( $subres = $this->literal( 'end_' ) ) !== FALSE) { $result["text"] .= $subres; }
@@ -4093,7 +4116,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		throw new SSTemplateParseException("Malformed closing block tag $tag. Perhaps you have tried to pass an " .
 			"argument to one?", $this);
 	}
-	
+
 	/* MalformedBlock: MalformedOpenTag | MalformedCloseTag */
 	protected $match_MalformedBlock_typestack = array('MalformedBlock');
 	function match_MalformedBlock ($stack = array()) {
@@ -4184,7 +4207,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function Comment__construct(&$res) {
 		$res['php'] = '';
 	}
-		
+
 	/* TopTemplate: (Comment | Translate | If | Require | CacheBlock | UncachedBlock | OldI18NTag | Include | ClosedBlock |
 	OpenBlock |  MalformedBlock | MismatchedEndBlock  | Injection | Text)+ */
 	protected $match_TopTemplate_typestack = array('TopTemplate','Template');
@@ -4454,7 +4477,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 
 
-	
+
 	/**
 	 * The TopTemplate also includes the opening stanza to start off the template
 	 */
@@ -4668,13 +4691,13 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 
 
-	
+
 	/**
-	 * We convert text 
+	 * We convert text
 	 */
 	function Text__finalise(&$res) {
 		$text = $res['text'];
-		
+
 		// Unescape any escaped characters in the text, then put back escapes for any single quotes and backslashes
 		$text = stripslashes($text);
 		$text = addcslashes($text, '\'\\');
@@ -4695,14 +4718,14 @@ EOC;
 
 		$res['php'] .= '$val .= \'' . $text . '\';' . PHP_EOL;
 	}
-		
+
 	/******************
 	 * Here ends the parser itself. Below are utility methods to use the parser
 	 */
-	
+
 	/**
 	 * Compiles some passed template source code into the php code that will execute as per the template source.
-	 * 
+	 *
 	 * @throws SSTemplateParseException
 	 * @param  $string The source of the template
 	 * @param string $templateName The name of the template, normally the filename the template source was loaded from
@@ -4716,13 +4739,13 @@ EOC;
 		}
 		else {
 			parent::__construct($string);
-			
+
 			$this->includeDebuggingComments = $includeDebuggingComments;
-	
+
 			// Ignore UTF8 BOM at begining of string. TODO: Confirm this is needed, make sure SSViewer handles UTF
 			// (and other encodings) properly
 			if(substr($string, 0,3) == pack("CCC", 0xef, 0xbb, 0xbf)) $this->pos = 3;
-			
+
 			// Match the source against the parser
 			if ($topTemplate) {
 				$result = $this->match_TopTemplate();
@@ -4730,7 +4753,7 @@ EOC;
 				$result = $this->match_Template();
 			}
 			if(!$result) throw new SSTemplateParseException('Unexpected problem parsing template', $this);
-	
+
 			// Get the result
 			$code = $result['php'];
 		}
@@ -4738,8 +4761,8 @@ EOC;
 		// Include top level debugging comments if desired
 		if($includeDebuggingComments && $templateName && stripos($code, "<?xml") === false) {
 			$code = $this->includeDebuggingComments($code, $templateName);
-		}	
-		
+		}
+
 		return $code;
 	}
 
@@ -4775,11 +4798,11 @@ EOC;
 		}
 		return $code;
 	}
-	
+
 	/**
 	 * Compiles some file that contains template source code, and returns the php code that will execute as per that
 	 * source
-	 * 
+	 *
 	 * @static
 	 * @param  $template - A file path that contains template source code
 	 * @return mixed|string - The php that, when executed (via include or exec) will behave as per the template source

--- a/view/SSTemplateParser.php.inc
+++ b/view/SSTemplateParser.php.inc
@@ -4,16 +4,16 @@
 
 /*!* !silent
 This is the uncompiled parser for the SilverStripe template language, PHP with special comments that define the
-parser. 
+parser.
 
-It gets run through the php-peg parser compiler to have those comments turned into code that match parts of the 
+It gets run through the php-peg parser compiler to have those comments turned into code that match parts of the
 template language, producing the executable version SSTemplateParser.php
 
 To recompile after changing this file, run this from the 'framework/view' directory via command line (in most cases
 this is: sapphire/view):
- 
-	php ../thirdparty/php-peg/cli.php SSTemplateParser.php.inc > SSTemplateParser.php 
-  
+
+	php ../thirdparty/php-peg/cli.php SSTemplateParser.php.inc > SSTemplateParser.php
+
 See the php-peg docs for more information on the parser format, and how to convert this file into SSTemplateParser.php
 
 TODO:
@@ -22,9 +22,9 @@ TODO:
 	Partial cache blocks
 	i18n - we dont support then deprecated _t() or sprintf(_t()) methods; or the new <% t %> block yet
 	Add with and loop blocks
-	Add Up and Top 
+	Add Up and Top
 	More error detection?
- 
+
 This comment will not appear in the output
 */
 
@@ -46,46 +46,46 @@ else {
  * @subpackage view
  */
 class SSTemplateParseException extends Exception {
-	
+
 	function __construct($message, $parser) {
 		$prior = substr($parser->string, 0, $parser->pos);
-		
+
 		preg_match_all('/\r\n|\r|\n/', $prior, $matches);
 		$line = count($matches[0])+1;
-		
+
 		parent::__construct("Parse error in template on line $line. Error was: $message");
 	}
-	
+
 }
 
 /**
   * This is the parser for the SilverStripe template language. It gets called on a string and uses a php-peg parser
   * to match that string against the language structure, building up the PHP code to execute that structure as it
   * parses
-  * 
+  *
   * The $result array that is built up as part of the parsing (see thirdparty/php-peg/README.md for more on how
   * parsers build results) has one special member, 'php', which contains the php equivalent of that part of the
   * template tree.
-  * 
+  *
   * Some match rules generate alternate php, or other variations, so check the per-match documentation too.
-  * 
+  *
   * Terms used:
-  * 
+  *
   * Marked: A string or lookup in the template that has been explictly marked as such - lookups by prepending with
   * "$" (like $Foo.Bar), strings by wrapping with single or double quotes ('Foo' or "Foo")
-  * 
+  *
   * Bare: The opposite of marked. An argument that has to has it's type inferred by usage and 2.4 defaults.
-  * 
+  *
   * Example of using a bare argument for a loop block: <% loop Foo %>
-  * 
+  *
   * Block: One of two SS template structures. The special characters "<%" and "%>" are used to wrap the opening and
   * (required or forbidden depending on which block exactly) closing block marks.
-  * 
+  *
   * Open Block: An SS template block that doesn't wrap any content or have a closing end tag (in fact, a closing end
   * tag is forbidden)
-  * 
+  *
   * Closed Block: An SS template block that wraps content, and requires a counterpart <% end_blockname %> tag
-  * 
+  *
   * Angle Bracket: angle brackets "<" and ">" are used to eat whitespace between template elements
   * N: eats white space including newlines (using in legacy _t support)
   *
@@ -141,7 +141,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 	/**
 	 * Set the closed blocks that the template parser should use
-	 * 
+	 *
 	 * This method will delete any existing closed blocks, please use addClosedBlock if you don't
 	 * want to overwrite
 	 * @param array $closedBlocks
@@ -216,75 +216,75 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			);
 		}
 	}
-	
+
 	/*!* SSTemplateParser
 
-	# Template is any structurally-complete portion of template (a full nested level in other words). It's the 
+	# Template is any structurally-complete portion of template (a full nested level in other words). It's the
 	# primary matcher, and is used by all enclosing blocks, as well as a base for the top level.
 	# Any new template elements need to be included in this list, if they are to work.
-	 
+
 	Template: (Comment | Translate | If | Require | CacheBlock | UncachedBlock | OldI18NTag | Include | ClosedBlock |
 		OpenBlock | MalformedBlock | Injection | Text)+
 	*/
 	function Template_STR(&$res, $sub) {
 		$res['php'] .= $sub['php'] . PHP_EOL ;
 	}
-	
+
 	/*!*
-	
+
 	Word: / [A-Za-z_] [A-Za-z0-9_]* /
 	Number: / [0-9]+ /
 	Value: / [A-Za-z0-9_]+ /
 
 	# CallArguments is a list of one or more comma seperated "arguments" (lookups or strings, either bare or marked)
 	# as passed to a Call within brackets
-	 
+
 	CallArguments: :Argument ( < "," < :Argument )*
 	*/
 
-	/** 
+	/**
 	 * Values are bare words in templates, but strings in PHP. We rely on PHP's type conversion to back-convert
 	 * strings to numbers when needed.
 	 */
 	function CallArguments_Argument(&$res, $sub) {
 		if (!empty($res['php'])) $res['php'] .= ', ';
-		
-		$res['php'] .= ($sub['ArgumentMode'] == 'default') ? $sub['string_php'] : 
+
+		$res['php'] .= ($sub['ArgumentMode'] == 'default') ? $sub['string_php'] :
 			str_replace('$$FINAL', 'XML_val', $sub['php']);
 	}
 
 	/*!*
-	
+
 	# Call is a php-style function call, e.g. Method(Argument, ...). Unlike PHP, the brackets are optional if no
 	# arguments are passed
-	 
+
 	Call: Method:Word ( "(" < :CallArguments? > ")" )?
 
 	# A lookup is a lookup of a value on the current scope object. It's a sequence of calls seperated by "."
-	# characters. This final call in the sequence needs handling specially, as different structures need different 
+	# characters. This final call in the sequence needs handling specially, as different structures need different
 	# sorts of values, which require a different final method to be called to get the right return value
-	 
+
 	LookupStep: :Call &"."
 	LastLookupStep: :Call
 
 	Lookup: LookupStep ("." LookupStep)* "." LastLookupStep | LastLookupStep
 	*/
-	
+
 	function Lookup__construct(&$res) {
 		$res['php'] = '$scope->locally()';
 		$res['LookupSteps'] = array();
 	}
-	
-	/** 
-	 * The basic generated PHP of LookupStep and LastLookupStep is the same, except that LookupStep calls 'obj' to 
+
+	/**
+	 * The basic generated PHP of LookupStep and LastLookupStep is the same, except that LookupStep calls 'obj' to
 	 * get the next ViewableData in the sequence, and LastLookupStep calls different methods (XML_val, hasValue, obj)
 	 * depending on the context the lookup is used in.
 	 */
 	function Lookup_AddLookupStep(&$res, $sub, $method) {
 		$res['LookupSteps'][] = $sub;
-		
+
 		$property = $sub['Call']['Method']['text'];
-		
+
 		if (isset($sub['Call']['CallArguments']) && $arguments = $sub['Call']['CallArguments']['php']) {
 			$res['php'] .= "->$method('$property', array($arguments), true)";
 		}
@@ -357,10 +357,10 @@ class SSTemplateParser extends Parser implements TemplateParser {
 
 
 	/*!*
-	
+
 	# Injections are where, outside of a block, a value needs to be inserted into the output. You can either
 	# just do $Foo, or {$Foo} if the surrounding text would cause a problem (e.g. {$Foo}Bar)
-	 
+
 	SimpleInjection: '$' :Lookup
 	BracketInjection: '{$' :Lookup "}"
 	Injection: BracketInjection | SimpleInjection
@@ -370,11 +370,11 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	}
 
 	/*!*
-	 
+
 	# Inside a block's arguments you can still use the same format as a simple injection ($Foo). In this case
 	# it marks the argument as being a lookup, not a string (if it was bare it might still be used as a lookup,
 	# but that depends on where it's used, a la 2.4)
-	 
+
 	DollarMarkedLookup: SimpleInjection
 	*/
 	function DollarMarkedLookup_STR(&$res, $sub) {
@@ -382,45 +382,45 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	}
 
 	/*!*
-	
+
 	# Inside a block's arguments you can explictly mark a string by surrounding it with quotes (single or double,
 	# but they must be matching). If you do, inside the quote you can escape any character, but the only character
-	# that _needs_ escaping is the matching closing quote 
-	 
+	# that _needs_ escaping is the matching closing quote
+
 	QuotedString: q:/['"]/   String:/ (\\\\ | \\. | [^$q\\])* /   '$q'
-	
+
 	# In order to support 2.4's base syntax, we also need to detect free strings - strings not surrounded by
 	# quotes, and containing spaces or punctuation, but supported as a single string. We support almost as flexible
 	# a string as 2.4 - we don't attempt to determine the closing character by context, but just break on any
 	# character which, in some context, would indicate the end of a free string, regardless of if we're actually in
-	# that context or not 
-	 
+	# that context or not
+
 	FreeString: /[^,)%!=><|&]+/
-	
+
 	# An argument - either a marked value, or a bare value, prefering lookup matching on the bare value over
-	# freestring matching as long as that would give a successful parse 
-	 
+	# freestring matching as long as that would give a successful parse
+
 	Argument:
 		:DollarMarkedLookup |
 		:QuotedString |
 		:Lookup !(< FreeString)|
 		:FreeString
 	*/
-	
+
 	/**
 	 * If we get a bare value, we don't know enough to determine exactly what php would be the translation, because
 	 * we don't know if the position of use indicates a lookup or a string argument.
-	 * 
+	 *
 	 * Instead, we record 'ArgumentMode' as a member of this matches results node, which can be:
 	 *   - lookup if this argument was unambiguously a lookup (marked as such)
 	 *   - string is this argument was unambiguously a string (marked as such, or impossible to parse as lookup)
 	 *   - default if this argument needs to be handled as per 2.4
-	 * 
+	 *
 	 * In the case of 'default', there is no php member of the results node, but instead 'lookup_php', which
 	 * should be used by the parent if the context indicates a lookup, and 'string_php' which should be used
 	 * if the context indicates a string
 	 */
-	
+
 	function Argument_DollarMarkedLookup(&$res, $sub) {
 		$res['ArgumentMode'] = 'lookup';
 		$res['php'] = $sub['Lookup']['php'];
@@ -442,16 +442,16 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			$res['php'] = $sub['php'];
 		}
 	}
-	
+
 	function Argument_FreeString(&$res, $sub) {
 		$res['ArgumentMode'] = 'string';
 		$res['php'] = "'" . str_replace("'", "\\'", trim($sub['text'])) . "'";
 	}
-	
+
 	/*!*
-	 
+
 	# if and else_if blocks allow basic comparisons between arguments
-	 
+
 	ComparisonOperator: "!=" | "==" | ">=" | ">" | "<=" | "<" | "="
 
 	Comparison: Argument < ComparisonOperator > Argument
@@ -460,7 +460,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		if ($sub['ArgumentMode'] == 'default') {
 			if (!empty($res['php'])) $res['php'] .= $sub['string_php'];
 			else $res['php'] = str_replace('$$FINAL', 'XML_val', $sub['lookup_php']);
-		}	
+		}
 		else {
 			$res['php'] .= str_replace('$$FINAL', 'XML_val', $sub['php']);
 		}
@@ -471,17 +471,17 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	}
 
 	/*!*
-	 
+
 	# If a comparison operator is not used in an if or else_if block, then the statement is a 'presence check',
 	# which checks if the argument given is present or not. For explicit strings (which were not allowed in 2.4)
 	# this falls back to simple truthiness check
-	 
+
 	PresenceCheck: (Not:'not' <)? Argument
 	*/
 	function PresenceCheck_Not(&$res, $sub) {
 		$res['php'] = '!';
 	}
-	
+
 	function PresenceCheck_Argument(&$res, $sub) {
 		if ($sub['ArgumentMode'] == 'string') {
 			$res['php'] .= '((bool)'.$sub['php'].')';
@@ -494,11 +494,11 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		}
 	}
 
-	/*!*	
-	 
-	# if and else_if arguments are a series of presence checks and comparisons, optionally seperated by boolean 
-	# operators 
-	 
+	/*!*
+
+	# if and else_if arguments are a series of presence checks and comparisons, optionally seperated by boolean
+	# operators
+
 	IfArgumentPortion: Comparison | PresenceCheck
 	*/
 	function IfArgumentPortion_STR(&$res, $sub) {
@@ -506,14 +506,14 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	}
 
 	/*!*
-	 
+
 	# if and else_if arguments can be combined via these two boolean operators. No precendence overriding is
 	# supported
-	 	
+
 	BooleanOperator: "||" | "&&"
-	
-	# This is the combination of the previous if and else_if argument portions 
-	 
+
+	# This is the combination of the previous if and else_if argument portions
+
 	IfArgument: :IfArgumentPortion ( < :BooleanOperator < :IfArgumentPortion )*
 	*/
 	function IfArgument_IfArgumentPortion(&$res, $sub) {
@@ -524,12 +524,12 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		$res['php'] .= $sub['text'];
 	}
 
-	/*!*	
-	 
+	/*!*
+
 	# ifs are handled seperately from other closed block tags, because (A) their structure is different - they
 	# can have else_if and else tags in between the if tag and the end_if tag, and (B) they have a different
-	# argument structure to every other block 
-	 
+	# argument structure to every other block
+
 	IfPart: '<%' < 'if' [ :IfArgument > '%>' Template:$TemplateMatcher?
 	ElseIfPart: '<%' < 'else_if' [ :IfArgument > '%>' Template:$TemplateMatcher?
 	ElsePart: '<%' < 'else' > '%>' Template:$TemplateMatcher?
@@ -537,45 +537,45 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	If: IfPart ElseIfPart* ElsePart? '<%' < 'end_if' > '%>'
 	*/
 	function If_IfPart(&$res, $sub) {
-		$res['php'] = 
+		$res['php'] =
 			'if (' . $sub['IfArgument']['php'] . ') { ' . PHP_EOL .
 				(isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
 			'}';
-	} 
+	}
 
 	function If_ElseIfPart(&$res, $sub) {
-		$res['php'] .= 
+		$res['php'] .=
 			'else if (' . $sub['IfArgument']['php'] . ') { ' . PHP_EOL .
 				(isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
 			'}';
 	}
 
 	function If_ElsePart(&$res, $sub) {
-		$res['php'] .= 
-			'else { ' . PHP_EOL . 
+		$res['php'] .=
+			'else { ' . PHP_EOL .
 				(isset($sub['Template']) ? $sub['Template']['php'] : '') . PHP_EOL .
 			'}';
 	}
 
 	/*!*
-	
+
 	# The require block is handled seperately to the other open blocks as the argument syntax is different
 	# - must have one call style argument, must pass arguments to that call style argument
-	 
+
 	Require: '<%' < 'require' [ Call:(Method:Word "(" < :CallArguments  > ")") > '%>'
 	*/
 	function Require_Call(&$res, $sub) {
 		$res['php'] = "Requirements::".$sub['Method']['text'].'('.$sub['CallArguments']['php'].');';
 	}
 
-	
+
 	/*!*
-	
+
 	# Cache block arguments don't support free strings
-	
+
 	CacheBlockArgument:
 	   !( "if " | "unless " )
-		( 
+		(
 			:DollarMarkedLookup |
 			:QuotedString |
 			:Lookup
@@ -584,38 +584,38 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function CacheBlockArgument_DollarMarkedLookup(&$res, $sub) {
 		$res['php'] = $sub['Lookup']['php'];
 	}
-	
+
 	function CacheBlockArgument_QuotedString(&$res, $sub) {
 		$res['php'] = "'" . str_replace("'", "\\'", $sub['String']['text']) . "'";
 	}
-	
+
 	function CacheBlockArgument_Lookup(&$res, $sub) {
 		$res['php'] = $sub['php'];
 	}
-		
+
 	/*!*
-	
+
 	# Collects the arguments passed in to be part of the key of a cacheblock
-	 
+
 	CacheBlockArguments: CacheBlockArgument ( < "," < CacheBlockArgument )*
-	 
+
 	*/
 	function CacheBlockArguments_CacheBlockArgument(&$res, $sub) {
 		if (!empty($res['php'])) $res['php'] .= ".'_'.";
 		else $res['php'] = '';
-		
+
 		$res['php'] .= str_replace('$$FINAL', 'XML_val', $sub['php']);
 	}
-	
+
 	/*!*
 	# CacheBlockTemplate is the same as Template, but doesn't include cache blocks (because they're handled seperately)
-	 
+
 	CacheBlockTemplate extends Template (TemplateMatcher = CacheRestrictedTemplate); CacheBlock | UncachedBlock | => ''
 	*/
-		
+
 	/*!*
-	  
-	UncachedBlock: 
+
+	UncachedBlock:
 		'<%' < "uncached" < CacheBlockArguments? ( < Conditional:("if"|"unless") > Condition:IfArgument )? > '%>'
 			Template:$TemplateMatcher?
 			'<%' < 'end_' ("uncached"|"cached"|"cacheblock") > '%>'
@@ -623,53 +623,53 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function UncachedBlock_Template(&$res, $sub){
 		$res['php'] = $sub['php'];
 	}
-	
+
 	/*!*
-	
+
 	# CacheRestrictedTemplate is the same as Template, but doesn't allow cache blocks
-	 
+
 	CacheRestrictedTemplate extends Template
 	*/
-	function CacheRestrictedTemplate_CacheBlock(&$res, $sub) { 
+	function CacheRestrictedTemplate_CacheBlock(&$res, $sub) {
 		throw new SSTemplateParseException('You cant have cache blocks nested within with, loop or control blocks ' .
 			'that are within cache blocks', $this);
 	}
-	
-	function CacheRestrictedTemplate_UncachedBlock(&$res, $sub) { 
+
+	function CacheRestrictedTemplate_UncachedBlock(&$res, $sub) {
 		throw new SSTemplateParseException('You cant have uncache blocks nested within with, loop or control blocks ' .
 			'that are within cache blocks', $this);
 	}
-	
+
 	/*!*
 	# The partial caching block
-	 
-	CacheBlock: 
+
+	CacheBlock:
 		'<%' < CacheTag:("cached"|"cacheblock") < (CacheBlockArguments)? ( < Conditional:("if"|"unless") >
 		Condition:IfArgument )? > '%>'
 			(CacheBlock | UncachedBlock | CacheBlockTemplate)*
 		'<%' < 'end_' ("cached"|"uncached"|"cacheblock") > '%>'
-	 
+
 	*/
 	function CacheBlock__construct(&$res){
 		$res['subblocks'] = 0;
 	}
-	
+
 	function CacheBlock_CacheBlockArguments(&$res, $sub){
 		$res['key'] = !empty($sub['php']) ? $sub['php'] : '';
 	}
-	
+
 	function CacheBlock_Condition(&$res, $sub){
 		$res['condition'] = ($res['Conditional']['text'] == 'if' ? '(' : '!(') . $sub['php'] . ') && ';
 	}
-	
+
 	function CacheBlock_CacheBlock(&$res, $sub){
 		$res['php'] .= $sub['php'];
 	}
-	
+
 	function CacheBlock_UncachedBlock(&$res, $sub){
 		$res['php'] .= $sub['php'];
 	}
-	
+
 	function CacheBlock_CacheBlockTemplate(&$res, $sub){
 		// Get the block counter
 		$block = ++$res['subblocks'];
@@ -694,21 +694,21 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			. ".'_$block'"; // block index
 		// Get any condition
 		$condition = isset($res['condition']) ? $res['condition'] : '';
-		
+
 		$res['php'] .= 'if ('.$condition.'($partial = $cache->load('.$key.'))) $val .= $partial;' . PHP_EOL;
 		$res['php'] .= 'else { $oldval = $val; $val = "";' . PHP_EOL;
 		$res['php'] .= $sub['php'] . PHP_EOL;
 		$res['php'] .= $condition . ' $cache->save($val); $val = $oldval . $val;' . PHP_EOL;
 		$res['php'] .= '}';
 	}
-	
+
 	/*!*
-	 
+
 	# Deprecated old-style i18n _t and sprintf(_t block tags. We support a slightly more flexible version than we used
 	# to, but just because it's easier to do so. It's strongly recommended to use the new syntax
-	 
+
 	# This is the core used by both syntaxes, without the block start & end tags
-	 
+
 	OldTPart: "_t" N "(" N QuotedString (N "," N CallArguments)? N ")" N (";")?
 
 	# whitespace with a newline
@@ -717,7 +717,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function OldTPart__construct(&$res) {
 		$res['php'] = "_t(";
 	}
-	
+
 	function OldTPart_QuotedString(&$res, $sub) {
 		$entity = $sub['String']['text'];
 		if (strpos($entity, '.') === false) {
@@ -727,7 +727,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			$res['php'] .= "'$entity'";
 		}
 	}
-	
+
 	function OldTPart_CallArguments(&$res, $sub) {
 		$res['php'] .= ',' . $sub['php'];
 	}
@@ -735,29 +735,29 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function OldTPart__finalise(&$res) {
 		$res['php'] .= ')';
 	}
-	
+
 	/*!*
-	 
+
 	# This is the old <% _t() %> tag
-	 
+
 	OldTTag: "<%" < OldTPart > "%>"
-	
+
 	*/
 	function OldTTag_OldTPart(&$res, $sub) {
 		$res['php'] = $sub['php'];
 	}
 
 	/*!*
-	 
+
 	# This is the old <% sprintf(_t()) %> tag
-	 
-	OldSprintfTag: "<%" < "sprintf" < "(" < OldTPart < "," < CallArguments > ")" > "%>" 
-	
+
+	OldSprintfTag: "<%" < "sprintf" < "(" < OldTPart < "," < CallArguments > ")" > "%>"
+
 	*/
 	function OldSprintfTag__construct(&$res) {
 		$res['php'] = "sprintf(";
 	}
-	
+
 	function OldSprintfTag_OldTPart(&$res, $sub) {
 		$res['php'] .= $sub['php'];
 	}
@@ -765,15 +765,15 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	function OldSprintfTag_CallArguments(&$res, $sub) {
 		$res['php'] .= ',' . $sub['php'] . ')';
 	}
-	
+
 	/*!*
-	
+
 	# This matches either the old style sprintf(_t()) or _t() tags. As well as including the output portion of the
 	# php, this rule combines all the old i18n stuff into a single match rule to make it easy to not support these
-	# tags later 
-	 
+	# tags later
+
 	OldI18NTag: OldSprintfTag | OldTTag
-	 
+
 	*/
 	function OldI18NTag_STR(&$res, $sub) {
 		$res['php'] = '$val .= ' . $sub['php'] . ';';
@@ -829,7 +829,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		$template = $res['template'];
 		$arguments = $res['arguments'];
 
-		$res['php'] = '$val .= SSViewer::execute_template('.$template.', $scope->getItem(), array(' . 
+		$res['php'] = '$val .= SSViewer::execute_template('.$template.', $scope->getItem(), array(' .
 			implode(',', $arguments)."), \$scope);\n";
 
 		if($this->includeDebuggingComments) { // Add include filename comments on dev sites
@@ -841,26 +841,26 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	}
 
 	/*!*
-	
+
 	# To make the block support reasonably extendable, we don't explicitly define each closed block and it's structure,
 	# but instead match against a generic <% block_name argument, ... %> pattern. Each argument is left as per the
 	# output of the Argument matcher, and the handler (see the PHPDoc block later for more on this) is responsible
-	# for pulling out the info required 
-	 
-	BlockArguments: :Argument ( < "," < :Argument)* 
-	
+	# for pulling out the info required
+
+	BlockArguments: :Argument ( < "," < :Argument)*
+
 	# NotBlockTag matches against any word that might come after a "<%" that the generic open and closed block handlers
-	# shouldn't attempt to match against, because they're handled by more explicit matchers 
-	 
+	# shouldn't attempt to match against, because they're handled by more explicit matchers
+
 	NotBlockTag: "end_" | (("if" | "else_if" | "else" | "require" | "cached" | "uncached" | "cacheblock" | "include")])
-	
+
 	# Match against closed blocks - blocks with an opening and a closing tag that surround some internal portion of
 	# template
-	 
-	ClosedBlock: '<%' < !NotBlockTag BlockName:Word ( [ :BlockArguments ] )? > Zap:'%>' Template:$TemplateMatcher? 
+
+	ClosedBlock: '<%' < !NotBlockTag BlockName:Word ( [ :BlockArguments ] )? > Zap:'%>' Template:$TemplateMatcher?
 		'<%' < 'end_' '$BlockName' > '%>'
 	*/
-	
+
 	/**
 	 * As mentioned in the parser comment, block handling is kept fairly generic for extensibility. The match rule
 	 * builds up two important elements in the match result array:
@@ -870,15 +870,15 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	 * Once a block has successfully been matched against, it will then look for the actual handler, which should
 	 * be on this class (either defined or extended on) as ClosedBlock_Handler_Name(&$res), where Name is the
 	 * tag name, first letter captialized (i.e Control, Loop, With, etc).
-	 * 
+	 *
 	 * This function will be called with the match rule result array as it's first argument. It should return
 	 * the php result of this block as it's return value, or throw an error if incorrect arguments were passed.
 	 */
-	
+
 	function ClosedBlock__construct(&$res) {
 		$res['ArgumentCount'] = 0;
 	}
-	
+
 	function ClosedBlock_BlockArguments(&$res, $sub) {
 		if (isset($sub['Argument']['ArgumentMode'])) {
 			$res['Arguments'] = array($sub['Argument']);
@@ -921,7 +921,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			if ($arg['ArgumentMode'] == 'string') {
 				throw new SSTemplateParseException('Control block cant take string as argument.', $this);
 			}
-			$on = str_replace('$$FINAL', 'obj', 
+			$on = str_replace('$$FINAL', 'obj',
 				($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
 		}
 
@@ -939,7 +939,7 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		Deprecation::notice('4.0', '<% control %> is deprecated. Use <% with %> or <% loop %> instead.');
 		return $this->ClosedBlock_Handle_Loop($res);
 	}
-	
+
 	/**
 	 * The closed block handler for with blocks
 	 */
@@ -948,30 +948,53 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			throw new SSTemplateParseException('Either no or too many arguments in with block. Must be one ' .
 				'argument only.', $this);
 		}
-		
+
 		$arg = $res['Arguments'][0];
 		if ($arg['ArgumentMode'] == 'string') {
 			throw new SSTemplateParseException('Control block cant take string as argument.', $this);
 		}
-		
+
 		$on = str_replace('$$FINAL', 'obj', ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
-		return 
+		return
 			$on . '; $scope->pushScope();' . PHP_EOL .
 				$res['Template']['php'] . PHP_EOL .
 			'; $scope->popScope(); ';
 	}
-	
+
+	/**
+	 * The closed block handler for withif blocks
+	 */
+	function ClosedBlock_Handle_Withif(&$res) {
+		if ($res['ArgumentCount'] != 1) {
+			throw new SSTemplateParseException('Either no or too many arguments in withif block. Must be one ' .
+				'argument only.', $this);
+		}
+
+		$arg = $res['Arguments'][0];
+		if ($arg['ArgumentMode'] == 'string') {
+			throw new SSTemplateParseException('Control block cant take string as argument.', $this);
+		}
+
+		$if = str_replace('$$FINAL', 'hasValue', ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
+		$on = str_replace('$$FINAL', 'obj', ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php']);
+		return
+			'if (' . $if . ') {'.
+			$on . '; $scope->pushScope();' . PHP_EOL .
+				$res['Template']['php'] . PHP_EOL .
+			'; $scope->popScope(); }';
+	}
+
 	/*!*
-	 
+
 	# Open blocks are handled in the same generic manner as closed blocks. There is no need to define which blocks
 	# are which - closed is tried first, and if no matching end tag is found, open is tried next
-	  
+
 	OpenBlock: '<%' < !NotBlockTag BlockName:Word ( [ :BlockArguments ] )? > '%>'
 	*/
 	function OpenBlock__construct(&$res) {
 		$res['ArgumentCount'] = 0;
 	}
-	
+
 	function OpenBlock_BlockArguments(&$res, $sub) {
 		if (isset($sub['Argument']['ArgumentMode'])) {
 			$res['Arguments'] = array($sub['Argument']);
@@ -1004,9 +1027,9 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		if ($res['ArgumentCount'] == 0) return '$scope->debug();';
 		else if ($res['ArgumentCount'] == 1) {
 			$arg = $res['Arguments'][0];
-			
+
 			if ($arg['ArgumentMode'] == 'string') return 'Debug::show('.$arg['php'].');';
-			
+
 			$php = ($arg['ArgumentMode'] == 'default') ? $arg['lookup_php'] : $arg['php'];
 			return '$val .= Debug::show('.str_replace('FINALGET!', 'cachedCall', $php).');';
 		}
@@ -1030,26 +1053,26 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		if ($res['ArgumentCount'] != 0) throw new SSTemplateParseException('Current_page takes no arguments', $this);
 		return '$val .= $_SERVER[SCRIPT_URL];';
 	}
-	
+
 	/*!*
-	
+
 	# This is used to detect when we have a mismatched closing tag (i.e., one with no equivilent opening tag)
 	# Because of parser limitations, this can only be used at the top nesting level of a template. Other mismatched
-	# closing tags are detected as an invalid open tag  
-	 
+	# closing tags are detected as an invalid open tag
+
 	MismatchedEndBlock: '<%' < 'end_' :Word > '%>'
 	*/
 	function MismatchedEndBlock__finalise(&$res) {
 		$blockname = $res['Word']['text'];
-		throw new SSTemplateParseException('Unexpected close tag end_' . $blockname . 
+		throw new SSTemplateParseException('Unexpected close tag end_' . $blockname .
 			' encountered. Perhaps you have mis-nested blocks, or have mis-spelled a tag?', $this);
 	}
 
-	/*!*	
-	 
+	/*!*
+
 	# This is used to detect a malformed opening tag - one where the tag is opened with the "<%" characters, but
-	# the tag is not structured properly 
-	 
+	# the tag is not structured properly
+
 	MalformedOpenTag: '<%' < !NotBlockTag Tag:Word  !( ( [ :BlockArguments ] )? > '%>' )
 	*/
 	function MalformedOpenTag__finalise(&$res) {
@@ -1057,12 +1080,12 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		throw new SSTemplateParseException("Malformed opening block tag $tag. Perhaps you have tried to use operators?"
 			, $this);
 	}
-	
+
 	/*!*
-	 
+
 	# This is used to detect a malformed end tag - one where the tag is opened with the "<%" characters, but
-	# the tag is not structured properly 
-	 
+	# the tag is not structured properly
+
 	MalformedCloseTag: '<%' < Tag:('end_' :Word ) !( > '%>' )
 	*/
 	function MalformedCloseTag__finalise(&$res) {
@@ -1070,32 +1093,32 @@ class SSTemplateParser extends Parser implements TemplateParser {
 		throw new SSTemplateParseException("Malformed closing block tag $tag. Perhaps you have tried to pass an " .
 			"argument to one?", $this);
 	}
-	
+
 	/*!*
-	 
+
 	# This is used to detect a malformed tag. It's mostly to keep the Template match rule a bit shorter
-	 
+
 	MalformedBlock: MalformedOpenTag | MalformedCloseTag
 	*/
 
 	/*!*
-	 
+
 	# This is used to remove template comments
-	 
+
 	Comment: "<%--" (!"--%>" /(?s)./)+ "--%>"
 	*/
 	function Comment__construct(&$res) {
 		$res['php'] = '';
 	}
-		
+
 	/*!*
-	
+
 	# TopTemplate is the same as Template, but should only be used at the top level (not nested), as it includes
-	# MismatchedEndBlock detection, which only works at the top level  
-	 
+	# MismatchedEndBlock detection, which only works at the top level
+
 	TopTemplate extends Template (TemplateMatcher = Template); MalformedBlock => MalformedBlock | MismatchedEndBlock
 	*/
-	
+
 	/**
 	 * The TopTemplate also includes the opening stanza to start off the template
 	 */
@@ -1104,11 +1127,11 @@ class SSTemplateParser extends Parser implements TemplateParser {
 	}
 
 	/*!*
-	
-	# Text matches anything that isn't a template command (not an injection, block of any kind or comment) 
-	 
+
+	# Text matches anything that isn't a template command (not an injection, block of any kind or comment)
+
 	Text: (
-			# Any set of characters that aren't potentially a control mark or an escaped character 
+			# Any set of characters that aren't potentially a control mark or an escaped character
 			/ [^<${\\]+ / |
 			# An escaped character
 			/ (\\.) / |
@@ -1122,13 +1145,13 @@ class SSTemplateParser extends Parser implements TemplateParser {
 			'{$' !(/[A-Za-z_]/)
 		)+
 	*/
-	
+
 	/**
-	 * We convert text 
+	 * We convert text
 	 */
 	function Text__finalise(&$res) {
 		$text = $res['text'];
-		
+
 		// Unescape any escaped characters in the text, then put back escapes for any single quotes and backslashes
 		$text = stripslashes($text);
 		$text = addcslashes($text, '\'\\');
@@ -1149,14 +1172,14 @@ EOC;
 
 		$res['php'] .= '$val .= \'' . $text . '\';' . PHP_EOL;
 	}
-		
+
 	/******************
 	 * Here ends the parser itself. Below are utility methods to use the parser
 	 */
-	
+
 	/**
 	 * Compiles some passed template source code into the php code that will execute as per the template source.
-	 * 
+	 *
 	 * @throws SSTemplateParseException
 	 * @param  $string The source of the template
 	 * @param string $templateName The name of the template, normally the filename the template source was loaded from
@@ -1170,13 +1193,13 @@ EOC;
 		}
 		else {
 			parent::__construct($string);
-			
+
 			$this->includeDebuggingComments = $includeDebuggingComments;
-	
+
 			// Ignore UTF8 BOM at begining of string. TODO: Confirm this is needed, make sure SSViewer handles UTF
 			// (and other encodings) properly
 			if(substr($string, 0,3) == pack("CCC", 0xef, 0xbb, 0xbf)) $this->pos = 3;
-			
+
 			// Match the source against the parser
 			if ($topTemplate) {
 				$result = $this->match_TopTemplate();
@@ -1184,7 +1207,7 @@ EOC;
 				$result = $this->match_Template();
 			}
 			if(!$result) throw new SSTemplateParseException('Unexpected problem parsing template', $this);
-	
+
 			// Get the result
 			$code = $result['php'];
 		}
@@ -1192,8 +1215,8 @@ EOC;
 		// Include top level debugging comments if desired
 		if($includeDebuggingComments && $templateName && stripos($code, "<?xml") === false) {
 			$code = $this->includeDebuggingComments($code, $templateName);
-		}	
-		
+		}
+
 		return $code;
 	}
 
@@ -1229,11 +1252,11 @@ EOC;
 		}
 		return $code;
 	}
-	
+
 	/**
 	 * Compiles some file that contains template source code, and returns the php code that will execute as per that
 	 * source
-	 * 
+	 *
 	 * @static
 	 * @param  $template - A file path that contains template source code
 	 * @return mixed|string - The php that, when executed (via include or exec) will behave as per the template source


### PR DESCRIPTION
***Don't merge yet please*** - this is a proof of concept to start a discussion.

Before
```html
<% if $Thing %>
	<% with $Thing %>
		$SomeProperty
	<% end_with %>
<% end_if %>
```

After
```html
<% withif $Thing %>
	$SomeProperty
<% end_withif %>
```

Just a little time saver for a common pattern. If people like the idea I'll add tests and docs etc. to this PR, and maybe a `loopif` equivalent - though that's a bit less useful as you often want to add a wrapper element around a loop block.

Assuming people like this idea what do we think of the block name `withif`? I don't love it but couldn't think of anything else that's fairly expressive but also compact.

Note: white space changes are due to .editorconfig... thought about removing them but if the config says that's the way to do it do we leave them in? FYI you can view the changes and [ignore whitespace changes by adding '?w=1' to the URL](https://github.com/silverstripe/silverstripe-framework/pull/4880/files?w=1).