### PR TITLE
FIX Ensure that mysite test boostrap configuration is loaded after core and before the database connection

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,5 +3,4 @@
 require __DIR__ . '/bootstrap/init.php';
 require __DIR__ . '/bootstrap/cli.php';
 require __DIR__ . '/bootstrap/environment.php';
-require __DIR__ . '/bootstrap/mysite.php';
 require __DIR__ . '/bootstrap/phpunit.php';

--- a/tests/bootstrap/phpunit.php
+++ b/tests/bootstrap/phpunit.php
@@ -8,6 +8,9 @@ use SilverStripe\ORM\DB;
 require_once __DIR__ . '/../../src/Core/Core.php';
 require_once __DIR__ . '/../php/Control/FakeController.php';
 
+// Bootstrap a mock project configuration
+require __DIR__ . '/mysite.php';
+
 global $databaseConfig;
 DB::connect($databaseConfig);
 


### PR DESCRIPTION
To reproduce the issue define `SS_SEND_ALL_EMAILS_TO="foo@example.com"` in your `.env` and run phpunit:

```
Notice: Undefined offset: -1 in .../framework/src/Core/Config/ConfigLoader.php on line 39
Notice: Undefined offset: -1 in .../framework/src/Core/Config/ConfigLoader.php on line 39
Fatal error: Call to a member function nest() on null in .../framework/src/Core/Config/Config.php on line 75
```

