### PR TITLE
Fix invalid markup in SelectionGroup selected values

### DIFF
--- a/templates/SilverStripe/Forms/SelectionGroup.ss
+++ b/templates/SilverStripe/Forms/SelectionGroup.ss
@@ -2,7 +2,7 @@
 	<ul class="SelectionGroup<% if extraClass %> $extraClass<% end_if %>">
 	<% loop $FieldSet %>
 	<% if $Selected %>
-		<li$Selected>
+		<li class="selected">
 			$RadioLabel
 			$FieldHolder
 		</li>
@@ -12,7 +12,7 @@
 <% else %>
 	<ul class="SelectionGroup<% if extraClass %> $extraClass<% end_if %>">
 	<% loop $FieldSet %>
-		<li$Selected>
+		<li <% if Selected %>class="selected"<% end_if %>>
 			<label>{$RadioButton} {$RadioLabel}</label>
 			<% if $FieldList %>
 				$FieldHolder

--- a/tests/php/Forms/SelectionGroupTest.php
+++ b/tests/php/Forms/SelectionGroupTest.php
@@ -41,6 +41,33 @@ class SelectionGroupTest extends SapphireTest
         $this->assertContains('two view', (string)$listElTwo->div);
     }
 
+    function testSelectedFieldHolder()
+    {
+        $items = array(
+            new SelectionGroup_Item(
+                'one',
+                new LiteralField('one', 'one view'),
+                'one title'
+            ),
+            new SelectionGroup_Item(
+                'two',
+                new LiteralField('two', 'two view'),
+                'two title'
+            ),
+        );
+        $field = new SelectionGroup('MyGroup', $items);
+        $field->setValue('two');
+
+        $parser = new CSSContentParser($field->FieldHolder());
+        $listEls = $parser->getBySelector('li');
+        $listElOne = $listEls[0];
+        $listElTwo = $listEls[1];
+
+        $this->assertEquals('one', (string)$listElOne->label[0]->input[0]['value']);
+        $this->assertEquals('two', (string)$listElTwo->label[0]->input[0]['value']);
+        $this->assertEquals('selected', (string)$listElTwo->attributes()->class);
+    }
+
     function testLegacyItemsFieldHolder()
     {
         $items = array(

--- a/tests/php/Forms/SelectionGroupTest.php
+++ b/tests/php/Forms/SelectionGroupTest.php
@@ -10,8 +10,7 @@ use SilverStripe\Forms\SelectionGroup;
 
 class SelectionGroupTest extends SapphireTest
 {
-
-    function testFieldHolder()
+    public function testFieldHolder()
     {
         $items = array(
             new SelectionGroup_Item(
@@ -41,7 +40,7 @@ class SelectionGroupTest extends SapphireTest
         $this->assertContains('two view', (string)$listElTwo->div);
     }
 
-    function testSelectedFieldHolder()
+    public function testSelectedFieldHolder()
     {
         $items = array(
             new SelectionGroup_Item(
@@ -68,7 +67,7 @@ class SelectionGroupTest extends SapphireTest
         $this->assertEquals('selected', (string)$listElTwo->attributes()->class);
     }
 
-    function testLegacyItemsFieldHolder()
+    public function testLegacyItemsFieldHolder()
     {
         $items = array(
             'one' => new LiteralField('one', 'one view'),
@@ -87,7 +86,7 @@ class SelectionGroupTest extends SapphireTest
         $this->assertEquals(' two', (string)$listElTwo->label[0]);
     }
 
-    function testLegacyItemsFieldHolderWithTitle()
+    public function testLegacyItemsFieldHolderWithTitle()
     {
         $items = array(
             'one//one title' => new LiteralField('one', 'one view'),


### PR DESCRIPTION
When providing a selected value to a `SelectionGroup` it resulted in markup - `<li1>` since `$Selected` has been changed from a string to a simple boolean. This corrects the default template so that a class is output.