### PR TITLE
NEW Add new SilverStripeVersionProvider to provider module versions

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -17,3 +17,9 @@ HTTP:
     must-revalidate: "true"
     no-transform: "true"
   vary: "Cookie, X-Forwarded-Protocol, User-Agent, Accept"
+LeftAndMain:
+  dependencies:
+    versionProvider: %$SilverStripeVersionProvider
+SilverStripeVersionProvider:
+  modules:
+    silverstripe/framework: Framework

--- a/core/manifest/SilverStripeVersionProvider.php
+++ b/core/manifest/SilverStripeVersionProvider.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * The version provider will look up configured modules and examine the composer.lock file
+ * to find the current version installed for each. This is used for the logo title in the CMS
+ * via {@link LeftAndMain::CMSVersion()}
+ *
+ * Example configuration:
+ *
+ * <code>
+ * SilverStripeVersionProvider:
+ *   modules:
+ *     # package/name: Package Title
+ *     silverstripe/framework: Framework
+ *     silverstripe/cms: CMS
+ * </code>
+ */
+class SilverStripeVersionProvider
+{
+	/**
+	 * Gets a comma delimited string of package titles and versions
+	 *
+	 * @return string
+	 */
+	public function getVersion()
+	{
+		$modules = $this->getModules();
+		$lockModules = $this->getModuleVersionFromComposer(array_keys($modules));
+		$output = array();
+		foreach ($modules as $module => $title) {
+			$version = isset($lockModules[$module])
+				? $lockModules[$module]
+				: _t('SilverStripeVersionProvider.VERSIONUNKNOWN', 'Unknown');
+			$output[] = $title . ': ' . $version;
+		}
+		return implode(', ', $output);
+	}
+
+	/**
+	 * Gets the configured core modules to use for the SilverStripe application version. Filtering
+	 * is used to ensure that modules can turn the result off for other modules, e.g. CMS can disable Framework.
+	 *
+	 * @return array
+	 */
+	public function getModules()
+	{
+		$modules = Config::inst()->get(get_class($this), 'modules');
+		return array_filter($modules);
+	}
+
+	/**
+	 * Tries to obtain version number from composer.lock if it exists
+	 *
+	 * @param  array $modules
+	 * @return array
+	 */
+	public function getModuleVersionFromComposer($modules = array())
+	{
+		$versions = array();
+		$composerLockPath = BASE_PATH . '/composer.lock';
+		if (file_exists($composerLockPath)) {
+			$cache = SS_Cache::factory('SilverStripeVersionProvider_composerlock');
+			$cacheKey = filemtime($composerLockPath);
+			$versions = $cache->load($cacheKey);
+			if ($versions) {
+				$versions = json_decode($versions, true);
+			} else {
+				$versions = array();
+			}
+			if (!$versions && $jsonData = file_get_contents($composerLockPath)) {
+				$lockData = json_decode($jsonData);
+				if ($lockData && isset($lockData->packages)) {
+					foreach ($lockData->packages as $package) {
+						if (in_array($package->name, $modules) && isset($package->version)) {
+							$versions[$package->name] = $package->version;
+						}
+					}
+					$cache->save(json_encode($versions), $cacheKey);
+				}
+			}
+		}
+		return $versions;
+	}
+}

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -444,7 +444,6 @@ en:
     ShowAsList: 'show as list'
     TooManyPages: 'Too many pages'
     ValidationError: 'Validation error'
-    VersionUnknown: unknown
   LeftAndMain_Menu_ss:
     Hello: Hi
     LOGOUT: 'Log out'
@@ -657,6 +656,8 @@ en:
     Tablet: Tablet
     ViewDeviceWidth: 'Select a preview width'
     Width: width
+  SilverStripeVersionProvider:
+    VERSIONUNKNOWN: Unknown
   SilverStripe\Admin\CMSProfileController:
     MENUTITLE: 'My Profile'
   SilverStripe\Admin\CampaignAdmin:

