### PR TITLE
API Remove artifact datalist overrides from UnsavedRelationList

### DIFF
--- a/model/UnsavedRelationList.php
+++ b/model/UnsavedRelationList.php
@@ -11,8 +11,6 @@
  * of $dataClass). Unsaved objects are then written when the list is saved
  * into an instance of {@link RelationList}.
  *
- * Most methods that alter the list of objects throw LogicExceptions.
- *
  * @package framework
  * @subpackage model
  */
@@ -49,6 +47,8 @@ class UnsavedRelationList extends ArrayList {
 	/**
 	 * Create a new UnsavedRelationList
 	 *
+	 * @param array $baseClass
+	 * @param string $relationName
 	 * @param string $dataClass The DataObject class used in the relation
 	 */
 	public function __construct($baseClass, $relationName, $dataClass) {
@@ -61,7 +61,8 @@ class UnsavedRelationList extends ArrayList {
 	/**
 	 * Add an item to this relationship
 	 *
-	 * @param $extraFields A map of additional columns to insert into the joinTable in the case of a many_many relation
+	 * @param mixed $item
+	 * @param array $extraFields A map of additional columns to insert into the joinTable in the case of a many_many relation
 	 */
 	public function add($item, $extraFields = null) {
 		$this->push($item, $extraFields);
@@ -85,6 +86,7 @@ class UnsavedRelationList extends ArrayList {
 	 * Pushes an item onto the end of this list.
 	 *
 	 * @param array|object $item
+	 * @param array $extraFields
 	 */
 	public function push($item, $extraFields = null) {
 		if((is_object($item) && !$item instanceof $this->dataClass)
@@ -153,6 +155,9 @@ class UnsavedRelationList extends ArrayList {
 
 	/**
 	 * Returns true if the given column can be used to filter the records.
+	 *
+	 * @param string $by
+	 * @return bool
 	 */
 	public function canFilterBy($by) {
 		return false;
@@ -161,6 +166,9 @@ class UnsavedRelationList extends ArrayList {
 
 	/**
 	 * Returns true if the given column can be used to sort the records.
+	 *
+	 * @param string $by
+	 * @return bool
 	 */
 	public function canSortBy($by) {
 		return false;
@@ -177,7 +185,8 @@ class UnsavedRelationList extends ArrayList {
 	/**
 	 * Remove the items from this list with the given IDs
 	 *
-	 * @param array $idList
+	 * @param array $items
+	 * @return $this
 	 */
 	public function removeMany($items) {
 		$this->items = array_diff($this->items, $items);
@@ -268,7 +277,7 @@ class UnsavedRelationList extends ArrayList {
 
 	/**
 	 * Returns a copy of this list with the relationship linked to the given foreign ID.
-	 * @param $id An ID or an array of IDs.
+	 * @param int|array $id An ID or an array of IDs.
 	 */
 	public function forForeignID($id) {
 		$class = singleton($this->baseClass);
@@ -285,160 +294,4 @@ class UnsavedRelationList extends ArrayList {
 	public function dbObject($fieldName) {
 		return singleton($this->dataClass)->dbObject($fieldName);
 	}
-
-	/**#@+
-	 * Prevents calling DataList methods that rely on the objects being saved
-	 */
-	public function addFilter() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function alterDataQuery() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function avg() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function byIDs() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function byID($id) {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function dataQuery() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function exclude() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function filter() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function getRange($offset, $length) {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function getRelationName() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function innerJoin() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function insertFirst() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function join() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function leftJoin() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function limit($length, $offset = 0) {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function map($keyField = 'ID', $titleField = 'Title') {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function max() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function merge($with) {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function min() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function newObject() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function offsetExists($offset) {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function offsetGet($offset) {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function offsetSet($offset, $value) {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function offsetUnset($offset) {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function pop() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function relation() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function removeByFilter() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function removeByID() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function reverse() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function setDataModel() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function setDataQuery() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function setQueriedColumns() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function shift() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function sql() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function subtract() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function sum() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function unshift($item) {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-
-	public function where() {
-		throw new LogicException(__FUNCTION__ . " can't be called on an UnsavedRelationList.");
-	}
-	/**#@-*/
 }


### PR DESCRIPTION
These only existed because this class used to extend DataList.

This brings the API in line with the current status in 4.0.

Fixes https://github.com/silverstripe/silverstripe-widgets/issues/123, and probably lots of other issues.