### PR TITLE
check for apc.enable_cli when running from CLI

### DIFF
--- a/src/Core/Cache/DefaultCacheFactory.php
+++ b/src/Core/Cache/DefaultCacheFactory.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Core\Cache;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
+use SilverStripe\Control\Director;
 use SilverStripe\Core\Injector\Injector;
 use Symfony\Component\Cache\Simple\FilesystemCache;
 use Symfony\Component\Cache\Simple\ApcuCache;
@@ -85,7 +86,8 @@ class DefaultCacheFactory implements CacheFactory
     {
         static $apcuSupported = null;
         if (null === $apcuSupported) {
-            $apcuSupported = ApcuAdapter::isSupported();
+            // Need to check for CLI because Symfony won't: https://github.com/symfony/symfony/pull/25080
+            $apcuSupported = Director::is_cli() ? ini_get('apc.enable_cli') && ApcuAdapter::isSupported() : ApcuAdapter::isSupported();
         }
         return $apcuSupported;
     }


### PR DESCRIPTION
Fixes an issue when running PHPUnit via CLI where it spews out warnings about not being able to save values.

IMO the problem is actually at Symfony's end - https://github.com/symfony/symfony/pull/25080 - but they say it will break their cache warming so I've applied the fix here as well.