### PR TITLE
Docs: Fix route that doesn't exist

### DIFF
--- a/docs/en/02_Developer_Guides/02_Controllers/05_Middlewares.md
+++ b/docs/en/02_Developer_Guides/02_Controllers/05_Middlewares.md
@@ -120,5 +120,5 @@ SilverStripe\Control\Director:
 
 ## API Documentation
 
-* [Built-in Middleware](./06_Builtin_Middlewares.md)
+* [Built-in Middleware](/developer_guides/controllers/builtin_middlewares)
 * [HTTPMiddleware](api:SilverStripe\Control\Middleware\HTTPMiddleware)


### PR DESCRIPTION
Fix link to Built-in Middleware not found.