### PR TITLE
FIX for #4909: Ensure RSSFeed_Entry is instantiated using the injector.

### DIFF
--- a/api/RSSFeed.php
+++ b/api/RSSFeed.php
@@ -149,7 +149,7 @@ class RSSFeed extends ViewableData {
 		if(isset($this->entries)) {
 			foreach($this->entries as $entry) {
 				$output->push(
-					new RSSFeed_Entry($entry, $this->titleField, $this->descriptionField, $this->authorField));
+					RSSFeed_Entry::create($entry, $this->titleField, $this->descriptionField, $this->authorField));
 			}
 		}
 		return $output;
@@ -184,7 +184,11 @@ class RSSFeed extends ViewableData {
 	}
 
 	/**
-	 * Output the feed to the browser
+	 * Output the feed to the browser.
+	 *
+	 * TODO: Pass $response object to ->outputToBrowser() to loosen dependence on global state for easier testing/prototyping so dev can inject custom SS_HTTPResponse instance.
+	 *
+	 * @return	HTMLText
 	 */
 	public function outputToBrowser() {
 		$prevState = Config::inst()->get('SSViewer', 'source_file_comments');


### PR DESCRIPTION
For #4909

Ensure RSSFeed_Entry is instantiated using the injector. Also extending `->outputToBrowser()` to loosen dependence on global state for easier testing/prototyping so dev can inject custom SS_HTTPResponse instance. There's already a lot of tight binding to global state, but this at least prevents it from crashing in case there is no "current controller" (yes I've setup a small framework to breakway from SS's standard paradigm to make it easier for me to prototype/test code in a totally isolated environment). Almost like unit tests, but not quite as formal :+1: 