### PR TITLE
DOCS Add note about applying forceSSL to non-live environments

### DIFF
--- a/docs/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
+++ b/docs/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
@@ -711,6 +711,19 @@ if (!Director::isDev()) {
 }
 ```
 
+`forceSSL()` will only take effect in environment types that `CanonicalURLMiddleware` is configured to apply to (by
+default, only `LIVE`). To apply this behaviour in all environment types, you'll need to update that configuration:
+
+```php
+use SilverStripe\Control\Director;
+use SilverStripe\Control\Middleware\CanonicalURLMiddleware;
+
+if (!Director::isDev()) {
+    CanonicalURLMiddleware::singleton()->setEnabledEnvs(true); // You can also specify individual environment types
+    Director::forceSSL();
+}
+```
+
 Forcing HTTPS so requires a certificate to be purchased or obtained through a vendor such as 
 [lets encrypt](https://letsencrypt.org/) and configured on your web server.
 


### PR DESCRIPTION
The documentation for the `Director::forceSSL()` method did not previously mention that it cannot be applied to non-live environments unless an additional configuration change is made.

Resolves #9308.