### PR TITLE
FIX: Allow absolute URLs be use as resources

### DIFF
--- a/src/Control/SimpleResourceURLGenerator.php
+++ b/src/Control/SimpleResourceURLGenerator.php
@@ -71,6 +71,9 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
             $relativePath = $resource->getRelativePath();
             $exists = $resource->exists();
             $absolutePath = $resource->getPath();
+        } else if (Director::is_absolute_url($relativePath)) {
+            // Path is not relative, and probably not of this site
+            return $relativePath;
         } else {
             // Use normal string
             $absolutePath = preg_replace('/\?.*/', '', Director::baseFolder() . '/' . $relativePath);

--- a/src/Control/SimpleResourceURLGenerator.php
+++ b/src/Control/SimpleResourceURLGenerator.php
@@ -71,7 +71,7 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
             $relativePath = $resource->getRelativePath();
             $exists = $resource->exists();
             $absolutePath = $resource->getPath();
-        } else if (Director::is_absolute_url($relativePath)) {
+        } elseif (Director::is_absolute_url($relativePath)) {
             // Path is not relative, and probably not of this site
             return $relativePath;
         } else {

--- a/tests/php/Control/SimpleResourceURLGeneratorTest.php
+++ b/tests/php/Control/SimpleResourceURLGeneratorTest.php
@@ -64,4 +64,12 @@ class SimpleResourceURLGeneratorTest extends SapphireTest
             $generator->urlForResource($module->getResource('client/style.css'))
         );
     }
+    
+    public function testAbsoluteResource()
+    {
+        /** @var SimpleResourceURLGenerator $generator */
+        $generator = Injector::inst()->get(ResourceURLGenerator::class);
+        $fakeExternalAsset = 'https://cdn.example.com/some_library.css';
+        $this->assertEquals($fakeExternalAsset, $generator->urlForResource($fakeExternalAsset));
+    }
 }


### PR DESCRIPTION
At current certain interfaces exist that assume only local assets will be loaded (e.g. `SilverStripe\Forms\HTMLEditor\TinyMCEConfig::getConfig()`), where as someone may wish to load an off site resource via the use of an absolute URL (e.g. for fontawesome css provided via a CDN). Because asset path parsing is filtered through a `SilverStripe\Core\Manifest\ResourceURLGenerator`, one must either know in advance if they want an internal or external resource (loading different generators), or the API must allow for this (i.e. an inclusion function for each type of asset). So we can either double the API on the implementing class, or simply make an exception for an absolute URL as high as possible; inside the filter - for which the `vendor/module : path/to/file.asset` shorthand syntax was specifically designed not to conflict with.


After discussion with @tractorcow about the issue, this was the solution we arrived at.