### PR TITLE
Update DebugView styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@ npm-debug.log
 /.buildpath
 /.project
 /.settings
-css/GridField_print.css
-admin/thirdparty/chosen/node_modules
 node_modules/
 coverage/
 /**/*.js.map

--- a/client/styles/debug.css
+++ b/client/styles/debug.css
@@ -1,159 +1,145 @@
 /* This file is manually maintained, it is not generated from SCSS sources */
 
-body{
-  background:#eee !important;
-  margin:0;
-  overflow-x:hidden;
-  padding:0;
-  font-family:Helvetica,Arial,sans-serif;
+body {
+    margin: 0;
+    overflow-x: hidden;
+    padding: 0;
+    color: #66727d;
+    background: #f6f7f8;
+    font-size: 15px;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    line-height: 1.5;
 }
 
-.info{
-  padding:18px;
-  position:relative;
-  z-index:9999;
+h2 {
+    margin: 0 0 12px;
 }
 
-.info,.info h1{
-  margin:0 0 6px;
+h3 {
+    margin: 0 0 12px;
+    color: #333;
+    font-size: 18px;
+    line-height: 24px;
 }
 
-.info h1{
-  padding:0 32px 0 0;
-  font-size:24px;
-  text-shadow:0 1px #002137;
-  line-height:30px;
-  background: url("../images/logo_small.png") no-repeat right 3px;
+p {
+    margin-bottom: 6px;
 }
 
-.info h3{
-  color:#003050;
-  font-size:16px;
-  line-height:18px;
+ul {
+    margin: 0 0 18px;
+    padding: 0 0 0 18px;
 }
 
-.info p{
-  margin:0;
-  font-size:14px;
+b {
+    color: #4f5861;
+    font-weight: bold;
 }
 
-.info a{
-  font-weight:700;
-  text-decoration:none;
-  color:#7da4be;
+a {
+    color: #4f5861;
 }
 
-.info a:active,.info a:hover{
-  text-decoration:underline;
-  color:#7da4be;
+a:hover,
+a:active {
+    color: #121212;
 }
 
-.info li{
-  font-size:14px;
-  margin:6px 0;
+/* Info block */
+.info {
+    position: relative;
+    z-index: 9999;
+    padding: 20px;
 }
 
-.header{
-  background-color:#003050;
-  background-image:-webkit-gradient(linear,left top,left bottom,from(#002137),color-stop(10%,#003050),color-stop(90%,#003050),color-stop(90%,#002137));
-  background-image:-webkit-linear-gradient(#002137,#003050 10%,#003050 90%,#002137);
-  background-image:linear-gradient(#002137,#003050 10%,#003050 90%,#002137);
-  color:#fff;
+.info h1 {
+    margin: 0 0 6px;
+    padding: 0 32px 0 0;
+    background: url("../images/logo_small.png") no-repeat right 3px;
+    font-size: 24px;
+    line-height: 30px;
 }
 
-.header h1{
-  background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABYAAAAWCAYAAADEtGw7AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAmdJREFUeNpiYCASxJ17p8BAAmAh0sD5QAyiFYk1mJGAoQFQQwWgQoKLjIQ+kG0w0EABqIEByOKLjYWZ/////48Yg5lwuPI+uqF/f/88TqyhKGEMdWU/ECegK/r358/Va8tnx5AceVBD9wOxAbqCX18+zbm+am7HpaktD9AcEQCNUBDYAAz7CxhhDFTYAKTqkSX+//37+N3tq4Xboh33ALmfYcEAVJsA9ZkAmhtABifCLIAZ/B5Z4Z9vX1ddXjK15srMzkdAA38iudQB6jNcAJRiFEEpBxbGAsiRtNxWLh3I/ITkSpC3QUGRTyBoYfGUiJFBmJiY/wIN/IAl2S1AdgAoQr88fdjHysMjwyks3ohkBCioEsFBEXv2zUdGRiY+JEmQIQ+hLoQZdgBo2BMmFpaYnx/e9a1yVu0AhT0QM0cefjSPhYs7DEm/IAs0TFewcvOmodmKnuSevLp0uouVi3sDMEJ3AX31GZ60uLjV0DLSJ7DB9/dsalHxDrcGukYbV+B9enJ/xu5Un2tA5i1YhCKVIwbIqQkUN+Ccd7Ip7+nlRZP9QakB3UCQwrc3LoVsDrY4BdTwF8nQAiB1HogdkNX//v5tOUpZwQgMZCDFZ906S51fQVUGmjk+7Un3vwRKRkgGYi1HYMkUmKJSQMGEUQgBLWBGyur/gIp+I6VjA2g6Rs8cDNAIbYalKIzkBvIuKDnjCGqMHAdKdi8vnCgE+uwESoQykAYc0MuRlfaKVdCg+o232MRT6AugRyjQ0BKgga/RDSUJgCI39vTrRxGHHszWzahQBfLZGagFgIaJAzE/NAXhBQABBgBJL0aZBy/F5wAAAABJRU5ErkJggg==) no-repeat right 3px;
+.info h3 {
+    color: #4f5861;
+    font-size: 16px;
+    line-height: 18px;
 }
 
-.header h3{
-  color:#7da4be;
-  font-weight:400;
+/* Header */
+.header {
+    border-bottom: solid 1px #004e7f;
+    color: white;
+    background: #005a93;
 }
 
-.header a,.header a:active,.header a:hover,.header p{
-  color:#fff;
+.header h1 {
+    background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABYAAAAWCAYAAADEtGw7AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAmdJREFUeNpiYCASxJ17p8BAAmAh0sD5QAyiFYk1mJGAoQFQQwWgQoKLjIQ+kG0w0EABqIEByOKLjYWZ/////48Yg5lwuPI+uqF/f/88TqyhKGEMdWU/ECegK/r358/Va8tnx5AceVBD9wOxAbqCX18+zbm+am7HpaktD9AcEQCNUBDYAAz7CxhhDFTYAKTqkSX+//37+N3tq4Xboh33ALmfYcEAVJsA9ZkAmhtABifCLIAZ/B5Z4Z9vX1ddXjK15srMzkdAA38iudQB6jNcAJRiFEEpBxbGAsiRtNxWLh3I/ITkSpC3QUGRTyBoYfGUiJFBmJiY/wIN/IAl2S1AdgAoQr88fdjHysMjwyks3ohkBCioEsFBEXv2zUdGRiY+JEmQIQ+hLoQZdgBo2BMmFpaYnx/e9a1yVu0AhT0QM0cefjSPhYs7DEm/IAs0TFewcvOmodmKnuSevLp0uouVi3sDMEJ3AX31GZ60uLjV0DLSJ7DB9/dsalHxDrcGukYbV+B9enJ/xu5Un2tA5i1YhCKVIwbIqQkUN+Ccd7Ip7+nlRZP9QakB3UCQwrc3LoVsDrY4BdTwF8nQAiB1HogdkNX//v5tOUpZwQgMZCDFZ906S51fQVUGmjk+7Un3vwRKRkgGYi1HYMkUmKJSQMGEUQgBLWBGyur/gIp+I6VjA2g6Rs8cDNAIbYalKIzkBvIuKDnjCGqMHAdKdi8vnCgE+uwESoQykAYc0MuRlfaKVdCg+o232MRT6AugRyjQ0BKgga/RDSUJgCI39vTrRxGHHszWzahQBfLZGagFgIaJAzE/NAXhBQABBgBJL0aZBy/F5wAAAABJRU5ErkJggg==) no-repeat right 3px;
 }
 
-.build,.options,.trace{
-  padding:6px 12px;
-  background:#eee !important;
-  position:relative;
-  z-index:9999;
+.header h3 {
+    color: #7da4be;
+    font-weight: 400;
 }
 
-a{
-  color:#666;
+.header a {
+    color: white;
+    text-decoration: underline;
 }
 
-a:hover{
-  color:#222;
+.header a:active,
+.header a:hover {
+    color: white;
+    text-decoration: none;
 }
 
-a:active{
-  color:#111;
+/* Content types */
+.build,
+.options,
+.trace {
+    position: relative;
+    z-index: 9999;
+    padding: 20px;
+    background: #f6f7f8 !important;
 }
 
-p{
-  margin-bottom:6px;
+.options .description {
+    display: block;
+    font-size: 14px;
+    line-height: 1.3;
 }
 
-pre{
-  margin-bottom:20px;
-  background-color:#f5f5f5;
-  border:1px solid #eee;
-  border:1px solid rgba(0,0,0,.08);
-  color:#333;
-  padding:11px;
-  overflow:auto;
-  border-radius:4px;
-  box-shadow:inset 0 1px 1px rgba(0,0,0,.05);
+.build .success {
+    color: #3fa142;
 }
 
-pre span{
-  color:#999;
+.build .error {
+    color: #d40404;
 }
 
-pre .error{
-  color:red;
+.build .warning {
+    color: #f0ad4e;
 }
 
-h2{
-  margin:0 0 12px;
+.build .info {
+    color: #5bc0de;
 }
 
-h3{
-  margin:0 0 6px;
-  color:#333;
-  font-size:18px;
-  line-height:24px;
+/* Backtrace styles */
+pre {
+    overflow: auto;
+    margin: 0;
+    padding: 12px;
+    background-color: #e9f0f4;
+    border: 1px solid #d9dee2;
+    color: #4f5861;
+    font-size: 14px;
 }
 
-ul{
-  margin:0 0 18px;
-  padding:0 0 0 18px;
+pre span {
+    color: #999;
 }
 
-fieldset{
-  border:1px solid #b2b2b2;
-  margin-bottom:18px;
-  padding:17px;
-}
-
-.pass{
-  color:#060;
-  background:#e2f9e3;
-  border:1px solid #8dd38d;
-  border-radius:4px;
-}
-
-.fail,.pass{
-  margin-top:18px;
-  padding:2px 20px 2px 40px;
-}
-
-.fail{
-  color:#c80700;
-  background:#ffe9e9;
-  border:1px solid #c80700;
-  border-radius:4px;
+pre .error {
+    color: #d40404;
 }

--- a/src/Dev/Backtrace.php
+++ b/src/Dev/Backtrace.php
@@ -178,7 +178,7 @@ class Backtrace
                 }
             }
 
-            $funcName .= "(" . implode(",", $args)  .")";
+            $funcName .= "(" . implode(", ", $args)  .")";
         }
 
         return $funcName;

--- a/src/Dev/DevelopmentAdmin.php
+++ b/src/Dev/DevelopmentAdmin.php
@@ -182,7 +182,7 @@ class DevelopmentAdmin extends Controller
             $renderer = DebugView::create();
             echo $renderer->renderHeader();
             echo $renderer->renderInfo("Defaults Builder", Director::absoluteBaseURL());
-            echo "<div style=\"margin: 0 2em\">";
+            echo "<div class=\"build\">";
         }
 
         $da->buildDefaults();

--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -793,30 +793,30 @@ abstract class DBSchemaManager
             } else {
                 switch ($type) {
                     case "created":
-                        $color = "green";
+                        $class = "success";
                         break;
                     case "obsolete":
-                        $color = "red";
+                        $class = "error";
                         break;
                     case "notice":
-                        $color = "orange";
+                        $class = "warning";
                         break;
                     case "error":
-                        $color = "red";
+                        $class = "error";
                         break;
                     case "deleted":
-                        $color = "red";
+                        $class = "error";
                         break;
                     case "changed":
-                        $color = "blue";
+                        $class = "info";
                         break;
                     case "repaired":
-                        $color = "blue";
+                        $class = "info";
                         break;
                     default:
-                        $color = "";
+                        $class = "";
                 }
-                echo "<li style=\"color: $color\">$message</li>";
+                echo "<li class=\"$class\">$message</li>";
             }
         }
     }

--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -167,9 +167,22 @@ class DatabaseAdmin extends Controller
     {
         $dataClasses = ClassInfo::subclassesFor('SilverStripe\ORM\DataObject');
         array_shift($dataClasses);
+
+        if (!Director::is_cli()) {
+            echo "<ul>";
+        }
+
         foreach ($dataClasses as $dataClass) {
             singleton($dataClass)->requireDefaultRecords();
-            print "Defaults loaded for $dataClass<br/>";
+            if (Director::is_cli()) {
+                echo "Defaults loaded for $dataClass\n";
+            } else {
+                echo "<li>Defaults loaded for $dataClass</li>\n";
+            }
+        }
+
+        if (!Director::is_cli()) {
+            echo "</ul>";
         }
     }
 
@@ -253,7 +266,7 @@ class DatabaseAdmin extends Controller
             if (Director::is_cli()) {
                 echo "\nCREATING DATABASE TABLES\n\n";
             } else {
-                echo "\n<p><b>Creating database tables</b></p>\n\n";
+                echo "\n<p><b>Creating database tables</b></p><ul>\n\n";
             }
         }
 
@@ -287,12 +300,16 @@ class DatabaseAdmin extends Controller
         });
         ClassInfo::reset_db_cache();
 
+        if (!$quiet && !Director::is_cli()) {
+            echo "</ul>";
+        }
+
         if ($populate) {
             if (!$quiet) {
                 if (Director::is_cli()) {
                     echo "\nCREATING DATABASE RECORDS\n\n";
                 } else {
-                    echo "\n<p><b>Creating database records</b></p>\n\n";
+                    echo "\n<p><b>Creating database records</b></p><ul>\n\n";
                 }
             }
 
@@ -343,6 +360,10 @@ class DatabaseAdmin extends Controller
                         DB::prepared_query($query, [$newClassName, $oldClassName]);
                     }
                 }
+            }
+
+            if (!$quiet && !Director::is_cli()) {
+                echo "</ul>";
             }
         }
 

--- a/tests/php/Dev/BacktraceTest.php
+++ b/tests/php/Dev/BacktraceTest.php
@@ -22,7 +22,7 @@ class BacktraceTest extends SapphireTest
             )
         );
         $this->assertEquals(
-            'MyClass->myFunction(1,more than 20 charact...)',
+            'MyClass->myFunction(1, more than 20 charact...)',
             Backtrace::full_func_name($func, true, 20)
         );
     }


### PR DESCRIPTION
Nothing major, just more closely matched to the new CMS styles. I didn’t think it was worth re-introducing a build system to `silverstripe-framework` for this one CSS file... Colours are all lifted from the CMS.

I’ve fixed some invalid HTML (`<li>`s not wrapped in `<ul>`) and removed a few things that look like “legacy” styles (as I can’t find anywhere they’re used in core): `fieldset`, `.fail` and `.pass`.

Before/afters:

<img width="1400" alt="screen shot 2017-05-16 at 17 04 28" src="https://cloud.githubusercontent.com/assets/1655548/26116317/a7f02f24-3a5a-11e7-9e42-0e766f5ee27a.png">
<img width="1665" alt="screen shot 2017-05-16 at 17 02 57" src="https://cloud.githubusercontent.com/assets/1655548/26116324/a9e24916-3a5a-11e7-8f2b-7868f7ee1201.png">

---

<img width="1164" alt="screen shot 2017-05-16 at 17 04 38" src="https://cloud.githubusercontent.com/assets/1655548/26116339/b80fd7ec-3a5a-11e7-9638-9a7dcf4ecee0.png">
<img width="1150" alt="screen shot 2017-05-16 at 17 03 36" src="https://cloud.githubusercontent.com/assets/1655548/26116340/b965ca84-3a5a-11e7-9464-69d8c377cdcc.png">

---

<img width="1229" alt="screen shot 2017-05-16 at 17 04 49" src="https://cloud.githubusercontent.com/assets/1655548/26116354/c33759b0-3a5a-11e7-904b-eed2f8d4f5b7.png">
<img width="1218" alt="screen shot 2017-05-16 at 17 03 10" src="https://cloud.githubusercontent.com/assets/1655548/26116357/c6229b94-3a5a-11e7-9fa1-5f96a71a904c.png">
