### PR TITLE
BUG Recommend install of upgrader with PHAR exec.

### DIFF
--- a/docs/en/03_Upgrading/index.md
+++ b/docs/en/03_Upgrading/index.md
@@ -91,8 +91,31 @@ For a description on how to handle issues with pre-existing composer installs or
 through the [Step 1 - Upgrade your dependencies](#step1) section.
 
 ### Install the upgrader tool (optional)
-Using the upgrader is not mandatory, but it can speed up the process.
-Although SilverStripe 4 can run in both PHP 5.6 and PHP 7, the upgrader itself requires PHP 7.1.
+Using the upgrader is not mandatory, but it can speed up the process. Although SilverStripe 4 can run in both PHP 5.6 and PHP 7, the upgrader itself requires PHP 7.1.
+
+The upgrader is available as a phar executable. 
+
+To install the PHAR executable:
+
+1. [Download the upgrader as a PHAR executable](https://silverstripe.github.io/silverstripe-upgrader/upgrade-code.phar) or `wget https://silverstripe.github.io/silverstripe-upgrader/upgrade-code.phar`
+2. Make the file executable `chmod +x upgrade-code.phar`
+3. Move the file to a folder in your path, for example `sudo mv upgrade-code.phar /usr/local/bin/upgrade-code` 
+
+
+Each command in the upgrader has somewhat different arguments. However, most of them accept these two options:
+* `--write` which tells the upgrader to apply changes to your code base
+* `--root-dir` which can be use to explicitly specify the root of your project — if not specified the current working directory is assume to be the root of the project.
+
+You can run `upgrade-code help` to get more information about the upgrader or `upgrade-code help command-name` to information about a specific command.
+
+<div class="info" markdown="1">
+Sample upgrader commands in this guide assume your working directory is the root of your SilverStripe project. You'll need to use the `--root-dir` flag if that's not the case.
+</div>
+
+#### Install the upgrader globally with composer
+
+You can install the upgrader globally with composer. This can make it easier to update to newer releases, however you can get dependency conflicts if you have other packages installed globally. 
+
 To install the upgrader globally run this command.
 
 ```bash
@@ -108,26 +131,6 @@ On *nix system, the following command will add your global composer bin director
 ```bash
 echo 'export PATH=$PATH:~/.composer/vendor/bin/' >> ~/.bash_profile
 ```
-
-Each command in the upgrader has somewhat different arguments. However, most of them accept these two options:
-* `--write` which tells the upgrader to apply changes to your code base
-* `--root-dir` which can be use to explicitly specify the root of your project — if not specified the current working directory is assume to be the root of the project.
-
-You can run `upgrade-code help` to get more information about the upgrader or `upgrade-code help command-name` to information about a specific command.
-
-<div class="info" markdown="1">
-Sample upgrader commands in this guide assume your working directory is the root of your SilverStripe project. You'll need to use the `--root-dir` flag if that's not the case.
-</div>
-
-#### Install the upgrader as a PHAR executable
-
-The upgrader is also available as a phar executable. This can be helpful if installing the upgrader globally through composer conflicts with other libraries.
-
-To install the PHAR executable:
-
-1. [Download the upgrader as a PHAR executable](https://silverstripe.github.io/silverstripe-upgrader/upgrade-code.phar) or `wget https://silverstripe.github.io/silverstripe-upgrader/upgrade-code.phar`
-2. Make the file executable `chmod +x upgrade-code.phar`
-3. Move the file to a folder in your path, for example `sudo mv upgrade-code.phar /usr/local/bin/upgrade-code` 
 
 ### Running all the upgrader commands in this guide in on line
 


### PR DESCRIPTION
Update the Upgrading guide to recommend installing of the PHAR
executable of the upgrader over using `composer glboal require`.

Related to https://github.com/silverstripe/silverstripe-upgrader/pull/129