### PR TITLE
MINOR: Fix mismatched brackets

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -231,10 +231,10 @@ en:
   SilverStripe\ORM\FieldType\DBEnum:
     ANY: Any
   SilverStripe\ORM\Hierarchy:
-    LIMITED_TITLE: 'Too many children ({count}}'
+    LIMITED_TITLE: 'Too many children ({count})'
   SilverStripe\ORM\Hierarchy\Hierarchy:
     InfiniteLoopNotAllowed: 'Infinite loop found within the "{type}" hierarchy. Please change the parent to resolve this'
-    LIMITED_TITLE: 'Too many children ({count}}'
+    LIMITED_TITLE: 'Too many children ({count})'
   SilverStripe\ORM\ValidationException:
     DEFAULT_ERROR: 'Validation error'
   SilverStripe\Security\BasicAuth:

--- a/templates/SilverStripe/Forms/Includes/TreeDropdownField_HTML.ss
+++ b/templates/SilverStripe/Forms/Includes/TreeDropdownField_HTML.ss
@@ -7,7 +7,7 @@
 <% end_if %>
 
 <% if $limited %>
-    <li><%t SilverStripe\\ORM\\Hierarchy.LIMITED_TITLE 'Too many children ({count}}' count=$count %></li>
+    <li><%t SilverStripe\\ORM\\Hierarchy.LIMITED_TITLE 'Too many children ({count})' count=$count %></li>
 <% else_if $children %>
     <% loop $children %>
         <li id="selector-{$name}-{$id}" data-id="{$id}"

--- a/templates/SilverStripe/ORM/Hierarchy/Includes/MarkedSet_HTML.ss
+++ b/templates/SilverStripe/ORM/Hierarchy/Includes/MarkedSet_HTML.ss
@@ -1,7 +1,7 @@
 <% if $children || $limited %>
 <ul>
     <% if $limited %>
-        <li><%t SilverStripe\\ORM\\Hierarchy\\Hierarchy.LIMITED_TITLE 'Too many children ({count}}' count=$count %></li>
+        <li><%t SilverStripe\\ORM\\Hierarchy\\Hierarchy.LIMITED_TITLE 'Too many children ({count})' count=$count %></li>
     <% else_if $children %>
         <% loop $children %><li>$node.Title.XML $SubTree</li><% end_loop %>
     <% end_if %>


### PR DESCRIPTION
`Too many children (1897}` just didn't look right....