### PR TITLE
BUG Renable the ability to do dynamic assignment with DBField

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -1331,11 +1331,15 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
             if (!isset($tableManipulation['fields'])) {
                 continue;
             }
-            foreach ($tableManipulation['fields'] as $fieldValue) {
+            foreach ($tableManipulation['fields'] as $fieldName => $fieldValue) {
                 if (is_array($fieldValue)) {
-                    throw new InvalidArgumentException(
-                        'DataObject::writeManipulation: parameterised field assignments are disallowed'
-                    );
+                    $dbObject = $this->dbObject($fieldName);
+                    // If the field allows non-scalar values we'll let it do dynamic assignments
+                    if ($dbObject && $dbObject->scalarValueOnly()) {
+                        throw new InvalidArgumentException(
+                            'DataObject::writeManipulation: parameterised field assignments are disallowed'
+                        );
+                    }
                 }
             }
         }

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -57,6 +57,7 @@ class DataObjectTest extends SapphireTest
         DataObjectTest\RelationParent::class,
         DataObjectTest\RelationChildFirst::class,
         DataObjectTest\RelationChildSecond::class,
+        DataObjectTest\MockDynamicAssignmentDataObject::class
     );
 
     public static function getExtraDataObjects()
@@ -2146,5 +2147,35 @@ class DataObjectTest extends SapphireTest
         $do = Company::singleton();
         $do->SalaryCap = array('Amount' => 123456, 'Currency' => 'CAD');
         $this->assertNotEmpty($do->SalaryCap);
+    }
+
+    public function testWriteManipulationWithNonScalarValuesAllowed()
+    {
+        $do = DataObjectTest\MockDynamicAssignmentDataObject::create();
+        $do->write();
+
+        $do->StaticScalarOnlyField = true;
+        $do->DynamicScalarOnlyField = false;
+        $do->DynamicField = true;
+
+        $do->write();
+
+        $this->assertTrue($do->StaticScalarOnlyField);
+        $this->assertFalse($do->DynamicScalarOnlyField);
+        $this->assertTrue($do->DynamicField);
+    }
+
+    public function testWriteManipulationWithNonScalarValuesDisallowed()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $do = DataObjectTest\MockDynamicAssignmentDataObject::create();
+        $do->write();
+
+        $do->StaticScalarOnlyField = false;
+        $do->DynamicScalarOnlyField = true;
+        $do->DynamicField = false;
+
+        $do->write();
     }
 }

--- a/tests/php/ORM/DataObjectTest/MockDynamicAssignmentDBField.php
+++ b/tests/php/ORM/DataObjectTest/MockDynamicAssignmentDBField.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\ORM\Tests\DataObjectTest;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\FieldType\DBBoolean;
 use SilverStripe\ORM\FieldType\DBField;
 
@@ -13,16 +14,16 @@ use SilverStripe\ORM\FieldType\DBField;
  * If the field is set to false, it will try to do a plain assignment. This is so you can save the initial value no
  * matter what. If the field is set to true, it will try to do a dynamic assignment.
  */
