### PR TITLE
Ensure document is not falsey before attempting to clone it

### DIFF
--- a/src/View/Parsers/HTMLValue.php
+++ b/src/View/Parsers/HTMLValue.php
@@ -35,7 +35,11 @@ abstract class HTMLValue extends ViewableData
      */
     public function getContent()
     {
-        $doc = clone $this->getDocument();
+        $document = $this->getDocument();
+        if (!$document) {
+            return '';
+        }
+        $doc = clone $document;
         $xp = new DOMXPath($doc);
 
         // If there's no body, the content is empty string

--- a/tests/php/View/Parsers/HTML4ValueTest.php
+++ b/tests/php/View/Parsers/HTML4ValueTest.php
@@ -80,4 +80,19 @@ class HTML4ValueTest extends SapphireTest
         $value->setContent('<a href="&quot;"></a>');
         $this->assertEquals('<a href="&quot;"></a>', $value->getContent(), "'\"' character is escaped");
     }
+
+    public function testGetContent()
+    {
+        $value = new HTML4Value();
+
+        $value->setContent('<p>This is valid</p>');
+        $this->assertEquals('<p>This is valid</p>', $value->getContent(), "Valid content is returned");
+
+        $value->setContent('<p?< This is not really valid but it will get parsed into something valid');
+        // can sometimes get a this state where HTMLValue->valid is false
+        // for instance if a content editor saves something really weird in a LiteralField
+        // we can manually get to this state via ->setInvalid()
+        $value->setInvalid();
+        $this->assertEquals('', $value->getContent(), "Blank string is returned when invalid");
+    }
 }


### PR DESCRIPTION
If !$this->valid, then getDocument() will return false.  

$doc = clone false; will throw a php error

Can get into this state if a user puts invalid html into a userforms EditableLiteralField e.g. '<p<Some text'