### PR TITLE
Add check for existence of 'which' command before proceeding with the…

### DIFF
--- a/sake
+++ b/sake
@@ -9,6 +9,11 @@ Executes a SilverStripe command"
 	exit 1
 fi
 
+if ! [ -x "$(command -v which)" ]; then
+  echo "Error: sake requires the 'which' command to operate." >&2
+  exit 1
+fi
+
 # find the silverstripe installation, looking first at sake
 # bin location, but falling back to current directory
 sakedir=`dirname $0`


### PR DESCRIPTION
As per #9338 - add a check to sake for the existence of 'which' before proceeding with the script execution.  This should ensure that a meaningful error is thrown if 'which' is not installed

Fixes #9339