### PR TITLE
[WIP] Bootstrap CMS forms - Use Bootstrap flavoured template markup

### DIFF
--- a/templates/forms/CheckboxField_holder.ss
+++ b/templates/forms/CheckboxField_holder.ss
@@ -1,6 +1,21 @@
 <div id="$HolderID" class="field<% if extraClass %> $extraClass<% end_if %>">
-	$Field
-	<label class="right" for="$ID">$Title</label>
-	<% if $Message %><span class="message $MessageType">$Message</span><% end_if %>
-	<% if $Description %><span class="description">$Description</span><% end_if %>
+	<div class="row form-group">
+		<div class="col-sm-10 col-sm-push-2 checkbox">
+			<label>
+				<!-- TODO: remove `.checkbox` class in the `$Field`'s `<input ...>` tag-->
+				$Field
+				$Title
+			</label>
+		</div>
+	</div>
+
+	<!-- TODO: refactor so it renders the below using a method, instead of template conditional -->
+	<% if $Message || $Description %>
+		<div class="row">
+			<div class="col-sm-10 col-sm-push-2">
+				<% if $Message %><div class="alert $MessageType" role="alert">$Message</div><% end_if %>
+				<% if $Description %><p class="description">$Description</p><% end_if %>
+			</div>
+		</div>
+	<% end_if %>
 </div>

--- a/templates/forms/CheckboxField_holder_small.ss
+++ b/templates/forms/CheckboxField_holder_small.ss
@@ -1,5 +1,4 @@
-$Field
-
-<% if $Title %>
-	<label class="checkboxfield-small" <% if $ID %>for="$ID"<% end_if %>>$Title</label>
-<% end_if %>
+<label class="checkboxfield-small">
+	$Field
+	$Title
+</label>

--- a/templates/forms/CheckboxSetField.ss
+++ b/templates/forms/CheckboxSetField.ss
@@ -1,12 +1,14 @@
-<ul $AttributesHTML>
+<div $AttributesHTML>
 	<% if $Options.Count %>
 		<% loop $Options %>
-			<li class="$Class">
-				<input id="$ID" class="checkbox" name="$Name" type="checkbox" value="$Value"<% if $isChecked %> checked="checked"<% end_if %><% if $isDisabled %> disabled="disabled"<% end_if %> />
-				<label for="$ID">$Title</label>
-			</li>
+			<div class="$Class">
+				<label>
+					<input id="$ID" class="checkbox" name="$Name" type="checkbox" value="$Value"<% if $isChecked %> checked="checked"<% end_if %><% if $isDisabled %> disabled="disabled"<% end_if %> />
+					$Title
+				</label>
+			</div>
 		<% end_loop %>
 	<% else %>
-		<li>No options available</li>
+		<p>No options available</p>
 	<% end_if %>
-</ul>
+</div>

--- a/templates/forms/CreditCardField.ss
+++ b/templates/forms/CreditCardField.ss
@@ -1,9 +1,9 @@
 <span id="{$Name}_Holder" class="creditCardField">
-	<input $AttributesHTML('id', 'name', 'value', 'tabindex') name="{$Name}[0]" value="{$ValueOne}" $TabIndexHTML(0)/>
+	<input $AttributesHTML('id', 'name', 'value', 'tabindex') class="form-control" name="{$Name}[0]" value="{$ValueOne}" $TabIndexHTML(0)/>
 	-
-	<input $AttributesHTML('id', 'name', 'value', 'tabindex') name="{$Name}[1]" value="{$ValueTwo}" $TabIndexHTML(1)/>
+	<input $AttributesHTML('id', 'name', 'value', 'tabindex') class="form-control" name="{$Name}[1]" value="{$ValueTwo}" $TabIndexHTML(1)/>
 	-
-	<input $AttributesHTML('id', 'name', 'value', 'tabindex') name="{$Name}[2]" value="{$ValueThree}" $TabIndexHTML(2)/>
+	<input $AttributesHTML('id', 'name', 'value', 'tabindex') class="form-control" name="{$Name}[2]" value="{$ValueThree}" $TabIndexHTML(2)/>
 	-
