### PR TITLE
API Add a GenericList interface to encapsulate a list that is fitlerable, sortable, limitable

### DIFF
--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -24,7 +24,7 @@ use SilverStripe\Dev\Deprecation;
  *   - filter
  *   - exclude
  */
-class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, Limitable
+class ArrayList extends ViewableData implements GenericList
 {
 
     /**

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -32,7 +32,7 @@ use LogicException;
  *
  * Subclasses of DataList may add other methods that have the same effect.
  */
-class DataList extends ViewableData implements SS_List, Filterable, Sortable, Limitable
+class DataList extends ViewableData implements GenericList
 {
 
     /**

--- a/src/ORM/GenericList.php
+++ b/src/ORM/GenericList.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SilverStripe\ORM;
+
+/**
+ * A Generic implementation of `SS_List` with all related interface to enable filtering, sorting and limiting.
+ *
+ * @see SS_List, Sortable, Limitable, Filterable
+ */
+interface GenericList extends SS_List, Filterable, Sortable, Limitable
+{
+}

--- a/src/ORM/Relation.php
+++ b/src/ORM/Relation.php
@@ -13,7 +13,7 @@ use SilverStripe\ORM\FieldType\DBField;
  * @method Relation forForeignID($id)
  * @method string dataClass()
  */
-interface Relation extends SS_List, Filterable, Sortable, Limitable
+interface Relation extends GenericList
 {
 
     /**


### PR DESCRIPTION
This is admittedly a somewhat academic point, but there's quite a few places where we say we expect/return an `SS_List` when what we really mean is an `SS_List` that is `Filterable`, `Sortable` and/or `Limitable`.

I think we should be explicit and provide an interface that encapsulate all of those other interfaces.

Aside from the additional clarity it will also help with code completion.

I'm not overly fuss about that `GenericList` name. If someone can think of a more descriptive name, go for it.