### PR TITLE
ENHANCEMENT Adjust tinymce footer, remove branding and restore path

### DIFF
--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -225,12 +225,14 @@ class TinyMCEConfig extends HTMLEditorConfig
         'priority' => 0, // used for Per-member config override
         'browser_spellcheck' => true,
         'body_class' => 'typography',
-        'elementpath' => false, // https://www.tinymce.com/docs/configure/editor-appearance/#elementpath
+        'statusbar' => true,
+        'elementpath' => true, // https://www.tinymce.com/docs/configure/editor-appearance/#elementpath
         'relative_urls' => true,
         'remove_script_host' => true,
         'convert_urls' => false, // Prevent site-root images being rewritten to base relative
         'menubar' => false,
         'language' => 'en',
+        'branding' => false,
     );
 
     /**


### PR DESCRIPTION
FIxes https://github.com/silverstripe/silverstripe-admin/issues/294

Since the option to restore the path was discovered, I've opted to use this instead of modifying the default tinymce styles.