### PR TITLE
avoid potential php warning

### DIFF
--- a/parsers/ShortcodeParser.php
+++ b/parsers/ShortcodeParser.php
@@ -624,7 +624,7 @@ class ShortcodeParser extends Object {
 				$this->replaceMarkerWithContent($shortcode, $tag);
 			}
 
-			$content = $htmlvalue->getContent();
+			$content = @$htmlvalue->getContent();
 
 			// Clean up any marker classes left over, for example, those injected into <script> tags
 			$parser = $this;


### PR DESCRIPTION
If markup is invalid, this will trigger a warning. Adding a @ suppress the error.