### PR TITLE
FIX: Manifest should ignore vendor folders within packages contained in vendor

### DIFF
--- a/src/Core/Manifest/ManifestFileFinder.php
+++ b/src/Core/Manifest/ManifestFileFinder.php
@@ -41,6 +41,11 @@ class ManifestFileFinder extends FileFinder
         // Keep searching inside vendor
         $inVendor = $this->isInsideVendor($basename, $pathname, $depth);
         if ($inVendor) {
+            // Skip nested vendor folders (e.g. vendor/silverstripe/framework/vendor)
+            if ($depth == 4 && basename($pathname) === self::VENDOR_DIR) {
+                return false;
+            }
+
             // Keep searching if we could have a subdir module
             if ($depth < 3) {
                 return true;

--- a/tests/php/Core/Manifest/fixtures/manifestfilefinder/vendor/myvendor/thismodule/vendor/nestedvendor.txt
+++ b/tests/php/Core/Manifest/fixtures/manifestfilefinder/vendor/myvendor/thismodule/vendor/nestedvendor.txt
@@ -1,0 +1,1 @@
+nestedvendor.txt


### PR DESCRIPTION
Without this change vendor/silverstripe/framework/vendor/silverstripe/config
will be pick up by the manifest, which is inappropriate.

Although this doesn’t happen often, it can occur if you have run
“composer install” within vendor/silverstripe/framework, which can be
done either accidentally or (in my case) as part of running the
framework tests isolated from the rest of your project (which is closer
to the execution model on Travis)

Note that the presence of the ‘nestedvendor.txt’ file tests that this
works without any explicit changes to the PHP of the tests, since it’s
merely confirming that such a file is *not* picked up.