### PR TITLE
FIX: MySQLQuery::seek() failed to return a row

### DIFF
--- a/src/ORM/Connect/MySQLQuery.php
+++ b/src/ORM/Connect/MySQLQuery.php
@@ -39,7 +39,8 @@ class MySQLQuery extends Query
     public function seek($row)
     {
         if (is_object($this->handle)) {
-            return $this->handle->data_seek($row);
+            $this->handle->data_seek($row);
+            return $this->handle->fetch_assoc();
         }
         return null;
     }


### PR DESCRIPTION
`mysqli_result::data_seek()` returns a boolean instead of the record: http://php.net/manual/en/mysqli-result.data-seek.php.

There’s a good reason for these changes to be revealed in an upcoming PR, but the [PHP docs for `Query::seek()`](https://github.com/silverstripe/silverstripe-framework/blob/1b1e921e3dded218a7c463e632ab3a49098ba652/src/ORM/Connect/Query.php#L247-L253) state that the method should return the row at the given offset.

Related:

- https://github.com/silverstripe/silverstripe-postgresql/pull/60
- https://github.com/silverstripe/silverstripe-sqlite3/pull/30