### PR TITLE
Update GridFieldAddExistingAutocompleter.php

### DIFF
--- a/forms/gridfield/GridFieldAddExistingAutocompleter.php
+++ b/forms/gridfield/GridFieldAddExistingAutocompleter.php
@@ -137,7 +137,7 @@ class GridFieldAddExistingAutocompleter
 	 * @return array
 	 */
 	public function getActions($gridField) {
-		return array('addto');
+		return array('addto', 'find');
 	}
 
 	/**


### PR DESCRIPTION
When saving by hitting enter, was receiving an error message 'Can't handle action "find"'

Traced this back to GridFieldAddExistingAutocompleter setting a 'find' action in getHTMLFragments (line 107) and then not declaring it on line 140