### PR TITLE
allow dataobject get_one without passing a class

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3090,8 +3090,11 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return DataObject|null The first item matching the query
      */
-    public static function get_one($callerClass, $filter = "", $cache = true, $orderby = "")
+    public static function get_one($callerClass = null, $filter = "", $cache = true, $orderby = "")
     {
+        if ($callerClass === null) {
+            $callerClass = static::class;
+        }
         $SNG = singleton($callerClass);
 
         $cacheComponents = array($filter, $orderby, $SNG->extend('cacheKeyComponent'));

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -322,6 +322,9 @@ class DataObjectTest extends SapphireTest
         $this->assertEquals('Bob', $comment->Name);
         $comment = DataObject::get_one(DataObjectTest\TeamComment::class, '', true, '"Name" DESC');
         $this->assertEquals('Phil', $comment->Name);
+
+        // Test get_one() without passing classname
+        $this->assertEquals(DataObjectTest\TeamComment::get_one(), DataObject::get_one(DataObjectTest\TeamComment::class));
     }
 
     public function testGetByIDCallerClass()


### PR DESCRIPTION
Allows you to call `MyObject::get_one()` instead of `DataObject::get_one(MyObject::class)` - which is a bit weird