### PR TITLE
FIX: SS_ConfigStaticManifest_Parser failed to handle ::class syntax (fixes #5701)

### DIFF
--- a/tests/core/manifest/ConfigStaticManifestTest.php
+++ b/tests/core/manifest/ConfigStaticManifestTest.php
@@ -257,6 +257,16 @@ DOC;
 
 		$this->assertEquals($expected, $statics[':ss:test2']);
 	}
+
+	public function testParsingClassKeyword() {
+		$parser = new SS_ConfigStaticManifest_Parser(__DIR__ .
+			'/ConfigStaticManifestTest/ConfigStaticManifestTestClassKeyword.php');
+		$parser->parse();
+
+		$statics = $parser->getStatics();
+
+		$this->assertEquals('bar', $statics['ConfigStaticManifestTestClassKeyword']['foo']['value']);
+	}
 }
 
 class ConfigStaticManifestTest_Parser extends SS_ConfigStaticManifest_Parser implements TestOnly {

--- a/tests/core/manifest/ConfigStaticManifestTest/ConfigStaticManifestTestClassKeyword.php
+++ b/tests/core/manifest/ConfigStaticManifestTest/ConfigStaticManifestTestClassKeyword.php
@@ -1,0 +1,11 @@
+<?php
+
+class ConfigStaticManifestTestClassKeyword implements TestOnly {
+
+	private static $foo = 'bar';
+
+	public function __construct() {
+		$this->inst = Injector::inst()->get(static::class);
+	}
+
+}


### PR DESCRIPTION
Targeted at 3 as it _technically_ adds new API. Happy to rebase against a different branch if preferred.