### PR TITLE
Fix obsolete naming

### DIFF
--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -454,16 +454,22 @@ MESSAGE
      */
     public function dontRequireTable($table)
     {
-        if (isset($this->tableList[strtolower($table)])) {
-            $suffix = '';
-            while (isset($this->tableList[strtolower("_obsolete_{$table}$suffix")])) {
-                $suffix = $suffix
-                        ? ((int)$suffix + 1)
-                        : 2;
-            }
-            $this->renameTable($table, "_obsolete_{$table}$suffix");
-            $this->alterationMessage("Table $table: renamed to _obsolete_{$table}$suffix", "obsolete");
+        if (!isset($this->tableList[strtolower($table)])) {
+            return;
         }
+
+        if (Config::inst()->get(static::class, 'fix_table_case_on_build')) {
+            $this->fixTableCase($table);
+        }
+
+        $suffix = '';
+        while (isset($this->tableList[strtolower("_obsolete_{$table}$suffix")])) {
+            $suffix = $suffix
+                    ? ((int)$suffix + 1)
+                    : 2;
+        }
+        $this->renameTable($table, "_obsolete_{$table}$suffix");
+        $this->alterationMessage("Table $table: renamed to _obsolete_{$table}$suffix", "obsolete");
     }
 
     /**

--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -457,19 +457,18 @@ MESSAGE
         if (!isset($this->tableList[strtolower($table)])) {
             return;
         }
-
-        if (Config::inst()->get(static::class, 'fix_table_case_on_build')) {
-            $this->fixTableCase($table);
-        }
-
+        $prefix = "_obsolete_{$table}";
         $suffix = '';
-        while (isset($this->tableList[strtolower("_obsolete_{$table}$suffix")])) {
+        $renameTo = $prefix . $suffix;
+        while (isset($this->tableList[strtolower($renameTo)])) {
             $suffix = $suffix
                     ? ((int)$suffix + 1)
                     : 2;
+            $renameTo = $prefix . $suffix;
         }
-        $this->renameTable($table, "_obsolete_{$table}$suffix");
-        $this->alterationMessage("Table $table: renamed to _obsolete_{$table}$suffix", "obsolete");
+        $renameFrom = $this->tableList[strtolower($table)];
+        $this->renameTable($renameFrom, $renameTo);
+        $this->alterationMessage("Table $table: renamed to $renameTo", "obsolete");
     }
 
     /**


### PR DESCRIPTION
Currently we try to rename obsolete tables without checking their case is correct. Therefore if, after upgrading 3->4 and running a dev/build for the first time, a misnamed table is marked as obsolete you get a failure.

For example
`ALTER TABLE "_obsolete_Page_Versions" RENAME "_obsolete__obsolete_Page_Versions"`

Where `_obsolete_Page_versions` exists but not `_obsolete_Page_Versions`.

This change updates the case of the table before running the rename to obsolete query.