### PR TITLE
Added development watch command to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "webpack",
+    "watch": "webpack --config ./webpack-dev.config.js --watch",
     "css": "WEBPACK_CHILD=css webpack",
     "lock": "npm-shrinkwrap --dev",
     "test": "NODE_PATH=\"./client/src:./admin/client/src\" jest",

--- a/webpack-dev.config.js
+++ b/webpack-dev.config.js
@@ -1,0 +1,25 @@
+const webpack = require('webpack');
+const Config = require('./webpack.config');
+
+if (Array.isArray(Config)) {
+  const jsConfig = Config.find((item) => item.name === 'js');
+
+  jsConfig.plugins = [
+    new webpack.ProvidePlugin({
+      jQuery: 'jQuery',
+      $: 'jQuery',
+    }),
+    // Most vendor libs are loaded directly into the 'vendor' bundle (through require() calls in vendor.js).
+    // This ensures that any further require() calls in other bundles aren't duplicating libs.
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'vendor',
+      minChunks: Infinity,
+    }),
+  ];
+
+  for (var i = 0; i < Config.length; i++) {
+    Config[i].devtool = 'source-map';
+  }
+}
+
+module.exports = Config;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const autoprefixer = require('autoprefixer');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const path = require('path');
 // const SprityWebpackPlugin = require('sprity-webpack-plugin');
 
 const PATHS = {
@@ -48,7 +49,8 @@ const config = [
       TinyMCE_SSPlugin: `${PATHS.ADMIN_JS_SRC}/legacy/TinyMCE_SSPlugin.js`,
     },
     resolve: {
-      modulesDirectories: [PATHS.ADMIN_JS_SRC, PATHS.MODULES],
+      root: [__dirname, path.resolve(__dirname, PATHS.ADMIN_JS_SRC)],
+      modulesDirectories: [PATHS.MODULES],
     },
     output: {
       path: 'admin/client/dist',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,7 +88,6 @@ const config = [
       config: 'Config',
       'lib/Router': 'Router',
     },
-    devtool: 'source-map',
     module: {
       loaders: [
         {
@@ -152,7 +151,6 @@ const config = [
       path: 'admin/client/dist',
       filename: '[name].css',
     },
-    devtool: 'source-map',
     module: {
       loaders: [
         {
@@ -202,7 +200,6 @@ const config = [
       path: './',
       filename: '[name].css',
     },
-    devtool: 'source-map',
     module: {
       loaders: [
         {


### PR DESCRIPTION
I've created a "dev" config for webpack, for development use only.

This work is a start to improve build time for development, and cuts build time while watching from average 6500ms to average 2500ms.

This does run the risk of developers committing and pushing this development build, which we can setup checks for.
Also a small risk of different behaviours between this development build and the production build, not common or likely but it's difficult to anticipate regressions from Uglify and Source-maps.

I do believe that this is an important step for improving contributor/developer experience, as currently some drawbacks with the current build are:
* Long build time, so if you're making rapid change+saves, it's possible that the last save does not trigger another build so you're missing changes in the build.
* Refreshing the browser too early and you don't get the new build.
* A combination of the two above leads to frustrating: emptying cache, reloading and restarting watch cycle.
* Source maps built for production are redundant because they are in `.gitignore`, only beneficial for development.
* resolve.root performance: https://github.com/webpack/webpack/issues/472#issuecomment-55706013 using resolve.modulesDirectory is slower and not necessary for our setup.

Things I'm looking into for improving this further:
* Dev-server hot-loading new changes. [This gist](https://gist.github.com/MrOrz/4f3da17fd73dbb4c7668) and [this post](http://stackoverflow.com/questions/33233785/installing-webpack-dev-server-with-php-application)
* Possibly a manifest file to separate development and production streams, so it reduces the risk of committing the development build... there are limitations (reference: https://github.com/webpack/webpack/issues/144 )
* Possibly look at upgrading webpack version for its tree-shaking, etc... features
* Looking into [HappyPack](https://github.com/amireh/happypack) 
