### PR TITLE
API Owned objects are now automatically published

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -521,7 +521,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		Config::inst()->update('SSViewer', 'theme_enabled', false);
 
 		//set the reading mode for the admin to stage
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 	}
 
 	public function handleRequest(SS_HTTPRequest $request, DataModel $model = null) {

--- a/control/Director.php
+++ b/control/Director.php
@@ -268,7 +268,7 @@ class Director implements TemplateGlobalProvider {
 
 		// These are needed so that calling Director::test() does not muck with whoever is calling it.
 		// Really, it's some inappropriate coupling and should be resolved by making less use of statics.
-		$oldStage = Versioned::current_stage();
+		$oldStage = Versioned::get_stage();
 		$getVars = array();
 
 		if(!$httpMethod) $httpMethod = ($postVars || is_array($postVars)) ? "POST" : "GET";
@@ -308,7 +308,7 @@ class Director implements TemplateGlobalProvider {
 
 			// These are needed so that calling Director::test() does not muck with whoever is calling it.
 			// Really, it's some inappropriate coupling and should be resolved by making less use of statics
-			Versioned::reading_stage($oldStage);
+			Versioned::set_stage($oldStage);
 
 			Injector::unnest(); // Restore old CookieJar, etc
 			Config::unnest();

--- a/dev/DevelopmentAdmin.php
+++ b/dev/DevelopmentAdmin.php
@@ -76,7 +76,7 @@ class DevelopmentAdmin extends Controller {
 		// Backwards compat: Default to "draft" stage, which is important
 		// for tasks like dev/build which call DataObject->requireDefaultRecords(),
 		// but also for other administrative tasks which have assumptions about the default stage.
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 	}
 
 	public function index() {

--- a/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
+++ b/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
@@ -13,14 +13,32 @@ Versioning in SilverStripe is handled through the [api:Versioned] class. As a [a
 be applied to any [api:DataObject] subclass. The extension class will automatically update read and write operations
 done via the ORM via the `augmentSQL` database hook.
 
-Adding Versioned to your `DataObject` subclass works the same as any other extension. It accepts two or more arguments 
-denoting the different "stages", which map to different database tables. 
+Adding Versioned to your `DataObject` subclass works the same as any other extension. It has one of two behaviours,
+which can be applied via the constructor argument.
 
-**mysite/_config/app.yml**
-	:::yml
-	MyRecord:
-	  extensions:
-	    - Versioned("Stage","Live")
+By default, adding the `Versioned extension will create a "Stage" and "Live" stage on your model, and will
+also track versioned history.
+
+
+	:::php
+	class MyStagedModel extends DataObject {
+		private staic $extensions = [
+			"Versioned"
+		];
+	}
+
+
+Alternatively, staging can be disabled, so that only versioned changes are tracked for your model. This
+can be specified by setting the constructor argument to "Versioned"
+
+
+	:::php
+	class VersionedModel extends DataObject {
+		private staic $extensions = [
+			"Versioned('Versioned')"
+		];
+	}
+
 
 <div class="notice" markdown="1">
 The extension is automatically applied to `SiteTree` class. For more information on extensions see 
@@ -34,8 +52,9 @@ of `DataObject`. Adding this extension to children of the base class will have u
 
 ## Database Structure
 
-Depending on how many stages you configured, two or more new tables will be created for your records. In the above, this
-will create a new `MyRecord_Live` table once you've rebuilt the database.
+Depending on whether staging is enabled, one or more new tables will be created for your records. `<class>_versions`
+is always created to track historic versions for your model. If staging is enabled this will also create a new
+`<class>_Live` table once you've rebuilt the database.
 
 <div class="notice" markdown="1">
 Note that the "Stage" naming has a special meaning here, it will leave the original table name unchanged, rather than 
@@ -143,6 +162,9 @@ and has_one/has_many, however it relies on a pre-existing relationship to functi
 
 For instance, in order to specify this dependency, you must apply `owns` and `owned_by` config
 on a relationship.
+
+When pages of type `MyPage` are published, any owned images and banners will be automatically published,
+without requiring any custom code.
 
 
 	:::php

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -7,6 +7,7 @@
  * Minimum PHP version raised to 5.5.0
  * Deprecate `SQLQuery` in favour `SQLSelect`
  * `DataList::filter` by null now internally generates "IS NULL" or "IS NOT NULL" conditions appropriately on queries
+ * `DataObject` constructor now has an additional parameter, which must be included in subclasses.
  * `DataObject::database_fields` now returns all fields on that table.
  * `DataObject::db` now returns composite fields.
  * `DataObject::ClassName` field has been refactored into a `DBClassName` type field.
@@ -34,6 +35,10 @@
    definitions of the [behat-extension](https://github.com/silverstripe-labs/silverstripe-behat-extension) module).
    Run `composer require --dev 'phpunit/phpunit:~4.8'` on existing projects to pull in the new dependency.
  * `Object::invokeWithExtensions` now has the same method signature as `Object::extend` and behaves the same way.
+ * `CMSMain` model actions have been changed:
+   * `CMSBatchAction_Delete` and `CMSMain::delete` are no longer deprecated.
+   * `CMSBatchAction_DeleteFromLive` is removed.
+   * `CMSMain.enabled_legacy_actions` config is removed.
 
 ## New API
 
@@ -69,6 +74,18 @@
    automatically check `can*()` permissions, and must be done by usercode before invocation.
  * GridField edit form now has improved support for versioned DataObjects, with basic publishing
    actions available when editing records.
+ * `Versioned` API has some breaking changes:
+   * Versioned constructor now only allows a single string to declare whether staging is enabled or not. The
+     number of names of stages are no longer able to be specified. See below for upgrading notes for models
+     with custom stages.
+   * `reading_stage` is now `set_stage`
+   * `current_stage` is now `get_stage`
+   * `getVersionedStages` is gone.
+   * `get_live_stage` is removed. Use the `Versioned::LIVE` constant instead.
+   * `getDefaultStage` is removed. Use the `Versioned::DRAFT` constant instead.
+   * `$versionableExtensions` is now `private static` instead of `protected static`
+   * `hasStages` is addded to check if an object has a given stage.
+   * `stageTable` is added to get the table for a given class and stage.
 
 ### Front-end build tooling for CMS interface
 
@@ -647,8 +664,42 @@ has been removed from core. You can configure the built-in `charmap` plugin inst
 For more information on available options and plugins please refer to the
 [tinymce documentation](https://www.tinymce.com/docs/configure/)
 
+### Upgrading DataObjects with the `Versioned` extension
+
+In most cases, versioned models with the default versioning parameters will not need to be changed. However,
+there are now additional restrictions on the use of custom stage names.
+
+Rather than declaring the list of stages a model has, the constructor for `Versioned` will take a single mode
+parameter, which declares whether or not the model is versioned and has a draft and live stage, or alternatively
+if it only has versioning without staging.
+
+For instance:
+
+
+	:::php
+	/**
+	 * This model has staging and versioning. Stages will be "Stage" and "Live"
+	 */
+	class MyStagedModel extends DataObject {
+		private staic $extensions = array(
+			"Versioned('StagedVersioned')"
+		);
+	}
+	
+	/**
+	 * This model has versioning only, and will not has a draft or live stage, nor be affected by the current stage.
+	 */
+	class MyVersionedModel extends DataObject {
+		private static $extensions = array(
+			"Versioned('Versioned')"
+		);
+	}
+
+
 ### Implementation of ownership API
 
 In order to support the recursive publishing of dataobjects, a new API has been developed to allow
 developers to declare dependencies between objects. See the
 [versioned documentation](/developer_guides/model/versioning) for more information.
+
+By default all versioned dataobjects will automatically publish objects that they own.

--- a/filesystem/AssetControlExtension.php
+++ b/filesystem/AssetControlExtension.php
@@ -99,10 +99,10 @@ class AssetControlExtension extends \DataExtension
 	protected function getRecordState($record) {
 		if($this->isVersioned()) {
 			// Check stage this record belongs to
-			$stage = $record->getSourceQueryParam('Versioned.stage') ?: Versioned::current_stage();
+			$stage = $record->getSourceQueryParam('Versioned.stage') ?: Versioned::get_stage();
 
 			// Non-live stages are automatically non-public
-			if($stage !== Versioned::get_live_stage()) {
+			if($stage !== Versioned::LIVE) {
 				return AssetManipulationList::STATE_PROTECTED;
 			}
 		}
@@ -159,7 +159,7 @@ class AssetControlExtension extends \DataExtension
 		$stages = $this->owner->getVersionedStages(); // {@see Versioned::getVersionedStages}
 		foreach ($stages as $stage) {
 			// Skip current stage; These should be handled explicitly
-			if($stage === Versioned::current_stage()) {
+			if($stage === Versioned::get_stage()) {
 				continue;
 			}
 

--- a/filesystem/FileMigrationHelper.php
+++ b/filesystem/FileMigrationHelper.php
@@ -34,8 +34,8 @@ class FileMigrationHelper extends Object {
 
 		// Loop over all files
 		$count = 0;
-		$originalState = \Versioned::get_reading_mode();
-		\Versioned::reading_stage('Stage');
+		$originalState = Versioned::get_reading_mode();
+		Versioned::set_stage(Versioned::DRAFT);
 		$filenameMap = $this->getFilenameArray();
 		foreach($this->getFileQuery() as $file) {
 			// Get the name of the file to import
@@ -45,7 +45,7 @@ class FileMigrationHelper extends Object {
 				$count++;
 			}
 		}
-		\Versioned::set_reading_mode($originalState);
+		Versioned::set_reading_mode($originalState);
 		return $count;
 	}
 
@@ -54,7 +54,7 @@ class FileMigrationHelper extends Object {
 	 *
 	 * @param string $base Absolute base path (parent of assets folder)
 	 * @param File $file
-	 * @param type $legacyFilename
+	 * @param string $legacyFilename
 	 * @return bool True if this file is imported successfully
 	 */
 	protected function migrateFile($base, File $file, $legacyFilename) {
@@ -64,8 +64,9 @@ class FileMigrationHelper extends Object {
 			return false;
 		}
 
+
 		// Copy local file into this filesystem
-		$filename = $file->getFilename();
+		$filename = $file->generateFilename();
 		$result = $file->setFromLocalFile(
 			$path, $filename, null, null,
 			array('conflict' => AssetStore::CONFLICT_OVERWRITE)
@@ -73,7 +74,7 @@ class FileMigrationHelper extends Object {
 
 		// Move file if the APL changes filename value
 		if($result['Filename'] !== $filename) {
-			$this->setFilename($result['Filename']);
+			$file->setFilename($result['Filename']);
 		}
 
 		// Save and publish

--- a/model/DataList.php
+++ b/model/DataList.php
@@ -748,10 +748,8 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 		if(class_exists($row['RecordClassName'])) {
 			$class = $row['RecordClassName'];
 		}
-		$item = Injector::inst()->create($class, $row, false, $this->model);
 
-		//set query params on the DataObject to tell the lazy loading mechanism the context the object creation context
-		$item->setSourceQueryParams($this->getQueryParams());
+		$item = Injector::inst()->create($class, $row, false, $this->model, $this->getQueryParams());
 
 		return $item;
 	}

--- a/model/Image.php
+++ b/model/Image.php
@@ -7,8 +7,8 @@
  * @subpackage filesystem
  */
 class Image extends File {
-	public function __construct($record = null, $isSingleton = false, $model = null) {
-		parent::__construct($record, $isSingleton, $model);
+	public function __construct($record = null, $isSingleton = false, $model = null, $queryParams = array()) {
+		parent::__construct($record, $isSingleton, $model, $queryParams);
 		$this->File->setAllowedCategories('image/supported');
 	}
 

--- a/model/RelationList.php
+++ b/model/RelationList.php
@@ -22,7 +22,7 @@ abstract class RelationList extends DataList implements Relation {
 		// Remove `Foreign.` query parameters for created objects,
 		// as this would interfere with relations on those objects.
 		foreach(array_keys($params) as $key) {
-			if(stripos($key, 'Foreign.') !== 0) {
+			if(stripos($key, 'Foreign.') === 0) {
 				unset($params[$key]);
 			}
 		}

--- a/model/fieldtypes/Datetime.php
+++ b/model/fieldtypes/Datetime.php
@@ -177,6 +177,7 @@ class SS_Datetime extends Date implements TemplateGlobalProvider {
 	 * Caution: This sets a fixed date that doesn't increment with time.
 	 *
 	 * @param SS_Datetime|string $datetime Either in object format, or as a SS_Datetime compatible string.
+	 * @throws Exception
 	 */
 	public static function set_mock_now($datetime) {
 		if($datetime instanceof SS_Datetime) {

--- a/model/queries/SQLSelect.php
+++ b/model/queries/SQLSelect.php
@@ -61,7 +61,7 @@ class SQLSelect extends SQLConditionalExpression {
 	/**
 	 * Construct a new SQLSelect.
 	 *
-	 * @param array $select An array of SELECT fields.
+	 * @param array|string $select An array of SELECT fields.
 	 * @param array|string $from An array of FROM clauses. The first one should be just the table name.
 	 * Each should be ANSI quoted.
 	 * @param array $where An array of WHERE clauses.

--- a/tests/filesystem/AssetControlExtensionTest.php
+++ b/tests/filesystem/AssetControlExtensionTest.php
@@ -15,7 +15,7 @@ class AssetControlExtensionTest extends SapphireTest {
 		parent::setUp();
 
 		// Set backend and base url
-		\Versioned::reading_stage('Stage');
+		\Versioned::set_stage(Versioned::DRAFT);
 		AssetStoreTest_SpyStore::activate('AssetControlExtensionTest');
 		$this->logInWithPermission('ADMIN');
 
@@ -46,7 +46,7 @@ class AssetControlExtensionTest extends SapphireTest {
 	}
 
 	public function testFileDelete() {
-		\Versioned::reading_stage('Stage');
+		\Versioned::set_stage(Versioned::DRAFT);
 
 		/** @var AssetControlExtensionTest_VersionedObject $object1 */
 		$object1 = AssetControlExtensionTest_VersionedObject::get()
@@ -120,7 +120,7 @@ class AssetControlExtensionTest extends SapphireTest {
 	 * Test files being replaced
 	 */
 	public function testReplaceFile() {
-		\Versioned::reading_stage('Stage');
+		\Versioned::set_stage(Versioned::DRAFT);
 
 		/** @var AssetControlExtensionTest_VersionedObject $object1 */
 		$object1 = AssetControlExtensionTest_VersionedObject::get()

--- a/tests/filesystem/AssetStoreTest.php
+++ b/tests/filesystem/AssetStoreTest.php
@@ -602,6 +602,7 @@ class AssetStoreTest_SpyStore extends FlysystemAssetStore {
 	 * Helper method to get local filesystem path for this file
 	 *
 	 * @param AssetContainer $asset
+	 * @return string
 	 */
 	public static function getLocalPath(AssetContainer $asset) {
 		if($asset instanceof Folder) {
@@ -621,7 +622,6 @@ class AssetStoreTest_SpyStore extends FlysystemAssetStore {
 		/** @var Local $adapter */
 		$adapter = $filesystem->getAdapter();
 		return $adapter->applyPathPrefix($fileID);
-
 	}
 
 	public function cleanFilename($filename) {

--- a/tests/filesystem/FileTest.php
+++ b/tests/filesystem/FileTest.php
@@ -15,7 +15,7 @@ class FileTest extends SapphireTest {
 	public function setUp() {
 		parent::setUp();
 		$this->logInWithPermission('ADMIN');
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 
 		// Set backend root to /ImageTest
 		AssetStoreTest_SpyStore::activate('FileTest');
@@ -242,7 +242,7 @@ class FileTest extends SapphireTest {
 		// Rename
 		$file->Name = 'renamed.txt';
 		$newTuple = $oldTuple;
-		$newTuple['Filename'] = $file->getFilename();
+		$newTuple['Filename'] = $file->generateFilename();
 
 		// Before write()
 		$this->assertTrue(
@@ -287,7 +287,7 @@ class FileTest extends SapphireTest {
 		// set ParentID
 		$file->ParentID = $subfolder->ID;
 		$newTuple = $oldTuple;
-		$newTuple['Filename'] = $file->getFilename();
+		$newTuple['Filename'] = $file->generateFilename();
 
 		// Before write()
 		$this->assertTrue(

--- a/tests/filesystem/UploadTest.php
+++ b/tests/filesystem/UploadTest.php
@@ -10,7 +10,7 @@ class UploadTest extends SapphireTest {
 
 	public function setUp() {
 		parent::setUp();
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 		AssetStoreTest_SpyStore::activate('UploadTest');
 	}
 

--- a/tests/forms/uploadfield/AssetFieldTest.php
+++ b/tests/forms/uploadfield/AssetFieldTest.php
@@ -16,7 +16,7 @@ class AssetFieldTest extends FunctionalTest {
 		parent::setUp();
 
 		$this->logInWithPermission('ADMIN');
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 
 		// Set backend root to /AssetFieldTest
 		AssetStoreTest_SpyStore::activate('AssetFieldTest');

--- a/tests/forms/uploadfield/UploadFieldTest.php
+++ b/tests/forms/uploadfield/UploadFieldTest.php
@@ -23,7 +23,7 @@ class UploadFieldTest extends FunctionalTest {
 
 		// Save versioned state
 		$this->oldReadingMode = Versioned::get_reading_mode();
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 
 		// Set backend root to /UploadFieldTest
 		AssetStoreTest_SpyStore::activate('UploadFieldTest');

--- a/tests/model/DataDifferencerTest.php
+++ b/tests/model/DataDifferencerTest.php
@@ -19,7 +19,7 @@ class DataDifferencerTest extends SapphireTest {
 	public function setUp() {
 		parent::setUp();
 
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 
 		// Set backend root to /DataDifferencerTest
 		AssetStoreTest_SpyStore::activate('DataDifferencerTest');

--- a/tests/model/DataObjectLazyLoadingTest.php
+++ b/tests/model/DataObjectLazyLoadingTest.php
@@ -408,7 +408,7 @@ class DataObjectLazyLoadingTest extends SapphireTest {
 			$obj1ID
 		));
 
-		Versioned::reading_stage('Live');
+		Versioned::set_stage(Versioned::LIVE);
 		$obj1 = VersionedLazy_DataObject::get()->byID($obj1ID);
 		$this->assertEquals(
 			'live-value',

--- a/tests/model/VersionedOwnershipTest.php
+++ b/tests/model/VersionedOwnershipTest.php
@@ -10,6 +10,7 @@ class VersionedOwnershipTest extends SapphireTest {
 		'VersionedOwnershipTest_Subclass',
 		'VersionedOwnershipTest_Related',
 		'VersionedOwnershipTest_Attachment',
+		'VersionedOwnershipTest_RelatedMany',
 	);
 
 	protected static $fixture_file = 'VersionedOwnershipTest.yml';
@@ -18,7 +19,7 @@ class VersionedOwnershipTest extends SapphireTest {
 	{
 		parent::setUp();
 
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 
 		// Automatically publish any object named *_published
 		foreach($this->getFixtureFactory()->getFixtures() as $class => $fixtures) {
@@ -33,6 +34,18 @@ class VersionedOwnershipTest extends SapphireTest {
 	}
 
 	/**
+	 * Virtual "sleep" that doesn't actually slow execution, only advances SS_DateTime::now()
+	 *
+	 * @param int $minutes
+	 */
+	protected function sleep($minutes) {
+		$now = SS_Datetime::now();
+		$date = DateTime::createFromFormat('Y-m-d H:i:s', $now->getValue());
+		$date->modify("+{$minutes} minutes");
+		SS_Datetime::set_mock_now($date->format('Y-m-d H:i:s'));
+	}
+
+	/**
 	 * Test basic findOwned() in stage mode
 	 */
 	public function testFindOwned() {
@@ -44,6 +57,9 @@ class VersionedOwnershipTest extends SapphireTest {
 				['Title' => 'Attachment 1'],
 				['Title' => 'Attachment 2'],
 				['Title' => 'Attachment 5'],
+				['Title' => 'Related Many 1'],
+				['Title' => 'Related Many 2'],
+				['Title' => 'Related Many 3'],
 			],
 			$subclass1->findOwned()
 		);
@@ -52,6 +68,9 @@ class VersionedOwnershipTest extends SapphireTest {
 		$this->assertDOSEquals(
 			[
 				['Title' => 'Related 1'],
+				['Title' => 'Related Many 1'],
+				['Title' => 'Related Many 2'],
+				['Title' => 'Related Many 3'],
 			],
 			$subclass1->findOwned(false)
 		);
@@ -64,6 +83,7 @@ class VersionedOwnershipTest extends SapphireTest {
 				['Title' => 'Attachment 3'],
 				['Title' => 'Attachment 4'],
 				['Title' => 'Attachment 5'],
+				['Title' => 'Related Many 4'],
 			],
 			$subclass2->findOwned()
 		);
@@ -71,7 +91,8 @@ class VersionedOwnershipTest extends SapphireTest {
 		// Non-recursive search
 		$this->assertDOSEquals(
 			[
-				['Title' => 'Related 2']
+				['Title' => 'Related 2'],
+				['Title' => 'Related Many 4'],
 			],
 			$subclass2->findOwned(false)
 		);
@@ -175,6 +196,7 @@ class VersionedOwnershipTest extends SapphireTest {
 				['Title' => 'Related 2 Modified'],
 				['Title' => 'Attachment 3 Modified'],
 				['Title' => 'Attachment 5'],
+				['Title' => 'Related Many 4'],
 			],
 			$subclass2Stage->findOwned()
 		);
@@ -183,6 +205,7 @@ class VersionedOwnershipTest extends SapphireTest {
 		$this->assertDOSEquals(
 			[
 				['Title' => 'Related 2 Modified'],
+				['Title' => 'Related Many 4'],
 			],
 			$subclass2Stage->findOwned(false)
 		);
@@ -196,6 +219,7 @@ class VersionedOwnershipTest extends SapphireTest {
 				['Title' => 'Attachment 3'],
 				['Title' => 'Attachment 4'],
 				['Title' => 'Attachment 5'],
+				['Title' => 'Related Many 4'],
 			],
 			$subclass2Live->findOwned()
 		);
@@ -204,10 +228,282 @@ class VersionedOwnershipTest extends SapphireTest {
 		$this->assertDOSEquals(
 			[
 				['Title' => 'Related 2'],
+				['Title' => 'Related Many 4'],
 			],
 			$subclass2Live->findOwned(false)
 		);
 	}
+
+	/**
+	 * Test that objects are correctly published recursively
+	 */
+	public function testRecursivePublish() {
+		/** @var VersionedOwnershipTest_Subclass $parent */
+		$parent = $this->objFromFixture('VersionedOwnershipTest_Subclass', 'subclass1_published');
+		$parentID = $parent->ID;
+		$banner1 = $this->objFromFixture('VersionedOwnershipTest_RelatedMany', 'relatedmany1_published');
+		$banner2 = $this->objFromFixture('VersionedOwnershipTest_RelatedMany', 'relatedmany2_published');
+		$banner2ID = $banner2->ID;
+
+		// Modify, Add, and Delete banners on stage
+		$banner1->Title = 'Renamed Banner 1';
+		$banner1->write();
+
+		$banner2->delete();
+
+		$banner4 = new VersionedOwnershipTest_RelatedMany();
+		$banner4->Title = 'New Banner';
+		$parent->Banners()->add($banner4);
+
+		// Check state of objects before publish
+		$oldLiveBanners = [
+			['Title' => 'Related Many 1'],
+			['Title' => 'Related Many 2'], // Will be deleted
+			// `Related Many 3` isn't published
+		];
+		$newBanners = [
+			['Title' => 'Renamed Banner 1'], // Renamed
+			['Title' => 'Related Many 3'], // Published without changes
+			['Title' => 'New Banner'], // Created
+		];
+		$parentDraft = Versioned::get_by_stage('VersionedOwnershipTest_Subclass', Versioned::DRAFT)
+			->byID($parentID);
+		$this->assertDOSEquals($newBanners, $parentDraft->Banners());
+		$parentLive = Versioned::get_by_stage('VersionedOwnershipTest_Subclass', Versioned::LIVE)
+			->byID($parentID);
+		$this->assertDOSEquals($oldLiveBanners, $parentLive->Banners());
+
+		// On publishing of owner, all children should now be updated
+		$parent->doPublish();
+
+		// Now check each object has the correct state
+		$parentDraft = Versioned::get_by_stage('VersionedOwnershipTest_Subclass', Versioned::DRAFT)
+			->byID($parentID);
+		$this->assertDOSEquals($newBanners, $parentDraft->Banners());
+		$parentLive = Versioned::get_by_stage('VersionedOwnershipTest_Subclass', Versioned::LIVE)
+			->byID($parentID);
+		$this->assertDOSEquals($newBanners, $parentLive->Banners());
+
+		// Check that the deleted banner hasn't actually been deleted from the live stage,
+		// but in fact has been unlinked.
+		$banner2Live = Versioned::get_by_stage('VersionedOwnershipTest_RelatedMany', Versioned::LIVE)
+			->byID($banner2ID);
+		$this->assertEmpty($banner2Live->PageID);
+	}
+
+	/**
+	 * Test that owning objects get unpublished as needed
+	 */
+	public function testRecursiveUnpublish() {
+		// Unsaved objects can't be unpublished
+		$unsaved = new VersionedOwnershipTest_Subclass();
+		$this->assertFalse($unsaved->doUnpublish());
+
+		// Draft-only objects can't be unpublished
+		/** @var VersionedOwnershipTest_RelatedMany $banner3Unpublished */
+		$banner3Unpublished = $this->objFromFixture('VersionedOwnershipTest_RelatedMany', 'relatedmany3');
+		$this->assertFalse($banner3Unpublished->doUnpublish());
+
+		// First test: mid-level unpublish; We expect that owners should be unpublished, but not
+		// owned objects, nor other siblings shared by the same owner.
+		$related2 = $this->objFromFixture('VersionedOwnershipTest_Related', 'related2_published');
+		/** @var VersionedOwnershipTest_Attachment $attachment3 */
+		$attachment3 = $this->objFromFixture('VersionedOwnershipTest_Attachment', 'attachment3_published');
+		/** @var VersionedOwnershipTest_RelatedMany $relatedMany4 */
+		$relatedMany4 = $this->objFromFixture('VersionedOwnershipTest_RelatedMany', 'relatedmany4_published');
+		/** @var VersionedOwnershipTest_Related $related2 */
+		$this->assertTrue($related2->doUnpublish());
+		$subclass2 = $this->objFromFixture('VersionedOwnershipTest_Subclass', 'subclass2_published');
+
+		/** @var VersionedOwnershipTest_Subclass $subclass2 */
+		$this->assertFalse($subclass2->isPublished()); // Owner IS unpublished
+		$this->assertTrue($attachment3->isPublished()); // Owned object is NOT unpublished
+		$this->assertTrue($relatedMany4->isPublished()); // Owned object by owner is NOT unpublished
+
+		// Second test: multi-level unpublish should recursively cascade down all owning objects
+		// Publish related2 again
+		$subclass2->doPublish();
+		$this->assertTrue($subclass2->isPublished());
+		$this->assertTrue($related2->isPublished());
+		$this->assertTrue($attachment3->isPublished());
+
+		// Unpublish leaf node
+		$this->assertTrue($attachment3->doUnpublish());
+
+		// Now all owning objects (only) are unpublished
+		$this->assertFalse($attachment3->isPublished()); // Unpublished because we just unpublished it
+		$this->assertFalse($related2->isPublished()); // Unpublished because it owns attachment3
+		$this->assertFalse($subclass2->isPublished()); // Unpublished ecause it owns related2
+		$this->assertTrue($relatedMany4->isPublished()); // Stays live because recursion only affects owners not owned.
+	}
+
+	public function testRecursiveArchive() {
+		// When archiving an object, any published owners should be unpublished at the same time
+		// but NOT achived
+
+		/** @var VersionedOwnershipTest_Attachment $attachment3 */
+		$attachment3 = $this->objFromFixture('VersionedOwnershipTest_Attachment', 'attachment3_published');
+		$attachment3ID = $attachment3->ID;
+		$this->assertTrue($attachment3->doArchive());
+
+		// This object is on neither stage nor live
+		$stageAttachment = Versioned::get_by_stage('VersionedOwnershipTest_Attachment', Versioned::DRAFT)
+			->byID($attachment3ID);
+		$liveAttachment = Versioned::get_by_stage('VersionedOwnershipTest_Attachment', Versioned::LIVE)
+			->byID($attachment3ID);
+		$this->assertEmpty($stageAttachment);
+		$this->assertEmpty($liveAttachment);
+
+		// Owning object is unpublished only
+		/** @var VersionedOwnershipTest_Related $stageOwner */
+		$stageOwner = $this->objFromFixture('VersionedOwnershipTest_Related', 'related2_published');
+		$this->assertTrue($stageOwner->isOnDraft());
+		$this->assertFalse($stageOwner->isPublished());
+
+		// Bottom level owning object is also unpublished
+		/** @var VersionedOwnershipTest_Subclass $stageTopOwner */
+		$stageTopOwner = $this->objFromFixture('VersionedOwnershipTest_Subclass', 'subclass2_published');
+		$this->assertTrue($stageTopOwner->isOnDraft());
+		$this->assertFalse($stageTopOwner->isPublished());
+	}
+
+	public function testRecursiveRevertToLive() {
+		/** @var VersionedOwnershipTest_Subclass $parent */
+		$parent = $this->objFromFixture('VersionedOwnershipTest_Subclass', 'subclass1_published');
+		$parentID = $parent->ID;
+		$banner1 = $this->objFromFixture('VersionedOwnershipTest_RelatedMany', 'relatedmany1_published');
+		$banner2 = $this->objFromFixture('VersionedOwnershipTest_RelatedMany', 'relatedmany2_published');
+		$banner2ID = $banner2->ID;
+
+		// Modify, Add, and Delete banners on stage
+		$banner1->Title = 'Renamed Banner 1';
+		$banner1->write();
+
+		$banner2->delete();
+
+		$banner4 = new VersionedOwnershipTest_RelatedMany();
+		$banner4->Title = 'New Banner';
+		$banner4->write();
+		$parent->Banners()->add($banner4);
+
+		// Check state of objects before publish
+		$liveBanners = [
+			['Title' => 'Related Many 1'],
+			['Title' => 'Related Many 2'],
+		];
+		$modifiedBanners = [
+			['Title' => 'Renamed Banner 1'], // Renamed
+			['Title' => 'Related Many 3'], // Published without changes
+			['Title' => 'New Banner'], // Created
+		];
+		$parentDraft = Versioned::get_by_stage('VersionedOwnershipTest_Subclass', Versioned::DRAFT)
+			->byID($parentID);
+		$this->assertDOSEquals($modifiedBanners, $parentDraft->Banners());
+		$parentLive = Versioned::get_by_stage('VersionedOwnershipTest_Subclass', Versioned::LIVE)
+			->byID($parentID);
+		$this->assertDOSEquals($liveBanners, $parentLive->Banners());
+
+		// When reverting parent, all records should be put back on stage
+		$this->assertTrue($parent->doRevertToLive());
+
+		// Now check each object has the correct state
+		$parentDraft = Versioned::get_by_stage('VersionedOwnershipTest_Subclass', Versioned::DRAFT)
+			->byID($parentID);
+		$this->assertDOSEquals($liveBanners, $parentDraft->Banners());
+		$parentLive = Versioned::get_by_stage('VersionedOwnershipTest_Subclass', Versioned::LIVE)
+			->byID($parentID);
+		$this->assertDOSEquals($liveBanners, $parentLive->Banners());
+
+		// Check that the newly created banner, even though it still exist, has been
+		// unlinked from the reverted draft record
+		/** @var VersionedOwnershipTest_RelatedMany $banner4Draft */
+		$banner4Draft = Versioned::get_by_stage('VersionedOwnershipTest_RelatedMany', Versioned::DRAFT)
+			->byID($banner4->ID);
+		$this->assertTrue($banner4Draft->isOnDraft());
+		$this->assertFalse($banner4Draft->isPublished());
+		$this->assertEmpty($banner4Draft->PageID);
+	}
+
+	/**
+	 * Test that rolling back to a single version works recursively
+	 */
+	public function testRecursiveRollback() {
+		/** @var VersionedOwnershipTest_Subclass $subclass2 */
+		$this->sleep(1);
+		$subclass2 = $this->objFromFixture('VersionedOwnershipTest_Subclass', 'subclass2_published');
+
+		// Create a few new versions
+		$versions = [];
+		for($version = 1; $version <= 3; $version++) {
+			// Write owned objects
+			$this->sleep(1);
+			foreach($subclass2->findOwned(true) as $obj) {
+				$obj->Title .= " - v{$version}";
+				$obj->write();
+			}
+			// Write parent
+			$this->sleep(1);
+			$subclass2->Title .= " - v{$version}";
+			$subclass2->write();
+			$versions[$version] = $subclass2->Version;
+		}
+
+
+		// Check reverting to first version
+		$this->sleep(1);
+		$subclass2->doRollbackTo($versions[1]);
+		/** @var VersionedOwnershipTest_Subclass $subclass2Draft */
+		$subclass2Draft = Versioned::get_by_stage('VersionedOwnershipTest_Subclass', Versioned::DRAFT)
+			->byID($subclass2->ID);
+		$this->assertEquals('Subclass 2 - v1', $subclass2Draft->Title);
+		$this->assertDOSEquals(
+			[
+				['Title' => 'Related 2 - v1'],
+				['Title' => 'Attachment 3 - v1'],
+				['Title' => 'Attachment 4 - v1'],
+				['Title' => 'Attachment 5 - v1'],
+				['Title' => 'Related Many 4 - v1'],
+			],
+			$subclass2Draft->findOwned(true)
+		);
+
+		// Check rolling forward to a later version
+		$this->sleep(1);
+		$subclass2->doRollbackTo($versions[3]);
+		/** @var VersionedOwnershipTest_Subclass $subclass2Draft */
+		$subclass2Draft = Versioned::get_by_stage('VersionedOwnershipTest_Subclass', Versioned::DRAFT)
+			->byID($subclass2->ID);
+		$this->assertEquals('Subclass 2 - v1 - v2 - v3', $subclass2Draft->Title);
+		$this->assertDOSEquals(
+			[
+				['Title' => 'Related 2 - v1 - v2 - v3'],
+				['Title' => 'Attachment 3 - v1 - v2 - v3'],
+				['Title' => 'Attachment 4 - v1 - v2 - v3'],
+				['Title' => 'Attachment 5 - v1 - v2 - v3'],
+				['Title' => 'Related Many 4 - v1 - v2 - v3'],
+			],
+			$subclass2Draft->findOwned(true)
+		);
+
+		// And rolling back one version
+		$this->sleep(1);
+		$subclass2->doRollbackTo($versions[2]);
+		/** @var VersionedOwnershipTest_Subclass $subclass2Draft */
+		$subclass2Draft = Versioned::get_by_stage('VersionedOwnershipTest_Subclass', Versioned::DRAFT)
+			->byID($subclass2->ID);
+		$this->assertEquals('Subclass 2 - v1 - v2', $subclass2Draft->Title);
+		$this->assertDOSEquals(
+			[
+				['Title' => 'Related 2 - v1 - v2'],
+				['Title' => 'Attachment 3 - v1 - v2'],
+				['Title' => 'Attachment 4 - v1 - v2'],
+				['Title' => 'Attachment 5 - v1 - v2'],
+				['Title' => 'Related Many 4 - v1 - v2'],
+			],
+			$subclass2Draft->findOwned(true)
+		);
+	}
+
 }
 
 /**
@@ -224,6 +520,11 @@ class VersionedOwnershipTest_Object extends DataObject implements TestOnly {
 	);
 }
 
+/**
+ * Object which:
+ * - owns a has_one object
+ * - owns has_many objects
+ */
 class VersionedOwnershipTest_Subclass extends VersionedOwnershipTest_Object implements TestOnly {
 	private static $db = array(
 		'Description' => 'Text',
@@ -233,12 +534,21 @@ class VersionedOwnershipTest_Subclass extends VersionedOwnershipTest_Object impl
 		'Related' => 'VersionedOwnershipTest_Related',
 	);
 
+	private static $has_many = array(
+		'Banners' => 'VersionedOwnershipTest_RelatedMany'
+	);
+
 	private static $owns = array(
 		'Related',
+		'Banners',
 	);
 }
 
 /**
+ * Object which:
+ * - owned by has_many objects
+ * - owns many_many Objects
+ *
  * @mixin Versioned
  */
 class VersionedOwnershipTest_Related extends DataObject implements TestOnly {
@@ -265,6 +575,29 @@ class VersionedOwnershipTest_Related extends DataObject implements TestOnly {
 
 	private static $owns = array(
 		'Attachments',
+	);
+}
+
+/**
+ * Object which is owned by a has_one object
+ *
+ * @mixin Versioned
+ */
+class VersionedOwnershipTest_RelatedMany extends DataObject implements TestOnly {
+	private static $extensions = array(
+		'Versioned',
+	);
+
+	private static $db = array(
+		'Title' => 'Varchar(255)',
+	);
+
+	private static $has_one = array(
+		'Page' => 'VersionedOwnershipTest_Subclass'
+	);
+
+	private static $owned_by = array(
+		'Page'
 	);
 }
 

--- a/tests/model/VersionedOwnershipTest.yml
+++ b/tests/model/VersionedOwnershipTest.yml
@@ -26,6 +26,20 @@ VersionedOwnershipTest_Subclass:
     Title: 'Subclass 2'
     Related: =>VersionedOwnershipTest_Related.related2_published
 
+VersionedOwnershipTest_RelatedMany:
+  relatedmany1_published:
+    Title: 'Related Many 1'
+    Page: =>VersionedOwnershipTest_Subclass.subclass1_published
+  relatedmany2_published:
+    Title: 'Related Many 2'
+    Page: =>VersionedOwnershipTest_Subclass.subclass1_published
+  relatedmany3:
+    Title: 'Related Many 3'
+    Page: =>VersionedOwnershipTest_Subclass.subclass1_published
+  relatedmany4_published:
+    Title: 'Related Many 4'
+    Page: =>VersionedOwnershipTest_Subclass.subclass2_published
+
 VersionedOwnershipTest_Object:
   object1:
     Title: 'Object 1'

--- a/tests/view/SSViewerCacheBlockTest.php
+++ b/tests/view/SSViewerCacheBlockTest.php
@@ -145,11 +145,11 @@ class SSViewerCacheBlockTest extends SapphireTest {
 
 	public function testVersionedCache() {
 
-		$origStage = Versioned::current_stage();
+		$origStage = Versioned::get_stage();
 
 		// Run without caching in stage to prove data is uncached
 		$this->_reset(false);
-		Versioned::reading_stage("Stage");
+		Versioned::set_stage(Versioned::DRAFT);
 		$data = new SSViewerCacheBlockTest_VersionedModel();
 		$data->setEntropy('default');
 		$this->assertEquals(
@@ -165,7 +165,7 @@ class SSViewerCacheBlockTest extends SapphireTest {
 
 		// Run without caching in live to prove data is uncached
 		$this->_reset(false);
-		Versioned::reading_stage("Live");
+		Versioned::set_stage(Versioned::LIVE);
 		$data = new SSViewerCacheBlockTest_VersionedModel();
 		$data->setEntropy('default');
 		$this->assertEquals(
@@ -183,7 +183,7 @@ class SSViewerCacheBlockTest extends SapphireTest {
 		// changing the versioned reading mode doesn't cache between modes, but it does
 		// within them
 		$this->_reset(true);
-		Versioned::reading_stage("Stage");
+		Versioned::set_stage(Versioned::DRAFT);
 		$data = new SSViewerCacheBlockTest_VersionedModel();
 		$data->setEntropy('default');
 		$this->assertEquals(
@@ -197,7 +197,7 @@ class SSViewerCacheBlockTest extends SapphireTest {
 			$this->_runtemplate('<% cached %>$Inspect<% end_cached %>', $data)
 		);
 
-		Versioned::reading_stage('Live');
+		Versioned::set_stage(Versioned::LIVE);
 		$data = new SSViewerCacheBlockTest_VersionedModel();
 		$data->setEntropy('first');
 		$this->assertEquals(
@@ -211,7 +211,7 @@ class SSViewerCacheBlockTest extends SapphireTest {
 			$this->_runtemplate('<% cached %>$Inspect<% end_cached %>', $data)
 		);
 
-		Versioned::reading_stage($origStage);
+		Versioned::set_stage($origStage);
 	}
 
 	/**


### PR DESCRIPTION
Versioned extension has had a cleanup and refactor in order to make it bearable to look at for more than a few seconds.

This is the first real-world use case for owned versioned dataobjects; Now objects will trigger publishing on owned objects when they are published to live.

Some parts of File/Folder needed to be changed to cope with partial publishing of the folder tree.

CMS PR at https://github.com/silverstripe/silverstripe-cms/pull/1415