### PR TITLE
FIX: Saving null values to the _versions table.

### DIFF
--- a/ORM/Versioning/Versioned.php
+++ b/ORM/Versioning/Versioned.php
@@ -788,7 +788,8 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 				$data = array_intersect_key($data, $fields);
 
 				foreach ($data as $k => $v) {
-					if (!isset($newManipulation['fields'][$k])) {
+					// If the value is not set at all in the manipulation currently, use the existing value from the database
+					if (is_array($newManipulation['fields']) && !array_key_exists($k, $newManipulation['fields'])) {
 						$newManipulation['fields'][$k] = $v;
 					}
 				}

--- a/ORM/Versioning/Versioned.php
+++ b/ORM/Versioning/Versioned.php
@@ -774,7 +774,7 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 		// Set up a new entry in (table)_versions
 		$newManipulation = array(
 			"command" => "insert",
-			"fields" => isset($manipulation[$table]['fields']) ? $manipulation[$table]['fields'] : null,
+			"fields" => isset($manipulation[$table]['fields']) ? $manipulation[$table]['fields'] : [],
 			"class" => $class,
 		);
 
@@ -789,7 +789,7 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 
 				foreach ($data as $k => $v) {
 					// If the value is not set at all in the manipulation currently, use the existing value from the database
-					if (is_array($newManipulation['fields']) && !array_key_exists($k, $newManipulation['fields'])) {
+					if (!array_key_exists($k, $newManipulation['fields'])) {
 						$newManipulation['fields'][$k] = $v;
 					}
 				}

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -1036,6 +1036,29 @@ class VersionedTest extends SapphireTest {
 		$this->assertTrue($public->canViewStage('Live'));
 		$this->assertTrue($private->canViewStage('Live'));
 	}
+
+	/**
+	 * Values that are overwritten with null are saved to the _versions table correctly.
+	 */
+	public function testWriteNullValueToVersion()
+	{
+		$record = VersionedTest_Subclass::create();
+		$record->Title = "Test A";
+		$record->write();
+
+		$version = Versioned::get_latest_version($record->ClassName, $record->ID);
+
+		$this->assertEquals(1, $version->Version);
+		$this->assertEquals($record->Title, $version->Title);
+
+		$record->Title = null;
+		$record->write();
+
+		$version = Versioned::get_latest_version($record->ClassName, $record->ID);
+
+		$this->assertEquals(2, $version->Version);
+		$this->assertEquals($record->Title, $version->Title);
+	}
 }
 
 


### PR DESCRIPTION
The isset() check does not return true when a value is set to null, so instead use array_key_exists(). 