### PR TITLE
Fix fieldgroups to flexbox the inner fields

### DIFF
--- a/admin/client/dist/styles/bundle.css
+++ b/admin/client/dist/styles/bundle.css
@@ -14943,6 +14943,37 @@ div.TreeDropdownField a.jstree-loading .jstree-pageicon{
   color:#66727d;
 }
 
+.fieldgroup--fill-width>.form__field-holder>.fieldgroup{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  width:100%;
+  -webkit-box-orient:horizontal;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:row;
+          flex-direction:row;
+}
+
+.fieldgroup--fill-width>.form__field-holder>.fieldgroup>.field:last-child{
+  margin-right:0;
+}
+
+.fieldgroup--fill-height>.form__field-holder>.fieldgroup{
+  display:-webkit-box;
+  display:-ms-flexbox;
+  display:flex;
+  height:100%;
+  min-height:0;
+  -webkit-box-orient:vertical;
+  -webkit-box-direction:normal;
+      -ms-flex-direction:column;
+          flex-direction:column;
+}
+
+.fieldgroup--fill-height>.form__field-holder>.fieldgroup>.field:last-child{
+  margin-bottom:0;
+}
+
 .list-group{
   margin-left:-1.5385rem;
   margin-right:-1.5385rem;

--- a/admin/client/src/components/FieldGroup/FieldGroup.scss
+++ b/admin/client/src/components/FieldGroup/FieldGroup.scss
@@ -13,3 +13,24 @@
     }
   }
 }
+
+.fieldgroup--fill-width > .form__field-holder > .fieldgroup {
+  display: flex;
+  width: 100%;
+  flex-direction: row;
+
+  > .field:last-child {
+    margin-right: 0;
+  }
+}
+
+.fieldgroup--fill-height > .form__field-holder > .fieldgroup {
+  display: flex;
+  height: 100%;
+  min-height: 0; // See https://www.fxsitecompat.com/en-GB/docs/2014/initial-value-of-min-width-height-on-flex-items-has-been-reverted-to-auto/
+  flex-direction: column;
+
+  > .field:last-child {
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
This is because adding the ".fill-width" class to the field-group affected both the label and inner fields, rather than the inner fields exclusively. (ends up squashing the "main" label very badly)

relies on https://github.com/silverstripe/silverstripe-asset-admin/pull/394