### PR TITLE
FIX: Fix bug when confirmed password is changed but not the password.

### DIFF
--- a/src/Forms/ConfirmedPasswordField.php
+++ b/src/Forms/ConfirmedPasswordField.php
@@ -341,6 +341,7 @@ class ConfirmedPasswordField extends FormField
 
         //store this for later
         $oldValue = $this->value;
+        $oldConfirmValue = $this->confirmValue;
 
         if (is_array($value)) {
             $this->value = $value['_Password'];
@@ -364,7 +365,8 @@ class ConfirmedPasswordField extends FormField
         if ($oldValue != $this->value) {
             $this->getChildren()->fieldByName($this->getName() . '[_Password]')
                 ->setValue($this->value);
-
+        }
+        if ($oldConfirmValue != $this->confirmValue) {
             $this->getChildren()->fieldByName($this->getName() . '[_ConfirmPassword]')
                 ->setValue($this->confirmValue);
         }

--- a/tests/php/Forms/ConfirmedPasswordFieldTest.php
+++ b/tests/php/Forms/ConfirmedPasswordFieldTest.php
@@ -148,12 +148,34 @@ class ConfirmedPasswordFieldTest extends SapphireTest
         $form->loadDataFrom([
             'Password' => [
                 '_Password' => '123',
-                '_ConfirmPassword' => '999',
+                '_ConfirmPassword' => '',
             ],
         ]);
 
         $this->assertEquals('123', $field->children->first()->Value());
-        $this->assertEquals('999', $field->children->last()->Value());
+        $this->assertEmpty($field->children->last()->Value());
+        $this->assertNotEquals($field->children->first()->Value(), $field->children->last()->Value());
+
+        $form->loadDataFrom([
+            'Password' => [
+                '_Password' => '123',
+                '_ConfirmPassword' => 'abc',
+            ],
+        ]);
+
+        $this->assertEquals('123', $field->children->first()->Value());
+        $this->assertEquals('abc', $field->children->last()->Value());
+        $this->assertNotEquals($field->children->first()->Value(), $field->children->last()->Value());
+
+        $form->loadDataFrom([
+            'Password' => [
+                '_Password' => '',
+                '_ConfirmPassword' => 'abc',
+            ],
+        ]);
+
+        $this->assertEmpty($field->children->first()->Value());
+        $this->assertEquals('abc', $field->children->last()->Value());
         $this->assertNotEquals($field->children->first()->Value(), $field->children->last()->Value());
     }
 


### PR DESCRIPTION
In this case the confirmed password field is not reflected. It’s 
unclear how often this situation would arise outside of test scenarios,
but may come up if $form->loadDataFrom() is called more than once.

Fixes #2496 (it’s a minor issue but I think this is why Dan flagged it
as a regression). Originally introduced as part of Dan’s initial fix
at 2a6f1f1949956b4c91c5b7925707f29653dc1033.