### PR TITLE
Added "owner system" limitation information to the Extension Docs

### DIFF
--- a/docs/en/02_Developer_Guides/05_Extending/01_Extensions.md
+++ b/docs/en/02_Developer_Guides/05_Extending/01_Extensions.md
@@ -250,7 +250,7 @@ class MyMemberExtension extends DataExtension
 ```
 
 [notice]
-Please note that while you can read protected properties (using `$this->owner->protectedProperty`) you cannot not call protected methods (`$this->owner->protectedMethod()`). You also cannot access any private properties or methods (So this would not work either `$this->owner->privateProperty`).
+Please note that while you can read protected properties of the source object (using `$this->owner->protectedProperty`) you cannot call any of it's protected methods (So this `$this->owner->protectedMethod()` would not work). You also cannot access any of the source object's private properties or methods (So this would not work either `$this->owner->privateProperty`).
 [/notice]
 
 ## Checking to see if an Object has an Extension

--- a/docs/en/02_Developer_Guides/05_Extending/01_Extensions.md
+++ b/docs/en/02_Developer_Guides/05_Extending/01_Extensions.md
@@ -250,7 +250,7 @@ class MyMemberExtension extends DataExtension
 ```
 
 [notice]
-Please note that while you can read protected properties of the source object (using `$this->owner->protectedProperty`) you cannot call any of it's protected methods (So this `$this->owner->protectedMethod()` would not work). You also cannot access any of the source object's private properties or methods (So this would not work either `$this->owner->privateProperty`).
+Please note that while you can read protected properties of the source object (using `$this->owner->protectedProperty`) you cannot call any of it's protected methods (`$this->owner->protectedMethod()` will not work). You also cannot access any of the source object's private properties or methods (`$this->owner->privateProperty` will not work either).
 [/notice]
 
 ## Checking to see if an Object has an Extension

--- a/docs/en/02_Developer_Guides/05_Extending/01_Extensions.md
+++ b/docs/en/02_Developer_Guides/05_Extending/01_Extensions.md
@@ -249,6 +249,10 @@ class MyMemberExtension extends DataExtension
 }
 ```
 
+[notice]
+Please note that while you can read protected properties (using `$this->owner->protectedProperty`) you cannot not call protected methods (`$this->owner->protectedMethod()`). You also cannot access any private properties or methods (So this would not work either `$this->owner->privateProperty`).
+[/notice]
+
 ## Checking to see if an Object has an Extension
 
 To see what extensions are currently enabled on an object, use the [getExtensionInstances()](api:SilverStripe\Core\Extensible::getExtensionInstances()) and 


### PR DESCRIPTION
Added a notice to the Owner section of the "Extensions and DataExtensions" documentation that will help to remind developers of the limitations of the owner system when it comes to private and protected properties and methods

You may read this Slack conversation for more information:
https://slackarchive.silverstripe.org/slack-archive/message/321404