### PR TITLE
Add more list sorting tests and fix many many through sorting

### DIFF
--- a/src/ORM/ManyManyThroughQueryManipulator.php
+++ b/src/ORM/ManyManyThroughQueryManipulator.php
@@ -3,6 +3,7 @@
 
 namespace SilverStripe\ORM;
 
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\Deprecation;
@@ -251,6 +252,13 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
                 "\"{$joinTableAlias}\".\"{$joinTableColumn}\"",
                 "{$joinTableAlias}_{$joinTableColumn}"
             );
+        }
+
+        // Set a default sort from the join model if available and nothing is already set
+        if (empty($sqlSelect->getOrderBy())
+            && $sort = Config::inst()->get($this->getJoinClass(), 'default_sort')
+        ) {
+            $sqlSelect->setOrderBy($sort);
         }
 
         // Apply join and record sql for later insertion (at end of replacements)

--- a/tests/php/ORM/HasManyListTest.php
+++ b/tests/php/ORM/HasManyListTest.php
@@ -11,17 +11,16 @@ use SilverStripe\ORM\Tests\HasManyListTest\Employee;
 class HasManyListTest extends SapphireTest
 {
 
-    // Borrow the model from DataObjectTest
     protected static $fixture_file = [
         'DataObjectTest.yml', // Borrow the model from DataObjectTest
         'HasManyListTest.yml',
     ];
 
-    public static $extra_data_objects = array(
+    public static $extra_data_objects = [
         Company::class,
         Employee::class,
         CompanyCar::class,
-    );
+    ];
 
     public static function getExtraDataObjects()
     {
@@ -36,7 +35,7 @@ class HasManyListTest extends SapphireTest
     {
         // Relies on the fact that (unrelated) comments exist in the fixture file already
         $newTeam = new Team(); // has_many Comments
-        $this->assertEquals(array(), $newTeam->Comments()->column('ID'));
+        $this->assertEquals([], $newTeam->Comments()->column('ID'));
     }
 
     /**
@@ -48,23 +47,23 @@ class HasManyListTest extends SapphireTest
         // Check that expected teams exist
         $list = Team::get();
         $this->assertEquals(
-            array('Subteam 1', 'Subteam 2', 'Subteam 3', 'Team 1', 'Team 2', 'Team 3'),
+            ['Subteam 1', 'Subteam 2', 'Subteam 3', 'Team 1', 'Team 2', 'Team 3'],
             $list->sort('Title')->column('Title')
         );
 
         // Test that each team has the correct fans
         $team1 = $this->objFromFixture(DataObjectTest\Team::class, 'team1');
         $team2 = $this->objFromFixture(DataObjectTest\Team::class, 'team2');
-        $this->assertEquals(array('Bob', 'Joe'), $team1->Comments()->sort('Name')->column('Name'));
-        $this->assertEquals(array('Phil'), $team2->Comments()->sort('Name')->column('Name'));
+        $this->assertEquals(['Bob', 'Joe'], $team1->Comments()->sort('Name')->column('Name'));
+        $this->assertEquals(['Phil'], $team2->Comments()->sort('Name')->column('Name'));
 
         // Test that removing comments from unrelated team has no effect
         $team1comment = $this->objFromFixture(DataObjectTest\TeamComment::class, 'comment1');
         $team2comment = $this->objFromFixture(DataObjectTest\TeamComment::class, 'comment3');
         $team1->Comments()->remove($team2comment);
         $team2->Comments()->remove($team1comment);
-        $this->assertEquals(array('Bob', 'Joe'), $team1->Comments()->sort('Name')->column('Name'));
-        $this->assertEquals(array('Phil'), $team2->Comments()->sort('Name')->column('Name'));
+        $this->assertEquals(['Bob', 'Joe'], $team1->Comments()->sort('Name')->column('Name'));
+        $this->assertEquals(['Phil'], $team2->Comments()->sort('Name')->column('Name'));
         $this->assertEquals($team1->ID, $team1comment->TeamID);
         $this->assertEquals($team2->ID, $team2comment->TeamID);
 
@@ -73,9 +72,45 @@ class HasManyListTest extends SapphireTest
         $team2comment = $this->objFromFixture(DataObjectTest\TeamComment::class, 'comment3');
         $team1->Comments()->remove($team1comment);
         $team2->Comments()->remove($team2comment);
-        $this->assertEquals(array('Bob'), $team1->Comments()->sort('Name')->column('Name'));
-        $this->assertEquals(array(), $team2->Comments()->sort('Name')->column('Name'));
+        $this->assertEquals(['Bob'], $team1->Comments()->sort('Name')->column('Name'));
+        $this->assertEquals([], $team2->Comments()->sort('Name')->column('Name'));
         $this->assertEmpty($team1comment->TeamID);
         $this->assertEmpty($team2comment->TeamID);
+    }
+
+    public function testDefaultSortIsUsedOnList()
+    {
+        /** @var Company $company */
+        $company = $this->objFromFixture(Company::class, 'silverstripe');
+
+        $this->assertListEquals([
+            ['Make' => 'Ferrari'],
+            ['Make' => 'Jaguar'],
+            ['Make' => 'Lamborghini'],
+        ], $company->CompanyCars());
+    }
+
+    public function testCanBeSortedDescending()
+    {
+        /** @var Company $company */
+        $company = $this->objFromFixture(Company::class, 'silverstripe');
+
+        $this->assertListEquals([
+            ['Make' => 'Lamborghini'],
+            ['Make' => 'Jaguar'],
+            ['Make' => 'Ferrari'],
+        ], $company->CompanyCars()->sort('"Make" DESC'));
+    }
+
+    public function testSortByModel()
+    {
+        /** @var Company $company */
+        $company = $this->objFromFixture(Company::class, 'silverstripe');
+
+        $this->assertListEquals([
+            ['Model' => 'Countach'],
+            ['Model' => 'E Type'],
+            ['Model' => 'F40'],
+        ], $company->CompanyCars()->sort('"Model" ASC'));
     }
 }

