### PR TITLE
Process actions on Form subclasses

### DIFF
--- a/src/Forms/FormRequestHandler.php
+++ b/src/Forms/FormRequestHandler.php
@@ -236,6 +236,11 @@ class FormRequestHandler extends RequestHandler
                 return $this->$funcName($vars, $this->form, $request);
             }
 
+            // Otherwise, try a handler method on the form itself
+            if ($this->form->hasMethod($funcName)) {
+                return $this->form->$funcName($vars, $this->form, $request);
+            }
+
             // Check for inline actions
             $field = $this->checkFieldsForAction($this->form->Fields(), $funcName);
             if ($field) {

--- a/tests/php/Forms/FormRequestHandlerTest.php
+++ b/tests/php/Forms/FormRequestHandlerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SilverStripe\Forms\Tests;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\FormAction;
+use SilverStripe\Forms\FormRequestHandler;
+use SilverStripe\Forms\Tests\FormRequestHandlerTest\TestForm;
+use SilverStripe\Forms\Tests\FormRequestHandlerTest\TestFormRequestHandler;
+
+class FormRequestHandlerTest extends SapphireTest
+{
+    public function testCallsActionOnFormHandler()
+    {
+        $form = new TestForm(
+            new Controller(),
+            'Form',
+            new FieldList(),
+            new FieldList(new FormAction('mySubmitOnFormHandler'))
+        );
+        $form->disableSecurityToken();
+        $handler = new TestFormRequestHandler($form);
+        $request = new HTTPRequest('POST', '/', null, ['action_mySubmitOnFormHandler' => 1]);
+        $response = $handler->httpSubmission($request);
+        $this->assertFalse($response->isError());
+    }
+
+    public function testCallsActionOnForm()
+    {
+        $form = new TestForm(
+            new Controller(),
+            'Form',
+            new FieldList(),
+            new FieldList(new FormAction('mySubmitOnForm'))
+        );
+        $form->disableSecurityToken();
+        $handler = new FormRequestHandler($form);
+        $request = new HTTPRequest('POST', '/', null, ['action_mySubmitOnForm' => 1]);
+        $response = $handler->httpSubmission($request);
+        $this->assertFalse($response->isError());
+    }
+}

--- a/tests/php/Forms/FormRequestHandlerTest/FormRequestHandler.php
+++ b/tests/php/Forms/FormRequestHandlerTest/FormRequestHandler.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\FormRequestHandlerTest;
+
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Forms\FormRequestHandler;
+
+class TestFormRequestHandler extends FormRequestHandler
+{
+    public function mySubmitOnFormHandler()
+    {
+        return new HTTPResponse('success', 200);
+    }
+}

--- a/tests/php/Forms/FormRequestHandlerTest/TestForm.php
+++ b/tests/php/Forms/FormRequestHandlerTest/TestForm.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\FormRequestHandlerTest;
+
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Forms\Form;
+
+class TestForm extends Form
+{
+    public function mySubmitOnForm()
+    {
+        return new HTTPResponse('success', 200);
+    }
+}


### PR DESCRIPTION
Regression introduced through https://github.com/silverstripe/silverstripe-framework/issues/6362.

One area where this surfaced: Importing members in admin/security (through MemberImportForm).

Quote from the RFC:

```
Thus the order of action precedence becomes

action callback
action on the Form
action on the FormRequestHandler
action on any parent controller (if given)
```