### PR TITLE
Fixes a bug with split file names during CSV import

### DIFF
--- a/src/Dev/CsvBulkLoader.php
+++ b/src/Dev/CsvBulkLoader.php
@@ -169,7 +169,7 @@ class CsvBulkLoader extends BulkLoader
      */
     protected function getNewSplitFileName()
     {
-        return TEMP_FOLDER . '/' . uniqid('SilverStripe\\Dev\\BulkLoader', true) . '.csv';
+        return TEMP_FOLDER . DIRECTORY_SEPARATOR . uniqid(str_replace('\\', '_', static::class), true) . '.csv';
     }
 
     /**


### PR DESCRIPTION
Howdy all,

I noticed while importing a CSV file into a `ModelAdmin` locally that there's a bug currently present with the namespaced split file name:

```php
protected function getNewSplitFileName()
{
    return TEMP_FOLDER . '/' . uniqid('SilverStripe\\Dev\\BulkLoader', true) . '.csv';
}
```

This fails on my Windows box due to the conversion of the namespace into a non-existent folder path within the temp folder.  The PR code replaces the backslashes with underscores for `static::class`, and also replaces the hardcoded forward slash with the `DIRECTORY_SEPARATOR` constant.