### PR TITLE
API LoginForm::authentiator_class is now deprecated, use getters or setters instead

### DIFF
--- a/.upgrade.yml
+++ b/.upgrade.yml
@@ -1325,6 +1325,8 @@ warnings:
       replacement: 'writeJavascriptToBody'
     'SilverStripe\Forms\Formfield->dontEscape':
       message: 'FormField::$dontEscape has been removed. Escaping is now managed on a class by class basis.'
+    'SilverStripe\Security\LoginForm->authenticator_class':
+      message: 'authenticator_class is deprecated. Use getAuthenticatorClass/setAuthenticatorClass.'
     'SilverStripe\Security\Permission::$declared_permissions':
       message: 'Deprecated'
     'SilverStripe\Security\Permission::$declared_permissions_list':

--- a/src/Security/LoginForm.php
+++ b/src/Security/LoginForm.php
@@ -15,24 +15,46 @@ use SilverStripe\Forms\Form;
  */
 abstract class LoginForm extends Form
 {
-
     /**
-     * Authenticator class to use with this login form
-     *
-     * Set this variable to the authenticator class to use with this login
-     * form.
+     * @deprecated 4.4.0:5.0.0 Use getAuthenticatorClass() or setAuthenticatorClass() instead
      * @var string
      */
     protected $authenticator_class;
 
+    /**
+     * Authenticator class to use with this login form
+     *
+     * Set this variable to the authenticator class to use with this login form.
+     *
+     * @var string
+     */
+    protected $authenticatorClass;
+
+    /**
+     * Set the authenticator class name to use
+     *
+     * @param string $class
+     * @return $this
+     */
     public function setAuthenticatorClass($class)
     {
-        $this->authenticator_class = $class;
+        $this->authenticatorClass = $class;
         $authenticatorField = $this->Fields()->dataFieldByName('AuthenticationMethod');
         if ($authenticatorField) {
             $authenticatorField->setValue($class);
         }
         return $this;
+    }
+
+    /**
+     * Returns the authenticator class name to use
+     *
+     * @return string
+     */
+    public function getAuthenticatorClass()
+    {
+        // B/C for deprecated authenticator_class property
+        return $this->authenticator_class ?: $this->authenticatorClass;
     }
 
     /**

--- a/src/Security/LoginForm.php
+++ b/src/Security/LoginForm.php
@@ -39,10 +39,18 @@ abstract class LoginForm extends Form
     public function setAuthenticatorClass($class)
     {
         $this->authenticatorClass = $class;
-        $authenticatorField = $this->Fields()->dataFieldByName('AuthenticationMethod');
+
+        /** @var FieldList|null $fields */
+        $fields = $this->Fields();
+        if (!$fields) {
+            return $this;
+        }
+
+        $authenticatorField = $fields->dataFieldByName('AuthenticationMethod');
         if ($authenticatorField) {
             $authenticatorField->setValue($class);
         }
+
         return $this;
     }
 

--- a/src/Security/MemberAuthenticator/CMSMemberLoginForm.php
+++ b/src/Security/MemberAuthenticator/CMSMemberLoginForm.php
@@ -30,7 +30,7 @@ class CMSMemberLoginForm extends MemberLoginForm
     {
         $this->controller = $controller;
 
-        $this->authenticator_class = $authenticatorClass;
+        $this->setAuthenticatorClass($authenticatorClass);
 
         $fields = $this->getFormFields();
 
@@ -48,7 +48,7 @@ class CMSMemberLoginForm extends MemberLoginForm
     {
         // Set default fields
         $fields = FieldList::create([
-            HiddenField::create("AuthenticationMethod", null, $this->authenticator_class, $this),
+            HiddenField::create("AuthenticationMethod", null, $this->getAuthenticatorClass(), $this),
             HiddenField::create('tempid', null, $this->controller->getRequest()->requestVar('tempid')),
             PasswordField::create("Password", _t('SilverStripe\\Security\\Member.PASSWORD', 'Password'))
         ]);

--- a/src/Security/MemberAuthenticator/MemberLoginForm.php
+++ b/src/Security/MemberAuthenticator/MemberLoginForm.php
@@ -77,7 +77,7 @@ class MemberLoginForm extends BaseLoginForm
         $checkCurrentUser = true
     ) {
         $this->setController($controller);
-        $this->authenticator_class = $authenticatorClass;
+        $this->setAuthenticatorClass($authenticatorClass);
 
         $customCSS = project() . '/css/member_login.css';
         if (Director::fileExists($customCSS)) {
@@ -88,7 +88,7 @@ class MemberLoginForm extends BaseLoginForm
             // @todo find a more elegant way to handle this
             $logoutAction = Security::logout_url();
             $fields = FieldList::create(
-                HiddenField::create('AuthenticationMethod', null, $this->authenticator_class, $this)
+                HiddenField::create('AuthenticationMethod', null, $this->getAuthenticatorClass(), $this)
             );
             $actions = FieldList::create(
                 FormAction::create('logout', _t(
@@ -133,7 +133,7 @@ class MemberLoginForm extends BaseLoginForm
 
         $label = Member::singleton()->fieldLabel(Member::config()->get('unique_identifier_field'));
         $fields = FieldList::create(
-            HiddenField::create("AuthenticationMethod", null, $this->authenticator_class, $this),
+            HiddenField::create("AuthenticationMethod", null, $this->getAuthenticatorClass(), $this),
             // Regardless of what the unique identifer field is (usually 'Email'), it will be held in the
             // 'Email' value, below:
             // @todo Rename the field to a more generic covering name


### PR DESCRIPTION
This pull request deprecates the protected `$authenticator_class` property (since it's not PSR-2 compliant) and replaces it with an `$authenticatorClass` property. It also adds a getter so that implementations don't need to set the property directly.