### PR TITLE
Update CMS_Alternating_Button.md

### DIFF
--- a/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/CMS_Alternating_Button.md
+++ b/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/CMS_Alternating_Button.md
@@ -71,7 +71,7 @@ public function getCMSActions()
 __Deprecated:__
 The following documentation regarding jQuery, jQueryUI and Entwine applies to legacy code only.
 If you're developing new functionality in React powered sections please refer to
-[ReactJS in SilverStripe](./Extend_CMS_Interface.md#reactjs-in-silverstripe).
+[ReactJS in SilverStripe](./extend_cms_interface.md#reactjs-in-silverstripe).
 
 As with the *Save* and *Save & publish* buttons, you might want to add some scripted reactions to user actions on the
 frontend. You can affect the state of the button through the jQuery UI calls.


### PR DESCRIPTION
The URL that points to ReactJS development appears to be case-sensitive. This fixes the link