### PR TITLE
Fix for void element closing tags

### DIFF
--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -333,7 +333,13 @@ class FormField extends RequestHandler
             }
         }
 
-        if ($content || $tag != 'input') {
+        if (
+            $content ||
+            !in_array($tag, array(
+                'area', 'base', 'br', 'col', 'embed', 'hr', 'img',
+                'input', 'link', 'meta', 'param', 'source', 'track', 'wbr'
+            ))
+        ) {
             return sprintf(
                 '<%s%s>%s</%s>',
                 $tag,


### PR DESCRIPTION
Prevent html errors when FormField::create_tag('meta') is called from $MetaTags() so 
```
<meta name="generator" content="SilverStripe - http://silverstripe.org"></meta>
```
becomes
```
<meta name="generator" content="SilverStripe - http://silverstripe.org" />
```