### PR TITLE
Fix Assets Admin Breadcrumbs

### DIFF
--- a/admin/client/src/components/Breadcrumb/Breadcrumb.scss
+++ b/admin/client/src/components/Breadcrumb/Breadcrumb.scss
@@ -8,6 +8,7 @@
 
 .breadcrumb__container {
   max-height: $toolbar-height;
+  flex-basis: 100%;
 }
 
 .breadcrumb>li.breadcrumb__item--last, // TODO Fix Bootstrap clash


### PR DESCRIPTION
Breadcrumb section doesn't fill availble space causing text wrap as per attached image
![silverstripe_-_files](https://cloud.githubusercontent.com/assets/1685217/22084427/1b7c261a-dd9e-11e6-9b03-fc40eee99cfc.png)
