### PR TITLE
FIX Set default stage to draft when running functional tests

### DIFF
--- a/dev/FunctionalTest.php
+++ b/dev/FunctionalTest.php
@@ -97,6 +97,10 @@ class FunctionalTest extends SapphireTest {
 		BasicAuth::protect_entire_site(false);
 
 		SecurityToken::disable();
+
+		if (!Versioned::get_reading_mode()) {
+			Versioned::set_reading_mode('Stage.Stage');
+		}
 	}
 
 	public function tearDown() {


### PR DESCRIPTION
The new change to validate reading mode in 3.7 is causing many functional tests to break with Invalid stage name "". When running a functional test we should at least use the draft reading mode, rather than allowing it to be empty.

Fixes https://github.com/silverstripe/silverstripe-contentreview/issues/88

The tests in this module are setting up fixtures, logging the user in then performing post requests and testing the results. There's nothing that explicitly deals with stages, which implies this is a core bug.

Open for discussion