### PR TITLE
FIX Provide alternatives to session for storing GridField_FormAction state

### DIFF
--- a/_config/gridfield.yml
+++ b/_config/gridfield.yml
@@ -1,0 +1,6 @@
+---
+Name: gridfieldconfig
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Forms\GridField\FormAction\StateStore:
+    class: SilverStripe\Forms\GridField\FormAction\SessionStore

--- a/docs/en/02_Developer_Guides/03_Forms/Field_types/04_GridField.md
+++ b/docs/en/02_Developer_Guides/03_Forms/Field_types/04_GridField.md
@@ -472,10 +472,28 @@ functionality. See [How to Create a GridFieldComponent](../how_tos/create_a_grid
 
 ## Saving the GridField State
 
-`GridState` is a class that is used to contain the current state and actions on the `GridField`. It's transfered 
+`GridState` is a class that is used to contain the current state and actions on the `GridField`. It's transferred 
 between page requests by being inserted as a hidden field in the form.
 
 The `GridState_Component` sets and gets data from the `GridState`.
+
+## Saving GridField_FormAction state
+
+By default state used for performing form actions is saved in the session and tagged with a key like `gf_abcd1234`. In 
+some cases session may not be an appropriate storage method. The storage method can be configured:
+
+```yaml
+Name: mysitegridfieldconfig
+After: gridfieldconfig
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Forms\GridField\FormAction\StateStore:
+    class: SilverStripe\Forms\GridField\FormAction\AttributeStore
+```
+
+The `AttributeStore` class configures action state to be stored in the DOM and sent back on the request that performs 
+the action. Custom storage methods can be created and used by implementing the `StateStore` interface and configuring 
+`Injector` in a similar fasion.
 
 ## API Documentation
 

--- a/docs/en/02_Developer_Guides/03_Forms/Field_types/04_GridField.md
+++ b/docs/en/02_Developer_Guides/03_Forms/Field_types/04_GridField.md
@@ -493,7 +493,7 @@ SilverStripe\Core\Injector\Injector:
 
 The `AttributeStore` class configures action state to be stored in the DOM and sent back on the request that performs 
 the action. Custom storage methods can be created and used by implementing the `StateStore` interface and configuring 
-`Injector` in a similar fasion.
+`Injector` in a similar fashion.
 
 ## API Documentation
 

--- a/docs/en/04_Changelogs/4.3.0.md
+++ b/docs/en/04_Changelogs/4.3.0.md
@@ -8,6 +8,7 @@
  - New React-based search UI for the CMS, Asset-Admin, GridFields and ModelAdmins.
  - A new `GridFieldLazyLoader` component can be added to `GridField`. This will delay the fetching of data until the user access the container Tab of the GridField.
  - `SilverStripe\VersionedAdmin\Controllers\CMSPageHistoryViewerController` is now the default CMS history controller and `SilverStripe\CMS\Controllers\CMSPageHistoryController` has been deprecated.
+ - It's now possible to avoid storing GridField data in session. See [the documentation on GridField](../developer_guides/forms/field_types/gridfield/#saving-the-gridfield-state).
 
 ## Upgrading {#upgrading}
 

--- a/src/Forms/GridField/FormAction/AbstractRequestAwareStore.php
+++ b/src/Forms/GridField/FormAction/AbstractRequestAwareStore.php
@@ -3,7 +3,7 @@ namespace SilverStripe\Forms\GridField\FormAction;
 
 use SilverStripe\Control\HTTPRequest;
 
-abstract class AbstractRequestAwareStore
+abstract class AbstractRequestAwareStore implements StateStore
 {
     private static $dependencies = [
         'request' => '%$' . HTTPRequest::class,

--- a/src/Forms/GridField/FormAction/AbstractRequestAwareStore.php
+++ b/src/Forms/GridField/FormAction/AbstractRequestAwareStore.php
@@ -1,34 +1,17 @@
 <?php
 namespace SilverStripe\Forms\GridField\FormAction;
 
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 
 abstract class AbstractRequestAwareStore implements StateStore
 {
-    private static $dependencies = [
-        'request' => '%$' . HTTPRequest::class,
-    ];
-
-    /**
-     * @var HTTPRequest
-     */
-    protected $request;
-
     /**
      * @return HTTPRequest
      */
     public function getRequest()
     {
-        return $this->request;
-    }
-
-    /**
-     * @param HTTPRequest $request
-     * @return $this
-     */
-    public function setRequest($request)
-    {
-        $this->request = $request;
-        return $this;
+        // Replicating existing functionality from GridField_FormAction
+        return Controller::curr()->getRequest();
     }
 }

--- a/src/Forms/GridField/FormAction/AbstractRequestAwareStore.php
+++ b/src/Forms/GridField/FormAction/AbstractRequestAwareStore.php
@@ -1,0 +1,34 @@
+<?php
+namespace SilverStripe\Forms\GridField\FormAction;
+
+use SilverStripe\Control\HTTPRequest;
+
+abstract class AbstractRequestAwareStore
+{
+    private static $dependencies = [
+        'request' => '%$' . HTTPRequest::class,
+    ];
+
+    /**
+     * @var HTTPRequest
+     */
+    protected $request;
+
+    /**
+     * @return HTTPRequest
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * @param HTTPRequest $request
+     * @return $this
+     */
+    public function setRequest($request)
+    {
+        $this->request = $request;
+        return $this;
+    }
+}

--- a/src/Forms/GridField/FormAction/AttributeStore.php
+++ b/src/Forms/GridField/FormAction/AttributeStore.php
@@ -1,12 +1,10 @@
 <?php
 namespace SilverStripe\Forms\GridField\FormAction;
 
-use SilverStripe\Control\HTTPRequest;
-
 /**
  * Stores GridField action state on an attribute on the action and then analyses request parameters to load it back
  */
-class AttributeStore extends AbstractRequestAwareStore implements StateStore
+class AttributeStore extends AbstractRequestAwareStore
 {
     /**
      * Save the given state against the given ID returning an associative array to be added as attributes on the form

--- a/src/Forms/GridField/FormAction/AttributeStore.php
+++ b/src/Forms/GridField/FormAction/AttributeStore.php
@@ -1,0 +1,51 @@
+<?php
+namespace SilverStripe\Forms\GridField\FormAction;
+
+use SilverStripe\Control\HTTPRequest;
+
+/**
+ * Stores GridField action state on an attribute on the action and then analyses request parameters to load it back
+ */
+class AttributeStore implements StateStore
+{
+    /**
+     * @var HTTPRequest
+     */
+    protected $request;
+
+    /**
+     * @param HTTPRequest $request
+     */
+    public function __construct(HTTPRequest $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * Save the given state against the given ID returning an associative array to be added as attributes on the form
+     * action
+     *
+     * @param string $id
+     * @param array $state
+     * @return array
+     */
+    public function save($id, array $state)
+    {
+        // Just save the state in the attributes of the action
+        return [
+            'data-action-state' => json_encode($state),
+        ];
+    }
+
+    /**
+     * Load state for a given ID
+     *
+     * @param string $id
+     * @return mixed
+     */
+    public function load($id)
+    {
+        // Check the request
+        return json_decode($this->request->requestVar('ActionState'), true);
+    }
+}

--- a/src/Forms/GridField/FormAction/AttributeStore.php
+++ b/src/Forms/GridField/FormAction/AttributeStore.php
@@ -6,21 +6,8 @@ use SilverStripe\Control\HTTPRequest;
 /**
  * Stores GridField action state on an attribute on the action and then analyses request parameters to load it back
  */
-class AttributeStore implements StateStore
+class AttributeStore extends AbstractRequestAwareStore implements StateStore
 {
-    /**
-     * @var HTTPRequest
-     */
-    protected $request;
-
-    /**
-     * @param HTTPRequest $request
-     */
-    public function __construct(HTTPRequest $request)
-    {
-        $this->request = $request;
-    }
-
     /**
      * Save the given state against the given ID returning an associative array to be added as attributes on the form
      * action
@@ -41,11 +28,11 @@ class AttributeStore implements StateStore
      * Load state for a given ID
      *
      * @param string $id
-     * @return mixed
+     * @return array
      */
     public function load($id)
     {
         // Check the request
-        return json_decode($this->request->requestVar('ActionState'), true);
+        return (array) json_decode((string) $this->getRequest()->requestVar('ActionState'), true);
     }
 }

--- a/src/Forms/GridField/FormAction/SessionStore.php
+++ b/src/Forms/GridField/FormAction/SessionStore.php
@@ -1,0 +1,50 @@
+<?php
+namespace SilverStripe\Forms\GridField\FormAction;
+
+use SilverStripe\Control\HTTPRequest;
+
+/**
+ * Stores GridField action state in the session in exactly the same way it has in the past
+ */
+class SessionStore implements StateStore
+{
+    /**
+     * @var HTTPRequest
+     */
+    protected $request;
+
+    /**
+     * @param HTTPRequest $request
+     */
+    public function __construct(HTTPRequest $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * Save the given state against the given ID returning an associative array to be added as attributes on the form
+     * action
+     *
+     * @param string $id
+     * @param array $state
+     * @return array
+     */
+    public function save($id, array $state)
+    {
+        $this->request->getSession()->set($id, $state);
+
+        // This adapter does not require any additional attributes...
+        return [];
+    }
+
+    /**
+     * Load state for a given ID
+     *
+     * @param string $id
+     * @return mixed
+     */
+    public function load($id)
+    {
+        return $this->request->getSession()->get($id);
+    }
+}

--- a/src/Forms/GridField/FormAction/SessionStore.php
+++ b/src/Forms/GridField/FormAction/SessionStore.php
@@ -6,21 +6,8 @@ use SilverStripe\Control\HTTPRequest;
 /**
  * Stores GridField action state in the session in exactly the same way it has in the past
  */
-class SessionStore implements StateStore
+class SessionStore extends AbstractRequestAwareStore implements StateStore
 {
-    /**
-     * @var HTTPRequest
-     */
-    protected $request;
-
-    /**
-     * @param HTTPRequest $request
-     */
-    public function __construct(HTTPRequest $request)
-    {
-        $this->request = $request;
-    }
-
     /**
      * Save the given state against the given ID returning an associative array to be added as attributes on the form
      * action
@@ -31,7 +18,7 @@ class SessionStore implements StateStore
      */
     public function save($id, array $state)
     {
-        $this->request->getSession()->set($id, $state);
+        $this->getRequest()->getSession()->set($id, $state);
 
         // This adapter does not require any additional attributes...
         return [];
@@ -41,10 +28,10 @@ class SessionStore implements StateStore
      * Load state for a given ID
      *
      * @param string $id
-     * @return mixed
+     * @return array
      */
     public function load($id)
     {
-        return $this->request->getSession()->get($id);
+        return (array) $this->getRequest()->getSession()->get($id);
     }
 }

--- a/src/Forms/GridField/FormAction/StateStore.php
+++ b/src/Forms/GridField/FormAction/StateStore.php
@@ -1,15 +1,8 @@
 <?php
 namespace SilverStripe\Forms\GridField\FormAction;
 
-use SilverStripe\Control\HTTPRequest;
-
 interface StateStore
 {
-    /**
-     * @param HTTPRequest $request
-     */
-    public function __construct(HTTPRequest $request);
-
     /**
      * Save the given state against the given ID returning an associative array to be added as attributes on the form
      * action
@@ -24,7 +17,7 @@ interface StateStore
      * Load state for a given ID
      *
      * @param string $id
-     * @return mixed
+     * @return array
      */
     public function load($id);
 }

--- a/src/Forms/GridField/FormAction/StateStore.php
+++ b/src/Forms/GridField/FormAction/StateStore.php
@@ -1,0 +1,30 @@
+<?php
+namespace SilverStripe\Forms\GridField\FormAction;
+
+use SilverStripe\Control\HTTPRequest;
+
+interface StateStore
+{
+    /**
+     * @param HTTPRequest $request
+     */
+    public function __construct(HTTPRequest $request);
+
+    /**
+     * Save the given state against the given ID returning an associative array to be added as attributes on the form
+     * action
+     *
+     * @param string $id
+     * @param array $state
+     * @return array
+     */
+    public function save($id, array $state);
+
+    /**
+     * Load state for a given ID
+     *
+     * @param string $id
+     * @return mixed
+     */
+    public function load($id);
+}

--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -1014,7 +1014,7 @@ class GridField extends FormField
 
         // Fetch the store for the "state" of actions (not the GridField)
         /** @var StateStore $store */
-        $store = Injector::inst()->create(StateStore::class . '.' . $this->getName(), $request);
+        $store = Injector::inst()->create(StateStore::class . '.' . $this->getName());
 
         foreach ($data as $dataKey => $dataValue) {
             if (preg_match('/^action_gridFieldAlterAction\?StateID=(.*)/', $dataKey, $matches)) {

--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -9,8 +9,11 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Control\RequestHandler;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormField;
+use SilverStripe\Forms\GridField\FormAction\SessionStore;
+use SilverStripe\Forms\GridField\FormAction\StateStore;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
@@ -1009,9 +1012,14 @@ class GridField extends FormField
             $state->setValue($fieldData['GridState']);
         }
 
+        // Fetch the store for the "state" of actions (not the GridField)
+        /** @var StateStore $store */
+        $store = Injector::inst()->create(StateStore::class . '.' . $this->getName(), $request);
+
         foreach ($data as $dataKey => $dataValue) {
             if (preg_match('/^action_gridFieldAlterAction\?StateID=(.*)/', $dataKey, $matches)) {
-                $stateChange = $request->getSession()->get($matches[1]);
+                $stateChange = $store->load($matches[1]);
+
                 $actionName = $stateChange['actionName'];
 
                 $arguments = array();

--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -289,14 +289,18 @@ class GridFieldFilterHeader implements GridField_URLHandler, GridField_HTMLProvi
             }, array_keys($filters)), $filters);
         }
 
+        $searchAction = GridField_FormAction::create($gridField, 'filter', false, 'filter', null);
+        $clearAction = GridField_FormAction::create($gridField, 'reset', false, 'reset', null);
         $schema = [
             'formSchemaUrl' => $schemaUrl,
             'name' => $searchField,
             'placeholder' => _t(__CLASS__ . '.Search', 'Search "{name}"', ['name' => $name]),
             'filters' => $filters ?: new \stdClass, // stdClass maps to empty json object '{}'
             'gridfield' => $gridField->getName(),
-            'searchAction' => GridField_FormAction::create($gridField, 'filter', false, 'filter', null)->getAttribute('name'),
-            'clearAction' => GridField_FormAction::create($gridField, 'reset', false, 'reset', null)->getAttribute('name')
+            'searchAction' => $searchAction->getAttribute('name'),
+            'searchActionState' => $searchAction->getAttribute('data-action-state'),
+            'clearAction' => $clearAction->getAttribute('name'),
+            'clearActionState' => $clearAction->getAttribute('data-action-state'),
         ];
 
         return Convert::raw2json($schema);

--- a/src/Forms/GridField/GridField_FormAction.php
+++ b/src/Forms/GridField/GridField_FormAction.php
@@ -3,8 +3,10 @@
 namespace SilverStripe\Forms\GridField;
 
 use SilverStripe\Control\Controller;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
+use SilverStripe\Forms\GridField\FormAction\StateStore;
 
 /**
  * This class is the base class when you want to have an action that alters the state of the
@@ -12,6 +14,11 @@ use SilverStripe\Forms\FormAction;
  */
 class GridField_FormAction extends FormAction
 {
+    /**
+     * A common string prefix for keys generated to store form action "state" against
+     */
+    const STATE_KEY_PREFIX = 'gf_';
+
     /**
      * @var GridField
      */
@@ -80,29 +87,39 @@ class GridField_FormAction extends FormAction
      */
     public function getAttributes()
     {
-        // Store state in session, and pass ID to client side.
+        // Determine the state that goes with this action
         $state = array(
             'grid' => $this->getNameFromParent(),
             'actionName' => $this->actionName,
             'args' => $this->args,
         );
 
-        // Ensure $id doesn't contain only numeric characters
-        $id = 'gf_' . substr(md5(serialize($state)), 0, 8);
+        // Generate a key and attach it to the action name
+        $key = static::STATE_KEY_PREFIX . substr(md5(serialize($state)), 0, 8);
+        // Note: This field needs to be less than 65 chars, otherwise Suhosin security patch will strip it
+        $name = 'action_gridFieldAlterAction?StateID=' . $key;
 
-        $session = Controller::curr()->getRequest()->getSession();
-        $session->set($id, $state);
-        $actionData['StateID'] = $id;
+        // Define attributes
+        $attributes = array(
+            'name' => $name,
+            'data-url' => $this->gridField->Link(),
+            'type' => "button",
+        );
 
+        // Create a "store" for the "state" of this action
+        /** @var StateStore $store */
+        $store = Injector::inst()->create(
+            StateStore::class . '.' . $this->gridField->getName(),
+            // For some reason `getRequest` on GridField_FormAction does not return the correct request
+            Controller::curr()->getRequest()
+        );
+        // Store the state and update attributes as required
+        $attributes += $store->save($key, $state);
+
+        // Return attributes
         return array_merge(
             parent::getAttributes(),
-            array(
-                // Note:  This field needs to be less than 65 chars, otherwise Suhosin security patch
-                // will strip it from the requests
-                'name' => 'action_gridFieldAlterAction' . '?' . http_build_query($actionData),
-                'data-url' => $this->gridField->Link(),
-                'type' => "button",
-            )
+            $attributes
         );
     }
 

--- a/src/Forms/GridField/GridField_FormAction.php
+++ b/src/Forms/GridField/GridField_FormAction.php
@@ -108,11 +108,7 @@ class GridField_FormAction extends FormAction
 
         // Create a "store" for the "state" of this action
         /** @var StateStore $store */
-        $store = Injector::inst()->create(
-            StateStore::class . '.' . $this->gridField->getName(),
-            // For some reason `getRequest` on GridField_FormAction does not return the correct request
-            Controller::curr()->getRequest()
-        );
+        $store = Injector::inst()->create(StateStore::class . '.' . $this->gridField->getName());
         // Store the state and update attributes as required
         $attributes += $store->save($key, $state);
 


### PR DESCRIPTION
Fixes #8589

Currently the session is used to store GridField action state. This PR doesn't change that _by default_. I've abstracted the storage method into an interface and provided an alternate that will just pass down the state to the DOM and then route it back when a request is built to perform an action.

I tried to go down the path of invalidating this action state but it's hard to tell exactly when the user navigates away from the GridField - especially as multiple GridFields can exist on one page, and some are loaded through AJAX requests.

Relies on silverstripe/silverstripe-admin#757