### PR TITLE
BUG switch to `trigger_error()` when a resource is not found

### DIFF
--- a/src/Control/SimpleResourceURLGenerator.php
+++ b/src/Control/SimpleResourceURLGenerator.php
@@ -77,7 +77,7 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
             $exists = file_exists($absolutePath);
         }
         if (!$exists) {
-            throw new InvalidArgumentException("File {$relativePath} does not exist");
+            trigger_error("File {$relativePath} does not exist", E_USER_NOTICE);
         }
 
         // Apply url rewrites
@@ -89,7 +89,7 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
         // Apply nonce
         $nonce = '';
         // Don't add nonce to directories
-        if ($this->nonceStyle && is_file($absolutePath)) {
+        if ($this->nonceStyle && $exists && is_file($absolutePath)) {
             $nonce = (strpos($relativePath, '?') === false) ? '?' : '&';
 
             switch ($this->nonceStyle) {

--- a/src/Core/Manifest/ModuleResourceLoader.php
+++ b/src/Core/Manifest/ModuleResourceLoader.php
@@ -106,9 +106,7 @@ class ModuleResourceLoader implements TemplateGlobalProvider
             throw new InvalidArgumentException("Can't find module '$module'");
         }
         $resourceObj = $moduleObj->getResource($resource);
-        if (!$resourceObj->exists()) {
-            throw new InvalidArgumentException("Module '$module' does not have specified resource '$resource'");
-        }
+
         return $resourceObj;
     }
 }

--- a/tests/php/Control/SimpleResourceURLGeneratorTest.php
+++ b/tests/php/Control/SimpleResourceURLGeneratorTest.php
@@ -64,4 +64,12 @@ class SimpleResourceURLGeneratorTest extends SapphireTest
             $generator->urlForResource($module->getResource('client/style.css'))
         );
     }
+
+    public function testURLForResourceFailsGracefully()
+    {
+        /** @var SimpleResourceURLGenerator $generator */
+        $generator = Injector::inst()->get(ResourceURLGenerator::class);
+        $url = @$generator->urlForResource('doesnotexist.jpg');
+        $this->assertEquals('/doesnotexist.jpg', $url);
+    }
 }


### PR DESCRIPTION
Rather than throw an exception.
This will now give a notice, which can be logged through a logger in production, and you can disable showing the notice through the normal php means `error_reporting()`

Fixes https://github.com/silverstripe/silverstripe-framework/issues/7333

