### PR TITLE
Remove obsolete template ModelSidebar.ss

### DIFF
--- a/admin/templates/ModelSidebar.ss
+++ b/admin/templates/ModelSidebar.ss
@@ -1,7 +1,0 @@
-<h3><%t ModelSidebar_ss.SEARCHLISTINGS 'Search' %></h3>
-$SearchForm
-
-<% if $ImportForm %>
-	<h3><%t ModelSidebar_ss.IMPORT_TAB_HEADER 'Import' %></h3>
-	$ImportForm
-<% end_if %>


### PR DESCRIPTION
This used to belong to the old 2.x ModelAdmin but is no longer used