### PR TITLE
FIX Default database connector to MySQLPDODatabase

### DIFF
--- a/src/Core/CoreKernel.php
+++ b/src/Core/CoreKernel.php
@@ -289,7 +289,7 @@ class CoreKernel implements Kernel
     {
         /** @skipUpgrade */
         $databaseConfig = [
-            "type" => Environment::getEnv('SS_DATABASE_CLASS') ?: 'MySQLDatabase',
+            "type" => Environment::getEnv('SS_DATABASE_CLASS') ?: 'MySQLPDODatabase',
             "server" => Environment::getEnv('SS_DATABASE_SERVER') ?: 'localhost',
             "username" => Environment::getEnv('SS_DATABASE_USERNAME') ?: null,
             "password" => Environment::getEnv('SS_DATABASE_PASSWORD') ?: null,


### PR DESCRIPTION
Set the default database type to MySQLPDODatabase if config `SS_DATABASE_CLASS` is not defined.
That means a PDO connector is used instead of a MySQLi connector.

## Reasoning:
As per changelog of SilverStripe 4.0 (https://docs.silverstripe.org/en/4/changelogs/4.0.0/) the DB Driver **defaults** to **PDO**. This change was introduced in commit https://github.com/silverstripe/silverstripe-framework/commit/9a0e01d4a083514c70992d8c7625c6cfedd6e54a
This has is also highlighted in the documentation of the core environment variables: https://docs.silverstripe.org/en/4/getting_started/environment_management/#core-environment-variables

_However_, when refactoring the API of bootstrap and request handling the behaviour prior to commit 9a0e01d4a was reintroduced.
That means the database connection does  **no**  longer default to **PDO** after commit  https://github.com/silverstripe/silverstripe-framework/commit/3873e4ba008cfc2af7e26ca86665affc289cd677, but uses the previous default MySQLi connection.