### PR TITLE
[FIX] Not `CascadeLogInTo` anymore, but `CascadeInTo`

### DIFF
--- a/src/Security/MemberAuthenticator/CookieAuthenticationHandler.php
+++ b/src/Security/MemberAuthenticator/CookieAuthenticationHandler.php
@@ -81,7 +81,7 @@ class CookieAuthenticationHandler implements AuthenticationHandler
      *
      * @return IdentityStore
      */
-    public function getCascadeLogInTo()
+    public function getCascadeInTo()
     {
         return $this->cascadeInTo;
     }
@@ -92,7 +92,7 @@ class CookieAuthenticationHandler implements AuthenticationHandler
      * @param IdentityStore $cascadeInTo
      * @return $this
      */
-    public function setCascadeLogInTo(IdentityStore $cascadeInTo)
+    public function setCascadeInTo(IdentityStore $cascadeInTo)
     {
         $this->cascadeInTo = $cascadeInTo;
         return $this;


### PR DESCRIPTION
I'm mildly surprised this didn't break. I changed it to CascadeInTo, as the logout action needs to cascade into the session as well.