### PR TITLE
BUGFIX: DBComposite doesn't allow arbitrary property assignment

### DIFF
--- a/src/ORM/FieldType/DBComposite.php
+++ b/src/ORM/FieldType/DBComposite.php
@@ -240,8 +240,9 @@ abstract class DBComposite extends DBField
     {
         $this->objCacheClear();
 
-        // Skip non-db fields
+        // Non-db fields get assigned as normal properties
         if (!$this->hasField($field)) {
+            $this->$field = $value;
             return $this;
         }
 

--- a/src/ORM/FieldType/DBComposite.php
+++ b/src/ORM/FieldType/DBComposite.php
@@ -242,7 +242,8 @@ abstract class DBComposite extends DBField
 
         // Non-db fields get assigned as normal properties
         if (!$this->hasField($field)) {
-            $this->$field = $value;
+            parent::setField($field, $value);
+            
             return $this;
         }
 


### PR DESCRIPTION
To be more consistent with `ViewableData`, whose `setField()` method will fallback on [assigning properties arbitrarily](https://github.com/silverstripe/silverstripe-framework/blob/4/src/View/ViewableData.php#L213), `DBComposite` shouldn't bail out of `setField` when the field specified isn't in the record.

Arbitrary property assignment is particularly important in injection.

```yaml
SilverStripe\ORM\FieldType\DBComposite:
  dependencies:
    myService: %$Service
```

Right now, that fails, because `$obj->myService = Service` invokes `__set()` which calls `setField()` which refuses the assignment when `myService`is not in the record.