### PR TITLE
Fixes for issues introduced in 5e19d905

### DIFF
--- a/admin/client/dist/js/bundle.js
+++ b/admin/client/dist/js/bundle.js
@@ -1128,10 +1128,8 @@ minHeight:370,maxHeight:400,closeOnEscape:!1,open:function e(){$(".ui-widget-ove
 
 }})},onunmatch:function x(){this._super()},open:function R(){this.ssdialog("open")},close:function I(){this.ssdialog("close")},toggle:function F(e){this.is(":visible")?this.close():this.open()},reauthenticate:function A(e){
 "undefined"!=typeof e.SecurityID&&$(":input[name=SecurityID]").val(e.SecurityID),"undefined"!=typeof e.TempID&&$("body").data("member-tempid",e.TempID),this.close()}}),$("form.loading,.cms-content.loading,.cms-content-fields.loading,.cms-content-view.loading").entwine({
-onmatch:function D(){this.closest("div").append('<div class="cms-content-loading-overlay ui-widget-overlay-light"></div><div class="cms-content-loading-spinner"></div>'),this._super()},onunmatch:function M(){
-this.closest("div").find(".cms-content-loading-overlay,.cms-content-loading-spinner").remove(),this._super()}}),$(".cms .cms-panel-link").entwine({onclick:function N(e){if($(this).hasClass("external-link"))return void e.stopPropagation()
-
-
+onmatch:function D(){this.append('<div class="cms-content-loading-overlay ui-widget-overlay-light"></div><div class="cms-content-loading-spinner"></div>'),this._super()},onunmatch:function M(){this.find(".cms-content-loading-overlay,.cms-content-loading-spinner").remove(),
+this._super()}}),$(".cms .cms-panel-link").entwine({onclick:function N(e){if($(this).hasClass("external-link"))return void e.stopPropagation()
 var t=this.attr("href"),n=t&&!t.match(/^#/)?t:this.data("href"),i={pjax:this.data("pjaxTarget")}
 $(".cms-container").loadPanel(n,null,i),e.preventDefault()}}),$(".cms .ss-ui-button-ajax").entwine({onclick:function onclick(e){$(this).removeClass("ui-button-text-only"),$(this).addClass("ss-ui-button-loading ui-button-text-icons")
 

--- a/admin/client/src/legacy/LeftAndMain.js
+++ b/admin/client/src/legacy/LeftAndMain.js
@@ -1041,11 +1041,11 @@ $.entwine('ss', function($) {
    */
   $('form.loading,.cms-content.loading,.cms-content-fields.loading,.cms-content-view.loading').entwine({
     onmatch: function() {
-      this.closest('div').append('<div class="cms-content-loading-overlay ui-widget-overlay-light"></div><div class="cms-content-loading-spinner"></div>');
+      this.append('<div class="cms-content-loading-overlay ui-widget-overlay-light"></div><div class="cms-content-loading-spinner"></div>');
       this._super();
     },
     onunmatch: function() {
-      this.closest('div').find('.cms-content-loading-overlay,.cms-content-loading-spinner').remove();
+      this.find('.cms-content-loading-overlay,.cms-content-loading-spinner').remove();
       this._super();
     }
   });


### PR DESCRIPTION
As the "onunmatch" is triggered AFTER the element is removed
  from the DOM it never finds the `closest('div')` when switching
  screens. E.g. when using GridField edit
  So when you go from the GridField edit screen back to the page
  you end up with the page loaded but the spinner doesn't disappear
Other option would be to do `$('body').find('.cms-content-loading-overlay,.cms-content-loading-spinner').remove()`
  but this is probably a bit drastic