### PR TITLE
FIX Filter hostname in TrustedProxyMiddleware

### DIFF
--- a/src/Control/Middleware/TrustedProxyMiddleware.php
+++ b/src/Control/Middleware/TrustedProxyMiddleware.php
@@ -150,7 +150,7 @@ class TrustedProxyMiddleware implements HTTPMiddleware
                 $host = $hostList ? strtok($hostList, ',') : null;
 
                 // Ensure the host name is valid
-                $host = filter_var($host, FILTER_VALIDATE_DOMAIN, ['flags' => FILTER_FLAG_HOSTNAME]);
+                $host = $this->filterHostname($host);
 
                 if ($host) {
                     $request->addHeader('Host', $host);
@@ -181,6 +181,22 @@ class TrustedProxyMiddleware implements HTTPMiddleware
         }
 
         return $delegate($request);
+    }
+
+    /**
+     * Make sure the provided value is a valid hostname
+     * @param string $hostname
+     * @return bool|string
+     */
+    private function filterHostname($hostname)
+    {
+        if (defined('FILTER_VALIDATE_DOMAIN') && defined('FILTER_FLAG_HOSTNAME')) {
+            // Only works on PHP 7
+            return filter_var($hostname, FILTER_VALIDATE_DOMAIN, ['flags' => FILTER_FLAG_HOSTNAME]);
+        } else {
+            $regex = "#^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])#i";
+            return preg_match($regex, $hostname) ? $hostname : false;
+        }
     }
 
     /**

--- a/src/Control/Middleware/TrustedProxyMiddleware.php
+++ b/src/Control/Middleware/TrustedProxyMiddleware.php
@@ -145,8 +145,15 @@ class TrustedProxyMiddleware implements HTTPMiddleware
             // Replace host
             foreach ($this->getProxyHostHeaders() as $header) {
                 $hostList = $request->getHeader($header);
-                if ($hostList) {
-                    $request->addHeader('Host', strtok($hostList, ','));
+
+                // Get first host (if passed through multiple proxies)
+                $host = $hostList ? strtok($hostList, ',') : null;
+
+                // Ensure the host name is valid
+                $host = filter_var($host, FILTER_VALIDATE_DOMAIN, ['flags' => FILTER_FLAG_HOSTNAME]);
+
+                if ($host) {
+                    $request->addHeader('Host', $host);
                     break;
                 }
             }

--- a/tests/php/Control/Middleware/TrustedProxyMiddlewareTest.php
+++ b/tests/php/Control/Middleware/TrustedProxyMiddlewareTest.php
@@ -8,6 +8,36 @@ use SilverStripe\Dev\SapphireTest;
 
 class TrustedProxyMiddlewareTest extends SapphireTest
 {
+    public function goodHostnames()
+    {
+        return [
+            ['127.0.0.1'],
+            ['test1.com'],
+            ['localhost'],
+            ['www.test.com'],
+            ['www.test.com'],
+            ['2001:0db8:85a3:0000:0000:8a2e:0370:7334'],
+            ['localhost:8080'],
+            ['127.0.0.1:8080'],
+            ['vAlId-hOsT'],
+            ['www.monkey.intranet.silverstripe.com'],
+            ['はじめよう.みんな'],
+        ];
+    }
+
+    public function badHostnames()
+    {
+        return [
+            ['">invalid-test.com'],
+            ['invalid_host'],
+            ['invalid host'],
+            ['invalid-char.com#$!#^%$&^&'],
+            ['www.invalid-char.com/some-path'],
+            ['https://www.invalid-char.com'],
+            ['-invalid-host.com'],
+        ];
+    }
+
     public function testIgnoresHostHeaderOnUntrustedIP()
     {
         $m = new TrustedProxyMiddleware();
@@ -29,12 +59,29 @@ class TrustedProxyMiddlewareTest extends SapphireTest
         $this->assertEquals('test1.com', $response->getHeader('Host'));
     }
 
-    public function testFiltersHostHeader()
+    /**
+     * @dataProvider goodHostnames
+     */
+    public function testSetSepecificHostheader($host)
     {
         $m = new TrustedProxyMiddleware();
         $m->setTrustedProxyIPs('*');
         $request = (new HTTPRequest('GET', ''))
-            ->addHeader('X-Forwarded-Host', '">invalid-test.com');
+            ->addHeader('X-Forwarded-Host', $host);
+
+        $response = $m->process($request, $this->getIdentityFn());
+        $this->assertEquals($host, $response->getHeader('Host'));
+    }
+
+    /**
+     * @dataProvider badHostnames
+     */
+    public function testFiltersHostHeader($host)
+    {
+        $m = new TrustedProxyMiddleware();
+        $m->setTrustedProxyIPs('*');
+        $request = (new HTTPRequest('GET', ''))
+            ->addHeader('X-Forwarded-Host', '$host');
 
         $response = $m->process($request, $this->getIdentityFn());
         $this->assertEquals('', $response->getHeader('Host'));

--- a/tests/php/Control/Middleware/TrustedProxyMiddlewareTest.php
+++ b/tests/php/Control/Middleware/TrustedProxyMiddlewareTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SilverStripe\Control\Tests\Middleware;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Middleware\TrustedProxyMiddleware;
+use SilverStripe\Dev\SapphireTest;
+
+class TrustedProxyMiddlewareTest extends SapphireTest
+{
+    public function testIgnoresHostHeaderOnUntrustedIP()
+    {
+        $m = new TrustedProxyMiddleware();
+        $request = (new HTTPRequest('GET', ''))
+            ->addHeader('X-Forwarded-Host', 'test1.com');
+
+        $response = $m->process($request, $this->getIdentityFn());
+        $this->assertEquals('', $response->getHeader('Host'));
+    }
+
+    public function testSetsFirstHostHeader()
+    {
+        $m = new TrustedProxyMiddleware();
+        $m->setTrustedProxyIPs('*');
+        $request = (new HTTPRequest('GET', ''))
+            ->addHeader('X-Forwarded-Host', 'test1.com,test2.com');
+
+        $response = $m->process($request, $this->getIdentityFn());
+        $this->assertEquals('test1.com', $response->getHeader('Host'));
+    }
+
+    public function testFiltersHostHeader()
+    {
+        $m = new TrustedProxyMiddleware();
+        $m->setTrustedProxyIPs('*');
+        $request = (new HTTPRequest('GET', ''))
+            ->addHeader('X-Forwarded-Host', '">invalid-test.com');
+
+        $response = $m->process($request, $this->getIdentityFn());
+        $this->assertEquals('', $response->getHeader('Host'));
+    }
+
+    protected function getIdentityFn()
+    {
+        return function ($response) { return $response; };
+    }
+}

--- a/tests/php/Control/Middleware/TrustedProxyMiddlewareTest.php
+++ b/tests/php/Control/Middleware/TrustedProxyMiddlewareTest.php
@@ -42,6 +42,8 @@ class TrustedProxyMiddlewareTest extends SapphireTest
 
     protected function getIdentityFn()
     {
-        return function ($response) { return $response; };
+        return function ($response) {
+            return $response;
+        };
     }
 }


### PR DESCRIPTION
In depth defense, rather than a security vulnerability.
The trusted proxy IP list is empty by default, meaning no request can set this information.
Systems need to opt in to this behaviour by setting specific proxy IPs.
While there is an "all IPs" option, it's not documented on
https://docs.silverstripe.org/en/4/developer_guides/security/secure_coding/#request-hostname-forgery.
If you find and configure this option, you're also expected to sanitise these layers (e.g. a load balancer).

This issue was originally referred to as SS-2018-024