### PR TITLE
FIX Duplicate config values for cascade_duplicates no longer duplicate their duplicates

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -428,6 +428,10 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         // Get duplicates
         if ($relations === null) {
             $relations = $this->config()->get('cascade_duplicates');
+            // Remove any duplicate entries before duplicating them
+            if (is_array($relations)) {
+                $relations = array_unique($relations);
+            }
         }
 
         // Create unsaved raw duplicate


### PR DESCRIPTION
Previously you could define identical values for this config prop via a DataExtension and on the base
class, resulting in double duplication

## Affected versions

Probably 4.0 onwards

## Description

If a DataObject with relations defines `$cascade_duplicates = ['FooRelation']` and then a DataExtension on this DataObject _also_ defines the same thing, the cascade_duplicates config prop contains `FooRelation` twice.

This results in `$dataObject->duplicate()` duplicating via cascade_duplicates twice.

**Here's a test that proves this: https://gist.github.com/robbieaverill/0e86150ff96a89f3ec57d1eded0ddb79**. I haven't added this to framework because the bulk of the test didn't seem worth it for this change to me, but if others think it'd be valuable then I'm happy to add it into this PR.

Resolves https://github.com/dnadesign/silverstripe-elemental/issues/220