### PR TITLE
BUG Fix incorrect ssviewertest path

### DIFF
--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -1470,7 +1470,7 @@ EOC;
 
 			$this->assertEquals(1, substr_count(
 				$template->process(array()),
-				"tests/forms/RequirementsTest_a.js"
+				"tests/javascript/forms/RequirementsTest_a.js"
 			));
 		}
 		else {


### PR DESCRIPTION
Seems to be a regression from the test refactor that incorrectly modified the expected path.