### PR TITLE
php-shell-cmd script from pear/php_shell package

### DIFF
--- a/dev/SapphireREPL.php
+++ b/dev/SapphireREPL.php
@@ -43,7 +43,7 @@ class SapphireREPL extends Controller {
 
 
 		/* Try using PHP_Shell if it exists */
-		@include 'php-shell-cmd.php' ;
+		@include 'scripts/php-shell-cmd.php' ;
 
 		/* Fall back to our simpler interface */
 		if( empty( $__shell ) ) {


### PR DESCRIPTION
[FIX] With this change we are allowed to use php-shell-cmd file from pear/php_shell package as that script now is located on scripts folder inside package.