### PR TITLE
Fix: calling full method name in template to pass attributes

### DIFF
--- a/templates/SilverStripe/Forms/CreditCardField.ss
+++ b/templates/SilverStripe/Forms/CreditCardField.ss
@@ -1,9 +1,9 @@
 <span id="{$Name}_Holder" class="creditCardField">
-	<input $AttributesHTML('id', 'name', 'value', 'tabindex') name="{$Name}[0]" value="{$ValueOne}" $TabIndexHTML(0)/>
+	<input $getAttributesHTML('id', 'name', 'value', 'tabindex') name="{$Name}[0]" value="{$ValueOne}" $TabIndexHTML(0)/>
 	-
-	<input $AttributesHTML('id', 'name', 'value', 'tabindex') name="{$Name}[1]" value="{$ValueTwo}" $TabIndexHTML(1)/>
+	<input $getAttributesHTML('id', 'name', 'value', 'tabindex') name="{$Name}[1]" value="{$ValueTwo}" $TabIndexHTML(1)/>
 	-
-	<input $AttributesHTML('id', 'name', 'value', 'tabindex') name="{$Name}[2]" value="{$ValueThree}" $TabIndexHTML(2)/>
+	<input $getAttributesHTML('id', 'name', 'value', 'tabindex') name="{$Name}[2]" value="{$ValueThree}" $TabIndexHTML(2)/>
 	-
-	<input $AttributesHTML('id', 'name', 'value', 'tabindex') name="{$Name}[3]" value="{$ValueFour}" $TabIndexHTML(3)/>
+	<input $getAttributesHTML('id', 'name', 'value', 'tabindex') name="{$Name}[3]" value="{$ValueFour}" $TabIndexHTML(3)/>
 </span>


### PR DESCRIPTION
Currently the CreditCardField.ss template causes invalid HTML as there are duplicate attributes. Calling`$getAttributesHTML` passes the excluded attributes properly and fixes the invalid HTML

Fix for issue [6497](https://github.com/silverstripe/silverstripe-framework/issues/6497)