### PR TITLE
API Enable Debug.friendly_error_httpcode to correctly set HTTP status code for errors

### DIFF
--- a/docs/en/04_Changelogs/3.4.0.md
+++ b/docs/en/04_Changelogs/3.4.0.md
@@ -16,3 +16,18 @@ was affected by these:
    outputted.
  * DataObject::isChanged() now defaults to only checking database fields. If you rely on this method
    for checking changes to non-db field properties, use getChangedFields() instead.
+   
+### Error handling
+
+Up until 3.4.0 error responses handled by SilverStripe have normally returned HTTP 200. The correct http response
+code can be turned on by setting `Debug.friendly_error_httpcode` config to true. This option will be removed in
+4.0 and fixed to always on.
+
+
+	:::yaml
+	---
+	Name: mydebug
+	---
+	Debug:
+  	  friendly_error_httpcode: true
+


### PR DESCRIPTION
Relies on https://github.com/silverstripe/silverstripe-framework/pull/5555 to correctly suppress errors from pre-emptively setting "headers_sent" to true.