### PR TITLE
FIX Remove double escaping of HTML values in print views

### DIFF
--- a/src/Forms/GridField/GridFieldPrintButton.php
+++ b/src/Forms/GridField/GridFieldPrintButton.php
@@ -227,10 +227,6 @@ class GridFieldPrintButton implements GridField_HTMLProvider, GridField_ActionPr
             foreach ($printColumns as $field => $label) {
                 $value = $gridField->getDataFieldValue($item, $field);
 
-                if ($item->escapeTypeForField($field) != 'xml') {
-                    $value = Convert::raw2xml($value);
-                }
-
                 $itemRow->push(new ArrayData(array(
                     "CellString" => $value,
                 )));


### PR DESCRIPTION
Print view uses the SilverStripe templating to render values which means that
values are safely escaped by default. This can be tested by chaing `$CellString`
to `$CellString.RAW` in the GridField_print.ss template to see this escaping
being disabled.

This pull request removes double escaping of HTML in strings.

Related issue: https://github.com/silverstripe/silverstripe-userforms/issues/633