### PR TITLE
FIX Allow lowercase and uppercase delcaration of legacy Int class

### DIFF
--- a/_config/database.yml
+++ b/_config/database.yml
@@ -22,5 +22,13 @@ Injector:
     type: prototype
   Int:
     class: DBInt
+  int:
+    class: DBInt
+  INT:
+    class: DBInt
   Float:
+    class: DBFloat
+  float:
+    class: DBFloat
+  FLOAT:
     class: DBFloat


### PR DESCRIPTION
Fixes issue where declaring lowercase or uppercase `int` type for DB fields breaks in 3.6 on PHP 7

eg:

```php
private static $db = array(
    'Field' => 'int',
);
```

Which results in:

`[User Error] Uncaught ReflectionException: Class int does not exist`