### PR TITLE
RFC Add chunk method to DataList to iterate over large dataset

### DIFF
--- a/docs/en/02_Developer_Guides/00_Model/03_Lists.md
+++ b/docs/en/02_Developer_Guides/00_Model/03_Lists.md
@@ -79,11 +79,11 @@ echo $members->column('Email');
 // ];
 ```
 
-## Iterating over a large list {#chunk}
+## Iterating over a large list {#chunkedFetch}
 
 When iterating over a DataList, all DataObjects in the list will be loaded in memory. This can consume a lot of memory when working with a large data set.
 
-To limit the number of DataObjects loaded in memory, you can use the `chunk()` method on your DataList. In most cases, you can iterate over the results of `chunk()` the same way you would iterate over your DataList. Internally, `chunk()` will split your DataList query into smaller queries and keep running through them until it runs out of results.
+To limit the number of DataObjects loaded in memory, you can use the `chunkedFetch()` method on your DataList. In most cases, you can iterate over the results of `chunkedFetch()` the same way you would iterate over your DataList. Internally, `chunkedFetch()` will split your DataList query into smaller queries and keep running through them until it runs out of results.
 
 ```php
 $members = Member::get();
@@ -92,26 +92,26 @@ foreach ($members as $member) {
 }
 
 // This call will produce the same output, but it will use less memory and run more queries against the database
-$members = Member::get()->chunk();
+$members = Member::get()->chunkedFetch();
 foreach ($members as $member) {
     echo $member->Email;
 }
 ```
 
-`chunk()` will respect any filter or sort condition applied to the DataList. By default, chunk will limit each query to 100 results. You can explicitly set this limit by passing an integer to `chunk()`.
+`chunkedFetch()` will respect any filter or sort condition applied to the DataList. By default, chunk will limit each query to 100 results. You can explicitly set this limit by passing an integer to `chunkedFetch()`.
 
 ```php
 $members = Member::get()
     ->filter('Email:PartialMatch', 'silverstripe.com')
     ->sort('Email')
-    ->chunk(10);
+    ->chunkedFetch(10);
 foreach ($members as $member) {
     echo $member->Email;
 }
 ```
 
 They are some limitations:
-* `chunk()` will ignore any limit or offset you have applied to your DataList
+* `chunkedFetch()` will ignore any limit or offset you have applied to your DataList
 * you can not "count" a chunked list or do any other call against it aside from iterating it
 * while iterating over a chunked list, you can not perform any operation that would alter the order of the items.
 

--- a/docs/en/02_Developer_Guides/00_Model/03_Lists.md
+++ b/docs/en/02_Developer_Guides/00_Model/03_Lists.md
@@ -98,7 +98,7 @@ foreach ($members as $member) {
 }
 ```
 
-`chunkedFetch()` will respect any filter or sort condition applied to the DataList. By default, chunk will limit each query to 100 results. You can explicitly set this limit by passing an integer to `chunkedFetch()`.
+`chunkedFetch()` will respect any filter or sort condition applied to the DataList. By default, chunk will limit each query to 1000 results. You can explicitly set this limit by passing an integer to `chunkedFetch()`.
 
 ```php
 $members = Member::get()

--- a/docs/en/02_Developer_Guides/00_Model/03_Lists.md
+++ b/docs/en/02_Developer_Guides/00_Model/03_Lists.md
@@ -10,7 +10,7 @@ Whenever using the ORM to fetch records or navigate relationships you will recei
 either [DataList](api:SilverStripe\ORM\DataList) or [RelationList](api:SilverStripe\ORM\RelationList). This object gives you the ability to iterate over each of the results or
 modify.
 
-## Iterating over the list.
+## Iterating over the list
 
 [SS_List](api:SilverStripe\ORM\SS_List) implements `IteratorAggregate`, allowing you to loop over the instance.
 
@@ -32,7 +32,7 @@ Or in the template engine:
 <% end_loop %>
 ```
 
