### PR TITLE
BUG Fix crash on ID in default_sort

### DIFF
--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -1857,6 +1857,8 @@ class DataObjectTest_Fixture extends DataObject implements TestOnly {
 		'DateField.Nice' => 'Date'
 	);
 
+	private static $default_sort = '"DataObjectTest_Fixture"."ID" ASC';
+
 	private static $searchable_fields = array();
 
 	public function populateDefaults() {


### PR DESCRIPTION
Not sure why this popped up recently.

Requesting a field from db('field') shouldn't return the entire list if it's not found.

ID fails because it's a fixed_fields, and is already indexed.