### PR TITLE
Missing a semicolon in the caching docs

### DIFF
--- a/docs/en/02_Developer_Guides/08_Performance/01_Caching.md
+++ b/docs/en/02_Developer_Guides/08_Performance/01_Caching.md
@@ -45,7 +45,7 @@ This factory allows us you to globally define an adapter for all cache instances
 
 
 ```php
-use Psr\SimpleCache\CacheInterface
+use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Injector\Injector;
 
 $cache = Injector::inst()->get(CacheInterface::class . '.myCache');


### PR DESCRIPTION
Missing a semicolon in the caching docs