### PR TITLE
Remove `use_gzip` from HTMLEditorField since it's been removed by TinyMCE codebase

### DIFF
--- a/docs/en/04_Changelogs/4.5.0.md
+++ b/docs/en/04_Changelogs/4.5.0.md
@@ -2,9 +2,11 @@
 
 ## Overview {#overview}
 
-TBC.
+ * Removed `use_gzip` option on `HtmlEditorField` which used to compress the rich text editor dependency. 
+   No longer required since compression is performed as part of the CMS build automatically.
+   See (#832)(https://github.com/silverstripe/silverstripe-admin/issues/832)
 
 ## Deprecation
 
-* `PasswordValidator` methods `minLength`, `characterStrength`, and `checkHistoricalPasswords` are now deprecated from
+ * `PasswordValidator` methods `minLength`, `characterStrength`, and `checkHistoricalPasswords` are now deprecated from
   4.5.0 onwards (previously 5.0).

--- a/src/Forms/HTMLEditor/HTMLEditorField.php
+++ b/src/Forms/HTMLEditor/HTMLEditorField.php
@@ -29,14 +29,6 @@ class HTMLEditorField extends TextareaField
     protected $schemaComponent = 'HtmlEditorField';
 
     /**
-     * Use TinyMCE's GZIP compressor
-     *
-     * @config
-     * @var bool
-     */
-    private static $use_gzip = true;
-
-    /**
      * @config
      * @var string Default alignment for Images and Media. Options: leftAlone|center|left|right
      */

--- a/src/Forms/HTMLEditor/TinyMCEGZIPGenerator.php
+++ b/src/Forms/HTMLEditor/TinyMCEGZIPGenerator.php
@@ -31,29 +31,6 @@ class TinyMCEGZIPGenerator implements TinyMCEScriptGenerator
      */
     public function getScriptURL(TinyMCEConfig $config)
     {
-        // If gzip is disabled just return core script url
-        $useGzip = HTMLEditorField::config()->get('use_gzip');
-        if (!$useGzip) {
-            return Controller::join_links($config->getTinyMCEResourceURL(), 'tinymce.min.js');
-        }
-
-        // tinyMCE JS requirement - use the original module path,
-        // don't assume the PHP file is copied alongside the resources
-        $gzipPath = $config->getTinyMCEResourcePath() . '/tiny_mce_gzip.php';
-        if (!file_exists($gzipPath)) {
-            throw new Exception("HTMLEditorField.use_gzip enabled, but file $gzipPath does not exist!");
-        }
-
-        require_once $gzipPath;
-
-        $tag = TinyMCE_Compressor::renderTag(array(
-            'url' => $config->getTinyMCEResourceURL() . '/tiny_mce_gzip.php',
-            'plugins' => implode(',', $config->getInternalPlugins()),
-            'themes' => $config->getTheme(),
-            'languages' => $config->getOption('language')
-        ), true);
-        preg_match('/src="([^"]*)"/', $tag, $matches);
-
-        return html_entity_decode($matches[1]);
+        return Controller::join_links($config->getTinyMCEResourceURL(), 'tinymce.min.js');
     }
 }

--- a/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
@@ -68,7 +68,6 @@ class HTMLEditorFieldTest extends FunctionalTest
             'base_dir',
             'silverstripe/framework: tests/php/Forms/HTMLEditor/TinyMCECombinedGeneratorTest/tinymce'
         );
-        HtmlEditorField::config()->set('use_gzip', false);
 
         // Test special characters
         $inputText = "These are some unicodes: ä, ö, & ü";


### PR DESCRIPTION
Original part of https://github.com/silverstripe/silverstripe-admin/issues/158

FYI: TinyMCE has removed it https://github.com/tinymce/tinymce-docs/pull/460