### PR TITLE
FIX for #5410 to help focus errors occuring on tabs within GridField controlled DataObjects (et al).

### DIFF
--- a/admin/javascript/LeftAndMain.EditForm.js
+++ b/admin/javascript/LeftAndMain.EditForm.js
@@ -46,6 +46,14 @@
 			ChangeTrackerOptions: {
 				ignoreFieldSelector: '.no-change-track, .ss-upload :input, .cms-navigator :input'
 			},
+
+			/**
+			 * Variable: ValidationErrorShown
+			 * Boolean for tracking whether a validation error has been already been shown. Used because tabs can
+			 * sometimes be inadvertently initialised multiple times, but we don't want duplicate messages
+			 * (Boolean)
+			 */
+			ValidationErrorShown: false,
 		
 			/**
 			 * Constructor: onmatch
@@ -77,22 +85,43 @@
 					}
 				}
 
+				// Reset error display
+				this.setValidationErrorShown(false);
+
 				// TODO
 				// // Rewrite # links
 				// html = html.replace(/(<a[^>]+href *= *")#/g, '$1' + window.location.href.replace(/#.*$/,'') + '#');
 				// 
 				// // Rewrite iframe links (for IE)
 				// html = html.replace(/(<iframe[^>]*src=")([^"]+)("[^>]*>)/g, '$1' + $('base').attr('href') + '$2$3');
-				
-				// Show validation errors if necessary
-				if(this.hasClass('validationerror')) {
-					// Ensure the first validation error is visible
-					var tabError = this.find('.message.validation, .message.required').first().closest('.tab');
-					$('.cms-container').clearCurrentTabState(); // clear state to avoid override later on
-					tabError.closest('.ss-tabset').tabs('option', 'active', tabError.index('.tab'));
-				}
 
 				this._super();
+			},
+			'from .cms-tabset': {
+				onafterredrawtabs: function () {
+					// Show validation errors if necessary
+					if(this.hasClass('validationerror')) {
+						// Ensure the first validation error is visible
+						var tabError = this.find('.message.validation, .message.required').first().closest('.tab');
+						$('.cms-container').clearCurrentTabState(); // clear state to avoid override later on
+
+						// Attempt #1: Look for nearest .ss-tabset (usually nested deeper underneath a .cms-tabset).
+						var $tabSet = tabError.closest('.ss-tabset');
+
+						// Attempt #2: Next level in tab-ception, try to select the tab within this higher level .cms-tabset if possible
+						if (!$tabSet.length) {
+							$tabSet = tabError.closest('.cms-tabset');
+						}
+
+						if ($tabSet.length) {
+							$tabSet.tabs('option', 'active', tabError.index('.tab'));
+						} else if (!this.getValidationErrorShown()) {
+							// Ensure that this error message popup won't be added more than once
+							this.setValidationErrorShown(true);
+							errorMessage(ss.i18n._t('ModelAdmin.VALIDATIONERROR', 'Validation Error'));
+						}
+					}
+				}
 			},
 			onremove: function() {
 				this.changetracker('destroy');

--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -1450,6 +1450,8 @@ jQuery.noConflict();
 						}
 					}
 				});
+
+				this.trigger('afterredrawtabs');
 			},
 
 			/**


### PR DESCRIPTION
Initial proof of concept to demonstrate a solution for #5410 for a regression that I believe was caused by PR #2397. By no means final in it's current state.

Some sort of recursive solution may be required, as mentioned in aforementioned issue. Also, using `setTimeout()` like this is obviously not a good idea. Anyone have a better solution? Maybe @wilr or @chillu? Since I know you both chimed in on PR #2397.