### PR TITLE
Add entry to change log about CMSPageHistoryController deprecation.

### DIFF
--- a/docs/en/04_Changelogs/4.3.0.md
+++ b/docs/en/04_Changelogs/4.3.0.md
@@ -7,6 +7,7 @@
  - Take care with `stageChildren()` overrides. `Hierarchy::numChildren() ` results will only make use of `stageChildren()` customisations that are applied to the base class and don't include record-specific behaviour.
  - New React-based search UI for the CMS, Asset-Admin, GridFields and ModelAdmins.
  - A new `GridFieldLazyLoader` component can be added to `GridField`. This will delay the fetching of data until the user access the container Tab of the GridField.
+ - `SilverStripe\VersionedAdmin\Controllers\CMSPageHistoryViewerController` is now the default CMS history controller and `SilverStripe\CMS\Controllers\CMSPageHistoryController` has been deprecated.
 
 ## Upgrading {#upgrading}
 
@@ -38,6 +39,50 @@ public function getCMSFields()
     $fields->addFieldToTab('Root.Company', $grid);
     
     return $fields;
+}
+
+```
+
+### Keep using the legacy `CMSPageHistoryController`
+
+To keep using the old CMS history controller for every page type, add the following entry to your your YML config.
+
+```yml
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\CMS\Controllers\CMSPageHistoryController:
+    class: SilverStripe\CMS\Controllers\CMSPageHistoryController
+```
+
+Alternatively, you can use `HistoryControllerFactory` to switch between both controllers.
+
+```yml
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\CMS\Controllers\CMSPageHistoryController:
+    factory:
+      SilverStripe\VersionedAdmin\Controllers\HistoryControllerFactory
+      
+SilverStripe\VersionedAdmin\Controllers\HistoryControllerFactory:
+  extensions:
+    - HistoryControllerFactoryExtension
+```
+
+```php
+<?php
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Core\Extension;
+
+class HistoryControllerFactoryExtension extends Extension
+{
+    /**
+     * If this method returns false, the legacy history controller will be used. 
+     * @param SiteTree|null $page
+     * @return bool
+     */
+    public function updateIsEnabled(SiteTree $page = null)
+    {
+        return false;
+    }
 }
 
 ```


### PR DESCRIPTION
Fix https://github.com/silverstripe/silverstripe-versioned-admin/issues/67 and https://github.com/silverstripe/silverstripe-cms/issues/2277