### PR TITLE
FIX Explicity mark nodes when searching

### DIFF
--- a/src/Forms/TreeDropdownField.php
+++ b/src/Forms/TreeDropdownField.php
@@ -499,6 +499,17 @@ class TreeDropdownField extends FormField
         // Begin marking
         $markingSet->markPartialTree();
 
+        // Explicitely mark our search results if necessary
+        foreach ($this->searchIds as $id => $marked) {
+            if ($marked) {
+                $object = $this->objectForKey($id);
+                if (!$object) {
+                    continue;
+                }
+                $markingSet->markToExpose($object);
+            }
+        }
+
         // Allow to pass values to be selected within the ajax request
         $value = $request->requestVar('forceValue') ?: $this->value;
         if ($value && ($values = preg_split('/,\s*/', $value))) {

--- a/tests/php/Forms/TreeDropdownFieldTest.yml
+++ b/tests/php/Forms/TreeDropdownFieldTest.yml
@@ -8,6 +8,7 @@ SilverStripe\Assets\Folder:
   folder1-subfolder1:
     Name: FileTest-folder1-subfolder1
     ParentID: =>SilverStripe\Assets\Folder.folder1
+
 SilverStripe\Assets\File:
   asdf:
     Filename: assets/FileTest.txt
@@ -24,3 +25,40 @@ SilverStripe\Assets\File:
     Filename: assets/FileTest-folder1/File1.txt
     Name: File1.txt
     ParentID: =>SilverStripe\Assets\Folder.folder1
+
+SilverStripe\ORM\Tests\HierarchyTest\TestObject:
+  zero:
+    Title: Zero MatchSearchCriteria
+  zeroA:
+    Title: Child A of Zero
+    ParentID: =>SilverStripe\ORM\Tests\HierarchyTest\TestObject.zero
+  zeroB:
+    Title: Child B of Zero
+    ParentID: =>SilverStripe\ORM\Tests\HierarchyTest\TestObject.zero
+  zeroC:
+    Title: Child C of Zero
+    ParentID: =>SilverStripe\ORM\Tests\HierarchyTest\TestObject.zero
+  one:
+    Title: One
+  oneA:
+    Title: Child A of One MatchSearchCriteria
+    ParentID: =>SilverStripe\ORM\Tests\HierarchyTest\TestObject.one
+  oneB:
+    Title: Child B of One
+    ParentID: =>SilverStripe\ORM\Tests\HierarchyTest\TestObject.one
+  oneC:
+    Title: Child C of One
+    ParentID: =>SilverStripe\ORM\Tests\HierarchyTest\TestObject.one
+  oneD:
+    Title: Child C of One
+    ParentID: =>SilverStripe\ORM\Tests\HierarchyTest\TestObject.one
+  two:
+    Title: Two
+  twoA:
+    Title: Child A of Two
+    ParentID: =>SilverStripe\ORM\Tests\HierarchyTest\TestObject.two
+  twoAi:
+    Title: Grandchild i of Child A of Two MatchSearchCriteria
+    ParentID: =>SilverStripe\ORM\Tests\HierarchyTest\TestObject.twoA
+  three:
+    Title: Three MatchSearchCriteria


### PR DESCRIPTION
If you do a search in the `TreeDropdownField` and you have a fair number of results, some of your results might be missed because your MarkedSet will exceed it's `node_threshold_total`. To bypass this problem, I've updated `TreeDropdownField::tree()` to explicitly mark nodes returned via the search query. 

Arguably this could have been fix in `MarkedSet`, however I felt this tree method is somewhat of a special case: it flattens the tree results and provides a custom filter function. I think it makes more sense to adapt `TreeDropdownField` to work around a limitation of `MarkedSet` than to update `MarkedSet` around the special use case of `TreeDropdownField`.

This is required by our key project.