### PR TITLE
FIX: Ensure that types are preserved fetching from database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,20 +20,20 @@ matrix:
   include:
     - php: 5.6
       env:
-        - DB=MYSQL
+        - DB=PGSQL
         - PHPCS_TEST=1
         - PHPUNIT_TEST=framework
 
     - php: 7.0
       env:
         - DB=PGSQL
+        - PDO=1
         - PHPUNIT_TEST=framework
 
     - php: 7.1
       if: type IN (cron)
       env:
         - DB=MYSQL
-        - PDO=1
         - PHPUNIT_COVERAGE_TEST=framework
 
     - php: 7.2
@@ -50,7 +50,6 @@ matrix:
     - php: 7.3.0RC1
       env:
         - DB=MYSQL
-        - PDO=1
         - PHPUNIT_TEST=framework
       sudo: required
       dist: xenial
@@ -74,7 +73,7 @@ before_script:
 # Install composer dependencies
   - composer validate
   - mkdir ./public
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.1.x-dev --no-update; fi
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.2.x-dev --no-update; fi
   - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --no-update; fi
   - composer require silverstripe/recipe-testing:^1 silverstripe/recipe-core:4.4.x-dev silverstripe/admin:1.4.x-dev silverstripe/versioned:1.4.x-dev --no-update
   - if [[ $PHPUNIT_TEST == cms ]]; then composer require silverstripe/recipe-cms:4.4.x-dev --no-update; fi

