### PR TITLE
Fixed issue with merging existing entities in text collector

### DIFF
--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -378,8 +378,8 @@ class i18nTextCollector
             // Merge
             if ($existingMessages) {
                 $entitiesByModule[$module] = array_merge(
-                    $existingMessages,
-                    $messages
+                    $messages,
+                    $existingMessages
                 );
             }
         }


### PR DESCRIPTION
When collecting new texts via i18nTextCollector, get var "merge" was used to skip already collected texts and only append new ones. That's how it worked in CMS3.

Problem is, in CMS4, this is not the case. Even with get var defined, text collector was overwriting translations in yaml files with default values found in classes and templates.

Debugging showed that problem was in single array_merge function:

> Merges the elements of one or more arrays together so that the values of one are appended to the end of the previous one. It returns the resulting array.
> 
> **If the input arrays have the same string keys, then the later value for that key will overwrite the previous one.** If, however, the arrays contain numeric keys, the later value will not overwrite the original value, but will be appended.

Simply reordering parameters in same call reverted to expected functionality - leave existing translations in place, just adding new.