### PR TITLE
BUG Fix internal date formatting inheriting default locale

### DIFF
--- a/src/Forms/DateField.php
+++ b/src/Forms/DateField.php
@@ -173,9 +173,9 @@ class DateField extends TextField
      */
     public function getDateFormat()
     {
+        // Browsers expect ISO 8601 dates, localisation is handled on the client
         if ($this->getHTML5()) {
-            // Browsers expect ISO 8601 dates, localisation is handled on the client
-            $this->setDateFormat(DBDate::ISO_DATE);
+            return DBDate::ISO_DATE;
         }
 
         if ($this->dateFormat) {
@@ -220,9 +220,7 @@ class DateField extends TextField
             );
         }
 
-
-
-        if ($this->getHTML5() && $this->locale) {
+        if ($this->getHTML5() && $this->locale && $this->locale !== DBDate::ISO_LOCALE) {
             throw new \LogicException(
                 'Please opt-out of HTML5 processing of ISO 8601 dates via setHTML5(false) if using setLocale()'
             );
@@ -254,9 +252,8 @@ class DateField extends TextField
      */
     protected function getInternalFormatter()
     {
-        $locale = i18n::config()->uninherited('default_locale');
         $formatter = IntlDateFormatter::create(
-            i18n::config()->uninherited('default_locale'),
+            DBDate::ISO_LOCALE,
             IntlDateFormatter::MEDIUM,
             IntlDateFormatter::NONE
         );
@@ -448,6 +445,10 @@ class DateField extends TextField
      */
     public function getLocale()
     {
+        // Use iso locale for html5
+        if ($this->getHTML5()) {
+            return DBDate::ISO_LOCALE;
+        }
         return $this->locale ?: i18n::get_locale();
     }
 

--- a/src/Forms/DatetimeField.php
+++ b/src/Forms/DatetimeField.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Forms;
 use IntlDateFormatter;
 use InvalidArgumentException;
 use SilverStripe\i18n\i18n;
+use SilverStripe\ORM\FieldType\DBDate;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\ValidationResult;
 
@@ -297,7 +298,7 @@ class DatetimeField extends TextField
         }
 
         $formatter = IntlDateFormatter::create(
-            i18n::config()->uninherited('default_locale'),
+            DBDate::ISO_LOCALE,
             IntlDateFormatter::MEDIUM,
             IntlDateFormatter::MEDIUM,
             $timezone
@@ -337,10 +338,10 @@ class DatetimeField extends TextField
         $internalFormatter = $this->getInternalFormatter();
         $timestamp = $internalFormatter->parse($value);
 
-        // Retry without "T" separator
+        // Retry with "T" separator
         if (!$timestamp) {
             $fallbackFormatter = $this->getInternalFormatter();
-            $fallbackFormatter->setPattern(DBDatetime::ISO_DATETIME);
+            $fallbackFormatter->setPattern(DBDatetime::ISO_DATETIME_NORMALISED);
             $timestamp = $fallbackFormatter->parse($value);
         }
 

--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -37,6 +37,8 @@ class DBDate extends DBField
     /**
      * Fixed locale to use for ISO date formatting. This is necessary to prevent
      * locale-specific numeric localisation breaking internal date strings.
+     *
+     * @internal (remove internal in 4.2)
      */
     const ISO_LOCALE = 'en_US';
 
@@ -214,6 +216,8 @@ class DBDate extends DBField
     /**
      * Return formatter in a given locale. Useful if localising in a format other than the current locale.
      *
+     * @internal (Remove internal in 4.2)
+     *
      * @param string|null $locale The current locale, or null to use default
      * @param string|null $pattern Custom pattern to use for this, if required
      * @param int $dateLength
@@ -262,11 +266,14 @@ class DBDate extends DBField
      * for the day of the month ("1st", "2nd", "3rd" etc)
      *
      * @param string $format Format code string. See http://userguide.icu-project.org/formatparse/datetime
-     * @param string $locale Custom locale to use
+     * @param string $locale Custom locale to use (add to signature in 5.0)
      * @return string The date in the requested format
      */
-    public function Format($format, $locale = null)
+    public function Format($format)
     {
+        // Note: soft-arg uses func_get_args() to respect semver. Add to signature in 5.0
+        $locale = func_num_args() > 1 ? func_get_arg(1) : null;
+
         if (!$this->value) {
             return null;
         }

--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -38,7 +38,7 @@ class DBDate extends DBField
      * Fixed locale to use for ISO date formatting. This is necessary to prevent
      * locale-specific numeric localisation breaking internal date strings.
      */
-    const ISO_LOCALE = 'en_NZ';
+    const ISO_LOCALE = 'en_US';
 
     public function setValue($value, $record = null, $markChanged = true)
     {
@@ -208,7 +208,7 @@ class DBDate extends DBField
      */
     public function getFormatter($dateLength = IntlDateFormatter::MEDIUM, $timeLength = IntlDateFormatter::NONE)
     {
-        return $this->getCustomFormatter(null, $dateLength, $timeLength);
+        return $this->getCustomFormatter(null, null, $dateLength, $timeLength);
     }
 
     /**
@@ -262,9 +262,10 @@ class DBDate extends DBField
      * for the day of the month ("1st", "2nd", "3rd" etc)
      *
      * @param string $format Format code string. See http://userguide.icu-project.org/formatparse/datetime
+     * @param string $locale Custom locale to use
      * @return string The date in the requested format
      */
-    public function Format($format)
+    public function Format($format, $locale = null)
     {
         if (!$this->value) {
             return null;
@@ -275,9 +276,8 @@ class DBDate extends DBField
             $format = str_replace('{o}', "'{$this->DayOfMonth(true)}'", $format);
         }
 
-        $formatter = $this->getFormatter();
-        $formatter->setPattern($format);
-        return $formatter->format($this->getTimestamp());
+        $formatter = $this->getCustomFormatter($locale, $format);
+        return $formatter->Format($this->getTimestamp());
     }
 
     /**
@@ -311,9 +311,7 @@ class DBDate extends DBField
         }
 
         // Get user format
-        $format = $member->getDateFormat();
-        $formatter = $this->getCustomFormatter($format, $member->getLocale());
-        return $formatter->format($this->getTimestamp());
+        return $this->Format($member->getDateFormat(), $member->getLocale());
     }
 
     /**
@@ -549,7 +547,7 @@ class DBDate extends DBField
      */
     public function URLDate()
     {
-        return rawurlencode($this->Format(self::ISO_DATE));
+        return rawurlencode($this->Format(self::ISO_DATE, self::ISO_LOCALE));
     }
 
     public function scaffoldFormField($title = null, $params = null)

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -111,7 +111,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
         $timeFormat = $member->getTimeFormat();
 
         // Get user format
-        return $this->Format($dateFormat . ' ' . $timeFormat);
+        return $this->Format($dateFormat . ' ' . $timeFormat, $member->getLocale());
     }
 
     public function requireField()
@@ -135,16 +135,17 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      */
     public function URLDatetime()
     {
-        return rawurlencode($this->Format(self::ISO_DATETIME));
+        return rawurlencode($this->Format(self::ISO_DATETIME, self::ISO_LOCALE));
     }
 
     public function scaffoldFormField($title = null, $params = null)
     {
         $field = DatetimeField::create($this->name, $title);
         $dateTimeFormat = $field->getDatetimeFormat();
+        $locale = $field->getLocale();
 
         // Set date formatting hints and example
-        $date = static::now()->Format($dateTimeFormat);
+        $date = static::now()->Format($dateTimeFormat, $locale);
         $field
             ->setDescription(_t(
                 'SilverStripe\\Forms\\FormField.EXAMPLE',
@@ -225,7 +226,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      */
     public function getFormatter($dateLength = IntlDateFormatter::MEDIUM, $timeLength = IntlDateFormatter::MEDIUM)
     {
-        return new IntlDateFormatter(i18n::get_locale(), $dateLength, $timeLength);
+        return parent::getFormatter($dateLength, $timeLength);
     }
 
 

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -2,15 +2,14 @@
 
 namespace SilverStripe\ORM\FieldType;
 
+use Exception;
 use IntlDateFormatter;
+use InvalidArgumentException;
 use SilverStripe\Forms\DatetimeField;
-use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\DB;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 use SilverStripe\View\TemplateGlobalProvider;
-use Exception;
-use InvalidArgumentException;
 
 /**
  * Represents a date-time field.
@@ -232,6 +231,8 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
 
     /**
      * Return formatter in a given locale. Useful if localising in a format other than the current locale.
+     *
+     * @internal (Remove internal in 4.2)
      *
      * @param string|null $locale The current locale, or null to use default
      * @param string|null $pattern Custom pattern to use for this, if required

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -228,6 +228,38 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
         return new IntlDateFormatter(i18n::get_locale(), $dateLength, $timeLength);
     }
 
+
+    /**
+     * Return formatter in a given locale. Useful if localising in a format other than the current locale.
+     *
+     * @param string|null $locale The current locale, or null to use default
+     * @param string|null $pattern Custom pattern to use for this, if required
+     * @param int $dateLength
+     * @param int $timeLength
+     * @return IntlDateFormatter
+     */
+    public function getCustomFormatter(
+        $locale = null,
+        $pattern = null,
+        $dateLength = IntlDateFormatter::MEDIUM,
+        $timeLength = IntlDateFormatter::MEDIUM
+    ) {
+        return parent::getCustomFormatter($locale, $pattern, $dateLength, $timeLength);
+    }
+
+    /**
+     * Formatter used internally
+     *
+     * @internal
+     * @return IntlDateFormatter
+     */
+    protected function getInternalFormatter()
+    {
+        $formatter = $this->getCustomFormatter(DBDate::ISO_LOCALE, DBDatetime::ISO_DATETIME);
+        $formatter->setLenient(false);
+        return $formatter;
+    }
+
     /**
      * Get standard ISO date format string
      *

--- a/tests/php/Forms/DatetimeFieldTest.php
+++ b/tests/php/Forms/DatetimeFieldTest.php
@@ -109,11 +109,11 @@ class DatetimeFieldTest extends SapphireTest
     {
         $f = new DatetimeField('Datetime', 'Datetime');
         $f->setValue('2003-03-29 23:59:38');
-        $this->assertEquals($f->dataValue(), '2003-03-29 23:59:38', 'Accepts ISO');
+        $this->assertEquals('2003-03-29 23:59:38', $f->dataValue(), 'Accepts ISO');
 
         $f = new DatetimeField('Datetime', 'Datetime');
         $f->setValue('2003-03-29T23:59:38');
-        $this->assertNull($f->dataValue(), 'Rejects normalised ISO');
+        $this->assertEquals('2003-03-29 23:59:38', $f->dataValue(), 'Accepts normalised ISO');
     }
 
     public function testSubmittedValue()
@@ -152,7 +152,7 @@ class DatetimeFieldTest extends SapphireTest
         $this->assertTrue($f->validate(new RequiredFields()));
 
         $f = new DatetimeField('Datetime', 'Datetime', '2003-03-29T23:59:38');
-        $this->assertFalse($f->validate(new RequiredFields()), 'Normalised ISO');
+        $this->assertTrue($f->validate(new RequiredFields()), 'Normalised ISO');
 
         $f = new DatetimeField('Datetime', 'Datetime', '2003-03-29');
         $this->assertFalse($f->validate(new RequiredFields()), 'Leaving out time');

--- a/tests/php/ORM/DBDatetimeTest.php
+++ b/tests/php/ORM/DBDatetimeTest.php
@@ -2,10 +2,9 @@
 
 namespace SilverStripe\ORM\Tests;
 
+use SilverStripe\Dev\SapphireTest;
 use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\FieldType\DBDatetime;
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Security\Member;
 
 /**
  * Tests for {@link Datetime} class.
@@ -68,6 +67,23 @@ class DBDatetimeTest extends SapphireTest
 
         $date = DBDatetime::create_field('Datetime', '3000-10-10 15:32:24');
         $this->assertEquals('10 Oct 3000 15 32 24', $date->Format('d MMM y H m s'));
+    }
+
+    /**
+     * Coverage for dates using hindi-numerals
+     */
+    public function testHindiNumerals()
+    {
+        // Parent locale is english; Can be localised to arabic
+        $date = DBDatetime::create_field('Datetime', '1600-10-10 15:32:24');
+        $this->assertEquals('10 Oct 1600 15 32 24', $date->Format('d MMM y H m s'));
+        $this->assertEquals('١٠ أكتوبر ١٦٠٠ ١٥ ٣٢ ٢٤', $date->Format('d MMM y H m s', 'ar'));
+
+        // Parent locale is arabic; Datavalue uses ISO date
+        i18n::set_locale('ar');
+        $date = DBDatetime::create_field('Datetime', '1600-10-10 15:32:24');
+        $this->assertEquals('١٠ أكتوبر ١٦٠٠ ١٥ ٣٢ ٢٤', $date->Format('d MMM y H m s'));
+        $this->assertEquals('1600-10-10 15:32:24', $date->getValue());
     }
 
     public function testNice()


### PR DESCRIPTION
Fixes #8097

Marked as WIP because there are other issues yet to test, and I haven't updated unit tests to cover the new issues.

The issue came about because we were using setPattern() for localisation of internal date formats, but we WEREN'T setting locale. This ment that "now" time `2018-06-13 12:37:40` would instead be localised as `٢٠١٨-٠٦-١٣ ١٢:٣٧:٤٠`, for instance, due to arabic numeric localisation rules.