### PR TITLE
Fixed issue where `canViewVersioned` caused a DB error…

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -795,9 +795,14 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 			return true;
 		}
 
+		// If there are less than 2 stages, we can exit early since comparing stages is not needed
+		if(count($this->stages) < 2){
+			return true;
+		}
+
 		// If we weren't definitely loaded from live, and we can't view non-live content, we need to
-		// check to make sure this version is the live version and so can be viewed
-		$latestVersion = Versioned::get_versionnumber_by_stage($this->owner->class, 'Live', $this->owner->ID);
+		// check to make sure this version is the live version and so can be viewed.
+		$latestVersion = Versioned::get_versionnumber_by_stage($this->owner->class, $this->liveStage, $this->owner->ID);
 		if ($latestVersion == $this->owner->Version) {
 			// Even if this is loaded from a non-live stage, this is the live version
 			return true;

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -812,6 +812,7 @@ class VersionedTest extends SapphireTest {
 		$public1ID = $this->idFromFixture('VersionedTest_PublicStage', 'public1');
 		$public2ID = $this->idFromFixture('VersionedTest_PublicViaExtension', 'public2');
 		$privateID = $this->idFromFixture('VersionedTest_DataObject', 'page1');
+		$singleID = $this->idFromFixture('VersionedTest_SingleStage', 'single');
 
 		// Test that all (and only) public pages are viewable in stage mode
 		Session::clear("loggedInAs");
@@ -819,16 +820,21 @@ class VersionedTest extends SapphireTest {
 		$public1 = Versioned::get_one_by_stage('VersionedTest_PublicStage', 'Stage', array('"ID"' => $public1ID));
 		$public2 = Versioned::get_one_by_stage('VersionedTest_PublicViaExtension', 'Stage', array('"ID"' => $public2ID));
 		$private = Versioned::get_one_by_stage('VersionedTest_DataObject', 'Stage', array('"ID"' => $privateID));
+		// Also test an object that has just a single-stage (eg. is only versioned)
+		$single = Versioned::get_one_by_stage('VersionedTest_SingleStage', 'Stage', array('"ID"' => $singleID));
+
 
 		$this->assertTrue($public1->canView());
 		$this->assertTrue($public2->canView());
 		$this->assertFalse($private->canView());
+		$this->assertFalse($single->canView());
 
 		// Adjusting the current stage should not allow objects loaded in stage to be viewable
 		Versioned::reading_stage('Live');
 		$this->assertTrue($public1->canView());
 		$this->assertTrue($public2->canView());
 		$this->assertFalse($private->canView());
+		$this->assertFalse($single->canView());
 
 		// Writing the private page to live should be fine though
 		$private->publish("Stage", "Live");
@@ -854,6 +860,7 @@ class VersionedTest extends SapphireTest {
 		$this->assertTrue($public1->canView());
 		$this->assertTrue($public2->canView());
 		$this->assertTrue($private->canView());
+		$this->assertTrue($single->canView());
 	}
 
 

--- a/tests/model/VersionedTest.yml
+++ b/tests/model/VersionedTest.yml
@@ -30,3 +30,7 @@ VersionedTest_AnotherSubclass:
   subclass1:
     Title: 'Subclass Page 1'
     AnotherField: 'Bob'
+
+VersionedTest_SingleStage:
+  single:
+    Title: 'Singlestage Title'


### PR DESCRIPTION
… when Versioned was used with stages other than the default "Stage" and "Live".
Updated VersionedTest to also check an Object with a single stage in the canView test.

Fixes #5189