### PR TITLE
Fix: Allow TinyMCE from-web image inserts to use https scheme.

### DIFF
--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -350,7 +350,7 @@ class HtmlEditorField_Toolbar extends RequestHandler {
 		$fromWeb = new CompositeField(
 			new LiteralField('headerURL',
 				'<h4>' . sprintf($numericLabelTmpl, '1', _t('HtmlEditorField.ADDURL', 'Add URL')) . '</h4>'),
-			$remoteURL = new TextField('RemoteURL', 'http://'),
+			$remoteURL = new TextField('RemoteURL', ''),
 			new LiteralField('addURLImage',
 				'<button type="button" class="action ui-action-constructive ui-button field add-url" data-icon="addMedia">' .
 				_t('HtmlEditorField.BUTTONADDURL', 'Add url').'</button>')

--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -1136,9 +1136,9 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 
 			validate: function() {
 				var val = this.val(), orig = val;
-				
+
 				val = $.trim(val);
-				val = val.replace(/^https?:\/\//i, '');
+
 				if (orig !== val) this.val(val);
 
 				this.getAddButton().button(!!val ? 'enable' : 'disable');
@@ -1158,8 +1158,17 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 				var urlField = this.getURLField(), container = this.closest('.CompositeField'), form = this.closest('form');
 
 				if (urlField.validate()) {
+
+					var val = urlField.val(), orig = val;
+
 					container.addClass('loading');
-					form.showFileView('http://' + urlField.val()).done(function() {
+
+					// add "http://" if a protocol is missing from the url
+					if (val.match(/^https?:\/\//i) == void 0) {
+						val = 'http://' + val;
+					}
+
+					form.showFileView(val).done(function() {
 						container.removeClass('loading');
 					});
 					form.redraw();


### PR DESCRIPTION
A [bug fix](https://github.com/silverstripe/silverstripe-framework/pull/556/files) for a [url validation issue](http://open.silverstripe.org/ticket/7494#no1) made four years ago rendered CMS authors unable to add images from-web using the https scheme.

This is troublesome for some government agencies that have https-only sites - this fix was requested by Pharmac for an https-only site they maintain.
