### PR TITLE
Fixed a pagination bug

### DIFF
--- a/core/PaginatedList.php
+++ b/core/PaginatedList.php
@@ -293,6 +293,7 @@ class PaginatedList extends SS_ListDecorator {
 		}
 
 		$left  = max($current - $offset, 1);
+		$right = min($current + $offset, $total);
 		$range = range($current - $offset, $current + $offset);
 
 		if ($left + $context > $total) {
@@ -304,7 +305,7 @@ class PaginatedList extends SS_ListDecorator {
 			$num     = $i + 1;
 
 			$emptyRange = $num != 1 && $num != $total && (
-				$num == $left - 1 || $num == $left + $context + 1
+				$num == $left - 1 || $num == $right + 1
 			);
 
 			if ($emptyRange) {


### PR DESCRIPTION
#6412 Depending on the current page, a page not supposed to show up in the pagination summary can be skipped without returning a null value. It then makes it difficult to know it is existent, but just skipped.