### PR TITLE
API Upgrade to PHPUnit 7.0 beta, bump minimum PHP to 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,19 +23,14 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env:
-        - DB=MYSQL
-        - PHPCS_TEST=1
-        - PHPUNIT_TEST=framework
-    - php: 7.0
+    - php: 7.1
       env:
         - DB=PGSQL
         - PHPUNIT_TEST=framework
     - php: 7.1
       env:
         - DB=MYSQL
-        - PDO=1
+        - PHPCS_TEST=1
         - PHPUNIT_COVERAGE_TEST=framework
     - php: 7.2
       env:
@@ -47,15 +42,15 @@ matrix:
         - DB=MYSQL
         - PDO=1
         - PHPUNIT_TEST=framework
-    - php: 7.0
+    - php: 7.1
       env:
        - DB=MYSQL
        - BEHAT_TEST=framework
-    - php: 7.0
+    - php: 7.1
       env:
         - DB=MYSQL
         - PHPUNIT_TEST=cms
-    - php: 7.0
+    - php: 7.1
       env:
         - DB=MYSQL
         - BEHAT_TEST=cms

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/translation": "^2.8",
         "symfony/yaml": "~3.2",
         "m1/env": "^2.1",
-        "php": ">=5.6.0",
+        "php": ">=7.1.0",
         "ext-intl": "*",
         "ext-mbstring": "*",
         "ext-xml": "*",
@@ -51,7 +51,7 @@
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^7@dev",
         "silverstripe/versioned": "^2@dev",
         "silverstripe/behat-extension": "^4",
         "silverstripe/serve": "^3",

--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -8,9 +8,9 @@ Our web-based [PHP installer](installation/) can check if you meet the requireme
 
 ## Web server software requirements
 
