### PR TITLE
Adding control to PDOConnector over stringifying returned values

### DIFF
--- a/src/ORM/Connect/PDOConnector.php
+++ b/src/ORM/Connect/PDOConnector.php
@@ -187,14 +187,10 @@ class PDOConnector extends DBConnector
             $charset = $connCharset;
         }
         $options = array(
-            PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES ' . $charset . ' COLLATE ' . $connCollation
+            PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES ' . $charset . ' COLLATE ' . $connCollation,
+            PDO::ATTR_EMULATE_PREPARES => self::is_emulate_prepare(),
+            PDO::ATTR_STRINGIFY_FETCHES => self::is_stringify_fetches(),
         );
-        if (self::is_emulate_prepare()) {
-            $options[PDO::ATTR_EMULATE_PREPARES] = true;
-        }
-        if (self::is_stringify_fetches()) {
-            $options[PDO::ATTR_STRINGIFY_FETCHES] = true;
-        }
 
         // May throw a PDOException if fails
         $this->pdoConnection = new PDO(

--- a/src/ORM/Connect/PDOConnector.php
+++ b/src/ORM/Connect/PDOConnector.php
@@ -22,6 +22,14 @@ class PDOConnector extends DBConnector
     private static $emulate_prepare = false;
 
     /**
+     * Should ATTR_STRINGIFY_FETCHES flag be used to make all fetched values strings?
+     *
+     * @config
+     * @var boolean
+     */
+    private static $stringify_fetches = false;
+
+    /**
      * The PDO connection instance
      *
      * @var PDO
@@ -101,6 +109,16 @@ class PDOConnector extends DBConnector
         return Config::inst()->get('SilverStripe\ORM\Connect\PDOConnector', 'emulate_prepare');
     }
 
+    /**
+     * Should we stringify fetches from the DB (ie: convert all values to strings)
+     *
+     * @return boolean
+     */
+    public static function is_stringify_fetches()
+    {
+        return (bool)Config::inst()->get('SilverStripe\ORM\Connect\PDOConnector', 'stringify_fetches');
+    }
+
     public function connect($parameters, $selectDB = false)
     {
         $this->flushStatements();
@@ -173,6 +191,9 @@ class PDOConnector extends DBConnector
         );
         if (self::is_emulate_prepare()) {
             $options[PDO::ATTR_EMULATE_PREPARES] = true;
+        }
+        if (self::is_stringify_fetches()) {
+            $options[PDO::ATTR_STRINGIFY_FETCHES] = true;
         }
 
         // May throw a PDOException if fails

--- a/tests/php/ORM/PDODatabaseTest.php
+++ b/tests/php/ORM/PDODatabaseTest.php
@@ -131,7 +131,9 @@ class PDODatabaseTest extends SapphireTest
 
         //store the current value so we can reset it back at the end
         $origStringify = $connection->getAttribute(PDO::ATTR_STRINGIFY_FETCHES);
-        $connection->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
+        @$connection->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, false);
+        $origEmulate = $connection->getAttribute(PDO::ATTR_EMULATE_PREPARES);
+        @$connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
 
 
         $result = DB::get_connector()->query(
@@ -154,6 +156,7 @@ class PDODatabaseTest extends SapphireTest
         $this->assertInternalType("string", $row['ID']);
         $this->assertInternalType("string", $row['Title']);
 
-        $connection->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, $origStringify);
+        @$connection->setAttribute(PDO::ATTR_STRINGIFY_FETCHES, $origStringify);
+        @$connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, $origEmulate);
     }
 }


### PR DESCRIPTION
At the moment we don't provide control over the `ATTR_STRINGIFY_FETCHES` attribute for PDO connections.

This plays a central role in correctly casting returned values from the DB,
