### PR TITLE
NEW: Test on php 7.2 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,11 @@ matrix:
         - DB=MYSQL
         - PDO=1
         - PHPUNIT_COVERAGE_TEST=framework
+    - php: 7.2
+      env:
+        - DB=MYSQL
+        - PDO=1
+        - PHPUNIT_TEST=framework
     - php: 7.0
       env:
        - DB=MYSQL
@@ -54,7 +59,7 @@ before_script:
   - export CORE_RELEASE=$TRAVIS_BRANCH
   - printf "\n" | pecl install imagick
   - phpenv rehash
-  - phpenv config-rm xdebug.ini
+  - phpenv config-rm xdebug.ini || true
   - echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 # Temporarily update to 1.5.x-dev of composer

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -807,8 +807,8 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
                     if ($relObj->$relation() instanceof DataObject) {
                         $parentObj = $relObj;
                         $relObj = $relObj->$relation();
-                        // If the intermediate relationship objects have been created, then write them
-                        if ($i<sizeof($relation)-1 && !$relObj->ID || (!$relObj->ID && $parentObj !== $this)) {
+                        // If the intermediate relationship objects haven't been created, then write them
+                        if ($i<sizeof($relations)-1 && !$relObj->ID || (!$relObj->ID && $parentObj !== $this)) {
                             $relObj->write();
                             $relatedFieldName = $relation."ID";
                             $parentObj->$relatedFieldName = $relObj->ID;

--- a/thirdparty/difflib/difflib.php
+++ b/thirdparty/difflib/difflib.php
@@ -418,7 +418,7 @@ class DiffEngine
         $i = 0;
         $j = 0;
 
-        assert('sizeof($lines) == sizeof($changed)');
+        assert(sizeof($lines) == sizeof($changed));
         $len = sizeof($lines);
         $other_len = sizeof($other_changed);
 
@@ -438,7 +438,7 @@ class DiffEngine
                 $j++;
 
             while ($i < $len && !$changed[$i]) {
-                assert('$j < $other_len && ! $other_changed[$j]');
+                assert($j < $other_len && ! $other_changed[$j]);
                 $i++;
                 $j++;
                 while ($j < $other_len && $other_changed[$j])
@@ -471,10 +471,10 @@ class DiffEngine
                     $changed[--$i] = false;
                     while ($start > 0 && $changed[$start - 1])
                         $start--;
-                    assert('$j > 0');
+                    assert($j > 0);
                     while ($other_changed[--$j])
                         continue;
-                    assert('$j >= 0 && !$other_changed[$j]');
+                    assert($j >= 0 && !$other_changed[$j]);
                 }
 
                 /*
@@ -497,7 +497,7 @@ class DiffEngine
                     while ($i < $len && $changed[$i])
                         $i++;
 
-                    assert('$j < $other_len && ! $other_changed[$j]');
+                    assert($j < $other_len && ! $other_changed[$j]);
                     $j++;
                     if ($j < $other_len && $other_changed[$j]) {
                         $corresponding = $i;
@@ -514,10 +514,10 @@ class DiffEngine
             while ($corresponding < $i) {
                 $changed[--$start] = 1;
                 $changed[--$i] = 0;
-                assert('$j > 0');
+                assert($j > 0);
                 while ($other_changed[--$j])
                     continue;
-                assert('$j >= 0 && !$other_changed[$j]');
+                assert($j >= 0 && !$other_changed[$j]);
             }
         }
     }


### PR DESCRIPTION
**UPDATE:*  It turns out that nightly is now running PHP 7.3 and there's a separate PHP 7.2 config.

It’s important that SS4 runs on PHP 7.2, and PHP 7.2 isn’t released
until November, which we expect will be later than SS4 stable. To 
maximise the chance that SS 4.0.0 works with PHP 7.2 I’d think we should
start testing on the PHP nightly, and change this to a 7.2 build once
it’s released.