### PR TITLE
NEW: Allow search field customisation

### DIFF
--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Forms\Tests\GridField;
 
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
@@ -155,5 +156,21 @@ class GridFieldFilterHeaderTest extends SapphireTest
             $this->assertEquals('stacked', $field->extraClasses['stacked']);
             $this->assertEquals('no-change-track', $field->extraClasses['no-change-track']);
         }
+    }
+
+    public function testCustomSearchField()
+    {
+        $searchSchema = json_decode($this->component->getSearchFieldSchema($this->gridField));
+        $this->assertEquals('Name', $searchSchema->name);
+
+        Config::modify()->set(Team::class, 'general_search_field', 'CustomSearch');
+        $searchSchema = json_decode($this->component->getSearchFieldSchema($this->gridField));
+        $this->assertEquals('CustomSearch', $searchSchema->name);
+
+        $this->component->setSearchField('ReallyCustomSearch');
+        $searchSchema = json_decode($this->component->getSearchFieldSchema($this->gridField));
+        $this->assertEquals('ReallyCustomSearch', $searchSchema->name);
+
+        $this->assertEquals('ReallyCustomSearch', $this->component->getSearchField());
     }
 }


### PR DESCRIPTION
By default, `GridFieldFilterHeader` chooses the first field in the searchable fields array for the search bar. This allows you to customise what that field is.

## Notes
- Assumes https://github.com/silverstripe/silverstripe-framework/pull/10382 will be merged in first.
- The reviewer should make a judgment call as to whether this is a useful enhancement following #10382. I (Guy) think it _probably_ is, as it allows people to customise their `SearchContext` and `GridField`s further and separately.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/9356