### PR TITLE
FIX Make sure image backends implement method getImageResource

### DIFF
--- a/src/Assets/Image_Backend.php
+++ b/src/Assets/Image_Backend.php
@@ -50,6 +50,13 @@ interface Image_Backend
     public function loadFrom($path);
 
     /**
+     * Get the currently assigned image resource
+     *
+     * @return mixed
+     */
+    public function getImageResource();
+
+    /**
      * Write to the given asset store
      *
      * @param AssetStore $assetStore

--- a/src/Assets/ImagickBackend.php
+++ b/src/Assets/ImagickBackend.php
@@ -23,6 +23,15 @@ class ImagickBackend extends Imagick implements Image_Backend
     private static $default_quality = 75;
 
     /**
+     * @return $this
+     */
+    public function getImageResource()
+    {
+        // the object represents the resource
+        return $this;
+    }
+
+    /**
      * Create a new backend with the given object
      *
      * @param AssetContainer $assetContainer Object to load from


### PR DESCRIPTION
Fixes an issue where `ImageManipulation` trait relies on `getImageResource` method on image backends