### PR TITLE
FIX Parse shortcodes in template helpers

### DIFF
--- a/model/fieldtypes/DBField.php
+++ b/model/fieldtypes/DBField.php
@@ -221,19 +221,19 @@ abstract class DBField extends ViewableData {
 	}
 
 	public function HTMLATT() {
-		return Convert::raw2htmlatt($this->value);
+		return Convert::raw2htmlatt($this->RAW());
 	}
 
 	public function URLATT() {
-		return urlencode($this->value);
+		return urlencode($this->RAW());
 	}
 
 	public function RAWURLATT() {
-		return rawurlencode($this->value);
+		return rawurlencode($this->RAW());
 	}
 
 	public function ATT() {
-		return Convert::raw2att($this->value);
+		return Convert::raw2att($this->RAW());
 	}
 
 	public function RAW() {
@@ -241,7 +241,7 @@ abstract class DBField extends ViewableData {
 	}
 
 	public function JS() {
-		return Convert::raw2js($this->value);
+		return Convert::raw2js($this->RAW());
 	}
 
 	/**
@@ -249,15 +249,15 @@ abstract class DBField extends ViewableData {
 	 * @return string
 	 */
 	public function JSON() {
-		return Convert::raw2json($this->value);
+		return Convert::raw2json($this->RAW());
 	}
 
 	public function HTML(){
-		return Convert::raw2xml($this->value);
+		return Convert::raw2xml($this->RAW());
 	}
 
 	public function XML(){
-		return Convert::raw2xml($this->value);
+		return Convert::raw2xml($this->RAW());
 	}
 
 	/**

--- a/model/fieldtypes/HTMLText.php
+++ b/model/fieldtypes/HTMLText.php
@@ -100,7 +100,7 @@ class HTMLText extends Text {
 			// Catch warnings thrown by loadHTML and turn them into a failure boolean rather than a SilverStripe error
 			set_error_handler(create_function('$no, $str', 'throw new Exception("HTML Parse Error: ".$str);'), E_ALL);
 			//  Nonbreaking spaces get converted into weird characters, so strip them
-			$value = str_replace('&nbsp;', ' ', $this->value);
+			$value = str_replace('&nbsp;', ' ', $this->RAW());
 			try {
 				$res = $doc->loadHTML('<meta content="text/html; charset=utf-8" http-equiv="Content-type"/>' . $value);
 			}
@@ -241,14 +241,16 @@ class HTMLText extends Text {
 			return false;
 		}
 
+		$value = $this->RAW();
+
 		// If it's got a content tag
-		if(preg_match('/<(img|embed|object|iframe|meta|source|link)[^>]*>/i', $this->value)) {
+		if(preg_match('/<(img|embed|object|iframe|meta|source|link)[^>]*>/i', $value)) {
 			return true;
 		}
 
 		// If it's just one or two tags on its own (and not the above) it's empty.
 		// This might be <p></p> or <h1></h1> or whatever.
-		if(preg_match('/^[\\s]*(<[^>]+>[\\s]*){1,2}$/', $this->value)) {
+		if(preg_match('/^[\\s]*(<[^>]+>[\\s]*){1,2}$/', $value)) {
 			return false;
 		}
 

--- a/model/fieldtypes/HTMLText.php
+++ b/model/fieldtypes/HTMLText.php
@@ -175,6 +175,15 @@ class HTMLText extends Text {
 		return $this->Summary();
 	}
 
+	public function RAW() {
+		if ($this->processShortcodes) {
+			return ShortcodeParser::get_active()->parse($this->value);
+		}
+		else {
+			return $this->value;
+		}
+	}
+
 	/**
 	 * Return the value of the field with relative links converted to absolute urls (with placeholders parsed).
 	 * @return string
@@ -184,12 +193,7 @@ class HTMLText extends Text {
 	}
 
 	public function forTemplate() {
-		if ($this->processShortcodes) {
-			return ShortcodeParser::get_active()->parse($this->value);
-		}
-		else {
-			return $this->value;
-		}
+		return $this->RAW();
 	}
 
 	public function prepValueForDB($value) {

--- a/model/fieldtypes/HTMLVarchar.php
+++ b/model/fieldtypes/HTMLVarchar.php
@@ -21,6 +21,10 @@ class HTMLVarchar extends Varchar {
 	}
 
 	public function forTemplate() {
+		return $this->RAW();
+	}
+
+	public function RAW() {
 		if ($this->processShortcodes) {
 			return ShortcodeParser::get_active()->parse($this->value);
 		}

--- a/model/fieldtypes/HTMLVarchar.php
+++ b/model/fieldtypes/HTMLVarchar.php
@@ -31,10 +31,11 @@ class HTMLVarchar extends Varchar {
 		else {
 			return $this->value;
 		}
+
 	}
 
 	public function exists() {
-		return parent::exists() && $this->value != '<p></p>';
+		return parent::exists() && $this->RAW() != '<p></p>';
 	}
 
 	public function scaffoldFormField($title = null, $params = null) {

--- a/model/fieldtypes/StringField.php
+++ b/model/fieldtypes/StringField.php
@@ -84,9 +84,10 @@ abstract class StringField extends DBField {
 	 * @see core/model/fieldtypes/DBField#exists()
 	 */
 	public function exists() {
-		return $this->getValue() // All truthy values exist
-			|| (is_string($this->getValue()) && strlen($this->getValue())) // non-empty strings exist ('0' but not (int)0)
-			|| (!$this->getNullifyEmpty() && $this->getValue() === ''); // Remove this stupid exemption in 4.0
+		$value = $this->RAW();
+		return $value // All truthy values exist
+			|| (is_string($value) && strlen($value)) // non-empty strings exist ('0' but not (int)0)
+			|| (!$this->getNullifyEmpty() && $value === ''); // Remove this stupid exemption in 4.0
 	}
 
 	/**
@@ -118,7 +119,7 @@ abstract class StringField extends DBField {
 	 * @return string
 	 */
 	public function LimitCharacters($limit = 20, $add = '...') {
-		$value = trim($this->value);
+		$value = trim($this->RAW());
 		if($this->stat('escape_type') == 'xml') {
 			$value = strip_tags($value);
 			$value = html_entity_decode($value, ENT_COMPAT, 'UTF-8');
@@ -142,13 +143,13 @@ abstract class StringField extends DBField {
 	 */
 	public function LimitCharactersToClosestWord($limit = 20, $add = '...') {
 		// Strip HTML tags if they exist in the field
-		$this->value = strip_tags($this->value);
+		$value = strip_tags($this->RAW());
 
 		// Determine if value exceeds limit before limiting characters
-		$exceedsLimit = mb_strlen($this->value) > $limit;
+		$exceedsLimit = mb_strlen($value) > $limit;
 
 		// Limit to character limit
-		$value = $this->LimitCharacters($limit, '');
+		$value = DBField::create_field(get_class($this), $value)->LimitCharacters($limit, '');
 
 		// If value exceeds limit, strip punctuation off the end to the last space and apply ellipsis
 		if($exceedsLimit) {
@@ -174,11 +175,11 @@ abstract class StringField extends DBField {
 	 * @return string
 	 */
 	public function LimitWordCount($numWords = 26, $add = '...') {
-		$this->value = trim(Convert::xml2raw($this->value));
-		$ret = explode(' ', $this->value, $numWords + 1);
+		$value = trim(Convert::xml2raw($this->RAW()));
+		$ret = explode(' ', $value, $numWords + 1);
 
 		if(count($ret) <= $numWords - 1) {
-			$ret = $this->value;
+			$ret = $value;
 		} else {
 			array_pop($ret);
 			$ret = implode(' ', $ret) . $add;
@@ -209,7 +210,7 @@ abstract class StringField extends DBField {
 	 * @return string
 	 */
 	public function LowerCase() {
-		return mb_strtolower($this->value);
+		return mb_strtolower($this->RAW());
 	}
 
 	/**
@@ -217,7 +218,7 @@ abstract class StringField extends DBField {
 	 * @return string
 	 */
 	public function UpperCase() {
-		return mb_strtoupper($this->value);
+		return mb_strtoupper($this->RAW());
 	}
 
 	/**
@@ -226,6 +227,6 @@ abstract class StringField extends DBField {
 	 * @return string
 	 */
 	public function NoHTML() {
-		return strip_tags($this->value);
+		return strip_tags($this->RAW());
 	}
 }

--- a/model/fieldtypes/Text.php
+++ b/model/fieldtypes/Text.php
@@ -60,7 +60,7 @@ class Text extends StringField {
 	 * @return string
 	 */
 	public function AbsoluteLinks() {
-		return HTTP::absoluteURLs($this->value);
+		return HTTP::absoluteURLs($this->RAW());
 	}
 
 	/**
@@ -74,7 +74,7 @@ class Text extends StringField {
 		}
 
 		$output = array();
-		$data = trim(Convert::xml2raw($this->value));
+		$data = trim(Convert::xml2raw($this->RAW()));
 		$sentences = explode('.', $data);
 
 		if ($sentCount == 0) return '';
@@ -94,7 +94,7 @@ class Text extends StringField {
 	 * Caution: Not XML/HTML-safe - does not respect closing tags.
 	 */
 	public function FirstSentence() {
-		$paragraph = Convert::xml2raw( $this->value );
+		$paragraph = Convert::xml2raw( $this->RAW() );
 		if( !$paragraph ) return "";
 
 		$words = preg_split('/\s+/', $paragraph);
@@ -115,7 +115,7 @@ class Text extends StringField {
 	public function Summary($maxWords = 50) {
 		// get first sentence?
 		// this needs to be more robust
-		$value = Convert::xml2raw( $this->value /*, true*/ );
+		$value = Convert::xml2raw( $this->RAW() /*, true*/ );
 		if(!$value) return '';
 
 		// grab the first paragraph, or, failing that, the whole content
@@ -157,7 +157,7 @@ class Text extends StringField {
 
 		// get first sentence?
 		// this needs to be more robust
-		$data = $plain ? Convert::xml2raw($this->value, true) : $this->value;
+		$data = $plain ? Convert::xml2raw($this->RAW(), true) : $this->RAW();
 
 		if(!$data) return '';
 
@@ -197,8 +197,9 @@ class Text extends StringField {
 	public function FirstParagraph($plain = 1) {
 		// get first sentence?
 		// this needs to be more robust
+		$value = $this->RAW();
 		if($plain && $plain != 'html') {
-			$data = Convert::xml2raw($this->value, true);
+			$data = Convert::xml2raw($value, true);
 			if(!$data) return "";
 
 			// grab the first paragraph, or, failing that, the whole content
@@ -207,12 +208,12 @@ class Text extends StringField {
 
 			return $data;
 		} else {
-			if(strpos($this->value, "</p>") === false) return $this->value;
+			if(strpos($value, "</p>") === false) return $value;
 
-			$data = substr($this->value, 0, strpos($this->value, "</p>") + 4);
+			$data = substr($value, 0, strpos($value, "</p>") + 4);
 
-			if(strlen($data) < 20 && strpos($this->value, "</p>", strlen($data))) {
-				$data = substr($this->value, 0, strpos( $this->value, "</p>", strlen($data)) + 4 );
+			if(strlen($data) < 20 && strpos($value, "</p>", strlen($data))) {
+				$data = substr($value, 0, strpos( $value, "</p>", strlen($data)) + 4 );
 			}
 
 			return $data;
@@ -241,7 +242,7 @@ class Text extends StringField {
 		}
 
 		// Remove HTML tags so we don't have to deal with matching tags
-		$text = $striphtml ? $this->NoHTML() : $this->value;
+		$text = $striphtml ? $this->NoHTML() : $this->RAW();
 
 		// Find the search string
 		$position = (int) stripos($text, $string);
@@ -273,7 +274,7 @@ class Text extends StringField {
 		$summary = trim($summary);
 
 		if($position > 0) $summary = $prefix . $summary;
-		if(strlen($this->value) > ($characters + $position)) $summary = $summary . $suffix;
+		if(strlen($this->RAW()) > ($characters + $position)) $summary = $summary . $suffix;
 
 		return $summary;
 	}
@@ -286,14 +287,14 @@ class Text extends StringField {
 	 */
 	public function Parse($parser = "TextParser") {
 		if($parser == "TextParser" || is_subclass_of($parser, "TextParser")) {
-			$obj = new $parser($this->value);
+			$obj = new $parser($this->RAW());
 			return $obj->parse();
 		} else {
 			// Fallback to using raw2xml and show a warning
 			// TODO Don't kill script execution, we can continue without losing complete control of the app
 			user_error("Couldn't find an appropriate TextParser sub-class to create (Looked for '$parser')."
 				. "Make sure it sub-classes TextParser and that you've done ?flush=1.", E_USER_WARNING);
-			return Convert::raw2xml($this->value);
+			return Convert::raw2xml($this->RAW());
 		}
 	}
 

--- a/model/fieldtypes/Varchar.php
+++ b/model/fieldtypes/Varchar.php
@@ -73,15 +73,19 @@ class Varchar extends StringField {
 	 * Return the first letter of the string followed by a .
 	 */
 	public function Initial() {
-		if($this->exists()) return $this->value[0] . '.';
+		if($this->exists()) {
+			$value = $this->RAW();
+			return $value[0] . '.';
+		}
 	}
 
 	/**
 	 * Ensure that the given value is an absolute URL.
 	 */
 	public function URL() {
-		if(preg_match('#^[a-zA-Z]+://#', $this->value)) return $this->value;
-		else return "http://" . $this->value;
+		$value = $this->RAW();
+		if(preg_match('#^[a-zA-Z]+://#', $value)) return $value;
+		else return "http://" . $value;
 	}
 
 	/**
@@ -89,7 +93,7 @@ class Varchar extends StringField {
 	 * @return string
 	 */
 	public function RTF() {
-		return str_replace("\n", '\par ', $this->value);
+		return str_replace("\n", '\par ', $this->RAW());
 	}
 
 	/**

--- a/parsers/ShortcodeParser.php
+++ b/parsers/ShortcodeParser.php
@@ -256,9 +256,18 @@ class ShortcodeParser extends Object {
 					preg_match_all(static::attrrx(), $match['attrs'][0], $attrmatches, PREG_SET_ORDER);
 
 					foreach ($attrmatches as $attr) {
-						list($whole, $name, $value) = array_values(array_filter($attr));
+						$name = '';
+						$value = '';
+						$parts = array_values(array_filter($attr));
+						//the first element in the array is the complete delcaration (`id=1`) - we don't need this
+						array_shift($parts);
+
+						//the next two parts are what we care about (id and 1 from `id=1`)
+						$name = array_shift($parts) ?: $name;
+						$value = array_shift($parts) ?: $value;
+
 						$attrs[$name] = $value;
-				}
+					}
 				}
 
 				// And store the indexes, tag details, etc

--- a/parsers/ShortcodeParser.php
+++ b/parsers/ShortcodeParser.php
@@ -537,6 +537,9 @@ class ShortcodeParser extends Object {
 		// If no content, don't try and parse it
 		if (!trim($content)) return $content;
 
+		// If no shortcode tag, don't try and parse it
+		if (strpos($content, '[') === false) return $content;
+
 		// First we operate in text mode, replacing any shortcodes with marker elements so that later we can
 		// use a proper DOM
 		list($content, $tags) = $this->replaceElementTagsWithMarkers($content);


### PR DESCRIPTION
Fixes #5661
Fixes #1381

See #5653 

Basically back-porting the approach from the above PR.

Use `RAW` to parse the shortcodes and rely on RAW for all the other helper methods.