### PR TITLE
FIX add_i18n_javascript calls not being updated after JS move

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -8,13 +8,13 @@ source_lang = en
 type = YML
 
 [silverstripe-framework.master-js]
-file_filter = javascript/lang/src/<lang>.js
-source_file = javascript/lang/src/en.js
+file_filter = client/lang/src/<lang>.js
+source_file = client/lang/src/en.js
 source_lang = en
 type = KEYVALUEJSON
 
 [silverstripe-framework.master-admin-js]
-file_filter = admin/javascript/lang/src/<lang>.js
-source_file = admin/javascript/lang/src/en.js
+file_filter = admin/client/lang/src/<lang>.js
+source_file = admin/client/lang/src/en.js
 source_lang = en
 type = KEYVALUEJSON

--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -510,7 +510,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 			]
 		]);
 
-		Requirements::add_i18n_javascript(FRAMEWORK_DIR . '/javascript/lang', false, true);
+		Requirements::add_i18n_javascript(FRAMEWORK_DIR . '/client/lang', false, true);
 		Requirements::add_i18n_javascript(FRAMEWORK_ADMIN_DIR . '/client/lang', false, true);
 
 		if ($this->config()->session_keepalive_ping) {

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -133,11 +133,13 @@ Care should also be taken when referencing images in these folders from your own
 
 ```
 framework/javascript       => framework/client/dist/
+framework/javascript/lang  => framework/client/lang/
 framework/images           => framework/client/dist/images/
 framework/css              => framework/client/dist/css/
 framework/scss             => framework/client/src/styles/
 admin/javascript/          => admin/client/src/
 admin/javascript/src/      => admin/client/src/legacy/ (mostly)
+admin/javascript/lang/     => admin/client/lang/
 admin/scss/                => admin/client/styles/legacy/
 admin/css/                 => admin/client/dist/css/
 admin/css/screen.css       => admin/client/dist/css/bundle.css

--- a/forms/AssetField.php
+++ b/forms/AssetField.php
@@ -493,7 +493,7 @@ class AssetField extends FileField {
 		Requirements::javascript(THIRDPARTY_DIR . '/jquery-ui/jquery-ui.js');
 		Requirements::javascript(THIRDPARTY_DIR . '/jquery-entwine/dist/jquery.entwine-dist.js');
 		Requirements::javascript(FRAMEWORK_ADMIN_DIR . '/client/dist/js/ssui.core.js');
-		Requirements::add_i18n_javascript(FRAMEWORK_DIR . '/javascript/lang');
+		Requirements::add_i18n_javascript(FRAMEWORK_DIR . '/client/lang');
 
 		Requirements::combine_files('uploadfield.js', array(
 			// @todo jquery templates is a project no longer maintained and should be retired at some point.

--- a/forms/TreeDropdownField.php
+++ b/forms/TreeDropdownField.php
@@ -207,7 +207,7 @@ class TreeDropdownField extends FormField {
 	 * @return HTMLText
 	 */
 	public function Field($properties = array()) {
-		Requirements::add_i18n_javascript(FRAMEWORK_DIR . '/javascript/lang');
+		Requirements::add_i18n_javascript(FRAMEWORK_DIR . '/client/lang');
 
 		Requirements::javascript(FRAMEWORK_DIR . '/thirdparty/jquery/jquery.js');
 		Requirements::javascript(FRAMEWORK_DIR . '/thirdparty/jquery-entwine/dist/jquery.entwine-dist.js');

--- a/forms/TreeMultiselectField.php
+++ b/forms/TreeMultiselectField.php
@@ -89,7 +89,7 @@ class TreeMultiselectField extends TreeDropdownField {
 	 * formfield can contain multiple values.
 	 */
 	public function Field($properties = array()) {
-		Requirements::add_i18n_javascript(FRAMEWORK_DIR . '/javascript/lang');
+		Requirements::add_i18n_javascript(FRAMEWORK_DIR . '/client/lang');
 
 		Requirements::javascript(FRAMEWORK_DIR . '/thirdparty/jquery/jquery.js');
 		Requirements::javascript(FRAMEWORK_DIR . '/thirdparty/jquery-entwine/dist/jquery.entwine-dist.js');

--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -928,7 +928,7 @@ class UploadField extends FileField {
 		Requirements::javascript(THIRDPARTY_DIR . '/jquery-ui/jquery-ui.js');
 		Requirements::javascript(THIRDPARTY_DIR . '/jquery-entwine/dist/jquery.entwine-dist.js');
 		Requirements::javascript(FRAMEWORK_ADMIN_DIR . '/client/dist/js/ssui.core.js');
-		Requirements::add_i18n_javascript(FRAMEWORK_DIR . '/javascript/lang');
+		Requirements::add_i18n_javascript(FRAMEWORK_DIR . '/client/lang');
 
 		Requirements::combine_files('uploadfield.js', array(
 			// @todo jquery templates is a project no longer maintained and should be retired at some point.

--- a/forms/gridfield/GridField.php
+++ b/forms/gridfield/GridField.php
@@ -295,7 +295,7 @@ class GridField extends FormField {
 		Requirements::javascript(THIRDPARTY_DIR . '/jquery/jquery.js');
 		Requirements::javascript(FRAMEWORK_DIR . '/thirdparty/jquery-ui/jquery-ui.js');
 		Requirements::javascript(FRAMEWORK_DIR . '/client/dist/js/i18n.js');
-		Requirements::add_i18n_javascript(FRAMEWORK_DIR . '/javascript/lang');
+		Requirements::add_i18n_javascript(FRAMEWORK_DIR . '/client/lang');
 		Requirements::javascript(THIRDPARTY_DIR . '/jquery-entwine/dist/jquery.entwine-dist.js');
 		Requirements::javascript(FRAMEWORK_DIR . '/client/dist/js/GridField.js');
 


### PR DESCRIPTION
This fixes alert / confirm boxes that were popping up without text (for
example silverstripe-cms/issues/1476), although ideally we wouldn't
show empty dialog boxes on this sort of error - we'd have some default,
or a way to detect the issue.