### PR TITLE
NEW Add (alt text) to title field for clarity

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -131,6 +131,8 @@ class Image extends File implements Flushable {
 		$fileAttributes = $fields->fieldByName('Root.Main.FilePreview')->fieldByName('FilePreviewData');
 		$fileAttributes->push(new ReadonlyField("Dimensions", _t('AssetTableField.DIM','Dimensions') . ':'));
 
+		$fields->fieldByName('Root.Main.Title')->setTitle(_t('Image.TITLE', 'Title (alt text)'));
+
 		return $fields;
 	}
 


### PR DESCRIPTION
We use the Title field for the alt tag when displaying an image, if it's defined. This PR makes it a bit clearer to users that it's used for that.

cc @clarkepaul 