### PR TITLE
DOCS Updating Session doc to reflect that you need to operation on an instance

### DIFF
--- a/.upgrade.yml
+++ b/.upgrade.yml
@@ -1285,9 +1285,9 @@ warnings:
     'days_between()':
       message: 'Removed SilverStripe\ORM\FieldType\DBDate->days_between()'
     'SilverStripe\Control\Session::get_all()':
-      message: 'Session can not be access statically and `get_all()` is now called `getAll()'
+      message: 'Session can not be accessed statically and `get_all()` is now called `getAll()'
     'SilverStripe\Control\Session::clear_all()':
-      message: 'Session can not be access statically and `clear_all()` is now called `clearAll()'
+      message: 'Session can not be accessed statically and `clear_all()` is now called `clearAll()'
   props:
     'class':
       message: '$this->class access has been removed'

--- a/.upgrade.yml
+++ b/.upgrade.yml
@@ -1284,6 +1284,10 @@ warnings:
       message: 'Removed SilverStripe\ORM\FieldType\DBDate->day_before()'
     'days_between()':
       message: 'Removed SilverStripe\ORM\FieldType\DBDate->days_between()'
+    'SilverStripe\Control\Session::get_all()':
+      message: 'Session can not be access statically and `get_all()` is now called `getAll()'
+    'SilverStripe\Control\Session::clear_all()':
+      message: 'Session can not be access statically and `clear_all()` is now called `clearAll()'
   props:
     'class':
       message: '$this->class access has been removed'

--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -9,46 +9,43 @@ use SilverStripe\Dev\Deprecation;
 /**
  * Handles all manipulation of the session.
  *
- * The static methods are used to manipulate the currently active controller's session.
- * The instance methods are used to manipulate a particular session.  There can be more than one of these created.
+ * An instance of `Session` object can be retrieve via an `HTTPRequest` by calling the `getSession()` method.
  *
  * In order to support things like testing, the session is associated with a particular Controller.  In normal usage,
  * this is loaded from and saved to the regular PHP session, but for things like static-page-generation and
  * unit-testing, you can create multiple Controllers, each with their own session.
  *
- * The instance object is basically just a way of manipulating a set of nested maps, and isn't specific to session
- * data.
- *
  * <b>Saving Data</b>
  *
- * You can write a value to a users session from your PHP code using the static function {@link Session::set()}. You
- * can add this line in any function or file you wish to save the value.
+ * Once you've retrieved a session instance, you can write a value to a users session using the function {@link Session::set()}.
  *
  * <code>
- *  Session::set('MyValue', 6);
+ *  $request->getSession()->set('MyValue', 6);
  * </code>
  *
  * Saves the value of "6" to the MyValue session data. You can also save arrays or serialized objects in session (but
  * note there may be size restrictions as to how much you can save)
  *
  * <code>
+ *
+ *  $session = $request->getSession();
+ *
  *  // save a variable
  *  $var = 1;
- *  Session::set('MyVar', $var);
+ *  $session->set('MyVar', $var);
  *
  *  // saves an array
- *  Session::set('MyArrayOfValues', array('1', '2', '3'));
+ *  $session->set('MyArrayOfValues', array('1', '2', '3'));
  *
  *  // saves an object (you'll have to unserialize it back)
  *  $object = new Object();
  *
- *  Session::set('MyObject', serialize($object));
+ *  $session->set('MyObject', serialize($object));
  * </code>
  *
  * <b>Accessing Data</b>
  *
  * Once you have saved a value to the Session you can access it by using the {@link Session::get()} function.
- * Like the {@link Session::set()} function you can use this anywhere in your PHP files.
  * Note that session data isn't persisted in PHP's own session store (via $_SESSION)
  * until {@link Session::save()} is called, which happens automatically at the end of a standard request
  * through {@link SilverStripe\Control\Middleware\SessionMiddleware}.
@@ -57,17 +54,18 @@ use SilverStripe\Dev\Deprecation;
  *
  * <code>
  * public function bar() {
- *  $value = Session::get('MyValue'); // $value = 6
- *  $var   = Session::get('MyVar'); // $var = 1
- *  $array = Session::get('MyArrayOfValues'); // $array = array(1,2,3)
- *  $object = Session::get('MyObject', unserialize($object)); // $object = Object()
+ *  $session = $this->getRequest()->getSession();
+ *  $value = $session->get('MyValue'); // $value = 6
+ *  $var   = $session->get('MyVar'); // $var = 1
+ *  $array = $session->get('MyArrayOfValues'); // $array = array(1,2,3)
+ *  $object = $session->get('MyObject', unserialize($object)); // $object = Object()
  * }
  * </code>
  *
  * You can also get all the values in the session at once. This is useful for debugging.
  *
  * <code>
- * Session::get_all(); // returns an array of all the session values.
+ * $session::getAll(); // returns an array of all the session values.
  * </code>
  *
  * <b>Clearing Data</b>
@@ -76,17 +74,18 @@ use SilverStripe\Dev\Deprecation;
  * to specifically remove it. To clear a value you can either delete 1 session value by the name that you saved it
  *
  * <code>
- * Session::clear('MyValue'); // MyValue is no longer 6.
+ * $session->clear('MyValue'); // MyValue is no longer 6.
  * </code>
  *
  * Or you can clear every single value in the session at once. Note SilverStripe stores some of its own session data
- * including form and page comment information. None of this is vital but clear_all will clear everything.
+ * including form and page comment information. None of this is vital but `clearAll()` will clear everything.
  *
  * <code>
- *  Session::clear_all();
+ *  $session->clearAll();
  * </code>
  *
  * @see Cookie
+ * @see HTTPRequest
  */
 class Session
 {

--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -9,7 +9,7 @@ use SilverStripe\Dev\Deprecation;
 /**
  * Handles all manipulation of the session.
  *
- * An instance of `Session` object can be retrieve via an `HTTPRequest` by calling the `getSession()` method.
+ * An instance of a `Session` object can be retrieved via an `HTTPRequest` by calling the `getSession()` method.
  *
  * In order to support things like testing, the session is associated with a particular Controller.  In normal usage,
  * this is loaded from and saved to the regular PHP session, but for things like static-page-generation and


### PR DESCRIPTION
Simply updates the PHPDoc for the session class to be more inline with the usage in SS4. Some related `.upgrade.yml` changes as well.

There's a few bits in there about how to use session in unit test. I left them in there because I'm sure if they're still true/relevant. If you're more knowledgeable than me about that, just jump in there.

# Parent Issue
* #8644