### PR TITLE
[FIX] #9029 Allow setting of memory limit to unlimited

### DIFF
--- a/src/Core/Environment.php
+++ b/src/Core/Environment.php
@@ -89,17 +89,20 @@ class Environment
             return true;
         }
 
-        // Check hard maximums
-        $max = static::getMemoryLimitMax();
-        if ($max > 0 && ($memoryLimit < 0 || $memoryLimit > $max)) {
-            $memoryLimit = $max;
-        }
 
         // Increase the memory limit if it's too low
         if ($memoryLimit < 0) {
             ini_set('memory_limit', '-1');
-        } elseif ($memoryLimit > $curLimit) {
-            ini_set('memory_limit', Convert::bytes2memstring($memoryLimit));
+        } else {
+            // Check hard maximums
+            $max = static::getMemoryLimitMax();
+            if ($max > 0 && ($memoryLimit < 0 || $memoryLimit > $max)) {
+                $memoryLimit = $max;
+            }
+
+            if ($memoryLimit > $curLimit) {
+                ini_set('memory_limit', Convert::bytes2memstring($memoryLimit));
+            }
         }
 
         return true;


### PR DESCRIPTION
Allow setting of the memory limit to unlimited, when calling Environment::increaseMemoryLimitTo()
This fixes issue #9029
