### PR TITLE
added addExtraClass

### DIFF
--- a/docs/en/02_Developer_Guides/03_Forms/How_Tos/04_Create_a_GridField_ActionProvider.md
+++ b/docs/en/02_Developer_Guides/03_Forms/How_Tos/04_Create_a_GridField_ActionProvider.md
@@ -203,7 +203,9 @@ class GridFieldCustomAction implements GridField_ColumnProvider, GridField_Actio
             'Custom action',
             "docustomaction",
             ['RecordID' => $record->ID]
-         );
+         )->addExtraClass(
+            'action-menu--handled'
+        );
     }
     
     public function getExtraData($gridField, $record, $columnName)


### PR DESCRIPTION
I am not quiet sure if this is needed but if you want to only add the custom action to the GridField action menu than you need to add the extra classes otherwise it would add it to the action menu and to the gridfield.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
