### PR TITLE
Remove TinyMCE spellchecker instructions

### DIFF
--- a/docs/en/02_Developer_Guides/03_Forms/Field_types/03_HTMLEditorField.md
+++ b/docs/en/02_Developer_Guides/03_Forms/Field_types/03_HTMLEditorField.md
@@ -331,33 +331,3 @@ Have a look in `HtmlEditorField.js` and the `ss.editorWrapper` object to get you
 on your own editor wrapper. Note that the [HtmlEditorConfig](api:SilverStripe\Forms\HTMLEditor\HtmlEditorConfig) is currently hardwired to support TinyMCE,
 so its up to you to either convert existing configuration as applicable,
 or start your own configuration.
-
-### Integrating a Spellchecker for TinyMCE
-
-The TinyMCE editor uses spellchecking integrated into the browser if possible
-([docs](http://www.tinymce.com/wiki.php/Plugin3x:spellchecker)).
-Most modern browsers support it, although Internet Explorer only has limited
-support in IE10. Alternatively, you can use the PSpell PHP module for server side checks.
-Assuming you have the module installed, here's how you enable its use in `mysite/_config.php`:
-
-
-```php
-    HtmlEditorConfig::get('cms')->enablePlugins('spellchecker', 'contextmenu');
-    HtmlEditorConfig::get('cms')->addButtonsToLine(2, 'spellchecker');
-    HtmlEditorConfig::get('cms')->setOption(
-        'spellchecker_rpc_url', 
-        THIRDPARTY_DIR . '/tinymce-spellchecker/rpc.php'
-    );
-    HtmlEditorConfig::get('cms')->setOption('browser_spellcheck', false);
-```
-
-Now change the default spellchecker in `framework/thirdparty/tinymce-spellchecker/config.php`:
-
-
-```php
-    
-    // ...
-    $config['general.engine'] = 'PSpell';
-```
-
-


### PR DESCRIPTION
They're broken since you can't access PHP files in the vendor dir any more,
and they're not easily fixed by creating a new rpc.php file in the webroot.
There's something around TinyMCE missing a base_uri.

Regardless, browsers have great built-in spellcheck these days,
so server-side spellchecking is more of an edge case that we don't have to cater for in core.

Merge with https://github.com/silverstripe/silverstripe-admin/pull/289