### PR TITLE
Upgrade swiftmailer

### DIFF
--- a/_config/email.yml
+++ b/_config/email.yml
@@ -2,7 +2,7 @@
 Name: emailconfig
 ---
 SilverStripe\Core\Injector\Injector:
-  Swift_Transport: Swift_MailTransport
+  Swift_Transport: Swift_SendmailTransport
   Swift_Mailer:
     constructor:
       - '%$Swift_Transport'

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "paragonie/random_compat": "^2.0",
         "silverstripe/config": "^2@dev",
         "silverstripe/assets": "^2@dev",
-        "swiftmailer/swiftmailer": "~5.4",
+        "swiftmailer/swiftmailer": "^6",
         "symfony/cache": "^3.3@dev",
         "symfony/config": "^3.2",
         "symfony/translation": "^2.8",

--- a/src/Control/Email/Email.php
+++ b/src/Control/Email/Email.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\Control\Email;
 
+use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\RFCValidation;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTP;
 use SilverStripe\Core\Convert;
@@ -98,7 +100,11 @@ class Email extends ViewableData
      */
     public static function is_valid_address($address)
     {
-        return \Swift_Validate::email($address);
+        static $validator;
+        if (!$validator) {
+            $validator = new EmailValidator();
+        }
+        return $validator->isValid($address, new RFCValidation());
     }
 
     /**

--- a/src/Control/Email/Email.php
+++ b/src/Control/Email/Email.php
@@ -273,7 +273,7 @@ class Email extends ViewableData
      */
     public function setSwiftMessage($swiftMessage)
     {
-        $swiftMessage->setDate(DBDatetime::now()->getTimestamp());
+        $swiftMessage->setDate((new \DateTime())->setTimestamp(DBDatetime::now()->getTimestamp()));
         if (!$swiftMessage->getFrom() && ($defaultFrom = $this->config()->get('admin_email'))) {
             $swiftMessage->setFrom($defaultFrom);
         }

--- a/tests/php/Control/Email/EmailTest.php
+++ b/tests/php/Control/Email/EmailTest.php
@@ -255,7 +255,7 @@ class EmailTest extends SapphireTest
         $email->setSwiftMessage($swiftMessage);
         $this->assertCount(1, $email->getFrom());
         $this->assertContains('admin@example.com', array_keys($swiftMessage->getFrom()));
-        $this->assertEquals(strtotime('2017-01-01 07:00:00'), $swiftMessage->getDate());
+        $this->assertEquals(strtotime('2017-01-01 07:00:00'), $swiftMessage->getDate()->getTimestamp());
         $this->assertEquals($swiftMessage, $email->getSwiftMessage());
 
         // check from field is retained

--- a/tests/php/Control/Email/SwiftMailerTest.php
+++ b/tests/php/Control/Email/SwiftMailerTest.php
@@ -6,10 +6,10 @@ use SilverStripe\Control\Email\Email;
 use SilverStripe\Control\Email\SwiftMailer;
 use SilverStripe\Dev\SapphireTest;
 use Swift_Mailer;
-use Swift_MailTransport;
 use Swift_Message;
 use Swift_NullTransport;
 use Swift_Plugins_AntiFloodPlugin;
+use Swift_SendmailTransport;
 
 class SwiftMailerTest extends SapphireTest
 {
@@ -23,8 +23,8 @@ class SwiftMailerTest extends SapphireTest
         SwiftMailer::config()->remove('swift_plugins');
         SwiftMailer::config()->update('swift_plugins', array(Swift_Plugins_AntiFloodPlugin::class));
 
-        /** @var Swift_MailTransport $transport */
-        $transport = $this->getMockBuilder(Swift_MailTransport::class)->getMock();
+        /** @var Swift_SendmailTransport $transport */
+        $transport = $this->getMockBuilder(Swift_SendmailTransport::class)->getMock();
         $transport
             ->expects($this->once())
             ->method('registerPlugin')


### PR DESCRIPTION
Swiftmailer v6 has been in the works a while and the main reason we didn't use it in 4.x is because it's php 7+ only.

Now SS 5 will be 7+ only too, we can use it :)

This will also lay the groundwork for us to be able to accept non-ASCII email addresses, which I believe is a somewhat legal requirement for NZ websites(?)