### PR TITLE
FIX Remove campaign related classes from upgrade map - moved to campaign-admin

### DIFF
--- a/.upgrade.yml
+++ b/.upgrade.yml
@@ -155,10 +155,7 @@ mappings:
   Security: SilverStripe\Security\Security
   SecurityToken: SilverStripe\Security\SecurityToken
   NullSecurityToken: SilverStripe\Security\NullSecurityToken
-  AddToCampaignHandler: SilverStripe\Admin\AddToCampaignHandler
-  AddToCampaignHandler_FormAction: SilverStripe\Admin\AddToCampaignHandler_FormAction
   AdminRootController: SilverStripe\Admin\AdminRootController
-  CampaignAdmin: SilverStripe\Admin\CampaignAdmin
   CMSBatchAction: SilverStripe\Admin\CMSBatchAction
   CMSBatchActionHandler: SilverStripe\Admin\CMSBatchActionHandler
   CMSMenu: SilverStripe\Admin\CMSMenu


### PR DESCRIPTION
When running the upgrader tool on the latest versions of these branches, it fails when campaign related classes are mapped in framework and campaign-admin:

```
[InvalidArgumentException]                                                              
  Config option AddToCampaignHandler is defined with different values in multiple files.
```

Issue: #6739