### PR TITLE
DOCS rerun composer on undefined MODULE_FILTER (#7948)

### DIFF
--- a/docs/en/04_Changelogs/4.1.0.md
+++ b/docs/en/04_Changelogs/4.1.0.md
@@ -7,6 +7,9 @@
 
 ## Upgrading
 
+Note: if you receive an error message about an undefined constant while
+upgrading with `composer`, re-running the command should solve the issue.
+
 ### Upgrade `public/` folder
 
 This release allows the maintenance of a public webroot folder which separates all


### PR DESCRIPTION
Just a mention that you need to rerun composer when upgrading to 4.1.0. Not sure it is still relevant after @tractorcow silverstripe/vendor-plugin#18 ... feel free to reject.