### PR TITLE
NEW Add ability to define image size preset for the TinyMCE editor.

### DIFF
--- a/_config/html.yml
+++ b/_config/html.yml
@@ -13,3 +13,14 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\Forms\HTMLEditor\TinyMCECombinedGenerator
     properties:
       AssetHandler: '%$SilverStripe\Assets\Storage\GeneratedAssetHandler'
+
+SilverStripe\Forms\HTMLEditor\TinyMCEConfig:
+  image_size_presets:
+    - width: 600,
+      i18n: SilverStripe\Forms\HTMLEditor\TinyMCEConfig.BEST_FIT
+      text: Best fit
+      name: bestfit
+      default: true
+    - i18n: SilverStripe\Forms\HTMLEditor\TinyMCEConfig.ORIGINAL
+      text: Original
+      name: originalsize

--- a/docs/en/02_Developer_Guides/03_Forms/Field_types/03_HTMLEditorField.md
+++ b/docs/en/02_Developer_Guides/03_Forms/Field_types/03_HTMLEditorField.md
@@ -190,6 +190,52 @@ We use [shortcodes](/developer_guides/extending/shortcodes) to store information
 [ShortcodeParser](api:SilverStripe\View\Parsers\ShortcodeParser) API post-processes the HTML content on rendering, and replaces the shortcodes accordingly. It also 
 takes care of care of placing the shortcode replacements relative to its surrounding markup (e.g. left/right alignment).
 
