### PR TITLE
BUG Fix filtersOnId ignoring `WHERE "ID" IN ()`

### DIFF
--- a/model/queries/SQLConditionalExpression.php
+++ b/model/queries/SQLConditionalExpression.php
@@ -650,9 +650,8 @@ abstract class SQLConditionalExpression extends SQLExpression {
 	 * @return boolean
 	 */
 	public function filtersOnID() {
-		$regexp = '/^(.*\.)?("|`)?ID("|`)?\s?=/';
+		$regexp = '/^(.*\.)?("|`)?ID("|`)?\s?(=|IN)/';
 
-		// @todo - Test this works with paramaterised queries
 		foreach($this->getWhereParameterised($parameters) as $predicate) {
 			if(preg_match($regexp, $predicate)) return true;
 		}
@@ -668,7 +667,7 @@ abstract class SQLConditionalExpression extends SQLExpression {
 	 * @return boolean
 	 */
 	public function filtersOnFK() {
-		$regexp = '/^(.*\.)?("|`)?[a-zA-Z]+ID("|`)?\s?=/';
+		$regexp = '/^(.*\.)?("|`)?[a-zA-Z]+ID("|`)?\s?(=|IN)/';
 
 		// @todo - Test this works with paramaterised queries
 		foreach($this->getWhereParameterised($parameters) as $predicate) {

--- a/tests/model/SQLQueryTest.php
+++ b/tests/model/SQLQueryTest.php
@@ -322,6 +322,41 @@ class SQLQueryTest extends SapphireTest {
 		);
 
 		$query = new SQLQuery();
+		$query->setWhere('"ID" = 5');
+		$this->assertTrue(
+			$query->filtersOnID(),
+			"filtersOnID() is true with simple quoted column name"
+		);
+
+		$query = new SQLQuery();
+		$query->setWhere(array('"ID"' => 4));
+		$this->assertTrue(
+			$query->filtersOnID(),
+			"filtersOnID() is true with parameterised quoted column name"
+		);
+
+		$query = new SQLQuery();
+		$query->setWhere(array('"ID" = ?' => 4));
+		$this->assertTrue(
+			$query->filtersOnID(),
+			"filtersOnID() is true with parameterised quoted column name"
+		);
+
+		$query = new SQLQuery();
+		$query->setWhere('"ID" IN (5,4)');
+		$this->assertTrue(
+			$query->filtersOnID(),
+			"filtersOnID() is true with WHERE ID IN"
+		);
+
+		$query = new SQLQuery();
+		$query->setWhere(array('"ID" IN ?' => array(1,2)));
+		$this->assertTrue(
+			$query->filtersOnID(),
+			"filtersOnID() is true with parameterised WHERE ID IN"
+		);
+
+		$query = new SQLQuery();
 		$query->setWhere("ID=5");
 		$this->assertTrue(
 			$query->filtersOnID(),


### PR DESCRIPTION
Fixes bug in subsites where it would apply subsites filter to queries on `ID IN ()`, which should not be subsite filterable.