### PR TITLE
FIX Update ORM DBField types to use Injector in scaffoldFormField()

### DIFF
--- a/src/ORM/FieldType/DBBoolean.php
+++ b/src/ORM/FieldType/DBBoolean.php
@@ -56,7 +56,7 @@ class DBBoolean extends DBField
 
     public function scaffoldFormField($title = null, $params = null)
     {
-        return new CheckboxField($this->name, $title);
+        return CheckboxField::create($this->name, $title);
     }
 
     public function scaffoldSearchField($title = null)

--- a/src/ORM/FieldType/DBHTMLText.php
+++ b/src/ORM/FieldType/DBHTMLText.php
@@ -203,7 +203,7 @@ class DBHTMLText extends DBText
 
     public function scaffoldFormField($title = null, $params = null)
     {
-        return new HTMLEditorField($this->name, $title);
+        return HTMLEditorField::create($this->name, $title);
     }
 
     public function scaffoldSearchField($title = null)

--- a/src/ORM/FieldType/DBInt.php
+++ b/src/ORM/FieldType/DBInt.php
@@ -58,7 +58,7 @@ class DBInt extends DBField
 
     public function scaffoldFormField($title = null, $params = null)
     {
-        return new NumericField($this->name, $title);
+        return NumericField::create($this->name, $title);
     }
 
     public function nullValue()

--- a/src/ORM/FieldType/DBText.php
+++ b/src/ORM/FieldType/DBText.php
@@ -246,10 +246,10 @@ class DBText extends DBString
     {
         if (!$this->nullifyEmpty) {
             // Allow the user to select if it's null instead of automatically assuming empty string is
-            return new NullableField(new TextareaField($this->name, $title));
+            return NullableField::create(TextareaField::create($this->name, $title));
         } else {
             // Automatically determine null (empty string)
-            return new TextareaField($this->name, $title);
+            return TextareaField::create($this->name, $title);
         }
     }
 

--- a/src/ORM/FieldType/DBYear.php
+++ b/src/ORM/FieldType/DBYear.php
@@ -20,7 +20,7 @@ class DBYear extends DBField
 
     public function scaffoldFormField($title = null, $params = null)
     {
-        $selectBox = new DropdownField($this->name, $title);
+        $selectBox = DropdownField::create($this->name, $title);
         $selectBox->setSource($this->getDefaultOptions());
         return $selectBox;
     }


### PR DESCRIPTION
- This is usable in cases where a DBField is needed to be overloaded through the Injector.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
