### PR TITLE
BUG Fix incorrect installer base tag generation

### DIFF
--- a/src/Dev/Install/config-form.html
+++ b/src/Dev/Install/config-form.html
@@ -5,7 +5,7 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 	<head>
 		<title>SilverStripe CMS / Framework Installation</title>
-        <base href="<?php echo htmlentities($base); ?>/" />
+        <base href="<?php echo htmlentities($base); ?>" />
 		<meta http-equiv="Content-type" content="text/html; charset=utf-8">
 		<script type="application/javascript" src="//code.jquery.com/jquery-1.7.2.min.js"></script>
 		<script type="application/javascript" src="<?=$clientPath; ?>/js/install.js"></script>

--- a/src/Dev/Install/install5.php
+++ b/src/Dev/Install/install5.php
@@ -105,7 +105,7 @@ if ($installFromCli && ($req->hasErrors() || $dbReq->hasErrors())) {
 }
 
 // Path to client resources (copied through silverstripe/vendor-plugin)
-$base = BASE_URL;
+$base = rtrim(BASE_URL, '/') . '/';
 $clientPath = PUBLIC_DIR
     ? 'resources/vendor/silverstripe/framework/src/Dev/Install/client'
     : 'resources/silverstripe/framework/src/Dev/Install/client';


### PR DESCRIPTION
Fixes #7926

I didn't notice the `/` hard coded into the template.

Copies the logic from Director::baseURL() to strip and re-add the trailing `/`