### PR TITLE
FIX: Fixed issue causing cacheblocks to capture url parameters inside of them

### DIFF
--- a/src/View/SSTemplateParser.peg
+++ b/src/View/SSTemplateParser.peg
@@ -744,9 +744,11 @@ class SSTemplateParser extends Parser implements TemplateParser
         $condition = isset($res['condition']) ? $res['condition'] : '';
 
         $res['php'] .= 'if ('.$condition.'($partial = $cache->get('.$key.'))) $val .= $partial;' . PHP_EOL;
-        $res['php'] .= 'else { $oldval = $val; $val = "";' . PHP_EOL;
+        $res['php'] .= 'else { $oldval = $val; $val = ""; $oldrewritehash = \\SilverStripe\\View\\SSViewer::getRewriteHashLinksDefault();' . PHP_EOL;
+        $res['php'] .= '\\SilverStripe\\View\\SSViewer::setRewriteHashLinksDefault(false);' . PHP_EOL;
         $res['php'] .= $sub['php'] . PHP_EOL;
         $res['php'] .= $condition . ' $cache->set('.$key.', $val); $val = $oldval . $val;' . PHP_EOL;
+        $res['php'] .= '\\SilverStripe\\View\\SSViewer::setRewriteHashLinksDefault($oldrewritehash);' . PHP_EOL;
         $res['php'] .= '}';
     }
 

--- a/src/View/SSTemplateParser.php
+++ b/src/View/SSTemplateParser.php
@@ -3052,9 +3052,11 @@ class SSTemplateParser extends Parser implements TemplateParser
         $condition = isset($res['condition']) ? $res['condition'] : '';
 
         $res['php'] .= 'if ('.$condition.'($partial = $cache->get('.$key.'))) $val .= $partial;' . PHP_EOL;
-        $res['php'] .= 'else { $oldval = $val; $val = "";' . PHP_EOL;
+        $res['php'] .= 'else { $oldval = $val; $val = ""; $oldrewritehash = \\SilverStripe\\View\\SSViewer::getRewriteHashLinksDefault();' . PHP_EOL;
+        $res['php'] .= '\\SilverStripe\\View\\SSViewer::setRewriteHashLinksDefault(false);' . PHP_EOL;
         $res['php'] .= $sub['php'] . PHP_EOL;
         $res['php'] .= $condition . ' $cache->set('.$key.', $val); $val = $oldval . $val;' . PHP_EOL;
+        $res['php'] .= '\\SilverStripe\\View\\SSViewer::setRewriteHashLinksDefault($oldrewritehash);' . PHP_EOL;
         $res['php'] .= '}';
     }
 


### PR DESCRIPTION
Per #8986, in SilverStripe 4.3.3 (likely prior and current future) url parameters can be caught in cache block rewrites.  This pull request disables the hash rewriting inside of the cache block re-generation of the cache, then re-enables it after setting the cache.