### PR TITLE
Disabled displaying SilverStripe Development Tools header when signed in user go to /dev/build page

### DIFF
--- a/dev/DevBuildController.php
+++ b/dev/DevBuildController.php
@@ -16,16 +16,15 @@ class DevBuildController extends Controller {
 			$da = DatabaseAdmin::create();
 			return $da->handleRequest($request, $this->model);
 		} else {
-			$renderer = DebugView::create();
-			$renderer->writeHeader();
-			$renderer->writeInfo("Environment Builder", Director::absoluteBaseURL());
-			echo "<div class=\"build\">";
+			if(Director::isDev() || Permission::check("ADMIN")) {
+				$renderer = DebugView::create();
+				$renderer->writeHeader();
+				$renderer->writeInfo("Environment Builder", Director::absoluteBaseURL());
+				echo "<div class=\"build\">";
+			}
 
 			$da = DatabaseAdmin::create();
 			return $da->handleRequest($request, $this->model);
-
-			echo "</div>";
-			$renderer->writeFooter();
 		}
 	}
 

--- a/dev/DevBuildController.php
+++ b/dev/DevBuildController.php
@@ -16,15 +16,16 @@ class DevBuildController extends Controller {
 			$da = DatabaseAdmin::create();
 			return $da->handleRequest($request, $this->model);
 		} else {
-			if(Director::isDev() || Permission::check("ADMIN")) {
-				$renderer = DebugView::create();
-				$renderer->writeHeader();
-				$renderer->writeInfo("Environment Builder", Director::absoluteBaseURL());
-				echo "<div class=\"build\">";
-			}
+			$renderer = DebugView::create();
+			$renderer->writeHeader();
+			$renderer->writeInfo("Environment Builder", Director::absoluteBaseURL());
+			echo "<div class=\"build\">";
 
 			$da = DatabaseAdmin::create();
 			return $da->handleRequest($request, $this->model);
+
+			echo "</div>";
+			$renderer->writeFooter();
 		}
 	}
 

--- a/dev/DevelopmentAdmin.php
+++ b/dev/DevelopmentAdmin.php
@@ -33,7 +33,7 @@ class DevelopmentAdmin extends Controller {
 		parent::init();
 
 		// Special case for dev/build: Defer permission checks to DatabaseAdmin->init() (see #4957)
-		$requestedDevBuild = (stripos($this->getRequest()->getURL(), 'dev/build') === 0);
+		$requestedDevBuild = (stripos($this->getRequest()->getURL(), 'dev/build') === 0 && !Security::database_is_ready());
 
 		// We allow access to this controller regardless of live-status or ADMIN permission only
 		// if on CLI.  Access to this controller is always allowed in "dev-mode", or of the user is ADMIN.


### PR DESCRIPTION
Check bug:
- Set your environment to *TEST*
- Sign in to your page as **normal user** (without administrator permissions) [this bug is visible only when user is signed in]
- Go to page */dev/build*

When you set environment to TEST or LIVE then normal user shouldn't see /dev tasks but when you go to /dev/build then you'll see SilverStripe Development Tool header and it can broke your CSS styles.

I added condition that only for *dev* environment or *Admin* SS header should be visible. 

Additionally lines below *return statement* are unnecessary. 