### PR TITLE
FIX Ignore exceptions thrown when deleting test databases

### DIFF
--- a/src/ORM/Connect/TempDatabase.php
+++ b/src/ORM/Connect/TempDatabase.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\ORM\Connect;
 
+use Exception;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
@@ -92,7 +93,6 @@ class TempDatabase
             }
         }
 
-        // echo "Deleted temp database " . $dbConn->currentDatabase() . "\n";
         $dbConn->dropSelectedDatabase();
     }
 
@@ -147,7 +147,11 @@ class TempDatabase
 
         // Ensure test db is killed on exit
         register_shutdown_function(function () {
-            $this->kill();
+            try {
+                $this->kill();
+            } catch (Exception $ex) {
+                // An exception thrown while trying to remove a test database shouldn't fail a build, ignore
+            }
         });
 
         return $dbname;


### PR DESCRIPTION
This will prevent long runnings builds (e.g. code coverage) from failing when the test database connection is gone (MySQL server has gone away) by the time the shutdown handler runs.

---

I've made an assumption here that an exception thrown at this point (after the test suite has finished running and we're in tidy up mode) should be ignored instead of causing the build to fail, since this has nothing to do with the actual test suite results.

This approach was cleaner than adding in some conditional logic to check for "MySQL server has gone away" exception messages and trying to reconnect, then kill again. If the team thinks it would be preferable to do that I've got an alternative branch that does that as well, but I suspect this approach is better in the long run.

Resolves #7164