### PR TITLE
API Update behat-extension from selenium > chromedriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 
 dist: trusty
 
+before_install:
+ - sudo apt-get update
+ - sudo apt-get install chromium-chromedriver
+
 cache:
   directories:
     - $HOME/.composer/cache/files
@@ -67,6 +71,10 @@ matrix:
         - PHPUNIT_TEST=framework
 
 before_script:
+# Extra $PATH
+  - export PATH=~/.composer/vendor/bin:$PATH
+  - export PATH=/usr/lib/chromium-browser/:$PATH
+
 # Init PHP
   - pecl channel-update pecl.php.net
   - phpenv rehash
@@ -74,11 +82,10 @@ before_script:
   - echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 # Install composer dependencies
-  - export PATH=~/.composer/vendor/bin:$PATH
   - composer validate
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --no-update; fi
   - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --no-update; fi
-  - composer require silverstripe/recipe-core:1.0.x-dev silverstripe/admin:1.0.x-dev silverstripe/versioned:1.0.x-dev --no-update
+  - composer require silverstripe/recipe-testing:^1 silverstripe/recipe-core:1.0.x-dev silverstripe/admin:1.0.x-dev silverstripe/versioned:1.0.x-dev --no-update
   - if [[ $PHPUNIT_TEST == cms ]] || [[ $BEHAT_TEST == cms ]]; then composer require silverstripe/recipe-cms:1.0.x-dev --no-update; fi
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
@@ -90,7 +97,7 @@ before_script:
   - if [[ $BEHAT_TEST ]]; then mkdir artifacts; fi
   - if [[ $BEHAT_TEST ]]; then cp composer.lock artifacts/; fi
   - if [[ $BEHAT_TEST ]]; then sh -e /etc/init.d/xvfb start; sleep 3; fi
-  - if [[ $BEHAT_TEST ]]; then (vendor/bin/selenium-server-standalone > artifacts/selenium.log 2>&1 &); fi
+  - if [[ $BEHAT_TEST ]]; then (chromedriver > artifacts/chromedriver.log 2>&1 &); fi
   - if [[ $BEHAT_TEST == framework ]]; then (vendor/bin/serve --bootstrap-file tests/behat/serve-bootstrap.php &> artifacts/serve.log &); fi
   - if [[ $BEHAT_TEST == cms ]]; then (vendor/bin/serve --bootstrap-file vendor/silverstripe/cms/tests/behat/serve-bootstrap.php &> artifacts/serve.log &); fi
 

--- a/behat.yml
+++ b/behat.yml
@@ -23,10 +23,11 @@ default:
 
   extensions:
     SilverStripe\BehatExtension\MinkExtension:
-      default_session: selenium2
-      javascript_session: selenium2
-      selenium2:
-        browser: firefox
+      default_session: facebook_web_driver
+      javascript_session: facebook_web_driver
+      facebook_web_driver:
+        browser: chrome
+        wd_host: "http://127.0.0.1:9515" #chromedriver port
 
     SilverStripe\BehatExtension\Extension:
       screenshot_path: %paths.base%/artifacts/screenshots

--- a/composer.json
+++ b/composer.json
@@ -52,10 +52,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",
-        "silverstripe/versioned": "^1.0",
-        "silverstripe/behat-extension": "^3",
-        "silverstripe/serve": "^2",
-        "se/selenium-server-standalone": "2.41.0"
+        "silverstripe/versioned": "^1.0"
     },
     "provide": {
         "psr/container-implementation": "1.0.0"

--- a/tests/behat/features/reauthenticate.feature
+++ b/tests/behat/features/reauthenticate.feature
@@ -18,8 +18,9 @@ Feature: Reauthenticate
     When I fill in "Password" with "Secret!123"
       And I press the "Let me back in" button
       And I am not in an iframe
-      And I click "ADMIN" in the "#Root_Users" element
-    Then I should see "Save" in the "#Form_ItemEditForm_action_doSave" element
+      And I go to "/admin/security"
+      When I press the "Add Member" button
+    Then I should see "Create" in the "#Form_ItemEditForm_action_doSave" element
 
   Scenario: Reauthenticate with wrong login
     When I press the "Add Member" button
@@ -31,5 +32,6 @@ Feature: Reauthenticate
     When I fill in "Password" with "Secret!123"
       And I press the "Let me back in" button
       And I am not in an iframe
-      And I click "ADMIN" in the "#Root_Users" element
-    Then I should see "Save" in the "#Form_ItemEditForm_action_doSave" element
+      And I go to "/admin/security"
+      When I press the "Add Member" button
+    Then I should see "Create" in the "#Form_ItemEditForm_action_doSave" element

--- a/tests/behat/src/CmsFormsContext.php
+++ b/tests/behat/src/CmsFormsContext.php
@@ -6,6 +6,7 @@ use BadMethodCallException;
 use Behat\Behat\Context\Context;
 use Behat\Mink\Exception\ElementHtmlException;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Session;
 use SilverStripe\BehatExtension\Context\MainContextAwareTrait;
 use SilverStripe\BehatExtension\Utility\StepHelper;
 use Symfony\Component\DomCrawler\Crawler;
@@ -24,6 +25,9 @@ class CmsFormsContext implements Context
 
     /**
      * Get Mink session from MinkContext
+     *
+     * @param string $name
+     * @return Session
      */
     public function getSession($name = null)
     {
@@ -210,6 +214,7 @@ JS;
         $page = $this->getSession()->getPage();
         $els = $page->findAll('named', array('field', "'$text'"));
         $matchedEl = null;
+        /** @var NodeElement $el */
         foreach ($els as $el) {
             if ($el->isVisible()) {
                 $matchedEl = $el;
@@ -267,6 +272,7 @@ JS;
     public function iSelectValueInTreeDropdown($text, $selector)
     {
         $page = $this->getSession()->getPage();
+        /** @var NodeElement $parentElement */
         $parentElement = null;
         $this->retryThrowable(function () use (&$parentElement, &$page, $selector) {
             $parentElement = $page->find('css', $selector);


### PR DESCRIPTION
This change requires a new (yet untagged) version of behat-extension, so be careful of merge order. :)

Parent story: https://github.com/silverstripe/silverstripe-behat-extension/issues/137

Instead of using selenium, switch behat to the custom https://github.com/open-sausages/MinkFacebookWebDriver I wrote which uses github.com/facebook/php-webdriver instead of the instaclick/webdriver.

See discussion on https://github.com/minkphp/MinkSelenium2Driver/issues/254 for why we aren't using latest firefox anymore (it's not quite ready for use with latest selenium).

In order to test see the composer.json with all the necessary repositories in my comment at https://github.com/silverstripe/silverstripe-behat-extension/issues/137#issuecomment-358791801