### PR TITLE
NEW Add actWithPermission to SapphireTest

### DIFF
--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -950,13 +950,24 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     }
 
     /**
-     * Create a member and group with the given permission code, and log in with it.
-     * Returns the member ID.
+     * A wrapper for automatically performing callbacks as a user with a specific permission
      *
-     * @param string|array $permCode Either a permission, or list of permissions
-     * @return int Member ID
+     * @param string|array $permCode
+     * @param callable $callback
+     * @return mixed
      */
-    public function logInWithPermission($permCode = "ADMIN")
+    public function actWithPermission($permCode, $callback)
+    {
+        return Member::actAs($this->createMemberWithPermission($permCode), $callback);
+    }
+
+    /**
+     * Create Member and Group objects on demand with specific permission code
+     *
+     * @param string|array $permCode
+     * @return Member
+     */
+    protected function createMemberWithPermission($permCode)
     {
         if (is_array($permCode)) {
             $permArray = $permCode;
@@ -997,6 +1008,19 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
 
             $this->cache_generatedMembers[$permCode] = $member;
         }
+        return $member;
+    }
+
+    /**
+     * Create a member and group with the given permission code, and log in with it.
+     * Returns the member ID.
+     *
+     * @param string|array $permCode Either a permission, or list of permissions
+     * @return int Member ID
+     */
+    public function logInWithPermission($permCode = "ADMIN")
+    {
+        $member = $this->createMemberWithPermission($permCode);
         $this->logInAs($member);
         return $member->ID;
     }

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -3,6 +3,8 @@
 namespace SilverStripe\Dev\Tests;
 
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Permission;
 
 class SapphireTestTest extends SapphireTest
 {
@@ -28,5 +30,25 @@ class SapphireTestTest extends SapphireTest
             dirname(__DIR__) . '/ORM/DataObjectTest.yml',
             $this->resolveFixturePath(dirname(__DIR__) .'/ORM/DataObjectTest.yml')
         );
+    }
+
+    public function testActWithPermission()
+    {
+        $this->logOut();
+        $this->assertFalse(Permission::check('ADMIN'));
+        $this->actWithPermission('ADMIN', function () {
+            $this->assertTrue(Permission::check('ADMIN'));
+            // check nested actAs calls work as expected
+            Member::actAs(null, function () {
+                $this->assertFalse(Permission::check('ADMIN'));
+            });
+        });
+    }
+
+    public function testCreateMemberWithPermission()
+    {
+        $this->assertCount(0, Member::get()->filter([ 'Email' => 'TESTPERM@example.org' ]));
+        $this->createMemberWithPermission('TESTPERM');
+        $this->assertCount(1, Member::get()->filter([ 'Email' => 'TESTPERM@example.org' ]));
     }
 }


### PR DESCRIPTION
Currently you need to be logged in to programmatically publish objects/changesets.

In a test suite this can be a bit annoying as it either means creating a specific user and using `Member::actAs` or you have to use the `logInWithPermission` helper in sapphiretest.  Both can be undesirable as the former requires creating member objects in test code, which is noisy and wasteful, and the latter means if you're logged in already you'll have to re-login again.

I've added a method `actWithPermission` which is a helper for using `Member::actAs` with a single permission code rather than using a Member object.

I've also split out the logic for creating Group/Member objects from the `logInWithPermission` method so it can be re-used.