### PR TITLE
Giving composer more responsibility over autoloading

### DIFF
--- a/cli-script.php
+++ b/cli-script.php
@@ -58,6 +58,15 @@ if(isset($_SERVER['argv'][1])) {
 	$_GET['url'] = $_SERVER['argv'][1];
 }
 
+// require composers autoloader
+if (file_exists($autoloadPath = dirname(__DIR__) . '/vendor/autoload.php')) {
+	require_once $autoloadPath;
+}
+else  {
+	echo "Failed to include composer's autoloader, unable to continue\n";
+	exit(1);
+}
+
 /**
  * Include SilverStripe's core code
  */

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,10 @@
 		}
 	},
 	"autoload": {
+		"psr-4": {
+			"SilverStripe\\": ""
+		},
+		"files": ["core/Constants.php"],
 		"classmap": ["tests/behat/features/bootstrap"]
 	}
 }

--- a/core/Core.php
+++ b/core/Core.php
@@ -3,7 +3,6 @@
  * This file is the Framework bootstrap.  It will get your environment ready to call Director::direct().
  *
  * It takes care of:
- *  - Including Constants.php to include _ss_environment and initialise necessary constants
  *  - Checking of PHP memory limit
  *  - Including all the files needed to get the manifest built
  *  - Building and including the manifest
@@ -21,11 +20,6 @@
  * live mode, where reporting is limited to fatal errors and warnings (see later in this file)
  */
 error_reporting(E_ALL | E_STRICT);
-
-/**
- * Include Constants (if it hasn't already been included) to pull in BASE_PATH, etc
- */
-require_once dirname(__FILE__).'/Constants.php';
 
 global $_increase_time_limit_max;
 $_increase_time_limit_max = -1;
@@ -109,11 +103,6 @@ $manifest = new SS_ClassManifest(BASE_PATH, false, $flush);
 $loader = SS_ClassLoader::instance();
 $loader->registerAutoloader();
 $loader->pushManifest($manifest);
-
-// Fall back to Composer's autoloader (e.g. for PHPUnit), if composer is used
-if(file_exists(BASE_PATH . '/vendor/autoload.php')) {
-	require_once BASE_PATH . '/vendor/autoload.php';
-}
 
 // Now that the class manifest is up, load the static configuration
 $configManifest = new SS_ConfigStaticManifest();

--- a/dev/install/install.php
+++ b/dev/install/install.php
@@ -15,7 +15,7 @@
 define('FRAMEWORK_NAME', 'framework');
 
 if (version_compare(phpversion(), '5.5.0', '<')) {
-	header("HTTP/1.1 500 Server Error");
+	header($_SERVER['SERVER_PROTOCOL'] . " 500 Server Error");
 	echo str_replace(
 		array('$PHPVersion', 'sapphire'),
 		array(phpversion(), FRAMEWORK_NAME),

--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -31,7 +31,18 @@ if(function_exists('session_start') && !session_id()) {
 	session_start();
 }
 
-require_once FRAMEWORK_NAME . '/core/Constants.php'; // this also includes TempPath.php;
+// require composers autoloader
+if (file_exists($autoloadPath = dirname(__DIR__) . '/../../vendor/autoload.php')) {
+	require_once $autoloadPath;
+}
+else  {
+	if (!headers_sent()) {
+		header($_SERVER['SERVER_PROTOCOL'] . " 500 Server Error");
+		header('Content-Type: text/plain');
+	}
+	echo "Failed to include composer's autoloader, unable to continue\n";
+	exit(1);
+}
 
 $envFileExists = defined('SS_ENVIRONMENT_FILE');
 $usingEnv = $envFileExists && !empty($_REQUEST['useEnv']);

--- a/main.php
+++ b/main.php
@@ -15,7 +15,7 @@
  */
 
 if (version_compare(phpversion(), '5.5.0', '<')) {
-	header("HTTP/1.1 500 Server Error");
+	header($_SERVER['SERVER_PROTOCOL'] . " 500 Server Error");
 	echo str_replace('$PHPVersion', phpversion(), file_get_contents("dev/install/php5-required.html"));
 	die();
 }
@@ -52,10 +52,18 @@ if (version_compare(phpversion(), '5.5.0', '<')) {
  * @see Director::direct()
  */
 
-/**
- * Include the defines that set BASE_PATH, etc
- */
-require_once('core/Constants.php');
+// require composers autoloader
+if (file_exists($autoloadPath = dirname(__DIR__) . '/vendor/autoload.php')) {
+	require_once $autoloadPath;
+}
+else {
+	if (!headers_sent()) {
+		header($_SERVER['SERVER_PROTOCOL'] . " 500 Server Error");
+		header('Content-Type: text/plain');
+	}
+	echo "Failed to include composer's autoloader, unable to continue\n";
+	exit(1);
+}
 
 // IIS will sometimes generate this.
 if(!empty($_SERVER['HTTP_X_ORIGINAL_URL'])) {

--- a/thirdparty/tinymce/tiny_mce_gzip.php
+++ b/thirdparty/tinymce/tiny_mce_gzip.php
@@ -12,7 +12,18 @@
 $frameworkPath = rtrim(dirname(dirname(dirname(__FILE__))), DIRECTORY_SEPARATOR);
 $basePath = rtrim(dirname($frameworkPath), DIRECTORY_SEPARATOR);
 
-require_once $frameworkPath . '/core/Constants.php';
+// require composers autoloader
+if(file_exists($basePath . '/vendor/autoload.php')) {
+	require_once $basePath . '/vendor/autoload.php';
+}
+else {
+	if (!headers_sent()) {
+		header($_SERVER['SERVER_PROTOCOL'] . " 500 Server Error");
+		header('Content-Type: text/plain');
+	}
+	echo "Failed to include composer's autoloader, unable to continue\n";
+	exit(1);
+}
 
 // Handle incoming request if it's a script call
 if (TinyMCE_Compressor::getParam("js")) {
@@ -374,4 +385,3 @@ class TinyMCE_Compressor {
 		return $content;
 	}
 }
-?>


### PR DESCRIPTION
Bring composer's autoloader into the fold as early as possible. This will allow us to stop manual class includes when we are fully up and running with PSR-4 compliant namespaces.