### PR TITLE
API Make FormField::hasClass return a boolean instead of an int

### DIFF
--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -1247,17 +1247,16 @@ class FormField extends RequestHandler
     }
 
     /**
+     * Returns whether the current field has the given class added
+     *
      * @param string $class
      *
-     * @return int
+     * @return bool
      */
     public function hasClass($class)
     {
-        $patten = '/' . strtolower($class) . '/i';
-
-        $subject = strtolower(static::class . ' ' . $this->extraClass());
-
-        return preg_match($patten, $subject);
+        $classes = explode(' ', strtolower($this->extraClass()));
+        return in_array(strtolower(trim($class)), $classes);
     }
 
     /**

--- a/tests/php/Forms/FormFieldTest.php
+++ b/tests/php/Forms/FormFieldTest.php
@@ -373,4 +373,15 @@ class FormFieldTest extends SapphireTest
             $schema['message']['value']
         );
     }
+
+    public function testHasClass()
+    {
+        $field = new FormField('Test');
+        $field->addExtraClass('foo BAr cool-banana');
+
+        $this->assertTrue($field->hasClass('foo'));
+        $this->assertTrue($field->hasClass('bAr'));
+        $this->assertFalse($field->hasClass('banana'));
+        $this->assertTrue($field->hasClass('cool-BAnana'));
+    }
 }


### PR DESCRIPTION
It's always bothered me that this method returns an integer. If nobody has a concern with this change being made, this PR makes it return a boolean.