### PR TITLE
ENHANCEMENT Display warning on always_populate_raw_post_data not being -1 in php 5

### DIFF
--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -791,6 +791,9 @@ specific functions.
   Please remove any PHPUnit related `require_once()` calls (e.g. in `FeatureContext`
   definitions of the [behat-extension](https://github.com/silverstripe-labs/silverstripe-behat-extension) module).
   Run `composer require --dev 'phpunit/phpunit:~4.8'` on existing projects to pull in the new dependency.
+* `always_populate_raw_post_data` will now raise a deprecation warning in install.php when running in php 5.x,
+  unless set to `-1`. This is due to `$HTTP_RAW_POST_DATA` being removed in php 7.
+  See the [http://php.net/manual/en/reserved.variables.httprawpostdata.php](php documentation) for more information.
 * Admin URL can now be configured via custom Director routing rule
 * `Controller::init` visibility changed to protected. Use `Controller::doInit()` instead.
 * `Controller::join_links` supports an array of link sections.

--- a/src/Dev/Install/install.php5
+++ b/src/Dev/Install/install.php5
@@ -665,6 +665,15 @@ class InstallRequirements {
 			. 'If not set to \'&\' this may cause issues with URL GET parameters'
 		));
 
+		// always_populate_raw_post_data should be set to -1 if PHP < 7.0
+        if (version_compare(PHP_VERSION, '7.0.0', '<')) {
+            $this->suggestPHPSetting('always_populate_raw_post_data', ['-1'], [
+                'PHP Configuration',
+                'always_populate_raw_post_data option',
+                'It\'s highly recommended to set this to \'-1\' in php 5.x, as $HTTP_RAW_POST_DATA is removed in php 7'
+            ]);
+        }
+
 		// Check memory allocation
 		$this->requireMemory(32 * 1024 * 1024, 64 * 1024 * 1024, array(
 			"PHP Configuration",


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-installer/issues/147

Screenshot:

![image](https://cloud.githubusercontent.com/assets/936064/21967000/2c668b3a-dbe3-11e6-97f7-a4f8ae940b11.png)
