### PR TITLE
FIX Add quotes to constants in YAML to ensure syntax validity

### DIFF
--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -5,7 +5,7 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Core\Cache\CacheFactory:
     class: 'SilverStripe\Core\Cache\DefaultCacheFactory'
     constructor:
-      directory: `TEMP_FOLDER`
+      directory: '`TEMP_FOLDER`'
   Psr\SimpleCache\CacheInterface.GDBackend_Manipulations:
     factory: SilverStripe\Core\Cache\CacheFactory
     constructor:

--- a/_config/i18n.yml
+++ b/_config/i18n.yml
@@ -39,7 +39,7 @@ SilverStripe\Core\Injector\Injector:
     constructor:
       0: 'en'
       1: null
-      2: `TEMP_FOLDER`
+      2: '`TEMP_FOLDER`'
     properties:
       ConfigCacheFactory: %$Symfony\Component\Config\ConfigCacheFactoryInterface
     calls:

--- a/docs/en/02_Developer_Guides/05_Extending/05_Injector.md
+++ b/docs/en/02_Developer_Guides/05_Extending/05_Injector.md
@@ -123,17 +123,17 @@ As well as properties, method calls can also be specified:
 
 ## Using constants as variables
 
-Any of the core constants can be used as a service argument by quoting with back ticks "`".
+Any of the core constants can be used as a service argument by quoting with back ticks "`". Please ensure you also quote the entire value (see below).
 
 
-    :::yaml
-    CachingService:
-      class: SilverStripe\Cache\CacheProvider
-      properties:
-        CacheDir: `TEMP_DIR`
+```yaml
+CachingService:
+  class: SilverStripe\Cache\CacheProvider
+  properties:
+    CacheDir: '`TEMP_DIR`'
+```
 
-
-Note: undefined variables will be replaced with null
+Note: undefined variables will be replaced with null.
 
 
 ## Factories


### PR DESCRIPTION
Resolves #6574

I didn't add a PHPUnit 5.7 build just yet.