### PR TITLE
Fix pipe use in new composer constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "symfony/yaml": "~2.7",
     "embed/embed": "^2.6",
     "swiftmailer/swiftmailer": "~5.4",
-    "symfony/config": "^2.8|^3",
-    "symfony/translation": "^2.8|^3",
+    "symfony/config": "^2.8||^3",
+    "symfony/translation": "^2.8||^3",
     "vlucas/phpdotenv": "^2.4"
   },
   "require-dev": {


### PR DESCRIPTION
Single pipes aren't defined in the composer spec,
and cause issues when installing other dependencies like silverstripe/behat-extension.

See https://getcomposer.org/doc/articles/versions.md#range