### PR TITLE
DOCS Added a useful code example around positioning of tabs in CMS.

### DIFF
--- a/docs/en/02_Developer_Guides/03_Forms/00_Introduction.md
+++ b/docs/en/02_Developer_Guides/03_Forms/00_Introduction.md
@@ -126,13 +126,17 @@ A field can be appended to the [api:FieldList].
 	$fields = $form->Fields();
 
 	// add a field
-	$fields->push(new TextField(..));
+	$fields->push(TextField::create(..));
 
 	// insert a field before another one
-	$fields->insertBefore(new TextField(..), 'Email');
+	$fields->insertBefore(TextField::create(..), 'Email');
 
 	// insert a field after another one
-	$fields->insertAfter(new TextField(..), 'Name');
+	$fields->insertAfter(TextField::create(..), 'Name');
+	
+	// insert a tab before the main content tab (used to position tabs in the CMS)
+	$fields->insertBefore(Tab::create(...), 'Main');
+	// Note: you need to create and position the new tab prior to adding fields via addFieldToTab()
 
 Fields can be fetched after they have been added in.
 	


### PR DESCRIPTION
This useful example wasn't in the docs when I needed it. I ended up tracking this information down at http://stackoverflow.com/questions/5033028/silverstripe-how-do-i-insert-a-tab-before-another-tab

It should really be in the docs.

Also a quick tidy of some of the create() factory methods as recommended form instantiation approach. 