### PR TITLE
Adjusted dbObject order of execution and make ignoreFields chainable

### DIFF
--- a/ORM/DataObject.php
+++ b/ORM/DataObject.php
@@ -2954,24 +2954,27 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	 * @return DBField The field as a DBField object
 	 */
 	public function dbObject($fieldName) {
+		// Check for field in DB
+		$helper = $this->db($fieldName, true);
+
+		if(!$helper) {
+			return null;
+		}
+
 		$value = isset($this->record[$fieldName])
 			? $this->record[$fieldName]
 			: null;
 
 		// If we have a DBField object in $this->record, then return that
-		if(is_object($value)) {
+		if($value instanceof DBField) {
 			return $value;
 		}
 
-		// Build and populate new field otherwise
-		$helper = $this->db($fieldName, true);
-		if($helper) {
-			list($table, $spec) = explode('.', $helper);
-			$obj = Object::create_from_string($spec, $fieldName);
-			$obj->setTable($table);
-			$obj->setValue($value, $this, false);
-			return $obj;
-		}
+		list($table, $spec) = explode('.', $helper);
+		$obj = Object::create_from_string($spec, $fieldName);
+		$obj->setTable($table);
+		$obj->setValue($value, $this, false);
+		return $obj;
 	}
 
 	/**

--- a/ORM/Versioning/DataDifferencer.php
+++ b/ORM/Versioning/DataDifferencer.php
@@ -75,6 +75,8 @@ class DataDifferencer extends ViewableData {
 	public function ignoreFields($ignoredFields) {
 		if(!is_array($ignoredFields)) $ignoredFields = func_get_args();
 		$this->ignoredFields = array_merge($this->ignoredFields, $ignoredFields);
+
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
Moving the check for `db($fieldName)` to the start would help ensure that `dbObject` returns a `DBField` object and not return `$dependencies` injected objects.
This way DataDifferencer would not require a DBField check as well.

ignoreFields `return $this;` so it could be chained e.g.
```
$diffFields = DataDifferencer::create($original, $new)
  ->ignoreFields(array('LastEdited'))
  ->ChangedFields();
```