### PR TITLE
Remove unnecessary require calls.

### DIFF
--- a/cli-script.php
+++ b/cli-script.php
@@ -80,9 +80,6 @@ global $databaseConfig;
 // We don't have a session in cli-script, but this prevents errors
 $_SESSION = null;
 
-require_once("ORM/DB.php");
-
-
 // Connect to database
 if(!isset($databaseConfig) || !isset($databaseConfig['database']) || !$databaseConfig['database']) {
 	echo "\nPlease configure your database connection details.  You can do this by creating a file

--- a/core/startup/ParameterConfirmationToken.php
+++ b/core/startup/ParameterConfirmationToken.php
@@ -49,7 +49,6 @@ class ParameterConfirmationToken {
 	 */
 	protected function genToken() {
 		// Generate a new random token (as random as possible)
-		require_once(dirname(dirname(dirname(__FILE__))).'/security/RandomGenerator.php');
 		$rg = new RandomGenerator();
 		$token = $rg->randomToken('md5');
 

--- a/main.php
+++ b/main.php
@@ -147,7 +147,6 @@ $chain
 		require_once('core/Core.php');
 
 		// Connect to database
-		require_once('ORM/DB.php');
 		global $databaseConfig;
 		if ($databaseConfig) DB::connect($databaseConfig);
 


### PR DESCRIPTION
Now that we have PSR-4 compliance on these classes, manual include
statements aren’t needed.