### PR TITLE
Ensure a member exists before calling `isLockedOut`

### DIFF
--- a/security/MemberAuthenticator.php
+++ b/security/MemberAuthenticator.php
@@ -51,7 +51,9 @@ class MemberAuthenticator extends Authenticator {
 		if($asDefaultAdmin) {
 			// If logging is as default admin, ensure record is setup correctly
 			$member = Member::default_admin();
-			$success = !$member->isLockedOut() && Security::check_default_admin($email, $data['Password']);
+			if($member && !is_null($member)) {
+				$success = !$member->isLockedOut() && Security::check_default_admin($email, $data['Password']);
+			}
 			//protect against failed login
 			if($success) {
 				return $member;


### PR DESCRIPTION
Keep seeing `PHP Fatal error: Call to a member function isLockedOut() on null` in logs, this should fix that.