### PR TITLE
[WIP] Move ThemeResourceLoader to ResourceLoader

### DIFF
--- a/src/Core/CoreKernel.php
+++ b/src/Core/CoreKernel.php
@@ -20,12 +20,12 @@ use SilverStripe\Core\Manifest\ClassLoader;
 use SilverStripe\Core\Manifest\ClassManifest;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Core\Manifest\ModuleManifest;
+use SilverStripe\Core\Manifest\ResourceLoader;
 use SilverStripe\Dev\DebugView;
 use SilverStripe\Dev\Install\DatabaseAdapterRegistry;
 use SilverStripe\Logging\ErrorHandler;
 use SilverStripe\ORM\DB;
 use SilverStripe\View\ThemeManifest;
-use SilverStripe\View\ThemeResourceLoader;
 
 /**
  * Simple Kernel container
@@ -68,9 +68,9 @@ class CoreKernel implements Kernel
     protected $injectorLoader = null;
 
     /**
-     * @var ThemeResourceLoader
+     * @var ResourceLoader
      */
-    protected $themeResourceLoader = null;
+    protected $resourceLoader = null;
 
     protected $basePath = null;
 
@@ -113,13 +113,13 @@ class CoreKernel implements Kernel
         $this->setConfigLoader($configLoader);
 
         // Load template manifest
-        $themeResourceLoader = ThemeResourceLoader::inst();
-        $themeResourceLoader->addSet('$default', new ThemeManifest(
+        $resourceLoader = ResourceLoader::inst();
+        $resourceLoader->addSet('$default', new ThemeManifest(
             $basePath,
             project(),
             $manifestCacheFactory
         ));
-        $this->setThemeResourceLoader($themeResourceLoader);
+        $this->setResourceLoader($resourceLoader);
     }
 
     public function getEnvironment()
@@ -480,7 +480,7 @@ class CoreKernel implements Kernel
         }
 
         // Find default templates
-        $defaultSet = $this->getThemeResourceLoader()->getSet('$default');
+        $defaultSet = $this->getResourceLoader()->getSet('$default');
         if ($defaultSet instanceof ThemeManifest) {
             $defaultSet->init($this->getIncludeTests(), $flush);
         }
@@ -600,14 +600,14 @@ class CoreKernel implements Kernel
         return $this;
     }
 
-    public function getThemeResourceLoader()
+    public function getResourceLoader()
     {
-        return $this->themeResourceLoader;
+        return $this->resourceLoader;
     }
 
-    public function setThemeResourceLoader($themeResourceLoader)
+    public function setResourceLoader($resourceLoader)
     {
-        $this->themeResourceLoader = $themeResourceLoader;
+        $this->resourceLoader = $resourceLoader;
         return $this;
     }
 }

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -7,7 +7,7 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Injector\InjectorLoader;
 use SilverStripe\Core\Manifest\ClassLoader;
 use SilverStripe\Core\Manifest\ModuleLoader;
-use SilverStripe\View\ThemeResourceLoader;
+use SilverStripe\Core\Manifest\ResourceLoader;
 
 /**
  * Represents the core state of a SilverStripe application
@@ -108,15 +108,15 @@ interface Kernel
     public function setConfigLoader($configLoader);
 
     /**
-     * @return ThemeResourceLoader
+     * @return ResourceLoader
      */
-    public function getThemeResourceLoader();
+    public function getResourceLoader();
 
     /**
-     * @param ThemeResourceLoader $themeResourceLoader
+     * @param ResourceLoader $resourceLoader
      * @return $this
      */
-    public function setThemeResourceLoader($themeResourceLoader);
+    public function setResourceLoader($resourceLoader);
 
     /**
      * One of dev, live, or test

--- a/src/Core/Manifest/ResourceLoader.php
+++ b/src/Core/Manifest/ResourceLoader.php
@@ -1,17 +1,15 @@
 <?php
 
-namespace SilverStripe\View;
-
-use SilverStripe\Core\Manifest\ModuleLoader;
+namespace SilverStripe\Core\Manifest;
 
 /**
- * Handles finding templates from a stack of template manifest objects.
+ * Finds resources from 1 or more themes/modules.
  */
