### PR TITLE
API Enhancement: Allow "removeComponentsByType" to remove multiple component"s"

### DIFF
--- a/src/Forms/GridField/GridFieldConfig.php
+++ b/src/Forms/GridField/GridFieldConfig.php
@@ -91,15 +91,22 @@ class GridFieldConfig extends Object
     }
 
     /**
-     * @param string $type Class name or interface
+     * @param string|string[] $types Class name or interface, or an array of the same
      * @return $this
      */
-    public function removeComponentsByType($type)
+    public function removeComponentsByType($types)
     {
-        $components = $this->getComponentsByType($type);
-        foreach ($components as $component) {
-            $this->removeComponent($component);
+        if (!is_array($types)) {
+            $types = [$types];
         }
+
+        foreach ($types as $type) {
+            $components = $this->getComponentsByType($type);
+            foreach ($components as $component) {
+                $this->removeComponent($component);
+            }
+        }
+
         return $this;
     }
 

--- a/tests/php/Forms/GridField/GridFieldConfigTest.php
+++ b/tests/php/Forms/GridField/GridFieldConfigTest.php
@@ -123,4 +123,24 @@ class GridFieldConfigTest extends SapphireTest
             $config->getComponents()->count()
         );
     }
+
+    /**
+     * Test that components can be removed with an array of class names or interfaces
+     */
+    public function testRemoveMultipleComponents()
+    {
+        $config = GridFieldConfig::create()
+            ->addComponent(new MyComponent)
+            ->addComponent(new MyComponent)
+            ->addComponent(new MyOtherComponent);
+
+        $config->removeComponentsByType(
+            [
+                MyComponent::class,
+                MyOtherComponent::class
+            ]
+        );
+
+        $this->assertSame(0, $config->getComponents()->count());
+    }
 }


### PR DESCRIPTION
As the method name `removeComponentsByType` suggests, this PR allows the method to remove component"s".
Existing behaviour is not affected.