### PR TITLE
Fix regression in ContextSummary

### DIFF
--- a/src/ORM/FieldType/DBText.php
+++ b/src/ORM/FieldType/DBText.php
@@ -198,7 +198,7 @@ class DBText extends DBString
         $keywords = Convert::raw2xml($keywords);
 
         // Find the search string
-        $position = (int) mb_stripos($text, $keywords);
+        $position = empty($keywords) ? 0 : (int) mb_stripos($text, $keywords);
 
         // We want to search string to be in the middle of our block to give it some context
         $position = max(0, $position - ($characters / 2));

--- a/tests/php/ORM/DBTextTest.php
+++ b/tests/php/ORM/DBTextTest.php
@@ -263,6 +263,13 @@ class DBTextTest extends SapphireTest
                 'schön',
                 // check UTF8 support
                 'both <mark>schön</mark> and können...',
+            ],
+            [
+                'both schön and können have umlauts',
+                21,
+                '',
+                // check non existant search term
+                'both schön and können...',
             ]
 
 


### PR DESCRIPTION
Fix "mb_stripos(): Empty delimiter" warning when no search-keywords are given for `DBText::ContextSummary`.
Introduced via https://github.com/silverstripe/silverstripe-framework/pull/7557
Add unit-test to cover that case.
