### PR TITLE
Port betterbuttons to framework

### DIFF
--- a/_config/buttons.yml
+++ b/_config/buttons.yml
@@ -1,0 +1,8 @@
+---
+Name: buttons
+---
+SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest:
+  formActions:
+    showPrevious: true
+    showNext: true
+    showAdd: true

--- a/_config/buttons.yml
+++ b/_config/buttons.yml
@@ -3,6 +3,5 @@ Name: buttons
 ---
 SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest:
   formActions:
-    showPrevious: true
-    showNext: true
+    showPagination: true
     showAdd: true

--- a/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/Customise_CMS_Menu.md
+++ b/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/Customise_CMS_Menu.md
@@ -126,13 +126,23 @@ SilverStripe\Admin\LeftAndMain:
 
 ## Customising the CMS form actions
 
-The `Previous`, `Next` and `Add` actions on the edit form are visible by default but can be hidden by adding the following `.yml` config:
+The `Previous`, `Next` and `Add` actions on the edit form are visible by default but can be hidden globally by adding the following `.yml` config:
 
 ```yml
 FormActions:
   showPrevious: false
   showNext: false
   showAdd: false
+```
+
+You can also configure this for a specific `GridField` instance when using the `GridFieldConfig_RecordEditor` constructor:
+
+```php
+$grid = new GridField(
+    "pages", 
+    "All Pages", 
+    SiteTree::get(), 
+    GridFieldConfig_RecordEditor::create(null, false, false, false));
 ```
 
 ## Related

--- a/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/Customise_CMS_Menu.md
+++ b/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/Customise_CMS_Menu.md
@@ -124,6 +124,17 @@ SilverStripe\Admin\LeftAndMain:
     'Feedback': ''
 ```
 
+## Customising the CMS form actions
+
+The `Previous`, `Next` and `Add` actions on the edit form are visible by default but can be hidden by adding the following `.yml` config:
+
+```yml
+FormActions:
+  showPrevious: false
+  showNext: false
+  showAdd: false
+```
+
 ## Related
 
  * [How to extend the CMS interface](extend_cms_interface)

--- a/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/Customise_CMS_Menu.md
+++ b/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/Customise_CMS_Menu.md
@@ -129,20 +129,20 @@ SilverStripe\Admin\LeftAndMain:
 The `Previous`, `Next` and `Add` actions on the edit form are visible by default but can be hidden globally by adding the following `.yml` config:
 
 ```yml
