### PR TITLE
FIX add missing $rootCall param from LeftAndMain

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -927,6 +927,7 @@ class LeftAndMain extends Controller implements PermissionProvider {
 				true,
 				$childrenMethod,
 				$numChildrenMethod,
+				true,
 				$nodeCountThreshold,
 				$nodeCountCallback
 			);


### PR DESCRIPTION
Thanks to @herbertcuba for reporting this

`LeftAndMain` makes a call to `Hierachy::getChildrenAsUL` but misses out the `$rootCall` argument.