### PR TITLE
#9114 - DBText::ContextSummary() cuts line breaks

### DIFF
--- a/src/ORM/FieldType/DBText.php
+++ b/src/ORM/FieldType/DBText.php
@@ -194,7 +194,7 @@ class DBText extends DBString
         }
 
         // Get raw text value, but XML encode it (as we'll be merging with HTML tags soon)
-        $text = nl2br(Convert::raw2xml($this->Plain()));
+        $text = Convert::raw2xml($this->Plain());
         $keywords = Convert::raw2xml($keywords);
 
         // Find the search string
@@ -239,7 +239,7 @@ class DBText extends DBString
             $summary = $summary . $suffix;
         }
 
-        return $summary;
+        return nl2br($summary);
     }
 
     public function scaffoldFormField($title = null, $params = null)

--- a/tests/php/ORM/DBHTMLTextTest.php
+++ b/tests/php/ORM/DBHTMLTextTest.php
@@ -333,6 +333,22 @@ class DBHTMLTextTest extends SapphireTest
                 'ate',
                 // it should highlight 3 letters or more.
                 'A dog <mark>ate</mark> a cat while looking at a Foobar',
+            ],
+            [
+                '<p>This is a lot of text before this but really, this is a test sentence</p>
+                 <p>with about more stuff after the line break</p>',
+                35,
+                'test',
+                '... really, this is a <mark>test</mark> sentence...'
+            ],
+            [
+                '<p>This is a lot of text before this but really, this is a test sentence</p>
+                 <p>with about more stuff after the line break</p>',
+                50,
+                'with',
+                '... sentence<br />
+<br />
+                 <mark>with</mark> about more stuff...'
             ]
         ];
     }


### PR DESCRIPTION
ContextSummary() was cutting the HTML which was added by nl2br because
it expected plain text elements as it's stripping and replacing text.
Instead this fix changes the behaviour to apply the nl2br after the text
changes have been made. That way we can't cut anything in the middle of
a HTML tag, but new lines, or paragraphs are replaced by BRs after,
should they exist.

See #9114 - DBText::ContextSummary() cuts line breaks

- Added tests to ensure text is not cut in the middle of a sentence.
- Added test to ensure that <br>'s are added in the correct place should
the summary span between new lines.

