### PR TITLE
Setting default db adapter in installation  as PDO MySQL

### DIFF
--- a/_register_database.php
+++ b/_register_database.php
@@ -1,26 +1,11 @@
 <?php
 
-// Register the SilverStripe provided databases
+// Register database adapters available in SilverStripe
 use SilverStripe\Dev\Install\DatabaseAdapterRegistry;
 use SilverStripe\Dev\Install\MySQLDatabaseConfigurationHelper;
 
-// Use MySQLi as default
-DatabaseAdapterRegistry::register(
-	array(
-		/** @skipUpgrade */
-		'class' => 'MySQLDatabase',
-		'module' => 'framework',
-		'title' => 'MySQL 5.0+ (using MySQLi)',
-		'helperPath' => __DIR__ . '/src/Dev/Install/MySQLDatabaseConfigurationHelper.php',
-		'helperClass' => MySQLDatabaseConfigurationHelper::class,
-		'supported' => class_exists('MySQLi'),
-		'missingExtensionText' =>
-			'The <a href="http://www.php.net/manual/en/book.mysqli.php">MySQLi</a>
-			PHP extension is not available. Please install or enable it and refresh this page.'
-	)
-);
 
-// Setup MySQL PDO as alternate option
+// Register MySQL PDO as a database adapter (listed as first option in Dev/Install/config-form.html)
 DatabaseAdapterRegistry::register(
 	array(
 		/** @skipUpgrade */
@@ -35,4 +20,20 @@ DatabaseAdapterRegistry::register(
 			the <a href="http://www.php.net/manual/en/ref.pdo-mysql.php">MySQL PDO Driver</a>
 			are unavailable. Please install or enable these and refresh this page.'
 	)
+);
+
+// Register MySQLi as a database adapter (listed as second option in Dev/Install/config-form.html)
+DatabaseAdapterRegistry::register(
+    array(
+        /** @skipUpgrade */
+        'class' => 'MySQLDatabase',
+        'module' => 'framework',
+        'title' => 'MySQL 5.0+ (using MySQLi)',
+        'helperPath' => __DIR__ . '/src/Dev/Install/MySQLDatabaseConfigurationHelper.php',
+        'helperClass' => MySQLDatabaseConfigurationHelper::class,
+        'supported' => class_exists('MySQLi'),
+        'missingExtensionText' =>
+            'The <a href="http://www.php.net/manual/en/book.mysqli.php">MySQLi</a>
+			PHP extension is not available. Please install or enable it and refresh this page.'
+    )
 );

--- a/src/Dev/Install/config-form.html
+++ b/src/Dev/Install/config-form.html
@@ -183,13 +183,14 @@
 
 									</div>
 
-									<div class="action">
-										<input type="submit" class="action" value="Re-check requirements">
-									</div>
 								</div>
 							</div>
 
 							<div class="clear"><!-- --></div>
+
+							<div class="action">
+								<input type="submit" class="action" value="Re-check requirements">
+							</div>
 
 							<h3 class="sectionHeading">CMS Admin Account <small>Step 3 of 5</small></h3>
 
@@ -238,6 +239,10 @@
 									</div>
 									<div class="clear"><!-- --></div>
 								</div>
+							</div>
+
+							<div class="action">
+								<input type="submit" class="action" value="Re-check requirements">
 							</div>
 
 							<h3 class="sectionHeading">Theme selection <small>Step 4 of 5</small></h3>

--- a/src/Dev/Install/install.php5
+++ b/src/Dev/Install/install.php5
@@ -142,8 +142,16 @@ if(isset($_REQUEST['db'])) {
 	if(isset($_REQUEST['db']['type'])) {
 		$type = $_REQUEST['db']['type'];
 	} else {
-		$type = $_REQUEST['db']['type'] = defined('SS_DATABASE_CLASS') ? SS_DATABASE_CLASS : 'MySQLDatabase';
-	}
+        if( defined('SS_DATABASE_CLASS') ){
+            $type = $_REQUEST['db']['type'] = SS_DATABASE_CLASS;
+        } elseif( $databaseClasses['MySQLPDODatabase']['supported'] ) {
+            $type = $_REQUEST['db']['type'] = 'MySQLPDODatabase';
+        } elseif( $databaseClasses['MySQLDatabase']['supported'] ) {
+            $type = $_REQUEST['db']['type'] = 'MySQLDatabase';
+        } else {
+            // handle error
+        }
+    }
 
 	// Disabled inputs don't submit anything - we need to use the environment (except the database name)
 	if($usingEnv) {
@@ -161,7 +169,15 @@ if(isset($_REQUEST['db'])) {
 		$databaseConfig['type'] = $type;
 	}
 } else {
-	$type = $_REQUEST['db']['type'] = defined('SS_DATABASE_CLASS') ? SS_DATABASE_CLASS : 'MySQLDatabase';
+    if( defined('SS_DATABASE_CLASS') ){
+        $type = $_REQUEST['db']['type'] = SS_DATABASE_CLASS;
+    } elseif( $databaseClasses['MySQLPDODatabase']['supported'] ) {
+        $type = $_REQUEST['db']['type'] = 'MySQLPDODatabase';
+    } elseif( $databaseClasses['MySQLDatabase']['supported'] ) {
+        $type = $_REQUEST['db']['type'] = 'MySQLDatabase';
+    } else {
+        // handle error
+    }
 	$_REQUEST['db'][$type] = $databaseConfig = array(
 		"type" => $type,
 		"server" => defined('SS_DATABASE_SERVER') ? SS_DATABASE_SERVER : "localhost",


### PR DESCRIPTION
Following up on https://github.com/silverstripe/silverstripe-framework/pull/6230.

I also added "Re-check requirements" button to CMS Admin Account section of `config-form.html`.

This solution works but is not all that satisfactory to me. There is repetition and I don't know how the error is best handled. More generally, the code between lines 140 and 188 seems awkward. 