### PR TITLE
Fix SQLConditionalExpression::getJoins

### DIFF
--- a/docs/en/04_Changelogs/5.0.0.md
+++ b/docs/en/04_Changelogs/5.0.0.md
@@ -10,6 +10,7 @@ guide developers in preparing existing 4.x code for compatibility with 5.0.
 
 * Minimum version dependencies have increased; PHP 7.1 or higher is required.
 * Core classes have begun implementing PHP 7 scalar type hinting and return type hints.
+* Fixed a "bug feature" where aliases on tables and subselects were previously ignored
 
 ## API Changes {#api-changes}
 
@@ -53,5 +54,9 @@ guide developers in preparing existing 4.x code for compatibility with 5.0.
 * `Query::first()` and `Query::current()` removed. Use `Query::record()` instead.
 * `Query::seek()` removed. To re-set the position, re-execute `Query::getIterator()` instead.
 * `Query::next()` and other Iterator methods removed. Call `Query::getIterator()` to get an iterator instead.
+* Prior to 5.0.0, when using `SQLSelect::setFrom` or `SQLSelect::create('*', $from)` to set table or subselect definitions,
+their aliases (applied by setting a string key of the array) were being ignored. This bug has been fixed but may cause 
+invalid SQL if the alias has been manually set. See 
+[#8917](https://github.com/silverstripe/silverstripe-framework/issues/8917)
 
 <!--- Changes below this line will be automatically regenerated -->

--- a/src/ORM/Queries/SQLConditionalExpression.php
+++ b/src/ORM/Queries/SQLConditionalExpression.php
@@ -287,13 +287,6 @@ abstract class SQLConditionalExpression extends SQLExpression
                     continue;
                 }
 
-                if (preg_match('/AS\s+(?:"[^"]+"|[A-Z0-9_]+)\s*$/i', $join)) {
-                    // custom aliases override the ones defined through array keys
-                    // this is only meant to keep backward compatibility with SS <= 4.3,
-                    // to be removed in SS5
-                    continue;
-                }
-
                 $trimmedAlias = trim($alias, '"');
 
                 if ($trimmedAlias !== trim($join, '"')) {

--- a/tests/php/ORM/SQLSelectTest.php
+++ b/tests/php/ORM/SQLSelectTest.php
@@ -855,15 +855,18 @@ class SQLSelectTest extends SapphireTest
             $sql
         );
 
+        // This feature is a bug that used to exist in SS4 and was removed in SS5
+        // so now we test it does not exist and we end up with incorrect SQL because of that
+        // In SS4 the "explicitAlias" would be ignored
         $query = SQLSelect::create('*', [
             'MyTableAlias' => '"MyTable"',
-            'ignoredAlias' => ', (SELECT * FROM "MyTable" where "something" = "whatever") as "CrossJoin"'
+            'explicitAlias' => ', (SELECT * FROM "MyTable" where "something" = "whatever") as "CrossJoin"'
         ]);
         $sql = $query->sql();
 
         $this->assertSQLEquals(
             'SELECT * FROM "MyTable" AS "MyTableAlias" , '.
-            '(SELECT * FROM "MyTable" where "something" = "whatever") as "CrossJoin"',
+            '(SELECT * FROM "MyTable" where "something" = "whatever") as "CrossJoin" AS "explicitAlias"',
             $sql
         );
     }


### PR DESCRIPTION
So it always adds explicit aliases

This is a revert of https://github.com/silverstripe/silverstripe-framework/pull/8956

Related to https://github.com/silverstripe/silverstripe-postgresql/issues/95