### PR TITLE
BUG Use simplexml_load_string instead of simplexml_load_file

### DIFF
--- a/main.php
+++ b/main.php
@@ -62,6 +62,9 @@ if(!empty($_SERVER['HTTP_X_ORIGINAL_URL'])) {
 	$_SERVER['REQUEST_URI'] = $_SERVER['HTTP_X_ORIGINAL_URL'];
 }
 
+// Enable the entity loader to be able to load XML in Zend_Locale_Data
+libxml_disable_entity_loader(false);
+
 /**
  * Figure out the request URL
  */


### PR DESCRIPTION
PHP #62577 [1] together with PHP #64938 [2] make simplexml_load_file()
fails when the "disable load external entities" flag is set.

As a workaround, use simplexml_load_string() that does succeed
independently of the external entities setting. We are loading internal
XML files after all, so no security implications should arise.

[1] https://bugs.php.net/bug.php?id=62577
[2] https://bugs.php.net/bug.php?id=64938

Fix #6174.
