### PR TITLE
FIX escaping blackslashes when using the new attribute store for gridfield actions

### DIFF
--- a/src/Forms/GridField/FormAction/AttributeStore.php
+++ b/src/Forms/GridField/FormAction/AttributeStore.php
@@ -18,7 +18,7 @@ class AttributeStore extends AbstractRequestAwareStore
     {
         // Just save the state in the attributes of the action
         return [
-            'data-action-state' => json_encode($state),
+            'data-action-state' => addcslashes(json_encode($state), '\\'),
         ];
     }
 


### PR DESCRIPTION
Currently it is possible for action state for gridfield actions to contain backslashes. This makes jQuery (silently) mad when it tries to parse objects from data attributes and in turn results in double escaped JSON objects being sent back server-side

We encountered this issue with userforms which is placing class names in the "action state" for the add button. You can see the issue without this patch by attempting to add fields to a userform in SS4.