### PR TITLE
FIX: Use DELETE FROM instead of TRUNCATE for clearTable

### DIFF
--- a/model/connect/MySQLDatabase.php
+++ b/model/connect/MySQLDatabase.php
@@ -362,4 +362,23 @@ class MySQLDatabase extends SS_Database {
 	public function random() {
 		return 'RAND()';
 	}
+
+	/**
+	 * Clear all data in a given table
+	 *
+	 * @param string $table Name of table
+	 */
+	public function clearTable($table) {
+		$this->query("DELETE FROM \"$table\"");
+
+		// Check if resetting the auto-increment is needed
+		$autoIncrement = $this->preparedQuery(
+			'SELECT "AUTO_INCREMENT" FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?',
+			[ $this->getSelectedDatabase(), $table]
+		)->value();
+
+		if ($autoIncrement > 1) {
+			$this->query("ALTER TABLE \"$table\" AUTO_INCREMENT = 1");
+		}
+	}
 }

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -29,6 +29,7 @@ class DataObjectTest extends SapphireTest {
 		'DataObjectTest_Play',
 		'DataObjectTest_Ploy',
 		'DataObjectTest_Bogey',
+		'DataObjectTest_Sortable',
 		'ManyManyListTest_Product',
 		'ManyManyListTest_Category',
 	);


### PR DESCRIPTION
clearTable is mainly used for clearing data between tests. In this case,
there are very few or zero records, and DELETE FROM is quicker than
TRUNCATE, which works by deleting and recreating the table.

This materially speeds up test execution, at least on MySQL.