### PR TITLE
Patch - corrupted image file proof

### DIFF
--- a/filesystem/Upload.php
+++ b/filesystem/Upload.php
@@ -139,6 +139,7 @@ class Upload extends Controller {
                 try {
                     $test = new ImagickBackend($tmp_name);
                 } catch (Exception $e) {
+					SS_Log::log($e, SS_Log::ERR);
                     if ($controller = Controller::curr()) {
                         if ($controller->request->isAjax()){
                             return $controller->httpError(500, 'Image corrupted');

--- a/filesystem/Upload.php
+++ b/filesystem/Upload.php
@@ -131,6 +131,20 @@ class Upload extends Controller {
 			$this->errors[] = _t('File.NOFILESIZE', 'File size is zero bytes.');
 			return false;
 		}
+		
+		$tmp_name = $tmpFile['tmp_name'];
+
+        try {
+            $test = new ImagickBackend($tmp_name);
+        } catch (Exception $e) {
+            if ($controller = Controller::curr()) {
+                if ($controller->request->isAjax()){
+                    return $controller->httpError(500, 'Image corrupted');
+                }
+            }
+            $this->errors[] = _t('File.CORRUPTED_IMAGE', 'Image corrupted.');
+            return false;
+        }
 
 		$valid = $this->validate($tmpFile);
 		if(!$valid) return false;

--- a/filesystem/Upload.php
+++ b/filesystem/Upload.php
@@ -132,20 +132,24 @@ class Upload extends Controller {
 			return false;
 		}
 		
-		$tmp_name = $tmpFile['tmp_name'];
-
-        try {
-            $test = new ImagickBackend($tmp_name);
-        } catch (Exception $e) {
-            if ($controller = Controller::curr()) {
-                if ($controller->request->isAjax()){
-                    return $controller->httpError(500, 'Image corrupted');
+		if (!empty($tmpFile['type'])) {
+            $type = $tmpFile['type'];
+            if (strpos($type, 'image/') !== false) {
+                $tmp_name = $tmpFile['tmp_name'];
+                try {
+                    $test = new ImagickBackend($tmp_name);
+                } catch (Exception $e) {
+                    if ($controller = Controller::curr()) {
+                        if ($controller->request->isAjax()){
+                            return $controller->httpError(500, 'Image corrupted');
+                        }
+                    }
+                    $this->errors[] = _t('File.CORRUPTED_IMAGE', 'Image corrupted.');
+                    return false;
                 }
             }
-            $this->errors[] = _t('File.CORRUPTED_IMAGE', 'Image corrupted.');
-            return false;
         }
-
+		
 		$valid = $this->validate($tmpFile);
 		if(!$valid) return false;
 


### PR DESCRIPTION
when a corrupted image file is uploaded onto the server, it sometimes bypasses the validation (e.g. by a customised form, or extended file uploader), and get stored into the asset directory, becomes an image object. Then, when SilverStripe tries to use this corrupted image, it breaks and displays below error message:

> [Error] Uncaught ImagickException: corrupt image `[PATH]/Screenshot-2017-02-21-at-18.53.31-AM.png' @ error/png.c/ReadPNGImage/3728 [PATH]/framework/filesystem/ImagickBackend.php:25

To resolve this issue, my patch does below steps:

1. Recovery - the precondition is: the corrupted images are already in your assets and DB. when a corrupted image is being handled by SS image backend, SS will catch the error,  wipe the file's existence from both DB and the file system, and then reload the page silently - so the frontend users won't even notice.

2. Prevention - when the user uploads an image file, Silverstripe will check if the file can be handled by the image backend. This is a proactive approach to trigger the error - the corrupted file will be stopped at the validation, and nothing harmful will be brought into SS's assets and DB.

