### PR TITLE
Fixes issue 5188: X-Forwarded Proto

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -19,4 +19,4 @@ HTTP:
     max-age: 0
     must-revalidate: "true"
     no-transform: "true"
-  vary: "Cookie, X-Forwarded-Protocol, User-Agent, Accept"
+  vary: "Cookie, X-Forwarded-Proto, User-Agent, Accept"


### PR DESCRIPTION
Removes X-Forwarded-Protocol in favour of the more standard X-Forwarded-Proto in the default Vary header config.
## To do before merge:
- [x] Update to include both `X-Forwarded-Protocol` and `X-Forwarded-Proto` in vary header
## Nice to have
- [x] Remove HTTP_FRONT_END_HTTPS reference from Director.php
- [ ] Throw deprecation warning if HTTP_X_FORWARDED_PROTOCOL is passed
- [ ] Update Vary header (but none of the deprecation changes) in the `3.5` branch.
