### PR TITLE
TreeMultiselectField empty value

### DIFF
--- a/src/Forms/TreeDropdownField.php
+++ b/src/Forms/TreeDropdownField.php
@@ -514,7 +514,7 @@ class TreeDropdownField extends FormField
         $value = $request->requestVar('forceValue') ?: $this->value;
         if ($value && ($values = preg_split('/,\s*/', $value))) {
             foreach ($values as $value) {
-                if (!$value || $value == 'unchanged') {
+                if (!$value) {
                     continue;
                 }
 

--- a/tests/php/Forms/TreeMultiselectFieldTest.php
+++ b/tests/php/Forms/TreeMultiselectFieldTest.php
@@ -10,7 +10,7 @@ use SilverStripe\Forms\TreeMultiselectField;
 
 class TreeMultiselectFieldTest extends SapphireTest
 {
-    protected static $fixture_file = 'TreeDropdownFieldTest.yml';
+    protected static $fixture_file = 'TreeMultiselectFieldTest.yml';
 
     protected $formId = 'TheFormID';
     protected $fieldName = 'TestTree';
@@ -128,7 +128,7 @@ class TreeMultiselectFieldTest extends SapphireTest
             [
                 'id' => $fieldId,
                 'name' => $this->fieldName,
-                'value' => 'unchanged'
+                'value' => null
             ],
             $schemaStateDefaults,
             true
@@ -162,7 +162,6 @@ class TreeMultiselectFieldTest extends SapphireTest
 
         $html = $field->Field();
         $this->assertContains($field->ID(), $html);
-        $this->assertContains('unchanged', $html);
     }
 
 
@@ -206,7 +205,7 @@ class TreeMultiselectFieldTest extends SapphireTest
             [
                 'id' => $field->ID(),
                 'name' => 'TestTree',
-                'value' => 'unchanged'
+                'value' => null
             ],
             $schemaStateDefaults,
             true

--- a/tests/php/Forms/TreeMultiselectFieldTest.yml
+++ b/tests/php/Forms/TreeMultiselectFieldTest.yml
@@ -1,0 +1,27 @@
+SilverStripe\Assets\Folder:
+  subfolder:
+    Name: FileTest-subfolder
+  folder1:
+    Name: FileTest-folder1
+  folder2:
+    Name: FileTest-folder2
+  folder1-subfolder1:
+    Name: FileTest-folder1-subfolder1
+    ParentID: =>SilverStripe\Assets\Folder.folder1
+
+SilverStripe\Assets\File:
+  asdf:
+    Filename: assets/FileTest.txt
+    Title: '<Special & characters>'
+  subfolderfile1:
+    Filename: assets/FileTest-subfolder/TestFile1InSubfolder.txt
+    Name: TestFile1InSubfolder
+    ParentID: =>SilverStripe\Assets\Folder.subfolder
+  subfolderfile2:
+    Filename: assets/FileTest-subfolder/TestFile2InSubfolder.txt
+    Name: TestFile2InSubfolder
+    ParentID: =>SilverStripe\Assets\Folder.subfolder
+  file1-folder1:
+    Filename: assets/FileTest-folder1/File1.txt
+    Name: File1.txt
+    ParentID: =>SilverStripe\Assets\Folder.folder1


### PR DESCRIPTION
Original issue:
 - [assets/#176](https://github.com/silverstripe/silverstripe-assets/issues/176)

The empty value of TreeMultiselectField used to be string "unchanged".
However, this is rather a legacy and obscure behaviour.
This patch changes the empty value to be null in the schema and an empty array
internally (strong typing for the win).

Relevant github issues:
 - silverstripe/silverstripe-assets#176
 - silverstripe/silverstripe-framework#8592
 - #8332