### PR TITLE
FIX: Drop seconds from DBDatetime::Nice() to restore SS3 behaviour.

### DIFF
--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -223,7 +223,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      * @param int $timeLength
      * @return IntlDateFormatter
      */
-    public function getFormatter($dateLength = IntlDateFormatter::MEDIUM, $timeLength = IntlDateFormatter::MEDIUM)
+    public function getFormatter($dateLength = IntlDateFormatter::MEDIUM, $timeLength = IntlDateFormatter::SHORT)
     {
         return parent::getFormatter($dateLength, $timeLength);
     }

--- a/tests/php/ORM/DBDatetimeTest.php
+++ b/tests/php/ORM/DBDatetimeTest.php
@@ -88,9 +88,14 @@ class DBDatetimeTest extends SapphireTest
 
     public function testNice()
     {
-        $date = DBDatetime::create_field('Datetime', '2001-12-31 22:10:59');
+        $date = DBDatetime::create_field('Datetime', '2001-12-11 22:10:59');
+
         // note: Some localisation packages exclude the ',' in default medium format
-        $this->assertRegExp('#31/12/2001(,)? 10:10:59 PM#i', $date->Nice());
+        i18n::set_locale('en_NZ');
+        $this->assertRegExp('#11/12/2001(,)? 10:10 PM#i', $date->Nice());
+
+        i18n::set_locale('en_US');
+        $this->assertRegExp('#Dec 11(,)? 2001(,)? 10:10 PM#i', $date->Nice());
     }
 
     public function testDate()


### PR DESCRIPTION
Note that the medium date format depends on locale, with en_NZ being
resolutely numeric. I’ve updated the test to verify a couple of locales
to make this more obvious.

Fixes #8121