### PR TITLE
Fixing HTMLEditorField API documentation

### DIFF
--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * A TinyMCE-powered WYSIWYG HTML editor field with image and link insertion and tracking capabilities. Editor fields
- * are created from <textarea> tags, which are then converted with JavaScript.
+ * are created from &lt;textarea&gt; tags, which are then converted with JavaScript.
  *
  * @package forms
  * @subpackage fields-formattedinput


### PR DESCRIPTION
The API documentation for HTMLEditorField is currently broken:
http://api.silverstripe.org/3/HtmlEditorField.html

This is because there is an unescaped start textarea tag in the class description. 

This fix changes the tag in the description to be escaped.