### PR TITLE
Fix for v4: Admin returns "Too many pages" for subpages below top level

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -1188,7 +1188,7 @@ class LeftAndMain extends Controller implements PermissionProvider
             $nodeCountCallback = function ($parent, $numChildren) use (&$controller, $className, $nodeThresholdLeaf) {
                 if ($className !== 'SilverStripe\\CMS\\Model\\SiteTree'
                     || !$parent->ID
-                    || $numChildren >= $nodeThresholdLeaf
+                    || $numChildren <= $nodeThresholdLeaf
                 ) {
                     return null;
                 }

--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -1199,7 +1199,7 @@ class LeftAndMain extends Controller implements PermissionProvider
                         _t('LeftAndMain.TooManyPages', 'Too many pages'),
                         Controller::join_links(
                             $controller->LinkWithSearch($controller->Link()),
-                            '?view=list&ParentID=' . $parent->ID
+                            '?view=listview&ParentID=' . $parent->ID
                         ),
                         _t(
                             'LeftAndMain.ShowAsList',

--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -1199,8 +1199,7 @@ class LeftAndMain extends Controller implements PermissionProvider
                         _t('LeftAndMain.TooManyPages', 'Too many pages'),
                         Controller::join_links(
                             $controller->LinkWithSearch($controller->Link()),
-                            '
-							?view=list&ParentID=' . $parent->ID
+                            '?view=list&ParentID=' . $parent->ID
                         ),
                         _t(
                             'LeftAndMain.ShowAsList',


### PR DESCRIPTION
Simple logic error during porting to new version it appears

**From**
![image](https://cloud.githubusercontent.com/assets/1453382/21764316/5357cf26-d65a-11e6-9770-f99b0317c720.png)

**To**
![image](https://cloud.githubusercontent.com/assets/1453382/21764292/3b7ae23a-d65a-11e6-834c-bb266efc927c.png)
