### PR TITLE
DON’T MERGE - NEW: Make DataList::getIterator a generator

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -815,11 +815,13 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * Returns an Iterator for this DataList.
      * This function allows you to use DataLists in foreach loops
      *
-     * @return ArrayIterator
+     * @return Generator
      */
     public function getIterator()
     {
-        return new ArrayIterator($this->toArray());
+        foreach ($this->dataQuery->query()->execute() as $row) {
+            yield $this->createDataObject($row);
+        }
     }
 
     /**


### PR DESCRIPTION
Huge hat tip to @SilbinaryWolf for suggesting this.

---

Currently, `DataList::getIterator()` wraps the result of `DataList::toArray()` in an `ArrayIterator`. `DataList::toArray()` will load every single row in the result into memory at once, creating a `DataObject` instance for each of them.

After this change, only the current row will be loaded into a `DataObject` and then discarded before the next one is loaded.

Crudely written benchmarks below:

### Small collections
No discernible difference in CPU or memory.
```php
$pages = Page::get()->limit(20);
$count = 0;
foreach ($pages as $page) {
	$count++;
}
echo $count;
```
<img width="1168" alt="screen shot 2017-01-13 at 10 01 30" src="https://cloud.githubusercontent.com/assets/1655548/21928179/329fc778-d981-11e6-893c-ea4ba6c607db.png">

### Large collections
Significant memory saving, some CPU sacrificed.
```php
$pages = Page::get()->limit(2000);
$count = 0;
foreach ($pages as $page) {
	$count++;
}
echo $count;
```
<img width="1285" alt="screen shot 2017-01-13 at 11 25 25" src="https://cloud.githubusercontent.com/assets/1655548/21928638/e778d1f6-d983-11e6-92bf-2219a18916d5.png">

Happy to do some more benchmarks if anyone has anything they’d like to see