### PR TITLE
FIX enable TinyMCE anchor plugin

### DIFF
--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -282,6 +282,7 @@ class TinyMCEConfig extends HTMLEditorConfig
         'code' => null,
         'importcss' => null,
         'lists' => null,
+        'anchor' => null,
     );
 
     /**
@@ -329,7 +330,7 @@ class TinyMCEConfig extends HTMLEditorConfig
         2 => [
             'formatselect', '|',
             'paste', 'pastetext', '|',
-            'table', 'sslink', 'unlink', '|',
+            'table', 'anchor', 'sslink', 'unlink', '|',
             'code'
         ],
         3 => []

--- a/tests/php/Forms/HTMLEditor/HTMLEditorConfigTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorConfigTest.php
@@ -58,7 +58,7 @@ class HTMLEditorConfigTest extends SapphireTest
         $c = new TinyMCEConfig();
         $c->setTheme('modern');
         $c->setOption('language', 'es');
-        $c->disablePlugins('table', 'emoticons', 'paste', 'code', 'link', 'importcss', 'lists');
+        $c->disablePlugins(array_keys($c->getPlugins()));
         $c->enablePlugins(
             array(
                 'plugin1' => 'mypath/plugin1.js',
@@ -140,7 +140,7 @@ class HTMLEditorConfigTest extends SapphireTest
         $this->assertNotContains('plugin1', array_keys($plugins));
         $this->assertNotContains('plugin2', array_keys($plugins));
     }
-    
+
     public function testRequireJSIncludesAllConfigs()
     {
         $a = HTMLEditorConfig::get('configA');


### PR DESCRIPTION
The sslink anchor module (which is enabled by default) allows an editor to insert links to named anchor elements contained in text on other pages in SilverStripe CMS. However there was no way to add an anchor besides the complicated task of directly editing HTML via TinyMCE's plugin for that. This was existing functionality in SilverStripe 3, but seems to have been lost with 4.0.0 onwards.

Partially addresses https://github.com/silverstripe/silverstripe-cms/issues/2268

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
