### PR TITLE
FIX allow extensions to be applied via injector service definitions

### DIFF
--- a/src/Core/Config/Middleware/ExtensionMiddleware.php
+++ b/src/Core/Config/Middleware/ExtensionMiddleware.php
@@ -10,6 +10,7 @@ use SilverStripe\Config\Middleware\MiddlewareCommon;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Extension;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataExtension;
 
 class ExtensionMiddleware implements Middleware
@@ -66,6 +67,9 @@ class ExtensionMiddleware implements Middleware
             list($extensionClass, $extensionArgs) = ClassInfo::parse_class_spec($extension);
             // Strip service name specifier
             $extensionClass = strtok($extensionClass, '.');
+            if ($extensionSpec = Injector::inst()->getServiceSpec($extensionClass)) {
+                $extensionClass = $extensionSpec['class'];
+            }
             if (!class_exists($extensionClass)) {
                 throw new InvalidArgumentException("$class references nonexistent $extensionClass in 'extensions'");
             }

--- a/src/Core/Extensible.php
+++ b/src/Core/Extensible.php
@@ -178,10 +178,13 @@ trait Extensible
             $extension = $classOrExtension;
         }
 
-        if (!preg_match('/^([^(]*)/', $extension, $matches)) {
+        if (!preg_match('/^(%\$)?([^(]+)/', $extension, $matches)) {
             return false;
         }
-        $extensionClass = $matches[1];
+        $extensionClass = $matches[2];
+        if ($extensionSpec = Injector::inst()->getServiceSpec($extensionClass)) {
+            $extensionClass = $extensionSpec['class'];
+        }
         if (!class_exists($extensionClass)) {
             user_error(
                 sprintf('Object::add_extension() - Can\'t find extension class for "%s"', $extensionClass),
@@ -346,6 +349,10 @@ trait Extensible
             // Strip service name specifier
             $extensionClass = strtok($extensionClass, '.');
             $sources[] = $extensionClass;
+
+            if ($extensionSpec = Injector::inst()->getServiceSpec($extensionClass)) {
+                $extensionClass = $extensionSpec['class'];
+            }
 
             if (!class_exists($extensionClass)) {
                 throw new InvalidArgumentException("$class references nonexistent $extensionClass in \$extensions");

--- a/tests/php/Core/ObjectTest.php
+++ b/tests/php/Core/ObjectTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Core\Tests;
 
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Extension;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Tests\ObjectTest\BaseObject;
@@ -12,6 +13,7 @@ use SilverStripe\Core\Tests\ObjectTest\ExtendTest2;
 use SilverStripe\Core\Tests\ObjectTest\ExtendTest3;
 use SilverStripe\Core\Tests\ObjectTest\ExtendTest4;
 use SilverStripe\Core\Tests\ObjectTest\ExtensionRemoveTest;
+use SilverStripe\Core\Tests\ObjectTest\ExtensionService;
 use SilverStripe\Core\Tests\ObjectTest\ExtensionTest;
 use SilverStripe\Core\Tests\ObjectTest\ExtensionTest2;
 use SilverStripe\Core\Tests\ObjectTest\ExtensionTest3;
@@ -537,5 +539,27 @@ class ObjectTest extends SapphireTest
         $this->assertInstanceOf($mockClass, $object->getExtensionInstance(TestExtension::class));
         $this->assertInstanceOf(TestExtension::class, $object->getExtensionInstance($mockClass));
         $this->assertInstanceOf($mockClass, $object->getExtensionInstance($mockClass));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testExtensionsAppliedViaANonExistentServiceAsAControl()
+    {
+        Config::modify()->set(BaseObject::class, 'extensions', ['NotAService']);
+        BaseObject::create();
+    }
+
+    public function testExtensionsCanBeAppliedViaInjectorServices()
+    {
+        $config = Config::modify();
+        $config->set(Injector::class, 'ATestService', [
+            'class' => ExtensionService::class,
+            'constructor' => ['nonsense'],
+        ]);
+        $config->set(BaseObject::class, 'extensions', ['ATestService']);
+
+        $nonsense = BaseObject::create();
+        $this->assertEquals('This extension is nonsense', $nonsense->aMethod());
     }
 }

--- a/tests/php/Core/ObjectTest/ExtensionService.php
+++ b/tests/php/Core/ObjectTest/ExtensionService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SilverStripe\Core\Tests\ObjectTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class ExtensionService extends Extension implements TestOnly
+{
+    private $property;
+
+    public function __construct($property)
+    {
+        $this->property = $property;
+    }
+
+    public function aMethod()
+    {
+        return 'This extension is ' . $this->property;
+    }
+}


### PR DESCRIPTION
Throughout the code there is the implication of being able to apply
extensions through an Injector service name - such as the stripping
of %$ before looking up an extensions name.

However this is not possible as class_exists is exclusively used to
ensure that the Extension is a valid subclass of Extension (or
DataExtension).

This commit seeks to rectify that by falling back to using Injector
to see if there is a service registered with the given name, and if
so using it via instantion before performing the sanity check of
the concrete class' inheritance heirarchy.

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/