### PR TITLE
FIX: Hierarchy was incorrectly unexpanding nodes that were previously expanded

### DIFF
--- a/model/Hierarchy.php
+++ b/model/Hierarchy.php
@@ -315,7 +315,8 @@ class Hierarchy extends DataExtension {
 			foreach($children as $child) {
 				$markingMatches = $this->markingFilterMatches($child);
 				if($markingMatches) {
-					if($child->$numChildrenMethod()) {
+					// Mark a child node as unexpanded if it has children and has not already been expanded
+					if($child->$numChildrenMethod() && !$child->isExpanded()) {
 						$child->markUnexpanded();
 					} else {
 						$child->markExpanded();

--- a/tests/model/HierarchyTest.php
+++ b/tests/model/HierarchyTest.php
@@ -61,12 +61,12 @@ class HierarchyTest extends SapphireTest {
 		// Obj 3 has been deleted; let's bring it back from the grave
 		$obj3 = Versioned::get_including_deleted("HierarchyTest_Object", "\"Title\" = 'Obj 3'")->First();
 
-		// Check that both obj 3 children are returned
-		$this->assertEquals(array("Obj 3a", "Obj 3b", "Obj 3c"),
+		// Check that all obj 3 children are returned
+		$this->assertEquals(array("Obj 3a", "Obj 3b", "Obj 3c", "Obj 3d"),
 			$obj3->AllHistoricalChildren()->column('Title'));
 
 		// Check numHistoricalChildren
-		$this->assertEquals(3, $obj3->numHistoricalChildren());
+		$this->assertEquals(4, $obj3->numHistoricalChildren());
 
 	}
 
@@ -96,11 +96,11 @@ class HierarchyTest extends SapphireTest {
 	public function testNumChildren() {
 		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj1')->numChildren(), 0);
 		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj2')->numChildren(), 2);
-		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj3')->numChildren(), 3);
+		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj3')->numChildren(), 4);
 		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj2a')->numChildren(), 2);
 		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj2b')->numChildren(), 0);
 		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj3a')->numChildren(), 2);
-		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj3b')->numChildren(), 0);
+		$this->assertEquals($this->objFromFixture('HierarchyTest_Object', 'obj3d')->numChildren(), 0);
 
 		$obj1 = $this->objFromFixture('HierarchyTest_Object', 'obj1');
 		$this->assertEquals($obj1->numChildren(), 0);
@@ -180,6 +180,53 @@ class HierarchyTest extends SapphireTest {
 		$this->assertEquals('Obj 1', $obj1->getBreadcrumbs());
 		$this->assertEquals('Obj 2 &raquo; Obj 2a', $obj2a->getBreadcrumbs());
 		$this->assertEquals('Obj 2 &raquo; Obj 2a &raquo; Obj 2aa', $obj2aa->getBreadcrumbs());
+	}
+
+	/**
+	 * @covers Hierarchy::markChildren()
+	 */
+	public function testMarkChildrenDoesntUnmarkPreviouslyMarked() {
+		$obj3 = $this->objFromFixture('HierarchyTest_Object', 'obj3');
+		$obj3aa = $this->objFromFixture('HierarchyTest_Object', 'obj3aa');
+		$obj3ba = $this->objFromFixture('HierarchyTest_Object', 'obj3ba');
+		$obj3ca = $this->objFromFixture('HierarchyTest_Object', 'obj3ca');
+
+		$obj3->markPartialTree();
+		$obj3->markToExpose($obj3aa);
+		$obj3->markToExpose($obj3ba);
+		$obj3->markToExpose($obj3ca);
+
+		$expected = <<<EOT
+<ul>
+<li>Obj 3a
+<ul>
+<li>Obj 3aa
+</li>
+<li>Obj 3ab
+</li>
+</ul>
+</li>
+<li>Obj 3b
+<ul>
+<li>Obj 3ba
+</li>
+<li>Obj 3bb
+</li>
+</ul>
+</li>
+<li>Obj 3c
+<ul>
+<li>Obj 3c
+</li>
+</ul>
+</li>
+<li>Obj 3d
+</li>
+</ul>
+
+EOT;
+
+		$this->assertSame($expected, $obj3->getChildrenAsUL());
 	}
 
 	public function testGetChildrenAsUL() {
@@ -569,6 +616,8 @@ class HierarchyTest_Object extends DataObject implements TestOnly {
 		'Hierarchy',
 		"Versioned('Stage', 'Live')",
 	);
+
+	private static $default_sort = 'Title ASC';
 
 	public function cmstreeclasses() {
 		return $this->markingClasses();

--- a/tests/model/HierarchyTest.yml
+++ b/tests/model/HierarchyTest.yml
@@ -20,6 +20,9 @@ HierarchyTest_Object:
    obj3c:
       Parent: =>HierarchyTest_Object.obj3
       Title: Obj 3c
+   obj3d:
+      Parent: =>HierarchyTest_Object.obj3
+      Title: Obj 3d
    obj2aa:
       Parent: =>HierarchyTest_Object.obj2a
       Title: Obj 2aa
@@ -32,6 +35,15 @@ HierarchyTest_Object:
    obj3ab:
       Parent: =>HierarchyTest_Object.obj3a
       Title: Obj 3ab
+   obj3ba:
+      Parent: =>HierarchyTest_Object.obj3b
+      Title: Obj 3ba
+   obj3bb:
+      Parent: =>HierarchyTest_Object.obj3b
+      Title: Obj 3bb
+   obj3ca:
+      Parent: =>HierarchyTest_Object.obj3c
+      Title: Obj 3c
 
 HierarchyHideTest_Object:
    obj4:


### PR DESCRIPTION
Given the following structure with a TreeMultiselectField:
![image](https://cloud.githubusercontent.com/assets/893117/14658947/dc51c780-06eb-11e6-8dbd-81e8b9f65705.png)

If this is saved and then you re-open the tree, you'll see the following bug:
![screencast-2016-04-20 11-35-39-f1dv2](https://cloud.githubusercontent.com/assets/893117/14659135/379d51da-06ed-11e6-80f5-dc685786a5a0.gif)

Opening the tree marks the field as dirty, and if you save the object it will remove the relations that are no longer ticked (`Grandchild 1` and `Grandchild 2` in this case).

This is due to a problem in `Hierarchy` when it recurses through nodes to find ones that need to be marked for inclusion when generating the tree structure. It correctly marks `Child 1` to be expanded, but then when it marks `Child 2`, it marks `Child 1` as not expanded but having children (this also explains the less serious bug with the arrow pointing down when it shouldn't).

XHProf comparison before and after shows it doesn't appear to recurse any further than it did previously.

Changes to other tests aren't because of this bug, but just because I had to add more children/grandchildren to confirm the bug is fixed.