### PR TITLE
NEW Allow GridFieldConfig::addComponents to accept an array

### DIFF
--- a/src/Forms/GridField/GridFieldConfig.php
+++ b/src/Forms/GridField/GridFieldConfig.php
@@ -68,12 +68,12 @@ class GridFieldConfig
     }
 
     /**
-     * @param GridFieldComponent $component,... One or more components
+     * @param GridFieldComponent|GridFieldComponent[] $component,... One or more components, or an array of components
      * @return $this
      */
     public function addComponents($component = null)
     {
-        $components = func_get_args();
+        $components = is_array($component) ? $component : func_get_args();
         foreach ($components as $component) {
             $this->addComponent($component);
         }

--- a/tests/php/Forms/GridField/GridFieldConfigTest.php
+++ b/tests/php/Forms/GridField/GridFieldConfigTest.php
@@ -92,6 +92,19 @@ class GridFieldConfigTest extends SapphireTest
         );
     }
 
+    public function testAddComponentsByArray()
+    {
+        $config = GridFieldConfig::create()
+            ->addComponents([
+                $c1 = new MyComponent(),
+            ]);
+
+        $this->assertEquals(
+            $c1,
+            $config->getComponentByType(MyComponent::class)
+        );
+    }
+
     public function testRemoveComponents()
     {
         $config = GridFieldConfig::create()


### PR DESCRIPTION
When I tried to use this method I expected that it would accept an array.
This pull request allows an array as well as an arbitrary number of arguments to be passed.