### PR TITLE
Stop duplicate session cookies on every request.

### DIFF
--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -324,7 +324,6 @@ class Session
                 }
 
                 session_start();
-
             } else {
                 // If headers are sent then we can't have a session_cache_limiter otherwise we'll get a warning
                 session_cache_limiter(null);
@@ -430,7 +429,7 @@ class Session
         }
 
         $var[] = $val;
-        $diffVar[sizeof($var)-1] = $val;
+        $diffVar[sizeof($var) - 1] = $val;
     }
 
     /**

--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -331,13 +331,10 @@ class Session
             $sessionParameters = [
                 "cookie_path" => $path,
                 "cookie_domain" => $domain ?: "",
+                "cookie_lifetime" => $timeout ?: 0,
                 "cookie_secure" => $secure,
                 "cookie_httponly" => true
             ];
-
-            if ($timeout) {
-                $sessionParameters["cookie_lifetime"] = $timeout;
-            }
 
             session_start($sessionParameters);
 


### PR DESCRIPTION
Ensure only a single Set-Cookie header is returned from Session once
we have data to save. Include backwards compatibility for PHP56

Headers were being sent twice, once by session_start() and once by Cookie::set()

The second header was unneeded, and meant Set-Cookie was appended to every request which
breaks WAF behaviour for sticky sessions

@see #8543