### PR TITLE
FIX PHPDocs on DataList::getIDList() and UnsavedRelationList::getIDList

### DIFF
--- a/model/DataList.php
+++ b/model/DataList.php
@@ -916,7 +916,9 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 
 	/**
 	 * Returns an array with both the keys and values set to the IDs of the records in this list.
+	 * Does not respect sort order. Use ->column("ID") to get an ID list with the current sort.
 	 *
+	 * @return array
 	 */
 	public function getIDList() {
 		$ids = $this->column("ID");

--- a/model/UnsavedRelationList.php
+++ b/model/UnsavedRelationList.php
@@ -206,8 +206,10 @@ class UnsavedRelationList extends ArrayList {
 
 	/**
 	 * Returns an array with both the keys and values set to the IDs of the records in this list.
+	 * Does not respect sort order. Use ->column("ID") to get an ID list with the current sort.
+	 * Does not return the IDs for unsaved DataObjects.
 	 *
-	 * Does not return the IDs for unsaved DataObjects
+	 * @return array
 	 */
 	public function getIDList() {
 		// Get a list of IDs of our current items - if it's not a number then object then assume it's a DO.


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/4179#issuecomment-174289595

getIDList no longer produces unsuspecting outcome.