### PR TITLE
Added install-requirement-check for php-intl

### DIFF
--- a/src/Dev/Install/InstallRequirements.php
+++ b/src/Dev/Install/InstallRequirements.php
@@ -384,6 +384,13 @@ class InstallRequirements
             'SimpleXML support not included in PHP.'
         ));
 
+        // Check for INTL support
+        $this->requireClass('IntlTimeZone', array(
+            'PHP Configuration',
+            'Intl support',
+            'Internationalization (php-intl) support not included in PHP.'
+        ));
+
         // Check for token_get_all
         $this->requireFunction('token_get_all', array(
             "PHP Configuration",


### PR DESCRIPTION
This PR adds a check that the php-intl extension is available, and prohibits the installation if missing. 

See: https://github.com/silverstripe/silverstripe-installer/issues/205 for details.