### PR TITLE
MINOR Add caching to the TreeDropdownField tree action

### DIFF
--- a/src/Forms/TreeDropdownField.php
+++ b/src/Forms/TreeDropdownField.php
@@ -453,6 +453,8 @@ class TreeDropdownField extends FormField
         /** @var DataObject|Hierarchy $obj */
         $obj = null;
         $sourceObject = $this->getSourceObject();
+
+        Hierarchy::prepopulate_numchildren_cache($sourceObject);
         if ($id && !$request->requestVar('forceFullTree')) {
             $obj = DataObject::get_by_id($sourceObject, $id);
             $isSubTree = true;

--- a/src/Forms/TreeDropdownField.php
+++ b/src/Forms/TreeDropdownField.php
@@ -454,7 +454,13 @@ class TreeDropdownField extends FormField
         $obj = null;
         $sourceObject = $this->getSourceObject();
 
-        Hierarchy::prepopulate_numchildren_cache($sourceObject);
+        // Precache numChildren count if possible.
+        if ($this->getNumChildrenMethod() == 'numChildren') {
+            // We're not calling `Hierarchy::prepopulateTreeDataCache()` because we're not customising results based
+            // on version or Fluent locales. So there would be no performance gain from additional caching.
+            Hierarchy::prepopulate_numchildren_cache($sourceObject);
+        }
+
         if ($id && !$request->requestVar('forceFullTree')) {
             $obj = DataObject::get_by_id($sourceObject, $id);
             $isSubTree = true;


### PR DESCRIPTION
This is more of an experimental PR. I'm not actually sure it's a plus.

Basically we apply some of the same logic that got introduced by https://github.com/silverstripe/silverstripe-framework/pull/8380 to the `TreeDropdownField`.

My preliminary profiling on my local box seems to indicate its faster. It's speed things up by 12%. 

It increases the time spent waiting for SQL query results, but reduces the number of query ... basically we are running a smaller number of more intensive queries. My guess is that if you a using a remote DB Server on SSP your actual waiting for queries time will go down as well because of latency.

![image](https://user-images.githubusercontent.com/1168676/46059033-a5cf5280-c1b1-11e8-8ace-7f3385c14ca6.png)

I'll try to run some test on SSP and on a site that does not have that has a smaller SiteTree.