### PR TITLE
API: <% loop %> and <% with %> only ever create one new scope level (fixes #4015)

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/01_Syntax.md
+++ b/docs/en/02_Developer_Guides/01_Templates/01_Syntax.md
@@ -478,21 +478,23 @@ Given the following structure, it will output the text.
 	Page 'Child 2' is a child of 'MyPage'
 
 <div class="notice" markdown="1">
-Additional selectors implicitely change the scope so you need to put additional `$Up` to get what you expect.
+Each `<% loop %>` or `<% with %>` block results in a change of scope, regardless of how the objects are traversed in the opening statement.
+See the example below:
 </div>
 
 ```ss
-<h1>Children of '$Title'</h1>
-<% loop $Children.Sort('Title').First %>
-    <%-- We have two additional selectors in the loop expression so... --%> 
-    <p>Page '$Title' is a child of '$Up.Up.Up.Title'</p>
-<% end_loop %>
+{$Title} <%-- Page title --%>
+<% with $Members.First.Organisation %>
+    {$Title} <%-- Organisation title --%>
+    {$Up.Title} <%-- Page title --%>
+    {$Up.Members.First.Name} <%-- Member name --%>
+<% end_with %>
 ```
 
 #### Top
 
 While `$Up` provides us a way to go up one level of scope, `$Top` is a shortcut to jump to the top most scope of the 
-page. The  previous example could be rewritten to use the following syntax.
+page. For example:
 
 ```ss
 <h1>Children of '$Title'</h1>

--- a/docs/en/04_Changelogs/5.0.0.md
+++ b/docs/en/04_Changelogs/5.0.0.md
@@ -13,6 +13,10 @@ guide developers in preparing existing 4.x code for compatibility with 5.0.
 
 ## API Changes {#api-changes}
 
+* `<% loop %>` and `<% with %>` now only ever result in one new scope level. For example
+  `<% loop $Pages.Limit(5) %>{$Up.Up.Title}<% end_loop %>` must be rewritten to use just one `$Up` statement to reach
+  the parent scope.
+
 ### General {#overview-general}
 
 * Minimum PHP version raised to 7.1

--- a/src/View/SSViewer_Scope.php
+++ b/src/View/SSViewer_Scope.php
@@ -192,7 +192,7 @@ class SSViewer_Scope
         switch ($name) {
             case 'Up':
                 if ($this->upIndex === null) {
-                    user_error('Up called when we\'re already at the top of the scope', E_USER_ERROR);
+                    throw new \LogicException('Up called when we\'re already at the top of the scope');
                 }
 
                 list(
@@ -258,6 +258,9 @@ class SSViewer_Scope
         $this->popIndex = $this->itemStack[$newLocalIndex][SSViewer_Scope::POP_INDEX] = $this->localIndex;
         $this->localIndex = $newLocalIndex;
 
+        // $Up now becomes the parent scope - the parent of the current <% loop %> or <% with %>
+        $this->upIndex = $this->itemStack[$newLocalIndex][SSViewer_Scope::UP_INDEX] = $this->popIndex;
+
         // We normally keep any previous itemIterator around, so local $Up calls reference the right element. But
         // once we enter a new global scope, we need to make sure we use a new one
         $this->itemIterator = $this->itemStack[$newLocalIndex][SSViewer_Scope::ITEM_ITERATOR] = null;
@@ -291,7 +294,7 @@ class SSViewer_Scope
 
         if (!$this->itemIterator) {
             // Note: it is important that getIterator() is called before count() as implemenations may rely on
-            // this to efficiency get both the number of records and an iterator (e.g. DataList does this)
+            // this to efficiently get both the number of records and an iterator (e.g. DataList does this)
 
             // Item may be an array or a regular IteratorAggregate
             if (is_array($this->item)) {

--- a/tests/php/View/SSViewerTest.php
+++ b/tests/php/View/SSViewerTest.php
@@ -1361,31 +1361,21 @@ after'
     {
 
         // Data to run the loop tests on - three levels deep
-        $data = new ArrayData(
-            array(
+        $data = new ArrayData([
             'Name' => 'Top',
-            'Foo' => new ArrayData(
-                array(
+            'Foo' => new ArrayData([
                 'Name' => 'Foo',
-                'Bar' => new ArrayData(
-                    array(
+                'Bar' => new ArrayData([
                     'Name' => 'Bar',
-                    'Baz' => new ArrayData(
-                        array(
+                    'Baz' => new ArrayData([
                         'Name' => 'Baz'
-                        )
-                    ),
-                    'Qux' => new ArrayData(
-                        array(
+                    ]),
+                    'Qux' => new ArrayData([
                         'Name' => 'Qux'
-                        )
-                    )
-                    )
-                )
-                )
-            )
-            )
-        );
+                    ])
+                ])
+            ])
+        ]);
 
         // Basic functionality
         $this->assertEquals(
@@ -1395,21 +1385,21 @@ after'
 
         // Two level with block, up refers to internally referenced Bar
         $this->assertEquals(
-            'BarFoo',
+            'BarTop',
             $this->render('<% with Foo.Bar %>{$Name}{$Up.Name}<% end_with %>', $data)
         );
 
         // Stepping up & back down the scope tree
         $this->assertEquals(
-            'BazBarQux',
-            $this->render('<% with Foo.Bar.Baz %>{$Name}{$Up.Name}{$Up.Qux.Name}<% end_with %>', $data)
+            'BazFooBar',
+            $this->render('<% with Foo.Bar.Baz %>{$Name}{$Up.Foo.Name}{$Up.Foo.Bar.Name}<% end_with %>', $data)
         );
 
         // Using $Up in a with block
         $this->assertEquals(
-            'BazBarQux',
+            'BazTopBar',
             $this->render(
-                '<% with Foo.Bar.Baz %>{$Name}<% with $Up %>{$Name}{$Qux.Name}<% end_with %>'
+                '<% with Foo.Bar.Baz %>{$Name}<% with $Up %>{$Name}{$Foo.Bar.Name}<% end_with %>'
                 . '<% end_with %>',
                 $data
             )
@@ -1417,9 +1407,9 @@ after'
 
         // Stepping up & back down the scope tree with with blocks
         $this->assertEquals(
-            'BazBarQuxBarBaz',
+            'BazTopBarTopBaz',
             $this->render(
-                '<% with Foo.Bar.Baz %>{$Name}<% with $Up %>{$Name}<% with Qux %>{$Name}<% end_with %>'
+                '<% with Foo.Bar.Baz %>{$Name}<% with $Up %>{$Name}<% with Foo.Bar %>{$Name}<% end_with %>'
                 . '{$Name}<% end_with %>{$Name}<% end_with %>',
                 $data
             )
@@ -1429,16 +1419,37 @@ after'
         $this->assertEquals(
             'Foo',
             $this->render(
-                '<% with Foo.Bar.Baz %><% with Up %><% with Qux %>{$Up.Up.Name}<% end_with %><% end_with %>'
+                '<% with Foo %><% with Bar %><% with Baz %>{$Up.Up.Name}<% end_with %><% end_with %>'
                 . '<% end_with %>',
                 $data
             )
         );
 
-        // Using $Up.Up, where first $Up points to an Up used in a local scope lookup, should still skip to Foo
+        // Using $Up as part of a lookup chain in <% with %>
+        $this->assertEquals(
+            'Top',
+            $this->render('<% with Foo.Bar.Baz.Up.Qux %>{$Up.Name}<% end_with %>', $data)
+        );
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Up called when we're already at the top of the scope
+     */
+    public function testTooManyUps()
+    {
+        $data = new ArrayData([
+            'Foo' => new ArrayData([
+                'Name' => 'Foo',
+                'Bar' => new ArrayData([
+                    'Name' => 'Bar'
+                ])
+            ])
+        ]);
+
         $this->assertEquals(
             'Foo',
-            $this->render('<% with Foo.Bar.Baz.Up.Qux %>{$Up.Up.Name}<% end_with %>', $data)
+            $this->render('<% with Foo.Bar %>{$Up.Up.Name}<% end_with %>', $data)
         );
     }
 


### PR DESCRIPTION
Removes up an age-old quirk where every `.` in `<% loop $Foo.Bar.Baz %>` would require an extra `$Up` to “escape” from. That was actually a feature, but I’m yet to see compelling use-case for it and it keeps causing confusion (see #4015).

Yes this will probably cause breakages for people upgrading, but they’re going to be easy ones to fix. I’ve changed the `user_error()` to an exception, because that way it’s at least possible to see the name of the template that’s affected (even if only the “compiled” line number is shown).

3.x and 4.x:
```html
{$Title}		<!-- Current page title -->
<% loop $Children.Limit(5) %>
    {$Title		<!-- Child page title -->
    {$Up.Title}		<!-- Nothing - equivalent to `$Children.Title` -->
    {$Up.Up.Title}	<!-- Current page title -->
<% end_loop %>
```

After this change:
```html
{$Title}		<!-- Current page title -->
<% loop $Children.Limit(5) %>
    {$Title		<!-- Child page title -->
    {$Up.Title}		<!-- Current page title -->
    {$Up.Up.Title}	<!-- Exception: Up called when we're already at the top of the scope -->
<% end_loop %>
```