### PR TITLE
add excludeAny() and tests for complicated excludes/filters

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -598,7 +598,9 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @todo extract the sql from this method into a SQLGenerator class
      *
-     * @param string|array Escaped SQL statement. If passed as array, all keys and values will be escaped internally
+     * @param string|array
+     * @param string [optional]
+     *
      * @return $this
      */
     public function exclude()
@@ -634,9 +636,9 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @example $list = $list->excludeAny(array('Name'=>array('bob','phil'), 'Age'=>array(21, 43)));
      *          // bob, phil, 21 or 43 would be excluded
      *
-     * @todo extract the sql from this method into a SQLGenerator class
+     * @param string|array
+     * @param string [optional]
      *
-     * @param string|array Escaped SQL statement. If passed as array, all keys and values will be escaped internally
      * @return $this
      */
     public function excludeAny()

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -653,14 +653,14 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
         } else {
             throw new InvalidArgumentException('Incorrect number of arguments passed to excludeAny()');
         }
-        $list = $this;
 
-        foreach ($whereArguments as $field => $value) {
-            $filter = $this->createSearchFilter($field, $value);
-            $list = $list->alterDataQuery(array($filter, 'exclude'));
-        }
-
-        return $list;
+        return $this->alterDataQuery(function (DataQuery $dataQuery) use ($whereArguments) {
+            foreach ($whereArguments as $field => $value) {
+                $filter = $this->createSearchFilter($field, $value);
+                $filter->exclude($dataQuery);
+            }
+            return $dataQuery;
+        });
     }
 
     /**

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -587,9 +587,8 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
     }
 
     /**
-     * Return a copy of this list which does not contain any items with these charactaristics
+     * Return a copy of this list which does not contain any items that match all params
      *
-     * @see SS_List::exclude()
      * @example $list = $list->exclude('Name', 'bob'); // exclude bob from list
      * @example $list = $list->exclude('Name', array('aziz', 'bob'); // exclude aziz and bob from list
      * @example $list = $list->exclude(array('Name'=>'bob, 'Age'=>21)); // exclude bob that has Age 21
@@ -623,6 +622,43 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
                 $filter->exclude($subquery);
             }
         });
+    }
+
+    /**
+     * Return a copy of this list which does not contain any items with any of these params
+     *
+     * @example $list = $list->excludeAny('Name', 'bob'); // exclude bob from list
+     * @example $list = $list->excludeAny('Name', array('aziz', 'bob'); // exclude aziz and bob from list
+     * @example $list = $list->excludeAny(array('Name'=>'bob, 'Age'=>21)); // exclude bob or Age 21
+     * @example $list = $list->excludeAny(array('Name'=>'bob, 'Age'=>array(21, 43))); // exclude bob or Age 21 or 43
+     * @example $list = $list->excludeAny(array('Name'=>array('bob','phil'), 'Age'=>array(21, 43)));
+     *          // bob, phil, 21 or 43 would be excluded
+     *
+     * @todo extract the sql from this method into a SQLGenerator class
+     *
+     * @param string|array Escaped SQL statement. If passed as array, all keys and values will be escaped internally
+     * @return $this
+     */
+    public function excludeAny()
+    {
+        $numberFuncArgs = count(func_get_args());
+        $whereArguments = array();
+
+        if ($numberFuncArgs == 1 && is_array(func_get_arg(0))) {
+            $whereArguments = func_get_arg(0);
+        } elseif ($numberFuncArgs == 2) {
+            $whereArguments[func_get_arg(0)] = func_get_arg(1);
+        } else {
+            throw new InvalidArgumentException('Incorrect number of arguments passed to excludeAny()');
+        }
+        $list = $this;
+
+        foreach ($whereArguments as $field => $value) {
+            $filter = $this->createSearchFilter($field, $value);
+            $list = $list->alterDataQuery(array($filter, 'exclude'));
+        }
+
+        return $list;
     }
 
     /**

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -1494,7 +1494,6 @@ class DataListTest extends SapphireTest
      */
     public function testMultipleExcludeWithMiss()
     {
-        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->exclude(array('Name'=>'Bob', 'Comment'=>'Does not match any comments'));
         $this->assertEquals(3, $list->count());
@@ -1505,7 +1504,6 @@ class DataListTest extends SapphireTest
      */
     public function testMultipleExclude()
     {
-        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->exclude(array('Name'=>'Bob', 'Comment'=>'This is a team comment by Bob'));
         $this->assertEquals(2, $list->count());
@@ -1517,7 +1515,6 @@ class DataListTest extends SapphireTest
      */
     public function testMultipleExcludeMultipleMatches()
     {
-        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->exclude(array('Name'=>'Bob', 'Comment'=>'Phil is a unique guy, and comments on team2'));
         $this->assertCount(3, $list);
@@ -1528,7 +1525,6 @@ class DataListTest extends SapphireTest
      */
     public function testMultipleExcludeArraysMultipleMatches()
     {
-        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->exclude(array(
             'Name'=> array('Bob', 'Phil'),
@@ -1545,7 +1541,6 @@ class DataListTest extends SapphireTest
      */
     public function testMultipleExcludeArraysMultipleMatchesOneMiss()
     {
-        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->exclude(array(
             'Name' => array('Bob', 'Phil'),
@@ -1569,7 +1564,6 @@ class DataListTest extends SapphireTest
      */
     public function testExcludeOnFilter()
     {
-        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->filter('Comment', 'Phil is a unique guy, and comments on team2');
         $list = $list->exclude('Name', 'Bob');
@@ -1589,7 +1583,6 @@ class DataListTest extends SapphireTest
      */
     public function testComplicatedExcludeOnFilter()
     {
-        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->filter('Name', array('Phil', 'Bob'));
         $list = $list->exclude('Name', array('Bob', 'Joe'));
@@ -1609,7 +1602,6 @@ class DataListTest extends SapphireTest
      */
     public function testVeryComplicatedExcludeOnFilter()
     {
-        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->filter('Name', array('Phil', 'Bob'));
         $list = $list->exclude(array(
@@ -1652,7 +1644,6 @@ class DataListTest extends SapphireTest
      */
     public function testExcludeAny()
     {
-        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->excludeAny(array(
             'Name' => 'Bob',
@@ -1666,7 +1657,6 @@ class DataListTest extends SapphireTest
      */
     public function testExcludeAnyArrays()
     {
-        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->excludeAny(array(
             'Name' => array('Bob', 'Phil'),
@@ -1680,7 +1670,6 @@ class DataListTest extends SapphireTest
      */
     public function testExcludeAnyMultiArrays()
     {
-        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->excludeAny(array(
             'Name' => array('Bob', 'Fred'),

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -1494,6 +1494,7 @@ class DataListTest extends SapphireTest
      */
     public function testMultipleExcludeWithMiss()
     {
+        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->exclude(array('Name'=>'Bob', 'Comment'=>'Does not match any comments'));
         $this->assertEquals(3, $list->count());
@@ -1504,6 +1505,7 @@ class DataListTest extends SapphireTest
      */
     public function testMultipleExclude()
     {
+        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->exclude(array('Name'=>'Bob', 'Comment'=>'This is a team comment by Bob'));
         $this->assertEquals(2, $list->count());
@@ -1515,9 +1517,10 @@ class DataListTest extends SapphireTest
      */
     public function testMultipleExcludeMultipleMatches()
     {
+        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->exclude(array('Name'=>'Bob', 'Comment'=>'Phil is a unique guy, and comments on team2'));
-        $this->assertEquals(3, $list->count());
+        $this->assertCount(3, $list);
     }
 
     /**
@@ -1525,6 +1528,7 @@ class DataListTest extends SapphireTest
      */
     public function testMultipleExcludeArraysMultipleMatches()
     {
+        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->exclude(array(
             'Name'=> array('Bob', 'Phil'),
@@ -1533,8 +1537,7 @@ class DataListTest extends SapphireTest
                 'Phil is a unique guy, and comments on team2'
             )
         ));
-        $this->assertEquals(1, $list->count());
-        $this->assertEquals('Joe', $list->last()->Name);
+        $this->assertListEquals([['Name' => 'Joe']], $list);
     }
 
     /**
@@ -1542,6 +1545,7 @@ class DataListTest extends SapphireTest
      */
     public function testMultipleExcludeArraysMultipleMatchesOneMiss()
     {
+        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->exclude(array(
             'Name' => array('Bob', 'Phil'),
@@ -1551,9 +1555,13 @@ class DataListTest extends SapphireTest
             )
         ));
         $list = $list->sort('Name');
-        $this->assertEquals(2, $list->count());
-        $this->assertEquals('Bob', $list->first()->Name);
-        $this->assertEquals('Joe', $list->last()->Name);
+        $this->assertListEquals(
+            [
+                ['Name' => 'Bob'],
+                ['Name' => 'Joe'],
+            ],
+            $list
+        );
     }
 
     /**
@@ -1561,9 +1569,7 @@ class DataListTest extends SapphireTest
      */
     public function testExcludeOnFilter()
     {
-        /**
-         * @var DataList $list
-         */
+        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->filter('Comment', 'Phil is a unique guy, and comments on team2');
         $list = $list->exclude('Name', 'Bob');
@@ -1575,8 +1581,7 @@ class DataListTest extends SapphireTest
             $sql
         );
         $this->assertEquals(array('Phil is a unique guy, and comments on team2', 'Bob'), $parameters);
-        $this->assertCount(1, $list);
-        $this->assertEquals('Phil', $list->first()->Name);
+        $this->assertListEquals([['Name' => 'Phil']], $list);
     }
 
     /**
@@ -1584,9 +1589,7 @@ class DataListTest extends SapphireTest
      */
     public function testComplicatedExcludeOnFilter()
     {
-        /**
-         * @var DataList $list
-         */
+        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->filter('Name', array('Phil', 'Bob'));
         $list = $list->exclude('Name', array('Bob', 'Joe'));
@@ -1598,8 +1601,7 @@ class DataListTest extends SapphireTest
             $sql
         );
         $this->assertEquals(array('Phil', 'Bob', 'Bob', 'Joe'), $parameters);
-        $this->assertCount(1, $list);
-        $this->assertEquals('Phil', $list->first()->Name);
+        $this->assertListEquals([['Name' => 'Phil']], $list);
     }
 
     /**
@@ -1607,9 +1609,7 @@ class DataListTest extends SapphireTest
      */
     public function testVeryComplicatedExcludeOnFilter()
     {
-        /**
- * @var DataList $list
-*/
+        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->filter('Name', array('Phil', 'Bob'));
         $list = $list->exclude(array(
@@ -1628,9 +1628,13 @@ class DataListTest extends SapphireTest
         );
         $this->assertEquals(array('Phil', 'Bob', 'Joe', 'Phil', 'Matches no comments', 'Not a matching comment'), $parameters);
         $list = $list->sort('Name');
-        $this->assertEquals(2, $list->count());
-        $this->assertEquals('Bob', $list->first()->Name);
-        $this->assertEquals('Phil', $list->last()->Name);
+        $this->assertListEquals(
+            [
+                ['Name' => 'Bob'],
+                ['Name' => 'Phil'],
+            ],
+            $list
+        );
     }
 
     public function testExcludeWithSearchFilter()
@@ -1648,15 +1652,13 @@ class DataListTest extends SapphireTest
      */
     public function testExcludeAny()
     {
-        /**
-         * @var DataList $list
-         */
+        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->excludeAny(array(
-                'Name' => 'Bob',
-                'Comment' => 'Phil is a unique guy, and comments on team2'
+            'Name' => 'Bob',
+            'Comment' => 'Phil is a unique guy, and comments on team2'
         ));
-        $this->assertCount(1, $list);
+        $this->assertListEquals([['Name' => 'Joe']], $list);
     }
 
     /**
@@ -1664,15 +1666,13 @@ class DataListTest extends SapphireTest
      */
     public function testExcludeAnyArrays()
     {
-        /**
-         * @var DataList $list
-         */
+        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->excludeAny(array(
-                'Name' => array('Bob', 'Phil'),
-                'Comment' => 'No matching comments'
+            'Name' => array('Bob', 'Phil'),
+            'Comment' => 'No matching comments'
         ));
-        $this->assertCount(1, $list);
+        $this->assertListEquals([['Name' => 'Joe']], $list);
     }
 
     /**
@@ -1680,15 +1680,13 @@ class DataListTest extends SapphireTest
      */
     public function testExcludeAnyMultiArrays()
     {
-        /**
-         * @var DataList $list
-         */
+        /** @var DataList $list */
         $list = TeamComment::get();
         $list = $list->excludeAny(array(
-                'Name' => array('Bob', 'Fred'),
-                'Comment' => array('No matching comments', 'Phil is a unique guy, and comments on team2')
+            'Name' => array('Bob', 'Fred'),
+            'Comment' => array('No matching comments', 'Phil is a unique guy, and comments on team2')
         ));
-        $this->assertCount(1, $list);
+        $this->assertListEquals([['Name' => 'Joe']], $list);
     }
 
     /**

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -1644,6 +1644,54 @@ class DataListTest extends SapphireTest
     }
 
     /**
+     * Test that Bob and Phil are excluded (one match each)
+     */
+    public function testExcludeAny()
+    {
+        /**
+         * @var DataList $list
+         */
+        $list = TeamComment::get();
+        $list = $list->excludeAny(array(
+                'Name' => 'Bob',
+                'Comment' => 'Phil is a unique guy, and comments on team2'
+        ));
+        $this->assertCount(1, $list);
+    }
+
+    /**
+     * Test that Bob and Phil are excluded by Name
+     */
+    public function testExcludeAnyArrays()
+    {
+        /**
+         * @var DataList $list
+         */
+        $list = TeamComment::get();
+        $list = $list->excludeAny(array(
+                'Name' => array('Bob', 'Phil'),
+                'Comment' => 'No matching comments'
+        ));
+        $this->assertCount(1, $list);
+    }
+
+    /**
+     * Test that Bob is excluded by Name, Phil by comment
+     */
+    public function testExcludeAnyMultiArrays()
+    {
+        /**
+         * @var DataList $list
+         */
+        $list = TeamComment::get();
+        $list = $list->excludeAny(array(
+                'Name' => array('Bob', 'Fred'),
+                'Comment' => array('No matching comments', 'Phil is a unique guy, and comments on team2')
+        ));
+        $this->assertCount(1, $list);
+    }
+
+    /**
      * Test exact match filter with empty array items
      *
      * @expectedException \InvalidArgumentException


### PR DESCRIPTION
Proves #6613 is behaving correctly.

Also adds `excludeAny()` to counterpart `exclude()` in the same way as `filterAny()` and `filter()`. This would be the option that devs have tried to use previously, and had to chain `exclude()`s