### PR TITLE
BUG Use classes for TinyMCE alignment buttons

### DIFF
--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -216,8 +216,46 @@ class TinyMCEConfig extends HTMLEditorConfig
      *
      * @var array
      */
-    protected $settings = array(
+    protected $settings = [
         'fix_list_elements' => true, // https://www.tinymce.com/docs/configure/content-filtering/#fix_list_elements
+        'formats' => [
+            'alignleft' => [
+                [
+                    'selector' => 'p,h1,h2,h3,h4,h5,h6,td,th,li',
+                    'classes' =>'text-left'
+                ],
+                [
+                    'selector' => 'div,ul,ol,table,img,figure',
+                    'classes' =>'left'
+                ]
+            ],
+            'aligncenter' => [
+                [
+                    'selector' => 'p,h1,h2,h3,h4,h5,h6,td,th,li',
+                    'classes' =>'text-center'
+                ],
+                [
+                    'selector' => 'div,ul,ol,table,img,figure',
+                    'classes' =>'center'
+                ]
+            ],
+            'alignright' => [
+                [
+                    'selector' => 'p,h1,h2,h3,h4,h5,h6,td,th,li',
+                    'classes' =>'text-right'
+                ],
+                [
+                    'selector' => 'div,ul,ol,table,img,figure',
+                    'classes' =>'right'
+                ]
+            ],
+            'alignjustify' => [
+                [
+                    'selector' => 'p,h1,h2,h3,h4,h5,h6,td,th,li',
+                    'classes' =>'text-justify'
+                ],
+            ],
+        ],
         'friendly_name' => '(Please set a friendly name for this config)',
         'priority' => 0, // used for Per-member config override
         'browser_spellcheck' => true,
@@ -230,7 +268,7 @@ class TinyMCEConfig extends HTMLEditorConfig
         'menubar' => false,
         'language' => 'en',
         'branding' => false,
-    );
+    ];
 
     /**
      * Holder list of enabled plugins


### PR DESCRIPTION
Fixes silverstripe/silverstripe-cms#2202

Rather than using inline-styles, the alignment buttons in the HTMLEditor field will now use classes which matches ones typically included in `editor.css`: 

For text specific elements i.e. `p` or `h1`:
- `text-left`
- `text-center`
- `text-right`
- `text-justify`

For block elements i.e. `img` or `div`:
- `left`
- `center`
- `right`