### PR TITLE
Allow version 4 of nikic/php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "league/csv": "^8",
         "league/flysystem": "~1.0.12",
         "monolog/monolog": "~1.11",
-        "nikic/php-parser": "^2 || ^3",
+        "nikic/php-parser": "^2 || ^3 || ^4",
         "paragonie/random_compat": "^2.0",
         "silverstripe/config": "^1@dev",
         "silverstripe/assets": "^1@dev",


### PR DESCRIPTION
Allow version 4 of the php-parser library.

According to the GitHub repo, version 3 is no longer actively supported and other dependencies or tools like PHPStan may require version 4, creating an uninstallable set of conflicting dependencies.