### PR TITLE
Modify getAuthenticator to fall back to get_default_authenticator

### DIFF
--- a/security/Security.php
+++ b/security/Security.php
@@ -324,10 +324,8 @@ class Security extends Controller implements TemplateGlobalProvider {
 			if(in_array($authenticator, $authenticators)) {
 				return $authenticator;
 			}
-		} else {
-			return Authenticator::get_default_authenticator();
 		}
-
+		return Authenticator::get_default_authenticator();
 	}
 
 	/**


### PR DESCRIPTION
As per #5863 PR'ing against 3.2. This will ensure that `getAuthenticator` falls back to `get_default_authenticator` if it fails to find any others. 