### PR TITLE
FIX: Only show table_name warning on dev/build

### DIFF
--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -51,6 +51,20 @@ abstract class DBSchemaManager
     protected $supressOutput = false;
 
     /**
+     * @var array
+     */
+    protected static $table_name_warnings = [];
+
+    /**
+     * @param string
+     * @deprecated 4.0..5.0
+     */
+    public static function showTableNameWarning($table, $class)
+    {
+        static::$table_name_warnings[$table] = $class;
+    }
+
+    /**
      * Injector injection point for database controller
      *
      * @param Database $database
@@ -408,6 +422,23 @@ abstract class DBSchemaManager
             foreach ($indexSchema as $indexName => $indexSpec) {
                 $this->requireIndex($table, $indexName, $indexSpec);
             }
+        }
+
+        // Check and display notice about $table_name
+        static $table_name_info_sent = false;
+
+        if (isset(static::$table_name_warnings[$table])) {
+            if (!$table_name_info_sent) {
+                $this->alterationMessage('<strong>Please note:</strong> It is strongly recommended to define a' .
+                    ' table_name for all namespaced models. Not defining a table_name may cause generated table' .
+                    ' names to be too long and may not be supported by your current database engine. The generated' .
+                    ' naming scheme will also change when upgrading to SilverStripe 5.0 and potentially break.',
+                    'error'
+                );
+                $table_name_info_sent = true;
+            }
+
+            $this->alterationMessage('table_name not set for class ' . static::$table_name_warnings[$table], 'notice');
         }
     }
 

--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -429,10 +429,14 @@ abstract class DBSchemaManager
 
         if (isset(static::$table_name_warnings[$table])) {
             if (!$table_name_info_sent) {
-                $this->alterationMessage('<strong>Please note:</strong> It is strongly recommended to define a' .
-                    ' table_name for all namespaced models. Not defining a table_name may cause generated table' .
-                    ' names to be too long and may not be supported by your current database engine. The generated' .
-                    ' naming scheme will also change when upgrading to SilverStripe 5.0 and potentially break.',
+                $this->alterationMessage(
+                    <<<'MESSAGE'
+<strong>Please note:</strong> It is strongly recommended to define a
+table_name for all namespaced models. Not defining a table_name may cause generated table
+names to be too long and may not be supported by your current database engine. The generated
+naming scheme will also change when upgrading to SilverStripe 5.0 and potentially break.
+MESSAGE
+                    ,
                     'error'
                 );
                 $table_name_info_sent = true;

--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -11,6 +11,7 @@ use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\Connect\DBSchemaManager;
 use SilverStripe\ORM\FieldType\DBComposite;
 use SilverStripe\ORM\FieldType\DBField;
 
@@ -317,17 +318,12 @@ class DataObjectSchema
             return $class;
         }
 
-        if (!ClassInfo::classImplements($class, TestOnly::class) && $this->classHasTable($class)) {
-            trigger_error(
-                "It is recommended to define a table_name for your '$class'." .
-                ' Not defining a table_name may cause subsequent table names to be too long and may not be supported' .
-                ' by your current database engine, the generated naming scheme will also change when upgrading to' .
-                ' SilverStripe 5.0 and potentially break.',
-                E_USER_WARNING
-            );
-        }
         $separator = DataObjectSchema::config()->uninherited('table_namespace_separator');
         $table = str_replace('\\', $separator, trim($class, '\\'));
+
+        if (!ClassInfo::classImplements($class, TestOnly::class) && $this->classHasTable($class)) {
+            DBSchemaManager::showTableNameWarning($table, $class);
+        }
 
         return $table;
     }


### PR DESCRIPTION
Extra fix for https://github.com/silverstripe/silverstripe-framework/issues/7686, as people still feel that `E_USER_WARNING` is too disruptive.

Shows the detailed info once in red (to terrify you into submission), then an orange notice for each offending model:

<img width="1121" alt="screen shot 2017-12-11 at 17 32 21" src="https://user-images.githubusercontent.com/1655548/33844908-a67f46c8-de99-11e7-9653-67ff32e1bfd5.png">
