### PR TITLE
FIX Table aliases are retained on base tables in queries built using SQLConditionalExpression

### DIFF
--- a/src/ORM/Queries/SQLConditionalExpression.php
+++ b/src/ORM/Queries/SQLConditionalExpression.php
@@ -283,10 +283,16 @@ abstract class SQLConditionalExpression extends SQLExpression
             // array('type' => 'inner', 'table' => 'SiteTree', 'filter' => array("SiteTree.ID = 1",
             // "Status = 'approved'", 'order' => 20))
             if (!is_array($join)) {
-                if (!empty($alias) && !is_numeric($alias) && $alias !== trim($join, '"')) {
-                    $trimmedAlias = trim($alias, '"');
+                if (empty($alias) || is_numeric($alias)) {
+                    continue;
+                }
+
+                $trimmedAlias = trim($alias, '"');
+
+                if ($trimmedAlias !== trim($join, '"')) {
                     $joins[$alias] = "{$join} AS \"{$trimmedAlias}\"";
                 }
+
                 continue;
             }
 

--- a/src/ORM/Queries/SQLConditionalExpression.php
+++ b/src/ORM/Queries/SQLConditionalExpression.php
@@ -283,6 +283,10 @@ abstract class SQLConditionalExpression extends SQLExpression
             // array('type' => 'inner', 'table' => 'SiteTree', 'filter' => array("SiteTree.ID = 1",
             // "Status = 'approved'", 'order' => 20))
             if (!is_array($join)) {
+                if (!empty($alias) && !is_numeric($alias) && $alias !== trim($join, '"')) {
+                    $trimmedAlias = trim($alias, '"');
+                    $joins[$alias] = "{$join} AS \"{$trimmedAlias}\"";
+                }
                 continue;
             }
 
@@ -321,8 +325,15 @@ abstract class SQLConditionalExpression extends SQLExpression
      */
     protected function getOrderedJoins($from)
     {
+        if (count($from) <= 1) {
+            return $from;
+        }
+
         // shift the first FROM table out from so we only deal with the JOINs
+        reset($from);
+        $baseFromAlias = key($from);
         $baseFrom = array_shift($from);
+
         $this->mergesort($from, function ($firstJoin, $secondJoin) {
             if (!is_array($firstJoin)
                 || !is_array($secondJoin)
@@ -335,7 +346,12 @@ abstract class SQLConditionalExpression extends SQLExpression
         });
 
         // Put the first FROM table back into the results
-        array_unshift($from, $baseFrom);
+        if (!empty($baseFromAlias) && !is_numeric($baseFromAlias)) {
+            $from = array_merge([$baseFromAlias => $baseFrom], $from);
+        } else {
+            array_unshift($from, $baseFrom);
+        }
+
         return $from;
     }
 

--- a/tests/php/ORM/SQLSelectTest.php
+++ b/tests/php/ORM/SQLSelectTest.php
@@ -830,5 +830,21 @@ class SQLSelectTest extends SapphireTest
         $sql = $query->sql();
 
         $this->assertSQLEquals('SELECT * FROM "MyTable" AS "MyTableAlias"', $sql);
+
+        $query = SQLSelect::create('*', ['MyTableAlias' => '"MyTable"']);
+        $sql = $query->sql();
+
+        $this->assertSQLEquals('SELECT * FROM "MyTable" AS "MyTableAlias"', $sql);
+
+        $query = SQLSelect::create('*', ['"MyTableAlias"' => '"MyTable"']);
+        $query->addLeftJoin('OtherTable', '"Thing" = "OtherThing"', 'OtherTableAlias');
+        $sql = $query->sql();
+
+        $this->assertSQLEquals(
+            'SELECT * 
+              FROM "MyTable" AS "MyTableAlias" 
+              LEFT JOIN "OtherTable" AS "OtherTableAlias" ON "Thing" = "OtherThing"',
+            $sql
+        );
     }
 }

--- a/tests/php/ORM/SQLSelectTest.php
+++ b/tests/php/ORM/SQLSelectTest.php
@@ -823,4 +823,12 @@ class SQLSelectTest extends SapphireTest
         $this->assertEquals(array('%MyName%', '2012-08-08 12:00'), $parameters);
         $query->execute();
     }
+
+    public function testBaseTableAliases()
+    {
+        $query = SQLSelect::create('*', ['"MyTableAlias"' => '"MyTable"']);
+        $sql = $query->sql();
+
+        $this->assertSQLEquals('SELECT * FROM "MyTable" AS "MyTableAlias"', $sql);
+    }
 }


### PR DESCRIPTION
Fixes #8917