### PR TITLE
Add namespace for appBoot, and fix syntax error in GridField

### DIFF
--- a/admin/client/src/boot/index.js
+++ b/admin/client/src/boot/index.js
@@ -45,4 +45,6 @@ function appBoot() {
 // Entwine hooks are being used to set up the <Provider>.
 // `window.onload` happens AFTER these Entwine hooks which means
 // the store is undefined when the <Provider> is constructed.
-$('body').entwine({ onadd: () => appBoot() });
+$.entwine('ss', () => {
+  $('body').entwine({ onadd: () => appBoot() });
+});

--- a/admin/client/src/components/GridField/GridField.js
+++ b/admin/client/src/components/GridField/GridField.js
@@ -11,6 +11,8 @@ import GridFieldAction from './GridFieldAction';
 import FormConstants from 'components/Form/FormConstants';
 import * as actions from 'state/records/RecordsActions';
 
+const NotYetLoaded = {};
+
 /**
  * The component acts as a container for a grid field,
  * with smarts around data retrieval from external sources.
@@ -161,13 +163,11 @@ GridField.propTypes = {
   }),
 };
 
-const NotYetLoaded = {};
-
 function mapStateToProps(state, ownProps) {
   const recordType = ownProps.data ? ownProps.data.recordType : null;
   return {
     config: state.config,
-    records: recordType && state.records[recordType] ? state.records[recordType] : NotYetLoaded
+    records: recordType && state.records[recordType] ? state.records[recordType] : NotYetLoaded,
   };
 }
 


### PR DESCRIPTION
We've found if a module creates another namespace, it triggers the appBoot again and throws an error.

I was debating about whether to use this pull request change or `$(document).ready(appBoot);`