### PR TITLE
Bump deprecation to 4.0 in preparation for rc and stable tags

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -15,5 +15,5 @@ use SilverStripe\View\Parsers\ShortcodeParser;
 ShortcodeParser::get('default')
     ->register('embed', [EmbedShortcodeProvider::class, 'handle_shortcode']);
 
-// If you don't want to see deprecation errors for the new APIs, change this to 3.2.0-dev.
-Deprecation::notification_version('3.2.0');
+// Set to 5.0.0 to show APIs marked for removal at that version
+Deprecation::notification_version('4.0.0');


### PR DESCRIPTION
The effect of this change is that all `Deprecation::notice('4.0')` calls will now display as actual deprecation notices. This is best done before RC in order to capture any un-upgraded APIs marked for removal at 4.0.