### PR TITLE
FIX: Restore BackURL preservation on log out (closes #7636)

### DIFF
--- a/src/Security/MemberAuthenticator/LogoutHandler.php
+++ b/src/Security/MemberAuthenticator/LogoutHandler.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Security\MemberAuthenticator;
 
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\RequestHandler;
@@ -109,6 +110,14 @@ class LogoutHandler extends RequestHandler
             return $this->redirect($backURL);
         }
 
-        return $this->redirect(Security::config()->get('login_url'));
+        $link = Security::config()->get('login_url');
+        $referer = $this->getReturnReferer();
+        if ($referer) {
+            $link = Controller::join_links($link, '?' . http_build_query([
+                'BackURL' => Director::makeRelative($referer)
+            ]));
+        }
+
+        return $this->redirect($link);
     }
 }


### PR DESCRIPTION
I overlooked this when adding the CSRF token to the logout action. It’s the same behaviour from the user’s point-of-view as 3.x and is in-place in the [logout form](https://github.com/silverstripe/silverstripe-framework/blob/4.0.0/src/Security/LogoutForm.php#L54-L63) (which people will hit if the token is missing/invalid), just not in `LogoutHandler` itself, which is why I’ve submitted against `4.0`. Happy to change branch if `4` is more appropriate.

This comes _after_ `RequestHandler::getBackURL()` is checked, so appending a `?BackURL` param to the logout action (like in https://github.com/silverstripe/silverstripe-admin/pull/368/) will take priority over the referer header.