### PR TITLE
BUG Changes being detected on TreeMulti as values not sorted

### DIFF
--- a/src/Forms/TreeMultiselectField.php
+++ b/src/Forms/TreeMultiselectField.php
@@ -103,7 +103,12 @@ class TreeMultiselectField extends TreeDropdownField
 
         // cannot rely on $this->value as this could be a many-many relationship
         $value = array_column($values, 'id');
-        $data['value'] = ($value) ? $value : 'unchanged';
+        if ($value) {
+            sort($value);
+            $data['value'] = $value;
+        } else {
+            $data['value'] = 'unchanged';
+        }
 
         return $data;
     }
@@ -182,6 +187,7 @@ class TreeMultiselectField extends TreeDropdownField
             }
 
             $title = implode(", ", $titleArray);
+            sort($idArray);
             $value = implode(",", $idArray);
         } else {
             $title = $emptyTitle;


### PR DESCRIPTION
TreeMultiSelectField initially provides the values unsorted and then once this field is rendered by React the field with the values is sorted which triggers change detection (even though the values are effectively the same)