### PR TITLE
Allow '0' in DropdownField

### DIFF
--- a/templates/forms/DropdownField.ss
+++ b/templates/forms/DropdownField.ss
@@ -1,5 +1,5 @@
 <select $AttributesHTML>
 <% loop $Options %>
-	<option value="$Value.XML"<% if $Selected %> selected="selected"<% end_if %><% if $Disabled %> disabled="disabled"<% end_if %>><% if Title %>$Title.XML<% else %>&nbsp;<% end_if %></option>
+	<option value="$Value.XML"<% if $Selected %> selected="selected"<% end_if %><% if $Disabled %> disabled="disabled"<% end_if %>><% if $Title.exists %>$Title.XML<% else %>&nbsp;<% end_if %></option>
 <% end_loop %>
 </select>


### PR DESCRIPTION
This fixes #5196. 

It's actually sort of a workaround, because I feel like whatever code prettifies `<select>`s in the CMS should not ignore `<option>`s without any content. But this works too, without any harm (it just adds an invisible space to _all_ values, instead of just to falsy values).