### PR TITLE
DOC Add warning about Semver status of modern JS / GraphQL tooling

### DIFF
--- a/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/07_ReactJS_Redux_and_GraphQL.md
+++ b/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/07_ReactJS_Redux_and_GraphQL.md
@@ -15,6 +15,12 @@ There are some several members of this ecosystem that all work together to provi
 
 All of these pillars of the frontend application can be customised, giving you more control over how the admin interface looks, feels, and behaves.
 
+<div class="alert" markdown="1">
+These technologies underpin the future of SilverStripe CMS development, but their current implementation is
+_experimental_. Our APIs are not expected to change drastically between releases, but they are excluded from
+our Semver commitments for the time being. Any breaking changes will be clearly signalled in release notes.
+</div>
+
 First, a brief summary of what each of these are:
 
 ## React

--- a/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/07_ReactJS_Redux_and_GraphQL.md
+++ b/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/07_ReactJS_Redux_and_GraphQL.md
@@ -18,7 +18,8 @@ All of these pillars of the frontend application can be customised, giving you m
 <div class="alert" markdown="1">
 These technologies underpin the future of SilverStripe CMS development, but their current implementation is
 _experimental_. Our APIs are not expected to change drastically between releases, but they are excluded from
-our Semver commitments for the time being. Any breaking changes will be clearly signalled in release notes.
+our [semantic versioning](https://semver.org) commitments for the time being. Any breaking changes will be
+clearly signalled in release notes.
 </div>
 
 First, a brief summary of what each of these are:


### PR DESCRIPTION
We are still in the process of developing and battle-testing the React / Redux / GraphQL / Injector stack, but we haven't thus far explicitly excluded it from Semver coverage - and it's likely that for developers using these APIs, we've therefore _implicitly_ committed to it.

This notice, to be added to the related documentation, gives a solid declaration of our commitments:

- These tools are considered _experimental_, and may be subject to breaking changes in minor core releases.
- _However_, we don't expect breakages frequently, and we pledge to clearly document them in release notes if they occur.