### PR TITLE
Disable subsite filters when running unit tests

### DIFF
--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -207,6 +207,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 
 		if(class_exists('RootURLController')) RootURLController::reset();
 		if(class_exists('Translatable')) Translatable::reset();
+		if(class_exists('Subsite', false)) Subsite::disable_subsite_filter(true);
 		Versioned::reset();
 		DataObject::reset();
 		if(class_exists('SiteTree')) SiteTree::reset();


### PR DESCRIPTION
If the subsites module is installed when running unit test it causes a number of framework unit tests to fail. This change disables the Subsite filter by default when running tests so they normally. 

Having framework needing to know about another module isn't ideal but I can't see another way of doing this right now.