### PR TITLE
Reinstate 7.0 support, clarify policy

### DIFF
--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -8,8 +8,9 @@ Our web-based [PHP installer](installation/) can check if you meet the requireme
 
 ## Web server software requirements
 
- * PHP 5.6 and PHP 7.1+
- * PHP 5.6 support will be dropped in Dec 2018 (see [php.net: Supported Versions](http://php.net/supported-versions.php))
+ * PHP 5.6 and PHP 7.x
+ * Once PHP versions become [unsupported by the PHP Project](http://php.net/supported-versions.php)),
+   we drop support for those versions in the [next minor release](/contributing/release-process)  
  * We recommend using a PHP accelerator or opcode cache, such as [xcache](http://xcache.lighttpd.net/) or [WinCache](http://www.iis.net/download/wincacheforphp).
  * Allocate at least 48MB of memory to each PHP process. (SilverStripe can be resource hungry for some intensive operations.)
  * Required modules: dom, gd2, fileinfo, hash, iconv, mbstring, mysqli (or other database driver), session, simplexml, tokenizer, xml.

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -1027,8 +1027,10 @@ now generally safer to use the default inherited config, where in the past you w
 
 #### <a name="overview-general-api"></a>General and Core API Additions / Changes
 
-* Minimum PHP version raised to 5.6 (with support for PHP 7.1+)
-* PHP 5.6 support will be dropped in Dec 2018 (see [php.net: Supported Versions](http://php.net/supported-versions.php))
+* Minimum PHP version raised to 5.6 (with support for PHP 7.x)
+* Once PHP versions become [unsupported by the PHP Project](http://php.net/supported-versions.php)),
+  we drop support for those versions in the [next minor release](/contributing/release-process 
+  This means PHP 5.6 and PHP 7.0 support will become unsupported in Dec 2018.
 * Minimum CMS browser requirement raised from Internet Explorer 8 to Internet Explorer 10
 * Updated PHPUnit from 3.7 to 4.8 ([upgrade notes](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-4.0.0#backwards-compatibility-issues)).
   Please remove any PHPUnit related `require_once()` calls (e.g. in `FeatureContext`


### PR DESCRIPTION
PLEASE WAIT FOR A VOTE UNTIL MERGE

Vote with 👍  or 👎 

We’ve discussed dropping support for 5.6 once it’s EOL on https://github.com/silverstripe/silverstripe-framework/issues/6705.
The same question needs to be asked for 7.0, which goes EOL in the same month. And should be generalised to future PHP versions.
Follow up to https://github.com/silverstripe/silverstripe-framework/pull/6718/