### PR TITLE
Fix $class variable from being clobbered

### DIFF
--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -922,9 +922,9 @@ class DataObjectSchema
         if (empty($remoteField)) {
             // look for remote has_one joins on this class or any parent classes
             $remoteRelationsMap = array_flip($remoteRelations);
-            foreach (array_reverse(ClassInfo::ancestry($class)) as $class) {
-                if (array_key_exists($class, $remoteRelationsMap)) {
-                    $remoteField = $remoteRelationsMap[$class];
+            foreach (array_reverse(ClassInfo::ancestry($class)) as $ancestryClass) {
+                if (array_key_exists($ancestryClass, $remoteRelationsMap)) {
+                    $remoteField = $remoteRelationsMap[$ancestryClass];
                     break;
                 }
             }


### PR DESCRIPTION
The $class variable gets overwritten in the function.

This causes error messages to be less helpful. For example if you setup a has_many but forget the has_one on the other side the error will look something like

`[Emergency] Uncaught Exception: No has_one found on class 'SomeObject', the has_many relation from 'SilverStripe\View\ViewableData' to 'SomeObject' requires a has_one on 'SomeObject'`

fixing this gives a more useful error, like

`[Emergency] Uncaught Exception: No has_one found on class 'SomeObject', the has_many relation from 'Page' to 'SomeObject' requires a has_one on 'SomeObject'`