### PR TITLE
BUG Prevent obsolete class cache breaking autoload

### DIFF
--- a/tests/php/Core/Manifest/ClassManifestTest.php
+++ b/tests/php/Core/Manifest/ClassManifestTest.php
@@ -50,8 +50,6 @@ class ClassManifestTest extends SapphireTest
             'classc'                   => "{$this->base}/module/classes/ClassC.php",
             'classd'                   => "{$this->base}/module/classes/ClassD.php",
             'classe'                   => "{$this->base}/module/classes/ClassE.php",
-            'sstemplateparser'         => FRAMEWORK_PATH."/src/View/SSTemplateParser.php",
-            'sstemplateparseexception' => FRAMEWORK_PATH."/src/View/SSTemplateParseException.php"
         );
         $this->assertEquals($expect, $this->manifest->getClasses());
     }
@@ -59,7 +57,7 @@ class ClassManifestTest extends SapphireTest
     public function testGetClassNames()
     {
         $this->assertEquals(
-            array('sstemplateparser', 'sstemplateparseexception', 'classa', 'classb', 'classc', 'classd', 'classe'),
+            ['classa', 'classb', 'classc', 'classd', 'classe'],
             $this->manifest->getClassNames()
         );
     }

--- a/tests/php/Core/Manifest/NamespacedClassManifestTest.php
+++ b/tests/php/Core/Manifest/NamespacedClassManifestTest.php
@@ -263,8 +263,6 @@ class NamespacedClassManifestTest extends SapphireTest
             'silverstripe\test\classf' => "{$this->base}/module/classes/ClassF.php",
             'silverstripe\test\classg' => "{$this->base}/module/classes/ClassG.php",
             'silverstripe\test\classh' => "{$this->base}/module/classes/ClassH.php",
-            'sstemplateparser'         => FRAMEWORK_PATH."/src/View/SSTemplateParser.php",
-            'sstemplateparseexception' => FRAMEWORK_PATH."/src/View/SSTemplateParseException.php",
             'silverstripe\framework\tests\classi' => "{$this->base}/module/classes/ClassI.php",
         );
 
@@ -274,7 +272,7 @@ class NamespacedClassManifestTest extends SapphireTest
     public function testGetClassNames()
     {
         $this->assertEquals(
-            array('sstemplateparser', 'sstemplateparseexception', 'silverstripe\test\classa',
+            array('silverstripe\test\classa',
                 'silverstripe\test\classb', 'silverstripe\test\classc', 'silverstripe\test\classd',
                 'silverstripe\test\classe', 'silverstripe\test\classf', 'silverstripe\test\classg',
                 'silverstripe\test\classh', 'silverstripe\framework\tests\classi'),


### PR DESCRIPTION
Remove hard-coded class paths. These are no longer necessary since we moved the source file to a `.peg` extension, and the class file finder only looks at `.php` files.