### PR TITLE
WIP - BUG Fix don't treat zero-date as invalid

### DIFF
--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -67,6 +67,9 @@ class DBDate extends DBField
         } else {
             // Convert US date -> iso, fix y2k, etc
             $value = $this->fixInputDate($value);
+            if (is_null($value)) {
+                return null;
+            }
             $source = strtotime($value); // convert string to timestamp
         }
         if ($value === false) {
@@ -529,6 +532,9 @@ class DBDate extends DBField
         // split
         list($year, $month, $day, $time) = $this->explodeDateString($value);
 
+        if ((int)$year === 0 && (int)$month === 0 && (int)$day === 0) {
+            return null;
+        }
         // Validate date
         if (!checkdate($month, $day, $year)) {
             throw new InvalidArgumentException(
@@ -568,7 +574,7 @@ class DBDate extends DBField
         if ($parts[0] < 1000 && $parts[2] > 1000) {
             $parts = array_reverse($parts);
         }
-        if ($parts[0] < 1000) {
+        if ($parts[0] < 1000 && (int)$parts[0] !== 0) {
             throw new InvalidArgumentException(
                 "Invalid date: '$value'. Use " . self::ISO_DATE . " to prevent this error."
             );

--- a/tests/php/ORM/DBDateTest.php
+++ b/tests/php/ORM/DBDateTest.php
@@ -218,6 +218,12 @@ class DBDateTest extends SapphireTest
 
         $date = DBField::create_field('Date', 0);
         $this->assertEquals('1970-01-01', $date->getValue(), 'Zero is UNIX epoch date');
+
+        $date = DBField::create_field('Date', '0000-00-00 00:00:00');
+        $this->assertNull($date->getValue(), '0000-00-00 00:00:00 is set as NULL');
+
+        $date = DBField::create_field('Date', '00/00/0000');
+        $this->assertNull($date->getValue(), '00/00/0000 is set as NULL');
     }
 
     public function testDayOfMonth()


### PR DESCRIPTION
Partially fixes https://github.com/silverstripe/silverstripe-cms/issues/2022

There is an issue where dates aren't saving properly as well (the Pages are created with 0000-00-00 00:00:00 LastEdited and Created value, which is incorrect as well)

There are still weird issues around numbers in Persian locale which needs a deeper investigation for, may be linked to the dates issue above. 
<img width="470" alt="screen shot 2017-11-14 at 11 27 23 pm" src="https://user-images.githubusercontent.com/1064889/32808425-e052c868-c9f7-11e7-99b8-5da0e56f4cf7.png">
