### PR TITLE
ENHANCEMENT Allow extensions to intercept incorrect deletes on unpublish

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -1453,8 +1453,11 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
             ->filter('ID', $this->ID)
             ->dataQuery()
             ->query();
-        foreach ($srcQuery->queriedTables() as $table) {
-            $delete = new SQLDelete("\"$table\"", array('"ID"' => $this->ID));
+        $queriedTables = $srcQuery->queriedTables();
+        $this->extend('updateDeleteTables', $queriedTables, $srcQuery);
+        foreach ($queriedTables as $table) {
+            $delete = SQLDelete::create("\"$table\"", array('"ID"' => $this->ID));
+            $this->extend('updateDeleteTable', $delete, $table, $queriedTables, $srcQuery);
             $delete->execute();
         }
         // Remove this item out of any caches


### PR DESCRIPTION
The issue with the existing behaviour is that some queried tables are NOT a part of the hierarchy, and the subsequent delete could unintentionally delete objects outside of this object.

For instance, fluent uses a localisation table as an inner join. This existing behaviour deletes these locales, but using the ID of the record, not the ID of the localisation (which is a separate ID itself).

With the given extension points extensions are able to intercept these queries and rewrite the delete safely without violating database integrity.