### PR TITLE
TestCase classes should be abstract to prevent warnings

### DIFF
--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -30,7 +30,7 @@ use SimpleXMLElement;
  *  }
  * </code>
  */
-class FunctionalTest extends SapphireTest implements TestOnly
+abstract class FunctionalTest extends SapphireTest implements TestOnly
 {
     /**
      * Set this to true on your sub-class to disable the use of themes in this test.

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -50,7 +50,7 @@ if (!class_exists(TestCase::class)) {
  * This class should not be used anywhere outside of unit tests, as phpunit may not be installed
  * in production sites.
  */
-class SapphireTest extends TestCase implements TestOnly
+abstract class SapphireTest extends TestCase implements TestOnly
 {
     /**
      * Path to fixture data for this test run.
@@ -227,12 +227,6 @@ class SapphireTest extends TestCase implements TestOnly
 
         // Call state helpers
         static::$state->setUp($this);
-
-        // We cannot run the tests on this abstract class.
-        if (static::class == __CLASS__) {
-            $this->markTestSkipped(sprintf('Skipping %s ', static::class));
-            return;
-        }
 
         // i18n needs to be set to the defaults or tests fail
         i18n::set_locale(i18n::config()->uninherited('default_locale'));


### PR DESCRIPTION
To prevent our base TestCase classes (`SapphireTest` and `FunctionalTest` causing warnings in the test suite, they should be `abstract`.

This PR fixes that,