### PR TITLE
BUGFIX MySQLi has collation conflict issues when using COALESCE()

### DIFF
--- a/src/ORM/Connect/MySQLiConnector.php
+++ b/src/ORM/Connect/MySQLiConnector.php
@@ -121,6 +121,13 @@ class MySQLiConnector extends DBConnector
         if (!empty($collation)) {
             $this->dbConn->query("SET collation_connection = {$collation}");
         }
+
+        // We need to do this otherwise the client character set doesn't get applied correctly since we may be
+        // using a different collation to the default.
+        // @see http://php.net/manual/en/mysqli.set-charset.php#121647
+        if (!empty($collation) && !empty($charset)) {
+            $this->dbConn->query("SET NAMES {$charset} COLLATE {$collation}");
+        }
     }
 
     public function __destruct()


### PR DESCRIPTION
To Reproduce:
- Install fluent https://github.com/tractorcow-farm/silverstripe-fluent
- Ensure SS_DATABASE_CLASS is not set or set to "MySQLDatabase"
- Login to the CMS
- Go to pages
- Search, entering a date range for LastEdited

Expected:
- Shows pages last edited within the given date range

Actual:
- MySQL Error "Illegal mix of collations (utf8mb4_unicode_ci,COERCIBLE) and (utf8mb4_general_ci,COERCIBLE) for operation '>='"

This is a problem with the MySQLi connector not setting the character set correctly between the client/database: http://php.net/manual/en/mysqli.set-charset.php#121647