### PR TITLE
BUGFIX many many through not sorting by join table

### DIFF
--- a/docs/en/02_Developer_Guides/00_Model/02_Relations.md
+++ b/docs/en/02_Developer_Guides/00_Model/02_Relations.md
@@ -295,6 +295,15 @@ class Supporter extends DataObject
 }
 ```
 
+To ensure this `many_many` is sorted by "Ranking" by default you can add this to your config:
+
+```yaml
+Team_Supporters:
+  default_sort: '"Team_Supporter"."Ranking" ASC'
+```
+
+`Team_Supporters` is the table name automatically generated for the many_many relation in this case.
+
 ### many_many through relationship joined on a separate DataObject
 
 If necessary, a third DataObject class can instead be specified as the joining table,
@@ -311,6 +320,9 @@ This is declared via array syntax, with the following keys on the many_many:
  - `through` Class name of the mapping table
  - `from` Name of the has_one relationship pointing back at the object declaring many_many
  - `to` Name of the has_one relationship pointing to the object declaring belongs_many_many.
+
+Just like a any normal DataObject, you can apply a default sort which will be applied when
+accessing many many through relations.
 
 Note: The `through` class must not also be the name of any field or relation on the parent
 or child record.
@@ -348,6 +360,8 @@ class TeamSupporter extends DataObject
         'Team' => Team::class,
         'Supporter' => Supporter::class,
     ];
+
+    private static $default_sort = '"TeamSupporter"."Ranking" ASC'
 }
 ```
 
@@ -467,6 +481,7 @@ the best way to think about it is that the object where the relationship will be
 (i.e. via checkboxes) should contain the `many_many`. For instance, in a `many_many` of
 Product => Categories, the `Product` should contain the `many_many`, because it is much
 more likely that the user will select Categories for a Product than vice-versa.
+
 
 ## Cascading deletions
 

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -2051,6 +2051,12 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
             $query->setQueryParam('Component.ExtraFields', $extraFields);
         });
 
+        // If we have a default sort set for our "join" then we should overwrite any default already set.
+        $joinSort = Config::inst()->get($manyManyComponent['join'], 'default_sort');
+        if (!empty($joinSort)) {
+            $result = $result->sort($joinSort);
+        }
+
         $this->extend('updateManyManyComponents', $result);
 
         // If this is called on a singleton, then we return an 'orphaned relation' that can have the

--- a/src/ORM/ManyManyThroughQueryManipulator.php
+++ b/src/ORM/ManyManyThroughQueryManipulator.php
@@ -254,13 +254,6 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
             );
         }
 
-        // Set a default sort from the join model if available and nothing is already set
-        if (empty($sqlSelect->getOrderBy())
-            && $sort = Config::inst()->get($this->getJoinClass(), 'default_sort')
-        ) {
-            $sqlSelect->setOrderBy($sort);
-        }
-
         // Apply join and record sql for later insertion (at end of replacements)
         // By using a string placeholder $$_SUBQUERY_$$ we protect field/table rewrites from interfering twice
         // on the already-finalised inner list

--- a/tests/php/ORM/ManyManyThroughListTest.yml
+++ b/tests/php/ORM/ManyManyThroughListTest.yml
@@ -51,3 +51,28 @@ SilverStripe\ORM\Tests\ManyManyThroughListTest\PolyJoinObject:
     Sort: 2
     Parent: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\PolyObjectB.objb2
     Child: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\PolyItem.child2
+SilverStripe\ORM\Tests\ManyManyThroughListTest\Locale:
+  international:
+    Title: 'International'
+    Locale: 'en_NZ'
+    URLSegment: 'international'
+    IsGlobalDefault: 1
+  mexico:
+    Title: 'Mexico'
+    Locale: 'es_MX'
+    URLSegment: 'mexico'
+    IsGlobalDefault: 0
+  argentina:
+    Title: 'Argentina'
+    Locale: 'es_AR'
+    URLSegment: 'argentina'
+    IsGlobalDefault: 0
+SilverStripe\ORM\Tests\ManyManyThroughListTest\FallbackLocale:
+  mexico_international:
+    Sort: 2
+    Parent: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\Locale.mexico
+    Locale: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\Locale.international
+  mexico_argentina:
+    Sort: 1
+    Parent: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\Locale.mexico
+    Locale: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\Locale.argentina

