### PR TITLE
NEW: Allow SapphireTest::objFromFixture() to accept either table or class

### DIFF
--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -475,7 +475,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
     /**
      * Get the ID of an object from the fixture.
      *
-     * @param string $className The data class, as specified in your fixture file.  Parent classes won't work
+     * @param string $className The data class or table name, as specified in your fixture file.  Parent classes won't work
      * @param string $identifier The identifier string, as provided in your fixture file
      * @return int
      */
@@ -498,7 +498,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
      * Return all of the IDs in the fixture of a particular class name.
      * Will collate all IDs form all fixtures if multiple fixtures are provided.
      *
-     * @param string $className
+     * @param string $className The data class or table name, as specified in your fixture file
      * @return array A map of fixture-identifier => object-id
      */
     protected function allFixtureIDs($className)
@@ -509,7 +509,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
     /**
      * Get an object from the fixture.
      *
-     * @param string $className The data class, as specified in your fixture file. Parent classes won't work
+     * @param string $className The data class or table name, as specified in your fixture file. Parent classes won't work
      * @param string $identifier The identifier string, as provided in your fixture file
      *
      * @return DataObject

--- a/tests/php/Dev/FixtureFactoryTest.php
+++ b/tests/php/Dev/FixtureFactoryTest.php
@@ -172,4 +172,19 @@ class FixtureFactoryTest extends SapphireTest
             DataObjectRelation::get()->byID($relation1->ID)
         );
     }
+
+    public function testGetByClassOrTable()
+    {
+        $factory = new FixtureFactory();
+        $obj1 = $factory->createObject(TestDataObject::class, 'object-one', [ 'Name' => 'test one' ]);
+        $this->assertInstanceOf(TestDataObject::class, $factory->get(TestDataObject::class, 'object-one'));
+        $this->assertEquals('test one', $factory->get(TestDataObject::class, 'object-one')->Name);
+
+        $obj2 = $factory->createRaw('FixtureFactoryTest_TestDataObject', 'object-two', [ 'Name' => 'test two' ]);
+        $this->assertInstanceOf(
+            TestDataObject::class,
+            $factory->get('FixtureFactoryTest_TestDataObject', 'object-two')
+        );
+        $this->assertEquals('test two', $factory->get('FixtureFactoryTest_TestDataObject', 'object-two')->Name);
+    }
 }


### PR DESCRIPTION
Right now SapphireTest::objFromFixture() requires a class as the first
argument. This is fine when your fixture file uses classes as the keys,
but if populating a fixture via tables, objFromFixture() won’t work.

This patch lets you specify either the table name or the class name as
the key.

The benefit here is that you can build fixtures as raw inserts, which is
substantially quicker, and is likely to be a useful tool in building
more efficient test suites.