### PR TITLE
FIX default_records are no longer inherited to child classes

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -3503,7 +3503,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	 * @uses DataExtension->requireDefaultRecords()
 	 */
 	public function requireDefaultRecords() {
-		$defaultRecords = $this->stat('default_records');
+		$defaultRecords = $this->config()->get('default_records', Config::UNINHERITED);
 
 		if(!empty($defaultRecords)) {
 			$hasData = DataObject::get_one($this->class);


### PR DESCRIPTION
At the moment `default_records` are inherited by child classes which means if you define a default record on an object or page class all child classes also build the same records.

This feels unintended and unhelpful so this patch only adds the records for the particular class the `default_records` config is defined on