### PR TITLE
ENHANCEMENT: DBField 'setter' methods return instance of themselves

### DIFF
--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -33,6 +33,7 @@ class DBDate extends DBField
      * @config
      * @see DBDateTime::nice_format
      * @see DBTime::nice_format
+     * @return $this
      */
     private static $nice_format = 'd/m/Y';
 
@@ -42,18 +43,19 @@ class DBDate extends DBField
             // don't try to evaluate empty values with strtotime() below, as it returns "1970-01-01" when it should be
             // saved as NULL in database
             $this->value = null;
-            return;
+            return $this;
         }
 
         // @todo This needs tidy up (what if you only specify a month and a year, for example?)
         if (is_array($value)) {
             if (!empty($value['Day']) && !empty($value['Month']) && !empty($value['Year'])) {
                 $this->value = $value['Year'] . '-' . $value['Month'] . '-' . $value['Day'];
-                return;
-            } else {
-                // return nothing (so checks below don't fail on an empty array)
-                return null;
             }
+            /*
+             * return $this whether successfully set values from array based
+             * input or not (so checks below don't fail on an empty array)
+             */
+            return $this;
         }
 
         // Default to NZ date format - strtotime expects a US date
@@ -67,12 +69,11 @@ class DBDate extends DBField
             try {
                 $date = new DateTime($value);
                 $this->value = $date->format('Y-m-d');
-                return;
             } catch (Exception $e) {
                 $this->value = null;
-                return;
             }
         }
+        return $this;
     }
 
     /**

--- a/src/ORM/FieldType/DBField.php
+++ b/src/ORM/FieldType/DBField.php
@@ -148,7 +148,7 @@ abstract class DBField extends ViewableData
      *
      * @param string $name
      *
-     * @return DBField
+     * @return $this
      */
     public function setName($name)
     {
@@ -196,10 +196,12 @@ abstract class DBField extends ViewableData
      * @param bool $markChanged Indicate wether this field should be marked changed.
      *  Set to FALSE if you are initializing this field after construction, rather
      *  than setting a new value.
+     * @return $this
      */
     public function setValue($value, $record = null, $markChanged = true)
     {
         $this->value = $value;
+        return $this;
     }
 
     /**
@@ -446,7 +448,9 @@ abstract class DBField extends ViewableData
     {
         $fieldName = $this->name;
         if (empty($fieldName)) {
-            throw new \BadMethodCallException("DBField::saveInto() Called on a nameless '" . get_class($this) . "' object");
+            throw new \BadMethodCallException(
+                "DBField::saveInto() Called on a nameless '" . get_class($this) . "' object"
+            );
         }
         $dataObject->$fieldName = $this->value;
     }

--- a/src/ORM/FieldType/DBMoney.php
+++ b/src/ORM/FieldType/DBMoney.php
@@ -103,10 +103,12 @@ class DBMoney extends DBComposite
     /**
      * @param string $currency
      * @param bool $markChanged
+     * @return $this
      */
     public function setCurrency($currency, $markChanged = true)
     {
         $this->setField('Currency', $currency, $markChanged);
+        return $this;
     }
 
     /**
@@ -120,10 +122,12 @@ class DBMoney extends DBComposite
     /**
      * @param float $amount
      * @param bool $markChanged
+     * @return $this
      */
     public function setAmount($amount, $markChanged = true)
     {
         $this->setField('Amount', (float)$amount, $markChanged);
+        return $this;
     }
 
     /**
@@ -145,11 +149,13 @@ class DBMoney extends DBComposite
 
     /**
      * @param string $locale
+     * @return $this
      */
     public function setLocale($locale)
     {
         $this->locale = $locale;
         $this->currencyLib->setLocale($locale);
+        return $this;
     }
 
     /**
@@ -214,10 +220,12 @@ class DBMoney extends DBComposite
 
     /**
      * @param array $arr
+     * @return $this
      */
     public function setAllowedCurrencies($arr)
     {
         $this->allowedCurrencies = $arr;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Many of the methods on DBField (mainly the 'setter' methods i.e. setValue()) and it's sub-classes (for example DBMoney and DBDate) simply set the corresponding value on the instance and return void via:
 - no return statement
 - return statement which does not specify any return value
 - return null

This is inconsistent with the behaviour of, for example, their corresponding extensions of FormField (e.g. MoneyField and DateField) which return an instance of themselves after performing the setting of any values.

This means that chaining of these setter methods is not possible, nor is setting a value on the DBField instance as part of another methods return statement (at least not if you expect/intend for the method to return an instance of DBMoney etc).

For example, instead of code like this:
```php
    public function getTotal()
    {
        // In practise, some calculation would be done here, but for this example it's hardcoded
        $t = 25.99;
        return DBMoney::create('Total')->setCurrency('GBP')->setValue($t);
    }
```

Which can then be used in other methods like so:

```php
    $config = GridFieldConfig_RelationEditor();
    $columns = $config->getComponentByType("GridFieldEditableColumns");
    $columns->setFieldFormatting(
        [
            "FormattedTotal" => function($value, $item) {
                $total = $item->getTotal();
                $class = ($total->getAmount() > 100.00) ? "high-value" : "standard-value";
	        return "<span class=\"" . $class . "\">" . $item->getTotal()->Nice() . "</span>";
	    }
	]
    );
```

or in SilverStripe templates like this:

```html
<div class="totals">
    <p><strong>Total:</strong> {$getTotal.Nice()}</p>
</div>
```

We need to write code like this (which seems un-nessercary and inconsistent with other usage of the create() 'factory' method and method chaining):
```php
    public function getTotal()
    {
        // In practise, some calculation would be done here, but for this example it's hardcoded
        $t = 25.99;
       
        $total = DBMoney::create('Total');
        $total->setCurrency('GBP')
        $total->setValue($t);

        return $total;
    }
```

I have started by making the required modifications to:

- DBField
- DBMoney
- DBDate

However, I wanted to validate that this PR will be accepted before going any further. I have had some discussion in the SilverStripe Users Slack channel regarding this and have been advised to create a PR for it.
