### PR TITLE
BUG Better upload error message

### DIFF
--- a/src/Forms/FileUploadReceiver.php
+++ b/src/Forms/FileUploadReceiver.php
@@ -294,7 +294,8 @@ trait FileUploadReceiver
         }
 
         if ($tmpFile['error']) {
-            $error = $tmpFile['error'];
+            $this->getUpload()->validate($tmpFile);
+            $error = implode(' ' . PHP_EOL, $this->getUpload()->getErrors());
             return null;
         }
 


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-asset-admin/issues/720

The issue was the literal PHP error integer was being used as the error message.

Using the in-built upload validator will turn this into a proper localised error message.