### PR TITLE
BUG Make regression in #7839 safer

### DIFF
--- a/src/Dev/FixtureFactory.php
+++ b/src/Dev/FixtureFactory.php
@@ -201,15 +201,20 @@ class FixtureFactory
      * If the $class argument is set, limit clearing to items of this class.
      *
      * @param string $limitToClass
+     * @param bool $metadata Clear internal mapping as well as data.
+     * Set to false by default since sometimes data is rolled back by translations.
      */
-    public function clear($limitToClass = null)
+    public function clear($limitToClass = null, $metadata = false)
     {
         $classes = ($limitToClass) ? array($limitToClass) : array_keys($this->fixtures);
         foreach ($classes as $class) {
             $ids = $this->fixtures[$class];
             foreach ($ids as $id => $dbId) {
                 if (class_exists($class)) {
-                    $class::get()->byId($dbId)->delete();
+                    $instance = DataObject::get($class)->byId($dbId);
+                    if ($instance) {
+                        $instance->delete();
+                    }
                 } else {
                     $table = $class;
                     $delete = new SQLDelete("\"$table\"", array(
@@ -218,7 +223,9 @@ class FixtureFactory
                     $delete->execute();
                 }
 
-                unset($this->fixtures[$class][$id]);
+                if ($metadata) {
+                    unset($this->fixtures[$class][$id]);
+                }
             }
         }
     }

--- a/tests/php/Dev/FixtureFactoryTest.php
+++ b/tests/php/Dev/FixtureFactoryTest.php
@@ -136,19 +136,25 @@ class FixtureFactoryTest extends SapphireTest
     public function testClear()
     {
         $factory = new FixtureFactory();
+        $table = TestDataObject::singleton()->baseTable();
         $obj1Id = $factory->createRaw(
-            TestDataObject::singleton()->baseTable(),
+            $table,
             'one',
             array('Name' => 'My Name')
         );
         $obj2 = $factory->createObject(TestDataObject::class, 'two');
 
+        // Clear models only
         $factory->clear();
-
-        $this->assertFalse($factory->getId(TestDataObject::class, 'one'));
+        $this->assertEquals($obj1Id, $factory->getId($table, 'one'));
         $this->assertNull(TestDataObject::get()->byID($obj1Id));
-        $this->assertFalse($factory->getId(TestDataObject::class, 'two'));
+        $this->assertEquals($obj2->ID, $factory->getId(TestDataObject::class, 'two'));
         $this->assertNull(TestDataObject::get()->byID($obj2->ID));
+
+        // Force metadata clear
+        $factory->clear(null, true);
+        $this->assertFalse($factory->getId($table, 'one'));
+        $this->assertFalse($factory->getId(TestDataObject::class, 'two'));
     }
 
     public function testClearWithClass()


### PR DESCRIPTION
The regression is that clearFixtures() used to be safe in tests, but now it flushes the entire fixture factory for the lifetime of the test class. This will break all tests in the same class that are executed afterwards.

By making it harder to flush the metadata un-upgrade tests will no longer break.

Related https://github.com/symbiote/silverstripe-advancedworkflow/pull/364

Replaces https://github.com/silverstripe/silverstripe-framework/pull/8178