### PR TITLE
API Replace FormActions with anchors to enable panel-based loading in GridField navigation buttons

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -98,6 +98,10 @@ en:
     DeletePermissionsFailure: 'No delete permissions'
     Deleted: 'Deleted {type} {name}'
     Save: Save
+  SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest:
+    PREVIOUS: 'Go to previous record'
+    NEXT: 'Go to next record'
+    NEW: 'Add new record'
   SilverStripe\Forms\GridField\GridFieldEditButton:
     EDIT: Edit
   SilverStripe\Forms\GridField\GridFieldFilterHeader:

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -289,16 +289,19 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
         $paginator = $this->getGridField()->getConfig()->getComponentByType(GridFieldPaginator::class);
         $gridState = $this->getRequest()->requestVar('gridState');
         if ($component && $paginator && $component->getShowPagination()) {
+            $previousIsDisabled = !$this->getPreviousRecordID();
+            $nextIsDisabled = !$this->getNextRecordID();
+
             $previousAndNextGroup->push(
                 LiteralField::create(
                     'previous-record',
-                    HTML::createTag('a', [
-                        'href' => $this->getEditLink($this->getPreviousRecordID()),
+                    HTML::createTag($previousIsDisabled ? 'span' : 'a', [
+                        'href' => $previousIsDisabled ? '#' : $this->getEditLink($this->getPreviousRecordID()),
                         'data-grid-state' => $gridState,
-                        'disabled' => !$this->getPreviousRecordID(),
                         'title' => _t(__CLASS__ . '.PREVIOUS', 'Go to previous record'),
                         'aria-label' => _t(__CLASS__ . '.PREVIOUS', 'Go to previous record'),
-                        'class' => 'btn btn-secondary font-icon-left-open action--previous discard-confirmation',
+                        'class' => 'btn btn-secondary font-icon-left-open action--previous discard-confirmation'
+                            . ($previousIsDisabled ? ' disabled' : ''),
                     ])
                 )
             );
@@ -306,13 +309,13 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
             $previousAndNextGroup->push(
                 LiteralField::create(
                     'next-record',
-                    HTML::createTag('a', [
-                        'href' => $this->getEditLink($this->getNextRecordID()),
+                    HTML::createTag($nextIsDisabled ? 'span' : 'a', [
+                        'href' => $nextIsDisabled ? '#' : $this->getEditLink($this->getNextRecordID()),
                         'data-grid-state' => $gridState,
-                        'disabled' => !$this->getNextRecordID(),
                         'title' => _t(__CLASS__ . '.NEXT', 'Go to next record'),
                         'aria-label' => _t(__CLASS__ . '.NEXT', 'Go to next record'),
-                        'class' => 'btn btn-secondary font-icon-right-open action--next discard-confirmation',
+                        'class' => 'btn btn-secondary font-icon-right-open action--next discard-confirmation'
+                            . ($nextIsDisabled ? ' disabled' : ''),
                     ])
                 )
             );

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -293,12 +293,16 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
                 ->setUseButtonTag(true)
                 ->setAttribute('data-grid-state', $gridState)
                 ->setDisabled(!$this->getPreviousRecordID())
+                ->setDescription(_t(__CLASS__ . '.PREVIOUS', 'Go to previous record'))
+                ->setAttribute('aria-label', _t(__CLASS__ . '.PREVIOUS', 'Go to previous record'))
                 ->addExtraClass('btn btn-secondary font-icon-left-open action--previous discard-confirmation'));
 
             $previousAndNextGroup->push(FormAction::create('doNext')
                 ->setUseButtonTag(true)
                 ->setAttribute('data-grid-state', $gridState)
                 ->setDisabled(!$this->getNextRecordID())
+                ->setDescription(_t(__CLASS__ . '.NEXT', 'Go to next record'))
+                ->setAttribute('aria-label', _t(__CLASS__ . '.NEXT', 'Go to next record'))
                 ->addExtraClass('btn btn-secondary font-icon-right-open action--next discard-confirmation'));
         }
 
@@ -308,6 +312,8 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
             $rightGroup->push(FormAction::create('doNew')
                 ->setUseButtonTag(true)
                 ->setAttribute('data-grid-state', $this->getRequest()->getVar('gridState'))
+                ->setDescription(_t(__CLASS__ . '.NEW', 'Add new record'))
+                ->setAttribute('aria-label', _t(__CLASS__ . '.NEW', 'Add new record'))
                 ->addExtraClass('btn btn-primary font-icon-plus-thin circular action--new discard-confirmation'));
         }
 

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -7,7 +7,6 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\RequestHandler;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
@@ -23,6 +22,7 @@ use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\ORM\ValidationResult;
 use SilverStripe\View\ArrayData;
+use SilverStripe\View\HTML;
 use SilverStripe\View\SSViewer;
 
 class GridFieldDetailForm_ItemRequest extends RequestHandler
@@ -281,40 +281,58 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
         $rightGroup->setFieldHolderTemplate(get_class($rightGroup) . '_holder_buttongroup');
 
         $previousAndNextGroup = CompositeField::create()->setName('PreviousAndNextGroup');
-        $previousAndNextGroup->addExtraClass('circular-group mr-2');
-        $previousAndNextGroup->setFieldHolderTemplate(get_class($previousAndNextGroup) . '_holder_buttongroup');
+        $previousAndNextGroup->addExtraClass('btn-group--circular mr-2');
+        $previousAndNextGroup->setFieldHolderTemplate(CompositeField::class . '_holder_buttongroup');
 
         /** @var GridFieldDetailForm $component */
         $component = $this->gridField->getConfig()->getComponentByType(GridFieldDetailForm::class);
         $paginator = $this->getGridField()->getConfig()->getComponentByType(GridFieldPaginator::class);
         $gridState = $this->getRequest()->requestVar('gridState');
         if ($component && $paginator && $component->getShowPagination()) {
-            $previousAndNextGroup->push(FormAction::create('doPrevious')
-                ->setUseButtonTag(true)
-                ->setAttribute('data-grid-state', $gridState)
-                ->setDisabled(!$this->getPreviousRecordID())
-                ->setDescription(_t(__CLASS__ . '.PREVIOUS', 'Go to previous record'))
-                ->setAttribute('aria-label', _t(__CLASS__ . '.PREVIOUS', 'Go to previous record'))
-                ->addExtraClass('btn btn-secondary font-icon-left-open action--previous discard-confirmation'));
+            $previousAndNextGroup->push(
+                LiteralField::create(
+                    'previous-record',
+                    HTML::createTag('a', [
+                        'href' => $this->getEditLink($this->getPreviousRecordID()),
+                        'data-grid-state' => $gridState,
+                        'disabled' => !$this->getPreviousRecordID(),
+                        'title' => _t(__CLASS__ . '.PREVIOUS', 'Go to previous record'),
+                        'aria-label' => _t(__CLASS__ . '.PREVIOUS', 'Go to previous record'),
+                        'class' => 'btn btn-secondary font-icon-left-open action--previous discard-confirmation',
+                    ])
+                )
+            );
 
-            $previousAndNextGroup->push(FormAction::create('doNext')
-                ->setUseButtonTag(true)
-                ->setAttribute('data-grid-state', $gridState)
-                ->setDisabled(!$this->getNextRecordID())
-                ->setDescription(_t(__CLASS__ . '.NEXT', 'Go to next record'))
-                ->setAttribute('aria-label', _t(__CLASS__ . '.NEXT', 'Go to next record'))
-                ->addExtraClass('btn btn-secondary font-icon-right-open action--next discard-confirmation'));
+            $previousAndNextGroup->push(
+                LiteralField::create(
+                    'next-record',
+                    HTML::createTag('a', [
+                        'href' => $this->getEditLink($this->getNextRecordID()),
+                        'data-grid-state' => $gridState,
+                        'disabled' => !$this->getNextRecordID(),
+                        'title' => _t(__CLASS__ . '.NEXT', 'Go to next record'),
+                        'aria-label' => _t(__CLASS__ . '.NEXT', 'Go to next record'),
+                        'class' => 'btn btn-secondary font-icon-right-open action--next discard-confirmation',
+                    ])
+                )
+            );
         }
 
         $rightGroup->push($previousAndNextGroup);
 
         if ($component && $component->getShowAdd()) {
-            $rightGroup->push(FormAction::create('doNew')
-                ->setUseButtonTag(true)
-                ->setAttribute('data-grid-state', $this->getRequest()->getVar('gridState'))
-                ->setDescription(_t(__CLASS__ . '.NEW', 'Add new record'))
-                ->setAttribute('aria-label', _t(__CLASS__ . '.NEW', 'Add new record'))
-                ->addExtraClass('btn btn-primary font-icon-plus-thin circular action--new discard-confirmation'));
+            $rightGroup->push(
+                LiteralField::create(
+                    'new-record',
+                    HTML::createTag('a', [
+                        'href' => Controller::join_links($this->gridField->Link('item'), 'new'),
+                        'data-grid-state' => $gridState,
+                        'title' => _t(__CLASS__ . '.NEW', 'Add new record'),
+                        'aria-label' => _t(__CLASS__ . '.NEW', 'Add new record'),
+                        'class' => 'btn btn-primary font-icon-plus-thin btn--circular action--new discard-confirmation',
+                    ])
+                )
+            );
         }
 
         return $rightGroup;
@@ -327,7 +345,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      */
     protected function getFormActions()
     {
-        $actions = new FieldList();
+        $actions = FieldList::create();
 
         if ($this->record->ID !== 0) { // existing record
             if ($this->record->canEdit()) {
@@ -467,45 +485,6 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
 
         // Redirect after save
         return $this->redirectAfterSave($isNewRecord);
-    }
-
-    /**
-     * Goes to the previous record
-     * @param  array $data The form data
-     * @param  Form $form The Form object
-     * @return HTTPResponse
-     */
-    public function doPrevious($data, $form)
-    {
-        $this->getToplevelController()->getResponse()->addHeader('X-Pjax', 'Content');
-        $link = $this->getEditLink($this->getPreviousRecordID());
-        return $this->redirect($link);
-    }
-
-    /**
-     * Goes to the next record
-     * @param  array $data The form data
-     * @param  Form $form The Form object
-     * @return HTTPResponse
-     */
-    public function doNext($data, $form)
-    {
-        $this->getToplevelController()->getResponse()->addHeader('X-Pjax', 'Content');
-        $link = $this->getEditLink($this->getNextRecordID());
-        return $this->redirect($link);
-    }
-
-    /**
-     * Creates a new record. If you're already creating a new record,
-     * this forces the URL to change.
-     *
-     * @param  array $data The form data
-     * @param  Form $form The Form object
-     * @return HTTPResponse
-     */
-    public function doNew($data, $form)
-    {
-        return $this->redirect(Controller::join_links($this->gridField->Link('item'), 'new'));
     }
 
     /**


### PR DESCRIPTION
This replaces the Prev, Next, and New buttons in GridField "better buttons" from FormActions to simple anchors. Doing this means that (a) they don't have their own loading indicators, and (b) the CMS panel automatically obtains a loading indicator while processing.

None of these actions are POST actions, so don't need to be FormActions (technically speaking).

This also adds tooltips and ARIA labels for accessibility to these buttons, and changed the new class names for circular buttons to be more BEM compliant.

Issue: https://github.com/silverstripe/silverstripe-admin/issues/815

**Note:** this is removing public API, but those were added in https://github.com/silverstripe/silverstripe-framework/pull/8569 and haven't been tagged in a stable release yet. They aren't needed for anchor based buttons, so I've deleted them.