### PR TITLE
no one writes as "한국어(韓國語)"  when referring to korean language

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -840,7 +840,7 @@ class i18n extends Object implements TemplateGlobalProvider, Flushable {
 		),
 		'ko' => array(
 			'name' => 'Korean',
-			'native' => '&#54620;&#44397;&#50612; [&#38867;&#22283;&#35486;]'
+			'native' => '&#54620;&#44397;&#50612;'
 		),
 		'ku' => array(
 			'name' => 'Kurdish',


### PR DESCRIPTION
so remove the chinese characters – "한국어(韓國語)" looks like
"English(anglicus)". Korean youth probably don't even know the meaning
of the chinese.