### PR TITLE
Ensure that decimal DB values are fetched as floats

### DIFF
--- a/src/ORM/Connect/MySQLQuery.php
+++ b/src/ORM/Connect/MySQLQuery.php
@@ -4,6 +4,7 @@ namespace SilverStripe\ORM\Connect;
 
 /**
  * A result-set from a MySQL database (using MySQLiConnector)
+ * Note that this class is only used for the results of non-prepared statements
  */
 class MySQLQuery extends Query
 {
@@ -18,6 +19,11 @@ class MySQLQuery extends Query
     protected $handle;
 
     /**
+     * Metadata about the columns of this query
+     */
+    protected $columns;
+
+    /**
      * Hook the result-set given into a Query class, suitable for use by SilverStripe.
      *
      * @param MySQLiConnector $database The database object that created this query.
@@ -27,6 +33,9 @@ class MySQLQuery extends Query
     public function __construct($database, $handle)
     {
         $this->handle = $handle;
+        if (is_object($this->handle)) {
+            $this->columns = $this->handle->fetch_fields();
+        }
     }
 
     public function __destruct()
@@ -40,7 +49,7 @@ class MySQLQuery extends Query
     {
         if (is_object($this->handle)) {
             $this->handle->data_seek($row);
-            return $this->handle->fetch_assoc();
+            return $this->nextRecord();
         }
         return null;
     }
@@ -55,7 +64,19 @@ class MySQLQuery extends Query
 
     public function nextRecord()
     {
-        if (is_object($this->handle) && ($data = $this->handle->fetch_assoc())) {
+        $floatTypes = [MYSQLI_TYPE_FLOAT, MYSQLI_TYPE_DOUBLE, MYSQLI_TYPE_DECIMAL, MYSQLI_TYPE_NEWDECIMAL];
+
+        if (is_object($this->handle) && ($row = $this->handle->fetch_array(MYSQLI_NUM))) {
+            $data = [];
+            foreach ($row as $i => $value) {
+                if (!isset($this->columns[$i])) {
+                    throw new DatabaseException("Can't get metadata for column $i");
+                }
+                if (in_array($this->columns[$i]->type, $floatTypes)) {
+                    $value = (float)$value;
+                }
+                $data[$this->columns[$i]->name] = $value;
+            }
             return $data;
         } else {
             return false;

--- a/src/ORM/Connect/PDOConnector.php
+++ b/src/ORM/Connect/PDOConnector.php
@@ -427,7 +427,7 @@ class PDOConnector extends DBConnector implements TransactionManager
         } elseif ($statement) {
             // Count and return results
             $this->rowCount = $statement->rowCount();
-            return new PDOQuery($statement, $this);
+            return new PDOQuery($statement);
         }
 
         // Ensure statement is closed

--- a/src/ORM/Connect/PDOQuery.php
+++ b/src/ORM/Connect/PDOQuery.php
@@ -18,33 +18,42 @@ class PDOQuery extends Query
 
     protected $results = null;
 
+    protected static $type_mapping = [
+        // PGSQL
+        'float8' => 'float',
+        'float16' => 'float',
+        'numeric' => 'float',
+
+        // MySQL
+        'NEWDECIMAL' => 'float',
+
+        // SQlite
+        'integer' => 'int',
+        'double' => 'float',
+    ];
+
     /**
      * Hook the result-set given into a Query class, suitable for use by SilverStripe.
      * @param PDOStatement $statement The internal PDOStatement containing the results
      */
-    public function __construct(PDOStatement $statement, PDOConnector $conn)
+    public function __construct(PDOStatement $statement)
     {
         $this->statement = $statement;
         // Since no more than one PDOStatement for any one connection can be safely
         // traversed, each statement simply requests all rows at once for safety.
         // This could be re-engineered to call fetchAll on an as-needed basis
 
-        // Special case for Postgres
-        if ($conn->getDriver() == 'pgsql') {
-            $this->results = $this->fetchAllPgsql($statement);
-        } else {
-            $this->results = $statement->fetchAll(PDO::FETCH_ASSOC);
-        }
+        $this->results = $this->typeCorrectedFetchAll($statement);
+
         $statement->closeCursor();
     }
 
     /**
      * Fetch a record form the statement with its type data corrected
-     * Necessary to fix float data retrieved from PGSQL
      * Returns data as an array of maps
      * @return array
      */
-    protected function fetchAllPgsql($statement)
+    protected function typeCorrectedFetchAll($statement)
     {
         $columnCount = $statement->columnCount();
         $columnMeta = [];
@@ -57,10 +66,9 @@ class PDOQuery extends Query
             function ($rowArray) use ($columnMeta) {
                 $row = [];
                 foreach ($columnMeta as $i => $meta) {
-                    // Coerce floats from string to float
-                    // PDO PostgreSQL fails to do this
-                    if (isset($meta['native_type']) && strpos($meta['native_type'], 'float') === 0) {
-                        $rowArray[$i] = (float)$rowArray[$i];
+                    // Coerce any column types that aren't correctly retrieved from the database
+                    if (isset($meta['native_type']) && isset(self::$type_mapping[$meta['native_type']])) {
+                        settype($rowArray[$i], self::$type_mapping[$meta['native_type']]);
                     }
                     $row[$meta['name']] = $rowArray[$i];
                 }

--- a/src/ORM/Connect/PDOQuery.php
+++ b/src/ORM/Connect/PDOQuery.php
@@ -2,80 +2,28 @@
 
 namespace SilverStripe\ORM\Connect;
 
-use PDOStatement;
-use PDO;
-
 /**
  * A result-set from a PDO database.
  */
 class PDOQuery extends Query
 {
     /**
-     * The internal MySQL handle that points to the result set.
-     * @var PDOStatement
+     * @var array
      */
-    protected $statement = null;
-
     protected $results = null;
-
-    protected static $type_mapping = [
-        // PGSQL
-        'float8' => 'float',
-        'float16' => 'float',
-        'numeric' => 'float',
-
-        // MySQL
-        'NEWDECIMAL' => 'float',
-
-        // SQlite
-        'integer' => 'int',
-        'double' => 'float',
-    ];
 
     /**
      * Hook the result-set given into a Query class, suitable for use by SilverStripe.
      * @param PDOStatement $statement The internal PDOStatement containing the results
      */
-    public function __construct(PDOStatement $statement)
+    public function __construct(PDOStatementHandle $statement)
     {
-        $this->statement = $statement;
         // Since no more than one PDOStatement for any one connection can be safely
         // traversed, each statement simply requests all rows at once for safety.
         // This could be re-engineered to call fetchAll on an as-needed basis
 
-        $this->results = $this->typeCorrectedFetchAll($statement);
-
+        $this->results = $statement->typeCorrectedFetchAll();
         $statement->closeCursor();
-    }
-
-    /**
-     * Fetch a record form the statement with its type data corrected
-     * Returns data as an array of maps
-     * @return array
-     */
-    protected function typeCorrectedFetchAll($statement)
-    {
-        $columnCount = $statement->columnCount();
-        $columnMeta = [];
-        for ($i = 0; $i<$columnCount; $i++) {
-            $columnMeta[$i] = $statement->getColumnMeta($i);
-        }
-
-        // Re-map fetched data using columnMeta
-        return array_map(
-            function ($rowArray) use ($columnMeta) {
-                $row = [];
-                foreach ($columnMeta as $i => $meta) {
-                    // Coerce any column types that aren't correctly retrieved from the database
-                    if (isset($meta['native_type']) && isset(self::$type_mapping[$meta['native_type']])) {
-                        settype($rowArray[$i], self::$type_mapping[$meta['native_type']]);
-                    }
-                    $row[$meta['name']] = $rowArray[$i];
-                }
-                return $row;
-            },
-            $statement->fetchAll(PDO::FETCH_NUM)
-        );
     }
 
     public function seek($row)

--- a/src/ORM/Connect/PDOStatementHandle.php
+++ b/src/ORM/Connect/PDOStatementHandle.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace SilverStripe\ORM\Connect;
+
+use PDO;
+use PDOStatement;
+
+/**
+ * A handle to a PDOStatement, with cached column metadata, and type conversion
+ *
+ * Column metadata can't be fetched from a native PDOStatement after multiple calls in some DB backends,
+ * so we wrap in this handle object, which also takes care of tidying up content types to keep in line
+ * with the SilverStripe 4.4+ type expectations.
+ */
+class PDOStatementHandle
+{
+
+    /**
+     * The statement to provide a handle to
+     *
+     * @var PDOStatement
+     */
+    private $statement;
+
+    /**
+     * Cached column metadata
+     *
+     * @var array
+     */
+    private $columnMeta = null;
+
+    /**
+     * Create a new handle.
+     *
+     * @param $statement The statement to provide a handle to
+     */
+    public function __construct(PDOStatement $statement)
+    {
+        $this->statement = $statement;
+    }
+
+    /**
+     * Mapping of PDO-reported "native types" to PHP types
+     */
+    protected static $type_mapping = [
+        // PGSQL
+        'float8' => 'float',
+        'float16' => 'float',
+        'numeric' => 'float',
+
+        // MySQL
+        'NEWDECIMAL' => 'float',
+
+        // SQlite
+        'integer' => 'int',
+        'double' => 'float',
+    ];
+
+    /**
+     * Fetch a record form the statement with its type data corrected
+     * Returns data as an array of maps
+     * @return array
+     */
+    public function typeCorrectedFetchAll()
+    {
+        if ($this->columnMeta === null) {
+            $columnCount = $this->statement->columnCount();
+            $this->columnMeta = [];
+            for ($i = 0; $i<$columnCount; $i++) {
+                $this->columnMeta[$i] = $this->statement->getColumnMeta($i);
+            }
+        }
+
+        // Re-map fetched data using columnMeta
+        return array_map(
+            function ($rowArray) {
+                $row = [];
+                foreach ($this->columnMeta as $i => $meta) {
+                    // Coerce any column types that aren't correctly retrieved from the database
+                    if (isset($meta['native_type']) && isset(self::$type_mapping[$meta['native_type']])) {
+                        settype($rowArray[$i], self::$type_mapping[$meta['native_type']]);
+                    }
+                    $row[$meta['name']] = $rowArray[$i];
+                }
+                return $row;
+            },
+            $this->statement->fetchAll(PDO::FETCH_NUM)
+        );
+    }
+
+    /**
+     * Closes the cursor, enabling the statement to be executed again (PDOStatement::closeCursor)
+     *
+     * @return bool Returns true on success
+     */
+    public function closeCursor()
+    {
+        return $this->statement->closeCursor();
+    }
+
+    /**
+     * Fetch the SQLSTATE associated with the last operation on the statement handle
+     * (PDOStatement::errorCode)
+     *
+     * @return string
+     */
+    public function errorCode()
+    {
+        return $this->statement->errorCode();
+    }
+
+    /**
+     * Fetch extended error information associated with the last operation on the statement handle
+     * (PDOStatement::errorInfo)
+     *
+     * @return array
+     */
+    public function errorInfo()
+    {
+        return $this->statement->errorInfo();
+    }
+
+    /**
+     * Returns the number of rows affected by the last SQL statement (PDOStatement::rowCount)
+     *
+     * @return int
+     */
+    public function rowCount()
+    {
+        return $this->statement->rowCount();
+    }
+
+    /**
+     * Executes a prepared statement (PDOStatement::execute)
+     *
+     * @param $parameters An array of values with as many elements as there are bound parameters in the SQL statement
+     *                    being executed
+     * @return bool Returns true on success
+     */
+    public function execute(array $parameters)
+    {
+        return $this->statement->execute($parameters);
+    }
+
+    /**
+     * Return the PDOStatement that this object provides a handle to
+     *
+     * @return PDOStatement
+     */
+    public function getPDOStatement()
+    {
+        return $this->statement;
+    }
+}

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -11,6 +11,7 @@ use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Filterable;
 use SilverStripe\ORM\Filters\ExactMatchFilter;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\Tests\DataObjectTest\Fixture;
 use SilverStripe\ORM\Tests\DataObjectTest\Bracket;
 use SilverStripe\ORM\Tests\DataObjectTest\EquipmentCompany;
 use SilverStripe\ORM\Tests\DataObjectTest\Fan;
@@ -938,6 +939,27 @@ class DataListTest extends SapphireTest
             'ID:GreaterThan' => 0,
         ));
         $this->assertCount(4, $list);
+    }
+
+    public function testFilterAnyWithTwoGreaterThanFilters()
+    {
+
+        for ($i=1; $i<=3; $i++) {
+            $f = new Fixture();
+            $f->MyDecimal = $i;
+            $f->write();
+
+            $f = new Fixture();
+            $f->MyInt = $i;
+            $f->write();
+        }
+
+        $list = Fixture::get()->filterAny([
+            'MyDecimal:GreaterThan' => 1, // 2 records
+            'MyInt:GreaterThan' => 2, // 1 record
+        ]);
+
+        $this->assertCount(3, $list);
     }
 
     public function testFilterAnyMultipleArray()

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -1932,8 +1932,34 @@ class DataObjectTest extends SapphireTest
     {
         $obj = new DataObjectTest\Fixture();
         $obj->write();
-        
+
         $this->assertInternalType("int", $obj->ID);
+    }
+
+    /**
+     * Tests that zero values are returned with the correct types
+     */
+    public function testZeroIsFalse()
+    {
+        $obj = new DataObjectTest\Fixture();
+        $obj->MyInt = 0;
+        $obj->MyDecimal = 0.00;
+        $obj->MyCurrency = 0.00;
+        $obj->write();
+
+        $this->assertEquals(0, $obj->MyInt, 'DBInt fields should be integer on first assignment');
+        $this->assertEquals(0.00, $obj->MyDecimal, 'DBDecimal fields should be float on first assignment');
+        $this->assertEquals(0.00, $obj->MyCurrency, 'DBCurrency fields should be float on first assignment');
+
+        $obj2 = DataObjectTest\Fixture::get()->byId($obj->ID);
+
+        $this->assertEquals(0, $obj2->MyInt, 'DBInt fields should be integer');
+        $this->assertEquals(0.00, $obj2->MyDecimal, 'DBDecimal fields should be float');
+        $this->assertEquals(0.00, $obj2->MyCurrency, 'DBCurrency fields should be float');
+
+        $this->assertFalse((bool)$obj2->MyInt, 'DBInt zero fields should be falsey on fetch from DB');
+        $this->assertFalse((bool)$obj2->MyDecimal, 'DBDecimal zero fields should be falsey on fetch from DB');
+        $this->assertFalse((bool)$obj2->MyCurrency, 'DBCurrency zero fields should be falsey on fetch from DB');
     }
 
     public function testTwoSubclassesWithTheSameFieldNameWork()

--- a/tests/php/ORM/DataObjectTest/Fixture.php
+++ b/tests/php/ORM/DataObjectTest/Fixture.php
@@ -20,7 +20,11 @@ class Fixture extends DataObject implements TestOnly
         'DatetimeField' => 'Datetime',
 
         'MyFieldWithDefault' => 'Varchar',
-        'MyFieldWithAltDefault' => 'Varchar'
+        'MyFieldWithAltDefault' => 'Varchar',
+
+        'MyInt' => 'Int',
+        'MyCurrency' => 'Currency',
+        'MyDecimal'=> 'Decimal',
     );
 
     private static $defaults = array(

--- a/tests/php/ORM/DatabaseTest.php
+++ b/tests/php/ORM/DatabaseTest.php
@@ -194,6 +194,9 @@ class DatabaseTest extends SapphireTest
         $obj->MyField = "value";
         $obj->MyInt = 5;
         $obj->MyFloat = 6.0;
+
+        // Note: in non-PDO SQLite, whole numbers of a decimal field will be returned as integers rather than floats
+        $obj->MyDecimal = 7.1;
         $obj->MyBoolean = true;
         $obj->write();
 
@@ -203,20 +206,40 @@ class DatabaseTest extends SapphireTest
         )->record();
 
         // IDs and ints are returned as ints
-        $this->assertInternalType('int', $record['ID']);
-        $this->assertInternalType('int', $record['MyInt']);
+        $this->assertInternalType('int', $record['ID'], 'Primary key should be integer');
+        $this->assertInternalType('int', $record['MyInt'], 'DBInt fields should be integer');
 
-        $this->assertInternalType('float', $record['MyFloat']);
+        $this->assertInternalType('float', $record['MyFloat'], 'DBFloat fields should be float');
+        $this->assertInternalType('float', $record['MyDecimal'], 'DBDecimal fields should be float');
 
         // Booleans are returned as ints – we follow MySQL's lead
-        $this->assertInternalType('int', $record['MyBoolean']);
+        $this->assertInternalType('int', $record['MyBoolean'], 'DBBoolean fields should be int');
 
         // Strings and enums are returned as strings
-        $this->assertInternalType('string', $record['MyField']);
-        $this->assertInternalType('string', $record['ClassName']);
+        $this->assertInternalType('string', $record['MyField'], 'DBVarchar fields should be string');
+        $this->assertInternalType('string', $record['ClassName'], 'DBEnum fields should be string');
 
         // Dates are returned as strings
-        $this->assertInternalType('string', $record['Created']);
-        $this->assertInternalType('string', $record['LastEdited']);
+        $this->assertInternalType('string', $record['Created'], 'DBDatetime fields should be string');
+
+        // Ensure that the same is true when using non-prepared statements
+        $record = DB::query('SELECT * FROM "DatabaseTest_MyObject" WHERE "ID" = ' . (int)$obj->ID)->record();
+
+        // IDs and ints are returned as ints
+        $this->assertInternalType('int', $record['ID'], 'Primary key should be integer');
+        $this->assertInternalType('int', $record['MyInt'], 'DBInt fields should be integer');
+
+        $this->assertInternalType('float', $record['MyFloat'], 'DBFloat fields should be float');
+        $this->assertInternalType('float', $record['MyDecimal'], 'DBDecimal fields should be float');
+
+        // Booleans are returned as ints – we follow MySQL's lead
+        $this->assertInternalType('int', $record['MyBoolean'], 'DBBoolean fields should be int');
+
+        // Strings and enums are returned as strings
+        $this->assertInternalType('string', $record['MyField'], 'DBVarchar fields should be string');
+        $this->assertInternalType('string', $record['ClassName'], 'DBEnum fields should be string');
+
+        // Dates are returned as strings
+        $this->assertInternalType('string', $record['Created'], 'DBDatetime fields should be string');
     }
 }

