### PR TITLE
add IPUtils.php to control and implement symfony IpUtils

### DIFF
--- a/control/IPUtils.php
+++ b/control/IPUtils.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * These helpful functions were lifted from the Symfony library
+ * https://github.com/symfony/http-foundation/blob/master/LICENSE
+ *
+ * Http utility functions.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+namespace SilverStripe\Control\Util;
+/**
+ * Http utility functions.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class IPUtils {
+	/**
+	 * This class should not be instantiated.
+	 */
+	private function __construct()
+	{
+	}
+	/**
+	 * Checks if an IPv4 or IPv6 address is contained in the list of given IPs or subnets.
+	 *
+	 * @param string       $requestIP IP to check
+	 * @param string|array $ips       List of IPs or subnets (can be a string if only a single one)
+	 *
+	 * @return bool Whether the IP is valid
+	 *
+	 * @package framework
+	 * @subpackage core
+	 */
+	public static function checkIP($requestIP, $ips) {
+		if (!is_array($ips)) {
+			$ips = array($ips);
+		}
+
+		$method = substr_count($requestIP, ':') > 1 ? 'checkIP6' : 'checkIP4';
+
+		foreach ($ips as $ip) {
+			if (self::$method($requestIP, trim($ip))) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+	/**
+	 * Compares two IPv4 addresses.
+	 * In case a subnet is given, it checks if it contains the request IP.
+	 *
+	 * @param string $requestIP IPv4 address to check
+	 * @param string $ip        IPv4 address or subnet in CIDR notation
+	 *
+	 * @return bool Whether the request IP matches the IP, or whether the request IP is within the CIDR subnet
+	 */
+	public static function checkIP4($requestIP, $ip) {
+		if (!filter_var($requestIP, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+			return false;
+		}
+
+		if (false !== strpos($ip, '/')) {
+			list($address, $netmask) = explode('/', $ip, 2);
+
+			if ($netmask === '0') {
+				return filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
+			}
+
+			if ($netmask < 0 || $netmask > 32) {
+				return false;
+			}
+		} else {
+			$address = $ip;
+			$netmask = 32;
+		}
+
+		return 0 === substr_compare(sprintf('%032b', ip2long($requestIP)), sprintf('%032b', ip2long($address)), 0, $netmask);
+	}
+	/**
+	 * Compares two IPv6 addresses.
+	 * In case a subnet is given, it checks if it contains the request IP.
+	 *
+	 * @author David Soria Parra <dsp at php dot net>
+	 *
+	 * @see https://github.com/dsp/v6tools
+	 *
+	 * @param string $requestIP IPv6 address to check
+	 * @param string $ip        IPv6 address or subnet in CIDR notation
+	 *
+	 * @return bool Whether the IP is valid
+	 *
+	 * @throws \RuntimeException When IPV6 support is not enabled
+	 */
+	public static function checkIP6($requestIP, $ip) {
+		if (!((extension_loaded('sockets') && defined('AF_INET6')) || @inet_pton('::1'))) {
+			throw new \RuntimeException('Unable to check IPv6. Check that PHP was not compiled with option "disable-ipv6".');
+		}
+
+		if (false !== strpos($ip, '/')) {
+			list($address, $netmask) = explode('/', $ip, 2);
+
+			if ($netmask < 1 || $netmask > 128) {
+				return false;
+			}
+		} else {
+			$address = $ip;
+			$netmask = 128;
+		}
+
+		$bytesAddr = unpack('n*', @inet_pton($address));
+		$bytesTest = unpack('n*', @inet_pton($requestIP));
+
+		if (!$bytesAddr || !$bytesTest) {
+			return false;
+		}
+
+		for ($i = 1, $ceil = ceil($netmask / 16); $i <= $ceil; ++$i) {
+			$left = $netmask - 16 * ($i - 1);
+			$left = ($left <= 16) ? $left : 16;
+			$mask = ~(0xffff >> $left) & 0xffff;
+			if (($bytesAddr[$i] & $mask) != ($bytesTest[$i] & $mask)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/core/Constants.php
+++ b/core/Constants.php
@@ -105,7 +105,10 @@ if(!defined('TRUSTED_PROXY')) {
 			if(SS_TRUSTED_PROXY_IPS === '*') {
 				$trusted = true;
 			} elseif(isset($_SERVER['REMOTE_ADDR'])) {
-				$trusted = in_array($_SERVER['REMOTE_ADDR'], explode(',', SS_TRUSTED_PROXY_IPS));
+				if(!class_exists('SilverStripe\\Control\\Util\\IPUtils')) {
+					require_once FRAMEWORK_PATH . '/control/IPUtils.php';
+				};
+				$trusted = IPUtils::checkIP($_SERVER['REMOTE_ADDR'], explode(',', SS_TRUSTED_PROXY_IPS));
 			}
 		}
 	}
@@ -122,7 +125,7 @@ if(!defined('TRUSTED_PROXY')) {
  */
 if(!isset($_SERVER['HTTP_HOST'])) {
 	// HTTP_HOST, REQUEST_PORT, SCRIPT_NAME, and PHP_SELF
-	global $_FILE_TO_URL_MAPPING;	
+	global $_FILE_TO_URL_MAPPING;
 	if(isset($_FILE_TO_URL_MAPPING)) {
 		$fullPath = $testPath = realpath($_SERVER['SCRIPT_FILENAME']);
 		while($testPath && $testPath != '/' && !preg_match('/^[A-Z]:\\\\$/', $testPath)) {
@@ -182,7 +185,7 @@ if(!isset($_SERVER['HTTP_HOST'])) {
 	$trustedProxyHeader = (defined('SS_TRUSTED_PROXY_HOST_HEADER'))
 		? SS_TRUSTED_PROXY_HOST_HEADER
 		: 'HTTP_X_FORWARDED_HOST';
-		
+
 	if (TRUSTED_PROXY && !empty($_SERVER[$trustedProxyHeader])) {
 		// Get the first host, in case there's multiple separated through commas
 		$_SERVER['HTTP_HOST'] = strtok($_SERVER[$trustedProxyHeader], ',');

--- a/tests/control/IPUtilsTest.php
+++ b/tests/control/IPUtilsTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * These helpful tests were lifted from the Symfony library
+ * https://github.com/symfony/http-foundation/blob/master/LICENSE
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use SilverStripe\Control\Util\IPUtils;
+
+class IPUtilsTest extends SapphireTest {
+	/**
+	 * @dataProvider testIPv4Provider
+	 */
+	public function testIPv4($matches, $remoteAddr, $cidr)
+	{
+		$this->assertSame($matches, IPUtils::checkIP($remoteAddr, $cidr));
+	}
+
+	public function testIPv4Provider()
+	{
+		return array(
+			array(true, '192.168.1.1', '192.168.1.1'),
+			array(true, '192.168.1.1', '192.168.1.1/1'),
+			array(true, '192.168.1.1', '192.168.1.0/24'),
+			array(false, '192.168.1.1', '1.2.3.4/1'),
+			array(false, '192.168.1.1', '192.168.1.1/33'), // invalid subnet
+			array(true, '192.168.1.1', array('1.2.3.4/1', '192.168.1.0/24')),
+			array(true, '192.168.1.1', array('192.168.1.0/24', '1.2.3.4/1')),
+			array(false, '192.168.1.1', array('1.2.3.4/1', '4.3.2.1/1')),
+			array(true, '1.2.3.4', '0.0.0.0/0'),
+			array(true, '1.2.3.4', '192.168.1.0/0'),
+			array(false, '1.2.3.4', '256.256.256/0'), // invalid CIDR notation
+			array(false, 'an_invalid_ip', '192.168.1.0/24'),
+		);
+	}
+
+	/**
+	 * @dataProvider testIPv6Provider
+	 */
+	public function testIPv6($matches, $remoteAddr, $cidr)
+	{
+		if (!defined('AF_INET6')) {
+			$this->markTestSkipped('Only works when PHP is compiled without the option "disable-ipv6".');
+		}
+
+		$this->assertSame($matches, IPUtils::checkIP($remoteAddr, $cidr));
+	}
+
+	public function testIPv6Provider()
+	{
+		return array(
+			array(true, '2a01:198:603:0:396e:4789:8e99:890f', '2a01:198:603:0::/65'),
+			array(false, '2a00:198:603:0:396e:4789:8e99:890f', '2a01:198:603:0::/65'),
+			array(false, '2a01:198:603:0:396e:4789:8e99:890f', '::1'),
+			array(true, '0:0:0:0:0:0:0:1', '::1'),
+			array(false, '0:0:603:0:396e:4789:8e99:0001', '::1'),
+			array(true, '2a01:198:603:0:396e:4789:8e99:890f', array('::1', '2a01:198:603:0::/65')),
+			array(true, '2a01:198:603:0:396e:4789:8e99:890f', array('2a01:198:603:0::/65', '::1')),
+			array(false, '2a01:198:603:0:396e:4789:8e99:890f', array('::1', '1a01:198:603:0::/65')),
+			array(false, '}__test|O:21:&quot;JDatabaseDriverMysqli&quot;:3:{s:2', '::1'),
+			array(false, '2a01:198:603:0:396e:4789:8e99:890f', 'unknown'),
+		);
+	}
+
+	/**
+	 * @expectedException \RuntimeException
+	 * @requires extension sockets
+	 */
+	public function testAnIPv6WithOptionDisabledIPv6()
+	{
+		if (defined('AF_INET6')) {
+			$this->markTestSkipped('Only works when PHP is compiled with the option "disable-ipv6".');
+		}
+
+		IPUtils::checkIP('2a01:198:603:0:396e:4789:8e99:890f', '2a01:198:603:0::/65');
+	}
+}


### PR DESCRIPTION
This implements some Symfony functions to check that a given IP is in a range. This can now be used for the TRUSTED_PROXY_IPS setting, so that we can define a range rather than a list of IPs.