### PR TITLE
API File is now Versioned

### DIFF
--- a/_config/versioning.yml
+++ b/_config/versioning.yml
@@ -1,0 +1,6 @@
+---
+Name: versioning
+---
+GridFieldDetailForm:
+  extensions:
+    - VersionedGridFieldDetailForm

--- a/control/RequestHandler.php
+++ b/control/RequestHandler.php
@@ -460,6 +460,7 @@ class RequestHandler extends ViewableData {
 	 * @param int $errorCode
 	 * @param string $errorMessage Plaintext error message
 	 * @uses SS_HTTPResponse_Exception
+	 * @throws SS_HTTPResponse_Exception
 	 */
 	public function httpError($errorCode, $errorMessage = null) {
 

--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -169,11 +169,20 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 
 	protected $model;
 
+	/**
+	 * State of Versioned before this test is run
+	 *
+	 * @var string
+	 */
+	protected $originalReadingMode = null;
+
 	public function setUp() {
 
 		//nest config and injector for each test so they are effectively sandboxed per test
 		Config::nest();
 		Injector::nest();
+
+		$this->originalReadingMode = \Versioned::get_reading_mode();
 
 		// We cannot run the tests on this abstract class.
 		if(get_class($this) == "SapphireTest") $this->skipTest = true;
@@ -525,6 +534,9 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 			$controller->response->setStatusCode(200);
 			$controller->response->removeHeader('Location');
 		}
+
+		\Versioned::set_reading_mode($this->originalReadingMode);
+
 		//unnest injector / config now that tests are over
 		Injector::unnest();
 		Config::unnest();

--- a/docs/en/02_Developer_Guides/14_Files/03_File_Security.md
+++ b/docs/en/02_Developer_Guides/14_Files/03_File_Security.md
@@ -278,23 +278,27 @@ You can customise this with the below config:
 ### Configuring: Archive behaviour
 
 By default, the default extension `AssetControlExtension` will control the disposal of assets
-attached to objects when those objects are deleted. For example, unpublished versioned objects
-will automatically have their attached assets moved to the protected store. The deletion of 
-draft or unversioned objects will have those assets permanantly deleted (along with all variants).
+attached to objects when those objects are archived. For example, unpublished versioned objects
+will automatically have their attached assets moved to the protected store. The archive of 
+draft or (or deletion of unversioned objects) will have those assets permanantly deleted
+(along with all variants).
 
-In some cases, it may be preferable to have any deleted assets archived for versioned dataobjects,
-rather than deleted. This uses more disk storage, but will allow the full recovery of archived
+Note that regardless of this setting, the database record will still be archived in the
+version history for all Versioned DataObjects.
+
+In some cases, it may be preferable to have any assets retained for archived versioned dataobjects,
+instead of deleting them. This uses more disk storage, but will allow the full recovery of archived
 records and files.
 
-This can be applied to DataObjects on a case by case basis by setting the `archive_assets`
+This can be applied to DataObjects on a case by case basis by setting the `keep_archived_assets`
 config to true on that class. Note that this feature only works with dataobjects with
 the `Versioned` extension.
 
 
     :::php
     class MyVersiondObject extends DataObject {
-        /** Enable archiving */
-        private static $archive_assets = true;
+        /** Ensure assets are archived along with the DataObject */
+        private static $keep_archived_assets = true;
         /** Versioned */
         private static $extensions = array('Versioned');
     }

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -25,6 +25,9 @@
    more information.
  * `Object::useCustomClass` has been removed. You should use the config API with Injector instead.
  * Upgrade of TinyMCE to version 4.
+ * `File` is now versioned, and should be published before they can be used on the frontend.
+   See section on [Migrating File DataObject from 3.x to 4.0](#migrating-file-dataobject-from-3x-to-40)
+   below for upgrade notes.
 
 ## New API
 
@@ -48,6 +51,12 @@
    TinyMCE editor.
  * `HtmlEditorField::setEditorConfig` may now take an instance of a `HtmlEditorConfig` class, as well as a
    standard config identifier name.
+ * A lot of standard versioned API has been refactored from `SiteTree` into `Versioned` extension. Now
+   all versioned DataObjects have canPublish(), canArchive(), canUnpublish(), doPublish(), doArchive()
+   doUnpublish(), isPublished() and isonDraft() out of the box. However, do*() methods will no longer
+   automatically check can*() permissions, and must be done by usercode before invocation.
+ * GridField edit form now has improved support for versioned DataObjects, with basic publishing
+   actions available when editing records.
 
 ### Front-end build tooling for CMS interface
 
@@ -243,6 +252,13 @@ large amounts of memory and run for an extended time.
 	  migrate_legacy_file: true
 
 
+This task will also support migration of existing File DataObjects to file versioning. Any
+pre-existing File DataObjects will be automatically published to the live stage, to ensure
+that previously visible assets remain visible to the public site.
+
+If additional security or visibility rules should be applied to File dataobjects, then
+make sure to correctly extend `canView` via extensions.
+
 ### Upgrade code which acts on `Image`
 
 As all image-specific manipulations has been refactored from `Image` into an `ImageManipulations` trait, which 
@@ -321,9 +337,11 @@ After:
 
 	:::php
 	function importTempFile($tmp) {
+	    Versioned::reading_stage('Stage');
 		$file = new File();
 		$file->setFromLocalFile($tmp, 'imported/'.basename($tmp));
 		$file->write();
+		$file->doPublish();
 	}
 
 
@@ -333,13 +351,19 @@ stored in the assets folder.
 
 There are other important considerations in working with File dataobjects which differ from legacy:
 
-* Deleting File dataobjects no longer removes the physical file directly. This is because any file could be referenced
-  from DBFile fields, and deleting these could be a potentially unsafe operation.
 * File synchronisation is no longer automatic. This is due to the fact that there is no longer a 1-to-1 relationship
   between physical files and File dataobjects.
-* Moving files now performs a file copy rather than moving the underlying file, although only a single DataObject
-  will exist, and will reference the destination path.
 * Folder dataobjects are now purely logical dataobjects, and perform no actual filesystem folder creation on write.
+* All Files are versioned, which means that by default, new File records will not be visibile
+  to the public site. You will need to make sure to invoke ->doPublish() on any File dataobject
+  you wish visitors to be able to see.
+
+You can disable File versioning by adding the following to your _config.php
+
+
+    :::php
+    File::remove_extension('Versioned');
+
 
 ### Upgrading code performs custom image manipulations
 

--- a/filesystem/AssetManipulationList.php
+++ b/filesystem/AssetManipulationList.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace SilverStripe\Filesystem;
+
+/**
+ * Provides a mechanism for determining the effective visibility of a set of assets (identified by
+ * filename and hash), given their membership to objects of varying visibility.
+ *
+ * The effective visibility of assets is based on three rules:
+ * - If an asset is attached to any public record, that asset is public.
+ * - If an asset is not attached to any public record, but is attached to a protected record,
+ *   that asset is protected.
+ * - If an asset is attached to a record being deleted, but not any existing public or protected
+ *   record, then that asset is marked for deletion.
+ *
+ * Variants are ignored for the purpose of determining visibility
+ */
+class AssetManipulationList
+{
+
+    const STATE_PUBLIC = 'public';
+
+    const STATE_PROTECTED = 'protected';
+
+    const STATE_DELETED = 'deleted';
+
+    /**
+     * List of public assets
+     *
+     * @var array
+     */
+    protected $public = array();
+
+    /**
+     * List of protected assets
+     *
+     * @var array
+     */
+    protected $protected = array();
+
+    /**
+     * List of deleted assets
+     *
+     * @var array
+     */
+    protected $deleted = array();
+
+    /**
+     * Get an identifying key for a given filename and hash
+     *
+     * @param array $asset Asset tuple
+     * @return string
+     */
+    protected function getAssetKey($asset)
+    {
+        return $asset['Hash'] . '/' . $asset['Filename'];
+    }
+
+    /**
+     * Add asset with the given state
+     *
+     * @param array $asset Asset tuple
+     * @param string $state One of the STATE_* const vars
+     * @return bool True if the asset was added to the set matching the given state
+     */
+    public function addAsset($asset, $state)
+    {
+        switch ($state) {
+            case self::STATE_PUBLIC:
+                return $this->addPublicAsset($asset);
+            case self::STATE_PROTECTED:
+                return $this->addProtectedAsset($asset);
+            case self::STATE_DELETED:
+                return $this->addDeletedAsset($asset);
+            default:
+                throw new \InvalidArgumentException("Invalid state {$state}");
+        }
+    }
+
+    /**
+     * Mark a file as public
+     *
+     * @param array $asset Asset tuple
+     * @return bool True if the asset was added to the public set
+     */
+    public function addPublicAsset($asset)
+    {
+        // Remove from protected / deleted lists
+        $key = $this->getAssetKey($asset);
+        unset($this->protected[$key]);
+        unset($this->deleted[$key]);
+        // Skip if already public
+        if(isset($this->public[$key])) {
+            return false;
+        }
+        unset($asset['Variant']);
+        $this->public[$key] = $asset;
+        return true;
+    }
+
+    /**
+     * Record an asset as protected
+     *
+     * @param array $asset Asset tuple
+     * @return bool True if the asset was added to the protected set
+     */
+    public function addProtectedAsset($asset)
+    {
+        $key = $this->getAssetKey($asset);
+        // Don't demote from public
+        if (isset($this->public[$key])) {
+            return false;
+        }
+        unset($this->deleted[$key]);
+        // Skip if already protected
+        if(isset($this->protected[$key])) {
+            return false;
+        }
+        unset($asset['Variant']);
+        $this->protected[$key] = $asset;
+        return true;
+    }
+
+    /**
+     * Record an asset as deleted
+     *
+     * @param array $asset Asset tuple
+     * @return bool True if the asset was added to the deleted set
+     */
+    public function addDeletedAsset($asset)
+    {
+        $key = $this->getAssetKey($asset);
+        // Only delete if this doesn't exist in any non-deleted state
+        if (isset($this->public[$key]) || isset($this->protected[$key])) {
+            return false;
+        }
+        // Skip if already deleted
+        if(isset($this->deleted[$key])) {
+            return false;
+        }
+        unset($asset['Variant']);
+        $this->deleted[$key] = $asset;
+        return true;
+    }
+
+    /**
+     * Get all public assets
+     *
+     * @return array
+     */
+    public function getPublicAssets()
+    {
+        return $this->public;
+    }
+
+    /**
+     * Get protected assets
+     *
+     * @return array
+     */
+    public function getProtectedAssets()
+    {
+        return $this->protected;
+    }
+
+    /**
+     * Get deleted assets
+     *
+     * @return array
+     */
+    public function getDeletedAssets()
+    {
+        return $this->deleted;
+    }
+}

--- a/filesystem/FileMigrationHelper.php
+++ b/filesystem/FileMigrationHelper.php
@@ -34,6 +34,8 @@ class FileMigrationHelper extends Object {
 
 		// Loop over all files
 		$count = 0;
+		$originalState = \Versioned::get_reading_mode();
+		\Versioned::reading_stage('Stage');
 		$filenameMap = $this->getFilenameArray();
 		foreach($this->getFileQuery() as $file) {
 			// Get the name of the file to import
@@ -43,6 +45,7 @@ class FileMigrationHelper extends Object {
 				$count++;
 			}
 		}
+		\Versioned::set_reading_mode($originalState);
 		return $count;
 	}
 
@@ -73,8 +76,9 @@ class FileMigrationHelper extends Object {
 			$this->setFilename($result['Filename']);
 		}
 
-		// Save
+		// Save and publish
 		$file->write();
+		$file->doPublish();
 		return true;
 	}
 

--- a/filesystem/storage/DBFile.php
+++ b/filesystem/storage/DBFile.php
@@ -17,7 +17,7 @@ use SilverStripe\Filesystem\Storage\AssetStore;
  * @package framework
  * @subpackage filesystem
  */
-class DBFile extends CompositeDBField implements AssetContainer, ShortcodeHandler {
+class DBFile extends CompositeDBField implements AssetContainer {
 
 	use ImageManipulation;
 
@@ -310,14 +310,6 @@ class DBFile extends CompositeDBField implements AssetContainer, ShortcodeHandle
 		return $this
 			->getStore()
 			->exists($this->Filename, $this->Hash, $this->Variant);
-	}
-
-	public static function get_shortcodes() {
-		return 'dbfile_link';
-	}
-
-	public static function handle_shortcode($arguments, $content, $parser, $shortcode, $extra = array()) {
-		// @todo
 	}
 	
 	public function getFilename() {

--- a/forms/FieldList.php
+++ b/forms/FieldList.php
@@ -313,6 +313,9 @@ class FieldList extends ArrayList {
 	 * You can use dot syntax to get fields from child composite fields
 	 *
 	 * @todo Implement similarly to dataFieldByName() to support nested sets - or merge with dataFields()
+	 *
+	 * @param string $name
+	 * @return FormField
 	 */
 	public function fieldByName($name) {
 		$name = $this->rewriteTabPath($name);

--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -1142,6 +1142,12 @@ class UploadField extends FileField {
 		// Search for relations that can hold the uploaded files, but don't fallback
 		// to default if there is no automatic relation
 		if ($relationClass = $this->getRelationAutosetClass(null)) {
+			// Allow File to be subclassed
+			if($relationClass === 'File' && isset($tmpFile['name'])) {
+				$relationClass = File::get_class_for_file_extension(
+					File::get_file_extension($tmpFile['name'])
+				);
+			}
 			// Create new object explicitly. Otherwise rely on Upload::load to choose the class.
 			$fileObject = Object::create($relationClass);
 			if(! ($fileObject instanceof DataObject) || !($fileObject instanceof AssetContainer)) {

--- a/model/DataExtension.php
+++ b/model/DataExtension.php
@@ -2,6 +2,8 @@
 /**
  * An extension that adds additional functionality to a {@link DataObject}.
  *
+ * @property DataObject $owner
+ *
  * @package framework
  * @subpackage model
  */

--- a/model/versioning/VersionedGridFieldDetailForm.php
+++ b/model/versioning/VersionedGridFieldDetailForm.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Extends {@see GridFieldDetailForm}
+ */
+class VersionedGridFieldDetailForm extends Extension {
+    public function updateItemRequestClass(&$class, $gridField, $record, $requestHandler) {
+        // Conditionally use a versioned item handler
+        if($record && $record->has_extension('Versioned')) {
+            $class = 'VersionedGridFieldItemRequest';
+        }
+    }
+}

--- a/model/versioning/VersionedGridFieldItemRequest.php
+++ b/model/versioning/VersionedGridFieldItemRequest.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * Provides versioned dataobject support to {@see GridFieldDetailForm_ItemRequest}
+ *
+ * @property GridFieldDetailForm_ItemRequest $owner
+ */
+class VersionedGridFieldItemRequest extends GridFieldDetailForm_ItemRequest {
+
+    protected function getFormActions() {
+        $actions = parent::getFormActions();
+
+		// Check if record is versionable
+		$record = $this->getRecord();
+        if(!$record || !$record->has_extension('Versioned')) {
+            return $actions;
+        }
+
+        // Save & Publish action
+		if($record->canPublish()) {
+			// "publish", as with "save", it supports an alternate state to show when action is needed.
+			$publish = FormAction::create(
+                'doPublish',
+                _t('VersionedGridFieldItemRequest.BUTTONPUBLISH', 'Publish')
+            )
+                ->setUseButtonTag(true)
+                ->addExtraClass('ss-ui-action-constructive')
+                ->setAttribute('data-icon', 'accept');
+
+            // Insert after save
+            if($actions->fieldByName('action_doSave')) {
+                $actions->insertAfter('action_doSave', $publish);
+            } else {
+                $actions->push($publish);
+            }
+		}
+
+        // Unpublish action
+        $isPublished = $record->isPublished();
+		if($isPublished && $record->canUnpublish()) {
+			$actions->push(
+				FormAction::create(
+                    'doUnpublish',
+                    _t('VersionedGridFieldItemRequest.BUTTONUNPUBLISH', 'Unpublish')
+                )
+                    ->setUseButtonTag(true)
+					->setDescription(_t(
+                        'VersionedGridFieldItemRequest.BUTTONUNPUBLISHDESC',
+                        'Remove this record from the published site'
+                    ))
+					->addExtraClass('ss-ui-action-destructive')
+			);
+		}
+
+        // Archive action
+		if($record->canArchive()) {
+            // Replace "delete" action
+            $actions->removeByName('action_doDelete');
+
+            // "archive"
+            $actions->push(
+                FormAction::create('doArchive', _t('VersionedGridFieldItemRequest.ARCHIVE','Archive'))
+                    ->setDescription(_t(
+                        'VersionedGridFieldItemRequest.BUTTONARCHIVEDESC',
+                        'Unpublish and send to archive'
+                    ))
+                    ->addExtraClass('delete ss-ui-action-destructive')
+            );
+		}
+		return $actions;
+    }
+
+    /**
+     * Archive this versioned record
+     *
+     * @param array $data
+     * @param Form $form
+	 * @return SS_HTTPResponse
+     */
+	public function doArchive($data, $form) {
+		$record = $this->getRecord();
+		if (!$record->canArchive()) {
+			return $this->httpError(403);
+		}
+
+		// Record name before it's deleted
+		$title = $record->Title;
+
+		try {
+			$record->doArchive();
+		} catch(ValidationException $e) {
+			return $this->generateValidationResponse($form, $e);
+		}
+
+		$message = sprintf(
+			_t('VersionedGridFieldItemRequest.Archived', 'Archived %s %s'),
+			$record->i18n_singular_name(),
+			Convert::raw2xml($title)
+		);
+		$this->setFormMessage($form, $message);
+
+		//when an item is deleted, redirect to the parent controller
+		$controller = $this->getToplevelController();
+		$controller->getRequest()->addHeader('X-Pjax', 'Content'); // Force a content refresh
+
+		return $controller->redirect($this->getBacklink(), 302); //redirect back to admin section
+    }
+
+    /**
+     * Publish this versioned record
+     *
+     * @param array $data
+     * @param Form $form
+	 * @return SS_HTTPResponse
+     */
+    public function doPublish($data, $form) {
+        $record = $this->getRecord();
+        $isNewRecord = $record->ID == 0;
+
+		// Check permission
+		if(!$record->canPublish()) {
+			return $this->httpError(403);
+		}
+
+		// Save from form data
+		try {
+            // Initial save and reload
+			$record = $this->saveFormIntoRecord($data, $form);
+            $record->doPublish();
+
+		} catch(ValidationException $e) {
+			return $this->generateValidationResponse($form, $e);
+		}
+
+		$editURL = $this->Link('edit');
+		$xmlTitle = Convert::raw2xml($record->Title);
+		$link = "<a href=\"{$editURL}\">{$xmlTitle}</a>";
+		$message = _t(
+			'VersionedGridFieldItemRequest.Published',
+			'Published {name} {link}',
+			array(
+				'name' => $record->i18n_singular_name(),
+				'link' => $link
+			)
+		);
+		$this->setFormMessage($form, $message);
+
+		return $this->redirectAfterSave($isNewRecord);
+    }
+
+    /**
+     * Delete this record from the live site
+     *
+     * @param array $data
+     * @param Form $form
+	 * @return SS_HTTPResponse
+     */
+    public function doUnpublish($data, $form) {
+		$record = $this->getRecord();
+		if (!$record->canUnpublish()) {
+			return $this->httpError(403);
+		}
+
+		// Record name before it's deleted
+		$title = $record->Title;
+
+		try {
+			$record->doUnpublish();
+		} catch(ValidationException $e) {
+			return $this->generateValidationResponse($form, $e);
+		}
+
+		$message = sprintf(
+			_t('VersionedGridFieldItemRequest.Unpublished', 'Unpublished %s %s'),
+			$record->i18n_singular_name(),
+			Convert::raw2xml($title)
+		);
+		$this->setFormMessage($form, $message);
+
+		// Redirect back to edit
+		return $this->redirectAfterSave(false);
+    }
+
+	/**
+	 * @param Form $form
+	 * @param string $message
+	 */
+	protected function setFormMessage($form, $message) {
+		$form->sessionMessage($message, 'good', false);
+		$controller = $this->getToplevelController();
+		if($controller->hasMethod('getEditForm')) {
+			$backForm = $controller->getEditForm();
+			$backForm->sessionMessage($message, 'good', false);
+		}
+	}
+}

--- a/parsers/ShortcodeHandler.php
+++ b/parsers/ShortcodeHandler.php
@@ -6,6 +6,13 @@
 interface ShortcodeHandler {
 
 	/**
+	 * Gets the list of shortcodes provided by this handler
+	 *
+	 * @return mixed
+	 */
+	public static function get_shortcodes();
+
+	/**
 	 * Generate content with a shortcode value
 	 * 
 	 * @param array $arguments Arguments passed to the parser

--- a/tasks/MigrateFileTask.php
+++ b/tasks/MigrateFileTask.php
@@ -17,6 +17,8 @@ class MigrateFileTask extends BuildTask {
 		$migrated = FileMigrationHelper::singleton()->run();
 		if($migrated) {
 			DB::alteration_message("{$migrated} File DataObjects upgraded", "changed");
+		} else {
+			DB::alteration_message("No File DataObjects need upgrading", "notice");
 		}
 	}
 

--- a/tests/filesystem/AssetControlExtensionTest.php
+++ b/tests/filesystem/AssetControlExtensionTest.php
@@ -15,7 +15,9 @@ class AssetControlExtensionTest extends SapphireTest {
 		parent::setUp();
 
 		// Set backend and base url
+		\Versioned::reading_stage('Stage');
 		AssetStoreTest_SpyStore::activate('AssetControlExtensionTest');
+		$this->logInWithPermission('ADMIN');
 
 		// Setup fixture manually
 		$object1 = new AssetControlExtensionTest_VersionedObject();
@@ -24,7 +26,7 @@ class AssetControlExtensionTest extends SapphireTest {
 		$object1->Header->setFromLocalFile($fish1, 'Header/MyObjectHeader.jpg');
 		$object1->Download->setFromString('file content', 'Documents/File.txt');
 		$object1->write();
-		$object1->publish('Stage', 'Live');
+		$object1->doPublish();
 
 		$object2 = new AssetControlExtensionTest_Object();
 		$object2->Title = 'Unversioned';
@@ -35,7 +37,7 @@ class AssetControlExtensionTest extends SapphireTest {
 		$object3->Title = 'Archived';
 		$object3->Header->setFromLocalFile($fish1, 'Archived/MyObjectHeader.jpg');
 		$object3->write();
-		$object3->publish('Stage', 'Live');
+		$object3->doPublish();
 	}
 
 	public function tearDown() {
@@ -44,6 +46,8 @@ class AssetControlExtensionTest extends SapphireTest {
 	}
 
 	public function testFileDelete() {
+		\Versioned::reading_stage('Stage');
+
 		/** @var AssetControlExtensionTest_VersionedObject $object1 */
 		$object1 = AssetControlExtensionTest_VersionedObject::get()
 				->filter('Title', 'My object')
@@ -111,6 +115,87 @@ class AssetControlExtensionTest extends SapphireTest {
 		$this->assertNull($object2->Image->getVisibility());
 		$this->assertEquals(AssetStore::VISIBILITY_PROTECTED, $object3->Header->getVisibility());
 	}
+
+	/**
+	 * Test files being replaced
+	 */
+	public function testReplaceFile() {
+		\Versioned::reading_stage('Stage');
+
+		/** @var AssetControlExtensionTest_VersionedObject $object1 */
+		$object1 = AssetControlExtensionTest_VersionedObject::get()
+				->filter('Title', 'My object')
+				->first();
+		/** @var AssetControlExtensionTest_Object $object2 */
+		$object2 = AssetControlExtensionTest_Object::get()
+				->filter('Title', 'Unversioned')
+				->first();
+
+		/** @var AssetControlExtensionTest_ArchivedObject $object3 */
+		$object3 = AssetControlExtensionTest_ArchivedObject::get()
+				->filter('Title', 'Archived')
+				->first();
+
+		$object1TupleOld = $object1->Header->getValue();
+		$object2TupleOld = $object2->Image->getValue();
+		$object3TupleOld = $object3->Header->getValue();
+
+		// Replace image and write each to filesystem
+		$fish1 = realpath(__DIR__ .'/../model/testimages/test-image-high-quality.jpg');
+		$object1->Header->setFromLocalFile($fish1, 'Header/Replaced_MyObjectHeader.jpg');
+		$object1->write();
+		$object2->Image->setFromLocalFile($fish1, 'Images/Replaced_BeautifulFish.jpg');
+		$object2->write();
+		$object3->Header->setFromLocalFile($fish1, 'Archived/Replaced_MyObjectHeader.jpg');
+		$object3->write();
+
+		// Check that old published records are left public, but removed for unversioned object2
+		$this->assertEquals(
+			AssetStore::VISIBILITY_PUBLIC,
+			$this->getAssetStore()->getVisibility($object1TupleOld['Filename'], $object1TupleOld['Hash'])
+		);
+		$this->assertEquals(
+			null, // Old file is destroyed
+			$this->getAssetStore()->getVisibility($object2TupleOld['Filename'], $object2TupleOld['Hash'])
+		);
+		$this->assertEquals(
+			AssetStore::VISIBILITY_PUBLIC,
+			$this->getAssetStore()->getVisibility($object3TupleOld['Filename'], $object3TupleOld['Hash'])
+		);
+
+		// Check that visibility of new file is correct
+		// Note that $object2 has no canView() is true, so assets end up public
+		$this->assertEquals(AssetStore::VISIBILITY_PROTECTED, $object1->Header->getVisibility());
+		$this->assertEquals(AssetStore::VISIBILITY_PUBLIC, $object2->Image->getVisibility());
+		$this->assertEquals(AssetStore::VISIBILITY_PROTECTED, $object3->Header->getVisibility());
+
+		// Publish changes to versioned records
+		$object1->doPublish();
+		$object3->doPublish();
+
+		// After publishing, old object1 is deleted, but since object3 has archiving enabled,
+		// the orphaned file is intentionally left in the protected store
+		$this->assertEquals(
+			null,
+			$this->getAssetStore()->getVisibility($object1TupleOld['Filename'], $object1TupleOld['Hash'])
+		);
+		$this->assertEquals(
+			AssetStore::VISIBILITY_PROTECTED,
+			$this->getAssetStore()->getVisibility($object3TupleOld['Filename'], $object3TupleOld['Hash'])
+		);
+
+		// And after publish, all files are public
+		$this->assertEquals(AssetStore::VISIBILITY_PUBLIC, $object1->Header->getVisibility());
+		$this->assertEquals(AssetStore::VISIBILITY_PUBLIC, $object3->Header->getVisibility());
+	}
+
+	/**
+	 * @return AssetStore
+	 */
+	protected function getAssetStore() {
+		return Injector::inst()->get('AssetStore');
+	}
+
 }
 
 /**
@@ -131,6 +216,25 @@ class AssetControlExtensionTest_VersionedObject extends DataObject implements Te
 		'Header' => "DBFile('image/supported')",
 		'Download' => 'DBFile'
 	);
+
+	/**
+	 * @param Member $member
+	 * @return bool
+	 */
+	public function canView($member = null) {
+		if(!$member) {
+			$member = Member::currentUser();
+		}
+
+		// Expectation that versioned::canView will hide this object in draft
+		$result = $this->extendedCan('canView', $member);
+		if($result !== null) {
+			return $result;
+		}
+
+		// Open to public
+		return true;
+	}
 }
 
 /**
@@ -144,11 +248,20 @@ class AssetControlExtensionTest_Object extends DataObject implements TestOnly {
 		'Title' => 'Varchar(255)',
 		'Image' => "DBFile('image/supported')"
 	);
+
+
+	/**
+	 * @param Member $member
+	 * @return bool
+	 */
+	public function canView($member = null) {
+		return true;
+	}
 }
 
 /**
  * Versioned object that always archives its assets
  */
 class AssetControlExtensionTest_ArchivedObject extends AssetControlExtensionTest_VersionedObject {
-	private static $archive_assets = true;
+	private static $keep_archived_assets = true;
 }

--- a/tests/filesystem/AssetManipulationListTest.php
+++ b/tests/filesystem/AssetManipulationListTest.php
@@ -1,0 +1,79 @@
+<?php
+use SilverStripe\Filesystem\AssetManipulationList;
+
+/**
+ * Tests set manipulations of groups of assets of differing visibilities
+ */
+class AssetManipulationListTest extends SapphireTest {
+
+    public function testVisibility() {
+        $set = new AssetManipulationList();
+        $file1 = ['Filename' => 'Test1.jpg', 'Hash' => '975677589962604d9e16b700cf84734f9dda2817'];
+        $file2 = ['Filename' => 'Test2.jpg', 'Hash' => '22af86a45ea56287437a12cf83aded5c077a5db5'];
+        $file3 = ['Filename' => 'DupeHash1.jpg', 'Hash' => 'f167433dd318e738281b845a07d7be2053b8c997'];
+        $file4 = ['Filename' => 'DupeName.jpg', 'Hash' => 'afde6577a034323959b7915f41ac8d1f53bc597f'];
+        $file5 = ['Filename' => 'DupeName.jpg', 'Hash' => '1e94b066e5aa16907d0e5e32556c7a2a0b692eb9'];
+        $file6 = ['Filename' => 'DupeHash2.jpg', 'Hash' => 'f167433dd318e738281b845a07d7be2053b8c997'];
+
+        // Non-overlapping assets remain in assigned sets
+        $this->assertTrue($set->addDeletedAsset($file1));
+        $this->assertTrue($set->addDeletedAsset($file2));
+        $this->assertTrue($set->addProtectedAsset($file3));
+        $this->assertTrue($set->addProtectedAsset($file4));
+        $this->assertTrue($set->addPublicAsset($file5));
+        $this->assertTrue($set->addPublicAsset($file6));
+
+        // Check initial state of list
+        $this->assertEquals(6, $this->countItems($set));
+        $this->assertContains($file1, $set->getDeletedAssets());
+        $this->assertContains($file2, $set->getDeletedAssets());
+        $this->assertContains($file3, $set->getProtectedAssets());
+        $this->assertContains($file4, $set->getProtectedAssets());
+        $this->assertContains($file5, $set->getPublicAssets());
+        $this->assertContains($file6, $set->getPublicAssets());
+
+        // Public or Protected assets will not be deleted
+        $this->assertFalse($set->addDeletedAsset($file3));
+        $this->assertFalse($set->addDeletedAsset($file4));
+        $this->assertFalse($set->addDeletedAsset($file5));
+        $this->assertFalse($set->addDeletedAsset($file6));
+        $this->assertEquals(6, $this->countItems($set));
+        $this->assertNotContains($file3, $set->getDeletedAssets());
+        $this->assertNotContains($file4, $set->getDeletedAssets());
+        $this->assertNotContains($file5, $set->getDeletedAssets());
+        $this->assertNotContains($file6, $set->getDeletedAssets());
+
+        // Adding records as protected will remove them from the deletion list, but
+        // not the public list
+        $this->assertTrue($set->addProtectedAsset($file1));
+        $this->assertFalse($set->addProtectedAsset($file5));
+        $this->assertEquals(6, $this->countItems($set));
+        $this->assertNotContains($file1, $set->getDeletedAssets());
+        $this->assertContains($file1, $set->getProtectedAssets());
+        $this->assertNotContains($file5, $set->getProtectedAssets());
+        $this->assertContains($file5, $set->getPublicAssets());
+
+        // Adding records as public will ensure they are not deleted or marked as protected
+        // Existing public assets won't be re-added
+        $this->assertTrue($set->addPublicAsset($file2));
+        $this->assertTrue($set->addPublicAsset($file4));
+        $this->assertFalse($set->addPublicAsset($file5));
+        $this->assertEquals(6, $this->countItems($set));
+        $this->assertNotContains($file2, $set->getDeletedAssets());
+        $this->assertNotContains($file2, $set->getProtectedAssets());
+        $this->assertContains($file2, $set->getPublicAssets());
+        $this->assertNotContains($file4, $set->getProtectedAssets());
+        $this->assertContains($file4, $set->getPublicAssets());
+        $this->assertContains($file5, $set->getPublicAssets());
+    }
+
+    /**
+     * Helper to count all items in a set
+     *
+     * @param AssetManipulationList $set
+     * @return int
+     */
+    protected function countItems(AssetManipulationList $set) {
+        return count($set->getPublicAssets()) + count($set->getProtectedAssets()) + count($set->getDeletedAssets());
+    }
+}

--- a/tests/filesystem/FileMigrationHelperTest.php
+++ b/tests/filesystem/FileMigrationHelperTest.php
@@ -60,6 +60,7 @@ class FileMigrationHelperTest extends SapphireTest {
 			$this->assertEmpty($file->File->getFilename(), "File {$file->Name} has no DBFile filename");
 			$this->assertEmpty($file->File->getHash(), "File {$file->Name} has no hash");
 			$this->assertFalse($file->exists(), "File with name {$file->Name} does not yet exist");
+			$this->assertFalse($file->isPublished(), "File is not published yet");
 		}
 
 		// Do migration
@@ -77,6 +78,7 @@ class FileMigrationHelperTest extends SapphireTest {
 				"File with name {$filename} has the correct hash"
 			);
 			$this->assertTrue($file->exists(), "File with name {$filename} exists");
+			$this->assertTrue($file->isPublished(), "File is published after migration");
 		}
 	}
 

--- a/tests/filesystem/FolderTest.php
+++ b/tests/filesystem/FolderTest.php
@@ -15,6 +15,9 @@ class FolderTest extends SapphireTest {
 	public function setUp() {
 		parent::setUp();
 
+		$this->logInWithPermission('ADMIN');
+		Versioned::reading_stage('Stage');
+
 		// Set backend root to /FolderTest
 		AssetStoreTest_SpyStore::activate('FolderTest');
 
@@ -123,7 +126,7 @@ class FolderTest extends SapphireTest {
 
 		// File should be located in new folder
 		$this->assertEquals(
-			ASSETS_PATH . '/FolderTest/FileTest-folder2/FileTest-folder1/55b443b601/File1.txt',
+			ASSETS_PATH . '/FolderTest/.protected/FileTest-folder2/FileTest-folder1/55b443b601/File1.txt',
 			AssetStoreTest_SpyStore::getLocalPath($file1)
 		);
 	}
@@ -153,7 +156,7 @@ class FolderTest extends SapphireTest {
 
 		// File should be located in new folder
 		$this->assertEquals(
-			ASSETS_PATH . '/FolderTest/FileTest-folder1-changed/55b443b601/File1.txt',
+			ASSETS_PATH . '/FolderTest/.protected/FileTest-folder1-changed/55b443b601/File1.txt',
 			AssetStoreTest_SpyStore::getLocalPath($file1)
 		);
 	}

--- a/tests/filesystem/UploadTest.php
+++ b/tests/filesystem/UploadTest.php
@@ -10,6 +10,7 @@ class UploadTest extends SapphireTest {
 
 	public function setUp() {
 		parent::setUp();
+		Versioned::reading_stage('Stage');
 		AssetStoreTest_SpyStore::activate('UploadTest');
 	}
 
@@ -48,7 +49,7 @@ class UploadTest extends SapphireTest {
 			$file1->getFilename()
 		);
 		$this->assertEquals(
-			BASE_PATH . '/assets/UploadTest/Uploads/315ae4c3d4/UploadTest-testUpload.txt',
+			BASE_PATH . '/assets/UploadTest/.protected/Uploads/315ae4c3d4/UploadTest-testUpload.txt',
 			AssetStoreTest_SpyStore::getLocalPath($file1)
 		);
 		$this->assertFileExists(
@@ -66,7 +67,7 @@ class UploadTest extends SapphireTest {
 			$file2->getFilename()
 		);
 		$this->assertEquals(
-			BASE_PATH . '/assets/UploadTest/UploadTest-testUpload/315ae4c3d4/UploadTest-testUpload.txt',
+			BASE_PATH . '/assets/UploadTest/.protected/UploadTest-testUpload/315ae4c3d4/UploadTest-testUpload.txt',
 			AssetStoreTest_SpyStore::getLocalPath($file2)
 		);
 		$this->assertFileExists(

--- a/tests/forms/uploadfield/AssetFieldTest.php
+++ b/tests/forms/uploadfield/AssetFieldTest.php
@@ -15,6 +15,9 @@ class AssetFieldTest extends FunctionalTest {
 	public function setUp() {
 		parent::setUp();
 
+		$this->logInWithPermission('ADMIN');
+		Versioned::reading_stage('Stage');
+
 		// Set backend root to /AssetFieldTest
 		AssetStoreTest_SpyStore::activate('AssetFieldTest');
 		$create = function($path) {
@@ -57,7 +60,7 @@ class AssetFieldTest extends FunctionalTest {
 		$this->assertEquals('315ae4c3d44412baa0c81515b6fb35829a337a5a', $responseJSON[0]['hash']);
 		$this->assertEmpty($responseJSON[0]['variant']);
 		$this->assertFileExists(
-			BASE_PATH . '/assets/AssetFieldTest/MyDocuments/315ae4c3d4/testUploadBasic.txt'
+			BASE_PATH . '/assets/AssetFieldTest/.protected/MyDocuments/315ae4c3d4/testUploadBasic.txt'
 		);
 	}
 
@@ -79,7 +82,7 @@ class AssetFieldTest extends FunctionalTest {
 		$responseJSON = json_decode($response->getBody(), true);
 		$this->assertFalse($response->isError());
 		$this->assertFileExists(
-			BASE_PATH . '/assets/AssetFieldTest/MyFiles/315ae4c3d4/testUploadHasOneRelation.txt'
+			BASE_PATH . '/assets/AssetFieldTest/.protected/MyFiles/315ae4c3d4/testUploadHasOneRelation.txt'
 		);
 
 		// Secondly, ensure that simply uploading an object does not save the file against the relation
@@ -148,8 +151,7 @@ class AssetFieldTest extends FunctionalTest {
 		$this->assertFalse($record->File->exists());
 
 		// Check file object itself exists
-		// @todo - When assets are removed from a DBFile reference, these files should be archived
-		$this->assertFileExists($filePath, 'File is only detached, not deleted from filesystem');
+		$this->assertFileNotExists($filePath, 'File is deleted once detached');
 	}
 
 	/**
@@ -248,6 +250,7 @@ class AssetFieldTest extends FunctionalTest {
 	}
 
 	public function testCanUploadWithPermissionCode() {
+		Session::clear("loggedInAs");
 		$field = AssetField::create('MyField');
 
 		$field->setCanUpload(true);

--- a/tests/forms/uploadfield/UploadFieldTest.php
+++ b/tests/forms/uploadfield/UploadFieldTest.php
@@ -14,8 +14,16 @@ class UploadFieldTest extends FunctionalTest {
 		'File' => array('UploadFieldTest_FileExtension')
 	);
 
+	protected $oldReadingMode = null;
+
 	public function setUp() {
 		parent::setUp();
+
+		$this->loginWithPermission('ADMIN');
+
+		// Save versioned state
+		$this->oldReadingMode = Versioned::get_reading_mode();
+		Versioned::reading_stage('Stage');
 
 		// Set backend root to /UploadFieldTest
 		AssetStoreTest_SpyStore::activate('UploadFieldTest');
@@ -39,6 +47,9 @@ class UploadFieldTest extends FunctionalTest {
 
 	public function tearDown() {
 		AssetStoreTest_SpyStore::reset();
+		if($this->oldReadingMode) {
+			Versioned::set_reading_mode($this->oldReadingMode);
+		}
 		parent::tearDown();
 	}
 
@@ -46,14 +57,13 @@ class UploadFieldTest extends FunctionalTest {
 	 * Test that files can be uploaded against an object with no relation
 	 */
 	public function testUploadNoRelation() {
-		$this->loginWithPermission('ADMIN');
-
 		$tmpFileName = 'testUploadBasic.txt';
 		$response = $this->mockFileUpload('NoRelationField', $tmpFileName);
 		$this->assertFalse($response->isError());
 		$uploadedFile = DataObject::get_one('File', array(
 			'"File"."Name"' => $tmpFileName
 		));
+
 		$this->assertFileExists(AssetStoreTest_SpyStore::getLocalPath($uploadedFile));
 		$this->assertTrue(is_object($uploadedFile), 'The file object is created');
 	}
@@ -62,8 +72,6 @@ class UploadFieldTest extends FunctionalTest {
 	 * Test that an object can be uploaded against an object with a has_one relation
 	 */
 	public function testUploadHasOneRelation() {
-		$this->loginWithPermission('ADMIN');
-
 		// Unset existing has_one relation before re-uploading
 		$record = $this->objFromFixture('UploadFieldTest_Record', 'record1');
 		$record->HasOneFileID = null;
@@ -95,8 +103,6 @@ class UploadFieldTest extends FunctionalTest {
 	 * Tests that has_one relations work with subclasses of File
 	 */
 	public function testUploadHasOneRelationWithExtendedFile() {
-		$this->loginWithPermission('ADMIN');
-
 		// Unset existing has_one relation before re-uploading
 		$record = $this->objFromFixture('UploadFieldTest_Record', 'record1');
 		$record->HasOneExtendedFileID = null;
@@ -129,8 +135,6 @@ class UploadFieldTest extends FunctionalTest {
 	 * Test that has_many relations work with files
 	 */
 	public function testUploadHasManyRelation() {
-		$this->loginWithPermission('ADMIN');
-
 		$record = $this->objFromFixture('UploadFieldTest_Record', 'record1');
 
 		// Test that uploaded files can be posted to a has_many relation
@@ -159,8 +163,6 @@ class UploadFieldTest extends FunctionalTest {
 	 * Test that many_many relationships work with files
 	 */
 	public function testUploadManyManyRelation() {
-		$this->loginWithPermission('ADMIN');
-
 		$record = $this->objFromFixture('UploadFieldTest_Record', 'record1');
 		$relationCount = $record->ManyManyFiles()->Count();
 
@@ -195,8 +197,6 @@ class UploadFieldTest extends FunctionalTest {
 	 * in this controller method.
 	 */
 	public function testAllowedExtensions() {
-		$this->loginWithPermission('ADMIN');
-
 		// Test invalid file
 		// Relies on Upload_Validator failing to allow this extension
 		$invalidFile = 'invalid.php';
@@ -237,8 +237,6 @@ class UploadFieldTest extends FunctionalTest {
 	 * Test that has_one relations do not support multiple files
 	 */
 	public function testAllowedMaxFileNumberWithHasOne() {
-		$this->loginWithPermission('ADMIN');
-
 		// Get references for each file to upload
 		$file1 = $this->objFromFixture('File', 'file1');
 		$file2 = $this->objFromFixture('File', 'file2');
@@ -272,8 +270,6 @@ class UploadFieldTest extends FunctionalTest {
 	 * Test that max number of items on has_many is validated
 	 */
 	public function testAllowedMaxFileNumberWithHasMany() {
-		$this->loginWithPermission('ADMIN');
-
 		// The 'HasManyFilesMaxTwo' field has a maximum of two files able to be attached to it.
 		// We want to add files to it until we attempt to add the third. We expect that the first
 		// two should work and the third will fail.
@@ -407,8 +403,6 @@ class UploadFieldTest extends FunctionalTest {
 	 * Test that files can be deleted from has_one
 	 */
 	public function testDeleteFromHasOne() {
-		$this->loginWithPermission('ADMIN');
-
 		$record = $this->objFromFixture('UploadFieldTest_Record', 'record1');
 		$file1 = $this->objFromFixture('File', 'file1');
 
@@ -431,8 +425,6 @@ class UploadFieldTest extends FunctionalTest {
 	 * Test that files can be deleted from has_many
 	 */
 	public function testDeleteFromHasMany() {
-		$this->loginWithPermission('ADMIN');
-
 		$record = $this->objFromFixture('UploadFieldTest_Record', 'record1');
 		$file2 = $this->objFromFixture('File', 'file2');
 		$file3 = $this->objFromFixture('File', 'file3');
@@ -457,8 +449,6 @@ class UploadFieldTest extends FunctionalTest {
 	 * Test that files can be deleted from many_many and the filesystem
 	 */
 	public function testDeleteFromManyMany() {
-		$this->loginWithPermission('ADMIN');
-
 		$record = $this->objFromFixture('UploadFieldTest_Record', 'record1');
 		$file4 = $this->objFromFixture('File', 'file4');
 		$file5 = $this->objFromFixture('File', 'file5');
@@ -496,8 +486,6 @@ class UploadFieldTest extends FunctionalTest {
 	 * Test control output html
 	 */
 	public function testView() {
-		$this->loginWithPermission('ADMIN');
-
 		$record = $this->objFromFixture('UploadFieldTest_Record', 'record1');
 		$file4 = $this->objFromFixture('File', 'file4');
 		$file5 = $this->objFromFixture('File', 'file5');
@@ -523,8 +511,6 @@ class UploadFieldTest extends FunctionalTest {
 	}
 
 	public function testEdit() {
-		$memberID = $this->loginWithPermission('ADMIN');
-
 		$record = $this->objFromFixture('UploadFieldTest_Record', 'record1');
 		$file4 = $this->objFromFixture('File', 'file4');
 		$fileNoEdit = $this->objFromFixture('File', 'file-noedit');
@@ -630,8 +616,6 @@ class UploadFieldTest extends FunctionalTest {
 	}
 
 	public function testReadonly() {
-		$this->loginWithPermission('ADMIN');
-
 		$response = $this->get('UploadFieldTest_Controller');
 		$this->assertFalse($response->isError());
 
@@ -655,8 +639,6 @@ class UploadFieldTest extends FunctionalTest {
 	}
 
 	public function testDisabled() {
-		$this->loginWithPermission('ADMIN');
-
 		$response = $this->get('UploadFieldTest_Controller');
 		$this->assertFalse($response->isError());
 
@@ -677,7 +659,6 @@ class UploadFieldTest extends FunctionalTest {
 	}
 
 	public function testCanUpload() {
-		$this->loginWithPermission('ADMIN');
 		$response = $this->get('UploadFieldTest_Controller');
 		$this->assertFalse($response->isError());
 
@@ -697,6 +678,7 @@ class UploadFieldTest extends FunctionalTest {
 
 	public function testCanUploadWithPermissionCode() {
 		$field = UploadField::create('MyField');
+		Session::clear("loggedInAs");
 
 		$field->setCanUpload(true);
 		$this->assertTrue($field->canUpload());
@@ -714,7 +696,6 @@ class UploadFieldTest extends FunctionalTest {
 	}
 
 	public function testCanAttachExisting() {
-		$this->loginWithPermission('ADMIN');
 		$response = $this->get('UploadFieldTest_Controller');
 		$this->assertFalse($response->isError());
 
@@ -740,8 +721,6 @@ class UploadFieldTest extends FunctionalTest {
 	}
 
 	public function testSelect() {
-		$this->loginWithPermission('ADMIN');
-
 		$record = $this->objFromFixture('UploadFieldTest_Record', 'record1');
 		$file4 = $this->objFromFixture('File', 'file4');
 		$fileSubfolder = $this->objFromFixture('File', 'file-subfolder');
@@ -758,8 +737,6 @@ class UploadFieldTest extends FunctionalTest {
 	}
 
 	public function testSelectWithDisplayFolderName() {
-		$this->loginWithPermission('ADMIN');
-
 		$record = $this->objFromFixture('UploadFieldTest_Record', 'record1');
 		$file4 = $this->objFromFixture('File', 'file4');
 		$fileSubfolder = $this->objFromFixture('File', 'file-subfolder');
@@ -779,8 +756,6 @@ class UploadFieldTest extends FunctionalTest {
 	 * Test that UploadField:overwriteWarning cannot overwrite Upload:replaceFile
 	 */
 	public function testConfigOverwriteWarningCannotRelaceFiles() {
-		$this->loginWithPermission('ADMIN');
-
 		Upload::config()->replaceFile = false;
 		UploadField::config()->defaultConfig = array_merge(
 			UploadField::config()->defaultConfig, array('overwriteWarning' => true)
@@ -815,8 +790,6 @@ class UploadFieldTest extends FunctionalTest {
 	 * Tests that UploadField::fileexist works
 	 */
 	public function testFileExists() {
-		$this->loginWithPermission('ADMIN');
-
 		// Check that fileexist works on subfolders
 		$nonFile = uniqid().'.txt';
 		$responseEmpty = $this->mockFileExists('NoRelationField', $nonFile);
@@ -834,7 +807,7 @@ class UploadFieldTest extends FunctionalTest {
 		$tmpFileName = 'testUploadBasic.txt';
 		$response = $this->mockFileUpload('RootFolderTest', $tmpFileName);
 		$this->assertFalse($response->isError());
-		$this->assertFileExists(ASSETS_PATH . "/UploadFieldTest/315ae4c3d4/$tmpFileName");
+		$this->assertFileExists(ASSETS_PATH . "/UploadFieldTest/.protected/315ae4c3d4/$tmpFileName");
 		$responseExists = $this->mockFileExists('RootFolderTest', $tmpFileName);
 		$responseExistsData = json_decode($responseExists->getBody());
 		$this->assertFalse($responseExists->isError());
@@ -843,7 +816,7 @@ class UploadFieldTest extends FunctionalTest {
 		// Check that uploaded files can be detected
 		$response = $this->mockFileUpload('NoRelationField', $tmpFileName);
 		$this->assertFalse($response->isError());
-		$this->assertFileExists(ASSETS_PATH . "/UploadFieldTest/UploadedFiles/315ae4c3d4/$tmpFileName");
+		$this->assertFileExists(ASSETS_PATH . "/UploadFieldTest/.protected/UploadedFiles/315ae4c3d4/$tmpFileName");
 		$responseExists = $this->mockFileExists('NoRelationField', $tmpFileName);
 		$responseExistsData = json_decode($responseExists->getBody());
 		$this->assertFalse($responseExists->isError());
@@ -855,7 +828,7 @@ class UploadFieldTest extends FunctionalTest {
 		$tmpFileNameExpected = 'test-Upload-Bad.txt';
 		$response = $this->mockFileUpload('NoRelationField', $tmpFileName);
 		$this->assertFalse($response->isError());
-		$this->assertFileExists(ASSETS_PATH . "/UploadFieldTest/UploadedFiles/315ae4c3d4/$tmpFileNameExpected");
+		$this->assertFileExists(ASSETS_PATH . "/UploadFieldTest/.protected/UploadedFiles/315ae4c3d4/$tmpFileNameExpected");
 		// With original file
 		$responseExists = $this->mockFileExists('NoRelationField', $tmpFileName);
 		$responseExistsData = json_decode($responseExists->getBody());
@@ -869,7 +842,6 @@ class UploadFieldTest extends FunctionalTest {
 
 		// Test that attempts to navigate outside of the directory return false
 		$responseExists = $this->mockFileExists('NoRelationField', "../../../../var/private/$tmpFileName");
-		$responseExistsData = json_decode($responseExists->getBody());
 		$this->assertTrue($responseExists->isError());
 		$this->assertContains('File is not a valid upload', $responseExists->getBody());
 	}
@@ -922,6 +894,7 @@ class UploadFieldTest extends FunctionalTest {
 
 		$form = new UploadFieldTestForm();
 		$form->loadDataFrom($data, true);
+
 		if($form->validate()) {
 			$record = $form->getRecord();
 			$form->saveInto($record);
@@ -994,6 +967,35 @@ class UploadFieldTest extends FunctionalTest {
 			"UploadFieldTest_Controller/Form/field/{$fileField}/item/{$fileID}/delete",
 			array()
 		);
+	}
+
+	public function get($url, $session = null, $headers = null, $cookies = null) {
+		// Inject stage=Stage into the URL, to force working on draft
+		$url = $this->addStageToUrl($url);
+		return parent::get($url, $session, $headers, $cookies);
+	}
+
+	public function post($url, $data, $headers = null, $session = null, $body = null, $cookies = null) {
+		// Inject stage=Stage into the URL, to force working on draft
+		$url = $this->addStageToUrl($url);
+		return parent::post($url, $data, $headers, $session, $body, $cookies);
+	}
+
+	/**
+	 * Adds ?stage=Stage to url
+	 *
+	 * @param string $url
+	 * @return string
+	 */
+	protected function addStageToUrl($url) {
+		if(stripos($url, 'stage=Stage') === false) {
+			if(stripos($url, '?') === false) {
+				$url .= '?stage=Stage';
+			} else {
+				$url .= '&stage=Stage';
+			}
+		}
+		return $url;
 	}
 
 }

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -102,6 +102,22 @@ class VersionedTest extends SapphireTest {
 		$this->assertEquals($count, $count2);
 	}
 
+	/**
+	 * Test that publishing from invalid stage will throw exception
+	 */
+	public function testInvalidPublish() {
+		$obj = new VersionedTest_Subclass();
+		$obj->ExtraField = 'Foo'; // ensure that child version table gets written
+		$obj->write();
+		$this->setExpectedException(
+			'InvalidArgumentException',
+			"Can't find VersionedTest_DataObject#{$obj->ID} in stage Live"
+		);
+
+		// Fail publishing from live to stage
+		$obj->publish('Live', 'Stage');
+	}
+
 	public function testDuplicate() {
 		$obj1 = new VersionedTest_Subclass();
 		$obj1->ExtraField = 'Foo';


### PR DESCRIPTION
This is the last major refactor necessary to implement [RFC-1 Asset Versioning](https://github.com/silverstripe/silverstripe-framework/issues/3792). In this update File finally is given the `Versioned` extension.

AssetAdmin has been upgraded with versioned file management.

The most important parts of this pull request are:
- AssetControlExtension extension for performing visibility control of underling DBFile assets on the dataobject.
- Update of Versioned to make it useful for non-SiteTree objects
- VersionedGridFieldItemRequest Which supports versioned objects in the GridField. Credit to @icecaster and @unclecheese for inspiration and ideas. :)

Not included in this pull request, and still remaining:
- New UX for managing assets
- Shortcodes for images in HTML area
- Secure file streaming
- Bulk versioned change management

Rebased against dependant PR https://github.com/silverstripe/silverstripe-framework/pull/4992.

CMS pull request https://github.com/silverstripe/silverstripe-cms/pull/1381.