### PR TITLE
BUG Prevent canonical URL causing a redirect on CLI unless explicitly enabled

### DIFF
--- a/src/Control/Middleware/CanonicalURLMiddleware.php
+++ b/src/Control/Middleware/CanonicalURLMiddleware.php
@@ -43,7 +43,8 @@ class CanonicalURLMiddleware implements HTTPMiddleware
 
     /**
      * Environment variables this middleware is enabled in, or a fixed boolean flag to
-     * apply to all environments
+     * apply to all environments. cli is disabled unless present here as `cli`, or set to true
+     * to force enabled.
      *
      * @var array|bool
      */
@@ -292,7 +293,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
     }
 
     /**
-     * Get enabled flag, or list of environments to enable in
+     * Get enabled flag, or list of environments to enable in.
      *
      * @return array|bool
      */
@@ -302,6 +303,10 @@ class CanonicalURLMiddleware implements HTTPMiddleware
     }
 
     /**
+     * Set enabled flag, or list of environments to enable in.
+     * Note: CLI is disabled by default, so `"cli"(string)` or `true(bool)` should be specified if you wish to
+     * enable for testing.
+     *
      * @param array|bool $enabledEnvs
      * @return $this
      */
@@ -326,6 +331,13 @@ class CanonicalURLMiddleware implements HTTPMiddleware
         if (is_bool($enabledEnvs)) {
             return $enabledEnvs;
         }
+
+        // If CLI, EnabledEnvs must contain CLI
+        if (Director::is_cli() && !in_array('cli', $enabledEnvs)) {
+            return false;
+        }
+
+        // Check other envs
         return empty($enabledEnvs) || in_array(Director::get_environment_type(), $enabledEnvs);
     }
 }


### PR DESCRIPTION
Replaces #8157

Should automatically respect the setEnabledEnvs(true) in tests, meaning these continue to work as expected when testing, even on CLI.