### PR TITLE
Disable xdebug on Travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_script:
  - if [ $(phpenv version-name) = "5.3" ]; then printf "\n" | pecl install imagick-3.3.0; fi
  - composer self-update || true
  - phpenv rehash
+ - phpenv config-rm xdebug.ini
  - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
  - "if [ \"$BEHAT_TEST\" = \"\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss; fi"
  - "if [ \"$BEHAT_TEST\" = \"1\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/behat-extension; fi"


### PR DESCRIPTION
We're not using it for code coverage,
and it's slowing down both composer and phpunit builds.

Recommended by Travis:
https://docs.travis-ci.com/user/speeding-up-the-build/#PHP-optimisations

Should be merged up to 3.3, 3 and master if successful.