### PR TITLE
CSV BOM stripping is now handled internally by league/csv

### DIFF
--- a/src/Dev/CsvBulkLoader.php
+++ b/src/Dev/CsvBulkLoader.php
@@ -77,7 +77,6 @@ class CsvBulkLoader extends BulkLoader
             $filepath = Director::getAbsFile($filepath);
             $csvReader = Reader::createFromPath($filepath, 'r');
             $csvReader->setDelimiter($this->delimiter);
-            $csvReader->stripBom(true);
 
             $tabExtractor = function ($row) {
                 foreach ($row as &$item) {

--- a/tests/php/Control/HTTPRequestTest.php
+++ b/tests/php/Control/HTTPRequestTest.php
@@ -53,7 +53,7 @@ class HTTPRequestTest extends SapphireTest
      * This test just asserts a warning is given if there is more than one wildcard parameter. Note that this isn't an
      * enforcement of an API and we an add new behaviour in the future to allow many wildcard params if we want to
      *
-     * @expectedException \PHPUnit_Framework_Error_Warning
+     * @expectedException \PHPUnit\Framework\Error\Warning
      */
     public function testWildCardWithFurtherParams()
     {


### PR DESCRIPTION
league/csv no longer exposes `stripBom` so we can't use it.

The stripping of BOMs is now handled internally in the library.