### PR TITLE
API Add extension points to MigrateFileTask

### DIFF
--- a/src/Dev/Tasks/MigrateFileTask.php
+++ b/src/Dev/Tasks/MigrateFileTask.php
@@ -56,7 +56,7 @@ class MigrateFileTask extends BuildTask
                 $this->logger->error("No file migration helper detected");
             } else {
                 $this->extend('preFileMigrationSubtask', $subtask);
-                $this->logger->info('### Migrating filesystem and database records (move-files)');
+                $this->logger->info("### Migrating filesystem and database records ({$subtask})");
                 $this->logger->info('If the task fails or times out, run it again and it will start where it left off.');
 
                 $migrated = FileMigrationHelper::singleton()->run();
@@ -75,7 +75,7 @@ class MigrateFileTask extends BuildTask
                 $this->logger->error("LegacyThumbnailMigrationHelper not found");
             } else {
                 $this->extend('preFileMigrationSubtask', $subtask);
-                $this->logger->info('### Migrating existing thumbnails (move-thumbnails)');
+                $this->logger->info("### Migrating existing thumbnails ({$subtask})");
 
                 $moved = LegacyThumbnailMigrationHelper::singleton()
                     ->setLogger($this->logger)
@@ -97,7 +97,7 @@ class MigrateFileTask extends BuildTask
                 $this->logger->error("ImageThumbnailHelper not found");
             } else {
                 $this->extend('preFileMigrationSubtask', $subtask);
-                $this->logger->info('### Generating new CMS UI thumbnails (generate-cms-thumbnails)');
+                $this->logger->info("### Generating new CMS UI thumbnails ({$subtask})");
                 ImageThumbnailHelper::singleton()->run();
                 $this->extend('postFileMigrationSubtask', $subtask);
             }