-## Finding an item by value.
+## Finding an item by value
 
 ```php
 // $list->find($key, $value);
@@ -78,6 +78,42 @@ echo $members->column('Email');
 //    'will@silverstripe.com'
 // ];
 ```
+
+## Iterating over a large list {#chunk}
+
+When iterating over a DataList, all DataObjects in the list will be loaded in memory. This can consume a lot of memory when working with a large data set.
+
+To limit the number of DataObjects loaded in memory, you can use the `chunk()` method on your DataList. In most cases, you can iterate over the results of `chunk()` the same way you would iterate over your DataList. Internally, `chunk()` will split your DataList query into smaller queries and keep running through them until it runs out of results.
+
+```php
+$members = Member::get();
+foreach ($members as $member) {
+    echo $member->Email;
+}
+
+// This call will produce the same output, but it will use less memory and run more queries against the database
+$members = Member::get()->chunk();
+foreach ($members as $member) {
+    echo $member->Email;
+}
+```
+
+`chunk()` will respect any filter or sort condition applied to the DataList. By default, chunk will limit each query to 100 results. You can explicitly set this limit by passing an integer to `chunk()`.
+
+```php
+$members = Member::get()
+    ->filter('Email:PartialMatch', 'silverstripe.com')
+    ->sort('Email')
+    ->chunk(10);
+foreach ($members as $member) {
+    echo $member->Email;
+}
+```
+
+They are some limitations:
+* `chunk()` will ignore any limit or offset you have applied to your DataList
+* you can not "count" a chunked list or do any other call against it aside from iterating it
+* while iterating over a chunked list, you can not perform any operation that would alter the order of the items.
 
 ## ArrayList
 

--- a/docs/en/04_Changelogs/4.8.0.md
+++ b/docs/en/04_Changelogs/4.8.0.md
@@ -6,6 +6,8 @@
 
 ## New features
 
