### PR TITLE
Improved CodeClimate excludes

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,9 +14,6 @@ ratings:
   - client/src/**
   - admin/client/src/**
 exclude_paths:
-- "client/dist/**"
-- "admin/client/dist/**"
-- "admin/thirdparty/**"
-- "templates/"
-- "tests/"
-- "thirdparty/"
+- "**/*"
+- "!client/src/**"
+- "!admin/client/src/**"


### PR DESCRIPTION
Exclude lang folders, make other includes less verbose
by using globs, see https://docs.codeclimate.com/docs/excluding-files-and-folders