### PR TITLE
FIX Comments ignored by classmanifest

### DIFF
--- a/core/manifest/ClassManifest.php
+++ b/core/manifest/ClassManifest.php
@@ -61,16 +61,16 @@ class SS_ClassManifest {
 	public static function get_namespaced_class_parser() {
 		return new TokenisedRegularExpression(array(
 			0 => T_CLASS,
-			1 => T_WHITESPACE,
+			1 => array(T_WHITESPACE, 'optional' => true),
 			2 => array(T_STRING, 'can_jump_to' => array(8, 16), 'save_to' => 'className'),
-			3 => T_WHITESPACE,
+			3 => array(T_WHITESPACE, 'optional' => true),
 			4 => T_EXTENDS,
-			5 => T_WHITESPACE,
+			5 => array(T_WHITESPACE, 'optional' => true),
 			6 => array(T_NS_SEPARATOR, 'save_to' => 'extends[]', 'optional' => true),
 			7 => array(T_STRING, 'save_to' => 'extends[]', 'can_jump_to' => array(6, 16)),
-			8 => T_WHITESPACE,
+			8 => array(T_WHITESPACE, 'optional' => true),
 			9 => T_IMPLEMENTS,
-			10 => T_WHITESPACE,
+			10 => array(T_WHITESPACE, 'optional' => true),
 			11 => array(T_NS_SEPARATOR, 'save_to' => 'interfaces[]', 'optional' => true),
 			12 => array(T_STRING, 'can_jump_to' => array(11, 16), 'save_to' => 'interfaces[]'),
 			13 => array(T_WHITESPACE, 'optional' => true),
@@ -87,7 +87,7 @@ class SS_ClassManifest {
 	public static function get_namespace_parser() {
 		return new TokenisedRegularExpression(array(
 			0 => T_NAMESPACE,
-			1 => T_WHITESPACE,
+			1 => array(T_WHITESPACE, 'optional' => true),
 			2 => array(T_NS_SEPARATOR, 'save_to' => 'namespaceName[]', 'optional' => true),
 			3 => array(T_STRING, 'save_to' => 'namespaceName[]', 'can_jump_to' => 2),
 			4 => array(T_WHITESPACE, 'optional' => true),
@@ -101,7 +101,7 @@ class SS_ClassManifest {
 	public static function get_interface_parser() {
 		return new TokenisedRegularExpression(array(
 			0 => T_INTERFACE,
-			1 => T_WHITESPACE,
+			1 => array(T_WHITESPACE, 'optional' => true),
 			2 => array(T_STRING, 'save_to' => 'interfaceName')
 		));
 	}
@@ -119,7 +119,7 @@ class SS_ClassManifest {
 	public static function get_imported_namespace_parser() {
 		return new TokenisedRegularExpression(array(
 			0 => T_USE,
-			1 => T_WHITESPACE,
+			1 => array(T_WHITESPACE, 'optional' => true),
 			2 => array(T_NS_SEPARATOR, 'save_to' => 'importString[]', 'optional' => true),
 			3 => array(T_STRING, 'save_to' => 'importString[]', 'can_jump_to' => array(2, 8)),
 			4 => array(T_WHITESPACE, 'save_to' => 'importString[]'),

--- a/core/manifest/TokenisedRegularExpression.php
+++ b/core/manifest/TokenisedRegularExpression.php
@@ -102,6 +102,9 @@ class TokenisedRegularExpression {
 			}
 			else return true;
 		}
+		else if (in_array($tokens[$tokenPos][0], array(T_COMMENT, T_DOC_COMMENT, T_WHITESPACE))) {
+			return $this->matchFrom($tokenPos + 1, $expressionPos, $tokens, $matches);
+		}
 
 		return false;
 

--- a/tests/core/manifest/ClassManifestTest.php
+++ b/tests/core/manifest/ClassManifestTest.php
@@ -41,6 +41,7 @@ class ClassManifestTest extends SapphireTest {
 			'classb'                   => "{$this->base}/module/classes/ClassB.php",
 			'classc'                   => "{$this->base}/module/classes/ClassC.php",
 			'classd'                   => "{$this->base}/module/classes/ClassD.php",
+			'classe'                   => "{$this->base}/module/classes/ClassE.php",
 			'sstemplateparser'         => FRAMEWORK_PATH."/view/SSTemplateParser.php",
 			'sstemplateparseexception' => FRAMEWORK_PATH."/view/SSTemplateParser.php"
 		);
@@ -49,7 +50,7 @@ class ClassManifestTest extends SapphireTest {
 
 	public function testGetClassNames() {
 		$this->assertEquals(
-			array('sstemplateparser', 'sstemplateparseexception', 'classa', 'classb', 'classc', 'classd'),
+			array('sstemplateparser', 'sstemplateparseexception', 'classa', 'classb', 'classc', 'classd', 'classe'),
 			$this->manifest->getClassNames());
 	}
 

--- a/tests/core/manifest/fixtures/classmanifest/module/classes/ClassE.php
+++ b/tests/core/manifest/fixtures/classmanifest/module/classes/ClassE.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @ignore
+ */
+class/* */ClassE /**  */ //test
+{
+
+}


### PR DESCRIPTION
Fixes #6615

`TokenizedRegularExpression` now takes an optional list of tokens to ignore when searching for matches.

This means that an unexpected comment or whitespace sprinkled between the expected structure of the TRE is ignored rather than causing silen failures or breakages.