### PR TITLE
FIX Switch to Trusty in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: precise
+dist: trusty
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
       env: DB=MYSQL BEHAT_TEST=1 CMS_TEST=1
 
 before_script:
+ # Fix bug in Selenium with duplicate localhost definitions: https://github.com/travis-ci/travis-ci/issues/3054
+ - "sed 's/localhost localhost/localhost/' /etc/hosts > /tmp/etchoststmp && cat /tmp/etchoststmp | sudo tee /etc/hosts"
+
  - export CORE_RELEASE=$TRAVIS_BRANCH
  - if ! [ $(phpenv version-name) = "5.3" ]; then printf "\n" | travis_retry pecl install imagick; fi
  - if [ $(phpenv version-name) = "5.3" ]; then printf "\n" | travis_retry pecl install imagick-3.3.0; fi


### PR DESCRIPTION
Follow on from #8161 to switch precise to trusty, to see what breaks. Composer won't install correctly in my fork's Travis set up for 3.x builds so couldn't test it outside of a PR (easily). _Edit:_ OK I worked out how to build in our fork. Behat tests are failing, will see what I can do quickly...