### PR TITLE
Improve Environment::getVariables() array copy

### DIFF
--- a/src/Core/Environment.php
+++ b/src/Core/Environment.php
@@ -44,6 +44,7 @@ class Environment
     {
         // Suppress return by-ref
         $vars = [ 'env' => static::$env ];
+        // needs to use a for loop, using `array_merge([], $GLOBALS);` left reference traces somehow
         foreach ($GLOBALS as $varName => $varValue) {
             $vars[$varName] = $varValue;
         }

--- a/src/Core/Environment.php
+++ b/src/Core/Environment.php
@@ -43,7 +43,12 @@ class Environment
     public static function getVariables()
     {
         // Suppress return by-ref
-        return array_merge($GLOBALS, [ 'env' => static::$env ]);
+        $vars = [ 'env' => static::$env ];
+        foreach ($GLOBALS as $varName => $varValue) {
+            $vars[$varName] = $varValue;
+        }
+
+        return $vars;
     }
 
     /**

--- a/tests/php/Core/EnvironmentTest.php
+++ b/tests/php/Core/EnvironmentTest.php
@@ -53,4 +53,17 @@ class EnvironmentTest extends SapphireTest
         Environment::setVariables($vars);
         $this->assertEquals('initial', Environment::getEnv('_ENVTEST_RESTORED'));
     }
+
+    public function testGetVariables()
+    {
+        $GLOBALS['test'] = 'global';
+        $vars = Environment::getVariables();
+        $this->assertArrayHasKey('test', $vars);
+        $this->assertEquals('global', $vars['test']);
+        $this->assertEquals('global', $GLOBALS['test']);
+
+        $vars['test'] = 'fail';
+        $this->assertEquals('fail', $vars['test']);
+        $this->assertEquals('global', $GLOBALS['test']);
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/silverstripe/silverstripe-cms/issues/2078

This is a bit of a dirty fix, but it was the only thing that seemed to work. There is some kind of return-by-reference issue happening in this function that is difficult to pin down. For documentation, this is the test that was failing. It resulted in a session being broken by `Director::test()` meaning subsequent requests to the CMS did not pass authentication.

Environment.php (line 205)

```php
        // Setup session
        if ($session instanceof Session) {
                    // ........
        } else {
           var_dump($_SESSION) // populated
            $newVars['_SESSION'] = $session ?: [];
            var_dump($_SESSION); // empty

        }
```