### PR TITLE
FIX: Use DELETE FROM instead of TRUNCATE for clearTable

### DIFF
--- a/src/ORM/Connect/MySQLDatabase.php
+++ b/src/ORM/Connect/MySQLDatabase.php
@@ -523,4 +523,24 @@ class MySQLDatabase extends Database
     {
         return 'RAND()';
     }
+
+    /**
+     * Clear all data in a given table
+     *
+     * @param string $table Name of table
+     */
+    public function clearTable($table)
+    {
+        $this->query("DELETE FROM \"$table\"");
+
+        // Check if resetting the auto-increment is needed
+        $autoIncrement = $this->preparedQuery(
+            'SELECT "AUTO_INCREMENT" FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?',
+            [ $this->getSelectedDatabase(), $table]
+        )->value();
+
+        if ($autoIncrement > 1) {
+            $this->query("ALTER TABLE \"$table\" AUTO_INCREMENT = 1");
+        }
+    }
 }


### PR DESCRIPTION
clearTable is mainly used for clearing data between tests. In this case,
there are very few or zero records, and DELETE FROM is quicker than
TRUNCATE, which works by deleting and recreating the table.

This materially speeds up test execution, at least on MySQL.

Cherry-pick of SS3 ae9ab22a8ff1b48c90f7dfe2899c09efaa65b161 provided in #8435
