### PR TITLE
Updated the "Template Syntax" Documentation

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/01_Syntax.md
+++ b/docs/en/02_Developer_Guides/01_Templates/01_Syntax.md
@@ -94,6 +94,10 @@ If a variable returns a string, that string will be inserted into the template. 
 the system will attempt to render the object through its `forTemplate()` method. If the `forTemplate()` method has not 
 been defined, the system will return an error.
 
+[notice]
+If you wish to pass parameters to getter functions, you must use the full method name, e.g. $getThing('param'). Also, parameters must be literals, and cannot be other template variables (`$getThing($variable)` will not work)
+[/notice]
+
 [note]
 For more detail around how variables are inserted and formatted into a template see 
 [Formating, Modifying and Casting Variables](casting)


### PR DESCRIPTION
Added a notice to the "Variables" section of the "Template Syntax" documentation to warn developers about common template variable gotchas.


I discussed this documentation change with null, firesphere and nightjarnz over on slack. Unfortunately the archives seem to be down so I cannot link to it :(