### PR TITLE
FIX: Injector may instantiate prototypes as if they're singletons (fixes #8567)

### DIFF
--- a/control/injector/Injector.php
+++ b/control/injector/Injector.php
@@ -866,7 +866,7 @@ class Injector {
 			return $this->instantiate($spec, $name);
 		}
 
-		return $this->instantiate($spec);
+		return $this->instantiate($spec, null, 'prototype');
 	}
 
 	/**

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -29,6 +29,7 @@ class DataObjectTest extends SapphireTest {
 		'DataObjectTest_Play',
 		'DataObjectTest_Ploy',
 		'DataObjectTest_Bogey',
+		'DataObjectTest_Sortable',
 		'ManyManyListTest_Product',
 		'ManyManyListTest_Category',
 	);
@@ -38,6 +39,13 @@ class DataObjectTest extends SapphireTest {
 	 */
 	public function testSingleton($inst, $defaultValue, $altDefaultValue)
 	{
+		// Calls to scaffold the test database may have cached service specs for DataObjects
+		// with the incorrect 'type' set (singleton instead of prototype)
+		Injector::nest();
+		$reflectionProp = new ReflectionProperty('Injector', 'specs');
+		$reflectionProp->setAccessible(true);
+		$reflectionProp->setValue(Injector::inst(), array());
+
 		$inst = $inst();
 		// Test that populateDefaults() isn't called on singletons
 		// which can lead to SQL errors during build, and endless loops
@@ -52,6 +60,8 @@ class DataObjectTest extends SapphireTest {
 		} else {
 			$this->assertEmpty($inst->MyFieldWithAltDefault);
 		}
+
+		Injector::unnest();
 	}
 
 	public function provideSingletons()


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/8567.

This is a bit of a tricky one to explain, I’ve done my best to simplify it below. Currently usercode and unit tests exhibit different behaviour, because Injector’s `$specs` cache is warmed by the test database scaffolding.

---

There’s a mismatch between how Injector behaves if a `type` (`prototype` or `singleton`) isn’t set for a service, based on whether the `$this->specs[$service]` cache is empty or not. If the spec cache is set (without a `type` key) Injector [assumes `prototype`](https://github.com/silverstripe/silverstripe-framework/blob/3.6.6/control/injector/Injector.php#L831), but if the cache isn’t set it [doesn’t make any assumption](https://github.com/silverstripe/silverstripe-framework/blob/3.6.6/control/injector/Injector.php#L864).

```php
// Current behaviour
MyDataObject::create(); // Treated as a singleton - populateDefaults() not called

// Current behaviour (unit tests call singleton() during database scaffolding)
MyDataObject::singleton(); // Warms the service cache
MyDataObject::create(); // Treated as a prototype - populateDefaults() is called

// Expected behaviour
MyDataObject::create(); // *Always* treated as a prototype
```