### PR TITLE
BUGFIX: DataQuery overwriting _SortColumn selects

### DIFF
--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -354,14 +354,12 @@ class DataQuery
     {
         if ($orderby = $query->getOrderBy()) {
             $newOrderby = array();
-            $i = 0;
             foreach ($orderby as $k => $dir) {
                 $newOrderby[$k] = $dir;
 
                 // don't touch functions in the ORDER BY or public function calls
                 // selected as fields
                 if (strpos($k, '(') !== false) {
-                    $i++;
                     continue;
                 }
 
@@ -373,7 +371,6 @@ class DataQuery
                     if (isset($originalSelect[$col])) {
                         $query->selectField($originalSelect[$col], $col);
                     }
-                    $i++;
                     continue;
                 }
 
@@ -403,10 +400,15 @@ class DataQuery
                     if (!in_array($qualCol, $query->getSelect())) {
                         unset($newOrderby[$k]);
 
-                        $newOrderby["\"_SortColumn$i\""] = $dir;
-                        $query->selectField($qualCol, "_SortColumn$i");
+                        // Find the first free "_SortColumnX" slot
+                        // and assign it to $key
+                        $i = 0;
+                        while (isset($orderby[$key = "\"_SortColumn$i\""])) {
+                            ++$i;
+                        }
 
-                        $i++;
+                        $newOrderby[$key] = $dir;
+                        $query->selectField($qualCol, "_SortColumn$i");
                     }
                 }
             }

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -361,6 +361,7 @@ class DataQuery
                 // don't touch functions in the ORDER BY or public function calls
                 // selected as fields
                 if (strpos($k, '(') !== false) {
+                    $i++;
                     continue;
                 }
 
@@ -372,7 +373,7 @@ class DataQuery
                     if (isset($originalSelect[$col])) {
                         $query->selectField($originalSelect[$col], $col);
                     }
-
+                    $i++;
                     continue;
                 }
 

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -308,6 +308,14 @@ class DataQueryTest extends SapphireTest
             true
         );
         $query->sort('SortOrder', 'ASC', false);
+        $query->sort(
+            sprintf(
+                '(case when "Title" = %s then 0 else 1 end)',
+                DB::get_conn()->quoteString('Fourth')
+            ),
+            'DESC',
+            false
+        );
         $this->assertEquals(
             $query->execute()->column('Title'),
             $query->column('Title')

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -296,6 +296,24 @@ class DataQueryTest extends SapphireTest
         static::resetDBSchema(true);
     }
 
+    public function testSurrogateFieldSort()
+    {
+        $query = new DataQuery(DataQueryTest\ObjectE::class);
+        $query->sort(
+            sprintf(
+                '(case when "Title" = %s then 1 else 0 end)',
+                DB::get_conn()->quoteString('Second')
+            ),
+            'DESC',
+            true
+        );
+        $query->sort('SortOrder', 'ASC', false);
+        $this->assertEquals(
+            $query->execute()->column('Title'),
+            $query->column('Title')
+        );
+    }
+
     public function testComparisonClauseDateStartsWith()
     {
         DB::query("INSERT INTO \"DataQueryTest_F\" (\"MyDate\") VALUES ('1988-03-04 06:30')");


### PR DESCRIPTION
Due to `$i` not being augmented properly, the `ensureSelectContainsOrderByColumns` function was overwriting previous indexes

Resolves: https://github.com/silverstripe/silverstripe-framework/issues/8926