### PR TITLE
[WIP] Don't include PasswordField values in responses when SecurityID is invalid

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -371,6 +371,16 @@ class Form extends RequestHandler {
 				// Clear invalid token on refresh
 				$data = $this->getData();
 				unset($data[$securityID]);
+
+				// Ensure we don't send passwords back in clear-text
+				/** @var FormField $f */
+				foreach($this->Fields()->dataFields() as $f) {
+
+					if(get_class($f) === 'PasswordField' && isset($data[$f->getName()])) {
+						unset($data[$f->getName()]);
+					}
+				}
+
 				Session::set("FormInfo.{$this->FormName()}.data", $data);
 				Session::set("FormInfo.{$this->FormName()}.errors", array());
 				$this->sessionMessage(


### PR DESCRIPTION
If the SecurityID is tampered with, or if the session is invalid, we probably don't want to send sensitive data back to the browser, mainly because these values could well be cached (the data is stored in session and then the user redirected back, so the browser makes a GET request which loads all form data into the form - if Cache-control headers are not set correctly then the browser may cache the response).

I don't like that I hard-code 'PasswordField' here. Ideally I think `FormField` would have some kind of `containsSensitiveData` member function that would return boolean `true` if the field may contain sensitive data like a password, credit card number etc. If it returns `true`, we shouldn't include it in the data stored in session.

It looks like the form tries to set cache headers to not cache if the form contains a security token, but that doesn't protect the GET request after the fact.

Perhaps if the user falls into this state we should never store anything in `Session::set()` because all this form data might be stored for another user to see if the site is behind e.g. CloudFlare...
