### PR TITLE
BUG Fix regressions in #4873

### DIFF
--- a/forms/CompositeField.php
+++ b/forms/CompositeField.php
@@ -128,10 +128,7 @@ class CompositeField extends FormField {
 	 */
 	public function extraClasses() {
 		Deprecation::notice('4.0', 'Use extraClass() instead');
-		return $this->extraClass();
-	}
 
-	public function extraClass() {
 		$classes = array('field', 'CompositeField', parent::extraClass());
 		if($this->columnCount) $classes[] = 'multicolumn';
 


### PR DESCRIPTION
See  https://github.com/silverstripe/silverstripe-framework/pull/4873

Previously, it did nothing. However, with the prior fix, suddenly extra classes popped up in places which broke certain layouts.

This fix reverts the method so that the old undesirable behaviour remains ONLY in the deprecated method.