### PR TITLE
Added unit tests for updating Config values on extensions

### DIFF
--- a/tests/php/Core/Config/ConfigTest/BaseObject.php
+++ b/tests/php/Core/Config/ConfigTest/BaseObject.php
@@ -3,9 +3,15 @@
 namespace SilverStripe\Core\Tests\Config\ConfigTest;
 
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Tests\Config\ConfigTest\ConfigExtension;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\Core\Extensible;
 
 class BaseObject implements TestOnly
 {
     use Configurable;
+
+    private static $extensions = [
+        ConfigExtension::class
+    ];
 }

--- a/tests/php/Core/Config/ConfigTest/ConfigExtension.php
+++ b/tests/php/Core/Config/ConfigTest/ConfigExtension.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Config\ConfigTest;
+
+use SilverStripe\Core\Extension;
+
+class ConfigExtension extends Extension
+{
+    private static $config_array = [
+        'foo' => 'foo'
+    ];
+
+    private static $config_value = true;
+}

--- a/tests/php/Core/Config/ConfigTest/First.php
+++ b/tests/php/Core/Config/ConfigTest/First.php
@@ -50,4 +50,9 @@ class First extends Config implements TestOnly
      */
     private static $default_zero = 0;
     public static $default_emtpy_string = '';
+
+    private static $default_array = [
+        'default_true' => true,
+        'default_false' => false
+    ];
 }


### PR DESCRIPTION
Demonstrates an issue with extension values not being able to be overridden.

This is blocking the 4.0 upgrade for comments as values on the comments extension are unable to be updated via the Config API.