### PR TITLE
BUG Fix FulltextsearchEnable

### DIFF
--- a/model/connect/DBSchemaManager.php
+++ b/model/connect/DBSchemaManager.php
@@ -310,15 +310,14 @@ abstract class DBSchemaManager {
 
 			// Check if options changed
 			$tableOptionsChanged = false;
-			if (isset($options[get_class($this)]) || true) {
-				if (isset($options[get_class($this)])) {
-					if (preg_match('/ENGINE=([^\s]*)/', $options[get_class($this)], $alteredEngineMatches)) {
-						$alteredEngine = $alteredEngineMatches[1];
-						$tableStatus = $this->query(sprintf(
-												'SHOW TABLE STATUS LIKE \'%s\'', $table
-										))->first();
-						$tableOptionsChanged = ($tableStatus['Engine'] != $alteredEngine);
-					}
+			// Check for DB constant on the schema class
+			$dbIDName = sprintf('%s::ID', get_class($this));
+			$dbID = defined($dbIDName) ? constant($dbIDName) : null;
+			if ($dbID && isset($options[$dbID])) {
+				if (preg_match('/ENGINE=([^\s]*)/', $options[$dbID], $alteredEngineMatches)) {
+					$alteredEngine = $alteredEngineMatches[1];
+					$tableStatus = $this->query(sprintf('SHOW TABLE STATUS LIKE \'%s\'', $table))->first();
+					$tableOptionsChanged = ($tableStatus['Engine'] != $alteredEngine);
 				}
 			}
 

--- a/model/connect/MySQLSchemaManager.php
+++ b/model/connect/MySQLSchemaManager.php
@@ -84,7 +84,8 @@ class MySQLSchemaManager extends DBSchemaManager {
 			}
 		}
 
-		if ($alteredOptions && isset($alteredOptions[get_class($this)])) {
+		$dbID = self::ID;
+		if ($alteredOptions && isset($alteredOptions[$dbID])) {
 			$indexList = $this->indexList($tableName);
 			$skip = false;
 			foreach ($indexList as $index) {
@@ -98,14 +99,14 @@ class MySQLSchemaManager extends DBSchemaManager {
 					sprintf(
 						"Table %s options not changed to %s due to fulltextsearch index",
 						$tableName,
-						$alteredOptions[get_class($this)]
+						$alteredOptions[$dbID]
 					),
 					"changed"
 				);
 			} else {
-				$this->query(sprintf("ALTER TABLE \"%s\" %s", $tableName, $alteredOptions[get_class($this)]));
+				$this->query(sprintf("ALTER TABLE \"%s\" %s", $tableName, $alteredOptions[$dbID]));
 				$this->alterationMessage(
-					sprintf("Table %s options changed: %s", $tableName, $alteredOptions[get_class($this)]),
+					sprintf("Table %s options changed: %s", $tableName, $alteredOptions[$dbID]),
 					"changed"
 				);
 			}


### PR DESCRIPTION
Fixes #5126

It looks like there were a few `get_class($this)` left over in the old ORM connectors that needed refactoring out.