### PR TITLE
FIX Reintroduce lost changes to CompositeField_holder.ss after namespacing

### DIFF
--- a/templates/SilverStripe/Forms/CompositeField.ss
+++ b/templates/SilverStripe/Forms/CompositeField.ss
@@ -1,9 +1,9 @@
 <% loop $FieldList %>
 	<% if $ColumnCount %>
 		<div class="column-{$ColumnCount} $FirstLast">
-			$Field
+			$FieldHolder
 		</div>
 	<% else %>
-		$Field
+		$FieldHolder
 	<% end_if %>
 <% end_loop %>


### PR DESCRIPTION
I'm not sure if this was deliberate or not, but a large amount of the CompositeField_holder.ss template was lost during namespacing (commit #8dd644d).

See [3.5](https://github.com/silverstripe/silverstripe-framework/blob/3ee8f505b75af39817d394bcf48623e092f43ed2/templates/forms/CompositeField_holder.ss) version compared with [current master](https://github.com/silverstripe/silverstripe-framework/blob/8dd644d25d4e01b6853922164440f8ac9c824f22/templates/SilverStripe/Forms/CompositeField_holder.ss).

In its current state, frontend composite fields do not render correctly. No labels are displayed as the individual field's holder templates are not used.

If I've mistaken this, and this was a deliberate change, please feel free to close this pull request!