### PR TITLE
FIX Allow HTML 5 input tags in FunctionalTest form submissions

### DIFF
--- a/thirdparty/simpletest/page.php
+++ b/thirdparty/simpletest/page.php
@@ -94,7 +94,7 @@ class SimpleTagBuilder {
             $tag_class = $map[$type];
             return new $tag_class($attributes);
         }
-        return false;
+        return new SimpleTextTag($attributes);
     }
 
     /**


### PR DESCRIPTION
At the moment if you write a `FunctionalTest` to submit a `Form` which has `HTML5` `<input>` tags the form will fail to submit because `simpletest/form` doesn't recognise the newer HTML5 input types.

This PR allows any non-recognised inputs to fallback to `text` type (as the HTML spec does).