### PR TITLE
SINGULARNAME and PLURALNAME are without underscore

### DIFF
--- a/docs/en/02_Developer_Guides/13_i18n/index.md
+++ b/docs/en/02_Developer_Guides/13_i18n/index.md
@@ -222,8 +222,8 @@ class MyObject extends DataObject implements i18nEntityProvider
     public function provideI18nEntities()
     {
         return [
-            'MyObject.SINGULAR_NAME' => 'object',
-            'MyObject.PLURAL_NAME' => 'objects',
+            'MyObject.SINGULARNAME' => 'object',
+            'MyObject.PLURALNAME' => 'objects',
             'MyObject.PLURALS' => [
                 'one' => 'An object',
                 'other' => '{count} objects',
@@ -239,8 +239,8 @@ In YML format this will be expressed as the below. This follows the
 ```yaml
 en:
   MyObject:
-    SINGULAR_NAME: 'object'
-    PLURAL_NAME: 'objects'
+    SINGULARNAME: 'object'
+    PLURALNAME: 'objects'
     PLURALS:
       one: 'An object',
       other: '{count} objects'


### PR DESCRIPTION
As used in https://github.com/silverstripe/silverstripe-framework/blob/4/src/ORM/DataObject.php#L824 and https://github.com/silverstripe/silverstripe-framework/blob/4/src/ORM/DataObject.php#L859.