### PR TITLE
FIX Dont use var_export for cache key generation

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -3224,7 +3224,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 		$SNG = singleton($callerClass);
 
 		$cacheComponents = array($filter, $orderby, $SNG->extend('cacheKeyComponent'));
-		$cacheKey = md5(var_export($cacheComponents, true));
+		$cacheKey = md5(serialize($cacheComponents));
 
 		// Flush destroyed items out of the cache
 		if($cache && isset(DataObject::$_cache_get_one[$callerClass][$cacheKey])


### PR DESCRIPTION
`var_export` doesn't handle circular references so shouldn't be used in this context to create a cache key

move to `serialize` for more resiliant cache key generation