### PR TITLE
FIX: prevent shortcodeparser warnings when sitetree link includes anchors or querystrings

### DIFF
--- a/src/View/Parsers/ShortcodeParser.php
+++ b/src/View/Parsers/ShortcodeParser.php
@@ -476,7 +476,7 @@ class ShortcodeParser
 
             if ($tags) {
                 $node->nodeValue = $this->replaceTagsWithText(
-                    $node->nodeValue,
+                    htmlspecialchars($node->nodeValue),
                     $tags,
                     function ($idx, $tag) use ($parser, $extra) {
                         return $parser->getShortcodeReplacementText($tag, $extra, false);

--- a/tests/php/View/Parsers/ShortcodeParserTest.php
+++ b/tests/php/View/Parsers/ShortcodeParserTest.php
@@ -311,6 +311,15 @@ class ShortcodeParserTest extends SapphireTest
         $this->assertEquals($this->extra['element']->tagName, 'a');
     }
 
+    public function testShortcodeWithAnchorAndQuerystring()
+    {
+        $result = $this->parser->parse('<a href="[test_shortcode]?my-string=this&thing=2#my-anchor">Link</a>');
+
+        $this->assertContains('my-string=this', $result);
+        $this->assertContains('thing=2', $result);
+        $this->assertContains('my-anchor', $result);
+    }
+
     public function testNoParseAttemptIfNoCode()
     {
         $stub = $this->getMockBuilder(ShortcodeParser::class)->setMethods(array('replaceElementTagsWithMarkers'))


### PR DESCRIPTION
If a sitetree link contains an anchor or querystring, such as `<a href="[sitetree_link,id=1]?my-string=this&thing=2#my-anchor">Link</a>` the shortcodeparser chokes. This is a simple fix.

Prevents this death message:

> [Warning] SilverStripe\View\Parsers\ShortcodeParser::replaceAttributeTagsWithContent(): unterminated entity reference
