### PR TITLE
$has_one docs

### DIFF
--- a/docs/en/02_Developer_Guides/00_Model/02_Relations.md
+++ b/docs/en/02_Developer_Guides/00_Model/02_Relations.md
@@ -12,11 +12,17 @@ SilverStripe supports a number of relationship types and each relationship type 
 
 ## has_one
 
-A 1-to-1 relation creates a database-column called "`<relationship-name>`ID", in the example below this would be
-"TeamID" on the "Player"-table.
+Many-to-1 and 1-to-1 relationships create a database-column called "`<relationship-name>`ID", in the example below this would be "TeamID" on the "Player"-table.
 
 ```php
 use SilverStripe\ORM\DataObject;
+
+class Player extends DataObject
+{
+    private static $has_one = [
+        "Team" => "Team",
+    ];
+}
 
 class Team extends DataObject
 {
@@ -26,12 +32,6 @@ class Team extends DataObject
 
     private static $has_many = [
         'Players' => 'Player'
-    ];
-}
-class Player extends DataObject
-{
-    private static $has_one = [
-        "Team" => "Team",
     ];
 }
 ```


### PR DESCRIPTION
The ` $has_one` can be used both for `1-to-1` and `many-to-1` relations, depending on how the inverse mapping is configured in the related class. The documentation seems to suggest that `$has_one` implies a `1-to-1` relation, but then it gives an example of a `many-to-1` relationship. Since we are focusing on `$has_one` I would also put the `Player` class before the `Team` class.

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/