### PR TITLE
DOCS Add docs for CMS help menu links

### DIFF
--- a/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/Customise_CMS_Menu.md
+++ b/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/Customise_CMS_Menu.md
@@ -24,7 +24,7 @@ black-and-transparent PNG graphics. In this case we'll place the icon in
 ```php
 use SilverStripe\Admin\ModelAdmin;
 
-class ProductAdmin extends ModelAdmin 
+class ProductAdmin extends ModelAdmin
 {
     // ...
     private static $menu_icon = 'app/images/product-icon.png';
@@ -41,7 +41,7 @@ controller, removing the "Admin" bit at the end.
 ```php
 use SilverStripe\Admin\ModelAdmin;
 
-class ProductAdmin extends ModelAdmin 
+class ProductAdmin extends ModelAdmin
 {
     // ...
     private static $menu_title = 'My Custom Admin';
@@ -69,10 +69,10 @@ button configuration.
 use SilverStripe\Admin\CMSMenu;
 use SilverStripe\Admin\LeftAndMainExtension;
 
-class CustomLeftAndMain extends LeftAndMainExtension 
+class CustomLeftAndMain extends LeftAndMainExtension
 {
 
-    public function init() 
+    public function init()
     {
         // unique identifier for this item. Will have an ID of Menu-$ID
         $id = 'LinkToGoogle';
@@ -105,6 +105,23 @@ class. For more information about configuring extensions see the
 
 ```php
 LeftAndMain::add_extension('CustomLeftAndMain')
+```
+
+## Customising the CMS help menu
+
+The CMS help menu links in the south toolbar are configurable via your [configuration file](../../configuration).
+You can edit, add or remove existing links as shown in the examples below:
+
+```yml
+# app/_config/config.yml
+SilverStripe\Admin\LeftAndMain:
+  help_links:
+    # Edit an existing link
+    'CMS User help': 'https://example.com'
+    # Add a new link
+    'Additional link': 'https://example.org'
+    # Remove an existing link
+    'Feedback': ''
 ```
 
 ## Related

--- a/docs/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
+++ b/docs/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
@@ -314,7 +314,7 @@ Further manual work on major or minor releases:
  * Check that `Deprecation::notification_version('4.0.0');` in framework/_config.php points to
 the right major version. This should match the major version of the current release. E.g. all versions of 4.x
 should be set to `4.0.0`.
- * Update the [userhelp.silverstripe.org](userhelp.silverstripe.org) version link in `LeftAndMain.help_link`
+ * Update the [userhelp.silverstripe.org](userhelp.silverstripe.org) version link in `LeftAndMain.help_links`
 
 *Updating markdown files*
 


### PR DESCRIPTION
Relies on https://github.com/silverstripe/silverstripe-admin/pull/615 to be merged first.