### PR TITLE
Cleanup SapphireTest and time related tests

### DIFF
--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -23,6 +23,7 @@ use SilverStripe\Core\Manifest\ClassManifest;
 use SilverStripe\Core\Manifest\ClassLoader;
 use SilverStripe\Core\Resettable;
 use SilverStripe\i18n\i18n;
+use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\ORM\DataObject;
@@ -461,7 +462,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
     public function getFixtureFactory()
     {
         if (!$this->fixtureFactory) {
-            $this->fixtureFactory = Injector::inst()->create('SilverStripe\\Dev\\FixtureFactory');
+            $this->fixtureFactory = Injector::inst()->create(FixtureFactory::class);
         }
         return $this->fixtureFactory;
     }
@@ -538,7 +539,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
      */
     public function loadFixture($fixtureFile)
     {
-        $fixture = Injector::inst()->create('SilverStripe\\Dev\\YamlFixture', $fixtureFile);
+        $fixture = Injector::inst()->create(YamlFixture::class, $fixtureFile);
         $fixture->writeInto($this->getFixtureFactory());
     }
 
@@ -1073,7 +1074,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
             if ($dbName && DB::get_conn()->databaseExists($dbName)) {
                 // Some DataExtensions keep a static cache of information that needs to
                 // be reset whenever the database is killed
-                foreach (ClassInfo::subclassesFor('SilverStripe\\ORM\\DataExtension') as $class) {
+                foreach (ClassInfo::subclassesFor(DataExtension::class) as $class) {
                     $toCall = array($class, 'on_db_reset');
                     if (is_callable($toCall)) {
                         call_user_func($toCall);
@@ -1096,7 +1097,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
 
             // Some DataExtensions keep a static cache of information that needs to
             // be reset whenever the database is cleaned out
-            $classes = array_merge(ClassInfo::subclassesFor('SilverStripe\\ORM\\DataExtension'), ClassInfo::subclassesFor('SilverStripe\\ORM\\DataObject'));
+            $classes = array_merge(ClassInfo::subclassesFor(DataExtension::class), ClassInfo::subclassesFor(DataObject::class));
             foreach ($classes as $class) {
                 $toCall = array($class, 'on_db_reset');
                 if (is_callable($toCall)) {

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -1231,9 +1231,9 @@ class SapphireTest extends PHPUnit_Framework_TestCase
                 $group->Permissions()->add($permission);
             }
 
-            $member = DataObject::get_one('SilverStripe\\Security\\Member', array(
-                '"Member"."Email"' => "$permCode@example.org"
-            ));
+            $member = Member::get()->filter([
+                'Email' => "$permCode@example.org",
+            ])->first();
             if (!$member) {
                 $member = Member::create();
             }

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -1110,7 +1110,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
     public static function create_temp_db()
     {
         // Disable PHPUnit error handling
-        restore_error_handler();
+        $oldErrorHandler = set_error_handler(null);
 
         // Create a temporary database, and force the connection to use UTC for time
         global $databaseConfig;
@@ -1127,7 +1127,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
         static::resetDBSchema();
 
         // Reinstate PHPUnit error handling
-        set_error_handler(array('PHPUnit_Util_ErrorHandler', 'handleError'));
+        set_error_handler($oldErrorHandler);
 
         // Ensure test db is killed on exit
         register_shutdown_function(function () {

--- a/tests/php/ORM/DBDatetimeTest.php
+++ b/tests/php/ORM/DBDatetimeTest.php
@@ -74,7 +74,7 @@ class DBDatetimeTest extends SapphireTest
     {
         $date = DBDatetime::create_field('Datetime', '2001-12-31 22:10:59');
         // note: Some localisation packages exclude the ',' in default medium format
-        $this->assertRegExp('#31/12/2001(,)? 10:10:59 PM#', $date->Nice());
+        $this->assertRegExp('#31/12/2001(,)? 10:10:59 PM#i', $date->Nice());
     }
 
     public function testDate()
@@ -86,8 +86,7 @@ class DBDatetimeTest extends SapphireTest
     public function testTime()
     {
         $date = DBDatetime::create_field('Datetime', '2001-12-31 22:10:59');
-        // casing depends on system ICU library
-        $this->assertRegexp('#10:10:59 (PM|pm)#', $date->Time());
+        $this->assertRegexp('#10:10:59 PM#i', $date->Time());
     }
 
     public function testTime24()

--- a/tests/php/ORM/DBTimeTest.php
+++ b/tests/php/ORM/DBTimeTest.php
@@ -48,12 +48,12 @@ class DBTimeTest extends SapphireTest
     public function testNice()
     {
         $time = DBTime::create_field('Time', '17:15:55');
-        $this->assertEquals('5:15:55 PM', $time->Nice());
+        $this->assertRegexp('#5:15:55 PM#i', $time->Nice());
     }
 
     public function testShort()
     {
         $time = DBTime::create_field('Time', '17:15:55');
-        $this->assertEquals('5:15 PM', $time->Short());
+        $this->assertRegexp('#5:15 PM#i', $time->Short());
     }
 }


### PR DESCRIPTION
A follow up to #6885 

1. Cleanup SapphireTest so it no longer users string FQCNs and usesed `ClassName::class` instead
2. Change format of ss_tmpdb name to be `[prefix]tpmdb_[timestamp]_[rand number]`
3. Don't use `DataObject::get_one()` in `SapphireTest`
4. Fix tests relying on specific capitalisation of am/pm in time formatting tests
5. Restore the phpunit error handler properly

Regarding point 5. PHPUnit only assings it's error handler if the `convertErrorsToExceptions` setting is true (default) so we shouldn't blindly restore it. This patch just sets the handler to default and then resets it to the previous handler (whatever that may have been)