### PR TITLE
WIP: FIX Remove coupling to DB when querying a pages CMS fields

### DIFF
--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -296,6 +296,10 @@ class Hierarchy extends DataExtension
         $cacheType = 'numChildren';
         $id = $this->owner->ID;
 
+        if (!$this->owner->isInDB()) {
+            return 0;
+        }
+
         // cached call
         if ($cache) {
             if (isset(self::$cache_numChildren[$baseClass][$cacheType][$id])) {


### PR DESCRIPTION
Fixes a bug where running unit tests on a Page instance (that isn't written to the DB) in a test class that doesn't use a DB connection will fail when it tries to query the non-existent DB.

Steps to reproduce:

* `composer create-project silverstrip/installer ./43test 4.3.x-dev`
* Add test class (below) into `app/tests/ExampleTest.php`
* `vendor/bin/phpunit app/tests`

Expected: should pass
Actual: "No database selected" exception thrown

```php
<?php

use SilverStripe\Dev\SapphireTest;
use SilverStripe\Forms\FieldList;

class ExampleTest extends SapphireTest
{
    public function testExample()
    {
        $page = new Page();
        $this->assertInstanceOf(FieldList::class, $page->getCMSFields());
    }
}

```