-	<input $AttributesHTML('id', 'name', 'value', 'tabindex') name="{$Name}[3]" value="{$ValueFour}" $TabIndexHTML(3)/>
+	<input $AttributesHTML('id', 'name', 'value', 'tabindex') class="form-control" name="{$Name}[3]" value="{$ValueFour}" $TabIndexHTML(3)/>
 </span>

--- a/templates/forms/FormField.ss
+++ b/templates/forms/FormField.ss
@@ -1,7 +1,7 @@
 <% if $isReadonly %>
-	<span id="$ID"<% if $extraClass %> class="$extraClass"<% end_if %>>
+	<p id="$ID" class="form-control-static<% if $extraClass %> $extraClass<% end_if %>">
 		$Value
-	</span>
+	</p>
 <% else %>
 	<input $AttributesHTML />
 <% end_if %>

--- a/templates/forms/FormField_holder.ss
+++ b/templates/forms/FormField_holder.ss
@@ -1,9 +1,25 @@
 <div id="$HolderID" class="field<% if $extraClass %> $extraClass<% end_if %>">
-	<% if $Title %><label class="left" for="$ID">$Title</label><% end_if %>
-	<div class="middleColumn">
-		$Field
+
+  	<div class="row form-group">
+		<% if $Title %><label class="col-sm-2 form-control-label" for="$ID">$Title</label><% end_if %>
+		<div class="col-sm-10<% if not $Title %> col-sm-push-2<% end_if %>">
+			<%-- TODO: add `.form-control` to `<input ...>` --%>
+			$Field
+		</div>
 	</div>
-	<% if $RightTitle %><label class="right" for="$ID">$RightTitle</label><% end_if %>
-	<% if $Message %><span class="message $MessageType">$Message</span><% end_if %>
-	<% if $Description %><span class="description">$Description</span><% end_if %>
+
+	<%-- TODO: render the below with a method, instead of template conditional --%>
+	<% if $RightTitle || $Message || $Description %>
+		<div class="row">
+			<div class="col-sm-10 col-sm-push-2">
+				<% if $RightTitle %><p class="text-muted">$RightTitle</p><% end_if %>
+
+				<%-- TODO: change $MessageType to match Bootstrap's alert types, e.g. alert-info, alert-danger etc --%>
+				<% if $Message %><div class="alert $MessageType" role="alert">$Message</div><% end_if %>
+
+				<% if $Description %><p class="description">$Description</p><% end_if %>
+			</div>
+		</div>
+	<% end_if %>
+
 </div>

--- a/templates/forms/FormField_holder_small.ss
+++ b/templates/forms/FormField_holder_small.ss
@@ -1,5 +1,14 @@
 <div class="fieldholder-small">
-	<% if $Title %><label class="fieldholder-small-label" <% if $ID %>for="$ID"<% end_if %>>$Title</label><% end_if %>
-	$Field
-	<% if $RightTitle %><label class="right fieldholder-small-label" <% if $ID %>for="$ID"<% end_if %>>$RightTitle</label><% end_if %>
+	<div class="row form-group">
+		<% if $Title %><label class="col-sm-2 fieldholder-small-label" <% if $ID %>for="$ID"<% end_if %>>$Title</label><% end_if %>
+	  	<div class="col-sm-10<% if $Title %> col-sm-push-2<% end_if %>">
+			<%-- TODO: add `.form-control` class to `<input ...>` --%>
+			$Field
+		</div>
+	</div>
+	<% if $RightTitle %>
+		<div class="col-sm-10- col-sm-push-2">
+			<p class="text-muted fieldholder-small-label" <% if $ID %>for="$ID"<% end_if %>>$RightTitle</p>
+		</div>
+	<% end_if %>
 </div>

--- a/templates/forms/LookupField.ss
+++ b/templates/forms/LookupField.ss
@@ -1,1 +1,1 @@
-<span class="readonly" id="$ID">$AttrValue</span><input type="hidden" name="$Name" value="$InputValue" />
+<p class="form-contro-static readonly" id="$ID">$AttrValue</p><input type="hidden" name="$Name" value="$InputValue" />

