### PR TITLE
FIX: ViewableData::setFailover() didn't remove cached methods

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -801,6 +801,25 @@ abstract class Object {
 	}
 
 	/**
+	 * @param object $extension
+	 * @return array
+	 */
+	protected function findMethodsFromExtension($extension) {
+		if (method_exists($extension, 'allMethodNames')) {
+			if ($extension instanceof Extension) $extension->setOwner($this);
+			$methods = $extension->allMethodNames(true);
+			if ($extension instanceof Extension) $extension->clearOwner();
+		} else {
+			if (!isset(self::$built_in_methods[$extension->class])) {
+				self::$built_in_methods[$extension->class] = array_map('strtolower', get_class_methods($extension));
+			}
+			$methods = self::$built_in_methods[$extension->class];
+		}
+
+		return $methods;
+	}
+
+	/**
 	 * Add all the methods from an object property (which is an {@link Extension}) to this object.
 	 *
 	 * @param string $property the property name
@@ -815,19 +834,8 @@ abstract class Object {
 			);
 		}
 
-		if(method_exists($extension, 'allMethodNames')) {
-			if ($extension instanceof Extension) $extension->setOwner($this);
-			$methods = $extension->allMethodNames(true);
-			if ($extension instanceof Extension) $extension->clearOwner();
-
-		} else {
-			if(!isset(self::$built_in_methods[$extension->class])) {
-				self::$built_in_methods[$extension->class] = array_map('strtolower', get_class_methods($extension));
-			}
-			$methods = self::$built_in_methods[$extension->class];
-		}
-
-		if($methods) {
+		$methods = $this->findMethodsFromExtension($extension);
+		if ($methods) {
 			$methodInfo = array(
 				'property' => $property,
 				'index'    => $index,
@@ -860,19 +868,8 @@ abstract class Object {
 			);
 		}
 
-		if(method_exists($extension, 'allMethodNames')) {
-			if ($extension instanceof Extension) $extension->setOwner($this);
-			$methods = $extension->allMethodNames(true);
-			if ($extension instanceof Extension) $extension->clearOwner();
-
-		} else {
-			if(!isset(self::$built_in_methods[$extension->class])) {
-				self::$built_in_methods[$extension->class] = array_map('strtolower', get_class_methods($extension));
-			}
-			$methods = self::$built_in_methods[$extension->class];
-		}
-
-		if($methods) {
+		$methods = $this->findMethodsFromExtension($extension);
+		if ($methods) {
 			foreach ($methods as $method) {
 				$methodInfo = self::$extra_methods[$this->class][$method];
 

--- a/tests/view/ViewableDataTest.php
+++ b/tests/view/ViewableDataTest.php
@@ -187,6 +187,11 @@ class ViewableDataTest extends SapphireTest {
 		// Ensure that defined methods detected from the failover aren't cached when setting a new failover
 		$container->setFailover(new ViewableDataTest_Failover);
 		$this->assertTrue($container->hasMethod('testMethod'));
+
+		// Test the reverse - that defined methods previously detected in a failover are removed if they no longer exist
+		$container->setFailover($failover);
+		$this->assertSame($failover, $container->getFailover(), 'getFailover() returned a different object');
+		$this->assertFalse($container->hasMethod('testMethod'), 'testMethod() incorrectly reported as existing');
 	}
 
 }

--- a/view/ViewableData.php
+++ b/view/ViewableData.php
@@ -134,6 +134,11 @@ class ViewableData extends Object implements IteratorAggregate {
 	 * @param ViewableData $failover
 	 */
 	public function setFailover(ViewableData $failover) {
+		// Ensure cached methods from previous failover are removed
+		if ($this->failover) {
+			$this->removeMethodsFrom('failover');
+		}
+
 		$this->failover = $failover;
 		$this->defineMethods();
 	}


### PR DESCRIPTION
Hopefully the unit test explains what’s going on here. Turns out @tractorcow was quite correct in his comment in https://github.com/silverstripe/silverstripe-framework/pull/4870#issuecomment-166722469:

> You might also need a mechanism and test to ensure you remove methods from the removed failover, since it looks like the new ones are being merged with the old.