### PR TITLE
applyRelation versioning fix, ORM enhancements

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -501,6 +501,13 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * Unlike getRelationName, this is immutable and will fallback to the quoted field
      * name if not a relation.
      *
+     * Example use (simple WHERE condition on data sitting in a related table):
+     *
+     * <code>
+     *  $columnName = null;
+     *  $list = Page::get()->applyRelation('TaxonomyTerms.ID', $columnName)->where([$columnName => <some_value>]);
+     * </code>
+     *
      * @param string $field Name of field or relation to apply
      * @param string &$columnName Quoted column name
      * @param bool $linearOnly Set to true to restrict to linear relations only. Set this

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -4,8 +4,6 @@ namespace SilverStripe\ORM\Tests;
 
 use InvalidArgumentException;
 use LogicException;
-use Page;
-use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\i18n\i18n;
@@ -20,11 +18,7 @@ use SilverStripe\ORM\FieldType\DBPolymorphicForeignKey;
 use SilverStripe\ORM\FieldType\DBVarchar;
 use SilverStripe\ORM\ManyManyList;
 use SilverStripe\ORM\Tests\DataObjectTest\Company;
-use SilverStripe\ORM\Tests\DataObjectTest\Fan;
-use SilverStripe\ORM\Tests\DataObjectTest\OtherSubclassWithSameField;
 use SilverStripe\ORM\Tests\DataObjectTest\Player;
-use SilverStripe\ORM\Tests\DataObjectTest\SubTeam;
-use SilverStripe\ORM\Tests\DataObjectTest\Team;
 use SilverStripe\View\ViewableData;
 use stdClass;
 
@@ -63,7 +57,12 @@ class DataObjectTest extends SapphireTest
         DataObjectTest\RelationParent::class,
         DataObjectTest\RelationChildFirst::class,
         DataObjectTest\RelationChildSecond::class,
-        DataObjectTest\MockDynamicAssignmentDataObject::class
+        DataObjectTest\MockDynamicAssignmentDataObject::class,
+        DataObjectTest\House::class,
+        DataObjectTest\HouseVisit::class,
+        DataObjectTest\Visitor::class,
+        DataObjectTest\Roof::class,
+        DataObjectTest\WoodenRoof::class,
     );
 
     public static function getExtraDataObjects()

--- a/tests/php/ORM/DataObjectTest.yml
+++ b/tests/php/ORM/DataObjectTest.yml
@@ -179,3 +179,21 @@ SilverStripe\ORM\Tests\DataObjectTest\RelationChildFirst:
     ManyNext:
       - =>SilverStripe\ORM\Tests\DataObjectTest\RelationChildSecond.test1
       - =>SilverStripe\ORM\Tests\DataObjectTest\RelationChildSecond.test3
+
+SilverStripe\ORM\Tests\DataObjectTest\WoodenRoof:
+  roof-1:
+    Title: 'Roof1'
+
+SilverStripe\ORM\Tests\DataObjectTest\House:
+  house-1:
+    Title: 'House1'
+    Roof: =>SilverStripe\ORM\Tests\DataObjectTest\WoodenRoof.roof-1
+
+SilverStripe\ORM\Tests\DataObjectTest\Visitor:
+  visitor-1:
+    Title: 'Visitor1'
+
+SilverStripe\ORM\Tests\DataObjectTest\HouseVisit:
+  visit-1:
+    House: =>SilverStripe\ORM\Tests\DataObjectTest\House.house-1
+    Visitor: =>SilverStripe\ORM\Tests\DataObjectTest\Visitor.visitor-1

