### PR TITLE
BUG Fix modeladmin scrollable height cropping pagination

### DIFF
--- a/admin/templates/SilverStripe/Admin/Includes/ModelAdmin_Content.ss
+++ b/admin/templates/SilverStripe/Admin/Includes/ModelAdmin_Content.ss
@@ -1,4 +1,4 @@
-<div class="cms-content flexbox-area-grow cms-tabset center $BaseCSSClasses" data-layout-type="border" data-pjax-fragment="Content">
+<div class="cms-content fill-height flexbox-area-grow cms-tabset center $BaseCSSClasses" data-layout-type="border" data-pjax-fragment="Content">
 
 	<div class="cms-content-header north">
 		<div class="cms-content-header-info">


### PR DESCRIPTION
Without this patch, the size of the modeladmin gridfield is 53 pixels too high, and pushes the pagination off the bottom of the scrollable area.

Apparently this fixes https://github.com/silverstripe/silverstripe-framework/issues/6545