### PR TITLE
NEW TabSet react component is no longer structural

### DIFF
--- a/src/Forms/TabSet.php
+++ b/src/Forms/TabSet.php
@@ -44,6 +44,13 @@ class TabSet extends CompositeField
     protected $schemaComponent = 'Tabs';
 
     /**
+     * Alter datatype from structural to track the current tab in redux state.
+     *
+     * @var string
+     */
+    protected $schemaDataType = FormField::SCHEMA_DATA_TYPE_STRING;
+
+    /**
      * @var TabSet
      */
     protected $tabSet;


### PR DESCRIPTION
Related to silverstripe/silverstripe-admin#669

The related admin PR adjusts the Tabs component to use redux-form state to store the active tab. This allows that to work by ensuring `Tabs` is wrapped with a `ReduxFormField` HOC. 

(See https://github.com/silverstripe/silverstripe-admin/blob/6e66c48d65b52d568fbd34f8a7c630b4a829c2c9/client/src/components/FormBuilder/FormBuilder.js#L169-L173 for reference)

Related issue dnadesign/silverstripe-elemental#325