### PR TITLE
ENH / Covering database collation with tests

### DIFF
--- a/tests/php/ORM/MySQLPDOConnectorTest.php
+++ b/tests/php/ORM/MySQLPDOConnectorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace SilverStripe\ORM\Tests;
+
+use PDO;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\ORM\Connect\MySQLDatabase;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\Tests\MySQLPDOConnectorTest\PDOConnector;
+use SilverStripe\ORM\DB;
+
+
+/**
+ * @requires extension PDO
+ * @requires extension pdo_mysql
+ */
+class MySQLPDOConnectorTest extends SapphireTest implements TestOnly
+{
+    /**
+     * @dataProvider charsetProvider
+     */
+    public function testConnectionCharsetControl($charset, $defaultCollation)
+    {
+        $config = DB::getConfig();
+        $config['driver'] = 'mysql';
+        $config['charset'] = $charset;
+        Config::inst()->set(MySQLDatabase::class, 'connection_collation', $defaultCollation);
+
+        $connector = new PDOConnector();
+        $connector->connect($config);
+        $connection = $connector->getPDOConnection();
+
+        $cset = $connection->query('show variables like "character_set_connection"')->fetch(PDO::FETCH_NUM)[1];
+        $collation = $connection->query('show variables like "collation_connection"')->fetch(PDO::FETCH_NUM)[1];
+
+        $this->assertEquals($charset, $cset);
+        $this->assertEquals($defaultCollation, $collation);
+
+        unset($cset, $connection, $connector, $config);
+    }
+
+    /**
+     * @depends testConnectionCharsetControl
+     * @dataProvider charsetProvider
+     */
+    public function testConnectionCollationControl($charset, $defaultCollation, $customCollation)
+    {
+        $config = DB::getConfig();
+        $config['charset'] = $charset;
+        $config['driver'] = 'mysql';
+        Config::inst()->set(MySQLDatabase::class, 'connection_collation', $customCollation);
+
+        $connector = new PDOConnector();
+        $connector->connect($config);
+        $connection = $connector->getPDOConnection();
+
+        $cset = $connection->query('show variables like "character_set_connection"')->fetch(PDO::FETCH_NUM)[1];
+        $collation = $connection->query('show variables like "collation_connection"')->fetch(PDO::FETCH_NUM)[1];
+
+        $this->assertEquals($charset, $cset);
+        $this->assertEquals($customCollation, $collation);
+
+        unset($cset, $connection, $connector, $config);
+    }
+
+    public function charsetProvider()
+    {
+        return [
+            ['ascii', 'ascii_general_ci', 'ascii_bin'],
+            ['utf8', 'utf8_general_ci', 'utf8_unicode_520_ci'],
+            ['utf8mb4', 'utf8mb4_general_ci', 'utf8mb4_unicode_520_ci']
+        ];
+    }
+}

--- a/tests/php/ORM/MySQLPDOConnectorTest/PDOConnector.php
+++ b/tests/php/ORM/MySQLPDOConnectorTest/PDOConnector.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\MySQLPDOConnectorTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\Connect\PDOConnector as OriginalPDOConnector;
+use PDO;
+
+class PDOConnector extends OriginalPDOConnector implements TestOnly
+{
+    public function getPDOConnection(): PDO
+    {
+        return $this->pdoConnection;
+    }
+}

--- a/tests/php/ORM/MySQLiConnectorTest.php
+++ b/tests/php/ORM/MySQLiConnectorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SilverStripe\ORM\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\Tests\MySQLiConnectorTest\MySQLiConnector;
+use SilverStripe\ORM\DB;
+
+
+/**
+ * @requires extension mysqli
+ */
+class MySQLiConnectorTest extends SapphireTest implements TestOnly
+{
+    /**
+     * @dataProvider charsetProvider
+     */
+    public function testConnectionCharsetControl($charset, $defaultCollation)
+    {
+        $config = DB::getConfig();
+        $config['charset'] = $charset;
+
+        $connector = new MySQLiConnector();
+        $connector->connect($config);
+        $connection = $connector->getMysqliConnection();
+
+        $cset = $connection->get_charset();
+
+        $this->assertEquals($charset, $cset->charset);
+        $this->assertEquals($defaultCollation, $cset->collation);
+
+        unset($cset, $connection, $connector, $config);
+    }
+
+    /**
+     * @depends testConnectionCharsetControl
+     * @dataProvider charsetProvider
+     */
+    public function testConnectionCollationControl($charset, $defaultCollation, $customCollation)
+    {
+        $config = DB::getConfig();
+        $config['charset'] = $charset;
+        $config['collation'] = $customCollation;
+
+        $connector = new MySQLiConnector();
+        $connector->connect($config);
+        $connection = $connector->getMysqliConnection();
+
+        $cset = $connection->get_charset();
+
+        $this->assertEquals($charset, $cset->charset);
+        $this->assertEquals($customCollation, $cset->collation);
+
+        $connection->close();
+        unset($cset, $connection, $connector, $config);
+    }
+
+    public function charsetProvider()
+    {
+        return [
+            ['ascii', 'ascii_general_ci', 'ascii_bin'],
+            ['utf8', 'utf8_general_ci', 'utf8_unicode_520_ci'],
+            ['utf8mb4', 'utf8mb4_general_ci', 'utf8mb4_unicode_520_ci']
+        ];
+    }
+}

--- a/tests/php/ORM/MySQLiConnectorTest/MySQLiConnector.php
+++ b/tests/php/ORM/MySQLiConnectorTest/MySQLiConnector.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\MySQLiConnectorTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\Connect\MySQLiConnector as OriginalMySQLiConnector;
+use mysqli;
+
+class MySQLiConnector extends OriginalMySQLiConnector implements TestOnly
+{
+    public function getMysqliConnection(): mysqli
+    {
+        return $this->dbConn;
+    }
+}


### PR DESCRIPTION
Proofing tests for #9160 

It looks like our `MySQLiConnector` doesn't support connection collation switching.
