### PR TITLE
Turn off codecov commenting on PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,3 @@
+comment: false
 codecov:
   branch: master


### PR DESCRIPTION
The codecov PR comments add a lot of noise IMO and I'd prefer we just use the review status as we do with travis to see the changes.