### PR TITLE
ENHANCEMENT: Add caching to InheritedPermissions

### DIFF
--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -22,3 +22,7 @@ SilverStripe\Core\Injector\Injector:
       factory: SilverStripe\Core\Cache\CacheFactory
       constructor:
         namespace: 'ratelimiter'
+  Psr\SimpleCache\CacheInterface.InheritedPermissions:
+    factory: SilverStripe\Core\Cache\CacheFactory
+    constructor:
+      namespace: "InheritedPermissions"

--- a/_config/security.yml
+++ b/_config/security.yml
@@ -38,7 +38,3 @@ SilverStripe\Core\Injector\Injector:
       Authenticators:
         cms: '%$SilverStripe\Security\MemberAuthenticator\CMSMemberAuthenticator'
   SilverStripe\Security\IdentityStore: '%$SilverStripe\Security\AuthenticationHandler'
-  SilverStripe\Security\InheritedPermissionFlusher:
-    properties:
-      Services:
-        - '%$SilverStripe\Security\PermissionChecker.sitetree'

--- a/_config/security.yml
+++ b/_config/security.yml
@@ -38,3 +38,7 @@ SilverStripe\Core\Injector\Injector:
       Authenticators:
         cms: '%$SilverStripe\Security\MemberAuthenticator\CMSMemberAuthenticator'
   SilverStripe\Security\IdentityStore: '%$SilverStripe\Security\AuthenticationHandler'
+  SilverStripe\Security\InheritedPermissionFlusher:
+    properties:
+      Services:
+        - '%$SilverStripe\Security\PermissionChecker.sitetree'

--- a/src/Security/Group.php
+++ b/src/Security/Group.php
@@ -305,7 +305,7 @@ class Group extends DataObject
      * including all members which are "inherited" from children groups of this record.
      * See {@link DirectMembers()} for retrieving members without any inheritance.
      *
-     * @param String $filter
+     * @param string $filter
      * @return ManyManyList
      */
     public function Members($filter = '')
@@ -330,15 +330,9 @@ class Group extends DataObject
 
         // Now set all children groups as a new foreign key
         $familyIDs = $this->collateFamilyIDs();
-        if (!empty($familyIDs)) {
-            $groups = Group::get()->byIDs($familyIDs);
-            $groupIDs = $groups->column('ID');
-            if (!empty($groupIDs)) {
-                $result = $result->forForeignID($groupIDs)->where($filter);
-            }
-        }
-
-        return $result;
+        $result = $result->forForeignID($familyIDs);
+        
+        return $result->where($filter);
     }
 
     /**
@@ -450,7 +444,7 @@ class Group extends DataObject
     }
 
     /**
-     * This isn't a decendant of SiteTree, but needs this in case
+     * This isn't a descendant of SiteTree, but needs this in case
      * the group is "reorganised";
      */
     public function cmsCleanup_parentChanged()
