### PR TITLE
MemberTest and SecurityTest now set the default authenticator to use

### DIFF
--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -46,6 +46,17 @@ class MemberTest extends FunctionalTest
         //This is because the test relies on the yaml file being interpreted according to a particular date format
         //and this setup occurs before the setUp method is run
         i18n::config()->set('default_locale', 'en_US');
+
+        // Set the default authenticator to use for these tests
+        Injector::inst()->load([
+            Security::class => [
+                'properties' => [
+                    'Authenticators' => [
+                        'default' => '%$' . MemberAuthenticator::class,
+                    ],
+                ],
+            ],
+        ]);
     }
 
     /**
@@ -393,6 +404,7 @@ class MemberTest extends FunctionalTest
         $member->PasswordExpiry = date('Y-m-d', time() + 86400);
         $this->assertFalse($member->isPasswordExpired());
     }
+
     public function testInGroups()
     {
         /** @var Member $staffmember */
@@ -844,8 +856,8 @@ class MemberTest extends FunctionalTest
         $fields = $member->getCMSFields();
 
         /**
- * @skipUpgrade
-*/
+         * @skipUpgrade
+         */
         $this->assertNotNull($fields->dataFieldByName('Email'), 'Scaffolded fields are retained');
         $this->assertNull($fields->dataFieldByName('Salt'), 'Field modifications run correctly');
         $this->assertNotNull($fields->dataFieldByName('TestMemberField'), 'Extension is applied correctly');

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -10,6 +10,7 @@ use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Session;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\DataObject;
@@ -46,6 +47,17 @@ class SecurityTest extends FunctionalTest
         // Set to an empty array of authenticators to enable the default
         Config::modify()->set(MemberAuthenticator::class, 'authenticators', []);
         Config::modify()->set(MemberAuthenticator::class, 'default_authenticator', MemberAuthenticator::class);
+
+        // Set the default authenticator to use for these tests
+        Injector::inst()->load([
+            Security::class => [
+                'properties' => [
+                    'Authenticators' => [
+                        'default' => '%$' . MemberAuthenticator::class,
+                    ],
+                ],
+            ],
+        ]);
 
         /**
          * @skipUpgrade


### PR DESCRIPTION
These tests assume that the default authenticator is MemberAuthenticator. Project code and third party modules can change it, which can be seen in the CWP kitchen sink (https://github.com/silverstripeltd/cc-issues/issues/295). This ensures a default value is set in the test setUp methods.