### PR TITLE
Fix preg_match interpreting filenames with / as modifiers.

### DIFF
--- a/model/Image.php
+++ b/model/Image.php
@@ -894,7 +894,7 @@ class Image extends File implements Flushable {
 		$base64url_match = "[a-zA-Z0-9_~]*={0,2}";
 		return array(
 				'FullPattern' => "/^((?P<Generator>{$generateFuncs})(?P<Args>" . $base64url_match . ")\/)+"
-									. preg_quote($filename) . "$/i",
+									. preg_quote($filename, '/') . "$/i",
 				'GeneratorPattern' => "/(?P<Generator>{$generateFuncs})(?P<Args>" . $base64url_match . ")\//i"
 		);
 	}


### PR DESCRIPTION
The filename passed to getFilenamePatterns is quoted with preg_quote, but preg_quote does not regard / as a special character by default. But  the regular expression uses / as delimiter so it should.
When passing "mydirectory/myimage.jpg" the original code interpreted /m as a regex modifier.
This fixes it by correctly regarding the delimiter.
