### PR TITLE
API Replace SS_HOST with SS_BASE_URL

### DIFF
--- a/docs/en/00_Getting_Started/03_Environment_Management.md
+++ b/docs/en/00_Getting_Started/03_Environment_Management.md
@@ -83,8 +83,8 @@ SilverStripe core environment variables are listed here, though you're free to d
 | `SS_TRUSTED_PROXY_PROTOCOL_HEADER` | Used to define the proxy header to be used to determine HTTPS status |
 | `SS_TRUSTED_PROXY_IP_HEADER` | Used to define the proxy header to be used to determine request IPs |
 | `SS_TRUSTED_PROXY_HOST_HEADER` | Used to define the proxy header to be used to determine the requested host name |
-| `SS_TRUSTED_PROXY_IPS` | IP address or CIDR range to trust proxy headers from |
+| `SS_TRUSTED_PROXY_IPS` | IP address or CIDR range to trust proxy headers from. If left blank no proxy headers are trusted. Can be set to 'none' (trust none) or '*' (trust all) |
 | `SS_ALLOWED_HOSTS` | A comma deliminated list of hostnames the site is allowed to respond to |
 | `SS_MANIFESTCACHE` | The manifest cache to use (defaults to file based caching). Must be a CacheInterface or CacheFactory class name |
 | `SS_IGNORE_DOT_ENV` | If set the .env file will be ignored. This is good for live to mitigate any performance implications of loading the .env file |
-| `SS_HOST` | The hostname to use when it isn't determinable by other means (eg: for CLI commands) |
+| `SS_BASE_URL` | The url to use when it isn't determinable by other means (eg: for CLI commands) |

--- a/docs/en/02_Developer_Guides/17_CLI/index.md
+++ b/docs/en/02_Developer_Guides/17_CLI/index.md
@@ -44,20 +44,12 @@ This currently only works on UNIX like systems, not on Windows.
 
 Sometimes SilverStripe needs to know the URL of your site. For example, when sending an email or generating static 
 files. When you're visiting the site in a web browser this is easy to work out, but when executing scripts on the 
-command line, it has no way of knowing. To work this out, there are several ways to resolve this. You can set alternate
-base URLs, hosts, and protocol.
+command line, it has no way of knowing.
 
-eg:
-
-```yml
-SilverStripe\Control\Director:
-  alternate_base_url: 'https://example.com/'
-```
-
-Alternatively you can use the `SS_HOST` environment variable to set a fallback hostname:
+You can use the `SS_BASE_URL` environment variable to specify this.
 
 ```
-SS_HOST="localhost"
+SS_BASE_URL="http://localhost/base-url"
 ```
 
 ### Usage

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -141,7 +141,8 @@ For example, if you have the below `_ss_environment.php` file, your `.env` would
     SS_ENVIRONMENT_TYPE="dev"
     SS_DEFAULT_ADMIN_USERNAME="admin"
     SS_DEFAULT_ADMIN_PASSWORD="password"
-    SS_HOST="localhost"
+    SS_BASE_URL="http://localhost/"
+
     ### Database
     SS_DATABASE_CHOOSE_NAME="true"
     SS_DATABASE_CLASS="MySQLDatabase"
@@ -154,7 +155,7 @@ The removal of the `_ss_environment.php` file means that conditional logic is no
 variable set-up process. This generally encouraged bad practice and should be avoided. If you still require conditional
 logic early in the bootstrap, this is best placed in the `_config.php` files.
 
-Note also that `$_FILE_TO_URL_MAPPING` has been removed and replaced with `SS_HOST` env var.
+Note also that `$_FILE_TO_URL_MAPPING` has been removed and replaced with `SS_BASE_URL` env var.
 
 See [Environment Management docs](/getting-started/environment_management/) for full details.
 
@@ -1200,6 +1201,19 @@ After (`mysite/_config/config.yml`):
   * `getsubtree()` -> moved to `CMSMain`
   * `updatetreenodes()` -> moved to `CMSMain`
   * `savetreenodes()` -> moved to `CMSMain`
