### PR TITLE
FIX: Don’t change state in ArrayList::getIterator()

### DIFF
--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -84,12 +84,13 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      */
     public function getIterator()
     {
-        foreach ($this->items as $i => $item) {
-            if (is_array($item)) {
-                $this->items[$i] = new ArrayData($item);
-            }
-        }
-        return new ArrayIterator($this->items);
+        $items = array_map(
+            function ($item) {
+                return is_array($item) ? new ArrayData($item) : $item;
+            },
+            $this->items
+        );
+        return new ArrayIterator($items);
     }
 
     /**


### PR DESCRIPTION
This prevents the map-to-ArrayData conversion from changing object
state and making the result of toArray() non-deterministic.

Fixes #2636. Other solutions were suggested on that ticket, but there is
no way of putting special code in for a SSViewer-specific iterator, and
having object state pre-emptively converted to ArrayData would
be an SS5-level change.