### PR TITLE
Update sqlite3 dependency for Travis tests using SQLite to 2.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ before_script:
   - composer validate
   - mkdir ./public
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.2.x-dev --no-update; fi
-  - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --no-update; fi
+  - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.2.x-dev --no-update; fi
   - composer require silverstripe/recipe-testing:^1 silverstripe/recipe-core:4.4.x-dev silverstripe/admin:1.4.x-dev silverstripe/versioned:1.4.x-dev --no-update
   - if [[ $PHPUNIT_TEST == cms ]]; then composer require silverstripe/recipe-cms:4.4.x-dev --no-update; fi
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi


### PR DESCRIPTION
Without this update, running Travis tests fails with an error
```
Uncaught Error: Call to undefined method SilverStripe\Dev\SapphireTest::using_temp_db() in /home/travis/build/silverstripe/silverstripe-framework/sqlite3/code/SQLite3SchemaManager.php:218
```

With the update, there are currently two failing ORM tests (https://travis-ci.org/silverstripe/silverstripe-framework/builds/583898749), but the whole suit runs.