### PR TITLE
Fix PHP versions in upgrade guide

### DIFF
--- a/docs/en/03_Upgrading/01_Upgrading_project.md
+++ b/docs/en/03_Upgrading/01_Upgrading_project.md
@@ -25,7 +25,7 @@ How easy will it be to update my project? It's a fair question, and sometimes a 
 
 There are some fundamental changes in SilverStripe 4:
 
-* PHP 5.6 is now the minimum required version and up to PHP 7.2 is supported.
+* PHP 5.6 is now the minimum required version and up to PHP 7.3 is supported. We strongly recommend you only use [supported versions of PHP](https://www.php.net/supported-versions.php).
 * SilverStripe is now even more modular which allows you to remove functionality your project might not need.
 * Common functionality sets can now be installed via SilverStripe _recipes_.
 * SilverStripe modules can now be installed in the `vendor/` folder along with your regular PHP packages.


### PR DESCRIPTION
Make versions less generic, and add note about following PHP's supported versions guide
