### PR TITLE
MINOR: Add test for defaults on subclasses

### DIFF
--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -1456,6 +1456,13 @@ class DataObjectTest extends SapphireTest
             'Default Value',
             'Defaults are populated from overloaded populateDefaults() method'
         );
+
+        // Test populate defaults on subclasses
+        $staffObj = new DataObjectTest\Staff();
+        $this->assertEquals('Staff', $staffObj->EmploymentType);
+
+        $ceoObj = new DataObjectTest\CEO();
+        $this->assertEquals('Staff', $ceoObj->EmploymentType);
     }
 
     /**

--- a/tests/php/ORM/DataObjectTest/Staff.php
+++ b/tests/php/ORM/DataObjectTest/Staff.php
@@ -9,6 +9,7 @@ class Staff extends DataObject implements TestOnly
 {
     private static $db = array(
         'Salary' => 'BigInt',
+        'EmploymentType' => 'Varchar',
     );
 
     private static $table_name = 'DataObjectTest_Staff';
@@ -17,4 +18,8 @@ class Staff extends DataObject implements TestOnly
         'CurrentCompany' => Company::class,
         'PreviousCompany' => Company::class
     );
+
+    private static $defaults = [
+        'EmploymentType' => 'Staff',
+    ];
 }


### PR DESCRIPTION
This was raised in https://github.com/silverstripe/silverstripe-framework/issues/8567
and wasn’t covered by a test.