### PR TITLE
ENH: moving hardcoded nice date/time formats to config

### DIFF
--- a/model/fieldtypes/Date.php
+++ b/model/fieldtypes/Date.php
@@ -20,6 +20,14 @@
  */
 class Date extends DBField {
 
+	/**
+	 * @config
+	 * @see SS_DateTime::nice_format
+	 * @see Time::nice_format
+	 */
+	private static $nice_format = 'd/m/Y';
+
+
 	public function setValue($value, $record = null) {
 		if($value === false || $value === null || (is_string($value) && !strlen($value))) {
 			// don't try to evaluate empty values with strtotime() below, as it returns "1970-01-01" when it should be
@@ -59,10 +67,10 @@ class Date extends DBField {
 	}
 
 	/**
-	 * Returns the date in the format dd/mm/yy
-	 */
+	 * Returns the date in the format specified by the config value nice_format, or dd/mm/yy by default
+	 */	 
 	public function Nice() {
-		if($this->value) return $this->Format('d/m/Y');
+		if($this->value) return $this->Format($this->config()->nice_format);
 	}
 
 	/**

--- a/model/fieldtypes/Datetime.php
+++ b/model/fieldtypes/Datetime.php
@@ -25,6 +25,14 @@
  */
 class SS_Datetime extends Date implements TemplateGlobalProvider {
 
+	/**
+	 * @config
+	 * @see Date::nice_format
+	 * @see Time::nice_format
+	 */
+	private static $nice_format = 'd/m/Y g:ia';
+
+
 	public function setValue($value, $record = null) {
 		if($value === false || $value === null || (is_string($value) && !strlen($value))) {
 			// don't try to evaluate empty values with strtotime() below, as it returns "1970-01-01" when it should be
@@ -54,11 +62,12 @@ class SS_Datetime extends Date implements TemplateGlobalProvider {
 	}
 
 	/**
-	 * Returns the date and time (in 12-hour format) using the format string 'd/m/Y g:ia' e.g. '31/01/2014 2:23pm'.
+	 * Returns the date and time in the format specified by the config value nice_format, or 'd/m/Y g:ia' 
+	 * by default (e.g. '31/01/2014 2:23pm').
 	 * @return string Formatted date and time.
 	 */
 	public function Nice() {
-		if($this->value) return $this->Format('d/m/Y g:ia');
+		if($this->value) return $this->Format($this->config()->nice_format);
 	}
 
 	/**

--- a/model/fieldtypes/Time.php
+++ b/model/fieldtypes/Time.php
@@ -16,6 +16,14 @@
  */
 class Time extends DBField {
 
+	/**
+	 * @config
+	 * @see Date::nice_format
+	 * @see SS_DateTime::nice_format
+	 */
+	private static $nice_format = 'g:ia';
+
+
 	public function setValue($value, $record = null) {
 		if($value) {
 			if(preg_match( '/(\d{1,2})[:.](\d{2})([a|A|p|P|][m|M])/', $value, $match )) $this->TwelveHour( $match );
@@ -26,13 +34,13 @@ class Time extends DBField {
 	}
 
 	/**
-	 * Return a user friendly format for time
-	 * in a 12 hour format.
+	 * Returns the time in the format specified by the config value nice_format, or 12 hour format by default 
+	 * e.g. "3:15pm"
 	 *
-	 * @return string Time in 12 hour format
+	 * @return string
 	 */
 	public function Nice() {
-		if($this->value) return date('g:ia', strtotime($this->value));
+		if($this->value) return $this->Format($this->config()->nice_format);
 	}
 
 	/**

--- a/tests/model/DateTest.php
+++ b/tests/model/DateTest.php
@@ -59,6 +59,10 @@ class DateTest extends SapphireTest {
 		$this->assertEquals('04/03/2003', DBField::create_field('Date', '04-03-2003')->Nice(),
 			"Date->Nice() works with DD/MM/YYYY format"
 		);
+
+		$date = DBField::create_field('Date', '2003-03-04');
+		Config::inst()->update('Date', 'nice_format', 'd F Y');
+		$this->assertEquals('04 March 2003', $date->Nice());
 	}
 
 	public function testNiceUS(){

--- a/tests/model/DatetimeTest.php
+++ b/tests/model/DatetimeTest.php
@@ -62,6 +62,9 @@ class SS_DatetimeTest extends SapphireTest {
 	public function testNice() {
 		$date = DBField::create_field('SS_Datetime', '2001-12-31 22:10:59');
 		$this->assertEquals('31/12/2001 10:10pm', $date->Nice());
+
+		Config::inst()->update('SS_Datetime', 'nice_format', 'd F Y, H:i:s');
+		$this->assertEquals('31 December 2001, 22:10:59', $date->Nice());
 	}
 
 	public function testNice24() {

--- a/tests/model/TimeTest.php
+++ b/tests/model/TimeTest.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @package framework
+ * @subpackage tests
+ */
+class TimeTest extends SapphireTest {
+
+	public function testNice() {
+		$time = DBField::create_field('Time', '17:15:55');
+		$this->assertEquals('5:15pm', $time->Nice());
+
+		Config::inst()->update('Time', 'nice_format', 'H:i:s');
+		$this->assertEquals('17:15:55', $time->Nice());
+	}
+
+}


### PR DESCRIPTION
Made Nice() formats configurable. Default formats are still the same (unit-tests confirm this). Updated and added tests for changing format.

Old PR: #4449