### PR TITLE
Fixes a count() php warning without an api change

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1347,6 +1347,12 @@ class Member extends DataObject
      */
     public static function mapInCMSGroups($groups = null)
     {
+        
+        // non-countable $groups will issue a warning when using count() in PHP 7.2+
+        if (!$groups) {
+            $groups = [];
+        }
+            
         // Check CMS module exists
         if (!class_exists(LeftAndMain::class)) {
             return ArrayList::create()->map();


### PR DESCRIPTION
Without this patch on PHP 7.2 you get the following warning if using count on a non-countable value:

Warning: count(): Parameter must be an array or an object that implements Countable in /path/to/vendor/silverstripe/framework/src/Security/Member.php on line 1355