### PR TITLE
drop random_compat dependency now PHP support is 7.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "m1/env": "^2.1",
         "monolog/monolog": "~1.11",
         "nikic/php-parser": "^2 || ^3 || ^4",
-        "paragonie/random_compat": "^2.0",
         "psr/container": "1.0.0",
         "psr/container-implementation": "1.0.0",
         "silverstripe/config": "^1@dev",


### PR DESCRIPTION
since 4.5+ is going to be PHP 7.1+(https://github.com/silverstripe/silverstripe-framework/commit/ac35344041e812e0ab842ee9f03961ac2abc4c5a#diff-a41a3b1a2c40df9bb3fff6ecf93d8f4d) random_compat should no longer be needed 