### PR TITLE
Prefer PHP 5.6 in sake

### DIFF
--- a/sake
+++ b/sake
@@ -45,7 +45,7 @@ else
 fi
 
 # Find the PHP binary
-for candidatephp in php php5; do
+for candidatephp in php5.6 php php5; do
 	if [ `which $candidatephp 2>/dev/null` -a -f `which $candidatephp 2>/dev/null` ]; then
 		php=`which $candidatephp 2>/dev/null`
 		break


### PR DESCRIPTION
php5.6 is more or less an afterthought in current operating system versions, and as Silverstripe 3 requires it, we need to adjust the tools to prefer 5.6 over the more common 7.x