### PR TITLE
PasswordValidator - Impossible to pass validation if min_test_score is set

### DIFF
--- a/src/Security/PasswordValidator.php
+++ b/src/Security/PasswordValidator.php
@@ -251,7 +251,7 @@ class PasswordValidator
                 );
             }
 
-            $score = count($this->testNames) - count($missedTests);
+            $score = count($testNames) - count($missedTests);
             if ($score < $minTestScore) {
                 $error = _t(
                     'SilverStripe\\Security\\PasswordValidator.LOWCHARSTRENGTH',


### PR DESCRIPTION
The `SilverStripe\Security\PasswordValidator.php` class has configuration based settings for specifying a simple minimum password strength policy via `private static $min_test_score;`

If used, there is logic in the `PasswordValidate()` method to check the required minimum score against the actual score (based on the usage of lowercase, uppercase, digit and symbol characters in the password).

However, the check to calculate the actual score incorrectly references ```count($this->testNames)``` (which defaults to ```null```) instead of using ```count($testNames)``` (which contains an array of values returned by ```public function getTestNames()```

This equates to ```$score = count(null) - count([FAILED TESTS]);``` which, if it is set, will be less than `private static $min_test_score;` (e.g. 0 at best, or -1, -2 etc).

This PR fixes this mistake/typo.

