### PR TITLE
[Minor] Split finding the member and authenticating the password

### DIFF
--- a/src/Security/MemberAuthenticator.php
+++ b/src/Security/MemberAuthenticator.php
@@ -27,6 +27,74 @@ class MemberAuthenticator extends Authenticator {
 		'sha1' => 'sha1_v2.4'
 	);
 
+    /**
+     * @param array $data
+     * @return array(Member|null, boolean)
+     */
+    protected static function find_authentication_member($data)
+    {
+
+        // Attempt to identify by temporary ID
+        $member = null;
+        $email = null;
+
+        if(!empty($data['tempid'])) {
+            // Find user by tempid, in case they are re-validating an existing session
+            $member = Member::member_from_tempid($data['tempid']);
+            if($member) {
+                $email = $member->Email;
+            }
+        }
+
+        // Otherwise, get email from posted value instead
+        /** @skipUpgrade */
+        if(!$member && !empty($data['Email'])) {
+            $email = $data['Email'];
+        }
+
+        // Check default login (see Security::setDefaultAdmin())
+        $asDefaultAdmin = $email === Security::default_admin_username();
+        if($asDefaultAdmin) {
+            // If logging is as default admin, ensure record is setup correctly
+            $member = Member::default_admin();
+        }
+
+        // Attempt to identify user by email
+        if(!$member && $email) {
+            // Find user by email
+            $member = Member::get()
+                ->filter(Member::config()->unique_identifier_field, $email)
+                ->first();
+        }
+        return array($member, $asDefaultAdmin);
+    }
+
+    /**
+     * @param array $data
+     * @param Member $member
+     * @param boolean $asDefaultAdmin
+     * @return Member|bool
+     */
+    protected static function authenticate_member_password($data, $member, $asDefaultAdmin)
+    {
+        $email = $data['Email'];
+        if($asDefaultAdmin) {
+            $success = !$member->isLockedOut() && Security::check_default_admin($email, $data['Password']);
+            //protect against failed login
+            if ($success) {
+                return true;
+            }
+        }
+
+        // Validate against member if possible
+        if($member && !$asDefaultAdmin) {
+            $result = $member->checkPassword($data['Password']);
+            return $result->valid();
+        }
+
+        return false;
+    }
+
 	/**
 	 * Attempt to find and authenticate member if possible from the given data
 	 *
@@ -38,54 +106,14 @@ class MemberAuthenticator extends Authenticator {
 	protected static function authenticate_member($data, $form, &$success) {
 		// Default success to false
 		$success = false;
-
-		// Attempt to identify by temporary ID
-		$member = null;
-		$email = null;
-		if(!empty($data['tempid'])) {
-			// Find user by tempid, in case they are re-validating an existing session
-			$member = Member::member_from_tempid($data['tempid']);
-			if($member) $email = $member->Email;
-		}
-
-		// Otherwise, get email from posted value instead
-		/** @skipUpgrade */
-		if(!$member && !empty($data['Email'])) {
-			$email = $data['Email'];
-		}
-
-		// Check default login (see Security::setDefaultAdmin())
-		$asDefaultAdmin = $email === Security::default_admin_username();
-		if($asDefaultAdmin) {
-			// If logging is as default admin, ensure record is setup correctly
-			$member = Member::default_admin();
-			$success = !$member->isLockedOut() && Security::check_default_admin($email, $data['Password']);
-			//protect against failed login
-			if($success) {
-				return $member;
-			}
-		}
-
-		// Attempt to identify user by email
-		if(!$member && $email) {
-			// Find user by email
-			$member = Member::get()
-				->filter(Member::config()->unique_identifier_field, $email)
-				->first();
-		}
-
-		// Validate against member if possible
-		if($member && !$asDefaultAdmin) {
-			$result = $member->checkPassword($data['Password']);
-			$success = $result->valid();
-		} else {
-			$result = new ValidationResult(false, _t('Member.ERRORWRONGCRED'));
-		}
+        /** @var Member $member */
+        list($member, $asDefaultAdmin) = static::find_authentication_member($data);
+        $success = static::authenticate_member_password($data, $member, $asDefaultAdmin);
 
 		// Emit failure to member and form (if available)
 		if(!$success) {
 			if($member) $member->registerFailedLogin();
-			if($form) $form->sessionMessage($result->message(), 'bad');
+			if($form) $form->sessionMessage(_t('Member.ERRORWRONGCRED'), 'bad');
 		} else {
 			if($member) $member->registerSuccessfulLogin();
 		}


### PR DESCRIPTION
This makes extending the Authentication from the MemberAuthenticator easier, for example if you do want SilverStripe to use the member, but want to validate the password against a different database.

The original authentication is unaffected and still works the same way. It's an implementation with "as few implications as possible"

There are obviously better methods, but this is a first step towards helping MFA modules bypass the SilverStripe authentication with their own. 