### PR TITLE
[WIP] Refactor Authenticators

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -12,12 +12,6 @@ use SilverStripe\View\Parsers\ShortcodeParser;
  * Here you can make different settings for the Framework module (the core
  * module).
  *
- * For example you can register the authentication methods you wish to use
- * on your site, e.g. to register the OpenID authentication method type
- *
- * <code>
- * Authenticator::register_authenticator('OpenIDAuthenticator');
- * </code>
  */
 
 ShortcodeParser::get('default')

--- a/_config/security.yml
+++ b/_config/security.yml
@@ -8,5 +8,26 @@ SilverStripe\Security\Security:
     default: SilverStripe\Security\MemberAuthenticator\Authenticator
     cms: SilverStripe\Security\MemberAuthenticator\CMSAuthenticator
 
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Control\RequestProcessor:
+    properties:
+      filters:
+        - '%$SilverStripe\Security\AuthenticationRequestFilter'
+  SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler:
+    properties:
+      SessionVariable: loggedInAs
+  SilverStripe\Security\MemberAuthenticator\CookieAuthenticationHandler:
+    properties:
+      TokenCookieName: alc_enc
+      DeviceCookieName: alc_device
+      CascadeLogInTo: %$SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler
+  SilverStripe\Security\IdentityStore:
+    class: SilverStripe\Security\AuthenticationRequestFilter
+
+SilverStripe\Security\AuthenticationRequestFilter:
+  handlers:
+    session: SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler
+    alc: SilverStripe\Security\MemberAuthenticator\CookieAuthenticationHandler
+
 SilverStripe\Security\MemberAuthenticator\CMSSecurity:
   reauth_enabled: true

--- a/_config/security.yml
+++ b/_config/security.yml
@@ -4,6 +4,5 @@ SilverStripe\Security\MemberAuthenticator\LoginForm:
     - Password
 
 SilverStripe\Security\Security:
-  default_authenticator: SilverStripe\Security\MemberAuthenticator\Authenticator
   authenticators:
-    - SilverStripe\Security\MemberAuthenticator\Authenticator
+    default: SilverStripe\Security\MemberAuthenticator\Authenticator

--- a/_config/security.yml
+++ b/_config/security.yml
@@ -6,3 +6,7 @@ SilverStripe\Security\MemberAuthenticator\LoginForm:
 SilverStripe\Security\Security:
   authenticators:
     default: SilverStripe\Security\MemberAuthenticator\Authenticator
+    cms: SilverStripe\Security\MemberAuthenticator\CMSAuthenticator
+
+SilverStripe\Security\MemberAuthenticator\CMSSecurity:
+  reauth_enabled: true

--- a/_config/security.yml
+++ b/_config/security.yml
@@ -1,4 +1,9 @@
-SilverStripe\Security\MemberLoginForm:
+SilverStripe\Security\MemberAuthenticator\LoginForm:
   required_fields:
     - Email
     - Password
+
+SilverStripe\Security\Security:
+  default_authenticator: SilverStripe\Security\MemberAuthenticator\Authenticator
+  authenticators:
+    - SilverStripe\Security\MemberAuthenticator\Authenticator

--- a/_config/security.yml
+++ b/_config/security.yml
@@ -1,18 +1,16 @@
-SilverStripe\Security\MemberAuthenticator\LoginForm:
+---
+Name: coresecurity
+---
+SilverStripe\Security\MemberAuthenticator\MemberLoginForm:
   required_fields:
     - Email
     - Password
-
-SilverStripe\Security\Security:
-  authenticators:
-    default: SilverStripe\Security\MemberAuthenticator\Authenticator
-    cms: SilverStripe\Security\MemberAuthenticator\CMSAuthenticator
 
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Control\RequestProcessor:
     properties:
       filters:
-        - '%$SilverStripe\Security\AuthenticationRequestFilter'
+        - %$SilverStripe\Security\AuthenticationRequestFilter
   SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler:
     properties:
       SessionVariable: loggedInAs
@@ -20,14 +18,15 @@ SilverStripe\Core\Injector\Injector:
     properties:
       TokenCookieName: alc_enc
       DeviceCookieName: alc_device
-      CascadeLogInTo: %$SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler
+      CascadeInTo: %$SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler
   SilverStripe\Security\IdentityStore:
     class: SilverStripe\Security\AuthenticationRequestFilter
-
+  SilverStripe\Security\Security:
+    properties:
+      authenticators:
+        default: %$SilverStripe\Security\MemberAuthenticator\MemberAuthenticator
+        cms: %$SilverStripe\Security\MemberAuthenticator\CMSMemberAuthenticator
 SilverStripe\Security\AuthenticationRequestFilter:
   handlers:
     session: SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler
     alc: SilverStripe\Security\MemberAuthenticator\CookieAuthenticationHandler
-
-SilverStripe\Security\MemberAuthenticator\CMSSecurity:
-  reauth_enabled: true

--- a/_config/security.yml
+++ b/_config/security.yml
@@ -1,16 +1,7 @@
 ---
-Name: coresecurity
+Name: coreauthentication
 ---
-SilverStripe\Security\MemberAuthenticator\MemberLoginForm:
-  required_fields:
-    - Email
-    - Password
-
 SilverStripe\Core\Injector\Injector:
-  SilverStripe\Control\RequestProcessor:
-    properties:
-      filters:
-        - %$SilverStripe\Security\AuthenticationRequestFilter
   SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler:
     properties:
       SessionVariable: loggedInAs
@@ -19,14 +10,26 @@ SilverStripe\Core\Injector\Injector:
       TokenCookieName: alc_enc
       DeviceCookieName: alc_device
       CascadeInTo: %$SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler
-  SilverStripe\Security\IdentityStore:
-    class: SilverStripe\Security\AuthenticationRequestFilter
+  SilverStripe\Security\AuthenticationHandler:
+    class: SilverStripe\Security\RequestAuthenticationHandler
+    properties:
+      Handlers:
+        session: %$SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler
+        alc: %$SilverStripe\Security\MemberAuthenticator\CookieAuthenticationHandler
+---
+Name: coresecurity
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Security\AuthenticationRequestFilter:
+    properties:
+      AuthenticationHandler: %$SilverStripe\Security\AuthenticationHandler
+  SilverStripe\Control\RequestProcessor:
+    properties:
+      filters:
+        - %$SilverStripe\Security\AuthenticationRequestFilter
   SilverStripe\Security\Security:
     properties:
-      authenticators:
+      Authenticators:
         default: %$SilverStripe\Security\MemberAuthenticator\MemberAuthenticator
         cms: %$SilverStripe\Security\MemberAuthenticator\CMSMemberAuthenticator
-SilverStripe\Security\AuthenticationRequestFilter:
-  handlers:
-    session: SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler
-    alc: SilverStripe\Security\MemberAuthenticator\CookieAuthenticationHandler
+  SilverStripe\Security\IdentityStore: %$SilverStripe\Security\AuthenticationHandler

