### PR TITLE
FIX Ensure consistent return type for FieldList::removeByName

### DIFF
--- a/src/Forms/FieldList.php
+++ b/src/Forms/FieldList.php
@@ -351,7 +351,7 @@ class FieldList extends ArrayList
             foreach ($fieldName as $field) {
                 $this->removeByName($field, $dataFieldOnly);
             }
-            return;
+            return $this;
         }
 
         $this->flushFieldsCache();


### PR DESCRIPTION
This method was made chainable in https://github.com/silverstripe/silverstripe-framework/commit/91f1a58018b208b3677550dc4d22ac5d83f5124a but we missed a spot :)

Resolves https://github.com/silverstripe/silverstripe-framework/issues/7929