### PR TITLE
[WIP][feature] Log queries to a logfile

### DIFF
--- a/docs/en/02_Developer_Guides/07_Debugging/02_URL_Variable_Tools.md
+++ b/docs/en/02_Developer_Guides/07_Debugging/02_URL_Variable_Tools.md
@@ -38,9 +38,19 @@ Append the option and corresponding value to your URL in your browser's address 
 ## Database
 
  | URL Variable | | Values | | Description                                                                                  | 
- | ------------ | | --------- | | -----------                                                                                  | 
- | showqueries  | | 1\|inline | | List all SQL queries executed, the `inline` option will do a fudge replacement of parameterised queries          | 
- | previewwrite | | 1      | | List all insert / update SQL queries, and **don't** execute them.  Useful for previewing writes to the database. | 
+ | ------------ | | -------------- | | -----------                                                                                  | 
+ | showqueries  | | 1\|inline\|log | | List all SQL queries executed, the `inline` option will do a fudge replacement of parameterised queries, log will log the queries to a file, if a logfile location is given and writeable          | 
+ | previewwrite | | 1              | | List all insert / update SQL queries, and **don't** execute them.  Useful for previewing writes to the database. | 
+
+To set the logging of the queries to a file, add the following to your `mysite/_config.php`:
+```php
+use SilverStripe\ORM\Connect\Database;
+
+Database::setQueryLog('/my/location/querylogs/queries-'.time().'.log');
+```
+
+Assuming the folder exists. The `time()` parameter is not required but helps making a separate log per request.
+The request URL is at the top of the log.
 
 ## Security Redirects
 


### PR DESCRIPTION
This feature enables logging the queries to a file. Although this has an impact on performance, it's only enabled in `dev` mode anyway, so there are no big issues there.

Reason for this change, is I found it incredibly useful to be able to log my queries to a file and compare them to MySQL's `slow_queries` log and by some deduction, improve performance of the whole.

I've opted to use inline and log to both try and make the best of the queries, because otherwise, the log file is slightly unreadable after the logging.

The added documentation contains a suggested use of `time()`

Also updated the output to have a precision of 5, as per the microtime() call, instead of the original 4.

I'm happy to add tests for this, but it as it is only used in dev-mode, I'm unsure if the tests actually run (hence, no tests yet)

todo: use the logger instead of manually writing