### PR TITLE
Backward compatible behaviour for SQLConditionalExpression::getJoins

### DIFF
--- a/src/ORM/Queries/SQLConditionalExpression.php
+++ b/src/ORM/Queries/SQLConditionalExpression.php
@@ -287,6 +287,13 @@ abstract class SQLConditionalExpression extends SQLExpression
                     continue;
                 }
 
+                if (preg_match('/AS\s+(?:"[^"]+"|[A-Z0-9_]+)\s*$/i', $join)) {
+                    // custom aliases override the ones defined through array keys
+                    // this is only meant to keep backward compatibility with SS <= 4.3,
+                    // to be removed in SS5
+                    continue;
+                }
+
                 $trimmedAlias = trim($alias, '"');
 
                 if ($trimmedAlias !== trim($join, '"')) {

--- a/tests/php/ORM/SQLSelectTest.php
+++ b/tests/php/ORM/SQLSelectTest.php
@@ -841,9 +841,21 @@ class SQLSelectTest extends SapphireTest
         $sql = $query->sql();
 
         $this->assertSQLEquals(
-            'SELECT * 
-              FROM "MyTable" AS "MyTableAlias" 
+            'SELECT *
+              FROM "MyTable" AS "MyTableAlias"
               LEFT JOIN "OtherTable" AS "OtherTableAlias" ON "Thing" = "OtherThing"',
+            $sql
+        );
+
+        $query = SQLSelect::create('*', [
+            'MyTableAlias' => '"MyTable"',
+            'ignoredAlias' => ', (SELECT * FROM "MyTable" where "something" = "whatever") as "CrossJoin"'
+        ]);
+        $sql = $query->sql();
+
+        $this->assertSQLEquals(
+            'SELECT * FROM "MyTable" AS "MyTableAlias" , '.
+            '(SELECT * FROM "MyTable" where "something" = "whatever") as "CrossJoin"',
             $sql
         );
     }


### PR DESCRIPTION
Patch for https://github.com/silverstripe/silverstripe-framework/pull/8918 to keep backward compatible behaviour.

Related: https://github.com/silverstripe/silverstripe-postgresql/issues/95

