### PR TITLE
email rendering should not include requirements

### DIFF
--- a/src/Control/Email/Email.php
+++ b/src/Control/Email/Email.php
@@ -790,6 +790,9 @@ class Email extends ViewableData
             return $this;
         }
 
+        // Do not interfere with emails styles
+        Requirements::clear();
+        
         // Render plain part
         if ($plainTemplate && !$plainPart) {
             $plainPart = $this->renderWith($plainTemplate, $this->getData());
@@ -806,6 +809,9 @@ class Email extends ViewableData
             $htmlPartObject = DBField::create_field('HTMLFragment', $htmlPart);
             $plainPart = $htmlPartObject->Plain();
         }
+        
+        // Rendering is finished
+        Requirements::restore();
 
         // Fail if no email to send
         if (!$plainPart && !$htmlPart) {


### PR DESCRIPTION
If no body is defined, the email is rendered according to a template. Clearing requirements prevent unnecessary styles/scripts to be included in the html (and that needs to be processed/stripped down the line).

I realized that additional scripts/styles were included when logging the email (for instance, by calling $message->getBody() and display it).