### PR TITLE
Move CSV writing/reading to league/csv library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "require": {
         "composer/installers": "~1.0",
         "embed/embed": "^3.0",
+        "league/csv": "^8",
         "league/flysystem": "~1.0.12",
         "monolog/monolog": "~1.11",
         "nikic/php-parser": "^2 || ^3",

--- a/src/Dev/BulkLoader_Result.php
+++ b/src/Dev/BulkLoader_Result.php
@@ -15,7 +15,7 @@ use SilverStripe\View\ArrayData;
  *
  * @author Ingo Schommer, Silverstripe Ltd. (<firstname>@silverstripe.com)
  */
-class BulkLoader_Result
+class BulkLoader_Result implements \Countable
 {
     use Injectable;
 

--- a/src/Dev/CSVParser.php
+++ b/src/Dev/CSVParser.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Dev;
 
+use League\Csv\Reader;
 use SilverStripe\Core\Injector\Injectable;
 use Iterator;
 
@@ -114,6 +115,7 @@ class CSVParser implements Iterator
      */
     public function __construct($filename, $delimiter = ",", $enclosure = '"')
     {
+        Deprecation::notice('5.0', __CLASS__ . ' is deprecated, use ' . Reader::class . ' instead');
         $filename = Director::getAbsFile($filename);
         $this->filename = $filename;
         $this->delimiter = $delimiter;

--- a/src/Forms/GridField/GridFieldExportButton.php
+++ b/src/Forms/GridField/GridFieldExportButton.php
@@ -62,6 +62,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
      * Place the export button in a <p> tag below the field
      *
      * @param GridField $gridField
+     *
      * @return array
      */
     public function getHTMLFragments($gridField)
@@ -75,20 +76,21 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
         );
         $button->addExtraClass('btn btn-secondary no-ajax font-icon-down-circled action_export');
         $button->setForm($gridField->getForm());
-        return array(
-            $this->targetFragment => $button->Field()
-        );
+        return [
+            $this->targetFragment => $button->Field(),
+        ];
     }
 
     /**
      * export is an action button
      *
      * @param GridField $gridField
+     *
      * @return array
      */
     public function getActions($gridField)
     {
-        return array('export');
+        return ['export'];
     }
 
     public function handleAction(GridField $gridField, $actionName, $arguments, $data)
@@ -103,13 +105,14 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
      * it is also a URL
      *
      * @param GridField $gridField
+     *
      * @return array
      */
     public function getURLHandlers($gridField)
     {
-        return array(
+        return [
             'export' => 'handleExport',
-        );
+        ];
     }
 
     /**
@@ -117,6 +120,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
      *
      * @param GridField $gridField
      * @param HTTPRequest $request
+     *
      * @return HTTPResponse
      */
     public function handleExport($gridField, $request = null)
@@ -156,6 +160,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
      * Generate export fields for CSV.
      *
      * @param GridField $gridField
+     *
      * @return string
      */
     public function generateExportFileData($gridField)
@@ -168,8 +173,20 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
         $csvWriter->setNewline("\r\n"); //use windows line endings for compatibility with some csv libraries
         $csvWriter->setOutputBOM(Writer::BOM_UTF8);
 
+        if (!Config::inst()->get(get_class($this), 'xls_export_disabled')) {
+            $csvWriter->addFormatter(function (array $row) {
+                foreach ($row as &$item) {
+                    // [SS-2017-007] Sanitise XLS executable column values with a leading tab
+                    if (preg_match('/^[-@=+].*/', $item)) {
+                        $item = "\t" . $item;
+                    }
+                }
+                return $row;
+            });
+        }
+
         if ($this->csvHasHeader) {
-            $headers = array();
+            $headers = [];
 
             // determine the CSV headers. If a field is callable (e.g. anonymous function) then use the
             // source name as the header instead
@@ -200,7 +217,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
         /** @var DataObject $item */
         foreach ($items->limit(null) as $item) {
             if (!$item->hasMethod('canView') || $item->canView()) {
-                $columnData = array();
+                $columnData = [];
 
                 foreach ($csvColumns as $columnSource => $columnHeader) {
                     if (!is_string($columnHeader) && is_callable($columnHeader)) {
@@ -219,12 +236,6 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
                         }
                     }
 
-                    // [SS-2017-007] Sanitise XLS executable column values with a leading tab
-                    if (!Config::inst()->get(get_class($this), 'xls_export_disabled')
-                        && preg_match('/^[-@=+].*/', $value)
-                    ) {
-                        $value = "\t" . $value;
-                    }
                     $columnData[] = $value;
                 }
 
@@ -236,7 +247,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
             }
         }
 
-        return (string) $csvWriter;
+        return (string)$csvWriter;
     }
 
     /**
@@ -249,6 +260,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 
     /**
      * @param array $cols
+     *
      * @return $this
      */
     public function setExportColumns($cols)
