### PR TITLE
NEW Show file path on PHP parser exceptions

### DIFF
--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -8,6 +8,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
+use PhpParser\ErrorHandler\ErrorHandler;
 use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Cache\CacheFactory;
 use SilverStripe\Dev\TestOnly;
@@ -490,11 +491,13 @@ class ClassManifest
             $changed = true;
             // Build from php file parser
             $fileContents = ClassContentRemover::remove_class_content($pathname);
+            // Not injectable, error handling is an implementation detail.
+            $errorHandler = new ClassManifestErrorHandler($pathname);
             try {
-                $stmts = $this->getParser()->parse($fileContents);
+                $stmts = $this->getParser()->parse($fileContents, $errorHandler);
             } catch (Error $e) {
                 // if our mangled contents breaks, try again with the proper file contents
-                $stmts = $this->getParser()->parse(file_get_contents($pathname));
+                $stmts = $this->getParser()->parse(file_get_contents($pathname), $errorHandler);
             }
             $this->getTraverser()->traverse($stmts);
 

--- a/src/Core/Manifest/ClassManifestErrorHandler.php
+++ b/src/Core/Manifest/ClassManifestErrorHandler.php
@@ -1,0 +1,33 @@
+<?php
+namespace SilverStripe\Core\Manifest;
+
+use PhpParser\Error;
+use PhpParser\ErrorHandler;
+
+/**
+
+ * Error handler which throws, but retains the original path context.
+ * For parsing errors, this is essential information to identify the issue.
+ */
+class ClassManifestErrorHandler implements ErrorHandler
+{
+    /**
+     * @var String
+     */
+    protected $pathname;
+
+    /**
+     * @param String $pathname
+     */
+    public function __construct($pathname)
+    {
+        $this->pathname = $pathname;
+    }
+
+    public function handleError(Error $error)
+    {
+        $newMessage = sprintf('%s in %s', $error->getRawMessage(), $this->pathname);
+        $error->setRawMessage($newMessage);
+        throw $error;
+    }
+}

--- a/src/Core/Manifest/ClassManifestErrorHandlerTest.php
+++ b/src/Core/Manifest/ClassManifestErrorHandlerTest.php
@@ -1,0 +1,20 @@
+<?php
+namespace SilverStripe\Core\Tests\Manifest;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Core\Manifest\ClassManifestErrorHandler;
+use PhpParser\Error;
+
+class ClassManifestErrorHandlerTest extends SapphireTest
+{
+    /**
+     * @expectedException \PhpParser\Error
+     * @expectedExceptionMessage my error in /my/path
+     */
+    public function testIncludesPathname()
+    {
+        $h = new ClassManifestErrorHandler('/my/path');
+        $e = new Error('my error');
+        $h->handleError($e);
+    }
+}


### PR DESCRIPTION
How did it take so long to fix this? How did developers put up with now knowing *in which file* their parse error happened, and only get the line.

And to top it off, they get a misleading message by having them pointed at a PHP parser file instead.

This must've mystified hundreds of devs over the last two years (https://github.com/silverstripe/silverstripe-framework/commit/cdb4a86e1c8fe4a0b01ddff4fb3f32c2568685e8)

We need to get better at real world testing of our APIs :(

Before:

```
 Fatal error: Uncaught PhpParser\Error: Syntax error, unexpected T_STRING, expecting '{' on line 9 in /var/www/mysite/www/vendor/nikic/php-parser/lib/PhpParser/ParserAbstract.php on line 313

```

After:

```
 Fatal error: Uncaught PhpParser\Error: Syntax error, unexpected T_STRING, expecting '{' in /var/www/mysite/www/app/src/Page.php on line 9 in /var/www/mysite/www/vendor/nikic/php-parser/lib/PhpParser/ParserAbstract.php on line 313
 ```