### PR TITLE
FIX Member argument is now passed to LeftAndMain::alternateAccessCheck()

### DIFF
--- a/admin/code/LeftAndMain.php
+++ b/admin/code/LeftAndMain.php
@@ -193,9 +193,11 @@ class LeftAndMain extends Controller implements PermissionProvider {
 		if(!$member) return false;
 
 		// alternative extended checks
-		if($this->hasMethod('alternateAccessCheck')) {
-			$alternateAllowed = $this->alternateAccessCheck();
-			if($alternateAllowed === FALSE) return false;
+		if ($this->hasMethod('alternateAccessCheck')) {
+			$alternateAllowed = $this->alternateAccessCheck($member);
+			if ($alternateAllowed === false) {
+				return false;
+			}
 		}
 
 		// Check for "CMS admin" permission


### PR DESCRIPTION
This is required for MFA to work in SilverStripe 3.7. Since it delays the setting of `Member::currentUser()`, we need the `$member` argument to be passed in order for `LeftAndMainSubsites::canAccess()` to correctly determine the current user for its permission checking.

This method is only used in CWP 1.9 in the subsites module, so has a low risk of regression.

This has already been implemented in SilverStripe 4 with https://github.com/silverstripe/silverstripe-admin/commit/ded64ba530da1540ac4f3eb4329b0a95eab4360b