### PR TITLE
BUGFIX: nullifyEmpty is immediately overridden

### DIFF
--- a/src/ORM/FieldType/DBString.php
+++ b/src/ORM/FieldType/DBString.php
@@ -26,8 +26,8 @@ abstract class DBString extends DBField
      */
     public function __construct($name = null, $options = [])
     {
-        $this->options['nullifyEmpty'] = true;
         parent::__construct($name, $options);
+        $this->options['nullifyEmpty'] = true;      
     }
 
     /**


### PR DESCRIPTION
## Steps to reproduce
* Enter a simple string into an `HTMLText` field (e.g. `ExtraMeta`)
* Save
* Observe error saying "NOTICE: undefined index nullifyEmpty"

This happens because the call to `parent::__construct($name, $options)` immediately overrides the forced setting of `nullifyEmpty` via `setOptions()` in the parent.