### PR TITLE
BUG Delimiter is ignored, BOM crashes CSV import

### DIFF
--- a/src/Dev/CsvBulkLoader.php
+++ b/src/Dev/CsvBulkLoader.php
@@ -76,6 +76,7 @@ class CsvBulkLoader extends BulkLoader
         try {
             $filepath = Director::getAbsFile($filepath);
             $csvReader = Reader::createFromPath($filepath, 'r');
+            $csvReader->setDelimiter($this->delimiter)->stripBom(true);
 
             $tabExtractor = function ($row) {
                 foreach ($row as &$item) {


### PR DESCRIPTION
Adding a delimiter was ignored and when using a CSV file with BOM, the import crashes (see Slack conversation https://silverstripe-users.slack.com/archives/C36U3BDHN/p1561182346266800).

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
