### PR TITLE
Abstraction of resource loading

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -6,6 +6,10 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\Forms\Schema\FormSchema
   FixtureFactory:
     class: SilverStripe\Dev\FixtureFactory
+  SilverStripe\Core\Manifest\ResourceURLGenerator:
+    class: SilverStripe\Control\SimpleResourceURLGenerator
+    properties:
+      NonceStyle: mtime
 SilverStripe\Control\HTTP:
   cache_control:
     max-age: 0

--- a/src/Control/SimpleResourceURLGenerator.php
+++ b/src/Control/SimpleResourceURLGenerator.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace SilverStripe\Control;
+
+use SilverStripe\Core\Manifest\ResourceURLGenerator;
+
+/**
+ * Generate URLs assuming that BASE_PATH is also the webroot
+ * Standard SilverStripe 3 operation
+ */
+class SimpleResourceURLGenerator implements ResourceURLGenerator
+{
+    /*
+     * @var string
+     */
+    private $nonceStyle;
+
+    /*
+     * Get the style of nonce-suffixes to use, or null if disabled
+     *
+     * @return string|null
+     */
+    public function getNonceStyle()
+    {
+        return $this->nonceStyle;
+    }
+
+    /*
+     * Set the style of nonce-suffixes to use, or null to disable
+     * Currently only "mtime" is allowed
+     *
+     * @param string|null $nonceStyle The style of nonces to apply, or null to disable
+     */
+    public function setNonceStyle($nonceStyle)
+    {
+        if ($nonceStyle && $nonceStyle !== 'mtime') {
+            throw new InvalidArgumentException('The only allowed NonceStyle is mtime');
+        }
+        $this->nonceStyle = $nonceStyle;
+    }
+
+    /**
+     * Return the URL for a resource, prefixing with Director::baseURL() and suffixing with a nonce
+     *
+     * @param string $relativePath File or directory path relative to BASE_PATH
+     * @return string Doman-relative URL
+     * @throws InvalidArgumentException If the resource doesn't exist
+     */
+    public function urlForResource($relativePath)
+    {
+        $absolutePath = preg_replace('/\?.*/', '', Director::baseFolder() . '/' . $relativePath);
+
+        if (!file_exists($absolutePath)) {
+            throw new InvalidArgumentException("File {$relativePath} does not exist");
+        }
+
+        $nonce = '';
+        if ($this->nonceStyle) {
+            $nonce = (strpos($relativePath, '?') === false) ? '?' : '&';
+
+            switch ($this->nonceStyle) {
+                case 'mtime':
+                    $nonce .= "m=" . filemtime($absolutePath);
+                    break;
+            }
+        }
+
+        return Director::baseURL() . $relativePath . $nonce;
+    }
+}

--- a/src/Control/SimpleResourceURLGenerator.php
+++ b/src/Control/SimpleResourceURLGenerator.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Control;
 
+use InvalidArgumentException;
 use SilverStripe\Core\Manifest\ResourceURLGenerator;
 
 /**
@@ -30,6 +31,7 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
      * Currently only "mtime" is allowed
      *
      * @param string|null $nonceStyle The style of nonces to apply, or null to disable
+     * @return $this
      */
     public function setNonceStyle($nonceStyle)
     {
@@ -37,6 +39,7 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
             throw new InvalidArgumentException('The only allowed NonceStyle is mtime');
         }
         $this->nonceStyle = $nonceStyle;
