### PR TITLE
Add onBeforeRenderHolder extension point for FormField

### DIFF
--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -1036,6 +1036,8 @@ class FormField extends RequestHandler
     {
         $context = $this;
 
+        $this->extend('onBeforeRenderHolder', $context, $properties);
+
         if (count($properties)) {
             $context = $this->customise($properties);
         }


### PR DESCRIPTION
Adds an extra extension function that gets called just before a field is rendered in its FieldHolder.

Motivation:

```php
<?php

use SilverStripe\Core\Extension;
use SilverStripe\Forms\FormField;

class FormFieldExtension extends Extension
{
    public function onBeforeRenderHolder(FormField &$field, array &$properties)
    {
        if ($field->Required()) {
            $field->addExtraClass('required');
        }
    }
}
```

I tried using `onBeforeRender` but that extension gets called after the `FormField_holder` template is already rendered. I prefer to do this in an extension rather than overwriting all the `*_holder` templates.