### PR TITLE
BUG Fix registered shutdown function not handling responsibility for outputting redirection response

### DIFF
--- a/src/Core/Startup/ErrorControlChainMiddleware.php
+++ b/src/Core/Startup/ErrorControlChainMiddleware.php
@@ -61,9 +61,10 @@ class ErrorControlChainMiddleware implements HTTPMiddleware
                 }
             })
             // Finally if a token was requested but there was an error while figuring out if it's allowed, do it anyway
-            ->thenIfErrored(function () use ($reloadToken, &$result) {
+            ->thenIfErrored(function () use ($reloadToken) {
                 if ($reloadToken) {
                     $result = $reloadToken->reloadWithToken();
+                    $result->output();
                 }
             })
             ->execute();


### PR DESCRIPTION
Since thenIfErrored is ONLY called via register_shutdown_function, the `return $result` is never invoked. We need to take responsibility for outputting the result ourselves.

This fixes an annoying white screen of death if flushing with error.