### PR TITLE
API Created a generic DataObject FormBuilder interface

### DIFF
--- a/Forms/DefaultFormFactory.php
+++ b/Forms/DefaultFormFactory.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace SilverStripe\Forms;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Core\Extensible;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * Default form builder class.
+ *
+ * @internal WARNING: Experimental and volatile API.
+ *
+ * Allows extension by either controller or object via the following methods:
+ * - updateFormActions
+ * - updateFormValidator
+ * - updateFormFields
+ * - updateForm
+ */
+class DefaultFormFactory implements FormFactory {
+	use Extensible;
+
+	/**
+	 * @var Controller $controller
+	 */
+	protected $controller;
+
+	/**
+	 * @var DataObject $record
+	 */
+	protected $record;
+
+	/**
+	 * @param Controller $controller
+	 * @param DataObject $model
+	 */
+	public function __construct($controller, $model) {
+		$this->setController($controller);
+		$this->setRecord($model);
+		$this->constructExtensions();
+	}
+
+	/**
+	 * Generates a form using the stored controller and model.
+	 *
+	 * @param string $name
+	 * @return Form $form
+	 */
+	public function getForm($name = 'Form') {
+		$record = $this->getRecord();
+		$fields = $this->getFormFields();
+		$actions = $this->getFormActions();
+		$validator = $this->getFormValidator();
+		$form = Form::create($this->controller, $name, $fields, $actions, $validator);
+
+		// Extend form
+		$this->extendAll('updateForm', $form);
+
+		// Load into form
+		$form->loadDataFrom($record);
+
+		return $form;
+	}
+
+	/**
+	 * Build field list for this form
+	 *
+	 * @return FieldList
+	 */
+	protected function getFormFields() {
+		// Fall back to standard "getCMSFields" which itself uses the FormScaffolder as a fallback
+		$record = $this->getRecord();
+		// @todo Deprecate or formalise support for getCMSFields()
+		$fields = $record->getCMSFields();
+		$this->extendAll('updateFormFields', $fields);
+		return $fields;
+	}
+
+	/**
+	 * Build list of actions for this form
+	 *
+	 * @return FieldList
+	 */
+	protected function getFormActions() {
+		// by default no actions, it's a bit unpredictable
+		$record = $this->getRecord();
+
+		// Support legacy behaviour
+		// @todo Deprecate or formalise support for getCMSActions()
+		$actions = $record->getCMSActions();
+
+		// Extend actions
+		$this->extendAll('updateFormActions', $actions);
+		return $actions;
+	}
+
+	/**
+	 * @return Controller
+	 */
+	public function getController() {
+		return $this->controller;
+	}
+
+	/**
+	 * @param Controller $controller
+	 * @return $this
+	 */
+	public function setController(Controller $controller) {
+		$this->controller = $controller;
+		return $this;
+	}
+
+	/**
+	 * @return DataObject
+	 */
+	public function getRecord() {
+		return $this->record;
+	}
+
+	/**
+	 * @param DataObject $record
+	 * @return $this
+	 */
+	public function setRecord(DataObject $record) {
+		$this->record = $record;
+		return $this;
+	}
+
+	/**
+	 * @return Validator|null
+	 */
+	protected function getFormValidator() {
+		$validator = null;
+		$record = $this->getRecord();
+
+		// Support legacy behaviour
+		if ($record->hasMethod('getCMSValidator')) {
+			// @todo Deprecate or formalise support for getCMSValidator()
+			$validator = $record->getCMSValidator();
+		}
+
+		// Extend validator
+		$this->extendAll('updateFormValidator', $validator);
+		return $validator;
+	}
+
+	/**
+	 * Runs the given extension on the builder, record, and controller
+	 *
+	 * @param string $method name of extension method to call
+	 * @param mixed $object Object parameter
+	 */
+	protected function extendAll($method, &$object) {
+		$this->invokeWithExtensions($method, $object, $this);
+		$this->getRecord()->invokeWithExtensions($method, $object, $this);
+		$this->getController()->invokeWithExtensions($method, $object, $this);
+	}
+}

--- a/Forms/FormFactory.php
+++ b/Forms/FormFactory.php
@@ -3,28 +3,33 @@
 namespace SilverStripe\Forms;
 
 use SilverStripe\Control\Controller;
