### PR TITLE
Remove additional spacing from buttons with no icon

### DIFF
--- a/admin/client/dist/styles/bundle.css
+++ b/admin/client/dist/styles/bundle.css
@@ -9536,6 +9536,10 @@ body.cms{
   line-height:1.539;
 }
 
+.ui-button-text-only .ui-button-text{
+  padding-left:0;
+}
+
 .cms .ui-tabs .ui-tabs-nav li a.icon-button,.cms a.icon-button,.cms button.ss-ui-button.icon-button,.ui-tabs .ui-tabs-nav li .cms a.icon-button{
   vertical-align:middle;
   margin:0 2px 0 0;

--- a/admin/client/src/styles/legacy/_style.scss
+++ b/admin/client/src/styles/legacy/_style.scss
@@ -299,6 +299,10 @@ body.cms {
 	line-height: $line-height;
 }
 
+.ui-button-text-only .ui-button-text {
+  padding-left: 0;
+}
+
 .cms {
 	a.icon-button,
 	button.ss-ui-button.icon-button {


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-cms/issues/1623
Before:
![image](https://cloud.githubusercontent.com/assets/555033/19580547/6274f8d2-9783-11e6-96e5-ebf3b376e75d.png)

After:
![image](https://cloud.githubusercontent.com/assets/555033/19580534/51d57ccc-9783-11e6-9d87-8ab3a11c2bc8.png)