--- a/tests/php/ORM/DatabaseTest.php
+++ b/tests/php/ORM/DatabaseTest.php
@@ -222,24 +222,50 @@ class DatabaseTest extends SapphireTest
         // Dates are returned as strings
         $this->assertInternalType('string', $record['Created'], 'DBDatetime fields should be string');
 
+
+        // Ensure that the same is true when calling a query a second time (cached prepared statement)
+
+        $record = DB::prepared_query(
+            'SELECT * FROM "DatabaseTest_MyObject" WHERE "ID" = ?',
+            [ $obj->ID ]
+        )->record();
+
+        // IDs and ints are returned as ints
+        $this->assertInternalType('int', $record['ID'], 'Primary key should be integer (2nd call)');
+        $this->assertInternalType('int', $record['MyInt'], 'DBInt fields should be integer (2nd call)');
+
+        $this->assertInternalType('float', $record['MyFloat'], 'DBFloat fields should be float (2nd call)');
+        $this->assertInternalType('float', $record['MyDecimal'], 'DBDecimal fields should be float (2nd call)');
+
+        // Booleans are returned as ints – we follow MySQL's lead
+        $this->assertInternalType('int', $record['MyBoolean'], 'DBBoolean fields should be int (2nd call)');
+
+        // Strings and enums are returned as strings
+        $this->assertInternalType('string', $record['MyField'], 'DBVarchar fields should be string (2nd call)');
+        $this->assertInternalType('string', $record['ClassName'], 'DBEnum fields should be string (2nd call)');
+
+        // Dates are returned as strings
+        $this->assertInternalType('string', $record['Created'], 'DBDatetime fields should be string (2nd call)');
+
+
         // Ensure that the same is true when using non-prepared statements
         $record = DB::query('SELECT * FROM "DatabaseTest_MyObject" WHERE "ID" = ' . (int)$obj->ID)->record();
 
         // IDs and ints are returned as ints
