### PR TITLE
Fix regression from #6668 - ModelAdmin form widths

### DIFF
--- a/admin/templates/Includes/ModelAdmin_Content.ss
+++ b/admin/templates/Includes/ModelAdmin_Content.ss
@@ -21,7 +21,7 @@
             <% end_if %>
 			<ul class="cms-tabset-nav-primary">
 				<% loop $ManagedModelTabs %>
-				<li class="tab-$ClassName $LinkOrCurrent<% if $LinkOrCurrent == 'current' %> ui-tabs-active<% end_if %>">
+				<li class="tab-$ClassName $LinkOrCurrent<% if $LinkOrCurrent == 'current' %> ui-tabs-active<% end_if %>" aria-controls="Form_EditForm">
 					<a href="$Link" class="cms-panel-link" title="$Title.ATT">$Title</a>
 				</li>
 				<% end_loop %>


### PR DESCRIPTION
Fixes bug highlighted in https://github.com/silverstripe/silverstripe-framework/pull/6668#issuecomment-291873671.

jQuery UI’s tabs component will use either the `aria-controls` attribute on the `<li>`, or the `title` attribute on the `<a>`, to match up the tab button to the tab contents. The tab contents in `ModelAdmin` are always `<form id="Form_EditForm"...`, so we need to keep that hard-coded somewhere.

See https://github.com/silverstripe/silverstripe-framework/blob/3.5.3/thirdparty/jquery-ui/jquery-ui.js#L14246-L14252