### PR TITLE
Wrong date used for <pubDate> in RSSFeed.ss

### DIFF
--- a/templates/RSSFeed.ss
+++ b/templates/RSSFeed.ss
@@ -11,7 +11,7 @@
 			<title>$Title.XML</title>
 			<link>$AbsoluteLink</link>
 			<% if $Description %><description>$Description.AbsoluteLinks.XML</description><% end_if %>
-			<% if $Date %><pubDate>$Date.Rfc822</pubDate>
+			<% if $PublishDate %><pubDate>$PublishDate.Rfc822</pubDate>
 			<% else %><pubDate>$Created.Rfc822</pubDate><% end_if %>
 			<% if $Author %><dc:creator>$Author.XML</dc:creator><% end_if %>
 			<guid>$AbsoluteLink</guid>


### PR DESCRIPTION
The default RSSFeed.ss uses $Date to populate <pubDate> in the template. As the latest SilverStripe Blog module uses $PublishDate instead of $Date, it falls back to $Created.