### PR TITLE
BUG Renable the ability to do dynamic assignment with DBField

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -1362,12 +1362,16 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 			if (!isset($tableManipulation['fields'])) {
 				continue;
 			}
-			foreach ($tableManipulation['fields'] as $fieldValue) {
+			foreach ($tableManipulation['fields'] as $fieldName => $fieldValue) {
 				if (is_array($fieldValue)) {
-					user_error(
-						'DataObject::writeManipulation: parameterised field assignments are disallowed',
-						E_USER_ERROR
-					);
+                    $dbObject = $this->dbObject($fieldName);
+                    // If the field allows non-scalar values we'll let it do dynamic assignments
+                    if ($dbObject && $dbObject->scalarValueOnly()) {
+                        user_error(
+                            'DataObject::writeManipulation: parameterised field assignments are disallowed',
+                            E_USER_ERROR
+                        );
+                    }
 				}
 			}
 		}

--- a/model/ManyManyList.php
+++ b/model/ManyManyList.php
@@ -254,8 +254,10 @@ class ManyManyList extends RelationList {
 				);
 			}
 
+            /** @var DBField[] $fieldObjects */
+            $fieldObjects = array();
 			if($extraFields && $this->extraFields) {
-				// Write extra field to manipluation in the same way
+				// Write extra field to manipulation in the same way
 				// that DataObject::prepareManipulationTable writes fields
 				foreach($this->extraFields as $fieldName => $fieldSpec) {
 					// Skip fields without an assignment
@@ -263,6 +265,7 @@ class ManyManyList extends RelationList {
 						$fieldObject = Object::create_from_string($fieldSpec, $fieldName);
 						$fieldObject->setValue($extraFields[$fieldName]);
 						$fieldObject->writeToManipulation($manipulation[$this->joinTable]);
+                        $fieldObjects[$fieldName] = $fieldObject;
 					}
 				}
 			}
