### PR TITLE
FIX TreeDropdownField cached items

### DIFF
--- a/forms/TreeDropdownField.php
+++ b/forms/TreeDropdownField.php
@@ -297,9 +297,13 @@ class TreeDropdownField extends FormField {
 		}
 
 		// pre-process the tree - search needs to operate globally, not locally as marking filter does
-		if ( $this->search != "" )
+		if ( $this->search != "" ) {
 			$this->populateIDs();
-
+			// flush the cache for the representative object, as any other 
+			// tree may have populated the statically cached data that hierarchy uses
+			$obj->flushCache();
+		}
+        
 		if ($this->filterCallback || $this->search != "" )
 			$obj->setMarkingFilterFunction(array($this, "filterMarking"));
 


### PR DESCRIPTION
When searching a tree dropdown field, and that dropdown field is looking at
the hierarchy of a class type that has already been iterated on that request,
the cached data present in Hierarchy will mean the search results do not
correctly mark items. Simplest solution is to clear the hierarchy cache.

There's likely a more elegant solution for someone with more time... 