### PR TITLE
"Discarded changes" message is no longer displayed onCreate().

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -265,6 +265,12 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
         if ($cb) {
             $cb($form, $this);
         }
+
+        // prevent "discarded changes" notification when creating new item
+        if (!$this->record->isInDB()) {
+            $form->addExtraClass('discardchanges');
+        }
+
         $this->extend("updateItemEditForm", $form);
         return $form;
     }


### PR DESCRIPTION
Related to:

https://github.com/dnadesign/silverstripe-elemental/pull/149
https://github.com/symbiote/silverstripe-gridfieldextensions/issues/226