### PR TITLE
Update 4.1.0.md

### DIFF
--- a/docs/en/04_Changelogs/4.1.0.md
+++ b/docs/en/04_Changelogs/4.1.0.md
@@ -7,7 +7,7 @@
 
 ## Upgrading
 
-### Upgrade `public/` folder
+### Upgrade `public/` folder (optional)
 
 This release allows the maintenance of a public webroot folder which separates all
 web-accessible files from protected project files (like the vendor folder
@@ -18,7 +18,7 @@ projects (updating from 3.x or 4.0) will continue working as-is, but we
 strongly recommend switching to the public webroot structure in order to
 get the security benefits.
 
-This folder name is not configurable, but is turned on by creating this folder, and off by ensuring
+> This folder name is not configurable, but is turned on by creating this folder, and off by ensuring
 this folder doesn't exist.
 
 When separating the public webroot from the BASE_PATH it is necessary to move a few files during migration:


### PR DESCRIPTION
Just to make it more clear that the public folder is optional, vhosts are a pain to configure for users with cPanel/WHM and some may not even have SSH access to configure vhosts so to prevent concern and hesitation this PR makes it more clear that the public folder is not a mandatory feature.