### PR TITLE
MINOR: More PHP7 in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.0
       env:
         - DB=PGSQL
         - PHPUNIT_TEST=framework
@@ -34,15 +34,15 @@ matrix:
         - DB=MYSQL
         - PDO=1
         - PHPUNIT_TEST=framework
-    - php: 5.6
+    - php: 7.0
       env:
        - DB=MYSQL
        - BEHAT_TEST=framework
-    - php: 5.6
+    - php: 7.0
       env:
         - DB=MYSQL
         - PHPUNIT_TEST=cms
-    - php: 5.6
+    - php: 7.0
       env:
         - DB=MYSQL
         - BEHAT_TEST=cms

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
-      env:
-        - DB=PGSQL
-        - PHPUNIT_TEST=framework
     - php: 5.6
       env:
         - DB=MYSQL
@@ -27,7 +23,7 @@ matrix:
         - PHPCS_TEST=1
     - php: 7.0
       env:
-        - DB=MYSQL
+        - DB=PGSQL
         - PHPUNIT_TEST=framework
     - php: 7.1.2
       env:


### PR DESCRIPTION
PHP7 is faster than PHP5.6 so we should use it for as many builds
as possible.

This leaves 1 build - the coverage build - running on PHP5.6
and puts the rest on PHP7.