### PR TITLE
Make column work

### DIFF
--- a/templates/forms/CompositeField_holder.ss
+++ b/templates/forms/CompositeField_holder.ss
@@ -4,8 +4,8 @@
 	<% end_if %>
 
 	<% loop $FieldList %>
-		<% if $ColumnCount %>
-			<div class="column-{$ColumnCount} $FirstLast">
+		<% if $Top.ColumnCount %>
+			<div class="column-{$Top.ColumnCount} $FirstLast">
 				$FieldHolder
 			</div>
 		<% else %>


### PR DESCRIPTION
The ColumnCount is set on the CompositeField class, and not on its FieldList. So to get the ColumnCount, we need to use $Top to get out of the loop.

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/