### PR TITLE
FIX Adjust HTMLEditorField tests to support alt attr changes in assets

### DIFF
--- a/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
@@ -122,9 +122,9 @@ class HTMLEditorFieldTest extends FunctionalTest
         $parser = new CSSContentParser($obj->dbObject('Content')->forTemplate());
         $xml = $parser->getByXpath('//img');
         $this->assertEquals(
-            'example',
+            '',
             (string)$xml[0]['alt'],
-            'Alt tags are added by default based on filename'
+            'Alt attribute is always present, even if empty'
         );
         $this->assertEquals('', (string)$xml[0]['title'], 'Title tags are added by default.');
         $this->assertEquals(10, (int)$xml[0]['width'], 'Width tag of resized image is set.');
@@ -180,7 +180,7 @@ class HTMLEditorFieldTest extends FunctionalTest
         $this->assertEquals(
             <<<EOS
 <span class="readonly typography" id="Content">
-	<img src="/assets/HTMLEditorFieldTest/f5c7c2f814/example__ResizedImageWzEwLDIwXQ.jpg" alt="example" width="10" height="20">
+	<img src="/assets/HTMLEditorFieldTest/f5c7c2f814/example__ResizedImageWzEwLDIwXQ.jpg" alt="" width="10" height="20">
 </span>
 
 
@@ -197,7 +197,7 @@ EOS
         $this->assertEquals(
             <<<EOS
 <span class="readonly typography" id="Content">
-	<img src="/assets/HTMLEditorFieldTest/f5c7c2f814/example__ResizedImageWzEwLDIwXQ.jpg" alt="example" width="10" height="20">
+	<img src="/assets/HTMLEditorFieldTest/f5c7c2f814/example__ResizedImageWzEwLDIwXQ.jpg" alt="" width="10" height="20">
 </span>
 
 	<input type="hidden" name="Content" value="[image src=&quot;/assets/HTMLEditorFieldTest/f5c7c2f814/example.jpg&quot; width=&quot;10&quot; height=&quot;20&quot; id=&quot;{$fileID}&quot;]" />


### PR DESCRIPTION
The default behaviour of the alt attribute has changed from using the filename to applying an empty value.

See [the test failure](https://travis-ci.org/silverstripe/recipe-core/jobs/611180498).