### PR TITLE
API Injector dependencies no longer inherit from parent classes

### DIFF
--- a/docs/en/02_Developer_Guides/05_Extending/05_Injector.md
+++ b/docs/en/02_Developer_Guides/05_Extending/05_Injector.md
@@ -225,6 +225,22 @@ Would setup the following
 * Look at the properties to be injected and look for the config for `MySQLDatabase`
 * Create a MySQLDatabase class, passing dbusername and dbpassword as the parameters to the constructor.
 
+## Service inheritance
+
+By default, services registered with Injector do not inherit from one another; This is because it registers
+named services, which may not be actual classes, and thus should not behave as though they were.
+
+Thus if you want an object to have the injected dependencies of a service of another name, you must
+assign a reference to that service.
+
+
+	:::yaml
+	Injector:
+	  JSONServiceDefinition:
+	    properties:
+	      Serialiser: JSONSerialiser
+	  GZIPJSONProvider: %$JSONServiceDefinition
+
 
 ## Testing with Injector
 

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -42,6 +42,7 @@
    * `CMSMain.enabled_legacy_actions` config is removed.
  * `DataObject::can` has new method signature with `$context` parameter.
  * `SiteTree.alternatePreviewLink` is deprecated. Use `updatePreviewLink` instead.
+ * `Injector` dependencies no longer automatically inherit from parent classes.
 
 ## New API
 


### PR DESCRIPTION
Now injector configs must be explicitly stated as inherting.

A partial resurrection of https://github.com/silverstripe/silverstripe-framework/pull/4580 but for a different reason.

Fixes #4774