### PR TITLE
FIX #5363 Add .JSON option for templates

### DIFF
--- a/model/fieldtypes/DBField.php
+++ b/model/fieldtypes/DBField.php
@@ -244,6 +244,14 @@ abstract class DBField extends ViewableData {
 		return Convert::raw2js($this->value);
 	}
 
+	/**
+	 * Return JSON encoded value
+	 * @return string
+	 */
+	public function JSON() {
+		return Convert::raw2json($this->value);
+	}
+
 	public function HTML(){
 		return Convert::raw2xml($this->value);
 	}


### PR DESCRIPTION
Resolves #5363 - adding the ability to format a field's value as JSON from a template, not just as Javascript