### PR TITLE
Cleaning up GridFieldAddExistingAutocompleter

### DIFF
--- a/forms/gridfield/GridFieldAddExistingAutocompleter.php
+++ b/forms/gridfield/GridFieldAddExistingAutocompleter.php
@@ -59,7 +59,7 @@ class GridFieldAddExistingAutocompleter
 	 *  	'Team.Name'
 	 *  )
 	 *
-	 * @var Array
+	 * @var array
 	 */
 	protected $searchFields = array();
 
@@ -69,7 +69,7 @@ class GridFieldAddExistingAutocompleter
 	protected $resultsFormat = '$Title';
 
 	/**
-	 * @var String Text shown on the search field, instructing what to search for.
+	 * @var string Text shown on the search field, instructing what to search for.
 	 */
 	protected $placeholderText;
 
@@ -90,7 +90,7 @@ class GridFieldAddExistingAutocompleter
 	/**
 	 *
 	 * @param GridField $gridField
-	 * @return string - HTML
+	 * @return string[] - HTML
 	 */
 	public function getHTMLFragments($gridField) {
 		$dataClass = $gridField->getList()->dataClass();
@@ -215,17 +215,20 @@ class GridFieldAddExistingAutocompleter
 			->limit($this->getResultsLimit());
 
 		$json = array();
-		$originalSourceFileComments = Config::inst()->get('SSViewer', 'source_file_comments');
+		Config::nest();
 		Config::inst()->update('SSViewer', 'source_file_comments', false);
+		$viewer = SSViewer::fromString($this->resultsFormat);
 		foreach($results as $result) {
-			$json[$result->ID] = html_entity_decode(SSViewer::fromString($this->resultsFormat)->process($result));
+			$json[$result->ID] = html_entity_decode($viewer->process($result));
 		}
-		Config::inst()->update('SSViewer', 'source_file_comments', $originalSourceFileComments);
+		Config::unnest();
 		return Convert::array2json($json);
 	}
 
 	/**
-	 * @param String
+	 * @param string $format
+	 *
+	 * @return $this
 	 */
 	public function setResultsFormat($format) {
 		$this->resultsFormat = $format;
@@ -233,7 +236,7 @@ class GridFieldAddExistingAutocompleter
 	}
 
 	/**
-	 * @return String
+	 * @return string
 	 */
 	public function getResultsFormat() {
 		return $this->resultsFormat;
@@ -247,10 +250,11 @@ class GridFieldAddExistingAutocompleter
 	 */
 	public function setSearchList(SS_List $list) {
 		$this->searchList = $list;
+		return $this;
 	}
 
 	/**
-	 * @param Array
+	 * @param array $fields
 	 */
 	public function setSearchFields($fields) {
 		$this->searchFields = $fields;
@@ -258,7 +262,7 @@ class GridFieldAddExistingAutocompleter
 	}
 
 	/**
-	 * @return Array
+	 * @return array
 	 */
 	public function getSearchFields() {
 		return $this->searchFields;
@@ -269,8 +273,8 @@ class GridFieldAddExistingAutocompleter
 	 * Falls back to {@link DataObject->summaryFields()} if
 	 * no custom search fields are defined.
 	 *
-	 * @param  String the class name
-	 * @return Array|null names of the searchable fields
+	 * @param  string $dataClass the class name
+	 * @return array|null names of the searchable fields
 	 */
 	public function scaffoldSearchFields($dataClass) {
 		$obj = singleton($dataClass);
@@ -306,8 +310,9 @@ class GridFieldAddExistingAutocompleter
 	}
 
 	/**
-	 * @param String The class of the object being searched for
-	 * @return String
+	 * @param string $dataClass The class of the object being searched for
+	 *
+	 * @return string
 	 */
 	public function getPlaceholderText($dataClass) {
 		$searchFields = ($this->getSearchFields())
@@ -339,10 +344,13 @@ class GridFieldAddExistingAutocompleter
 	}
 
 	/**
-	 * @param String
+	 * @param string $text
+	 *
+	 * @return $this
 	 */
 	public function setPlaceholderText($text) {
 		$this->placeholderText = $text;
+		return $this;
 	}
 
 	/**
@@ -356,8 +364,11 @@ class GridFieldAddExistingAutocompleter
 
 	/**
 	 * @param int $limit
+	 *
+	 * @return $this
 	 */
 	public function setResultsLimit($limit) {
 		$this->resultsLimit = $limit;
+		return $this;
 	}
 }


### PR DESCRIPTION
- PHPDoc fixes
- Proper use of `Config::nest()`/`Config::unnest()`
- `return $this` on setters
- Minor optimisation on repeated `SSViewer` instantiations 