### PR TITLE
NEW $belongs_to relations to be used in $searchable_fields of gridfie…

### DIFF
--- a/forms/gridfield/GridFieldAddExistingAutocompleter.php
+++ b/forms/gridfield/GridFieldAddExistingAutocompleter.php
@@ -214,6 +214,17 @@ class GridFieldAddExistingAutocompleter
 			->sort(strtok($searchFields[0], ':'), 'ASC')
 			->limit($this->getResultsLimit());
 
+		$belongs_to = Config::inst()->get($dataClass, 'belongs_to');
+		if( !empty($belongs_to) ) {
+			foreach ($searchFields as $searchField) {
+				if( $relation = strtok($searchField,'.') ) {
+					if (in_array($relation, $belongs_to)) {
+						$results = $results->leftJoin($relation, "{$relation}.{$dataClass}ID={$dataClass}.ID");
+					}
+				}
+			}
+		}
+
 		$json = array();
 		$originalSourceFileComments = Config::inst()->get('SSViewer', 'source_file_comments');
 		Config::inst()->update('SSViewer', 'source_file_comments', false);


### PR DESCRIPTION
GridFieldAddExistingAutocompleter uses the $searchable_fields from DataObject.
If you use fields of related objects to search in, you can use it like this:
$searchable_fields = array(
'Relation.Field'=>'Field'
);
This works if Relation is a $has_one field, but not if it is a $belongs_to field.
The $belongs_to fields are supported if used in $summary_fields, but strangely not if used in $searchable_fields.
This change adds the needed extra leftJoin to enable searching in $belongs_to.
