### PR TITLE
Fix reference to webconfig.php, an invalid file

### DIFF
--- a/docs/en/03_Upgrading/01_Upgrading_project.md
+++ b/docs/en/03_Upgrading/01_Upgrading_project.md
@@ -1094,11 +1094,11 @@ If you are using a modified `index.php`, `.htaccess`, or `web.config`, you will 
 * Create a `public` folder in the root of your project
 * Move the following files and folder to your new public folder
   * `index.php`
-  * `.htaccess`
-  * `webconfig.php`
+  * `.htaccess` (if you're using Apache)
+  * `web.config` (if you're using IIS)
   * `assets`
   * Any `favicon` files
-  * Other common files that should be accssible in your project webroot (example: `robots.txt`)
+  * Other common files that should be accessible in your project webroot (e.g. `robots.txt`, or the `.well-known` directory)
 * Delete the root `resources` or `_resources` directories if present.
 * Run the following command `composer vendor-expose` to make static assets files accessible via the `public` directory.
 


### PR DESCRIPTION
The upgrading docs reference webconfig.php, which is incorrect and has never existed. I presume the docs mean to reference web.config, which is the IIS configuration file.

I've also fixed a couple of minor spelling mistakes and mentioned Apache for htaccess and IIS for web.config so people know what they're for.

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/