### PR TITLE
Form validation should throw ValidationException

### DIFF
--- a/docs/en/02_Developer_Guides/03_Forms/01_Validation.md
+++ b/docs/en/02_Developer_Guides/03_Forms/01_Validation.md
@@ -163,9 +163,9 @@ class Page_Controller extends ContentController
         $check = Member::get()->filter('Email', $data['Email'])->first();
 
         if ($check) {
-            $form->addErrorMessage('Email', 'This email already exists', 'bad');
-
-            return $this->redirectBack();
+            $validationResult = new ValidationResult();
+            $validationResult->addFieldError('Email', 'This email already exists');
+            throw new ValidationException($validationResult);
         }
 
 

--- a/docs/en/02_Developer_Guides/03_Forms/01_Validation.md
+++ b/docs/en/02_Developer_Guides/03_Forms/01_Validation.md
@@ -165,7 +165,9 @@ class Page_Controller extends ContentController
         if ($check) {
             $validationResult = new ValidationResult();
             $validationResult->addFieldError('Email', 'This email already exists');
-            throw new ValidationException($validationResult);
+            $form->setSessionValidationResult($validationResult);
+            $form->setSessionData($form->getData());
+            return $this->redirectBack();
         }
 
 


### PR DESCRIPTION
Method `addErrorMessage()` doesn't exists on the `Form`. Instead of it `ValidationException` should be thrown with the appropriate message or `ValidationResult`.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
