### PR TITLE
Update CheckboxSetField validate function

### DIFF
--- a/forms/CheckboxSetField.php
+++ b/forms/CheckboxSetField.php
@@ -328,40 +328,46 @@ class CheckboxSetField extends OptionsetField {
 	 * @return bool
 	 */
 	public function validate($validator) {
-		$values = $this->value;
-		if (!$values) {
-			return true;
-		}
-		$sourceArray = $this->getSourceAsArray();
-		$validValues = array_keys($sourceArray);
-		if (is_array($values)) {
-			if (!array_intersect($validValues, $values)) {
-				$validator->validationError(
-					$this->name,
-					_t(
-						'CheckboxSetField.SOURCE_VALIDATION',
-						"Please select a value within the list provided. '{value}' is not a valid option",
-						array('value' => implode(' and ', $values))
-					),
-					"validation"
-				);
-				return false;
-			}
-		} else {
-			if (!in_array($this->value, $validValues)) {
-				$validator->validationError(
-					$this->name,
-					_t(
-						'CheckboxSetField.SOURCE_VALIDATION',
-						"Please select a value within the list provided. '{value}' is not a valid option",
-						array('value' => $this->value)
-					),
-					"validation"
-				);
-				return false;
-			}
-		}
-		return true;
-	}
+        $values = $this->value;
+        if (!$values) {
+            return true;
+        }
+
+        $tempValues = explode(',', $values);
+        if(count($tempValues) > 1){
+            $values = $tempValues;
+        }
+
+        $sourceArray = $this->getSourceAsArray();
+        $validValues = array_keys($sourceArray);
+        if (is_array($values)) {
+            if (!array_intersect($validValues, $values)) {
+                $validator->validationError(
+                    $this->name,
+                    _t(
+                        'CheckboxSetField.SOURCE_VALIDATION',
+                        "Please select a value within the list provided. '{value}' is not a valid option",
+                        array('value' => implode(' and ', $values))
+                    ),
+                    "validation"
+                );
+                return false;
+            }
+        } else {
+            if (!in_array($this->value, $validValues)) {
+                $validator->validationError(
+                    $this->name,
+                    _t(
+                        'CheckboxSetField.SOURCE_VALIDATION',
+                        "Please select a value within the list provided. '{value}' is not a valid option",
+                        array('value' => $this->value)
+                    ),
+                    "validation"
+                );
+                return false;
+            }
+        }
+        return true;
+    }
 
 }


### PR DESCRIPTION
I have noticed that if user tick more than one checkbox in the CheckboxSetField, then the validation will always fail. After debugging, it is apparent that $this->value return from the CheckboxSetField is always a string, never an array. Therefore when user tick more than one checkboxes, the validation will always fail at 

if (!in_array($this->value, $validValues)) {
    ...
}

$this->value is now comma separated value. In my case, string(23) "TV,Online,Word of mouth".

Thank you for your time. 
Ben