### PR TITLE
Add "option" to list elements that belong to "listbox"

### DIFF
--- a/src/Forms/CheckboxSetField.php
+++ b/src/Forms/CheckboxSetField.php
@@ -90,6 +90,7 @@ class CheckboxSetField extends MultiSelectField
             $options->push(new ArrayData(array(
                 'ID' => $itemID,
                 'Class' => $extraClass,
+                'Role' => 'option',
                 'Name' => "{$this->name}[{$itemValue}]",
                 'Value' => $itemValue,
                 'Title' => $title,

--- a/src/Forms/OptionsetField.php
+++ b/src/Forms/OptionsetField.php
@@ -72,6 +72,7 @@ class OptionsetField extends SingleSelectField
         return new ArrayData(array(
             'ID' => $this->getOptionID($value),
             'Class' => $this->getOptionClass($value, $odd),
+            'Role' => 'option',
             'Name' => $this->getOptionName(),
             'Value' => $value,
             'Title' => $title,

--- a/templates/SilverStripe/Forms/CheckboxSetField.ss
+++ b/templates/SilverStripe/Forms/CheckboxSetField.ss
@@ -1,7 +1,7 @@
 <ul $AttributesHTML>
 	<% if $Options.Count %>
 		<% loop $Options %>
-			<li class="$Class">
+			<li class="$Class" role="$Role">
 				<input id="$ID" class="checkbox" name="$Name" type="checkbox" value="$Value.ATT"<% if $isChecked %> checked="checked"<% end_if %><% if $isDisabled %> disabled="disabled"<% end_if %> />
 				<label for="$ID">$Title</label>
 			</li>

--- a/templates/SilverStripe/Forms/OptionsetField.ss
+++ b/templates/SilverStripe/Forms/OptionsetField.ss
@@ -1,6 +1,6 @@
 <ul $AttributesHTML>
 	<% loop $Options %>
-		<li class="$Class">
+		<li class="$Class" role="$Role">
 			<input id="$ID" class="radio" name="$Name" type="radio" value="$Value"<% if $isChecked %> checked<% end_if %><% if $isDisabled %> disabled<% end_if %> <% if $Up.Required %>required<% end_if %> />
 			<label for="$ID">$Title</label>
 		</li>


### PR DESCRIPTION
The accessibility attribute `role="listbox"` requires its immediate children to be set as `role="option"`, currently they don't contain this attribute, which is causing all automated accessibility tests to fail.

Since the `role="listbox"` is hardcoded into the attributes, I've just added a new entry on the ArrayList for each option that contains a hardcoded value for the attribute.

For a list that does not contain any items, I can see the `role="listbox"` is still being added, but the respective `<li>` which announces that there are no options, does not contain the individual option attributes. I could hardcode the role attribute in the template, but seems to me a better option to check in the code of `CheckboxsetField.php` and `OptionsetField.php` if the list contains any items before setting the "listbox" role to the list, because the warning that there are no options is not really an option in itself.

Please let me know if the above is acceptable, I can work on it as well.

Thanks

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
