### PR TITLE
Add CIDR range functionality for SS_TRUSTED_PROXY_IPS

### DIFF
--- a/core/Constants.php
+++ b/core/Constants.php
@@ -87,6 +87,25 @@ function stripslashes_recursively(&$array) {
 }
 
 /**
+ * Check if a given ip is in a network
+ * @param  string $ip    IP to check in IPV4 format eg. 127.0.0.1
+ * @param  string $range IP/CIDR netmask eg. 127.0.0.0/24, also 127.0.0.1 is accepted and /32 assumed
+ * @return boolean true if the ip is in this range / false if not.
+ */
+function ip_in_range( $ip, $range ) {
+	if ( strpos( $range, '/' ) == false ) {
+		$range .= '/32';
+	}
+	// $range is in IP/CIDR format eg 127.0.0.1/24
+	list( $range, $netmask ) = explode( '/', $range, 2 );
+	$range_decimal = ip2long( $range );
+	$ip_decimal = ip2long( $ip );
+	$wildcard_decimal = pow( 2, ( 32 - $netmask ) ) - 1;
+	$netmask_decimal = ~ $wildcard_decimal;
+	return ( ( $ip_decimal & $netmask_decimal ) == ( $range_decimal & $netmask_decimal ) );
+}
+
+/**
  * Validate whether the request comes directly from a trusted server or not
  * This is necessary to validate whether or not the values of X-Forwarded-
  * or Client-IP HTTP headers can be trusted
@@ -104,7 +123,12 @@ if(!defined('TRUSTED_PROXY')) {
 			if(SS_TRUSTED_PROXY_IPS === '*') {
 				$trusted = true;
 			} elseif(isset($_SERVER['REMOTE_ADDR'])) {
-				$trusted = in_array($_SERVER['REMOTE_ADDR'], explode(',', SS_TRUSTED_PROXY_IPS));
+				foreach (explode(',', SS_TRUSTED_PROXY_IPS) as $ipAddress) {
+					if (ip_in_range($_SERVER['REMOTE_ADDR'], $ipAddress)) {
+						$trusted = true;
+						break;
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## To do before merge

 * [ ] Refactor logic into `ip_in_any_range($ipAddress, $rangeList)`
 * [ ] Add a unit test for `ip_in_any_range()` and/or `ip_in_range()`
 * [ ] Ensure exact-matches on ipv6 addresses (e.g. `::1`) will work.

## Nice to have

 * [ ] Parsing of IPv6 subnet ranges