### PR TITLE
FIX password validation min length message

### DIFF
--- a/src/Security/PasswordValidator.php
+++ b/src/Security/PasswordValidator.php
@@ -236,7 +236,7 @@ class PasswordValidator
             $error = _t(
                 __CLASS__ . '.TOOSHORT',
                 'Password is too short, it must be {minimum} or more characters long',
-                ['minimum' => $this->minLength]
+                ['minimum' => $minLength]
             );
 
             $valid->addError($error, 'bad', 'TOO_SHORT');


### PR DESCRIPTION
When relying on static config instead of an explicitly set minLength then this message would show without the value, like "it must be  or more characters long".
