### PR TITLE
MINOR: Add “npm run add-git-hooks” action.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@ docs/                 export-ignore
 javascript/src/       export ignore
 
 # Hide diffs
-admin/javascript/dist/ -diff
-javascript/dist/ -diff
-admin/javascript/css/* -diff
-javascript/css/* -diff
+admin/javascript/dist/ -diff merge=ours
+javascript/dist/ -diff merge=ours
+admin/javascript/css/* -diff merge=ours
+javascript/css/* -diff merge=ours

--- a/.githooks/post-rewrite/rebuild-files.sh
+++ b/.githooks/post-rewrite/rebuild-files.sh
@@ -1,0 +1,9 @@
+if [[ $1 = "rebase" ]]; then
+    echo "\nRebuiling compiled files post $1..."
+
+    npm run build
+
+    echo "Adding built files to the last commit"
+    git add -u
+    git commit --amend --no-edit
+fi

--- a/.githooks/pre-commit/check-built-files.sh
+++ b/.githooks/pre-commit/check-built-files.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Check for built files, and yell at user if not
+
+# Find source files that are marked as modified
+sources=`git status -s | grep 'M.*javascript\/src\/.*'`
+
+# Find built files that have changed (we don't use M because they could be deleted, etc)
+built=`git status -s | grep '^M.*javascript\/dist'`
+
+# If source files have changed, but not built files, block the commit
+if [ -n "$sources" ] &&  [ -z "$built" ]; then
+    echo "
+ERROR: CAN'T COMMIT
+===================
+Build the files using 'npm run build' and add the dist files to the commit,
+before committing your change.
+"
+    exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "NODE_PATH=\"./javascript/src:./admin/javascript/src\" jest",
     "coverage": "NODE_PATH=\"./javascript/src:./admin/javascript/src\" jest --coverage",
     "thirdparty": "gulp thirdparty",
-    "lint": "eslint gulpfile.js & eslint javascript/src & eslint admin/javascript/src"
+    "lint": "eslint gulpfile.js & eslint javascript/src & eslint admin/javascript/src",
+    "add-git-hooks": "./node_modules/.bin/git-hooks --install; git config merge.ours.driver true"
   },
   "repository": {
     "type": "git",
@@ -70,6 +71,7 @@
     "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-react": "^4.2.3",
     "event-stream": "^3.3.2",
+    "git-hooks": "^1.0.2",
     "glob": "^6.0.4",
     "gulp": "^3.9.0",
     "gulp-babel": "^6.1.1",


### PR DESCRIPTION
This commit add an "npm run add-git-hooks" command that will configure
an environment's git hooks and config file to support the development
conventions that we set out.

It's based on recommendations from this post:
http://blog.andrewray.me/dealing-with-compiled-files-in-git/

More git hooks can be added to .githooks

To do:
- [ ] Test what happens when the merge failures happen without the git config
- [ ] Test what happens when you a conflicting non-rebase merge happens
- [ ] Add docs to `en/05_Contributing/01_Code.md#npm`
- [ ] Add checks for SCSS files