--- a/docs/en/02_Developer_Guides/00_Model/05_Extending_DataObjects.md
+++ b/docs/en/02_Developer_Guides/00_Model/05_Extending_DataObjects.md
@@ -30,7 +30,7 @@ Example: Disallow creation of new players if the currently logged-in player is n
 	  public function onBeforeWrite() {
 	    // check on first write action, aka "database row creation" (ID-property is not set)
 	    if(!$this->isInDb()) {
-	      $currentPlayer = Member::currentUser();
+	      $currentPlayer = Security::getCurrentUser();
 
 	      if(!$currentPlayer->IsTeamManager()) {
 	        user_error('Player-creation not allowed', E_USER_ERROR);

--- a/docs/en/02_Developer_Guides/00_Model/07_Permissions.md
+++ b/docs/en/02_Developer_Guides/00_Model/07_Permissions.md
@@ -9,7 +9,7 @@ checks. Often it makes sense to centralize those checks on the model, regardless
 The API provides four methods for this purpose: `canEdit()`, `canCreate()`, `canView()` and `canDelete()`.
 
 Since they're PHP methods, they can contain arbitrary logic matching your own requirements. They can optionally receive 
-a `$member` argument, and default to the currently logged in member (through `Member::currentUser()`).
+a `$member` argument, and default to the currently logged in member (through `Security::getCurrentUser()`).
 
 <div class="notice" markdown="1">
 By default, all `DataObject` subclasses can only be edited, created and viewed by users with the 'ADMIN' permission 

--- a/docs/en/02_Developer_Guides/01_Templates/04_Rendering_Templates.md
+++ b/docs/en/02_Developer_Guides/01_Templates/04_Rendering_Templates.md
@@ -40,7 +40,7 @@ includes [api:Controller], [api:FormField] and [api:DataObject] instances.
 ```php
 $controller->renderWith(array('MyController', 'MyBaseController'));
 
-Member::currentUser()->renderWith('Member_Profile');
+Security::getCurrentUser()->renderWith('Member_Profile');
 ```
 
 `renderWith` can be used to override the default template process. For instance, to provide an ajax version of a 

--- a/docs/en/02_Developer_Guides/05_Extending/01_Extensions.md
+++ b/docs/en/02_Developer_Guides/05_Extending/01_Extensions.md
@@ -109,7 +109,7 @@ we added a `SayHi` method which is unique to our extension.
 
 **mysite/code/Page.php**
 	:::php
-	$member = Member::currentUser();
+	$member = Security::getCurrentUser();
 	echo $member->SayHi;
 
 	// "Hi Sam"
@@ -220,7 +220,7 @@ To see what extensions are currently enabled on an object, use [api:Object::getE
 
 
 	:::php
-	$member = Member::currentUser();
+	$member = Security::getCurrentUser();
 
 	print_r($member->getExtensionInstances());
 	

--- a/docs/en/02_Developer_Guides/09_Security/00_Member.md
+++ b/docs/en/02_Developer_Guides/09_Security/00_Member.md
@@ -24,12 +24,12 @@ next method for testing if you just need to test.
 	}
 
 
-**Member::currentUser()**
+**Security::getCurrentUser()**
 
 Returns the full *Member* Object for the current user, returns *null* if user is not logged in.
 
 	:::php
-	if( $member = Member::currentUser() ) {
+	if( $member = Security::getCurrentUser() ) {
 		// Work with $member
 	} else {
 		// Do non-member stuff

--- a/docs/en/02_Developer_Guides/10_Email/index.md
+++ b/docs/en/02_Developer_Guides/10_Email/index.md
@@ -60,7 +60,7 @@ The PHP Logic..
 $email = SilverStripe\Control\Email\Email::create()
     ->setHTMLTemplate('Email\\MyCustomEmail') 
     ->setData(array(
-        'Member' => Member::currentUser(),
+        'Member' => Security::getCurrentUser(),
         'Link'=> $link,
     ))
     ->setFrom($from)

--- a/src/Control/Controller.php
+++ b/src/Control/Controller.php
@@ -9,6 +9,7 @@ use SilverStripe\ORM\DataModel;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Security\BasicAuth;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 use SilverStripe\View\SSViewer;
 use SilverStripe\View\TemplateGlobalProvider;
 
@@ -575,7 +576,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
     public function can($perm, $member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
         if (is_array($perm)) {
             $perm = array_map(array($this, 'can'), $perm, array_fill(0, count($perm), $member));

--- a/src/Control/RequestHandler.php
+++ b/src/Control/RequestHandler.php
@@ -297,6 +297,20 @@ class RequestHandler extends ViewableData
     }
 
     /**
+     * @param string $link
+     * @return string
+     */
+    protected function addBackURLParam($link)
+    {
+        $backURL = $this->getBackURL();
+        if ($backURL) {
+            return Controller::join_links($link, '?BackURL=' . urlencode($backURL));
+        }
+
+        return $link;
+    }
+
+    /**
      * Given a request, and an action name, call that action name on this RequestHandler
      *
      * Must not raise HTTPResponse_Exceptions - instead it should return

--- a/src/Core/Config/Config_ForClass.php
+++ b/src/Core/Config/Config_ForClass.php
@@ -9,7 +9,7 @@ class Config_ForClass
     /**
      * @var string $class
      */
-    protected $class;
+    public $class;
 
     /**
      * @param string|object $class

--- a/src/Core/Config/Config_ForClass.php
+++ b/src/Core/Config/Config_ForClass.php
@@ -9,7 +9,7 @@ class Config_ForClass
     /**
      * @var string $class
      */
-    public $class;
+    protected $class;
 
     /**
      * @param string|object $class

--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -399,37 +399,6 @@ class FunctionalTest extends SapphireTest
     }
 
     /**
-     * Log in as the given member
-     *
-     * @param Member|int|string $member The ID, fixture codename, or Member object of the member that you want to log in
-     */
-    public function logInAs($member)
-    {
-        if (is_numeric($member)) {
-            $member = DataObject::get_by_id(Member::class, $member);
-        } elseif (!is_object($member)) {
-            $member = $this->objFromFixture('SilverStripe\\Security\\Member', $member);
-        }
-
-        $this->logIn($member);
-    }
-
-    /**
-     * Log out the member
-     *
-     */
-    public function logOut()
-    {
-        $this->session()->inst_clear('loggedInAs');
-        Security::setCurrentUser(null);
-    }
-
-    public function logIn($member)
-    {
-        Security::setCurrentUser($member);
-    }
-
-    /**
      * Use the draft (stage) site for testing.
      * This is helpful if you're not testing publication functionality and don't want "stage management" cluttering
      * your test.

--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Dev;
 use SilverStripe\Control\Session;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\BasicAuth;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
@@ -415,11 +416,9 @@ class FunctionalTest extends SapphireTest
         Security::setCurrentUser($member);
     }
 
-
     /**
-     * Log in as the given member
+     * Log out the member
      *
-     * @param Member|int|string $member The ID, fixture codename, or Member object of the member that you want to log in
      */
     public function logOut()
     {

--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -106,8 +106,7 @@ class FunctionalTest extends SapphireTest
         // basis.
         BasicAuth::protect_entire_site(false);
 
-        $this->session()->inst_clear('loggedInAs');
-        Security::setCurrentUser(null);
+        $this->logOut();
 
         SecurityToken::disable();
     }
@@ -412,8 +411,7 @@ class FunctionalTest extends SapphireTest
             $member = $this->objFromFixture('SilverStripe\\Security\\Member', $member);
         }
 
-        $this->session()->inst_set('loggedInAs', $member->ID);
-        Security::setCurrentUser($member);
+        $this->logIn($member);
     }
 
     /**
@@ -422,8 +420,13 @@ class FunctionalTest extends SapphireTest
      */
     public function logOut()
     {
-        $this->session()->inst_set('loggedInAs', null);
+        $this->session()->inst_clear('loggedInAs');
         Security::setCurrentUser(null);
+    }
+
+    public function logIn($member)
+    {
+        Security::setCurrentUser($member);
     }
 
     /**

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -276,7 +276,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
         if (Controller::has_curr()) {
             Controller::curr()->setSession(Session::create(array()));
         }
-        Security::$database_is_ready = null;
+        Security::clear_database_is_ready();
 
         // Set up test routes
         $this->setUpRoutes();

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -1251,8 +1251,31 @@ class SapphireTest extends PHPUnit_Framework_TestCase
 
             $this->cache_generatedMembers[$permCode] = $member;
         }
-        Injector::inst()->get(IdentityStore::class)->logIn($member);
+        $this->logInAs($member);
         return $member->ID;
+    }
+
+    /**
+     * Log in as the given member
+     *
+     * @param Member|int|string $member The ID, fixture codename, or Member object of the member that you want to log in
+     */
+    public function logInAs($member)
+    {
+        if (is_numeric($member)) {
+            $member = DataObject::get_by_id(Member::class, $member);
+        } elseif (!is_object($member)) {
+            $member = $this->objFromFixture(Member::class, $member);
+        }
+        Injector::inst()->get(IdentityStore::class)->logIn($member);
+    }
+
+    /**
+     * Log out the current user
+     */
+    public function logOut()
+    {
+        Injector::inst()->get(IdentityStore::class)->logOut();
     }
 
     /**

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -1250,7 +1250,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
 
             $this->cache_generatedMembers[$permCode] = $member;
         }
-        $member->logIn();
+        Security::setCurrentUser($member);
         return $member->ID;
     }
 

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -25,6 +25,7 @@ use SilverStripe\Core\Resettable;
 use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\SS_List;
+use SilverStripe\Security\IdentityStore;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataModel;
@@ -1250,7 +1251,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
 
             $this->cache_generatedMembers[$permCode] = $member;
         }
-        Security::setCurrentUser($member);
+        Injector::inst()->get(IdentityStore::class)->logIn($member);
         return $member->ID;
     }
 

--- a/src/Dev/TestSession.php
+++ b/src/Dev/TestSession.php
@@ -38,7 +38,7 @@ class TestSession
     /**
      * Necessary to use the mock session
      * created in {@link session} in the normal controller stack,
-     * e.g. to overwrite Member::currentUser() with custom login data.
+     * e.g. to overwrite Security::getCurrentUser() with custom login data.
      *
      * @var Controller
      */

--- a/src/Forms/ConfirmedPasswordField.php
+++ b/src/Forms/ConfirmedPasswordField.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Forms;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectInterface;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 use SilverStripe\View\Requirements;
 
 /**
@@ -504,7 +505,7 @@ class ConfirmedPasswordField extends FormField
             }
 
             // Check this password is valid for the current user
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
             if (!$member) {
                 $validator->validationError(
                     $name,

--- a/src/Forms/FormRequestHandler.php
+++ b/src/Forms/FormRequestHandler.php
@@ -228,7 +228,7 @@ class FormRequestHandler extends RequestHandler
             // First, try a handler method on the controller (has been checked for allowed_actions above already)
             $controller = $this->form->getController();
             if ($controller && $controller->hasMethod($funcName)) {
-                return $controller->$funcName($vars, $this->form, $request);
+                return $controller->$funcName($vars, $this->form, $request, $this);
             }
 
             // Otherwise, try a handler method on the form request handler.

--- a/src/Forms/FormRequestHandler.php
+++ b/src/Forms/FormRequestHandler.php
@@ -233,18 +233,18 @@ class FormRequestHandler extends RequestHandler
 
             // Otherwise, try a handler method on the form request handler.
             if ($this->hasMethod($funcName)) {
-                return $this->$funcName($vars, $this->form, $request);
+                return $this->$funcName($vars, $this->form, $request, $this);
             }
 
             // Otherwise, try a handler method on the form itself
             if ($this->form->hasMethod($funcName)) {
-                return $this->form->$funcName($vars, $this->form, $request);
+                return $this->form->$funcName($vars, $this->form, $request, $this);
             }
 
             // Check for inline actions
             $field = $this->checkFieldsForAction($this->form->Fields(), $funcName);
             if ($field) {
-                return $field->$funcName($vars, $this->form, $request);
+                return $field->$funcName($vars, $this->form, $request, $this);
             }
         } catch (ValidationException $e) {
             // The ValdiationResult contains all the relevant metadata

--- a/src/Forms/GridField/GridFieldPrintButton.php
+++ b/src/Forms/GridField/GridFieldPrintButton.php
@@ -10,6 +10,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 use SilverStripe\View\Requirements;
 use SilverStripe\View\ArrayData;
 
@@ -249,7 +250,7 @@ class GridFieldPrintButton implements GridField_HTMLProvider, GridField_ActionPr
             "Header" => $header,
             "ItemRows" => $itemRows,
             "Datetime" => DBDatetime::now(),
-            "Member" => Member::currentUser(),
+            "Member" => Security::getCurrentUser(),
         ));
 
         return $ret;

--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -491,6 +491,17 @@ abstract class Database
     abstract public function datetimeDifferenceClause($date1, $date2);
 
     /**
+     * String operator for concatenation of strings
+     *
+     * @return string
+     */
+    public function concatOperator()
+    {
+        // @todo Make ' + ' in mssql
+        return ' || ';
+    }
+
+    /**
      * Returns true if this database supports collations
      *
      * @return boolean

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -24,6 +24,7 @@ use SilverStripe\ORM\FieldType\DBComposite;
 use SilverStripe\ORM\FieldType\DBClassName;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
+use SilverStripe\Security\Security;
 use SilverStripe\View\ViewableData;
 use LogicException;
 use InvalidArgumentException;
@@ -76,11 +77,11 @@ use stdClass;
  *   static $api_access = true;
  *
  *   function canView($member = false) {
- *     if(!$member) $member = Member::currentUser();
+ *     if(!$member) $member = Security::getCurrentUser();
  *     return $member->inGroup('Subscribers');
  *   }
  *   function canEdit($member = false) {
- *     if(!$member) $member = Member::currentUser();
+ *     if(!$member) $member = Security::getCurrentUser();
  *     return $member->inGroup('Editors');
  *   }
  *
@@ -2498,7 +2499,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     public function can($perm, $member = null, $context = array())
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         if ($member && Permission::checkMember($member, "ADMIN")) {

--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -9,6 +9,7 @@ use SilverStripe\Forms\DateField;
 use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\DB;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 
 /**
  * Represents a date field.
@@ -250,7 +251,7 @@ class DBDate extends DBField
     public function FormatFromSettings($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         // Fall back to nice

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -7,6 +7,7 @@ use SilverStripe\Forms\DatetimeField;
 use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\DB;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 use SilverStripe\View\TemplateGlobalProvider;
 use Exception;
 use InvalidArgumentException;
@@ -97,7 +98,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
     public function FormatFromSettings($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         // Fall back to nice

--- a/src/ORM/FieldType/DBTime.php
+++ b/src/ORM/FieldType/DBTime.php
@@ -8,6 +8,7 @@ use SilverStripe\Forms\TimeField;
 use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\DB;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 
 /**
  * Represents a column in the database with the type 'Time'.
@@ -153,7 +154,7 @@ class DBTime extends DBField
     public function FormatFromSettings($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         // Fall back to nice

--- a/src/Security/AuthenticationHandler.php
+++ b/src/Security/AuthenticationHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SilverStripe\Security;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\Security\Member;
+
+/**
+ * An AuthenticationHandler is responsible for providing an identity (in the form of a Member object) for
+ * a given HTTPRequest.
+ *
+ * It should return the authenticated Member if successful. If a Member cannot be found from the current
+ * request it should *not* attempt to redirect the visitor to a log-in from or 3rd party handler, as that
+ * is the responsibiltiy of other systems.
+ */
+interface AuthenticationHandler
+{
+    /**
+     * Given the current request, authenticate the request for non-session authorization (outside the CMS).
+     *
+     * The Member returned from this method will be provided to the Manager for use in the OperationResolver context
+     * in place of the current CMS member.
+     *
+     * Authenticators can be given a priority. In this case, the authenticator with the highest priority will be
+     * returned first. If not provided, it will default to a low number.
+     *
+     * An example for configuring the BasicAuthAuthenticator:
+     *
+     * <code>
+     * SilverStripe\Security\Security:
+     *   authentication_handlers:
+     *     - SilverStripe\Security\BasicAuthentionHandler
+     * </code>
+     *
+     * @param  HTTPRequest $request The current HTTP request
+     * @return Member|null          The authenticated Member, or null if this auth mechanism isn't used.
+     * @throws ValidationException  If authentication data exists but does not match a member.
+     */
+    public function authenticateRequest(HTTPRequest $request);
+}

--- a/src/Security/AuthenticationHandler.php
+++ b/src/Security/AuthenticationHandler.php
@@ -3,9 +3,7 @@
 namespace SilverStripe\Security;
 
 use SilverStripe\Control\HTTPRequest;
-use SilverStripe\Control\HTTPResponse;
 use SilverStripe\ORM\ValidationException;
-use SilverStripe\Security\Member;
 
 /**
  * An AuthenticationHandler is responsible for providing an identity (in the form of a Member object) for
@@ -15,7 +13,7 @@ use SilverStripe\Security\Member;
  * request it should *not* attempt to redirect the visitor to a log-in from or 3rd party handler, as that
  * is the responsibiltiy of other systems.
  */
-interface AuthenticationHandler
+interface AuthenticationHandler extends IdentityStore
 {
     /**
      * Given the current request, authenticate the request for non-session authorization (outside the CMS).

--- a/src/Security/AuthenticationRequestFilter.php
+++ b/src/Security/AuthenticationRequestFilter.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace SilverStripe\Security;
+
+use SilverStripe\Control\RequestFilter;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\Session;
+use SilverStripe\ORM\DataModel;
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Injector\Injector;
+
+class AuthenticationRequestFilter implements RequestFilter, IdentityStore
+{
+
+    use Configurable;
+
+    protected function getHandlers()
+    {
+        return array_map(
+            function ($identifier) {
+                return Injector::inst()->get($identifier);
+            },
+            $this->config()->get('handlers')
+        );
+    }
+
+    /**
+     * Identify the current user from the request
+     */
+    public function preRequest(HTTPRequest $request, Session $session, DataModel $model)
+    {
+        try {
+            foreach ($this->getHandlers() as $handler) {
+                // @todo Update requestfilter logic to allow modification of initial response
+                // in order to add cookies, etc
+                $member = $handler->authenticateRequest($request, new HTTPResponse());
+                if ($member) {
+                    // @todo Remove the static coupling here
+                    Security::setCurrentUser($member);
+                    break;
+                }
+            }
+        } catch (ValidationException $e) {
+            throw new HTTPResponse_Exception(
+                "Bad log-in details: " . $e->getMessage(),
+                400
+            );
+        }
+    }
+
+    /**
+     * No-op
+     */
+    public function postRequest(HTTPRequest $request, HTTPResponse $response, DataModel $model)
+    {
+    }
+
+    /**
+     * Log into the identity-store handlers attached to this request filter
+     *
+     * @inherit
+     */
+    public function logIn(Member $member, $persistent, HTTPRequest $request)
+    {
+        // @todo Coupling here isn't ideal.
+        $member->beforeMemberLoggedIn();
+
+        foreach ($this->getHandlers() as $handler) {
+            if ($handler instanceof IdentityStore) {
+                $handler->logIn($member, $persistent, $request);
+            }
+        }
+
+        // @todo Coupling here isn't ideal.
+        Security::setCurrentUser($member);
+        $member->afterMemberLoggedIn();
+    }
+
+    /**
+     * Log out of all the identity-store handlers attached to this request filter
+     *
+     * @inherit
+     */
+    public function logOut(HTTPRequest $request)
+    {
+        foreach ($this->getHandlers() as $handler) {
+            if ($handler instanceof IdentityStore) {
+                $handler->logOut($request);
+            }
+        }
+
+        // @todo Coupling here isn't ideal.
+        Security::setCurrentUser(null);
+    }
+}

--- a/src/Security/AuthenticationRequestFilter.php
+++ b/src/Security/AuthenticationRequestFilter.php
@@ -2,15 +2,16 @@
 
 namespace SilverStripe\Security;
 
-use Exception;
 use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Control\RequestFilter;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Session;
+use SilverStripe\Dev\Debug;
 use SilverStripe\ORM\DataModel;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\ValidationException;
 
 class AuthenticationRequestFilter implements RequestFilter, IdentityStore
 {
@@ -18,10 +19,21 @@ class AuthenticationRequestFilter implements RequestFilter, IdentityStore
     use Configurable;
 
     /**
-     * @return array|IdentityStore[]
+     * @var array|AuthenticationHandler[]
+     */
+    protected $handlers;
+
+    /**
+     * This method currently uses a fallback as loading the handlers via YML has proven unstable
+     *
+     * @return array|AuthenticationHandler[]
      */
     protected function getHandlers()
     {
+        if (is_array($this->handlers)) {
+            return $this->handlers;
+        }
+
         return array_map(
             function ($identifier) {
                 return Injector::inst()->get($identifier);
@@ -31,23 +43,38 @@ class AuthenticationRequestFilter implements RequestFilter, IdentityStore
     }
 
     /**
+     * Set an associative array of handlers
+     *
+     * @param array|AuthenticationHandler[] $handlers
+     */
+    public function setHandlers($handlers)
+    {
+        $this->handlers = $handlers;
+    }
+
+    /**
      * Identify the current user from the request
+     *
+     * @param HTTPRequest $request
+     * @param Session $session
+     * @param DataModel $model
+     * @return bool|void
+     * @throws HTTPResponse_Exception
      */
     public function preRequest(HTTPRequest $request, Session $session, DataModel $model)
     {
         try {
             /** @var AuthenticationHandler $handler */
-            foreach ($this->getHandlers() as $handler) {
+            foreach ($this->getHandlers() as $name => $handler) {
                 // @todo Update requestfilter logic to allow modification of initial response
                 // in order to add cookies, etc
-                $member = $handler->authenticateRequest($request, new HTTPResponse());
+                $member = $handler->authenticateRequest($request);
                 if ($member) {
-                    // @todo Remove the static coupling here
                     Security::setCurrentUser($member);
                     break;
                 }
             }
-        } catch (Exception $e) { // There's no valid exception currently. I would say AuthenticationException?
+        } catch (ValidationException $e) {
             throw new HTTPResponse_Exception(
                 "Bad log-in details: " . $e->getMessage(),
                 400
@@ -57,6 +84,11 @@ class AuthenticationRequestFilter implements RequestFilter, IdentityStore
 
     /**
      * No-op
+     *
+     * @param HTTPRequest $request
+     * @param HTTPResponse $response
+     * @param DataModel $model
+     * @return bool|void
      */
     public function postRequest(HTTPRequest $request, HTTPResponse $response, DataModel $model)
     {
@@ -65,11 +97,13 @@ class AuthenticationRequestFilter implements RequestFilter, IdentityStore
     /**
      * Log into the identity-store handlers attached to this request filter
      *
-     * @inherit
+     * @param Member $member
+     * @param bool $persistent
+     * @param HTTPRequest $request
+     * @return HTTPResponse|void
      */
-    public function logIn(Member $member, $persistent, HTTPRequest $request)
+    public function logIn(Member $member, $persistent = false, HTTPRequest $request = null)
     {
-        // @todo Coupling here isn't ideal.
         $member->beforeMemberLoggedIn();
 
         foreach ($this->getHandlers() as $handler) {
@@ -78,7 +112,6 @@ class AuthenticationRequestFilter implements RequestFilter, IdentityStore
             }
         }
 
-        // @todo Coupling here isn't ideal.
         Security::setCurrentUser($member);
         $member->afterMemberLoggedIn();
     }
@@ -86,9 +119,10 @@ class AuthenticationRequestFilter implements RequestFilter, IdentityStore
     /**
      * Log out of all the identity-store handlers attached to this request filter
      *
-     * @inherit
+     * @param HTTPRequest $request
+     * @return HTTPResponse|void
      */
-    public function logOut(HTTPRequest $request)
+    public function logOut(HTTPRequest $request = null)
     {
         foreach ($this->getHandlers() as $handler) {
             if ($handler instanceof IdentityStore) {
@@ -96,7 +130,6 @@ class AuthenticationRequestFilter implements RequestFilter, IdentityStore
             }
         }
 
-        // @todo Coupling here isn't ideal.
         Security::setCurrentUser(null);
     }
 }

--- a/src/Security/Authenticator.php
+++ b/src/Security/Authenticator.php
@@ -16,125 +16,74 @@ use SilverStripe\Forms\Form;
  *
  * @author Markus Lanthaler <markus@silverstripe.com>
  */
-abstract class Authenticator
+interface Authenticator
 {
-    use Injectable;
-    use Configurable;
-    use Extensible;
 
-    public function __construct()
-    {
-        $this->constructExtensions();
-    }
+    const LOGIN = 1;
+    const LOGOUT = 2;
+    const CHANGE_PASSWORD = 4;
+    const RESET_PASSWORD = 8;
+    const CMS_LOGIN = 16;
 
     /**
-     * This variable holds all authenticators that should be used
+     * Returns the services supported by this authenticator
      *
-     * @var array
-     */
-    private static $authenticators = [];
-
-    /**
-     * Used to influence the order of authenticators on the login-screen
-     * (default shows first).
+     * The number should be a bitwise-OR of 1 or more of the following constants:
+     * Authenticator::LOGIN, Authenticator::LOGOUT, Authenticator::CHANGE_PASSWORD,
+     * Authenticator::RESET_PASSWORD, or Authenticator::CMS_LOGIN
      *
-     * @var string
+     * @return int
      */
-    private static $default_authenticator = MemberAuthenticator::class;
-
+    public function supportedServices();
 
     /**
-     * Method to authenticate an user
+     * Return RequestHandler to manage the log-in process.
      *
-     * @param array $RAW_data Raw data to authenticate the user
-     * @param Form $form Optional: If passed, better error messages can be
-     *                             produced by using
-     *                             {@link Form::sessionMessage()}
-     * @return bool|Member Returns FALSE if authentication fails, otherwise
-     *                     the member object
-     */
-    public static function authenticate($RAW_data, Form $form = null)
-    {
-    }
-
-    /**
-     * Method that creates the login form for this authentication method
+     * The default URL of the RequetHandler should return the initial log-in form, any other
+     * URL may be added for other steps & processing.
      *
-     * @param Controller $controller The parent controller, necessary to create the
-     *                   appropriate form action tag
-     * @return Form Returns the login form to use with this authentication
-     *              method
-     */
-    public static function get_login_form(Controller $controller)
-    {
-    }
-
-    /**
-     * Method that creates the re-authentication form for the in-CMS view
+     * URL-handling methods may return an array [ "Form" => (form-object) ] which can then
+     * be merged into a default controller.
      *
-     * @param Controller $controller
+     * @param $link The base link to use for this RequestHnadler
      */
-    public static function get_cms_login_form(Controller $controller)
-    {
-    }
+    public function getLoginHandler($link);
 
     /**
-     * Determine if this authenticator supports in-cms reauthentication
+     * @todo
+     */
+    public function getCMSLoginHandler($link);
+
+    /**
+     * Return RequestHandler to manage the change-password process.
      *
-     * @return bool
-     */
-    public static function supports_cms()
-    {
-        return false;
-    }
-
-    /**
-     * Check if a given authenticator is registered
+     * The default URL of the RequetHandler should return the initial change-password form,
+     * any other URL may be added for other steps & processing.
      *
-     * @param string $authenticator Name of the authenticator class to check
-     * @return bool Returns TRUE if the authenticator is registered, FALSE
-     *              otherwise.
-     */
-    public static function is_registered($authenticator)
-    {
-        $authenticators = self::config()->get('authenticators');
-        if (count($authenticators) === 0) {
-            $authenticators = [self::config()->get('default_authenticator')];
-        }
-
-        return in_array($authenticator, $authenticators, true);
-    }
-
-
-    /**
-     * Get all registered authenticators
+     * URL-handling methods may return an array [ "Form" => (form-object) ] which can then
+     * be merged into a default controller.
      *
-     * @return array Returns an array with the class names of all registered
-     *               authenticators.
+     * @param $link The base link to use for this RequestHnadler
      */
-    public static function get_authenticators()
-    {
-        $authenticators = self::config()->get('authenticators');
-        $default = self::config()->get('default_authenticator');
-
-        if (count($authenticators) === 0) {
-            $authenticators = [$default];
-        }
-        // put default authenticator first (mainly for tab-order on loginform)
-        // But only if there's no other authenticator
-        if (($key = array_search($default, $authenticators, true)) && count($authenticators) > 1) {
-            unset($authenticators[$key]);
-            array_unshift($authenticators, $default);
-        }
-
-        return $authenticators;
-    }
+    public function getChangePasswordHandler($link);
 
     /**
-     * @return string
+     * @todo
      */
-    public static function get_default_authenticator()
-    {
-        return self::config()->get('default_authenticator');
-    }
+    public function getLostPasswordHandler($link);
+
+    /**
+     * Method to authenticate an user.
+     *
+     * @param array $data Raw data to authenticate the user.
+     * @param string $message A variable to return an error message if authentication fails
+     * @return Member The matched member, or null if the authentication fails
+     */
+    public function authenticate($data, &$message);
+
+    /**
+     * Return the keys that should be passed to authenticate()
+     * @return array
+     */
+//    public function getAuthenticateFields();
 }

--- a/src/Security/Authenticator.php
+++ b/src/Security/Authenticator.php
@@ -7,6 +7,7 @@ use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Control\Controller;
 use SilverStripe\Forms\Form;
+use SilverStripe\ORM\ValidationResult;
 
 /**
  * Abstract base class for an authentication method
@@ -74,7 +75,8 @@ interface Authenticator
 
 
     /**
-     * @todo
+     * @param $link
+     * @return mixed
      */
     public function getLostPasswordHandler($link);
 
@@ -82,14 +84,8 @@ interface Authenticator
      * Method to authenticate an user.
      *
      * @param array $data Raw data to authenticate the user.
-     * @param string $message A variable to return an error message if authentication fails
+     * @param ValidationResult $result A validationresult which is either valid or contains the error message(s)
      * @return Member The matched member, or null if the authentication fails
      */
-    public function authenticate($data, &$message);
-
-    /**
-     * Return the keys that should be passed to authenticate()
-     * @return array
-     */
-//    public function getAuthenticateFields();
+    public function authenticate($data, &$result);
 }

--- a/src/Security/Authenticator.php
+++ b/src/Security/Authenticator.php
@@ -39,15 +39,25 @@ interface Authenticator
     /**
      * Return RequestHandler to manage the log-in process.
      *
-     * The default URL of the RequetHandler should return the initial log-in form, any other
+     * The default URL of the RequestHandler should return the initial log-in form, any other
      * URL may be added for other steps & processing.
      *
      * URL-handling methods may return an array [ "Form" => (form-object) ] which can then
      * be merged into a default controller.
      *
-     * @param string $link The base link to use for this RequestHnadler
+     * @param string $link The base link to use for this RequestHandler
      */
     public function getLoginHandler($link);
+
+    /**
+     * Return the RequestHandler to manage the log-out process.
+     *
+     * The default URL of the RequestHandler should log the user out immediately and destroy the session.
+     *
+     * @param string $link The base link to use for this RequestHandler
+     * @return mixed
+     */
+    public function getLogOutHandler($link);
 
     /**
      * Return RequestHandler to manage the change-password process.
@@ -61,6 +71,7 @@ interface Authenticator
      * @param string $link The base link to use for this RequestHnadler
      */
     public function getChangePasswordHandler($link);
+
 
     /**
      * @todo
@@ -81,13 +92,4 @@ interface Authenticator
      * @return array
      */
 //    public function getAuthenticateFields();
-
-    /**
-     * Log the member out of this Authentication method.
-     *
-     * @param Member $member by reference, to allow for multiple actions on the member with a single write
-     * @return boolean|Member if logout was unsuccessfull, return true, otherwise, the member is returned
-     */
-    public function doLogOut(&$member);
-
 }

--- a/src/Security/Authenticator.php
+++ b/src/Security/Authenticator.php
@@ -2,12 +2,9 @@
 
 namespace SilverStripe\Security;
 
-use SilverStripe\Core\Config\Configurable;
-use SilverStripe\Core\Extensible;
-use SilverStripe\Core\Injector\Injectable;
-use SilverStripe\Control\Controller;
-use SilverStripe\Forms\Form;
 use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Security\MemberAuthenticator\LoginHandler;
+use SilverStripe\Security\MemberAuthenticator\LogoutHandler;
 
 /**
  * Abstract base class for an authentication method
@@ -47,6 +44,7 @@ interface Authenticator
      * be merged into a default controller.
      *
      * @param string $link The base link to use for this RequestHandler
+     * @return LoginHandler
      */
     public function getLoginHandler($link);
 
@@ -56,7 +54,7 @@ interface Authenticator
      * The default URL of the RequestHandler should log the user out immediately and destroy the session.
      *
      * @param string $link The base link to use for this RequestHandler
-     * @return mixed
+     * @return LogoutHandler
      */
     public function getLogOutHandler($link);
 
@@ -75,7 +73,7 @@ interface Authenticator
 
 
     /**
-     * @param $link
+     * @param string $link
      * @return mixed
      */
     public function getLostPasswordHandler($link);
@@ -87,5 +85,5 @@ interface Authenticator
      * @param ValidationResult $result A validationresult which is either valid or contains the error message(s)
      * @return Member The matched member, or null if the authentication fails
      */
-    public function authenticate($data, &$result);
+    public function authenticate($data, &$result = null);
 }

--- a/src/Security/Authenticator.php
+++ b/src/Security/Authenticator.php
@@ -45,14 +45,9 @@ interface Authenticator
      * URL-handling methods may return an array [ "Form" => (form-object) ] which can then
      * be merged into a default controller.
      *
-     * @param $link The base link to use for this RequestHnadler
+     * @param string $link The base link to use for this RequestHnadler
      */
     public function getLoginHandler($link);
-
-    /**
-     * @todo
-     */
-    public function getCMSLoginHandler($link);
 
     /**
      * Return RequestHandler to manage the change-password process.
@@ -63,7 +58,7 @@ interface Authenticator
      * URL-handling methods may return an array [ "Form" => (form-object) ] which can then
      * be merged into a default controller.
      *
-     * @param $link The base link to use for this RequestHnadler
+     * @param string $link The base link to use for this RequestHnadler
      */
     public function getChangePasswordHandler($link);
 
@@ -86,4 +81,13 @@ interface Authenticator
      * @return array
      */
 //    public function getAuthenticateFields();
+
+    /**
+     * Log the member out of this Authentication method.
+     *
+     * @param Member $member by reference, to allow for multiple actions on the member with a single write
+     * @return boolean|Member if logout was unsuccessfull, return true, otherwise, the member is returned
+     */
+    public function doLogOut(&$member);
+
 }

--- a/src/Security/BasicAuth.php
+++ b/src/Security/BasicAuth.php
@@ -8,6 +8,9 @@ use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Core\Injector\Injector;
+
+use SilverStripe\Security\MemberAuthenticator\Authenticator;
 
 /**
  * Provides an interface to HTTP basic authentication.
@@ -82,10 +85,12 @@ class BasicAuth
 
         $member = null;
         if (isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {
-            $member = MemberAuthenticator::authenticate(array(
+            $authenticator = Injector::inst()->get(Authenticator::class);
+
+            $member = $authenticator->authenticate([
                 'Email' => $_SERVER['PHP_AUTH_USER'],
                 'Password' => $_SERVER['PHP_AUTH_PW'],
-            ), null);
+            ], $dummy);
         }
 
         if (!$member && $tryUsingSessionLogin) {

--- a/src/Security/BasicAuth.php
+++ b/src/Security/BasicAuth.php
@@ -85,6 +85,7 @@ class BasicAuth
 
         $member = null;
         if (isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {
+            /** @var Authenticator $authenticator */
             $authenticator = Injector::inst()->get(Authenticator::class);
 
             $member = $authenticator->authenticate([
@@ -151,9 +152,9 @@ class BasicAuth
      */
     public static function protect_entire_site($protect = true, $code = 'ADMIN', $message = null)
     {
-        Config::inst()->update('SilverStripe\\Security\\BasicAuth', 'entire_site_protected', $protect);
-        Config::inst()->update('SilverStripe\\Security\\BasicAuth', 'entire_site_protected_code', $code);
-        Config::inst()->update('SilverStripe\\Security\\BasicAuth', 'entire_site_protected_message', $message);
+        Config::inst()->update(self::class, 'entire_site_protected', $protect);
+        Config::inst()->update(self::class, 'entire_site_protected_code', $code);
+        Config::inst()->update(self::class, 'entire_site_protected_message', $message);
     }
 
     /**
@@ -165,7 +166,7 @@ class BasicAuth
      */
     public static function protect_site_if_necessary()
     {
-        $config = Config::forClass('SilverStripe\\Security\\BasicAuth');
+        $config = Config::forClass(BasicAuth::class);
         if ($config->entire_site_protected) {
             self::requireLogin($config->entire_site_protected_message, $config->entire_site_protected_code, false);
         }

--- a/src/Security/BasicAuth.php
+++ b/src/Security/BasicAuth.php
@@ -2,11 +2,14 @@
 
 namespace SilverStripe\Security;
 
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Dev\Debug;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Core\Injector\Injector;
 
@@ -51,15 +54,16 @@ class BasicAuth
      *
      * Used by {@link Controller::init()}.
      *
-     * @throws HTTPResponse_Exception
      *
+     * @param HTTPRequest $request
      * @param string $realm
      * @param string|array $permissionCode Optional
      * @param boolean $tryUsingSessionLogin If true, then the method with authenticate against the
      *  session log-in if those credentials are disabled.
-     * @return Member|bool $member
+     * @return bool|Member
+     * @throws HTTPResponse_Exception
      */
-    public static function requireLogin($realm, $permissionCode = null, $tryUsingSessionLogin = true)
+    public static function requireLogin(HTTPRequest $request, $realm, $permissionCode = null, $tryUsingSessionLogin = true)
     {
         $isRunningTests = (class_exists('SilverStripe\\Dev\\SapphireTest', false) && SapphireTest::is_running_test());
         if (!Security::database_is_ready() || (Director::is_cli() && !$isRunningTests)) {
@@ -74,28 +78,32 @@ class BasicAuth
 		 * The follow rewrite rule must be in the sites .htaccess file to enable this workaround
 		 * RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 		 */
-        $authHeader = (isset($_SERVER['HTTP_AUTHORIZATION']) ? $_SERVER['HTTP_AUTHORIZATION'] :
-                  (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION']) ? $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] : null));
+        $authHeader = $request->getHeader('Authorization');
         $matches = array();
         if ($authHeader && preg_match('/Basic\s+(.*)$/i', $authHeader, $matches)) {
             list($name, $password) = explode(':', base64_decode($matches[1]));
-            $_SERVER['PHP_AUTH_USER'] = strip_tags($name);
-            $_SERVER['PHP_AUTH_PW'] = strip_tags($password);
+            $request->addHeader('PHP_AUTH_USER', strip_tags($name));
+            $request->addHeader('PHP_AUTH_PW', strip_tags($password));
         }
 
         $member = null;
-        if (isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {
+
+        if ($request->getHeader('PHP_AUTH_USER') && $request->getHeader('PHP_AUTH_PW')) {
             /** @var Authenticator $authenticator */
             $authenticator = Injector::inst()->get(Authenticator::class);
 
             $member = $authenticator->authenticate([
-                'Email' => $_SERVER['PHP_AUTH_USER'],
-                'Password' => $_SERVER['PHP_AUTH_PW'],
+                'Email' => $request->getHeader('PHP_AUTH_USER'),
+                'Password' => $request->getHeader('PHP_AUTH_PW'),
             ], $dummy);
         }
 
+        if($member) {
+            Security::setCurrentUser($member);
+        }
+
         if (!$member && $tryUsingSessionLogin) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         // If we've failed the authentication mechanism, then show the login form
@@ -103,7 +111,7 @@ class BasicAuth
             $response = new HTTPResponse(null, 401);
             $response->addHeader('WWW-Authenticate', "Basic realm=\"$realm\"");
 
-            if (isset($_SERVER['PHP_AUTH_USER'])) {
+            if ($request->getHeader('PHP_AUTH_USER')) {
                 $response->setBody(_t('SilverStripe\\Security\\BasicAuth.ERRORNOTREC', "That username / password isn't recognised"));
             } else {
                 $response->setBody(_t('SilverStripe\\Security\\BasicAuth.ENTERINFO', "Please enter a username and password."));
@@ -119,7 +127,7 @@ class BasicAuth
             $response = new HTTPResponse(null, 401);
             $response->addHeader('WWW-Authenticate', "Basic realm=\"$realm\"");
 
-            if (isset($_SERVER['PHP_AUTH_USER'])) {
+            if ($request->getHeader('PHP_AUTH_USER')) {
                 $response->setBody(_t('SilverStripe\\Security\\BasicAuth.ERRORNOTADMIN', "That user is not an administrator."));
             }
 
@@ -152,9 +160,9 @@ class BasicAuth
      */
     public static function protect_entire_site($protect = true, $code = 'ADMIN', $message = null)
     {
-        Config::inst()->update(self::class, 'entire_site_protected', $protect);
-        Config::inst()->update(self::class, 'entire_site_protected_code', $code);
-        Config::inst()->update(self::class, 'entire_site_protected_message', $message);
+        Config::modify()->set(self::class, 'entire_site_protected', $protect);
+        Config::modify()->set(self::class, 'entire_site_protected_code', $code);
+        Config::modify()->set(self::class, 'entire_site_protected_message', $message);
     }
 
     /**
@@ -167,8 +175,14 @@ class BasicAuth
     public static function protect_site_if_necessary()
     {
         $config = Config::forClass(BasicAuth::class);
-        if ($config->entire_site_protected) {
-            self::requireLogin($config->entire_site_protected_message, $config->entire_site_protected_code, false);
+        $request = Controller::curr()->getRequest();
+        if ($config->get('entire_site_protected')) {
+            /** @noinspection ExceptionsAnnotatingAndHandlingInspection */
+            static::requireLogin(
+                $request,
+                $config->get('entire_site_protected_message'),
+                $config->get('entire_site_protected_code'),
+                false);
         }
     }
 }

--- a/src/Security/BasicAuth.php
+++ b/src/Security/BasicAuth.php
@@ -9,7 +9,6 @@ use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Dev\SapphireTest;
-
 use SilverStripe\Security\MemberAuthenticator\MemberAuthenticator;
 
 /**

--- a/src/Security/CMSMemberLoginForm.php
+++ b/src/Security/CMSMemberLoginForm.php
@@ -15,7 +15,7 @@ use SilverStripe\Security\Security;
 /**
  * Provides the in-cms session re-authentication form for the "member" authenticator
  */
-class CMSMemberLoginForm extends LoginForm
+class CMSMemberLoginForm extends MemberLoginForm
 {
 
     /**

--- a/src/Security/CMSSecurity.php
+++ b/src/Security/CMSSecurity.php
@@ -180,7 +180,7 @@ PHP
 
     public function LoginForm()
     {
-        $authenticator = $this->getAuthenticator();
+        $authenticator = $this->getAuthenticator('default');
         if ($authenticator && $authenticator::supports_cms()) {
             return $authenticator::get_cms_login_form($this);
         }

--- a/src/Security/CMSSecurity.php
+++ b/src/Security/CMSSecurity.php
@@ -3,14 +3,12 @@
 namespace SilverStripe\Security;
 
 use SilverStripe\Admin\AdminRootController;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Session;
 use SilverStripe\Core\Convert;
-use SilverStripe\Control\Director;
-use SilverStripe\Control\Controller;
-use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\FieldType\DBField;
-use SilverStripe\Security\MemberAuthenticator\CMSMemberAuthenticator;
 use SilverStripe\View\Requirements;
 
 /**
@@ -194,7 +192,7 @@ PHP
         $backURLs = array(
             $this->getRequest()->requestVar('BackURL'),
             Session::get('BackURL'),
-            Director::absoluteURL(AdminRootController::config()->url_base, true),
+            Director::absoluteURL(AdminRootController::config()->get('url_base'), true),
         );
         $backURL = null;
         foreach ($backURLs as $backURL) {

--- a/src/Security/Group.php
+++ b/src/Security/Group.php
@@ -476,7 +476,7 @@ class Group extends DataObject
     public function canEdit($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         // extended access checks
@@ -512,7 +512,7 @@ class Group extends DataObject
     public function canView($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         // extended access checks
@@ -534,7 +534,7 @@ class Group extends DataObject
     public function canDelete($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         // extended access checks

--- a/src/Security/GroupCsvBulkLoader.php
+++ b/src/Security/GroupCsvBulkLoader.php
@@ -2,8 +2,8 @@
 
 namespace SilverStripe\Security;
 
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\CsvBulkLoader;
+use SilverStripe\ORM\DataObject;
 
 /**
  * @todo Migrate Permission->Arg and Permission->Type values
@@ -15,12 +15,8 @@ class GroupCsvBulkLoader extends CsvBulkLoader
         'Code' => 'Code',
     );
 
-    public function __construct($objectClass = null)
+    public function __construct($objectClass = Group::class)
     {
-        if (!$objectClass) {
-            $objectClass = 'SilverStripe\\Security\\Group';
-        }
-
         parent::__construct($objectClass);
     }
 

--- a/src/Security/IdentityStore.php
+++ b/src/Security/IdentityStore.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SilverStripe\Security;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+
+/**
+ * Represents an authentication handler that can have identities logged into & out of it.
+ * For example, SessionAuthenticationHandler is an IdentityStore (as we can write a new member to it)
+ * but BasicAuthAuthenticationHandler is not (as it's up to the browser to handle log-in / log-out)
+ */
+interface IdentityStore
+{
+    /**
+     * Log the given member into this identity store.
+     *
+     * @param $member The member to log in.
+     * @param $persistent boolean If set to true, the login may persist beyond the current session.
+     * @param $request The request of the visitor that is logging in, to get, for example, cookies.
+     * @param $response The response object to modify, if needed.
+     */
+    public function logIn(Member $member, $persistent, HTTPRequest $request);
+
+    /**
+     * Log any logged-in member out of this identity store.
+     *
+     * @param $request The request of the visitor that is logging out, to get, for example, cookies.
+     * @param $response The response object to modify, if needed.
+     */
+    public function logOut(HTTPRequest $request);
+}

--- a/src/Security/IdentityStore.php
+++ b/src/Security/IdentityStore.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Security;
 
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\Config\Configurable;
 
 /**
  * Represents an authentication handler that can have identities logged into & out of it.
@@ -18,15 +19,15 @@ interface IdentityStore
      * @param Member $member The member to log in.
      * @param Boolean $persistent boolean If set to true, the login may persist beyond the current session.
      * @param HTTPRequest $request The request of the visitor that is logging in, to get, for example, cookies.
-     * @param HTTPResponse $response The response object to modify, if needed.
+     * @return HTTPResponse $response The response object to modify, if needed.
      */
-    public function logIn(Member $member, $persistent, HTTPRequest $request);
+    public function logIn(Member $member, $persistent = false, HTTPRequest $request = null);
 
     /**
      * Log any logged-in member out of this identity store.
      *
      * @param HTTPRequest $request The request of the visitor that is logging out, to get, for example, cookies.
-     * @param HTTPResponse $response The response object to modify, if needed.
+     * @return HTTPResponse $response The response object to modify, if needed.
      */
-    public function logOut(HTTPRequest $request);
+    public function logOut(HTTPRequest $request = null);
 }

--- a/src/Security/IdentityStore.php
+++ b/src/Security/IdentityStore.php
@@ -4,7 +4,6 @@ namespace SilverStripe\Security;
 
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\Core\Config\Configurable;
 
 /**
  * Represents an authentication handler that can have identities logged into & out of it.
@@ -19,7 +18,6 @@ interface IdentityStore
      * @param Member $member The member to log in.
      * @param Boolean $persistent boolean If set to true, the login may persist beyond the current session.
      * @param HTTPRequest $request The request of the visitor that is logging in, to get, for example, cookies.
-     * @return HTTPResponse $response The response object to modify, if needed.
      */
     public function logIn(Member $member, $persistent = false, HTTPRequest $request = null);
 
@@ -27,7 +25,6 @@ interface IdentityStore
      * Log any logged-in member out of this identity store.
      *
      * @param HTTPRequest $request The request of the visitor that is logging out, to get, for example, cookies.
-     * @return HTTPResponse $response The response object to modify, if needed.
      */
     public function logOut(HTTPRequest $request = null);
 }

--- a/src/Security/IdentityStore.php
+++ b/src/Security/IdentityStore.php
@@ -15,18 +15,18 @@ interface IdentityStore
     /**
      * Log the given member into this identity store.
      *
-     * @param $member The member to log in.
-     * @param $persistent boolean If set to true, the login may persist beyond the current session.
-     * @param $request The request of the visitor that is logging in, to get, for example, cookies.
-     * @param $response The response object to modify, if needed.
+     * @param Member $member The member to log in.
+     * @param Boolean $persistent boolean If set to true, the login may persist beyond the current session.
+     * @param HTTPRequest $request The request of the visitor that is logging in, to get, for example, cookies.
+     * @param HTTPResponse $response The response object to modify, if needed.
      */
     public function logIn(Member $member, $persistent, HTTPRequest $request);
 
     /**
      * Log any logged-in member out of this identity store.
      *
-     * @param $request The request of the visitor that is logging out, to get, for example, cookies.
-     * @param $response The response object to modify, if needed.
+     * @param HTTPRequest $request The request of the visitor that is logging out, to get, for example, cookies.
+     * @param HTTPResponse $response The response object to modify, if needed.
      */
     public function logOut(HTTPRequest $request);
 }

--- a/src/Security/InheritedPermissions.php
+++ b/src/Security/InheritedPermissions.php
@@ -158,13 +158,13 @@ class InheritedPermissions implements PermissionChecker
     {
         switch ($permission) {
             case self::EDIT:
-                $this->canEditMultiple($ids, Member::currentUser(), false);
+                $this->canEditMultiple($ids, Security::getCurrentUser(), false);
                 break;
             case self::VIEW:
-                $this->canViewMultiple($ids, Member::currentUser(), false);
+                $this->canViewMultiple($ids, Security::getCurrentUser(), false);
                 break;
             case self::DELETE:
-                $this->canDeleteMultiple($ids, Member::currentUser(), false);
+                $this->canDeleteMultiple($ids, Security::getCurrentUser(), false);
                 break;
             default:
                 throw new InvalidArgumentException("Invalid permission type $permission");

--- a/src/Security/LoginForm.php
+++ b/src/Security/LoginForm.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Security;
 
-use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -368,7 +368,7 @@ class Member extends DataObject implements TemplateGlobalProvider
                     'Your account has been temporarily disabled because of too many failed attempts at ' .
                     'logging in. Please try again in {count} minutes.',
                     null,
-                    array('count' => $this->config()->lock_out_delay_mins)
+                    array('count' => static::config()->get('lock_out_delay_mins'))
                 )
             );
         }
@@ -382,7 +382,7 @@ class Member extends DataObject implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public function isLockedOut()
+    protected function isLockedOut()
     {
         if (!$this->LockedOutUntil) {
             return false;
@@ -499,7 +499,7 @@ class Member extends DataObject implements TemplateGlobalProvider
         $this->write();
 
         // Audit logging hook
-        $this->extend('memberLoggedIn');
+        $this->extend('afterMemberLoggedIn');
     }
 
     /**
@@ -627,40 +627,6 @@ class Member extends DataObject implements TemplateGlobalProvider
     }
 
     /**
-     * Logs this member out.
-     */
-    public function logOut()
-    {
-        $this->extend('beforeMemberLoggedOut');
-
-        Session::clear("loggedInAs");
-        if (Member::config()->login_marker_cookie) {
-            Cookie::set(Member::config()->login_marker_cookie, null, 0);
-        }
-
-        Session::destroy();
-
-        $this->extend('memberLoggedOut');
-
-        // Clears any potential previous hashes for this member
-        RememberLoginHash::clear($this, Cookie::get('alc_device'));
-
-        Cookie::set('alc_enc', null); // // Clear the Remember Me cookie
-        Cookie::force_expiry('alc_enc');
-        Cookie::set('alc_device', null);
-        Cookie::force_expiry('alc_device');
-
-        // Switch back to live in order to avoid infinite loops when
-        // redirecting to the login screen (if this login screen is versioned)
-        Session::clear('readingMode');
-
-        $this->write();
-
-        // Audit logging hook
-        $this->extend('memberLoggedOut');
-    }
-
-    /**
      * Utility for generating secure password hashes for this member.
      *
      * @param string $string
@@ -762,7 +728,7 @@ class Member extends DataObject implements TemplateGlobalProvider
             ->filter('TempIDHash', $tempid);
 
         // Exclude expired
-        if (static::config()->temp_id_lifetime) {
+        if (static::config()->get('temp_id_lifetime')) {
             $members = $members->filter('TempIDExpired:GreaterThan', DBDatetime::now()->getValue());
         }
 
@@ -788,7 +754,7 @@ class Member extends DataObject implements TemplateGlobalProvider
             i18n::getSources()->getKnownLocales()
         ));
 
-        $fields->removeByName(static::config()->hidden_fields);
+        $fields->removeByName(static::config()->get('hidden_fields'));
         $fields->removeByName('FailedLoginCount');
 
 
@@ -988,7 +954,7 @@ class Member extends DataObject implements TemplateGlobalProvider
         if ((Director::isLive() || Injector::inst()->get(Mailer::class) instanceof TestMailer)
             && $this->isChanged('Password')
             && $this->record['Password']
-            && $this->config()->notify_password_change
+            && static::config()->get('notify_password_change')
         ) {
             Email::create()
                 ->setHTMLTemplate('SilverStripe\\Control\\Email\\ChangePasswordEmail')
@@ -1219,7 +1185,7 @@ class Member extends DataObject implements TemplateGlobalProvider
      */
     public function getTitle()
     {
-        $format = $this->config()->title_format;
+        $format = static::config()->get('title_format');
         if ($format) {
             $values = array();
             foreach ($format['columns'] as $col) {
@@ -1254,7 +1220,7 @@ class Member extends DataObject implements TemplateGlobalProvider
         $op = (DB::get_conn() instanceof MSSQLDatabase) ? " + " : " || ";
 
         // Get title_format with fallback to default
-        $format = static::config()->title_format;
+        $format = static::config()->get('title_format');
         if (!$format) {
             $format = [
                 'columns' => ['Surname', 'FirstName'],
@@ -1542,9 +1508,9 @@ class Member extends DataObject implements TemplateGlobalProvider
                 _t(__CLASS__.'.INTERFACELANG', "Interface Language", 'Language of the CMS'),
                 i18n::getSources()->getKnownLocales()
             ));
-            $mainFields->removeByName($this->config()->hidden_fields);
+            $mainFields->removeByName(static::config()->get('hidden_fields'));
 
-            if (! $this->config()->lock_out_after_incorrect_logins) {
+            if (! static::config()->get('lock_out_after_incorrect_logins')) {
                 $mainFields->removeByName('FailedLoginCount');
             }
 

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -57,7 +57,7 @@ use DateTime;
  * @property string $DateFormat
  * @property string $TimeFormat
  */
-class Member extends DataObject implements TemplateGlobalProvider
+class Member extends DataObject
 {
 
     private static $db = array(
@@ -717,6 +717,8 @@ class Member extends DataObject implements TemplateGlobalProvider
     /**
      * Returns the current logged in user
      *
+     * @deprecated use Security::getCurrentUser()
+     *
      * @return Member
      */
     public static function currentUser()
@@ -758,6 +760,8 @@ class Member extends DataObject implements TemplateGlobalProvider
 
     /**
      * Get the ID of the current logged in user
+     *
+     * @deprecated use Security::getCurrentUser()
      *
      * @return int Returns the ID of the current logged in user or 0.
      */
@@ -1077,7 +1081,7 @@ class Member extends DataObject implements TemplateGlobalProvider
             foreach ($format['columns'] as $col) {
                 $values[] = $this->getField($col);
             }
-            return join($format['sep'], $values);
+            return implode($format['sep'], $values);
         }
         if ($this->getField('ID') === 0) {
             return $this->getField('Surname');
@@ -1491,7 +1495,7 @@ class Member extends DataObject implements TemplateGlobalProvider
     {
         //get member
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
         //check for extensions, we do this first as they can overrule everything
         $extended = $this->extendedCan(__FUNCTION__, $member);
@@ -1522,7 +1526,7 @@ class Member extends DataObject implements TemplateGlobalProvider
     {
         //get member
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
         //check for extensions, we do this first as they can overrule everything
         $extended = $this->extendedCan(__FUNCTION__, $member);
@@ -1556,7 +1560,7 @@ class Member extends DataObject implements TemplateGlobalProvider
     public function canDelete($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
         //check for extensions, we do this first as they can overrule everything
         $extended = $this->extendedCan(__FUNCTION__, $member);
@@ -1685,13 +1689,5 @@ class Member extends DataObject implements TemplateGlobalProvider
 
         // If can't find a suitable editor, just default to cms
         return $currentName ? $currentName : 'cms';
-    }
-
-    public static function get_template_global_variables()
-    {
-        return array(
-            'CurrentMember' => 'currentUser',
-            'currentUser',
-        );
     }
 }

--- a/src/Security/MemberAuthenticator/Authenticator.php
+++ b/src/Security/MemberAuthenticator/Authenticator.php
@@ -3,12 +3,10 @@
 namespace SilverStripe\Security\MemberAuthenticator;
 
 use SilverStripe\Control\Controller;
-use SilverStripe\Control\Cookie;
 use SilverStripe\Control\Session;
 use SilverStripe\ORM\ValidationResult;
 use InvalidArgumentException;
 use SilverStripe\Security\Authenticator as BaseAuthenticator;
-use SilverStripe\Security\RememberLoginHash;
 use SilverStripe\Security\Security;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\LoginAttempt;
@@ -186,38 +184,10 @@ class Authenticator implements BaseAuthenticator
     }
 
     /**
-     *
-     * @param Member $member
-     * @return bool|Member
+     * @inherit
      */
-    public function doLogOut(&$member)
+    public function getLogoutHandler($link)
     {
-        if($member instanceof Member) {
-            Session::clear("loggedInAs");
-            if (Member::config()->login_marker_cookie) {
-                Cookie::set(Member::config()->login_marker_cookie, null, 0);
-            }
-
-            Session::destroy();
-
-            // Clears any potential previous hashes for this member
-            RememberLoginHash::clear($member, Cookie::get('alc_device'));
-
-            Cookie::set('alc_enc', null); // // Clear the Remember Me cookie
-            Cookie::force_expiry('alc_enc');
-            Cookie::set('alc_device', null);
-            Cookie::force_expiry('alc_device');
-
-            // Switch back to live in order to avoid infinite loops when
-            // redirecting to the login screen (if this login screen is versioned)
-            Session::clear('readingMode');
-
-            // Log out unsuccessful. Useful for 3rd-party logins that return failure. Shouldn't happen
-            // on the default authenticator though.
-            if(Member::currentUserID()) {
-                return Member::currentUser();
-            }
-        }
-        return true;
+        return LogoutHandler::create($link, $this);
     }
 }

--- a/src/Security/MemberAuthenticator/Authenticator.php
+++ b/src/Security/MemberAuthenticator/Authenticator.php
@@ -10,6 +10,7 @@ use InvalidArgumentException;
 use SilverStripe\Security\Authenticator as BaseAuthenticator;
 use SilverStripe\Security\Security;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\LoginAttempt;
 
 /**
  * Authenticator for the default "member" method
@@ -134,7 +135,7 @@ class Authenticator implements BaseAuthenticator
      * @param array $data
      * @param Member $member
      */
-    protected function recordLoginAttempt($data, $member)
+    protected function recordLoginAttempt($data, $member, $success)
     {
         if (!Security::config()->login_recording) {
             return;

--- a/src/Security/MemberAuthenticator/CMSAuthenticator.php
+++ b/src/Security/MemberAuthenticator/CMSAuthenticator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SilverStripe\Security\MemberAuthenticator;
+
+use SilverStripe\Security\Authenticator as BaseAuthenticator;
+use SilverStripe\Security\Member;
+
+class CMSAuthenticator extends Authenticator
+{
+
+    public function supportedServices()
+    {
+        return BaseAuthenticator::CMS_LOGIN;
+    }
+
+    /**
+     * @param array $data
+     * @param $message
+     * @param bool $success
+     * @return Member
+     */
+    protected function authenticateMember($data, &$message, &$success, $member = null)
+    {
+        // Attempt to identify by temporary ID
+        if (!empty($data['tempid'])) {
+            // Find user by tempid, in case they are re-validating an existing session
+            $member = Member::member_from_tempid($data['tempid']);
+            if ($member) {
+                $data['email'] = $member->Email;
+            }
+        }
+
+        return parent::authenticateMember($data, $message, $success, $member);
+    }
+
+    public function getLoginHandler($link)
+    {
+        return CMSLoginHandler::create($link, $this);
+    }
+
+}

--- a/src/Security/MemberAuthenticator/CMSAuthenticator.php
+++ b/src/Security/MemberAuthenticator/CMSAuthenticator.php
@@ -37,5 +37,4 @@ class CMSAuthenticator extends Authenticator
     {
         return CMSLoginHandler::create($link, $this);
     }
-
 }

--- a/src/Security/MemberAuthenticator/CMSLoginHandler.php
+++ b/src/Security/MemberAuthenticator/CMSLoginHandler.php
@@ -4,24 +4,26 @@ namespace SilverStripe\Security\MemberAuthenticator;
 
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Convert;
+use SilverStripe\Security\CMSSecurity;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 
 class CMSLoginHandler extends LoginHandler
 {
-    /**
-     * Login form handler method
-     *
-     * This method is called when the user clicks on "Log in"
-     *
-     * @param array $data Submitted data
-     * @return HTTPResponse
-     */
-    public function dologin($data, $formHandler)
-    {
-        if ($this->performLogin($data)) {
-            return $this->logInUserAndRedirect($data);
-        }
+    private static $allowed_actions = [
+        'LoginForm'
+    ];
 
-        return $this->redirectBackToForm();
+    /**
+     * Return the CMSMemberLoginForm form
+     */
+    public function loginForm()
+    {
+        return CMSMemberLoginForm::create(
+            $this,
+            get_class($this->authenticator),
+            'LoginForm'
+        );
     }
 
     public function redirectBackToForm()
@@ -75,10 +77,9 @@ PHP
     /**
      * Send user to the right location after login
      *
-     * @param array $data
      * @return HTTPResponse
      */
-    protected function logInUserAndRedirect($data, $formHandler)
+    protected function redirectAfterSuccessfulLogin()
     {
         // Check password expiry
         if (Member::currentUser()->isPasswordExpired()) {

--- a/src/Security/MemberAuthenticator/CMSLoginHandler.php
+++ b/src/Security/MemberAuthenticator/CMSLoginHandler.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SilverStripe\Security;
+namespace SilverStripe\Security\MemberAuthenticator;
 
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Convert;
 
-class CMSMemberLoginHandler extends MemberLoginHandler
+class CMSLoginHandler extends LoginHandler
 {
     /**
      * Login form handler method
@@ -15,7 +15,7 @@ class CMSMemberLoginHandler extends MemberLoginHandler
      * @param array $data Submitted data
      * @return HTTPResponse
      */
-    public function dologin($data)
+    public function dologin($data, $formHandler)
     {
         if ($this->performLogin($data)) {
             return $this->logInUserAndRedirect($data);
@@ -78,7 +78,7 @@ PHP
      * @param array $data
      * @return HTTPResponse
      */
-    protected function logInUserAndRedirect($data)
+    protected function logInUserAndRedirect($data, $formHandler)
     {
         // Check password expiry
         if (Member::currentUser()->isPasswordExpired()) {

--- a/src/Security/MemberAuthenticator/CMSLoginHandler.php
+++ b/src/Security/MemberAuthenticator/CMSLoginHandler.php
@@ -5,7 +5,6 @@ namespace SilverStripe\Security\MemberAuthenticator;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Convert;
 use SilverStripe\Security\CMSSecurity;
-use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 
 class CMSLoginHandler extends LoginHandler

--- a/src/Security/MemberAuthenticator/CMSLoginHandler.php
+++ b/src/Security/MemberAuthenticator/CMSLoginHandler.php
@@ -82,7 +82,7 @@ PHP
     protected function redirectAfterSuccessfulLogin()
     {
         // Check password expiry
-        if (Member::currentUser()->isPasswordExpired()) {
+        if (Security::getCurrentUser()->isPasswordExpired()) {
             // Redirect the user to the external password change form if necessary
             return $this->redirectToChangePassword();
         }

--- a/src/Security/MemberAuthenticator/CMSMemberAuthenticator.php
+++ b/src/Security/MemberAuthenticator/CMSMemberAuthenticator.php
@@ -2,10 +2,11 @@
 
 namespace SilverStripe\Security\MemberAuthenticator;
 
+use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Security\Authenticator as BaseAuthenticator;
 use SilverStripe\Security\Member;
 
-class CMSAuthenticator extends Authenticator
+class CMSMemberAuthenticator extends MemberAuthenticator
 {
 
     public function supportedServices()
@@ -15,11 +16,11 @@ class CMSAuthenticator extends Authenticator
 
     /**
      * @param array $data
-     * @param $message
-     * @param bool $success
+     * @param ValidationResult|null $result
+     * @param Member|null $member
      * @return Member
      */
-    protected function authenticateMember($data, &$message, &$success, $member = null)
+    protected function authenticateMember($data, &$result = null, $member = null)
     {
         // Attempt to identify by temporary ID
         if (!empty($data['tempid'])) {
@@ -30,9 +31,13 @@ class CMSAuthenticator extends Authenticator
             }
         }
 
-        return parent::authenticateMember($data, $message, $success, $member);
+        return parent::authenticateMember($data, $result, $member);
     }
 
+    /**
+     * @param string $link
+     * @return CMSLoginHandler
+     */
     public function getLoginHandler($link)
     {
         return CMSLoginHandler::create($link, $this);

--- a/src/Security/MemberAuthenticator/ChangePasswordForm.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordForm.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\Security;
+namespace SilverStripe\Security\MemberAuthenticator;
 
 use SilverStripe\Control\Session;
 use SilverStripe\Control\RequestHandler;
@@ -10,6 +10,7 @@ use SilverStripe\Forms\PasswordField;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\Form;
+use SilverStripe\Security\Member;
 
 /**
  * Standard Change Password Form

--- a/src/Security/MemberAuthenticator/ChangePasswordForm.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordForm.php
@@ -31,36 +31,51 @@ class ChangePasswordForm extends Form
         $backURL = $controller->getBackURL() ?: Session::get('BackURL');
 
         if (!$fields) {
-            $fields = new FieldList();
-
-            // Security/changepassword?h=XXX redirects to Security/changepassword
-            // without GET parameter to avoid potential HTTP referer leakage.
-            // In this case, a user is not logged in, and no 'old password' should be necessary.
-            if (Security::getCurrentUser()) {
-                $fields->push(new PasswordField("OldPassword", _t('SilverStripe\\Security\\Member.YOUROLDPASSWORD', "Your old password")));
-            }
-
-            $fields->push(new PasswordField("NewPassword1", _t('SilverStripe\\Security\\Member.NEWPASSWORD', "New Password")));
-            $fields->push(new PasswordField("NewPassword2", _t('SilverStripe\\Security\\Member.CONFIRMNEWPASSWORD', "Confirm New Password")));
+            $fields = $this->getFormFields();
         }
         if (!$actions) {
-            $actions = new FieldList(
-                new FormAction("doChangePassword", _t('SilverStripe\\Security\\Member.BUTTONCHANGEPASSWORD', "Change Password"))
-            );
+            $actions = $this->getFormActions();
         }
 
         if ($backURL) {
-            $fields->push(new HiddenField('BackURL', false, $backURL));
+            $fields->push(HiddenField::create('BackURL', false, $backURL));
         }
 
         parent::__construct($controller, $name, $fields, $actions);
     }
 
     /**
-     * @return ChangePasswordHandler
+     * @return FieldList
      */
-    protected function buildRequestHandler()
+    protected function getFormFields()
     {
-        return ChangePasswordHandler::create($this);
+        $fields = FieldList::create();
+
+        // Security/changepassword?h=XXX redirects to Security/changepassword
+        // without GET parameter to avoid potential HTTP referer leakage.
+        // In this case, a user is not logged in, and no 'old password' should be necessary.
+        if (Security::getCurrentUser()) {
+            $fields->push(PasswordField::create('OldPassword', _t('SilverStripe\\Security\\Member.YOUROLDPASSWORD', 'Your old password')));
+        }
+
+        $fields->push(PasswordField::create('NewPassword1', _t('SilverStripe\\Security\\Member.NEWPASSWORD', 'New Password')));
+        $fields->push(PasswordField::create('NewPassword2', _t('SilverStripe\\Security\\Member.CONFIRMNEWPASSWORD', 'Confirm New Password')));
+
+        return $fields;
+    }
+
+    /**
+     * @return FieldList
+     */
+    protected function getFormActions()
+    {
+        $actions = FieldList::create(
+            FormAction::create(
+                'doChangePassword',
+                _t('SilverStripe\\Security\\Member.BUTTONCHANGEPASSWORD', 'Change Password')
+            )
+        );
+
+        return $actions;
     }
 }

--- a/src/Security/MemberAuthenticator/ChangePasswordForm.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordForm.php
@@ -10,7 +10,7 @@ use SilverStripe\Forms\PasswordField;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\Form;
-use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 
 /**
  * Standard Change Password Form
@@ -36,7 +36,7 @@ class ChangePasswordForm extends Form
             // Security/changepassword?h=XXX redirects to Security/changepassword
             // without GET parameter to avoid potential HTTP referer leakage.
             // In this case, a user is not logged in, and no 'old password' should be necessary.
-            if (Member::currentUser()) {
+            if (Security::getCurrentUser()) {
                 $fields->push(new PasswordField("OldPassword", _t('SilverStripe\\Security\\Member.YOUROLDPASSWORD', "Your old password")));
             }
 

--- a/src/Security/MemberAuthenticator/ChangePasswordForm.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordForm.php
@@ -2,14 +2,14 @@
 
 namespace SilverStripe\Security\MemberAuthenticator;
 
-use SilverStripe\Control\Session;
 use SilverStripe\Control\RequestHandler;
+use SilverStripe\Control\Session;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\Forms\FormField;
-use SilverStripe\Forms\PasswordField;
-use SilverStripe\Forms\FormAction;
-use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\Form;
+use SilverStripe\Forms\FormAction;
+use SilverStripe\Forms\FormField;
+use SilverStripe\Forms\HiddenField;
+use SilverStripe\Forms\PasswordField;
 use SilverStripe\Security\Security;
 
 /**

--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -3,12 +3,13 @@
 
 namespace SilverStripe\Security\MemberAuthenticator;
 
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Session;
 use SilverStripe\Forms\FormRequestHandler;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
-
+use SilverStripe\Security\IdentityStore;
 
 class ChangePasswordHandler extends FormRequestHandler
 {
@@ -18,7 +19,7 @@ class ChangePasswordHandler extends FormRequestHandler
      * @param array $data The user submitted data
      * @return HTTPResponse
      */
-    public function doChangePassword(array $data)
+    public function doChangePassword(array $data, $form)
     {
         $member = Member::currentUser();
         // The user was logged in, check the current password
@@ -80,7 +81,8 @@ class ChangePasswordHandler extends FormRequestHandler
         $member->write();
 
         if ($member->canLogIn()->isValid()) {
-            $member->logIn();
+            Injector::inst()->get(IdentityStore::class)
+                ->logIn($member, false, $form->getRequestHandler()->getRequest());
         }
 
         // TODO Add confirmation message to login redirect

--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -1,11 +1,14 @@
 <?php
 
 
-namespace SilverStripe\Security;
+namespace SilverStripe\Security\MemberAuthenticator;
 
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Session;
 use SilverStripe\Forms\FormRequestHandler;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
+
 
 class ChangePasswordHandler extends FormRequestHandler
 {

--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -21,7 +21,7 @@ class ChangePasswordHandler extends FormRequestHandler
      */
     public function doChangePassword(array $data, $form)
     {
-        $member = Member::currentUser();
+        $member = Security::getCurrentUser();
         // The user was logged in, check the current password
         if ($member && (
             empty($data['OldPassword']) ||

--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -4,18 +4,16 @@
 namespace SilverStripe\Security\MemberAuthenticator;
 
 use SilverStripe\Control\Controller;
-use SilverStripe\Control\RequestHandler;
-use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\RequestHandler;
 use SilverStripe\Control\Session;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\FieldType\DBField;
-use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Security\Authenticator;
-use SilverStripe\Security\CMSSecurity;
+use SilverStripe\Security\IdentityStore;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
-use SilverStripe\Security\IdentityStore;
 
 class ChangePasswordHandler extends RequestHandler
 {

--- a/src/Security/MemberAuthenticator/CookieAuthenticationHandler.php
+++ b/src/Security/MemberAuthenticator/CookieAuthenticationHandler.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace SilverStripe\Security\MemberAuthenticator;
+
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Member;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Security\AuthenticationHandler as AuthenticationHandlerInterface;
+use SilverStripe\Security\IdentityStore;
+use SilverStripe\Security\RememberLoginHash;
+use SilverStripe\Security\Security;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\Control\Cookie;
+
+/**
+ * Authenticate a member pased on a session cookie
+ */
+class CookieAuthenticationHandler implements AuthenticationHandlerInterface, IdentityStore
+{
+
+    private $deviceCookieName;
+    private $tokenCookieName;
+    private $cascadeLogInTo;
+
+    /**
+     * Get the name of the cookie used to track this device
+     *
+     * @return string
+     */
+    public function getDeviceCookieName()
+    {
+        return $this->deviceCookieName;
+    }
+
+    /**
+     * Set the name of the cookie used to track this device
+     *
+     * @param string $cookieName
+     * @return null
+     */
+    public function setDeviceCookieName($deviceCookieName)
+    {
+        $this->deviceCookieName = $deviceCookieName;
+    }
+
+    /**
+     * Get the name of the cookie used to store an login token
+     *
+     * @return string
+     */
+    public function getTokenCookieName()
+    {
+        return $this->tokenCookieName;
+    }
+
+    /**
+     * Set the name of the cookie used to store an login token
+     *
+     * @param string $cookieName
+     * @return null
+     */
+    public function setTokenCookieName($tokenCookieName)
+    {
+        $this->tokenCookieName = $tokenCookieName;
+    }
+
+    /**
+     * Once a member is found by authenticateRequest() pass it to this identity store
+     *
+     * @return IdentityStore
+     */
+    public function getCascadeLogInTo()
+    {
+        return $this->cascadeLogInTo;
+    }
+
+    /**
+     * Set the name of the cookie used to store an login token
+     *
+     * @param $cascadeLogInTo
+     * @return null
+     */
+    public function setCascadeLogInTo(IdentityStore $cascadeLogInTo)
+    {
+        $this->cascadeLogInTo = $cascadeLogInTo;
+    }
+
+    /**
+     * @inherit
+     */
+    public function authenticateRequest(HTTPRequest $request)
+    {
+        $uidAndToken = Cookie::get($this->getTokenCookieName());
+        $deviceID = Cookie::get($this->getDeviceCookieName());
+
+        // @todo Consider better placement of database_is_ready test
+        if (!$deviceID || strpos($uidAndToken, ':') === false || !Security::database_is_ready()) {
+            return;
+        }
+
+        list($uid, $token) = explode(':', $uidAndToken, 2);
+
+        if (!$uid || !$token) {
+            return;
+        }
+
+        /** @var Member $member */
+        $member = Member::get()->byID($uid);
+
+        /** @var RememberLoginHash $rememberLoginHash */
+        $rememberLoginHash = null;
+
+        // check if autologin token matches
+        if ($member) {
+            $hash = $member->encryptWithUserSettings($token);
+            $rememberLoginHash = RememberLoginHash::get()
+                ->filter(array(
+                    'MemberID' => $member->ID,
+                    'DeviceID' => $deviceID,
+                    'Hash' => $hash
+                ))->first();
+
+            if (!$rememberLoginHash) {
+                $member = null;
+            } else {
+                // Check for expired token
+                $expiryDate = new \DateTime($rememberLoginHash->ExpiryDate);
+                $now = DBDatetime::now();
+                $now = new \DateTime($now->Rfc2822());
+                if ($now > $expiryDate) {
+                    $member = null;
+                }
+            }
+        }
+
+        if ($member) {
+            if ($this->cascadeLogInTo) {
+                // @todo look at how to block "regular login" triggers from happening here
+                // @todo deal with the fact that the Session::current_session() isn't correct here :-/
+                $this->cascadeLogInTo->logIn($member, false, $request);
+                //\SilverStripe\Dev\Debug::message('here');
+            }
+
+            // @todo Consider whether response should be part of logIn() as well
+
+            // Renew the token
+            if ($rememberLoginHash) {
+                $rememberLoginHash->renew();
+                $tokenExpiryDays = RememberLoginHash::config()->uninherited('token_expiry_days');
+                Cookie::set(
+                    $this->getTokenCookieName(),
+                    $member->ID . ':' . $rememberLoginHash->getToken(),
+                    $tokenExpiryDays,
+                    null,
+                    null,
+                    false,
+                    true
+                );
+            }
+
+            return $member;
+
+            // Audit logging hook
+            $member->extend('memberAutoLoggedIn');
+        }
+    }
+
+    /**
+     * @inherit
+     */
+    public function logIn(Member $member, $persistent, HTTPRequest $request)
+    {
+        // @todo couple the cookies to the response object
+
+        // Cleans up any potential previous hash for this member on this device
+        if ($alcDevice = Cookie::get($this->getDeviceCookieName())) {
+            RememberLoginHash::get()->filter('DeviceID', $alcDevice)->removeAll();
+        }
+
+        // Set a cookie for persistent log-ins
+        if ($persistent) {
+            $rememberLoginHash = RememberLoginHash::generate($member);
+            $tokenExpiryDays = RememberLoginHash::config()->uninherited('token_expiry_days');
+            $deviceExpiryDays = RememberLoginHash::config()->uninherited('device_expiry_days');
+            Cookie::set(
+                $this->getTokenCookieName(),
+                $member->ID . ':' . $rememberLoginHash->getToken(),
+                $tokenExpiryDays,
+                null,
+                null,
+                null,
+                true
+            );
+            Cookie::set(
+                $this->getDeviceCookieName(),
+                $rememberLoginHash->DeviceID,
+                $deviceExpiryDays,
+                null,
+                null,
+                null,
+                true
+            );
+
+        // Clear a cookie for non-persistent log-ins
+        } else {
+            $this->logOut($request);
+        }
+    }
+
+    /**
+     * @inherit
+     */
+    public function logOut(HTTPRequest $request)
+    {
+        // @todo couple the cookies to the response object
+
+        Cookie::set($this->getTokenCookieName(), null);
+        Cookie::set($this->getDeviceCookieName(), null);
+        Cookie::force_expiry($this->getTokenCookieName());
+        Cookie::force_expiry($this->getDeviceCookieName());
+    }
+}

--- a/src/Security/MemberAuthenticator/CookieAuthenticationHandler.php
+++ b/src/Security/MemberAuthenticator/CookieAuthenticationHandler.php
@@ -2,10 +2,8 @@
 
 namespace SilverStripe\Security\MemberAuthenticator;
 
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
 use SilverStripe\Control\HTTPRequest;
-use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Security\AuthenticationHandler as AuthenticationHandlerInterface;
 use SilverStripe\Security\IdentityStore;
 use SilverStripe\Security\RememberLoginHash;
@@ -19,8 +17,19 @@ use SilverStripe\Control\Cookie;
 class CookieAuthenticationHandler implements AuthenticationHandlerInterface, IdentityStore
 {
 
+    /**
+     * @var string
+     */
     private $deviceCookieName;
+
+    /**
+     * @var string
+     */
     private $tokenCookieName;
+
+    /**
+     * @var IdentityStore
+     */
     private $cascadeLogInTo;
 
     /**
@@ -36,7 +45,7 @@ class CookieAuthenticationHandler implements AuthenticationHandlerInterface, Ide
     /**
      * Set the name of the cookie used to track this device
      *
-     * @param string $cookieName
+     * @param $deviceCookieName
      * @return null
      */
     public function setDeviceCookieName($deviceCookieName)
@@ -57,7 +66,7 @@ class CookieAuthenticationHandler implements AuthenticationHandlerInterface, Ide
     /**
      * Set the name of the cookie used to store an login token
      *
-     * @param string $cookieName
+     * @param $tokenCookieName
      * @return null
      */
     public function setTokenCookieName($tokenCookieName)
@@ -213,11 +222,17 @@ class CookieAuthenticationHandler implements AuthenticationHandlerInterface, Ide
      */
     public function logOut(HTTPRequest $request)
     {
+        $member = Security::getCurrentUser();
+        if ($member) {
+            RememberLoginHash::clear($member, Cookie::get('alc_device'));
+        }
         // @todo couple the cookies to the response object
 
         Cookie::set($this->getTokenCookieName(), null);
         Cookie::set($this->getDeviceCookieName(), null);
         Cookie::force_expiry($this->getTokenCookieName());
         Cookie::force_expiry($this->getDeviceCookieName());
+
+        Security::setCurrentUser(null);
     }
 }

--- a/src/Security/MemberAuthenticator/LoginForm.php
+++ b/src/Security/MemberAuthenticator/LoginForm.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Security\MemberAuthenticator;
 
 use SilverStripe\Control\Director;
+use SilverStripe\Control\RequestHandler;
 use SilverStripe\Control\Session;
 use SilverStripe\Control\Controller;
 use SilverStripe\Forms\HiddenField;
@@ -49,7 +50,7 @@ class LoginForm extends BaseLoginForm
      * Constructor
      *
      * @skipUpgrade
-     * @param Controller $controller The parent controller, necessary to
+     * @param RequestHandler $controller The parent controller, necessary to
      *                               create the appropriate form action tag.
      * @param string $authenticatorClass Authenticator for this LoginForm
      * @param string $name The method on the controller that will return this

--- a/src/Security/MemberAuthenticator/LoginForm.php
+++ b/src/Security/MemberAuthenticator/LoginForm.php
@@ -87,7 +87,9 @@ class LoginForm extends BaseLoginForm
             $backURL = Session::get('BackURL');
         }
 
-        if ($checkCurrentUser && Member::currentUser() && Member::logged_in_session_exists()) {
+        if ($checkCurrentUser && Security::getCurrentUser() && Member::logged_in_session_exists()) {
+            // @todo find a more elegant way to handle this
+            $logoutAction = Security::logout_url();
             $fields = FieldList::create(
                 HiddenField::create("AuthenticationMethod", null, $this->authenticator_class, $this)
             );
@@ -112,6 +114,9 @@ class LoginForm extends BaseLoginForm
 
         parent::__construct($controller, $name, $fields, $actions);
 
+        if (isset($logoutAction)) {
+            $this->setFormAction($logoutAction);
+        }
         $this->setValidator(RequiredFields::create(self::config()->get('required_fields')));
     }
 
@@ -182,7 +187,7 @@ class LoginForm extends BaseLoginForm
         parent::restoreFormState();
 
         $forceMessage = Session::get('MemberLoginForm.force_message');
-        if (($member = Member::currentUser()) && !$forceMessage) {
+        if (($member = Security::getCurrentUser()) && !$forceMessage) {
             $message = _t(
                 'SilverStripe\\Security\\Member.LOGGEDINAS',
                 "You're logged in as {name}.",

--- a/src/Security/MemberAuthenticator/LoginForm.php
+++ b/src/Security/MemberAuthenticator/LoginForm.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\Security;
+namespace SilverStripe\Security\MemberAuthenticator;
 
 use SilverStripe\Control\Director;
 use SilverStripe\Control\Session;
@@ -14,6 +14,10 @@ use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\RequiredFields;
 use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
+use SilverStripe\Security\RememberLoginHash;
+use SilverStripe\Security\LoginForm as BaseLoginForm;
 use SilverStripe\View\Requirements;
 
 /**
@@ -26,7 +30,7 @@ use SilverStripe\View\Requirements;
  *    allowing extensions to "veto" execution by returning FALSE.
  *    Arguments: $member containing the detected Member record
  */
-class MemberLoginForm extends LoginForm
+class LoginForm extends BaseLoginForm
 {
 
     /**
@@ -161,7 +165,7 @@ class MemberLoginForm extends LoginForm
     protected function getFormActions()
     {
         $actions = FieldList::create(
-            FormAction::create('dologin', _t('SilverStripe\\Security\\Member.BUTTONLOGIN', "Log in")),
+            FormAction::create('doLogin', _t('SilverStripe\\Security\\Member.BUTTONLOGIN', "Log in")),
             LiteralField::create(
                 'forgotPassword',
                 '<p id="ForgotPassword"><a href="' . Security::lost_password_url() . '">'
@@ -192,14 +196,6 @@ class MemberLoginForm extends LoginForm
         }
 
         return $this;
-    }
-
-    /**
-     * @return MemberLoginHandler
-     */
-    protected function buildRequestHandler()
-    {
-        return MemberLoginHandler::create($this);
     }
 
     /**

--- a/src/Security/MemberAuthenticator/LoginHandler.php
+++ b/src/Security/MemberAuthenticator/LoginHandler.php
@@ -7,7 +7,6 @@ use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Session;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\ORM\ValidationResult;
-use SilverStripe\Security\MemberAuthenticator\Authenticator;
 use SilverStripe\Security\Security;
 use SilverStripe\Security\Member;
 
@@ -91,7 +90,7 @@ class LoginHandler extends RequestHandler
      * This method is called when the user clicks on "Log in"
      *
      * @param array $data Submitted data
-     * @param LoginHandler $formHandler
+     * @param LoginForm $form
      * @return HTTPResponse
      */
     public function doLogin($data, $form)
@@ -223,7 +222,7 @@ class LoginHandler extends RequestHandler
      */
     public function performLogin($member, $data)
     {
-        $member->LogIn(isset($data['Remember']));
+        $member->logIn(isset($data['Remember']));
         return $member;
     }
     /**

--- a/src/Security/MemberAuthenticator/LoginHandler.php
+++ b/src/Security/MemberAuthenticator/LoginHandler.php
@@ -9,6 +9,8 @@ use SilverStripe\Control\RequestHandler;
 use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Security\Security;
 use SilverStripe\Security\Member;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Security\IdentityStore;
 
 /**
  * Handle login requests from MemberLoginForm
@@ -99,7 +101,7 @@ class LoginHandler extends RequestHandler
 
         // Successful login
         if ($member = $this->checkLogin($data, $failureMessage)) {
-            $this->performLogin($member, $data);
+            $this->performLogin($member, $data, $form->getRequestHandler()->getRequest());
             return $this->redirectAfterSuccessfulLogin();
         }
 
@@ -220,9 +222,10 @@ class LoginHandler extends RequestHandler
      * @return Member Returns the member object on successful authentication
      *                or NULL on failure.
      */
-    public function performLogin($member, $data)
+    public function performLogin($member, $data, $request)
     {
-        $member->logIn(isset($data['Remember']));
+        // @todo pass request/response
+        Injector::inst()->get(IdentityStore::class)->logIn($member, !empty($data['Remember']), $request);
         return $member;
     }
     /**

--- a/src/Security/MemberAuthenticator/LoginHandler.php
+++ b/src/Security/MemberAuthenticator/LoginHandler.php
@@ -5,14 +5,14 @@ namespace SilverStripe\Security\MemberAuthenticator;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\Control\Session;
 use SilverStripe\Control\RequestHandler;
+use SilverStripe\Control\Session;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Security\Authenticator;
-use SilverStripe\Security\Security;
-use SilverStripe\Security\Member;
-use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Security\IdentityStore;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 
 /**
  * Handle login requests from MemberLoginForm

--- a/src/Security/MemberAuthenticator/LogoutHandler.php
+++ b/src/Security/MemberAuthenticator/LogoutHandler.php
@@ -16,7 +16,6 @@ use SilverStripe\Security\Security;
  * The logout process destroys all traces of the member on the server (not the actual computer user
  * at the other end of the line, don't worry)
  *
- * @package SilverStripe\Security\MemberAuthenticator
  */
 class LogoutHandler extends RequestHandler
 {

--- a/src/Security/MemberAuthenticator/LogoutHandler.php
+++ b/src/Security/MemberAuthenticator/LogoutHandler.php
@@ -2,13 +2,10 @@
 
 namespace SilverStripe\Security\MemberAuthenticator;
 
-use SilverStripe\Control\Cookie;
 use SilverStripe\Control\RequestHandler;
-use SilverStripe\Control\Session;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Security\IdentityStore;
 use SilverStripe\Security\Member;
-use SilverStripe\Security\RememberLoginHash;
 use SilverStripe\Security\Security;
 
 /**

--- a/src/Security/MemberAuthenticator/LogoutHandler.php
+++ b/src/Security/MemberAuthenticator/LogoutHandler.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace SilverStripe\Security\MemberAuthenticator;
+
+use SilverStripe\Control\Cookie;
+use SilverStripe\Control\RequestHandler;
+use SilverStripe\Control\Session;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Security\IdentityStore;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\RememberLoginHash;
+use SilverStripe\Security\Security;
+
+/**
+ * Class LogoutHandler handles logging out Members from their session and/or cookie.
+ * The logout process destroys all traces of the member on the server (not the actual computer user
+ * at the other end of the line, don't worry)
+ *
+ * @package SilverStripe\Security\MemberAuthenticator
+ */
+class LogoutHandler extends RequestHandler
+{
+    /**
+     * @var array
+     */
+    private static $url_handlers = [
+        '' => 'logout'
+    ];
+
+    /**
+     * @var array
+     */
+    private static $allowed_actions = [
+        'logout'
+    ];
+
+
+    /**
+     * Log out form handler method
+     *
+     * This method is called when the user clicks on "logout" on the form
+     * created when the parameter <i>$checkCurrentUser</i> of the
+     * {@link __construct constructor} was set to TRUE and the user was
+     * currently logged in.
+     *
+     * @return bool|Member
+     */
+    public function logout()
+    {
+        $member = Security::getCurrentUser();
+
+        return $this->doLogOut($member);
+    }
+
+    /**
+     *
+     * @param Member $member
+     * @return bool|Member Return a member if something goes wrong
+     */
+    public function doLogOut($member)
+    {
+        if ($member instanceof Member) {
+            Injector::inst()->get(IdentityStore::class)->logOut($this->getRequest());
+        }
+
+        return true;
+    }
+}

--- a/src/Security/MemberAuthenticator/LostPasswordForm.php
+++ b/src/Security/MemberAuthenticator/LostPasswordForm.php
@@ -1,0 +1,45 @@
+<?php
+
+
+namespace SilverStripe\Security\MemberAuthenticator;
+
+use SilverStripe\Forms\EmailField;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\FormAction;
+
+/**
+ * Class LostPasswordForm handles the requests for lost password form generation
+ *
+ * We need the MemberLoginForm for the getFormFields logic.
+ */
+class LostPasswordForm extends MemberLoginForm
+{
+
+    /**
+     * Create a single EmailField form that has the capability
+     * of using the MemberLoginForm Authenticator
+     *
+     * @return FieldList
+     */
+    public function getFormFields()
+    {
+        return FieldList::create(
+            EmailField::create('Email', _t('SilverStripe\\Security\\Member.EMAIL', 'Email'))
+        );
+    }
+
+    /**
+     * Give the member a friendly button to push
+     *
+     * @return FieldList
+     */
+    public function getFormActions()
+    {
+        return FieldList::create(
+            FormAction::create(
+                'forgotPassword',
+                _t('SilverStripe\\Security\\Security.BUTTONSEND', 'Send me the password reset link')
+            )
+        );
+    }
+}

--- a/src/Security/MemberAuthenticator/LostPasswordHandler.php
+++ b/src/Security/MemberAuthenticator/LostPasswordHandler.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace SilverStripe\Security\MemberAuthenticator;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\Email\Email;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\Session;
+use SilverStripe\Control\RequestHandler;
+use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\EmailField;
+use SilverStripe\Forms\FormAction;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
+use SilverStripe\Core\Convert;
+use SilverStripe\ORM\FieldType\DBField;
+
+/**
+ * Handle login requests from MemberLoginForm
+ */
+class LostPasswordHandler extends RequestHandler
+{
+    protected $authenticatorClass = MemberAuthenticator::class;
+
+    private static $url_handlers = [
+        'passwordsent/$EmailAddress' => 'passwordsent',
+        '' => 'lostpassword',
+    ];
+
+    /**
+     * Since the logout and dologin actions may be conditionally removed, it's necessary to ensure these
+     * remain valid actions regardless of the member login state.
+     *
+     * @var array
+     * @config
+     */
+    private static $allowed_actions = [
+        'lostpassword',
+        'LostPasswordForm',
+        'passwordsent',
+    ];
+
+    private $link = null;
+
+    /**
+     * @param $link The URL to recreate this request handler
+     */
+    public function __construct($link)
+    {
+        $this->link = $link;
+        parent::__construct();
+    }
+
+    /**
+     * Return a link to this request handler.
+     * The link returned is supplied in the constructor
+     * @return string
+     */
+    public function link($action = null)
+    {
+        if ($action) {
+            return Controller::join_links($this->link, $action);
+        } else {
+            return $this->link;
+        }
+    }
+
+    /**
+     * URL handler for the initial lost-password screen
+     */
+    public function lostpassword()
+    {
+
+        $message = _t(
+            'Security.NOTERESETPASSWORD',
+            'Enter your e-mail address and we will send you a link with which you can reset your password'
+        );
+
+        return [
+            'Content' => DBField::create_field('HTMLFragment', "<p>$message</p>"),
+            'Form' => $this->lostPasswordForm(),
+        ];
+    }
+
+    /**
+     * Show the "password sent" page, after a user has requested
+     * to reset their password.
+     */
+    public function passwordsent()
+    {
+        $request = $this->getRequest();
+        $email = Convert::raw2xml(rawurldecode($request->param('EmailAddress')) . '.' . $request->getExtension());
+
+        $message = _t(
+            'Security.PASSWORDSENTTEXT',
+            "Thank you! A reset link has been sent to '{email}', provided an account exists for this email"
+            . " address.",
+            [ 'email' => Convert::raw2xml($email) ]
+        );
+
+        return [
+            'Title' => _t(
+                'Security.PASSWORDSENTHEADER',
+                "Password reset link sent to '{email}'",
+                array('email' => $email)
+            ),
+            'Content' => DBField::create_field('HTMLFragment', "<p>$message</p>"),
+            'Email' => $email
+        ];
+    }
+
+
+    /**
+     * Factory method for the lost password form
+     *
+     * @skipUpgrade
+     * @return Form Returns the lost password form
+     */
+    public function lostPasswordForm()
+    {
+        return LoginForm::create(
+            $this,
+            $this->authenticatorClass,
+            'LostPasswordForm',
+            new FieldList(
+                new EmailField('Email', _t('Member.EMAIL', 'Email'))
+            ),
+            new FieldList(
+                new FormAction(
+                    'forgotPassword',
+                    _t('Security.BUTTONSEND', 'Send me the password reset link')
+                )
+            ),
+            false
+        );
+    }
+
+    /**
+     * Redirect to password recovery form
+     *
+     * @return HTTPResponse
+     */
+    public function redirectToLostPassword()
+    {
+        $lostPasswordLink = Security::singleton()->Link('lostpassword');
+        return $this->redirect($this->addBackURLParam($lostPasswordLink));
+    }
+
+    public function getReturnReferer()
+    {
+        return $this->link();
+    }
+
+    /**
+     * Log out form handler method
+     *
+     * This method is called when the user clicks on "logout" on the form
+     * created when the parameter <i>$checkCurrentUser</i> of the
+     * {@link __construct constructor} was set to TRUE and the user was
+     * currently logged in.
+     *
+     * @return HTTPResponse
+     */
+    public function logout()
+    {
+        return Security::singleton()->logout();
+    }
+
+    /**
+     * Try to authenticate the user
+     *
+     * @param array $data Submitted data
+     * @return Member Returns the member object on successful authentication
+     *                or NULL on failure.
+     */
+    public function performLogin($data)
+    {
+        $member = call_user_func_array(
+            [$this->authenticator_class, 'authenticate'],
+            [$data, $this->form]
+        );
+        if ($member) {
+            $member->LogIn(isset($data['Remember']));
+            return $member;
+        }
+
+        // No member, can't login
+        $this->extend('authenticationFailed', $data);
+        return null;
+    }
+
+    /**
+     * Forgot password form handler method.
+     * Called when the user clicks on "I've lost my password".
+     * Extensions can use the 'forgotPassword' method to veto executing
+     * the logic, by returning FALSE. In this case, the user will be redirected back
+     * to the form without further action. It is recommended to set a message
+     * in the form detailing why the action was denied.
+     *
+     * @skipUpgrade
+     * @param array $data Submitted data
+     * @return HTTPResponse
+     */
+    public function forgotPassword($data)
+    {
+        // Ensure password is given
+        if (empty($data['Email'])) {
+            $this->form->sessionMessage(
+                _t('Member.ENTEREMAIL', 'Please enter an email address to get a password reset link.'),
+                'bad'
+            );
+            return $this->redirectToLostPassword();
+        }
+
+        // Find existing member
+        /** @var Member $member */
+        $member = Member::get()->filter("Email", $data['Email'])->first();
+
+        // Allow vetoing forgot password requests
+        $results = $this->extend('forgotPassword', $member);
+        if ($results && is_array($results) && in_array(false, $results, true)) {
+            return $this->redirectToLostPassword();
+        }
+
+        if ($member) {
+            $token = $member->generateAutologinTokenAndStoreHash();
+
+            Email::create()
+                ->setHTMLTemplate('SilverStripe\\Control\\Email\\ForgotPasswordEmail')
+                ->setData($member)
+                ->setSubject(_t('Member.SUBJECTPASSWORDRESET', "Your password reset link", 'Email subject'))
+                ->addData('PasswordResetLink', Security::getPasswordResetLink($member, $token))
+                ->setTo($member->Email)
+                ->send();
+        }
+
+        // Avoid information disclosure by displaying the same status,
+        // regardless wether the email address actually exists
+        $link = Controller::join_links(
+            $this->link('passwordsent'),
+            rawurlencode($data['Email']),
+            '/'
+        );
+        return $this->redirect($this->addBackURLParam($link));
+    }
+
+    /**
+     * @todo copypaste from FormRequestHandler - refactor
+     */
+    protected function addBackURLParam($link)
+    {
+        $backURL = $this->getBackURL();
+        if ($backURL) {
+            return Controller::join_links($link, '?BackURL=' . urlencode($backURL));
+        }
+        return $link;
+    }
+}

--- a/src/Security/MemberAuthenticator/LostPasswordHandler.php
+++ b/src/Security/MemberAuthenticator/LostPasswordHandler.php
@@ -5,19 +5,12 @@ namespace SilverStripe\Security\MemberAuthenticator;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\Control\Session;
 use SilverStripe\Control\RequestHandler;
-use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\Convert;
 use SilverStripe\Forms\Form;
-use SilverStripe\ORM\ValidationResult;
-use SilverStripe\Forms\FieldList;
-use SilverStripe\Forms\EmailField;
-use SilverStripe\Forms\FormAction;
-use SilverStripe\Security\IdentityStore;
+use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
-use SilverStripe\Core\Convert;
-use SilverStripe\ORM\FieldType\DBField;
 
 /**
  * Handle login requests from MemberLoginForm

--- a/src/Security/MemberAuthenticator/MemberAuthenticator.php
+++ b/src/Security/MemberAuthenticator/MemberAuthenticator.php
@@ -2,14 +2,14 @@
 
 namespace SilverStripe\Security\MemberAuthenticator;
 
+use InvalidArgumentException;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Session;
 use SilverStripe\ORM\ValidationResult;
-use InvalidArgumentException;
 use SilverStripe\Security\Authenticator;
-use SilverStripe\Security\Security;
-use SilverStripe\Security\Member;
 use SilverStripe\Security\LoginAttempt;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 
 /**
  * Authenticator for the default "member" method
@@ -162,7 +162,7 @@ class MemberAuthenticator implements Authenticator
     }
 
     /**
-     * @param $link
+     * @param string $link
      * @return LostPasswordHandler
      */
     public function getLostPasswordHandler($link)

--- a/src/Security/MemberAuthenticator/MemberLoginForm.php
+++ b/src/Security/MemberAuthenticator/MemberLoginForm.php
@@ -5,20 +5,19 @@ namespace SilverStripe\Security\MemberAuthenticator;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Control\Session;
-use SilverStripe\Control\Controller;
-use SilverStripe\Forms\HiddenField;
+use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormAction;
-use SilverStripe\Forms\TextField;
-use SilverStripe\Forms\PasswordField;
-use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\LiteralField;
+use SilverStripe\Forms\PasswordField;
 use SilverStripe\Forms\RequiredFields;
+use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\ValidationResult;
-use SilverStripe\Security\Member;
-use SilverStripe\Security\Security;
-use SilverStripe\Security\RememberLoginHash;
 use SilverStripe\Security\LoginForm as BaseLoginForm;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\RememberLoginHash;
+use SilverStripe\Security\Security;
 use SilverStripe\View\Requirements;
 
 /**
@@ -42,9 +41,14 @@ class MemberLoginForm extends BaseLoginForm
 
     /**
      * Required fields for validation
+     *
+     * @config
      * @var array
      */
-    private static $required_fields;
+    private static $required_fields = [
+        'Email',
+        'Password',
+    ];
 
     /**
      * Constructor

--- a/src/Security/MemberAuthenticator/MemberLoginForm.php
+++ b/src/Security/MemberAuthenticator/MemberLoginForm.php
@@ -31,7 +31,7 @@ use SilverStripe\View\Requirements;
  *    allowing extensions to "veto" execution by returning FALSE.
  *    Arguments: $member containing the detected Member record
  */
-class LoginForm extends BaseLoginForm
+class MemberLoginForm extends BaseLoginForm
 {
 
     /**
@@ -87,7 +87,7 @@ class LoginForm extends BaseLoginForm
             $backURL = Session::get('BackURL');
         }
 
-        if ($checkCurrentUser && Security::getCurrentUser() && Member::logged_in_session_exists()) {
+        if ($checkCurrentUser && Security::getCurrentUser()) {
             // @todo find a more elegant way to handle this
             $logoutAction = Security::logout_url();
             $fields = FieldList::create(
@@ -145,7 +145,7 @@ class LoginForm extends BaseLoginForm
             $this->setAttribute('autocomplete', 'off');
             $emailField->setAttribute('autocomplete', 'off');
         }
-        if (Security::config()->autologin_enabled) {
+        if (Security::config()->get('autologin_enabled')) {
             $fields->push(
                 CheckboxField::create(
                     "Remember",

--- a/src/Security/MemberAuthenticator/SessionAuthenticationHandler.php
+++ b/src/Security/MemberAuthenticator/SessionAuthenticationHandler.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace SilverStripe\Security\MemberAuthenticator;
+
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Member;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\Session;
+use SilverStripe\Control\Director;
+use SilverStripe\Security\AuthenticationHandler as AuthenticationHandlerInterface;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\Security\IdentityStore;
+
+/**
+ * Authenticate a member pased on a session cookie
+ */
+class SessionAuthenticationHandler implements AuthenticationHandlerInterface, IdentityStore
+{
+
+    private $sessionVariable;
+
+    /**
+     * Get the session variable name used to track member ID
+     *
+     * @return string
+     */
+    public function getSessionVariable()
+    {
+        return $this->sessionVariable;
+    }
+
+    /**
+     * Set the session variable name used to track member ID
+     *
+     * @param string $sessionVariable
+     * @return null
+     */
+    public function setSessionVariable($sessionVariable)
+    {
+        $this->sessionVariable = $sessionVariable;
+    }
+
+    /**
+     * @inherit
+     */
+    public function authenticateRequest(HTTPRequest $request)
+    {
+        // @todo couple the session to a request object
+        // $session = $request->getSession();
+
+        if ($id = Session::get($this->getSessionVariable())) {
+            // If ID is a bad ID it will be treated as if the user is not logged in, rather than throwing a
+            // ValidationException
+            return DataObject::get_by_id(Member::class, $id);
+        }
+
+        return null;
+    }
+
+    /**
+     * @inherit
+     */
+    public function logIn(Member $member, $persistent, HTTPRequest $request)
+    {
+        // @todo couple the session to a request object
+        // $session = $request->getSession();
+
+        $this->regenerateSessionId();
+        Session::set($this->getSessionVariable(), $member->ID);
+
+        // This lets apache rules detect whether the user has logged in
+        // @todo make this a settign on the authentication handler
+        if (Member::config()->login_marker_cookie) {
+            Cookie::set(Member::config()->login_marker_cookie, 1, 0);
+        }
+    }
+
+    /**
+     * Regenerate the session_id.
+     */
+    protected static function regenerateSessionId()
+    {
+        if (!Member::config()->session_regenerate_id) {
+            return;
+        }
+
+        // This can be called via CLI during testing.
+        if (Director::is_cli()) {
+            return;
+        }
+
+        $file = '';
+        $line = '';
+
+        // @ is to supress win32 warnings/notices when session wasn't cleaned up properly
+        // There's nothing we can do about this, because it's an operating system function!
+        if (!headers_sent($file, $line)) {
+            @session_regenerate_id(true);
+        }
+    }
+    /**
+     * @inherit
+     */
+    public function logOut(HTTPRequest $request)
+    {
+        // @todo couple the session to a request object
+        // $session = $request->getSession();
+
+        Session::clear($this->getSessionVariable());
+    }
+}

--- a/src/Security/MemberAuthenticator/SessionAuthenticationHandler.php
+++ b/src/Security/MemberAuthenticator/SessionAuthenticationHandler.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Security\MemberAuthenticator;
 
+use SilverStripe\Control\Cookie;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
 use SilverStripe\Control\HTTPRequest;
@@ -52,7 +53,7 @@ class SessionAuthenticationHandler implements AuthenticationHandlerInterface, Id
         if ($id = Session::get($this->getSessionVariable())) {
             // If ID is a bad ID it will be treated as if the user is not logged in, rather than throwing a
             // ValidationException
-            return DataObject::get_by_id(Member::class, $id);
+            return Member::get()->byID($id);
         }
 
         return null;
@@ -66,13 +67,13 @@ class SessionAuthenticationHandler implements AuthenticationHandlerInterface, Id
         // @todo couple the session to a request object
         // $session = $request->getSession();
 
-        $this->regenerateSessionId();
+        static::regenerateSessionId();
         Session::set($this->getSessionVariable(), $member->ID);
 
         // This lets apache rules detect whether the user has logged in
         // @todo make this a settign on the authentication handler
-        if (Member::config()->login_marker_cookie) {
-            Cookie::set(Member::config()->login_marker_cookie, 1, 0);
+        if (Member::config()->get('login_marker_cookie')) {
+            Cookie::set(Member::config()->get('login_marker_cookie'), 1, 0);
         }
     }
 

--- a/src/Security/MemberAuthenticator/SessionAuthenticationHandler.php
+++ b/src/Security/MemberAuthenticator/SessionAuthenticationHandler.php
@@ -3,21 +3,17 @@
 namespace SilverStripe\Security\MemberAuthenticator;
 
 use SilverStripe\Control\Cookie;
-use SilverStripe\Control\HTTPResponse;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\Security\Member;
+use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Session;
-use SilverStripe\Control\Director;
 use SilverStripe\Security\AuthenticationHandler;
-use SilverStripe\Security\IdentityStore;
+use SilverStripe\Security\Member;
 
 /**
  * Authenticate a member pased on a session cookie
  */
-class SessionAuthenticationHandler implements AuthenticationHandler, IdentityStore
+class SessionAuthenticationHandler implements AuthenticationHandler
 {
-
     /**
      * @var string
      */
@@ -44,27 +40,26 @@ class SessionAuthenticationHandler implements AuthenticationHandler, IdentitySto
     }
 
     /**
-     * @inherit
      * @param HTTPRequest $request
-     * @return null|DataObject|Member
+     * @return Member
      */
     public function authenticateRequest(HTTPRequest $request)
     {
-        if ($id = Session::get($this->getSessionVariable())) {
-            // If ID is a bad ID it will be treated as if the user is not logged in, rather than throwing a
-            // ValidationException
-            return Member::get()->byID($id);
+        // If ID is a bad ID it will be treated as if the user is not logged in, rather than throwing a
+        // ValidationException
+        $id = Session::get($this->getSessionVariable());
+        if (!$id) {
+            return null;
         }
-
-        return null;
+        /** @var Member $member */
+        $member = Member::get()->byID($id);
+        return $member;
     }
 
     /**
-     * @inherit
      * @param Member $member
      * @param bool $persistent
-     * @param HTTPRequest|null $request
-     * @return HTTPResponse|void
+     * @param HTTPRequest $request
      */
     public function logIn(Member $member, $persistent = false, HTTPRequest $request = null)
     {
@@ -103,8 +98,7 @@ class SessionAuthenticationHandler implements AuthenticationHandler, IdentitySto
     }
 
     /**
-     * @param HTTPRequest|null $request
-     * @return HTTPResponse|void
+     * @param HTTPRequest $request
      */
     public function logOut(HTTPRequest $request = null)
     {

--- a/src/Security/Member_GroupSet.php
+++ b/src/Security/Member_GroupSet.php
@@ -109,7 +109,7 @@ class Member_GroupSet extends ManyManyList
     {
         $id = $this->getForeignID();
         if ($id) {
-            return DataObject::get_by_id('SilverStripe\\Security\\Member', $id);
+            return DataObject::get_by_id(Member::class, $id);
         }
     }
 }

--- a/src/Security/Member_Validator.php
+++ b/src/Security/Member_Validator.php
@@ -2,8 +2,8 @@
 
 namespace SilverStripe\Security;
 
-use SilverStripe\Forms\RequiredFields;
 use SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest;
+use SilverStripe\Forms\RequiredFields;
 
 /**
  * Member Validator

--- a/src/Security/PasswordEncryptor.php
+++ b/src/Security/PasswordEncryptor.php
@@ -2,8 +2,8 @@
 
 namespace SilverStripe\Security;
 
-use SilverStripe\Core\Config\Config;
 use ReflectionClass;
+use SilverStripe\Core\Config\Config;
 
 /**
  * Allows pluggable password encryption.

--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -347,7 +347,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
     {
         // Default to current member, with session-caching
         if (!$memberID) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
             if ($member && isset($_SESSION['Permission_groupList'][$member->ID])) {
                 return $_SESSION['Permission_groupList'][$member->ID];
             }

--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -4,12 +4,11 @@ namespace SilverStripe\Security;
 
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Resettable;
-use SilverStripe\Dev\Debug;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\i18n\i18nEntityProvider;
-use SilverStripe\ORM\DB;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\View\TemplateGlobalProvider;
 
@@ -459,7 +458,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
     /**
      * Returns all members for a specific permission.
      *
-     * @param $code String|array Either a single permission code, or a list of permission codes
+     * @param string|array $code Either a single permission code, or a list of permission codes
      * @return SS_List Returns a set of member that have the specified
      *                       permission.
      */

--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Security;
 
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Resettable;
+use SilverStripe\Dev\Debug;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\i18n\i18nEntityProvider;
 use SilverStripe\ORM\DB;
@@ -131,10 +132,10 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
     public static function check($code, $arg = "any", $member = null, $strict = true)
     {
         if (!$member) {
-            if (!Member::currentUserID()) {
+            if (!Security::getCurrentUser()) {
                 return false;
             }
-            $member = Member::currentUserID();
+            $member = Security::getCurrentUser();
         }
 
         return self::checkMember($member, $code, $arg, $strict);
@@ -171,10 +172,9 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
     public static function checkMember($member, $code, $arg = "any", $strict = true)
     {
         if (!$member) {
-            $memberID = $member = Member::currentUserID();
-        } else {
-            $memberID = (is_object($member)) ? $member->ID : $member;
+            $member = Security::getCurrentUser();
         }
+        $memberID = ($member instanceof Member) ? $member->ID : $member;
 
         if (!$memberID) {
             return false;

--- a/src/Security/PermissionCheckboxSetField.php
+++ b/src/Security/PermissionCheckboxSetField.php
@@ -2,14 +2,13 @@
 
 namespace SilverStripe\Security;
 
+use InvalidArgumentException;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\FormField;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectInterface;
-use SilverStripe\View\Requirements;
-use InvalidArgumentException;
+use SilverStripe\ORM\SS_List;
 
 /**
  * Shows a categorized list of available permissions (through {@link Permission::get_codes()}).

--- a/src/Security/RememberLoginHash.php
+++ b/src/Security/RememberLoginHash.php
@@ -2,10 +2,10 @@
 
 namespace SilverStripe\Security;
 
-use SilverStripe\ORM\FieldType\DBDatetime;
-use SilverStripe\ORM\DataObject;
-use DateTime;
 use DateInterval;
+use DateTime;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\FieldType\DBDatetime;
 
 /**
  * Persists a token associated with a device for users who opted for the "Remember Me"
@@ -16,7 +16,8 @@ use DateInterval;
  * is discarded as well.
  *
  * @property string $DeviceID
- * @property string $RememberLoginHash
+ * @property string $ExpiryDate
+ * @property string $Hash
  * @method Member Member()
  */
 class RememberLoginHash extends DataObject

--- a/src/Security/RequestAuthenticationHandler.php
+++ b/src/Security/RequestAuthenticationHandler.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace SilverStripe\Security;
+
+use SilverStripe\Control\HTTPRequest;
+
+/**
+ * Core authentication handler / store
+ */
+class RequestAuthenticationHandler implements AuthenticationHandler
+{
+    /**
+     * @var AuthenticationHandler[]
+     */
+    protected $handlers = [];
+
+    /**
+     * This method currently uses a fallback as loading the handlers via YML has proven unstable
+     *
+     * @return AuthenticationHandler[]
+     */
+    protected function getHandlers()
+    {
+        return $this->handlers;
+    }
+
+    /**
+     * Set an associative array of handlers
+     *
+     * @param AuthenticationHandler[] $handlers
+     * @return $this
+     */
+    public function setHandlers(array $handlers)
+    {
+        $this->handlers = $handlers;
+        return $this;
+    }
+
+    public function authenticateRequest(HTTPRequest $request)
+    {
+        /** @var AuthenticationHandler $handler */
+        foreach ($this->getHandlers() as $name => $handler) {
+            // in order to add cookies, etc
+            $member = $handler->authenticateRequest($request);
+            if ($member) {
+                Security::setCurrentUser($member);
+                return;
+            }
+        }
+    }
+    /**
+     * Log into the identity-store handlers attached to this request filter
+     *
+     * @param Member $member
+     * @param bool $persistent
+     * @param HTTPRequest $request
+     */
+    public function logIn(Member $member, $persistent = false, HTTPRequest $request = null)
+    {
+        $member->beforeMemberLoggedIn();
+
+        foreach ($this->getHandlers() as $handler) {
+            $handler->logIn($member, $persistent, $request);
+        }
+
+        Security::setCurrentUser($member);
+        $member->afterMemberLoggedIn();
+    }
+
+    /**
+     * Log out of all the identity-store handlers attached to this request filter
+     *
+     * @param HTTPRequest $request
+     */
+    public function logOut(HTTPRequest $request = null)
+    {
+        foreach ($this->getHandlers() as $handler) {
+            $handler->logOut($request);
+        }
+
+        Security::setCurrentUser(null);
+    }
+}

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -428,6 +428,18 @@ class Security extends Controller implements TemplateGlobalProvider
         ));
     }
 
+    private static $currentUser;
+
+    public static function setCurrentUser($currentUser)
+    {
+        self::$currentUser = $currentUser;
+    }
+
+    public static function getCurrentUser()
+    {
+        return self::$currentUser;
+    }
+
     /**
      * Get the login forms for all available authentication methods
      *

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -214,7 +214,7 @@ class Security extends Controller implements TemplateGlobalProvider
     /**
      * @var Authenticator[] available authenticators
      */
-    private static $authenticators = [];
+    private $authenticators = [];
 
     /**
      * @var Member Currently logged in user (if available)
@@ -224,17 +224,17 @@ class Security extends Controller implements TemplateGlobalProvider
     /**
      * @return array
      */
-    public static function getAuthenticators()
+    public function getAuthenticators()
     {
-        return self::$authenticators;
+        return $this->authenticators;
     }
 
     /**
      * @param array|Authenticator $authenticators
      */
-    public static function setAuthenticators(array $authenticators)
+    public function setAuthenticators(array $authenticators)
     {
-        self::$authenticators = $authenticators;
+        $this->authenticators = $authenticators;
     }
 
     /**
@@ -274,7 +274,7 @@ class Security extends Controller implements TemplateGlobalProvider
      */
     protected function getAuthenticator($name = 'default')
     {
-        $authenticators = static::$authenticators;
+        $authenticators = $this->authenticators;
 
         if (isset($authenticators[$name])) {
             return $authenticators[$name];
@@ -291,7 +291,7 @@ class Security extends Controller implements TemplateGlobalProvider
      */
     public function getApplicableAuthenticators($service = Authenticator::LOGIN)
     {
-        $authenticators = static::$authenticators;
+        $authenticators = $this->authenticators;
 
         /** @var Authenticator $class */
         foreach ($authenticators as $name => $class) {
@@ -312,7 +312,7 @@ class Security extends Controller implements TemplateGlobalProvider
      */
     public function hasAuthenticator($authenticator)
     {
-        $authenticators = static::$authenticators;
+        $authenticators = $this->authenticators;
 
         return !empty($authenticators[$authenticator]);
     }

--- a/src/Security/SecurityToken.php
+++ b/src/Security/SecurityToken.php
@@ -2,11 +2,11 @@
 
 namespace SilverStripe\Security;
 
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Session;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
-use SilverStripe\Control\Session;
-use SilverStripe\Control\Controller;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\View\TemplateGlobalProvider;
@@ -61,11 +61,11 @@ class SecurityToken implements TemplateGlobalProvider
     protected $name = null;
 
     /**
-     * @param $name
+     * @param string $name
      */
     public function __construct($name = null)
     {
-        $this->name = ($name) ? $name : self::get_default_name();
+        $this->name = $name ?: self::get_default_name();
     }
 
     /**

--- a/src/View/ViewableData.php
+++ b/src/View/ViewableData.php
@@ -329,7 +329,7 @@ class ViewableData implements IteratorAggregate
         }
 
         // Fall back to default_cast
-        $default = $this->config()->get('default_cast');
+        $default = self::config()->get('default_cast');
         if (empty($default)) {
             throw new Exception("No default_cast");
         }

--- a/src/View/ViewableData.php
+++ b/src/View/ViewableData.php
@@ -312,7 +312,7 @@ class ViewableData implements IteratorAggregate
      */
     public function castingHelper($field)
     {
-        $specs = $this->config()->get('casting');
+        $specs = static::config()->get('casting');
         if (isset($specs[$field])) {
             return $specs[$field];
         }
@@ -329,7 +329,7 @@ class ViewableData implements IteratorAggregate
         }
 
         // Fall back to default_cast
-        $default = self::config()->get('default_cast');
+        $default = $this->config()->get('default_cast');
         if (empty($default)) {
             throw new Exception("No default_cast");
         }

--- a/tests/behat/features/login.feature
+++ b/tests/behat/features/login.feature
@@ -6,7 +6,7 @@ Feature: Log in
 
   Scenario: Bad login
     Given I log in with "bad@example.com" and "badpassword"
-    Then I will see a "error" log-in message
+    Then I should see "The provided details don't seem to be correct"
 
   Scenario: Valid login
     Given I am logged in with "ADMIN" permissions

--- a/tests/php/Control/ControllerTest.php
+++ b/tests/php/Control/ControllerTest.php
@@ -23,6 +23,7 @@ use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\ORM\DataModel;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 use SilverStripe\View\SSViewer;
 
 class ControllerTest extends FunctionalTest
@@ -203,7 +204,7 @@ class ControllerTest extends FunctionalTest
             'if action is not a method but rather a template discovered by naming convention'
         );
 
-        $this->session()->inst_set('loggedInAs', $adminUser->ID);
+        Security::setCurrentUser($adminUser);
         $response = $this->get("AccessSecuredController/templateaction");
         $this->assertEquals(
             200,
@@ -211,8 +212,8 @@ class ControllerTest extends FunctionalTest
             'Access granted for logged in admin on action with $allowed_actions on defining controller, ' .
             'if action is not a method but rather a template discovered by naming convention'
         );
-        $this->session()->inst_set('loggedInAs', null);
 
+        Security::setCurrentUser(null);
         $response = $this->get("AccessSecuredController/adminonly");
         $this->assertEquals(
             403,
@@ -236,15 +237,15 @@ class ControllerTest extends FunctionalTest
             "Access denied to protected method even if its listed in allowed_actions"
         );
 
-        $this->session()->inst_set('loggedInAs', $adminUser->ID);
+        Security::setCurrentUser($adminUser);
         $response = $this->get("AccessSecuredController/adminonly");
         $this->assertEquals(
             200,
             $response->getStatusCode(),
             "Permission codes are respected when set in \$allowed_actions"
         );
-        $this->session()->inst_set('loggedInAs', null);
 
+        Security::setCurrentUser(null);
         $response = $this->get('AccessBaseController/extensionmethod1');
         $this->assertEquals(
             200,
@@ -285,7 +286,7 @@ class ControllerTest extends FunctionalTest
             "and doesn't satisfy checks"
         );
 
-        $this->session()->inst_set('loggedInAs', $adminUser->ID);
+        Security::setCurrentUser($adminUser);
         $response = $this->get('IndexSecuredController/');
         $this->assertEquals(
             200,
@@ -293,7 +294,7 @@ class ControllerTest extends FunctionalTest
             "Access granted when index action is limited through allowed_actions, " .
             "and does satisfy checks"
         );
-        $this->session()->inst_set('loggedInAs', null);
+        Security::setCurrentUser(null);
     }
 
     public function testWildcardAllowedActions()

--- a/tests/php/Forms/GridField/GridFieldDeleteActionTest.php
+++ b/tests/php/Forms/GridField/GridFieldDeleteActionTest.php
@@ -10,11 +10,10 @@ use SilverStripe\Forms\Tests\GridField\GridFieldTest\Team;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\ValidationException;
-use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 use SilverStripe\Security\SecurityToken;
 use SilverStripe\Dev\CSSContentParser;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Session;
 use SilverStripe\Forms\FieldList;
@@ -67,8 +66,8 @@ class GridFieldDeleteActionTest extends SapphireTest
 
     public function testDontShowDeleteButtons()
     {
-        if (Member::currentUser()) {
-            Member::currentUser()->logOut();
+        if (Security::getCurrentUser()) {
+            Security::setCurrentUser(null);
         }
         $content = new CSSContentParser($this->gridField->FieldHolder());
         // Check that there are content
@@ -116,8 +115,8 @@ class GridFieldDeleteActionTest extends SapphireTest
 
     public function testDeleteActionWithoutCorrectPermission()
     {
-        if (Member::currentUser()) {
-            Member::currentUser()->logOut();
+        if (Security::getCurrentUser()) {
+            Security::setCurrentUser(null);
         }
         $this->setExpectedException(ValidationException::class);
 

--- a/tests/php/Forms/GridField/GridFieldEditButtonTest.php
+++ b/tests/php/Forms/GridField/GridFieldEditButtonTest.php
@@ -64,7 +64,7 @@ class GridFieldEditButtonTest extends SapphireTest
     public function testShowEditLinks()
     {
         if (Security::getCurrentUser()) {
-            Security::getCurrentUser()->logOut();
+            Security::setCurrentUser(null);
         }
 
         $content = new CSSContentParser($this->gridField->FieldHolder());

--- a/tests/php/Forms/GridField/GridFieldEditButtonTest.php
+++ b/tests/php/Forms/GridField/GridFieldEditButtonTest.php
@@ -17,6 +17,7 @@ use SilverStripe\Forms\Form;
 use SilverStripe\Forms\GridField\GridFieldConfig;
 use SilverStripe\Forms\GridField\GridFieldEditButton;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Security\Security;
 
 class GridFieldEditButtonTest extends SapphireTest
 {
@@ -62,8 +63,8 @@ class GridFieldEditButtonTest extends SapphireTest
 
     public function testShowEditLinks()
     {
-        if (Member::currentUser()) {
-            Member::currentUser()->logOut();
+        if (Security::getCurrentUser()) {
+            Security::getCurrentUser()->logOut();
         }
 
         $content = new CSSContentParser($this->gridField->FieldHolder());

--- a/tests/php/Security/BasicAuthTest.php
+++ b/tests/php/Security/BasicAuthTest.php
@@ -30,7 +30,7 @@ class BasicAuthTest extends FunctionalTest
 
         // Fixtures assume Email is the field used to identify the log in identity
         Member::config()->unique_identifier_field = 'Email';
-        Security::$force_database_is_ready = true; // Prevents Member test subclasses breaking ready test
+        Security::force_database_is_ready(true); // Prevents Member test subclasses breaking ready test
         Member::config()->lock_out_after_incorrect_logins = 10;
     }
 

--- a/tests/php/Security/BasicAuthTest.php
+++ b/tests/php/Security/BasicAuthTest.php
@@ -87,7 +87,7 @@ class BasicAuthTest extends FunctionalTest
 
         $_SERVER['PHP_AUTH_USER'] = 'user-in-mygroup@test.com';
         $_SERVER['PHP_AUTH_PW'] = 'test';
-        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission', null, $_SESSION, null, null, $_SERVER);;
+        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission', null, $_SESSION, null, null, $_SERVER);
         $this->assertEquals(200, $response->getStatusCode(), 'Valid user with required permission has access');
 
         $_SERVER['PHP_AUTH_USER'] = $origUser;

--- a/tests/php/Security/BasicAuthTest.php
+++ b/tests/php/Security/BasicAuthTest.php
@@ -15,7 +15,7 @@ use SilverStripe\Security\Tests\BasicAuthTest\ControllerSecuredWithPermission;
 class BasicAuthTest extends FunctionalTest
 {
 
-    static $original_unique_identifier_field;
+    protected static $original_unique_identifier_field;
 
     protected static $fixture_file = 'BasicAuthTest.yml';
 
@@ -42,7 +42,7 @@ class BasicAuthTest extends FunctionalTest
         unset($_SERVER['PHP_AUTH_USER']);
         unset($_SERVER['PHP_AUTH_PW']);
 
-        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission');
+        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission', null, $_SESSION, null, null, $_SERVER);
         $this->assertEquals(401, $response->getStatusCode());
 
         $_SERVER['PHP_AUTH_USER'] = $origUser;
@@ -56,13 +56,13 @@ class BasicAuthTest extends FunctionalTest
 
         unset($_SERVER['PHP_AUTH_USER']);
         unset($_SERVER['PHP_AUTH_PW']);
-        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission');
+        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission', null, $_SESSION, null, null, $_SERVER);
         $this->assertFalse(BasicAuthTest\ControllerSecuredWithPermission::$index_called);
         $this->assertFalse(BasicAuthTest\ControllerSecuredWithPermission::$post_init_called);
 
         $_SERVER['PHP_AUTH_USER'] = 'user-in-mygroup@test.com';
         $_SERVER['PHP_AUTH_PW'] = 'test';
-        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission');
+        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission', null, $_SESSION, null, null, $_SERVER);
         $this->assertTrue(BasicAuthTest\ControllerSecuredWithPermission::$index_called);
         $this->assertTrue(BasicAuthTest\ControllerSecuredWithPermission::$post_init_called);
 
@@ -77,17 +77,17 @@ class BasicAuthTest extends FunctionalTest
 
         $_SERVER['PHP_AUTH_USER'] = 'user-in-mygroup@test.com';
         $_SERVER['PHP_AUTH_PW'] = 'wrongpassword';
-        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission');
+        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission', null, $_SESSION, null, null, $_SERVER);
         $this->assertEquals(401, $response->getStatusCode(), 'Invalid users dont have access');
 
         $_SERVER['PHP_AUTH_USER'] = 'user-without-groups@test.com';
         $_SERVER['PHP_AUTH_PW'] = 'test';
-        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission');
+        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission', null, $_SESSION, null, null, $_SERVER);
         $this->assertEquals(401, $response->getStatusCode(), 'Valid user without required permission has no access');
 
         $_SERVER['PHP_AUTH_USER'] = 'user-in-mygroup@test.com';
         $_SERVER['PHP_AUTH_PW'] = 'test';
-        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission');
+        $response = Director::test('BasicAuthTest_ControllerSecuredWithPermission', null, $_SESSION, null, null, $_SERVER);;
         $this->assertEquals(200, $response->getStatusCode(), 'Valid user with required permission has access');
 
         $_SERVER['PHP_AUTH_USER'] = $origUser;
@@ -101,17 +101,17 @@ class BasicAuthTest extends FunctionalTest
 
         $_SERVER['PHP_AUTH_USER'] = 'user-without-groups@test.com';
         $_SERVER['PHP_AUTH_PW'] = 'wrongpassword';
-        $response = Director::test('BasicAuthTest_ControllerSecuredWithoutPermission');
+        $response = Director::test('BasicAuthTest_ControllerSecuredWithoutPermission', null, $_SESSION, null, null, $_SERVER);
         $this->assertEquals(401, $response->getStatusCode(), 'Invalid users dont have access');
 
         $_SERVER['PHP_AUTH_USER'] = 'user-without-groups@test.com';
         $_SERVER['PHP_AUTH_PW'] = 'test';
-        $response = Director::test('BasicAuthTest_ControllerSecuredWithoutPermission');
+        $response = Director::test('BasicAuthTest_ControllerSecuredWithoutPermission', null, $_SESSION, null, null, $_SERVER);
         $this->assertEquals(200, $response->getStatusCode(), 'All valid users have access');
 
         $_SERVER['PHP_AUTH_USER'] = 'user-in-mygroup@test.com';
         $_SERVER['PHP_AUTH_PW'] = 'test';
-        $response = Director::test('BasicAuthTest_ControllerSecuredWithoutPermission');
+        $response = Director::test('BasicAuthTest_ControllerSecuredWithoutPermission', null, $_SESSION, null, null, $_SERVER);
         $this->assertEquals(200, $response->getStatusCode(), 'All valid users have access');
 
         $_SERVER['PHP_AUTH_USER'] = $origUser;
@@ -127,19 +127,19 @@ class BasicAuthTest extends FunctionalTest
         // First failed attempt
         $_SERVER['PHP_AUTH_USER'] = 'failedlogin@test.com';
         $_SERVER['PHP_AUTH_PW'] = 'test';
-        $response = Director::test('BasicAuthTest_ControllerSecuredWithoutPermission');
+        $response = Director::test('BasicAuthTest_ControllerSecuredWithoutPermission', null, $_SESSION, null, null, $_SERVER);
         $check = Member::get()->filter('Email', 'failedlogin@test.com')->first();
         $this->assertEquals(1, $check->FailedLoginCount);
 
         // Second failed attempt
         $_SERVER['PHP_AUTH_PW'] = 'testwrong';
-        $response = Director::test('BasicAuthTest_ControllerSecuredWithoutPermission');
+        $response = Director::test('BasicAuthTest_ControllerSecuredWithoutPermission', null, $_SESSION, null, null, $_SERVER);
         $check = Member::get()->filter('Email', 'failedlogin@test.com')->first();
         $this->assertEquals(2, $check->FailedLoginCount);
 
         // successful basic auth should reset failed login count
         $_SERVER['PHP_AUTH_PW'] = 'Password';
-        $response = Director::test('BasicAuthTest_ControllerSecuredWithoutPermission');
+        $response = Director::test('BasicAuthTest_ControllerSecuredWithoutPermission', null, $_SESSION, null, null, $_SERVER);
         $check = Member::get()->filter('Email', 'failedlogin@test.com')->first();
         $this->assertEquals(0, $check->FailedLoginCount);
     }

--- a/tests/php/Security/InheritedPermissionsTest/TestPermissionNode.php
+++ b/tests/php/Security/InheritedPermissionsTest/TestPermissionNode.php
@@ -9,6 +9,7 @@ use SilverStripe\Security\InheritedPermissions;
 use SilverStripe\Security\InheritedPermissionsExtension;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\PermissionChecker;
+use SilverStripe\Security\Security;
 use SilverStripe\Versioned\Versioned;
 
 /**
@@ -45,7 +46,7 @@ class TestPermissionNode extends DataObject implements TestOnly
     public function canEdit($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
         return static::getInheritedPermissions()->canEdit($this->ID, $member);
     }
@@ -53,7 +54,7 @@ class TestPermissionNode extends DataObject implements TestOnly
     public function canView($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
         return static::getInheritedPermissions()->canView($this->ID, $member);
     }
@@ -61,7 +62,7 @@ class TestPermissionNode extends DataObject implements TestOnly
     public function canDelete($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
         return static::getInheritedPermissions()->canDelete($this->ID, $member);
     }

--- a/tests/php/Security/MemberAuthenticatorTest.php
+++ b/tests/php/Security/MemberAuthenticatorTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Security\Tests;
 
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\ValidationResult;
@@ -13,6 +14,7 @@ use SilverStripe\Security\Member;
 use SilverStripe\Security\MemberAuthenticator\Authenticator;
 use SilverStripe\Security\MemberAuthenticator\LoginForm;
 use SilverStripe\Security\CMSMemberLoginForm;
+use SilverStripe\Security\IdentityStore;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\FieldList;
@@ -103,7 +105,7 @@ class MemberAuthenticatorTest extends SapphireTest
         $this->assertEmpty($tempID);
 
         // If the user logs in then they have a temp id
-        $member->logIn(true);
+        Injector::inst()->get(IdentityStore::class)->logIn($member, true, new HTTPRequest('GET', '/'));
         $tempID = $member->TempIDHash;
         $this->assertNotEmpty($tempID);
 

--- a/tests/php/Security/MemberAuthenticatorTest.php
+++ b/tests/php/Security/MemberAuthenticatorTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Security\Tests;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Security\MemberAuthenticator\CMSAuthenticator;
 use SilverStripe\Security\PasswordEncryptor;
 use SilverStripe\Security\PasswordEncryptor_PHPHash;
 use SilverStripe\Security\Security;
@@ -89,7 +90,7 @@ class MemberAuthenticatorTest extends SapphireTest
      */
     public function testAuthenticateByTempID()
     {
-        $authenticator = new Authenticator();
+        $authenticator = new CMSAuthenticator();
 
         $member = new Member();
         $member->Email = 'test1@test.com';
@@ -186,7 +187,7 @@ class MemberAuthenticatorTest extends SapphireTest
             $dummy
         );
 
-        $this->assertTrue(Member::default_admin()->isLockedOut());
+        $this->assertFalse(Member::default_admin()->canLogin()->isValid());
         $this->assertEquals('2016-04-18 00:10:00', Member::default_admin()->LockedOutUntil);
     }
 }

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -237,13 +237,13 @@ class MemberTest extends FunctionalTest
         $this->assertNotNull($member);
 
         // Initiate a password-reset
-        $response = $this->post('Security/LostPasswordForm', array('Email' => $member->Email));
+        $response = $this->post('Security/lostpassword/LostPasswordForm', array('Email' => $member->Email));
 
         $this->assertEquals($response->getStatusCode(), 302);
 
         // We should get redirected to Security/passwordsent
         $this->assertContains(
-            'Security/passwordsent/testuser@example.com',
+            'Security/lostpassword/passwordsent/testuser@example.com',
             urldecode($response->getHeader('Location'))
         );
 
@@ -942,12 +942,11 @@ class MemberTest extends FunctionalTest
         // Re-logging (ie 'alc_enc' has expired), and not checking the "Remember Me" option
         // should remove all previous hashes for this device
         $response = $this->post(
-            'Security/LoginForm',
+            'Security/login/default/LoginForm',
             array(
                 'Email' => $m1->Email,
                 'Password' => '1nitialPassword',
-                'AuthenticationMethod' => MemberAuthenticator::class,
-                'action_dologin' => 'action_dologin'
+                'action_doLogin' => 'action_doLogin'
             ),
             null,
             $this->session(),

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Security\Tests;
 
 use SilverStripe\Core\Convert;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Control\Cookie;
 use SilverStripe\i18n\i18n;
@@ -553,7 +554,6 @@ class MemberTest extends FunctionalTest
         $this->assertFalse($member->canDelete());
         $this->assertFalse($member->canEdit());
 
-        $this->addExtensions($extensions);
         $this->logOut();
     }
 
@@ -568,14 +568,11 @@ class MemberTest extends FunctionalTest
         $this->assertTrue($member2->canDelete());
         $this->assertTrue($member2->canEdit());
 
-        $this->addExtensions($extensions);
         $this->logOut();
     }
 
     public function testExtendedCan()
     {
-
-        $extensions = $this->removeExtensions(Object::get_extensions(Member::class));
         $member = $this->objFromFixture(Member::class, 'test');
 
         /* Normal behaviour is that you can't view a member unless canView() on an extension returns true */
@@ -1369,12 +1366,12 @@ class MemberTest extends FunctionalTest
 
     public function testCurrentUser()
     {
-        $this->assertNull(Member::currentUser());
+        $this->assertNull(Security::getCurrentUser());
 
         $adminMember = $this->objFromFixture(Member::class, 'admin');
         $this->logInAs($adminMember);
 
-        $userFromSession = Member::currentUser();
+        $userFromSession = Security::getCurrentUser();
         $this->assertEquals($adminMember->ID, $userFromSession->ID);
     }
 
@@ -1383,7 +1380,7 @@ class MemberTest extends FunctionalTest
      */
     public function testActAsUserPermissions()
     {
-        $this->assertNull(Member::currentUser());
+        $this->assertNull(Security::getCurrentUser());
 
         /** @var Member $adminMember */
         $adminMember = $this->objFromFixture(Member::class, 'admin');
@@ -1422,7 +1419,7 @@ class MemberTest extends FunctionalTest
      */
     public function testActAsUser()
     {
-        $this->assertNull(Member::currentUser());
+        $this->assertNull(Security::getCurrentUser());
 
         /** @var Member $adminMember */
         $adminMember = $this->objFromFixture(Member::class, 'admin');

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -1155,8 +1155,8 @@ class MemberTest extends FunctionalTest
                 'Failed to increment $member->FailedLoginCount'
             );
 
-            $this->assertFalse(
-                $member->isLockedOut(),
+            $this->assertTrue(
+                $member->canLogin()->isValid(),
                 "Member has been locked out too early"
             );
         }

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -11,7 +11,6 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\Member;
-use SilverStripe\Security\MemberAuthenticator;
 use SilverStripe\Security\Security;
 use SilverStripe\Security\MemberPassword;
 use SilverStripe\Security\Group;
@@ -875,7 +874,7 @@ class MemberTest extends FunctionalTest
     {
         $m1 = $this->objFromFixture(Member::class, 'grouplessmember');
 
-        Injector::inst()->get(IdentityStore::class)->logIn($m1, true, new HTTPRequest('GET', '/'));
+        Injector::inst()->get(IdentityStore::class)->logIn($m1, true);
 
         $hashes = RememberLoginHash::get()->filter('MemberID', $m1->ID);
         $this->assertEquals($hashes->count(), 1);
@@ -891,7 +890,7 @@ class MemberTest extends FunctionalTest
 */
         $m1 = $this->objFromFixture(Member::class, 'noexpiry');
 
-        Injector::inst()->get(IdentityStore::class)->logIn($m1, true, new HTTPRequest('GET', '/'));
+        Injector::inst()->get(IdentityStore::class)->logIn($m1, true);
 
         $firstHash = RememberLoginHash::get()->filter('MemberID', $m1->ID)->first();
         $this->assertNotNull($firstHash);
@@ -970,7 +969,7 @@ class MemberTest extends FunctionalTest
  * @var Member $m1
 */
         $m1 = $this->objFromFixture(Member::class, 'noexpiry');
-        Injector::inst()->get(IdentityStore::class)->logIn($m1, true, new HTTPRequest('GET', '/'));
+        Injector::inst()->get(IdentityStore::class)->logIn($m1, true);
         $firstHash = RememberLoginHash::get()->filter('MemberID', $m1->ID)->first();
         $this->assertNotNull($firstHash);
 
@@ -1029,10 +1028,10 @@ class MemberTest extends FunctionalTest
         $m1 = $this->objFromFixture(Member::class, 'noexpiry');
 
         // First device
-        Injector::inst()->get(IdentityStore::class)->logIn($m1, true, new HTTPRequest('GET', '/'));
+        Injector::inst()->get(IdentityStore::class)->logIn($m1, true);
         Cookie::set('alc_device', null);
         // Second device
-        Injector::inst()->get(IdentityStore::class)->logIn($m1, true, new HTTPRequest('GET', '/'));
+        Injector::inst()->get(IdentityStore::class)->logIn($m1, true);
 
         // Hash of first device
         $firstHash = RememberLoginHash::get()->filter('MemberID', $m1->ID)->first();
@@ -1105,7 +1104,7 @@ class MemberTest extends FunctionalTest
 
         // Logging out from any device when all login hashes should be removed
         RememberLoginHash::config()->update('logout_across_devices', true);
-        Injector::inst()->get(IdentityStore::class)->logIn($m1, true, new HTTPRequest('GET', '/'));
+        Injector::inst()->get(IdentityStore::class)->logIn($m1, true);
         $response = $this->get('Security/logout', $this->session());
         $this->assertEquals(
             RememberLoginHash::get()->filter('MemberID', $m1->ID)->count(),
@@ -1423,17 +1422,17 @@ class MemberTest extends FunctionalTest
 
         /** @var Member $adminMember */
         $adminMember = $this->objFromFixture(Member::class, 'admin');
-        $memberID = Member::actAs($adminMember, function () {
-            return Member::currentUserID();
+        $member = Member::actAs($adminMember, function () {
+            return Security::getCurrentUser();
         });
-        $this->assertEquals($adminMember->ID, $memberID);
+        $this->assertEquals($adminMember->ID, $member->ID);
 
         // Check nesting
-        $memberID = Member::actAs($adminMember, function () {
+        $member = Member::actAs($adminMember, function () {
             return Member::actAs(null, function () {
-                return Member::currentUserID();
+                return Security::getCurrentUser();
             });
         });
-        $this->assertEmpty($memberID);
+        $this->assertEmpty($member);
     }
 }

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -11,6 +11,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler;
 use SilverStripe\Security\Security;
 use SilverStripe\Security\MemberPassword;
 use SilverStripe\Security\Group;
@@ -1072,7 +1073,11 @@ class MemberTest extends FunctionalTest
         );
         $this->assertContains($message, $response->getBody());
 
-        $this->logOut();
+        // Test that removing session but not cookie keeps user
+        /** @var SessionAuthenticationHandler $sessionHandler */
+        $sessionHandler = Injector::inst()->get(SessionAuthenticationHandler::class);
+        $sessionHandler->logOut();
+        Security::setCurrentUser(null);
 
         // Accessing the login page from the second device
         $response = $this->get(

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -49,8 +49,8 @@ class SecurityTest extends FunctionalTest
     protected function setUp()
     {
         // This test assumes that MemberAuthenticator is present and the default
-        $this->priorAuthenticators = Authenticator::get_authenticators();
-        $this->priorDefaultAuthenticator = Authenticator::get_default_authenticator();
+        // $this->priorAuthenticators = Authenticator::get_authenticators();
+        // $this->priorDefaultAuthenticator = Authenticator::get_default_authenticator();
 
         // Set to an empty array of authenticators to enable the default
         Config::modify()->set(Authenticator::class, 'authenticators', []);
@@ -74,8 +74,8 @@ class SecurityTest extends FunctionalTest
         // Restore selected authenticator
 
         // MemberAuthenticator might not actually be present
-        Config::modify()->set(Authenticator::class, 'authenticators', $this->priorAuthenticators);
-        Config::modify()->set(Authenticator::class, 'default_authenticator', $this->priorDefaultAuthenticator);
+        // Config::modify()->set(Authenticator::class, 'authenticators', $this->priorAuthenticators);
+        // Config::modify()->set(Authenticator::class, 'default_authenticator', $this->priorDefaultAuthenticator);
 
         // Restore unique identifier field
         Member::config()->unique_identifier_field = $this->priorUniqueIdentifierField;

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -378,6 +378,8 @@ class SecurityTest extends FunctionalTest
         );
         $this->assertEquals($this->idFromFixture(Member::class, 'test'), $this->session()->inst_get('loggedInAs'));
 
+        $this->logOut();
+
         /* EXPIRED PASSWORDS ARE SENT TO THE CHANGE PASSWORD FORM */
         $expiredResponse = $this->doTestLoginForm('expired@silverstripe.com', '1nitialPassword');
         $this->assertEquals(302, $expiredResponse->getStatusCode());
@@ -415,6 +417,7 @@ class SecurityTest extends FunctionalTest
         $this->assertEquals($this->idFromFixture(Member::class, 'test'), $this->session()->inst_get('loggedInAs'));
 
         // Check if we can login with the new password
+        $this->logOut();
         $goodResponse = $this->doTestLoginForm('testuser@example.com', 'changedPassword');
         $this->assertEquals(302, $goodResponse->getStatusCode());
         $this->assertEquals(
@@ -460,6 +463,7 @@ class SecurityTest extends FunctionalTest
         $this->assertEquals($this->idFromFixture(Member::class, 'test'), $this->session()->inst_get('loggedInAs'));
 
         // Check if we can login with the new password
+        $this->logOut();
         $goodResponse = $this->doTestLoginForm('testuser@example.com', 'changedPassword');
         $this->assertEquals(302, $goodResponse->getStatusCode());
         $this->assertEquals($this->idFromFixture(Member::class, 'test'), $this->session()->inst_get('loggedInAs'));
@@ -532,7 +536,7 @@ class SecurityTest extends FunctionalTest
         );
 
         // Log the user out
-        $this->session()->inst_set('loggedInAs', null);
+        $this->logOut();
 
         // Login again with wrong password, but less attempts than threshold
         for ($i = 1; $i < Member::config()->lock_out_after_incorrect_logins; $i++) {

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -182,8 +182,8 @@ class SecurityTest extends FunctionalTest
     public function testAutomaticRedirectionOnLogin()
     {
         // BackURL with permission error (not authenticated) should not redirect
-        if ($member = Member::currentUser()) {
-            $member->logOut();
+        if ($member = Security::getCurrentUser()) {
+            Security::setCurrentUser(null);
         }
         $response = $this->getRecursive('SecurityTest_SecuredController');
         $this->assertContains(Convert::raw2xml("That page is secured."), $response->getBody());
@@ -228,7 +228,7 @@ class SecurityTest extends FunctionalTest
         $member = DataObject::get_one(Member::class);
 
         /* Log in with any user that we can find */
-        $this->session()->inst_set('loggedInAs', $member->ID);
+        Security::setCurrentUser($member);
 
         /* View the Security/login page */
         $response = $this->get(Config::inst()->get(Security::class, 'login_url'));
@@ -254,7 +254,7 @@ class SecurityTest extends FunctionalTest
         $this->assertNotNull($response->getBody(), 'There is body content on the page');
 
         /* Log the user out */
-        $this->session()->inst_set('loggedInAs', null);
+        Security::setCurrentUser(null);
     }
 
     public function testMemberIDInSessionDoesntExistInDatabaseHasToLogin()

--- a/tests/php/View/SSViewerTest.php
+++ b/tests/php/View/SSViewerTest.php
@@ -16,6 +16,7 @@ use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\PaginatedList;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
 use SilverStripe\Security\SecurityToken;
 use SilverStripe\Security\Permission;
 use SilverStripe\View\ArrayData;
@@ -406,22 +407,22 @@ SS;
         );
 
         $this->assertEquals(
-            (string)Member::currentUser(),
+            (string)Security::getCurrentUser(),
             $this->render('{$CurrentMember}'),
             'Member template functions result correct result'
         );
         $this->assertEquals(
-            (string)Member::currentUser(),
+            (string)Security::getCurrentUser(),
             $this->render('{$CurrentUser}'),
             'Member template functions result correct result'
         );
         $this->assertEquals(
-            (string)Member::currentUser(),
+            (string)Security::getCurrentUser(),
             $this->render('{$currentMember}'),
             'Member template functions result correct result'
         );
         $this->assertEquals(
-            (string)Member::currentUser(),
+            (string)Security::getCurrentUser(),
             $this->render('{$currentUser}'),
             'Member template functions result correct result'
         );


### PR DESCRIPTION
I've been working with @Firesphere on a pretty substantial refactor of the authenticator classes. This is the work in progress. It would be good to get feedback on the approach before it's finalised.

Main changes:

 * Authenticator is now an interface, not an abstract base class, and the static methods have become instance methods.
 * The authenticator provides extension points for lost password & change password as well as log-in, so that these systems can be authenticator-specific also
 * Instead of just having a Form as the extension point, we have a RequestHandler. This means that authenticators can provide multiple forms for a multi-step process, action handlers for OAuth, etc. @chillu @Firesphere and I discussed "what's the best abstraction for an arbitrary multi-step workflow?" and came to the conclusion that RequestHandler gives us most of what we need rather than needing some overblown new abstraction.
   * The handlers can return array key/values to substitute content into the default controller provided by Security. This requires a bit of extra code in Security but follows patterns already present in RequestHandler.
 * Authenticators can indicate the services that they support via the `supportedServices` method.

## Tasks

- [x] Make supportedServices() actually do something
- [x] Finish refactoring changepassword
- [x] Get unit tests working
- [x] Complete manual testing
- [x] Determine best way of providing addBackURLParam to the handlers - right now it's copypasta
- [x] Review and potentially remove the LoginForm base. -- I would prefer to keep it
- [x] Review and potentially move getAuthenticatorName() back into the authenticator -- I found it better fitting on the Form, due to the nature of the template rendering
- [x] Get support for multiple authenticators working again
- [x] Try upgrading @Firesphere's MFA module to validate that this API is useful
- [x] Try upgrading @dhensby's MFA module to do the same as above
- [ ] Try upgrading a facebook login module, for the same reason -- Seems to work, but it doesn't accept `localhost:8080` as a valid domain

### Verifying status of these tasks

- [x] Determine best way of handling messages from `authenticate()` in `LoginHandler::performLogin()`
- [ ] Potentially add configuration to the login handler so that the writing together of steps can be more easily modified on subclasses (e.g. to subclass `MemberAuthenticator\LoginHandler` and then wire in a 2nd step)

## Pull requests

- [ ] https://github.com/silverstripe/silverstripe-behat-extension/pull/159
- [ ] https://github.com/silverstripe/silverstripe-framework/pull/6829
- [ ] https://github.com/silverstripe/silverstripe-admin/pull/98
- [ ] https://github.com/silverstripe/silverstripe-versioned/pull/15
- [ ] https://github.com/silverstripe/silverstripe-asset-admin/pull/495
- [ ] https://github.com/silverstripe/silverstripe-assets/pull/24
- [ ] https://github.com/silverstripe/silverstripe-reports/pull/72
- [ ] https://github.com/silverstripe/silverstripe-siteconfig/pull/60
- [ ] https://github.com/silverstripe/silverstripe-graphql/pull/103

## Worthy notes

from @Firesphere 
All my local tests are green, except for a few that are unrelated (I seem to be missing some seeding files or something). These tests _do_ pass on Travis though.

All Behat tests are green for me as well, but happy to get feedback from someone else, as this is a huge piece of work.

I'm aiming to squash it all into a single commit and add relevant documentation somewhere this week or next week.

The PHPDoc comments from @tractorcow are currently on low-priority for me, but if anyone feels like doing that, please do so! It could always be a hackday-task. Low effort to do when the PR is in.

What is not (yet) touched, is the `Permission`s... which looks like it could use some update as well, more in cleaning up/improving than actual API changes (Although, maybe, a many_many relation to the groups instead of duplicating a bunch of has_one's?)