### PR TITLE
Cast SmallFieldHolder to HTMLFragment - fixes #6568

### DIFF
--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -255,6 +255,7 @@ class FormField extends RequestHandler
 
     private static $casting = array(
         'FieldHolder' => 'HTMLFragment',
+        'SmallFieldHolder' => 'HTMLFragment',
         'Field' => 'HTMLFragment',
         'AttributesHTML' => 'HTMLFragment', // property $AttributesHTML version
         'getAttributesHTML' => 'HTMLFragment', // method $getAttributesHTML($arg) version


### PR DESCRIPTION
`LiteralField` should now render correctly in `FieldGroup`.