### PR TITLE
BUG Fix incorrect backslash escaping in htaccess template

### DIFF
--- a/templates/SilverStripe/Assets/Flysystem/PublicAssetAdapter_HTAccess.ss
+++ b/templates/SilverStripe/Assets/Flysystem/PublicAssetAdapter_HTAccess.ss
@@ -14,10 +14,10 @@
 
     # Allow error pages
     RewriteCond %{REQUEST_FILENAME} -f
-    RewriteRule error[^\\/]*\.html$ - [L]
+    RewriteRule error[^\\\\/]*\\.html$ - [L]
 
     # Block invalid file extensions
-    RewriteCond %{REQUEST_URI} !\.(?i:<% loop $AllowedExtensions %>$Extension<% if not $Last %>|<% end_if %><% end_loop %>)$
+    RewriteCond %{REQUEST_URI} !\\.(?i:<% loop $AllowedExtensions %>$Extension<% if not $Last %>|<% end_if %><% end_loop %>)$
     RewriteRule .* - [F]
 
     # Non existant files passed to requesthandler

--- a/tests/filesystem/AssetAdapterTest.php
+++ b/tests/filesystem/AssetAdapterTest.php
@@ -44,14 +44,14 @@ class AssetAdapterTest extends SapphireTest {
         $htaccess = $adapter->read('.htaccess');
         $content = $htaccess['contents'];
         // Allowed extensions set
-        $this->assertContains('RewriteCond %{REQUEST_URI} !.(?i:', $content);
+        $this->assertContains('RewriteCond %{REQUEST_URI} !\\.(?i:', $content);
         foreach(File::config()->allowed_extensions as $extension) {
             $this->assertRegExp('/\b'.preg_quote($extension).'\b/', $content);
         }
 
         // Rewrite rules
         $this->assertContains('RewriteRule .* ../framework/main.php?url=%1 [QSA]', $content);
-        $this->assertContains('RewriteRule error[^\\/]*.html$ - [L]', $content);
+        $this->assertContains('RewriteRule error[^\\\\/]*\\.html$ - [L]', $content);
 
         // Test flush restores invalid content
         \file_put_contents($this->rootDir . '/.htaccess', '# broken content');


### PR DESCRIPTION
Need to escape these slashes since they were resulting in unescaped `.` in the htaccess regex.

Merge with https://github.com/silverstripe/silverstripe-installer/pull/140