### PR TITLE
Add Chris to core committers list

### DIFF
--- a/docs/en/05_Contributing/09_Core_committers.md
+++ b/docs/en/05_Contributing/09_Core_committers.md
@@ -3,6 +3,7 @@ The core committers team is reviewed approximately annually, new members are add
 
 ## Core committer team
 * [Aaron Carlino](https://github.com/unclecheese/)
+* [Chris Joe](https://github.com/flamerohr/)
 * [Damian Mooyman](https://github.com/tractorcow/)
 * [Daniel Hensby](https://github.com/dhensby)
 * [Hamish Friedlander](https://github.com/hafriedlander)

--- a/docs/en/05_Contributing/09_Core_committers.md
+++ b/docs/en/05_Contributing/09_Core_committers.md
@@ -3,7 +3,6 @@ The core committers team is reviewed approximately annually, new members are add
 
 ## Core committer team
 * [Aaron Carlino](https://github.com/unclecheese/)
-* [Steview Mayhew](https://github.com/stevie-mayhew/)
 * [Damian Mooyman](https://github.com/tractorcow/)
 * [Daniel Hensby](https://github.com/dhensby)
 * [Hamish Friedlander](https://github.com/hafriedlander)
@@ -12,6 +11,7 @@ The core committers team is reviewed approximately annually, new members are add
 * [Loz Calver](https://github.com/kinglozzer)
 * [Sam Minnée](https://github.com/sminnee)
 * [Sean Harvey](https://github.com/halkyon/)
+* [Steview Mayhew](https://github.com/stevie-mayhew/)
 * [Stig Lindqvist](https://github.com/stojg)
 * [Will Rossiter](https://github.com/wilr/)
 


### PR DESCRIPTION
The core team has voted him in this morning on the public Core Committers Hangout,
see https://www.youtube.com/watch?v=O0xYogrIo3o

@silverstripe/core-team 