### PR TITLE
API Allow table_name to be declared / introduce DataObjectSchema

### DIFF
--- a/admin/code/CampaignAdmin.php
+++ b/admin/code/CampaignAdmin.php
@@ -271,7 +271,7 @@ JSON;
 	 * @return array
 	 */
 	protected function getChangeSetItemResource(ChangeSetItem $changeSetItem) {
-		$baseClass = ClassInfo::baseDataClass($changeSetItem->ObjectClass);
+		$baseClass = DataObject::getSchema()->baseDataClass($changeSetItem->ObjectClass);
 		$baseSingleton = DataObject::singleton($baseClass);
 		$thumbnailWidth = (int)$this->config()->thumbnail_width;
 		$thumbnailHeight = (int)$this->config()->thumbnail_height;

--- a/control/Director.php
+++ b/control/Director.php
@@ -268,7 +268,7 @@ class Director implements TemplateGlobalProvider {
 
 		// These are needed so that calling Director::test() does not muck with whoever is calling it.
 		// Really, it's some inappropriate coupling and should be resolved by making less use of statics.
-		$oldStage = Versioned::get_stage();
+		$oldReadingMode = Versioned::get_reading_mode();
 		$getVars = array();
 
 		if (!$httpMethod) $httpMethod = ($postVars || is_array($postVars)) ? "POST" : "GET";
@@ -294,7 +294,7 @@ class Director implements TemplateGlobalProvider {
 		// Set callback to invoke prior to return
 		$onCleanup = function() use(
 			$existingRequestVars, $existingGetVars, $existingPostVars, $existingSessionVars,
-			$existingCookies, $existingServer, $existingRequirementsBackend, $oldStage
+			$existingCookies, $existingServer, $existingRequirementsBackend, $oldReadingMode
 		) {
 			// Restore the super globals
 			$_REQUEST = $existingRequestVars;
@@ -308,7 +308,7 @@ class Director implements TemplateGlobalProvider {
 
 			// These are needed so that calling Director::test() does not muck with whoever is calling it.
 			// Really, it's some inappropriate coupling and should be resolved by making less use of statics
-			Versioned::set_stage($oldStage);
+			Versioned::set_reading_mode($oldReadingMode);
 
 			Injector::unnest(); // Restore old CookieJar, etc
 			Config::unnest();

--- a/control/injector/Injector.php
+++ b/control/injector/Injector.php
@@ -918,6 +918,7 @@ class Injector {
 	 * Additional parameters are passed through as
 	 *
 	 * @param string $name
+	 * @param mixed $arguments,... arguments to pass to the constructor
 	 * @return mixed A new instance of the specified object
 	 */
 	public function create($name) {

--- a/core/ClassInfo.php
+++ b/core/ClassInfo.php
@@ -14,6 +14,8 @@ class ClassInfo {
 
 	/**
 	 * Wrapper for classes getter.
+	 *
+	 * @return array
 	 */
 	public static function allClasses() {
 		return SS_ClassLoader::instance()->getManifest()->getClasses();
@@ -93,7 +95,9 @@ class ClassInfo {
 		);
 
 		foreach ($classes as $class) {
-			if (DataObject::has_own_table($class)) $result[$class] = $class;
+			if (DataObject::has_own_table($class)) {
+				$result[$class] = $class;
+			}
 		}
 
 		return $result;
@@ -143,7 +147,9 @@ class ClassInfo {
 	 * @return array Names of all subclasses as an associative array.
 	 */
 	public static function subclassesFor($class) {
-		if(is_string($class) && !class_exists($class)) return array();
+		if(is_string($class) && !class_exists($class)) {
+			return [];
+		}
 
 		//normalise class case
 		$className = self::class_name($class);
@@ -163,21 +169,14 @@ class ClassInfo {
 	 * eg: self::class_name('dataobJEct'); //returns 'DataObject'
 	 *
 	 * @param string|object $nameOrObject The classname or object you want to normalise
-	 *
 	 * @return string The normalised class name
 	 */
 	public static function class_name($nameOrObject) {
 		if (is_object($nameOrObject)) {
 			return get_class($nameOrObject);
 		} elseif (!self::exists($nameOrObject)) {
-			Deprecation::notice(
-				'4.0',
-				"ClassInfo::class_name() passed a class that doesn't exist. Support for this will be removed in 4.0",
-				Deprecation::SCOPE_GLOBAL
-			);
-			return $nameOrObject;
+			throw new InvalidArgumentException("Class {$nameOrObject} doesn't exist");
 		}
-
 		$reflection = new ReflectionClass($nameOrObject);
 		return $reflection->getName();
 	}

--- a/core/ClassInfo.php
+++ b/core/ClassInfo.php
@@ -78,8 +78,9 @@ class ClassInfo {
 	 * Returns an array of the current class and all its ancestors and children
 	 * which require a DB table.
 	 *
+	 * @todo Move this into {@see DataObjectSchema}
+	 *
 	 * @param string|object $class
-	 * @todo Move this into data object
 	 * @return array
 	 */
 	public static function dataClassesFor($class) {
@@ -104,28 +105,11 @@ class ClassInfo {
 	}
 
 	/**
-	 * Returns the root class (the first to extend from DataObject) for the
-	 * passed class.
-	 *
-	 * @param  string|object $class
-	 * @return string
+	 * @deprecated 4.0..5.0
 	 */
 	public static function baseDataClass($class) {
-		if(is_string($class) && !class_exists($class)) return null;
-
-		$class = self::class_name($class);
-
-		if (!is_subclass_of($class, 'DataObject')) {
-			throw new InvalidArgumentException("$class is not a subclass of DataObject");
-		}
-
-		while ($next = get_parent_class($class)) {
-			if ($next == 'DataObject') {
-				return $class;
-			}
-
-			$class = $next;
-		}
+		Deprecation::notice('5.0', 'Use DataObject::getSchema()->baseDataClass()');
+		return DataObject::getSchema()->baseDataClass($class);
 	}
 
 	/**
@@ -174,8 +158,6 @@ class ClassInfo {
 	public static function class_name($nameOrObject) {
 		if (is_object($nameOrObject)) {
 			return get_class($nameOrObject);
-		} elseif (!self::exists($nameOrObject)) {
-			throw new InvalidArgumentException("Class {$nameOrObject} doesn't exist");
 		}
 		$reflection = new ReflectionClass($nameOrObject);
 		return $reflection->getName();
@@ -291,53 +273,12 @@ class ClassInfo {
 		return strtolower(self::$method_from_cache[$lClass][$lMethod]) == $lCompclass;
 	}
 
-
 	/**
-	 * Returns the table name in the class hierarchy which contains a given
-	 * field column for a {@link DataObject}. If the field does not exist, this
-	 * will return null.
-	 *
-	 * @param string $candidateClass
-	 * @param string $fieldName
-	 *
-	 * @return string
+	 * @deprecated 4.0..5.0
 	 */
 	public static function table_for_object_field($candidateClass, $fieldName) {
-		if(!$candidateClass
-			|| !$fieldName
-			|| !class_exists($candidateClass)
-			|| !is_subclass_of($candidateClass, 'DataObject')
-		) {
-			return null;
-		}
-
-		//normalise class name
-		$candidateClass = self::class_name($candidateClass);
-		$exists = self::exists($candidateClass);
-
-		// Short circuit for fixed fields
-		$fixed = DataObject::config()->fixed_fields;
-		if($exists && isset($fixed[$fieldName])) {
-			return self::baseDataClass($candidateClass);
-		}
-
-		// Find regular field
-		while($candidateClass && $candidateClass != 'DataObject' && $exists) {
-			if( DataObject::has_own_table($candidateClass)
-				&& DataObject::has_own_table_database_field($candidateClass, $fieldName)
-			) {
-				break;
-			}
-
-			$candidateClass = get_parent_class($candidateClass);
-			$exists = $candidateClass && self::exists($candidateClass);
-		}
-
-		if(!$candidateClass || !$exists) {
-			return null;
-		}
-
-		return $candidateClass;
+		Deprecation::notice('5.0', 'Use DataObject::getSchema()->tableForField()');
+		return DataObject::getSchema()->tableForField($candidateClass, $fieldName);
 	}
 }
 

--- a/core/Convert.php
+++ b/core/Convert.php
@@ -176,19 +176,13 @@ class Convert {
 	 * table, or column name. Supports encoding of multi identfiers separated by
 	 * a delimiter (e.g. ".")
 	 *
-	 * @param string|array $identifier The identifier to escape. E.g. 'SiteTree.Title'
+	 * @param string|array $identifier The identifier to escape. E.g. 'SiteTree.Title' or list of identifiers
+	 * to be joined via the separator.
 	 * @param string $separator The string that delimits subsequent identifiers
-	 * @return string|array The escaped identifier. E.g. '"SiteTree"."Title"'
+	 * @return string The escaped identifier. E.g. '"SiteTree"."Title"'
 	 */
 	public static function symbol2sql($identifier, $separator = '.') {
-		if(is_array($identifier)) {
-			foreach($identifier as $k => $v) {
-				$identifier[$k] = self::symbol2sql($v, $separator);
-			}
-			return $identifier;
-		} else {
-			return DB::get_conn()->escapeIdentifier($identifier, $separator);
-		}
+		return DB::get_conn()->escapeIdentifier($identifier, $separator);
 	}
 
 	/**

--- a/dev/Debug.php
+++ b/dev/Debug.php
@@ -90,10 +90,8 @@ class Debug {
 	}
 
 	/**
-	 * ??
-	 *
-	 * @param unknown_type $val
-	 * @return unknown
+	 * @param mixed $val
+	 * @return string
 	 */
 	public static function text($val) {
 		if(is_object($val)) {

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -83,7 +83,7 @@
    * Versioned constructor now only allows a single string to declare whether staging is enabled or not. The
      number of names of stages are no longer able to be specified. See below for upgrading notes for models
      with custom stages.
-   * `reading_stage` is now `set_stage`
+   * `reading_stage` is now `set_stage` and throws an error if setting an invalid stage.
    * `current_stage` is now `get_stage`
    * `getVersionedStages` is gone.
    * `get_live_stage` is removed. Use the `Versioned::LIVE` constant instead.
@@ -91,8 +91,13 @@
    * `$versionableExtensions` is now `private static` instead of `protected static`
    * `hasStages` is addded to check if an object has a given stage.
    * `stageTable` is added to get the table for a given class and stage.
+   * Any extension declared via `versionableExtensions` config on Versioned dataobject must now 
+     `VersionableExtension` interface at a minimum. `Translatable` has been removed from default
+     `versionableExtensions`
  * `ChangeSet` and `ChangeSetItem` have been added for batch publishing of versioned dataobjects.
  * `FormAction::setValidationExempt` can be used to turn on or off form validation for individual actions
+ * `DataObject.table_name` config can now be used to customise the database table for any record.
+ * `DataObjectSchema` class added to assist with mapping between classes and tables.
 
 ### Front-end build tooling for CMS interface
 
@@ -162,6 +167,10 @@ admin/font/                => admin/client/dist/font/
    * History.js
 
  * `debugmethods` querystring argument has been removed from debugging.
+ 
+ * The following ClassInfo methods are now deprecated:
+   * `ClassInfo::baseDataClass` - Use `DataObject::getSchema()->baseDataClass()` instead.
+   * `ClassInfo::table_for_object_field` - Use `DataObject::getSchema()->tableForField()` instead
 
 ### ORM
 
@@ -562,6 +571,36 @@ Take care for any code or functions which expect an object of type `SQLQuery`, a
 these references should be replaced with `SQLSelect`. Legacy code which generates
 `SQLQuery` can still communicate with new code that expects `SQLSelect` as it is a
 subclass of `SQLSelect`, but the inverse is not true.
+
+### Update code that references table names
+
+A major change in 4.0.0 is that now tables and class names can differ from model to model. In order to
+fix a table name, to prevent it being changed (for instance, when applying a namespace to a model)
+the `table_name` config can be applied to any DataObject class.
+
+
+	:::php
+	namespace SilverStripe\BannerManager;
+	class BannerImage extends \DataObject {
+		private static $table_name = 'BannerImage';
+	}
+
+
+In order to ensure you are using the correct table for any class a new [api:DataObjectSchema] service
+is available to manage these mappings.
+
+
+	:::php
+	public function countDuplicates($model, $fieldToCheck) {
+		$table = DataObject::getSchema()->tableForField($model, $field);
+		$query = new SQLSelect();
+		$query->setFrom("\"{$table}\"");
+		$query->setWhere(["\"{$table}\".\"{$field}\"" => $model->$fieldToCheck]);
+		return $query->count();
+	}
+
+
+See [versioned documentation](/developer_guides/model/data_model_and_orm) for more information.
 
 ### Update implementations of augmentSQL
 

--- a/filesystem/AssetControlExtension.php
+++ b/filesystem/AssetControlExtension.php
@@ -155,7 +155,7 @@ class AssetControlExtension extends \DataExtension
 		}
 
 		// Unauthenticated member to use for checking visibility
-		$baseClass = \ClassInfo::baseDataClass($this->owner);
+		$baseClass = $this->owner->baseClass();
 		$filter = array("\"{$baseClass}\".\"ID\"" => $this->owner->ID);
 		$stages = $this->owner->getVersionedStages(); // {@see Versioned::getVersionedStages}
 		foreach ($stages as $stage) {

--- a/model/DataList.php
+++ b/model/DataList.php
@@ -511,12 +511,7 @@ class DataList extends ViewableData implements SS_List, SS_Filterable, SS_Sortab
 				$relationModelName = $query->applyRelation($relations, $linearOnly);
 
 				// Find the db field the relation belongs to
-				$className = ClassInfo::table_for_object_field($relationModelName, $fieldName);
-				if(empty($className)) {
-					$className = $relationModelName;
-				}
-
-				$columnName = '"'.$className.'"."'.$fieldName.'"';
+				$columnName = DataObject::getSchema()->sqlColumnForField($relationModelName, $fieldName);
 			}
 		);
 	}

--- a/model/DataObjectSchema.php
+++ b/model/DataObjectSchema.php
@@ -1,0 +1,362 @@
+<?php
+
+use SilverStripe\Framework\Core\Configurable;
+use SilverStripe\Framework\Core\Injectable;
+use SilverStripe\Model\FieldType\DBComposite;
+
+/**
+ * Provides dataobject and database schema mapping functionality
+ */
+class DataObjectSchema {
+	use Injectable;
+	use Configurable;
+
+	/**
+	 * Default separate for table namespaces. Can be set to any string for
+	 * databases that do not support some characters.
+	 *
+	 * Defaults to \ to to conform to 3.x convention.
+	 *
+	 * @config
+	 * @var string
+	 */
+	private static $table_namespace_separator = '\\';
+
+	/**
+	 * Cache of database fields
+	 *
+	 * @var array
+	 */
+	protected $databaseFields = [];
+
+	/**
+	 * Cache of composite database field
+	 *
+	 * @var array
+	 */
+	protected $compositeFields = [];
+
+	/**
+	 * Cache of table names
+	 *
+	 * @var array
+	 */
+	protected $tableNames = [];
+
+	/**
+	 * Clear cached table names
+	 */
+	public function reset() {
+		$this->tableNames = [];
+		$this->databaseFields = [];
+		$this->compositeFields = [];
+	}
+
+	/**
+	 * Get all table names
+	 *
+	 * @return array
+	 */
+	public function getTableNames() {
+		$this->cacheTableNames();
+		return $this->tableNames;
+	}
+
+	/**
+	 * Given a DataObject class and a field on that class, determine the appropriate SQL for
+	 * selecting / filtering on in a SQL string. Note that $class must be a valid class, not an
+	 * arbitrary table.
+	 *
+	 * The result will be a standard ANSI-sql quoted string in "Table"."Column" format.
+	 *
+	 * @param string $class Class name (not a table).
+	 * @param string $field Name of field that belongs to this class (or a parent class)
+	 * @return string The SQL identifier string for the corresponding column for this field
+	 */
+	public function sqlColumnForField($class, $field) {
+		$table = $this->tableForField($class, $field);
+		if(!$table) {
+			throw new InvalidArgumentException("\"{$field}\" is not a field on class \"{$class}\"");
+		}
+		return "\"{$table}\".\"{$field}\"";
+	}
+
+	/**
+	 * Get table name for the given class.
+	 *
+	 * Note that this does not confirm a table actually exists (or should exist), but returns
+	 * the name that would be used if this table did exist.
+	 *
+	 * @param string $class
+	 * @return string Returns the table name, or null if there is no table
+	 */
+	public function tableName($class) {
+		$tables = $this->getTableNames();
+		$class = ClassInfo::class_name($class);
+		if(isset($tables[$class])) {
+			return $tables[$class];
+		}
+		return null;
+	}
+	/**
+	 * Returns the root class (the first to extend from DataObject) for the
+	 * passed class.
+	 *
+	 * @param string|object $class
+	 * @return string
+	 * @throws InvalidArgumentException
+	 */
+	public function baseDataClass($class) {
+		$class = ClassInfo::class_name($class);
+		$current = $class;
+		while ($next = get_parent_class($current)) {
+			if ($next === 'DataObject') {
+				return $current;
+			}
+			$current = $next;
+		}
+		throw new InvalidArgumentException("$class is not a subclass of DataObject");
+	}
+
+	/**
+	 * Get the base table
+	 *
+	 * @param string|object $class
+	 * @return string
+	 */
+	public function baseDataTable($class) {
+		return $this->tableName($this->baseDataClass($class));
+	}
+
+	/**
+	 * Find the class for the given table
+	 *
+	 * @param string $table
+	 * @return string|null The FQN of the class, or null if not found
+	 */
+	public function tableClass($table) {
+		$tables = $this->getTableNames();
+		$class = array_search($table, $tables, true);
+		if($class) {
+			return $class;
+		}
+
+		// If there is no class for this table, strip table modifiers (e.g. _Live / _versions)
+		// from the end and re-attempt a search.
+		if(preg_match('/^(?<class>.+)(_[^_]+)$/i', $table, $matches)) {
+			$table = $matches['class'];
+			$class = array_search($table, $tables, true);
+			if($class) {
+				return $class;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Cache all table names if necessary
+	 */
+	protected function cacheTableNames() {
+		if($this->tableNames) {
+			return;
+		}
+		$this->tableNames = [];
+		foreach(ClassInfo::subclassesFor('DataObject') as $class) {
+			if($class === 'DataObject') {
+				continue;
+			}
+			$table = $this->buildTableName($class);
+
+			// Check for conflicts
+			$conflict = array_search($table, $this->tableNames, true);
+			if($conflict) {
+				throw new LogicException(
+					"Multiple classes (\"{$class}\", \"{$conflict}\") map to the same table: \"{$table}\""
+				);
+			}
+			$this->tableNames[$class] = $table;
+		}
+	}
+
+	/**
+	 * Generate table name for a class.
+	 *
+	 * Note: some DB schema have a hard limit on table name length. This is not enforced by this method.
+	 * See dev/build errors for details in case of table name violation.
+	 *
+	 * @param string $class
+	 * @return string
+	 */
+	protected function buildTableName($class) {
+		$table = Config::inst()->get($class, 'table_name', Config::UNINHERITED);
+
+		// Generate default table name
+		if(!$table) {
+			$separator = $this->config()->table_namespace_separator;
+			$table = str_replace('\\', $separator, trim($class, '\\'));
+		}
+
+		return $table;
+	}
+
+	/**
+	 * Return the complete map of fields to specification on this object, including fixed_fields.
+	 * "ID" will be included on every table.
+	 *
+	 * @param string $class Class name to query from
+	 * @return array Map of fieldname to specification, similiar to {@link DataObject::$db}.
+	 */
+	public function databaseFields($class) {
+		$class = ClassInfo::class_name($class);
+		if($class === 'DataObject') {
+			return [];
+		}
+		$this->cacheDatabaseFields($class);
+		return $this->databaseFields[$class];
+	}
+
+	/**
+	 * Returns a list of all the composite if the given db field on the class is a composite field.
+	 * Will check all applicable ancestor classes and aggregate results.
+	 *
+	 * Can be called directly on an object. E.g. Member::composite_fields(), or Member::composite_fields(null, true)
+	 * to aggregate.
+	 *
+	 * Includes composite has_one (Polymorphic) fields
+	 *
+	 * @param string $class Name of class to check
+	 * @param bool $aggregated Include fields in entire hierarchy, rather than just on this table
+	 * @return array List of composite fields and their class spec
+	 */
+	public function compositeFields($class, $aggregated = true) {
+		$class = ClassInfo::class_name($class);
+		if($class === 'DataObject') {
+			return [];
+		}
+		$this->cacheDatabaseFields($class);
+
+		// Get fields for this class
+		$compositeFields = $this->compositeFields[$class];
+		if(!$aggregated) {
+			return $compositeFields;
+		}
+
+		// Recursively merge
+		$parentFields = $this->compositeFields(get_parent_class($class));
+		return array_merge($compositeFields, $parentFields);
+	}
+
+	/**
+	 * Cache all database and composite fields for the given class.
+	 * Will do nothing if already cached
+	 *
+	 * @param string $class Class name to cache
+	 */
+	protected function cacheDatabaseFields($class) {
+		// Skip if already cached
+		if (isset($this->databaseFields[$class]) && isset($this->compositeFields[$class])) {
+			return;
+		}
+		$compositeFields = array();
+		$dbFields = array();
+
+		// Ensure fixed fields appear at the start
+		$fixedFields = DataObject::config()->fixed_fields;
+		if(get_parent_class($class) === 'DataObject') {
+			// Merge fixed with ClassName spec and custom db fields
+			$dbFields = $fixedFields;
+		} else {
+			$dbFields['ID'] = $fixedFields['ID'];
+		}
+
+		// Check each DB value as either a field or composite field
+		$db = Config::inst()->get($class, 'db', Config::UNINHERITED) ?: array();
+		foreach($db as $fieldName => $fieldSpec) {
+			$fieldClass = strtok($fieldSpec, '(');
+			if(singleton($fieldClass) instanceof DBComposite) {
+				$compositeFields[$fieldName] = $fieldSpec;
+			} else {
+				$dbFields[$fieldName] = $fieldSpec;
+			}
+		}
+
+		// Add in all has_ones
+		$hasOne = Config::inst()->get($class, 'has_one', Config::UNINHERITED) ?: array();
+		foreach($hasOne as $fieldName => $hasOneClass) {
+			if($hasOneClass === 'DataObject') {
+				$compositeFields[$fieldName] = 'PolymorphicForeignKey';
+			} else {
+				$dbFields["{$fieldName}ID"] = 'ForeignKey';
+			}
+		}
+
+		// Merge composite fields into DB
+		foreach($compositeFields as $fieldName => $fieldSpec) {
+			$fieldObj = Object::create_from_string($fieldSpec, $fieldName);
+			$fieldObj->setTable($class);
+			$nestedFields = $fieldObj->compositeDatabaseFields();
+			foreach($nestedFields as $nestedName => $nestedSpec) {
+				$dbFields["{$fieldName}{$nestedName}"] = $nestedSpec;
+			}
+		}
+
+		// Prevent field-less tables
+		if(count($dbFields) < 2) {
+			$dbFields = [];
+		}
+
+		// Return cached results
+		$this->databaseFields[$class] = $dbFields;
+		$this->compositeFields[$class] = $compositeFields;
+	}
+
+	/**
+	 * Returns the table name in the class hierarchy which contains a given
+	 * field column for a {@link DataObject}. If the field does not exist, this
+	 * will return null.
+	 *
+	 * @param string $candidateClass
+	 * @param string $fieldName
+	 * @return string
+	 */
+	public function tableForField($candidateClass, $fieldName) {
+		$class = $this->classForField($candidateClass, $fieldName);
+		if($class) {
+			return $this->tableName($class);
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the class name in the class hierarchy which contains a given
+	 * field column for a {@link DataObject}. If the field does not exist, this
+	 * will return null.
+	 *
+	 * @param string $candidateClass
+	 * @param string $fieldName
+	 * @return string
+	 */
+	public function classForField($candidateClass, $fieldName)  {
+		// normalise class name
+		$candidateClass = ClassInfo::class_name($candidateClass);
+		if($candidateClass === 'DataObject') {
+			return null;
+		}
+
+		// Short circuit for fixed fields
+		$fixed = DataObject::config()->fixed_fields;
+		if(isset($fixed[$fieldName])) {
+			return $this->baseDataClass($candidateClass);
+		}
+
+		// Find regular field
+		while($candidateClass) {
+			$fields = $this->databaseFields($candidateClass);
+			if(isset($fields[$fieldName])) {
+				return $candidateClass;
+			}
+			$candidateClass = get_parent_class($candidateClass);
+		}
+		return null;
+	}
+}

--- a/model/FieldType/DBClassName.php
+++ b/model/FieldType/DBClassName.php
@@ -91,13 +91,14 @@ class DBClassName extends DBEnum {
 			return $this->baseClass;
 		}
 		// Default to the basename of the record
+		$schema = DataObject::getSchema();
 		if($this->record) {
-			return ClassInfo::baseDataClass($this->record);
+			return $schema->baseDataClass($this->record);
 		}
 		// During dev/build only the table is assigned
-		$tableClass = $this->getClassNameFromTable($this->getTable());
-		if($tableClass) {
-			return $tableClass;
+		$tableClass = $schema->tableClass($this->getTable());
+		if($tableClass && ($baseClass = $schema->baseDataClass($tableClass))) {
+			return $baseClass;
 		}
 		// Fallback to global default
 		return 'DataObject';
@@ -112,28 +113,6 @@ class DBClassName extends DBEnum {
 	public function setBaseClass($baseClass) {
 		$this->baseClass = $baseClass;
 		return $this;
-	}
-
-	/**
-	 * Given a table name, find the base data class
-	 *
-	 * @param string $table
-	 * @return string|null
-	 */
-	protected function getClassNameFromTable($table) {
-		if(empty($table)) {
-			return null;
-		}
-		$class = ClassInfo::baseDataClass($table);
-		if($class) {
-			return $class;
-		}
-		// If there is no class for this table, strip table modifiers (_Live / _versions) off the end
-		if(preg_match('/^(?<class>.+)(_[^_]+)$/i', $table, $matches)) {
-			return $this->getClassNameFromTable($matches['class']);
-		}
-
-		return null;
 	}
 
 	/**

--- a/model/HasManyList.php
+++ b/model/HasManyList.php
@@ -35,15 +35,18 @@ class HasManyList extends RelationList {
 	}
 
 	protected function foreignIDFilter($id = null) {
-		if ($id === null) $id = $this->getForeignID();
+		if ($id === null) {
+			$id = $this->getForeignID();
+		}
 
 		// Apply relation filter
-		$key = "\"$this->foreignKey\"";
+		$key = DataObject::getSchema()->sqlColumnForField($this->dataClass(), $this->getForeignKey());
 		if(is_array($id)) {
 			return array("$key IN (".DB::placeholders($id).")"  => $id);
 		} else if($id !== null){
 			return array($key => $id);
 		}
+		return null;
 	}
 
 	/**

--- a/model/HasManyList.php
+++ b/model/HasManyList.php
@@ -51,7 +51,7 @@ class HasManyList extends RelationList {
 	 *
 	 * It does so by setting the relationFilters.
 	 *
-	 * @param $item The DataObject to be added, or its ID
+	 * @param DataObject|int $item The DataObject to be added, or its ID
 	 */
 	public function add($item) {
 		if(is_numeric($item)) {
@@ -83,7 +83,7 @@ class HasManyList extends RelationList {
 	 *
 	 * Doesn't actually remove the item, it just clears the foreign key value.
 	 *
-	 * @param $itemID The ID of the item to be removed.
+	 * @param int $itemID The ID of the item to be removed.
 	 */
 	public function removeByID($itemID) {
 		$item = $this->byID($itemID);
@@ -95,7 +95,7 @@ class HasManyList extends RelationList {
 	 * Remove an item from this relation.
 	 * Doesn't actually remove the item, it just clears the foreign key value.
 	 *
-	 * @param $item The DataObject to be removed
+	 * @param DataObject $item The DataObject to be removed
 	 * @todo Maybe we should delete the object instead?
 	 */
 	public function remove($item) {

--- a/model/connect/DBConnector.php
+++ b/model/connect/DBConnector.php
@@ -175,26 +175,6 @@ abstract class DBConnector {
 	abstract public function quoteString($value);
 
 	/**
-	 * Escapes an identifier (table / database name). Typically the value
-	 * is simply double quoted. Don't pass in already escaped identifiers in,
-	 * as this will double escape the value!
-	 *
-	 * @param string $value The identifier to escape
-	 * @param string $separator optional identifier splitter
-	 */
-	public function escapeIdentifier($value, $separator = '.') {
-		// ANSI standard id escape is to surround with double quotes
-		if(empty($separator)) return '"'.trim($value).'"';
-
-		// Split, escape, and glue back multiple identifiers
-		$segments = array();
-		foreach(explode($separator, $value) as $item) {
-			$segments[] = $this->escapeIdentifier($item, null);
-		}
-		return implode($separator, $segments);
-	}
-
-	/**
 	 * Executes the following query with the specified error level.
 	 * Implementations of this function should respect previewWrite and benchmarkQuery
 	 *

--- a/model/connect/Database.php
+++ b/model/connect/Database.php
@@ -232,11 +232,18 @@ abstract class SS_Database {
 	 * is simply double quoted. Don't pass in already escaped identifiers in,
 	 * as this will double escape the value!
 	 *
-	 * @param string $value The identifier to escape
-	 * @param string $separator optional identifier splitter
+	 * @param string|array $value The identifier to escape or list of split components
+	 * @param string $separator Splitter for each component
+	 * @return string
 	 */
 	public function escapeIdentifier($value, $separator = '.') {
-		return $this->connector->escapeIdentifier($value, $separator);
+		// Split string into components
+		if(!is_array($value)) {
+			$value = explode($separator, $value);
+		}
+
+		// Implode quoted column
+		return '"' . implode('"'.$separator.'"', $value) . '"';
 	}
 
 	/**

--- a/model/queries/SQLExpression.php
+++ b/model/queries/SQLExpression.php
@@ -24,24 +24,6 @@ abstract class SQLExpression {
 	protected $replacementsNew = array();
 
 	/**
-	 * @deprecated since version 4.0
-	 */
-	public function __get($field) {
-		Deprecation::notice('4.0', 'use get{Field} to get the necessary protected field\'s value');
-		return $this->$field;
-	}
-
-	/**
-	 * @deprecated since version 4.0
-	 */
-	public function __set($field, $value) {
-		Deprecation::notice('4.0', 'use set{Field} to set the necessary protected field\'s value');
-		return $this->$field = $value;
-	}
-
-
-
-	/**
 	 * Swap some text in the SQL query with another.
 	 *
 	 * Note that values in parameters will not be replaced
@@ -125,7 +107,7 @@ abstract class SQLExpression {
 	 * Copies the query parameters contained in this object to another
 	 * SQLExpression
 	 *
-	 * @param SQLExpression $expression The object to copy properties to
+	 * @param SQLExpression $object The object to copy properties to
 	 */
 	protected function copyTo(SQLExpression $object) {
 		$target = array_keys(get_object_vars($object));

--- a/model/versioning/ChangeSetItem.php
+++ b/model/versioning/ChangeSetItem.php
@@ -67,7 +67,7 @@ class ChangeSetItem extends DataObject implements Thumbnail {
 
 	public function onBeforeWrite() {
 		// Make sure ObjectClass refers to the base data class in the case of old or wrong code
-		$this->ObjectClass = ClassInfo::baseDataClass($this->ObjectClass);
+		$this->ObjectClass = $this->getSchema()->baseDataClass($this->ObjectClass);
 		parent::onBeforeWrite();
 	}
 
@@ -328,7 +328,7 @@ class ChangeSetItem extends DataObject implements Thumbnail {
 	public static function get_for_object($object) {
 		return ChangeSetItem::get()->filter([
 			'ObjectID' => $object->ID,
-			'ObjectClass' => ClassInfo::baseDataClass($object)
+			'ObjectClass' => $object->baseClass(),
 		]);
 	}
 
@@ -342,7 +342,7 @@ class ChangeSetItem extends DataObject implements Thumbnail {
 	public static function get_for_object_by_id($objectID, $objectClass) {
 		return ChangeSetItem::get()->filter([
 			'ObjectID' => $objectID,
-			'ObjectClass' => ClassInfo::baseDataClass($objectClass)
+			'ObjectClass' => static::getSchema()->baseDataClass($objectClass)
 		]);
 	}
 

--- a/model/versioning/VersionableExtension.php
+++ b/model/versioning/VersionableExtension.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Minimum level extra fields required by extensions that are versonable
+ */
+interface VersionableExtension {
+
+	/**
+	 * Determine if the given table is versionable
+	 *
+	 * @param string $table
+	 * @return bool True if versioned tables should be built for the given suffix
+	 */
+	public function isVersionedTable($table);
+
+	/**
+	 * Update fields and indexes for the versonable suffix table
+	 *
+	 * @param string $suffix Table suffix being built
+	 * @param array $fields List of fields in this model
+	 * @param array $indexes List of indexes in this model
+	 */
+	public function updateVersionableFields($suffix, &$fields, &$indexes);
+}

--- a/search/SearchContext.php
+++ b/search/SearchContext.php
@@ -93,8 +93,11 @@ class SearchContext extends Object {
 	 */
 	protected function applyBaseTableFields() {
 		$classes = ClassInfo::dataClassesFor($this->modelClass);
-		$fields = array("\"".ClassInfo::baseDataClass($this->modelClass).'".*');
-		if($this->modelClass != $classes[0]) $fields[] = '"'.$classes[0].'".*';
+		$baseTable = DataObject::getSchema()->baseDataTable($this->modelClass);
+		$fields = array("\"{$baseTable}\".*");
+		if($this->modelClass != $classes[0]) {
+			$fields[] = '"'.$classes[0].'".*';
+		}
 		//$fields = array_keys($model->db());
 		$fields[] = '"'.$classes[0].'".\"ClassName\" AS "RecordClassName"';
 		return $fields;

--- a/search/SearchContext.php
+++ b/search/SearchContext.php
@@ -108,11 +108,12 @@ class SearchContext extends Object {
 	 *  If a filter is applied to a relationship in dot notation,
 	 *  the parameter name should have the dots replaced with double underscores,
 	 *  for example "Comments__Name" instead of the filter name "Comments.Name".
-	 * @param string|array $sort Database column to sort on.
+	 * @param array|bool|string $sort Database column to sort on.
 	 *  Falls back to {@link DataObject::$default_sort} if not provided.
-	 * @param string|array $limit
+	 * @param array|bool|string $limit
 	 * @param DataList $existingQuery
 	 * @return DataList
+	 * @throws Exception
 	 */
 	public function getQuery($searchParams, $sort = false, $limit = false, $existingQuery = null) {
 		if($existingQuery) {
@@ -140,7 +141,6 @@ class SearchContext extends Object {
 		$query = $query->sort($sort);
 
 		// hack to work with $searchParems when it's an Object
-		$searchParamArray = array();
 		if (is_object($searchParams)) {
 			$searchParamArray = $searchParams->getVars();
 		} else {
@@ -171,9 +171,10 @@ class SearchContext extends Object {
 	 * @todo rearrange start and limit params to reflect DataObject
 	 *
 	 * @param array $searchParams
-	 * @param string|array $sort
-	 * @param string|array $limit
+	 * @param array|bool|string $sort
+	 * @param array|bool|string $limit
 	 * @return SS_List
+	 * @throws Exception
 	 */
 	public function getResults($searchParams, $sort = false, $limit = false) {
 		$searchParams = array_filter((array)$searchParams, array($this,'clearEmptySearchFields'));
@@ -186,7 +187,7 @@ class SearchContext extends Object {
 	 * Callback map function to filter fields with empty values from
 	 * being included in the search expression.
 	 *
-	 * @param unknown_type $value
+	 * @param mixed $value
 	 * @return boolean
 	 */
 	public function clearEmptySearchFields($value) {

--- a/search/filters/ExactMatchFilter.php
+++ b/search/filters/ExactMatchFilter.php
@@ -27,6 +27,7 @@ class ExactMatchFilter extends SearchFilter {
 	/**
 	 * Applies an exact match (equals) on a field value.
 	 *
+	 * @param DataQuery $query
 	 * @return DataQuery
 	 */
 	protected function applyOne(DataQuery $query) {
@@ -36,6 +37,7 @@ class ExactMatchFilter extends SearchFilter {
 	/**
 	 * Excludes an exact match (equals) on a field value.
 	 *
+	 * @param DataQuery $query
 	 * @return DataQuery
 	 */
 	protected function excludeOne(DataQuery $query) {
@@ -81,6 +83,7 @@ class ExactMatchFilter extends SearchFilter {
 	 * Applies an exact match (equals) on a field value against multiple
 	 * possible values.
 	 *
+	 * @param DataQuery $query
 	 * @return DataQuery
 	 */
 	protected function applyMany(DataQuery $query) {
@@ -91,6 +94,7 @@ class ExactMatchFilter extends SearchFilter {
 	 * Excludes an exact match (equals) on a field value against multiple
 	 * possible values.
 	 *
+	 * @param DataQuery $query
 	 * @return DataQuery
 	 */
 	protected function excludeMany(DataQuery $query) {

--- a/search/filters/FulltextFilter.php
+++ b/search/filters/FulltextFilter.php
@@ -51,6 +51,7 @@ class FulltextFilter extends SearchFilter {
 	 * 	MyDataObject::get()->filter('SearchFields:fulltext', 'search term')
 	 * </code>
 	 *
+	 * @throws Exception
 	 * @return string
 	*/
 	public function getDbName() {
@@ -65,8 +66,11 @@ class FulltextFilter extends SearchFilter {
 				if(preg_match('/^fulltext\s+\((.+)\)$/i', $index, $matches)) {
 					return $this->prepareColumns($matches[1]);
 				} else {
-					throw new Exception("Invalid fulltext index format for '" . $this->getName()
-						. "' on '" . $this->model . "'");
+					throw new Exception(sprintf(
+						"Invalid fulltext index format for '%s' on '%s'",
+						$this->getName(),
+						$this->model
+					));
 				}
 			}
 		}
@@ -78,13 +82,14 @@ class FulltextFilter extends SearchFilter {
 	 * Adds table identifier to the every column.
 	 * Columns must have table identifier to prevent duplicate column name error.
 	 *
+	 * @param array $columns
 	 * @return string
-	*/
+	 */
 	protected function prepareColumns($columns) {
 		$cols = preg_split('/"?\s*,\s*"?/', trim($columns, '(") '));
-		$class = ClassInfo::table_for_object_field($this->model, current($cols));
-		$cols = array_map(function($col) use ($class) {
-			return sprintf('"%s"."%s"', $class, $col);
+		$table = DataObject::getSchema()->tableForField($this->model, current($cols));
+		$cols = array_map(function($col) use ($table) {
+			return sprintf('"%s"."%s"', $table, $col);
 		}, $cols);
 		return implode(',', $cols);
 	}

--- a/search/filters/SearchFilter.php
+++ b/search/filters/SearchFilter.php
@@ -161,9 +161,10 @@ abstract class SearchFilter extends Object {
 	 */
 	public function getDbName() {
 		// Special handler for "NULL" relations
-		if($this->name == "NULL") {
+		if($this->name === "NULL") {
 			return $this->name;
 		}
+
 		// Ensure that we're dealing with a DataObject.
 		if (!is_subclass_of($this->model, 'DataObject')) {
 			throw new InvalidArgumentException(
@@ -171,19 +172,16 @@ abstract class SearchFilter extends Object {
 			);
 		}
 
-		$candidateClass = ClassInfo::table_for_object_field(
-			$this->model,
-			$this->name
-		);
-
-		if($candidateClass == 'DataObject') {
+		// Find table this field belongs to
+		$table = DataObject::getSchema()->tableForField($this->model, $this->name);
+		if(!$table) {
 			// fallback to the provided name in the event of a joined column
 			// name (as the candidate class doesn't check joined records)
 			$parts = explode('.', $this->fullName);
 			return '"' . implode('"."', $parts) . '"';
 		}
 
-		return sprintf('"%s"."%s"', $candidateClass, $this->name);
+		return sprintf('"%s"."%s"', $table, $this->name);
 	}
 
 	/**

--- a/tests/model/ChangeSetItemTest.php
+++ b/tests/model/ChangeSetItemTest.php
@@ -28,7 +28,7 @@ class ChangeSetItemTest extends SapphireTest {
 
 		$item = new ChangeSetItem([
 			'ObjectID' => $object->ID,
-			'ObjectClass' => ClassInfo::baseDataClass($object->ClassName)
+			'ObjectClass' => $object->baseClass(),
 		]);
 
 		$this->assertEquals(
@@ -80,7 +80,7 @@ class ChangeSetItemTest extends SapphireTest {
 
 		$item = new ChangeSetItem([
 			'ObjectID' => $object->ID,
-			'ObjectClass' => ClassInfo::baseDataClass($object)
+			'ObjectClass' => $object->baseClass(),
 		]);
 		$item->write();
 

--- a/tests/model/ChangeSetTest.php
+++ b/tests/model/ChangeSetTest.php
@@ -150,7 +150,10 @@ class ChangeSetTest extends SapphireTest {
 			$object = $this->objFromFixture($class, $identifier);
 
 			foreach($items as $i => $item) {
-				if ($item->ObjectClass == ClassInfo::baseDataClass($object) && $item->ObjectID == $object->ID && $item->Added == $mode) {
+				if ( $item->ObjectClass == $object->baseClass()
+					&& $item->ObjectID == $object->ID
+					&& $item->Added == $mode
+				) {
 					unset($items[$i]);
 					continue 2;
 				}
@@ -171,7 +174,7 @@ class ChangeSetTest extends SapphireTest {
 			);
 		}
 	}
-	
+
 	public function testAddObject() {
 		$cs = new ChangeSet();
 		$cs->write();

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -9,32 +9,10 @@ class DataListTest extends SapphireTest {
 	// Borrow the model from DataObjectTest
 	protected static $fixture_file = 'DataObjectTest.yml';
 
-	protected $extraDataObjects = array(
-		// From DataObjectTest
-		'DataObjectTest_Team',
-		'DataObjectTest_Fixture',
-		'DataObjectTest_SubTeam',
-		'OtherSubclassWithSameField',
-		'DataObjectTest_FieldlessTable',
-		'DataObjectTest_FieldlessSubTable',
-		'DataObjectTest_ValidatedObject',
-		'DataObjectTest_Player',
-		'DataObjectTest_TeamComment',
-		'DataObjectTest_EquipmentCompany',
-		'DataObjectTest_SubEquipmentCompany',
-		'DataObjectTest\NamespacedClass',
-		'DataObjectTest\RelationClass',
-		'DataObjectTest_ExtendedTeamComment',
-		'DataObjectTest_Company',
-		'DataObjectTest_Staff',
-		'DataObjectTest_CEO',
-		'DataObjectTest_Fan',
-		'DataObjectTest_Play',
-		'DataObjectTest_Ploy',
-		'DataObjectTest_Bogey',
-		'ManyManyListTest_Product',
-		'ManyManyListTest_Category',
-	);
+	public function setUpOnce() {
+		$this->extraDataObjects = DataObjectTest::$extra_data_objects;
+		parent::setUpOnce();
+	}
 
 	public function testFilterDataObjectByCreatedDate() {
 		// create an object to test with

--- a/tests/model/DataObjectSchemaTest.php
+++ b/tests/model/DataObjectSchemaTest.php
@@ -1,0 +1,354 @@
+<?php
+
+/**
+ * Tests schema inspection of DataObjects
+ */
+class DataObjectSchemaTest extends SapphireTest
+{
+	protected static $fixture_file = 'DataObjectSchemaTest.yml';
+
+	protected $extraDataObjects = array(
+		// Classes in base namespace
+		'DataObjectSchemaTest_BaseClass',
+		'DataObjectSchemaTest_BaseDataClass',
+		'DataObjectSchemaTest_ChildClass',
+		'DataObjectSchemaTest_GrandChildClass',
+		'DataObjectSchemaTest_HasFields',
+		'DataObjectSchemaTest_NoFields',
+		'DataObjectSchemaTest_WithCustomTable',
+		'DataObjectSchemaTest_WithRelation',
+		// Classes in sub-namespace (See DataObjectSchemaTest_Namespacejd.php)
+		'Namespaced\DOST\MyObject',
+		'Namespaced\DOST\MyObject_CustomTable',
+		'Namespaced\DOST\MyObject_NestedObject',
+		'Namespaced\DOST\MyObject_NamespacedTable',
+		'Namespaced\DOST\MyObject_Namespaced_Subclass',
+		'Namespaced\DOST\MyObject_NoFields',
+	);
+
+	/**
+	 * Test table name generation
+	 */
+	public function testTableName() {
+		$schema = DataObject::getSchema();
+
+		// Non-namespaced tables
+		$this->assertEquals(
+			'DataObjectSchemaTest_WithRelation',
+			$schema->tableName('DataObjectSchemaTest_WithRelation')
+		);
+		$this->assertEquals(
+			'DOSTWithCustomTable',
+			$schema->tableName('DataObjectSchemaTest_WithCustomTable')
+		);
+
+		// Namespaced tables
+		$this->assertEquals(
+			'Namespaced\DOST\MyObject',
+			$schema->tableName('Namespaced\DOST\MyObject')
+		);
+		$this->assertEquals(
+			'CustomNamespacedTable',
+			$schema->tableName('Namespaced\DOST\MyObject_CustomTable')
+		);
+		$this->assertEquals(
+			'Namespaced\DOST\MyObject_NestedObject',
+			$schema->tableName('Namespaced\DOST\MyObject_NestedObject')
+		);
+		$this->assertEquals(
+			'Custom\NamespacedTable',
+			$schema->tableName('Namespaced\DOST\MyObject_NamespacedTable')
+		);
+		$this->assertEquals(
+			'Custom\SubclassedTable',
+			$schema->tableName('Namespaced\DOST\MyObject_Namespaced_Subclass')
+		);
+		$this->assertEquals(
+			'Namespaced\DOST\MyObject_NoFields',
+			$schema->tableName('Namespaced\DOST\MyObject_NoFields')
+		);
+	}
+
+	/**
+	 * Test that the class name is convertable from the table
+	 */
+	public function testClassNameForTable() {
+		$schema = DataObject::getSchema();
+
+		// Tables that aren't classes
+		$this->assertNull($schema->tableClass('NotARealTable'));
+
+
+		// Non-namespaced tables
+		$this->assertEquals(
+			'DataObjectSchemaTest_WithRelation',
+			$schema->tableClass('DataObjectSchemaTest_WithRelation')
+		);
+		$this->assertEquals(
+			'DataObjectSchemaTest_WithCustomTable',
+			$schema->tableClass('DOSTWithCustomTable')
+		);
+
+		// Namespaced tables
+		$this->assertEquals(
+			'Namespaced\DOST\MyObject',
+			$schema->tableClass('Namespaced\DOST\MyObject')
+		);
+		$this->assertEquals(
+			'Namespaced\DOST\MyObject_CustomTable',
+			$schema->tableClass('CustomNamespacedTable')
+		);
+		$this->assertEquals(
+			'Namespaced\DOST\MyObject_NestedObject',
+			$schema->tableClass('Namespaced\DOST\MyObject_NestedObject')
+		);
+		$this->assertEquals(
+			'Namespaced\DOST\MyObject_NamespacedTable',
+			$schema->tableClass('Custom\NamespacedTable')
+		);
+		$this->assertEquals(
+			'Namespaced\DOST\MyObject_Namespaced_Subclass',
+			$schema->tableClass('Custom\SubclassedTable')
+		);
+		$this->assertEquals(
+			'Namespaced\DOST\MyObject_NoFields',
+			$schema->tableClass('Namespaced\DOST\MyObject_NoFields')
+		);
+	}
+
+	/**
+	 * Test non-namespaced tables
+	 */
+	public function testTableForObjectField() {
+		$schema = DataObject::getSchema();
+		$this->assertEquals(
+			'DataObjectSchemaTest_WithRelation',
+			$schema->tableForField('DataObjectSchemaTest_WithRelation', 'RelationID')
+		);
+
+		$this->assertEquals(
+			'DataObjectSchemaTest_WithRelation',
+			$schema->tableForField('DataObjectSchemaTest_withrelation', 'RelationID')
+		);
+
+		$this->assertEquals(
+			'DataObjectSchemaTest_BaseDataClass',
+			$schema->tableForField('DataObjectSchemaTest_BaseDataClass', 'Title')
+		);
+
+		$this->assertEquals(
+			'DataObjectSchemaTest_BaseDataClass',
+			$schema->tableForField('DataObjectSchemaTest_HasFields', 'Title')
+		);
+
+		$this->assertEquals(
+			'DataObjectSchemaTest_BaseDataClass',
+			$schema->tableForField('DataObjectSchemaTest_NoFields', 'Title')
+		);
+
+		$this->assertEquals(
+			'DataObjectSchemaTest_BaseDataClass',
+			$schema->tableForField('DataObjectSchemaTest_nofields', 'Title')
+		);
+
+		$this->assertEquals(
+			'DataObjectSchemaTest_HasFields',
+			$schema->tableForField('DataObjectSchemaTest_HasFields', 'Description')
+		);
+
+		// Class and table differ for this model
+		$this->assertEquals(
+			'DOSTWithCustomTable',
+			$schema->tableForField('DataObjectSchemaTest_WithCustomTable', 'Description')
+		);
+		$this->assertEquals(
+			'DataObjectSchemaTest_WithCustomTable',
+			$schema->classForField('DataObjectSchemaTest_WithCustomTable', 'Description')
+		);
+		$this->assertNull(
+			$schema->tableForField('DataObjectSchemaTest_WithCustomTable', 'NotAField')
+		);
+		$this->assertNull(
+			$schema->classForField('DataObjectSchemaTest_WithCustomTable', 'NotAField')
+		);
+
+		// Non-existant fields shouldn't match any table
+		$this->assertNull(
+			$schema->tableForField('DataObjectSchemaTest_BaseClass', 'Nonexist')
+		);
+
+		$this->assertNull(
+			$schema->tableForField('Object', 'Title')
+		);
+
+		// Test fixed fields
+		$this->assertEquals(
+			'DataObjectSchemaTest_BaseDataClass',
+			$schema->tableForField('DataObjectSchemaTest_HasFields', 'ID')
+		);
+		$this->assertEquals(
+			'DataObjectSchemaTest_BaseDataClass',
+			$schema->tableForField('DataObjectSchemaTest_NoFields', 'Created')
+		);
+	}
+
+	/**
+	 * Check table for fields with namespaced objects can be found
+	 */
+	public function testTableForNamespacedObjectField() {
+		$schema = DataObject::getSchema();
+
+		// MyObject
+		$this->assertEquals(
+			'Namespaced\DOST\MyObject',
+			$schema->tableForField('Namespaced\DOST\MyObject', 'Title')
+		);
+
+		// MyObject_CustomTable
+		$this->assertEquals(
+			'CustomNamespacedTable',
+			$schema->tableForField('Namespaced\DOST\MyObject_CustomTable', 'Title')
+		);
+
+		// MyObject_NestedObject
+		$this->assertEquals(
+			'Namespaced\DOST\MyObject',
+			$schema->tableForField('Namespaced\DOST\MyObject_NestedObject', 'Title')
+		);
+		$this->assertEquals(
+			'Namespaced\DOST\MyObject_NestedObject',
+			$schema->tableForField('Namespaced\DOST\MyObject_NestedObject', 'Content')
+		);
+
+		// MyObject_NamespacedTable
+		$this->assertEquals(
+			'Custom\NamespacedTable',
+			$schema->tableForField('Namespaced\DOST\MyObject_NamespacedTable', 'Description')
+		);
+		$this->assertEquals(
+			'Custom\NamespacedTable',
+			$schema->tableForField('Namespaced\DOST\MyObject_NamespacedTable', 'OwnerID')
+		);
+
+		// MyObject_Namespaced_Subclass
+		$this->assertEquals(
+			'Custom\NamespacedTable',
+			$schema->tableForField('Namespaced\DOST\MyObject_Namespaced_Subclass', 'OwnerID')
+		);
+		$this->assertEquals(
+			'Custom\NamespacedTable',
+			$schema->tableForField('Namespaced\DOST\MyObject_Namespaced_Subclass', 'Title')
+		);
+		$this->assertEquals(
+			'Custom\NamespacedTable',
+			$schema->tableForField('Namespaced\DOST\MyObject_Namespaced_Subclass', 'ID')
+		);
+		$this->assertEquals(
+			'Custom\SubclassedTable',
+			$schema->tableForField('Namespaced\DOST\MyObject_Namespaced_Subclass', 'Details')
+		);
+
+		// MyObject_NoFields
+		$this->assertEquals(
+			'Namespaced\DOST\MyObject_NoFields',
+			$schema->tableForField('Namespaced\DOST\MyObject_NoFields', 'Created')
+		);
+	}
+
+	/**
+	 * Test that relations join on the correct columns
+	 */
+	public function testRelationsQuery() {
+		$namespaced1 = $this->objFromFixture('Namespaced\DOST\MyObject_NamespacedTable', 'namespaced1');
+		$nofields = $this->objFromFixture('Namespaced\DOST\MyObject_NoFields', 'nofields1');
+		$subclass1 = $this->objFromFixture('Namespaced\DOST\MyObject_Namespaced_Subclass', 'subclass1');
+		$customtable1 = $this->objFromFixture('Namespaced\DOST\MyObject_CustomTable', 'customtable1');
+		$customtable3 = $this->objFromFixture('Namespaced\DOST\MyObject_CustomTable', 'customtable3');
+
+		// Check has_one / has_many
+		$this->assertEquals($nofields->ID, $namespaced1->Owner()->ID);
+		$this->assertDOSEquals([
+			['Title' => 'Namespaced 1'],
+		], $nofields->Owns());
+
+		// Check many_many / belongs_many_many
+		$this->assertDOSEquals(
+			[
+				['Title' => 'Custom Table 1'],
+				['Title' => 'Custom Table 2'],
+			],
+			$subclass1->Children()
+		);
+		$this->assertDOSEquals(
+			[
+				['Title' => 'Subclass 1', 'Details' => 'Oh, Hi!',]]
+			,
+			$customtable1->Parents()
+		);
+		$this->assertEmpty($customtable3->Parents()->count());
+
+	}
+
+
+	/**
+	 * @covers DataObjectSchema::baseDataClass()
+	 */
+	public function testBaseDataClass() {
+		$schema = DataObject::getSchema();
+
+		$this->assertEquals('DataObjectSchemaTest_BaseClass', $schema->baseDataClass('DataObjectSchemaTest_BaseClass'));
+		$this->assertEquals('DataObjectSchemaTest_BaseClass', $schema->baseDataClass('DataObjectSchemaTest_baseclass'));
+		$this->assertEquals('DataObjectSchemaTest_BaseClass', $schema->baseDataClass('DataObjectSchemaTest_ChildClass'));
+		$this->assertEquals('DataObjectSchemaTest_BaseClass', $schema->baseDataClass('DataObjectSchemaTest_CHILDCLASS'));
+		$this->assertEquals('DataObjectSchemaTest_BaseClass', $schema->baseDataClass('DataObjectSchemaTest_GrandChildClass'));
+		$this->assertEquals('DataObjectSchemaTest_BaseClass', $schema->baseDataClass('DataObjectSchemaTest_GRANDChildClass'));
+
+		$this->setExpectedException('InvalidArgumentException');
+		$schema->baseDataClass('DataObject');
+	}
+}
+
+class DataObjectSchemaTest_BaseClass extends DataObject implements TestOnly {
+
+}
+
+class DataObjectSchemaTest_ChildClass extends DataObjectSchemaTest_BaseClass {
+
+}
+
+class DataObjectSchemaTest_GrandChildClass extends DataObjectSchemaTest_ChildClass {
+
+}
+
+class DataObjectSchemaTest_BaseDataClass extends DataObject implements TestOnly {
+
+	private static $db = array(
+		'Title' => 'Varchar'
+	);
+}
+
+
+class DataObjectSchemaTest_NoFields extends DataObjectSchemaTest_BaseDataClass {
+
+}
+
+class DataObjectSchemaTest_HasFields extends DataObjectSchemaTest_NoFields {
+
+	private static $db = array(
+		'Description' => 'Varchar'
+	);
+}
+
+class DataObjectSchemaTest_WithCustomTable extends DataObjectSchemaTest_NoFields {
+	private static $table_name = 'DOSTWithCustomTable';
+	private static $db = array(
+		'Description' => 'Text'
+	);
+}
+
+class DataObjectSchemaTest_WithRelation extends DataObjectSchemaTest_NoFields {
+
+	private static $has_one = array(
+		'Relation' => 'DataObjectSchemaTest_HasFields'
+	);
+}

--- a/tests/model/DataObjectSchemaTest.yml
+++ b/tests/model/DataObjectSchemaTest.yml
@@ -1,0 +1,36 @@
+Namespaced\DOST\MyObject:
+  object1:
+    Title: 'Object 1'
+    Description: 'Description 1'
+
+Namespaced\DOST\MyObject_CustomTable:
+  customtable1:
+    Title: 'Custom Table 1'
+    Description: 'Description A'
+  customtable2:
+    Title: 'Custom Table 2'
+    Description: 'Description B'
+  customtable3:
+    Title: 'Custom Table 3'
+    Description: 'Orphaned item'
+
+Namespaced\DOST\MyObject_NestedObject:
+  nested1:
+    Title: 'Nested 1'
+    Description: 'Nested Description'
+    Content: '<p>Hello!</p>'
+
+Namespaced\DOST\MyObject_NoFields:
+  nofields1: {}
+
+Namespaced\DOST\MyObject_NamespacedTable:
+  namespaced1:
+    Title: 'Namespaced 1'
+    Owner: =>Namespaced\DOST\MyObject_NoFields.nofields1
+
+Namespaced\DOST\MyObject_Namespaced_Subclass:
+  subclass1:
+    Title: 'Subclass 1'
+    Details: 'Oh, Hi!'
+    Children: =>Namespaced\DOST\MyObject_CustomTable.customtable1, =>Namespaced\DOST\MyObject_CustomTable.customtable2
+

--- a/tests/model/DataObjectSchemaTest_Namespaced.php
+++ b/tests/model/DataObjectSchemaTest_Namespaced.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Namespaced dataobjcets used by DataObjectSchemaTest
+ */
+namespace Namespaced\DOST;
+
+/**
+ * Basic namespaced object
+ */
+class MyObject extends \DataObject implements \TestOnly {
+	private static $db = [
+		'Title' => 'Varchar',
+		'Description' => 'Text',
+	];
+}
+
+/**
+ * Namespaced object with custom table
+ */
+class MyObject_CustomTable extends \DataObject implements \TestOnly {
+	private static $table_name = 'CustomNamespacedTable';
+	private static $db = [
+		'Title' => 'Varchar',
+		'Description' => 'Text',
+	];
+
+	private static $belongs_many_many = [
+		'Parents' => 'Namespaced\DOST\MyObject_Namespaced_Subclass',
+	];
+}
+
+/**
+ * Namespaced subclassed object
+ */
+class MyObject_NestedObject extends MyObject implements \TestOnly {
+	private static $db = [
+		'Content' => 'HTMLText',
+	];
+}
+
+/**
+ * Namespaced object with custom table that itself is namespaced
+ */
+class MyObject_NamespacedTable extends \DataObject implements \TestOnly {
+	private static $table_name = 'Custom\NamespacedTable';
+	private static $db = [
+		'Title' => 'Varchar',
+		'Description' => 'Text',
+	];
+	private static $has_one = [
+		'Owner' => 'Namespaced\DOST\MyObject_NoFields',
+	];
+}
+
+/**
+ * Subclass of a namespaced class
+ * Has a many_many to another namespaced table
+ */
+class MyObject_Namespaced_Subclass extends MyObject_NamespacedTable implements \TestOnly {
+	private static $table_name = 'Custom\SubclassedTable';
+	private static $db = [
+		'Details' => 'Varchar',
+	];
+	private static $many_many = [
+		'Children' => 'Namespaced\DOST\MyObject_CustomTable',
+	];
+}
+
+/**
+ * Namespaced class without any fields
+ * has a has_many to another namespaced table
+ */
+class MyObject_NoFields extends \DataObject implements \TestOnly {
+	private static $has_many = [
+		'Owns' => 'Namespaced\DOST\MyObject_NamespacedTable',
+	];
+}

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -10,7 +10,12 @@ class DataObjectTest extends SapphireTest {
 
 	protected static $fixture_file = 'DataObjectTest.yml';
 
-	protected $extraDataObjects = array(
+	/**
+	 * Standard set of dataobject test classes
+	 *
+	 * @var array
+	 */
+	public static $extra_data_objects = array(
 		'DataObjectTest_Team',
 		'DataObjectTest_Fixture',
 		'DataObjectTest_SubTeam',
@@ -32,9 +37,16 @@ class DataObjectTest extends SapphireTest {
 		'DataObjectTest_Play',
 		'DataObjectTest_Ploy',
 		'DataObjectTest_Bogey',
+		// From ManyManyListTest
+		'ManyManyListTest_ExtraFields',
 		'ManyManyListTest_Product',
 		'ManyManyListTest_Category',
 	);
+
+	public function setUpOnce() {
+		$this->extraDataObjects = static::$extra_data_objects;
+		parent::setUpOnce();
+	}
 
 	public function testDb() {
 		$obj = new DataObjectTest_TeamComment();

--- a/tests/model/DataQueryTest.php
+++ b/tests/model/DataQueryTest.php
@@ -75,7 +75,7 @@ class DataQueryTest extends SapphireTest {
 
 		//test many_many with separate inheritance
 		$newDQ = new DataQuery('DataQueryTest_C');
-		$baseDBTable = ClassInfo::baseDataClass('DataQueryTest_C');
+		$baseDBTable = DataObject::getSchema()->baseDataTable('DataQueryTest_C');
 		$newDQ->applyRelation('ManyTestAs');
 		//check we are "joined" to the DataObject's table (there is no distinction between FROM or JOIN clauses)
 		$this->assertTrue($newDQ->query()->isJoinedTo($baseDBTable));
@@ -84,7 +84,7 @@ class DataQueryTest extends SapphireTest {
 
 		//test many_many with shared inheritance
 		$newDQ = new DataQuery('DataQueryTest_E');
-		$baseDBTable = ClassInfo::baseDataClass('DataQueryTest_E');
+		$baseDBTable = DataObject::getSchema()->baseDataTable('DataQueryTest_E');
 		//check we are "joined" to the DataObject's table (there is no distinction between FROM or JOIN clauses)
 		$this->assertTrue($newDQ->query()->isJoinedTo($baseDBTable));
 		//check we are explicitly selecting "FROM" the DO's table

--- a/tests/model/HasManyListTest.php
+++ b/tests/model/HasManyListTest.php
@@ -5,32 +5,10 @@ class HasManyListTest extends SapphireTest {
 	// Borrow the model from DataObjectTest
 	protected static $fixture_file = 'DataObjectTest.yml';
 
-	protected $extraDataObjects = array(
-		// From DataObjectTest
-		'DataObjectTest_Team',
-		'DataObjectTest_Fixture',
-		'DataObjectTest_SubTeam',
-		'OtherSubclassWithSameField',
-		'DataObjectTest_FieldlessTable',
-		'DataObjectTest_FieldlessSubTable',
-		'DataObjectTest_ValidatedObject',
-		'DataObjectTest_Player',
-		'DataObjectTest_TeamComment',
-		'DataObjectTest_EquipmentCompany',
-		'DataObjectTest_SubEquipmentCompany',
-		'DataObjectTest\NamespacedClass',
-		'DataObjectTest\RelationClass',
-		'DataObjectTest_ExtendedTeamComment',
-		'DataObjectTest_Company',
-		'DataObjectTest_Staff',
-		'DataObjectTest_CEO',
-		'DataObjectTest_Fan',
-		'DataObjectTest_Play',
-		'DataObjectTest_Ploy',
-		'DataObjectTest_Bogey',
-		'ManyManyListTest_Product',
-		'ManyManyListTest_Category',
-	);
+	public function setUpOnce() {
+		$this->extraDataObjects = DataObjectTest::$extra_data_objects;
+		parent::setUpOnce();
+	}
 
 	public function testRelationshipEmptyOnNewRecords() {
 		// Relies on the fact that (unrelated) comments exist in the fixture file already

--- a/tests/model/ManyManyListTest.php
+++ b/tests/model/ManyManyListTest.php
@@ -10,35 +10,10 @@ class ManyManyListTest extends SapphireTest {
 
 	protected static $fixture_file = 'DataObjectTest.yml';
 
-	protected $extraDataObjects = array(
-		// From DataObjectTest
-		'DataObjectTest_Team',
-		'DataObjectTest_Fixture',
-		'DataObjectTest_SubTeam',
-		'OtherSubclassWithSameField',
-		'DataObjectTest_FieldlessTable',
-		'DataObjectTest_FieldlessSubTable',
-		'DataObjectTest_ValidatedObject',
-		'DataObjectTest_Player',
-		'DataObjectTest_TeamComment',
-		'DataObjectTest_EquipmentCompany',
-		'DataObjectTest_SubEquipmentCompany',
-		'DataObjectTest\NamespacedClass',
-		'DataObjectTest\RelationClass',
-		'DataObjectTest_ExtendedTeamComment',
-		'DataObjectTest_Company',
-		'DataObjectTest_Staff',
-		'DataObjectTest_CEO',
-		'DataObjectTest_Fan',
-		'DataObjectTest_Play',
-		'DataObjectTest_Ploy',
-		'DataObjectTest_Bogey',
-		// From ManyManyListTest
-		'ManyManyListTest_ExtraFields',
-		'ManyManyListTest_Product',
-		'ManyManyListTest_Category',
-	);
-
+	public function setUpOnce() {
+		$this->extraDataObjects = DataObjectTest::$extra_data_objects;
+		parent::setUpOnce();
+	}
 
 	public function testAddCompositedExtraFields() {
 		$obj = new ManyManyListTest_ExtraFields();

--- a/tests/model/MapTest.php
+++ b/tests/model/MapTest.php
@@ -5,37 +5,15 @@
  * @subpackage tests
  */
 class SS_MapTest extends SapphireTest {
-	
+
 	// Borrow the model from DataObjectTest
 	protected static $fixture_file = 'DataObjectTest.yml';
 
-	protected $extraDataObjects = array(
-		// From DataObjectTest
-		'DataObjectTest_Team',
-		'DataObjectTest_Fixture',
-		'DataObjectTest_SubTeam',
-		'OtherSubclassWithSameField',
-		'DataObjectTest_FieldlessTable',
-		'DataObjectTest_FieldlessSubTable',
-		'DataObjectTest_ValidatedObject',
-		'DataObjectTest_Player',
-		'DataObjectTest_TeamComment',
-		'DataObjectTest_EquipmentCompany',
-		'DataObjectTest_SubEquipmentCompany',
-		'DataObjectTest\NamespacedClass',
-		'DataObjectTest\RelationClass',
-		'DataObjectTest_ExtendedTeamComment',
-		'DataObjectTest_Company',
-		'DataObjectTest_Staff',
-		'DataObjectTest_CEO',
-		'DataObjectTest_Fan',
-		'DataObjectTest_Play',
-		'DataObjectTest_Ploy',
-		'DataObjectTest_Bogey',
-		'ManyManyListTest_Product',
-		'ManyManyListTest_Category',
-	);
-	
+	public function setUpOnce() {
+		$this->extraDataObjects = DataObjectTest::$extra_data_objects;
+		parent::setUpOnce();
+	}
+
 
 	public function testValues() {
 		$list = DataObjectTest_TeamComment::get()->sort('Name');
@@ -91,13 +69,13 @@ class SS_MapTest extends SapphireTest {
 			. "Bob: This is a team comment by Bob\n"
 			. "Phil: Phil is a unique guy, and comments on team2\n", $text);
 	}
-	
+
 	public function testDefaultConfigIsIDAndTitle() {
 		$list = DataObjectTest_Team::get();
 		$map = new SS_Map($list);
 		$this->assertEquals('Team 1', $map[$this->idFromFixture('DataObjectTest_Team', 'team1')]);
 	}
-	
+
 	public function testSetKeyFieldAndValueField() {
 		$list = DataObjectTest_TeamComment::get();
 		$map = new SS_Map($list);
@@ -105,7 +83,7 @@ class SS_MapTest extends SapphireTest {
 		$map->setValueField('Comment');
 		$this->assertEquals('This is a team comment by Joe', $map['Joe']);
 	}
-	
+
 	public function testToArray() {
 		$list = DataObjectTest_TeamComment::get();
 		$map = new SS_Map($list, 'Name', 'Comment');
@@ -183,10 +161,10 @@ class SS_MapTest extends SapphireTest {
 			"Phil" => "Phil is a unique guy, and comments on team2"), $map->toArray());
 
 		$map->unshift(0, '(Select)');
-		
+
 		$this->assertEquals('(All)', $map[-1]);
 		$this->assertEquals('(Select)', $map[0]);
-		
+
 		$this->assertEquals(array(
 			0 => "(Select)",
 			-1 => "(All)",
@@ -232,7 +210,7 @@ class SS_MapTest extends SapphireTest {
 			1 => "(All)"
 		), $map->toArray());
 	}
-	
+
 	public function testCount() {
 		$list = DataObjectTest_TeamComment::get();
 		$map = new SS_Map($list, 'Name', 'Comment');
@@ -277,7 +255,7 @@ class SS_MapTest extends SapphireTest {
 		$list = DataObjectTest_TeamComment::get()->sort('ID');
 		$map = new SS_Map($list, 'Name', 'Comment');
 		$map->push(1, 'Pushed');
-		
+
 		$text = "";
 
 		foreach($map as $k => $v) {
@@ -300,7 +278,7 @@ class SS_MapTest extends SapphireTest {
 		foreach($map as $k => $v) {
 			$text .= "$k: $v\n";
 		}
-		
+
 		$this->assertEquals("1: unshifted\n", $text);
 	}
 
@@ -313,7 +291,7 @@ class SS_MapTest extends SapphireTest {
 		foreach($map as $k => $v) {
 			$text .= "$k: $v\n";
 		}
-		
+
 		$this->assertEquals("1: pushed\n", $text);
 	}
 }

--- a/tests/model/PolymorphicHasManyListTest.php
+++ b/tests/model/PolymorphicHasManyListTest.php
@@ -15,30 +15,10 @@ class PolymorphicHasManyListTest extends SapphireTest {
 	// Borrow the model from DataObjectTest
 	protected static $fixture_file = 'DataObjectTest.yml';
 
-	protected $extraDataObjects = array(
-		// From DataObjectTest
-		'DataObjectTest_Team',
-		'DataObjectTest_Fixture',
-		'DataObjectTest_SubTeam',
-		'OtherSubclassWithSameField',
-		'DataObjectTest_FieldlessTable',
-		'DataObjectTest_FieldlessSubTable',
-		'DataObjectTest_ValidatedObject',
-		'DataObjectTest_Player',
-		'DataObjectTest_TeamComment',
-		'DataObjectTest_EquipmentCompany',
-		'DataObjectTest_SubEquipmentCompany',
-		'DataObjectTest\NamespacedClass',
-		'DataObjectTest\RelationClass',
-		'DataObjectTest_ExtendedTeamComment',
-		'DataObjectTest_Company',
-		'DataObjectTest_Staff',
-		'DataObjectTest_CEO',
-		'DataObjectTest_Fan',
-		'DataObjectTest_Play',
-		'DataObjectTest_Ploy',
-		'DataObjectTest_Bogey',
-	);
+	public function setUpOnce() {
+		$this->extraDataObjects = DataObjectTest::$extra_data_objects;
+		parent::setUpOnce();
+	}
 
 	public function testRelationshipEmptyOnNewRecords() {
 		// Relies on the fact that (unrelated) comments exist in the fixture file already

--- a/tests/model/VersionableExtensionsTest.php
+++ b/tests/model/VersionableExtensionsTest.php
@@ -68,30 +68,24 @@ class VersionableExtensionsTest_DataObject extends DataObject implements TestOnl
 }
 
 
-class VersionableExtensionsTest_Extension extends DataExtension implements TestOnly {
+class VersionableExtensionsTest_Extension extends DataExtension implements VersionableExtension, TestOnly {
 
 
-	public function isVersionedTable($table){
+	public function isVersionedTable($table) {
 		return true;
 	}
 
 
 	/**
-	 * fieldsInExtraTables function.
+	 * Update fields and indexes for the versonable suffix table
 	 *
-	 * @access public
-	 * @param mixed $suffix
+	 * @param string $suffix Table suffix being built
+	 * @param array $fields List of fields in this model
+	 * @param array $indexes List of indexes in this model
 	 * @return array
 	 */
-	public function fieldsInExtraTables($suffix){
-		$fields = array();
-		//$fields['db'] = DataObject::database_fields($this->owner->class);
-		$fields['indexes'] = $this->owner->databaseIndexes();
-
-		$fields['db'] = array_merge(
-			DataObject::database_fields($this->owner->class)
-		);
-
-		return $fields;
+	public function updateVersionableFields($suffix, &$fields, &$indexes){
+		$indexes['ExtraField'] = true;
+		$fields['ExtraField'] = 'Varchar()';
 	}
 }

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -33,7 +33,7 @@ class VersionedTest extends SapphireTest {
 			'VersionedTest_WithIndexes_versions' =>
 				array('value' => false, 'message' => 'Unique indexes are no longer unique in _versions table'),
 			'VersionedTest_WithIndexes_Live' =>
-				array('value' => false, 'message' => 'Unique indexes are no longer unique in _Live table'),
+				array('value' => true, 'message' => 'Unique indexes are unique in _Live table'),
 		);
 
 		// Test each table's performance
@@ -56,7 +56,7 @@ class VersionedTest extends SapphireTest {
 				if (in_array($indexSpec['value'], $expectedColumns)) {
 					$isUnique = $indexSpec['type'] === 'unique';
 					$this->assertEquals($isUnique, $expectation['value'], $expectation['message']);
-}
+				}
 			}
 		}
 	}
@@ -314,7 +314,7 @@ class VersionedTest extends SapphireTest {
 	}
 
 	public function testWritingNewToStage() {
-		$origStage = Versioned::get_stage();
+		$origReadingMode = Versioned::get_reading_mode();
 
 		Versioned::set_stage(Versioned::DRAFT);
 		$page = new VersionedTest_DataObject();
@@ -333,7 +333,7 @@ class VersionedTest extends SapphireTest {
 		$this->assertEquals(1, $stage->count());
 		$this->assertEquals($stage->First()->Title, 'testWritingNewToStage');
 
-		Versioned::set_stage($origStage);
+		Versioned::set_reading_mode($origReadingMode);
 	}
 
 	/**
@@ -343,7 +343,7 @@ class VersionedTest extends SapphireTest {
 	 * the VersionedTest_DataObject record though.
 	 */
 	public function testWritingNewToLive() {
-		$origStage = Versioned::get_stage();
+		$origReadingMode = Versioned::get_reading_mode();
 
 		Versioned::set_stage(Versioned::LIVE);
 		$page = new VersionedTest_DataObject();
@@ -362,7 +362,7 @@ class VersionedTest extends SapphireTest {
 		));
 		$this->assertEquals(0, $stage->count());
 
-		Versioned::set_stage($origStage);
+		Versioned::set_reading_mode($origReadingMode);
 	}
 
 	/**

--- a/tests/view/SSViewerCacheBlockTest.php
+++ b/tests/view/SSViewerCacheBlockTest.php
@@ -144,8 +144,7 @@ class SSViewerCacheBlockTest extends SapphireTest {
 	}
 
 	public function testVersionedCache() {
-
-		$origStage = Versioned::get_stage();
+		$origReadingMode = Versioned::get_reading_mode();
 
 		// Run without caching in stage to prove data is uncached
 		$this->_reset(false);
@@ -211,7 +210,7 @@ class SSViewerCacheBlockTest extends SapphireTest {
 			$this->_runtemplate('<% cached %>$Inspect<% end_cached %>', $data)
 		);
 
-		Versioned::set_stage($origStage);
+		Versioned::set_reading_mode($origReadingMode);
 	}
 
 	/**


### PR DESCRIPTION
This change introduces a `table_name` config for dataobjects, which can be used to customise the table name for any model. This is necessary as a precursor to namespacing, in order to prevent tables changing as we introduce namespaces for existing models.

I've split this change into a general "cleanup" commit for PHP linting errors I've resolved along the way, as well as the new API.

A minor CMS pull request is at https://github.com/silverstripe/silverstripe-cms/pull/1519

Fixes #5419