### PR TITLE
Fix: negative values in read only currency field

### DIFF
--- a/src/Forms/CurrencyField_Disabled.php
+++ b/src/Forms/CurrencyField_Disabled.php
@@ -22,7 +22,7 @@ class CurrencyField_Disabled extends CurrencyField
     {
         if ($this->value) {
             $val = Convert::raw2xml($this->value);
-            $val = _t('SilverStripe\\Forms\\CurrencyField.CURRENCYSYMBOL', '$') . number_format(preg_replace('/[^0-9.]/', "", $val), 2);
+            $val = _t('SilverStripe\\Forms\\CurrencyField.CURRENCYSYMBOL', '$') . number_format(preg_replace('/[^0-9.-]/', "", $val), 2);
             $valforInput = Convert::raw2att($val);
         } else {
             $valforInput = '';

--- a/src/Forms/CurrencyField_Readonly.php
+++ b/src/Forms/CurrencyField_Readonly.php
@@ -20,7 +20,7 @@ class CurrencyField_Readonly extends ReadonlyField
     {
         if ($this->value) {
             $val = Convert::raw2xml($this->value);
-            $val = _t('SilverStripe\\Forms\\CurrencyField.CURRENCYSYMBOL', '$') . number_format(preg_replace('/[^0-9.]/', "", $val), 2);
+            $val = _t('SilverStripe\\Forms\\CurrencyField.CURRENCYSYMBOL', '$') . number_format(preg_replace('/[^0-9.-]/', "", $val), 2);
             $valforInput = Convert::raw2att($val);
         } else {
             $val = '<i>' . _t('SilverStripe\\Forms\\CurrencyField.CURRENCYSYMBOL', '$') . '0.00</i>';


### PR DESCRIPTION
Don’t strip out ‘-‘ character as this makes negative values appear to be positive (Fixes #8126)