### PR TITLE
NEW Ensure changePassword is called by onBeforeWrite for a consistent API

### DIFF
--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -2507,6 +2507,7 @@ New `TimeField` methods replace `getConfig()` / `setConfig()`
 
  * `LoginForm` now has an abstract method `getAuthenticatorName()`. If you have made subclasses of this,
    you will need to define this method and return a short name describing the login method.
- * `MemberLoginForm` has a new constructor argument for the authenticator class, athough tis is usually
+ * `MemberLoginForm` has a new constructor argument for the authenticator class, although this is usually
    constructed by `MemberAuthenticator` and won't affect normal use.
- * `Authenticator` methods `register` and `unregister` are deprecated in favor of using `Config`
+ * `Authenticator` methods `register` and `unregister` are deprecated in favour of using `Config`
+ * Unused `SetPassword` property removed from `Member`. Use `Member::changePassword` or set `Password` directly.

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -56,7 +56,6 @@ use SilverStripe\ORM\ValidationResult;
  * @property int $FailedLoginCount
  * @property string $DateFormat
  * @property string $TimeFormat
- * @property string $SetPassword Pseudo-DB field for temp storage. Not emitted to DB
  */
 class Member extends DataObject
 {
@@ -858,10 +857,6 @@ class Member extends DataObject
      */
     public function onBeforeWrite()
     {
-        if ($this->SetPassword && !$this->passwordChangesToWrite) {
-            $this->Password = $this->SetPassword;
-        }
-
         // If a member with the same "unique identifier" already exists with a different ID, don't allow merging.
         // Note: This does not a full replacement for safeguards in the controller layer (e.g. in a registration form),
         // but rather a last line of defense against data inconsistencies.
@@ -1650,12 +1645,6 @@ class Member extends DataObject
         if (!$this->ID || $this->isChanged('Password')) {
             if ($this->Password && $validator) {
                 $valid->combineAnd($validator->validate($this->Password, $this));
-            }
-        }
-
-        if ((!$this->ID && $this->SetPassword) || $this->isChanged('SetPassword')) {
-            if ($this->SetPassword && $validator) {
-                $valid->combineAnd($validator->validate($this->SetPassword, $this));
             }
         }
 


### PR DESCRIPTION
This ensures that however you change a member's password, `Member::changePassword` is always called.

Resolves #7435 

**Update:** I've removed the `Member::SetPassword` property. It's unused from what I can tell. Was introduced in SS 2.2.2 and hasn't been touched since then.