### PR TITLE
Limited nodes with too many children are no longer accessible

### DIFF
--- a/src/ORM/Hierarchy/MarkedSet.php
+++ b/src/ORM/Hierarchy/MarkedSet.php
@@ -407,13 +407,14 @@ class MarkedSet
         // Build root rode
         $expanded = $this->isExpanded($node);
         $opened = $this->isTreeOpened($node);
+        $count = ($limited && $numChildren > $this->getMaxChildNodes()) ? 0 : $numChildren;
         $output = [
             'node' => $node,
             'marked' => $this->isMarked($node),
             'expanded' => $expanded,
             'opened' => $opened,
             'depth' => $depth,
-            'count' => $numChildren, // Count of DB children
+            'count' => $count, // Count of DB children
             'limited' => $limited, // Flag whether 'items' has been limited
             'children' => [], // Children to return in this request
         ];


### PR DESCRIPTION
Limited nodes that have more children than allowed limit are no longer accessible to the user.

This is a follow up change set to this one:

https://github.com/silverstripe/silverstripe-framework/pull/7035

The idea is to test SilverStripe performance with a site that has thousands of pages. The mentioned PR was related to SS3, this PR tries to do the same with SS4. I tested the same setup and same cases with SS4. I am pleased to say that with the exception of one minor issue, all cases were already covered and changes were not necessary.

The one issue I found is that when a page has too many children (tested with ~4000) the tree dropdown will allow the user to enter such list which will result in error. I addressed this issue with following change:  I made such list of children inaccessible.

Additionally, I'm a little bit confused by the lack of search functionality in the UI of the tree dropdown. Search is fully functional on the backend and results are even properly displayed on the UI. I'm not sure if the search was intentionally removed, or it's still in development. Either way, that's just a side note since search UI is beyond the scope of this change set.

The testing setup required me to do some additional work since creating 4000 pages on the site will instantly break the site. First, I upgraded Lumberjack module so it could be used with SilverStripe 4. Next, I found a performance issue within the CMS which prevented me from testing and had to be fixed first.

Please see these PRs for more information:

https://github.com/silverstripe/silverstripe-cms/pull/1882
https://github.com/silverstripe/silverstripe-lumberjack/pull/57