### PR TITLE
Docs - sort by random instructions

### DIFF
--- a/docs/en/02_Developer_Guides/00_Model/01_Data_Model_and_ORM.md
+++ b/docs/en/02_Developer_Guides/00_Model/01_Data_Model_and_ORM.md
@@ -268,10 +268,11 @@ However you might have several entries with the same `FirstName` and would like 
 		'LastName'=>'ASC'
 	));
 
-You can also sort randomly.
+You can also sort randomly. Using the `DB` class, you can get the random sort method per database type.
 
 	:::php
-	$players = Player::get()->sort('RAND()')
+	$random = DB::get_conn()->random(); 
+	$players = Player::get()->sort($random)
 	
 
 ## Filtering Results


### PR DESCRIPTION
Added instructions for random sorting per database type. `RAND()` throws errors in PostgreSQL and SQLite