### PR TITLE
API Change behaviour of filter API to support injected search filter classes

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -1,3 +1,6 @@
+---
+Name: corefieldtypes
+---
 Injector:
   Boolean:
     class: SilverStripe\ORM\FieldType\DBBoolean
@@ -55,3 +58,28 @@ Injector:
     class: SilverStripe\ORM\FieldType\DBVarchar
   Year:
     class: SilverStripe\ORM\FieldType\DBYear
+---
+Name: coresearchfilters
+---
+Injector:
+  DataListFilter.default: %$DataListFilter.ExactMatch
+  DataListFilter.EndsWith:
+    class: EndsWithFilter
+  DataListFilter.ExactMatch:
+    class: ExactMatchFilter
+  DataListFilter.Fulltext:
+    class: FulltextFilter
+  DataListFilter.GreaterThan:
+    class: GreaterThanFilter
+  DataListFilter.GreaterThanOrEqual:
+    class: GreaterThanOrEqualFilter
+  DataListFilter.LessThan:
+    class: LessThanFilter
+  DataListFilter.LessThanOrEqual:
+    class: LessThanOrEqualFilter
+  DataListFilter.PartialMatch:
+    class: PartialMatchFilter
+  DataListFilter.StartsWith:
+    class: StartsWithFilter
+  DataListFilter.WithinRange:
+    class: WithinRangeFilter

--- a/docs/en/02_Developer_Guides/00_Model/06_SearchFilters.md
+++ b/docs/en/02_Developer_Guides/00_Model/06_SearchFilters.md
@@ -36,6 +36,17 @@ These suffixes can also take modifiers themselves. The modifiers currently suppo
 comparison uses the database's default. For MySQL and MSSQL, this is case-insensitive. For PostgreSQL, this is 
 case-sensitive.
 
+Note that all search filters (e.g. `:PartialMatch`) refer to services registered with [api:Injector]
+within the `DataListFilter.` prefixed namespace. New filters can be registered using the below yml
+config:
+
+
+	:::yaml
+	Injector:
+	  DataListFilter.CustomMatch:
+	    class: MyVendor/Search/CustomMatchFilter
+
+
 The following is a query which will return everyone whose first name starts with "S", either lowercase or uppercase:
 
 	:::php

--- a/docs/en/02_Developer_Guides/12_Search/02_FulltextSearch.md
+++ b/docs/en/02_Developer_Guides/12_Search/02_FulltextSearch.md
@@ -71,7 +71,7 @@ Example DataObject:
 Performing the search:
 
 	:::php
-	SearchableDataObject::get()->filter('SearchFields:fulltext', 'search term');
+	SearchableDataObject::get()->filter('SearchFields:Fulltext', 'search term');
 
 If your search index is a single field size, then you may also specify the search filter by the name of the
 field instead of the index.

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -59,6 +59,10 @@
  * `UpgradeSiteTreePermissionSchemaTask` is removed.
  * `$action` parameter to `Controller::Link()` method is standardised.
  * Removed `UpgradeSiteTreePermissionSchemaTask`
+ * Removed `DataList::applyFilterContext` private method
+ * Search filter classes (e.g. `ExactMatchFilter`) are now registered with `Injector`
+   via a new `DataListFilter.` prefix convention.
+   see [search filter documentation](/developer_guides/model/searchfilters) for more information.
 
 ## New API
 

