### PR TITLE
Set HTTP status code to 400 on AJAX validation error response

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -874,7 +874,7 @@ class Form extends RequestHandler {
 	/**
 	 * Set the target of this form to any value - useful for opening the form contents in a new window or refreshing
 	 * another frame
-	 *
+	 * 
 	 * @param string|FormTemplateHelper
 	 */
 	public function setTemplateHelper($helper) {

--- a/forms/Form.php
+++ b/forms/Form.php
@@ -506,6 +506,7 @@ class Form extends RequestHandler {
 					// Send validation errors back as JSON with a flag at the start
 					$response = new SS_HTTPResponse(Convert::array2json($this->validator->getErrors()));
 					$response->addHeader('Content-Type', 'application/json');
+					$response->setStatusCode(400);
 				} else {
 					$this->setupFormErrors();
 					// Send the newly rendered form tag as HTML
@@ -873,7 +874,7 @@ class Form extends RequestHandler {
 	/**
 	 * Set the target of this form to any value - useful for opening the form contents in a new window or refreshing
 	 * another frame
-	 * 
+	 *
 	 * @param string|FormTemplateHelper
 	 */
 	public function setTemplateHelper($helper) {


### PR DESCRIPTION
Would be good for form validation errors to respond with an appropriate 400 HTTP status code. This also means that it would trigger an error with javascript AJAX request.