### PR TITLE
NEW Adding a shuffle method to ArrayList

### DIFF
--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -573,6 +573,18 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     }
 
     /**
+     * Shuffle the items in this array list
+     *
+     * @return $this
+     */
+    public function shuffle()
+    {
+        shuffle($this->items);
+
+        return $this;
+    }
+
+    /**
      * Returns true if the given column can be used to filter the records.
      *
      * It works by checking the fields available in the first record of the list.

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1134,6 +1134,16 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
     }
 
     /**
+     * Shuffle the datalist using a random function provided by the SQL engine
+     *
+     * @return $this
+     */
+    public function shuffle()
+    {
+        return $this->sort(DB::get_conn()->random());
+    }
+
+    /**
      * Remove every element in this DataList.
      *
      * @return $this

--- a/tests/php/ORM/ArrayListTest.php
+++ b/tests/php/ORM/ArrayListTest.php
@@ -1236,4 +1236,19 @@ class ArrayListTest extends SapphireTest
         $list->setDataClass(DataObject::class);
         $this->assertEquals(DataObject::class, $list->dataClass());
     }
+
+    public function testShuffle()
+    {
+        $upperLimit = 50;
+
+        $list = new ArrayList(range(1, $upperLimit));
+
+        $list->shuffle();
+
+        for ($i = 1; $i <= $upperLimit; $i++) {
+            $this->assertContains($i, $list);
+        }
+
+        $this->assertNotEquals(range(1, $upperLimit), $list->toArray());
+    }
 }

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -1837,4 +1837,11 @@ class DataListTest extends SapphireTest
             $list->column("Title")
         );
     }
+
+    public function testShuffle()
+    {
+        $list = Team::get()->shuffle();
+
+        $this->assertSQLContains(DB::get_conn()->random() . ' AS "_SortColumn', $list->dataQuery()->sql());
+    }
 }


### PR DESCRIPTION
I considered adding some `applyCallback(callable $callable)` API but I couldn't think of any other use case for it. It's different from `each` because we want one callback on the whole list... not each individual item.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->