### PR TITLE
Fix i18n.sprintf() parameters being off by one

### DIFF
--- a/javascript/src/i18n.js
+++ b/javascript/src/i18n.js
@@ -146,7 +146,7 @@ class i18n {
 				return match; 
 			}
 
-			return subMatch1 + params[i += 1];
+			return subMatch1 + params[i++];
 		});
 	}
 


### PR DESCRIPTION
Should be a post increment, not pre.

This fixes clicking on specific version history items.
This fixes right click on a page and adding a child.