### PR TITLE
BUGFIX: Fixed issue where multiple relationship sort order columns would be lost in favor of only the last relationship column in the sort order

### DIFF
--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -403,7 +403,7 @@ class DataQuery
                         // Find the first free "_SortColumnX" slot
                         // and assign it to $key
                         $i = 0;
-                        while (isset($orderby[$key = "\"_SortColumn$i\""])) {
+                        while (isset($newOrderby[$key = "\"_SortColumn$i\""]) || isset($orderby[$key = "\"_SortColumn$i\""])) {
                             ++$i;
                         }
 

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -24,6 +24,8 @@ class DataQueryTest extends SapphireTest
         DataQueryTest\ObjectE::class,
         DataQueryTest\ObjectF::class,
         DataQueryTest\ObjectG::class,
+        DataQueryTest\ObjectH::class,
+        DataQueryTest\ObjectI::class,
         SQLSelectTest\TestObject::class,
         SQLSelectTest\TestBase::class,
         SQLSelectTest\TestChild::class,
@@ -404,5 +406,26 @@ class DataQueryTest extends SapphireTest
         $this->assertNotNull($second);
         $this->assertEquals('Last', $second['Title']);
         $this->assertEmpty(array_shift($arrayResult));
+    }
+
+    /**
+     * Tests that sorting against multiple relationships is working
+     */
+    public function testMultipleRelationSort()
+    {
+        $query = new DataQuery(DataQueryTest\ObjectH::class);
+        $query->applyRelation('ManyTestEs');
+        $query->applyRelation('ManyTestIs');
+        $query->sort([
+            '"manytestes_DataQueryTest_E"."SortOrder"',
+            '"manytestis_DataQueryTest_I"."SortOrder"',
+            '"SortOrder"',
+        ]);
+
+        $titles = $query->column('Name');
+
+        $this->assertEquals('First', $titles[0]);
+        $this->assertEquals('Second', $titles[1]);
+        $this->assertEquals('Last', $titles[2]);
     }
 }

--- a/tests/php/ORM/DataQueryTest.yml
+++ b/tests/php/ORM/DataQueryTest.yml
@@ -8,3 +8,31 @@ SilverStripe\ORM\Tests\DataQueryTest\ObjectE:
   query3:
     Title: 'Second'
     SortOrder: 2
+
+SilverStripe\ORM\Tests\DataQueryTest\ObjectI:
+  query1:
+    Title: 'First'
+    SortOrder: 1
+  query2:
+    Title: 'Second'
+    SortOrder: 2
+  query3:
+    Title: 'Last'
+    SortOrder: 3
+
+SilverStripe\ORM\Tests\DataQueryTest\ObjectH:
+  query1:
+    Name: 'First'
+    SortOrder: 3
+    ManyTestEs: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectE.query2
+    ManyTestIs: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectI.query2
+  query2:
+    Name: 'Last'
+    SortOrder: 1
+    ManyTestEs: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectE.query1
+    ManyTestIs: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectI.query1
+  query3:
+    Name: 'Second'
+    SortOrder: 2
+    ManyTestEs: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectE.query2
+    ManyTestIs: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectI.query3

--- a/tests/php/ORM/DataQueryTest/ObjectH.php
+++ b/tests/php/ORM/DataQueryTest/ObjectH.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataQueryTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class ObjectH extends DataObject implements TestOnly
+{
+    private static $table_name = 'DataQueryTest_H';
+
+    private static $db = array(
+        'Name' => 'Varchar',
+        'SortOrder' => 'Int',
+    );
+
+    private static $many_many = array(
+        'ManyTestEs' => ObjectE::class,
+        'ManyTestIs' => ObjectI::class,
+    );
+}

--- a/tests/php/ORM/DataQueryTest/ObjectI.php
+++ b/tests/php/ORM/DataQueryTest/ObjectI.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataQueryTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class ObjectI extends DataObject implements TestOnly
+{
+    private static $table_name = 'DataQueryTest_I';
+
+    private static $db = array(
+        'Name' => 'Varchar',
+        'SortOrder' => 'Int',
+    );
+}


### PR DESCRIPTION
Per #9145 this pull request fixes an issue where multiple relationship sort order columns would be lost in favor of only the last relationship column in the sort order.