- * PHP 5.6 and PHP 7.x
+ * PHP 7.1 or higher
  * Once PHP versions become [unsupported by the PHP Project](http://php.net/supported-versions.php),
-   we drop support for those versions in the [next minor release](/contributing/release-process). This means that PHP 5.6 support may be dropped in a 4.x minor release after December 2018.
+   we drop support for those versions in the [next minor release](/contributing/release-process). This means that PHP 7.1 support may be dropped in a 5.x minor release after December 2019.
  * We recommend using a PHP accelerator or opcode cache, such as [xcache](http://xcache.lighttpd.net/) or [WinCache](http://www.iis.net/download/wincacheforphp).
      * Note: Some PHP 5.5+ packages already have [Zend OpCache](http://php.net/manual/en/book.opcache.php) installed by default. If this is the case on your system, do not try and run additional opcaches alongside Zend OpCache without first disabling it, as it will likely have unexpected consequences.
  * Allocate at least 48MB of memory to each PHP process. (SilverStripe can be resource hungry for some intensive operations.)
@@ -20,11 +20,6 @@ Our web-based [PHP installer](installation/) can check if you meet the requireme
      * `arc4random_buf` (OpenBSD & NetBSD only)
      * `getrandom(2)` (Linux only)
      * `/dev/urandom`
-   * PHP 5 [`random_compat`](https://github.com/paragonie/random_compat) polyfill:
-     * libsodium
-     * `/dev/urandom`
-     * [`mcrypt_create_iv()`](http://php.net/manual/en/function.mcrypt-create-iv.php)
-     * CAPICOM Utilities (`CAPICOM.Utilities.1`, Windows only)
  * Required modules: ctype, dom, fileinfo, hash, intl, mbstring, session, simplexml, tokenizer, xml.
  * At least one from each group of extensions:
      * Image library extension (gd2, imagick)

--- a/docs/en/00_Getting_Started/02_Composer.md
+++ b/docs/en/00_Getting_Started/02_Composer.md
@@ -56,10 +56,10 @@ For example, on OS X, you might use a subdirectory of `~/Sites`.
 As long as your web server is up and running, this will get all the code that you need.
 Now visit the site in your web browser, and the installation process will be completed.
 
-You can also specify a version to download that version explicitly, i.e. this will download the older `3.5.0` release:
+You can also specify a version to download that version explicitly, i.e. this will download the older `3.6.0` release:
 
 ```
-composer create-project silverstripe/installer ./my/website/folder 3.5.0
+composer create-project silverstripe/installer ./my/website/folder 3.6.0
 ```
 
 When `create-project` is used with a release version like above,
@@ -183,9 +183,9 @@ Full example of composer.json with the SSAutoGitIgnore installed and enabled
     "name": "silverstripe/installer",
     "description": "The SilverStripe Framework Installer",
     "require": {
-        "php": ">=5.5.0",
-        "silverstripe/cms": "^4.0",
-        "silverstripe/framework": "^4.0",
+        "php": ">=7.1.0",
+        "silverstripe/cms": "^5",
+        "silverstripe/framework": "^5",
         "silverstripe-themes/simple": "~3.2.0"
     },
     "require-dev": {
@@ -212,11 +212,11 @@ You have to tell composer three things in order to be able to do this:
 The first two steps are done as part of the initial create project using additional arguments.
 
 ```
-composer create-project --keep-vcs --dev silverstripe/installer ./my/website/folder 4.0.x-dev --prefer-source
+composer create-project --keep-vcs --dev silverstripe/installer ./my/website/folder 5.x-dev --prefer-source
 ```
 
-The process will take a bit longer, since all modules are checked out as full git repositories which you can work on. The command checks out from the 4.0 release line. To check out from master instead,
-replace `4.0.x-dev` with `dev-master` (more info on [composer version naming](http://getcomposer.org/doc/02-libraries.md#specifying-the-version)).
+The process will take a bit longer, since all modules are checked out as full git repositories which you can work on. The command checks out from the 5.0 release line. To check out from master instead,
+replace `5.x-dev` with `dev-master` (more info on [composer version naming](http://getcomposer.org/doc/02-libraries.md#specifying-the-version)).
 
 The `--keep-vcs` flag will make sure you have access to the git history of the installer and the requirements
 
@@ -246,9 +246,9 @@ To remove dependencies, or if you prefer seeing all your dependencies in a text 
     "name": "silverstripe/installer",
     "description": "The SilverStripe Framework Installer",
     "require": {
-        "php": ">=5.5.0",
-        "silverstripe/cms": "^4.0",
-        "silverstripe/framework": "^4.0",
+        "php": ">=7.1.0",
+        "silverstripe/cms": "^5",
+        "silverstripe/framework": "^5",
         "silverstripe-themes/simple": "~3.2.0"
     },
     "require-dev": {
@@ -282,10 +282,10 @@ the latest unstable silverstripe/installer
 composer create-project silverstripe/installer ./my/website/folder dev-master
 ```
 
-Or for the latest development version in the 4.0.x series
+Or for the latest development version in the 5.x series
 
 ```
-composer create-project silverstripe/installer ./my/website/folder 4.0.x-dev
+composer create-project silverstripe/installer ./my/website/folder 5.x-dev
 ```
 
 ## Working with project forks and unreleased modules
@@ -347,7 +347,7 @@ Open `composer.json`, and find the module's `require`. Then put `as (core versio
 ```json
 {
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.1.0",
         "silverstripe/cms": "3.5.1.2",
         "silverstripe/framework": "dev-myproj as 4.0.x-dev",
         "silverstripe-themes/simple": "~3.2.0"

--- a/docs/en/04_Changelogs/5.0.0.md
+++ b/docs/en/04_Changelogs/5.0.0.md
@@ -1,0 +1,34 @@
+# 5.0.0
+
+## Introduction
+
+This version introduces many breaking changes, which in most projects can be managed through a combination
+of automatic upgrade processes as well as manual code review. This document reviews these changes and will
+guide developers in preparing existing 4.x code for compatibility with 5.0.
+
+## Overview {#overview}
+
+* Minimum version dependencies have increased; PHP 7.1 or higher is required.
+* Core classes have begun implementing PHP 7 scalar type hinting and return type hints.
+
+## API Changes {#api-changes}
+
+### General {#overview-general}
+
+* Minimum PHP version raised to 7.1
+* Once PHP versions become [unsupported by the PHP Project](http://php.net/supported-versions.php),
+  we drop support for those versions in the [next minor release](/contributing/release-process) 
+  This means PHP 7.1 support will become dropped in Dec 2019.
+* Updated PHPUnit from 5.7 to 7.0 (upgrade notes unavailable - @todo).
+  Any PHPUnit classes that are referenced directly will need to be updated to support the new PHPUnit
+  namespaces. Overloaded PHP methods that originate in PHPUnit classes may need to be updated to support
+  new PHP 7 method signatures.
+  You may also need to update your phpunit.xml.dist file to implement the PHPUnit 7.0 schema. See the
+  [SilverStripe installer](https://github.com/silverstripe/silverstripe-installer) for a base template you
+  can copy into your project.
+  Run `composer require --dev phpunit/phpunit ^7@dev` on existing projects to pull in the new dependency.
+* Some of the core SilverStripe methods have begun implementing PHP 7 scalar type hinting and return type
+  hints. Wherever your project code overloads methods with new signatures you will need to update them to
+  match.
+
+<!--- Changes below this line will be automatically regenerated -->

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -2,14 +2,14 @@
 
 namespace SilverStripe\Dev\Constraint;
 
-use PHPUnit_Framework_Constraint;
-use PHPUnit_Framework_ExpectationFailedException;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
 use SilverStripe\Dev\SSListExporter;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\View\ViewableData;
 
-if (!class_exists(PHPUnit_Framework_Constraint::class)) {
+if (!class_exists(Constraint::class)) {
     return;
 }
 
@@ -17,7 +17,7 @@ if (!class_exists(PHPUnit_Framework_Constraint::class)) {
  * Constraint for checking if a SS_List contains items matching the given
  * key-value pairs.
  */
-class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
+class SSListContains extends Constraint implements TestOnly
 {
     /**
      * @var array
@@ -55,7 +55,7 @@ class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
      *
      * @return null|bool
      *
-     * @throws PHPUnit_Framework_ExpectationFailedException
+     * @throws ExpectationFailedException
      */
     public function evaluate($other, $description = '', $returnResult = false)
     {
@@ -86,7 +86,7 @@ class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
      * @param ViewableData $item
      * @return bool
      */
-    protected function checkIfItemEvaluatesRemainingMatches(ViewableData $item)
+    protected function checkIfItemEvaluatesRemainingMatches(ViewableData $item) : bool
     {
         $success = false;
         foreach ($this->matches as $key => $match) {
@@ -107,7 +107,7 @@ class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
      *
      * @return string
      */
-    public function toString()
+    public function toString() : string
     {
         $matchToString = function ($key, $value) {
             return ' "' . $key . '" is "' . $value . '"';
@@ -132,7 +132,7 @@ class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
         return $this->getStubForToString() . $allMatchesAsString;
     }
 
-    protected function getStubForToString()
+    protected function getStubForToString() : string
     {
         return ' contains an item matching ';
     }

--- a/src/Dev/Constraint/SSListContainsOnly.php
+++ b/src/Dev/Constraint/SSListContainsOnly.php
@@ -2,12 +2,12 @@
 
 namespace SilverStripe\Dev\Constraint;
 
-use PHPUnit_Framework_Constraint;
-use PHPUnit_Framework_ExpectationFailedException;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\SS_List;
 
-if (!class_exists(PHPUnit_Framework_Constraint::class)) {
+if (!class_exists(Constraint::class)) {
     return;
 }
 
@@ -40,7 +40,7 @@ class SSListContainsOnly extends SSListContains implements TestOnly
      *
      * @return null|bool
      *
-     * @throws PHPUnit_Framework_ExpectationFailedException
+     * @throws ExpectationFailedException
      */
     public function evaluate($other, $description = '', $returnResult = false)
     {
@@ -71,7 +71,7 @@ class SSListContainsOnly extends SSListContains implements TestOnly
         return null;
     }
 
-    protected function getStubForToString()
+    protected function getStubForToString() : string
     {
         return $this->itemNotMatching
             ? parent::getStubForToString()

--- a/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
+++ b/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
@@ -2,13 +2,13 @@
 
 namespace SilverStripe\Dev\Constraint;
 
-use PHPUnit_Framework_Constraint;
-use PHPUnit_Framework_ExpectationFailedException;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
 use SilverStripe\Dev\SSListExporter;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\SS_List;
 
-if (!class_exists(PHPUnit_Framework_Constraint::class)) {
+if (!class_exists(Constraint::class)) {
     return;
 }
 
@@ -16,7 +16,7 @@ if (!class_exists(PHPUnit_Framework_Constraint::class)) {
  * Constraint for checking if every item in a SS_List matches a given match,
  * e.g. every Member has isActive set to true
  */
-class SSListContainsOnlyMatchingItems extends PHPUnit_Framework_Constraint implements TestOnly
+class SSListContainsOnlyMatchingItems extends Constraint implements TestOnly
 {
     /**
      * @var array
@@ -53,7 +53,7 @@ class SSListContainsOnlyMatchingItems extends PHPUnit_Framework_Constraint imple
      *
      * @return null|bool
      *
-     * @throws PHPUnit_Framework_ExpectationFailedException
+     * @throws ExpectationFailedException
      */
     public function evaluate($other, $description = '', $returnResult = false)
     {
@@ -82,7 +82,7 @@ class SSListContainsOnlyMatchingItems extends PHPUnit_Framework_Constraint imple
      *
      * @return string
      */
-    public function toString()
+    public function toString() : string
     {
         return 'contains only Objects where "' . key($this->match) . '" is "' . current($this->match) . '"';
     }

--- a/src/Dev/Constraint/ViewableDataContains.php
+++ b/src/Dev/Constraint/ViewableDataContains.php
@@ -2,13 +2,13 @@
 
 namespace SilverStripe\Dev\Constraint;
 
-use PHPUnit_Framework_Constraint;
-use PHPUnit_Framework_ExpectationFailedException;
-use PHPUnit_Util_InvalidArgumentHelper;
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Util\InvalidArgumentHelper;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\View\ViewableData;
 
-if (!class_exists(PHPUnit_Framework_Constraint::class)) {
+if (!class_exists(Constraint::class)) {
     return;
 }
 
@@ -16,7 +16,7 @@ if (!class_exists(PHPUnit_Framework_Constraint::class)) {
  * Constraint for checking if a ViewableData (e.g. ArrayData or any DataObject) contains fields matching the given
  * key-value pairs.
  */
-class ViewableDataContains extends PHPUnit_Framework_Constraint implements TestOnly
+class ViewableDataContains extends Constraint implements TestOnly
 {
     /**
      * @var array
@@ -32,7 +32,7 @@ class ViewableDataContains extends PHPUnit_Framework_Constraint implements TestO
         parent::__construct();
 
         if (!is_array($match)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+            throw InvalidArgumentHelper::factory(
                 1,
                 'array'
             );
@@ -57,9 +57,9 @@ class ViewableDataContains extends PHPUnit_Framework_Constraint implements TestO
      *
      * @return null|bool
      *
-     * @throws PHPUnit_Framework_ExpectationFailedException
+     * @throws ExpectationFailedException
      */
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, $description = '', $returnResult = false) : bool
     {
         $success = true;
 
@@ -89,7 +89,7 @@ class ViewableDataContains extends PHPUnit_Framework_Constraint implements TestO
      *
      * @return string
      */
-    public function toString()
+    public function toString() : string
     {
         return 'contains only Objects where "' . key($this->match) . '" is "' . current($this->match) . '"';
     }

--- a/src/Dev/Deprecation.php
+++ b/src/Dev/Deprecation.php
@@ -2,9 +2,11 @@
 
 namespace SilverStripe\Dev;
 
+use const DEBUG_BACKTRACE_IGNORE_ARGS;
+use function debug_print_backtrace;
+use const E_USER_DEPRECATED;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Environment;
-use SilverStripe\Core\Manifest\ClassLoader;
 use SilverStripe\Core\Manifest\Module;
 use SilverStripe\Core\Manifest\ModuleLoader;
 

--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -2,18 +2,13 @@
 
 namespace SilverStripe\Dev;
 
-use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\Session;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Config\Config;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\BasicAuth;
-use SilverStripe\Security\Member;
-use SilverStripe\Security\Security;
 use SilverStripe\Security\SecurityToken;
 use SilverStripe\View\SSViewer;
-use PHPUnit_Framework_AssertionFailedError;
 use SimpleXMLElement;
 
 /**
@@ -79,7 +74,7 @@ class FunctionalTest extends SapphireTest implements TestOnly
      *
      * @return Session
      */
-    public function session()
+    public function session() : Session
     {
         return $this->mainSession->session();
     }
@@ -127,7 +122,7 @@ class FunctionalTest extends SapphireTest implements TestOnly
      * @param string $url The base URL to use for this test
      * @param callable $callback The test to run
      */
-    protected function withBaseURL($url, $callback)
+    protected function withBaseURL(string $url, callable $callback)
     {
         $oldBase = Config::inst()->get(Director::class, 'alternate_base_url');
         Config::modify()->set(Director::class, 'alternate_base_url', $url);
@@ -140,7 +135,7 @@ class FunctionalTest extends SapphireTest implements TestOnly
      * @param string $folder The base folder to use for this test
      * @param callable $callback The test to run
      */
-    protected function withBaseFolder($folder, $callback)
+    protected function withBaseFolder(string $folder, callable $callback)
     {
         $oldFolder = Config::inst()->get(Director::class, 'alternate_base_folder');
         Config::modify()->set(Director::class, 'alternate_base_folder', $folder);
@@ -158,7 +153,7 @@ class FunctionalTest extends SapphireTest implements TestOnly
      * @param array $cookies
      * @return HTTPResponse
      */
-    public function get($url, $session = null, $headers = null, $cookies = null)
+    public function get(string $url, Session $session = null, array $headers = null, array $cookies = null) : HTTPResponse
     {
         $this->cssParser = null;
         $response = $this->mainSession->get($url, $session, $headers, $cookies);

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -4,9 +4,9 @@ namespace SilverStripe\Dev;
 
 use Exception;
 use LogicException;
-use PHPUnit_Framework_Constraint_Not;
-use PHPUnit_Framework_TestCase;
-use PHPUnit_Util_InvalidArgumentHelper;
+use PHPUnit\Framework\Constraint\LogicalNot;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\InvalidArgumentHelper;
 use SilverStripe\CMS\Controllers\RootURLController;
 use SilverStripe\Control\CLIRequestBuilder;
 use SilverStripe\Control\Controller;
@@ -38,7 +38,7 @@ use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
 use SilverStripe\View\SSViewer;
 
-if (!class_exists(PHPUnit_Framework_TestCase::class)) {
+if (!class_exists(TestCase::class)) {
     return;
 }
 
@@ -50,7 +50,7 @@ if (!class_exists(PHPUnit_Framework_TestCase::class)) {
  * This class should not be used anywhere outside of unit tests, as phpunit may not be installed
  * in production sites.
  */
-class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
+class SapphireTest extends TestCase implements TestOnly
 {
     /**
      * Path to fixture data for this test run.
@@ -60,7 +60,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @var string|array
      */
-    protected static $fixture_file = null;
+    protected static $fixture_file = '';
 
     /**
      * @var FixtureFactory
@@ -163,7 +163,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @return array
      */
-    public static function getIllegalExtensions()
+    public static function getIllegalExtensions() : array
     {
         return static::$illegal_extensions;
     }
@@ -173,7 +173,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @return array
      */
-    public static function getRequiredExtensions()
+    public static function getRequiredExtensions() : array
     {
         return static::$required_extensions;
     }
@@ -184,7 +184,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @return bool
      */
-    protected static function is_running_test()
+    protected static function is_running_test() : bool
     {
         return self::$is_running_test;
     }
@@ -194,13 +194,13 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @param bool $bool
      */
-    protected static function set_is_running_test($bool)
+    protected static function set_is_running_test(bool $bool) : void
     {
         self::$is_running_test = $bool;
     }
 
     /**
-     * @return String
+     * @return string|string[]
      */
     public static function get_fixture_file()
     {
@@ -297,10 +297,10 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     /**
      * Helper method to determine if the current test should enable a test database
      *
-     * @param $fixtureFiles
+     * @param array|string $fixtureFiles
      * @return bool
      */
-    protected function shouldSetupDatabaseForCurrentTest($fixtureFiles)
+    protected function shouldSetupDatabaseForCurrentTest($fixtureFiles) : bool
     {
         $databaseEnabledByDefault = $fixtureFiles || $this->usesDatabase;
 
@@ -314,7 +314,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @return bool
      */
-    protected function currentTestEnablesDatabase()
+    protected function currentTestEnablesDatabase() : bool
     {
         $annotations = $this->getAnnotations();
 
@@ -328,7 +328,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @return bool
      */
-    protected function currentTestDisablesDatabase()
+    protected function currentTestDisablesDatabase() : bool
     {
         $annotations = $this->getAnnotations();
 
@@ -394,7 +394,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     /**
      * @return FixtureFactory
      */
-    public function getFixtureFactory()
+    public function getFixtureFactory() : FixtureFactory
     {
         if (!$this->fixtureFactory) {
             $this->fixtureFactory = Injector::inst()->create(FixtureFactory::class);
@@ -408,7 +408,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param FixtureFactory $factory
      * @return $this
      */
-    public function setFixtureFactory(FixtureFactory $factory)
+    public function setFixtureFactory(FixtureFactory $factory) : SapphireTest
     {
         $this->fixtureFactory = $factory;
         return $this;
@@ -421,7 +421,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param string $identifier The identifier string, as provided in your fixture file
      * @return int
      */
-    protected function idFromFixture($className, $identifier)
+    protected function idFromFixture(string $className, string $identifier) : int
     {
         $id = $this->getFixtureFactory()->getId($className, $identifier);
 
@@ -443,7 +443,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param string $className The data class or table name, as specified in your fixture file
      * @return array A map of fixture-identifier => object-id
      */
-    protected function allFixtureIDs($className)
+    protected function allFixtureIDs(string $className) : array
     {
         return $this->getFixtureFactory()->getIds($className);
     }
@@ -456,7 +456,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @return DataObject
      */
-    protected function objFromFixture($className, $identifier)
+    protected function objFromFixture(string $className, string $identifier) : DataObject
     {
         $obj = $this->getFixtureFactory()->get($className, $identifier);
 
@@ -478,7 +478,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @param string $fixtureFile The location of the .yml fixture file, relative to the site base dir
      */
-    public function loadFixture($fixtureFile)
+    public function loadFixture(string $fixtureFile) : void
     {
         $fixture = Injector::inst()->create(YamlFixture::class, $fixtureFile);
         $fixture->writeInto($this->getFixtureFactory());
@@ -488,7 +488,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * Clear all fixtures which were previously loaded through
      * {@link loadFixture()}
      */
-    public function clearFixtures()
+    public function clearFixtures() : void
     {
         $this->getFixtureFactory()->clear();
     }
@@ -498,7 +498,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @return string Absolute path to current class.
      */
-    protected function getCurrentAbsolutePath()
+    protected function getCurrentAbsolutePath() : string
     {
         $filename = ClassLoader::inst()->getItemPath(static::class);
         if (!$filename) {
@@ -511,7 +511,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     /**
      * @return string File path relative to webroot
      */
-    protected function getCurrentRelativePath()
+    protected function getCurrentRelativePath() : string
     {
         $base = Director::baseFolder();
         $path = $this->getCurrentAbsolutePath();
@@ -551,25 +551,32 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     public static function assertContains(
         $needle,
         $haystack,
-        $message = '',
-        $ignoreCase = false,
-        $checkForObjectIdentity = true,
-        $checkForNonObjectIdentity = false
-    ) {
+        string $message = '',
+        bool $ignoreCase = false,
+        bool $checkForObjectIdentity = true,
+        bool $checkForNonObjectIdentity = false
+    ) : void {
         if ($haystack instanceof DBField) {
             $haystack = (string)$haystack;
         }
-        parent::assertContains($needle, $haystack, $message, $ignoreCase, $checkForObjectIdentity, $checkForNonObjectIdentity);
+        parent::assertContains(
+            $needle,
+            $haystack,
+            $message,
+            $ignoreCase,
+            $checkForObjectIdentity,
+            $checkForNonObjectIdentity
+        );
     }
 
     public static function assertNotContains(
         $needle,
         $haystack,
-        $message = '',
-        $ignoreCase = false,
-        $checkForObjectIdentity = true,
-        $checkForNonObjectIdentity = false
-    ) {
+        string $message = '',
+        bool $ignoreCase = false,
+        bool $checkForObjectIdentity = true,
+        bool $checkForNonObjectIdentity = false
+    ) : void {
         if ($haystack instanceof DBField) {
             $haystack = (string)$haystack;
         }
@@ -581,7 +588,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @return bool True if emails cleared
      */
-    public function clearEmails()
+    public function clearEmails() : bool
     {
         /** @var Mailer $mailer */
         $mailer = Injector::inst()->get(Mailer::class);
@@ -599,17 +606,17 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param string $from
      * @param string $subject
      * @param string $content
-     * @return array|null Contains keys: 'Type', 'To', 'From', 'Subject', 'Content', 'PlainContent', 'AttachedFiles',
+     * @return array Contains keys: 'Type', 'To', 'From', 'Subject', 'Content', 'PlainContent', 'AttachedFiles',
      *               'HtmlContent'
      */
-    public static function findEmail($to, $from = null, $subject = null, $content = null)
+    public static function findEmail($to, $from = null, $subject = null, $content = null) : array
     {
         /** @var Mailer $mailer */
         $mailer = Injector::inst()->get(Mailer::class);
         if ($mailer instanceof TestMailer) {
             return $mailer->findEmail($to, $from, $subject, $content);
         }
-        return null;
+        return [];
     }
 
     /**
@@ -621,7 +628,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param string $subject
      * @param string $content
      */
-    public static function assertEmailSent($to, $from = null, $subject = null, $content = null)
+    public static function assertEmailSent($to, $from = null, $subject = null, $content = null) : void
     {
         $found = (bool)static::findEmail($to, $from, $subject, $content);
 
@@ -671,10 +678,10 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *         ['Email' => 'i...@example.com'],
      *      ], $members);
      */
-    public static function assertListContains($matches, SS_List $list, $message = '')
+    public static function assertListContains($matches, SS_List $list, $message = '') : void
     {
         if (!is_array($matches)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+            throw InvalidArgumentHelper::factory(
                 1,
                 'array'
             );
@@ -692,13 +699,13 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     /**
      * @deprecated 4.0.0:5.0.0 Use assertListContains() instead
      *
-     * @param $matches
+     * @param array $matches
      * @param $dataObjectSet
      */
     public function assertDOSContains($matches, $dataObjectSet)
     {
         Deprecation::notice('5.0', 'Use assertListContains() instead');
-        return static::assertListContains($matches, $dataObjectSet);
+        static::assertListContains($matches, $dataObjectSet);
     }
 
     /**
@@ -721,16 +728,16 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *          ['Email' => 'i...@example.com'],
      *      ], $members);
      */
-    public static function assertListNotContains($matches, SS_List $list, $message = '')
+    public static function assertListNotContains($matches, SS_List $list, $message = '') : void
     {
         if (!is_array($matches)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+            throw InvalidArgumentHelper::factory(
                 1,
                 'array'
             );
         }
 
-        $constraint =  new PHPUnit_Framework_Constraint_Not(
+        $constraint =  new LogicalNot(
             new SSListContains(
                 $matches
             )
@@ -752,7 +759,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     public static function assertNotDOSContains($matches, $dataObjectSet)
     {
         Deprecation::notice('5.0', 'Use assertListNotContains() instead');
-        return static::assertListNotContains($matches, $dataObjectSet);
+        static::assertListNotContains($matches, $dataObjectSet);
     }
 
     /**
@@ -773,10 +780,10 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param mixed $list The {@link SS_List} to test.
      * @param string $message
      */
-    public static function assertListEquals($matches, SS_List $list, $message = '')
+    public static function assertListEquals($matches, SS_List $list, $message = '') : void
     {
         if (!is_array($matches)) {
-            throw PHPUnit_Util_InvalidArgumentHelper::factory(
+            throw InvalidArgumentHelper::factory(
                 1,
                 'array'
             );
@@ -800,7 +807,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     public function assertDOSEquals($matches, $dataObjectSet)
     {
         Deprecation::notice('5.0', 'Use assertListEquals() instead');
-        return static::assertListEquals($matches, $dataObjectSet);
+        static::assertListEquals($matches, $dataObjectSet);
     }
 
 
@@ -817,7 +824,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param mixed $list The {@link SS_List} to test.
      * @param string $message
      */
-    public static function assertListAllMatch($match, SS_List $list, $message = '')
+    public static function assertListAllMatch($match, SS_List $list, $message = '') : void
     {
         if (!is_array($match)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(
@@ -844,7 +851,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     public function assertDOSAllMatch($match, SS_List $dataObjectSet)
     {
         Deprecation::notice('5.0', 'Use assertListAllMatch() instead');
-        return static::assertListAllMatch($match, $dataObjectSet);
+        static::assertListAllMatch($match, $dataObjectSet);
     }
 
     /**
@@ -854,7 +861,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param string $sql
      * @return string The cleaned and normalised SQL string
      */
-    protected static function normaliseSQL($sql)
+    protected static function normaliseSQL($sql) : string
     {
         return trim(preg_replace('/\s+/m', ' ', $sql));
     }
@@ -873,12 +880,12 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     public static function assertSQLEquals(
         $expectedSQL,
         $actualSQL,
-        $message = '',
-        $delta = 0,
-        $maxDepth = 10,
-        $canonicalize = false,
-        $ignoreCase = false
-    ) {
+        string $message = '',
+        int $delta = 0,
+        int $maxDepth = 10,
+        bool $canonicalize = false,
+        bool $ignoreCase = false
+    ) : void {
         // Normalise SQL queries to remove patterns of repeating whitespace
         $expectedSQL = static::normaliseSQL($expectedSQL);
         $actualSQL = static::normaliseSQL($actualSQL);
@@ -898,10 +905,10 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     public static function assertSQLContains(
         $needleSQL,
         $haystackSQL,
-        $message = '',
-        $ignoreCase = false,
-        $checkForObjectIdentity = true
-    ) {
+        string $message = '',
+        bool $ignoreCase = false,
+        bool $checkForObjectIdentity = true
+    ) : void {
         $needleSQL = static::normaliseSQL($needleSQL);
         $haystackSQL = static::normaliseSQL($haystackSQL);
 
@@ -920,10 +927,10 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     public static function assertSQLNotContains(
         $needleSQL,
         $haystackSQL,
-        $message = '',
-        $ignoreCase = false,
-        $checkForObjectIdentity = true
-    ) {
+        string $message = '',
+        bool $ignoreCase = false,
+        bool $checkForObjectIdentity = true
+    ) : void {
         $needleSQL = static::normaliseSQL($needleSQL);
         $haystackSQL = static::normaliseSQL($haystackSQL);
 
@@ -933,7 +940,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     /**
      * Start test environment
      */
-    public static function start()
+    public static function start() : void
     {
         if (static::is_running_test()) {
             return;
@@ -980,7 +987,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param bool $includeExtraDataObjects If true, the extraDataObjects tables will also be included
      * @param bool $forceCreate Force DB to be created if it doesn't exist
      */
-    public static function resetDBSchema($includeExtraDataObjects = false, $forceCreate = false)
+    public static function resetDBSchema(bool $includeExtraDataObjects = false, bool $forceCreate = false) : void
     {
         // Check if DB is active before reset
         if (!static::$tempDB->isUsed()) {
@@ -1000,7 +1007,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param callable $callback
      * @return mixed
      */
-    public function actWithPermission($permCode, $callback)
+    public function actWithPermission($permCode, callable $callback)
     {
         return Member::actAs($this->createMemberWithPermission($permCode), $callback);
     }
@@ -1011,7 +1018,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param string|array $permCode
      * @return Member
      */
-    protected function createMemberWithPermission($permCode)
+    protected function createMemberWithPermission($permCode) : Member
     {
         if (is_array($permCode)) {
             $permArray = $permCode;
@@ -1074,7 +1081,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @param Member|int|string $member The ID, fixture codename, or Member object of the member that you want to log in
      */
-    public function logInAs($member)
+    public function logInAs($member) : void
     {
         if (is_numeric($member)) {
             $member = DataObject::get_by_id(Member::class, $member);
@@ -1087,7 +1094,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     /**
      * Log out the current user
      */
-    public function logOut()
+    public function logOut() : void
     {
         /** @var IdentityStore $store */
         $store = Injector::inst()->get(IdentityStore::class);
@@ -1097,7 +1104,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     /**
      * Cache for logInWithPermission()
      */
-    protected $cache_generatedMembers = array();
+    protected $cache_generatedMembers = [];
 
     /**
      * Test against a theme.
@@ -1107,7 +1114,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param callable $callback
      * @throws Exception
      */
-    protected function useTestTheme($themeBaseDir, $theme, $callback)
+    protected function useTestTheme(string $themeBaseDir, string $theme, callable $callback) : void
     {
         Config::nest();
         if (strpos($themeBaseDir, BASE_PATH) === 0) {
@@ -1128,7 +1135,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @return array List of paths
      */
-    protected function getFixturePaths()
+    protected function getFixturePaths() : array
     {
         $fixtureFile = static::get_fixture_file();
         if (empty($fixtureFile)) {
@@ -1156,7 +1163,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      *
      * @return array
      */
-    public static function getExtraControllers()
+    public static function getExtraControllers() : array
     {
         return static::$extra_controllers;
     }
@@ -1167,7 +1174,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param string $fixtureFilePath
      * @return string
      */
-    protected function resolveFixturePath($fixtureFilePath)
+    protected function resolveFixturePath(string $fixtureFilePath) : string
     {
         // Support fixture paths relative to the test class, rather than relative to webroot
         // String checking is faster than file_exists() calls.

--- a/tests/php/Control/IPUtilsTest.php
+++ b/tests/php/Control/IPUtilsTest.php
@@ -17,14 +17,14 @@ use SilverStripe\Control\Util\IPUtils;
 class IPUtilsTest extends SapphireTest
 {
     /**
-     * @dataProvider testIPv4Provider
+     * @dataProvider ipv4Provider
      */
     public function testIPv4($matches, $remoteAddr, $cidr)
     {
         $this->assertSame($matches, IPUtils::checkIP($remoteAddr, $cidr));
     }
 
-    public function testIPv4Provider()
+    public function ipv4Provider()
     {
         return array(
             array(true, '192.168.1.1', '192.168.1.1'),
@@ -43,7 +43,7 @@ class IPUtilsTest extends SapphireTest
     }
 
     /**
-     * @dataProvider testIPv6Provider
+     * @dataProvider ipv6Provider
      */
     public function testIPv6($matches, $remoteAddr, $cidr)
     {
@@ -54,7 +54,7 @@ class IPUtilsTest extends SapphireTest
         $this->assertSame($matches, IPUtils::checkIP($remoteAddr, $cidr));
     }
 
-    public function testIPv6Provider()
+    public function ipv6Provider()
     {
         return array(
             array(true, '2a01:198:603:0:396e:4789:8e99:890f', '2a01:198:603:0::/65'),

--- a/tests/php/Core/Manifest/ManifestFileFinderTest.php
+++ b/tests/php/Core/Manifest/ManifestFileFinderTest.php
@@ -26,7 +26,7 @@ class ManifestFileFinderTest extends SapphireTest
      * @param array $expect
      * @param string $message
      */
-    public function assertFinderFinds(ManifestFileFinder $finder, $base, $expect, $message = null)
+    public function assertFinderFinds(ManifestFileFinder $finder, $base, $expect, string $message = '')
     {
         if (!$base) {
             $base = $this->defaultBase;

--- a/tests/php/Dev/DeprecationTest.php
+++ b/tests/php/Dev/DeprecationTest.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Dev\Tests;
 
-use PHPUnit_Framework_Error;
 use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\Tests\DeprecationTest\TestDeprecation;
@@ -34,7 +33,7 @@ class DeprecationTest extends SapphireTest
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException \PHPUnit\Framework\Error\Error
      */
     public function testEqualVersionTriggersNotice()
     {
@@ -50,7 +49,7 @@ class DeprecationTest extends SapphireTest
     }
 
     /**
-    * @expectedException PHPUnit_Framework_Error
+     * @expectedException \PHPUnit\Framework\Error\Error
      */
     public function testGreaterVersionTriggersNotice()
     {
@@ -66,7 +65,7 @@ class DeprecationTest extends SapphireTest
     }
 
     /**
-    * @expectedException PHPUnit_Framework_Error
+     * @expectedException \PHPUnit\Framework\Error\Error
      */
     public function testMatchingModuleNotifcationVersionAffectsNotice()
     {
@@ -84,7 +83,7 @@ class DeprecationTest extends SapphireTest
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException \PHPUnit\Framework\Error\Error
      * @expectedExceptionMessage DeprecationTest->testScopeMethod is deprecated. Method scope
      */
     public function testScopeMethod()
@@ -94,7 +93,7 @@ class DeprecationTest extends SapphireTest
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException \PHPUnit\Framework\Error\Error
      * @expectedExceptionMessage DeprecationTest is deprecated. Class scope
      */
     public function testScopeClass()
@@ -104,7 +103,7 @@ class DeprecationTest extends SapphireTest
     }
 
     /**
-     * @expectedException PHPUnit_Framework_Error
+     * @expectedException \PHPUnit\Framework\Error\Error
      * @expectedExceptionMessage Global scope
      */
     public function testScopeGlobal()

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -86,7 +86,7 @@ class SapphireTestTest extends SapphireTest
      *
      * @testdox assertion assertListAllMatch fails when not all items are matching
      *
-     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
     public function testAssertListAllMatchFailsWhenNotMatchingAllItems($match, $itemsForList)
     {
@@ -119,7 +119,7 @@ class SapphireTestTest extends SapphireTest
      * @param $matches
      * @param $itemsForList array
      *
-     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
     public function testAssertListContainsFailsIfListDoesNotContainMatch($matches, $itemsForList)
     {
@@ -153,7 +153,7 @@ class SapphireTestTest extends SapphireTest
      * @param $itemsForList
      * @testdox assertion assertListNotContains throws a exception when a matching item is found in the list
      *
-     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
     public function testAssertListNotContainsFailsWhenListContainsAMatch($matches, $itemsForList)
     {
@@ -187,7 +187,7 @@ class SapphireTestTest extends SapphireTest
      * @param $matches
      * @param $itemsForList
      *
-     * @expectedException \PHPUnit_Framework_ExpectationFailedException
+     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
     public function testAssertListEqualsFailsOnNonEqualLists($matches, $itemsForList)
     {

--- a/tests/php/ORM/ArrayListTest.php
+++ b/tests/php/ORM/ArrayListTest.php
@@ -6,7 +6,7 @@ use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Filterable;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\View\ArrayData;
+use SilverStripe\ORM\SS_List;
 use stdClass;
 
 class ArrayListTest extends SapphireTest
@@ -723,7 +723,7 @@ class ArrayListTest extends SapphireTest
         $items->add($itemB);
 
         // This call will trigger a fatal error if there are issues with circular dependencies
-        $items->sort('Sort');
+        $this->assertInstanceOf(SS_List::class, $items->sort('Sort'));
     }
     /**
      * $list->filter('Name', 'bob'); // only bob in the list

--- a/tests/php/ORM/DBDateTest.php
+++ b/tests/php/ORM/DBDateTest.php
@@ -2,9 +2,9 @@
 
 namespace SilverStripe\ORM\Tests;
 
+use PHPUnit\Framework\Error\Notice;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\i18n\i18n;
-use SilverStripe\ORM\FieldType\DBDate;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\FieldType\DBField;
 
@@ -36,7 +36,7 @@ class DBDateTest extends SapphireTest
     protected function suppressNotices()
     {
         error_reporting(error_reporting() & ~E_USER_NOTICE);
-        \PHPUnit_Framework_Error_Notice::$enabled = false;
+        Notice::$enabled = false;
     }
 
     /**
@@ -45,7 +45,7 @@ class DBDateTest extends SapphireTest
     protected function restoreNotices()
     {
         error_reporting($this->oldError);
-        \PHPUnit_Framework_Error_Notice::$enabled = true;
+        Notice::$enabled = true;
     }
 
     public function testNiceDate()

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\ORM\Tests;
 
+use SilverStripe\ORM\Connect\Query;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
@@ -167,7 +168,7 @@ class DataQueryTest extends SapphireTest
     {
         $dataQuery = new DataQuery(DataQueryTest\ObjectB::class);
         $dataQuery->innerJoin('DataQueryTest_D', '"DataQueryTest_D"."RelationID" = "DataQueryTest_B"."ID"');
-        $dataQuery->execute();
+        $this->assertInstanceOf(Query::class, $dataQuery->execute());
     }
 
     public function testDisjunctiveGroup()

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -782,7 +782,7 @@ class SecurityTest extends FunctionalTest
      * @param string $expected
      * @param string $errorMessage
      */
-    protected function assertHasMessage($expected, $errorMessage = null)
+    protected function assertHasMessage($expected, string $errorMessage = '')
     {
         $messages = [];
         $result = $this->getValidationResult();

--- a/tests/php/View/Parsers/ShortcodeParserTest.php
+++ b/tests/php/View/Parsers/ShortcodeParserTest.php
@@ -208,7 +208,7 @@ class ShortcodeParserTest extends SapphireTest
         $this->assertEquals('', $this->parser->parse('[test_shortcode][test_shortcode]'));
     }
 
-    protected function assertEqualsIgnoringWhitespace($a, $b, $message = null)
+    protected function assertEqualsIgnoringWhitespace($a, $b, string $message = '')
     {
         $this->assertEquals(preg_replace('/\s+/', '', $a), preg_replace('/\s+/', '', $b), $message);
     }

--- a/tests/php/i18n/i18nTextCollectorTest.php
+++ b/tests/php/i18n/i18nTextCollectorTest.php
@@ -2,7 +2,7 @@
 
 namespace SilverStripe\i18n\Tests;
 
-use PHPUnit_Framework_Error_Notice;
+use PHPUnit\Framework\Error\Notice;
 use SilverStripe\Assets\Filesystem;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Dev\SapphireTest;
@@ -114,7 +114,7 @@ SS;
 
         // Test warning is raised on empty default
         $c->setWarnOnEmptyDefault(true);
-        $this->expectException(PHPUnit_Framework_Error_Notice::class);
+        $this->expectException(Notice::class);
         $this->expectExceptionMessage('Missing localisation default for key i18nTestModule.INJECTIONS_3');
 
         $c->collectFromTemplate($html, null, $mymodule);
@@ -189,7 +189,7 @@ SS;
 
         // Test warning is raised on empty default
         $c->setWarnOnEmptyDefault(true);
-        $this->expectException(PHPUnit_Framework_Error_Notice::class);
+        $this->expectException(Notice::class);
         $this->expectExceptionMessage('Missing localisation default for key Test.PRIOANDCOMMENT');
 
         $c->collectFromTemplate($html, 'Test', $mymodule);
@@ -425,7 +425,7 @@ PHP;
         $this->assertEquals($expectedArray, $collectedTranslatables);
 
         // Test warning is raised on empty default
-        $this->expectException(PHPUnit_Framework_Error_Notice::class);
+        $this->expectException(Notice::class);
         $this->expectExceptionMessage('Missing localisation default for key i18nTestModule.INJECTIONS4');
 
         $php = <<<PHP


### PR DESCRIPTION
This is the start of #7653 which will update the PHPUnit version to 7.0 (currently in beta).

As part of this change, we:

* Bump the minimum PHP version to 7.1 (as PHP 7.0 and lower are now out of active support)
* Start implementing some PHP 7 return type hints, mostly where we've extended PHPUnit which now implements these in its own classes

