### PR TITLE
BUGFIX: many_many through should allow subclasses

### DIFF
--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -1239,7 +1239,7 @@ class DataObjectSchema
         }
 
         // Validate bad types on parent relation
-        if ($key === 'from' && $relationClass !== $parentClass) {
+        if ($key === 'from' && $relationClass !== $parentClass && !is_subclass_of($parentClass, $relationClass)) {
             throw new InvalidArgumentException(
                 "many_many through relation {$parentClass}.{$component} {$key} references a field name "
                 . "{$joinClass}::{$relation} of type {$relationClass}; {$parentClass} expected"

--- a/tests/php/ORM/ManyManyThroughListTest.yml
+++ b/tests/php/ORM/ManyManyThroughListTest.yml
@@ -3,6 +3,11 @@ SilverStripe\ORM\Tests\ManyManyThroughListTest\TestObject:
     Title: 'my object'
   parent2:
     Title: 'my object2'
+SilverStripe\ORM\Tests\ManyManyThroughListTest\TestObjectSubclass:
+  parent1:
+    Title: 'my object'
+  parent2:
+    Title: 'my object2'
 SilverStripe\ORM\Tests\ManyManyThroughListTest\Item:
   # Having this one first means the IDs of records aren't the same as the IDs of the join objects.
   child0:
@@ -29,6 +34,25 @@ SilverStripe\ORM\Tests\ManyManyThroughListTest\JoinObject:
   join4:
     Title: 'join 4'
     Parent: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\TestObject.parent2
+    Child: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\Item.child2
+SilverStripe\ORM\Tests\ManyManyThroughListTest\PseudoPolyJoinObject:
+  join1:
+    Title: 'join 1'
+    Sort: 4
+    Parent: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\TestObjectSubclass.parent1
+    Child: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\Item.child1
+  join2:
+    Title: 'join 2'
+    Sort: 2
+    Parent: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\TestObjectSubclass.parent1
+    Child: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\Item.child2
+  join3:
+    Title: 'join 3'
+    Parent: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\TestObjectSubclass.parent2
+    Child: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\Item.child1
+  join4:
+    Title: 'join 4'
+    Parent: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\TestObjectSubclass.parent2
     Child: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\Item.child2
 SilverStripe\ORM\Tests\ManyManyThroughListTest\PolyObjectA:
   obja1:

--- a/tests/php/ORM/ManyManyThroughListTest/PseudoPolyJoinObject.php
+++ b/tests/php/ORM/ManyManyThroughListTest/PseudoPolyJoinObject.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\ManyManyThroughListTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * @property string $Title
+ * @method TestObject Parent()
+ * @method Item Child()
+ */
+class PseudoPolyJoinObject extends DataObject implements TestOnly
+{
+    private static $table_name = 'ManyManyThroughListTest_PseudoPolyJoinObject';
+
+    private static $db = [
+        'Title' => 'Varchar',
+        'Sort' => 'Int',
+    ];
+
+    private static $has_one = [
+        'Parent' => TestObject::class,
+        'Child' => Item::class,
+    ];
+
+    private static $default_sort = '"Sort" ASC';
+}

--- a/tests/php/ORM/ManyManyThroughListTest/TestObjectSubclass.php
+++ b/tests/php/ORM/ManyManyThroughListTest/TestObjectSubclass.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\ManyManyThroughListTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ManyManyThroughList;
+
+/**
+ * Basic parent object
+ *
+ * @property string $Title
+ * @method ManyManyThroughList Items()
+ */
+class TestObjectSubclass extends TestObject implements TestOnly
+{
+    private static $table_name = 'ManyManyThroughListTest_TestObjectSubclass';
+
+    private static $db = [
+        'Title' => 'Varchar'
+    ];
+
+    private static $many_many = [
+        'MoreItems' => [
+            'through' => PseudoPolyJoinObject::class,
+            'from' => 'Parent',
+            'to' => 'Child',
+        ]
+    ];
+}


### PR DESCRIPTION
```php
class HomePage extends Page
{
    private static $many_many = [
        'HeroImages' => [
            'through' => PageImageLink::class,
            'from' => 'Page',
            'to' => 'Image',
        ]
    ];

}
```

```php
class PageImageLink extends DataObject
{
    private static $has_one = [
        'Page' => SiteTree::class,
        'Image' => Image::class,
    ];
}
```

This fails because the linking object's relation class doesn't exactly match the owner. Sharing the linking objects across various entries in the ancestry should be a supported use case.
