### PR TITLE
Initially set a default height for the html editor to 350px

### DIFF
--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -331,7 +331,8 @@ class TinyMCEConfig extends HTMLEditorConfig
     {
         return [
             'data-editor' => 'tinyMCE', // Register ss.editorWrappers.tinyMCE
-            'data-config' => Convert::array2json($this->getConfig())
+            'data-config' => Convert::array2json($this->getConfig()),
+            'style' => 'height:350px'
         ];
     }
 


### PR DESCRIPTION
BUG TinyMCE WYSIWYG loses height after saving page #1831

This merge request will set the initial tinymce editor height
See https://github.com/silverstripe/silverstripe-cms/issues/1831