### PR TITLE
Fix db autodiscover comment on loading behavior.

### DIFF
--- a/src/Dev/Install/DatabaseAdapterRegistry.php
+++ b/src/Dev/Install/DatabaseAdapterRegistry.php
@@ -112,7 +112,7 @@ class DatabaseAdapterRegistry
 
     /**
      * Detects all _register_database.php files and invokes them.
-     * Searches through vendor/ folder only,
+     * Searches through vendor/*\/* folders only,
      * does not support "legacy" folder location in webroot
      */
     public static function autodiscover()


### PR DESCRIPTION
Reading this comment it seems placing a module folder under vendor will cause it to load however it needs to be under vendor/*/