### PR TITLE
Enhance GD::greyscale to allow darker or lighter results

### DIFF
--- a/tests/filesystem/GDTest.php
+++ b/tests/filesystem/GDTest.php
@@ -91,8 +91,8 @@ class GDTest extends SapphireTest {
 		}
 
 		// check various sample points
-		$this->assertColourEquals(96, $samples[0]['red'], $tolerance);
-		$this->assertColourEquals(91, $samples[2]['red'], $tolerance);
+		$this->assertColourEquals(76, $samples[0]['red'], $tolerance);
+		$this->assertColourEquals(149, $samples[2]['red'], $tolerance);
 		$this->assertColourEquals(0, $samples[8]['red'], $tolerance);
 		$this->assertColourEquals(127, $samples[9]['red'], $tolerance);
 


### PR DESCRIPTION
Tweaking the first three parameters (R, G, B) allows you to get a different mix of colors into grey, but it does not allow you to make the result lighter or darker because their total is normalized. This is quite a common operation on greyscaled images though, so I added a fourth parameter: brightness. It defaults to 100% so that it does not have any effect when not used (making this backwards compatible). $brightness = 50 will make it darker, $brithgness = 150 will overlight it.

By the way, please note that the default R, G, B values for the current greyscale function are very wrong, but I didn't dare change that because that would cause images to come out differently than before... It just makes no sense though in *any* scheme to allocate more weight to red than to green! A better scheme would be this common one: 30, 59, 11 -- or more accurately (why not) 299, 587, 114. Just as a note; I'd be happy to add this as a change of course, but assume I shouldn't.