### PR TITLE
BUG Prevent basic-auth from disallowing logout

### DIFF
--- a/src/Security/BasicAuth.php
+++ b/src/Security/BasicAuth.php
@@ -109,10 +109,6 @@ class BasicAuth
             return true;
         }
 
-        if ($member instanceof Member) {
-            Security::setCurrentUser($member);
-        }
-
         if (!$member && $tryUsingSessionLogin) {
             $member = Security::getCurrentUser();
         }


### PR DESCRIPTION
Fixes #7555

Unfortunately, as a result of this change, if users want to access authorised sections (such as /admin) they need to enter their login details again. This is because as those details cannot be removed from the php auth headers, we cannot use those to automatically log the user in.

However, we can use these details to either pass or fail access to basicauth.

The number of problems remains constant, but less critical. :)