### PR TITLE
FIX Files without extensions (folders) do not have a trailing period added

### DIFF
--- a/filesystem/File.php
+++ b/filesystem/File.php
@@ -634,7 +634,7 @@ class File extends DataObject {
 	 *
 	 * Does not change the filesystem itself, please use {@link write()} for this.
 	 *
-	 * @param String $name
+	 * @param string $name
 	 */
 	public function setName($name) {
 		$oldName = $this->Name;
@@ -663,7 +663,10 @@ class File extends DataObject {
 				))->first()
 			) {
 				$suffix++;
-				$name = "$base-$suffix.$ext";
+				$name = "$base-$suffix";
+				if (!empty($ext)) {
+					$name .= ".$ext";
+				}
 			}
 		}
 

--- a/tests/filesystem/FileTest.php
+++ b/tests/filesystem/FileTest.php
@@ -187,6 +187,30 @@ class FileTest extends SapphireTest {
 		}
 	}
 
+	/**
+	 * Uses fixtures Folder.folder1 and File.setfromname
+	 * @dataProvider setNameFileProvider
+	 */
+	public function testSetNameAddsUniqueSuffixWhenFilenameAlreadyExists($name, $expected)
+	{
+		$duplicate = new Folder;
+		$duplicate->setName($name);
+		$duplicate->write();
+
+		$this->assertSame($expected, $duplicate->Name);
+	}
+
+	/**
+	 * @return array[]
+	 */
+	public function setNameFileProvider()
+	{
+		return array(
+			array('FileTest-folder1', 'FileTest-folder1-2'),
+			array('FileTest.png', 'FileTest-2.png'),
+		);
+	}
+
 	public function testLinkAndRelativeLink() {
 		$file = $this->objFromFixture('File', 'asdf');
 		$this->assertEquals(ASSETS_DIR . '/FileTest.txt', $file->RelativeLink());


### PR DESCRIPTION
Fixes #7265

The issue is that `Folder::setName` calls `File::setName`, which assumes there will always be an extension and so returns `original-2.` in the format of `[original]-[unique].[extension]`, which is invalid for folders, and files without an extension in principle.