### PR TITLE
Feature: Convert::raw2filename

### DIFF
--- a/src/Core/Convert.php
+++ b/src/Core/Convert.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Core;
 
+use SilverStripe\Assets\FileNameFilter;
 use SilverStripe\ORM\DB;
 use SilverStripe\View\Parsers\URLSegmentFilter;
 use InvalidArgumentException;
@@ -466,6 +467,21 @@ class Convert
         $f = URLSegmentFilter::create();
         return $f->filter($title);
     }
+
+    /**
+     * Convert a string (normally a title) to a string suitable for using
+     * as a filename. Uses {@link FileNameFilter}.
+     *
+     * @param string
+     * @return string
+     */
+    public static function raw2filename($title)
+    {
+        $f = FileNameFilter::create();
+        return $f->filter($title);
+    }
+
+
 
     /**
      * Normalises newline sequences to conform to (an) OS specific format.

--- a/tests/php/Core/ConvertTest.php
+++ b/tests/php/Core/ConvertTest.php
@@ -276,6 +276,25 @@ PHP
         $this->assertEquals('foos-bar-2', Convert::raw2url('foo\'s [bar] (2)'));
     }
 
+    public function filenameProvider()
+    {
+        return [
+            ['localhost:8080', 'localhost8080'], //remove : froma  filename
+            ['foo.bar', 'foo.bar'], //nothing, is fine
+            ['/this\-is-a-test', 'this-is-a-test'], //remove trailing slash and backslash inside
+            ['no whitespace', 'no-whitespace'],
+            ['österreich.jpg', 'oesterreich.jpg'], //convert umlaut
+        ];
+    }
+
+    /**
+     * @dataProvider filenameProvider
+     */
+    public function testRaw2Filename($orig, $expected)
+    {
+        $this->assertEquals($expected, Convert::raw2filename($orig));
+    }
+
     /**
      * Helper function for comparing characters with significant whitespaces
   *


### PR DESCRIPTION
This might be a handy shortcut for sanitising a filename.

See https://github.com/silverstripe/silverstripe-errorpage/issues/8
See https://github.com/silverstripe/silverstripe-subsites/issues/299