### PR TITLE
NEW Adding a helper to find a form field by label content (Behat)

### DIFF
--- a/tests/behat/src/CmsFormsContext.php
+++ b/tests/behat/src/CmsFormsContext.php
@@ -310,9 +310,36 @@ JS;
     {
         $locator = $this->fixStepArgument($locator);
         $page = $this->getSession()->getPage();
+        
+        // Searching by name is usually good...
         $element = $page->find('css', 'textarea.htmleditor[name=\'' . $locator . '\']');
+        
+        if ($element === null) {
+            $element = $this->findInputByLabelContent($locator);
+        }
+        
         assertNotNull($element, sprintf('HTML field "%s" not found', $locator));
         return $element;
+    }
+
+    protected function findInputByLabelContent($locator)
+    {
+        $page = $this->getSession()->getPage();
+        $label = $page->findAll('xpath', sprintf('//label[contains(text(), \'%s\')]', $locator));
+
+        if (empty($label)) {
+            return null;
+        }
+
+        assertCount(1, $label, sprintf(
+            'Found more than one element containing the phrase "%s".',
+            $locator
+        ));
+
+        $label = array_shift($label);
+
+        $fieldId = $label->getAttribute('for');
+        return $page->find('css', '#' . $fieldId);
     }
 
     /**


### PR DESCRIPTION
This allows step authors to use `$this->findInputByLabelContent("Label")` to find the related input. It searches for the label and uses the `for` attribute to find an ID selector for the field.

Additionally I've added this to the `getHtmlField` method for a fallback if the field was not found using the "name" of the field - this can be quite specfic when there are nested forms.