### PR TITLE
FIX Array to string conversion message after CSV export

### DIFF
--- a/forms/gridfield/GridFieldExportButton.php
+++ b/forms/gridfield/GridFieldExportButton.php
@@ -111,7 +111,11 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 			// determine the CSV headers. If a field is callable (e.g. anonymous function) then use the
 			// source name as the header instead
 			foreach($csvColumns as $columnSource => $columnHeader) {
-				$headers[] = (!is_string($columnHeader) && is_callable($columnHeader)) ? $columnSource : $columnHeader;
+                if (is_array($columnHeader) && array_key_exists('title', $columnHeader)) {
+                    $headers[] = $columnHeader['title'];
+                } else {
+                    $headers[] = (!is_string($columnHeader) && is_callable($columnHeader)) ? $columnSource : $columnHeader;
+                }
 			}
 
 			$fileData .= "\"" . implode("\"{$separator}\"", array_values($headers)) . "\"";


### PR DESCRIPTION
Added a check where an array column definition is used instead
of just a string (fixes #6617).