### PR TITLE
FIX Remove use of deprecated each method from thirdparty

### DIFF
--- a/core/Diff.php
+++ b/core/Diff.php
@@ -278,15 +278,17 @@ class _DiffEngine
 				if (empty($ymatches[$line]))
 			continue;
 		$matches = $ymatches[$line];
-				reset($matches);
-		while (list ($junk, $y) = each($matches))
+		$y = reset($matches);
+		do {
 			if (empty($this->in_seq[$y])) {
-			$k = $this->_lcs_pos($y);
-			USE_ASSERTS && assert($k > 0);
-			$ymids[$k] = $ymids[$k-1];
-			break;
-					}
-		while (list ($junk, $y) = each($matches)) {
+				$k = $this->_lcs_pos($y);
+				USE_ASSERTS && assert($k > 0);
+				$ymids[$k] = $ymids[$k - 1];
+				break;
+			}
+		} while (false !== ($y = next($matches)));
+
+		while (false !== ($y = next($matches))) {
 			if ($y > $this->seq[$k-1]) {
 			USE_ASSERTS && assert($y < $this->seq[$k]);
 			// Optimization: this is a common case:
@@ -797,18 +799,19 @@ class Diff
 
 		$content = str_replace(array("&nbsp;","<", ">"),array(" "," <", "> "),$content);
 		$candidateChunks = preg_split("/[\t\r\n ]+/", $content);
-		while(list($i,$item) = each($candidateChunks)) {
+		$item = reset($candidateChunks);
+		do {
 			if(isset($item[0]) && $item[0] == "<") {
 				$newChunk = $item;
 				while($item[strlen($item)-1] != ">") {
-					list($i,$item) = each($candidateChunks);
+					$item = next($candidateChunks);
 					$newChunk .= ' ' . $item;
 				}
 				$chunks[] = $newChunk;
 			} else {
 				$chunks[] = $item;
 			}
-		}
+		} while (false !== ($item = next($candidateChunks)));
 		return $chunks;
 	}
 

--- a/dev/Profiler.php
+++ b/dev/Profiler.php
@@ -161,7 +161,7 @@ class Profiler {
 			echo"============================================================================\n";
 			print( "Calls                    Time  Routine\n");
 			echo"-----------------------------------------------------------------------------\n";
-			while (list ($key, $val) = each ($this->description)) {
+			foreach ($this->description as $key => $val) {
 				$t = $this->elapsedTime($key);
 				$total = $this->running[$key];
 				$count = $this->count[$key];

--- a/model/Hierarchy.php
+++ b/model/Hierarchy.php
@@ -247,8 +247,10 @@ class Hierarchy extends DataExtension {
 		$this->markedNodes = array($this->owner->ID => $this->owner);
 		$this->owner->markUnexpanded();
 
+		$node = reset($this->markedNodes);
+
 		// foreach can't handle an ever-growing $nodes list
-		while(list($id, $node) = each($this->markedNodes)) {
+		do {
 			// first determine the number of children, if it's too high the tree view can't be used
 			// so will will not even bother to display the subtree
 			// this covers two cases:
@@ -267,7 +269,7 @@ class Hierarchy extends DataExtension {
 				if($children) foreach($children as $child) $child->markClosed();
 				break;
 			}
-		}
+		} while (false !== ($node = next($this->markedNodes)));
 		return sizeof($this->markedNodes);
 	}
 

--- a/thirdparty/Zend/Cache/Backend.php
+++ b/thirdparty/Zend/Cache/Backend.php
@@ -63,7 +63,7 @@ class Zend_Cache_Backend
      */
     public function __construct(array $options = array())
     {
-        while (list($name, $value) = each($options)) {
+        foreach ($options as $name => $value) {
             $this->setOption($name, $value);
         }
     }
@@ -78,7 +78,7 @@ class Zend_Cache_Backend
     public function setDirectives($directives)
     {
         if (!is_array($directives)) Zend_Cache::throwException('Directives parameter must be an array');
-        while (list($name, $value) = each($directives)) {
+        foreach ($directives as $name => $value) {
             if (!is_string($name)) {
                 Zend_Cache::throwException("Incorrect option name : $name");
             }

--- a/thirdparty/Zend/Cache/Core.php
+++ b/thirdparty/Zend/Cache/Core.php
@@ -143,7 +143,7 @@ class Zend_Cache_Core
             Zend_Cache::throwException("Options passed were not an array"
             . " or Zend_Config instance.");
         }
-        while (list($name, $value) = each($options)) {
+        foreach ($options as $name => $value) {
             $this->setOption($name, $value);
         }
         $this->_loggerSanity();
@@ -158,7 +158,7 @@ class Zend_Cache_Core
     public function setConfig(Zend_Config $config)
     {
         $options = $config->toArray();
-        while (list($name, $value) = each($options)) {
+        foreach ($options as $name => $value) {
             $this->setOption($name, $value);
         }
         return $this;

--- a/thirdparty/Zend/Cache/Frontend/Class.php
+++ b/thirdparty/Zend/Cache/Frontend/Class.php
@@ -107,7 +107,7 @@ class Zend_Cache_Frontend_Class extends Zend_Cache_Core
      */
     public function __construct(array $options = array())
     {
-        while (list($name, $value) = each($options)) {
+    	foreach ($options as $name => $value) {
             $this->setOption($name, $value);
         }
         if ($this->_specificOptions['cached_entity'] === null) {

--- a/thirdparty/Zend/Cache/Frontend/File.php
+++ b/thirdparty/Zend/Cache/Frontend/File.php
@@ -88,7 +88,7 @@ class Zend_Cache_Frontend_File extends Zend_Cache_Core
      */
     public function __construct(array $options = array())
     {
-        while (list($name, $value) = each($options)) {
+    	foreach ($options as $name => $value) {
             $this->setOption($name, $value);
         }
         if (!isset($this->_specificOptions['master_files'])) {

--- a/thirdparty/Zend/Cache/Frontend/Function.php
+++ b/thirdparty/Zend/Cache/Frontend/Function.php
@@ -63,7 +63,7 @@ class Zend_Cache_Frontend_Function extends Zend_Cache_Core
      */
     public function __construct(array $options = array())
     {
-        while (list($name, $value) = each($options)) {
+    	foreach ($options as $name => $value) {
             $this->setOption($name, $value);
         }
         $this->setOption('automatic_serialization', true);

--- a/thirdparty/Zend/Cache/Frontend/Page.php
+++ b/thirdparty/Zend/Cache/Frontend/Page.php
@@ -129,7 +129,7 @@ class Zend_Cache_Frontend_Page extends Zend_Cache_Core
      */
     public function __construct(array $options = array())
     {
-        while (list($name, $value) = each($options)) {
+    	foreach ($options as $name => $value) {
             $name = strtolower($name);
             switch ($name) {
                 case 'regexps':


### PR DESCRIPTION
For php 7.2 compatibility we need to remove uses of `each` which is now deprecated