### PR TITLE
Update 01_Syntax.md - Fix How To's links

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/01_Syntax.md
+++ b/docs/en/02_Developer_Guides/01_Templates/01_Syntax.md
@@ -567,11 +567,11 @@ $EditForm <%-- Some hidden comment about the form --%>
 
 ## Related Documentation
 
-[CHILDREN]
+[CHILDREN Exclude="How_Tos"]
 
 ## How to's
 
-[CHILDREN How_Tos]
+[CHILDREN Folder="How_Tos"]
 
 ## API Documentation
 


### PR DESCRIPTION
It seemed like the links to the How To's were incorrectly being created. I looked at how other files had it and copied the code. Not sure if it is the correct way to do so.