### PR TITLE
Update 02_Routing.md

### DIFF
--- a/docs/en/02_Developer_Guides/02_Controllers/02_Routing.md
+++ b/docs/en/02_Developer_Guides/02_Controllers/02_Routing.md
@@ -23,6 +23,7 @@ Name: approutes
 After:
   - '#rootroutes'
   - '#coreroutes'
+  - '#modelascontrollerroutes'
 ---
 SilverStripe\Control\Director:
   rules:


### PR DESCRIPTION
Seem like we need to add ‘#modelascontrollerroutes’ to the “After” block of myroutes, to be able to override the '' route to HomeController

Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/