### PR TITLE
FIX: Fix occasional error in SQLite3 PDO usage, Add SQLite + MariaDB builds, ensure PDO builds for all, clarify database versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,37 +16,50 @@ env:
   global:
     - COMPOSER_ROOT_VERSION=4.4.x-dev
 
+# Note that the "DBV" variable below doesnt do anything other than improve travis display
 matrix:
   fast_finish: true
   include:
     - php: 5.6
       env:
         - DB=SQLITE
+        - DBV=3.8
         - PHPCS_TEST=1
         - PHPUNIT_TEST=framework
     - php: 7.0
       env:
         - DB=MYSQL
+        - DBV=5.7
         - PHPUNIT_TEST=framework
+      dist: xenial
+      services:
+        - mysql
     - php: 7.1
       env:
         - DB=PGSQL
+        - DBV=9.2
         - PHPUNIT_TEST=framework
     - php: 7.2
       env:
         - DB=SQLITE
+        - DBV=3.11
         - PDO=1
         - PHPUNIT_TEST=framework
+      dist: xenial
     - php: 7.3
       env:
         - DB=MYSQL
+        - DBV=5.6
         - PDO=1
         - PHPUNIT_TEST=framework
     - php: 7.2
       env:
         - DB=PGSQL
+        - DBV=9.4
         - PDO=1
         - PHPUNIT_TEST=framework
+      addons:
+        postgresql: "9.4"
 
     - php: 7.1
       if: type IN (cron)
@@ -57,6 +70,7 @@ matrix:
     - php: 7.2
       env:
         - DB=MYSQL
+
         - PHPUNIT_TEST=cms
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,14 @@ matrix:
       dist: xenial
       services:
         - mysql
+    - php: 7.2
+      env:
+        - DB=MARIADB
+        - DBV=10.0
+        - PHPUNIT_TEST=framework
+      addons:
+        mariadb: "10.0"
+      addions:
     - php: 7.1
       env:
         - DB=PGSQL
@@ -52,6 +60,14 @@ matrix:
         - DBV=5.6
         - PDO=1
         - PHPUNIT_TEST=framework
+    - php: 7.3
+      env:
+        - DB=MARIADB
+        - DBV=10.3
+        - PDO=1
+        - PHPUNIT_TEST=framework
+      addons:
+        mariadb: "10.3"
     - php: 7.2
       env:
         - DB=PGSQL

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,9 +75,9 @@ before_script:
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.2.x-dev --no-update; fi
   - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.x-dev --no-update; fi
   - composer require silverstripe/recipe-testing:^1 silverstripe/recipe-core:4.4.x-dev silverstripe/admin:1.4.x-dev silverstripe/versioned:1.4.x-dev --no-update
-  - if [[ $PHPUNIT_TEST == cms ]]; then composer require silverstripe/recipe-cms:4.4.x-dev --no-update; fi
-  - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
-  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+  - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest --no-update -o; fi
+  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+  - if [[ $PHPUNIT_TEST == cms ]]; then composer require --prefer-source silverstripe/recipe-cms:4.4.x-dev; fi
 
 # Log constants to CI for debugging purposes
   - php ./tests/dump_constants.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+
 language: php
 
 dist: trusty
@@ -20,11 +21,28 @@ matrix:
   include:
     - php: 5.6
       env:
-        - DB=PGSQL
+        - DB=SQLITE
         - PHPCS_TEST=1
         - PHPUNIT_TEST=framework
-
     - php: 7.0
+      env:
+        - DB=MYSQL
+        - PHPUNIT_TEST=framework
+    - php: 7.1
+      env:
+        - DB=PGSQL
+        - PHPUNIT_TEST=framework
+    - php: 7.2
+      env:
+        - DB=SQLITE
+        - PDO=1
+        - PHPUNIT_TEST=framework
+    - php: 7.3
+      env:
+        - DB=MYSQL
+        - PDO=1
+        - PHPUNIT_TEST=framework
+    - php: 7.2
       env:
         - DB=PGSQL
         - PDO=1
@@ -39,26 +57,7 @@ matrix:
     - php: 7.2
       env:
         - DB=MYSQL
-        - PDO=1
-        - PHPUNIT_TEST=framework
-
-    - php: 7.0
-      env:
-        - DB=MYSQL
         - PHPUNIT_TEST=cms
-
-    - php: 7.3.0RC1
-      env:
-        - DB=MYSQL
-        - PHPUNIT_TEST=framework
-      sudo: required
-      dist: xenial
-      addons:
-        apt:
-          packages:
-            - libzip4
-      services:
-       - mysql
 
 before_script:
 # Extra $PATH
@@ -74,7 +73,7 @@ before_script:
   - composer validate
   - mkdir ./public
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.2.x-dev --no-update; fi
-  - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --no-update; fi
+  - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.x-dev --no-update; fi
   - composer require silverstripe/recipe-testing:^1 silverstripe/recipe-core:4.4.x-dev silverstripe/admin:1.4.x-dev silverstripe/versioned:1.4.x-dev --no-update
   - if [[ $PHPUNIT_TEST == cms ]]; then composer require silverstripe/recipe-cms:4.4.x-dev --no-update; fi
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi

