### PR TITLE
API Consistent use of inst() naming across framework

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/03_Requirements.md
+++ b/docs/en/02_Developer_Guides/01_Templates/03_Requirements.md
@@ -212,7 +212,7 @@ You can also combine CSS files into a media-specific stylesheets as you would wi
 the third paramter of the `combine_files` function:
 
 ```php
-$loader = ThemeResourceLoader::instance();
+$loader = ThemeResourceLoader::inst();
 $themes = SSViewer::get_themes();
 
 $printStylesheets = array(
@@ -237,7 +237,7 @@ You can also add the 'async' and/or 'defer' attributes to combined Javascript fi
 `Requirements::javascript` call - use the third paramter of the `combine_files` function:
 
 ```php
-$loader = ThemeResourceLoader::instance();
+$loader = ThemeResourceLoader::inst();
 $themes = SSViewer::get_themes();
 
 $scripts = array(

--- a/docs/en/02_Developer_Guides/16_Execution_Pipeline/02_Manifests.md
+++ b/docs/en/02_Developer_Guides/16_Execution_Pipeline/02_Manifests.md
@@ -37,7 +37,7 @@ It finds the following information:
  * All implementors of an interface
  * All module configuration files
 
-The gathered information can be accessed through [api:ClassLoader::instance()],
+The gathered information can be accessed through [api:ClassLoader::inst()],
 as well as [api:ClassInfo]. Some useful commands of the `ClassInfo` API:
 
  * `ClassInfo::subclassesFor($class)`: Returns a list of classes that inherit from the given class

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -1201,7 +1201,7 @@ After (`mysite/_config/config.yml`):
   See upgrading notes below.
 * Falsey config values (null, 0, false, etc) can now replace non-falsey values.
 * Introduced new ModuleLoader manifest, which allows modules to be found via composer name.
- E.g. `$cms = ModuleLoader::instance()->getManifest()->getModule('silverstripe/cms')`
+ E.g. `$cms = ModuleLoader::inst()->getManifest()->getModule('silverstripe/cms')`
 * `ClassManifest::getOwnerModule()` now returns a `Module` object instance.
 * Certain methods have been moved from `Controller` to `RequestHandler`:
   * `Link`

--- a/src/Core/ClassInfo.php
+++ b/src/Core/ClassInfo.php
@@ -27,7 +27,7 @@ class ClassInfo
      */
     public static function allClasses()
     {
-        return ClassLoader::instance()->getManifest()->getClasses();
+        return ClassLoader::inst()->getManifest()->getClasses();
     }
 
     /**
@@ -38,7 +38,7 @@ class ClassInfo
      */
     public static function exists($class)
     {
-        return class_exists($class, false) || interface_exists($class, false) || ClassLoader::instance()->getItemPath($class);
+        return class_exists($class, false) || interface_exists($class, false) || ClassLoader::inst()->getItemPath($class);
     }
 
     /**
@@ -164,7 +164,7 @@ class ClassInfo
 
         //normalise class case
         $className = self::class_name($nameOrObject);
-        $descendants = ClassLoader::instance()->getManifest()->getDescendantsOf($className);
+        $descendants = ClassLoader::inst()->getManifest()->getDescendantsOf($className);
         $result      = array($className => $className);
 
         if ($descendants) {
@@ -231,7 +231,7 @@ class ClassInfo
      */
     public static function implementorsOf($interfaceName)
     {
-        return ClassLoader::instance()->getManifest()->getImplementorsOf($interfaceName);
+        return ClassLoader::inst()->getManifest()->getImplementorsOf($interfaceName);
     }
 
     /**
@@ -260,7 +260,7 @@ class ClassInfo
     {
         $absFilePath    = Director::getAbsFile($filePath);
         $matchedClasses = array();
-        $manifest       = ClassLoader::instance()->getManifest()->getClasses();
+        $manifest       = ClassLoader::inst()->getManifest()->getClasses();
 
         foreach ($manifest as $class => $compareFilePath) {
             if ($absFilePath == $compareFilePath) {
@@ -284,7 +284,7 @@ class ClassInfo
     {
         $absFolderPath  = Director::getAbsFile($folderPath);
         $matchedClasses = array();
-        $manifest       = ClassLoader::instance()->getManifest()->getClasses();
+        $manifest       = ClassLoader::inst()->getManifest()->getClasses();
 
         foreach ($manifest as $class => $compareFilePath) {
             if (stripos($compareFilePath, $absFolderPath) === 0) {

--- a/src/Core/Config/Config.php
+++ b/src/Core/Config/Config.php
@@ -35,7 +35,7 @@ abstract class Config
      */
     public static function inst()
     {
-        return ConfigLoader::instance()->getManifest();
+        return ConfigLoader::inst()->getManifest();
     }
 
     /**
@@ -73,7 +73,7 @@ abstract class Config
     {
         // Clone current config and nest
         $new = self::inst()->nest();
-        ConfigLoader::instance()->pushManifest($new);
+        ConfigLoader::inst()->pushManifest($new);
         return $new;
     }
 
@@ -86,7 +86,7 @@ abstract class Config
     public static function unnest()
     {
         // Unnest unless we would be left at 0 manifests
-        $loader = ConfigLoader::instance();
+        $loader = ConfigLoader::inst();
         if ($loader->countManifests() < 2) {
             user_error(
                 "Unable to unnest root Config, please make sure you don't have mis-matched nest/unnest",

--- a/src/Core/Config/ConfigLoader.php
+++ b/src/Core/Config/ConfigLoader.php
@@ -23,7 +23,7 @@ class ConfigLoader
     /**
      * @return self
      */
-    public static function instance()
+    public static function inst()
     {
         return self::$instance ? self::$instance : self::$instance = new self();
     }

--- a/src/Core/Config/CoreConfigFactory.php
+++ b/src/Core/Config/CoreConfigFactory.php
@@ -99,7 +99,7 @@ class CoreConfigFactory
     protected function buildYamlTransformer()
     {
         // Get all module dirs
-        $modules = ModuleLoader::instance()->getManifest()->getModules();
+        $modules = ModuleLoader::inst()->getManifest()->getModules();
         $dirs = [];
         foreach ($modules as $module) {
             // Load from _config dirs
@@ -118,7 +118,7 @@ class CoreConfigFactory
     public function buildStaticTransformer()
     {
         return new PrivateStaticTransformer(function () {
-            $classes = ClassLoader::instance()->getManifest()->getClasses();
+            $classes = ClassLoader::inst()->getManifest()->getClasses();
             return array_keys($classes);
         });
     }
@@ -175,7 +175,7 @@ class CoreConfigFactory
                 return strtolower($current) === strtolower($env);
             })
             ->addRule('moduleexists', function ($module) {
-                return ModuleLoader::instance()->getManifest()->moduleExists($module);
+                return ModuleLoader::inst()->getManifest()->moduleExists($module);
             });
     }
 }

