### PR TITLE
BUG Fix _configure_database.php being ignored

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,9 +52,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",
-        "silverstripe/versioned": "^1.0@dev",
+        "silverstripe/versioned": "^1.0",
         "silverstripe/behat-extension": "^3",
-        "silverstripe/serve": "dev-master",
+        "silverstripe/serve": "^2",
         "se/selenium-server-standalone": "2.41.0"
     },
     "provide": {

--- a/src/Core/CoreKernel.php
+++ b/src/Core/CoreKernel.php
@@ -359,7 +359,7 @@ class CoreKernel implements Kernel
         }
 
         // Allow database adapters to handle their own configuration
-        DatabaseAdapterRegistry::autoconfigure();
+        DatabaseAdapterRegistry::autoconfigure($databaseConfig);
         return $databaseConfig;
     }
 

--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -899,8 +899,7 @@ abstract class DBSchemaManager
      *
      * @param string $tableName The name of the table.
      * @param string $indexName The name of the index.
-     * @param string $indexSpec The specification of the index, see {@link SS_Database::requireIndex()}
-     *                          for more details.
+     * @param array $indexSpec The specification of the index, see Database::requireIndex() for more details.
      * @todo Find out where this is called from - Is it even used? Aren't indexes always dropped and re-added?
      */
     abstract public function alterIndex($tableName, $indexName, $indexSpec);


### PR DESCRIPTION
Fixes #7590 and Fixes https://github.com/silverstripe/silverstripe-sqlite3/issues/38

Also deprecates `global $databaseConfig` for _configure_database.php (no longer necessary, but still supported).

SQLite3 fix at https://github.com/silverstripe/silverstripe-sqlite3/pull/37