### PR TITLE
DOCS Update getRelativeResourcePath (deprecated) to getResource()->getRelativePath() in upgrade examples

### DIFF
--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -410,13 +410,13 @@ Usage with custom logic:
 +use SilverStripe\View\ThemeResourceLoader;
 
 -$moduleFilePath = FRAMEWORK_DIR . '/MyFile.php';
-+$moduleFilePath = ModuleLoader::getModule('silverstripe/framework')->getRelativeResourcePath('MyFile.php');
++$moduleFilePath = ModuleLoader::getModule('silverstripe/framework')->getResource('MyFile.php')->getRelativePath();
 
 -$baseFilePath = BASE_PATH . '/composer.json';
 +$baseFilePath = Director::baseFolder() . '/composer.json';
  
 -$mysiteFilePath = 'mysite/css/styles.css';
-+$mysiteFilePath = ModuleLoader::getModule('mysite')->getRelativeResourcePath('css/styles.css');
++$mysiteFilePath = ModuleLoader::getModule('mysite')->getResource('css/styles.css')->getRelativePath();
 
 -$themesFilePath = SSViewer::get_theme_folder() . '/css/styles.css';
 +$themesFilePath = ThemeResourceLoader::inst()->findThemedResource('css/styles.css');
@@ -428,13 +428,15 @@ Usage with custom logic:
 Usage for Page and ModelAdmin:
 
 ```php
-class ListingPage extends \Page {
+class ListingPage extends \Page
+{
     private static $icon = 'mycompany/silverstripe-mymodule: client/images/sitetree_icon.png';
 }
 ```
 
 ```php
-class MyCustomModelAdmin extends \SilverStripe\Admin\ModelAdmin {
+class MyCustomModelAdmin extends \SilverStripe\Admin\ModelAdmin
+{
     private static $menu_icon = 'mycompany/silverstripe-mymodule: client/images/modeladmin_icon.png';
 }
 ```


### PR DESCRIPTION
Minor update to the changelog to use non-deprecated examples for updating module path references.