### PR TITLE
Include custom bootstrap.php file if one exists.

### DIFF
--- a/src/Dev/Install/Installer.php
+++ b/src/Dev/Install/Installer.php
@@ -249,6 +249,12 @@ use SilverStripe\Control\HTTPRequestBuilder;
 use SilverStripe\Core\CoreKernel;
 use SilverStripe\Core\Startup\ErrorControlChainMiddleware;
 
+if (file_exists(__DIR__ . '/bootstrap.php')) {
+    require __DIR__ . '/bootstrap.php';
+} elseif (file_exists(__DIR__ . '/../bootstrap.php')) {
+    require __DIR__ . '/../bootstrap.php';
+}
+
 // Find autoload.php
 if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
For background on why I created this read #8366 and #8077

I noticed that there is no way to set constants in SilverStripe before the constants.php file is loaded by autoload.php reliably. Altering index.php is not a good idea, since there are more entry points to SilverStripe (like [sake](https://docs.silverstripe.org/en/4/developer_guides/cli/#sake-silverstripe-make))

The simples solution with no backward compatibility issues that I could see is to load a custom file before loading autoload.php if it exists (bootstrap.php seemed like a good name to me).

This needs to be changed in two places. In this repo (which this PR does) and the in the [index.php](https://github.com/silverstripe/recipe-core/blob/4/public/index.php) file of [SilverStripe - Recipe Core](https://github.com/silverstripe/recipe-core/).

If you think this is useful, I will create a PR in [SilverStripe - Recipe Core](https://github.com/silverstripe/recipe-core/).

Also, documentation should be updated, but I am not sure where it should go.