### PR TITLE
MINOR: Better error message in SapphireTest

### DIFF
--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -472,7 +472,8 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 	 */
 	protected function getCurrentAbsolutePath() {
 		$filename = self::$test_class_manifest->getItemPath(get_class($this));
-		if(!$filename) throw new LogicException("getItemPath returned null for " . get_class($this));
+		if(!$filename) throw new LogicException("getItemPath returned null for " . get_class($this)
+			. ". Try adding flush=1 to the test run.");
 		return dirname($filename);
 	}
 


### PR DESCRIPTION
This error usually occurs when you've added a
module but haven't run flush on your test classes.

I’ve made the error message more explicit.