@@ -275,12 +278,15 @@ class ManyManyList extends RelationList {
                 if (!isset($tableManipulation['fields'])) {
                     continue;
                 }
-                foreach ($tableManipulation['fields'] as $fieldValue) {
+                foreach ($tableManipulation['fields'] as $fieldName => $fieldValue) {
                     if (is_array($fieldValue)) {
-                        user_error(
-                            'ManyManyList::add: parameterised field assignments are disallowed',
-                            E_USER_ERROR
-                        );
+                        // If the field allows non-scalar values we'll let it do dynamic assignments
+                        if (isset($fieldObjects[$fieldName]) && $fieldObjects[$fieldName]->scalarValueOnly()) {
+                            user_error(
+                                'ManyManyList::add: parameterised field assignments are disallowed',
+                                E_USER_ERROR
+                            );
+                        }
                     }
                 }
             }

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -32,6 +32,7 @@ class DataObjectTest extends SapphireTest {
 		'DataObjectTest_Sortable',
 		'ManyManyListTest_Product',
 		'ManyManyListTest_Category',
+        'MockDynamicAssignmentDataObject'
 	);
 
 	/**
@@ -1773,6 +1774,36 @@ class DataObjectTest extends SapphireTest {
         $this->assertNotEmpty($do->CompositeMoneyField);
     }
 
+
+    public function testWriteManipulationWithNonScalarValuesAllowed()
+    {
+        $do = MockDynamicAssignmentDataObject::create();
+        $do->write();
+        $do->StaticScalarOnlyField = true;
+        $do->DynamicScalarOnlyField = false;
+        $do->DynamicField = true;
+        $do->write();
+        $this->assertEquals(1, $do->StaticScalarOnlyField);
+        $this->assertEquals(0, $do->DynamicScalarOnlyField);
+        $this->assertEquals(1, $do->DynamicField);
+    }
+
+    public function testWriteManipulationWithNonScalarValuesDisallowed()
+    {
+
+        $do = MockDynamicAssignmentDataObject::create();
+        $do->write();
+        $do->StaticScalarOnlyField = false;
+        $do->DynamicScalarOnlyField = true;
+        $do->DynamicField = false;
+
+        try {
+            $do->write();
+            $this->fail("Expected exception \"parameterised field assignments are disallowed\"");
+        } catch (Exception $ex) {
+            $this->assertContains('parameterised field assignments are disallowed', $ex->getMessage());
+        }
+    }
 }
 
 class DataObjectTest_Sortable extends DataObject implements TestOnly {

--- a/tests/model/DataObjectTest.php
+++ b/tests/model/DataObjectTest.php
@@ -1788,6 +1788,10 @@ class DataObjectTest extends SapphireTest {
         $this->assertEquals(1, $do->DynamicField);
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_Error
+     * @expectedExceptionMessageRegExp /parameterised field assignments are disallowed/
+     */
     public function testWriteManipulationWithNonScalarValuesDisallowed()
     {
 
@@ -1797,12 +1801,7 @@ class DataObjectTest extends SapphireTest {
         $do->DynamicScalarOnlyField = true;
         $do->DynamicField = false;
 
-        try {
-            $do->write();
-            $this->fail("Expected exception \"parameterised field assignments are disallowed\"");
-        } catch (Exception $ex) {
-            $this->assertContains('parameterised field assignments are disallowed', $ex->getMessage());
-        }
+        $do->write();
     }
 }
 

--- a/tests/model/ManyManyListTest.php
+++ b/tests/model/ManyManyListTest.php
@@ -324,6 +324,10 @@ class ManyManyListTest extends SapphireTest {
         $this->assertEquals(1, $pivot->ManyManyDynamicField);
     }
 
+    /**
+     * @expectedException PHPUnit_Framework_Error
+     * @expectedExceptionMessageRegExp /parameterised field assignments are disallowed/
+     */
     public function testWriteManipulationWithNonScalarValuesDisallowed()
     {
         $left = MockDynamicAssignmentDataObject::create();
@@ -331,16 +335,11 @@ class ManyManyListTest extends SapphireTest {
         $right = MockDynamicAssignmentDataObject::create();
         $right->write();
 
-        try {
-            $left->MockManyMany()->add($right, array(
-                'ManyManyStaticScalarOnlyField' => true,
-                'ManyManyDynamicScalarOnlyField' => false,
-                'ManyManyDynamicField' => true
-            ));
-            $this->fail("Expected exception \"parameterised field assignments are disallowed\"");
-        } catch (Exception $ex) {
-            $this->assertContains('parameterised field assignments are disallowed', $ex->getMessage());
-        }
+        $left->MockManyMany()->add($right, array(
+            'ManyManyStaticScalarOnlyField' => false,
+            'ManyManyDynamicScalarOnlyField' => true,
+            'ManyManyDynamicField' => false
+        ));
     }
 }
 

--- a/tests/model/ManyManyListTest.php
+++ b/tests/model/ManyManyListTest.php
@@ -21,6 +21,7 @@ class ManyManyListTest extends SapphireTest {
 		'ManyManyListTest_ExtraFields',
 		'ManyManyListTest_Product',
 		'ManyManyListTest_Category',
+        'MockDynamicAssignmentDataObject',
 	);
 
 
@@ -306,7 +307,41 @@ class ManyManyListTest extends SapphireTest {
 		$this->assertEquals(1, $productsRelatedToProductB->count());
 	}
 
+    public function testWriteManipulationWithNonScalarValuesAllowed()
+    {
+        $left = MockDynamicAssignmentDataObject::create();
+        $left->write();
+        $right = MockDynamicAssignmentDataObject::create();
+        $right->write();
+        $left->MockManyMany()->add($right, array(
+            'ManyManyStaticScalarOnlyField' => true,
+            'ManyManyDynamicScalarOnlyField' => false,
+            'ManyManyDynamicField' => true
+        ));
+        $pivot = $left->MockManyMany()->first();
+        $this->assertEquals(1, $pivot->ManyManyStaticScalarOnlyField);
+        $this->assertEquals(0, $pivot->ManyManyDynamicScalarOnlyField);
+        $this->assertEquals(1, $pivot->ManyManyDynamicField);
+    }
 
+    public function testWriteManipulationWithNonScalarValuesDisallowed()
+    {
+        $left = MockDynamicAssignmentDataObject::create();
+        $left->write();
+        $right = MockDynamicAssignmentDataObject::create();
+        $right->write();
+
+        try {
+            $left->MockManyMany()->add($right, array(
+                'ManyManyStaticScalarOnlyField' => true,
+                'ManyManyDynamicScalarOnlyField' => false,
+                'ManyManyDynamicField' => true
+            ));
+            $this->fail("Expected exception \"parameterised field assignments are disallowed\"");
+        } catch (Exception $ex) {
+            $this->assertContains('parameterised field assignments are disallowed', $ex->getMessage());
+        }
+    }
 }
 
 /**

--- a/tests/model/Mock/MockDynamicAssignmentDBField.php
+++ b/tests/model/Mock/MockDynamicAssignmentDBField.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This is a fake DB field specifically design to test dynamic value assignment. You can set `scalarValueOnly` in
+ * the constructor. You can control whetever the field will try to do a dynamic assignment by specifing
+ * `$dynamicAssignment` in nthe consturctor.
+ *
+ * If the field is set to false, it will try to do a plain assignment. This is so you can save the initial value no
+ * matter what. If the field is set to true, it will try to do a dynamic assignment.
+ */
+class MockDynamicAssignmentDBField extends Boolean
+{
+
+    private $scalarOnly;
+    private $dynamicAssignment;
+
+    /**
+     * @param $name
+     * @param boolean $scalarOnly Whether our fake field should be scalar only.
+     * @param boolean $dynamicAssignment Whether our fake field will try to do a dynamic assignment.
+     */
+    public function __construct($name = '', $scalarOnly = false, $dynamicAssignment = false)
+    {
+        $this->scalarOnly = $scalarOnly;
+        $this->dynamicAssignment = $dynamicAssignment;
+        parent::__construct($name);
+    }
+
+    /**
+     * If the field value and dynamicAssignment are true, we'll try to do a dynamic assignment
+     * @param $value
+     * @return array|int|mixed
+     */
+    public function prepValueForDB($value)
+    {
+        if ($value) {
+            return $this->dynamicAssignment
+                ? array('GREATEST(?, ?)' => array(0, 1))
+                : 1;
+        }
+
+        return 0;
+    }
+
+    public function scalarValueOnly()
+    {
+        return $this->scalarOnly;
+    }
+}

