### PR TITLE
Readonlyfield return value broke history view

### DIFF
--- a/forms/ReadonlyField.php
+++ b/forms/ReadonlyField.php
@@ -53,7 +53,7 @@ class ReadonlyField extends FormField {
 	}
 
 	public function Value() {
-		if($this->value) return $this->value;
+		if($this->value) return $this->dontEscape ? $this->value : Convert::raw2xml($this->value);
 		else return '<i>(' . _t('FormField.NONE', 'none') . ')</i>';
 	}
 


### PR DESCRIPTION
Readonlyfield component  value() method update broke history view after upgrade from 3.4.1 -> 3.4.3.
Please review this is good to go. 