### PR TITLE
 DataQueryTest::column does not respect sorting by surrogate fields

### DIFF
--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -266,6 +266,33 @@ class DataQueryTest extends SapphireTest
         $this->assertEquals(array('First', 'Second', 'Last'), $result);
     }
 
+    public function testSurrogateFieldSort()
+    {
+        $query = new DataQuery(DataQueryTest\ObjectE::class);
+        $query->sort(
+            sprintf(
+                '(case when "Title" = %s then 1 else 0 end)',
+                DB::get_conn()->quoteString('Second')
+            ),
+            'DESC',
+            true
+        );
+        $query->sort('SortOrder', 'ASC', false);
+        $query->sort(
+            sprintf(
+                '(case when "Title" = %s then 0 else 1 end)',
+                DB::get_conn()->quoteString('Fourth')
+            ),
+            'DESC',
+            false
+        );
+
+        $this->assertEquals(
+            $query->execute()->column('Title'),
+            $query->column('Title')
+        );
+    }
+
     public function testDistinct()
     {
         $query = new DataQuery(DataQueryTest\ObjectE::class);


### PR DESCRIPTION
This is a failing test for #8926 
Should not be merged before 8926 gets a fix

Here's the result of the test execution:
```
$ ./vendor/bin/phpunit --testsuite core --filter DataQueryTest::testSurrogateFieldSort
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

F                                                                   1 / 1 (100%)

Time: 5.43 seconds, Memory: 211.75MB

There was 1 failure:

1) SilverStripe\ORM\Tests\DataQueryTest::testSurrogateFieldSort
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'Second'
-    1 => 'First'
+    0 => 'First'
+    1 => 'Second'
     2 => 'Last'
 )

/home/vagrant/bench/893-44/vendor/silverstripe/framework/tests/php/ORM/DataQueryTest.php:285
/home/vagrant/bench/893-44/vendor/phpunit/phpunit/phpunit:52

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```