### PR TITLE
Add copyright note to contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,12 @@ Any open source product is only as good as the community behind it. You can part
 
 See our [high level overview](http://silverstripe.org/contributing-to-silverstripe) on silverstripe.org on how you can help out.
 
+## Copyright
+
+**IMPORTANT: By supplying code to the SilverStripe core team in patches, tickets and pull requests, you agree to assign copyright of that code to SilverStripe Limited, on the condition that SilverStripe Limited releases that code under the BSD license.**
+
+We ask for this so that the ownership in the license is clear and unambiguous, and so that community involvement doesn't stop us from being able to continue supporting these projects. By releasing this code under a permissive license, this copyright assignment won't prevent you from using the code in any way you see fit.
+
 ## Contributing code
 
 See [contributing code](docs/en/05_Contributing/01_Code.md)


### PR DESCRIPTION
This is important and so I think it shouldn't solely exist buried in the contributing guidelines.