### PR TITLE
3.7 HTTP Caching fixes

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -221,6 +221,8 @@ class LeftAndMain extends Controller implements PermissionProvider {
 	public function init() {
 		parent::init();
 
+		HTTPCacheControl::singleton()->disableCache();
+
 		Config::inst()->update('SSViewer', 'rewrite_hash_links', false);
 		Config::inst()->update('ContentNegotiator', 'enabled', false);
 

--- a/security/Security.php
+++ b/security/Security.php
@@ -413,6 +413,7 @@ class Security extends Controller implements TemplateGlobalProvider {
 	 * sessions don't timeout. A common use is in the admin.
 	 */
 	public function ping() {
+		HTTPCacheControl::singleton()->disableCache();
 		Requirements::clear();
 		return 1;
 	}


### PR DESCRIPTION
Fixes #8289

1. Ensures all requests to `LeftAndMain` will disable HTTP Caching
2. Disabled HTTP Caching on Security/ping
3. ~~Stops `privateCache` from removing current state (disabled, etc).~~