### PR TITLE
FIX GridFieldPrintButton no longer assumes that children of GridField would implement their own print template

### DIFF
--- a/src/Forms/GridField/GridFieldPrintButton.php
+++ b/src/Forms/GridField/GridFieldPrintButton.php
@@ -133,7 +133,10 @@ class GridFieldPrintButton implements GridField_HTMLProvider, GridField_ActionPr
         $this->extend('updatePrintData', $data);
 
         if ($data) {
-            return $data->renderWith(get_class($gridField) . "_print");
+            return $data->renderWith([
+                get_class($gridField) . '_print',
+                GridField::class . '_print',
+            ]);
         }
 
         return null;


### PR DESCRIPTION
This allows it to fall back to `GridField_print.ss`.

Fixes https://github.com/silverstripe/silverstripe-framework/issues/8759 and fixes https://github.com/silverstripe/silverstripe-sitewidecontent-report/issues/37