### PR TITLE
CheckboxField creates invalid HTML when required #2939

### DIFF
--- a/src/Forms/CheckboxField.php
+++ b/src/Forms/CheckboxField.php
@@ -28,10 +28,16 @@ class CheckboxField extends FormField
 
     public function getAttributes()
     {
-        $attrs = parent::getAttributes();
-        $attrs['value'] = 1;
+        $attributes = parent::getAttributes();
+        $attributes['value'] = 1;
+        if ($this->Required()) {
+            // Semantically, it doesn't make sense to have a required attribute
+            // on a field in which both checked and unchecked are allowable.
+            unset($attributes['aria-required']);
+        }
+
         return array_merge(
-            $attrs,
+            $attributes,
             array(
                 'checked' => ($this->Value()) ? 'checked' : null,
                 'type' => 'checkbox',

--- a/src/Forms/CheckboxSetField.php
+++ b/src/Forms/CheckboxSetField.php
@@ -104,4 +104,18 @@ class CheckboxSetField extends MultiSelectField
     {
         return 'optionset checkboxset';
     }
+
+    public function getAttributes()
+    {
+        $attributes = array_merge(
+            parent::getAttributes(),
+            array('role' => 'listbox')
+        );
+
+        // Remove invalid attributes from wrapper.
+        unset($attributes['name']);
+        unset($attributes['required']);
+        unset($attributes['aria-required']);
+        return $attributes;
+    }
 }

--- a/src/Forms/DropdownField.php
+++ b/src/Forms/DropdownField.php
@@ -114,6 +114,17 @@ class DropdownField extends SingleSelectField
     }
 
     /**
+     * A required DropdownField must have a user selected attribute,
+     * so require an empty default for a required field
+     *
+     * @return bool
+     */
+    public function getHasEmptyDefault()
+    {
+        return parent::getHasEmptyDefault() || $this->Required();
+    }
+
+    /**
      * @param array $properties
      * @return string
      */

--- a/src/Forms/OptionsetField.php
+++ b/src/Forms/OptionsetField.php
@@ -148,11 +148,13 @@ class OptionsetField extends SingleSelectField
 
     public function getAttributes()
     {
-        $attributes = parent::getAttributes();
+        $attributes = array_merge(
+            parent::getAttributes(),
+            array('role' => 'listbox')
+        );
+
         unset($attributes['name']);
         unset($attributes['required']);
-        unset($attributes['role']);
-
         return $attributes;
     }
 }

--- a/tests/php/Forms/CheckboxFieldTest.php
+++ b/tests/php/Forms/CheckboxFieldTest.php
@@ -2,6 +2,9 @@
 
 namespace SilverStripe\Forms\Tests;
 
+use SilverStripe\Control\Controller;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
 use SilverStripe\Forms\Tests\CheckboxFieldtest\Article;
 use SilverStripe\ORM\DB;
 use SilverStripe\Dev\SapphireTest;
@@ -184,5 +187,22 @@ class CheckboxFieldTest extends SapphireTest
             $field->validate($validator),
             'Field correct validates null as allowed'
         );
+    }
+
+    /**
+     * #2939 CheckboxField creates invalid HTML when required
+     */
+    public function testNoAriaRequired()
+    {
+        $field = new CheckboxField('RequiredField', 'myRequiredField');
+
+        $form = new Form(
+            Controller::curr(), "form", new FieldList($field), new FieldList(),
+            new RequiredFields(["RequiredField"])
+        );
+        $this->assertTrue($field->Required());
+
+        $attributes = $field->getAttributes();
+        $this->assertFalse(array_key_exists("aria-required", $attributes));
     }
 }

--- a/tests/php/Forms/CheckboxSetFieldTest.php
+++ b/tests/php/Forms/CheckboxSetFieldTest.php
@@ -370,4 +370,23 @@ class CheckboxSetFieldTest extends SapphireTest
         $this->assertContains('&lt;firstname&gt;', $fieldHTML);
         $this->assertNotContains('<firstname>', $fieldHTML);
     }
