### PR TITLE
Fix phpdoc for DataList::relation method (namespace)

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1047,7 +1047,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * Example: Get members from all Groups:
      *
-     *     DataList::Create("Group")->relation("Members")
+     *     DataList::Create(\SilverStripe\Security\Group::class)->relation("Members")
      *
      * @param string $relationName
      * @return HasManyList|ManyManyList


### PR DESCRIPTION
Fixed an old non-namespaced phpdoc. 

The example from that doc still **doesn't seem to work** though. Perhaps I should create an issue about that, but you never know someone here knows what's wrong.

When I try `DataList::Create(\SilverStripe\Security\Group::class)->relation("Members")->Count()` it returns `0`. Even on a brand-new installation, it should at least return the Default Administrator (belonging to the Administrator group), shouldn't it? At least, `\SilverStripe\Security\Group::get()->byID(2)->Members()->Count()` does return `1`.

(I'm trying to [fix an issue in symbiote/silverstripe-memberprofiles](https://github.com/symbiote/silverstripe-memberprofiles/pull/138#issuecomment-368744525) where I have the same issue of `relation("Members")` returning an empty list while expecting Members)