### PR TITLE
DOC Updated search filter modifiers documentation

### DIFF
--- a/docs/en/02_Developer_Guides/00_Model/06_SearchFilters.md
+++ b/docs/en/02_Developer_Guides/00_Model/06_SearchFilters.md
@@ -6,7 +6,7 @@ icon: search
 
 # SearchFilter Modifiers
 
-The `filter` and `exclude` operations specify exact matches by default. However, there are a number of suffixes that
+The `filter` and `exclude` operations specify exact matches by default. However, when filtering `DataList`s, there are a number of suffixes that
 you can put on field names to change this behavior. These are represented as `SearchFilter` subclasses and include.
 
  * [StartsWithFilter](api:SilverStripe\ORM\Filters\StartsWithFilter)


### PR DESCRIPTION
The documentation for search filter modifiers does not mention that they only work on data lists. 
I think the documentation should mention that somewhere in the beginning of the documentation.
One can easily get confused to think that the modifiers also work on other lists, such as `ArrayList`, as they share other common features. 

E.g. https://stackoverflow.com/questions/59435156/silverstripe-3-filter-arraylist