### PR TITLE
Remove double quotes so example is not parsed.

### DIFF
--- a/model/Map.php
+++ b/model/Map.php
@@ -196,7 +196,7 @@ class SS_Map implements ArrayAccess, Countable, IteratorAggregate {
 		}
 
 		user_error(
-			"SS_Map is read-only. Please use $map->push($key, $value) to append values", 
+			'SS_Map is read-only. Please use $map->push($key, $value) to append values', 
 			E_USER_ERROR
 		);
 	}


### PR DESCRIPTION
[Notice] Undefined variable: map

Since it's using double quotes it tries to process $map, $key and $value

--

This is a re-submit of https://github.com/silverstripe/silverstripe-framework/pull/6225 which was against the wrong branch.