### PR TITLE
Add composer autloading to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,16 @@
 		}
 	},
 	"autoload": {
-		"classmap": ["tests/behat/features/bootstrap"]
+		"psr-0": {
+			"SilverStripe\\": "src/",
+			"Zend_": "thirdparty/Zend/"
+		},
+		"classmap": [
+			"tests/behat/features/bootstrap",
+			"admin/code", "api", "cache", "cli", "control", "core", "dev", "email",  "filesystem",
+			"forms", "i18n", "model", "oembed", "parsers", "search", "security", "tasks", "view",
+			"thirdparty/php-peg", "thirdparty/simpletest", "thirdparty/zend_translate_railsyaml"
+		],
+		"exclude-from-classmap": ["view/SSTemplateParser.php.inc", "dev/phpunit/PhpUnitWrapper.php"]
 	}
 }

--- a/control/injector/Injector.php
+++ b/control/injector/Injector.php
@@ -260,7 +260,7 @@ class Injector {
 	 * @return Injector Reference to new active Injector instance
 	 */
 	public static function nest() {
-		$current = self::$instance;
+		$current = self::inst();
 
 		$new = clone $current;
 		$new->nestedFrom = $current;

--- a/core/Config.php
+++ b/core/Config.php
@@ -223,7 +223,7 @@ class Config {
 	 * @return Config Reference to new active Config instance
 	 */
 	public static function nest() {
-		$current = self::$instance;
+		$current = self::inst();
 
 		$new = clone $current;
 		$new->nestedFrom = $current;

--- a/dev/SapphireTest.php
+++ b/dev/SapphireTest.php
@@ -171,6 +171,13 @@ class SapphireTest extends PHPUnit_Framework_TestCase {
 
 	public function setUp() {
 
+		if (!defined('FRAMEWORK_PATH')) {
+			trigger_error(
+				'Missing constants, did you remember to include the test bootstrap in your phpunit.xml file?',
+				E_USER_WARNING
+			);
+		}
+
 		//nest config and injector for each test so they are effectively sandboxed per test
 		Config::nest();
 		Injector::nest();


### PR DESCRIPTION
Fixes #7229

I've implemented composer classmap autoloading and a couple of fixes to resolve issues where PHPUnit will throw a class not found error on SapphireTest.

This may also help performance as we'll be using the composer autoloader more often.