### PR TITLE
NEW: Add PHP 7.4’s daily snapshot to the travis suite.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,15 @@ matrix:
         - DB=MYSQL
         - PHPUNIT_TEST=framework
 
+    - php: 7.4snapshot
+      env:
+        - DB=MYSQL
+        - PHPUNIT_TEST=framework
+      addons:
+        apt:
+          packages:
+            - libonig-dev
+
 before_script:
 # Extra $PATH
   - export PATH=~/.composer/vendor/bin:$PATH


### PR DESCRIPTION
This will help avoid any inadvertent 7.4 failures; IMO the sooner we
add new releases to the test mix the better.

If this ends up creating intermittent failures outside of our control
I would recommend rolling back entirely rather than adding to
allowed_failures.