### PR TITLE
API TestSession request methods now use the correct HTTP method

### DIFF
--- a/docs/en/02_Developer_Guides/06_Testing/01_Functional_Testing.md
+++ b/docs/en/02_Developer_Guides/06_Testing/01_Functional_Testing.md
@@ -24,6 +24,18 @@ $page = $this->post($url);
 Performs a POST request on $url and retrieves the [HTTPResponse](api:SilverStripe\Control\HTTPResponse). This also changes the current page to the value
 of the response.
 
+<div class="notice" markdown="1">
+**Compatibility Notice:** Previous versions of SilverStripe would send a GET request if `post()` was called with no POST variables supplied in the second argument.
+SilverStripe 4.6 and later always sends a POST request for consistency.
+</div>
+
+## Other Requests
+```php
+$page = $this->sendRequest('PUT', $url);
+```
+
+Performs a request on $url with the HTTP method provided (useful for PUT, PATCH, DELETE, etc.). This also changes the current page to the value of the response.
+
 ## Submit
 
 


### PR DESCRIPTION
TestSession currently exposes 2 methods for sending a GET request:

- `get($url)`
- `post($url, [])`

The first one makes sense! The second... not so much.

If we follow the trail down, each of these methods is calling `Director::test` and passing `null` as the HTTP method, relying on `Director::test` to decide what method to use. Turns out, it decides based on whether the `$postVars` parameter passed is truthy. If yes, it's POST. Otherwise, it's GET.

Traditionally, `post()` would normally work as expected, as the vast majority of POST endpoints expect POST vars to be present. However, many POST endpoints in RESTful APIs use a JSON blob in the body of the request instead. To test these endpoints with TestSession today, we have to pass dummy POST vars into the `post()` call.

This PR makes `post()` POST, always. It also makes `get()` explicitly GET, and provides a third method - `sendRequest()` - which allows the developer to specify what HTTP method should be used (PUT and DELETE exist too!)

I'm raising this PR against master as it results in an API breakage - most uses of `post()` won't be relying on that request actually being passed as a GET, but some might.