### PR TITLE
BUGFIX: Fixed issue where TimeField_Readonly would only show "(not set)"

### DIFF
--- a/src/Forms/TimeField.php
+++ b/src/Forms/TimeField.php
@@ -373,6 +373,14 @@ class TimeField extends TextField
     {
         /** @var TimeField_Readonly $result */
         $result = $this->castedCopy(TimeField_Readonly::class);
+        $result
+            ->setValue(false)
+            ->setHTML5($this->html5)
+            ->setTimeFormat($this->timeFormat)
+            ->setTimezone($this->getTimezone())
+            ->setLocale($this->locale)
+            ->setTimeLength($this->timeLength)
+            ->setValue($this->value);
         return $result;
     }
 

--- a/src/Forms/TimeField_Readonly.php
+++ b/src/Forms/TimeField_Readonly.php
@@ -9,18 +9,11 @@ use SilverStripe\Core\Convert;
  */
 class TimeField_Readonly extends TimeField
 {
-
     protected $readonly = true;
-
-    public function Field($properties = array())
+    protected $disabled = true;
+    
+    public function Type()
     {
-        if ($this->valueObj) {
-            $val = Convert::raw2xml($this->valueObj->toString($this->getConfig('timeformat')));
-        } else {
-            // TODO Localization
-            $val = '<i>(not set)</i>';
-        }
-
-        return "<span class=\"readonly\" id=\"" . $this->ID() . "\">$val</span>";
+        return 'readonly';
     }
 }

--- a/tests/php/Forms/TimeFieldReadonlyTest.php
+++ b/tests/php/Forms/TimeFieldReadonlyTest.php
@@ -1,0 +1,46 @@
+<?php
+namespace SilverStripe\Forms;
+
+use IntlDateFormatter;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\TimeField;
+use SilverStripe\Forms\TimeField_Readonly;
+use SilverStripe\i18n\i18n;
+
+class TimeFieldReadonlyTest extends SapphireTest
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        i18n::set_locale('en_NZ');
+    }
+    
+    public function testPerformReadonly()
+    {
+        $field = new TimeField('Time', 'Time', '23:00:00');
+        $roField = $field->performReadonlyTransformation();
+        $this->assertInstanceOf(TimeField_Readonly::class, $roField);
+        
+        $this->assertTrue($roField->isReadonly());
+        $this->assertEquals($roField->dataValue(), '23:00:00');
+    }
+    
+    public function testSettingsCarryOver()
+    {
+        $field = new TimeField('Time', 'Time');
+        $field
+            ->setHTML5(false)
+            ->setTimeFormat('KK:mma')
+            ->setTimezone('America/Halifax')
+            ->setLocale('en_US')
+            ->setTimeLength(IntlDateFormatter::SHORT)
+            ->setValue('23:00:00');
+        
+        $roField = $field->performReadonlyTransformation();
+        $this->assertFalse($roField->getHTML5());
+        $this->assertEquals($roField->getTimeFormat(), 'KK:mma');
+        $this->assertEquals($roField->getTimezone(), 'America/Halifax');
+        $this->assertEquals($roField->getLocale(), 'en_US');
+        $this->assertEquals($roField->getTimeLength(), IntlDateFormatter::SHORT);
+    }
+}


### PR DESCRIPTION
When using a `TimeField` in a form and either the form is made readonly or the field itself is made readonly the created `TimeField_Readonly` instance will only show `(not set)` due to `$this->valueObj` not being defined or used in the `TimeField` class.

This pull request changes the `TimeField_Readonly` class to use the output of `TimeField::Value()` as the value displayed. It also passes through the values of some of the `TimeField` specific properties so it appears closer to what the `TimeField` would.

This issue was observed under 4.5 but also affects 4.4 (and likely prior) as the 4,4 version of the file has not changed between the two.