### PR TITLE
FIX, adding a missing return statement.

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -949,7 +949,7 @@ abstract class Object {
 	protected function createMethod($method, $code) {
 		self::$extra_methods[get_class($this)][strtolower($method)] = array (
 			'function' => function($obj, $args) use ($code) {
-                eval($code);
+                return eval($code);
             }
 		);
 	}


### PR DESCRIPTION
This causes issues such as an `_function` to incorrectly return null.

This fixes https://github.com/silverstripe/silverstripe-framework/issues/7740.