### PR TITLE
FIX Ensure phpdbg calls are registered by SilverStripe core as a CLI call

### DIFF
--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -944,7 +944,7 @@ class Director implements TemplateGlobalProvider
      */
     public static function is_cli()
     {
-        return php_sapi_name() === "cli";
+        return in_array(php_sapi_name(), ['cli', 'phpdbg']);
     }
 
     /**

--- a/tests/php/Control/DirectorTest.php
+++ b/tests/php/Control/DirectorTest.php
@@ -761,4 +761,12 @@ class DirectorTest extends SapphireTest
         $this->assertEquals(2, $middleware->preCalls);
         $this->assertEquals(1, $specificMiddleware->postCalls);
     }
+
+    /**
+     * If using phpdbg it returns itself instead of "cli" from php_sapi_name()
+     */
+    public function testIsCli()
+    {
+        $this->assertTrue(Director::is_cli(), 'is_cli should be true for PHP CLI and phpdbg');
+    }
 }


### PR DESCRIPTION
Currently running `phpdbg -qrr vendor/bin/phpunit` will return false from `Director::is_cli()`, since `php_sapi_name` returns `phpdbg` instead of `cli` when running the debugger (e.g. for faster code coverage than xdebug).

This change will handle both cases, and adds a test which can show the problem without the patch to `Director`.

Similar PR a couple of weeks ago on Laravel: https://github.com/laravel/framework/pull/18198