### PR TITLE
NEW: Switch default password encryptor to password_hash()

### DIFF
--- a/_config/encryptors.yml
+++ b/_config/encryptors.yml
@@ -15,3 +15,5 @@ name: coreencryptors
       'SilverStripe\Security\PasswordEncryptor_PHPHash': sha1
     blowfish:
       'SilverStripe\Security\PasswordEncryptor_Blowfish':
+    password_hash:
+      'SilverStripe\Security\PasswordEncryptor_PHPPasswordHash':

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -67,7 +67,7 @@ class Member extends DataObject
         'Email'              => 'Varchar(254)', // See RFC 5321, Section 4.5.3.1.3. (256 minus the < and > character)
         'TempIDHash'         => 'Varchar(160)', // Temporary id used for cms re-authentication
         'TempIDExpired'      => 'Datetime', // Expiry of temp login
-        'Password'           => 'Varchar(160)',
+        'Password'           => 'Varchar(255)',
         'AutoLoginHash'      => 'Varchar(160)', // Used to auto-login the user on password reset
         'AutoLoginExpired'   => 'Datetime',
         // This is an arbitrary code pointing to a PasswordEncryptor instance,

--- a/src/Security/PasswordEncryptor_PHPPasswordHash.php
+++ b/src/Security/PasswordEncryptor_PHPPasswordHash.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SilverStripe\Security;
+
+use Exception;
+use SilverStripe\Core\Config\Config;
+
+/**
+ * Hashing using built-in password_hash()/password_verify() in PHP
+ */
+class PasswordEncryptor_PHPPasswordHash extends PasswordEncryptor
+{
+    /**
+     * @var int
+     * @config
+     */
+    private static $algorithm = PASSWORD_DEFAULT;
+
+    /**
+     * @var array
+     * @config
+     */
+    private static $options = [];
+
+    public function encrypt($password, $salt = null, $member = null)
+    {
+        $algorithm = Config::inst()->get(static::class, 'algorithm');
+        $options = Config::inst()->get(static::class, 'options');
+        return password_hash($password, $algorithm, $options);
+    }
+
+    public function check($hash, $password, $salt = null, $member = null)
+    {
+        return password_verify($password, $hash);
+    }
+
+    public function salt($password, $member = null)
+    {
+        return '';
+    }
+}

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -62,7 +62,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @config
      * @var string
      */
-    private static $password_encryption_algorithm = 'blowfish';
+    private static $password_encryption_algorithm = 'password_hash';
 
     /**
      * Showing "Remember me"-checkbox

--- a/tests/php/Security/PasswordEncryptorTest.php
+++ b/tests/php/Security/PasswordEncryptorTest.php
@@ -165,4 +165,14 @@ class PasswordEncryptorTest extends SapphireTest
         $this->assertTrue($e->check($intelHash, "mypassword"));
         $this->assertFalse($e->check($wrongHash, "mypassword"));
     }
+
+    public function testPHPPasswordHashEncryptor()
+    {
+        $password = 'correcthorsebatterystaple';
+        $e = PasswordEncryptor::create_for_algorithm('password_hash');
+        $hash = $e->encrypt($password);
+        $this->assertTrue($e->check($hash, $password));
+        $this->assertFalse($e->check($hash, 'wrongpassword'));
+        $this->assertFalse($e->check('wronghash', $password));
+    }
 }


### PR DESCRIPTION
Submitted against 4 because there shouldn’t be any BC risk here: existing passwords will continue to work, `password_hash()` will be used for new members and when passwords are next changed

Updated the password column on `Member` to 255 characters just as a precaution - that’s what the [PHP manual](http://php.net/manual/en/function.password-hash.php) recommends as a safe default.