### PR TITLE
Improve performance of TokenisedRegularExpression

### DIFF
--- a/core/manifest/TokenisedRegularExpression.php
+++ b/core/manifest/TokenisedRegularExpression.php
@@ -13,32 +13,40 @@ class TokenisedRegularExpression {
 	 */
 	protected $expression;
 
+	/**
+	 * The first expression to match
+	 */
+	protected $firstMatch;
+
 	public function __construct($expression) {
 		$this->expression = $expression;
+		$this->firstMatch = is_array($expression[0]) ? $expression[0][0] : $expression[0];
 	}
 
 	public function findAll($tokens) {
 		$tokenTypes = array();
 		foreach($tokens as $i => $token) {
 			if(is_array($token)) {
-				$tokenTypes[$i] = $token[0];
+				$tokenType = $token[0];
 			} else {
-				$tokenTypes[$i] = $token;
+				$tokenType = $token;
 				// Pre-process string tokens for matchFrom()
 				$tokens[$i] = array($token, $token);
 			}
+
+			if ($tokenType == $this->firstMatch) {
+				$tokenTypes[$i] = $tokenType;
+			}
 		}
 
-		$startKeys = array_keys($tokenTypes, is_array($this->expression[0])
-			? $this->expression[0][0] : $this->expression[0]);
 		$allMatches = array();
-
-		foreach($startKeys as $startKey) {
+		foreach($tokenTypes as $startKey => $dud) {
 			$matches = array();
 			if($this->matchFrom($startKey, 0, $tokens, $matches)) {
 				$allMatches[] = $matches;
 			}
 		}
+
 		return $allMatches;
 	}
 


### PR DESCRIPTION
tldr; `$tokenTypes` contained everything, then relied on `array_keys()` to filter. New approach is to only add to the `$tokenTypes` array if it matches.

Saves ~1.5mb peak memory on a blank install (tested with XHProf).

<img width="1273" alt="screen shot 2016-05-24 at 10 18 18" src="https://cloud.githubusercontent.com/assets/1655548/15499601/f6e6f78e-219c-11e6-9bdc-0b4894031819.png">


Also tested on the “largest” site (in terms of number of PHP classes) I had on my machine, this time using `time` and `memory_get_peak_usage(true)` instead of XHProf in case of any overhead:

```
<!-- 22 mb -->
real	0m3.215s
user	0m2.838s
sys	0m0.275s


<!-- 20 mb -->
real	0m2.878s
user	0m2.562s
sys	0m0.273s
```

Runs were done by simply hitting the home page after deleting the entire temp directory each time.