--- a/tests/model/Mock/MockDynamicAssignmentDBField.php
+++ b/tests/model/Mock/MockDynamicAssignmentDBField.php
@@ -15,7 +15,7 @@ class MockDynamicAssignmentDBField extends Boolean
     private $dynamicAssignment;
 
     /**
-     * @param $name
+     * @param string $name
      * @param boolean $scalarOnly Whether our fake field should be scalar only.
      * @param boolean $dynamicAssignment Whether our fake field will try to do a dynamic assignment.
      */
@@ -28,7 +28,7 @@ class MockDynamicAssignmentDBField extends Boolean
 
     /**
      * If the field value and dynamicAssignment are true, we'll try to do a dynamic assignment
-     * @param $value
+     * @param mixed $value
      * @return array|int|mixed
      */
     public function prepValueForDB($value)

--- a/tests/model/Mock/MockDynamicAssignmentDBField.php
+++ b/tests/model/Mock/MockDynamicAssignmentDBField.php
@@ -35,7 +35,7 @@ class MockDynamicAssignmentDBField extends Boolean
     {
         if ($value) {
             return $this->dynamicAssignment
-                ? array('GREATEST(?, ?)' => array(0, 1))
+                ? array('ABS(?)' => array(1))
                 : 1;
         }
 

--- a/tests/model/Mock/MockDynamicAssignmentDataObject.php
+++ b/tests/model/Mock/MockDynamicAssignmentDataObject.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This is a fake DB field specifically design to test dynamic value assignment
+ * @property boolean $StaticScalarOnlyField
+ * @property boolean $DynamicScalarOnlyField
+ * @property boolean $DynamicField
+ * @method ManyManyList MockManyMany
+ */
+class MockDynamicAssignmentDataObject extends DataObject implements TestOnly
+{
+
+    private static $db = array(
+        // This field only emits scalar value and will save
+        'StaticScalarOnlyField' => 'MockDynamicAssignmentDBField(1,0)',
+
+        // This field tries to emit dynamic assignment but will fail because of scalar only
+        'DynamicScalarOnlyField' => 'MockDynamicAssignmentDBField(1,1)',
+
+        // This field does dynamic assignment and will pass
+        'DynamicField' => 'MockDynamicAssignmentDBField(0,1)',
+    );
+
+    private static $many_many = array(
+        "MockManyMany" => 'MockDynamicAssignmentDataObject'
+    );
+
+    private static $belongs_many_many = array(
+        "MockBelongsManyMany" => 'MockDynamicAssignmentDataObject'
+    );
+
+    private static $many_many_extraFields = array(
+        'MockManyMany' => array(
+            // This field only emits scalar value and will save
+            'ManyManyStaticScalarOnlyField' => 'MockDynamicAssignmentDBField(1,0)',
+
+            // This field tries to emit dynamic assignment but will fail because of scalar only
+            'ManyManyDynamicScalarOnlyField' => 'MockDynamicAssignmentDBField(1,1)',
+
+            // This field does dynamic assignment and will pass
+            'ManyManyDynamicField' => 'MockDynamicAssignmentDBField(0,1)',
+        )
+    );
+}


### PR DESCRIPTION
This partially restores the ability for DBField classes to do dynamic assignment if scalarValueOnly is false.

# Parent issue
* #8814