### PR TITLE
FIX: Repeated iteration should return all records

### DIFF
--- a/src/ORM/Connect/MySQLQuery.php
+++ b/src/ORM/Connect/MySQLQuery.php
@@ -48,8 +48,11 @@ class MySQLQuery extends Query
     public function seek($row)
     {
         if (is_object($this->handle)) {
+            // Fix for https://github.com/silverstripe/silverstripe-framework/issues/9097 without breaking the seek() API
             $this->handle->data_seek($row);
-            return $this->nextRecord();
+            $result = $this->nextRecord();
+            $this->handle->data_seek($row);
+            return $result;
         }
         return null;
     }

--- a/src/ORM/Connect/MySQLStatement.php
+++ b/src/ORM/Connect/MySQLStatement.php
@@ -105,8 +105,12 @@ class MySQLStatement extends Query
     public function seek($row)
     {
         $this->rowNum = $row - 1;
+
+        // Fix for https://github.com/silverstripe/silverstripe-framework/issues/9097 without breaking the seek() API
         $this->statement->data_seek($row);
-        return $this->next();
+        $result = $this->next();
+        $this->statement->data_seek($row);
+        return $result;
     }
 
     public function numRecords()
@@ -135,6 +139,6 @@ class MySQLStatement extends Query
 
     public function rewind()
     {
-        return $this->seek(0);
+        $this->seek(0);
     }
 }

--- a/src/ORM/Connect/MySQLStatement.php
+++ b/src/ORM/Connect/MySQLStatement.php
@@ -136,9 +136,4 @@ class MySQLStatement extends Query
         }
         return $row;
     }
-
-    public function rewind()
-    {
-        $this->seek(0);
-    }
 }

--- a/src/ORM/Connect/Query.php
+++ b/src/ORM/Connect/Query.php
@@ -168,16 +168,15 @@ abstract class Query implements Iterator
      * Iterator function implementation. Rewind the iterator to the first item and return it.
      * Makes use of {@link seek()} and {@link numRecords()}, takes care of the plumbing.
      *
-     * @return array
+     * @return void
      */
     public function rewind()
     {
         if ($this->queryHasBegun && $this->numRecords() > 0) {
             $this->queryHasBegun = false;
             $this->currentRecord = null;
-            return $this->seek(0);
+            $this->seek(0);
         }
-        return null;
     }
 
     /**

--- a/tests/php/ORM/DatabaseTest.php
+++ b/tests/php/ORM/DatabaseTest.php
@@ -272,4 +272,25 @@ class DatabaseTest extends SapphireTest
         $result = DB::query('SELECT TRUE')->first();
         $this->assertInternalType('int', reset($result));
     }
+
+    /**
+     * Test that repeated iteration of a query returns all records.
+     * See https://github.com/silverstripe/silverstripe-framework/issues/9097
+     */
+    public function testRepeatedIteration()
+    {
+        $inputData = ['one', 'two', 'three', 'four'];
+
+        foreach ($inputData as $i => $text) {
+            $x = new MyObject();
+            $x->MyField = $text;
+            $x->MyInt = $i;
+            $x->write();
+        }
+
+        $query = DB::query('SELECT "MyInt", "MyField" FROM "DatabaseTest_MyObject" ORDER BY "MyInt"');
+
+        $this->assertEquals($inputData, $query->map());
+        $this->assertEquals($inputData, $query->map());
+    }
 }


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/9097

This is a bugfix whose root-cause is a long-standing misunderstanding of the Iterator::rewind() API. Therefore this change is correcting that – rewind() no longer returns a value; nor does its supporting method, seek().

Is this an API change or a bugfix? Given that this is generally speaking an internal API accessed via Iterator, and our implementation is wrong, I recommend that we include it on the 4.4 branch. To put it another way, the stated API _was_ the bug.