### PR TITLE
NEW Adding constructor auto-DI for classes resolved through Injector

### DIFF
--- a/docs/en/02_Developer_Guides/05_Extending/05_Injector.md
+++ b/docs/en/02_Developer_Guides/05_Extending/05_Injector.md
@@ -82,7 +82,7 @@ class MyController extends Controller
 
     // we declare the types for each of the properties on the object. Anything we pass in via the Injector API must
     // match these data types.
-    static $dependencies = [
+    private static $dependencies = [
         'textProperty'        => 'a string value',
         'permissions'        => '%$PermissionService',
     ];
@@ -137,6 +137,51 @@ SilverStripe\Core\Injector\Injector:
     calls:
       - [ pushHandler, [ %$DefaultHandler ] ]
 ```
+
+## Constructor dependency injection
+
+Any class resolved through `Injector` may optionally have constructor parameters resolved and auto-provided with `Injector`. Injector will attempt this on constructors that are tagged with `@Injectable` in the docblock.
+
+```php
+use SilverStripe\Control\Controller;
+use My\Project\PermissionService;
+
+class MyController extends Controller 
+{
+    protected $permissions;
+    
+    /**
+     * @Injectable
+     */
+    public function __construct(PermissionService $permissions) 
+    {
+        $this->permissions = $permissions;
+    }
+}
+```
+
+Additionally, overriding constructors that already take some arguments is also supported. For example, when overriding `ContentController` from silverstripe/cms:
+
+```php
+use SilverStripe\CMS\Controllers\ContentController;
+
+class MyPageController extends ContentController 
+{
+    protected $cacheFactory;
+    
+    /**
+     * @Injectable
+     */
+    public function __construct(CacheFactory $factory, $dataRecord = null)
+    {
+        $this->cacheFactory = $factory;
+        
+        parent::__construct($dataRecord);
+    } 
+}
+```
+
+You may also used tagged injections
 
 ## Using constants as variables
 

--- a/src/Core/Config/AnnotationTransformer/InjectableDefinition.php
+++ b/src/Core/Config/AnnotationTransformer/InjectableDefinition.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\Core\Config\AnnotationTransformer;
+
+use ReflectionClass;
+use ReflectionMethod;
+use SilverStripe\Config\Transformer\AnnotationTransformer\AnnotationDefinitionInterface;
+use SilverStripe\Core\Injector\MethodInjector;
+
+class InjectableDefinition implements AnnotationDefinitionInterface
+{
+    /**
+     * Return a bitwise integer combining COLLECT_* constants indicating what doc blocks to collect annotations from
+     *
+     * @return int
+     */
+    public function defineCollectionScopes(): int
+    {
+        return AnnotationDefinitionInterface::COLLECT_CONSTRUCTOR;
+    }
+
+    /**
+     * Indicates whether annotations should be collected from the given class
+     *
+     * @param string $className
+     * @return bool
+     */
+    public function shouldCollect(string $className): bool
+    {
+        return true;
+    }
+
+    /**
+     * Indicates whether annotations should be collected from the given method within the given class
+     *
+     * @param ReflectionClass $class
+     * @param ReflectionMethod $method
+     * @return bool
+     */
+    public function shouldCollectFromMethod(ReflectionClass $class, ReflectionMethod $method): bool
+    {
+        return false;
+    }
+
+    /**
+     * Get an array of annotations to look for. For example 'Foo' would indicate that '@Foo' should be matched
+     *
+     * @return array
+     */
+    public function getAnnotationStrings(): array
+    {
+        return [MethodInjector::TAG_INJECTABLE, MethodInjector::TAG_ATTRIBUTE];
+    }
+
+    /**
+     * Create config from a matched annotation.
+     *
+     * @param string $annotation The annotation string that was matched (defined in @see getAnnotationStrings)
+     * @param array $arguments An array of strings that were passed as arguments (eg. @Foo(argument1,argument2)
+     * @param int $context A COLLECT_* constant that indicates what context this annotation was found in
+     * @param string|null $contextDetail A method name, provided the context of the annotation was a method
+     * @return array
+     */
+    public function createConfigForAnnotation(
+        string $annotation,
+        array $arguments,
+        int $context,
+        ?string $contextDetail = null
+    ): array {
+        // Check if this is just being tagged as injectable...
+        if ($annotation === MethodInjector::TAG_INJECTABLE) {
+            return ['injectable' => true];
+        }
+
+        // Otherwise this is naming services for injection. This should be provided as [$className, $serviceName]
+        if (count($arguments) !== 2) {
+            throw new InvalidAnnotationException(sprintf(
+                '@%s annotations must provide two arguments, the classname and the service name. For example '
+                . '@%s(MyClass, test) references MyClass.test from Injector.',
+                MethodInjector::TAG_ATTRIBUTE,
+                MethodInjector::TAG_ATTRIBUTE
+            ));
+        }
+
+        return ['named_injections' => [['class' => $arguments[0], 'key' => $arguments[1]]]];
+    }
+}

--- a/src/Core/Config/AnnotationTransformer/InvalidAnnotationException.php
+++ b/src/Core/Config/AnnotationTransformer/InvalidAnnotationException.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\Core\Config\AnnotationTransformer;
+
+use LogicException;
+
+class InvalidAnnotationException extends LogicException
+{
+
+}

--- a/src/Core/Injector/InjectionCreator.php
+++ b/src/Core/Injector/InjectionCreator.php
@@ -10,13 +10,20 @@ use ReflectionException;
  */
 class InjectionCreator implements Factory
 {
-
-    public function create($class, array $params = array())
+    public function create($class, array $params = [])
     {
         try {
             $reflector = new ReflectionClass($class);
         } catch (ReflectionException $e) {
             throw new InjectorNotFoundException($e);
+        }
+
+        if ($constructor = $reflector->getConstructor()) {
+            $constructorInjector = new MethodInjector($constructor);
+
+            if ($constructorInjector->isMarkedInjectable()) {
+                $params = $constructorInjector->provideMethodParams($params);
+            }
         }
 
         if (count($params)) {

--- a/src/Core/Injector/Injector.php
+++ b/src/Core/Injector/Injector.php
@@ -41,7 +41,7 @@ use SilverStripe\ORM\DataObject;
  *      public $permissions;
  *      public $defaultText;
  *
- *      static $dependencies = array(
+ *      private static $dependencies = array(
  *          'defaultText'       => 'Override in configuration',
  *          'permissions'       => '%$PermissionService',
  *      );

--- a/src/Core/Injector/MethodInjector.php
+++ b/src/Core/Injector/MethodInjector.php
@@ -1,0 +1,108 @@
+<?php
+namespace SilverStripe\Core\Injector;
+
+use ReflectionMethod;
+
+/**
+ * Parses method reflections and attempts to auro-wire parameters for injection
+ */
+class MethodInjector
+{
+    const TAG_INJECTABLE = 'Injectable';
+    const TAG_ATTRIBUTE = 'Inject';
+
+    /**
+     * @var ReflectionMethod
+     */
+    protected $method;
+
+    /**
+     * MethodInjector constructor.
+     * @param ReflectionMethod $method
+     */
+    public function __construct(ReflectionMethod $method)
+    {
+        $this->method = $method;
+    }
+
+    /**
+     * Indicates that the method is marked as injectable in the doc-comment for the method (with @Injectable)
+     *
+     * @return bool
+     */
+    public function isMarkedInjectable()
+    {
+        return preg_match('/^\s*\*\s*@' . static::TAG_INJECTABLE . '\s*$/m', $this->method->getDocComment()) > 0;
+    }
+
+    public function provideMethodParams(array $providedParams = [])
+    {
+        $attributes = $this->getInjectorAttributes();
+        $reflectedParams = $this->method->getParameters();
+        $params = [];
+
+        foreach ($reflectedParams as $param) {
+            if (!$param->getClass()) {
+                break;
+            }
+
+            $class = $param->getClass()->getName();
+
+            // Look in params for this
+            foreach ($providedParams as $key => $candidate) {
+                if ($candidate instanceof $class) {
+                    $params[] = $candidate;
+                    unset($providedParams[$key]);
+                    continue 2;
+                }
+            }
+
+            // Do we have a specific key for this?
+            $key = '';
+            foreach ($attributes as $attribute) {
+                if (false !== strpos($class, $attribute['class'])) {
+                    $key = '.' . $attribute['key'];
+                }
+            }
+
+            $params[] = Injector::inst()->get($class . $key);
+        }
+
+        if (count($providedParams)) {
+            $params = array_merge($params, $providedParams);
+        }
+
+        return $params;
+    }
+
+    protected function getInjectorAttributes()
+    {
+        $docblock = $this->method->getDocComment();
+
+        preg_match_all('/^\s*\*\s*@' . static::TAG_ATTRIBUTE . '\s(.+)$/m', $docblock, $matches);
+
+        if (!isset($matches[1])) {
+            return [];
+        }
+
+        $attributes = [];
+        foreach ($matches[1] as $definition) {
+            if (false !== ($attribute = $this->parseAttributeDefinition($definition))) {
+                $attributes[] = $attribute;
+            }
+        }
+
+        return $attributes;
+    }
+
+    protected function parseAttributeDefinition($definition)
+    {
+        $parts = explode(' ', $definition);
+
+        if (count($parts) !== 2) {
+            return false;
+        }
+
+        return array_combine(['class', 'key'], $parts);
+    }
+}

--- a/tests/php/Core/Injector/MethodInjectorTest.php
+++ b/tests/php/Core/Injector/MethodInjectorTest.php
@@ -1,0 +1,42 @@
+<?php
+namespace SilverStripe\Core\Tests\Injector;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\Injector\SilverStripeServiceConfigurationLocator;
+use SilverStripe\Core\Tests\Injector\MethodInjectorTest\AlternateTestDependency;
+use SilverStripe\Core\Tests\Injector\MethodInjectorTest\InjectableConstructor;
+use SilverStripe\Core\Tests\Injector\MethodInjectorTest\InjectableConstructorTagged;
+use SilverStripe\Core\Tests\Injector\MethodInjectorTest\TestDependency;
+use SilverStripe\Dev\SapphireTest;
+
+class MethodInjectorTest extends SapphireTest
+{
+    public function testSimpleInjectableConstructors()
+    {
+        /** @var InjectableConstructor $object */
+        $object = Injector::inst()->get(InjectableConstructor::class);
+        $this->assertInstanceOf(TestDependency::class, $object->getProtectedDependency());
+    }
+
+    public function testInjectableConstructorsWithAdditionalArgs()
+    {
+        $extraParams = [1, 2];
+        /** @var InjectableConstructor $object */
+        $object = Injector::inst()->get(InjectableConstructor::class, true, $extraParams);
+        $this->assertInstanceOf(TestDependency::class, $object->getProtectedDependency());
+        $this->assertSame($extraParams, $object->getAdditionalParams());
+    }
+
+    public function testTaggedInjectableConstructors()
+    {
+        Config::nest()->set(Injector::class, TestDependency::class . '.testTag', AlternateTestDependency::class);
+        // Reset the config locator to dump any existing caches...
+        Injector::inst()->setConfigLocator(new SilverStripeServiceConfigurationLocator());
+
+
+        /** @var InjectableConstructor $object */
+        $object = Injector::inst()->get(InjectableConstructorTagged::class);
+        $this->assertInstanceOf(AlternateTestDependency::class, $object->getProtectedDependency());
+    }
+}

--- a/tests/php/Core/Injector/MethodInjectorTest/AlternateTestDependency.php
+++ b/tests/php/Core/Injector/MethodInjectorTest/AlternateTestDependency.php
@@ -1,0 +1,9 @@
+<?php
+namespace SilverStripe\Core\Tests\Injector\MethodInjectorTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class AlternateTestDependency extends TestDependency implements TestOnly
+{
+
+}

--- a/tests/php/Core/Injector/MethodInjectorTest/InjectableConstructor.php
+++ b/tests/php/Core/Injector/MethodInjectorTest/InjectableConstructor.php
@@ -1,0 +1,44 @@
+<?php
+namespace SilverStripe\Core\Tests\Injector\MethodInjectorTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class InjectableConstructor implements TestOnly
+{
+    /**
+     * @var TestDependency
+     */
+    protected $protectedDependency;
+
+    /**
+     * @var array
+     */
+    protected $additionalParams;
+
+    /**
+     * @param TestDependency $protectedDependency
+     * @param array $additionalParams
+     * @Injectable
+     */
+    public function __construct(TestDependency $protectedDependency, ...$additionalParams)
+    {
+        $this->protectedDependency = $protectedDependency;
+        $this->additionalParams = $additionalParams;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getProtectedDependency()
+    {
+        return $this->protectedDependency;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAdditionalParams()
+    {
+        return $this->additionalParams;
+    }
+}

--- a/tests/php/Core/Injector/MethodInjectorTest/InjectableConstructorTagged.php
+++ b/tests/php/Core/Injector/MethodInjectorTest/InjectableConstructorTagged.php
@@ -19,7 +19,7 @@ class InjectableConstructorTagged extends InjectableConstructor implements TestO
      * @param TestDependency $protectedDependency
      * @param array $additionalParams
      * @Injectable
-     * @Inject TestDependency testTag
+     * @Inject(TestDependency,testTag)
      */
     public function __construct(TestDependency $protectedDependency, ...$additionalParams)
     {

--- a/tests/php/Core/Injector/MethodInjectorTest/InjectableConstructorTagged.php
+++ b/tests/php/Core/Injector/MethodInjectorTest/InjectableConstructorTagged.php
@@ -1,0 +1,28 @@
+<?php
+namespace SilverStripe\Core\Tests\Injector\MethodInjectorTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class InjectableConstructorTagged extends InjectableConstructor implements TestOnly
+{
+    /**
+     * @var TestDependency
+     */
+    protected $protectedDependency;
+
+    /**
+     * @var array
+     */
+    protected $additionalParams;
+
+    /**
+     * @param TestDependency $protectedDependency
+     * @param array $additionalParams
+     * @Injectable
+     * @Inject TestDependency testTag
+     */
+    public function __construct(TestDependency $protectedDependency, ...$additionalParams)
+    {
+        parent::__construct($protectedDependency, ...$additionalParams);
+    }
+}

--- a/tests/php/Core/Injector/MethodInjectorTest/TestDependency.php
+++ b/tests/php/Core/Injector/MethodInjectorTest/TestDependency.php
@@ -1,0 +1,9 @@
+<?php
+namespace SilverStripe\Core\Tests\Injector\MethodInjectorTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class TestDependency implements TestOnly
+{
+
+}


### PR DESCRIPTION
I can RFC whether this is a feature that the core team is interested in for 4.4 if wanted.

This adds auto-DI for constructors of classes resolved through `Injector`. This works by checking the constructor docblock for a tag `@Injectable` and then using typehint reflection to resolve dependecies. There's some docs in the PR.

Having dependencies expressed in the constructor is a good way to indicate a classes dependencies in a clear way - producing expressive and testable classes. I think we should be encouraging this sort of DI, and perhaps make the `@Injectable` tag not required in 5.0