### PR TITLE
FIX: Don't mistake \ for _ in dev/build

### DIFF
--- a/src/ORM/Connect/MySQLSchemaManager.php
+++ b/src/ORM/Connect/MySQLSchemaManager.php
@@ -185,7 +185,8 @@ class MySQLSchemaManager extends DBSchemaManager
     public function hasTable($table)
     {
         // MySQLi doesn't like parameterised queries for some queries
-        $sqlTable = $this->database->quoteString($table);
+        // underscores need to be escaped in a SHOW TABLES LIKE query
+        $sqlTable = str_replace('_', '\\_', $this->database->quoteString($table));
         return (bool) ($this->query("SHOW TABLES LIKE $sqlTable")->value());
     }
 


### PR DESCRIPTION
The query SHOW TABLES LIKE 'some_thing' will match the table some\thing.

This causes issues when the namespace separator has changed.

The fix is to escape the _s in this LIKE statement, as done here.