### PR TITLE
Adds extension hooks to ManyManyList for add and remove operations.

### DIFF
--- a/src/ORM/ManyManyList.php
+++ b/src/ORM/ManyManyList.php
@@ -299,6 +299,8 @@ class ManyManyList extends RelationList
             $manipulation[$this->joinTable]['fields'][$this->localKey] = $itemID;
             $manipulation[$this->joinTable]['fields'][$this->foreignKey] = $foreignID;
 
+            $this->extend('onBeforeAdd', $manipulation, $itemID);
+
             DB::manipulate($manipulation);
         }
     }
@@ -345,6 +347,9 @@ class ManyManyList extends RelationList
         $query->addWhere(array(
             "\"{$this->joinTable}\".\"{$this->localKey}\"" => $itemID
         ));
+
+        $this->extend('onBeforeRemove', $query, $itemID);
+
         $query->execute();
     }
 


### PR DESCRIPTION
As a developer, I want to notify other parts of my application when relationships on objects are updated.  Without this hook, I can't, for example, update a field in the database when many-many relationships are modified.  This is especially useful for partial caching, so that I can update LastEdited on an object when objects are added or removed from its relation list.