### PR TITLE
check a value is_scalar only on the database fields

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -2677,8 +2677,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 				user_error('DataObject::setField: passed an object that is not a DBField', E_USER_WARNING);
 			}
 
-			$dbField = $this->dbObject($fieldName);
-			if ($dbField && $dbField->scalarValueOnly() && !empty($val) && !is_scalar($val)){
+			if ($this->db($fieldName) && ($dbField = $this->dbObject($fieldName))  && $dbField->scalarValueOnly() && !empty($val) && !is_scalar($val)){
 			    $val = null;
                 user_error(
                     sprintf(


### PR DESCRIPTION
The new security check `scalarValueOnly` affects on any of the variables assigned on to a data object regardless its going to be saved on to the database or not. 

By adding an extra check on the condition to see whether the field is actually going to be stored in the database it still let you set / overwrite the values on to a data object. 

```
$myDataObject->Image = $myImage; // this sort of this is denied with the is scalar function when it is overridden. 
```



Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/