### PR TITLE
API: Use symfony/http-foundation for sessions

### DIFF
--- a/_config/session.yml
+++ b/_config/session.yml
@@ -1,0 +1,13 @@
+---
+Name: coresession
+---
+SilverStripe\Core\Injector\Injector:
+  Symfony\Component\HttpFoundation\Session\SessionInterface:
+    class: Symfony\Component\HttpFoundation\Session\Session
+    constructor:
+      storage: '%$SymfonyNativeSessionStorage'
+  SymfonyNativeSessionStorage:
+    class: Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage
+    constructor:
+      config:
+        cookie_path: '`SS_SESSION_COOKIE_PATH`'

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "swiftmailer/swiftmailer": "^6",
         "symfony/cache": "^3.3@dev",
         "symfony/config": "^3.2",
+        "symfony/http-foundation": "^3.4",
         "symfony/translation": "^2.8",
         "symfony/yaml": "~3.2",
         "php": ">=7.1.0",

--- a/docs/en/04_Changelogs/5.0.0.md
+++ b/docs/en/04_Changelogs/5.0.0.md
@@ -54,4 +54,10 @@ guide developers in preparing existing 4.x code for compatibility with 5.0.
 * `Query::seek()` removed. To re-set the position, re-execute `Query::getIterator()` instead.
 * `Query::next()` and other Iterator methods removed. Call `Query::getIterator()` to get an iterator instead.
 
+### Sessions
+
+* Sessions are now backed by `symfony/http-foundation`
+* All config values have been removed from `Session`, see [the sessions guide](/developer-guides/cookies-and-sessions/sessions) for more information on configuring sessions
+* `Session::addToArray()` removed
+
 <!--- Changes below this line will be automatically regenerated -->

--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -3,8 +3,9 @@
 namespace SilverStripe\Control;
 
 use BadMethodCallException;
-use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\Deprecation;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
  * Handles all manipulation of the session.
