### PR TITLE
remove $CleartextPassword from ChangePasswordEmail.ss

### DIFF
--- a/templates/email/ChangePasswordEmail.ss
+++ b/templates/email/ChangePasswordEmail.ss
@@ -6,6 +6,6 @@
 </p>
 
 <p>
-	<%t ChangePasswordEmail_ss.EMAIL 'Email' %>: $Email<br />
-	<%t ChangePasswordEmail_ss.PASSWORD 'Password' %>: $CleartextPassword
+	<%t ChangePasswordEmail_ss.EMAIL 'Email' %>: $Email<% if $CleartextPassword %><br />
+	<%t ChangePasswordEmail_ss.PASSWORD 'Password' %>: $CleartextPassword<% end_if %>
 </p>


### PR DESCRIPTION
The $CleartextPassword value is never populated as reported https://github.com/silverstripe/silverstripe-framework/issues/3257 and in agreeance with the two comments (cc @kinglozzer) I also don't think plaintext passwords should be included in emails by default. As Loz suggests if somebody wants this it can easily be added by overriding the template.