### PR TITLE
Added missing Permission class to example

### DIFF
--- a/docs/en/02_Developer_Guides/09_Security/02_Permissions.md
+++ b/docs/en/02_Developer_Guides/09_Security/02_Permissions.md
@@ -23,6 +23,7 @@ The simple usage, Permission::check("PERM_CODE") will detect if the currently lo
 This method should return a map of permission code names with a human readable explanation of its purpose.
 
 ```php
+use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
 use SilverStripe\Security\Security;
 


### PR DESCRIPTION
Following the example will give the following error;

```[Emergency] Uncaught Error: Class {my namespace}\Permission not found```

Added the missing class

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/