### PR TITLE
BUG: Fix `ENTER` not triggering form save button as `GridField`s used `submit` type buttons

### DIFF
--- a/src/Forms/GridField/GridField_FormAction.php
+++ b/src/Forms/GridField/GridField_FormAction.php
@@ -101,6 +101,7 @@ class GridField_FormAction extends FormAction
                 // will strip it from the requests
                 'name' => 'action_gridFieldAlterAction' . '?' . http_build_query($actionData),
                 'data-url' => $this->gridField->Link(),
+                'type' => "button",
             )
         );
     }


### PR DESCRIPTION
FormActions use the `submit` type by default which means that they take priority when used in a form and pressing `enter`. This is unexpected as you would expect this to save the form, but instead it triggers the search of a gridfield in the `Link Tracking` tab which isn't even focused.