### PR TITLE
Allow extensions to modify form scaffolder in DataObject

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -2318,6 +2318,8 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         $fs->fieldClasses = $params['fieldClasses'];
         $fs->ajaxSafe = $params['ajaxSafe'];
 
+        $this->extend('updateFormScaffolder', $fs, $this);
+
         return $fs->getFieldList();
     }
 


### PR DESCRIPTION
I've added this because it's actually coming up where we want to add to `FormScaffolder::$restrictFields` before the form is scaffolded for performance reasons. Scaffolding a form field for a relation, just to remove it again in `getCMSFields` is just a performance loss. Alternatively I could add some API to allow updating this from within your DataObject definition but that might have to be a 4.5 feature.