### PR TITLE
Fix for prototype `evalResponse` detection

### DIFF
--- a/core/model/Versioned.php
+++ b/core/model/Versioned.php
@@ -275,7 +275,14 @@ class Versioned extends DataObjectDecorator {
 					}
 					*/
 				}
-				
+
+				// Remove any UNIQUE indexes from the versioned stage (just index normally) otherwise will fail to ADD
+				foreach ($indexes As $index => $val) {
+					if (is_array($val) && isset($val['type']) && strtolower($val['type']) == 'unique') {
+						$indexes[$index]['type'] = 'btree';
+					}
+				}
+
 				if($isRootClass) {
 					// Create table for all versions
 					$versionFields = array_merge(

--- a/thirdparty/prototype/prototype.js
+++ b/thirdparty/prototype/prototype.js
@@ -846,9 +846,9 @@ Ajax.Request.prototype = Object.extend(new Ajax.Base(), {
     	      /*} catch (e) {
     	        prototypeAjax.dispatchException(e);
     	      }*/
-	
-    	      if (prototypeAjax.header('Content-type') == 'text/javascript')
-    	        prototypeAjax.evalResponse();
+
+              if (prototypeAjax.header('Content-type').indexOf('text/javascript') !== -1)
+                prototypeAjax.evalResponse();
     	    }
 	    }
 	    


### PR DESCRIPTION
If the response header has a `chartset` in the *Content-Type* then it doesn't match and `evalResponse()` doesn't get run