### PR TITLE
BUG fix config rules to match updated `Except`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 sudo: false
 
+dist: precise
+
 addons:
   apt:
     packages:

--- a/tests/php/Core/Manifest/ConfigManifestTest.php
+++ b/tests/php/Core/Manifest/ConfigManifestTest.php
@@ -210,9 +210,9 @@ class ConfigManifestTest extends SapphireTest
             'Fragment is included if both Only rules succeed.'
         );
 
-        $this->assertTrue(
-            isset($config['TwoExceptSucceed']),
-            'Fragment is included if one of the Except rules matches.'
+        $this->assertFalse(
+            isset($config['OneExceptFail']),
+            'Fragment is not included if one of the Except rules fails.'
         );
 
         $this->assertFalse(

--- a/tests/php/Core/Manifest/fixtures/configmanifest/mysite/_config/multiplerules.yml
+++ b/tests/php/Core/Manifest/fixtures/configmanifest/mysite/_config/multiplerules.yml
@@ -21,7 +21,7 @@ Except:
 ---
 SilverStripe\Core\Tests\Manifest\ConfigManifestTest:
   MultipleRules:
-    TwoExceptSucceed: "included - one of the excepts succeeds"
+    OneExceptFail: "excluded - one of the excepts fails"
 ---
 Except:
   ConstantDefined: MULTIPLERULES_DEFINEDCONSTANT


### PR DESCRIPTION
Except rules were meant to be exclusive, not inclusive. Patched in upstream config module, but framework tests need updating.