### PR TITLE
BUG Fix typing of DB types for supported drivers

### DIFF
--- a/src/ORM/Connect/MySQLiConnector.php
+++ b/src/ORM/Connect/MySQLiConnector.php
@@ -73,10 +73,15 @@ class MySQLiConnector extends DBConnector
         $selectedDB = ($selectDB && !empty($parameters['database'])) ? $parameters['database'] : null;
 
         // Connection charset and collation
-        $connCharset = Config::inst()->get('SilverStripe\ORM\Connect\MySQLDatabase', 'connection_charset');
-        $connCollation = Config::inst()->get('SilverStripe\ORM\Connect\MySQLDatabase', 'connection_collation');
+        $connCharset = $this->config()->get('connection_charset');
+        $connCollation = $this->config()->get('connection_collation');
 
         $this->dbConn = mysqli_init();
+
+        // Use native types (MysqlND only)
+        if (defined('MYSQLI_OPT_INT_AND_FLOAT_NATIVE')) {
+            $this->dbConn->options(MYSQLI_OPT_INT_AND_FLOAT_NATIVE, true);
+        }
 
         // Set SSL parameters if they exist. All parameters are required.
         if (array_key_exists('ssl_key', $parameters) &&


### PR DESCRIPTION
Fixes #7039

Unfortunately, only the MysqlND driver supports native type returns (both PDO / mysqli version), but this change will support those options if available.

I've found that with mysqlnd, it's necessary to set ATTR_EMULATE_PREPARES to false explicitly; It's not enough to simply not set it. Given that there are situations where we need to avoid setting this, I've allowed this to be set to `null` to bypass assignment from the default `false`.