### PR TITLE
DOCS: fix parsed base_tag code in alert note

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/02_Common_Variables.md
+++ b/docs/en/02_Developer_Guides/01_Templates/02_Common_Variables.md
@@ -45,7 +45,7 @@ to locate your site’s images and css files.
 It renders in the template as `<base href="http://www.yoursite.com" /><!--[if lte IE 6]></base><![endif]-->`
 
 <div class="alert" markdown="1">
-A `<% base_tag %>` is nearly always required or assumed by SilverStripe to exist.
+A `&lt;% base_tag %&gt;` is nearly always required or assumed by SilverStripe to exist.
 </div>
 
 ## CurrentMember


### PR DESCRIPTION
It's a bit hard to fix the *alert* blocks, as the preview doesn't display them at all. Using HTML entities should do the trick though. 