### PR TITLE
Update to 00_CSV_Import.md

### DIFF
--- a/docs/en/02_Developer_Guides/11_Integration/00_CSV_Import.md
+++ b/docs/en/02_Developer_Guides/11_Integration/00_CSV_Import.md
@@ -194,6 +194,22 @@ Sample implementation of a custom loader. Assumes a CSV-file in a certain format
 	   }
 	}
 	?>
+	
+Building off of the ModelAdmin example up top, use a custom loader instead of the default loader by adding it to `$model_importers`. In this example, `CsvBulkLoader` is replaced with `PlayerCsvBulkLoader`.
+
+	:::php
+	<?php
+	class PlayerAdmin extends ModelAdmin {
+	   private static $managed_models = array(
+		  'Player'
+	   );
+	   private static $model_importers = array(
+		  'Player' => 'PlayerCsvBulkLoader',
+	   );
+	   private static $url_segment = 'players';
+	}
+	?>
+
 
 ## Related
 


### PR DESCRIPTION
Adding further explanation for using a custom CsvBulkLoader in ModelAdmin instead of the default one. I think some people might be able to guess at this, but others (like me) might benefit from making things a bit more explicit. This is a follow up from my [question on StackOverflow](https://stackoverflow.com/questions/44271755/adding-custom-csvbulkuploader-to-modeladmin-in-silverstripe).