### PR TITLE
FIX Postgres booleans should return as int for consistency

### DIFF
--- a/src/ORM/Connect/PDOStatementHandle.php
+++ b/src/ORM/Connect/PDOStatementHandle.php
@@ -47,6 +47,7 @@ class PDOStatementHandle
         'float8' => 'float',
         'float16' => 'float',
         'numeric' => 'float',
+        'bool' => 'int', // Bools should be ints
 
         // MySQL
         'NEWDECIMAL' => 'float',

--- a/tests/php/ORM/DatabaseTest.php
+++ b/tests/php/ORM/DatabaseTest.php
@@ -267,5 +267,9 @@ class DatabaseTest extends SapphireTest
 
         // Dates are returned as strings
         $this->assertInternalType('string', $record['Created'], 'DBDatetime fields should be string (non-prepared)');
+
+        // Booleans selected directly are ints
+        $result = DB::query('SELECT TRUE')->first();
+        $this->assertInternalType('int', reset($result));
     }
 }


### PR DESCRIPTION
This is related to @sminnee's work in #8590. In the case where a boolean literal is being selected (ie. `SELECT TRUE`) then PostgreSQL PDO would return `bool(true)` not `int(1)`. This patch makes all DB adapters consistent with a `int` return type for booleans.