### PR TITLE
DOCS Session::save() needs to be called after Session::set()

### DIFF
--- a/docs/en/02_Developer_Guides/18_Cookies_And_Sessions/02_Sessions.md
+++ b/docs/en/02_Developer_Guides/18_Cookies_And_Sessions/02_Sessions.md
@@ -14,6 +14,7 @@ unit-testing, you can create multiple Controllers, each with their own session.
 
 	:::php
 	Session::set('MyValue', 6);
+	Session::save();
 
 Saves the value of to session data. You can also save arrays or serialized objects in session (but note there may be 
 size restrictions as to how much you can save).
@@ -21,10 +22,12 @@ size restrictions as to how much you can save).
 	:::php
 	// saves an array
 	Session::set('MyArrayOfValues', array('1','2','3'));
+	Session::save();
 
 	// saves an object (you'll have to unserialize it back)
 	$object = new Object();
 	Session::set('MyObject', serialize($object));
+	Session::save();
  
 ## get
 


### PR DESCRIPTION
I'm not sure if this is needed in earlier versions. If it does I can do additional pr's if needed.