### PR TITLE
Reintroduce checking against original php.ini values.

### DIFF
--- a/src/Dev/Install/InstallRequirements.php
+++ b/src/Dev/Install/InstallRequirements.php
@@ -227,8 +227,9 @@ class InstallRequirements
     /**
      * Check everything except the database
      */
-    public function check()
+    public function check($originalIni)
     {
+        $this->originalIni = $originalIni;
         $this->errors = [];
         $isApache = $this->isApache();
         $isIIS = $this->isIIS();

--- a/src/Dev/Install/install5.php
+++ b/src/Dev/Install/install5.php
@@ -66,7 +66,7 @@ $theme = $config->getTheme($_REQUEST);
 
 // Check requirements
 $req = new InstallRequirements();
-$req->check();
+$req->check($originalIni);
 
 if ($req->isIIS()) {
     $webserverConfigFile = 'web.config';


### PR DESCRIPTION
Seems to have been accidentally removed in 806ffb934e32644ddefc0dfb470d76218bd39334

Fixes https://github.com/silverstripe/silverstripe-installer/issues/211