### PR TITLE
FIX: many_many_extraFields breaks _SortColumn0 ordering (fixes #6730)

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -763,17 +763,33 @@ class DataQuery {
 	}
 
 	/**
-	 * Select the given fields from the given table.
+	 * Select only the given fields from the given table.
 	 *
 	 * @param String $table Unquoted table name (will be escaped automatically)
 	 * @param Array $fields Database column names (will be escaped automatically)
 	 */
 	public function selectFromTable($table, $fields) {
 		$fieldExpressions = array_map(function($item) use($table) {
-			return "\"$table\".\"$item\"";
+			return Convert::symbol2sql("{$table}.{$item}");
 		}, $fields);
 
 		$this->query->setSelect($fieldExpressions);
+
+		return $this;
+	}
+
+	/**
+	 * Add the given fields from the given table to the select statement.
+	 *
+	 * @param String $table Unquoted table name (will be escaped automatically)
+	 * @param Array $fields Database column names (will be escaped automatically)
+	 */
+	public function addSelectFromTable($table, $fields) {
+		$fieldExpressions = array_map(function($item) use($table) {
+			return Convert::symbol2sql("{$table}.{$item}");
+		}, $fields);
+
+		$this->query->addSelect($fieldExpressions);
 
 		return $this;
 	}

--- a/model/ManyManyList.php
+++ b/model/ManyManyList.php
@@ -104,7 +104,7 @@ class ManyManyList extends RelationList {
 			}
 		}
 
-		$this->dataQuery->selectFromTable($this->joinTable, $finalized);
+		$this->dataQuery->addSelectFromTable($this->joinTable, $finalized);
 	}
 
 	/**
@@ -352,7 +352,7 @@ class ManyManyList extends RelationList {
 	 */
 	public function getExtraData($componentName, $itemID) {
 		$result = array();
-		
+
 		// Skip if no extrafields or unsaved record
 		if(empty($this->extraFields) || empty($itemID)) {
 			return $result;


### PR DESCRIPTION
Proposed solution to #6730. The new method `DataQuery:: addSelectFromTable()` is essentially a clone of `DataQuery:: selectFromTable()`, but using `SQLQuery::addSelect` instead of `SQLQuery::setSelect()`. I didn’t want to alter the behaviour of an existing method for a bugfix/patch release.