### PR TITLE
Allow extensions for TextParser

### DIFF
--- a/parsers/TextParser.php
+++ b/parsers/TextParser.php
@@ -35,6 +35,7 @@ abstract class TextParser extends Object {
 	 */
 	public function __construct($content = "") {
 		$this->content = $content;
+		parent::__construct();
 	}
 
 	/**


### PR DESCRIPTION
* Call `Object::__construct` to make it extendable
* Resolves #5685