### PR TITLE
FIX core memory limit test

### DIFF
--- a/tests/php/Core/MemoryLimitTest.php
+++ b/tests/php/Core/MemoryLimitTest.php
@@ -66,6 +66,7 @@ class MemoryLimitTest extends SapphireTest
 
         // No argument means unlimited (but only if originally allowed)
         if (is_numeric($this->origMemLimitMax) && $this->origMemLimitMax < 0) {
+            Environment::setMemoryLimitMax(-1);
             Environment::increaseMemoryLimitTo();
             $this->assertEquals(-1, ini_get('memory_limit'));
         }


### PR DESCRIPTION
The line 46 explicitly sets the max memory limit. The test only breaks when something heavy increases memory limit before this test (e.g. `assets/tests/php/Dev/Tasks/FileMigrationHelperTest.php`) so that if condition is true. By default this test never breaks in the framework tests on its own, but it breaks on recipes (e.g. recipe-core - https://travis-ci.org/silverstripe/recipe-core/jobs/555598815)