### PR TITLE
FIX behat CmsUiContext waits for cms-loading-container after step

### DIFF
--- a/tests/behat/src/CmsUiContext.php
+++ b/tests/behat/src/CmsUiContext.php
@@ -58,7 +58,10 @@ class CmsUiContext implements Context
         $timeoutMs = $this->getMainContext()->getAjaxTimeout();
         $this->getSession()->wait(
             $timeoutMs,
-            "document.getElementsByClassName('cms-content-loading-overlay').length == 0"
+            "(".
+            "document.getElementsByClassName('cms-content-loading-overlay').length +".
+            "document.getElementsByClassName('cms-loading-container').length".
+            ") == 0"
         );
     }
 


### PR DESCRIPTION
following up [admin/#772](https://github.com/silverstripe/silverstripe-admin/pull/772)

Adding new `Loading` component wrapper classname to the CmsUI context AfterStep, so that we don't have to manually wait for loading in behat scripts.