### PR TITLE
Reduce dependence on session state for accessing draft stages

### DIFF
--- a/docs/en/02_Developer_Guides/02_Controllers/01_Introduction.md
+++ b/docs/en/02_Developer_Guides/02_Controllers/01_Introduction.md
@@ -159,20 +159,23 @@ For more information about templates, inheritance and how to render into views, 
 
 ## Link
 
-Each controller should define a `Link()` method. This should be used to avoid hard coding your routing in views etc.
+Each controller should define a `Link()` method. This should be used to avoid hard coding your routing in views,
+as well as give other features in SilverStripe the ability to influence link behaviour.
 
 **mysite/code/controllers/TeamController.php**
 
 ```php
 public function Link($action = null) 
 {
-    return Controller::join_links('teams', $action);
+    // Construct link with graceful handling of GET parameters
+    $link = Controller::join_links('teams', $ction);
+    
+    // Allow Versioned and other extension to update $link by reference.
+    $this->extend('updateLink', $link, $action);
+    
+    return $link;
 }
-```
-
-<div class="info" markdown="1">
-The [Controller::join_links()](api:SilverStripe\Control\Controller::join_links()) is optional, but makes `Link()` more flexible by allowing an `$action` argument, and concatenates the path segments with slashes. The action should map to a method on your controller.
-</div>
+``` 
 
 ## Related Lessons
 * [Controller actions/DataObjects as pages](https://www.silverstripe.org/learn/lessons/v4/controller-actions-dataobjects-as-pages-1)

--- a/docs/en/04_Changelogs/4.2.0.md
+++ b/docs/en/04_Changelogs/4.2.0.md
@@ -35,3 +35,6 @@ Alternatively, you can opt-out of this security feature via YAML configuration:
 SilverStripe\Versioned\Versioned:
   use_session: true
 ```
