### PR TITLE
check for UPLOAD_ERR_NO_FILE on FileField::saveinto

### DIFF
--- a/src/Forms/FileField.php
+++ b/src/Forms/FileField.php
@@ -128,7 +128,7 @@ class FileField extends FormField implements FileHandleField
      */
     public function saveInto(DataObjectInterface $record)
     {
-        if (!isset($_FILES[$this->name])) {
+        if (!isset($_FILES[$this->name]['error']) || $_FILES[$this->name]['error'] == UPLOAD_ERR_NO_FILE) {
             return;
         }
 


### PR DESCRIPTION
When using a `FileField` in a form and calling `saveInto()`, if the `FileField` is not required it cannot be empty at the moment. This is because the `isset($_FILE[$this->name])` check will always return true, even though the `error` is 4 ([UPLOAD_ERR_NO_FILE](http://php.net/manual/en/features.file-upload.errors.php)) and the `size` is 0.

This change checks for the existence of `error` - it will be 0 (UPLOAD_ERR_OK) on success - and then will bypass validation if there is no file.