### PR TITLE
BUG Error if invalid stage specified for get_by_stage

### DIFF
--- a/model/Versioned.php
+++ b/model/Versioned.php
@@ -1481,7 +1481,7 @@ class Versioned extends DataExtension implements TemplateGlobalProvider {
 	 */
 	public static function get_by_stage($class, $stage, $filter = '', $sort = '', $join = '', $limit = '',
 			$containerClass = 'DataList') {
-
+		VersionedReadingMode::validateStage($stage);
 		$result = DataObject::get($class, $filter, $sort, $join, $limit, $containerClass);
 		return $result->setDataQueryParam(array(
 			'Versioned.mode' => 'stage',


### PR DESCRIPTION
With this PR, modules that set invalid stage when calling Versioned::get_by_stage() can actually be debugged. Without this, versioned will throw random errors later on in the execution stack which aren't easy to debug.