### PR TITLE
Removed "release maintainer" from docs

### DIFF
--- a/docs/en/05_Contributing/04_Release_Process.md
+++ b/docs/en/05_Contributing/04_Release_Process.md
@@ -4,10 +4,6 @@ summary: Describes the process followed for "core" releases.
 
 This page describes the process followed for "core" releases (mainly the `framework` and `cms` modules).
 
-## Release Maintainer
-
-The current maintainer responsible for planning and performing releases is Ingo Schommer (ingo at silverstripe dot com).
-
 ## Release Planning
 
 Our most up-to-date release plans are typically in the ["framework" milestone](https://github.com/silverstripe/silverstripe-framework/milestones) and ["cms" milestone](https://github.com/silverstripe/silverstripe-cms/milestones).


### PR DESCRIPTION
The role moves around based on current availability.
@tractorcow has done most of the last releases,
but a separate team (headed by @dhensby) will be
responsible for 3.x releases.

There's not really much point to declaring a release maintainer,
unless there's disagreements in the core team where we need
an arbitrator. So far those conflicts have been resolved
on individual tickets (e.g. what should go into a release),
and the process for that seems to work well.