### PR TITLE
FIX: List default items in the readonly view of ListboxField

### DIFF
--- a/src/Forms/MultiSelectField.php
+++ b/src/Forms/MultiSelectField.php
@@ -276,6 +276,11 @@ abstract class MultiSelectField extends SelectField
         $field->setSource($this->getSource());
         $field->setReadonly(true);
 
+        // Pass through default items
+        if (!$this->getValueArray() && $this->getDefaultItems()) {
+            $field->setValue($this->getDefaultItems());
+        }
+
         return $field;
     }
 }

--- a/tests/php/Forms/ListboxFieldTest/Tag.php
+++ b/tests/php/Forms/ListboxFieldTest/Tag.php
@@ -12,4 +12,8 @@ class Tag extends DataObject implements TestOnly
     private static $belongs_many_many = array(
         'Articles' => Article::class
     );
+
+    private static $db = [
+        'Title' => 'Varchar',
+    ];
 }


### PR DESCRIPTION
Adds tests for non-readonly default items too.

Fixes #4142
