### PR TITLE
NEW: Add support for ordinals in DBDate::Format()

### DIFF
--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -217,7 +217,8 @@ class DBDate extends DBField
     }
 
     /**
-     * Return the date using a particular formatting string.
+     * Return the date using a particular formatting string. Use {o} to include an ordinal representation
+     * for the day of the month ("1st", "2nd", "3rd" etc)
      *
      * @param string $format Format code string. See http://userguide.icu-project.org/formatparse/datetime
      * @return string The date in the requested format
@@ -227,6 +228,12 @@ class DBDate extends DBField
         if (!$this->value) {
             return null;
         }
+
+        // Replace {o} with ordinal representation of day of the month
+        if (strpos($format, '{o}') !== false) {
+            $format = str_replace('{o}', "'{$this->DayOfMonth(true)}'", $format);
+        }
+
         $formatter = $this->getFormatter();
         $formatter->setPattern($format);
         return $formatter->format($this->getTimestamp());

--- a/tests/php/ORM/DBDateTest.php
+++ b/tests/php/ORM/DBDateTest.php
@@ -238,6 +238,21 @@ class DBDateTest extends SapphireTest
         $this->assertEquals('10th - 20th Oct 2000', $range);
     }
 
+    public function testFormatReplacesOrdinals()
+    {
+        $this->assertEquals(
+            '20th October 2000',
+            DBField::create_field('Date', '2000-10-20')->Format('{o} MMMM YYYY'),
+            'Ordinal day of month was not injected'
+        );
+
+        $this->assertEquals(
+            '20th is the 20th day of the month',
+            DBField::create_field('Date', '2000-10-20')->Format("{o} 'is the' {o} 'day of the month'"),
+            'Failed to inject multiple ordinal values into one string'
+        );
+    }
+
     public function testExtendedDates()
     {
         $date = DBField::create_field('Date', '1800-10-10');


### PR DESCRIPTION
E.g. `{$LastEdited.Format('EEEE d{o} MMMM YYYY')}` would display `Wednesday 24th January 2018`.

This solution only really works for ordinal suffixes. Apparently there are some languages which will [display the ordinal as a prefix](https://en.wikipedia.org/wiki/Ordinal_indicator#Representation_as_prefix), but from what I’ve seen true internationalisation is only really possible by using `DBDate::Full()` so I think that limitation is acceptable.