### PR TITLE
DOCS: Update GridFieldCustomAction boilerplate

### DIFF
--- a/docs/en/02_Developer_Guides/03_Forms/How_Tos/04_Create_a_GridField_ActionProvider.md
+++ b/docs/en/02_Developer_Guides/03_Forms/How_Tos/04_Create_a_GridField_ActionProvider.md
@@ -203,7 +203,9 @@ class GridFieldCustomAction implements GridField_ColumnProvider, GridField_Actio
             'Custom action',
             "docustomaction",
             ['RecordID' => $record->ID]
-         );
+         )->addExtraClass(
+            'action-menu--handled'
+        )->setAttribute('classNames', 'font-icon-universal-access'); //replace with class of icon you'd like to show in menu
     }
     
     public function getExtraData($gridField, $record, $columnName)


### PR DESCRIPTION
Update Basic GridFieldCustomAction boilerplate so that Action is not shown twice and has an icon in CMS.

When using the Basic GridFieldCustomAction boilerplate implementing GridField_ActionMenuItem boilerplate, the custom action is shown twice, once in the GridField_ActionMenuItem and then again on the side. It also will not have an icon.

This just updates the boilerplate so its clearer on what needs to be done in code to show the custom action only in the dropdown actionmenu which is a cleaner UI.

You can see the difference with the current boilerplate and then what happens with the proposed changes in the attached images:
<img width="450" alt="Before" src="https://user-images.githubusercontent.com/38059212/73037555-93e3e980-3ea3-11ea-8eff-54731ebf7537.PNG">

<img width="309" alt="After" src="https://user-images.githubusercontent.com/38059212/73037576-a827e680-3ea3-11ea-885d-5ce766c72635.PNG">



