### PR TITLE
FIX Don't flush manifests in tests by default

### DIFF
--- a/docs/en/02_Developer_Guides/06_Testing/index.md
+++ b/docs/en/02_Developer_Guides/06_Testing/index.md
@@ -31,7 +31,7 @@ Tests are run from the commandline, in your webroot folder:
  * `vendor/bin/phpunit vendor/silverstripe/framework/tests/`: Run all tests of a specific module
  * `vendor/bin/phpunit vendor/silverstripe/framework/tests/filesystem`: Run specific tests within a specific module
  * `vendor/bin/phpunit vendor/silverstripe/framework/tests/filesystem/FolderTest.php`: Run a specific test 
- * `vendor/bin/phpunit vendor/silverstripe/framework/tests '' flush=all`: Run tests with optional request parameters (note the empty second argument)
+ * `vendor/bin/phpunit vendor/silverstripe/framework/tests '' flush=1`: Run tests with optional request parameters (note the empty second argument)
 
 Check the PHPUnit manual for all available [command line arguments](http://www.phpunit.de/manual/current/en/textui.html).
 

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -983,6 +983,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
         // Test application
         $kernel = new TestKernel(BASE_PATH);
         $app = new HTTPApplication($kernel);
+        $flush = array_key_exists('flush', $request->getVars());
 
         // Custom application
         $app->execute($request, function (HTTPRequest $request) {
@@ -998,7 +999,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
             $controller->setRequest($request);
             $controller->pushCurrent();
             $controller->doInit();
-        }, true);
+        }, $flush);
 
         // Register state
         static::$state = SapphireTestState::singleton();


### PR DESCRIPTION
It's massively slowing down test execution,
particularly for rapid execution through test-driven-development (TDD)

Regression since 4.0.0-beta1, see https://github.com/silverstripe/silverstripe-framework/commit/3873e4ba008cfc2af7e26ca86665affc289cd677#diff-e2f3520673dab1cd0127a469fe3a2a29R925

It replaced prior behaviour which respected the flush parameter: https://github.com/silverstripe/silverstripe-framework/commit/3873e4ba008cfc2af7e26ca86665affc289cd677#diff-e2f3520673dab1cd0127a469fe3a2a29R925

You could argue this is an API change, but I think it's not going to affect anyone negatively in production. CI based tests are quite unlikely to change files or YAML config between test runs which would require a manifest rebuild. And developers executing tests should follow our existing documentation which always said to use `flush` between test runs when you change stuff.