### PR TITLE
API Move PreviewLink logic into File dataobject

### DIFF
--- a/Assets/File.php
+++ b/Assets/File.php
@@ -473,8 +473,7 @@ class File extends DataObject implements ShortcodeHandler, AssetContainer, Thumb
 	public function getCMSFields() {
 		$path = '/' . dirname($this->getFilename());
 
-		$width = (int)Image::config()->get('asset_preview_width');
-		$previewLink = Convert::raw2att($this->ScaleMaxWidth($width)->getIcon());
+		$previewLink = Convert::raw2att($this->PreviewLink());
 		$image = "<img src=\"{$previewLink}\" class=\"editor__thumbnail\" />";
 
 		$content = Tab::create('Main',
@@ -1219,8 +1218,12 @@ class File extends DataObject implements ShortcodeHandler, AssetContainer, Thumb
 	}
 
 	public function PreviewLink($action = null) {
-		// No preview for non-images by default
-		$link = null;
+		// Since AbsoluteURL can whitelist protected assets,
+		// do permission check first
+		if (!$this->canView()) {
+			return null;
+		}
+		$link = $this->getIcon();
 		$this->extend('updatePreviewLink', $link, $action);
 		return $link;
 	}

--- a/Assets/Image.php
+++ b/Assets/Image.php
@@ -47,12 +47,7 @@ class Image extends File implements ShortcodeHandler {
 	public function getCMSFields() {
 		$path = '/' . dirname($this->getFilename());
 
-		$width = (int)Image::config()->get('asset_preview_width');
-		$height = (int)Image::config()->get('asset_preview_height');
-		$previewLink = Convert::raw2att($this
-			->FitMax($width, $height)
-			->PreviewLink()
-		);
+		$previewLink = Convert::raw2att($this->PreviewLink());
 		$image = "<img src=\"{$previewLink}\" class=\"editor__thumbnail\" />";
 
 		$link = $this->Link();
@@ -215,7 +210,16 @@ class Image extends File implements ShortcodeHandler {
 		if(!$this->canView()) {
 			return false;
 		}
-		$link = $this->AbsoluteLink();
+
+		// Size to width / height
+		$width = (int)$this->config()->get('asset_preview_width');
+		$height = (int)$this->config()->get('asset_preview_height');
+		$resized = $this->FitMax($width, $height);
+		if ($resized && $resized->exists()) {
+			$link = $resized->getAbsoluteURL();
+		} else {
+			$link = $this->getIcon();
+		}
 		$this->extend('updatePreviewLink', $link, $action);
 		return $link;
 	}

--- a/Assets/Storage/DBFile.php
+++ b/Assets/Storage/DBFile.php
@@ -529,27 +529,4 @@ class DBFile extends DBComposite implements AssetContainer, Thumbnail {
 				->getStore()
 				->canView($this->Filename, $this->Hash);
 	}
-
-	/**
-	 * Generates the URL for this DBFile preview, this is particularly important for images that
-	 * have been manipulated e.g. by {@link ImageManipulation}
-	 * Use the 'updatePreviewLink' extension point to customise the link.
-	 *
-	 * @param null $action
-	 * @return bool|string
-	 */
-	public function PreviewLink($action = null) {
-		// Since AbsoluteURL can whitelist protected assets,
-		// do permission check first
-		if (!$this->failover->canView()) {
-			return false;
-		}
-		if ($this->getIsImage()) {
-			$link = $this->getAbsoluteURL();
-		} else {
-			$link = Convert::raw2att($this->failover->getIcon());
-		}
-		$this->extend('updatePreviewLink', $link, $action);
-		return $link;
-	}
 }


### PR DESCRIPTION
Sorry, I thought this was merged earlier.

The previewlink logic being in DBFile isn't correct, as DBFile isn't a `CMSPreviewable` dataobject, and the failover code there would not worked as coded.

This fixes the issues by moving the logic back into the File / Image dataobjects and cleans up the thumbnail generation.