### PR TITLE
Fixed Rfc3339 implementation of Date and Datetime

### DIFF
--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -322,19 +322,7 @@ class DBDate extends DBField
      */
     public function Rfc3339()
     {
-        $date = $this->Format('y-MM-dd\\THH:mm:ss');
-        if (!$date) {
-            return null;
-        }
-
-        $matches = array();
-        if (preg_match('/^([\-+])(\d{2})(\d{2})$/', date('O', $this->getTimestamp()), $matches)) {
-            $date .= $matches[1] . $matches[2] . ':' . $matches[3];
-        } else {
-            $date .= 'Z';
-        }
-
-        return $date;
+        return date('c', $this->getTimestamp());
     }
 
     /**

--- a/tests/php/ORM/DBDateTest.php
+++ b/tests/php/ORM/DBDateTest.php
@@ -330,4 +330,11 @@ class DBDateTest extends SapphireTest
 
         DBDatetime::clear_mock_now();
     }
+
+    public function testRfc3999()
+    {
+        // Dates should be formatted as: 2018-01-24T14:05:53+00:00
+        $date = DBDate::create_field('Date', '2010-12-31');
+        $this->assertEquals('2010-12-31T00:00:00+00:00', $date->Rfc3339());
+    }
 }

--- a/tests/php/ORM/DBDatetimeTest.php
+++ b/tests/php/ORM/DBDatetimeTest.php
@@ -204,4 +204,11 @@ class DBDatetimeTest extends SapphireTest
 
         DBDatetime::clear_mock_now();
     }
+
+    public function testRfc3999()
+    {
+        // Dates should be formatted as: 2018-01-24T14:05:53+00:00
+        $date = DBDatetime::create_field('Datetime', '2010-12-31 16:58:59');
+        $this->assertEquals('2010-12-31T16:58:59+00:00', $date->Rfc3339());
+    }
 }


### PR DESCRIPTION
Fix implementation of Rfc3339, which returned malformed strings like:  `2010-12-31\+00:00`