### PR TITLE
FIX SapphireTest can load relative fixtures in subfolders, switch "needs db" priority check order

### DIFF
--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -1191,15 +1191,9 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
         
         // Support fixture paths relative to the test class, rather than relative to webroot
         // String checking is faster than file_exists() calls.
-        $isRelativeToFile
-            = (strpos('/', $fixtureFilePath) === false)
-            || preg_match('/^(\.){1,2}/', $fixtureFilePath);
-
-        if ($isRelativeToFile) {
-            $resolvedPath = realpath($this->getCurrentAbsolutePath() . '/' . $fixtureFilePath);
-            if ($resolvedPath) {
-                return $resolvedPath;
-            }
+        $resolvedPath = realpath($this->getCurrentAbsolutePath() . '/' . $fixtureFilePath);
+        if ($resolvedPath) {
+            return $resolvedPath;
         }
 
         // Check if file exists relative to base dir


### PR DESCRIPTION
A minute performance gain by checking instance properties for "uses database" before loading and parsing PHPDoc
annotations for the same thing, rather than doing it afterwards.

Fixes #8175 and fixes https://github.com/silverstripe/cwp/issues/104