### PR TITLE
NEW: Added support for config condition if PHP extension is loaded

### DIFF
--- a/docs/en/02_Developer_Guides/04_Configuration/00_Configuration.md
+++ b/docs/en/02_Developer_Guides/04_Configuration/00_Configuration.md
@@ -339,6 +339,7 @@ You then list any of the following rules as sub-keys, with informational values 
   - 'envvarset', in which case the value(s) should be environment variables that must be set
   - 'constantdefined', in which case the value(s) should be constants that must be defined
   - 'envorconstant' A variable which should be defined either via environment vars or constants
+  - 'extensionloaded', in which case the PHP extension(s) must be loaded
 
 For instance, to add a property to "foo" when a module exists, and "bar" otherwise, you could do this:
 

--- a/src/Core/Config/CoreConfigFactory.php
+++ b/src/Core/Config/CoreConfigFactory.php
@@ -182,6 +182,9 @@ class CoreConfigFactory
             })
             ->addRule('moduleexists', function ($module) {
                 return ModuleLoader::inst()->getManifest()->moduleExists($module);
+            })
+            ->addRule('extensionloaded', function ($extension) {
+                return extension_loaded($extension);
             });
     }
 }

--- a/tests/php/Core/Manifest/ConfigManifestTest.php
+++ b/tests/php/Core/Manifest/ConfigManifestTest.php
@@ -225,4 +225,21 @@ class ConfigManifestTest extends SapphireTest
             'Fragment is included if both blocks succeed.'
         );
     }
+    
+    public function testExtensionLoaded()
+    {
+        $config = $this->getConfigFixtureValue('ExtensionLoaded');
+
+        $this->assertEquals(
+            'Yes',
+            @$config['SessionExtLoaded'],
+            'Only rule correctly detects loaded PHP extension'
+        );
+
+        $this->assertEquals(
+            'No',
+            @$config['DummyExtLoaded'],
+            'Except rule correctly detects not-loaded PHP extension'
+        );
+    }
 }

--- a/tests/php/Core/Manifest/fixtures/configmanifest/mysite/_config/extloadedrules.yml
+++ b/tests/php/Core/Manifest/fixtures/configmanifest/mysite/_config/extloadedrules.yml
@@ -1,0 +1,28 @@
+---
+Only:
+  extensionloaded: "session"
+---
+SilverStripe\Core\Tests\Manifest\ConfigManifestTest:
+  ExtensionLoaded:
+    SessionExtLoaded: Yes
+---
+Only:
+  extensionloaded: "silverstripe_ext"
+---
+SilverStripe\Core\Tests\Manifest\ConfigManifestTest:
+  ExtensionLoaded:
+    DummyExtLoaded: Yes
+---
+Except:
+  extensionloaded: "session"
+---
+SilverStripe\Core\Tests\Manifest\ConfigManifestTest:
+  ExtensionLoaded:
+    SessionExtLoaded: No
+---
+Except:
+  extensionloaded: "silverstripe_ext"
+---
+SilverStripe\Core\Tests\Manifest\ConfigManifestTest:
+  ExtensionLoaded:
+    DummyExtLoaded: No


### PR DESCRIPTION
This pull request implements the new config exclusionary rule for if the given PHP extension(s) are loaded, fixing #9096