### PR TITLE
Docs: Fix link to Middleware not found

### DIFF
--- a/docs/en/02_Developer_Guides/09_Security/05_Rate_Limiting.md
+++ b/docs/en/02_Developer_Guides/09_Security/05_Rate_Limiting.md
@@ -6,7 +6,7 @@ icon: tachometer-alt
 
 # Rate Limiting
 
-SilverStripe Framework comes with a [Middleware](developer_guides/controllers/middlewares/) that provides rate limiting
+SilverStripe Framework comes with a [Middleware](../controllers/middlewares/) that provides rate limiting
 for the Security controller. This provides added protection to a potentially vulnerable part of a SilverStripe application
 where an attacker is free to bombard your login forms or other Security endpoints.
 


### PR DESCRIPTION
- Fix link to Middleware not found in page Rate Limiting
