### PR TITLE
FIX: Fixes #7181 Use config system for userland config of node_threshold_total

### DIFF
--- a/forms/TreeDropdownField.php
+++ b/forms/TreeDropdownField.php
@@ -51,6 +51,13 @@ class TreeDropdownField extends FormField {
 	);
 
 	/**
+	 * @config
+	 * @var int
+	 * @see {@link Hierarchy::$node_threshold_total}.
+	 */
+	private static $node_threshold_total = 30;
+
+	/**
 	 * @ignore
 	 */
 	protected $sourceObject, $keyField, $labelField, $filterCallback,
@@ -303,7 +310,8 @@ class TreeDropdownField extends FormField {
 		if ($this->filterCallback || $this->search != "" )
 			$obj->setMarkingFilterFunction(array($this, "filterMarking"));
 
-		$obj->markPartialTree($nodeCountThreshold = 30, $context = null,
+		$nodeCountThreshold = Config::inst()->get('TreeDropdownField', 'node_threshold_total');
+		$obj->markPartialTree($nodeCountThreshold, $context = null,
 			$this->childrenMethod, $this->numChildrenMethod);
 
 		// allow to pass values to be selected within the ajax request

--- a/model/Hierarchy.php
+++ b/model/Hierarchy.php
@@ -218,10 +218,12 @@ class Hierarchy extends DataExtension {
 	 * @param int $nodeCountThreshold See {@link getChildrenAsUL()}
 	 * @return int The actual number of nodes marked.
 	 */
-	public function markPartialTree($nodeCountThreshold = 30, $context = null,
+	public function markPartialTree($nodeCountThreshold = null, $context = null,
 			$childrenMethod = "AllChildrenIncludingDeleted", $numChildrenMethod = "numChildren") {
 
-		if(!is_numeric($nodeCountThreshold)) $nodeCountThreshold = 30;
+		if(!is_numeric($nodeCountThreshold)) {
+			$nodeCountThreshold = Config::inst()->get('Hierarchy', 'node_threshold_total');
+		}
 
 		$this->markedNodes = array($this->owner->ID => $this->owner);
 		$this->owner->markUnexpanded();


### PR DESCRIPTION
Substitutes baked-in defaults for x2 methods on `TreeDropdownField` and `Hierarchy` for configurable defaults via a `node_threshold_total` private static.