### PR TITLE
Remove dead code from GridFieldDetailForm

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm.php
+++ b/src/Forms/GridField/GridFieldDetailForm.php
@@ -66,8 +66,7 @@ class GridFieldDetailForm implements GridField_URLHandler
     public function getURLHandlers($gridField)
     {
         return array(
-            'item/$ID' => 'handleItem',
-            'autocomplete' => 'handleAutocomplete',
+            'item/$ID' => 'handleItem'
         );
     }
 


### PR DESCRIPTION
There is no action for 'autocomplete', there is no method 'handleAutocomplete', and out of the box there is no extension that applies it.
Manually testing the URL that would take us through such a handler does not give an exception about missing details from the URI (such as a required query string), but instead gives us an exception on there not being a handler for such.
`[Emergency] Uncaught BadMethodCallException: Object->__call(): the method 'handleAutocomplete' does not exist on 'SilverStripe\Forms\GridField\GridFieldDetailForm'`
@ e.g. `http://localhost/admin/pages/edit/EditForm/1/field/ElementalArea/autocomplete`.

Auto complete should be (and is) handled in it's own component code, such as https://github.com/silverstripe/silverstripe-framework/blob/4.0/src/Forms/GridField/GridFieldAddExistingAutocompleter.php#L210