### PR TITLE
FIX Manipulation ID is now always present although it can be null

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -1414,9 +1414,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         // attempt an update, as though it were a normal update.
         $manipulation[$table]['command'] = $isNewRecord ? 'insert' : 'update';
         $manipulation[$table]['class'] = $class;
-        if ($this->isInDB()) {
-            $manipulation[$table]['id'] = $this->record['ID'];
-        }
+        $manipulation[$table]['id'] = isset($this->record['ID']) ? $this->record['ID'] : null;
     }
 
     /**


### PR DESCRIPTION
A follow on from https://github.com/silverstripe/silverstripe-framework/pull/8831 that still defines the manipulation ID but with a null value instead. Removing it entirely seems to break some behaviour in manipulation proxy modules that we use (fulltextsearch, auditor, etc). See https://travis-ci.org/silverstripe/cwp-recipe-kitchen-sink/jobs/500785254.

Fixes https://github.com/silverstripeltd/cc-issues/issues/252