### PR TITLE
FIX Escape wildcard characters when matching database name in databaseExists

### DIFF
--- a/src/ORM/Connect/MySQLSchemaManager.php
+++ b/src/ORM/Connect/MySQLSchemaManager.php
@@ -207,7 +207,7 @@ class MySQLSchemaManager extends DBSchemaManager
     public function databaseExists($name)
     {
         // MySQLi doesn't like parameterised queries for some queries
-        $sqlName = $this->database->quoteString($name);
+        $sqlName = addcslashes($this->database->quoteString($name), '%_');
         return !!($this->query("SHOW DATABASES LIKE $sqlName")->value());
     }
 


### PR DESCRIPTION
Currently it's possible that `databaseExists` may return true when a database does not exist if a database name like `my_database` is being checked when a database named `my-database` already exists. We should escape wildcard characters - apparently even `%` is a valid character for table names :cold_sweat: