### PR TITLE
Remove reliance on SapphireTest::is_running_test

### DIFF
--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -8,7 +8,6 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\Deprecation;
-use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ArrayLib;
 use SilverStripe\ORM\DataModel;
 use SilverStripe\Versioned\Versioned;
@@ -101,6 +100,13 @@ class Director implements TemplateGlobalProvider
      * @var string
      */
     protected static $environment_type;
+
+    /**
+     * Flag if the system is under test
+     *
+     * @var bool
+     */
+    protected static $system_under_test = false;
 
     /**
      * Process the given URL, creating the appropriate controller and executing it.
@@ -1021,7 +1027,7 @@ class Director implements TemplateGlobalProvider
             $destURL = str_replace('http:', 'https:', Director::absoluteURL($url));
 
             // This coupling to SapphireTest is necessary to test the destination URL and to not interfere with tests
-            if (class_exists('SilverStripe\\Dev\\SapphireTest', false) && SapphireTest::is_running_test()) {
+            if (static::is_system_under_test()) {
                 return $destURL;
             } else {
                 self::force_redirect($destURL);
@@ -1204,6 +1210,25 @@ class Director implements TemplateGlobalProvider
         } else {
             return null;
         }
+    }
+
+    /**
+     * Determines if unit tests are currently run, flag set during test bootstrap.
+     * This is used as a cheap replacement for fully mockable state
+     * in certain contiditions (e.g. access checks).
+     * Caution: When set to FALSE, certain controllers might bypass
+     * access checks, so this is a very security sensitive setting.
+     *
+     * @return boolean
+     */
+    public static function is_system_under_test()
+    {
+        return self::$system_under_test;
+    }
+
+    public static function set_is_system_under_test($state)
+    {
+        self::$system_under_test = $state;
     }
 
     /**

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -94,11 +94,6 @@ class SapphireTest extends PHPUnit_Framework_TestCase
     protected static $regular_manifest;
 
     /**
-     * @var boolean
-     */
-    protected static $is_running_test = false;
-
-    /**
      * @var ClassManifest
      */
     protected static $test_class_manifest;
@@ -182,12 +177,14 @@ class SapphireTest extends PHPUnit_Framework_TestCase
      */
     public static function is_running_test()
     {
-        return self::$is_running_test;
+        Deprecation::notice(4.0, 'SapphireTest::is_running_test is deprecated, please use Director::is_system_under_test');
+        return Director::is_system_under_test();
     }
 
     public static function set_is_running_test($bool)
     {
-        self::$is_running_test = $bool;
+        Deprecation::notice(4.0, 'SapphireTest::set_is_running_test is deprecated, please use Director::set_is_system_under_test');
+        Director::set_is_system_under_test($bool);
     }
 
     /**
@@ -247,8 +244,8 @@ class SapphireTest extends PHPUnit_Framework_TestCase
         }
 
         // Mark test as being run
-        $this->originalIsRunningTest = self::$is_running_test;
-        self::$is_running_test = true;
+        $this->originalIsRunningTest = Director::is_system_under_test();
+        Director::set_is_system_under_test(true);
 
         // i18n needs to be set to the defaults or tests fail
         i18n::set_locale(i18n::config()->uninherited('default_locale'));
@@ -597,7 +594,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
         }
 
         // Mark test as no longer being run - we use originalIsRunningTest to allow for nested SapphireTest calls
-        self::$is_running_test = $this->originalIsRunningTest;
+        Director::set_is_system_under_test($this->originalIsRunningTest);
         $this->originalIsRunningTest = null;
 
         // Reset mocked datetime
@@ -1015,10 +1012,10 @@ class SapphireTest extends PHPUnit_Framework_TestCase
      */
     public static function start()
     {
-        if (!static::is_running_test()) {
+        if (!Director::is_system_under_test()) {
             new FakeController();
             static::use_test_manifest();
-            static::set_is_running_test(true);
+            Director::set_is_system_under_test(true);
         }
     }
 

--- a/src/Dev/TaskRunner.php
+++ b/src/Dev/TaskRunner.php
@@ -29,7 +29,7 @@ class TaskRunner extends Controller
     {
         parent::init();
 
-        $isRunningTests = (class_exists('SilverStripe\\Dev\\SapphireTest', false) && SapphireTest::is_running_test());
+        $isRunningTests = Director::is_system_under_test();
         $canAccess = (
             Director::isDev()
             // We need to ensure that DevelopmentAdminTest can simulate permission failures when running

--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -6,7 +6,6 @@ use SilverStripe\Control\Director;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Manifest\ClassLoader;
-use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\Dev\Deprecation;
 use SilverStripe\Versioned\Versioned;
@@ -58,7 +57,7 @@ class DatabaseAdmin extends Controller
         // if on CLI or with the database not ready. The latter makes it less errorprone to do an
         // initial schema build without requiring a default-admin login.
         // Access to this controller is always allowed in "dev-mode", or of the user is ADMIN.
-        $isRunningTests = (class_exists('SilverStripe\\Dev\\SapphireTest', false) && SapphireTest::is_running_test());
+        $isRunningTests = Director::is_system_under_test();
         $canAccess = (
             Director::isDev()
             || !Security::database_is_ready()

--- a/src/Security/BasicAuth.php
+++ b/src/Security/BasicAuth.php
@@ -7,7 +7,6 @@ use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Config\Configurable;
-use SilverStripe\Dev\SapphireTest;
 
 /**
  * Provides an interface to HTTP basic authentication.
@@ -58,7 +57,7 @@ class BasicAuth
      */
     public static function requireLogin($realm, $permissionCode = null, $tryUsingSessionLogin = true)
     {
-        $isRunningTests = (class_exists('SilverStripe\\Dev\\SapphireTest', false) && SapphireTest::is_running_test());
+        $isRunningTests = Director::is_system_under_test();
         if (!Security::database_is_ready() || (Director::is_cli() && !$isRunningTests)) {
             return true;
         }

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -12,7 +12,6 @@ use SilverStripe\Control\Email\Mailer;
 use SilverStripe\Control\Session;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestMailer;
 use SilverStripe\Forms\ConfirmedPasswordField;
 use SilverStripe\Forms\DropdownField;
@@ -547,7 +546,7 @@ class Member extends DataObject implements TemplateGlobalProvider
     public static function autoLogin()
     {
         // Don't bother trying this multiple times
-        if (!class_exists(SapphireTest::class, false) || !SapphireTest::is_running_test()) {
+        if (!Director::is_system_under_test()) {
             self::$_already_tried_to_auto_log_in = true;
         }
 

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -13,7 +13,6 @@ use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\Debug;
 use SilverStripe\Dev\Deprecation;
-use SilverStripe\Dev\SapphireTest;
 use SilverStripe\i18n\i18n;
 
 class Requirements_Backend
@@ -1343,7 +1342,7 @@ class Requirements_Backend
         }
 
         // Tests should be combined
-        if (class_exists('SilverStripe\\Dev\\SapphireTest', false) && SapphireTest::is_running_test()) {
+        if (Director::is_system_under_test()) {
             return true;
         }
 


### PR DESCRIPTION
A first attempt at removing the coupling of SapphireTest with core code.

This should allow us to remove the `PHPUnitShim` file