### PR TITLE
FIX: service class name definitions incorrectly inherited by subclasses (fixes #4774)

### DIFF
--- a/control/injector/SilverStripeServiceConfigurationLocator.php
+++ b/control/injector/SilverStripeServiceConfigurationLocator.php
@@ -33,6 +33,12 @@ class SilverStripeServiceConfigurationLocator extends ServiceConfigurationLocato
 				// have we already got for this?
 				$config = $this->configFor($parent);
 				if($config !== null) {
+					// Class name should not be inherited: attempting to instantiate a child class
+					// should never result in the parent class being created
+					if (isset($config['class'])) {
+						$config['class'] = $name;
+					}
+
 					// Cache this result
 					$this->configs[$name] = $config;
 					return $config;


### PR DESCRIPTION
Fix for #4774. I’m not sure whether the config locator should actually be aware of/care about what’s *in* the config it finds, but it seemed like the cleanest place to put this. If we put it here, we _know_ that the config that was found was inherited from a parent class - if we move it elsewhere then we have no way of knowing that.

I also figured that `class` is the only key of the config definition that shouldn’t be inherited - everything else makes sense when inherited afaict. 

Ping @tractorcow. Also pinging others who I can spot in the blame view for `Injector` for their input: @hafriedlander @nyeholt @chillu.