### PR TITLE
Ensure silverstripe/recipe-cms is installed from source during Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_script:
   - composer require silverstripe/recipe-testing:^1 silverstripe/recipe-core:4.2.x-dev silverstripe/admin:1.2.x-dev silverstripe/versioned:1.2.x-dev --no-update
   - if [[ $PHPUNIT_TEST == cms ]]; then composer require silverstripe/recipe-cms:4.2.x-dev --no-update; fi
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
-  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 # Log constants to CI for debugging purposes
   - php ./tests/dump_constants.php


### PR DESCRIPTION
The 4.2+ CMS Travis runs aren't doing anything at the moment because the module is being installed from dist, excluding test files.