### PR TITLE
MINOR: Fix PHPUnit @covers assertions for DBStringTest

### DIFF
--- a/tests/model/DBStringTest.php
+++ b/tests/model/DBStringTest.php
@@ -11,7 +11,7 @@ use SilverStripe\Model\FieldType\DBString;
 class DBStringTest extends SapphireTest {
 
 	/**
-	 * @covers DBString->forTemplate()
+	 * @covers SilverStripe\Model\FieldType\DBField::forTemplate()
 	 */
 	public function testForTemplate() {
 		$this->assertEquals(
@@ -21,7 +21,7 @@ class DBStringTest extends SapphireTest {
 	}
 
 	/**
-	 * @covers DBString->LowerCase()
+	 * @covers SilverStripe\Model\FieldType\DBString::LowerCase()
 	 */
 	public function testLowerCase() {
 		$this->assertEquals(
@@ -31,7 +31,7 @@ class DBStringTest extends SapphireTest {
 	}
 
 	/**
-	 * @covers DBString->UpperCase()
+	 * @covers SilverStripe\Model\FieldType\DBString::UpperCase()
 	 */
 	public function testUpperCase() {
 		$this->assertEquals(


### PR DESCRIPTION
This resolves issues when PHPUnit is run strictly, where it exits when
it hits an @covers annotation that references a method that doesn't exist