### PR TITLE
Client-side email validation rule

### DIFF
--- a/admin/client/dist/js/bundle.js
+++ b/admin/client/dist/js/bundle.js
@@ -424,7 +424,8 @@ case"alphanumeric":return u["default"].isAlphanumeric(e)
 case"alpha":return u["default"].isAlpha(e)
 case"regex":return u["default"].matches(e,n.pattern)
 case"max":return e.length<=n.length
-default:throw new Error("Unknown validation rule used: '"+t+"'")}}},{key:"validateFieldSchema",value:function l(e){return this.validateField(e.name,e.validation,null!==e.leftTitle?e.leftTitle:e.title,e.customValidationMessage)
+case"email":return u["default"].isEmail(e)
+default:console.warn("Unknown validation rule used: '"+t+"'")}}},{key:"validateFieldSchema",value:function l(e){return this.validateField(e.name,e.validation,null!==e.leftTitle?e.leftTitle:e.title,e.customValidationMessage)
 
 }},{key:"getMessage",value:function d(e,t){var n=""
 if("string"==typeof t.message)n=t.message

--- a/admin/client/src/lib/Validator.js
+++ b/admin/client/src/lib/Validator.js
@@ -56,6 +56,9 @@ class Validator {
       case 'max': {
         return value.length <= config.length;
       }
+      case 'email': {
+        return validator.isEmail(value);
+      }
       default: {
         throw new Error(`Unknown validation rule used: '${rule}'`);
       }

--- a/admin/client/src/lib/Validator.js
+++ b/admin/client/src/lib/Validator.js
@@ -60,7 +60,9 @@ class Validator {
         return validator.isEmail(value);
       }
       default: {
-        throw new Error(`Unknown validation rule used: '${rule}'`);
+        // eslint-disable-next-line no-console
+        console.warn(`Unknown validation rule used: '${rule}'`);
+        return false;
       }
     }
   }

--- a/admin/client/src/lib/tests/Validator-test.js
+++ b/admin/client/src/lib/tests/Validator-test.js
@@ -1,4 +1,7 @@
-/* global jest, describe, beforeEach, it, expect */
+/* global jest, describe, beforeEach, it, expect, console */
+
+// Needs to be set before requiring other libraries
+global.console = { warn: jest.fn() };
 
 jest.unmock('react');
 jest.unmock('react-addons-test-utils');
@@ -56,9 +59,9 @@ describe('Validator', () => {
   describe('validateValue()', () => {
     it('should throw an error', () => {
       validator = new Validator({});
-      const callRuleDoesNotExist = () => validator.validateValue('one', 'ruledoesnotexist');
-
-      expect(callRuleDoesNotExist).toThrowError(/unknown/i);
+      validator.validateValue('one', 'ruledoesnotexist');
+      // eslint-disable-next-line no-console
+      expect(console.warn).toBeCalled();
     });
   });
 


### PR DESCRIPTION
This fixes the "admin/test-react" UI for frameworktest,
which we're using frequently to sanity check our stuff.
Not having this UI available is impacting our ability to determien regressions,
e.g. from styling merges.