### PR TITLE
FIX: Don’t assume posix_getpwuid is available.

### DIFF
--- a/src/Core/TempPath.php
+++ b/src/Core/TempPath.php
@@ -34,7 +34,7 @@ function getTempFolderUsername()
     if (!$user) {
         $user = getenv('USERNAME');
     }
-    if (!$user && function_exists('posix_getuid')) {
+    if (!$user && function_exists('posix_getpwuid') && function_exists('posix_getuid')) {
         $userDetails = posix_getpwuid(posix_getuid());
         $user = $userDetails['name'];
     }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/2494

In Silverstripe 3.1, on some shared hosts the following bug can occur:
Warning: posix_getpwuid() has been disabled for security reasons