### PR TITLE
FIX Remove default password validation rules before running unit tests

### DIFF
--- a/tests/php/Security/PasswordValidatorTest.php
+++ b/tests/php/Security/PasswordValidatorTest.php
@@ -2,9 +2,9 @@
 
 namespace SilverStripe\Security\Tests;
 
-use SilverStripe\Security\PasswordValidator;
-use SilverStripe\Security\Member;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\PasswordValidator;
 
 class PasswordValidatorTest extends SapphireTest
 {
@@ -13,6 +13,16 @@ class PasswordValidatorTest extends SapphireTest
      * @var bool
      */
     protected $usesDatabase = true;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // Unset framework default values
+        PasswordValidator::config()
+            ->remove('min_length')
+            ->remove('historic_count');
+    }
 
     public function testValidate()
     {


### PR DESCRIPTION
I'm not sure why the tests didn't show up as broken in #8587, possibly because the recipe-core change wasn't made at that point.

The tests in the 4.3 broke after #8587 was merged, so this fixes them again.