### PR TITLE
Use customizable controller name method in Security::getResponseController

### DIFF
--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -547,7 +547,7 @@ class Security extends Controller implements TemplateGlobalProvider
         // Disable ID-based caching  of the log-in page by making it a random number
         $tmpPage->ID = -1 * rand(1, 10000000);
 
-        $controllerClass = $tmpPage->getControllerName();
+        $controllerClass = $tmpPage->getFrontendControllerName();
         $controller = $controllerClass::create($tmpPage);
         $controller->setDataModel($this->model);
         $controller->doInit();


### PR DESCRIPTION
This is a follow up PR for consistency, from silverstripe/silverstripe-cms#1722 to ensure we use a consistent public API throughout.

The builds shouldn't pass until that PR is merged.

Part of #6549 