### PR TITLE
FIX: Misconfiguration for versioned cache segmentation (fixes #8754)

### DIFF
--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -18,17 +18,14 @@ SilverStripe\Core\Injector\Injector:
       factory: SilverStripe\Core\Cache\CacheFactory
       constructor:
         namespace: "VersionProvider_composerlock"
-        args:
-          disable-container: true
+        disable-container: true
   Psr\SimpleCache\CacheInterface.RateLimiter:
       factory: SilverStripe\Core\Cache\CacheFactory
       constructor:
         namespace: 'ratelimiter'
-        args:
-          disable-container: true
+        disable-container: true
   Psr\SimpleCache\CacheInterface.InheritedPermissions:
     factory: SilverStripe\Core\Cache\CacheFactory
     constructor:
       namespace: "InheritedPermissions"
-      args:
-        disable-container: true
+      disable-container: true

--- a/docs/en/04_Changelogs/4.2.0.md
+++ b/docs/en/04_Changelogs/4.2.0.md
@@ -198,8 +198,7 @@ SilverStripe\Core\Injector\Injector:
     factory: SilverStripe\Core\Cache\CacheFactory     
     constructor:
       namespace: "MyInsensitiveData"
-      args:
-        disable-container: true 
+      disable-container: true 
 ``` 
 
 ### HTTP Cache Header changes


### PR DESCRIPTION
Fixes #8754

No unit tests exist for this in framework (as the cache proxy exists in `silverstripe/versioned`)