### PR TITLE
Drop PHP 5.5 support, limit PHP 5.6 to 2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
+    - php: 5.6
       env: DB=PGSQL PHPUNIT_TEST=1
     - php: 5.6
       env: DB=MYSQL PHPUNIT_TEST=1 PHPCS_TEST=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ matrix:
 before_script:
   - export CORE_RELEASE=$TRAVIS_BRANCH
   - printf "\n" | pecl install imagick
-  - composer self-update || true
   - "if [ \"$PHPCS_TEST\" = \"1\" ]; then pyrus install pear/PHP_CodeSniffer; fi"
   - phpenv rehash
   - phpenv config-rm xdebug.ini

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": ">=5.5.0",
+    "php": ">=5.6.0",
     "composer/installers": "~1.0",
     "embed/embed": "^2.6",
     "league/flysystem": "~1.0.12",

--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -8,7 +8,8 @@ Our web-based [PHP installer](installation/) can check if you meet the requireme
 
 ## Web server software requirements
 
- * PHP 5.5 or newer
+ * PHP 5.6 and PHP 7.1+
+ * PHP 5.6 support will be dropped in Dec 2018 (see [php.net: Supported Versions](http://php.net/supported-versions.php))
  * We recommend using a PHP accelerator or opcode cache, such as [xcache](http://xcache.lighttpd.net/) or [WinCache](http://www.iis.net/download/wincacheforphp).
  * Allocate at least 48MB of memory to each PHP process. (SilverStripe can be resource hungry for some intensive operations.)
  * Required modules: dom, gd2, fileinfo, hash, iconv, mbstring, mysqli (or other database driver), session, simplexml, tokenizer, xml.

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -1027,7 +1027,8 @@ now generally safer to use the default inherited config, where in the past you w
 
 #### <a name="overview-general-api"></a>General and Core API Additions / Changes
 
-* Minimum PHP version raised to 5.5.0
+* Minimum PHP version raised to 5.6 (with support for PHP 7.1+)
+* PHP 5.6 support will be dropped in Dec 2018 (see [php.net: Supported Versions](http://php.net/supported-versions.php))
 * Minimum CMS browser requirement raised from Internet Explorer 8 to Internet Explorer 10
 * Updated PHPUnit from 3.7 to 4.8 ([upgrade notes](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-4.0.0#backwards-compatibility-issues)).
   Please remove any PHPUnit related `require_once()` calls (e.g. in `FeatureContext`


### PR DESCRIPTION
Fixes #6705