--- a/search/filters/ExactMatchFilter.php
+++ b/search/filters/ExactMatchFilter.php
@@ -18,13 +18,9 @@ use SilverStripe\ORM\DB;
  */
 class ExactMatchFilter extends SearchFilter {
 
-	public function setModifiers(array $modifiers) {
-		if(($extras = array_diff($modifiers, array('not', 'nocase', 'case'))) != array()) {
-			throw new InvalidArgumentException(
-				get_class($this) . ' does not accept ' . implode(', ', $extras) . ' as modifiers');
-		}
-
-		parent::setModifiers($modifiers);
+	public function getSupportedModifiers()
+	{
+		return ['not', 'nocase', 'case'];
 	}
 
 	/**

--- a/search/filters/PartialMatchFilter.php
+++ b/search/filters/PartialMatchFilter.php
@@ -15,13 +15,9 @@ use SilverStripe\ORM\DB;
  */
 class PartialMatchFilter extends SearchFilter {
 
-	public function setModifiers(array $modifiers) {
-		if(($extras = array_diff($modifiers, array('not', 'nocase', 'case'))) != array()) {
-			throw new InvalidArgumentException(
-				get_class($this) . ' does not accept ' . implode(', ', $extras) . ' as modifiers');
-		}
-
-		parent::setModifiers($modifiers);
+	public function getSupportedModifiers()
+	{
+		return ['not', 'nocase', 'case'];
 	}
 
 	/**

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -649,9 +649,22 @@ class DataListTest extends SapphireTest {
 	}
 
 	public function testSimpleFilterWithNonExistingComparisator() {
-		$this->setExpectedException('InvalidArgumentException');
+		$this->setExpectedException(
+			'ReflectionException',
+			'Class DataListFilter.Bogus does not exist'
+		);
 		$list = DataObjectTest_TeamComment::get();
-		$list = $list->filter('Comment:Bogus', 'team comment');
+		$list->filter('Comment:Bogus', 'team comment');
+	}
+
+	public function testInvalidModifier() {
+		// Invalid modifiers are treated as failed filter construction
+		$this->setExpectedException(
+			'ReflectionException',
+			'Class DataListFilter.invalidmodifier does not exist'
+		);
+		$list = DataObjectTest_TeamComment::get();
+		$list->filter('Comment:invalidmodifier', 'team comment');
 	}
 
 	/**

--- a/tests/search/FulltextFilterTest.php
+++ b/tests/search/FulltextFilterTest.php
@@ -19,25 +19,25 @@ class FulltextFilterTest extends SapphireTest {
 			$this->assertEquals(3, $baseQuery->count(), "FulltextFilterTest_DataObject count does not match.");
 
 			// First we'll text the 'SearchFields' which has been set using an array
-			$search = $baseQuery->filter("SearchFields:fulltext", 'SilverStripe');
+			$search = $baseQuery->filter("SearchFields:Fulltext", 'SilverStripe');
 			$this->assertEquals(1, $search->count());
 
-			$search = $baseQuery->exclude("SearchFields:fulltext", "SilverStripe");
+			$search = $baseQuery->exclude("SearchFields:Fulltext", "SilverStripe");
 			$this->assertEquals(2, $search->count());
 
 			// Now we'll run the same tests on 'OtherSearchFields' which should yield the same resutls
 			// but has been set using a string.
-			$search = $baseQuery->filter("OtherSearchFields:fulltext", 'SilverStripe');
+			$search = $baseQuery->filter("OtherSearchFields:Fulltext", 'SilverStripe');
 			$this->assertEquals(1, $search->count());
 
-			$search = $baseQuery->exclude("OtherSearchFields:fulltext", "SilverStripe");
+			$search = $baseQuery->exclude("OtherSearchFields:Fulltext", "SilverStripe");
 			$this->assertEquals(2, $search->count());
 
 			// Search on a single field
-			$search = $baseQuery->filter("ColumnE:fulltext", 'Dragons');
+			$search = $baseQuery->filter("ColumnE:Fulltext", 'Dragons');
 			$this->assertEquals(1, $search->count());
 
-			$search = $baseQuery->exclude("ColumnE:fulltext", "Dragons");
+			$search = $baseQuery->exclude("ColumnE:Fulltext", "Dragons");
 			$this->assertEquals(2, $search->count());
 		} else {
 			$this->markTestSkipped("FulltextFilter only supports MySQL syntax.");


### PR DESCRIPTION
In order to support ambiguous syntax (e.g. `Field:Filter`,  `Field:Filter:modifier`, `Field:modifier`) I've updated the behaviour of SearchFilter to check the case of any supplied argument. Previously, this would use class_exists to resolve ambiguity, but with namespaced classes (and injector aliases) this isn't possible.

Broken out of https://github.com/silverstripe/silverstripe-framework/pull/5921