### PR TITLE
Add class to clear underline styling for fieldholders

### DIFF
--- a/admin/client/dist/styles/bundle.css
+++ b/admin/client/dist/styles/bundle.css
@@ -15093,6 +15093,11 @@ div.TreeDropdownField a.jstree-loading .jstree-pageicon{
   display:block;
 }
 
+.form-group.field--merge-below:after{
+  border-bottom:0;
+  box-shadow:none;
+}
+
 .btn-toolbar{
   margin-top:1.2308rem;
   margin-bottom:1.2308rem;

--- a/admin/client/src/components/FieldHolder/FieldHolder.scss
+++ b/admin/client/src/components/FieldHolder/FieldHolder.scss
@@ -1,3 +1,8 @@
 .form__field-message-item {
   display: block;
 }
+
+.form-group.field--merge-below:after {
+  border-bottom: 0;
+  box-shadow: none;
+}


### PR DESCRIPTION
So that fields that could be visually grouped together when placed next to each other.

Works with https://github.com/silverstripe/silverstripe-cms/pull/1747