### PR TITLE
BUGFIX: Deleting images with ImagickBackend fails

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -991,7 +991,9 @@ class Image extends File implements Flushable {
 	}
 
 	protected function onBeforeDelete() {
-		$backend = Injector::inst()->create(self::get_backend());
+		$backend = Injector::inst()->createWithArgs(self::config()->backend, array(
+			Director::baseFolder()."/" . $this->Filename		
+		));
 		$backend->onBeforeDelete($this);
 
 		$this->deleteFormattedImages();


### PR DESCRIPTION
Received the following error when attempting to delete an image using ImagickBackend.

[Error] Uncaught ImagickException: Can not process empty Imagick object
/framework/filesystem/ImagickBackend.php:63 

Imagick->setimagecompressionquality(75) 
ImagickBackend.php:63 
ImagickBackend->setQuality(75) 
ImagickBackend.php:27 
ImagickBackend->__construct() 

ReflectionClass->newInstance() 
InjectionCreator.php:20 
InjectionCreator->create(ImagickBackend,Array) 
Injector.php:553 
Injector->instantiate(Array) 
Injector.php:862 
Injector->get(ImagickBackend,,) 
Injector.php:887 
Injector->create(ImagickBackend) 
Image.php:994 
Image->onBeforeDelete() 
DataObject.php:1456 
DataObject->delete() 
GridFieldDeleteAction.php:150 
GridFieldDeleteAction->handleAction(GridField,deleterecord,Array,Array) 
GridField.php:907 
GridField->handleAlterAction(deleterecord,Array,Array) 
GridField.php:873 
GridField->gridFieldAlterAction(Array,CMSForm,SS_HTTPRequest) 
GridField.php:120 
GridField->index(SS_HTTPRequest) 
RequestHandler.php:288 
RequestHandler->handleAction(SS_HTTPRequest,index) 
RequestHandler.php:200 
RequestHandler->handleRequest(SS_HTTPRequest,DataModel) 
GridField.php:1013 
GridField->handleRequest(SS_HTTPRequest,DataModel) 
RequestHandler.php:222 
RequestHandler->handleRequest(SS_HTTPRequest,DataModel) 
RequestHandler.php:222 
RequestHandler->handleRequest(SS_HTTPRequest,DataModel) 
Controller.php:157 
Controller->handleRequest(SS_HTTPRequest,DataModel) 
LeftAndMain.php:451 
LeftAndMain->handleRequest(SS_HTTPRequest,DataModel) 
AdminRootController.php:93 
AdminRootController->handleRequest(SS_HTTPRequest,DataModel) 
Director.php:385 
Director::handleRequest(SS_HTTPRequest,Session,DataModel) 
Director.php:149 
Director::direct(/admin/assets/EditForm/field/File,DataModel) 
main.php:184 