### PR TITLE
Batch action on Page loading screen fix

### DIFF
--- a/admin/javascript/LeftAndMain.BatchActions.js
+++ b/admin/javascript/LeftAndMain.BatchActions.js
@@ -281,7 +281,7 @@
 				tree.find('li').removeClass('failed');
 
 				var button = this.find(':submit:first');
-				$('.cms-content-fields').addClass('loading');
+				jQuery('.cms-content-fields').addClass('loading');
 				button.addClass('loading');
 
 				jQuery.ajax({
@@ -290,7 +290,7 @@
 					type: 'POST',
 					data: this.serializeArray(),
 					complete: function(xmlhttp, status) {
-						$('.cms-content-fields').removeClass('loading');
+						jQuery('.cms-content-fields').removeClass('loading');
 						button.removeClass('loading');
 
 						// Refresh the tree.

--- a/admin/javascript/LeftAndMain.BatchActions.js
+++ b/admin/javascript/LeftAndMain.BatchActions.js
@@ -281,6 +281,7 @@
 				tree.find('li').removeClass('failed');
 
 				var button = this.find(':submit:first');
+				$('.cms-content-fields').addClass('loading');
 				button.addClass('loading');
 
 				jQuery.ajax({
@@ -289,6 +290,7 @@
 					type: 'POST',
 					data: this.serializeArray(),
 					complete: function(xmlhttp, status) {
+						$('.cms-content-fields').removeClass('loading');
 						button.removeClass('loading');
 
 						// Refresh the tree.


### PR DESCRIPTION
Fixes batch actions that were not triggering the SS loading overlay. Issue affects 4 as well so will need to be merged up. 

Fixes https://github.com/silverstripe/silverstripe-cms/issues/441