### PR TITLE
BUG Added warning for auto-generated table_name

### DIFF
--- a/tests/php/Core/ClassInfoTest/ChildClass.php
+++ b/tests/php/Core/ClassInfoTest/ChildClass.php
@@ -2,7 +2,9 @@
 
 namespace SilverStripe\Core\Tests\ClassInfoTest;
 
-class ChildClass extends BaseClass
+use SilverStripe\Dev\TestOnly;
+
+class ChildClass extends BaseClass implements TestOnly
 {
 
 }


### PR DESCRIPTION
As discussed https://github.com/silverstripe/silverstripe-framework/issues/6904
a warning will be added for 4.0.1

The new shorter table_name generated will be available in 5.0 (https://github.com/silverstripe/silverstripe-framework/pull/7621)

Related https://github.com/silverstripe/silverstripe-frameworktest/pull/44