### PR TITLE
Update tests to pass in CWP kitchen sink context

### DIFF
--- a/tests/php/Forms/ConfirmedPasswordFieldTest.php
+++ b/tests/php/Forms/ConfirmedPasswordFieldTest.php
@@ -19,7 +19,9 @@ class ConfirmedPasswordFieldTest extends SapphireTest
     {
         parent::setUp();
 
-        PasswordValidator::singleton()->setMinLength(0);
+        PasswordValidator::singleton()
+            ->setMinLength(0)
+            ->setTestNames([]);
     }
 
     public function testSetValue()

--- a/tests/php/Security/MemberAuthenticatorTest.php
+++ b/tests/php/Security/MemberAuthenticatorTest.php
@@ -18,6 +18,7 @@ use SilverStripe\Security\MemberAuthenticator\CMSMemberAuthenticator;
 use SilverStripe\Security\MemberAuthenticator\CMSMemberLoginForm;
 use SilverStripe\Security\MemberAuthenticator\MemberAuthenticator;
 use SilverStripe\Security\MemberAuthenticator\MemberLoginForm;
+use SilverStripe\Security\PasswordValidator;
 use SilverStripe\Security\Security;
 
 /**
@@ -44,6 +45,10 @@ class MemberAuthenticatorTest extends SapphireTest
             $this->defaultPassword = null;
         }
         DefaultAdminService::setDefaultAdmin('admin', 'password');
+
+        PasswordValidator::singleton()
+            ->setMinLength(0)
+            ->setTestNames([]);
     }
 
     protected function tearDown()

--- a/tests/php/Security/MemberCsvBulkLoaderTest.php
+++ b/tests/php/Security/MemberCsvBulkLoaderTest.php
@@ -6,12 +6,22 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Group;
 use SilverStripe\Security\MemberCsvBulkLoader;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\PasswordValidator;
 use SilverStripe\Security\Security;
 use SilverStripe\Dev\SapphireTest;
 
 class MemberCsvBulkLoaderTest extends SapphireTest
 {
     protected static $fixture_file = 'MemberCsvBulkLoaderTest.yml';
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        PasswordValidator::singleton()
+            ->setMinLength(0)
+            ->setTestNames([]);
+    }
 
     public function testNewImport()
     {

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -57,7 +57,9 @@ class MemberTest extends FunctionalTest
 
         Member::config()->set('unique_identifier_field', 'Email');
 
-        PasswordValidator::singleton()->setMinLength(0);
+        PasswordValidator::singleton()
+            ->setMinLength(0)
+            ->setTestNames([]);
 
         i18n::set_locale('en_US');
     }

--- a/tests/php/Security/PasswordValidatorTest.php
+++ b/tests/php/Security/PasswordValidatorTest.php
@@ -18,10 +18,10 @@ class PasswordValidatorTest extends SapphireTest
     {
         parent::setUp();
 
-        // Unset framework default values
         PasswordValidator::config()
             ->remove('min_length')
-            ->remove('historic_count');
+            ->remove('historic_count')
+            ->set('min_test_score', 0);
     }
 
     public function testValidate()


### PR DESCRIPTION
More global state isolation essentially by settings more configurable settings before running tests.

Context: https://travis-ci.org/silverstripe/cwp-recipe-kitchen-sink/jobs/457825214