### PR TITLE
FIX Allow cleanup marker regex to handle self closing HTML5 tags

### DIFF
--- a/src/View/Parsers/ShortcodeParser.php
+++ b/src/View/Parsers/ShortcodeParser.php
@@ -726,7 +726,7 @@ class ShortcodeParser
             $content = preg_replace_callback(
                 // Not a general-case parser; assumes that the HTML generated in replaceElementTagsWithMarkers()
                 // hasn't been heavily modified
-                '/<img[^>]+class="' . preg_quote(self::$marker_class) . '"[^>]+data-tagid="([^"]+)"[^>]+>/i',
+                '/<img[^>]+class="' . preg_quote(self::$marker_class) . '"[^>]+data-tagid="([^"]+)"[^>]*>/i',
                 function ($matches) use ($tags, $parser) {
                     $tag = $tags[$matches[1]];
                     return $parser->getShortcodeReplacementText($tag);

--- a/tests/php/View/Parsers/ShortcodeParserTest.php
+++ b/tests/php/View/Parsers/ShortcodeParserTest.php
@@ -328,6 +328,17 @@ class ShortcodeParserTest extends SapphireTest
         $stub->parse('<p>test</p>');
     }
 
+    public function testSelfClosingHtmlTags()
+    {
+        $this->parser->register('img', function () {
+            return '<img src="http://example.com/image.jpg">';
+        });
+
+        $result = $this->parser->parse('[img]');
+
+        $this->assertContains('http://example.com/image.jpg', $result);
+    }
+
     // -----------------------------------------------------------------------------------------------------------------
 
     /**


### PR DESCRIPTION
When using self closing HTML5 tags, the regex to find left over marker classes in content and replace them with valid tags is looking for at least one character between `data-tagid="123"` and `>`, which isn't the case when using something like [silverstripe/html5](https://github.com/silverstripe/silverstripe-html5).

The result, for example in CWP 2.0, is that images embedded in content disappear when saving the page in the CMS, and are not rendered on the frontend. Instead you see `<img class="--ss-shortcode-marker" data-tagid="0">` instead.

The change is "at least one" to "any" for the regex quantifier.