--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -310,7 +310,8 @@ class Session
                 }
 
             // If headers are sent then we can't have a session_cache_limiter otherwise we'll get a warning
-            } else {
+            // This behaviour flipped in PHP 7.2
+            } elseif (version_compare(phpversion(), '7.2.0', '<')) {
                 session_cache_limiter(null);
             }
 

--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -652,6 +652,10 @@ abstract class Database
      * See http://developer.postgresql.org/pgdocs/postgres/sql-set-transaction.html for details on
      * transaction isolation options
      *
+     * Note that transactionMode does not work in MySQL <= 5.5 or SQLite. Both transancationMode
+     * and sessionCharacteristics are deprecated and neither of these features are included in the
+     * core unit suite. We recommend that you avoid their use.
+     *
      * @param string|boolean $transactionMode Transaction mode, or false to ignore
      * @param string|boolean $sessionCharacteristics Session characteristics, or false to ignore
      */

--- a/src/ORM/Connect/PDOConnector.php
+++ b/src/ORM/Connect/PDOConnector.php
@@ -401,7 +401,7 @@ class PDOConnector extends DBConnector implements TransactionManager
         // Bind and invoke statement safely
         if ($statement) {
             $this->bindParameters($statement, $parameters);
-            $statement->execute($parameters);
+            $statement->execute();
         }
 
         // Generate results

--- a/tests/php/Control/SessionTest.php
+++ b/tests/php/Control/SessionTest.php
@@ -13,6 +13,7 @@ use SilverStripe\Control\HTTPRequest;
  */
 class SessionTest extends SapphireTest
 {
+
     /**
      * @var Session
      */
@@ -24,10 +25,6 @@ class SessionTest extends SapphireTest
         return parent::setUp();
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testInitDoesNotStartSessionWithoutIdentifier()
     {
         $req = new HTTPRequest('GET', '/');
@@ -36,10 +33,6 @@ class SessionTest extends SapphireTest
         $this->assertFalse($session->isStarted());
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testInitStartsSessionWithIdentifier()
     {
         $req = new HTTPRequest('GET', '/');
@@ -49,10 +42,6 @@ class SessionTest extends SapphireTest
         $this->assertTrue($session->isStarted());
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testInitStartsSessionWithData()
     {
         $req = new HTTPRequest('GET', '/');
@@ -61,10 +50,6 @@ class SessionTest extends SapphireTest
         $this->assertTrue($session->isStarted());
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testStartUsesDefaultCookieNameWithHttp()
     {
         $req = (new HTTPRequest('GET', '/'))
@@ -75,10 +60,6 @@ class SessionTest extends SapphireTest
         $this->assertNotEquals(session_name(), $session->config()->get('cookie_name_secure'));
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testStartUsesDefaultCookieNameWithHttpsAndCookieSecureOff()
     {
         $req = (new HTTPRequest('GET', '/'))
@@ -105,8 +86,6 @@ class SessionTest extends SapphireTest
     }
 
     /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
      * @expectedException BadMethodCallException
      * @expectedExceptionMessage Session has already started
      */
@@ -118,10 +97,6 @@ class SessionTest extends SapphireTest
         $session->start($req);
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testStartRetainsInMemoryData()
     {
         $this->markTestIncomplete('Test');

--- a/tests/php/Security/MemberAuthenticator/SessionAuthenticationHandlerTest.php
+++ b/tests/php/Security/MemberAuthenticator/SessionAuthenticationHandlerTest.php
@@ -13,10 +13,6 @@ class SessionAuthenticationHandlerTest extends SapphireTest
 {
     protected $usesDatabase = true;
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testAuthenticateRequestDefersSessionStartWithoutSessionIdentifier()
     {
         $member = new Member(['Email' => 'test@example.com']);
@@ -34,10 +30,6 @@ class SessionAuthenticationHandlerTest extends SapphireTest
         $this->assertNull($matchedMember);
     }
 
-    /**
-     * @runInSeparateProcess
-     * @preserveGlobalState disabled
-     */
     public function testAuthenticateRequestStartsSessionWithSessionIdentifier()
     {
         $member = new Member(['Email' => 'test@example.com']);
@@ -51,7 +43,10 @@ class SessionAuthenticationHandlerTest extends SapphireTest
         $req = new HTTPRequest('GET', '/');
         $req->setSession($session);
 
+        // Set up global state
         Cookie::set(session_name(), '1234');
+        $_COOKIE[session_name()] = '1234';
+
         $session->start($req); // simulate detection of session cookie
 
         $matchedMember = $handler->authenticateRequest($req);


### PR DESCRIPTION
This PR pulls together a few interrelated changes to the databases we support and the built matrix necessary to cover them:

 * It fixes a couple of final things blocking SQLite from working nicely.
 * The build matrix now covers
   * MySQL (5.6 and 5.7), MariaDB (10.0 and 10.3), PostgreSQL (9.2 and 9.4), and SQLite (3.8 and 3.11)
   * PDO and non for each database
   * 2 specific database versions for each database (as listed above)

The built matrix is bigger but a couple of the builds are a bit faster. The total build time goes from about 50m to about 1h20. However, the wall-clock time is similar at about 15m - 20m.