### PR TITLE
Remember the basic details about a user when they are deleted

### DIFF
--- a/security/DeletedMember.php
+++ b/security/DeletedMember.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * The delete member class which represents a user that has been deleted from the system
+ */
+class DeletedMember extends DataObject {
+
+    private static $db = array(
+        'FirstName' => 'Varchar',
+        'Surname' => 'Varchar',
+        'Email' => 'Varchar',
+        'NumVisit' => 'Int',
+        'LastVisited' => 'SS_Datetime',
+        'Locale' => 'Varchar(6)',
+        // In ISO format
+        'DateFormat' => 'Varchar(30)',
+        'TimeFormat' => 'Varchar(30)',
+    );
+
+    function getFirstName() {
+        return '(deleted) ' . $this->getField('FirstName');
+    }
+
+    public function getTitle() {
+        return '(deleted) ' . $this->getField('Surname') . ', ' . $this->getField('FirstName');
+    }
+
+    public function getEmail() {
+        return '(deleted) ' . $this->getField('Email');
+    }
+
+    /**
+     * Get the complete name of the member
+     *
+     * @return string Returns the first- and surname of the member.
+     */
+    public function getName() {
+        return ($this->data()->Surname) ? trim($this->data()->FirstName . ' ' . $this->data()->Surname) : $this->data()->FirstName;
+    }
+
+}

--- a/security/Member.php
+++ b/security/Member.php
@@ -921,6 +921,20 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		}
 	}
 
+    /**
+     * Remeber the basic details of a member when they are deleted
+     */
+    public function onBeforeDelete() {
+        $deleted = new DeletedMember();
+        $original = $this->toMap();
+        unset($original['ClassName']);
+        foreach ($original as $k => $v) {
+            $deleted->$k = $v;
+        }
+        $deleted->write();
+        parent::onBeforeDelete();
+    }
+
 	public function onAfterDelete() {
 		parent::onAfterDelete();
 

--- a/tests/security/MemberTest.php
+++ b/tests/security/MemberTest.php
@@ -1271,6 +1271,29 @@ class MemberTest extends FunctionalTest {
 		$this->assertTrue($fail, 'Passes with email and surname now (no firstname)');
 	}
 
+    /**
+     * Test that deleteing a member causes the creation of a DeletedMemeber record
+     */
+    public function testDeletingMember() {
+        $member = $this->objFromFixture('Member', 'test');
+        $memberID = $member->ID;
+
+        // delete the member
+        $member->delete();
+
+        // Check for DeletedMember
+        $deletedMember = DataObject::get_by_id('DeletedMember', $memberID);
+        $this->assertNotNull($deletedMember);
+
+        // Ensure the basic fields are present
+        $this->assertEquals($deletedMember->Surname, "User");
+
+        // Ensure the name and email is prefixed
+        $this->assertEquals($deletedMember->Email, "(deleted) testuser@example.com");
+        $this->assertEquals($deletedMember->FirstName, "(deleted) Test");
+        $this->assertEquals($deletedMember->Name, "(deleted) Test User");
+
+    }
 }
 
 /**


### PR DESCRIPTION
When looking a page history, or other actions it is not possible to attribute these to a Member once they are deleted. We simply display "Unknown".

This change creates a DeletedMember object and stores the basic details about a member when they are deleted. This allows other modules to retrieve the name of members after they have been deleted so they can still be 'blamed' for the actions.

