### PR TITLE
FIX: Better error message when GridFieldLevelup passed bad record details

### DIFF
--- a/src/Forms/GridField/GridFieldLevelup.php
+++ b/src/Forms/GridField/GridFieldLevelup.php
@@ -62,6 +62,11 @@ class GridFieldLevelup implements GridField_HTMLProvider
 
         /** @var DataObject|Hierarchy $modelObj */
         $modelObj = DataObject::get_by_id($modelClass, $this->currentID);
+        if (!$modelObj) {
+            throw new \LogicException(
+                "Can't find object of class $modelClass ID #{$this->currentID} for GridFieldLevelup"
+            );
+        }
 
         $parent = null;
         if ($modelObj->hasMethod('getParent')) {


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/3519
