### PR TITLE
WIP NEW Add better HTTP cache-control manipulation

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -14,6 +14,7 @@ MySQLDatabase:
 HTTP:
   cache_control:
     no-cache: "true"
+    no-store: "true"
     must-revalidate: "true"
   vary: "X-Requested-With, X-Forwarded-Protocol"
 LeftAndMain:

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -13,6 +13,7 @@ MySQLDatabase:
   collation: utf8_general_ci
 HTTP:
   cache_control:
+    no-cache: "true"
     must-revalidate: "true"
   vary: "X-Requested-With"
 LeftAndMain:

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -13,10 +13,8 @@ MySQLDatabase:
   collation: utf8_general_ci
 HTTP:
   cache_control:
-    max-age: 0
     must-revalidate: "true"
-    no-transform: "true"
-  vary: "Cookie, X-Forwarded-Protocol, User-Agent, Accept"
+  vary: "X-Requested-With"
 LeftAndMain:
   dependencies:
     versionProvider: %$SilverStripeVersionProvider

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -22,3 +22,9 @@ LeftAndMain:
 SilverStripeVersionProvider:
   modules:
     silverstripe/framework: Framework
+---
+Only:
+  environment: dev
+---
+HTTP:
+  disable_http_cache: true

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -15,7 +15,7 @@ HTTP:
   cache_control:
     no-cache: "true"
     must-revalidate: "true"
-  vary: "X-Requested-With"
+  vary: "X-Requested-With, X-Forwarded-Protocol"
 LeftAndMain:
   dependencies:
     versionProvider: %$SilverStripeVersionProvider

--- a/api/RSSFeed.php
+++ b/api/RSSFeed.php
@@ -204,10 +204,7 @@ class RSSFeed extends ViewableData {
 			HTTP::register_etag($this->etag);
 		}
 
-		if(!headers_sent()) {
-			HTTP::add_cache_headers();
-			$response->addHeader("Content-Type", "application/rss+xml; charset=utf-8");
-		}
+		$response->addHeader("Content-Type", "application/rss+xml; charset=utf-8");
 
 		Config::inst()->update('SSViewer', 'source_file_comments', $prevState);
 

--- a/control/Controller.php
+++ b/control/Controller.php
@@ -169,10 +169,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider {
 			$response->setBody($body);
 		}
 
-
 		ContentNegotiator::process($response);
-		HTTP::add_cache_headers($response);
-
 		$this->popCurrent();
 		return $response;
 	}