-        $this->assertInternalType('int', $record['ID'], 'Primary key should be integer');
-        $this->assertInternalType('int', $record['MyInt'], 'DBInt fields should be integer');
+        $this->assertInternalType('int', $record['ID'], 'Primary key should be integer (non-prepared)');
+        $this->assertInternalType('int', $record['MyInt'], 'DBInt fields should be integer (non-prepared)');
 
-        $this->assertInternalType('float', $record['MyFloat'], 'DBFloat fields should be float');
-        $this->assertInternalType('float', $record['MyDecimal'], 'DBDecimal fields should be float');
+        $this->assertInternalType('float', $record['MyFloat'], 'DBFloat fields should be float (non-prepared)');
+        $this->assertInternalType('float', $record['MyDecimal'], 'DBDecimal fields should be float (non-prepared)');
 
         // Booleans are returned as ints – we follow MySQL's lead
-        $this->assertInternalType('int', $record['MyBoolean'], 'DBBoolean fields should be int');
+        $this->assertInternalType('int', $record['MyBoolean'], 'DBBoolean fields should be int (non-prepared)');
 
         // Strings and enums are returned as strings
-        $this->assertInternalType('string', $record['MyField'], 'DBVarchar fields should be string');
-        $this->assertInternalType('string', $record['ClassName'], 'DBEnum fields should be string');
+        $this->assertInternalType('string', $record['MyField'], 'DBVarchar fields should be string (non-prepared)');
+        $this->assertInternalType('string', $record['ClassName'], 'DBEnum fields should be string (non-prepared)');
 
         // Dates are returned as strings
