### PR TITLE
Update MigrationTask class to be an abstract class

### DIFF
--- a/src/Dev/MigrationTask.php
+++ b/src/Dev/MigrationTask.php
@@ -7,16 +7,17 @@ namespace SilverStripe\Dev;
  *
  * <b>Creating Migration Tasks</b>
  *
- * To create your own migration task all you need to do is define your own subclass of MigrationTask and define the
- * following functions
+ * To create your own migration task, you need to define your own subclass of MigrationTask
+ * and implement the following methods
  *
- * <i>mysite/code/MyMigrationTask.php</i>
+ * <i>app/src/MyMigrationTask.php</i>
  *
  * <code>
- * class MyMigrationTask extends BuildTask {
+ * class MyMigrationTask extends MigrationTask {
  *
+ *  private static $segment = 'MyMigrationTask'; // segment in the dev/tasks/ namespace for URL access
  *  protected $title = "My Database Migrations"; // title of the script
- *  protected $description = "Description"; // description of what it does
+ *  protected $description = "My Description"; // description of what it does
  *
  *  public function run($request) {
  *      if ($request->getVar('Direction') == 'down') {
@@ -37,18 +38,19 @@ namespace SilverStripe\Dev;
  * </code>
  *
  * <b>Running Migration Tasks</b>
- * To run any tasks you can find them under the dev/ namespace. To run the above script you would need to run
- * the following and note - Either the site has to be in [devmode](debugging) or you need to add ?isDev=1 to the URL
+ * You can find all tasks under the dev/tasks/ namespace.
+ * To run the above script you would need to run the following and note - Either the site has to be
+ * in [devmode](debugging) or you need to add ?isDev=1 to the URL.
  *
  * <code>
  * // url to visit if in dev mode.
- * http://www.yoursite.com/dev/tasks/MyMigrationTask
+ * https://www.yoursite.com/dev/tasks/MyMigrationTask
  *
- * // url if you are in live mode but need to run this
- * http://www.yoursite.com/dev/tasks/MyMigrationTask?isDev=1
+ * // url to visit if you are in live mode but need to run this
+ * https://www.yoursite.com/dev/tasks/MyMigrationTask?isDev=1
  * </code>
  */
-class MigrationTask extends BuildTask
+abstract class MigrationTask extends BuildTask
 {
 
     private static $segment = 'MigrationTask';


### PR DESCRIPTION
Following on from #9426, making `MigrationTask` class `abstract`.