### PR TITLE
Bug Fix - Change Password Page

### DIFF
--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -112,21 +112,19 @@ class ChangePasswordHandler extends RequestHandler
         }
         // Show a friendly message saying the login token has expired
         if ($token !== null && $member && !$member->validateAutoLoginToken($token)) {
-            $message = [
-                'Content' => DBField::create_field(
-                    'HTMLFragment',
-                    _t(
-                        'SilverStripe\\Security\\Security.NOTERESETLINKINVALID',
-                        '<p>The password reset link is invalid or expired.</p>'
-                        . '<p>You can request a new one <a href="{link1}">here</a> or change your password after'
-                        . ' you <a href="{link2}">logged in</a>.</p>',
-                        [
-                            'link1' => $this->link('lostpassword'),
-                            'link2' => $this->link('login')
-                        ]
-                    )
+            $message = DBField::create_field(
+                'HTMLFragment',
+                _t(
+                    'SilverStripe\\Security\\Security.NOTERESETLINKINVALID',
+                    '<p>The password reset link is invalid or expired.</p>'
+                    . '<p>You can request a new one <a href="{link1}">here</a> or change your password after'
+                    . ' you <a href="{link2}">logged in</a>.</p>',
+                    [
+                        'link1' => $this->link('lostpassword'),
+                        'link2' => $this->link('login')
+                    ]
                 )
-            ];
+            );
 
             return [
                 'Content' => $message,


### PR DESCRIPTION
Bugfix - Correct duplicate nesting of 'Content' to be returned to template

In scenarios where:

- No member is logged in
- An 'AutoLoginHash' is provided via the 't' (token) query param
- The token isn't valid (determined by Member::validateAutoLoginToken())

The message which is intended to be returned to the end-user via $Content
in the template, is mistakenly double nested in ['Content' => ['Content' => 'Message']]
this leads to "The method forTemplate() doesn't exist on ArrayData" errors.

See - [silverstripe#7866](https://github.com/silverstripe/silverstripe-framework/issues/7866)