### PR TITLE
BUG Fix double casting in login authenticator name

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -271,7 +271,7 @@ en:
     ERRORWRONGCRED: 'The provided details don''t seem to be correct. Please try again.'
     NoPassword: 'There is no password on this member.'
   SilverStripe\Security\MemberAuthenticator\MemberLoginForm:
-    AUTHENTICATORNAME: 'E-mail &amp; Password'
+    AUTHENTICATORNAME: 'E-mail & Password'
   SilverStripe\Security\MemberPassword:
     PLURALNAME: 'Member Passwords'
     PLURALS:

--- a/src/Security/MemberAuthenticator/MemberLoginForm.php
+++ b/src/Security/MemberAuthenticator/MemberLoginForm.php
@@ -224,6 +224,6 @@ class MemberLoginForm extends BaseLoginForm
      */
     public function getAuthenticatorName()
     {
-        return _t(self::class . '.AUTHENTICATORNAME', "E-mail &amp; Password");
+        return _t(self::class . '.AUTHENTICATORNAME', "E-mail & Password");
     }
 }


### PR DESCRIPTION
Fixes #7769

Given that this field is only ever used in places where the casting ends up broken, I'm going to err in favour of securing the source string instead of raw-ifying the output casting.