### PR TITLE
BUG Explicitely define a dependency conflict with phpunit 6 and above

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,5 +101,8 @@
         "php-peg": "php thirdparty/php-peg/cli.php src/View/SSTemplateParser.peg > src/View/SSTemplateParser.php"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "conflict": {
+        "phpunit/phpunit": "<5.3 || >=6"
+    }
 }


### PR DESCRIPTION
This PR updates `composer.json` to explicitly state that SilverStripe won't work with any version of phpunit 6 or above.

The issue here is that if you add phpunit with this command, composer will try to install version 7.5, which will not work at all: `composer require phpunit/phpunit --dev`.

The impetus for this is that it will make my life a bit easier for fixing https://github.com/silverstripe/silverstripe-upgrader/issues/86. They are other ways I could address this, but this one is probably the most elegant.

I've set the lower limit to phpunit 5.3. I ran some quick tests with 5.3 and it appears to work reasonably well, although I didn't throw the kitchen sink at it.