### PR TITLE
Update 01_Caching.md

### DIFF
--- a/docs/en/02_Developer_Guides/08_Performance/01_Caching.md
+++ b/docs/en/02_Developer_Guides/08_Performance/01_Caching.md
@@ -125,7 +125,7 @@ To use this backend, you need a memcached daemon and the memcache PECL extension
 				'timeout' => 5,
 				'retry_interval' => 15, 
 				'status' => true, 
-				'failure_callback' => ''
+				'failure_callback' => null
 			)
 		)
 	);


### PR DESCRIPTION
`'failure_callback' => ''` fails but providing `'failure_callback' => null` seems to work fine (since it expects a closure but gets a string, I think).