@@ -267,6 +279,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 
     /**
      * @param string $separator
+     *
      * @return $this
      */
     public function setCsvSeparator($separator)
@@ -285,6 +298,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 
     /**
      * @param string $enclosure
+     *
      * @return $this
      */
     public function setCsvEnclosure($enclosure)
@@ -303,6 +317,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
 
     /**
      * @param boolean $bool
+     *
      * @return $this
      */
     public function setCsvHasHeader($bool)

--- a/tests/php/Dev/CsvBulkLoaderTest.php
+++ b/tests/php/Dev/CsvBulkLoaderTest.php
@@ -246,9 +246,9 @@ class CsvBulkLoaderTest extends SapphireTest
         $results = $loader->load($filepath);
         $createdPlayers = $results->Created();
         $player = $createdPlayers->first();
-        $this->assertEquals($player->FirstName, 'Customized John');
-        $this->assertEquals($player->Biography, "He's a good guy");
-        $this->assertEquals($player->IsRegistered, "1");
+        $this->assertEquals('Customized John', $player->FirstName);
+        $this->assertEquals("He's a good guy", $player->Biography);
+        $this->assertEquals("1", $player->IsRegistered);
     }
 
     public function testLoadWithCustomImportMethodDuplicateMap()

--- a/tests/php/Dev/CsvBulkLoaderTest.php
+++ b/tests/php/Dev/CsvBulkLoaderTest.php
@@ -50,7 +50,7 @@ class CsvBulkLoaderTest extends SapphireTest
         $results = $loader->load($filepath);
 
         // Test that right amount of columns was imported
