### PR TITLE
FIX Prevent array to string conversion for default_sort on a fixed field

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -213,6 +213,9 @@ abstract class SS_Object {
 	 * Returns a 2-elemnent array, with classname and arguments
 	 */
 	public static function parse_class_spec($classSpec) {
+		if ($classSpec === array()) {
+			$classSpec = '';
+		}
 		$tokens = token_get_all("<?php $classSpec");
 		$class = null;
 		$args = array();

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -1772,8 +1772,8 @@ class DataObjectTest_SortOnFixed extends DataObject implements TestOnly {
 		'Name' => 'Varchar',
 	);
 
-	// Sorts on a "fixed field"
-	private static $default_sort = '"Created" DESC';
+	// Sorts on a "fixed field" - adding name as a second option since fixtures are created at the same time
+	private static $default_sort = '"Created" DESC, "Name" DESC';
 }
 
 class DataObjectTest_Player extends Member implements TestOnly {

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -29,6 +29,7 @@ class DataObjectTest extends SapphireTest {
 		'DataObjectTest_Play',
 		'DataObjectTest_Ploy',
 		'DataObjectTest_Bogey',
+		'DataObjectTest_SortOnFixed',
 		'ManyManyListTest_Product',
 		'ManyManyListTest_Category',
 	);
@@ -1744,6 +1745,19 @@ class DataObjectTest extends SapphireTest {
 		$this->assertEquals(PHP_INT_MAX, DataObjectTest_Staff::get()->byID($staff->ID)->Salary);
 	}
 
+	public function testSortOnFixedField() {
+		$model = new DataObjectTest_SortOnFixed();
+		$model->Name = 'Apple';
+		$model->write();
+
+		$model2 = new DataObjectTest_SortOnFixed();
+		$model2->Name = 'Orange';
+		$model2->write();
+
+		$result = DataObjectTest_SortOnFixed::get()->column('Name');
+		$this->assertSame(array('Orange', 'Apple'), $result);
+	}
+
 }
 
 class DataObjectTest_Sortable extends DataObject implements TestOnly {
@@ -1751,6 +1765,15 @@ class DataObjectTest_Sortable extends DataObject implements TestOnly {
 		'Sort' => 'Int',
 		'Name' => 'Varchar',
 	);
+}
+
+class DataObjectTest_SortOnFixed extends DataObject implements TestOnly {
+	private static $db = array(
+		'Name' => 'Varchar',
+	);
+
+	// Sorts on a "fixed field"
+	private static $default_sort = '"Created" DESC';
 }
 
 class DataObjectTest_Player extends Member implements TestOnly {


### PR DESCRIPTION
This shows a regression in **3.7.x-dev** where you can no longer define a `default_sort` that is a "fixed field" (e.g. Created from DataObject) without throwing an "array to string conversion" error.

One option is to cast empty arrays in `Object::parse_class_spec` to an empty string so this doesn't happen. I'm not sure where the regression happened, but this test shows it.