### PR TITLE
Original File Title charset on upload.

### DIFF
--- a/filesystem/Upload.php
+++ b/filesystem/Upload.php
@@ -208,6 +208,7 @@ class Upload extends Controller {
 			$this->file->ParentID = $parentFolder ? $parentFolder->ID : 0;
 			// This is to prevent it from trying to rename the file
 			$this->file->Name = basename($relativeFilePath);
+			$this->file->Title = preg_replace("/{$fileSuffix}$/", '', $tmpFile['name']);
 			$this->file->write();
 			$this->file->onAfterUpload();
 			$this->extend('onAfterLoad', $this->file, $tmpFile);   //to allow extensions to e.g. create a version after an upload


### PR DESCRIPTION
For example content-manager uploads "мой файл.jpg"
File name will be "moi-fail.jpg"
but file title will be "мой файл".

For now framework makes file title like "moi-fail".

I think it's comfortable to left original filename's charset for file title.
What do you think about it?