### PR TITLE
FIX: Prevent crash when saving page with <img> that has an SVG source.

### DIFF
--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -87,13 +87,14 @@ class HtmlEditorField extends TextareaField {
 			$img->setAttribute('src', preg_replace('/([^\?]*)\?r=[0-9]+$/i', '$1', $img->getAttribute('src')));
 
 			// Resample the images if the width & height have changed.
-			if($image = File::find(urldecode(Director::makeRelative($img->getAttribute('src'))))){
+			$image = File::find(urldecode(Director::makeRelative($img->getAttribute('src'))));
+			if($image instanceof Image){
 				$width  = (int)$img->getAttribute('width');
 				$height = (int)$img->getAttribute('height');
 
 				if($width && $height && ($width != $image->getWidth() || $height != $image->getHeight())) {
 					//Make sure that the resized image actually returns an image:
-					$resized=$image->ResizedImage($width, $height);
+					$resized = $image->ResizedImage($width, $height);
 					if($resized) $img->setAttribute('src', $resized->getRelativePath());
 				}
 			}


### PR DESCRIPTION
Fix that addresses #7606. Ensure the object we're handling is actually an Image instance before calling methods specific to that class (e.g. in case of using SVG's in `<img>` tag which may be File instances).  This works even if (or especially if) you haven't configured `Image` to [treat SVG files as images](https://stackoverflow.com/questions/28491842/treat-svg-as-an-image-in-silverstripe) (which is unrelated).