### PR TITLE
FIX Dont use superglobals for backurl

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -520,7 +520,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 
 	public function isPasswordExpired() {
 		if(!$this->PasswordExpiry) return false;
-		return strtotime(date('Y-m-d')) >= strtotime($this->PasswordExpiry);
+		return $this->dbObject('PasswordExpiry')->InPast();
 	}
 
 	/**

--- a/security/MemberLoginForm.php
+++ b/security/MemberLoginForm.php
@@ -246,7 +246,7 @@ JS;
 			);
 			Session::set("Security.Message.type", "good");
 		}
-		Controller::curr()->redirectBack();
+		return Controller::curr()->redirectBack();
 	}
 
 
@@ -272,9 +272,10 @@ JS;
 	 *                or NULL on failure.
 	 */
 	public function performLogin($data) {
+		/** @var Member $member */
 		$member = call_user_func_array(array($this->authenticator_class, 'authenticate'), array($data, $this));
 		if($member) {
-			$member->LogIn(isset($data['Remember']));
+			$member->logIn(isset($data['Remember']));
 			return $member;
 		} else {
 			$this->extend('authenticationFailed', $data);

--- a/security/MemberLoginForm.php
+++ b/security/MemberLoginForm.php
@@ -201,7 +201,7 @@ JS;
 		Session::clear('SessionForms.MemberLoginForm.Remember');
 
 		if(Member::currentUser()->isPasswordExpired()) {
-			if(isset($_REQUEST['BackURL']) && $backURL = $_REQUEST['BackURL']) {
+			if(isset($data['BackURL']) && $backURL = $data['BackURL']) {
 				Session::set('BackURL', $backURL);
 			}
 			$cp = ChangePasswordForm::create($this->controller, 'ChangePasswordForm');
@@ -213,8 +213,8 @@ JS;
 		}
 
 		// Absolute redirection URLs may cause spoofing
-		if(!empty($_REQUEST['BackURL'])) {
-			$url = $_REQUEST['BackURL'];
+		if(!empty($data['BackURL'])) {
+			$url = $data['BackURL'];
 			if(Director::is_site_url($url) ) {
 				$url = Director::absoluteURL($url);
 			} else {

--- a/tests/security/MemberLoginFormTest.php
+++ b/tests/security/MemberLoginFormTest.php
@@ -1,0 +1,98 @@
+<?php
+
+class MemberLoginFormTest extends SapphireTest
+{
+	protected $usesDatabase = true;
+
+	public function testLogInUserAndRedirect()
+	{
+		// logout current user
+		Member::currentUser()->logOut();
+
+		// create a new member to login as
+		$member = new Member();
+		$member->FirstName = 'Test';
+		$member->Surname = 'User';
+		$member->Email = 'test@example.com';
+		$member->SetPassword = 'password';
+		$member->write();
+
+		$requestData = array(
+			'Email' => 'test@example.com',
+			'Password' => 'password',
+			'BackURL' => '/home/',
+		);
+
+		$controller = $this->getMockBuilder('Controller')
+			->setMethods(array(
+				'redirect',
+			))
+			->getMock();
+
+		$controller->expects($this->once())->method('redirect')->with('http://localhost/home/');
+
+		$loginForm = $this->getMockBuilder('MemberLoginForm')
+			->setMethods(array(
+				'performLogin',
+				'logInUserAndRedirect',
+			))
+			->setConstructorArgs(array(
+				$controller,
+				'MemberLoginForm',
+			))
+			->enableProxyingToOriginalMethods()
+			->getMock();
+
+		$loginForm->expects($this->once())->method('performLogin')->with($requestData);
+		$loginForm->expects($this->once())->method('logInUserAndRedirect')->with($requestData);
+
+		$loginForm->dologin($requestData);
+	}
+
+	public function testLogInUserAndRedirectWithExpiredPassword()
+	{
+		SS_Datetime::set_mock_now('2018-01-16 00:00:00');
+		// logout current user
+		Member::currentUser()->logOut();
+
+		// create a new member to login as
+		$member = new Member();
+		$member->FirstName = 'Test';
+		$member->Surname = 'User';
+		$member->Email = 'test@example.com';
+		$member->SetPassword = 'password';
+		$member->PasswordExpiry = '2018-01-01';
+		$member->write();
+
+		$requestData = array(
+			'Email' => 'test@example.com',
+			'Password' => 'password',
+			'BackURL' => '/home/',
+		);
+
+		$controller = $this->getMockBuilder('Controller')
+			->setMethods(array(
+				'redirect',
+			))
+			->getMock();
+
+		$controller->expects($this->once())->method('redirect')->with('Security/changepassword');
+
+		$loginForm = $this->getMockBuilder('MemberLoginForm')
+			->setMethods(array(
+				'performLogin',
+				'logInUserAndRedirect',
+			))
+			->setConstructorArgs(array(
+				$controller,
+				'MemberLoginForm',
+			))
+			->enableProxyingToOriginalMethods()
+			->getMock();
+
+		$loginForm->expects($this->once())->method('performLogin')->with($requestData);
+		$loginForm->expects($this->once())->method('logInUserAndRedirect')->with($requestData);
+
+		$loginForm->dologin($requestData);
+	}
+}


### PR DESCRIPTION
This `$data` var comes from the form submission which includes a hiddenfield containing the backurl.

This is the back url a form submission should be using rather than `$_REQUEST`.

This change also allows users to send `$data` outside of a typical form submission flow.
