### PR TITLE
API LeftAndMain::menu_title can be overridden

### DIFF
--- a/admin/code/CMSMenu.php
+++ b/admin/code/CMSMenu.php
@@ -79,8 +79,7 @@ class CMSMenu extends Object implements IteratorAggregate, i18nEntityProvider {
 		// doesn't work if called outside of a controller context (e.g. in _config.php)
 		// as the locale won't be detected properly. Use {@link LeftAndMain->MainMenu()} to update
 		// titles for existing menu entries
-		$defaultTitle = LeftAndMain::menu_title_for_class($controllerClass);
-		$menuTitle = _t("{$controllerClass}.MENUTITLE", $defaultTitle);
+		$menuTitle = LeftAndMain::menu_title($controllerClass);
 
 		return new CMSMenuItem($menuTitle, $link, $controllerClass, $menuPriority);
 	}
@@ -335,7 +334,7 @@ class CMSMenu extends Object implements IteratorAggregate, i18nEntityProvider {
 		$cmsClasses = self::get_cms_classes();
 		$entities = array();
 		foreach($cmsClasses as $cmsClass) {
-			$defaultTitle = LeftAndMain::menu_title_for_class($cmsClass);
+			$defaultTitle = LeftAndMain::menu_title($cmsClass, false);
 			$ownerModule = i18n::get_owner_module($cmsClass);
 			$entities["{$cmsClass}.MENUTITLE"] = array($defaultTitle, 'Menu title', $ownerModule);
 		}

--- a/admin/code/SecurityAdmin.php
+++ b/admin/code/SecurityAdmin.php
@@ -297,7 +297,7 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider {
 	}
 
 	public function providePermissions() {
-		$title = _t("SecurityAdmin.MENUTITLE", LeftAndMain::menu_title_for_class($this->class));
+		$title = $this->menu_title();
 		return array(
 			"CMS_ACCESS_SecurityAdmin" => array(
 				'name' => _t('CMSMain.ACCESS', "Access to '{title}' section", array('title' => $title)),

--- a/admin/tests/CMSMenuTest.php
+++ b/admin/tests/CMSMenuTest.php
@@ -25,6 +25,14 @@ class CMSMenuTest extends SapphireTest implements TestOnly {
 			'Controller menu item has the correct priority');
 		CMSMenu::clear_menu();
 
+		// Add another controller
+		CMSMenu::add_controller('CMSMenuTest_CustomTitle');
+		$menuItems = CMSMenu::get_menu_items();
+		$menuItem = $menuItems['CMSMenuTest_CustomTitle'];
+		$this->assertInstanceOf('CMSMenuItem', $menuItem, 'Controller menu item is of class CMSMenuItem');
+		$this->assertEquals('CMSMenuTest_CustomTitle (localised)', $menuItem->title);
+		CMSMenu::clear_menu();
+
 		// Add a link to the menu
 		CMSMenu::add_link('LinkCode', 'link title', 'http://www.example.com');
 		$menuItems = CMSMenu::get_menu_items();
@@ -106,4 +114,19 @@ class CMSMenuTest_LeftAndMainController extends LeftAndMain implements TestOnly 
 	private static $menu_title = 'CMSMenuTest_LeftAndMainController';
 
 	private static $menu_priority = 50;
+}
+
+class CMSMenuTest_CustomTitle extends LeftAndMain implements TestOnly {
+
+	private static $url_segment = 'CMSMenuTest_CustomTitle';
+
+	private static $menu_priority = 50;
+
+	public static function menu_title($class = null, $localised = false) {
+		if($localised) {
+			return __CLASS__ . ' (localised)';
+		} else {
+			return __CLASS__ . ' (unlocalised)';
+		}
+	}
 }


### PR DESCRIPTION
Solves https://github.com/silverstripe/silverstripe-asset-admin/pull/119 without forcing master transifex strings to need to be changed.

Actual fix is at https://github.com/silverstripe/silverstripe-cms/pull/1467, which relies on this framework API being merged first.