### PR TITLE
ENHANCEMENT: Debug class emits plain text for application/json requests

### DIFF
--- a/src/Control/HTTPRequest.php
+++ b/src/Control/HTTPRequest.php
@@ -428,7 +428,7 @@ class HTTPRequest implements ArrayAccess
     {
         return (
             $this->requestVar('ajax') ||
-            $this->getHeader('X-Requested-With') && $this->getHeader('X-Requested-With') == "XMLHttpRequest"
+            $this->getHeader('X-Requested-With') === "XMLHttpRequest"
         );
     }
 

--- a/tests/php/Dev/CLIDebugViewTest.php
+++ b/tests/php/Dev/CLIDebugViewTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SilverStripe\Dev\Tests;
+
+use SilverStripe\Dev\CliDebugView;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\Tests\DebugViewTest\ObjectWithDebug;
+
+class CLIDebugViewTest extends SapphireTest
+{
+    protected $caller = null;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->caller = [
+            'line' => 17,
+            'file' => __FILE__,
+            'args' => [],
+            'type' => '->',
+            'class' => __CLASS__,
+            'function' => __FUNCTION__,
+        ];
+    }
+
+    public function testDebugVariable()
+    {
+        $view = new CliDebugView();
+        $this->assertEquals(
+            <<<EOS
+Debug (CLIDebugViewTest.php:17 - SilverStripe\Dev\Tests\CLIDebugViewTest::setUp())
+string
+
+
+EOS
+            ,
+            $view->debugVariable('string', $this->caller)
+        );
+
+        $this->assertEquals(
+            <<<EOS
+Debug (CLIDebugViewTest.php:17 - SilverStripe\Dev\Tests\CLIDebugViewTest::setUp())
+key = value
+another = text
+
+
+
+EOS
+            ,
+            $view->debugVariable([ 'key' => 'value', 'another' => 'text' ], $this->caller)
+        );
+
+        $this->assertEquals(
+            <<<EOS
+Debug (CLIDebugViewTest.php:17 - SilverStripe\Dev\Tests\CLIDebugViewTest::setUp())
+SilverStripe\Dev\Tests\DebugViewTest\ObjectWithDebug::debug() custom content
+
+
+EOS
+            ,
+            $view->debugVariable(new ObjectWithDebug(), $this->caller)
+        );
+    }
+}

--- a/tests/php/Dev/DebugViewTest.php
+++ b/tests/php/Dev/DebugViewTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace SilverStripe\Dev\Tests;
+
+use SilverStripe\Dev\DebugView;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\Tests\DebugViewTest\ObjectWithDebug;
+
+class DebugViewTest extends SapphireTest
+{
+    protected $caller = null;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->caller = [
+            'line' => 17,
+            'file' => __FILE__,
+            'args' => [],
+            'type' => '->',
+            'class' => __CLASS__,
+            'function' => __FUNCTION__,
+        ];
+    }
+
+    public function testDebugVariable()
+    {
+        $view = new DebugView();
+        $this->assertEquals(
+            <<<EOS
+<div style="background-color: white; text-align: left;">
+<hr>
+<h3>Debug <span style="font-size: 65%">(DebugViewTest.php:17 - SilverStripe\Dev\Tests\DebugViewTest::setUp())</span>
+</h3>
+<pre style="font-family: Courier new, serif">string</pre>
+</div>
+EOS
+            ,
+            $view->debugVariable('string', $this->caller)
+        );
+
+        $this->assertEquals(
+            <<<EOS
+<div style="background-color: white; text-align: left;">
+<hr>
+<h3>Debug <span style="font-size: 65%">(DebugViewTest.php:17 - SilverStripe\Dev\Tests\DebugViewTest::setUp())</span>
+</h3>
+<ul>
+<li>key = <pre style="font-family: Courier new, serif">value</pre>
+</li>
+<li>another = <pre style="font-family: Courier new, serif">text</pre>
+</li>
+</ul>
+</div>
+EOS
+            ,
+            $view->debugVariable([ 'key' => 'value', 'another' => 'text' ], $this->caller)
+        );
+
+        $this->assertEquals(
+            <<<EOS
+<div style="background-color: white; text-align: left;">
+<hr>
+<h3>Debug <span style="font-size: 65%">(DebugViewTest.php:17 - SilverStripe\Dev\Tests\DebugViewTest::setUp())</span>
+</h3>
+SilverStripe\Dev\Tests\DebugViewTest\ObjectWithDebug::debug() custom content</div>
+EOS
+            ,
+            $view->debugVariable(new ObjectWithDebug(), $this->caller)
+        );
+    }
+}

--- a/tests/php/Dev/DebugViewTest/ObjectWithDebug.php
+++ b/tests/php/Dev/DebugViewTest/ObjectWithDebug.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Dev\Tests\DebugViewTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class ObjectWithDebug implements TestOnly
+{
+    public function debug()
+    {
+        return __CLASS__ . '::debug() custom content';
+    }
+}


### PR DESCRIPTION
Also see https://github.com/silverstripe/silverstripe-admin/pull/137

I've majorly cleaned up and refactored the html generation from Debug class into either CliDebugView or DebugView