### PR TITLE
📝 DOCS - Update path

### DIFF
--- a/docs/en/02_Developer_Guides/03_Forms/Field_types/03_HTMLEditorField.md
+++ b/docs/en/02_Developer_Guides/03_Forms/Field_types/03_HTMLEditorField.md
@@ -164,7 +164,7 @@ HtmlEditorConfig::get('cms')->setOption(
 
 <div class="notice" markdown="1">
 The default setting for the CMS's `extended_valid_elements` we are overriding here can be found in 
-`vendor/silverstripe/framework/admin/_config.php`.
+`vendor/silverstripe/admin/_config.php`.
 </div>
 
 ## Writing custom plugins


### PR DESCRIPTION
The valid elements config for the HTML Editor have shifted from the framework into admin.

Have updated the path to match.