### PR TITLE
OPTMIZATION 200% speed increase with ConfigManifest

### DIFF
--- a/core/manifest/ConfigManifest.php
+++ b/core/manifest/ConfigManifest.php
@@ -202,7 +202,9 @@ class SS_ConfigManifest {
 		$finder->setOptions(array(
 			'name_regex'    => '/(^|[\/\\\\])_config.php$/',
 			'ignore_tests'  => !$includeTests,
-			'file_callback' => array($this, 'addSourceConfigFile')
+			'file_callback' => array($this, 'addSourceConfigFile'),
+			// Cannot be max_depth: 1 due to "/framework/admin/_config.php"
+			'max_depth'     => 2
 		));
 		$finder->find($this->base);
 
@@ -210,7 +212,8 @@ class SS_ConfigManifest {
 		$finder->setOptions(array(
 			'name_regex'    => '/\.ya?ml$/',
 			'ignore_tests'  => !$includeTests,
-			'file_callback' => array($this, 'addYAMLConfigFile')
+			'file_callback' => array($this, 'addYAMLConfigFile'),
+			'max_depth'     => 2
 		));
 		$finder->find($this->base);
 


### PR DESCRIPTION
OPTMIZATION 200% speed increase with ConfigManifest.

By only making the FileFinder search 2 directories deep on a Silverstripe build with ~69 modules, I was able to shave off 1 second on PHP 5.x.

My results (i5-6600K, 3.5ghz, 8GB RAM, 64-bit Windows):
- PHP 5.6.25 -- before -- 1.8809859752655 seconds
- PHP 5.6.25 -- after -- 0.8601610660553 seconds
- PHP 7.0.10 -- before -- 1.6998739242554 seconds
- PHP 7.0.10 -- after -- 0.99255394935608 seconds

Other machine (i7-2620M, 2.7ghz, 8GB RAM, Samsung EVO 840 SSD, 64-bit Windows):
- PHP 5.5.12 -- before -- 2.9904389381409 seconds
- PHP 5.5.12 -- after -- 1.0939319133759 seconds

I also checked the 'count()' of config sources and YAML config fragments to ensure all of them were being picked up.

My testing code:
```
$t = microtime(true);

$finder = new ManifestFileFinder();
$finder->setOptions(array(
	'name_regex'    => '/(^|[\/\\\\])_config.php$/',
	'ignore_tests'  => !$includeTests,
	'file_callback' => array($this, 'addSourceConfigFile'),
	// Cannot be max_depth: 1 due to "/framework/admin/_config.php"
	'max_depth'		=> 2
));
$finder->find($this->base);

$finder = new ManifestFileFinder();
$finder->setOptions(array(
	'name_regex'    => '/\.ya?ml$/',
	'ignore_tests'  => !$includeTests,
	'file_callback' => array($this, 'addYAMLConfigFile'),
	'max_depth'		=> 2
));
$finder->find($this->base);

$t = microtime(true) - $t;
Debug::dump($t);
Debug::dump('Config: '.count($this->phpConfigSources));
Debug::dump('YML: ' .count($this->yamlConfigFragments));
```