### PR TITLE
FIX Ambiguous column SQL error

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -392,7 +392,8 @@ class DataQuery {
 	 * automatically so must not contain double quotes.
 	 */
 	public function max($field) {
-		return $this->aggregate("MAX(\"$field\")");
+		$table = ClassInfo::table_for_object_field($this->dataClass, $field);
+		return $this->aggregate("MAX(\"$table\".\"$field\")");
 	}
 
 	/**
@@ -402,7 +403,8 @@ class DataQuery {
 	 * automatically so must not contain double quotes.
 	 */
 	public function min($field) {
-		return $this->aggregate("MIN(\"$field\")");
+		$table = ClassInfo::table_for_object_field($this->dataClass, $field);
+		return $this->aggregate("MIN(\"$table\".\"$field\")");
 	}
 
 	/**
@@ -412,7 +414,8 @@ class DataQuery {
 	 * automatically so must not contain double quotes.
 	 */
 	public function avg($field) {
-		return $this->aggregate("AVG(\"$field\")");
+		$table = ClassInfo::table_for_object_field($this->dataClass, $field);
+		return $this->aggregate("AVG(\"$table\".\"$field\")");
 	}
 
 	/**
@@ -422,7 +425,8 @@ class DataQuery {
 	 * automatically so must not contain double quotes.
 	 */
 	public function sum($field) {
-		return $this->aggregate("SUM(\"$field\")");
+		$table = ClassInfo::table_for_object_field($this->dataClass, $field);
+		return $this->aggregate("SUM(\"$table\".\"$field\")");
 	}
 
 	/**

--- a/tests/model/DataListTest.php
+++ b/tests/model/DataListTest.php
@@ -363,6 +363,17 @@ class DataListTest extends SapphireTest {
 		$this->assertEquals($otherExpected, $otherMap);
 	}
 
+	public function testAmbiguousAggregate() {
+		// Test that we avoid ambiguity error when a field exists on two joined tables
+		// Fetch the sponsors in a round-about way to simulate this
+		$teamID = $this->idFromFixture('DataObjectTest_Team','team2');
+		$sponsors = DataObjectTest_EquipmentCompany::get()->filter('SponsoredTeams.ID', $teamID);
+		$this->assertNotNull($sponsors->Max('ID'));
+		$this->assertNotNull($sponsors->Min('ID'));
+		$this->assertNotNull($sponsors->Avg('ID'));
+		$this->assertNotNull($sponsors->Sum('ID'));
+	}
+
 	public function testEach() {
 		$list = DataObjectTest_TeamComment::get();
 


### PR DESCRIPTION
I noticed that I couldn't use `Max('LastEdited')` with certain Datalists. Seems to be an issue if you use a filter that joins other tables, and results in an error such as:

>  "Column 'LastEdited' in field list is ambiguous"

Have included a test which fails prior to this patch.

In limited testing this seems to fix the problem and not cause side effects. To be honest though I don't understand very well what I've done here, so would appreciate the fine-toothed comb treatment from someone who understand SQL and the ORM better and would know if this is likely to cause regressions.