### PR TITLE
Existing sessions need to set a new cookie on each request, if the

### DIFF
--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -325,9 +325,9 @@ class Session
 
                 session_start();
 
-                // Session start emits a cookie, but only if there's no existing session. If there is a session tied to
-                // this request, make sure the session is held for the entire timeout by refreshing the cookie age.
-                if ($this->requestContainsSessionId($request)) {
+                // Session start emits a cookie, but only if there's no existing session. If there is a session timeout
+                // tied to this request, make sure the session is held for the entire timeout by refreshing the cookie age.
+                if ($timeout && $this->requestContainsSessionId($request)) {
                     Cookie::set(session_name(), session_id(), $timeout / 86400, $path, $domain ?: null, $secure, true);
                 }
             } else {

--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -324,6 +324,12 @@ class Session
                 }
 
                 session_start();
+
+                // Session start emits a cookie, but only if there's no existing session. If there is a session tied to
+                // this request, make sure the session is held for the entire timeout by refreshing the cookie age.
+                if ($this->requestContainsSessionId($request)) {
+                    Cookie::set(session_name(), session_id(), $timeout / 86400, $path, $domain ?: null, $secure, true);
+                }
             } else {
                 // If headers are sent then we can't have a session_cache_limiter otherwise we'll get a warning
                 session_cache_limiter(null);


### PR DESCRIPTION
Existing sessions need to set a new cookie on each request, if the
session exists, otherwise our expiry is never updated and sessions
can't roll on every request.

This resolves the regression that the existing behaviour: remember sessions for inactive users which was in place before 4.3.1 and https://github.com/silverstripe/silverstripe-framework/issues/8724#issuecomment-454586145

See issue #8724


