### PR TITLE
Remove deprecated @package and @subpackage

### DIFF
--- a/docs/en/05_Contributing/14_PHP_Coding_Conventions.md
+++ b/docs/en/05_Contributing/14_PHP_Coding_Conventions.md
@@ -90,7 +90,6 @@ public function getTitle()
 Use [phpdoc](http://phpdoc.org/) syntax before each definition (see [tutorial](http://manual.phpdoc.org/HTMLSmartyConverter/HandS/phpDocumentor/tutorial_phpDocumentor.quickstart.pkg.html)
 and [tag overview](http://manual.phpdoc.org/HTMLSmartyConverter/HandS/phpDocumentor/tutorial_tags.pkg.html)).
 
- * All class definitions and PHP files should have `@package` and `@subpackage`.
  * Methods should include at least `@param` and `@return`.
  * Include a blank line after the description.
  * Use `{@link MyOtherClass}` and `{@link MyOtherClass->otherMethod}` for inline references.


### PR DESCRIPTION
On Slack #General at 11:17 nightjarnz maintains that @package is deprecated.

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/