### PR TITLE
DOCS Add details about the recommended community support options

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,9 +10,9 @@ Community support is provided by members of our open source community and is pro
 
 You can find support via:
 
-- [Forum](https://forum.silverstripe.com)
-- [Slack](https://silverstripe.org/slack)
 - [Stack Overflow (remember to tag as silverstripe)](http://stackoverflow.com/questions/tagged/silverstripe)
+- [Slack](https://silverstripe.org/slack)
+- [Forum](https://forum.silverstripe.com)
 
 We recommend choosing the support forum based on the nature of your question:
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -14,6 +14,22 @@ You can find support via:
 - [Slack](https://silverstripe.org/slack)
 - [Stack Overflow (remember to tag as silverstripe)](http://stackoverflow.com/questions/tagged/silverstripe)
 
+We recommend choosing the support forum based on the nature of your question:
+
+##### Do you have some code you've tried that isn't working?
+
+Your question will likely be best on Stack Overflow. You can add some detail about what you're trying to achieve and include some code that you have tried. Stack Overflow is a good forum for answers to be detailed and become available in the future for other developers in your position. Remember to [follow the guidance on Stack Overflow](https://stackoverflow.com/help/how-to-ask) for asking good questions!
+
+##### Are you looking for an answer to a quick question or a recommendation for an approach or suitable SilverStripe module?
+
+The SilverStripe community Slack has a wealth of active SilverStripe developers active daily. Remember that those who contribute usually do so in their free time so be considerate when messaging people directly. Consider if your issue might benefit another developer before choosing Slack. An alternate forum like StackOverflow may help other developers that are experiencing the same issue find a resolution.
+
+##### Are you looking for detailed feedback on a suggestion or module you have developed?
+
+Try starting a discussion in the community forum. Developers and users alike use the forum to keep up to date with the SilverStripe community and contributions that people are making or discussing.
+
+##### More information
+
 For more information please see our [community page](http://www.silverstripe.org/community/#introduction).
 
 ## Commercial support

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -12,23 +12,23 @@ You can find support via:
 
 - [Stack Overflow (remember to tag as silverstripe)](http://stackoverflow.com/questions/tagged/silverstripe)
 - [Slack](https://silverstripe.org/slack)
-- [Forum](https://forum.silverstripe.com)
+- [Forum](https://forum.silverstripe.org)
 
 We recommend choosing the support forum based on the nature of your question:
 
-##### Do you have some code you've tried that isn't working?
+### Do you have some code you've tried that isn't working?
 
 Your question will likely be best on Stack Overflow. You can add some detail about what you're trying to achieve and include some code that you have tried. Stack Overflow is a good forum for answers to be detailed and become available in the future for other developers in your position. Remember to [follow the guidance on Stack Overflow](https://stackoverflow.com/help/how-to-ask) for asking good questions!
 
-##### Are you looking for an answer to a quick question or a recommendation for an approach or suitable SilverStripe module?
+### Are you looking for an answer to a quick question or a recommendation for an approach or suitable SilverStripe module?
 
 The SilverStripe community Slack has a wealth of active SilverStripe developers active daily. Remember that those who contribute usually do so in their free time so be considerate when messaging people directly. Consider if your issue might benefit another developer before choosing Slack. An alternate forum like StackOverflow may help other developers that are experiencing the same issue find a resolution.
 
-##### Are you looking for detailed feedback on a suggestion or module you have developed?
+### Are you looking for detailed feedback on a suggestion or module you have developed?
 
 Try starting a discussion in the community forum. Developers and users alike use the forum to keep up to date with the SilverStripe community and contributions that people are making or discussing.
 
-##### More information
+### More information
 
 For more information please see our [community page](http://www.silverstripe.org/community/#introduction).
 


### PR DESCRIPTION
This is a suggestion that we try to be a little more specific about recommending support options. Currently we list the three support options in our documentation; Slack, our forum, and Stack Overflow. It seems to me that the vast majority of users will choose the Slack option. Although I think Slack is a great resource there is one often easy to miss drawback - it's not particularly useful for contributing back - support provided on Slack is not particularly _reusable_.

I recommend we do more to advocate Stack Overflow as an option. This community has put in a bunch of effort to ensure questions are asked well, are well moderated (by the community), and that there is a good interface/experience for an answerer to contribute. Additionally I think all developers can agree that StackOverflow have some pretty amazing SEO - something evident by how often you see Stack Overflow answers in your Google search results.

To this effect I've suggested some changes to our `SUPPORT.md` file that lists these community options - just some potential lead-in questions that you may have when looking for support. I'm very happy to receive feedback here - I'm not sure that I've been particularly eloquent here.