### PR TITLE
Allow —no-dev install via a PHPUnit shim

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,10 @@
       "SilverStripe\\View\\": "src/View/",
       "SilverStripe\\View\\Tests\\": "tests/php/View/"
     },
-    "files": ["src/Core/Constants.php"],
+    "files": [
+      "src/Core/Constants.php",
+      "src/Dev/PhpUnitShim.php"
+    ],
     "classmap": ["tests/behat/features/bootstrap"]
   },
   "include-path": [

--- a/src/Dev/PhpUnitShim.php
+++ b/src/Dev/PhpUnitShim.php
@@ -1,0 +1,14 @@
+<?php
+// Ensure this class can be autoloaded when installed without dev dependencies.
+// It's included by default through composer's autoloading.
+// class_exists() triggers PSR-4 autoloaders, which should discover if PHPUnit is installed.
+// TODO Factor out SapphireTest references from non-dev core code (avoid autoloading in the first place)
+namespace {
+
+    if (!class_exists('PHPUnit_Framework_TestCase')) {
+        class PHPUnit_Framework_TestCase
+        {
+        }
+    }
+
+}


### PR DESCRIPTION
Partially reinstates the 3.x style PhpUnitWrapper which was removed in d1af214ef5efb817c14b85b639525104d94ef2d9.
While we no longer need the full wrapper, the part which creates a fake class is still useful.

The preferred alternative would be to remove any references to SapphireTest from non-dev files,
which mostly applies to `SapphireTest::is_running_test()`. This should be solved in a larger refactor
of SapphireTest into optional traits and more fine grained functionality. I've started this effort but it quickly got messy without looking at the bigger picture (see https://gist.github.com/chillu/7c2698467a55851d58439cb38fd8a389). For example, it might be more consistent to encode that information in the class manifest (which already has a "test mode").

Anyway, this is simply reinstating an aspect of 3.x which was prematurely removed from 4.x.
At the moment, this blocks installing SS4 on SilverStripe Platform (because we run `install --no-dev`)

Reproduce through these steps:

```
composer create-project --prefer-dist --no-dev silverstripe/installer shim-test dev-master
cd shim-test

# Add this to composer.json
"repositories": [
      {
        "type": "vcs",
        "url": "https://github.com/open-sausages/silverstripe-framework.git"
      }
    ]

composer require --update-no-dev  silverstripe/framework:"dev-pulls/4.0/shim-phpunit as 4.0.x-dev"
framework/sake dev/build
```