-use SilverStripe\ORM\DataObject;
 
 /**
- * A service which can generate a form for a given record and controller
+ * A service which can generate a form
  */
 interface FormFactory {
 
 	/**
-	 * @return DataObject
+	 * Default form name.
 	 */
-	public function getRecord();
-
-	/**
-	 * @return Controller
-	 */
-	public function getController();
+	const DEFAULT_NAME = 'Form';
 
 	/**
 	 * Generates the form
 	 *
+	 * @param Controller $controller Parent controller
 	 * @param string $name
+	 * @param array $context List of properties which may influence form scaffolding.
+	 * E.g. 'Record' if building a form for a record.
+	 * Custom factories may support more advanced parameters.
 	 * @return Form
 	 */
-	public function getForm($name = 'Form');
+	public function getForm(Controller $controller, $name = self::DEFAULT_NAME, $context = []);
+
+	/**
+	 * Return list of mandatory context keys
+	 *
+	 * @return mixed
+	 */
+	public function getRequiredContext();
 }

--- a/Forms/FormFactory.php
+++ b/Forms/FormFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SilverStripe\Forms;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * A service which can generate a form for a given record and controller
+ */
+interface FormFactory {
+
+	/**
+	 * @return DataObject
+	 */
+	public function getRecord();
+
+	/**
+	 * @return Controller
+	 */
+	public function getController();
+
+	/**
+	 * Generates the form
+	 *
+	 * @param string $name
+	 * @return Form
+	 */
+	public function getForm($name = 'Form');
+}

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -1044,6 +1044,10 @@ The following filesystem synchronisation methods and tasks are also removed
   actions available when editing records.
 * `PopoverField` added to provide popup-menu behaviour in react forms (currently not available for
   non-react forms).
+* Introduction of experimental `FormFactory` API as a substitute for DataObject classes being responsible
+  for building their own form fields. This builds a form based on a given controller and model,
+  and can be customised on a case by case basis. This has been introduced initially for the asset-admin
+  module.
   
 The following methods and properties on `Requirements_Backend` have been renamed:
 

