### PR TITLE
Move code coverage report upload to after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,11 @@ script:
   - "if [ \"$NPM_TEST\" = \"1\" ]; then git diff -w --no-color; fi"
   - "if [ \"$NPM_TEST\" = \"1\" ]; then npm run test; fi"
   - "if [ \"$NPM_TEST\" = \"1\" ]; then npm run lint; fi"
+  - "if [ \"$PHPCS_TEST\" = \"1\" ]; then composer run-script lint; fi"
+
+after_success:
   - "if [ \"$PHPUNIT_COVERAGE_TEST\" = \"1\" ] && [ \"$CMS_TEST\" = \"\" ]; then phpdbg -qrr ./vendor/bin/phpunit --coverage-clover=coverage.xml; fi"
   - "if [ \"$PHPUNIT_COVERAGE_TEST\" = \"1\" ] && [ \"$CMS_TEST\" = \"\" ]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi"
-  - "if [ \"$PHPCS_TEST\" = \"1\" ]; then composer run-script lint; fi"
 
 after_failure:
   - php ./tests/behat/travis-upload-artifacts.php --if-env BEHAT_TEST,ARTIFACTS_BUCKET,ARTIFACTS_KEY,ARTIFACTS_SECRET --target-path $TRAVIS_REPO_SLUG/$TRAVIS_BUILD_ID/$TRAVIS_JOB_ID --artifacts-base-url https://s3.amazonaws.com/$ARTIFACTS_BUCKET/


### PR DESCRIPTION
Code coverage takes so long it normally causes builds to timeout.

This change means that if we do get through the test suite and the upload just takes too long we will get a successful build status regardless.