### PR TITLE
FIX Rename template parser from .inc to .peg so PHP doesn't include it automatically

### DIFF
--- a/src/View/SSTemplateParser.peg
+++ b/src/View/SSTemplateParser.peg
@@ -12,7 +12,7 @@ template language, producing the executable version SSTemplateParser.php
 To recompile after changing this file, run this from the 'framework/View' directory via command line (in most cases
 this is: sapphire/view):
 
-	php ../thirdparty/php-peg/cli.php SSTemplateParser.php.inc > SSTemplateParser.php
+	php ../thirdparty/php-peg/cli.php SSTemplateParser.peg > SSTemplateParser.php
 
 See the php-peg docs for more information on the parser format, and how to convert this file into SSTemplateParser.php
 


### PR DESCRIPTION
The `.inc` file is picked up by PHP, for example during a deployment on SSP:

```plain
[2017-01-10 15:59:45] OUT > Warning: Ambiguous class resolution, "SilverStripe\View\SSTemplateParser" was found in both "/tmp/rainforest/500a3f880c3f0ac76596499694cfbdbad905eb7c/site/framework/src/View/SSTemplateParser.php.inc" and "/tmp/rainforest/500a3f880c3f0ac76596499694cfbdbad905eb7c/site/framework/src/View/SSTemplateParser.php", the first will be used.
```