### PR TITLE
Check for \r\n as well as just \n\n in FirstParagraph

### DIFF
--- a/model/fieldtypes/Text.php
+++ b/model/fieldtypes/Text.php
@@ -203,7 +203,10 @@ class Text extends StringField {
 			if(!$data) return "";
 
 			// grab the first paragraph, or, failing that, the whole content
-			$pos = strpos($data, "\n\n");
+			$pos = max(array(
+				strpos($data, "\n\n"),
+				strpos($data, "\r\n"),
+			));
 			if($pos) $data = substr($data, 0, $pos);
 
 			return $data;


### PR DESCRIPTION
Makes the `FirstParagraph` check a bit more robust depending on the OS used when creating the content.