### PR TITLE
API Allow empty arraylists to be typed

### DIFF
--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -2,13 +2,13 @@
 
 namespace SilverStripe\ORM;
 
-use SilverStripe\Dev\Debug;
-use SilverStripe\View\ArrayData;
-use SilverStripe\View\ViewableData;
 use ArrayIterator;
 use InvalidArgumentException;
 use LogicException;
+use SilverStripe\Dev\Debug;
 use SilverStripe\Dev\Deprecation;
+use SilverStripe\View\ArrayData;
+use SilverStripe\View\ViewableData;
 
 /**
  * A list object that wraps around an array of objects or arrays.
@@ -45,16 +45,38 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     }
 
     /**
+     * Underlying type class for this list
+     *
+     * @var string
+     */
+    protected $dataClass = null;
+
+    /**
      * Return the class of items in this list, by looking at the first item inside it.
      *
      * @return string
      */
     public function dataClass()
     {
+        if ($this->dataClass) {
+            return $this->dataClass;
+        }
         if (count($this->items) > 0) {
             return get_class($this->items[0]);
         }
         return null;
+    }
+
+    /**
+     * Hint this list to a specific type
+     *
+     * @param string $class
+     * @return $this
+     */
+    public function setDataClass($class)
+    {
+        $this->dataClass = $class;
+        return $this;
     }
 
     /**
@@ -257,6 +279,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * field. This is especially useful when combining lists.
      *
      * @param string $field
+     * @return $this
      */
     public function removeDuplicates($field = 'ID')
     {

--- a/tests/behat/src/CmsUiContext.php
+++ b/tests/behat/src/CmsUiContext.php
@@ -58,9 +58,9 @@ class CmsUiContext implements Context
         $timeoutMs = $this->getMainContext()->getAjaxTimeout();
         $this->getSession()->wait(
             $timeoutMs,
-            "(".
-            "document.getElementsByClassName('cms-content-loading-overlay').length +".
-            "document.getElementsByClassName('cms-loading-container').length".
+            "(" .
+            "document.getElementsByClassName('cms-content-loading-overlay').length +" .
+            "document.getElementsByClassName('cms-loading-container').length" .
             ") == 0"
         );
     }

--- a/tests/php/Control/SimpleResourceURLGeneratorTest.php
+++ b/tests/php/Control/SimpleResourceURLGeneratorTest.php
@@ -36,7 +36,7 @@ class SimpleResourceURLGeneratorTest extends SapphireTest
             __DIR__ . '/SimpleResourceURLGeneratorTest/_fakewebroot/basemodule/client/file.js'
         );
         $this->assertEquals(
-            '/'. RESOURCES_DIR . '/basemodule/client/file.js?m=' . $mtime,
+            '/' . RESOURCES_DIR . '/basemodule/client/file.js?m=' . $mtime,
             $generator->urlForResource('basemodule/client/file.js')
         );
     }
@@ -49,7 +49,7 @@ class SimpleResourceURLGeneratorTest extends SapphireTest
             __DIR__ . '/SimpleResourceURLGeneratorTest/_fakewebroot/vendor/silverstripe/mymodule/client/style.css'
         );
         $this->assertEquals(
-            '/'. RESOURCES_DIR . '/vendor/silverstripe/mymodule/client/style.css?m=' . $mtime,
+            '/' . RESOURCES_DIR . '/vendor/silverstripe/mymodule/client/style.css?m=' . $mtime,
             $generator->urlForResource('vendor/silverstripe/mymodule/client/style.css')
         );
     }
@@ -72,7 +72,7 @@ class SimpleResourceURLGeneratorTest extends SapphireTest
         );
 
         $this->assertEquals(
-            '/'. RESOURCES_DIR . '/basemodule/client/file.js?m=' . $mtime,
+            '/' . RESOURCES_DIR . '/basemodule/client/file.js?m=' . $mtime,
             $generator->urlForResource('basemodule/client/file.js')
         );
     }
@@ -89,7 +89,7 @@ class SimpleResourceURLGeneratorTest extends SapphireTest
             __DIR__ . '/SimpleResourceURLGeneratorTest/_fakewebroot/vendor/silverstripe/mymodule/client/style.css'
         );
         $this->assertEquals(
-            '/'. RESOURCES_DIR . '/vendor/silverstripe/mymodule/client/style.css?m=' . $mtime,
+            '/' . RESOURCES_DIR . '/vendor/silverstripe/mymodule/client/style.css?m=' . $mtime,
             $generator->urlForResource($module->getResource('client/style.css'))
         );
     }

--- a/tests/php/Core/Manifest/ModuleResourceTest.php
+++ b/tests/php/Core/Manifest/ModuleResourceTest.php
@@ -42,7 +42,7 @@ class ModuleResourceTest extends SapphireTest
             $resource->getPath()
         );
         $this->assertStringStartsWith(
-            '/basefolder/'. RESOURCES_DIR . '/module/client/script.js?m=',
+            '/basefolder/' . RESOURCES_DIR . '/module/client/script.js?m=',
             $resource->getURL()
         );
     }
@@ -60,7 +60,7 @@ class ModuleResourceTest extends SapphireTest
             $resource->getPath()
         );
         $this->assertStringStartsWith(
-            '/basefolder/'. RESOURCES_DIR . '/vendor/silverstripe/modulec/client/script.js?m=',
+            '/basefolder/' . RESOURCES_DIR . '/vendor/silverstripe/modulec/client/script.js?m=',
             $resource->getURL()
         );
     }
@@ -80,7 +80,7 @@ class ModuleResourceTest extends SapphireTest
             $resource->getPath()
         );
         $this->assertStringStartsWith(
-            '/basefolder/'. RESOURCES_DIR . '/vendor/silverstripe/modulec/client/script.js?m=',
+            '/basefolder/' . RESOURCES_DIR . '/vendor/silverstripe/modulec/client/script.js?m=',
             $resource->getURL()
         );
     }

--- a/tests/php/ORM/ArrayListTest.php
+++ b/tests/php/ORM/ArrayListTest.php
@@ -2,12 +2,11 @@
 
 namespace SilverStripe\ORM\Tests;
 
+use SilverStripe\Dev\Deprecation;
+use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Filterable;
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\View\ArrayData;
-use SilverStripe\Dev\Deprecation;
 use stdClass;
 
 class ArrayListTest extends SapphireTest
@@ -739,6 +738,7 @@ class ArrayListTest extends SapphireTest
         // This call will trigger a fatal error if there are issues with circular dependencies
         $items->sort('Sort');
     }
+
     /**
      * $list->filter('Name', 'bob'); // only bob in the list
      */
@@ -1223,5 +1223,17 @@ class ArrayListTest extends SapphireTest
 
         $element = $list->byID(1);
         $this->assertNull($element);
+    }
+
+    public function testDataClass()
+    {
+        $list = new ArrayList([
+            new DataObject(['Title' => 'one']),
+        ]);
+        $this->assertEquals(DataObject::class, $list->dataClass());
+        $list->pop();
+        $this->assertNull($list->dataClass());
+        $list->setDataClass(DataObject::class);
+        $this->assertEquals(DataObject::class, $list->dataClass());
     }
 }


### PR DESCRIPTION
Replaces https://github.com/silverstripe/silverstripe-framework/pull/8852

Allows an empty typed list to be created. Useful for GridFields or other areas where dataclass is essential, even for empty sets.

I've run the phpcs linter over framework and it caught a few issues on the way.