--- a/templates/forms/MemberDatetimeOptionsetField.ss
+++ b/templates/forms/MemberDatetimeOptionsetField.ss
@@ -1,14 +1,16 @@
-<ul $AttributesHTML>
+<div $AttributesHTML>
 	<% loop $Options %>
-		<li class="$Class">
-			<input id="$ID" class="radio" name="$Name" type="radio" value="$Value.ATT" <% if $isChecked %> checked<% end_if %><% if $isDisabled %> disabled<% end_if %> />
-			<label for="$ID">$Title.XML</label>
+		<div class="radio $Class">
+			<label>
+		  		<input id="$ID" name="$Name" type="radio" value="$Value.ATT" <% if $isChecked %> checked<% end_if %><% if $isDisabled %> disabled<% end_if %> />
+				$Title.XML
+			</label>
 			<% if $CustomName %>
-				<input class="customFormat cms-help cms-help-tooltip" name="$CustomName" value="$CustomValue.ATT">
+				<input class="form-control customFormat cms-help cms-help-tooltip" name="$CustomName" value="$CustomValue.ATT">
 				<% if $CustomPreview %>
 					<span class="preview">({$CustomPreviewLabel.XML}: "{$CustomPreview.XML}")</span>
 				<% end_if %>
 			<% end_if %>
-		</li>
+		</div>
 	<% end_loop %>
-</ul>
+</div>

--- a/templates/forms/OptionsetField.ss
+++ b/templates/forms/OptionsetField.ss
@@ -1,8 +1,10 @@
-<ul $AttributesHTML>
+<div $AttributesHTML>
 	<% loop $Options %>
-		<li class="$Class">
-			<input id="$ID" class="radio" name="$Name" type="radio" value="$Value"<% if $isChecked %> checked<% end_if %><% if $isDisabled %> disabled<% end_if %> <% if $Up.Required %>required<% end_if %> />
-			<label for="$ID">$Title</label>
-		</li>
+		<div class="radio $Class">
+			<label>
+				<input id="$ID" name="$Name" type="radio" value="$Value"<% if $isChecked %> checked<% end_if %><% if $isDisabled %> disabled<% end_if %> <% if $Up.Required %>required<% end_if %> />
+				$Title
+			</label>
+		</div>
 	<% end_loop %>
-</ul>
+</div>

--- a/templates/forms/OptionsetField_holder.ss
+++ b/templates/forms/OptionsetField_holder.ss
@@ -1,9 +1,18 @@
 <div id="$Name" class="field<% if $extraClass %> $extraClass<% end_if %>">
-	<% if $Title %><label class="left">$Title</label><% end_if %>
-	<div class="middleColumn">
-		$Field
+  	<div class="row form-group">
+		<% if $Title %><label class="col-sm-2 form-control-label">$Title</label><% end_if %>
+		<div class="col-sm-10<% if not $Title %> col-sm-push-2<% end_if %>">
+			$Field
+		</div>
 	</div>
-	<% if $RightTitle %><label class="right">$RightTitle</label><% end_if %>
-	<% if $Message %><span class="message $MessageType">$Message</span><% end_if %>
-	<% if $Description %><span class="description">$Description</span><% end_if %>
+
+  	<%-- TODO: refactor so it renders the below using a method, instead of template conditional --%>
+	<% if $RightTitle || $Message || $Description %>
+		<% if $RightTitle %><p class="text-muted">$RightTitle</p><% end_if %>
+
+		<%-- TODO: use Bootstrap's alert classes in $MessageType --%>
+		<% if $Message %><div class="alert $MessageType" role="alert">$Message</div><% end_if %>
+
+		<% if $Description %><p class="description">$Description</p><% end_if %>
+	<% end_if %>
 </div>


### PR DESCRIPTION
Changed CMS form fields to use Bootstrap 4 flavoured html markup.

Note: left some TODOs in comment as it's very difficult for me to change the following:
- [ ] remove `.checkbox` class from `$Field`
- [ ] add Bootstrap alert classes to `$MessageType`
- [ ] add `.form-control` class to input elements
- [ ] refactor template conditionals