### PR TITLE
Add getLastName() method to Member.php

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1124,7 +1124,7 @@ class Member extends DataObject
     //------------------- HELPER METHODS -----------------------------------//
 
     /**
-     * Simple prxoy method to get the Surname property of the member
+     * Simple proxy method to get the Surname property of the member
      *
      * @return string
      */

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1124,9 +1124,10 @@ class Member extends DataObject
     //------------------- HELPER METHODS -----------------------------------//
 
     /**
-     * Get the Surname of the member
+     * Simple prxoy method to get the Surname property of the member
+     *
+     * @return string
      */
-    
     public function getLastName()
     {
         return $this->owner->Surname;

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1124,6 +1124,15 @@ class Member extends DataObject
     //------------------- HELPER METHODS -----------------------------------//
 
     /**
+     * Get the Surname of the member
+     */
+    
+    public function getLastName()
+    {
+        return $this->owner->Surname;
+    }
+    
+    /**
      * Get the complete name of the member, by default in the format "<Surname>, <FirstName>".
      * Falls back to showing either field on its own.
      *


### PR DESCRIPTION
Add getLastName() method to Silverstripe\Security\Member.php to allow use of $LastName instead of $Surname in templates as it is a common mistake made

this is for issue #9219
as discussed in Slack on 04-Sep-2019
