### PR TITLE
Fixing button destroy bug

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -1081,7 +1081,7 @@ jQuery.noConflict();
 				this._super();
 			},
 			onremove: function() {
-				if(this.data('button')) this.button('destroy');
+				if(!this.data('button')) this.button('destroy');
 				this._super();
 			}
 		});


### PR DESCRIPTION
When you want to add a button to the CMS but don't want LeftAndMain to apply jQuery UI button to it we add the `data-button="true"` attribute to our button. 

The `onadd` function checks that this attribute does not exist before calling `this.button()`.

The `onremove` incorrectly checks that this attribute does exist before calling `this.button('destroy')`. This should be checking that this attribute does not exist, just like the `onadd` function.

What this causes is when you have a button with the `data-button` attribute a button is not created, but when you leave the page `destory` gets called on an item which doesn't exist. We end up with the following error:

> Uncaught Error: cannot call methods on button prior to initialization; attempted to call method 'destroy'

The other issue with this logic is buttons are never getting destroyed when `onremove` is called.

The whole issue is caused by a missing `!` in the if statement. This change adds it in to fix the problem.