### PR TITLE
FIX Allow extension instances to be overridden by injector

### DIFF
--- a/src/Core/ClassInfo.php
+++ b/src/Core/ClassInfo.php
@@ -208,6 +208,7 @@ class ClassInfo
      * eg: self::class_name('dataobJEct'); //returns 'DataObject'
      *
      * @param string|object $nameOrObject The classname or object you want to normalise
+     * @throws \ReflectionException
      * @return string The normalised class name
      */
     public static function class_name($nameOrObject)

--- a/tests/php/Core/ObjectTest.php
+++ b/tests/php/Core/ObjectTest.php
@@ -195,11 +195,13 @@ class ObjectTest extends SapphireTest
         );
         $inst = new ExtensionTest();
         $extensions = $inst->getExtensionInstances();
-        $this->assertEquals(count($extensions), 2);
+        $this->assertCount(2, $extensions);
+        $this->assertArrayHasKey(ExtendTest1::class, $extensions);
         $this->assertInstanceOf(
             ExtendTest1::class,
             $extensions[ExtendTest1::class]
         );
+        $this->assertArrayHasKey(ExtendTest2::class, $extensions);
         $this->assertInstanceOf(
             ExtendTest2::class,
             $extensions[ExtendTest2::class]
@@ -506,5 +508,34 @@ class ObjectTest extends SapphireTest
             array('\Test\MyClass', array()),
             ClassInfo::parse_class_spec('\Test\MyClass')
         );
+    }
+
+    public function testInjectedExtensions()
+    {
+        $mockExtension = $this->createMock(TestExtension::class);
+        $mockClass = get_class($mockExtension);
+
+        $object = new ExtensionTest2();
+
+        // sanity check
+        $this->assertNotEquals(TestExtension::class, $mockClass);
+
+        $this->assertTrue($object->hasExtension(TestExtension::class));
+        $this->assertFalse($object->hasExtension($mockClass));
+        $this->assertCount(1, $object->getExtensionInstances());
+        $this->assertInstanceOf(TestExtension::class, $object->getExtensionInstance(TestExtension::class));
+        $this->assertNotInstanceOf($mockClass, $object->getExtensionInstance(TestExtension::class));
+
+        Injector::inst()->registerService($mockExtension, TestExtension::class);
+
+        $object = new ExtensionTest2();
+
+        $this->assertTrue($object->hasExtension(TestExtension::class));
+        $this->assertTrue($object->hasExtension($mockClass));
+        $this->assertCount(1, $object->getExtensionInstances());
+        $this->assertInstanceOf(TestExtension::class, $object->getExtensionInstance(TestExtension::class));
+        $this->assertInstanceOf($mockClass, $object->getExtensionInstance(TestExtension::class));
+        $this->assertInstanceOf(TestExtension::class, $object->getExtensionInstance($mockClass));
+        $this->assertInstanceOf($mockClass, $object->getExtensionInstance($mockClass));
     }
 }


### PR DESCRIPTION
If you override an Extension instance in injector with Yaml like so:

```yaml
SilverStripe\Core\Injector\Injector:
  WidgetExtension:
    class: MyWidgetExtension
```

The checks on `$object->hasExtension('WidgetExtension')` will fail because `Extensible` adds the class of the actual extension instance (`MyWidgetExtension`) as the name of the extension. This can result in logic that uses `hasExtension` in modules to fail when `Injector` is used to override the `Extension` instance.

This change would allow the `$object->hasExtension` (and related methods) to return correctly when `Injector` has been used to redefine the class of an `Extension`.