### PR TITLE
BUG Fix issue with Folder::validate() failing on allowed_extensions

### DIFF
--- a/Assets/File.php
+++ b/Assets/File.php
@@ -997,7 +997,7 @@ class File extends DataObject implements ShortcodeHandler, AssetContainer, Thumb
 		}
 
 	public function validate() {
-		$result = new ValidationResult();
+		$result = ValidationResult::create();
 		$this->File->validate($result, $this->Name);
 		$this->extend('validate', $result);
 		return $result;

--- a/Assets/Folder.php
+++ b/Assets/Folder.php
@@ -9,6 +9,7 @@ use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\ValidationResult;
 use SilverStripe\ORM\Versioning\Versioned;
 
 /**
@@ -324,5 +325,11 @@ class Folder extends File {
 
 	public function StripThumbnail() {
 		return null;
+	}
+
+	public function validate() {
+		$result = ValidationResult::create();
+		$this->extend('validate', $result);
+		return $result;
 	}
 }


### PR DESCRIPTION
Fixes issue found in https://github.com/silverstripe/silverstripe-framework/pull/5962#issuecomment-245481457

Folders should not really invoke `$this->File->validate($result, $this->Name);` because they don't store themselves using `DBFile` the way that `File` does.
