### PR TITLE
BUG fix CMS_ACCESS permission being ignored if in incorrect order in array

### DIFF
--- a/security/Permission.php
+++ b/security/Permission.php
@@ -185,13 +185,12 @@ class Permission extends DataObject implements TemplateGlobalProvider {
 						}
 					}
 				}
-				elseif (substr($permCode, 0, 11) === 'CMS_ACCESS_') {
+				elseif (substr($permCode, 0, 11) === 'CMS_ACCESS_' && !in_array('CMS_ACCESS_LeftAndMain', $code)) {
 					//cms_access_leftandmain means access to all CMS areas
 					$code[] = 'CMS_ACCESS_LeftAndMain';
-					break;
 				}
 			}
-			
+
 			// if ADMIN has all privileges, then we need to push that code in
 			if($adminImpliesAll) {
 				$code[] = "ADMIN";

--- a/tests/security/PermissionTest.php
+++ b/tests/security/PermissionTest.php
@@ -27,6 +27,8 @@ class PermissionTest extends SapphireTest {
 		$members = Member::get()->byIDs($this->allFixtureIDs('Member'));
 		foreach ($members as $member) {
 			$this->assertTrue(Permission::checkMember($member, 'CMS_ACCESS'));
+			$this->assertTrue(Permission::checkMember($member, array('CMS_ACCESS', 'CMS_ACCESS_Security')));
+			$this->assertTrue(Permission::checkMember($member, array('CMS_ACCESS_Security', 'CMS_ACCESS')));
 		}
 
 		$member = new Member();
@@ -37,6 +39,8 @@ class PermissionTest extends SapphireTest {
 		));
 		$member->write();
 		$this->assertFalse(Permission::checkMember($member, 'CMS_ACCESS'));
+		$this->assertFalse(Permission::checkMember($member, array('CMS_ACCESS', 'CMS_ACCESS_Security')));
+		$this->assertFalse(Permission::checkMember($member, array('CMS_ACCESS_Security', 'CMS_ACCESS')));
 	}
 
 	public function testLeftAndMainAccessAll() {
@@ -47,7 +51,7 @@ class PermissionTest extends SapphireTest {
 		$this->assertTrue(Permission::checkMember($member, "CMS_ACCESS_AssetAdmin"));
 		$this->assertTrue(Permission::checkMember($member, "CMS_ACCESS_SecurityAdmin"));
 	}
-	
+
 	public function testPermissionAreInheritedFromOneRole() {
 		$member = $this->objFromFixture('Member', 'author');
 		$this->assertTrue(Permission::checkMember($member, "CMS_ACCESS_MyAdmin"));


### PR DESCRIPTION
@dhensby this is a bugfix for that permission you added a while back. :) I found out it's ignored if placed after some other CMS_ACCESS_ permission (which is necessary when writing backwards-compatible security code).