### PR TITLE
Fix intl ICU inconsistencies

### DIFF
--- a/tests/php/ORM/DBDatetimeTest.php
+++ b/tests/php/ORM/DBDatetimeTest.php
@@ -86,7 +86,8 @@ class DBDatetimeTest extends SapphireTest
     public function testTime()
     {
         $date = DBDatetime::create_field('Datetime', '2001-12-31 22:10:59');
-        $this->assertEquals('10:10:59 PM', $date->Time());
+        // casing depends on system ICU library
+        $this->assertRegexp('#10:10:59 (PM|pm)#', $date->Time());
     }
 
     public function testTime24()

--- a/tests/php/ORM/DBMoneyTest.php
+++ b/tests/php/ORM/DBMoneyTest.php
@@ -156,10 +156,6 @@ class DBMoneyTest extends SapphireTest
         // USD in de locale
         $USD->setLocale('de_DE');
         $this->assertSame($this->clean('53.292,18 $'), $this->clean($USD->Nice()));
-
-        // USD in swedish locale is fun
-        $USD->setLocale('sv');
-        $this->assertSame($this->clean('53 292,18 US$'), $this->clean($USD->Nice()));
     }
 
     public function testGetSymbol()


### PR DESCRIPTION
@dhensby wanna run tests on your CentOS please?

------

From Slack:

anyone here got experience with php-intl? I'm having problems running the test suite locally as the formatting that the tests expect isn't being used. a couple instances:

1. am/pm is lowercase locally but expected to be uppercase in the tests (https://github.com/silverstripe/silverstripe-framework/blob/master/tests/php/ORM/DBDatetimeTest.php#L89)
2. Money format is not coming out the same for Swedish (I get `53.292:18 US$`) (https://github.com/silverstripe/silverstripe-framework/blob/master/tests/php/ORM/DBMoneyTest.php#L162)

[3:22] 
I'm guessing there's some kind of mapping for locale -> format that's either wrong or different for my version of PHP but I can't find anything online

[3:23] 
it seems a bit OTT that our tests enforce specific formatting rules that are actually the job of the intl library, but hey - it's weird that my local copy (CentOS 7.2, PHP 5.6) are different to our travis builds that seem to pass