### PR TITLE
Fix CleanupTestDatabasesTask permission failure response

### DIFF
--- a/tasks/CleanupTestDatabasesTask.php
+++ b/tasks/CleanupTestDatabasesTask.php
@@ -13,7 +13,7 @@ class CleanupTestDatabasesTask extends BuildTask {
 
 	public function run($request) {
 		if(!Permission::check('ADMIN') && !Director::is_cli()) {
-			$response = Security::permissionFailure($this);
+			$response = Security::permissionFailure();
 			if($response) {
 				$response->output();
 			}


### PR DESCRIPTION
`BuildTask` isn’t a controller, so this results in a “method `redirect` does not exist” error. Omitting the first param will cause `Security::permissionFailure()` to fall back to `Controller::curr()` instead