### PR TITLE
Make sure that CMS requests disable caching

### DIFF
--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -11,6 +11,7 @@ use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\HTTPResponse_Exception;
+use SilverStripe\Control\Middleware\HTTPCacheControlMiddleware;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Convert;
@@ -494,6 +495,7 @@ class Security extends Controller implements TemplateGlobalProvider
      */
     public function ping()
     {
+        HTTPCacheControlMiddleware::singleton()->disableCache();
         Requirements::clear();
         return 1;
     }


### PR DESCRIPTION
Original author: @dhensby

Forward port from 3.7 fix at https://github.com/silverstripe/silverstripe-framework/pull/8318