### PR TITLE
fix Versioned::choose_site_stage() if no request given

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -1216,7 +1216,7 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 	 */
 	public static function choose_site_stage(SS_HTTPRequest $request = null) {
 		if (!$request) {
-			throw new InvalidArgumentException("Request not found");
+			$request = Controller::curr()->getRequest();
 		}
 		$mode = static::get_default_reading_mode();
 

--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -1215,9 +1215,13 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 	 * @param SS_HTTPRequest|null $request
 	 */
 	public static function choose_site_stage(SS_HTTPRequest $request = null) {
-		if (!$request) {
+		if (!$request && Controller::has_curr()) {
 			$request = Controller::curr()->getRequest();
 		}
+		if (!$request) {
+			throw new InvalidArgumentException("Request not found");
+		}
+		
 		$mode = static::get_default_reading_mode();
 
         // Check any pre-existing session mode


### PR DESCRIPTION
Load request from current controller as a fallback if none is given.

Several modules break because previous version of choose_site_stage() didn't need the request. 