### PR TITLE
SS_Object::removeMethodsFrom silence notices

### DIFF
--- a/core/Object.php
+++ b/core/Object.php
@@ -908,10 +908,12 @@ abstract class SS_Object {
 		$methods = $this->findMethodsFromExtension($extension);
 		if ($methods) {
 			foreach ($methods as $method) {
-				$methodInfo = self::$extra_methods[$this->class][$method];
+				if (isset(self::$extra_methods[$this->class][$method])) {
+					$methodInfo = self::$extra_methods[$this->class][$method];
 
-				if ($methodInfo['property'] === $property && $methodInfo['index'] === $index) {
-					unset(self::$extra_methods[$this->class][$method]);
+					if ($methodInfo['property'] === $property && $methodInfo['index'] === $index) {
+						unset(self::$extra_methods[$this->class][$method]);
+					}
 				}
 			}
 

--- a/core/Object.php
+++ b/core/Object.php
@@ -908,12 +908,14 @@ abstract class SS_Object {
 		$methods = $this->findMethodsFromExtension($extension);
 		if ($methods) {
 			foreach ($methods as $method) {
-				if (isset(self::$extra_methods[$this->class][$method])) {
-					$methodInfo = self::$extra_methods[$this->class][$method];
+				if (!isset(self::$extra_methods[$this->class][$method])) {
+					continue;
+				}
+				
+				$methodInfo = self::$extra_methods[$this->class][$method];
 
-					if ($methodInfo['property'] === $property && $methodInfo['index'] === $index) {
-						unset(self::$extra_methods[$this->class][$method]);
-					}
+				if ($methodInfo['property'] === $property && $methodInfo['index'] === $index) {
+					unset(self::$extra_methods[$this->class][$method]);
 				}
 			}
 


### PR DESCRIPTION
Check to ensure `self::$extra_methods[$this->class][$method]` exists before trying to retrieve it. This prevents a bunch of notices from being generated.

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/