### PR TITLE
DOCS: Update incorrect documentation for Introduction

### DIFF
--- a/docs/en/02_Developer_Guides/02_Controllers/01_Introduction.md
+++ b/docs/en/02_Developer_Guides/02_Controllers/01_Introduction.md
@@ -19,12 +19,12 @@ class TeamController extends Controller
         'index'
     ];
     
-    public function index(HTTPRequest $request) 
+    public function index() 
     {
         // ..
     }
 
-    public function players(HTTPRequest $request) 
+    public function players() 
     {
         print_r($request->allParams());
     }


### PR DESCRIPTION
HTTPRequest is no longer passed in as a variable. Documentation should not have controller functions with the request variable. 