@@ -626,6 +620,8 @@ class Group extends DataObject
     /**
      * Returns all of the children for the CMS Tree.
      * Filters to only those groups that the current user can edit
+     *
+     * @return ArrayList
      */
     public function AllChildrenIncludingDeleted()
     {
@@ -635,6 +631,7 @@ class Group extends DataObject
 
         if ($children) {
             foreach ($children as $child) {
+                /** @var DataObject $child */
                 if ($child->canView()) {
                     $filteredChildren->push($child);
                 }

--- a/src/Security/InheritedPermissionFlusher.php
+++ b/src/Security/InheritedPermissionFlusher.php
@@ -16,7 +16,7 @@ class InheritedPermissionFlusher extends DataExtension implements Flushable
     protected $services = [];
 
     /**
-     * Flush all CacheFlusher services
+     * Flush all MemberCacheFlusher services
      */
     public static function flush()
     {

--- a/src/Security/InheritedPermissionFlusher.php
+++ b/src/Security/InheritedPermissionFlusher.php
@@ -94,9 +94,7 @@ class InheritedPermissionFlusher extends DataExtension implements Flushable
         }
 
         if ($this->owner instanceof Group) {
-            return $this->owner->Members()->exists()
-                ? $this->owner->Members()->column('ID')
-                : null;
+            return $this->owner->Members()->column('ID');
         }
 
         return [$this->owner->ID];

--- a/src/Security/InheritedPermissions.php
+++ b/src/Security/InheritedPermissions.php
@@ -9,7 +9,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Hierarchy\Hierarchy;
 use SilverStripe\Versioned\Versioned;
 use Psr\SimpleCache\CacheInterface;
-use SilverStripe\Core\Cache\CacheFlusher;
+use SilverStripe\Core\Cache\MemberCacheFlusher;
 /**
  * Calculates batch permissions for nested objects for:
  *  - canView: Supports 'Anyone' type
@@ -17,7 +17,7 @@ use SilverStripe\Core\Cache\CacheFlusher;
  *  - canDelete: Includes special logic for ensuring parent objects can only be deleted if their children can
  *    be deleted also.
  */
-class InheritedPermissions implements PermissionChecker, CacheFlusher
+class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
 {
     use Injectable;
 
@@ -127,20 +127,20 @@ class InheritedPermissions implements PermissionChecker, CacheFlusher
      * Clear the cache for this instance only
      * @param array $ids A list of member IDs
      */
-    public function flushCache($ids = null)
+    public function flushMemberCache($memberIDs = null)
     {
         if (!$this->cacheService) {
             return;
         }
 
         // Hard flush, e.g. flush=1
-        if (!$ids) {
+        if (!$memberIDs) {
             $this->cacheService->clear();
         }
 
-        if ($ids && is_array($ids)) {
+        if ($memberIDs && is_array($memberIDs)) {
             foreach ([self::VIEW, self::EDIT, self::DELETE] as $type) {
-                foreach ($ids as $memberID) {
+                foreach ($memberIDs as $memberID) {
                     $key = $this->generateCacheKey($type, $memberID);
                     $this->cacheService->delete($key);
                 }

--- a/tests/php/Security/InheritedPermissionsTest.php
+++ b/tests/php/Security/InheritedPermissionsTest.php
@@ -347,13 +347,13 @@ class InheritedPermissionsTest extends SapphireTest
         $permissionChecker = new InheritedPermissions(TestPermissionNode::class, $cache);
 
         // Non existent ID
-        $permissionChecker->flushCache('dummy');
+        $permissionChecker->flushMemberCache('dummy');
         foreach([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
             $this->assertNotNull($cache->get($key));
         }
 
         // Precision strike
-        $permissionChecker->flushCache([$member1->ID]);
+        $permissionChecker->flushMemberCache([$member1->ID]);
         // Member1 should be clear
         $this->assertNull($cache->get($editKey1));
         $this->assertNull($cache->get($viewKey1));
@@ -362,7 +362,7 @@ class InheritedPermissionsTest extends SapphireTest
         $this->assertNotNull($cache->get($viewKey2));
 
         // Nuclear
-        $permissionChecker->flushCache();
+        $permissionChecker->flushMemberCache();
         foreach([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
             $this->assertNull($cache->get($key));
         }

--- a/tests/php/Security/InheritedPermissionsTest.php
+++ b/tests/php/Security/InheritedPermissionsTest.php
@@ -11,6 +11,8 @@ use SilverStripe\Security\PermissionChecker;
 use SilverStripe\Security\Test\InheritedPermissionsTest\TestPermissionNode;
 use SilverStripe\Security\Test\InheritedPermissionsTest\TestDefaultPermissionChecker;
 use SilverStripe\Versioned\Versioned;
+use Psr\SimpleCache\CacheInterface;
+use ReflectionClass;
 
 class InheritedPermissionsTest extends SapphireTest
 {
@@ -266,4 +268,114 @@ class InheritedPermissionsTest extends SapphireTest
             $this->assertFalse($history->canView());
         });
     }
+
+    public function testPermissionsPersistCache()
+    {
+        /* @var CacheInterface $cache */
+        $cache = Injector::inst()->create(CacheInterface::class . '.InheritedPermissions');
+        $cache->clear();
+
+        $member = $this->objFromFixture(Member::class, 'editor');
+
+        /** @var TestPermissionNode $history */
+        $history = $this->objFromFixture(TestPermissionNode::class, 'history');
+        /** @var TestPermissionNode $historyGallery */
+        $historyGallery = $this->objFromFixture(TestPermissionNode::class, 'history-gallery');
+        $permissionChecker = new InheritedPermissions(TestPermissionNode::class, $cache);
+
+        $viewKey = $this->generateCacheKey($permissionChecker, InheritedPermissions::VIEW, $member->ID);
+        $editKey = $this->generateCacheKey($permissionChecker, InheritedPermissions::EDIT, $member->ID);
+
+        $this->assertNull($cache->get($editKey));
+        $this->assertNull($cache->get($viewKey));
+
+        $permissionChecker->canEditMultiple([$history->ID, $historyGallery->ID], $member);
+        $this->assertNull($cache->get($editKey));
+        $this->assertNull($cache->get($viewKey));
+
+        unset($permissionChecker);
+        $this->assertTrue(is_array($cache->get($editKey)));
+        $this->assertNull($cache->get($viewKey));
+        $this->assertArrayHasKey($history->ID, $cache->get($editKey));
+        $this->assertArrayHasKey($historyGallery->ID, $cache->get($editKey));
+
+        $permissionChecker = new InheritedPermissions(TestPermissionNode::class, $cache);
+        $permissionChecker->canViewMultiple([$history->ID], $member);
+        $this->assertNotNull($cache->get($editKey));
+        $this->assertNull($cache->get($viewKey));
+
+        unset($permissionChecker);
+        $this->assertTrue(is_array($cache->get($viewKey)));
+        $this->assertTrue(is_array($cache->get($editKey)));
+        $this->assertArrayHasKey($history->ID, $cache->get($viewKey));
+        $this->assertArrayNotHasKey($historyGallery->ID, $cache->get($viewKey));
+    }
+
+    public function testPermissionsFlushCache()
+    {
+        /* @var CacheInterface $cache */
+        $cache = Injector::inst()->create(CacheInterface::class . '.InheritedPermissions');
+        $cache->clear();
+        
+        $permissionChecker = new InheritedPermissions(TestPermissionNode::class, $cache);
+        $member1 = $this->objFromFixture(Member::class, 'editor');
+        $member2 = $this->objFromFixture(Member::class, 'admin');
+        $editKey1 = $this->generateCacheKey($permissionChecker, InheritedPermissions::EDIT, $member1->ID);
+        $editKey2 = $this->generateCacheKey($permissionChecker, InheritedPermissions::EDIT, $member2->ID);
+        $viewKey1 = $this->generateCacheKey($permissionChecker, InheritedPermissions::VIEW, $member1->ID);
+        $viewKey2 = $this->generateCacheKey($permissionChecker, InheritedPermissions::VIEW, $member2->ID);
+
+        foreach([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
+            $this->assertNull($cache->get($key));
+        }
+
+        /** @var TestPermissionNode $history */
+        $history = $this->objFromFixture(TestPermissionNode::class, 'history');
+        /** @var TestPermissionNode $historyGallery */
+        $historyGallery = $this->objFromFixture(TestPermissionNode::class, 'history-gallery');
+
+        $permissionChecker->canEditMultiple([$history->ID, $historyGallery->ID], $member1);
+        $permissionChecker->canViewMultiple([$history->ID, $historyGallery->ID], $member1);
+        $permissionChecker->canEditMultiple([$history->ID, $historyGallery->ID], $member2);
+        $permissionChecker->canViewMultiple([$history->ID, $historyGallery->ID], $member2);
+
+        unset($permissionChecker);
+
+        foreach([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
+            $this->assertNotNull($cache->get($key));
+        }
+        $permissionChecker = new InheritedPermissions(TestPermissionNode::class, $cache);
+
+        // Non existent ID
+        $permissionChecker->flushCache('dummy');
+        foreach([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
+            $this->assertNotNull($cache->get($key));
+        }
+
+        // Precision strike
+        $permissionChecker->flushCache([$member1->ID]);
+        // Member1 should be clear
+        $this->assertNull($cache->get($editKey1));
+        $this->assertNull($cache->get($viewKey1));
+        // Member 2 is unaffected
+        $this->assertNotNull($cache->get($editKey2));
+        $this->assertNotNull($cache->get($viewKey2));
+
+        // Nuclear
+        $permissionChecker->flushCache();
+        foreach([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
+            $this->assertNull($cache->get($key));
+        }
+
+    }
+
+    protected function generateCacheKey(InheritedPermissions $inst, $type, $memberID)
+    {
+        $reflection = new ReflectionClass(InheritedPermissions::class);
+        $method = $reflection->getMethod('generateCacheKey');
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($inst, [$type, $memberID]);
+    }
+
 }

--- a/tests/php/Security/InheritedPermissionsTest.php
+++ b/tests/php/Security/InheritedPermissionsTest.php
@@ -325,7 +325,7 @@ class InheritedPermissionsTest extends SapphireTest
         $viewKey1 = $this->generateCacheKey($permissionChecker, InheritedPermissions::VIEW, $member1->ID);
         $viewKey2 = $this->generateCacheKey($permissionChecker, InheritedPermissions::VIEW, $member2->ID);
 
-        foreach([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
+        foreach ([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
             $this->assertNull($cache->get($key));
         }
 
@@ -341,14 +341,14 @@ class InheritedPermissionsTest extends SapphireTest
 
         unset($permissionChecker);
 
-        foreach([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
+        foreach ([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
             $this->assertNotNull($cache->get($key));
         }
         $permissionChecker = new InheritedPermissions(TestPermissionNode::class, $cache);
 
         // Non existent ID
         $permissionChecker->flushMemberCache('dummy');
-        foreach([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
+        foreach ([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
             $this->assertNotNull($cache->get($key));
         }
 
@@ -363,10 +363,9 @@ class InheritedPermissionsTest extends SapphireTest
 
         // Nuclear
         $permissionChecker->flushMemberCache();
-        foreach([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
+        foreach ([$editKey1, $editKey2, $viewKey1, $viewKey2] as $key) {
             $this->assertNull($cache->get($key));
         }
-
     }
 
     protected function generateCacheKey(InheritedPermissions $inst, $type, $memberID)
@@ -377,5 +376,4 @@ class InheritedPermissionsTest extends SapphireTest
 
         return $method->invokeArgs($inst, [$type, $memberID]);
     }
-
 }


### PR DESCRIPTION
## Do not merge
Until https://github.com/silverstripe/silverstripe-framework/pull/7673 is merged!

Adds backend caching to `InheritedPermissions`, e.g. `canEditMultiple()`.

Resolves https://github.com/silverstripe/silverstripe-framework/issues/7442