### PR TITLE
FIX Deprecated yml syntax

### DIFF
--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -8,7 +8,7 @@ SilverStripe\Core\Injector\Injector:
       args:
         directory: '`TEMP_FOLDER`'
         version: null
-      logger: %$Psr\Log\LoggerInterface
+      logger: '%$Psr\Log\LoggerInterface'
   Psr\SimpleCache\CacheInterface.cacheblock:
     factory: SilverStripe\Core\Cache\CacheFactory
     constructor:

--- a/_config/database.yml
+++ b/_config/database.yml
@@ -5,15 +5,15 @@ SilverStripe\Core\Injector\Injector:
   MySQLPDODatabase:
     class: 'SilverStripe\ORM\Connect\MySQLDatabase'
     properties:
-      connector: %$PDOConnector
-      schemaManager: %$MySQLSchemaManager
-      queryBuilder: %$MySQLQueryBuilder
+      connector: '%$PDOConnector'
+      schemaManager: '%$MySQLSchemaManager'
+      queryBuilder: '%$MySQLQueryBuilder'
   MySQLDatabase:
     class: 'SilverStripe\ORM\Connect\MySQLDatabase'
     properties:
-      connector: %$MySQLiConnector
-      schemaManager: %$MySQLSchemaManager
-      queryBuilder: %$MySQLQueryBuilder
+      connector: '%$MySQLiConnector'
+      schemaManager: '%$MySQLSchemaManager'
+      queryBuilder: '%$MySQLQueryBuilder'
   MySQLiConnector:
     class: 'SilverStripe\ORM\Connect\MySQLiConnector'
     type: prototype

--- a/_config/i18n.yml
+++ b/_config/i18n.yml
@@ -24,14 +24,14 @@ SilverStripe\Core\Injector\Injector:
   Symfony\Component\Translation\Loader\LoaderInterface:
     class: SilverStripe\i18n\Messages\Symfony\ModuleYamlLoader
     properties:
-      Reader: %$SilverStripe\i18n\Messages\Reader
+      Reader: '%$SilverStripe\i18n\Messages\Reader'
   # Ensure our cache respects ModuleYamlLoader's self-invalidation
   # @see DirectoryListResource::isFresh()
   # Note: This could be replaced with a more aggressive cache if necessary on a live environment
   Symfony\Component\Config\ConfigCacheFactoryInterface:
     class: Symfony\Component\Config\ResourceCheckerConfigCacheFactory
     constructor:
-      0: [ %$Symfony\Component\Config\Resource\SelfCheckingResourceChecker ]
+      0: [ '%$Symfony\Component\Config\Resource\SelfCheckingResourceChecker' ]
   # Create default translator with standard cache path and our custom loader
   Symfony\Component\Translation\TranslatorInterface:
     class: Symfony\Component\Translation\Translator
@@ -40,23 +40,23 @@ SilverStripe\Core\Injector\Injector:
       1: null
       2: '`TEMP_FOLDER`'
     properties:
-      ConfigCacheFactory: %$Symfony\Component\Config\ConfigCacheFactoryInterface
+      ConfigCacheFactory: '%$Symfony\Component\Config\ConfigCacheFactoryInterface'
     calls:
       FallbackLocales: [ setFallbackLocales, [['en']]]
-      Loader: [ addLoader, ['ss', %$Symfony\Component\Translation\Loader\LoaderInterface ]]
+      Loader: [ addLoader, ['ss', '%$Symfony\Component\Translation\Loader\LoaderInterface' ]]
   # Set this translator as our message provider for silverstripe's i18n
   SilverStripe\i18n\Messages\MessageProvider:
     class: SilverStripe\i18n\Messages\Symfony\SymfonyMessageProvider
     properties:
-      Translator: %$Symfony\Component\Translation\TranslatorInterface
+      Translator: '%$Symfony\Component\Translation\TranslatorInterface'
 ---
 Name: textcollector
 ---
 SilverStripe\Core\Injector\Injector:
   SilverStripe\i18n\TextCollection\i18nTextCollector:
     properties:
-      Reader: %$SilverStripe\i18n\Messages\Reader
-      Writer: %$SilverStripe\i18n\Messages\Writer
+      Reader: '%$SilverStripe\i18n\Messages\Reader'
+      Writer: '%$SilverStripe\i18n\Messages\Writer'
 ---
 Name: i18ndata
 ---

--- a/_config/logging.yml
+++ b/_config/logging.yml
@@ -10,14 +10,14 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Logging\ErrorHandler:
     class: SilverStripe\Logging\MonologErrorHandler
     properties:
-      Logger: %$Psr\Log\LoggerInterface
+      Logger: '%$Psr\Log\LoggerInterface'
   Psr\Log\LoggerInterface:
     type: singleton
     class: Monolog\Logger
     constructor:
       - "error-log"
     calls:
