### PR TITLE
cache currentUser query

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -834,10 +834,16 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * @return Member|null
 	 */
 	public static function currentUser() {
+		static $cache = array();
+		
 		$id = Member::currentUserID();
 
 		if($id) {
-			return Member::get()->byId($id);
+			if(!empty($cache[$id])) {
+				return $cache[$id];
+			}
+			$cache[$id] = Member::get()->byId($id);
+			return $cache[$id];
 		}
 	}
 

--- a/security/Member.php
+++ b/security/Member.php
@@ -837,7 +837,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		$id = Member::currentUserID();
 
 		if($id) {
-			DataObject::get_by_id('Member', $id);
+			return DataObject::get_by_id('Member', $id);
 		}
 		return null;
 	}

--- a/security/Member.php
+++ b/security/Member.php
@@ -834,17 +834,12 @@ class Member extends DataObject implements TemplateGlobalProvider {
 	 * @return Member|null
 	 */
 	public static function currentUser() {
-		static $cache = array();
-		
 		$id = Member::currentUserID();
 
 		if($id) {
-			if(!empty($cache[$id])) {
-				return $cache[$id];
-			}
-			$cache[$id] = Member::get()->byId($id);
-			return $cache[$id];
+			DataObject::get_by_id('Member', $id);
 		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Various modules can call a lot of time Member::currentUser(). We can avoid querying the database multiple times. Cache is implemented as a static array inside the method and store the data byID, in case the currentUserID changes within the same request (not very likely, but..)