### PR TITLE
Resolve duplicate session headers #8543

### DIFF
--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -494,7 +494,7 @@ class Session
 
     /**
      * Set user agent key
-*/
+     */
     public function finalize(HTTPRequest $request)
     {
         $this->set('HTTP_USER_AGENT', $this->userAgent($request));

--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -298,6 +298,7 @@ class Session
             }
         }
 
+        $data = [];
         if (!session_id() && !headers_sent()) {
             // Allow storing the session in a non standard location
             if ($session_path) {
@@ -331,14 +332,14 @@ class Session
             if (isset($_SESSION)) {
                 // Initialise data from session store if present
                 $data = $_SESSION;
+
                 // Merge in existing in-memory data, taking priority over session store data
                 $this->recursivelyApply((array)$this->data, $data);
-                $this->data = $data;
             }
-        } else {
-            // Use in-memory data if the session is lazy started
-            $this->data = [];
         }
+
+        // Save any modified session data back to the session store if present, otherwise initialise it to an array.
+        $this->data = $data;
 
         $this->started = true;
     }


### PR DESCRIPTION
Headers were being sent twice, once by session_start() and once by Cookie::set()

The second header was unneeded, and meant `Set-Cookie` was appended to every request which
breaks WAF behaviour for sticky sessions

@see https://github.com/silverstripe/silverstripe-framework/issues/8543