### PR TITLE
Update secure coding standards

### DIFF
--- a/docs/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
+++ b/docs/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
@@ -697,9 +697,7 @@ following in your .htaccess to ensure this behaviour is activated.
 </IfModule>
 ```
 
-In a future release this behaviour will be changed to be on by default, and this environment
-variable will be no longer necessary, thus it will be necessary to always set
-`SS_TRUSTED_PROXY_IPS` if using a proxy.
+As of SilverStripe 4, this behaviour is on by default, and the environment variable is no longer required. For correct operation, it is necessary to always set `SS_TRUSTED_PROXY_IPS` if using a proxy.
 
 ## Secure Sessions, Cookies and TLS (HTTPS)
 


### PR DESCRIPTION
As of SS4.0.0 and the introduction of TrustedProxyMiddleware, the default now if no trusted proxies are defined is that nothing is a trusted proxy, whereas in SS3 a missing declaration was treated as everything being allowed.

Note: Sorry, it seems GitHub's online editor just opens a branch on the target repo if I have push access, which I didn't think that I had to the core repos, so it's created a branch on the core silverstripe-framework repo rather than my fork :(