### PR TITLE
NEW Add memory cache to ThemeResourceLoader::findTemplate()

### DIFF
--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -15,20 +15,24 @@ SilverStripe\Core\Injector\Injector:
       namespace: "cacheblock"
       defaultLifetime: 600
   Psr\SimpleCache\CacheInterface.VersionProvider_composerlock:
-      factory: SilverStripe\Core\Cache\CacheFactory
-      constructor:
-        namespace: "VersionProvider_composerlock"
-        args:
-          disable-container: true
+    factory: SilverStripe\Core\Cache\CacheFactory
+    constructor:
+      namespace: "VersionProvider_composerlock"
+      args:
+        disable-container: true
   Psr\SimpleCache\CacheInterface.RateLimiter:
-      factory: SilverStripe\Core\Cache\CacheFactory
-      constructor:
-        namespace: 'ratelimiter'
-        args:
-          disable-container: true
+    factory: SilverStripe\Core\Cache\CacheFactory
+    constructor:
+      namespace: 'ratelimiter'
+      args:
+        disable-container: true
   Psr\SimpleCache\CacheInterface.InheritedPermissions:
     factory: SilverStripe\Core\Cache\CacheFactory
     constructor:
       namespace: "InheritedPermissions"
       args:
         disable-container: true
+  Psr\SimpleCache\CacheInterface.ThemeResourceLoader:
+    factory: SilverStripe\Core\Cache\CacheFactory
+    constructor:
+      namespace: 'ThemeResourceLoader'

--- a/src/ORM/Connect/MySQLSchemaManager.php
+++ b/src/ORM/Connect/MySQLSchemaManager.php
@@ -151,7 +151,7 @@ class MySQLSchemaManager extends DBSchemaManager
     public function renameTable($oldTableName, $newTableName)
     {
         if (!$this->hasTable($oldTableName)) {
-            throw new LogicException('Table '. $oldTableName . ' does not exist.');
+            throw new LogicException('Table ' . $oldTableName . ' does not exist.');
         }
 
         return $this->query("ALTER TABLE \"$oldTableName\" RENAME \"$newTableName\"");

--- a/src/View/ThemeResourceLoader.php
+++ b/src/View/ThemeResourceLoader.php
@@ -350,4 +350,12 @@ class ThemeResourceLoader
         }
         return $paths;
     }
+
+    /**
+     * Clear any internally cached data from memory
+     */
+    public static function flushCache()
+    {
+        static::$cacheData = [];
+    }
 }

--- a/src/View/ThemeResourceLoader.php
+++ b/src/View/ThemeResourceLoader.php
@@ -191,14 +191,14 @@ class ThemeResourceLoader implements Flushable
      */
     public function findTemplate($template, $themes = null)
     {
+        if ($themes === null) {
+            $themes = SSViewer::get_themes();
+        }
+
         // Look for a cached result for this data set
         $cacheKey = md5(json_encode($template) . json_encode($themes));
         if ($this->getCache()->has($cacheKey)) {
             return $this->getCache()->get($cacheKey);
-        }
-
-        if ($themes === null) {
-            $themes = SSViewer::get_themes();
         }
 
         $type = '';

--- a/tests/php/Core/Manifest/ThemeResourceLoaderTest.php
+++ b/tests/php/Core/Manifest/ThemeResourceLoaderTest.php
@@ -397,7 +397,7 @@ class ThemeResourceLoaderTest extends SapphireTest
     public function testFindTemplateWithCacheHit()
     {
         $mockCache = $this->createMock(CacheInterface::class);
-        $mockCache->expects($this->once())->method('has')->willReturn(true);;
+        $mockCache->expects($this->once())->method('has')->willReturn(true);
         $mockCache->expects($this->never())->method('set');
         $mockCache->expects($this->once())->method('get')->willReturn('mock_template.ss');
 

--- a/tests/php/Core/Manifest/ThemeResourceLoaderTest.php
+++ b/tests/php/Core/Manifest/ThemeResourceLoaderTest.php
@@ -54,6 +54,9 @@ class ThemeResourceLoaderTest extends SapphireTest
         // New Loader for that root
         $this->loader = new ThemeResourceLoader($this->base);
         $this->loader->addSet('$default', $this->manifest);
+
+        // Flush any cached values
+        ThemeResourceLoader::flushCache();
     }
 
     protected function tearDown()

--- a/tests/php/Core/Manifest/ThemeResourceLoaderTest.php
+++ b/tests/php/Core/Manifest/ThemeResourceLoaderTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Core\Tests\Manifest;
 
+use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\View\ThemeResourceLoader;
@@ -55,8 +56,8 @@ class ThemeResourceLoaderTest extends SapphireTest
         $this->loader = new ThemeResourceLoader($this->base);
         $this->loader->addSet('$default', $this->manifest);
 
-        // Flush any cached values
-        ThemeResourceLoader::flushCache();
+        // Ensure the cache is flushed between tests
+        ThemeResourceLoader::flush();
     }
 
     protected function tearDown()
@@ -379,5 +380,29 @@ class ThemeResourceLoaderTest extends SapphireTest
     public function testGetPath($name, $path)
     {
         $this->assertEquals($path, $this->loader->getPath($name));
+    }
+
+    public function testFindTemplateWithCacheMiss()
+    {
+        $mockCache = $this->createMock(CacheInterface::class);
+        $mockCache->expects($this->once())->method('has')->willReturn(false);
+        $mockCache->expects($this->never())->method('get');
+        $mockCache->expects($this->once())->method('set');
+
+        $loader = new ThemeResourceLoader();
+        $loader->setCache($mockCache);
+        $loader->findTemplate('Page', ['$default']);
+    }
+
+    public function testFindTemplateWithCacheHit()
+    {
+        $mockCache = $this->createMock(CacheInterface::class);
+        $mockCache->expects($this->once())->method('has')->willReturn(true);;
+        $mockCache->expects($this->never())->method('set');
+        $mockCache->expects($this->once())->method('get')->willReturn('mock_template.ss');
+
+        $loader = new ThemeResourceLoader();
+        $loader->setCache($mockCache);
+        $this->assertSame('mock_template.ss', $loader->findTemplate('Page', ['$default']));
     }
 }


### PR DESCRIPTION
For large sites, this reduces the number of file_exists, Path::join, getThemePaths etc calls and can contribute to 26% reduction in TTFB load time

For example, a comparison from Blackfire showing a large site's reduction in time for a 0.1% gain in memory use:

![image](https://user-images.githubusercontent.com/5170590/46485302-b740dc00-c7fb-11e8-9746-1ef6a215a985.png)
