### PR TITLE
FIX: Remove some unnecessary ClassInfo calls in DataObjectSchema

### DIFF
--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -1341,10 +1341,7 @@ class DataObjectTest extends SapphireTest
         $this->assertFalse($schema->classHasTable(DataObject::class));
         $this->assertFalse($schema->classHasTable(ViewableData::class));
 
-        // Invalid class
-        $this->expectException(ReflectionException::class);
-        $this->expectExceptionMessage('Class ThisIsntADataObject does not exist');
-
+        /* Invalid class name */
         $this->assertFalse($schema->classHasTable("ThisIsntADataObject"));
     }
 


### PR DESCRIPTION
`ClassInfo::ancestry()` will include `ViewableData` and `DataObject` in its results. Subsequent calls to `DataObjectSchema::databaseFields(ViewableData::class)` are a waste of time of course, as there are no database fields on those classes.

Below profile is for a homepage load on a blank install, but the performance difference will only grow the more `DataObject` classes are referenced during a given request.

<img width="1330" alt="screen shot 2017-12-05 at 12 23 47" src="https://user-images.githubusercontent.com/1655548/33606954-301458a2-d9b7-11e7-92ff-2f35291973e5.png">

