### PR TITLE
array_key_exists() on objects is deprecated in PHP 7.4

### DIFF
--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -588,7 +588,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
 
         $firstRecord = $this->first();
 
-        return array_key_exists($by, $firstRecord);
+        return is_array($firstRecord) ? array_key_exists($by, $firstRecord) : property_exists($by, $firstRecord);
     }
 
     /**


### PR DESCRIPTION
Ref: https://wiki.php.net/rfc/deprecations_php_7_4#array_key_exists_with_objects