### PR TITLE
Populate foreign key before getting CMS fields

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -385,20 +385,22 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 				$actions->push(new LiteralField('cancelbutton', $text));
 			}
 		}
+		
+		// If we are creating a new record in a has-many list, then
+		// pre-populate the record's foreign key.
+		if($list instanceof HasManyList && !$this->record->isInDB()) {
+			$key = $list->getForeignKey();
+			$id = $list->getForeignID();
+			$this->record->$key = $id;
+		}
 
 		$fields = $this->component->getFields();
 		if(!$fields) $fields = $this->record->getCMSFields();
 
 		// If we are creating a new record in a has-many list, then
-		// pre-populate the record's foreign key. Also disable the form field as
-		// it has no effect.
+		// Disable the form field as it has no effect.
 		if($list instanceof HasManyList) {
 			$key = $list->getForeignKey();
-			$id = $list->getForeignID();
-
-			if(!$this->record->isInDB()) {
-				$this->record->$key = $id;
-			}
 
 			if($field = $fields->dataFieldByName($key)) {
 				$fields->makeFieldReadonly($field);


### PR DESCRIPTION
In it's current state you need to revert to something like `Session::get('CMSMain.currentPage')` to get the foreign key of what the item you are creating relates to (e.g. a Book => has_many Author) - if you create a new Author you may need to reference the owning Book in the `getCMSFields` function.

This is just a small quality of life buff that populates that foreign key before calling `getCMSFields()` rather than after.

This should not break backwards compatibility in any way and isn't exactly a new feature so could be considered a bug fix.