### PR TITLE
DOC Explain how to mgirate SS3.2 variants

### DIFF
--- a/docs/en/02_Developer_Guides/14_Files/05_File_Migration.md
+++ b/docs/en/02_Developer_Guides/14_Files/05_File_Migration.md
@@ -176,7 +176,19 @@ After running the file migration, you can run the short code migration task to u
 sake dev/tasks/TagsToShortcode
 ``` 
 
-This will rewrite your existing shortcodes to the newer format SilverStripe 4 expects as well as convert `img` and `a` tags to use shortcodes..
+This will rewrite your existing shortcodes to the newer format SilverStripe 4 expects as well as convert `img` and `a` tags to use shortcodes.
+
+### Migrating from SilverStripe 3.2 (or below) to SilverStripe 4.4
+
+The format for image variants was changed in SilverStripe 3.3. In SilverStripe 3.2 and below variants would be included in the file name with a dash:
+* `Uploads/_resampled/FitWzQwLDMwXQ-image.jpg` in SilverStripe 3.2 and below
+* `Uploads/_resampled/FitWzQwLDMwXQ/image.jpg` in SilverStripe 3.3 and above.
+
+The file migration task didn't account for this nuance until the SilverStripe 4.4.4 release. If you ran the file migration task using a prior version, your SilverStripe 3.2 thumbnails might not have been migrated ... or their path might have been appended as variants. e.g.: `FitWzQwLDMwXQ-image__Uploads__resampled.jpg`
+
+Those variants will need to be regenarated. Thumbnails generated through templates or code will automatically be regenerated on the next uncached request to SilverStripe. Thumbnails embedded in HTML fields will be regenerated when the page is republished. Variants that got improperly renamed can be removed manually.
+
+If you are running SilverStripe 4.4.4 or greater, SilverStripe 3.2 variants will be migrated normally.
 
 ## Migrating from SilverStripe 4.3 or below to SilverStripe 4.4 or above
 

--- a/docs/en/02_Developer_Guides/14_Files/05_File_Migration.md
+++ b/docs/en/02_Developer_Guides/14_Files/05_File_Migration.md
@@ -182,11 +182,11 @@ This will rewrite your existing shortcodes to the newer format SilverStripe 4 ex
 
 The format for image variants was changed in SilverStripe 3.3. In SilverStripe 3.2 and below variants would be included in the file name with a dash:
 * `Uploads/_resampled/FitWzQwLDMwXQ-image.jpg` in SilverStripe 3.2 and below
-* `Uploads/_resampled/FitWzQwLDMwXQ/image.jpg` in SilverStripe 3.3 and above.
+* `Uploads/_resampled/FitWzQwLDMwXQ/image.jpg` in SilverStripe 3.3 and above
 
 The file migration task didn't account for this nuance until the SilverStripe 4.4.4 release. If you ran the file migration task using a prior version, your SilverStripe 3.2 thumbnails might not have been migrated, or their paths might have been appended as variants. e.g.: `FitWzQwLDMwXQ-image__Uploads__resampled.jpg`
 
-Those variants will need to be regenarated. Thumbnails generated through templates or code will automatically be regenerated on the next uncached request to SilverStripe. Thumbnails embedded in HTML fields will be regenerated when the page is republished. Variants that were improperly renamed must be removed manually.
+Those variants will need to be regenerated. Thumbnails generated through templates or code will automatically be regenerated on the next uncached request to SilverStripe. Thumbnails embedded in HTML fields will be regenerated when the page is republished. Variants that were improperly renamed must be removed manually.
 
 If you are running SilverStripe 4.4.4 or greater, SilverStripe 3.2 variants will be migrated normally.
 

--- a/docs/en/02_Developer_Guides/14_Files/05_File_Migration.md
+++ b/docs/en/02_Developer_Guides/14_Files/05_File_Migration.md
@@ -184,9 +184,9 @@ The format for image variants was changed in SilverStripe 3.3. In SilverStripe 3
 * `Uploads/_resampled/FitWzQwLDMwXQ-image.jpg` in SilverStripe 3.2 and below
 * `Uploads/_resampled/FitWzQwLDMwXQ/image.jpg` in SilverStripe 3.3 and above.
 
-The file migration task didn't account for this nuance until the SilverStripe 4.4.4 release. If you ran the file migration task using a prior version, your SilverStripe 3.2 thumbnails might not have been migrated ... or their path might have been appended as variants. e.g.: `FitWzQwLDMwXQ-image__Uploads__resampled.jpg`
+The file migration task didn't account for this nuance until the SilverStripe 4.4.4 release. If you ran the file migration task using a prior version, your SilverStripe 3.2 thumbnails might not have been migrated, or their paths might have been appended as variants. e.g.: `FitWzQwLDMwXQ-image__Uploads__resampled.jpg`
 
-Those variants will need to be regenarated. Thumbnails generated through templates or code will automatically be regenerated on the next uncached request to SilverStripe. Thumbnails embedded in HTML fields will be regenerated when the page is republished. Variants that got improperly renamed can be removed manually.
+Those variants will need to be regenarated. Thumbnails generated through templates or code will automatically be regenerated on the next uncached request to SilverStripe. Thumbnails embedded in HTML fields will be regenerated when the page is republished. Variants that were improperly renamed must be removed manually.
 
 If you are running SilverStripe 4.4.4 or greater, SilverStripe 3.2 variants will be migrated normally.
 


### PR DESCRIPTION
SilverStripe 4.4.4 will introduce a patch to better handle old SS3 variants. 

The main issue will be patched by https://github.com/silverstripe/silverstripe-assets/pull/314

# Parent
* https://github.com/silverstripe/silverstripe-assets/issues/313

