### PR TITLE
Clarify DataObject::__construct()

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -425,8 +425,9 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	/**
 	 * Construct a new DataObject.
 	 *
-	 * @param array|null $record This will be null for a new database record.  Alternatively, you can pass an array of
-	 * field values.  Normally this contructor is only used by the internal systems that get objects from the database.
+	 * @param array|null $record Used internally for rehydrating an object from database content.
+	 *                           Bypasses setters on this class, and hence should not be used
+	 *                           for populating data on new records.
 	 * @param boolean $isSingleton This this to true if this is a singleton() object, a stub for calling methods.
 	 *                             Singletons don't have their defaults set.
 	 */


### PR DESCRIPTION
The $record argument should NOT be used for object construction, since it bypasses setters.
While the original PHPDoc hints at this (“internal systems”), it doesn’t make it clear enough.

See https://github.com/silverstripe/silverstripe-framework/issues/6460