### PR TITLE
API Rename resources to _resources

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "ext-session": "*",
         "psr/container-implementation": "1.0.0",
         "psr/container": "1.0.0",
-        "silverstripe/vendor-plugin": "^1.0"
+        "silverstripe/vendor-plugin": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "7.1.3",

--- a/src/Control/SimpleResourceURLGenerator.php
+++ b/src/Control/SimpleResourceURLGenerator.php
@@ -200,7 +200,7 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
 
     /**
      * Resolve a resource that may either exist in a public/ folder, or be exposed from the base path to
-     * public/resources/
+     * public/_resources/
      *
      * @param string $relativePath
      * @return array List of [$exists, $absolutePath, $relativePath]

--- a/src/Core/Manifest/ManifestFileFinder.php
+++ b/src/Core/Manifest/ManifestFileFinder.php
@@ -22,7 +22,7 @@ class ManifestFileFinder extends FileFinder
     const LANG_DIR = 'lang';
     const TESTS_DIR = 'tests';
     const VENDOR_DIR = 'vendor';
-    const RESOURCES_DIR = 'resources';
+    const RESOURCES_DIR = '_resources';
 
     protected static $default_options = array(
         'include_themes' => false,

--- a/src/Core/Manifest/ModuleResource.php
+++ b/src/Core/Manifest/ModuleResource.php
@@ -49,7 +49,7 @@ class ModuleResource
     /**
      * Return the full filesystem path to this resource.
      *
-     * Note: In the case that this resource is mapped to the `resources` folder, this will
+     * Note: In the case that this resource is mapped to the `_resources` folder, this will
      * return the original rather than the copy / symlink.
      *
      * @return string Path with no trailing slash E.g. /var/www/module
@@ -62,7 +62,7 @@ class ModuleResource
     /**
      * Get the path of this resource relative to the base path.
      *
-     * Note: In the case that this resource is mapped to the `resources` folder, this will
+     * Note: In the case that this resource is mapped to the `_resources` folder, this will
      * return the original rather than the copy / symlink.
      *
      * @return string Relative path (no leading /)
@@ -81,7 +81,7 @@ class ModuleResource
      * Public URL to this resource.
      * Note: May be either absolute url, or root-relative url
      *
-     * In the case that this resource is mapped to the `resources` folder this
+     * In the case that this resource is mapped to the `_resources` folder this
      * will be the mapped url rather than the original path.
      *
      * @return string

--- a/src/Dev/Install/Installer.php
+++ b/src/Dev/Install/Installer.php
@@ -55,8 +55,8 @@ class Installer
     protected function installHeader()
     {
         $clientPath = PUBLIC_DIR
-            ? 'resources/vendor/silverstripe/framework/src/Dev/Install/client'
-            : 'resources/silverstripe/framework/src/Dev/Install/client';
+            ? '_resources/vendor/silverstripe/framework/src/Dev/Install/client'
+            : '_resources/silverstripe/framework/src/Dev/Install/client';
         ?>
         <html>
         <head>

--- a/src/Dev/Install/install5.php
+++ b/src/Dev/Install/install5.php
@@ -107,8 +107,8 @@ if ($installFromCli && ($req->hasErrors() || $dbReq->hasErrors())) {
 // Path to client resources (copied through silverstripe/vendor-plugin)
 $base = rtrim(BASE_URL, '/') . '/';
 $clientPath = PUBLIC_DIR
-    ? 'resources/vendor/silverstripe/framework/src/Dev/Install/client'
-    : 'resources/silverstripe/framework/src/Dev/Install/client';
+    ? '_resources/vendor/silverstripe/framework/src/Dev/Install/client'
+    : '_resources/silverstripe/framework/src/Dev/Install/client';
 
 // If already installed, ensure the user clicked "reinstall"
 $expectedArg = $alreadyInstalled ? 'reinstall' : 'go';

--- a/tests/php/Control/SimpleResourceURLGeneratorTest.php
+++ b/tests/php/Control/SimpleResourceURLGeneratorTest.php
@@ -34,7 +34,7 @@ class SimpleResourceURLGeneratorTest extends SapphireTest
         $generator = Injector::inst()->get(ResourceURLGenerator::class);
         $mtime = filemtime(__DIR__ . '/SimpleResourceURLGeneratorTest/_fakewebroot/basemodule/client/file.js');
         $this->assertEquals(
-            '/resources/basemodule/client/file.js?m=' . $mtime,
+            '/_resources/basemodule/client/file.js?m=' . $mtime,
             $generator->urlForResource('basemodule/client/file.js')
         );
     }
@@ -47,7 +47,7 @@ class SimpleResourceURLGeneratorTest extends SapphireTest
             __DIR__ . '/SimpleResourceURLGeneratorTest/_fakewebroot/vendor/silverstripe/mymodule/client/style.css'
         );
         $this->assertEquals(
-            '/resources/vendor/silverstripe/mymodule/client/style.css?m=' . $mtime,
+            '/_resources/vendor/silverstripe/mymodule/client/style.css?m=' . $mtime,
             $generator->urlForResource('vendor/silverstripe/mymodule/client/style.css')
         );
     }
@@ -70,7 +70,7 @@ class SimpleResourceURLGeneratorTest extends SapphireTest
         );
 
         $this->assertEquals(
-            '/resources/basemodule/client/file.js?m=' . $mtime,
+            '/_resources/basemodule/client/file.js?m=' . $mtime,
             $generator->urlForResource('basemodule/client/file.js')
         );
     }
@@ -87,7 +87,7 @@ class SimpleResourceURLGeneratorTest extends SapphireTest
             __DIR__ . '/SimpleResourceURLGeneratorTest/_fakewebroot/vendor/silverstripe/mymodule/client/style.css'
         );
         $this->assertEquals(
-            '/resources/vendor/silverstripe/mymodule/client/style.css?m=' . $mtime,
+            '/_resources/vendor/silverstripe/mymodule/client/style.css?m=' . $mtime,
             $generator->urlForResource($module->getResource('client/style.css'))
         );
     }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/7932

Requires https://github.com/silverstripe/vendor-plugin/pull/25

Also all other modules will need to have their vendor-plugin dependency bumped to ^2 as well. My suggestion is to get the module merged first and migrate the modules one at a time.