### PR TITLE
 FIX Update branch alias in Scrutinizer config for 4 branch 6f2551e

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,17 @@
+
 inherit: true
+
+build:
+  environment:
+    variables:
+      # Must match actual branch, not alias. E.g. 4.x-dev rather than 4.1.x-dev for 4 branch, but 4.0.x-dev for 4.0 branch
+      COMPOSER_ROOT_VERSION: 4.0.x-dev
+  nodes:
+    analysis:
+      tests:
+        override: [php-scrutinizer-run]
+
 filter:
-  excluded_paths:
-    - thirdparty/*
-    - parsers/*
-    - docs/*
-    - images/*
+  paths:
+    - src/*
+    - tests/*

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,7 +5,7 @@ build:
   environment:
     variables:
       # Must match actual branch, not alias. E.g. 4.x-dev rather than 4.1.x-dev for 4 branch, but 4.0.x-dev for 4.0 branch
-      COMPOSER_ROOT_VERSION: 4.0.x-dev
+      COMPOSER_ROOT_VERSION: 4.x-dev
   nodes:
     analysis:
       tests:


### PR DESCRIPTION
This fix has been made already in 4.0, so cherry picking that commit in and updating the branch alias for the 4 branch.

If there were compatibility fixes made in the 4.0 branch other than this then we should close this PR and merge up instead at some stage.