### PR TITLE
Fix Email test issue discovered in #5271.

### DIFF
--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -222,12 +222,6 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 
 		$prefix = defined('SS_DATABASE_PREFIX') ? SS_DATABASE_PREFIX : 'ss_';
 
-		// Set up email
-		$this->originalMailer = Email::mailer();
-		$this->mailer = new TestMailer();
-		Injector::inst()->registerService($this->mailer, 'Mailer');
-		Config::inst()->remove('Email', 'send_all_emails_to');
-
 		// Todo: this could be a special test model
 		$this->model = DataModel::inst();
 
@@ -288,6 +282,12 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 
 		// Clear requirements
 		Requirements::clear();
+
+		// Set up email
+		$this->originalMailer = Email::mailer();
+		$this->mailer = new TestMailer();
+		Injector::inst()->registerService($this->mailer, 'Mailer');
+		Config::inst()->remove('Email', 'send_all_emails_to');
 	}
 
 	/**

--- a/tests/security/MemberTest.php
+++ b/tests/security/MemberTest.php
@@ -185,16 +185,44 @@ class MemberTest extends FunctionalTest {
 	 * Test that changed passwords will send an email
 	 */
 	public function testChangedPasswordEmaling() {
+		$oldSetting = Config::inst()->get('Member', 'notify_password_change');
+		Config::inst()->update('Member', 'notify_password_change', true);
+
 		$this->clearEmails();
 
 		$member = $this->objFromFixture('Member', 'test');
 		$this->assertNotNull($member);
 		$valid = $member->changePassword('32asDF##$$%%');
 		$this->assertTrue($valid->valid());
-		/*
-		$this->assertEmailSent("sam@silverstripe.com", null, "/changed password/",
-		'/sam@silverstripe\.com.*32asDF##\$\$%%/');
-		*/
+
+		$this->assertEmailSent('dummy@silverstripe.tld', null, 'Your password has been changed',
+			'/dummy@silverstripe\.tld/');
+
+		Config::inst()->update('Member', 'notify_password_change', $oldSetting);
+	}
+
+	/**
+	 * Test that triggering "forgotPassword" sends an Email with a reset link
+	 */
+	public function testForgotPasswordEmaling() {
+		$this->clearEmails();
+		$this->autoFollowRedirection = false;
+
+		$member = $this->objFromFixture('Member', 'test');
+		$this->assertNotNull($member);
+
+		// Initiate a password-reset
+		$response = $this->post('Security/LostPasswordForm', array('Email' => $member->Email));
+
+		$this->assertEquals($response->getStatusCode(), 302);
+
+		// We should get redirected to Security/passwordsent
+		$this->assertContains('Security/passwordsent/dummy@silverstripe.tld',
+			urldecode($response->getHeader('Location')));
+
+		// Check existance of reset link
+		$this->assertEmailSent("dummy@silverstripe.tld", null, 'Your password reset link',
+			'/Security\/changepassword\?m='.$member->ID.'&t=[^"]+/');
 	}
 
 	/**

--- a/tests/security/MemberTest.yml
+++ b/tests/security/MemberTest.yml
@@ -42,7 +42,7 @@ Member:
   test:
     FirstName: Test
     Surname: User
-    Email: sam@silverstripe.com
+    Email: dummy@silverstripe.tld
     Password: 1nitialPassword
     PasswordExpiry: 2030-01-01
     Groups: =>Group.securityadminsgroup

--- a/tests/security/SecurityTest.php
+++ b/tests/security/SecurityTest.php
@@ -301,13 +301,13 @@ class SecurityTest extends FunctionalTest {
 	 */
 	public function testExpiredPassword() {
 		/* BAD PASSWORDS ARE LOCKED OUT */
-		$badResponse = $this->doTestLoginForm('sam@silverstripe.com' , 'badpassword');
+		$badResponse = $this->doTestLoginForm('dummy@silverstripe.tld' , 'badpassword');
 		$this->assertEquals(302, $badResponse->getStatusCode());
 		$this->assertRegExp('/Security\/login/', $badResponse->getHeader('Location'));
 		$this->assertNull($this->session()->inst_get('loggedInAs'));
 
 		/* UNEXPIRED PASSWORD GO THROUGH WITHOUT A HITCH */
-		$goodResponse = $this->doTestLoginForm('sam@silverstripe.com' , '1nitialPassword');
+		$goodResponse = $this->doTestLoginForm('dummy@silverstripe.tld' , '1nitialPassword');
 		$this->assertEquals(302, $goodResponse->getStatusCode());
 		$this->assertEquals(
 			Controller::join_links(Director::absoluteBaseURL(), 'test/link'),
@@ -336,7 +336,7 @@ class SecurityTest extends FunctionalTest {
 	}
 
 	public function testChangePasswordForLoggedInUsers() {
-		$goodResponse = $this->doTestLoginForm('sam@silverstripe.com' , '1nitialPassword');
+		$goodResponse = $this->doTestLoginForm('dummy@silverstripe.tld' , '1nitialPassword');
 
 		// Change the password
 		$this->get('Security/changepassword?BackURL=test/back');
@@ -349,7 +349,7 @@ class SecurityTest extends FunctionalTest {
 		$this->assertEquals($this->idFromFixture('Member', 'test'), $this->session()->inst_get('loggedInAs'));
 
 		// Check if we can login with the new password
-		$goodResponse = $this->doTestLoginForm('sam@silverstripe.com' , 'changedPassword');
+		$goodResponse = $this->doTestLoginForm('dummy@silverstripe.tld' , 'changedPassword');
 		$this->assertEquals(302, $goodResponse->getStatusCode());
 		$this->assertEquals(
 			Controller::join_links(Director::absoluteBaseURL(), 'test/link'),
@@ -368,9 +368,9 @@ class SecurityTest extends FunctionalTest {
 
 		// Request new password by email
 		$response = $this->get('Security/lostpassword');
-		$response = $this->post('Security/LostPasswordForm', array('Email' => 'sam@silverstripe.com'));
+		$response = $this->post('Security/LostPasswordForm', array('Email' => 'dummy@silverstripe.tld'));
 
-		$this->assertEmailSent('sam@silverstripe.com');
+		$this->assertEmailSent('dummy@silverstripe.tld');
 
 		// Load password link from email
 		$admin = DataObject::get_by_id('Member', $admin->ID);
@@ -390,7 +390,7 @@ class SecurityTest extends FunctionalTest {
 		$this->assertEquals($this->idFromFixture('Member', 'test'), $this->session()->inst_get('loggedInAs'));
 
 		// Check if we can login with the new password
-		$goodResponse = $this->doTestLoginForm('sam@silverstripe.com' , 'changedPassword');
+		$goodResponse = $this->doTestLoginForm('dummy@silverstripe.tld' , 'changedPassword');
 		$this->assertEquals(302, $goodResponse->getStatusCode());
 		$this->assertEquals($this->idFromFixture('Member', 'test'), $this->session()->inst_get('loggedInAs'));
 
@@ -408,7 +408,7 @@ class SecurityTest extends FunctionalTest {
 
 		// Login with a wrong password for more than the defined threshold
 		for($i = 1; $i <= Member::config()->lock_out_after_incorrect_logins+1; $i++) {
-			$this->doTestLoginForm('sam@silverstripe.com' , 'incorrectpassword');
+			$this->doTestLoginForm('dummy@silverstripe.tld' , 'incorrectpassword');
 			$member = DataObject::get_by_id("Member", $this->idFromFixture('Member', 'test'));
 
 			if($i < Member::config()->lock_out_after_incorrect_logins) {
@@ -438,7 +438,7 @@ class SecurityTest extends FunctionalTest {
 			}
 		}
 
-		$this->doTestLoginForm('sam@silverstripe.com' , '1nitialPassword');
+		$this->doTestLoginForm('dummy@silverstripe.tld' , '1nitialPassword');
 		$this->assertNull(
 			$this->session()->inst_get('loggedInAs'),
 			'The user can\'t log in after being locked out, even with the right password'
@@ -448,7 +448,7 @@ class SecurityTest extends FunctionalTest {
 		$member = DataObject::get_by_id("Member", $this->idFromFixture('Member', 'test'));
 		$member->LockedOutUntil = date('Y-m-d H:i:s', time() - 30);
 		$member->write();
-		$this->doTestLoginForm('sam@silverstripe.com' , '1nitialPassword');
+		$this->doTestLoginForm('dummy@silverstripe.tld' , '1nitialPassword');
 		$this->assertEquals(
 			$this->session()->inst_get('loggedInAs'),
 			$member->ID,
@@ -460,7 +460,7 @@ class SecurityTest extends FunctionalTest {
 
 		// Login again with wrong password, but less attempts than threshold
 		for($i = 1; $i < Member::config()->lock_out_after_incorrect_logins; $i++) {
-			$this->doTestLoginForm('sam@silverstripe.com' , 'incorrectpassword');
+			$this->doTestLoginForm('dummy@silverstripe.tld' , 'incorrectpassword');
 		}
 		$this->assertNull($this->session()->inst_get('loggedInAs'));
 		$this->assertContains(
@@ -469,7 +469,7 @@ class SecurityTest extends FunctionalTest {
 			'The user can retry with a wrong password after the lockout expires'
 		);
 
-		$this->doTestLoginForm('sam@silverstripe.com' , '1nitialPassword');
+		$this->doTestLoginForm('dummy@silverstripe.tld' , '1nitialPassword');
 		$this->assertEquals(
 			$this->session()->inst_get('loggedInAs'),
 			$member->ID,
@@ -484,8 +484,8 @@ class SecurityTest extends FunctionalTest {
 
 		// ATTEMPTING LOG-IN TWICE WITH ONE ACCOUNT AND TWICE WITH ANOTHER SHOULDN'T LOCK ANYBODY OUT
 
-		$this->doTestLoginForm('sam@silverstripe.com' , 'incorrectpassword');
-		$this->doTestLoginForm('sam@silverstripe.com' , 'incorrectpassword');
+		$this->doTestLoginForm('dummy@silverstripe.tld' , 'incorrectpassword');
+		$this->doTestLoginForm('dummy@silverstripe.tld' , 'incorrectpassword');
 
 		$this->doTestLoginForm('noexpiry@silverstripe.com' , 'incorrectpassword');
 		$this->doTestLoginForm('noexpiry@silverstripe.com' , 'incorrectpassword');
@@ -499,7 +499,7 @@ class SecurityTest extends FunctionalTest {
 		// BUT, DOING AN ADDITIONAL LOG-IN WITH EITHER OF THEM WILL LOCK OUT, SINCE THAT IS THE 3RD FAILURE IN
 		// THIS SESSION
 
-		$this->doTestLoginForm('sam@silverstripe.com' , 'incorrectpassword');
+		$this->doTestLoginForm('dummy@silverstripe.tld' , 'incorrectpassword');
 		$member1 = DataObject::get_by_id("Member", $this->idFromFixture('Member', 'test'));
 		$this->assertNotNull($member1->LockedOutUntil);
 
@@ -512,16 +512,16 @@ class SecurityTest extends FunctionalTest {
 		Security::config()->login_recording = true;
 
 		/* UNSUCCESSFUL ATTEMPTS WITH WRONG PASSWORD FOR EXISTING USER ARE LOGGED */
-		$this->doTestLoginForm('sam@silverstripe.com', 'wrongpassword');
+		$this->doTestLoginForm('dummy@silverstripe.tld', 'wrongpassword');
 		$attempt = DataObject::get_one('LoginAttempt', array(
-			'"LoginAttempt"."Email"' => 'sam@silverstripe.com'
+			'"LoginAttempt"."Email"' => 'dummy@silverstripe.tld'
 		));
 		$this->assertTrue(is_object($attempt));
 		$member = DataObject::get_one('Member', array(
-			'"Member"."Email"' => 'sam@silverstripe.com'
+			'"Member"."Email"' => 'dummy@silverstripe.tld'
 		));
 		$this->assertEquals($attempt->Status, 'Failure');
-		$this->assertEquals($attempt->Email, 'sam@silverstripe.com');
+		$this->assertEquals($attempt->Email, 'dummy@silverstripe.tld');
 		$this->assertEquals($attempt->Member(), $member);
 
 		/* UNSUCCESSFUL ATTEMPTS WITH NONEXISTING USER ARE LOGGED */
@@ -541,16 +541,16 @@ class SecurityTest extends FunctionalTest {
 		Security::config()->login_recording = true;
 
 		/* SUCCESSFUL ATTEMPTS ARE LOGGED */
-		$this->doTestLoginForm('sam@silverstripe.com', '1nitialPassword');
+		$this->doTestLoginForm('dummy@silverstripe.tld', '1nitialPassword');
 		$attempt = DataObject::get_one('LoginAttempt', array(
-			'"LoginAttempt"."Email"' => 'sam@silverstripe.com'
+			'"LoginAttempt"."Email"' => 'dummy@silverstripe.tld'
 		));
 		$member = DataObject::get_one('Member', array(
-			'"Member"."Email"' => 'sam@silverstripe.com'
+			'"Member"."Email"' => 'dummy@silverstripe.tld'
 		));
 		$this->assertTrue(is_object($attempt));
 		$this->assertEquals($attempt->Status, 'Success');
-		$this->assertEquals($attempt->Email, 'sam@silverstripe.com');
+		$this->assertEquals($attempt->Email, 'dummy@silverstripe.tld');
 		$this->assertEquals($attempt->Member(), $member);
 	}
 


### PR DESCRIPTION
Updated/added tests for changed- and forgot-password Emails.
Updated fixture and tests to no longer use a real Email address.