### PR TITLE
BUGFIX: Ensure diff arrays are one-dimensional

### DIFF
--- a/src/View/Parsers/Diff.php
+++ b/src/View/Parsers/Diff.php
@@ -174,6 +174,7 @@ class Diff extends \Diff
             $content = $content ? "true" : "false";
         }
         if (is_array($content)) {
+            $content = array_filter($content, 'is_scalar');
             // Convert array to CSV
             $content = implode(',', $content);
         }

--- a/tests/php/View/Parsers/DiffTest.php
+++ b/tests/php/View/Parsers/DiffTest.php
@@ -86,6 +86,5 @@ class DiffTest extends SapphireTest
         $actual = Diff::compareHTML($from, $to);
 
         $this->assertRegExp($expected, $actual);
-
     }
 }

--- a/tests/php/View/Parsers/DiffTest.php
+++ b/tests/php/View/Parsers/DiffTest.php
@@ -77,4 +77,15 @@ class DiffTest extends SapphireTest
 
         $this->assertRegExp($expected, $actual);
     }
+
+    public function testDiffArray()
+    {
+        $from = ['Lorem', ['array here please ignore'], 'ipsum dolor'];
+        $to = 'Lorem,ipsum';
+        $expected = "/^Lorem,ipsum *<del>dolor<\/del> *$/";
+        $actual = Diff::compareHTML($from, $to);
+
+        $this->assertRegExp($expected, $actual);
+
+    }
 }


### PR DESCRIPTION
Arrays are supposed to be converted to CSV, but if they're two dimensional, as is sometimes the case with Upload fields, those should be filtered out.