### PR TITLE
BUG Fix writeBaseRecord with unique indexes

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -1413,8 +1413,10 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         // Inserts done one the base table are performed in another step, so the manipulation should instead
         // attempt an update, as though it were a normal update.
         $manipulation[$table]['command'] = $isNewRecord ? 'insert' : 'update';
-        $manipulation[$table]['id'] = $this->record['ID'];
         $manipulation[$table]['class'] = $class;
+        if ($this->isInDB()) {
+            $manipulation[$table]['id'] = $this->record['ID'];
+        }
     }
 
     /**
@@ -1433,10 +1435,10 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         }
 
         // Perform an insert on the base table
-        $insert = new SQLInsert('"' . $baseTable . '"');
-        $insert
-            ->assign('"Created"', $now)
-            ->execute();
+        $manipulation = [];
+        $this->prepareManipulationTable($baseTable, $now, true, $manipulation, $this->baseClass());
+        DB::manipulate($manipulation);
+
         $this->changed['ID'] = self::CHANGE_VALUE;
         $this->record['ID'] = DB::get_generated_id($baseTable);
     }

--- a/tests/php/ORM/DataObjectSchemaTest.php
+++ b/tests/php/ORM/DataObjectSchemaTest.php
@@ -343,4 +343,35 @@ class DataObjectSchemaTest extends SapphireTest
             'columns' => ['IndexedMoneyCurrency', 'IndexedMoneyAmount']
         ], $indexes['IndexedMoney']);
     }
+
+    /**
+     * Ensure that records with unique indexes can be written
+     */
+    public function testWriteUniqueIndexes()
+    {
+        // Create default object
+        $zeroObject = new AllIndexes();
+        $zeroObject->Number = 0;
+        $zeroObject->write();
+
+        $this->assertListEquals(
+            [
+                ['Number' => 0],
+            ],
+            AllIndexes::get()
+        );
+
+        // Test a new record can be created without clashing with default value
+        $validObject = new AllIndexes();
+        $validObject->Number = 1;
+        $validObject->write();
+
+        $this->assertListEquals(
+            [
+                ['Number' => 0],
+                ['Number' => 1],
+            ],
+            AllIndexes::get()
+        );
+    }
 }

--- a/tests/php/ORM/DataObjectSchemaTest/AllIndexes.php
+++ b/tests/php/ORM/DataObjectSchemaTest/AllIndexes.php
@@ -5,6 +5,11 @@ use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBIndexable;
 
+/**
+ * @property int $Number
+ * @property string $Content
+ * @property string $Title
+ */
 class AllIndexes extends DataObject implements TestOnly
 {
     private static $table_name = 'DataObjectSchemaTest_AllIndexes';


### PR DESCRIPTION
Fixes #6819

I've had this bug in mind for years. This will fix the below bug once and for all:

```
Couldn't run query:

INSERT INTO "App_MemberRole"
 (\"Created\")
 VALUES
 (?)

Duplicate entry '0-0' for key 'OneMemberPerProperty'
```

This often came up when writing ChangesetItem due to the primary key being a composite on a couple of columns.