### PR TITLE
FIX Regex range identifier correctly escaped

### DIFF
--- a/src/Core/TempFolder.php
+++ b/src/Core/TempFolder.php
@@ -76,7 +76,7 @@ class TempFolder
         }
 
         // failing the above, try finding a namespaced silverstripe-cache dir in the system temp
-        $tempPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-cache-php' . preg_replace('/[^\w-\.+]+/', '-', PHP_VERSION) . str_replace(array(' ', '/', ':', '\\'), '-', $base);
+        $tempPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-cache-php' . preg_replace('/[^\w\-\.+]+/', '-', PHP_VERSION) . str_replace(array(' ', '/', ':', '\\'), '-', $base);
         if (!@file_exists($tempPath)) {
             $oldUMask = umask(0);
             @mkdir($tempPath, 0777);

--- a/tests/php/Core/CoreTest.php
+++ b/tests/php/Core/CoreTest.php
@@ -29,7 +29,7 @@ class CoreTest extends SapphireTest
             $this->assertEquals(TempFolder::getTempFolder(BASE_PATH), $this->tempPath . DIRECTORY_SEPARATOR . $user);
         } else {
             $user = TempFolder::getTempFolderUsername();
-            $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-cache-php' . preg_replace('/[^\w-\.+]+/', '-', PHP_VERSION);
+            $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-cache-php' . preg_replace('/[^\w\-\.+]+/', '-', PHP_VERSION);
 
             // A typical Windows location for where sites are stored on IIS
             $this->assertEquals(
@@ -55,7 +55,7 @@ class CoreTest extends SapphireTest
     {
         parent::tearDown();
         $user = TempFolder::getTempFolderUsername();
-        $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-cache-php' . preg_replace('/[^\w-\.+]+/', '-', PHP_VERSION);
+        $base = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'silverstripe-cache-php' . preg_replace('/[^\w\-\.+]+/', '-', PHP_VERSION);
         foreach (array(
             'C--inetpub-wwwroot-silverstripe-test-project',
             '-Users-joebloggs-Sites-silverstripe-test-project',


### PR DESCRIPTION
This should fix the nightly builds on travis.