### PR TITLE
MINOR Add a reference to SS_Object in .upgrade.yml to allow upgrade from SS3.7

### DIFF
--- a/.upgrade.yml
+++ b/.upgrade.yml
@@ -958,6 +958,9 @@ warnings:
     'Object':
       message: 'Replaced with traits'
       url: 'https://docs.silverstripe.org/en/4/changelogs/4.0.0#object-replace'
+    'SS_Object':
+      message: 'Replaced with traits'
+      url: 'https://docs.silverstripe.org/en/4/changelogs/4.0.0#object-replace'
     'SS_Log':
       message: 'Replaced with a PSR-3 logger'
       url: 'https://docs.silverstripe.org/en/4/changelogs/4.0.0#psr3-logging'


### PR DESCRIPTION
SS3.7 renames Object to SS_Object to be compatible with PHP7.2. However SS_Object wasn't mentioned in `.upgrade.yml`, which would make it very difficult to upgrade to 4 from 3.7

# Related issue
* https://github.com/silverstripe/silverstripe-framework/issues/8478