### PR TITLE
DOCS 3.0 : fixes broken internal links

### DIFF
--- a/docs/en/changelogs/2.3.0.md
+++ b/docs/en/changelogs/2.3.0.md
@@ -7,7 +7,7 @@
 **Don't use Translatable for multilingual database content.  Don't upgrade to 2.3.0 if you're already using
 Translatable.**
 
-The [Translatable extension](/topics/translation) is currently marked as
+The [Translatable extension](/topics/i18n) is currently marked as
 unstable for the initial 2.3 release. **If your site uses more than one language for page content, don't upgrade to this
 release.** We're working on bugfixes which will be contained in a minor 2.3.x release soon. Check our [releaseannouncements](http://groups.google.com/group/silverstripe-announce) for updates on Translatable bugfixes.
 
@@ -33,7 +33,7 @@ calling `dev/build`. See [#2847](http://open.silverstripe.com/ticket/2847)
 
 ### Newsletter moved into new module
 
-Newsletter functionality has been moved into its own module called **[newsletter](modules/newsletter)**. If you were
+Newsletter functionality has been moved into its own module called **[newsletter](http://addons.silverstripe.org/add-ons/silverstripe/newsletter)**. If you were
 previously using this as a feature out of the box with SilverStripe, then you will need to download the userforms module
 to continue using it.
 
@@ -197,7 +197,7 @@ also that the DOCTYPE altering, which was a frequent cause of pain, only execute
 *  Removed deprecated File::loadallcontent(), use Upload class
 *  Image->URL returns relative instead of absolute URL.  Use Image->AbsoluteURL instead.
 *  Moved DataReport and SQLReport into the ecommerce module.  If you're using these classes, please download the
-[ecommerce module](modules/ecommerce).
+[ecommerce module](http://addons.silverstripe.org/add-ons?search=ecommerce).
 
 ### Default mysite/_config.php
 

--- a/docs/en/changelogs/2.3.2.md
+++ b/docs/en/changelogs/2.3.2.md
@@ -31,9 +31,9 @@ Here's an example of how the default Blackcandy theme was changed:
 
 The datamodel for the Translatable extension was changed from multiple language tables to multiple rows for each
 translated record in the original table. We've also introduced the concept of "Translation groups", which means not
-every translated record has to exist in a "master language". Please review our updated documentation on how to [enable Translatable](/topics/translation).
+every translated record has to exist in a "master language". Please review our updated documentation on how to [enable Translatable](/misc/contributing/translation).
 
-If you are upgrading an existing database with existing translations, you'll need to run our [Migration Script](/topics/translation#migrating_from_2.1_datamodel) before using the
+If you are upgrading an existing database with existing translations, you'll need to migrate these before using the
 database. 
 
 For in-depth discussion of the schema changes and translation groups, please refer to our developer mailinglist:

--- a/docs/en/changelogs/index.md
+++ b/docs/en/changelogs/index.md
@@ -23,7 +23,7 @@ For information on how to upgrade to newer versions consult the [upgrading](/ins
  * [2.4.7](2.4.7) - 1 February 2012
  * [2.4.6](2.4.6) - 18 October 2011
  * [2.4.10](2.4.10) - 2013-02-19
- * [2.4.9](2.4.9) - 2012-12-04
+ * 2.4.9 - 2012-12-04
  * [2.4.8](2.4.8) - 2012-10-30
  * [2.4.7](2.4.7) - 2012-02-01
  * [2.4.6](2.4.6) - 2011-10-17
@@ -111,8 +111,8 @@ For information on how to upgrade to newer versions consult the [upgrading](/ins
 
 
  * [2.3.11-rc1](rc/2.3.11-rc1) - 31 January 2011
- * [2.3.10-rc2](rc/2.3.10-rc2) - 20 December 2010
- * [2.3.10-rc1](rc/2.3.10-rc1) - 10 December 2010
- * [2.3.9-rc2](rc/2.3.9-rc2) - 4 November 2010
- * [2.3.9-rc1](rc/2.3.9-rc1) - 1 November 2010
+ * 2.3.10-rc2 - 20 December 2010
+ * 2.3.10-rc1 - 10 December 2010
+ * 2.3.9-rc2 - 4 November 2010
+ * 2.3.9-rc1 - 1 November 2010
  * [2.3.8-rc1](rc/2.3.8-rc1) - 16 July 2010

--- a/docs/en/howto/customize-cms-menu.md
+++ b/docs/en/howto/customize-cms-menu.md
@@ -32,7 +32,7 @@ removing the "Admin" bit at the end.
  
 In order to localize the menu title in different languages, use the `<classname>.MENUTITLE`
 entity name, which is automatically created when running the i18n text collection.
-For more information on language and translations, please refer to the [i18n](../reference/ii8n) docs.
+For more information on language and translations, please refer to the [i18n](/topics/1i8n) docs.
 	
 ## Related
 

--- a/docs/en/howto/navigation-menu.md
+++ b/docs/en/howto/navigation-menu.md
@@ -18,4 +18,4 @@ located in `themes/<mytheme>/templates/Page.ss`.
      	<% end_loop %> 
     </ul>
 
-More details on creating a menu are explained as part of ["Tutorial 1: Building a basic site"](/tutorials/1-building-a-basic-site), as well as ["Page type templates" topic](/topics/page-type-templates).
+More details on creating a menu are explained as part of ["Building a basic site"](/tutorials/building-a-basic-site), as well as ["Page type templates" topic](/topics/page-type-templates).

--- a/docs/en/installation/index.md
+++ b/docs/en/installation/index.md
@@ -11,13 +11,13 @@ SilverStripe is a web application. This means that you will need to have a webse
 
 ## Getting the code
 
-The best way to get SilverStripe is with [Composer](composer). Composer is a package management tool for PHP that
+The best way to get SilverStripe is with [Composer](/installation/composer). Composer is a package management tool for PHP that
 lets you install and upgrade SilverStripe and its modules.  Although installing Composer is one extra step, it will give you much more flexibility than just downloading the file from silverstripe.org.
 
 Other ways to get SilverStripe:
 
  * If you just want to get the code as quickly as possible, you can [download SilverStripe from our website](http://silverstripe.org/download).
- * If you already have an installed version of SilverStripe, and you haven't used Composer to get it, please see our [upgrading](upgrading) guide.  Note that [Composer](composer) provides its own tools for upgrading.
+ * If you already have an installed version of SilverStripe, and you haven't used Composer to get it, please see our [upgrading](upgrading) guide.  Note that [Composer](/installatin/composer) provides its own tools for upgrading.
 
 ## Setting up a server
 
@@ -53,5 +53,5 @@ If you run into trouble, see [common-problems](common-problems) or post to the
 
 ## Related
 
- * [Module installation](../topics/modules)
+ * [Module installation](/topics/modules)
  * [Suggested web hosts](http://doc.silverstripe.org/old/suggested-web-hosts)

--- a/docs/en/installation/upgrading.md
+++ b/docs/en/installation/upgrading.md
@@ -29,7 +29,7 @@ See our [upgrade notes and changelogs](/changelogs) for release-specific informa
 
 How easy will it be to update my project? It's a fair question, and sometimes a difficult one to answer. 
 
-*  "Micro" releases (x.y.z) are explicitly backwards compatible, "minor" and "major" releases can deprecate features and change APIs (see our [/misc/release-process](release process) for details)
+*  "Micro" releases (x.y.z) are explicitly backwards compatible, "minor" and "major" releases can deprecate features and change APIs (see our [Release process](/misc/release process) for details)
 *  If you've made custom branches of SilverStripe core, or any thirdparty module, it's going to be harder to upgrade.
 *  The more custom features you have, the harder it will be to upgrade.  You will have to re-test all of those features, and adapt to API changes in core.
 *  Customisations of a well defined type - such as custom page types or custom blog widgets - are going to be easier to upgrade than customisations that modify deep system internals like rewriting SQL queries.
@@ -38,4 +38,4 @@ How easy will it be to update my project? It's a fair question, and sometimes a 
 
 *  [Release Announcements](http://groups.google.com/group/silverstripe-announce/)
 *  [Blog posts about releases on silverstripe.org](http://silverstripe.org/blog/tag/release)
-* [/misc/release-process](Release Process)
+*  [Release process](/misc/release-process)

--- a/docs/en/installation/windows-manual-iis-6.md
+++ b/docs/en/installation/windows-manual-iis-6.md
@@ -116,7 +116,7 @@ You should see some output showing the PHP version. If you get something else, o
   - Open **inetmgr.exe**
   - Right click **Web Sites** and go to **New** > **Web Site**
   - Fill in all appropriate details. If you enter **(All Unassigned)** for the IP address field, make sure the port is something other than **80**, as this will conflict with "Default Web Site" in IIS. When asked for path, enter **C:\Inetpub\wwwroot\silverstripe**
-  - Browse to **http://localhost:8888** or to the IP address you just assigned in your browser.
+  - Browse to **`http://localhost:8888`** or to the IP address you just assigned in your browser.
 
 An installation screen should appear. There may be some permission problems, which you should be able to correct by assigning the **Users** group write permissions by right clicking files / folders in Windows Explorer and going to **Properties** then the **Security** tab.
 

--- a/docs/en/installation/windows-manual-iis-7.md
+++ b/docs/en/installation/windows-manual-iis-7.md
@@ -51,7 +51,7 @@ IIS 7.x comes with Windows. However, it needs to be installed. Follow these step
 
 **NOTE**: These instructions are slightly different for Windows Vista and Windows 7. Instead of a Server Manager popup, you'll just get a list of features to enable. Do the same as above except click the **Internet Information Services** checkbox when the Windows Features popup appears and then expand this node and select **CGI** under World Wide Web Services > Application Development Features.
 
-Once the installation is finished, browse to http://localhost in your browser. If an image pops up, then IIS has been installed correctly.
+Once the installation is finished, browse to `http://localhost` in your browser. If an image pops up, then IIS has been installed correctly.
 
 ## IIS URL Rewrite Module
 
@@ -191,7 +191,7 @@ After gettng the code installed, make sure you set the folder permissions proper
 
 ## Start SilverStripe installer
 
-Open a browser and point it to http://localhost/ss
+Open a browser and point it to `http://localhost/ss`
 
 If an installation screen shows up, congratulations! We're very close now.
 
@@ -260,7 +260,7 @@ To find out who the current user is, try echoing the result of get_current_user(
 
 **Q: When I try to access my SilverStripe site for the first time, I get a 404 error**
 
-**A:** Try accessing dev/build?username=admin&password=password at the end of the URL you requested. For example, http://localhost/ss/dev/build?username=admin&password=password. This will ensure the database is built properly
+**A:** Try accessing dev/build?username=admin&password=password at the end of the URL you requested. For example, `http://localhost/ss/dev/build?username=admin&password=password`. This will ensure the database is built properly
 
 **Q: How do I make IIS expose errors instead of giving a generic 500 or 404 page?**
 
@@ -268,7 +268,7 @@ To find out who the current user is, try echoing the result of get_current_user(
 
 Also, make sure that display_errors, display_startup_errors and html_errors in are set to On in php.ini.
 
-**Q: I get a 500 server error when trying to access the SilverStripe site. e.g. http://localhost/ss**
+**Q: I get a 500 server error when trying to access the SilverStripe site. e.g. `http://localhost/ss`**
 
 **A:** One of the reasons why this could be happening is the web.config file inside the ss directory has XML that is not well formed. Make sure there are NO spaces before the starting <?xml> tag, and make sure that everything is tabbed out correctly.
 

--- a/docs/en/misc/coding-conventions.md
+++ b/docs/en/misc/coding-conventions.md
@@ -451,4 +451,4 @@ which are licensed under BSD (see [license](http://framework.zend.com/license)).
 ## Related
 
  * [Topics: CSS](/topics/css)
- * [Reference: CMS Architecture](/reference/cms-archirecture)
+ * [Reference: CMS Architecture](/reference/cms-architecture)

--- a/docs/en/misc/contributing/code.md
+++ b/docs/en/misc/contributing/code.md
@@ -6,7 +6,7 @@ The SilverStripe core modules (`framework` and `cms`), as well as some of the mo
 git version control. SilverStripe hosts its modules on [github.com/silverstripe](http://github.com/silverstripe) and [github.com/silverstripe-labs](http://github.com/silverstripe-labs).  After [installing git](http://help.github.com/git-installation-redirect) and creating a [free github.com account](https://github.com/signup/free), you can "fork" a module,
 which creates a copy that you can commit to (see github's [guide to "forking"](http://help.github.com/forking/)).
 
-For other modules, our [module list on silverstripe.org](http://silverstripe.org/modules) lists the repository locations, typically using a version control system like "git" or "[subversion](subversion)". 
+For other modules, our [module list on silverstripe.org](http://silverstripe.org/modules) lists the repository locations, typically using a version control system like "git" or "subversion". 
 
 <div class="hint" markdown="1">
 Note: By supplying code to the SilverStripe core team in patches, tickets and pull requests, you agree to assign copyright of that code to SilverStripe Limited, on the condition that SilverStripe Limited releases that code under the BSD license.
@@ -92,7 +92,7 @@ After you have edited the file, GitHub will offer to create a pull request for y
 
 ## Check List
 
-*  Adhere to our [coding conventions](coding-conventions)
+*  Adhere to our [coding conventions](/misc/coding-conventions)
 *  If your patch is extensive, discuss it first on the [silverstripe-dev google group](https://groups.google.com/group/silverstripe-dev) (ideally before doing any serious coding)
 *  When working on existing tickets, assign them to you and provide status updates through ticket comments
 *  Check your patches against the latest "trunk" or "master", as well as the latest release. 

--- a/docs/en/misc/contributing/issues.md
+++ b/docs/en/misc/contributing/issues.md
@@ -49,7 +49,7 @@ it to the community through the [forums](http://silverstripe.org/forums), [core 
 
 ## Reporting Security Issues
 
-Report security issues to [security@silverstripe.com](mailto:security@silverstripe.com). See our "[Release Process](release-process)" documentation for more info, and read our guide on [how to write secure code](/topics/security).
+Report security issues to [security@silverstripe.com](mailto:security@silverstripe.com). See our "[Release Process](/misc/release-process)" documentation for more info, and read our guide on [how to write secure code](/topics/security).
 
 ## Sharing your Opinion
 

--- a/docs/en/misc/module-release-process.md
+++ b/docs/en/misc/module-release-process.md
@@ -238,4 +238,3 @@ trunk.
 * [Documentation Guide](contributing/documentation)
 * [Contributing to SilverStripe](contributing)
 * [Submit your Module](http://silverstripe.org/modules/manage/add)
-* [subversion](subversion)

--- a/docs/en/reference/dataobject.md
+++ b/docs/en/reference/dataobject.md
@@ -37,7 +37,7 @@ by adding, removing or configuring fields.
 	  }
 	}
 
-There's various [form field types](/references/form-field-types), for editing text, dates,
+There's various [form field types](/reference/form-field-types), for editing text, dates,
 restricting input to numbers, and much more.
 
 ## Scaffolding Form Fields

--- a/docs/en/reference/execution-pipeline.md
+++ b/docs/en/reference/execution-pipeline.md
@@ -90,4 +90,4 @@ You can access the following controller-method with /team/signup
 
 ## SSViewer template rendering
 
-See [templates](/topics/templates) for information on the SSViewer template system.
+See [templates](/reference/templates) for information on the SSViewer template system.

--- a/docs/en/reference/grid-field.md
+++ b/docs/en/reference/grid-field.md
@@ -7,7 +7,7 @@ It's built in a way that provides developers with an extensible way to display t
 table and minimise the amount of code that needs to be written.
 
 In order to quickly get data-focused UIs up and running,
-you might also be interested in the [/reference/modeladmin](ModelAdmin) class
+you might also be interested in the [ModelAdmin](/reference/modeladmin) class
 which is driven largely by the `GridField` class explained here.
 
 ## Overview
@@ -263,4 +263,4 @@ A GridFieldComponent sets and gets data from the GridState.
 ## Related
 
  * [ModelAdmin: A UI driven by GridField](/reference/modeladmin)
- * [Tutorial 5: Dataobject Relationship Management](/tutorials/5-dataobject-relationship-management)
+ * [Dataobject Relationship Management](/tutorials/dataobject-relationship-management)

--- a/docs/en/reference/modeladmin.md
+++ b/docs/en/reference/modeladmin.md
@@ -162,7 +162,7 @@ They provide a list/detail interface within a single record edited in your Model
 `canView()`, `canEdit()`, `canDelete()`, and `canCreate`.
 
 In terms of access control to the interface itself, every `ModelAdmin` subclass
-creates its own "[permission code](/reference/permissions)", which can be assigned
+creates its own "[permission code](/reference/permission)", which can be assigned
 to groups through the `admin/security` management interface. To further limit
 permission, either override checks in `ModelAdmin->init()`, or define
 more permission codes through the `ModelAdmin::$required_permission_codes` static.
@@ -234,7 +234,7 @@ For an introduction how to customize the CMS templates, see our [CMS Architectur
 ## Related
 
 * [GridField](../reference/grid-field): The UI component powering ModelAdmin
-* [Tutorial 5: Dataobject Relationship Management](../tutorials/5-dataobject-relationship-management)
+* [Dataobject Relationship Management](/tutorials/dataobject-relationship-management)
 *  `[api:SearchContext]`
 * [genericviews Module](http://silverstripe.org/generic-views-module)
 * [Presentation about ModelAdmin at SupperHappyDevHouse Wellington](http://www.slideshare.net/chillu/modeladmin-in-silverstripe-23)

--- a/docs/en/reference/rssfeed.md
+++ b/docs/en/reference/rssfeed.md
@@ -106,7 +106,7 @@ If the items are all displayed on a single page you may simply hard code the lin
 point to a particular page.
 
 Take an example, we want to create an RSS feed of all the Students, a DataObject we 
-defined in the [fifth tutorial](/tutorials/5-dataobject-relationship-management).
+defined in the [fifth tutorial](/tutorials/dataobject-relationship-management).
 
 	:::php
 	<?php 

--- a/docs/en/reference/searchcontext.md
+++ b/docs/en/reference/searchcontext.md
@@ -127,7 +127,7 @@ The change is in **$results = $this->getResults($data);**, because you are using
 Another thing you cant forget is to check the name of the singleton you are using in your project. the example uses
 **MyDataObject**, you need to change it for the one you are using
 
-For more information on how to paginate your results within the template, see [Tutorial: Site Search](/tutorials/4-site-search).
+For more information on how to paginate your results within the template, see [Tutorial: Site Search](/tutorials/site-search).
 
 
 ### The Pagination Template
@@ -189,4 +189,4 @@ See `[api:SearchFilter]` API Documentation
 
 *  [ModelAdmin](/reference/modeladmin)
 *  [RestfulServer module](https://github.com/silverstripe/silverstripe-restfulserver)
-*  [Tutorial: Site Search](/tutorials/4-site-search)
+*  [Site Search](/tutorials/site-search)

--- a/docs/en/reference/templates.md
+++ b/docs/en/reference/templates.md
@@ -119,7 +119,7 @@ pass arguments to the include, which are available on the scope top within the i
 	<% end_with %>
 
 You can also perform includes using the Requirements Class via the template controls. See the section on
-[Includes in Templates](requirements#including_inside_template_files) for more details and examples.
+[Includes in Templates](/reference/requirements#including_inside_template_files) for more details and examples.
 
 	:::ss
 	<% require themedCSS(LeftNavMenu) %>
@@ -127,7 +127,7 @@ You can also perform includes using the Requirements Class via the template cont
 ### Including CSS and JavaScript files (a.k.a "Requirements")
 
 See [CSS](/topics/css) and [Javascript](/topics/javascript) topics for individual including of files and
-[requirements](reference/requirements) for good examples of including both Javascript and CSS files.
+[requirements](/reference/requirements) for good examples of including both Javascript and CSS files.
 
 ## Conditional Logic
 
@@ -700,8 +700,6 @@ width independently.
 *  Break down your templates into groups of includes.  Site integrators would then have the power to override individual
 includes, rather than entire templates.
 
-For more information about templates go to the [Advanced Templates](/reference/advanced-templates) page.
-
 ## Related
 
  * [Built in page controls](/reference/built-in-page-controls)
@@ -710,7 +708,7 @@ For more information about templates go to the [Advanced Templates](/reference/a
  * [Themes](/topics/themes)
  * [Widgets](/topics/widgets)
  * [Images](/reference/image)
- * [Tutorial 1: Building a basic site](/tutorials/1-building-a-basic-site)
- * [Tutorial 2: Extending a basic site](/tutorials/2-extending-a-basic-site)
+ * [Building a basic site](/tutorials/building-a-basic-site)
+ * [Extending a basic site](/tutorials/extending-a-basic-site)
  * [Developing Themes](/topics/theme-development)
  * [Templates: formal syntax description](/reference/templates-formal-syntax)

--- a/docs/en/reference/urlvariabletools.md
+++ b/docs/en/reference/urlvariabletools.md
@@ -54,8 +54,8 @@ Append the option and corresponding value to your URL in your browser's address 
 
 ## Security Redirects
 
-You can set an URL to redirect back to after a [Security](/topics/security) action.  See the section on [URL
-Redirections](security#redirect_back_to_another_page_after_login) for more information and examples.
+You can set an URL to redirect back to after a [Security](/topics/security) action.  See the section on
+[URL Redirections](/topics/controller/#redirection) for more information and examples.
 
  | URL Variable | | Values | | Description                                                          | 
  | ------------ | | ------ | | -----------                                                          | 

--- a/docs/en/topics/commandline.md
+++ b/docs/en/topics/commandline.md
@@ -53,7 +53,7 @@ To work this out, you should add lines of this form to your [_ss_environment.php
 
 
 What the line says is that any Folder under /Users/sminnee/Sites/ can be accessed in a web browser from
-http://localhost.  For example, /Users/sminnee/Sites/mysite will be available at http://localhost/mysite.
+`http://localhost`.  For example, /Users/sminnee/Sites/mysite will be available at `http://localhost/mysite`.
 
 You can add multiple file to url mapping definitions.  The most specific mapping will be used. For example:
 
@@ -63,8 +63,8 @@ You can add multiple file to url mapping definitions.  The most specific mapping
 	$_FILE_TO_URL_MAPPING['/Users/sminnee/Sites/mysite'] = 'http://mysite.localhost';
 
 
-Using this example, /Users/sminnee/Sites/mysite/ would be accessed at http://mysite.localhost/, and
-/Users/sminnee/Sites/othersite/ would be accessed at http://localhost/othersite/
+Using this example, /Users/sminnee/Sites/mysite/ would be accessed at `http://mysite.localhost/`, and
+/Users/sminnee/Sites/othersite/ would be accessed at `http://localhost/othersite/`
 
 ## Usage
 

--- a/docs/en/topics/debugging.md
+++ b/docs/en/topics/debugging.md
@@ -134,9 +134,11 @@ with core modules, such as the templates.
 
 #### Unit Testing
 
-A good way to avoid writing the same test stubs and var_dump() commands over and over again is to codify them as [unit
-tests](testing-guide). This way you integrate the debugging process right into your quality control, and eventually in
-the development effort itself as "test-driven development".
+A good way to avoid writing the same test stubs and var_dump()
+commands over and over again is to codify them as
+[unit tests](/topics/testing). This way you integrate the debugging
+process right into your quality control, and eventually in the
+development effort itself as "test-driven development".
 
 #### Profiling
 

--- a/docs/en/topics/directory-structure.md
+++ b/docs/en/topics/directory-structure.md
@@ -22,7 +22,7 @@ existing modules or the directories lists in "Core Structure".
  | ---------           | -----------                                                         | 
  | `<mysite>/`           | This directory contains all of your code that defines your website. | 
  | `<mysite>/code`       | PHP code for model and controller (subdirectories are optional)     | 
- | `<mysite>/templates`  | HTML [templates](templates) with *.ss-extension                     | 
+ | `<mysite>/templates`  | HTML [templates](/reference/templates) with *.ss-extension                     | 
  | `<mysite>/css `       | CSS files                                                           | 
  | `<mysite>/images `    | Images used in the HTML templates                                   | 
  | `<mysite>/javascript` | Javascript and other script files 

--- a/docs/en/topics/email.md
+++ b/docs/en/topics/email.md
@@ -34,7 +34,7 @@ The default HTML template is located in `framework/templates/email/GenericEmail.
 ### Templates
 
 *  Create a SS-template file called, in this example we will use 'MyEmail.ss' inside `mysite/templates/email`.
-*  Fill this out with the body text for your email. You can use any [SS-template syntax](/topics/templates) (e.g. `<% loop %>`,
+*  Fill this out with the body text for your email. You can use any [SS-template syntax](/reference/templates) (e.g. `<% loop %>`,
 `<% if %>`, $FirstName etc)
 *  Choose your template with **setTemplate()**
 *  Populate any custom data into the template before sending with **populateTemplate()**

--- a/docs/en/topics/forms.md
+++ b/docs/en/topics/forms.md
@@ -11,7 +11,7 @@ A fully implemented form in SilverStripe includes a couple of classes that indiv
  * Form - Holds sets of fields, actions and validators.
  * FormField  - Fields that recieves data or displays them, e.g input fields.
  * FormActions - Often submit buttons that executes actions.
- * Validators - Validates the whole form, see [Form validation](form-validation.md) topic for more information.
+ * Validators - Validates the whole form, see [Form validation](/topics/form-validation) topic for more information.
 
 Depending on your needs you can customize and override any of the above classes, however the defaults are often 
 sufficient.
@@ -56,7 +56,7 @@ these are handled separately through `Form->httpSubmission()`.
 You can control access on form actions either by conditionally removing 
 a `FormAction` from the form construction,
 or by defining `$allowed_actions` in your own `Form` class
-(more information in the ["controllers" topic](/topics/controllers)).
+(more information in the ["controllers" topic](/topics/controller)).
 	
 **Page.ss**
 

--- a/docs/en/topics/i18n.md
+++ b/docs/en/topics/i18n.md
@@ -319,7 +319,7 @@ Example Translation Table (mymodule/javascript/lang/de_DE.js)
 
 ## Links
 
- * [Help to translate](/misc/contribute/translation) - Instructions for online collaboration to translate core
+ * [Help to translate](/misc/contributing/translation) - Instructions for online collaboration to translate core
  * [Help to translate](/misc/translation-process) - Instructions for adding translation to your own modules
  * [http://www.i18nguy.com/](http://www.i18nguy.com/)
  * [balbus.tk i18n notes](http://www.balbus.tk/internationalize)

--- a/docs/en/topics/index.md
+++ b/docs/en/topics/index.md
@@ -26,7 +26,7 @@ It is where most documentation should live, and is the natural "second step" aft
  * [Search](search): Searching for properties in the database as well as other documents
  * [Security](security): How to develop secure SilverStripe applications with good code examples
  * [Shortcodes](shortcodes): Use simple placeholders for powerful content replacements like multimedia embeds
- * [Templates](templates): SilverStripe template syntax: Variables, loops, includes and much more
+ * [Templates](/reference/templates): SilverStripe template syntax: Variables, loops, includes and much more
  * [Testing](testing): Functional and Unit Testing with PHPUnit and SilverStripe's testing framework
  * [Developing Themes](theme-development): Package templates, images and CSS to a reusable theme
  * [Widgets](widgets): Small feature blocks which can be placed on a page by the CMS editor, also outlines how to create and add widgets

--- a/docs/en/topics/javascript.md
+++ b/docs/en/topics/javascript.md
@@ -635,7 +635,6 @@ Here's an example of hooking the 'PageLoaded' and 'BeforeSave' methods:
 	});
 
 
-See ['onload' javascript in the CMS](/reference/leftandmain#onload-javascript)
 
 
 ### Break the rules!

--- a/docs/en/topics/module-development.md
+++ b/docs/en/topics/module-development.md
@@ -47,11 +47,11 @@ adherence to conventions, writing documentation, and releasing updates. See [con
 
 **How To:**
 
-*  [Add a link to your module in the main SilverStripe Admin Menu](/reference/leftandmain)
+*  [Add a link to your module in the main SilverStripe Admin Menu](/reference/modeladmin)
 
 **Useful Links:**
 
 *  [Modules](modules)
-*  [Module Release Process](module-release-process)
+*  [Module Release Process](/misc/module-release-process)
 *  [Debugging methods](/topics/debugging)
 *  [URL Variable Tools](/reference/urlvariabletools) - Lists a number of page options, rendering tools or special URL variables that you can use to debug your SilverStripe applications

--- a/docs/en/topics/modules.md
+++ b/docs/en/topics/modules.md
@@ -104,5 +104,5 @@ and comes with the same caveats.
 
 ## Related
 
-* [Modules Development](/topics/module-developement)
+* [Modules Development](/topics/module-development)
 * [Module Release Process](/misc/module-release-process)

--- a/docs/en/topics/page-type-templates.md
+++ b/docs/en/topics/page-type-templates.md
@@ -75,7 +75,7 @@ meaning that draft content edited in the CMS can be different from published con
 shown to your website visitors. In templates, you don't need to worry about this distinction.
 The `$Content` variable contain the published content by default,
 and only preview draft content if explicitly requested (e.g. by the "preview" feature in the CMS)
-(see the ["versioning" topic](topics/versioning) for more details).
+(see the ["versioning" topic](/topics/versioning) for more details).
 
 ### Menu Loops
 

--- a/docs/en/topics/page-types.md
+++ b/docs/en/topics/page-types.md
@@ -9,7 +9,7 @@ Page Types are the basic building blocks of any SilverStripe website. A page typ
 *  Behaviour specific to a page type. For example a contact form on a ‘Contact Us’ page type, sending an email when the form is submitted
 
 All the pages on the base installation are of the page type called "Page". See
-[tutorial:2-extending-a-basic-site](/tutorials/2-extending-a-basic-site) for a good introduction to page-types.
+[extending-a-basic-site](/tutorials/extending-a-basic-site) for a good introduction to page-types.
 
 ## Class and Template Inheritance
 
@@ -65,7 +65,7 @@ model works.
 
 ## Adding Form Fields and Tabs
 
-See [form](/topics/forms) and [tutorial:2-extending-a-basic-site](/tutorials/2-extending-a-basic-site).
+See [form](/topics/forms) and [extending-a-basic-site](/tutorials/extending-a-basic-site).
 Note: To modify fields in the "Settings" tab, you need to use `updateSettingsFields()` instead.
 
 ## Removing inherited form fields and tabs
@@ -119,5 +119,5 @@ required on a certain page-type.
 This will also work if you want to remove a whole tab e.g. $fields->removeByName('Metadata'); will remove the whole
 Metadata tab.
 
-For more information on forms, see [form](/topics/forms), [tutorial:2-extending-a-basic-site](/tutorials/2-extending-a-basic-site)
-and [tutorial:3-forms](/tutorials/3-forms).
+For more information on forms, see [form](/topics/forms), [extending-a-basic-site](/tutorials/extending-a-basic-site)
+and [Forms](/tutorials/forms).

--- a/docs/en/topics/search.md
+++ b/docs/en/topics/search.md
@@ -3,7 +3,7 @@
 ## Searching for Pages (and Files)
 
 Fulltext search for page content (and other attributes like "Title" or "MetaTags") can be easily added to SilverStripe.
-See [Tutorial: Site Search](/tutorials/4-site-search) for details.
+See [Site Search](/tutorials/site-search) for details.
 
 ## Searching for DataObjects
 
@@ -35,7 +35,7 @@ dedicated search service like the [sphinx module](http://silverstripe.org/sphinx
 
 *  [ModelAdmin](/reference/modeladmin)
 *  [RestfulServer module](https://github.com/silverstripe/silverstripe-restfulserver)
-*  [Tutorial: Site Search](/tutorials/4-site-search)
+*  [Site Search](/tutorials/site-search)
 *  [SearchContext](/reference/searchcontext)
 *  [genericviews module](http://silverstripe.org/generic-views-module)
 *  [sphinx module](http://silverstripe.org/sphinx-module)

--- a/docs/en/topics/testing/index.md
+++ b/docs/en/topics/testing/index.md
@@ -25,7 +25,7 @@ To get started now, follow the installation instructions below, and check
 
 Unit tests are not included in the normal SilverStripe downloads,
 you are expected to work with local git repositories 
-([installation instructions](/topics/installation/composer)).
+([installation instructions](/installation/composer)).
 
 Once you've got the project up and running,
 check out the additional requirements to run unit tests:

--- a/docs/en/topics/testing/testing-guide-troubleshooting.md
+++ b/docs/en/topics/testing/testing-guide-troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-Part of the [SilverStripe Testing Guide](testing-guide).
+Part of the [SilverStripe Testing Guide](/topics/testing).
 
 ## I can't run my new test class
 

--- a/docs/en/topics/theme-development.md
+++ b/docs/en/topics/theme-development.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-[Tutorial 1](/tutorials/1-building-a-basic-site#templates) shows you how to create page templates. This guide will help
+[Building a basic site](/tutorials/building-a-basic-site#templates) shows you how to create page templates. This guide will help
 you create your own SilverStripe website theme.
 
 Developing your own theme in SilverStripe is a piece of cake thanks to a very straight forward and clean templating
@@ -40,7 +40,7 @@ Layout template.
 ### HTML Templates
 
 Once you have created your folders you need to start to fill it out with a couple 'Core' files. First and most
-importantly is we need a HTML template for our design. Read the [Tutorial 1](/tutorials/1-building-a-basic-site#templates)
+importantly is we need a HTML template for our design. Read the [Tutorial 1](/tutorials/building-a-basic-site#templates)
 and the HTML pages for more in-depth discussion about the HTML templates and how they work. At the very least
 we need a Page.ss file (note the .ss extenstion - Don't worry its just HTML and any text editor will still read it). So
 go ahead and create 2 Page.ss files. One in templates, the other in Layout.
@@ -110,7 +110,7 @@ All you have to do now is tell your site to use your new theme - This is defined
 Go to yoursite.com/?flush=1 and check it out. You should be using your new theme! Not really that awesome or amazing is
 it? Next we need to add some CSS Magic!
 
-See [Templates](/reference/themes) for more information about templates.
+See [Templates](/reference/templates) for more information about templates.
 
 
 ### CSS Files

--- a/docs/en/tutorials/building-a-basic-site.md
+++ b/docs/en/tutorials/building-a-basic-site.md
@@ -45,7 +45,7 @@ When designing your site you should only need to modify the *mysite*, *themes* a
 
 ![](_images/tutorial1_cms-basic.jpg)
 
-The CMS is the area in which you can manage your site content. You can access the cms at http://localhost/your_site_name/admin (or http://yourdomain.com/admin if you are using you own domain name). You
+The CMS is the area in which you can manage your site content. You can access the cms at `http://localhost/your_site_name/admin` (or `http://yourdomain.com/admin` if you are using you own domain name). You
 will be presented with a login screen. Login using the details you provided at installation. After logging in you
 should see the CMS interface with a list of the pages currently on your website (the site tree). Here you can add, delete and reorganize pages. If you need to delete, publish, or unpublish a page, first check "multi-selection" at the top. You will then be able to perform actions on any checked files using the "Actions" dropdown. Clicking on a page will open it in the page editing interface pictured below (we've entered some test content).
 
@@ -79,7 +79,7 @@ The page type specifies the templates used to render the page, the fields that a
 **SilverStripe's friendly URLs**
 
 While you are on the draft or live SilverStripe site, you may notice the URLs point to files that don't exist, e.g.
-http://localhost/contact or http://yourdomainname.com/about-us etc. SilverStripe uses the URL field on the Meta-Data tab of the Edit Page -> Content section to look up the appropriate
+`http://localhost/contact` or `http://yourdomainname.com/about-us` etc. SilverStripe uses the URL field on the Meta-Data tab of the Edit Page -> Content section to look up the appropriate
 page in the database.
 
 Note that if you have sub-pages, changing the Top level URL field for a page will affect the URL for all sub-pages. For example, if we changed the URL field "/about-us/" to "/about-silverstripe/" then the sub-pages URLs would now be "/about-silverstripe/URL-of-subpage/" rather than "/about-us/URL-of-subpage/".
@@ -146,7 +146,7 @@ or placed between SilverStripe template tags:
 **Flushing the cache**
 
 Whenever we edit a template file, we need to append *?flush=1* onto the end of the URL, e.g.
-http://localhost/your_site_name/?flush=1. SilverStripe stores template files in a cache for quicker load times. Whenever there are
+`http://localhost/your_site_name/?flush=1`. SilverStripe stores template files in a cache for quicker load times. Whenever there are
 changes to the template, we must flush the cache in order for the changes to take effect.
 
 ##  The Navigation System
@@ -330,7 +330,7 @@ Earlier we stated that every page in a SilverStripe site has a **page type**, an
 template, or template layout, corresponding to the page type. Therefore, the first step when switching the homepage template is to create a new page type.
 
 Each page type is represented by two PHP classes: a *data object* and a *controller*. Don't worry about the details of page
-types right now, we will go into much more detail in the [next tutorial](2-extending-a-basic-site).
+types right now, we will go into much more detail in the [next tutorial](extending-a-basic-site).
 
 Create a new file *HomePage.php* in *mysite/code*. Copy the following code into it:
 
@@ -343,7 +343,7 @@ Create a new file *HomePage.php* in *mysite/code*. Copy the following code into 
 
 
 Every page type also has a database table corresponding to it. Every time we modify the database, we need to rebuild it.
-We can do this by going to [http://localhost/your_site_name/dev/build](http://localhost/your_site_name/dev/build) (replace *localhost/your_site_name* with your own domain name if applicable). 
+We can do this by going to `http://localhost/your_site_name/dev/build`. 
 
 It may take a moment, so be patient. This adds tables and fields needed by your site, and modifies any structures that have changed. It
 does this non-destructively - it will never delete your data.
@@ -402,9 +402,9 @@ then descend into the *themes/simple/templates/Layout* folder, and will use *Pag
 
 So far we have taken a look at the different areas and functionality within the pages area of the CMS. We have learnt about template variables, controls and if statements and used these to build a basic, but fully functional, website. We have also briefly covered page types, and looked at how they correspond to templates and sub-templates. Using this knowledge, we have customized our website's homepage design.
 
-In the next tutorial, [Extending a Basic Site](2-extending-a-basic-site), we will explore page types on a deeper level, and look at customising our own page types to extend the functionality of SilverStripe.
+In the next tutorial, [Extending a Basic Site](extending-a-basic-site), we will explore page types on a deeper level, and look at customising our own page types to extend the functionality of SilverStripe.
 
-[Next tutorial >>](2-extending-a-basic-site)
+[Next tutorial >>](extending-a-basic-site)
 
 ## Books on SilverStripe 
 

--- a/docs/en/tutorials/dataobject-relationship-management.md
+++ b/docs/en/tutorials/dataobject-relationship-management.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This tutorial explores the relationship and management of [DataObjects](/topics/datamodel#relations). It builds on the [second tutorial](2-extending-a-basic-site) where we learnt how to define
+This tutorial explores the relationship and management of [DataObjects](/topics/datamodel#relations). It builds on the [second tutorial](extending-a-basic-site) where we learnt how to define
 additional fields on our models, and attach images to them.
 
 ## What are we working towards?

--- a/docs/en/tutorials/extending-a-basic-site.md
+++ b/docs/en/tutorials/extending-a-basic-site.md
@@ -3,7 +3,7 @@
 ## Overview
 
 
-In the [first tutorial (Building a basic site)](1-building-a-basic-site) we learnt how to create a basic site using SilverStripe. This tutorial will build on that, and explore extending SilverStripe by creating our own page types. After doing this we should have a better understanding of how SilverStripe works.
+In the [first tutorial (Building a basic site)](building-a-basic-site) we learnt how to create a basic site using SilverStripe. This tutorial will build on that, and explore extending SilverStripe by creating our own page types. After doing this we should have a better understanding of how SilverStripe works.
 
 ## What are we working towards?
 
@@ -303,7 +303,7 @@ Here we use the page control *Children*. As the name suggests, this control allo
 
 ### Using include files in templates
 
-We can make our templates more modular and easier to maintain by separating commonly-used components in to *include files*.  We are already familiar with the `<% include Sidebar %>` line from looking at the menu in the [first tutorial (Building a basic site)](1-building-a-basic-site).
+We can make our templates more modular and easier to maintain by separating commonly-used components in to *include files*.  We are already familiar with the `<% include Sidebar %>` line from looking at the menu in the [first tutorial (Building a basic site)](building-a-basic-site).
 
 We'll separate the display of linked articles as we want to reuse this code later on.
 
@@ -532,4 +532,4 @@ a complete staff section.
 
 In this tutorial we have explored the concept of page types. In the process of creating and extending page types we have covered many of the concepts required to build a site with SilverStripe.
 
-[Next Tutorial >>](3-forms)
+[Next Tutorial >>](forms)

--- a/docs/en/tutorials/forms.md
+++ b/docs/en/tutorials/forms.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This tutorial is intended to be a continuation of the first two tutorials ([first tutorial](1-building-a-basic-site), [second tutorial](2-extending-a-basic-site)). In this tutorial we will build on the site we developed in the earlier tutorials and explore forms in SilverStripe. We will look at custom coded forms: forms which need to be written in PHP.
+This tutorial is intended to be a continuation of the first two tutorials ([first tutorial](building-a-basic-site), [second tutorial](extending-a-basic-site)). In this tutorial we will build on the site we developed in the earlier tutorials and explore forms in SilverStripe. We will look at custom coded forms: forms which need to be written in PHP.
 
 Instead of using a custom coded form, we could use the [userforms module](http://silverstripe.org/user-forms-module). This module allows users to construct forms via the CMS. A form created this way is much quicker to implement, but also lacks the flexibility of a coded form. 
 
@@ -168,7 +168,7 @@ All going according to plan, if you visit [http://localhost/your_site_name/home?
 Great! We now have a browser poll form, but it doesn't actually do anything. In order to make the form work, we have to implement the 'doBrowserPoll()' method that we told it about.
 
 First, we need some way of saving the poll submissions to the database, so we can retrieve the results later. We can do this by creating a new object that extends from `[api:DataObject]`.
-If you recall, in the [second tutorial](2-extending-a-basic-site) we said that all objects that inherit from DataObject and have their own fields are stored in tables the database. Also recall that all pages extend DataObject indirectly through `[api:SiteTree]`. Here instead of extending SiteTree (or `[api:Page]`) to create a page type, we will extend `[api:DataObject]` directly:
+If you recall, in the [second tutorial](extending-a-basic-site) we said that all objects that inherit from DataObject and have their own fields are stored in tables the database. Also recall that all pages extend DataObject indirectly through `[api:SiteTree]`. Here instead of extending SiteTree (or `[api:Page]`) to create a page type, we will extend `[api:DataObject]` directly:
 
 **mysite/code/BrowserPollSubmission.php**
 
@@ -268,7 +268,7 @@ Although the form is not shown, you'll still see the 'Browser Poll' heading. We'
 
 Now that we're collecting data, it would be nice to show the results on the website as well. We could simply output every vote, but that's boring. Let's group the results by browser, through the SilverStripe data model.
 
-In the [second tutorial](/tutorials/2-extending-a-basic-site), we got a collection of news articles for the home page by using the 'ArticleHolder::get()' function, which returns a `[api:DataList]`. We can get all submissions in the same fashion, through `BrowserPollSubmission::get()`. This list will be the starting point for our result aggregation.
+In the [second tutorial](/tutorials/extending-a-basic-site), we got a collection of news articles for the home page by using the 'ArticleHolder::get()' function, which returns a `[api:DataList]`. We can get all submissions in the same fashion, through `BrowserPollSubmission::get()`. This list will be the starting point for our result aggregation.
 
 Create the function 'BrowserPollResults' on the *HomePage_Controller* class.
 
@@ -351,4 +351,4 @@ We use the normal tactic of putting the data into an unordered list and using CS
 
 In this tutorial we have explored custom php forms, and displayed result sets through Grouped Lists. We have briefly covered the different approaches to creating and using forms. Whether you decide to use the [userforms module](http://silverstripe.org/user-forms-module) or create a form in PHP depends on the situation and flexibility required.
 
-[Next Tutorial >>](4-site-search)
+[Next Tutorial >>](site-search)

--- a/docs/en/tutorials/site-search.md
+++ b/docs/en/tutorials/site-search.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This is a short tutorial demonstrating how to add search functionality to a SilverStripe site. It is recommended that you have completed the earlier tutorials  ([Building a basic site](1-building-a-basic-site), [Extending a basic site](2-extending-a-basic-site), [Forms](3-forms)), especially the tutorial on forms, before attempting this tutorial. While this tutorial will add search functionality to the site built in the previous tutorials, it should be straight  forward to follow this tutorial on any site of your own. 
+This is a short tutorial demonstrating how to add search functionality to a SilverStripe site. It is recommended that you have completed the earlier tutorials  ([Building a basic site](building-a-basic-site), [Extending a basic site](extending-a-basic-site), [Forms](forms)), especially the tutorial on forms, before attempting this tutorial. While this tutorial will add search functionality to the site built in the previous tutorials, it should be straight  forward to follow this tutorial on any site of your own. 
 
 ## What are we working towards?
 
@@ -155,4 +155,4 @@ Then finally add ?flush=1 to the URL and you should see the new template.
 
 This tutorial has demonstrated how easy it is to have full text searching on your site. To add search to a SilverStripe site add a search form, a results page, and you're done!
 
-[Next Tutorial >>](5-dataobject-relationship-management)
+[Next Tutorial >>](dataobject-relationship-management)


### PR DESCRIPTION
Following up on rewrite rules (see silverstripe/doc.silverstripe.org#91)  :)

Note:

(1) links to missing changelogs have been deleted (4 in all).
(2) links to .md files that do not exist and have no obvious alternative are also deleted (2 in all).