### PR TITLE
FIX sizeof doesnt work with null types

### DIFF
--- a/dev/install/install.php5
+++ b/dev/install/install.php5
@@ -1232,11 +1232,11 @@ class InstallRequirements {
 	}
 
 	public function hasErrors() {
-		return sizeof($this->errors);
+		return empty($this->errors) ? 0 : sizeof($this->errors);
 	}
 
 	public function hasWarnings() {
-		return sizeof($this->warnings);
+		return empty($this->warnings) ? 0 : sizeof($this->warnings);
 	}
 
 }


### PR DESCRIPTION
Getting a warning when using the installer

I've attempted to keep the return type / values the same even though it appears that the result is only used as a boolean