### PR TITLE
Make column query not distinct

### DIFF
--- a/docs/en/04_Changelogs/4.3.0.md
+++ b/docs/en/04_Changelogs/4.3.0.md
@@ -1,0 +1,13 @@
+# 4.2.0
+
+## Overview {#overview}
+
+ - `DataList::column()` now returns all values and not just "distinct" values from a column as per the API docs
+ - `DataList`, `ArrayList` and `UnsavedRalationList` all have `columnUnique()` method for fetching distinct column values
+
+## Upgrading {#upgrading}
+
+### Fetching distinct column values on DataList
+
+Prior to this release `DataList` would erroneously return a distinct list of values from a column on an object.
+If this behaviour is still required, please use `columnUnique()` instead.

--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -371,6 +371,17 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     }
 
     /**
+     * Returns a unique array of a single field value for all the items in the list
+     *
+     * @param string $colName
+     * @return array
+     */
+    public function columnUnique($colName = 'ID')
+    {
+        return array_unique($this->column($colName));
+    }
+
+    /**
      * You can always sort a ArrayList
      *
      * @param string $by

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -990,7 +990,18 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      */
     public function column($colName = "ID")
     {
-        return $this->dataQuery->column($colName);
+        return $this->dataQuery->distinct(false)->column($colName);
+    }
+
+    /**
+     * Returns a unque array of a single field value for all items in the list.
+     *
+     * @param string $colName
+     * @return array
+     */
+    public function columnUnique($colName = "ID")
+    {
+        return $this->dataQuery->distinct(true)->column($colName);
     }
 
     // Member altering methods

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -1147,7 +1147,6 @@ class DataQuery
     {
         $fieldExpression = $this->expressionForField($field);
         $query = $this->getFinalisedQuery(array($field));
-        $query->setDistinct(false);
         $originalSelect = $query->getSelect();
         $query->setSelect(array());
         $query->selectField($fieldExpression, $field);

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -1147,6 +1147,7 @@ class DataQuery
     {
         $fieldExpression = $this->expressionForField($field);
         $query = $this->getFinalisedQuery(array($field));
+        $query->setDistinct(false);
         $originalSelect = $query->getSelect();
         $query->setSelect(array());
         $query->selectField($fieldExpression, $field);

--- a/src/ORM/ListDecorator.php
+++ b/src/ORM/ListDecorator.php
@@ -142,6 +142,11 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
         return $this->list->column($value);
     }
 
+    public function columnUnique($value = "ID")
+    {
+        return $this->list->columnUnique($value);
+    }
+
     public function each($callback)
     {
         return $this->list->each($callback);

--- a/src/ORM/UnsavedRelationList.php
+++ b/src/ORM/UnsavedRelationList.php
@@ -276,6 +276,18 @@ class UnsavedRelationList extends ArrayList implements Relation
     }
 
     /**
+     * Returns a unique array of a single field value for all items in the list.
+     *
+     * @param  string $colName
+     * @return array
+     */
+    public function columnUnique($colName = "ID")
+    {
+        $list = new ArrayList($this->toArray());
+        return $list->columnUnique($colName);
+    }
+
+    /**
      * Returns a copy of this list with the relationship linked to the given foreign ID.
      * @param int|array $id An ID or an array of IDs.
      * @return Relation

--- a/tests/php/Forms/GridField/GridFieldSortableHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldSortableHeaderTest.php
@@ -68,7 +68,7 @@ class GridFieldSortableHeaderTest extends SapphireTest
 
     public function testGetManipulatedData()
     {
-        $list = new DataList(Team::class);
+        $list = Team::get()->filter([ 'ClassName' => Team::class ]);
         $config = new GridFieldConfig_RecordEditor();
         $gridField = new GridField('testfield', 'testfield', $list, $config);
 

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -379,4 +379,22 @@ class DataQueryTest extends SapphireTest
         $this->assertEquals('Last', $second['Title']);
         $this->assertEmpty(array_shift($arrayResult));
     }
+
+    public function testColumnReturnsAllValues()
+    {
+        $first = new DataQueryTest\ObjectA();
+        $first->Name = 'Bar';
+        $first->write();
+
+        $second = new DataQueryTest\ObjectA();
+        $second->Name = 'Foo';
+        $second->write();
+
+        $third = new DataQueryTest\ObjectA();
+        $third->Name = 'Bar';
+        $third->write();
+
+        $result = DataQueryTest\ObjectA::get()->column('Name');
+        $this->assertEquals(['Bar', 'Foo', 'Bar'], $result);
+    }
 }

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -397,4 +397,24 @@ class DataQueryTest extends SapphireTest
         $result = DataQueryTest\ObjectA::get()->column('Name');
         $this->assertEquals(['Bar', 'Foo', 'Bar'], $result);
     }
+
+    public function testColumnUniqueReturnsAllValues()
+    {
+        $first = new DataQueryTest\ObjectA();
+        $first->Name = 'Bar';
+        $first->write();
+
+        $second = new DataQueryTest\ObjectA();
+        $second->Name = 'Foo';
+        $second->write();
+
+        $third = new DataQueryTest\ObjectA();
+        $third->Name = 'Bar';
+        $third->write();
+
+        $result = DataQueryTest\ObjectA::get()->columnUnique('Name');
+        $this->assertCount(2, $result);
+        $this->assertContains('Bar', $result);
+        $this->assertContains('Foo', $result);
+    }
 }


### PR DESCRIPTION
When selecting a column, it doesn't make sense to have it `DISTINCT`. Selecting `$person->column('Age')` would be a prime example.

As an alternative, the API could be changed to give the end user the option
(eg `->column($field, $distinct = false)`)
However if we did that, we would need to make sure we do something
similar with `SilverStripe\ORM\UnsavedRelationList` to ensure consistency.

