### PR TITLE
FIX Add unique prefix to cache stores to prevent cache leak

### DIFF
--- a/cache/Cache.php
+++ b/cache/Cache.php
@@ -174,7 +174,9 @@ class SS_Cache {
 
 		$backend = self::$backends[$backend_name];
 
-		$basicOptions = array('cache_id_prefix' => $for);
+		$basicOptions = array(
+		    'cache_id_prefix' => $for . '_' . md5(BASE_PATH) . '_',
+        );
 
 		if ($cache_lifetime >= 0) {
 			$basicOptions['lifetime'] = $cache_lifetime;

--- a/core/manifest/ConfigManifest.php
+++ b/core/manifest/ConfigManifest.php
@@ -115,7 +115,8 @@ class SS_ConfigManifest {
 	{
 		return SS_Cache::factory('SS_Configuration', 'Core', array(
 			'automatic_serialization' => true,
-			'lifetime' => null
+			'lifetime' => null,
+			'cache_id_prefix' => 'SS_Configuration_',
 		));
 	}
 


### PR DESCRIPTION
fixes #6358 

This adds a default prefix to cache identifiers so that servers with multiple sites have a lower likelihood of accessing each-others caches.