### PR TITLE
FIX Remap versioned ClassNames during build process

### DIFF
--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -9,6 +9,7 @@ use SilverStripe\Core\Manifest\ClassLoader;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\Dev\Deprecation;
+use SilverStripe\ORM\Versioning\Versioned;
 use SilverStripe\Security\Security;
 use SilverStripe\Security\Permission;
 
@@ -325,10 +326,19 @@ class DatabaseAdmin extends Controller
                         echo "<li>Correcting $badRecordCount obsolete classname values for $newClassName</li>\n";
                     }
                     $table = $schema->baseDataTable($baseDataClass);
-                    DB::prepared_query(
-                        "UPDATE \"$table\" SET \"ClassName\" = ? WHERE \"ClassName\" = ?",
-                        [ $newClassName, $oldClassName ]
-                    );
+
+                    $updateQuery = "UPDATE \"$table%s\" SET \"ClassName\" = ? WHERE \"ClassName\" = ?";
+                    $updateQueries = [sprintf($updateQuery, '')];
+
+                    // Remap versioned table ClassName values as well
+                    if (singleton($newClassName)->has_extension(Versioned::class)) {
+                        $updateQueries[] = sprintf($updateQuery, '_Live');
+                        $updateQueries[] = sprintf($updateQuery, '_Versions');
+                    }
+
+                    foreach ($updateQueries as $query) {
+                        DB::prepared_query($query, [$newClassName, $oldClassName]);
+                    }
                 }
             }
         }

--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -331,8 +331,11 @@ class DatabaseAdmin extends Controller
                     $updateQueries = [sprintf($updateQuery, '')];
 
                     // Remap versioned table ClassName values as well
-                    if (singleton($newClassName)->has_extension(Versioned::class)) {
-                        $updateQueries[] = sprintf($updateQuery, '_Live');
+                    $class = singleton($newClassName);
+                    if ($class->has_extension(Versioned::class)) {
+                        if ($class->hasStages()) {
+                            $updateQueries[] = sprintf($updateQuery, '_Live');
+                        }
                         $updateQueries[] = sprintf($updateQuery, '_Versions');
                     }
 


### PR DESCRIPTION
## Problem

Missed ClassName remapping causes the default "Getting Started" page to render if the home page is a custom class (extending Page). Since the Live table will use `HomePage` and not be able to resolve it to a controller, then falls back to `SiteTree`  and renders a default template.

Re-publishing the page from admin fixes the problem, as the ClassName is updated to a FQCN.

---

## Fix

This prevents the current behaviour from happening during `DatabaseAdmin::doBuild`:

```
mysql> select a.ClassName, b.ClassName, c.ClassName from SiteTree as a inner join SiteTree_Versions as b on a.ID = b.ID inner join SiteTree_Live as c on a.ID = c.ID where a.URLSegment = 'home';
+--------------------------+-----------+-----------+
| ClassName                | ClassName | ClassName |
+--------------------------+-----------+-----------+
| MyProject\Model\HomePage | Page      | HomePage  |
+--------------------------+-----------+-----------+
1 row in set (0.00 sec)
```

Updated behaviour:

```
mysql> select a.ClassName, b.ClassName, c.ClassName from SiteTree as a inner join SiteTree_Versions as b on a.ID = b.ID inner join SiteTree_Live as c on a.ID = c.ID where a.URLSegment = 'home';
+--------------------------+-----------+--------------------------+
| ClassName                | ClassName | ClassName                |
+--------------------------+-----------+--------------------------+
| MyProject\Model\HomePage | Page      | MyProject\Model\HomePage |
+--------------------------+-----------+--------------------------+
```