### PR TITLE
add segment config var to buildtask

### DIFF
--- a/dev/BuildTask.php
+++ b/dev/BuildTask.php
@@ -13,6 +13,14 @@
 abstract class BuildTask extends Object {
 
 	/**
+	 * Set a custom url segment (to follow dev/tasks/)
+	 *
+	 * @config
+	 * @var string
+	 */
+	private static $segment = null;
+
+	/**
 	 * @var bool $enabled If set to FALSE, keep it from showing in the list
 	 * and from being executable through URL or CLI.
 	 */

--- a/dev/TaskRunner.php
+++ b/dev/TaskRunner.php
@@ -103,17 +103,18 @@ class TaskRunner extends Controller {
 		// remove the base class
 		array_shift($taskClasses);
 
-		if($taskClasses) foreach($taskClasses as $class) {
+		foreach($taskClasses as $class) {
 			if (!$this->taskEnabled($class)) continue;
+			$singleton = singleton($class);
 
 			$desc = (Director::is_cli())
-				? Convert::html2raw(singleton($class)->getDescription())
-				: singleton($class)->getDescription();
+				? Convert::html2raw($singleton->getDescription())
+				: $singleton->getDescription();
 
 			$availableTasks[] = array(
 				'class' => $class,
 				'title' => singleton($class)->getTitle(),
-				'segment' => str_replace('\\', '-', $class),
+				'segment' => $singleton->config()->segment ?: str_replace('\\', '-', $class),
 				'description' => $desc,
 			);
 		}


### PR DESCRIPTION
Resolves #6556 

Backport of the SS4 `$segment` config variable to allow for namespaced `Buildtask`s to not have awful URLs.