### PR TITLE
[WIP] API: Don’t auto-convert update to an insert in DB::manipulate()

### DIFF
--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -343,12 +343,8 @@ abstract class Database
                         $query->addWhere(array('"ID"' => $writeInfo['id']));
                     }
 
-                    // Test to see if this update query shouldn't, in fact, be an insert
-                    if ($query->toSelect()->count()) {
-                        $query->execute();
-                        break;
-                    }
-                    // ...if not, we'll skip on to the insert code
+                    $query->execute();
+                    break;
 
                 case "insert":
                     // Ensure that the ID clause is given if possible


### PR DESCRIPTION
This feature creates an extra SELECT on every update and its 
only benefit is to paper over other bugs that should be fixed
with better data integrity.

Fixes #7072