### PR TITLE
Added after priority to replace default authenticator.

### DIFF
--- a/docs/en/02_Developer_Guides/09_Security/03_Authentication.md
+++ b/docs/en/02_Developer_Guides/09_Security/03_Authentication.md
@@ -61,6 +61,7 @@ SilverStripe\Core\Injector\Injector:
 If there is no authenticator registered, `Authenticator` will try to fall back on the default provided authenticator (`default`), which can be changed using the following config, replacing the MemberAuthenticator with your authenticator:
 ```yaml
 ---
+Name: MyAuth
 After:
   - '#coresecurity'
 ---

--- a/docs/en/02_Developer_Guides/09_Security/03_Authentication.md
+++ b/docs/en/02_Developer_Guides/09_Security/03_Authentication.md
@@ -60,6 +60,10 @@ SilverStripe\Core\Injector\Injector:
 ```
 If there is no authenticator registered, `Authenticator` will try to fall back on the default provided authenticator (`default`), which can be changed using the following config, replacing the MemberAuthenticator with your authenticator:
 ```yaml
+---
+After:
+  - '#coresecurity'
+---
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Security\Security:
     properties:


### PR DESCRIPTION
The documentation needs to include the after priority in order to override the default authenticator.  Currently there is no clear indication of this and without it, coresecurity will override your changes.