### PR TITLE
fix #9075 log example yml-config in docs

### DIFF
--- a/docs/en/02_Developer_Guides/07_Debugging/01_Error_Handling.md
+++ b/docs/en/02_Developer_Guides/07_Debugging/01_Error_Handling.md
@@ -128,7 +128,7 @@ To send emails, you can use Monolog's [NativeMailerHandler](https://github.com/S
 SilverStripe\Core\Injector\Injector:
   Psr\Log\LoggerInterface: 
     calls:
-      MailHandler: [ pushHandler, [ %$MailHandler ] ]
+      MailHandler: [ pushHandler, [ '%$MailHandler' ] ]
   MailHandler:
       class: Monolog\Handler\NativeMailerHandler
       constructor:
@@ -155,7 +155,7 @@ To log to a file, you can use Monolog's [StreamHandler](https://github.com/Selda
 SilverStripe\Core\Injector\Injector:
   Psr\Log\LoggerInterface: 
     calls:
-      LogFileHandler: [ pushHandler, [ %$LogFileHandler ] ]
+      LogFileHandler: [ pushHandler, [ '%$LogFileHandler' ] ]
   LogFileHandler:
     class: Monolog\Handler\StreamHandler
     constructor:
@@ -195,7 +195,7 @@ Only:
 SilverStripe\Core\Injector\Injector:
   Psr\Log\LoggerInterface.errorhandler:
     calls:
-      pushMyDisplayErrorHandler: [ pushHandler, [ %$DisplayErrorHandler ]]
+      pushMyDisplayErrorHandler: [ pushHandler, [ '%$DisplayErrorHandler' ]]
   DisplayErrorHandler:
     class: SilverStripe\Logging\HTTPOutputHandler
     constructor:
@@ -213,15 +213,15 @@ SilverStripe\Core\Injector\Injector:
   Psr\Log\LoggerInterface:
     calls:
       # Save system logs to file
-      pushFileLogHandler: [ pushHandler, [ %$LogFileHandler ]]
+      pushFileLogHandler: [ pushHandler, [ '%$LogFileHandler' ]]
   
   # Core error handler for system use
   Psr\Log\LoggerInterface.errorhandler:
     calls:
       # Save errors to file
-      pushFileLogHandler: [ pushHandler, [ %$LogFileHandler ]]
+      pushFileLogHandler: [ pushHandler, [ '%$LogFileHandler' ]]
       # Format and display errors in the browser/CLI 
-      pushMyDisplayErrorHandler: [ pushHandler, [ %$DisplayErrorHandler ]]
+      pushMyDisplayErrorHandler: [ pushHandler, [ '%$DisplayErrorHandler' ]]
   
   # Custom handler to log to a file
   LogFileHandler:

--- a/docs/en/02_Developer_Guides/07_Debugging/01_Error_Handling.md
+++ b/docs/en/02_Developer_Guides/07_Debugging/01_Error_Handling.md
@@ -195,7 +195,7 @@ Only:
 SilverStripe\Core\Injector\Injector:
   Psr\Log\LoggerInterface.errorhandler:
     calls:
-      pushDisplayErrorHandler: [ pushHandler, [ %$DisplayErrorHandler ]] 
+      pushMyDisplayErrorHandler: [ pushHandler, [ %$DisplayErrorHandler ]]
   DisplayErrorHandler:
     class: SilverStripe\Logging\HTTPOutputHandler
     constructor:
@@ -221,7 +221,7 @@ SilverStripe\Core\Injector\Injector:
       # Save errors to file
       pushFileLogHandler: [ pushHandler, [ %$LogFileHandler ]]
       # Format and display errors in the browser/CLI 
-      pushDisplayErrorHandler: [ pushHandler, [ %$DisplayErrorHandler ]] 
+      pushMyDisplayErrorHandler: [ pushHandler, [ %$DisplayErrorHandler ]]
   
   # Custom handler to log to a file
   LogFileHandler:


### PR DESCRIPTION
Fatal error: Uncaught InvalidArgumentException: 'calls' entries in service definition should be 1 or 2 element arrays. See #9075