### PR TITLE
FIX Force line endings to LF on sake file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Line endings
+sake text eol=lf


### PR DESCRIPTION
Git (by default) will change line endings to the environment standard during checkout.

This change forces the sake bash script to keep `lf` line endings which is needed for better compatibility with windows hosts/shared files/VMs/whatever