### PR TITLE
FIX hard-coded boolean in CsvBulkLoader (fixes #6363)

### DIFF
--- a/dev/CsvBulkLoader.php
+++ b/dev/CsvBulkLoader.php
@@ -70,7 +70,7 @@ class CsvBulkLoader extends BulkLoader {
 			foreach ($files as $file) {
 				$last = $file;
 
-				$next = $this->processChunk($file, false);
+				$next = $this->processChunk($file, $preview);
 
 				if ($result instanceof BulkLoader_Result) {
 					$result->merge($next);


### PR DESCRIPTION
* replaced hard-coded boolean in `processAll` with `$preview` argument