### PR TITLE
DOCS fix 4.0.0 changelog example code for findThemedResource

### DIFF
--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -484,6 +484,7 @@ Usage with custom logic:
 ```diff
 +use SilverStripe\Core\Manifest\ModuleLoader;
 +use SilverStripe\View\ThemeResourceLoader;
++use SilverStripe\View\SSViewer;
 
 -$moduleFilePath = FRAMEWORK_DIR . '/MyFile.php';
 +$moduleFilePath = ModuleLoader::getModule('silverstripe/framework')->getResource('MyFile.php')->getRelativePath();
@@ -495,7 +496,8 @@ Usage with custom logic:
 +$mysiteFilePath = ModuleLoader::getModule('mysite')->getResource('css/styles.css')->getRelativePath();
 
 -$themesFilePath = SSViewer::get_theme_folder() . '/css/styles.css';
-+$themesFilePath = ThemeResourceLoader::inst()->findThemedResource('css/styles.css');
++$themes = SSViewer::get_themes();
++$themesFilePath = ThemeResourceLoader::inst()->findThemedResource('css/styles.css', $themes);
 
 -$themeFolderPath = THEMES_DIR . '/simple';
 +$themeFolderPath = ThemeResourceLoader::inst()->getPath('simple');


### PR DESCRIPTION
ThemeResourceLoader::inst()->findThemedResource() requires two arguments https://github.com/silverstripe/silverstripe-framework/blob/af2c3886b90bcb2c2964633c9dcc33c91d960140/src/View/ThemeResourceLoader.php#L286-L294

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/