### PR TITLE
Fix deprecated usage of getMock in unit tests

### DIFF
--- a/tests/core/manifest/ConfigManifestTest.php
+++ b/tests/core/manifest/ConfigManifestTest.php
@@ -30,13 +30,10 @@ class ConfigManifestTest extends SapphireTest {
 	 * @return Zend_Cache_Core
 	 */
 	protected function getCacheMock() {
-		return $this->getMock(
-			'Zend_Cache_Core',
-			array('load', 'save'),
-			array(),
-			'',
-			false
-		);
+		return $this->getMockBuilder('Zend_Cache_Core')
+			->setMethods(array('load', 'save'))
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	/**
@@ -45,13 +42,10 @@ class ConfigManifestTest extends SapphireTest {
 	 * @return SS_ConfigManifest
 	 */
 	protected function getManifestMock($methods) {
-		return $this->getMock(
-			'SS_ConfigManifest',
-			$methods,
-			array(), // no constructor arguments
-			'', // default
-			false // don't call the constructor
-		);
+		return $this->getMockBuilder('SS_ConfigManifest')
+			->setMethods($methods)
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	/**

--- a/tests/injector/InjectorTest.php
+++ b/tests/injector/InjectorTest.php
@@ -605,7 +605,7 @@ class InjectorTest extends SapphireTest {
 			'service' => array('factory' => 'factory', 'constructor' => array(1, 2, 3))
 		));
 
-		$factory = $this->getMock('SilverStripe\\Framework\\Injector\\Factory');
+		$factory = $this->getMockBuilder('SilverStripe\\Framework\\Injector\\Factory')->getMock();
 		$factory
 			->expects($this->once())
 			->method('create')

--- a/tests/model/PaginatedListTest.php
+++ b/tests/model/PaginatedListTest.php
@@ -43,7 +43,7 @@ class PaginatedListTest extends SapphireTest {
 	}
 
 	public function testSetPaginationFromQuery() {
-		$query = $this->getMock('SQLQuery');
+		$query = $this->getMockBuilder('SQLQuery')->getMock();
 		$query->expects($this->once())
 				->method('getLimit')
 				->will($this->returnValue(array('limit' => 15, 'start' => 30)));

--- a/tests/parsers/ShortcodeParserTest.php
+++ b/tests/parsers/ShortcodeParserTest.php
@@ -277,7 +277,9 @@ class ShortcodeParserTest extends SapphireTest {
 	}
 
 	public function testNoParseAttemptIfNoCode() {
-		$stub = $this->getMock('ShortcodeParser', array('replaceElementTagsWithMarkers'));
+		$stub = $this->getMockBuilder('ShortcodeParser')
+			->setMethods(array('replaceElementTagsWithMarkers'))
+			->getMock();
 		$stub->register('test', function() {
 			return '';
 		});

--- a/tests/view/SSViewerTest.php
+++ b/tests/view/SSViewerTest.php
@@ -138,7 +138,9 @@ class SSViewerTest extends SapphireTest {
 	}
 
 	public function testRequirements() {
-		$requirements = $this->getMock("Requirements_Backend", array("javascript", "css"));
+		$requirements = $this->getMockBuilder("Requirements_Backend")
+			->setMethods(array("javascript", "css"))
+			->getMock();
 		$jsFile = FRAMEWORK_DIR . '/tests/forms/a.js';
 		$cssFile = FRAMEWORK_DIR . '/tests/forms/a.js';
 


### PR DESCRIPTION
Suppresses warnings from newer versions of phpunit so tests can still execute 