### PR TITLE
BUG Suppress HTMLEditorField casting

### DIFF
--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -26,14 +26,6 @@ class HtmlEditorField extends TextareaField {
 	 */
 	private static $sanitise_server_side = false;
 
-	/**
-	 * @config
-	 * @var array
-	 */
-	private static $casting = array(
-		'Value' => 'HTMLText',
-	);
-
 	protected $rows = 30;
 
 	/**

--- a/forms/TextareaField.php
+++ b/forms/TextareaField.php
@@ -20,7 +20,7 @@
 class TextareaField extends FormField {
 
 	private static $casting = array(
-		'Value' => 'HTMLText',
+		'Value' => 'HTMLText(array("shortcodes" => 0))',
 	);
 
 	/**

--- a/tests/forms/HtmlEditorFieldTest.php
+++ b/tests/forms/HtmlEditorFieldTest.php
@@ -15,6 +15,20 @@ class HtmlEditorFieldTest extends FunctionalTest {
 
 	protected $extraDataObjects = array('HtmlEditorFieldTest_Object');
 
+	public function testCasting() {
+		// Test special characters
+		$inputText = "These are some unicodes: ä, ö, & ü";
+		$field = new HTMLEditorField("Test", "Test");
+		$field->setValue($inputText);
+		$this->assertContains('These are some unicodes: &auml;, &ouml;, &amp; &uuml;', $field->Field());
+
+		// Test shortcodes
+		$inputText = "Shortcode: [file_link id=4]";
+		$field = new HTMLEditorField("Test", "Test");
+		$field->setValue($inputText);
+		$this->assertContains('Shortcode: [file_link id=4]', $field->Field());
+	}
+
 	public function testBasicSaving() {
 		$obj = new HtmlEditorFieldTest_Object();
 		$editor   = new HtmlEditorField('Content');

--- a/tests/forms/TextareaFieldTest.php
+++ b/tests/forms/TextareaFieldTest.php
@@ -2,6 +2,20 @@
 
 class TextareaFieldTest extends SapphireTest {
 
+	public function testCasting() {
+		// Test special characters
+		$inputText = "These are some unicodes: ä, ö, & ü";
+		$field = new TextareaField("Test", "Test");
+		$field->setValue($inputText);
+		$this->assertContains('These are some unicodes: &auml;, &ouml;, &amp; &uuml;', $field->Field());
+
+		// Test shortcodes
+		$inputText = "Shortcode: [file_link id=4]";
+		$field = new TextareaField("Test", "Test");
+		$field->setValue($inputText);
+		$this->assertContains('Shortcode: [file_link id=4]', $field->Field());
+	}
+
 	/**
 	 * Quick smoke test to ensure that text with unicodes is being displayed properly in readonly fields.
 	 */


### PR DESCRIPTION
Fixes #6396

Note that `.RAW` no longer works, as it now parses shortcodes. The second `.Value` invokes the HTMLText::getValue() method, which bypasses shortcodes.