### PR TITLE
ENHANCEMENT: Prevent lazy loading on setComponent

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -1755,6 +1755,9 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 
             // Update local ID
             $joinField = $componentName . 'ID';
+            if ($item) {
+                unset($this->record[$joinField . '_Lazy']);
+            }
             $this->setField($joinField, $item ? $item->ID : null);
             // Update Class (Polymorphic has_one)
             // Extract class name for polymorphic relations


### PR DESCRIPTION
The call to `setField` for the foreign key triggers a lazy load of the component. If you're setting a component explicitly, this query is unnecessary, from what I can see.

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/