### PR TITLE
Fix: Allow editing of relation if item is created.

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -206,7 +206,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
 
         // If we are creating a new record in a has-many list, then
         // Disable the form field as it has no effect.
-        if ($list instanceof HasManyList) {
+        if ($list instanceof HasManyList && !$this->record->isInDB()) {
             $key = $list->getForeignKey();
 
             if ($field = $fields->dataFieldByName($key)) {


### PR DESCRIPTION
Based on the comments in source

```
// If we are creating a new record in a has-many list, then
// Disable the form field as it has no effect.
```

but it still disable the field when the record was already created. 

This fix allow user to edit the field. 