### PR TITLE
FIX Move Member log out extension points to non-deprecated methods

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -10,6 +10,7 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Control\Email\Mailer;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
@@ -539,14 +540,30 @@ class Member extends DataObject
     {
         Deprecation::notice(
             '5.0.0',
-            'This method is deprecated and now does not persist. Please use Security::setCurrentUser(null) or an IdenityStore'
+            'This method is deprecated and now does not persist. Please use Security::setCurrentUser(null) or an IdentityStore'
         );
 
-        $this->extend('beforeMemberLoggedOut');
-
         Injector::inst()->get(IdentityStore::class)->logOut(Controller::curr()->getRequest());
-        // Audit logging hook
-        $this->extend('afterMemberLoggedOut');
+    }
+
+    /**
+     * Audit logging hook, called before a member is logged out
+     *
+     * @param HTTPRequest|null $request
+     */
+    public function beforeMemberLoggedOut(HTTPRequest $request = null)
+    {
+        $this->extend('beforeMemberLoggedOut', $request);
+    }
+
+    /**
+     * Audit logging hook, called after a member is logged out
+     *
+     * @param HTTPRequest|null $request
+     */
+    public function afterMemberLoggedOut(HTTPRequest $request = null)
+    {
+        $this->extend('afterMemberLoggedOut', $request);
     }
 
     /**

--- a/src/Security/RequestAuthenticationHandler.php
+++ b/src/Security/RequestAuthenticationHandler.php
@@ -74,10 +74,19 @@ class RequestAuthenticationHandler implements AuthenticationHandler
      */
     public function logOut(HTTPRequest $request = null)
     {
+        $member = Security::getCurrentUser();
+        if ($member) {
+            $member->beforeMemberLoggedOut($request);
+        }
+
         foreach ($this->getHandlers() as $handler) {
             $handler->logOut($request);
         }
 
         Security::setCurrentUser(null);
+
+        if ($member) {
+            $member->afterMemberLoggedOut($request);
+        }
     }
 }


### PR DESCRIPTION
The log out extension points are in a deprecated part of the code. This pull request moves them to the RequestAuthenticationHandler instead, which isn't deprecated.