### PR TITLE
JSON.parse does not like empty strings

### DIFF
--- a/admin/javascript/LeftAndMain.js
+++ b/admin/javascript/LeftAndMain.js
@@ -73,7 +73,7 @@ jQuery.noConflict();
 		$(window).on("message", function(e) {
 			var target,
 				event = e.originalEvent,
-				data = typeof event.data === 'object' ? event.data : JSON.parse(event.data);
+				data = typeof event.data === 'object' ? event.data : event.data ? JSON.parse(event.data) : {};
 
 			// Reject messages outside of the same origin
 			if($.path.parseUrl(window.location.href).domain !== $.path.parseUrl(event.origin).domain) return;


### PR DESCRIPTION
Add some protection for the case that `event.data` is empty or null. Why the backend chose not to send data, I do not know, but I guess having the code not to crash is good anyway.