@@ -90,96 +91,16 @@ use SilverStripe\Dev\Deprecation;
  */
 class Session
 {
-    use Configurable;
-
     /**
-     * Set session timeout in seconds.
-     *
-     * @var int
-     * @config
-     */
-    private static $timeout = 0;
-
-    /**
-     * @config
+     * Original session data before modification
      * @var array
      */
-    private static $session_ips = array();
+    protected $original;
 
     /**
-     * @config
-     * @var string
+     * @var SessionInterface
      */
-    private static $cookie_domain;
-
-    /**
-     * @config
-     * @var string
-     */
-    private static $cookie_path;
-
-    /**
-     * @config
-     * @var string
-     */
-    private static $session_store_path;
-
-    /**
-     * @config
-     * @var boolean
-     */
-    private static $cookie_secure = false;
-
-    /**
-     * @config
-     * @var string
-     */
-    private static $cookie_name_secure = 'SECSESSID';
-
-    /**
-     * Name of session cache limiter to use.
-     * Defaults to '' to disable cache limiter entirely.
-     *
-     * @see https://secure.php.net/manual/en/function.session-cache-limiter.php
-     * @var string|null
-     */
-    private static $sessionCacheLimiter = '';
-
-    /**
-     * Session data.
-     * Will be null if session has not been started
-     *
-     * @var array|null
-     */
-    protected $data = null;
-
-    /**
-     * @var bool
-     */
-    protected $started = false;
-
-    /**
-     * List of keys changed. This is a nested array which represents the
-     * keys modified in $this->data. The value of each item is either "true"
-     * or a nested array.
-     *
-     * If a value is in changedData but not in data, it must be removed
-     * from the destination during save().
-     *
-     * Only highest level changes are stored. E.g. changes to `Base.Sub`
-     * and then `Base` only records `Base` as the change.
-     *
-     * E.g.
-     * [
-     *   'Base' => true,
-     *   'Key' => [
-     *      'Nested' => true,
-     *   ],
-     * ]
-     *
-     * @var array
-     */
-    protected $changedData = array();
+    protected $handler;
 
     /**
      * Get user agent for this request
@@ -198,14 +119,30 @@ class Session
      * @param array|null|Session $data Can be an array of data (such as $_SESSION) or another Session object to clone.
      * If null, this session is treated as unstarted.
      */
-    public function __construct($data)
+    public function __construct($data = [])
     {
         if ($data instanceof Session) {
             $data = $data->getAll();
         }
 
-        $this->data = $data;
-        $this->started = isset($data);
+        $this->original = $data ?: [];
+    }
+
+    /**
+     * @return SessionInterface
+     */
+    protected function getHandler()
+    {
+        if (!$this->handler) {
+            $this->handler = Injector::inst()->get(SessionInterface::class);
+
+            // If source session data was provided, set it now
+            if ($this->original) {
+                $this->handler->replace($this->original);
+            }
+        }
+
+        return $this->handler;
     }
 
     /**
@@ -218,18 +155,15 @@ class Session
      */
     public function init(HTTPRequest $request)
     {
-
-        if (!$this->isStarted() && $this->requestContainsSessionId($request)) {
-            $this->start($request);
+        $handler = $this->getHandler();
+        if (!$this->isStarted()) {
+            $this->start();
         }
 
         // Funny business detected!
-        if (isset($this->data['HTTP_USER_AGENT'])) {
-            if ($this->data['HTTP_USER_AGENT'] !== $this->userAgent($request)) {
-                $this->clearAll();
+        if ($handler->has('HTTP_USER_AGENT')) {
+            if ($handler->get('HTTP_USER_AGENT') !== $this->userAgent($request)) {
                 $this->destroy();
-                $this->started = false;
-                $this->start($request);
             }
         }
     }
@@ -252,184 +186,69 @@ class Session
      */
     public function isStarted()
     {
-        return $this->started;
+        return $this->getHandler()->isStarted();
     }
 
     /**
-     * @param HTTPRequest $request
-     * @return bool
+     * Begin session
+     * @return $this
      */
-    public function requestContainsSessionId(HTTPRequest $request)
-    {
-        $secure = Director::is_https($request) && $this->config()->get('cookie_secure');
-        $name = $secure ? $this->config()->get('cookie_name_secure') : session_name();
-        return (bool)Cookie::get($name);
-    }
-
-    /**
-     * Begin session, regardless if a session identifier is present in the request,
-     * or whether any session data needs to be written.
-     * See {@link init()} if you want to "lazy start" a session.
-     *
-     * @param HTTPRequest $request The request for which to start a session
-     */
-    public function start(HTTPRequest $request)
+    public function start()
     {
         if ($this->isStarted()) {
             throw new BadMethodCallException("Session has already started");
         }
 
-        $path = $this->config()->get('cookie_path');
-        if (!$path) {
-            $path = Director::baseURL();
-        }
-        $domain = $this->config()->get('cookie_domain');
-        $secure = Director::is_https($request) && $this->config()->get('cookie_secure');
-        $session_path = $this->config()->get('session_store_path');
-        $timeout = $this->config()->get('timeout');
-
-        // Director::baseURL can return absolute domain names - this extracts the relevant parts
-        // for the session otherwise we can get broken session cookies
-        if (Director::is_absolute_url($path)) {
-            $urlParts = parse_url($path);
-            $path = $urlParts['path'];
-            if (!$domain) {
-                $domain = $urlParts['host'];
-            }
-        }
-
-        // If the session cookie is already set, then the session can be read even if headers_sent() = true
-        // This helps with edge-case such as debugging.
-        $data = [];
-        if (!session_id() && (!headers_sent() || $this->requestContainsSessionId($request))) {
-            if (!headers_sent()) {
-                session_set_cookie_params($timeout ?: 0, $path, $domain ?: null, $secure, true);
-
-                $limiter = $this->config()->get('sessionCacheLimiter');
-                if (isset($limiter)) {
-                    session_cache_limiter($limiter);
-                }
-
-                // Allow storing the session in a non standard location
-                if ($session_path) {
-                    session_save_path($session_path);
-                }
-
-                // If we want a secure cookie for HTTPS, use a separate session name. This lets us have a
-                // separate (less secure) session for non-HTTPS requests
-                // if headers_sent() is true then it's best to throw the resulting error rather than risk
-                // a security hole.
-                if ($secure) {
-                    session_name($this->config()->get('cookie_name_secure'));
-                }
-
-                session_start();
-            } else {
-                // If headers are sent then we can't have a session_cache_limiter otherwise we'll get a warning
-                session_cache_limiter(null);
-            }
-
-            if (isset($_SESSION)) {
-                // Initialise data from session store if present
-                $data = $_SESSION;
-
-                // Merge in existing in-memory data, taking priority over session store data
-                $this->recursivelyApply((array)$this->data, $data);
-            }
-        }
-
-        // Save any modified session data back to the session store if present, otherwise initialise it to an array.
-        $this->data = $data;
-
-        $this->started = true;
+        $this->getHandler()->start();
+        $this->original = $this->getHandler()->all();
+        return $this;
     }
 
     /**
      * Destroy this session
-     *
-     * @param bool $removeCookie
+     * @return $this
      */
-    public function destroy($removeCookie = true)
+    public function destroy()
     {
-        if (session_id()) {
-            if ($removeCookie) {
-                $path = $this->config()->get('cookie_path') ?: Director::baseURL();
-                $domain = $this->config()->get('cookie_domain');
-                $secure = $this->config()->get('cookie_secure');
-                Cookie::force_expiry(session_name(), $path, $domain, $secure, true);
-            }
-            session_destroy();
-        }
-        // Clean up the superglobal - session_destroy does not do it.
-        // http://nz1.php.net/manual/en/function.session-destroy.php
-        unset($_SESSION);
-        $this->data = null;
+        $this->getHandler()->invalidate();
+        return $this;
     }
 
     /**
      * Set session value
      *
      * @param string $name
-     * @param mixed $val
+     * @param mixed $value
      * @return $this
      */
-    public function set($name, $val)
+    public function set($name, $value)
     {
-        $var = &$this->nestedValueRef($name, $this->data);
+        $handler = $this->getHandler();
+        $pieces = explode('.', $name);
+        $key = array_shift($pieces);
 
-        // Mark changed
-        if ($var !== $val) {
-            $var = $val;
-            $this->markChanged($name);
+        // If the name doesn't include any dots, we can just set the value
+        if (empty($pieces)) {
+            $handler->set($name, $value);
+            return $this;
         }
+
+        // Traverse down existing array (adding placeholders if needed) to set the value
+        $existing = $handler->get($key);
+        $var =& $existing;
+        foreach ($pieces as $namePart) {
+            if (!isset($var) || !is_array($var)) {
+                $var = [];
+            }
+            if (!isset($var[$namePart])) {
+                $var[$namePart] = null;
+            }
+            $var =& $var[$namePart];
+        }
+        $var = $value;
+        $handler->set($key, $existing);
+
         return $this;
-    }
-
-    /**
-     * Mark key as changed
-     *
-     * @internal
-     * @param string $name
-     */
-    protected function markChanged($name)
-    {
-        $diffVar = &$this->changedData;
-        foreach (explode('.', $name) as $namePart) {
-            if (!isset($diffVar[$namePart])) {
-                $diffVar[$namePart] = [];
-            }
-            $diffVar = &$diffVar[$namePart];
-
-            // Already diffed
-            if ($diffVar === true) {
-                return;
-            }
-        }
-        // Mark changed
-        $diffVar = true;
-    }
-
-    /**
-     * Merge value with array
-     *
-     * @param string $name
-     * @param mixed $val
-     */
-    public function addToArray($name, $val)
-    {
-        $names = explode('.', $name);
-
-        // We still want to do this even if we have strict path checking for legacy code
-        $var = &$this->data;
-        $diffVar = &$this->changedData;
-
-        foreach ($names as $n) {
-            $var = &$var[$n];
-            $diffVar = &$diffVar[$n];
-        }
-
-        $var[] = $val;
-        $diffVar[sizeof($var) - 1] = $val;
     }
 
     /**
@@ -440,7 +259,20 @@ class Session
      */
     public function get($name)
     {
-        return $this->nestedValue($name, $this->data);
+        $handler = $this->getHandler();
+        $pieces = explode('.', $name);
+        $key = array_shift($pieces);
+
+        $value = $handler->get($key);
+        foreach ($pieces as $namePart) {
+            if (!isset($value) || !is_array($value) || !isset($value[$namePart])) {
+                return null;
+            }
+
+            $value = $value[$namePart];
+        }
+
+        return $value;
     }
 
     /**
@@ -451,55 +283,70 @@ class Session
      */
     public function clear($name)
     {
-        // Get var by path
-        $var = $this->nestedValue($name, $this->data);
+        $handler = $this->getHandler();
+        $pieces = explode('.', $name);
+        $key = array_shift($pieces);
 
-        // Unset var
-        if ($var !== null) {
-            // Unset parent key
-            $parentParts = explode('.', $name);
-            $basePart = array_pop($parentParts);
-            if ($parentParts) {
-                $parent = &$this->nestedValueRef(implode('.', $parentParts), $this->data);
-                unset($parent[$basePart]);
-            } else {
-                unset($this->data[$name]);
-            }
-            $this->markChanged($name);
+        $existing = $handler->get($key);
+
+        // If the value is scalar, or the name doesn't include any dots, just remove it
+        if (!is_array($existing) || empty($pieces)) {
+            $this->getHandler()->remove($name);
+            return $this;
         }
+
+        // Otherwise we need to traverse down through the array value to find the key to remove
+        $var =& $existing;
+        $i = 0;
+        $length = count($pieces);
+        foreach ($pieces as $namePart) {
+            // If the key doesn't exist, or the last key didn't point to an array, we can't remove anything
+            if (!is_array($var) || !isset($var[$namePart])) {
+                return $this;
+            }
+
+            $i++;
+            if ($i === $length) {
+                unset($var[$namePart]);
+            } else {
+                $var =& $var[$namePart];
+            }
+        }
+        $handler->set($key, $existing);
+
         return $this;
     }
 
     /**
      * Clear all values
+     * @return $this
      */
     public function clearAll()
     {
-        if ($this->data && is_array($this->data)) {
-            foreach (array_keys($this->data) as $key) {
-                $this->clear($key);
-            }
-        }
+        $this->getHandler()->clear();
+        return $this;
     }
 
     /**
      * Get all values
      *
-     * @return array|null
+     * @return array
      */
     public function getAll()
     {
-        return $this->data;
+        return $this->getHandler()->all();
     }
 
     /**
      * Set user agent key
      *
      * @param HTTPRequest $request
+     * @return $this
      */
     public function finalize(HTTPRequest $request)
     {
         $this->set('HTTP_USER_AGENT', $this->userAgent($request));
+        return $this;
     }
 
     /**
@@ -507,126 +354,54 @@ class Session
      * Only save the changes, so that anyone manipulating $_SESSION directly doesn't get burned.
      *
      * @param HTTPRequest $request
+     * @return $this
      */
     public function save(HTTPRequest $request)
     {
-        if ($this->changedData) {
-            $this->finalize($request);
-
-            if (!$this->isStarted()) {
-                $this->start($request);
-            }
-
-            // Apply all changes recursively, implicitly writing them to the actual PHP session store.
-            $this->recursivelyApplyChanges($this->changedData, $this->data, $_SESSION);
-        }
+        $this->finalize($request);
+        $this->getHandler()->save();
+        return $this;
     }
 
     /**
-     * Recursively apply the changes represented in $data to $dest.
-     * Used to update $_SESSION
-     *
-     * @deprecated 4.1.0:5.0.0 Use recursivelyApplyChanges() instead
-     * @param array $data
-     * @param array $dest
-     */
-    protected function recursivelyApply($data, &$dest)
-    {
-        Deprecation::notice('5.0', 'Use recursivelyApplyChanges() instead');
-        foreach ($data as $k => $v) {
-            if (is_array($v)) {
-                if (!isset($dest[$k]) || !is_array($dest[$k])) {
-                    $dest[$k] = array();
-                }
-                $this->recursivelyApply($v, $dest[$k]);
-            } else {
-                $dest[$k] = $v;
-            }
-        }
-    }
-
-    /**
-     * Returns the list of changed keys
+     * Returns the list of changed data
      *
      * @return array
      */
     public function changedData()
     {
-        return $this->changedData;
+        return array_merge(
+            $this->recursiveDiff($this->original, $this->getAll()),
+            $this->recursiveDiff($this->getAll(), $this->original)
+        );
     }
 
     /**
-     * Navigate to nested value in source array by name,
-     * creating a null placeholder if it doesn't exist.
-     *
      * @internal
-     * @param string $name
-     * @param array $source
-     * @return mixed Reference to value in $source
+     * @param $array1
+     * @param $array2
+     * @return array
      */
-    protected function &nestedValueRef($name, &$source)
+    protected function recursiveDiff($array1, $array2)
     {
-        // Find var to change
-        $var = &$source;
-        foreach (explode('.', $name) as $namePart) {
-            if (!isset($var)) {
-                $var = [];
-            }
-            if (!isset($var[$namePart])) {
-                $var[$namePart] = null;
-            }
-            $var = &$var[$namePart];
-        }
-        return $var;
-    }
-
-    /**
-     * Navigate to nested value in source array by name,
-     * returning null if it doesn't exist.
-     *
-     * @internal
-     * @param string $name
-     * @param array $source
-     * @return mixed Value in array in $source
-     */
-    protected function nestedValue($name, $source)
-    {
-        // Find var to change
-        $var = $source;
-        foreach (explode('.', $name) as $namePart) {
-            if (!isset($var[$namePart])) {
-                return null;
-            }
-            $var = $var[$namePart];
-        }
-        return $var;
-    }
-
-    /**
-     * Apply all changes using separate keys and data sources and a destination
-     *
-     * @internal
-     * @param array $changes
-     * @param array $source
-     * @param array $destination
-     */
-    protected function recursivelyApplyChanges($changes, $source, &$destination)
-    {
-        $source = $source ?: [];
-        foreach ($changes as $key => $changed) {
-            if ($changed === true) {
-                // Determine if replacement or removal
-                if (array_key_exists($key, $source)) {
-                    $destination[$key] = $source[$key];
+        $result = [];
+        foreach ($array1 as $key => $value) {
+            if (array_key_exists($key, $array2)) {
+                if (is_array($value)) {
+                    $nestedDiff = $this->recursiveDiff($value, $array2[$key]);
+                    if (!empty($nestedDiff)) {
+                        $result[$key] = $nestedDiff;
+                    }
                 } else {
-                    unset($destination[$key]);
+                    if ($value != $array2[$key]) {
+                        $result[$key] = true;
+                    }
                 }
             } else {
-                // Recursively apply
-                $destVal = &$this->nestedValueRef($key, $destination);
-                $sourceVal = $this->nestedValue($key, $source);
-                $this->recursivelyApplyChanges($changed, $sourceVal, $destVal);
+                $result[$key] = true;
             }
         }
+
+        return $result;
     }
 }

--- a/src/Core/CoreKernel.php
+++ b/src/Core/CoreKernel.php
@@ -147,6 +147,7 @@ class CoreKernel implements Kernel
         $this->bootManifests($flush);
         $this->bootErrorHandling();
         $this->bootDatabaseEnvVars();
+        $this->bootSessionEnvVars();
         $this->bootConfigs();
         $this->bootDatabaseGlobals();
         $this->validateDatabase();
@@ -209,6 +210,16 @@ class CoreKernel implements Kernel
         $databaseConfig = $this->getDatabaseConfig();
         $databaseConfig['database'] = $this->getDatabaseName();
         DB::setConfig($databaseConfig);
+    }
+
+    /**
+     * Load base URL path into a constant - this is injected
+     */
+    protected function bootSessionEnvVars()
+    {
+        if (!defined('SS_SESSION_COOKIE_PATH')) {
+            define('SS_SESSION_COOKIE_PATH', Director::baseURL());
+        }
     }
 
     /**

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -20,12 +20,12 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Injector\InjectorLoader;
 use SilverStripe\Core\Manifest\ClassLoader;
+use SilverStripe\Core\Manifest\ModuleResourceLoader;
 use SilverStripe\Dev\Constraint\SSListContains;
 use SilverStripe\Dev\Constraint\SSListContainsOnly;
 use SilverStripe\Dev\Constraint\SSListContainsOnlyMatchingItems;
 use SilverStripe\Dev\State\FixtureTestState;
 use SilverStripe\Dev\State\SapphireTestState;
-use SilverStripe\Dev\State\TestState;
 use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\Connect\TempDatabase;
 use SilverStripe\ORM\DataObject;
@@ -38,7 +38,9 @@ use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
 use SilverStripe\View\SSViewer;
-use SilverStripe\Core\Manifest\ModuleResourceLoader;
+use Symfony\Component\HttpFoundation\Session\Session as SymfonySession;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 
 if (!class_exists(TestCase::class)) {
     return;
@@ -994,6 +996,11 @@ abstract class SapphireTest extends TestCase implements TestOnly
         $kernel = new TestKernel(BASE_PATH);
         $app = new HTTPApplication($kernel);
         $flush = array_key_exists('flush', $request->getVars());
+
+        // Mock session storage - PHPUnit already triggers output so native session handler is unable to start
+        $mockSessionStorage = new MockFileSessionStorage();
+        $mockSession = new SymfonySession($mockSessionStorage);
+        Injector::inst()->registerService($mockSession, SessionInterface::class);
 
         // Custom application
         $app->execute($request, function (HTTPRequest $request) {


### PR DESCRIPTION
I was going to do an RFC, but I got so far with my proof-of-concept that I ended up carrying on with it... so this is my RFC

An alternative proposal would be to remove the `SilverStripe\Control\Session` class entirely, and make `HTTPRequest::getSession()` return an instance of `Symfony\Component\HttpFoundation\Session\SessionInterface`. I didn’t go for that approach, because we still rely on the `Foo.Bar.Baz` session-name-to-array-traversal magic for things like form errors.

Pros are slightly less code to maintain (at least less complexity handling cookies on our end) and better support for/easier to configure save handlers.