### PR TITLE
FIX: Use isolated scope when requiring files for module activation

### DIFF
--- a/src/Core/Manifest/Module.php
+++ b/src/Core/Manifest/Module.php
@@ -158,7 +158,7 @@ class Module implements Serializable
     {
         $config = "{$this->path}/_config.php";
         if (file_exists($config)) {
-            require_once $config;
+            requireFile($config);
         }
     }
 
@@ -246,4 +246,16 @@ class Module implements Serializable
             ->getResource($path)
             ->exists();
     }
+}
+
+/**
+ * Scope isolated require - prevents access to $this, and prevents module _config.php
+ * files potentially leaking variables. Required argument $file is commented out
+ * to avoid leaking that into _config.php
+ *
+ * @param string $file
+ */
+function requireFile()
+{
+    require_once func_get_arg(0);
 }


### PR DESCRIPTION
Prevents access to `$this` inside `_config.php` files, and removes the need for [hacks to avoid exposing variables](https://github.com/silverstripe/silverstripe-asset-admin/blob/1.0.0-beta4/_config.php#L7) to other scopes.

Same approach used by [Composer](https://github.com/composer/composer/blob/e42e1156d51ca5494b058b1a7b480bc703c4f57a/src/Composer/Autoload/ClassLoader.php#L437-L445).