### PR TITLE
Ensure errors are reported to users from cli-scripts

### DIFF
--- a/cli-script.php
+++ b/cli-script.php
@@ -18,6 +18,13 @@ if(isset($_SERVER['HTTP_HOST'])) {
 	die();
 }
 
+
+/**
+ * Ensure errors are reported to users via CLI, as this script can only be run via CLI risk of surfacing
+ * errors to end users is minimised.
+ */
+ini_set("display_errors", 1);
+
 /**
  * Identify the cli-script.php file and change to its container directory, so that require_once() works
  */


### PR DESCRIPTION
Surfaces errors from the cli-scripts to the terminal, has the bonus side effect of outputting errors to deployment logs on the SilverStripe Platforms.

With change:
```
# sudo -u www-data framework/sake dev

Parse error: syntax error, unexpected 'global' (T_GLOBAL) in /sites/mediumtest-uat/releases/20180131205002/mysite/_config.php on line 3
```

Without change this fails silently (of course the error is logged).

If we are happy with this approach I can make a similar PR for 4.