### PR TITLE
NEW Ensure polymorphic has_one fields are indexed

### DIFF
--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -44,6 +44,13 @@ class DataObjectSchema
     protected $databaseIndexes = [];
 
     /**
+     * Fields that should be indexed, by class name
+     *
+     * @var array
+     */
+    protected $defaultDatabaseIndexes = [];
+
+    /**
      * Cache of composite database field
      *
      * @var array
@@ -65,6 +72,7 @@ class DataObjectSchema
         $this->tableNames = [];
         $this->databaseFields = [];
         $this->databaseIndexes = [];
+        $this->defaultDatabaseIndexes = [];
         $this->compositeFields = [];
     }
 
@@ -193,7 +201,6 @@ class DataObjectSchema
         foreach ($classes as $tableClass) {
             // Find all fields on this class
             $fields = $this->databaseFields($tableClass, false);
-
             // Merge with composite fields
             if (!$dbOnly) {
                 $compositeFields = $this->compositeFields($tableClass, false);
@@ -486,30 +493,59 @@ class DataObjectSchema
     }
 
     /**
-     * Cache all indexes for the given class.
-     * Will do nothing if already cached
+     * Cache all indexes for the given class. Will do nothing if already cached.
      *
      * @param $class
      */
     protected function cacheDatabaseIndexes($class)
     {
-        if (array_key_exists($class, $this->databaseIndexes)) {
-            return;
+        if (!array_key_exists($class, $this->databaseIndexes)) {
+            $this->databaseIndexes[$class] = array_merge(
+                $this->cacheDefaultDatabaseIndexes($class),
+                $this->buildCustomDatabaseIndexes($class)
+            );
         }
-        $indexes = [];
+    }
 
-        // look for indexable field types
-        foreach ($this->databaseFields($class, false) as $field => $type) {
-            /** @skipUpgrade */
-            if ($type === 'ForeignKey' || $type === 'DBClassName') {
-                $indexes[$field] = [
+    /**
+     * Get "default" database indexable field types
+     *
+     * @param  string $class
+     * @return array
+     */
+    protected function cacheDefaultDatabaseIndexes($class)
+    {
+        $indexes = [];
+        if (array_key_exists($class, $this->defaultDatabaseIndexes)) {
+            return $this->defaultDatabaseIndexes[$class];
+        }
+        $this->defaultDatabaseIndexes[$class] = [];
+
+        $fieldSpecs = $this->fieldSpecs($class, self::UNINHERITED);
+        foreach ($fieldSpecs as $field => $spec) {
+            /** @var DBField $fieldObj */
+            $fieldObj = Injector::inst()->create($spec, $field);
+            if ($fieldObj->getIndexed()) {
+                $this->defaultDatabaseIndexes[$class][$field] = [
                     'type' => 'index',
-                    'columns' => [$field],
+                    'columns' => $fieldObj->getIndexSpecs(),
                 ];
             }
         }
+        return $this->defaultDatabaseIndexes[$class];
+    }
 
-        // look for custom indexes declared on the class
+    /**
+     * Look for custom indexes declared on the class
+     *
+     * @param  string $class
+     * @return array
+     * @throws InvalidArgumentException If an index already exists on the class
+     * @throws InvalidArgumentException If a custom index format is not valid
+     */
+    protected function buildCustomDatabaseIndexes($class)
+    {
+        $indexes = [];
         $classIndexes = Config::inst()->get($class, 'indexes', Config::UNINHERITED) ?: [];
         foreach ($classIndexes as $indexName => $indexSpec) {
             if (array_key_exists($indexName, $indexes)) {
@@ -546,8 +582,7 @@ class DataObjectSchema
             }
             $indexes[$indexName] = $indexSpec;
         }
-
-        $this->databaseIndexes[$class] = $indexes;
+        return $indexes;
     }
 
     /**

--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -525,9 +525,9 @@ class DataObjectSchema
         foreach ($fieldSpecs as $field => $spec) {
             /** @var DBField $fieldObj */
             $fieldObj = Injector::inst()->create($spec, $field);
-            if ($fieldObj->getIndexed()) {
+            if ($type = $fieldObj->getIndexType()) {
                 $this->defaultDatabaseIndexes[$class][$field] = [
-                    'type' => 'index',
+                    'type' => $type,
                     'columns' => $fieldObj->getIndexSpecs(),
                 ];
             }

--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -525,11 +525,8 @@ class DataObjectSchema
         foreach ($fieldSpecs as $field => $spec) {
             /** @var DBField $fieldObj */
             $fieldObj = Injector::inst()->create($spec, $field);
-            if ($type = $fieldObj->getIndexType()) {
-                $this->defaultDatabaseIndexes[$class][$field] = [
-                    'type' => $type,
-                    'columns' => $fieldObj->getIndexSpecs(),
-                ];
+            if ($indexSpecs = $fieldObj->getIndexSpecs()) {
+                $this->defaultDatabaseIndexes[$class][$field] = $indexSpecs;
             }
         }
         return $this->defaultDatabaseIndexes[$class];

--- a/src/ORM/FieldType/DBClassName.php
+++ b/src/ORM/FieldType/DBClassName.php
@@ -37,6 +37,8 @@ class DBClassName extends DBEnum
      */
     protected static $classname_cache = array();
 
+    private static $indexed = true;
+
     /**
      * Clear all cached classname specs. It's necessary to clear all cached subclassed names
      * for any classes if a new class manifest is generated.
@@ -49,13 +51,14 @@ class DBClassName extends DBEnum
     /**
      * Create a new DBClassName field
      *
-     * @param string $name Name of field
+     * @param string      $name      Name of field
      * @param string|null $baseClass Optional base class to limit selections
+     * @param array       $options   Optional parameters for this DBField instance
      */
-    public function __construct($name = null, $baseClass = null)
+    public function __construct($name = null, $baseClass = null, $options = [])
     {
         $this->setBaseClass($baseClass);
-        parent::__construct($name);
+        parent::__construct($name, null, null, $options);
     }
 
     /**

--- a/src/ORM/FieldType/DBClassName.php
+++ b/src/ORM/FieldType/DBClassName.php
@@ -37,7 +37,7 @@ class DBClassName extends DBEnum
      */
     protected static $classname_cache = array();
 
-    private static $indexed = true;
+    private static $index = true;
 
     /**
      * Clear all cached classname specs. It's necessary to clear all cached subclassed names

--- a/src/ORM/FieldType/DBComposite.php
+++ b/src/ORM/FieldType/DBComposite.php
@@ -293,4 +293,11 @@ abstract class DBComposite extends DBField
 
         return parent::castingHelper($field);
     }
+
+    public function getIndexSpecs()
+    {
+        return array_map(function ($name) {
+            return $this->getName() . $name;
+        }, array_keys((array) static::config()->get('composite_db')));
+    }
 }

--- a/src/ORM/FieldType/DBComposite.php
+++ b/src/ORM/FieldType/DBComposite.php
@@ -296,8 +296,15 @@ abstract class DBComposite extends DBField
 
     public function getIndexSpecs()
     {
-        return array_map(function ($name) {
-            return $this->getName() . $name;
-        }, array_keys((array) static::config()->get('composite_db')));
+        if ($type = $this->getIndexType()) {
+            $columns = array_map(function ($name) {
+                return $this->getName() . $name;
+            }, array_keys((array) static::config()->get('composite_db')));
+
+            return [
+                'type' => $type,
+                'columns' => $columns,
+            ];
+        }
     }
 }

--- a/src/ORM/FieldType/DBEnum.php
+++ b/src/ORM/FieldType/DBEnum.php
@@ -51,8 +51,9 @@ class DBEnum extends DBString
      * @param string $name
      * @param string|array $enum A string containing a comma separated list of options or an array of Vals.
      * @param string $default The default option, which is either NULL or one of the items in the enumeration.
+     * @param array  $options Optional parameters for this DB field
      */
-    public function __construct($name = null, $enum = null, $default = null)
+    public function __construct($name = null, $enum = null, $default = null, $options = [])
     {
         if ($enum) {
             $this->setEnum($enum);
@@ -73,7 +74,7 @@ class DBEnum extends DBString
             }
         }
 
-        parent::__construct($name);
+        parent::__construct($name, $options);
     }
 
     /**

--- a/src/ORM/FieldType/DBField.php
+++ b/src/ORM/FieldType/DBField.php
@@ -635,6 +635,11 @@ DBG;
 
     public function getIndexSpecs()
     {
-        return [$this->getName()];
+        if ($type = $this->getIndexType()) {
+            return [
+                'type' => $type,
+                'columns' => [$this->getName()],
+            ];
+        }
     }
 }

--- a/src/ORM/FieldType/DBForeignKey.php
+++ b/src/ORM/FieldType/DBForeignKey.php
@@ -29,7 +29,7 @@ class DBForeignKey extends DBInt
      */
     protected $object;
 
-    private static $indexed = true;
+    private static $index = true;
 
     private static $default_search_filter_class = 'ExactMatchFilter';
 

--- a/src/ORM/FieldType/DBForeignKey.php
+++ b/src/ORM/FieldType/DBForeignKey.php
@@ -29,6 +29,8 @@ class DBForeignKey extends DBInt
      */
     protected $object;
 
+    private static $indexed = true;
+
     private static $default_search_filter_class = 'ExactMatchFilter';
 
     public function __construct($name, $object = null)

--- a/src/ORM/FieldType/DBIndexable.php
+++ b/src/ORM/FieldType/DBIndexable.php
@@ -42,7 +42,14 @@ interface DBIndexable
     public function getIndexType();
 
     /**
-     * Get the field(s) that should be used if this instance is indexed
+     * Returns the index specifications for the field instance, for example:
+     *
+     * <code>
+     * [
+     *     'type' => 'unique',
+     *     'columns' => ['FieldName']
+     * ]
+     * </code>
      *
      * @return array
      */

--- a/src/ORM/FieldType/DBIndexable.php
+++ b/src/ORM/FieldType/DBIndexable.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SilverStripe\ORM\FieldType;
+
+/**
+ * Classes that implement the DBIndexable interface will provide options to set various index types and index
+ * contents, which will be processed by {@link \SilverStripe\ORM\DataObjectSchema}
+ */
+interface DBIndexable
+{
+    /**
+     * Index types that can be used. Please check your database driver to ensure choices are supported.
+     *
+     * @var string
+     */
+    const TYPE_INDEX = 'index';
+    const TYPE_UNIQUE = 'unique';
+    const TYPE_FULLTEXT = 'fulltext';
+
+    /**
+     * If "true" is provided to setIndexType, this default index type will be returned
+     *
+     * @var string
+     */
+    const TYPE_DEFAULT = 'index';
+
+    /**
+     * Set the desired index type to use
+     *
+     * @param string|bool $indexType Either of the types listed in {@link SilverStripe\ORM\FieldType\DBIndexable}, or
+     *                               boolean true to indicate that the default index type should be used.
+     * @return $this
+     * @throws InvalidArgumentException If $type is not one of TYPE_INDEX, TYPE_UNIQUE or TYPE_FULLTEXT
+     */
+    public function setIndexType($type);
+
+    /**
+     * Return the desired index type to use. Will return false if the field instance should not be indexed.
+     *
+     * @return string|bool
+     */
+    public function getIndexType();
+
+    /**
+     * Get the field(s) that should be used if this instance is indexed
+     *
+     * @return array
+     */
+    public function getIndexSpecs();
+}

--- a/src/ORM/FieldType/DBPolymorphicForeignKey.php
+++ b/src/ORM/FieldType/DBPolymorphicForeignKey.php
@@ -9,11 +9,11 @@ use SilverStripe\ORM\DataObject;
  */
 class DBPolymorphicForeignKey extends DBComposite
 {
-    private static $indexed = true;
+    private static $index = true;
 
     private static $composite_db = array(
         'ID' => 'Int',
-        'Class' => "DBClassName('" . DataObject::class . "', ['indexed' => false])"
+        'Class' => "DBClassName('" . DataObject::class . "', ['index' => false])"
     );
 
     public function scaffoldFormField($title = null, $params = null)

--- a/src/ORM/FieldType/DBPolymorphicForeignKey.php
+++ b/src/ORM/FieldType/DBPolymorphicForeignKey.php
@@ -9,10 +9,11 @@ use SilverStripe\ORM\DataObject;
  */
 class DBPolymorphicForeignKey extends DBComposite
 {
+    private static $indexed = true;
 
     private static $composite_db = array(
         'ID' => 'Int',
-        'Class' => "DBClassName('SilverStripe\\ORM\\DataObject')"
+        'Class' => "DBClassName('" . DataObject::class . "', ['indexed' => false])"
     );
 
     public function scaffoldFormField($title = null, $params = null)

--- a/src/ORM/FieldType/DBString.php
+++ b/src/ORM/FieldType/DBString.php
@@ -7,12 +7,6 @@ namespace SilverStripe\ORM\FieldType;
  */
 abstract class DBString extends DBField
 {
-
-    /**
-     * @var boolean
-     */
-    protected $nullifyEmpty = true;
-
     /**
      * @var array
      */
@@ -26,22 +20,14 @@ abstract class DBString extends DBField
     );
 
     /**
-     * Construct a string type field with a set of optional parameters.
+     * Set the default value for "nullify empty"
      *
-     * @param string $name string The name of the field
-     * @param array $options array An array of options e.g. array('nullifyEmpty'=>false).  See
-     *                       {@link StringField::setOptions()} for information on the available options
+     * {@inheritDoc}
      */
-    public function __construct($name = null, $options = array())
+    public function __construct($name = null, $options = [])
     {
-        if ($options) {
-            if (!is_array($options)) {
-                throw new \InvalidArgumentException("Invalid options $options");
-            }
-            $this->setOptions($options);
-        }
-
-        parent::__construct($name);
+        $this->options['nullifyEmpty'] = true;
+        parent::__construct($name, $options);
     }
 
     /**
@@ -56,14 +42,17 @@ abstract class DBString extends DBField
      *   </li></ul>
      * @return $this
      */
-    public function setOptions(array $options = array())
+    public function setOptions(array $options = [])
     {
-        if (array_key_exists("nullifyEmpty", $options)) {
-            $this->nullifyEmpty = $options["nullifyEmpty"] ? true : false;
+        parent::setOptions($options);
+
+        if (array_key_exists('nullifyEmpty', $options)) {
+            $this->options['nullifyEmpty'] = (bool) $options['nullifyEmpty'];
         }
-        if (array_key_exists("default", $options)) {
-            $this->setDefaultValue($options["default"]);
+        if (array_key_exists('default', $options)) {
+            $this->setDefaultValue($options['default']);
         }
+
         return $this;
     }
 
@@ -72,10 +61,12 @@ abstract class DBString extends DBField
      * them to null.
      *
      * @param $value boolean True if empty strings are to be converted to null
+     * @return $this
      */
     public function setNullifyEmpty($value)
     {
-        $this->nullifyEmpty = ($value ? true : false);
+        $this->options['nullifyEmpty'] = (bool) $value;
+        return $this;
     }
 
     /**
@@ -86,7 +77,7 @@ abstract class DBString extends DBField
      */
     public function getNullifyEmpty()
     {
-        return $this->nullifyEmpty;
+        return $this->options['nullifyEmpty'];
     }
 
     /**
@@ -108,7 +99,7 @@ abstract class DBString extends DBField
         }
 
         // Return "empty" value
-        if ($this->nullifyEmpty || $value === null) {
+        if ($this->options['nullifyEmpty'] || $value === null) {
             return null;
         }
         return '';

--- a/tests/php/ORM/DataObjectSchemaTest.php
+++ b/tests/php/ORM/DataObjectSchemaTest.php
@@ -4,8 +4,8 @@ namespace SilverStripe\ORM\Tests;
 
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
-use SilverStripe\ORM\FieldType\DBMoney;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\FieldType\DBMoney;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectSchema;
 use SilverStripe\ORM\Tests\DataObjectSchemaTest\AllIndexes;
@@ -298,12 +298,26 @@ class DataObjectSchemaTest extends SapphireTest
 
     public function testCompositeFieldsCanBeIndexedByDefaultConfiguration()
     {
-        Config::modify()->set(DBMoney::class, 'indexed', true);
+        Config::modify()->set(DBMoney::class, 'index', true);
         $indexes = DataObject::getSchema()->databaseIndexes(HasComposites::class);
+
         $this->assertCount(4, $indexes);
         $this->assertArrayHasKey('Amount', $indexes);
         $this->assertEquals([
             'type' => 'index',
+            'columns' => ['AmountCurrency', 'AmountAmount']
+        ], $indexes['Amount']);
+    }
+
+    public function testIndexTypeIsConfigurable()
+    {
+        Config::modify()->set(DBMoney::class, 'index', 'unique');
+
+        $indexes = DataObject::getSchema()->databaseIndexes(HasComposites::class);
+        $this->assertCount(4, $indexes);
+        $this->assertArrayHasKey('Amount', $indexes);
+        $this->assertEquals([
+            'type' => 'unique',
             'columns' => ['AmountCurrency', 'AmountAmount']
         ], $indexes['Amount']);
     }
@@ -317,7 +331,7 @@ class DataObjectSchemaTest extends SapphireTest
 
         $this->assertArrayHasKey('IndexedTitle', $indexes);
         $this->assertEquals([
-            'type' => 'index',
+            'type' => 'fulltext',
             'columns' => ['IndexedTitle']
         ], $indexes['IndexedTitle']);
 

--- a/tests/php/ORM/DataObjectSchemaTest/AllIndexes.php
+++ b/tests/php/ORM/DataObjectSchemaTest/AllIndexes.php
@@ -3,6 +3,7 @@ namespace SilverStripe\ORM\Tests\DataObjectSchemaTest;
 
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\FieldType\DBIndexable;
 
 class AllIndexes extends DataObject implements TestOnly
 {
@@ -18,7 +19,7 @@ class AllIndexes extends DataObject implements TestOnly
         'Content' => true,
         'IndexCols' => ['Title', 'Content'],
         'IndexUnique' => [
-            'type' => 'unique',
+            'type' => DBIndexable::TYPE_UNIQUE,
             'columns' => ['Number'],
         ],
         'IndexNormal' => [

--- a/tests/php/ORM/DataObjectSchemaTest/HasComposites.php
+++ b/tests/php/ORM/DataObjectSchemaTest/HasComposites.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectSchemaTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class HasComposites extends DataObject implements TestOnly
+{
+    private static $db = [
+        'Amount' => 'Money'
+    ];
+
+    private static $has_one = [
+        'RegularHasOne' => ChildClass::class,
+        'Polymorpheus' => DataObject::class
+    ];
+}

--- a/tests/php/ORM/DataObjectSchemaTest/HasIndexesInFieldSpecs.php
+++ b/tests/php/ORM/DataObjectSchemaTest/HasIndexesInFieldSpecs.php
@@ -9,8 +9,8 @@ class HasIndexesInFieldSpecs extends DataObject implements TestOnly
 {
     private static $db = [
         'Normal' => 'Varchar',
-        'IndexedTitle' => 'Varchar(255, ["indexed" => true])',
+        'IndexedTitle' => 'Varchar(255, ["index" => "fulltext"])',
         'NormalMoney' => 'Money',
-        'IndexedMoney' => 'Money(["indexed" => true])'
+        'IndexedMoney' => 'Money(["index" => true])'
     ];
 }

--- a/tests/php/ORM/DataObjectSchemaTest/HasIndexesInFieldSpecs.php
+++ b/tests/php/ORM/DataObjectSchemaTest/HasIndexesInFieldSpecs.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectSchemaTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class HasIndexesInFieldSpecs extends DataObject implements TestOnly
+{
+    private static $db = [
+        'Normal' => 'Varchar',
+        'IndexedTitle' => 'Varchar(255, ["indexed" => true])',
+        'NormalMoney' => 'Money',
+        'IndexedMoney' => 'Money(["indexed" => true])'
+    ];
+}


### PR DESCRIPTION
I'm not sure whether this is the best way to tackle this, but at the point where you're looping database fields there's nothing to indicate that the relationship is polymorphic other than it is a ClassName enum. I've used that to look for a matching field name with the "ID" suffix and treat those as polymorphic.

Resolves #6966