### PR TITLE
FIX Do not escape the readonly values since they get escaped when rendered

### DIFF
--- a/src/Forms/LookupField.php
+++ b/src/Forms/LookupField.php
@@ -53,7 +53,6 @@ class LookupField extends MultiSelectField
         if ($mapped) {
             $attrValue = implode(', ', array_values($mapped));
 
-            $attrValue = Convert::raw2xml($attrValue);
             $inputValue = implode(', ', array_values($values));
         } else {
             $attrValue = '<i>('._t('SilverStripe\\Forms\\FormField.NONE', 'none').')</i>';


### PR DESCRIPTION
Since, in SS4, HTMLFragment is escaped by default in the template, this line of code results in double escaping.

Fixes #7474