### PR TITLE
Add test assertion for response instance

### DIFF
--- a/tests/php/Control/DirectorTest.php
+++ b/tests/php/Control/DirectorTest.php
@@ -593,6 +593,7 @@ class DirectorTest extends SapphireTest
         }, 'http://www.mysite.com:9090/some-url');
 
         // Middleware returns non-exception redirect
+        $this->assertInstanceOf(HTTPResponse::class, $response);
         $this->assertEquals('https://www.mysite.com:9090/some-url', $response->getHeader('Location'));
         $this->assertEquals(301, $response->getStatusCode());
     }

--- a/tests/php/Control/DirectorTest.php
+++ b/tests/php/Control/DirectorTest.php
@@ -31,8 +31,13 @@ class DirectorTest extends SapphireTest
         Director::config()->set('alternate_base_url', 'http://www.mysite.com:9090/');
 
         // Ensure redirects enabled on all environments
-        CanonicalURLMiddleware::singleton()->setEnabledEnvs(true);
+        $middleware = CanonicalURLMiddleware::singleton()->setEnabledEnvs(true);
         $this->expectedRedirect = null;
+
+        // Ensure global state doesn't affect this test
+        $middleware
+            ->setForceSSLDomain(null)
+            ->setForceSSLPatterns([]);
     }
 
     protected function getExtraRoutes()


### PR DESCRIPTION
This prevents middlewares that return null (like the example delegate in this test) from killing a testsuite

Example error without this:

```
Fatal error: Call to a member function getHeader() on null in /Users/robbieaverill/dev/releases/release-cwp_cwp-recipe-kitchen-sink-2.0.0-rc4/vendor/silverstripe/framework/tests/php/Control/DirectorTest.php on line 596
```

Also adds some config resets to ensure global state pollution doesn't affect the tests when running in a CWP 2.0 context