### PR TITLE
Correct typo and commit hash in 4.3.1 changelog

### DIFF
--- a/docs/en/04_Changelogs/4.3.1.md
+++ b/docs/en/04_Changelogs/4.3.1.md
@@ -6,4 +6,4 @@
 
 ### Security
 
- * 2018-12-18 [c0338d191](https://github.com/silverstripe/silverstripe-framework/commit/25bba49923a5a2cc90afcc64c58184b2fb0f2e20) Fix potential SQL vulnerability in non-scalar value hydration (Maxime Rainville) - See [ss-2018-021](https://www.silverstripe.org/download/security-releases/ss-2018-021)
+ * 2018-12-18 [25bba4992](https://github.com/silverstripe/silverstripe-framework/commit/25bba49923a5a2cc90afcc64c58184b2fb0f2e20) Fix potential SQL vulnerability in non-scalar value hydration (Maxime Rainville) - See [ss-2018-021](https://www.silverstripe.org/download/security-releases/ss-2018-021)

--- a/docs/en/04_Changelogs/4.3.1.md
+++ b/docs/en/04_Changelogs/4.3.1.md
@@ -6,4 +6,4 @@
 
 ### Security
 
- * 2018-12-18 [c0338d191](https://github.com/silverstripe/silverstripe-framework/commit/c0338d191d8be0000ddb16b74832ed8e05ba7ff5) Fix potential SQL vulnerability in non-scalar value hyrdation (Maxime Rainville) - See [ss-2018-021](https://www.silverstripe.org/download/security-releases/ss-2018-021)
+ * 2018-12-18 [c0338d191](https://github.com/silverstripe/silverstripe-framework/commit/25bba49923a5a2cc90afcc64c58184b2fb0f2e20) Fix potential SQL vulnerability in non-scalar value hydration (Maxime Rainville) - See [ss-2018-021](https://www.silverstripe.org/download/security-releases/ss-2018-021)


### PR DESCRIPTION
The previous commit was leading to a 404 page in GitHub.