### PR TITLE
FIX Byte Order Marks (BOM) are now stripped when importing CSV files

### DIFF
--- a/src/Dev/CsvBulkLoader.php
+++ b/src/Dev/CsvBulkLoader.php
@@ -76,6 +76,7 @@ class CsvBulkLoader extends BulkLoader
             $filepath = Director::getAbsFile($filepath);
             $csvReader = Reader::createFromPath($filepath, 'r');
             $csvReader->setDelimiter($this->delimiter);
+            $csvReader->stripBom(true);
 
             $tabExtractor = function ($row, $rowOffset, $iterator) {
                 foreach ($row as &$item) {

--- a/tests/php/Dev/CsvBulkLoaderTest.php
+++ b/tests/php/Dev/CsvBulkLoaderTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Dev\Tests;
 
+use League\Csv\Writer;
 use SilverStripe\Dev\Tests\CsvBulkLoaderTest\CustomLoader;
 use SilverStripe\Dev\Tests\CsvBulkLoaderTest\Player;
 use SilverStripe\Dev\Tests\CsvBulkLoaderTest\PlayerContract;
@@ -300,6 +301,20 @@ class CsvBulkLoaderTest extends SapphireTest
         $this->assertEquals($player->FirstName, "John. He's a good guy. ");
     }
 
+    public function testLoadWithByteOrderMark()
+    {
+        $loader = new CsvBulkLoader(Player::class);
+        $loader->load($this->csvPath . 'PlayersWithHeaderAndBOM.csv');
+
+        $players = Player::get();
+
+        $this->assertCount(3, $players);
+        $this->assertListContains([
+            ['FirstName' => 'Jamie', 'Birthday' => '1882-01-31'],
+            ['FirstName' => 'Järg', 'Birthday' => '1982-06-30'],
+            ['FirstName' => 'Jacob', 'Birthday' => '2000-04-30'],
+        ], $players);
+    }
 
     protected function getLineCount(&$file)
     {

--- a/tests/php/Dev/CsvBulkLoaderTest/csv/PlayersWithHeaderAndBOM.csv
+++ b/tests/php/Dev/CsvBulkLoaderTest/csv/PlayersWithHeaderAndBOM.csv
@@ -1,0 +1,4 @@
+﻿FirstName,Biography,Birthday,IsRegistered
+Jamie,"Pretty old\, with an escaped comma",1882-01-31,1
+Järg,"Unicode FTW",1982-06-30,1
+Jacob,"	Likes leading tabs in his biography",2000-04-30,0


### PR DESCRIPTION
We add a BOM when we export to CSV. This change now means that BOMs are stripped when importing a CSV as well.

Part of https://github.com/silverstripe/silverstripe-framework/issues/8884