### PR TITLE
FIX: Only set MYSQL_ATTR_INIT_COMMAND when using mysql driver (fixes #8103)

### DIFF
--- a/src/ORM/Connect/PDOConnector.php
+++ b/src/ORM/Connect/PDOConnector.php
@@ -176,9 +176,11 @@ class PDOConnector extends DBConnector
         if (!isset($charset)) {
             $charset = $connCharset;
         }
-        $options = array(
-            PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES ' . $charset . ' COLLATE ' . $connCollation
-        );
+
+        $options = [];
+        if ($parameters['driver'] === 'mysql') {
+            $options[PDO::MYSQL_ATTR_INIT_COMMAND] = 'SET NAMES ' . $charset . ' COLLATE ' . $connCollation;
+        }
 
         // Set SSL options if they are defined
         if (array_key_exists('ssl_key', $parameters) &&


### PR DESCRIPTION
Looks like this was actually fixed in https://github.com/silverstripe/silverstripe-framework/pull/6612, but must have been lost during the merge up to 4.x