### PR TITLE
FIX: Don’t use USE_FRM in MySQL repair. Fixes #6300.

### DIFF
--- a/src/ORM/Connect/MySQLSchemaManager.php
+++ b/src/ORM/Connect/MySQLSchemaManager.php
@@ -167,7 +167,7 @@ class MySQLSchemaManager extends DBSchemaManager
             "Table $tableName: repaired",
             "repaired"
         );
-        return $this->runTableCheckCommand("REPAIR TABLE \"$tableName\" USE_FRM");
+        return $this->runTableCheckCommand("REPAIR TABLE \"$tableName\"");
     }
 
     /**


### PR DESCRIPTION
USE_FRM is a sufficiently dangerous option that it should require
manual DBA activity to carry out.

See http://dev.mysql.com/doc/refman/5.7/en/repair-table.html for more
info.