--- a/tests/forms/FormFactoryTest.php
+++ b/tests/forms/FormFactoryTest.php
@@ -1,0 +1,195 @@
+<?php
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Core\Convert;
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\Debug;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\DefaultFormFactory;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\FormAction;
+use SilverStripe\Forms\FormFactory;
+use SilverStripe\Forms\HiddenField;
+use SilverStripe\Forms\LiteralField;
+use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\Versioning\Versioned;
+
+class FormFactoryTest extends SapphireTest
+{
+	protected $extraDataObjects = [
+		FormFactoryTest_TestObject::class,
+	];
+
+	protected static $fixture_file = 'FormFactoryTest.yml';
+
+	/**
+	 * Test versioned form
+	 */
+	public function testVersionedForm() {
+		$controller = new FormFactoryTest_TestController();
+		$form = $controller->Form();
+
+		// Check formfields
+		$this->assertInstanceOf(TextField::class, $form->Fields()->fieldByName('Title'));
+		$this->assertInstanceOf(HiddenField::class, $form->Fields()->fieldByName('ID'));
+		$this->assertInstanceOf(HiddenField::class, $form->Fields()->fieldByName('SecurityID'));
+
+
+		// Check preview link
+		/** @var LiteralField $previewLink */
+		$previewLink = $form->Fields()->fieldByName('PreviewLink');
+		$this->assertInstanceOf(LiteralField::class, $previewLink);
+		$this->assertEquals(
+			'<a href="FormFactoryTest_TestController/preview/" rel="external" target="_blank">Preview</a>',
+			$previewLink->getContent()
+		);
+
+		// Check actions
+		$this->assertInstanceOf(FormAction::class, $form->Actions()->fieldByName('action_save'));
+		$this->assertInstanceOf(FormAction::class, $form->Actions()->fieldByName('action_publish'));
+		$this->assertTrue($controller->hasAction('publish'));
+	}
+
+	/**
+	 * Removing versioning from an object should result in a simpler form
+	 */
+	public function testBasicForm() {
+		FormFactoryTest_TestObject::remove_extension(Versioned::class);
+		$controller = new FormFactoryTest_TestController();
+		$form = $controller->Form();
+
+		// Check formfields
+		$this->assertInstanceOf(TextField::class, $form->Fields()->fieldByName('Title'));
+		$this->assertNull($form->Fields()->fieldByName('PreviewLink'));
+
+		// Check actions
+		$this->assertInstanceOf(FormAction::class, $form->Actions()->fieldByName('action_save'));
+		$this->assertNull($form->Actions()->fieldByName('action_publish'));
+	}
+}
+
+/**
+ * @mixin Versioned
+ */
+class FormFactoryTest_TestObject extends DataObject {
+	private static $db = [
+		'Title' => 'Varchar',
+	];
+
+	private static $extensions = [
+		Versioned::class,
+	];
+}
+
+/**
+ * Edit controller for this form
+ */
+class FormFactoryTest_TestController extends Controller {
+	private static $extensions = [
+		FormFactoryTest_ControllerExtension::class,
+	];
+
+	public function Link($action = null) {
+		return Controller::join_links('FormFactoryTest_TestController', $action, '/');
+	}
+
+	public function Form() {
+		// Simple example; Just get the first draft record
+		$record = $this->getRecord();
+		$factory = new FormFactoryTest_EditFactory($this, $record);
+		return $factory->getForm('Form');
+	}
+
+	public function save($data, Form $form) {
+		// Noop
+	}
+
+	/**
+	 * @return DataObject
+	 */
+	protected function getRecord()
+	{
+		return Versioned::get_by_stage(FormFactoryTest_TestObject::class, Versioned::DRAFT)->first();
+	}
+}
+
+/**
+ * Provides versionable extensions to a controller
+ */
+class FormFactoryTest_ControllerExtension extends Extension {
+
+	/**
+	 * Handlers for extra actions added by this extension
+	 *
+	 * @var array
+	 */
+	private static $allowed_actions = [
+		'publish',
+		'preview',
+	];
+
+	/**
+	 * Adds additional form actions
+	 *
+	 * @param FieldList $actions
+	 * @param FormFactory $factory
+	 */
+	public function updateFormActions(FieldList &$actions, FormFactory &$factory) {
+		$record = $factory->getRecord();
+		if ($record->hasExtension(Versioned::class)) {
+			$actions->push(new FormAction('publish', 'Publish'));
+		}
+	}
+
+	/**
+	 * Adds extra fields to this form
+	 *
+	 * @param FieldList $fields
+	 * @param FormFactory $factory
+	 */
+	public function updateFormFields(FieldList &$fields, FormFactory &$factory) {
+		// Add preview link
+		if ($factory->getRecord()->hasExtension(Versioned::class)) {
+			$link = $factory->getController()->Link('preview');
+			$fields->unshift(new LiteralField(
+				"PreviewLink",
+				sprintf('<a href="%s" rel="external" target="_blank">Preview</a>', Convert::raw2att($link))
+			));
+		}
+	}
+
+	public function publish($data, $form) {
+		// noop
+	}
+
+	public function preview() {
+		// noop
+	}
+}
+
+/**
+ * Test factory
+ */
+class FormFactoryTest_EditFactory extends DefaultFormFactory  {
+
+	protected function getFormFields()
+	{
+		$fields = new FieldList(
+			new HiddenField('ID'),
+			new TextField('Title')
+		);
+		$this->extendAll('updateFormFields', $fields);
+		return $fields;
+	}
+
+	public function getFormActions()
+	{
+		$actions = new FieldList(
+			new FormAction('save', 'Save')
+		);
+		$this->extendAll('updateFormActions', $actions);
+		return $actions;
+	}
+}

--- a/tests/forms/FormFactoryTest.yml
+++ b/tests/forms/FormFactoryTest.yml
@@ -1,0 +1,3 @@
+FormFactoryTest_TestObject:
+  object:
+    Title: 'Test Object'


### PR DESCRIPTION
This is an experimental interface we are looking to introduce as an alternative to the getCMSFields model built on top of dataobjects self-scaffolding their own fields.

Initially we will be using this for AssetAdmin, where we have built specific File, Folder, and Image field scaffolder services.

Implements https://github.com/silverstripe/silverstripe-asset-admin/issues/253

Also includes asset-admin PR at https://github.com/silverstripe/silverstripe-asset-admin/pull/288