### PR TITLE
Add getLastName() method to Member.php

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1123,6 +1123,12 @@ class Member extends DataObject
 
     //------------------- HELPER METHODS -----------------------------------//
 
+    /* a method to allow using $LastName as an alternative to $Surname in templates since it is a commonly made mistake */
+    
+    public function getLastName() {
+      return $this->Surname;
+    }
+    
     /**
      * Get the complete name of the member, by default in the format "<Surname>, <FirstName>".
      * Falls back to showing either field on its own.


### PR DESCRIPTION
Add getLastName() method to Silverstripe\Security\Member.php to allow use of $LastName instead of $Surname in templates as it is a common mistake made

this is for issue #9219 
as discussed in Slack on 04-Sep-2019

Fixes #9219 
