### PR TITLE
FIX HTTP Headers are case insensitive

### DIFF
--- a/src/Control/HTTPRequest.php
+++ b/src/Control/HTTPRequest.php
@@ -349,12 +349,14 @@ class HTTPRequest implements ArrayAccess
     /**
      * Add a HTTP header to the response, replacing any header of the same name.
      *
-     * @param string $header Example: "Content-Type"
+     * @param string $header Example: "content-type"
      * @param string $value Example: "text/xml"
      */
     public function addHeader($header, $value)
     {
+        $header = strtolower($header);
         $this->headers[$header] = $value;
+        return $this;
     }
 
     /**
@@ -373,6 +375,7 @@ class HTTPRequest implements ArrayAccess
      */
     public function getHeader($header)
     {
+        $header = strtolower($header);
         return (isset($this->headers[$header])) ? $this->headers[$header] : null;
     }
 
@@ -385,9 +388,8 @@ class HTTPRequest implements ArrayAccess
      */
     public function removeHeader($header)
     {
-        if (isset($this->headers[$header])) {
-            unset($this->headers[$header]);
-        }
+        $header = strtolower($header);
+        unset($this->headers[$header]);
         return $this;
     }
 
@@ -428,7 +430,7 @@ class HTTPRequest implements ArrayAccess
     {
         return (
             $this->requestVar('ajax') ||
-            $this->getHeader('X-Requested-With') === "XMLHttpRequest"
+            $this->getHeader('x-requested-with') === "XMLHttpRequest"
         );
     }
 
@@ -483,10 +485,10 @@ class HTTPRequest implements ArrayAccess
             $mimeType = HTTP::get_mime_type($fileName);
         }
         $response = new HTTPResponse($fileData);
-        $response->addHeader("Content-Type", "$mimeType; name=\"" . addslashes($fileName) . "\"");
+        $response->addHeader("content-type", "$mimeType; name=\"" . addslashes($fileName) . "\"");
         // Note a IE-only fix that inspects this header in HTTP::add_cache_headers().
-        $response->addHeader("Content-Disposition", "attachment; filename=\"" . addslashes($fileName) . "\"");
-        $response->addHeader("Content-Length", strlen($fileData));
+        $response->addHeader("content-disposition", "attachment; filename=\"" . addslashes($fileName) . "\"");
+        $response->addHeader("content-length", strlen($fileData));
 
         return $response;
     }
@@ -809,7 +811,7 @@ class HTTPRequest implements ArrayAccess
     public function getAcceptMimetypes($includeQuality = false)
     {
         $mimetypes = array();
-        $mimetypesWithQuality = preg_split('#\s*,\s*#', $this->getHeader('Accept'));
+        $mimetypesWithQuality = preg_split('#\s*,\s*#', $this->getHeader('accept'));
         foreach ($mimetypesWithQuality as $mimetypeWithQuality) {
             $mimetypes[] = ($includeQuality) ? $mimetypeWithQuality : preg_replace('/;.*/', '', $mimetypeWithQuality);
         }

--- a/src/Control/HTTPResponse.php
+++ b/src/Control/HTTPResponse.php
@@ -85,13 +85,13 @@ class HTTPResponse
     protected $statusDescription = "OK";
 
     /**
-     * HTTP Headers like "Content-Type: text/xml"
+     * HTTP Headers like "content-type: text/xml"
      *
      * @see http://en.wikipedia.org/wiki/List_of_HTTP_headers
      * @var array
      */
     protected $headers = array(
-        "Content-Type" => "text/html; charset=utf-8",
+        "content-type" => "text/html; charset=utf-8",
     );
 
     /**
@@ -200,12 +200,13 @@ class HTTPResponse
     /**
      * Add a HTTP header to the response, replacing any header of the same name.
      *
-     * @param string $header Example: "Content-Type"
+     * @param string $header Example: "content-type"
      * @param string $value Example: "text/xml"
      * @return $this
      */
     public function addHeader($header, $value)
     {
+        $header = strtolower($header);
         $this->headers[$header] = $value;
         return $this;
     }
@@ -218,6 +219,7 @@ class HTTPResponse
      */
     public function getHeader($header)
     {
+        $header = strtolower($header);
         if (isset($this->headers[$header])) {
             return $this->headers[$header];
         }
@@ -241,6 +243,7 @@ class HTTPResponse
      */
     public function removeHeader($header)
     {
+        strtolower($header);
         unset($this->headers[$header]);
         return $this;
     }
@@ -257,7 +260,7 @@ class HTTPResponse
             $code = 302;
         }
         $this->setStatusCode($code);
-        $this->addHeader('Location', $dest);
+        $this->addHeader('location', $dest);
         return $this;
     }
 
@@ -285,7 +288,7 @@ class HTTPResponse
     protected function htmlRedirect()
     {
         $headersSent = headers_sent($file, $line);
-        $location = $this->getHeader('Location');
+        $location = $this->getHeader('location');
         $url = Director::absoluteURL($location);
         $urlATT = Convert::raw2htmlatt($url);
         $urlJS = Convert::raw2js($url);


### PR DESCRIPTION
HTTP Headers are case insensitive but the framework treats them as case sensitive which means setting headers can be risky as "content-type" is treated as a distinct header from "Content-Type", which is wrong.