### PR TITLE
FIX calling $record->write() on ListboxField::saveInto breaks other 3rd party fields that write to an UnsavedRelationList.

### DIFF
--- a/forms/ListboxField.php
+++ b/forms/ListboxField.php
@@ -182,12 +182,6 @@ class ListboxField extends DropdownField {
 			if($fieldname && $record && $relation &&
 				($relation instanceof RelationList || $relation instanceof UnsavedRelationList)) {
 				$idList = (is_array($this->value)) ? array_values($this->value) : array();
-				if(!$record->ID) {
-					$record->write(); // record needs to have an ID in order to set relationships
-					$relation = ($fieldname && $record && $record->hasMethod($fieldname))
-						? $record->$fieldname()
-						: null;
-				}
 				$relation->setByIDList($idList);
 			} elseif($fieldname && $record) {
 				if($this->value) {


### PR DESCRIPTION
FIX calling $record->write() on ListboxField::saveInto breaks other 3rd party fields that write to an UnsavedRelationList.

Had a quick look at the Git history, Ingo Schommer added that fix in 2012. I'm guessing it was needed in 3.0 but the need for it went away when 3.1 was released in 2013.

(https://www.silverstripe.org/blog/3.1.0-goes-stable/)