### PR TITLE
FIX: Use DELETE FROM instead of TRUNCATE for clearTable

### DIFF
--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -403,7 +403,7 @@ abstract class Database
      */
     public function clearTable($table)
     {
-        $this->query("TRUNCATE \"$table\"");
+        $this->query("DELETE FROM \"$table\"");
     }
 
     /**


### PR DESCRIPTION
clearTable is mainly used for clearing data between tests. In this case,
there are very few or zero records, and DELETE FROM is quicker than
TRUNCATE, which works by deleting and recreating the table.

This materially speeds up test execution, at least on MySQL.

Implemented in SS3 at 815da76b056a716c8831d22bbf93528912cbcb28