### PR TITLE
Fix Chosen.js selector for Behat feature

### DIFF
--- a/tests/behat/features/bootstrap/SilverStripe/Framework/Test/Behaviour/CmsUiContext.php
+++ b/tests/behat/features/bootstrap/SilverStripe/Framework/Test/Behaviour/CmsUiContext.php
@@ -490,7 +490,7 @@ class CmsUiContext extends BehatContext {
 		assertNotNull($container, 'Chosen.js field container not found');
 
 		// Click on newly expanded list element, indirectly setting the dropdown value
-		$linkEl = $container->find('xpath', './/a[./@href]');
+		$linkEl = $container->find('xpath', './/a');
 		assertNotNull($linkEl, 'Chosen.js link element not found');
 		$this->getSession()->wait(100); // wait for dropdown overlay to appear
 		$linkEl->click();


### PR DESCRIPTION
The recent upgrade to Chosen.js 1.5 changes the generated markup:
It still renders an <a> tag, but without the "href" attribute.
This attribute isn't actually required to uniquely identify
the link in this structure.

See https://travis-ci.org/silverstripe/silverstripe-cms/jobs/124050257

/cc @hafriedlander