### PR TITLE
API Improvements to ownership api

### DIFF
--- a/core/Extension.php
+++ b/core/Extension.php
@@ -12,6 +12,7 @@
  * @subpackage core
  */
 abstract class Extension {
+
 	/**
 	 * This is used by extensions designed to be applied to controllers.
 	 * It works the same way as {@link Controller::$allowed_actions}.
@@ -32,10 +33,12 @@ abstract class Extension {
 	protected $ownerBaseClass;
 
 	/**
-	 * Reference counter to ensure that the owner isn't cleared until clearOwner() has
-	 * been called as many times as setOwner()
+	 * Ownership stack for recursive methods.
+	 * Last item is current owner.
+	 *
+	 * @var array
 	 */
-	private $ownerRefs = 0;
+	private $ownerStack = [];
 
 	public $class;
 
@@ -55,6 +58,7 @@ abstract class Extension {
 
 	/**
 	 * Set the owner of this extension.
+	 *
 	 * @param Object $owner The owner object,
 	 * @param string $ownerBaseClass The base class that the extension is applied to; this may be
 	 * the class of owner, or it may be a parent.  For example, if Versioned was applied to SiteTree,
@@ -62,17 +66,32 @@ abstract class Extension {
 	 * would be 'SiteTree'.
 	 */
 	public function setOwner($owner, $ownerBaseClass = null) {
-		if($owner) $this->ownerRefs++;
+		if($owner) {
+			$this->ownerStack[] = $owner;
+		}
 		$this->owner = $owner;
 
-		if($ownerBaseClass) $this->ownerBaseClass = $ownerBaseClass;
-		else if(!$this->ownerBaseClass && $owner) $this->ownerBaseClass = $owner->class;
+		// Set ownerBaseClass
+		if($ownerBaseClass) {
+			$this->ownerBaseClass = $ownerBaseClass;
+		} elseif(!$this->ownerBaseClass && $owner) {
+			$this->ownerBaseClass = get_class($owner);
+		}
 	}
 
+	/**
+	 * Clear the current owner, and restore extension to the state prior to the last setOwner()
+	 */
 	public function clearOwner() {
-		if($this->ownerRefs <= 0) user_error("clearOwner() called more than setOwner()", E_USER_WARNING);
-		$this->ownerRefs--;
-		if($this->ownerRefs == 0) $this->owner = null;
+		if(empty($this->ownerStack)) {
+			throw new BadMethodCallException("clearOwner() called more than setOwner()");
+		}
+		array_pop($this->ownerStack);
+		if($this->ownerStack) {
+			$this->owner = end($this->ownerStack);
+		} else {
+			$this->owner = null;
+		}
 	}
 
 	/**
@@ -97,7 +116,4 @@ abstract class Extension {
 		return $parts[0];
 	}
 
-
-
 }
-

--- a/tests/model/DataExtensionTest.php
+++ b/tests/model/DataExtensionTest.php
@@ -220,6 +220,39 @@ class DataExtensionTest extends SapphireTest {
 		$this->assertNotEmpty($fields->dataFieldByName('ChildField'));
 		$this->assertNotEmpty($fields->dataFieldByName('GrandchildField'));
 	}
+
+	/**
+	 * Test setOwner behaviour
+	 */
+	public function testSetOwner() {
+		$extension = new DataExtensionTest_Ext1();
+		$obj1 = $this->objFromFixture('DataExtensionTest_RelatedObject', 'obj1');
+		$obj2 = $this->objFromFixture('DataExtensionTest_RelatedObject', 'obj1');
+
+		$extension->setOwner(null);
+		$this->assertNull($extension->getOwner());
+
+		// Set original owner
+		$extension->setOwner($obj1);
+		$this->assertEquals($obj1, $extension->getOwner());
+
+		// Set nested owner
+		$extension->setOwner($obj2);
+		$this->assertEquals($obj2, $extension->getOwner());
+
+		// Clear nested owner
+		$extension->clearOwner();
+		$this->assertEquals($obj1, $extension->getOwner());
+
+		// Clear original owner
+		$extension->clearOwner();
+		$this->assertNull($extension->getOwner());
+
+		// Another clearOwner should error
+		$this->setExpectedException("BadMethodCallException", "clearOwner() called more than setOwner()");
+		$extension->clearOwner();
+	}
+
 }
 
 class DataExtensionTest_Member extends DataObject implements TestOnly {

--- a/tests/model/VersionedOwnershipTest.yml
+++ b/tests/model/VersionedOwnershipTest.yml
@@ -43,3 +43,34 @@ VersionedOwnershipTest_RelatedMany:
 VersionedOwnershipTest_Object:
   object1:
     Title: 'Object 1'
+
+VersionedOwnershipTest_Image:
+  image1_published:
+    Title: 'Image 1'
+  image2_published:
+    Title: 'Image 2'
+
+VersionedOwnershipTest_Banner:
+  banner1_published:
+    Title: 'Banner 1'
+    Image: =>VersionedOwnershipTest_Image.image1_published
+  banner2_published:
+    Title: 'Banner 2'
+    Image: =>VersionedOwnershipTest_Image.image1_published
+  banner3_published:
+    Title: 'Banner 3'
+    Image: =>VersionedOwnershipTest_Image.image2_published
+
+VersionedOwnershipTest_Page:
+  page1_published:
+    Title: 'Page 1'
+    Banners: =>VersionedOwnershipTest_Banner.banner1_published
+  page2_published:
+    Title: 'Page 2'
+    Banners: =>VersionedOwnershipTest_Banner.banner2_published,=>VersionedOwnershipTest_Banner.banner3_published
+
+VersionedOwnershipTest_CustomRelation:
+  custom1_published:
+    Title: 'Custom 1'
+  custom2_published:
+    Title: 'Custom 2'


### PR DESCRIPTION
This introduces formal support for custom ownership relations, as well as making owned_by optional for standard DB relations. This should make usage in most real-world use cases (e.g. owning files) a lot simpler, and reduce the need to add custom extensions to core modules.

Part of this work requires the abliity to traverse relations on DataObjects where only one side (e.g. the has_one) is declared. I've implemented getNonReciprocalComponent to mock missing relations, although this can still be used even if both sides of the relation are declared.

Extension setOwner/clearOwner is now nested. This resolves issues with $this->owner getting set to null occasionally in extensions when extensions invoke methods recursively. Until now I was working around this with `$owner = $this->owner` at the start of every extension method, but this should be a more robust fix.