### PR TITLE
FIX Admin bloacklisted messages using correct $.inArray check

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -150,7 +150,7 @@ jQuery.noConflict();
 			}
 
 			// Show message (but ignore aborted requests)
-			if(xhr.status !== 0 && msg && $.inArray(msg, ignoredMessages)) {
+			if(xhr.status !== 0 && msg && $.inArray(msg, ignoredMessages) != -1) {
 				// Decode into UTF-8, HTTP headers don't allow multibyte
 				statusMessage(decodeURIComponent(msg), msgType);
 			}


### PR DESCRIPTION
See discussion #5312 

The $.inArray returns the index of the found item and `-1` if there is no match.