### PR TITLE
META: Add action for netlify docs build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: Build Docs
+on:
+  push:
+    branches:
+      - '3.7'
+      - '4'
+    paths:
+      - 'docs/**'
+jobs:
+  build:
+    name: build-docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run build hook
+        run: curl -X POST -d {} https://api.netlify.com/build_hooks/${{ secrets.NETLIFY_BUILD_HOOK }}


### PR DESCRIPTION
Now that our docs are hosted on Netlify, we should trigger builds every time a `docs/` file is added

Resolves: https://github.com/silverstripe/doc.silverstripe.org/issues/208