### PR TITLE
FIX updateValidatePassword calls need to be masked from backtraces

### DIFF
--- a/src/Dev/Backtrace.php
+++ b/src/Dev/Backtrace.php
@@ -45,6 +45,7 @@ class Backtrace
         array('SilverStripe\\Security\\PasswordEncryptor_MySQLOldPassword', 'salt'),
         array('SilverStripe\\Security\\PasswordEncryptor_Blowfish', 'encrypt'),
         array('SilverStripe\\Security\\PasswordEncryptor_Blowfish', 'salt'),
+        array('*', 'updateValidatePassword'),
     );
 
     /**
@@ -106,7 +107,10 @@ class Backtrace
             $match = false;
             if (!empty($bt[$i]['class'])) {
                 foreach ($ignoredArgs as $fnSpec) {
-                    if (is_array($fnSpec) && $bt[$i]['class'] == $fnSpec[0] && $bt[$i]['function'] == $fnSpec[1]) {
+                    if (is_array($fnSpec) &&
+                        ('*' == $fnSpec[0] || $bt[$i]['class'] == $fnSpec[0]) &&
+                        $bt[$i]['function'] == $fnSpec[1]
+                    ) {
                         $match = true;
                     }
                 }

--- a/tests/php/Dev/BacktraceTest.php
+++ b/tests/php/Dev/BacktraceTest.php
@@ -68,4 +68,45 @@ class BacktraceTest extends SapphireTest
         $this->assertEquals('<filtered>', $filtered[1]['args']['password'], 'Filters class functions');
         $this->assertEquals('myval', $filtered[2]['args']['myarg'], 'Doesnt filter other functions');
     }
+
+    public function testFilteredWildCard()
+    {
+        $bt = array(
+            array(
+                'type' => '->',
+                'file' => 'MyFile.php',
+                'line' => 99,
+                'function' => 'myIgnoredGlobalFunction',
+                'args' => array('password' => 'secred',)
+            ),
+            array(
+                'class' => 'MyClass',
+                'type' => '->',
+                'file' => 'MyFile.php',
+                'line' => 99,
+                'function' => 'myIgnoredClassFunction',
+                'args' => array('password' => 'secred',)
+            ),
+            array(
+                'class' => 'MyClass',
+                'type' => '->',
+                'file' => 'MyFile.php',
+                'line' => 99,
+                'function' => 'myFunction',
+                'args' => array('myarg' => 'myval')
+            )
+        );
+        Backtrace::config()->update(
+            'ignore_function_args',
+            array(
+                array('*', 'myIgnoredClassFunction'),
+            )
+        );
+
+        $filtered = Backtrace::filter_backtrace($bt);
+
+        $this->assertEquals('secred', $filtered[0]['args']['password']);
+        $this->assertEquals('<filtered>', $filtered[1]['args']['password']);
+        $this->assertEquals('myval', $filtered[2]['args']['myarg']);
+    }
 }


### PR DESCRIPTION
#7800 should really have made sure that any arguments passed to the `updateValidatePassword` were masked.

Because we can't know what the class name will be, I've introduce the ability to use wildcards for class names when declaring what methods should be filtered.

Future enhancements would be to inspect if the class implements an interface or shares a common class ancestor when filtering