### PR TITLE
Remove mcrypt references

### DIFF
--- a/docs/en/00_Getting_Started/01_Installation/04_Other_installation_Options/Mac_OSX_Homebrew.md
+++ b/docs/en/00_Getting_Started/01_Installation/04_Other_installation_Options/Mac_OSX_Homebrew.md
@@ -27,9 +27,9 @@ First we're telling Homebrew about some new repositories to get the PHP installa
 	brew tap homebrew/dupes
 	brew tap homebrew/php
 
-We're installing PHP 5.6 here, with the required `mcrypt` module:
+We're installing PHP 5.6 here, with the required `intl` module:
 
-	brew install php56 php56-mcrypt php56-intl php56-apcu
+	brew install php56 php56-intl php56-apcu
 
 There's a [Homebrew Troubleshooting](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Troubleshooting.md) guide if Homebrew doesn't work out as expected (run `brew update` and `brew doctor`).
 

--- a/docs/en/00_Getting_Started/01_Installation/04_Other_installation_Options/Vagrant_Virtualbox.md
+++ b/docs/en/00_Getting_Started/01_Installation/04_Other_installation_Options/Vagrant_Virtualbox.md
@@ -119,7 +119,7 @@ yum update -y --disableplugin=fastestmirror
 systemctl restart sshd
 
 yum install -y httpd httpd-devel mod_ssl
-yum -y install php php-common php-mysql php-pdo php-mcrypt* php-gd php-xml php-mbstring
+yum -y install php php-common php-mysql php-pdo php-intl php-gd php-xml php-mbstring
 echo "Include /vagrant/apache/*.conf" >> /etc/httpd/conf/httpd.conf
 echo "date.timezone = Pacific/Auckland" >> /etc/php.ini
 systemctl start httpd.service

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -120,15 +120,6 @@ class Security extends Controller implements TemplateGlobalProvider
     private static $default_message_set;
 
     /**
-     * Random secure token, can be used as a crypto key internally.
-     * Generate one through 'sake dev/generatesecuretoken'.
-     *
-     * @config
-     * @var String
-     */
-    private static $token;
-
-    /**
      * The default login URL
      *
      * @config


### PR DESCRIPTION
Use session for alternativeDatabaseName instead
Fixes #7280

Test session doesn't even use this API anymore. Extra config option added to allow modules such as https://github.com/silverstripe/silverstripe-hybridsessions to continue to work. :)