### PR TITLE
Fixed problem with direct compare in SELECT statement

### DIFF
--- a/src/ORM/FieldType/DBForeignKey.php
+++ b/src/ORM/FieldType/DBForeignKey.php
@@ -96,7 +96,7 @@ class DBForeignKey extends DBInt
             // Remove distinct. Applying distinct shouldn't be required provided relations are not applied.
             $dataQuery->setDistinct(false);
 
-            $dataQuery->setSelect(['over_threshold' => 'count(*) > ' . (int) $threshold]);
+            $dataQuery->setSelect(['over_threshold' => '(CASE WHEN count(*) > ' . (int)$threshold . ' THEN 1 ELSE 0 END)']);
             $result = $dataQuery->execute()->column('over_threshold');
 
             // Checking for 't' supports PostgreSQL before silverstripe/postgresql@2.2


### PR DESCRIPTION
Due the nature of some database engines it is not possible to directly return result from expressions like "X > 10" (i.e. SQL Server), thus it is necessary to write expression with "CASE WHEN", and assign return values manually which is also compatible with MySQL or PostgreSQL.

Fixes #9218