### PR TITLE
FIX Member::getLastName() now correctly returns the Member surname

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1130,9 +1130,9 @@ class Member extends DataObject
      */
     public function getLastName()
     {
-        return $this->owner->Surname;
+        return $this->Surname;
     }
-    
+
     /**
      * Get the complete name of the member, by default in the format "<Surname>, <FirstName>".
      * Falls back to showing either field on its own.

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -1585,4 +1585,12 @@ class MemberTest extends FunctionalTest
         $result = $member->changePassword('Password123456789'); // 17 characters long
         $this->assertTrue($result->isValid());
     }
+
+    public function testGetLastName()
+    {
+        $member = new Member();
+        $member->Surname = 'Johnson';
+
+        $this->assertSame('Johnson', $member->getLastName(), 'getLastName should proxy to Surname');
+    }
 }


### PR DESCRIPTION
Follow up fix from https://github.com/silverstripe/silverstripe-framework/pull/9222#pullrequestreview-285046311