### PR TITLE
API: Don’t allow modules in 2nd level directories

### DIFF
--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -1440,6 +1440,7 @@ After (`mysite/_config/config.yml`):
   Accordingly, `hasService()` has been renamed to `has()`, and `get()` will throw
   `SilverStripe\Core\Injector\InjectorNotFoundException` when the service can't be found.
 * Removed `CustomMethods::createMethod()`. Use closures instead.
+* Remove supported for nested modules such as 'framework/admin'. All modules must be top-level, although support for modules in vendor/ is planned.
 
 #### <a name="overview-general-deprecated"></a>General and Core Deprecated API
 

--- a/src/Core/Manifest/ModuleManifest.php
+++ b/src/Core/Manifest/ModuleManifest.php
@@ -148,8 +148,8 @@ class ModuleManifest
             'name_regex'    => '/(^|[\/\\\\])_config.php$/',
             'ignore_tests'  => !$includeTests,
             'file_callback' => array($this, 'addSourceConfigFile'),
-            // Cannot be max_depth: 1 due to "/framework/admin/_config.php"
-            'max_depth'     => 2
+            // In SS3 this was max_depth 2 to support framework/admin, which is no longer used
+            'max_depth'     => 1
         ));
         $finder->find($this->base);
 
@@ -158,7 +158,7 @@ class ModuleManifest
             'name_regex'    => '/\.ya?ml$/',
             'ignore_tests'  => !$includeTests,
             'file_callback' => array($this, 'addYAMLConfigFile'),
-            'max_depth'     => 2
+            'max_depth'     => 1
         ));
         $finder->find($this->base);
 


### PR DESCRIPTION
This was a setting that was only used for framework/admin, which has
since been removed. I’ve patched this so that we don’t need to support
this feature for the 4.x lifetime.

Post beta1 we’ll likely add support for modules in vendor, but that’s
a new feature so doesn’t require a major change.