### PR TITLE
Including is_array validation to getEnv method.

### DIFF
--- a/src/Core/Environment.php
+++ b/src/Core/Environment.php
@@ -185,11 +185,11 @@ class Environment
     public static function getEnv($name)
     {
         switch (true) {
-            case array_key_exists($name, static::$env):
+            case  is_array(static::$env) && array_key_exists($name, static::$env):
                 return static::$env[$name];
-            case array_key_exists($name, $_ENV):
+            case  is_array($_ENV) && array_key_exists($name, $_ENV):
                 return $_ENV[$name];
-            case array_key_exists($name, $_SERVER):
+            case  is_array($_SERVER) && array_key_exists($name, $_SERVER):
                 return $_SERVER[$name];
             default:
                 return getenv($name);


### PR DESCRIPTION
When SS website is deployed to FortRabbit .env file is read as string what causes the website to crash, due to the lack of type check at getEnv method.
This validation is required for anyone trying to deploy an SS website to FortRabbit.

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/