### PR TITLE
BUG Setting $tmpFile property in Upload class. Attempt 2.

### DIFF
--- a/filesystem/Upload.php
+++ b/filesystem/Upload.php
@@ -134,6 +134,8 @@ class Upload extends Controller {
 
 		$valid = $this->validate($tmpFile);
 		if(!$valid) return false;
+		
+		$this->tmpFile = $tmpFile;
 
 		// @TODO This puts a HUGE limitation on files especially when lots
 		// have been uploaded.


### PR DESCRIPTION
Attempt 2.

There is a protected $tmpFile property.
If it is defined in this place (see my commit)
I would be able to create an extension for upload class like this (example is simplified):
```
class CustomUploadExtension extends Extension {
    public function onAfterLoad($file){
        $originalName = $this->owner->getField('tmpFile')['name'];
        $file->setField('Title', $originalName);
        $file->write();
        return;
    }
}
```
------------------------------------
```
Upload::add_extension('CustomUploadExtension');
Config::inst()->update('FileNameFilter', 'default_replacements', array(
    '/\s/' => '-', // remove whitespace
    '/_/' => '-', // underscores to dashes

    '/а/u'=>"a",'/б/u'=>"b",'/в/u'=>"v",
        /*......*/
    '/Я/u'=>"YA",

    '/[^A-Za-z0-9+.\-]+/' => '', // remove non-ASCII chars, only allow alphanumeric plus dash and dot
    '/[\-]{2,}/' => '-', // remove duplicate dashes
    '/^[\.\-_]+/' => '', // Remove all leading dots, dashes or underscores
));
```
It is useful for uploading cyrrilic-named file and leaving title as original filename.