### PR TITLE
DOCS: remove backticks from Markdown link

### DIFF
--- a/docs/en/02_Developer_Guides/05_Extending/04_Shortcodes.md
+++ b/docs/en/02_Developer_Guides/05_Extending/04_Shortcodes.md
@@ -115,7 +115,7 @@ Links to internal `File` database records work exactly the same, but with the `[
 ### Images
 
 Images inserted through the "Insert Media" form (WYSIWYG editor) need to retain a relationship with
-the underlying `[Image](api:SilverStripe\Assets\Image)` database record. The `[image]` shortcode saves this database reference
+the underlying [Image](api:SilverStripe\Assets\Image) database record. The `[image]` shortcode saves this database reference
 instead of hard-linking to the filesystem path of a given image.
 
 ```html


### PR DESCRIPTION
Markdown does not render links within backticks.
