### PR TITLE
FIX Altering ID of authenticator tabs to resolve ID conflict

### DIFF
--- a/templates/SilverStripe/Security/Security_MultiAuthenticatorTabbedForms.ss
+++ b/templates/SilverStripe/Security/Security_MultiAuthenticatorTabbedForms.ss
@@ -1,12 +1,12 @@
 <ul>
 	<% loop $Forms %>
 	<li>
-		<a href="#{$FormName}">$AuthenticatorName</a>
+		<a href="#{$FormName}_Tab">$AuthenticatorName</a>
 	</li>
 	<% end_loop %>
 </ul>
 <% loop $Forms %>
-<div class="form-tab" id="{$FormName}">
+<div class="form-tab" id="{$FormName}_Tab">
 	<h3>$AuthenticatorName</h3>
 	$forTemplate
 </div>


### PR DESCRIPTION
Currently when using multiple authenticators it uses a template called `Security_MultiAuthenticatorTabbedForms.ss`: https://github.com/silverstripe/silverstripe-framework/blob/4.2/templates/SilverStripe/Security/Security_MultiAuthenticatorTabbedForms.ss

The problem is the tab IDs are set to the form name, but the default rendering of the LoginForms also uses the form name as the ID of the form. This results in duplicate IDs (which makes an invalid DOM).

This PR alters the ID (and prior reference) of the tabs so they are suffixed with `_Tab`.