+
+Check our [versioning docs](/developer_guides/model/versioning#controllers)
+for more details.

--- a/docs/en/04_Changelogs/4.2.0.md
+++ b/docs/en/04_Changelogs/4.2.0.md
@@ -3,6 +3,7 @@
 ## Overview {#overview}
 
  * Disable session-based stage setting in `Versioned` (see [#1578](https://github.com/silverstripe/silverstripe-cms/issues/1578))
+ * Deprecated `FunctionalTest::useDraftSite()`. You should use querystring args instead for setting stage.
 
 ## Upgrading {#upgrading}
 
@@ -38,3 +39,24 @@ SilverStripe\Versioned\Versioned:
 
 Check our [versioning docs](/developer_guides/model/versioning#controllers)
 for more details.
+
+### New Versioned API
+
+The following methods have been added to [api:SilverStripe\Versioned\Versioned] class:
+
+ * `withVersionedMode()` Allows users to execute a closure which may internally modify
+   the current stage, but will guarantee these changes are reverted safely on return.
+   Helpful when temporarily performing a task in another stage or view mode.
+ * `get_draft_site_secured()` / `set_draft_site_secured()` Enables the explicit toggle
+   of draft site security. By setting this to false, you can expose a draft mode to
+   unauthenticated users. Replaces `unsecuredDraftSite` session var.
+ * `get_default_reading_mode()` / `set_default_reading_mode()` The default reading
+  mode is now configurable. Any non-default reading mode must have querystring args
+  to be visible. This will be the mode choosen for requests that do not have these args.
+  Note that the default mode for CMS is now draft, but is live on the frontend.
+
+A new class [api:SilverStripe\Versioned\ReadingMode] has also been added to assist with
+conversion of the reading mode between:
+ - Reading mode string
+ - DataQuery parameters
+ - Querystring parameters

--- a/docs/en/04_Changelogs/4.2.0.md
+++ b/docs/en/04_Changelogs/4.2.0.md
@@ -1,0 +1,37 @@
+# 4.2.0
+
+## Overview {#overview}
+
+ * Disable session-based stage setting in `Versioned` (see [#1578](https://github.com/silverstripe/silverstripe-cms/issues/1578))
+
+## Upgrading {#upgrading}
+
+### Disable session-based stage setting
+
+When viewing a versioned record (usually pages) in "draft" mode,
+SilverStripe used to record this mode in the session for further requests.
+This has the advantage of transparently working on XHR and API requests,
+as well as authenticated users navigating through other views.
+
+These subsequent requests no longer carried an explicit `stage` query parameter,
+which meant the same URL might show draft or live content depending on your session state.
+While most HTTP caching layers deal gracefully with this variation by disabling
+any caching when a session cookie is present, there is a small chance
+that draft content is exposed to unauthenticated users for the lifetime of the cache.
+
+Due to this potential risk for information leakage,
+we have decided to only rely on the `stage` query parameter.
+If you are consistently using the built-in `SiteTree->Link()`
+and `Controller->Link()` methods to get URLs, this change likely won't affect you. 
+
+If you are manually concatenating URLs to SilverStripe controllers
+rather than through their `Link()` methods (in custom PHP or JavaScript),
+or have implemented your own `Link()` methods on controllers exposing
+versioned objects, you'll need to check your business logic.
+
+Alternatively, you can opt-out of this security feature via YAML configuration:
+
+```yml
+SilverStripe\Versioned\Versioned:
+  use_session: true
+```

--- a/src/Control/RequestHandler.php
+++ b/src/Control/RequestHandler.php
@@ -560,9 +560,11 @@ class RequestHandler extends ViewableData
         // Check configured url_segment
         $url = $this->config()->get('url_segment');
         if ($url) {
+            $link = Controller::join_links($url, $action, '/');
+
             // Give extensions the chance to modify by reference
             $this->extend('updateLink', $link, $action);
-            return Controller::join_links($url, $action, '/');
+            return $link;
         }
 
         // no link defined by default

--- a/src/Control/RequestHandler.php
+++ b/src/Control/RequestHandler.php
@@ -560,6 +560,8 @@ class RequestHandler extends ViewableData
         // Check configured url_segment
         $url = $this->config()->get('url_segment');
         if ($url) {
+            // Give extensions the chance to modify by reference
+            $this->extend('updateLink', $link, $action);
             return Controller::join_links($url, $action, '/');
         }
 

--- a/src/Core/Extensible.php
+++ b/src/Core/Extensible.php
@@ -211,13 +211,6 @@ trait Extensible
             ));
 
         Injector::inst()->unregisterNamedObject($class);
-
-        // load statics now for DataObject classes
-        if (is_subclass_of($class, DataObject::class)) {
-            if (!is_subclass_of($extensionClass, DataExtension::class)) {
-                user_error("$extensionClass cannot be applied to $class without being a DataExtension", E_USER_ERROR);
-            }
-        }
         return true;
     }
 

--- a/src/Core/Extensible.php
+++ b/src/Core/Extensible.php
@@ -48,7 +48,6 @@ trait Extensible
      */
     private static $unextendable_classes = array(
         ViewableData::class,
-        RequestHandler::class,
     );
 
     /**

--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Dev;
 
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTP;
 use SilverStripe\Control\Session;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Config\Config;
@@ -12,6 +13,7 @@ use SilverStripe\Security\BasicAuth;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 use SilverStripe\Security\SecurityToken;
+use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\SSViewer;
 use PHPUnit_Framework_AssertionFailedError;
 use SimpleXMLElement;
@@ -161,6 +163,9 @@ class FunctionalTest extends SapphireTest implements TestOnly
     public function get($url, $session = null, $headers = null, $cookies = null)
     {
         $this->cssParser = null;
+        if (Versioned::get_stage() === Versioned::DRAFT) {
+            $url = HTTP::setGetVar('stage', Versioned::DRAFT, $url);
+        }
         $response = $this->mainSession->get($url, $session, $headers, $cookies);
         if ($this->autoFollowRedirection && is_object($response) && $response->getHeader('Location')) {
             $response = $this->mainSession->followRedirection();
@@ -411,11 +416,9 @@ class FunctionalTest extends SapphireTest implements TestOnly
     public function useDraftSite($enabled = true)
     {
         if ($enabled) {
-            $this->session()->set('readingMode', 'Stage.Stage');
-            $this->session()->set('unsecuredDraftSite', true);
+            Versioned::set_stage(Versioned::DRAFT);
         } else {
-            $this->session()->set('readingMode', 'Stage.Live');
-            $this->session()->set('unsecuredDraftSite', false);
+            Versioned::set_stage(Versioned::LIVE);
         }
     }
 

--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -406,15 +406,13 @@ class FunctionalTest extends SapphireTest implements TestOnly
      * This is helpful if you're not testing publication functionality and don't want "stage management" cluttering
      * your test.
      *
-     * @param bool $enabled toggle the use of the draft site
+     * @param bool $draft toggle the use of the draft site
      */
-    public function useDraftSite($enabled = true)
+    public function useDraftSite($draft = true)
     {
-        if ($enabled) {
-            Versioned::set_stage(Versioned::DRAFT);
-        } else {
-            Versioned::set_stage(Versioned::LIVE);
-        }
+        $stage = $draft ? Versioned::DRAFT : Versioned::LIVE;
+        Versioned::set_stage($stage);
+        Versioned::set_default_reading_mode(Versioned::get_reading_mode());
     }
 
     /**

--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -403,16 +403,17 @@ class FunctionalTest extends SapphireTest implements TestOnly
      * This is helpful if you're not testing publication functionality and don't want "stage management" cluttering
      * your test.
      *
-     * @param bool $draft toggle the use of the draft site
+     * @param bool $enabled toggle the use of the draft site
      */
-    public function useDraftSite($draft = true)
+    public function useDraftSite($enabled = true)
     {
-        if (!class_exists(Versioned::class)) {
-            return;
+        if ($enabled) {
+            $this->session()->set('readingMode', 'Stage.Stage');
+            $this->session()->set('unsecuredDraftSite', true);
+        } else {
+            $this->session()->set('readingMode', 'Stage.Live');
+            $this->session()->set('unsecuredDraftSite', false);
         }
-        $stage = $draft ? Versioned::DRAFT : Versioned::LIVE;
-        Versioned::set_stage($stage);
-        Versioned::set_default_reading_mode(Versioned::get_reading_mode());
     }
 
     /**

--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -9,7 +9,6 @@ use SilverStripe\Control\Session;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Security\BasicAuth;
 use SilverStripe\Security\SecurityToken;
-use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\SSViewer;
 use SimpleXMLElement;
 
@@ -46,6 +45,7 @@ class FunctionalTest extends SapphireTest implements TestOnly
     /**
      * Set this to true on your sub-class to use the draft site by default for every test in this class.
      *
+     * @deprecated 4.2..5.0 Use ?stage=Stage in your ->get() querystring requests instead
      * @var bool
      */
     protected static $use_draft_site = false;
@@ -101,6 +101,7 @@ class FunctionalTest extends SapphireTest implements TestOnly
         $this->logOut();
 
         // Switch to draft site, if necessary
+        // If you rely on this you should be crafting stage-specific urls instead though.
         if (static::get_use_draft_site()) {
             $this->useDraftSite();
         }
@@ -403,16 +404,18 @@ class FunctionalTest extends SapphireTest implements TestOnly
      * This is helpful if you're not testing publication functionality and don't want "stage management" cluttering
      * your test.
      *
+     * @deprecated 4.2..5.0 Use ?stage=Stage querystring arguments instead of useDraftSite
      * @param bool $enabled toggle the use of the draft site
      */
     public function useDraftSite($enabled = true)
     {
+        Deprecation::notice('5.0', 'Use ?stage=Stage querystring arguments instead of useDraftSite');
         if ($enabled) {
             $this->session()->set('readingMode', 'Stage.Stage');
             $this->session()->set('unsecuredDraftSite', true);
         } else {
-            $this->session()->set('readingMode', 'Stage.Live');
-            $this->session()->set('unsecuredDraftSite', false);
+            $this->session()->clear('readingMode');
+            $this->session()->clear('unsecuredDraftSite');
         }
     }
 
@@ -425,6 +428,7 @@ class FunctionalTest extends SapphireTest implements TestOnly
     }
 
     /**
+     * @deprecated 4.2..5.0 Use ?stage=Stage in your querystring arguments instead
      * @return bool
      */
     public static function get_use_draft_site()

--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -105,11 +105,6 @@ class FunctionalTest extends SapphireTest implements TestOnly
         // Flush user
         $this->logOut();
 
-        // Switch to draft site, if necessary
-        if (static::get_use_draft_site()) {
-            $this->useDraftSite();
-        }
-
         // Unprotect the site, tests are running with the assumption it's off. They will enable it on a case-by-case
         // basis.
         BasicAuth::protect_entire_site(false);
@@ -163,7 +158,7 @@ class FunctionalTest extends SapphireTest implements TestOnly
     public function get($url, $session = null, $headers = null, $cookies = null)
     {
         $this->cssParser = null;
-        if (Versioned::get_stage() === Versioned::DRAFT) {
+        if (self::get_use_draft_site()) {
             $url = HTTP::setGetVar('stage', Versioned::DRAFT, $url);
         }
         $response = $this->mainSession->get($url, $session, $headers, $cookies);

--- a/src/Dev/State/SapphireTestState.php
+++ b/src/Dev/State/SapphireTestState.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\Dev\State;
 
 use SilverStripe\Core\Injector\Injectable;
-use SilverStripe\Dev\Debug;
 use SilverStripe\Dev\SapphireTest;
 
 class SapphireTestState implements TestState

--- a/src/Dev/TestSession.php
+++ b/src/Dev/TestSession.php
@@ -2,15 +2,16 @@
 
 namespace SilverStripe\Dev;
 
-use SilverStripe\Control\Cookie_Backend;
-use SilverStripe\Control\HTTPRequest;
-use SilverStripe\Control\Session;
+use Exception;
 use SilverStripe\Control\Controller;
+use SilverStripe\Control\Cookie_Backend;
 use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\Session;
+use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injector;
 use SimpleByName;
-use Exception;
 use SimplePage;
 use SimplePageBuilder;
 
@@ -20,6 +21,7 @@ use SimplePageBuilder;
  */
 class TestSession
 {
+    use Extensible;
 
     /**
      * @var Session
@@ -89,6 +91,7 @@ class TestSession
      */
     public function get($url, $session = null, $headers = null, $cookies = null)
     {
+        $this->extend('updateGetURL', $url, $session, $headers, $cookies);
         $headers = (array) $headers;
         if ($this->lastUrl && !isset($headers['Referer'])) {
             $headers['Referer'] = $this->lastUrl;
@@ -123,6 +126,7 @@ class TestSession
      */
     public function post($url, $data, $headers = null, $session = null, $body = null, $cookies = null)
     {
+        $this->extend('updatePostURL', $url, $data, $headers, $session, $body, $cookies);
         $headers = (array) $headers;
         if ($this->lastUrl && !isset($headers['Referer'])) {
             $headers['Referer'] = $this->lastUrl;

--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -363,7 +363,9 @@ class FormField extends RequestHandler
      */
     public function Link($action = null)
     {
-        return Controller::join_links($this->form->FormAction(), 'field/' . $this->name, $action);
+        $link = Controller::join_links($this->form->FormAction(), 'field/' . $this->name, $action);
+        $this->extend('updateLink', $link, $action);
+        return $link;
     }
 
     /**

--- a/src/Forms/FormRequestHandler.php
+++ b/src/Forms/FormRequestHandler.php
@@ -85,15 +85,15 @@ class FormRequestHandler extends RequestHandler
 
         // Respect FormObjectLink() method
         if ($controller->hasMethod("FormObjectLink")) {
-            return Controller::join_links(
-                $controller->FormObjectLink($this->form->getName()),
-                $action,
-                '/'
-            );
+            $base = $controller->FormObjectLink($this->form->getName());
+        } else {
+            $base = Controller::join_links($controller->Link(), $this->form->getName());
         }
 
-        // Default form link
-        return Controller::join_links($controller->Link(), $this->form->getName(), $action, '/');
+        // Join with action and decorate
+        $link = Controller::join_links($base, $action, '/');
+        $this->extend('updateLink', $link, $action);
+        return $link;
     }
 
     /**

--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -7,7 +7,6 @@ use Psr\Container\NotFoundExceptionInterface;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\RequestHandler;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\FieldType\DBField;
@@ -25,9 +24,11 @@ class ChangePasswordHandler extends RequestHandler
     protected $authenticator;
 
     /**
+     * Link to this handler
+     *
      * @var string
      */
-    protected $link;
+    protected $link = null;
 
     /**
      * @var array Allowed Actions
@@ -123,8 +124,8 @@ class ChangePasswordHandler extends RequestHandler
                     . '<p>You can request a new one <a href="{link1}">here</a> or change your password after'
                     . ' you <a href="{link2}">logged in</a>.</p>',
                     [
-                        'link1' => $this->link('lostpassword'),
-                        'link2' => $this->link('login')
+                        'link1' => $this->Link('lostpassword'),
+                        'link2' => $this->Link('login')
                     ]
                 )
             );
@@ -164,16 +165,15 @@ class ChangePasswordHandler extends RequestHandler
     /**
      * Return a link to this request handler.
      * The link returned is supplied in the constructor
-     * @param null $action
+     *
+     * @param string|null $action
      * @return string
      */
-    public function link($action = null)
+    public function Link($action = null)
     {
-        if ($action) {
-            return Controller::join_links($this->link, $action);
-        }
-
-        return $this->link;
+        $link = Controller::join_links($this->link, $action);
+        $this->extend('updateLink', $link, $action);
+        return $link;
     }
 
     /**

--- a/src/Security/MemberAuthenticator/LoginHandler.php
+++ b/src/Security/MemberAuthenticator/LoginHandler.php
@@ -41,9 +41,11 @@ class LoginHandler extends RequestHandler
     ];
 
     /**
-     * @var string Called link on this handler
+     * Link to this handler
+     *
+     * @var string
      */
-    private $link;
+    protected $link = null;
 
     /**
      * @param string $link The URL to recreate this request handler
@@ -59,16 +61,15 @@ class LoginHandler extends RequestHandler
     /**
      * Return a link to this request handler.
      * The link returned is supplied in the constructor
+     *
      * @param null|string $action
      * @return string
      */
-    public function link($action = null)
+    public function Link($action = null)
     {
-        if ($action) {
-            return Controller::join_links($this->link, $action);
-        }
-
-        return $this->link;
+        $link = Controller::join_links($this->link, $action);
+        $this->extend('updateLink', $link, $action);
+        return $link;
     }
 
     /**
@@ -152,7 +153,7 @@ class LoginHandler extends RequestHandler
 
     public function getReturnReferer()
     {
-        return $this->link();
+        return $this->Link();
     }
 
     /**

--- a/src/Security/MemberAuthenticator/LostPasswordHandler.php
+++ b/src/Security/MemberAuthenticator/LostPasswordHandler.php
@@ -44,7 +44,12 @@ class LostPasswordHandler extends RequestHandler
         'passwordsent',
     ];
 
-    private $link = null;
+    /**
+     * Link to this handler
+     *
+     * @var string
+     */
+    protected $link = null;
 
     /**
      * @param string $link The URL to recreate this request handler
@@ -59,16 +64,14 @@ class LostPasswordHandler extends RequestHandler
      * Return a link to this request handler.
      * The link returned is supplied in the constructor
      *
-     * @param string $action
+     * @param string|null $action
      * @return string
      */
-    public function link($action = null)
+    public function Link($action = null)
     {
-        if ($action) {
-            return Controller::join_links($this->link, $action);
-        }
-
-        return $this->link;
+        $link = Controller::join_links($this->link, $action);
+        $this->extend('updateLink', $link, $action);
+        return $link;
     }
 
     /**
@@ -261,7 +264,7 @@ class LostPasswordHandler extends RequestHandler
     protected function redirectToSuccess(array $data)
     {
         $link = Controller::join_links(
-            $this->link('passwordsent'),
+            $this->Link('passwordsent'),
             rawurlencode($data['Email']),
             '/'
         );

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -483,7 +483,9 @@ class Security extends Controller implements TemplateGlobalProvider
     public function Link($action = null)
     {
         /** @skipUpgrade */
-        return Controller::join_links(Director::baseURL(), "Security", $action);
+        $link = Controller::join_links(Director::baseURL(), "Security", $action);
+        $this->extend('updateLink', $link, $action);
+        return $link;
     }
 
     /**

--- a/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
@@ -2,29 +2,24 @@
 
 namespace SilverStripe\Forms\Tests\HTMLEditor;
 
+use Silverstripe\Assets\Dev\TestAssetStore;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\FileNameFilter;
 use SilverStripe\Assets\Filesystem;
 use SilverStripe\Assets\Folder;
 use SilverStripe\Assets\Image;
-use Silverstripe\Assets\Dev\TestAssetStore;
 use SilverStripe\Core\Config\Config;
-use SilverStripe\Core\Manifest\ModuleLoader;
-use SilverStripe\Core\Manifest\ModuleManifest;
-use SilverStripe\Core\Manifest\ModuleResourceLoader;
 use SilverStripe\Dev\CSSContentParser;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
+use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 use SilverStripe\Forms\HTMLReadonlyField;
 use SilverStripe\Forms\Tests\HTMLEditor\HTMLEditorFieldTest\TestObject;
 use SilverStripe\ORM\FieldType\DBHTMLText;
-use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 
 class HTMLEditorFieldTest extends FunctionalTest
 {
     protected static $fixture_file = 'HTMLEditorFieldTest.yml';
-
-    protected static $use_draft_site = true;
 
     protected static $extra_dataobjects = [
         TestObject::class,


### PR DESCRIPTION
This attempts to lay the foundations to move away from using the session to store the current stage.

This is an issue which is raised by clients regarding unexpectedly seeing staged content when navigating the site outside of the CMS or when wanting to open multiple tabs to see one draft and one live site in each.