### PR TITLE
BUG Ensure readonly tree dropdown is safely encoded

### DIFF
--- a/src/Forms/LookupField.php
+++ b/src/Forms/LookupField.php
@@ -2,10 +2,10 @@
 
 namespace SilverStripe\Forms;
 
-use SilverStripe\ORM\ArrayLib;
-use SilverStripe\ORM\FieldType\DBField;
-use SilverStripe\ORM\DataObjectInterface;
 use SilverStripe\Core\Convert;
+use SilverStripe\ORM\ArrayLib;
+use SilverStripe\ORM\DataObjectInterface;
+use SilverStripe\ORM\FieldType\DBField;
 
 /**
  * Read-only complement of {@link DropdownField}.
@@ -36,23 +36,22 @@ class LookupField extends MultiSelectField
         $values = $this->getValueArray();
 
         // Get selected values
-        $mapped = array();
+        $mapped = [];
         foreach ($values as $value) {
             if (isset($source[$value])) {
-                $mapped[] = $source[$value];
+                $mapped[] = Convert::raw2xml($source[$value]);
             }
         }
 
         // Don't check if string arguments are matching against the source,
         // as they might be generated HTML diff views instead of the actual values
         if ($this->value && is_string($this->value) && empty($mapped)) {
-            $mapped = array(trim($this->value));
-            $values = array();
+            $mapped[] = Convert::raw2xml(trim($this->value));
+            $values = [];
         }
 
         if ($mapped) {
             $attrValue = implode(', ', array_values($mapped));
-
             $inputValue = implode(', ', array_values($values));
         } else {
             $attrValue = '<i>('._t('SilverStripe\\Forms\\FormField.NONE', 'none').')</i>';

--- a/src/Forms/TreeDropdownField_Readonly.php
+++ b/src/Forms/TreeDropdownField_Readonly.php
@@ -8,18 +8,15 @@ class TreeDropdownField_Readonly extends TreeDropdownField
 
     public function Field($properties = array())
     {
-        $fieldName = $this->getLabelField();
+        $fieldName = $this->getTitleField();
         if ($this->value) {
             $keyObj = $this->objectForKey($this->value);
-            $obj = $keyObj ? $keyObj->$fieldName : '';
+            $title = $keyObj ? $keyObj->$fieldName : '';
         } else {
-            $obj = null;
+            $title = null;
         }
 
-        $source = array(
-            $this->value => $obj
-        );
-
+        $source = [ $this->value => $title ];
         $field = new LookupField($this->name, $this->title, $source);
         $field->setValue($this->value);
         $field->setForm($this->form);

--- a/src/Forms/TreeMultiselectField_Readonly.php
+++ b/src/Forms/TreeMultiselectField_Readonly.php
@@ -9,27 +9,28 @@ class TreeMultiselectField_Readonly extends TreeMultiselectField
 
     public function Field($properties = array())
     {
-        $titleArray = $itemIDs = array();
-        $titleList = $itemIDsList = "";
-        if ($items = $this->getItems()) {
-            foreach ($items as $item) {
-                $titleArray[] = $item->Title;
-            }
-            foreach ($items as $item) {
-                $itemIDs[] = $item->ID;
-            }
-            if ($titleArray) {
-                $titleList = implode(", ", $titleArray);
-            }
-            if ($itemIDs) {
-                $itemIDsList = implode(",", $itemIDs);
-            }
+        // Build list of titles
+        $titleField = $this->getTitleField();
+        $items = $this->getItems();
+        $titleArray = [];
+        foreach ($items as $item) {
+            $titleArray[] = $item->$titleField;
         }
+        $titleList = implode(", ", $titleArray);
 
+        // Build list of values
+        $itemIDs = [];
+        foreach ($items as $item) {
+            $itemIDs[] = $item->ID;
+        }
+        $itemIDsList = implode(",", $itemIDs);
+
+        // Readonly field for display
         $field = new ReadonlyField($this->name . '_ReadonlyValue', $this->title);
         $field->setValue($titleList);
         $field->setForm($this->form);
 
+        // Store values to hidden field
         $valueField = new HiddenField($this->name);
         $valueField->setValue($itemIDsList);
         $valueField->setForm($this->form);

--- a/tests/php/Forms/TreeDropdownFieldTest.yml
+++ b/tests/php/Forms/TreeDropdownFieldTest.yml
@@ -11,6 +11,7 @@ SilverStripe\Assets\Folder:
 SilverStripe\Assets\File:
   asdf:
     Filename: assets/FileTest.txt
+    Title: '<Special & characters>'
   subfolderfile1:
     Filename: assets/FileTest-subfolder/TestFile1InSubfolder.txt
     Name: TestFile1InSubfolder

--- a/tests/php/Forms/TreeMultiselectFieldTest.php
+++ b/tests/php/Forms/TreeMultiselectFieldTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SilverStripe\Forms\Tests;
+
+use SilverStripe\Assets\File;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\TreeMultiselectField;
+
+class TreeMultiselectFieldTest extends SapphireTest
+{
+    protected static $fixture_file = 'TreeDropdownFieldTest.yml';
+
+    public function testReadonly()
+    {
+        $field = new TreeMultiselectField('TestTree', 'Test tree', File::class);
+        $asdf = $this->objFromFixture(File::class, 'asdf');
+        $subfolderfile1 = $this->objFromFixture(File::class, 'subfolderfile1');
+        $field->setValue(implode(',', [$asdf->ID, $subfolderfile1->ID]));
+
+        $readonlyField = $field->performReadonlyTransformation();
+        $this->assertEquals(
+            <<<"HTML"
+<span id="TestTree_ReadonlyValue" class="readonly">
+	&lt;Special &amp; characters&gt;, TestFile1InSubfolder
+</span><input type="hidden" name="TestTree" value="{$asdf->ID},{$subfolderfile1->ID}" class="hidden" id="TestTree" />
+HTML
+            ,
+            (string)$readonlyField->Field()
+        );
+    }
+}


### PR DESCRIPTION
Removed legacy entwine dead code
Added soft-deprecation to label field

Replaces prior fix https://github.com/silverstripe/silverstripe-framework/pull/7512

Fixes https://github.com/silverstripe/silverstripe-framework/issues/7474