### PR TITLE
API Shorten overly-verbose invalid extension error

### DIFF
--- a/Assets/Upload_Validator.php
+++ b/Assets/Upload_Validator.php
@@ -277,10 +277,8 @@ class Upload_Validator
 		// extension validation
 		if (!$this->isValidExtension()) {
 			$this->errors[] = _t(
-				'File.INVALIDEXTENSION',
-				'Extension is not allowed (valid: {extensions})',
-				'Argument 1: Comma-separated list of valid extensions',
-				array('extensions' => wordwrap(implode(', ', $this->allowedExtensions)))
+				'File.INVALIDEXTENSION_SHORT',
+				'Extension is not allowed'
 			);
 			return false;
 		}

--- a/tests/filesystem/UploadTest.php
+++ b/tests/filesystem/UploadTest.php
@@ -831,10 +831,8 @@ class UploadTest_Validator extends Upload_Validator implements TestOnly {
 		// extension validation
 		if(!$this->isValidExtension()) {
 			$this->errors[] = _t(
-				'File.INVALIDEXTENSION',
-				'Extension is not allowed (valid: {extensions})',
-				'Argument 1: Comma-separated list of valid extensions',
-				array('extensions' => implode(',', $this->allowedExtensions))
+				'File.INVALIDEXTENSION_SHORT',
+				'Extension is not allowed'
 			);
 			return false;
 		}


### PR DESCRIPTION
Fixes #6198

I suggest that, instead of a super long error message, there should be another way to pre-determine allowed types. Maybe an info box you can click to get a tooltip?