### PR TITLE
Fixed iframe postmessage breaking non-string messages

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -73,7 +73,7 @@ jQuery.noConflict();
 		$(window).on("message", function(e) {
 			var target,
 				event = e.originalEvent,
-				data = JSON.parse(event.data);
+				data = typeof event.data === 'object' ? event.data : JSON.parse(event.data);
 
 			// Reject messages outside of the same origin
 			if($.path.parseUrl(window.location.href).domain !== $.path.parseUrl(event.origin).domain) return;


### PR DESCRIPTION
See issue: https://github.com/silverstripe/silverstripe-framework/issues/6562

This is a fix for that, which was already implemented in the code for version 4.0.