--- a/docs/en/02_Developer_Guides/00_Model/08_SQL_Select.md
+++ b/docs/en/02_Developer_Guides/00_Model/08_SQL_Select.md
@@ -291,6 +291,18 @@ $players = Player::get();
 $map = $players->map('Name', 'NameWithBirthyear');
 ```
 
+### Data types
+
+As of SilverStripe 4.4, the following PHP types will be used to return datbase content:
+
+ * booleans will be an integer 1 or 0, to ensure consistency with MySQL that doesn't have native booleans.
+ * integer types returned as integers
+ * floating point / decimal types returned as floats
+ * strings returned as strings
+ * dates / datetimes returned as strings
+
+Up until SilverStripe 4.3, bugs meant that strings were used for every column type.
+
 ## Related Lessons
 * [Building custom SQL](https://www.silverstripe.org/learn/lessons/v4/beyond-the-orm-building-custom-sql-1)
 

--- a/docs/en/04_Changelogs/4.4.0.md
+++ b/docs/en/04_Changelogs/4.4.0.md
@@ -1,0 +1,14 @@
+# 4.4.0
+
+## Overview {#overview}
+
+ - [Correct PHP types are now returned from database queries](/developer_guides/model/sql_select#data-types)
+ 
+## Upgrading {#upgrading}
+
+tbc
+
+## Changes to internal APIs
+
+ - `PDOQuery::__construct()` now has a 2nd argument. If you have subclassed PDOQuery and overridden __construct() 
+   you may see an E_STRICT error

--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -584,6 +584,17 @@ abstract class Database
     abstract public function supportsTransactions();
 
     /**
+     * Does this database support savepoints in transactions
+     * By default it is assumed that they don't unless they are explicitly enabled.
+     *
+     * @return boolean Flag indicating support for savepoints in transactions
+     */
+    public function supportsSavepoints()
+    {
+        return false;
+    }
+
+    /**
      * Invoke $callback within a transaction
      *
      * @param callable $callback Callback to run

--- a/src/ORM/Connect/MySQLTransactionManager.php
+++ b/src/ORM/Connect/MySQLTransactionManager.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace SilverStripe\ORM\Connect;
+
+use SilverStripe\Dev\Deprecation;
+
+/**
+ * TransactionManager that executes MySQL-compatible transaction control queries
+ */
+class MySQLTransactionManager implements TransactionManager
+{
+    protected $dbConn;
+
+    protected $inTransaction = false;
+
+    public function __construct(Database $dbConn)
+    {
+        $this->dbConn = $dbConn;
+    }
+
+    public function transactionStart($transactionMode = false, $sessionCharacteristics = false)
+    {
+        if ($transactionMode || $sessionCharacteristics) {
+            Deprecation::notice(
+                '4.4',
+                '$transactionMode and $sessionCharacteristics are deprecated and will be removed in SS5'
+            );
+        }
+
+        if ($this->inTransaction) {
+            throw new DatabaseException(
+                "Already in transaction, can't start another. Consider decorating with NestedTransactionManager."
+            );
+        }
+
+        // This sets the isolation level for the NEXT transaction, not the current one.
+        if ($transactionMode) {
+            $this->dbConn->query('SET TRANSACTION ' . $transactionMode);
+        }
+
+        $this->dbConn->query('START TRANSACTION');
+
+        if ($sessionCharacteristics) {
+            $this->dbConn->query('SET SESSION TRANSACTION ' . $sessionCharacteristics);
+        }
+
+        $this->inTransaction = true;
+        return true;
+    }
+
+    public function transactionEnd($chain = false)
+    {
+        if (!$this->inTransaction) {
+            throw new DatabaseException("Not in transaction, can't end.");
+        }
+
+        if ($chain) {
+            user_error(
+                "transactionEnd() chain argument no longer implemented. Use NestedTransactionManager",
+                E_USER_WARNING
+            );
+        }
+
+        $this->dbConn->query('COMMIT');
+
+        $this->inTransaction = false;
+        return true;
+    }
+
+    public function transactionRollback($savepoint = null)
+    {
+        if (!$this->inTransaction) {
+            throw new DatabaseException("Not in transaction, can't roll back.");
+        }
+
+        if ($savepoint) {
+            $this->dbConn->query("ROLLBACK TO SAVEPOINT $savepoint");
+        } else {
+            $this->dbConn->query('ROLLBACK');
+            $this->inTransaction = false;
+        }
+
+        return true;
+    }
+
+    public function transactionSavepoint($savepoint)
+    {
+        $this->dbConn->query("SAVEPOINT $savepoint");
+    }
+
+    public function transactionDepth()
+    {
+        return (int)$this->inTransaction;
+    }
+
+    public function supportsSavepoints()
+    {
+        return true;
+    }
+}

--- a/src/ORM/Connect/MySQLiConnector.php
+++ b/src/ORM/Connect/MySQLiConnector.php
@@ -78,6 +78,18 @@ class MySQLiConnector extends DBConnector
 
         $this->dbConn = mysqli_init();
 
+        // Use native types (MysqlND only)
+        if (defined('MYSQLI_OPT_INT_AND_FLOAT_NATIVE')) {
+            $this->dbConn->options(MYSQLI_OPT_INT_AND_FLOAT_NATIVE, true);
+
+        // The alternative is not ideal, throw a notice-level error
+        } else {
+            user_error(
+                'mysqlnd PHP library is not available, numeric values will be fetched from the DB as strings',
+                E_USER_NOTICE
+            );
+        }
+
         // Set SSL parameters if they exist. All parameters are required.
         if (array_key_exists('ssl_key', $parameters) &&
             array_key_exists('ssl_cert', $parameters) &&

--- a/src/ORM/Connect/NestedTransactionManager.php
+++ b/src/ORM/Connect/NestedTransactionManager.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace SilverStripe\ORM\Connect;
+
+/**
+ * TransactionManager decorator that adds virtual nesting support.
+ * Because this is managed in PHP and not the database, it has the following limitations:
+ *   - Committing a nested transaction won't change anything until the parent transaction is committed
+ *   - Rolling back a nested transaction means that the parent transaction must be rolled backed
+ *
+ * DBAL describes this behaviour nicely in their docs: https://www.doctrine-project.org/projects/doctrine-dbal/en/2.8/reference/transactions.html#transaction-nesting
+ */
+
+class NestedTransactionManager implements TransactionManager
+{
+
+    /**
+     * @var int
+     */
+    protected $transactionNesting = 0;
+
+    /**
+     * @var TransactionManager
+     */
+    protected $child;
+
+    /**
+     * Set to true if all transactions must roll back to the parent
+     * @var boolean
+     */
+    protected $mustRollback = false;
+
+    /**
+     * Create a NestedTransactionManager
+     * @param TransactionManager $child The transaction manager that will handle the topmost transaction
+     */
+    public function __construct(TransactionManager $child)
+    {
+        $this->child = $child;
+    }
+
+    /**
+     * Start a transaction
+     * @throws DatabaseException on failure
+     * @return bool True on success
+     */
+    public function transactionStart($transactionMode = false, $sessionCharacteristics = false)
+    {
+        if ($this->transactionNesting <= 0) {
+            $this->transactionNesting = 1;
+            $this->child->transactionStart($transactionMode, $sessionCharacteristics);
+        } else {
+            if ($this->child->supportsSavepoints()) {
+                $this->child->transactionSavepoint("nesting" . $this->transactionNesting);
+            }
+            $this->transactionNesting++;
+        }
+    }
+
+    public function transactionEnd($chain = false)
+    {
+        if ($this->mustRollback) {
+            throw new DatabaseException("Child transaction was rolled back, so parent can't be committed");
+        }
+
+        if ($this->transactionNesting < 1) {
+            throw new DatabaseException("Not within a transaction, so can't commit");
+        }
+
+        $this->transactionNesting--;
+
+        if ($this->transactionNesting === 0) {
+            $this->child->transactionEnd();
+        }
+
+        if ($chain) {
+            return $this->transactionStart();
+        }
+    }
+
+    public function transactionRollback($savepoint = null)
+    {
+        if ($this->transactionNesting < 1) {
+            throw new DatabaseException("Not within a transaction, so can't roll back");
+        }
+
+        if ($savepoint) {
+            return $this->child->transactionRollback($savepoint);
+        }
+
+        $this->transactionNesting--;
+
+        if ($this->transactionNesting === 0) {
+            $this->child->transactionRollback();
+            $this->mustRollback = false;
+        } else {
+            if ($this->child->supportsSavepoints()) {
+                $this->child->transactionRollback("nesting" . $this->transactionNesting);
+                $this->mustRollback = false;
+
+            // Without savepoints, parent transactions must roll back if a child one has
+            } else {
+                $this->mustRollback = true;
+            }
+        }
+    }
+
+    /**
+     * Return the depth of the transaction.
+     *
+     * @return int
+     */
+    public function transactionDepth()
+    {
+        return $this->transactionNesting;
+    }
+
+    public function transactionSavepoint($savepoint)
+    {
+        return $this->child->transactionSavepoint($savepoint);
+    }
+
+    public function supportsSavepoints()
+    {
+        return $this->child->supportsSavepoints();
+    }
+}

--- a/src/ORM/Connect/PDOQuery.php
+++ b/src/ORM/Connect/PDOQuery.php
@@ -22,14 +22,52 @@ class PDOQuery extends Query
      * Hook the result-set given into a Query class, suitable for use by SilverStripe.
      * @param PDOStatement $statement The internal PDOStatement containing the results
      */
-    public function __construct(PDOStatement $statement)
+    public function __construct(PDOStatement $statement, PDOConnector $conn)
     {
         $this->statement = $statement;
         // Since no more than one PDOStatement for any one connection can be safely
         // traversed, each statement simply requests all rows at once for safety.
         // This could be re-engineered to call fetchAll on an as-needed basis
-        $this->results = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+        // Special case for Postgres
+        if ($conn->getDriver() == 'pgsql') {
+            $this->results = $this->fetchAllPgsql($statement);
+        } else {
+            $this->results = $statement->fetchAll(PDO::FETCH_ASSOC);
+        }
         $statement->closeCursor();
+    }
+
+    /**
+     * Fetch a record form the statement with its type data corrected
+     * Necessary to fix float data retrieved from PGSQL
+     * Returns data as an array of maps
+     * @return array
+     */
+    protected function fetchAllPgsql($statement)
+    {
+        $columnCount = $statement->columnCount();
+        $columnMeta = [];
+        for ($i = 0; $i<$columnCount; $i++) {
+            $columnMeta[$i] = $statement->getColumnMeta($i);
+        }
+
+        // Re-map fetched data using columnMeta
+        return array_map(
+            function ($rowArray) use ($columnMeta) {
+                $row = [];
+                foreach ($columnMeta as $i => $meta) {
+                    // Coerce floats from string to float
+                    // PDO PostgreSQL fails to do this
+                    if (isset($meta['native_type']) && strpos($meta['native_type'], 'float') === 0) {
+                        $rowArray[$i] = (float)$rowArray[$i];
+                    }
+                    $row[$meta['name']] = $rowArray[$i];
+                }
+                return $row;
+            },
+            $statement->fetchAll(PDO::FETCH_NUM)
+        );
     }
 
     public function seek($row)

--- a/src/ORM/Connect/Query.php
+++ b/src/ORM/Connect/Query.php
@@ -6,12 +6,24 @@ use SilverStripe\Core\Convert;
 use Iterator;
 
 /**
- * Abstract query-result class.
+ * Abstract query-result class. A query result provides an iterator that returns a map for each record of a query
+ * result.
+ *
+ * The map should be keyed by the column names, and the values should use the following types:
+ *
+ *  - boolean returned as integer 1 or 0 (to ensure consistency with MySQL that doesn't have native booleans)
+ *  - integer types returned as integers
+ *  - floating point / decimal types returned as floats
+ *  - strings returned as strings
+ *  - dates / datetimes returned as strings
+ *
+ * Note that until SilverStripe 4.3, bugs meant that strings were used for every column type.
+ *
  * Once again, this should be subclassed by an actual database implementation.  It will only
  * ever be constructed by a subclass of SS_Database.  The result of a database query - an iteratable object
  * that's returned by DB::SS_Query
  *
- * Primarily, the SS_Query class takes care of the iterator plumbing, letting the subclasses focusing
+ * Primarily, the Query class takes care of the iterator plumbing, letting the subclasses focusing
  * on providing the specific data-access methods that are required: {@link nextRecord()}, {@link numRecords()}
  * and {@link seek()}
  */

--- a/src/ORM/Connect/TransactionManager.php
+++ b/src/ORM/Connect/TransactionManager.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace SilverStripe\ORM\Connect;
+
+/**
+ * Represents an object that is capable of controlling transactions
+ */
+interface TransactionManager
+{
+    /**
+     * Start a prepared transaction
+     *
+     * @param string|boolean $transactionMode Transaction mode, or false to ignore. Deprecated and will be removed in SS5.
+     * @param string|boolean $sessionCharacteristics Session characteristics, or false to ignore. Deprecated and will be removed in SS5.
+     * @throws DatabaseException on failure
+     * @return bool True on success
+     */
+    public function transactionStart($transactionMode = false, $sessionCharacteristics = false);
+
+    /**
+     * Complete a transaction
+     *
+     * @throws DatabaseException on failure
+     * @return bool True on success
+     */
+    public function transactionEnd();
+
+    /**
+     * Roll-back a transaction
+     *
+     * @param string $savepoint If set, roll-back to the named savepoint
+     * @throws DatabaseException on failure
+     * @return bool True on success
+     */
+    public function transactionRollback($savepoint = null);
+
+    /**
+     * Create a new savepoint
+     *
+     * @param string $savepoint The savepoint name
+     * @throws DatabaseException on failure
+     */
+    public function transactionSavepoint($savepoint);
+
+    /**
+     * Return the depth of the transaction
+     * For unnested transactions returns 1 while in a transaction, 0 otherwise
+     *
+     * @return int
+     */
+    public function transactionDepth();
+
+    /**
+     * Return true if savepoints are supported by this transaction manager
+     *
+     * @return boolean
+     */
+    public function supportsSavepoints();
+}

--- a/src/ORM/Connect/TransactionManager.php
+++ b/src/ORM/Connect/TransactionManager.php
@@ -3,7 +3,13 @@
 namespace SilverStripe\ORM\Connect;
 
 /**
- * Represents an object that is capable of controlling transactions
+ * Represents an object that is capable of controlling transactions.
+ *
+ * The TransactionManager might be the database connection itself, calling queries to orchestrate
+ * transactions, or a connector such as the PDOConnector.
+ *
+ * Generally speaking you should rely on your Database object to manage the creation of a TansactionManager
+ * for you; unless you are building new database connectors this should be treated as an internal API.
  */
 interface TransactionManager
 {
@@ -51,7 +57,9 @@ interface TransactionManager
     public function transactionDepth();
 
     /**
-     * Return true if savepoints are supported by this transaction manager
+     * Return true if savepoints are supported by this transaction manager.
+     * Savepoints aren't supported by all database connectors (notably PDO doesn't support them)
+     * and should be used with caution.
      *
      * @return boolean
      */

--- a/tests/php/ORM/DatabaseTest.php
+++ b/tests/php/ORM/DatabaseTest.php
@@ -21,6 +21,11 @@ class DatabaseTest extends SapphireTest
 
     protected $usesDatabase = true;
 
+    /**
+     * Disable transactions so that we can test them
+     */
+    protected $usesTransactions = false;
+
     public function testDontRequireField()
     {
         $schema = DB::get_schema();

--- a/tests/php/ORM/DatabaseTest.php
+++ b/tests/php/ORM/DatabaseTest.php
@@ -231,4 +231,38 @@ class DatabaseTest extends SapphireTest
         $this->assertInstanceOf('Exception', $ex);
         $this->assertEquals('error', $ex->getMessage());
     }
+
+
+    public function testFieldTypes()
+    {
+        // Scaffold some data
+        $obj = new MyObject();
+        $obj->MyField = "value";
+        $obj->MyInt = 5;
+        $obj->MyFloat = 6.0;
+        $obj->MyBoolean = true;
+        $obj->write();
+
+        $record = DB::prepared_query(
+            'SELECT * FROM "DatabaseTest_MyObject" WHERE "ID" = ?',
+            [ $obj->ID ]
+        )->record();
+
+        // IDs and ints are returned as ints
+        $this->assertInternalType('int', $record['ID']);
+        $this->assertInternalType('int', $record['MyInt']);
+
+        $this->assertInternalType('float', $record['MyFloat']);
+
+        // Booleans are returned as ints – we follow MySQL's lead
+        $this->assertInternalType('int', $record['MyBoolean']);
+
+        // Strings and enums are returned as strings
+        $this->assertInternalType('string', $record['MyField']);
+        $this->assertInternalType('string', $record['ClassName']);
+
+        // Dates are returned as strings
+        $this->assertInternalType('string', $record['Created']);
+        $this->assertInternalType('string', $record['LastEdited']);
+    }
 }

--- a/tests/php/ORM/DatabaseTest.php
+++ b/tests/php/ORM/DatabaseTest.php
@@ -21,11 +21,6 @@ class DatabaseTest extends SapphireTest
 
     protected $usesDatabase = true;
 
-    /**
-     * Disable transactions so that we can test them
-     */
-    protected $usesTransactions = false;
-
     public function testDontRequireField()
     {
         $schema = DB::get_schema();
@@ -191,52 +186,6 @@ class DatabaseTest extends SapphireTest
         $db->releaseLock('DatabaseTest');
         $this->assertTrue($db->canLock('DatabaseTest'), 'Can lock again after releasing it');
     }
-
-    public function testTransactions()
-    {
-        $conn = DB::get_conn();
-        if (!$conn->supportsTransactions()) {
-            $this->markTestSkipped("DB Doesn't support transactions");
-            return;
-        }
-
-        // Test that successful transactions are comitted
-        $obj = new DatabaseTest\MyObject();
-        $failed = false;
-        $conn->withTransaction(
-            function () use (&$obj) {
-                $obj->MyField = 'Save 1';
-                $obj->write();
-            },
-            function () use (&$failed) {
-                $failed = true;
-            }
-        );
-        $this->assertEquals('Save 1', DatabaseTest\MyObject::get()->first()->MyField);
-        $this->assertFalse($failed);
-
-        // Test failed transactions are rolled back
-        $ex = null;
-        $failed = false;
-        try {
-            $conn->withTransaction(
-                function () use (&$obj) {
-                    $obj->MyField = 'Save 2';
-                    $obj->write();
-                    throw new Exception("error");
-                },
-                function () use (&$failed) {
-                    $failed = true;
-                }
-            );
-        } catch (Exception $ex) {
-        }
-        $this->assertTrue($failed);
-        $this->assertEquals('Save 1', DatabaseTest\MyObject::get()->first()->MyField);
-        $this->assertInstanceOf('Exception', $ex);
-        $this->assertEquals('error', $ex->getMessage());
-    }
-
 
     public function testFieldTypes()
     {

--- a/tests/php/ORM/DatabaseTest/MyObject.php
+++ b/tests/php/ORM/DatabaseTest/MyObject.php
@@ -13,6 +13,9 @@ class MyObject extends DataObject implements TestOnly
     private static $create_table_options = array(MySQLSchemaManager::ID => 'ENGINE=InnoDB');
 
     private static $db = array(
-        'MyField' => 'Varchar'
+        'MyField' => 'Varchar',
+        'MyInt' => 'Int',
+        'MyFloat' => 'Float',
+        'MyBoolean' => 'Boolean',
     );
 }

--- a/tests/php/ORM/TransactionTest.php
+++ b/tests/php/ORM/TransactionTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\ORM\Tests;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\Tests\TransactionTest\TestObject;
 
 class TransactionTest extends SapphireTest
@@ -17,6 +18,20 @@ class TransactionTest extends SapphireTest
         TransactionTest\TestObject::class,
     ];
 
+    private static $originalVersionInfo;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        self::$originalVersionInfo = Deprecation::dump_settings();
+    }
+
+    protected function tearDown()
+    {
+        Deprecation::restore_settings(self::$originalVersionInfo);
+        parent::tearDown();
+    }
+
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
@@ -25,8 +40,57 @@ class TransactionTest extends SapphireTest
         }
     }
 
+    public function testTransactions()
+    {
+        $conn = DB::get_conn();
+        if (!$conn->supportsTransactions()) {
+            $this->markTestSkipped("DB Doesn't support transactions");
+            return;
+        }
+
+        // Test that successful transactions are comitted
+        $obj = new TestObject();
+        $failed = false;
+        $conn->withTransaction(
+            function () use (&$obj) {
+                $obj->Title = 'Save 1';
+                $obj->write();
+            },
+            function () use (&$failed) {
+                $failed = true;
+            }
+        );
+        $this->assertEquals('Save 1', TestObject::get()->first()->Title);
+        $this->assertFalse($failed);
+
+        // Test failed transactions are rolled back
+        $ex = null;
+        $failed = false;
+        try {
+            $conn->withTransaction(
+                function () use (&$obj) {
+                    $obj->Title = 'Save 2';
+                    $obj->write();
+                    throw new \Exception("error");
+                },
+                function () use (&$failed) {
+                    $failed = true;
+                }
+            );
+        } catch (\Exception $ex) {
+        }
+        $this->assertTrue($failed);
+        $this->assertEquals('Save 1', TestObject::get()->first()->Title);
+        $this->assertInstanceOf('Exception', $ex);
+        $this->assertEquals('error', $ex->getMessage());
+    }
+
     public function testNestedTransaction()
     {
+        if (!DB::get_conn()->supportsSavepoints()) {
+            static::markTestSkipped('Current database does not support savepoints');
+        }
+
         $this->assertCount(0, TestObject::get());
         try {
             DB::get_conn()->withTransaction(function () {
@@ -88,5 +152,45 @@ class TransactionTest extends SapphireTest
         //These pages should NOT exist, we rolled back
         $this->assertFalse(is_object($third) && $third->exists());
         $this->assertFalse(is_object($fourth) && $fourth->exists());
+    }
+
+    public function testReadOnlyTransaction()
+    {
+        if (!DB::get_conn()->supportsTransactions()) {
+            $this->markTestSkipped('Current database is doesn\'t support transactions');
+            return;
+        }
+
+        // This feature is deprecated in 4.4, but we're still testing it.
+        Deprecation::notification_version('4.3.0');
+
+        $page = new TestObject();
+        $page->Title = 'Read only success';
+        $page->write();
+
+        DB::get_conn()->transactionStart('READ ONLY');
+
+        try {
+            $page = new TestObject();
+            $page->Title = 'Read only page failed';
+            $page->write();
+            DB::get_conn()->transactionEnd();
+        } catch (\Exception $e) {
+            //could not write this record
+            //We need to do a rollback or a commit otherwise we'll get error messages
+            DB::get_conn()->transactionRollback();
+        }
+
+        DataObject::flush_and_destroy_cache();
+
+        $success = DataObject::get_one(TestObject::class, "\"Title\"='Read only success'");
+        $fail = DataObject::get_one(TestObject::class, "\"Title\"='Read only page failed'");
+
+        //This page should be in the system
+        $this->assertInternalType('object', $success);
+        $this->assertTrue($success->exists());
+
+        //This page should NOT exist, we had 'read only' permissions
+        $this->assertNull($fail);
     }
 }


### PR DESCRIPTION
This ensures that numeric fields appear in PHP as int/float values
rather than strings, which allows the development of more type-safe PHP
code.

This doesn’t work on the legacy mysql driver and this will now throw
a notice-level error. It requires mysqlnd.

Fixes #7039, and other bugs such as #6709

Also requires https://github.com/silverstripe/silverstripe-postgresql/pull/91

Taken from https://github.com/open-sausages/silverstripe-framework/commit/f4e6aae411f2ffcfd52ff08e6bf66dbe4eeee464
