### PR TITLE
Fixing TabSet.js error when expected elements are not available

### DIFF
--- a/javascript/TabSet.js
+++ b/javascript/TabSet.js
@@ -1,5 +1,5 @@
-(function($){
-	$.entwine('ss', function($){
+(function($) {
+	$.entwine('ss', function($) {
 		/**
 		 * Lightweight wrapper around jQuery UI tabs for generic tab set-up
 		 */
@@ -34,11 +34,11 @@
 			 * @param {string} hash
 			 * @desc Allows linking to a specific tab.
 			 */
-			openTabFromURL: function (hash) {
+			openTabFromURL: function(hash) {
 				var $trigger;
 
 				// Make sure the hash relates to a valid tab.
-				$.each(this.find('.cms-panel-link'), function () {
+				$.each(this.find('.ui-tabs-anchor'), function() {
 					// The hash in in the button's href and there is exactly one tab with that id.
 					if (this.href.indexOf(hash) !== -1 && $(hash).length === 1) {
 						$trigger = $(this);
@@ -52,7 +52,7 @@
 				}
 
 				// Switch to the correct tab when AJAX loading completes.
-				$(window).one('ajaxComplete', function () {
+				$(document).ready(function() {
 					$trigger.click();
 				});
 			},
@@ -66,7 +66,7 @@
 					if (!$(this).attr('href')) return;
 
 					var matches = $(this).attr('href').match(/#.*/);
-					if(!matches) return;
+					if (!matches) return;
 					$(this).attr('href', document.location.href.replace(/#.*/, '') + matches[0]);
 				});
 			}


### PR DESCRIPTION
Updating TabSet.js to open tabs correctly on page load when a hash is added to URL within the CMS.

This was done to fix a JS error found when clicking the "Manage roles" link inside the "Roles" tab when viewing a Group within the CMS. The error was:

`Uncaught TypeError: Cannot read property 'indexOf' of undefined`

It looks like the `openTabFromURL` method was looping over a JS selector that has been updated or is only used in some cases so when it tries to find the `href` property it can't (and hence calling `indexOf` on `this.href` produces the above error).

The suggested fix changes the following line as the `ajaxComplete` event is not being fired so needed to use another appropriate event instead:

`$(window).one('ajaxComplete', function () { ... });`