### PR TITLE
FIX: Removed unnecessary database_is_ready call.

### DIFF
--- a/src/Security/AuthenticationMiddleware.php
+++ b/src/Security/AuthenticationMiddleware.php
@@ -7,6 +7,7 @@ use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Middleware\HTTPMiddleware;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\ORM\ValidationException;
+use SilverStripe\ORM\Connect\DatabaseException;
 
 class AuthenticationMiddleware implements HTTPMiddleware
 {
@@ -44,17 +45,17 @@ class AuthenticationMiddleware implements HTTPMiddleware
      */
     public function process(HTTPRequest $request, callable $delegate)
     {
-        if (Security::database_is_ready()) {
-            try {
-                $this
-                    ->getAuthenticationHandler()
-                    ->authenticateRequest($request);
-            } catch (ValidationException $e) {
-                return new HTTPResponse(
-                    "Bad log-in details: " . $e->getMessage(),
-                    400
-                );
-            }
+        try {
+            $this
+                ->getAuthenticationHandler()
+                ->authenticateRequest($request);
+        } catch (ValidationException $e) {
+            return new HTTPResponse(
+                "Bad log-in details: " . $e->getMessage(),
+                400
+            );
+        } catch (DatabaseException $e) {
+            // Database isn't ready, carry on.
         }
 
         return $delegate($request);

--- a/src/Security/MemberAuthenticator/CookieAuthenticationHandler.php
+++ b/src/Security/MemberAuthenticator/CookieAuthenticationHandler.php
@@ -107,8 +107,7 @@ class CookieAuthenticationHandler implements AuthenticationHandler
         $uidAndToken = Cookie::get($this->getTokenCookieName());
         $deviceID = Cookie::get($this->getDeviceCookieName());
 
-        // @todo Consider better placement of database_is_ready test
-        if ($deviceID === null || strpos($uidAndToken, ':') === false || !Security::database_is_ready()) {
+        if ($deviceID === null || strpos($uidAndToken, ':') === false) {
             return null;
         }
 


### PR DESCRIPTION
This shaves about 45ms from every request (PHP 7.1 on a 2013 rMBP), 
cutting down execution time of a “hello world” controller by about 33%.

database_is_ready is still used in dev/build and ?flush=1 to stop people
from people bypassing security by DOSing the database or otherwise
forcing a DatabaseException