### PR TITLE
ENHANCEMENT: Added onBeforeRender extension point to form fields that call renderWith (fixes #4790)

### DIFF
--- a/forms/CheckboxSetField.php
+++ b/forms/CheckboxSetField.php
@@ -54,6 +54,8 @@ class CheckboxSetField extends OptionsetField {
 			'Options' => $this->getOptions()
 		));
 
+		$this->extend('onBeforeRender', $this);
+
 		return $this->customise($properties)->renderWith(
 			$this->getTemplates()
 		);

--- a/forms/ListboxField.php
+++ b/forms/ListboxField.php
@@ -102,6 +102,8 @@ class ListboxField extends DropdownField {
 			'Options' => new ArrayList($options)
 		));
 
+		$this->extend('onBeforeRender', $this);
+
 		return $this->customise($properties)->renderWith($this->getTemplates());
 	}
 

--- a/forms/OptionsetField.php
+++ b/forms/OptionsetField.php
@@ -83,6 +83,8 @@ class OptionsetField extends DropdownField {
 			'Options' => new ArrayList($options)
 		));
 
+		$this->extend('onBeforeRender', $this);
+
 		return $this->customise($properties)->renderWith(
 			$this->getTemplates()
 		);

--- a/forms/TreeDropdownField.php
+++ b/forms/TreeDropdownField.php
@@ -248,6 +248,8 @@ class TreeDropdownField extends FormField {
 			)
 		);
 
+		$this->extend('onBeforeRender', $this);
+
 		return $this->customise($properties)->renderWith('TreeDropdownField');
 	}
 

--- a/forms/TreeMultiselectField.php
+++ b/forms/TreeMultiselectField.php
@@ -135,6 +135,9 @@ class TreeMultiselectField extends TreeDropdownField {
 				'Value' => $value
 			)
 		);
+
+		$this->extend('onBeforeRender', $this);
+
 		return $this->customise($properties)->renderWith('TreeDropdownField');
 	}
 

--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -973,6 +973,8 @@ class UploadField extends FileField {
 				_t('UploadField.OVERWRITEWARNING', 'File with the same name already exists');
 		}
 
+		$this->extend('onBeforeRender', $this);
+
 		$mergedConfig = array_merge($config, $this->ufConfig);
 		return $this->customise(array(
 			'configString' => str_replace('"', "&quot;", Convert::raw2json($mergedConfig)),


### PR DESCRIPTION
This pull request adds the onBeforeRender extension point to the following form fields, the other built in form fields that are not listed either don't seem to call renderWith and instead use raw html or already have the onBeforeRender extension point in the Field method,.

* CheckboxSetField
* OptionsetField
* TreedropdownField
* TreeMultiselectField
* UploadField
* ListboxField