### PR TITLE
Implement __isset for ViewableData_Customised

### DIFF
--- a/src/View/ViewableData_Customised.php
+++ b/src/View/ViewableData_Customised.php
@@ -49,6 +49,11 @@ class ViewableData_Customised extends ViewableData
         $this->customised->$property = $this->original->$property = $value;
     }
 
+    public function __isset($property)
+    {
+        return isset($this->customised->$property) || isset($this->original->$property) || parent::__isset($property);
+    }
+
     public function hasMethod($method)
     {
         return $this->customised->hasMethod($method) || $this->original->hasMethod($method);

--- a/tests/php/View/ViewableDataCustomisedTest.php
+++ b/tests/php/View/ViewableDataCustomisedTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SilverStripe\View\Tests;
+
+use SilverStripe\Dev\Constraint\ViewableDataContains;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\View\ArrayData;
+use SilverStripe\View\ViewableData_Customised;
+
+/**
+ * Test for ViewableData_Customised.
+ */
+class ViewableDataCustomisedTest extends SapphireTest
+{
+    public function testNestedViewableDataCustomisedAsCustomised()
+    {
+        $outerCustomised = ViewableData_Customised::create($this->makeOuterOriginal(), $this->makeInnerViewableDataCustomised());
+        $this->assertThat($outerCustomised, $this->makeTestConstraint());
+    }
+
+    public function testNestedViewableDataCustomisedAsOriginal()
+    {
+        $outerCustomised = ViewableData_Customised::create($this->makeInnerViewableDataCustomised(), $this->makeOuterOriginal());
+        $this->assertThat($outerCustomised, $this->makeTestConstraint());
+    }
+
+    private function makeTestConstraint()
+    {
+        return new ViewableDataContains([
+            'outerOriginal'   => 'foobar',
+            'innerOriginal'   => 'hello',
+            'innerCustomised' => 'world',
+        ]);
+    }
+
+    private function makeOuterOriginal()
+    {
+        return ArrayData::create([
+            'outerOriginal' => 'foobar',
+        ]);
+    }
+
+    private function makeInnerViewableDataCustomised()
+    {
+        $original = ArrayData::create([
+            'innerOriginal' => 'hello',
+        ]);
+
+        $customised = ArrayData::create([
+            'innerCustomised' => 'world',
+        ]);
+
+        return ViewableData_Customised::create($original, $customised);
+    }
+}


### PR DESCRIPTION
Resolves #8302.

When a nested `ViewableData_Customised` provides some fields, an outer `ViewableData_Customised` will return `isset($outer->nestedField) === false` and so `$outer->nestedField === null` in contexts like a template.

Implementing `__isset` to check the nested objects resolves this by returning `isset === true` for nested fields that are available. This also allows for arbitrary levels of nesting in a `ViewableData_Customised` to be resolved recursively.