### PR TITLE
Fixes #3182 Fixes lazy loading of fields when query was created in default stage

### DIFF
--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -749,6 +749,27 @@ class VersionedTest extends SapphireTest {
 		Versioned::set_reading_mode($originalMode);
 	}
 
+	public function testLazyLoadFieldsRetrieval() {
+		// Set reading mode to Stage
+		Versioned::set_stage(Versioned::DRAFT);
+
+		// Create object only in reading stage
+		$original = new VersionedTest_Subclass();
+		$original->ExtraField = 'Foo';
+		$original->write();
+
+		// Query for object using base class
+		$query = VersionedTest_DataObject::get()->filter('ID', $original->ID);
+
+		// Set reading mode to Live
+		Versioned::set_stage(Versioned::LIVE);
+
+		$fetched = $query->first();
+		$this->assertTrue($fetched instanceof VersionedTest_Subclass);
+		$this->assertEquals($original->ID, $fetched->ID); // Eager loaded
+		$this->assertEquals($original->ExtraField, $fetched->ExtraField); // Lazy loaded
+	}
+
 	/**
 	 * Tests that reading mode persists between requests
 	 */


### PR DESCRIPTION
Replaces #3183
Fixes #3182

Rebase of https://github.com/silverstripe/silverstripe-framework/pull/3183 onto master.

There is no change to Versioned.php because it's already fixed in master; This rebase just includes the new test to prove the fix works. :)