### PR TITLE
BUG: Fix GridFieldExportButton column selection for export

### DIFF
--- a/forms/gridfield/GridFieldExportButton.php
+++ b/forms/gridfield/GridFieldExportButton.php
@@ -98,11 +98,16 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 	 * @return array
 	 */
 	public function generateExportFileData($gridField) {
-		$separator = $this->csvSeparator;
-		$csvColumns = ($this->exportColumns)
-			? $this->exportColumns
-			: singleton($gridField->getModelClass())->summaryFields();
 		$fileData = '';
+		$separator = $this->csvSeparator;
+
+		if($this->exportColumns) {
+			$csvColumns = $this->exportColumns;
+		} else if($dataCols = $gridField->getConfig()->getComponentByType('GridFieldDataColumns')) {
+			$csvColumns = $dataCols->getDisplayFields($gridField);
+		} else {
+			$csvColumns = singleton($gridField->getModelClass())->summaryFields();
+		}
 
 		if($this->csvHasHeader) {
 			$headers = array();

--- a/tests/forms/gridfield/GridFieldExportButtonTest.php
+++ b/tests/forms/gridfield/GridFieldExportButtonTest.php
@@ -115,6 +115,26 @@ class GridFieldExportButtonTest extends SapphireTest {
 			$button->generateExportFileData($this->gridField)
 		);
 	}
+
+	/**
+	 * @covers GridFieldExportButton::generateExportFileData()
+	 */
+	public function testMultipleColumnExport() {
+		$list = new ArrayList();
+		$list->add(new DataObject([
+			'Key' => 'FAKE_KEY',
+			'Val' => 22
+		]));
+
+		/** @var GridField $field */
+		$field = clone $this->gridField;
+		$columns = new GridFieldDataColumns();
+		$field->getConfig()->addComponent($columns->setDisplayFields(['Key', 'Val']));
+		$field->setList($list);
+		$button = new GridFieldExportButton();
+
+		$this->assertSame("\"Key\",\"Val\"\n\"FAKE_KEY\",\"22\"\n", $button->generateExportFileData($field));
+	}
 }
 
 /**


### PR DESCRIPTION
`GridFieldPrintButton` uses a three-phase approach to finding columns to export:

 1. Look for `GridFieldPrintButton->printColumns` set directly on the button
 2. Look for the presence of `GridFieldDataColumns` config on the `GridField` to determine the columns included in the browser view
 3. Fallback on the `DataObject->summaryFields()` for the given object to export

By contrast, `GridFieldExportButton` only looks at (1) and (3) above. This isn't consistent across both buttons, which leads to a lot of people defining either their own implementation of `GridFieldExportButton`, or explicitly setting fields on the export button, but not needing to for the print button.

This fixes that, but making sure that `GridFieldExportButton` is updated to look in the same 3 places (in the same order) as `GridFieldPrintButton`.