### PR TITLE
DOCS: fixed links in Images doc

### DIFF
--- a/docs/en/02_Developer_Guides/14_Files/02_Images.md
+++ b/docs/en/02_Developer_Guides/14_Files/02_Images.md
@@ -2,22 +2,22 @@ summary: Learn how to crop and resize images in templates and PHP code
 
 # Image
 
-Image files can be stored either through the [Image](api:SilverStripe\Assets\Image) dataobject, or though [DBFile](api:SilverStripe\Assets\Storage\DBFile) fields.
+Image files can be stored either through the [`Image`](api:SilverStripe\Assets\Image) dataobject, or though [`DBFile`](api:SilverStripe\Assets\Storage\DBFile) fields.
 In either case, the same image resizing and manipulation functionality is available though the common
-[ImageManipulation](api:SilverStripe\Assets\ImageManipulation) trait.
+[`ImageManipulation`](api:SilverStripe\Assets\ImageManipulation) trait.
 
 ## Usage
 
 ### Managing images through form fields
 
-Images can be uploaded like any other file, through [FileField](api:SilverStripe\Forms\FileField).
+Images can be uploaded like any other file, through [`FileField`](api:SilverStripe\Forms\FileField).
 Allows upload of images through limiting file extensions with `setAllowedExtensions()`.
 
 ### Inserting images into the WYSIWYG editor
 
-Images can be inserted into [HTMLValue](api:SilverStripe\View\Parsers\HTMLValue) database fields
+Images can be inserted into [`HTMLValue`](api:SilverStripe\View\Parsers\HTMLValue) database fields
 through the built-in WYSIWYG editor. In order to retain a relationship
-to the underlying [Image](api:SilverStripe\Assets\Image) records, images are saved as [shortcodes](/developer-guides/extending/shortcodes).
+to the underlying [`Image`](api:SilverStripe\Assets\Image) records, images are saved as [shortcodes](/developer-guides/extending/shortcodes).
 The shortcode (`[image id="<id>" alt="My text" ...]`) will be converted
 into an `<img>` tag on your website automatically.
 
@@ -96,7 +96,7 @@ The image manipulation functions can be used in your code with the same names, e
 
 Some of the MetaData functions need to be prefixed with 'get', example `getHeight()`, `getOrientation()` etc.
 
-Please refer to the [ImageManipulation](api:SilverStripe\Assets\ImageManipulation) API documentation for specific functions.
+Please refer to the [`ImageManipulation`](api:SilverStripe\Assets\ImageManipulation) API documentation for specific functions.
 
 ### Creating custom image functions
 
@@ -145,7 +145,7 @@ SilverStripe\Filesystem\Storage\DBFile:
 
 ### Form Upload
 
-For usage on a website form, see [FileField](api:SilverStripe\Assets\FileField).
+For usage on a website form, see [`FileField`](api:SilverStripe\Assets\FileField).
 
 ### Image Quality
 
@@ -188,7 +188,7 @@ SilverStripe\Assets\Storage\DBFile:
 #### Resampled image quality
 
 To adjust the quality of the generated images when they are resampled, add the
-following to your mysite/config/config.yml file:
+following to your `mysite/config/config.yml` file:
 
 
 ```yml

--- a/docs/en/02_Developer_Guides/14_Files/02_Images.md
+++ b/docs/en/02_Developer_Guides/14_Files/02_Images.md
@@ -2,7 +2,7 @@ summary: Learn how to crop and resize images in templates and PHP code
 
 # Image
 
-Image files can be stored either through the `[Image](api:SilverStripe\Assets\Image)` dataobject, or though [DBFile](api:SilverStripe\Assets\Storage\DBFile) fields.
+Image files can be stored either through the [Image](api:SilverStripe\Assets\Image) dataobject, or though [DBFile](api:SilverStripe\Assets\Storage\DBFile) fields.
 In either case, the same image resizing and manipulation functionality is available though the common
 [ImageManipulation](api:SilverStripe\Assets\ImageManipulation) trait.
 
@@ -15,9 +15,9 @@ Allows upload of images through limiting file extensions with `setAllowedExtensi
 
 ### Inserting images into the WYSIWYG editor
 
-Images can be inserted into `[HTMLValue](api:SilverStripe\View\Parsers\HTMLValue)` database fields
+Images can be inserted into [HTMLValue](api:SilverStripe\View\Parsers\HTMLValue) database fields
 through the built-in WYSIWYG editor. In order to retain a relationship
-to the underlying `[Image](api:SilverStripe\Assets\Image)` records, images are saved as [shortcodes](/developer-guides/extending/shortcodes).
+to the underlying [Image](api:SilverStripe\Assets\Image) records, images are saved as [shortcodes](/developer-guides/extending/shortcodes).
 The shortcode (`[image id="<id>" alt="My text" ...]`) will be converted
 into an `<img>` tag on your website automatically.
 


### PR DESCRIPTION
Fixed a few links in the Images document that were wrapped in code markdown. They function as actual links now. :)