### PR TITLE
Fix docs for configuring before/after a specific config file

### DIFF
--- a/_config/i18n.yml
+++ b/_config/i18n.yml
@@ -1,6 +1,6 @@
 ---
 Name: basei18n
-Before: '/i18n'
+Before: '#defaulti18n'
 ---
 SilverStripe\i18n\Data\Sources:
   module_priority:

--- a/docs/en/02_Developer_Guides/02_Controllers/01_Introduction.md
+++ b/docs/en/02_Developer_Guides/02_Controllers/01_Introduction.md
@@ -51,7 +51,7 @@ Make sure that after you have modified the `routes.yml` file, that you clear you
 ```yml
 ---
 Name: mysiteroutes
-After: framework/routes#coreroutes
+After: framework/_config/routes#coreroutes
 ---
 SilverStripe\Control\Director:
   rules:

--- a/docs/en/02_Developer_Guides/02_Controllers/02_Routing.md
+++ b/docs/en/02_Developer_Guides/02_Controllers/02_Routing.md
@@ -20,7 +20,7 @@ These routes by standard, go into a `routes.yml` file in your applications `_con
 ```yml
 ---
 Name: mysiteroutes
-After: framework/routes#coreroutes
+After: framework/_config/routes#coreroutes
 ---
 SilverStripe\Control\Director:
   rules:

--- a/docs/en/02_Developer_Guides/13_i18n/index.md
+++ b/docs/en/02_Developer_Guides/13_i18n/index.md
@@ -337,7 +337,7 @@ To create a custom module order, you need to specify a config fragment that inse
 ```yml
 ---
 Name: customi18n
-Before: 'defaulti18n'
+Before: '#defaulti18n'
 ---
 SilverStripe\i18n\i18n:
   module_priority:


### PR DESCRIPTION
silverstripe/config uses pathname to figure out before and after rules, so `framework/routes` needs to be `framework/_config/routes`.

Please see https://github.com/silverstripe/silverstripe-framework/issues/7749 for more details