### PR TITLE
FIX Add 'legal empty attributes' to allow empty alt values on imgs

### DIFF
--- a/src/View/HTML.php
+++ b/src/View/HTML.php
@@ -40,6 +40,16 @@ class HTML
     ];
 
     /**
+     * List of attributes that should be rendered even if they contain no value
+     *
+     * @config
+     * @var array
+     */
+    private static $legal_empty_attributes = [
+        'alt',
+    ];
+
+    /**
      * Construct and return HTML tag.
      *
      * @param string $tag
@@ -52,10 +62,13 @@ class HTML
         $tag = strtolower($tag);
 
         // Build list of arguments
+        $legalEmptyAttributes = static::config()->get('legal_empty_attributes');
         $preparedAttributes = '';
         foreach ($attributes as $attributeKey => $attributeValue) {
+            $whitelisted = in_array($attributeKey, $legalEmptyAttributes);
+
             // Only set non-empty strings (ensures strlen(0) > 0)
-            if (strlen($attributeValue) > 0) {
+            if (strlen($attributeValue) > 0 || $whitelisted) {
                 $preparedAttributes .= sprintf(
                     ' %s="%s"',
                     $attributeKey,

--- a/tests/php/View/HTMLTest.php
+++ b/tests/php/View/HTMLTest.php
@@ -45,6 +45,16 @@ class HTMLTest extends SapphireTest
         $this->assertEquals('<a title="HTML &amp; Text">Some <strong>content!</strong></a>', $tag);
     }
 
+    public function testImgTag()
+    {
+        $tag = HTML::createTag('img', [
+            'src' => 'example.png',
+            'alt' => '',
+        ]);
+
+        $this->assertEquals('<img src="example.png" alt="" />', $tag);
+    }
+
     public function testVoidContentError()
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
In some situations, a caption is used in place of a value in the alt attribute, and in others an image may be cosmetic and not in need of an alt attribute value (though the alt attribute must still be rendered in this case).

This PR adds configuration to 'whitelist' specific attributes that should be rendered whether they have a value or not, and includes `alt` in this list as a start.

I looked into removing the conditional entirely and having all empty attributes render, but unfortunately browsers treat the presence of some boolean attributes as indication they are 'true' (e.g. `disabled`, `autofocus`), even if they have an empty value applied to them (i.e. `disabled=""`).

Helps with [asset-admin#983](https://github.com/silverstripe/silverstripe-asset-admin/issues/983).
