### PR TITLE
NEW Add API to create a generator from a DataList

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -771,6 +771,20 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
         return $this;
     }
 
+    /**
+     * Returns a generator for this DataList
+     *
+     * @return \Generator&DataObject[]
+     */
+    public function getGenerator()
+    {
+        $query = $this->dataQuery->query()->execute();
+
+        while ($row = $query->record()) {
+            yield $this->createDataObject($row);
+        }
+    }
+
     public function debug()
     {
         $val = "<h2>" . static::class . "</h2><ul>";


### PR DESCRIPTION
In many cases it's more memory efficient to loop a generator as opposed to an array - especially if the full list might not be required. We don't really have a clear way of accessing this sort of API so it makes sense we provide a nicer way to allow people to write performant code.