### PR TITLE
Add doc blocks for the $request given to BuildTasks

### DIFF
--- a/dev/BuildTask.php
+++ b/dev/BuildTask.php
@@ -33,9 +33,14 @@ abstract class BuildTask extends Object {
 	/**
  	 * Implement this method in the task subclass to
 	 * execute via the TaskRunner
+	 *
+	 * @param SS_HTTPRequest $request
 	 */
 	abstract public function run($request);
 
+	/**
+	 * @return bool
+	 */
 	public function isEnabled() {
 		return $this->enabled;
 	}
@@ -55,5 +60,3 @@ abstract class BuildTask extends Object {
 	}
 
 }
-
-

--- a/dev/TaskRunner.php
+++ b/dev/TaskRunner.php
@@ -59,6 +59,10 @@ class TaskRunner extends Controller {
 		}
 	}
 
+	/**
+	 * Runs a BuildTask
+	 * @param SS_HTTPRequest $request
+	 */
 	public function runTask($request) {
 		$name = $request->param('TaskName');
 		$tasks = $this->getTasks();
@@ -73,7 +77,7 @@ class TaskRunner extends Controller {
 
 		foreach ($tasks as $task) {
 			if ($task['segment'] == $name) {
-				$inst = Injector::inst()->create($task['class']);
+				$inst = Injector::inst()->create($task['class']); /** @var BuildTask $inst */
 				$title(sprintf('Running Task %s', $inst->getTitle()));
 
 				if (!$inst->isEnabled()) {


### PR DESCRIPTION
Allows BuildTask developers to know what the $request is, and outline BuildTask instances.