### PR TITLE
check SERVER for HTTPS so _config.php doesn't infinite loop

### DIFF
--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -875,6 +875,10 @@ class Director implements TemplateGlobalProvider
     {
         // if no request i.e. has been set in _config.php - prevents loops
         if (!static::currentRequest()) {
+            user_error(
+                'Director::forceSSL() requires a current request. This usually means you have tried to  call this from _config.php. If so, please add this to the init() method of your PageController.',
+                E_USER_WARNING
+            );
             return false;
         }
 
@@ -922,6 +926,10 @@ class Director implements TemplateGlobalProvider
     {
         // if no request i.e. has been set in _config.php - prevents loops
         if (!static::currentRequest()) {
+            user_error(
+                'Director::forceWWW() requires a current request. This usually means you have tried to call this from _config.php. If so, please add this to the init() method of your PageController.',
+                E_USER_WARNING
+            );
             return false;
         }
 

--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -843,7 +843,7 @@ class Director implements TemplateGlobalProvider
     /**
      * Force the site to run on SSL.
      *
-     * To use, call from _config.php. For example:
+     * To use, call from the init() method of your PageController. For example:
      * <code>
      * if (Director::isLive()) Director::forceSSL();
      * </code>
@@ -873,6 +873,11 @@ class Director implements TemplateGlobalProvider
      */
     public static function forceSSL($patterns = null, $secureDomain = null)
     {
+        // if no request i.e. has been set in _config.php - prevents loops
+        if (!static::currentRequest()) {
+            return false;
+        }
+
         // Already on SSL
         if (static::is_https()) {
             return true;
@@ -915,6 +920,11 @@ class Director implements TemplateGlobalProvider
      */
     public static function forceWWW()
     {
+        // if no request i.e. has been set in _config.php - prevents loops
+        if (!static::currentRequest()) {
+            return false;
+        }
+
         if (!Director::isDev() && !Director::isTest() && strpos(static::host(), 'www') !== 0) {
             $destURL = str_replace(
                 Director::protocol(),

--- a/tests/php/Control/DirectorTest.php
+++ b/tests/php/Control/DirectorTest.php
@@ -415,7 +415,8 @@ class DirectorTest extends SapphireTest
     public function testForceSSLProtectsEntireSite()
     {
         $this->expectExceptionRedirect('https://www.mysite.com/some-url');
-        Director::mockRequest(function () {
+        Director::mockRequest(function ($request) {
+            Injector::inst()->registerService($request);
             Director::forceSSL();
         }, '/some-url');
     }
@@ -424,7 +425,8 @@ class DirectorTest extends SapphireTest
     {
         // Expect admin to trigger redirect
         $this->expectExceptionRedirect('https://www.mysite.com/admin');
-        Director::mockRequest(function () {
+        Director::mockRequest(function ($request) {
+            Injector::inst()->registerService($request);
             Director::forceSSL(array('/^admin/'));
         }, '/admin');
     }
@@ -433,7 +435,8 @@ class DirectorTest extends SapphireTest
     {
         // Expect to redirect to security login page
         $this->expectExceptionRedirect('https://www.mysite.com/Security/login');
-        Director::mockRequest(function () {
+        Director::mockRequest(function ($request) {
+            Injector::inst()->registerService($request);
             Director::forceSSL(array('/^Security/'));
         }, '/Security/login');
     }
@@ -441,12 +444,14 @@ class DirectorTest extends SapphireTest
     public function testForceSSLWithPatternDoesNotMatchOtherPages()
     {
         // Not on same url should not trigger redirect
-        Director::mockRequest(function () {
+        Director::mockRequest(function ($request) {
+            Injector::inst()->registerService($request);
             $this->assertFalse(Director::forceSSL(array('/^admin/')));
         }, Director::baseURL() . 'normal-page');
 
         // nested url should not triger redirect either
-        Director::mockRequest(function () {
+        Director::mockRequest(function ($request) {
+            Injector::inst()->registerService($request);
             $this->assertFalse(Director::forceSSL(array('/^admin/', '/^Security/')));
         }, Director::baseURL() . 'just-another-page/sub-url');
     }
@@ -455,7 +460,8 @@ class DirectorTest extends SapphireTest
     {
         // Ensure that forceSSL throws the appropriate exception
         $this->expectExceptionRedirect('https://secure.mysite.com/admin');
-        Director::mockRequest(function (HTTPRequest $request) {
+        Director::mockRequest(function ($request) {
+            Injector::inst()->registerService($request);
             return Director::forceSSL(array('/^admin/'), 'secure.mysite.com');
         }, Director::baseURL() . 'admin');
     }


### PR DESCRIPTION
Re-adds the check in $_SERVER so that using `Director::forceSSL()` in `_config.php` as recommended doesn't result in an infinite loop.

Fixes #7214 