### PR TITLE
FIX UploadField FileExists check

### DIFF
--- a/javascript/UploadField.js
+++ b/javascript/UploadField.js
@@ -63,7 +63,7 @@
 			if (config.overwriteWarning && config.replaceFile) {
 				$.get(
 					config['urlFileExists'],
-					{'filename': data.files[0].name},
+					{'filename': data.files[0].name, 'foldername': config['folderName']},
 					function(response, status, xhr) {
 						if(response.exists) {
 							//display the dialogs with the question to overwrite or not


### PR DESCRIPTION
UploadField in asset admin area would only check root folder for existing files (Fixes https://github.com/silverstripe/silverstripe-cms/issues/950)

ping @dhensby 

Copied the filtered name check functionality to the Action so we can do this as a point fix.

It all seems a bit funky... I'd prefer to use an ID for folder but since this is a bugfix I'm trying not to stray to far from the existing structure.

Is it okay to target 3.5.1 or should this go somewhere else, like 3.4?