### PR TITLE
FIX Avoid having search fields with the same names as form elements

### DIFF
--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -264,6 +264,11 @@ class GridFieldFilterHeader implements GridField_URLHandler, GridField_HTMLProvi
             return new HTTPResponse(_t(__CLASS__ . '.SearchFormFaliure', 'No search form could be generated'), 400);
         }
 
+        // Append a prefix to search field names to prevent conflicts with other fields in the search form
+        foreach ($searchFields as $field) {
+            $field->setName('Search__' . $field->getName());
+        }
+
         $columns = $gridField->getColumns();
 
         // Update field titles to match column titles

--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -235,11 +235,19 @@ class GridFieldFilterHeader implements GridField_URLHandler, GridField_HTMLProvi
 
         $name = $gridField->Title ?: singleton($gridField->getModelClass())->i18n_plural_name();
 
+        // Prefix "Search__" onto the filters for the React component
+        $filters = $context->getSearchParams();
+        if (!$this->useLegacyFilterHeader && !empty($filters)) {
+            $filters = array_combine(array_map(function ($key) {
+                return 'Search__' . $key;
+            }, array_keys($filters)), $filters);
+        }
+
         $schema = [
             'formSchemaUrl' => $schemaUrl,
             'name' => $searchField,
             'placeholder' => _t(__CLASS__ . '.Search', 'Search "{name}"', ['name' => $name]),
-            'filters' => $context->getSearchParams() ?: new \stdClass, // stdClass maps to empty json object '{}'
+            'filters' => $filters ?: new \stdClass, // stdClass maps to empty json object '{}'
             'gridfield' => $gridField->getName(),
             'searchAction' => GridField_FormAction::create($gridField, 'filter', false, 'filter', null)->getAttribute('name'),
             'clearAction' => GridField_FormAction::create($gridField, 'reset', false, 'reset', null)->getAttribute('name')
@@ -294,6 +302,7 @@ class GridFieldFilterHeader implements GridField_URLHandler, GridField_HTMLProvi
             $searchFields,
             new FieldList()
         );
+
         $form->setFormMethod('get');
         $form->setFormAction($gridField->Link());
         $form->addExtraClass('cms-search-form form--no-dividers');

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -114,8 +114,8 @@ class GridFieldFilterHeaderTest extends SapphireTest
         $this->assertEquals('field/testfield/schema/SearchForm', $searchSchema->formSchemaUrl);
         $this->assertEquals('Name', $searchSchema->name);
         $this->assertEquals('Search "Teams"', $searchSchema->placeholder);
-        $this->assertEquals('test', $searchSchema->filters->Name);
-        $this->assertEquals('place', $searchSchema->filters->City);
+        $this->assertEquals('test', $searchSchema->filters->Search__Name);
+        $this->assertEquals('place', $searchSchema->filters->Search__City);
         $this->assertEquals('testfield', $searchSchema->gridfield);
     }
 }


### PR DESCRIPTION
This fixes an issue where search filters would create form elements with simple titles that were further down the DOM than some other form elements. This means that the search form fields were being used when saving on pages like CMS page edit.

To be honest I'm not sure if this is the best fix, but it works and it seems way lower impact than people suddenly not having their pages save.

This is coupled to a PR on admin (silverstripe/silverstripe-admin#664)

Issue: https://github.com/silverstripe/silverstripe-cms/issues/2251