### PR TITLE
FIX: Stop Member->write() being called two times unnecessarily during login

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -476,11 +476,11 @@ class Member extends DataObject
     public function afterMemberLoggedIn()
     {
         // Clear the incorrect log-in count
-        $this->registerSuccessfulLogin();
+        $this->registerSuccessfulLogin(false);
 
         $this->LockedOutUntil = null;
 
-        $this->regenerateTempID();
+        $this->regenerateTempID(false);
 
         $this->write();
 
@@ -493,8 +493,10 @@ class Member extends DataObject
      *
      * This should be performed any time the user presents their normal identification (normally Email)
      * and is successfully authenticated.
+     *
+     * @param bool $write Whether this method should persist the Member object to the database or not
      */
-    public function regenerateTempID()
+    public function regenerateTempID($write = true)
     {
         $generator = new RandomGenerator();
         $lifetime = self::config()->get('temp_id_lifetime');
@@ -502,7 +504,10 @@ class Member extends DataObject
         $this->TempIDExpired = $lifetime
             ? date('Y-m-d H:i:s', strtotime(DBDatetime::now()->getValue()) + $lifetime)
             : null;
-        $this->write();
+
+        if ($write) {
+            $this->write();
+        }
     }
 
     /**
@@ -1802,14 +1807,19 @@ class Member extends DataObject
 
     /**
      * Tell this member that a successful login has been made
+     *
+     * @param bool $write Whether this method should persist the Member object to the database or not
      */
-    public function registerSuccessfulLogin()
+    public function registerSuccessfulLogin($write = true)
     {
         if (self::config()->get('lock_out_after_incorrect_logins')) {
             // Forgive all past login failures
             $this->FailedLoginCount = 0;
             $this->LockedOutUntil = null;
-            $this->write();
+
+            if ($write) {
+                $this->write();
+            }
         }
     }
 

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -496,7 +496,7 @@ class Member extends DataObject
      *
      * @param bool $write Whether this method should persist the Member object to the database or not
      */
-    public function regenerateTempID($write = true)
+    public function regenerateTempID(bool $write = true)
     {
         $generator = new RandomGenerator();
         $lifetime = self::config()->get('temp_id_lifetime');
@@ -1810,7 +1810,7 @@ class Member extends DataObject
      *
      * @param bool $write Whether this method should persist the Member object to the database or not
      */
-    public function registerSuccessfulLogin($write = true)
+    public function registerSuccessfulLogin(bool $write = true)
     {
         if (self::config()->get('lock_out_after_incorrect_logins')) {
             // Forgive all past login failures


### PR DESCRIPTION
Prior to this patch, `Member->afterMemberLoggedIn()` did the following things:
* Called `registerSuccessfulLogin()` which called `->write()`
* Called `regenerateTempID()` which called `->write()`
* Directly called `->write()` itself

This means that every time a `Member` is considered 'logged in', the member ends up being written to the database 3 times, when only once is necessary.

This wouldn't normally be a particular problem as it normally only happens explicitly when a member logs in via the login form (or at worst, on some random page via the auto-login cookie). However for a site that is protected by Basic Auth (e.g. with `BasicAuthMiddleware`), every single page loads re-authenticates the `Member` and therefore requires 3 additional writes.

This PR doesn't fix the underlying issue of basicauth re-authenticating every page load (which is a bigger patch), but it does remove two unnecessary `->write()` calls on the `Member` object.

I couldn't think of a cleaner way to do this that didn't involve changing method signatures, except for perhaps setting some `private $do_not_write` flag or similar on the `Member` instance. As far as I understand it, this isn't a BC-breaking change as the default for these methods is still to write the `Member` object (unchanged behaviour), but I'm not sure if *any* change to a method signature is considered BC breaking.

I've raised the PR against `4`, but let me know if it should be targeted elsewhere.