### PR TITLE
FIX Check array keys existence when removing methods in CustomMethods

### DIFF
--- a/src/Core/CustomMethods.php
+++ b/src/Core/CustomMethods.php
@@ -282,10 +282,15 @@ trait CustomMethods
                 if (!isset(self::$extra_methods[$class][$method])) {
                     continue;
                 }
-                    
+
                 $methodInfo = self::$extra_methods[$class][$method];
 
-                if ($methodInfo['property'] === $property && $methodInfo['index'] === $index) {
+                if (
+                    // always check for property
+                    (isset($methodInfo['property']) && $methodInfo['property'] === $property) &&
+                    // check for index only if provided (otherwise assume true)
+                    (($index && isset($methodInfo['index']) && $methodInfo['index'] === $index) || true)
+                ) {
                     unset(self::$extra_methods[$class][$method]);
                 }
             }

--- a/src/Core/CustomMethods.php
+++ b/src/Core/CustomMethods.php
@@ -288,8 +288,8 @@ trait CustomMethods
                 if (
                     // always check for property
                     (isset($methodInfo['property']) && $methodInfo['property'] === $property) &&
-                    // check for index only if provided (otherwise assume true)
-                    (($index && isset($methodInfo['index']) && $methodInfo['index'] === $index) || true)
+                    // check for index only if provided
+                    (!$index || ($index && isset($methodInfo['index']) && $methodInfo['index'] === $index))
                 ) {
                     unset(self::$extra_methods[$class][$method]);
                 }


### PR DESCRIPTION
There are instances where the `property` and `index` keys are not set in the array map, e.g. when extension methods are added via a callback mechanism.