### PR TITLE
Throw error message when searchable_field does not return a object

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -2241,7 +2241,15 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 
             // Otherwise, use the database field's scaffolder
             } elseif ($object = $this->relObject($fieldName)) {
-                $field = $object->scaffoldSearchField();
+                if (is_object($object) && $object->hasMethod('scaffoldSearchField')) {
+                    $field = $object->scaffoldSearchField();
+                } else {
+                    throw new Exception(sprintf(
+                        "SearchField '%s' on '%s' does not return a valid DBField instance.",
+                        $fieldName,
+                        get_class($this)
+                    ));
+                }
             }
 
             // Allow fields to opt out of search


### PR DESCRIPTION
While upgrading 4.2 to 4.3 the behaviour of GridFieldFilterHeader has changed (example code: https://gist.github.com/wilr/7c59f577e1d072eb66e4c0c84cba6732).

This patch doesn’t affect the behaviour (since the explict object is a better API) but it makes upgrading easier to identify the field.