### PR TITLE
BUG Ensure that canCreate() context matches that respected by GridFieldAddNewButton

### DIFF
--- a/src/Control/Middleware/ConfirmationMiddleware/GetParameter.php
+++ b/src/Control/Middleware/ConfirmationMiddleware/GetParameter.php
@@ -61,7 +61,7 @@ class GetParameter implements Rule, Bypass
     {
         return new Confirmation\Item(
             $token,
-            _t(__CLASS__.'.CONFIRMATION_NAME', '"{key}" GET parameter', ['key' => $this->name]),
+            _t(__CLASS__ . '.CONFIRMATION_NAME', '"{key}" GET parameter', ['key' => $this->name]),
             sprintf('%s = "%s"', $this->name, $value)
         );
     }

--- a/src/Control/Middleware/ConfirmationMiddleware/Url.php
+++ b/src/Control/Middleware/ConfirmationMiddleware/Url.php
@@ -178,8 +178,8 @@ class Url implements Rule, Bypass
     {
         return new Confirmation\Item(
             $token,
-            _t(__CLASS__.'.CONFIRMATION_NAME', 'URL is protected'),
-            _t(__CLASS__.'.CONFIRMATION_DESCRIPTION', 'The URL is: "{url}"', ['url' => $url])
+            _t(__CLASS__ . '.CONFIRMATION_NAME', 'URL is protected'),
+            _t(__CLASS__ . '.CONFIRMATION_DESCRIPTION', 'The URL is: "{url}"', ['url' => $url])
         );
     }
 

--- a/src/Control/Middleware/ConfirmationMiddleware/UrlPathStartswith.php
+++ b/src/Control/Middleware/ConfirmationMiddleware/UrlPathStartswith.php
@@ -34,8 +34,8 @@ class UrlPathStartswith implements Rule, Bypass
     {
         return new Confirmation\Item(
             $token,
-            _t(__CLASS__.'.CONFIRMATION_NAME', 'URL begins with "{path}"', ['path' => $this->getPath()]),
-            _t(__CLASS__.'.CONFIRMATION_DESCRIPTION', 'The complete URL is: "{url}"', ['url' => $url])
+            _t(__CLASS__ . '.CONFIRMATION_NAME', 'URL begins with "{path}"', ['path' => $this->getPath()]),
+            _t(__CLASS__ . '.CONFIRMATION_DESCRIPTION', 'The complete URL is: "{url}"', ['url' => $url])
         );
     }
 

--- a/src/Dev/DevConfirmationController.php
+++ b/src/Dev/DevConfirmationController.php
@@ -23,9 +23,9 @@ class DevConfirmationController extends Confirmation\Handler
         $renderer = DebugView::create();
         echo $renderer->renderHeader();
         echo $renderer->renderInfo(
-            _t(__CLASS__.".INFO_TITLE", "Security Confirmation"),
+            _t(__CLASS__ . ".INFO_TITLE", "Security Confirmation"),
             Director::absoluteBaseURL(),
-            _t(__CLASS__.".INFO_DESCRIPTION", "Confirm potentially dangerous operation")
+            _t(__CLASS__ . ".INFO_DESCRIPTION", "Confirm potentially dangerous operation")
         );
 
         return $response;

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -18,6 +18,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\ORM\HasManyList;
 use SilverStripe\ORM\ManyManyList;
+use SilverStripe\ORM\RelationList;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\ORM\ValidationResult;
@@ -177,26 +178,18 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
             return $controller->redirect($noActionURL, 302);
         }
 
