### PR TITLE
NEW Only get an authenticator if it's an object

### DIFF
--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -202,7 +202,7 @@ class Security extends Controller implements TemplateGlobalProvider
      */
     public function getAuthenticators()
     {
-        return $this->authenticators;
+        return array_filter($this->authenticators);
     }
 
     /**
@@ -244,7 +244,7 @@ class Security extends Controller implements TemplateGlobalProvider
      */
     protected function getAuthenticator($name = 'default')
     {
-        $authenticators = $this->authenticators;
+        $authenticators = $this->getAuthenticators();
 
         if (isset($authenticators[$name])) {
             return $authenticators[$name];
@@ -286,7 +286,7 @@ class Security extends Controller implements TemplateGlobalProvider
      */
     public function hasAuthenticator($authenticator)
     {
-        $authenticators = $this->authenticators;
+        $authenticators = $this->getAuthenticators();
 
         return !empty($authenticators[$authenticator]);
     }


### PR DESCRIPTION
Use-case: if a module is defining its own authenticator and you want to disable it, as it seems we don't have `Authenticator::unregister_authenticator()` anymore in SS4 and I can't spot how to remove YAML-based injected properties, then this lets you mark it as null or false to stop it from being used. Without this code fix it errors out when it attempts to call `supportedServices()`

Example YAML config
```
---
Name: removemoduleauthenticator
After:
  - 'moduleauthenticator'
---
SilverStripe\Core\Injector\Injector:
  SilverStripe\Security\Security:
    properties:
      Authenticators:
        SomeAuthenticatorProvidedByAModule: false
```

If you _can_ un-define a property in YAML, I humbly withdraw this PR if it's not needed 😄 