### PR TITLE
Add 'updateComponents' extend in DataObject->getComponents()

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1639,6 +1639,8 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 		}
 
 		if($this->model) $result->setDataModel($this->model);
+		
+		$this->extend('updateComponents', $result);
 
 		return $result
 			->forForeignID($this->ID)


### PR DESCRIPTION
At the moment there is `$this->extend('updateManyManyComponents', $result);` in `DataObject->getManyManyComponents()`. If the suggested change is accepted this will allow developer to extend `HasManyList` (like it's possible at the moment for ManyManyList) for different relations and add additional and specific filters for these relations. And if filter should be modified to work some other way all changes will be made on one place. Another benefit is that default filters also could be added.

Here is simple example:

```php
<?php

class Order extends DataObject {
    protected static $has_many = array(
        'OrderItems' => 'OrderItem',
    );
}

class OrderItem extends DataObject {
    protected static $db = array(
        'StartDateTime' => 'DateTime',
        'Quantity' => 'Int',
        'Cost' => 'Int'
    );

    protected static $has_one = array(
        'Order' => 'Order',
        'Product' => 'Product',
    );
}

class Product extends DataObject {
    protected static $has_many = array(
        'OrderItems' => 'OrderItem',
    );
}

class DataObjectExtention extends DataExtention {
    //At the moment this is possible becauase there is $this->extend('updateManyManyComponents', $result); in DataObject->getManyManyComponents()
    public function updateManyManyComponents($result) {
        //Logic to find the correct class
        //Logit to create this new object
        $result = $newObject; 
    }

    //At the moment this is NOT possible becauase there is NO $this->extend('updateComponents', $result); in DataObject->getComponents()
    public function updateComponents($result) {
        //Logic to find the correct class
        //Logit to create this new object
        $result = $newObject; // In the code executed by Something->SomeFunction() it will return OrderItemHasManyList
    }
}

class OrderItemHasManyList extends HasManyList {
    public function inFuture($strDateTime = '') {
        if (empty($strDateTime))
            $strDateTime = SS_DateTime::now()->format('Y-m-d H:i:s');

        return $this->filter(array(
            'StartDateTime:GreaterThan' => $strDateTime,
        ));
    }

    public function quantityGreaterThan($iQuantity) {
        return $this->filter(array(
            'Quantity:GreaterThan' => $iQuantity,
        ));
    }
}

class Something {
    public function SomeFunction() {
        $order = Order::get()->first();
        $order->OrderItems() //because DataObjectExtention->updateComponents() will be called this will return OrderItemHasManyList
              ->inFuture()
              ->quantityGreaterThan(100);
        $product = Product::get()->first();
        $product->OrderItems() //because DataObjectExtention->updateComponents() will be called this will return OrderItemHasManyList
                ->quantityGreaterThan(50);
    }
}

```