### PR TITLE
Checking for resource before closing MySQL connection

### DIFF
--- a/model/connect/MySQLiConnector.php
+++ b/model/connect/MySQLiConnector.php
@@ -96,7 +96,7 @@ class MySQLiConnector extends DBConnector {
 	}
 
 	public function __destruct() {
-		if ($this->dbConn) {
+		if (is_resource($this->dbConn)) {
 			mysqli_close($this->dbConn);
 			$this->dbConn = null;
 		}


### PR DESCRIPTION
This change avoids a warning in situations where `$this->dbConn` is not falsy but also not a valid, open connection to the database. 

![error](https://cloud.githubusercontent.com/assets/200609/16636186/ad965b5a-442a-11e6-9eae-a0311c5aa337.jpg)
