### PR TITLE
Prevent undefined index notices

### DIFF
--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -246,12 +246,12 @@ abstract class ModelAdmin extends LeftAndMain {
 
 		if(is_array($params)) {
 			$params = ArrayLib::array_map_recursive('trim', $params);
-		}
 
-		// Parse all DateFields to handle user input non ISO 8601 dates
-		foreach($context->getFields() as $field) {
-			if($field instanceof DatetimeField) {
-				$params[$field->getName()] = date('Y-m-d', strtotime($params[$field->getName()]));
+			// Parse all DateFields to handle user input non ISO 8601 dates
+			foreach($context->getFields() as $field) {
+				if($field instanceof DatetimeField) {
+					$params[$field->getName()] = date('Y-m-d', strtotime($params[$field->getName()]));
+				}
 			}
 		}
 


### PR DESCRIPTION
Moving the foreach loop to inside the if statements makes sure the array is actually an array. The old way was generating 'Undefined index' notices.

Perhaps an `isset($params[$field->getName()])` should also be performed.