### PR TITLE
Fix incorrect $has_one documentation

### DIFF
--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -861,10 +861,11 @@ In cases where image-only assets may be assigned to relationships then your data
 an `Image` datatype, or refer to `DBFile('image/supported')`.
 
 ```php
+use SilverStripe\Assets\Image;
 class MyObject extends SilverStripe\ORM\DataObject
 {
     private static $has_one = [
-        "ImageObject" => "Image"
+        "ImageObject" => Image::class
     ];
     private static $db = [
         "ImageField" => "DBFile('image/supported')"


### PR DESCRIPTION
The first mention of `$has_one` and `$db` in this file is incorrect, which is misleading. It's explained properly later on in the document, but it's easy to get it wrong based on this first code snippet.