### PR TITLE
NEW Add method to flush extra_methods static cache data and implement into test state

### DIFF
--- a/src/Core/Extensible.php
+++ b/src/Core/Extensible.php
@@ -3,12 +3,9 @@
 namespace SilverStripe\Core;
 
 use InvalidArgumentException;
-use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\Deprecation;
-use SilverStripe\ORM\DataExtension;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\View\ViewableData;
 
 /**
@@ -212,6 +209,14 @@ trait Extensible
 
         Injector::inst()->unregisterNamedObject($class);
         return true;
+    }
+
+    /**
+     * Clears all cached extra_methods cache data
+     */
+    public static function flush_extra_methods_cache()
+    {
+        self::$extra_methods = [];
     }
 
 

--- a/src/Dev/State/ExtensionTestState.php
+++ b/src/Dev/State/ExtensionTestState.php
@@ -14,16 +14,6 @@ use SilverStripe\ORM\DataObject;
 class ExtensionTestState implements TestState
 {
     /**
-     * @var array
-     */
-    protected $extensionsToReapply = [];
-
-    /**
-     * @var array
-     */
-    protected $extensionsToRemove = [];
-
-    /**
      * Called on setup
      *
      * @param SapphireTest $test
@@ -41,8 +31,6 @@ class ExtensionTestState implements TestState
     {
         // May be altered by another class
         $isAltered = false;
-        $this->extensionsToReapply = [];
-        $this->extensionsToRemove = [];
 
         /** @var string|SapphireTest $class */
         /** @var string|DataObject $dataClass */
@@ -58,10 +46,6 @@ class ExtensionTestState implements TestState
                 if (!class_exists($extension) || !$dataClass::has_extension($extension)) {
                     continue;
                 }
-                if (!isset($this->extensionsToReapply[$dataClass])) {
-                    $this->extensionsToReapply[$dataClass] = [];
-                }
-                $this->extensionsToReapply[$dataClass][] = $extension;
                 $dataClass::remove_extension($extension);
                 $isAltered = true;
             }
@@ -78,10 +62,6 @@ class ExtensionTestState implements TestState
                     throw new LogicException("Test {$class} requires extension {$extension} which doesn't exist");
                 }
                 if (!$dataClass::has_extension($extension)) {
-                    if (!isset($this->extensionsToRemove[$dataClass])) {
-                        $this->extensionsToRemove[$dataClass] = [];
-                    }
-                    $this->extensionsToRemove[$dataClass][] = $extension;
                     $dataClass::add_extension($extension);
                     $isAltered = true;
                 }

--- a/src/Dev/State/ExtensionTestState.php
+++ b/src/Dev/State/ExtensionTestState.php
@@ -30,6 +30,7 @@ class ExtensionTestState implements TestState
      */
     public function setUp(SapphireTest $test)
     {
+        DataObject::flush_extra_methods_cache();
     }
 
     public function tearDown(SapphireTest $test)
@@ -104,23 +105,5 @@ class ExtensionTestState implements TestState
 
     public function tearDownOnce($class)
     {
-        // @todo: This isn't strictly necessary to restore extensions, but only to ensure that
-        // Object::$extra_methods is properly flushed. This should be replaced with a simple
-        // flush mechanism for each $class.
-        /** @var string|DataObject $dataClass */
-
-        // Remove extensions added for testing
-        foreach ($this->extensionsToRemove as $dataClass => $extensions) {
-            foreach ($extensions as $extension) {
-                $dataClass::remove_extension($extension);
-            }
-        }
-
-        // Reapply ones removed
-        foreach ($this->extensionsToReapply as $dataClass => $extensions) {
-            foreach ($extensions as $extension) {
-                $dataClass::add_extension($extension);
-            }
-        }
     }
 }

--- a/tests/php/Core/Injector/InjectorTest.php
+++ b/tests/php/Core/Injector/InjectorTest.php
@@ -21,12 +21,13 @@ use SilverStripe\Core\Tests\Injector\InjectorTest\NeedsBothCirculars;
 use SilverStripe\Core\Tests\Injector\InjectorTest\NewRequirementsBackend;
 use SilverStripe\Core\Tests\Injector\InjectorTest\OriginalRequirementsBackend;
 use SilverStripe\Core\Tests\Injector\InjectorTest\OtherTestObject;
