### PR TITLE
[WIP] Make PDOQuery::getIterator() a generator

### DIFF
--- a/src/ORM/Connect/PDOQuery.php
+++ b/src/ORM/Connect/PDOQuery.php
@@ -17,8 +17,6 @@ class PDOQuery extends Query
      */
     protected $statement = null;
 
-    protected $results = null;
-
     /**
      * Hook the result-set given into a Query class, suitable for use by SilverStripe.
      * @param PDOStatement $statement The internal PDOStatement containing the results
@@ -26,20 +24,19 @@ class PDOQuery extends Query
     public function __construct(PDOStatement $statement)
     {
         $this->statement = $statement;
-        // Since no more than one PDOStatement for any one connection can be safely
-        // traversed, each statement simply requests all rows at once for safety.
-        // This could be re-engineered to call fetchAll on an as-needed basis
-        $this->results = $statement->fetchAll(PDO::FETCH_ASSOC);
-        $statement->closeCursor();
     }
 
     public function getIterator()
     {
-        return new ArrayIterator($this->results);
+        if (is_object($this->statement)) {
+            while ($data = $this->statement->fetch(PDO::FETCH_ASSOC)) {
+                yield $data;
+            }
+        }
     }
 
     public function numRecords()
     {
-        return count($this->results);
+        return $this->statement->rowCount();
     }
 }

--- a/src/ORM/Connect/PDOQuery.php
+++ b/src/ORM/Connect/PDOQuery.php
@@ -28,10 +28,8 @@ class PDOQuery extends Query
 
     public function getIterator()
     {
-        if (is_object($this->statement)) {
-            while ($data = $this->statement->fetch(PDO::FETCH_ASSOC)) {
-                yield $data;
-            }
+        while ($data = $this->statement->fetch(PDO::FETCH_ASSOC)) {
+            yield $data;
         }
     }
 

--- a/src/ORM/Connect/PDOQuery.php
+++ b/src/ORM/Connect/PDOQuery.php
@@ -26,6 +26,11 @@ class PDOQuery extends Query
         $this->statement = $statement;
     }
 
+    public function __destruct()
+    {
+        $this->statement->closeCursor();
+    }
+
     public function getIterator()
     {
         while ($data = $this->statement->fetch(PDO::FETCH_ASSOC)) {

--- a/tests/php/Dev/CsvBulkLoaderTest.php
+++ b/tests/php/Dev/CsvBulkLoaderTest.php
@@ -216,8 +216,8 @@ class CsvBulkLoaderTest extends SapphireTest
         // Test nested setting of relation properties
         $contractAmount = DBField::create_field('Currency', $compareRow[5])->RAW();
         $this->assertEquals(
-            $testPlayer->Contract()->Amount,
             $contractAmount,
+            $testPlayer->Contract()->Amount,
             'Setting nested values in a relation works'
         );
 

--- a/tests/php/Dev/CsvBulkLoaderTest.php
+++ b/tests/php/Dev/CsvBulkLoaderTest.php
@@ -214,10 +214,10 @@ class CsvBulkLoaderTest extends SapphireTest
         $this->assertEquals($testPlayer->ContractID, $testContract->ID, 'Creating new has_one relation works');
 
         // Test nested setting of relation properties
-        $contractAmount = DBField::create_field('Currency', $compareRow[5])->RAW();
+        $contractAmount = DBField::create_field('Currency', $compareRow[5])->Nice();
         $this->assertEquals(
             $contractAmount,
-            $testPlayer->Contract()->Amount,
+            $testPlayer->Contract()->dbObject('Amount')->Nice(),
             'Setting nested values in a relation works'
         );
 

--- a/tests/php/ORM/DBMoneyTest.php
+++ b/tests/php/ORM/DBMoneyTest.php
@@ -292,7 +292,7 @@ class DBMoneyTest extends SapphireTest
             )->value()
         );
         $this->assertEquals(
-            '1.23',
+            '1.2300',
             DB::query(
                 sprintf(
                     'SELECT "MyMoneyAmount" FROM "MoneyTest_DataObject" WHERE "ID" = %d',

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -8,6 +8,7 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\Connect\MySQLDatabase;
+use SilverStripe\ORM\Connect\PDOQuery;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectSchema;
 use SilverStripe\ORM\DB;

--- a/tests/php/ORM/DataObjectTest.yml
+++ b/tests/php/ORM/DataObjectTest.yml
@@ -49,7 +49,7 @@ SilverStripe\ORM\Tests\DataObjectTest\Player:
   captain1:
     FirstName: Captain
     Surname: Zookeeper
-    ShirtNumber: 007
+    ShirtNumber: '007'
     FavouriteTeam: =>SilverStripe\ORM\Tests\DataObjectTest\Team.team1
     Teams: =>SilverStripe\ORM\Tests\DataObjectTest\Team.team1
     FoundingTeams: =>SilverStripe\ORM\Tests\DataObjectTest\Team.team1


### PR DESCRIPTION
The one-statement-at-a-time limitation mentioned [here](https://github.com/silverstripe/silverstripe-framework/blob/4.2.0-beta1/src/ORM/Connect/PDOQuery.php#L28-L30) is apparently only applicable when PHP is compiled with `libmysqlclient`. `mysqlnd` is highly recommended, and has apparently been the default since PHP 5.4: http://php.net/manual/en/mysqlinfo.library.choosing.php. ~I’m yet to get a `libmysqlclient` environment set up to test on, but if we really want to keep `libmysqlclient` support then hopefully there is some way to detect the library in use, and use the existing `fetchAll()` upfront if needed.~

I’ve not benchmarked before/after removing prepared statement caching yet, but I suspect the difference will be small. The number of repeated queries is small for most sites, and the roundtrip to prepare them is fast. The reason for that change is highlighted in one test specifically:

- https://github.com/silverstripe/silverstripe-framework/blob/4.2.0-beta1/tests/php/ORM/PDODatabaseTest.php#L29-L32 binds a parameter `0` into the query
- https://github.com/silverstripe/silverstripe-framework/blob/4.2.0-beta1/tests/php/ORM/PDODatabaseTest.php#L34-L37 has identical SQL, so re-uses the prepared statement but overrides the bound value to `2`

Currently, this only “works” accidentally because we’re calling `fetchAll()` as soon as the query is executed. You can’t clone a `PDOStatement` as a workaround either 😞.

The benefit of this change is memory savings, especially for large result sets, as currently every single row is loaded into memory at once, for every active query.