### PR TITLE
FIX HeaderField requires the optional Title field

### DIFF
--- a/src/Forms/HeaderField.php
+++ b/src/Forms/HeaderField.php
@@ -30,7 +30,7 @@ class HeaderField extends DatalessField
      * @param string $title
      * @param int $headingLevel
      */
-    public function __construct($name, $title, $headingLevel = 2)
+    public function __construct($name, $title = null, $headingLevel = 2)
     {
         $this->setHeadingLevel($headingLevel);
         parent::__construct($name, $title);


### PR DESCRIPTION
`FormField` marks the Title constructor argument as optional, and `DatalessField` does not override the `__construct` method. HeaderField on the other hand goes against the grain of FormFields as a whole and requires the Title field, seemingly for no good reason (at least, not that the commit message for a68ba384781086f902708c7364550cc996c15b16 indicates) - this seems like an accidental omission. This commit looks to reinstate the "optionality" of this constructor argument for consistency's sake.

Plus it broke a module I was investigating.