### PR TITLE
Revert deprecation of Object::get_static()

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -393,11 +393,7 @@ abstract class Object {
 		return $default;
 	}
 
-	/**
-	 * @deprecated
-	 */
 	public static function get_static($class, $name, $uncached = false) {
-		Deprecation::notice('4.0', 'Replaced by Config#get');
 		return Config::inst()->get($class, $name, Config::FIRST_SET);
 	}
 


### PR DESCRIPTION
Inside a theme you cannot add code to the controller so I am providing
some sort of customization by leveraging `Object::get_static`, e.g.:

```yaml
SSViewer:
  label_class: col-xs-3
```

```html
  <label class="$get_static(SSViewer,label_class)">...</label>
```

I think it is quite handy and not being able to do such things in 4.0
should be considered a regression.