### PR TITLE
DOC Tweak names and link in 4.5.0 changelog

### DIFF
--- a/docs/en/04_Changelogs/4.5.0.md
+++ b/docs/en/04_Changelogs/4.5.0.md
@@ -8,7 +8,7 @@
  * [Generic login form styling](#login-forms) is now available as an optional module
  * Removed `use_gzip` option on `HtmlEditorField` which used to compress the rich text editor dependency.
    No longer required since compression is performed as part of the CMS build automatically.
-   See (#832)(https://github.com/silverstripe/silverstripe-admin/issues/832)
+   See [#832](https://github.com/silverstripe/silverstripe-admin/issues/832)
 
 
 ## PHP 7.1 is the minimum supported version {#php71}
@@ -30,7 +30,7 @@ run CMS on a different software.
 
 ## Installer UI has been removed {#installer-ui}
 
-Until now, core releases of SilverStripe would put an `install.php` file in the
+Until now, core releases of Silverstripe CMS would put an `install.php` file in the
 public root that, when accessed with a browser, would offer an installation
 UI prompting the user for all the necessary configuration of your project
 and environment, and validating it before performing the installation.
@@ -47,7 +47,7 @@ It is no longer a commercially supported module.
 
 ## Archive downloads have been removed
 
-SilverStripe has gradually switched from using file archives
+Silverstripe CMS has gradually switched from using file archives
 to installation via [Composer](https://getcomposer.org).
 This enabled a much more diverse module ecosystem,
 with clear dependency management and greater ability to
@@ -60,7 +60,7 @@ See [#9232](https://github.com/silverstripe/silverstripe-framework/issues/9232) 
 
 ## Generic login form styling {#login-forms}
 
-Login forms in SilverStripe are traditionally embedded in your page template.
+Login forms in Silverstripe CMS are traditionally embedded in your page template.
 This often requires style adjustments in your website, for example, to cover variations
 such as error messages and validation feedback. It also complicates
 more advanced login flows such as multi-factor authentication.
@@ -71,7 +71,7 @@ module. It provides generic styles which look great without any adjustments.
 You can choose to add your own logo or customise the templates.
 The URLs to login functionality have not changed (e.g. `Security/login`).
 
-Existing SilverStripe websites upgrading to this release can opt into using
+Existing Silverstripe CMS websites upgrading to this release can opt into using
 login forms via composer:
 
 ```


### PR DESCRIPTION
- Ensure we consistently reference Silverstripe CMS rather than SilverStripe
- Fix formatting of link