--- a/tests/php/ORM/DataObjectTest/House.php
+++ b/tests/php/ORM/DataObjectTest/House.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\HasManyList;
+use SilverStripe\ORM\ManyManyThroughList;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Class House
+ *
+ * @property string $Title
+ * @property int $RoofID
+ * @method WoodenRoof Roof()
+ * @method ManyManyThroughList|Visitor[] Visitors()
+ * @method HasManyList|HouseVisit[] HouseVisits()
+ * @package SilverStripe\ORM\Tests\DataObjectTest
+ */
+class House extends DataObject implements TestOnly
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'DataObjectTest_House';
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'Title' => 'Varchar(50)',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $has_one = [
+        'Roof' => WoodenRoof::class,
+    ];
+
+    /**
+     * @var array
+     */
+    private static $has_many = [
+        'HouseVisits' => HouseVisit::class . '.House',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $many_many = [
+        'Visitors' => [
+            'through' => HouseVisit::class,
+            'from' => 'House',
+            'to' => 'Visitor',
+        ],
+    ];
+
+    /**
+     * @var array
+     */
+    private static $extensions = [
+        Versioned::class,
+    ];
+}

--- a/tests/php/ORM/DataObjectTest/HouseVisit.php
+++ b/tests/php/ORM/DataObjectTest/HouseVisit.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Class HouseVisit
+ *
+ * @property int $HouseID
+ * @property int $VisitorID
+ * @method House House()
+ * @method Visitor Visitor()
+ * @package SilverStripe\ORM\Tests\DataObjectTest
+ */
+class HouseVisit extends DataObject implements TestOnly
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'DataObjectTest_HouseVisit';
+
+    /**
+     * @var array
+     */
+    private static $has_one = [
+        'House' => House::class,
+        'Visitor' => Visitor::class,
+    ];
+
+    /**
+     * @var array
+     */
+    private static $extensions = [
+        Versioned::class,
+    ];
+}

--- a/tests/php/ORM/DataObjectTest/Roof.php
+++ b/tests/php/ORM/DataObjectTest/Roof.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Class Roof
+ *
+ * @property string $Title
+ * @package SilverStripe\ORM\Tests\DataObjectTest
+ */
+class Roof extends DataObject implements TestOnly
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'DataObjectTest_Roof';
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'Title' => 'Varchar(50)',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $extensions = [
+        Versioned::class,
+    ];
+}

--- a/tests/php/ORM/DataObjectTest/Visitor.php
+++ b/tests/php/ORM/DataObjectTest/Visitor.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\HasManyList;
+use SilverStripe\ORM\ManyManyThroughList;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Class Visitor
+ *
+ * @property string $Title
+ * @method ManyManyThroughList|House[] Houses()
+ * @method HasManyList|HouseVisit[] VisitedHouses()
+ * @package SilverStripe\ORM\Tests\DataObjectTest
+ */
+class Visitor extends DataObject implements TestOnly
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'DataObjectTest_Visitor';
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'Title' => 'Varchar(50)',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $has_many = [
+        'VisitedHouses' => HouseVisit::class.'.Visitor',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $belongs_many_many = [
+        'Houses' => House::class.'.Visitors',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $extensions = [
+        Versioned::class,
+    ];
+}

--- a/tests/php/ORM/DataObjectTest/WoodenRoof.php
+++ b/tests/php/ORM/DataObjectTest/WoodenRoof.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+/**
+ * Class WoodenRoof
+ *
+ * @property int $WoodType
+ * @method House House()
+ * @package SilverStripe\ORM\Tests\DataObjectTest
+ */
+class WoodenRoof extends Roof
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'DataObjectTest_WoodenRoof';
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'WoodType' => 'Int',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $belongs_to = [
+        'House' => House::class.'.WoodenRoof',
+    ];
+}


### PR DESCRIPTION
ORM functionality fixes / enhancements:

* `DataQuery::applyRelation` now supports versioned tables
* improved documentation on how to use `DataList::applyRelation`
* `column` function now accepts table prefix format of DB fields, which allows querying data of related tables (via join)
* column function now throws `InvalidArgumentException` if an invalid field is provided instead of failing on the query later

Example use:

* pages `<- many many ->` taxonomy terms
* fetch all pages that have a specific taxonomy term
* fetch IDs of all taxonomy terms which are attached to specific pages