### PR TITLE
Fix TreeDropdownField auto-close regression

### DIFF
--- a/admin/javascript/LeftAndMain.Menu.js
+++ b/admin/javascript/LeftAndMain.Menu.js
@@ -204,7 +204,10 @@
 			fromContainingPanel: {
 				ontoggle: function(e){
 					this.toggleClass('collapsed', $(e.target).hasClass('collapsed'));
-					$(window).resize(); //Trigger jLayout
+
+					// Trigger synthetic resize event. Avoid native window.resize event
+					// since it causes other behaviour which should be reserved for actual window dimension changes.
+					$('.cms-container').trigger('windowresize');
 				}
 			},
 


### PR DESCRIPTION
Causes build failures due to Behat not being able to select
a link from a dropdown in "Insert Media".

Follow on effect from triggering a window.resize event
when the window wasn't actually resized (in order to force a layout redraw).

See https://github.com/silverstripe/silverstripe-framework/pull/5087 for context

Needs to be merged up to 3.3, 3 and master - since it currently breaks all those builds.