### PR TITLE
BUG Update installer to create the assets folder if its missing

### DIFF
--- a/src/Dev/Install/InstallRequirements.php
+++ b/src/Dev/Install/InstallRequirements.php
@@ -283,6 +283,10 @@ class InstallRequirements
             array("File permissions", "Is the assets/ directory writeable?", null),
             true
         );
+        // Make sure asset path actually exists
+        if (!file_exists(ASSETS_PATH)) {
+            mkdir(ASSETS_PATH);
+        }
 
         // Ensure all assets files are writable
         $innerIterator = new RecursiveDirectoryIterator(ASSETS_PATH, RecursiveDirectoryIterator::SKIP_DOTS);


### PR DESCRIPTION
If you start your project with `composer create-project silverstripe/recipe-cms`, the assets folder doesn't get created automatically. The installer falls on its face if the assets folder doesn't exists.

This PR simply makes that directory if it's missing and writeable. 

# Parent issue
* https://github.com/silverstripe/recipe-cms/issues/25