### PR TITLE
Major performance improvements

### DIFF
--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -429,8 +429,9 @@ Object has been superseded by a trio of traits which replace components of this 
 
  - Injectable: Provides `MyClass::create()` and `MyClass::singleton()`
  - Configurable: Provides `MyClass::config()`
- - Extensible: Provides all methods related to extensions (E.g. add_extension()). Note:
-   All classes which use this trait MUST invoke `constructExtensions()` in its constructor.
+ - Extensible: Provides all methods related to extensions (E.g. add_extension()).
+ 
+All custom method and extension instances are constructed lazily.
  
 In particular specific Object class usages should be replaced as below:
 
@@ -450,12 +451,6 @@ Upgrade subclasses
 +    use Extensible;
 +    use Injectable;
 +    use Configurable;
-+    
-+    public function __construct()
-+    {
-+        // Only needed if using Extensible trait
-+        $this->constructExtensions();
-+    }
 +}
 ```
 

--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -108,7 +108,6 @@ class Director implements TemplateGlobalProvider
 
     public function __construct()
     {
-        $this->constructExtensions();
     }
 
     /**

--- a/src/Core/Config/Middleware/ExtensionMiddleware.php
+++ b/src/Core/Config/Middleware/ExtensionMiddleware.php
@@ -8,6 +8,8 @@ use SilverStripe\Config\MergeStrategy\Priority;
 use SilverStripe\Config\Middleware\Middleware;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Extension;
+use SilverStripe\ORM\DataExtension;
 
 class ExtensionMiddleware implements Middleware
 {
@@ -61,6 +63,14 @@ class ExtensionMiddleware implements Middleware
 
             // Check class hierarchy from root up
             foreach (ClassInfo::ancestry($extensionClass) as $extensionClassParent) {
+                // Skip base classes
+                switch ($extensionClassParent) {
+                    case Extension::class:
+                    case DataExtension::class:
+                        continue 2;
+                    default:
+                        // continue
+                }
                 // Merge config from extension
                 $extensionConfig = Config::inst()->get($extensionClassParent, null, true);
                 if ($extensionConfig) {

--- a/src/Dev/BuildTask.php
+++ b/src/Dev/BuildTask.php
@@ -22,7 +22,6 @@ abstract class BuildTask
 
     public function __construct()
     {
-        $this->constructExtensions();
     }
 
     /**

--- a/src/Forms/DefaultFormFactory.php
+++ b/src/Forms/DefaultFormFactory.php
@@ -23,7 +23,6 @@ class DefaultFormFactory implements FormFactory
 
     public function __construct()
     {
-        $this->constructExtensions();
     }
 
     /**

--- a/src/Forms/FormTransformation.php
+++ b/src/Forms/FormTransformation.php
@@ -28,7 +28,6 @@ class FormTransformation
 
     public function __construct()
     {
-        $this->constructExtensions();
     }
 
     public function transform(FormField $field)

--- a/src/Forms/GridField/GridFieldConfig.php
+++ b/src/Forms/GridField/GridFieldConfig.php
@@ -38,7 +38,6 @@ class GridFieldConfig
     public function __construct()
     {
         $this->components = new ArrayList();
-        $this->constructExtensions();
     }
 
     /**

--- a/src/Forms/GridField/GridFieldDetailForm.php
+++ b/src/Forms/GridField/GridFieldDetailForm.php
@@ -84,7 +84,6 @@ class GridFieldDetailForm implements GridField_URLHandler
     public function __construct($name = 'DetailForm')
     {
         $this->name = $name;
-        $this->constructExtensions();
     }
 
     /**

--- a/src/Forms/GridField/GridFieldPrintButton.php
+++ b/src/Forms/GridField/GridFieldPrintButton.php
@@ -49,7 +49,6 @@ class GridFieldPrintButton implements GridField_HTMLProvider, GridField_ActionPr
     {
         $this->targetFragment = $targetFragment;
         $this->printColumns = $printColumns;
-        $this->constructExtensions();
     }
 
     /**

--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -21,7 +21,6 @@ abstract class Validator
     public function __construct()
     {
         $this->resetResult();
-        $this->constructExtensions();
     }
 
     /**

--- a/src/Security/DefaultAdminService.php
+++ b/src/Security/DefaultAdminService.php
@@ -37,7 +37,6 @@ class DefaultAdminService
 
     public function __construct()
     {
-        $this->constructExtensions();
     }
 
     /**

--- a/src/View/Parsers/ShortcodeParser.php
+++ b/src/View/Parsers/ShortcodeParser.php
@@ -26,7 +26,6 @@ class ShortcodeParser
 
     public function __construct()
     {
-        $this->constructExtensions();
     }
 
     public function img_shortcode($attrs)

--- a/src/View/ViewableData.php
+++ b/src/View/ViewableData.php
@@ -85,7 +85,6 @@ class ViewableData implements IteratorAggregate
 
     public function __construct()
     {
-        $this->constructExtensions();
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/src/i18n/i18n.php
+++ b/src/i18n/i18n.php
@@ -350,7 +350,10 @@ class i18n implements TemplateGlobalProvider
      */
     public static function get_locale()
     {
-        return self::$current_locale ?: i18n::config()->uninherited('default_locale');
+        if (!self::$current_locale) {
+            self::$current_locale = i18n::config()->uninherited('default_locale');
+        }
+        return self::$current_locale;
     }
 
     /**

--- a/tests/php/Core/ObjectTest.php
+++ b/tests/php/Core/ObjectTest.php
@@ -4,10 +4,8 @@ namespace SilverStripe\Core\Tests;
 
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\ClassInfo;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Extension;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Core\Manifest\ClassLoader;
 use SilverStripe\Core\Tests\ObjectTest\BaseObject;
 use SilverStripe\Core\Tests\ObjectTest\ExtendTest1;
 use SilverStripe\Core\Tests\ObjectTest\ExtendTest2;
@@ -54,7 +52,7 @@ class ObjectTest extends SapphireTest
         $objs[] = new ObjectTest\T2();
 
         // All these methods should exist and return true
-        $trueMethods = array('testMethod','otherMethod','someMethod','t1cMethod','normalMethod');
+        $trueMethods = array('testMethod','otherMethod','someMethod','t1cMethod','normalMethod', 'failoverCallback');
 
         foreach ($objs as $i => $obj) {
             foreach ($trueMethods as $method) {

--- a/tests/php/Core/ObjectTest/BaseObject.php
+++ b/tests/php/Core/ObjectTest/BaseObject.php
@@ -15,6 +15,5 @@ class BaseObject implements TestOnly
 
     public function __construct()
     {
-        $this->constructExtensions();
     }
 }

--- a/tests/php/Core/ObjectTest/T2.php
+++ b/tests/php/Core/ObjectTest/T2.php
@@ -23,6 +23,9 @@ class T2 extends BaseObject
         $this->addMethodsFrom('failover');
         $this->addMethodsFrom('failoverArr', 0);
         $this->addMethodsFrom('failoverArr', 1);
+        $this->addCallbackMethod('failoverCallback', function ($inst, $args) {
+            return true;
+        });
     }
 
     public function wrappedMethod($val)

--- a/tests/php/ORM/ArrayListTest.php
+++ b/tests/php/ORM/ArrayListTest.php
@@ -941,9 +941,9 @@ class ArrayListTest extends SapphireTest
     {
         $list = new ArrayList(
             array(
-            array('Name' => 'Steve', 'ID' => 1, 'Age' => 21),
+            $steve = array('Name' => 'Steve', 'ID' => 1, 'Age' => 21),
             array('Name' => 'Bob', 'ID' => 2, 'Age' => 18),
-            array('Name' => 'Clair', 'ID' => 2, 'Age' => 21),
+            $clair = array('Name' => 'Clair', 'ID' => 2, 'Age' => 21),
             array('Name' => 'Oscar', 'ID' => 2, 'Age' => 52),
             array('Name' => 'Mike', 'ID' => 3, 'Age' => 43)
             )
@@ -955,13 +955,9 @@ class ArrayListTest extends SapphireTest
             }
         );
 
-        $expected = array(
-            new ArrayData(array('Name' => 'Steve', 'ID' => 1, 'Age' => 21)),
-            new ArrayData(array('Name' => 'Clair', 'ID' => 2, 'Age' => 21)),
-        );
-
         $this->assertEquals(2, $list->count());
-        $this->assertEquals($expected, $list->toArray(), 'List should only contain Steve and Clair');
+        $this->assertEquals($steve, $list[0]->toMap(), 'List should only contain Steve and Clair');
+        $this->assertEquals($clair, $list[1]->toMap(), 'List should only contain Steve and Clair');
         $this->assertTrue($list instanceof Filterable, 'The List should be of type SS_Filterable');
     }
 


### PR DESCRIPTION
Based on results of config profiling at https://github.com/silverstripe/silverstripe-admin/issues/199 I've made the following improvements to cut down uncessary config API calls:

 - i18n.default_locale was invoked a huge amount of times. This change reduces overall page load by about 20ms in the CMS
 - Extension construction being done excessively caused a massive amount of performance degradation, especially with 4 times the DBField's being constructed due to default_cast changes
 - Stopped merging in config from Extension and DataExtension which provide no config worth merging in.