### PR TITLE
[DOCS] Update link to reactjs_redux_and_graphql

### DIFF
--- a/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/Extend_CMS_Interface.md
+++ b/docs/en/02_Developer_Guides/15_Customising_the_Admin_Interface/How_Tos/Extend_CMS_Interface.md
@@ -247,7 +247,7 @@ how-to.
 
 ## React-rendered UI
 For sections of the admin that are rendered with React, Redux, and GraphQL, please refer
-to [the introduction on those concepts](../../reactjs_redux_and_graphql/),
+to [the introduction on those concepts](../reactjs_redux_and_graphql/),
 as well as their respective How-To's in this section.
 
 ### Implementing handlers


### PR DESCRIPTION
The link currently goes to a 404, it should only go to the `parent` URLSegment, not the parents' parent.