-class ThemeResourceLoader
+class ResourceLoader
 {
 
     /**
-     * @var ThemeResourceLoader
+     * @var ResourceLoader
      */
     private static $instance;
 
@@ -26,7 +24,7 @@ class ThemeResourceLoader
     protected $sets = [];
 
     /**
-     * @return ThemeResourceLoader
+     * @return ResourceLoader
      */
     public static function inst()
     {
@@ -36,9 +34,9 @@ class ThemeResourceLoader
     /**
      * Set instance
      *
-     * @param ThemeResourceLoader $instance
+     * @param ResourceLoader $instance
      */
-    public static function set_instance(ThemeResourceLoader $instance)
+    public static function set_instance(ResourceLoader $instance)
     {
         self::$instance = $instance;
     }
@@ -71,6 +69,23 @@ class ThemeResourceLoader
             return $this->sets[$set];
         }
         return null;
+    }
+
+    /**
+     * Returns the absolute path to the given resource
+     */
+    public function getResourcePath($theme, $resource)
+    {
+
+    }
+
+    /**
+     * Returns the URL of the given resource.
+     * The URL will be relative to the domain root (it will start with "/") unless it exists on a different domain.
+     */
+    public function getResourceURL($theme, $resource)
+    {
+
     }
 
     /**

--- a/src/Core/Manifest/ThemeList.php
+++ b/src/Core/Manifest/ThemeList.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\View;
+namespace SilverStripe\Core\Manifest;
 
 /**
  * Contains references to any number of themes or theme directories

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -618,12 +618,12 @@ class TinyMCEConfig extends HTMLEditorConfig
         $editor = array();
 
         // Add standard editor.css
-        $editor[] = Director::absoluteURL(ltrim($this->getAdminPath() . '/client/dist/styles/editor.css', '/'));
+        $editor[] = ResourceLoader::inst()->getResourceURL('framework/admin/', 'client/dist/styles/css/editor.css');
 
         // Themed editor.css
-        $themedEditor = ResourceLoader::inst()->findThemedCSS('editor', SSViewer::get_themes());
+        $themedEditor = ResourceLoader::inst()->getResourceURL(SSViewer::get_themes(), 'css/editor.css');
         if ($themedEditor) {
-            $editor[] = Director::absoluteURL($themedEditor, Director::BASE);
+            $editor[] = $themedEditor;
         }
 
         return $editor;

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -9,7 +9,7 @@ use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\i18n\i18n;
 use SilverStripe\View\Requirements;
 use SilverStripe\View\SSViewer;
-use SilverStripe\View\ThemeResourceLoader;
+use SilverStripe\Core\Manifest\ResourceLoader;
 use TinyMCE_Compressor;
 use Exception;
 
@@ -621,7 +621,7 @@ class TinyMCEConfig extends HTMLEditorConfig
         $editor[] = Director::absoluteURL(ltrim($this->getAdminPath() . '/client/dist/styles/editor.css', '/'));
 
         // Themed editor.css
-        $themedEditor = ThemeResourceLoader::inst()->findThemedCSS('editor', SSViewer::get_themes());
+        $themedEditor = ResourceLoader::inst()->findThemedCSS('editor', SSViewer::get_themes());
         if ($themedEditor) {
             $editor[] = Director::absoluteURL($themedEditor, Director::BASE);
         }

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -1445,12 +1445,19 @@ MESSAGE
      */
     public function themedCSS($name, $media = null)
     {
-        $path = ResourceLoader::inst()->findThemedCSS($name, SSViewer::get_themes());
+        if (substr($name, -4) !== '.css') {
+            $name .= '.css';
+        }
+
+        $path = ResourceLoader::inst()->getRelativeResourcePath(SSViewer::get_themes(), "css/$name");
+        if (!$path) {
+            $path =  ResourceLoader::inst()->getRelativeResourcePath(SSViewer::get_themes(), $name);
+        }
         if ($path) {
             $this->css($path, $media);
         } else {
             throw new \InvalidArgumentException(
-                "The css file doesn't exist. Please check if the file $name.css exists in any context or search for "
+                "The css file doesn't exist. Please check if the file $name exists in any context or search for "
                 . "themedCSS references calling this file in your templates."
             );
         }
@@ -1469,7 +1476,14 @@ MESSAGE
      */
     public function themedJavascript($name, $type = null)
     {
-        $path = ResourceLoader::inst()->findThemedJavascript($name, SSViewer::get_themes());
+        if (substr($name, -3) !== '.js') {
+            $name .= '.js';
+        }
+
+        $path = ResourceLoader::inst()->getRelativeResourcePath(SSViewer::get_themes(), "javascript/$name");
+        if (!$path) {
+            $path =  ResourceLoader::inst()->getRelativeResourcePath(SSViewer::get_themes(), $name);
+        }
         if ($path) {
             $opts = [];
             if ($type) {
@@ -1478,7 +1492,7 @@ MESSAGE
             $this->javascript($path, $opts);
         } else {
             throw new \InvalidArgumentException(
-                "The javascript file doesn't exist. Please check if the file $name.js exists in any "
+                "The javascript file doesn't exist. Please check if the file $name exists in any "
                 . "context or search for themedJavascript references calling this file in your templates."
             );
         }

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -4,6 +4,7 @@ namespace SilverStripe\View;
 
 use Exception;
 use InvalidArgumentException;
+use SilverStripe\Core\Manifest\ResourceLoader;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Storage\GeneratedAssetHandler;
 use SilverStripe\Control\Director;
@@ -1444,7 +1445,7 @@ MESSAGE
      */
     public function themedCSS($name, $media = null)
     {
-        $path = ThemeResourceLoader::inst()->findThemedCSS($name, SSViewer::get_themes());
+        $path = ResourceLoader::inst()->findThemedCSS($name, SSViewer::get_themes());
         if ($path) {
             $this->css($path, $media);
         } else {
@@ -1468,7 +1469,7 @@ MESSAGE
      */
     public function themedJavascript($name, $type = null)
     {
-        $path = ThemeResourceLoader::inst()->findThemedJavascript($name, SSViewer::get_themes());
+        $path = ResourceLoader::inst()->findThemedJavascript($name, SSViewer::get_themes());
         if ($path) {
             $opts = [];
             if ($type) {

--- a/src/View/SSViewer.php
+++ b/src/View/SSViewer.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\View;
 
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Manifest\ResourceLoader;
 use SilverStripe\Core\ClassInfo;
 use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Convert;
@@ -284,7 +285,7 @@ class SSViewer implements Flushable
      */
     public static function chooseTemplate($templates)
     {
-        return ThemeResourceLoader::inst()->findTemplate($templates, self::get_themes());
+        return ResourceLoader::inst()->findTemplate($templates, self::get_themes());
     }
 
     /**
@@ -319,7 +320,7 @@ class SSViewer implements Flushable
      */
     public static function hasTemplate($templates)
     {
-        return (bool)ThemeResourceLoader::inst()->findTemplate($templates, self::get_themes());
+        return (bool)ResourceLoader::inst()->findTemplate($templates, self::get_themes());
     }
 
     /**
@@ -362,7 +363,7 @@ class SSViewer implements Flushable
      */
     public static function getTemplateFileByType($identifier, $type = null)
     {
-        return ThemeResourceLoader::inst()->findTemplate(['type' => $type, $identifier], self::get_themes());
+        return ResourceLoader::inst()->findTemplate(['type' => $type, $identifier], self::get_themes());
     }
 
     /**

--- a/src/View/ThemeManifest.php
+++ b/src/View/ThemeManifest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\View;
 use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Cache\CacheFactory;
 use SilverStripe\Core\Manifest\ManifestFileFinder;
+use SilverStripe\Core\Manifest\ThemeList;
 
 /**
  * A class which builds a manifest of all themes (which is really just a directory called "templates")

--- a/src/i18n/Data/Sources.php
+++ b/src/i18n/Data/Sources.php
@@ -5,10 +5,10 @@ namespace SilverStripe\i18n\Data;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Manifest\ModuleLoader;
+use SilverStripe\Core\Manifest\ResourceLoader;
 use SilverStripe\Core\Resettable;
 use SilverStripe\i18n\i18n;
 use SilverStripe\View\SSViewer;
-use SilverStripe\View\ThemeResourceLoader;
 
 /**
  * Data sources for localisation strings. I.e. yml files stored
@@ -100,7 +100,7 @@ class Sources implements Resettable
         }
 
         // Search theme dirs (receives relative paths)
-        $locator = ThemeResourceLoader::inst();
+        $locator = ResourceLoader::inst();
         foreach (SSViewer::get_themes() as $theme) {
             if ($locator->getSet($theme)) {
                 continue;

--- a/src/i18n/Data/Sources.php
+++ b/src/i18n/Data/Sources.php
@@ -105,7 +105,7 @@ class Sources implements Resettable
             if ($locator->getSet($theme)) {
                 continue;
             }
-            $path = $locator->getPath($theme);
+            $path = $locator->getThemePath($theme);
             $langPath = BASE_PATH . "/{$path}/lang/";
             if (is_dir($langPath)) {
                 $paths[] = $langPath;

--- a/tests/php/Core/Manifest/ResourceLoaderTest.php
+++ b/tests/php/Core/Manifest/ResourceLoaderTest.php
@@ -2,14 +2,14 @@
 
 namespace SilverStripe\Core\Tests\Manifest;
 
-use SilverStripe\View\ThemeResourceLoader;
+use SilverStripe\Core\Manifest\ResourceLoader;
 use SilverStripe\View\ThemeManifest;
 use SilverStripe\Dev\SapphireTest;
 
 /**
  * Tests for the {@link TemplateLoader} class.
  */
-class ThemeResourceLoaderTest extends SapphireTest
+class ResourceLoaderTest extends SapphireTest
 {
     /**
      * @var string
@@ -22,7 +22,7 @@ class ThemeResourceLoaderTest extends SapphireTest
     private $manifest;
 
     /**
-     * @var ThemeResourceLoader
+     * @var ResourceLoader
      */
     private $loader;
 
@@ -39,7 +39,7 @@ class ThemeResourceLoaderTest extends SapphireTest
         $this->manifest = new ThemeManifest($this->base, 'myproject');
         $this->manifest->init();
         // New Loader for that root
-        $this->loader = new ThemeResourceLoader($this->base);
+        $this->loader = new ResourceLoader($this->base);
         $this->loader->addSet('$default', $this->manifest);
     }
 

--- a/tests/php/i18n/i18nTestManifest.php
+++ b/tests/php/i18n/i18nTestManifest.php
@@ -8,6 +8,7 @@ use SilverStripe\Core\Manifest\ClassManifest;
 use SilverStripe\Core\Manifest\ClassLoader;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Core\Manifest\ModuleManifest;
+use SilverStripe\Core\Manifest\ResourceLoader;
 use SilverStripe\i18n\i18n;
 use SilverStripe\i18n\Messages\MessageProvider;
 use SilverStripe\i18n\Messages\Symfony\ModuleYamlLoader;
@@ -18,7 +19,6 @@ use SilverStripe\i18n\Tests\i18nTest\MySubObject;
 use SilverStripe\i18n\Tests\i18nTest\TestDataObject;
 use SilverStripe\View\SSViewer;
 use SilverStripe\View\SSViewer_DataPresenter;
-use SilverStripe\View\ThemeResourceLoader;
 use SilverStripe\View\ThemeManifest;
 use SilverStripe\View\ViewableData;
 use Symfony\Component\Translation\Loader\ArrayLoader;
@@ -60,9 +60,9 @@ trait i18nTestManifest
     }
 
     /**
-     * @var ThemeResourceLoader
+     * @var ResourceLoader
      */
-    protected $oldThemeResourceLoader = null;
+    protected $oldResourceLoader = null;
 
     /**
      * @var string
@@ -87,8 +87,8 @@ trait i18nTestManifest
         $this->pushModuleManifest($moduleManifest);
 
         // Replace old template loader with new one with alternate base path
-        $this->oldThemeResourceLoader = ThemeResourceLoader::inst();
-        ThemeResourceLoader::set_instance($loader = new ThemeResourceLoader($this->alternateBasePath));
+        $this->oldResourceLoader = ResourceLoader::inst();
+        ResourceLoader::set_instance($loader = new ResourceLoader($this->alternateBasePath));
         $loader->addSet(
             '$default',
             $default = new ThemeManifest($this->alternateBasePath, project())
@@ -123,7 +123,7 @@ trait i18nTestManifest
 
     public function tearDownManifest()
     {
-        ThemeResourceLoader::set_instance($this->oldThemeResourceLoader);
+        ResourceLoader::set_instance($this->oldResourceLoader);
         i18n::set_locale($this->originalLocale);
 
         // Reset any manifests pushed during this test


### PR DESCRIPTION
I've tried to keep this minimal so as not to completely hose beta1, but this is a minimal set of changes to provide an API that would let us be more flexible in where modules are saved.

In particular, this will let use move modules to vendor in beta2. Specifically, we could add this as an opt-in feature and have ResourceLoader transparently return the right values.

I'm not sure if we could also introduce BASE_PATH != webroot without breaking APIs, but hopefully that would be possible too.

My goal has been to provide an API for this that was a minimal distance from what we already have, rather than designing the deal API.