### PR TITLE
WIP: Adding 308 HTTP Response as an redirect code

### DIFF
--- a/src/Control/HTTPResponse.php
+++ b/src/Control/HTTPResponse.php
@@ -35,6 +35,7 @@ class HTTPResponse
         304 => 'Not Modified',
         305 => 'Use Proxy',
         307 => 'Temporary Redirect',
+        308 => 'Permanent Redirect',
         400 => 'Bad Request',
         401 => 'Unauthorized',
         403 => 'Forbidden',
@@ -71,7 +72,8 @@ class HTTPResponse
         303,
         304,
         305,
-        307
+        307,
+        308
     );
 
     /**


### PR DESCRIPTION
https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml

Often times, 308 are preferred over 301 redirects, as they tell the requester to, for example, re-POST a form submission on the final URL.