### PR TITLE
BUG Prevent live manifest loading files from nested test directories

### DIFF
--- a/core/manifest/ManifestFileFinder.php
+++ b/core/manifest/ManifestFileFinder.php
@@ -37,9 +37,8 @@ class ManifestFileFinder extends SS_FileFinder {
 			return false;
 		}
 
-		// If we're not in testing mode, then skip over the tests directory in
-		// the module root.
-		if ($this->getOption('ignore_tests') && $depth == 2 && $basename == self::TESTS_DIR) {
+		// If we're not in testing mode, then skip over any tests directories.
+		if ($this->getOption('ignore_tests') && $basename == self::TESTS_DIR) {
 			return false;
 		}
 

--- a/tests/core/manifest/ManifestFileFinderTest.php
+++ b/tests/core/manifest/ManifestFileFinderTest.php
@@ -43,7 +43,8 @@ class ManifestFileFinderTest extends SapphireTest {
 
 		$this->assertFinderFinds($finder, array(
 			'module/module.txt',
-			'module/tests/tests.txt'
+			'module/tests/tests.txt',
+			'module/code/tests/tests2.txt'
 		));
 	}
 


### PR DESCRIPTION
E.g. framework/admin/tests

I have no idea why, but 3.x doesn't seem to whinge about this so much.

At the moment trying to deploy a 4.0 site with --no-dev and --prefer-dist is impossible because certain classes can't be loaded properly (lack of phpunit means test classes are unloadable).