### PR TITLE
Enforce unique Folder names, use AssetNameGenerator

### DIFF
--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -808,6 +808,7 @@ specific functions.
 * `Injector::load` given a `src` parameter will no longer guess the
   service name from the filename. Now the service name will either
   by the array key, or the `class` parameter value.
+* Uniqueness checks for `File.Name` is performed on write only (not in `setName()`)
 
 #### <a name="overview-general-removed"></a>General and Core Removed API
 

--- a/src/Assets/FileNameFilter.php
+++ b/src/Assets/FileNameFilter.php
@@ -77,7 +77,8 @@ class FileNameFilter extends Object
         // Safeguard against empty file names
         $nameWithoutExt = pathinfo($name, PATHINFO_FILENAME);
         if (empty($nameWithoutExt)) {
-            $name = $this->getDefaultName() . '.' . $ext;
+            $name = $this->getDefaultName();
+            $name .= $ext ? '.' . $ext : '';
         }
 
         return $name;

--- a/src/Assets/Folder.php
+++ b/src/Assets/Folder.php
@@ -129,7 +129,9 @@ class Folder extends File
      */
     public function setTitle($title)
     {
-        $this->setName($title);
+        $this->setField('Title', $title);
+        $this->setField('Name', $title);
+
         return $this;
     }
 
