### PR TITLE
Add `PUBLIC_*` constants to 4.0.x for easier compatibility

### DIFF
--- a/src/includes/constants.php
+++ b/src/includes/constants.php
@@ -22,6 +22,8 @@ use SilverStripe\Core\TempFolder;
  * - THEMES_PATH: Absolute filepath, e.g. "/var/www/my-webroot/themes"
  * - FRAMEWORK_DIR: Path relative to webroot, e.g. "framework"
  * - FRAMEWORK_PATH:Absolute filepath, e.g. "/var/www/my-webroot/framework"
+ * - PUBLIC_DIR: Webroot path relative to project root, e.g. "public" or ""
+ * - PUBLIC_PATH: Absolute path to webroot, e.g. "/var/www/project/public"
  * - THIRDPARTY_DIR: Path relative to webroot, e.g. "framework/thirdparty"
  * - THIRDPARTY_PATH: Absolute filepath, e.g. "/var/www/my-webroot/framework/thirdparty"
  */
@@ -54,6 +56,14 @@ if (!defined('BASE_PATH')) {
         // This likely only happens on chrooted environemnts
         return $candidateBasePath ?: DIRECTORY_SEPARATOR;
     }));
+}
+
+// Set public webroot dir / path
+if (!defined('PUBLIC_DIR')) {
+    define('PUBLIC_DIR', '');
+}
+if (!defined('PUBLIC_PATH')) {
+    define('PUBLIC_PATH', BASE_PATH);
 }
 
 // Allow a first class env var to be set that disables .env file loading

--- a/src/includes/constants.php
+++ b/src/includes/constants.php
@@ -8,7 +8,6 @@ use SilverStripe\Core\TempFolder;
  * This file is the Framework constants bootstrap. It will prepare some basic common constants.
  *
  * It takes care of:
- *  - Normalisation of $_SERVER values
  *  - Initialisation of necessary constants (mostly paths)
  *
  * Initialized constants:


### PR DESCRIPTION
4.x now has support for a separate public dir to be used as the webroot.

This fix back-ports the definition of the `PUBLIC_*` constants so that modules that want to support 4.0 and 4.1 don't have to either litter their code with `if (defined('PUBLIC_PATH'))` or mandate 4.1 as a dependency.

At the moment supporting the public webroot requires extra logic that would best be avoided if we truly want it to be opt-in.