### PR TITLE
Remove fork of mock-objects, update phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,7 @@
         "ext-xml": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "7.1.3",
-        "sminnee/phpunit-mock-objects": "^3.4.5",
+        "phpunit/phpunit": "^7.5",
         "silverstripe/versioned": "^2"
     },
     "provide": {

--- a/src/Dev/CsvBulkLoader.php
+++ b/src/Dev/CsvBulkLoader.php
@@ -77,7 +77,7 @@ class CsvBulkLoader extends BulkLoader
             $filepath = Director::getAbsFile($filepath);
             $csvReader = Reader::createFromPath($filepath, 'r');
             $csvReader->setDelimiter($this->delimiter);
-            $csvReader->stripBom(true);
+            $csvReader->skipInputBOM();
 
             $tabExtractor = function ($row) {
                 foreach ($row as &$item) {

--- a/tests/php/ORM/DataObjectTest.yml
+++ b/tests/php/ORM/DataObjectTest.yml
@@ -49,7 +49,7 @@ SilverStripe\ORM\Tests\DataObjectTest\Player:
   captain1:
     FirstName: Captain
     Surname: Zookeeper
-    ShirtNumber: 007
+    ShirtNumber: '007'
     FavouriteTeam: =>SilverStripe\ORM\Tests\DataObjectTest\Team.team1
     Teams: =>SilverStripe\ORM\Tests\DataObjectTest\Team.team1
     FoundingTeams: =>SilverStripe\ORM\Tests\DataObjectTest\Team.team1


### PR DESCRIPTION
Also includes a fix for an API change in stripping BOM characters from CSVs in the league/csv package we use, and quote a fixtured number which should be treated as a string so PHPUnit compares it as such.

According to Composer, the mock-objects fork is no longer installable, so I've removed it. I've updated PHPUnit to 7.5 at the same time, since the int with leading zero comparison issue (which is why we locked it at 7.1.3) is no longer a problem when quoting it.

Previous build failure after merging up: https://travis-ci.org/silverstripe/silverstripe-framework/builds/638558700