### PR TITLE
Fixed PDO returning int as string

### DIFF
--- a/model/connect/PDOConnector.php
+++ b/model/connect/PDOConnector.php
@@ -156,6 +156,9 @@ class PDOConnector extends DBConnector {
 		if(self::is_emulate_prepare()) {
 			$options[PDO::ATTR_EMULATE_PREPARES] = true;
 		}
+		else {
+			$options[PDO::ATTR_EMULATE_PREPARES] = false;
+		}
 
 		// May throw a PDOException if fails
 		$this->pdoConnection = new PDO(


### PR DESCRIPTION
Without the fix PDO returns integers as strings, which is bad if you write a JSON API. Seems like ATTR_EMULATE_PREPARES has to be explicitly set to false ([see this SO post](http://stackoverflow.com/questions/1197005/how-to-get-numeric-types-from-mysql-using-pdo#answer-1197424)).