### PR TITLE
invokeWithExtensions should accept multiple args

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -939,13 +939,13 @@ abstract class Object {
 	 * all results into an array
 	 *
 	 * @param string $method the method name to call
-	 * @param mixed $argument a single argument to pass
+	 * @param mixed $a1,... up to 7 arguments to be passed to the method
 	 * @return mixed
 	 * @todo integrate inheritance rules
 	 */
-	public function invokeWithExtensions($method, $argument = null) {
-		$result = method_exists($this, $method) ? array($this->$method($argument)) : array();
-		$extras = $this->extend($method, $argument);
+	public function invokeWithExtensions($method, &$a1=null, &$a2=null, &$a3=null, &$a4=null, &$a5=null, &$a6=null, &$a7=null) {
+		$result = method_exists($this, $method) ? array($this->$method($a1, $a2, $a3, $a4, $a5, $a6, $a7)) : array();
+		$extras = $this->extend($method, $a1, $a2, $a3, $a4, $a5, $a6, $a7);
 
 		return $extras ? array_merge($result, $extras) : $result;
 	}

--- a/core/Object.php
+++ b/core/Object.php
@@ -943,7 +943,7 @@ abstract class Object {
 	 * @return mixed
 	 * @todo integrate inheritance rules
 	 */
-	public function invokeWithExtensions($method, &$a1=null, &$a2=null, &$a3=null, &$a4=null, &$a5=null, &$a6=null, &$a7=null) {
+	public function invokeWithExtensions($method, $a1=null, $a2=null, $a3=null, $a4=null, $a5=null, $a6=null, $a7=null) {
 		$result = method_exists($this, $method) ? array($this->$method($a1, $a2, $a3, $a4, $a5, $a6, $a7)) : array();
 		$extras = $this->extend($method, $a1, $a2, $a3, $a4, $a5, $a6, $a7);
 


### PR DESCRIPTION
Currently it's setup so it only accepts a single arg, and it isn't passed by reference even though it's effective purpose is to first call the method on the Object itself and finally on any extensions as opposed to extend which can accept 7 args and passes them by reference.

An example of where this is an issue is on the duplicate method of DataObject - the doWrite value is never received.
https://github.com/silverstripe/silverstripe-framework/blob/3/model/DataObject.php#L537

Since this function is the same +1 I've mirrored the constructor.
I'm not sure if this is likely to break anything now that we're passing by reference so I'd be happy to release in 3.4 or 3.3.* with just multiple parameters but not passing by reference, and in 4.0 update it to pass by reference if we believe this counts as a backwards compatibility breaker.