--- a/tests/php/ORM/HasManyListTest.yml
+++ b/tests/php/ORM/HasManyListTest.yml
@@ -1,26 +1,26 @@
-SilverStripe\ORM\Tests\DataObjectTest\Company:
+SilverStripe\ORM\Tests\HasManyListTest\Company:
   silverstripe:
     Name: 'SilverStripe Ltd'
 SilverStripe\ORM\Tests\HasManyListTest\Employee:
   john:
     Name: 'John Smith'
-    Company: =>SilverStripe\ORM\Tests\DataObjectTest\Company.silverstripe
+    Company: =>SilverStripe\ORM\Tests\HasManyListTest\Company.silverstripe
   jenny:
     Name: 'Jenny Smith'
-    Company: =>SilverStripe\ORM\Tests\DataObjectTest\Company.silverstripe
+    Company: =>SilverStripe\ORM\Tests\HasManyListTest\Company.silverstripe
 SilverStripe\ORM\Tests\HasManyListTest\CompanyCar:
   jaguar:
     Make: 'Jaguar'
     Model: 'E Type'
     User: =>SilverStripe\ORM\Tests\HasManyListTest\Employee.john
-    Company: =>SilverStripe\ORM\Tests\DataObjectTest\Company.silverstripe
+    Company: =>SilverStripe\ORM\Tests\HasManyListTest\Company.silverstripe
   ferrari:
     Make: 'Ferrari'
     Model: 'F40'
     User: =>SilverStripe\ORM\Tests\HasManyListTest\Employee.jenny
-    Company: =>SilverStripe\ORM\Tests\DataObjectTest\Company.silverstripe
+    Company: =>SilverStripe\ORM\Tests\HasManyListTest\Company.silverstripe
   lamborghini:
     Make: 'Lamborghini'
     Model: 'Countach'
     User: =>SilverStripe\ORM\Tests\HasManyListTest\Employee.jenny
-    Company: =>SilverStripe\ORM\Tests\DataObjectTest\Company.silverstripe
+    Company: =>SilverStripe\ORM\Tests\HasManyListTest\Company.silverstripe

