### PR TITLE
Revisit close button overlap

### DIFF
--- a/admin/client/dist/styles/bundle.css
+++ b/admin/client/dist/styles/bundle.css
@@ -15778,6 +15778,10 @@ div.grid-field__sort-field+.form__fieldgroup-item{
   margin-right:5px;
 }
 
+.toolbar__navigation{
+  position:relative;
+}
+
 .nav-tabs{
   margin-bottom:1.5385rem;
 }

--- a/admin/client/src/components/Toolbar/Toolbar.scss
+++ b/admin/client/src/components/Toolbar/Toolbar.scss
@@ -105,3 +105,7 @@
     margin-right: 5px;
   }
 }
+
+.toolbar__navigation {
+  position: relative;
+}


### PR DESCRIPTION
I'm not sure what changed to cause this issue to show up again... https://github.com/silverstripe/silverstripe-asset-admin/pull/366

This sets the search container to be the relative point.
Please merge https://github.com/silverstripe/silverstripe-asset-admin/pull/392 after