### PR TITLE
Remove FormField non-scalar attributes support

### DIFF
--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -742,12 +742,6 @@ class FormField extends RequestHandler
         foreach ($attributes as $name => $value) {
             if ($value === true) {
                 $value = $name;
-            } else {
-                if (is_scalar($value)) {
-                    $value = (string) $value;
-                } else {
-                    $value = json_encode($value);
-                }
             }
 
             $parts[] = sprintf('%s="%s"', Convert::raw2att($name), Convert::raw2att($value));

--- a/tests/php/Forms/FormFieldTest.php
+++ b/tests/php/Forms/FormFieldTest.php
@@ -201,46 +201,18 @@ class FormFieldTest extends SapphireTest
         $this->assertStringContainsString('three="3"', $field->getAttributesHTML('one', 'two'));
     }
 
-    /**
-     * Covering all potential inputs for Convert::raw2xml
-     */
-    public function escapeHtmlDataProvider()
+    public function testGetAttributesEscapeHtml()
     {
-        return [
-            ['<html>'],
-            [['<html>']],
-            [['<html>' => '<html>']]
-        ];
-    }
-
-    /**
-     * @dataProvider escapeHtmlDataProvider
-     **/
-    public function testGetAttributesEscapeHtml($value)
-    {
-        $key = bin2hex(random_bytes(4));
-
-        if (is_scalar($value)) {
-            $field = new FormField('<html>', '<html>', '<html>');
-            $field->setAttribute($value, $key);
-            $html = $field->getAttributesHTML();
-            $this->assertFalse(strpos($html, '<html>'));
-        }
-
         $field = new FormField('<html>', '<html>', '<html>');
-        $field->setAttribute($key, $value);
+        $field->setAttribute('<html>', '<html>');
         $html = $field->getAttributesHTML();
-
         $this->assertFalse(strpos($html, '<html>'));
     }
 
-    /**
-     * @dataProvider escapeHtmlDataProvider
-     */
-    public function testDebugEscapeHtml($value)
+    public function testDebugEscapeHtml()
     {
         $field = new FormField('<html>', '<html>', '<html>');
-        $field->setAttribute('<html>', $value);
+        $field->setAttribute('<html>', '<html>');
         $field->setMessage('<html>', null, ValidationResult::CAST_HTML);
 
         $html = $field->debug();


### PR DESCRIPTION
This patch removes support for non-scalar attributes and as such simplifies the functionality provided by the FormField component.
Where users wish to use non-scalar values (or names) for attributes, they should implement appropriate serialization for those values on the application level.

This PR is a follow up on the [discussion](https://github.com/silverstripe-security/security-issues/issues/65) happened while resolving the security issue [CVE-2019-19325](https://www.silverstripe.org/download/security-releases/CVE-2019-19325/)