### PR TITLE
FIX: removing hardcoded target _blank for tinymce file links

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -626,7 +626,6 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 					
 					case 'file':
 						href = '[file_link,id=' + this.find('.ss-uploadfield .ss-uploadfield-item').attr('data-fileid') + ']';
-						target = '_blank';
 						break;
 					
 					case 'email':


### PR DESCRIPTION
This will allow file links to respect content editor input, fixes #4985.