### PR TITLE
Corrected `legacy_paths` to `legacy_filenames`

### DIFF
--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -746,13 +746,13 @@ Because the filesystem now uses the sha1 of file contents in order to version mu
 filename, the default storage paths in 4.0 will not be the same as in 3.
 
 In order to retain existing file paths in line with framework version 3 you should set the
-`\SilverStripe\Filesystem\Flysystem\FlysystemAssetStore.legacy_paths` config to true.
+`\SilverStripe\Filesystem\Flysystem\FlysystemAssetStore.legacy_filenames` config to true.
 Note that this will not allow you to utilise certain file versioning features in 4.0.
 
 
 ```yml
 SilverStripe\Filesystem\Flysystem\FlysystemAssetStore:
-  legacy_paths: true
+  legacy_filenames: true
 ```
 
 


### PR DESCRIPTION
The correct config option for enabling 3.x asset paths appears to be `legacy_filenames` and not`legacy_paths` for which I can't find any instances of.