### PR TITLE
NEW Introduce a (default false) test configuration for enabling translations in tests

### DIFF
--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -24,9 +24,11 @@ use SilverStripe\Core\Manifest\ModuleResourceLoader;
 use SilverStripe\Dev\Constraint\SSListContains;
 use SilverStripe\Dev\Constraint\SSListContainsOnly;
 use SilverStripe\Dev\Constraint\SSListContainsOnlyMatchingItems;
+use SilverStripe\Dev\i18n\TestMessageProvider;
 use SilverStripe\Dev\State\FixtureTestState;
 use SilverStripe\Dev\State\SapphireTestState;
 use SilverStripe\i18n\i18n;
+use SilverStripe\i18n\Messages\MessageProvider;
 use SilverStripe\ORM\Connect\TempDatabase;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
@@ -85,6 +87,13 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @var bool
      */
     protected $usesTransactions = true;
+
+    /**
+     * Indicates that the translation catalogue should be loaded for this test class.
+     *
+     * @var bool
+     */
+    protected $usesTranslations = false;
 
     /**
      * @var bool
@@ -268,6 +277,11 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
                 'Missing constants, did you remember to include the test bootstrap in your phpunit.xml file?',
                 E_USER_WARNING
             );
+        }
+
+        // Disable translation service. This specifically happens before any other test state start up
+        if (!$this->usesTranslations) {
+            Injector::inst()->registerService(new TestMessageProvider, MessageProvider::class);
         }
 
         // Call state helpers

--- a/src/Dev/State/FlushableTestState.php
+++ b/src/Dev/State/FlushableTestState.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Dev\State;
 
 use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Flushable;
 use SilverStripe\Core\Resettable;
 use SilverStripe\Dev\SapphireTest;

--- a/src/Dev/i18n/TestMessageProvider.php
+++ b/src/Dev/i18n/TestMessageProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace SilverStripe\Dev\i18n;
+
+use SilverStripe\i18n\Messages\MessageProvider;
+use Symfony\Component\Translation\MessageSelector;
+
+class TestMessageProvider implements MessageProvider
+{
+    /**
+     * @var MessageSelector
+     */
+    protected $selector;
+
+    public function __construct()
+    {
+        $this->selector = new MessageSelector();
+    }
+
+    /**
+     * Localise this message
+     *
+     * @param string $entity Identifier for this message in Namespace.key format
+     * @param string $default Default message
+     * @param array $injection List of injection variables
+     * @return string Localised string
+     */
+    public function translate($entity, $default, $injection)
+    {
+        return $this->inject($default, $injection);
+    }
+
+    /**
+     * Pluralise a message
+     *
+     * @param string $entity Identifier for this message in Namespace.key format
+     * @param array|string $default Default message with pipe-separated delimiters, or array
+     * @param array $injection List of injection variables
+     * @param int $count Number to pluralise against
+     * @return string Localised string
+     */
+    public function pluralise($entity, $default, $injection, $count)
+    {
+        // Choose the right "option" for injecting
+        $default = $this->selector->choose($default, $count, 'en');
+
+        return $this->inject($default, $injection);
+    }
+
+    protected function inject($default, $injection)
+    {
+        return strtr($default, array_combine(array_map(function($key) {
+            return '{' . $key . '}';
+        }, array_keys($injection)), array_values($injection)));
+    }
+}


### PR DESCRIPTION
Loading the translation catalogue on a large project can take several seconds. Additionally - tests that rely on locale translations are prone to failure - you should be specifically mocking or initialising translation services as part of your test - that's why I've set the default to false.

In the (hopefully) rare case that your tests relies on a translation from a specific locale (that's not the passed in "fallback"/default) then you can set `usesTranslations` to true in your test class.