### PR TITLE
ENHANCEMENT: more consistent Member can* methods.

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -1470,15 +1470,14 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * This is likely to be customized for social sites etc. with a looser permission model.
 	 */
 	public function canView($member = null) {
-		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) $member = Member::currentUser();
-
-		// extended access checks
-		$results = $this->extend('canView', $member);
-		if($results && is_array($results)) {
-			if(!min($results)) return false;
-			else return true;
+		if(!($member instanceof Member) {
+			$member = Member::currentUser();
+		}		
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
 		}
-
+		
 		// members can usually edit their own record
 		if($member && $this->ID == $member->ID) return true;
 
@@ -1497,26 +1496,28 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * Otherwise they'll need ADMIN or CMS_ACCESS_SecurityAdmin permissions
 	 */
 	public function canEdit($member = null) {
-		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) $member = Member::currentUser();
-
-		// extended access checks
-		$results = $this->extend('canEdit', $member);
-		if($results && is_array($results)) {
-			if(!min($results)) return false;
-			else return true;
+		if(!($member instanceof Member) {
+			$member = Member::currentUser();
+		}	
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
 		}
 
-		// No member found
-		if(!($member && $member->exists())) return false;
-
-		// If the requesting member is not an admin, but has access to manage members,
-		// they still can't edit other members with ADMIN permission.
-		// This is a bit weak, strictly speaking they shouldn't be allowed to
-		// perform any action that could change the password on a member
-		// with "higher" permissions than himself, but thats hard to determine.
+		// HACK: we should not allow for an non-Admin to edit an Admin
 		if(!Permission::checkMember($member, 'ADMIN') && Permission::checkMember($this, 'ADMIN')) return false;
 
-		return $this->canView($member);
+		// members can usually edit their own record
+		if($member && $this->ID == $member->ID) return true;
+
+		if(
+			Permission::checkMember($member, 'ADMIN')
+			|| Permission::checkMember($member, 'CMS_ACCESS_SecurityAdmin')
+		) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -1524,23 +1525,30 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * Otherwise they'll need ADMIN or CMS_ACCESS_SecurityAdmin permissions
 	 */
 	public function canDelete($member = null) {
-		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) $member = Member::currentUser();
-
-		// extended access checks
-		$results = $this->extend('canDelete', $member);
-		if($results && is_array($results)) {
-			if(!min($results)) return false;
-			else return true;
+		if(!($member instanceof Member) {
+			$member = Member::currentUser();
+		}
+		$extended = $this->extendedCan(__FUNCTION__, $member);
+		if($extended !== null) {
+			return $extended;
 		}
 
-		// No member found
-		if(!($member && $member->exists())) return false;
+		// HACK: we should not allow for an non-Admin to delete an Admin
+		if(!Permission::checkMember($member, 'ADMIN') && Permission::checkMember($this, 'ADMIN')) return false;
 
 		// Members are not allowed to remove themselves,
 		// since it would create inconsistencies in the admin UIs.
 		if($this->ID && $member->ID == $this->ID) return false;
 
-		return $this->canEdit($member);
+
+		if(
+			Permission::checkMember($member, 'ADMIN')
+			|| Permission::checkMember($member, 'CMS_ACCESS_SecurityAdmin')
+		) {
+			return true;
+		}
+
+		return false;
 	}
 
 

--- a/security/Member.php
+++ b/security/Member.php
@@ -1470,7 +1470,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * This is likely to be customized for social sites etc. with a looser permission model.
 	 */
 	public function canView($member = null) {
-		if(!($member instanceof Member) {
+		if(!($member instanceof Member)) {
 			$member = Member::currentUser();
 		}		
 		$extended = $this->extendedCan(__FUNCTION__, $member);
@@ -1496,7 +1496,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * Otherwise they'll need ADMIN or CMS_ACCESS_SecurityAdmin permissions
 	 */
 	public function canEdit($member = null) {
-		if(!($member instanceof Member) {
+		if(!($member instanceof Member)) {
 			$member = Member::currentUser();
 		}	
 		$extended = $this->extendedCan(__FUNCTION__, $member);
@@ -1525,7 +1525,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * Otherwise they'll need ADMIN or CMS_ACCESS_SecurityAdmin permissions
 	 */
 	public function canDelete($member = null) {
-		if(!($member instanceof Member) {
+		if(!($member instanceof Member)) {
 			$member = Member::currentUser();
 		}
 		$extended = $this->extendedCan(__FUNCTION__, $member);


### PR DESCRIPTION
now uses extendedCan rather than custom code
removed superfluous stuff
stopped relying on each other (canDelete was relying on canView to make the final decision)