### PR TITLE
Allow ManyManyListTest to run standalone

### DIFF
--- a/tests/model/ManyManyListTest.php
+++ b/tests/model/ManyManyListTest.php
@@ -12,7 +12,9 @@ class ManyManyListTest extends SapphireTest {
 		'DataObjectTest_Team',
 		'DataObjectTest_SubTeam',
 		'DataObjectTest_Player',
-		'ManyManyListTest_ExtraFields'
+		'DataObjectTest_Company',
+		'DataObjectTest_TeamComment',
+		'ManyManyListTest_ExtraFields',
 	);
 
 


### PR DESCRIPTION
Currently the tests will fail if this is run standalone because the correct classes are not loaded