### PR TITLE
CustomMethods->removeMethodsFrom Warnings

### DIFF
--- a/src/Core/CustomMethods.php
+++ b/src/Core/CustomMethods.php
@@ -279,10 +279,12 @@ trait CustomMethods
         $methods = $this->findMethodsFromExtension($extension);
         if ($methods) {
             foreach ($methods as $method) {
-                $methodInfo = self::$extra_methods[$class][$method];
+                if (isset(self::$extra_methods[$class][$method])) {
+                    $methodInfo = self::$extra_methods[$class][$method];
 
-                if ($methodInfo['property'] === $property && $methodInfo['index'] === $index) {
-                    unset(self::$extra_methods[$class][$method]);
+                    if ($methodInfo['property'] === $property && $methodInfo['index'] === $index) {
+                        unset(self::$extra_methods[$class][$method]);
+                    }
                 }
             }
 

--- a/src/Core/CustomMethods.php
+++ b/src/Core/CustomMethods.php
@@ -279,7 +279,9 @@ trait CustomMethods
         $methods = $this->findMethodsFromExtension($extension);
         if ($methods) {
             foreach ($methods as $method) {
-                if (!isset(self::$extra_methods[$class][$method])) continue;
+                if (!isset(self::$extra_methods[$class][$method])) {
+                    continue;
+                }
                     
                 $methodInfo = self::$extra_methods[$class][$method];
 

--- a/src/Core/CustomMethods.php
+++ b/src/Core/CustomMethods.php
@@ -279,12 +279,12 @@ trait CustomMethods
         $methods = $this->findMethodsFromExtension($extension);
         if ($methods) {
             foreach ($methods as $method) {
-                if (isset(self::$extra_methods[$class][$method])) {
-                    $methodInfo = self::$extra_methods[$class][$method];
+                if (!isset(self::$extra_methods[$class][$method])) continue;
+                    
+                $methodInfo = self::$extra_methods[$class][$method];
 
-                    if ($methodInfo['property'] === $property && $methodInfo['index'] === $index) {
-                        unset(self::$extra_methods[$class][$method]);
-                    }
+                if ($methodInfo['property'] === $property && $methodInfo['index'] === $index) {
+                    unset(self::$extra_methods[$class][$method]);
                 }
             }
 


### PR DESCRIPTION
Check to ensure `self::$extra_methods[$class][$method]` exists before trying to retrieve its value. Silences warnings generated by updating a controller's failover.

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/