### PR TITLE
BUGFIX: Fixed crash when BASE_PATH is set by assuming the location of Constants.php

### DIFF
--- a/src/Core/Constants.php
+++ b/src/Core/Constants.php
@@ -188,10 +188,10 @@ if(!defined('BASE_PATH')) {
 	}
 }
 
-// Determine BASE_PATH by assuming that this file is framework/core/Core.php
+// Determine BASE_PATH by assuming that this file is framework/src/Core/Constants.php
 if(!defined('BASE_PATH')) {
 	//  we can then determine the base path
-	$candidateBasePath = rtrim(dirname(dirname(dirname(__FILE__))), DIRECTORY_SEPARATOR);
+	$candidateBasePath = rtrim(dirname(dirname(dirname(dirname(__FILE__)))), DIRECTORY_SEPARATOR);
 	// We can't have an empty BASE_PATH.  Making it / means that double-slashes occur in places but that's benign.
 	// This likely only happens on chrooted environemnts
 	if($candidateBasePath == '') $candidateBasePath = DIRECTORY_SEPARATOR;


### PR DESCRIPTION
This pull fixes a crash when BASE_PATH is set by assuming the location of Constants.php, this appears to have been inadvertently caused by 7a10c194bdd751f74669c07836befecc1fde400e it wasn't taking into account the fact that the path now contains the src folder. Noticed in SilverStripe 4 Alpha 3.