### PR TITLE
FIX: Add PHP extension requirements to composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     }
   ],
   "require": {
-    "php": ">=5.6.0",
     "composer/installers": "~1.0",
     "embed/embed": "^3.0",
     "league/flysystem": "~1.0.12",
@@ -29,7 +28,18 @@
     "symfony/config": "^2.8",
     "symfony/translation": "^2.8",
     "symfony/yaml": "~2.7",
-    "vlucas/phpdotenv": "^2.4"
+    "vlucas/phpdotenv": "^2.4",
+
+    "php": ">=5.6.0",
+    "ext-intl": "*",
+    "ext-mbstring": "*",
+    "ext-xml": "*",
+    "ext-simplexml": "*",
+    "ext-dom": "*",
+    "ext-tokenizer": "*",
+    "ext-ctype": "*",
+    "ext-hash": "*",
+    "ext-session": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
This will raise incompatibilities sooner rather than relying on the 
installer.

GD is excluded from this as it’s a requirement of silverstripe/assets