### PR TITLE
BUGFIX: check token and UID before member autologin

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -582,6 +582,10 @@ class Member extends DataObject implements TemplateGlobalProvider {
 
 		list($uid, $token) = explode(':', Cookie::get('alc_enc'), 2);
 
+		if (!$uid || !$token) {
+			return;
+		}
+
 		$member = DataObject::get_by_id("Member", $uid);
 
 		// check if autologin token matches


### PR DESCRIPTION
Don't assume that the cookie is correct before trying to log in a member

Fixes #5565