### PR TITLE
Minor performance improvement in DatabaseAdapterRegistry::autoconfigure()

### DIFF
--- a/src/Dev/Install/DatabaseAdapterRegistry.php
+++ b/src/Dev/Install/DatabaseAdapterRegistry.php
@@ -145,12 +145,8 @@ class DatabaseAdapterRegistry
             $databaseConfig = $config;
         }
         // Search through all composer packages in vendor, updating $databaseConfig
-        foreach (glob(BASE_PATH . '/vendor/*', GLOB_ONLYDIR) as $vendor) {
-            foreach (glob($vendor . '/*', GLOB_ONLYDIR) as $directory) {
-                if (file_exists($directory . '/_configure_database.php')) {
-                    include_once($directory . '/_configure_database.php');
-                }
-            }
+        foreach (glob(BASE_PATH . '/vendor/*/*/_configure_database.php') as $configFile) {
+            include_once $configFile;
         }
         // Update modified variable
         $config = $databaseConfig;


### PR DESCRIPTION
This is called by [`CoreKernel::getDatabaseConfig()`](https://github.com/silverstripe/silverstripe-framework/blob/f75094abcd8ff29ece4bca05a297fda106e3ba89/src/Core/CoreKernel.php#L372) on every request. Currently, this results in a `file_exists('vendor/<vendor>/<package>/_configure_database.php')` call for every composer dependency & sub-dependency (`find vendor/*/* -maxdepth 0 -type d | wc -l` - I have almost 300 in one project!).

Micro-optimisations ftw.