### PR TITLE
Commenting out the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,7 @@
+<!--
 Thanks for contributing, you're awesome! :star:
 Please describe expected and observed behaviour, and what you're fixing.
 For visual fixes, please include tested browsers and screenshots.
 Search for related existing issues and link to them if possible.
 Please read https://docs.silverstripe.org/en/contributing/code/
+-->


### PR DESCRIPTION
This is an idea for a slight improvement to our PR template. Considering that we intend for the author to delete the PR template (it's just a message) we can just comment it out (HTML style) and if they accidentally leave it in it won't be shown.

As POC, I haven't touched the PR template for this PR. Contributors can see it by attempting to edit my message.


<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->