### PR TITLE
Change example domains

### DIFF
--- a/docs/en/02_Developer_Guides/04_Configuration/01_SiteConfig.md
+++ b/docs/en/02_Developer_Guides/04_Configuration/01_SiteConfig.md
@@ -73,8 +73,8 @@ Silverstripe\SiteConfig\SiteConfig:
 ```
 
 <div class="notice" markdown="1">
-After adding the class and the YAML change, make sure to rebuild your database by visiting http://yoursite.com/dev/build.
-You may also need to reload the screen with a `?flush=1` i.e http://yoursite.com/admin/settings?flush=1.
+After adding the class and the YAML change, make sure to rebuild your database by visiting http://example.com/dev/build.
+You may also need to reload the screen with a `?flush=1` i.e http://example.com/admin/settings?flush=1.
 </div>
 
 You can define as many extensions for `SiteConfig` as you need. For example, if you're developing a module and want to


### PR DESCRIPTION
The current examples use an actual, real-world domain.   Have changed to the 'example.com' domain, reserved by IANA for this kind of purpose.