-        $canView = $this->record->canView();
-        $canEdit = $this->record->canEdit();
-        $canDelete = $this->record->canDelete();
-        $canCreate = $this->record->canCreate();
-
-        if (!$canView) {
-            $controller = $this->getToplevelController();
-            // TODO More friendly error
-            return $controller->httpError(403);
-        }
-
-        // Build actions
-        $actions = $this->getFormActions();
-
         // If we are creating a new record in a has-many list, then
         // pre-populate the record's foreign key.
         if ($list instanceof HasManyList && !$this->record->isInDB()) {
             $key = $list->getForeignKey();
             $id = $list->getForeignID();
             $this->record->$key = $id;
+        }
+
+        if (!$this->record->canView()) {
+            $controller = $this->getToplevelController();
+            // TODO More friendly error
+            return $controller->httpError(403);
         }
 
         $fields = $this->component->getFields();
@@ -218,20 +211,23 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
             $this,
             'ItemEditForm',
             $fields,
-            $actions,
+            $this->getFormActions(),
             $this->component->getValidator()
         );
 
         $form->loadDataFrom($this->record, $this->record->ID == 0 ? Form::MERGE_IGNORE_FALSEISH : Form::MERGE_DEFAULT);
 
-        if ($this->record->ID && !$canEdit) {
+        if ($this->record->ID && !$this->record->canEdit()) {
             // Restrict editing of existing records
             $form->makeReadonly();
             // Hack to re-enable delete button if user can delete
-            if ($canDelete) {
+            if ($this->record->canDelete()) {
                 $form->Actions()->fieldByName('action_doDelete')->setReadonly(false);
             }
-        } elseif (!$this->record->ID && !$canCreate) {
+        } elseif (
+            !$this->record->ID
+            && !$this->record->canCreate(null, $this->getCreateContext())
+        ) {
             // Restrict creation of new records
             $form->makeReadonly();
         }
@@ -269,6 +265,25 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
         }
         $this->extend("updateItemEditForm", $form);
         return $form;
+    }
+
+    /**
+     * Build context for verifying canCreate
+     * @see GridFieldAddNewButton::getHTMLFragments()
+     *
+     * @return array
+     */
+    protected function getCreateContext()
+    {
+        $gridField = $this->gridField;
+        $context = [];
+        if ($gridField->getList() instanceof RelationList) {
+            $record = $gridField->getForm()->getRecord();
+            if ($record && $record instanceof DataObject) {
+                $context['Parent'] = $record;
+            }
+        }
+        return $context;
     }
 
     /**

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -224,8 +224,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
             if ($this->record->canDelete()) {
                 $form->Actions()->fieldByName('action_doDelete')->setReadonly(false);
             }
-        } elseif (
-            !$this->record->ID
+        } elseif (!$this->record->ID
             && !$this->record->canCreate(null, $this->getCreateContext())
         ) {
             // Restrict creation of new records

--- a/src/Security/Confirmation/Form.php
+++ b/src/Security/Confirmation/Form.php
@@ -99,8 +99,8 @@ class Form extends BaseForm
 
     protected function buildActionList(Storage $storage)
     {
-        $cancel = FormAction::create('doRefuse', _t(__CLASS__.'.REFUSE', 'Cancel'));
-        $confirm = FormAction::create('doConfirm', _t(__CLASS__.'.CONFIRM', 'Run the action'))->setAutofocus(true);
+        $cancel = FormAction::create('doRefuse', _t(__CLASS__ . '.REFUSE', 'Cancel'));
+        $confirm = FormAction::create('doConfirm', _t(__CLASS__ . '.CONFIRM', 'Run the action'))->setAutofocus(true);
 
         if ($storage->getHttpMethod() === 'POST') {
             $confirm->setAttribute('formaction', htmlspecialchars($storage->getSuccessUrl()));
@@ -165,7 +165,7 @@ class Form extends BaseForm
     protected function buildEmptyFieldList()
     {
         return FieldList::create(
-            HeaderField::create(null, _t(__CLASS__.'.EMPTY_TITLE', 'Nothing to confirm'))
+            HeaderField::create(null, _t(__CLASS__ . '.EMPTY_TITLE', 'Nothing to confirm'))
         );
     }
 }

--- a/src/Security/Confirmation/Handler.php
+++ b/src/Security/Confirmation/Handler.php
@@ -47,7 +47,7 @@ class Handler extends RequestHandler
     public function index()
     {
         return [
-            'Title' => _t(__CLASS__.'.FORM_TITLE', 'Confirm potentially dangerous action'),
+            'Title' => _t(__CLASS__ . '.FORM_TITLE', 'Confirm potentially dangerous action'),
             'Form' => $this->Form()
         ];
         return $this;

--- a/src/Security/Confirmation/Storage.php
+++ b/src/Security/Confirmation/Storage.php
@@ -125,7 +125,7 @@ class Storage
         $token = $item->getToken();
         $salt = $this->getSessionSalt();
 
-        $salted = $salt.$token;
+        $salted = $salt . $token;
 
         return hash(static::HASH_ALGO, $salted, true);
     }
@@ -139,7 +139,7 @@ class Storage
     {
         $salt = $this->getSessionSalt();
 
-        return bin2hex(hash(static::HASH_ALGO, $salt.'cookie key', true));
+        return bin2hex(hash(static::HASH_ALGO, $salt . 'cookie key', true));
     }
 
     /**
@@ -151,7 +151,7 @@ class Storage
     {
         $salt = $this->getSessionSalt();
 
-        return base64_encode(hash(static::HASH_ALGO, $salt.'csrf token', true));
+        return base64_encode(hash(static::HASH_ALGO, $salt . 'csrf token', true));
     }
 
     /**
@@ -441,7 +441,7 @@ class Storage
             '%s.%s%s',
             str_replace('\\', '.', __CLASS__),
             $this->id,
-            $key ? '.'.$key : ''
+            $key ? '.' . $key : ''
         );
     }
 }

--- a/tests/php/Control/HttpRequestMockBuilder.php
+++ b/tests/php/Control/HttpRequestMockBuilder.php
@@ -29,7 +29,7 @@ trait HttpRequestMockBuilder
         $request->method('getSession')->willReturn($session);
 
         $request->method('getURL')->will($this->returnCallback(static function ($addParams) use ($url, $getVars) {
-            return $addParams && count($getVars) ? $url.'?'.http_build_query($getVars) : $url;
+            return $addParams && count($getVars) ? $url . '?' . http_build_query($getVars) : $url;
         }));
 
         $request->method('getVars')->willReturn($getVars);

--- a/tests/php/Control/Middleware/ConfirmationMiddlewareTest.php
+++ b/tests/php/Control/Middleware/ConfirmationMiddlewareTest.php
@@ -68,7 +68,7 @@ class ConfirmationMiddlewareTest extends SapphireTest
         $this->assertFalse($next);
         $this->assertInstanceOf(HTTPResponse::class, $response);
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals(Director::baseURL().'dev/confirm/middleware', $response->getHeader('location'));
+        $this->assertEquals(Director::baseURL() . 'dev/confirm/middleware', $response->getHeader('location'));
 
         // Test bypasses have more priority than rules
         $middleware->setBypasses([new Url('dev/build')]);

--- a/tests/php/Security/Confirmation/StorageTest.php
+++ b/tests/php/Security/Confirmation/StorageTest.php
@@ -14,7 +14,7 @@ class StorageTest extends SapphireTest
 
     private function getNamespace($id)
     {
-        return str_replace('\\', '.', Storage::class).'.'.$id;
+        return str_replace('\\', '.', Storage::class) . '.' . $id;
     }
 
     public function testNewStorage()


### PR DESCRIPTION
There are cases where a canCreate() method that respects `Parent` will return `true`.

`GridFieldAddNewButton` takes the effort to respect this when determining if a record can be created.

however, `GridFieldDetailForm_ItemRequest` ignores that context, meaning you can end up in a case where your create form is readonly, and you can't edit anything.

I've also shifted the various can() methods so that they are only called when (and if) needed, reducing unnecessary wasted processing. 

I've also moved the 403 error check to after `$this->record->$key` is assigned, in case canView() relies on the ParentID field.