### PR TITLE
FIX: Show RightTitle on CheckboxField

### DIFF
--- a/templates/SilverStripe/Forms/CheckboxField_holder.ss
+++ b/templates/SilverStripe/Forms/CheckboxField_holder.ss
@@ -1,6 +1,6 @@
 <div id="$HolderID" class="field<% if extraClass %> $extraClass<% end_if %>">
 	$Field
-	<label class="right" for="$ID">$Title</label>
+    <label class="right" for="$ID">$Title<% if $RightTitle %> $RightTitle<% end_if %></label>
 	<% if $Message %><span class="message $MessageType">$Message</span><% end_if %>
 	<% if $Description %><span class="description">$Description</span><% end_if %>
 </div>

--- a/templates/SilverStripe/Forms/CheckboxField_holder_small.ss
+++ b/templates/SilverStripe/Forms/CheckboxField_holder_small.ss
@@ -1,5 +1,5 @@
 $Field
 
 <% if $Title %>
-	<label class="checkboxfield-small" <% if $ID %>for="$ID"<% end_if %>>$Title</label>
+	<label class="checkboxfield-small" <% if $ID %>for="$ID"<% end_if %>>$Title<% if $RightTitle %> $RightTitle<% end_if %></label>
 <% end_if %>


### PR DESCRIPTION
RightTitle, if set, will be shown after Title
with a space between them.

Fixes https://github.com/silverstripe/silverstripe-framework/issues/3819

Also related: https://github.com/silverstripe/silverstripe-admin/pull/854