### PR TITLE
FIX Version provider uses non LSB config getters, move LeftAndMain config to admin module

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -12,9 +12,6 @@ SilverStripe\Control\HTTP:
     must-revalidate: "true"
     no-transform: "true"
   vary: "Cookie, X-Forwarded-Protocol, User-Agent, Accept"
-LeftAndMain:
-  dependencies:
-    versionProvider: %$VersionProvider
 SilverStripe\Core\Manifest\VersionProvider:
   modules:
     silverstripe/framework: Framework

--- a/src/Core/Manifest/VersionProvider.php
+++ b/src/Core/Manifest/VersionProvider.php
@@ -33,11 +33,11 @@ class VersionProvider
     {
         $modules = $this->getModules();
         $lockModules = $this->getModuleVersionFromComposer(array_keys($modules));
-        $output = array();
+        $output = [];
         foreach ($modules as $module => $title) {
             $version = isset($lockModules[$module])
                 ? $lockModules[$module]
-                : _t('SilverStripe\Core\Manifest\VersionProvider.VERSIONUNKNOWN', 'Unknown');
+                : _t(__CLASS__.'.VERSIONUNKNOWN', 'Unknown');
             $output[] = $title . ': ' . $version;
         }
         return implode(', ', $output);
@@ -51,8 +51,8 @@ class VersionProvider
      */
     public function getModules()
     {
-        $modules = Config::inst()->get(static::class, 'modules');
-        return $modules ? array_filter($modules) : array();
+        $modules = Config::inst()->get(self::class, 'modules');
+        return $modules ? array_filter($modules) : [];
     }
 
     /**
@@ -61,9 +61,9 @@ class VersionProvider
      * @param  array $modules
      * @return array
      */
-    public function getModuleVersionFromComposer($modules = array())
+    public function getModuleVersionFromComposer($modules = [])
     {
-        $versions = array();
+        $versions = [];
         $lockData = $this->getComposerLock();
         if ($lockData && !empty($lockData['packages'])) {
             foreach ($lockData['packages'] as $package) {
@@ -85,10 +85,10 @@ class VersionProvider
     {
         $composerLockPath = BASE_PATH . '/composer.lock';
         if (!file_exists($composerLockPath)) {
-            return array();
+            return [];
         }
 
-        $lockData = array();
+        $lockData = [];
         $jsonData = file_get_contents($composerLockPath);
 
         if ($cache) {

--- a/tests/php/Core/Manifest/VersionProviderTest.php
+++ b/tests/php/Core/Manifest/VersionProviderTest.php
@@ -21,11 +21,11 @@ class VersionProviderTest extends SapphireTest
 
     public function testGetModules()
     {
-        Config::modify()->set(VersionProvider::class, 'modules', array(
+        Config::modify()->set(VersionProvider::class, 'modules', [
             'silverstripe/somepackage' => 'Some Package',
             'silverstripe/hidden' => '',
             'silverstripe/another' => 'Another'
-        ));
+        ]);
 
         $result = $this->provider->getModules();
         $this->assertArrayHasKey('silverstripe/somepackage', $result);
@@ -36,22 +36,22 @@ class VersionProviderTest extends SapphireTest
 
     public function testGetModuleVersionFromComposer()
     {
-        Config::modify()->set(VersionProvider::class, 'modules', array(
+        Config::modify()->set(VersionProvider::class, 'modules', [
             'silverstripe/framework' => 'Framework',
             'silverstripe/siteconfig' => 'SiteConfig'
-        ));
+        ]);
 
-        $result = $this->provider->getModules(array('silverstripe/framework'));
+        $result = $this->provider->getModules(['silverstripe/framework']);
         $this->assertArrayHasKey('silverstripe/framework', $result);
         $this->assertNotEmpty($result['silverstripe/framework']);
     }
 
     public function testGetVersion()
     {
-        Config::modify()->set(VersionProvider::class, 'modules', array(
+        Config::modify()->set(VersionProvider::class, 'modules', [
             'silverstripe/framework' => 'Framework',
             'silverstripe/siteconfig' => 'SiteConfig'
-        ));
+        ]);
 
         $result = $this->provider->getVersion();
         $this->assertContains('SiteConfig: ', $result);
@@ -61,30 +61,28 @@ class VersionProviderTest extends SapphireTest
 
     public function testGetModulesFromComposerLock()
     {
-        $this->markTestSkipped('Unable to get this passing');
-        
         $mock = $this->getMockBuilder(VersionProvider::class)
-            ->setMethods(array('getComposerLock'))
+            ->setMethods(['getComposerLock'])
             ->getMock();
 
         $mock->expects($this->once())
             ->method('getComposerLock')
-            ->will($this->returnValue(array(
-                'packages' => array(
-                    array(
+            ->will($this->returnValue([
+                'packages' => [
+                    [
                         'name' => 'silverstripe/somepackage',
                         'version' => '1.2.3'
-                    ),
-                    array(
+                    ],
+                    [
                         'name' => 'silverstripe/another',
                         'version' => '2.3.4'
-                    )
-                )
-            )));
+                    ]
+                ]
+            ]));
 
-        Config::modify()->set(VersionProvider::class, 'modules', array(
+        Config::modify()->set(VersionProvider::class, 'modules', [
             'silverstripe/somepackage' => 'Some Package'
-        ));
+        ]);
 
         $result = $mock->getVersion();
         $this->assertContains('Some Package: 1.2.3', $result);


### PR DESCRIPTION
Follows merge up of https://github.com/silverstripe/silverstripe-framework/pull/7125

The skipped `testGetModulesFromComposerLock` test showed that the config for the version provider needed to be gathered from the base class, not that provided from late static binding.

Moved LeftAndMain configuration to admin module: https://github.com/silverstripe/silverstripe-admin/pull/153

cc @dhensby