### PR TITLE
Configurable Build Task

### DIFF
--- a/src/Dev/BuildTask.php
+++ b/src/Dev/BuildTask.php
@@ -9,8 +9,8 @@ use SilverStripe\Core\Object;
  * Interface for a generic build task. Does not support dependencies. This will simply
  * run a chunk of code when called.
  *
- * To disable the task (in the case of potentially destructive updates or deletes), declare
- * the $Disabled property on the subclass.
+ * To disable the task (in the case of potentially destructive updates or deletes), change the
+ * `enabled` property on the subclass to true.
  */
 abstract class BuildTask extends Object
 {
@@ -27,7 +27,7 @@ abstract class BuildTask extends Object
      * @var bool $enabled If set to FALSE, keep it from showing in the list
      * and from being executable through URL or CLI.
      */
-    protected $enabled = true;
+    private static $enabled = true;
 
     /**
      * @var string $title Shown in the overview on the {@link TaskRunner}
@@ -55,7 +55,7 @@ abstract class BuildTask extends Object
      */
     public function isEnabled()
     {
-        return $this->enabled;
+        return static::config()->enabled;
     }
 
     /**


### PR DESCRIPTION
This change will allow Build Tasks to be enabled or disabled using the Config API.

I noticed on another project that certain tasks (such as those from modules) were not able to be enabled or disabled via the Config system. This change will allow those tasks to be disabled by a developer by setting the `$enable` variable to `true` or `false` in their project's `.yml` files.

It should work on older versions of SilverStripe as well, but since I had to change the visibility and scope of the $enable variable, it's a potentially breaking change for legacy code.

