### PR TITLE
NEW Update FieldList::replaceField API to match removeByName

### DIFF
--- a/src/Forms/CompositeField.php
+++ b/src/Forms/CompositeField.php
@@ -379,9 +379,17 @@ class CompositeField extends FormField
         $this->children->removeByName($fieldName, $dataFieldOnly);
     }
 
-    public function replaceField($fieldName, $newField)
+    /**
+     * @param $fieldName
+     * @param $newField
+     * @param boolean $dataFieldOnly If this is true, then a field will only
+     * be replaced if it's a data field.  Dataless fields, such as tabs, will
+     * not be considered for replacement.
+     * @return bool
+     */
+    public function replaceField($fieldName, $newField, $dataFieldOnly = true)
     {
-        return $this->children->replaceField($fieldName, $newField);
+        return $this->children->replaceField($fieldName, $newField, $dataFieldOnly);
     }
 
     public function rootFieldList()

--- a/src/Forms/FieldList.php
+++ b/src/Forms/FieldList.php
@@ -379,14 +379,16 @@ class FieldList extends ArrayList
      *
      * @param string $fieldName The name of the field to replace
      * @param FormField $newField The field object to replace with
+     * @param boolean $dataFieldOnly If this is true, then a field will only be replaced if it's a data field.  Dataless
+     *                               fields, such as tabs, will be not be considered for replacement.
      * @return boolean TRUE field was successfully replaced
      *                   FALSE field wasn't found, nothing changed
      */
-    public function replaceField($fieldName, $newField)
+    public function replaceField($fieldName, $newField, $dataFieldOnly = true)
     {
         $this->flushFieldsCache();
         foreach ($this as $i => $field) {
-            if ($field->getName() == $fieldName && $field->hasData()) {
+            if ($field->getName() == $fieldName && (!$dataFieldOnly || $field->hasData())) {
                 $this->items[$i] = $newField;
                 return true;
             } elseif ($field instanceof CompositeField) {


### PR DESCRIPTION
This specifically adds the parameter that `removeByName` has but `replaceField` does not. This parameter is set to `true` by default rather than inheriting the same default as `removeByField`. This is because the existing funtionality of `replaceField` was the same as if this parameter was set to `true`. This should be updated in SS5 to match the `removeByField` API.

Fixes #8875 - See this issue for more detail