### PR TITLE
FIX isInDB actually checks if the object is in DB

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -781,6 +781,8 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
 
         $item = Injector::inst()->create($class, $row, false, $this->getQueryParams());
 
+        DataObject::register_object($item);
+
         return $item;
     }
 

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -18,6 +18,7 @@ use SilverStripe\ORM\FieldType\DBPolymorphicForeignKey;
 use SilverStripe\ORM\FieldType\DBVarchar;
 use SilverStripe\ORM\ManyManyList;
 use SilverStripe\ORM\Tests\DataObjectTest\Player;
+use SilverStripe\ORM\Tests\DataObjectTest\Staff;
 use SilverStripe\View\ViewableData;
 use stdClass;
 
@@ -2134,5 +2135,21 @@ class DataObjectTest extends SapphireTest
             DataObjectTest\TeamComment::class,
             ['"DataObjectTest_TeamComment"."Name"' => 'does not exists']
         ));
+    }
+
+    public function testIsInDB()
+    {
+        $nonExistantID = Staff::get()->max('ID') + 1;
+        $staff = new Staff([
+            'ID' => $nonExistantID,
+            'Salary' => 12,
+        ]);
+        $this->assertFalse($staff->isInDB());
+        $staff->write();
+        $this->assertTrue($staff->isInDB());
+        $staff->delete();
+        $this->assertFalse($staff->isInDB());
+        $staff->ID = $nonExistantID;
+        $this->assertFalse($staff->isInDB());
     }
 }


### PR DESCRIPTION
Both `DataObject::exists()` and `DataObject::isInDB()` claim to check if the current object is in the DB yet neither do so and both provide a slightly different way of determining if the object does in fact "exist in the DB".

This change introduces checking of the DB when checking the DB for an object's existence.