### PR TITLE
FIX Regression from 3.x: allow $required_extensions to have arguments

### DIFF
--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -16,6 +16,7 @@ use SilverStripe\Core\Config\ConfigLoader;
 use SilverStripe\Core\Config\CoreConfigFactory;
 use SilverStripe\Core\Config\DefaultConfig;
 use SilverStripe\Core\Config\Middleware\ExtensionMiddleware;
+use SilverStripe\Core\Extension;
 use SilverStripe\Core\Flushable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Manifest\ClassManifest;
@@ -376,7 +377,8 @@ class SapphireTest extends PHPUnit_Framework_TestCase
             }
             self::$extensions_to_remove[$class] = array();
             foreach ($extensions as $extension) {
-                if (!class_exists($extension)) {
+                $extensionClass = Extension::get_classname_without_arguments($extension);
+                if (!class_exists($extensionClass)) {
                     $self = static::class;
                     throw new LogicException("Test {$self} requires extension {$extension} which doesn't exist");
                 }


### PR DESCRIPTION
For example in one of the Translatable tests we have the following:

```php
	protected $requiredExtensions = array(
		'SiteTree' => array(
			'Translatable',
			"FulltextSearchable('Title,MenuTitle,Content,MetaDescription')",
		)
	);
```

After converting this to SS4 equivalent the tests fail with:

```
1) SilverStripe\Translatable\Tests\TranslatableSearchFormTest
exception 'LogicException' with message 'Test SilverStripe\Translatable\Tests\TranslatableSearchFormTest requires extension SilverStripe\ORM\Search\FulltextSearchable('Title,MenuTitle,Content,MetaDescription') which doesn't exist'
```

The SS3 equivalent of `setUpBeforeClass` (`setUpOnce`) doesn't do a `class_exists` check before calling `Object::add_extension`, so I've added the method from inside that that trims off the arguments to be able to accurately check whether the extension class exists before using it.