-      pushDisplayErrorHandler: [ pushHandler, [ %$Monolog\Handler\HandlerInterface ] ]
+      pushDisplayErrorHandler: [ pushHandler, [ '%$Monolog\Handler\HandlerInterface' ] ]
 ---
 Name: loggingformatters
 ---
@@ -43,7 +43,7 @@ SilverStripe\Core\Injector\Injector:
     constructor:
       - "notice"
     properties:
-      DefaultFormatter: %$Monolog\Formatter\FormatterInterface.detailed
+      DefaultFormatter: '%$Monolog\Formatter\FormatterInterface.detailed'
 ---
 Name: live-logging
 Except:
@@ -57,5 +57,5 @@ SilverStripe\Core\Injector\Injector:
     constructor:
       - "error"
     properties:
-      DefaultFormatter: %$Monolog\Formatter\FormatterInterface.friendly
-      CLIFormatter: %$Monolog\Formatter\FormatterInterface.detailed
+      DefaultFormatter: '%$Monolog\Formatter\FormatterInterface.friendly'
+      CLIFormatter: '%$Monolog\Formatter\FormatterInterface.detailed'

--- a/_config/mimetypes.yml
+++ b/_config/mimetypes.yml
@@ -756,7 +756,6 @@ SilverStripe\Control\HTTP:
     stl: application/vnd.ms-pki.stl
     str: application/vnd.pg.format
     stw: application/vnd.sun.xml.writer.template
-    sub: image/vnd.dvb.subtitle
     sub: text/vnd.dvb.subtitle
     sus: application/vnd.sus-calendar
     susp: application/vnd.sus-calendar
@@ -900,7 +899,6 @@ SilverStripe\Control\HTTP:
     wmv: video/x-ms-wmv
     wmx: video/x-ms-wmx
     wmz: application/x-ms-wmz
-    wmz: application/x-msmetafile
     woff: application/x-font-woff
     wpd: application/vnd.wordperfect
     wpl: application/vnd.ms-wpl

--- a/_config/model.yml
+++ b/_config/model.yml
@@ -62,7 +62,7 @@ SilverStripe\Core\Injector\Injector:
 Name: coresearchfilters
 ---
 SilverStripe\Core\Injector\Injector:
-  DataListFilter.default: %$DataListFilter.ExactMatch
+  DataListFilter.default: '%$DataListFilter.ExactMatch'
   DataListFilter.EndsWith:
     class: SilverStripe\ORM\Filters\EndsWithFilter
   DataListFilter.ExactMatch:
@@ -87,13 +87,13 @@ SilverStripe\Core\Injector\Injector:
 Name: coresearchaliases
 ---
 SilverStripe\Core\Injector\Injector:
-  EndsWithFilter: %$DataListFilter.EndsWith
-  ExactMatchFilter: %$DataListFilter.ExactMatch
-  FulltextFilter: %$DataListFilter.Fulltext
-  GreaterThanFilter: $&DataListFilter.GreaterThan
-  GreaterThanOrEqualFilter: %$DataListFilter.GreaterThanOrEqual
-  LessThanFilter: %$DataListFilter.LessThan
-  LessThanOrEqualFilter: %$DataListFilter.LessThanOrEqual
-  PartialMatchFilter: %$DataListFilter.PartialMatch
-  StartsWithFilter: %$DataListFilter.StartsWith
-  WithinRangeFilter: %$DataListFilter.WithinRange
+  EndsWithFilter: '%$DataListFilter.EndsWith'
+  ExactMatchFilter: '%$DataListFilter.ExactMatch'
+  FulltextFilter: '%$DataListFilter.Fulltext'
+  GreaterThanFilter: '%$$DataListFilter.GreaterThan'
+  GreaterThanOrEqualFilter: '%$DataListFilter.GreaterThanOrEqual'
+  LessThanFilter: '%$DataListFilter.LessThan'
+  LessThanOrEqualFilter: '%$DataListFilter.LessThanOrEqual'
+  PartialMatchFilter: '%$DataListFilter.PartialMatch'
+  StartsWithFilter: '%$DataListFilter.StartsWith'
+  WithinRangeFilter: '%$DataListFilter.WithinRange'

--- a/_config/requestprocessors.yml
+++ b/_config/requestprocessors.yml
@@ -5,11 +5,11 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Control\Director:
     properties:
       Middlewares:
