### PR TITLE
Fixes #5086

### DIFF
--- a/security/Group.php
+++ b/security/Group.php
@@ -115,7 +115,7 @@ class Group extends DataObject {
 			$config->getComponentByType('GridFieldAddExistingAutocompleter')
 				->setResultsFormat('$Title ($Email)')->setSearchFields(array('FirstName', 'Surname', 'Email'));
 			$config->getComponentByType('GridFieldDetailForm')
-				->setValidator(new Member_Validator())
+				->setValidator(Member_Validator::create())
 				->setItemEditFormCallback(function($form, $component) use($group) {
 					$record = $form->getRecord();
 					$groupsField = $form->Fields()->dataFieldByName('DirectGroups');

--- a/security/Member.php
+++ b/security/Member.php
@@ -1801,21 +1801,33 @@ class Member_ForgotPasswordEmail extends Email {
  * Member Validator
  *
  * Custom validation for the Member object can be achieved either through an
- * {@link DataExtension} on the Member object or, by specifying a subclass of
+ * {@link DataExtension} on the Member_Validator object or, by specifying a subclass of
  * {@link Member_Validator} through the {@link Injector} API.
- *
+ * The Validator can also be modified by adding an Extension to Member and implement the
+ * <code>updateValidator</code> hook.
  * {@see Member::getValidator()}
+ *
+ * Additional required fields can also be set via config API, eg.
+ * <code>
+ * Member_Validator:
+ *   customRequired:
+ *     - Surname
+ * </code>
  *
  * @package framework
  * @subpackage security
  */
-class Member_Validator extends RequiredFields {
-
+class Member_Validator extends RequiredFields
+{
+	/**
+	 * Fields that are required by this validator
+	 * @config
+	 * @var array
+	 */
 	protected $customRequired = array(
 		'FirstName',
 		'Email'
 	);
-
 
 	/**
 	 * Constructor
@@ -1829,44 +1841,44 @@ class Member_Validator extends RequiredFields {
 
 		$required = array_merge($required, $this->customRequired);
 
-		parent::__construct($required);
-	}
-
-	/**
-	 * Check if the submitted member data is valid (server-side)
-	 *
-	 * Check if a member with that email doesn't already exist, or if it does
-	 * that it is this member.
-	 *
-	 * @param array $data Submitted data
-	 * @return bool Returns TRUE if the submitted data is valid, otherwise
-	 *              FALSE.
-	 */
-	public function php($data) {
-		$valid = parent::php($data);
-
-		$identifierField = Member::config()->unique_identifier_field;
-		$member = DataObject::get_one('Member', array(
-			"\"$identifierField\"" => $data[$identifierField]
-		));
-
-		// if we are in a complex table field popup, use ctf[childID], else use ID
-		if(isset($_REQUEST['ctf']['childID'])) {
-			$id = $_REQUEST['ctf']['childID'];
-		} elseif(isset($_REQUEST['ID'])) {
-			$id = $_REQUEST['ID'];
-		} else {
-			$id = null;
+		// check for config API values and merge them in
+		$config = $this->config()->customRequired;
+		if(is_array($config)){
+			$required = array_merge($required, $config);
 		}
 
-		if($id && is_object($member) && $member->ID != $id) {
-			$uniqueField = $this->form->Fields()->dataFieldByName($identifierField);
+		parent::__construct(array_unique($required));
+	}
+
+	public function php($data)
+	{
+		$valid = parent::php($data);
+
+		$identifierField = (string)Member::config()->unique_identifier_field;
+
+		$id = isset($data['ID']) ? (int)$data['ID'] : 0;
+		if(!$id && ($ctrl = $this->form->getController())){
+			// get the record when within GridField (Member editing page in CMS)
+			if($ctrl instanceof GridFieldDetailForm_ItemRequest && $record = $ctrl->getRecord()){
+				$id = $record->ID;
+				// set the ID to the data array, so that extensions can also use it
+				$data['ID'] = $id;
+			}
+		}
+
+		$members = Member::get()->filter($identifierField, $data[$identifierField]);
+		if($id) {
+			$members = $members->exclude('ID', $id);
+		}
+		$existingMember = $members->First();
+
+		if($existingMember && $existingMember instanceof Member) {
 			$this->validationError(
-				$uniqueField->id(),
+				$identifierField,
 				_t(
 					'Member.VALIDATIONMEMBEREXISTS',
-					'A member already exists with the same %s',
-					array('identifier' => strtolower($identifierField))
+					'A member already exists with the same {identifier}',
+					array('identifier' => $existingMember->fieldLabel($identifierField))
 				),
 				'required'
 			);
@@ -1874,15 +1886,8 @@ class Member_Validator extends RequiredFields {
 		}
 
 		// Execute the validators on the extensions
-		if($this->extension_instances) {
-			foreach($this->extension_instances as $extension) {
-				if(method_exists($extension, 'hasMethod') && $extension->hasMethod('updatePHP')) {
-					$valid &= $extension->updatePHP($data, $this->form);
-				}
-			}
-		}
-
-		return $valid;
+		$results = $this->extend('updatePHP', $data, $this->form);
+		$results[] = $valid;
+		return min($results);
 	}
-
 }

--- a/tests/security/MemberTest.php
+++ b/tests/security/MemberTest.php
@@ -678,7 +678,7 @@ class MemberTest extends FunctionalTest {
 		$newAdminGroup = new Group(array('Title' => 'newadmin'));
 		$newAdminGroup->write();
 		Permission::grant($newAdminGroup->ID, 'ADMIN');
-		
+
 		// Test staff member can't be added to admin groups
 		$this->assertFalse($staffMember->inGroup($newAdminGroup));
 		$staffMember->Groups()->setByIDList(array($newAdminGroup->ID));
@@ -842,6 +842,124 @@ class MemberTest extends FunctionalTest {
 		}
 	}
 
+	public function testMemberValidator()
+	{
+		$memberA = $this->objFromFixture('Member', 'admin');
+		$memberB = $this->objFromFixture('Member', 'test');
+
+		// create a blank form
+		$form = new MemberTest_ValidatorForm();
+
+		$validator = new Member_Validator();
+		$validator->setForm($form);
+
+		// Simulate creation of a new member via form, but use an existing member identifier
+		$fail = $validator->php(array(
+			'FirstName' => 'Test',
+			'Email' => $memberA->Email
+		));
+
+		$this->assertFalse(
+			$fail,
+			'Member_Validator must fail when trying to create new Member with existing Email.'
+		);
+
+		// populate the form with values from another member
+		$form->loadDataFrom($memberB);
+
+		// Simulate update of a member via form and use an existing member identifier
+		$fail = $validator->php(array(
+			'ID' => $memberB->ID,
+			'FirstName' => 'Test',
+			'Email' => $memberA->Email
+		));
+
+		// Simulate update to a new Email address
+		$pass1 = $validator->php(array(
+			'ID' => $memberB->ID,
+			'FirstName' => 'Test',
+			'Email' => 'membervalidatortest@testing.com'
+		));
+
+		// Pass in the same Email address that the member already has. Ensure that case is valid
+		$pass2 = $validator->php(array(
+			'ID' => $memberB->ID,
+			'FirstName' => 'Test',
+			'Surname' => 'User',
+			'Email' => $memberB->Email
+		));
+
+		$this->assertFalse(
+			$fail,
+			'Member_Validator must fail when trying to update existing member with existing Email.'
+		);
+
+		$this->assertTrue(
+			$pass1,
+			'Member_Validator must pass when Email is updated to a value that\'s not in use.'
+		);
+
+		$this->assertTrue(
+			$pass2,
+			'Member_Validator must pass when Member updates his own Email to the already existing value.'
+		);
+	}
+
+	public function testMemberValidatorWithExtensions()
+	{
+		// create a blank form
+		$form = new MemberTest_ValidatorForm();
+
+		// Test extensions
+		Member_Validator::add_extension('MemberTest_MemberValidator_SurnameMustMatchFirstNameExtension');
+		$validator = new Member_Validator();
+		$validator->setForm($form);
+
+		// This test should fail, since the extension enforces FirstName == Surname
+		$fail = $validator->php(array(
+			'FirstName' => 'Test',
+			'Surname' => 'User',
+			'Email' => 'test-member-validator-extension@testing.com'
+		));
+
+		$pass = $validator->php(array(
+			'FirstName' => 'Test',
+			'Surname' => 'Test',
+			'Email' => 'test-member-validator-extension@testing.com'
+		));
+
+		$this->assertFalse(
+			$fail,
+			'Member_Validator must fail because of added extension.'
+		);
+
+		$this->assertTrue(
+			$pass,
+			'Member_Validator must succeed, since it meets all requirements.'
+		);
+
+		// Add another extension that always fails. This ensures that all extensions are considered in the validation
+		Member_Validator::add_extension('MemberTest_MemberValidator_AlwaysFailsExtension');
+		$validator = new Member_Validator();
+		$validator->setForm($form);
+
+		// Even though the data is valid, This test should still fail, since one extension always returns false
+		$fail = $validator->php(array(
+			'FirstName' => 'Test',
+			'Surname' => 'Test',
+			'Email' => 'test-member-validator-extension@testing.com'
+		));
+
+		$this->assertFalse(
+			$fail,
+			'Member_Validator must fail because of added extensions.'
+		);
+
+		// Remove added extensions
+		Member_Validator::remove_extension('MemberTest_MemberValidator_AlwaysFailsExtension');
+		Member_Validator::remove_extension('MemberTest_MemberValidator_SurnameMustMatchFirstNameExtension');
+	}
+
 	public function testCustomMemberValidator() {
 		$member = $this->objFromFixture('Member', 'admin');
 
@@ -916,6 +1034,30 @@ class MemberTest_ValidatorExtension extends DataExtension implements TestOnly {
 	public function updateValidator(&$validator) {
 		$validator->addRequiredField('Surname');
 		$validator->removeRequiredField('FirstName');
+	}
+}
+
+/**
+ * Extension that adds additional validation criteria
+ * @package framework
+ * @subpackage tests
+ */
+class MemberTest_MemberValidator_SurnameMustMatchFirstNameExtension extends DataExtension implements TestOnly
+{
+	public function updatePHP($data, $form) {
+		return $data['FirstName'] == $data['Surname'];
+	}
+}
+
+/**
+ * Extension that adds additional validation criteria
+ * @package framework
+ * @subpackage tests
+ */
+class MemberTest_MemberValidator_AlwaysFailsExtension extends DataExtension implements TestOnly
+{
+	public function updatePHP($data, $form) {
+		return false;
 	}
 }
 


### PR DESCRIPTION
Improve `Member_Validator` to:
- properly check for existing members.
- allow extensions.
- remove old code and replace with new syntax and add config api.

Fix issue in Group code where Member_Validator was instantiated via "new" which didn't allow injector overrides.
Added unit-tests.