### PR TITLE
MINOR: Fix PHPUnit @covers assertions for GridFieldTest

### DIFF
--- a/tests/forms/GridFieldTest.php
+++ b/tests/forms/GridFieldTest.php
@@ -22,8 +22,8 @@ class GridFieldTest extends SapphireTest {
 	/**
 	 * @covers GridField::__construct
 	 * @covers GridField::getConfig
-	 * @covers GridField::setComponents
-	 * @covers GridField::getDefaultConfig
+	 * @covers GridFieldConfig_Base::__construct
+	 * @covers GridFieldConfig::addComponent
 	 */
 	public function testGridFieldDefaultConfig() {
 		$obj = new GridField('testfield', 'testfield');
@@ -45,8 +45,8 @@ class GridFieldTest extends SapphireTest {
 	}
 
 	/**
-	 * @covers GridField::__construct
-	 * @covers GridField::setComponents
+	 * @covers GridFieldConfig::__construct
+	 * @covers GridFieldConfig::addComponent
 	 */
 	public function testGridFieldSetCustomConfig() {
 


### PR DESCRIPTION
This resolves issues when PHPUnit is run strictly, where it exits when
it hits an @covers annotation that references a method that doesn't exist