### PR TITLE
FIX Ensure extensions are not marked to remove after removal

### DIFF
--- a/src/Dev/State/ExtensionTestState.php
+++ b/src/Dev/State/ExtensionTestState.php
@@ -115,6 +115,7 @@ class ExtensionTestState implements TestState
                 $dataClass::remove_extension($extension);
             }
         }
+        $this->extensionsToRemove = [];
 
         // Reapply ones removed
         foreach ($this->extensionsToReapply as $dataClass => $extensions) {
@@ -122,5 +123,6 @@ class ExtensionTestState implements TestState
                 $dataClass::add_extension($extension);
             }
         }
+        $this->extensionsToReapply = [];
     }
 }


### PR DESCRIPTION
Not entirely sure the underlying cause on this but I'm managing to get an occasional occurance in tests where extensions that are required are not actually being added. This fixes the issue.