### PR TITLE
[DO NOT MERGE] Fix ArrayList sort error with old (supported) PHP

### DIFF
--- a/model/ArrayList.php
+++ b/model/ArrayList.php
@@ -448,7 +448,8 @@ class ArrayList extends ViewableData implements SS_List, SS_Filterable, SS_Sorta
 			// First argument is the direction to be sorted,
 			$multisortArgs[] = &$sortDirection[$column];
 			if ($firstRun) {
-				$multisortArgs[] = SORT_REGULAR;
+				$sortArg = SORT_REGULAR;
+				$multisortArgs[] = &$sortArg;
 			}
 			$firstRun = false;
 		}


### PR DESCRIPTION
PHP 5.3 at least (the reported and tested against version) requires arguments to `call_user_func_array` to be passed by reference. There exists a note as a comment in the code, but was unfortunately overlooked in a previous commit to fix case sensitive sorting https://github.com/silverstripe/silverstripe-framework/commit/4998b8044530a83c617194d544b76a98f742386e#diff-6ba746c3d31fd6b4c4a99d7efe35eb21L442

To solve this issue we simply first assign the constant to a variable, so we can then pass that by reference. This has no functional impact, however fixes an issue for users locked in to old PHP versions which we still list as supported (https://docs.silverstripe.org/en/3/getting_started/server_requirements/#web-server-software-requirements).

As requested by @dhensby please tag this PR as DO NOT MERGE