### PR TITLE
Expose sake via vendor/bin dir with composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
             "homepage": "http://silverstripe.org"
         }
     ],
+    "bin": [
+        "sake"
+    ],
     "require": {
         "composer/installers": "~1.0",
         "embed/embed": "^3.0",


### PR DESCRIPTION
Well it's about time we could use `vendor/bin/sake`!