### PR TITLE
Clarify UK-english in coding conventions

### DIFF
--- a/docs/en/05_Contributing/12_JavaScript_Coding_Conventions.md
+++ b/docs/en/05_Contributing/12_JavaScript_Coding_Conventions.md
@@ -21,6 +21,11 @@ as well as the [AirBnB React Conventions](https://github.com/airbnb/javascript/t
 A lot of their rules can be validated via [ESLint](http://eslint.org/),
 and can be checked locally via `npm run lint`.
 
+## Spelling
+
+All symbols and documentation should use UK-English spelling (e.g. "behaviour" instead of "behavior"),
+except when necessitated by third party conventions (e.g using "color" for CSS styles).
+
 ## File and Folder Naming
 
 - All frontend files (CSS, JavaScript, images) should be placed in

--- a/docs/en/05_Contributing/14_PHP_Coding_Conventions.md
+++ b/docs/en/05_Contributing/14_PHP_Coding_Conventions.md
@@ -34,6 +34,11 @@ linefeed combination (CRLF) as is standard for the Windows OS (0x0D, 0x0A).
 
 Class, function, variable and constant names may only contain alphanumeric characters and underscores.
 
+## Spelling
+
+All symbols and documentation should use UK-English spelling (e.g. "behaviour" instead of "behavior"),
+except when necessitated by third party conventions (e.g using PHP's `Serializable` interface).
+
 ### Classes
 
 Class and filenames are in `UpperCamelCase` format:


### PR DESCRIPTION
Discussed with @tractorcow - we're mostly using NZ spelling already, e.g. `ViewableData->customise()` and `CLI::supports_colour()`. It's not entirely consistent (e.g. `ShortcodeParser::$error_behavior` is US spelling)

https://docs.silverstripe.org/en/4/contributing/documentation already contains this:

> Use UK English and not US English. SilverStripe is proudly a New Zealand open source project we use the UK spelling and forms of English. The most common of these differences are -ize vs -ise, or -or vs our (eg color vs colour).