### PR TITLE
DOCS HistoryViewerField updates

### DIFF
--- a/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
+++ b/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
@@ -1014,6 +1014,7 @@ SilverStripe\GraphQL\Manager:
             fields: [ID, LastEdited]
             operations:
               readOne: true
+              rollback: true
           SilverStripe\Security\Member:
             fields: [ID, FirstName, Surname]
             operations:
@@ -1087,7 +1088,7 @@ const config = {
       variables: {
         limit,
         offset: ((page || 1) - 1) * limit,
-        block_id: recordId,
+        id: recordId,
       }
     };
   },
@@ -1125,7 +1126,7 @@ const config = {
             refetch({
               offset: ((page || 1) - 1) * limit,
               limit,
-              block_id: recordId,
+              id: recordId,
             });
           }
         },


### PR DESCRIPTION
* Add missing rollback operation in scaffolding example
* Update block_id references to id  to allow query to read query to run successfully in conjunction with HistoryViewerField (assume originally copied from Elemental)