### PR TITLE
API Use mysql-safe table namespace separator

### DIFF
--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -24,12 +24,10 @@ class DataObjectSchema
      * Default separate for table namespaces. Can be set to any string for
      * databases that do not support some characters.
      *
-     * Defaults to \ to to conform to 3.x convention.
-     *
      * @config
      * @var string
      */
-    private static $table_namespace_separator = '\\';
+    private static $table_namespace_separator = '_';
 
     /**
      * Cache of database fields

--- a/tests/php/ORM/DataObjectSchemaTest.php
+++ b/tests/php/ORM/DataObjectSchemaTest.php
@@ -9,6 +9,7 @@ use SilverStripe\ORM\DataObjectSchema;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\BaseClass;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\BaseDataClass;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\ChildClass;
+use SilverStripe\ORM\Tests\DataObjectSchemaTest\DefaultTableName;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\GrandChildClass;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\HasFields;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\NoFields;
@@ -31,7 +32,8 @@ class DataObjectSchemaTest extends SapphireTest
         HasFields::Class,
         NoFields::class,
         WithCustomTable::class,
-        WithRelation::class
+        WithRelation::class,
+        DefaultTableName::class
     );
 
     /**
@@ -48,6 +50,11 @@ class DataObjectSchemaTest extends SapphireTest
         $this->assertEquals(
             'DOSTWithCustomTable',
             $schema->tableName(WithCustomTable::class)
+        );
+        // Default table name is FQN
+        $this->assertEquals(
+            'SilverStripe_ORM_Tests_DataObjectSchemaTest_DefaultTableName',
+            $schema->tableName(DefaultTableName::class)
         );
     }
 

--- a/tests/php/ORM/DataObjectSchemaTest/DefaultTableName.php
+++ b/tests/php/ORM/DataObjectSchemaTest/DefaultTableName.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace SilverStripe\ORM\Tests\DataObjectSchemaTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class DefaultTableName extends DataObject implements TestOnly
+{
+    private static $db = [
+        'Title' => 'Varchar',
+    ];
+}


### PR DESCRIPTION
The idea behind the original behaviour is that pre-namespaced tables in 3.x would continue to work.

However, namespaced dataobjects were not feasibly in 3.x. They were theoretically possible, but ran into several edge cases which made it impossible in practice. I don't believe it's worth trying to soft-support automatic upgrades for these classes in this case.

As a result of this change, all new namespaced classes (without any table_name) will be buildable in mysql.

Note: Please leave this PR open for a few days for public approval. There are a few opinions that need to be considered on the matter. :)