### PR TITLE
Safari layout bugs for page actions toolbar and menu toggle area

### DIFF
--- a/admin/client/dist/styles/bundle.css
+++ b/admin/client/dist/styles/bundle.css
@@ -12044,10 +12044,6 @@ li.class-ErrorPage>a .jstree-pageicon{
   display:none;
 }
 
-.cms-menu.collapsed.cms-panel .cms-panel-content{
-  display:block;
-}
-
 .cms-menu.collapsed .cms-menu-list li a{
   padding-left:18px;
   padding-right:18px;
@@ -12062,6 +12058,7 @@ li.class-ErrorPage>a .jstree-pageicon{
   height:53px;
   background-color:#e9f0f4;
   box-shadow:inset -1px 0 0 #c1c7cc;
+  position:relative;
 }
 
 .cms-menu .cms-panel-toggle a,.cms-menu .cms-panel-toggle a.toggle-expand{

--- a/admin/client/src/styles/legacy/_menu.scss
+++ b/admin/client/src/styles/legacy/_menu.scss
@@ -149,10 +149,6 @@
 			}
 		}
 
-		&.cms-panel .cms-panel-content {
-			display: block; // override panel defaults
-		}
-
 		.cms-menu-list li a {
 			padding-left: 18px;
 			padding-right: 18px;
@@ -168,6 +164,7 @@
 		height: $toolbar-total-height;
 		background-color: $color-theme-bg;
 		box-shadow: inset $color-separator -1px 0 0;
+		position: relative;
 
 		a,
 		a.toggle-expand {

--- a/admin/templates/SilverStripe/Admin/Includes/LeftAndMain_Menu.ss
+++ b/admin/templates/SilverStripe/Admin/Includes/LeftAndMain_Menu.ss
@@ -1,10 +1,10 @@
-<div class="cms-menu cms-panel cms-panel-layout" id="cms-menu" data-layout-type="border">
-	<div class="cms-logo-header north">
+<div class="fill-height cms-menu cms-panel cms-panel-layout" id="cms-menu" data-layout-type="border">
+	<div class="cms-logo-header">
 		<% include SilverStripe\\Admin\\LeftAndMain_MenuLogo %>
 		<% include SilverStripe\\Admin\\LeftAndMain_MenuStatus %>
 	</div>
 
-	<div class="panel--scrollable panel--triple-toolbar cms-panel-content">
+	<div class="flexbox-area-grow panel--scrollable panel--triple-toolbar cms-panel-content">
 		<% include SilverStripe\\Admin\\LeftAndMain_MenuList %>
 	</div>
 

--- a/admin/templates/SilverStripe/Admin/Includes/LeftAndMain_MenuToggle.ss
+++ b/admin/templates/SilverStripe/Admin/Includes/LeftAndMain_MenuToggle.ss
@@ -1,4 +1,4 @@
 <button class="sticky-toggle" type="button" title="Sticky nav">Sticky nav</button>
-<span class="sticky-status-indicator">auto</span>
+<span class="sticky-status-indicator">Auto</span>
 <a class="toggle-expand" href="#"><span>&raquo;</span></a>
 <a class="toggle-collapse" href="#"><span>&laquo;</span></a>


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-cms/issues/1674
Fixes https://github.com/silverstripe/silverstripe-cms/issues/1676
Requires https://github.com/silverstripe/silverstripe-cms/pull/1679/files

Added flexbox layout to menu to fix the safari issue. 

Tested on Safari, Firefox, IE10, Chrome