### PR TITLE
API Add $action parameter to Controller::Link

### DIFF
--- a/control/Controller.php
+++ b/control/Controller.php
@@ -127,10 +127,11 @@ class Controller extends RequestHandler implements TemplateGlobalProvider {
 	/**
 	 * Returns a link to this controller. Overload with your own Link rules if they exist.
 	 *
+	 * @param string $action Optional action
 	 * @return string
 	 */
-	public function Link() {
-		return get_class($this) .'/';
+	public function Link($action = null) {
+		return Controller::join_links(get_class($this), $action, '/');
 	}
 
 	/**

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -56,6 +56,7 @@
  * `CMSMain::buildbrokenlinks()` action is removed.
  * `Folder_UnusedAssetsField` is removed.
  * `UpgradeSiteTreePermissionSchemaTask` is removed.
+ * `$action` parameter to `Controller::Link()` method is standardised.
 
 ## New API
 

--- a/tests/control/ControllerTest.php
+++ b/tests/control/ControllerTest.php
@@ -273,6 +273,14 @@ class ControllerTest extends FunctionalTest {
 		$this->assertEquals("my-page/0", Controller::join_links("my-page", 0));
 	}
 
+	public function testLink() {
+		$controller = new ControllerTest_HasAction();
+		$this->assertEquals('ControllerTest_HasAction/', $controller->Link());
+		$this->assertEquals('ControllerTest_HasAction/', $controller->Link(null));
+		$this->assertEquals('ControllerTest_HasAction/', $controller->Link(false));
+		$this->assertEquals('ControllerTest_HasAction/allowed-action/', $controller->Link('allowed-action'));
+	}
+
 	/**
 	 * @covers Controller::hasAction
 	 */

--- a/tests/forms/MemberDatetimeOptionsetFieldTest.php
+++ b/tests/forms/MemberDatetimeOptionsetFieldTest.php
@@ -118,8 +118,8 @@ class MemberDatetimeOptionsetFieldTest extends SapphireTest {
 }
 class MemberDatetimeOptionsetFieldTest_Controller extends Controller {
 
-	public function Link() {
-		return 'test';
+	public function Link($action = null) {
+		return Controller::join_links('test', $action, '/');
 	}
 
 }

--- a/tests/forms/gridfield/GridField_URLHandlerTest.php
+++ b/tests/forms/gridfield/GridField_URLHandlerTest.php
@@ -35,9 +35,6 @@ class GridField_URLHandlerTest_Controller extends Controller implements TestOnly
 
 	private static $allowed_actions = array('Form');
 
-	public function Link() {
-		return get_class($this) ."/";
-	}
 	public function Form() {
 		$gridConfig = GridFieldConfig::create();
 		$gridConfig->addComponent(new GridField_URLHandlerTest_Component());


### PR DESCRIPTION
Reverts https://github.com/silverstripe/silverstripe-framework/commit/1ccdcbac5dbabf0cac43004e7c9e8048be95a93e

This is necessary to fix some actions in gridfield, where the form Link() action isn't being correctly concatenated to the parent controller.

Prior to this fix, clicking the gridfield header would cause a HTTP error (HTTP request was to `/admin/reports/EditForm/field/Reports`, instead of `/admin/reports/index/EditForm/field/Reports`)

The problem is that some controllers need to know if they are being appended to nested controllers, and occasionally need to add the full urlsegment in those cases. The 'home' page and the reports 'index' actions are two examples.