### PR TITLE
Move to travis trusty dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
   apt:
     packages:
       - tidy
+  firefox: "31.0"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
-dist: precise
-
-sudo: false
+dist: trusty
 
 cache:
   directories:


### PR DESCRIPTION
DONTMERGE This is an attempt to replicate what lead to the discussion in https://github.com/silverstripe/silverstripe-framework/pull/7092. My theory is that we can just stay on Selenium 2 and all the downstream deps (php-webdriver, Mink, behat-extension), and just need to pin the Firefox dependency to an older version (like cms already does).

It sure would be nice to upgrade to all the latest tools, but at the moment it's about keeping tests passing for 3.x and 4.x.