### PR TITLE
FIX Use plural name for ModelAdmin tab name

### DIFF
--- a/admin/code/ModelAdmin.php
+++ b/admin/code/ModelAdmin.php
@@ -300,7 +300,7 @@ abstract class ModelAdmin extends LeftAndMain {
 		// Normalize models to have their model class in array key
 		foreach($models as $k => $v) {
 			if(is_numeric($k)) {
-				$models[$v] = array('title' => singleton($v)->i18n_singular_name());
+				$models[$v] = array('title' => singleton($v)->i18n_plural_name());
 				unset($models[$k]);
 			}
 		}


### PR DESCRIPTION
This is a port of #5736 which is in SS4, targeting the 3.5.x release line.

Original issue: #3362