### PR TITLE
Allow removeDuplicates to be chainable

### DIFF
--- a/model/ArrayList.php
+++ b/model/ArrayList.php
@@ -216,6 +216,8 @@ class ArrayList extends ViewableData implements SS_List, SS_Filterable, SS_Sorta
 		}
 
 		if($renumberKeys) $this->items = array_values($this->items);
+		
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
Added `return $this` to allow chaining of removeDuplicates. Same PR as one I added to SS4