### PR TITLE
BUG Fix singleton('DBLocale')

### DIFF
--- a/model/fieldtypes/DBLocale.php
+++ b/model/fieldtypes/DBLocale.php
@@ -9,7 +9,7 @@
  */
 class DBLocale extends Varchar {
 
-	public function __construct($name, $size = 16) {
+	public function __construct($name = null, $size = 16) {
 		parent::__construct($name, $size);
 	}
 


### PR DESCRIPTION
With a mandatory first argument DBLocale cannot be created as a singleton, and breaks certain DataObject operations which do reflection on field types.

This seems to appear in translatable running against master, but the bug is in all versions of framework.
