### PR TITLE
Enforce type integer in DataLists byID and byIDs methods

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -948,15 +948,17 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      */
     public function byIDs($ids)
     {
-        foreach ($ids AS $id) {
-            if (!is_int($id)) {
+        $intIDs = array();
+        foreach ($ids as $id) {
+            if (!is_numeric($id)) {
                 throw new InvalidArgumentException(
-                    'Invalid value passed to byIDs() in param array. All params have to be of type Integer.'
+                    'Invalid value passed to byIDs() in param array. All params have to be numeric or of type Integer.'
                 );
             }
+            $intIDs[] = intval($id, 10);
         }
 
-        return $this->filter('ID', $ids);
+        return $this->filter('ID', $intIDs);
     }
 
     /**
@@ -968,11 +970,12 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      */
     public function byID($id)
     {
-        if (is_int($id)) {
-            return $this->filter('ID', (int)$id)->first();
-        } else {
-            throw new InvalidArgumentException('Incorrect param type for $id passed to byID(). Integer is expected.');
+        if (!is_numeric($id)) {
+            throw new InvalidArgumentException(
+                'Incorrect param type for $id passed to byID(). Numeric value is expected.'
+            );
         }
+        return $this->filter('ID', intval($id, 10))->first();
     }
 
     /**

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -943,10 +943,19 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * Filter this list to only contain the given Primary IDs
      *
      * @param array $ids Array of integers
+     * @throws InvalidArgumentException
      * @return $this
      */
     public function byIDs($ids)
     {
+        foreach ($ids AS $id) {
+            if (!is_int($id)) {
+                throw new InvalidArgumentException(
+                    'Invalid value passed to byIDs() in param array. All params have to be of type Integer.'
+                );
+            }
+        }
+
         return $this->filter('ID', $ids);
     }
 
@@ -955,10 +964,15 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @param int $id
      * @return DataObject
+     * @throws InvalidArgumentException
      */
     public function byID($id)
     {
-        return $this->filter('ID', $id)->first();
+        if (is_int($id)) {
+            return $this->filter('ID', (int)$id)->first();
+        } else {
+            throw new InvalidArgumentException('Incorrect param type for $id passed to byID(). Integer is expected.');
+        }
     }
 
     /**


### PR DESCRIPTION
Enforce type integer in DataLists byID and byIDs methods and throws exception if invalid type is given.
This is to prevent unexpected behaviour when filtering by ID without checking the type of params.
E.g. If using the get parameter **1;\"}};alert("ALERT");** unfiltered as parameter in byID it would return the entry with ID 1.