### PR TITLE
FIX: Remove X-Requested-With from default Vary header.

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -16,7 +16,7 @@ HTTP:
     no-cache: "true"
     no-store: "true"
     must-revalidate: "true"
-  vary: "X-Requested-With, X-Forwarded-Protocol"
+  vary: "X-Forwarded-Protocol"
 LeftAndMain:
   dependencies:
     versionProvider: %$SilverStripeVersionProvider

--- a/control/Director.php
+++ b/control/Director.php
@@ -918,6 +918,9 @@ class Director implements TemplateGlobalProvider {
 	 * by checking for a custom header set by jQuery or
 	 * wether a manually set request-parameter 'ajax' is present.
 	 *
+	 * Note that if you plan to use this to alter your HTTP response on a cached page,
+	 * you should add X-Requested-With to the Vary header.
+	 *
 	 * @return boolean
 	 */
 	public static function is_ajax() {

--- a/docs/en/02_Developer_Guides/08_Performance/02_HTTP_Cache_Headers.md
+++ b/docs/en/02_Developer_Guides/08_Performance/02_HTTP_Cache_Headers.md
@@ -209,7 +209,7 @@ when calculating a cache key, usually in addition to the full URL path.
 By default, SilverStripe will output a `Vary` header with the following content: 
 
 ```
-Vary: X-Requested-With, X-Forwarded-Protocol
+Vary: X-Forwarded-Protocol
 ```
 
 To change the value of the `Vary` header, you can change this value by specifying the header in configuration.
@@ -218,3 +218,6 @@ To change the value of the `Vary` header, you can change this value by specifyin
 HTTP:
   vary: ""
 ```
+
+Note that if you use `Director::is_ajax()` on cached pages then you should add `X-Requested-With` to the vary
+header.

--- a/tests/control/HTTPTest.php
+++ b/tests/control/HTTPTest.php
@@ -77,7 +77,6 @@ class HTTPTest extends FunctionalTest {
 		$this->assertNotEmpty($v);
 
 		$this->assertContains("X-Forwarded-Protocol", $v);
-		$this->assertContains("X-Requested-With", $v);
 		$this->assertNotContains("Cookie", $v);
 		$this->assertNotContains("User-Agent", $v);
 		$this->assertNotContains("Accept", $v);


### PR DESCRIPTION
The X-Requested-With header does modify the result of Director::is_ajax
and so this should strictly be in there. In practise, this can cause
issues with CDNs such as Incapsula, and LeftAndMain adds this vary
header itself, which is the principle place where Director::is_ajax
is used.