### PR TITLE
Use new "eslint-2" channel for CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,7 @@
 engines:
   eslint:
     enabled: true
+    channel: "eslint-2"
   scss-lint:
     enabled: true
   duplication:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -20,3 +20,4 @@ exclude_paths:
 - "templates/"
 - "tests/"
 - "thirdparty/"
+- "admin/thirdparty/"


### PR DESCRIPTION
Should avoid some false positives we're getting from validating with eslint 2
locally (npm dependency), but checking with eslint 1 remotely