### PR TITLE
Html editor selection is now properly stored while the dialog is open.

### DIFF
--- a/javascript/HtmlEditorField.js
+++ b/javascript/HtmlEditorField.js
@@ -873,9 +873,6 @@ ss.editorWrappers['default'] = ss.editorWrappers.tinyMCE;
 						linkDataSource = selectedEl = selectedEl.parents('a:first');
 					}
 				}
-				if(linkDataSource && linkDataSource.length) this.modifySelection(function(ed){
-					ed.selectNode(linkDataSource[0]);
-				});
 
 				// Is anchor not a link
 				if (!linkDataSource.attr('href')) linkDataSource = null;


### PR DESCRIPTION
In SilverStripe 3.5.3 the `update link` functionality in HTML editor is not working. `update link` is invoked when CMS user opens `insert link` dialog while an existing link is already selected in the HTML editor and then clicks on `insert link` button. The expected behaviour is to update the link data based on the form, however current behaviour is that the link gets removed instead. This is a big annoyance for CMS users as the only way to change an existing link is to remove it and re-add it.

After detailed investigation I was able to locate the source of the issue. When dialog opens, the current selection is bookmarked (saved for later use) and after dialog closes, the selection gets restored. Current version changes the selection by wrapping it inside the parent element for some reason. This causes the target anchor element to get lost. If target anchor is not found, removal action is chosen instead of update action.

The cause of this issue is located in the getCurrentLink() function. This function contains several instances of questionable code like unused variables. It claims to correct the selection if the selection reaches outside of the anchor element, however after some testing I wasn't able to see this functionality actually working.

My change removes part of the broken functionality and causes the selection to be properly restored. After this change the anchor is no longer lost and thus the update action is correctly chosen instead of removal.