### PR TITLE
BUGFIX: Fixed lookup of next closest visible field for focus restoring (fixes #5618)

### DIFF
--- a/admin/javascript/LeftAndMain.EditForm.js
+++ b/admin/javascript/LeftAndMain.EditForm.js
@@ -318,7 +318,7 @@
 
 					//Fall back to nearest visible element if hidden (for select type fields)
 					if(!$(elementID).is(':visible')){
-						elementID = '#' + $(elementID).closest('.field').attr('id');
+						elementID = '#' + $(elementID).closest('.field:visible').attr('id');
 						scrollY = $(elementID).position().top;
 					}
 


### PR DESCRIPTION
As mentioned in #5618 if a field is not visible LeftAndMain.EditForm.js looks to the immediate parent for the next visible element which may not always be true. This results in a JavaScript error when the vertical position of that element is attempted to be retrieved. This pull request simply changes the selector to look for the closest visible element with the field class.