### PR TITLE
FIX: Fixes SapphireTest masking userland coding errors.

### DIFF
--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -343,11 +343,17 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *  - Custom state helpers
      *
      * User code should call parent::setUpBeforeClass() before custom setup code
+     *
+     * @throws Exception
      */
     public static function setUpBeforeClass()
     {
         // Start tests
         static::start();
+
+        if (!static::$state) {
+            throw new Exception('SapphireTest failed to bootstrap!');
+        }
 
         // Call state helpers
         static::$state->setUpOnce(static::class);


### PR DESCRIPTION
Errors in 3rd party packages or other project code is "masked" in SapphireTest when running unit tests, due to those errors causing $state to be null.