### PR TITLE
Revert "Disable subsite filters when running unit tests"

### DIFF
--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -207,7 +207,6 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 
 		if(class_exists('RootURLController')) RootURLController::reset();
 		if(class_exists('Translatable')) Translatable::reset();
-		if(class_exists('Subsite', false)) Subsite::disable_subsite_filter(true);
 		Versioned::reset();
 		DataObject::reset();
 		if(class_exists('SiteTree')) SiteTree::reset();


### PR DESCRIPTION
Reverts silverstripe/silverstripe-framework#5480

Fixes some (but not all) CI failures on subsites module.