### PR TITLE
BUG Require a PHP7.4 compatible fork of phpunit-mock-objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
       env: DB=SQLITE
 
     - php: 7.4snapshot
-      env: DB=SQLITE
+      env: DB=SQLITE INSTALL_PHPUNIT_FORK=1
 
     # CMS test
     - php: 5.5
@@ -58,6 +58,7 @@ before_script:
  - if ! [ $(phpenv version-name) = "5.3" ]; then printf "\n" | travis_retry pecl install imagick; fi
  - if [ $(phpenv version-name) = "5.3" ]; then printf "\n" | travis_retry pecl install imagick-3.3.0; fi
  - composer self-update || true
+ - if [ $INSTALL_PHPUNIT_FORK ]; then composer require --no-update --dev sminnee/phpunit-mock-objects:^3.4.7; fi
  - phpenv rehash
  - phpenv config-rm xdebug.ini || true
  - echo 'memory_limit = 3G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^3 || ^4 || ^5"
-    },
+	},
     "extra": [],
     "autoload": {
         "psr-0": {

--- a/docs/en/04_Changelogs/3.7.3.md
+++ b/docs/en/04_Changelogs/3.7.3.md
@@ -1,20 +1,5 @@
 # 3.7.3
 
-* [Minor update to support PHP 7.4](https://github.com/silverstripe/silverstripe-framework/pull/9110) 
-
-# Running SilverStripe 3.7 on PHP 7.4
-
-SilverStripe's standard test tools require `phpunit/phpunit-mock-objects` to run. This package has been deprecated and doesn't support PHP 7.4.
-
-SilverStripe is using a fork, `sminnee/phpunit-mock-objects`, for its own PHP 7.4 tests.
-
-You can use this fork for your own project by running this command:
-```bash
-composer require --dev sminnee/phpunit-mock-objects:^3.4.7
-``` 
-
-This fork is not a supported module and SilverStripe does not commit to maintaining it.
-
 <!--- Changes below this line will be automatically regenerated -->
 
 ## Change Log

--- a/docs/en/04_Changelogs/3.7.3.md
+++ b/docs/en/04_Changelogs/3.7.3.md
@@ -1,5 +1,20 @@
 # 3.7.3
 
+* [Minor update to support PHP 7.4](https://github.com/silverstripe/silverstripe-framework/pull/9110) 
+
+# Running SilverStripe 3.7 on PHP 7.4
+
+SilverStripe's standard test tools require `phpunit/phpunit-mock-objects` to run. This package has been deprecated and doesn't support PHP 7.4.
+
+SilverStripe is using a fork, `sminnee/phpunit-mock-objects`, for its own PHP 7.4 tests.
+
+You can use this fork for your own project by running this command:
+```bash
+composer require --dev sminnee/phpunit-mock-objects:^3.4.7
+``` 
+
+This fork is not a supported module and SilverStripe does not commit to maintaining it.
+
 <!--- Changes below this line will be automatically regenerated -->
 
 ## Change Log

--- a/docs/en/04_Changelogs/3.7.4.md
+++ b/docs/en/04_Changelogs/3.7.4.md
@@ -1,0 +1,19 @@
+# 3.7.4 (unreleased)
+
+* [Minor update to support PHP 7.4](https://github.com/silverstripe/silverstripe-framework/pull/9110)
+
+## Running SilverStripe 3.7 on PHP 7.4
+
+SilverStripe's standard test tools require `phpunit/phpunit-mock-objects` to run. This package has been deprecated and
+doesn't support PHP 7.4.
+
+SilverStripe is using a fork for its own PHP 7.3 unit tests: `sminnee/phpunit-mock-objects`.
+
+You can use this fork for your own project by running this command:
+```bash
+composer require --dev sminnee/phpunit-mock-objects:^3.4.7
+```
+
+This fork is not a supported module and SilverStripe does not commit to maintaining it.
+
+<!--- Changes below this line will be automatically regenerated -->

--- a/filesystem/GD.php
+++ b/filesystem/GD.php
@@ -140,7 +140,11 @@ class GDBackend extends SS_Object implements Image_Backend {
 		$bytesPerPixel = $bits * $channels;
 
 		// width * height * bytes per pixel
-		$memoryRequired = $imageInfo[0] * $imageInfo[1] * $bytesPerPixel;
+		if ($imageInfo) {
+			$memoryRequired = $imageInfo[0] * $imageInfo[1] * $bytesPerPixel;
+		} else {
+			$memoryRequired = 0;
+		}
 
 		return $memoryRequired + memory_get_usage() < $limit;
 	}


### PR DESCRIPTION
SilverStripe 3.7 builds fail on PHP7.4 because we use a phpunit library that doesn't work with this PHP version.

We'll try to apply the same patch Sam did for SilverStripe 4.