### PR TITLE
Ensure currentUserID() returns an int

### DIFF
--- a/security/Member.php
+++ b/security/Member.php
@@ -894,7 +894,7 @@ class Member extends DataObject implements TemplateGlobalProvider {
 			$id = Session::get("loggedInAs");
 		}
 
-		return is_numeric($id) ? $id : 0;
+		return is_numeric($id) ? (int) $id : 0;
 	}
 	private static $_already_tried_to_auto_log_in = false;
 


### PR DESCRIPTION
Cast $id returned from Session as an int to ensure it's never returned as a string
