### PR TITLE
FIX Ensure last GridField column when non sortable has its title displayed

### DIFF
--- a/src/Forms/GridField/GridFieldSortableHeader.php
+++ b/src/Forms/GridField/GridFieldSortableHeader.php
@@ -196,7 +196,7 @@ class GridFieldSortableHeader implements GridField_HTMLProvider, GridField_DataM
                             '<button type="button" name="showFilter" title="Open search and filter" class="btn btn-secondary font-icon-search btn--no-text btn--icon-large grid-field__filter-open"></button>'
                         );
                     } else {
-                        $field = new LiteralField($fieldName, '<span class="non-sortable"></span>');
+                        $field = new LiteralField($fieldName, '<span class="non-sortable">' . $title . '</span>');
                     }
                 } else {
                     $field = new LiteralField($fieldName, '<span class="non-sortable">' . $title . '</span>');


### PR DESCRIPTION
This ensures that GridField header columns that do not have the filterable component will still show the "title" for the last column.

Fixes https://github.com/silverstripe/silverstripe-reports/issues/96