### PR TITLE
FIX: DataObject::get_one() misses return null, not false

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -2824,7 +2824,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param boolean $cache Use caching
      * @param string $orderby A sort expression to be inserted into the ORDER BY clause.
      *
-     * @return DataObject The first item matching the query
+     * @return DataObject|null The first item matching the query
      */
     public static function get_one($callerClass, $filter = "", $cache = true, $orderby = "")
     {
@@ -2851,7 +2851,12 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
                 }
             }
         }
-        return $cache ? self::$_cache_get_one[$callerClass][$cacheKey] : $item;
+
+        if ($cache) {
+            return self::$_cache_get_one[$callerClass][$cacheKey] ?: null;
+        } else {
+            return $item;
+        }
     }
 
     /**

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -2071,4 +2071,14 @@ class DataObjectTest extends SapphireTest
         $staff->write();
         $this->assertEquals(PHP_INT_MAX, DataObjectTest\Staff::get()->byID($staff->ID)->Salary);
     }
+
+    public function testGetOneMissingValueReturnsNull()
+    {
+
+        // Test that missing values return null
+        $this->assertEquals(null, DataObject::get_one(
+            DataObjectTest\TeamComment::class,
+            ['"DataObjectTest_TeamComment"."Name"' => 'does not exists']
+        ));
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/5441

Also merge:

 * [ ] https://github.com/silverstripe/silverstripe-cms/pull/1874