### PR TITLE
[bugfix] $request == null breaks

### DIFF
--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -651,7 +651,7 @@ class Security extends Controller implements TemplateGlobalProvider
     {
         if ($request) {
             $this->setRequest($request);
-        } elseif ($request) {
+        } elseif ($this->getRequest()) {
             $request = $this->getRequest();
         } else {
             throw new HTTPResponse_Exception("No request available", 500);


### PR DESCRIPTION
The $request incoming as null was not properly detected by the if/elseif structure.

Observed behaviour:
- A call without a request is arriving at login throws a 500
Expected behaviour:
- The controller should attempt to read the request from itself before breaking
