### PR TITLE
Allow displaying partial/full query message for debugging

### DIFF
--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -32,7 +32,6 @@ abstract class Database
      *      'SELECT "Version" FROM "SiteTree_Live" WHERE "ID" = ?' => 'full_query',
      * ])
      * </code>
-     * @internal
      * @var array
      */
     protected static $whitelist_array = [];
@@ -266,7 +265,7 @@ abstract class Database
      * @param mixed $query
      * @param float $endtime
      */
-    private function displayQuery($query, $endtime)
+    protected function displayQuery($query, $endtime)
     {
         $queryCount = sprintf("%04d", $this->queryCount);
         Debug::message("\n$queryCount: $query\n{$endtime}s\n", false);
@@ -280,6 +279,16 @@ abstract class Database
     public static function setWhitelistQueryArray($whitelistArray)
     {
         self::$whitelist_array = $whitelistArray;
+    }
+
+    /**
+     * Get the sql queries that need to be partially or fully matched
+     *
+     * @return array
+     */
+    public static function getWhitelistQueryArray()
+    {
+        return self::$whitelist_array;
     }
 
     /**


### PR DESCRIPTION
In benchmarkQuery function, we only allow to display all of the queries that are run in the request. However, in this feature, I added an option `whitelist` which would let user to either specify a query partially or fully. In this way, we don't have to load ALL of the queries which takes so long. 