### PR TITLE
BUG Remove usage of deprecated each() and use a helper method instead

### DIFF
--- a/src/ORM/ArrayLib.php
+++ b/src/ORM/ArrayLib.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\ORM;
 
+use Generator;
+
 /**
  * Library of static methods for manipulating arrays.
  */
@@ -262,5 +264,32 @@ class ArrayLib
         }
 
         return $out;
+    }
+
+    /**
+     * Iterate list, but allowing for modifications to the underlying list.
+     * Items in $list will only be iterated exactly once for each key, and supports
+     * items being removed or deleted.
+     * List must be associative.
+     *
+     * @param array $list
+     * @return Generator
+     */
+    public static function iterateVolatile(array &$list)
+    {
+        // Keyed by already-iterated items
+        $iterated = [];
+        // Get all items not yet iterated
+        while ($items = array_diff_key($list, $iterated)) {
+            // Yield all results
+            foreach ($items as $key => $value) {
+                // Skip items removed by a prior step
+                if (array_key_exists($key, $list)) {
+                    // Ensure we yield from the source list
+                    $iterated[$key] = true;
+                    yield $key => $list[$key];
+                }
+            }
+        }
     }
 }

--- a/src/ORM/Hierarchy/MarkedSet.php
+++ b/src/ORM/Hierarchy/MarkedSet.php
@@ -5,6 +5,7 @@ namespace SilverStripe\ORM\Hierarchy;
 use InvalidArgumentException;
 use LogicException;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\ORM\ArrayLib;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
@@ -459,7 +460,7 @@ class MarkedSet
 
         // Build markedNodes for this subtree until we reach the threshold
         // foreach can't handle an ever-growing $nodes list
-        while (list(, $node) = each($this->markedNodes)) {
+        foreach (ArrayLib::iterateVolatile($this->markedNodes) as $node) {
             $children = $this->markChildren($node);
             if ($nodeCountThreshold && sizeof($this->markedNodes) > $nodeCountThreshold) {
                 // Undo marking children as opened since they're lazy loaded

--- a/src/View/Parsers/Diff.php
+++ b/src/View/Parsers/Diff.php
@@ -181,16 +181,15 @@ class Diff extends \Diff
         $content = str_replace(array("&nbsp;", "<", ">"), array(" "," <", "> "), $content);
         $candidateChunks = preg_split("/[\t\r\n ]+/", $content);
         $chunks = [];
-        while ($chunk = each($candidateChunks)) {
-            $item = $chunk['value'];
+        for ($i = 0; $i < count($candidateChunks); $i++) {
+            $item = $candidateChunks[$i];
             if (isset($item[0]) && $item[0] == "<") {
                 $newChunk = $item;
                 while ($item[strlen($item)-1] != ">") {
-                    $chunk = each($candidateChunks);
-                    if ($chunk === false) {
+                    if (++$i >= count($candidateChunks)) {
                         break;
                     }
-                    $item = $chunk['value'];
+                    $item = $candidateChunks[$i];
                     $newChunk .= ' ' . $item;
                 }
                 $chunks[] = $newChunk;


### PR DESCRIPTION
Replaces https://github.com/silverstripe/silverstripe-framework/pull/7544

There is still one reference to the `each()` method, but it's in a thirdparty folder library that I don't want to touch.

CMS PR at https://github.com/silverstripe/silverstripe-cms/pull/2010 (doesn't need to be merged at the same time)