### PR TITLE
BUG Remove placeholder text on new group form

### DIFF
--- a/src/Security/Group.php
+++ b/src/Security/Group.php
@@ -83,15 +83,6 @@ class Group extends DataObject
 
     private static $table_name = "Group";
 
-    public function populateDefaults()
-    {
-        parent::populateDefaults();
-
-        if (!$this->Title) {
-            $this->Title = _t(__CLASS__ . '.NEWGROUP', "New Group");
-        }
-    }
-
     public function getAllChildren()
     {
         $doSet = new ArrayList();


### PR DESCRIPTION
The group creation form pre-populated the group name with "New Group". This is the only place I know off where we do this and it forces the user to remove our pre-populated label.
