### PR TITLE
Replace self:: with static:: for shortcode methods

### DIFF
--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -114,11 +114,11 @@ class EmbedShortcodeProvider implements ShortcodeHandler
                 if (empty($arguments['width']) && $embed->getWidth()) {
                     $arguments['width'] = $embed->getWidth();
                 }
-                return self::videoEmbed($arguments, $embed->getCode());
+                return static::videoEmbed($arguments, $embed->getCode());
             case 'link':
-                return self::linkEmbed($arguments, $embed->getUrl(), $embed->getTitle());
+                return static::linkEmbed($arguments, $embed->getUrl(), $embed->getTitle());
             case 'photo':
-                return self::photoEmbed($arguments, $embed->getUrl());
+                return static::photoEmbed($arguments, $embed->getUrl());
             default:
                 return null;
         }


### PR DESCRIPTION
In lieu of a proper solution to https://github.com/silverstripe/silverstripe-framework/issues/8762, this is a minor tweak so you can override just the `videoEmbed`/`linkEmbed `/`photoEmbed ` methods directly without also having to override `embedForTemplate`.