### PR TITLE
Remove invalid attributes

### DIFF
--- a/forms/HeaderField.php
+++ b/forms/HeaderField.php
@@ -72,6 +72,8 @@ class HeaderField extends DatalessField {
 			array(
 				'id' => $this->ID(),
 				'class' => $this->extraClass(),
+				'type' => null,
+				'name' => null
 			)
 		);
 	}


### PR DESCRIPTION
Headers do not have `type` & `name` attributes which are being inherited from the extended classes.