### PR TITLE
FIX: Make PR builds work.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ before_script:
  - phpenv config-rm xdebug.ini
  - "export DISPLAY=\":99\""
  - "export XVFBARGS=\":99 -ac -screen 0 1024x768x16\""
+ - "export COMPOSER_ROOT_VERSION=4.0.x-dev"
  - "if [ \"$na\" = \"\" ]; then composer install --prefer-dist; fi"
  - "if [ \"$DB\" = \"PGSQL\" ]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi"
  - "if [ \"$DB\" = \"SQLITE\" ]; then composer require silverstripe/sqlite3:2.0.x-dev --prefer-dist; fi"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,13 @@
 use SilverStripe\ORM\DB;
 use SilverStripe\Dev\SapphireTest;
 
+if(!defined('BASE_PATH')) {
+	echo "BASE_PATH hasn't been defined. This probably means that framework/Core/Constants.php hasn't been " .
+		"included by Composer's autoloader.\n" .
+		"Make sure the you are running your tests via vendor/bin/phpunit and your autoloader is up to date.\n";
+	exit(1);
+}
+
 
 /**
  * This bootstraps the SilverStripe system so that phpunit can be run directly on SilverStripe tests.


### PR DESCRIPTION
PR builds are consistently failing because the version of framework
being used cannot be inferred. This environment variable provides the
answer.

It will need to be fixed for each major release, but I think that’s
less maintenance burden than complicating the build script to read this
from composer.json:extra.branch-alias.dev-master.