### PR TITLE
FIX Restore default delete action on GridFieldConfig_RecordEditor

### DIFF
--- a/src/Forms/GridField/GridFieldConfig_RecordEditor.php
+++ b/src/Forms/GridField/GridFieldConfig_RecordEditor.php
@@ -22,7 +22,7 @@ class GridFieldConfig_RecordEditor extends GridFieldConfig
         $this->addComponent($filter = new GridFieldFilterHeader());
         $this->addComponent(new GridFieldDataColumns());
         $this->addComponent(new GridFieldEditButton());
-        $this->addComponent(new GridFieldDeleteAction(true));
+        $this->addComponent(new GridFieldDeleteAction());
         $this->addComponent(new GridField_ActionMenu());
         $this->addComponent(new GridFieldPageCount('toolbar-header-right'));
         $this->addComponent($pagination = new GridFieldPaginator($itemsPerPage));


### PR DESCRIPTION
Restore the default action of the record editor to the plain delete.

# Parent issue
https://github.com/silverstripe/silverstripe-admin/issues/578