### PR TITLE
Try Catch for embeded media

### DIFF
--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -95,17 +95,16 @@ class EmbedShortcodeProvider implements ShortcodeHandler
             $embed = $embed->getEmbed();
         }
         catch (InvalidUrlException $e) {
+            $message = (Director::isDev()) ? $e->getMessage() : _t(__CLASS__.'.INVALID_URL','There was a problem loading the media.');
+
             $attr = [
                 'class' => 'ss-media-exception embed'
             ];
-            if (Director::isDev()) {
-                $result = HTML::createTag('div', $attr, $e->getMessage());
-                return $result;
-            }
+
             $result = HTML::createTag(
                 'div',
                 $attr,
-                HTML::createTag('p', [], _t(__CLASS__.'.INVALID_URL','There was a problem loading the media.'))
+                HTML::createTag('p', [], $message)
             );
             return $result;
         }

--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -14,7 +14,9 @@ use SilverStripe\View\HTML;
 use SilverStripe\View\Parsers\ShortcodeHandler;
 use Embed\Adapters\Adapter;
 use Embed\Embed;
+use Embed\Exceptions\InvalidUrlException;
 use SilverStripe\View\Parsers\ShortcodeParser;
+use SilverStripe\Control\Director;
 
 /**
  * Provider for the [embed] shortcode tag used by the embedding service
@@ -92,10 +94,10 @@ class EmbedShortcodeProvider implements ShortcodeHandler
         try {
             $embed = $embed->getEmbed();
         }
-        catch(\Embed\Exceptions\InvalidUrlException $e) {
-            $attr = array(
+        catch (InvalidUrlException $e) {
+            $attr = [
                 'class' => 'ss-media-exception embed'
-            );
+            ];
             if (Director::isDev()) {
                 $result = HTML::createTag('div', $attr, $e->getMessage());
                 return $result;
@@ -103,7 +105,7 @@ class EmbedShortcodeProvider implements ShortcodeHandler
             $result = HTML::createTag(
                 'div',
                 $attr,
-                HTML::createTag('p', array(), 'There was a problem loading the media.')
+                HTML::createTag('p', [], _t(__CLASS__.'.INVALID_URL','There was a problem loading the media.'))
             );
             return $result;
         }

--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -89,7 +89,24 @@ class EmbedShortcodeProvider implements ShortcodeHandler
         }
 
         // Process embed
-        $embed = $embed->getEmbed();
+        try {
+            $embed = $embed->getEmbed();
+        }
+        catch(\Embed\Exceptions\InvalidUrlException $e) {
+            $attr = array(
+                'class' => 'ss-media-exception embed'
+            );
+            if (Director::isDev()) {
+                $result = HTML::createTag('div', $attr, $e->getMessage());
+                return $result;
+            }
+            $result = HTML::createTag(
+                'div',
+                $attr,
+                HTML::createTag('p', array(), 'There was a problem loading the media.')
+            );
+            return $result;
+        }
 
         // Convert embed object into HTML
         if ($embed && $embed instanceof Adapter) {

--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -96,7 +96,7 @@ class EmbedShortcodeProvider implements ShortcodeHandler
         } catch (InvalidUrlException $e) {
             $message = (Director::isDev())
                 ? $e->getMessage()
-                : _t(__CLASS__.'.INVALID_URL', 'There was a problem loading the media.');
+                : _t(__CLASS__ . '.INVALID_URL', 'There was a problem loading the media.');
 
             $attr = [
                 'class' => 'ss-media-exception embed'

--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -94,7 +94,7 @@ class EmbedShortcodeProvider implements ShortcodeHandler
         try {
             $embed = $embed->getEmbed();
         } catch (InvalidUrlException $e) {
-            $message = (Director::isDev()) ? $e->getMessage() : _t(__CLASS__.'.INVALID_URL','There was a problem loading the media.');
+            $message = (Director::isDev()) ? $e->getMessage() : _t(__CLASS__.'.INVALID_URL', 'There was a problem loading the media.');
 
             $attr = [
                 'class' => 'ss-media-exception embed'

--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -93,8 +93,7 @@ class EmbedShortcodeProvider implements ShortcodeHandler
         // Process embed
         try {
             $embed = $embed->getEmbed();
-        }
-        catch (InvalidUrlException $e) {
+        } catch (InvalidUrlException $e) {
             $message = (Director::isDev()) ? $e->getMessage() : _t(__CLASS__.'.INVALID_URL','There was a problem loading the media.');
 
             $attr = [

--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -94,7 +94,9 @@ class EmbedShortcodeProvider implements ShortcodeHandler
         try {
             $embed = $embed->getEmbed();
         } catch (InvalidUrlException $e) {
-            $message = (Director::isDev()) ? $e->getMessage() : _t(__CLASS__.'.INVALID_URL', 'There was a problem loading the media.');
+            $message = (Director::isDev())
+                ? $e->getMessage()
+                : _t(__CLASS__.'.INVALID_URL', 'There was a problem loading the media.');
 
             $attr = [
                 'class' => 'ss-media-exception embed'


### PR DESCRIPTION
BUG Embedded media throws E_EMERGENCY error if url returns status codes other than 200.

If a media that is already embedded on the page from a url is removed from the server/url it throws an E_EMERGENCY error that breaks the whole page. Added a try / catch block to EmbedShortcodeProvider.php in function handle_shortcode() that will prevent this and just give a message based on the environment.
Dev environment will display the response message from the url.
Live environment will just display the text 'There was a problem loading the media.'

The text is wrapped in a div that has the class ss-media-exception so it can be styled by admin.