### PR TITLE
BUG Fix DBEnum ignoring empty defaults

### DIFF
--- a/src/ORM/Connect/PDOConnector.php
+++ b/src/ORM/Connect/PDOConnector.php
@@ -163,7 +163,7 @@ class PDOConnector extends DBConnector
         $connCollation = Config::inst()->get('SilverStripe\ORM\Connect\MySQLDatabase', 'connection_collation');
 
         // Set charset if given and not null. Can explicitly set to empty string to omit
-        if ($parameters['driver'] !== 'sqlsrv') {
+        if (!in_array($parameters['driver'], ['sqlsrv', 'pgsql'])) {
             $charset = isset($parameters['charset'])
                     ? $parameters['charset']
                     : $connCharset;

--- a/tests/php/ORM/DBEnumTest.php
+++ b/tests/php/ORM/DBEnumTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SilverStripe\ORM\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\FieldType\DBEnum;
+use SilverStripe\ORM\FieldType\DBField;
+
+class DBEnumTest extends SapphireTest
+{
+    public function testDefault()
+    {
+        /** @var DBEnum $enum1 */
+        $enum1 = DBField::create_field('Enum("A, B, C, D")', null);
+        /** @var DBEnum $enum2 */
+        $enum2 = DBField::create_field('Enum("A, B, C, D", "")', null);
+        /** @var DBEnum $enum3 */
+        $enum3 = DBField::create_field('Enum("A, B, C, D", null)', null);
+        /** @var DBEnum $enum4 */
+        $enum4 = DBField::create_field('Enum("A, B, C, D", 1)', null);
+
+        $this->assertEquals('A', $enum1->getDefaultValue());
+        $this->assertEquals('A', $enum1->getDefault());
+        $this->assertEquals(null, $enum2->getDefaultValue());
+        $this->assertEquals(null, $enum2->getDefault());
+        $this->assertEquals(null, $enum3->getDefaultValue());
+        $this->assertEquals(null, $enum3->getDefault());
+        $this->assertEquals('B', $enum4->getDefaultValue());
+        $this->assertEquals('B', $enum4->getDefault());
+    }
+}

--- a/tests/php/ORM/PDODatabaseTest.php
+++ b/tests/php/ORM/PDODatabaseTest.php
@@ -104,17 +104,17 @@ class PDODatabaseTest extends SapphireTest
             $this->markTestSkipped('This test requires the current DB connector is PDO');
         }
 
-        $query = new SQLUpdate('MySQLDatabaseTest_Data');
-        $query->setAssignments(array('Title' => 'New Title'));
+        $query = new SQLUpdate('"MySQLDatabaseTest_Data"');
+        $query->setAssignments(array('"Title"' => 'New Title'));
 
         // Test update which affects no rows
-        $query->setWhere(array('Title' => 'Bob'));
+        $query->setWhere(array('"Title"' => 'Bob'));
         $result = $query->execute();
         $this->assertInstanceOf(PDOQuery::class, $result);
         $this->assertEquals(0, DB::affected_rows());
 
         // Test update which affects some rows
-        $query->setWhere(array('Title' => 'First Item'));
+        $query->setWhere(array('"Title"' => 'First Item'));
         $result = $query->execute();
         $this->assertInstanceOf(PDOQuery::class, $result);
         $this->assertEquals(1, DB::affected_rows());


### PR DESCRIPTION
Fixes #7582

DBEnum was ignoring `null` as default option, meaning that you couldn't set an empty default.

I also discovered a potential issue with DBField::create_field() where field specifications and $object arg would silently create a mal-formed DBField. I've added a warning in this case, as a separate commit, without modifying the behaviour.

In 5.x we can make that warning an InvalidArgumentException.