### PR TITLE
Fix/remove buttons from tiny mce

### DIFF
--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -201,6 +201,13 @@ class TinyMCEConfig extends HTMLEditorConfig
      * @var array
      */
     private static $editor_css = [];
+    
+    /**
+     * List of unwanted buttons to be removed from TinyMCE. List to be loaded from YAML file.
+     *
+     * @var array
+     */
+    protected $unwantedButtons = null;
 
     /**
      * List of content css files to use for this instance, or null to default to editor_css config.
@@ -602,6 +609,8 @@ class TinyMCEConfig extends HTMLEditorConfig
      */
     protected function getConfig()
     {
+        $this->removeButtons(static::config()->get('unwantedButtons'));
+        
         $settings = $this->getSettings();
 
         // https://www.tinymce.com/docs/configure/url-handling/#document_base_url

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -207,7 +207,7 @@ class TinyMCEConfig extends HTMLEditorConfig
      *
      * @var array
      */
-    protected $unwantedButtons = null;
+    protected $unwantedButtons = [];
 
     /**
      * List of content css files to use for this instance, or null to default to editor_css config.


### PR DESCRIPTION
Provides a mechanism to fix https://github.com/silverstripe/silverstripe-framework/issues/6787.

A user can add a list of buttons to be removed from TinyMCE.

Eg :

SilverStripe\Forms\HTMLEditor\TinyMCEConfig:
  unwantedButtons:
    - 'underline'