### PR TITLE
remove FRAMEWORK_PATH and namespace IPUtils

### DIFF
--- a/core/Constants.php
+++ b/core/Constants.php
@@ -106,9 +106,9 @@ if(!defined('TRUSTED_PROXY')) {
 				$trusted = true;
 			} elseif(isset($_SERVER['REMOTE_ADDR'])) {
 				if(!class_exists('SilverStripe\\Control\\Util\\IPUtils')) {
-					require_once FRAMEWORK_PATH . '/control/IPUtils.php';
+					require_once 'control/IPUtils.php';
 				};
-				$trusted = IPUtils::checkIP($_SERVER['REMOTE_ADDR'], explode(',', SS_TRUSTED_PROXY_IPS));
+				$trusted = SilverStripe\Control\Util\IPUtils::checkIP($_SERVER['REMOTE_ADDR'], explode(',', SS_TRUSTED_PROXY_IPS));
 			}
 		}
 	}


### PR DESCRIPTION
On a non-optimised composer update (i.e. not composer update -o), if you have SS_TRUSTED_PROXY_IPS defined, your site will break on two errors:

a) FRAMEWORK_PATH not defined
b) Couldn't find class IPUtils

These are both remedied in this commit.

Backport from #6395 