### PR TITLE
FIX Replace substr with mb_substr to get the correct position

### DIFF
--- a/src/ORM/FieldType/DBText.php
+++ b/src/ORM/FieldType/DBText.php
@@ -206,8 +206,8 @@ class DBText extends DBString
         if ($position > 0) {
             // We don't want to start mid-word
             $position = max(
-                (int) mb_strrpos(substr($text, 0, $position), ' '),
-                (int) mb_strrpos(substr($text, 0, $position), "\n")
+                (int) mb_strrpos(mb_substr($text, 0, $position), ' '),
+                (int) mb_strrpos(mb_substr($text, 0, $position), "\n")
             );
         }
 


### PR DESCRIPTION
Example content:
![Screen Shot 2019-04-15 at 16 42 29](https://user-images.githubusercontent.com/340514/56108010-80633400-5f9d-11e9-9566-683189716cd5.png)

We're using `DBText::ContextSummary()` for search results and noticed that the summary didn't contain the keywords. This is due to not returning the correct position when extracting texts from a multibyte string. This fix will update the remaining `substr` to `mb_substr`.
