### PR TITLE
Fix changetracker checkbox bugs

### DIFF
--- a/admin/javascript/jquery-changetracker/lib/jquery.changetracker.js
+++ b/admin/javascript/jquery-changetracker/lib/jquery.changetracker.js
@@ -92,7 +92,10 @@
 			fields.not(':radio,:checkbox').bind('change.changetracker', onchange);
 			fields.each(function() {
 				if($(this).is(':radio,:checkbox')) {
-					origVal = self.find(':input[name=' + $(this).attr('name') + ']:checked').val();
+					origVal = self.find(':input[name="' + $(this).attr('name') + '"]:checked').val();
+					if("undefined" === typeof origVal){
+						origVal = 0;
+					}
 				} else {
 					origVal = $(this).val();
 				}


### PR DESCRIPTION
Checkboxes that are initially unchecked, do not work with the changetracker correctly (eg activating/deactivating "Save draft" and "Save & publish" buttons properly).

There are two bugs, both in the “setup original values” code (jquery.changetracker.js, line ~95):
1) The radio/checkbox jQuery selector does not use a quoted attribute for searching the name field, which breaks on CheckboxsetField’s bracketed[] names
2) The “has changed” logic for checkboxes treats all new values as 1 or 0, however the initialization ends up setting the original values for unchecked boxes to `undefined`, which will not match the 0 value when the box is unchecked again

This commit fixes both of these issues.