### PR TITLE
Fixing HTMLEditorField API documentation

### DIFF
--- a/forms/HtmlEditorField.php
+++ b/forms/HtmlEditorField.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * A TinyMCE-powered WYSIWYG HTML editor field with image and link insertion and tracking capabilities. Editor fields
- * are created from &lt;textarea&gt; tags, which are then converted with JavaScript.
+ * are created from `<textarea>` tags, which are then converted with JavaScript.
  *
  * @package forms
  * @subpackage fields-formattedinput


### PR DESCRIPTION
The SS3 API documentation for HTMLEditorField was broken before change #7904:
http://api.silverstripe.org/3/HtmlEditorField.html

This was because there was an unescaped textarea tag in the class description. In #7904 we escaped the tag. 

However in a similar pull request #7927 it was suggested we should use backticks instead. 

This changes the documentation to use backticks around the textarea tag.