### PR TITLE
Update Versioned.php

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -607,7 +607,7 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 				$data = array_intersect_key($data, $fields);
 
 				foreach ($data as $k => $v) {
-					if (!isset($newManipulation['fields'][$k])) {
+					if (!array_key_exists($k, $newManipulation['fields'])) {
 						$newManipulation['fields'][$k] = $v;
 					}
 				}


### PR DESCRIPTION
Change isset() to array_key_exists(). In the CMS, if you have a FormField such as 'My value', then you change it to '' (blank), isset() will return false because even though the key exists, the value === null by the time it reaches this point in the code, and isset() return false on null values. array_key_exists will return true with a null value

All FormFields with a blank value such as empty string get converted to null in DBField.php in the function writeToManipulation()