### PR TITLE
Extra semi-colon and double quotes on Redirecting to page

### DIFF
--- a/control/HTTPResponse.php
+++ b/control/HTTPResponse.php
@@ -246,7 +246,7 @@ class SS_HTTPResponse {
 <meta http-equiv="refresh" content="1; url={$urlATT}" />
 <script type="application/javascript">setTimeout(function(){
 	window.location.href = "{$urlJS}";
-}, 50);</script>";
+}, 50);</script>
 EOT
 			;
 		} else {


### PR DESCRIPTION
```
Redirecting to page _URL_

";
```
will become 
`Redirecting to page _URL_`