+### Image size pre-sets
+SilverStripe will suggest pre-set image size in the HTMLEditor. Editors can quickly switch between the pre-set size when interacting with images in the HTMLEditorField.
+
+The default values are "Best fit" (600 pixels width) and original size. Developers can customise the pre-set sizes by altering their HTMLEditorConfig.
+
+You can alter the defaults for all HTMLEditor in your YML configuration.
+
+```yaml
+SilverStripe\Forms\HTMLEditor\TinyMCEConfig:
+  image_size_presets:
+    - name: widesize
+      i18n: SilverStripe\Forms\HTMLEditor\TinyMCEConfig.WIDE_SIZE
+      text: Wide size
+      width: 900
+```
+
+You can edit the image size pre-sets for an individual configuration with this code snippet.
+
+```php
+<?php
+use SilverStripe\Forms\HTMLEditor\HtmlEditorConfig;
+use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
+
+HtmlEditorConfig::get('cms')->setOption('image_size_presets', [
+    [
+        'width' => 300,
+        'text' => 'Small fit',
+        'name' => 'smallfit'
+    ],
+    [
+        'width' => 600,
+        'i18n' =>  TinyMCEConfig::class . '.BEST_FIT',
+        'text' => 'Best fit',
+        'name' => 'bestfit'
+    ],
+    [
+        'i18n' =>  TinyMCEConfig::class . '.ORIGINAL_SIZE',
+        'text' => 'Original size',
+        'name' => 'originalsize'
+    ]
+]);
+```
+
+
+
+
 ## oEmbed: Embedding media through external services
 
 The ["oEmbed" standard](http://www.oembed.com/) is implemented by many media services around the web, allowing easy 

--- a/docs/en/02_Developer_Guides/03_Forms/Field_types/03_HTMLEditorField.md
+++ b/docs/en/02_Developer_Guides/03_Forms/Field_types/03_HTMLEditorField.md
@@ -217,7 +217,8 @@ HtmlEditorConfig::get('cms')->setOption('image_size_presets', [
     [
         'width' => 300,
         'text' => 'Small fit',
-        'name' => 'smallfit'
+        'name' => 'smallfit',
+        'default' => true
     ],
     [
         'width' => 600,

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -209,6 +209,31 @@ class TinyMCEConfig extends HTMLEditorConfig
      */
     protected $contentCSS = null;
 
+
+    /**
+     * List of image size preset that will appear when you select an image. Each preset can have the following:
+     * * `name` to store an internal name for the preset (required)
+     * * `i18n` to store a translation key (e.g.: `SilverStripe\Forms\HTMLEditor\TinyMCEConfig.BESTFIT`)
+     * * `text` that will appear in the button (should be the default English translation)
+     * * `width` which will define the horizontal size of the preset. If not provided, the preset will match the
+     *   original size of the image.
+     * @var array
+     * @config
+     */
+    private static $image_size_presets = [
+        [
+            'width' => 600,
+            'i18n' => self::class . '.BEST_FIT',
+            'text' => 'Best fit',
+            'name' => 'bestfit'
+        ],
+        [
+            'i18n' => self::class . '.ORIGINAL_SIZE',
+            'text' => 'Original size',
+            'name' => 'originalsize'
+        ]
+    ];
+
     /**
      * TinyMCE JS settings
      *
@@ -662,8 +687,31 @@ class TinyMCEConfig extends HTMLEditorConfig
         }
         $settings['theme_url'] = $theme;
 
+        $this->initImageSizePresets($settings);
+
         // Send back
         return $settings;
+    }
+
+    /**
+     * Initialise the image preset on the settings array. This is a custom configuration option that asset-admin reads
+     * to provide some preset image sizes.
+     * @param array $settings
+     */
+    private function initImageSizePresets(array &$settings): void
+    {
+        if (empty($settings['image_size_presets'])) {
+            $settings['image_size_presets'] = self::config()->get('image_size_presets');
+        }
+
+        foreach($settings['image_size_presets'] as &$preset) {
+            if (isset($preset['i18n'])) {
+                $preset['text'] = i18n::_t(
+                    $preset['i18n'],
+                    isset($preset['text']) ? $preset['text'] : ''
+                );
+            }
+        }
     }
 
     /**

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -705,7 +705,7 @@ class TinyMCEConfig extends HTMLEditorConfig
             $settings['image_size_presets'] = self::config()->get('image_size_presets');
         }
 
-        foreach($settings['image_size_presets'] as &$preset) {
+        foreach ($settings['image_size_presets'] as &$preset) {
             if (isset($preset['i18n'])) {
                 $preset['text'] = i18n::_t(
                     $preset['i18n'],

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -695,9 +695,15 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
 
         foreach ($settings['image_size_presets'] as &$preset) {
             if (isset($preset['i18n'])) {
-                $preset['text'] = i18n::_t(
+                $preset['text'] = _t(
                     $preset['i18n'],
                     isset($preset['text']) ? $preset['text'] : ''
+                );
+            } elseif (empty($preset['text']) && isset($preset['width'])) {
+                $preset['text'] = _t(
+                    self::class . '.PIXEL_WIDTH',
+                    '{width} pixels',
+                    $preset
                 );
             }
         }
@@ -900,7 +906,9 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
 
     public function provideI18nEntities()
     {
-        $entities = [];
+        $entities = [
+            self::class . '.PIXEL_WIDTH' => '{width} pixels',
+        ];
         foreach (self::config()->get('image_size_presets') as $preset) {
             if (empty($preset['i18n']) || empty($preset['text'])) {
                 continue;

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -225,11 +225,12 @@ class TinyMCEConfig extends HTMLEditorConfig
             'width' => 600,
             'i18n' => self::class . '.BEST_FIT',
             'text' => 'Best fit',
-            'name' => 'bestfit'
+            'name' => 'bestfit',
+            'default' => true
         ],
         [
-            'i18n' => self::class . '.ORIGINAL_SIZE',
-            'text' => 'Original size',
+            'i18n' => self::class . '.ORIGINAL',
+            'text' => 'Original',
             'name' => 'originalsize'
         ]
     ];

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -13,6 +13,7 @@ use SilverStripe\Core\Manifest\ModuleResource;
 use SilverStripe\Core\Manifest\ModuleResourceLoader;
 use SilverStripe\Dev\Deprecation;
 use SilverStripe\i18n\i18n;
+use SilverStripe\i18n\i18nEntityProvider;
 use SilverStripe\View\Requirements;
 use SilverStripe\View\SSViewer;
 use SilverStripe\View\ThemeResourceLoader;
@@ -20,7 +21,7 @@ use SilverStripe\View\ThemeResourceLoader;
 /**
  * Default configuration for HtmlEditor specific to tinymce
  */
-class TinyMCEConfig extends HTMLEditorConfig
+class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
 {
     /**
      * @config
@@ -908,5 +909,18 @@ class TinyMCEConfig extends HTMLEditorConfig
         $folderID = $folder ? $folder->ID : null;
         $this->setOption('upload_folder_id', $folderID);
         return $this;
+    }
+
+    public function provideI18nEntities()
+    {
+        $entities = [];
+        foreach (self::config()->get('image_size_presets') as $preset) {
+            if (empty($preset['i18n']) || empty($preset['text'])) {
+                continue;
+            }
+            $entities[$preset['i18n']] = $preset['text'];
+        }
+
+        return $entities;
     }
 }

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -218,23 +218,10 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      * * `text` that will appear in the button (should be the default English translation)
      * * `width` which will define the horizontal size of the preset. If not provided, the preset will match the
      *   original size of the image.
-     * @var array
+     * @var array[]
      * @config
      */
-    private static $image_size_presets = [
-        [
-            'width' => 600,
-            'i18n' => self::class . '.BEST_FIT',
-            'text' => 'Best fit',
-            'name' => 'bestfit',
-            'default' => true
-        ],
-        [
-            'i18n' => self::class . '.ORIGINAL',
-            'text' => 'Original',
-            'name' => 'originalsize'
-        ]
-    ];
+    private static $image_size_presets = [ ];
 
     /**
      * TinyMCE JS settings

--- a/tests/php/Forms/HTMLEditor/TinyMCEConfigTest.php
+++ b/tests/php/Forms/HTMLEditor/TinyMCEConfigTest.php
@@ -81,8 +81,13 @@ class TinyMCEConfigTest extends SapphireTest
         $config = TinyMCEConfig::create();
         $translations = $config->provideI18nEntities();
 
-        $this->assertEquals(2, sizeof($translations));
+        $this->assertEquals(
+            3,
+            sizeof($translations),
+            'Only two presets have valid translation + the generic PIXEL_WIDTH one'
+        );
         $this->assertEquals('Foo bar', $translations[TinyMCEConfig::class . '.TEST']);
         $this->assertEquals('Bar foo', $translations[TinyMCEConfig::class . '.TEST_TWO']);
+        $this->assertEquals('{width} pixels', $translations[TinyMCEConfig::class . '.PIXEL_WIDTH']);
     }
 }

--- a/tests/php/Forms/HTMLEditor/TinyMCEConfigTest.php
+++ b/tests/php/Forms/HTMLEditor/TinyMCEConfigTest.php
@@ -68,4 +68,21 @@ class TinyMCEConfigTest extends SapphireTest
             $config->getContentCSS()
         );
     }
+
+    public function testProvideI18nEntities()
+    {
+        TinyMCEConfig::config()->set('image_size_presets', [
+            ['i18n' => TinyMCEConfig::class . '.TEST', 'text' => 'Foo bar'],
+            ['text' => 'No translation key'],
+            ['i18n' => TinyMCEConfig::class . '.NO_TRANSLATION_TEXT'],
+            ['i18n' => TinyMCEConfig::class . '.TEST_TWO', 'text' => 'Bar foo'],
+        ]);
+
+        $config = TinyMCEConfig::create();
+        $translations = $config->provideI18nEntities();
+
+        $this->assertEquals(2, sizeof($translations));
+        $this->assertEquals('Foo bar', $translations[TinyMCEConfig::class . '.TEST']);
+        $this->assertEquals('Bar foo', $translations[TinyMCEConfig::class . '.TEST_TWO']);
+    }
 }


### PR DESCRIPTION
Add the ability to define image size presets on the editor config.


# Parent issue
* https://github.com/silverstripe/silverstripe-asset-admin/issues/961

# Related PR
* https://github.com/silverstripe/silverstripe-asset-admin/pull/1018
