### PR TITLE
BUG The "Link existing" should be disabled rather than readonly

### DIFF
--- a/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
+++ b/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
@@ -136,7 +136,7 @@ class GridFieldAddExistingAutocompleter implements GridField_HTMLProvider, GridF
 
         // If an object is not found, disable the action
         if (!is_int($gridField->State->GridFieldAddRelation(null))) {
-            $addAction->setReadonly(true);
+            $addAction->setDisabled(true);
         }
 
         $forTemplate->Fields->push($searchField);


### PR DESCRIPTION
Buttons aren't form fields. They shouldn't be "readonly", they should disabled. This make sure we display the correct icon on mouse over when the button is enabled.

# Parent issue
* https://github.com/silverstripe/silverstripe-framework/issues/9269
