### PR TITLE
Include baseURL with relative setGetVar() links

### DIFF
--- a/src/Control/HTTP.php
+++ b/src/Control/HTTP.php
@@ -268,7 +268,7 @@ class HTTP
         $newUri = $scheme . '://' . $user . $host . $port . $path . $params . $fragment;
 
         if ($isRelative) {
-            return Director::makeRelative($newUri);
+            return Director::baseURL() . Director::makeRelative($newUri);
         }
 
         return $newUri;

--- a/tests/php/Control/HTTPTest.php
+++ b/tests/php/Control/HTTPTest.php
@@ -246,13 +246,13 @@ class HTTPTest extends FunctionalTest
         }, 'relative/url/');
 
         $this->assertEquals(
-            'relative/url?foo=bar',
+            '/relative/url?foo=bar',
             HTTP::setGetVar('foo', 'bar', 'relative/url'),
             'Relative URL without existing query params'
         );
 
         $this->assertEquals(
-            'relative/url?baz=buz&foo=bar',
+            '/relative/url?baz=buz&foo=bar',
             HTTP::setGetVar('foo', 'bar', '/relative/url?baz=buz'),
             'Relative URL with existing query params, and new added key'
         );


### PR DESCRIPTION
Ensures relative URLs returned with `HTTP::setGetVar()` include `Director::baseURL()`, and thus no reliance on the meta `base` tag. One example where this is an issue is with all URLs generated from `PaginatedList` as reported in #8823 

This should also be fixed in the SilverStripe 3 branch. Assuming this solution is accepted, should I create a separate pull request for that branch too?