### PR TITLE
FIX avoid javascript error when preview is https

### DIFF
--- a/admin/javascript/src/LeftAndMain.ActionTabSet.js
+++ b/admin/javascript/src/LeftAndMain.ActionTabSet.js
@@ -31,7 +31,9 @@ $.entwine('ss', function($) {
 			// because the panel is still open when the ajax edit form reloads.
 			var frame = $('.cms-container').find('iframe');
 			frame.each(function(index, iframe){
-				$(iframe).contents().off('click.ss-ui-action-tabset');
+				try {
+					$(iframe).contents().off('click.ss-ui-action-tabset');
+				} catch (e) {}
 			});
 			$(document).off('click.ss-ui-action-tabset');
 

--- a/admin/javascript/src/LeftAndMain.Preview.js
+++ b/admin/javascript/src/LeftAndMain.Preview.js
@@ -501,8 +501,16 @@ $.entwine('ss.preview', function($){
 		_loadCurrentPage: function() {
 			if (!this.getIsPreviewEnabled()) return;
 
-			var doc = this.find('iframe')[0].contentDocument,
-				containerEl = $('.cms-container');
+            var doc,
+                containerEl = $('.cms-container');
+            try {
+                doc = this.find('iframe')[0].contentDocument;
+            } catch (e) {
+                // iframe can't be accessed - might be secure?
+            }
+            if (!doc) {
+                return;
+            }
 
 			// Load this page in the admin interface if appropriate
 			var id = $(doc).find('meta[name=x-page-id]').attr('content'); 
@@ -521,14 +529,20 @@ $.entwine('ss.preview', function($){
 		 * Prepare the iframe content for preview.
 		 */
 		_adjustIframeForPreview: function() {
-			var iframe = this.find('iframe')[0];
-			if(iframe){
-				var doc = iframe.contentDocument;
-			}else{
-				return;
-			}
-	
-			if(!doc) return;
+            var iframe = this.find('iframe')[0],
+                doc;
+            if(!iframe){
+                return;
+            }
+
+            try {
+                doc = iframe.contentDocument;
+            } catch (e) {
+                // iframe can't be accessed - might be secure?
+            }
+            if(!doc) {
+                return;
+            }
 
 			// Open external links in new window to avoid "escaping" the internal page context in the preview
 			// iframe, which is important to stay in for the CMS logic.


### PR DESCRIPTION
When the admin interface is http but the preview is https, javascript isn't able to read the contentDocument of the secure preview iframe. This currently results in a javascript error. Patch wraps try/catches around the two instances,