### PR TITLE
BUG Ensure sake works when called from any directory

### DIFF
--- a/sake
+++ b/sake
@@ -9,39 +9,29 @@ Executes a SilverStripe command"
 	exit 1
 fi
 
-# find the silverstripe installation
+# find the silverstripe installation, looking first at sake
+# bin location, but falling back to current directory
 sakedir=`dirname $0`
+directory="$PWD"
 if [ -f "$sakedir/cli-script.php" ]; then
+    # Calling sake from vendor/silverstripe/framework/sake
 	framework="$sakedir"
-	base=`dirname $sakedir`
-elif [ -f ./cli-script.php ]; then
-	framework=.
-	base=..
+	base="$sakedir/../../.."
+elif [ -f "$sakedir/../silverstripe/framework/cli-script.php" ]; then
+    # Calling sake from vendor/bin/sake
+	framework="$sakedir/../silverstripe/framework"
+	base="$sakedir/../.."
+elif [ -f "$directory/vendor/silverstripe/framework/cli-script.php" ]; then
+    # Vendor framework (from base) if sake installed globally
+    framework="$directory/vendor/silverstripe/framework"
+    base=.
+elif [ -f "$directory/framework/cli-script.php" ]; then
+    # Legacy directory (from base) if sake installed globally
+    framework="$directory/framework"
+    base=.
 else
-	# look up the tree for the first parent folder that has a framework
-	# installation
-	slashes=${PWD//[^\/]/}
-	directory="$PWD"
-	base=.
-	for (( n=${#slashes}; n>0; --n )) do
-		if [ -d "$directory/vendor/silverstripe/framework" ]; then
-			framework="$directory/vendor/silverstripe/framework"
-
-			break
-		elif [ -d "$directory/framework" ]; then
-			framework="$directory/framework"
-
-			break
-		fi
-
-		directory=`dirname $directory`
-		base="$base."
-	done
-
-	if [ ! -f "$framework/cli-script.php" ]; then
-		echo "Can't find cli-script.php in $framework"
-		exit 1
-	fi
+    echo "Can't find cli-script.php in $sakedir"
+    exit 1
 fi
 
 # Find the PHP binary


### PR DESCRIPTION
Credit to the kind users of silverstripe-users slack for testing this out.

Checks have been simplified and cleaned up, checking:
 - relative path from vendor/bin/sake. (simlink dir)
 - relative path from vendor/silverstripe/framework/sake (real dir)
 - base relative search for vendor/silvestripe/framework (for global sake install)
 - base relative search for legacy framework (in case run on an old framework installation, for global sake install)