-FormActions:
-  showPrevious: false
-  showNext: false
-  showAdd: false
+SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest:
+  formActions:
+    showPagination: false
+    showAdd: false
 ```
 
-You can also configure this for a specific `GridField` instance when using the `GridFieldConfig_RecordEditor` constructor:
+You can also override this for a specific `GridField` instance when using the `GridFieldConfig_RecordEditor` constructor:
 
 ```php
 $grid = new GridField(
     "pages", 
     "All Pages", 
     SiteTree::get(), 
-    GridFieldConfig_RecordEditor::create(null, false, false, false));
+    GridFieldConfig_RecordEditor::create(null, false, false));
 ```
 
 ## Related

--- a/src/Forms/GridField/GridFieldConfig_RecordEditor.php
+++ b/src/Forms/GridField/GridFieldConfig_RecordEditor.php
@@ -10,11 +10,10 @@ class GridFieldConfig_RecordEditor extends GridFieldConfig
     /**
      *
      * @param int $itemsPerPage - How many items per page should show up
-     * @param bool $showPrevious Whether the `Previous` button should display or not, leave as null to use default
-     * @param bool $showNext Whether the `Next` button should display or not, leave as null to use default
+     * @param bool $showPagination Whether the `Previous` and `Next` buttons should display or not, leave as null to use default
      * @param bool $showAdd Whether the `Add` button should display or not, leave as null to use default
      */
-    public function __construct($itemsPerPage = null, $showPrevious = null, $showNext = null, $showAdd = null)
+    public function __construct($itemsPerPage = null, $showPagination = null, $showAdd = null)
     {
         parent::__construct();
 
@@ -29,7 +28,7 @@ class GridFieldConfig_RecordEditor extends GridFieldConfig
         $this->addComponent(new GridField_ActionMenu());
         $this->addComponent(new GridFieldPageCount('toolbar-header-right'));
         $this->addComponent($pagination = new GridFieldPaginator($itemsPerPage));
-        $this->addComponent(new GridFieldDetailForm(null, $showPrevious, $showNext, $showAdd));
+        $this->addComponent(new GridFieldDetailForm(null, $showPagination, $showAdd));
 
         $sort->setThrowExceptionOnBadDataType(false);
         $filter->setThrowExceptionOnBadDataType(false);

--- a/src/Forms/GridField/GridFieldConfig_RecordEditor.php
+++ b/src/Forms/GridField/GridFieldConfig_RecordEditor.php
@@ -10,8 +10,11 @@ class GridFieldConfig_RecordEditor extends GridFieldConfig
     /**
      *
      * @param int $itemsPerPage - How many items per page should show up
+     * @param bool $showPrevious Whether the `Previous` button should display or not, leave as null to use default
+     * @param bool $showNext Whether the `Next` button should display or not, leave as null to use default
+     * @param bool $showAdd Whether the `Add` button should display or not, leave as null to use default
      */
-    public function __construct($itemsPerPage = null)
+    public function __construct($itemsPerPage = null, $showPrevious = null, $showNext = null, $showAdd = null)
     {
         parent::__construct();
 
@@ -26,7 +29,7 @@ class GridFieldConfig_RecordEditor extends GridFieldConfig
         $this->addComponent(new GridField_ActionMenu());
         $this->addComponent(new GridFieldPageCount('toolbar-header-right'));
         $this->addComponent($pagination = new GridFieldPaginator($itemsPerPage));
-        $this->addComponent(new GridFieldDetailForm());
+        $this->addComponent(new GridFieldDetailForm(null, $showPrevious, $showNext, $showAdd));
 
         $sort->setThrowExceptionOnBadDataType(false);
         $filter->setThrowExceptionOnBadDataType(false);

--- a/src/Forms/GridField/GridFieldDetailForm.php
+++ b/src/Forms/GridField/GridFieldDetailForm.php
@@ -93,6 +93,10 @@ class GridFieldDetailForm implements GridField_URLHandler
      */
     public function handleItem($gridField, $request)
     {
+        if ($gridStateStr = $request->getVar('gridState')) {
+            $gridField->getState(false)->setValue($gridStateStr);
+        }
+
         // Our getController could either give us a true Controller, if this is the top-level GridField.
         // It could also give us a RequestHandler in the form of GridFieldDetailForm_ItemRequest if this is a
         // nested GridField.

--- a/src/Forms/GridField/GridFieldDetailForm.php
+++ b/src/Forms/GridField/GridFieldDetailForm.php
@@ -119,7 +119,7 @@ class GridFieldDetailForm implements GridField_URLHandler
         if (is_numeric($request->param('ID'))) {
             /** @var Filterable $dataList */
             $dataList = $gridField->getList();
-            $record = $dataList->byID($request->param("ID"));
+            $record = $dataList->byID($request->param('ID'));
         } else {
             $record = Injector::inst()->create($gridField->getModelClass());
         }
@@ -199,10 +199,10 @@ class GridFieldDetailForm implements GridField_URLHandler
     /**
      * @return bool
      */
-    private function getDefaultShowPagination()
+    protected function getDefaultShowPagination()
     {
-        $formActionsConfig = GridFieldDetailForm_ItemRequest::config()->get("formActions");
-        return $formActionsConfig["showPagination"];
+        $formActionsConfig = GridFieldDetailForm_ItemRequest::config()->get('formActions');
+        return isset($formActionsConfig['showPagination']) ? (boolean) $formActionsConfig['showPagination'] : false;
     }
 
     /**
@@ -210,11 +210,15 @@ class GridFieldDetailForm implements GridField_URLHandler
      */
     public function getShowPagination()
     {
-        return is_bool($this->showPagination) ? $this->showPagination : $this->getDefaultShowPagination();
+        if ($this->showPagination === null) {
+            return $this->getDefaultShowPagination();
+        }
+
+        return (boolean) $this->showPagination;
     }
 
     /**
-     * @param mixed $showPagination
+     * @param bool|null $showPagination
      * @return GridFieldDetailForm
      */
     public function setShowPagination($showPagination)
@@ -226,10 +230,10 @@ class GridFieldDetailForm implements GridField_URLHandler
     /**
      * @return bool
      */
-    private function getDefaultShowAdd()
+    protected function getDefaultShowAdd()
     {
-        $formActionsConfig = GridFieldDetailForm_ItemRequest::config()->get("formActions");
-        return $formActionsConfig["showAdd"];
+        $formActionsConfig = GridFieldDetailForm_ItemRequest::config()->get('formActions');
+        return isset($formActionsConfig['showAdd']) ? (boolean) $formActionsConfig['showAdd'] : false;
     }
 
     /**
@@ -237,11 +241,15 @@ class GridFieldDetailForm implements GridField_URLHandler
      */
     public function getShowAdd()
     {
-        return is_bool($this->showAdd) ? $this->showAdd : $this->getDefaultShowAdd();
+        if ($this->showAdd === null) {
+            return $this->getDefaultShowAdd();
+        }
+
+        return (boolean) $this->showAdd;
     }
 
     /**
-     * @param mixed $showAdd
+     * @param bool|null $showAdd
      * @return GridFieldDetailForm
      */
     public function setShowAdd($showAdd)
@@ -303,8 +311,8 @@ class GridFieldDetailForm implements GridField_URLHandler
     {
         if ($this->itemRequestClass) {
             return $this->itemRequestClass;
-        } elseif (ClassInfo::exists(static::class . "_ItemRequest")) {
-            return static::class . "_ItemRequest";
+        } elseif (ClassInfo::exists(static::class . '_ItemRequest')) {
+            return static::class . '_ItemRequest';
         } else {
             return GridFieldDetailForm_ItemRequest::class;
         }

--- a/src/Forms/GridField/GridFieldDetailForm.php
+++ b/src/Forms/GridField/GridFieldDetailForm.php
@@ -38,25 +38,16 @@ class GridFieldDetailForm implements GridField_URLHandler
     protected $template = null;
 
     /**
-     *
      * @var string
      */
     protected $name;
 
     /**
-     *
      * @var bool
      */
-    protected $showPrevious;
+    protected $showPagination;
 
     /**
-     *
-     * @var bool
-     */
-    protected $showNext;
-
-    /**
-     *
      * @var bool
      */
     protected $showAdd;
@@ -97,16 +88,14 @@ class GridFieldDetailForm implements GridField_URLHandler
      * controller who wants to display the getCMSFields
      *
      * @param string $name The name of the edit form to place into the pop-up form
-     * @param bool $showPrevious Whether the `Previous` button should display or not, leave as null to use default
-     * @param bool $showNext Whether the `Next` button should display or not, leave as null to use default
+     * @param bool $showPagination Whether the `Previous` and `Next` buttons should display or not, leave as null to use default
      * @param bool $showAdd Whether the `Add` button should display or not, leave as null to use default
      */
-    public function __construct($name = null, $showPrevious = null, $showNext = null, $showAdd = null)
+    public function __construct($name = null, $showPagination = null, $showAdd = null)
     {
-        $this->name = $name ?: 'DetailForm';
-        $this->showPrevious = $showPrevious;
-        $this->showNext = $showNext;
-        $this->showAdd = $showAdd;
+        $this->setName($name ?: 'DetailForm');
+        $this->setShowPagination($showPagination);
+        $this->setShowAdd($showAdd);
     }
 
     /**
@@ -210,17 +199,37 @@ class GridFieldDetailForm implements GridField_URLHandler
     /**
      * @return bool
      */
-    public function getShowPrevious()
+    private function getDefaultShowPagination()
     {
-        return $this->showPrevious;
+        $formActionsConfig = GridFieldDetailForm_ItemRequest::config()->get("formActions");
+        return $formActionsConfig["showPagination"];
     }
 
     /**
      * @return bool
      */
-    public function getShowNext()
+    public function getShowPagination()
     {
-        return $this->showNext;
+        return is_bool($this->showPagination) ? $this->showPagination : $this->getDefaultShowPagination();
+    }
+
+    /**
+     * @param mixed $showPagination
+     * @return GridFieldDetailForm
+     */
+    public function setShowPagination($showPagination)
+    {
+        $this->showPagination = $showPagination;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    private function getDefaultShowAdd()
+    {
+        $formActionsConfig = GridFieldDetailForm_ItemRequest::config()->get("formActions");
+        return $formActionsConfig["showAdd"];
     }
 
     /**
@@ -228,7 +237,17 @@ class GridFieldDetailForm implements GridField_URLHandler
      */
     public function getShowAdd()
     {
-        return $this->showAdd;
+        return is_bool($this->showAdd) ? $this->showAdd : $this->getDefaultShowAdd();
+    }
+
+    /**
+     * @param mixed $showAdd
+     * @return GridFieldDetailForm
+     */
+    public function setShowAdd($showAdd)
+    {
+        $this->showAdd = $showAdd;
+        return $this;
     }
 
     /**

--- a/src/Forms/GridField/GridFieldDetailForm.php
+++ b/src/Forms/GridField/GridFieldDetailForm.php
@@ -44,6 +44,24 @@ class GridFieldDetailForm implements GridField_URLHandler
     protected $name;
 
     /**
+     *
+     * @var bool
+     */
+    protected $showPrevious;
+
+    /**
+     *
+     * @var bool
+     */
+    protected $showNext;
+
+    /**
+     *
+     * @var bool
+     */
+    protected $showAdd;
+
+    /**
      * @var Validator The form validator used for both add and edit fields.
      */
     protected $validator;
@@ -79,10 +97,16 @@ class GridFieldDetailForm implements GridField_URLHandler
      * controller who wants to display the getCMSFields
      *
      * @param string $name The name of the edit form to place into the pop-up form
+     * @param bool $showPrevious Whether the `Previous` button should display or not, leave as null to use default
+     * @param bool $showNext Whether the `Next` button should display or not, leave as null to use default
+     * @param bool $showAdd Whether the `Add` button should display or not, leave as null to use default
      */
-    public function __construct($name = 'DetailForm')
+    public function __construct($name = null, $showPrevious = null, $showNext = null, $showAdd = null)
     {
-        $this->name = $name;
+        $this->name = $name ?: 'DetailForm';
+        $this->showPrevious = $showPrevious;
+        $this->showNext = $showNext;
+        $this->showAdd = $showAdd;
     }
 
     /**
@@ -181,6 +205,30 @@ class GridFieldDetailForm implements GridField_URLHandler
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getShowPrevious()
+    {
+        return $this->showPrevious;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getShowNext()
+    {
+        return $this->showNext;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getShowAdd()
+    {
+        return $this->showAdd;
     }
 
     /**

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -308,10 +308,13 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
             $previousAndNextGroup->addExtraClass('rounded');
             $previousAndNextGroup->setFieldHolderTemplate(get_class($previousAndNextGroup) . '_holder_buttongroup');
 
+
+            $component = $this->gridField->getConfig()->getComponentByType(GridFieldDetailForm::class);
             $formActionsConfig = $this->config()->get("formActions");
-            $showPrevious = $formActionsConfig["showPrevious"];
-            $showNext = $formActionsConfig["showNext"];
-            $showAdd = $formActionsConfig["showAdd"];
+
+            $showPrevious = is_bool($component->getShowPrevious()) ? $component->getShowPrevious() : $formActionsConfig["showPrevious"];
+            $showNext = is_bool($component->getShowNext()) ? $component->getShowNext() : $formActionsConfig["showNext"];
+            $showAdd = is_bool($component->getShowAdd()) ? $component->getShowAdd() : $formActionsConfig["showAdd"];
 
             if ($showPrevious) {
                 $previousAndNextGroup->push(FormAction::create('doPrevious')
@@ -515,7 +518,6 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
             $this->gridField->Link(),
             "item",
             $id,
-            // todo: use http header instead
             '?gridState=' . urlencode($this->gridField->getState(false)->Value())
         );
     }

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -467,7 +467,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      */
     public function doPrevious($data, $form)
     {
-        $this->getToplevelController()->getResponse()->addHeader("X-Pjax", "Content");
+        $this->getToplevelController()->getResponse()->addHeader('X-Pjax', 'Content');
         $link = $this->getEditLink($this->getPreviousRecordID());
         return $this->redirect($link);
     }
@@ -480,7 +480,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      */
     public function doNext($data, $form)
     {
-        $this->getToplevelController()->getResponse()->addHeader("X-Pjax", "Content");
+        $this->getToplevelController()->getResponse()->addHeader('X-Pjax', 'Content');
         $link = $this->getEditLink($this->getNextRecordID());
         return $this->redirect($link);
     }
@@ -495,7 +495,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      */
     public function doNew($data, $form)
     {
-        return $this->redirect(Controller::join_links($this->gridField->Link("item"), "new"));
+        return $this->redirect(Controller::join_links($this->gridField->Link('item'), 'new'));
     }
 
     /**
@@ -508,7 +508,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
     {
         return Controller::join_links(
             $this->gridField->Link(),
-            "item",
+            'item',
             $id,
             '?gridState=' . urlencode($this->gridField->getState(false)->Value())
         );
@@ -516,16 +516,20 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
 
     /**
      * @param int $offset The offset from the current record
-     * @return bool
+     * @return int|bool
      */
     private function getAdjacentRecordID($offset)
     {
-        $gridField = $this->gridField;
+        $gridField = $this->getGridField();
         $gridStateStr = $this->getRequest()->requestVar('gridState');
         $state = $gridField->getState(false);
         $state->setValue($gridStateStr);
-
         $data = $state->getData();
+        $paginator = $data->getData('GridFieldPaginator');
+        if (!$paginator) {
+            return false;
+        }
+
         $currentPage = $data->getData('GridFieldPaginator')->getData('currentPage');
         $itemsPerPage = $data->getData('GridFieldPaginator')->getData('itemsPerPage');
 

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -503,7 +503,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      */
     public function doNew($data, $form)
     {
-        return Controller::curr()->redirect($this->Link('addnew'));
+        return Controller::curr()->redirect(Controller::join_links($this->gridField->Link("item"), "new"));
     }
 
     /**

--- a/src/Forms/GridField/GridFieldEditButton.php
+++ b/src/Forms/GridField/GridFieldEditButton.php
@@ -62,7 +62,12 @@ class GridFieldEditButton implements GridField_ColumnProvider, GridField_ActionP
      */
     public function getUrl($gridField, $record, $columnName)
     {
-        return Controller::join_links($gridField->Link('item'), $record->ID, 'edit');
+        return Controller::join_links(
+            $gridField->Link('item'),
+            $record->ID,
+            'edit',
+            '?gridState=' . urlencode($gridField->getState(false)->Value())
+        );
     }
 
     /**

--- a/src/Forms/GridField/GridFieldPaginator.php
+++ b/src/Forms/GridField/GridFieldPaginator.php
@@ -144,6 +144,7 @@ class GridFieldPaginator implements GridField_HTMLProvider, GridField_DataManipu
 
         // Force the state to the initial page if none is set
         $state->currentPage(1);
+        $state->itemsPerPage($this->getItemsPerPage());
 
         return $state;
     }


### PR DESCRIPTION
This adds `Previous`, `Next` and `Add` buttons to the edit form. It should also retain the search filters from the grid field where it was opened from.

Fixes #436