### PR TITLE
Correct path in $ModulePath example for templates

### DIFF
--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -467,7 +467,7 @@ Usage in templates:
 
 ```diff
 -<img src="framework/images/image.png" />
-+<img src="$ModulePath(silverstripe/framework)/image.png" />
++<img src="$ModulePath(silverstripe/framework)/images/image.png" />
 
 -<% require css("framework/css/styles.css") %>
 +<% require css("silverstripe/framework: css/styles.css") %>


### PR DESCRIPTION
The images/ subfolder was missing from the example. That said, this is not working as expected for me (see  #8210).