### PR TITLE
NEW: Added ImagickBackend::crop() for compatibility with GDBackend

### DIFF
--- a/filesystem/ImagickBackend.php
+++ b/filesystem/ImagickBackend.php
@@ -265,6 +265,21 @@ class ImagickBackend extends Imagick implements Image_Backend {
 		$new->ThumbnailImage($width,$height,true);
 		return $new;
 	}
+	
+	/**
+	 * Crop's part of image.
+	 * @param int $top y position of left upper corner of crop rectangle
+	 * @param int $left x position of left upper corner of crop rectangle
+	 * @param int $width rectangle width
+	 * @param int $height rectangle height
+	 * @return Image_Backend
+	 */
+	public function crop($top, $left, $width, $height) {
+		$new = clone $this;
+		$new->cropImage($width, $height, $left, $top);
+		
+		return $new;
+	}
 
 	/**
 	 * @param Image $frontend


### PR DESCRIPTION
This pull request adds the crop method to ImagickBackend for compatibility with GDBackend, this was suggested to be added to the core in jonom/silverstripe-focuspoint#37. I've based this pull off of the 3 branch, I do have a [branch here](https://github.com/webbuilders-group/silverstripe-framework/tree/image-backend-crop) that is compatible with master but also adds the crop method stub to the interface Image_Backend. I can open a pull against master as well if it's desired.