### PR TITLE
FIX JS Tree is whitespace sensitive

### DIFF
--- a/admin/templates/Includes/LeftAndMain_TreeNode.ss
+++ b/admin/templates/Includes/LeftAndMain_TreeNode.ss
@@ -1,5 +1,4 @@
-<li id="record-$ID" data-id="$ID" data-pagetype="$ClassName" class="$Classes">
-	<ins class="jstree-icon">&nbsp;</ins>
+<li id="record-$ID" data-id="$ID" data-pagetype="$ClassName" class="$Classes"><ins class="jstree-icon">&nbsp;</ins>
 	<a href="$Link" title="$Title.ATT"><ins class="jstree-icon">&nbsp;</ins>
 		<span class="text">$TreeTitle</span>
 	</a>


### PR DESCRIPTION
fixes #6606 

I found this with the original patch, but the current jstree lib is very sensitive to whitespace when it manipulates the XHR resposne