### PR TITLE
FIX Ensuring pagination buttons have a consistent state to work off of

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -525,9 +525,12 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
     private function getAdjacentRecordID($offset)
     {
         $gridField = $this->getGridField();
-        $gridStateStr = $this->getRequest()->requestVar('gridState');
+        $list = $gridField->getManipulatedList();
         $state = $gridField->getState(false);
-        $state->setValue($gridStateStr);
+        $gridStateStr = $this->getRequest()->requestVar('gridState');
+        if (!empty($gridStateStr)) {
+            $state->setValue($gridStateStr);
+        }
         $data = $state->getData();
         $paginator = $data->getData('GridFieldPaginator');
         if (!$paginator) {
@@ -540,7 +543,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
         $limit = $itemsPerPage + 2;
         $limitOffset = max(0, $itemsPerPage * ($currentPage-1) -1);
 
-        $map = $gridField->getManipulatedList()->limit($limit, $limitOffset)->column('ID');
+        $map = $list->limit($limit, $limitOffset)->column('ID');
         $index = array_search($this->record->ID, $map);
         return isset($map[$index+$offset]) ? $map[$index+$offset] : false;
     }


### PR DESCRIPTION
Fixes #8955

I'm not 100% sure on this fix as the code seems a bit specific and I'm not sure I have the full context on what's happening here. In my case it seemed to be often referencing pagination state before it had the chance to be generated. Moving the `getManipulatedList` call above the `getState` call fixes this.