### PR TITLE
Add ClassInfo method to get all classes with a given extension applied

### DIFF
--- a/src/Core/ClassInfo.php
+++ b/src/Core/ClassInfo.php
@@ -560,4 +560,40 @@ class ClassInfo
         static::$_cache_parse[$classSpec] = $result;
         return $result;
     }
+
+    /**
+     * Returns a list of classes with a particular extension applied
+     *
+     * This reflects all extensions added (or removed) both via the configuration API as well as dynamically
+     * using Extensible::add_extension() and Extensible::remove_extension().
+     *
+     * @param string $extensionClass        Extension class name
+     * @param string $baseClassOrObject     Class or object to find subclasses of with the extension applied
+     * @param bool $includeBaseClass        Include the base class itself if it has the extension applied?
+     * @return string[] Class names with the extension applied
+     * @throws \ReflectionException
+     */
+    public static function classesWithExtension(
+        string $extensionClass,
+        string $baseClassOrObject = DataObject::class,
+        bool $includeBaseClass = false
+    ): array {
+        // get class names
+        $baseClass = self::class_name($baseClassOrObject);
+
+        // get a list of all subclasses for a given class
+        $classes = ClassInfo::subclassesFor($baseClass, $includeBaseClass);
+
+        // include the base class if required
+        if ($includeBaseClass) {
+            $classes = array_merge([strtolower($baseClass) => $baseClass], $classes);
+        }
+
+        // only keep classes with the Extension applied
+        $classes = array_filter($classes, function ($class) use ($extensionClass) {
+            return Extensible::has_extension($class, $extensionClass);
+        });
+
+        return $classes;
+    }
 }

--- a/tests/php/Core/ClassInfoTest/BaseObject.php
+++ b/tests/php/Core/ClassInfoTest/BaseObject.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Core\Tests\ClassInfoTest;
+
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Extensible;
+use SilverStripe\Dev\TestOnly;
+
+class BaseObject implements TestOnly
+{
+    use Configurable;
+    use Extensible;
+}

--- a/tests/php/Core/ClassInfoTest/ExtendTest.php
+++ b/tests/php/Core/ClassInfoTest/ExtendTest.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SilverStripe\Core\Tests\ClassInfoTest;
+
+class ExtendTest extends BaseObject
+{
+    private static $extensions = [
+        ExtensionTest1::class,
+    ];
+}

--- a/tests/php/Core/ClassInfoTest/ExtendTest2.php
+++ b/tests/php/Core/ClassInfoTest/ExtendTest2.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace SilverStripe\Core\Tests\ClassInfoTest;
+
+class ExtendTest2 extends ExtendTest
+{
+}

--- a/tests/php/Core/ClassInfoTest/ExtendTest3.php
+++ b/tests/php/Core/ClassInfoTest/ExtendTest3.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace SilverStripe\Core\Tests\ClassInfoTest;
+
+class ExtendTest3 extends ExtendTest2
+{
+}

--- a/tests/php/Core/ClassInfoTest/ExtensionTest1.php
+++ b/tests/php/Core/ClassInfoTest/ExtensionTest1.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SilverStripe\Core\Tests\ClassInfoTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class ExtensionTest1 extends Extension implements TestOnly
+{
+}

--- a/tests/php/Core/ClassInfoTest/ExtensionTest2.php
+++ b/tests/php/Core/ClassInfoTest/ExtensionTest2.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace SilverStripe\Core\Tests\ClassInfoTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class ExtensionTest2 extends Extension implements TestOnly
+{
+}


### PR DESCRIPTION
Adding a simple method to list all classes (subclasses of a given class) that had a given extension applied.

Classes inheriting from the class having the extension applied are added to the mix as the code has access to the methods there.

Optionally, the base class can be added to the mix if it has the extension applied too.

Classes implementing TestOnly interface are excluded by default.