### PR TITLE
FIX: Session::restart() didn't correctly restart session (fixes #9259)

### DIFF
--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -226,9 +226,7 @@ class Session
         if (isset($this->data['HTTP_USER_AGENT'])) {
             if ($this->data['HTTP_USER_AGENT'] !== $this->userAgent($request)) {
                 $this->clearAll();
-                $this->destroy();
-                $this->started = false;
-                $this->start($request);
+                $this->restart($request);
             }
         }
     }
@@ -241,7 +239,7 @@ class Session
     public function restart(HTTPRequest $request)
     {
         $this->destroy();
-        $this->init($request);
+        $this->start($request);
     }
 
     /**
@@ -369,6 +367,7 @@ class Session
         // http://nz1.php.net/manual/en/function.session-destroy.php
         unset($_SESSION);
         $this->data = null;
+        $this->started = false;
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/9259

There are two problems with this currently:

-  `Session::destroy()` leaves `protected $started = true;`, so calling `init()` or `start()` will have no effect as they both check `isStarted()` before doing anything.
- `Session::restart()` calls `init()` instead of `start()`. `init()` will check `requestContainsSessionId()` before calling `start()`, but as we’ve just called `destroy()` we’ve removed the session id from the request