### PR TITLE
Quick fix for HTTP/2.0 on OSX/Safari v9.1.1

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -141,7 +141,7 @@ jQuery.noConflict();
 			var msg = (xhr.getResponseHeader('X-Status')) ? xhr.getResponseHeader('X-Status') : xhr.statusText,
 				reathenticate = xhr.getResponseHeader('X-Reauthenticate'),
 				msgType = (xhr.status < 200 || xhr.status > 399) ? 'bad' : 'good',
-				ignoredMessages = ['OK', 'success'];
+				ignoredMessages = ['OK', 'success', 'HTTP/2.0 200'];
 
 			// Enable reauthenticate dialog if requested
 			if(reathenticate) {


### PR DESCRIPTION
Workaround to issue #5772 that adds an exception in the `XHR` ignored messages list to account for Safari rewriting status codes in `HTTP/2.0` to string messages.