### PR TITLE
FIX Make sure that we only send arrays on construct of HTTPCacheControl

### DIFF
--- a/control/HTTPCacheControl.php
+++ b/control/HTTPCacheControl.php
@@ -81,7 +81,10 @@ class HTTPCacheControl extends SS_Object {
 
 		// If we've not been provided an initial state, then grab HTTP.cache_contrpl from config
 		if (!$this->state) {
-			$this->setDirectivesFromArray(Config::inst()->get('HTTP', 'cache_control'));
+			$defaultDirectives = Config::inst()->get('HTTP', 'cache_control');
+			if (!empty($defaultDirectives)) {
+				$this->setDirectivesFromArray($defaultDirectives);
+			}
 		}
 	}
 


### PR DESCRIPTION
If you unset the `HTTP.cache_control` config on your site, you get an error because we don't check it's actually got a value...