### PR TITLE
fix for handling arrays in url params when filter is used

### DIFF
--- a/admin/javascript/lib.js
+++ b/admin/javascript/lib.js
@@ -183,7 +183,9 @@
 					parts = search ? search.split( '&' ) : [], i, tmp;
 				for(i=0; i < parts.length; i++) {
 					tmp = parts[i].split( '=' );
-					params[tmp[0]] = tmp[1];
+					// if key already exists, do not override its value but try to build url query instead
+					if (params.hasOwnProperty(tmp[0])) params[tmp[0]] += "&" + tmp[0] + "=" + tmp[1];
+					else params[tmp[0]] = tmp[1];
 				}
 				return params;
 			},


### PR DESCRIPTION
when filter is used and there is an array in url query params (i.e. Listbox with multiple options selected), then is clicked on record (edit) and you got redirected, params in url will get broken
fix this by building query on first match in js object to serialize it correctly to prevent losing values

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/