### PR TITLE
Check which table should be used for leftJoin

### DIFF
--- a/forms/gridfield/GridFieldSortableHeader.php
+++ b/forms/gridfield/GridFieldSortableHeader.php
@@ -233,9 +233,12 @@ class GridFieldSortableHeader implements GridField_HTMLProvider, GridField_DataM
 					// been aliased. In that event, assume what the user has
 					// provided is the correct value
 					if(!$joinClass) $joinClass = $lastAlias;
+					
+					// Check on which table is the sort column
+					$table = ClassInfo::table_for_object_field($tmpItem->class, $parts[sizeof($parts)-1]);
 
 					$dataList = $dataList->leftJoin(
-						$tmpItem->class,
+						$table,
 						'"' . $methodName . '"."ID" = "' . $joinClass . '"."' . $methodName . 'ID"',
 						$methodName
 					);

--- a/forms/gridfield/GridFieldSortableHeader.php
+++ b/forms/gridfield/GridFieldSortableHeader.php
@@ -236,7 +236,11 @@ class GridFieldSortableHeader implements GridField_HTMLProvider, GridField_DataM
 					
 					// Check on which table is the sort column
 					$table = ClassInfo::table_for_object_field($tmpItem->class, $parts[sizeof($parts)-1]);
-
+					// In case the method doesn't return any proper table, use item class as before
+					if(!$table || $table == 'DataObject') {
+						$table = $tmpItem->class;
+					}
+					
 					$dataList = $dataList->leftJoin(
 						$table,
 						'"' . $methodName . '"."ID" = "' . $joinClass . '"."' . $methodName . 'ID"',


### PR DESCRIPTION
In the current situation, the join may not be made on the right table in case of a DataObject extending another DataObject. This change use table_for_object_field to ensure that we use the right table for the given field.
