### PR TITLE
API: Drop PHP 5.6 and PHP 7.0 support in SS 4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,38 +18,22 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
+    - php: 7.1
       env:
         - DB=PGSQL
         - PHPCS_TEST=1
         - PHPUNIT_TEST=framework
 
-    - php: 7.0
+    - php: 7.2
       env:
         - DB=PGSQL
         - PDO=1
         - PHPUNIT_TEST=framework
 
-    - php: 7.1
-      if: type IN (cron)
-      env:
-        - DB=MYSQL
-        - PHPUNIT_COVERAGE_TEST=framework
-
-    - php: 7.2
-      env:
-        - DB=MYSQL
-        - PDO=1
-        - PHPUNIT_TEST=framework
-
-    - php: 7.0
-      env:
-        - DB=MYSQL
-        - PHPUNIT_TEST=cms
-
     - php: 7.3
       env:
         - DB=MYSQL
+        - PDO=1
         - PHPUNIT_TEST=framework
 
     - php: 7.4snapshot
@@ -60,6 +44,17 @@ matrix:
         apt:
           packages:
             - libonig-dev
+
+    - php: 7.3
+      if: type IN (cron)
+      env:
+        - DB=MYSQL
+        - PHPUNIT_COVERAGE_TEST=framework
+
+    - php: 7.3
+      env:
+        - DB=MYSQL
+        - PHPUNIT_TEST=cms
 
 before_script:
 # Extra $PATH

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/config": "^3.2",
         "symfony/translation": "^2.8",
         "symfony/yaml": "~3.2",
-        "php": ">=5.6.0",
+        "php": ">=7.1.0",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-hash": "*",

--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -8,11 +8,9 @@ Our web-based [PHP installer](installation/) can check if you meet the requireme
 
 ## Web server software requirements
 
-SilverStripe 4 has the following server requirements:
+SilverStripe 4.5 has the following server requirements:
 
- * PHP 5.6, 7.0, 7.1 or 7.2
-   * Note: Although we do our best to support 5.6 and 7.0, they are deprecated and [unsupported by the PHP Project](http://php.net/supported-versions.php).
-     If you are using these, we strongly recommend you to upgrade.
+ * PHP 7.1+ (5.6+ was supported 4.0 - 4.4, we dropped support for these 6 months after PHP EOL'd them)
  * Allocate at least 48MB of memory to each PHP process. (SilverStripe can be resource hungry for some intensive operations.)
  * PHP requires a suitable CSPRNG (random number generator) source for generating random tokens, password salts etc. This can be any of the following, and most operating systems will have at least one source available:
    * PHP 7 `random_bytes()`:


### PR DESCRIPTION
This was discussed and agreed in #8556. The two changes are 
composer.json and travis. The docs have also been updated. No other
code changes have been made.