### PR TITLE
Bug: Complex (curly) syntax

### DIFF
--- a/model/connect/DBSchemaManager.php
+++ b/model/connect/DBSchemaManager.php
@@ -591,7 +591,7 @@ abstract class DBSchemaManager {
 		if (!isset($this->tableList[strtolower($table)])) $newTable = true;
 
 		if (is_array($spec)) {
-			$specValue = $this->$spec_orig['type']($spec_orig['parts']);
+			$specValue = $this->{$spec_orig['type']}($spec_orig['parts']);
 		} else {
 			$specValue = $spec;
 		}


### PR DESCRIPTION
This maybe an overlook at recent php7 fixes which other lines of code has been updated.
Fixing this error help me install ss3.6 with PHP7.1 using PostgreSQL database
"PostgreSQL 9.5.6 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609, 64-bit"