### PR TITLE
NEW Add basic authentication middleware handler

### DIFF
--- a/src/Security/MemberAuthenticator/BasicAuthenticationHandler.php
+++ b/src/Security/MemberAuthenticator/BasicAuthenticationHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SilverStripe\Security\MemberAuthenticator;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\Security\AuthenticationHandler;
+use SilverStripe\Security\BasicAuth;
+use SilverStripe\Security\Member;
+
+/**
+ * Authenticates requests using {@link \SilverStripe\Security\BasicAuth}. Can be applied to routes as middleware
+ * via the {@link \SilverStripe\Security\AuthenticationMiddleware} middleware.
+ */
+class BasicAuthenticationHandler implements AuthenticationHandler
+{
+    /**
+     * Try to authenticate a member with basic authentication
+     *
+     * {@inheritDoc}
+     */
+    public function authenticateRequest(HTTPRequest $request)
+    {
+        try {
+            return BasicAuth::requireLogin($request, 'Restricted');
+        } catch (HTTPResponse_Exception $ex) {
+            throw new ValidationException($ex->getMessage());
+        }
+    }
+
+    public function logIn(Member $member, $persistent = false, HTTPRequest $request = null)
+    {
+        // no op
+    }
+
+    public function logOut(HTTPRequest $request = null)
+    {
+        // no op
+    }
+}


### PR DESCRIPTION
This can be applied to the AuthenticationHandler via middleware to enable basic authentication across the site, or to any middleware aware controller.

Issue: https://github.com/silverstripe/silverstripe-framework/issues/7268 and also required for https://github.com/silverstripe/silverstripe-graphql/pull/111