### PR TITLE
NEW: Add ?showqueries=backtrace

### DIFF
--- a/docs/en/02_Developer_Guides/07_Debugging/02_URL_Variable_Tools.md
+++ b/docs/en/02_Developer_Guides/07_Debugging/02_URL_Variable_Tools.md
@@ -41,6 +41,7 @@ session variables, used templates and much more.
  | URL Variable | | Values | | Description                                                                                  | 
  | ------------ | | --------- | | -----------                                                                                  | 
  | showqueries  | | 1&vert;inline | | List all SQL queries executed, the `inline` option will do a fudge replacement of parameterised queries          | 
+ | showqueries  | | 1&vert;backtrace | | List all SQL queries executed, the `backtrace` option will do a fudge replacement of parameterised queries *and* show a backtrace of every query          |
  | previewwrite | | 1      | | List all insert / update SQL queries, and **don't** execute them.  Useful for previewing writes to the database. | 
 
 ## Security Redirects

--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -11,6 +11,7 @@ use SilverStripe\ORM\Queries\SQLUpdate;
 use SilverStripe\ORM\Queries\SQLInsert;
 use BadMethodCallException;
 use Exception;
+use SilverStripe\Dev\Backtrace;
 
 /**
  * Abstract database connectivity class.
@@ -212,11 +213,16 @@ abstract class Database
             $result = $callback($sql);
             $endtime = round(microtime(true) - $starttime, 4);
             // replace parameters as closely as possible to what we'd expect the DB to put in
-            if (strtolower($_REQUEST['showqueries']) == 'inline') {
+            if (in_array(strtolower($_REQUEST['showqueries']), ['inline', 'backtrace'])) {
                 $sql = DB::inline_parameters($sql, $parameters);
             }
             $queryCount = sprintf("%04d", $this->queryCount);
             Debug::message("\n$queryCount: $sql\n{$endtime}s\n", false);
+
+            // Show a backtrace if ?showqueries=backtrace
+            if ($_REQUEST['showqueries'] === 'backtrace') {
+                Backtrace::backtrace();
+            }
             return $result;
         } else {
             return $callback($sql);


### PR DESCRIPTION
This variant of showqueries will include a backtrace after each query.
This is extremely verbose but can be helpful when diagnosing where
queries have come from.

This is something that I have frequently added as a local hack on my
environment, I figured that exposing it as a formal feature would be
useful.