### PR TITLE
FIX: prevent shortcodeparser warnings when sitetree link includes anchors or querystrings

### DIFF
--- a/parsers/ShortcodeParser.php
+++ b/parsers/ShortcodeParser.php
@@ -411,7 +411,7 @@ class ShortcodeParser extends SS_Object {
 			$extra = array('node' => $node, 'element' => $node->ownerElement);
 
 			if($tags) {
-				$node->nodeValue = $this->replaceTagsWithText($node->nodeValue, $tags,
+				$node->nodeValue = $this->replaceTagsWithText(htmlspecialchars($node->nodeValue), $tags,
 					function($idx, $tag) use ($parser, $extra) {
 						return $parser->getShortcodeReplacementText($tag, $extra, false);
 					}


### PR DESCRIPTION
If a sitetree link contains an anchor or querystring, such as `<a href="[sitetree_link,id=1]?my-string=this&#my-anchor">Link</a>` the shortcodeparser chokes. This is a simple fix.

Prevents this message:
> [Warning] ShortcodeParser::replaceAttributeTagsWithContent(): unterminated entity reference 