### PR TITLE
FIX: File::find() should respect case-sensitive filesystems properly

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -247,7 +247,7 @@ class File extends DataObject {
 		foreach($parts as $part) {
 			if($part == ASSETS_DIR && !$parentID) continue;
 			$item = File::get()->filter(array(
-				'Name' => $part,
+				'Name:ExactMatch:case' => $part,
 				'ParentID' => $parentID
 			))->first();
 			if(!$item) break;

--- a/tests/filesystem/FileTest.php
+++ b/tests/filesystem/FileTest.php
@@ -276,6 +276,19 @@ class FileTest extends SapphireTest {
 		$this->assertEquals("93132.3 GB", File::format_size(100000000000000));
 	}
 
+	/**
+	 * @covers File::find()
+	 */
+	public function testFind() {
+		$file1 = $this->objFromFixture('File', 'lowercase');
+		$file2 = $this->objFromFixture('File', 'uppercase');
+		$errorMsg = 'File::find() is not finding files in a case-sensitive manner';
+
+		$this->assertSame($file2->ID, File::find($file2->Filename)->ID, $errorMsg);
+		$this->assertSame($file1->ID, File::find($file1->Filename)->ID, $errorMsg);
+
+	}
+
 	public function testDeleteDatabaseOnly() {
 		$file = $this->objFromFixture('File', 'asdf');
 		$fileID = $file->ID;

--- a/tests/filesystem/FileTest.yml
+++ b/tests/filesystem/FileTest.yml
@@ -30,6 +30,14 @@ File:
     Filename: assets/FileTest-folder1/File1.txt
     Name: File1.txt
     ParentID: =>Folder.folder1
+  lowercase:
+    Filename: assets/FileTest-folder1/casetest.txt
+    Name: casetest.txt
+    ParentID: =>Folder.folder1
+  uppercase:
+    Filename: assets/FileTest-folder1/Casetest.TXT
+    Name: Casetest.TXT
+    ParentID: =>Folder.folder1
 Permission:
   admin:
     Code: ADMIN

--- a/tests/filesystem/FolderTest.php
+++ b/tests/filesystem/FolderTest.php
@@ -26,7 +26,7 @@ class FolderTest extends SapphireTest {
 		$file1 = $this->objFromFixture('File', 'file1-folder1');
 
 		$children = $folder1->allChildren();
-		$this->assertEquals(2, $children->Count());
+		$this->assertEquals(4, $children->Count());
 		$this->assertContains($subfolder1->ID, $children->column('ID'));
 		$this->assertContains($file1->ID, $children->column('ID'));
 	}


### PR DESCRIPTION
Prior to this fix, if you two files with the same case-insensitive filename (e.g. test.jpg and test.JPG), these would be stored correctly on the filesystem and in the database, but when `File::find('test.JPG')` was called, it would return the first matching `File` object, which might point at test.jpg instead of test.JPG.

`File::find()` now properly respects case-sensitive filesystems. This change does mean that you can't search the database in a case-insensitive manner for files, but I can't see a good use-case for this, even of case-insensitive filesystems.