### PR TITLE
Outputting the Exception message too

### DIFF
--- a/src/Dev/CsvBulkLoader.php
+++ b/src/Dev/CsvBulkLoader.php
@@ -88,7 +88,7 @@ class CsvBulkLoader extends BulkLoader
                 @unlink($file);
             }
         } catch (Exception $e) {
-            print "Failed to parse {$last}\n";
+            printf("Failed to parse %s because %s\n", $last, $e->getMessage());
         }
 
         return $result;


### PR DESCRIPTION
I just encountered a problem with this bit of code that forced me to edit the framework to see why my Import failed. I think by adding the exception message will help developers in the future. My problem was that the custom loader had a bad definition so it throw an error like this

```
Error at framework/model/DataObject.php line 1570: Uncaught Exception: DataObject->getComponent(): Could not find component 'Tags'.
```

There also seems to be no tests based around this so it looks like it could fail for any number of reasons. Maybe in updating this the tests should then include testing when it should throw an Exception?

I think this could also be done in 3.x too just to give a better output