### PR TITLE
FIX Regression from #8009

### DIFF
--- a/tests/model/DataObjectDuplicationTest.php
+++ b/tests/model/DataObjectDuplicationTest.php
@@ -83,6 +83,13 @@ class DataObjectDuplicationTest extends SapphireTest {
 		$two = DataObject::get_by_id("DataObjectDuplicateTestClass2", $two->ID);
 		$three = DataObject::get_by_id("DataObjectDuplicateTestClass3", $three->ID);
 
+		$this->assertCount(1, $one->twos(),
+			"Many-to-one relation not copied (has_many)");
+		$this->assertCount(1, $one->threes(),
+			"Object has the correct number of relations");
+		$this->assertCount(1, $three->ones(),
+			"Object has the correct number of relations");
+
 		//test duplication
 		$oneCopy = $one->duplicate();
 		$twoCopy = $two->duplicate();
@@ -100,16 +107,16 @@ class DataObjectDuplicationTest extends SapphireTest {
 		$this->assertEquals($text2, $twoCopy->text);
 		$this->assertEquals($text3, $threeCopy->text);
 
-		$this->assertNotEquals($one->twos()->Count(), $oneCopy->twos()->Count(),
+		$this->assertCount(0, $oneCopy->twos(),
 			"Many-to-one relation not copied (has_many)");
-		$this->assertEquals($one->threes()->Count(), $oneCopy->threes()->Count(),
+		$this->assertCount(2, $oneCopy->threes(),
 			"Object has the correct number of relations");
-		$this->assertEquals($three->ones()->Count(), $threeCopy->ones()->Count(),
+		$this->assertCount(2, $threeCopy->ones(),
 			"Object has the correct number of relations");
 
 		$this->assertEquals($one->ID, $twoCopy->one()->ID,
 			"Match between relation of copy and the original");
-		$this->assertEquals(0, $oneCopy->twos()->Count(),
+		$this->assertCount(0, $oneCopy->twos(),
 			"Many-to-one relation not copied (has_many)");
 		$this->assertEquals($three->ID, $oneCopy->threes()->First()->ID,
 			"Match between relation of copy and the original");
@@ -142,6 +149,8 @@ class DataObjectDuplicateTestClass1 extends DataObject implements TestOnly {
             'TestExtra' => 'Varchar'
         )
 	);
+
+	private static $default_sort = '"ID" ASC';
 }
 
 class DataObjectDuplicateTestClass2 extends DataObject implements TestOnly {
@@ -154,6 +163,8 @@ class DataObjectDuplicateTestClass2 extends DataObject implements TestOnly {
 		'one' => 'DataObjectDuplicateTestClass1'
 	);
 
+	private static $default_sort = '"ID" ASC';
+
 }
 
 class DataObjectDuplicateTestClass3 extends DataObject implements TestOnly {
@@ -165,6 +176,8 @@ class DataObjectDuplicateTestClass3 extends DataObject implements TestOnly {
 	private static $belongs_many_many = array(
 		'ones' => 'DataObjectDuplicateTestClass1'
 	);
+
+	private static $default_sort = '"ID" ASC';
 }
 
 


### PR DESCRIPTION
fixes #8009 

This fixes the typical sort issue with fetching from postgres DBs

I've replaced the `$this->assertEquals($list->Count(), $listDuplicate->count())` with predefined numbers because this helps show what's going on to people reading it and also helps catch regressions.

It *is* expected that if you duplicate both sides of a `ManyMany` that you'd get 2 relations where you previously had only 1 and so these changed assertions are correct, the (intermittent) test failures reported in #8009 come from the fact that postgres has unreliable default sorting on objects so the first item wasn't always the one we were asserting against.