### PR TITLE
Require LICENSE in supported modules (no *.md)

### DIFF
--- a/docs/en/02_Developer_Guides/05_Extending/00_Modules.md
+++ b/docs/en/02_Developer_Guides/05_Extending/00_Modules.md
@@ -140,7 +140,7 @@ Documentation will use the following format:
    * Security, license, links to more detailed docs.
  * CONTRIBUTING.md explaining terms of contribution.
  * A changelog: CHANGELOG.md (may link to other more detailed docs or GitHub releases if you want). You could [use a changelog generator](https://github.com/skywinder/Github-Changelog-Generator) to help create this.
- * Has a licence (LICENSE.md file) - for SilverStripe supported this needs to be BSD.
+ * Has a licence (`LICENSE` file) - for SilverStripe supported this needs to be BSD.
  * Detailed documentation in `/docs/en` as a nested set of GitHub-compatible Markdown files.
  * It is suggested to use a documentation page named `userguide.md` in `docs/en/` that includes documentation of module features that have CMS user functionality (if applicable). For modules with large userguides, this should be in a directory named `userguide` with an `index.md` linking to any other userguide pages.
  * Links and image references are relative, and are able to be followed in viewers such as GitHub.


### PR DESCRIPTION
It's more standard to have this file in the webroot.
It's technically markdown compatible text (e.g. asterisk bullet points),
but there's not much point in rendering it via markdown.

If you use the Github "new repo" dialog, it'll create the file without
an extension, so that's pretty much considered the standard.