### PR TITLE
Fix bug: In addOrderBy method, _SortColumn will only keep the last one if there are more than 1 multi-word columns

### DIFF
--- a/model/queries/SQLSelect.php
+++ b/model/queries/SQLSelect.php
@@ -334,10 +334,12 @@ class SQLSelect extends SQLConditionalExpression {
 
 					// Move the clause to the select fragment, substituting a placeholder column in the sort fragment.
 					$clause = trim($clause);
-					$column = "_SortColumn{$i}";
+					do {
+						$column = "_SortColumn{$i}";
+						$i++;
+					} while(array_key_exists('"' . $column . '"', $this->orderby));
 					$this->selectField($clause, $column);
 					$clause = '"' . $column . '"';
-					$i++;
 				}
 				$orderby[$clause] = $dir;
 			}

--- a/tests/model/SQLQueryTest.php
+++ b/tests/model/SQLQueryTest.php
@@ -125,6 +125,18 @@ class SQLQueryTest extends SapphireTest {
 		$this->assertTrue($query->canSortBy('Name'));
 	}
 
+    /**
+     * Test multiple order by SQL clauses.
+     */
+	public function testAddOrderBy() {
+		$query = new SQLQuery();
+		$query->setSelect('ID', "Title")->setFrom('Page')->addOrderBy('(ID % 2)  = 0', 'ASC')->addOrderBy('ID > 50', 'ASC');
+		$this->assertSQLEquals(
+			'SELECT ID, Title, (ID % 2)  = 0 AS "_SortColumn0", ID > 50 AS "_SortColumn1" FROM Page ORDER BY "_SortColumn0" ASC, "_SortColumn1" ASC',
+			$query->sql($parameters)
+		);
+	}
+
 	public function testSelectWithChainedFilterParameters() {
 		$query = new SQLQuery();
 		$query->setSelect(array("Name","Meta"))->setFrom("MyTable");


### PR DESCRIPTION
Fix bug: In addOrderBy method, _SortColumn will only keep the last one if there are more than 1 multi-word columns