### PR TITLE
 FEATURE (update form hook): add extension hook to update form

### DIFF
--- a/forms/Form.php
+++ b/forms/Form.php
@@ -272,6 +272,8 @@ class Form extends RequestHandler {
 		$this->securityToken = ($securityEnabled) ? new SecurityToken() : new NullSecurityToken();
 
 		$this->setupDefaultClasses();
+
+		$this->extend('updateForm');
 	}
 
 	/**


### PR DESCRIPTION
Okay, I understand that this one's going to open a huge can of worms, and I can definitely see how it's going to be a less than ideal implementation, however if it's at least canned, the discussion is here for historical purposes.

There are some circumstances in the past where on work that I've done, it's been required to update to the form fields of all forms in a site, so this was patched in. A lot of the work done was on instances of the base form class, rather than an extended form object (e.g. CMSForm).

I'm aware that having a hook like this can be undesirable as it will also hook into CMSForm, GridfieldDetailForm, etc and can produce undesirable or unexpected results.

If, as I'm guessing this PR isn't going to make it through due to certain complications arising, I'd like thoughts on a better approach.