### PR TITLE
Create a more generic travis installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,11 +57,13 @@ before_script:
 
 # Install composer dependencies
   - composer validate
-  - composer install --prefer-dist
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
-  - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --prefer-dist; fi
-  - composer require silverstripe/config:1.0.x-dev silverstripe/admin:1.0.x-dev silverstripe/assets:1.0.x-dev silverstripe/versioned:1.0.x-dev --prefer-dist
-  - if [[ $PHPUNIT_TEST == cms ]] || [[ $BEHAT_TEST == cms ]]; then composer require silverstripe/cms:4.0.x-dev silverstripe/campaign-admin:1.0.x-dev silverstripe/siteconfig:4.0.x-dev silverstripe/reports:4.0.x-dev --prefer-dist; fi
+  - composer install --prefer-dist --no-interaction --no-progress --no-suggest
+  - composer config prefer-stable false
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql --dev --prefer-dist --no-interaction --no-progress --no-suggest; fi
+  - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3 --dev --prefer-dist --no-interaction --no-progress --no-suggest; fi
+  - composer require silverstripe/config silverstripe/admin silverstripe/assets silverstripe/versioned --dev --prefer-dist --no-interaction --no-progress --no-suggest
+  - if [[ $PHPUNIT_TEST == cms ]] || [[ $BEHAT_TEST == cms ]]; then composer require silverstripe/cms silverstripe/campaign-admin silverstripe/siteconfig silverstripe/reports --dev --prefer-dist --no-interaction --no-progress --no-suggest; fi
+  - composer dump-autoload --optimize
 
 # Bootstrap dependencies
   - if [[ $PHPUNIT_TEST == cms ]] || [[ $BEHAT_TEST == cms ]]; then php ./cms/tests/bootstrap/mysite.php; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,10 @@ before_script:
   - composer validate
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest
   - composer config prefer-stable false
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql --dev --prefer-dist --no-interaction --no-progress --no-suggest; fi
-  - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3 --dev --prefer-dist --no-interaction --no-progress --no-suggest; fi
-  - composer require silverstripe/config silverstripe/admin silverstripe/assets silverstripe/versioned --dev --prefer-dist --no-interaction --no-progress --no-suggest
-  - if [[ $PHPUNIT_TEST == cms ]] || [[ $BEHAT_TEST == cms ]]; then composer require silverstripe/cms silverstripe/campaign-admin silverstripe/siteconfig silverstripe/reports --dev --prefer-dist --no-interaction --no-progress --no-suggest; fi
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql --dev --prefer-dist --no-interaction --no-progress --no-suggest --prefer-lowest; fi
+  - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3 --dev --prefer-dist --no-interaction --no-progress --no-suggest --prefer-lowest; fi
+  - composer require silverstripe/config silverstripe/admin silverstripe/assets silverstripe/versioned --dev --prefer-dist --no-interaction --no-progress --no-suggest --prefer-lowest
+  - if [[ $PHPUNIT_TEST == cms ]] || [[ $BEHAT_TEST == cms ]]; then composer require silverstripe/cms silverstripe/campaign-admin silverstripe/siteconfig silverstripe/reports --dev --prefer-dist --no-interaction --no-progress --no-suggest --prefer-lowest; fi
   - composer dump-autoload --optimize
 
 # Bootstrap dependencies


### PR DESCRIPTION
At the moment travis tests explicitly require a `.x-dev` branch to make sure we test the latest code. This means that when we add new branches and aliases we then need to update our travis configs - this is (hopefully) unnecessary.

This patch should mean less maintenance overhead for travis config