### PR TITLE
FIX Add macron to Māori language name

### DIFF
--- a/src/Dev/Install/InstallConfig.php
+++ b/src/Dev/Install/InstallConfig.php
@@ -228,7 +228,7 @@ class InstallConfig
             'lv_LV' => 'Latvian (Latvia)',
             'lt_LT' => 'Lithuanian (Lithuania)',
             'ms_MY' => 'Malay (Malaysia)',
-            'mi_NZ' => 'Maori (New Zealand)',
+            'mi_NZ' => 'Māori (New Zealand)',
             'ne_NP' => 'Nepali (Nepal)',
             'nb_NO' => 'Norwegian',
             'fa_IR' => 'Persian (Iran)',


### PR DESCRIPTION
Related to https://github.com/silverstripe/cwp/issues/84