### PR TITLE
Persist GridField readonly state, add view button

### DIFF
--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -255,7 +255,7 @@ class GridField extends FormField
         }
 
         // As the edit button may have been removed, add a view button if it doesn't have one
-        if ($copyConfig->getComponentsByType(GridFieldViewButton::class)->count() === 0) {
+        if (!$copyConfig->getComponentByType(GridFieldViewButton::class)) {
             $copyConfig->addComponent(new GridFieldViewButton);
         }
 
@@ -306,7 +306,7 @@ class GridField extends FormField
     public function setReadonly($readonly)
     {
         parent::setReadonly($readonly);
-        $this->getState()->Readonly($readonly);
+        $this->getState()->Readonly = $readonly;
         return $this;
     }
 
@@ -1029,7 +1029,7 @@ class GridField extends FormField
         }
 
         if ($request->getHeader('X-Pjax') === 'CurrentField') {
-            if ($this->getState(true)->Readonly) {
+            if ($this->getState()->Readonly) {
                 $this->performDisabledTransformation();
             }
             return $this->FieldHolder();

--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -113,11 +113,13 @@ class GridField extends FormField
     protected $readonlyComponents = [
         GridField_ActionMenu::class,
         GridFieldConfig_RecordViewer::class,
+        GridFieldButtonRow::class,
         GridFieldDataColumns::class,
         GridFieldDetailForm::class,
         GridFieldLazyLoader::class,
         GridFieldPageCount::class,
         GridFieldPaginator::class,
+        GridFieldFilterHeader::class,
         GridFieldSortableHeader::class,
         GridFieldToolbarHeader::class,
         GridFieldViewButton::class,
@@ -241,14 +243,20 @@ class GridField extends FormField
     {
         $copy = clone $this;
         $copy->setReadonly(true);
+        $copyConfig = $copy->getConfig();
 
         // get the whitelist for allowable readonly components
         $allowedComponents = $this->getReadonlyComponents();
         foreach ($this->getConfig()->getComponents() as $component) {
             // if a component doesn't exist, remove it from the readonly version.
             if (!in_array(get_class($component), $allowedComponents)) {
-                $copy->getConfig()->removeComponent($component);
+                $copyConfig->removeComponent($component);
             }
+        }
+
+        // As the edit button may have been removed, add a view button if it doesn't have one
+        if ($copyConfig->getComponentsByType(GridFieldViewButton::class)->count() === 0) {
+            $copyConfig->addComponent(new GridFieldViewButton);
         }
 
         return $copy;
@@ -287,6 +295,18 @@ class GridField extends FormField
             $this->config->addComponent(new GridState_Component());
         }
 
+        return $this;
+    }
+
+    /**
+     * @param bool $readonly
+     *
+     * @return $this
+     */
+    public function setReadonly($readonly)
+    {
+        parent::setReadonly($readonly);
+        $this->getState()->Readonly($readonly);
         return $this;
     }
 
@@ -1009,6 +1029,9 @@ class GridField extends FormField
         }
 
         if ($request->getHeader('X-Pjax') === 'CurrentField') {
+            if ($this->getState(true)->Readonly) {
+                $this->performDisabledTransformation();
+            }
             return $this->FieldHolder();
         }
 


### PR DESCRIPTION
Resolves #3357 (remaining ACs/bugs)

- Fixes an issue that when the GridField is called via pjax it loses it's readonly state i.e. when pagination buttons are pushed
- Add a couple missing components to readonly whitelist
- Add view button to re-enable access to view records as edit buttons will be removed