### PR TITLE
FIX for #5683: Address security warning in CMS on 3.3 and above.

### DIFF
--- a/admin/javascript/LeftAndMain.ActionTabSet.js
+++ b/admin/javascript/LeftAndMain.ActionTabSet.js
@@ -30,7 +30,11 @@
 				// because the panel is still open when the ajax edit form reloads.
 				var frame = $('.cms-container').find('iframe');
 				frame.each(function(index, iframe){
-					$(iframe).contents().off('click.ss-ui-action-tabset');
+					try {
+						$(iframe).contents().off('click.ss-ui-action-tabset');
+					} catch (e) {
+						console.warn('Unable to access iframe, possible https mis-match');
+					}
 				});
 				$(document).off('click.ss-ui-action-tabset');
 


### PR DESCRIPTION
A quick fix for #5683, back-porting  PR #5163 to `3.3` and newer