### PR TITLE
ModelAdmin Menu Icon Class Documentation Added + Namespace Permissions

### DIFF
--- a/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/01_ModelAdmin.md
+++ b/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/01_ModelAdmin.md
@@ -114,25 +114,39 @@ class Category extends DataObject
 {
     public function canView($member = null) 
     {
-        return Permission::check('CMS_ACCESS_MyAdmin', 'any', $member);
+        return Permission::check('CMS_ACCESS_Company\Website\MyAdmin', 'any', $member);
     }
 
     public function canEdit($member = null) 
     {
-        return Permission::check('CMS_ACCESS_MyAdmin', 'any', $member);
+        return Permission::check('CMS_ACCESS_Company\Website\MyAdmin', 'any', $member);
     }
 
     public function canDelete($member = null) 
     {
-        return Permission::check('CMS_ACCESS_MyAdmin', 'any', $member);
+        return Permission::check('CMS_ACCESS_Company\Website\MyAdmin', 'any', $member);
     }
 
     public function canCreate($member = null) 
     {
-        return Permission::check('CMS_ACCESS_MyAdmin', 'any', $member);
+        return Permission::check('CMS_ACCESS_Company\Website\MyAdmin', 'any', $member);
     }
 }
 ```
+## Custom ModelAdmin CSS Menu Icons using built in Icon Font
+
+An extended ModelAdmin class supports adding a custom menu icon to the CMS.
+
+```
+class NewsAdmin extends ModelAdmin
+{
+...
+private static $menu_icon_class = 'font-icon-news';
+}
+```
+A complete list of supported font icons is available to view in the SilverStripe Design System Manager here:
+https://projects.invisionapp.com/dsm/silver-stripe/silver-stripe/section/icons/5a8b972d656c91001150f8b6
+
 
 ## Searching Records
 

--- a/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/01_ModelAdmin.md
+++ b/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/01_ModelAdmin.md
@@ -133,7 +133,7 @@ class Category extends DataObject
     }
 }
 ```
-## Custom ModelAdmin css menu icons using built in icon font
+## Custom ModelAdmin CSS menu icons using built in icon font
 
 An extended ModelAdmin class supports adding a custom menu icon to the CMS.
 

--- a/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/01_ModelAdmin.md
+++ b/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/01_ModelAdmin.md
@@ -133,20 +133,19 @@ class Category extends DataObject
     }
 }
 ```
-## Custom ModelAdmin CSS Menu Icons using built in Icon Font
+## Custom ModelAdmin css menu icons using built in icon font
 
 An extended ModelAdmin class supports adding a custom menu icon to the CMS.
 
 ```
 class NewsAdmin extends ModelAdmin
 {
-...
-private static $menu_icon_class = 'font-icon-news';
+    ...
+    private static $menu_icon_class = 'font-icon-news';
 }
 ```
 A complete list of supported font icons is available to view in the SilverStripe Design System Manager here:
-https://projects.invisionapp.com/dsm/silver-stripe/silver-stripe/section/icons/5a8b972d656c91001150f8b6
-
+[Design System Manager](https://projects.invisionapp.com/dsm/silver-stripe/silver-stripe/section/icons/5a8b972d656c91001150f8b6)
 
 ## Searching Records
 

--- a/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/01_ModelAdmin.md
+++ b/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/01_ModelAdmin.md
@@ -144,8 +144,7 @@ class NewsAdmin extends ModelAdmin
     private static $menu_icon_class = 'font-icon-news';
 }
 ```
-A complete list of supported font icons is available to view in the SilverStripe Design System Manager here:
-[Design System Manager](https://projects.invisionapp.com/dsm/silver-stripe/silver-stripe/section/icons/5a8b972d656c91001150f8b6)
+A complete list of supported font icons is available to view in the [SilverStripe Design System Manager](https://projects.invisionapp.com/dsm/silver-stripe/silver-stripe/section/icons/5a8b972d656c91001150f8b6)
 
 ## Searching Records
 


### PR DESCRIPTION
Undocumented feature private static $menu_icon_class added to documentation page. This was discussed on the SS4 Forum and would be a nice addition to the official documentation.

Namespace added to permission check for Model Admin view.