### PR TITLE
remove Created field on duplicate

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -531,7 +531,9 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	 */
 	public function duplicate($doWrite = true) {
 		$className = $this->class;
-		$clone = new $className( $this->toMap(), false, $this->model );
+		$map = $this->toMap();
+		unset($map['Created']);
+		$clone = new $className( $map, false, $this->model );
 		$clone->ID = 0;
 
 		$clone->invokeWithExtensions('onBeforeDuplicate', $this, $doWrite);

--- a/tests/model/DataObjectDuplicationTest.php
+++ b/tests/model/DataObjectDuplicationTest.php
@@ -11,10 +11,11 @@ class DataObjectDuplicationTest extends SapphireTest {
 	);
 
 	public function testDuplicate() {
+		SS_Datetime::set_mock_now('2016-01-01 01:01:01');
 		$orig = new DataObjectDuplicateTestClass1();
 		$orig->text = 'foo';
 		$orig->write();
-
+		SS_Datetime::set_mock_now('2016-01-02 01:01:01');
 		$duplicate = $orig->duplicate();
 		$this->assertInstanceOf('DataObjectDuplicateTestClass1', $duplicate,
 			'Creates the correct type'
@@ -28,6 +29,8 @@ class DataObjectDuplicationTest extends SapphireTest {
 		$this->assertEquals(2, DataObjectDuplicateTestClass1::get()->Count(),
 			'Only creates a single duplicate'
 		);
+		$this->assertEquals(SS_Datetime::now()->Nice(), $duplicate->dbObject('Created')->Nice());
+		$this->assertNotEquals($orig->dbObject('Created')->Nice(), $duplicate->dbObject('Created')->Nice());
 	}
 
 	public function testDuplicateHasOne() {


### PR DESCRIPTION
Currently, using the `duplicate()` method on a Page will also duplicate the 'Created' date. This is counter-intuitive and should be fixed to represent the creation date of the new record. This PR will unset the 'Created' field from the map, allowing it to be set on `write()`.