### PR TITLE
BUGFIX: Prevent infinite loop

### DIFF
--- a/src/View/Parsers/Diff.php
+++ b/src/View/Parsers/Diff.php
@@ -182,6 +182,9 @@ class Diff extends \Diff
                 $newChunk = $item;
                 while ($item[strlen($item)-1] != ">") {
                     $chunk = each($candidateChunks);
+                    if ($chunk === false) {
+                        break;
+                    }
                     $item = $chunk['value'];
                     $newChunk .= ' ' . $item;
                 }


### PR DESCRIPTION
Prevent infinite loop when a < is present without a matching >