### PR TITLE
Switch from using ORM in ForeignKey to SQL query

### DIFF
--- a/model/fieldtypes/ForeignKey.php
+++ b/model/fieldtypes/ForeignKey.php
@@ -37,17 +37,16 @@ class ForeignKey extends Int {
 			$field = new UploadField($relationName, $title);
 		} else {
 			$titleField = (singleton($hasOneClass)->hasField('Title')) ? "Title" : "Name";
-			// Use a SQL query instead of the ORM to save on PHP memory, DB objects and queries
-			$list = array();
-			$sqlQuery = new SQLSelect();
-			$sqlQuery->setFrom($hasOneClass);
-
-			$result = $sqlQuery->execute();
-			foreach ($result as $row) {
-				$list[$row['ID']] = $row[$titleField];
+			$list = DataList::create($hasOneClass);
+			// Don't scaffold a dropdown for large tables, as making the list concrete
+			// might exceed the available PHP memory in creating too many DataObject instances
+			if($list->count() < 100) {
+				$field = new DropdownField($this->name, $title, $list->map('ID', $titleField));
+				$field->setEmptyString(' ');
+			} else {
+				$field = null;
 			}
-			$field = new DropdownField($this->name, $title, $list);
-			$field->setEmptyString(' ');
+
 		}
 
 		return $field;

--- a/model/fieldtypes/ForeignKey.php
+++ b/model/fieldtypes/ForeignKey.php
@@ -37,16 +37,17 @@ class ForeignKey extends Int {
 			$field = new UploadField($relationName, $title);
 		} else {
 			$titleField = (singleton($hasOneClass)->hasField('Title')) ? "Title" : "Name";
-			$list = DataList::create($hasOneClass);
-			// Don't scaffold a dropdown for large tables, as making the list concrete
-			// might exceed the available PHP memory in creating too many DataObject instances
-			if($list->count() < 100) {
-				$field = new DropdownField($this->name, $title, $list->map('ID', $titleField));
-				$field->setEmptyString(' ');
-			} else {
-				$field = new NumericField($this->name, $title);
-			}
+			// Use a SQL query instead of the ORM to save on PHP memory, DB objects and queries
+			$list = array();
+			$sqlQuery = new SQLSelect();
+			$sqlQuery->setFrom($hasOneClass);
 
+			$result = $sqlQuery->execute();
+			foreach ($result as $row) {
+				$list[$row['ID']] = $row[$titleField];
+			}
+			$field = new DropdownField($this->name, $title, $list);
+			$field->setEmptyString(' ');
 		}
 
 		return $field;


### PR DESCRIPTION
Using a SQLSelect object to grab the dropdown list as a standard array seems to improve the memory usage and result in less DB queries, it also overcomes the problem of the dropdown being replaced with a numeric field when more then 100 results are turned.

The results I received from memory_get_usage and showqueries are below.

**Current result**
Memory: 27540712 (26.26 mb)
Main SQL Queries:
SELECT DISTINCT count(DISTINCT "SiteTree"."ID") AS "Count" FROM "SiteTree" 0.0001s

SELECT DISTINCT "SiteTree"."ClassName", "SiteTree"."LastEdited", "SiteTree"."Created", "SiteTree"."URLSegment", "SiteTree"."Title", "SiteTree"."MenuTitle", "SiteTree"."Content", "SiteTree"."MetaDescription", "SiteTree"."ExtraMeta", "SiteTree"."ShowInMenus", "SiteTree"."
ShowInSearch", "SiteTree"."Sort", "SiteTree"."HasBrokenFile", "SiteTree"."HasBrokenLink", "SiteTree"."ReportClass", "SiteTree"."CanViewType", "SiteTree"."CanEditType", "SiteTree"."Version", "SiteTree"."ParentID", "SiteTree"."ID", CASE WHEN "SiteTree"."ClassName" IS NOT
NULL THEN "SiteTree"."ClassName" ELSE 'SiteTree' END AS "RecordClassName" FROM "SiteTree" ORDER BY "SiteTree"."Sort" ASC 0.0003s

**With applied patch results**
Memory: 26630040 (25.39 mb)

Main SQL Queries:
SELECT * FROM SiteTree 0.0003s