### PR TITLE
Arrow icons (back button in edit forms)

### DIFF
--- a/admin/scss/_fonts.scss
+++ b/admin/scss/_fonts.scss
@@ -163,3 +163,15 @@
 .font-icon-resize:before {
   content: "L";
 }
+.font-icon-left-open-big:before {
+  content: "\35";
+}
+.font-icon-down-open-big:before {
+  content: "\36";
+}
+.font-icon-up-open-big:before {
+  content: "\37";
+}
+.font-icon-right-open-big:before {
+  content: "\38";
+}


### PR DESCRIPTION
Back button was no more visible in 3.4, issue #5657