### PR TITLE
FIX Flyout cms menu panels

### DIFF
--- a/admin/javascript/LeftAndMain.Menu.js
+++ b/admin/javascript/LeftAndMain.Menu.js
@@ -223,8 +223,15 @@
 			}
 		});
 
-		/** Toggle the flyout panel to appear/disappear when mouse over */
+		$('.cms-menu-list .toggle').entwine({
+			onclick: function(e) {
+				this.getMenuItem().toggle();
+				e.preventDefault();
+			}
+		});
+
 		$('.cms-menu-list li').entwine({
+			/** Toggle the flyout panel to appear/disappear when mouse over */
 			toggleFlyout: function(bool) {
 				fly = $(this);
 				if (fly.children('ul').first().hasClass('collapsed-flyout')) {
@@ -234,23 +241,13 @@
 						fly.children('ul').find('li').hide();
 					}
 				}
-			}
-		});
-		//slight delay to prevent flyout closing from "sloppy mouse movement"
-		$('.cms-menu-list li').hoverIntent(function(){$(this).toggleFlyout(true);},function(){$(this).toggleFlyout(false);});
-		
-		$('.cms-menu-list .toggle').entwine({
-			onclick: function(e) {
-				this.getMenuItem().toggle();
-				e.preventDefault();
-			}
-		});
-		
-		$('.cms-menu-list li').entwine({
+			},
 			onmatch: function() {
 				if(this.find('ul').length) {
 					this.find('a:first').append('<span class="toggle-children"><span class="toggle-children-icon"></span></span>');
 				}
+				//Set up flyout panel with slight delay to prevent flyout closing from "sloppy mouse movement"
+				$(this).hoverIntent(function(){$(this).toggleFlyout(true);},function(){$(this).toggleFlyout(false);});
 				this._super();
 			},
 			onunmatch: function() {


### PR DESCRIPTION
The hover flyout functionality for nested CMS menu items seems to be broken in 3.3. Seems to be failing because behaviour was added with regular jquery (just once at runtime) rather than using entwine.

![screen shot 2016-01-29 at 10 20 34 am](https://cloud.githubusercontent.com/assets/1079425/12662693/0f418a82-c672-11e5-8736-0c8c6f4c30ea.png)
