### PR TITLE
Doc dateformats with calendar year

### DIFF
--- a/docs/en/02_Developer_Guides/13_i18n/index.md
+++ b/docs/en/02_Developer_Guides/13_i18n/index.md
@@ -75,7 +75,7 @@ Formats can be set globally in the i18n class.
 You can use these settings for your own view logic.
 
 	:::php
-	Config::inst()->update('i18n', 'date_format', 'dd.MM.YYYY');
+	Config::inst()->update('i18n', 'date_format', 'dd.MM.yyyy');
 	Config::inst()->update('i18n', 'time_format', 'HH:mm');
 
 Localization in SilverStripe uses PHP's [intl extension](http://php.net/intl).


### PR DESCRIPTION
https://github.com/silverstripe/silverstripe-framework/issues/3749
http://stackoverflow.com/questions/1978051/zend-datetostring-outputs-the-wrong-year-bug-in-my-code-or-zend-date
https://en.wikipedia.org/wiki/ISO_week_date#Disadvantages