### PR TITLE
FIX allow for Injector service dot notation to fall-back to classes

### DIFF
--- a/src/Core/Injector/Injector.php
+++ b/src/Core/Injector/Injector.php
@@ -1037,7 +1037,7 @@ class Injector implements ContainerInterface
         } else {
             // Late-generate config spec for non-configured spec
             $spec = [
-                'class' => $name,
+                'class' => strtok($name, '.'),
                 'constructor' => $constructorArgs,
             ];
         }

--- a/tests/php/Core/Injector/InjectorTest.php
+++ b/tests/php/Core/Injector/InjectorTest.php
@@ -1047,4 +1047,20 @@ class InjectorTest extends SapphireTest
         Injector::unnest();
         $this->nestingLevel--;
     }
+
+    public function testServiceConfigFallback()
+    {
+        $config = [
+            SomeService::class . '.Another' => AnotherService::class,
+        ];
+        $injector = new Injector($config);
+
+        // test 'sub-service'
+        $subservice = $injector->create(SomeService::class . '.Another');
+        $this->assertInstanceOf(AnotherService::class, $subservice, 'dot notation service should work as normal');
+
+        // test falling back
+        $fallback = $injector->create(AnotherService::class . '.Fallback');
+        $this->assertInstanceOf(AnotherService::class, $fallback, 'undefined dot notation should fall back');
+    }
 }


### PR DESCRIPTION
A feature was introduced to Injector with SilverStripe 4 allowing
developers to define services in the format
`ServiceName.SubAlias`
allowing for ServiceName to have contextual information to allow it
to be used in a modified way for a particular situation where that
context is relevant. The idea being that if a particular contextual
alias of a service is undefined, instantiation will fall back to
the service proper.

Injector also allows for an undefined service to be treated as a
classname, and attempt to instantiate it as such. This has always
been a feature so far as I know.

However the two features are incompatible, a contextual service will
only fall back to another pre-defined service, which is contrary to
expectation if the fallback is a valid classname, and an undefined
service.

So we can fix this by treating the section of the service definition
preceding a dot as we would with any service definition without a
dot - that is if the service is undefined, to treat the name as a
fully qualified class name.