### PR TITLE
NEW: Add Requirements_Backend.nonce_format config

### DIFF
--- a/view/Requirements.php
+++ b/view/Requirements.php
@@ -987,7 +987,7 @@ class Requirements_Backend {
 			$mtimesuffix = "";
 			$suffix = '';
 			if($this->suffix_requirements) {
-				$mtimesuffix = "?m=" . filemtime($filePath);
+				$mtimesuffix = "?m=" . $this->generateNonce($filePath);
 				$suffix = '&';
 			}
 			if(strpos($fileOrUrl, '?') !== false) {
@@ -1002,6 +1002,16 @@ class Requirements_Backend {
 			return "{$prefix}{$fileOrUrl}{$mtimesuffix}{$suffix}";
 		} else {
 			return false;
+		}
+	}
+
+	protected function generateNonce($filePath) {
+		if(!file_exists($filePath)) return 'notfound';
+
+		if(Config::inst()->get('Requirements_Backend', 'nonce_format') === 'md5') {
+			return hash_file('md5', $filePath);
+		} else {
+			return filemtime($filePath);
 		}
 	}
 


### PR DESCRIPTION
This config option can be set to ‘md5’ to use nonces based on the
md5-checksum of the content, rather than filemtime. This can be useful
when sessions aren’t blocking (e.g. when using database-backed sessions)

When sessions aren’t blocking, the CMS combined-files calls will
introduce race conditions that lead to unnecessary reloads of combined
files.
