### PR TITLE
FIX Debug::caller() will now handle errors from outside function calls

### DIFF
--- a/dev/Debug.php
+++ b/dev/Debug.php
@@ -89,11 +89,12 @@ class Debug {
 	 */
 	public static function caller() {
 		$bt = debug_backtrace();
-		$caller = $bt[2];
+		$caller = isset($bt[2]) ? $bt[2] : array();
 		$caller['line'] = $bt[1]['line'];
 		$caller['file'] = $bt[1]['file'];
 		if(!isset($caller['class'])) $caller['class'] = '';
 		if(!isset($caller['type'])) $caller['type'] = '';
+		if(!isset($caller['function'])) $caller['function'] = '';
 		return $caller;
 	}
 


### PR DESCRIPTION
If you place a `Debug::show(...)` call in `framework/main.php` the debugger throws an undefined index error on `$bt[2]`. This is because there is no parent function/caller.

This probably was never a problem until the composer autoloader was added