+* Some `Director` API have been removed.
+  * $dev_servers
+  * $test_servers
+  * $urlParams and setUrlParams()
+  * `Director.alternate_host` removed. Use `Director.alternate_base_url` instead.
+  * `Director.alternate_protocol` removed. Use `Director.alternate_base_url` instead.
+* Global enviromnent variables changed:
+  * 'BlockUntrustedIPS' env setting has been removed.
+    All IPs are untrusted unless `SS_TRUSTED_PROXY_IPS` is set to '*'
+    See [Environment Management docs](/getting-started/environment_management/) for full details.
+  * `MODULES_PATH` removed
+  * `MODULES_DIR` removed
+  * `SS_HOST` removed. Use `SS_BASE_URL` instead.
   
 
 #### <a name="overview-general-removed"></a>General and Core Removed API

--- a/docs/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
+++ b/docs/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
@@ -57,8 +57,8 @@ Example `.env`:
     SS_DEFAULT_ADMIN_USERNAME="admin"
     SS_DEFAULT_ADMIN_PASSWORD="password"
     
-    # Basic CLI hostname
-    SS_HOST="localhost";
+    # Basic CLI request url default
+    SS_BASE_URL="http://localhost/"
 
 
 You will also need to be assigned the following permissions. Contact one of the SS staff from

--- a/src/Core/Injector/Injector.php
+++ b/src/Core/Injector/Injector.php
@@ -527,7 +527,13 @@ class Injector
 
         // Evaluate constants surrounded by back ticks
         if (preg_match('/^`(?<name>[^`]+)`$/', $value, $matches)) {
-            $value = defined($matches['name']) ? constant($matches['name']) : null;
+            if (getenv($matches['name']) !== false) {
+                $value = getenv($matches['name']);
+            } elseif (defined($matches['name'])) {
+                $value = constant($matches['name']);
+            } else {
+                $value = null;
+            }
         }
 
         return $value;

--- a/tests/php/Control/DirectorTest.php
+++ b/tests/php/Control/DirectorTest.php
@@ -191,10 +191,31 @@ class DirectorTest extends SapphireTest
             Director::absoluteURL('subfolder/test')
         );
 
+        // absolute base URLS with subdirectory - You should end them in a /
+        Director::config()->set('alternate_base_url', 'http://www.example.org/relativebase/');
+        $_SERVER['REQUEST_URI'] = "http://www.example.org/relativebase/sub-page/";
+        $this->assertEquals('/relativebase/', Director::baseURL()); // Non-absolute url
+        $this->assertEquals('http://www.example.org/relativebase/', Director::absoluteBaseURL());
+        $this->assertEquals('http://www.example.org/relativebase/sub-page/', Director::absoluteURL('', Director::REQUEST));
+        $this->assertEquals('http://www.example.org/relativebase/', Director::absoluteURL('', Director::BASE));
+        $this->assertEquals('http://www.example.org/', Director::absoluteURL('', Director::ROOT));
+        $this->assertEquals(
+            'http://www.example.org/relativebase/sub-page/subfolder/test',
+            Director::absoluteURL('subfolder/test', Director::REQUEST)
+        );
+        $this->assertEquals(
+            'http://www.example.org/subfolder/test',
+            Director::absoluteURL('subfolder/test', Director::ROOT)
+        );
+        $this->assertEquals(
+            'http://www.example.org/relativebase/subfolder/test',
+            Director::absoluteURL('subfolder/test', Director::BASE)
+        );
+
         // absolute base URLs - you should end them in a /
         Director::config()->set('alternate_base_url', 'http://www.example.org/');
         $_SERVER['REQUEST_URI'] = "http://www.example.org/sub-page/";
-        $this->assertEquals('http://www.example.org/', Director::baseURL());
+        $this->assertEquals('/', Director::baseURL()); // Non-absolute url
         $this->assertEquals('http://www.example.org/', Director::absoluteBaseURL());
         $this->assertEquals('http://www.example.org/sub-page/', Director::absoluteURL('', Director::REQUEST));
         $this->assertEquals('http://www.example.org/', Director::absoluteURL('', Director::BASE));


### PR DESCRIPTION
API Remove Director::$test_servers / $dev_servers
API Remove MODULES_PATH / MODULES_DIR constants
ENHANCEMENT Injector backtick syntax now supports environment variables as well as constants
Fixes #6588

Also merge with https://github.com/silverstripe/silverstripe-installer/pull/171 to remove .htaccess declaration

CMS pr https://github.com/silverstripe/silverstripe-cms/pull/1794