### PR TITLE
Fix for CheckboxSetField not disabling items correctly

### DIFF
--- a/src/Forms/CheckboxSetField.php
+++ b/src/Forms/CheckboxSetField.php
@@ -72,6 +72,7 @@ class CheckboxSetField extends MultiSelectField
     {
         $selectedValues = $this->getValueArray();
         $defaultItems = $this->getDefaultItems();
+        $disabledItems = $this->getDisabledItems();
 
         // Generate list of options to display
         $odd = false;
@@ -84,7 +85,7 @@ class CheckboxSetField extends MultiSelectField
             $extraClass .= ' val' . preg_replace('/[^a-zA-Z0-9\-\_]/', '_', $itemValue);
 
             $itemChecked = in_array($itemValue, $selectedValues) || in_array($itemValue, $defaultItems);
-            $itemDisabled = $this->isDisabled() || in_array($itemValue, $defaultItems);
+            $itemDisabled = $this->isDisabled() || in_array($itemValue, $disabledItems);
 
             $options->push(new ArrayData(array(
                 'ID' => $itemID,


### PR DESCRIPTION
Adds a new variable `$disabledItems` to get disabled items from `getDisabledItems()`

Bug was caused by checking $itemValue against $defaultItems to check for disabled items.