### PR TITLE
Optimise travis composer installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,12 +59,12 @@ before_script:
 # Install composer dependencies
   - export PATH=~/.composer/vendor/bin:$PATH
   - composer validate
-  - composer install --prefer-dist
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
-  - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --prefer-dist; fi
-  - composer require silverstripe/config:1.0.x-dev silverstripe/admin:1.0.x-dev silverstripe/assets:1.0.x-dev silverstripe/versioned:1.0.x-dev --prefer-dist
-  - if [[ $PHPUNIT_TEST == cms ]] || [[ $BEHAT_TEST == cms ]]; then composer require silverstripe/cms:4.0.x-dev silverstripe/campaign-admin:1.0.x-dev silverstripe/siteconfig:4.0.x-dev silverstripe/reports:4.0.x-dev --prefer-dist; fi
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --no-update; fi
+  - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --no-update; fi
+  - composer require silverstripe/config:1.0.x-dev silverstripe/admin:1.0.x-dev silverstripe/assets:1.0.x-dev silverstripe/versioned:1.0.x-dev --no-update
+  - if [[ $PHPUNIT_TEST == cms ]] || [[ $BEHAT_TEST == cms ]]; then composer require silverstripe/cms:4.0.x-dev silverstripe/campaign-admin:1.0.x-dev silverstripe/siteconfig:4.0.x-dev silverstripe/reports:4.0.x-dev --no-update; fi
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
+  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 # Bootstrap dependencies
   - if [[ $PHPUNIT_TEST == cms ]] || [[ $BEHAT_TEST == cms ]]; then php ./cms/tests/bootstrap/mysite.php; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ dist: precise
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+    - vendor/
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache/files
-    - vendor/
 
 addons:
   apt:


### PR DESCRIPTION
ping @tractorcow 

We had previously attempted to add caching to travis but given up on it because it caused cross build pollination due to the way our travis-support module worked.

However, we now don't use travis-support and use the more conventional composer installation approach which should make this caching safer and we can start to see some performance gains 🤞 

---
Postgres build on PHP7:

Branch | Time
--- | ---
Current 4 branch | 56.5s
Optimised installation | 36s
Travis caching | 40s