### PR TITLE
Add required package for firefox to run behat tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
   apt:
     packages:
       - tidy
+      - dbus-x11
 
 matrix:
   include:


### PR DESCRIPTION
Attempted fix to get behat tests running again