### PR TITLE
Setting default branch in codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  branch: master


### PR DESCRIPTION
Was defaulting to 3, presumably because we've added codecov
a while ago without actually using the integration.