### PR TITLE
BUG Using ports different than 80/443 within alternate_base_url

### DIFF
--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -468,8 +468,9 @@ class Director implements TemplateGlobalProvider
         if ($baseURL = self::config()->get('alternate_base_url')) {
             $baseURL = Injector::inst()->convertServiceProperty($baseURL);
             $host = parse_url($baseURL, PHP_URL_HOST);
+            $port = parse_url($baseURL, PHP_URL_PORT);
             if ($host) {
-                return $host;
+                return $port ? "$host:$port" : $host;
             }
         }
 
@@ -487,8 +488,9 @@ class Director implements TemplateGlobalProvider
         if ($baseURL = self::config()->uninherited('default_base_url')) {
             $baseURL = Injector::inst()->convertServiceProperty($baseURL);
             $host = parse_url($baseURL, PHP_URL_HOST);
+            $port = parse_url($baseURL, PHP_URL_PORT);
             if ($host) {
-                return $host;
+                return $port ? "$host:$port" : $host;
             }
         }
 


### PR DESCRIPTION
Currently, specifying a URL with a port number in `alternate_base_url` different than 80 (http) or 443 (https), will make the `Director` class not to detect this and break most URLs in the application.

Note that in our case, the URL must be specified in most cases when SilverStripe is working on a URL prefix, e.g. `/silverstripe`.

Steps to reproduce:

- Change the frontend's HTTP port to something different than 80.
- Set `alternate_base_url` for SilverStripe to use this new port:

```
SilverStripe\Control\Director:
  alternate_base_url: http://HOSTNAME:PORT/silverstripe
```

Next, if you access SilverStripe, you will see that most URLs are wrong and stylesheets are not loading.

For instance, by setting the URL `http://127.0.0.1:8080/silverstripe`, the `<base>` tag appears as following:

```
<base href="http://127.0.0.1/silverstripe/"><!--[if lte IE 6]></base><![endif]-->
```

And no mentions of the port `8080`.