@@ -141,21 +143,6 @@ class Folder extends File
     public function getTitle()
     {
         return $this->Name;
-    }
-
-    /**
-     * Override setting the Title of Folders to that Name and Title are always in sync.
-     * Note that this is not appropriate for files, because someone might want to create a human-readable name
-     * of a file that is different from its name on disk. But folders should always match their name on disk.
-     *
-     * @param string $name
-     * @return $this
-     */
-    public function setName($name)
-    {
-        parent::setName($name);
-        $this->setField('Title', $this->Name);
-        return $this;
     }
 
     /**

--- a/tests/php/Assets/FileNameFilterTest.php
+++ b/tests/php/Assets/FileNameFilterTest.php
@@ -142,4 +142,11 @@ class FileNameFilterTest extends SapphireTest
         $filter = new FileNameFilter();
         $this->assertEquals('test-document.txt', $filter->filter($name));
     }
+
+    public function testDoesntAddExtensionWhenMissing()
+    {
+        $name = 'no-extension';
+        $filter = new FileNameFilter();
+        $this->assertEquals('no-extension', $filter->filter($name));
+    }
 }

--- a/tests/php/Assets/FileTest.php
+++ b/tests/php/Assets/FileTest.php
@@ -535,6 +535,88 @@ class FileTest extends SapphireTest
         );
     }
 
+    public function testRenamesDuplicateFilesInSameFolder()
+    {
+        $original = new File();
+        $original->update([
+            'Name' => 'file1.txt',
+            'ParentID' => 0
+        ]);
+        $original->write();
+
+        $duplicate = new File();
+        $duplicate->update([
+            'Name' => 'file1.txt',
+            'ParentID' => 0
+        ]);
+        $duplicate->write();
+
+        $original = File::get()->byID($original->ID);
+
+        $this->assertEquals($original->Name, 'file1.txt');
+        $this->assertEquals($original->Title, 'file1');
+        $this->assertEquals($duplicate->Name, 'file1-v2.txt');
+        $this->assertEquals($duplicate->Title, 'file1 v2');
+    }
+
+    public function testSetsEmptyTitleToNameWithoutExtensionAndSpecialCharacters()
+    {
+        $fileWithTitle = new File();
+        $fileWithTitle->update([
+            'Name' => 'file1-with-title.txt',
+            'Title' => 'Some Title'
+        ]);
+        $fileWithTitle->write();
+
+        $this->assertEquals($fileWithTitle->Name, 'file1-with-title.txt');
+        $this->assertEquals($fileWithTitle->Title, 'Some Title');
+
+        $fileWithoutTitle = new File();
+        $fileWithoutTitle->update([
+            'Name' => 'file1-without-title.txt',
+        ]);
+        $fileWithoutTitle->write();
+
+        $this->assertEquals($fileWithoutTitle->Name, 'file1-without-title.txt');
+        $this->assertEquals($fileWithoutTitle->Title, 'file1 without title');
+    }
+
+    public function testSetsEmptyNameToSingularNameWithoutTitle()
+    {
+        $fileWithTitle = new File();
+        $fileWithTitle->update([
+            'Name' => '',
+            'Title' => 'Some Title',
+        ]);
+        $fileWithTitle->write();
+
+        $this->assertEquals($fileWithTitle->Name, 'Some-Title');
+        $this->assertEquals($fileWithTitle->Title, 'Some Title');
+
+        $fileWithoutTitle = new File();
+        $fileWithoutTitle->update([
+            'Name' => '',
+            'Title' => '',
+        ]);
+        $fileWithoutTitle->write();
+
+        $this->assertEquals($fileWithoutTitle->Name, $fileWithoutTitle->i18n_singular_name());
+        $this->assertEquals($fileWithoutTitle->Title, $fileWithoutTitle->i18n_singular_name());
+    }
+
+    public function testSetsEmptyNameToTitleIfPresent()
+    {
+        $file = new File();
+        $file->update([
+            'Name' => '',
+            'Title' => 'file1',
+        ]);
+        $file->write();
+
+        $this->assertEquals($file->Name, 'file1');
+        $this->assertEquals($file->Title, 'file1');
+    }
+
     public function testSetsOwnerOnFirstWrite()
     {
         Session::set('loggedInAs', null);

--- a/tests/php/Assets/FolderTest.php
+++ b/tests/php/Assets/FolderTest.php
@@ -76,6 +76,30 @@ class FolderTest extends SapphireTest
         $this->assertEquals($folder1->Filename . 'CreateFromNameAndParentID/', $newFolder->Filename);
     }
 
+    public function testRenamesDuplicateFolders()
+    {
+        $original = new Folder();
+        $original->update([
+            'Name' => 'folder1',
+            'ParentID' => 0
+        ]);
+        $original->write();
+
+        $duplicate = new Folder();
+        $duplicate->update([
+            'Name' => 'folder1',
+            'ParentID' => 0
+        ]);
+        $duplicate->write();
+
+        $original = Folder::get()->byID($original->ID);
+
+        $this->assertEquals($original->Name, 'folder1');
+        $this->assertEquals($original->Title, 'folder1');
+        $this->assertEquals($duplicate->Name, 'folder1-v2');
+        $this->assertEquals($duplicate->Title, 'folder1-v2');
+    }
+
     public function testAllChildrenIncludesFolders()
     {
         $folder1 = $this->objFromFixture(Folder::class, 'folder1');
@@ -255,14 +279,18 @@ class FolderTest extends SapphireTest
 
         $newFolder->Name = 'TestNameCopiedToTitle';
         $this->assertEquals($newFolder->Name, $newFolder->Title);
+        $this->assertEquals($newFolder->Title, 'TestNameCopiedToTitle');
 
         $newFolder->Title = 'TestTitleCopiedToName';
         $this->assertEquals($newFolder->Name, $newFolder->Title);
+        $this->assertEquals($newFolder->Title, 'TestTitleCopiedToName');
 
         $newFolder->Name = 'TestNameWithIllegalCharactersCopiedToTitle <!BANG!>';
         $this->assertEquals($newFolder->Name, $newFolder->Title);
+        $this->assertEquals($newFolder->Title, 'TestNameWithIllegalCharactersCopiedToTitle <!BANG!>');
 
         $newFolder->Title = 'TestTitleWithIllegalCharactersCopiedToName <!BANG!>';
         $this->assertEquals($newFolder->Name, $newFolder->Title);
+        $this->assertEquals($newFolder->Title, 'TestTitleWithIllegalCharactersCopiedToName <!BANG!>');
     }
 }

--- a/tests/php/Assets/Storage/DefaultAssetNameGeneratorTest.php
+++ b/tests/php/Assets/Storage/DefaultAssetNameGeneratorTest.php
@@ -104,4 +104,32 @@ class DefaultAssetNameGeneratorTest extends SapphireTest
         $this->assertEquals('folder/MyFile-v99.jpg', $suggestions[98]);
         $this->assertNotEquals('folder/MyFile-v100.jpg', $suggestions[99]);
     }
+
+    public function testFolderWithoutDefaultPrefix()
+    {
+        Config::inst()->update(DefaultAssetNameGenerator::class, 'version_prefix', '');
+        $generator = new DefaultAssetNameGenerator('folder/subfolder');
+        $suggestions = iterator_to_array($generator);
+
+        // Expect 100 suggestions
+        $this->assertEquals(100, count($suggestions));
+
+        // First item is always the same as input
+        $this->assertEquals('folder/subfolder', $suggestions[0]);
+        $this->assertEquals('folder/subfolder2', $suggestions[1]);
+    }
+
+    public function testFolderWithDefaultPrefix()
+    {
+        Config::inst()->update(DefaultAssetNameGenerator::class, 'version_prefix', '-v');
+        $generator = new DefaultAssetNameGenerator('folder/subfolder');
+        $suggestions = iterator_to_array($generator);
+
+        // Expect 100 suggestions
+        $this->assertEquals(100, count($suggestions));
+
+        // First item is always the same as input
+        $this->assertEquals('folder/subfolder', $suggestions[0]);
+        $this->assertEquals('folder/subfolder-v2', $suggestions[1]);
+    }
 }


### PR DESCRIPTION
Regression from 3.x. Also makes behaviour between File->write()
and Upload->load() more consistent. The latter was using AssetNameGenerator,
which suffixed "-v2", but File->setName() was using a "-2" suffix.

This also fixes a bug where folder duplicates try to set an extension,
so creating a duplicate folder called "test" results in "test-2."
with a suffixed dot.

Merge together with https://github.com/silverstripe/silverstripe-graphql/pull/49