### PR TITLE
Fix for "too few parameters" error when using DBMultiEnum

### DIFF
--- a/src/ORM/FieldType/DBMultiEnum.php
+++ b/src/ORM/FieldType/DBMultiEnum.php
@@ -11,7 +11,7 @@ use SilverStripe\Forms\CheckboxSetField;
  */
 class DBMultiEnum extends DBEnum
 {
-    public function __construct($name, $enum = null, $default = null)
+    public function __construct($name = null, $enum = null, $default = null)
     {
         // MultiEnum needs to take care of its own defaults
         parent::__construct($name, $enum, null);


### PR DESCRIPTION
When adding a DBMultiEnum and doing a dev/build the following error message is displayed: 

"Too few arguments to function SilverStripe\ORM\FieldType\DBMultiEnum::__construct(), 0 passed and at least 1 expected". The field in by $db array looks like this: "Status" => "MultiEnum('Option1, Option2, Option3', 'Option2')""

This is a fix for that bug.