### PR TITLE
NEW: check changed state text fields on keyup, rather than just change

### DIFF
--- a/admin/javascript/LeftAndMain.EditForm.js
+++ b/admin/javascript/LeftAndMain.EditForm.js
@@ -44,7 +44,12 @@
 			 * (Object)
 			 */
 			ChangeTrackerOptions: {
-				ignoreFieldSelector: '.no-change-track, .ss-upload :input, .cms-navigator :input'
+				ignoreFieldSelector: '.no-change-track, .ss-upload :input, .cms-navigator :input',
+				customChangeEvents: {
+					// Use the "input" event so both keyboard and right-click paste inputs are captured
+					'input[type=text]': 'input.changetracker change.changetracker',
+					'textarea': 'input.changetracker change.changetracker'
+				}
 			},
 
 			/**

--- a/admin/javascript/jquery-changetracker/lib/jquery.changetracker.js
+++ b/admin/javascript/jquery-changetracker/lib/jquery.changetracker.js
@@ -46,7 +46,8 @@
 		this.defaults = {
 			fieldSelector: ':input:not(:submit)',
 			ignoreFieldSelector: "",
-			changedCssClass: 'changed'
+			changedCssClass: 'changed',
+			customChangeEvents: {}
 		};
 
 		var options = $.extend({}, this.defaults, _options);
@@ -88,9 +89,31 @@
 
 			// setup original values
 			var fields = this.getFields(), origVal;
-			fields.filter(':radio,:checkbox').bind('click.changetracker', onchange);
-			fields.not(':radio,:checkbox').bind('change.changetracker', onchange);
+
+			// omit radio buttons and checkboxes, along with any other selectors that have a custom change event
+			var omittedSelectors = [':radio', ':checkbox']
+				.concat($.map(options, function(key, val) {
+					if(typeof key === 'string') return key;
+				}))
+				.join(',');
+
+			fields.filter(omittedSelectors).on('click.changetracker', onchange);
+			fields.not(omittedSelectors).on('change.changetracker', onchange);
+			
+			// Handle omitted selectors
 			fields.each(function() {
+				// For selectors with custom change events
+				for(var selector in options.customChangeEvents) {
+					var eventName;
+					if(options.customChangeEvents.hasOwnProperty(selector)) {
+						eventName = options.customChangeEvents[selector];
+						if($(this).is(selector)) {
+							$(this).on(eventName, onchange);
+						}
+					}					
+				}
+
+				// For radio and checkbox
 				if($(this).is(':radio,:checkbox')) {
 					origVal = self.find(':input[name=' + $(this).attr('name') + ']:checked').val();
 				} else {
@@ -109,10 +132,10 @@
 
 		this.destroy = function() {
 			this.getFields()
-				.unbind('.changetracker')
+				.off('.changetracker')
 				.removeClass(options.changedCssClass)
 				.removeData('changetracker.origVal');
-			this.unbind('.changetracker')
+			this.off('.changetracker')
 				.removeData('changetracker');
 		};
 

--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -106,14 +106,27 @@ ss.editorWrappers.tinyMCE = (function() {
 					});
 				}
 			});
-			this.instance.onChange.add(function(ed, l) {
-				// Update underlying textarea on every change, so external handlers
-				// such as changetracker have a chance to trigger properly.
-				ed.save();
-				jQuery(ed.getElement()).trigger('change');
-			});
-			// Add more events here as needed.
+			
+			var changeHandler = function(wait) {
+				var timeoutID;
+				return function(ed) {
+					var context = this, args = arguments;
+					var later = function() {
+						timeoutID = null;
+						ed.save();
+						jQuery(ed.getElement()).trigger('change');
+					};					
+					clearTimeout(timeoutID);
+					timeoutID = setTimeout(later, wait);
+				};
+			};	
 
+			// Update underlying textarea on every change, so external handlers
+			// such as changetracker have a chance to trigger properly.
+			this.instance.onKeyUp.add(changeHandler(250));			
+			
+			// Add more events here as needed.
+			
 			this.instance.render();
 		},
 		/**


### PR DESCRIPTION
This is a continuation of an old PR https://github.com/silverstripe/silverstripe-framework/pull/3592 but against the newer branch.
