### PR TITLE
BUG Files dataobjects with missing asset shouldn't un-attach themselves on save

### DIFF
--- a/src/Forms/FileUploadReceiver.php
+++ b/src/Forms/FileUploadReceiver.php
@@ -182,8 +182,9 @@ trait FileUploadReceiver
         // Filter items by what's allowed to be viewed
         $filteredItems = new ArrayList();
         $fileIDs = array();
+        /** @var File $file */
         foreach ($items as $file) {
-            if ($file->exists() && $file->canView()) {
+            if ($file->isInDB() && $file->canView()) {
                 $filteredItems->push($file);
                 $fileIDs[] = $file->ID;
             }


### PR DESCRIPTION
At the moment if a parent dataobject has one or more images attached to an upload field, and the asset backing the image becomes deleted, the next save to the parent object will detatch the file dataobject incorrectly.

E.g.

![image](https://user-images.githubusercontent.com/936064/37061761-52a00878-21f9-11e8-911e-ac76425dde29.png)

This fixes the issue by using an ->isInDB() check instead of a (more expensive) ->exists() check.