### PR TITLE
FIX: prevent unnecessary field alterations for enums with empty defaults

### DIFF
--- a/src/ORM/Connect/MySQLSchemaManager.php
+++ b/src/ORM/Connect/MySQLSchemaManager.php
@@ -284,7 +284,7 @@ class MySQLSchemaManager extends DBSchemaManager
                 $fieldSpec .= " character set $collInfo[Charset] collate $field[Collation]";
             }
 
-            if ($field['Default'] || $field['Default'] === "0") {
+            if ($field['Default'] || $field['Default'] === "0" || $field['Default'] === '') {
                 $fieldSpec .= " default " . $this->database->quoteString($field['Default']);
             }
             if ($field['Extra']) {


### PR DESCRIPTION
Given a db config with:

```php
private static $db = [
    'MyEnum' => 'Enum(array("", "Y", "N"))'
];
```

Every `dev/build` will result in an unnecessary field alteration and the message (note the `(from ...` is missing the `default ''` on the end):

```
Field Table.MyEnum: changed to enum('','Y','N') character set utf8 collate
utf8_general_ci default ''
(from enum('','Y','N') character set utf8 collate utf8_general_ci)
```