-        $this->assertInternalType('string', $record['Created'], 'DBDatetime fields should be string');
+        $this->assertInternalType('string', $record['Created'], 'DBDatetime fields should be string (non-prepared)');
     }
 }

--- a/tests/php/ORM/DatabaseTest/MyObject.php
+++ b/tests/php/ORM/DatabaseTest/MyObject.php
@@ -16,6 +16,7 @@ class MyObject extends DataObject implements TestOnly
         'MyField' => 'Varchar',
         'MyInt' => 'Int',
         'MyFloat' => 'Float',
+        'MyDecimal' => 'Decimal',
         'MyBoolean' => 'Boolean',
     );
 }


### PR DESCRIPTION
It turns out that the work from #8448 was incomplete in to important ways:

 * Decimal values (rather than Float) values are still being treated as strings
 * SQLite still had a number of bugs relating to this functionality (wasn't part of our test suite at the time of testing)

In order to fix this, most Query subclasses are going to end up with some value processing a la the code currently reserved for MySQL. Since I've added the tests for these issues to this branch I'll continue the work here.

---

Original ticket:

Validates that https://github.com/silverstripe/silverstripe-framework/issues/3473 has been fixed

The bug was fixed in #8448

I'm not sure how important it is to merge this test, but the more the merrier, I guess? ;-)