### PR TITLE
Check if $database is empty before adding prefix/suffix

### DIFF
--- a/src/conf/ConfigureFromEnv.php
+++ b/src/conf/ConfigureFromEnv.php
@@ -99,15 +99,25 @@ if (!isset($database) || !$database) {
 
 if (defined('SS_DATABASE_USERNAME') && defined('SS_DATABASE_PASSWORD')) {
     global $databaseConfig;
+
+    // Checks if the database global is defined (if present, wraps with prefix and suffix)
+    $databaseNameWrapper = function ($name) {
+        if (!$name) {
+            return '';
+        } else {
+            return (defined('SS_DATABASE_PREFIX') ? SS_DATABASE_PREFIX : '')
+            . $name
+            . (defined('SS_DATABASE_SUFFIX') ? SS_DATABASE_SUFFIX : '');
+        }
+    };
+
     /** @skipUpgrade */
     $databaseConfig = array(
         "type" => defined('SS_DATABASE_CLASS') ? SS_DATABASE_CLASS : 'MySQLDatabase',
         "server" => defined('SS_DATABASE_SERVER') ? SS_DATABASE_SERVER : 'localhost',
         "username" => SS_DATABASE_USERNAME,
         "password" => SS_DATABASE_PASSWORD,
-        "database" => (defined('SS_DATABASE_PREFIX') ? SS_DATABASE_PREFIX : '')
-            . $database
-            . (defined('SS_DATABASE_SUFFIX') ? SS_DATABASE_SUFFIX : ''),
+        "database" => $databaseNameWrapper($database),
     );
 
     // Set the port if called for


### PR DESCRIPTION
I noticed while using `silverstripe/installer` for SS4 that upon loading `install.php` in the browser, a mysterious database suddenly appeared:

![image](https://cloud.githubusercontent.com/assets/1853705/21872009/0115ad98-d8ba-11e6-9cdb-6fe21fd12e69.png)

In my parent `_ss_environment.php` I use:

```php
define('SS_DATABASE_PREFIX', 'dev_');
```

...to auto-prefix my local development databases.

The problem was traced to https://github.com/silverstripe/silverstripe-framework/blob/master/src/Dev/Install/config-form.html#L277:

```html
<img src="<?php echo FRAMEWORK_NAME; ?>/images/network-save.gif" alt="Saving">
```

When this hits up the server, it actually causes SS to automatically build a database based on the config it currently has, which is none.  😉  Because `ConfigureFromEnv.php` is not checking whether or not `$database` is empty before it wraps it with a prefix and suffix, the end result is (if you have a prefix or suffix), a database created when it shouldn't be.

This PR adds a little check to make sure `$database` is not empty before it wraps it with the prefix and suffix.

P.S.  This network-save.gif image probably doesn't exist anymore, at least not outside of `client/dist/`... @sminnee suggested perhaps it can be replaced with "Saving..." text...?