### PR TITLE
Simplify permissions displayed when admin (fixes #3310)

### DIFF
--- a/admin/client/dist/styles/bundle.css
+++ b/admin/client/dist/styles/bundle.css
@@ -7639,7 +7639,7 @@ h1{
   content:"z";
 }
 
-.font-icon-cancel-circled:before{
+.font-icon-cancel-circled:before,.font-icon-disable-circled:before{
   content:"Q";
 }
 
@@ -13510,7 +13510,7 @@ li.class-ErrorPage>a .jstree-pageicon{
   list-style-type:none;
 }
 
-.permissioncheckboxset .font-icon-cancel-circled,.permissioncheckboxset .font-icon-check-mark-circle,.permissioncheckboxsetfield_readonly .font-icon-cancel-circled,.permissioncheckboxsetfield_readonly .font-icon-check-mark-circle{
+.permissioncheckboxset .font-icon-cancel-circled,.permissioncheckboxset .font-icon-check-mark-circle,.permissioncheckboxset .font-icon-disable-circled,.permissioncheckboxsetfield_readonly .font-icon-cancel-circled,.permissioncheckboxsetfield_readonly .font-icon-check-mark-circle,.permissioncheckboxsetfield_readonly .font-icon-disable-circled{
   font-size:18px;
   position:relative;
   top:2px;
@@ -13522,6 +13522,10 @@ li.class-ErrorPage>a .jstree-pageicon{
 
 .permissioncheckboxset .font-icon-cancel-circled,.permissioncheckboxsetfield_readonly .font-icon-cancel-circled{
   color:#d40404;
+}
+
+.permissioncheckboxset .font-icon-disable-circle,.permissioncheckboxsetfield_readonly .font-icon-disable-circle{
+  color:#545d67;
 }
 
 .permissioncheckboxsetfield_readonly li,.permissioncheckboxset li{

--- a/admin/client/src/styles/_fonts.scss
+++ b/admin/client/src/styles/_fonts.scss
@@ -117,7 +117,8 @@
   content: "\7a";
 }
 
-.font-icon-cancel-circled::before {
+.font-icon-cancel-circled::before,
+.font-icon-disable-circled::before {
   content: "\51";
 }
 

--- a/admin/client/src/styles/legacy/_SecurityAdmin.scss
+++ b/admin/client/src/styles/legacy/_SecurityAdmin.scss
@@ -22,7 +22,8 @@
   }
 
   .font-icon-check-mark-circle,
-  .font-icon-cancel-circled {
+  .font-icon-cancel-circled,
+  .font-icon-disable-circled {
     font-size: 18px;
     position: relative;
     top: 2px;
@@ -34,6 +35,10 @@
 
   .font-icon-cancel-circled {
     color: $brand-danger;
+  }
+
+  .font-icon-disable-circle {
+  	color: $gray;
   }
 
   li {

--- a/src/Security/PermissionCheckboxSetField.php
+++ b/src/Security/PermissionCheckboxSetField.php
@@ -238,6 +238,11 @@ class PermissionCheckboxSetField extends FormField
                     $inheritMessage = '<small>' . $inheritMessage . '</small>';
                     $icon = ($checked) ? 'check-mark-circle' : 'cancel-circled';
 
+                    // Inherited codes are shown as a gray x
+                    if (Permission::check('ADMIN') && $code != 'ADMIN') {
+                        $icon = 'disable-circled';
+                    }
+
                     // If the field is readonly, add a span that will replace the disabled checkbox input
                     if ($this->readonly) {
                         $options .= "<li class=\"$extraClass\">"


### PR DESCRIPTION
This changes permissions inherited by being a superuser to a grey x. Fixes #3310.
![screenshot from 2017-01-18 14-23-27](https://cloud.githubusercontent.com/assets/9827696/22047109/d096605c-dd89-11e6-9a8c-a143693982d3.png)
