### PR TITLE
WIP [CMS-2064] BUGFIX: getCMSActions should add actions when defined on the DataObject

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -188,6 +188,9 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
 
         // Build actions
         $actions = $this->getFormActions();
+        if(method_exists($this->record, 'getCMSActions')) {
+            $actions->merge($this->record->getCMSActions());
+        }
 
         // If we are creating a new record in a has-many list, then
         // pre-populate the record's foreign key.


### PR DESCRIPTION
I raised this issue on https://github.com/silverstripe/silverstripe-cms/issues/2064. This is not a complete fix - the new FormAction buttons appear, but the actions are not invoked if they are added via a DataExtension.

I found that when you create a method "getCMSActions" and attempt to add some new formactions to the record, the method is never invoked. @flamerohr discovered that getCMSActions is never called from GridfieldDetailForm_ItemRequest.

Again, this is a partial fix and it still needs some work.
