### PR TITLE
FIX Do not hang on nested parameters in search context

### DIFF
--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -212,7 +212,7 @@ abstract class ModelAdmin extends LeftAndMain {
 		$params = $this->getRequest()->requestVar('q');
 
 		if(is_array($params)) {
-			$params = array_map('trim', $params);
+			$params = ArrayLib::array_map_recursive('trim', $params);
 		}
 
 		$list = $context->getResults($params);

--- a/core/ArrayLib.php
+++ b/core/ArrayLib.php
@@ -164,6 +164,23 @@ class ArrayLib {
 	}
 
 	/**
+	 * Similar to array_map, but recurses when arrays are encountered.
+	 *
+	 * Actually only one array argument is supported.
+	 *
+	 * @param $f callback to apply
+	 * @param $array array
+	 * @return array
+	 */
+	public static function array_map_recursive($f, $array) {
+		$applyOrRecurse = function($v) use($f) {
+			return is_array($v) ? ArrayLib::array_map_recursive($f, $v) : call_user_func($f, $v);
+		};
+
+		return array_map($applyOrRecurse, $array);
+	}
+
+	/**
 	 * Recursively merges two or more arrays.
 	 *
 	 * Behaves similar to array_merge_recursive(), however it only merges

--- a/tests/core/ArrayLibTest.php
+++ b/tests/core/ArrayLibTest.php
@@ -48,6 +48,29 @@ class ArrayLibTest extends SapphireTest {
 		);
 	}
 
+	public function testArrayMapRecursive() {
+		$array = array(
+			'a ',
+			array('  b', 'c'),
+		);
+		$strtoupper = array(
+			'A ',
+			array('  B', 'C'),
+		);
+		$trim = array(
+			'a',
+			array('b', 'c'),
+		);
+		$this->assertEquals(
+			$strtoupper,
+			ArrayLib::array_map_recursive('strtoupper', $array)
+		);
+		$this->assertEquals(
+			$trim,
+			ArrayLib::array_map_recursive('trim', $array)
+		);
+	}
+
 	public function testArrayMergeRecursive() {
 		$first = array(
 			'first' => 'a',


### PR DESCRIPTION
Backport of https://github.com/silverstripe/silverstripe-framework/pull/4619 to 3.2