### PR TITLE
FIX Calculate threshold condition with SQL rather than PHP

### DIFF
--- a/src/ORM/FieldType/DBForeignKey.php
+++ b/src/ORM/FieldType/DBForeignKey.php
@@ -98,6 +98,8 @@ class DBForeignKey extends DBInt
 
             $dataQuery->setSelect(['over_threshold' => 'count(*) > ' . (int) $threshold]);
             $result = $dataQuery->execute()->column('over_threshold');
+
+            // Checking for 't' supports PostgreSQL before silverstripe/postgresql@2.2
             $overThreshold = !empty($result) && ($result[0] === 't' ||  (int) $result[0] === 1);
 
             static::$foreignListCache[$hasOneClass] = [

--- a/src/ORM/FieldType/DBForeignKey.php
+++ b/src/ORM/FieldType/DBForeignKey.php
@@ -87,12 +87,27 @@ class DBForeignKey extends DBInt
 
         // Add the count of the list to a cache for subsequent calls
         if (!isset(static::$foreignListCache[$hasOneClass])) {
+            // Let the DB do the threshold check as it will be faster - depending on the SQL engine it might only have
+            // to count indexes
+            $dataQuery = $list->dataQuery()->getFinalisedQuery();
+
+            // Clear order-by as it's not relevant for counts
+            $dataQuery->setOrderBy(false);
+            // Remove distinct. Applying distinct shouldn't be required provided relations are not applied.
+            $dataQuery->setDistinct(false);
+
+            $dataQuery->setSelect(['over_threshold' => 'count(*) > ' . (int) $threshold]);
+            $result = $dataQuery->execute()->column('over_threshold');
+            $overThreshold = !empty($result) && ($result[0] === 't' ||  (int) $result[0] === 1);
+
             static::$foreignListCache[$hasOneClass] = [
-                'count' => $list->count(),
+                'overThreshold' => $overThreshold,
             ];
         }
 
-        if (static::$foreignListCache[$hasOneClass]['count'] < $threshold) {
+        $overThreshold = static::$foreignListCache[$hasOneClass]['overThreshold'];
+
+        if (!$overThreshold) {
             // Add the mapped list for the cache
             if (!isset(static::$foreignListCache[$hasOneClass]['map'])) {
                 static::$foreignListCache[$hasOneClass]['map'] = $list->map('ID', $titleField);


### PR DESCRIPTION
This is a performance fix. Modern SQL engines can avoid counting a whole result set (potentially thousands of records) when you are only interested if the count exceeds a threshold.

Split from #8915. This is now targeting 4.3 as a patch. Happy to retarget any other branch if requested 🙂 

I am setting this query to not be `DISTINCT` which I __think__ is an okay assumption. Feel free to close this PR if I'm wrong.