### PR TITLE
DOCS Remove confusing API change from changelog

### DIFF
--- a/docs/en/04_Changelogs/4.4.0.md
+++ b/docs/en/04_Changelogs/4.4.0.md
@@ -359,7 +359,6 @@ SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest:
 
 ### API Changes
 
- * 2019-05-06 [8ee50d2ba](https://github.com/silverstripe/silverstripe-framework/commit/8ee50d2ba7ff582bf317de7c1149d17bab1eb4fa) Remove DataObjectSchema::getFieldMap() (#8960) (Maxime Rainville)
  * 2019-05-03 [5337e6d04](https://github.com/silverstripe/silverstripe-framework/commit/5337e6d04847c66d0a293e9c6c53a58d97aea3a1) Replace FormActions with anchors to enable panel-based loading in GridField navigation buttons (#8953) (Robbie Averill)
  * 2019-04-30 [d325b8a](https://github.com/silverstripe/silverstripe-assets/commit/d325b8a6e0594ba50de1033edc5b99428ed6e5dd) Mark the FlysystemAssetStore FileResolutionStrategy getters and setters as internal (#255) (Maxime Rainville)
  * 2019-04-16 [3c6357d](https://github.com/silverstripe/silverstripe-assets/commit/3c6357d5856857fe21d893495071d989a8500bed) Add an extension to the regular AssetStore interface (Maxime Rainville)


### PR DESCRIPTION
This change was removing a method that was added in 4.4.0 also - this makes it not a breaking change for SemVer