### PR TITLE
CMS default fields removal configuration

### DIFF
--- a/src/Forms/DefaultCmsFields/Extension.php
+++ b/src/Forms/DefaultCmsFields/Extension.php
@@ -23,23 +23,23 @@ use SilverStripe\ORM\DataObject;
  *    extensions:
  *      defaultFields: SilverStripe\Forms\DefaultCmsFields\Extension
  *      field_removal:
- *        db-keep: # remove all db fields except Title and ShowTitle
+ *        - # remove all db fields except Title and ShowTitle
  *          property: db
  *          type: keep
  *          fields:
  *            Title: true
  *            ShowTitle: true
- *        has-one-keep: # remove all has_one fields
+ *        - # remove all has_one fields
  *          property: has_one
  *          type: keep
- *        many-many-remove: # remove LinkTracking, FileTracking and BackLinkTracking fields from many_many
+ *        - # remove LinkTracking, FileTracking and BackLinkTracking fields from many_many
  *          property: many_many
  *          type: remove
  *          fields:
  *            LinkTracking: true
  *            FileTracking: true
  *            BackLinkTracking: true
- *        extra-remove: # remove Settings field (not part of any static property)
+ *        - # remove Settings field (not part of any static property)
  *          property: extra
  *          fields:
  *            Settings: true

