### PR TITLE
Traversing searchcontext fix

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3215,10 +3215,14 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
                 //   'field' => 'NumericField', // optional
                 //   'title' => 'My Title', // optional
                 // ))
-                $rewrite[$identifer] = array_merge(
-                    array('filter' => $this->relObject($identifer)->config()->get('default_search_filter_class')),
-                    (array)$specOrName
-                );
+                try {
+                    $rewrite[$identifer] = array_merge(
+                        array('filter' => $this->relObject($identifer)->config()->get('default_search_filter_class')),
+                        (array)$specOrName
+                    );
+                } catch (Exception $exception) {
+                    $rewrite[$identifer] = (array)$specOrName;
+                }
             } else {
                 // Format: array('MyFieldName' => 'ExactMatchFilter')
                 $rewrite[$identifer] = array(

--- a/src/ORM/Search/SearchContext.php
+++ b/src/ORM/Search/SearchContext.php
@@ -356,12 +356,12 @@ class SearchContext
             if (empty($searchValue)) {
                 continue;
             }
-            $filter = $this->getFilter($searchField);
+            $filter = $this->getFilter(str_replace('__', '.', $searchField));
             if (!$filter) {
                 continue;
             }
 
-            $field = $this->fields->fieldByName($filter->getFullName());
+            $field = $this->fields->fieldByName(str_replace('.', '__', $filter->getFullName()));
             if (!$field) {
                 continue;
             }

--- a/tests/php/ORM/Search/TraversingSearchContextTest.php
+++ b/tests/php/ORM/Search/TraversingSearchContextTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Search;
+
+use SilverStripe\Dev\SapphireTest;
+
+class TraversingSearchContextTest extends SapphireTest
+{
+
+    protected static $fixture_file = 'TraversingSearchContextTest.yml';
+
+    protected static $extra_dataobjects = array(
+        TraversingSearchContextTest\Student::class,
+        TraversingSearchContextTest\Teacher::class,
+        TraversingSearchContextTest\Competency::class,
+    );
+
+    // searchableFields() called on a singleton DataObject does not throw an exception for traversing search fields
+    // while trying to find a default search filter type but returns the explicitly set filter
+    public function testTraversingSearchableFields()
+    {
+        $student = singleton(TraversingSearchContextTest\Student::class);
+        $fields = $student->searchableFields();
+        $statics = TraversingSearchContextTest\Student::config()->get('searchable_fields');
+        $this->assertEquals($statics, $fields);
+    }
+
+    public function testTraversingSearchContextSummary()
+    {
+        $student = singleton(TraversingSearchContextTest\Student::class);
+        $context = $student->getDefaultSearchContext();
+        $context->setSearchParams([
+            'Name' => 'James',
+            'Teachers__Name' => 'Susann',
+            'Teachers__Competencies__Name' => 'Physics',
+        ]);
+        $summary = $context->getSummary()->toNestedArray();
+        $this->assertEquals([
+            [ 'Field' => 'Name', 'Value' => 'James' ],
+            [ 'Field' => 'Teacher', 'Value' => 'Susann' ],
+            [ 'Field' => 'Competency', 'Value' => 'Physics' ],
+        ], $summary);
+    }
+
+    public function testTraversingSearchContextResults()
+    {
+        $student = singleton(TraversingSearchContextTest\Student::class);
+        $context = $student->getDefaultSearchContext();
+        $results = $context->getResults([
+            'Teachers__Competencies__Name' => 'Physics',
+        ]);
+        $this->assertEquals(['James'], array_values($results->map()->toArray()));
+    }
+}

--- a/tests/php/ORM/Search/TraversingSearchContextTest.yml
+++ b/tests/php/ORM/Search/TraversingSearchContextTest.yml
@@ -1,0 +1,34 @@
+SilverStripe\ORM\Tests\Search\TraversingSearchContextTest\Competency:
+  competency1:
+    Name: Math
+  competency2:
+    Name: Physics
+  competency3:
+    Name: Biology
+  competency4:
+    Name: English
+  competency5:
+    Name: French
+
+SilverStripe\ORM\Tests\Search\TraversingSearchContextTest\Teacher:
+  teacher1:
+    Name: Susann
+    Competencies:
+      - =>SilverStripe\ORM\Tests\Search\TraversingSearchContextTest\Competency.competency2
+      - =>SilverStripe\ORM\Tests\Search\TraversingSearchContextTest\Competency.competency3
+  teacher2:
+    Name: Anna
+    Competencies:
+      - =>SilverStripe\ORM\Tests\Search\TraversingSearchContextTest\Competency.competency4
+      - =>SilverStripe\ORM\Tests\Search\TraversingSearchContextTest\Competency.competency5
+  teacher3:
+    Name: Mary
+
+SilverStripe\ORM\Tests\Search\TraversingSearchContextTest\Student:
+  student1:
+    Name: James
+    Teachers:
+      - =>SilverStripe\ORM\Tests\Search\TraversingSearchContextTest\Teacher.teacher1
+      - =>SilverStripe\ORM\Tests\Search\TraversingSearchContextTest\Teacher.teacher3
+  student2:
+    Name: John

--- a/tests/php/ORM/Search/TraversingSearchContextTest/Competency.php
+++ b/tests/php/ORM/Search/TraversingSearchContextTest/Competency.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Search\TraversingSearchContextTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class Competency extends DataObject implements TestOnly
+{
+    private static $table_name = 'TraversingSearchContextTest_Competency';
+
+    private static $db = array(
+        'Name' => 'Varchar'
+    );
+
+    private static $belongs_many_many = array(
+        'Teachers' => Teacher::class,
+    );
+}

--- a/tests/php/ORM/Search/TraversingSearchContextTest/Student.php
+++ b/tests/php/ORM/Search/TraversingSearchContextTest/Student.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Search\TraversingSearchContextTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\Filters\PartialMatchFilter;
+
+class Student extends DataObject implements TestOnly
+{
+    private static $table_name = 'TraversingSearchContextTest_Student';
+
+    private static $db = array(
+        'Name' => 'Varchar'
+    );
+
+    private static $many_many = array(
+        'Teachers' => Teacher::class,
+    );
+
+    private static $searchable_fields = [
+        'Name' => [
+            'filter' => PartialMatchFilter::class,
+            'field' => TextField::class,
+            'title' => 'Name',
+        ],
+        'Teachers.Name' => [
+            'filter' => PartialMatchFilter::class,
+            'field' => TextField::class,
+            'title' => 'Teacher',
+        ],
+        'Teachers.Competencies.Name' => [
+            'filter' => PartialMatchFilter::class,
+            'field' => TextField::class,
+            'title' => 'Competency',
+        ],
+    ];
+}

--- a/tests/php/ORM/Search/TraversingSearchContextTest/Teacher.php
+++ b/tests/php/ORM/Search/TraversingSearchContextTest/Teacher.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Search\TraversingSearchContextTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class Teacher extends DataObject implements TestOnly
+{
+    private static $table_name = 'TraversingSearchContextTest_Teacher';
+
+    private static $db = array(
+        'Name' => 'Varchar'
+    );
+
+    private static $belongs_many_many = array(
+        'Students' => Student::class,
+    );
+
+    private static $many_many = array(
+        'Competencies' => Competency::class,
+    );
+}


### PR DESCRIPTION
I am using ModelAdmin to manage a nested model (A many many B many_many C). When I set up $searchable_fields in A to search A for a property in C (A.B.C.Name) I get an Error saying:

    [Emergency] Uncaught BadMethodCallException: Object->__call(): the method 'relation' does not exist on 'SilverStripe\ORM\UnsavedRelationList'

because DataObject::searchableFields() is traversing into the relation, trying to find a default_search_filter_class for C.Name to be merged with the specific filter spec, specified in the config or like in my case private static.

This can be worked around by not defining the filter in the config but by overloading DataObject::searchableFields() and adding the filter there.

There are various ways to fix the issue and my favourite is to return null on unresolvable traversal paths in DataObject::relObject(), but in my request I went with catching the exception, because it's least prone to cause side effects.

Here is my setup:

```
class A extends SilverStripe\ORM\DataObject
{
	private static $db = [
		'Name' => 'Varchar',
	];

	private static $many_many = [
		'Bs' => B::class,
	];

	private static $searchable_fields = [
		'Name' => [
			'filter' => 'PartialMatchFilter',
			'field' => SilverStripe\Forms\TextField::class,
			'title' => 'Name',
		],
		'Bs.Cs.Name' => [
			'filter' => 'PartialMatchFilter',
			'field' => SilverStripe\Forms\TextField::class,
			'title' => 'Name of Bs of Cs',
		],
	];
}

class B extends SilverStripe\ORM\DataObject
{
	private static $db = [
		'Name' => 'Varchar',
	];

	private static $belongs_many_many = [
		'As' => A::class,
	];

	private static $many_many = [
		'Cs' => C::class,
	];
}

class C extends SilverStripe\ORM\DataObject
{
	private static $db = [
		'Name' => 'Varchar',
	];

	private static $belongs_many_many = [
		'Bs' => B::class,
	];
}
```

The other issue with traversing SearchContexts is that they are not showing in the search summary: E.g. if you search for A.B.C.Name in the ModelAdmin, the parameterName = searchValue pair doesn't show at the to of the GridField to indicate that you are looking at a filtered list, consequently the "clear filter" button is missing also.

This is due to the fact that SearchContext::getSummary() is failing to find a filter A__B__C__Name (because it's called A.B.C.Name) and later failing to find a field called q[A.B.C.Name] (because it is called q[A__B__C__Name]).

I am not entirely sure how to best implement the translation between field and filter names. In order to demonstrate the issue the pull request shows an ad hoc translation.

Sorry for basing this off of 4.0.0-rc1. That's all I had for testing.

Thanks for the many cool new features in ss4 which allowed me to pull of a project, that would have been impossible in the previous version!