### PR TITLE
MINOR Always cast formfield display value as a string to avoid 0 being blank

### DIFF
--- a/src/Forms/DropdownField.php
+++ b/src/Forms/DropdownField.php
@@ -106,7 +106,7 @@ class DropdownField extends SingleSelectField
         }
 
         return new ArrayData(array(
-            'Title' => $title,
+            'Title' => (string)$title,
             'Value' => $value,
             'Selected' => $selected,
             'Disabled' => $disabled,


### PR DESCRIPTION
If you have a DropdownField with a display value of `0` as an int, the template doesn't thinkg it exists and displays blank instead.

```php
$sources = ArrayLib::valuekey(range(-1, 10));
$fields->addFieldToTab(
    'Root.Main',
     DropdownField::create('Number', 'Number')->setSource($sources)
);
```

There was a fix for SS3 that never got over the line. https://github.com/silverstripe/silverstripe-framework/pull/7810