### PR TITLE
Adjusted button submit action to respect _super()

### DIFF
--- a/Forms/GridField/GridFieldPrintButton.php
+++ b/Forms/GridField/GridFieldPrintButton.php
@@ -119,7 +119,7 @@ class GridFieldPrintButton implements GridField_HTMLProvider, GridField_ActionPr
 	public function handlePrint($gridField, $request = null) {
 		set_time_limit(60);
 		Requirements::clear();
-		Requirements::css(ltrim(FRAMEWORK_DIR . '/client/dist/styles/GridField_print.css', '/'));
+		Requirements::css(ltrim(FRAMEWORK_DIR . '/admin/client/dist/styles/GridField_print.css', '/'));
 
 		if($data = $this->generatePrintData($gridField)){
 			return $data->renderWith(get_class($gridField)."_print");

--- a/admin/client/dist/js/bundle.js
+++ b/admin/client/dist/js/bundle.js
@@ -1273,10 +1273,9 @@ if(s=e(o).closest(".ss-tabset").find(".ui-tabs-nav .ui-tabs-active .ui-tabs-anch
 u=e(o).closest(".togglecomposite"),u.length>0&&u.accordion("activate",u.find(".ui-accordion-header")),d=e(o).position().top,e(o).is(":visible")||(o="#"+e(o).closest(".field").attr("id"),d=e(o).position().top),
 e(o).focus(),d>e(window).height()/2&&t.find(".cms-content-fields").scrollTop(d)}else this.focusFirstInput()}},focusFirstInput:function w(){this.find(':input:not(:submit)[data-skip-autofocus!="true"]').filter(":visible:first").focus()
 
-}}),e(".cms-edit-form .btn-toolbar input.action[type=submit], .cms-edit-form .btn-toolbar button.action").entwine({onclick:function C(e){return this.hasClass("gridfield-button-delete")&&!confirm(a["default"]._t("TABLEFIELD.DELETECONFIRMMESSAGE"))?(e.preventDefault(),
-!1):(this.is(":disabled")||this.parents("form").trigger("submit",[this]),e.preventDefault(),!1)}}),e(".cms-edit-form .btn-toolbar input.action[type=submit].ss-ui-action-cancel, .cms-edit-form .btn-toolbar button.action.ss-ui-action-cancel").entwine({
-onclick:function T(e){window.history.length>1?window.history.back():this.parents("form").trigger("submit",[this]),e.preventDefault()}}),e(".cms-edit-form .ss-tabset").entwine({onmatch:function E(){if(!this.hasClass("ss-ui-action-tabset")){
-var e=this.find("> ul:first")
+}}),e(".cms-edit-form .btn-toolbar input.action[type=submit], .cms-edit-form .btn-toolbar button.action").entwine({onclick:function C(e){return this.is(":disabled")?(e.preventDefault(),!1):this._super(e)===!1||e.defaultPrevented||e.isDefaultPrevented()?void 0:(this.parents("form").trigger("submit",[this]),
+e.preventDefault(),!1)}}),e(".cms-edit-form .btn-toolbar input.action[type=submit].ss-ui-action-cancel, .cms-edit-form .btn-toolbar button.action.ss-ui-action-cancel").entwine({onclick:function T(e){window.history.length>1?window.history.back():this.parents("form").trigger("submit",[this]),
+e.preventDefault()}}),e(".cms-edit-form .ss-tabset").entwine({onmatch:function E(){if(!this.hasClass("ss-ui-action-tabset")){var e=this.find("> ul:first")
 1==e.children("li").length&&e.hide().parent().addClass("ss-tabset-tabshidden")}this._super()},onunmatch:function P(){this._super()}})})
 var s=function l(t){e.noticeAdd({text:t,type:"error",stayTime:5e3,inEffect:{left:"0",opacity:"show"}})}}).call(t,n(1))},function(e,t){e.exports=i18n},function(e,t,n){"use strict"
 function i(e){return e&&e.__esModule?e:{"default":e}}var r=n(1),o=i(r)

--- a/admin/client/src/legacy/LeftAndMain.EditForm.js
+++ b/admin/client/src/legacy/LeftAndMain.EditForm.js
@@ -394,20 +394,17 @@ $.entwine('ss', function($){
      * Function: onclick
      */
     onclick: function(e) {
-      // Confirmation on delete.
-      if(
-        this.hasClass('gridfield-button-delete')
-        && !confirm(i18n._t('TABLEFIELD.DELETECONFIRMMESSAGE'))
-      ) {
+      if(this.is(':disabled')) {
         e.preventDefault();
         return false;
       }
 
-      if(!this.is(':disabled')) {
+      // only run submit if other handlers didn't preventDefault
+      if (this._super(e) !== false && !e.defaultPrevented && !e.isDefaultPrevented()) {
         this.parents('form').trigger('submit', [this]);
+        e.preventDefault();
+        return false;
       }
-      e.preventDefault();
-      return false;
     }
   });
 


### PR DESCRIPTION
Buttons such as those from GridField (print, export, custom actions) may not necessarily need a form submit. So this checks before trying to submit the form.

Some behaviour changed in entwine (or a dependency of entwine) which had shuffled the order of execution for event handlers I think, as this code exists in v3.x and it's working there.