### PR TITLE
Update 02_Images.md

### DIFF
--- a/docs/en/02_Developer_Guides/14_Files/02_Images.md
+++ b/docs/en/02_Developer_Guides/14_Files/02_Images.md
@@ -180,9 +180,9 @@ You can turn this on with the below config:
 Name: resamplefiles
 ---
 SilverStripe\Assets\File:
-  force_resample: false
+  force_resample: true
 SilverStripe\Assets\Storage\DBFile:
-  force_resample: false
+  force_resample: true
 ```
 
 #### Resampled image quality


### PR DESCRIPTION
If the default is that resampling is off, shouldn't the example be that force_resample is set to true to enable resample?

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/