### PR TITLE
Mark password fields as required if canBeEmpty is false

### DIFF
--- a/forms/ConfirmedPasswordField.php
+++ b/forms/ConfirmedPasswordField.php
@@ -166,6 +166,9 @@ class ConfirmedPasswordField extends FormField {
 			/** @var FormField $field */
 			$field->setDisabled($this->isDisabled());
 			$field->setReadonly($this->isReadonly());
+			if(!$this->canBeEmpty && $field->getAttribute('required') === null){
+				$field->setAttribute('required', true);
+			}
 
 			if(count($this->attributes)) {
 				foreach($this->attributes as $name => $value) {


### PR DESCRIPTION
Because submitting the form to get told it's required is annoying when say the FirstName field told you straight away!

I'm still annoyed that we can't just chuck "Password" in a RequiredFields validator though...