### PR TITLE
FIX Add Embed dispatchers to be configured with injector

### DIFF
--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\View\Shortcodes;
 
+use Embed\Http\DispatcherInterface;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\View\HTML;
@@ -68,6 +69,8 @@ class EmbedShortcodeProvider implements ShortcodeHandler
                 $serviceURL,
                 $extra['resolver']['config']
             );
+        } elseif (Injector::inst()->has(DispatcherInterface::class)) {
+            $dispatcher = Injector::inst()->get(DispatcherInterface::class);
         }
 
         // Process embed


### PR DESCRIPTION
Provides the foundation for fixing https://github.com/silverstripe/silverstripe-cms/issues/2168 in CWP by allowing configuration based proxy configuration for the dispatcher than `Embed` uses.

Also see https://github.com/silverstripe/silverstripe-asset-admin/pull/793