### PR TITLE
FIX: tableList() function slow

### DIFF
--- a/model/connect/MySQLSchemaManager.php
+++ b/model/connect/MySQLSchemaManager.php
@@ -336,7 +336,7 @@ class MySQLSchemaManager extends DBSchemaManager {
 
 	public function tableList() {
 		$tables = array();
-		foreach ($this->query("SHOW FULL TABLES WHERE Table_Type != 'VIEW'") as $record) {
+		foreach ($this->query("SELECT table_name, table_type FROM information_schema.tables WHERE table_schema = database()") as $record) {
 			$table = reset($record);
 			$tables[strtolower($table)] = $table;
 		}


### PR DESCRIPTION
Observed behaviour: After upgrading our site to 3.7 our pages were slow to load. It seemed the "SHOW FULL TABLES WHERE Table_Type != 'VIEW'" query was taking 2s+ in production.

What I'm fixing:

Researching why this query is so slow, it seems to relate to MySQL (we're using 5.7) permission checks when the query is written this way. There is an open bug that has gone nowhere: https://bugs.mysql.com/bug.php?id=81865

If I change:

SHOW FULL TABLES WHERE Table_Type != 'VIEW';
to
SELECT table_name, table_type FROM information_schema.tables WHERE table_schema = database();

We get the same result however the latter query takes 0.093s.