--- a/control/Controller.php
+++ b/control/Controller.php
@@ -502,7 +502,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider {
 	 */
 	public function redirectBack() {
 		// Don't cache the redirect back ever
-		HTTP::set_cache_age(0);
+		HTTPCacheControl::singleton()->disableCaching();
 
 		$url = null;
 

--- a/control/Controller.php
+++ b/control/Controller.php
@@ -502,7 +502,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider {
 	 */
 	public function redirectBack() {
 		// Don't cache the redirect back ever
-		HTTPCacheControl::singleton()->disableCaching();
+		HTTPCacheControl::singleton()->disableCache(true);
 
 		$url = null;
 

--- a/control/Director.php
+++ b/control/Director.php
@@ -384,7 +384,7 @@ class Director implements TemplateGlobalProvider {
 					try {
 						$result = $controllerObj->handleRequest($request, $model);
 					} catch(SS_HTTPResponse_Exception $responseException) {
-						HTTPCacheControl::singleton()->disableCache(true);
+						HTTPCacheControl::singleton()->disableCache();
 						$result = $responseException->getResponse();
 					}
 					if(!is_object($result) || $result instanceof SS_HTTPResponse) return $result;

--- a/control/Director.php
+++ b/control/Director.php
@@ -384,8 +384,9 @@ class Director implements TemplateGlobalProvider {
 					try {
 						$result = $controllerObj->handleRequest($request, $model);
 					} catch(SS_HTTPResponse_Exception $responseException) {
-						HTTPCacheControl::singleton()->disableCache();
 						$result = $responseException->getResponse();
+						// If catching controller exception, retroactively add cache-breaking for errors
+						HTTP::add_cache_headers($result);
 					}
 					if(!is_object($result) || $result instanceof SS_HTTPResponse) return $result;
 

--- a/control/Director.php
+++ b/control/Director.php
@@ -384,7 +384,7 @@ class Director implements TemplateGlobalProvider {
 					try {
 						$result = $controllerObj->handleRequest($request, $model);
 					} catch(SS_HTTPResponse_Exception $responseException) {
-						HTTPCacheControl::singleton()->disableCaching();
+						HTTPCacheControl::singleton()->disableCache(true);
 						$result = $responseException->getResponse();
 					}
 					if(!is_object($result) || $result instanceof SS_HTTPResponse) return $result;

--- a/control/Director.php
+++ b/control/Director.php
@@ -385,10 +385,15 @@ class Director implements TemplateGlobalProvider {
 						$result = $controllerObj->handleRequest($request, $model);
 					} catch(SS_HTTPResponse_Exception $responseException) {
 						$result = $responseException->getResponse();
-						// If catching controller exception, retroactively add cache-breaking for errors
-						HTTP::add_cache_headers($result);
 					}
-					if(!is_object($result) || $result instanceof SS_HTTPResponse) return $result;
+					// Ensure cache headers are added
+					if ($result instanceof SS_HTTPResponse) {
+						HTTP::add_cache_headers($result);
+						return $result;
+					}
+					if(!is_object($result)) {
+						return $result;
+					}
 
 					user_error("Bad result from url " . $request->getURL() . " handled by " .
 						get_class($controllerObj)." controller: ".get_class($result), E_USER_WARNING);

--- a/control/Director.php
+++ b/control/Director.php
@@ -384,6 +384,7 @@ class Director implements TemplateGlobalProvider {
 					try {
 						$result = $controllerObj->handleRequest($request, $model);
 					} catch(SS_HTTPResponse_Exception $responseException) {
+						HTTPCacheControl::singleton()->disableCaching();
 						$result = $responseException->getResponse();
 					}
 					if(!is_object($result) || $result instanceof SS_HTTPResponse) return $result;

--- a/control/FlushRequestFilter.php
+++ b/control/FlushRequestFilter.php
@@ -19,7 +19,7 @@ class FlushRequestFilter implements RequestFilter {
 
 	public function postRequest(SS_HTTPRequest $request, SS_HTTPResponse $response, DataModel $model) {
 		if(array_key_exists('flush', $request->getVars())) {
-			HTTPCacheControl::singleton()->disableCaching();
+			HTTPCacheControl::singleton()->disableCache(true);
 		}
 		return true;
 	}

--- a/control/FlushRequestFilter.php
+++ b/control/FlushRequestFilter.php
@@ -18,6 +18,9 @@ class FlushRequestFilter implements RequestFilter {
 	}
 
 	public function postRequest(SS_HTTPRequest $request, SS_HTTPResponse $response, DataModel $model) {
+		if(array_key_exists('flush', $request->getVars())) {
+			HTTPCacheControl::singleton()->disableCaching();
+		}
 		return true;
 	}
 

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -294,7 +294,7 @@ class HTTP {
 	 */
 	public static function set_cache_age($age) {
 		self::$cache_age = $age;
-		HTTPCacheControl::inst()->setMaxAge($age);
+		HTTPCacheControl::singleton()->setMaxAge($age);
 	}
 
 	public static function register_modification_date($dateString) {
@@ -343,7 +343,7 @@ class HTTP {
 		// if http caching is disabled by config, disable it - used on dev environments due to frequently changing
 		// templates and other data
 		if ($config->get(__CLASS__, 'disable_http_cache')) {
-			HTTPCacheControl::inst()->disableCaching();
+			HTTPCacheControl::singleton()->disableCaching();
 		}
 
 		// Populate $responseHeaders with all the headers that we want to build
@@ -356,7 +356,7 @@ class HTTP {
 			$requestHeaders = array_change_key_case(apache_request_headers(), CASE_LOWER);
 
 			if (array_key_exists('x-requested-with', $requestHeaders) && strtolower($requestHeaders['x-requested-with']) == 'xmlhttprequest') {
-				HTTPCacheControl::inst()->disableCaching();
+				HTTPCacheControl::singleton()->disableCaching();
 			}
 		}
 
@@ -392,21 +392,21 @@ class HTTP {
 			strstr($_SERVER['HTTP_USER_AGENT'], 'MSIE')==true &&
 			strstr($contentDisposition, 'attachment;')==true &&
 			(
-				HTTPCacheControl::inst()->hasDirective('no-cache') ||
-				HTTPCacheControl::inst()->hasDirective('no-store')
+				HTTPCacheControl::singleton()->hasDirective('no-cache') ||
+				HTTPCacheControl::singleton()->hasDirective('no-store')
 			)
 		) {
 			// IE6-IE8 have problems saving files when https and no-cache/no-store are used
 			// (http://support.microsoft.com/kb/323308)
 			// Note: this is also fixable by ticking "Do not save encrypted pages to disk" in advanced options.
-			HTTPCacheControl::inst()
+			HTTPCacheControl::singleton()
 				->privateCache()
 				->removeDirective('no-cache')
 				->removeDirective('no-store');
 		}
 
 		if (!empty($cacheControlHeaders)) {
-			HTTPCacheControl::inst()->setDirectivesFromArray($cacheControlHeaders);
+			HTTPCacheControl::singleton()->setDirectivesFromArray($cacheControlHeaders);
 		}
 
 		if (self::$modification_date) {
@@ -414,7 +414,7 @@ class HTTP {
 		}
 
 		// if we can store the cache responses we should generate and send etags
-		if (!HTTPCacheControl::inst()->hasDirective('no-store')) {
+		if (!HTTPCacheControl::singleton()->hasDirective('no-store')) {
 
 			// Chrome ignores Varies when redirecting back (http://code.google.com/p/chromium/issues/detail?id=79758)
 			// which means that if you log out, you get redirected back to a page which Chrome then checks against
@@ -446,11 +446,11 @@ class HTTP {
 			}
 		}
 
-		if (HTTPCacheControl::inst()->hasDirective('max-age')) {
-			$expires = time() + HTTPCacheControl::inst()->getDirective('max-age');
+		if (HTTPCacheControl::singleton()->hasDirective('max-age')) {
+			$expires = time() + HTTPCacheControl::singleton()->getDirective('max-age');
 			$responseHeaders["Expires"] = self::gmt_date($expires);
 		}
-		
+
 		// etag needs to be a quoted string according to HTTP spec
 		if (!empty($responseHeaders['ETag']) && 0 !== strpos($responseHeaders['ETag'], '"')) {
 			$responseHeaders['ETag'] = sprintf('"%s"', $responseHeaders['ETag']);
@@ -469,9 +469,9 @@ class HTTP {
 		}
 
 		if ($body) {
-			HTTPCacheControl::inst()->applyToResponse($body);
+			HTTPCacheControl::singleton()->applyToResponse($body);
 		} elseif (!headers_sent()) {
-			header('Cache-Control: ' . HTTPCacheControl::inst()->generateCacheHeader());
+			header('Cache-Control: ' . HTTPCacheControl::singleton()->generateCacheHeader());
 		}
 	}
 

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -369,8 +369,7 @@ class HTTP {
 		else {
 			if($body) {
 				// Grab header for checking. Unfortunately HTTPRequest uses a mistyped variant.
-				$contentDisposition = $body->getHeader('Content-disposition');
-				if (!$contentDisposition) $contentDisposition = $body->getHeader('Content-Disposition');
+				$contentDisposition = $body->getHeader('Content-disposition', true);
 			}
 
 			if(

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -398,7 +398,8 @@ class HTTP {
 
 		// Errors disable cache (unless some errors are cached intentionally by usercode)
 		if ($body && $body->isError()) {
-			$cacheControl->disableCache();
+			// Even if publicCache(true) is specfied, errors will be uncachable
+			$cacheControl->disableCache(true);
 		}
 
 		// If sessions exist we assume that the responses should not be cached by CDNs / proxies as we are

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -543,7 +543,7 @@ class HTTP {
 	/**
 	 * Combine vary strings
 	 *
-	 * @param string ...$vary Each vary as a separate arg
+	 * @param string $vary,... Each vary as a separate arg
 	 * @return string
 	 */
 	protected static function combineVary($vary)
@@ -551,7 +551,9 @@ class HTTP {
 		$varies = array();
 		foreach (func_get_args() as $arg) {
 			$argVaries = preg_split("/\s*,\s*/", trim($arg));
-			$varies = array_merge($varies, $argVaries);
+			if ($argVaries) {
+				$varies = array_merge($varies, $argVaries);
+			}
 		}
 		return implode(', ', array_unique($varies));
 	}

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -363,6 +363,20 @@ class HTTP {
 			// varying according to user-agent.
 			$vary = $config->get('HTTP', 'vary');
 			if ($vary && strlen($vary)) {
+				if ($body) {
+					// split the current vary header into it's parts and merge it with the config settings
+					// to create a list of unique vary values
+					if ($body->getHeader('Vary')) {
+						$currentVary = explode(',', $body->getHeader('Vary'));
+					} else {
+						$currentVary = array();
+					}
+					$vary = explode(',', $vary);
+					$vary = array_merge($currentVary, $vary);
+					$vary = array_map('trim', $vary);
+					$vary = array_unique($vary);
+					$vary = implode(', ', $vary);
+				}
 				$responseHeaders['Vary'] = $vary;
 			}
 		}

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -341,9 +341,9 @@ class HTTP {
 		$config = Config::inst()->forClass(__CLASS__);
 
 		// if http caching is disabled by config, disable it - used on dev environments due to frequently changing
-		// templates and other data
+		// templates and other data. will be overridden by forced publicCache() or privateCache() calls
 		if ($config->get('disable_http_cache')) {
-			HTTPCacheControl::singleton()->disableCaching();
+			HTTPCacheControl::singleton()->disableCache();
 		}
 
 		// Populate $responseHeaders with all the headers that we want to build
@@ -356,7 +356,7 @@ class HTTP {
 			$requestHeaders = array_change_key_case(apache_request_headers(), CASE_LOWER);
 
 			if (array_key_exists('x-requested-with', $requestHeaders) && strtolower($requestHeaders['x-requested-with']) == 'xmlhttprequest') {
-				HTTPCacheControl::singleton()->disableCaching();
+				HTTPCacheControl::singleton()->disableCache(true);
 			}
 		}
 
@@ -400,11 +400,12 @@ class HTTP {
 			// (http://support.microsoft.com/kb/323308)
 			// Note: this is also fixable by ticking "Do not save encrypted pages to disk" in advanced options.
 			HTTPCacheControl::singleton()
-				->privateCache()
+				->privateCache(true)
 				->removeDirective('no-cache')
 				->removeDirective('no-store');
 		}
 
+		// TODO: These risk overriding nocache / privatecache calls. Perhaps this should only be applied if caching is unspecified or specified as public
 		if (!empty($cacheControlHeaders)) {
 			HTTPCacheControl::singleton()->setDirectivesFromArray($cacheControlHeaders);
 		}

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -550,7 +550,7 @@ class HTTP {
 	{
 		$varies = array();
 		foreach (func_get_args() as $arg) {
-			$argVaries = preg_split("/\s*,\s*/", trim($arg));
+			$argVaries = array_filter(preg_split("/\s*,\s*/", trim($arg)));
 			if ($argVaries) {
 				$varies = array_merge($varies, $argVaries);
 			}

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -348,7 +348,6 @@ class HTTP {
 
 		// Populate $responseHeaders with all the headers that we want to build
 		$responseHeaders = array();
-		$cacheControlHeaders = $config->get('cache_control');
 
 		// if no caching ajax requests, disable ajax if is ajax request
 		// why are we using apache_request_headers here when we use `$_SERVER` later to inspect request headers?
@@ -403,11 +402,6 @@ class HTTP {
 				->privateCache(true)
 				->removeDirective('no-cache')
 				->removeDirective('no-store');
-		}
-
-		// TODO: These risk overriding nocache / privatecache calls. Perhaps this should only be applied if caching is unspecified or specified as public
-		if (!empty($cacheControlHeaders)) {
-			HTTPCacheControl::singleton()->setDirectivesFromArray($cacheControlHeaders);
 		}
 
 		if (self::$modification_date) {

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -338,21 +338,21 @@ class HTTP {
 			return;
 		}
 
-		$config = Config::inst();
+		$config = Config::inst()->forClass(__CLASS__);
 
 		// if http caching is disabled by config, disable it - used on dev environments due to frequently changing
 		// templates and other data
-		if ($config->get(__CLASS__, 'disable_http_cache')) {
+		if ($config->get('disable_http_cache')) {
 			HTTPCacheControl::singleton()->disableCaching();
 		}
 
 		// Populate $responseHeaders with all the headers that we want to build
 		$responseHeaders = array();
-		$cacheControlHeaders = Config::inst()->get(__CLASS__, 'cache_control');
+		$cacheControlHeaders = $config->get('cache_control');
 
 		// if no caching ajax requests, disable ajax if is ajax request
 		// why are we using apache_request_headers here when we use `$_SERVER` later to inspect request headers?
-		if (!$config->get(__CLASS__, 'cache_ajax_requests') && function_exists('apache_request_headers')) {
+		if (!$config->get('cache_ajax_requests') && function_exists('apache_request_headers')) {
 			$requestHeaders = array_change_key_case(apache_request_headers(), CASE_LOWER);
 
 			if (array_key_exists('x-requested-with', $requestHeaders) && strtolower($requestHeaders['x-requested-with']) == 'xmlhttprequest') {
@@ -360,7 +360,7 @@ class HTTP {
 			}
 		}
 
-		$vary = $config->get(__CLASS__, 'vary');
+		$vary = $config->get('vary');
 		if ($vary && strlen($vary)) {
 			if ($body) {
 				// split the current vary header into it's parts and merge it with the config settings

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -449,6 +449,9 @@ class HTTP {
 			$responseHeaders['ETag'] = sprintf('"%s"', $responseHeaders['ETag']);
 		}
 
+		// Merge with cache control headers
+		$responseHeaders = array_merge($responseHeaders, $cacheControl->generateHeaders());
+
 		// Now that we've generated them, either output them or attach them to the SS_HTTPResponse as appropriate
 		foreach($responseHeaders as $k => $v) {
 			if($body) {
@@ -459,12 +462,6 @@ class HTTP {
 			} elseif(!headers_sent()) {
 				header("$k: $v");
 			}
-		}
-
-		if ($body) {
-			$cacheControl->applyToResponse($body);
-		} elseif (!headers_sent()) {
-			header('Cache-Control: ' . $cacheControl->generateCacheHeader());
 		}
 	}
 

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -326,13 +326,13 @@ class HTTP {
 			$body = null;
 		}
 
-		// Development sites have frequently changing templates; this can get stuffed up by the code
-		// below.
-		if(Director::isDev()) $cacheAge = 0;
-
 		// The headers have been sent and we don't have an SS_HTTPResponse object to attach things to; no point in
 		// us trying.
 		if(headers_sent() && !$body) return;
+
+		// Development sites have frequently changing templates; this can get stuffed up by the code
+		// below.
+		if(Director::isDev()) $cacheAge = 0;
 
 		// Populate $responseHeaders with all the headers that we want to build
 		$responseHeaders = array();

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -374,7 +374,11 @@ class HTTP {
 
 		// Warn if already assigned cache-control headers
 		if ($body && $body->getHeader('Cache-Control')) {
-			trigger_error("Cache-Control header has already been set", E_USER_WARNING);
+			trigger_error(
+				'Cache-Control header has already been set. '
+				. 'Please use HTTPCacheControl API to set caching options instead.',
+				E_USER_WARNING
+			);
 			return;
 		}
 

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -360,7 +360,6 @@ class HTTP {
 	 *                            deprecated; in these cases, the headers are output directly.
 	 */
 	public static function add_cache_headers($body = null) {
-
 		// Validate argument
 		if($body && !($body instanceof SS_HTTPResponse)) {
 			user_error("HTTP::add_cache_headers() must be passed an SS_HTTPResponse object", E_USER_WARNING);
@@ -370,6 +369,10 @@ class HTTP {
 		// The headers have been sent and we don't have an SS_HTTPResponse object to attach things to; no point in
 		// us trying.
 		if(headers_sent() && !$body) {
+			return;
+		}
+		// Skip already assigned cache-control headers
+		if ($body && $body->getHeader('Cache-Control')) {
 			return;
 		}
 

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -371,8 +371,10 @@ class HTTP {
 		if(headers_sent() && !$body) {
 			return;
 		}
-		// Skip already assigned cache-control headers
+
+		// Warn if already assigned cache-control headers
 		if ($body && $body->getHeader('Cache-Control')) {
+			trigger_error("Cache-Control header has already been set", E_USER_WARNING);
 			return;
 		}
 

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -30,6 +30,12 @@ class HTTP {
 	private static $cache_ajax_requests = true;
 
 	/**
+	 * @config
+	 * @var bool
+	 */
+	private static $disable_http_cache = false;
+
+	/**
 	 * Turns a local system filename into a URL by comparing it to the script
 	 * filename.
 	 *
@@ -332,16 +338,16 @@ class HTTP {
 			return;
 		}
 
-		// Development sites have frequently changing templates; this can get stuffed up by the code
-		// below.
-		if(Director::isDev()) {
+		$config = Config::inst();
+
+		// if http caching is disabled by config, disable it - used on dev environments due to frequently changing
+		// templates and other data
+		if ($config->get(__CLASS__, 'disable_http_cache')) {
 			HTTPCacheControl::inst()->disableCaching();
 		}
 
 		// Populate $responseHeaders with all the headers that we want to build
 		$responseHeaders = array();
-
-		$config = Config::inst();
 		$cacheControlHeaders = Config::inst()->get(__CLASS__, 'cache_control');
 
 		// if no caching ajax requests, disable ajax if is ajax request

--- a/control/HTTP.php
+++ b/control/HTTP.php
@@ -6,6 +6,7 @@
  *
  * @package framework
  * @subpackage misc
+ * @see https://docs.silverstripe.org/en/developer_guides/performance/http_cache_headers/
  */
 class HTTP {
 

--- a/control/HTTPCacheControl.php
+++ b/control/HTTPCacheControl.php
@@ -432,4 +432,11 @@ class HTTPCacheControl extends SS_Object {
 			'Cache-Control' => $this->generateCacheHeader(),
 		);
 	}
+
+	/**
+	 * Reset registered http cache control and force a fresh instance to be built
+	 */
+	public static function reset() {
+		Injector::inst()->unregisterNamedObject(__CLASS__);
+	}
 }

--- a/control/HTTPCacheControl.php
+++ b/control/HTTPCacheControl.php
@@ -31,22 +31,22 @@ class HTTPCacheControl extends SS_Object {
 	/**
 	 * Forcing level forced, optionally combined with one of the below.
 	 */
-	private const LEVEL_FORCED = 10;
+	const LEVEL_FORCED = 10;
 
 	/**
 	 * Forcing level caching disabled. Overrides public/private.
 	 */
-	private const LEVEL_DISABLED = 3;
+	const LEVEL_DISABLED = 3;
 
 	/**
 	 * Forcing level private-cached. Overrides public.
 	 */
-	private const LEVEL_PRIVATE = 2;
+	const LEVEL_PRIVATE = 2;
 
 	/**
 	 * Forcing level public cached. Lowest priority.
 	 */
-	private const LEVEL_PUBLIC = 1;
+	const LEVEL_PUBLIC = 1;
 
 
 	/**

--- a/control/HTTPCacheControl.php
+++ b/control/HTTPCacheControl.php
@@ -85,7 +85,21 @@ class HTTPCacheControl extends SS_Object {
 		}
 	}
 
-	protected function allowChange($level, $force)
+	/**
+	 * Instruct the cache to apply a change with a given level, optionally
+	 * modifying it with a force flag to increase priority of this action.
+	 *
+	 * If the apply level was successful, the change is made and the internal level
+	 * threshold is incremented.
+	 *
+	 * @param int $level Priority of the given change
+	 * @param bool $force If usercode has requested this action is forced to a higher priority.
+	 * Note: Even if $force is set to true, other higher-priority forced changes can still
+	 * cause a change to be rejected if it is below the required threshold.
+	 * @return bool True if the given change is accepted, and that the internal
+	 * level threshold is updated (if necessary) to the new minimum level.
+	 */
+	protected function applyChangeLevel($level, $force)
 	{
 		$forcingLevel = $level + ($force ? self::LEVEL_FORCED : 0);
 		if ($forcingLevel < $this->forcingLevel) {
@@ -283,7 +297,7 @@ class HTTPCacheControl extends SS_Object {
 	public function enableCache($force = false)
 	{
 		// Only execute this if its forcing level is high enough
-		if (!$this->allowChange(self::LEVEL_ENABLED, $force)) {
+		if (!$this->applyChangeLevel(self::LEVEL_ENABLED, $force)) {
 			SS_Log::log("Call to enableCache($force) didn't execute as it's lower priority than a previous call", SS_Log::DEBUG);
 			return $this;
 		}
@@ -311,7 +325,7 @@ class HTTPCacheControl extends SS_Object {
 	public function disableCache($force = false)
 	{
 		// Only execute this if its forcing level is high enough
-		if (!$this->allowChange(self::LEVEL_DISABLED, $force )) {
+		if (!$this->applyChangeLevel(self::LEVEL_DISABLED, $force )) {
 			SS_Log::log("Call to disableCache($force) didn't execute as it's lower priority than a previous call", SS_Log::DEBUG);
 			return $this;
 		}
@@ -336,7 +350,7 @@ class HTTPCacheControl extends SS_Object {
 	public function privateCache($force = false)
 	{
 		// Only execute this if its forcing level is high enough
-		if (!$this->allowChange(self::LEVEL_PRIVATE, $force)) {
+		if (!$this->applyChangeLevel(self::LEVEL_PRIVATE, $force)) {
 			SS_Log::log("Call to privateCache($force) didn't execute as it's lower priority than a previous call", SS_Log::DEBUG);
 			return $this;
 		}
@@ -361,7 +375,7 @@ class HTTPCacheControl extends SS_Object {
 	public function publicCache($force = false)
 	{
 		// Only execute this if its forcing level is high enough
-		if (!$this->allowChange(self::LEVEL_PUBLIC, $force)) {
+		if (!$this->applyChangeLevel(self::LEVEL_PUBLIC, $force)) {
 			SS_Log::log("Call to publicCache($force) didn't execute as it's lower priority than a previous call", SS_Log::DEBUG);
 			return $this;
 		}

--- a/control/HTTPCacheControl.php
+++ b/control/HTTPCacheControl.php
@@ -48,6 +48,11 @@ class HTTPCacheControl extends SS_Object {
 	 */
 	const LEVEL_PUBLIC = 1;
 
+	/**
+	 * Forcing level caching enabled.
+	 */
+	const LEVEL_ENABLED = 0;
+
 
 	/**
 	 * A list of allowed cache directives for HTTPResponses
@@ -258,6 +263,27 @@ class HTTPCacheControl extends SS_Object {
 		} else {
 			$this->removeDirective('must-revalidate');
 		}
+		return $this;
+	}
+
+	/**
+	 * Helper method to turn the cache control header into a cacheable state
+	 *
+	 * Removes `no-store` and `no-cache` directives; other directives will remain in place.
+	 *
+	 * @param bool $force
+	 * @return $this
+	 */
+	public function enableCache($force = false)
+	{
+		// Only execute this if its forcing level is high enough
+		if (!$this->allowChange(self::LEVEL_ENABLED, $force)) {
+			SS_Log::log("Call to enableCache($force) didn't execute as it's lower priority than a previous call", SS_Log::DEBUG);
+			return $this;
+		}
+
+		$this->removeDirective('no-store');
+		$this->removeDirective('no-cache');
 		return $this;
 	}
 

--- a/control/HTTPCacheControl.php
+++ b/control/HTTPCacheControl.php
@@ -267,6 +267,7 @@ class HTTPCacheControl extends SS_Object {
 		// Only exeucute this if its forcing level is high enough
 		$forcingLevel = self::LEVEL_DISABLED + ($force ? self::LEVEL_FORCED : 0);
 		if ($forcingLevel < $this->forcingLevel) {
+			SS_Log::log("Call to publicCache($force) didn't execute as it's lower priority than a previous call", SS_Log::DEBUG);
 			return;
 		}
 		$this->forcingLevel = $forcingLevel;
@@ -293,6 +294,7 @@ class HTTPCacheControl extends SS_Object {
 		// Only exeucute this if its forcing level is high enough
 		$forcingLevel = self::LEVEL_PRIVATE + ($force ? self::LEVEL_FORCED : 0);
 		if ($forcingLevel < $this->forcingLevel) {
+			SS_Log::log("Call to privateCache($force) didn't execute as it's lower priority than a previous call", SS_Log::DEBUG);
 			return;
 		}
 		$this->forcingLevel = $forcingLevel;
@@ -318,6 +320,7 @@ class HTTPCacheControl extends SS_Object {
 		// Only exeucute this if its forcing level is high enough
 		$forcingLevel = self::LEVEL_PUBLIC + ($force ? self::LEVEL_FORCED : 0);
 		if ($forcingLevel < $this->forcingLevel) {
+			SS_Log::log("Call to publicCache($force) didn't execute as it's lower priority than a previous call", SS_Log::DEBUG);
 			return;
 		}
 		$this->forcingLevel = $forcingLevel;

--- a/control/HTTPCacheControl.php
+++ b/control/HTTPCacheControl.php
@@ -80,6 +80,16 @@ class HTTPCacheControl extends SS_Object {
 		}
 	}
 
+	protected function allowChange($level, $force)
+	{
+		$forcingLevel = $level + ($force ? self::LEVEL_FORCED : 0);
+		if ($forcingLevel < $this->forcingLevel) {
+			return false;
+		}
+		$this->forcingLevel = $forcingLevel;
+		return true;
+	}
+
 	/**
 	 * Low level method for setting directives include any experimental or custom ones added via config
 	 *
@@ -264,13 +274,11 @@ class HTTPCacheControl extends SS_Object {
 	 */
 	public function disableCache($force = false)
 	{
-		// Only exeucute this if its forcing level is high enough
-		$forcingLevel = self::LEVEL_DISABLED + ($force ? self::LEVEL_FORCED : 0);
-		if ($forcingLevel < $this->forcingLevel) {
-			SS_Log::log("Call to publicCache($force) didn't execute as it's lower priority than a previous call", SS_Log::DEBUG);
-			return;
+		// Only execute this if its forcing level is high enough
+		if (!$this->allowChange(self::LEVEL_DISABLED, $force )) {
+			SS_Log::log("Call to disableCache($force) didn't execute as it's lower priority than a previous call", SS_Log::DEBUG);
+			return $this;
 		}
-		$this->forcingLevel = $forcingLevel;
 
 		$this->state = array(
 			'no-cache' => null,
@@ -291,13 +299,11 @@ class HTTPCacheControl extends SS_Object {
 	 */
 	public function privateCache($force = false)
 	{
-		// Only exeucute this if its forcing level is high enough
-		$forcingLevel = self::LEVEL_PRIVATE + ($force ? self::LEVEL_FORCED : 0);
-		if ($forcingLevel < $this->forcingLevel) {
+		// Only execute this if its forcing level is high enough
+		if (!$this->allowChange(self::LEVEL_PRIVATE, $force)) {
 			SS_Log::log("Call to privateCache($force) didn't execute as it's lower priority than a previous call", SS_Log::DEBUG);
-			return;
+			return $this;
 		}
-		$this->forcingLevel = $forcingLevel;
 
 		// Update the directives
 		$this->setDirective('private');
@@ -317,13 +323,11 @@ class HTTPCacheControl extends SS_Object {
 	 */
 	public function publicCache($force = false)
 	{
-		// Only exeucute this if its forcing level is high enough
-		$forcingLevel = self::LEVEL_PUBLIC + ($force ? self::LEVEL_FORCED : 0);
-		if ($forcingLevel < $this->forcingLevel) {
+		// Only execute this if its forcing level is high enough
+		if (!$this->allowChange(self::LEVEL_PUBLIC, $force)) {
 			SS_Log::log("Call to publicCache($force) didn't execute as it's lower priority than a previous call", SS_Log::DEBUG);
-			return;
+			return $this;
 		}
-		$this->forcingLevel = $forcingLevel;
 
 		$this->setDirective('public');
 		$this->removeDirective('private');

--- a/control/HTTPCacheControl.php
+++ b/control/HTTPCacheControl.php
@@ -396,7 +396,10 @@ class HTTPCacheControl extends SS_Object {
 	 */
 	public function applyToResponse($response)
 	{
-		$response->addHeader('Cache-Control', $this->generateCacheHeader());
+		$headers = $this->generateHeaders();
+		foreach ($headers as $name => $value) {
+			$response->addHeader($name, $value);
+		}
 		return $this;
 	}
 
@@ -405,7 +408,7 @@ class HTTPCacheControl extends SS_Object {
 	 *
 	 * @return string
 	 */
-	public function generateCacheHeader()
+	protected function generateCacheHeader()
 	{
 		$cacheControl = array();
 		foreach ($this->state as $directive => $value) {
@@ -416,6 +419,18 @@ class HTTPCacheControl extends SS_Object {
 			}
 		}
 		return implode(', ', $cacheControl);
+	}
+
+	/**
+	 * Generate all headers to output
+	 *
+	 * @return array
+	 */
+	public function generateHeaders()
+	{
+		return array(
+			'Cache-Control' => $this->generateCacheHeader(),
+		);
 	}
 
 }

--- a/control/HTTPCacheControl.php
+++ b/control/HTTPCacheControl.php
@@ -3,7 +3,7 @@
 /**
  * Class HTTPCacheControl
  *
- *
+ * @see https://docs.silverstripe.org/en/developer_guides/performance/http_cache_headers/
  */
 class HTTPCacheControl extends SS_Object {
 
@@ -267,11 +267,17 @@ class HTTPCacheControl extends SS_Object {
 	}
 
 	/**
-	 * Helper method to turn the cache control header into a cacheable state
+	 * Simple way to set cache control header to a cacheable state.
+	 * Use this method over `publicCache()` if you are unsure about caching details.
 	 *
 	 * Removes `no-store` and `no-cache` directives; other directives will remain in place.
+	 * Use alongside `setMaxAge()` to indicate caching.
 	 *
-	 * @param bool $force
+	 * Does not set `public` directive. Usually, `setMaxAge()` is sufficient. Use `publicCache()` if this is explicitly required.
+	 * See https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#public_vs_private
+	 *
+	 * @see https://docs.silverstripe.org/en/developer_guides/performance/http_cache_headers/
+	 * @param bool $force Force the cache to public even if its unforced private or public
 	 * @return $this
 	 */
 	public function enableCache($force = false)
@@ -288,14 +294,18 @@ class HTTPCacheControl extends SS_Object {
 	}
 
 	/**
-	 * Helper method to turn the cache control header into a non-cacheable state
+	 * Simple way to set cache control header to a non-cacheable state.
+	 * Use this method over `privateCache()` if you are unsure about caching details.
+	 * Takes precendence over unforced `enableCache()`, `privateCache()` or `publicCache()` calls.
 	 *
 	 * Removes all state and replaces it with `no-cache, no-store, must-revalidate`. Although `no-store` is sufficient
 	 * the others are added under recommendation from Mozilla (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Examples)
 	 *
-	 * This will take precendence over unforced privateCache / publicCache calls
+	 * Does not set `private` directive, use `privateCache()` if this is explicitly required.
+	 * See https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#public_vs_private
 	 *
-	 * @param bool $force Force the cache to private even if it's forced private or public
+	 * @see https://docs.silverstripe.org/en/developer_guides/performance/http_cache_headers/
+	 * @param bool $force Force the cache to diabled even if it's forced private or public
 	 * @return $this
 	 */
 	public function disableCache($force = false)
@@ -315,11 +325,11 @@ class HTTPCacheControl extends SS_Object {
 	}
 
 	/**
+	 * Advanced way to set cache control header to a non-cacheable state.
 	 * Indicates that the response is intended for a single user and must not be stored by a shared cache.
-	 * A private cache may store the response.
+	 * A private cache (e.g. Web Browser) may store the response. Also removes `public` as this is a contradictory directive.
 	 *
-	 * Also removes `private` as this is a contradictory directive
-	 *
+	 * @see https://docs.silverstripe.org/en/developer_guides/performance/http_cache_headers/
 	 * @param bool $force Force the cache to private even if it's forced public
 	 * @return $this
 	 */
@@ -340,10 +350,11 @@ class HTTPCacheControl extends SS_Object {
 	}
 
 	/**
- 	 * Indicates that the response may be cached by any cache. (eg: CDNs, Proxies, Web browsers)
+ 	 * Advanced way to set cache control header to a cacheable state.
+	 * Indicates that the response may be cached by any cache. (eg: CDNs, Proxies, Web browsers)
+	 * Also removes `private` as this is a contradictory directive
 	 *
-	 * Also removes `public` as this is a contradictory directive
-	 *
+	 * @see https://docs.silverstripe.org/en/developer_guides/performance/http_cache_headers/
 	 * @param bool $force Force the cache to public even if it's private, unless it's been forced private
 	 * @return $this
 	 */

--- a/control/HTTPCacheControl.php
+++ b/control/HTTPCacheControl.php
@@ -5,7 +5,7 @@
  *
  *
  */
-class HTTPCacheControl {
+class HTTPCacheControl extends SS_Object {
 
 	/**
 	 * @var static
@@ -35,22 +35,9 @@ class HTTPCacheControl {
 		'no-transform',
 	);
 
-	/**
-	 * @return static
-	 */
-	public static function inst()
-	{
-		return static::$inst ?: static::$inst = new static();
-	}
-
-	public static function reset()
-	{
-		static::$inst = null;
-	}
-
 	public function setDirective($directive, $value = null)
 	{
-		$allowedDirectives = Config::inst()->get(__CLASS__, 'allowed_directives');
+		$allowedDirectives = $this->config()->get('allowed_directives');
 		$directive = strtolower($directive);
 		if (in_array($directive, $allowedDirectives)) {
 			$this->state[$directive] = $value;

--- a/control/HTTPCacheControl.php
+++ b/control/HTTPCacheControl.php
@@ -18,11 +18,7 @@ class HTTPCacheControl extends SS_Object {
 	 *
 	 * @var array
 	 */
-	private $state = array(
-		'no-cache' => null,
-		'no-store' => null,
-		'must-revalidate' => null,
-	);
+	private $state = array();
 
 	/**
 	 * Forcing level of previous setting; higher number wins
@@ -73,6 +69,16 @@ class HTTPCacheControl extends SS_Object {
 		'no-store',
 		'no-transform',
 	);
+
+	public function __construct()
+	{
+		parent::__construct();
+
+		// If we've not been provided an initial state, then grab HTTP.cache_contrpl from config
+		if (!$this->state) {
+			$this->setDirectivesFromArray(Config::inst()->get('HTTP', 'cache_control'));
+		}
+	}
 
 	/**
 	 * Low level method for setting directives include any experimental or custom ones added via config

--- a/control/HTTPCacheControl.php
+++ b/control/HTTPCacheControl.php
@@ -432,5 +432,4 @@ class HTTPCacheControl extends SS_Object {
 			'Cache-Control' => $this->generateCacheHeader(),
 		);
 	}
-
 }

--- a/control/HTTPCacheControl.php
+++ b/control/HTTPCacheControl.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * Class HTTPCacheControl
+ *
+ *
+ */
+class HTTPCacheControl {
+
+	/**
+	 * @var static
+	 */
+	private static $inst;
+
+	private $state = array();
+
+	/**
+	 * A list of allowed cache directives for HTTPResponses
+	 *
+	 * This doesn't include any experimental directives,
+	 * use the config system to add to these if you want to enable them
+	 *
+	 * @config
+	 * @var array
+	 */
+	private static $allowed_directives = array(
+		'public',
+		'private',
+		'no-cache',
+		'max-age',
+		's-maxage',
+		'must-revalidate',
+		'proxy-revalidate',
+		'no-store',
+		'no-transform',
+	);
+
+	/**
+	 * @return static
+	 */
+	public static function inst()
+	{
+		return static::$inst ?: static::$inst = new static();
+	}
+
+	public static function reset()
+	{
+		static::$inst = null;
+	}
+
+	public function setDirective($directive, $value = null)
+	{
+		$allowedDirectives = Config::inst()->get(__CLASS__, 'allowed_directives');
+		$directive = strtolower($directive);
+		if (in_array($directive, $allowedDirectives)) {
+			$this->state[$directive] = $value;
+		} else {
+			throw new InvalidArgumentException('Directive ' . $directive . ' is not allowed');
+		}
+		return $this;
+	}
+
+	public function setDirectivesFromArray($directives)
+	{
+		foreach ($directives as $directive => $value) {
+			if (is_null($value)) {
+				$this->removeDirective($directive);
+			} else {
+				if ($value && (is_bool($value) || strtolower($value) === 'true')) {
+					$value = null;
+				}
+				$this->setDirective($directive, $value);
+			}
+		}
+		return $this;
+	}
+
+	public function removeDirective($directive)
+	{
+		unset($this->state[strtolower($directive)]);
+		return $this;
+	}
+
+	public function hasDirective($directive)
+	{
+		return array_key_exists(strtolower($directive), $this->state);
+	}
+
+	public function getDirective($directive)
+	{
+		if ($this->hasDirective($directive)) {
+			return $this->state[strtolower($directive)];
+		}
+		return false;
+	}
+
+	public function setNoStore($noStore = true)
+	{
+		if ($noStore) {
+			$this->setDirective('no-store');
+			$this->removeDirective('max-age');
+			$this->removeDirective('s-maxage');
+		} else {
+			$this->removeDirective('no-store');
+		}
+		return $this;
+	}
+
+	public function setNoCache($noCache = true)
+	{
+		if ($noCache) {
+			$this->setDirective('no-cache');
+		} else {
+			$this->removeDirective('no-cache');
+		}
+		return $this;
+	}
+
+	public function setPublic()
+	{
+		$this->setDirective('public');
+		$this->removeDirective('private');
+		return $this;
+	}
+
+	public function setPrivate()
+	{
+		$this->setDirective('private');
+		$this->removeDirective('public');
+		return $this;
+	}
+
+	public function setMaxAge($age)
+	{
+		$this->setDirective('max-age', $age);
+		return $this;
+	}
+
+	public function setSharedMaxAge($age)
+	{
+		$this->setDirective('s-maxage', $age);
+		return $this;
+	}
+
+	public function setMustRevalidate($mustRevalidate = true)
+	{
+		if ($mustRevalidate) {
+			$this->setDirective('must-revalidate');
+		} else {
+			$this->removeDirective('must-revalidate');
+		}
+		return $this;
+	}
+
+	public function disableCaching()
+	{
+		$this->state = array(
+			'no-cache' => null,
+			'no-store' => null,
+			'must-revalidate' => null,
+		);
+		return $this;
+	}
+
+	public function privateCache()
+	{
+		$this->setPrivate();
+		$this->setMustRevalidate();
+		return $this;
+	}
+
+	public function publicCache()
+	{
+		$this->setPublic();
+		return $this;
+	}
+
+	/**
+	 * @param SS_HTTPResponse $response
+	 *
+	 * @return $this
+	 */
+	public function applyToResponse($response)
+	{
+		$response->addHeader('Cache-Control', $this->generateCacheHeader());
+		return $this;
+	}
+
+	public function generateCacheHeader()
+	{
+		$cacheControl = array();
+		foreach ($this->state as $directive => $value) {
+			if (is_null($value)) {
+				$cacheControl[] = $directive;
+			} else {
+				$cacheControl[] = $directive . '=' . $value;
+			}
+		}
+		return implode(', ', $cacheControl);
+	}
+
+}

--- a/control/HTTPResponse.php
+++ b/control/HTTPResponse.php
@@ -189,9 +189,15 @@ class SS_HTTPResponse {
 	 * @param string $header
 	 * @returns null|string
 	 */
-	public function getHeader($header) {
-		if(isset($this->headers[$header]))
-			return $this->headers[$header];
+	public function getHeader($header, $anyCase = false) {
+		if ($anyCase) {
+			$headers = array_change_key_case($this->headers, CASE_LOWER);
+			$header = strtolower($header);
+		} else {
+			$headers = $this->headers;
+		}
+		if(isset($headers[$header]))
+			return $headers[$header];
 		}
 
 	/**

--- a/control/Session.php
+++ b/control/Session.php
@@ -595,6 +595,9 @@ class Session {
 	 * @param string $sid Start the session with a specific ID
 	 */
 	public static function start($sid = null) {
+		// When sessions start, we assume that the responses should not be cached by CDNs / proxies as we are
+		// likely to be supplying information relevant to the current user only
+		HTTPCacheControl::singleton()->privateCache();
 		self::current_session()->inst_start($sid);
 	}
 

--- a/control/Session.php
+++ b/control/Session.php
@@ -595,9 +595,6 @@ class Session {
 	 * @param string $sid Start the session with a specific ID
 	 */
 	public static function start($sid = null) {
-		// When sessions start, we assume that the responses should not be cached by CDNs / proxies as we are
-		// likely to be supplying information relevant to the current user only
-		HTTPCacheControl::singleton()->privateCache();
 		self::current_session()->inst_start($sid);
 	}
 

--- a/control/VersionedRequestFilter.php
+++ b/control/VersionedRequestFilter.php
@@ -46,7 +46,7 @@ class VersionedRequestFilter implements RequestFilter {
 
 	public function postRequest(SS_HTTPRequest $request, SS_HTTPResponse $response, DataModel $model) {
 		if (Versioned::current_stage() !== Versioned::LIVE && !HTTPCacheControl::singleton()->hasDirective('no-store')) {
-			HTTPCacheControl::singleton()->privateCache();
+			HTTPCacheControl::singleton()->privateCache(true);
 		}
 		return true;
 	}

--- a/control/VersionedRequestFilter.php
+++ b/control/VersionedRequestFilter.php
@@ -44,6 +44,9 @@ class VersionedRequestFilter implements RequestFilter {
 	}
 
 	public function postRequest(SS_HTTPRequest $request, SS_HTTPResponse $response, DataModel $model) {
+		if (Versioned::current_stage() !== Versioned::LIVE && !HTTPCacheControl::singleton()->hasDirective('no-store')) {
+			HTTPCacheControl::singleton()->privateCache();
+		}
 		return true;
 	}
 

--- a/control/VersionedRequestFilter.php
+++ b/control/VersionedRequestFilter.php
@@ -34,6 +34,7 @@ class VersionedRequestFilter implements RequestFilter {
 			if(class_exists('SapphireTest', false) && SapphireTest::is_running_test()) {
 				throw new SS_HTTPResponse_Exception($response);
 			}
+			HTTP::add_cache_headers($response);
 			$response->output();
 			die;
 		}

--- a/dev/Log.php
+++ b/dev/Log.php
@@ -131,8 +131,8 @@ class SS_Log {
 	/**
 	 * Add a writer instance to the logger.
 	 * @param object $writer Zend_Log_Writer_Abstract instance
-	 * @param const $priority Priority. Possible values: SS_Log::ERR, SS_Log::WARN or SS_Log::NOTICE
-	 * @param $comparison Priority comparison operator.  Acts on the integer values of the error
+	 * @param int $priority Priority. Possible values: SS_Log::ERR, SS_Log::WARN or SS_Log::NOTICE
+	 * @param string $comparison Priority comparison operator.  Acts on the integer values of the error
 	 * levels, where more serious errors are lower numbers.  By default this is "=", which means only
 	 * the given priority will be logged.  Set to "<=" if you want to track errors of *at least*
 	 * the given priority.
@@ -151,7 +151,7 @@ class SS_Log {
 	 * error code, error line, error context (backtrace).
 	 *
 	 * @param mixed $message Exception object or array of error context variables
-	 * @param const $priority Priority. Possible values: SS_Log::ERR, SS_Log::WARN or SS_Log::NOTICE
+	 * @param int $priority Priority. Possible values: SS_Log::ERR, SS_Log::WARN or SS_Log::NOTICE
 	 * @param  mixed    $extras    Extra information to log in event
 	 */
 	public static function log($message, $priority, $extras = null) {

--- a/docs/en/02_Developer_Guides/03_Forms/04_Form_Security.md
+++ b/docs/en/02_Developer_Guides/03_Forms/04_Form_Security.md
@@ -65,7 +65,18 @@ application errors or edge cases.
 SilverStripe has no built-in protection for detailing with bots, captcha or other spam protection methods. This 
 functionality is available as an additional [Spam Protection](https://github.com/silverstripe/silverstripe-spamprotection) 
 module if required. The module provides an consistent API for allowing third-party spam protection handlers such as 
-[Recaptcha](http://www.google.com/recaptcha/intro/) and [Mollom](https://mollom.com/) to work within the `Form` API. 
+[Recaptcha](http://www.google.com/recaptcha/intro/) and [Mollom](https://mollom.com/) to work within the `Form` API.
+
+## Data disclosure through HTTP Caching (since 3.7.0)
+
+Forms, and particularly their responses, can contain sensitive data (such as when data is pre-populated or re-posted due
+to validation errors). This data can inadvertently be stored either in a user's browser cache or in an intermediary
+cache such as a CDN or other caching-proxy. If incorrect `Cache-Conrol` headers are used, private data may be cached and
+accessible publicly through the CDN.
+
+To ensure this doesn't happen SilverStripe adds `Cache-Control: no-store, no-cache, must-revalidate` headers to any 
+forms that have validators or security tokens (all of them by default) applied to them; this ensures that CDNs
+(and browsers) will not cache these pages.
 
 ## Related Documentation
 

--- a/docs/en/02_Developer_Guides/08_Performance/02_HTTP_Cache_Headers.md
+++ b/docs/en/02_Developer_Guides/08_Performance/02_HTTP_Cache_Headers.md
@@ -1,7 +1,125 @@
 title: HTTP Cache Headers
 summary: Set the correct HTTP cache headers for your responses.
 
-# Caching Headers
+# HTTP Cache Headers
+
+## Overview
+
+By default, SilverStripe sends headers which signal to HTTP caches
+that the response should be considered not cacheable.
+HTTP caches can either be intermediary caches (e.g. CDNs and proxies), or clients (e.g. browsers).
+The cache headers sent are `Cache-Control: no-store, no-cache, must-revalidate`;
+
+HTTP caching can be a great way to speed up your website, but needs to be properly applied.
+Getting it wrong can accidentally expose draft pages or other protected content.
+The [Google Web Fundamentals](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#public_vs_private)
+are a great way to learn about HTTP caching.
+
+## Cache Control Headers
+
+In order to support developers in making safe choices around HTTP caching,
+we're using a `HTTPCacheControl` class to control if a response
+should be considered public or private. This is an abstraction on existing
+lowlevel APIs like `HTTP::add_cache_headers()` and `SS_HTTPResponse->addHeader()`.
+
+The `HTTPCacheControl` API makes it easier to express your caching preferences
+without running the risk of overriding essential core safety measures.
+Most commonly, these APIs will prevent HTTP caching of draft content.
+
+It will also prevent content generated with an active session,
+since the system can't tell whether session data was used to vary the output.
+In this case, it's up to the developer to opt-in to caching,
+after ensuring that certain execution paths are safe despite of using sessions.
+
+The system behaviour does not guard against accidentally caching "private" content,
+since there are too many variations under which output could be considered private
+(e.g. a custom "approval" flag on a comment object). It is up to
+the developer to ensure caching is used appropriately there.
+
+The `HTTPCacheControl` class supplements the `HTTP` helper class.
+It comes with methods which let developers safely interact with the `Cache-Control` header.
+
+ * `disableCache()`: Disables caching in intermediary caches as well as HTTP clients.
+    Removes all state and replaces it with `no-cache, no-store, must-revalidate`.
+ * `privateCache()`: Disables caching in intermediary caches, but allows it in HTTP clients.
+    Sends `Cache-Control: private`.
+ * `publicCache()`: Enables caching in intermediary caches and HTTP clients.
+    Sends `Cache-Control: public`.
+    
+Each of these highlevel methods has a boolean `$force` parameter which determines
+their application priority regardless of execution order.
+The priority order is as followed, sorted in descending order
+(earlier items will overrule later items): 
+
+ * `disableCache($force=true)`
+ * `privateCache($force=true)`
+ * `publicCache($force=true)`
+ * `disableCache()`
+ * `privateCache()`
+ * `publicCache()`
+
+## Cache Control Examples
+
+Globally opting into HTTP caching for all page content.
+SilverStripe will still override this preference when a session is active,
+or draft content has been requested. 
+
+```php
+class Page_Controller extends ContentController
+{
+    public function init()
+    {
+        HTTPCacheControl::inst()
+           ->publicCache()
+           ->setMaxAge(60); // 1 minute
+
+        
+        parent::init();
+    }
+}
+```
+
+Opting out of HTTP caching in a particular controller action.
+
+```php
+class MyPage_Controller extends Page_Controller
+{
+    public function myprivateaction($request)
+    {
+        $response = $this->myPrivateResponse();
+        HTTPCacheControl::inst()
+           ->privateCache();
+        
+        return $response;
+    }
+}
+```
+
+Globally opting into HTTP caching for all page content, ignoring active session.
+This can be helpful in situations where forms are embedded on the website.
+SilverStripe will still override this preference when draft content has been requested.
+CAUTION: This mode relies on a developer examining each execution path to ensure
+that no session data is used to vary output. 
+
+Use case: By default, forms include a [CSRF token](/developer_guides/forms/form_security)
+which starts a session with a value that's unique to the visitor, which makes the output uncacheable.
+But any subsequent requests by this visitor will also carry a session, leading to uncacheable output
+for this visitor. This is the case even if the output does not contain any forms,
+and does not vary for this particular visitor.
+
+```php
+class Page_Controller extends ContentController
+{
+    public function init()
+    {
+        HTTPCacheControl::inst()
+           ->publicCache($force=true) // DANGER ZONE
+           ->setMaxAge(60); // 1 minute
+        
+        parent::init();
+    }
+}
+```
 
 By default, PHP adds caching headers that make the page appear purely dynamic. This isn't usually appropriate for most 
 sites, even ones that are updated reasonably frequently. SilverStripe overrides the default settings with the following 
@@ -14,40 +132,39 @@ headers:
   * Since a visitor cookie is set, the site won't be cached by proxies.
   * Ajax requests are never cached.
 
-## Customizing Cache Headers
+## Max Age
 
-### HTTP::set_cache_age
-	
-	:::php
-	HTTP::set_cache_age(0);
-
-Used to set the max-age component of the cache-control line, in seconds. Set it to 0 to disable caching; the "no-cache" 
-clause in `Cache-Control` and `Pragma` will be included.
-
-### HTTP::register_modification_date
+The cache age determines the lifetime of your cache, in seconds.
+It only takes effect if you instruct the cache control
+that your response is public in the first place (`setPublic()`).
+Note that `setMaxAge(0)` is NOT sufficient to disable caching in all cases.
 
 	:::php
-	HTTP::register_modification_date('2014-10-10');
+	HTTPCacheControl::singleton()
+	    ->setPublic()
+	    ->setMaxAge(60)
+
+### Last Modified
 
 Used to set the modification date to something more recent than the default. [api:DataObject::__construct] calls 
 [api:HTTP::register_modification_date(] whenever a record comes from the database ensuring the newest date is present.
 
-### Vary: cache header
+	:::php
+	HTTP::register_modification_date('2014-10-10');
 
-By default, SilverStripe will output a `Vary` header (used by upstream caches for determining uniqueness) 
-that looks like
+### Vary
+
+A `Vary` header tells caches which aspects of the response should be considered
+when calculating a cache key, usually in addition to the full URL path.
+By default, SilverStripe will output a `Vary` header with the following content: 
 
 ```
-Cookie, X-Forwarded-Protocol, User-Agent, Accept
+Vary: X-Requested-With, X-Forwarded-Protocol
 ```
 
-To change the value of the `Vary` header, you can change this value by specifying the header in configuration
+To change the value of the `Vary` header, you can change this value by specifying the header in configuration.
 
 ```yml
 HTTP:
   vary: ""
 ```
-
-
-
-

--- a/docs/en/02_Developer_Guides/08_Performance/02_HTTP_Cache_Headers.md
+++ b/docs/en/02_Developer_Guides/08_Performance/02_HTTP_Cache_Headers.md
@@ -28,7 +28,7 @@ The `HTTPCacheControl` API makes it easier to express your caching preferences
 without running the risk of overriding essential core safety measures.
 Most commonly, these APIs will prevent HTTP caching of draft content.
 
-It will also prevent content generated with an active session,
+It will also prevent caching of content generated with an active session,
 since the system can't tell whether session data was used to vary the output.
 In this case, it's up to the developer to opt-in to caching,
 after ensuring that certain execution paths are safe despite of using sessions.
@@ -94,9 +94,9 @@ The priority order is as followed, sorted in descending order
 
 ## Cache Control Examples
 
-Globally opting into HTTP caching for all page content.
-SilverStripe will still override this preference when a session is active,
-or draft content has been requested. 
+### Global opt-in for page content 
+
+Enable caching for all page content (through `Page_Controller`).
 
 ```php
 class Page_Controller extends ContentController
@@ -104,7 +104,7 @@ class Page_Controller extends ContentController
     public function init()
     {
         HTTPCacheControl::inst()
-           ->publicCache()
+           ->enableCache()
            ->setMaxAge(60); // 1 minute
 
         
@@ -113,7 +113,16 @@ class Page_Controller extends ContentController
 }
 ```
 
-Opting out of HTTP caching in a particular controller action.
+Note: SilverStripe will still override this preference when a session is active,
+a [CSRF token](/developer_guides/forms/form_security) token is present,
+or draft content has been requested.
+
+### Opt-out for a particular controller action
+
+If a controller output relies on session data, cookies,
+permission checks or other triggers for conditional output,
+you can disable caching either on a controller level
+(through `init()`) or for a particular action.
 
 ```php
 class MyPage_Controller extends Page_Controller
@@ -122,14 +131,19 @@ class MyPage_Controller extends Page_Controller
     {
         $response = $this->myPrivateResponse();
         HTTPCacheControl::inst()
-           ->privateCache();
+           ->disableCache();
         
         return $response;
     }
 }
 ```
 
-Globally opting into HTTP caching for all page content, ignoring active session.
+Note: SilverStripe will still override this preference when a session is active,
+a [CSRF token](/developer_guides/forms/form_security) token is present,
+or draft content has been requested. 
+
+### Global opt-in, ignoring session (advanced) 
+
 This can be helpful in situations where forms are embedded on the website.
 SilverStripe will still override this preference when draft content has been requested.
 CAUTION: This mode relies on a developer examining each execution path to ensure
@@ -147,13 +161,15 @@ class Page_Controller extends ContentController
     public function init()
     {
         HTTPCacheControl::inst()
-           ->publicCache($force=true) // DANGER ZONE
+           ->enableCache($force=true) // DANGER ZONE
            ->setMaxAge(60); // 1 minute
         
         parent::init();
     }
 }
 ```
+
+## Defaults
 
 By default, PHP adds caching headers that make the page appear purely dynamic. This isn't usually appropriate for most 
 sites, even ones that are updated reasonably frequently. SilverStripe overrides the default settings with the following 

--- a/docs/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
+++ b/docs/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
@@ -607,6 +607,15 @@ In a future release this behaviour will be changed to be on by default, and this
 variable will be no longer necessary, thus it will be necessary to always set
 SS_TRUSTED_PROXY_IPS if using a proxy.
 
+## HTTP Caching Headers
+
+Caching is hard. If you get it wrong, private or draft content might leak
+to unauthenticated users. We have created an abstraction which allows you to express
+your intent around HTTP caching without worrying too much about the details.
+See [/developer_guides/performances/http_cache_headers](Developer Guides > Performance > HTTP Cache Headers)
+for details on how to apply caching safely, and read Google's
+[Web Fundamentals on Caching](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching). 
+
 ##  Related
 
  * [http://silverstripe.org/security-releases/](http://silverstripe.org/security-releases/)

--- a/docs/en/04_Changelogs/3.7.0.md
+++ b/docs/en/04_Changelogs/3.7.0.md
@@ -1,4 +1,4 @@
-# 3.7.0 (unreleased)
+# 3.7.0
 
 ## SilverStripe 3.7 and PHP 7.2 and Object subclasses
 
@@ -67,3 +67,118 @@ Data that is not content sensitive can be cached across stages by simply opting 
 $cache = SS_Cache::factory('myapp', 'Output', array('disable-segmentation' => true));
 ``` 
 
+## HTTP Cache Header changes
+
+### Overview
+
+In order to support developers in making safe choices around HTTP caching,
+we've introduced a `HTTPCacheControl` class to control if a response
+should be considered public or private. This is an abstraction on existing
+lowlevel APIs like `HTTP::add_cache_headers()` and `SS_HTTPResponse->addHeader()`.
+
+This change introduces smaller but necessary changes to HTTP caching headers
+sent by SilverStripe. If you are relying on HTTP caching in your implementation,
+or use modules such as [silverstripe/controllerpolicy](https://github.com/silverstripe/silverstripe-controllerpolicy),
+please review the implications of these changes below. 
+
+In short, these APIs make it easier to express your caching preferences
+without running the risk of overriding essential core safety measures.
+Most commonly, these APIs will prevent HTTP caching of draft content.
+
+It will also prevent content generated with an active session,
+since the system can't tell whether session data was used to vary the output.
+In this case, it's up to the developer to opt-in to caching,
+after ensuring that certain execution paths are safe despite of using sessions.
+
+The system behaviour does not guard against accidentally caching "private" content,
+since there are too many variations under which output could be considered private
+(e.g. a custom "approval" flag on a comment object). It is up to
+the developer to ensure caching is used appropriately there.
+
+By default, SilverStripe sends headers which signal to HTTP caches
+that the response should be considered not cacheable.
+
+See [Developer Guide: Performance > HTTP Cache Headers](/developer_guide/performance/http_cache_headers)
+for details on the new API.
+
+### Example Usage
+
+Globally opting into HTTP caching for all page content.
+SilverStripe will still override this preference when a session is active,
+or draft content has been requested. 
+
+```diff
+class Page_Controller extends ContentController
+{
+    public function init()
+    {
+-        HTTP::set_cache_age(60);
++        HTTPCacheControl::inst()
++           ->publicCache()
++           ->setMaxAge(60); // 1 minute
+
+        
+        parent::init();
+    }
+}
+```
+
+Opting out of HTTP caching in a particular controller action.
+
+```diff
+class MyPage_Controller extends Page_Controller
+{
+    public function myprivateaction($request)
+    {
+        $response = $this->myPrivateResponse();
+-        HTTP::set_cache_age(0);
++        HTTPCacheControl::inst()
++           ->privateCache();
+
+        
+        return $response;
+    }
+}
+```
+
+Globally opting into HTTP caching for all page content, ignoring active session.
+This can be helpful in situations where forms are embedded on the website.
+SilverStripe will still override this preference when draft content has been requested.
+CAUTION: This mode relies on a developer examining each execution path to ensure
+that no session data is used to vary output. 
+
+Use case: By default, forms include a [CSRF token](/developer_guides/forms/form_security)
+which starts a session with a value that's unique to the visitor, which makes the output uncacheable.
+But any subsequent requests by this visitor will also carry a session, leading to uncacheable output
+for this visitor. This is the case even if the output does not contain any forms,
+and does not vary for this particular visitor.
+
+```diff
+class Page_Controller extends ContentController
+{
+    public function init()
+    {
+-        HTTP::set_cache_age(60);
++        HTTPCacheControl::inst()
++           ->publicCache($force=true) // DANGER ZONE
++           ->setMaxAge(60); // 1 minute
+
+        
+        parent::init();
+    }
+}
+```
+
+### Detailed Changes
+
+ * Added `Cache-Control: no-store` header to default responses,
+   to prevent intermediary HTTP proxies (e.g. CDNs) from caching unless developers opt-in
+ * Removed `Cache-Control: no-transform` header from default responses
+ * Removed `Vary: Cookie` as an unreliable cache buster,
+   rely on the existing `Cache-Control: no-store` defaults instead
+ * Removed `Vary: Accept`, since it's very uncommon to vary content on
+   the `Content-Type` headers submitted through the request,
+   and it can significantly decrease the likelyhood of a cache hit.
+   Note this is different from `Vary: Accept-Encoding`,
+   which is important for compression (e.g. gzip), and usually added by
+   other layers such as Apache's mod_gzip.

--- a/docs/en/04_Changelogs/3.7.0.md
+++ b/docs/en/04_Changelogs/3.7.0.md
@@ -114,7 +114,7 @@ class Page_Controller extends ContentController
     {
 -        HTTP::set_cache_age(60);
 +        HTTPCacheControl::inst()
-+           ->publicCache()
++           ->enableCache()
 +           ->setMaxAge(60); // 1 minute
 
         
@@ -133,7 +133,7 @@ class MyPage_Controller extends Page_Controller
         $response = $this->myPrivateResponse();
 -        HTTP::set_cache_age(0);
 +        HTTPCacheControl::inst()
-+           ->privateCache();
++           ->disableCache();
 
         
         return $response;
@@ -160,7 +160,7 @@ class Page_Controller extends ContentController
     {
 -        HTTP::set_cache_age(60);
 +        HTTPCacheControl::inst()
-+           ->publicCache($force=true) // DANGER ZONE
++           ->enableCache($force=true) // DANGER ZONE
 +           ->setMaxAge(60); // 1 minute
 
         

--- a/docs/en/04_Changelogs/3.7.0.md
+++ b/docs/en/04_Changelogs/3.7.0.md
@@ -85,7 +85,7 @@ In short, these APIs make it easier to express your caching preferences
 without running the risk of overriding essential core safety measures.
 Most commonly, these APIs will prevent HTTP caching of draft content.
 
-It will also prevent content generated with an active session,
+It will also prevent caching of content generated with an active session,
 since the system can't tell whether session data was used to vary the output.
 In this case, it's up to the developer to opt-in to caching,
 after ensuring that certain execution paths are safe despite of using sessions.
@@ -103,9 +103,9 @@ for details on the new API.
 
 ### Example Usage
 
-Globally opting into HTTP caching for all page content.
-SilverStripe will still override this preference when a session is active,
-or draft content has been requested. 
+#### Global opt-in for page content 
+
+Enable caching for all page content (through `Page_Controller`).
 
 ```diff
 class Page_Controller extends ContentController
@@ -123,7 +123,16 @@ class Page_Controller extends ContentController
 }
 ```
 
-Opting out of HTTP caching in a particular controller action.
+Note: SilverStripe will still override this preference when a session is active,
+a [CSRF token](/developer_guides/forms/form_security) token is present,
+or draft content has been requested.
+
+#### Opt-out for a particular controller action
+
+If a controller output relies on session data, cookies,
+permission checks or other triggers for conditional output,
+you can disable caching either on a controller level
+(through `init()`) or for a particular action.
 
 ```diff
 class MyPage_Controller extends Page_Controller
@@ -141,7 +150,12 @@ class MyPage_Controller extends Page_Controller
 }
 ```
 
-Globally opting into HTTP caching for all page content, ignoring active session.
+Note: SilverStripe will still override this preference when a session is active,
+a [CSRF token](/developer_guides/forms/form_security) token is present,
+or draft content has been requested.
+
+#### Global opt-in, ignoring session (advanced)
+
 This can be helpful in situations where forms are embedded on the website.
 SilverStripe will still override this preference when draft content has been requested.
 CAUTION: This mode relies on a developer examining each execution path to ensure

--- a/forms/Form.php
+++ b/forms/Form.php
@@ -854,7 +854,9 @@ class Form extends RequestHandler {
 		}
 
 		// If we need to disable cache, do it
-		if ($needsCacheDisabled) HTTP::set_cache_age(0);
+		if ($needsCacheDisabled) {
+			HTTPCacheControl::singleton()->disableCaching();
+		}
 
 		$attrs = $this->getAttributes();
 

--- a/forms/Form.php
+++ b/forms/Form.php
@@ -855,7 +855,7 @@ class Form extends RequestHandler {
 
 		// If we need to disable cache, do it
 		if ($needsCacheDisabled) {
-			HTTPCacheControl::singleton()->disableCaching();
+			HTTPCacheControl::singleton()->disableCache(true);
 		}
 
 		$attrs = $this->getAttributes();

--- a/main.php
+++ b/main.php
@@ -57,6 +57,9 @@ if (version_compare(phpversion(), '5.3.3', '<')) {
  */
 require_once('core/Constants.php');
 
+// we handle our own cache headers in this application
+session_cache_limiter('');
+
 // IIS will sometimes generate this.
 if(!empty($_SERVER['HTTP_X_ORIGINAL_URL'])) {
 	$_SERVER['REQUEST_URI'] = $_SERVER['HTTP_X_ORIGINAL_URL'];

--- a/security/Security.php
+++ b/security/Security.php
@@ -240,7 +240,7 @@ class Security extends Controller implements TemplateGlobalProvider {
 
 		if(!$controller) $controller = Controller::curr();
 
-		HTTPCacheControl::singleton()->disableCaching();
+		HTTPCacheControl::singleton()->disableCache(true);
 
 		if(Director::is_ajax()) {
 			$response = ($controller) ? $controller->getResponse() : new SS_HTTPResponse();

--- a/security/Security.php
+++ b/security/Security.php
@@ -240,6 +240,8 @@ class Security extends Controller implements TemplateGlobalProvider {
 
 		if(!$controller) $controller = Controller::curr();
 
+		HTTPCacheControl::singleton()->disableCaching();
+
 		if(Director::is_ajax()) {
 			$response = ($controller) ? $controller->getResponse() : new SS_HTTPResponse();
 			$response->setStatusCode(403);

--- a/tests/control/HTTPCacheControlIntegrationTest.php
+++ b/tests/control/HTTPCacheControlIntegrationTest.php
@@ -1,0 +1,150 @@
+<?php
+
+class HTTPCacheControlIntegrationTest extends FunctionalTest {
+
+	public function setUp() {
+		parent::setUp();
+		Config::inst()->remove('HTTP', 'disable_http_cache');
+		Injector::inst()->unregisterNamedObject('HTTPCacheControl');
+	}
+
+	public function testFormCSRF() {
+		// CSRF sets caching to disabled
+		$response = $this->get('HTTPCacheControlIntegrationTest_SessionController/showform');
+		$header = $response->getHeader('Cache-Control');
+		$this->assertContains('no-cache', $header);
+		$this->assertContains('no-store', $header);
+		$this->assertContains('must-revalidate', $header);
+	}
+
+	public function testPublicForm() {
+		// Public forms (http get) allow public caching
+		$response = $this->get('HTTPCacheControlIntegrationTest_SessionController/showpublicform');
+		$header = $response->getHeader('Cache-Control');
+		$this->assertContains('public', $header);
+		$this->assertContains('must-revalidate', $header);
+		$this->assertNotContains('no-cache', $response->getHeader('Cache-Control'));
+		$this->assertNotContains('no-store', $response->getHeader('Cache-Control'));
+	}
+
+	public function testPrivateActionsError()
+	{
+		// disallowed private actions don't cache
+		$response = $this->get('HTTPCacheControlIntegrationTest_SessionController/privateaction');
+		$header = $response->getHeader('Cache-Control');
+		$this->assertContains('no-cache', $header);
+		$this->assertContains('no-store', $header);
+		$this->assertContains('must-revalidate', $header);
+	}
+
+	public function testPrivateActionsAuthenticated()
+	{
+		$this->logInWithPermission('ADMIN');
+		// Authenticated actions are private cache
+		$response = $this->get('HTTPCacheControlIntegrationTest_SessionController/privateaction');
+		$header = $response->getHeader('Cache-Control');
+		$this->assertContains('private', $header);
+		$this->assertContains('must-revalidate', $header);
+		$this->assertNotContains('no-cache', $response->getHeader('Cache-Control'));
+		$this->assertNotContains('no-store', $response->getHeader('Cache-Control'));
+	}
+}
+
+/**
+ * Test caching based on session
+ */
+class HTTPCacheControlIntegrationTest_SessionController extends Controller implements TestOnly
+{
+	private static $allowed_actions = array(
+		'showform',
+		'privateaction',
+		'publicaction',
+		'showpublicform',
+		'Form',
+	);
+
+	public function init()
+	{
+		parent::init();
+		// Prefer public by default
+		HTTPCacheControl::singleton()->publicCache();
+	}
+
+	public function getContent()
+	{
+		return '<p>Hello world</p>';
+	}
+
+	public function showform()
+	{
+		// Form should be set to private due to CSRF
+		SecurityToken::enable();
+		return $this->renderWith('BlankPage');
+	}
+
+	public function showpublicform()
+	{
+		// Public form doesn't use CSRF and thus no session usage
+		SecurityToken::disable();
+		return $this->renderWith('BlankPage');
+	}
+
+	public function privateaction()
+	{
+		if (!Permission::check('ANYCODE')) {
+			$this->httpError(403, 'Not allowed');
+		}
+		return 'ok';
+	}
+
+	public function publicaction()
+	{
+		return 'Hello!';
+	}
+
+	public function Form()
+	{
+		$form = new Form(
+			$this,
+			'Form',
+			new FieldList(new TextField('Name')),
+			new FieldList(new FormAction('submit', 'Submit'))
+		);
+		$form->setFormMethod('GET');
+		return $form;
+	}
+}
+
+/**
+ * Test caching based on specific http caching directives
+ */
+class HTTPCacheControlIntegrationTest_RuleController extends Controller implements TestOnly
+{
+	private static $allowed_actions = array(
+		'privateaction',
+		'publicaction',
+		'disabledaction',
+	);
+
+	public function init()
+	{
+		parent::init();
+		// Prefer public by default
+		HTTPCacheControl::singleton()->publicCache();
+	}
+
+	public function privateaction() {
+		HTTPCacheControl::singleton()->privateCache();
+		return 'private content';
+	}
+
+	private function publicaction() {
+		HTTPCacheControl::singleton()->publicCache();
+		return 'public content';
+	}
+
+	private function disabledaction() {
+		HTTPCacheControl::singleton()->disableCache();
+		return 'uncached content';
+	}
+}

--- a/tests/control/HTTPCacheControlIntegrationTest.php
+++ b/tests/control/HTTPCacheControlIntegrationTest.php
@@ -5,7 +5,7 @@ class HTTPCacheControlIntegrationTest extends FunctionalTest {
 	public function setUp() {
 		parent::setUp();
 		Config::inst()->remove('HTTP', 'disable_http_cache');
-		Injector::inst()->unregisterNamedObject('HTTPCacheControl');
+		HTTPCacheControl::reset();
 	}
 
 	public function testFormCSRF() {

--- a/tests/control/HTTPCacheControlTest.php
+++ b/tests/control/HTTPCacheControlTest.php
@@ -5,7 +5,7 @@
  */
 class HTTPCacheControlTest extends SapphireTest
 {
-	function testCachingPriorities()
+	public function testCachingPriorities()
 	{
 		$hcc = new HTTPCacheControl();
 		$this->assertTrue($this->isDisabled($hcc), 'caching starts as disabled');

--- a/tests/control/HTTPCacheControlTest.php
+++ b/tests/control/HTTPCacheControlTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Testing of  HTTPCacheControl class
+ */
+class HTTPCacheControlTest extends SapphireTest
+{
+	function testCachingPriorities()
+	{
+		$hcc = new HTTPCacheControl();
+		$this->assertTrue($this->isDisabled($hcc), 'caching starts as disabled');
+
+		$hcc->publicCache();
+		$this->assertTrue($this->isPublic($hcc), 'public can be set at start');
+
+		$hcc->privateCache();
+		$this->assertTrue($this->isPrivate($hcc), 'private overrides public');
+
+		$hcc->publicCache();
+		$this->assertFalse($this->isPublic($hcc), 'public does not overrides private');
+
+		$hcc->disableCache();
+		$this->assertTrue($this->isDisabled($hcc), 'disabled overrides private');
+
+		$hcc->privateCache();
+		$this->assertFalse($this->isPrivate($hcc), 'private does not override disabled');
+
+		$hcc->publicCache(true);
+		$this->assertTrue($this->isPublic($hcc), 'force-public overrides disabled');
+
+		$hcc->privateCache();
+		$this->assertFalse($this->isPrivate($hcc), 'private does not overrdie force-public');
+
+		$hcc->privateCache(true);
+		$this->assertTrue($this->isPrivate($hcc), 'force-private overrides force-public');
+
+		$hcc->publicCache(true);
+		$this->assertFalse($this->isPublic($hcc), 'force-public does not override force-private');
+
+		$hcc->disableCache(true);
+		$this->assertTrue($this->isDisabled($hcc), 'force-disabled overrides force-private');
+
+		$hcc->publicCache(true);
+		$this->assertFalse($this->isPublic($hcc), 'force-public does not overrides force-disabled');
+	}
+
+	protected function isPrivate(HTTPCacheControl $hcc)
+	{
+		return $hcc->hasDirective('private') && !$hcc->hasDirective('public') && !$hcc->hasDirective('no-cache');
+	}
+
+	protected function isPublic(HTTPCacheControl $hcc)
+	{
+		return $hcc->hasDirective('public') && !$hcc->hasDirective('private') && !$hcc->hasDirective('no-cache');
+	}
+	protected function isDisabled(HTTPCacheControl $hcc)
+	{
+		return $hcc->hasDirective('no-cache') && !$hcc->hasDirective('private') && !$hcc->hasDirective('public');
+	}
+}

--- a/tests/control/HTTPCacheControlTest.php
+++ b/tests/control/HTTPCacheControlTest.php
@@ -10,6 +10,9 @@ class HTTPCacheControlTest extends SapphireTest
 		$hcc = new HTTPCacheControl();
 		$this->assertTrue($this->isDisabled($hcc), 'caching starts as disabled');
 
+		$hcc->enableCache();
+		$this->assertFalse($this->isDisabled($hcc));
+
 		$hcc->publicCache();
 		$this->assertTrue($this->isPublic($hcc), 'public can be set at start');
 
@@ -24,6 +27,9 @@ class HTTPCacheControlTest extends SapphireTest
 
 		$hcc->privateCache();
 		$this->assertFalse($this->isPrivate($hcc), 'private does not override disabled');
+
+		$hcc->enableCache(true);
+		$this->assertFalse($this->isDisabled($hcc));
 
 		$hcc->publicCache(true);
 		$this->assertTrue($this->isPublic($hcc), 'force-public overrides disabled');

--- a/tests/control/HTTPTest.php
+++ b/tests/control/HTTPTest.php
@@ -59,7 +59,11 @@ class HTTPTest extends FunctionalTest {
 		}
 
 		// Expect a warning if the header is already set
-		$this->setExpectedException('PHPUnit_Framework_Error_Warning', 'Cache-Control header has already been set');
+		$this->setExpectedException(
+			'PHPUnit_Framework_Error_Warning',
+			'Cache-Control header has already been set. '
+			. 'Please use HTTPCacheControl API to set caching options instead.'
+		);
 		HTTP::add_cache_headers($response);
 	}
 

--- a/tests/control/HTTPTest.php
+++ b/tests/control/HTTPTest.php
@@ -57,10 +57,10 @@ class HTTPTest extends FunctionalTest {
 		foreach($headers as $name => $value) {
 			$response->addHeader($name, $value);
 		}
+
+		// Expect a warning if the header is already set
+		$this->setExpectedException('PHPUnit_Framework_Error_Warning', 'Cache-Control header has already been set');
 		HTTP::add_cache_headers($response);
-		foreach($headers as $name => $value) {
-			$this->assertEquals($value, $response->getHeader($name));
-		}
 	}
 
     public function testConfigVary() {

--- a/tests/control/HTTPTest.php
+++ b/tests/control/HTTPTest.php
@@ -12,6 +12,7 @@ class HTTPTest extends FunctionalTest {
 		parent::setUp();
 		// Remove dev-only config
 		Config::inst()->remove('HTTP', 'disable_http_cache');
+		Injector::inst()->unregisterNamedObject('HTTPCacheControl');
 	}
 
 	public function testAddCacheHeaders() {
@@ -54,7 +55,6 @@ class HTTPTest extends FunctionalTest {
 			$this->assertEquals($value, $response->getHeader($name));
 		}
 	}
-
 
     public function testConfigVary() {
 		$body = "<html><head></head><body><h1>Mysite</h1></body></html>";

--- a/tests/control/HTTPTest.php
+++ b/tests/control/HTTPTest.php
@@ -65,10 +65,11 @@ class HTTPTest extends FunctionalTest {
 		$v = $response->getHeader('Vary');
 		$this->assertNotEmpty($v);
 
-		$this->assertContains("Cookie", $v);
 		$this->assertContains("X-Forwarded-Protocol", $v);
-		$this->assertContains("User-Agent", $v);
-		$this->assertContains("Accept", $v);
+		$this->assertContains("X-Requested-With", $v);
+		$this->assertNotContains("Cookie", $v);
+		$this->assertNotContains("User-Agent", $v);
+		$this->assertNotContains("Accept", $v);
 
 		Config::inst()->update('HTTP', 'vary', '');
 

--- a/tests/control/HTTPTest.php
+++ b/tests/control/HTTPTest.php
@@ -18,16 +18,16 @@ class HTTPTest extends FunctionalTest {
 	public function testAddCacheHeaders() {
 		$body = "<html><head></head><body><h1>Mysite</h1></body></html>";
 		$response = new SS_HTTPResponse($body, 200);
-		$this->assertEmpty($response->getHeader('Cache-Control'));
-
+		HTTPCacheControl::singleton()->publicCache();
 		HTTP::set_cache_age(30);
-
 		HTTP::add_cache_headers($response);
 		$this->assertNotEmpty($response->getHeader('Cache-Control'));
 
 		// Ensure cache headers are set correctly when disabled via config (e.g. when dev)
 		Config::inst()->update('HTTP', 'disable_http_cache', true);
 		HTTPCacheControl::reset();
+		HTTPCacheControl::singleton()->publicCache();
+		HTTP::set_cache_age(30);
 		$response = new SS_HTTPResponse($body, 200);
 		HTTP::add_cache_headers($response);
 		$this->assertContains('no-cache', $response->getHeader('Cache-Control'));
@@ -37,6 +37,8 @@ class HTTPTest extends FunctionalTest {
 		// Ensure max-age setting is respected in production.
 		Config::inst()->remove('HTTP', 'disable_http_cache');
 		HTTPCacheControl::reset();
+		HTTPCacheControl::singleton()->publicCache();
+		HTTP::set_cache_age(30);
 		$response = new SS_HTTPResponse($body, 200);
 		HTTP::add_cache_headers($response);
 		$this->assertContains('max-age=30', $response->getHeader('Cache-Control'));
@@ -49,6 +51,8 @@ class HTTPTest extends FunctionalTest {
 			'Cache-Control' => 'max-age=0, no-cache, no-store',
 		);
 		HTTPCacheControl::reset();
+		HTTPCacheControl::singleton()->publicCache();
+		HTTP::set_cache_age(30);
 		$response = new SS_HTTPResponse($body, 200);
 		foreach($headers as $name => $value) {
 			$response->addHeader($name, $value);

--- a/tests/control/HTTPTest.php
+++ b/tests/control/HTTPTest.php
@@ -12,7 +12,7 @@ class HTTPTest extends FunctionalTest {
 		parent::setUp();
 		// Remove dev-only config
 		Config::inst()->remove('HTTP', 'disable_http_cache');
-		Injector::inst()->unregisterNamedObject('HTTPCacheControl');
+		HTTPCacheControl::reset();
 	}
 
 	public function testAddCacheHeaders() {
@@ -27,6 +27,7 @@ class HTTPTest extends FunctionalTest {
 
 		// Ensure cache headers are set correctly when disabled via config (e.g. when dev)
 		Config::inst()->update('HTTP', 'disable_http_cache', true);
+		HTTPCacheControl::reset();
 		$response = new SS_HTTPResponse($body, 200);
 		HTTP::add_cache_headers($response);
 		$this->assertContains('no-cache', $response->getHeader('Cache-Control'));
@@ -35,6 +36,7 @@ class HTTPTest extends FunctionalTest {
 
 		// Ensure max-age setting is respected in production.
 		Config::inst()->remove('HTTP', 'disable_http_cache');
+		HTTPCacheControl::reset();
 		$response = new SS_HTTPResponse($body, 200);
 		HTTP::add_cache_headers($response);
 		$this->assertContains('max-age=30', $response->getHeader('Cache-Control'));
@@ -46,6 +48,7 @@ class HTTPTest extends FunctionalTest {
 			'Pragma' => 'no-cache',
 			'Cache-Control' => 'max-age=0, no-cache, no-store',
 		);
+		HTTPCacheControl::reset();
 		$response = new SS_HTTPResponse($body, 200);
 		foreach($headers as $name => $value) {
 			$response->addHeader($name, $value);
@@ -72,6 +75,7 @@ class HTTPTest extends FunctionalTest {
 		$this->assertNotContains("Accept", $v);
 
 		Config::inst()->update('HTTP', 'vary', '');
+		HTTPCacheControl::reset();
 
 		$response = new SS_HTTPResponse($body, 200);
 		HTTP::add_cache_headers($response);

--- a/tests/control/HTTPTest.php
+++ b/tests/control/HTTPTest.php
@@ -25,7 +25,7 @@ class HTTPTest extends FunctionalTest {
 		HTTP::add_cache_headers($response);
 		$this->assertNotEmpty($response->getHeader('Cache-Control'));
 
-		// Ensure cache is disabled and max-age is ignored when disabled (e.g. when dev)
+		// Ensure cache headers are set correctly when disabled via config (e.g. when dev)
 		Config::inst()->update('HTTP', 'disable_http_cache', true);
 		$response = new SS_HTTPResponse($body, 200);
 		HTTP::add_cache_headers($response);


### PR DESCRIPTION
SS3 code for https://github.com/silverstripe/silverstripe-versioned/issues/146

@chillu / @sminnee please don't hate me with this. This is just an initial POC of how we can get Cache-Control working in a more controlled way. Once the general approach is accepted I'd then start applying `HTTPCacheControl::inst()->disableCaching()` (`or even `HTTPCacheControl::inst()->privateCache()`) to the relevant parts of the framework that indicate to us that there's some globally non-cachable content being passed around.

1. I've addded a new class `HTTPCacheControl` which keeps better track of the `Cache-Control` directives and adds some helper methods to set up the cache-control to what we'd want (eg: `disableCaching` to add the holy trinity of `no-cache, no-store, must-revalidate` and `privateCache` to set the cache-control to the sensible defaults for private cache-control headers.
2. I've reworked `HTTP::add_cache_headers()` to fix the issues outlined here: https://github.com/silverstripe/silverstripe-versioned/issues/146#issuecomment-391058327
3. I've added case-insenstive queries of `SS_HTTPRequest::getHeader` so that we can simplify a small piece of silly code here
4, Fixed our inconsistent ETag generation
