### PR TITLE
BUGFIX: Fixed issue where a shortcode's location would not get set to split when using the class leftAlone

### DIFF
--- a/parsers/ShortcodeParser.php
+++ b/parsers/ShortcodeParser.php
@@ -572,7 +572,7 @@ class ShortcodeParser extends Object {
 			
 			$location = self::INLINE;
 			if($class == 'left' || $class == 'right') $location = self::BEFORE;
-			if($class == 'center' || $class == 'leftALone') $location = self::SPLIT;
+			if($class == 'center' || $class == 'leftAlone') $location = self::SPLIT;
 
 			if(!$parent) {
 				if($location !== self::INLINE) {


### PR DESCRIPTION
In 3.1 to 3.4 at least when using the class or the location ``leftAlone`` in a shortcode the location does not get set to split. Which causes the html tag to not get split up correctly, this is simply caused by the wrong case being used in the check for leftAlone, the check is looking for ``leftALone`` instead.