### PR TITLE
Fix for v4: Admin returns "Too many pages" for subpages below top level

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -1126,7 +1126,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 			$nodeCountCallback = function($parent, $numChildren) use(&$controller, $className, $nodeThresholdLeaf) {
 				if ($className !== 'SilverStripe\\CMS\\Model\\SiteTree'
 					|| !$parent->ID
-					|| $numChildren >= $nodeThresholdLeaf
+					|| $numChildren <= $nodeThresholdLeaf
 				) {
 					return null;
 				}


### PR DESCRIPTION
Simple logic error during porting to new version it appears

If Number of Children is greater than threshold then return the Too Many pages response