### PR TITLE
SapphireTest fix for issue that caused assertEmailSent to always fail

### DIFF
--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -55,7 +55,9 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 	protected $originalNestedURLsState;
 	protected $originalMemoryLimit;
 
-	protected $mailer;
+	public static function mailer() {
+		return Injector::inst()->get('Mailer');
+	}
 
 	/**
 	 * Pointer to the manifest that isn't a test manifest
@@ -223,9 +225,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 		$prefix = defined('SS_DATABASE_PREFIX') ? SS_DATABASE_PREFIX : 'ss_';
 
 		// Set up email
-		$this->originalMailer = Email::mailer();
-		$this->mailer = new TestMailer();
-		Injector::inst()->registerService($this->mailer, 'Mailer');
+		Injector::inst()->registerService(new TestMailer(), 'Mailer');
 		Config::inst()->remove('Email', 'send_all_emails_to');
 
 		// Todo: this could be a special test model
@@ -496,10 +496,6 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 		// Preserve memory settings
 		ini_set('memory_limit', ($this->originalMemoryLimit) ? $this->originalMemoryLimit : -1);
 
-		// Restore email configuration
-		$this->originalMailer = null;
-		$this->mailer = null;
-
 		// Restore password validation
 		if($this->originalMemberPasswordValidator) {
 			Member::set_password_validator($this->originalMemberPasswordValidator);
@@ -558,7 +554,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 	 * Clear the log of emails sent
 	 */
 	public function clearEmails() {
-		return $this->mailer->clearEmails();
+		return static::mailer()->clearEmails();
 	}
 
 	/**
@@ -572,7 +568,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 	 *               'customHeaders', 'htmlContent', 'inlineImages'
 	 */
 	public function findEmail($to, $from = null, $subject = null, $content = null) {
-		return $this->mailer->findEmail($to, $from, $subject, $content);
+		return static::mailer()->findEmail($to, $from, $subject, $content);
 	}
 
 	/**


### PR DESCRIPTION
Ran into this issue when upgrading a couple of sites from 3.1 to 3.2.
# Reproduce

Install SilverStripe with composer `composer create-project silverstripe/installer . 3.2.1`

Add a method to Page.php that can be tested for sending email

``` php
class Page extends SiteTree {

    private static $db = array();
    private static $has_one = array();

    public static function method_to_test() {
        $email = new Email('test@test.com', 'test@test.com', 'test', 'test');
        $email->send();
    }

}
```

Write a test for that method

``` php
class PageTest extends SapphireTest {

    public function testMethodToTest() {
        Page::method_to_test();

        $this->assertEmailSent('test@test.com');
    }

}
```

Running this test will fail with an error similar to:

```
F
PageTest::testMethodToTest
Failed asserting that an email was sent to 'test@test.com'.
```
# Fix

I'm not smart enough to explain why it was broken but the fix was to use a mailer method (rather than a field) similar to what the `Email` class does.

In the process of making this change I found that the `$originalMailer` and `$mailer` fields were no longer required so have removed any references to these I could find.
