### PR TITLE
BUG Remove duplicate extension hook

### DIFF
--- a/control/RequestHandler.php
+++ b/control/RequestHandler.php
@@ -287,7 +287,7 @@ class RequestHandler extends ViewableData {
 
 		$actionRes = $this->$action($request);
 
-		$res = $this->extend('afterCallActionHandler', $request, $action);
+		$res = $this->extend('afterCallActionHandler', $request, $action, $actionRes);
 		if ($res) return reset($res);
 
 		return $actionRes;


### PR DESCRIPTION
Fixes #5170
Reverts #3355

This isn't needed, since the hook will be invoked in the `parent::handleAction` call.