### PR TITLE
NEW Make Member::changePassword extensible

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1680,8 +1680,10 @@ class Member extends DataObject
     }
 
     /**
-     * Change password. This will cause rehashing according to
-     * the `PasswordEncryption` property.
+     * Change password. This will cause rehashing according to the `PasswordEncryption` property. This method will
+     * allow extensions to perform actions and augment the validation result if required before the password is written
+     * and can check it after the write also. Note that the onAfterChangePassword extension point receives a clone of
+     * the validation result which cannot be modified.
      *
      * @param string $password Cleartext password
      * @return ValidationResult
@@ -1691,10 +1693,14 @@ class Member extends DataObject
         $this->Password = $password;
         $valid = $this->validate();
 
+        $this->extend('onBeforeChangePassword', $password, $valid);
+
         if ($valid->isValid()) {
             $this->AutoLoginHash = null;
             $this->write();
         }
+
+        $this->extend('onAfterChangePassword', $password, $valid);
 
         return $valid;
     }

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -11,6 +11,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\ValidationException;
+use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Security\Group;
 use SilverStripe\Security\IdentityStore;
 use SilverStripe\Security\Member;
@@ -1461,5 +1462,21 @@ class MemberTest extends FunctionalTest
             });
         });
         $this->assertEmpty($member);
+    }
+
+    public function testChangePasswordWithExtensionsThatModifyValidationResult()
+    {
+        // Default behaviour
+        $member = $this->objFromFixture(Member::class, 'admin');
+        $result = $member->changePassword('my-secret-new-password');
+        $this->assertInstanceOf(ValidationResult::class, $result);
+        $this->assertTrue($result->isValid());
+
+        // With an extension added
+        Member::add_extension(MemberTest\ExtendedChangePasswordExtension::class);
+        $member = $this->objFromFixture(Member::class, 'admin');
+        $result = $member->changePassword('my-second-secret-password');
+        $this->assertInstanceOf(ValidationResult::class, $result);
+        $this->assertFalse($result->isValid());
     }
 }

--- a/tests/php/Security/MemberTest/ExtendedChangePasswordExtension.php
+++ b/tests/php/Security/MemberTest/ExtendedChangePasswordExtension.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SilverStripe\Security\Tests\MemberTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\ValidationResult;
+
+/**
+ * Extension that does something extra when changing a member's password
+ */
+class ExtendedChangePasswordExtension extends DataExtension implements TestOnly
+{
+    public function onBeforeChangePassword($newPassword, $valid)
+    {
+        $valid->addError('Extension failed to handle Mary changing her password');
+    }
+}


### PR DESCRIPTION
PR allows extensions to perform logic after core when `Member::changePassword` is called. Extensions are provided the member instance, the new password and the current validation result.

If an extension returns a ValidationResult it will be merged and returned with the original.

Use case: the LDAP module's reset password functionality doesn't need to completely override the `doChangePassword` functionality, but it also can't really just call `parent::doChangePassword` then handle the return since it's always a HTTPResponse, regardless of the result of the operation. This change would mean that it can simply add `onAfterChangePassword(...)` to LDAPMemberExtension to sync the new password to an AD server instead.

Another option might be to refactor `doChangePassword::doChangePassword` into smaller (more overloadable) methods. I'm open to suggestions here!