### PR TITLE
FIX: Make custom error messages available to extensions

### DIFF
--- a/src/Control/RequestHandler.php
+++ b/src/Control/RequestHandler.php
@@ -514,10 +514,10 @@ class RequestHandler extends ViewableData
         $request = $this->getRequest();
 
         // Call a handler method such as onBeforeHTTPError404
-        $this->extend("onBeforeHTTPError{$errorCode}", $request);
+        $this->extend("onBeforeHTTPError{$errorCode}", $request, $errorMessage);
 
         // Call a handler method such as onBeforeHTTPError, passing 404 as the first arg
-        $this->extend('onBeforeHTTPError', $errorCode, $request);
+        $this->extend('onBeforeHTTPError', $errorCode, $request, $errorMessage);
 
         // Throw a new exception
         throw new HTTPResponse_Exception($errorMessage, $errorCode);


### PR DESCRIPTION
By default if you call `->httpError(404, 'My Custom Message')` on a controller you'll get a plain text response that displays your custom message. Plain text doesn't look very pretty though so we use modules like ErrorPage to render a themed HTML response instead.

To provide a themed response from `RequestHandler::httpError()` you need to hook in to that method and throw an alternate exception before the default one is thrown. The extension points don't currently pass through the custom error message though, so it's not currently possible for extensions to access and use the custom error message when generating a response.

I guess this would be considered 'new backwards compatible API' so I've opened this against 4, but I'll happily redirect to 4.0 if this might be considered a bug fix.