### PR TITLE
NEW Add getJoinTable to MMTL

### DIFF
--- a/src/ORM/ManyManyThroughList.php
+++ b/src/ORM/ManyManyThroughList.php
@@ -230,4 +230,13 @@ class ManyManyThroughList extends RelationList
         $joinClass = $this->manipulator->getJoinClass();
         return Config::inst()->get($joinClass, 'db');
     }
+
+    /**
+     * @return string
+     */
+    public function getJoinTable()
+    {
+        $joinClass = $this->manipulator->getJoinClass();
+        return DataObject::getSchema()->tableName($joinClass);
+    }
 }

--- a/tests/php/ORM/ManyManyThroughListTest.php
+++ b/tests/php/ORM/ManyManyThroughListTest.php
@@ -6,6 +6,7 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ManyManyThroughList;
 use SilverStripe\ORM\Tests\ManyManyThroughListTest\PolyItem;
+use SilverStripe\ORM\Tests\ManyManyThroughListTest\PolyJoinObject;
 
 class ManyManyThroughListTest extends SapphireTest
 {
@@ -260,5 +261,20 @@ class ManyManyThroughListTest extends SapphireTest
             ['Title' => 'item 1'],
             ['Title' => 'New Item'],
         ], $objB2->Items());
+    }
+
+    public function testGetJoinTable()
+    {
+        $joinTable = DataObject::getSchema()->tableName(PolyJoinObject::class);
+        /** @var ManyManyThroughListTest\PolyObjectA $objA1 */
+        $objA1 = $this->objFromFixture(ManyManyThroughListTest\PolyObjectA::class, 'obja1');
+        /** @var ManyManyThroughListTest\PolyObjectB $objB1 */
+        $objB1 = $this->objFromFixture(ManyManyThroughListTest\PolyObjectB::class, 'objb1');
+        /** @var ManyManyThroughListTest\PolyObjectB $objB2 */
+        $objB2 = $this->objFromFixture(ManyManyThroughListTest\PolyObjectB::class, 'objb2');
+
+        $this->assertEquals($joinTable, $objA1->Items()->getJoinTable());
+        $this->assertEquals($joinTable, $objB1->Items()->getJoinTable());
+        $this->assertEquals($joinTable, $objB2->Items()->getJoinTable());
     }
 }


### PR DESCRIPTION
This is a small step to more closely aligning the API for `ManyManyList` and `ManyManyThroughList`

Ideally we'd add all the extra public methods that `ManyManyList` has to `ManyManyThroughList`

Missing methods:

- getLocalKey
- getForeignKey