### PR TITLE
change Chinese language name to 中文

### DIFF
--- a/i18n/i18n.php
+++ b/i18n/i18n.php
@@ -732,7 +732,7 @@ class i18n extends Object implements TemplateGlobalProvider, Flushable {
 		),
 		'zh' => array(
 			'name' => 'Chinese',
-			'native' => '&#20013;&#22269;&#30340;'
+			'native' => '&#20013;&#25991;'
 		),
 		'cs' => array(
 			'name' => 'Czech',


### PR DESCRIPTION
The direct translation of 中国的 (current value) would be "Chinese", but it means this in purely a possessive aspect - something or someone that is from China. 中文, on the other hand means Chinese (Mandarin) language.