### PR TITLE
BUG Prevent ConfirmPasswordField from showing value on validation failure

### DIFF
--- a/src/Forms/ConfirmedPasswordField.php
+++ b/src/Forms/ConfirmedPasswordField.php
@@ -150,6 +150,9 @@ class ConfirmedPasswordField extends FormField
             )
         );
 
+        // Ensure passwords are never sent to the frontend
+        $this->setDisplaysSetValue(false);
+
         // has to be called in constructor because Field() isn't triggered upon saving the instance
         if ($showOnClick) {
             $this->children->push($this->hiddenField = new HiddenField("{$name}[_PasswordFieldVisible]"));
@@ -360,6 +363,12 @@ class ConfirmedPasswordField extends FormField
 
             $this->children->fieldByName($this->getName() . '[_ConfirmPassword]')
                 ->setValue($this->confirmValue);
+        }
+
+        // If values are set but differ (validation error) then forbid these being emitted to
+        // the frontend, even if set to true
+        if (($this->value || $this->confirmValue) && $this->value !== $this->confirmValue) {
+            $this->setDisplaysSetValue(false);
         }
 
         return $this;
@@ -605,6 +614,29 @@ class ConfirmedPasswordField extends FormField
         } else {
             $this->children->removeByName($currentName, true);
         }
+        return $this;
+    }
+
+    /**
+     * Set if the assigned value should be emitted to the frontend
+     *
+     * @return bool
+     */
+    public function getDisplaysSetValue()
+    {
+        return $this->passwordField->getDisplaysSetValue();
+    }
+
+    /**
+     * Set if the assigned value should be emitted to the frontend
+     *
+     * @param bool $displaysSetValue
+     * @return $this
+     */
+    public function setDisplaysSetValue($displaysSetValue)
+    {
+        $this->passwordField->setDisplaysSetValue($displaysSetValue);
+        $this->confirmPasswordfield->setDisplaysSetValue($displaysSetValue);
         return $this;
     }
 }

--- a/src/Forms/PasswordField.php
+++ b/src/Forms/PasswordField.php
@@ -17,6 +17,15 @@ class PasswordField extends TextField
      */
     private static $autocomplete;
 
+    /**
+     * Determines if the value should be set in the frontend when rendering.
+     * Set to a default safe value. You should set this to true if you need these values
+     * to be sent back by the server.
+     *
+     * @var bool
+     */
+    protected $displaysSetValue = false;
+
     protected $inputType = 'password';
 
     /**
@@ -44,7 +53,7 @@ class PasswordField extends TextField
      */
     public function getAttributes()
     {
-        $attributes = array();
+        $attributes = parent::getAttributes();
 
         $autocomplete = $this->config()->get('autocomplete');
 
@@ -54,10 +63,12 @@ class PasswordField extends TextField
             $attributes['autocomplete'] = 'off';
         }
 
-        return array_merge(
-            parent::getAttributes(),
-            $attributes
-        );
+        // Hide value when rendering
+        if (!$this->getDisplaysSetValue()) {
+            $attributes['value'] = null;
+        }
+
+        return $attributes;
     }
 
     /**
@@ -80,5 +91,27 @@ class PasswordField extends TextField
     public function Type()
     {
         return 'text password';
+    }
+
+    /**
+     * Set if the assigned value should be emitted to the frontend
+     *
+     * @return bool
+     */
+    public function getDisplaysSetValue()
+    {
+        return $this->displaysSetValue;
+    }
+
+    /**
+     * Set if the assigned value should be emitted to the frontend
+     *
+     * @param bool $displaysSetValue
+     * @return $this
+     */
+    public function setDisplaysSetValue($displaysSetValue)
+    {
+        $this->displaysSetValue = $displaysSetValue;
+        return $this;
     }
 }


### PR DESCRIPTION
Fixes #2496 for 4.1

Pulling against 4 branch since it introduces new API for controlling password value visibility.

Will probably need a more-nasty fix for 4.0.1 / 3.x, although we may need to break some expected behaviour (e.g. just never set the value if they don't match). I don't think that negates the ability to fix this for 4.1 with new API.