### PR TITLE
Update Configure_Nginx.md

### DIFF
--- a/docs/en/00_Getting_Started/01_Installation/How_To/Configure_Nginx.md
+++ b/docs/en/00_Getting_Started/01_Installation/How_To/Configure_Nginx.md
@@ -48,8 +48,17 @@ server {
   error_page 503 /assets/error-500.html;
 
   location ^~ /assets/ {
-    sendfile on;
-    try_files $uri =404;
+      sendfile on;
+      try_files $uri =404;
+      rewrite ^(.*)$ /index.php;
+  }
+
+  location ~ /assets/[^.]*\.(?i:css|js|ace|arc|arj|asf|au|avi|bmp|bz2|cab|cda|csv|dmg|doc|docx|dotx|flv|gif|gpx|gz|hqx|ico|jpeg|jpg|kml|m4a|m4v|mid|midi|mkv|mov|mp3|mp4|mpa|mpeg|mpg|ogg|ogv|pages|pcx|pdf|png|pps|ppt|pptx|potx|ra|ram|rm|rtf|sit|sitx|tar|tgz|tif|tiff|txt|wav|webm|wma|wmv|xls|xlsx|xltx|zip|zipx|css|svg|graphql)$ {
+      return 400;
+  }
+
+  location ~ ^/assets/(.*)$ {
+      return 403;
   }
 
   location /index.php {


### PR DESCRIPTION
The current config does not take into account serving draft assets from ./protected (the framework generates the required .htaccess files, but nginx needs additional rules).

This config should now mean that draft images have their preview versions shown in the CMS rather than displaying 404s.

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/