### PR TITLE
Remove unnecessary nesting of config/injector in tests

### DIFF
--- a/tests/control/CookieTest.php
+++ b/tests/control/CookieTest.php
@@ -6,14 +6,7 @@ class CookieTest extends SapphireTest {
 
 	public function setUp() {
 		parent::setUp();
-		Injector::nest();
 		Injector::inst()->registerService(new CookieJar($_COOKIE), 'Cookie_Backend');
-	}
-
-	public function tearDown() {
-		//restore the cookie_backend
-		Injector::unnest();
-		parent::tearDown();
 	}
 
 	/**

--- a/tests/filesystem/UploadTest.php
+++ b/tests/filesystem/UploadTest.php
@@ -134,8 +134,6 @@ class UploadTest extends SapphireTest {
 	}
 
 	public function testGetAllowedMaxFileSize() {
-		Config::nest();
-
 		// Check the max file size uses the config values
 		$configMaxFileSizes = array(
 			'[image]' => '1k',
@@ -176,15 +174,13 @@ class UploadTest extends SapphireTest {
 
 		$retrievedSize = $v->getAllowedMaxFileSize('txt');
 		$this->assertEquals(4096, $retrievedSize, 'Max file size check on instance values failed (instance extension set check)');
-		
+
 		// Check a wildcard max file size against a file with an extension
 		$v = new UploadTest_Validator();
 		$v->setAllowedMaxFileSize(2000);
 
 		$retrievedSize = $v->getAllowedMaxFileSize('.jpg');
 		$this->assertEquals(2000, $retrievedSize, 'Max file size check on instance values failed (wildcard max file size)');
-
-		Config::unnest();
 	}
 
 	public function testAllowedSizeOnFileWithNoExtension() {

--- a/tests/forms/FormFieldTest.php
+++ b/tests/forms/FormFieldTest.php
@@ -10,8 +10,6 @@ class FormFieldTest extends SapphireTest {
 	);
 
 	public function testDefaultClasses() {
-		Config::nest();
-
 		Config::inst()->update('FormField', 'default_classes', array(
 			'class1',
 		));
@@ -50,8 +48,6 @@ class FormFieldTest extends SapphireTest {
 		//check default classes inherit
 		$this->assertContains('class3', $field->extraClass(), 'Class list does not contain inherited class');
 		$this->assertContains('textfield-class', $field->extraClass(), 'Class list does not contain expected class');
-
-		Config::unnest();
 	}
 
 	public function testAddExtraClass() {

--- a/tests/forms/FormTest.php
+++ b/tests/forms/FormTest.php
@@ -549,8 +549,6 @@ class FormTest extends FunctionalTest {
 	}
 
 	public function testDefaultClasses() {
-		Config::nest();
-
 		Config::inst()->update('Form', 'default_classes', array(
 			'class1',
 		));
@@ -579,8 +577,6 @@ class FormTest extends FunctionalTest {
 		$form->removeExtraClass('class3');
 
 		$this->assertNotContains('class3', $form->extraClass(), 'Class list contains unexpected class');
-
-		Config::unnest();
 	}
 
 	public function testAttributes() {

--- a/tests/forms/HtmlEditorFieldToolbarTest.php
+++ b/tests/forms/HtmlEditorFieldToolbarTest.php
@@ -25,15 +25,8 @@ class HtmlEditorFieldToolbarTest extends SapphireTest {
 	public function setUp() {
 		parent::setUp();
 
-		Config::nest();
 		Config::inst()->update('HtmlEditorField_Toolbar', 'fileurl_scheme_whitelist', array('http'));
 		Config::inst()->update('HtmlEditorField_Toolbar', 'fileurl_domain_whitelist', array('example.com'));
-	}
-
-	public function tearDown() {
-		Config::unnest();
-
-		parent::tearDown();
 	}
 
 	public function testValidLocalReference() {

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -1126,7 +1126,6 @@ class DataObjectTest extends SapphireTest {
 	}
 
 	public function testValidateModelDefinitionsFailsWithArray() {
-		Config::nest();
 
 		$object = new DataObjectTest_Team;
 		$method = $this->makeAccessible($object, 'validateModelDefinitions');
@@ -1134,54 +1133,33 @@ class DataObjectTest extends SapphireTest {
 		Config::inst()->update('DataObjectTest_Team', 'has_one', array('NotValid' => array('NoArraysAllowed')));
 		$this->setExpectedException('LogicException');
 
-		try {
-			$method->invoke($object);
-		} catch(Exception $e) {
-			Config::unnest(); // Catch the exception so we can unnest config before failing the test
-			throw $e;
-		}
+		$method->invoke($object);
 	}
 
 	public function testValidateModelDefinitionsFailsWithIntKey() {
-		Config::nest();
-
 		$object = new DataObjectTest_Team;
 		$method = $this->makeAccessible($object, 'validateModelDefinitions');
 
 		Config::inst()->update('DataObjectTest_Team', 'has_many', array(12 => 'DataObjectTest_Player'));
 		$this->setExpectedException('LogicException');
 
-		try {
-			$method->invoke($object);
-		} catch(Exception $e) {
-			Config::unnest(); // Catch the exception so we can unnest config before failing the test
-			throw $e;
-		}
+		$method->invoke($object);
 	}
 
 	public function testValidateModelDefinitionsFailsWithIntValue() {
-		Config::nest();
-
 		$object = new DataObjectTest_Team;
 		$method = $this->makeAccessible($object, 'validateModelDefinitions');
 
 		Config::inst()->update('DataObjectTest_Team', 'many_many', array('Players' => 12));
 		$this->setExpectedException('LogicException');
 
-		try {
-			$method->invoke($object);
-		} catch(Exception $e) {
-			Config::unnest(); // Catch the exception so we can unnest config before failing the test
-			throw $e;
-		}
+		$method->invoke($object);
 	}
 
 	/**
 	 * many_many_extraFields is allowed to have an array value, so shouldn't throw an exception
 	 */
 	public function testValidateModelDefinitionsPassesWithExtraFields() {
-		Config::nest();
-
 		$object = new DataObjectTest_Team;
 		$method = $this->makeAccessible($object, 'validateModelDefinitions');
 
@@ -1191,12 +1169,9 @@ class DataObjectTest extends SapphireTest {
 		try {
 			$method->invoke($object);
 		} catch(Exception $e) {
-			Config::unnest();
 			$this->fail('Exception should not be thrown');
 			throw $e;
 		}
-
-		Config::unnest();
 	}
 
 	public function testNewClassInstance() {

--- a/tests/model/VersionableExtensionsTest.php
+++ b/tests/model/VersionableExtensionsTest.php
@@ -37,6 +37,13 @@ class VersionableExtensionsTest extends SapphireTest
 		parent::setUpOnce();
 	}
 
+	public function tearDownOnce()
+	{
+		parent::tearDownOnce();
+
+		Config::unnest();
+	}
+
 	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 

--- a/tests/security/MemberTest.php
+++ b/tests/security/MemberTest.php
@@ -846,7 +846,6 @@ class MemberTest extends FunctionalTest {
 	public function testFailedLoginCount() {
 		$maxFailedLoginsAllowed = 3;
 		//set up the config variables to enable login lockouts
-		Config::nest();
 		Config::inst()->update('Member', 'lock_out_after_incorrect_logins', $maxFailedLoginsAllowed);
 
 		$member = $this->objFromFixture('Member', 'test');

--- a/tests/security/SecurityTest.php
+++ b/tests/security/SecurityTest.php
@@ -75,8 +75,6 @@ class SecurityTest extends FunctionalTest {
 	}
 
 	public function testPermissionFailureSetsCorrectFormMessages() {
-		Config::nest();
-
 		// Controller that doesn't attempt redirections
 		$controller = new SecurityTest_NullController();
 		$controller->setResponse(new SS_HTTPResponse());
@@ -111,8 +109,6 @@ class SecurityTest extends FunctionalTest {
 			array('default' => 'default', 'alreadyLoggedIn' => 'One-off failure message'));
 		$this->assertContains('One-off failure message', $controller->getResponse()->getBody(),
 			"Message set passed to Security::permissionFailure() didn't override Config values");
-
-		Config::unnest();
 	}
 
 	/**


### PR DESCRIPTION
This removes unnecessary nesting/unnesting of config/injector in tests