### PR TITLE
FIX: Update “original” DataObject data to be the content of the last write

### DIFF
--- a/src/ORM/FieldType/DBComposite.php
+++ b/src/ORM/FieldType/DBComposite.php
@@ -37,6 +37,12 @@ abstract class DBComposite extends DBField
     private static $composite_db = array();
 
     /**
+     * Marker as to whether this record has changed
+     * Only used when deference to the parent object isn't possible
+     */
+    protected $isChanged = false;
+
+    /**
      * Either the parent dataobject link, or a record of saved values for each field
      *
      * @var array|DataObject
@@ -113,6 +119,10 @@ abstract class DBComposite extends DBField
     }
 
 
+    /**
+     * Returns true if this composite field has changed.
+     * For fields bound to a DataObject, this will be cleared when the DataObject is written.
+     */
     public function isChanged()
     {
         // When unbound, use the local changed flag

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -802,17 +802,30 @@ class DataObjectTest extends SapphireTest
         $this->assertFalse($obj->isChanged('FirstName'));
         $this->assertFalse($obj->isChanged('Surname'));
 
+        // Force change marks the records as changed
         $obj->forceChange();
         $this->assertTrue($obj->isChanged('FirstName'));
         $this->assertTrue($obj->isChanged('Surname'));
 
+        // ...but not if we explicitly ask if the value has changed
         $this->assertFalse($obj->isChanged('FirstName', DataObject::CHANGE_VALUE));
         $this->assertFalse($obj->isChanged('Surname', DataObject::CHANGE_VALUE));
 
+        // Not overwritten by setting the value to is original value
         $obj->FirstName = 'Captain';
         $this->assertTrue($obj->isChanged('FirstName'));
         $this->assertTrue($obj->isChanged('Surname'));
 
+        // Not overwritten by changing it to something else and back again
+        $obj->FirstName = 'Captain-changed';
+        $this->assertTrue($obj->isChanged('FirstName', DataObject::CHANGE_VALUE));
+
+        $obj->FirstName = 'Captain';
+        $this->assertFalse($obj->isChanged('FirstName', DataObject::CHANGE_VALUE));
+        $this->assertTrue($obj->isChanged('FirstName'));
+        $this->assertTrue($obj->isChanged('Surname'));
+
+        // Cleared after write
         $obj->write();
         $this->assertFalse($obj->isChanged('FirstName'));
         $this->assertFalse($obj->isChanged('Surname'));

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -765,6 +765,62 @@ class DataObjectTest extends SapphireTest
         );
     }
 
+    public function testChangedFieldsWhenRestoringData()
+    {
+        $obj = $this->objFromFixture(DataObjectTest\Player::class, 'captain1');
+        $obj->FirstName = 'Captain-changed';
+        $obj->FirstName = 'Captain';
+
+        $this->assertEquals(
+            [],
+            $obj->getChangedFields(true, DataObject::CHANGE_STRICT)
+        );
+    }
+
+    public function testChangedFieldsAfterWrite()
+    {
+        $obj = $this->objFromFixture(DataObjectTest\Player::class, 'captain1');
+        $obj->FirstName = 'Captain-changed';
+        $obj->write();
+        $obj->FirstName = 'Captain';
+
+        $this->assertEquals(
+            array(
+                'FirstName' => array(
+                    'before' => 'Captain-changed',
+                    'after' => 'Captain',
+                    'level' => DataObject::CHANGE_VALUE,
+                ),
+            ),
+            $obj->getChangedFields(true, DataObject::CHANGE_VALUE)
+        );
+    }
+
+    public function testForceChangeCantBeCancelledUntilWrite()
+    {
+        $obj = $this->objFromFixture(DataObjectTest\Player::class, 'captain1');
+        $this->assertFalse($obj->isChanged('FirstName'));
+        $this->assertFalse($obj->isChanged('Surname'));
+
+        $obj->forceChange();
+        $this->assertTrue($obj->isChanged('FirstName'));
+        $this->assertTrue($obj->isChanged('Surname'));
+
+        $this->assertFalse($obj->isChanged('FirstName', DataObject::CHANGE_VALUE));
+        $this->assertFalse($obj->isChanged('Surname', DataObject::CHANGE_VALUE));
+
+        $obj->FirstName = 'Captain';
+        $this->assertTrue($obj->isChanged('FirstName'));
+        $this->assertTrue($obj->isChanged('Surname'));
+
+        $obj->write();
+        $this->assertFalse($obj->isChanged('FirstName'));
+        $this->assertFalse($obj->isChanged('Surname'));
+
+        $obj->FirstName = 'Captain';
+        $this->assertFalse($obj->isChanged('FirstName'));
+    }
+
     /**
      * @skipUpgrade
      */

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -655,10 +655,14 @@ class MemberTest extends FunctionalTest
         $member = $this->objFromFixture(Member::class, 'test');
         $member->setName('Test Some User');
         $this->assertEquals('Test Some User', $member->getName());
+        $this->assertEquals('Test Some', $member->FirstName);
+        $this->assertEquals('User', $member->Surname);
         $member->setName('Test');
         $this->assertEquals('Test', $member->getName());
         $member->FirstName = 'Test';
         $member->Surname = '';
+        $this->assertEquals('Test', $member->FirstName);
+        $this->assertEquals('', $member->Surname);
         $this->assertEquals('Test', $member->getName());
     }
 


### PR DESCRIPTION
FIX: Compare to original when determining fields changes

This fixes a number of edge-case issues relating to change detection.

Fixes #8443
Fixes #3821
Fixes #4561