### PR TITLE
FIX #5557 Tests with no DB requirements wont create test DB

### DIFF
--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -223,13 +223,9 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 		$this->model = DataModel::inst();
 
 		// Set up fixture
-		if($fixtureFile || $this->usesDatabase || !self::using_temp_db()) {
-			if(substr(DB::getConn()->currentDatabase(), 0, strlen($prefix) + 5)
-					!= strtolower(sprintf('%stmpdb', $prefix))) {
-
-				//echo "Re-creating temp database... ";
+		if($fixtureFile || $this->usesDatabase) {
+			if (!self::using_temp_db()) {
 				self::create_temp_db();
-				//echo "done.\n";
 			}
 
 			singleton('DataObject')->flushCache();


### PR DESCRIPTION
- Removed duplicate logic that is already in `using_temp_db`
- Only need to create the temp db if we aren't using one - this logic is not needed to wrap the entire set of logic around fixtures, etc.