### PR TITLE
NEW: Add PHP 7.4’s daily snapshot to the travis suite (SS 3.7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,11 @@ matrix:
       services:
        - mysql
 
-    - php: 7.3.0RC1
+    - php: 7.3
       env: DB=SQLITE
-      sudo: required
-      dist: xenial
-      addons:
-        apt:
-          packages:
-            - libzip4
+
+    - php: 7.4snapshot
+      env: DB=SQLITE
 
     # CMS test
     - php: 5.5


### PR DESCRIPTION
Also clean up the PHP 7.3 build.

This will help avoid any inadvertent 7.4 failures; IMO the sooner we
add new releases to the test mix the better.

If this ends up creating intermittent failures outside of our control
I would recommend rolling back entirely rather than adding to
allowed_failures.

The main goal of testing PHP 7.4 on SS3 sites is to let us keep 
upgrading PHP versions regularly until the end of SS3’s life.
