### PR TITLE
added if statement to catch NULL validators

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -1301,7 +1301,9 @@ class LeftAndMain extends Controller implements PermissionProvider {
 				// The clientside (mainly LeftAndMain*.js) rely on ajax responses
 				// which can be evaluated as javascript, hence we need
 				// to override any global changes to the validation handler.
-				$form->setValidator($validator);
+				if($validator != NULL){
+					$form->setValidator($validator);
+				}
 			} else {
 				$form->unsetValidator();
 			}


### PR DESCRIPTION
Problem found on CWP:

"Since upgrading to 1.2.0, we've noticed a problem with workflows that have a second transition on them ie accept or reject. When an author goes to publish, they receive a message in the right hand corner saying "Not Allowed".

When trying to preview pages, we get a message saying "Service Temporarily Unavailable". 

We can go through and approve items in the workflow, but cannot preview them first. It is as if the pages are locked out for editing for everyone but when this is disabled for the workflow it makes no difference. 

Workflows with single transitions aren't affected. "

Error was:

"auth.log:Feb 24 14:42:08 EXAMPLE SilverStripe[27392]: PHP Catchable fatal error:  Argument 1 passed to Form::setValidator() must be an instance of Validator, null given, called in /sites/EXAMPLE/releases/20160223201643/framework/admin/code/LeftAndMain.php on line 1298 and defined in /sites/EXMAPLE/releases/20160223201643/framework/forms/Form.php on line 654"