--- a/src/Core/Core.php
+++ b/src/Core/Core.php
@@ -82,23 +82,23 @@ $manifestCacheFactory = new ManifestCacheFactory([
 $manifest = new ClassManifest(BASE_PATH, false, $flush, $manifestCacheFactory);
 
 // Register SilverStripe's class map autoload
-$loader = ClassLoader::instance();
+$loader = ClassLoader::inst();
 $loader->registerAutoloader();
 $loader->pushManifest($manifest);
 
 // Init module manifest
 $moduleManifest = new ModuleManifest(BASE_PATH, false, $flush, $manifestCacheFactory);
-ModuleLoader::instance()->pushManifest($moduleManifest);
+ModuleLoader::inst()->pushManifest($moduleManifest);
 
 // Build config manifest
 $configManifest = CoreConfigFactory::inst()->createRoot($flush, $manifestCacheFactory);
-ConfigLoader::instance()->pushManifest($configManifest);
+ConfigLoader::inst()->pushManifest($configManifest);
 
 // After loading config, boot _config.php files
-ModuleLoader::instance()->getManifest()->activateConfig();
+ModuleLoader::inst()->getManifest()->activateConfig();
 
 // Load template manifest
-SilverStripe\View\ThemeResourceLoader::instance()->addSet('$default', new SilverStripe\View\ThemeManifest(
+SilverStripe\View\ThemeResourceLoader::inst()->addSet('$default', new SilverStripe\View\ThemeManifest(
     BASE_PATH,
     project(),
     false,

--- a/src/Core/Manifest/ClassLoader.php
+++ b/src/Core/Manifest/ClassLoader.php
@@ -26,7 +26,7 @@ class ClassLoader
     /**
      * @return ClassLoader
      */
-    public static function instance()
+    public static function inst()
     {
         return self::$instance ? self::$instance : self::$instance = new self();
     }

--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -330,7 +330,7 @@ class ClassManifest
         $rootModule = null;
 
         // Find based on loaded modules
-        $modules = ModuleLoader::instance()->getManifest()->getModules();
+        $modules = ModuleLoader::inst()->getManifest()->getModules();
         foreach ($modules as $module) {
             // Leave root module as fallback
             if (empty($module->getRelativePath())) {

--- a/src/Core/Manifest/ModuleLoader.php
+++ b/src/Core/Manifest/ModuleLoader.php
@@ -20,21 +20,21 @@ class ModuleLoader
     /**
      * @return self
      */
-    public static function instance()
+    public static function inst()
     {
         return self::$instance ? self::$instance : self::$instance = new self();
     }
 
     /**
      * Get module by name from the current manifest.
-     * Alias for ::instance()->getManifest()->getModule()
+     * Alias for ::inst()->getManifest()->getModule()
      *
      * @param string $module
      * @return Module
      */
     public static function getModule($module)
     {
-        return static::instance()->getManifest()->getModule($module);
+        return static::inst()->getManifest()->getModule($module);
     }
 
     /**

--- a/src/Dev/Deprecation.php
+++ b/src/Dev/Deprecation.php
@@ -108,7 +108,7 @@ class Deprecation
 
         $callingfile = realpath($backtrace[1]['file']);
 
-        $modules = ModuleLoader::instance()->getManifest()->getModules();
+        $modules = ModuleLoader::inst()->getManifest()->getModules();
         foreach ($modules as $module) {
             if (strpos($callingfile, realpath($module->getPath())) === 0) {
                 return $module;

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -1036,10 +1036,10 @@ class SapphireTest extends PHPUnit_Framework_TestCase
             $flush
         );
 
-        ClassLoader::instance()->pushManifest($classManifest, false);
+        ClassLoader::inst()->pushManifest($classManifest, false);
         static::set_test_class_manifest($classManifest);
 
-        ThemeResourceLoader::instance()->addSet('$default', new ThemeManifest(
+        ThemeResourceLoader::inst()->addSet('$default', new ThemeManifest(
             BASE_PATH,
             project(),
             true,
@@ -1048,7 +1048,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase
 
         // Once new class loader is registered, push a new uncached config
         $config = CoreConfigFactory::inst()->createCore();
-        ConfigLoader::instance()->pushManifest($config);
+        ConfigLoader::inst()->pushManifest($config);
 
         // Invalidate classname spec since the test manifest will now pull out new subclasses for each internal class
         // (e.g. Member will now have various subclasses of DataObjects that implement TestOnly)

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -621,7 +621,7 @@ class TinyMCEConfig extends HTMLEditorConfig
         $editor[] = Director::absoluteURL(ltrim($this->getAdminPath() . '/client/dist/styles/editor.css', '/'));
 
         // Themed editor.css
-        $themedEditor = ThemeResourceLoader::instance()->findThemedCSS('editor', SSViewer::get_themes());
+        $themedEditor = ThemeResourceLoader::inst()->findThemedCSS('editor', SSViewer::get_themes());
         if ($themedEditor) {
             $editor[] = Director::absoluteURL($themedEditor, Director::BASE);
         }
@@ -712,7 +712,7 @@ class TinyMCEConfig extends HTMLEditorConfig
         }
 
         throw new Exception(sprintf(
-            'If the silverstripe/admin module is not installed, 
+            'If the silverstripe/admin module is not installed,
             you must set the TinyMCE path in %s.base_dir',
             __CLASS__
         ));
@@ -723,6 +723,6 @@ class TinyMCEConfig extends HTMLEditorConfig
      */
     protected function getAdminModule()
     {
-        return ModuleLoader::instance()->getManifest()->getModule('silverstripe/admin');
+        return ModuleLoader::inst()->getManifest()->getModule('silverstripe/admin');
     }
 }

--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -125,7 +125,7 @@ class DatabaseAdmin extends Controller
         increase_time_limit_to(600);
 
         // Get all our classes
-        ClassLoader::instance()->getManifest()->regenerate();
+        ClassLoader::inst()->getManifest()->regenerate();
 
         $url = $this->getReturnURL();
         if ($url) {

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -1310,7 +1310,7 @@ class Requirements_Backend
             throw new Exception(
                 sprintf(
                     'Cannot minify files without a minification service defined.
-        			Set %s::minifyCombinedFiles to false, or inject a %s service on 
+        			Set %s::minifyCombinedFiles to false, or inject a %s service on
         			%s.properties.minifier',
                     __CLASS__,
                     Requirements_Minifier::class,
@@ -1435,7 +1435,7 @@ class Requirements_Backend
      */
     public function themedCSS($name, $media = null)
     {
-        $path = ThemeResourceLoader::instance()->findThemedCSS($name, SSViewer::get_themes());
+        $path = ThemeResourceLoader::inst()->findThemedCSS($name, SSViewer::get_themes());
         if ($path) {
             $this->css($path, $media);
         } else {
@@ -1459,7 +1459,7 @@ class Requirements_Backend
      */
     public function themedJavascript($name, $type = null)
     {
-        $path = ThemeResourceLoader::instance()->findThemedJavascript($name, SSViewer::get_themes());
+        $path = ThemeResourceLoader::inst()->findThemedJavascript($name, SSViewer::get_themes());
         if ($path) {
             $opts = [];
             if ($type) {

--- a/src/View/SSViewer.php
+++ b/src/View/SSViewer.php
@@ -284,7 +284,7 @@ class SSViewer implements Flushable
      */
     public static function chooseTemplate($templates)
     {
-        return ThemeResourceLoader::instance()->findTemplate($templates, self::get_themes());
+        return ThemeResourceLoader::inst()->findTemplate($templates, self::get_themes());
     }
 
     /**
@@ -319,7 +319,7 @@ class SSViewer implements Flushable
      */
     public static function hasTemplate($templates)
     {
-        return (bool)ThemeResourceLoader::instance()->findTemplate($templates, self::get_themes());
+        return (bool)ThemeResourceLoader::inst()->findTemplate($templates, self::get_themes());
     }
 
     /**
@@ -362,7 +362,7 @@ class SSViewer implements Flushable
      */
     public static function getTemplateFileByType($identifier, $type = null)
     {
-        return ThemeResourceLoader::instance()->findTemplate(['type' => $type, $identifier], self::get_themes());
+        return ThemeResourceLoader::inst()->findTemplate(['type' => $type, $identifier], self::get_themes());
     }
 
     /**

--- a/src/View/ThemeResourceLoader.php
+++ b/src/View/ThemeResourceLoader.php
@@ -29,7 +29,7 @@ class ThemeResourceLoader
     /**
      * @return ThemeResourceLoader
      */
-    public static function instance()
+    public static function inst()
     {
         return self::$instance ? self::$instance : self::$instance = new self();
     }
@@ -123,7 +123,7 @@ class ThemeResourceLoader
             $package = $parts[0];
 
             // Find matching module for this package
-            $module = ModuleLoader::instance()->getManifest()->getModule($package);
+            $module = ModuleLoader::inst()->getManifest()->getModule($package);
             if ($module) {
                 $modulePath = $module->getRelativePath();
             } else {

--- a/src/i18n/Data/Sources.php
+++ b/src/i18n/Data/Sources.php
@@ -35,7 +35,7 @@ class Sources implements Resettable
     public function getSortedModules()
     {
         // Get list of module => path pairs, and then just the names
-        $modules = ModuleLoader::instance()->getManifest()->getModules();
+        $modules = ModuleLoader::inst()->getManifest()->getModules();
         $moduleNames = array_keys($modules);
 
         // Remove the "project" module from the list - we'll add it back specially later if needed
@@ -100,7 +100,7 @@ class Sources implements Resettable
         }
 
         // Search theme dirs (receives relative paths)
-        $locator = ThemeResourceLoader::instance();
+        $locator = ThemeResourceLoader::inst();
         foreach (SSViewer::get_themes() as $theme) {
             if ($locator->getSet($theme)) {
                 continue;

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -183,7 +183,7 @@ class i18nTextCollector
 
             // Clean sorting prior to writing
             ksort($entities);
-            $module = ModuleLoader::instance()->getManifest()->getModule($moduleName);
+            $module = ModuleLoader::inst()->getManifest()->getModule($moduleName);
             $this->write($module, $entities);
         }
     }
@@ -211,7 +211,7 @@ class i18nTextCollector
         if (!empty($restrictToModules)) {
             // Normalise module names
             $modules = array_filter(array_map(function ($name) {
-                $module = ModuleLoader::instance()->getManifest()->getModule($name);
+                $module = ModuleLoader::inst()->getManifest()->getModule($name);
                 return $module ? $module->getName() : null;
             }, $restrictToModules));
             // Remove modules
@@ -328,7 +328,7 @@ class i18nTextCollector
     protected function findModuleForClass($class)
     {
         if (ClassInfo::exists($class)) {
-            $module = ClassLoader::instance()
+            $module = ClassLoader::inst()
                 ->getManifest()
                 ->getOwnerModule($class);
             if ($module) {
@@ -344,12 +344,12 @@ class i18nTextCollector
         // Find FQN that ends with $class
         $classes = preg_grep(
             '/'.preg_quote("\\{$class}", '\/').'$/i',
-            ClassLoader::instance()->getManifest()->getClassNames()
+            ClassLoader::inst()->getManifest()->getClassNames()
         );
 
         // Find all modules for candidate classes
         $modules = array_unique(array_map(function ($class) {
-            $module = ClassLoader::instance()->getManifest()->getOwnerModule($class);
+            $module = ClassLoader::inst()->getManifest()->getOwnerModule($class);
             return $module ? $module->getName() : null;
         }, $classes));
 
@@ -395,7 +395,7 @@ class i18nTextCollector
     {
         // A master string tables array (one mst per module)
         $entitiesByModule = array();
-        $modules = ModuleLoader::instance()->getManifest()->getModules();
+        $modules = ModuleLoader::inst()->getManifest()->getModules();
         foreach ($modules as $module) {
             // we store the master string tables
             $processedEntities = $this->processModule($module);
@@ -417,7 +417,7 @@ class i18nTextCollector
                 // Rewrite spec if module is specified
                 if (is_array($spec) && isset($spec['module'])) {
                     // Normalise name (in case non-composer name is specified)
-                    $specModule = ModuleLoader::instance()->getManifest()->getModule($spec['module']);
+                    $specModule = ModuleLoader::inst()->getManifest()->getModule($spec['module']);
                     if ($specModule) {
                         $specModuleName = $specModule->getName();
                     }

--- a/tests/php/Core/Manifest/ConfigManifestTest.php
+++ b/tests/php/Core/Manifest/ConfigManifestTest.php
@@ -17,12 +17,12 @@ class ConfigManifestTest extends SapphireTest
         parent::setUp();
 
         $moduleManifest = new ModuleManifest(dirname(__FILE__) . '/fixtures/configmanifest');
-        ModuleLoader::instance()->pushManifest($moduleManifest);
+        ModuleLoader::inst()->pushManifest($moduleManifest);
     }
 
     protected function tearDown()
     {
-        ModuleLoader::instance()->popManifest();
+        ModuleLoader::inst()->popManifest();
         parent::tearDown();
     }
 

--- a/tests/php/Core/Manifest/NamespacedClassManifestTest.php
+++ b/tests/php/Core/Manifest/NamespacedClassManifestTest.php
@@ -29,13 +29,13 @@ class NamespacedClassManifestTest extends SapphireTest
 
         $this->base = dirname(__FILE__) . '/fixtures/namespaced_classmanifest';
         $this->manifest = new ClassManifest($this->base, false);
-        ClassLoader::instance()->pushManifest($this->manifest, false);
+        ClassLoader::inst()->pushManifest($this->manifest, false);
     }
 
     protected function tearDown()
     {
         parent::tearDown();
-        ClassLoader::instance()->popManifest();
+        ClassLoader::inst()->popManifest();
     }
 
     public function testClassInfoIsCorrect()

--- a/tests/php/Core/Startup/ErrorControlChainTest/ErrorControlChainTest_Chain.php
+++ b/tests/php/Core/Startup/ErrorControlChainTest/ErrorControlChainTest_Chain.php
@@ -49,7 +49,7 @@ class ErrorControlChainTest_Chain extends ErrorControlChain
     {
         // Get the path to the ErrorControlChain class
         $erroControlClass = 'SilverStripe\\Core\\Startup\\ErrorControlChain';
-        $classpath = ClassLoader::instance()->getItemPath($erroControlClass);
+        $classpath = ClassLoader::inst()->getItemPath($erroControlClass);
         $suppression = $this->suppression ? 'true' : 'false';
 
         // Start building a PHP file that will execute the chain

--- a/tests/php/Forms/HTMLEditor/HTMLEditorConfigTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorConfigTest.php
@@ -101,7 +101,7 @@ class HTMLEditorConfigTest extends SapphireTest
 
     public function testPluginCompression()
     {
-        $module = ModuleLoader::instance()->getManifest()->getModule('silverstripe/admin');
+        $module = ModuleLoader::inst()->getManifest()->getModule('silverstripe/admin');
         if (!$module) {
             $this->markTestSkipped('No silverstripe/admin module loaded');
         }
@@ -191,7 +191,7 @@ class HTMLEditorConfigTest extends SapphireTest
     public function testExceptionThrownWhenTinyMCEPathCannotBeComputed()
     {
         TinyMCEConfig::config()->remove('base_dir');
-        ModuleLoader::instance()->pushManifest(new ModuleManifest(
+        ModuleLoader::inst()->pushManifest(new ModuleManifest(
             dirname(__FILE__),
             false
         ));
@@ -204,7 +204,7 @@ class HTMLEditorConfigTest extends SapphireTest
 
         $c->getScriptURL();
 
-        ModuleLoader::instance()->popManifest();
+        ModuleLoader::inst()->popManifest();
     }
 
     public function testExceptionThrownWhenTinyMCEGZipPathDoesntExist()

--- a/tests/php/i18n/i18nTestManifest.php
+++ b/tests/php/i18n/i18nTestManifest.php
@@ -86,7 +86,7 @@ trait i18nTestManifest
         $this->pushModuleManifest($moduleManifest);
 
         // Replace old template loader with new one with alternate base path
-        $this->oldThemeResourceLoader = ThemeResourceLoader::instance();
+        $this->oldThemeResourceLoader = ThemeResourceLoader::inst();
         ThemeResourceLoader::set_instance($loader = new ThemeResourceLoader($this->alternateBasePath));
         $loader->addSet(
             '$default',
@@ -136,13 +136,13 @@ trait i18nTestManifest
     protected function pushManifest(ClassManifest $manifest)
     {
         $this->manifests++;
-        ClassLoader::instance()->pushManifest($manifest);
+        ClassLoader::inst()->pushManifest($manifest);
     }
 
     protected function pushModuleManifest(ModuleManifest $manifest)
     {
         $this->moduleManifests++;
-        ModuleLoader::instance()->pushManifest($manifest);
+        ModuleLoader::inst()->pushManifest($manifest);
     }
 
     /**
@@ -152,11 +152,11 @@ trait i18nTestManifest
     {
         // Reset any manifests pushed during this test
         while ($this->manifests > 0) {
-            ClassLoader::instance()->popManifest();
+            ClassLoader::inst()->popManifest();
             $this->manifests--;
         }
         while ($this->moduleManifests > 0) {
-            ModuleLoader::instance()->popManifest();
+            ModuleLoader::inst()->popManifest();
             $this->moduleManifests--;
         }
     }

--- a/tests/php/i18n/i18nTextCollectorTest.php
+++ b/tests/php/i18n/i18nTextCollectorTest.php
@@ -42,7 +42,7 @@ class i18nTextCollectorTest extends SapphireTest
     public function testConcatenationInEntityValues()
     {
         $c = i18nTextCollector::create();
-        $module = ModuleLoader::instance()->getManifest()->getModule('i18ntestmodule');
+        $module = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
 
         $php = <<<PHP
 _t(
@@ -75,7 +75,7 @@ PHP;
     {
         $c = i18nTextCollector::create();
         $c->setWarnOnEmptyDefault(false);
-        $mymodule = ModuleLoader::instance()->getManifest()->getModule('i18ntestmodule');
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
 
         $html = <<<SS
         <% _t('Test.SINGLEQUOTE','Single Quote'); %>
@@ -124,7 +124,7 @@ SS;
     public function testCollectFromTemplateSimple()
     {
         $c = i18nTextCollector::create();
-        $mymodule = ModuleLoader::instance()->getManifest()->getModule('i18ntestmodule');
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
 
         $html = <<<SS
 <% _t('Test.SINGLEQUOTE','Single Quote'); %>
@@ -155,7 +155,7 @@ SS;
     {
         $c = i18nTextCollector::create();
         $c->setWarnOnEmptyDefault(false);
-        $mymodule = ModuleLoader::instance()->getManifest()->getModule('i18ntestmodule');
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
 
         $html = <<<SS
 <% _t(
@@ -221,7 +221,7 @@ SS;
     public function testCollectFromCodeSimple()
     {
         $c = i18nTextCollector::create();
-        $mymodule = ModuleLoader::instance()->getManifest()->getModule('i18ntestmodule');
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
 
         $php = <<<PHP
 _t('Test.SINGLEQUOTE','Single Quote');
@@ -243,7 +243,7 @@ PHP;
     public function testCollectFromCodeAdvanced()
     {
         $c = i18nTextCollector::create();
-        $mymodule = ModuleLoader::instance()->getManifest()->getModule('i18ntestmodule');
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
 
         $php = <<<PHP
 _t(
@@ -305,8 +305,8 @@ PHP;
 _t(
 	'Test.PRIOANDCOMMENT',
 	"Doublequoted Value with 'Unescaped Single Quotes'"
-	
-	
+
+
 );
 PHP;
         $this->assertEquals(
@@ -318,7 +318,7 @@ PHP;
     public function testCollectFromCodeNamespace()
     {
         $c = i18nTextCollector::create();
-        $mymodule = ModuleLoader::instance()->getManifest()->getModule('i18ntestmodule');
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
         $php = <<<PHP
 <?php
 namespace SilverStripe\Framework\Core;
@@ -361,7 +361,7 @@ PHP;
     public function testNewlinesInEntityValues()
     {
         $c = i18nTextCollector::create();
-        $mymodule = ModuleLoader::instance()->getManifest()->getModule('i18ntestmodule');
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
 
         $php = <<<PHP
 _t(
@@ -397,7 +397,7 @@ PHP;
     {
         $c = i18nTextCollector::create();
         $c->setWarnOnEmptyDefault(false); // Disable warnings for tests
-        $mymodule = ModuleLoader::instance()->getManifest()->getModule('i18ntestmodule');
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
 
         $php = <<<PHP
 _t('i18nTestModule.NEWMETHODSIG',"New _t method signature test");
@@ -453,7 +453,7 @@ PHP;
     public function testUncollectableCode()
     {
         $c = i18nTextCollector::create();
-        $mymodule = ModuleLoader::instance()->getManifest()->getModule('i18ntestmodule');
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
 
         $php = <<<PHP
 _t(static::class.'.KEY1', 'Default');
@@ -472,7 +472,7 @@ PHP;
     {
         $c = i18nTextCollector::create();
         $c->setWarnOnEmptyDefault(false); // Disable warnings for tests
-        $mymodule = ModuleLoader::instance()->getManifest()->getModule('i18ntestmodule');
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
 
         $templateFilePath = $this->alternateBasePath . '/i18ntestmodule/templates/Layout/i18nTestModule.ss';
         $html = file_get_contents($templateFilePath);
@@ -730,7 +730,7 @@ PHP;
     public function testModuleDetection()
     {
         $collector = new Collector();
-        $modules = ModuleLoader::instance()->getManifest()->getModules();
+        $modules = ModuleLoader::inst()->getManifest()->getModules();
         $this->assertEquals(
             array(
                 'i18nnonstandardmodule',

--- a/tests/php/i18n/i18nTextCollectorTest/Collector.php
+++ b/tests/php/i18n/i18nTextCollectorTest/Collector.php
@@ -19,7 +19,7 @@ class Collector extends i18nTextCollector implements TestOnly
 
     public function getFileListForModule_Test($modulename)
     {
-        $module = ModuleLoader::instance()->getManifest()->getModule($modulename);
+        $module = ModuleLoader::inst()->getManifest()->getModule($modulename);
         if (!$module) {
             throw new \BadMethodCallException("No module named {$modulename}");
         }


### PR DESCRIPTION
Issue: #6851

## Blockers

* [x] https://github.com/silverstripe/silverstripe-behat-extension/pull/158 (also requires this PR)

## Blocks

* [ ] https://github.com/silverstripe/silverstripe-admin/issues/79