### PR TITLE
BUG $this->tableName in CompositeDBField->addToQuery is blank.

### DIFF
--- a/model/DataQuery.php
+++ b/model/DataQuery.php
@@ -490,6 +490,7 @@ class DataQuery {
 		if($compositeFields) foreach($compositeFields as $k => $v) {
 			if((is_null($columns) || in_array($k, $columns)) && $v) {
 				$dbO = Object::create_from_string($v, $k);
+				$dbO->setTable($tableClass);
 				$dbO->addToQuery($query);
 			}
 		}


### PR DESCRIPTION
`$this->tableName` is currently just blank in `addToQuery()` method of a CompositeDBField, because the `setTable()`-method is not called.

This is already fixed in 4.0 branch but not in 3.6.