### PR TITLE
Catch Path::join() exceptions in findTemplate() (fixes #9084)

### DIFF
--- a/src/View/ThemeResourceLoader.php
+++ b/src/View/ThemeResourceLoader.php
@@ -218,9 +218,13 @@ class ThemeResourceLoader
             foreach ($themePaths as $themePath) {
                 // Join path
                 $pathParts = [ $this->base, $themePath, 'templates', $head, $type, $tail ];
-                $path = Path::join($pathParts) . '.ss';
-                if (file_exists($path)) {
-                    return $path;
+                try {
+                    $path = Path::join($pathParts) . '.ss';
+                    if (file_exists($path)) {
+                        return $path;
+                    }
+                } catch (InvalidArgumentException $e) {
+                    // No-op
                 }
             }
         }


### PR DESCRIPTION
Fixes #9084.

I decided to fix this internally (rather than up the chain in `Controller->hasActionTemplate(foo..)` for example), because `ThemeResourceLoader` will cache that the given template doesn’t exist.