### PR TITLE
var_export does not handle circular references

### DIFF
--- a/src/Dev/CliDebugView.php
+++ b/src/Dev/CliDebugView.php
@@ -176,7 +176,7 @@ class CliDebugView extends DebugView
 
         // Format object
         if (is_object($val)) {
-            return var_export($val, true);
+            return print_r($val, true);
         }
 
         // Format bool


### PR DESCRIPTION
this often happens in SilverStripe, a plain print_r is much safer