### PR TITLE
Remove optional Symfony 3.x dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "symfony/yaml": "~2.7",
     "embed/embed": "^2.6",
     "swiftmailer/swiftmailer": "~5.4",
-    "symfony/config": "^2.8|^3",
-    "symfony/translation": "^2.8|^3",
+    "symfony/config": "^2.8",
+    "symfony/translation": "^2.8",
     "vlucas/phpdotenv": "^2.4"
   },
   "require-dev": {


### PR DESCRIPTION
They cause issues with installing silverstripe/behat-extension after the fact,
since it requires 2.x - and would need the existing project to downgrade the dep.
While this should be composer's default behaviour (https://github.com/composer/composer/issues/6121), from a SilverStripe perspective we should have consistent dependencies regardless of the execution path in your require calls - anything else will lead to fragile test vs. prod errors.

We can require Symfony 3.x once we've upgraded to Behat 3.x.