### PR TITLE
unset http scheme on CLIRequestBuilder

### DIFF
--- a/src/Control/CLIRequestBuilder.php
+++ b/src/Control/CLIRequestBuilder.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\Control;
 
+use SilverStripe\Core\Environment;
+
 /**
  * CLI specific request building logic
  */
@@ -65,5 +67,20 @@ class CLIRequestBuilder extends HTTPRequestBuilder
 
         // Parse rest of variables as standard
         return parent::cleanEnvironment($variables);
+    }
+
+    /**
+     * @param array $variables
+     * @param string $input
+     * @return HTTPRequest
+     */
+    public static function createFromVariables(array $variables, $input)
+    {
+        $request = parent::createFromVariables($variables, $input);
+        // unset scheme so that SS_BASE_URL can provide `is_https` information if required
+        $scheme = parse_url(Environment::getEnv('SS_BASE_URL'), PHP_URL_SCHEME);
+        $request->setScheme($scheme);
+
+        return $request;
     }
 }


### PR DESCRIPTION
Encountered [a bug](https://github.com/silverstripe/silverstripe-staticpublishqueue/issues/77) when running StaticPublishQueue with `SS_BASE_URL` set to an https address.

When the full static cache job is run via CLI, the scheme will always be set to HTTP. This is because we [generate a dummy request](https://github.com/silverstripe/silverstripe-framework/blob/4.0/src/Control/Director.php#L969-L976), which when constructed [sets the scheme to HTTP by default](https://github.com/silverstripe/silverstripe-framework/blob/4.0/src/Control/HTTPRequest.php#L164).

Then when building the URL in the cache collection, when we use `Director::absoluteURL()`, `Director::is_https()` will always return `false` unless we set `Director::alternate_base_url()`, as the current request [takes priority](https://github.com/silverstripe/silverstripe-framework/blob/4.0/src/Control/Director.php#L533-L560) over `Director::default_base_url()`

In practice, I expect the CLI runner to return the protocol it has information for. In this case, it is blindly assuming that the dummy request has accurate information about the protocol the site expects. This PR unsets the set scheme to let it fall through to `SS_BASE_URL`.

An alternative idea was to check:

```php
        if ($request && $request->getScheme() === 'https') {
            return true;
        }
```

instead, to allow for deliberate overriding in `Director::is_https()`, but that means if you make an HTTP request, but the base tag is HTTPS, you end up with a pile of CORS errors.