### PR TITLE
Patch 2

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1352,7 +1352,7 @@ class Member extends DataObject
             return ArrayList::create()->map();
         }
 
-        if (count($groups) == 0) {
+        if ($groups && count($groups) == 0) {
             $perms = array('ADMIN', 'CMS_ACCESS_AssetAdmin');
 
             if (class_exists(CMSMain::class)) {

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1352,7 +1352,7 @@ class Member extends DataObject
             return ArrayList::create()->map();
         }
 
-        if ($groups && count($groups) == 0) {
+        if (is_iterable($groups) && count($groups) == 0) {
             $perms = array('ADMIN', 'CMS_ACCESS_AssetAdmin');
 
             if (class_exists(CMSMain::class)) {

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1352,7 +1352,7 @@ class Member extends DataObject
             return ArrayList::create()->map();
         }
 
-        if (is_iterable($groups) && count($groups) == 0) {
+        if (is_countable($groups) && count($groups) == 0) {
             $perms = array('ADMIN', 'CMS_ACCESS_AssetAdmin');
 
             if (class_exists(CMSMain::class)) {

--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -62,3 +62,20 @@ function _t($entity, $arg = null)
     // Pass args directly to handle deprecation
     return call_user_func_array([i18n::class, '_t'], func_get_args());
 }
+
+/**
+ * Polyfill for is_iterable for PHP5.6 and PHP7.0
+ * http://php.net/manual/en/function.is-iterable.php
+ **/
+if (!function_exists('is_iterable')) {
+
+    /**
+     * Verify that the contents of a variable is an iterable value
+     * @param  mixed    $obj    the variable to test
+     * @return boolean          Returns TRUE if $obj is iterable, FALSE otherwise.
+     */
+    function is_iterable($obj) {
+        return is_array($obj) || (is_object($obj) && ($obj instanceof \Traversable));
+    }
+}
+

--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -63,6 +63,7 @@ function _t($entity, $arg = null)
     return call_user_func_array([i18n::class, '_t'], func_get_args());
 }
 
+
 /**
  * Polyfill for is_iterable for PHP5.6 and PHP7.0
  * http://php.net/manual/en/function.is-iterable.php
@@ -76,6 +77,22 @@ if (!function_exists('is_iterable')) {
      */
     function is_iterable($obj) {
         return is_array($obj) || (is_object($obj) && ($obj instanceof \Traversable));
+    }
+}
+
+/**
+ * Polyfill for is_countable for < PHP7.3
+ * https://wiki.php.net/rfc/is-countable
+ **/
+if (!function_exists('is_countable')) {
+
+    /**
+     * Verify that the contents of a variable is a countable value
+     * @param  mixed    $obj    the variable to test
+     * @return boolean          Returns TRUE if $obj is countable, FALSE otherwise.
+     */
+    function is_countable($obj) {
+        return is_array($obj) || (is_object($obj) && ($obj instanceof \Countable));
     }
 }
 


### PR DESCRIPTION
Without this patch on PHP 7.2 you get the following warning if using `count` on a non-countable value:

`Warning: count(): Parameter must be an array or an object that implements Countable in /path/to/vendor/silverstripe/framework/src/Security/Member.php on line 1355`

Patch includes a couple of polyfills for helper functions introduced in newer 7.x Versions of php and a check on the `$groups` param prior to calling `count`