### PR TITLE
Added support for SubResource Integrity and Cross Origin attribute

### DIFF
--- a/src/View/Requirements.php
+++ b/src/View/Requirements.php
@@ -194,10 +194,13 @@ class Requirements implements Flushable
      * @param string $file  The CSS file to load, relative to site root
      * @param string $media Comma-separated list of media types to use in the link tag
      *                      (e.g. 'screen,projector')
+     * @param array $options List of options. Available options include:
+     * - 'integrity' : SubResource Integrity hash
+     * - 'crossorigin' : Cross-origin policy for the resource
      */
-    public static function css($file, $media = null)
+    public static function css($file, $media = null, $options = [])
     {
-        self::backend()->css($file, $media);
+        self::backend()->css($file, $media, $options);
     }
 
     /**

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -631,13 +631,21 @@ class Requirements_Backend
      * @param string $file The CSS file to load, relative to site root
      * @param string $media Comma-separated list of media types to use in the link tag
      *                      (e.g. 'screen,projector')
+     * @param array $options List of options. Available options include:
+     * - 'integrity' : SubResource Integrity hash
+     * - 'crossorigin' : Cross-origin policy for the resource
      */
-    public function css($file, $media = null)
+    public function css($file, $media = null, $options = [])
     {
         $file = ModuleResourceLoader::singleton()->resolvePath($file);
 
+        $integrity = isset($options['integrity']) ? $options['integrity'] : null;
+        $crossorigin = isset($options['crossorigin']) ? $options['crossorigin'] : null;
+
         $this->css[$file] = [
-            "media" => $media
+            "media" => $media,
+            "integrity" => $integrity,
+            "crossorigin" => $crossorigin,
         ];
     }
 
@@ -837,6 +845,12 @@ class Requirements_Backend
             ];
             if (!empty($params['media'])) {
                 $htmlAttributes['media'] = $params['media'];
+            }
+            if (!empty($params['integrity'])) {
+                $htmlAttributes['integrity'] = $params['integrity'];
+            }
+            if (!empty($params['crossorigin'])) {
+                $htmlAttributes['crossorigin'] = $params['crossorigin'];
             }
             $requirements .= HTML::createTag('link', $htmlAttributes);
             $requirements .= "\n";
@@ -1136,7 +1150,7 @@ class Requirements_Backend
             }
             switch ($type) {
                 case 'css':
-                    $this->css($path, (isset($options['media']) ? $options['media'] : null));
+                    $this->css($path, (isset($options['media']) ? $options['media'] : null), $options);
                     break;
                 case 'js':
                     $this->javascript($path, $options);
@@ -1283,7 +1297,11 @@ class Requirements_Backend
                         if (!in_array($css, $fileList)) {
                             $newCSS[$css] = $spec;
                         } elseif (!$included && $combinedURL) {
-                            $newCSS[$combinedURL] = array('media' => (isset($options['media']) ? $options['media'] : null));
+                            $newCSS[$combinedURL] = array(
+                                'media' => (isset($options['media']) ? $options['media'] : null),
+                                'integrity' => (isset($options['integrity']) ? $options['integrity'] : null),
+                                'crossorigin' => (isset($options['crossorigin']) ? $options['crossorigin'] : null),
+                            );
                             $included = true;
                         }
                         // If already included, or otherwise blocked, then don't add into CSS


### PR DESCRIPTION
Added support for SubResource Integrity and Cross Origin attribute in Requirements::css.

Requirements::css($file, $media = null, $options = []);

$options = [
    'integrity' => 'the_generated_resource_hash',
    'crossorigin' => 'cross_origin_policy_for_the_resource'
];
