### PR TITLE
FIX Default cache state should be `no-cache`

### DIFF
--- a/src/Control/Middleware/HTTPCacheControlMiddleware.php
+++ b/src/Control/Middleware/HTTPCacheControlMiddleware.php
@@ -26,6 +26,8 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
 
     const STATE_DISABLED = 'disabled';
 
+    const STATE_DEFAULT = 'default';
+
     /**
      * Generate response for the given request
      *
@@ -90,6 +92,9 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
         self::STATE_ENABLED => [
             'must-revalidate' => true,
         ],
+        self::STATE_DEFAULT => [
+            'no-cache' => true,
+        ],
     ];
 
     /**
@@ -98,7 +103,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @config
      * @var string
      */
-    protected static $defaultState = self::STATE_DISABLED;
+    protected static $defaultState = self::STATE_DEFAULT;
 
     /**
      * Current state


### PR DESCRIPTION
In SS <4.2 the default cache-control headers directives are: `max-age=0, must-revalidate, no-transform`

It was agreed that `no-transform` would be dropped from the directives list as it wasn't really relevant.

These remaining directives are equivalent to `no-cache` not `no-store`, we should set a default state to `no-cache` to keep this behaviour consistent and allow responses to have `ETag`s included.