### PR TITLE
FIX: Prevent null->null being flagged as a value change (fixes #8774)

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -2650,14 +2650,14 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
             }
 
             // if a field is not existing or has strictly changed
-            if (!isset($this->original[$fieldName]) || $this->original[$fieldName] !== $val) {
+            if (!array_key_exists($fieldName, $this->original) || $this->original[$fieldName] !== $val) {
                 // TODO Add check for php-level defaults which are not set in the db
                 // TODO Add check for hidden input-fields (readonly) which are not set in the db
                 // At the very least, the type has changed
                 $this->changed[$fieldName] = self::CHANGE_STRICT;
 
-                if ((!isset($this->original[$fieldName]) && $val)
-                    || (isset($this->original[$fieldName]) && $this->original[$fieldName] != $val)
+                if ((!array_key_exists($fieldName, $this->original) && $val)
+                    || (array_key_exists($fieldName, $this->original) && $this->original[$fieldName] != $val)
                 ) {
                     // Value has changed as well, not just the type
                     $this->changed[$fieldName] = self::CHANGE_VALUE;

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -918,6 +918,13 @@ class DataObjectTest extends SapphireTest
         $this->assertTrue($obj->isChanged('FirstName', DataObject::CHANGE_STRICT));
         $this->assertTrue($obj->isChanged('FirstName', DataObject::CHANGE_VALUE));
 
+        $obj->write();
+        $obj->FirstName = null;
+        $this->assertFalse($obj->isChanged('FirstName', DataObject::CHANGE_STRICT), 'Unchanged property was marked as changed');
+        $obj->FirstName = 0;
+        $this->assertTrue($obj->isChanged('FirstName', DataObject::CHANGE_STRICT), 'Strict (type) change was not detected');
+        $this->assertFalse($obj->isChanged('FirstName', DataObject::CHANGE_VALUE), 'Type-only change was marked as a value change');
+
         /* Test when there's not field provided */
         $obj = $this->objFromFixture(DataObjectTest\Player::class, 'captain2');
         $this->assertFalse($obj->isChanged());


### PR DESCRIPTION
Fixes #8774