### PR TITLE
BEM class names for filter-buttons

### DIFF
--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -221,7 +221,7 @@ class GridFieldFilterHeader implements GridField_HTMLProvider, GridField_DataMan
                         ->setAttribute('title', _t('SilverStripe\\Forms\\GridField\\GridField.ResetFilter', "Reset"))
                         ->setAttribute('id', 'action_reset_' . $gridField->getModelClass() . '_' . $columnField)
                 );
-                $fields->addExtraClass('filter-buttons');
+                $fields->addExtraClass('grid-field__filter-buttons');
                 $fields->addExtraClass('no-change-track');
             }
 

--- a/templates/SilverStripe/Forms/GridField/GridFieldFilterHeader_Row.ss
+++ b/templates/SilverStripe/Forms/GridField/GridFieldFilterHeader_Row.ss
@@ -1,5 +1,5 @@
-<% if Fields %>
-    <tr class="filter-header" style="display:none;">
+<% if $Fields %>
+    <tr class="grid-field__filter-header" style="display:none;">
 	   <% loop $Fields %>
 	       <th class="extra">$Field</th>
 	   <% end_loop %>


### PR DESCRIPTION
This is required for changes to GridField.scss in silverstripe-admin

Hackday trello card:

We mostly follow BEM in new CSS. Styles are co-located with components, mostly in silverstripe/admin, silverstripe/asset-admin and silverstripe/campaign-admin. Search for *.scss in client/src.

Component names should be reflected in CSS class names. For example, the HistoryList component has a CSS class name of "file-history", it should be "history-list".
The styles for a component shouldn't include unrelated toplevel CSS selectors. For example, Gallery.scss contains selectors for ".griddle-footer"