### PR TITLE
Add missing use statement in Session documentation

### DIFF
--- a/docs/en/02_Developer_Guides/18_Cookies_And_Sessions/02_Sessions.md
+++ b/docs/en/02_Developer_Guides/18_Cookies_And_Sessions/02_Sessions.md
@@ -30,6 +30,7 @@ Otherwise, if you're not in a controller, get the request as a service.
 
 ```php
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Injector\Injector;
 
 $request = Injector::inst()->get(HTTPRequest::class);
 $session = $request->getSession();


### PR DESCRIPTION
Add additional 'use' statement (for Injector) in example of getting a session outside a controller.

