### PR TITLE
API Convert::raw2json can be passed an optional bitmask of JSON constants as options

### DIFF
--- a/core/Convert.php
+++ b/core/Convert.php
@@ -126,24 +126,27 @@ class Convert {
 	}
 
 	/**
-	 * Encode a value as a JSON encoded string.
+	 * Encode a value as a JSON encoded string. You can optionally pass a bitmask of
+	 * JSON constants as options through to the encode function.
 	 *
-	 * @param mixed $val Value to be encoded
-	 * @return string JSON encoded string
+	 * @param  mixed $val     Value to be encoded
+	 * @param  int   $options Optional bitmask of JSON constants
+	 * @return string 		  JSON encoded string
 	 */
-	public static function raw2json($val) {
-		return json_encode($val);
+	public static function raw2json($val, $options = 0) {
+		return json_encode($val, $options);
 	}
 
 	/**
 	 * Encode an array as a JSON encoded string.
-	 * THis is an alias to {@link raw2json()}
+	 * This is an alias to {@link raw2json()}
 	 *
-	 * @param array $val Array to convert
-	 * @return string JSON encoded string
+	 * @param  array  $val     Array to convert
+	 * @param  int    $options Optional bitmask of JSON constants
+	 * @return string          JSON encoded string
 	 */
-	public static function array2json($val) {
-		return self::raw2json($val);
+	public static function array2json($val, $options = 0) {
+		return self::raw2json($val, $options);
 	}
 
 	/**

--- a/tests/core/ConvertTest.php
+++ b/tests/core/ConvertTest.php
@@ -304,6 +304,20 @@ PHP
 	}
 
 	/**
+	 * Test that a context bitmask can be passed through to the json_encode method in {@link Convert::raw2json()}
+	 * and in {@link Convert::array2json()}
+	 */
+	public function testRaw2JsonWithContext()
+	{
+	    $data = array('foo' => 'b"ar');
+	    $expected = '{"foo":"b\u0022ar"}';
+	    $result = Convert::raw2json($data, JSON_HEX_QUOT);
+	    $this->assertSame($expected, $result);
+	    $wrapperResult = Convert::array2json($data, JSON_HEX_QUOT);
+	    $this->assertSame($expected, $wrapperResult);
+	}
+
+	/**
 	 * Tests {@link Convert::xml2array()}
 	 */
 	public function testXML2Array() {


### PR DESCRIPTION
This allows for JSON constants like `JSON_PRETTY_PRINT` and `JSON_UNESCAPED_SLASHES` to be passed through `Convert::raw2json`.

Resolves #6550 