### PR TITLE
i18n::default_locale should return the value set via config.

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -2150,7 +2150,7 @@ class i18n extends Object implements TemplateGlobalProvider, Flushable {
 			self::$translators[$defaultPriority] = array(
 				'core' => new Zend_Translate(array(
 					'adapter' => 'i18nRailsYamlAdapter',
-					'locale' => self::$default_locale,
+					'locale' => Config::inst()->get('i18n', 'default_locale'),
 					'disableNotices' => true,
 				))
 			);
@@ -2375,7 +2375,7 @@ class i18n extends Object implements TemplateGlobalProvider, Flushable {
 				is_dir($moduleDir)
 				&& is_file($moduleDir . DIRECTORY_SEPARATOR . "_config.php")
 				&& is_file($moduleDir . DIRECTORY_SEPARATOR . "lang" . DIRECTORY_SEPARATOR
-					. self::$default_locale . ".php")
+					. Config::inst()->get('i18n', 'default_locale') . ".php")
 			) {
 				$translatableModules[] = $module;
 			}
@@ -2493,7 +2493,7 @@ class i18n extends Object implements TemplateGlobalProvider, Flushable {
 	 * @return string Current locale in the system
 	 */
 	public static function get_locale() {
-		return (!empty(self::$current_locale)) ? self::$current_locale : self::$default_locale;
+		return (!empty(self::$current_locale)) ? self::$current_locale : Config::inst()->get('i18n', 'default_locale');
 	}
 
 	/**
@@ -2506,20 +2506,23 @@ class i18n extends Object implements TemplateGlobalProvider, Flushable {
 	 * For example, {@link Requirements::add_i18n_javascript()} and {@link i18n::include_by_class()}
 	 * use this "fallback locale" value to include fallback language files.
 	 *
+	 * @deprecated since version 4.0; Use the "i18n.default_locale" config setting instead
 	 * @return String
 	 */
 	public static function default_locale() {
-		return self::$default_locale;
+		Deprecation::notice('4.0', 'Use the "i18n.default_locale" config setting instead');
+		return Config::inst()->get('i18n', 'default_locale');
 	}
 
 	/**
 	 * See {@link default_locale()} for usage.
 	 *
-	 *
+	 * @deprecated since version 4.0; Use the "i18n.default_locale" config setting instead
 	 * @param String $locale
 	 */
 	public static function set_default_locale($locale) {
-		self::$default_locale = $locale;
+		Deprecation::notice('4.0', 'Use the "i18n.default_locale" config setting instead');
+		Config::inst()->update('i18n', 'default_locale', $locale);
 	}
 
 	/**


### PR DESCRIPTION
Deprecate `default_locale` setter and getter methods, analoguous to other config getters and setters.
Fixes #4920.