### PR TITLE
FIX Ensure tests pass by reducing to PHPUnit 7.1.3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.{yml,js,json,css,scss,eslintrc,feature}]
+[*.{yml,js,json,css,scss,eslintrc,feature,xml,xml.dist}]
 indent_size = 2
 indent_style = space
 

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7",
+        "phpunit/phpunit": "7.1.3",
         "silverstripe/versioned": "^2"
     },
     "provide": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,25 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 Standard module phpunit configuration.
-Requires PHPUnit ^5.7
+Requires PHPUnit ^7.1
 -->
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
-	<testsuite name="Default">
-		<directory>tests/php</directory>
+<phpunit
+  bootstrap="tests/bootstrap.php"
+  colors="true"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.1/phpunit.xsd"
+>
+  <testsuites>
+    <testsuite name="Default">
+      <directory>tests/php</directory>
     </testsuite>
     <testsuite name="framework">
-        <directory>tests/php</directory>
+      <directory>tests/php</directory>
     </testsuite>
     <testsuite name="cms">
-        <directory>vendor/silverstripe/cms/tests</directory>
+      <directory>vendor/silverstripe/cms/tests</directory>
     </testsuite>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">.</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-                <directory suffix=".php">thirdparty/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+  </testsuites>
+  <filter>
+    <whitelist addUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">.</directory>
+      <exclude>
+        <directory suffix=".php">tests/</directory>
+        <directory suffix=".php">thirdparty/</directory>
+      </exclude>
+    </whitelist>
+  </filter>
 </phpunit>

--- a/src/Control/HTTP.php
+++ b/src/Control/HTTP.php
@@ -463,9 +463,10 @@ class HTTP
 
         // Run middleware
         ChangeDetectionMiddleware::singleton()->process($request, function (HTTPRequest $request) use ($response) {
-            return HTTPCacheControlMiddleware::singleton()->process($request, function (HTTPRequest $request) use ($response) {
-                return $response;
-            });
+            return HTTPCacheControlMiddleware::singleton()
+                ->process($request, function (HTTPRequest $request) use ($response) {
+                    return $response;
+                });
         });
     }
 

--- a/src/Control/HTTPResponse.php
+++ b/src/Control/HTTPResponse.php
@@ -435,9 +435,13 @@ EOT
                 $headers[] = sprintf('%s: %s', $header, $value);
             }
         }
-        return
-            sprintf('HTTP/%s %s %s', $this->getProtocolVersion(), $this->getStatusCode(), $this->getStatusDescription()) . "\r\n" .
-            implode("\r\n", $headers) . "\r\n" . "\r\n" .
-            $this->getBody();
+        return sprintf(
+            'HTTP/%s %s %s',
+            $this->getProtocolVersion(),
+            $this->getStatusCode(),
+            $this->getStatusDescription()
+        ) . "\r\n"
+            . implode("\r\n", $headers) . "\r\n" . "\r\n"
+            . $this->getBody();
     }
 }

--- a/src/Control/Middleware/HTTPCacheControlMiddleware.php
+++ b/src/Control/Middleware/HTTPCacheControlMiddleware.php
@@ -553,8 +553,10 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      *
      * The resulting cache-control headers will be chosen from the 'enabled' set of directives.
      *
-     * Does not set `public` directive. Usually, `setMaxAge()` is sufficient. Use `publicCache()` if this is explicitly required.
-     * See https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#public_vs_private
+     * Does not set `public` directive. Usually, `setMaxAge()` is sufficient. Use `publicCache()` if this is
+     * explicitly required.
+     * See https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency...
+     *      /http-caching#public_vs_private
      *
      * @see https://docs.silverstripe.org/en/developer_guides/performance/http_cache_headers/
      * @param bool $force Force the cache to public even if its unforced private or public
@@ -577,10 +579,12 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * The resulting cache-control headers will be chosen from the 'disabled' set of directives.
      *
      * Removes all state and replaces it with `no-cache, no-store, must-revalidate`. Although `no-store` is sufficient
-     * the others are added under recommendation from Mozilla (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Examples)
+     * the others are added under recommendation from Mozilla
+     * (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Examples)
      *
      * Does not set `private` directive, use `privateCache()` if this is explicitly required.
-     * See https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#public_vs_private
+     * See https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency...
+     *       /http-caching#public_vs_private
      *
      * @see https://docs.silverstripe.org/en/developer_guides/performance/http_cache_headers/
      * @param bool $force Force the cache to diabled even if it's forced private or public

--- a/tests/php/Core/Injector/InjectorTest.php
+++ b/tests/php/Core/Injector/InjectorTest.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Factory;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\Injector\InjectorNotFoundException;
 use SilverStripe\Core\Injector\SilverStripeServiceConfigurationLocator;
 use SilverStripe\Core\Tests\Injector\AopProxyServiceTest\AnotherService;
 use SilverStripe\Core\Tests\Injector\AopProxyServiceTest\SampleService;


### PR DESCRIPTION
PHPUnit 7.1.4 and higher introduces a bug with float comparisons in strings. The fix until this is resolved is to use PHPUnit 7.1.3.

Reference: https://github.com/sebastianbergmann/phpunit/issues/3185

Also updates the phpunit config file to match [the schema](https://phpunit.readthedocs.io/en/7.1/configuration.html) and imports a missing exception namespace.