### PR TITLE
FIX for #5028: Ensure empty YML configs don't break when merging them in.

### DIFF
--- a/core/manifest/ConfigManifest.php
+++ b/core/manifest/ConfigManifest.php
@@ -652,8 +652,10 @@ class SS_ConfigManifest {
 	 * @return void
 	 */
 	public function mergeInYamlFragment(&$into, $fragment) {
-		foreach ($fragment as $k => $v) {
-			Config::merge_high_into_low($into[$k], $v);
+		if (is_array($fragment) || ($fragment instanceof  Traversable)) {
+			foreach ($fragment as $k => $v) {
+				Config::merge_high_into_low($into[$k], $v);
+			}
 		}
 	}
 


### PR DESCRIPTION
This is simply making sure that the $fragment variable is traversable before foreach'ing over it. Should work as a solid fix against #5028.