### PR TITLE
Absolute paths for theme lang dirs (fixes #1354)

### DIFF
--- a/src/i18n/Data/Sources.php
+++ b/src/i18n/Data/Sources.php
@@ -91,7 +91,7 @@ class Sources implements Resettable
         }
         $paths = [];
 
-        // Search sorted modules
+        // Search sorted modules (receives absolute paths)
         foreach ($this->getSortedModules() as $module => $path) {
             $langPath = "{$path}/lang/";
             if (is_dir($langPath)) {
@@ -99,14 +99,14 @@ class Sources implements Resettable
             }
         }
 
-        // Search theme dirs
+        // Search theme dirs (receives relative paths)
         $locator = ThemeResourceLoader::instance();
         foreach (SSViewer::get_themes() as $theme) {
             if ($locator->getSet($theme)) {
                 continue;
             }
             $path = $locator->getPath($theme);
-            $langPath = "{$path}/lang/";
+            $langPath = BASE_PATH . "/{$path}/lang/";
             if (is_dir($langPath)) {
                 $paths[] = $langPath;
             }


### PR DESCRIPTION
Regression in 4.x i18n rewrite. Can’t test this since ThemeResourceLoader hardcodes constants like THEME_DIR,
so its impossible to mock in different directory structures. Ideally this would use an application object with access
to environment variables, but that’s too much of a refactor to validate this simple fix.