### PR TITLE
FIX Persist TinyMCE updates when writing with Behat

### DIFF
--- a/tests/behat/src/CmsFormsContext.php
+++ b/tests/behat/src/CmsFormsContext.php
@@ -75,6 +75,10 @@ class CmsFormsContext implements Context
             $inputField->getAttribute('id'),
             addcslashes($value, "'")
         ));
+        $this->getSession()->evaluateScript(sprintf(
+            "jQuery('#%s').entwine('ss').getEditor().save()",
+            $inputField->getAttribute('id')
+        ));
     }
 
     /**


### PR DESCRIPTION
Fixes an issue when you set content of a TinyMCE field and then assert the value of that TinyMCE field is updated. The textarea behind TinyMCE is not updated.

For context, we're working with a test case where the editor is hidden (within React) and we're asserting the content is still there when re-expanded. Currently this is done by hiding the dom element but could change in the future to destroy and remount the dom element.