### PR TITLE
BUG Fix DataObject::isChanged() detecting non saveble changes

### DIFF
--- a/docs/en/04_Changelogs/3.4.0.md
+++ b/docs/en/04_Changelogs/3.4.0.md
@@ -14,3 +14,5 @@ was affected by these:
  * When FormFields are rendered, leading & trailing whitespace is now stripped. The resulting HTML for form fields is
    the same for the default fields, but if you have a custom form field that is relying on trailing whitespace being
    outputted.
+ * DataObject::isChanged() now defaults to only checking database fields. If you rely on this method
+   for checking changes to non-db field properties, use getChangedFields() instead.

--- a/tests/model/MoneyTest.php
+++ b/tests/model/MoneyTest.php
@@ -71,6 +71,35 @@ class MoneyTest extends SapphireTest {
 		$this->assertEquals(0.0000, $moneyTest->MyMoneyAmount);
 	}
 
+	public function testIsChanged() {
+		$obj1 = $this->objFromFixture('MoneyTest_DataObject', 'test1');
+		$this->assertFalse($obj1->isChanged());
+		$this->assertFalse($obj1->isChanged('MyMoney'));
+
+		// modify non-db field
+		$m1 = new Money();
+		$m1->setAmount(500);
+		$m1->setCurrency('NZD');
+		$obj1->NonDBMoneyField = $m1;
+		$this->assertFalse($obj1->isChanged()); // Because only detects DB fields
+		$this->assertTrue($obj1->isChanged('NonDBMoneyField')); // Allow change detection to non-db fields explicitly named
+
+		// Modify db field
+		$obj2 = $this->objFromFixture('MoneyTest_DataObject', 'test2');
+		$m2 = new Money();
+		$m2->setAmount(500);
+		$m2->setCurrency('NZD');
+		$obj2->MyMoney = $m2;
+		$this->assertTrue($obj2->isChanged()); // Detects change to DB field
+		$this->assertTrue($obj2->ischanged('MyMoney'));
+
+		// Modify sub-fields
+		$obj3 = $this->objFromFixture('MoneyTest_DataObject', 'test3');
+		$obj3->MyMoneyCurrency = 'USD';
+		$this->assertTrue($obj3->isChanged()); // Detects change to DB field
+		$this->assertTrue($obj3->ischanged('MyMoneyCurrency'));
+	}
+
 	/**
 	 * Write a Money object to the database, then re-read it to ensure it
 	 * is re-read properly.

--- a/tests/model/MoneyTest.yml
+++ b/tests/model/MoneyTest.yml
@@ -1,8 +1,14 @@
 MoneyTest_DataObject:
-   test1:
-      MyMoneyCurrency: EUR
-      MyMoneyAmount: 1.23
+ test1:
+   MyMoneyCurrency: EUR
+   MyMoneyAmount: 1.23
+ test2:
+   MyMoneyCurrency: USD
+   MyMoneyAmount: 4.45
+ test3:
+   MyMoneyCurrency: NZD
+   MyMoneyAmount: 7.66
 MoneyTest_SubClass:
-   test2:
-      MyOtherMoneyCurrency: GBP
-      MyOtherMoneyAmount: 2.46
+  test2:
+    MyOtherMoneyCurrency: GBP
+    MyOtherMoneyAmount: 2.46


### PR DESCRIPTION
When certain properties are saved against a dataobject (e.g. via dependency injection) it often has the effect of incorrectly marking the object as dirty (even if those properties aren't database fields).

This change also removes a lot of duplicate code from updateChanges() that really isn't necessary. If $forceChanges is true, change detection isn't necessary, and updating changes can be done by simply piggy backing off isChanged() which invokes getChangedFields().

If users want to get all changed fields, even if they aren't database fields (which is the exception rather than the rule) they can still use getChangedFields(true) to get all non-db fields also.

This is against 3.x since it is a slight change in behaviour, and has a risk of regression.

I'm not sure if this should go into 3.4.0 or 3.5.0, due to the risk.