### PR TITLE
raw2att accepts array, but sprintf doesn't

### DIFF
--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -730,7 +730,11 @@ class FormField extends RequestHandler
             if ($value === true) {
                 $parts[] = sprintf('%s="%s"', $name, $name);
             } else {
-                $parts[] = sprintf('%s="%s"', $name, Convert::raw2att($value));
+                $strValue = Convert::raw2att($value);
+                if (!is_string($strValue)) {
+                    $strValue = json_encode($strValue);
+                }
+                $parts[] = sprintf('%s="%s"', $name, $strValue);
             }
         }
 


### PR DESCRIPTION
it's not very likely to happen (it did in my case :-) ) but if the value is an array, sprintf will fail (because raw2att accepts array, but sprintf doesn't). i suggest to json encode any array data to ensure it's safely included in the html. Or we should throw proper exceptions to make sure invalid values do not result in a php error.