### PR TITLE
jquery.jstree patched to improve drag-and-drop handling

### DIFF
--- a/thirdparty/jstree/jquery.jstree.js
+++ b/thirdparty/jstree/jquery.jstree.js
@@ -1,5 +1,5 @@
 /*
- * jsTree 1.0-rc3
+ * jsTree (custom version for SilverStripe: 1.0-rc3 + minor bugfixes)
  * http://jstree.com/
  *
  * Copyright (c) 2010 Ivan Bozhanov (vakata.com)
@@ -2442,7 +2442,7 @@
 							0);
 						}
 					}, this))
-				.delegate("a", "mouseup.jstree", $.proxy(function (e) { 
+				.delegate("a, #jstree-marker-line", "mouseup.jstree", $.proxy(function (e) {
 						if($.vakata.dnd.is_drag && $.vakata.dnd.user_data.jstree) {
 							this.dnd_finish(e);
 						}
@@ -2524,7 +2524,7 @@
 								$.vakata.dnd.helper.children("ins").attr("class","jstree-invalid");
 							}
 						}, this))
-					.delegate(s.drop_target, "mouseup.jstree-" + this.get_index(), $.proxy(function (e) {
+					.delegate(s.drop_target + ", #jstree-marker-line", "mouseup.jstree-" + this.get_index(), $.proxy(function (e) {
 							if(this.data.dnd.active && $.vakata.dnd.helper.children("ins").hasClass("jstree-ok")) {
 								this._get_settings().dnd.drop_finish.call(this, { "o" : o, "r" : $(e.target), "e" : e });
 							}


### PR DESCRIPTION
This proposes a fix of #4881. The two small patches are backported from https://github.com/vakata/jstree/issues/174#issuecomment-8060768 and https://github.com/vakata/jstree/issues/174#issuecomment-8135128.

There are some other useability issues remaining but it is the fastest way to fix this especially annoying issue. Updating to a new jstree version seems to be more work...

P.S.: I am not sure about how to handle changes to a thirdparty library. I have only added a notice at the beginning of the js file.