### PR TITLE
FIX: Correct afterCallActionHandler arguments to match SS4.

### DIFF
--- a/control/RequestHandler.php
+++ b/control/RequestHandler.php
@@ -295,7 +295,7 @@ class RequestHandler extends ViewableData {
 
 		$actionRes = $this->$action($request);
 
-		$res = $this->extend('afterCallActionHandler', $request, $action);
+		$res = $this->extend('afterCallActionHandler', $request, $action, $actionRes);
 		if ($res) return reset($res);
 
 		return $actionRes;


### PR DESCRIPTION
The extension point RequestHandler::afterCallActionHandler was missing a critical
argument that has since been added to SS4. This patch backports the change to 3.x.