### PR TITLE
Remove unnecessary DataObject::write in fixture blueprint

### DIFF
--- a/src/Dev/FixtureBlueprint.php
+++ b/src/Dev/FixtureBlueprint.php
@@ -143,8 +143,6 @@ class FixtureBlueprint
                 }
             }
 
-            $obj->write();
-
             // Save to fixture before relationship processing in case of reflexive relationships
             if (!isset($fixtures[$class])) {
                 $fixtures[$class] = array();


### PR DESCRIPTION
This line doesn't seem necessary, and shaves ~1 min off overall build time without it.