### PR TITLE
Ensure no cli requests get forced to HTTPS

### DIFF
--- a/src/Control/Middleware/CanonicalURLMiddleware.php
+++ b/src/Control/Middleware/CanonicalURLMiddleware.php
@@ -349,6 +349,10 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      */
     protected function isEnabled()
     {
+        if (Director::is_cli()) {
+            return false;
+        }
+
         // At least one redirect must be enabled
         if (!$this->getForceWWW() && !$this->getForceSSL()) {
             return false;


### PR DESCRIPTION
This resolves an issue where it is possible to break CLI commands by attempting to route them to HTTPS. For example if you have a global `Director::ForceSSL()` you break dev/builds via CLI.

Notably this is causing issues in the CWP 2.0 release which forces SSL in specific places. This means that dev/builds _cannot_ complete during deployments resulting in broken sites.