@@ -112,7 +112,7 @@ class MigrateFileTask extends BuildTask
             } else {
                 $this->extend('preFileMigrationSubtask', $subtask);
 
-                $this->logger->info('### Fixing folder permissions (fix-folder-permissions)');
+                $this->logger->info("### Fixing folder permissions ({$subtask})");
                 $updated = FixFolderPermissionsHelper::singleton()->run();
 
                 if ($updated > 0) {
@@ -132,7 +132,7 @@ class MigrateFileTask extends BuildTask
             } else {
                 $this->extend('preFileMigrationSubtask', $subtask);
 
-                $this->logger->info('### Fixing secure-assets (fix-secureassets)');
+                $this->logger->info("### Fixing secure-assets ({$subtask})");
                 $moved = SecureAssetsMigrationHelper::singleton()
                     ->setLogger($this->logger)
                     ->run($this->getStore());

--- a/src/Dev/Tasks/MigrateFileTask.php
+++ b/src/Dev/Tasks/MigrateFileTask.php
@@ -46,85 +46,102 @@ class MigrateFileTask extends BuildTask
         $args = $request->getVars();
         $this->validateArgs($args);
 
+        $this->extend('preFileMigration');
+
         $subtasks = !empty($args['only']) ? explode(',', $args['only']) : $this->defaultSubtasks;
 
-        if (in_array('move-files', $subtasks)) {
+        $subtask = 'move-files';
+        if (in_array($subtask, $subtasks)) {
             if (!class_exists(FileMigrationHelper::class)) {
                 $this->logger->error("No file migration helper detected");
-                return;
-            }
-
-            $this->logger->info('### Migrating filesystem and database records (move-files)');
-
-            $this->logger->info('If the task fails or times out, run it again and it will start where it left off.');
-
-            $migrated = FileMigrationHelper::singleton()->run();
-            if ($migrated) {
-                $this->logger->info("{$migrated} File DataObjects upgraded");
             } else {
-                $this->logger->info("No File DataObjects need upgrading");
+                $this->extend('preFileMigrationSubtask', $subtask);
+                $this->logger->info('### Migrating filesystem and database records (move-files)');
+                $this->logger->info('If the task fails or times out, run it again and it will start where it left off.');
+
+                $migrated = FileMigrationHelper::singleton()->run();
+                if ($migrated) {
+                    $this->logger->info("{$migrated} File DataObjects upgraded");
+                } else {
+                    $this->logger->info("No File DataObjects need upgrading");
+                }
+                $this->extend('postFileMigrationSubtask', $subtask);
             }
         }
 
-        if (in_array('move-thumbnails', $subtasks)) {
+        $subtask = 'move-thumbnails';
+        if (in_array($subtask, $subtasks)) {
             if (!class_exists(LegacyThumbnailMigrationHelper::class)) {
                 $this->logger->error("LegacyThumbnailMigrationHelper not found");
-                return;
-            }
-
-            $this->logger->info('### Migrating existing thumbnails (move-thumbnails)');
-
-            $moved = LegacyThumbnailMigrationHelper::singleton()
-                ->setLogger($this->logger)
-                ->run($this->getStore());
-
-            if ($moved) {
-                $this->logger->info(sprintf("%d thumbnails moved", count($moved)));
             } else {
-                $this->logger->info("No thumbnails moved");
+                $this->extend('preFileMigrationSubtask', $subtask);
+                $this->logger->info('### Migrating existing thumbnails (move-thumbnails)');
+
+                $moved = LegacyThumbnailMigrationHelper::singleton()
+                    ->setLogger($this->logger)
+                    ->run($this->getStore());
+
+                if ($moved) {
+                    $this->logger->info(sprintf("%d thumbnails moved", count($moved)));
+                } else {
+                    $this->logger->info("No thumbnails moved");
+                }
+
+                $this->extend('postFileMigrationSubtask', $subtask);
             }
         }
 
-        if (in_array('generate-cms-thumbnails', $subtasks)) {
+        $subtask = 'generate-cms-thumbnails';
+        if (in_array($subtask, $subtasks)) {
             if (!class_exists(ImageThumbnailHelper::class)) {
                 $this->logger->error("ImageThumbnailHelper not found");
-                return;
+            } else {
+                $this->extend('preFileMigrationSubtask', $subtask);
+                $this->logger->info('### Generating new CMS UI thumbnails (generate-cms-thumbnails)');
+                ImageThumbnailHelper::singleton()->run();
+                $this->extend('postFileMigrationSubtask', $subtask);
             }
 
-            $this->logger->info('### Generating new CMS UI thumbnails (generate-cms-thumbnails)');
 
-            ImageThumbnailHelper::singleton()->run();
         }
 
-        if (in_array('fix-folder-permissions', $subtasks)) {
+        $subtask = 'fix-folder-permissions';
+        if (in_array($subtask, $subtasks)) {
             if (!class_exists(FixFolderPermissionsHelper::class)) {
                 $this->logger->error("FixFolderPermissionsHelper not found");
-                return;
-            }
-
-            $this->logger->info('### Fixing folder permissions (fix-folder-permissions)');
-
-            $updated = FixFolderPermissionsHelper::singleton()->run();
-
-            if ($updated > 0) {
-                $this->logger->info("Repaired {$updated} folders with broken CanViewType settings");
             } else {
-                $this->logger->info("No folders required fixes");
+                $this->extend('preFileMigrationSubtask', $subtask);
+
+                $this->logger->info('### Fixing folder permissions (fix-folder-permissions)');
+                $updated = FixFolderPermissionsHelper::singleton()->run();
+
+                if ($updated > 0) {
+                    $this->logger->info("Repaired {$updated} folders with broken CanViewType settings");
+                } else {
+                    $this->logger->info("No folders required fixes");
+                }
+
+                $this->extend('postFileMigrationSubtask', $subtask);
             }
         }
 
-        if (in_array('fix-secureassets', $subtasks)) {
+        $subtask = 'fix-secureassets';
+        if (in_array($subtask, $subtasks)) {
             if (!class_exists(SecureAssetsMigrationHelper::class)) {
                 $this->logger->error("SecureAssetsMigrationHelper not found");
-                return;
+            } else {
+                $this->extend('preFileMigrationSubtask', $subtask);
+
+                $this->logger->info('### Fixing secure-assets (fix-secureassets)');
+                $moved = SecureAssetsMigrationHelper::singleton()
+                    ->setLogger($this->logger)
+                    ->run($this->getStore());
+
+                $this->extend('postFileMigrationSubtask', $subtask);
             }
-
-            $this->logger->info('### Fixing secure-assets (fix-secureassets)');
-
-            $moved = SecureAssetsMigrationHelper::singleton()
-                ->setLogger($this->logger)
-                ->run($this->getStore());
         }
+
+        $this->extend('postFileMigration');
     }
 
     public function getDescription()


### PR DESCRIPTION
This PR adds a few extension points to `MigrateFileTask` so the `solr` module can hook into there to know it needs to temporarely disable itself to avoid constant reindexing as the migration occurs.

The doc describes how to use the extension points.

I've also fix a parallel issue where the task would have quite prematurely if one of the File Helper was not present.

# Parent issue
* #8965
