### PR TITLE
Added an option to create an empty DataList.

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1185,6 +1185,25 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
     }
 
     /**
+     * Returns a DataList of the same dataClass which will always yield empty results
+     *
+     * @return DataList
+     */
+    public function getEmptyList()
+    {
+        // clear any existing query conditions to make the query as lightweight as possible
+        $list = DataList::create($this->dataClass);
+
+        // set an impossible condition which targets indexed DB column
+        $list = $list->byIDs([0]);
+
+        // limit further minimizes the query (can't do limit 0 though T_T)
+        $list = $list->limit(1);
+
+        return $list;
+    }
+
+    /**
      * Reverses a list of items.
      *
      * @return static

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -1815,4 +1815,13 @@ class DataListTest extends SapphireTest
             $list->column("Title")
         );
     }
+
+    public function testGetEmptyList()
+    {
+        $players = Player::get();
+        $this->assertGreaterThan(0, (int) $players->count());
+
+        $players = $players->getEmptyList();
+        $this->assertEquals(0, (int) $players->count());
+    }
 }


### PR DESCRIPTION
Added an option to create an empty `DataList` via a helper function. This is useful when handling some special cases where:

* empty results should be returned and the logic that shapes the `DataList` is quite complex
* we are interested to keep function signature unchanged (mostly for PHP 7)
* don't want to deal with `null` values