--- a/tests/php/ORM/HasManyListTest/CompanyCar.php
+++ b/tests/php/ORM/HasManyListTest/CompanyCar.php
@@ -7,13 +7,15 @@ use SilverStripe\ORM\DataObject;
 
 class CompanyCar extends DataObject implements TestOnly
 {
-    private static $db = array(
+    private static $db = [
         'Make' => 'Varchar(100)',
         'Model' => 'Varchar(100)',
-    );
+    ];
 
-    private static $has_one = array(
+    private static $has_one = [
         'User' => Employee::class,
         'Company' => Company::class,
-    );
+    ];
+
+    private static $default_sort = 'Make';
 }

--- a/tests/php/ORM/ManyManyThroughListTest.php
+++ b/tests/php/ORM/ManyManyThroughListTest.php
@@ -70,8 +70,13 @@ class ManyManyThroughListTest extends SapphireTest
         $this->assertNotNull($item2->getJoin());
         $this->assertEquals('join 2', $item2->getJoin()->Title);
         $this->assertEquals('join 2', $item2->ManyManyThroughListTest_JoinObject->Title);
+    }
 
-        // Test sorting on join table
+    public function testSortingOnJoinTable()
+    {
+        /** @var ManyManyThroughListTest\TestObject $parent */
+        $parent = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
+
         $items = $parent->Items()->sort('"ManyManyThroughListTest_JoinObject"."Sort"');
         $this->assertListEquals(
             [
@@ -89,11 +94,63 @@ class ManyManyThroughListTest extends SapphireTest
             ],
             $items
         );
+
         $items = $parent->Items()->sort('"ManyManyThroughListTest_JoinObject"."Title" DESC');
         $this->assertListEquals(
             [
                 ['Title' => 'item 2'],
                 ['Title' => 'item 1'],
+            ],
+            $items
+        );
+
+        $items = $parent->Items()->sort('"ManyManyThroughListTest_JoinObject"."Title" ASC');
+        $this->assertListEquals(
+            [
+                ['Title' => 'item 1'],
+                ['Title' => 'item 2'],
+            ],
+            $items
+        );
+    }
+
+    public function testSortingOnJoinTableWithoutTableAlias()
+    {
+        /** @var ManyManyThroughListTest\TestObject $parent */
+        $parent = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
+
+        $items = $parent->Items()->sort('"Sort"');
+        $this->assertListEquals(
+            [
+                ['Title' => 'item 2'],
+                ['Title' => 'item 1'],
+            ],
+            $items
+        );
+
+        $items = $parent->Items()->sort('"Sort" ASC');
+        $this->assertListEquals(
+            [
+                ['Title' => 'item 1'],
+                ['Title' => 'item 2'],
+            ],
+            $items
+        );
+
+        $items = $parent->Items()->sort('"Title" DESC');
+        $this->assertListEquals(
+            [
+                ['Title' => 'item 2'],
+                ['Title' => 'item 1'],
+            ],
+            $items
+        );
+
+        $items = $parent->Items()->sort('"Title" ASC');
+        $this->assertListEquals(
+            [
+                ['Title' => 'item 1'],
+                ['Title' => 'item 2'],
             ],
             $items
         );

--- a/tests/php/ORM/ManyManyThroughListTest.php
+++ b/tests/php/ORM/ManyManyThroughListTest.php
@@ -72,88 +72,83 @@ class ManyManyThroughListTest extends SapphireTest
         $this->assertEquals('join 2', $item2->ManyManyThroughListTest_JoinObject->Title);
     }
 
