### PR TITLE
Replace hard-coded directory separators constant

### DIFF
--- a/src/Core/Manifest/ManifestCache_File.php
+++ b/src/Core/Manifest/ManifestCache_File.php
@@ -12,7 +12,7 @@ class ManifestCache_File implements ManifestCache
 
 	function __construct($name)
 	{
-		$this->folder = TEMP_FOLDER . '/' . $name;
+		$this->folder = TEMP_FOLDER . DIRECTORY_SEPARATOR . $name;
 		if (!is_dir($this->folder)) {
 			mkdir($this->folder);
 		}
@@ -20,18 +20,18 @@ class ManifestCache_File implements ManifestCache
 
 	function load($key)
 	{
-		$file = $this->folder . '/cache_' . $key;
+		$file = $this->folder . DIRECTORY_SEPARATOR . 'cache_' . $key;
 		return file_exists($file) ? unserialize(file_get_contents($file)) : null;
 	}
 
 	function save($data, $key)
 	{
-		$file = $this->folder . '/cache_' . $key;
+		$file = $this->folder . DIRECTORY_SEPARATOR . 'cache_' . $key;
 		file_put_contents($file, serialize($data));
 	}
 
 	function clear()
 	{
-		array_map('unlink', glob($this->folder . '/cache_*'));
+		array_map('unlink', glob($this->folder . DIRECTORY_SEPARATOR . 'cache_*'));
 	}
 }


### PR DESCRIPTION
This removes warnings when building the manifest cache in Windows environments.