### PR TITLE
URLSegmentFilter: Remove : characters from url segments when multibyt…

### DIFF
--- a/src/View/Parsers/URLSegmentFilter.php
+++ b/src/View/Parsers/URLSegmentFilter.php
@@ -36,7 +36,7 @@ class URLSegmentFilter
         '/\s|\+/u' => '-', // remove whitespace/plus
         '/[_.]+/u' => '-', // underscores and dots to dashes
         '/[^A-Za-z0-9\-]+/u' => '', // remove non-ASCII chars, only allow alphanumeric and dashes
-        '/[\/\?=#]+/u' => '-', // remove forward slashes, question marks, equal signs and hashes in case multibyte is allowed (and non-ASCII chars aren't removed)
+        '/[\/\?=#:]+/u' => '-', // remove forward slashes, question marks, equal signs, hashes and colons in case multibyte is allowed (and non-ASCII chars aren't removed)
         '/[\-]{2,}/u' => '-', // remove duplicate dashes
         '/^[\-]+/u' => '', // Remove all leading dashes
         '/[\-]+$/u' => '' // Remove all trailing dashes

--- a/tests/php/ORM/URLSegmentFilterTest.php
+++ b/tests/php/ORM/URLSegmentFilterTest.php
@@ -113,6 +113,6 @@ class URLSegmentFilterTest extends SapphireTest
     {
         $filter = new URLSegmentFilter();
         $filter->setAllowMultibyte(true);
-        $this->assertEquals('url-with-bad-characters', $filter->filter('url?-with/-bad#-characters='));
+        $this->assertEquals('url-with-some-bad-characters', $filter->filter('url?-with/-some:-bad#-characters='));
     }
 }


### PR DESCRIPTION
…e characters are allowed.

For example when creating a new Page in the CMS and giving it a title like _What I have learned: Colons should be removed from URLs_ the colon didn't get removed from the URL segment if you had allowed multibyte characters by using the following YAML configuration:
```YAML
SilverStripe\View\Parsers\URLSegmentFilter:
  default_allow_multibyte: true
```
Similar pull requests that I've made in 2016 when I added `?`, `=` and `#` to the removable characters:
#4958
#4963

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
