### PR TITLE
BUG Temporarilly allow PHP 7.4 build to fail without failing the entire build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,8 @@ matrix:
       env:
         - DB=MYSQL
         - PHPUNIT_TEST=cms
+  allow_failures:
+    - php: 7.4snapshot
 
 before_script:
 # Extra $PATH


### PR DESCRIPTION
PHPUnit 5 is not compatible with PHP 7.4 ... we need to address this properly, but for now we can allow that specific matrix entry to fail.

# Parent issue
* https://github.com/silverstripe/silverstripe-framework/issues/9062