### PR TITLE
Do not default to locale if hasEmptyDefault is true

### DIFF
--- a/forms/CountryDropdownField.php
+++ b/forms/CountryDropdownField.php
@@ -58,16 +58,18 @@ class CountryDropdownField extends DropdownField {
 	public function Field($properties = array()) {
 		$source = $this->getSource();
 
-		if (!$this->value || !isset($source[$this->value])) {
-			if ($this->config()->default_to_locale && $this->locale()) {
-				$locale = new Zend_Locale();
-				$locale->setLocale($this->locale());
-				$this->value = $locale->getRegion();
+		if(!$this->getHasEmptyDefault()){
+			if (!$this->value || !isset($source[$this->value])) {
+				if ($this->config()->default_to_locale && $this->locale()) {
+					$locale = new Zend_Locale();
+					$locale->setLocale($this->locale());
+					$this->value = $locale->getRegion();
+				}
 			}
-		}
 
-		if (!$this->value || !isset($source[$this->value])) {
-			$this->value = $this->config()->default_country;
+			if (!$this->value || !isset($source[$this->value])) {
+				$this->value = $this->config()->default_country;
+			}
 		}
 
 		return parent::Field();


### PR DESCRIPTION
Currently there is no per-instance way to say "don't default to the current locale".
If you've explicitly said "This field right here, it has an empty default value" then we should probably respect that.