### PR TITLE
ENHANCEMENT Don't force all class names to lowercase

### DIFF
--- a/src/Control/ContentNegotiator.php
+++ b/src/Control/ContentNegotiator.php
@@ -116,7 +116,7 @@ class ContentNegotiator
                 $chosenFormat = "xhtml";
             } else {
                 foreach ($mimes as $format => $mime) {
-                    $regExp = '/' . str_replace(array('+','/'), array('\+','\/'), $mime) . '(;q=(\d+\.\d+))?/i';
+                    $regExp = '/' . str_replace(array('+', '/'), array('\+', '\/'), $mime) . '(;q=(\d+\.\d+))?/i';
                     if (isset($_SERVER['HTTP_ACCEPT']) && preg_match($regExp, $_SERVER['HTTP_ACCEPT'], $matches)) {
                         $preference = isset($matches[2]) ? $matches[2] : 1;
                         if (!isset($q[$preference])) {
@@ -130,13 +130,13 @@ class ContentNegotiator
                     krsort($q);
                     $chosenFormat = reset($q);
                 } else {
-                    $chosenFormat = Config::inst()->get('SilverStripe\\Control\\ContentNegotiator', 'default_format');
+                    $chosenFormat = Config::inst()->get(static::class, 'default_format');
                 }
             }
         }
 
         $negotiator = new ContentNegotiator();
-        $negotiator->$chosenFormat( $response );
+        $negotiator->$chosenFormat($response);
     }
 
     /**
@@ -202,7 +202,7 @@ class ContentNegotiator
         $response->addHeader("Vary", "Accept");
 
         $content = $response->getBody();
-        $hasXMLHeader = (substr($content, 0, 5) == '<' . '?xml' );
+        $hasXMLHeader = (substr($content, 0, 5) == '<' . '?xml');
 
         // Fix base tag
         $content = preg_replace(
@@ -212,7 +212,11 @@ class ContentNegotiator
         );
 
         $content = preg_replace("#<\\?xml[^>]+\\?>\n?#", '', $content);
-        $content = str_replace(array('/>','xml:lang','application/xhtml+xml'), array('>','lang','text/html'), $content);
+        $content = str_replace(
+            array('/>', 'xml:lang', 'application/xhtml+xml'),
+            array('>', 'lang', 'text/html'),
+            $content
+        );
 
         // Only replace the doctype in templates with the xml header
         if ($hasXMLHeader) {

--- a/src/Core/Config/CoreConfigFactory.php
+++ b/src/Core/Config/CoreConfigFactory.php
@@ -112,8 +112,9 @@ class CoreConfigFactory
     public function buildStaticTransformer()
     {
         return new PrivateStaticTransformer(function () {
-            $classes = ClassLoader::inst()->getManifest()->getClasses();
-            return array_keys($classes);
+            return ClassLoader::inst()
+                ->getManifest()
+                ->getClassNames();
         });
     }
 

--- a/src/Core/Config/Middleware/InheritanceMiddleware.php
+++ b/src/Core/Config/Middleware/InheritanceMiddleware.php
@@ -31,6 +31,7 @@ class InheritanceMiddleware implements Middleware
             $nextConfig = $next($nextClass, $excludeMiddleware);
             $config = Priority::mergeArray($nextConfig, $config);
         }
+
         return $config;
     }
 }

--- a/src/Core/Manifest/ModuleManifest.php
+++ b/src/Core/Manifest/ModuleManifest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Core\Manifest;
 use LogicException;
 use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Cache\CacheFactory;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injector;
 
@@ -49,6 +50,22 @@ class ModuleManifest
      * @var Module[]
      */
     protected $modules = [];
