### PR TITLE
FIX currentPage should always be set

### DIFF
--- a/src/Forms/GridField/GridFieldPaginator.php
+++ b/src/Forms/GridField/GridFieldPaginator.php
@@ -128,6 +128,10 @@ class GridFieldPaginator implements GridField_HTMLProvider, GridField_DataManipu
         }
         $state = $this->getGridPagerState($gridField);
         $state->currentPage = (int)$arguments;
+
+        if ($state->currentPage < 1) {
+            $state->currentPage = 1;
+        }
     }
 
     protected $totalItems = 0;


### PR DESCRIPTION
In a project when using recursive nested GridFields (3+ deep) the `currentPage` value is incorrectly set to 0 (not sure of the root cause). The page fails to load due to `($state->currentPage - 1)` returning -1. -1  triggers errors throughout due to SQLSelect::setLimit() not accepting negative values.