### PR TITLE
API Add FormRequestHandler::forTemplate() for backwards compatibility

### DIFF
--- a/src/Forms/FormRequestHandler.php
+++ b/src/Forms/FormRequestHandler.php
@@ -507,4 +507,9 @@ class FormRequestHandler extends RequestHandler
         $this->form->loadMessagesFrom($result);
         return $result;
     }
+
+    public function forTemplate()
+    {
+        return $this->form->forTemplate();
+    }
 }


### PR DESCRIPTION
Fix for https://github.com/silverstripe/silverstripe-cms/pull/1758