-    public function testSortingOnJoinTable()
+    /**
+     * @param string $sort
+     * @param array $expected
+     * @dataProvider sortingProvider
+     */
+    public function testSorting($sort, $expected)
     {
         /** @var ManyManyThroughListTest\TestObject $parent */
         $parent = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
 
-        $items = $parent->Items()->sort('"ManyManyThroughListTest_JoinObject"."Sort"');
-        $this->assertListEquals(
-            [
-                ['Title' => 'item 2'],
-                ['Title' => 'item 1'],
-            ],
-            $items
-        );
-
-        $items = $parent->Items()->sort('"ManyManyThroughListTest_JoinObject"."Sort" ASC');
-        $this->assertListEquals(
-            [
-                ['Title' => 'item 1'],
-                ['Title' => 'item 2'],
-            ],
-            $items
-        );
-
-        $items = $parent->Items()->sort('"ManyManyThroughListTest_JoinObject"."Title" DESC');
-        $this->assertListEquals(
-            [
-                ['Title' => 'item 2'],
-                ['Title' => 'item 1'],
-            ],
-            $items
-        );
-
-        $items = $parent->Items()->sort('"ManyManyThroughListTest_JoinObject"."Title" ASC');
-        $this->assertListEquals(
-            [
-                ['Title' => 'item 1'],
-                ['Title' => 'item 2'],
-            ],
-            $items
-        );
+        $items = $parent->Items()->sort($sort);
+        $this->assertListEquals($expected, $items);
     }
 
