### PR TITLE
FIX: Frontend UploadField wouldn't call ssdialog

### DIFF
--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -263,8 +263,8 @@
 			},
 			openSelectDialog: function(uploadedFile) {
 				// Create dialog and load iframe
-				var self = this, config = this.getConfig(), dialogId = 'ss-uploadfield-dialog-' + this.attr('id'), dialog = jQuery('#' + dialogId);
-				if(!dialog.length) dialog = jQuery('<div class="ss-uploadfield-dialog" id="' + dialogId + '" />');
+				var self = this, config = this.getConfig(), dialogId = 'ss-uploadfield-dialog-' + this.attr('id'), dialog = $('#' + dialogId);
+				if(!dialog.length) dialog = $('<div class="ss-uploadfield-dialog" id="' + dialogId + '" />');
 
 				// If user selected 'Choose another file', we need the ID of the file to replace
 				var iframeUrl = config['urlSelectDialog'];


### PR DESCRIPTION
As in front end jQuery would be redefined by user's custom version. Also the script should use the scope variable ```$``` as it represents the instance of jQuery with all the requirements loaded.