### PR TITLE
Display all roles when an admin, filter by OnlyAdminCanApply when not

### DIFF
--- a/security/Group.php
+++ b/security/Group.php
@@ -183,7 +183,7 @@ class Group extends DataObject {
 
 			// Add roles (and disable all checkboxes for inherited roles)
 			$allRoles = PermissionRole::get();
-			if(Permission::check('ADMIN')) {
+			if(!Permission::check('ADMIN')) {
 				$allRoles = $allRoles->filter("OnlyAdminCanApply", 0);
 			}
 			if($this->ID) {


### PR DESCRIPTION
There's a logic problem when trying to apply Roles to Groups. When the `OnlyAdminCanApply` checkbox for Roles is check, the Roles don't show up in the dropdown for Groups when the logged in user is an admin. It does appear when the logged in user is not an admin.
<img width="762" alt="screen shot 2016-01-11 at 14 37 16" src="https://cloud.githubusercontent.com/assets/12027814/12225509/da0fc266-b870-11e5-94fb-4710655e5a9a.png">

<img width="576" alt="screen shot 2016-01-11 at 14 37 59" src="https://cloud.githubusercontent.com/assets/12027814/12225513/f23a2aa2-b870-11e5-9794-31e939d555ca.png">

This doesn't make any sense, so I'm just reverting the logic there. When the user is an admin it will display all Roles, when not, it will filter by the `OnlyAdminCanApply` attribute.