### PR TITLE
Fixing broken search in SecurityAdmin Groups field 

### DIFF
--- a/admin/code/SecurityAdmin.php
+++ b/admin/code/SecurityAdmin.php
@@ -94,10 +94,10 @@ class SecurityAdmin extends LeftAndMain implements PermissionProvider {
 		);
 		$columns = $groupList->getConfig()->getComponentByType('GridFieldDataColumns');
 		$columns->setDisplayFields(array(
-			'Breadcrumbs' => singleton('Group')->fieldLabel('Title')
+			'Title' => singleton('Group')->fieldLabel('Title')
 		));
 		$columns->setFieldFormatting(array(
-			'Breadcrumbs' => function($val, $item) {
+			'Title' => function($val, $item) {
 				return Convert::raw2xml($item->getBreadcrumbs(' > '));
 			}
 		));


### PR DESCRIPTION
Breadcrumbs is not a database field, so can't be searched.

Before and after:

![before](https://cloud.githubusercontent.com/assets/138450/24936945/49a98c56-1f81-11e7-9937-c3dd06d6385e.PNG)
![after](https://cloud.githubusercontent.com/assets/138450/24936946/4b331b96-1f81-11e7-84b2-14c073c27171.PNG)
