### PR TITLE
Update index.md

### DIFF
--- a/docs/en/03_Upgrading/index.md
+++ b/docs/en/03_Upgrading/index.md
@@ -131,6 +131,7 @@ composer global config bin-dir
 On *nix system, the following command will add your global composer bin directory to your path if `bash` is your default shell environment:
 ```bash
 echo 'export PATH=$PATH:~/.composer/vendor/bin/' >> ~/.bash_profile
+source  ~/.bash_profile
 ```
 
 ### Running all the upgrader commands in this guide in on line


### PR DESCRIPTION
When exporting path to ~/.bash_profile the change do not take action before you reload the shell. Calling 'source  ~/.bash_profile' executes the change.

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/