### PR TITLE
FIX DBTime timestamps should return the time in seconds

### DIFF
--- a/src/ORM/FieldType/DBTime.php
+++ b/src/ORM/FieldType/DBTime.php
@@ -185,7 +185,8 @@ class DBTime extends DBField
     public function getTimestamp()
     {
         if ($this->value) {
-            return strtotime($this->value);
+            $now = DBDatetime::now()->getTimestamp();
+            return strtotime($this->value, $now) - $now;
         }
         return 0;
     }

--- a/tests/php/ORM/DBTimeTest.php
+++ b/tests/php/ORM/DBTimeTest.php
@@ -56,4 +56,12 @@ class DBTimeTest extends SapphireTest
         $time = DBTime::create_field('Time', '17:15:55');
         $this->assertRegexp('#5:15 PM#i', $time->Short());
     }
+
+    public function testTimeStamp()
+    {
+        $time = DBTime::create_field('Time', '01:00:00');
+        $this->assertEquals(3600, $time->getTimestamp());
+        $time = DBTime::create_field('Time', '23:30:00');
+        $this->assertEquals(3600*23.5, $time->getTimestamp());
+    }
 }


### PR DESCRIPTION
To me it is unexpected that the `getTimestamp` method on `DBTime` returns the timestamp of that time as of "today" when the application is running, rather than the time represented in seconds.