### PR TITLE
NEW Avoid repeat readonly transformations in FieldList and Form

### DIFF
--- a/src/Forms/FieldList.php
+++ b/src/Forms/FieldList.php
@@ -35,6 +35,14 @@ class FieldList extends ArrayList
      */
     protected $containerField;
 
+    /**
+     * Determines if the entire field list was transformed to readonly state.
+     * Even if this is false, the list might still contain readonly fields.
+     *
+     * @var bool
+     */
+    protected $readonly = false;
+
     public function __construct($items = array())
     {
         if (!is_array($items) || func_num_args() > 1) {
@@ -808,13 +816,43 @@ class FieldList extends ArrayList
     }
 
     /**
-     * Transforms this FieldList instance to readonly.
+     * @return bool
+     */
+    public function isReadonly()
+    {
+        return $this->readonly;
+    }
+
+    /**
+     * Sets a read-only flag.
+     * Use makeReadonly() to transform this instance.
+     * Setting this to false has no effect.
+     *
+     * @param bool $readonly
+     *
+     * @return $this
+     */
+    public function setReadonly($readonly)
+    {
+        $this->readonly = $readonly;
+        return $this;
+    }
+
+    /**
+     * Transforms this FieldList instance to readonly, and returns a new instance.
+     * Returns the original instance if it's already marked as readonly.
      *
      * @return FieldList
      */
     public function makeReadonly()
     {
-        return $this->transform(new ReadonlyTransformation());
+        if ($this->isReadonly()) {
+            return $this;
+        }
+
+        $clone = $this->transform(new ReadonlyTransformation());
+        $clone->setReadonly(true);
+        return $clone;
     }
 
     /**

--- a/tests/php/Forms/FieldListTest.php
+++ b/tests/php/Forms/FieldListTest.php
@@ -1141,6 +1141,26 @@ class FieldListTest extends SapphireTest
         );
     }
 
+    public function testIsReadonly()
+    {
+        $list = new FieldList(
+            new TextField('A')
+        );
+        $this->assertFalse($list->isReadonly());
+        $list->setReadonly(true);
+        $this->assertTrue($list->isReadonly());
+    }
+
+    public function testMakeReadonly()
+    {
+        $list = new FieldList(
+            $field = new TextField('A')
+        );
+        $readonlyList = $list->makeReadonly();
+        $this->assertTrue($readonlyList->isReadonly());
+        $this->assertTrue($readonlyList->fieldByName('A')->isReadonly());
+    }
+
     /**
      * Test VisibleFields and HiddenFields
      */

--- a/tests/php/Forms/FormTest.php
+++ b/tests/php/Forms/FormTest.php
@@ -148,6 +148,29 @@ class FormTest extends FunctionalTest
         $this->assertNotContains('hacxzored', $response->getBody());
     }
 
+    public function testMakeReadonly()
+    {
+        $form = new Form(
+            Controller::curr(),
+            'Form',
+            new FieldList(
+                new TextField('MyField')
+            ),
+            new FieldList(
+                new FormAction('MyAction')
+            )
+        );
+        $this->assertFalse($form->isReadonly());
+        $this->assertFalse($form->Fields()->isReadonly());
+        $this->assertFalse($form->Actions()->isReadonly());
+
+        $form = $form->makeReadonly();
+
+        $this->assertTrue($form->isReadonly());
+        $this->assertTrue($form->Fields()->isReadonly());
+        $this->assertTrue($form->Actions()->isReadonly());
+    }
+
     public function testLoadDataFromUnchangedHandling()
     {
         $form = new Form(


### PR DESCRIPTION
This is an important performance optimisation to avoid repeatedly transforming those objects.
Since field sets can be deeply nested, and return clones of all fields on readonly transformation,
that's a significant processing overhead. It can also confuse fields which assume they're already transformed.

In particular, both LeftAndMain->getEditForm() and CMSMain->getEditForm() call $fields->makeReadonly(),
with slightly different criteria:
- LeftAndMain checks for $record->canEdit()
- CMSMain checks for !$record->canEdit() || $deletedFromStage
- If you have workflow installed, it transforms to readonly a *third time* in AdvancedWorkflowExtension->updateEditForm() based on $record->canEditWorkflow()

Admittedly this is increasing the surface of an already inconsistent API:
- Form->makeReadonly(), FieldList->makeReadonly(), but FormField->performReadonlyTransformation()
- setReadonly() is an internal helper, but needs to be public since it's called on cloned instances
- FormField->isDisabled(), but no higher level functions on Form or FieldList to transform all fields to disabled
- A readonly form can still process submissions (I think, haven't tested if it checks for FormAction->isReadonly())

I still think it's worthwhile due to the large performance impact of doing the same work repeatedly.
It relies on the code invoking readonly transformations to check, rather than making the readonly state setting
part of the transformation itself. I could call setReadonly() in ReadonlyTransformation, but that would only apply to FormField.
Neither Form nor FieldList use ReadonlyTransformation in their makeReadonly() implementations.