### PR TITLE
BUG Installer - Warn if theme.yml isn't writeable

### DIFF
--- a/src/Dev/Install/InstallRequirements.php
+++ b/src/Dev/Install/InstallRequirements.php
@@ -279,9 +279,9 @@ class InstallRequirements
             null
         ));
 
-        $this->requireWriteable('mysite/_config/config.yml', array(
+        $this->requireWriteable('mysite/_config/theme.yml', array(
             "File permissions",
-            "Is the mysite/_config/config.yml file writeable?",
+            "Is the mysite/_config/theme.yml file writeable?",
             null
         ));
 


### PR DESCRIPTION
In 4.0, the installer likes to write changes to "mysite/_config/theme.yml". It should ask if the file is writeable first or else a fatal error will happen during the install process.

Note: the file "mysite/_config/config.yml" is absent in 4.0 and the writeable check no longer necessary.

`Fatal error: Uncaught InvalidArgumentException: Invalid error in /[...]/_silverstripe40/vendor/silverstripe/framework/src/Dev/Install/InstallRequirements.php on line 1158`

4 | 0.0096 | 515160 | SilverStripe\Dev\Install\Installer->install(  ) | .../install5.php:143
-- | -- | -- | -- | --
5 | 0.0101 | 515296 | SilverStripe\Dev\Install\Installer->writeConfigYaml(  ) | .../Installer.php:85
6 | 0.0101 | 515544 | SilverStripe\Dev\Install\Installer->writeToFile(  ) | .../Installer.php:356
7 | 0.0102 | 515752 | SilverStripe\Dev\Install\InstallRequirements->error(  ) | .../Installer.php:390
