### PR TITLE
DOC Clarify that Security release is a SilverStripe Core release

### DIFF
--- a/docs/en/05_Contributing/04_Release_Process.md
+++ b/docs/en/05_Contributing/04_Release_Process.md
@@ -125,6 +125,8 @@ SS_DEPRECATION_ENABLED="0"
 
 ## Security Releases
 
+A security release is a [SilverStripe Core Release](making_a_silverstripe_core_release#standard-release-process) with patches for one or more security issues.
+
 ### Reporting an issue
 
 Report security issues in our [commercially supported modules](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/)
@@ -164,7 +166,7 @@ This rating determines which release lines are targetd with security fixes.
 
 ### Internal Security Process
 
-See [SilverStripe Core Release Process](making-a-silverstripe-core-release).
+See [SilverStripe Core Release Process](making_a_silverstripe_core_release).
 
 ### Pre-announcement mailing list
 

--- a/docs/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
+++ b/docs/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
@@ -144,7 +144,7 @@ is available, or within a reasonable period of time of such a release.
   containing security fixes. See below for setting up a temporary satis repository.
    * Once release testing is completed and the release is ready for stabilisation, then these fixes
   can then be pushed to the upstream module fork, and the release completed as per normal.
-   * Follow the steps for [making a core release](making-a-silverstripe-core-release)
+   * Follow the steps for [making a core release](making_a_silverstripe_core_release)
  
 ### After release
 


### PR DESCRIPTION
As such, performing a security release we'll have to perform a core release, issuing new versions for the core recipes.

/cc @silverstripe/core-team