### PR TITLE
NEW Add FilterInterface and retrofit into URLSegmentFilter

### DIFF
--- a/src/View/Parsers/FilterInterface.php
+++ b/src/View/Parsers/FilterInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SilverStripe\View\Parsers;
+
+/**
+ * A FilterInterface is given an input string and returns a filtered string. Replacements will be provided and
+ * performed (typically in regex format), and transliteration may be used as a separate service to replace
+ * characters rather than remove them.
+ *
+ * For example implementations, see {@link URLSegmentFilter}.
+ */
+interface FilterInterface
+{
+    /**
+     * Performs a set of replacement rules against the input string, applying transliteration if a service is
+     * provided, and returns the filtered result.
+     *
+     * @param string $input
+     * @return string
+     */
+    public function filter($input);
+}

--- a/src/View/Parsers/URLSegmentFilter.php
+++ b/src/View/Parsers/URLSegmentFilter.php
@@ -15,7 +15,7 @@ use SilverStripe\Core\Injector\Injectable;
  *
  * See {@link FileNameFilter} for similar implementation for filesystem-based URLs.
  */
-class URLSegmentFilter
+class URLSegmentFilter implements FilterInterface
 {
     use Configurable;
     use Injectable;
@@ -59,6 +59,17 @@ class URLSegmentFilter
     public $replacements = array();
 
     /**
+     * @var Transliterator
+     */
+    protected $transliterator;
+
+
+    /**
+     * @var boolean
+     */
+    protected $allowMultibyte;
+
+    /**
      * Note: Depending on the applied replacement rules, this method might result in an empty string.
      *
      * @param string $name URL path (without domain or query parameters), in utf8 encoding
@@ -96,49 +107,43 @@ class URLSegmentFilter
     }
 
     /**
-     * @param array $r Map of find/replace used for preg_replace().
+     * @param string[] $replacements Map of find/replace used for preg_replace().
+     * @return $this
      */
-    public function setReplacements($r)
+    public function setReplacements($replacements)
     {
-        $this->replacements = $r;
+        $this->replacements = $replacements;
+        return $this;
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function getReplacements()
     {
-        return ($this->replacements) ? $this->replacements : (array)$this->config()->default_replacements;
+        return $this->replacements ?: (array)$this->config()->get('default_replacements');
     }
 
     /**
-     * @var Transliterator
-     */
-    protected $transliterator;
-
-    /**
-     * @return Transliterator
+     * @return Transliterator|null
      */
     public function getTransliterator()
     {
-        if ($this->transliterator === null && $this->config()->default_use_transliterator) {
+        if ($this->transliterator === null && $this->config()->get('default_use_transliterator')) {
             $this->transliterator = Transliterator::create();
         }
         return $this->transliterator;
     }
 
     /**
-     * @param Transliterator $t
+     * @param Transliterator $transliterator
+     * @return $this
      */
-    public function setTransliterator($t)
+    public function setTransliterator($transliterator)
     {
-        $this->transliterator = $t;
+        $this->transliterator = $transliterator;
+        return $this;
     }
-
-    /**
-     * @var boolean
-     */
-    protected $allowMultibyte;
 
     /**
      * @param boolean


### PR DESCRIPTION
There are other filters in the core SilverStripe product, e.g. FileNameFilter in silverstripe/assets which would benefit from having a common filter interface. This retrofits one for URLSegmentFilter in framework. I have not added any PHP 7 syntax in method signatures to avoid breaking backwards compatibility.

Note: it's possible this could be seen as a breaking change, if someone had replaced URLSegmentFilter with their own implementation that didn't extend it. At this point there are no consumers of the FilterInterface directly, so this wouldn't break anything immediately, but there is a possibility it could break something in a future release if FilterInterface is type hinted somewhere. For this reason I'd be OK with retargetting at SilverStripe 5.x if somebody is concerned about this. If people have typehints on this class it would be on URLSegmentFilter, in which case retrofitting this interface won't break those.