### PR TITLE
FIX: Correct return type for Member::currentUser()

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -837,9 +837,8 @@ class Member extends DataObject implements TemplateGlobalProvider {
 		$id = Member::currentUserID();
 
 		if($id) {
-			return DataObject::get_by_id('Member', $id);
+			return DataObject::get_by_id('Member', $id) ?: null;
 		}
-		return null;
 	}
 
 	/**

--- a/tests/security/MemberTest.php
+++ b/tests/security/MemberTest.php
@@ -1041,6 +1041,16 @@ class MemberTest extends FunctionalTest {
 		$this->assertTrue($fail, 'Passes with email and surname now (no firstname)');
 	}
 
+	public function testCurrentUser() {
+		$this->assertNull(Member::currentUser());
+
+		$adminMember = $this->objFromFixture('Member', 'admin');
+		$this->logInAs($adminMember);
+
+		$userFromSession = Member::currentUser();
+		$this->assertEquals($adminMember->ID, $userFromSession->ID);
+	}
+
 }
 
 /**


### PR DESCRIPTION
See [this comment](https://github.com/silverstripe/silverstripe-framework/commit/995d07756d0b7aeef611d61fe3a31663b70e4c51#commitcomment-19754518).