### PR TITLE
API Apply logging to cache system

### DIFF
--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -5,7 +5,10 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Core\Cache\CacheFactory:
     class: 'SilverStripe\Core\Cache\DefaultCacheFactory'
     constructor:
-      directory: '`TEMP_FOLDER`'
+      args:
+        directory: '`TEMP_FOLDER`'
+        version: null
+      logger: %$Psr\Log\LoggerInterface
   Psr\SimpleCache\CacheInterface.GDBackend_Manipulations:
     factory: SilverStripe\Core\Cache\CacheFactory
     constructor:

--- a/_config/logging.yml
+++ b/_config/logging.yml
@@ -5,8 +5,8 @@ SilverStripe\Core\Injector\Injector:
   ErrorHandler:
     class: SilverStripe\Logging\MonologErrorHandler
     properties:
-      Logger: %$Logger
-  Logger:
+      Logger: %$Psr\Log\LoggerInterface
+  Psr\Log\LoggerInterface:
     type: singleton
     class: Monolog\Logger
     constructor:

--- a/docs/en/02_Developer_Guides/07_Debugging/01_Error_Handling.md
+++ b/docs/en/02_Developer_Guides/07_Debugging/01_Error_Handling.md
@@ -14,8 +14,8 @@ For informational and debug logs, you can use the Logger directly. The Logger is
 can be accessed via the `Injector`:
 
 	:::php
-	Injector::inst()->get('Logger')->info('User has logged in: ID #' . Member::currentUserID());
-	Injector::inst()->get('Logger')->debug('Query executed: ' . $sql);
+	Injector::inst()->get(LoggerInterface::class)->info('User has logged in: ID #' . Member::currentUserID());
+	Injector::inst()->get(LoggerInterface::class)->debug('Query executed: ' . $sql);
 
 Although you can raise more important levels of alerts in this way, we recommend using PHP's native error systems for
 these instead.
@@ -48,16 +48,16 @@ but they can be caught with a try/catch clause.
 
 ### Accessing the logger via dependency injection.
 
-It can quite verbose to call `Injector::inst()->get('Logger')` all the time. More importantly, it also means that you're
-coupling your code to global state, which is a bad design practise. A better approach is to use depedency injection to
-pass the logger in for you. The [Injector](../extending/Injector) can help with this. The most straightforward is to
-specify a `dependencies` config setting, like this:
+It can quite verbose to call `Injector::inst()->get(LoggerInterface::class)` all the time. More importantly,
+it also means that you're coupling your code to global state, which is a bad design practise. A better
+approach is to use depedency injection to pass the logger in for you. The [Injector](../extending/Injector)
+can help with this. The most straightforward is to specify a `dependencies` config setting, like this:
 
 	:::php
 	class MyController {
 
 		private static $dependencies = array(
-			'logger' => '%$Logger',
+			'logger' => '%$Psr\Log\LoggerInterface',
 		);
 
 		// This will be set automatically, as long as MyController is instantiated via Injector

--- a/src/Core/Cache/CacheFactory.php
+++ b/src/Core/Cache/CacheFactory.php
@@ -12,8 +12,8 @@ interface CacheFactory extends InjectorFactory
      * Note: While the returned object is used as a singleton (by the originating Injector->get() call),
      * this cache object shouldn't be a singleton itself - it has varying constructor args for the same service name.
      *
-     * @param string $class
-     * @param array $args
+     * @param string $service
+     * @param array $params
      * @return CacheInterface
      */
     public function create($service, array $params = array());

--- a/src/Logging/Log.php
+++ b/src/Logging/Log.php
@@ -36,8 +36,8 @@ class Log
      */
     public static function get_logger()
     {
-        Deprecation::notice('5.0', 'Use Injector::inst()->get(\'Logger\') instead');
-        return Injector::inst()->get('Logger');
+        Deprecation::notice('5.0', 'Use Injector::inst()->get(LoggerInterface::class) instead');
+        return Injector::inst()->get(LoggerInterface::class);
     }
 
     /**
@@ -55,7 +55,7 @@ class Log
      */
     public static function log($message, $priority)
     {
-        Deprecation::notice('5.0', 'Use Injector::inst()->get(\'Logger\')->log($priority, $message) instead');
-        Injector::inst()->get('Logger')->log($priority, $message);
+        Deprecation::notice('5.0', 'Use Injector::inst()->get(LoggerInterface::class)->log($priority, $message) instead');
+        Injector::inst()->get(LoggerInterface::class)->log($priority, $message);
     }
 }

--- a/src/Logging/MonologErrorHandler.php
+++ b/src/Logging/MonologErrorHandler.php
@@ -10,17 +10,22 @@ use Monolog\ErrorHandler;
  */
 class MonologErrorHandler
 {
+    /**
+     * @var LoggerInterface
+     */
     private $logger;
 
     /**
      * Set the PSR-3 logger to send errors & exceptions to
+     *
+     * @param LoggerInterface $logger
      */
-    function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger)
     {
         $this->logger = $logger;
     }
 
-    function start()
+    public function start()
     {
         if (!$this->logger) {
             throw new \InvalidArgumentException("No Logger property passed to MonologErrorHandler."

--- a/src/conf/ConfigureFromEnv.php
+++ b/src/conf/ConfigureFromEnv.php
@@ -48,6 +48,7 @@
 
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
+use Psr\Log\LoggerInterface;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\Install\DatabaseAdapterRegistry;
@@ -138,7 +139,7 @@ if ($useBasicAuth = getenv('SS_USE_BASIC_AUTH')) {
 }
 
 if ($errorLog = getenv('SS_ERROR_LOG')) {
-    $logger = Injector::inst()->get('Logger');
+    $logger = Injector::inst()->get(LoggerInterface::class);
     if ($logger instanceof Logger) {
         $logger->pushHandler(new StreamHandler(BASE_PATH . '/' . $errorLog, Logger::WARNING));
     } else {


### PR DESCRIPTION
Follow up from https://github.com/silverstripe/silverstripe-framework/issues/6670: Errors were causing performance issues, but were not surfacing.

Actual cache failure was resolved with https://github.com/silverstripe/silverstripe-framework/pull/6671.

This fix ensures that any future cache failures are caught by the logging system.

Note that while we apply the logger to the cache factory (for simplicity), a cache that necessitates a custom logger (or no logger) can be constructed by creating another cache factory, of the same factory class, with no logger assigned.