### PR TITLE
NEW: Downgrade MSSQL from commercially supported to community supported

### DIFF
--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -9,8 +9,8 @@ Our web-based [PHP installer](installation/) can check if you meet the requireme
 ## Web server software requirements
 
  * PHP 5.6 and PHP 7.x
- * Once PHP versions become [unsupported by the PHP Project](http://php.net/supported-versions.php)),
-   we drop support for those versions in the [next minor release](/contributing/release-process)  
+ * Once PHP versions become [unsupported by the PHP Project](http://php.net/supported-versions.php),
+   we drop support for those versions in the [next minor release](/contributing/release-process). This means that PHP 5.6 support may be dropped in a 4.x minor release after December 2018.
  * We recommend using a PHP accelerator or opcode cache, such as [xcache](http://xcache.lighttpd.net/) or [WinCache](http://www.iis.net/download/wincacheforphp).
  * Allocate at least 48MB of memory to each PHP process. (SilverStripe can be resource hungry for some intensive operations.)
  * Required modules: dom, gd2, fileinfo, hash, iconv, mbstring, mysqli (or other database driver), session, simplexml, tokenizer, xml.

--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -22,19 +22,18 @@ Our web-based [PHP installer](installation/) can check if you meet the requireme
 
  * See [phpinfo()](http://php.net/manual/en/function.phpinfo.php) for more information about your environment
  * One of the following databases: 
-  * MySQL 5.0+
-  * PostgreSQL 8.3+ (requires ["postgresql" module](http://silverstripe.org/postgresql-module))
-  * SQL Server 2008+ (requires ["mssql" module](http://silverstripe.org/microsoft-sql-server-database/))
-  * Support for [Oracle](https://github.com/smindel/silverstripe-oracle) and [SQLite](http://silverstripe.org/sqlite-database/) is not commercially supported, but is under development by our open source community.
+   * MySQL 5.0+
+   * PostgreSQL 8.3+ (requires ["postgresql" module](http://silverstripe.org/postgresql-module))
+   * [SQL Server 2008+](http://silverstripe.org/microsoft-sql-server-database/), [Oracle](https://github.com/smindel/silverstripe-oracle) and [SQLite](http://silverstripe.org/sqlite-database/) are not commercially supported, but are under development by our open source community.
  * One of the following web server products: 
-  * Apache 2.0+ with mod_rewrite and "AllowOverride All" set
-  * IIS 7+
-  * Support for Lighttpd, IIS 6, and other web servers may work if you are familiar with configuring those products.
+   * Apache 2.0+ with mod_rewrite and "AllowOverride All" set
+   * IIS 7+
+   * Support for Lighttpd, IIS 6, and other web servers may work if you are familiar with configuring those products.
  * We recommend enabling content compression (for example with mod_deflate) to speed up the delivery of HTML, CSS, and JavaScript.
  * One of the following operating systems:
-  * Linux/Unix/BSD
-  * Microsoft Windows XP SP3, Vista, Windows 7, Server 2008, Server 2008 R2
-  * Mac OS X 10.4+
+   * Linux/Unix/BSD
+   * Microsoft Windows XP SP3, Vista, Windows 7, Server 2008, Server 2008 R2
+   * Mac OS X 10.4+
 
 ## Web server hardware requirements
 


### PR DESCRIPTION
As of SS4 I recommend that we clarify the level of support we provide
for MSSQL. The testing coverage of MSSQL and production use of it in
systems supported by the core team both seems very low.

MSSQL support was a lot more important in a pre-cloud-hosting world, but
these days our recommendation is to run SilverStripe on a stack that its
designed to work with rather than trying to fit it into your existing
hosting infrastructure.