### PR TITLE
Temp patch to 5987 to prevent cms crashing

### DIFF
--- a/src/View/Parsers/ShortcodeParser.php
+++ b/src/View/Parsers/ShortcodeParser.php
@@ -689,12 +689,15 @@ class ShortcodeParser extends Object
                 }
 
                 $location = self::INLINE;
+                /**
+                 * Below code disabled due to https://github.com/silverstripe/silverstripe-framework/issues/5987
                 if ($class == 'left' || $class == 'right') {
                     $location = self::BEFORE;
                 }
                 if ($class == 'center' || $class == 'leftAlone') {
                     $location = self::SPLIT;
                 }
+                 */
 
                 if (!$parent) {
                     if ($location !== self::INLINE) {

--- a/tests/php/View/Parsers/ShortcodeParserTest.php
+++ b/tests/php/View/Parsers/ShortcodeParserTest.php
@@ -188,6 +188,9 @@ class ShortcodeParserTest extends SapphireTest {
 	}
 
 	public function testtExtract() {
+		$this->markTestSkipped(
+			'Feature disabled due to https://github.com/silverstripe/silverstripe-framework/issues/5987'
+		);
 		// Left extracts to before the current block
 		$this->assertEqualsIgnoringWhitespace(
 			'Code<div>FooBar</div>',


### PR DESCRIPTION
A temp fix for https://github.com/silverstripe/silverstripe-framework/issues/5987

This fix is now critical due to current breakages in CI. We believe this is due to https://github.com/silverstripe/silverstripe-framework/pull/6335 being merged up to master.