### PR TITLE
[Improvement|testing] Use scriptfusion to immediately print PHPUnit output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",
+    "scriptfusion/phpunit-immediate-exception-printer": "^1",
     "silverstripe/versioned": "^1.0@dev",
     "silverstripe/behat-extension": "^3",
     "silverstripe/serve": "dev-master",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,9 @@
 Standard module phpunit configuration.
 Requires PHPUnit ^5.7
 -->
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
+<phpunit printerClass="ScriptFUSION\PHPUnitImmediateExceptionPrinter\ImmediateExceptionPrinter"
+             bootstrap="tests/bootstrap.php"
+             colors="true">
 	<testsuite name="Default">
 		<directory>tests/php</directory>
     </testsuite>


### PR DESCRIPTION
Props to @madmatt for the idea.

This change updates the output of the unit tests, to use the pretty-print method, which outputs errors immediately (no waiting for all tests to finish), and show a better progress of the tests.

More information:
https://github.com/ScriptFUSION/PHPUnit-Immediate-Exception-Printer