### PR TITLE
Use `Config` for authenticator settings

### DIFF
--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -1015,6 +1015,23 @@ to update those with the appropriate function or config call. See
 [CMS architecture](/developer_guides/customising_the_admin_interface/cms-architecture#the-admin-url) for language
 specific functions.
 
+#### Upgrading custom Authenticators
+
+The methods `register` and `unregister` on `Authenticator` are deprecated in favor of the `Config` system. This means that any custom Authenticator needs to be registered through the yml config:
+```yaml
+SilverStripe\Security\Authenticator;
+  authenticators:
+    - MyVendor\MyModule\MyAuthenticator
+```
+If there is no authenticator registered, `Authenticator` will try to fall back on the `default_authenticator`, which can be changed using the following config, replacing the MemberAuthenticator with your authenticator:
+```yaml
+SilverStripe\Security\Authenticator:
+  default_authenticator: SilverStripe\Security\MemberAuthenticator
+```
+
+As soon as a custom authenticator is registered, the default authenticator will not be available anymore, unless enabled specifically in the config.
+
+By default, the `SilverStripe\Security\MemberAuthenticator` is seen as the default authenticator until it's explicitly set in the config.
 
 #### Upgrading Config API usages
 
@@ -1784,3 +1801,4 @@ New `TimeField` methods replace `getConfig()` / `setConfig()`
    you will need to define this method and return a short name describing the login method.
  * `MemberLoginForm` has a new constructor argument for the authenticator class, athough tis is usually
    constructed by `MemberAuthenticator` and won't affect normal use.
+ * `Authenticator` methods `register` and `unregister` are deprecated in favor of using `Config`

--- a/src/Security/LoginForm.php
+++ b/src/Security/LoginForm.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Security;
 
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 
 /**
@@ -32,4 +33,18 @@ abstract class LoginForm extends Form
      * @return string
      */
     abstract public function getAuthenticatorName();
+
+    /**
+     * Required FieldList creation on a LoginForm
+     *
+     * @return FieldList
+     */
+    abstract protected function getFormFields();
+
+    /**
+     * Required FieldList creation for the login actions on this LoginForm
+     *
+     * @return FieldList
+     */
+    abstract protected function getFormActions();
 }

--- a/src/Security/MemberAuthenticator.php
+++ b/src/Security/MemberAuthenticator.php
@@ -208,7 +208,7 @@ class MemberAuthenticator extends Authenticator
     public static function get_cms_login_form(Controller $controller)
     {
         /** @skipUpgrade */
-        return CMSMemberLoginForm::create($controller, "LoginForm");
+        return CMSMemberLoginForm::create($controller, self::class, "LoginForm");
     }
 
     public static function supports_cms()

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -369,7 +369,7 @@ class Security extends Controller implements TemplateGlobalProvider
         $authenticator = $this->getRequest()->requestVar('AuthenticationMethod');
         if ($authenticator && Authenticator::is_registered($authenticator)) {
             return $authenticator;
-        } elseif ($authenticator !== "" && Authenticator::is_registered(Authenticator::get_default_authenticator())) {
+        } elseif ($authenticator !== '' && Authenticator::is_registered(Authenticator::get_default_authenticator())) {
             return Authenticator::get_default_authenticator();
         }
 


### PR DESCRIPTION
Unless there's a specific reason for not using `Config`? 
This change reads the authentication methods etc. from config instead of static.