### PR TITLE
Browser support for SilverStripe 4.x

### DIFF
--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -49,9 +49,7 @@ For more information on how to scale SilverStripe see the [Performance](/develop
 
 ## Client side (CMS) requirements
 
-SilverStripe CMS is designed to work well with Google Chrome, Mozilla Firefox and Internet Explorer 8+. We aim to
-provide satisfactory experiences in Apple Safari. SilverStripe CMS works well across Windows, Linux, and Mac operating
-systems.
+SilverStripe CMS is designed for Google Chrome, Mozilla Firefox, Microsoft Edge, Internet Explorer 11+ and Apple Safari 5+. SilverStripe CMS works well across Windows, Linux, and Mac operating systems.
 
 ## End user requirements
 


### PR DESCRIPTION
So now we can discuss what exactly browser support should be :D I'll be happy to test stuff in all Windows browsers. 

My arguments for dropping support for IE8-10: 

1. **Microsoft support**: IE<11 is no longer supported by Microsoft since 12 January this year, and WinXP (which can only update to IE8) hasn't been supported for almost 2 years.
2. **Javascript libraries**: several javascript libraries have dropped support for <11 in response to this news. TinyMCE also has several plugins that are not supported by IE8 and IE9 (such as their image upload/edit plugins), so we can use those if IE8-9 doesn't need to be supported. Finally 10 then: this one doesn't have a large browser share (it's lower than IE9) because those that upgrade to 10 also upgrade to 11. So if support for IE9 is dropped, might as well drop it for IE10 too. 

Next: I think we should do more testing on Apple Safari so that we can include it in the "Supported" list. Despite the relatively low browser market share, this would be nice to include Apple users more, especially as Apple does keep that browser up to date (it's on version 9 at the moment). Its behavior is supposed to be close to Chrome (as another Webkit browser), so as long as we have a developer that can test it on Apple, this shouldn't be too much work! I'm not sure how early a version we can support, but I'm happy to test on 5.1.7, the final version released for Windows (TinyMCE supports 5+). As an example, I just tried out most CMS actions on SS 3.2, and haven't encountered any issue. 

And I suppose "Microsoft Edge" should be included nowadays, too.