### PR TITLE
Forms with FormHandlers don't have access to current request object

### DIFF
--- a/src/Forms/FormRequestHandler.php
+++ b/src/Forms/FormRequestHandler.php
@@ -228,6 +228,7 @@ class FormRequestHandler extends RequestHandler
             // First, try a handler method on the controller (has been checked for allowed_actions above already)
             $controller = $this->form->getController();
             if ($controller && $controller->hasMethod($funcName)) {
+                $controller->setRequest($request);
                 return $controller->$funcName($vars, $this->form, $request, $this);
             }
 


### PR DESCRIPTION
At the moment non-controller `FormHandler`s fail to have the current request object available to them through `$this->getRequest()` when form submission actions are sent to them.

This is most noticeable when trying to use `$LoginForm` on non Security controllers.

To replicate:
1. Add `$LoginForm` to your Page.ss Layout file
2. Submit valid login credentials to the Form from a normal page (ie: not from the login page)
3. See `[Emergency] Uncaught BadMethodCallException: No session available for this HTTPRequest` error

This is because `setRequest` is never called on the `FormHandler` when it is invoked with `FormRequestHandler::httpSubmission()`

This PR fixes the problem by correctly assigning the current request to the FormHanlder.