### PR TITLE
FIX `SSViwer::execute_template` should allow requirements to be included

### DIFF
--- a/src/View/SSTemplateParser.peg
+++ b/src/View/SSTemplateParser.peg
@@ -893,7 +893,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
         // Note: 'type' here is important to disable subTemplates in SSViewer::getSubtemplateFor()
         $res['php'] = '$val .= \\SilverStripe\\View\\SSViewer::execute_template([["type" => "Includes", '.$template.'], '.$template.'], $scope->getItem(), array(' .
-            implode(',', $arguments)."), \$scope);\n";
+            implode(',', $arguments)."), \$scope, true);\n";
 
         if ($this->includeDebuggingComments) { // Add include filename comments on dev sites
             $res['php'] =

--- a/src/View/SSTemplateParser.php
+++ b/src/View/SSTemplateParser.php
@@ -3501,7 +3501,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
         // Note: 'type' here is important to disable subTemplates in SSViewer::getSubtemplateFor()
         $res['php'] = '$val .= \\SilverStripe\\View\\SSViewer::execute_template([["type" => "Includes", '.$template.'], '.$template.'], $scope->getItem(), array(' .
-            implode(',', $arguments)."), \$scope);\n";
+            implode(',', $arguments)."), \$scope, true);\n";
 
         if ($this->includeDebuggingComments) { // Add include filename comments on dev sites
             $res['php'] =

--- a/src/View/SSViewer.php
+++ b/src/View/SSViewer.php
@@ -745,14 +745,28 @@ PHP;
      * @param mixed $data Data context
      * @param array $arguments Additional arguments
      * @param Object $scope
+     * @param bool $globalRequirements
+     *
      * @return string Evaluated result
      */
-    public static function execute_template($template, $data, $arguments = null, $scope = null)
+    public static function execute_template($template, $data, $arguments = null, $scope = null, $globalRequirements = false)
     {
         $v = SSViewer::create($template);
-        $v->includeRequirements(false);
 
-        return $v->process($data, $arguments, $scope);
+        if ($globalRequirements) {
+            $v->includeRequirements(false);
+        } else {
+            //nest a requirements backend for our template rendering
+            $origBackend = Requirements::backend();
+            Requirements::set_backend(Requirements_Backend::create());
+        }
+        try {
+            return $v->process($data, $arguments, $scope);
+        } finally {
+            if (!$globalRequirements) {
+                Requirements::set_backend($origBackend);
+            }
+        }
     }
 
     /**
@@ -763,14 +777,28 @@ PHP;
      * @param string $content Input string
      * @param mixed $data Data context
      * @param array $arguments Additional arguments
+     * @param bool $globalRequirements
+     *
      * @return string Evaluated result
      */
-    public static function execute_string($content, $data, $arguments = null)
+    public static function execute_string($content, $data, $arguments = null, $globalRequirements = false)
     {
         $v = SSViewer::fromString($content);
-        $v->includeRequirements(false);
 
-        return $v->process($data, $arguments);
+        if ($globalRequirements) {
+            $v->includeRequirements(false);
+        } else {
+            //nest a requirements backend for our template rendering
+            $origBackend = Requirements::backend();
+            Requirements::set_backend(Requirements_Backend::create());
+        }
+        try {
+            return $v->process($data, $arguments);
+        } finally {
+            if (!$globalRequirements) {
+                Requirements::set_backend($origBackend);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Potential fix to #7729 

This creates a `Requirements_Backend` instance for the rendering of template when using `SSViewer::execute_template` so that requirements can be safely included in templates that are rendered standalone.