### PR TITLE
FIX UploadField incorrectly setting max upload size

### DIFF
--- a/forms/UploadField.php
+++ b/forms/UploadField.php
@@ -220,11 +220,6 @@ class UploadField extends FileField {
 		$this->getValidator()->setAllowedExtensions(
 			array_filter(Config::inst()->get('File', 'allowed_extensions'))
 		);
-
-		// get the lower max size
-		$maxUpload = File::ini2bytes(ini_get('upload_max_filesize'));
-		$maxPost = File::ini2bytes(ini_get('post_max_size'));
-		$this->getValidator()->setAllowedMaxFileSize(min($maxUpload, $maxPost));
 	}
 
 	/**


### PR DESCRIPTION
Fixed #6286 

`UploadField` is capable of looking up the max upload size itself rather than needing it to be set on `__construct`.