### PR TITLE
API Enable combined requirements to persist between flushes

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/03_Requirements.md
+++ b/docs/en/02_Developer_Guides/01_Templates/03_Requirements.md
@@ -130,6 +130,9 @@ the third paramter of the `combine_files` function:
 
 	Requirements::combine_files('print.css', $printStylesheets, 'print');
 
+By default, all requirements files are flushed (deleted) when ?flush querystring parameter is set.
+This can be disabled by setting the `Requirements.disable_flush_combined` config to `true`.
+
 ## Clearing assets
 
 	:::php

--- a/view/Requirements.php
+++ b/view/Requirements.php
@@ -9,10 +9,24 @@
 class Requirements implements Flushable {
 
 	/**
+	 * Flag whether combined files should be deleted on flush.
+	 *
+	 * By default all combined files are deleted on flush. If combined files are stored in source control,
+	 * and thus updated manually, you might want to turn this on to disable this behaviour.
+	 *
+	 * @config
+	 * @var bool
+	 */
+	private static $disable_flush_combined = false;
+
+	/**
 	 * Triggered early in the request when a flush is requested
 	 */
 	public static function flush() {
-		self::delete_all_combined_files();
+		$disabled = Config::inst()->get(__CLASS__, 'disable_flush_combined');
+		if(!$disabled) {
+			self::delete_all_combined_files();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Partially mitigates the issue of https://github.com/silverstripe/silverstripe-framework/issues/4553.

Back-port of functionality from master branch.

Non-core patch at https://gist.github.com/tractorcow/cccf035d4cd13a0de62edf69e7a63126 in case anyone on 3.3 or below wishes to fix this issue for static cached sites.