### PR TITLE
NEW Add hideNav flag to schema defaults

### DIFF
--- a/src/Forms/TabSet.php
+++ b/src/Forms/TabSet.php
@@ -243,4 +243,19 @@ class TabSet extends CompositeField
         }
         return parent::insertAfter($insertAfter, $field);
     }
+
+    /**
+     * Sets an additional default for $schemaData.
+     * The existing keys are immutable. HideNav is added in this overriding method to ensure it is not ignored by
+     * {@link setSchemaData()}
+     * It allows hiding of the navigation in the Tabs.js React component.
+     *
+     * @return array
+     */
+    public function getSchemaStateDefaults()
+    {
+        $defaults = parent::getSchemaStateDefaults();
+        $defaults['hideNav'] = false;
+        return $defaults;
+    }
 }


### PR DESCRIPTION
The solution for https://github.com/dnadesign/silverstripe-elemental/issues/324 relies on an additional boolean prop `hideNav`. 

The changes in this PR allow us to add hideNav to the schema data defaults by overriding the getSchmeaDefaults() method inherited from FormField. 

This is necessary to be able to use setSchemaState(['hideNav' => true]), since "Any passed keys that are not defined in {@link getSchemaDataDefaults()} are ignored."