### PR TITLE
Update validation in Developer guides

### DIFF
--- a/docs/en/02_Developer_Guides/00_Model/09_Validation.md
+++ b/docs/en/02_Developer_Guides/00_Model/09_Validation.md
@@ -37,7 +37,7 @@ class MyObject extends DataObject
         $result = parent::validate();
 
         if($this->Country == 'DE' && $this->Postcode && strlen($this->Postcode) != 5) {
-            $result->error('Need five digits for German postcodes');
+            $result->addError('Need five digits for German postcodes');
         }
 
         return $result;


### PR DESCRIPTION
I believe that ValidationResult's error method is called, `addError` - and not `error` as stated in the docs.

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/