### PR TITLE
Small optimizations for 'Hierachy::Children' and 'Config' class.

### DIFF
--- a/core/ClassInfo.php
+++ b/core/ClassInfo.php
@@ -20,10 +20,13 @@ class ClassInfo {
 	}
 
 	/**
-	 * @todo Improve documentation
+	 * Returns true if a class or interface name exists.
+	 *
+	 * @param  string $class
+	 * @return bool
 	 */
 	public static function exists($class) {
-		return SS_ClassLoader::instance()->classExists($class);
+		return class_exists($class, false) || interface_exists($class, false) || SS_ClassLoader::instance()->getItemPath($class);
 	}
 
 	/**

--- a/core/Config.php
+++ b/core/Config.php
@@ -514,7 +514,7 @@ class Config {
 		// Include extensions only if not flagged not to, and some have been set
 		if (($sourceOptions & self::EXCLUDE_EXTRA_SOURCES) != self::EXCLUDE_EXTRA_SOURCES) {
 			// If we don't have a fresh list of extra sources, get it from the class itself
-			if (!isset($class[$this->extraConfigSources]) || $class[$this->extraConfigSources] === null) {
+			if (!array_key_exists($class, $this->extraConfigSources)) {
 				$this->extraConfigSources[$class] = Object::get_extra_config_sources($class);
 			}
 
@@ -617,7 +617,7 @@ class Config {
 		} else {
 			if (!isset($this->overrides[0][$class])) $this->overrides[0][$class] = array();
 
-			if (!isset($name[$this->overrides[0][$class]]) || $name[$this->overrides[0][$class]] === null) {
+			if (!array_key_exists($name, $this->overrides[0][$class])) {
 				$this->overrides[0][$class][$name] = $val;
 			} else {
 				self::merge_high_into_low($this->overrides[0][$class][$name], $val);

--- a/core/Config.php
+++ b/core/Config.php
@@ -514,7 +514,7 @@ class Config {
 		// Include extensions only if not flagged not to, and some have been set
 		if (($sourceOptions & self::EXCLUDE_EXTRA_SOURCES) != self::EXCLUDE_EXTRA_SOURCES) {
 			// If we don't have a fresh list of extra sources, get it from the class itself
-			if (!array_key_exists($class, $this->extraConfigSources)) {
+			if (!isset($class[$this->extraConfigSources]) || $class[$this->extraConfigSources] === null) {
 				$this->extraConfigSources[$class] = Object::get_extra_config_sources($class);
 			}
 
@@ -617,7 +617,7 @@ class Config {
 		} else {
 			if (!isset($this->overrides[0][$class])) $this->overrides[0][$class] = array();
 
-			if (!array_key_exists($name, $this->overrides[0][$class])) {
+			if (!isset($name[$this->overrides[0][$class]]) || $name[$this->overrides[0][$class]] === null) {
 				$this->overrides[0][$class][$name] = $val;
 			} else {
 				self::merge_high_into_low($this->overrides[0][$class][$name], $val);

--- a/core/manifest/ClassLoader.php
+++ b/core/manifest/ClassLoader.php
@@ -101,6 +101,7 @@ class SS_ClassLoader {
 	 * @return bool
 	 */
 	public function classExists($class) {
+		Deprecation::notice('3.3', 'Not necessary anymore as this function is inlined in \'ClassInfo::exists\' for speed and that\'s the only place where it is used in core.');
 		return class_exists($class, false) || interface_exists($class, false) || $this->getItemPath($class);
 	}
 

--- a/core/manifest/ClassLoader.php
+++ b/core/manifest/ClassLoader.php
@@ -101,8 +101,8 @@ class SS_ClassLoader {
 	 * @return bool
 	 */
 	public function classExists($class) {
-		Deprecation::notice('3.3', 'Not necessary anymore as this function is inlined in \'ClassInfo::exists\' for speed and that\'s the only place where it is used in core.');
-		return class_exists($class, false) || interface_exists($class, false) || $this->getItemPath($class);
+		Deprecation::notice('4.0', 'Use ClassInfo::exists.');
+		return ClassInfo::exists($class);
 	}
 
 }

--- a/model/Hierarchy.php
+++ b/model/Hierarchy.php
@@ -493,10 +493,14 @@ class Hierarchy extends DataExtension {
 	public function Children() {
 		if(!(isset($this->_cache_children) && $this->_cache_children)) {
 			$result = $this->owner->stageChildren(false);
-			$this->_cache_children = $result->filterByCallback(function($item) {
-				return $item->canView();
-			});
-					}
+			$children = array();
+			foreach ($result as $record) {
+				if ($record->canView()) {
+					$children[] = $record;
+				}
+			}
+			$this->_cache_children = new ArrayList($children);
+		}
 		return $this->_cache_children;
 	}
 


### PR DESCRIPTION
Replaced filterByCallback for 'Children' to just create a new array as function calls are exponentially expensive in PHP (the more functions that exist, the slower a function call becomes) and replaced 'array_key_exists' with op-code equivalent for speed. The best increase isn't really noticeable but we should work towards optimizing the core as much as possible.