### PR TITLE
Removed validation from LookupField as it's readonly

### DIFF
--- a/forms/LookupField.php
+++ b/forms/LookupField.php
@@ -80,6 +80,24 @@ class LookupField extends DropdownField {
 	}
 
 	/**
+	 * Ignore validation as the field is readonly 
+	 *
+	 * @param Validator $validator
+	 * @return bool
+	 */
+	public function validate($validator) {
+		return true;
+	}
+
+	/**
+	 * Stubbed so invalid data doesn't save into the DB
+	 *
+	 * @param DataObjectInterface $record DataObject to save data into
+	 */
+	public function saveInto(DataObjectInterface $record) {
+	}
+
+	/**
 	 * @return LookupField
 	 */
 	public function performReadonlyTransformation() {


### PR DESCRIPTION
This pull request covers an issue fixed in pull request #4851 (cherry picked the changes). The affect of not including this is that when a CMS editor reverts a sitetree page a validation error is thrown on null dropdown fields, core cms feature issue. Have discussed this with @chillu and got his ok.