### PR TITLE
FIX Message when changing password with invalid token now contains correct links to login

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -323,7 +323,7 @@ en:
     LOGOUT: 'Log out'
     LOSTPASSWORDHEADER: 'Lost Password'
     NOTEPAGESECURED: 'That page is secured. Enter your credentials below and we will send you right along.'
-    NOTERESETLINKINVALID: '<p>The password reset link is invalid or expired.</p><p>You can request a new one <a href="{link1}">here</a> or change your password after you <a href="{link2}">logged in</a>.</p>'
+    NOTERESETLINKINVALID: '<p>The password reset link is invalid or expired.</p><p>You can request a new one <a href="{link1}">here</a> or change your password after you <a href="{link2}">log in</a>.</p>'
     NOTERESETPASSWORD: 'Enter your e-mail address and we will send you a link with which you can reset your password'
     PASSWORDRESETSENTHEADER: 'Password reset link sent'
     PASSWORDRESETSENTTEXT: 'Thank you. A reset link has been sent, provided an account exists for this email address.'

--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -74,7 +74,7 @@ class ChangePasswordHandler extends RequestHandler
         }
         $token = $request->getVar('t');
 
-        // Check whether we are merely changin password, or resetting.
+        // Check whether we are merely changing password, or resetting.
         if ($token !== null && $member && $member->validateAutoLoginToken($token)) {
             $this->setSessionToken($member, $token);
 
@@ -124,8 +124,8 @@ class ChangePasswordHandler extends RequestHandler
                     . '<p>You can request a new one <a href="{link1}">here</a> or change your password after'
                     . ' you <a href="{link2}">logged in</a>.</p>',
                     [
-                        'link1' => $this->Link('lostpassword'),
-                        'link2' => $this->Link('login')
+                        'link1' => Security::lost_password_url(),
+                        'link2' => Security::login_url(),
                     ]
                 )
             );

--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -122,7 +122,7 @@ class ChangePasswordHandler extends RequestHandler
                     'SilverStripe\\Security\\Security.NOTERESETLINKINVALID',
                     '<p>The password reset link is invalid or expired.</p>'
                     . '<p>You can request a new one <a href="{link1}">here</a> or change your password after'
-                    . ' you <a href="{link2}">logged in</a>.</p>',
+                    . ' you <a href="{link2}">log in</a>.</p>',
                     [
                         'link1' => Security::lost_password_url(),
                         'link2' => Security::login_url(),

--- a/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.php
+++ b/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SilverStripe\Security\Tests\MemberAuthenticator;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Session;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\MemberAuthenticator\ChangePasswordHandler;
+use SilverStripe\Security\MemberAuthenticator\MemberAuthenticator;
+use SilverStripe\Security\Security;
+
+class ChangePasswordHandlerTest extends SapphireTest
+{
+    protected static $fixture_file = 'ChangePasswordHandlerTest.yml';
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        Config::modify()
+            ->set(Security::class, 'login_url', 'Security/login')
+            ->set(Security::class, 'lost_password_url', 'Security/lostpassword');
+
+        $this->logOut();
+    }
+
+    public function testExpiredOrInvalidTokenProvidesLostPasswordAndLoginLink()
+    {
+        $request = new HTTPRequest('GET', '/Security/changepassword', [
+            'm' => $this->idFromFixture(Member::class, 'sarah'),
+            't' => 'an-old-or-expired-hash',
+        ]);
+        $request->setSession(new Session([]));
+
+        /** @var ChangePasswordHandler $handler */
+        $handler = $this->getMockBuilder(ChangePasswordHandler::class)
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $result = $handler->setRequest($request)->changepassword();
+
+        $this->assertInternalType('array', $result, 'An array is returned');
+        $this->assertContains('Security/lostpassword', $result['Content'], 'Lost password URL is included');
+        $this->assertContains('Security/login', $result['Content'], 'Login URL is included');
+    }
+}

--- a/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.yml
+++ b/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.yml
@@ -1,0 +1,5 @@
+SilverStripe\Security\Member:
+  sarah:
+    FirstName: Sarah
+    Surname: Smith
+    AutoLoginToken: foobar


### PR DESCRIPTION
The Security controller should be used to return these links rather than the ChangePasswordHandler.

Also updates the message so it reads better.

Fixes #8197