### PR TITLE
FIX Do not try and access sessions when they are not ready

### DIFF
--- a/src/ORM/DB.php
+++ b/src/ORM/DB.php
@@ -233,11 +233,17 @@ class DB
         if (Director::is_cli()) {
             return false;
         }
+        // Skip if there's no request object yet
         if (!Injector::inst()->has(HTTPRequest::class)) {
             return null;
         }
         /** @var HTTPRequest $request */
         $request = Injector::inst()->get(HTTPRequest::class);
+        // Skip if the session hasn't been started
+        if (!$request->getSession()->isStarted()) {
+            return null;
+        }
+
         $name = $request->getSession()->get(self::ALT_DB_KEY);
         if (self::valid_alternative_database_name($name)) {
             return $name;


### PR DESCRIPTION
By calling `$session->get('key_here')` an assumption is made that the session is ready. In some cases it may be available via the injector, but may not be ready yet. In this case we should skip it the same way as the existing logic does when no request is available.

I believe I've had this happen by using a `ClassInfo::hasTable()` call which subsequently checks `DB:: is_active()` called early in execution. Here's an example stack trace:

```
[Emergency] Uncaught BadMethodCallException: Session cannot be accessed until it's started
GET /admin/pages/edit/EditForm/19/field/EmailRecipients/item/3

Line 376 in /Users/robbieaverill/dev/ss40/framework/src/Control/Session.php

SilverStripe\Control\Session->get(alternativeDatabaseName) 
    DB.php:241
SilverStripe\ORM\DB::get_alternative_database_name() 
    DB.php:281
SilverStripe\ORM\DB::connect(<filtered>, <filtered>) 
    DB.php:107
SilverStripe\ORM\DB::get_conn() 
    DB.php:507
SilverStripe\ORM\DB::is_active() 
    ClassInfo.php:84
SilverStripe\Core\ClassInfo::hasTable(Fluent_Locale) 
    CachableModel.php:72
TractorCow\Fluent\Model\Locale::databaseIsReady() 
    CachableModel.php:32
TractorCow\Fluent\Model\Locale::getCached() 
    FluentDirectorExtension.php:118
TractorCow\Fluent\Extension\FluentDirectorExtension->getExplicitRoutes() 
    FluentDirectorExtension.php:69
TractorCow\Fluent\Extension\FluentDirectorExtension->updateRules(Array, , , , , , ) 
    Extensible.php:470
SilverStripe\Control\Director->extend(updateRules, Array) 
    Director.php:322
SilverStripe\Control\Director->handleRequest(SilverStripe\Control\HTTPRequest) 
    HTTPApplication.php:48
...
```