### PR TITLE
BUGFIX: Changed form fields that call renderWith in Field() to call parent::Field() instead

### DIFF
--- a/forms/CheckboxSetField.php
+++ b/forms/CheckboxSetField.php
@@ -54,9 +54,7 @@ class CheckboxSetField extends OptionsetField {
 			'Options' => $this->getOptions()
 		));
 
-		return $this->customise($properties)->renderWith(
-			$this->getTemplates()
-		);
+		return FormField::Field($properties);
 	}
 
 	/**

--- a/forms/ListboxField.php
+++ b/forms/ListboxField.php
@@ -102,7 +102,7 @@ class ListboxField extends DropdownField {
 			'Options' => new ArrayList($options)
 		));
 
-		return $this->customise($properties)->renderWith($this->getTemplates());
+		return FormField::Field($properties);
 	}
 
 	public function getAttributes() {

--- a/forms/OptionsetField.php
+++ b/forms/OptionsetField.php
@@ -83,9 +83,7 @@ class OptionsetField extends DropdownField {
 			'Options' => new ArrayList($options)
 		));
 
-		return $this->customise($properties)->renderWith(
-			$this->getTemplates()
-		);
+		return FormField::Field($properties);
 	}
 
 	/**

--- a/forms/TreeDropdownField.php
+++ b/forms/TreeDropdownField.php
@@ -248,7 +248,7 @@ class TreeDropdownField extends FormField {
 			)
 		);
 
-		return $this->customise($properties)->renderWith('TreeDropdownField');
+		return parent::Field($properties);
 	}
 
 	public function extraClass() {

--- a/forms/TreeMultiselectField.php
+++ b/forms/TreeMultiselectField.php
@@ -135,7 +135,7 @@ class TreeMultiselectField extends TreeDropdownField {
 				'Value' => $value
 			)
 		);
-		return $this->customise($properties)->renderWith('TreeDropdownField');
+		return FormField::Field($properties);
 	}
 
 	/**

--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -972,11 +972,11 @@ class UploadField extends FileField {
 		}
 
 		$mergedConfig = array_merge($config, $this->ufConfig);
-		return $this->customise(array(
+		return parent::Field(array(
 			'configString' => str_replace('"', "&quot;", Convert::raw2json($mergedConfig)),
 			'config' => new ArrayData($mergedConfig),
 			'multiple' => $allowedMaxFileNumber !== 1
-		))->renderWith($this->getTemplates());
+		));
 	}
 
 	/**


### PR DESCRIPTION
Per request in #5718 this pull request is to make similar changes to what was in that pull request to the below classes. The main difference with this pull is that ``parent::Field()`` or ``FormField::Field()`` is used instead of calling renderWith and adding the extension point at each of those classes. The reason for using ``FormField::Field()`` in some instances is to jump over the ``parent::Field()`` which in some instances is causing issues like the [failed tests here](https://travis-ci.org/silverstripe/silverstripe-framework/jobs/142966336).

Affected classes:
* CheckboxSetField
* OptionsetField
* TreeDropdownField
* TreeMultiselectField
* UploadField
* ListboxField