-        $this->assertEquals(5, $results->Count(), 'Test correct count of imported data');
+        $this->assertCount(5, $results, 'Test correct count of imported data');
 
         // Test that columns were correctly imported
         $obj = DataObject::get_one(
@@ -76,18 +76,48 @@ class CsvBulkLoaderTest extends SapphireTest
         $filepath = $this->csvPath . 'PlayersWithHeader.csv';
         $loader->deleteExistingRecords = true;
         $results1 = $loader->load($filepath);
-        $this->assertEquals(5, $results1->Count(), 'Test correct count of imported data on first load');
+        $this->assertCount(5, $results1, 'Test correct count of imported data on first load');
 
         //delete existing data before doing second CSV import
         $results2 = $loader->load($filepath);
         //get all instances of the loaded DataObject from the database and count them
         $resultDataObject = DataObject::get(Player::class);
 
-        $this->assertEquals(
+        $this->assertCount(
             5,
-            $resultDataObject->count(),
+            $resultDataObject,
             'Test if existing data is deleted before new data is added'
         );
+    }
+
+    public function testLeadingTabs()
+    {
+        $loader = new CsvBulkLoader(Player::class);
+        $loader->hasHeaderRow = false;
+        $loader->columnMap = array(
+            'FirstName',
+            'Biography',
+            null, // ignored column
+            'Birthday',
+            'IsRegistered'
+        );
+        $filepath = $this->csvPath . 'PlayersWithTabs.csv';
+        $results = $loader->load($filepath);
+        $this->assertCount(5, $results);
+
+        $expectedBios = [
+            "\tHe's a good guy",
+            "=She is awesome.\nSo awesome that she gets multiple rows and \"escaped\" strings in her biography",
+            "-Pretty old\, with an escaped comma",
+            "@Unicode FTW",
+            "+Unicode FTW",
+        ];
+
+        foreach (Player::get()->column('Biography') as $bio) {
+            $this->assertContains($bio, $expectedBios);
+        }
+
+        $this->assertEquals(Player::get()->count(), count($expectedBios));
     }
 
     /**
@@ -111,7 +141,7 @@ class CsvBulkLoaderTest extends SapphireTest
         $results = $loader->load($filepath);
 
         // Test that right amount of columns was imported
-        $this->assertEquals(4, $results->Count(), 'Test correct count of imported data');
+        $this->assertCount(4, $results, 'Test correct count of imported data');
 
         // Test that columns were correctly imported
         $obj = DataObject::get_one(
@@ -167,7 +197,7 @@ class CsvBulkLoaderTest extends SapphireTest
         $results = $loader->load($filepath);
 
         // Test that right amount of columns was imported
-        $this->assertEquals(1, $results->Count(), 'Test correct count of imported data');
+        $this->assertCount(1, $results, 'Test correct count of imported data');
 
         // Test of augumenting existing relation (created by fixture)
         $testTeam = DataObject::get_one(Team::class, null, null, '"Created" DESC');
@@ -290,6 +320,6 @@ class CsvBulkLoaderTest extends SapphireTest
 
         $results = $loader->load($path);
 
-        $this->assertEquals(10, $results->Count());
+        $this->assertCount(10, $results);
     }
 }

--- a/tests/php/Dev/CsvBulkLoaderTest/csv/PlayersWithTabs.csv
+++ b/tests/php/Dev/CsvBulkLoaderTest/csv/PlayersWithTabs.csv
@@ -1,0 +1,6 @@
+"John","	He's a good guy","ignored","1988-01-31","1"
+"Jane","	=She is awesome.
+So awesome that she gets multiple rows and ""escaped"" strings in her biography","ignored","1982-01-31","0"
+"Jamie","	-Pretty old\, with an escaped comma","ignored","1882-01-31","1"
+"Järg","	@Unicode FTW","ignored","1982-06-30","1"
+"Järg","	+Unicode FTW","ignored","1982-06-30","1"

--- a/tests/php/Forms/GridField/GridFieldExportButtonTest.php
+++ b/tests/php/Forms/GridField/GridFieldExportButtonTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms\Tests\GridField;
 
+use League\Csv\Reader;
 use SilverStripe\Forms\Tests\GridField\GridFieldExportButtonTest\NoView;
 use SilverStripe\Forms\Tests\GridField\GridFieldExportButtonTest\Team;
 use SilverStripe\ORM\DataList;
@@ -54,9 +55,12 @@ class GridFieldExportButtonTest extends SapphireTest
         $config = GridFieldConfig::create()->addComponent(new GridFieldExportButton());
         $gridField = new GridField('testfield', 'testfield', $list, $config);
 
+        $csvReader = Reader::createFromString($button->generateExportFileData($gridField));
+        $bom = $csvReader->getInputBOM();
+
         $this->assertEquals(
-            "\"My Name\"\n",
-            $button->generateExportFileData($gridField)
+            "$bom\"My Name\"\r\n",
+            (string) $csvReader
         );
     }
 
@@ -65,9 +69,12 @@ class GridFieldExportButtonTest extends SapphireTest
         $button = new GridFieldExportButton();
         $button->setExportColumns(['Name' => 'My Name']);
 
+        $csvReader = Reader::createFromString($button->generateExportFileData($this->gridField));
+        $bom = $csvReader->getInputBOM();
+
         $this->assertEquals(
-            '"My Name"' . "\n" . 'Test' . "\n" . 'Test2' . "\n",
-            $button->generateExportFileData($this->gridField)
+            $bom . '"My Name"' . "\r\n" . 'Test' . "\r\n" . 'Test2' . "\r\n",
+            (string) $csvReader
         );
     }
 
@@ -82,9 +89,12 @@ class GridFieldExportButtonTest extends SapphireTest
         $button = new GridFieldExportButton();
         $button->setExportColumns(['Name' => 'My Name']);
 
+        $csvReader = Reader::createFromString($button->generateExportFileData($this->gridField));
+        $bom = $csvReader->getInputBOM();
+
         $this->assertEquals(
-            "\"My Name\"\n\"\t=SUM(1, 2)\"\nTest\nTest2\n",
-            $button->generateExportFileData($this->gridField)
+            "$bom\"My Name\"\r\n\"\t=SUM(1, 2)\"\r\nTest\r\nTest2\r\n",
+            (string) $csvReader
         );
     }
 
@@ -98,9 +108,12 @@ class GridFieldExportButtonTest extends SapphireTest
             }
         ]);
 
+        $csvReader = Reader::createFromString($button->generateExportFileData($this->gridField));
+        $bom = $csvReader->getInputBOM();
+
         $this->assertEquals(
-            'Name,City' . "\n" . 'Test,"City city"' . "\n" . 'Test2,"Quoted ""City"" 2 city"' . "\n",
-            $button->generateExportFileData($this->gridField)
+            $bom . 'Name,City' . "\r\n" . 'Test,"City city"' . "\r\n" . 'Test2,"Quoted ""City"" 2 city"' . "\r\n",
+            (string) $csvReader
         );
     }
 
@@ -112,9 +125,12 @@ class GridFieldExportButtonTest extends SapphireTest
             'City' => 'strtolower',
         ]);
 
+        $csvReader = Reader::createFromString($button->generateExportFileData($this->gridField));
+        $bom = $csvReader->getInputBOM();
+
         $this->assertEquals(
-            'Name,strtolower' . "\n" . 'Test,City' . "\n" . 'Test2,"Quoted ""City"" 2"' . "\n",
-            $button->generateExportFileData($this->gridField)
+            $bom . 'Name,strtolower' . "\r\n" . 'Test,City' . "\r\n" . 'Test2,"Quoted ""City"" 2"' . "\r\n",
+            (string) $csvReader
         );
     }
 
@@ -127,9 +143,12 @@ class GridFieldExportButtonTest extends SapphireTest
         ]);
         $button->setCsvHasHeader(false);
 
+        $csvReader = Reader::createFromString($button->generateExportFileData($this->gridField));
+        $bom = $csvReader->getInputBOM();
+
         $this->assertEquals(
-            'Test,City' . "\n" . 'Test2,"Quoted ""City"" 2"' . "\n",
-            $button->generateExportFileData($this->gridField)
+            $bom . 'Test,City' . "\r\n" . 'Test2,"Quoted ""City"" 2"' . "\r\n",
+            (string) $csvReader
         );
     }
 
@@ -146,9 +165,14 @@ class GridFieldExportButtonTest extends SapphireTest
         }
         $this->gridField->setList($arrayList);
 
+        $exportData = $button->generateExportFileData($this->gridField);
+
+        $csvReader = Reader::createFromString($exportData);
+        $bom = $csvReader->getInputBOM();
+
         $this->assertEquals(
-            "ID\n" . "1\n" . "2\n" . "3\n" . "4\n" . "5\n" . "6\n" . "7\n" . "8\n" . "9\n" . "10\n" . "11\n" . "12\n" . "13\n" . "14\n" . "15\n" . "16\n",
-            $button->generateExportFileData($this->gridField)
+            $bom . "ID\r\n" . "1\r\n" . "2\r\n" . "3\r\n" . "4\r\n" . "5\r\n" . "6\r\n" . "7\r\n" . "8\r\n" . "9\r\n" . "10\r\n" . "11\r\n" . "12\r\n" . "13\r\n" . "14\r\n" . "15\r\n" . "16\r\n",
+            (string) $csvReader
         );
     }
 
@@ -159,9 +183,12 @@ class GridFieldExportButtonTest extends SapphireTest
             'RugbyTeamNumber' => 'Rugby Team Number'
         ]);
 
+        $csvReader = Reader::createFromString($button->generateExportFileData($this->gridField));
+        $bom = $csvReader->getInputBOM();
+
         $this->assertEquals(
-            "\"Rugby Team Number\"\n2\n0\n",
-            $button->generateExportFileData($this->gridField)
+            "$bom\"Rugby Team Number\"\r\n2\r\n0\r\n",
+            (string) $csvReader
         );
     }
 }


### PR DESCRIPTION
Moved the writing and reading of CSVs to the [`league/csv`](https://github.com/thephpleague/csv) library for better compatibility.

Improvements:
- Add UTF-8 BOM to start of CSV files
- Unified and standard way to read/write CSVs
- Push CSV code maintenance to external library