--- a/tests/core/manifest/SilverStripeVersionProviderTest.php
+++ b/tests/core/manifest/SilverStripeVersionProviderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+class SilverStripeVersionProviderTest extends SapphireTest
+{
+	/**
+	 * @var SilverStripeVersionProvider
+	 */
+	protected $provider;
+
+	public function setUp()
+	{
+		parent::setUp();
+		$this->provider = new SilverStripeVersionProvider;
+	}
+
+	public function testGetModules()
+	{
+		Config::inst()->update('SilverStripeVersionProvider', 'modules', array(
+			'silverstripe/somepackage' => 'Some Package',
+			'silverstripe/hidden' => '',
+			'silverstripe/another' => 'Another'
+		));
+
+		$result = $this->provider->getModules();
+		$this->assertArrayHasKey('silverstripe/somepackage', $result);
+		$this->assertSame('Some Package', $result['silverstripe/somepackage']);
+		$this->assertArrayHasKey('silverstripe/another', $result);
+		$this->assertArrayNotHasKey('silverstripe/hidden', $result);
+	}
+
+	public function testGetModuleVersionFromComposer()
+	{
+		Config::inst()->update('SilverStripeVersionProvider', 'modules', array(
+			'silverstripe/framework' => 'Framework',
+			'silverstripe/siteconfig' => 'SiteConfig'
+		));
+
+		$result = $this->provider->getModules(array('silverstripe/framework'));
+		$this->assertArrayHasKey('silverstripe/framework', $result);
+		$this->assertNotEmpty($result['silverstripe/framework']);
+	}
+
+	public function testGetVersion()
+	{
+		Config::inst()->update('SilverStripeVersionProvider', 'modules', array(
+			'silverstripe/framework' => 'Framework',
+			'silverstripe/siteconfig' => 'SiteConfig'
+		));
+
+		$result = $this->provider->getVersion();
+		$this->assertContains('SiteConfig: ', $result);
+		$this->assertContains('Framework: ', $result);
+		$this->assertContains(', ', $result);
+	}
+}

--- a/tests/core/manifest/SilverStripeVersionProviderTest.php
+++ b/tests/core/manifest/SilverStripeVersionProviderTest.php
@@ -52,4 +52,33 @@ class SilverStripeVersionProviderTest extends SapphireTest
 		$this->assertContains('Framework: ', $result);
 		$this->assertContains(', ', $result);
 	}
+
+	public function testGetModulesFromComposerLock()
+	{
+		$mock = $this->getMockBuilder('SilverStripeVersionProvider')
+			->setMethods(array('getComposerLock'))
+			->getMock();
+
+		$mock->expects($this->once())
+			->method('getComposerLock')
+			->will($this->returnValue(array(
+				'packages' => array(
+					array(
+						'name' => 'silverstripe/somepackage',
+						'version' => '1.2.3'
+					),
+					array(
+						'name' => 'silverstripe/another',
+						'version' => '2.3.4'
+					)
+				)
+			)));
+
+		Config::inst()->update('SilverStripeVersionProvider', 'modules', array(
+			'silverstripe/somepackage' => 'Some Package'
+		));
+
+		$result = $mock->getVersion();
+		$this->assertContains('Some Package: 1.2.3', $result);
+	}
 }


### PR DESCRIPTION

Issue: #6880 

This PR adds a new service provider for gathering module versions from the composer lock file, and replaces the logic in `LeftAndMain::CMSVersion`.

Example configuration to add modules:

```yaml
SilverStripeVersionProvider:
  modules:
    silverstripe/framework: Framework
    silverstripe/somemodule: Some Module
```

The `getVersion` method would return `Framework: 3.7.0, Some Module: 1.2.3` for example.

The CMS (see PR) can block the framework version from being displayed in favour of the CMS. Exaple `CMS: 3.7.0` instead of `Framework: 3.7.0, CMS: 3.7.0` - assumption being that in 99% of cases the CMS and framework versions will be identical. This will also allow CWP to add its version to the tooltip as well, e.g. `SilverStripe: 3.7.0, CWP recipe: 1.7.0` for example.

---

It's worth mentioning that `LeftAndMain::CMSVersion` used to try and fall back to loading the `silverstripe_version` file if a composer lock doesn't exist and get the version from that. I didn't port this change over because the file is currently empty, so it wouldn't result in different behaviour from 3.7.x onwards - and most installs would be with composer now.


---

Related PR for CMS: https://github.com/silverstripe/silverstripe-cms/pull/1881