### PR TITLE
DOCS composer autoload examples should be psr-4

### DIFF
--- a/docs/en/03_Upgrading/02_Upgrading_module.md
+++ b/docs/en/03_Upgrading/02_Upgrading_module.md
@@ -140,7 +140,7 @@ You can do this manually:
 -    }
 +    },
 +    "autoload": {
-+        "psr4": {
++        "psr-4": {
 +            "ExampleUser\\SilverstripeExampleModule\\": "code/",
 +            "ExampleUser\\SilverstripeExampleModule\\Tests\\": "tests/"
 +        }
@@ -270,12 +270,12 @@ You'll need to update your module's `composer.json` file with an `extra.expose` 
         "silverstripe/vendor-plugin": "^1"
     },
     "autoload": {
-        "psr4": {
+        "psr-4": {
             "ExampleUser\\SilverstripeExampleModule\\": "code/"
         }
     },
     "autoload-dev": {
-        "psr4": {
+        "psr-4": {
             "ExampleUser\\SilverstripeExampleModule\\Tests\\": "tests/"
         }
 -    }


### PR DESCRIPTION
currently 'psr4'

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/