### PR TITLE
TEST Make travis install codesniffer with composer global

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ before_script:
 # Init PHP
   - export CORE_RELEASE=$TRAVIS_BRANCH
   - printf "\n" | pecl install imagick
-  - if [[ $PHPCS_TEST ]]; then pyrus install pear/PHP_CodeSniffer; fi
   - phpenv rehash
   - phpenv config-rm xdebug.ini
   - echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
@@ -56,12 +55,14 @@ before_script:
   - composer self-update --snapshot
 
 # Install composer dependencies
+  - export PATH=~/.composer/vendor/bin:$PATH
   - composer validate
   - composer install --prefer-dist
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
   - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --prefer-dist; fi
   - composer require silverstripe/config:1.0.x-dev silverstripe/admin:1.0.x-dev silverstripe/assets:1.0.x-dev silverstripe/versioned:1.0.x-dev --prefer-dist
   - if [[ $PHPUNIT_TEST == cms ]] || [[ $BEHAT_TEST == cms ]]; then composer require silverstripe/cms:4.0.x-dev silverstripe/campaign-admin:1.0.x-dev silverstripe/siteconfig:4.0.x-dev silverstripe/reports:4.0.x-dev --prefer-dist; fi
+  - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
 
 # Bootstrap dependencies
   - if [[ $PHPUNIT_TEST == cms ]] || [[ $BEHAT_TEST == cms ]]; then php ./cms/tests/bootstrap/mysite.php; fi


### PR DESCRIPTION
`pyrus` doesn't seem to be supported in PHP 5 travis builds anymore.