### PR TITLE
Fix extra blank Group being created when creating a new Group

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -1643,6 +1643,11 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      */
     private function skipWriteComponents($recursive, DataObject $target, array &$skip)
     {
+        // skip writing component if it doesn't exist
+        if (!$target->exists()) {
+            return true;
+        }
+
         // We only care about the skip list if our call is meant to be recursive
         if (!$recursive) {
             return false;

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -2169,7 +2169,10 @@ class DataObjectTest extends SapphireTest
         // Write object with components
         $ceo->Name = 'Edward Scissorhands';
         $ceo->write(false, false, false, true);
-        $this->assertTrue($ceo->Company()->isInDB(), 'write() writes belongs_to components to the database.');
+        $this->assertFalse(
+            $ceo->Company()->isInDB(),
+            'write() does not write belongs_to components to the database that do not already exist.'
+        );
 
         $newCEO = DataObject::get_by_id(DataObjectTest\CEO::class, $ceo->ID);
         $this->assertEquals(
@@ -2212,7 +2215,10 @@ class DataObjectTest extends SapphireTest
 
         // Write object with components
         $ceo->write(false, false, false, true);
-        $this->assertTrue($ceo->CompanyOwned()->isInDB(), 'write() writes belongs_to components to the database.');
+        $this->assertFalse(
+            $ceo->CompanyOwned()->isInDB(),
+            'write() does not write belongs_to components to the database that do not already exist.'
+        );
 
         $newCEO = DataObject::get_by_id(DataObjectTest\CEO::class, $ceo->ID);
         $this->assertEquals(

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -1011,6 +1011,12 @@ class DataObjectTest extends SapphireTest
             DB::query("SELECT \"CaptainID\" FROM \"DataObjectTest_Team\" WHERE \"ID\" = $team->ID")->value()
         );
 
+        // Can write to component directly
+        $this->assertEquals(false, $team->Captain()->IsRetired);
+        $team->Captain()->IsRetired = true;
+        $team->Captain()->write();
+        $this->assertEquals(true, $team->Captain()->IsRetired, 'Saves writes to components directly');
+
         /* After giving it a value, you should also be able to set it back to null */
         $team->CaptainID = '';
         $team->write();
@@ -2202,7 +2208,7 @@ class DataObjectTest extends SapphireTest
             'belongs_to returns the right results.'
         );
 
-        // Test automatic creation of class where no assigment exists
+        // Test automatic creation of class where no assignment exists
         $ceo = new DataObjectTest\CEO();
         $ceo->write();
 
@@ -2211,9 +2217,9 @@ class DataObjectTest extends SapphireTest
             'DataObjects across polymorphic belongs_to relations are automatically created.'
         );
         $this->assertEquals($ceo->ID, $ceo->CompanyOwned()->OwnerID, 'Remote IDs are automatically set.');
-        $this->assertInstanceOf($ceo->CompanyOwned()->OwnerClass, $ceo, 'Remote class is automatically  set');
+        $this->assertInstanceOf($ceo->CompanyOwned()->OwnerClass, $ceo, 'Remote class is automatically set.');
 
-        // Write object with components
+        // Skip writing components that do not exist
         $ceo->write(false, false, false, true);
         $this->assertFalse(
             $ceo->CompanyOwned()->isInDB(),


### PR DESCRIPTION
Components on `DataObject`s are automatically created when you call the magic method, e.g: `$group->Parent()` even though it does not exist.

Here we make sure that the component actually exists before we try and save it.

Hopefully that stops blank groups from being saved when you create new groups.