### PR TITLE
Bugfix: i18nTextCollector merge direction is incorrect and overwrites existing values

### DIFF
--- a/src/Dev/Tasks/i18nTextCollectorTask.php
+++ b/src/Dev/Tasks/i18nTextCollectorTask.php
@@ -26,7 +26,7 @@ class i18nTextCollectorTask extends BuildTask
 		- locale: Sets default locale
 		- writer: Custom writer class (defaults to i18nTextCollector_Writer_RailsYaml)
 		- module: One or more modules to limit collection (comma-separated)
-		- merge: Merge new strings with existing ones already defined in language files (default: FALSE)
+		- merge: Merge new strings with existing ones already defined in language files (default: TRUE)
 	";
 
     /**

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -378,8 +378,8 @@ class i18nTextCollector
             // Merge
             if ($existingMessages) {
                 $entitiesByModule[$module] = array_merge(
-                    $existingMessages,
-                    $messages
+                    $messages,
+                    $existingMessages
                 );
             }
         }


### PR DESCRIPTION
Also update comment that it is actually enabled by default, just wasn't working so no one noticed?