### PR TITLE
Clarify that $title in FormField can accept ViewableData

### DIFF
--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -331,7 +331,7 @@ class FormField extends RequestHandler
      * Creates a new field.
      *
      * @param string $name The internal field name, passed to forms.
-     * @param null|string $title The human-readable field label.
+     * @param null|string|SilverStripe\View\ViewableData $title The human-readable field label.
      * @param mixed $value The value of the field.
      */
     public function __construct($name, $title = null, $value = null)


### PR DESCRIPTION
When constructing a `FormField`, an IDE would previously tell you the `$title` needs to be a `string` (or null). Let's make it more clear that a `ViewableData` instance (such as `HTMLValue::create($title)`) is also accepted. This should help people more quickly find a solution to put html in labels.