### PR TITLE
showqueries debugging tool now inserts parameters in place

### DIFF
--- a/docs/en/02_Developer_Guides/07_Debugging/02_URL_Variable_Tools.md
+++ b/docs/en/02_Developer_Guides/07_Debugging/02_URL_Variable_Tools.md
@@ -38,10 +38,10 @@ Append the option and corresponding value to your URL in your browser's address 
 
 ## Database
 
- | URL Variable | | Values | | Description                                                                                  | 
- | ------------ | | ------ | | -----------                                                                                  | 
- | showqueries  | | 1      | | List all SQL queries executed                                                                | 
- | previewwrite | | 1      | | List all insert / update SQL queries, and **don't** execute them.  Useful for previewing writes to the database. | 
+ | URL Variable | | Values    | | Description                                                                                  | 
+ | ------------ | | --------- | | -----------                                                                                  | 
+ | showqueries  | | 1\|inline | | List all SQL queries executed, the `inline` option will do a fudge replacement of parameterised queries          | 
+ | previewwrite | | 1         | | List all insert / update SQL queries, and **don't** execute them.  Useful for previewing writes to the database. | 
 
 ## Security Redirects
 

--- a/model/connect/Database.php
+++ b/model/connect/Database.php
@@ -141,7 +141,8 @@ abstract class SS_Database {
 			$sql,
 			function($sql) use($connector, $parameters, $errorLevel) {
 				return $connector->preparedQuery($sql, $parameters, $errorLevel);
-			}
+			},
+			$parameters
 		);
 	}
 
@@ -174,13 +175,18 @@ abstract class SS_Database {
 	 *
 	 * @param string $sql Query to run, and single parameter to callback
 	 * @param callable $callback Callback to execute code
+	 * @param array $parameters Parameters for any parameterised query
 	 * @return mixed Result of query
 	 */
-	protected function benchmarkQuery($sql, $callback) {
+	protected function benchmarkQuery($sql, $callback, $parameters = array()) {
 		if (isset($_REQUEST['showqueries']) && Director::isDev()) {
 			$starttime = microtime(true);
 			$result = $callback($sql);
 			$endtime = round(microtime(true) - $starttime, 4);
+			// replace parameters as closely as possible to what we'd expect the DB to put in
+			if (strtolower($_REQUEST['showqueries']) == 'inline') {
+				$sql = DB::inline_parameters($sql, $parameters);
+			}
 			Debug::message("\n$sql\n{$endtime}s\n", false);
 			return $result;
 		} else {

--- a/model/queries/SQLQuery.php
+++ b/model/queries/SQLQuery.php
@@ -160,35 +160,7 @@ class SQLQuery_ParameterInjector {
 	 * @return string
 	 */
 	protected function injectValues($sql, $parameters) {
-		$segments = preg_split('/\?/', $sql);
-		$joined = '';
-		$inString = false;
-		for($i = 0; $i < count($segments); $i++) {
-			// Append next segment
-			$joined .= $segments[$i];
-			// Don't add placeholder after last segment
-			if($i === count($segments) - 1) {
-				break;
-			}
-			// check string escape on previous fragment
-			if($this->checkStringTogglesLiteral($segments[$i])) {
-				$inString = !$inString;
-			}
-			// Append placeholder replacement
-			if($inString) {
-				// Literal questionmark
-				$joined .= '?';
-				continue;
-			}
-
-			// Encode and insert next parameter
-			$next = array_shift($parameters);
-			if(is_array($next) && isset($next['value'])) {
-				$next = $next['value'];
-			}
-			$joined .= "'".Convert::raw2sql($next)."'";
-		}
-		return $joined;
+		return DB::inline_parameters($sql, $parameters);
 	}
 
 	/**


### PR DESCRIPTION
Well, here's something to start a lively debate. Whilst I know in master we show the params at the end of the query and that there's an argument users might not realise their queries are parameterised and thus think this is literal queryies being run - I do think this is much more useful for debugging help.

A list of params later on is difficult to reconcile to the right `?` when there are a lot of params. (think `IN` clauses).

If we're really against this, can I suggest that we have `?showqueries=2` which is basically "fudge parameters" (ie: this change)?

see #4582