+use SilverStripe\Core\Tests\Injector\InjectorTest\SomeCustomisedExtension;
+use SilverStripe\Core\Tests\Injector\InjectorTest\SomeExtension;
 use SilverStripe\Core\Tests\Injector\InjectorTest\TestObject;
 use SilverStripe\Core\Tests\Injector\InjectorTest\TestSetterInjections;
 use SilverStripe\Core\Tests\Injector\InjectorTest\TestStaticInjections;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Dev\TestOnly;
-use stdClass;
+use SilverStripe\Security\Member;
 
 define('TEST_SERVICES', __DIR__ . '/AopProxyServiceTest');
 
@@ -1046,5 +1047,24 @@ class InjectorTest extends SapphireTest
         // Return to nestingLevel 0
         Injector::unnest();
         $this->nestingLevel--;
+    }
+
+    /**
+     * Tests that overloaded extensions work, see {@link Extensible::getExtensionInstance()}
+     */
+    public function testExtendedExtensions()
+    {
+        Config::modify()
+            ->set(Injector::class, SomeExtension::class, [
+                'class' => SomeCustomisedExtension::class,
+            ])
+            ->merge(Member::class, 'extensions', [
+                SomeExtension::class,
+            ]);
+
+        /** @var Member|SomeExtension $member */
+        $member = new Member();
+        $this->assertTrue($member->hasExtension(SomeExtension::class));
+        $this->assertSame('bar', $member->someMethod());
     }
 }

--- a/tests/php/Core/Injector/InjectorTest.php
+++ b/tests/php/Core/Injector/InjectorTest.php
@@ -1065,6 +1065,7 @@ class InjectorTest extends SapphireTest
         /** @var Member|SomeExtension $member */
         $member = new Member();
         $this->assertTrue($member->hasExtension(SomeExtension::class));
+        $this->assertTrue($member->hasMethod('someMethod'));
         $this->assertSame('bar', $member->someMethod());
     }
 }

--- a/tests/php/Core/Injector/InjectorTest/SomeCustomisedExtension.php
+++ b/tests/php/Core/Injector/InjectorTest/SomeCustomisedExtension.php
@@ -2,7 +2,9 @@
 
 namespace SilverStripe\Core\Tests\Injector\InjectorTest;
 
-class SomeCustomisedExtension extends SomeExtension
+use SilverStripe\Dev\TestOnly;
+
+class SomeCustomisedExtension extends SomeExtension implements TestOnly
 {
     public function someMethod()
     {

--- a/tests/php/Core/Injector/InjectorTest/SomeCustomisedExtension.php
+++ b/tests/php/Core/Injector/InjectorTest/SomeCustomisedExtension.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Injector\InjectorTest;
+
+class SomeCustomisedExtension extends SomeExtension
+{
+    public function someMethod()
+    {
+        return 'bar';
+    }
+}

--- a/tests/php/Core/Injector/InjectorTest/SomeExtension.php
+++ b/tests/php/Core/Injector/InjectorTest/SomeExtension.php
@@ -2,9 +2,10 @@
 
 namespace SilverStripe\Core\Tests\Injector\InjectorTest;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataExtension;
 
-class SomeExtension extends DataExtension
+class SomeExtension extends DataExtension implements TestOnly
 {
     public function someMethod()
     {

--- a/tests/php/Core/Injector/InjectorTest/SomeExtension.php
+++ b/tests/php/Core/Injector/InjectorTest/SomeExtension.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Injector\InjectorTest;
+
+use SilverStripe\ORM\DataExtension;
+
+class SomeExtension extends DataExtension
+{
+    public function someMethod()
+    {
+        return 'foo';
+    }
+}


### PR DESCRIPTION
This replaces a todo comment to do the same, and means that dynamically added extensions via config in individual test cases will work. The first commit has a test that proves this bug.