### PR TITLE
Fix administrators not being able to see files that are restricted to groups

### DIFF
--- a/src/Security/InheritedPermissions.php
+++ b/src/Security/InheritedPermissions.php
@@ -357,21 +357,25 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
         $baseTable = DataObject::getSchema()->baseDataTable($this->getBaseClass());
 
         if ($member && $member->ID) {
-            // Determine if this member matches any of the group or other rules
-            $groupJoinTable = $this->getJoinTable($type);
-            $uninheritedPermissions = $stageRecords
-                ->where([
-                    "(\"$typeField\" IN (?, ?) OR " . "(\"$typeField\" = ? AND \"$groupJoinTable\".\"{$baseTable}ID\" IS NOT NULL))"
-                    => [
-                        self::ANYONE,
-                        self::LOGGED_IN_USERS,
-                        self::ONLY_THESE_USERS
-                    ]
-                ])
-                ->leftJoin(
-                    $groupJoinTable,
-                    "\"$groupJoinTable\".\"{$baseTable}ID\" = \"{$baseTable}\".\"ID\" AND " . "\"$groupJoinTable\".\"GroupID\" IN ($groupIDsSQLList)"
-                )->column('ID');
+            if (!Permission::checkMember($member, 'ADMIN')) {
+                // Determine if this member matches any of the group or other rules
+                $groupJoinTable = $this->getJoinTable($type);
+                $uninheritedPermissions = $stageRecords
+                    ->where([
+                        "(\"$typeField\" IN (?, ?) OR " . "(\"$typeField\" = ? AND \"$groupJoinTable\".\"{$baseTable}ID\" IS NOT NULL))"
+                        => [
+                            self::ANYONE,
+                            self::LOGGED_IN_USERS,
+                            self::ONLY_THESE_USERS
+                        ]
+                    ])
+                    ->leftJoin(
+                        $groupJoinTable,
+                        "\"$groupJoinTable\".\"{$baseTable}ID\" = \"{$baseTable}\".\"ID\" AND " . "\"$groupJoinTable\".\"GroupID\" IN ($groupIDsSQLList)"
+                    )->column('ID');
+            } else {
+                $uninheritedPermissions = $stageRecords->column('ID');
+            }
         } else {
             // Only view pages with ViewType = Anyone if not logged in
             $uninheritedPermissions = $stageRecords

--- a/tests/php/Security/InheritedPermissionsTest.php
+++ b/tests/php/Security/InheritedPermissionsTest.php
@@ -151,6 +151,8 @@ class InheritedPermissionsTest extends SapphireTest
         $protected = $this->objFromFixture(TestPermissionNode::class, 'protected');
         $protectedChild = $this->objFromFixture(TestPermissionNode::class, 'protected-child');
         $editor = $this->objFromFixture(Member::class, 'editor');
+        $restricted = $this->objFromFixture(TestPermissionNode::class, 'restricted-page');
+        $admin = $this->objFromFixture(Member::class, 'admin');
 
         // Not logged in user can only access Inherit or Anyone pages
         Member::actAs(
@@ -182,6 +184,9 @@ class InheritedPermissionsTest extends SapphireTest
         $this->rootPermissions->setCanView(false);
 
         $this->assertFalse($history->canView($editor));
+
+        // Ensure admins can view everything, even if only a certain group is allowed to view it
+        $this->assertTrue($restricted->canView($admin));
     }
 
     public function testUnstagedViewPermissions()

--- a/tests/php/Security/InheritedPermissionsTest.yml
+++ b/tests/php/Security/InheritedPermissionsTest.yml
@@ -100,6 +100,10 @@ SilverStripe\Security\Tests\InheritedPermissionsTest\TestPermissionNode:
     Title: Child
     CanViewType: Inherit
     Parent: =>SilverStripe\Security\Tests\InheritedPermissionsTest\TestPermissionNode.protected
+  restricted-page:
+    Title: Restricted Page
+    CanViewType: OnlyTheseUsers
+    ViewerGroups: =>SilverStripe\Security\Group.allsections
 
 SilverStripe\Security\Tests\InheritedPermissionsTest\UnstagedNode:
   about:
@@ -167,3 +171,7 @@ SilverStripe\Security\Tests\InheritedPermissionsTest\UnstagedNode:
     Title: Child
     CanViewType: Inherit
     Parent: =>SilverStripe\Security\Tests\InheritedPermissionsTest\UnstagedNode.protected
+  restricted-page:
+    Title: Restricted Page
+    CanViewType: OnlyTheseUsers
+    ViewerGroups: =>SilverStripe\Security\Group.allsections


### PR DESCRIPTION
Resolves https://github.com/silverstripe/silverstripe-asset-admin/issues/777