### PR TITLE
CSVParser API doc fix

### DIFF
--- a/dev/CSVParser.php
+++ b/dev/CSVParser.php
@@ -11,9 +11,9 @@
  * <code>
  * $parser = new CSVParser('myfile.csv');
  * $parser->mapColumns(array(
- *    'first name' => 'FirstName'
+ *    'first name' => 'FirstName',
  *    'lastname' => 'Surname',
- *    'last name' => 'Surname',
+ *    'last name' => 'Surname'
  * ));
  * foreach($parser as $row) {
  * 	 // $row is a map of column name => column value


### PR DESCRIPTION
CSVParser API doc example code has an error:
http://api.silverstripe.org/en/3.6/class-CSVParser.html

    $parser->mapColumns(array(
       'first name' => 'FirstName'
       'lastname' => 'Surname',
       'last name' => 'Surname',
    ));

This fixes that example to be correct.