### PR TITLE
Add special flag to CMS preview requests

### DIFF
--- a/admin/javascript/LeftAndMain.Preview.js
+++ b/admin/javascript/LeftAndMain.Preview.js
@@ -434,6 +434,9 @@
 					// No state available at all.
 					this.setCurrentStateName(null);
 				}
+				
+				// Mark url as a preview url so it can get special treatment
+				url += ((url.indexOf('?') === -1) ? '?' : '&') + 'CMSPreview=1';
 
 				// If this preview panel isn't visible at the moment, delay loading the URL until it (maybe) is later
 				if (this.is('.column-hidden')) {


### PR DESCRIPTION
This affects the iframe used in the CMS for page previews. With this change, we can have the page behave differently based on whether it's a preview or not. The page itself would have to check for the parameter, nothing is done automatically.

Our specific use case is to prevent redirecting to another page, as it would normally. However this may also be useful in e.g. plastering a PREVIEW message, or having other preview-specific content.