### PR TITLE
Cast DropdownField's source value as string

### DIFF
--- a/forms/DropdownField.php
+++ b/forms/DropdownField.php
@@ -189,7 +189,7 @@ class DropdownField extends FormField {
 				}
 
 				$options[] = new ArrayData(array(
-					'Title' => $title,
+					'Title' => (string)$title,
 					'Value' => $value,
 					'Selected' => $selected,
 					'Disabled' => $disabled,


### PR DESCRIPTION
Fixes a bug, where passing `0` as number results in an empty value, caused by https://github.com/silverstripe/silverstripe-framework/pull/5199

Demo code:

```
DropdownField::create('Number', 'Number')
->setSource(ArrayLib::valuekey(range(0, 10));
```

results in "0" not being displayed in the dropdown
