### PR TITLE
MINOR Add default value to ArrayData constructor

### DIFF
--- a/src/View/ArrayData.php
+++ b/src/View/ArrayData.php
@@ -29,7 +29,7 @@ class ArrayData extends ViewableData
      * @param object|array $value An associative array, or an object with simple properties.
      * Converts object properties to keys of an associative array.
      */
-    public function __construct($value)
+    public function __construct($value = [])
     {
         if (is_object($value)) {
             $this->array = get_object_vars($value);


### PR DESCRIPTION
This is a small change, but allows users to create empty ArrayData instances without having to provide an empty array to the constructor:

```diff
-            return ArrayData::create([]);
+            return ArrayData::create();
```