### PR TITLE
Added SRI support for Requirements::css, Requirements::javascript

### DIFF
--- a/src/View/Requirements.php
+++ b/src/View/Requirements.php
@@ -194,10 +194,13 @@ class Requirements implements Flushable
      * @param string $file  The CSS file to load, relative to site root
      * @param string $media Comma-separated list of media types to use in the link tag
      *                      (e.g. 'screen,projector')
+     * @param array $options List of options. Available options include:
+     * - 'integrity' : SubResource Integrity hash
+     * - 'crossorigin' : Cross-origin policy for the resource
      */
-    public static function css($file, $media = null)
+    public static function css($file, $media = null, $options = [])
     {
-        self::backend()->css($file, $media);
+        self::backend()->css($file, $media, $options);
     }
 
     /**

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -1313,7 +1313,7 @@ class Requirements_Backend
                             $newCSS[$combinedURL] = array(
                                 'media' => $options['media'] ?? null,
                                 'integrity' => $options['integrity'] ?? null,
-                                'crossorigin' => (isset($options['crossorigin']) ? $options['crossorigin'] : null),
+                                'crossorigin' => $options['crossorigin'] ?? null,
                             );
                             $included = true;
                         }

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -1312,7 +1312,7 @@ class Requirements_Backend
                         } elseif (!$included && $combinedURL) {
                             $newCSS[$combinedURL] = array(
                                 'media' => $options['media'] ?? null,
-                                'integrity' => (isset($options['integrity']) ? $options['integrity'] : null),
+                                'integrity' => $options['integrity'] ?? null,
                                 'crossorigin' => (isset($options['crossorigin']) ? $options['crossorigin'] : null),
                             );
                             $included = true;

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -647,7 +647,7 @@ class Requirements_Backend
         $file = ModuleResourceLoader::singleton()->resolvePath($file);
 
         $integrity = $options['integrity'] ?? null;
-        $crossorigin = isset($options['crossorigin']) ? $options['crossorigin'] : null;
+        $crossorigin = $options['crossorigin'] ?? null;
 
         $this->css[$file] = [
             "media" => $media,

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -646,7 +646,7 @@ class Requirements_Backend
     {
         $file = ModuleResourceLoader::singleton()->resolvePath($file);
 
-        $integrity = isset($options['integrity']) ? $options['integrity'] : null;
+        $integrity = $options['integrity'] ?? null;
         $crossorigin = isset($options['crossorigin']) ? $options['crossorigin'] : null;
 
         $this->css[$file] = [

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -400,6 +400,8 @@ class Requirements_Backend
      * - 'async' : Boolean value to set async attribute to script tag
      * - 'defer' : Boolean value to set defer attribute to script tag
      * - 'type' : Override script type= value.
+     * - 'integrity' : SubResource Integrity hash
+     * - 'crossorigin' : Cross-origin policy for the resource
      */
     public function javascript($file, $options = array())
     {
@@ -431,10 +433,15 @@ class Requirements_Backend
                 && $this->javascript[$file]['defer'] == true
             )
         );
+        $integrity = isset($options['integrity']) ? $options['integrity'] : null;
+        $crossorigin = isset($options['crossorigin']) ? $options['crossorigin'] : null;
+
         $this->javascript[$file] = array(
             'async' => $async,
             'defer' => $defer,
             'type' => $type,
+            'integrity' => $integrity,
+            'crossorigin' => $crossorigin,
         );
 
         // Record scripts included in this file
@@ -631,13 +638,21 @@ class Requirements_Backend
      * @param string $file The CSS file to load, relative to site root
      * @param string $media Comma-separated list of media types to use in the link tag
      *                      (e.g. 'screen,projector')
+     * @param array $options List of options. Available options include:
+     * - 'integrity' : SubResource Integrity hash
+     * - 'crossorigin' : Cross-origin policy for the resource
      */
-    public function css($file, $media = null)
+    public function css($file, $media = null, $options = [])
     {
         $file = ModuleResourceLoader::singleton()->resolvePath($file);
 
+        $integrity = isset($options['integrity']) ? $options['integrity'] : null;
+        $crossorigin = isset($options['crossorigin']) ? $options['crossorigin'] : null;
+
         $this->css[$file] = [
-            "media" => $media
+            "media" => $media,
+            "integrity" => $integrity,
+            "crossorigin" => $crossorigin,
         ];
     }
 
@@ -814,6 +829,12 @@ class Requirements_Backend
             if (!empty($attributes['defer'])) {
                 $htmlAttributes['defer'] = 'defer';
             }
+            if (!empty($attributes['integrity'])) {
+                $htmlAttributes['integrity'] = $attributes['integrity'];
+            }
+            if (!empty($attributes['crossorigin'])) {
+                $htmlAttributes['crossorigin'] = $attributes['crossorigin'];
+            }
             $jsRequirements .= HTML::createTag('script', $htmlAttributes);
             $jsRequirements .= "\n";
         }
