### PR TITLE
Reverting a page to a specific version is not working correctly : SS 3.2

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -2733,6 +2733,11 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 		// Since database_fields omits 'ID'
 		if($field == "ID") return "Int";
 
+        // Add fields from Versioned extension
+        if($field == 'Version' && singleton($class)->hasExtension('Versioned')) {
+            return 'Int';
+        }
+
 		$fieldMap = self::database_fields($class, false);
 
 		// Remove string-based "constructor-arguments" from the DBField definition

--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -1283,7 +1283,7 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 	 */
 	public function doRollbackTo($version) {
 		$this->owner->extend('onBeforeRollback', $version);
-		$this->publish($version, "Stage");
+		$this->publish($version, "Stage", true);
 
 		$this->owner->writeWithoutVersion();
 

--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -1283,7 +1283,7 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 	 */
 	public function doRollbackTo($version) {
 		$this->owner->extend('onBeforeRollback', $version);
-		$this->publish($version, "Stage", true);
+		$this->publish($version, "Stage");
 
 		$this->owner->writeWithoutVersion();
 


### PR DESCRIPTION
disabled creating a new version record for child Page_versions table but not in SiteTree_versions (Page extends SiteTree and when Page has db array) . Issue #5040