### PR TITLE
API PSR-11 compliance (fixes #6594)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     "ext-tokenizer": "*",
     "ext-ctype": "*",
     "ext-hash": "*",
-    "ext-session": "*"
+    "ext-session": "*",
+    "psr/container-implementation": "1.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",
@@ -47,6 +48,9 @@
     "silverstripe/behat-extension": "^3",
     "silverstripe/serve": "dev-master",
     "se/selenium-server-standalone": "2.41.0"
+  },
+  "provide": {
+    "psr/container-implementation": "1.0.0"
   },
   "extra": {
     "branch-alias": {

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -1292,6 +1292,9 @@ After (`mysite/_config/config.yml`):
 * Removed `CreditCardField`, `CountryDropdownField`, `PhoneNumberField`, `MemberDatetimeOptionsetField`, `InlineFormAction`.
   Use custom code instead
 * Removed `ResetFormAction`, use `FormAction::create()->setAttribute('type', 'reset')` instead
+* `Injector` now complies with [PSR-11](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md).
+  Accordingly, `hasService()` has been renamed to `has()`, and `get()` will throw
+  `SilverStripe\Core\Injector\InjectorNotFoundException` when the service can't be found.
 
 #### <a name="overview-general-deprecated"></a>General and Core Deprecated API
 

--- a/src/Core/Injector/InjectionCreator.php
+++ b/src/Core/Injector/InjectionCreator.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Core\Injector;
 
 use ReflectionClass;
+use ReflectionException;
 
 /**
  * A class for creating new objects by the injector.
@@ -12,7 +13,11 @@ class InjectionCreator implements Factory
 
     public function create($class, array $params = array())
     {
-        $reflector = new ReflectionClass($class);
+        try {
+            $reflector = new ReflectionClass($class);
+        } catch (ReflectionException $e) {
+            throw new InjectorNotFoundException($e);
+        }
 
         if (count($params)) {
             return $reflector->newInstanceArgs($params);

--- a/src/Core/Injector/InjectorNotFoundException.php
+++ b/src/Core/Injector/InjectorNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace SilverStripe\Core\Injector;
+
+use Psr\Container\NotFoundExceptionInterface;
+
+class InjectorNotFoundException extends \Exception implements NotFoundExceptionInterface
+{
+}

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\ORM\Tests;
 
 use SilverStripe\Core\Convert;
+use SilverStripe\Core\Injector\InjectorNotFoundException;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Filterable;
@@ -744,7 +745,7 @@ class DataListTest extends SapphireTest
     public function testSimpleFilterWithNonExistingComparisator()
     {
         $this->setExpectedException(
-            'ReflectionException',
+            InjectorNotFoundException::class,
             'Class DataListFilter.Bogus does not exist'
         );
         $list = TeamComment::get();
@@ -755,7 +756,7 @@ class DataListTest extends SapphireTest
     {
         // Invalid modifiers are treated as failed filter construction
         $this->setExpectedException(
-            'ReflectionException',
+            InjectorNotFoundException::class,
             'Class DataListFilter.invalidmodifier does not exist'
         );
         $list = TeamComment::get();


### PR DESCRIPTION
Note that our usage of `$asSingleton` in `get()` is fine. Quote from the PSR:

> Two successive calls to get with the same identifier SHOULD return the same value. However, depending on the implementor design and/or user configuration, different values might be returned, so user SHOULD NOT rely on getting the same value on 2 successive calls.