### PR TITLE
Show the query number as part of debugging

### DIFF
--- a/model/connect/Database.php
+++ b/model/connect/Database.php
@@ -15,6 +15,13 @@ abstract class SS_Database {
 	 * @var DBConnector
 	 */
 	protected $connector = null;
+	
+	/**
+	 * Amount of queries executed, for debugging purposes.
+	 * 
+	 * @var int
+	 */
+	protected $queryCount = 0;
 
 	/**
 	 * Get the current connector
@@ -171,6 +178,7 @@ abstract class SS_Database {
 	 */
 	protected function benchmarkQuery($sql, $callback, $parameters = null) {
 		if (isset($_REQUEST['showqueries']) && Director::isDev()) {
+			$this->queryCount++;
 			$starttime = microtime(true);
 			$result = $callback($sql);
 			$endtime = round(microtime(true) - $starttime, 4);
@@ -178,7 +186,7 @@ abstract class SS_Database {
 			if($parameters) {
 				$message .= "\nparams: \"" . implode('", "', $parameters) . '"';
 			}
-			Debug::message("\n{$message}\n{$endtime}s\n", false);
+			Debug::message("\n$this->queryCount: {$message}\n{$endtime}s\n", false);
 
 			return $result;
 		} else {


### PR DESCRIPTION
Show the query number, easier to see the amount of queries executed, and for debugging purposes of a certain slow query, also useful, since a breakpoint can be set, with a parameter saying something in the lines of `$this->queryCount == 50`, so the debugger only breaks on that specific query.

Without `dev` and `showqueries=1`, performance is not impacted according to XHProf.

Behat failures are unrelated. I have no idea where those come from.