### PR TITLE
NEW DataQuery::exists now generates EXISTS SQL statements

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -963,7 +963,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      */
     public function exists()
     {
-        return $this->count() > 0;
+        return $this->dataQuery->exists();
     }
 
     /**

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -459,7 +459,7 @@ class DataQuery
      *
      * @return bool
      */
-    public function exists()
+    public function exists(): bool
     {
         // Grab a statement selecting "everything" - the engine shouldn't care what's being selected in an "EXISTS"
         // statement anyway

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -466,11 +466,16 @@ class DataQuery
         $statement = $this->getFinalisedQuery();
         $statement->setSelect('*');
 
-        // Clear limit, distinct, grouping, and order as it's not relevant for an exists query
+        // Clear limit, distinct, and order as it's not relevant for an exists query
         $statement->setDistinct(false);
         $statement->setOrderBy(null);
-        $statement->setGroupBy(null);
         $statement->setLimit(null);
+
+        // We can remove grouping if there's no "having" that might be relying on an aggregate
+        $having = $statement->getHaving();
+        if (empty($having)) {
+            $statement->setGroupBy(null);
+        }
 
         // Wrap the whole thing in an "EXISTS"
         $sql = 'SELECT EXISTS(' . $statement->sql($params) . ')';

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -484,7 +484,7 @@ class DataQuery
         $result = reset($row);
 
         // Checking for 't' supports PostgreSQL before silverstripe/postgresql@2.2
-        return $result === 1 || $result === 't';
+        return $result === true || $result === 1 || $result === 't';
     }
 
     /**

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -464,7 +464,6 @@ class DataQuery
         // Grab a statement selecting "everything" - the engine shouldn't care what's being selected in an "EXISTS"
         // statement anyway
         $statement = $this->getFinalisedQuery();
-        $statement->setSelect('*');
 
         // Clear limit, distinct, and order as it's not relevant for an exists query
         $statement->setDistinct(false);
@@ -472,8 +471,10 @@ class DataQuery
         $statement->setLimit(null);
 
         // We can remove grouping if there's no "having" that might be relying on an aggregate
+        // Additionally, the columns being selected no longer matter
         $having = $statement->getHaving();
         if (empty($having)) {
+            $statement->setSelect('*');
             $statement->setGroupBy(null);
         }
 

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -6,6 +6,7 @@ use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\Tests\DataQueryTest\ObjectE;
 use SilverStripe\Security\Member;
 
 /**
@@ -386,11 +387,7 @@ class DataQueryTest extends SapphireTest
         $query = new DataQuery(DataQueryTest\ObjectC::class);
         $query->sort('"SortOrder"');
         $query->where(
-            [
-            '"DataQueryTest_C"."Title" = ? OR "DataQueryTest_E"."SortOrder" > ?' => [
-                'First', 2
-            ]
-            ]
+            ['"DataQueryTest_C"."Title" = ? OR "DataQueryTest_E"."SortOrder" > ?' => ['First', 2]]
         );
         $result = $query->getFinalisedQuery(['Title']);
         $from = $result->getFrom();
@@ -465,5 +462,12 @@ class DataQueryTest extends SapphireTest
         $this->assertEquals('First', $titles[0]);
         $this->assertEquals('Second', $titles[1]);
         $this->assertEquals('Last', $titles[2]);
+    }
+
+    public function testExistsCreatesFunctionalQueries()
+    {
+        $this->assertTrue(ObjectE::get()->exists());
+        $this->assertFalse(ObjectE::get()->where(['"Title" = ?' => 'Foo'])->exists());
+        $this->assertTrue(ObjectE::get()->dataQuery()->groupby('"SortOrder"')->exists());
     }
 }


### PR DESCRIPTION
This PR adds an `exists` method to DataQuery that will generate an `EXISTS` statement from the existing query. This basically looks like this:

```
SELECT EXISTS(SELECT * FROM MyDataObject WHERE SomeProperty)
```

This is the preferred way to do these sorts of queries as the engine can just do checks like "does the `MyDataObject.SomeProperty` index have _any_ entries for `true`" - this can be a lot faster than counting results.

