### PR TITLE
Update form template directory

### DIFF
--- a/docs/en/02_Developer_Guides/03_Forms/03_Form_Templates.md
+++ b/docs/en/02_Developer_Guides/03_Forms/03_Form_Templates.md
@@ -16,7 +16,7 @@ $field = new TextField(..);
 $field->setTemplate('MyCustomTextField');
 ```
 
-Both `MyCustomTemplate.ss` and `MyCustomTextField.ss` should be located in **mysite/templates/forms/** or the same directory as the core.
+Both `MyCustomTemplate.ss` and `MyCustomTextField.ss` should be located in **mysite/templates/** or the same directory as the core.
 
 <div class="notice" markdown="1">
 It's recommended to copy the contents of the template you're going to replace and use that as a start. For instance, if


### PR DESCRIPTION
As of SS4.0, template files for forms need to be in the root template directory as the core forms folder no longer exists.