### PR TITLE
FIX: Duplicating many_many relationships looses the extra fields (fixes #7973)

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -585,7 +585,21 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 	private function duplicateRelations($sourceObject, $destinationObject, $name) {
 		$relations = $sourceObject->$name();
 		if ($relations) {
-			if ($relations instanceOf RelationList) {   //many-to-something relation
+            if ($relations instanceOf ManyManyList) { //many-to-many relation
+                $source = $sourceObject->getManyManyComponents($name);
+                $extraFieldNames = $source->getExtraFields();
+
+                if ($relations->Count() > 0) {  //with more than one thing it is related to
+					foreach($relations as $relation) {
+                        // Merge extra fields
+                        $extraFields = array();
+                        foreach ($extraFieldNames as $fieldName => $fieldType) {
+                            $extraFields[$fieldName] = $relation->getField($fieldName);
+                        }
+                        $destinationObject->$name()->add($relation, $extraFields);
+                    }
+                }
+            } else if ($relations instanceOf RelationList) {   //many-to-something relation
 				if ($relations->Count() > 0) {  //with more than one thing it is related to
 					foreach($relations as $relation) {
 						$destinationObject->$name()->add($relation);

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -586,8 +586,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 		$relations = $sourceObject->$name();
 		if ($relations) {
             if ($relations instanceOf ManyManyList) { //many-to-many relation
-                $source = $sourceObject->getManyManyComponents($name);
-                $extraFieldNames = $source->getExtraFields();
+                $extraFieldNames = $relations->getExtraFields();
 
                 if ($relations->Count() > 0) {  //with more than one thing it is related to
 					foreach($relations as $relation) {

--- a/tests/model/DataObjectDuplicationTest.php
+++ b/tests/model/DataObjectDuplicationTest.php
@@ -77,7 +77,7 @@ class DataObjectDuplicationTest extends SapphireTest {
 
 		//create relations
 		$one->twos()->add($two);
-		$one->threes()->add($three);
+		$one->threes()->add($three, array('TestExtra'=>'three'));
 
 		$one = DataObject::get_by_id("DataObjectDuplicateTestClass1", $one->ID);
 		$two = DataObject::get_by_id("DataObjectDuplicateTestClass2", $two->ID);
@@ -115,6 +115,9 @@ class DataObjectDuplicationTest extends SapphireTest {
 			"Match between relation of copy and the original");
 		$this->assertEquals($one->ID, $threeCopy->ones()->First()->ID,
 			"Match between relation of copy and the original");
+
+		$this->assertEquals('three', $oneCopy->threes()->First()->TestExtra,
+			"Match between extra field of copy and the original");
 	}
 
 }
@@ -132,6 +135,12 @@ class DataObjectDuplicateTestClass1 extends DataObject implements TestOnly {
 
 	private static $many_many = array(
 		'threes' => 'DataObjectDuplicateTestClass3'
+	);
+
+	private static $many_many_extraFields = array(
+		'threes' => array(
+            'TestExtra' => 'Varchar'
+        )
 	);
 }
 


### PR DESCRIPTION
Fixes issue when you duplicate a DataObject with a many_many relationship with extra fields defined for the relationship extra fields are lost due to how DataObject::duplicateManyManyRelations() and DataObject::duplicateRelations() function. In short when the new items are added to the many_many relationship the extra fields are not included or even retrieved when DataObject::duplicateRelations() adds the item to the list. This issue also seems to affect 4.0 but the fix required would be slightly different see #7973 for details.