### PR TITLE
NEW Allow setting of unlimited row counts on GridFieldPaginator

### DIFF
--- a/forms/gridfield/GridFieldPaginator.php
+++ b/forms/gridfield/GridFieldPaginator.php
@@ -179,15 +179,23 @@ class GridFieldPaginator implements GridField_HTMLProvider, GridField_DataManipu
 		$totalRows = $this->totalItems;
 		if(!$totalRows) return null;
 
-		$totalPages = (int)ceil($totalRows/$this->itemsPerPage);
-		if($totalPages == 0)
-			$totalPages = 1;
-		$firstShownRecord = ($state->currentPage - 1) * $this->itemsPerPage + 1;
-		if($firstShownRecord > $totalRows)
-			$firstShownRecord = $totalRows;
-		$lastShownRecord = $state->currentPage * $this->itemsPerPage;
-		if($lastShownRecord > $totalRows)
-			$lastShownRecord = $totalRows;
+		$totalPages = 1;
+		$firstShownRecord = 1;
+		$lastShownRecord = $totalRows;
+		if ($itemsPerPage = $this->getItemsPerPage()) {
+			$totalPages = (int)ceil($totalRows / $itemsPerPage);
+			if ($totalPages == 0) {
+				$totalPages = 1;
+			}
+			$firstShownRecord = ($state->currentPage - 1) * $itemsPerPage + 1;
+			if ($firstShownRecord > $totalRows) {
+				$firstShownRecord = $totalRows;
+			}
+			$lastShownRecord = $state->currentPage * $itemsPerPage;
+			if ($lastShownRecord > $totalRows) {
+				$lastShownRecord = $totalRows;
+			}
+		}
 
 		// If there is only 1 page for all the records in list, we don't need to go further
 		// to sort out those first page, last page, pre and next pages, etc

--- a/tests/forms/gridfield/GridFieldPaginatorTest.php
+++ b/tests/forms/gridfield/GridFieldPaginatorTest.php
@@ -52,6 +52,26 @@ class GridFieldPaginatorTest extends FunctionalTest {
 		$this->assertEquals(2, count($content->getBySelector('.pagination-records-number')));
 	}
 
+	public function testUnlimitedRowCount() {
+		$total = $this->list->count();
+		// set up the paginator
+		/** @var GridFieldPaginator $paginator */
+		$paginator = $this->gridField->getConfig()->getComponentByType("GridFieldPaginator");
+		$paginator->setThrowExceptionOnBadDataType(true);
+		$paginator->setItemsPerPage(1);
+		$paginator->getManipulatedData($this->gridField, $this->list);
+
+
+		$params = $paginator->getTemplateParameters($this->gridField)->toMap();
+		$this->assertFalse($params['OnlyOnePage']);
+		$this->assertEquals($total, $params['NumRecords']);
+
+		$paginator->setItemsPerPage(0);
+		$params = $paginator->getTemplateParameters($this->gridField)->toMap();
+		$this->assertTrue($params['OnlyOnePage']);
+		$this->assertEquals($total, $params['NumRecords']);
+	}
+
 	public function testPaginationAvoidsIllegalOffsets() {
 		$grid = $this->gridField;
 		$total = $this->list->count();


### PR DESCRIPTION
This change allows a dev to use `->setItemsPerPage(0)` to create a GridField with unlimited row count.