### PR TITLE
Refactor prepopulation

### DIFF
--- a/docs/en/04_Changelogs/4.3.0.md
+++ b/docs/en/04_Changelogs/4.3.0.md
@@ -4,6 +4,7 @@
 
  - `DataList::column()` now returns all values and not just "distinct" values from a column as per the API docs
  - `DataList`, `ArrayList` and `UnsavedRalationList` all have `columnUnique()` method for fetching distinct column values
+ - Take care with `stageChildren()` overrides. `Hierarchy::numChildren() ` results will only make use of `stageChildren()` customisations that are applied to the base class and don't include record-specific behaviour.
 
 ## Upgrading {#upgrading}
 


### PR DESCRIPTION
NEW: Add Hierarchy::prepopulateTreeDataCache()

This provides a more extensible way of preopulating caches for optimised
tree generation.

Fixes #8391