### PR TITLE
Fixes member import show advanced usage toggle

### DIFF
--- a/admin/javascript/MemberImportForm.js
+++ b/admin/javascript/MemberImportForm.js
@@ -26,7 +26,7 @@
 			 * Function: onclick
 			 */
 			onclick: function(e) {
-				this.parents('form:eq(0)').find('.advanced').toggle();
+				this.parents('form:eq(0)').find('.advanced').fadeToggle(250);
 				return false;
 			}
 		});


### PR DESCRIPTION
Fixes member import show advanced usage toggle.

In SilverStripe 3.x when a site is in `Live` mode the import users show advanced usage toggle button does not work.

This fixes the issue by using jQuery `fadeToggle` instead of just `toggle`. This also looks pretty.

As described in issue #6635 