### PR TITLE
MINOR Separate some areas of logic in LostPasswordHandler to make them more overridable

### DIFF
--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -283,7 +283,10 @@ class ChangePasswordHandler extends RequestHandler
 
         // Redirect to backurl
         $backURL = $this->getBackURL();
-        if ($backURL) {
+        if ($backURL
+            // Don't redirect back to itself
+            && $backURL !== Security::singleton()->Link('changepassword')
+        ) {
             return $this->redirect($backURL);
         }
 


### PR DESCRIPTION
This PR does this:

* Don't redirect from `/Security/changepassword` back to `/Security/changepassword` when resetting your password if it's set as the "back URL"
* Separate some logic out of `LostPasswordHandler:: forgotPassword` into their own methods to allow child classes to modify behaviour more easily without overloading `forgotPassword` entirely
* Use the configurable `unique_identifier_field` property for the input form data as well as the lookup field on Member