### PR TITLE
DOCS: Import HTTPRequest missing in Controller example

### DIFF
--- a/docs/en/02_Developer_Guides/02_Controllers/01_Introduction.md
+++ b/docs/en/02_Developer_Guides/02_Controllers/01_Introduction.md
@@ -10,6 +10,7 @@ subclass the base `Controller` class.
 
 ```php
 use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
 
 class TeamController extends Controller 
 {


### PR DESCRIPTION
Added a missing import that is required to use the HTTPRequest object