### PR TITLE
FIX Do not hang on nested parameters in search context

### DIFF
--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -212,7 +212,10 @@ abstract class ModelAdmin extends LeftAndMain {
 		$params = $this->getRequest()->requestVar('q');
 
 		if(is_array($params)) {
-			$params = array_map('trim', $params);
+			$trimRecursive = function($v) use(&$trimRecursive) {
+				return is_array($v) ? array_map($trimRecursive, $v) : trim($v);
+			};
+			$params = $trimRecursive($params);
 		}
 
 		$list = $context->getResults($params);


### PR DESCRIPTION
Backport of 0b5a57389b09 for 3.2 that does not add a new API, as requested by @tractorcow on #5056  to be semver compatible.