### PR TITLE
search term highlighting without altering case (fixes #1400)

### DIFF
--- a/model/fieldtypes/Text.php
+++ b/model/fieldtypes/Text.php
@@ -265,8 +265,7 @@ class Text extends StringField {
 
 				foreach($stringPieces as $stringPiece) {
 					if(strlen($stringPiece) > 2) {
-						$summary = str_ireplace($stringPiece, "<span class=\"highlight\">$stringPiece</span>",
-							$summary);
+						$summary = preg_replace('/' . preg_quote($stringPiece, '/') . '/i', '<span class="highlight">$0</span>', $summary);
 					}
 				}
 			}

--- a/tests/model/TextTest.php
+++ b/tests/model/TextTest.php
@@ -194,9 +194,10 @@ class TextTest extends SapphireTest {
 
 		$textObj->setValue($testString2);
 
+		// test that it preserves case
 		$this->assertEquals(
 			'This is <span class="highlight">some</span> <span class="highlight">test</span> text.'
-				. ' <span class="highlight">test</span> <span class="highlight">test</span> what if you have...',
+				. ' <span class="highlight">Test</span> <span class="highlight">test</span> what if you have...',
 			$textObj->ContextSummary(50, $testKeywords2)
 		);
 


### PR DESCRIPTION
using preg_replace instead of str_ireplace