### PR TITLE
Fix for SiteTree icons within TreeDropdownField

### DIFF
--- a/src/Core/Convert.php
+++ b/src/Core/Convert.php
@@ -103,7 +103,29 @@ class Convert
             );
         }
     }
-
+    
+    /**
+     * Convert a value to be suitable for an HTML class attribute. Replaces non
+     * supported characters with a hyphen and converts to lowercase.
+     *
+     * @param array|string $val String to escape, or array of strings
+     *
+     * @return array|string
+     */
+    public static function raw2htmlclass($val)
+    {
+        $val = self::raw2htmlid($val);
+        
+        if (is_array($val)) {
+            foreach ($val as $k => $v) {
+                $val[$k] = strtolower(str_replace('_', '-', $v));
+            }
+            return $val;
+        } else {
+            return strtolower(str_replace('_', '-', $val));
+        }
+    }
+    
     /**
      * Ensure that text is properly escaped for XML.
      *

--- a/src/Forms/TreeDropdownField.php
+++ b/src/Forms/TreeDropdownField.php
@@ -368,7 +368,7 @@ class TreeDropdownField extends FormField
                 Convert::raw2xml($self->getName()),
                 Convert::raw2xml($child->$keyField),
                 Convert::raw2xml($child->$keyField),
-                Convert::raw2xml($child->class),
+                Convert::raw2htmlclass($child->class),
                 Convert::raw2xml($child->markingClasses($self->numChildrenMethod)),
                 ($self->nodeIsDisabled($child)) ? 'disabled' : '',
                 (int)$child->ID,


### PR DESCRIPTION
(see also silverstripe/silverstripe-cms#980)

This PR adds a `raw2htmlclass()` static method to `SilverStripe\Core\Convert`, which converts a mixed-case, namespaced class such as:

`SilverStripe\CMS\Model\ErrorPage`

to:

`silverstripe-cms-model-errorpage`

The resulting string (or array of strings) is CSS-friendly, maintains the SS convention of lowercase CSS class names, and rectifies the CMS issue of broken namespaced `SiteTree` icons (silverstripe/silverstripe-cms#980) when used in conjuction with the accompanying CMS PR.

`SilverStripe\Forms\TreeDropdownField` has also been patched to make use of the new conversion method.