### PR TITLE
DOCS: Use environment variables in example SMTP config

### DIFF
--- a/docs/en/02_Developer_Guides/10_Email/index.md
+++ b/docs/en/02_Developer_Guides/10_Email/index.md
@@ -18,7 +18,7 @@ SilverStripe\Core\Injector\Injector:
   Swift_Transport: Swift_SendmailTransport
 ```
 
-For example, to use SMTP, create a file app/_config/email.yml:
+For example, to use SMTP, create a file `app/_config/email.yml`:
 
 ```yml
 ---
@@ -34,10 +34,12 @@ SilverStripe\Core\Injector\Injector:
       Port: <port>
       Encryption: tls
     calls:
-      Username: [ setUsername, ['<username>'] ]
-      Password: [ setPassword, ['<password>'] ]
+      Username: [ setUsername, ['`APP_SMTP_USERNAME`'] ]
+      Password: [ setPassword, ['`APP_SMTP_PASSWORD`'] ]
       AuthMode: [ setAuthMode, ['login'] ]
 ```
+
+Note the usage of backticks to designate environment variables for the credentials - ensure you set these in your `.env` file or in your webserver configuration.
 
 ## Usage
 


### PR DESCRIPTION
Currently the email documentation provides an example of how to use the SMTP adapter in SwiftMailer, but this example hardcodes the password in the config file which is a security issue. It is possible to reference environment variables instead, so we should document and encourage this.