### PR TITLE
Replace hard-coded directory separators constant

### DIFF
--- a/core/manifest/ManifestCache.php
+++ b/core/manifest/ManifestCache.php
@@ -21,22 +21,22 @@ interface ManifestCache {
  */
 class ManifestCache_File implements ManifestCache {
 	function __construct($name) {
-		$this->folder = TEMP_FOLDER.'/'.$name;
+		$this->folder = TEMP_FOLDER.DIRECTORY_SEPARATOR.$name;
 		if (!is_dir($this->folder)) mkdir($this->folder);
 	}
 
 	function load($key) {
-		$file = $this->folder.'/cache_'.$key;
+		$file = $this->folder.DIRECTORY_SEPARATOR.'cache_'.$key;
 		return file_exists($file) ? unserialize(file_get_contents($file)) : null;
 	}
 
 	function save($data, $key) {
-		$file = $this->folder.'/cache_'.$key;
+		$file = $this->folder.DIRECTORY_SEPARATOR.'cache_'.$key;
 		file_put_contents($file, serialize($data));
 	}
 
 	function clear() {
-		array_map('unlink', glob($this->folder.'/cache_*'));
+		array_map('unlink', glob($this->folder.DIRECTORY_SEPARATOR.'cache_*'));
 	}
 }
 
@@ -52,14 +52,14 @@ class ManifestCache_File_PHP extends ManifestCache_File {
 		global $loaded_manifest;
 		$loaded_manifest = null;
 
-		$file = $this->folder.'/cache_'.$key;
+		$file = $this->folder.DIRECTORY_SEPARATOR.'cache_'.$key;
 		if (file_exists($file)) include $file;
 
 		return $loaded_manifest;
 	}
 
 	function save($data, $key) {
-		$file = $this->folder.'/cache_'.$key;
+		$file = $this->folder.DIRECTORY_SEPARATOR.'cache_'.$key;
 		file_put_contents($file, '<?php $loaded_manifest = '.var_export($data, true).';');
 	}
 }


### PR DESCRIPTION
This removes warnings when building the manifest cache in Windows environments.