--- a/tests/php/ORM/ManyManyThroughListTest/FallbackLocale.php
+++ b/tests/php/ORM/ManyManyThroughListTest/FallbackLocale.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\ManyManyThroughListTest;
+
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Dev\TestOnly;
+
+class FallbackLocale extends DataObject implements TestOnly
+{
+    private static $db = [
+        'Sort' => 'Int',
+    ];
+
+    private static $has_one = [
+        'Parent' => Locale::class,
+        'Locale' => Locale::class,
+    ];
+
+    private static $table_name = 'ManyManyThroughTest_FallbackLocale';
+
+    private static $default_sort = 'Sort';
+}

--- a/tests/php/ORM/ManyManyThroughListTest/Locale.php
+++ b/tests/php/ORM/ManyManyThroughListTest/Locale.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\ManyManyThroughListTest;
+
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Dev\TestOnly;
+
+class Locale extends DataObject implements TestOnly
+{
+    private static $table_name = 'ManyManyThroughTest_Locale';
+
+    /**
+     * @config
+     * @var array
+     */
+    private static $db = [
+        'Title' => 'Varchar(100)',
+        'Locale' => 'Varchar(10)',
+        'URLSegment' => 'Varchar(100)',
+        'IsGlobalDefault' => 'Boolean',
+    ];
+
+    private static $has_many = [
+        'FallbackLocales' => FallbackLocale::class . '.Parent',
+    ];
+
+    private static $many_many = [
+        'Fallbacks' => [
+            'through' => FallbackLocale::class,
+            'from' => 'Parent',
+            'to' => 'Locale',
+        ],
+    ];
+
+    private static $default_sort = '"ManyManyThroughTest_Locale"."Locale" ASC';
+}


### PR DESCRIPTION
Resolves #7981 

Todo:

- [x] Write new tests to cover default sort on main dataobject as well as join table
- [x] Add docs on sorting many many lists

`many_many` joins work by doing a join with two separate queries.

eg.
```
SELECT ...
 FROM "Fluent_Locale" INNER JOIN (
     SELECT ...
     FROM "Fluent_FallbackLocale"
     WHERE ("Fluent_FallbackLocale"."ParentID" = ?)
     ORDER BY "Fluent_FallbackLocale"."Sort" ASC
 ) AS "Fluent_FallbackLocale" ON "Fluent_FallbackLocale"."LocaleID" = "Fluent_Locale"."ID"
 ORDER BY "Fluent_Locale"."Locale" ASC
```

As you can see, the inner query is sorting correctly on the join table (by Sort ASC). However, the main query has its own sort which overrides that when you get the final set of results.

This inner query is built by SilverStripe using the standard ORM functions and assumes the default sort of the join DataObject (FluentFallbackLocale in this case). Likewise for the main query.

With @robbieaverill's [fix](https://github.com/silverstripe/silverstripe-framework/pull/8417/files#diff-d3a5863552455ed2232ba1082ea6e1fbR257) it will sort correctly in cases where no default sort is set on the main DataObject and default is set on the join table data object. However, if the default sort is set on the main Dataobject, the fix will essentially be bypassed since sort is already set which is what we're seeing with Fluent.

The fix i've added applies the sort order much earlier, when it first starts building the ORM query objects. It will check to see if there is config which defines a default sort on the join table (this should also work for standard many-many sort too) and applies that if so. If that has no value, it will fallback to whatever sort SilverStripe gives it (default sort on dataobject or natural database sort).

This happens early enough that `->sort()` will function as normal if the user decides to sort by something else and early enough that `updateManymanyComponents` can be hooked into.
