### PR TITLE
Cache ClassInfo::class_name() calls

### DIFF
--- a/src/Core/ClassInfo.php
+++ b/src/Core/ClassInfo.php
@@ -65,6 +65,14 @@ class ClassInfo
     private static $_cache_parse = [];
 
     /**
+     * Cache for class_name
+     *
+     * @internal
+     * @var array
+     */
+    private static $_cache_class_names = [];
+
+    /**
      * @todo Move this to SS_Database or DB
      *
      * @param string $tableName
@@ -200,8 +208,14 @@ class ClassInfo
         if (is_object($nameOrObject)) {
             return get_class($nameOrObject);
         }
-        $reflection = new ReflectionClass($nameOrObject);
-        return $reflection->getName();
+
+        $key = strtolower($nameOrObject);
+        if (!isset(static::$_cache_class_names[$key])) {
+            $reflection = new ReflectionClass($nameOrObject);
+            static::$_cache_class_names[$key] = $reflection->getName();
+        }
+
+        return static::$_cache_class_names[$key];
     }
 
     /**


### PR DESCRIPTION
A lot of these calls, especially in the admin area, are repeated. Memory impact is tiny as it’s just an array of string values.

Examples:

- `admin/pages` on a clean install:
  - saves ~18,000 `(new ReflectionClass($class)->getName())` calls
  - 14kb memory increase
- home page on a clean install:
  - saves ~1,800 `(new ReflectionClass($class)->getName())` calls
  - 6kb memory increase