### PR TITLE
Cleaning up DB index definition

### DIFF
--- a/docs/en/02_Developer_Guides/00_Model/12_Indexes.md
+++ b/docs/en/02_Developer_Guides/00_Model/12_Indexes.md
@@ -29,14 +29,14 @@ descriptor. There are several supported notations:
 
 	class MyObject extends DataObject {
 
-		private static $indexes = array(
+		private static $indexes = [
 			'<column-name>' => true,
-			'<index-name>' => 'unique("<column-name>")'
-			'<index-name>' => array(
+			'<index-name>' => [
 				'type' => '<type>', 
-				'value' => '"<column-name>"'
-			),
-		);
+				'columns' => ['<column-name>', '<other-column-name>'],
+			],
+			'<index-name>' => ['<column-name>', '<other-column-name>'],
+		];
 	}
 
 The `<column-name>` is used to put a standard non-unique index on the column specified. For complex or large tables 
@@ -57,17 +57,14 @@ support the following:
 
 	class MyTestObject extends DataObject {
 
-		private static $db = array(
+		private static $db = [
 			'MyField' => 'Varchar',
 			'MyOtherField' => 'Varchar',
-		);
+		];
 
-		private static $indexes = array(
-			'MyIndexName' => array(
-				'type' => 'index', 
-				'value' => '"MyField","MyOtherField"'
-			)
-		);
+		private static $indexes = [
+			'MyIndexName' => ['MyField', 'MyOtherField'],
+		];
 	}
 
 ## Complex/Composite Indexes

--- a/docs/en/02_Developer_Guides/12_Search/02_FulltextSearch.md
+++ b/docs/en/02_Developer_Guides/12_Search/02_FulltextSearch.md
@@ -57,8 +57,7 @@ Example DataObject:
 		private static $indexes = array(
 			'SearchFields' => array(
 				'type' => 'fulltext',
-				'name' => 'SearchFields',
-				'value' => '"Title", "Content"',
+				'columns' => ['Title', 'Content'],
 			)
 		);
 

--- a/src/ORM/Filters/FulltextFilter.php
+++ b/src/ORM/Filters/FulltextFilter.php
@@ -20,9 +20,11 @@ use Exception;
  * database table, using the {$indexes} hash in your DataObject subclass:
  *
  * <code>
