### PR TITLE
Update 03_Form_Templates.md - form template locations

### DIFF
--- a/docs/en/02_Developer_Guides/03_Forms/03_Form_Templates.md
+++ b/docs/en/02_Developer_Guides/03_Forms/03_Form_Templates.md
@@ -16,7 +16,7 @@ $field = new TextField(..);
 $field->setTemplate('MyCustomTextField');
 ```
 
-Both `MyCustomTemplate.ss` and `MyCustomTextField.ss` should be located in **app/templates/** or the same directory as the core.
+Both `MyCustomTemplate.ss` and `MyCustomTextField.ss` should be located in **app/templates/** or your theme's **templates/** directory.
 
 <div class="notice" markdown="1">
 It's recommended to copy the contents of the template you're going to replace and use that as a start. For instance, if

--- a/docs/en/02_Developer_Guides/03_Forms/03_Form_Templates.md
+++ b/docs/en/02_Developer_Guides/03_Forms/03_Form_Templates.md
@@ -16,7 +16,7 @@ $field = new TextField(..);
 $field->setTemplate('MyCustomTextField');
 ```
 
-Both `MyCustomTemplate.ss` and `MyCustomTextField.ss` should be located in **app/templates/** or your theme's **templates/** directory.
+To override the template for CMS forms, the custom templates should be located in **/app/templates**. Front-end form templates can be located in **/app/templates** or in the active theme's **/templates** directory.
 
 <div class="notice" markdown="1">
 It's recommended to copy the contents of the template you're going to replace and use that as a start. For instance, if


### PR DESCRIPTION
Update guidance on form template location.  They don't necessarily have to be placed in /app/templates, they'll work in the theme directory too.    The current text also seems to suggest that they can be placed in the core directory - something which I don't believe should be advised,

