### PR TITLE
FIX FormField::Link works when no form is currently set

### DIFF
--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms;
 
+use LogicException;
 use ReflectionClass;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\RequestHandler;
@@ -355,14 +356,20 @@ class FormField extends RequestHandler
     }
 
     /**
-     * Return a link to this field.
+     * Return a link to this field
      *
      * @param string $action
-     *
      * @return string
+     * @throws LogicException If no form is set yet
      */
     public function Link($action = null)
     {
+        if (!$this->form) {
+            throw new LogicException(
+                'Field must be associated with a form to call Link(). Please use $field->setForm($form);'
+            );
+        }
+
         $link = Controller::join_links($this->form->FormAction(), 'field/' . $this->name, $action);
         $this->extend('updateLink', $link, $action);
         return $link;

--- a/tests/php/Forms/FormFieldTest.php
+++ b/tests/php/Forms/FormFieldTest.php
@@ -384,4 +384,22 @@ class FormFieldTest extends SapphireTest
         $this->assertFalse($field->hasClass('banana'));
         $this->assertTrue($field->hasClass('cool-BAnana'));
     }
+
+    public function testLinkWithForm()
+    {
+        $field = new FormField('Test');
+        $form = new Form(null, 'Test', new FieldList, new FieldList);
+        $form->setFormAction('foo');
+        $field->setForm($form);
+        $this->assertSame('foo/field/Test/bar', $field->Link('bar'));
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testLinkWithoutForm()
+    {
+        $field = new FormField('Test');
+        $field->Link('bar');
+    }
 }


### PR DESCRIPTION
Most places where `$this->form` is used in FormField are checked for truthy first, this part of the code fails when requesting a form schema for a readonly form (e.g. history viewer) when an UploadField (that uses `$this->Link('upload')`) is cast as readonly with no form set.

This PR returns null from `FormField::Link` if there isn't a form available to the instance yet.

Related: https://github.com/silverstripe/cwp/issues/115