### PR TITLE
Reorder HTML to be semantically correct on render

### DIFF
--- a/templates/SilverStripe/Forms/SelectionGroup.ss
+++ b/templates/SilverStripe/Forms/SelectionGroup.ss
@@ -6,9 +6,9 @@
 			$RadioLabel
 			$FieldHolder
 		</li>
-	</ul>
 	<% end_if %>
 	<% end_loop %>
+	</ul>
 <% else %>
 	<ul class="SelectionGroup<% if extraClass %> $extraClass<% end_if %>">
 	<% loop $FieldSet %>


### PR DESCRIPTION
Don't close the unordered list every iteration :)

Resolves #7964 