### PR TITLE
Remove redundant gc_collect_cycles()

### DIFF
--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -2035,6 +2035,7 @@ The below methods have been added or had their functionality updated to `DBDate`
 * `DataObject::has_own_table` renamed and moved to `DataObjectSchema::classHasTable`
 * `DataObject::composite_fields` renamed and moved to `DataObjectSchema::compositeFields``
 * `DataObject::manyManyExtraFieldsForComponent` moved to `DataObjectSchema`
+* `DataObject::$destroyed` is now deprecated
 * Removed `DataObject::validateModelDefinitions`. Relations are now validated within `DataObjectSchema`
 * Removed `DataObject` methods `hasOwnTableDatabaseField`, `has_own_table_database_field` and
   `hasDatabaseFields` are superceded by `DataObjectSchema::fieldSpec`.

--- a/src/Core/CustomMethods.php
+++ b/src/Core/CustomMethods.php
@@ -61,9 +61,11 @@ trait CustomMethods
                 return $config['callback']($this, $arguments);
             }
             case isset($config['property']) : {
-                $obj = $config['index'] !== null ?
-                    $this->{$config['property']}[$config['index']] :
-                    $this->{$config['property']};
+                $property = $config['property'];
+                $index = $config['index'];
+                $obj = $index !== null ?
+                    $this->{$property}[$index] :
+                    $this->{$property};
 
                 if ($obj) {
                     if (!empty($config['callSetOwnerFirst'])) {
@@ -78,16 +80,10 @@ trait CustomMethods
                     return $retVal;
                 }
 
-                if (!empty($this->destroyed)) {
-                    throw new BadMethodCallException(
-                        "Object->__call(): attempt to call $method on a destroyed $class object"
-                    );
-                } else {
-                    throw new BadMethodCallException(
-                        "Object->__call(): $class cannot pass control to $config[property]($config[index])."
-                        . ' Perhaps this object was mistakenly destroyed?'
-                    );
-                }
+                throw new BadMethodCallException(
+                    "Object->__call(): {$class} cannot pass control to {$property}({$index})."
+                    . ' Perhaps this object was mistakenly destroyed?'
+                );
             }
             case isset($config['wrap']): {
                 array_unshift($arguments, $config['method']);

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -137,8 +137,8 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     private static $default_classname = null;
 
     /**
-     * True if this DataObject has been destroyed.
-     * @var boolean
+     * @deprecated 4.0..5.0
+     * @var bool
      */
     public $destroyed = false;
 
@@ -386,8 +386,6 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      */
     public function destroy()
     {
-        //$this->destroyed = true;
-        gc_collect_cycles();
         $this->flushCache(false);
     }
 
@@ -2868,12 +2866,6 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         $cacheComponents = array($filter, $orderby, $SNG->extend('cacheKeyComponent'));
         $cacheKey = md5(var_export($cacheComponents, true));
 
-        // Flush destroyed items out of the cache
-        if ($cache && isset(self::$_cache_get_one[$callerClass][$cacheKey])
-                && self::$_cache_get_one[$callerClass][$cacheKey] instanceof DataObject
-                && self::$_cache_get_one[$callerClass][$cacheKey]->destroyed) {
-            self::$_cache_get_one[$callerClass][$cacheKey] = false;
-        }
         $item = null;
         if (!$cache || !isset(self::$_cache_get_one[$callerClass][$cacheKey])) {
             $dl = DataObject::get($callerClass)->where($filter)->sort($orderby);


### PR DESCRIPTION
Cleanup dead references to DataObject::$destroyed
Fixes #7326

It looks as though https://github.com/silverstripe/silverstripe-framework/commit/f65a7c6b212caee8ad0b4036324962592266f87c removed the update of `destroyed` but not the references.