### PR TITLE
API Implement many_many through

### DIFF
--- a/Assets/AssetControlExtension.php
+++ b/Assets/AssetControlExtension.php
@@ -212,10 +212,11 @@ class AssetControlExtension extends DataExtension
 	{
 		// Search for dbfile instances
 		$files = array();
-		foreach ($record->db() as $field => $db) {
+		$fields = DataObject::getSchema()->fieldSpecs($record);
+		foreach ($fields as $field => $db) {
 			$fieldObj = $record->$field;
-			if(!is_object($fieldObj) || !($record->$field instanceof DBFile)) {
-							continue;
+			if (!($fieldObj instanceof DBFile)) {
+				continue;
 			}
 
 			// Omit variant and merge with set

--- a/Core/ClassInfo.php
+++ b/Core/ClassInfo.php
@@ -112,7 +112,7 @@ class ClassInfo {
 		);
 
 		foreach ($classes as $class) {
-			if (DataObject::has_own_table($class)) {
+			if (DataObject::getSchema()->classHasTable($class)) {
 				$result[$class] = $class;
 			}
 		}
@@ -201,7 +201,7 @@ class ClassInfo {
 		if(!isset(self::$_cache_ancestry[$cacheKey])) {
 			$ancestry = array();
 			do {
-				if (!$tablesOnly || DataObject::has_own_table($parent)) {
+				if (!$tablesOnly || DataObject::getSchema()->classHasTable($parent)) {
 					$ancestry[$parent] = $parent;
 				}
 			} while ($parent = get_parent_class($parent));

--- a/Dev/CsvBulkLoader.php
+++ b/Dev/CsvBulkLoader.php
@@ -222,7 +222,9 @@ class CsvBulkLoader extends BulkLoader {
 
 		// find existing object, or create new one
 		$existingObj = $this->findExistingObject($record, $columnMap);
+		/** @var DataObject $obj */
 		$obj = ($existingObj) ? $existingObj : new $class();
+		$schema = DataObject::getSchema();
 
 		// first run: find/create any relations and store them on the object
 		// we can't combine runs, as other columns might rely on the relation being present
@@ -243,7 +245,7 @@ class CsvBulkLoader extends BulkLoader {
 					$relationObj = $obj->{$this->relationCallbacks[$fieldName]['callback']}($val, $record);
 				}
 				if(!$relationObj || !$relationObj->exists()) {
-					$relationClass = $obj->hasOneComponent($relationName);
+					$relationClass = $schema->hasOneComponent(get_class($obj), $relationName);
 					$relationObj = new $relationClass();
 					//write if we aren't previewing
 					if (!$preview) $relationObj->write();
@@ -327,7 +329,7 @@ class CsvBulkLoader extends BulkLoader {
 	 *
 	 * @param array $record CSV data column
 	 * @param array $columnMap
-	 * @return mixed
+	 * @return DataObject
 	 */
 	public function findExistingObject($record, $columnMap = []) {
 		$SNG_objectClass = singleton($this->objectClass);

--- a/Forms/FileField.php
+++ b/Forms/FileField.php
@@ -123,8 +123,8 @@ class FileField extends FormField {
 		/** @var File $file */
 		if($this->relationAutoSetting) {
 			// assume that the file is connected via a has-one
-			$objectClass = $record->hasOneComponent($this->name);
-			if($objectClass === 'SilverStripe\\Assets\\File' || empty($objectClass)) {
+			$objectClass = DataObject::getSchema()->hasOneComponent(get_class($record), $this->name);
+			if($objectClass === File::class || empty($objectClass)) {
 				// Create object of the appropriate file class
 				$file = Object::create($fileClass);
 			} else {

--- a/Forms/GridField/GridFieldSortableHeader.php
+++ b/Forms/GridField/GridFieldSortableHeader.php
@@ -114,6 +114,7 @@ class GridFieldSortableHeader implements GridField_HTMLProvider, GridField_DataM
 		$columns = $gridField->getColumns();
 		$currentColumn = 0;
 
+		$schema = DataObject::getSchema();
 		foreach($columns as $columnField) {
 			$currentColumn++;
 			$metadata = $gridField->getColumnMetadata($columnField);
@@ -139,7 +140,7 @@ class GridFieldSortableHeader implements GridField_HTMLProvider, GridField_DataM
 					} elseif(method_exists($tmpItem, 'hasMethod') && $tmpItem->hasMethod($methodName)) {
 						// The part is a relation name, so get the object/list from it
 						$tmpItem = $tmpItem->$methodName();
-					} elseif($tmpItem instanceof DataObject && $tmpItem->hasDatabaseField($methodName)) {
+					} elseif ($tmpItem instanceof DataObject && $schema->fieldSpec($tmpItem, $methodName, ['dbOnly'])) {
 						// Else, if we've found a database field at the end of the chain, we can sort on it.
 						// If a method is applied further to this field (E.g. 'Cost.Currency') then don't try to sort.
 						$allowSort = $idx === sizeof($parts) - 1;

--- a/Forms/UploadField.php
+++ b/Forms/UploadField.php
@@ -543,7 +543,7 @@ class UploadField extends FileField {
 		if($relation && ($relation instanceof RelationList || $relation instanceof UnsavedRelationList)) {
 			// has_many or many_many
 			$relation->setByIDList($idList);
-		} elseif($record->hasOneComponent($fieldname)) {
+		} elseif(DataObject::getSchema()->hasOneComponent(get_class($record), $fieldname)) {
 			// has_one
 			$record->{"{$fieldname}ID"} = $idList ? reset($idList) : 0;
 		}
@@ -631,7 +631,7 @@ class UploadField extends FileField {
 		if(empty($allowedMaxFileNumber)) {
 			$record = $this->getRecord();
 			$name = $this->getName();
-			if($record && $record->hasOneComponent($name)) {
+			if($record && DataObject::getSchema()->hasOneComponent(get_class($record), $name)) {
 				return 1; // Default for has_one
 			} else {
 				return null; // Default for has_many and many_many

--- a/ORM/DataList.php
+++ b/ORM/DataList.php
@@ -736,8 +736,12 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
 	 * @param array $row
 	 * @return DataObject
 	 */
-	protected function createDataObject($row) {
+	public function createDataObject($row) {
 		$class = $this->dataClass;
+
+		if (empty($row['ClassName'])) {
+			$row['ClassName'] = $class;
+		}
 
 		// Failover from RecordClassName to ClassName
 		if(empty($row['RecordClassName'])) {

--- a/ORM/DataObjectSchema.php
+++ b/ORM/DataObjectSchema.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\ORM;
 
+use Exception;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\ORM\FieldType\DBComposite;
@@ -118,7 +119,7 @@ class DataObjectSchema {
 		$class = ClassInfo::class_name($class);
 		$current = $class;
 		while ($next = get_parent_class($current)) {
-			if ($next === 'SilverStripe\ORM\DataObject') {
+			if ($next === DataObject::class) {
 				return $current;
 			}
 			$current = $next;
@@ -169,8 +170,8 @@ class DataObjectSchema {
 			return;
 		}
 		$this->tableNames = [];
-		foreach(ClassInfo::subclassesFor('SilverStripe\ORM\DataObject') as $class) {
-			if($class === 'SilverStripe\ORM\DataObject') {
+		foreach(ClassInfo::subclassesFor(DataObject::class) as $class) {
+			if($class === DataObject::class) {
 				continue;
 			}
 			$table = $this->buildTableName($class);
@@ -216,7 +217,7 @@ class DataObjectSchema {
 	 */
 	public function databaseFields($class) {
 		$class = ClassInfo::class_name($class);
-		if($class === 'SilverStripe\ORM\DataObject') {
+		if($class === DataObject::class) {
 			return [];
 		}
 		$this->cacheDatabaseFields($class);
@@ -238,7 +239,7 @@ class DataObjectSchema {
 	 */
 	public function compositeFields($class, $aggregated = true) {
 		$class = ClassInfo::class_name($class);
-		if($class === 'SilverStripe\ORM\DataObject') {
+		if($class === DataObject::class) {
 			return [];
 		}
 		$this->cacheDatabaseFields($class);
@@ -270,7 +271,7 @@ class DataObjectSchema {
 
 		// Ensure fixed fields appear at the start
 		$fixedFields = DataObject::config()->fixed_fields;
-		if(get_parent_class($class) === 'SilverStripe\ORM\DataObject') {
+		if(get_parent_class($class) === DataObject::class) {
 			// Merge fixed with ClassName spec and custom db fields
 			$dbFields = $fixedFields;
 		} else {
@@ -291,7 +292,7 @@ class DataObjectSchema {
 		// Add in all has_ones
 		$hasOne = Config::inst()->get($class, 'has_one', Config::UNINHERITED) ?: array();
 		foreach($hasOne as $fieldName => $hasOneClass) {
-			if($hasOneClass === 'SilverStripe\ORM\DataObject') {
+			if($hasOneClass === DataObject::class) {
 				$compositeFields[$fieldName] = 'PolymorphicForeignKey';
 			} else {
 				$dbFields["{$fieldName}ID"] = 'ForeignKey';
@@ -347,7 +348,7 @@ class DataObjectSchema {
 	public function classForField($candidateClass, $fieldName)  {
 		// normalise class name
 		$candidateClass = ClassInfo::class_name($candidateClass);
-		if($candidateClass === 'SilverStripe\\ORM\\DataObject') {
+		if($candidateClass === DataObject::class) {
 			return null;
 		}
 
@@ -366,5 +367,397 @@ class DataObjectSchema {
 			$candidateClass = get_parent_class($candidateClass);
 		}
 		return null;
+	}
+
+	/**
+	 * Return information about a specific many_many component. Returns a numeric array.
+	 * The first item in the array will be the class name of the relation: either
+	 * RELATION_MANY_MANY or RELATION_MANY_MANY_THROUGH constant value.
+	 *
+	 * Standard many_many return type is:
+	 *
+	 * array(
+	 *  <manyManyClass>,		Name of class for relation
+	 * 	<classname>,			The class that relation is defined in e.g. "Product"
+	 * 	<candidateName>,		The target class of the relation e.g. "Category"
+	 * 	<parentField>,			The field name pointing to <classname>'s table e.g. "ProductID".
+	 * 	<childField>,			The field name pointing to <candidatename>'s table e.g. "CategoryID".
+	 * 	<joinTableOrRelation>	The join table between the two classes e.g. "Product_Categories".
+	 *							If the class name is 'ManyManyThroughList' then this is the name of the
+	 * 							has_many relation.
+	 * )
+	 * @param string $class Name of class to get component for
+	 * @param string $component The component name
+	 * @return array|null
+	 */
+	public function manyManyComponent($class, $component) {
+		$classes = ClassInfo::ancestry($class);
+		foreach($classes as $parentClass) {
+			// Check if the component is defined in many_many on this class
+			$manyMany = Config::inst()->get($parentClass, 'many_many', Config::UNINHERITED);
+			if(isset($manyMany[$component])) {
+				return $this->parseManyManyComponent($parentClass, $component, $manyMany[$component]);
+			}
+
+			// Check if the component is defined in belongs_many_many on this class
+			$belongsManyMany = Config::inst()->get($parentClass, 'belongs_many_many', Config::UNINHERITED);
+			if(!isset($belongsManyMany[$component])) {
+				continue;
+			}
+
+			// Extract class and relation name from dot-notation
+			$childClass = $belongsManyMany[$component];
+			$relationName = null;
+			if(strpos($childClass, '.') !== false) {
+				list($childClass, $relationName) = explode('.', $childClass, 2);
+			}
+
+			// We need to find the inverse component name, if not explicitly given
+			if (!$relationName) {
+				$relationName = $this->getManyManyInverseRelationship($childClass, $parentClass);
+			}
+
+			// Check valid relation found
+			if (!$relationName) {
+				throw new LogicException("Inverse component of $childClass not found ({$class})");
+			}
+
+			// Build inverse relationship from other many_many, and swap parent/child
+			list($relationClass, $childClass, $parentClass, $childField, $parentField, $joinTable)
+				= $this->parseManyManyComponent($childClass, $relationName, $parentClass);
+			return [$relationClass, $parentClass, $childClass, $parentField, $childField, $joinTable];
+		}
+		return null;
+	}
+
+	/**
+	 * Return data for a specific has_many component.
+	 *
+	 * @param string $class Parent class
+	 * @param string $component
+	 * @param bool $classOnly If this is TRUE, than any has_many relationships in the form
+	 * "ClassName.Field" will have the field data stripped off. It defaults to TRUE.
+	 * @return string|null
+	 */
+	public function hasManyComponent($class, $component, $classOnly = true) {
+		$hasMany = (array)Config::inst()->get($class, 'has_many');
+		if(!isset($hasMany[$component])) {
+			return null;
+		}
+
+		// Remove has_one specifier if given
+		$hasMany = $hasMany[$component];
+		$hasManyClass = strtok($hasMany, '.');
+
+		// Validate
+		$this->checkRelationClass($class, $component, $hasManyClass, 'has_many');
+		return $classOnly ? $hasManyClass : $hasMany;
+	}
+
+	/**
+	 * Return data for a specific has_one component.
+	 *
+	 * @param string $class
+	 * @param string $component
+	 * @return string|null
+	 */
+	public function hasOneComponent($class, $component) {
+		$hasOnes = Config::inst()->get($class, 'has_one');
+		if(!isset($hasOnes[$component])) {
+			return null;
+		}
+
+		// Validate
+		$relationClass = $hasOnes[$component];
+		$this->checkRelationClass($class, $component, $relationClass, 'has_one');
+		return $relationClass;
+	}
+
+	/**
+	 * Return data for a specific belongs_to component.
+	 *
+	 * @param string $class
+	 * @param string $component
+	 * @param bool $classOnly If this is TRUE, than any has_many relationships in the
+	 * form "ClassName.Field" will have the field data stripped off. It defaults to TRUE.
+	 * @return string|null
+	 */
+	public function belongsToComponent($class, $component, $classOnly = true) {
+		$belongsTo = (array)Config::inst()->get($class, 'belongs_to');
+		if(!isset($belongsTo[$component])) {
+			return null;
+		}
+
+		// Remove has_one specifier if given
+		$belongsTo = $belongsTo[$component];
+		$belongsToClass = strtok($belongsTo, '.');
+
+		// Validate
+		$this->checkRelationClass($class, $component, $belongsToClass, 'belongs_to');
+		return $classOnly ? $belongsToClass : $belongsTo;
+	}
+
+	/**
+	 *
+	 * @param string $parentClass Parent class name
+	 * @param string $component ManyMany name
+	 * @param string|array $specification Declaration of many_many relation type
+	 * @return array
+	 */
+	protected function parseManyManyComponent($parentClass, $component, $specification)
+	{
+		// Check if this is many_many_through
+		if (is_array($specification)) {
+			// Validate join, parent and child classes
+			$joinClass = $this->checkManyManyJoinClass($parentClass, $component, $specification);
+			$parentClass = $this->checkManyManyFieldClass($parentClass, $component, $joinClass, $specification, 'from');
+			$joinChildClass = $this->checkManyManyFieldClass($parentClass, $component, $joinClass, $specification, 'to');
+			return [
+				ManyManyThroughList::class,
+				$parentClass,
+				$joinChildClass,
+				$specification['from'] . 'ID',
+				$specification['to'] . 'ID',
+				$joinClass,
+			];
+		}
+
+		// Validate $specification class is valid
+		$this->checkRelationClass($parentClass, $component, $specification, 'many_many');
+
+		// automatic scaffolded many_many table
+		$classTable = $this->tableName($parentClass);
+		$parentField = "{$classTable}ID";
+		if ($parentClass === $specification) {
+			$childField = "ChildID";
+		} else {
+			$candidateTable = $this->tableName($specification);
+			$childField = "{$candidateTable}ID";
+		}
+		$joinTable = "{$classTable}_{$component}";
+		return [
+			ManyManyList::class,
+			$parentClass,
+			$specification,
+			$parentField,
+			$childField,
+			$joinTable,
+		];
+	}
+
+	/**
+	 * Find a many_many on the child class that points back to this many_many
+	 *
+	 * @param string $childClass
+	 * @param string $parentClass
+	 * @return string|null
+	 */
+	protected function getManyManyInverseRelationship($childClass, $parentClass)
+	{
+		$otherManyMany = Config::inst()->get($childClass, 'many_many', Config::UNINHERITED);
+		if (!$otherManyMany) {
+			return null;
+		}
+		foreach ($otherManyMany as $inverseComponentName => $nextClass) {
+			if ($nextClass === $parentClass) {
+				return $inverseComponentName;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Tries to find the database key on another object that is used to store a
+	 * relationship to this class. If no join field can be found it defaults to 'ParentID'.
+	 *
+	 * If the remote field is polymorphic then $polymorphic is set to true, and the return value
+	 * is in the form 'Relation' instead of 'RelationID', referencing the composite DBField.
+	 *
+	 * @param string $class
+	 * @param string $component Name of the relation on the current object pointing to the
+	 * remote object.
+	 * @param string $type the join type - either 'has_many' or 'belongs_to'
+	 * @param boolean $polymorphic Flag set to true if the remote join field is polymorphic.
+	 * @return string
+	 * @throws Exception
+	 */
+	public function getRemoteJoinField($class, $component, $type = 'has_many', &$polymorphic = false) {
+		// Extract relation from current object
+		if($type === 'has_many') {
+			$remoteClass = $this->hasManyComponent($class, $component, false);
+		} else {
+			$remoteClass = $this->belongsToComponent($class, $component, false);
+		}
+
+		if(empty($remoteClass)) {
+			throw new Exception("Unknown $type component '$component' on class '$class'");
+		}
+		if(!ClassInfo::exists(strtok($remoteClass, '.'))) {
+			throw new Exception(
+				"Class '$remoteClass' not found, but used in $type component '$component' on class '$class'"
+			);
+		}
+
+		// If presented with an explicit field name (using dot notation) then extract field name
+		$remoteField = null;
+		if(strpos($remoteClass, '.') !== false) {
+			list($remoteClass, $remoteField) = explode('.', $remoteClass);
+		}
+
+		// Reference remote has_one to check against
+		$remoteRelations = Config::inst()->get($remoteClass, 'has_one');
+
+		// Without an explicit field name, attempt to match the first remote field
+		// with the same type as the current class
+		if(empty($remoteField)) {
+			// look for remote has_one joins on this class or any parent classes
+			$remoteRelationsMap = array_flip($remoteRelations);
+			foreach(array_reverse(ClassInfo::ancestry($class)) as $class) {
+				if(array_key_exists($class, $remoteRelationsMap)) {
+					$remoteField = $remoteRelationsMap[$class];
+					break;
+				}
+			}
+		}
+
+		// In case of an indeterminate remote field show an error
+		if(empty($remoteField)) {
+			$polymorphic = false;
+			$message = "No has_one found on class '$remoteClass'";
+			if($type == 'has_many') {
+				// include a hint for has_many that is missing a has_one
+				$message .= ", the has_many relation from '$class' to '$remoteClass'";
+				$message .= " requires a has_one on '$remoteClass'";
+			}
+			throw new Exception($message);
+		}
+
+		// If given an explicit field name ensure the related class specifies this
+		if(empty($remoteRelations[$remoteField])) {
+			throw new Exception("Missing expected has_one named '$remoteField'
+				on class '$remoteClass' referenced by $type named '$component'
+				on class {$class}"
+			);
+		}
+
+		// Inspect resulting found relation
+		if($remoteRelations[$remoteField] === DataObject::class) {
+			$polymorphic = true;
+			return $remoteField; // Composite polymorphic field does not include 'ID' suffix
+		} else {
+			$polymorphic = false;
+			return $remoteField . 'ID';
+		}
+	}
+
+	/**
+	 * Validate the to or from field on a has_many mapping class
+	 *
+	 * @param string $parentClass Name of parent class
+	 * @param string $component Name of many_many component
+	 * @param string $joinClass Class for the joined table
+	 * @param array $specification Complete many_many specification
+	 * @param string $key Name of key to check ('from' or 'to')
+	 * @return string Class that matches the given relation
+	 * @throws InvalidArgumentException
+	 */
+	protected function checkManyManyFieldClass($parentClass, $component, $joinClass, $specification, $key)
+	{
+		// Ensure value for this key exists
+		if (empty($specification[$key])) {
+			throw new InvalidArgumentException(
+				"many_many relation {$parentClass}.{$component} has missing {$key} which "
+				. "should be a has_one on class {$joinClass}"
+			);
+		}
+
+		// Check that the field exists on the given object
+		$relation = $specification[$key];
+		$relationClass = $this->hasOneComponent($joinClass, $relation);
+		if (empty($relationClass)) {
+			throw new InvalidArgumentException(
+				"many_many through relation {$parentClass}.{$component} {$key} references a field name "
+				. "{$joinClass}::{$relation} which is not a has_one"
+			);
+		}
+
+		// Check for polymorphic
+		if ($relationClass === DataObject::class) {
+			throw new InvalidArgumentException(
+				"many_many through relation {$parentClass}.{$component} {$key} references a polymorphic field "
+				. "{$joinClass}::{$relation} which is not supported"
+			);
+		}
+
+		// Validate bad types on parent relation
+		if ($key === 'from' && $relationClass !== $parentClass) {
+			throw new InvalidArgumentException(
+				"many_many through relation {$parentClass}.{$component} {$key} references a field name "
+				. "{$joinClass}::{$relation} of type {$relationClass}; {$parentClass} expected"
+			);
+		}
+		return $relationClass;
+	}
+
+	/**
+	 * @param string $parentClass Name of parent class
+	 * @param string $component Name of many_many component
+	 * @param array $specification Complete many_many specification
+	 * @return string Name of join class
+	 */
+	protected function checkManyManyJoinClass($parentClass, $component, $specification)
+	{
+		if (empty($specification['through'])) {
+			throw new InvalidArgumentException(
+				"many_many relation {$parentClass}.{$component} has missing through which should be "
+				. "a DataObject class name to be used as a join table"
+			);
+		}
+		$joinClass = $specification['through'];
+		if (!class_exists($joinClass)) {
+			throw new InvalidArgumentException(
+				"many_many relation {$parentClass}.{$component} has through class \"{$joinClass}\" which does not exist"
+			);
+		}
+		return $joinClass;
+	}
+
+	/**
+	 * Validate a given class is valid for a relation
+	 *
+	 * @param string $class Parent class
+	 * @param string $component Component name
+	 * @param string $relationClass Candidate class to check
+	 * @param string $type Relation type (e.g. has_one)
+	 */
+	protected function checkRelationClass($class, $component, $relationClass, $type)
+	{
+		if (!is_string($component) || is_numeric($component)) {
+			throw new InvalidArgumentException(
+				"{$class} has invalid {$type} relation name"
+			);
+		}
+		if (!is_string($relationClass)) {
+			throw new InvalidArgumentException(
+				"{$type} relation {$class}.{$component} is not a class name"
+			);
+		}
+		if (!class_exists($relationClass)) {
+			throw new InvalidArgumentException(
+				"{$type} relation {$class}.{$component} references class {$relationClass} which doesn't exist"
+			);
+		}
+		// Support polymorphic has_one
+		if ($type === 'has_one') {
+			$valid = is_a($relationClass, DataObject::class, true);
+		} else {
+			$valid = is_subclass_of($relationClass, DataObject::class, true);
+		}
+		if (!$valid) {
+			throw new InvalidArgumentException(
+				"{$type} relation {$class}.{$component} references class {$relationClass} "
+				. " which is not a subclass of " . DataObject::class
+			);
+		}
 	}
 }

--- a/ORM/DataQueryManipulator.php
+++ b/ORM/DataQueryManipulator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SilverStripe\ORM;
+
+use SilverStripe\ORM\Queries\SQLSelect;
+
+/**
+ * Allows middleware to modily finalised dataquery on a per-instance basis
+ */
+interface DataQueryManipulator
+{
+	/**
+	 * Invoked prior to getFinalisedQuery()
+	 *
+	 * @param DataQuery $dataQuery
+	 * @param array $queriedColumns
+	 * @param SQLSelect $sqlSelect
+	 */
+	public function beforeGetFinalisedQuery(DataQuery $dataQuery, $queriedColumns = [], SQLSelect $sqlSelect);
+
+	/**
+	 * Invoked after getFinalisedQuery()
+	 *
+	 * @param DataQuery $dataQuery
+	 * @param array $queriedColumns
+	 * @param SQLSelect $sqlQuery
+	 */
+	public function afterGetFinalisedQuery(DataQuery $dataQuery, $queriedColumns = [], SQLSelect $sqlQuery);
+}

--- a/ORM/FieldType/DBForeignKey.php
+++ b/ORM/FieldType/DBForeignKey.php
@@ -39,7 +39,7 @@ class DBForeignKey extends DBInt {
 			return null;
 		}
 		$relationName = substr($this->name,0,-2);
-		$hasOneClass = $this->object->hasOneComponent($relationName);
+		$hasOneClass = DataObject::getSchema()->hasOneComponent(get_class($this->object), $relationName);
 		if(empty($hasOneClass)) {
 			return null;
 		}

--- a/ORM/Hierarchy/Hierarchy.php
+++ b/ORM/Hierarchy/Hierarchy.php
@@ -736,7 +736,7 @@ class Hierarchy extends DataExtension {
 		if ($hide_from_cms_tree && $this->showingCMSTree()) {
 			$staged = $staged->exclude('ClassName', $hide_from_cms_tree);
 		}
-		if (!$showAll && $this->owner->db('ShowInMenus')) {
+		if (!$showAll && DataObject::getSchema()->fieldSpec($this->owner, 'ShowInMenus')) {
 			$staged = $staged->filter('ShowInMenus', 1);
 		}
 		$this->owner->extend("augmentStageChildren", $staged, $showAll);
@@ -753,7 +753,7 @@ class Hierarchy extends DataExtension {
 	 * @throws Exception
 	 */
 	public function liveChildren($showAll = false, $onlyDeletedFromStage = false) {
-		if(!$this->owner->hasExtension('SilverStripe\ORM\Versioning\Versioned')) {
+		if(!$this->owner->hasExtension(Versioned::class)) {
 			throw new Exception('Hierarchy->liveChildren() only works with Versioned extension applied');
 		}
 
@@ -773,7 +773,9 @@ class Hierarchy extends DataExtension {
 		if ($hide_from_cms_tree && $this->showingCMSTree()) {
 			$children = $children->exclude('ClassName', $hide_from_cms_tree);
 		}
-		if(!$showAll && $this->owner->db('ShowInMenus')) $children = $children->filter('ShowInMenus', 1);
+		if(!$showAll && DataObject::getSchema()->fieldSpec($this->owner, 'ShowInMenus')) {
+			$children = $children->filter('ShowInMenus', 1);
+		}
 
 		return $children;
 	}

--- a/ORM/ManyManyList.php
+++ b/ORM/ManyManyList.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\ORM;
 
+use BadMethodCallException;
 use SilverStripe\Core\Object;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\ORM\Queries\SQLDelete;
@@ -122,7 +123,7 @@ class ManyManyList extends RelationList {
 	 * @param array $row
 	 * @return DataObject
 	 */
-	protected function createDataObject($row) {
+	public function createDataObject($row) {
 		// remove any composed fields
 		$add = array();
 
@@ -210,23 +211,30 @@ class ManyManyList extends RelationList {
 		if(empty($extraFields)) $extraFields = array();
 
 		// Determine ID of new record
+		$itemID = null;
 		if(is_numeric($item)) {
 			$itemID = $item;
 		} elseif($item instanceof $this->dataClass) {
 			$itemID = $item->ID;
 		} else {
-			throw new InvalidArgumentException("ManyManyList::add() expecting a $this->dataClass object, or ID value",
-				E_USER_ERROR);
+			throw new InvalidArgumentException(
+				"ManyManyList::add() expecting a $this->dataClass object, or ID value"
+			);
+		}
+		if (empty($itemID)) {
+			throw new InvalidArgumentException("ManyManyList::add() doesn't accept unsaved records");
 		}
 
 		// Validate foreignID
 		$foreignIDs = $this->getForeignID();
 		if(empty($foreignIDs)) {
-			throw new Exception("ManyManyList::add() can't be called until a foreign ID is set", E_USER_WARNING);
+			throw new BadMethodCallException("ManyManyList::add() can't be called until a foreign ID is set", E_USER_WARNING);
 		}
 
 		// Apply this item to each given foreign ID record
-		if(!is_array($foreignIDs)) $foreignIDs = array($foreignIDs);
+		if(!is_array($foreignIDs)) {
+			$foreignIDs = array($foreignIDs);
+		}
 		foreach($foreignIDs as $foreignID) {
 			// Check for existing records for this item
 			if($foreignFilter = $this->foreignIDWriteFilter($foreignID)) {

--- a/ORM/ManyManyList.php
+++ b/ORM/ManyManyList.php
@@ -228,7 +228,7 @@ class ManyManyList extends RelationList {
 		// Validate foreignID
 		$foreignIDs = $this->getForeignID();
 		if(empty($foreignIDs)) {
-			throw new BadMethodCallException("ManyManyList::add() can't be called until a foreign ID is set", E_USER_WARNING);
+			throw new BadMethodCallException("ManyManyList::add() can't be called until a foreign ID is set");
 		}
 
 		// Apply this item to each given foreign ID record
@@ -317,7 +317,7 @@ class ManyManyList extends RelationList {
 		if($filter = $this->foreignIDWriteFilter($this->getForeignID())) {
 			$query->setWhere($filter);
 		} else {
-			user_error("Can't call ManyManyList::remove() until a foreign ID is set", E_USER_WARNING);
+			user_error("Can't call ManyManyList::remove() until a foreign ID is set");
 		}
 
 		$query->addWhere(array(
@@ -380,7 +380,7 @@ class ManyManyList extends RelationList {
 		}
 
 		if(!is_numeric($itemID)) {
-			user_error('ComponentSet::getExtraData() passed a non-numeric child ID', E_USER_ERROR);
+			throw new InvalidArgumentException('ManyManyList::getExtraData() passed a non-numeric child ID');
 		}
 
 		$cleanExtraFields = array();
@@ -392,7 +392,7 @@ class ManyManyList extends RelationList {
 		if($filter) {
 			$query->setWhere($filter);
 		} else {
-			user_error("Can't call ManyManyList::getExtraData() until a foreign ID is set", E_USER_WARNING);
+			throw new BadMethodCallException("Can't call ManyManyList::getExtraData() until a foreign ID is set");
 		}
 		$query->addWhere(array(
 			"\"{$this->joinTable}\".\"{$this->localKey}\"" => $itemID

--- a/ORM/ManyManyThroughList.php
+++ b/ORM/ManyManyThroughList.php
@@ -50,7 +50,8 @@ class ManyManyThroughList extends RelationList
 	public function createDataObject($row) {
 		// Add joined record
 		$joinRow = [];
-		$prefix = ManyManyThroughQueryManipulator::JOIN_TABLE_ALIAS . '_';
+		$joinAlias = $this->manipulator->getJoinAlias();
+		$prefix = $joinAlias . '_';
 		foreach ($row as $key => $value) {
 			if (strpos($key, $prefix) === 0) {
 				$joinKey = substr($key, strlen($prefix));
@@ -67,7 +68,7 @@ class ManyManyThroughList extends RelationList
 			$joinClass = $this->manipulator->getJoinClass();
 			$joinQueryParams = $this->manipulator->extractInheritableQueryParameters($this->dataQuery);
 			$joinRecord = Injector::inst()->create($joinClass, $joinRow, false, $this->model, $joinQueryParams);
-			$record->setJoin($joinRecord);
+			$record->setJoin($joinRecord, $joinAlias);
 		}
 
 		return $record;
@@ -151,7 +152,7 @@ class ManyManyThroughList extends RelationList
 		// Validate foreignID
 		$foreignIDs = $this->getForeignID();
 		if (empty($foreignIDs)) {
-			throw new BadMethodCallException("ManyManyList::add() can't be called until a foreign ID is set", E_USER_WARNING);
+			throw new BadMethodCallException("ManyManyList::add() can't be called until a foreign ID is set");
 		}
 
 		// Apply this item to each given foreign ID record

--- a/ORM/ManyManyThroughList.php
+++ b/ORM/ManyManyThroughList.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace SilverStripe\ORM;
+
+use BadMethodCallException;
+use InvalidArgumentException;
+use SilverStripe\Core\Injector\Injector;
+
+/**
+ * ManyManyList backed by a dataobject join table
+ */
+class ManyManyThroughList extends RelationList
+{
+	/**
+	 * @var ManyManyThroughQueryManipulator
+	 */
+	protected $manipulator;
+
+	/**
+	 * Create a new ManyManyRelationList object. This relation will utilise an intermediary dataobject
+	 * as a join table, unlike ManyManyList which scaffolds a table automatically.
+	 *
+	 * @param string $dataClass The class of the DataObjects that this will list.
+	 * @param string $joinClass Class name of the joined dataobject record
+	 * @param string $localKey The key in the join table that maps to the dataClass' PK.
+	 * @param string $foreignKey The key in the join table that maps to joined class' PK.
+	 *
+	 * @example new ManyManyThroughList('Banner', 'PageBanner', 'BannerID', 'PageID');
+	 */
+	public function __construct($dataClass, $joinClass, $localKey, $foreignKey) {
+		parent::__construct($dataClass);
+
+		// Inject manipulator
+		$this->manipulator = ManyManyThroughQueryManipulator::create($joinClass, $localKey, $foreignKey);
+		$this->dataQuery->pushQueryManipulator($this->manipulator);
+	}
+
+	/**
+	 * Don't apply foreign ID filter until getFinalisedQuery()
+	 *
+	 * @param array|integer $id (optional) An ID or an array of IDs - if not provided, will use the current ids as
+	 * per getForeignID
+	 * @return array Condition In array(SQL => parameters format)
+	 */
+	protected function foreignIDFilter($id = null) {
+		// foreignIDFilter is applied to the HasManyList via ManyManyThroughQueryManipulator, not here
+		return [];
+	}
+
+	public function createDataObject($row) {
+		// Add joined record
+		$joinRow = [];
+		$prefix = ManyManyThroughQueryManipulator::JOIN_TABLE_ALIAS . '_';
+		foreach ($row as $key => $value) {
+			if (strpos($key, $prefix) === 0) {
+				$joinKey = substr($key, strlen($prefix));
+				$joinRow[$joinKey] = $value;
+				unset($row[$key]);
+			}
+		}
+
+		// Create parent record
+		$record =  parent::createDataObject($row);
+
+		// Create joined record
+		if ($joinRow) {
+			$joinClass = $this->manipulator->getJoinClass();
+			$joinQueryParams = $this->manipulator->extractInheritableQueryParameters($this->dataQuery);
+			$joinRecord = Injector::inst()->create($joinClass, $joinRow, false, $this->model, $joinQueryParams);
+			$record->setJoin($joinRecord);
+		}
+
+		return $record;
+	}
+
+	/**
+	 * Remove the given item from this list.
+	 *
+	 * Note that for a ManyManyList, the item is never actually deleted, only
+	 * the join table is affected.
+	 *
+	 * @param DataObject $item
+	 */
+	public function remove($item) {
+		if(!($item instanceof $this->dataClass)) {
+			throw new InvalidArgumentException(
+				"ManyManyThroughList::remove() expecting a {$this->dataClass} object"
+			);
+		}
+
+		$this->removeByID($item->ID);
+	}
+
+	/**
+	 * Remove the given item from this list.
+	 *
+	 * Note that for a ManyManyList, the item is never actually deleted, only
+	 * the join table is affected
+	 *
+	 * @param int $itemID The item ID
+	 */
+	public function removeByID($itemID) {
+		if(!is_numeric($itemID)) {
+			throw new InvalidArgumentException("ManyManyThroughList::removeById() expecting an ID");
+		}
+
+		// Find has_many row with a local key matching the given id
+		$hasManyList = $this->manipulator->getParentRelationship($this->dataQuery());
+		$records = $hasManyList->filter($this->manipulator->getLocalKey(), $itemID);
+
+		// Rather than simple un-associating the record (as in has_many list)
+		// Delete the actual mapping row as many_many deletions behave.
+		/** @var DataObject $record */
+		foreach($records as $record) {
+			$record->delete();
+		}
+	}
+
+	public function removeAll()
+	{
+		// Empty has_many table matching the current foreign key
+		$hasManyList = $this->manipulator->getParentRelationship($this->dataQuery());
+		$hasManyList->removeAll();
+	}
+
+	/**
+	 * @param mixed $item
+	 * @param array $extraFields
+	 */
+	public function add($item, $extraFields = []) {
+		// Ensure nulls or empty strings are correctly treated as empty arrays
+		if(empty($extraFields)) {
+			$extraFields = array();
+		}
+
+		// Determine ID of new record
+		$itemID = null;
+		if(is_numeric($item)) {
+			$itemID = $item;
+		} elseif($item instanceof $this->dataClass) {
+			$itemID = $item->ID;
+		} else {
+			throw new InvalidArgumentException(
+				"ManyManyThroughList::add() expecting a $this->dataClass object, or ID value"
+			);
+		}
+		if (empty($itemID)) {
+			throw new InvalidArgumentException("ManyManyThroughList::add() doesn't accept unsaved records");
+		}
+
+		// Validate foreignID
+		$foreignIDs = $this->getForeignID();
+		if (empty($foreignIDs)) {
+			throw new BadMethodCallException("ManyManyList::add() can't be called until a foreign ID is set", E_USER_WARNING);
+		}
+
+		// Apply this item to each given foreign ID record
+		if(!is_array($foreignIDs)) {
+			$foreignIDs = [$foreignIDs];
+		}
+		$foreignIDsToAdd = array_combine($foreignIDs, $foreignIDs);
+
+		// Update existing records
+		$localKey = $this->manipulator->getLocalKey();
+		$foreignKey = $this->manipulator->getForeignKey();
+		$hasManyList = $this->manipulator->getParentRelationship($this->dataQuery());
+		$records = $hasManyList->filter($localKey, $itemID);
+		/** @var DataObject $record */
+		foreach($records as $record) {
+			if ($extraFields) {
+				foreach ($extraFields as $field => $value) {
+					$record->$field = $value;
+				}
+				$record->write();
+			}
+			//
+			$foreignID = $record->$foreignKey;
+			unset($foreignIDsToAdd[$foreignID]);
+		}
+
+		// Once existing records are updated, add missing mapping records
+		foreach($foreignIDsToAdd as $foreignID) {
+			$record = $hasManyList->createDataObject($extraFields ?: []);
+			$record->$foreignKey = $foreignID;
+			$record->$localKey = $itemID;
+			$record->write();
+		}
+	}
+}

--- a/ORM/ManyManyThroughQueryManipulator.php
+++ b/ORM/ManyManyThroughQueryManipulator.php
@@ -1,0 +1,219 @@
+<?php
+
+
+namespace SilverStripe\ORM;
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\Debug;
+use SilverStripe\ORM\Queries\SQLSelect;
+
+/**
+ * Injected into DataQuery to augment getFinalisedQuery() with a join table
+ */
+class ManyManyThroughQueryManipulator implements DataQueryManipulator
+{
+	/**
+	 * Alias to use for sql join table
+	 */
+	const JOIN_TABLE_ALIAS = 'Join';
+
+	use Injectable;
+
+	/**
+	 * DataObject that backs the joining table
+	 *
+	 * @var string
+	 */
+	protected $joinClass;
+
+	/**
+	 * Key that joins to the data class
+	 *
+	 * @var string $localKey
+	 */
+	protected $localKey;
+
+	/**
+	 * Key that joins to the parent class
+	 *
+	 * @var string $foreignKey
+	 */
+	protected $foreignKey;
+
+	/**
+	 * Build query manipulator for a given join table. Additional parameters (foreign key, etc)
+	 * will be infered at evaluation from query parameters set via the ManyManyThroughList
+	 *
+	 * @param string $joinClass Class name of the joined dataobject record
+	 * @param string $localKey The key in the join table that maps to the dataClass' PK.
+	 * @param string $foreignKey The key in the join table that maps to joined class' PK.
+	 */
+	public function __construct($joinClass, $localKey, $foreignKey)
+	{
+		$this->setJoinClass($joinClass);
+		$this->setLocalKey($localKey);
+		$this->setForeignKey($foreignKey);
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getJoinClass()
+	{
+		return $this->joinClass;
+	}
+
+	/**
+	 * @param mixed $joinClass
+	 * @return $this
+	 */
+	public function setJoinClass($joinClass)
+	{
+		$this->joinClass = $joinClass;
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getLocalKey()
+	{
+		return $this->localKey;
+	}
+
+	/**
+	 * @param string $localKey
+	 * @return $this
+	 */
+	public function setLocalKey($localKey)
+	{
+		$this->localKey = $localKey;
+		return $this;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getForeignKey()
+	{
+		return $this->foreignKey;
+	}
+
+	/**
+	 * @param string $foreignKey
+	 * @return $this
+	 */
+	public function setForeignKey($foreignKey)
+	{
+		$this->foreignKey = $foreignKey;
+		return $this;
+	}
+
+	/**
+	 * Get has_many relationship between parent and join table (for a given DataQuery)
+	 *
+	 * @param DataQuery $query
+	 * @return HasManyList
+	 */
+	public function getParentRelationship(DataQuery $query) {
+		// Create has_many
+		$list = HasManyList::create($this->getJoinClass(), $this->getForeignKey());
+		$list = $list->setDataQueryParam($this->extractInheritableQueryParameters($query));
+
+		// Limit to given foreign key
+		if ($foreignID = $query->getQueryParam('Foreign.ID')) {
+			$list = $list->forForeignID($foreignID);
+		}
+		return $list;
+	}
+
+	/**
+	 * Calculate the query parameters that should be inherited from the base many_many
+	 * to the nested has_many list.
+	 *
+	 * @param DataQuery $query
+	 * @return mixed
+	 */
+	public function extractInheritableQueryParameters(DataQuery $query) {
+		$params = $query->getQueryParams();
+
+		// Remove `Foreign.` query parameters for created objects,
+		// as this would interfere with relations on those objects.
+		foreach(array_keys($params) as $key) {
+			if(stripos($key, 'Foreign.') === 0) {
+				unset($params[$key]);
+			}
+		}
+
+		// Get inheritable parameters from an instance of the base query dataclass
+		$inst = Injector::inst()->create($query->dataClass());
+		$inst->setSourceQueryParams($params);
+		return $inst->getInheritableQueryParams();
+	}
+
+	/**
+	 * Invoked prior to getFinalisedQuery()
+	 *
+	 * @param DataQuery $dataQuery
+	 * @param array $queriedColumns
+	 * @param SQLSelect $sqlSelect
+	 */
+	public function beforeGetFinalisedQuery(DataQuery $dataQuery, $queriedColumns = [], SQLSelect $sqlSelect)
+	{
+		// Get metadata and SQL from join table
+		$hasManyRelation = $this->getParentRelationship($dataQuery);
+		$joinTableSQLSelect = $hasManyRelation->dataQuery()->query();
+		$joinTableSQL = $joinTableSQLSelect->sql($joinTableParameters);
+		$joinTableColumns = array_keys($joinTableSQLSelect->getSelect()); // Get aliases (keys) only
+		$joinTableAlias = static::JOIN_TABLE_ALIAS;
+
+		// Get fields to join on
+		$localKey = $this->getLocalKey();
+		$schema = DataObject::getSchema();
+		$baseTable = $schema->baseDataClass($dataQuery->dataClass());
+		$childField = $schema->sqlColumnForField($baseTable, 'ID');
+
+		// Add select fields
+		foreach($joinTableColumns as $joinTableColumn) {
+			$sqlSelect->selectField(
+				"\"{$joinTableAlias}\".\"{$joinTableColumn}\"",
+				"{$joinTableAlias}_{$joinTableColumn}"
+			);
+		}
+
+		// Apply join and record sql for later insertion (at end of replacements)
+		$sqlSelect->addInnerJoin(
+			'(SELECT $$_SUBQUERY_$$)',
+			"\"{$joinTableAlias}\".\"{$localKey}\" = {$childField}",
+			$joinTableAlias,
+			20,
+			$joinTableParameters
+		);
+		$dataQuery->setQueryParam('Foreign.JoinTableSQL', $joinTableSQL);
+
+		// After this join, and prior to afterGetFinalisedQuery, $sqlSelect will be populated with the
+		// necessary sql rewrites (versioned, etc) that effect the base table.
+		// By using a placeholder for the subquery we can protect the subquery (already rewritten)
+		// from being re-written a second time. However we DO want the join predicate (above) to be rewritten.
+		// See http://php.net/manual/en/function.str-replace.php#refsect1-function.str-replace-notes
+		// for the reason we only add the final substitution at the end of getFinalisedQuery()
+	}
+
+	/**
+	 * Invoked after getFinalisedQuery()
+	 *
+	 * @param DataQuery $dataQuery
+	 * @param array $queriedColumns
+	 * @param SQLSelect $sqlQuery
+	 */
+	public function afterGetFinalisedQuery(DataQuery $dataQuery, $queriedColumns = [], SQLSelect $sqlQuery)
+	{
+		// Inject final replacement after manipulation has been performed on the base dataquery
+		$joinTableSQL = $dataQuery->getQueryParam('Foreign.JoinTableSQL');
+		if ($joinTableSQL) {
+			$sqlQuery->replaceText('SELECT $$_SUBQUERY_$$', $joinTableSQL);
+			$dataQuery->setQueryParam('Foreign.JoinTableSQL', null);
+		}
+	}
+}

--- a/ORM/ManyManyThroughQueryManipulator.php
+++ b/ORM/ManyManyThroughQueryManipulator.php
@@ -153,7 +153,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
 	 * @return string
 	 */
 	public function getJoinAlias() {
-		return $this->getJoinClass();
+		return DataObject::getSchema()->tableName($this->getJoinClass());
 	}
 
 	/**

--- a/ORM/ManyManyThroughQueryManipulator.php
+++ b/ORM/ManyManyThroughQueryManipulator.php
@@ -5,7 +5,6 @@ namespace SilverStripe\ORM;
 
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Dev\Debug;
 use SilverStripe\ORM\Queries\SQLSelect;
 
 /**
@@ -13,10 +12,6 @@ use SilverStripe\ORM\Queries\SQLSelect;
  */
 class ManyManyThroughQueryManipulator implements DataQueryManipulator
 {
-	/**
-	 * Alias to use for sql join table
-	 */
-	const JOIN_TABLE_ALIAS = 'Join';
 
 	use Injectable;
 
@@ -153,6 +148,15 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
 	}
 
 	/**
+	 * Get name of join table alias for use in queries.
+	 *
+	 * @return string
+	 */
+	public function getJoinAlias() {
+		return $this->getJoinClass();
+	}
+
+	/**
 	 * Invoked prior to getFinalisedQuery()
 	 *
 	 * @param DataQuery $dataQuery
@@ -166,7 +170,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
 		$joinTableSQLSelect = $hasManyRelation->dataQuery()->query();
 		$joinTableSQL = $joinTableSQLSelect->sql($joinTableParameters);
 		$joinTableColumns = array_keys($joinTableSQLSelect->getSelect()); // Get aliases (keys) only
-		$joinTableAlias = static::JOIN_TABLE_ALIAS;
+		$joinTableAlias = $this->getJoinAlias();
 
 		// Get fields to join on
 		$localKey = $this->getLocalKey();

--- a/ORM/Queries/SQLSelect.php
+++ b/ORM/Queries/SQLSelect.php
@@ -146,12 +146,7 @@ class SQLSelect extends SQLConditionalExpression {
 			$fields = array($fields);
 		}
 		foreach($fields as $idx => $field) {
-			if(preg_match('/^(.*) +AS +"([^"]*)"/i', $field, $matches)) {
-				Deprecation::notice("3.0", "Use selectField() to specify column aliases");
-				$this->selectField($matches[1], $matches[2]);
-			} else {
-				$this->selectField($field, is_numeric($idx) ? null : $idx);
-			}
+			$this->selectField($field, is_numeric($idx) ? null : $idx);
 		}
 
 		return $this;
@@ -167,8 +162,11 @@ class SQLSelect extends SQLConditionalExpression {
 	 */
 	public function selectField($field, $alias = null) {
 		if(!$alias) {
-			if(preg_match('/"([^"]+)"$/', $field, $matches)) $alias = $matches[1];
-			else $alias = $field;
+			if(preg_match('/"([^"]+)"$/', $field, $matches)) {
+				$alias = $matches[1];
+			} else {
+				$alias = $field;
+			}
 		}
 		$this->select[$alias] = $field;
 		return $this;

--- a/ORM/RelationList.php
+++ b/ORM/RelationList.php
@@ -12,7 +12,9 @@ use Exception;
 abstract class RelationList extends DataList implements Relation {
 
 	/**
-	 * @return string|null
+	 * Any number of foreign keys to apply to this list
+	 *
+	 * @return string|array|null
 	 */
 	public function getForeignID() {
 		return $this->dataQuery->getQueryParam('Foreign.ID');
@@ -47,10 +49,8 @@ abstract class RelationList extends DataList implements Relation {
 		// Calculate the new filter
 		$filter = $this->foreignIDFilter($id);
 
-		$list = $this->alterDataQuery(function($query) use ($id, $filter){
-			/** @var DataQuery $query */
+		$list = $this->alterDataQuery(function(DataQuery $query) use ($id, $filter){
 			// Check if there is an existing filter, remove if there is
-			/** @var DataQuery $query */
 			$currentFilter = $query->getQueryParam('Foreign.Filter');
 			if($currentFilter) {
 				try {

--- a/ORM/Versioning/Versioned.php
+++ b/ORM/Versioning/Versioned.php
@@ -575,8 +575,9 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 	public function augmentDatabase() {
 		$owner = $this->owner;
 		$class = get_class($owner);
+		$schema = $owner->getSchema();
 		$baseTable = $this->baseTable();
-		$classTable = $owner->getSchema()->tableName($owner);
+		$classTable = $schema->tableName($owner);
 
 		$isRootClass = $class === $owner->baseClass();
 
@@ -606,10 +607,10 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 				$suffixTable = $classTable;
 			}
 
-			$fields = DataObject::database_fields($owner->class);
+			$fields = $schema->databaseFields($class, false);
 			unset($fields['ID']);
 			if($fields) {
-				$options = Config::inst()->get($owner->class, 'create_table_options', Config::FIRST_SET);
+				$options = Config::inst()->get($class, 'create_table_options', Config::FIRST_SET);
 				$indexes = $owner->databaseIndexes();
 				$extensionClass = $allSuffixes[$suffix];
 				if ($suffix && ($extension = $owner->getExtensionInstance($extensionClass))) {
@@ -760,8 +761,9 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 	 * @param int $recordID ID of record to version
 	 */
 	protected function augmentWriteVersioned(&$manipulation, $class, $table, $recordID) {
-		$baseDataClass = DataObject::getSchema()->baseDataClass($class);
-		$baseDataTable = DataObject::getSchema()->tableName($baseDataClass);
+		$schema = DataObject::getSchema();
+		$baseDataClass = $schema->baseDataClass($class);
+		$baseDataTable = $schema->tableName($baseDataClass);
 
 		// Set up a new entry in (table)_versions
 		$newManipulation = array(
@@ -774,8 +776,7 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 		$data = DB::prepared_query("SELECT * FROM \"{$table}\" WHERE \"ID\" = ?", array($recordID))->record();
 
 		if ($data) {
-			$fields = DataObject::database_fields($class);
-
+			$fields = $schema->databaseFields($class, false);
 			if (is_array($fields)) {
 				$data = array_intersect_key($data, $fields);
 
@@ -1383,8 +1384,8 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 	 */
 	public function canBeVersioned($class) {
 		return ClassInfo::exists($class)
-			&& is_subclass_of($class, 'SilverStripe\ORM\DataObject')
-			&& DataObject::has_own_table($class);
+			&& is_subclass_of($class, DataObject::class)
+			&& DataObject::getSchema()->classHasTable($class);
 	}
 
 	/**
@@ -1514,11 +1515,12 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 			return;
 		}
 
+		$schema = DataObject::getSchema();
 		$ownedHasMany = array_intersect($owns, array_keys($hasMany));
 		foreach($ownedHasMany as $relationship) {
 			// Find metadata on relationship
-			$joinClass = $owner->hasManyComponent($relationship);
-			$joinField = $owner->getRemoteJoinField($relationship, 'has_many', $polymorphic);
+			$joinClass = $schema->hasManyComponent(get_class($owner), $relationship);
+			$joinField = $schema->getRemoteJoinField(get_class($owner), $relationship, 'has_many', $polymorphic);
 			$idField = $polymorphic ? "{$joinField}ID" : $joinField;
 			$joinTable = DataObject::getSchema()->tableForField($joinClass, $idField);
 

--- a/Security/PermissionCheckboxSetField.php
+++ b/Security/PermissionCheckboxSetField.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Security;
 
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\FormField;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObjectInterface;
@@ -281,7 +282,11 @@ class PermissionCheckboxSetField extends FormField {
 			$permission->delete();
 		}
 
-		if($fieldname && $record && ($record->hasManyComponent($fieldname) || $record->manyManyComponent($fieldname))) {
+		$schema = DataObject::getSchema();
+		if($fieldname && $record && (
+			$schema->hasManyComponent(get_class($record), $fieldname)
+			|| $schema->manyManyComponent(get_class($record), $fieldname)
+		)) {
 
 			if(!$record->ID) $record->write(); // We need a record ID to write permissions
 

--- a/Security/Security.php
+++ b/Security/Security.php
@@ -12,6 +12,7 @@ use SilverStripe\Core\Convert;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\Deprecation;
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\Forms\EmailField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
@@ -1009,18 +1010,18 @@ class Security extends Controller implements TemplateGlobalProvider {
 			return self::$database_is_ready;
 		}
 
-		$requiredClasses = ClassInfo::dataClassesFor('SilverStripe\\Security\\Member');
-		$requiredClasses[] = 'SilverStripe\\Security\\Group';
-		$requiredClasses[] = 'SilverStripe\\Security\\Permission';
-
+		$requiredClasses = ClassInfo::dataClassesFor(Member::class);
+		$requiredClasses[] = Group::class;
+		$requiredClasses[] = Permission::class;
+		$schema = DataObject::getSchema();
 		foreach($requiredClasses as $class) {
 			// Skip test classes, as not all test classes are scaffolded at once
-			if(is_subclass_of($class, 'SilverStripe\\Dev\\TestOnly')) {
+			if(is_a($class, TestOnly::class, true)) {
 				continue;
 			}
 
 			// if any of the tables aren't created in the database
-			$table = DataObject::getSchema()->tableName($class);
+			$table = $schema->tableName($class);
 			if(!ClassInfo::hasTable($table)) {
 				return false;
 			}
@@ -1035,7 +1036,7 @@ class Security extends Controller implements TemplateGlobalProvider {
 				return false;
 			}
 
-			$objFields = DataObject::database_fields($class);
+			$objFields = $schema->databaseFields($class, false);
 			$missingFields = array_diff_key($objFields, $dbFields);
 
 			if($missingFields) {

--- a/docs/en/02_Developer_Guides/00_Model/02_Relations.md
+++ b/docs/en/02_Developer_Guides/00_Model/02_Relations.md
@@ -213,32 +213,18 @@ This is not mandatory unless the relationship would be otherwise ambiguous.
 
 ## many_many
 
-Defines many-to-many joins. A new table, (this-class)_(relationship-name), will be created with a pair of ID fields.
+Defines many-to-many joins, which uses a third table created between the two to join pairs.
+There are two ways in which this can be declared, which are described below, depending on
+how the developer wishes to manage this join table.
 
 <div class="warning" markdown='1'>
-Please specify a $belongs_many_many-relationship on the related class as well, in order to have the necessary accessors 
-available on both ends.
+Please specify a $belongs_many_many-relationship on the related class as well, in order
+to have the necessary accessors available on both ends.
 </div>
 
-	:::php
-	<?php
-
-	class Team extends DataObject {
-
-	  private static $many_many = array(
-	    "Supporters" => "Supporter",
-	  );
-	}
-
-	class Supporter extends DataObject {
-
-	  private static $belongs_many_many = array(
-	    "Supports" => "Team",
-	  );
-	}
-
-Much like the `has_one` relationship, `many_many` can be navigated through the `ORM` as well. The only difference being
-you will get an instance of [api:ManyManyList] rather than the object.
+Much like the `has_one` relationship, `many_many` can be navigated through the `ORM` as well.
+The only difference being you will get an instance of [api:SilverStripe\ORM\ManyManyList] or
+[api:SilverStripe\ORM\ManyManyThroughList] rather than the object.
 
 	:::php
 	$team = Team::get()->byId(1);
@@ -247,16 +233,119 @@ you will get an instance of [api:ManyManyList] rather than the object.
 	// returns a 'ManyManyList' instance.
 
 
+### Automatic many_many table
+
+If you specify only a single class as the other side of the many-many relationship, then a
+table will be automatically created between the two (this-class)_(relationship-name), will
+be created with a pair of ID fields.
+
+Extra fields on the mapping table can be created by declaring a `many_many_extraFields`
+config to add extra columns.
+
+
+	:::php
+	<?php
+
+	class Team extends DataObject {
+	  private static $many_many = [
+	    "Supporters" => "Supporter",
+	  ];
+	  private static $many_many_extraFields = [
+	    'Supporters' => [
+	      'Ranking' => 'Int' 
+	    ]
+	  ];
+	}
+
+	class Supporter extends DataObject {
+
+	  private static $belongs_many_many = [
+	    "Supports" => "Team",
+	  ];
+	}
+
+
+### many_many through relationship joined on a separate DataObject
+
+If necessary, a third DataObject class can instead be specified as the joining table,
+rather than having the ORM generate an automatically scaffolded table. This has the following
+advantages:
+
+ - Allows versioning of the mapping table, including support for the
+   [ownership api](/developer_guides/model/versioning).
+ - Allows support of other extensions on the mapping table (e.g. subsites).
+ - Extra fields can be managed separately to the joined dataobject, even via a separate
+   GridField or form.
+
+This is declared via array syntax, with the following keys on the many_many:
+ - `through` Class name of the mapping table
+ - `from` Name of the has_one relationship pointing back at the object declaring many_many
+ - `to` Name of the has_one relationship pointing to the object declaring belongs_many_many.
+
+The syntax for `belongs_many_many` is unchanged.
+
+	:::php
+	<?php
+
+	class Team extends DataObject {
+	  private static $many_many = [
+	    "Supporters" => [
+	      'through' => 'TeamSupporter',
+	      'from' => 'Team',
+	      'to' => 'Supporter',
+	    ]
+	  ];
+	}
+
+	class Supporter extends DataObject {
+	  private static $belongs_many_many = [
+	    "Supports" => "Team",
+	  ];
+	}
+	
+	class TeamSupporter extends DataObject {
+	  private static $db = [
+	    'Ranking' => 'Int',
+	  ];
+	  
+	  private static $has_one = [
+	    'Team' => 'Team',
+	    'Supporter' => 'Supporter'
+	  ];
+	}
+
+In order to filter on the join table during queries, you can use the "Join" table alias
+for any sql conditions.
+
+
+	:::php
+	$team = Team::get()->byId(1);
+	$supporters = $team->Supporters()->where(['"Join"."Ranking"' => 1]);
+
+
+Note: ->filter() currently does not support joined fields natively.
+  
+
+### Using many_many in templates
+
 The relationship can also be navigated in [templates](../templates).
+The joined record can be accessed via getJoin() (many_many through only)
 	
 	:::ss
 	<% with $Supporter %>
 		<% loop $Supports %>
-			Supports $Title
+			Supports $Title <% if $Join %>(rank $Join.Ranking)<% end_if %>
 		<% end_if %>
 	<% end_with %>
 
-To specify multiple $many_manys between the same classes, use the dot notation to distinguish them like below:
+## belongs_many_many
+
+The belongs_many_many represents the other side of the relationship on the target data class.
+When using either a basic many_many or a many_many through, the syntax for belongs_many_many is the same.
+
+To specify multiple $many_manys between the same classes, specify use the dot notation to
+distinguish them like below:
+
 
 	:::php
 	<?php
@@ -277,10 +366,12 @@ To specify multiple $many_manys between the same classes, use the dot notation t
 		);
 	}
 
-## many_many or belongs_many_many?
 
-If you're unsure about whether an object should take on `many_many` or `belongs_many_many`, the best way to think about it is that the object where the relationship will be edited (i.e. via checkboxes) should contain the `many_many`. For instance, in a `many_many` of Product => Categories, the `Product` should contain the `many_many`, because it is much more likely that the user will select Categories for a Product than vice-versa.
-
+If you're unsure about whether an object should take on `many_many` or `belongs_many_many`,
+the best way to think about it is that the object where the relationship will be edited
+(i.e. via checkboxes) should contain the `many_many`. For instance, in a `many_many` of
+Product => Categories, the `Product` should contain the `many_many`, because it is much
+more likely that the user will select Categories for a Product than vice-versa.
 
 ## Adding relations
 

--- a/docs/en/02_Developer_Guides/00_Model/02_Relations.md
+++ b/docs/en/02_Developer_Guides/00_Model/02_Relations.md
@@ -281,6 +281,9 @@ This is declared via array syntax, with the following keys on the many_many:
  - `through` Class name of the mapping table
  - `from` Name of the has_one relationship pointing back at the object declaring many_many
  - `to` Name of the has_one relationship pointing to the object declaring belongs_many_many.
+ 
+Note: The `through` class must not also be the name of any field or relation on the parent
+or child record.
 
 The syntax for `belongs_many_many` is unchanged.
 
@@ -314,29 +317,34 @@ The syntax for `belongs_many_many` is unchanged.
 	  ];
 	}
 
-In order to filter on the join table during queries, you can use the "Join" table alias
+In order to filter on the join table during queries, you can use the class name of the joining table
 for any sql conditions.
 
 
 	:::php
 	$team = Team::get()->byId(1);
-	$supporters = $team->Supporters()->where(['"Join"."Ranking"' => 1]);
+	$supporters = $team->Supporters()->where(['"TeamSupporter"."Ranking"' => 1]);
 
 
-Note: ->filter() currently does not support joined fields natively.
-  
+Note: ->filter() currently does not support joined fields natively due to the fact that the
+query for the join table is isolated from the outer query controlled by DataList.
+
 
 ### Using many_many in templates
 
 The relationship can also be navigated in [templates](../templates).
-The joined record can be accessed via getJoin() (many_many through only)
+The joined record can be accessed via `Join` or `TeamSupporter` property (many_many through only)
 	
 	:::ss
 	<% with $Supporter %>
 		<% loop $Supports %>
-			Supports $Title <% if $Join %>(rank $Join.Ranking)<% end_if %>
+			Supports $Title <% if $TeamSupporter %>(rank $TeamSupporter.Ranking)<% end_if %>
 		<% end_if %>
 	<% end_with %>
+
+
+You can also use `$Join` in place of the join class alias (`$TeamSupporter`), if your template
+is class-agnostic and doesn't know the type of the join table. 
 
 ## belongs_many_many
 

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -859,7 +859,6 @@ A very small number of methods were chosen for deprecation, and will be removed 
   appropriately on queries.
 * `DataList::createDataObject` is now public.
 * `DataObject` constructor now has an additional parameter, which must be included in subclasses.
-* `DataObject::database_fields` now returns all fields on that table.
 * `DataObject::db` now returns composite fields.
 * `DataObject::ClassName` field has been refactored into a `DBClassName` type field.
 * `DataObject::can` has new method signature with `$context` parameter.
@@ -910,7 +909,24 @@ A very small number of methods were chosen for deprecation, and will be removed 
  
 #### <a name="overview-orm-removed"></a>ORM Removed API
 
+* `DataObject::db` removed and replaced with `DataObjectSchema::fieldSpec` and `DataObjectSchema::fieldSpecs`
+* `DataObject::manyManyComponent` moved to `DataObjectSchema`
+* `DataObject::belongsToComponent` moved to `DataObjectSchema`
+* `DataObject::hasOneComponent` moved to `DataObjectSchema`
+* `DataObject::hasManyComponent` moved to `DataObjectSchema`
+* `DataObject::getRemoteJoinField` moved to `DataObjectSchema`
+* `DataObject::database_fields` renamed and moved to `DataObjectSchema::databaseFields`
+* `DataObject::has_own_table` renamed and moved to `DataObjectSchema::classHasTable`
+* `DataObject::composite_fields` renamed and moved to `DataObjectSchema::compositeFields``
+* `DataObject::manyManyExtraFieldsForComponent` moved to `DataObjectSchema`
 * Removed `DataObject::validateModelDefinitions`. Relations are now validated within `DataObjectSchema`
+* Removed `DataObject` methods `hasOwnTableDatabaseField`, `has_own_table_database_field` and
+  `hasDatabaseFields` are superceded by `DataObjectSchema::fieldSpec`.
+  Use `$schema->fieldSpec($class, $field, ['dbOnly', 'uninherited'])`.
+  Exclude `uninherited` option to search all tables in the class hierarchy.
+* Removed `DataObject::is_composite_field`. Use `DataObjectSchema::compositeField` instead.
+* Removed `DataObject::custom_database_fields`. Use `DataObjectSchema::databaseFields`
+  or `DataObjectSchema::fieldSpecs` instead.
 * Removed `DataList::getRelation`, as it was mutable. Use `DataList::applyRelation` instead, which is immutable.
 * Removed `DataList::applyFilterContext` private method
 * `Member` Field 'RememberLoginToken' removed, replaced with 'RememberLoginHashes' has_many relationship

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -852,7 +852,12 @@ A very small number of methods were chosen for deprecation, and will be removed 
 #### <a name="overview-orm-api"></a>ORM API Additions / Changes
 
 * Deprecate `SQLQuery` in favour `SQLSelect`
-* `DataList::filter` by null now internally generates "IS NULL" or "IS NOT NULL" conditions appropriately on queries
+* `DataObject.many_many` 'through' relationships now support join dataobjects in place of
+  automatically generated join tables. See the [/developer_guides/relations](datamodel relationship docs)
+  for more info.
+* `DataList::filter` by null now internally generates "IS NULL" or "IS NOT NULL" conditions
+  appropriately on queries.
+* `DataList::createDataObject` is now public.
 * `DataObject` constructor now has an additional parameter, which must be included in subclasses.
 * `DataObject::database_fields` now returns all fields on that table.
 * `DataObject::db` now returns composite fields.
@@ -905,6 +910,7 @@ A very small number of methods were chosen for deprecation, and will be removed 
  
 #### <a name="overview-orm-removed"></a>ORM Removed API
 
+* Removed `DataObject::validateModelDefinitions`. Relations are now validated within `DataObjectSchema`
 * Removed `DataList::getRelation`, as it was mutable. Use `DataList::applyRelation` instead, which is immutable.
 * Removed `DataList::applyFilterContext` private method
 * `Member` Field 'RememberLoginToken' removed, replaced with 'RememberLoginHashes' has_many relationship
@@ -913,6 +919,10 @@ A very small number of methods were chosen for deprecation, and will be removed 
 * Removed `DBString::LimitWordCountXML()` method. Use `LimitWordCount` for XML safe version.
 * Removed `SiteTree::getExistsOnLive()`. Use `isPublished()` instead.
 * Removed `SiteTree::getIsDeletedFromStage()`. Use `isOnDraft()` instead (inverse case).
+* `DataObject.many_many` no longer supports triangular resolution. Both the `many_many` and `belongs_many_many`
+  must point directly to the specific class on the opposing side, not a subclass or parent.
+* `DataObject::validateModelDefinitions()` has been removed. Validation and parsing of config is now handled
+  within `DataObjectSchema`.
  
 ### <a name="overview-filesystem"></a>Filesystem API
 

--- a/tests/forms/GridFieldTest.php
+++ b/tests/forms/GridFieldTest.php
@@ -26,11 +26,14 @@ use SilverStripe\Forms\GridField\GridField_ActionProvider;
 use SilverStripe\Forms\GridField\GridField_DataManipulator;
 use SilverStripe\Forms\GridField\GridField_HTMLProvider;
 
-
-
-
-
 class GridFieldTest extends SapphireTest {
+
+	protected $extraDataObjects = [
+		GridFieldTest_Permissions::class,
+		GridFieldTest_Cheerleader::class,
+		GridFieldTest_Player::class,
+		GridFieldTest_Team::class,
+	];
 
 	/**
 	 * @covers SilverStripe\Forms\GridField\GridField::__construct

--- a/tests/model/DBCompositeTest.php
+++ b/tests/model/DBCompositeTest.php
@@ -48,28 +48,29 @@ class DBCompositeTest extends SapphireTest {
 	 * Test DataObject::composite_fields() and DataObject::is_composite_field()
 	 */
 	public function testCompositeFieldMetaDataFunctions() {
-		$this->assertEquals('Money', DataObject::is_composite_field('DBCompositeTest_DataObject', 'MyMoney'));
-		$this->assertFalse(DataObject::is_composite_field('DBCompositeTest_DataObject', 'Title'));
+		$schema = DataObject::getSchema();
+		$this->assertEquals('Money', $schema->compositeField(DBCompositeTest_DataObject::class, 'MyMoney'));
+		$this->assertNull($schema->compositeField(DBCompositeTest_DataObject::class, 'Title'));
 		$this->assertEquals(
 			array(
 				'MyMoney' => 'Money',
 				'OverriddenMoney' => 'Money'
 			),
-			DataObject::composite_fields('DBCompositeTest_DataObject')
+			$schema->compositeFields(DBCompositeTest_DataObject::class)
 		);
 
 
-		$this->assertEquals('Money', DataObject::is_composite_field('SubclassedDBFieldObject', 'MyMoney'));
-		$this->assertEquals('Money', DataObject::is_composite_field('SubclassedDBFieldObject', 'OtherMoney'));
-		$this->assertFalse(DataObject::is_composite_field('SubclassedDBFieldObject', 'Title'));
-		$this->assertFalse(DataObject::is_composite_field('SubclassedDBFieldObject', 'OtherField'));
+		$this->assertEquals('Money', $schema->compositeField(SubclassedDBFieldObject::class, 'MyMoney'));
+		$this->assertEquals('Money', $schema->compositeField(SubclassedDBFieldObject::class, 'OtherMoney'));
+		$this->assertNull($schema->compositeField(SubclassedDBFieldObject::class, 'Title'));
+		$this->assertNull($schema->compositeField(SubclassedDBFieldObject::class, 'OtherField'));
 		$this->assertEquals(
 			array(
 				'MyMoney' => 'Money',
 				'OtherMoney' => 'Money',
 				'OverriddenMoney' => 'Money',
 			),
-			DataObject::composite_fields('SubclassedDBFieldObject')
+			$schema->compositeFields(SubclassedDBFieldObject::class)
 		);
 	}
 

--- a/tests/model/DataObjectSchemaGenerationTest.php
+++ b/tests/model/DataObjectSchemaGenerationTest.php
@@ -139,11 +139,12 @@ class DataObjectSchemaGenerationTest extends SapphireTest {
 	 * by the order of classnames of existing records
 	 */
 	public function testClassNameSpecGeneration() {
+		$schema = DataObject::getSchema();
 
 		// Test with blank entries
 		DBClassName::clear_classname_cache();
 		$do1 = new DataObjectSchemaGenerationTest_DO();
-		$fields = DataObject::database_fields('DataObjectSchemaGenerationTest_DO');
+		$fields = $schema->databaseFields(DataObjectSchemaGenerationTest_DO::class, false);
 		/** @skipUpgrade */
 		$this->assertEquals("DBClassName", $fields['ClassName']);
 		$this->assertEquals(
@@ -159,9 +160,6 @@ class DataObjectSchemaGenerationTest extends SapphireTest {
 		$item1 = new DataObjectSchemaGenerationTest_IndexDO();
 		$item1->write();
 		DBClassName::clear_classname_cache();
-		$fields = DataObject::database_fields('DataObjectSchemaGenerationTest_DO');
-		/** @skipUpgrade */
-		$this->assertEquals("DBClassName", $fields['ClassName']);
 		$this->assertEquals(
 			array(
 				'DataObjectSchemaGenerationTest_DO' => 'DataObjectSchemaGenerationTest_DO',
@@ -175,9 +173,6 @@ class DataObjectSchemaGenerationTest extends SapphireTest {
 		$item2 = new DataObjectSchemaGenerationTest_DO();
 		$item2->write();
 		DBClassName::clear_classname_cache();
-		$fields = DataObject::database_fields('DataObjectSchemaGenerationTest_DO');
-		/** @skipUpgrade */
-		$this->assertEquals("DBClassName", $fields['ClassName']);
 		$this->assertEquals(
 			array(
 				'DataObjectSchemaGenerationTest_DO' => 'DataObjectSchemaGenerationTest_DO',
@@ -193,9 +188,6 @@ class DataObjectSchemaGenerationTest extends SapphireTest {
 		$item2 = new DataObjectSchemaGenerationTest_DO();
 		$item2->write();
 		DBClassName::clear_classname_cache();
-		$fields = DataObject::database_fields('DataObjectSchemaGenerationTest_DO');
-		/** @skipUpgrade */
-		$this->assertEquals("DBClassName", $fields['ClassName']);
 		$this->assertEquals(
 			array(
 				'DataObjectSchemaGenerationTest_DO' => 'DataObjectSchemaGenerationTest_DO',

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -12,6 +12,7 @@ use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\ManyManyList;
 use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Security\Member;
+use SilverStripe\View\ViewableData;
 
 /**
  * @package framework
@@ -60,8 +61,8 @@ class DataObjectTest extends SapphireTest {
 	}
 
 	public function testDb() {
-		$obj = new DataObjectTest_TeamComment();
-		$dbFields = $obj->db();
+		$schema = DataObject::getSchema();
+		$dbFields = $schema->fieldSpecs(DataObjectTest_TeamComment::class);
 
 		// Assert fields are included
 		$this->assertArrayHasKey('Name', $dbFields);
@@ -73,15 +74,20 @@ class DataObjectTest extends SapphireTest {
 		$this->assertArrayHasKey('ID', $dbFields);
 
 		// Assert that the correct field type is returned when passing a field
-		$this->assertEquals('Varchar', $obj->db('Name'));
-		$this->assertEquals('Text', $obj->db('Comment'));
+		$this->assertEquals('Varchar', $schema->fieldSpec(DataObjectTest_TeamComment::class, 'Name'));
+		$this->assertEquals('Text', $schema->fieldSpec(DataObjectTest_TeamComment::class, 'Comment'));
 
 		// Test with table required
-		$this->assertEquals('DataObjectTest_TeamComment.Varchar', $obj->db('Name', true));
-		$this->assertEquals('DataObjectTest_TeamComment.Text', $obj->db('Comment', true));
-
+		$this->assertEquals(
+			'DataObjectTest_TeamComment.Varchar',
+			$schema->fieldSpec(DataObjectTest_TeamComment::class, 'Name', ['includeClass'])
+		);
+		$this->assertEquals(
+			'DataObjectTest_TeamComment.Text',
+			$schema->fieldSpec(DataObjectTest_TeamComment::class, 'Comment', ['includeClass'])
+		);
 		$obj = new DataObjectTest_ExtendedTeamComment();
-		$dbFields = $obj->db();
+		$dbFields = $schema->fieldSpecs(DataObjectTest_ExtendedTeamComment::class);
 
 		// fixed fields are still included in extended classes
 		$this->assertArrayHasKey('Created', $dbFields);
@@ -90,7 +96,7 @@ class DataObjectTest extends SapphireTest {
 		$this->assertArrayHasKey('ID', $dbFields);
 
 		// Assert overloaded fields have correct data type
-		$this->assertEquals('HTMLText', $obj->db('Comment'));
+		$this->assertEquals('HTMLText', $schema->fieldSpec(DataObjectTest_ExtendedTeamComment::class, 'Comment'));
 		$this->assertEquals('HTMLText', $dbFields['Comment'],
 			'Calls to DataObject::db without a field specified return correct data types');
 
@@ -786,7 +792,7 @@ class DataObjectTest extends SapphireTest {
 		$teamSingleton = singleton('DataObjectTest_Team');
 
 		$subteamInstance = $this->objFromFixture('DataObjectTest_SubTeam', 'subteam1');
-		$subteamSingleton = singleton('DataObjectTest_SubTeam');
+		$schema = DataObject::getSchema();
 
 		/* hasField() singleton checks */
 		$this->assertTrue($teamSingleton->hasField('ID'),
@@ -837,35 +843,35 @@ class DataObjectTest extends SapphireTest {
 		/* hasDatabaseField() singleton checks */
 		//$this->assertTrue($teamSingleton->hasDatabaseField('ID'),
 		//'hasDatabaseField() finds built-in fields in singletons');
-		$this->assertTrue($teamSingleton->hasDatabaseField('Title'),
+		$this->assertNotEmpty($schema->fieldSpec(DataObjectTest_Team::class, 'Title'),
 			'hasDatabaseField() finds custom fields in singletons');
 
 		/* hasDatabaseField() instance checks */
-		$this->assertFalse($teamInstance->hasDatabaseField('NonExistingField'),
+		$this->assertNull($schema->fieldSpec(DataObjectTest_Team::class, 'NonExistingField'),
 			'hasDatabaseField() doesnt find non-existing fields in instances');
-		//$this->assertTrue($teamInstance->hasDatabaseField('ID'),
+		//$this->assertNotEmpty($schema->fieldSpec(DataObjectTest_Team::class, 'ID'),
 		//'hasDatabaseField() finds built-in fields in instances');
-		$this->assertTrue($teamInstance->hasDatabaseField('Created'),
+		$this->assertNotEmpty($schema->fieldSpec(DataObjectTest_Team::class, 'Created'),
 			'hasDatabaseField() finds built-in fields in instances');
-		$this->assertTrue($teamInstance->hasDatabaseField('DatabaseField'),
+		$this->assertNotEmpty($schema->fieldSpec(DataObjectTest_Team::class, 'DatabaseField'),
 			'hasDatabaseField() finds custom fields in instances');
-		$this->assertFalse($teamInstance->hasDatabaseField('SubclassDatabaseField'),
+		$this->assertNull($schema->fieldSpec(DataObjectTest_Team::class, 'SubclassDatabaseField'),
 			'hasDatabaseField() doesnt find subclass fields in parentclass instances');
-		//$this->assertFalse($teamInstance->hasDatabaseField('DynamicField'),
+		//$this->assertNull($schema->fieldSpec(DataObjectTest_Team::class, 'DynamicField'),
 		//'hasDatabaseField() doesnt dynamic getters in instances');
-		$this->assertTrue($teamInstance->hasDatabaseField('HasOneRelationshipID'),
+		$this->assertNotEmpty($schema->fieldSpec(DataObjectTest_Team::class, 'HasOneRelationshipID'),
 			'hasDatabaseField() finds foreign keys in instances');
-		$this->assertTrue($teamInstance->hasDatabaseField('ExtendedDatabaseField'),
+		$this->assertNotEmpty($schema->fieldSpec(DataObjectTest_Team::class, 'ExtendedDatabaseField'),
 			'hasDatabaseField() finds extended fields in instances');
-		$this->assertTrue($teamInstance->hasDatabaseField('ExtendedHasOneRelationshipID'),
+		$this->assertNotEmpty($schema->fieldSpec(DataObjectTest_Team::class, 'ExtendedHasOneRelationshipID'),
 			'hasDatabaseField() finds extended foreign keys in instances');
-		$this->assertFalse($teamInstance->hasDatabaseField('ExtendedDynamicField'),
+		$this->assertNull($schema->fieldSpec(DataObjectTest_Team::class, 'ExtendedDynamicField'),
 			'hasDatabaseField() doesnt include extended dynamic getters in instances');
 
 		/* hasDatabaseField() subclass checks */
-		$this->assertTrue($subteamInstance->hasDatabaseField('DatabaseField'),
+		$this->assertNotEmpty($schema->fieldSpec(DataObjectTest_SubTeam::class, 'DatabaseField'),
 			'hasField() finds custom fields in subclass instances');
-		$this->assertTrue($subteamInstance->hasDatabaseField('SubclassDatabaseField'),
+		$this->assertNotEmpty($schema->fieldSpec(DataObjectTest_SubTeam::class, 'SubclassDatabaseField'),
 			'hasField() finds custom fields in subclass instances');
 
 	}
@@ -874,9 +880,10 @@ class DataObjectTest extends SapphireTest {
 	 * @todo Re-enable all test cases for field inheritance aggregation after behaviour has been fixed
 	 */
 	public function testFieldInheritance() {
-		$teamInstance = $this->objFromFixture('DataObjectTest_Team', 'team1');
-		$subteamInstance = $this->objFromFixture('DataObjectTest_SubTeam', 'subteam1');
+		$schema = DataObject::getSchema();
 
+		// Test logical fields (including composite)
+		$teamSpecifications = $schema->fieldSpecs(DataObjectTest_Team::class);
 		$this->assertEquals(
 			array(
 				'ID',
@@ -891,10 +898,11 @@ class DataObjectTest extends SapphireTest {
 				'HasOneRelationshipID',
 				'ExtendedHasOneRelationshipID'
 			),
-			array_keys($teamInstance->db()),
-			'inheritedDatabaseFields() contains all fields defined on instance: base, extended and foreign keys'
+			array_keys($teamSpecifications),
+			'fieldSpecifications() contains all fields defined on instance: base, extended and foreign keys'
 		);
 
+		$teamFields = $schema->databaseFields(DataObjectTest_Team::class, false);
 		$this->assertEquals(
 			array(
 				'ID',
@@ -909,10 +917,11 @@ class DataObjectTest extends SapphireTest {
 				'HasOneRelationshipID',
 				'ExtendedHasOneRelationshipID'
 			),
-			array_keys(DataObject::database_fields('DataObjectTest_Team', false)),
+			array_keys($teamFields),
 			'databaseFields() contains only fields defined on instance, including base, extended and foreign keys'
 		);
 
+		$subteamSpecifications = $schema->fieldSpecs(DataObjectTest_SubTeam::class);
 		$this->assertEquals(
 			array(
 				'ID',
@@ -929,17 +938,18 @@ class DataObjectTest extends SapphireTest {
 				'SubclassDatabaseField',
 				'ParentTeamID',
 			),
-			array_keys($subteamInstance->db()),
-			'inheritedDatabaseFields() on subclass contains all fields, including base, extended  and foreign keys'
+			array_keys($subteamSpecifications),
+			'fieldSpecifications() on subclass contains all fields, including base, extended  and foreign keys'
 		);
 
+		$subteamFields = $schema->databaseFields(DataObjectTest_SubTeam::class, false);
 		$this->assertEquals(
 			array(
 				'ID',
 				'SubclassDatabaseField',
 				'ParentTeamID',
 			),
-			array_keys(DataObject::database_fields('DataObjectTest_SubTeam')),
+			array_keys($subteamFields),
 			'databaseFields() on subclass contains only fields defined on instance'
 		);
 	}
@@ -1103,22 +1113,26 @@ class DataObjectTest extends SapphireTest {
 			DB::query("SELECT \"ID\" FROM \"DataObjectTest_Team\" WHERE \"Title\" = 'asdfasdf'")->value());
 	}
 
-	public function TestHasOwnTable() {
+	public function testHasOwnTable() {
+		$schema = DataObject::getSchema();
 		/* Test DataObject::has_own_table() returns true if the object has $has_one or $db values */
-		$this->assertTrue(DataObject::has_own_table("DataObjectTest_Player"));
-		$this->assertTrue(DataObject::has_own_table("DataObjectTest_Team"));
-		$this->assertTrue(DataObject::has_own_table("DataObjectTest_Fixture"));
+		$this->assertTrue($schema->classHasTable(DataObjectTest_Player::class));
+		$this->assertTrue($schema->classHasTable(DataObjectTest_Team::class));
+		$this->assertTrue($schema->classHasTable(DataObjectTest_Fixture::class));
 
 		/* Root DataObject that always have a table, even if they lack both $db and $has_one */
-		$this->assertTrue(DataObject::has_own_table("DataObjectTest_FieldlessTable"));
+		$this->assertTrue($schema->classHasTable(DataObjectTest_FieldlessTable::class));
 
 		/* Subclasses without $db or $has_one don't have a table */
-		$this->assertFalse(DataObject::has_own_table("DataObjectTest_FieldlessSubTable"));
+		$this->assertFalse($schema->classHasTable(DataObjectTest_FieldlessSubTable::class));
 
 		/* Return false if you don't pass it a subclass of DataObject */
-		$this->assertFalse(DataObject::has_own_table("SilverStripe\\ORM\\DataObject"));
-		$this->assertFalse(DataObject::has_own_table("SilverStripe\\View\\ViewableData"));
-		$this->assertFalse(DataObject::has_own_table("ThisIsntADataObject"));
+		$this->assertFalse($schema->classHasTable(DataObject::class));
+		$this->assertFalse($schema->classHasTable(ViewableData::class));
+
+		// Invalid class
+		$this->setExpectedException(ReflectionException::class, 'Class ThisIsntADataObject does not exist');
+		$this->assertFalse($schema->classHasTable("ThisIsntADataObject"));
 	}
 
 	public function testMerge() {
@@ -1190,22 +1204,19 @@ class DataObjectTest extends SapphireTest {
 	public function testValidateModelDefinitionsFailsWithArray() {
 		Config::inst()->update('DataObjectTest_Team', 'has_one', array('NotValid' => array('NoArraysAllowed')));
 		$this->setExpectedException(InvalidArgumentException::class);
-		$object = new DataObjectTest_Team();
-		$object->hasOneComponent('NotValid');
+		DataObject::getSchema()->hasOneComponent(DataObjectTest_Team::class, 'NotValid');
 	}
 
 	public function testValidateModelDefinitionsFailsWithIntKey() {
 		Config::inst()->update('DataObjectTest_Team', 'has_many', array(12 => 'DataObjectTest_Player'));
 		$this->setExpectedException(InvalidArgumentException::class);
-		$object = new DataObjectTest_Team();
-		$object->hasManyComponent(12);
+		DataObject::getSchema()->hasManyComponent(DataObjectTest_Team::class, 12);
 	}
 
 	public function testValidateModelDefinitionsFailsWithIntValue() {
 		Config::inst()->update('DataObjectTest_Team', 'many_many', array('Players' => 12));
 		$this->setExpectedException(InvalidArgumentException::class);
-		$object = new DataObjectTest_Team();
-		$object->manyManyComponent('Players');
+		DataObject::getSchema()->manyManyComponent(DataObjectTest_Team::class, 'Players');
 	}
 
 	public function testNewClassInstance() {
@@ -1241,7 +1252,8 @@ class DataObjectTest extends SapphireTest {
 		$equipmentSuppliers = $team->EquipmentSuppliers();
 
 		// Check that DataObject::many_many() works as expected
-		list($relationClass, $class, $targetClass, $parentField, $childField, $joinTable) = $team->manyManyComponent('Sponsors');
+		list($relationClass, $class, $targetClass, $parentField, $childField, $joinTable)
+			= DataObject::getSchema()->manyManyComponent(DataObjectTest_Team::class, 'Sponsors');
 		$this->assertEquals(ManyManyList::class, $relationClass);
 		$this->assertEquals('DataObjectTest_Team', $class,
 			'DataObject::many_many() didn\'t find the correct base class');
@@ -1312,8 +1324,8 @@ class DataObjectTest extends SapphireTest {
 	}
 
 	public function testManyManyExtraFields() {
-		$player = $this->objFromFixture('DataObjectTest_Player', 'player1');
 		$team = $this->objFromFixture('DataObjectTest_Team', 'team1');
+		$schema = DataObject::getSchema();
 
 		// Get all extra fields
 		$teamExtraFields = $team->manyManyExtraFields();
@@ -1330,13 +1342,13 @@ class DataObjectTest extends SapphireTest {
 		), $teamExtraFields);
 
 		// Extra fields are immediately available on the Team class (defined in $many_many_extraFields)
-		$teamExtraFields = $team->manyManyExtraFieldsForComponent('Players');
+		$teamExtraFields = $schema->manyManyExtraFieldsForComponent(DataObjectTest_Team::class, 'Players');
 		$this->assertEquals($teamExtraFields, array(
 			'Position' => 'Varchar(100)'
 		));
 
 		// We'll have to go through the relation to get the extra fields on Player
-		$playerExtraFields = $player->manyManyExtraFieldsForComponent('Teams');
+		$playerExtraFields = $schema->manyManyExtraFieldsForComponent(DataObjectTest_Player::class, 'Teams');
 		$this->assertEquals($playerExtraFields, array(
 			'Position' => 'Varchar(100)'
 		));
@@ -1522,7 +1534,7 @@ class DataObjectTest extends SapphireTest {
 
 		$this->assertEquals (
 			'DataObjectTest_Staff',
-			$company->hasManyComponent('CurrentStaff'),
+			DataObject::getSchema()->hasManyComponent(DataObjectTest_Company::class, 'CurrentStaff'),
 			'has_many strips field name data by default on single relationships.'
 		);
 
@@ -1537,33 +1549,44 @@ class DataObjectTest extends SapphireTest {
 
 		$this->assertEquals (
 			'DataObjectTest_Staff.CurrentCompany',
-			$company->hasManyComponent('CurrentStaff', false),
+			DataObject::getSchema()->hasManyComponent(DataObjectTest_Company::class, 'CurrentStaff', false),
 			'has_many returns field name data on single records when $classOnly is false.'
 		);
 	}
 
 	public function testGetRemoteJoinField() {
-		$company = new DataObjectTest_Company();
+		$schema = DataObject::getSchema();
 
-		$staffJoinField = $company->getRemoteJoinField('CurrentStaff', 'has_many', $polymorphic);
+		// Company schema
+		$staffJoinField = $schema->getRemoteJoinField(
+			DataObjectTest_Company::class, 'CurrentStaff', 'has_many', $polymorphic
+		);
 		$this->assertEquals('CurrentCompanyID', $staffJoinField);
 		$this->assertFalse($polymorphic, 'DataObjectTest_Company->CurrentStaff is not polymorphic');
-		$previousStaffJoinField = $company->getRemoteJoinField('PreviousStaff', 'has_many', $polymorphic);
+		$previousStaffJoinField = $schema->getRemoteJoinField(
+			DataObjectTest_Company::class, 'PreviousStaff', 'has_many', $polymorphic
+		);
 		$this->assertEquals('PreviousCompanyID', $previousStaffJoinField);
 		$this->assertFalse($polymorphic, 'DataObjectTest_Company->PreviousStaff is not polymorphic');
 
-		$ceo = new DataObjectTest_CEO();
-
-		$this->assertEquals('CEOID', $ceo->getRemoteJoinField('Company', 'belongs_to', $polymorphic));
+		// CEO Schema
+		$this->assertEquals('CEOID', $schema->getRemoteJoinField(
+			DataObjectTest_CEO::class, 'Company', 'belongs_to', $polymorphic
+		));
 		$this->assertFalse($polymorphic, 'DataObjectTest_CEO->Company is not polymorphic');
-		$this->assertEquals('PreviousCEOID', $ceo->getRemoteJoinField('PreviousCompany', 'belongs_to', $polymorphic));
+		$this->assertEquals('PreviousCEOID', $schema->getRemoteJoinField(
+			DataObjectTest_CEO::class, 'PreviousCompany', 'belongs_to', $polymorphic
+		));
 		$this->assertFalse($polymorphic, 'DataObjectTest_CEO->PreviousCompany is not polymorphic');
 
-		$team = new DataObjectTest_Team();
-
-		$this->assertEquals('Favourite', $team->getRemoteJoinField('Fans', 'has_many', $polymorphic));
+		// Team schema
+		$this->assertEquals('Favourite', $schema->getRemoteJoinField(
+			DataObjectTest_Team::class, 'Fans', 'has_many', $polymorphic
+		));
 		$this->assertTrue($polymorphic, 'DataObjectTest_Team->Fans is polymorphic');
-		$this->assertEquals('TeamID', $team->getRemoteJoinField('Comments', 'has_many', $polymorphic));
+		$this->assertEquals('TeamID', $schema->getRemoteJoinField(
+			DataObjectTest_Team::class, 'Comments', 'has_many', $polymorphic
+		));
 		$this->assertFalse($polymorphic, 'DataObjectTest_Team->Comments is not polymorphic');
 	}
 

--- a/tests/model/ManyManyThroughListTest.php
+++ b/tests/model/ManyManyThroughListTest.php
@@ -206,8 +206,37 @@ class ManyManyThroughListTest extends SapphireTest
 			'ManyManyThroughListTest_JoinObject' => 'Text'
 		]);
 		$this->setExpectedException(InvalidArgumentException::class);
-		$object = new ManyManyThroughListTest_Object();
-		$object->manyManyComponent('Items');
+		DataObject::getSchema()->manyManyComponent(ManyManyThroughListTest_Object::class, 'Items');
+	}
+
+	public function testRelationParsing() {
+		$schema = DataObject::getSchema();
+
+		// Parent components
+		$this->assertEquals(
+			[
+				ManyManyThroughList::class,
+				ManyManyThroughListTest_Object::class,
+				ManyManyThroughListTest_Item::class,
+				'ParentID',
+				'ChildID',
+				ManyManyThroughListTest_JoinObject::class
+			],
+			$schema->manyManyComponent(ManyManyThroughListTest_Object::class, 'Items')
+		);
+
+		// Belongs_many_many is the same, but with parent/child substituted
+		$this->assertEquals(
+			[
+				ManyManyThroughList::class,
+				ManyManyThroughListTest_Item::class,
+				ManyManyThroughListTest_Object::class,
+				'ChildID',
+				'ParentID',
+				ManyManyThroughListTest_JoinObject::class
+			],
+			$schema->manyManyComponent(ManyManyThroughListTest_Item::class, 'Objects')
+		);
 	}
 }
 

--- a/tests/model/ManyManyThroughListTest.php
+++ b/tests/model/ManyManyThroughListTest.php
@@ -1,0 +1,275 @@
+<?php
+
+use SilverStripe\Dev\Debug;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\ORM\ManyManyThroughList;
+use SilverStripe\ORM\Versioning\Versioned;
+
+class ManyManyThroughListTest extends SapphireTest
+{
+	protected static $fixture_file = 'ManyManyThroughListTest.yml';
+
+	protected $extraDataObjects = [
+		ManyManyThroughListTest_Item::class,
+		ManyManyThroughListTest_JoinObject::class,
+		ManyManyThroughListTest_Object::class,
+		ManyManyThroughListTest_VersionedItem::class,
+		ManyManyThroughListTest_VersionedJoinObject::class,
+		ManyManyThroughListTest_VersionedObject::class,
+	];
+
+	public function testSelectJoin() {
+		/** @var ManyManyThroughListTest_Object $parent */
+		$parent = $this->objFromFixture(ManyManyThroughListTest_Object::class, 'parent1');
+		$this->assertDOSEquals(
+			[
+				['Title' => 'item 1'],
+				['Title' => 'item 2']
+			],
+			$parent->Items()
+		);
+		// Check filters on list work
+		$item1 = $parent->Items()->filter('Title', 'item 1')->first();
+		$this->assertNotNull($item1);
+		$this->assertNotNull($item1->getJoin());
+		$this->assertEquals('join 1', $item1->getJoin()->Title);
+
+		// Check filters on list work
+		$item2 = $parent->Items()->filter('Title', 'item 2')->first();
+		$this->assertNotNull($item2);
+		$this->assertNotNull($item2->getJoin());
+		$this->assertEquals('join 2', $item2->getJoin()->Title);
+
+		// To filter on join table need to use some raw sql
+		$item2 = $parent->Items()->where(['"Join"."Title"' => 'join 2'])->first();
+		$this->assertNotNull($item2);
+		$this->assertEquals('item 2', $item2->Title);
+		$this->assertNotNull($item2->getJoin());
+		$this->assertEquals('join 2', $item2->getJoin()->Title);
+	}
+
+	public function testAdd() {
+		/** @var ManyManyThroughListTest_Object $parent */
+		$parent = $this->objFromFixture(ManyManyThroughListTest_Object::class, 'parent1');
+		$newItem = new ManyManyThroughListTest_Item();
+		$newItem->Title = 'my new item';
+		$newItem->write();
+		$parent->Items()->add($newItem, ['Title' => 'new join record']);
+
+		// Check select
+		$newItem = $parent->Items()->filter(['Title' => 'my new item'])->first();
+		$this->assertNotNull($newItem);
+		$this->assertEquals('my new item', $newItem->Title);
+		$this->assertNotNull($newItem->getJoin());
+		$this->assertEquals('new join record', $newItem->getJoin()->Title);
+	}
+
+	public function testRemove() {
+		/** @var ManyManyThroughListTest_Object $parent */
+		$parent = $this->objFromFixture(ManyManyThroughListTest_Object::class, 'parent1');
+		$this->assertDOSEquals(
+			[
+				['Title' => 'item 1'],
+				['Title' => 'item 2']
+			],
+			$parent->Items()
+		);
+		$item1 = $parent->Items()->filter(['Title' => 'item 1'])->first();
+		$parent->Items()->remove($item1);
+		$this->assertDOSEquals(
+			[['Title' => 'item 2']],
+			$parent->Items()
+		);
+	}
+
+	public function testPublishing() {
+		/** @var ManyManyThroughListTest_VersionedObject $draftParent */
+		$draftParent = $this->objFromFixture(ManyManyThroughListTest_VersionedObject::class, 'parent1');
+		$draftParent->publishRecursive();
+
+		// Modify draft stage
+		$item1 = $draftParent->Items()->filter(['Title' => 'versioned item 1'])->first();
+		$item1->Title = 'new versioned item 1';
+		$item1->getJoin()->Title = 'new versioned join 1';
+		$item1->write(false, false, false, true); // Write joined components
+		$draftParent->Title = 'new versioned title';
+		$draftParent->write();
+
+		// Check owned objects on stage
+		$draftOwnedObjects = $draftParent->findOwned(true);
+		$this->assertDOSEquals(
+			[
+				['Title' => 'new versioned join 1'],
+				['Title' => 'versioned join 2'],
+				['Title' => 'new versioned item 1'],
+				['Title' => 'versioned item 2'],
+			],
+			$draftOwnedObjects
+		);
+
+		// Check live record is still old values
+		// This tests that both the join table and many_many tables
+		// inherit the necessary query parameters from the parent object.
+		/** @var ManyManyThroughListTest_VersionedObject $liveParent */
+		$liveParent = Versioned::get_by_stage(
+			ManyManyThroughListTest_VersionedObject::class,
+			Versioned::LIVE
+		)->byID($draftParent->ID);
+		$liveOwnedObjects = $liveParent->findOwned(true);
+		$this->assertDOSEquals(
+			[
+				['Title' => 'versioned join 1'],
+				['Title' => 'versioned join 2'],
+				['Title' => 'versioned item 1'],
+				['Title' => 'versioned item 2'],
+			],
+			$liveOwnedObjects
+		);
+
+		// Publish draft changes
+		$draftParent->publishRecursive();
+		$liveParent = Versioned::get_by_stage(
+			ManyManyThroughListTest_VersionedObject::class,
+			Versioned::LIVE
+		)->byID($draftParent->ID);
+		$liveOwnedObjects = $liveParent->findOwned(true);
+		$this->assertDOSEquals(
+			[
+				['Title' => 'new versioned join 1'],
+				['Title' => 'versioned join 2'],
+				['Title' => 'new versioned item 1'],
+				['Title' => 'versioned item 2'],
+			],
+			$liveOwnedObjects
+		);
+	}
+}
+
+/**
+ * Basic parent object
+ *
+ * @property string $Title
+ * @method ManyManyThroughList Items()
+ */
+class ManyManyThroughListTest_Object extends DataObject implements TestOnly
+{
+	private static $db = [
+		'Title' => 'Varchar'
+	];
+
+	private static $many_many = [
+		'Items' => [
+			'through' => ManyManyThroughListTest_JoinObject::class,
+			'from' => 'Parent',
+			'to' => 'Child',
+		]
+	];
+}
+
+/**
+ * @property string $Title
+ * @method ManyManyThroughListTest_Object Parent()
+ * @method ManyManyThroughListTest_Item Child()
+ */
+class ManyManyThroughListTest_JoinObject extends DataObject implements TestOnly
+{
+	private static $db = [
+		'Title' => 'Varchar'
+	];
+
+	private static $has_one = [
+		'Parent' => ManyManyThroughListTest_Object::class,
+		'Child' => ManyManyThroughListTest_Item::class,
+	];
+}
+
+/**
+ * @property string $Title
+ * @method ManyManyThroughList Objects()
+ */
+class ManyManyThroughListTest_Item extends DataObject implements TestOnly
+{
+	private static $db = [
+		'Title' => 'Varchar'
+	];
+
+	private static $belongs_many_many = [
+		'Objects' => 'ManyManyThroughListTest_Object.Items'
+	];
+}
+
+/**
+ * Basic parent object
+ *
+ * @property string $Title
+ * @method ManyManyThroughList Items()
+ * @mixin Versioned
+ */
+class ManyManyThroughListTest_VersionedObject extends DataObject implements TestOnly
+{
+	private static $db = [
+		'Title' => 'Varchar'
+	];
+
+	private static $extensions = [
+		Versioned::class
+	];
+
+	private static $owns = [
+		'Items' // Should automatically own both mapping and child records
+	];
+
+	private static $many_many = [
+		'Items' => [
+			'through' => ManyManyThroughListTest_VersionedJoinObject::class,
+			'from' => 'Parent',
+			'to' => 'Child',
+		]
+	];
+}
+
+/**
+ * @property string $Title
+ * @method ManyManyThroughListTest_VersionedObject Parent()
+ * @method ManyManyThroughListTest_VersionedItem Child()
+ * @mixin Versioned
+ */
+class ManyManyThroughListTest_VersionedJoinObject extends DataObject implements TestOnly
+{
+	private static $db = [
+		'Title' => 'Varchar'
+	];
+
+	private static $extensions = [
+		Versioned::class
+	];
+
+	private static $has_one = [
+		'Parent' => ManyManyThroughListTest_VersionedObject::class,
+		'Child' => ManyManyThroughListTest_VersionedItem::class,
+	];
+}
+
+/**
+ * @property string $Title
+ * @method ManyManyThroughList Objects()
+ * @mixin Versioned
+ */
+class ManyManyThroughListTest_VersionedItem extends DataObject implements TestOnly
+{
+	private static $db = [
+		'Title' => 'Varchar'
+	];
+
+	private static $extensions = [
+		Versioned::class
+	];
+
+	private static $belongs_many_many = [
+		'Objects' => 'ManyManyThroughListTest_VersionedObject.Items'
+	];
+}
+

--- a/tests/model/ManyManyThroughListTest.yml
+++ b/tests/model/ManyManyThroughListTest.yml
@@ -1,0 +1,34 @@
+ManyManyThroughListTest_Object:
+  parent1:
+    Title: 'my object'
+ManyManyThroughListTest_Item:
+  child1:
+    Title: 'item 1'
+  child2:
+    Title: 'item 2'
+ManyManyThroughListTest_JoinObject:
+  join1:
+    Title: 'join 1'
+    Parent: =>ManyManyThroughListTest_Object.parent1
+    Child: =>ManyManyThroughListTest_Item.child1
+  join2:
+    Title: 'join 2'
+    Parent: =>ManyManyThroughListTest_Object.parent1
+    Child: =>ManyManyThroughListTest_Item.child2
+ManyManyThroughListTest_VersionedObject:
+  parent1:
+    Title: 'versioned object'
+ManyManyThroughListTest_VersionedItem:
+  child1:
+    Title: 'versioned item 1'
+  child2:
+    Title: 'versioned item 2'
+ManyManyThroughListTest_VersionedJoinObject:
+  join1:
+    Title: 'versioned join 1'
+    Parent: =>ManyManyThroughListTest_VersionedObject.parent1
+    Child: =>ManyManyThroughListTest_VersionedItem.child1
+  join2:
+    Title: 'versioned join 2'
+    Parent: =>ManyManyThroughListTest_VersionedObject.parent1
+    Child: =>ManyManyThroughListTest_VersionedItem.child2

--- a/tests/model/ManyManyThroughListTest.yml
+++ b/tests/model/ManyManyThroughListTest.yml
@@ -9,10 +9,12 @@ ManyManyThroughListTest_Item:
 ManyManyThroughListTest_JoinObject:
   join1:
     Title: 'join 1'
+    Sort: 4
     Parent: =>ManyManyThroughListTest_Object.parent1
     Child: =>ManyManyThroughListTest_Item.child1
   join2:
     Title: 'join 2'
+    Sort: 2
     Parent: =>ManyManyThroughListTest_Object.parent1
     Child: =>ManyManyThroughListTest_Item.child2
 ManyManyThroughListTest_VersionedObject:

--- a/tests/model/VersionedTest.php
+++ b/tests/model/VersionedTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use SilverStripe\Dev\Debug;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\HasManyList;
 use SilverStripe\ORM\ManyManyList;
@@ -405,32 +406,28 @@ class VersionedTest extends SapphireTest {
 	 * Tests DataObject::hasOwnTableDatabaseField
 	 */
 	public function testHasOwnTableDatabaseFieldWithVersioned() {
-		$noversion    = new DataObject();
-		$versioned    = new VersionedTest_DataObject();
-		$versionedSub = new VersionedTest_Subclass();
-		$versionedAno = new VersionedTest_AnotherSubclass();
-		$versionField = new VersionedTest_UnversionedWithField();
+		$schema = DataObject::getSchema();
 
-		$this->assertFalse(
-			(bool) $noversion->hasOwnTableDatabaseField('Version'),
+		$this->assertNull(
+			$schema->fieldSpec(DataObject::class, 'Version', ['uninherited']),
 			'Plain models have no version field.'
 		);
 		$this->assertEquals(
-			'Int', $versioned->hasOwnTableDatabaseField('Version'),
+			'Int',
+			$schema->fieldSpec(VersionedTest_DataObject::class, 'Version', ['uninherited']),
 			'The versioned ext adds an Int version field.'
 		);
-		$this->assertEquals(
-			null,
-			$versionedSub->hasOwnTableDatabaseField('Version'),
+		$this->assertNull(
+			$schema->fieldSpec(VersionedTest_Subclass::class, 'Version', ['uninherited']),
+			'Sub-classes of a versioned model don\'t have a Version field.'
+		);
+		$this->assertNull(
+			$schema->fieldSpec(VersionedTest_AnotherSubclass::class, 'Version', ['uninherited']),
 			'Sub-classes of a versioned model don\'t have a Version field.'
 		);
 		$this->assertEquals(
-			null,
-			$versionedAno->hasOwnTableDatabaseField('Version'),
-			'Sub-classes of a versioned model don\'t have a Version field.'
-		);
-		$this->assertEquals(
-			'Varchar', $versionField->hasOwnTableDatabaseField('Version'),
+			'Varchar(255)',
+			$schema->fieldSpec(VersionedTest_UnversionedWithField::class, 'Version', ['uninherited']),
 			'Models w/o Versioned can have their own Version field.'
 		);
 	}


### PR DESCRIPTION
Fixes #5615

Merge with CMS changes: https://github.com/silverstripe/silverstripe-cms/pull/1639

This change introduces a slight refactor in model relationship handling; Validation has been updated, and moved to DataObjectSchema.

The basic implementation of this feature is that a many_many relation now utilises a nested has_many relation, which is rewritten as a joined subquery within it in place of a join table.

In order to ensure that both has_many and many_many queries are joined, and independently augmented correctly, a ManyManyThroughQueryManipulator object has been implemented to merge them during `getFinalisedQuery()`.

I've also taken advantage of the `::class` language feature in PHP 5.5 to replace some class literals.

Includes the following ORM changes:
- API Remove DataObject::validateModelDefinitions, and move to DataObjectSchema
- API Remove deprecated 3.0 syntax for addSelect()
- API made DataList::createDataObject public
- API Move component parsing logic to DataObjectSchema
- API Remove support for triangular has_many / belongs_many relationships