### PR TITLE
Revert "ENHANCEMENT Add config var to skip confirm logout (#7977)"

### DIFF
--- a/src/Security/MemberAuthenticator/LogoutHandler.php
+++ b/src/Security/MemberAuthenticator/LogoutHandler.php
@@ -37,11 +37,6 @@ class LogoutHandler extends RequestHandler
         'LogoutForm'
     ];
 
-    /**
-     * @config
-     * @var bool
-     */
-    private static $confirm_logout = true;
 
     /**
      * Log out form handler method
@@ -59,7 +54,7 @@ class LogoutHandler extends RequestHandler
 
         // If the user doesn't have a security token, show them a form where they can get one.
         // This protects against nuisance CSRF attacks to log out users.
-        if ($member && self::config()->get('confirm_logout') && !SecurityToken::inst()->checkRequest($this->getRequest())) {
+        if ($member && !SecurityToken::inst()->checkRequest($this->getRequest())) {
             Security::singleton()->setSessionMessage(
                 _t(
                     'SilverStripe\\Security\\Security.CONFIRMLOGOUT',


### PR DESCRIPTION
The correct fix is to use `$LogoutURL` instead or hard coding `Security/logout` in templates.