### PR TITLE
Adding SS_ENVIRONMENT_TYPE to documentation

### DIFF
--- a/docs/en/00_Getting_Started/index.md
+++ b/docs/en/00_Getting_Started/index.md
@@ -41,6 +41,7 @@ SS_DATABASE_USERNAME="<user>"
 SS_DATABASE_PASSWORD="<password>"
 SS_DEFAULT_ADMIN_USERNAME="admin"
 SS_DEFAULT_ADMIN_PASSWORD="password"
+SS_ENVIRONMENT_TYPE="<dev|test|live>"
 ```
 
 Now you should be able to build your database by running this command:


### PR DESCRIPTION
Before running a dev/build the first time, you need to specify dev as your environment type. The variable wasn't mentioned as part of the list so I've added it. Let me know if it's not clear about the difference between the states, or it should be better documented here somehow.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
