### PR TITLE
FIX Ensure that Zend_ classes can still be autoloaded

### DIFF
--- a/src/Core/Core.php
+++ b/src/Core/Core.php
@@ -54,6 +54,14 @@ mb_regex_encoding('UTF-8');
  */
 gc_enable();
 
+/**
+ * Include the Zend autoloader. This will be removed in the near future.
+ */
+if (file_exists('thirdparty/Zend/Loader/Autoloader.php')) {
+    require_once 'thirdparty/Zend/Loader/Autoloader.php';
+    Zend_Loader_Autoloader::getInstance();
+}
+
 // Initialise the dependency injector as soon as possible, as it is
 // subsequently used by some of the following code
 $injector = new Injector(array('locator' => 'SilverStripe\\Core\\Injector\\SilverStripeServiceConfigurationLocator'));


### PR DESCRIPTION
cc @tractorcow

This is a temporary change to support the autoloading of `Zend_*` classes since the removal of some of them during the Zend -> Symfony translation PR.

This change ensures that the Zend autoloader is instantiated early on in the process.

Resolves #6572.