### PR TITLE
Allow use of display names with SwiftMailer

### DIFF
--- a/docs/en/02_Developer_Guides/10_Email/index.md
+++ b/docs/en/02_Developer_Guides/10_Email/index.md
@@ -133,6 +133,14 @@ SilverStripe\Control\Email\Email:
   admin_email: support@example.com
 ```
 
+To add a display name, set `admin_email` as follow.
+
+```yaml
+SilverStripe\Control\Email\Email:
+  admin_email:
+    support@example.com: 'Support team'
+```
+
 <div class="alert" markdown="1">
 Remember, setting a `from` address that doesn't come from your domain (such as the users email) will likely see your
 email marked as spam. If you want to send from another address think about using the `setReplyTo` method.

--- a/src/Control/Email/Email.php
+++ b/src/Control/Email/Email.php
@@ -269,7 +269,12 @@ class Email extends ViewableData
     {
         $swiftMessage->setDate(DBDatetime::now()->getTimestamp());
         if (!$swiftMessage->getFrom() && ($defaultFrom = $this->config()->get('admin_email'))) {
-            $swiftMessage->setFrom($defaultFrom);
+            if ($defaultFromName = $this->config()->get('admin_email_displayname')) {
+                $swiftMessage->setFrom([$defaultFrom => $defaultFromName]);
+            }
+            else {
+                $swiftMessage->setFrom($defaultFrom);
+            }
         }
         $this->swiftMessage = $swiftMessage;
 

--- a/src/Control/Email/Email.php
+++ b/src/Control/Email/Email.php
@@ -269,12 +269,7 @@ class Email extends ViewableData
     {
         $swiftMessage->setDate(DBDatetime::now()->getTimestamp());
         if (!$swiftMessage->getFrom() && ($defaultFrom = $this->config()->get('admin_email'))) {
-            if ($defaultFromName = $this->config()->get('admin_email_displayname')) {
-                $swiftMessage->setFrom([$defaultFrom => $defaultFromName]);
-            }
-            else {
-                $swiftMessage->setFrom($defaultFrom);
-            }
+            $swiftMessage->setFrom($defaultFrom);
         }
         $this->swiftMessage = $swiftMessage;
 


### PR DESCRIPTION
The syntax to allow display names with SwiftMailer is as follow:
`->setFrom(['john@doe.com' => 'John Doe'])`

Just like you set the `Email.admin_email`, you can set the default sender display name through the `Email.admin_email_displayname` configuration setting.

Refs:
- https://swiftmailer.symfony.com/docs/introduction.html#basic-usage
- https://docs.silverstripe.org/en/4/developer_guides/email/#administrator-emails

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/