- *   private static $indexes = array(
- *      'SearchFields' => 'fulltext(Name, Title, Description)'
- *   );
+ *   private static $indexes = [
+ *      'SearchFields' => [
+ *          'type' => 'fulltext',
+ *          'columns' => ['Name', 'Title', 'Description'],
+ *   ];
  * </code>
  *
  * @todo Add support for databases besides MySQL

--- a/src/ORM/Filters/FulltextFilter.php
+++ b/src/ORM/Filters/FulltextFilter.php
@@ -2,9 +2,9 @@
 
 namespace SilverStripe\ORM\Filters;
 
+use SilverStripe\Core\Convert;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\Core\Config\Config;
 use Exception;
 
 /**
@@ -63,27 +63,21 @@ class FulltextFilter extends SearchFilter
     */
     public function getDbName()
     {
-        $indexes = Config::inst()->get($this->model, "indexes");
-        if (is_array($indexes) && array_key_exists($this->getName(), $indexes)) {
+        $indexes = DataObject::getSchema()->databaseIndexes($this->model);
+        if (array_key_exists($this->getName(), $indexes)) {
             $index = $indexes[$this->getName()];
-            if (is_array($index) && array_key_exists("value", $index)) {
-                return $this->prepareColumns($index['value']);
-            } else {
-                // Parse a fulltext string (eg. fulltext ("ColumnA", "ColumnB")) to figure out which columns
-                // we need to search.
-                if (preg_match('/^fulltext\s+\((.+)\)$/i', $index, $matches)) {
-                    return $this->prepareColumns($matches[1]);
-                } else {
-                    throw new Exception(sprintf(
-                        "Invalid fulltext index format for '%s' on '%s'",
-                        $this->getName(),
-                        $this->model
-                    ));
-                }
-            }
+        } else {
+            return parent::getDbName();
         }
-
-        return parent::getDbName();
+        if (is_array($index) && array_key_exists('columns', $index)) {
+            return $this->prepareColumns($index['columns']);
+        } else {
+            throw new Exception(sprintf(
+                "Invalid fulltext index format for '%s' on '%s'",
+                var_export($this->getName(), true),
+                var_export($this->model, true)
+            ));
+        }
     }
 
     /**
@@ -95,11 +89,10 @@ class FulltextFilter extends SearchFilter
      */
     protected function prepareColumns($columns)
     {
-        $cols = preg_split('/"?\s*,\s*"?/', trim($columns, '(") '));
-        $table = DataObject::getSchema()->tableForField($this->model, current($cols));
-        $cols = array_map(function ($col) use ($table) {
-            return sprintf('"%s"."%s"', $table, $col);
-        }, $cols);
-        return implode(',', $cols);
+        $table = DataObject::getSchema()->tableForField($this->model, current($columns));
+        $columns = array_map(function ($column) use ($table) {
+            return Convert::symbol2sql("$table.$column");
+        }, $columns);
+        return implode(',', $columns);
     }
 }

--- a/tests/php/ORM/DataObjectSchemaGenerationTest.php
+++ b/tests/php/ORM/DataObjectSchemaGenerationTest.php
@@ -175,11 +175,11 @@ class DataObjectSchemaGenerationTest extends SapphireTest
         // Update the SearchFields index here
         TestIndexObject::config()->update(
             'indexes',
-            array(
-            'SearchFields' => array(
-                'value' => 'Title'
-            )
-            )
+            [
+                'SearchFields' => [
+                    'columns' => ['Title'],
+                ],
+            ]
         );
 
         // Verify that the above index change triggered a schema update

--- a/tests/php/ORM/DataObjectSchemaGenerationTest/TestIndexObject.php
+++ b/tests/php/ORM/DataObjectSchemaGenerationTest/TestIndexObject.php
@@ -7,29 +7,35 @@ use SilverStripe\Dev\TestOnly;
 class TestIndexObject extends TestObject implements TestOnly
 {
     private static $table_name = 'DataObjectSchemaGenerationTest_IndexDO';
-    private static $db = array(
+    private static $db = [
         'Title' => 'Varchar(255)',
-        'Content' => 'Text'
-    );
+        'Content' => 'Text',
+    ];
 
-    private static $indexes = array(
-        'NameIndex' => 'unique ("Title")',
-        'SearchFields' => array(
+    private static $indexes = [
+        'NameIndex' => [
+            'type' => 'unique',
+            'columns' => ['Title'],
+        ],
+        'SearchFields' => [
             'type' => 'fulltext',
             'name' => 'SearchFields',
-            'value' => '"Title","Content"'
-        )
-    );
+            'columns' => ['Title', 'Content'],
+        ],
+    ];
 
     /**
- * @config
-*/
-    private static $indexes_alt = array(
-        'NameIndex' => array(
+     * @config
+     */
+    private static $indexes_alt = [
+        'NameIndex' => [
             'type' => 'unique',
             'name' => 'NameIndex',
-            'value' => '"Title"'
-        ),
-        'SearchFields' => 'fulltext ("Title","Content")'
-    );
+            'columns' => ['Title'],
+        ],
+        'SearchFields' => [
+            'type' => 'fulltext',
+            'columns' => ['Title', 'Content'],
+        ],
+    ];
 }

--- a/tests/php/ORM/DataObjectSchemaTest.php
+++ b/tests/php/ORM/DataObjectSchemaTest.php
@@ -6,6 +6,7 @@ use SilverStripe\Core\ClassInfo;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataObjectSchema;
+use SilverStripe\ORM\Tests\DataObjectSchemaTest\AllIndexes;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\BaseClass;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\BaseDataClass;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\ChildClass;
@@ -23,7 +24,7 @@ use SilverStripe\ORM\Tests\DataObjectSchemaTest\WithRelation;
  */
 class DataObjectSchemaTest extends SapphireTest
 {
-    protected static $extra_dataobjects = array(
+    protected static $extra_dataobjects = [
         // Classes in base namespace
         BaseClass::class,
         BaseDataClass::class,
@@ -33,8 +34,9 @@ class DataObjectSchemaTest extends SapphireTest
         NoFields::class,
         WithCustomTable::class,
         WithRelation::class,
-        DefaultTableName::class
-    );
+        DefaultTableName::class,
+        AllIndexes::class,
+    ];
 
     /**
      * Test table name generation
@@ -233,5 +235,40 @@ class DataObjectSchemaTest extends SapphireTest
 
         $this->setExpectedException('InvalidArgumentException');
         $schema->baseDataClass(DataObject::class);
+    }
+
+    public function testDatabaseIndexes()
+    {
+        $indexes = DataObject::getSchema()->databaseIndexes(AllIndexes::class);
+        $this->assertCount(5, $indexes);
+        $this->assertArrayHasKey('ClassName', $indexes);
+        $this->assertEquals([
+            'type' => 'index',
+            'columns' => ['ClassName'],
+        ], $indexes['ClassName']);
+
+        $this->assertArrayHasKey('Content', $indexes);
+        $this->assertEquals([
+            'type' => 'index',
+            'columns' => ['Content'],
+        ], $indexes['Content']);
+
+        $this->assertArrayHasKey('IndexCols', $indexes);
+        $this->assertEquals([
+            'type' => 'index',
+            'columns' => ['Title', 'Content'],
+        ], $indexes['IndexCols']);
+
+        $this->assertArrayHasKey('IndexUnique', $indexes);
+        $this->assertEquals([
+            'type' => 'unique',
+            'columns' => ['Number'],
+        ], $indexes['IndexUnique']);
+
+        $this->assertArrayHasKey('IndexNormal', $indexes);
+        $this->assertEquals([
+            'type' => 'index',
+            'columns' => ['Title'],
+        ], $indexes['IndexNormal']);
     }
 }

--- a/tests/php/ORM/DataObjectSchemaTest/AllIndexes.php
+++ b/tests/php/ORM/DataObjectSchemaTest/AllIndexes.php
@@ -1,0 +1,28 @@
+<?php
+namespace SilverStripe\ORM\Tests\DataObjectSchemaTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class AllIndexes extends DataObject implements TestOnly
+{
+    private static $table_name = 'DataObjectSchemaTest_AllIndexes';
+
+    private static $db = [
+        'Title' => 'Varchar',
+        'Content' => 'Varchar',
+        'Number' => 'Int',
+    ];
+
+    private static $indexes = [
+        'Content' => true,
+        'IndexCols' => ['Title', 'Content'],
+        'IndexUnique' => [
+            'type' => 'unique',
+            'columns' => ['Number'],
+        ],
+        'IndexNormal' => [
+            'columns' => ['Title'],
+        ],
+    ];
+}

--- a/tests/php/ORM/Filters/FulltextFilterTest/TestObject.php
+++ b/tests/php/ORM/Filters/FulltextFilterTest/TestObject.php
@@ -11,22 +11,28 @@ class TestObject extends DataObject implements TestOnly
 
     private static $table_name = 'FulltextFilterTest_DataObject';
 
-    private static $db = array(
-        "ColumnA" => "Varchar(255)",
-        "ColumnB" => "HTMLText",
-        "ColumnC" => "Varchar(255)",
-        "ColumnD" => "HTMLText",
-        "ColumnE" => 'Varchar(255)'
-    );
+    private static $db = [
+        'ColumnA' => 'Varchar(255)',
+        'ColumnB' => 'HTMLText',
+        'ColumnC' => 'Varchar(255)',
+        'ColumnD' => 'HTMLText',
+        'ColumnE' => 'Varchar(255)',
+    ];
 
     private static $indexes = array(
-        'SearchFields' => array(
+        'SearchFields' => [
             'type' => 'fulltext',
             'name' => 'SearchFields',
-            'value' => '"ColumnA", "ColumnB"',
-        ),
-        'OtherSearchFields' => 'fulltext ("ColumnC", "ColumnD")',
-        'SingleIndex' => 'fulltext ("ColumnE")'
+            'columns' => ['ColumnA', 'ColumnB'],
+        ],
+        'OtherSearchFields' => [
+            'type' => 'fulltext',
+            'columns' => ['ColumnC', 'ColumnD'],
+        ],
+        'SingleIndex' => [
+            'type' => 'fulltext',
+            'columns' => ['ColumnE'],
+        ],
     );
 
     private static $create_table_options = array(

--- a/tests/php/ORM/Search/FulltextSearchableTest.php
+++ b/tests/php/ORM/Search/FulltextSearchableTest.php
@@ -6,6 +6,7 @@ use SilverStripe\Assets\File;
 use SilverStripe\ORM\Connect\MySQLSchemaManager;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Search\FulltextSearchable;
 
 class FulltextSearchableTest extends SapphireTest
@@ -48,5 +49,14 @@ class FulltextSearchableTest extends SapphireTest
 
         File::remove_extension(FulltextSearchable::class);
         $this->assertFalse(File::has_extension(FulltextSearchable::class));
+    }
+
+    public function testIndexesAdded()
+    {
+        $indexes = DataObject::getSchema()->databaseIndexes(File::class);
+        $this->assertArrayHasKey('SearchFields', $indexes);
+        $this->assertCount(2, $indexes['SearchFields']['columns']);
+        $this->assertContains('Name', $indexes['SearchFields']['columns']);
+        $this->assertContains('Title', $indexes['SearchFields']['columns']);
     }
 }


### PR DESCRIPTION
Currently there are 3 ways to define custom indexes on a `DataObject`:

```php
private static $indexes = [
    'FieldName' => true, // a normal index on column 'FieldName'
    'IndexName' => 'type ("FieldName")', // a 'type' index on field 'FieldName' called 'IndexName'
    'AnotherIndex' => [
        'name' => 'SomeNameNeverReallyUsed',
        'type' => 'type',
        'value' => '"FieldName"',
    ], // a 'type' index on field 'FieldName' called 'AnotherIndex'
];
```

Further, the index specs are built up in `DataObject::databaseIndexes()` and other parts of `DBSchemaManager`.

### Issues with this approach

1. 3 ways to define an index is too many adding to confusion and lack of consistency within code bases
2. These definition strings are closely related to literal DB strings, which we should be abstracting away
3. 'value' as a key is confusing and doesn't self document.

### Solutions

1. I've tightened up the API for defining indexes, there are now only two options.
   - The concise `'FieldName' => true` option for creating a standard index
   - The full option of defining an index spec:
```php
'indexname' => [
    'type' => 'index', //optional
    'columns' => ['FieldName'],
]
```
2. I've moved the index spec generation onto `DataObjectSchema` so it lives alongside the other DO -> Database schema mapping logic.

### Todo:
- [ ] Update dependent DB drivers
- [x] Update other core modules
- [x] Update docs


### Related PRS:
- [x] https://github.com/silverstripe/silverstripe-versioned/pull/13
- [x] https://github.com/silverstripe/silverstripe-postgresql/pull/68