### PR TITLE
Update Test documentation about test database behaviours

### DIFF
--- a/docs/en/02_Developer_Guides/06_Testing/00_Unit_Testing.md
+++ b/docs/en/02_Developer_Guides/06_Testing/00_Unit_Testing.md
@@ -61,7 +61,7 @@ documentation.
 
 ## Test Databases and Fixtures
 
-SilverStripe tests create their own database when the test starts. New `ss_tmp` databases are created using the same 
+SilverStripe tests create their own database when the test starts and fixture files are specified. New `ss_tmp` databases are created using the same 
 connection details you provide for the main website. The new `ss_tmp` database does not copy what is currently in your 
 application database. To provide seed data use a [Fixture](fixtures) file.
 
@@ -71,7 +71,7 @@ permissions to create new databases on your server.
 </div>
 
 <div class="notice" markdown="1">
-The test database is rebuilt every time one of the test methods is run. Over time, you may have several hundred test 
+The test database is rebuilt every time one of the test methods is run and cleaned up afterwards. If the test is interrupted the database is not cleaned up, over time, you may have several hundred test 
 databases on your machine. To get rid of them, run `sake dev/tasks/CleanupTestDatabasesTask`.
 </div>
 

--- a/docs/en/02_Developer_Guides/06_Testing/00_Unit_Testing.md
+++ b/docs/en/02_Developer_Guides/06_Testing/00_Unit_Testing.md
@@ -71,7 +71,7 @@ permissions to create new databases on your server.
 </div>
 
 <div class="notice" markdown="1">
-The test database is rebuilt every time one of the test methods is run and cleaned up afterwards. If the test is interrupted the database is not cleaned up, over time, you may have several hundred test 
+The test database is rebuilt every time one of the test methods is run and is removed afterwards. If the test is interrupted, the database will not be removed. Over time, you may have several hundred test 
 databases on your machine. To get rid of them, run `sake dev/tasks/CleanupTestDatabasesTask`.
 </div>
 


### PR DESCRIPTION
This update is based on what I have experienced and this conversation on Slack https://silverstripe-users.slack.com/archives/C6PLF83H9/p1571281365001600

The test database wasn't created unless I had a fixture file specified in my test class. Also the test databases were cleaned up after running the tests, no need to run the clean up task unless the test gets interrupted. (like hitting C-c during the run)

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
