### PR TITLE
ENHANCEMENT composer.json missing notice

### DIFF
--- a/src/Core/Manifest/ModuleResourceLoader.php
+++ b/src/Core/Manifest/ModuleResourceLoader.php
@@ -103,7 +103,7 @@ class ModuleResourceLoader implements TemplateGlobalProvider
         $resource = $matches['resource'];
         $moduleObj = ModuleLoader::getModule($module);
         if (!$moduleObj) {
-            throw new InvalidArgumentException("Can't find module '$module'");
+            throw new InvalidArgumentException("Can't find module '$module', the composer.json file may be missing from the modules installation directory");
         }
         $resourceObj = $moduleObj->getResource($resource);
         if (!$resourceObj->exists()) {


### PR DESCRIPTION
This goes towards helping a dev resolve a "resource could not be found" error message when the lookup is of `vendor/package:resource` format but the composer.json file (or package directory) is missing.