### PR TITLE
NEW: Image_Backend now includes a crop method stub for compatibility with GDBackend

### DIFF
--- a/src/Assets/Image_Backend.php
+++ b/src/Assets/Image_Backend.php
@@ -131,4 +131,14 @@ interface Image_Backend
      * @return static
      */
     public function croppedResize($width, $height);
+    
+    /**
+     * Crop's part of image.
+     * @param int $top y position of left upper corner of crop rectangle
+     * @param int $left x position of left upper corner of crop rectangle
+     * @param int $width rectangle width
+     * @param int $height rectangle height
+     * @return Image_Backend
+     */
+    public function crop($top, $left, $width, $height);
 }

--- a/src/Assets/ImagickBackend.php
+++ b/src/Assets/ImagickBackend.php
@@ -257,4 +257,20 @@ class ImagickBackend extends Imagick implements Image_Backend
         $new->thumbnailImage($width, $height, true);
         return $new;
     }
+    
+    /**
+     * Crop's part of image.
+     * @param int $top y position of left upper corner of crop rectangle
+     * @param int $left x position of left upper corner of crop rectangle
+     * @param int $width rectangle width
+     * @param int $height rectangle height
+     * @return Image_Backend
+     */
+    public function crop($top, $left, $width, $height)
+    {
+        $new = clone $this;
+        $new->cropImage($width, $height, $left, $top);
+        
+        return $new;
+    }
 }


### PR DESCRIPTION
Per #6393 This adds the crop method stub to Image_Backend however it also does what the #6393's pull did and adds the crop method to ImagickBackend. I can adjust to remove the method from this pull if it makes the merge easier ;). But it will break ImagickBackend on master until 3 is merged.