+
+    /**
+     * List of modules sorted by priority
+     *
+     * @config
+     * @var array
+     */
+    private static $module_priority = [];
+
+    /**
+     * Project name
+     *
+     * @config
+     * @var string
+     */
+    private static $project = null;
 
     /**
      * Adds a path as a module
@@ -244,6 +261,7 @@ class ModuleManifest
     {
         $order = static::config()->uninherited('module_priority');
         $project = static::config()->get('project');
+
         /* @var PrioritySorter $sorter */
         $sorter = Injector::inst()->createWithArgs(
             PrioritySorter::class . '.modulesorter',

--- a/src/Dev/TaskRunner.php
+++ b/src/Dev/TaskRunner.php
@@ -116,7 +116,7 @@ class TaskRunner extends Controller
     {
         $availableTasks = array();
 
-        $taskClasses = ClassInfo::subclassesFor('SilverStripe\\Dev\\BuildTask');
+        $taskClasses = ClassInfo::subclassesFor(BuildTask::class);
         // remove the base class
         array_shift($taskClasses);
 

--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -167,7 +167,7 @@ class DatabaseAdmin extends Controller
      */
     public function buildDefaults()
     {
-        $dataClasses = ClassInfo::subclassesFor('SilverStripe\ORM\DataObject');
+        $dataClasses = ClassInfo::subclassesFor(DataObject::class);
         array_shift($dataClasses);
 
         if (!Director::is_cli()) {
@@ -260,7 +260,7 @@ class DatabaseAdmin extends Controller
         }
 
         // Build the database.  Most of the hard work is handled by DataObject
-        $dataClasses = ClassInfo::subclassesFor('SilverStripe\ORM\DataObject');
+        $dataClasses = ClassInfo::subclassesFor(DataObject::class);
         array_shift($dataClasses);
 
         if (!$quiet) {

--- a/src/ORM/FieldType/DBClassName.php
+++ b/src/ORM/FieldType/DBClassName.php
@@ -129,8 +129,9 @@ class DBClassName extends DBEnum
     public function getEnum()
     {
         $classNames = ClassInfo::subclassesFor($this->getBaseClass());
-        unset($classNames[DataObject::class]);
-        return $classNames;
+        $dataobject = strtolower(DataObject::class);
+        unset($classNames[$dataobject]);
+        return array_values($classNames);
     }
 
     /**

--- a/src/ORM/PolymorphicHasManyList.php
+++ b/src/ORM/PolymorphicHasManyList.php
@@ -37,9 +37,8 @@ class PolymorphicHasManyList extends HasManyList
      * to generate the ID and Class foreign keys.
      * @param string $foreignClass Name of the class filter this relation is filtered against
      */
-    function __construct($dataClass, $foreignField, $foreignClass)
+    public function __construct($dataClass, $foreignField, $foreignClass)
     {
-
         // Set both id foreign key (as in HasManyList) and the class foreign key
         parent::__construct($dataClass, "{$foreignField}ID");
         $this->classForeignKey = "{$foreignField}Class";
@@ -120,7 +119,8 @@ class PolymorphicHasManyList extends HasManyList
         $foreignClass = $this->getForeignClass();
         $classNames = ClassInfo::subclassesFor($foreignClass);
         $classForeignKey = $this->classForeignKey;
-        if (!in_array($item->$classForeignKey, $classNames)) {
+        $classValueLower = strtolower($item->$classForeignKey);
+        if (!array_key_exists($classValueLower, $classNames)) {
             return;
         }
 

--- a/tests/php/Core/Manifest/ClassManifestTest.php
+++ b/tests/php/Core/Manifest/ClassManifestTest.php
@@ -71,7 +71,13 @@ class ClassManifestTest extends SapphireTest
     public function testGetClassNames()
     {
         $this->assertEquals(
-            ['classa', 'classb', 'classc', 'classd', 'classe'],
+            [
+                'classa' => 'ClassA',
+                'classb' => 'ClassB',
+                'classc' => 'ClassC',
+                'classd' => 'ClassD',
+                'classe' => 'ClassE',
+            ],
             $this->manifest->getClassNames()
         );
     }
@@ -79,28 +85,36 @@ class ClassManifestTest extends SapphireTest
     public function testGetTraitNames()
     {
         $this->assertEquals(
-            array('testtraita', 'testnamespace\testing\testtraitb'),
+            array(
+                'testtraita' => 'TestTraitA',
+                'testnamespace\testing\testtraitb' => 'TestNamespace\Testing\TestTraitB',
+            ),
             $this->manifest->getTraitNames()
         );
     }
 
     public function testGetDescendants()
     {
-        $expect = array(
-            'classa' => array('ClassC', 'ClassD'),
-            'classc' => array('ClassD')
-        );
+        $expect = [
+            'classa' => [
+                'classc' => 'ClassC',
+                'classd' => 'ClassD',
+            ],
+            'classc' => [
+                'classd' => 'ClassD',
+            ],
+        ];
         $this->assertEquals($expect, $this->manifest->getDescendants());
     }
 
     public function testGetDescendantsOf()
     {
-        $expect = array(
-            'CLASSA' => array('ClassC', 'ClassD'),
-            'classa' => array('ClassC', 'ClassD'),
-            'CLASSC' => array('ClassD'),
-            'classc' => array('ClassD')
-        );
+        $expect = [
+            'CLASSA' => ['classc' => 'ClassC', 'classd' => 'ClassD'],
+            'classa' => ['classc' => 'ClassC', 'classd' => 'ClassD'],
+            'CLASSC' => ['classd' => 'ClassD'],
+            'classc' => ['classd' => 'ClassD'],
+        ];
 
         foreach ($expect as $class => $desc) {
             $this->assertEquals($desc, $this->manifest->getDescendantsOf($class));
@@ -118,21 +132,21 @@ class ClassManifestTest extends SapphireTest
 
     public function testGetImplementors()
     {
-        $expect = array(
-            'interfacea' => array('ClassB'),
-            'interfaceb' => array('ClassC')
-        );
+        $expect = [
+            'interfacea' => ['classb' => 'ClassB'],
+            'interfaceb' => ['classc' => 'ClassC'],
+        ];
         $this->assertEquals($expect, $this->manifest->getImplementors());
     }
 
     public function testGetImplementorsOf()
     {
-        $expect = array(
-            'INTERFACEA' => array('ClassB'),
-            'interfacea' => array('ClassB'),
-            'INTERFACEB' => array('ClassC'),
-            'interfaceb' => array('ClassC')
-        );
+        $expect = [
+            'INTERFACEA' => ['classb' => 'ClassB'],
+            'interfacea' => ['classb' => 'ClassB'],
+            'INTERFACEB' => ['classc' => 'ClassC'],
+            'interfaceb' => ['classc' => 'ClassC'],
+        ];
 
         foreach ($expect as $interface => $impl) {
             $this->assertEquals($impl, $this->manifest->getImplementorsOf($interface));
@@ -141,13 +155,13 @@ class ClassManifestTest extends SapphireTest
 
     public function testTestManifestIncludesTestClasses()
     {
-        $this->assertNotContains('testclassa', array_keys($this->manifest->getClasses()));
-        $this->assertContains('testclassa', array_keys($this->manifestTests->getClasses()));
+        $this->assertArrayNotHasKey('testclassa', $this->manifest->getClasses());
+        $this->assertArrayHasKey('testclassa', $this->manifestTests->getClasses());
     }
 
     public function testManifestExcludeFilesPrefixedWithUnderscore()
     {
-        $this->assertNotContains('ignore', array_keys($this->manifest->getClasses()));
+        $this->assertArrayNotHasKey('ignore', $this->manifest->getClasses());
     }
 
     /**

--- a/tests/php/ORM/DBClassNameTest.php
+++ b/tests/php/ORM/DBClassNameTest.php
@@ -28,21 +28,27 @@ class DBClassNameTest extends SapphireTest
     {
         // Object 1 fields
         $object = new DBClassNameTest\TestObject();
+        /** @var DBClassName $defaultClass */
         $defaultClass = $object->dbObject('DefaultClass');
+        /** @var DBClassName $anyClass */
         $anyClass = $object->dbObject('AnyClass');
+        /** @var DBClassName $childClass */
         $childClass = $object->dbObject('ChildClass');
+        /** @var DBClassName $leafClass */
         $leafClass = $object->dbObject('LeafClass');
 
         // Object 2 fields
         $object2 = new DBClassNameTest\ObjectSubClass();
+        /** @var DBClassName $midDefault */
         $midDefault = $object2->dbObject('MidClassDefault');
+        /** @var DBClassName $midClass */
         $midClass = $object2->dbObject('MidClass');
 
         // Default fields always default to children of base class (even if put in a subclass)
         $mainSubclasses = array (
-            DBClassNameTest\TestObject::class => DBClassNameTest\TestObject::class,
-            DBClassNameTest\ObjectSubClass::class => DBClassNameTest\ObjectSubClass::class,
-            DBClassNameTest\ObjectSubSubClass::class => DBClassNameTest\ObjectSubSubClass::class,
+            DBClassNameTest\TestObject::class,
+            DBClassNameTest\ObjectSubClass::class,
+            DBClassNameTest\ObjectSubSubClass::class,
         );
         $this->assertEquals($mainSubclasses, $defaultClass->getEnumObsolete());
         $this->assertEquals($mainSubclasses, $midDefault->getEnumObsolete());
@@ -56,15 +62,15 @@ class DBClassNameTest extends SapphireTest
 
         // Classes bound to the middle of a tree
         $midSubClasses = $mainSubclasses = array (
-            DBClassNameTest\ObjectSubClass::class => DBClassNameTest\ObjectSubClass::class,
-            DBClassNameTest\ObjectSubSubClass::class => DBClassNameTest\ObjectSubSubClass::class,
+            DBClassNameTest\ObjectSubClass::class,
+            DBClassNameTest\ObjectSubSubClass::class,
         );
         $this->assertEquals($midSubClasses, $childClass->getEnumObsolete());
         $this->assertEquals($midSubClasses, $midClass->getEnumObsolete());
 
         // Leaf clasess contain only exactly one node
         $this->assertEquals(
-            array(DBClassNameTest\ObjectSubSubClass::class => DBClassNameTest\ObjectSubSubClass::class,),
+            [ DBClassNameTest\ObjectSubSubClass::class ],
             $leafClass->getEnumObsolete()
         );
     }

--- a/tests/php/ORM/DataExtensionTest.php
+++ b/tests/php/ORM/DataExtensionTest.php
@@ -2,13 +2,9 @@
 
 namespace SilverStripe\ORM\Tests;
 
-use SilverStripe\Assets\Tests\FileMigrationHelperTest\Extension;
-use SilverStripe\Core\Config\Middleware\ExtensionMiddleware;
-use SilverStripe\Dev\Debug;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\ORM\DB;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
 
 class DataExtensionTest extends SapphireTest
@@ -207,9 +203,7 @@ class DataExtensionTest extends SapphireTest
 
     public function testExtensionAllMethodNamesHasOwner()
     {
-        /**
- * @var DataExtensionTest\MyObject $do
-*/
+        /** @var DataExtensionTest\MyObject $do */
         $do = DataExtensionTest\MyObject::create();
 
         $this->assertTrue($do->hasMethod('getTestValueWith_MyObject'));

--- a/tests/php/ORM/DataObjectSchemaGenerationTest.php
+++ b/tests/php/ORM/DataObjectSchemaGenerationTest.php
@@ -12,7 +12,6 @@ use SilverStripe\ORM\Tests\DataObjectSchemaGenerationTest\TestObject;
 
 class DataObjectSchemaGenerationTest extends SapphireTest
 {
-
     protected static $extra_dataobjects = array(
         TestObject::class,
         TestIndexObject::class
@@ -20,6 +19,8 @@ class DataObjectSchemaGenerationTest extends SapphireTest
 
     public static function setUpBeforeClass()
     {
+        // Start tests
+        static::start();
 
         // enable fulltext option on this table
         TestIndexObject::config()->update(
@@ -197,6 +198,7 @@ class DataObjectSchemaGenerationTest extends SapphireTest
     /**
      * Tests the generation of the ClassName spec and ensure it's not unnecessarily influenced
      * by the order of classnames of existing records
+     * @skipUpgrade
      */
     public function testClassNameSpecGeneration()
     {
@@ -206,15 +208,12 @@ class DataObjectSchemaGenerationTest extends SapphireTest
         DBClassName::clear_classname_cache();
         $do1 = new TestObject();
         $fields = $schema->databaseFields(TestObject::class, false);
-        /**
- * @skipUpgrade
-*/
         $this->assertEquals("DBClassName", $fields['ClassName']);
         $this->assertEquals(
-            array(
-                TestObject::class => TestObject::class,
-                TestIndexObject::class => TestIndexObject::class
-            ),
+            [
+                TestObject::class,
+                TestIndexObject::class,
+            ],
             $do1->dbObject('ClassName')->getEnum()
         );
 
@@ -224,10 +223,10 @@ class DataObjectSchemaGenerationTest extends SapphireTest
         $item1->write();
         DBClassName::clear_classname_cache();
         $this->assertEquals(
-            array(
-                TestObject::class => TestObject::class,
-                TestIndexObject::class => TestIndexObject::class
-            ),
+            [
+                TestObject::class,
+                TestIndexObject::class,
+            ],
             $item1->dbObject('ClassName')->getEnum()
         );
         $item1->delete();
@@ -237,10 +236,10 @@ class DataObjectSchemaGenerationTest extends SapphireTest
         $item2->write();
         DBClassName::clear_classname_cache();
         $this->assertEquals(
-            array(
-                TestObject::class => TestObject::class,
-                TestIndexObject::class => TestIndexObject::class
-            ),
+            [
+                TestObject::class,
+                TestIndexObject::class,
+            ],
             $item2->dbObject('ClassName')->getEnum()
         );
         $item2->delete();
@@ -252,10 +251,10 @@ class DataObjectSchemaGenerationTest extends SapphireTest
         $item2->write();
         DBClassName::clear_classname_cache();
         $this->assertEquals(
-            array(
-                TestObject::class => TestObject::class,
-                TestIndexObject::class => TestIndexObject::class
-            ),
+            [
+                TestObject::class,
+                TestIndexObject::class,
+            ],
             $item1->dbObject('ClassName')->getEnum()
         );
         $item1->delete();


### PR DESCRIPTION
Speeds up autoloading because composer psr-4 works properly now. (~40ms on assets section load).

Requires https://github.com/silverstripe/silverstripe-config/pull/21

Fixes: https://github.com/silverstripe/silverstripe-framework/issues/7385

Parent story: https://github.com/silverstripe/silverstripe-admin/issues/199

CMS tests fixed with https://github.com/silverstripe/silverstripe-cms/pull/1973

Before:

![image](https://user-images.githubusercontent.com/936064/30578095-3cd01834-9d66-11e7-867d-9c3ade0a0603.png)

![image](https://user-images.githubusercontent.com/936064/30578083-29e469a0-9d66-11e7-8690-81c5efe1d080.png)

After:

![image](https://user-images.githubusercontent.com/936064/30578109-45addf86-9d66-11e7-9815-5aaa2467e632.png)


![image](https://user-images.githubusercontent.com/936064/30578089-3310e896-9d66-11e7-9a0a-a52c7253fb82.png)
