### PR TITLE
FIX Member::changePassword() no longer applies password validation rules to the hashed value

### DIFF
--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -279,7 +279,7 @@ class MemberTest extends FunctionalTest
     {
         /**
          * @var Member $member
-        */
+         */
         $member = $this->objFromFixture(Member::class, 'test');
         $this->assertNotNull($member);
 
@@ -1570,5 +1570,19 @@ class MemberTest extends FunctionalTest
         $newMember->write();
 
         $this->assertSame('en_US', $newMember->Locale, 'New members receive the default locale');
+    }
+
+    public function testChangePasswordHashesPasswordsOnce()
+    {
+        // This validator requires passwords to be 17 characters long
+        Member::set_password_validator(new MemberTest\VerySpecificPasswordValidator());
+
+        // This algorithm will never return a 17 character hash
+        Security::config()->set('password_encryption_algorithm', 'blowfish');
+
+        /** @var Member $member */
+        $member = $this->objFromFixture(Member::class, 'test');
+        $result = $member->changePassword('Password123456789'); // 17 characters long
+        $this->assertTrue($result->isValid());
     }
 }

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -1572,7 +1572,7 @@ class MemberTest extends FunctionalTest
         $this->assertSame('en_US', $newMember->Locale, 'New members receive the default locale');
     }
 
-    public function testChangePasswordHashesPasswordsOnce()
+    public function testChangePasswordOnlyValidatesPlaintext()
     {
         // This validator requires passwords to be 17 characters long
         Member::set_password_validator(new MemberTest\VerySpecificPasswordValidator());

--- a/tests/php/Security/MemberTest/TestPasswordValidator.php
+++ b/tests/php/Security/MemberTest/TestPasswordValidator.php
@@ -2,9 +2,10 @@
 
 namespace SilverStripe\Security\Tests\MemberTest;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\Security\PasswordValidator;
 
-class TestPasswordValidator extends PasswordValidator
+class TestPasswordValidator extends PasswordValidator implements TestOnly
 {
     public function __construct()
     {

--- a/tests/php/Security/MemberTest/VerySpecificPasswordValidator.php
+++ b/tests/php/Security/MemberTest/VerySpecificPasswordValidator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\Security\Tests\MemberTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\ValidationResult;
+use SilverStripe\Security\PasswordValidator;
+
+class VerySpecificPasswordValidator extends PasswordValidator implements TestOnly
+{
+    public function validate($password, $member)
+    {
+        $result = ValidationResult::create();
+        if (strlen($password) !== 17) {
+            $result->addError('Password must be 17 characters long');
+        }
+        return $result;
+    }
+}


### PR DESCRIPTION
Existing 4.x release lines validate the password you provide to `Member::changePassword()`, hash it, then write it. When you write it, the `onBeforeWrite()` call validates the password again - at this point, it's a hash, so the password validation rules are enforced on the hash. This hasn't been a problem with default settings, because blowfish produces hashes that contain a complex variety of character types and length.

The problem can be shown by the unit test, which has a fake validator that enforces a password being 17 characters long. Because the hash of the password is not 17 characters long, the test fails. The changes in this pull request make `changePassword()` call validate and write if needed, but leave hashing to the `onBeforeWrite()` method instead so it doesn't get done before the second validation call is performed.

This bug can be seen if you use [PBKDF2](https://github.com/silverstripe/cwp-core/pull/69) as your hashing algorithm, in that you can set user passwords from the CMS interfaces (which set the Password field directly), but you cannot change your password via the login system since that uses `Member::changePassword()`.