### PR TITLE
DOCS incorrect method referenced

### DIFF
--- a/docs/en/02_Developer_Guides/12_Search/01_Searchcontext.md
+++ b/docs/en/02_Developer_Guides/12_Search/01_Searchcontext.md
@@ -46,7 +46,7 @@ and `MyDate`. The attribute `HiddenProperty` should not be searchable, and `MyDa
 			'MyDate' => 'Date'
 		);
 		
-		public function getCustomSearchContext() {
+		public function getDefaultSearchContext() {
 			$fields = $this->scaffoldSearchFields(array(
 				'restrictFields' => array('PublicProperty','MyDate')
 			));


### PR DESCRIPTION
ModelAdmin uses `getDefaultSearchContext`: http://api.silverstripe.org/3.3/source-class-ModelAdmin.html#173