### PR TITLE
Ensure ClassManifest isn't flushed twice on build

### DIFF
--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -122,8 +122,12 @@ class DatabaseAdmin extends Controller
         // The default time limit of 30 seconds is normally not enough
         Environment::increaseTimeLimitTo(600);
 
-        // Get all our classes
-        ClassLoader::inst()->getManifest()->regenerate(false);
+        // If this code is being run outside of a dev/build or without a ?flush query string param,
+        // the class manifest hasn't been flushed, so do it here
+        $request = $this->getRequest();
+        if (!array_key_exists('flush', $request->getVars()) && strpos($request->getURL(), 'dev/build') !== 0) {
+            ClassLoader::inst()->getManifest()->regenerate(false);
+        }
 
         $url = $this->getReturnURL();
         if ($url) {


### PR DESCRIPTION
Shaves ~10% off the wall time of a `dev/build` for a “blank” install

<img width="1125" alt="screen shot 2017-07-21 at 14 39 30" src="https://user-images.githubusercontent.com/1655548/28465927-71efc9d8-6e22-11e7-91c9-392e0ab909d7.png">
