### PR TITLE
WIP: Rename assert dos to assert list

### DIFF
--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -6,6 +6,7 @@ use PHPUnit_Framework_Constraint;
 use PHPUnit_Framework_ExpectationFailedException;
 use SilverStripe\Dev\SSListExporter;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\SS_List;
 use SilverStripe\View\ViewableData;
 
 if (!class_exists(PHPUnit_Framework_Constraint::class)) {
@@ -48,7 +49,7 @@ class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
      * a boolean value instead: true in case of success, false in case of a
      * failure.
      *
-     * @param mixed $other Value or object to evaluate.
+     * @param SS_List $other Value or object to evaluate.
      * @param string $description Additional information about the test
      * @param bool $returnResult Whether to return a result or throw an exception
      *
@@ -61,7 +62,7 @@ class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
         $success = true;
 
         foreach ($other as $item) {
-            $this->checkIfItemEvaltuatesRemainingMatches($item);
+            $this->checkIfItemEvaluatesRemainingMatches($item);
         }
 
         //we have remaining matches?
@@ -85,7 +86,7 @@ class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
      * @param ViewableData $item
      * @return bool
      */
-    protected function checkIfItemEvaltuatesRemainingMatches(ViewableData $item)
+    protected function checkIfItemEvaluatesRemainingMatches(ViewableData $item)
     {
         $success = false;
         foreach ($this->matches as $key => $match) {

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -7,15 +7,13 @@ use SilverStripe\Dev\SSListExporter;
 use SilverStripe\View\ViewableData;
 
 /**
- * Constraint for checking if a SS_List contains only items matching the given
- * key-value pairs.  Each match must correspond to 1 distinct record.
- *
- * @todo can this be solved more elegantly using a Comparator?
+ * Constraint for checking if a SS_List contains items matching the given
+ * key-value pairs.
  *
  * Class SSListContainsOnly
  * @package SilverStripe\Dev\Constraint
  */
-class SSListContainsOnly extends \PHPUnit_Framework_Constraint
+class SSListContains extends \PHPUnit_Framework_Constraint
 {
 
     private $matches = [];
@@ -55,15 +53,11 @@ class SSListContainsOnly extends \PHPUnit_Framework_Constraint
         $success = true;
 
         foreach ($other as $item) {
-            if (!$this->checkIfItemEvaltuatesRemainingMatches($item)) {
-                $this->item_not_matching = true;
-                $success = false;
-                break;
-            }
+            $this->checkIfItemEvaltuatesRemainingMatches($item);
         }
 
         //we have remaining matches?
-        if (!$this->item_not_matching && count($this->matches) !== 0) {
+        if (count($this->matches) !== 0) {
             $success = false;
             $this->has_leftover_items = true;
         }
@@ -105,10 +99,7 @@ class SSListContainsOnly extends \PHPUnit_Framework_Constraint
      */
     public function toString()
     {
-        $stub = $this->item_not_matching
-            ? ' contains an item matching '
-            : " contained only the given items, the following items were left over:\n";
-
+        $stub = ' contains an item matching ';
 
         $matchToString = function ($key, $value) {
             return ' "' . $key . '" is "' . $value . '"';

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -9,9 +9,6 @@ use SilverStripe\View\ViewableData;
 /**
  * Constraint for checking if a SS_List contains items matching the given
  * key-value pairs.
- *
- * Class SSListContainsOnly
- * @package SilverStripe\Dev\Constraint
  */
 class SSListContains extends \PHPUnit_Framework_Constraint
 {

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -52,7 +52,7 @@ class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
      * @param string $description Additional information about the test
      * @param bool $returnResult Whether to return a result or throw an exception
      *
-     * @return mixed
+     * @return null|bool
      *
      * @throws PHPUnit_Framework_ExpectationFailedException
      */
@@ -77,6 +77,8 @@ class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
         if (!$success) {
             $this->fail($other, $description);
         }
+
+        return null;
     }
 
     /**

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -18,9 +18,17 @@ if (!class_exists(PHPUnit_Framework_Constraint::class)) {
  */
 class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
 {
+    /**
+     * @var array
+     */
     protected $matches = [];
 
-    protected $has_leftover_items = false;
+    /**
+     * Check if the list has left over items that don't match
+     *
+     * @var bool
+     */
+    protected $hasLeftoverItems = false;
 
     public function __construct($matches)
     {
@@ -59,7 +67,7 @@ class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
         //we have remaining matches?
         if (count($this->matches) !== 0) {
             $success = false;
-            $this->has_leftover_items = true;
+            $this->hasLeftoverItems = true;
         }
 
         if ($returnResult) {

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -2,17 +2,22 @@
 
 namespace SilverStripe\Dev\Constraint;
 
+use PHPUnit_Framework_Constraint;
 use PHPUnit_Framework_ExpectationFailedException;
 use SilverStripe\Dev\SSListExporter;
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\View\ViewableData;
+
+if (!class_exists(PHPUnit_Framework_Constraint::class)) {
+    return;
+}
 
 /**
  * Constraint for checking if a SS_List contains items matching the given
  * key-value pairs.
  */
-class SSListContains extends \PHPUnit_Framework_Constraint
+class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
 {
-
     protected $matches = [];
 
     protected $has_leftover_items = false;

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -16,11 +16,9 @@ use SilverStripe\View\ViewableData;
 class SSListContains extends \PHPUnit_Framework_Constraint
 {
 
-    private $matches = [];
+    protected $matches = [];
 
-    private $item_not_matching = false;
-
-    private $has_leftover_items = false;
+    protected $has_leftover_items = false;
 
     public function __construct($matches)
     {
@@ -75,7 +73,7 @@ class SSListContains extends \PHPUnit_Framework_Constraint
      * @param ViewableData $item
      * @return bool
      */
-    private function checkIfItemEvaltuatesRemainingMatches(ViewableData $item)
+    protected function checkIfItemEvaltuatesRemainingMatches(ViewableData $item)
     {
         $success = false;
         foreach ($this->matches as $key => $match) {
@@ -99,8 +97,6 @@ class SSListContains extends \PHPUnit_Framework_Constraint
      */
     public function toString()
     {
-        $stub = ' contains an item matching ';
-
         $matchToString = function ($key, $value) {
             return ' "' . $key . '" is "' . $value . '"';
         };
@@ -120,6 +116,10 @@ class SSListContains extends \PHPUnit_Framework_Constraint
             array_map($matchesToString, $this->matches));
 
 
-        return $stub . $allMatchesAsString;
+        return $this->getStubForToString() . $allMatchesAsString;
+    }
+
+    protected function getStubForToString() {
+        return ' contains an item matching ';
     }
 }

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -113,13 +113,15 @@ class SSListContains extends \PHPUnit_Framework_Constraint
 
         $allMatchesAsString = implode(
             "\n or ",
-            array_map($matchesToString, $this->matches));
+            array_map($matchesToString, $this->matches)
+        );
 
 
         return $this->getStubForToString() . $allMatchesAsString;
     }
 
-    protected function getStubForToString() {
+    protected function getStubForToString()
+    {
         return ' contains an item matching ';
     }
 }

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -89,7 +89,6 @@ class SSListContains extends \PHPUnit_Framework_Constraint
         return $success;
     }
 
-
     /**
      * Returns a string representation of the object.
      *

--- a/src/Dev/Constraint/SSListContainsOnly.php
+++ b/src/Dev/Constraint/SSListContainsOnly.php
@@ -36,7 +36,7 @@ class SSListContainsOnly extends SSListContains
      * @param string $description Additional information about the test
      * @param bool $returnResult Whether to return a result or throw an exception
      *
-     * @return mixed
+     * @return null|bool
      *
      * @throws PHPUnit_Framework_ExpectationFailedException
      */
@@ -65,6 +65,8 @@ class SSListContainsOnly extends SSListContains
         if (!$success) {
             $this->fail($other, $description);
         }
+
+        return null;
     }
 
     protected function getStubForToString()

--- a/src/Dev/Constraint/SSListContainsOnly.php
+++ b/src/Dev/Constraint/SSListContainsOnly.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: Werner
+ * Date: 03.10.2017
+ * Time: 23:07
+ */
+
+namespace SilverStripe\Dev\Constraint;
+
+
+class SSListContainsOnly extends \PHPUnit_Framework_Constraint
+{
+
+    private $constraint;
+
+    public function __construct($match)
+    {
+        parent::__construct();
+
+        $this->constraint = new ViewableDataContains($match);
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other
+     *
+     * If $returnResult is set to false (the default), an exception is thrown
+     * in case of a failure. null is returned otherwise.
+     *
+     * If $returnResult is true, the result of the evaluation is returned as
+     * a boolean value instead: true in case of success, false in case of a
+     * failure.
+     *
+     * @param mixed $other Value or object to evaluate.
+     * @param string $description Additional information about the test
+     * @param bool $returnResult Whether to return a result or throw an exception
+     *
+     * @return mixed
+     *
+     * @throws PHPUnit_Framework_ExpectationFailedException
+     */
+    public function evaluate($other, $description = '', $returnResult = false)
+    {
+        $success = true;
+
+        foreach ($other as $item) {
+            if (!$this->constraint->evaluate($item, '', true)) {
+                $success = false;
+                break;
+            }
+        }
+
+        if ($returnResult) {
+            return $success;
+        }
+
+        if (!$success) {
+            $this->fail($other, $description);
+        }
+    }
+
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'contains only Objects where "' . key($this->match) . '" is "' . current($this->match) . '"';
+
+    }
+}

--- a/src/Dev/Constraint/SSListContainsOnly.php
+++ b/src/Dev/Constraint/SSListContainsOnly.php
@@ -2,7 +2,12 @@
 
 namespace SilverStripe\Dev\Constraint;
 
+use PHPUnit_Framework_Constraint;
 use PHPUnit_Framework_ExpectationFailedException;
+
+if (!class_exists(PHPUnit_Framework_Constraint::class)) {
+    return;
+}
 
 /**
  * Constraint for checking if a SS_List contains only items matching the given
@@ -10,7 +15,6 @@ use PHPUnit_Framework_ExpectationFailedException;
  */
 class SSListContainsOnly extends SSListContains
 {
-
     private $item_not_matching = false;
 
     /**

--- a/src/Dev/Constraint/SSListContainsOnly.php
+++ b/src/Dev/Constraint/SSListContainsOnly.php
@@ -15,7 +15,12 @@ if (!class_exists(PHPUnit_Framework_Constraint::class)) {
  */
 class SSListContainsOnly extends SSListContains
 {
-    private $item_not_matching = false;
+    /**
+     * Check if the test fails due to a not matching item
+     *
+     * @var bool
+     */
+    private $itemNotMatching = false;
 
     /**
      * Evaluates the constraint for parameter $other
@@ -41,16 +46,16 @@ class SSListContainsOnly extends SSListContains
 
         foreach ($other as $item) {
             if (!$this->checkIfItemEvaltuatesRemainingMatches($item)) {
-                $this->item_not_matching = true;
+                $this->itemNotMatching = true;
                 $success = false;
                 break;
             }
         }
 
         //we have remaining matches?
-        if (!$this->item_not_matching && count($this->matches) !== 0) {
+        if (!$this->itemNotMatching && count($this->matches) !== 0) {
             $success = false;
-            $this->has_leftover_items = true;
+            $this->hasLeftoverItems = true;
         }
 
         if ($returnResult) {
@@ -64,7 +69,7 @@ class SSListContainsOnly extends SSListContains
 
     protected function getStubForToString()
     {
-        $this->item_not_matching
+        return $this->itemNotMatching
             ? parent::getStubForToString()
             : " contained only the given items, the following items were left over:\n";
     }

--- a/src/Dev/Constraint/SSListContainsOnly.php
+++ b/src/Dev/Constraint/SSListContainsOnly.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Dev\Constraint;
 
 use PHPUnit_Framework_Constraint;
 use PHPUnit_Framework_ExpectationFailedException;
+use SilverStripe\ORM\SS_List;
 
 if (!class_exists(PHPUnit_Framework_Constraint::class)) {
     return;
@@ -32,7 +33,7 @@ class SSListContainsOnly extends SSListContains
      * a boolean value instead: true in case of success, false in case of a
      * failure.
      *
-     * @param mixed $other Value or object to evaluate.
+     * @param SS_List $other Value or object to evaluate.
      * @param string $description Additional information about the test
      * @param bool $returnResult Whether to return a result or throw an exception
      *
@@ -45,7 +46,7 @@ class SSListContainsOnly extends SSListContains
         $success = true;
 
         foreach ($other as $item) {
-            if (!$this->checkIfItemEvaltuatesRemainingMatches($item)) {
+            if (!$this->checkIfItemEvaluatesRemainingMatches($item)) {
                 $this->itemNotMatching = true;
                 $success = false;
                 break;

--- a/src/Dev/Constraint/SSListContainsOnly.php
+++ b/src/Dev/Constraint/SSListContainsOnly.php
@@ -3,8 +3,6 @@
 namespace SilverStripe\Dev\Constraint;
 
 use PHPUnit_Framework_ExpectationFailedException;
-use SilverStripe\Dev\SSListExporter;
-use SilverStripe\View\ViewableData;
 
 /**
  * Constraint for checking if a SS_List contains only items matching the given
@@ -65,7 +63,8 @@ class SSListContainsOnly extends SSListContains
         }
     }
 
-    protected function getStubForToString() {
+    protected function getStubForToString()
+    {
         $this->item_not_matching
             ? parent::getStubForToString()
             : " contained only the given items, the following items were left over:\n";

--- a/src/Dev/Constraint/SSListContainsOnly.php
+++ b/src/Dev/Constraint/SSListContainsOnly.php
@@ -7,11 +7,6 @@ use PHPUnit_Framework_ExpectationFailedException;
 /**
  * Constraint for checking if a SS_List contains only items matching the given
  * key-value pairs.  Each match must correspond to 1 distinct record.
- *
- * @todo can this be solved more elegantly using a Comparator?
- *
- * Class SSListContainsOnly
- * @package SilverStripe\Dev\Constraint
  */
 class SSListContainsOnly extends SSListContains
 {

--- a/src/Dev/Constraint/SSListContainsOnly.php
+++ b/src/Dev/Constraint/SSListContainsOnly.php
@@ -15,22 +15,10 @@ use SilverStripe\View\ViewableData;
  * Class SSListContainsOnly
  * @package SilverStripe\Dev\Constraint
  */
-class SSListContainsOnly extends \PHPUnit_Framework_Constraint
+class SSListContainsOnly extends SSListContains
 {
 
-    private $matches = [];
-
     private $item_not_matching = false;
-
-    private $has_leftover_items = false;
-
-    public function __construct($matches)
-    {
-        parent::__construct();
-        $this->exporter = new SSListExporter();
-
-        $this->matches = $matches;
-    }
 
     /**
      * Evaluates the constraint for parameter $other
@@ -77,58 +65,9 @@ class SSListContainsOnly extends \PHPUnit_Framework_Constraint
         }
     }
 
-    /**
-     * @param ViewableData $item
-     * @return bool
-     */
-    private function checkIfItemEvaltuatesRemainingMatches(ViewableData $item)
-    {
-        $success = false;
-        foreach ($this->matches as $key => $match) {
-            $constraint = new ViewableDataContains($match);
-
-            if ($constraint->evaluate($item, '', true)) {
-                $success = true;
-                unset($this->matches[$key]);
-                break;
-            }
-        }
-
-        return $success;
-    }
-
-
-    /**
-     * Returns a string representation of the object.
-     *
-     * @return string
-     */
-    public function toString()
-    {
-        $stub = $this->item_not_matching
-            ? ' contains an item matching '
+    protected function getStubForToString() {
+        $this->item_not_matching
+            ? parent::getStubForToString()
             : " contained only the given items, the following items were left over:\n";
-
-
-        $matchToString = function ($key, $value) {
-            return ' "' . $key . '" is "' . $value . '"';
-        };
-
-        $matchesToString = function ($matches) use ($matchToString) {
-            $matchesAsString = implode(' and ', array_map(
-                $matchToString,
-                array_keys($matches),
-                array_values($matches)
-            ));
-
-            return '(' . $matchesAsString . ')';
-        };
-
-        $allMatchesAsString = implode(
-            "\n or ",
-            array_map($matchesToString, $this->matches));
-
-
-        return $stub . $allMatchesAsString;
     }
 }

--- a/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
+++ b/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
@@ -42,7 +42,7 @@ class SSListContainsOnlyMatchingItems extends PHPUnit_Framework_Constraint imple
      * @param string $description Additional information about the test
      * @param bool $returnResult Whether to return a result or throw an exception
      *
-     * @return mixed
+     * @return null|bool
      *
      * @throws PHPUnit_Framework_ExpectationFailedException
      */
@@ -64,6 +64,8 @@ class SSListContainsOnlyMatchingItems extends PHPUnit_Framework_Constraint imple
         if (!$success) {
             $this->fail($other, $description);
         }
+
+        return null;
     }
 
     /**

--- a/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
+++ b/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
@@ -3,8 +3,10 @@
 namespace SilverStripe\Dev\Constraint;
 
 use PHPUnit_Framework_Constraint;
+use PHPUnit_Framework_ExpectationFailedException;
 use SilverStripe\Dev\SSListExporter;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\SS_List;
 
 if (!class_exists(PHPUnit_Framework_Constraint::class)) {
     return;
@@ -16,7 +18,14 @@ if (!class_exists(PHPUnit_Framework_Constraint::class)) {
  */
 class SSListContainsOnlyMatchingItems extends PHPUnit_Framework_Constraint implements TestOnly
 {
-    private $match = [];
+    /**
+     * @var array
+     */
+    private $match;
+
+    /**
+     * @var ViewableDataContains
+     */
     private $constraint;
 
     public function __construct($match)
@@ -38,7 +47,7 @@ class SSListContainsOnlyMatchingItems extends PHPUnit_Framework_Constraint imple
      * a boolean value instead: true in case of success, false in case of a
      * failure.
      *
-     * @param mixed $other Value or object to evaluate.
+     * @param SS_List $other Value or object to evaluate.
      * @param string $description Additional information about the test
      * @param bool $returnResult Whether to return a result or throw an exception
      *

--- a/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
+++ b/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
@@ -2,13 +2,19 @@
 
 namespace SilverStripe\Dev\Constraint;
 
+use PHPUnit_Framework_Constraint;
 use SilverStripe\Dev\SSListExporter;
+use SilverStripe\Dev\TestOnly;
+
+if (!class_exists(PHPUnit_Framework_Constraint::class)) {
+    return;
+}
 
 /**
  * Constraint for checking if every item in a SS_List matches a given match,
  * e.g. every Member has isActive set to true
  */
-class SSListContainsOnlyMatchingItems extends \PHPUnit_Framework_Constraint
+class SSListContainsOnlyMatchingItems extends PHPUnit_Framework_Constraint implements TestOnly
 {
     private $match = [];
     private $constraint;

--- a/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
+++ b/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
@@ -7,13 +7,9 @@ use SilverStripe\Dev\SSListExporter;
 /**
  * Constraint for checking if every item in a SS_List matches a given match,
  * e.g. every Member has isActive set to true
- *
- * Class SSListContainsOnly
- * @package SilverStripe\Dev\Constraint
  */
 class SSListContainsOnlyMatchingItems extends \PHPUnit_Framework_Constraint
 {
-
     private $match = [];
     private $constraint;
 

--- a/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
+++ b/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
@@ -2,25 +2,27 @@
 
 namespace SilverStripe\Dev\Constraint;
 
+use SilverStripe\Dev\SSListExporter;
 
-use PHPUnit_Util_InvalidArgumentHelper;
-
-class ViewableDataContains extends \PHPUnit_Framework_Constraint
+/**
+ * Constraint for checking if every item in a SS_List matches a given match,
+ * e.g. every Member has isActive set to true
+ *
+ * Class SSListContainsOnly
+ * @package SilverStripe\Dev\Constraint
+ */
+class SSListContainsOnlyMatchingItems extends \PHPUnit_Framework_Constraint
 {
 
     private $match = [];
+    private $constraint;
 
     public function __construct($match)
     {
         parent::__construct();
+        $this->exporter = new SSListExporter();
 
-        if (!is_array($match)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(
-                1,
-                'array'
-            );
-        }
-
+        $this->constraint = new ViewableDataContains($match);
         $this->match = $match;
     }
 
@@ -40,18 +42,14 @@ class ViewableDataContains extends \PHPUnit_Framework_Constraint
      *
      * @return mixed
      *
-     * @throws \PHPUnit_Framework_ExpectationFailedException
+     * @throws PHPUnit_Framework_ExpectationFailedException
      */
     public function evaluate($other, $description = '', $returnResult = false)
     {
         $success = true;
 
-        foreach ($this->match as $fieldName => $value) {
-            if (!$other->hasField($fieldName)) {
-                $success = false;
-                break;
-            }
-            if ($other->getField($fieldName) != $value) {
+        foreach ($other as $item) {
+            if (!$this->constraint->evaluate($item, '', true)) {
                 $success = false;
                 break;
             }
@@ -66,11 +64,8 @@ class ViewableDataContains extends \PHPUnit_Framework_Constraint
         }
     }
 
-
     /**
      * Returns a string representation of the object.
-     *
-     * @todo: add representation for more than one match
      *
      * @return string
      */

--- a/src/Dev/Constraint/ViewableDataContains.php
+++ b/src/Dev/Constraint/ViewableDataContains.php
@@ -3,21 +3,30 @@
 namespace SilverStripe\Dev\Constraint;
 
 use PHPUnit_Framework_Constraint;
+use PHPUnit_Framework_ExpectationFailedException;
 use PHPUnit_Util_InvalidArgumentHelper;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\View\ViewableData;
 
 if (!class_exists(PHPUnit_Framework_Constraint::class)) {
     return;
 }
 
 /**
- * Constraint for checking if a VieableData (e.g. ArrayData or any DataObject) contains fields matching the given
+ * Constraint for checking if a ViewableData (e.g. ArrayData or any DataObject) contains fields matching the given
  * key-value pairs.
  */
 class ViewableDataContains extends PHPUnit_Framework_Constraint implements TestOnly
 {
-    private $match = [];
+    /**
+     * @var array
+     */
+    private $match;
 
+    /**
+     * ViewableDataContains constructor.
+     * @param array $match
+     */
     public function __construct($match)
     {
         parent::__construct();
@@ -42,13 +51,13 @@ class ViewableDataContains extends PHPUnit_Framework_Constraint implements TestO
      * a boolean value instead: true in case of success, false in case of a
      * failure.
      *
-     * @param mixed $other Value or object to evaluate.
+     * @param ViewableData $other Value or object to evaluate.
      * @param string $description Additional information about the test
      * @param bool $returnResult Whether to return a result or throw an exception
      *
      * @return null|bool
      *
-     * @throws \PHPUnit_Framework_ExpectationFailedException
+     * @throws PHPUnit_Framework_ExpectationFailedException
      */
     public function evaluate($other, $description = '', $returnResult = false)
     {

--- a/src/Dev/Constraint/ViewableDataContains.php
+++ b/src/Dev/Constraint/ViewableDataContains.php
@@ -46,7 +46,7 @@ class ViewableDataContains extends PHPUnit_Framework_Constraint implements TestO
      * @param string $description Additional information about the test
      * @param bool $returnResult Whether to return a result or throw an exception
      *
-     * @return mixed
+     * @return null|bool
      *
      * @throws \PHPUnit_Framework_ExpectationFailedException
      */
@@ -68,6 +68,8 @@ class ViewableDataContains extends PHPUnit_Framework_Constraint implements TestO
         if (!$success) {
             $this->fail($other, $description);
         }
+
+        return null;
     }
 
 

--- a/src/Dev/Constraint/ViewableDataContains.php
+++ b/src/Dev/Constraint/ViewableDataContains.php
@@ -2,11 +2,20 @@
 
 namespace SilverStripe\Dev\Constraint;
 
+use PHPUnit_Framework_Constraint;
 use PHPUnit_Util_InvalidArgumentHelper;
+use SilverStripe\Dev\TestOnly;
 
-class ViewableDataContains extends \PHPUnit_Framework_Constraint
+if (!class_exists(PHPUnit_Framework_Constraint::class)) {
+    return;
+}
+
+/**
+ * Constraint for checking if a VieableData (e.g. ArrayData or any DataObject) contains fields matching the given
+ * key-value pairs.
+ */
+class ViewableDataContains extends PHPUnit_Framework_Constraint implements TestOnly
 {
-
     private $match = [];
 
     public function __construct($match)

--- a/src/Dev/Constraint/ViewableDataContains.php
+++ b/src/Dev/Constraint/ViewableDataContains.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: Werner
+ * Date: 03.10.2017
+ * Time: 23:07
+ */
+
+namespace SilverStripe\Dev\Constraint;
+
+
+use PHPUnit_Util_InvalidArgumentHelper;
+
+class ViewableDataContains extends \PHPUnit_Framework_Constraint
+{
+
+    private $match = [];
+
+    public function __construct($match)
+    {
+        parent::__construct();
+
+        if (!is_array($match)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+                1,
+                'array'
+            );
+        }
+
+        $this->match = $match;
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other
+     *
+     * If $returnResult is set to false (the default), an exception is thrown
+     * in case of a failure. null is returned otherwise.
+     *
+     * If $returnResult is true, the result of the evaluation is returned as
+     * a boolean value instead: true in case of success, false in case of a
+     * failure.
+     *
+     * @param mixed $other Value or object to evaluate.
+     * @param string $description Additional information about the test
+     * @param bool $returnResult Whether to return a result or throw an exception
+     *
+     * @return mixed
+     *
+     * @throws \PHPUnit_Framework_ExpectationFailedException
+     */
+    public function evaluate($other, $description = '', $returnResult = false)
+    {
+        $success = true;
+
+        foreach ($this->match as $fieldName => $value) {
+            if (!$other->hasField($fieldName)) {
+                $success = false;
+                break;
+            }
+            if ($other->getField($fieldName) != $value) {
+                $success = false;
+                break;
+            }
+        }
+
+        if ($returnResult) {
+            return $success;
+        }
+
+        if (!$success) {
+            $this->fail($other, $description);
+        }
+    }
+
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @todo: add representation for more than one match
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return 'contains only Objects where "' . key($this->match) . '" is "' . current($this->match) . '"';
+    }
+}

--- a/src/Dev/Constraint/ViewableDataContains.php
+++ b/src/Dev/Constraint/ViewableDataContains.php
@@ -47,10 +47,6 @@ class ViewableDataContains extends \PHPUnit_Framework_Constraint
         $success = true;
 
         foreach ($this->match as $fieldName => $value) {
-            if (!$other->hasField($fieldName)) {
-                $success = false;
-                break;
-            }
             if ($other->getField($fieldName) != $value) {
                 $success = false;
                 break;

--- a/src/Dev/Constraint/ViewableDataContains.php
+++ b/src/Dev/Constraint/ViewableDataContains.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Dev\Constraint;
 
-
 use PHPUnit_Util_InvalidArgumentHelper;
 
 class ViewableDataContains extends \PHPUnit_Framework_Constraint

--- a/src/Dev/SSListExporter.php
+++ b/src/Dev/SSListExporter.php
@@ -16,6 +16,13 @@ if (!class_exists(Exporter::class)) {
  */
 class SSListExporter extends Exporter implements TestOnly
 {
+    /**
+     * @param mixed $value
+     * @param int $indentation
+     * @param null|Context $processed
+     * @return string
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
     protected function recursiveExport(&$value, $indentation, $processed = null)
     {
         if (!$processed) {

--- a/src/Dev/SSListExporter.php
+++ b/src/Dev/SSListExporter.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Dev;
 
-
 use SebastianBergmann\Exporter\Exporter;
 use SebastianBergmann\RecursionContext\Context;
 use SilverStripe\ORM\SS_List;
@@ -10,7 +9,6 @@ use SilverStripe\View\ViewableData;
 
 class SSListExporter extends Exporter
 {
-
     protected function recursiveExport(&$value, $indentation, $processed = null)
     {
         if (!$processed) {
@@ -25,8 +23,8 @@ class SSListExporter extends Exporter
                 return $className . ' &' . $key;
             }
 
-            $list  = $value;
-            $key    = $processed->add($value);
+            $list = $value;
+            $key = $processed->add($value);
             $values = '';
 
             if ($list->count() > 0) {

--- a/src/Dev/SSListExporter.php
+++ b/src/Dev/SSListExporter.php
@@ -7,7 +7,14 @@ use SebastianBergmann\RecursionContext\Context;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\View\ViewableData;
 
-class SSListExporter extends Exporter
+if (!class_exists(Exporter::class)) {
+    return;
+}
+
+/**
+ * A custom exporter for prettier formatting of SilverStripe specific Objects in PHPUnit's failing test messages.
+ */
+class SSListExporter extends Exporter implements TestOnly
 {
     protected function recursiveExport(&$value, $indentation, $processed = null)
     {

--- a/src/Dev/SSListExporter.php
+++ b/src/Dev/SSListExporter.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace SilverStripe\Dev;
+
+
+use SebastianBergmann\Exporter\Exporter;
+use SebastianBergmann\RecursionContext\Context;
+use SilverStripe\ORM\SS_List;
+use SilverStripe\View\ViewableData;
+
+class SSListExporter extends Exporter
+{
+
+    protected function recursiveExport(&$value, $indentation, $processed = null)
+    {
+        if (!$processed) {
+            $processed = new Context;
+        }
+
+        $whitespace = str_repeat(' ', 4 * $indentation);
+
+        if ($value instanceof SS_List) {
+            $className = get_class($value);
+            if (($key = $processed->contains($value)) !== false) {
+                return $className . ' &' . $key;
+            }
+
+            $list  = $value;
+            $key    = $processed->add($value);
+            $values = '';
+
+            if ($list->count() > 0) {
+                foreach ($list as $k => $v) {
+                    $values .= sprintf(
+                        '%s    %s ' . "\n",
+                        $whitespace,
+                        $this->recursiveExport($v, $indentation)
+                    );
+                }
+
+                $values = "\n" . $values . $whitespace;
+            }
+
+            return sprintf($className . ' &%s (%s)', $key, $values);
+        }
+
+        if ($value instanceof ViewableData) {
+            $className = get_class($value);
+            $data = $this->toMap($value);
+
+            return sprintf(
+                '%s    %s => %s' . "\n",
+                $whitespace,
+                $className,
+                $this->recursiveExport($data, $indentation + 2, $processed)
+            );
+        }
+
+
+        return parent::recursiveExport($value, $indentation, $processed);
+    }
+
+    /**
+     * @param ViewableData $object
+     * @return array
+     */
+    public function toMap(ViewableData $object)
+    {
+        return $object->hasMethod('toMap')
+            ? $object->toMap()
+            : [];
+    }
+}

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -271,7 +271,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
                 $fixture->writeInto($this->getFixtureFactory());
             }
 
-            $this->logInWithPermission("ADMIN");
+            $this->logInWithPermission('ADMIN');
         }
 
         // turn off template debugging
@@ -489,8 +489,8 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     {
         $filename = ClassLoader::inst()->getItemPath(static::class);
         if (!$filename) {
-            throw new LogicException("getItemPath returned null for " . static::class
-                . ". Try adding flush=1 to the test run.");
+            throw new LogicException('getItemPath returned null for ' . static::class
+                . '. Try adding flush=1 to the test run.');
         }
         return dirname($filename);
     }
@@ -612,7 +612,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     {
         $found = (bool)static::findEmail($to, $from, $subject, $content);
 
-        $infoParts = "";
+        $infoParts = '';
         $withParts = array();
         if ($to) {
             $infoParts .= " to '$to'";
@@ -627,7 +627,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
             $withParts[] = "content '$content'";
         }
         if ($withParts) {
-            $infoParts .= " with " . implode(" and ", $withParts);
+            $infoParts .= ' with ' . implode(' and ', $withParts);
         }
 
         static::assertTrue(
@@ -928,7 +928,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
 
         // Health check
         if (InjectorLoader::inst()->countManifests()) {
-            throw new LogicException("SapphireTest::start() cannot be called within another application");
+            throw new LogicException('SapphireTest::start() cannot be called within another application');
         }
         static::set_is_running_test(true);
 
@@ -1032,7 +1032,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
             }
 
             $member->FirstName = $permCode;
-            $member->Surname = "User";
+            $member->Surname = 'User';
             $member->Email = "$permCode@example.org";
             $member->write();
             $group->Members()->add($member);
@@ -1049,7 +1049,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param string|array $permCode Either a permission, or list of permissions
      * @return int Member ID
      */
-    public function logInWithPermission($permCode = "ADMIN")
+    public function logInWithPermission($permCode = 'ADMIN')
     {
         $member = $this->createMemberWithPermission($permCode);
         $this->logInAs($member);
@@ -1122,7 +1122,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
             return [];
         }
 
-        $fixtureFiles = (is_array($fixtureFile)) ? $fixtureFile : [$fixtureFile];
+        $fixtureFiles = is_array($fixtureFile) ? $fixtureFile : [$fixtureFile];
 
         return array_map(function ($fixtureFilePath) {
             return $this->resolveFixturePath($fixtureFilePath);

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -700,16 +700,16 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * Examples
      * --------
      * Check that $members doesn't have an entry with Email = sam@example.com:
-     *      $this->assertNotListContains(['Email' => '...@example.com'], $members);
+     *      $this->assertListNotContains(['Email' => '...@example.com'], $members);
      *
      * Check that $members doesn't have entries with Email = sam@example.com and with
      * Email = ingo@example.com:
-     *      $this->assertNotListContains([
+     *      $this->assertListNotContains([
      *          ['Email' => '...@example.com'],
      *          ['Email' => 'i...@example.com'],
      *      ], $members);
      */
-    public static function assertNotListContains($matches, SS_List $list)
+    public static function assertListNotContains($matches, SS_List $list)
     {
         $extracted = array();
         foreach ($list as $object) {
@@ -736,14 +736,14 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     }
 
     /**
-     * @deprecated 4.0.0:5.0.0 Use assertNotListContains() instead
+     * @deprecated 4.0.0:5.0.0 Use assertListNotContains() instead
      *
      * @param $matches
      * @param $dataObjectSet
      */
     public static function assertNotDOSContains($matches, $dataObjectSet) {
-        Deprecation::notice('5.0', 'Use assertNotListContains() instead');
-        return static::assertNotListContains($matches, $dataObjectSet);
+        Deprecation::notice('5.0', 'Use assertListNotContains() instead');
+        return static::assertListNotContains($matches, $dataObjectSet);
     }
 
     /**

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -247,7 +247,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
         $fixtureFiles = $this->getFixturePaths();
 
         // Set up fixture
-        if ($this->setupDatabaseForCurrentTest($fixtureFiles)) {
+        if ($this->shouldSetupDatabaseForCurrentTest($fixtureFiles)) {
             if (!static::$tempDB->isUsed()) {
                 static::$tempDB->build();
             }
@@ -293,7 +293,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param $fixtureFiles
      * @return bool
      */
-    protected function setupDatabaseForCurrentTest($fixtureFiles)
+    protected function shouldSetupDatabaseForCurrentTest($fixtureFiles)
     {
         $databaseEnabledByDefault = $fixtureFiles || $this->usesDatabase;
 

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -18,6 +18,7 @@ use SilverStripe\Control\HTTPApplication;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Injector\InjectorLoader;
 use SilverStripe\Core\Manifest\ClassLoader;
+use SilverStripe\Dev\Constraint\SSListContainsOnly;
 use SilverStripe\Dev\State\SapphireTestState;
 use SilverStripe\Dev\State\TestState;
 use SilverStripe\i18n\i18n;
@@ -831,22 +832,24 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @param mixed $match The pattern to match.  The pattern is a map of key-value pairs.
      * @param mixed $list The {@link SS_List} to test.
+     * @param string $message
      */
-    public static function assertListAllMatch($match, SS_List $list)
+    public static function assertListAllMatch($match, SS_List $list, $message = '')
     {
-        $extracted = array();
-        foreach ($list as $object) {
-            /** @var DataObject $object */
-            $extracted[] = $object->toMap();
-        }
-
-        foreach ($extracted as $i => $item) {
-            static::assertTrue(
-                static::dataObjectArrayMatch($item, $match),
-                "Failed asserting that the the following item matched "
-                . var_export($match, true) . ": " . var_export($item, true)
+        if (!is_array($match)) {
+            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+                1,
+                'array'
             );
         }
+
+        static::assertThat(
+            $list,
+            new SSListContainsOnly(
+                $match
+            ),
+            $message
+        );
     }
 
     /**

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -594,24 +594,24 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @param SS_List|array $matches The patterns to match.  Each pattern is a map of key-value pairs.  You can
      * either pass a single pattern or an array of patterns.
-     * @param SS_List $dataObjectSet The {@link SS_List} to test.
+     * @param SS_List $list The {@link SS_List} to test.
      *
      * Examples
      * --------
      * Check that $members includes an entry with Email = sam@example.com:
-     *      $this->assertDOSContains(array('Email' => '...@example.com'), $members);
+     *      $this->assertListContains(['Email' => '...@example.com'], $members);
      *
      * Check that $members includes entries with Email = sam@example.com and with
      * Email = ingo@example.com:
-     *      $this->assertDOSContains(array(
-     *         array('Email' => '...@example.com'),
-     *         array('Email' => 'i...@example.com'),
-     *      ), $members);
+     *      $this->assertListContains([
+     *         ['Email' => '...@example.com'],
+     *         ['Email' => 'i...@example.com'],
+     *      ], $members);
      */
-    public function assertDOSContains($matches, $dataObjectSet)
+    public function assertListContains($matches, $list)
     {
         $extracted = array();
-        foreach ($dataObjectSet as $object) {
+        foreach ($list as $object) {
             /** @var DataObject $object */
             $extracted[] = $object->toMap();
         }
@@ -632,33 +632,45 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
                 $matched,
                 "Failed asserting that the SS_List contains an item matching "
                 . var_export($match, true) . "\n\nIn the following SS_List:\n"
-                . $this->DOSSummaryForMatch($dataObjectSet, $match)
+                . $this->ListSummaryForMatch($list, $match)
             );
         }
     }
+
+    /**
+     * @deprecated 4.0.0:5.0.0 Use assertListContains() instead
+     *
+     * @param $matches
+     * @param $dataObjectSet
+     */
+    public function assertDOSContains($matches, $dataObjectSet) {
+        Deprecation::notice('5.0', 'Use assertListContains() instead');
+        return $this->assertListContains($matches, $dataObjectSet);
+    }
+
     /**
      * Asserts that no items in a given list appear in the given dataobject list
      *
      * @param SS_List|array $matches The patterns to match.  Each pattern is a map of key-value pairs.  You can
      * either pass a single pattern or an array of patterns.
-     * @param SS_List $dataObjectSet The {@link SS_List} to test.
+     * @param SS_List $list The {@link SS_List} to test.
      *
      * Examples
      * --------
      * Check that $members doesn't have an entry with Email = sam@example.com:
-     *      $this->assertNotDOSContains(array('Email' => '...@example.com'), $members);
+     *      $this->assertNotListContains(['Email' => '...@example.com'], $members);
      *
      * Check that $members doesn't have entries with Email = sam@example.com and with
      * Email = ingo@example.com:
-     *      $this->assertNotDOSContains(array(
-     *         array('Email' => '...@example.com'),
-     *         array('Email' => 'i...@example.com'),
-     *      ), $members);
+     *      $this->assertNotListContains([
+     *          ['Email' => '...@example.com'],
+     *          ['Email' => 'i...@example.com'],
+     *      ], $members);
      */
-    public function assertNotDOSContains($matches, $dataObjectSet)
+    public function assertNotListContains($matches, SS_List $list)
     {
         $extracted = array();
-        foreach ($dataObjectSet as $object) {
+        foreach ($list as $object) {
             /** @var DataObject $object */
             $extracted[] = $object->toMap();
         }
@@ -682,6 +694,17 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     }
 
     /**
+     * @deprecated 4.0.0:5.0.0 Use assertNotListContains() instead
+     *
+     * @param $matches
+     * @param $dataObjectSet
+     */
+    public function assertNotDOSContains($matches, $dataObjectSet) {
+        Deprecation::notice('5.0', 'Use assertNotListContains() instead');
+        return $this->assertNotListContains($matches, $dataObjectSet);
+    }
+
+    /**
      * Assert that the given {@link SS_List} includes only DataObjects matching the given
      * key-value pairs.  Each match must correspond to 1 distinct record.
      *
@@ -689,21 +712,21 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * --------
      * Check that *only* the entries Sam Minnee and Ingo Schommer exist in $members.  Order doesn't
      * matter:
-     *     $this->assertDOSEquals(array(
-     *        array('FirstName' =>'Sam', 'Surname' => 'Minnee'),
-     *        array('FirstName' => 'Ingo', 'Surname' => 'Schommer'),
-     *      ), $members);
+     *     $this->assertListEquals([
+     *        '[FirstName' =>'Sam', 'Surname' => 'Minnee'],
+     *        ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
+     *      ], $members);
      *
      * @param mixed $matches The patterns to match.  Each pattern is a map of key-value pairs.  You can
      * either pass a single pattern or an array of patterns.
-     * @param mixed $dataObjectSet The {@link SS_List} to test.
+     * @param mixed $list The {@link SS_List} to test.
      */
-    public function assertDOSEquals($matches, $dataObjectSet)
+    public function assertListEquals($matches, SS_List $list)
     {
         // Extract dataobjects
         $extracted = array();
-        if ($dataObjectSet) {
-            foreach ($dataObjectSet as $object) {
+        if ($list) {
+            foreach ($list as $object) {
                 /** @var DataObject $object */
                 $extracted[] = $object->toMap();
             }
@@ -727,12 +750,12 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
                     $matched,
                     "Failed asserting that the SS_List contains an item matching "
                     . var_export($match, true) . "\n\nIn the following SS_List:\n"
-                    . $this->DOSSummaryForMatch($dataObjectSet, $match)
+                    . $this->ListSummaryForMatch($list, $match)
                 );
             }
         }
 
-        // If we have leftovers than the DOS has extra data that shouldn't be there
+        // If we have leftovers than the List has extra data that shouldn't be there
         $this->assertTrue(
             (count($extracted) == 0),
             // If we didn't break by this point then we couldn't find a match
@@ -742,21 +765,35 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     }
 
     /**
+     * @deprecated 4.0.0:5.0.0 Use assertListEquals() instead
+     *
+     * @param $matches
+     * @param SS_List $dataObjectSet
+     */
+    public function assertDOSEquals($matches, $dataObjectSet)
+    {
+        Deprecation::notice('5.0', 'Use assertListEquals() instead');
+        return $this->assertListEquals($matches, $dataObjectSet);
+    }
+
+
+
+    /**
      * Assert that the every record in the given {@link SS_List} matches the given key-value
      * pairs.
      *
      * Example
      * --------
      * Check that every entry in $members has a Status of 'Active':
-     *     $this->assertDOSAllMatch(array('Status' => 'Active'), $members);
+     *     $this->assertListAllMatch(['Status' => 'Active'], $members);
      *
      * @param mixed $match The pattern to match.  The pattern is a map of key-value pairs.
-     * @param mixed $dataObjectSet The {@link SS_List} to test.
+     * @param mixed $list The {@link SS_List} to test.
      */
-    public function assertDOSAllMatch($match, $dataObjectSet)
+    public function assertListAllMatch($match, SS_List $list)
     {
         $extracted = array();
-        foreach ($dataObjectSet as $object) {
+        foreach ($list as $object) {
             /** @var DataObject $object */
             $extracted[] = $object->toMap();
         }
@@ -768,6 +805,18 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
                 . var_export($match, true) . ": " . var_export($item, true)
             );
         }
+    }
+
+    /**
+     * @deprecated 4.0.0:5.0.0 Use assertListAllMatch() instead
+     *
+     * @param $match
+     * @param SS_List $dataObjectSet
+     */
+    public function assertDOSAllMatch($match, SS_List $dataObjectSet)
+    {
+        Deprecation::notice('5.0', 'Use assertListAllMatch() instead');
+        return $this->assertListAllMatch($match, $dataObjectSet);
     }
 
     /**
@@ -854,7 +903,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     }
 
     /**
-     * Helper function for the DOS matchers
+     * Helper function for the List matchers
      *
      * @param array $item
      * @param array $match
@@ -871,16 +920,16 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     }
 
     /**
-     * Helper function for the DOS matchers
+     * Helper function for the List matchers
      *
-     * @param SS_List|array $dataObjectSet
+     * @param SS_List|array $list
      * @param array $match
      * @return string
      */
-    private function DOSSummaryForMatch($dataObjectSet, $match)
+    private function ListSummaryForMatch($list, $match)
     {
         $extracted = array();
-        foreach ($dataObjectSet as $item) {
+        foreach ($list as $item) {
             $extracted[] = array_intersect_key($item->toMap(), $match);
         }
         return var_export($extracted, true);

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -632,7 +632,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
                 $matched,
                 "Failed asserting that the SS_List contains an item matching "
                 . var_export($match, true) . "\n\nIn the following SS_List:\n"
-                . static::ListSummaryForMatch($list, $match)
+                . static::listSummaryForMatch($list, $match)
             );
         }
     }
@@ -643,7 +643,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param $matches
      * @param $dataObjectSet
      */
-    public static function assertDOSContains($matches, $dataObjectSet) {
+    public function assertDOSContains($matches, $dataObjectSet) {
         Deprecation::notice('5.0', 'Use assertListContains() instead');
         return static::assertListContains($matches, $dataObjectSet);
     }
@@ -687,7 +687,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
             // We couldn't find a match - assertion failed
             static::assertEmpty(
                 $matched,
-                "Failed asserting that the SS_List dosn't contain a set of objects. "
+                "Failed asserting that the SS_List doesn't contain a set of objects. "
                 . "Found objects were: " . var_export($matched, true)
             );
         }
@@ -750,7 +750,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
                     $matched,
                     "Failed asserting that the SS_List contains an item matching "
                     . var_export($match, true) . "\n\nIn the following SS_List:\n"
-                    . static::ListSummaryForMatch($list, $match)
+                    . static::listSummaryForMatch($list, $match)
                 );
             }
         }
@@ -770,7 +770,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param $matches
      * @param SS_List $dataObjectSet
      */
-    public static function assertDOSEquals($matches, $dataObjectSet)
+    public function assertDOSEquals($matches, $dataObjectSet)
     {
         Deprecation::notice('5.0', 'Use assertListEquals() instead');
         return static::assertListEquals($matches, $dataObjectSet);
@@ -813,7 +813,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param $match
      * @param SS_List $dataObjectSet
      */
-    public static function assertDOSAllMatch($match, SS_List $dataObjectSet)
+    public function assertDOSAllMatch($match, SS_List $dataObjectSet)
     {
         Deprecation::notice('5.0', 'Use assertListAllMatch() instead');
         return static::assertListAllMatch($match, $dataObjectSet);
@@ -926,7 +926,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param array $match
      * @return string
      */
-    private static function ListSummaryForMatch($list, $match)
+    private static function listSummaryForMatch($list, $match)
     {
         $extracted = array();
         foreach ($list as $item) {

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -713,7 +713,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * Check that *only* the entries Sam Minnee and Ingo Schommer exist in $members.  Order doesn't
      * matter:
      *     $this->assertListEquals([
-     *        '[FirstName' =>'Sam', 'Surname' => 'Minnee'],
+     *        ['FirstName' =>'Sam', 'Surname' => 'Minnee'],
      *        ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
      *      ], $members);
      *

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -242,7 +242,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
         $fixtureFiles = $this->getFixturePaths();
 
         // Set up fixture
-        if ($fixtureFiles || $this->usesDatabase) {
+        if ($this->setupDatabaseForCurrentTest($fixtureFiles)) {
             if (!static::$tempDB->isUsed()) {
                 static::$tempDB->build();
             }
@@ -278,6 +278,48 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
         Email::config()->remove('send_all_emails_from');
         Email::config()->remove('cc_all_emails_to');
         Email::config()->remove('bcc_all_emails_to');
+    }
+
+
+
+    /**
+     * Helper method to determine if the current test should enable a test database
+     *
+     * @param $fixtureFiles
+     * @return bool
+     */
+    protected function setupDatabaseForCurrentTest($fixtureFiles): bool
+    {
+        $databaseEnabledByDefault = $fixtureFiles || $this->usesDatabase;
+
+        return ($databaseEnabledByDefault && !$this->currentTestDisablesDatabase())
+            || $this->currentTestEnablesDatabase();
+    }
+
+    /**
+     * Helper method to check, if the current test uses the database.
+     * This can be switched on with the annotation "@useDatabase"
+     *
+     * @return bool
+     */
+    protected function currentTestEnablesDatabase() {
+        $annotations = $this->getAnnotations();
+
+        return array_key_exists('useDatabase', $annotations['method'])
+            && $annotations['method']['useDatabase'][0] !== 'false';
+    }
+
+    /**
+     * Helper method to check, if the current test uses the database.
+     * This can be switched on with the annotation "@useDatabase false"
+     *
+     * @return bool
+     */
+    protected function currentTestDisablesDatabase() {
+        $annotations = $this->getAnnotations();
+
+        return array_key_exists('useDatabase', $annotations['method'])
+            && $annotations['method']['useDatabase'][0] === 'false';
     }
 
     /**

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -307,7 +307,8 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @return bool
      */
-    protected function currentTestEnablesDatabase() {
+    protected function currentTestEnablesDatabase()
+    {
         $annotations = $this->getAnnotations();
 
         return array_key_exists('useDatabase', $annotations['method'])
@@ -320,7 +321,8 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @return bool
      */
-    protected function currentTestDisablesDatabase() {
+    protected function currentTestDisablesDatabase()
+    {
         $annotations = $this->getAnnotations();
 
         return array_key_exists('useDatabase', $annotations['method'])
@@ -679,7 +681,8 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param $matches
      * @param $dataObjectSet
      */
-    public function assertDOSContains($matches, $dataObjectSet) {
+    public function assertDOSContains($matches, $dataObjectSet)
+    {
         Deprecation::notice('5.0', 'Use assertListContains() instead');
         return static::assertListContains($matches, $dataObjectSet);
     }
@@ -731,7 +734,8 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param $matches
      * @param $dataObjectSet
      */
-    public static function assertNotDOSContains($matches, $dataObjectSet) {
+    public static function assertNotDOSContains($matches, $dataObjectSet)
+    {
         Deprecation::notice('5.0', 'Use assertListNotContains() instead');
         return static::assertListNotContains($matches, $dataObjectSet);
     }

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -911,39 +911,6 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     }
 
     /**
-     * Helper function for the List matchers
-     *
-     * @param array $item
-     * @param array $match
-     * @return bool
-     */
-    private static function dataObjectArrayMatch($item, $match)
-    {
-        foreach ($match as $k => $v) {
-            if (!array_key_exists($k, $item) || $item[$k] != $v) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Helper function for the List matchers
-     *
-     * @param SS_List|array $list
-     * @param array $match
-     * @return string
-     */
-    private static function listSummaryForMatch($list, $match)
-    {
-        $extracted = array();
-        foreach ($list as $item) {
-            $extracted[] = array_intersect_key($item->toMap(), $match);
-        }
-        return var_export($extracted, true);
-    }
-
-    /**
      * Start test environment
      */
     public static function start()

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -540,7 +540,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @return array|null Contains keys: 'Type', 'To', 'From', 'Subject', 'Content', 'PlainContent', 'AttachedFiles',
      *               'HtmlContent'
      */
-    public function findEmail($to, $from = null, $subject = null, $content = null)
+    public static function findEmail($to, $from = null, $subject = null, $content = null)
     {
         /** @var Mailer $mailer */
         $mailer = Injector::inst()->get(Mailer::class);
@@ -559,9 +559,9 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param string $subject
      * @param string $content
      */
-    public function assertEmailSent($to, $from = null, $subject = null, $content = null)
+    public static function assertEmailSent($to, $from = null, $subject = null, $content = null)
     {
-        $found = (bool)$this->findEmail($to, $from, $subject, $content);
+        $found = (bool)static::findEmail($to, $from, $subject, $content);
 
         $infoParts = "";
         $withParts = array();
@@ -581,7 +581,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
             $infoParts .= " with " . implode(" and ", $withParts);
         }
 
-        $this->assertTrue(
+        static::assertTrue(
             $found,
             "Failed asserting that an email was sent$infoParts."
         );
@@ -608,7 +608,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *         ['Email' => 'i...@example.com'],
      *      ], $members);
      */
-    public function assertListContains($matches, $list)
+    public static function assertListContains($matches, $list)
     {
         $extracted = array();
         foreach ($list as $object) {
@@ -619,7 +619,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
         foreach ($matches as $match) {
             $matched = false;
             foreach ($extracted as $i => $item) {
-                if ($this->dataObjectArrayMatch($item, $match)) {
+                if (static::dataObjectArrayMatch($item, $match)) {
                     // Remove it from $extracted so that we don't get duplicate mapping.
                     unset($extracted[$i]);
                     $matched = true;
@@ -628,11 +628,11 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
             }
 
             // We couldn't find a match - assertion failed
-            $this->assertTrue(
+            static::assertTrue(
                 $matched,
                 "Failed asserting that the SS_List contains an item matching "
                 . var_export($match, true) . "\n\nIn the following SS_List:\n"
-                . $this->ListSummaryForMatch($list, $match)
+                . static::ListSummaryForMatch($list, $match)
             );
         }
     }
@@ -643,9 +643,9 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param $matches
      * @param $dataObjectSet
      */
-    public function assertDOSContains($matches, $dataObjectSet) {
+    public static function assertDOSContains($matches, $dataObjectSet) {
         Deprecation::notice('5.0', 'Use assertListContains() instead');
-        return $this->assertListContains($matches, $dataObjectSet);
+        return static::assertListContains($matches, $dataObjectSet);
     }
 
     /**
@@ -667,7 +667,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *          ['Email' => 'i...@example.com'],
      *      ], $members);
      */
-    public function assertNotListContains($matches, SS_List $list)
+    public static function assertNotListContains($matches, SS_List $list)
     {
         $extracted = array();
         foreach ($list as $object) {
@@ -678,14 +678,14 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
         $matched = [];
         foreach ($matches as $match) {
             foreach ($extracted as $i => $item) {
-                if ($this->dataObjectArrayMatch($item, $match)) {
+                if (static::dataObjectArrayMatch($item, $match)) {
                     $matched[] = $extracted[$i];
                     break;
                 }
             }
 
             // We couldn't find a match - assertion failed
-            $this->assertEmpty(
+            static::assertEmpty(
                 $matched,
                 "Failed asserting that the SS_List dosn't contain a set of objects. "
                 . "Found objects were: " . var_export($matched, true)
@@ -699,9 +699,9 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param $matches
      * @param $dataObjectSet
      */
-    public function assertNotDOSContains($matches, $dataObjectSet) {
+    public static function assertNotDOSContains($matches, $dataObjectSet) {
         Deprecation::notice('5.0', 'Use assertNotListContains() instead');
-        return $this->assertNotListContains($matches, $dataObjectSet);
+        return static::assertNotListContains($matches, $dataObjectSet);
     }
 
     /**
@@ -721,7 +721,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * either pass a single pattern or an array of patterns.
      * @param mixed $list The {@link SS_List} to test.
      */
-    public function assertListEquals($matches, SS_List $list)
+    public static function assertListEquals($matches, SS_List $list)
     {
         // Extract dataobjects
         $extracted = array();
@@ -737,7 +737,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
             foreach ($matches as $match) {
                 $matched = false;
                 foreach ($extracted as $i => $item) {
-                    if ($this->dataObjectArrayMatch($item, $match)) {
+                    if (static::dataObjectArrayMatch($item, $match)) {
                         // Remove it from $extracted so that we don't get duplicate mapping.
                         unset($extracted[$i]);
                         $matched = true;
@@ -746,17 +746,17 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
                 }
 
                 // We couldn't find a match - assertion failed
-                $this->assertTrue(
+                static::assertTrue(
                     $matched,
                     "Failed asserting that the SS_List contains an item matching "
                     . var_export($match, true) . "\n\nIn the following SS_List:\n"
-                    . $this->ListSummaryForMatch($list, $match)
+                    . static::ListSummaryForMatch($list, $match)
                 );
             }
         }
 
         // If we have leftovers than the List has extra data that shouldn't be there
-        $this->assertTrue(
+        static::assertTrue(
             (count($extracted) == 0),
             // If we didn't break by this point then we couldn't find a match
             "Failed asserting that the SS_List contained only the given items, the "
@@ -770,10 +770,10 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param $matches
      * @param SS_List $dataObjectSet
      */
-    public function assertDOSEquals($matches, $dataObjectSet)
+    public static function assertDOSEquals($matches, $dataObjectSet)
     {
         Deprecation::notice('5.0', 'Use assertListEquals() instead');
-        return $this->assertListEquals($matches, $dataObjectSet);
+        return static::assertListEquals($matches, $dataObjectSet);
     }
 
 
@@ -790,7 +790,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param mixed $match The pattern to match.  The pattern is a map of key-value pairs.
      * @param mixed $list The {@link SS_List} to test.
      */
-    public function assertListAllMatch($match, SS_List $list)
+    public static function assertListAllMatch($match, SS_List $list)
     {
         $extracted = array();
         foreach ($list as $object) {
@@ -799,8 +799,8 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
         }
 
         foreach ($extracted as $i => $item) {
-            $this->assertTrue(
-                $this->dataObjectArrayMatch($item, $match),
+            static::assertTrue(
+                static::dataObjectArrayMatch($item, $match),
                 "Failed asserting that the the following item matched "
                 . var_export($match, true) . ": " . var_export($item, true)
             );
@@ -813,10 +813,10 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param $match
      * @param SS_List $dataObjectSet
      */
-    public function assertDOSAllMatch($match, SS_List $dataObjectSet)
+    public static function assertDOSAllMatch($match, SS_List $dataObjectSet)
     {
         Deprecation::notice('5.0', 'Use assertListAllMatch() instead');
-        return $this->assertListAllMatch($match, $dataObjectSet);
+        return static::assertListAllMatch($match, $dataObjectSet);
     }
 
     /**
@@ -826,7 +826,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param string $sql
      * @return string The cleaned and normalised SQL string
      */
-    protected function normaliseSQL($sql)
+    protected static function normaliseSQL($sql)
     {
         return trim(preg_replace('/\s+/m', ' ', $sql));
     }
@@ -842,7 +842,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param boolean $canonicalize
      * @param boolean $ignoreCase
      */
-    public function assertSQLEquals(
+    public static function assertSQLEquals(
         $expectedSQL,
         $actualSQL,
         $message = '',
@@ -852,10 +852,10 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
         $ignoreCase = false
     ) {
         // Normalise SQL queries to remove patterns of repeating whitespace
-        $expectedSQL = $this->normaliseSQL($expectedSQL);
-        $actualSQL = $this->normaliseSQL($actualSQL);
+        $expectedSQL = static::normaliseSQL($expectedSQL);
+        $actualSQL = static::normaliseSQL($actualSQL);
 
-        $this->assertEquals($expectedSQL, $actualSQL, $message, $delta, $maxDepth, $canonicalize, $ignoreCase);
+        static::assertEquals($expectedSQL, $actualSQL, $message, $delta, $maxDepth, $canonicalize, $ignoreCase);
     }
 
     /**
@@ -867,17 +867,17 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param boolean $ignoreCase
      * @param boolean $checkForObjectIdentity
      */
-    public function assertSQLContains(
+    public static function assertSQLContains(
         $needleSQL,
         $haystackSQL,
         $message = '',
         $ignoreCase = false,
         $checkForObjectIdentity = true
     ) {
-        $needleSQL = $this->normaliseSQL($needleSQL);
-        $haystackSQL = $this->normaliseSQL($haystackSQL);
+        $needleSQL = static::normaliseSQL($needleSQL);
+        $haystackSQL = static::normaliseSQL($haystackSQL);
 
-        $this->assertContains($needleSQL, $haystackSQL, $message, $ignoreCase, $checkForObjectIdentity);
+        static::assertContains($needleSQL, $haystackSQL, $message, $ignoreCase, $checkForObjectIdentity);
     }
 
     /**
@@ -889,17 +889,17 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param boolean $ignoreCase
      * @param boolean $checkForObjectIdentity
      */
-    public function assertSQLNotContains(
+    public static function assertSQLNotContains(
         $needleSQL,
         $haystackSQL,
         $message = '',
         $ignoreCase = false,
         $checkForObjectIdentity = true
     ) {
-        $needleSQL = $this->normaliseSQL($needleSQL);
-        $haystackSQL = $this->normaliseSQL($haystackSQL);
+        $needleSQL = static::normaliseSQL($needleSQL);
+        $haystackSQL = static::normaliseSQL($haystackSQL);
 
-        $this->assertNotContains($needleSQL, $haystackSQL, $message, $ignoreCase, $checkForObjectIdentity);
+        static::assertNotContains($needleSQL, $haystackSQL, $message, $ignoreCase, $checkForObjectIdentity);
     }
 
     /**
@@ -909,7 +909,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param array $match
      * @return bool
      */
-    private function dataObjectArrayMatch($item, $match)
+    private static function dataObjectArrayMatch($item, $match)
     {
         foreach ($match as $k => $v) {
             if (!array_key_exists($k, $item) || $item[$k] != $v) {
@@ -926,7 +926,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param array $match
      * @return string
      */
-    private function ListSummaryForMatch($list, $match)
+    private static function ListSummaryForMatch($list, $match)
     {
         $extracted = array();
         foreach ($list as $item) {

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -293,7 +293,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param $fixtureFiles
      * @return bool
      */
-    protected function setupDatabaseForCurrentTest($fixtureFiles): bool
+    protected function setupDatabaseForCurrentTest($fixtureFiles)
     {
         $databaseEnabledByDefault = $fixtureFiles || $this->usesDatabase;
 
@@ -644,6 +644,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param SS_List|array $matches The patterns to match.  Each pattern is a map of key-value pairs.  You can
      * either pass a single pattern or an array of patterns.
      * @param SS_List $list The {@link SS_List} to test.
+     * @param string $message
      *
      * Examples
      * --------
@@ -693,6 +694,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param SS_List|array $matches The patterns to match.  Each pattern is a map of key-value pairs.  You can
      * either pass a single pattern or an array of patterns.
      * @param SS_List $list The {@link SS_List} to test.
+     * @param string $message
      *
      * Examples
      * --------
@@ -756,6 +758,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param mixed $matches The patterns to match.  Each pattern is a map of key-value pairs.  You can
      * either pass a single pattern or an array of patterns.
      * @param mixed $list The {@link SS_List} to test.
+     * @param string $message
      */
     public static function assertListEquals($matches, SS_List $list, $message = '')
     {

--- a/tests/php/Control/ControllerTest.php
+++ b/tests/php/Control/ControllerTest.php
@@ -292,9 +292,12 @@ class ControllerTest extends FunctionalTest
         Security::setCurrentUser(null);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid allowed_action '*'
+     */
     public function testWildcardAllowedActions()
     {
-        $this->setExpectedException(InvalidArgumentException::class, "Invalid allowed_action '*'");
         $this->get('AccessWildcardSecuredController');
     }
 

--- a/tests/php/Dev/SSListContainsOnlyMatchingItemsTest.php
+++ b/tests/php/Dev/SSListContainsOnlyMatchingItemsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SilverStripe\Dev\Tests;
+
+use SilverStripe\Dev\Constraint\SSListContainsOnly;
+use SilverStripe\Dev\Constraint\SSListContainsOnlyMatchingItems;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\Security\Member;
+
+class SSListContainsOnlyMatchingItemsTest extends SapphireTest
+{
+    public function testEvaluateListMatchesCorrectly()
+    {
+        $constraint = new SSListContainsOnlyMatchingItems(['IsActive' => 1]);
+
+        $this->assertTrue($constraint->evaluate($this->getListToMatch(), '', true));
+    }
+
+    /**
+     * @return ArrayList|Member[]
+     */
+    private function getListToMatch()
+    {
+        $list = ArrayList::create();
+        $list->push(Member::create(['FirstName' => 'Ingo', 'Surname' => 'Schommer', 'IsActive' => 1]));
+        $list->push(Member::create(['FirstName' => 'Sam', 'Surname' => 'Minnee', 'IsActive' => 1]));
+
+        return $list;
+    }
+
+
+    public function testEvaluateListDoesNotMatchWrongMatches()
+    {
+        $constraint = new SSListContainsOnlyMatchingItems(['IsActive' => 1]);
+
+        $failingList = $this->getListToMatch();
+        $failingList->push(Member::create(['FirstName' => 'Foo', 'IsActive' => 0]));
+
+        $this->assertFalse($constraint->evaluate($failingList, '', true));
+    }
+}

--- a/tests/php/Dev/SSListContainsOnlyTest.php
+++ b/tests/php/Dev/SSListContainsOnlyTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SilverStripe\Dev\Tests;
+
+use SilverStripe\Dev\Constraint\SSListContainsOnly;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\Security\Member;
+
+class SSListContainsOnlyTest extends SapphireTest
+{
+    public function provideMatchesForList()
+    {
+        return [
+            [
+                [
+                    ['FirstName' => 'Ingo'],
+                    ['Surname' => 'Minnee']
+                ]
+            ],
+            [
+                [
+                    ['FirstName' => 'Sam', 'Surname' => 'Minnee'], //Sam Minee or Ingo
+                    ['FirstName' => 'Ingo']
+                ]
+            ],
+        ];
+    }
+
+
+    public function provideInvalidMatchesForList()
+    {
+        return [
+            [
+                [['FirstName' => 'AnyoneNotInList']]
+            ],
+            [
+                [['Surname' => 'NotInList']]
+            ],
+            [
+                [['FirstName' => 'Ingo', 'Surname' => 'Minnee']] //more matches in List
+            ],
+            [
+                [
+                    ['FirstName' => 'Ingo', 'Surname' => 'Minnee'], //mixed
+                    ['FirstName' => 'NotInList']
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMatchesForList()
+     *
+     * @param $matches
+     */
+    public function testEvaluateListMatchesCorrectly($matches)
+    {
+        $constraint = new SSListContainsOnly($matches);
+
+        $this->assertTrue($constraint->evaluate($this->getListToMatch(), '', true));
+    }
+
+    /**
+     * @return ArrayList|Member[]
+     */
+    private function getListToMatch()
+    {
+        $list = ArrayList::create();
+        $list->push(Member::create(['FirstName' => 'Ingo', 'Surname' => 'Schommer']));
+        $list->push(Member::create(['FirstName' => 'Sam', 'Surname' => 'Minnee']));
+
+        return $list;
+    }
+
+    /**
+     * @dataProvider provideInvalidMatchesForList()
+     *
+     * @param $matches
+     */
+    public function testEvaluateListDoesNotMatchWrongMatches($matches)
+    {
+        $constraint = new SSListContainsOnly($matches);
+
+        $this->assertFalse($constraint->evaluate($this->getListToMatch(), '', true));
+    }
+}

--- a/tests/php/Dev/SSListContainsTest.php
+++ b/tests/php/Dev/SSListContainsTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace SilverStripe\Dev\Tests;
+
+use SilverStripe\Dev\Constraint\SSListContains;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\Security\Member;
+
+class SSListContainsTest extends SapphireTest
+{
+    public function provideMatchesForList()
+    {
+        return [
+            [
+                [['FirstName' => 'Ingo']]
+            ],
+            [
+                [['Surname' => 'Minnee']]
+            ],
+            [
+                [['FirstName' => 'Sam', 'Surname' => 'Minnee']]
+            ],
+            [
+                [
+                    ['FirstName' => 'Sam', 'Surname' => 'Minnee'], //Sam Minee or Ingo
+                    ['FirstName' => 'Ingo']
+                ]
+            ],
+        ];
+    }
+
+
+    public function provideInvalidMatchesForList()
+    {
+        return [
+            [
+                [['FirstName' => 'AnyoneNotInList']]
+            ],
+            [
+                [['Surname' => 'NotInList']]
+            ],
+            [
+                [['FirstName' => 'Ingo', 'Surname' => 'Minnee']]
+            ],
+            [
+                [
+                    ['FirstName' => 'Ingo', 'Surname' => 'Minnee'],
+                    ['FirstName' => 'NotInList']
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMatchesForList()
+     *
+     * @param $matches
+     */
+    public function testEvaluateListMatchesCorrectly($matches)
+    {
+        $constraint = new SSListContains($matches);
+
+        $this->assertTrue($constraint->evaluate($this->getListToMatch(), '', true));
+    }
+
+    /**
+     * @dataProvider provideInvalidMatchesForList()
+     *
+     * @param $matches
+     */
+    public function testEvaluateListDoesNotMatchWrongMatches($matches)
+    {
+        $constraint = new SSListContains($matches);
+
+        $this->assertFalse($constraint->evaluate($this->getListToMatch(), '', true));
+    }
+
+    /**
+     * @return ArrayList|Member[]
+     */
+    private function getListToMatch()
+    {
+        $list = ArrayList::create();
+        $list->push(Member::create(['FirstName' => 'Ingo', 'Surname' => 'Schommer']));
+        $list->push(Member::create(['FirstName' => 'Sam', 'Surname' => 'Minnee']));
+        $list->push(Member::create(['FirstName' => 'Foo', 'Surname' => 'Bar']));
+
+        return $list;
+    }
+}

--- a/tests/php/Dev/SSListExporterTest.php
+++ b/tests/php/Dev/SSListExporterTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace SilverStripe\Dev\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\SSListExporter;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Member;
+use SilverStripe\View\ArrayData;
+
+class SSListExporterTest extends SapphireTest
+{
+
+    /**
+     * @var SSListExporter
+     */
+    private $exporter;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->exporter = new SSListExporter();
+    }
+
+    public function provideClassesForExport()
+    {
+        return [
+            [ArrayList::class, false],
+            [DataObject::class, false],
+            [DataList::class, Member::class],
+            [ArrayData::class, false]
+        ];
+    }
+
+    /**
+     * @dataProvider provideClassesForExport()
+     * @param $className
+     * @param $constructorParam
+     */
+    public function testExportStartsWithClassName($className, $constructorParam)
+    {
+        $obj = $constructorParam
+            ? $className::create($constructorParam)
+            : $className::create();
+
+        $export = ltrim($this->exporter->export($obj));
+
+        $this->assertStringStartsWith(get_class($obj), $export, 'Export should start with object\'s class name');
+    }
+
+
+    /**
+     * @testdox toMap() returns DataObjects's data
+     */
+    public function testToMapReturnsDataOfDataObjects()
+    {
+        $data = [
+            'Foo' => 'Bar',
+            'Baz' => 'Boom',
+            'One' => 'Two'
+        ];
+
+        $map = $this->exporter->toMap(DataObject::create($data));
+
+        $this->assertEquals($data, $map, 'Map should match data passed to DataObject');
+    }
+
+    /**
+     * @testdox toMap() returns ArrayData's data
+     */
+    public function testToMapReturnsDataOfArrayData()
+    {
+        $data = [
+            'Foo' => 'Bar',
+            'Baz' => 'Boom',
+            'One' => 'Two'
+        ];
+
+        $map = $this->exporter->toMap(ArrayData::create($data));
+
+        $this->assertEquals($data, $map, 'Map should match data passed to ArrayData');
+    }
+}

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -86,7 +86,7 @@ class SapphireTestTest extends SapphireTest
      *
      * @testdox assertion assertListAllMatch fails when not all items are matching
      *
-     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedException \PHPUnit_Framework_Error_Notice
      */
     public function testAssertListAllMatchFailsWhenNotMatchingAllItems($match, $itemsForList)
     {

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -3,32 +3,31 @@
 namespace SilverStripe\Dev\Tests;
 
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ArrayList;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 
 class SapphireTestTest extends SapphireTest
 {
-    public function testResolveFixturePath()
+
+    public function provideResolveFixturePath()
     {
-        // Same directory
+        return [
+            [__DIR__ . '/CsvBulkLoaderTest.yml', './CsvBulkLoaderTest.yml'], //same dir
+            [__DIR__ . '/CsvBulkLoaderTest.yml', 'CsvBulkLoaderTest.yml'],  // Filename only
+            [dirname(__DIR__) . '/ORM/DataObjectTest.yml', '../ORM/DataObjectTest.yml'], // Parent path
+            [dirname(__DIR__) . '/ORM/DataObjectTest.yml', dirname(__DIR__) .'/ORM/DataObjectTest.yml'], // Absolute path
+        ];
+    }
+
+    /**
+     * @dataProvider provideResolveFixturePath
+     */
+    public function testResolveFixturePath($expected, $path)
+    {
         $this->assertEquals(
-            __DIR__ . '/CsvBulkLoaderTest.yml',
-            $this->resolveFixturePath('./CsvBulkLoaderTest.yml')
-        );
-        // Filename only
-        $this->assertEquals(
-            __DIR__ . '/CsvBulkLoaderTest.yml',
-            $this->resolveFixturePath('CsvBulkLoaderTest.yml')
-        );
-        // Parent path
-        $this->assertEquals(
-            dirname(__DIR__) . '/ORM/DataObjectTest.yml',
-            $this->resolveFixturePath('../ORM/DataObjectTest.yml')
-        );
-        // Absolute path
-        $this->assertEquals(
-            dirname(__DIR__) . '/ORM/DataObjectTest.yml',
-            $this->resolveFixturePath(dirname(__DIR__) .'/ORM/DataObjectTest.yml')
+            $expected,
+            $this->resolveFixturePath($path)
         );
     }
 
@@ -50,5 +49,165 @@ class SapphireTestTest extends SapphireTest
         $this->assertCount(0, Member::get()->filter([ 'Email' => 'TESTPERM@example.org' ]));
         $this->createMemberWithPermission('TESTPERM');
         $this->assertCount(1, Member::get()->filter([ 'Email' => 'TESTPERM@example.org' ]));
+    }
+
+    /**
+     * @testdox Has assertion assertListAllMatch
+     */
+    public function testAssertListAllMatch()
+    {
+
+    }
+
+    /**
+     * @testdox Has assertion assertListContains
+     */
+    public function testAssertListContains()
+    {
+
+    }
+
+    /**
+     * @testdox Has assertion assertNotListContains
+     */
+    public function testAssertNotListContains()
+    {
+
+    }
+
+    public function provideEqualLists()
+    {
+        $oneItemList = [
+            ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
+        ];
+        $twoItemList = [
+            ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
+            ['FirstName' => 'Sam', 'Surname' => 'Minnee']
+        ];
+
+        return [
+            [ //empty list
+                [],
+                []
+            ],
+            [
+                [ //one param
+                    ['FirstName' => 'Ingo']
+                ]
+                , $oneItemList
+            ],
+            [
+                [ //two params
+                    ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
+                ],
+                $oneItemList
+            ],
+            [ //only one param
+                [
+                    ['FirstName' => 'Ingo'],
+                    ['FirstName' => 'Sam']
+                ]
+                , $twoItemList
+            ],
+            [
+                [ //two params
+                    ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
+                    ['FirstName' => 'Sam', 'Surname' => 'Minnee']
+                ],
+                $twoItemList
+            ],
+            [
+                [ //mixed
+                    ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
+                    ['FirstName' => 'Sam']
+                ],
+                $twoItemList
+            ],
+        ];
+    }
+    public function provideNonEqualLists()
+    {
+        $oneItemList = [
+            ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
+        ];
+        $twoItemList = [
+            ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
+            ['FirstName' => 'Sam', 'Surname' => 'Minnee']
+        ];
+
+        return [
+            [ //empty list
+                [
+                    ['FirstName' => 'Ingo']
+                ],
+                []
+            ],
+            [
+                [ //one item expected
+                    ['FirstName' => 'Ingo']
+                ]
+                , $twoItemList
+            ],
+            [ //one item with wrong param
+                [
+                    ['FirstName' => 'IngoXX'],
+                    ['FirstName' => 'Sam']
+                ]
+                , $twoItemList
+            ],
+            [
+                [ //two params wrong
+                    ['FirstName' => 'IngoXXX', 'Surname' => 'Schommer'],
+                    ['FirstName' => 'Sam', 'Surname' => 'MinneeXXX']
+                ],
+                $twoItemList
+            ],
+            [
+                [ //mixed
+                    ['FirstName' => 'Daniel', 'Surname' => 'Foo'],
+                    ['FirstName' => 'Dan']
+                ],
+                $twoItemList
+            ],
+        ];
+    }
+
+
+    /**
+     * @dataProvider provideEqualLists
+     * @testdox Has assertion assertListEquals
+     *
+     * @param $matches
+     * @param $itemsForList
+     */
+    public function testAssertListEquals($matches, $itemsForList)
+    {
+        //generate List as this is not possible in dataProvider
+        $list = ArrayList::create();
+        foreach ($itemsForList as $data) {
+            $list->push(Member::create($data));
+        }
+
+        $this->assertListEquals($matches, $list);
+    }
+
+    /**
+     * @dataProvider provideNonEqualLists
+     * @testdox assertion assertListEquals fails on non equal Lists
+     *
+     * @param $matches
+     * @param $itemsForList
+     *
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     */
+    public function testAssertListEqualsFailsOnNonEqualLists($matches, $itemsForList)
+    {
+        //generate List as this is not possible in dataProvider
+        $list = ArrayList::create();
+        foreach ($itemsForList as $data) {
+            $list->push(Member::create($data));
+        }
+
+        $this->assertListEquals($matches, $list);
     }
 }

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -16,10 +16,14 @@ class SapphireTestTest extends SapphireTest
     public function provideResolveFixturePath()
     {
         return [
-            [__DIR__ . '/CsvBulkLoaderTest.yml', './CsvBulkLoaderTest.yml'], //same dir
-            [__DIR__ . '/CsvBulkLoaderTest.yml', 'CsvBulkLoaderTest.yml'],  // Filename only
-            [dirname(__DIR__) . '/ORM/DataObjectTest.yml', '../ORM/DataObjectTest.yml'], // Parent path
-            [dirname(__DIR__) . '/ORM/DataObjectTest.yml', dirname(__DIR__) .'/ORM/DataObjectTest.yml'], // Absolute path
+            [__DIR__ . '/CsvBulkLoaderTest.yml', './CsvBulkLoaderTest.yml'],
+            //same dir
+            [__DIR__ . '/CsvBulkLoaderTest.yml', 'CsvBulkLoaderTest.yml'],
+            // Filename only
+            [dirname(__DIR__) . '/ORM/DataObjectTest.yml', '../ORM/DataObjectTest.yml'],
+            // Parent path
+            [dirname(__DIR__) . '/ORM/DataObjectTest.yml', dirname(__DIR__) . '/ORM/DataObjectTest.yml'],
+            // Absolute path
         ];
     }
 
@@ -49,9 +53,9 @@ class SapphireTestTest extends SapphireTest
 
     public function testCreateMemberWithPermission()
     {
-        $this->assertCount(0, Member::get()->filter([ 'Email' => 'TESTPERM@example.org' ]));
+        $this->assertCount(0, Member::get()->filter(['Email' => 'TESTPERM@example.org']));
         $this->createMemberWithPermission('TESTPERM');
-        $this->assertCount(1, Member::get()->filter([ 'Email' => 'TESTPERM@example.org' ]));
+        $this->assertCount(1, Member::get()->filter(['Email' => 'TESTPERM@example.org']));
     }
 
     /**
@@ -63,11 +67,7 @@ class SapphireTestTest extends SapphireTest
      */
     public function testAssertListAllMatch($match, $itemsForList)
     {
-        //generate List as this is not possible in dataProvider
-        $list = ArrayList::create();
-        foreach ($itemsForList as $data) {
-            $list->push(Member::create($data));
-        }
+        $list = $this->generateArrayListFromItems($itemsForList);
 
         $this->assertListAllMatch($match, $list);
     }
@@ -84,14 +84,11 @@ class SapphireTestTest extends SapphireTest
      */
     public function testAssertListAllMatchFailsWhenNotMatchingAllItems($match, $itemsForList)
     {
-        //generate List as this is not possible in dataProvider
-        $list = ArrayList::create();
-        foreach ($itemsForList as $data) {
-            $list->push(Member::create($data));
-        }
+        $list = $this->generateArrayListFromItems($itemsForList);
 
         $this->assertListAllMatch($match, $list);
     }
+
     /**
      * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideEqualListsWithEmptyList()
      *
@@ -101,14 +98,10 @@ class SapphireTestTest extends SapphireTest
      */
     public function testAssertListContains($matches, $itemsForList)
     {
-        //generate List as this is not possible in dataProvider
-        $list = ArrayList::create();
+        $list = $this->generateArrayListFromItems($itemsForList);
         $list->push(Member::create(['FirstName' => 'Foo', 'Surname' => 'Foo']));
         $list->push(Member::create(['FirstName' => 'Bar', 'Surname' => 'Bar']));
         $list->push(Member::create(['FirstName' => 'Baz', 'Surname' => 'Baz']));
-        foreach ($itemsForList as $data) {
-            $list->push(Member::create($data));
-        }
 
         $this->assertListContains($matches, $list);
     }
@@ -124,14 +117,10 @@ class SapphireTestTest extends SapphireTest
      */
     public function testAssertListContainsFailsIfListDoesNotContainMatch($matches, $itemsForList)
     {
-        //generate List as this is not possible in dataProvider
-        $list = ArrayList::create();
+        $list = $this->generateArrayListFromItems($itemsForList);
         $list->push(Member::create(['FirstName' => 'Foo', 'Surname' => 'Foo']));
         $list->push(Member::create(['FirstName' => 'Bar', 'Surname' => 'Bar']));
         $list->push(Member::create(['FirstName' => 'Baz', 'Surname' => 'Baz']));
-        foreach ($itemsForList as $data) {
-            $list->push(Member::create($data));
-        }
 
         $this->assertListContains($matches, $list);
     }
@@ -146,11 +135,7 @@ class SapphireTestTest extends SapphireTest
      */
     public function testAssertNotListContains($matches, $itemsForList)
     {
-        //generate List as this is not possible in dataProvider
-        $list = ArrayList::create();
-        foreach ($itemsForList as $data) {
-            $list->push(Member::create($data));
-        }
+        $list = $this->generateArrayListFromItems($itemsForList);
 
         $this->assertNotListContains($matches, $list);
     }
@@ -160,21 +145,16 @@ class SapphireTestTest extends SapphireTest
      *
      * @param $matches
      * @param $itemsForList
-
      * @testdox assertion assertNotListContains throws a exception when a matching item is found in the list
      *
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
      */
     public function testAssertNotListContainsFailsWhenListContainsAMatch($matches, $itemsForList)
     {
-        //generate List as this is not possible in dataProvider
-        $list = ArrayList::create();
+        $list = $this->generateArrayListFromItems($itemsForList);
         $list->push(Member::create(['FirstName' => 'Foo', 'Surname' => 'Foo']));
         $list->push(Member::create(['FirstName' => 'Bar', 'Surname' => 'Bar']));
         $list->push(Member::create(['FirstName' => 'Baz', 'Surname' => 'Baz']));
-        foreach ($itemsForList as $data) {
-            $list->push(Member::create($data));
-        }
 
         $this->assertNotListContains($matches, $list);
     }
@@ -189,11 +169,7 @@ class SapphireTestTest extends SapphireTest
      */
     public function testAssertListEquals($matches, $itemsForList)
     {
-        //generate List as this is not possible in dataProvider
-        $list = ArrayList::create();
-        foreach ($itemsForList as $data) {
-            $list->push(Member::create($data));
-        }
+        $list = $this->generateArrayListFromItems($itemsForList);
 
         $this->assertListEquals($matches, $list);
     }
@@ -209,12 +185,23 @@ class SapphireTestTest extends SapphireTest
      */
     public function testAssertListEqualsFailsOnNonEqualLists($matches, $itemsForList)
     {
-        //generate List as this is not possible in dataProvider
+        $list = $this->generateArrayListFromItems($itemsForList);
+
+        $this->assertListEquals($matches, $list);
+    }
+
+    /**
+     * generate SS_List as this is not possible in dataProvider
+     *
+     * @param $itemsForList array
+     * @return ArrayList
+     */
+    private function generateArrayListFromItems($itemsForList)
+    {
         $list = ArrayList::create();
         foreach ($itemsForList as $data) {
             $list->push(Member::create($data));
         }
-
-        $this->assertListEquals($matches, $list);
+        return $list;
     }
 }

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -56,15 +56,33 @@ class SapphireTestTest extends SapphireTest
      */
     public function testAssertListAllMatch()
     {
-
+        $this->markTestIncomplete();
     }
 
     /**
+     * @dataProvider provideEqualLists
+     *
+     * @param $matches
+     * @param $itemsForList
      * @testdox Has assertion assertListContains
      */
-    public function testAssertListContains()
+    public function testAssertListContains($matches, $itemsForList)
     {
+        //generate List as this is not possible in dataProvider
+        $list = ArrayList::create();
+        $list->push(Member::create(['FirstName' => 'Foo', 'Surname' => 'Foo']));
+        $list->push(Member::create(['FirstName' => 'Bar', 'Surname' => 'Bar']));
+        $list->push(Member::create(['FirstName' => 'Baz', 'Surname' => 'Baz']));
+        foreach ($itemsForList as $data) {
+            $list->push(Member::create($data));
+        }
 
+        $this->assertListContains($matches, $list);
+    }
+
+    public function testAssertListContainsFailsIfListDoesNotContainMatch()
+    {
+        $this->markTestIncomplete();
     }
 
     /**
@@ -72,7 +90,7 @@ class SapphireTestTest extends SapphireTest
      */
     public function testAssertNotListContains()
     {
-
+        $this->markTestIncomplete();
     }
 
     public function provideEqualLists()

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -134,16 +134,16 @@ class SapphireTestTest extends SapphireTest
     /**
      * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideNotContainingList
      *
-     * @testdox Has assertion assertNotListContains
+     * @testdox Has assertion assertListNotContains
      *
      * @param $matches
      * @param $itemsForList
      */
-    public function testAssertNotListContains($matches, $itemsForList)
+    public function testAssertListNotContains($matches, $itemsForList)
     {
         $list = $this->generateArrayListFromItems($itemsForList);
 
-        $this->assertNotListContains($matches, $list);
+        $this->assertListNotContains($matches, $list);
     }
 
     /**
@@ -151,18 +151,18 @@ class SapphireTestTest extends SapphireTest
      *
      * @param $matches
      * @param $itemsForList
-     * @testdox assertion assertNotListContains throws a exception when a matching item is found in the list
+     * @testdox assertion assertListNotContains throws a exception when a matching item is found in the list
      *
      * @expectedException \PHPUnit_Framework_ExpectationFailedException
      */
-    public function testAssertNotListContainsFailsWhenListContainsAMatch($matches, $itemsForList)
+    public function testAssertListNotContainsFailsWhenListContainsAMatch($matches, $itemsForList)
     {
         $list = $this->generateArrayListFromItems($itemsForList);
         $list->push(Member::create(['FirstName' => 'Foo', 'Surname' => 'Foo']));
         $list->push(Member::create(['FirstName' => 'Bar', 'Surname' => 'Bar']));
         $list->push(Member::create(['FirstName' => 'Baz', 'Surname' => 'Baz']));
 
-        $this->assertNotListContains($matches, $list);
+        $this->assertListNotContains($matches, $list);
     }
 
 

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -60,7 +60,7 @@ class SapphireTestTest extends SapphireTest
     }
 
     /**
-     * @dataProvider provideEqualLists
+     * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideEqualLists
      *
      * @param $matches
      * @param $itemsForList
@@ -93,106 +93,9 @@ class SapphireTestTest extends SapphireTest
         $this->markTestIncomplete();
     }
 
-    public function provideEqualLists()
-    {
-        $oneItemList = [
-            ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
-        ];
-        $twoItemList = [
-            ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
-            ['FirstName' => 'Sam', 'Surname' => 'Minnee']
-        ];
-
-        return [
-            [ //empty list
-                [],
-                []
-            ],
-            [
-                [ //one param
-                    ['FirstName' => 'Ingo']
-                ]
-                , $oneItemList
-            ],
-            [
-                [ //two params
-                    ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
-                ],
-                $oneItemList
-            ],
-            [ //only one param
-                [
-                    ['FirstName' => 'Ingo'],
-                    ['FirstName' => 'Sam']
-                ]
-                , $twoItemList
-            ],
-            [
-                [ //two params
-                    ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
-                    ['FirstName' => 'Sam', 'Surname' => 'Minnee']
-                ],
-                $twoItemList
-            ],
-            [
-                [ //mixed
-                    ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
-                    ['FirstName' => 'Sam']
-                ],
-                $twoItemList
-            ],
-        ];
-    }
-    public function provideNonEqualLists()
-    {
-        $oneItemList = [
-            ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
-        ];
-        $twoItemList = [
-            ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
-            ['FirstName' => 'Sam', 'Surname' => 'Minnee']
-        ];
-
-        return [
-            [ //empty list
-                [
-                    ['FirstName' => 'Ingo']
-                ],
-                []
-            ],
-            [
-                [ //one item expected
-                    ['FirstName' => 'Ingo']
-                ]
-                , $twoItemList
-            ],
-            [ //one item with wrong param
-                [
-                    ['FirstName' => 'IngoXX'],
-                    ['FirstName' => 'Sam']
-                ]
-                , $twoItemList
-            ],
-            [
-                [ //two params wrong
-                    ['FirstName' => 'IngoXXX', 'Surname' => 'Schommer'],
-                    ['FirstName' => 'Sam', 'Surname' => 'MinneeXXX']
-                ],
-                $twoItemList
-            ],
-            [
-                [ //mixed
-                    ['FirstName' => 'Daniel', 'Surname' => 'Foo'],
-                    ['FirstName' => 'Dan']
-                ],
-                $twoItemList
-            ],
-        ];
-    }
-
 
     /**
-     * @dataProvider provideEqualLists
+     * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideEqualLists
      * @testdox Has assertion assertListEquals
      *
      * @param $matches
@@ -210,7 +113,7 @@ class SapphireTestTest extends SapphireTest
     }
 
     /**
-     * @dataProvider provideNonEqualLists
+     * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideNonEqualLists
      * @testdox assertion assertListEquals fails on non equal Lists
      *
      * @param $matches

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -86,7 +86,7 @@ class SapphireTestTest extends SapphireTest
      *
      * @testdox assertion assertListAllMatch fails when not all items are matching
      *
-     * @expectedException \PHPUnit_Framework_Error_Notice
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
      */
     public function testAssertListAllMatchFailsWhenNotMatchingAllItems($match, $itemsForList)
     {

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -10,6 +10,9 @@ use SilverStripe\Security\Permission;
 class SapphireTestTest extends SapphireTest
 {
 
+    /**
+     * @return array
+     */
     public function provideResolveFixturePath()
     {
         return [
@@ -52,15 +55,45 @@ class SapphireTestTest extends SapphireTest
     }
 
     /**
+     * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideAllMatchingList()
+     *
+     * @param $match
+     * @param $itemsForList
      * @testdox Has assertion assertListAllMatch
      */
-    public function testAssertListAllMatch()
+    public function testAssertListAllMatch($match, $itemsForList)
     {
-        $this->markTestIncomplete();
+        //generate List as this is not possible in dataProvider
+        $list = ArrayList::create();
+        foreach ($itemsForList as $data) {
+            $list->push(Member::create($data));
+        }
+
+        $this->assertListAllMatch($match, $list);
     }
 
     /**
-     * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideEqualLists
+     * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideNotMatchingList()
+     *
+     * @param $match
+     * @param $itemsForList
+     *
+     * @testdox assertion assertListAllMatch fails when not all items are matching
+     *
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     */
+    public function testAssertListAllMatchFailsWhenNotMatchingAllItems($match, $itemsForList)
+    {
+        //generate List as this is not possible in dataProvider
+        $list = ArrayList::create();
+        foreach ($itemsForList as $data) {
+            $list->push(Member::create($data));
+        }
+
+        $this->assertListAllMatch($match, $list);
+    }
+    /**
+     * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideEqualListsWithEmptyList()
      *
      * @param $matches
      * @param $itemsForList
@@ -104,16 +137,51 @@ class SapphireTestTest extends SapphireTest
     }
 
     /**
+     * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideNotContainingList
+     *
      * @testdox Has assertion assertNotListContains
+     *
+     * @param $matches
+     * @param $itemsForList
      */
-    public function testAssertNotListContains()
+    public function testAssertNotListContains($matches, $itemsForList)
     {
-        $this->markTestIncomplete();
+        //generate List as this is not possible in dataProvider
+        $list = ArrayList::create();
+        foreach ($itemsForList as $data) {
+            $list->push(Member::create($data));
+        }
+
+        $this->assertNotListContains($matches, $list);
+    }
+
+    /**
+     * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideEqualLists
+     *
+     * @param $matches
+     * @param $itemsForList
+
+     * @testdox assertion assertNotListContains throws a exception when a matching item is found in the list
+     *
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     */
+    public function testAssertNotListContainsFailsWhenListContainsAMatch($matches, $itemsForList)
+    {
+        //generate List as this is not possible in dataProvider
+        $list = ArrayList::create();
+        $list->push(Member::create(['FirstName' => 'Foo', 'Surname' => 'Foo']));
+        $list->push(Member::create(['FirstName' => 'Bar', 'Surname' => 'Bar']));
+        $list->push(Member::create(['FirstName' => 'Baz', 'Surname' => 'Baz']));
+        foreach ($itemsForList as $data) {
+            $list->push(Member::create($data));
+        }
+
+        $this->assertNotListContains($matches, $list);
     }
 
 
     /**
-     * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideEqualLists
+     * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideEqualListsWithEmptyList()
      * @testdox Has assertion assertListEquals
      *
      * @param $matches

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -80,9 +80,27 @@ class SapphireTestTest extends SapphireTest
         $this->assertListContains($matches, $list);
     }
 
-    public function testAssertListContainsFailsIfListDoesNotContainMatch()
+    /**
+     * @dataProvider \SilverStripe\Dev\Tests\SapphireTestTest\DataProvider::provideNotContainingList
+     * @testdox assertion assertListEquals fails on non equal Lists
+     *
+     * @param $matches
+     * @param $itemsForList array
+     *
+     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     */
+    public function testAssertListContainsFailsIfListDoesNotContainMatch($matches, $itemsForList)
     {
-        $this->markTestIncomplete();
+        //generate List as this is not possible in dataProvider
+        $list = ArrayList::create();
+        $list->push(Member::create(['FirstName' => 'Foo', 'Surname' => 'Foo']));
+        $list->push(Member::create(['FirstName' => 'Bar', 'Surname' => 'Bar']));
+        $list->push(Member::create(['FirstName' => 'Baz', 'Surname' => 'Baz']));
+        foreach ($itemsForList as $data) {
+            $list->push(Member::create($data));
+        }
+
+        $this->assertListContains($matches, $list);
     }
 
     /**

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -38,6 +38,9 @@ class SapphireTestTest extends SapphireTest
         );
     }
 
+    /**
+     * @useDatabase
+     */
     public function testActWithPermission()
     {
         $this->logOut();
@@ -51,6 +54,9 @@ class SapphireTestTest extends SapphireTest
         });
     }
 
+    /**
+     * @useDatabase
+     */
     public function testCreateMemberWithPermission()
     {
         $this->assertCount(0, Member::get()->filter(['Email' => 'TESTPERM@example.org']));

--- a/tests/php/Dev/SapphireTestTest/DataProvider.php
+++ b/tests/php/Dev/SapphireTestTest/DataProvider.php
@@ -7,17 +7,17 @@ use SilverStripe\Dev\TestOnly;
 
 class DataProvider implements TestOnly
 {
+    protected static $oneItemList = [
+        ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
+    ];
+
+    protected static $twoItemList = [
+        ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
+        ['FirstName' => 'Sam', 'Surname' => 'Minnee']
+    ];
 
     public static function provideEqualLists()
     {
-        $oneItemList = [
-            ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
-        ];
-        $twoItemList = [
-            ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
-            ['FirstName' => 'Sam', 'Surname' => 'Minnee']
-        ];
-
         return [
             [ //empty list
                 [],
@@ -26,50 +26,41 @@ class DataProvider implements TestOnly
             [
                 [ //one param
                     ['FirstName' => 'Ingo']
-                ]
-                ,
-                $oneItemList
+                ],
+                self::$oneItemList
             ],
             [
                 [ //two params
                     ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
                 ],
-                $oneItemList
+                self::$oneItemList
             ],
             [ //only one param
                 [
                     ['FirstName' => 'Ingo'],
                     ['FirstName' => 'Sam']
-                ]
-                ,
-                $twoItemList
+                ],
+                self::$twoItemList
             ],
             [
                 [ //two params
                     ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
                     ['FirstName' => 'Sam', 'Surname' => 'Minnee']
                 ],
-                $twoItemList
+                self::$twoItemList
             ],
             [
                 [ //mixed
                     ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
                     ['FirstName' => 'Sam']
                 ],
-                $twoItemList
+                self::$twoItemList
             ],
         ];
     }
 
     public static function provideNonEqualLists()
     {
-        $oneItemList = [
-            ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
-        ];
-        $twoItemList = [
-            ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
-            ['FirstName' => 'Sam', 'Surname' => 'Minnee']
-        ];
 
         return [
             [ //empty list
@@ -82,28 +73,30 @@ class DataProvider implements TestOnly
                 [ //one item expected
                     ['FirstName' => 'Ingo']
                 ]
-                , $twoItemList
+                ,
+                self::$twoItemList
             ],
             [ //one item with wrong param
                 [
                     ['FirstName' => 'IngoXX'],
                     ['FirstName' => 'Sam']
                 ]
-                , $twoItemList
+                ,
+                self::$twoItemList
             ],
             [
                 [ //two params wrong
                     ['FirstName' => 'IngoXXX', 'Surname' => 'Schommer'],
                     ['FirstName' => 'Sam', 'Surname' => 'MinneeXXX']
                 ],
-                $twoItemList
+                self::$twoItemList
             ],
             [
                 [ //mixed
                     ['FirstName' => 'Daniel', 'Surname' => 'Foo'],
                     ['FirstName' => 'Dan']
                 ],
-                $twoItemList
+                self::$twoItemList
             ],
         ];
     }
@@ -111,14 +104,6 @@ class DataProvider implements TestOnly
 
     public static function provideNotContainingList()
     {
-        $oneItemList = [
-            ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
-        ];
-        $twoItemList = [
-            ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
-            ['FirstName' => 'Sam', 'Surname' => 'Minnee']
-        ];
-
         return [
             [ //empty list
                 [
@@ -130,21 +115,22 @@ class DataProvider implements TestOnly
                 [ //one item expected
                     ['FirstName' => 'Sam']
                 ]
-                , $oneItemList
+                ,
+                self::$oneItemList
             ],
             [
                 [ //two params wrong
                     ['FirstName' => 'IngoXXX', 'Surname' => 'Schommer'],
                     ['FirstName' => 'Sam', 'Surname' => 'MinneeXXX']
                 ],
-                $twoItemList
+                self::$twoItemList
             ],
             [
                 [ //mixed
                     ['FirstName' => 'Daniel', 'Surname' => 'Foo'],
                     ['FirstName' => 'Dan']
                 ],
-                $twoItemList
+                self::$twoItemList
             ],
         ];
     }

--- a/tests/php/Dev/SapphireTestTest/DataProvider.php
+++ b/tests/php/Dev/SapphireTestTest/DataProvider.php
@@ -16,6 +16,9 @@ class DataProvider implements TestOnly
         ['FirstName' => 'Sam', 'Surname' => 'Minnee']
     ];
 
+    /**
+     * @return array
+     */
     public static function provideEqualListsWithEmptyList()
     {
         return array_merge(
@@ -71,6 +74,9 @@ class DataProvider implements TestOnly
         ];
     }
 
+    /**
+     * @return array
+     */
     public static function provideNonEqualLists()
     {
 
@@ -113,6 +119,9 @@ class DataProvider implements TestOnly
         ];
     }
 
+    /**
+     * @return array
+     */
     public static function provideNotContainingList()
     {
         return [
@@ -146,6 +155,9 @@ class DataProvider implements TestOnly
         ];
     }
 
+    /**
+     * @return array
+     */
     public static function provideAllMatchingList()
     {
         $list = [
@@ -159,6 +171,9 @@ class DataProvider implements TestOnly
         ];
     }
 
+    /**
+     * @return array
+     */
     public static function provideNotMatchingList()
     {
         $list = [

--- a/tests/php/Dev/SapphireTestTest/DataProvider.php
+++ b/tests/php/Dev/SapphireTestTest/DataProvider.php
@@ -4,7 +4,6 @@ namespace SilverStripe\Dev\Tests\SapphireTestTest;
 
 use SilverStripe\Dev\TestOnly;
 
-
 class DataProvider implements TestOnly
 {
     protected static $oneItemList = [

--- a/tests/php/Dev/SapphireTestTest/DataProvider.php
+++ b/tests/php/Dev/SapphireTestTest/DataProvider.php
@@ -61,7 +61,7 @@ class DataProvider implements TestOnly
         ];
     }
 
-    public function provideNonEqualLists()
+    public static function provideNonEqualLists()
     {
         $oneItemList = [
             ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
@@ -108,4 +108,44 @@ class DataProvider implements TestOnly
         ];
     }
 
+
+    public static function provideNotContainingList()
+    {
+        $oneItemList = [
+            ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
+        ];
+        $twoItemList = [
+            ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
+            ['FirstName' => 'Sam', 'Surname' => 'Minnee']
+        ];
+
+        return [
+            [ //empty list
+                [
+                    ['FirstName' => 'Ingo']
+                ],
+                []
+            ],
+            [
+                [ //one item expected
+                    ['FirstName' => 'Sam']
+                ]
+                , $oneItemList
+            ],
+            [
+                [ //two params wrong
+                    ['FirstName' => 'IngoXXX', 'Surname' => 'Schommer'],
+                    ['FirstName' => 'Sam', 'Surname' => 'MinneeXXX']
+                ],
+                $twoItemList
+            ],
+            [
+                [ //mixed
+                    ['FirstName' => 'Daniel', 'Surname' => 'Foo'],
+                    ['FirstName' => 'Dan']
+                ],
+                $twoItemList
+            ],
+        ];
+    }
 }

--- a/tests/php/Dev/SapphireTestTest/DataProvider.php
+++ b/tests/php/Dev/SapphireTestTest/DataProvider.php
@@ -16,13 +16,25 @@ class DataProvider implements TestOnly
         ['FirstName' => 'Sam', 'Surname' => 'Minnee']
     ];
 
+    public static function provideEqualListsWithEmptyList()
+    {
+        return array_merge(
+            [ //empty list
+                [
+                    [],
+                    []
+                ]
+            ],
+            self::provideEqualLists()
+        );
+    }
+
+    /**
+     * @return array
+     */
     public static function provideEqualLists()
     {
         return [
-            [ //empty list
-                [],
-                []
-            ],
             [
                 [ //one param
                     ['FirstName' => 'Ingo']
@@ -101,7 +113,6 @@ class DataProvider implements TestOnly
         ];
     }
 
-
     public static function provideNotContainingList()
     {
         return [
@@ -132,6 +143,31 @@ class DataProvider implements TestOnly
                 ],
                 self::$twoItemList
             ],
+        ];
+    }
+
+    public static function provideAllMatchingList()
+    {
+        $list = [
+            ['FirstName' => 'Ingo', 'Surname' => 'Schommer', 'Locale' => 'en_US'],
+            ['FirstName' => 'Sam', 'Surname' => 'Minnee', 'Locale' => 'en_US']
+        ];
+
+        return [
+            [[], $list], //empty match
+            [['Locale' => 'en_US'], $list] //all items have this field set
+        ];
+    }
+
+    public static function provideNotMatchingList()
+    {
+        $list = [
+            ['FirstName' => 'Ingo', 'Surname' => 'Schommer', 'Locale' => 'en_US'],
+            ['FirstName' => 'Sam', 'Surname' => 'Minnee', 'Locale' => 'en_US']
+        ];
+
+        return [
+            [['FirstName' => 'Ingo'], $list] //not all items have this field set
         ];
     }
 }

--- a/tests/php/Dev/SapphireTestTest/DataProvider.php
+++ b/tests/php/Dev/SapphireTestTest/DataProvider.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace SilverStripe\Dev\Tests\SapphireTestTest;
+
+use SilverStripe\Dev\TestOnly;
+
+
+class DataProvider implements TestOnly
+{
+
+    public static function provideEqualLists()
+    {
+        $oneItemList = [
+            ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
+        ];
+        $twoItemList = [
+            ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
+            ['FirstName' => 'Sam', 'Surname' => 'Minnee']
+        ];
+
+        return [
+            [ //empty list
+                [],
+                []
+            ],
+            [
+                [ //one param
+                    ['FirstName' => 'Ingo']
+                ]
+                ,
+                $oneItemList
+            ],
+            [
+                [ //two params
+                    ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
+                ],
+                $oneItemList
+            ],
+            [ //only one param
+                [
+                    ['FirstName' => 'Ingo'],
+                    ['FirstName' => 'Sam']
+                ]
+                ,
+                $twoItemList
+            ],
+            [
+                [ //two params
+                    ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
+                    ['FirstName' => 'Sam', 'Surname' => 'Minnee']
+                ],
+                $twoItemList
+            ],
+            [
+                [ //mixed
+                    ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
+                    ['FirstName' => 'Sam']
+                ],
+                $twoItemList
+            ],
+        ];
+    }
+
+    public function provideNonEqualLists()
+    {
+        $oneItemList = [
+            ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
+        ];
+        $twoItemList = [
+            ['FirstName' => 'Ingo', 'Surname' => 'Schommer'],
+            ['FirstName' => 'Sam', 'Surname' => 'Minnee']
+        ];
+
+        return [
+            [ //empty list
+                [
+                    ['FirstName' => 'Ingo']
+                ],
+                []
+            ],
+            [
+                [ //one item expected
+                    ['FirstName' => 'Ingo']
+                ]
+                , $twoItemList
+            ],
+            [ //one item with wrong param
+                [
+                    ['FirstName' => 'IngoXX'],
+                    ['FirstName' => 'Sam']
+                ]
+                , $twoItemList
+            ],
+            [
+                [ //two params wrong
+                    ['FirstName' => 'IngoXXX', 'Surname' => 'Schommer'],
+                    ['FirstName' => 'Sam', 'Surname' => 'MinneeXXX']
+                ],
+                $twoItemList
+            ],
+            [
+                [ //mixed
+                    ['FirstName' => 'Daniel', 'Surname' => 'Foo'],
+                    ['FirstName' => 'Dan']
+                ],
+                $twoItemList
+            ],
+        ];
+    }
+
+}

--- a/tests/php/Dev/ViewableDataContainsTest.php
+++ b/tests/php/Dev/ViewableDataContainsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace SilverStripe\Dev\Tests;
+
+use SilverStripe\Dev\Constraint\ViewableDataContains;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Security\Member;
+use SilverStripe\View\ArrayData;
+
+class ViewableDataContainsTest extends SapphireTest
+{
+    private $test_data = [
+        'FirstName' => 'Ingo',
+        'Surname' => 'Schommer'
+    ];
+
+    public function provideMatchesForList()
+    {
+        return [
+            [
+                ['FirstName' => 'Ingo']
+            ],
+            [
+                ['Surname' => 'Schommer']
+            ],
+            [
+                ['FirstName' => 'Ingo', 'Surname' => 'Schommer']
+            ]
+        ];
+    }
+
+
+    public function provideInvalidMatchesForList()
+    {
+        return [
+            [
+                ['FirstName' => 'AnyoneNotInList']
+            ],
+            [
+                ['Surname' => 'NotInList']
+            ],
+            [
+                ['FirstName' => 'Ingo', 'Surname' => 'Minnee']
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider provideMatchesForList()
+     *
+     * @param $match
+     */
+    public function testEvaluateMatchesCorrectlyArrayData($match)
+    {
+        $constraint = new ViewableDataContains($match);
+
+        $item = ArrayData::create($this->test_data);
+
+        $this->assertTrue($constraint->evaluate($item, '', true));
+    }
+
+    /**
+     * @dataProvider provideMatchesForList()
+     *
+     * @param $match
+     */
+    public function testEvaluateMatchesCorrectlyDataObject($match)
+    {
+        $constraint = new ViewableDataContains($match);
+
+        $item = Member::create($this->test_data);
+
+        $this->assertTrue($constraint->evaluate($item, '', true));
+    }
+
+    /**
+     * @dataProvider provideInvalidMatchesForList()
+     *
+     * @param $matches
+     */
+    public function testEvaluateDoesNotMatchWrongMatchInArrayData($match)
+    {
+        $constraint = new ViewableDataContains($match);
+
+        $item = ArrayData::create($this->test_data);
+
+        $this->assertFalse($constraint->evaluate($item, '', true));
+    }
+
+    /**
+     * @dataProvider provideInvalidMatchesForList()
+     *
+     * @param $matches
+     */
+    public function testEvaluateDoesNotMatchWrongMatchInDataObject($match)
+    {
+        $constraint = new ViewableDataContains($match);
+
+        $item = Member::create($this->test_data);
+
+        $this->assertFalse($constraint->evaluate($item, '', true));
+    }
+}

--- a/tests/php/Forms/GridField/GridFieldAddExistingAutocompleterTest.php
+++ b/tests/php/Forms/GridField/GridFieldAddExistingAutocompleterTest.php
@@ -119,7 +119,7 @@ class GridFieldAddExistingAutocompleterTest extends FunctionalTest
         $parser = new CSSContentParser($response->getBody());
         $items = $parser->getBySelector('.grid-field .ss-gridfield-items .ss-gridfield-item');
         $this->assertEquals(2, count($items));
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('ID' => (int)$items[0]['data-id']),
             array('ID' => (int)$items[1]['data-id']),

--- a/tests/php/Forms/GridField/GridFieldDataColumnsTest.php
+++ b/tests/php/Forms/GridField/GridFieldDataColumnsTest.php
@@ -41,10 +41,11 @@ class GridFieldDataColumnsTest extends SapphireTest
     /**
      * @covers \SilverStripe\Forms\GridField\GridFieldDataColumns::setDisplayFields
      * @covers \SilverStripe\Forms\GridField\GridFieldDataColumns::getDisplayFields
+     *
+     * @expectedException \InvalidArgumentException
      */
     public function testGridFieldDisplayFieldsWithBadArguments()
     {
-        $this->setExpectedException('InvalidArgumentException');
         $obj = new GridField('testfield', 'testfield', Member::get());
         $columns = $obj->getConfig()->getComponentByType(GridFieldDataColumns::class);
         $columns->setDisplayFields(new stdClass());

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest.php
@@ -176,7 +176,7 @@ class GridFieldDetailFormTest extends FunctionalTest
             ->filter('Name', 'My Group')
             ->sort('Name')
             ->First();
-        $this->assertDOSContains(array(array('Surname' => 'Baggins')), $group->People());
+        $this->assertListContains(array(array('Surname' => 'Baggins')), $group->People());
     }
 
     public function testEditFormWithManyMany()

--- a/tests/php/Forms/GridField/GridFieldTest.php
+++ b/tests/php/Forms/GridField/GridFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms\Tests\GridField;
 
+use Psr\Log\InvalidArgumentException;
 use SilverStripe\Dev\CSSContentParser;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\FieldList;
@@ -123,10 +124,11 @@ class GridFieldTest extends SapphireTest
 
     /**
      * @covers \SilverStripe\Forms\GridField\GridField::getModelClass
+     *
+     * @expectedException \LogicException
      */
     public function testGridFieldModelClassThrowsException()
     {
-        $this->setExpectedException('LogicException');
         $obj = new GridField('testfield', 'testfield', ArrayList::create());
         $obj->getModelClass();
     }
@@ -247,10 +249,11 @@ class GridFieldTest extends SapphireTest
     /**
      * @skipUpgrade
      * @covers \SilverStripe\Forms\GridField\GridField::getColumnContent
+     *
+     * @expectedException \InvalidArgumentException
      */
     public function testGetColumnContentBadArguments()
     {
-        $this->setExpectedException('InvalidArgumentException');
         $list = new ArrayList(
             array(
             new Member(array("ID" => 1, "Email" => "test@example.org"))
@@ -293,10 +296,11 @@ class GridFieldTest extends SapphireTest
 
     /**
      * @covers \SilverStripe\Forms\GridField\GridField::getColumnAttributes
+     *
+     * @expectedException \InvalidArgumentException
      */
     public function testGetColumnAttributesBadArguments()
     {
-        $this->setExpectedException('InvalidArgumentException');
         $list = new ArrayList(
             array(
             new Member(array("ID" => 1, "Email" => "test@example.org"))
@@ -307,9 +311,11 @@ class GridFieldTest extends SapphireTest
         $obj->getColumnAttributes($list->first(), 'Non-existing');
     }
 
+    /**
+     * @expectedException \LogicException
+     */
     public function testGetColumnAttributesBadResponseFromComponent()
     {
-        $this->setExpectedException('LogicException');
         $list = new ArrayList(
             array(
             new Member(array("ID" => 1, "Email" => "test@example.org"))
@@ -338,10 +344,11 @@ class GridFieldTest extends SapphireTest
 
     /**
      * @covers \SilverStripe\Forms\GridField\GridField::getColumnMetadata
+     *
+     * @expectedException \LogicException
      */
     public function testGetColumnMetadataBadResponseFromComponent()
     {
-        $this->setExpectedException('LogicException');
         $list = new ArrayList(
             array(
             new Member(array("ID" => 1, "Email" => "test@example.org"))
@@ -354,10 +361,11 @@ class GridFieldTest extends SapphireTest
 
     /**
      * @covers \SilverStripe\Forms\GridField\GridField::getColumnMetadata
+     *
+     * @expectedException \InvalidArgumentException
      */
     public function testGetColumnMetadataBadArguments()
     {
-        $this->setExpectedException('InvalidArgumentException');
         $list = ArrayList::create();
         $config = GridFieldConfig::create()->addComponent(new Component);
         $obj = new GridField('testfield', 'testfield', $list, $config);
@@ -366,10 +374,11 @@ class GridFieldTest extends SapphireTest
 
     /**
      * @covers \SilverStripe\Forms\GridField\GridField::handleAction
+     *
+     * @expectedException \InvalidArgumentException
      */
     public function testHandleActionBadArgument()
     {
-        $this->setExpectedException('InvalidArgumentException');
         $obj = new GridField('testfield', 'testfield');
         $obj->handleAlterAction('prft', array(), array());
     }
@@ -506,6 +515,8 @@ class GridFieldTest extends SapphireTest
 
     /**
      * Test that circular dependencies throw an exception
+     *
+     * @expectedException \LogicException
      */
     public function testGridFieldCustomFragmentsCircularDependencyThrowsException()
     {
@@ -534,7 +545,6 @@ class GridFieldTest extends SapphireTest
         $field = new GridField('testfield', 'testfield', ArrayList::create(), $config);
         $form = new Form(null, 'testform', new FieldList(array($field)), new FieldList());
 
-        $this->setExpectedException('LogicException');
         $field->FieldHolder();
     }
 

--- a/tests/php/ORM/CascadeDeleteTest.php
+++ b/tests/php/ORM/CascadeDeleteTest.php
@@ -22,14 +22,14 @@ class CascadeDeleteTest extends SapphireTest
     {
         /** @var CascadeDeleteTest\ChildObject $child1 */
         $child1 = $this->objFromFixture(CascadeDeleteTest\ChildObject::class, 'child1');
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 [ 'Title' => 'Grandchild 1'],
                 [ 'Title' => 'Grandchild 2'],
             ],
             $child1->findCascadeDeletes(true)
         );
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 [ 'Title' => 'Grandchild 1'],
                 [ 'Title' => 'Grandchild 2'],
@@ -39,7 +39,7 @@ class CascadeDeleteTest extends SapphireTest
 
         /** @var CascadeDeleteTest\ParentObject $parent1 */
         $parent1 = $this->objFromFixture(CascadeDeleteTest\ParentObject::class, 'parent1');
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 [ 'Title' => 'Child 1'],
                 [ 'Title' => 'Grandchild 1'],
@@ -47,7 +47,7 @@ class CascadeDeleteTest extends SapphireTest
             ],
             $parent1->findCascadeDeletes(true)
         );
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 [ 'Title' => 'Child 1'],
             ],
@@ -65,7 +65,7 @@ class CascadeDeleteTest extends SapphireTest
         $this->assertNotEmpty($this->objFromFixture(CascadeDeleteTest\ParentObject::class, 'parent1'));
 
         // Related objects never deleted
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => 'Related 1'],
                 ['Title' => 'Related 2'],
@@ -75,7 +75,7 @@ class CascadeDeleteTest extends SapphireTest
         );
 
         // Ensure only remaining grandchild are those outside the relation
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => 'Grandchild 3'],
             ],
@@ -90,13 +90,13 @@ class CascadeDeleteTest extends SapphireTest
         $parent1->delete();
 
         // Ensure affected cascading tables have expected content
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => 'Child 2'],
             ],
             CascadeDeleteTest\ChildObject::get()
         );
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => 'Grandchild 3'],
             ],
@@ -104,7 +104,7 @@ class CascadeDeleteTest extends SapphireTest
         );
 
         // Related objects never deleted
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => 'Related 1'],
                 ['Title' => 'Related 2'],
@@ -116,7 +116,7 @@ class CascadeDeleteTest extends SapphireTest
         // Ensure that other parents which share cascade deleted objects have the correct result
         /** @var CascadeDeleteTest\ChildObject $child2 */
         $child2 = $this->objFromFixture(CascadeDeleteTest\ChildObject::class, 'child2');
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => 'Grandchild 3'],
             ],

--- a/tests/php/ORM/DBDateTest.php
+++ b/tests/php/ORM/DBDateTest.php
@@ -92,21 +92,21 @@ class DBDateTest extends SapphireTest
         );
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid date: '3/16/2003'. Use y-MM-dd to prevent this error.
+     */
     public function testMDYConversion()
     {
-        $this->setExpectedException(
-            \InvalidArgumentException::class,
-            "Invalid date: '3/16/2003'. Use " . DBDate::ISO_DATE . " to prevent this error."
-        );
         DBField::create_field('Date', '3/16/2003');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid date: '03-03-04'. Use y-MM-dd to prevent this error.
+     */
     public function testY2kCorrection()
     {
-        $this->setExpectedException(
-            \InvalidArgumentException::class,
-            "Invalid date: '03-03-04'. Use " . DBDate::ISO_DATE . " to prevent this error."
-        );
         DBField::create_field('Date', '03-03-04');
     }
 

--- a/tests/php/ORM/DataExtensionTest.php
+++ b/tests/php/ORM/DataExtensionTest.php
@@ -270,6 +270,9 @@ class DataExtensionTest extends SapphireTest
 
     /**
      * Test setOwner behaviour
+     *
+     * @expectedException \BadMethodCallException
+     * @expectedExceptionMessage clearOwner() called more than setOwner()
      */
     public function testSetOwner()
     {
@@ -297,7 +300,6 @@ class DataExtensionTest extends SapphireTest
         $this->assertNull($extension->getOwner());
 
         // Another clearOwner should error
-        $this->setExpectedException("BadMethodCallException", "clearOwner() called more than setOwner()");
         $extension->clearOwner();
     }
 }

--- a/tests/php/ORM/DataExtensionTest.php
+++ b/tests/php/ORM/DataExtensionTest.php
@@ -270,9 +270,6 @@ class DataExtensionTest extends SapphireTest
 
     /**
      * Test setOwner behaviour
-     *
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage clearOwner() called more than setOwner()
      */
     public function testSetOwner()
     {
@@ -300,6 +297,8 @@ class DataExtensionTest extends SapphireTest
         $this->assertNull($extension->getOwner());
 
         // Another clearOwner should error
+        $this->expectExceptionMessage(\BadMethodCallException::class);
+        $this->expectExceptionMessage('clearOwner() called more than setOwner()');
         $extension->clearOwner();
     }
 }

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -870,21 +870,21 @@ class DataListTest extends SapphireTest
 
         // grand child can be found from parent
         $found = Bracket::get()->filter('Next.Next.Title', $final1->Title);
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [['Title' => $semifinal1->Title]],
             $found
         );
 
         // grand child can be found from child
         $found = Bracket::get()->filter('Next.Title', $prefinal1->Title);
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [['Title' => $semifinal1->Title]],
             $found
         );
 
         // child can be found from parent
         $found = Bracket::get()->filter('Next.Title', $final1->Title);
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => $prefinal1->Title],
                 ['Title' => $prefinal2->Title]
@@ -895,7 +895,7 @@ class DataListTest extends SapphireTest
         // Complex filter, get brackets where the following bracket was won by team 1
         // Note: Includes results from multiple levels
         $found = Bracket::get()->filter('Next.Winner.Title', $team2->Title);
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => $prefinal1->Title],
                 ['Title' => $prefinal2->Title],
@@ -1093,7 +1093,7 @@ class DataListTest extends SapphireTest
 
         // Filter by null email
         $nullEmails = $list->filter('Email', null);
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array(
                 'Name' => 'Stephen',
@@ -1107,7 +1107,7 @@ class DataListTest extends SapphireTest
 
         // Filter by non-null
         $nonNullEmails = $list->filter('Email:not', null);
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array(
                 'Name' => 'Damian',
@@ -1126,7 +1126,7 @@ class DataListTest extends SapphireTest
 
         // Filter by empty only
         $emptyOnly = $list->filter('Email', '');
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array(
                 'Name' => 'Hamish',
@@ -1138,7 +1138,7 @@ class DataListTest extends SapphireTest
         // Non-empty only. This should include null values, since ExactMatchFilter works around
         // the caveat that != '' also excludes null values in ANSI SQL-92 behaviour.
         $nonEmptyOnly = $list->filter('Email:not', '');
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array(
                 'Name' => 'Damian',
@@ -1160,7 +1160,7 @@ class DataListTest extends SapphireTest
 
         // Filter by many including null, empty string, and non-empty
         $items1 = $list->filter('Email', array(null, '', 'damian@thefans.com'));
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array(
                 'Name' => 'Damian',
@@ -1181,7 +1181,7 @@ class DataListTest extends SapphireTest
 
         // Filter exclusion of above list
         $items2 = $list->filter('Email:not', array(null, '', 'damian@thefans.com'));
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array(
                 'Name' => 'Richard',
@@ -1193,7 +1193,7 @@ class DataListTest extends SapphireTest
 
         // Filter by many including empty string and non-empty
         $items3 = $list->filter('Email', array('', 'damian@thefans.com'));
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array(
                 'Name' => 'Damian',
@@ -1209,7 +1209,7 @@ class DataListTest extends SapphireTest
         // Filter by many including empty string and non-empty
         // This also relies no the workaround for null comparison as in the $nonEmptyOnly test
         $items4 = $list->filter('Email:not', array('', 'damian@thefans.com'));
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array(
                 'Name' => 'Richard',
@@ -1233,7 +1233,7 @@ class DataListTest extends SapphireTest
             'Email' => null
             )
         );
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array(
                 'Name' => 'Richard',
@@ -1251,7 +1251,7 @@ class DataListTest extends SapphireTest
 
         // Filter by null or empty values
         $items6 = $list->filter('Email', array(null, ''));
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array(
                 'Name' => 'Stephen',

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\ORM\Tests;
 
+use InvalidArgumentException;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\InjectorNotFoundException;
 use SilverStripe\ORM\DataList;
@@ -88,9 +89,11 @@ class DataListTest extends SapphireTest
         $this->assertEquals(2, $newList->Count(), 'List should only contain two objects after subtraction');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testSubtractBadDataclassThrowsException()
     {
-        $this->setExpectedException('InvalidArgumentException');
         $teamsComments = TeamComment::get();
         $teams = Team::get();
         $teamsComments->subtract($teams);
@@ -579,12 +582,12 @@ class DataListTest extends SapphireTest
         $this->assertEquals('Phil', $list->last()->Name);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Fans is not a linear relation on model SilverStripe\ORM\Tests\DataObjectTest\Player
+     */
     public function testSortInvalidParameters()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            'Fans is not a linear relation on model '.Player::class
-        );
         $list = Team::get();
         $list->sort('Founder.Fans.Surname'); // Can't sort on has_many
     }
@@ -747,23 +750,24 @@ class DataListTest extends SapphireTest
         $this->assertEquals('Bob', $list->first()->Name, 'First comment should be from Bob');
     }
 
+    /**
+     * @expectedException \SilverStripe\Core\Injector\InjectorNotFoundException
+     * @expectedExceptionMessage Class DataListFilter.Bogus does not exist
+     */
     public function testSimpleFilterWithNonExistingComparisator()
     {
-        $this->setExpectedException(
-            InjectorNotFoundException::class,
-            'Class DataListFilter.Bogus does not exist'
-        );
         $list = TeamComment::get();
         $list->filter('Comment:Bogus', 'team comment');
     }
 
+    /**
+     * Invalid modifiers are treated as failed filter construction
+     *
+     * @expectedException \SilverStripe\Core\Injector\InjectorNotFoundException
+     * @expectedExceptionMessage Class DataListFilter.invalidmodifier does not exist
+     */
     public function testInvalidModifier()
     {
-        // Invalid modifiers are treated as failed filter construction
-        $this->setExpectedException(
-            InjectorNotFoundException::class,
-            'Class DataListFilter.invalidmodifier does not exist'
-        );
         $list = TeamComment::get();
         $list->filter('Comment:invalidmodifier', 'team comment');
     }
@@ -1058,12 +1062,12 @@ class DataListTest extends SapphireTest
         $this->assertEquals('007', $list->first()->ShirtNumber);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage MascotAnimal is not a relation on model SilverStripe\ORM\Tests\DataObjectTest\Team
+     */
     public function testFilterOnInvalidRelation()
     {
-        $this->setExpectedException(
-            'InvalidArgumentException',
-            "MascotAnimal is not a relation on model ".Team::class
-        );
         // Filter on missing relation 'MascotAnimal'
         Team::get()
             ->filter('MascotAnimal.Name', 'Richard')
@@ -1528,13 +1532,12 @@ class DataListTest extends SapphireTest
 
     /**
      * Test exact match filter with empty array items
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Cannot filter "DataObjectTest_TeamComment"."Name" against an empty set
      */
     public function testEmptyFilter()
     {
-        $this->setExpectedException(
-            "InvalidArgumentException",
-            'Cannot filter "DataObjectTest_TeamComment"."Name" against an empty set'
-        );
         $list = TeamComment::get();
         $list->exclude('Name', array());
     }

--- a/tests/php/ORM/DataObjectDuplicationTest.php
+++ b/tests/php/ORM/DataObjectDuplicationTest.php
@@ -183,7 +183,7 @@ class DataObjectDuplicationTest extends SapphireTest
         // Duplcating $child should only duplicate grandchild
         $childDuplicate = $child->duplicate(true, 'many_many');
         $this->assertEquals(0, $childDuplicate->Parents()->count());
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [['Title' => 'GrandChild']],
             $childDuplicate->Children()
         );
@@ -191,18 +191,18 @@ class DataObjectDuplicationTest extends SapphireTest
         // Duplicate belongs_many_many only
         $belongsDuplicate = $child->duplicate(true, 'belongs_many_many');
         $this->assertEquals(0, $belongsDuplicate->Children()->count());
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [['Title' => 'Parent']],
             $belongsDuplicate->Parents()
         );
 
         // Duplicate all
         $allDuplicate = $child->duplicate(true, true);
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [['Title' => 'Parent']],
             $allDuplicate->Parents()
         );
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [['Title' => 'GrandChild']],
             $allDuplicate->Children()
         );
@@ -218,14 +218,14 @@ class DataObjectDuplicationTest extends SapphireTest
         $three = new DataObjectDuplicationTest\Class3();
         $three->text = "Test Text 3";
         $one->threes()->add($three);
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [['text' => 'Test Text 3']],
             $one->threes()
         );
         // Test duplicate
         $dupe = $one->duplicate(false, true);
         $this->assertEquals('Test Text 1', $dupe->text);
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [['text' => 'Test Text 3']],
             $dupe->threes()
         );

--- a/tests/php/ORM/DataObjectSchemaTest.php
+++ b/tests/php/ORM/DataObjectSchemaTest.php
@@ -226,8 +226,6 @@ class DataObjectSchemaTest extends SapphireTest
 
     /**
      * @covers \SilverStripe\ORM\DataObjectSchema::baseDataClass()
-     *
-     * @expectedException \InvalidArgumentException
      */
     public function testBaseDataClass()
     {
@@ -239,6 +237,8 @@ class DataObjectSchemaTest extends SapphireTest
         $this->assertEquals(BaseClass::class, $schema->baseDataClass(strtoupper(ChildClass::class)));
         $this->assertEquals(BaseClass::class, $schema->baseDataClass(GrandChildClass::class));
         $this->assertEquals(BaseClass::class, $schema->baseDataClass(ucfirst(GrandChildClass::class)));
+
+        $this->expectException(InvalidArgumentException::class);
 
         $schema->baseDataClass(DataObject::class);
     }

--- a/tests/php/ORM/DataObjectSchemaTest.php
+++ b/tests/php/ORM/DataObjectSchemaTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\ORM\Tests;
 
+use InvalidArgumentException;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
@@ -225,6 +226,8 @@ class DataObjectSchemaTest extends SapphireTest
 
     /**
      * @covers \SilverStripe\ORM\DataObjectSchema::baseDataClass()
+     *
+     * @expectedException \InvalidArgumentException
      */
     public function testBaseDataClass()
     {
@@ -237,7 +240,6 @@ class DataObjectSchemaTest extends SapphireTest
         $this->assertEquals(BaseClass::class, $schema->baseDataClass(GrandChildClass::class));
         $this->assertEquals(BaseClass::class, $schema->baseDataClass(ucfirst(GrandChildClass::class)));
 
-        $this->setExpectedException('InvalidArgumentException');
         $schema->baseDataClass(DataObject::class);
     }
 

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -1323,10 +1323,6 @@ class DataObjectTest extends SapphireTest
         );
     }
 
-    /**
-     * @expectedException \ReflectionException
-     * @expectedExceptionMessage Class ThisIsntADataObject does not exist
-     */
     public function testHasOwnTable()
     {
         $schema = DataObject::getSchema();
@@ -1346,6 +1342,9 @@ class DataObjectTest extends SapphireTest
         $this->assertFalse($schema->classHasTable(ViewableData::class));
 
         // Invalid class
+        $this->expectException(ReflectionException::class);
+        $this->expectExceptionMessage('Class ThisIsntADataObject does not exist');
+
         $this->assertFalse($schema->classHasTable("ThisIsntADataObject"));
     }
 
@@ -1438,10 +1437,6 @@ class DataObjectTest extends SapphireTest
         DataObject::getSchema()->manyManyComponent(DataObjectTest\Team::class, 'Players');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Controller is not a valid subclass of DataObject
-     */
     public function testNewClassInstance()
     {
         $dataObject = $this->objFromFixture(DataObjectTest\Team::class, 'team1');
@@ -1464,6 +1459,8 @@ class DataObjectTest extends SapphireTest
         $this->assertEquals($changedDO->ClassName, DataObjectTest\SubTeam::class);
 
         // Test invalid classes fail
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Controller is not a valid subclass of DataObject');
         /**
  * @skipUpgrade
 */
@@ -2086,9 +2083,6 @@ class DataObjectTest extends SapphireTest
         $this->assertEquals("Team 1", $player->relObject('Teams.First.Title')->getValue());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testLateStaticBindingStyle()
     {
         // Confirm that DataObjectTest_Player::get() operates as excepted
@@ -2096,6 +2090,8 @@ class DataObjectTest extends SapphireTest
         $this->assertInstanceOf(DataObjectTest\Player::class, DataObjectTest\Player::get()->first());
 
         // You can't pass arguments to LSB syntax - use the DataList methods instead.
+        $this->expectException(InvalidArgumentException::class);
+
         DataObjectTest\Player::get(null, "\"ID\" = 1");
     }
 

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -517,10 +517,10 @@ class DataObjectTest extends SapphireTest
         ];
 
         // Test the IDs on the DataObjects are set correctly
-        $this->assertDOSEquals($team1Comments, $team1->Comments());
+        $this->assertListEquals($team1Comments, $team1->Comments());
 
         // Test that has_many can be infered from the has_one via getNonReciprocalComponent
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             $team1Comments,
             $team1->inferReciprocalComponent(DataObjectTest\TeamComment::class, 'Team')
         );
@@ -1493,7 +1493,7 @@ class DataObjectTest extends SapphireTest
         $this->assertEquals(0, $teamWithoutSponsor->Sponsors()->count());
 
         // Test that belongs_many_many can be infered from with getNonReciprocalComponent
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Name' => 'Company corp'],
                 ['Name' => 'Team co.'],
@@ -1502,7 +1502,7 @@ class DataObjectTest extends SapphireTest
         );
 
         // Test that many_many can be infered from getNonReciprocalComponent
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => 'Team 1'],
                 ['Title' => 'Team 2'],
@@ -1902,7 +1902,7 @@ class DataObjectTest extends SapphireTest
 
         // Test belongs_to can be infered via getNonReciprocalComponent
         // Note: Will be returned as has_many since the belongs_to is ignored.
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [['Name' => 'New Company']],
             $ceo->inferReciprocalComponent(DataObjectTest\Company::class, 'CEO')
         );

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -1259,10 +1259,13 @@ class DataObjectTest extends SapphireTest
         $this->assertEquals('New and improved team 1', $reloadedTeam1->Title);
     }
 
+
+    /**
+     * @expectedException \SilverStripe\ORM\ValidationException
+     */
     public function testWritingInvalidDataObjectThrowsException()
     {
         $validatedObject = new DataObjectTest\ValidatedObject();
-        $this->setExpectedException(ValidationException::class);
         $validatedObject->write();
     }
 
@@ -1320,6 +1323,10 @@ class DataObjectTest extends SapphireTest
         );
     }
 
+    /**
+     * @expectedException \ReflectionException
+     * @expectedExceptionMessage Class ThisIsntADataObject does not exist
+     */
     public function testHasOwnTable()
     {
         $schema = DataObject::getSchema();
@@ -1339,7 +1346,6 @@ class DataObjectTest extends SapphireTest
         $this->assertFalse($schema->classHasTable(ViewableData::class));
 
         // Invalid class
-        $this->setExpectedException(ReflectionException::class, 'Class ThisIsntADataObject does not exist');
         $this->assertFalse($schema->classHasTable("ThisIsntADataObject"));
     }
 
@@ -1405,27 +1411,37 @@ class DataObjectTest extends SapphireTest
         );
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testValidateModelDefinitionsFailsWithArray()
     {
         Config::modify()->merge(DataObjectTest\Team::class, 'has_one', array('NotValid' => array('NoArraysAllowed')));
-        $this->setExpectedException(InvalidArgumentException::class);
         DataObject::getSchema()->hasOneComponent(DataObjectTest\Team::class, 'NotValid');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testValidateModelDefinitionsFailsWithIntKey()
     {
         Config::modify()->set(DataObjectTest\Team::class, 'has_many', array(0 => DataObjectTest\Player::class));
-        $this->setExpectedException(InvalidArgumentException::class);
         DataObject::getSchema()->hasManyComponent(DataObjectTest\Team::class, 0);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testValidateModelDefinitionsFailsWithIntValue()
     {
         Config::modify()->merge(DataObjectTest\Team::class, 'many_many', array('Players' => 12));
-        $this->setExpectedException(InvalidArgumentException::class);
         DataObject::getSchema()->manyManyComponent(DataObjectTest\Team::class, 'Players');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Controller is not a valid subclass of DataObject
+     */
     public function testNewClassInstance()
     {
         $dataObject = $this->objFromFixture(DataObjectTest\Team::class, 'team1');
@@ -1448,7 +1464,6 @@ class DataObjectTest extends SapphireTest
         $this->assertEquals($changedDO->ClassName, DataObjectTest\SubTeam::class);
 
         // Test invalid classes fail
-        $this->setExpectedException('InvalidArgumentException', "Controller is not a valid subclass of DataObject");
         /**
  * @skipUpgrade
 */
@@ -2071,6 +2086,9 @@ class DataObjectTest extends SapphireTest
         $this->assertEquals("Team 1", $player->relObject('Teams.First.Title')->getValue());
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testLateStaticBindingStyle()
     {
         // Confirm that DataObjectTest_Player::get() operates as excepted
@@ -2078,14 +2096,15 @@ class DataObjectTest extends SapphireTest
         $this->assertInstanceOf(DataObjectTest\Player::class, DataObjectTest\Player::get()->first());
 
         // You can't pass arguments to LSB syntax - use the DataList methods instead.
-        $this->setExpectedException('InvalidArgumentException');
         DataObjectTest\Player::get(null, "\"ID\" = 1");
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testBrokenLateStaticBindingStyle()
     {
         // If you call DataObject::get() you have to pass a first argument
-        $this->setExpectedException('InvalidArgumentException');
         DataObject::get();
     }
 

--- a/tests/php/ORM/ManyManyThroughListTest.php
+++ b/tests/php/ORM/ManyManyThroughListTest.php
@@ -139,6 +139,8 @@ class ManyManyThroughListTest extends SapphireTest
 
     /**
      * Test validation
+     *
+     * @expectedException \InvalidArgumentException
      */
     public function testValidateModelValidatesJoinType()
     {
@@ -149,7 +151,7 @@ class ManyManyThroughListTest extends SapphireTest
             ManyManyThroughListTest\JoinObject::class => 'Text'
             ]
         );
-        $this->setExpectedException(InvalidArgumentException::class);
+
         DataObject::getSchema()->manyManyComponent(ManyManyThroughListTest\TestObject::class, 'Items');
     }
 

--- a/tests/php/ORM/ManyManyThroughListTest.php
+++ b/tests/php/ORM/ManyManyThroughListTest.php
@@ -33,7 +33,7 @@ class ManyManyThroughListTest extends SapphireTest
     {
         /** @var ManyManyThroughListTest\TestObject $parent */
         $parent = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => 'item 1'],
                 ['Title' => 'item 2']
@@ -68,7 +68,7 @@ class ManyManyThroughListTest extends SapphireTest
 
         // Test sorting on join table
         $items = $parent->Items()->sort('"ManyManyThroughListTest_JoinObject"."Sort"');
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => 'item 2'],
                 ['Title' => 'item 1'],
@@ -77,7 +77,7 @@ class ManyManyThroughListTest extends SapphireTest
         );
 
         $items = $parent->Items()->sort('"ManyManyThroughListTest_JoinObject"."Sort" ASC');
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => 'item 1'],
                 ['Title' => 'item 2'],
@@ -85,7 +85,7 @@ class ManyManyThroughListTest extends SapphireTest
             $items
         );
         $items = $parent->Items()->sort('"ManyManyThroughListTest_JoinObject"."Title" DESC');
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => 'item 2'],
                 ['Title' => 'item 1'],
@@ -122,7 +122,7 @@ class ManyManyThroughListTest extends SapphireTest
     {
         /** @var ManyManyThroughListTest\TestObject $parent */
         $parent = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 ['Title' => 'item 1'],
                 ['Title' => 'item 2']
@@ -131,7 +131,7 @@ class ManyManyThroughListTest extends SapphireTest
         );
         $item1 = $parent->Items()->filter(['Title' => 'item 1'])->first();
         $parent->Items()->remove($item1);
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [['Title' => 'item 2']],
             $parent->Items()
         );

--- a/tests/php/ORM/PaginatedListTest.php
+++ b/tests/php/ORM/PaginatedListTest.php
@@ -103,30 +103,30 @@ class PaginatedListTest extends SapphireTest
         );
         $list->setPageLength(2);
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(array('Num' => 1), array('Num' => 2)),
             $list->getIterator()
         );
 
         $list->setCurrentPage(2);
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(array('Num' => 3), array('Num' => 4)),
             $list->getIterator()
         );
 
         $list->setCurrentPage(3);
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(array('Num' => 5)),
             $list->getIterator()
         );
 
         $list->setCurrentPage(999);
-        $this->assertDOSEquals(array(), $list->getIterator());
+        $this->assertListEquals(array(), $list->getIterator());
 
         // Test disabled paging
         $list->setPageLength(0);
         $list->setCurrentPage(1);
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             [
                 array('Num' => 1),
                 array('Num' => 2),
@@ -168,21 +168,21 @@ class PaginatedListTest extends SapphireTest
             array('PageNum' => 4),
             array('PageNum' => 5),
         );
-        $this->assertDOSEquals($expectAll, $list->Pages());
+        $this->assertListEquals($expectAll, $list->Pages());
 
         $expectLimited = array(
             array('PageNum' => 2),
             array('PageNum' => 3, 'CurrentBool' => true),
             array('PageNum' => 4),
         );
-        $this->assertDOSEquals($expectLimited, $list->Pages(3));
+        $this->assertListEquals($expectLimited, $list->Pages(3));
 
         // Disable paging
         $list->setPageLength(0);
         $expectAll = array(
             array('PageNum' => 1, 'CurrentBool' => true),
         );
-        $this->assertDOSEquals($expectAll, $list->Pages());
+        $this->assertListEquals($expectAll, $list->Pages());
     }
 
     public function testPaginationSummary()
@@ -204,14 +204,14 @@ class PaginatedListTest extends SapphireTest
             array('PageNum' => null),
             array('PageNum' => 25),
         );
-        $this->assertDOSEquals($expect, $list->PaginationSummary(4));
+        $this->assertListEquals($expect, $list->PaginationSummary(4));
 
         // Disable paging
         $list->setPageLength(0);
         $expect = array(
             array('PageNum' => 1, 'CurrentBool' => true)
         );
-        $this->assertDOSEquals($expect, $list->PaginationSummary(4));
+        $this->assertListEquals($expect, $list->PaginationSummary(4));
     }
 
     public function testLimitItems()

--- a/tests/php/ORM/PaginatedListTest.php
+++ b/tests/php/ORM/PaginatedListTest.php
@@ -105,23 +105,26 @@ class PaginatedListTest extends SapphireTest
 
         $this->assertListEquals(
             array(array('Num' => 1), array('Num' => 2)),
-            $list->getIterator()
+            ArrayList::create($list->getIterator()->getInnerIterator()->getArrayCopy())
         );
 
         $list->setCurrentPage(2);
         $this->assertListEquals(
             array(array('Num' => 3), array('Num' => 4)),
-            $list->getIterator()
+            ArrayList::create($list->getIterator()->getInnerIterator()->getArrayCopy())
         );
 
         $list->setCurrentPage(3);
         $this->assertListEquals(
             array(array('Num' => 5)),
-            $list->getIterator()
+            ArrayList::create($list->getIterator()->getInnerIterator()->getArrayCopy())
         );
 
         $list->setCurrentPage(999);
-        $this->assertListEquals(array(), $list->getIterator());
+        $this->assertListEquals(
+            array(),
+            ArrayList::create($list->getIterator()->getInnerIterator()->getArrayCopy())
+        );
 
         // Test disabled paging
         $list->setPageLength(0);
@@ -134,7 +137,7 @@ class PaginatedListTest extends SapphireTest
                 array('Num' => 4),
                 array('Num' => 5),
             ],
-            $list->getIterator()
+            ArrayList::create($list->getIterator()->getInnerIterator()->getArrayCopy())
         );
 
         // Test with dataobjectset

--- a/tests/php/ORM/UnsavedRelationListTest.php
+++ b/tests/php/ORM/UnsavedRelationListTest.php
@@ -55,7 +55,7 @@ class UnsavedRelationListTest extends SapphireTest
 
         $children = $object->Children();
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('Name' => 'A'),
             array('Name' => 'B'),
@@ -68,7 +68,7 @@ class UnsavedRelationListTest extends SapphireTest
 
         $this->assertNotEquals($children, $object->Children());
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('Name' => 'A'),
             array('Name' => 'B'),
@@ -89,7 +89,7 @@ class UnsavedRelationListTest extends SapphireTest
 
         $siblings = $object->Siblings();
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('Name' => 'A'),
             array('Name' => 'B'),
@@ -102,7 +102,7 @@ class UnsavedRelationListTest extends SapphireTest
 
         $this->assertNotEquals($siblings, $object->Siblings());
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('Name' => 'A'),
             array('Name' => 'B'),
@@ -123,7 +123,7 @@ class UnsavedRelationListTest extends SapphireTest
 
         $children = $object->Children();
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('Name' => 'A'),
             array('Name' => 'B'),
@@ -136,7 +136,7 @@ class UnsavedRelationListTest extends SapphireTest
 
         $this->assertNotEquals($children, $object->Children());
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('Name' => 'A'),
             array('Name' => 'B'),
@@ -157,7 +157,7 @@ class UnsavedRelationListTest extends SapphireTest
 
         $children = $object->RelatedObjects();
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('Name' => 'A'),
             array('Name' => 'B'),
@@ -170,7 +170,7 @@ class UnsavedRelationListTest extends SapphireTest
 
         $this->assertNotEquals($children, $object->RelatedObjects());
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('Name' => 'A'),
             array('Name' => 'B'),
@@ -191,7 +191,7 @@ class UnsavedRelationListTest extends SapphireTest
 
         $siblings = $object->Siblings();
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('Name' => 'A'),
             array('Name' => 'B'),
@@ -204,7 +204,7 @@ class UnsavedRelationListTest extends SapphireTest
 
         $this->assertNotEquals($siblings, $object->Siblings());
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('Name' => 'A'),
             array('Name' => 'B'),
@@ -225,7 +225,7 @@ class UnsavedRelationListTest extends SapphireTest
 
         $siblings = $object->Siblings();
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('Name' => 'A', 'Number' => 1),
             array('Name' => 'B', 'Number' => 2),
@@ -238,7 +238,7 @@ class UnsavedRelationListTest extends SapphireTest
 
         $this->assertNotEquals($siblings, $object->Siblings());
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('Name' => 'A', 'Number' => 1),
             array('Name' => 'B', 'Number' => 2),
@@ -292,7 +292,7 @@ class UnsavedRelationListTest extends SapphireTest
 
         $children = $object->Children();
 
-        $this->assertDOSEquals(
+        $this->assertListEquals(
             array(
             array('Name' => 'A'),
             array('Name' => 'B'),

--- a/tests/php/i18n/i18nTest.php
+++ b/tests/php/i18n/i18nTest.php
@@ -242,10 +242,6 @@ class i18nTest extends SapphireTest
         i18n::set_locale($oldLocale);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Injection must be an associative array
-     */
     public function testNewTMethodSignature()
     {
         /** @var SymfonyMessageProvider $provider */
@@ -300,6 +296,9 @@ class i18nTest extends SapphireTest
         );
 
         // Passing in non-associative arrays for placeholders is now an error
+        $this->expectExceptionMessage(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Injection must be an associative array');
+
         i18n::_t(
             $entity, // has {name} placeholders
             $default,

--- a/tests/php/i18n/i18nTest.php
+++ b/tests/php/i18n/i18nTest.php
@@ -242,6 +242,10 @@ class i18nTest extends SapphireTest
         i18n::set_locale($oldLocale);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Injection must be an associative array
+     */
     public function testNewTMethodSignature()
     {
         /** @var SymfonyMessageProvider $provider */
@@ -296,7 +300,6 @@ class i18nTest extends SapphireTest
         );
 
         // Passing in non-associative arrays for placeholders is now an error
-        $this->setExpectedException(InvalidArgumentException::class, 'Injection must be an associative array');
         i18n::_t(
             $entity, // has {name} placeholders
             $default,

--- a/tests/php/i18n/i18nTextCollectorTest.php
+++ b/tests/php/i18n/i18nTextCollectorTest.php
@@ -71,6 +71,10 @@ PHP;
         );
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_Error_Notice
+     * @expectedExceptionMessage Missing localisation default for key i18nTestModule.INJECTIONS_3
+     */
     public function testCollectFromNewTemplateSyntaxUsingParserSubclass()
     {
         $c = i18nTextCollector::create();
@@ -114,10 +118,6 @@ SS;
 
         // Test warning is raised on empty default
         $c->setWarnOnEmptyDefault(true);
-        $this->setExpectedException(
-            PHPUnit_Framework_Error_Notice::class,
-            'Missing localisation default for key i18nTestModule.INJECTIONS_3'
-        );
         $c->collectFromTemplate($html, null, $mymodule);
     }
 
@@ -151,6 +151,10 @@ SS;
         );
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_Error_Notice
+     * @expectedExceptionMessage Missing localisation default for key Test.PRIOANDCOMMENT
+     */
     public function testCollectFromTemplateAdvanced()
     {
         $c = i18nTextCollector::create();
@@ -190,10 +194,6 @@ SS;
 
         // Test warning is raised on empty default
         $c->setWarnOnEmptyDefault(true);
-        $this->setExpectedException(
-            PHPUnit_Framework_Error_Notice::class,
-            'Missing localisation default for key Test.PRIOANDCOMMENT'
-        );
         $c->collectFromTemplate($html, 'Test', $mymodule);
     }
 
@@ -372,6 +372,9 @@ PHP;
 
     /**
      * Test extracting entities from the new _t method signature
+     *
+     * @expectedException PHPUnit_Framework_Error_Notice
+     * @expectedExceptionMessage Missing localisation default for key i18nTestModule.INJECTIONS4
      */
     public function testCollectFromCodeNewSignature()
     {
@@ -419,10 +422,6 @@ PHP;
         $this->assertEquals($expectedArray, $collectedTranslatables);
 
         // Test warning is raised on empty default
-        $this->setExpectedException(
-            PHPUnit_Framework_Error_Notice::class,
-            'Missing localisation default for key i18nTestModule.INJECTIONS4'
-        );
         $php = <<<PHP
 _t('i18nTestModule.INJECTIONS4', array("name"=>"Cat", "greeting"=>"meow", "goodbye"=>"meow"));
 PHP;

--- a/tests/php/i18n/i18nTextCollectorTest.php
+++ b/tests/php/i18n/i18nTextCollectorTest.php
@@ -71,10 +71,6 @@ PHP;
         );
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Notice
-     * @expectedExceptionMessage Missing localisation default for key i18nTestModule.INJECTIONS_3
-     */
     public function testCollectFromNewTemplateSyntaxUsingParserSubclass()
     {
         $c = i18nTextCollector::create();
@@ -118,6 +114,9 @@ SS;
 
         // Test warning is raised on empty default
         $c->setWarnOnEmptyDefault(true);
+        $this->expectException(PHPUnit_Framework_Error_Notice::class);
+        $this->expectExceptionMessage('Missing localisation default for key i18nTestModule.INJECTIONS_3');
+
         $c->collectFromTemplate($html, null, $mymodule);
     }
 
@@ -151,10 +150,6 @@ SS;
         );
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Notice
-     * @expectedExceptionMessage Missing localisation default for key Test.PRIOANDCOMMENT
-     */
     public function testCollectFromTemplateAdvanced()
     {
         $c = i18nTextCollector::create();
@@ -194,6 +189,9 @@ SS;
 
         // Test warning is raised on empty default
         $c->setWarnOnEmptyDefault(true);
+        $this->expectException(PHPUnit_Framework_Error_Notice::class);
+        $this->expectExceptionMessage('Missing localisation default for key Test.PRIOANDCOMMENT');
+
         $c->collectFromTemplate($html, 'Test', $mymodule);
     }
 
@@ -372,9 +370,6 @@ PHP;
 
     /**
      * Test extracting entities from the new _t method signature
-     *
-     * @expectedException PHPUnit_Framework_Error_Notice
-     * @expectedExceptionMessage Missing localisation default for key i18nTestModule.INJECTIONS4
      */
     public function testCollectFromCodeNewSignature()
     {
@@ -422,6 +417,9 @@ PHP;
         $this->assertEquals($expectedArray, $collectedTranslatables);
 
         // Test warning is raised on empty default
+        $this->expectException(PHPUnit_Framework_Error_Notice::class);
+        $this->expectExceptionMessage('Missing localisation default for key i18nTestModule.INJECTIONS4');
+
         $php = <<<PHP
 _t('i18nTestModule.INJECTIONS4', array("name"=>"Cat", "greeting"=>"meow", "goodbye"=>"meow"));
 PHP;


### PR DESCRIPTION
As discussed in [Slack](https://silverstripe-users.slack.com/archives/C6PLF83H9/p1506493049000056) I renamed SapphireTest's `assertDOS*()` methods to `assertList*()` 

Todo:
- [x] write tests for that assertions
- [x] make assert* static methods
- [x] refactor assert* to show a meaningful failure message and the actual test location (throw exception)
- - [x] assertListAllMatch
- - [x] assertListContains
- - [x] assertListNotContains
- - [x] assertListEquals
- [x] write test for new Constraint classes
- [ ] should we rename and deprecate SapphireTest also, as this is a relict from good ol' 2.x days?