+* [Added a `chunkedFetch()` method to `DataList`](/Developer_Guides/Model/Lists#chunkedFetch) to avoid loading large result sets in memory all at once. 
+
 ### Support for silverstripe/graphql v4 {#graphql-v4}
 
 The [silverstripe/graphql](http://github.com/silverstripe/silverstripe-graphql/issues) module

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1298,7 +1298,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @throws InvalidArgumentException If `$chunkSize` has an invalid size.
      * @return Generator|DataObject[]
      */
-    public function chunk(int $chunkSize = 100): iterable
+    public function chunkedFetch(int $chunkSize = 100): iterable
     {
         if ($chunkSize < 1) {
             throw new InvalidArgumentException(sprintf(

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1298,7 +1298,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @throws InvalidArgumentException If `$chunkSize` has an invalid size.
      * @return Generator|DataObject[]
      */
-    public function chunkedFetch(int $chunkSize = 100): iterable
+    public function chunkedFetch(int $chunkSize = 1000): iterable
     {
         if ($chunkSize < 1) {
             throw new InvalidArgumentException(sprintf(

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -1876,23 +1876,23 @@ class DataListTest extends SapphireTest
         ], $productTitles);
     }
 
-    public function testChunk()
+    public function testChunkedFetch()
     {
         $expectedIDs = Team::get()->map('ID', 'ID')->toArray();
         $expectedSize = sizeof($expectedIDs);
 
-        $this->chunkTester($expectedIDs, Team::get()->chunk());
-        $this->chunkTester($expectedIDs, Team::get()->chunk(1));
-        $this->chunkTester($expectedIDs, Team::get()->chunk($expectedSize));
-        $this->chunkTester($expectedIDs, Team::get()->chunk($expectedSize-1));
-        $this->chunkTester($expectedIDs, Team::get()->chunk($expectedSize+1));
+        $this->chunkTester($expectedIDs, Team::get()->chunkedFetch());
+        $this->chunkTester($expectedIDs, Team::get()->chunkedFetch(1));
+        $this->chunkTester($expectedIDs, Team::get()->chunkedFetch($expectedSize));
+        $this->chunkTester($expectedIDs, Team::get()->chunkedFetch($expectedSize-1));
+        $this->chunkTester($expectedIDs, Team::get()->chunkedFetch($expectedSize+1));
     }
 
     public function testFilteredChunk()
     {
         $this->chunkTester(
             Team::get()->filter('ClassName', Team::class)->map('ID', 'ID')->toArray(),
-            Team::get()->filter('ClassName', Team::class)->chunk(2)
+            Team::get()->filter('ClassName', Team::class)->chunkedFetch(2)
         );
     }
 
@@ -1900,19 +1900,19 @@ class DataListTest extends SapphireTest
     {
         $this->chunkTester(
             Team::get()->sort('ID', 'Desc')->map('ID', 'ID')->toArray(),
-            Team::get()->sort('ID', 'Desc')->chunk(2)
+            Team::get()->sort('ID', 'Desc')->chunkedFetch(2)
         );
     }
 
     public function testEmptyChunk()
     {
-        $this->chunkTester([], Team::get()->filter('ClassName', 'non-sense')->chunk());
+        $this->chunkTester([], Team::get()->filter('ClassName', 'non-sense')->chunkedFetch());
     }
 
     public function testInvalidChunkSize()
     {
         $this->expectException(InvalidArgumentException::class);
-        foreach (Team::get()->chunk(0) as $item) {
+        foreach (Team::get()->chunkedFetch(0) as $item) {
             // You don't get the error until you iterate over the list
         };
     }

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -16,7 +16,6 @@ use SilverStripe\ORM\Tests\DataObjectTest\Fixture;
 use SilverStripe\ORM\Tests\DataObjectTest\Bracket;
 use SilverStripe\ORM\Tests\DataObjectTest\EquipmentCompany;
 use SilverStripe\ORM\Tests\DataObjectTest\Fan;
-use SilverStripe\ORM\Tests\DataObjectTest\Fixture;
 use SilverStripe\ORM\Tests\DataObjectTest\Player;
 use SilverStripe\ORM\Tests\DataObjectTest\Sortable;
 use SilverStripe\ORM\Tests\DataObjectTest\Staff;

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -11,7 +11,6 @@ use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Filterable;
 use SilverStripe\ORM\Filters\ExactMatchFilter;
-use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\Tests\DataObjectTest\DataListQueryCounter;
 use SilverStripe\ORM\Tests\DataObjectTest\Fixture;
 use SilverStripe\ORM\Tests\DataObjectTest\Bracket;
@@ -1887,7 +1886,7 @@ class DataListTest extends SapphireTest
         $dataQuery = new DataListQueryCounter(Team::class);
         $this->chunkTester(
             $expectedIDs,
-            Team::get()->setDataQuery($dataQuery)->chunk(),
+            Team::get()->setDataQuery($dataQuery)->chunkedFetch(),
             $dataQuery,
             1
         );
@@ -1895,7 +1894,7 @@ class DataListTest extends SapphireTest
         $dataQuery = new DataListQueryCounter(Team::class);
         $this->chunkTester(
             $expectedIDs,
-            Team::get()->setDataQuery($dataQuery)->chunk(1),
+            Team::get()->setDataQuery($dataQuery)->chunkedFetch(1),
             $dataQuery,
             $expectedSize+1
         );
@@ -1903,7 +1902,7 @@ class DataListTest extends SapphireTest
         $dataQuery = new DataListQueryCounter(Team::class);
         $this->chunkTester(
             $expectedIDs,
-            Team::get()->setDataQuery($dataQuery)->chunk($expectedSize),
+            Team::get()->setDataQuery($dataQuery)->chunkedFetch($expectedSize),
             $dataQuery,
             2
         );
@@ -1911,7 +1910,7 @@ class DataListTest extends SapphireTest
         $dataQuery = new DataListQueryCounter(Team::class);
         $this->chunkTester(
             $expectedIDs,
-            Team::get()->setDataQuery($dataQuery)->chunk($expectedSize-1),
+            Team::get()->setDataQuery($dataQuery)->chunkedFetch($expectedSize-1),
             $dataQuery,
             2
         );
@@ -1919,7 +1918,7 @@ class DataListTest extends SapphireTest
         $dataQuery = new DataListQueryCounter(Team::class);
         $this->chunkTester(
             $expectedIDs,
-            Team::get()->setDataQuery($dataQuery)->chunk($expectedSize+1),
+            Team::get()->setDataQuery($dataQuery)->chunkedFetch($expectedSize+1),
             $dataQuery,
             1
         );
@@ -1930,7 +1929,7 @@ class DataListTest extends SapphireTest
         $dataQuery = new DataListQueryCounter(Team::class);
         $this->chunkTester(
             Team::get()->filter('ClassName', Team::class)->map('ID', 'ID')->toArray(),
-            Team::get()->setDataQuery($dataQuery)->filter('ClassName', Team::class)->chunk(),
+            Team::get()->setDataQuery($dataQuery)->filter('ClassName', Team::class)->chunkedFetch(),
             $dataQuery,
             1
         );
@@ -1941,7 +1940,7 @@ class DataListTest extends SapphireTest
         $dataQuery = new DataListQueryCounter(Team::class);
         $this->chunkTester(
             Team::get()->sort('ID', 'Desc')->map('ID', 'ID')->toArray(),
-            Team::get()->setDataQuery($dataQuery)->sort('ID', 'Desc')->chunk(),
+            Team::get()->setDataQuery($dataQuery)->sort('ID', 'Desc')->chunkedFetch(),
             $dataQuery,
             1
         );
@@ -1952,7 +1951,7 @@ class DataListTest extends SapphireTest
         $dataQuery = new DataListQueryCounter(Team::class);
         $this->chunkTester(
             [],
-            Team::get()->setDataQuery($dataQuery)->filter('ClassName', 'non-sense')->chunk(),
+            Team::get()->setDataQuery($dataQuery)->filter('ClassName', 'non-sense')->chunkedFetch(),
             $dataQuery,
             1
         );

--- a/tests/php/ORM/DataObjectTest/DataListQueryCounter.php
+++ b/tests/php/ORM/DataObjectTest/DataListQueryCounter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\ORM\DataQuery;
+
+/**
+ * This is designed around the chunk method so we can count the number of queries run.
+ */
+class DataListQueryCounter extends DataQuery
+{
+    private $queryCount = 0;
+    
+    /**
+     * When the DataList gets clone our reference to parent will be attached to our cloned DataListQueryCounter. So all
+     * DataListQueryCounter::parent will point back to the original one that go created by with the constructor.
+     * @var DataListQueryCounter
+     */
+    private $parent;
+
+    public function __construct($dataClass)
+    {
+        parent::__construct($dataClass);
+        $this->parent = $this;
+    }
+
+    public function getFinalisedQuery($queriedColumns = null)
+    {
+        $this->increment();
+        return parent::getFinalisedQuery($queriedColumns);
+    }
+
+    private function increment()
+    {
+        $this->parent->queryCount++;
+    }
+
+    public function getCount()
+    {
+        return $this->parent->queryCount;
+    }
+}


### PR DESCRIPTION
I'm [stealing this one from Laravel](https://laravel.com/docs/5.8/collections#method-chunk).

Basically, this will take your regular DataList query and split it up into smaller queries using limits and offsets. That way, if you have a huge result set, you don't have to load it all in memory at once.

You can specify a chunk size or let it default to 100.

It's bit different from the Laravel implementation in that Laravel return a list of chunks which you have to loop over yourself ... while my implementation will loop over the chunks for you and yield each result individually.

If you think this is worthwhile, I'll write some unit test for it.

CC @silverstripe/core-team

