### PR TITLE
FIX Extensions inherited from parent classes should be retained when removing subclass extensions

### DIFF
--- a/src/Core/Extensible.php
+++ b/src/Core/Extensible.php
@@ -255,7 +255,6 @@ trait Extensible
             ) {
                 $found = true;
                 unset($config[$key]);
-                break;
             }
         }
         // Don't dirty cache if no changes

--- a/src/Core/Extensible.php
+++ b/src/Core/Extensible.php
@@ -245,9 +245,9 @@ trait Extensible
     {
         $class = get_called_class();
 
-        // Build filtered extension list
+        // Build extension list
         $found = false;
-        $config = Config::inst()->get($class, 'extensions', Config::EXCLUDE_EXTRA_SOURCES | Config::UNINHERITED) ?: [];
+        $config = Config::inst()->get($class, 'extensions') ?: [];
         foreach ($config as $key => $candidate) {
             // extensions with parameters will be stored in config as ExtensionName("Param").
             if (strcasecmp($candidate, $extension) === 0 ||
@@ -255,6 +255,7 @@ trait Extensible
             ) {
                 $found = true;
                 unset($config[$key]);
+                break;
             }
         }
         // Don't dirty cache if no changes

--- a/tests/php/Core/ObjectTest.php
+++ b/tests/php/Core/ObjectTest.php
@@ -329,6 +329,39 @@ class ObjectTest extends SapphireTest
         );
     }
 
+    public function testRemoveExtensionPreservesParentExtensions()
+    {
+        ObjectTest\ExtensionRemoveTestSubclass::add_extension(ExtendTest2::class);
+        $this->assertTrue(
+            ObjectTest\ExtensionRemoveTestSubclass::has_extension(ExtendTest1::class),
+            'Extensions should be inherited from parent classes'
+        );
+        $this->assertTrue(
+            ObjectTest\ExtensionRemoveTestSubclass::has_extension(ExtendTest2::class),
+            'Extensions added to a subclass should be registered to the subclass'
+        );
+
+        ObjectTest\ExtensionRemoveTestSubclass::remove_extension(ExtendTest2::class);
+        $this->assertTrue(
+            ObjectTest\ExtensionRemoveTestSubclass::has_extension(ExtendTest1::class),
+            'Non-specified extensions inherited from a parent class should not be removed from subclass'
+        );
+        $this->assertFalse(
+            ObjectTest\ExtensionRemoveTestSubclass::has_extension(ExtendTest2::class),
+            'Specified extensions should be removed from specified class'
+        );
+
+        ObjectTest\ExtensionRemoveTestSubclass::remove_extension(ExtendTest1::class);
+        $this->assertFalse(
+            ObjectTest\ExtensionRemoveTestSubclass::has_extension(ExtendTest1::class),
+            'Specified extensions inherited from parent class should be removed from specified class'
+        );
+        $this->assertTrue(
+            ObjectTest\ExtensionRemoveTest::has_extension(ExtendTest1::class),
+            'Parent class should still have an extension that is removed from its children'
+        );
+    }
+
     public function testRemoveExtensionWithParameters()
     {
         ObjectTest\ExtensionRemoveTest::add_extension(ExtendTest2::class . '("MyParam")');

--- a/tests/php/Core/ObjectTest/ExtensionRemoveTestSubclass.php
+++ b/tests/php/Core/ObjectTest/ExtensionRemoveTestSubclass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace SilverStripe\Core\Tests\ObjectTest;
+
+class ExtensionRemoveTestSubclass extends ExtensionRemoveTest
+{
+
+}


### PR DESCRIPTION
The test added in this PR shows the bug is valid. From my testing I could see that by the time the delta config change is applied to the subclass to remove some extension, the inherited list of extensions including parent extensions has been merged and normalised on the class config. This means that when we only ask for the uninherited extensions in `remove_extension()` and set the new config array back again, we overwrite any parent extensions.

Fixes #8613