### PR TITLE
HTTP Caching fixes :/

### DIFF
--- a/src/Control/Middleware/HTTPCacheControlMiddleware.php
+++ b/src/Control/Middleware/HTTPCacheControlMiddleware.php
@@ -26,6 +26,8 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
 
     const STATE_DISABLED = 'disabled';
 
+    const STATE_DEFAULT = 'default';
+
     /**
      * Generate response for the given request
      *
@@ -90,6 +92,9 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
         self::STATE_ENABLED => [
             'must-revalidate' => true,
         ],
+        self::STATE_DEFAULT => [
+            'no-cache' => true,
+        ],
     ];
 
     /**
@@ -98,7 +103,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @config
      * @var string
      */
-    protected static $defaultState = self::STATE_DISABLED;
+    protected static $defaultState = self::STATE_DEFAULT;
 
     /**
      * Current state

--- a/src/Control/Middleware/HTTPCacheControlMiddleware.php
+++ b/src/Control/Middleware/HTTPCacheControlMiddleware.php
@@ -771,13 +771,8 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
         }
 
         // Errors disable cache (unless some errors are cached intentionally by usercode)
-        if ($response->isError()) {
+        if ($response->isError() || $response->isRedirect()) {
             // Even if publicCache(true) is specified, errors will be uncacheable
-            $this->disableCache(true);
-        }
-
-        // Don't cache redirects
-        if ($response->isRedirect()) {
             $this->disableCache(true);
         }
     }

--- a/src/Control/Middleware/HTTPCacheControlMiddleware.php
+++ b/src/Control/Middleware/HTTPCacheControlMiddleware.php
@@ -103,7 +103,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @config
      * @var string
      */
-    protected static $defaultState = self::STATE_DEFAULT;
+    private static $defaultState = self::STATE_DEFAULT;
 
     /**
      * Current state


### PR DESCRIPTION
This PR consists of:

1. Backport of ~#8165~ https://github.com/silverstripe/silverstripe-framework/pull/8195 (which should have gone into 4.2 not 4)
2. Making the defaultState config a `private static` (the `@config` tag is not working for me locally)

I've noticed during testing that if you have a session active, the default state changes to `private, must-revalidate` which doesn't seem right to me when it should probably hold the current state and simply add `private` and `must-revalidate` to the current state...