### PR TITLE
FIX Installer no longer causes recursion in yml config

### DIFF
--- a/src/Dev/Install/install.php5
+++ b/src/Dev/Install/install.php5
@@ -1445,9 +1445,6 @@ PHP
 		$this->writeToFile("mysite/_config/config.yml", <<<YML
 ---
 Name: mysite
-After:
-  - 'framework/*'
-  - 'cms/*'
 ---
 # YAML configuration for SilverStripe
 # See http://doc.silverstripe.org/framework/en/topics/configuration


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-cms/issues/1752

The config.yml file that the `install.php5` file creates is now inline with the same file inside our installer module.