-        TrustedProxyMiddleware: %$SilverStripe\Control\Middleware\TrustedProxyMiddleware
-        AllowedHostsMiddleware: %$SilverStripe\Control\Middleware\AllowedHostsMiddleware
-        SessionMiddleware: %$SilverStripe\Control\Middleware\SessionMiddleware
-        RequestProcessorMiddleware: %$SilverStripe\Control\RequestProcessor
-        FlushMiddleware: %$SilverStripe\Control\Middleware\FlushMiddleware
+        TrustedProxyMiddleware: '%$SilverStripe\Control\Middleware\TrustedProxyMiddleware'
+        AllowedHostsMiddleware: '%$SilverStripe\Control\Middleware\AllowedHostsMiddleware'
+        SessionMiddleware: '%$SilverStripe\Control\Middleware\SessionMiddleware'
+        RequestProcessorMiddleware: '%$SilverStripe\Control\RequestProcessor'
+        FlushMiddleware: '%$SilverStripe\Control\Middleware\FlushMiddleware'
   SilverStripe\Control\AllowedHostsMiddleware:
     properties:
       AllowedHosts: "`SS_ALLOWED_HOSTS`"

--- a/_config/security.yml
+++ b/_config/security.yml
@@ -9,13 +9,13 @@ SilverStripe\Core\Injector\Injector:
     properties:
       TokenCookieName: alc_enc
       DeviceCookieName: alc_device
-      CascadeInTo: %$SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler
+      CascadeInTo: '%$SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler'
   SilverStripe\Security\AuthenticationHandler:
     class: SilverStripe\Security\RequestAuthenticationHandler
     properties:
       Handlers:
-        session: %$SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler
-        alc: %$SilverStripe\Security\MemberAuthenticator\CookieAuthenticationHandler
+        session: '%$SilverStripe\Security\MemberAuthenticator\SessionAuthenticationHandler'
+        alc: '%$SilverStripe\Security\MemberAuthenticator\CookieAuthenticationHandler'
 ---
 Name: coresecurity
 After:
@@ -25,16 +25,16 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Control\Director:
     properties:
       Middlewares:
-        AuthenticationMiddleware: %$SilverStripe\Security\AuthenticationMiddleware
+        AuthenticationMiddleware: '%$SilverStripe\Security\AuthenticationMiddleware'
   SilverStripe\Security\AuthenticationMiddleware:
     properties:
-      AuthenticationHandler: %$SilverStripe\Security\AuthenticationHandler
+      AuthenticationHandler: '%$SilverStripe\Security\AuthenticationHandler'
   SilverStripe\Security\Security:
     properties:
       Authenticators:
-        default: %$SilverStripe\Security\MemberAuthenticator\MemberAuthenticator
+        default: '%$SilverStripe\Security\MemberAuthenticator\MemberAuthenticator'
   SilverStripe\Security\CMSSecurity:
     properties:
       Authenticators:
-        cms: %$SilverStripe\Security\MemberAuthenticator\CMSMemberAuthenticator
-  SilverStripe\Security\IdentityStore: %$SilverStripe\Security\AuthenticationHandler
+        cms: '%$SilverStripe\Security\MemberAuthenticator\CMSMemberAuthenticator'
+  SilverStripe\Security\IdentityStore: '%$SilverStripe\Security\AuthenticationHandler'

--- a/_config/tests.yml
+++ b/_config/tests.yml
@@ -5,10 +5,10 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Dev\State\SapphireTestState:
     properties:
       States:
-        globals: %$SilverStripe\Dev\State\GlobalsTestState
-        extensions: %$SilverStripe\Dev\State\ExtensionTestState
-        flushable: %$SilverStripe\Dev\State\FlushableTestState
-        requirements: %$SilverStripe\View\Dev\RequirementsTestState
+        globals: '%$SilverStripe\Dev\State\GlobalsTestState'
+        extensions: '%$SilverStripe\Dev\State\ExtensionTestState'
+        flushable: '%$SilverStripe\Dev\State\FlushableTestState'
+        requirements: '%$SilverStripe\View\Dev\RequirementsTestState'
 ---
 Name: kerneltest
 Before: '*'
@@ -17,4 +17,4 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Dev\State\SapphireTestState:
     properties:
       States:
-        kernel: %$SilverStripe\Dev\State\KernelTestState
+        kernel: '%$SilverStripe\Dev\State\KernelTestState'


### PR DESCRIPTION
Since 3.1 of symfony/yaml having unquoted strings starting with `%` is deprecated (https://github.com/symfony/yaml/blob/v3.1.0/Inline.php#L301-L303)

Since 3.2 having duplicate keys fail silently is deprecated (https://github.com/symfony/yaml/blob/v3.2.0/Parser.php#L246)

This PR aims to address those issues.

---

Related PRs:

- [x] https://github.com/silverstripe/silverstripe-cms/pull/1908
- [x] https://github.com/silverstripe/silverstripe-assets/pull/54
- [x] https://github.com/silverstripe/silverstripe-versioned/pull/30