### PR TITLE
Added missing @deprecated tags

### DIFF
--- a/src/Core/Config/Configurable.php
+++ b/src/Core/Config/Configurable.php
@@ -25,6 +25,7 @@ trait Configurable
     /**
      * Get inherited config value
      *
+     * @deprecated 5.0 Use ->config()->get() instead
      * @param string $name
      * @return mixed
      */
@@ -48,6 +49,7 @@ trait Configurable
     /**
      * Update the config value for a given property
      *
+     * @deprecated 5.0 Use ->config()->set() instead
      * @param string $name
      * @param mixed $value
      * @return $this


### PR DESCRIPTION
This PR just adds a couple of `@deprecated` tags where they were missing, where IDE's like PHPStorm immediately alert the user that it's deprecated.