### PR TITLE
FIX Capitalisation fixes in welcome back message

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/02_Common_Variables.md
+++ b/docs/en/02_Developer_Guides/01_Templates/02_Common_Variables.md
@@ -54,7 +54,7 @@ Returns the currently logged in [Member](api:SilverStripe\Security\Member) insta
 
 ```ss
 <% if $CurrentMember %>
-  Welcome Back, $CurrentMember.FirstName
+  Welcome back, $CurrentMember.FirstName
 <% end_if %>
 ```
 

--- a/docs/en/02_Developer_Guides/06_Testing/How_Tos/01_Write_a_FunctionalTest.md
+++ b/docs/en/02_Developer_Guides/06_Testing/How_Tos/01_Write_a_FunctionalTest.md
@@ -44,7 +44,7 @@ class HomePageTest extends FunctionalTest
         $page = $this->get('home/');
 
         $this->assertExactHTMLMatchBySelector("#Welcome", [
-            'Welcome Back'
+            'Welcome back'
         ]);
     }
 }

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -272,7 +272,7 @@ en:
     SURNAME: Surname
     VALIDATIONADMINLOSTACCESS: 'Cannot remove all admin groups from your profile'
     ValidationIdentifierFailed: 'Can''t overwrite existing member #{id} with identical identifier ({name} = {value}))'
-    WELCOMEBACK: 'Welcome Back, {firstname}'
+    WELCOMEBACK: 'Welcome back, {firstname}'
     YOUROLDPASSWORD: 'Your old password'
     belongs_many_many_Groups: Groups
     db_Locale: 'Interface Locale'

--- a/src/Security/MemberAuthenticator/LoginHandler.php
+++ b/src/Security/MemberAuthenticator/LoginHandler.php
@@ -201,7 +201,7 @@ class LoginHandler extends RequestHandler
             // Welcome message
             $message = _t(
                 'SilverStripe\\Security\\Member.WELCOMEBACK',
-                'Welcome Back, {firstname}',
+                'Welcome back, {firstname}',
                 ['firstname' => $member->FirstName]
             );
             Security::singleton()->setSessionMessage($message, ValidationResult::TYPE_GOOD);


### PR DESCRIPTION
"Back" should be "back" since it's not a proper noun or a title


<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->