+
+    /**
+     * #2939 CheckboxSetField creates invalid HTML when required
+     */
+    public function testNoAriaRequired()
+    {
+        $field = new CheckboxSetField('RequiredField', 'myRequiredField');
+
+        $form = new Form(
+            Controller::curr(), "form", new FieldList($field), new FieldList(),
+            new RequiredFields(["RequiredField"])
+        );
+        $this->assertTrue($field->Required());
+
+        $attributes = $field->getAttributes();
+        $this->assertFalse(array_key_exists("aria-required", $attributes));
+        $this->assertFalse(array_key_exists("name", $attributes));
+        $this->assertFalse(array_key_exists("required", $attributes));
+    }
 }

--- a/tests/php/Forms/DropdownFieldTest.php
+++ b/tests/php/Forms/DropdownFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms\Tests;
 
+use SilverStripe\Control\Controller;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\Dev\CSSContentParser;
 use SilverStripe\Dev\SapphireTest;
@@ -497,5 +498,20 @@ class DropdownFieldTest extends SapphireTest
         $field->setDisabledItems(array('Five'));
         $field->setValue('Five');
         $this->assertFalse($field->validate($validator));
+    }
+
+    /**
+     * #2939 DropdownField creates invalid HTML when required
+     */
+    public function testRequiredDropdownHasEmptyDefault()
+    {
+        $field = new \SilverStripe\Forms\DropdownField("RequiredField", "dropdown", ["item 1", "item 2"]);
+
+        $form = new Form(
+            Controller::curr(), "form", new FieldList($field), new FieldList(),
+            new RequiredFields(["RequiredField"])
+        );
+
+        $this->assertTrue($field->getHasEmptyDefault());
     }
 }

--- a/tests/php/Forms/OptionsetFieldTest.php
+++ b/tests/php/Forms/OptionsetFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms\Tests;
 
+use SilverStripe\Control\Controller;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Dev\CSSContentParser;
 use SilverStripe\Dev\SapphireTest;
@@ -99,5 +100,24 @@ class OptionsetFieldTest extends SapphireTest
         $this->assertNotContains('Two & Three', $fieldHTML);
         $this->assertContains('Four &amp; Five &amp; Six', $fieldHTML);
         $this->assertNotContains('Four & Five & Six', $fieldHTML);
+    }
+
+    /**
+     * #2939 OptionSetField creates invalid HTML when required
+     */
+    public function testNoAriaRequired()
+    {
+        $field = new OptionsetField('RequiredField', 'myRequiredField');
+
+        $form = new Form(
+            Controller::curr(), "form", new FieldList($field), new FieldList(),
+            new RequiredFields(["RequiredField"])
+        );
+        $this->assertTrue($field->Required());
+
+        $attributes = $field->getAttributes();
+        $this->assertFalse(array_key_exists("name", $attributes));
+        $this->assertFalse(array_key_exists("required", $attributes));
+        $this->assertTrue(array_key_exists("role", $attributes));
     }
 }


### PR DESCRIPTION
Fixes #2939

Semantically, it doesn't make sense to have a required attribute on a 
field in which both checked and unchecked attributes are 'valid',

For checkboxes, required might make more sense where it is the 
equivalent of "check this checkbox" (for example accepting license 
terms).but we can't use the aria-required attribute here. 

For a radio button grouping OptionSet, the "required" attribute applies 
to the group and not to the individual items. It is impossible to 
select all the radio buttons in a group for example but it does make 
sense to have a grouping with no default value and expect the user to 
choose one value. Here we can enforce the user to select an option, 
without selecting one first. 

For Dropdowns, we have to include an empty option, so the user must
 select a valid option from the dropdown, otherwise the first option 
 would be required and might not be a valid user-input. 

https://www.w3.org/TR/wai-aria/states_and_properties#aria-required

relates to #4901