### PR TITLE
BUG Prevent invalid members being written to database if validation_enabled is false

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1654,6 +1654,11 @@ class Member extends DataObject
      */
     public function validate()
     {
+        // If validation is disabled, skip this step
+        if (!DataObject::config()->uninherited('validation_enabled')) {
+            return ValidationResult::create();
+        }
+
         $valid = parent::validate();
         $validator = static::password_validator();
 

--- a/src/Security/PasswordEncryptor.php
+++ b/src/Security/PasswordEncryptor.php
@@ -28,7 +28,7 @@ abstract class PasswordEncryptor
      */
     public static function get_encryptors()
     {
-        return Config::inst()->get('SilverStripe\\Security\\PasswordEncryptor', 'encryptors');
+        return Config::inst()->get(self::class, 'encryptors');
     }
 
     /**


### PR DESCRIPTION
The issue was that validation_enabled = false was not stopping invalid records from writing to the database (as expected), but Member was still only writing the password to the database if ->validate() passed anyway.

The result was a blank value written to the DB for PasswordEncryption, which failed the next login to that account.