### PR TITLE
Fix the GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,9 @@
 ## Affected Version
 
 Show version numbers by pasting the output of `composer info --direct`.
-Alternatively, hover over the SilverStripe logo in the CMS to basic version information.
+Alternatively, get the framework version information from the CMS.
+In SilverStripe 4.3 and newer you may find the Help menu in the bottom left corner, unfold it and hover over the version number to get the information.
+Otherwise, simply hover over the SilverStripe logo in the bottom left corner of the CMS.
 
 ## Description
 


### PR DESCRIPTION
Add description of how to find the installed framework version in CMS for 4.3.0 and later.

Fixes #8530 