### PR TITLE
Fixing FormAction API documentation SS4

### DIFF
--- a/src/Forms/FormAction.php
+++ b/src/Forms/FormAction.php
@@ -5,7 +5,7 @@ namespace SilverStripe\Forms;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 
 /**
- * The action buttons are <input type="submit"> as well as <button> tags.
+ * The action buttons are `<input type="submit">` as well as `<button>` tags.
  *
  * Upon clicking the button below will redirect the user to doAction under the current controller.
  *
@@ -49,7 +49,7 @@ class FormAction extends FormField
     protected $schemaComponent = 'FormAction';
 
     /**
-     * Enables the use of <button> instead of <input>
+     * Enables the use of `<button>` instead of `<input>`
      * in {@link Field()} - for more customisable styling.
      *
      * @var boolean
@@ -218,7 +218,7 @@ class FormAction extends FormField
     }
 
     /**
-     * Enable or disable the rendering of this action as a <button />
+     * Enable or disable the rendering of this action as a `<button />`
      *
      * @param boolean
      * @return $this
@@ -230,7 +230,7 @@ class FormAction extends FormField
     }
 
     /**
-     * Determine if this action is rendered as a <button />
+     * Determine if this action is rendered as a `<button />`
      *
      * @return boolean
      */


### PR DESCRIPTION
The API documentation for FormAction is currently broken:
https://api.silverstripe.org/4/SilverStripe/Forms/FormAction.html

This is because there are unescaped tags in the class description.

This fix wraps the tags in backticks.

This is the ss4 version of the #7927 pull request.