### PR TITLE
API Enable theming of GroupedDropdownField

### DIFF
--- a/templates/Includes/GroupedDropdownFieldOption.ss
+++ b/templates/Includes/GroupedDropdownFieldOption.ss
@@ -1,0 +1,12 @@
+<% if $Options %>
+	<optgroup label="$Title.ATT">
+		<% loop $Options %>
+			<% include GroupedDropdownFieldOption %>
+		<% end_loop %>
+	</optgroup>
+<% else %>
+	<option value="$Value.ATT"
+		<% if $Selected %> selected="selected"<% end_if %>
+		<% if $Disabled %> disabled="disabled"<% end_if %>
+		><% if $Title %>$Title.XML<% else %>&nbsp;<% end_if %></option>
+<% end_if %>

--- a/templates/forms/GroupedDropdownField.ss
+++ b/templates/forms/GroupedDropdownField.ss
@@ -1,0 +1,5 @@
+<select $AttributesHTML>
+	<% loop $Options %>
+		<% include GroupedDropdownFieldOption %>
+	<% end_loop %>
+</select>

--- a/tests/forms/GroupedDropdownFieldTest.php
+++ b/tests/forms/GroupedDropdownFieldTest.php
@@ -51,4 +51,22 @@ class GroupedDropdownFieldTest extends SapphireTest {
 		$this->assertFalse($field->validate($validator));
 	}
 
+	public function testRendering() {
+		$field = GroupedDropdownField::create('Test', 'Testing', array(
+			"1" => "One",
+			"Group One" => array(
+				"2" => "Two",
+				"3" => "Three"
+			),
+			"Group Two" => array(
+				"4" => "Four"
+			)
+		));
+		$body= $field->Field()->forTemplate();
+		$this->assertContains('<option value="1"', $body);
+		$this->assertContains('<optgroup label="Group One">', $body);
+		$this->assertContains('<option value="3"', $body);
+		$this->assertContains('>Three</option>', $body);
+	}
+
 }


### PR DESCRIPTION
Based on partial back-port of 4.0 code

This is necessary so that we can create custom themes that modify this field.