### PR TITLE
 Remove sminee/phpunit-mock-objects from 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "7.1.3",
-        "sminnee/phpunit-mock-objects": "^3.4.5",
         "silverstripe/versioned": "^2"
     },
     "provide": {


### PR DESCRIPTION
5.x uses phpunit 7 so we don't need this and it's preventing composer installs from completing