### PR TITLE
fix glitch duplicate jstree-icon in nested pages

### DIFF
--- a/admin/templates/Includes/LeftAndMain_TreeNode.ss
+++ b/admin/templates/Includes/LeftAndMain_TreeNode.ss
@@ -1,4 +1,4 @@
-<li id="record-$ID" data-id="$ID" data-pagetype="$ClassName" class="$Classes"><ins class="jstree-icon">&nbsp;</ins>
+<li id="record-$ID" data-id="$ID" data-pagetype="$ClassName" class="$Classes">
 	<a href="$Link" title="$Title.ATT"><ins class="jstree-icon">&nbsp;</ins>
 		<span class="text">$TreeTitle</span>
 	</a>


### PR DESCRIPTION
Nested pages having their own children are shown in the site tree with a duplicate `jstree-icon`. I have no idea why there are two icons in this template file, however, by removing the first one the glitch doesn't happen.

![screen shot 2017-03-22 at 13 39 57](https://cloud.githubusercontent.com/assets/4563795/24198503/737f8674-0f06-11e7-83f7-a1112e7d3bd3.png)
