### PR TITLE
Ensure test objects implement TestOnly

### DIFF
--- a/tests/php/Forms/FormFactoryTest/TestObject.php
+++ b/tests/php/Forms/FormFactoryTest/TestObject.php
@@ -2,13 +2,14 @@
 
 namespace SilverStripe\Forms\Tests\FormFactoryTest;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Versioning\Versioned;
 
 /**
  * @mixin Versioned
  */
-class TestObject extends DataObject
+class TestObject extends DataObject implements TestOnly
 {
     private static $table_name = 'FormFactoryTest_TestObject';
 

--- a/tests/php/Forms/GridField/GridFieldPaginatorTest.php
+++ b/tests/php/Forms/GridField/GridFieldPaginatorTest.php
@@ -12,6 +12,7 @@ use SilverStripe\Forms\GridField\GridFieldConfig;
 use SilverStripe\Forms\GridField\GridFieldPageCount;
 use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\Forms\GridField\GridFieldToolbarHeader;
+use SilverStripe\Forms\Tests\GridField\GridFieldTest\Cheerleader;
 use SilverStripe\Forms\Tests\GridField\GridFieldTest\Player;
 use SilverStripe\Forms\Tests\GridField\GridFieldTest\Team;
 use SilverStripe\ORM\ArrayList;
@@ -44,7 +45,8 @@ class GridFieldPaginatorTest extends FunctionalTest
      */
     protected $extraDataObjects = array(
         Team::class,
-        Player::class
+        Player::class,
+        Cheerleader::class,
     );
 
     public function setUp()

--- a/tests/php/ORM/ChangeSetItemTest/VersionedObject.php
+++ b/tests/php/ORM/ChangeSetItemTest/VersionedObject.php
@@ -2,13 +2,14 @@
 
 namespace SilverStripe\ORM\Tests\ChangeSetItemTest;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Versioning\Versioned;
 
 /**
  * @mixin Versioned
  */
-class VersionedObject extends DataObject
+class VersionedObject extends DataObject implements TestOnly
 {
     private static $table_name = 'ChangeSetItemTest_Versioned';
 


### PR DESCRIPTION
Make sure test objects implement `TestOnly` interface and that they are in the `$extraDataObjects` array where needed.