### PR TITLE
Fixed bug where breadcrumb title wouldn't appear if title was blank

### DIFF
--- a/forms/gridfield/GridFieldDetailForm.php
+++ b/forms/gridfield/GridFieldDetailForm.php
@@ -680,8 +680,9 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler {
 
 		$items = $this->popupController->Breadcrumbs($unlinked);
 		if($this->record && $this->record->ID) {
+			$title = ($this->record->Title) ? $this->record->Title : "#{$this->record->ID}";
 			$items->push(new ArrayData(array(
-				'Title' => $this->record->Title,
+				'Title' => $title,
 				'Link' => $this->Link()
 			)));
 		} else {


### PR DESCRIPTION
Fixed bug where breadcrumb title wouldn't appear if the title was blank.
(This bug showed itself to me when I overwrote 'getTitle()' on my data objects)