+        return $this;
     }
 
     /**
@@ -55,7 +58,8 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
         }
 
         $nonce = '';
-        if ($this->nonceStyle) {
+        // Don't add nonce to directories
+        if ($this->nonceStyle && is_file($absolutePath)) {
             $nonce = (strpos($relativePath, '?') === false) ? '?' : '&';
 
             switch ($this->nonceStyle) {

--- a/src/Core/CoreKernel.php
+++ b/src/Core/CoreKernel.php
@@ -318,7 +318,6 @@ class CoreKernel implements Kernel
      */
     protected function getDatabaseConfig()
     {
-
         /** @skipUpgrade */
         $databaseConfig = [
             "type" => getenv('SS_DATABASE_CLASS') ?: 'MySQLDatabase',
@@ -361,7 +360,7 @@ class CoreKernel implements Kernel
      */
     protected function getDatabasePrefix()
     {
-        return getenv('SS_DATABASE_PREFIX');
+        return getenv('SS_DATABASE_PREFIX') ?: '';
     }
 
     /**
@@ -406,8 +405,12 @@ class CoreKernel implements Kernel
             $database = str_replace('.', '', basename($databaseDir));
             $prefix = $this->getDatabasePrefix();
 
-            if ($prefix === false) {
+            if ($prefix) {
                 $prefix = 'SS_';
+            } else {
+                // If no prefix, hard-code prefix into database global
+                $prefix = '';
+                $database = 'SS_' . $database;
             }
 
             return $prefix . $database;

--- a/src/Core/Manifest/ResourceURLGenerator.php
+++ b/src/Core/Manifest/ResourceURLGenerator.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SilverStripe\Core\Manifest;
+
+use InvalidArgumentException;
+
+/**
+ * Generate URLs for client-side assets and perform any preparation of those assets needed.
+ */
+interface ResourceURLGenerator
+{
+    /**
+     * Return the URL for a given resource within the project.
+     *
+     * As well as returning the URL, this method may also perform any changes needed to ensure that this
+     * URL will resolve, for example, by copying files to another location
+     *
+     * @param string $resource File or directory path relative to BASE_PATH
+     * @return string URL, either domain-relative (starting with /) or absolute
+     * @throws InvalidArgumentException If the resource doesn't exist or can't be sent to the browser
+     */
+    public function urlForResource($resource);
+}

--- a/src/Dev/Install/Installer.php
+++ b/src/Dev/Install/Installer.php
@@ -212,7 +212,7 @@ PHP
         // Build db within HTTPApplication
         $app->execute($request, function (HTTPRequest $request) use ($config) {
             // Start session and execute
-            $request->getSession()->init();
+            $request->getSession()->init($request);
 
             // Output status
             $this->statusMessage("Building database schema...");
@@ -242,7 +242,7 @@ PHP
 
             $request->getSession()->set('username', $config['admin']['username']);
             $request->getSession()->set('password', $config['admin']['password']);
-            $request->getSession()->save();
+            $request->getSession()->save($request);
         }, true);
 
         // Check result of install

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -555,10 +555,7 @@ class TinyMCEConfig extends HTMLEditorConfig
         $settings['document_base_url'] = Director::absoluteBaseURL();
 
         // https://www.tinymce.com/docs/api/class/tinymce.editormanager/#baseURL
-        $tinyMCEBaseURL = Controller::join_links(
-            Director::absoluteBaseURL(),
-            $this->getTinyMCEPath()
-        );
+        $tinyMCEBaseURL = $this->getAdminModule()->getResourceURL('thirdparty/tinymce');
         $settings['baseURL'] = $tinyMCEBaseURL;
 
         // map all plugins to absolute urls for loading
@@ -618,7 +615,7 @@ class TinyMCEConfig extends HTMLEditorConfig
         $editor = array();
 
         // Add standard editor.css
-        $editor[] = Director::absoluteURL(ltrim($this->getAdminPath() . '/client/dist/styles/editor.css', '/'));
+        $editor[] = $this->getAdminModule()->getResourceURL('client/dist/styles/editor.css');
 
         // Themed editor.css
         $themedEditor = ThemeResourceLoader::inst()->findThemedCSS('editor', SSViewer::get_themes());
@@ -635,6 +632,7 @@ class TinyMCEConfig extends HTMLEditorConfig
      * so that multiple HTTP requests on the client don't need to be made.
      *
      * @return string
+     * @throws Exception
      */
     public function getScriptURL()
     {
@@ -687,18 +685,7 @@ class TinyMCEConfig extends HTMLEditorConfig
 
     /**
      * @return string|false
-     */
-    public function getAdminPath()
-    {
-        $module = $this->getAdminModule();
-        if ($module) {
-            return $module->getRelativePath();
-        }
-        return false;
-    }
-
-    /**
-     * @return string|false
+     * @throws Exception
      */
     public function getTinyMCEPath()
     {
@@ -708,7 +695,7 @@ class TinyMCEConfig extends HTMLEditorConfig
         }
 
         if ($admin = $this->getAdminModule()) {
-            return $admin->getResourcePath('thirdparty/tinymce');
+            return $admin->getRelativeResourcePath('thirdparty/tinymce');
         }
 
         throw new Exception(sprintf(
@@ -723,6 +710,6 @@ class TinyMCEConfig extends HTMLEditorConfig
      */
     protected function getAdminModule()
     {
-        return ModuleLoader::inst()->getManifest()->getModule('silverstripe/admin');
+        return ModuleLoader::getModule('silverstripe/admin');
     }
 }

--- a/src/View/GenericTemplateGlobalProvider.php
+++ b/src/View/GenericTemplateGlobalProvider.php
@@ -2,7 +2,7 @@
 
 namespace SilverStripe\View;
 
-use InvalidArgumentException;
+use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\ORM\DataList;
 
 class GenericTemplateGlobalProvider implements TemplateGlobalProvider
@@ -17,31 +17,23 @@ class GenericTemplateGlobalProvider implements TemplateGlobalProvider
     }
 
     /**
-     * @var array Module paths
-     */
-    public static $modules = array(
-        'framework' => FRAMEWORK_DIR,
-        'frameworkadmin' => FRAMEWORK_ADMIN_DIR,
-        'thirdparty' => THIRDPARTY_DIR,
-        'assets' => ASSETS_DIR
-    );
-
-    /**
      * Given some pre-defined modules, return the filesystem path of the module.
      * @param string $name Name of module to find path of
      * @return string
      */
     public static function ModulePath($name)
     {
-        if (isset(self::$modules[$name])) {
-            return self::$modules[$name];
-        } else {
-            throw new InvalidArgumentException(sprintf(
-                '%s is not a supported argument. Possible values: %s',
-                $name,
-                implode(', ', self::$modules)
-            ));
+        // BC for a couple fo the key modules in the old syntax. Reduces merge brittleness but can
+        // be removed before 4.0 stable
+        $legacyMapping = [
+            'framework' => 'silverstripe/framework',
+            'frameworkadmin' => 'silverstripe/admin',
+        ];
+        if (isset($legacyMapping[$name])) {
+            $name = $legacyMapping[$name];
         }
+
+        return ModuleLoader::getModule($name)->getRelativePath();
     }
 
     /**

--- a/tests/php/Core/Manifest/ModuleManifestTest.php
+++ b/tests/php/Core/Manifest/ModuleManifestTest.php
@@ -82,7 +82,7 @@ class ModuleManifestTest extends SapphireTest
         $this->assertFalse($module->hasResource('package.json'));
         $this->assertEquals(
             'moduleb/composer.json',
-            $module->getResourcePath('composer.json')
+            $module->getRelativeResourcePath('composer.json')
         );
     }
 
@@ -96,7 +96,7 @@ class ModuleManifestTest extends SapphireTest
         $this->assertTrue($module->hasResource('composer.json'));
         $this->assertEquals(
             'composer.json',
-            $module->getResourcePath('composer.json')
+            $module->getRelativeResourcePath('composer.json')
         );
     }
 }

--- a/tests/php/Forms/HTMLEditor/HTMLEditorConfigTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorConfigTest.php
@@ -5,10 +5,13 @@ namespace SilverStripe\Forms\Tests\HTMLEditor;
 use Exception;
 use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Control\Director;
+use SilverStripe\Control\SimpleResourceURLGenerator;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Core\Manifest\ModuleManifest;
+use SilverStripe\Core\Manifest\ResourceURLGenerator;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
@@ -49,6 +52,10 @@ class HTMLEditorConfigTest extends SapphireTest
 
     public function testEnablePluginsByArrayWithPaths()
     {
+        // Disable nonces
+        $urlGenerator = new SimpleResourceURLGenerator();
+        Injector::inst()->registerService($urlGenerator, ResourceURLGenerator::class);
+
         Config::modify()->set(Director::class, 'alternate_base_url', 'http://mysite.com/subdir');
         $c = new TinyMCEConfig();
         $c->setTheme('modern');
@@ -92,7 +99,7 @@ class HTMLEditorConfigTest extends SapphireTest
         // Plugin specified with standard location
         $this->assertContains('plugin4', array_keys($plugins));
         $this->assertEquals(
-            'http://mysite.com/subdir/test/thirdparty/tinymce/plugins/plugin4/plugin.min.js',
+            '/subdir/silverstripe-admin/thirdparty/tinymce/plugins/plugin4/plugin.min.js',
             $plugins['plugin4']
         );
 


### PR DESCRIPTION
This has 3 key changes:

 * API: ModulePath template global now takes any composer package name.
 * NEW: URL generation now handled by pluggable ResourceURLGenerator service.
 * NEW: Requirements::javascript() and Requirements::css() now support “vendor/package:resource” syntax.

These changes will make it easier to us to fully abstract the following in the future without API breakages:

 * file access from module location
 * file location from URL generation

The goal is that we can do the following after beta1:

 * Allow the optional moving of modules into the vendor/ path
 * Allow the optional moving of the webroot to somewhere other than BASE_PATH (e.g. a public_html subfolder)

----

After merging this PR there are no _necessary_ changes, but you can merge all these, in this order:

 * [ ] https://github.com/silverstripe/silverstripe-siteconfig/pull/66
 * [ ] https://github.com/silverstripe/silverstripe-reports/pull/78
 * [ ] https://github.com/silverstripe/silverstripe-cms/pull/1871
 * [ ] https://github.com/silverstripe/silverstripe-admin/pull/121
 * [ ] https://github.com/silverstripe/silverstripe-assets/pull/37
 * [ ] https://github.com/silverstripe/silverstripe-asset-admin/pull/514
 * [ ] https://github.com/silverstripe/silverstripe-campaign-admin/pull/32