### PR TITLE
Use '/' as an alternative designation for root in routing

### DIFF
--- a/docs/en/02_Developer_Guides/02_Controllers/02_Routing.md
+++ b/docs/en/02_Developer_Guides/02_Controllers/02_Routing.md
@@ -214,6 +214,30 @@ Director:
     'feed': 'FeedController'
 ```
 
+## Root URL Handlers
+
+In some cases, the Director rule covers the entire URL you intend to match, and you simply want the controller to respond to a 'root' request. This request will automatically direct to an `index()` method if it exists on the controller, but you can also set a custom method to use in `$url_handlers` with the `'/'` key:
+
+```php
+use SilverStripe\Control\Controller;
+
+class BreadAPIController extends Controller
+{
+    private static $allowed_actions = [
+        'getBreads',
+        'createBread',
+    ];
+
+    private static $url_handlers = [
+        'GET /' => 'getBreads',
+        'POST /' => 'createBread',
+    ];
+```
+
+<div class="alert" markdown="1">
+In SilverStripe Framework versions prior to 4.6, an empty key (`''`) must be used in place of the `'/'` key. When specifying an HTTP method, the empty string must be separated from the method (e.g. `'GET '`). The empty key and slash key are also equivalent in Director rules.
+</div>
+
 ## Related Lessons
 * [Creating filtered views](https://www.silverstripe.org/learn/lessons/v4/creating-filtered-views-1)
 * [Controller actions / DataObjects as pages](https://www.silverstripe.org/learn/lessons/v4/controller-actions-dataobjects-as-pages-1)

--- a/src/Control/HTTPRequest.php
+++ b/src/Control/HTTPRequest.php
@@ -521,8 +521,8 @@ class HTTPRequest implements ArrayAccess
             $pattern = $matches[2];
         }
 
-        // Special case for the root URL controller
-        if (!$pattern) {
+        // Special case for the root URL controller (designated as an empty string, or a slash)
+        if (!$pattern || $pattern === '/') {
             return ($this->dirParts == array()) ? array('Matched' => true) : false;
         }
 

--- a/tests/php/Control/ControllerTest.php
+++ b/tests/php/Control/ControllerTest.php
@@ -14,6 +14,7 @@ use SilverStripe\Control\Tests\ControllerTest\IndexSecuredController;
 use SilverStripe\Control\Tests\ControllerTest\SubController;
 use SilverStripe\Control\Tests\ControllerTest\TestController;
 use SilverStripe\Control\Tests\ControllerTest\UnsecuredController;
+use SilverStripe\Control\Tests\RequestHandlingTest\HTTPMethodTestController;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Security\Member;
 use SilverStripe\View\SSViewer;
@@ -34,6 +35,7 @@ class ControllerTest extends FunctionalTest
         ContainerController::class,
         HasAction::class,
         HasAction_Unsecured::class,
+        HTTPMethodTestController::class,
         IndexSecuredController::class,
         SubController::class,
         TestController::class,
@@ -492,5 +494,16 @@ class ControllerTest extends FunctionalTest
         // Handle nested action
         $response = $this->get('ContainerController/subcontroller/substring/subvieweraction');
         $this->assertEquals('Hope this works', $response->getBody());
+    }
+
+    public function testSpecificHTTPMethods()
+    {
+        // 'GET /'
+        $response = $this->get('HTTPMethodTestController');
+        $this->assertEquals('Routed to getRoot', $response->getBody());
+
+        // 'POST ' (legacy method of specifying root route)
+        $response = $this->post('HTTPMethodTestController', ['dummy' => 'example']);
+        $this->assertEquals('Routed to postLegacyRoot', $response->getBody());
     }
 }

--- a/tests/php/Control/RequestHandlingTest/HTTPMethodTestController.php
+++ b/tests/php/Control/RequestHandlingTest/HTTPMethodTestController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SilverStripe\Control\Tests\RequestHandlingTest;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\TestOnly;
+
+class HTTPMethodTestController extends Controller implements TestOnly
+{
+    private static $url_segment = 'HTTPMethodTestController';
+
+    private static $url_handlers = [
+        'GET /' => 'getRoot',
+        'POST ' => 'postLegacyRoot',
+    ];
+
+    private static $allowed_actions = [
+        'getRoot',
+        'postLegacyRoot',
+    ];
+
+    public function getRoot(HTTPRequest $request)
+    {
+        return "Routed to getRoot";
+    }
+
+    public function postLegacyRoot(HTTPRequest $request)
+    {
+        return "Routed to postLegacyRoot";
+    }
+}

--- a/tests/php/Control/RequestHandlingTest/TestFormHandler.php
+++ b/tests/php/Control/RequestHandlingTest/TestFormHandler.php
@@ -13,8 +13,8 @@ class TestFormHandler extends FormRequestHandler
 {
     private static $url_handlers = array(
         'fields/$FieldName' => 'handleField',
-        "POST " => "handleSubmission",
-        "GET " => "handleGet",
+        "POST /" => "handleSubmission",
+        "GET /" => "handleGet",
     );
 
     // These are a different case from those in url_handlers to confirm that it's all case-insensitive


### PR DESCRIPTION
Currently, SilverStripe's router logic uses an empty string (`''`) as the sole designation for a 'root' rule in Director config and in URL Handlers in controllers. This generally makes sense and works fine, until you try to specify an HTTP method in your URL Handler:

```
private static $url_handler = [
    'GET' => 'getMethod' // Matches /GET as a URL
    'GET /' => 'getMethod' // Calls getMethod, but _also_ throws a 'cannot handle sub-URLs' error
    'GET ' => 'getMethod' // Works, but looks bizarre and is undocumented
];
```

Specifying HTTP methods is arguably an important security practice, and avoids adding boilerplate in the top of Controller methods in order to fail early when the wrong method is used. It also allows different controller methods to be used for different HTTP methods against the same URL, e.g. separating 'GET the things' from 'POST a new thing'.

This PR adds `'/'` as a valid alternative to `''` for designating a 'root' rule, which results in more sensible config:

```
private static $url_handler = [
    'GET /' => 'getMethod' // Now works as expected!
    '/' => 'anyMethod' // Also works
];
```

This will also apply to Director rules, though it's less relevant there. I opted not to push for the empty string matching to be deprecated at this stage, but it might make sense to minimise inconsistencies - keen to get feedback on the new behaviour first.