### PR TITLE
Fix for issue #5086

### DIFF
--- a/security/Group.php
+++ b/security/Group.php
@@ -115,7 +115,7 @@ class Group extends DataObject {
 			$config->getComponentByType('GridFieldAddExistingAutocompleter')
 				->setResultsFormat('$Title ($Email)')->setSearchFields(array('FirstName', 'Surname', 'Email'));
 			$config->getComponentByType('GridFieldDetailForm')
-				->setValidator(new Member_Validator())
+				->setValidator(Member_Validator::create())
 				->setItemEditFormCallback(function($form, $component) use($group) {
 					$record = $form->getRecord();
 					$groupsField = $form->Fields()->dataFieldByName('DirectGroups');


### PR DESCRIPTION
Improve `Member_Validator` to:
- properly check for existing members.
- allow extensions.
- remove old code and replace with new syntax and config api.

Fix issue in Group code where Member_Validator was instantiated via "new" which didn't allow injector overrides.