### PR TITLE
Removal of FlushGeneratedImagesTask was not documented.

### DIFF
--- a/docs/en/02_Developer_Guides/14_Files/02_Images.md
+++ b/docs/en/02_Developer_Guides/14_Files/02_Images.md
@@ -157,7 +157,11 @@ and whenever you upload or modify an Image through SilverStripe.
 If you encounter problems with images not appearing, or have mysteriously 
 disappeared, you can try manually flushing the image cache.
 
-	http://localhost/dev/tasks/FlushGeneratedImagesTask
+	http://localhost/dev/tasks/RegenerateCachedImagesTask
+
+<div class="notice" markdown="1">
+This task was renamed to `RegenerateCachedImagesTask` (originally `FlushGeneratedImagesTask`) circa SilverStripe 3.2.
+</div>
 
 ## API Documentation
 [api:Image]


### PR DESCRIPTION
This task appears to have been superseded by a new task called `RegenerateCachedImagesTask` but it was not documented, so `FlushGeneratedImagesTask` simply appeared to have vanished. This will update the documentation to reflect this change for both v3.2 and v3.3 (separate PR).