### PR TITLE
Moving a field between tabs, wrong variable name

### DIFF
--- a/docs/en/02_Developer_Guides/03_Forms/06_Tabbed_Forms.md
+++ b/docs/en/02_Developer_Guides/03_Forms/06_Tabbed_Forms.md
@@ -37,7 +37,7 @@ display up to two levels of tabs in the interface. If you want to group data fur
 ## Moving a field between tabs
 
 	:::php
-	$field = $fields->dataFieldByName('Content');
+	$content = $fields->dataFieldByName('Content');
 
 	$fields->removeFieldFromTab('Root.Main', 'Content');
 	$fields->addFieldToTab('Root.MyContent', $content);


### PR DESCRIPTION
The variable $field should be $content, since its added later as "$content"