### PR TITLE
Add schema information for HTMLEditorField

### DIFF
--- a/src/Forms/HTMLEditor/HTMLEditorConfig.php
+++ b/src/Forms/HTMLEditor/HTMLEditorConfig.php
@@ -224,4 +224,17 @@ abstract class HTMLEditorConfig
      * Initialise the editor on the client side
      */
     abstract public function init();
+
+    /**
+     * Provide additional schema data for the field this object configures
+     *
+     * @return array
+     */
+    public function getConfigSchemaData()
+    {
+        return [
+            'attributes' => $this->getAttributes(),
+            'editorjs' => null,
+        ];
+    }
 }

--- a/src/Forms/HTMLEditor/HTMLEditorField.php
+++ b/src/Forms/HTMLEditor/HTMLEditorField.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Forms\HTMLEditor;
 
 use SilverStripe\Assets\Shortcodes\ImageShortcodeProvider;
+use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectInterface;
@@ -22,6 +23,10 @@ class HTMLEditorField extends TextareaField
     private static $casting = [
         'Value' => 'HTMLText',
     ];
+
+    protected $schemaDataType = FormField::SCHEMA_DATA_TYPE_HTML;
+
+    protected $schemaComponent = 'HtmlEditorField';
 
     /**
      * Use TinyMCE's GZIP compressor
@@ -184,5 +189,13 @@ class HTMLEditorField extends TextareaField
         // Include requirements
         $this->getEditorConfig()->init();
         return parent::Field($properties);
+    }
+
+    public function getSchemaStateDefaults()
+    {
+        $stateDefaults = parent::getSchemaStateDefaults();
+        $config = $this->getEditorConfig();
+        $stateDefaults['data'] = $config->getConfigSchemaData();
+        return $stateDefaults;
     }
 }

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -713,6 +713,12 @@ class TinyMCEConfig extends HTMLEditorConfig
         Requirements::javascript($this->getScriptURL());
     }
 
+    public function getConfigSchemaData()
+    {
+        $data = parent::getConfigSchemaData();
+        $data['editorjs'] = $this->getScriptURL();
+        return $data;
+    }
 
     /**
      * Get the current tinyMCE language


### PR DESCRIPTION
This allows React form builders (or other such view layer builders in a
headless environment) to obtain the details that would otherwise only be
rendered in a PHP side template. Some of the details are critical for
rendering correctly, and are necessary to be passed through -
particularly when moving toward replacing the Entwine initiator for
TinyMCE with a React component in `silverstripe/admin`.

Required as part of https://github.com/dnadesign/silverstripe-elemental/issues/327