### PR TITLE
Fix for badly escaped values in CSV export

### DIFF
--- a/tests/forms/gridfield/GridFieldExportButtonTest.php
+++ b/tests/forms/gridfield/GridFieldExportButtonTest.php
@@ -48,7 +48,9 @@ class GridFieldExportButtonTest extends SapphireTest {
 		$button->setExportColumns(array('Name' => 'My Name'));
 
 		$this->assertEquals(
-			"\"My Name\"\n\"Test\"\n\"Test2\"\n",
+			'"My Name"'."\n".
+			'Test'."\n".
+			'Test2'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -64,7 +66,7 @@ class GridFieldExportButtonTest extends SapphireTest {
 		$button->setExportColumns(array('Name' => 'My Name'));
 
 		$this->assertEquals(
-			"\"My Name\"\n\"\t=SUM(1, 2)\"\n\"Test\"\n\"Test2\"\n",
+			"\"My Name\"\n\"\t=SUM(1, 2)\"\nTest\nTest2\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -79,7 +81,9 @@ class GridFieldExportButtonTest extends SapphireTest {
 		));
 
 		$this->assertEquals(
-			"\"Name\",\"City\"\n\"Test\",\"City city\"\n\"Test2\",\"City2 city\"\n",
+			'Name,City'."\n".
+			'Test,"City city"'."\n".
+			'Test2,"Quoted ""City"" 2 city"'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -92,7 +96,9 @@ class GridFieldExportButtonTest extends SapphireTest {
 		));
 
 		$this->assertEquals(
-			"\"Name\",\"strtolower\"\n\"Test\",\"City\"\n\"Test2\",\"City2\"\n",
+			'Name,strtolower'."\n".
+			'Test,City'."\n".
+			'Test2,"Quoted ""City"" 2"'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -106,7 +112,8 @@ class GridFieldExportButtonTest extends SapphireTest {
 		$button->setCsvHasHeader(false);
 
 		$this->assertEquals(
-			"\"Test\",\"City\"\n\"Test2\",\"City2\"\n",
+			'Test,City'."\n".
+			'Test2,"Quoted ""City"" 2"'."\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -126,8 +133,23 @@ class GridFieldExportButtonTest extends SapphireTest {
 		$this->gridField->setList($arrayList);
 
 		$this->assertEquals(
-			"\"ID\"\n\"1\"\n\"2\"\n\"3\"\n\"4\"\n\"5\"\n\"6\"\n\"7\"\n\"8\"\n"
-			."\"9\"\n\"10\"\n\"11\"\n\"12\"\n\"13\"\n\"14\"\n\"15\"\n\"16\"\n",
+			"ID\n".
+			"1\n".
+			"2\n".
+			"3\n".
+			"4\n".
+			"5\n".
+			"6\n".
+			"7\n".
+			"8\n".
+			"9\n".
+			"10\n".
+			"11\n".
+			"12\n".
+			"13\n".
+			"14\n".
+			"15\n".
+			"16\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}
@@ -139,7 +161,7 @@ class GridFieldExportButtonTest extends SapphireTest {
 		));
 
 		$this->assertEquals(
-			"\"Rugby Team Number\"\n\"2\"\n\"0\"\n",
+			"\"Rugby Team Number\"\n2\n0\n",
 			$button->generateExportFileData($this->gridField)
 		);
 	}

--- a/tests/forms/gridfield/GridFieldExportButtonTest.yml
+++ b/tests/forms/gridfield/GridFieldExportButtonTest.yml
@@ -5,7 +5,7 @@ GridFieldExportButtonTest_Team:
         RugbyTeamNumber: 2
     test-team-2:
         Name: Test2
-        City: City2
+        City: 'Quoted "City" 2'
         RugbyTeamNumber: 0
 
 GridFieldExportButtonTest_NoView:


### PR DESCRIPTION
The current functionality wouldn't escape characters correctly, have switched this over to `fputcsv` and result is much better inclusive of the fact that values will only be encapsulated with quotes IF required etc.

I couldn't discover why this was never used in the first place

Aside, I tried to refrain from using `ob_start()` and `ob_get_clean()` but `stream_get_contents($stream)` had unexpected results (the page would render unstyled instead of downloading the CSV)