### PR TITLE
Modify getAuthenticator to fall back on default

### DIFF
--- a/Security/Security.php
+++ b/Security/Security.php
@@ -371,10 +371,8 @@ class Security extends Controller implements TemplateGlobalProvider {
 			if(in_array($authenticator, $authenticators)) {
 				return $authenticator;
 			}
-		} else {
-			return Authenticator::get_default_authenticator();
 		}
-
+		return Authenticator::get_default_authenticator();
 	}
 
 	/**


### PR DESCRIPTION
Currently it is possible to successfully return `$authenticator`, but if it is not in the array `$authenticators`, you are returned `NULL` instead of falling back to the `default_authenticator`. This PR changes the flow so that `default_authenticator` is returned in that circumstance.