### PR TITLE
Add X-Robots-Tag noindex,nofollow header from Security controller to prevent indexing

### DIFF
--- a/security/Security.php
+++ b/security/Security.php
@@ -147,6 +147,14 @@ class Security extends Controller implements TemplateGlobalProvider {
 	private static $frame_options = 'SAMEORIGIN';
 
 	/**
+	 * Value of the X-Robots-Tag header (for the Security section)
+	 *
+	 * @config
+	 * @var string
+	 */
+	private static $robots_tag = 'noindex, nofollow';
+
+	/**
 	 * Get location of word list file
 	 *
 	 * @deprecated 4.0 Use the "Security.word_list" config setting instead
@@ -326,6 +334,9 @@ class Security extends Controller implements TemplateGlobalProvider {
 
 		// Prevent clickjacking, see https://developer.mozilla.org/en-US/docs/HTTP/X-Frame-Options
 		$this->getResponse()->addHeader('X-Frame-Options', $this->config()->frame_options);
+
+		// Prevent search engines from indexing the login page
+		$this->getResponse()->addHeader('X-Robots-Tag', $this->config()->robots_tag);
 	}
 
 	public function index() {

--- a/security/Security.php
+++ b/security/Security.php
@@ -336,7 +336,9 @@ class Security extends Controller implements TemplateGlobalProvider {
 		$this->getResponse()->addHeader('X-Frame-Options', $this->config()->frame_options);
 
 		// Prevent search engines from indexing the login page
-		$this->getResponse()->addHeader('X-Robots-Tag', $this->config()->robots_tag);
+		if ($this->config()->robots_tag) {
+			$this->getResponse()->addHeader('X-Robots-Tag', $this->config()->robots_tag);
+		}
 	}
 
 	public function index() {

--- a/tests/security/SecurityTest.php
+++ b/tests/security/SecurityTest.php
@@ -581,6 +581,13 @@ class SecurityTest extends FunctionalTest {
 		$this->assertContains('noindex', $robotsHeader);
 	}
 
+	public function testDoNotSendEmptyRobotsHeaderIfNotDefined() {
+		Config::inst()->update('Security', 'robots_tag', null);
+		$response = $this->get(Config::inst()->get('Security', 'login_url'));
+		$robotsHeader = $response->getHeader('X-Robots-Tag');
+		$this->assertNull($robotsHeader);
+	}
+
 	/**
 	 * Execute a log-in form using Director::test().
 	 * Helper method for the tests above

--- a/tests/security/SecurityTest.php
+++ b/tests/security/SecurityTest.php
@@ -574,6 +574,13 @@ class SecurityTest extends FunctionalTest {
 		Security::$force_database_is_ready = $old;
 	}
 
+	public function testSecurityControllerSendsRobotsTagHeader() {
+		$response = $this->get(Config::inst()->get('Security', 'login_url'));
+		$robotsHeader = $response->getHeader('X-Robots-Tag');
+		$this->assertNotNull($robotsHeader);
+		$this->assertContains('noindex', $robotsHeader);
+	}
+
 	/**
 	 * Execute a log-in form using Director::test().
 	 * Helper method for the tests above


### PR DESCRIPTION
Search engines will index the `/Security*` routes, which is probably not wanted in most installations.

This PR adds the `X-Robots-Tag` header with `nofollow` and `noindex`.

Reference: https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag