### PR TITLE
NEW Add new execmetric debur URL parameter to print out exection time and peak memory usage

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -8,8 +8,16 @@ SilverStripe\Core\Manifest\VersionProvider:
 Name: httpconfig-dev
 Only:
   environment: dev
+After:
+  - 'requestprocessors'
 ---
 # Set dev level to disabled with a higher forcing level
 SilverStripe\Control\Middleware\HTTPCacheControlMiddleware:
   defaultState: 'disabled'
   defaultForcingLevel: 3
+
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Control\Director:
+    properties:
+      Middlewares:
+        ExecMetricMiddleware: '%$SilverStripe\Control\Middleware\ExecMetricMiddleware'

--- a/docs/en/02_Developer_Guides/07_Debugging/02_URL_Variable_Tools.md
+++ b/docs/en/02_Developer_Guides/07_Debugging/02_URL_Variable_Tools.md
@@ -28,7 +28,8 @@ session variables, used templates and much more.
  | isDev         | | 1      | | Put the site into [development mode](../), enabling debugging messages to the browser on a live server.  For security, you'll be asked to log in with an administrator log-in. Will persist for the current browser session. | 
  | isTest        | | 1      | | See above. | 
  | debug         | | 1      | | Show a collection of debugging information about the director / controller operation        |
- | debug_request | | 1      | | Show all steps of the request from initial [HTTPRequest](api:SilverStripe\Control\HTTPRequest) to [Controller](api:SilverStripe\Control\Controller) to Template Rendering  | 
+ | debug_request | | 1      | | Show all steps of the request from initial [HTTPRequest](api:SilverStripe\Control\HTTPRequest) to [Controller](api:SilverStripe\Control\Controller) to Template Rendering  |
+ | execmetric    | | 1      | | Display the execution time and peak memory usage for the request |  
 
 ## Classes and Objects
 

--- a/src/Control/Middleware/ExecMetricMiddleware.php
+++ b/src/Control/Middleware/ExecMetricMiddleware.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SilverStripe\Control\Middleware;
+
+use SilverStripe\Assets\File;
+use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Dev\Debug;
+
+/**
+ * Secures requests by only allowing a whitelist of Host values
+ */
+class ExecMetricMiddleware implements HTTPMiddleware
+{
+    /**
+     * @inheritdoc
+     */
+    public function process(HTTPRequest $request, callable $delegate)
+    {
+        if (!$this->showMetric($request)) {
+            return $delegate($request);
+        }
+
+        $start = microtime(true);
+        try {
+            return $delegate($request);
+        } finally {
+            $end = microtime(true);
+            Debug::message(
+                sprintf(
+                    "Execution time: %s, Peak memory usage: %s\n",
+                    $this->formatExecutionTime($start, $end),
+                    $this->formatPeakMemoryUsage()
+                ),
+                false
+            );
+        }
+    }
+
+    private function showMetric(HTTPRequest $request)
+    {
+        return Director::isDev() && array_key_exists('execmetric', $request->getVars());
+    }
+
+    /**
+     * Convert the provided start and end time to a interval in secs.
+     * @param float $start
+     * @param float $end
+     * @return string
+     */
+    private function formatExecutionTime($start, $end)
+    {
+        $diff = round($end - $start, 4);
+        return $diff . ' seconds';
+    }
+
+    /**
+     * Get the peak memory usage formatted has a string and a meaningful unit.
+     * @return string
+     */
+    private function formatPeakMemoryUsage()
+    {
+        $bytes = memory_get_peak_usage(true);
+        return File::format_size($bytes);
+    }
+}


### PR DESCRIPTION
This is a quick something I put together to help debug https://github.com/silverstripe/silverstripe-framework/issues/8664

Basically, if you add `execmetrics` as a URL Get parameter, you'll get a print out of how long the request took and the peak memory usage.

Figure it might be helpful going forward.