### PR TITLE
DOCS fix link to XHProf article

### DIFF
--- a/docs/en/02_Developer_Guides/08_Performance/03_Profiling.md
+++ b/docs/en/02_Developer_Guides/08_Performance/03_Profiling.md
@@ -9,5 +9,5 @@ optimization.
 SilverStripe does not include any profiling tools out of the box, but we recommend the use of existing tools such as 
 [XHProf](https://github.com/facebook/xhprof/) and [XDebug](http://xdebug.org/).
 
-* [Profiling with XHProf](http://techportal.inviqa.com/2009/12/01/profiling-with-xhprof/)
+* [Profiling with XHProf](https://inviqa.com/blog/profiling-xhprof)
 * [Profiling PHP Applications With xdebug](http://devzone.zend.com/1139/profiling-php-applications-with-xdebug/)


### PR DESCRIPTION
Current link is a 404. Looks like this is the new URL for this resource