### PR TITLE
FIX Use baseDataClass for allVersions as with other methods

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -1050,7 +1050,7 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 		$oldMode = self::get_reading_mode();
 		self::reading_stage('Stage');
 
-		$list = DataObject::get(get_class($this->owner), $filter, $sort, $join, $limit);
+		$list = DataObject::get(ClassInfo::baseDataClass($this->owner), $filter, $sort, $join, $limit);
 		if($having) $having = $list->having($having);
 
 		$query = $list->dataQuery()->query();


### PR DESCRIPTION
The other methods in `Versioned` use `ClassInfo::baseDataClass()` to find base classes to grab versions from and I feel it should be used here too.

At the moment it's not possible to use `$this->allVersions()` with mocked objects because the mock class doesn't exist as a table/registered `DataObject`