### PR TITLE
renderWith() - Namespace added for Template Loading

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/How_Tos/03_Disable_Anchor_Links.md
+++ b/docs/en/02_Developer_Guides/01_Templates/How_Tos/03_Disable_Anchor_Links.md
@@ -45,7 +45,7 @@ use SilverStripe\View\SSViewer;
 public function RenderCustomTemplate() 
 {
     SSViewer::setRewriteHashLinks(false);
-    $html = $this->renderWith('MyCustomTemplate');
+    $html = $this->renderWith('My/Namespace/MyCustomTemplate');
     SSViewer::setRewriteHashLinks(true);
 
     return $html;


### PR DESCRIPTION
Just calling MyCustomTemplate does not work in SS 4.2.X. Adding the full Namespace as a path is now required.