### PR TITLE
BUG Remove bad default when scaffolding form field for DBHTMLVarchar

### DIFF
--- a/src/ORM/FieldType/DBHTMLVarchar.php
+++ b/src/ORM/FieldType/DBHTMLVarchar.php
@@ -124,7 +124,7 @@ class DBHTMLVarchar extends DBVarchar
 
     public function scaffoldFormField($title = null, $params = null)
     {
-        return HTMLEditorField::create($this->name, $title)->setRows(1);
+        return HTMLEditorField::create($this->name, $title);
     }
 
     public function scaffoldSearchField($title = null)

--- a/src/ORM/FieldType/DBHTMLVarchar.php
+++ b/src/ORM/FieldType/DBHTMLVarchar.php
@@ -124,7 +124,7 @@ class DBHTMLVarchar extends DBVarchar
 
     public function scaffoldFormField($title = null, $params = null)
     {
-        return HTMLEditorField::create($this->name, $title, 1);
+        return HTMLEditorField::create($this->name, $title)->setRows(1);
     }
 
     public function scaffoldSearchField($title = null)


### PR DESCRIPTION
Remove a bad default when scaffolding the form field for a DBHTMLVarchar col.
# Parent issue 
* https://github.com/silverstripe/silverstripe-framework/issues/9358