-    public function testSortingOnJoinTableWithoutTableAlias()
+    /**
+     * @return array[]
+     */
+    public function sortingProvider()
     {
-        /** @var ManyManyThroughListTest\TestObject $parent */
-        $parent = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
-
-        $items = $parent->Items()->sort('"Sort"');
-        $this->assertListEquals(
-            [
-                ['Title' => 'item 2'],
-                ['Title' => 'item 1'],
+        return [
+            'table with default column' => [
+                '"ManyManyThroughListTest_JoinObject"."Sort"',
+                [
+                    ['Title' => 'item 2'],
+                    ['Title' => 'item 1'],
+                ]
             ],
-            $items
-        );
-
-        $items = $parent->Items()->sort('"Sort" ASC');
-        $this->assertListEquals(
-            [
-                ['Title' => 'item 1'],
-                ['Title' => 'item 2'],
+            'table with default column ascending' => [
+                '"ManyManyThroughListTest_JoinObject"."Sort" ASC',
+                [
+                    ['Title' => 'item 1'],
+                    ['Title' => 'item 2'],
+                ]
             ],
-            $items
-        );
-
-        $items = $parent->Items()->sort('"Title" DESC');
-        $this->assertListEquals(
-            [
-                ['Title' => 'item 2'],
-                ['Title' => 'item 1'],
+            'table with column descending' => [
+                '"ManyManyThroughListTest_JoinObject"."Title" DESC',
+                [
+                    ['Title' => 'item 2'],
+                    ['Title' => 'item 1'],
+                ]
             ],
-            $items
-        );
-
-        $items = $parent->Items()->sort('"Title" ASC');
-        $this->assertListEquals(
-            [
-                ['Title' => 'item 1'],
-                ['Title' => 'item 2'],
+            'table with column ascending' => [
+                '"ManyManyThroughListTest_JoinObject"."Title" ASC',
+                [
+                    ['Title' => 'item 1'],
+                    ['Title' => 'item 2'],
+                ]
             ],
-            $items
-        );
+            'default column' => [
+                '"Sort"',
+                [
+                    ['Title' => 'item 2'],
+                    ['Title' => 'item 1'],
+                ]
+            ],
+            'default column ascending' => [
+                '"Sort" ASC',
+                [
+                    ['Title' => 'item 1'],
+                    ['Title' => 'item 2'],
+                ]
+            ],
+            'column descending' => [
+                '"Title" DESC',
+                [
+                    ['Title' => 'item 2'],
+                    ['Title' => 'item 1'],
+                ]
+            ],
+            'column ascending' => [
+                '"Title" ASC',
+                [
+                    ['Title' => 'item 1'],
+                    ['Title' => 'item 2'],
+                ]
+            ],
+        ];
     }
 
     public function testAdd()

--- a/tests/php/ORM/ManyManyThroughListTest.php
+++ b/tests/php/ORM/ManyManyThroughListTest.php
@@ -82,8 +82,11 @@ class ManyManyThroughListTest extends SapphireTest
         /** @var ManyManyThroughListTest\TestObject $parent */
         $parent = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
 
-        $items = $parent->Items()->sort($sort);
-        $this->assertListEquals($expected, $items);
+        $items = $parent->Items();
+        if ($sort) {
+            $items = $items->sort($sort);
+        }
+        $this->assertSame($expected, $items->column('Title'));
     }
 
     /**
@@ -92,61 +95,41 @@ class ManyManyThroughListTest extends SapphireTest
     public function sortingProvider()
     {
         return [
+            'nothing passed (default)' => [
+                null,
+                ['item 2', 'item 1'],
+            ],
             'table with default column' => [
                 '"ManyManyThroughListTest_JoinObject"."Sort"',
-                [
-                    ['Title' => 'item 2'],
-                    ['Title' => 'item 1'],
-                ]
+                ['item 2', 'item 1'],
             ],
             'table with default column ascending' => [
                 '"ManyManyThroughListTest_JoinObject"."Sort" ASC',
-                [
-                    ['Title' => 'item 1'],
-                    ['Title' => 'item 2'],
-                ]
+                ['item 2', 'item 1'],
             ],
             'table with column descending' => [
                 '"ManyManyThroughListTest_JoinObject"."Title" DESC',
-                [
-                    ['Title' => 'item 2'],
-                    ['Title' => 'item 1'],
-                ]
+                ['item 2', 'item 1'],
             ],
             'table with column ascending' => [
                 '"ManyManyThroughListTest_JoinObject"."Title" ASC',
-                [
-                    ['Title' => 'item 1'],
-                    ['Title' => 'item 2'],
-                ]
+                ['item 1', 'item 2'],
             ],
             'default column' => [
                 '"Sort"',
-                [
-                    ['Title' => 'item 2'],
-                    ['Title' => 'item 1'],
-                ]
+                ['item 2', 'item 1'],
             ],
             'default column ascending' => [
                 '"Sort" ASC',
-                [
-                    ['Title' => 'item 1'],
-                    ['Title' => 'item 2'],
-                ]
+                ['item 2', 'item 1'],
             ],
             'column descending' => [
                 '"Title" DESC',
-                [
-                    ['Title' => 'item 2'],
-                    ['Title' => 'item 1'],
-                ]
+                ['item 2', 'item 1'],
             ],
             'column ascending' => [
                 '"Title" ASC',
-                [
-                    ['Title' => 'item 1'],
-                    ['Title' => 'item 2'],
-                ]
+                ['item 1', 'item 2'],
             ],
         ];
     }

--- a/tests/php/ORM/ManyManyThroughListTest.php
+++ b/tests/php/ORM/ManyManyThroughListTest.php
@@ -107,6 +107,10 @@ class ManyManyThroughListTest extends SapphireTest
                 '"ManyManyThroughListTest_JoinObject"."Sort" ASC',
                 ['item 2', 'item 1'],
             ],
+            'table with default column descending' => [
+                '"ManyManyThroughListTest_JoinObject"."Sort" DESC',
+                ['item 1', 'item 2'],
+            ],
             'table with column descending' => [
                 '"ManyManyThroughListTest_JoinObject"."Title" DESC',
                 ['item 2', 'item 1'],
@@ -122,6 +126,10 @@ class ManyManyThroughListTest extends SapphireTest
             'default column ascending' => [
                 '"Sort" ASC',
                 ['item 2', 'item 1'],
+            ],
+            'default column descending' => [
+                '"Sort" DESC',
+                ['item 1', 'item 2'],
             ],
             'column descending' => [
                 '"Title" DESC',

--- a/tests/php/ORM/ManyManyThroughListTest/JoinObject.php
+++ b/tests/php/ORM/ManyManyThroughListTest/JoinObject.php
@@ -23,4 +23,6 @@ class JoinObject extends DataObject implements TestOnly
         'Parent' => TestObject::class,
         'Child' => Item::class,
     ];
+
+    private static $default_sort = '"Sort" ASC';
 }


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-framework/issues/7981

This separates the sorting assertions out of an existing test into its own method, and adds another sorting test that doesn't use table aliases in the sort field.

I've also added some tests for sorting HasManyLists

---

This now fixes #7981 - a ManyManyThroughList will now use its joinClass's default_sort if nothing else has been provided already