### PR TITLE
DOCS 2.4 : fixes broken internal links

### DIFF
--- a/docs/en/installation/windows-manual-iis-7.md
+++ b/docs/en/installation/windows-manual-iis-7.md
@@ -50,7 +50,7 @@ IIS 7.x comes with Windows. However, it needs to be installed. Follow these step
 
 **NOTE**: These instructions are slightly different for Windows Vista and Windows 7. Instead of a Server Manager popup, you'll just get a list of features to enable. Do the same as above except click the **Internet Information Services** checkbox when the Windows Features popup appears and then expand this node and select **CGI** under World Wide Web Services > Application Development Features.
 
-Once the installation is finished, browse to http://localhost in your browser. If an image pops up, then IIS has been installed correctly.
+Once the installation is finished, browse to `http://localhost` in your browser. If an image pops up, then IIS has been installed correctly.
 
 ## IIS URL Rewrite Module
 

--- a/docs/en/misc/module-release-process.md
+++ b/docs/en/misc/module-release-process.md
@@ -44,7 +44,7 @@ available for opensource projects, including wiki and bugtracker functionality
 your modules page on silverstripe.org
 * Be involved in our community 
     * Subscripe to our developer mailing list and be available to answer questions on the forum. 
-    * Attend [irc:our weekly core discussions on IRC](irc/our weekly core discussions on IRC) as regularly as you can.
+    * Attend [irc:our weekly core discussions on IRC](https://irc.silverstripe.org) as regularly as you can.
 * Create an **issue tracker** so your users can file bugs and feature requests (see ["Feedback and Bugtracking"](module-release-process#feedback-and-bugtracking) below)
 * Create a **roadmap** and **milestones** outlining future release planning
 

--- a/docs/en/topics/commandline.md
+++ b/docs/en/topics/commandline.md
@@ -53,7 +53,7 @@ To work this out, you should add lines of this form to your [_ss_environment.php
 
 
 What the line says is that any Folder under /Users/sminnee/Sites/ can be accessed in a web browser from
-http://localhost.  For example, /Users/sminnee/Sites/mysite will be available at `http://localhost/mysite`.
+`http://localhost`.  For example, /Users/sminnee/Sites/mysite will be available at `http://localhost/mysite`.
 
 You can add multiple file to url mapping definitions.  The most specific mapping will be used. For example:
 
@@ -63,8 +63,8 @@ You can add multiple file to url mapping definitions.  The most specific mapping
 	$_FILE_TO_URL_MAPPING['/Users/sminnee/Sites/mysite'] = 'http://mysite.localhost';
 
 
-Using this example, /Users/sminnee/Sites/mysite/ would be accessed at http://mysite.localhost/, and
-/Users/sminnee/Sites/othersite/ would be accessed at http://localhost/othersite/
+Using this example, /Users/sminnee/Sites/mysite/ would be accessed at `http://mysite.localhost/`, and
+/Users/sminnee/Sites/othersite/ would be accessed at `http://localhost/othersite/`
 
 ## Usage
 

--- a/docs/en/topics/modules.md
+++ b/docs/en/topics/modules.md
@@ -90,4 +90,4 @@ Exit the editor and then run
 **Useful Links:**
 
 *  [Module Development](/topics/module-development)
-*  [Module Release Process](/topics/module-release-process)
+*  [Module Release Process](/misc/module-release-process)


### PR DESCRIPTION
Following up on rewrite rules (see silverstripe/doc.silverstripe.org/pull/91)