--- a/src/Forms/DefaultCmsFields/Extension.php
+++ b/src/Forms/DefaultCmsFields/Extension.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace SilverStripe\Forms\DefaultCmsFields;
+
+use SilverStripe\Forms\FieldList;
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * Class Extension
+ *
+ * Removal of scaffolded fields
+ * this is useful for project setup where scaffolded fields are not needed
+ * there are various options on how to remove scaffolded fields
+ *
+ * Note that this extension needs to be applied manually and order matters
+ * you want to apply this extension after all scaffolded fields are present nut before your model level
+ * fields customisation
+ *
+ * example config
+ *
+ *  DNADesign\Elemental\Models\BaseElement:
+ *    extensions:
+ *      defaultFields: SilverStripe\Forms\DefaultCmsFields\Extension
+ *      field_removal:
+ *        db-keep: # remove all db fields except Title and ShowTitle
+ *          property: db
+ *          type: keep
+ *          fields:
+ *            Title: true
+ *            ShowTitle: true
+ *        has-one-keep: # remove all has_one fields
+ *          property: has_one
+ *          type: keep
+ *        many-many-remove: # remove LinkTracking, FileTracking and BackLinkTracking fields from many_many
+ *          property: many_many
+ *          type: remove
+ *          fields:
+ *            LinkTracking: true
+ *            FileTracking: true
+ *            BackLinkTracking: true
+ *        extra-remove: # remove Settings field (not part of any static property)
+ *          property: extra
+ *          fields:
+ *            Settings: true
+ *
+ * @property DataObject $owner
+ * @package SilverStripe\Forms\DefaultCmsFields
+ */
+class Extension extends DataExtension
+{
+    const TYPE_KEEP = 'keep';
+    const TYPE_REMOVE = 'remove';
+
+    /**
+     * Specify which default fields need to be kept and which should be removed
+     * configuration is a collection of rules
+     * each rules has consist of the following
+     * - property (db, has_one, has_many, many_many or extra)
+     * - type (keep or remove), this is not required when extra property is used
+     * - fields (FieldName => Active) list of fields that the configuration applies to
+     *
+     * @config
+     * @var array
+     */
+    private static $field_removal = [];
+
+    /**
+     * Extension point in @see DataObject::getCMSFields()
+     *
+     * @param FieldList $fields
+     */
+    public function updateCMSFields(FieldList $fields)
+    {
+        $this->removeFields($fields);
+    }
+
+    /**
+     * @param FieldList $fields
+     */
+    private function removeFields(FieldList $fields)
+    {
+        $rules = $this->owner->config()->get('field_removal');
+
+        if (!is_array($rules)) {
+            return;
+        }
+
+        foreach ($rules as $rule) {
+            if (!$this->validateRule($rule)) {
+                continue;
+            }
+
+            $property = $rule['property'];
+            $list = array_key_exists('fields', $rule) ? $rule['fields'] : [];
+            $list = is_array($list) ? $list : [];
+
+            if ($property === 'extra') {
+                $this->removeExtraFields($list, $fields);
+
+                continue;
+            }
+
+            $type = $rule['type'];
+            $this->removeDbFields($property, $type, $list, $fields);
+        }
+    }
+
+    /**
+     * @param $property
+     * @param $type
+     * @param array $list
+     * @param FieldList $fields
+     */
+    private function removeDbFields($property, $type, array $list, FieldList $fields)
+    {
+        $config = $this->owner->config()->get($property);
+
+        if (!is_array($config)) {
+            return;
+        }
+
+        $fieldsToRemove = array_keys($config);
+
+        foreach ($fieldsToRemove as $fieldName) {
+            $active = array_key_exists($fieldName, $list) && $list[$fieldName];
+            $keep = $type === self::TYPE_KEEP && $active || $type === self::TYPE_REMOVE && !$active;
+
+            if ($keep) {
+                continue;
+            }
+
+            if ($property === 'has_one') {
+                $fields->removeByName($fieldName . 'ID');
+            }
+
+            $fields->removeByName($fieldName);
+        }
+    }
+
+    /**
+     * @param array $list
+     * @param FieldList $fields
+     */
+    private function removeExtraFields(array $list, FieldList $fields)
+    {
+        foreach ($list as $fieldName => $active) {
+            if (!$active) {
+                continue;
+            }
+
+            $fields->removeByName($fieldName);
+        }
+    }
+
+    /**
+     * @param mixed $rule
+     * @return bool
+     */
+    private function validateRule($rule)
+    {
+        if (!is_array($rule)) {
+            return false;
+        }
+
+        if (!array_key_exists('property', $rule)) {
+            return false;
+        }
+
+        $property = $rule['property'];
+
+        if ($property === 'extra') {
+            return true;
+        }
+
+        if (!in_array($property, ['db', 'has_one', 'has_many', 'many_many'])) {
+            return false;
+        }
+
+        if (!in_array($rule['type'], [self::TYPE_KEEP, self::TYPE_REMOVE])) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/php/Forms/DefaultCmsFields/Entrance.php
+++ b/tests/php/Forms/DefaultCmsFields/Entrance.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\DefaultCmsFields;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * Class Entrance
+ *
+ * @property string $Title
+ * @method House House()
+ * @package SilverStripe\Forms\Tests\DefaultCmsFields
+ */
+class Entrance extends DataObject implements TestOnly
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'TestEntrance';
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'Title' => 'Varchar',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $belongs_to = [
+        'House' => House::class . '.Entrance',
+    ];
+}

--- a/tests/php/Forms/DefaultCmsFields/ExtensionTest.php
+++ b/tests/php/Forms/DefaultCmsFields/ExtensionTest.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\DefaultCmsFields;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\DefaultCmsFields\Extension;
+
+class ExtensionTest extends SapphireTest
+{
+    /**
+     * @var string
+     */
+    protected static $fixture_file = 'ExtensionTest.yml';
+
+    /**
+     * @var array
+     */
+    protected static $extra_dataobjects = [
+        Entrance::class,
+        House::class,
+    ];
+
+    /**
+     * @var array
+     */
+    protected static $required_extensions = [
+        House::class => [
+            Extension::class,
+        ]
+    ];
+
+    /**
+     * @param array $expected
+     * @dataProvider fieldsProvider
+     */
+    public function testCmsFields(array $config, array $expected)
+    {
+        Config::modify()->set(House::class, 'field_removal', $config);
+
+        /** @var House $house */
+        $house = $this->objFromFixture(House::class, 'house1');
+
+        $fields = $house->getCMSFields();
+        $tab = $fields->findOrMakeTab('Root.Main');
+
+        foreach ($expected as $fieldName => $present) {
+            $field = $tab->fieldByName($fieldName);
+
+            if ($present) {
+                $this->assertNotNull($field);
+
+                continue;
+            }
+
+            $this->assertNull($field);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function fieldsProvider()
+    {
+        return [
+            [
+                [],
+                [
+                    'Title' => true,
+                    'Address' => true,
+                    'EntranceID' => true,
+                    'Image' => true,
+                ],
+            ],
+            [
+                [
+                    [
+                        'property' => 'db',
+                        'type' => Extension::TYPE_KEEP,
+                        'fields' => [
+                            'Title' => true,
+                            'Address' => false,
+                        ],
+                    ],
+                ],
+                [
+                    'Title' => true,
+                    'Address' => false,
+                    'EntranceID' => true,
+                    'Image' => true,
+                ],
+            ],
+            [
+                [
+                    [
+                        'property' => 'db',
+                        'type' => Extension::TYPE_KEEP,
+                        'fields' => [
+                            'Title' => true,
+                        ],
+                    ],
+                ],
+                [
+                    'Title' => true,
+                    'Address' => false,
+                    'EntranceID' => true,
+                    'Image' => true,
+                ],
+            ],
+            [
+                [
+                    [
+                        'property' => 'db',
+                        'type' => Extension::TYPE_KEEP,
+                    ],
+                ],
+                [
+                    'Title' => false,
+                    'Address' => false,
+                    'EntranceID' => true,
+                    'Image' => true,
+                ],
+            ],
+            [
+                [
+                    [
+                        'property' => 'db',
+                        'type' => Extension::TYPE_REMOVE,
+                        'fields' => [
+                            'Title' => true,
+                            'Address' => false,
+                        ],
+                    ],
+                ],
+                [
+                    'Title' => false,
+                    'Address' => true,
+                    'EntranceID' => true,
+                    'Image' => true,
+                ],
+            ],
+            [
+                [
+                    [
+                        'property' => 'db',
+                        'type' => Extension::TYPE_REMOVE,
+                        'fields' => [
+                            'Title' => true,
+                        ],
+                    ],
+                ],
+                [
+                    'Title' => false,
+                    'Address' => true,
+                    'EntranceID' => true,
+                    'Image' => true,
+                ],
+            ],
+            [
+                [
+                    [
+                        'property' => 'db',
+                        'type' => Extension::TYPE_REMOVE,
+                    ],
+                ],
+                [
+                    'Title' => true,
+                    'Address' => true,
+                    'EntranceID' => true,
+                    'Image' => true,
+                ],
+            ],
+            [
+                [
+                    [
+                        'property' => 'has_one',
+                        'type' => Extension::TYPE_KEEP,
+                    ],
+                ],
+                [
+                    'Title' => true,
+                    'Address' => true,
+                    'EntranceID' => false,
+                    'Image' => false,
+                ],
+            ],
+            [
+                [
+                    [
+                        'property' => 'has_one',
+                        'type' => Extension::TYPE_KEEP,
+                        'fields' => [
+                            'Entrance' => true,
+                        ],
+                    ],
+                ],
+                [
+                    'Title' => true,
+                    'Address' => true,
+                    'EntranceID' => true,
+                    'Image' => false,
+                ],
+            ],
+            [
+                [
+                    [
+                        'property' => 'has_one',
+                        'type' => Extension::TYPE_REMOVE,
+                        'fields' => [
+                            'Image' => true,
+                        ],
+                    ],
+                ],
+                [
+                    'Title' => true,
+                    'Address' => true,
+                    'EntranceID' => true,
+                    'Image' => false,
+                ],
+            ],
+            [
+                [
+                    [
+                        'property' => 'extra',
+                        'fields' => [
+                            'Address' => true,
+                            'Entrance' => true,
+                        ],
+                    ],
+                ],
+                [
+                    'Title' => true,
+                    'Address' => false,
+                    'EntranceID' => true,
+                    'Image' => true,
+                ],
+            ],
+            [
+                [
+                    [
+                        'property' => 'extra',
+                        'fields' => [
+                            'Address' => true,
+                            'EntranceID' => true,
+                        ],
+                    ],
+                ],
+                [
+                    'Title' => true,
+                    'Address' => false,
+                    'EntranceID' => false,
+                    'Image' => true,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/php/Forms/DefaultCmsFields/ExtensionTest.yml
+++ b/tests/php/Forms/DefaultCmsFields/ExtensionTest.yml
@@ -1,0 +1,9 @@
+SilverStripe\Forms\Tests\DefaultCmsFields\Entrance:
+  entrance1:
+    Title: Entrance1
+
+SilverStripe\Forms\Tests\DefaultCmsFields\House:
+  house1:
+    Title: House1
+    Address: Address1
+    EntranceID: =>SilverStripe\Forms\Tests\DefaultCmsFields\Entrance.entrance1

--- a/tests/php/Forms/DefaultCmsFields/House.php
+++ b/tests/php/Forms/DefaultCmsFields/House.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\DefaultCmsFields;
+
+use SilverStripe\Assets\Image;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * Class House
+ *
+ * @property string $Title
+ * @property string $Address
+ * @property int $EntranceID
+ * @property int $ImageID
+ * @method Entrance Entrance()
+ * @method Image Image()
+ * @package SilverStripe\Forms\Tests\DefaultCmsFields
+ */
+class House extends DataObject implements TestOnly
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'TestHouse';
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'Title' => 'Varchar',
+        'Address' => 'Varchar',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $has_one = [
+        'Image' => Image::class,
+        'Entrance' => Entrance::class,
+    ];
+}


### PR DESCRIPTION
# CMS default fields

Scaffolded fields are nice for a quick project startups but are often hindrance as these fields make customisation of CMS fields more complex. Most notable cases are:

* customising existing scaffolded field takes more lines of code compared to defining it from scratch
* customising field order takes more lines of code compared to defining it from scratch

In many cases it's preferable to simply remove these scaffolded fields and redefine them in the model. As a result field definition is more readable as all fields are defined in one place. The code is also easier to maintain as we don't have to be concerned on where in the `FieldList` the scaffolded fields are located.

## Configure which scaffolded fields are kept and which are removed

I couldn't avoid creating scaffolded fields as there are many code dependencies which assume scaffolded fields will be there. This new extension allows configurable removal of scaffolded fields. The moment of removal is also configurable as this extension is not applied by default, it has to be applied manually.

## Compatibility

This feature is disabled by default to enable it you have to:

* apply extension to a data object
* provide field removal configuration (empty configuration does nothing)

## Related issues

https://github.com/silverstripe/silverstripe-framework/issues/9403