-class MockDynamicAssignmentDBField extends DBBoolean
+class MockDynamicAssignmentDBField extends DBBoolean implements TestOnly
 {
 
     private $scalarOnly;
     private $dynamicAssignment;
 
     /**
-     * @param $name
-     * @param $scalarOnly Whether our fake field should be scalar only
-     * @param $dynamicAssigment Wheter our fake field will try to do a dynamic assignement
+     * @param string $name
+     * @param boolean $scalarOnly Whether our fake field should be scalar only.
+     * @param boolean $dynamicAssignment Whether our fake field will try to do a dynamic assignment.
      */
     public function __construct($name = '', $scalarOnly = false, $dynamicAssignment = false)
     {
@@ -32,15 +33,15 @@ class MockDynamicAssignmentDBField extends DBBoolean
     }
 
     /**
-     * If the field value and dynamicAssignment are true, we'll try to do a dynamic assignement
+     * If the field value and $dynamicAssignment are true, we'll try to do a dynamic assignment.
      * @param $value
-     * @return array|int|mixed
+     * @return array|int
      */
     public function prepValueForDB($value)
     {
         if ($value) {
             return $this->dynamicAssignment
-                ? ['GREATEST(?, ?)' => [0, 1]]
+                ? ['ABS(?)' => [1]]
                 : 1;
         }
 

--- a/tests/php/ORM/DataObjectTest/MockDynamicAssignmentDBField.php
+++ b/tests/php/ORM/DataObjectTest/MockDynamicAssignmentDBField.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\ORM\FieldType\DBBoolean;
+use SilverStripe\ORM\FieldType\DBField;
+
+/**
+ * This is a fake DB field specifically design to test dynamic value assignment. You can set `scalarValueOnly` in
+ * the constructor. You can control whetever the field will try to do a dynamic assignment by specifing
+ * `$dynamicAssignment` in nthe consturctor.
+ *
+ * If the field is set to false, it will try to do a plain assignment. This is so you can save the initial value no
+ * matter what. If the field is set to true, it will try to do a dynamic assignment.
+ */
+class MockDynamicAssignmentDBField extends DBBoolean
+{
+
+    private $scalarOnly;
+    private $dynamicAssignment;
+
+    /**
+     * @param $name
+     * @param $scalarOnly Whether our fake field should be scalar only
+     * @param $dynamicAssigment Wheter our fake field will try to do a dynamic assignement
+     */
+    public function __construct($name = '', $scalarOnly = false, $dynamicAssignment = false)
+    {
+        $this->scalarOnly = $scalarOnly;
+        $this->dynamicAssignment = $dynamicAssignment;
+        parent::__construct($name);
+    }
+
+    /**
+     * If the field value and dynamicAssignment are true, we'll try to do a dynamic assignement
+     * @param $value
+     * @return array|int|mixed
+     */
+    public function prepValueForDB($value)
+    {
+        if ($value) {
+            return $this->dynamicAssignment
+                ? ['GREATEST(?, ?)' => [0, 1]]
+                : 1;
+        }
+
+        return 0;
+    }
+
+    public function scalarValueOnly()
+    {
+        return $this->scalarOnly;
+    }
+}

--- a/tests/php/ORM/DataObjectTest/MockDynamicAssignmentDataObject.php
+++ b/tests/php/ORM/DataObjectTest/MockDynamicAssignmentDataObject.php
@@ -30,11 +30,11 @@ class MockDynamicAssignmentDataObject extends DataObject implements TestOnly
     ];
 
     private static $many_many = [
-        "MockManyMany" => self::class,
+        'MockManyMany' => self::class,
     ];
 
     private static $belongs_many_many = [
-        "MockBelongsManyMany" => self::class,
+        'MockBelongsManyMany' => self::class,
     ];
 
     private static $many_many_extraFields = [

--- a/tests/php/ORM/DataObjectTest/MockDynamicAssignmentDataObject.php
+++ b/tests/php/ORM/DataObjectTest/MockDynamicAssignmentDataObject.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ManyManyList;
+
+/**
+ * This is a fake DB field specifically design to test dynamic value assignment
+ * @property boolean $StaticScalarOnlyField
+ * @property boolean $DynamicScalarOnlyField
+ * @property boolean $DynamicField
+ * @method ManyManyList MockManyMany
+ */
+class MockDynamicAssignmentDataObject extends DataObject implements TestOnly
+{
+
+    private static $table_name = 'MockDynamicAssignmentDataObject';
+
+    private static $db = [
+        // This field only emits scalar value and will save
+        'StaticScalarOnlyField' => MockDynamicAssignmentDBField::class . '(1,0)',
+
+        // This field tries to emit dynamic assignment but will fail because of scalar only
+        'DynamicScalarOnlyField' => MockDynamicAssignmentDBField::class . '(1,1)',
+
+        // This field does dynamic assignement and will pass
+        'DynamicField' => MockDynamicAssignmentDBField::class . '(0,1)',
+    ];
+
+    private static $many_many = [
+        "MockManyMany" => self::class,
+    ];
+
+    private static $belongs_many_many = [
+        "MockBelongsManyMany" => self::class,
+    ];
+
+    private static $many_many_extraFields = [
+        'MockManyMany' => [
+            // This field only emits scalar value and will save
+            'ManyManyStaticScalarOnlyField' => MockDynamicAssignmentDBField::class . '(1,0)',
+
+            // This field tries to emit dynamic assignment but will fail because of scalar only
+            'ManyManyDynamicScalarOnlyField' => MockDynamicAssignmentDBField::class . '(1,1)',
+
+            // This field does dynamic assignement and will pass
+            'ManyManyDynamicField' => MockDynamicAssignmentDBField::class . '(0,1)',
+        ]
+    ];
+}

--- a/tests/php/ORM/ManyManyListTest.php
+++ b/tests/php/ORM/ManyManyListTest.php
@@ -10,6 +10,7 @@ use SilverStripe\ORM\Tests\DataObjectTest\Player;
 use SilverStripe\ORM\Tests\DataObjectTest\Team;
 use SilverStripe\ORM\Tests\ManyManyListTest\ExtraFieldsObject;
 use SilverStripe\ORM\Tests\ManyManyListTest\Product;
+use InvalidArgumentException;
 
 class ManyManyListTest extends SapphireTest
 {
@@ -402,7 +403,7 @@ class ManyManyListTest extends SapphireTest
 
     public function testWriteManipulationWithNonScalarValuesDisallowed()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $left = DataObjectTest\MockDynamicAssignmentDataObject::create();
         $left->write();

--- a/tests/php/ORM/ManyManyListTest.php
+++ b/tests/php/ORM/ManyManyListTest.php
@@ -20,6 +20,7 @@ class ManyManyListTest extends SapphireTest
         ManyManyListTest\Category::class,
         ManyManyListTest\ExtraFieldsObject::class,
         ManyManyListTest\Product::class,
+        DataObjectTest\MockDynamicAssignmentDataObject::class
     ];
 
     public static function getExtraDataObjects()
@@ -377,5 +378,41 @@ class ManyManyListTest extends SapphireTest
         /** @var ManyManyList $productsRelatedToProductB */
         $productsRelatedToProductB = $category->Products()->filter('RelatedProducts.Title', 'Product A');
         $this->assertEquals(1, $productsRelatedToProductB->count());
+    }
+
+    public function testWriteManipulationWithNonScalarValuesAllowed()
+    {
+        $left = DataObjectTest\MockDynamicAssignmentDataObject::create();
+        $left->write();
+        $right = DataObjectTest\MockDynamicAssignmentDataObject::create();
+        $right->write();
+
+        $left->MockManyMany()->add($right, [
+            'ManyManyStaticScalarOnlyField' => true,
+            'ManyManyDynamicScalarOnlyField' => false,
+            'ManyManyDynamicField' => true,
+        ]);
+
+        $pivot = $left->MockManyMany()->first();
+
+        $this->assertNotFalse($pivot->ManyManyStaticScalarOnlyField);
+        $this->assertNotTrue($pivot->ManyManyDynamicScalarOnlyField);
+        $this->assertNotFalse($pivot->ManyManyDynamicField);
+    }
+
+    public function testWriteManipulationWithNonScalarValuesDisallowed()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $left = DataObjectTest\MockDynamicAssignmentDataObject::create();
+        $left->write();
+        $right = DataObjectTest\MockDynamicAssignmentDataObject::create();
+        $right->write();
+
+        $left->MockManyMany()->add($right, [
+            'ManyManyStaticScalarOnlyField' => false,
+            'ManyManyDynamicScalarOnlyField' => true,
+            'ManyManyDynamicField' => false,
+        ]);
     }
 }


### PR DESCRIPTION
This partially restores the ability for DBField classes to do dynamic assignment if scalarValueOnly is false.

# Parent issue
* #8814 