### PR TITLE
Fix Truncate Error Issue when using views in a Unittest.

### DIFF
--- a/model/connect/MySQLSchemaManager.php
+++ b/model/connect/MySQLSchemaManager.php
@@ -336,7 +336,7 @@ class MySQLSchemaManager extends DBSchemaManager {
 
 	public function tableList() {
 		$tables = array();
-		foreach ($this->query("SHOW TABLES") as $record) {
+		foreach ($this->query("SHOW FULL TABLES WHERE Table_Type != 'VIEW'") as $record) {
 			$table = reset($record);
 			$tables[strtolower($table)] = $table;
 		}


### PR DESCRIPTION
When using a view in a SilverStripe project, whenever the tear down scripts for the Unittests are run the following error occurs:

```
Couldn't run query:
TRUNCATE "ActivityPoints_view"
Table 'ss_tmpdb2391727.ActivityPoints_view' doesn't exist
```

This was due to the MySQLSchemaManager::tableList() function assuming that all records in the TABLES were actual tables containing data.

This small tweak fixes the issue by modifying the SQL to filter out views from the list before truncating.