### PR TITLE
BUGFIX Installer redirect to home/ (without domain)

### DIFF
--- a/src/Dev/Install/Installer.php
+++ b/src/Dev/Install/Installer.php
@@ -601,7 +601,7 @@ TEXT;
         $token = new ParameterConfirmationToken('flush', new HTTPRequest('GET', '/'));
         $params = http_build_query($token->params());
 
-        $destinationURL = BASE_URL . '/' . (
+        $destinationURL = rtrim(BASE_URL, '/') . '/' . (
             $this->checkModuleExists('cms')
                 ? "home/successfullyinstalled?$params"
                 : "?$params"


### PR DESCRIPTION
This fixes a bug where the installer redirects to home/ ('home' as the domain) as the url as opposed to localhost/home.

To reproduce:
* Use chrome (untested in other browsers)
* composer create project silverstripe/installer
* Run through the installer

Expected:
* Silverstripe installs and it takes you to the success page

Actual:
* SilverStripe installs and takes you to a different domain (ie. 'http://home')

The problem seems to be, any URL starting with `//` (two slashes) is normalised by the browser to an absolute URL by removing both slashes meaning `//home` becomes just `home` (as in http://home)