### PR TITLE
 BUG Ensure that tests run with flush=1 clean Flushables

### DIFF
--- a/tests/php/Control/FlushRequestFilterTest.php
+++ b/tests/php/Control/FlushRequestFilterTest.php
@@ -2,20 +2,20 @@
 
 namespace SilverStripe\Control\Tests;
 
+use SilverStripe\Control\Tests\FlushRequestFilterTest\TestFlushable;
 use SilverStripe\Dev\FunctionalTest;
 
 class FlushRequestFilterTest extends FunctionalTest
 {
-
     /**
      * Assert that classes that implement flushable are called
      */
     public function testImplementorsAreCalled()
     {
-        $this->assertFalse(FlushRequestFilterTest\TestFlushable::$flushed);
+        TestFlushable::$flushed = false;
 
         $this->get('?flush=1');
 
-        $this->assertTrue(FlushRequestFilterTest\TestFlushable::$flushed);
+        $this->assertTrue(TestFlushable::$flushed);
     }
 }


### PR DESCRIPTION
flush=all will set a flushed test manifest, but no other flushables are invoked.