### PR TITLE
Fix readonly grid state always being truthy

### DIFF
--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -1029,7 +1029,7 @@ class GridField extends FormField
         }
 
         if ($request->getHeader('X-Pjax') === 'CurrentField') {
-            if ($this->getState()->Readonly) {
+            if ($this->getState()->Readonly === true) {
                 $this->performDisabledTransformation();
             }
             return $this->FieldHolder();


### PR DESCRIPTION
Fix GridFields changing to readonly (even if they originally weren't) if an alter action was called i.e. pagination. Introduced by https://github.com/silverstripe/silverstripe-framework/pull/8535