### PR TITLE
BUG Fix : relObject() should return null if one of the node is null

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -3069,8 +3069,11 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 			$relations = explode('.', $fieldName);
 			$fieldName = array_pop($relations);
 			foreach($relations as $relation) {
+				// Bail if the component is null
+				if(!$component) {
+					return null;
 				// Inspect $component for element $relation
-				if($component->hasMethod($relation)) {
+				} elseif($component->hasMethod($relation)) {
 					// Check nested method
 					$component = $component->$relation();
 				} elseif($component instanceof SS_List) {


### PR DESCRIPTION
# Current Problem

`relObject()` didn't check if $component is null in `foreach` loop. In some cases, following fatal error happens.

> ( ! ) Fatal error: Call to a member function hasMethod() on a non-object in /www/framework/model/DataObject.php on line 3073
# Sample Codes

```
class Product extends Page {
    private static $has_many = array (
        'Images' => 'ProductImage',
    );
    private static $summary_fields = array(
        'Images.First.Image.CMSThumbnail'   => 'Image',
        'Title'             => 'Title',
        'URLSegment'        => 'URL'
    );
}
```

```
class ProductImage extends DataObject {
    private static $db = array (
        ....
    );

    private static $has_one = array (
        'Image' => 'Image',
        'Parent' => 'Product'
    );
}
```

```
class ShopAdmin extends VersionedModelAdmin {

    private static $title       = 'Shop';
    private static $menu_title  = 'Shop';
    private static $url_segment = 'shop';          

    private static $managed_models  = array(
        'Product'
    );
}
```
# Steps to reproduce
1. Create Product without adding ProductImage.
2. Go to ShopAdmin and fatal error happens.
