### PR TITLE
TESTS: code-climate should ignore admin/thirdparty

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,6 +15,7 @@ ratings:
 exclude_paths:
 - "client/dist/**"
 - "admin/client/dist/**"
+- "admin/thirdparty/**"
 - "templates/"
 - "tests/"
 - "thirdparty/"


### PR DESCRIPTION
admin/thirdparty shouldn’t be checked by code climate as it isn’t code
that we maintain.

This causes false failures on tickets such as #5820