### PR TITLE
BUG FormAction title property cannot be set if useButtonTag is false

### DIFF
--- a/src/Forms/FormAction.php
+++ b/src/Forms/FormAction.php
@@ -184,15 +184,20 @@ class FormAction extends FormField
 
     public function getAttributes()
     {
-        return array_merge(
+        $attributes = array_merge(
             parent::getAttributes(),
-            array(
+            [
                 'disabled' => ($this->isReadonly() || $this->isDisabled()),
-                'value' => $this->Title(),
-                'type' => $this->getInputType(),
-                'title' => ($this->useButtonTag) ? $this->description : null,
-            )
+                'value'    => $this->Title(),
+                'type'     => $this->getInputType(),
+            ]
         );
+
+        // Override title with description if supplied
+        if ($this->getDescription()) {
+            $attributes['title'] = $this->getDescription();
+        }
+        return $attributes;
     }
 
     /**

--- a/tests/php/Forms/FormActionTest.php
+++ b/tests/php/Forms/FormActionTest.php
@@ -16,4 +16,17 @@ class FormActionTest extends SapphireTest
         $formAction->setAttribute('src', 'file.png');
         $this->assertContains('type="image"', $formAction->getAttributesHTML());
     }
+
+    public function testGetTitle()
+    {
+        // Test that description overrides title attribute, but doesn't prevent it from
+        // working if blank.
+        $action = new FormAction('test');
+        $action->setAttribute('title', 'this is the title');
+        $this->assertEquals('this is the title', $action->getAttribute('title'));
+        $action->setDescription('this is a better title');
+        $this->assertEquals('this is a better title', $action->getAttribute('title'));
+        $action->setDescription(null);
+        $this->assertEquals('this is the title', $action->getAttribute('title'));
+    }
 }


### PR DESCRIPTION
I was trying to set a `title` property for my form action, then noticed the code wouldn't let you set it at all unless using a button tag.

This changes description to override title, but only if description is set to a non-empty value.