### PR TITLE
Remove redundant cache config

### DIFF
--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -14,10 +14,6 @@ SilverStripe\Core\Injector\Injector:
     constructor:
       namespace: "cacheblock"
       defaultLifetime: 600
-  Psr\SimpleCache\CacheInterface.LeftAndMain_CMSVersion:
-    factory: SilverStripe\Core\Cache\CacheFactory
-    constructor:
-      namespace: "LeftAndMain_CMSVersion"
   Psr\SimpleCache\CacheInterface.VersionProvider_composerlock:
       factory: SilverStripe\Core\Cache\CacheFactory
       constructor:


### PR DESCRIPTION
This cache config should have been defined in the [admin module](https://github.com/silverstripe/silverstripe-admin/) as it pertained to that class. However this cache has now been removed any way (see https://github.com/silverstripe/silverstripe-admin/pull/153).