### PR TITLE
FIX: path to ParameterConfirmationToken.php

### DIFF
--- a/Dev/Install/install.php5
+++ b/Dev/Install/install.php5
@@ -1661,7 +1661,7 @@ TEXT;
 	}
 
 	public function checkRewrite() {
-		require_once 'core/startup/ParameterConfirmationToken.php';
+		require_once 'Core/Startup/ParameterConfirmationToken.php';
 		$token = new ParameterConfirmationToken('flush');
 		$params = http_build_query($token->params());
 


### PR DESCRIPTION
`ParameterConfirmationToken.php` is in `framework/Core/Startup` not `framework/core/startup`.
