### PR TITLE
FIX Enable code coverage builds with phpdbg and 7.1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,17 @@ matrix:
     - php: 5.6
       env:
         - DB=MYSQL
-        - PHPUNIT_COVERAGE_TEST=framework
         - PHPCS_TEST=1
+        - PHPUNIT_TEST=framework
     - php: 7.0
       env:
         - DB=PGSQL
         - PHPUNIT_TEST=framework
-    - php: 7.1.2
+    - php: 7.1
       env:
         - DB=MYSQL
         - PDO=1
-        - PHPUNIT_TEST=framework
+        - PHPUNIT_COVERAGE_TEST=framework
     - php: 7.0
       env:
        - DB=MYSQL
@@ -77,7 +77,7 @@ before_script:
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit --testsuite $PHPUNIT_TEST; fi
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then vendor/bin/phpunit --testsuite $PHPUNIT_COVERAGE_TEST --coverage-clover=coverage.xml; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --testsuite $PHPUNIT_COVERAGE_TEST --coverage-clover=coverage.xml; fi
   - if [[ $BEHAT_TEST == framework ]]; then vendor/bin/behat @framework; fi
   - if [[ $BEHAT_TEST == cms ]]; then vendor/bin/behat @cms; fi
   - if [[ $PHPCS_TEST ]]; then composer run-script lint; fi

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,4 +13,12 @@ Requires PHPUnit ^5.7
     <testsuite name="cms">
         <directory>cms/tests</directory>
     </testsuite>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">.</directory>
+            <exclude>
+                <directory suffix=".php">tests/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Core/Startup/ParameterConfirmationToken.php
+++ b/src/Core/Startup/ParameterConfirmationToken.php
@@ -185,8 +185,7 @@ class ParameterConfirmationToken
     protected function currentURL()
     {
         return Controller::join_links(
-            BASE_URL,
-            '/',
+            BASE_URL ?: '/',
             $this->request->getURL(false)
         );
     }


### PR DESCRIPTION
PHP 7.1.7 is currently not segfaulting when generating coverage reports with phpdbg

~~Due to some weird behaviour happening with this combination on TravisCI not setting the base URL correctly, I've moved the SS_BASE_URL environment variable from being a fallback option to being the priority if it's defined - in constants.php.~~ Reverted

Resolves #7156