### PR TITLE
FIX: Hierarchy was incorrectly unexpanding nodes that had been previously expanded

### DIFF
--- a/model/Hierarchy.php
+++ b/model/Hierarchy.php
@@ -274,7 +274,8 @@ class Hierarchy extends DataExtension {
 			foreach($children as $child) {
 				$markingMatches = $this->markingFilterMatches($child);
 				if($markingMatches) {
-					if($child->$numChildrenMethod()) {
+					// Mark a child node as unexpanded if it has children and has not already been expanded
+					if($child->$numChildrenMethod() && !$child->isExpanded()) {
 						$child->markUnexpanded();
 					} else {
 						$child->markExpanded();

--- a/tests/model/HierarchyTest.yml
+++ b/tests/model/HierarchyTest.yml
@@ -20,6 +20,9 @@ HierarchyTest_Object:
    obj3c:
       Parent: =>HierarchyTest_Object.obj3
       Title: Obj 3c
+   obj3d:
+      Parent: =>HierarchyTest_Object.obj3
+      Title: Obj 3d
    obj2aa:
       Parent: =>HierarchyTest_Object.obj2a
       Title: Obj 2aa
@@ -32,3 +35,12 @@ HierarchyTest_Object:
    obj3ab:
       Parent: =>HierarchyTest_Object.obj3a
       Title: Obj 3ab
+   obj3ba:
+      Parent: =>HierarchyTest_Object.obj3b
+      Title: Obj 3ba
+   obj3bb:
+      Parent: =>HierarchyTest_Object.obj3b
+      Title: Obj 3bb
+   obj3ca:
+      Parent: =>HierarchyTest_Object.obj3c
+      Title: Obj 3c


### PR DESCRIPTION
Original pull-request with comments and notes: https://github.com/silverstripe/silverstripe-framework/pull/5349

This is opened against the 3.2 branch so it gets merged back to earlier versions of framework as well as the latest.