### PR TITLE
Remove pagination get param from links pointing to page 1 within pagination

### DIFF
--- a/core/PaginatedList.php
+++ b/core/PaginatedList.php
@@ -229,9 +229,19 @@ class PaginatedList extends SS_ListDecorator {
 		}
 
 		for ($i = $start; $i < $end; $i++) {
+
+			// Remove the query sting for the first page link
+			// /?start=0 returns the same page as /
+			$link = HTTP::setGetVar($this->getPaginationGetVar(), $i * $this->getPageLength());
+
+			if($i === 0) {
+				$parts = explode("?", $link);
+				$link = $parts[0];
+			}
+
 			$result->push(new ArrayData(array(
 				'PageNum'     => $i + 1,
-				'Link'        => HTTP::setGetVar($this->getPaginationGetVar(), $i * $this->getPageLength()),
+				'Link'        => $link,
 				'CurrentBool' => $this->CurrentPage() == ($i + 1)
 			)));
 		}
@@ -430,7 +440,16 @@ class PaginatedList extends SS_ListDecorator {
 	 */
 	public function PrevLink() {
 		if ($this->NotFirstPage()) {
-			return HTTP::setGetVar($this->getPaginationGetVar(), $this->getPageStart() - $this->getPageLength());
+
+			$start = $this->getPageStart() - $this->getPageLength();
+
+			$link = HTTP::setGetVar($this->getPaginationGetVar(), $start);
+
+			if($start === 0) {
+				$parts = explode("?", $link);
+				$link = $parts[0];
+			}
+			return $link;
 		}
 	}
 

--- a/core/PaginatedList.php
+++ b/core/PaginatedList.php
@@ -235,8 +235,7 @@ class PaginatedList extends SS_ListDecorator {
 			$link = HTTP::setGetVar($this->getPaginationGetVar(), $i * $this->getPageLength());
 
 			if($i === 0) {
-				$parts = explode("?", $link);
-				$link = $parts[0];
+				$link = $this->removeFirstPagePaginationParam($link);
 			}
 
 			$result->push(new ArrayData(array(
@@ -446,8 +445,7 @@ class PaginatedList extends SS_ListDecorator {
 			$link = HTTP::setGetVar($this->getPaginationGetVar(), $start);
 
 			if($start === 0) {
-				$parts = explode("?", $link);
-				$link = $parts[0];
+				$link = $this->removeFirstPagePaginationParam($link);
 			}
 			return $link;
 		}
@@ -476,4 +474,30 @@ class PaginatedList extends SS_ListDecorator {
 		return $this->request;
 	}
 
+	/**
+	 * Remove the first page pagination get var to stop duplicate page issues
+	 * / and /?start=0 return the same page
+	 *
+	 * @param  string $link
+	 * @return string
+	 */
+	private function removeFirstPagePaginationParam($link)
+	{
+		// get the path and query string
+		$parts = explode("?", $link);
+
+		$path = $parts[0];
+		$qs = $parts[1];
+
+		// remove the pagination get var
+		$qs = str_replace($this->getPaginationGetVar()."=0", "", $qs);
+
+		// remove extra & if there is one
+		$qs = implode("&amp;", array_filter(explode("&amp;", $qs)));
+
+		// append the query string to the path if there are any remaining vars
+		$link = $path . ($qs !== "" ? "?" . $qs : "");
+
+		return $link;
+	}
 }

--- a/tests/model/PaginatedListTest.php
+++ b/tests/model/PaginatedListTest.php
@@ -325,7 +325,8 @@ class PaginatedListTest extends SapphireTest {
 
 		$this->assertNull($list->PrevLink());
 		$list->setCurrentPage(2);
-		$this->assertContains('start=0', $list->PrevLink());
+		$this->assertNotNull($list->PrevLink());
+		$this->assertNotContains('start=0', $list->PrevLink());
 		$list->setCurrentPage(3);
 		$this->assertContains('start=10', $list->PrevLink());
 		$list->setCurrentPage(5);


### PR DESCRIPTION
On page 2 of a paginated list the "previous" and "1" pagination link point to /?start=0 as the first page in the pagination series. Both / and /?start=0 will return the same page and therefore its preferable to point to the non param version for duplicate content reasons. A page when first visited will use the non param version / of the URL. Its only when we start navigation through pagination and are on page 2 that there is a link back to /?start=0. Search engines will navigate the site the same as users can and will crawl this this URL (/?start=0) and index it alongside the main URL (/) causing a duplicate page.
