### PR TITLE
BUG Fix Versioned::doRollbackTo

### DIFF
--- a/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
+++ b/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
@@ -27,6 +27,11 @@ The extension is automatically applied to `SiteTree` class. For more information
 [Extending](../extending) and the [Configuration](../configuration) documentation.
 </div>
 
+<div class="warning" markdown="1">
+Versioning only works if you are adding the extension to the base class. That is, the first subclass
+of `DataObject`. Adding this extension to children of the base class will have unpredictable behaviour.
+</div>
+
 ## Database Structure
 
 Depending on how many stages you configured, two or more new tables will be created for your records. In the above, this

--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -652,25 +652,30 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 			
 			// Get ID field
 			$id = $manipulation[$table]['id'] ? $manipulation[$table]['id'] : $manipulation[$table]['fields']['ID'];
-			if(!$id) user_error("Couldn't find ID in " . var_export($manipulation[$table], true), E_USER_ERROR);
+			if(!$id) {
+				user_error("Couldn't find ID in " . var_export($manipulation[$table], true), E_USER_ERROR);
+			}
 
 			if($this->migratingVersion) {
 				$manipulation[$table]['fields']['Version'] = $this->migratingVersion;
 			}
 
-			// If we haven't got a version #, then we're creating a new version.
-			// Otherwise, we're just copying a version to another table
-			if(empty($manipulation[$table]['fields']['Version'])) {
+			$version = isset($manipulation[$table]['fields']['Version'])
+				? $manipulation[$table]['fields']['Version']
+				: null;
+			if($version < 0 || $this->_nextWriteWithoutVersion) {
+				// Putting a Version of -1 is a signal to leave the version table alone, despite their being no version
+				unset($manipulation[$table]['fields']['Version']);
+			} elseif(empty($version)) {
+				// If we haven't got a version #, then we're creating a new version.
+				// Otherwise, we're just copying a version to another table
 				$this->augmentWriteVersioned($manipulation, $table, $id);
 			}
 
-			// Putting a Version of -1 is a signal to leave the version table alone, despite their being no version
-			if($manipulation[$table]['fields']['Version'] < 0 || $this->_nextWriteWithoutVersion) {
+			// For base classes of versioned data objects
+			if(!$this->hasVersionField($table)) {
 				unset($manipulation[$table]['fields']['Version']);
 			}
-
-			// For base classes of versioned data objects
-			if(!$this->hasVersionField($table)) unset($manipulation[$table]['fields']['Version']);
 
 			// Grab a version number - it should be the same across all tables.
 			if(isset($manipulation[$table]['fields']['Version'])) {

--- a/tests/model/DataObjectLazyLoadingTest.php
+++ b/tests/model/DataObjectLazyLoadingTest.php
@@ -13,6 +13,7 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 
 	// These are all defined in DataObjectTest.php and VersionedTest.php
 	protected $extraDataObjects = array(
+		// From DataObjectTest
 		'DataObjectTest_Team',
 		'DataObjectTest_Fixture',
 		'DataObjectTest_SubTeam',
@@ -24,8 +25,24 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 		'DataObjectTest_TeamComment',
 		'DataObjectTest_EquipmentCompany',
 		'DataObjectTest_SubEquipmentCompany',
+		'DataObjectTest\NamespacedClass',
+		'DataObjectTest\RelationClass',
+		'DataObjectTest_ExtendedTeamComment',
+		'DataObjectTest_Company',
+		'DataObjectTest_Staff',
+		'DataObjectTest_CEO',
+		'DataObjectTest_Fan',
+		'DataObjectTest_Play',
+		'DataObjectTest_Ploy',
+		'DataObjectTest_Bogey',
+		// From VersionedTest
 		'VersionedTest_DataObject',
 		'VersionedTest_Subclass',
+		'VersionedTest_AnotherSubclass',
+		'VersionedTest_RelatedWithoutVersion',
+		'VersionedTest_SingleStage',
+		'VersionedTest_WithIndexes',
+		// From DataObjectLazyLoadingTest
 		'VersionedLazy_DataObject',
 		'VersionedLazySub_DataObject',
 	);

--- a/tests/model/VersionedTest.yml
+++ b/tests/model/VersionedTest.yml
@@ -1,19 +1,24 @@
 VersionedTest_DataObject:
-   page1:
-      Title: Page 1
-   page2:
-      Title: Page 2
-   page3:
-      Title: Page 3
-   page2a:
-      Parent: =>VersionedTest_DataObject.page2
-      Title: Page 2a
-   page2b:
-      Parent: =>VersionedTest_DataObject.page2
-      Title: Page 2b
-   page3a:
-      Parent: =>VersionedTest_DataObject.page3
-      Title: Page 3a
-   page3b:
-      Parent: =>VersionedTest_DataObject.page3
-      Title: Page 3b
+  page1:
+    Title: Page 1
+  page2:
+    Title: Page 2
+  page3:
+    Title: Page 3
+  page2a:
+    Parent: =>VersionedTest_DataObject.page2
+    Title: Page 2a
+  page2b:
+    Parent: =>VersionedTest_DataObject.page2
+    Title: Page 2b
+  page3a:
+    Parent: =>VersionedTest_DataObject.page3
+    Title: Page 3a
+  page3b:
+    Parent: =>VersionedTest_DataObject.page3
+    Title: Page 3b
+
+VersionedTest_AnotherSubclass:
+  subclass1:
+    Title: 'Subclass Page 1'
+    AnotherField: 'Bob'


### PR DESCRIPTION
Document correct configuration of Versioned DataObjects
Fixes #4936

Super special thanks to @sb-relaxt-at  for helping with this. I've tried my best to keep your original test cases as demonstration of this issue. :)

The main problem is that _nextWriteWithoutVersion was getting ignored at certain times, and a _versions manipulation was getting created anyway. I've moved that action into an else so it always blocks the manipulation creation.