### PR TITLE
BUG prevent form data / validation persisting in state when using form schema

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -341,6 +341,10 @@ class LeftAndMain extends Controller implements PermissionProvider {
 			$data = $this->getSchemaForForm($form);
 			$response = new HTTPResponse(Convert::raw2json($data));
 			$response->addHeader('Content-Type', 'application/json');
+
+			// Clear non-schema form validation / data / message
+			// since it does not need to be redirected
+			$form->clearMessage();
 			return $response;
 		}
 		return null;


### PR DESCRIPTION
These messages are normally cleared when a form is rendered after redirection. However, when a form is rendered via form schema, this render action is never used, so we need to flush the session messages explicitly.