### PR TITLE
BUG Fix issue with assertListEquals() ignoring field getters

### DIFF
--- a/src/Dev/Constraint/ViewableDataContains.php
+++ b/src/Dev/Constraint/ViewableDataContains.php
@@ -64,7 +64,7 @@ class ViewableDataContains extends PHPUnit_Framework_Constraint implements TestO
         $success = true;
 
         foreach ($this->match as $fieldName => $value) {
-            if ($other->getField($fieldName) != $value) {
+            if ($other->$fieldName != $value) {
                 $success = false;
                 break;
             }

--- a/tests/php/Dev/ViewableDataContainsTest.php
+++ b/tests/php/Dev/ViewableDataContainsTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Dev\Tests;
 
 use SilverStripe\Dev\Constraint\ViewableDataContains;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\Tests\ViewableDataContainsTest\TestObject;
 use SilverStripe\Security\Member;
 use SilverStripe\View\ArrayData;
 
@@ -99,5 +100,15 @@ class ViewableDataContainsTest extends SapphireTest
         $item = Member::create($this->test_data);
 
         $this->assertFalse($constraint->evaluate($item, '', true));
+    }
+
+    public function testFieldAccess()
+    {
+        $data = new TestObject(['name' => 'Damian']);
+        $constraint = new ViewableDataContains(['name' => 'Damian', 'Something' => 'something']);
+        $this->assertTrue($constraint->evaluate($data, '', true));
+
+        $constraint = new ViewableDataContains(['name' => 'Damian', 'Something' => 'notthing']);
+        $this->assertFalse($constraint->evaluate($data, '', true));
     }
 }

--- a/tests/php/Dev/ViewableDataContainsTest/TestObject.php
+++ b/tests/php/Dev/ViewableDataContainsTest/TestObject.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SilverStripe\Dev\Tests\ViewableDataContainsTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\View\ViewableData;
+
+class TestObject extends ViewableData implements TestOnly
+{
+    protected $data = null;
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    public function hasField($name)
+    {
+        return isset($this->data[$name]);
+    }
+
+    public function getField($name)
+    {
+        return isset($this->data[$name]) ?: null;
+    }
+
+    public function getSomething()
+    {
+        return 'something';
+    }
+}


### PR DESCRIPTION
This is mostly an issue with DataObjects, since in order to respect both getField() and getSomeField(), you need to access it via __get(). I've created a test class to replicate this.

The issue I came across was where I had a non-db field getter that I couldn't test with assertListContains().