### PR TITLE
Explictly set the FileNameFilter replacements before testing them

### DIFF
--- a/tests/filesystem/FileNameFilterTest.php
+++ b/tests/filesystem/FileNameFilterTest.php
@@ -5,6 +5,18 @@
  */
 class FileNameFilterTest extends SapphireTest {
 
+    public function setUp() {
+        parent::setUp();
+
+        Config::inst()->update('FileNameFilter', 'default_replacements', array(
+            '/\s/' => '-', // remove whitespace
+            '/_/' => '-', // underscores to dashes
+            '/[^A-Za-z0-9+.\-]+/' => '', // remove non-ASCII chars, only allow alphanumeric plus dash and dot
+            '/[\-]{2,}/' => '-', // remove duplicate dashes
+            '/^[\.\-_]+/' => '', // Remove all leading dots, dashes or underscores
+        ));
+    }
+
 	public function testFilter() {
 		$name = 'Brötchen  für allë-mit_Unterstrich!.jpg';
 		$filter = new FileNameFilter();

--- a/tests/filesystem/FolderTest.php
+++ b/tests/filesystem/FolderTest.php
@@ -21,6 +21,15 @@ class FolderTest extends SapphireTest {
 		// Set backend root to /FolderTest
 		AssetStoreTest_SpyStore::activate('FolderTest');
 
+		// Set the File Name Filter replacements so files have the expected names
+        Config::inst()->update('FileNameFilter', 'default_replacements', array(
+            '/\s/' => '-', // remove whitespace
+            '/_/' => '-', // underscores to dashes
+            '/[^A-Za-z0-9+.\-]+/' => '', // remove non-ASCII chars, only allow alphanumeric plus dash and dot
+            '/[\-]{2,}/' => '-', // remove duplicate dashes
+            '/^[\.\-_]+/' => '', // Remove all leading dots, dashes or underscores
+        ));
+
 		// Create a test folders for each of the fixture references
 		foreach(Folder::get() as $folder) {
 			$path = AssetStoreTest_SpyStore::getLocalPath($folder);

--- a/tests/forms/HTMLEditorFieldTest.php
+++ b/tests/forms/HTMLEditorFieldTest.php
@@ -24,6 +24,15 @@ class HTMLEditorFieldTest extends FunctionalTest {
 		// Set backend root to /HTMLEditorFieldTest
 		AssetStoreTest_SpyStore::activate('HTMLEditorFieldTest');
 
+		// Set the File Name Filter replacements so files have the expected names
+        Config::inst()->update('FileNameFilter', 'default_replacements', array(
+            '/\s/' => '-', // remove whitespace
+            '/_/' => '-', // underscores to dashes
+            '/[^A-Za-z0-9+.\-]+/' => '', // remove non-ASCII chars, only allow alphanumeric plus dash and dot
+            '/[\-]{2,}/' => '-', // remove duplicate dashes
+            '/^[\.\-_]+/' => '', // Remove all leading dots, dashes or underscores
+        ));
+
 		// Create a test files for each of the fixture references
 		$files = File::get()->exclude('ClassName', 'Folder');
 		foreach($files as $file) {

--- a/tests/forms/uploadfield/UploadFieldTest.php
+++ b/tests/forms/uploadfield/UploadFieldTest.php
@@ -28,6 +28,15 @@ class UploadFieldTest extends FunctionalTest {
 		// Set backend root to /UploadFieldTest
 		AssetStoreTest_SpyStore::activate('UploadFieldTest');
 
+		// Set the File Name Filter replacements so files have the expected names
+        Config::inst()->update('FileNameFilter', 'default_replacements', array(
+            '/\s/' => '-', // remove whitespace
+            '/_/' => '-', // underscores to dashes
+            '/[^A-Za-z0-9+.\-]+/' => '', // remove non-ASCII chars, only allow alphanumeric plus dash and dot
+            '/[\-]{2,}/' => '-', // remove duplicate dashes
+            '/^[\.\-_]+/' => '', // Remove all leading dots, dashes or underscores
+        ));
+
 		// Create a test folders for each of the fixture references
 		foreach(Folder::get() as $folder) {
 			$path = AssetStoreTest_SpyStore::getLocalPath($folder);


### PR DESCRIPTION
If the developer overrides the FileNameFilter default_replacements the unit tests will fail. Explicitly set the defaults before testing that they work.