@@ -837,6 +858,12 @@ class Requirements_Backend
             ];
             if (!empty($params['media'])) {
                 $htmlAttributes['media'] = $params['media'];
+            }
+            if (!empty($params['integrity'])) {
+                $htmlAttributes['integrity'] = $params['integrity'];
+            }
+            if (!empty($params['crossorigin'])) {
+                $htmlAttributes['crossorigin'] = $params['crossorigin'];
             }
             $requirements .= HTML::createTag('link', $htmlAttributes);
             $requirements .= "\n";
@@ -1136,7 +1163,7 @@ class Requirements_Backend
             }
             switch ($type) {
                 case 'css':
-                    $this->css($path, (isset($options['media']) ? $options['media'] : null));
+                    $this->css($path, (isset($options['media']) ? $options['media'] : null), $options);
                     break;
                 case 'js':
                     $this->javascript($path, $options);
@@ -1283,7 +1310,11 @@ class Requirements_Backend
                         if (!in_array($css, $fileList)) {
                             $newCSS[$css] = $spec;
                         } elseif (!$included && $combinedURL) {
-                            $newCSS[$combinedURL] = array('media' => (isset($options['media']) ? $options['media'] : null));
+                            $newCSS[$combinedURL] = array(
+                                'media' => (isset($options['media']) ? $options['media'] : null),
+                                'integrity' => (isset($options['integrity']) ? $options['integrity'] : null),
+                                'crossorigin' => (isset($options['crossorigin']) ? $options['crossorigin'] : null),
+                            );
                             $included = true;
                         }
                         // If already included, or otherwise blocked, then don't add into CSS

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -433,7 +433,7 @@ class Requirements_Backend
                 && $this->javascript[$file]['defer'] == true
             )
         );
-        $integrity = isset($options['integrity']) ? $options['integrity'] : null;
+        $integrity = $options['integrity'] ?? null;
         $crossorigin = isset($options['crossorigin']) ? $options['crossorigin'] : null;
 
         $this->javascript[$file] = array(

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -434,7 +434,7 @@ class Requirements_Backend
             )
         );
         $integrity = $options['integrity'] ?? null;
-        $crossorigin = isset($options['crossorigin']) ? $options['crossorigin'] : null;
+        $crossorigin = $options['crossorigin'] ?? null;
 
         $this->javascript[$file] = array(
             'async' => $async,

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -1311,7 +1311,7 @@ class Requirements_Backend
                             $newCSS[$css] = $spec;
                         } elseif (!$included && $combinedURL) {
                             $newCSS[$combinedURL] = array(
-                                'media' => (isset($options['media']) ? $options['media'] : null),
+                                'media' => $options['media'] ?? null,
                                 'integrity' => (isset($options['integrity']) ? $options['integrity'] : null),
                                 'crossorigin' => (isset($options['crossorigin']) ? $options['crossorigin'] : null),
                             );

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -1183,4 +1183,29 @@ EOS
         $this->assertArrayHasKey('i18n/en-us.js', $actual);
         $this->assertArrayHasKey('i18n/fr.js', $actual);
     }
+
+    public function testSriAttributes()
+    {
+        /** @var Requirements_Backend $backend */
+        $backend = Injector::inst()->create(Requirements_Backend::class);
+        $this->setupRequirements($backend);
+
+        $backend->javascript('javascript/RequirementsTest_a.js', ['integrity' => 'abc', 'crossorigin' => 'use-credentials']);
+        $backend->css('css/RequirementsTest_a.css', null, ['integrity' => 'def', 'crossorigin' => 'anonymous']);
+        $html = $backend->includeInHTML(self::$html_template);
+
+        /* Javascript has correct attributes */
+        $this->assertRegExp(
+            '#<script type="application/javascript" src=".*/javascript/RequirementsTest_a.js.*" integrity="abc" crossorigin="use-credentials"#',
+            $html,
+            'javascript has correct sri attributes'
+        );
+
+        /* CSS has correct attributes */
+        $this->assertRegExp(
+            '#<link .*href=".*/RequirementsTest_a\.css.*" integrity="def" crossorigin="anonymous"#',
+            $html,
+            'css has correct sri attributes'
+        );
+    }
 }


### PR DESCRIPTION
Added support for attributes "integrity" and "crossorigin" to Requirements::css(), Requirements::javascript()

Requirements::css($file, $media = null, $options = []);
Requirements::javascript($file, $options);
$options = [
    'integrity' => 'the_generated_resource_hash',
    'crossorigin' => 'cross_origin_policy_for_the_resource'
];

Reference previous pull request [https://github.com/silverstripe/silverstripe-framework/pull/9132](url)