### PR TITLE
Allow THEMES_DIR to be modified

### DIFF
--- a/core/Constants.php
+++ b/core/Constants.php
@@ -231,8 +231,13 @@ if(!defined('BASE_URL')) {
 }
 define('MODULES_DIR', 'modules');
 define('MODULES_PATH', BASE_PATH . '/' . MODULES_DIR);
-define('THEMES_DIR', 'themes');
+
+if(!defined('THEMES_DIR')) {
+	define('THEMES_DIR', 'themes');
+}
+
 define('THEMES_PATH', BASE_PATH . '/' . THEMES_DIR);
+
 // Relies on this being in a subdir of the framework.
 // If it isn't, or is symlinked to a folder with a different name, you must define FRAMEWORK_DIR
 if(!defined('FRAMEWORK_DIR')) {

--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -2599,7 +2599,8 @@ class i18n extends Object implements TemplateGlobalProvider, Flushable {
 
 				// Load translations from themes
 				// TODO Replace with theme listing once implemented in TemplateManifest
-				$themesBase = Director::baseFolder() . '/themes';
+				$themesBase = THEMES_PATH;
+
 				if(is_dir($themesBase)) {
 					foreach(scandir($themesBase) as $theme) {
 						if(

--- a/i18n/i18nTextCollector.php
+++ b/i18n/i18nTextCollector.php
@@ -152,10 +152,10 @@ class i18nTextCollector extends Object {
 		}
 
 		// Get all themes
-		foreach(glob($directory."/themes/*", GLOB_ONLYDIR) as $path) {
+		foreach(glob($directory. '/'. THEMES_DIR. "/*", GLOB_ONLYDIR) as $path) {
 			// Check for templates
 			if(is_dir("$path/templates")) {
-				$modules[] = 'themes/'.basename($path);
+				$modules[] = THEMES_DIR . basename($path);
 			}
 		}
 


### PR DESCRIPTION
This allows developers to override THEMES_DIR, allowing source code and themes to remain inside one folder (e.g point to mysite/themes) rather than separate folders for mysite and themes.