### PR TITLE
Replaced filterByCallback for 'Children' to just create a new array a…

### DIFF
--- a/core/ClassInfo.php
+++ b/core/ClassInfo.php
@@ -20,10 +20,13 @@ class ClassInfo {
 	}
 
 	/**
-	 * @todo Improve documentation
+	 * Returns true if a class or interface name exists.
+	 *
+	 * @param  string $class
+	 * @return bool
 	 */
 	public static function exists($class) {
-		return SS_ClassLoader::instance()->classExists($class);
+		return class_exists($class, false) || interface_exists($class, false) || SS_ClassLoader::instance()->getItemPath($class);
 	}
 
 	/**

--- a/core/manifest/ClassLoader.php
+++ b/core/manifest/ClassLoader.php
@@ -101,7 +101,8 @@ class SS_ClassLoader {
 	 * @return bool
 	 */
 	public function classExists($class) {
-		return class_exists($class, false) || interface_exists($class, false) || $this->getItemPath($class);
+		Deprecation::notice('4.0', 'Use ClassInfo::exists.');
+		return ClassInfo::exists($class);
 	}
 
 }

--- a/model/Hierarchy.php
+++ b/model/Hierarchy.php
@@ -493,10 +493,14 @@ class Hierarchy extends DataExtension {
 	public function Children() {
 		if(!(isset($this->_cache_children) && $this->_cache_children)) {
 			$result = $this->owner->stageChildren(false);
-			$this->_cache_children = $result->filterByCallback(function($item) {
-				return $item->canView();
-			});
-					}
+			$children = array();
+			foreach ($result as $record) {
+				if ($record->canView()) {
+					$children[] = $record;
+				}
+			}
+			$this->_cache_children = new ArrayList($children);
+		}
 		return $this->_cache_children;
 	}
 


### PR DESCRIPTION
…s function calls are exponentially expensive in PHP (the more functions that exist, the slower a function call becomes) and replaced 'array_key_exists' with op-code equivalent for speed. The best increase isn't really noticeable but we should work towards optimizing the core as much as possible.

Squashed version of #4884