### PR TITLE
fix user feedback when jquery could not be loaded

### DIFF
--- a/src/Dev/Install/Installer.php
+++ b/src/Dev/Install/Installer.php
@@ -549,7 +549,7 @@ TEXT;
 <li id="ModRewriteResult">Testing...</li>
 <script>
     if (typeof $ == 'undefined') {
-        document.getElemenyById('ModeRewriteResult').innerHTML = "I can't run jQuery ajax to set rewriting; I will redirect you to the homepage to see if everything is working.";
+        document.getElementById('ModeRewriteResult').innerHTML = "I can't run jQuery ajax to set rewriting; I will redirect you to the homepage to see if everything is working.";
         setTimeout(function() {
             window.location = "$destinationURL";
         }, 10000);


### PR DESCRIPTION
### expected 
if code.jquery.com can not reached, display error message and execute fallback

### observed behaviour
fallback can not be executed because of typo