### PR TITLE
FIX Move password complexity requirements into framework

### DIFF
--- a/_config/passwords.yml
+++ b/_config/passwords.yml
@@ -1,0 +1,13 @@
+---
+Name: corepasswords
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Security\PasswordValidator:
+    properties:
+      MinLength: 8
+      HistoricCount: 6
+
+# In the case someone uses `new PasswordValidator` instead of Injector, provide some safe defaults through config.
+SilverStripe\Security\PasswordValidator:
+  min_length: 8
+  historic_count: 6


### PR DESCRIPTION
The contents of this file are not extensible, so I'm proposing we move it into framework YAML config

Issue: https://github.com/silverstripe/cwp-core/issues/52

Requires recipe-core: https://github.com/silverstripe/recipe-core/pull/34