### PR TITLE
Implement recommended pecl channel-update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
 
 before_script:
 # Init PHP
-  - export CORE_RELEASE=$TRAVIS_BRANCH
+  - pecl channel-update pecl.php.net
   - printf "\n" | pecl install imagick
   - phpenv rehash
   - phpenv config-rm xdebug.ini || true


### PR DESCRIPTION
Attempt to fix the below.

```
$ printf "\n" | pecl install imagick
WARNING: channel "pecl.php.net" has updated its protocols, use "pecl channel-update pecl.php.net" to update
Could not download from "http://pecl.php.net/get/imagick-3.4.3.tgz", cannot download "pecl/imagick" (Connection to `pecl.php.net:80' failed: Connection timed out)
Error: cannot download "pecl/imagick"
Download failed
install failed
```