### PR TITLE
Use plural name for ModelAdmin tab name

### DIFF
--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -281,7 +281,7 @@ abstract class ModelAdmin extends LeftAndMain {
 		// Normalize models to have their model class in array key
 		foreach($models as $k => $v) {
 			if(is_numeric($k)) {
-				$models[$v] = array('title' => singleton($v)->i18n_singular_name());
+				$models[$v] = array('title' => singleton($v)->i18n_plural_name());
 				unset($models[$k]);
 			}
 		}


### PR DESCRIPTION
* Fixes #3362

As discussed in the issue, it makes more sense to use the DataObject's plural name by default than have to write something like this for each managed model:

```php
private static $managed_models = [
    'Player' => [
        'title' => 'Players'
    ],
    'Team' => [
        'title' => 'Teams'
    ]
];
```