### PR TITLE
NEW HTTPRequest now has hasSession() to determine whether a session exists for it

### DIFF
--- a/src/Control/HTTPRequest.php
+++ b/src/Control/HTTPRequest.php
@@ -883,11 +883,21 @@ class HTTPRequest implements ArrayAccess
     }
 
     /**
+     * Determines whether the request has a session
+     *
+     * @return bool
+     */
+    public function hasSession(): bool
+    {
+        return !empty($this->session);
+    }
+
+    /**
      * @return Session
      */
     public function getSession()
     {
-        if (empty($this->session)) {
+        if (!$this->hasSession()) {
             throw new BadMethodCallException("No session available for this HTTPRequest");
         }
         return $this->session;

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Security;
 
-use BadMethodCallException;
 use LogicException;
 use Page;
 use ReflectionClass;
@@ -417,17 +416,15 @@ class Security extends Controller implements TemplateGlobalProvider
             $controller->extend('permissionDenied', $member);
 
             return $response;
-        } else {
-            $message = $messageSet['default'];
         }
+        $message = $messageSet['default'];
 
-        try {
+        $request = $controller->getRequest();
+        if ($request->hasSession()) {
             list($messageText, $messageCast) = $parseMessage($message);
             static::singleton()->setSessionMessage($messageText, ValidationResult::TYPE_WARNING, $messageCast);
 
-            $controller->getRequest()->getSession()->set("BackURL", $_SERVER['REQUEST_URI']);
-        } catch (BadMethodCallException $ex) {
-            // noop, if session was not set yet
+            $request->getSession()->set("BackURL", $_SERVER['REQUEST_URI']);
         }
 
         // TODO AccessLogEntry needs an extension to handle permission denied errors

--- a/tests/php/Control/HTTPRequestTest.php
+++ b/tests/php/Control/HTTPRequestTest.php
@@ -2,10 +2,11 @@
 
 namespace SilverStripe\Control\Tests;
 
-use SilverStripe\Control\Middleware\TrustedProxyMiddleware;
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Control\HTTPRequest;
 use ReflectionMethod;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Middleware\TrustedProxyMiddleware;
+use SilverStripe\Control\Session;
+use SilverStripe\Dev\SapphireTest;
 
 class HTTPRequestTest extends SapphireTest
 {
@@ -285,5 +286,14 @@ class HTTPRequestTest extends SapphireTest
         foreach ($headers as $header => $ip) {
             $this->assertEquals($ip, $reflectionMethod->invoke($req, $header));
         }
+    }
+
+    public function testHasSession()
+    {
+        $request = new HTTPRequest('GET', '/');
+        $this->assertFalse($request->hasSession());
+
+        $request->setSession($this->createMock(Session::class));
+        $this->assertTrue($request->hasSession());
     }
 }


### PR DESCRIPTION
Follow up from https://github.com/silverstripe/silverstripe-framework/pull/9152

The getter throws an exception if there is no session. This method allows you to check for this without a try/catch.

Resolves https://github.com/silverstripe/silverstripe-framework/issues/9117