### PR TITLE
Fix Missing Part of Sentence

### DIFF
--- a/docs/en/02_Developer_Guides/07_Debugging/01_Error_Handling.md
+++ b/docs/en/02_Developer_Guides/07_Debugging/01_Error_Handling.md
@@ -24,7 +24,7 @@ Although you can raise more important levels of alerts in this way, we recommend
 these instead.
 
 For notice-level and warning-level issues, you should use [user_error](http://www.php.net/user_error) to throw errors
-where appropriate. These will not halt execution but will send a message to the 
+where appropriate. These will not halt execution but will send a message to the PHP error log.
 
 ```php
 public function delete()


### PR DESCRIPTION
It seems to be missing the words **PHP error log**.

Add words (without bold type).

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/