### PR TITLE
BUGFIX: Fixed issue on Windows where the BASE_URL constant would get set wrong if the site was in a sub-folder of the web root

### DIFF
--- a/src/includes/constants.php
+++ b/src/includes/constants.php
@@ -100,7 +100,7 @@ if (!defined('BASE_URL')) {
         // This tends not to work on CLI
         $path = realpath($_SERVER['SCRIPT_FILENAME']);
         if (substr($path, 0, strlen(BASE_PATH)) == BASE_PATH) {
-            $urlSegmentToRemove = substr($path, strlen(BASE_PATH));
+            $urlSegmentToRemove = str_replace('\\', '/', substr($path, strlen(BASE_PATH)));
             if (substr($_SERVER['SCRIPT_NAME'], -strlen($urlSegmentToRemove)) == $urlSegmentToRemove) {
                 $baseURL = substr($_SERVER['SCRIPT_NAME'], 0, -strlen($urlSegmentToRemove));
                 // ltrim('.'), normalise slashes to '/', and rtrim('/')


### PR DESCRIPTION
On Windows the BASE_URL constant will get incorrectly set to ``/`` if the SilverStripe site is in a sub folder of the web root. This is thanks to windows using backslashes instead of forward slashes again, normalizing the ``$urlSegmentToRemove`` variable before attempting to remove it seems to address the issue.