### PR TITLE
Make removeDuplicates() chainable

### DIFF
--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -253,6 +253,8 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
         if ($renumberKeys) {
             $this->items = array_values($this->items);
         }
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Added the return to allow removeDuplicates to be chained. Would need testing to ensure it doesn't break previous functionality.