### PR TITLE
suffix subfolder in silverstripe-chache with php-version

### DIFF
--- a/core/TempPath.php
+++ b/core/TempPath.php
@@ -11,8 +11,9 @@
 function getTempFolder($base = null) {
 	$parent = getTempParentFolder($base);
 
-	// The actual temp folder is a subfolder of getTempParentFolder(), named by username
-	$subfolder = $parent . DIRECTORY_SEPARATOR . getTempFolderUsername();
+	// The actual temp folder is a subfolder of getTempParentFolder(), named by username and suffixed with currently used php-version
+	$phpversion = '-php' . preg_replace('/[^\w-\.+]+/', '-', PHP_VERSION);
+	$subfolder = $parent . DIRECTORY_SEPARATOR . getTempFolderUsername() . $phpversion;
 
 	if(!@file_exists($subfolder)) {
 		mkdir($subfolder);

--- a/core/TempPath.php
+++ b/core/TempPath.php
@@ -65,7 +65,7 @@ function getTempParentFolder($base = null) {
 
 	// failing the above, try finding a namespaced silverstripe-cache dir in the system temp
 	$tempPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR .
-		'silverstripe-cache-php' . preg_replace('/[^\w-\.+]+/', '-', PHP_VERSION) .
+		'silverstripe-cache' .
 		str_replace(array(' ', '/', ':', '\\'), '-', $base);
 	if(!@file_exists($tempPath)) {
 		$oldUMask = umask(0);

--- a/tests/core/CoreTest.php
+++ b/tests/core/CoreTest.php
@@ -17,9 +17,9 @@ class CoreTest extends SapphireTest {
 
 	public function testGetTempPathInProject() {
 		$user = getTempFolderUsername();
-
+		$phpversion = '-php' . preg_replace('/[^\w-\.+]+/', '-', PHP_VERSION);
 		if(file_exists($this->tempPath)) {
-			$this->assertEquals(getTempFolder(BASE_PATH), $this->tempPath . DIRECTORY_SEPARATOR . $user);
+			$this->assertEquals(getTempFolder(BASE_PATH), $this->tempPath . DIRECTORY_SEPARATOR . $user . $phpversion);
 		} else {
 			$user = getTempFolderUsername();
 			$base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-cache-php' .
@@ -27,17 +27,17 @@ class CoreTest extends SapphireTest {
 
 			// A typical Windows location for where sites are stored on IIS
 			$this->assertEquals(
-				$base . 'C--inetpub-wwwroot-silverstripe-test-project' . DIRECTORY_SEPARATOR . $user,
+				$base . 'C--inetpub-wwwroot-silverstripe-test-project' . DIRECTORY_SEPARATOR . $user . $phpversion,
 				getTempFolder('C:\\inetpub\\wwwroot\\silverstripe-test-project'));
 
 			// A typical Mac OS X location for where sites are stored
 			$this->assertEquals(
-				$base . '-Users-joebloggs-Sites-silverstripe-test-project' . DIRECTORY_SEPARATOR . $user,
+				$base . '-Users-joebloggs-Sites-silverstripe-test-project' . DIRECTORY_SEPARATOR . $user . $phpversion,
 				getTempFolder('/Users/joebloggs/Sites/silverstripe-test-project'));
 
 			// A typical Linux location for where sites are stored
 			$this->assertEquals(
-				$base . '-var-www-silverstripe-test-project' . DIRECTORY_SEPARATOR . $user,
+				$base . '-var-www-silverstripe-test-project' . DIRECTORY_SEPARATOR . $user . $phpversion,
 				getTempFolder('/var/www/silverstripe-test-project'));
 		}
 	}
@@ -47,6 +47,7 @@ class CoreTest extends SapphireTest {
 		$user = getTempFolderUsername();
 		$base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-cache-php' .
 			preg_replace('/[^\w-\.+]+/', '-', PHP_VERSION);
+		$phpversion = '-php' . preg_replace('/[^\w-\.+]+/', '-', PHP_VERSION);
 		foreach(array(
 			'C--inetpub-wwwroot-silverstripe-test-project',
 			'-Users-joebloggs-Sites-silverstripe-test-project',
@@ -54,7 +55,7 @@ class CoreTest extends SapphireTest {
 		) as $dir) {
 			$path = $base . $dir;
 			if(file_exists($path)) {
-				rmdir($path . DIRECTORY_SEPARATOR . $user);
+				rmdir($path . DIRECTORY_SEPARATOR . $user . $phpversion);
 				rmdir($path);
 			}
 		}

--- a/tests/core/CoreTest.php
+++ b/tests/core/CoreTest.php
@@ -21,9 +21,7 @@ class CoreTest extends SapphireTest {
 		if(file_exists($this->tempPath)) {
 			$this->assertEquals(getTempFolder(BASE_PATH), $this->tempPath . DIRECTORY_SEPARATOR . $user . $phpversion);
 		} else {
-			$user = getTempFolderUsername();
-			$base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-cache-php' .
-				preg_replace('/[^\w-\.+]+/', '-', PHP_VERSION);
+			$base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-cache';
 
 			// A typical Windows location for where sites are stored on IIS
 			$this->assertEquals(
@@ -45,9 +43,9 @@ class CoreTest extends SapphireTest {
 	public function tearDown() {
 		parent::tearDown();
 		$user = getTempFolderUsername();
-		$base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-cache-php' .
-			preg_replace('/[^\w-\.+]+/', '-', PHP_VERSION);
 		$phpversion = '-php' . preg_replace('/[^\w-\.+]+/', '-', PHP_VERSION);
+		$base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-cache' . $phpversion;
+		
 		foreach(array(
 			'C--inetpub-wwwroot-silverstripe-test-project',
 			'-Users-joebloggs-Sites-silverstripe-test-project',
@@ -60,5 +58,4 @@ class CoreTest extends SapphireTest {
 			}
 		}
 	}
-
 }


### PR DESCRIPTION
If the cache-folder is in system-tmp php-version is added to the path
https://github.com/silverstripe/silverstripe-framework/pull/3882

...but not, if silverstripe-cache is in webroot
https://github.com/silverstripe/silverstripe-framework/issues/2986

something like that would prevent a crash if minor php-version changes without ?flush and silverstripe-cache is in webroot and would also solve the CLI vs. HTTP PHP-Version dilemma in those cases.