### PR TITLE
[WIP] Don't set a BOM on exported CSVs

### DIFF
--- a/src/Forms/GridField/GridFieldExportButton.php
+++ b/src/Forms/GridField/GridFieldExportButton.php
@@ -171,7 +171,6 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
         $csvWriter->setDelimiter($this->getCsvSeparator());
         $csvWriter->setEnclosure($this->getCsvEnclosure());
         $csvWriter->setNewline("\r\n"); //use windows line endings for compatibility with some csv libraries
-        $csvWriter->setOutputBOM(Writer::BOM_UTF8);
 
         if (!Config::inst()->get(get_class($this), 'xls_export_disabled')) {
             $csvWriter->addFormatter(function (array $row) {


### PR DESCRIPTION
Adding a BOM to CSV files causes all sorts of problems, especially when opening them in Excel (https://superuser.com/questions/1158036/excel-often-save-csv-files-as-tab-delimited-format-what-happened).

It also seems to cause problems when simply re-importing exported files without changes. It appears that the BOM may be considered part of the name in the first header field. I've verified this by removing the BOM and importing the same file with or without the BOM. When the BOM is there the first field is blanked out whereas without the BOM the import works as expected.

Note that in SS3 the exported file format is UTF-8 without a BOM.

Fixes #8884.