### PR TITLE
Update ReadOnlyTransaction test to correctly fail and use the rollback

### DIFF
--- a/tests/php/ORM/TransactionTest/ReadOnlyTestObject.php
+++ b/tests/php/ORM/TransactionTest/ReadOnlyTestObject.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\TransactionTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationResult;
+
+class ReadOnlyTestObject extends DataObject implements TestOnly
+{
+    private static $table_name = 'TransactionTest_ReadOnlyObject';
+
+    private static $db = array(
+        'Title' => 'Varchar(255)'
+    );
+
+    /**
+     * Workaround to force the object can't be written to a db
+     *
+     * @return bool|\SilverStripe\ORM\ValidationResult
+     */
+    public function validate()
+    {
+        $result = ValidationResult::create();
+        $result->addError('The DataObject is read-only.');
+
+        return $result;
+    }
+}


### PR DESCRIPTION
## Disclaimer

The test is deprecated since 4.3.0, but still left in the suit.

## Problem

Test failing for SQLite database.

I couldn't figure out why would the rollback event be triggered in the catch section of the try/catch block. So I introduced a read-only object to intentionally fail the write. With that mechanism, the rollback is triggered and the rest of the test works.

## Questions

- Is there a better way to enforce an object to be read-only (non-writable) that the test could leverage? One way is to return false from onBeforeWrite hook, but that would require an extension anyway. Open to suggestions.
- Should the test be removed completely?