### PR TITLE
[FIX] CMSSecurity doesn't have Authenticators assigned.

### DIFF
--- a/_config/security.yml
+++ b/_config/security.yml
@@ -31,5 +31,8 @@ SilverStripe\Core\Injector\Injector:
     properties:
       Authenticators:
         default: %$SilverStripe\Security\MemberAuthenticator\MemberAuthenticator
+  SilverStripe\Security\CMSSecurity:
+    properties:
+      Authenticators:
         cms: %$SilverStripe\Security\MemberAuthenticator\CMSMemberAuthenticator
   SilverStripe\Security\IdentityStore: %$SilverStripe\Security\AuthenticationHandler

--- a/src/Security/CMSSecurity.php
+++ b/src/Security/CMSSecurity.php
@@ -165,14 +165,14 @@ PHP
      *
      * @return bool
      */
-    public static function enabled()
+    public function enabled()
     {
         // Disable shortcut
         if (!static::config()->get('reauth_enabled')) {
             return false;
         }
 
-        return count(Security::singleton()->getApplicableAuthenticators(Authenticator::CMS_LOGIN)) > 0;
+        return count($this->getApplicableAuthenticators(Authenticator::CMS_LOGIN)) > 0;
     }
 
     /**

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -356,7 +356,7 @@ class Security extends Controller implements TemplateGlobalProvider
                     _t('SilverStripe\\CMS\\Controllers\\ContentController.NOTLOGGEDIN', 'Not logged in')
                 );
                 // Tell the CMS to allow re-authentication
-                if (CMSSecurity::enabled()) {
+                if (CMSSecurity::singleton()->enabled()) {
                     $response->addHeader('X-Reauthenticate', '1');
                 }
             }


### PR DESCRIPTION
 Switching to Security::singleton()->getApplicableAuthenticators() and Security::singleton()->getAuthenticators() fixes this and makes it more robust.