### PR TITLE
Bump phpunit version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "ext-xml": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "7.1.3",
+        "phpunit/phpunit": "^8 || ^9",
         "silverstripe/versioned": "^2"
     },
     "provide": {

--- a/docs/en/04_Changelogs/5.0.0.md
+++ b/docs/en/04_Changelogs/5.0.0.md
@@ -23,18 +23,18 @@ guide developers in preparing existing 4.x code for compatibility with 5.0.
 
 ### General {#overview-general}
 
-* Minimum PHP version raised to 7.1
+* Minimum PHP version raised to 7.2
 * Once PHP versions become [unsupported by the PHP Project](http://php.net/supported-versions.php),
   we drop support for those versions in the [next minor release](/contributing/release-process) 
-  This means PHP 7.1 support will become dropped in Dec 2019.
-* Updated PHPUnit from 5.7 to 7.0 (upgrade notes unavailable - @todo).
+  This means PHP 7.2 support will become dropped in Nov 2020.
+* Updated PHPUnit from 5.7 to 8+ (upgrade notes unavailable - @todo).
   Any PHPUnit classes that are referenced directly will need to be updated to support the new PHPUnit
   namespaces. Overloaded PHP methods that originate in PHPUnit classes may need to be updated to support
   new PHP 7 method signatures.
-  You may also need to update your phpunit.xml.dist file to implement the PHPUnit 7.0 schema. See the
+  You may also need to update your phpunit.xml.dist file to implement the PHPUnit 7+ schema. See the
   [SilverStripe installer](https://github.com/silverstripe/silverstripe-installer) for a base template you
   can copy into your project.
-  Run `composer require --dev phpunit/phpunit ^7@dev` on existing projects to pull in the new dependency.
+  Run `composer require --dev phpunit/phpunit ^8` on existing projects to pull in the new dependency.
 * Some of the core SilverStripe methods have begun implementing PHP 7 scalar type hinting and return type
   hints. Wherever your project code overloads methods with new signatures you will need to update them to
   match.

--- a/src/Control/HTTPRequest.php
+++ b/src/Control/HTTPRequest.php
@@ -566,7 +566,10 @@ class HTTPRequest implements ArrayAccess
                 $key = "Controller";
                 if ($varName === '*' || $varName === '@') {
                     if (isset($patternParts[$i + 1])) {
-                        user_error(sprintf('All URL params after wildcard parameter $%s will be ignored', $varName), E_USER_WARNING);
+                        user_error(
+                            sprintf('All URL params after wildcard parameter $%s will be ignored', $varName),
+                            E_USER_WARNING
+                        );
                     }
                     if ($varName === '*') {
                         array_pop($patternParts);

--- a/src/Dev/Constraint/ArraySubset.php
+++ b/src/Dev/Constraint/ArraySubset.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SilverStripe\Dev\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\ExpectationFailedException;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+if (!class_exists(Constraint::class)) {
+    return;
+}
+
+/**
+ * Constraint that asserts that the array it is evaluated for has a specified subset.
+ *
+ * Uses array_replace_recursive() to check if a key value subset is part of the
+ * subject array.
+ *
+ * @codeCoverageIgnore
+ */
+final class ArraySubset extends Constraint
+{
+    /**
+     * @var iterable
+     */
+    private $subset;
+
+    /**
+     * @var bool
+     */
+    private $strict;
+
+    public function __construct(iterable $subset, bool $strict = false)
+    {
+        $this->strict = $strict;
+        $this->subset = $subset;
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other
+     *
+     * If $returnResult is set to false (the default), an exception is thrown
+     * in case of a failure. null is returned otherwise.
+     *
+     * If $returnResult is true, the result of the evaluation is returned as
+     * a boolean value instead: true in case of success, false in case of a
+     * failure.
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public function evaluate($other, string $description = '', bool $returnResult = false)
+    {
+        //type cast $other & $this->subset as an array to allow
+        //support in standard array functions.
+        $other        = $this->toArray($other);
+        $this->subset = $this->toArray($this->subset);
+
+        $patched = \array_replace_recursive($other, $this->subset);
+
+        if ($this->strict) {
+            $result = $other === $patched;
+        } else {
+            $result = $other == $patched;
+        }
+
+        if ($returnResult) {
+            return $result;
+        }
+
+        if (!$result) {
+            $f = new ComparisonFailure(
+                $patched,
+                $other,
+                \var_export($patched, true),
+                \var_export($other, true)
+            );
+
+            $this->fail($other, $description, $f);
+        }
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    public function toString(): string
+    {
+        return 'has the subset ' . $this->exporter()->export($this->subset);
+    }
+
+    /**
+     * Returns the description of the failure
+     *
+     * The beginning of failure messages is "Failed asserting that" in most
+     * cases. This method should return the second part of that sentence.
+     *
+     * @param mixed $other evaluated value or object
+     *
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     */
+    protected function failureDescription($other): string
+    {
+        return 'an array ' . $this->toString();
+    }
+
+    private function toArray(iterable $other): array
+    {
+        if (\is_array($other)) {
+            return $other;
+        }
+
+        if ($other instanceof \ArrayObject) {
+            return $other->getArrayCopy();
+        }
+
+        if ($other instanceof \Traversable) {
+            return \iterator_to_array($other);
+        }
+
+        // Keep BC even if we know that array would not be the expected one
+        return (array) $other;
+    }
+}

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Dev\Constraint;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
+use SebastianBergmann\Exporter\Exporter;
 use SilverStripe\Dev\SSListExporter;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\SS_List;
@@ -25,6 +26,11 @@ class SSListContains extends Constraint implements TestOnly
     protected $matches = [];
 
     /**
+     * @var SSListExporter
+     */
+    private $exporter;
+
+    /**
      * Check if the list has left over items that don't match
      *
      * @var bool
@@ -33,10 +39,16 @@ class SSListContains extends Constraint implements TestOnly
 
     public function __construct($matches)
     {
-        parent::__construct();
-        $this->exporter = new SSListExporter();
-
         $this->matches = $matches;
+    }
+
+    protected function exporter(): Exporter
+    {
+        if ($this->exporter === null) {
+            $this->exporter = new SSListExporter();
+        }
+
+        return $this->exporter;
     }
 
     /**

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -57,7 +57,7 @@ class SSListContains extends Constraint implements TestOnly
      *
      * @throws ExpectationFailedException
      */
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {
         $success = true;
 

--- a/src/Dev/Constraint/SSListContainsOnly.php
+++ b/src/Dev/Constraint/SSListContainsOnly.php
@@ -42,7 +42,7 @@ class SSListContainsOnly extends SSListContains implements TestOnly
      *
      * @throws ExpectationFailedException
      */
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {
         $success = true;
 

--- a/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
+++ b/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Dev\Constraint;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
+use SebastianBergmann\Exporter\Exporter;
 use SilverStripe\Dev\SSListExporter;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\SS_List;
@@ -28,13 +29,24 @@ class SSListContainsOnlyMatchingItems extends Constraint implements TestOnly
      */
     private $constraint;
 
+    /**
+     * @var SSListExporter
+     */
+    private $exporter;
+
     public function __construct($match)
     {
-        parent::__construct();
-        $this->exporter = new SSListExporter();
-
         $this->constraint = new ViewableDataContains($match);
         $this->match = $match;
+    }
+
+    protected function exporter(): Exporter
+    {
+        if ($this->exporter === null) {
+            $this->exporter = new SSListExporter;
+        }
+
+        return $this->exporter;
     }
 
     /**

--- a/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
+++ b/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
@@ -55,7 +55,7 @@ class SSListContainsOnlyMatchingItems extends Constraint implements TestOnly
      *
      * @throws ExpectationFailedException
      */
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {
         $success = true;
 

--- a/src/Dev/Constraint/ViewableDataContains.php
+++ b/src/Dev/Constraint/ViewableDataContains.php
@@ -4,7 +4,7 @@ namespace SilverStripe\Dev\Constraint;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Util\InvalidArgumentHelper;
+use PHPUnit\Framework\InvalidArgumentException;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\View\ViewableData;
 
@@ -29,10 +29,8 @@ class ViewableDataContains extends Constraint implements TestOnly
      */
     public function __construct($match)
     {
-        parent::__construct();
-
         if (!is_array($match)) {
-            throw InvalidArgumentHelper::factory(
+            throw InvalidArgumentException::create(
                 1,
                 'array'
             );

--- a/src/Dev/CsvBulkLoader.php
+++ b/src/Dev/CsvBulkLoader.php
@@ -77,6 +77,7 @@ class CsvBulkLoader extends BulkLoader
             $filepath = Director::getAbsFile($filepath);
             $csvReader = Reader::createFromPath($filepath, 'r');
             $csvReader->setDelimiter($this->delimiter);
+            $csvReader->skipInputBOM();
 
             $tabExtractor = function ($row) {
                 foreach ($row as &$item) {

--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -80,7 +80,7 @@ abstract class FunctionalTest extends SapphireTest implements TestOnly
         return $this->mainSession->session();
     }
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -112,7 +112,7 @@ abstract class FunctionalTest extends SapphireTest implements TestOnly
         SecurityToken::disable();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         SecurityToken::enable();
         unset($this->mainSession);

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -956,7 +956,7 @@ abstract class SapphireTest extends TestCase implements TestOnly
         $needleSQL = static::normaliseSQL($needleSQL);
         $haystackSQL = static::normaliseSQL($haystackSQL);
 
-        static::assertContains($needleSQL, $haystackSQL, $message, $ignoreCase, $checkForObjectIdentity);
+        static::assertStringContainsString($needleSQL, $haystackSQL, $message, $ignoreCase, $checkForObjectIdentity);
     }
 
     /**
@@ -978,7 +978,7 @@ abstract class SapphireTest extends TestCase implements TestOnly
         $needleSQL = static::normaliseSQL($needleSQL);
         $haystackSQL = static::normaliseSQL($haystackSQL);
 
-        static::assertNotContains($needleSQL, $haystackSQL, $message, $ignoreCase, $checkForObjectIdentity);
+        static::assertStringNotContainsString($needleSQL, $haystackSQL, $message, $ignoreCase, $checkForObjectIdentity);
     }
 
     /**

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -261,7 +261,7 @@ abstract class SapphireTest extends TestCase implements TestOnly
      *
      * User code should call parent::setUp() before custom setup code
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         if (!defined('FRAMEWORK_PATH')) {
             trigger_error(
@@ -373,7 +373,7 @@ abstract class SapphireTest extends TestCase implements TestOnly
      *
      * @throws Exception
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         // Start tests
         static::start();
@@ -402,7 +402,7 @@ abstract class SapphireTest extends TestCase implements TestOnly
      *
      * User code should call parent::tearDownAfterClass() after custom tear down code
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass() : void
     {
         // Call state helpers
         static::$state->tearDownOnce(static::class);
@@ -567,7 +567,7 @@ abstract class SapphireTest extends TestCase implements TestOnly
      *
      * User code should call parent::tearDown() after custom tear down code
      */
-    protected function tearDown()
+    protected function tearDown() : void
     {
         // Reset mocked datetime
         DBDatetime::clear_mock_now();

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -2,9 +2,13 @@
 
 namespace SilverStripe\Dev;
 
+use ArrayAccess;
 use Exception;
 use LogicException;
+use PHPUnit\Framework\Constraint\ArraySubset;
 use PHPUnit\Framework\Constraint\LogicalNot;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Util\InvalidArgumentHelper;
 use SilverStripe\CMS\Controllers\RootURLController;
@@ -583,6 +587,43 @@ abstract class SapphireTest extends TestCase implements TestOnly
 
         // Call state helpers
         static::$state->tearDown($this);
+    }
+
+    /**
+     * Asserts that an array has a specified subset.
+     *
+     * @param array|ArrayAccess $subset
+     * @param array|ArrayAccess $array
+     *
+     * @throws ExpectationFailedException
+     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
+     * @throws \PHPUnit\Framework\Exception
+     *
+     * @codeCoverageIgnore
+     */
+    public static function assertArraySubset(
+        $subset,
+        $array,
+        bool $checkForObjectIdentity = false,
+        string $message = ''
+    ): void {
+        if (!(\is_array($subset) || $subset instanceof ArrayAccess)) {
+            throw InvalidArgumentException::create(
+                1,
+                'array or ArrayAccess'
+            );
+        }
+
+        if (!(\is_array($array) || $array instanceof ArrayAccess)) {
+            throw InvalidArgumentException::create(
+                2,
+                'array or ArrayAccess'
+            );
+        }
+
+        $constraint = new ArraySubset($subset, $checkForObjectIdentity);
+
+        static::assertThat($array, $constraint, $message);
     }
 
     public static function assertContains(

--- a/src/ORM/Connect/MySQLQuery.php
+++ b/src/ORM/Connect/MySQLQuery.php
@@ -48,6 +48,8 @@ class MySQLQuery extends Query
     public function getIterator()
     {
         if (is_object($this->handle)) {
+            // reset to the beginning of the result set before iterating
+            $this->handle->data_seek(0);
             while ($data = $this->nextRecord()) {
                 yield $data;
             }

--- a/tests/php/Control/ControllerTest.php
+++ b/tests/php/Control/ControllerTest.php
@@ -60,7 +60,10 @@ class ControllerTest extends FunctionalTest
     {
         /* For a controller with a template, the default action will simple run that template. */
         $response = $this->get("TestController/");
-        $this->assertContains("This is the main template. Content is 'default content'", $response->getBody());
+        $this->assertStringContainsString(
+            "This is the main template. Content is 'default content'",
+            $response->getBody()
+        );
     }
 
     public function testMethodActions()
@@ -68,18 +71,21 @@ class ControllerTest extends FunctionalTest
         /* The Action can refer to a method that is called on the object.  If a method returns an array, then it
         * will be used to customise the template data */
         $response = $this->get("TestController/methodaction");
-        $this->assertContains("This is the main template. Content is 'methodaction content'.", $response->getBody());
+        $this->assertStringContainsString(
+            "This is the main template. Content is 'methodaction content'.",
+            $response->getBody()
+        );
 
         /* If the method just returns a string, then that will be used as the response */
         $response = $this->get("TestController/stringaction");
-        $this->assertContains("stringaction was called.", $response->getBody());
+        $this->assertStringContainsString("stringaction was called.", $response->getBody());
     }
 
     public function testTemplateActions()
     {
         /* If there is no method, it can be used to point to an alternative template. */
         $response = $this->get("TestController/templateaction");
-        $this->assertContains(
+        $this->assertStringContainsString(
             "This is the template for templateaction. Content is 'default content'.",
             $response->getBody()
         );
@@ -284,12 +290,10 @@ class ControllerTest extends FunctionalTest
         });
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid allowed_action '*'
-     */
     public function testWildcardAllowedActions()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid allowed_action \'*\'');
         $this->get('AccessWildcardSecuredController');
     }
 

--- a/tests/php/Control/ControllerTest.php
+++ b/tests/php/Control/ControllerTest.php
@@ -42,7 +42,7 @@ class ControllerTest extends FunctionalTest
         UnsecuredController::class,
     ];
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         Director::config()->update('alternate_base_url', '/');

--- a/tests/php/Control/CookieTest.php
+++ b/tests/php/Control/CookieTest.php
@@ -10,7 +10,7 @@ use SilverStripe\Control\Cookie;
 class CookieTest extends SapphireTest
 {
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         Injector::inst()->registerService(new CookieJar($_COOKIE), 'SilverStripe\\Control\\Cookie_Backend');

--- a/tests/php/Control/DirectorTest.php
+++ b/tests/php/Control/DirectorTest.php
@@ -29,7 +29,7 @@ class DirectorTest extends SapphireTest
 
     private $originalEnvType;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         Director::config()->set('alternate_base_url', 'http://www.mysite.com:9090/');
@@ -44,10 +44,10 @@ class DirectorTest extends SapphireTest
         $this->expectedRedirect = null;
     }
 
-    protected function tearDown(...$args)
+    protected function tearDown() : void
     {
         Environment::setEnv('SS_ENVIRONMENT_TYPE', $this->originalEnvType);
-        parent::tearDown(...$args);
+        parent::tearDown();
     }
 
     protected function getExtraRoutes()

--- a/tests/php/Control/Email/EmailTest.php
+++ b/tests/php/Control/Email/EmailTest.php
@@ -2,7 +2,7 @@
 
 namespace SilverStripe\Control\Tests\Email;
 
-use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit\Framework\MockObject\MockObject;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Control\Email\Mailer;
 use SilverStripe\Control\Email\SwiftMailer;
@@ -627,11 +627,11 @@ class EmailTest extends SapphireTest
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject|Email
+     * @return MockObject|Email
      */
     protected function makeEmailMock($subject)
     {
-        /** @var Email|PHPUnit_Framework_MockObject_MockObject $email */
+        /** @var Email|MockObject $email */
         $email = $this->getMockBuilder(Email::class)
             ->enableProxyingToOriginalMethods()
             ->getMock();

--- a/tests/php/Control/Email/EmailTest.php
+++ b/tests/php/Control/Email/EmailTest.php
@@ -207,7 +207,7 @@ class EmailTest extends SapphireTest
         $email->send();
         $this->assertTrue($email->hasPlainPart());
         $this->assertNotEmpty($email->getBody());
-        $this->assertContains('<h1>Email Sub-class</h1>', $email->getBody());
+        $this->assertStringContainsString('<h1>Email Sub-class</h1>', $email->getBody());
     }
 
     public function testConsturctor()
@@ -549,7 +549,7 @@ class EmailTest extends SapphireTest
             'EmailContent' => 'my content',
         ));
         $email->render();
-        $this->assertContains('my content', $email->getBody());
+        $this->assertStringContainsString('my content', $email->getBody());
         $children = $email->getSwiftMessage()->getChildren();
         $this->assertCount(1, $children);
         $plainPart = reset($children);
@@ -595,8 +595,8 @@ class EmailTest extends SapphireTest
         $children = $email->getSwiftMessage()->getChildren();
         $this->assertCount(1, $children);
         $plainPart = reset($children);
-        $this->assertContains('Test', $plainPart->getBody());
-        $this->assertNotContains('<h1>Test</h1>', $plainPart->getBody());
+        $this->assertStringContainsString('Test', $plainPart->getBody());
+        $this->assertStringNotContainsString('<h1>Test</h1>', $plainPart->getBody());
     }
 
     public function testMultipleEmailSends()
@@ -608,22 +608,22 @@ class EmailTest extends SapphireTest
         $this->assertEmpty($email->getBody());
         $this->assertEmpty($email->getSwiftMessage()->getChildren());
         $email->send();
-        $this->assertContains('Test', $email->getBody());
+        $this->assertStringContainsString('Test', $email->getBody());
         $this->assertCount(1, $email->getSwiftMessage()->getChildren());
         $children = $email->getSwiftMessage()->getChildren();
         /** @var \Swift_MimePart $plainPart */
         $plainPart = reset($children);
-        $this->assertContains('Test', $plainPart->getBody());
+        $this->assertStringContainsString('Test', $plainPart->getBody());
 
 
         //send again
         $email->send();
-        $this->assertContains('Test', $email->getBody());
+        $this->assertStringContainsString('Test', $email->getBody());
         $this->assertCount(1, $email->getSwiftMessage()->getChildren());
         $children = $email->getSwiftMessage()->getChildren();
         /** @var \Swift_MimePart $plainPart */
         $plainPart = reset($children);
-        $this->assertContains('Test', $plainPart->getBody());
+        $this->assertStringContainsString('Test', $plainPart->getBody());
     }
 
     /**

--- a/tests/php/Control/Email/SwiftPluginTest.php
+++ b/tests/php/Control/Email/SwiftPluginTest.php
@@ -9,7 +9,7 @@ use SilverStripe\Dev\SapphireTest;
 class SwiftPluginTest extends SapphireTest
 {
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Control/HTTPCacheControlIntegrationTest.php
+++ b/tests/php/Control/HTTPCacheControlIntegrationTest.php
@@ -31,11 +31,11 @@ class HTTPCacheControlIntegrationTest extends FunctionalTest
         $response = $this->get('HTTPCacheControlIntegrationTest_SessionController/showform');
         $header = $response->getHeader('Cache-Control');
         $this->assertFalse($response->isError());
-        $this->assertNotContains('public', $header);
-        $this->assertNotContains('private', $header);
-        $this->assertContains('no-cache', $header);
-        $this->assertContains('no-store', $header);
-        $this->assertContains('must-revalidate', $header);
+        $this->assertStringNotContainsString('public', $header);
+        $this->assertStringNotContainsString('private', $header);
+        $this->assertStringContainsString('no-cache', $header);
+        $this->assertStringContainsString('no-store', $header);
+        $this->assertStringContainsString('must-revalidate', $header);
     }
 
     public function testPublicForm()
@@ -44,10 +44,10 @@ class HTTPCacheControlIntegrationTest extends FunctionalTest
         $response = $this->get('HTTPCacheControlIntegrationTest_SessionController/showpublicform');
         $header = $response->getHeader('Cache-Control');
         $this->assertFalse($response->isError());
-        $this->assertContains('public', $header);
-        $this->assertContains('must-revalidate', $header);
-        $this->assertNotContains('no-cache', $response->getHeader('Cache-Control'));
-        $this->assertNotContains('no-store', $response->getHeader('Cache-Control'));
+        $this->assertStringContainsString('public', $header);
+        $this->assertStringContainsString('must-revalidate', $header);
+        $this->assertStringNotContainsString('no-cache', $response->getHeader('Cache-Control'));
+        $this->assertStringNotContainsString('no-store', $response->getHeader('Cache-Control'));
     }
 
     public function testPrivateActionsError()
@@ -56,9 +56,9 @@ class HTTPCacheControlIntegrationTest extends FunctionalTest
         $response = $this->get('HTTPCacheControlIntegrationTest_SessionController/privateaction');
         $header = $response->getHeader('Cache-Control');
         $this->assertTrue($response->isError());
-        $this->assertContains('no-cache', $header);
-        $this->assertContains('no-store', $header);
-        $this->assertContains('must-revalidate', $header);
+        $this->assertStringContainsString('no-cache', $header);
+        $this->assertStringContainsString('no-store', $header);
+        $this->assertStringContainsString('must-revalidate', $header);
     }
 
     public function testPrivateActionsAuthenticated()
@@ -68,10 +68,10 @@ class HTTPCacheControlIntegrationTest extends FunctionalTest
         $response = $this->get('HTTPCacheControlIntegrationTest_SessionController/privateaction');
         $header = $response->getHeader('Cache-Control');
         $this->assertFalse($response->isError());
-        $this->assertContains('private', $header);
-        $this->assertContains('must-revalidate', $header);
-        $this->assertNotContains('no-cache', $header);
-        $this->assertNotContains('no-store', $header);
+        $this->assertStringContainsString('private', $header);
+        $this->assertStringContainsString('must-revalidate', $header);
+        $this->assertStringNotContainsString('no-cache', $header);
+        $this->assertStringNotContainsString('no-store', $header);
     }
 
     public function testPrivateCache()
@@ -79,10 +79,10 @@ class HTTPCacheControlIntegrationTest extends FunctionalTest
         $response = $this->get('HTTPCacheControlIntegrationTest_RuleController/privateaction');
         $header = $response->getHeader('Cache-Control');
         $this->assertFalse($response->isError());
-        $this->assertContains('private', $header);
-        $this->assertContains('must-revalidate', $header);
-        $this->assertNotContains('no-cache', $header);
-        $this->assertNotContains('no-store', $header);
+        $this->assertStringContainsString('private', $header);
+        $this->assertStringContainsString('must-revalidate', $header);
+        $this->assertStringNotContainsString('no-cache', $header);
+        $this->assertStringNotContainsString('no-store', $header);
     }
 
     public function testPublicCache()
@@ -90,11 +90,11 @@ class HTTPCacheControlIntegrationTest extends FunctionalTest
         $response = $this->get('HTTPCacheControlIntegrationTest_RuleController/publicaction');
         $header = $response->getHeader('Cache-Control');
         $this->assertFalse($response->isError());
-        $this->assertContains('public', $header);
-        $this->assertContains('must-revalidate', $header);
-        $this->assertNotContains('no-cache', $header);
-        $this->assertNotContains('no-store', $header);
-        $this->assertContains('max-age=9000', $header);
+        $this->assertStringContainsString('public', $header);
+        $this->assertStringContainsString('must-revalidate', $header);
+        $this->assertStringNotContainsString('no-cache', $header);
+        $this->assertStringNotContainsString('no-store', $header);
+        $this->assertStringContainsString('max-age=9000', $header);
     }
 
     public function testDisabledCache()
@@ -102,10 +102,10 @@ class HTTPCacheControlIntegrationTest extends FunctionalTest
         $response = $this->get('HTTPCacheControlIntegrationTest_RuleController/disabledaction');
         $header = $response->getHeader('Cache-Control');
         $this->assertFalse($response->isError());
-        $this->assertNotContains('public', $header);
-        $this->assertNotContains('private', $header);
-        $this->assertContains('no-cache', $header);
-        $this->assertContains('no-store', $header);
-        $this->assertContains('must-revalidate', $header);
+        $this->assertStringNotContainsString('public', $header);
+        $this->assertStringNotContainsString('private', $header);
+        $this->assertStringContainsString('no-cache', $header);
+        $this->assertStringContainsString('no-store', $header);
+        $this->assertStringContainsString('must-revalidate', $header);
     }
 }

--- a/tests/php/Control/HTTPCacheControlIntegrationTest.php
+++ b/tests/php/Control/HTTPCacheControlIntegrationTest.php
@@ -16,7 +16,7 @@ class HTTPCacheControlIntegrationTest extends FunctionalTest
         RuleController::class,
     ];
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         HTTPCacheControlMiddleware::config()

--- a/tests/php/Control/HTTPRequestTest.php
+++ b/tests/php/Control/HTTPRequestTest.php
@@ -40,7 +40,10 @@ class HTTPRequestTest extends SapphireTest
         $this->assertEquals('crm/test', $request->remaining());
 
         $request = new HTTPRequest('GET', 'admin/crm/test/part1/part2');
-        $this->assertEquals(['Action' => 'crm', '$1' => 'test', '$2' => 'part1', '$3' => 'part2'], $request->match('admin/$Action/$@', true));
+        $this->assertEquals(
+            ['Action' => 'crm', '$1' => 'test', '$2' => 'part1', '$3' => 'part2'],
+            $request->match('admin/$Action/$@', true)
+        );
         $this->assertTrue($request->allParsed());
 
         $request = new HTTPRequest('GET', 'admin/crm/test/part1/part2');

--- a/tests/php/Control/HTTPRequestTest.php
+++ b/tests/php/Control/HTTPRequestTest.php
@@ -56,10 +56,10 @@ class HTTPRequestTest extends SapphireTest
      * This test just asserts a warning is given if there is more than one wildcard parameter. Note that this isn't an
      * enforcement of an API and we an add new behaviour in the future to allow many wildcard params if we want to
      *
-     * @expectedException \PHPUnit\Framework\Error\Warning
      */
     public function testWildCardWithFurtherParams()
     {
+        $this->expectException(\PHPUnit\Framework\Error\Warning::class);
         $request = new HTTPRequest('GET', 'admin/crm/test');
         // all parameters after the first wildcard parameter are ignored
         $request->match('admin/$Action/$@/$Other/$*', true);

--- a/tests/php/Control/HTTPTest.php
+++ b/tests/php/Control/HTTPTest.php
@@ -48,9 +48,9 @@ class HTTPTest extends FunctionalTest
         HTTPCacheControlMiddleware::singleton()->setMaxAge(30);
         $response = new HTTPResponse($body, 200);
         $this->addCacheHeaders($response);
-        $this->assertContains('no-cache', $response->getHeader('Cache-Control'));
-        $this->assertContains('no-store', $response->getHeader('Cache-Control'));
-        $this->assertContains('must-revalidate', $response->getHeader('Cache-Control'));
+        $this->assertStringContainsString('no-cache', $response->getHeader('Cache-Control'));
+        $this->assertStringContainsString('no-store', $response->getHeader('Cache-Control'));
+        $this->assertStringContainsString('must-revalidate', $response->getHeader('Cache-Control'));
 
         // Ensure max-age setting is respected in production.
         HTTPCacheControlMiddleware::config()
@@ -61,8 +61,8 @@ class HTTPTest extends FunctionalTest
         HTTPCacheControlMiddleware::singleton()->setMaxAge(30);
         $response = new HTTPResponse($body, 200);
         $this->addCacheHeaders($response);
-        $this->assertContains('max-age=30', $response->getHeader('Cache-Control'));
-        $this->assertNotContains('max-age=0', $response->getHeader('Cache-Control'));
+        $this->assertStringContainsString('max-age=30', $response->getHeader('Cache-Control'));
+        $this->assertStringNotContainsString('max-age=0', $response->getHeader('Cache-Control'));
 
         // Still "live": Ensure header's aren't overridden if already set (using purposefully different values).
         $headers = array(
@@ -93,11 +93,11 @@ class HTTPTest extends FunctionalTest
 
         // Vary set properly
         $v = $response->getHeader('Vary');
-        $this->assertContains("X-Forwarded-Protocol", $v);
-        $this->assertContains("X-Requested-With", $v);
-        $this->assertNotContains("Cookie", $v);
-        $this->assertNotContains("User-Agent", $v);
-        $this->assertNotContains("Accept", $v);
+        $this->assertStringContainsString("X-Forwarded-Protocol", $v);
+        $this->assertStringContainsString("X-Requested-With", $v);
+        $this->assertStringNotContainsString("Cookie", $v);
+        $this->assertStringNotContainsString("User-Agent", $v);
+        $this->assertStringNotContainsString("Accept", $v);
 
         // No vary
         HTTPCacheControlMiddleware::singleton()
@@ -124,7 +124,7 @@ class HTTPTest extends FunctionalTest
         $response = new HTTPResponse('', 200);
         $this->addCacheHeaders($response);
         $header = $response->getHeader('Vary');
-        $this->assertContains('X-Foo', $header);
+        $this->assertStringContainsString('X-Foo', $header);
     }
 
     public function testDeprecatedCacheControlHandling()
@@ -143,8 +143,8 @@ class HTTPTest extends FunctionalTest
         $response = new HTTPResponse('', 200);
         $this->addCacheHeaders($response);
         $header = $response->getHeader('Cache-Control');
-        $this->assertContains('no-store', $header);
-        $this->assertContains('no-cache', $header);
+        $this->assertStringContainsString('no-store', $header);
+        $this->assertStringContainsString('no-cache', $header);
     }
 
     public function testDeprecatedCacheControlHandlingOnMaxAge()
@@ -164,15 +164,13 @@ class HTTPTest extends FunctionalTest
         $response = new HTTPResponse('', 200);
         $this->addCacheHeaders($response);
         $header = $response->getHeader('Cache-Control');
-        $this->assertContains('max-age=99', $header);
+        $this->assertStringContainsString('max-age=99', $header);
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessageRegExp /Found unsupported legacy directives in HTTP\.cache_control: unknown/
-     */
     public function testDeprecatedCacheControlHandlingThrowsWithUnknownDirectives()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/Found unsupported legacy directives in HTTP\\.cache_control: unknown/');
         /** @var Config */
         Config::modify()->set(
             HTTP::class,
@@ -219,7 +217,7 @@ class HTTPTest extends FunctionalTest
         sort($result);
         sort($expected);
 
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertEquals($expected, $result, 'Test that all links within the content are found.');
     }
 
@@ -235,7 +233,7 @@ class HTTPTest extends FunctionalTest
             $controller->setRequest($request);
             $controller->pushCurrent();
             try {
-                $this->assertContains(
+                $this->assertStringContainsString(
                     'relative/url?foo=bar',
                     HTTP::setGetVar('foo', 'bar'),
                     'Omitting a URL falls back to current URL'
@@ -263,7 +261,7 @@ class HTTPTest extends FunctionalTest
             'Absolute URL without path and multipe existing query params, overwriting an existing parameter'
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'http://test.com/?foo=new',
             HTTP::setGetVar('foo', 'new', 'http://test.com/?foo=&foo=old'),
             'Absolute URL and empty query param'

--- a/tests/php/Control/HTTPTest.php
+++ b/tests/php/Control/HTTPTest.php
@@ -19,7 +19,7 @@ use SilverStripe\Dev\FunctionalTest;
  */
 class HTTPTest extends FunctionalTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         // Set to disabled at null forcing level

--- a/tests/php/Control/IPUtilsTest.php
+++ b/tests/php/Control/IPUtilsTest.php
@@ -71,11 +71,11 @@ class IPUtilsTest extends SapphireTest
     }
 
     /**
-     * @expectedException \RuntimeException
      * @requires extension sockets
      */
     public function testAnIPv6WithOptionDisabledIPv6()
     {
+        $this->expectException(\RuntimeException::class);
         if (defined('AF_INET6')) {
             $this->markTestSkipped('Only works when PHP is compiled with the option "disable-ipv6".');
         }

--- a/tests/php/Control/Middleware/CanonicalURLMiddlewareTest.php
+++ b/tests/php/Control/Middleware/CanonicalURLMiddlewareTest.php
@@ -45,7 +45,11 @@ class CanonicalURLMiddlewareTest extends SapphireTest
 
         $this->assertNotSame($mockResponse, $result, 'New response is created and returned');
         $this->assertEquals(301, $result->getStatusCode(), 'Basic auth responses are redirected');
-        $this->assertContains('https://', $result->getHeader('Location'), 'HTTPS is in the redirect location');
+        $this->assertStringContainsString(
+            'https://',
+            $result->getHeader('Location'),
+            'HTTPS is in the redirect location'
+        );
     }
 
     public function testMiddlewareDelegateIsReturnedWhenBasicAuthRedirectIsDisabled()

--- a/tests/php/Control/Middleware/CanonicalURLMiddlewareTest.php
+++ b/tests/php/Control/Middleware/CanonicalURLMiddlewareTest.php
@@ -16,7 +16,7 @@ class CanonicalURLMiddlewareTest extends SapphireTest
      */
     protected $middleware;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Control/Middleware/HTTPCacheControlMiddlewareTest.php
+++ b/tests/php/Control/Middleware/HTTPCacheControlMiddlewareTest.php
@@ -39,7 +39,7 @@ class HTTPCacheControlMiddlewareTest extends SapphireTest
         $response = new HTTPResponse();
         $cc->applyToResponse($response);
 
-        $this->assertContains('must-revalidate', $response->getHeader('cache-control'));
+        $this->assertStringContainsString('must-revalidate', $response->getHeader('cache-control'));
     }
 
     /**
@@ -62,9 +62,9 @@ class HTTPCacheControlMiddlewareTest extends SapphireTest
         if ($immutable) {
             $this->assertEquals($originalResponse->getHeader('cache-control'), $response->getHeader('cache-control'));
         } else {
-            $this->assertContains('max-age=300', $response->getHeader('cache-control'));
-            $this->assertNotContains('no-cache', $response->getHeader('cache-control'));
-            $this->assertNotContains('no-store', $response->getHeader('cache-control'));
+            $this->assertStringContainsString('max-age=300', $response->getHeader('cache-control'));
+            $this->assertStringNotContainsString('no-cache', $response->getHeader('cache-control'));
+            $this->assertStringNotContainsString('no-store', $response->getHeader('cache-control'));
         }
     }
 
@@ -78,9 +78,9 @@ class HTTPCacheControlMiddlewareTest extends SapphireTest
         $response = new HTTPResponse();
         $cc->applyToResponse($response);
 
-        $this->assertContains('max-age=300', $response->getHeader('cache-control'));
-        $this->assertNotContains('no-cache', $response->getHeader('cache-control'));
-        $this->assertNotContains('no-store', $response->getHeader('cache-control'));
+        $this->assertStringContainsString('max-age=300', $response->getHeader('cache-control'));
+        $this->assertStringNotContainsString('no-cache', $response->getHeader('cache-control'));
+        $this->assertStringNotContainsString('no-store', $response->getHeader('cache-control'));
     }
 
     public function testEnableCacheWithMaxAgeAppliesWhenLevelDoesNot()
@@ -94,7 +94,7 @@ class HTTPCacheControlMiddlewareTest extends SapphireTest
         $response = new HTTPResponse();
         $cc->applyToResponse($response);
 
-        $this->assertContains('max-age=300', $response->getHeader('cache-control'));
+        $this->assertStringContainsString('max-age=300', $response->getHeader('cache-control'));
     }
 
     public function testPublicCacheWithMaxAge()
@@ -107,10 +107,10 @@ class HTTPCacheControlMiddlewareTest extends SapphireTest
         $response = new HTTPResponse();
         $cc->applyToResponse($response);
 
-        $this->assertContains('max-age=300', $response->getHeader('cache-control'));
+        $this->assertStringContainsString('max-age=300', $response->getHeader('cache-control'));
         // STATE_PUBLIC doesn't contain no-cache or no-store headers to begin with,
         // so can't test their removal effectively
-        $this->assertNotContains('no-cache', $response->getHeader('cache-control'));
+        $this->assertStringNotContainsString('no-cache', $response->getHeader('cache-control'));
     }
 
     public function testPublicCacheWithMaxAgeAppliesWhenLevelDoesNot()
@@ -124,7 +124,7 @@ class HTTPCacheControlMiddlewareTest extends SapphireTest
         $response = new HTTPResponse();
         $cc->applyToResponse($response);
 
-        $this->assertContains('max-age=300', $response->getHeader('cache-control'));
+        $this->assertStringContainsString('max-age=300', $response->getHeader('cache-control'));
     }
 
     /**
@@ -150,9 +150,9 @@ class HTTPCacheControlMiddlewareTest extends SapphireTest
         if ($immutable) {
             $this->assertEquals($originalResponse->getHeader('cache-control'), $response->getHeader('cache-control'));
         } else {
-            $this->assertContains('no-store', $response->getHeader('cache-control'));
-            $this->assertNotContains('max-age', $response->getHeader('cache-control'));
-            $this->assertNotContains('s-maxage', $response->getHeader('cache-control'));
+            $this->assertStringContainsString('no-store', $response->getHeader('cache-control'));
+            $this->assertStringNotContainsString('max-age', $response->getHeader('cache-control'));
+            $this->assertStringNotContainsString('s-maxage', $response->getHeader('cache-control'));
         }
     }
 
@@ -179,9 +179,9 @@ class HTTPCacheControlMiddlewareTest extends SapphireTest
         if ($immutable) {
             $this->assertEquals($originalResponse->getHeader('cache-control'), $response->getHeader('cache-control'));
         } else {
-            $this->assertContains('no-cache', $response->getHeader('cache-control'));
-            $this->assertNotContains('max-age', $response->getHeader('cache-control'));
-            $this->assertNotContains('s-maxage', $response->getHeader('cache-control'));
+            $this->assertStringContainsString('no-cache', $response->getHeader('cache-control'));
+            $this->assertStringNotContainsString('max-age', $response->getHeader('cache-control'));
+            $this->assertStringNotContainsString('s-maxage', $response->getHeader('cache-control'));
         }
     }
 
@@ -206,9 +206,9 @@ class HTTPCacheControlMiddlewareTest extends SapphireTest
         if ($immutable) {
             $this->assertEquals($originalResponse->getHeader('cache-control'), $response->getHeader('cache-control'));
         } else {
-            $this->assertContains('s-maxage=300', $response->getHeader('cache-control'));
-            $this->assertNotContains('no-cache', $response->getHeader('cache-control'));
-            $this->assertNotContains('no-store', $response->getHeader('cache-control'));
+            $this->assertStringContainsString('s-maxage=300', $response->getHeader('cache-control'));
+            $this->assertStringNotContainsString('no-cache', $response->getHeader('cache-control'));
+            $this->assertStringNotContainsString('no-store', $response->getHeader('cache-control'));
         }
     }
 
@@ -233,9 +233,9 @@ class HTTPCacheControlMiddlewareTest extends SapphireTest
         if ($immutable) {
             $this->assertEquals($originalResponse->getHeader('cache-control'), $response->getHeader('cache-control'));
         } else {
-            $this->assertContains('must-revalidate', $response->getHeader('cache-control'));
-            $this->assertNotContains('max-age', $response->getHeader('cache-control'));
-            $this->assertNotContains('s-maxage', $response->getHeader('cache-control'));
+            $this->assertStringContainsString('must-revalidate', $response->getHeader('cache-control'));
+            $this->assertStringNotContainsString('max-age', $response->getHeader('cache-control'));
+            $this->assertStringNotContainsString('s-maxage', $response->getHeader('cache-control'));
         }
     }
 

--- a/tests/php/Control/Middleware/HTTPCacheControlMiddlewareTest.php
+++ b/tests/php/Control/Middleware/HTTPCacheControlMiddlewareTest.php
@@ -8,7 +8,7 @@ use SilverStripe\Dev\SapphireTest;
 
 class HTTPCacheControlMiddlewareTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         // Set to disabled at null forcing level

--- a/tests/php/Control/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/php/Control/Middleware/RateLimitMiddlewareTest.php
@@ -17,7 +17,7 @@ class RateLimitMiddlewareTest extends FunctionalTest
         TestController::class,
     ];
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         DBDatetime::set_mock_now('2017-09-27 00:00:00');

--- a/tests/php/Control/RSS/RSSFeedTest.php
+++ b/tests/php/Control/RSS/RSSFeedTest.php
@@ -24,17 +24,17 @@ class RSSFeedTest extends SapphireTest
         $rssFeed = new RSSFeed($list, "http://www.example.com", "Test RSS Feed", "Test RSS Feed Description");
         $content = $rssFeed->outputToBrowser();
 
-        $this->assertContains('<link>http://www.example.org/item-a/</link>', $content);
-        $this->assertContains('<link>http://www.example.com/item-b.html</link>', $content);
-        $this->assertContains('<link>http://www.example.com/item-c.html</link>', $content);
+        $this->assertStringContainsString('<link>http://www.example.org/item-a/</link>', $content);
+        $this->assertStringContainsString('<link>http://www.example.com/item-b.html</link>', $content);
+        $this->assertStringContainsString('<link>http://www.example.com/item-c.html</link>', $content);
 
-        $this->assertContains('<title>ItemA</title>', $content);
-        $this->assertContains('<title>ItemB</title>', $content);
-        $this->assertContains('<title>ItemC</title>', $content);
+        $this->assertStringContainsString('<title>ItemA</title>', $content);
+        $this->assertStringContainsString('<title>ItemB</title>', $content);
+        $this->assertStringContainsString('<title>ItemC</title>', $content);
 
-        $this->assertContains('<description>ItemA Content</description>', $content);
-        $this->assertContains('<description>ItemB Content</description>', $content);
-        $this->assertContains('<description>ItemC Content</description>', $content);
+        $this->assertStringContainsString('<description>ItemA Content</description>', $content);
+        $this->assertStringContainsString('<description>ItemB Content</description>', $content);
+        $this->assertStringContainsString('<description>ItemC Content</description>', $content);
 
 
         // Feed #2 - put Content() into <title> and AltContent() into <description>
@@ -48,13 +48,13 @@ class RSSFeedTest extends SapphireTest
         );
         $content = $rssFeed->outputToBrowser();
 
-        $this->assertContains('<title>ItemA Content</title>', $content);
-        $this->assertContains('<title>ItemB Content</title>', $content);
-        $this->assertContains('<title>ItemC Content</title>', $content);
+        $this->assertStringContainsString('<title>ItemA Content</title>', $content);
+        $this->assertStringContainsString('<title>ItemB Content</title>', $content);
+        $this->assertStringContainsString('<title>ItemC Content</title>', $content);
 
-        $this->assertContains('<description>ItemA AltContent</description>', $content);
-        $this->assertContains('<description>ItemB AltContent</description>', $content);
-        $this->assertContains('<description>ItemC AltContent</description>', $content);
+        $this->assertStringContainsString('<description>ItemA AltContent</description>', $content);
+        $this->assertStringContainsString('<description>ItemB AltContent</description>', $content);
+        $this->assertStringContainsString('<description>ItemC AltContent</description>', $content);
     }
 
     public function testLinkEncoding()
@@ -62,7 +62,7 @@ class RSSFeedTest extends SapphireTest
         $list = new ArrayList();
         $rssFeed = new RSSFeed($list, "http://www.example.com/?param1=true&param2=true", "Test RSS Feed");
         $content = $rssFeed->outputToBrowser();
-        $this->assertContains('<link>http://www.example.com/?param1=true&amp;param2=true', $content);
+        $this->assertStringContainsString('<link>http://www.example.com/?param1=true&amp;param2=true', $content);
     }
 
     public function testRSSFeedWithShortcode()
@@ -73,11 +73,11 @@ class RSSFeedTest extends SapphireTest
         $rssFeed = new RSSFeed($list, "http://www.example.com", "Test RSS Feed", "Test RSS Feed Description");
         $content = $rssFeed->outputToBrowser();
 
-        $this->assertContains('<link>http://www.example.org/item-d.html</link>', $content);
+        $this->assertStringContainsString('<link>http://www.example.org/item-d.html</link>', $content);
 
-        $this->assertContains('<title>ItemD</title>', $content);
+        $this->assertStringContainsString('<title>ItemD</title>', $content);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<description><![CDATA[<p>ItemD Content test shortcode output</p>]]></description>',
             $content
         );
@@ -92,11 +92,11 @@ class RSSFeedTest extends SapphireTest
         $rssFeed->setTemplate('RSSFeedTest');
 
         $content = $rssFeed->outputToBrowser();
-        $this->assertContains('<title>Test Custom Template</title>', $content);
+        $this->assertStringContainsString('<title>Test Custom Template</title>', $content);
 
         $rssFeed->setTemplate(null);
         $content = $rssFeed->outputToBrowser();
-        $this->assertNotContains('<title>Test Custom Template</title>', $content);
+        $this->assertStringNotContainsString('<title>Test Custom Template</title>', $content);
     }
 
     protected function setUp() : void

--- a/tests/php/Control/RSS/RSSFeedTest.php
+++ b/tests/php/Control/RSS/RSSFeedTest.php
@@ -99,7 +99,7 @@ class RSSFeedTest extends SapphireTest
         $this->assertNotContains('<title>Test Custom Template</title>', $content);
     }
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         Config::modify()->set(Director::class, 'alternate_base_url', '/');
@@ -116,7 +116,7 @@ class RSSFeedTest extends SapphireTest
         );
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         parent::tearDown();
         $_SERVER['HTTP_HOST'] = self::$original_host;

--- a/tests/php/Control/RequestHandlingTest.php
+++ b/tests/php/Control/RequestHandlingTest.php
@@ -357,7 +357,7 @@ class RequestHandlingTest extends FunctionalTest
         $response = $this->post('ControllerFormWithAllowedActions/Form', $data);
         $this->assertEquals(403, $response->getStatusCode());
         // Note: Looks for a specific 403 thrown by Form->httpSubmission(), not RequestHandler->handleRequest()
-        $this->assertContains('not allowed on form', $response->getBody());
+        $this->assertStringContainsString('not allowed on form', $response->getBody());
     }
 
     public function testActionHandlingOnField()

--- a/tests/php/Control/SessionTest.php
+++ b/tests/php/Control/SessionTest.php
@@ -20,7 +20,7 @@ class SessionTest extends SapphireTest
     protected function setUp() : void
     {
         $this->session = new Session([]);
-        return parent::setUp();
+        parent::setUp();
     }
 
     /**
@@ -106,7 +106,7 @@ class SessionTest extends SapphireTest
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled
-     * @expectedException BadMethodCallException
+     * @expectedException \BadMethodCallException
      * @expectedExceptionMessage Session has already started
      */
     public function testStartErrorsWhenStartingTwice()

--- a/tests/php/Control/SessionTest.php
+++ b/tests/php/Control/SessionTest.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Control\Tests;
 
-use http\Exception\BadMessageException;
 use SilverStripe\Control\Cookie;
 use SilverStripe\Control\Session;
 use SilverStripe\Dev\SapphireTest;
@@ -18,7 +17,7 @@ class SessionTest extends SapphireTest
      */
     protected $session = null;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->session = new Session([]);
         return parent::setUp();

--- a/tests/php/Control/SessionTest.php
+++ b/tests/php/Control/SessionTest.php
@@ -106,11 +106,11 @@ class SessionTest extends SapphireTest
     /**
      * @runInSeparateProcess
      * @preserveGlobalState disabled
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Session has already started
      */
     public function testStartErrorsWhenStartingTwice()
     {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Session has already started');
         $req = new HTTPRequest('GET', '/');
         $session = new Session(null); // unstarted session
         $session->start($req);

--- a/tests/php/Control/SimpleResourceURLGeneratorTest.php
+++ b/tests/php/Control/SimpleResourceURLGeneratorTest.php
@@ -11,7 +11,7 @@ use SilverStripe\Dev\SapphireTest;
 
 class SimpleResourceURLGeneratorTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         Director::config()->set(

--- a/tests/php/Core/Cache/CacheTest.php
+++ b/tests/php/Core/Cache/CacheTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Cache\Simple\MemcachedCache;
 
 class CacheTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Core/Cache/RateLimiterTest.php
+++ b/tests/php/Core/Cache/RateLimiterTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Cache\Simple\ArrayCache;
 class RateLimiterTest extends SapphireTest
 {
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         DBDatetime::set_mock_now('2017-09-27 00:00:00');

--- a/tests/php/Core/ClassInfoTest.php
+++ b/tests/php/Core/ClassInfoTest.php
@@ -30,7 +30,7 @@ class ClassInfoTest extends SapphireTest
         WithRelation::class,
     );
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         ClassInfo::reset_db_cache();

--- a/tests/php/Core/ConvertTest.php
+++ b/tests/php/Core/ConvertTest.php
@@ -247,7 +247,7 @@ PHP
         $this->assertEquals(3, count($decoded), '3 items in the decoded array');
         $this->assertContains('Bloggs', $decoded, 'Contains "Bloggs" value in decoded array');
         $this->assertContains('Jones', $decoded, 'Contains "Jones" value in decoded array');
-        $this->assertContains('Structure', $decoded['My']['Complicated']);
+        $this->assertStringContainsString('Structure', $decoded['My']['Complicated']);
     }
 
     /**

--- a/tests/php/Core/ConvertTest.php
+++ b/tests/php/Core/ConvertTest.php
@@ -19,14 +19,14 @@ class ConvertTest extends SapphireTest
 
     private $previousLocaleSetting = null;
 
-    public function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         // clear the previous locale setting
         $this->previousLocaleSetting = null;
     }
 
-    public function tearDown()
+    protected function tearDown() : void
     {
         parent::tearDown();
         // If a test sets the locale, reset it on teardown

--- a/tests/php/Core/CoreTest.php
+++ b/tests/php/Core/CoreTest.php
@@ -15,7 +15,7 @@ class CoreTest extends SapphireTest
 
     protected $tempPath;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->tempPath = Director::baseFolder() . DIRECTORY_SEPARATOR . 'silverstripe-cache';
@@ -52,7 +52,7 @@ class CoreTest extends SapphireTest
         }
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         parent::tearDown();
         $user = TempFolder::getTempFolderUsername();

--- a/tests/php/Core/Injector/InjectorTest.php
+++ b/tests/php/Core/Injector/InjectorTest.php
@@ -918,11 +918,9 @@ class InjectorTest extends SapphireTest
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testNonExistentMethods()
     {
+        $this->expectException(InvalidArgumentException::class);
         $injector = new Injector();
         $config = array(
             'TestService' => array(
@@ -937,11 +935,9 @@ class InjectorTest extends SapphireTest
         $item = $injector->get('TestService');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testProtectedMethods()
     {
+        $this->expectException(InvalidArgumentException::class);
         $injector = new Injector();
         $config = array(
             'TestService' => array(
@@ -956,11 +952,9 @@ class InjectorTest extends SapphireTest
         $item = $injector->get('TestService');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testTooManyArrayValues()
     {
+        $this->expectException(InvalidArgumentException::class);
         $injector = new Injector();
         $config = array(
             'TestService' => array(
@@ -975,11 +969,9 @@ class InjectorTest extends SapphireTest
         $item = $injector->get('TestService');
     }
 
-    /**
-     * @expectedException \SilverStripe\Core\Injector\InjectorNotFoundException
-     */
     public function testGetThrowsOnNotFound()
     {
+        $this->expectException(\SilverStripe\Core\Injector\InjectorNotFoundException::class);
         $injector = new Injector();
         $injector->get('UnknownService');
     }

--- a/tests/php/Core/Injector/InjectorTest.php
+++ b/tests/php/Core/Injector/InjectorTest.php
@@ -44,14 +44,14 @@ class InjectorTest extends SapphireTest
 
     protected $nestingLevel = 0;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
         $this->nestingLevel = 0;
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
 
         while ($this->nestingLevel > 0) {

--- a/tests/php/Core/Manifest/ClassLoaderTest.php
+++ b/tests/php/Core/Manifest/ClassLoaderTest.php
@@ -32,7 +32,7 @@ class ClassLoaderTest extends SapphireTest
      */
     protected $testManifest2;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Core/Manifest/ClassManifestErrorHandlerTest.php
+++ b/tests/php/Core/Manifest/ClassManifestErrorHandlerTest.php
@@ -7,12 +7,10 @@ use PhpParser\Error;
 
 class ClassManifestErrorHandlerTest extends SapphireTest
 {
-    /**
-     * @expectedException \PhpParser\Error
-     * @expectedExceptionMessage my error in /my/path
-     */
     public function testIncludesPathname()
     {
+        $this->expectException(\PhpParser\Error::class);
+        $this->expectExceptionMessage('my error in /my/path');
         $h = new ClassManifestErrorHandler('/my/path');
         $e = new Error('my error');
         $h->handleError($e);

--- a/tests/php/Core/Manifest/ClassManifestTest.php
+++ b/tests/php/Core/Manifest/ClassManifestTest.php
@@ -27,7 +27,7 @@ class ClassManifestTest extends SapphireTest
      */
     protected $manifestTests;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Core/Manifest/ConfigManifestTest.php
+++ b/tests/php/Core/Manifest/ConfigManifestTest.php
@@ -13,7 +13,7 @@ use SilverStripe\Dev\SapphireTest;
 
 class ConfigManifestTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -22,7 +22,7 @@ class ConfigManifestTest extends SapphireTest
         ModuleLoader::inst()->pushManifest($moduleManifest);
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         ModuleLoader::inst()->popManifest();
         parent::tearDown();
@@ -225,7 +225,7 @@ class ConfigManifestTest extends SapphireTest
             'Fragment is included if both blocks succeed.'
         );
     }
-    
+
     public function testExtensionLoaded()
     {
         $config = $this->getConfigFixtureValue('ExtensionLoaded');

--- a/tests/php/Core/Manifest/ModuleManifestTest.php
+++ b/tests/php/Core/Manifest/ModuleManifestTest.php
@@ -17,7 +17,7 @@ class ModuleManifestTest extends SapphireTest
      */
     protected $manifest;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Core/Manifest/ModuleResourceTest.php
+++ b/tests/php/Core/Manifest/ModuleResourceTest.php
@@ -18,7 +18,7 @@ class ModuleResourceTest extends SapphireTest
      */
     protected $manifest;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Core/Manifest/NamespacedClassManifestTest.php
+++ b/tests/php/Core/Manifest/NamespacedClassManifestTest.php
@@ -25,7 +25,7 @@ class NamespacedClassManifestTest extends SapphireTest
      */
     protected $manifest;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -35,7 +35,7 @@ class NamespacedClassManifestTest extends SapphireTest
         ClassLoader::inst()->pushManifest($this->manifest, false);
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         parent::tearDown();
         ClassLoader::inst()->popManifest();

--- a/tests/php/Core/Manifest/PrioritySorterTest.php
+++ b/tests/php/Core/Manifest/PrioritySorterTest.php
@@ -12,7 +12,7 @@ class PrioritySorterTest extends SapphireTest
      */
     protected $sorter;
 
-    public function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $modules = [

--- a/tests/php/Core/Manifest/ThemeResourceLoaderTest.php
+++ b/tests/php/Core/Manifest/ThemeResourceLoaderTest.php
@@ -33,7 +33,7 @@ class ThemeResourceLoaderTest extends SapphireTest
     /**
      * Set up manifest before each test
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -60,7 +60,7 @@ class ThemeResourceLoaderTest extends SapphireTest
         ThemeResourceLoader::flush();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         ModuleLoader::inst()->popManifest();
         parent::tearDown();

--- a/tests/php/Core/Manifest/VersionProviderTest.php
+++ b/tests/php/Core/Manifest/VersionProviderTest.php
@@ -54,9 +54,9 @@ class VersionProviderTest extends SapphireTest
         ]);
 
         $result = $this->provider->getVersion();
-        $this->assertContains('SiteConfig: ', $result);
-        $this->assertContains('Framework: ', $result);
-        $this->assertContains(', ', $result);
+        $this->assertStringContainsString('SiteConfig: ', $result);
+        $this->assertStringContainsString('Framework: ', $result);
+        $this->assertStringContainsString(', ', $result);
     }
 
     public function testGetModulesFromComposerLock()
@@ -85,6 +85,6 @@ class VersionProviderTest extends SapphireTest
         ]);
 
         $result = $mock->getVersion();
-        $this->assertContains('Some Package: 1.2.3', $result);
+        $this->assertStringContainsString('Some Package: 1.2.3', $result);
     }
 }

--- a/tests/php/Core/Manifest/VersionProviderTest.php
+++ b/tests/php/Core/Manifest/VersionProviderTest.php
@@ -13,7 +13,7 @@ class VersionProviderTest extends SapphireTest
      */
     protected $provider;
 
-    public function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->provider = new VersionProvider;

--- a/tests/php/Core/MemoryLimitTest.php
+++ b/tests/php/Core/MemoryLimitTest.php
@@ -12,7 +12,7 @@ class MemoryLimitTest extends SapphireTest
     protected $origMemLimit;
     protected $origTimeLimit;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -29,7 +29,7 @@ class MemoryLimitTest extends SapphireTest
         }
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         if (!in_array('suhosin', get_loaded_extensions())) {
             ini_set('memory_limit', $this->origMemLimit);

--- a/tests/php/Core/ObjectTest.php
+++ b/tests/php/Core/ObjectTest.php
@@ -31,7 +31,7 @@ use SilverStripe\Versioned\Versioned;
 class ObjectTest extends SapphireTest
 {
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         Injector::inst()->unregisterObjects([
@@ -290,7 +290,7 @@ class ObjectTest extends SapphireTest
             $objectTest_ExtensionTest->hasExtension(ExtendTest3::class),
             "Extensions are detected with instance hasExtension() when added through add_extension()"
         );
-        
+
         // load in a custom implementation
         Injector::inst()->registerService(new ExtendTest5(), ExtendTest4::class);
         $this->assertTrue(

--- a/tests/php/Core/PhpSyntaxTest.php
+++ b/tests/php/Core/PhpSyntaxTest.php
@@ -9,7 +9,7 @@ use SilverStripe\Dev\SapphireTest;
  */
 class PhpSyntaxTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->markTestSkipped('This needs to be written to include only core php files, not test/thirdparty files');

--- a/tests/php/Dev/BulkLoaderResultTest.php
+++ b/tests/php/Dev/BulkLoaderResultTest.php
@@ -13,7 +13,7 @@ class BulkLoaderResultTest extends SapphireTest
         Player::class,
     ];
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         Player::create(array('Name' => 'Vincent', 'Status' => 'Available'))->write();

--- a/tests/php/Dev/CLIDebugViewTest.php
+++ b/tests/php/Dev/CLIDebugViewTest.php
@@ -10,7 +10,7 @@ class CLIDebugViewTest extends SapphireTest
 {
     protected $caller = null;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Dev/CSVParserTest.php
+++ b/tests/php/Dev/CSVParserTest.php
@@ -15,7 +15,7 @@ class CSVParserTest extends SapphireTest
      */
     protected $csvPath = null;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->csvPath = __DIR__ . '/CsvBulkLoaderTest/csv/';

--- a/tests/php/Dev/CsvBulkLoaderTest.php
+++ b/tests/php/Dev/CsvBulkLoaderTest.php
@@ -31,7 +31,7 @@ class CsvBulkLoaderTest extends SapphireTest
      */
     protected $csvPath = null;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->csvPath = __DIR__ . '/CsvBulkLoaderTest/csv/';

--- a/tests/php/Dev/DebugViewTest.php
+++ b/tests/php/Dev/DebugViewTest.php
@@ -10,7 +10,7 @@ class DebugViewTest extends SapphireTest
 {
     protected $caller = null;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Dev/DeprecationTest.php
+++ b/tests/php/Dev/DeprecationTest.php
@@ -32,11 +32,9 @@ class DeprecationTest extends SapphireTest
         $this->assertNull(Deprecation::notice('2.0', 'Deprecation test failed'));
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\Error\Error
-     */
     public function testEqualVersionTriggersNotice()
     {
+        $this->expectException(\PHPUnit\Framework\Error\Error::class);
         Deprecation::notification_version('2.0.0');
         Deprecation::notice('2.0.0', 'Deprecation test passed');
     }
@@ -48,11 +46,9 @@ class DeprecationTest extends SapphireTest
         $this->assertNull(Deprecation::notice('2.0.0', 'Deprecation test failed'));
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\Error\Error
-     */
     public function testGreaterVersionTriggersNotice()
     {
+        $this->expectException(\PHPUnit\Framework\Error\Error::class);
         Deprecation::notification_version('3.0.0');
         Deprecation::notice('2.0', 'Deprecation test passed');
     }
@@ -64,11 +60,9 @@ class DeprecationTest extends SapphireTest
         $this->callThatOriginatesFromFramework();
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\Error\Error
-     */
     public function testMatchingModuleNotifcationVersionAffectsNotice()
     {
+        $this->expectException(\PHPUnit\Framework\Error\Error::class);
         Deprecation::notification_version('1.0.0');
         Deprecation::notification_version('3.0.0', 'silverstripe/framework');
         $this->callThatOriginatesFromFramework();
@@ -82,32 +76,26 @@ class DeprecationTest extends SapphireTest
         );
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\Error\Error
-     * @expectedExceptionMessage DeprecationTest->testScopeMethod is deprecated. Method scope
-     */
     public function testScopeMethod()
     {
+        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $this->expectExceptionMessage('DeprecationTest->testScopeMethod is deprecated. Method scope');
         Deprecation::notification_version('2.0.0');
         Deprecation::notice('2.0.0', 'Method scope', Deprecation::SCOPE_METHOD);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\Error\Error
-     * @expectedExceptionMessage DeprecationTest is deprecated. Class scope
-     */
     public function testScopeClass()
     {
+        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $this->expectExceptionMessage('DeprecationTest is deprecated. Class scope');
         Deprecation::notification_version('2.0.0');
         Deprecation::notice('2.0.0', 'Class scope', Deprecation::SCOPE_CLASS);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\Error\Error
-     * @expectedExceptionMessage Global scope
-     */
     public function testScopeGlobal()
     {
+        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $this->expectExceptionMessage('Global scope');
         Deprecation::notification_version('2.0.0');
         Deprecation::notice('2.0.0', 'Global scope', Deprecation::SCOPE_GLOBAL);
     }

--- a/tests/php/Dev/DeprecationTest.php
+++ b/tests/php/Dev/DeprecationTest.php
@@ -11,7 +11,7 @@ class DeprecationTest extends SapphireTest
 
     static $originalVersionInfo;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -20,7 +20,7 @@ class DeprecationTest extends SapphireTest
         Deprecation::set_enabled(true);
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         Deprecation::restore_settings(self::$originalVersionInfo);
         parent::tearDown();

--- a/tests/php/Dev/DevAdminControllerTest.php
+++ b/tests/php/Dev/DevAdminControllerTest.php
@@ -43,8 +43,8 @@ class DevAdminControllerTest extends FunctionalTest
     {
         // Check for the controller running from the registered url above
         // (we use contains rather than equals because sometimes you get a warning)
-        $this->assertContains(Controller1::OK_MSG, $this->getCapture('/dev/x1'));
-        $this->assertContains(Controller1::OK_MSG, $this->getCapture('/dev/x1/y1'));
+        $this->assertStringContainsString(Controller1::OK_MSG, $this->getCapture('/dev/x1'));
+        $this->assertStringContainsString(Controller1::OK_MSG, $this->getCapture('/dev/x1/y1'));
     }
 
     public function testGoodRegisteredControllerStatus()

--- a/tests/php/Dev/DevAdminControllerTest.php
+++ b/tests/php/Dev/DevAdminControllerTest.php
@@ -14,7 +14,7 @@ use SilverStripe\Dev\Tests\DevAdminControllerTest\Controller1;
 class DevAdminControllerTest extends FunctionalTest
 {
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Dev/FixtureBlueprintTest.php
+++ b/tests/php/Dev/FixtureBlueprintTest.php
@@ -144,12 +144,10 @@ class FixtureBlueprintTest extends SapphireTest
         $this->assertNotNull($obj2->HasManyRelation()->find('ID', $relation2->ID));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage No fixture definitions found
-     */
     public function testCreateWithInvalidRelationName()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No fixture definitions found');
         $blueprint = new FixtureBlueprint(TestDataObject::class);
 
         $obj = $blueprint->createObject(
@@ -165,12 +163,10 @@ class FixtureBlueprintTest extends SapphireTest
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage No fixture definitions found
-     */
     public function testCreateWithInvalidRelationIdentifier()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No fixture definitions found');
         $blueprint = new FixtureBlueprint(TestDataObject::class);
 
         $obj = $blueprint->createObject(
@@ -186,12 +182,10 @@ class FixtureBlueprintTest extends SapphireTest
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Invalid format
-     */
     public function testCreateWithInvalidRelationFormat()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid format');
         $factory = new FixtureFactory();
         $blueprint = new FixtureBlueprint(TestDataObject::class);
 

--- a/tests/php/Dev/SSListExporterTest.php
+++ b/tests/php/Dev/SSListExporterTest.php
@@ -18,7 +18,7 @@ class SSListExporterTest extends SapphireTest
      */
     private $exporter;
 
-    public function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->exporter = new SSListExporter();

--- a/tests/php/Dev/SapphireTestTest.php
+++ b/tests/php/Dev/SapphireTestTest.php
@@ -123,10 +123,10 @@ class SapphireTestTest extends SapphireTest
      *
      * @testdox assertion assertListAllMatch fails when not all items are matching
      *
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
     public function testAssertListAllMatchFailsWhenNotMatchingAllItems($match, $itemsForList)
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
         $list = $this->generateArrayListFromItems($itemsForList);
 
         $this->assertListAllMatch($match, $list);
@@ -157,10 +157,10 @@ class SapphireTestTest extends SapphireTest
      * @param $matches
      * @param $itemsForList array
      *
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
     public function testAssertListContainsFailsIfListDoesNotContainMatch($matches, $itemsForList)
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
         $list = $this->generateArrayListFromItems($itemsForList);
         $list->push(Member::create(['FirstName' => 'Foo', 'Surname' => 'Foo']));
         $list->push(Member::create(['FirstName' => 'Bar', 'Surname' => 'Bar']));
@@ -192,10 +192,10 @@ class SapphireTestTest extends SapphireTest
      *
      * @testdox assertion assertListNotContains throws a exception when a matching item is found in the list
      *
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
     public function testAssertListNotContainsFailsWhenListContainsAMatch($matches, $itemsForList)
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
         $list = $this->generateArrayListFromItems($itemsForList);
         $list->push(Member::create(['FirstName' => 'Foo', 'Surname' => 'Foo']));
         $list->push(Member::create(['FirstName' => 'Bar', 'Surname' => 'Bar']));
@@ -225,10 +225,10 @@ class SapphireTestTest extends SapphireTest
      * @param $matches
      * @param $itemsForList
      *
-     * @expectedException \PHPUnit\Framework\ExpectationFailedException
      */
     public function testAssertListEqualsFailsOnNonEqualLists($matches, $itemsForList)
     {
+        $this->expectException(\PHPUnit\Framework\ExpectationFailedException::class);
         $list = $this->generateArrayListFromItems($itemsForList);
 
         $this->assertListEquals($matches, $list);

--- a/tests/php/Dev/YamlFixtureTest.php
+++ b/tests/php/Dev/YamlFixtureTest.php
@@ -45,11 +45,9 @@ class YamlFixtureTest extends SapphireTest
         $this->assertNull($obj->getFixtureFile());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testFailsWithInvalidFixturePath()
     {
+        $this->expectException(InvalidArgumentException::class);
         $invalidPath = ltrim(FRAMEWORK_DIR . '/tests/testing/invalid.yml', '/');
         $obj = Injector::inst()->create(YamlFixture::class, $invalidPath);
     }

--- a/tests/php/Forms/CheckboxSetFieldMultiEnumTest.php
+++ b/tests/php/Forms/CheckboxSetFieldMultiEnumTest.php
@@ -26,7 +26,7 @@ class CheckboxSetFieldMulitEnumTest extends SapphireTest
         }
     }
 
-    public function setUp()
+    protected function setUp() : void
     {
         if (!(DB::get_conn() instanceof MySQLDatabase)) {
             $this->markTestSkipped('DBMultiEnum only supported by MySQL');
@@ -35,7 +35,7 @@ class CheckboxSetFieldMulitEnumTest extends SapphireTest
         parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown() : void
     {
         if (!(DB::get_conn() instanceof MySQLDatabase)) {
             return;

--- a/tests/php/Forms/CheckboxSetFieldTest.php
+++ b/tests/php/Forms/CheckboxSetFieldTest.php
@@ -359,13 +359,13 @@ class CheckboxSetFieldTest extends SapphireTest
             )
         );
         $fieldHTML = (string)$field1->Field();
-        $this->assertContains('One', $fieldHTML);
-        $this->assertContains('Two &amp; Three', $fieldHTML);
-        $this->assertNotContains('Two & Three', $fieldHTML);
-        $this->assertContains('Four &amp; Five &amp; Six', $fieldHTML);
-        $this->assertNotContains('Four & Five & Six', $fieldHTML);
-        $this->assertContains('&lt;firstname&gt;', $fieldHTML);
-        $this->assertNotContains('<firstname>', $fieldHTML);
+        $this->assertStringContainsString('One', $fieldHTML);
+        $this->assertStringContainsString('Two &amp; Three', $fieldHTML);
+        $this->assertStringNotContainsString('Two & Three', $fieldHTML);
+        $this->assertStringContainsString('Four &amp; Five &amp; Six', $fieldHTML);
+        $this->assertStringNotContainsString('Four & Five & Six', $fieldHTML);
+        $this->assertStringContainsString('&lt;firstname&gt;', $fieldHTML);
+        $this->assertStringNotContainsString('<firstname>', $fieldHTML);
     }
 
     /**

--- a/tests/php/Forms/CompositeFieldTest.php
+++ b/tests/php/Forms/CompositeFieldTest.php
@@ -134,9 +134,9 @@ class CompositeFieldTest extends SapphireTest
         $field->setColumnCount(3);
         $result = $field->extraClass();
 
-        $this->assertContains('field', $result, 'Default class was not added');
-        $this->assertContains('CompositeField', $result, 'Default class was not added');
-        $this->assertContains('multicolumn', $result, 'Multi column field did not have extra class added');
+        $this->assertStringContainsString('field', $result, 'Default class was not added');
+        $this->assertStringContainsString('CompositeField', $result, 'Default class was not added');
+        $this->assertStringContainsString('multicolumn', $result, 'Multi column field did not have extra class added');
     }
 
     public function testGetAttributes()
@@ -160,17 +160,13 @@ class CompositeFieldTest extends SapphireTest
         $this->assertNull($result['title']);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\Error\Error
-     * @expectedExceptionMessageRegExp /a field called 'Test' appears twice in your form.*TextField.*TextField/
-     */
     public function testCollateDataFieldsThrowsErrorOnDuplicateChildren()
     {
-        $field = CompositeField::create(
-            TextField::create('Test'),
-            TextField::create('Test')
+        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $this->expectExceptionMessageMatches(
+            '/a field called \'Test\' appears twice in your form.*TextField.*TextField/'
         );
-
+        $field = CompositeField::create(TextField::create('Test'), TextField::create('Test'));
         $list = [];
         $field->collateDataFields($list);
     }
@@ -265,8 +261,8 @@ class CompositeFieldTest extends SapphireTest
         $field->setName('TestComposite');
 
         $result = $field->debug();
-        $this->assertContains(CompositeField::class . ' (TestComposite)', $result);
-        $this->assertContains('TestTextField', $result);
-        $this->assertContains('<ul', $result, 'Result should be formatted as a <ul>');
+        $this->assertStringContainsString(CompositeField::class . ' (TestComposite)', $result);
+        $this->assertStringContainsString('TestTextField', $result);
+        $this->assertStringContainsString('<ul', $result, 'Result should be formatted as a <ul>');
     }
 }

--- a/tests/php/Forms/ConfirmedPasswordFieldTest.php
+++ b/tests/php/Forms/ConfirmedPasswordFieldTest.php
@@ -67,12 +67,12 @@ class ConfirmedPasswordFieldTest extends SapphireTest
         //hide by default and display show/hide toggle button
         $field = new ConfirmedPasswordField('Test', 'Testing', 'valueA', null, true);
         $fieldHTML = $field->Field();
-        $this->assertContains(
+        $this->assertStringContainsString(
             "showOnClickContainer",
             $fieldHTML,
             "Test class for hiding/showing the form contents is set"
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "showOnClick",
             $fieldHTML,
             "Test class for hiding/showing the form contents is set"
@@ -81,12 +81,12 @@ class ConfirmedPasswordFieldTest extends SapphireTest
         //show all by default
         $field = new ConfirmedPasswordField('Test', 'Testing', 'valueA', null, false);
         $fieldHTML = $field->Field();
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "showOnClickContainer",
             $fieldHTML,
             "Test class for hiding/showing the form contents is set"
         );
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "showOnClick",
             $fieldHTML,
             "Test class for hiding/showing the form contents is set"
@@ -200,7 +200,7 @@ class ConfirmedPasswordFieldTest extends SapphireTest
         $this->assertSame($expectValid, $result, 'Validate method should return its result');
         $this->assertSame($expectValid, $validator->getResult()->isValid());
         if ($expectedMessage) {
-            $this->assertContains($expectedMessage, $validator->getResult()->serialize());
+            $this->assertStringContainsString($expectedMessage, $validator->getResult()->serialize());
         }
     }
 
@@ -233,7 +233,7 @@ class ConfirmedPasswordFieldTest extends SapphireTest
 
         $this->assertFalse($result, 'Validate method should return its result');
         $this->assertFalse($validator->getResult()->isValid());
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Passwords must have at least one digit and one alphanumeric character',
             $validator->getResult()->serialize()
         );
@@ -252,7 +252,7 @@ class ConfirmedPasswordFieldTest extends SapphireTest
 
         $this->assertFalse($result, 'Validate method should return its result');
         $this->assertFalse($validator->getResult()->isValid());
-        $this->assertContains(
+        $this->assertStringContainsString(
             'You must enter your current password',
             $validator->getResult()->serialize()
         );
@@ -274,7 +274,7 @@ class ConfirmedPasswordFieldTest extends SapphireTest
 
         $this->assertFalse($result, 'Validate method should return its result');
         $this->assertFalse($validator->getResult()->isValid());
-        $this->assertContains(
+        $this->assertStringContainsString(
             'You must be logged in to change your password',
             $validator->getResult()->serialize()
         );
@@ -300,7 +300,7 @@ class ConfirmedPasswordFieldTest extends SapphireTest
 
         $this->assertFalse($result, 'Validate method should return its result');
         $this->assertFalse($validator->getResult()->isValid());
-        $this->assertContains(
+        $this->assertStringContainsString(
             'The current password you have entered is not correct',
             $validator->getResult()->serialize()
         );
@@ -357,7 +357,7 @@ class ConfirmedPasswordFieldTest extends SapphireTest
 
         $this->assertInstanceOf(ReadonlyField::class, $result);
         $this->assertSame('Change it', $result->Title());
-        $this->assertContains('***', $result->Value());
+        $this->assertStringContainsString('***', $result->Value());
     }
 
     public function testPerformDisabledTransformation()

--- a/tests/php/Forms/ConfirmedPasswordFieldTest.php
+++ b/tests/php/Forms/ConfirmedPasswordFieldTest.php
@@ -16,7 +16,7 @@ class ConfirmedPasswordFieldTest extends SapphireTest
 {
     protected $usesDatabase = true;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Forms/CurrencyFieldDisabledTest.php
+++ b/tests/php/Forms/CurrencyFieldDisabledTest.php
@@ -13,9 +13,9 @@ class CurrencyFieldDisabledTest extends SapphireTest
         $field = new CurrencyField_Disabled('Test', '', '$5.00');
         $result = $field->Field();
 
-        $this->assertContains('<input', $result, 'An input should be rendered');
-        $this->assertContains('disabled', $result, 'The input should be disabled');
-        $this->assertContains('$5.00', $result, 'The value should be rendered');
+        $this->assertStringContainsString('<input', $result, 'An input should be rendered');
+        $this->assertStringContainsString('disabled', $result, 'The input should be disabled');
+        $this->assertStringContainsString('$5.00', $result, 'The value should be rendered');
     }
 
     /**
@@ -27,8 +27,8 @@ class CurrencyFieldDisabledTest extends SapphireTest
         $field = new CurrencyField_Disabled('Test', '', '€5.00');
         $result = $field->Field();
 
-        $this->assertContains('<input', $result, 'An input should be rendered');
-        $this->assertContains('disabled', $result, 'The input should be disabled');
-        $this->assertContains('€5.00', $result, 'The value should be rendered');
+        $this->assertStringContainsString('<input', $result, 'An input should be rendered');
+        $this->assertStringContainsString('disabled', $result, 'The input should be disabled');
+        $this->assertStringContainsString('€5.00', $result, 'The value should be rendered');
     }
 }

--- a/tests/php/Forms/CurrencyFieldReadonlyTest.php
+++ b/tests/php/Forms/CurrencyFieldReadonlyTest.php
@@ -21,9 +21,9 @@ class CurrencyFieldReadonlyTest extends SapphireTest
         $field = new CurrencyField_Readonly('Test', '', '$5.00');
         $result = $field->Field();
 
-        $this->assertContains('<input', $result, 'An input should be rendered');
-        $this->assertContains('readonly', $result, 'The input should be readonly');
-        $this->assertContains('$5.00', $result, 'The value should be rendered');
+        $this->assertStringContainsString('<input', $result, 'An input should be rendered');
+        $this->assertStringContainsString('readonly', $result, 'The input should be readonly');
+        $this->assertStringContainsString('$5.00', $result, 'The value should be rendered');
     }
 
     public function testFieldWithOutValue()
@@ -32,9 +32,9 @@ class CurrencyFieldReadonlyTest extends SapphireTest
         $field = new CurrencyField_Readonly('Test', '', null);
         $result = $field->Field();
 
-        $this->assertContains('<input', $result, 'An input should be rendered');
-        $this->assertContains('readonly', $result, 'The input should be readonly');
-        $this->assertContains('AUD0.00', $result, 'The value should be rendered');
+        $this->assertStringContainsString('<input', $result, 'An input should be rendered');
+        $this->assertStringContainsString('readonly', $result, 'The input should be readonly');
+        $this->assertStringContainsString('AUD0.00', $result, 'The value should be rendered');
     }
 
     /**
@@ -46,8 +46,8 @@ class CurrencyFieldReadonlyTest extends SapphireTest
         $field = new CurrencyField_Readonly('Test', '', '€5.00');
         $result = $field->Field();
 
-        $this->assertContains('<input', $result, 'An input should be rendered');
-        $this->assertContains('readonly', $result, 'The input should be readonly');
-        $this->assertContains('€5.00', $result, 'The value should be rendered');
+        $this->assertStringContainsString('<input', $result, 'An input should be rendered');
+        $this->assertStringContainsString('readonly', $result, 'The input should be readonly');
+        $this->assertStringContainsString('€5.00', $result, 'The value should be rendered');
     }
 }

--- a/tests/php/Forms/CurrencyFieldTest.php
+++ b/tests/php/Forms/CurrencyFieldTest.php
@@ -307,6 +307,6 @@ class CurrencyFieldTest extends SapphireTest
 
         $this->assertFalse($result, 'Validation should fail since wrong currency was used');
         $this->assertFalse($validator->getResult()->isValid(), 'Validator should receive failed state');
-        $this->assertContains('Please enter a valid currency', $validator->getResult()->serialize());
+        $this->assertStringContainsString('Please enter a valid currency', $validator->getResult()->serialize());
     }
 }

--- a/tests/php/Forms/DateFieldDisabledTest.php
+++ b/tests/php/Forms/DateFieldDisabledTest.php
@@ -12,7 +12,7 @@ use SilverStripe\ORM\FieldType\DBDatetime;
  */
 class DateFieldDisabledTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         i18n::set_locale('en_NZ');

--- a/tests/php/Forms/DateFieldDisabledTest.php
+++ b/tests/php/Forms/DateFieldDisabledTest.php
@@ -79,7 +79,7 @@ class DateFieldDisabledTest extends SapphireTest
     {
         $field = new DateField_Disabled('Test');
         $result = $field->Type();
-        $this->assertContains('readonly', $result, 'Disabled field should be treated as readonly');
-        $this->assertContains('date_disabled', $result, 'Field should contain date_disabled class');
+        $this->assertStringContainsString('readonly', $result, 'Disabled field should be treated as readonly');
+        $this->assertStringContainsString('date_disabled', $result, 'Field should contain date_disabled class');
     }
 }

--- a/tests/php/Forms/DateFieldTest.php
+++ b/tests/php/Forms/DateFieldTest.php
@@ -192,36 +192,30 @@ class DateFieldTest extends SapphireTest
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessageRegExp /Please opt-out .* if using setDateFormat/
-     */
     public function testHtml5WithCustomFormatThrowsException()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/Please opt-out .* if using setDateFormat/');
         $dateField = new DateField('Date', 'Date');
         $dateField->setValue('2010-03-31');
         $dateField->setDateFormat('d/M/y');
         $dateField->Value();
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessageRegExp /Please opt-out .* if using setDateLength/
-     */
     public function testHtml5WithCustomDateLengthThrowsException()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/Please opt-out .* if using setDateLength/');
         $dateField = new DateField('Date', 'Date');
         $dateField->setValue('2010-03-31');
         $dateField->setDateLength(IntlDateFormatter::MEDIUM);
         $dateField->Value();
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessageRegExp /Please opt-out .* if using setLocale/
-     */
     public function testHtml5WithCustomLocaleThrowsException()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/Please opt-out .* if using setLocale/');
         $dateField = new DateField('Date', 'Date');
         $dateField->setValue('2010-03-31');
         $dateField->setLocale('de_DE');

--- a/tests/php/Forms/DateFieldTest.php
+++ b/tests/php/Forms/DateFieldTest.php
@@ -16,7 +16,7 @@ use SilverStripe\ORM\FieldType\DBDatetime;
  */
 class DateFieldTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         i18n::set_locale('en_NZ');

--- a/tests/php/Forms/DatetimeFieldTest.php
+++ b/tests/php/Forms/DatetimeFieldTest.php
@@ -17,7 +17,7 @@ class DatetimeFieldTest extends SapphireTest
 {
     protected $timezone = null;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         i18n::set_locale('en_NZ');
@@ -26,7 +26,7 @@ class DatetimeFieldTest extends SapphireTest
         $this->timezone = date_default_timezone_get();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         DBDatetime::clear_mock_now();
         date_default_timezone_set($this->timezone);

--- a/tests/php/Forms/DatetimeFieldTest.php
+++ b/tests/php/Forms/DatetimeFieldTest.php
@@ -490,12 +490,10 @@ class DatetimeFieldTest extends SapphireTest
         $this->assertTrue($result->isReadonly());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage Can't change timezone after setting a value
-     */
     public function testSetTimezoneThrowsExceptionWhenChangingTimezoneAfterSettingValue()
     {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('Can\'t change timezone after setting a value');
         date_default_timezone_set('Europe/Berlin');
         $field = new DatetimeField('Datetime', 'Time', '2003-03-29 23:59:38');
         $field->setTimezone('Pacific/Auckland');

--- a/tests/php/Forms/DefaultFormFactoryTest.php
+++ b/tests/php/Forms/DefaultFormFactoryTest.php
@@ -9,12 +9,10 @@ use SilverStripe\ORM\DataObject;
 
 class DefaultFormFactoryTest extends SapphireTest
 {
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Missing required context/
-     */
     public function testGetFormThrowsExceptionOnMissingContext()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Missing required context/');
         $factory = new DefaultFormFactory();
         $factory->getForm();
     }

--- a/tests/php/Forms/DropdownFieldTest.php
+++ b/tests/php/Forms/DropdownFieldTest.php
@@ -400,7 +400,7 @@ class DropdownFieldTest extends SapphireTest
      * string of HTML.
      *
      * @param  string $html HTML to scan for elements
-     * @return SimpleXMLElement
+     * @return SimpleXMLElement[]
      */
     public function findOptionElements($html)
     {

--- a/tests/php/Forms/EmailFieldTest.php
+++ b/tests/php/Forms/EmailFieldTest.php
@@ -77,6 +77,6 @@ class EmailFieldTest extends FunctionalTest
             ['Email' => 'test@test.com']
         );
 
-        $this->assertContains('Test save was successful', $response->getBody());
+        $this->assertStringContainsString('Test save was successful', $response->getBody());
     }
 }

--- a/tests/php/Forms/FormActionTest.php
+++ b/tests/php/Forms/FormActionTest.php
@@ -11,10 +11,10 @@ class FormActionTest extends SapphireTest
     public function testGetField()
     {
         $formAction = new FormAction('test');
-        $this->assertContains('type="submit"', $formAction->getAttributesHTML());
+        $this->assertStringContainsString('type="submit"', $formAction->getAttributesHTML());
 
         $formAction->setAttribute('src', 'file.png');
-        $this->assertContains('type="image"', $formAction->getAttributesHTML());
+        $this->assertStringContainsString('type="image"', $formAction->getAttributesHTML());
     }
 
     public function testGetTitle()

--- a/tests/php/Forms/FormFactoryTest.php
+++ b/tests/php/Forms/FormFactoryTest.php
@@ -28,7 +28,7 @@ class FormFactoryTest extends SapphireTest
         return [];
     }
 
-    public function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Forms/FormFieldTest.php
+++ b/tests/php/Forms/FormFieldTest.php
@@ -39,7 +39,7 @@ class FormFieldTest extends SapphireTest
 
         $field = new FormField('MyField');
 
-        $this->assertContains('class1', $field->extraClass(), 'Class list does not contain expected class');
+        $this->assertStringContainsString('class1', $field->extraClass(), 'Class list does not contain expected class');
 
         FormField::config()->update(
             'default_classes',
@@ -51,7 +51,11 @@ class FormFieldTest extends SapphireTest
 
         $field = new FormField('MyField');
 
-        $this->assertContains('class1 class2', $field->extraClass(), 'Class list does not contain expected class');
+        $this->assertStringContainsString(
+            'class1 class2',
+            $field->extraClass(),
+            'Class list does not contain expected class'
+        );
 
         FormField::config()->update(
             'default_classes',
@@ -62,11 +66,11 @@ class FormFieldTest extends SapphireTest
 
         $field = new FormField('MyField');
 
-        $this->assertContains('class3', $field->extraClass(), 'Class list does not contain expected class');
+        $this->assertStringContainsString('class3', $field->extraClass(), 'Class list does not contain expected class');
 
         $field->removeExtraClass('class3');
 
-        $this->assertNotContains('class3', $field->extraClass(), 'Class list contains unexpected class');
+        $this->assertStringNotContainsString('class3', $field->extraClass(), 'Class list contains unexpected class');
 
         TextField::config()->update(
             'default_classes',
@@ -78,8 +82,16 @@ class FormFieldTest extends SapphireTest
         $field = new TextField('MyField');
 
         //check default classes inherit
-        $this->assertContains('class3', $field->extraClass(), 'Class list does not contain inherited class');
-        $this->assertContains('textfield-class', $field->extraClass(), 'Class list does not contain expected class');
+        $this->assertStringContainsString(
+            'class3',
+            $field->extraClass(),
+            'Class list does not contain inherited class'
+        );
+        $this->assertStringContainsString(
+            'textfield-class',
+            $field->extraClass(),
+            'Class list does not contain expected class'
+        );
 
         Config::unnest();
     }
@@ -158,35 +170,35 @@ class FormFieldTest extends SapphireTest
         $field = new FormField('MyField');
 
         $field->setAttribute('foo', 'bar');
-        $this->assertContains('foo="bar"', $field->getAttributesHTML());
+        $this->assertStringContainsString('foo="bar"', $field->getAttributesHTML());
 
         $field->setAttribute('foo', null);
-        $this->assertNotContains('foo=', $field->getAttributesHTML());
+        $this->assertStringNotContainsString('foo=', $field->getAttributesHTML());
 
         $field->setAttribute('foo', '');
-        $this->assertNotContains('foo=', $field->getAttributesHTML());
+        $this->assertStringNotContainsString('foo=', $field->getAttributesHTML());
 
         $field->setAttribute('foo', false);
-        $this->assertNotContains('foo=', $field->getAttributesHTML());
+        $this->assertStringNotContainsString('foo=', $field->getAttributesHTML());
 
         $field->setAttribute('foo', true);
-        $this->assertContains('foo="foo"', $field->getAttributesHTML());
+        $this->assertStringContainsString('foo="foo"', $field->getAttributesHTML());
 
         $field->setAttribute('foo', 'false');
-        $this->assertContains('foo="false"', $field->getAttributesHTML());
+        $this->assertStringContainsString('foo="false"', $field->getAttributesHTML());
 
         $field->setAttribute('foo', 'true');
-        $this->assertContains('foo="true"', $field->getAttributesHTML());
+        $this->assertStringContainsString('foo="true"', $field->getAttributesHTML());
 
         $field->setAttribute('foo', 0);
-        $this->assertContains('foo="0"', $field->getAttributesHTML());
+        $this->assertStringContainsString('foo="0"', $field->getAttributesHTML());
 
         $field->setAttribute('one', 1);
         $field->setAttribute('two', 2);
         $field->setAttribute('three', 3);
-        $this->assertNotContains('one="1"', $field->getAttributesHTML('one', 'two'));
-        $this->assertNotContains('two="2"', $field->getAttributesHTML('one', 'two'));
-        $this->assertContains('three="3"', $field->getAttributesHTML('one', 'two'));
+        $this->assertStringNotContainsString('one="1"', $field->getAttributesHTML('one', 'two'));
+        $this->assertStringNotContainsString('two="2"', $field->getAttributesHTML('one', 'two'));
+        $this->assertStringContainsString('three="3"', $field->getAttributesHTML('one', 'two'));
     }
 
     /**
@@ -240,18 +252,18 @@ class FormFieldTest extends SapphireTest
     {
         $field = new FormField('MyField');
         $field->setReadonly(true);
-        $this->assertContains('readonly="readonly"', $field->getAttributesHTML());
+        $this->assertStringContainsString('readonly="readonly"', $field->getAttributesHTML());
         $field->setReadonly(false);
-        $this->assertNotContains('readonly="readonly"', $field->getAttributesHTML());
+        $this->assertStringNotContainsString('readonly="readonly"', $field->getAttributesHTML());
     }
 
     public function testDisabled()
     {
         $field = new FormField('MyField');
         $field->setDisabled(true);
-        $this->assertContains('disabled="disabled"', $field->getAttributesHTML());
+        $this->assertStringContainsString('disabled="disabled"', $field->getAttributesHTML());
         $field->setDisabled(false);
-        $this->assertNotContains('disabled="disabled"', $field->getAttributesHTML());
+        $this->assertStringNotContainsString('disabled="disabled"', $field->getAttributesHTML());
     }
 
     public function testEveryFieldTransformsReadonlyAsClone()
@@ -357,7 +369,7 @@ class FormFieldTest extends SapphireTest
     {
         $field = new FormField('MyField');
         $schema = $field->getSchemaDataDefaults();
-        $this->assertInternalType('array', $schema);
+        $this->assertIsArray($schema);
     }
 
     public function testGetSchemaData()
@@ -443,11 +455,9 @@ class FormFieldTest extends SapphireTest
         $this->assertSame('foo/field/Test/bar', $field->Link('bar'));
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testLinkWithoutForm()
     {
+        $this->expectException(\LogicException::class);
         $field = new FormField('Test');
         $field->Link('bar');
     }

--- a/tests/php/Forms/FormSchemaTest.php
+++ b/tests/php/Forms/FormSchemaTest.php
@@ -20,7 +20,7 @@ use SilverStripe\Forms\PopoverField;
  */
 class FormSchemaTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Forms/FormSchemaTest.php
+++ b/tests/php/Forms/FormSchemaTest.php
@@ -38,7 +38,7 @@ class FormSchemaTest extends SapphireTest
         $expected = json_decode(file_get_contents(__DIR__ . '/FormSchemaTest/testGetSchema.json'), true);
 
         $schema = $formSchema->getSchema($form);
-        $this->assertInternalType('array', $schema);
+        $this->assertIsArray($schema);
         $this->assertEquals($expected, $schema);
     }
 
@@ -62,7 +62,7 @@ class FormSchemaTest extends SapphireTest
         ];
 
         $state = $formSchema->getState($form);
-        $this->assertInternalType('array', $state);
+        $this->assertIsArray($state);
         $this->assertEquals($expected, $state);
     }
 
@@ -92,7 +92,7 @@ class FormSchemaTest extends SapphireTest
         ];
 
         $state = $formSchema->getState($form);
-        $this->assertInternalType('array', $state);
+        $this->assertIsArray($state);
         $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($state));
     }
 
@@ -136,7 +136,7 @@ class FormSchemaTest extends SapphireTest
         ];
 
         $state = $formSchema->getState($form);
-        $this->assertInternalType('array', $state);
+        $this->assertIsArray($state);
         $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($state));
     }
 
@@ -167,7 +167,7 @@ class FormSchemaTest extends SapphireTest
         $expected = json_decode(file_get_contents(__DIR__ . '/FormSchemaTest/testGetNestedSchema.json'), true);
         $schema = $formSchema->getSchema($form);
 
-        $this->assertInternalType('array', $schema);
+        $this->assertIsArray($schema);
         $this->assertEquals($expected, $schema);
     }
 
@@ -207,7 +207,7 @@ class FormSchemaTest extends SapphireTest
         $formSchema = new FormSchema();
         $schema = $formSchema->getSchema($form);
         $expected = json_decode(file_get_contents(__DIR__ . '/FormSchemaTest/testSchemaValidation.json'), true);
-        $this->assertInternalType('array', $schema);
+        $this->assertIsArray($schema);
         $this->assertEquals($expected, $schema);
     }
 }

--- a/tests/php/Forms/FormTest.php
+++ b/tests/php/Forms/FormTest.php
@@ -136,16 +136,16 @@ class FormTest extends FunctionalTest
         );
 
         // Number field updates its value
-        $this->assertContains('<input type="text" name="Number" value="888"', $response->getBody());
+        $this->assertStringContainsString('<input type="text" name="Number" value="888"', $response->getBody());
 
 
         // Readonly field remains
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<input type="text" name="ReadonlyField" value="This value is readonly"',
             $response->getBody()
         );
 
-        $this->assertNotContains('hacxzored', $response->getBody());
+        $this->assertStringNotContainsString('hacxzored', $response->getBody());
     }
 
     public function testLoadDataFromUnchangedHandling()
@@ -492,13 +492,13 @@ class FormTest extends FunctionalTest
             'Required fields show a notification on field when left blank'
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '&#039;&lt;a href=&quot;http://mysite.com&quot;&gt;link&lt;/a&gt;&#039; is not a number, only '
             . 'numbers can be accepted for this field',
             $response->getBody(),
             "Validation messages are safely XML encoded"
         );
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             '<a href="http://mysite.com">link</a>',
             $response->getBody(),
             "Unsafe content is not emitted directly inside the response body"
@@ -779,7 +779,7 @@ class FormTest extends FunctionalTest
 
         $form = $this->getStubForm();
 
-        $this->assertContains('class1', $form->extraClass(), 'Class list does not contain expected class');
+        $this->assertStringContainsString('class1', $form->extraClass(), 'Class list does not contain expected class');
 
         Form::config()->update(
             'default_classes',
@@ -791,7 +791,11 @@ class FormTest extends FunctionalTest
 
         $form = $this->getStubForm();
 
-        $this->assertContains('class1 class2', $form->extraClass(), 'Class list does not contain expected class');
+        $this->assertStringContainsString(
+            'class1 class2',
+            $form->extraClass(),
+            'Class list does not contain expected class'
+        );
 
         Form::config()->update(
             'default_classes',
@@ -802,11 +806,11 @@ class FormTest extends FunctionalTest
 
         $form = $this->getStubForm();
 
-        $this->assertContains('class3', $form->extraClass(), 'Class list does not contain expected class');
+        $this->assertStringContainsString('class3', $form->extraClass(), 'Class list does not contain expected class');
 
         $form->removeExtraClass('class3');
 
-        $this->assertNotContains('class3', $form->extraClass(), 'Class list contains unexpected class');
+        $this->assertStringNotContainsString('class3', $form->extraClass(), 'Class list contains unexpected class');
     }
 
     public function testAttributes()
@@ -894,22 +898,22 @@ class FormTest extends FunctionalTest
         $form = $this->getStubForm();
 
         $form->setAttribute('foo', 'bar');
-        $this->assertContains('foo="bar"', $form->getAttributesHTML());
+        $this->assertStringContainsString('foo="bar"', $form->getAttributesHTML());
 
         $form->setAttribute('foo', null);
-        $this->assertNotContains('foo="bar"', $form->getAttributesHTML());
+        $this->assertStringNotContainsString('foo="bar"', $form->getAttributesHTML());
 
         $form->setAttribute('foo', true);
-        $this->assertContains('foo="foo"', $form->getAttributesHTML());
+        $this->assertStringContainsString('foo="foo"', $form->getAttributesHTML());
 
         $form->setAttribute('one', 1);
         $form->setAttribute('two', 2);
         $form->setAttribute('three', 3);
         $form->setAttribute('<html>', '<html>');
-        $this->assertNotContains('one="1"', $form->getAttributesHTML('one', 'two'));
-        $this->assertNotContains('two="2"', $form->getAttributesHTML('one', 'two'));
-        $this->assertContains('three="3"', $form->getAttributesHTML('one', 'two'));
-        $this->assertNotContains('<html>', $form->getAttributesHTML());
+        $this->assertStringNotContainsString('one="1"', $form->getAttributesHTML('one', 'two'));
+        $this->assertStringNotContainsString('two="2"', $form->getAttributesHTML('one', 'two'));
+        $this->assertStringContainsString('three="3"', $form->getAttributesHTML('one', 'two'));
+        $this->assertStringNotContainsString('<html>', $form->getAttributesHTML());
     }
 
     public function testMessageEscapeHtml()
@@ -918,7 +922,7 @@ class FormTest extends FunctionalTest
         $form->setMessage('<em>Escaped HTML</em>', 'good', ValidationResult::CAST_TEXT);
         $parser = new CSSContentParser($form->forTemplate());
         $messageEls = $parser->getBySelector('.message');
-        $this->assertContains(
+        $this->assertStringContainsString(
             '&lt;em&gt;Escaped HTML&lt;/em&gt;',
             $messageEls[0]->asXML()
         );
@@ -927,7 +931,7 @@ class FormTest extends FunctionalTest
         $form->setMessage('<em>Unescaped HTML</em>', 'good', ValidationResult::CAST_HTML);
         $parser = new CSSContentParser($form->forTemplate());
         $messageEls = $parser->getBySelector('.message');
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<em>Unescaped HTML</em>',
             $messageEls[0]->asXML()
         );
@@ -939,7 +943,7 @@ class FormTest extends FunctionalTest
         $form->Fields()->dataFieldByName('key1')->setMessage('<em>Escaped HTML</em>', 'good');
         $parser = new CSSContentParser($result = $form->forTemplate());
         $messageEls = $parser->getBySelector('#Form_Form_key1_Holder .message');
-        $this->assertContains(
+        $this->assertStringContainsString(
             '&lt;em&gt;Escaped HTML&lt;/em&gt;',
             $messageEls[0]->asXML()
         );
@@ -952,7 +956,7 @@ class FormTest extends FunctionalTest
             ->setMessage('<em>Unescaped HTML</em>', 'good', ValidationResult::CAST_HTML);
         $parser = new CSSContentParser($form->forTemplate());
         $messageEls = $parser->getBySelector('#Form_Form_key1_Holder .message');
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<em>Unescaped HTML</em>',
             $messageEls[0]->asXML()
         );
@@ -1046,25 +1050,25 @@ class FormTest extends FunctionalTest
 
         // Test our reloaded form field
         $body = $response->getBody();
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<input type="text" name="SomeDateField" value="15/06/2018"',
             $body,
             'Our reloaded form should contain a SomeDateField with the value "15/06/2018"'
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<input type="text" name="SomeFrenchNumericField" value="9 876,5432" ',
             $body,
             'Our reloaded form should contain a SomeFrenchNumericField with the value "9 876,5432"'
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<input type="text" name="SomeFrenchMoneyField[Currency]" value="NZD"',
             $body,
             'Our reloaded form should contain a SomeFrenchMoneyField[Currency] with the value "NZD"'
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<input type="text" name="SomeFrenchMoneyField[Amount]" value="9 876,54" ',
             $body,
             'Our reloaded form should contain a SomeFrenchMoneyField[Amount] with the value "9 876,54"'

--- a/tests/php/Forms/FormTest.php
+++ b/tests/php/Forms/FormTest.php
@@ -56,7 +56,7 @@ class FormTest extends FunctionalTest
 
     protected static $disable_themes = true;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Forms/GridField/GridFieldActionMenuTest.php
+++ b/tests/php/Forms/GridField/GridFieldActionMenuTest.php
@@ -55,7 +55,7 @@ class GridFieldActionMenuTest extends SapphireTest
         Permissions::class,
     );
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->list = new DataList(Team::class);

--- a/tests/php/Forms/GridField/GridFieldDataColumnsTest.php
+++ b/tests/php/Forms/GridField/GridFieldDataColumnsTest.php
@@ -42,10 +42,10 @@ class GridFieldDataColumnsTest extends SapphireTest
      * @covers \SilverStripe\Forms\GridField\GridFieldDataColumns::setDisplayFields
      * @covers \SilverStripe\Forms\GridField\GridFieldDataColumns::getDisplayFields
      *
-     * @expectedException \InvalidArgumentException
      */
     public function testGridFieldDisplayFieldsWithBadArguments()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $obj = new GridField('testfield', 'testfield', Member::get());
         $columns = $obj->getConfig()->getComponentByType(GridFieldDataColumns::class);
         $columns->setDisplayFields(new stdClass());

--- a/tests/php/Forms/GridField/GridFieldDeleteActionTest.php
+++ b/tests/php/Forms/GridField/GridFieldDeleteActionTest.php
@@ -56,7 +56,7 @@ class GridFieldDeleteActionTest extends SapphireTest
         Permissions::class,
     ];
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->list = new DataList(Team::class);

--- a/tests/php/Forms/GridField/GridFieldEditButtonTest.php
+++ b/tests/php/Forms/GridField/GridFieldEditButtonTest.php
@@ -52,7 +52,7 @@ class GridFieldEditButtonTest extends SapphireTest
         Permissions::class,
     );
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->list = new DataList(Team::class);

--- a/tests/php/Forms/GridField/GridFieldEditButtonTest.php
+++ b/tests/php/Forms/GridField/GridFieldEditButtonTest.php
@@ -100,7 +100,7 @@ class GridFieldEditButtonTest extends SapphireTest
         $result = $button->getExtraClass();
 
         foreach ($expected as $className) {
-            $this->assertContains($className, $result);
+            $this->assertStringContainsString($className, $result);
         }
     }
 
@@ -109,15 +109,15 @@ class GridFieldEditButtonTest extends SapphireTest
         $button = new GridFieldEditButton;
 
         $button->addExtraClass('foobar');
-        $this->assertContains('foobar', $button->getExtraClass());
+        $this->assertStringContainsString('foobar', $button->getExtraClass());
 
         $button->removeExtraClass('foobar');
-        $this->assertNotContains('foobar', $button->getExtraClass());
+        $this->assertStringNotContainsString('foobar', $button->getExtraClass());
 
         // Check that duplicates are removed
         $button->addExtraClass('foobar');
         $button->addExtraClass('foobar');
         $button->removeExtraClass('foobar');
-        $this->assertNotContains('foobar', $button->getExtraClass());
+        $this->assertStringNotContainsString('foobar', $button->getExtraClass());
     }
 }

--- a/tests/php/Forms/GridField/GridFieldExportButtonTest.php
+++ b/tests/php/Forms/GridField/GridFieldExportButtonTest.php
@@ -35,7 +35,7 @@ class GridFieldExportButtonTest extends SapphireTest
         NoView::class,
     ];
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -70,11 +70,11 @@ class GridFieldFilterHeaderTest extends SapphireTest
         $htmlFragment = $this->component->getHTMLFragments($this->gridField);
 
         // Check that the output is the new search field
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<div class="search-holder grid-field__search-holder grid-field__search-holder--hidden"',
             $htmlFragment['before']
         );
-        $this->assertContains('Open search and filter', $htmlFragment['buttons-before-right']);
+        $this->assertStringContainsString('Open search and filter', $htmlFragment['buttons-before-right']);
 
         $this->gridField->getConfig()->removeComponentsByType(GridFieldFilterHeader::class);
         $this->gridField->getConfig()->addComponent(new GridFieldFilterHeader(true));
@@ -82,7 +82,7 @@ class GridFieldFilterHeaderTest extends SapphireTest
         $htmlFragment = $this->component->getHTMLFragments($this->gridField);
 
         // Check that the output is the legacy filter header
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<tr class="grid-field__filter-header grid-field__search-holder--hidden">',
             $htmlFragment['header']
         );

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -50,7 +50,7 @@ class GridFieldFilterHeaderTest extends SapphireTest
         Mom::class,
     );
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->list = new DataList(Team::class);

--- a/tests/php/Forms/GridField/GridFieldLazyLoaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldLazyLoaderTest.php
@@ -44,7 +44,7 @@ class GridFieldLazyLoaderTest extends SapphireTest
         Team::class,
     ];
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->list = DataList::create(Team::class);

--- a/tests/php/Forms/GridField/GridFieldLazyLoaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldLazyLoaderTest.php
@@ -89,8 +89,8 @@ class GridFieldLazyLoaderTest extends SapphireTest
         $gridField = $this->getHeaderlessGridField();
         $actual = $this->component->getHTMLFragments($gridField);
         $this->assertEmpty($actual, 'getHTMLFragments should always return an array');
-        $this->assertContains('grid-field--lazy-loadable', $gridField->extraClass());
-        $this->assertNotContains('grid-field--lazy-loaded', $gridField->extraClass());
+        $this->assertStringContainsString('grid-field--lazy-loadable', $gridField->extraClass());
+        $this->assertStringNotContainsString('grid-field--lazy-loaded', $gridField->extraClass());
     }
 
     public function testGetHTMLFragmentsWithoutTabSet()
@@ -98,8 +98,8 @@ class GridFieldLazyLoaderTest extends SapphireTest
         $gridField = $this->getOutOfTabSetGridField();
         $actual = $this->component->getHTMLFragments($gridField);
         $this->assertEmpty($actual, 'getHTMLFragments should always return an array');
-        $this->assertContains('grid-field--lazy-loaded', $gridField->extraClass());
-        $this->assertNotContains('grid-field--lazy-loadable', $gridField->extraClass());
+        $this->assertStringContainsString('grid-field--lazy-loaded', $gridField->extraClass());
+        $this->assertStringNotContainsString('grid-field--lazy-loadable', $gridField->extraClass());
     }
 
     public function testGetHTMLFragmentsNonLazy()
@@ -107,8 +107,8 @@ class GridFieldLazyLoaderTest extends SapphireTest
         $gridField = $this->getNonLazyGridField();
         $actual = $this->component->getHTMLFragments($gridField);
         $this->assertEmpty($actual, 'getHTMLFragments should always return an array');
-        $this->assertContains('grid-field--lazy-loaded', $gridField->extraClass());
-        $this->assertNotContains('grid-field--lazy-loadable', $gridField->extraClass());
+        $this->assertStringContainsString('grid-field--lazy-loaded', $gridField->extraClass());
+        $this->assertStringNotContainsString('grid-field--lazy-loadable', $gridField->extraClass());
     }
 
 
@@ -150,8 +150,8 @@ class GridFieldLazyLoaderTest extends SapphireTest
         $gridField = $this->makeGridFieldReadonly($this->getHeaderlessGridField());
         $actual = $this->component->getHTMLFragments($gridField);
         $this->assertEmpty($actual, 'getHTMLFragments should always return an array');
-        $this->assertContains('grid-field--lazy-loadable', $gridField->extraClass());
-        $this->assertNotContains('grid-field--lazy-loaded', $gridField->extraClass());
+        $this->assertStringContainsString('grid-field--lazy-loadable', $gridField->extraClass());
+        $this->assertStringNotContainsString('grid-field--lazy-loaded', $gridField->extraClass());
     }
 
     public function testReadOnlyGetHTMLFragmentsWithoutTabSet()
@@ -159,8 +159,8 @@ class GridFieldLazyLoaderTest extends SapphireTest
         $gridField = $this->makeGridFieldReadonly($this->getOutOfTabSetGridField());
         $actual = $this->component->getHTMLFragments($gridField);
         $this->assertEmpty($actual, 'getHTMLFragments should always return an array');
-        $this->assertContains('grid-field--lazy-loaded', $gridField->extraClass());
-        $this->assertNotContains('grid-field--lazy-loadable', $gridField->extraClass());
+        $this->assertStringContainsString('grid-field--lazy-loaded', $gridField->extraClass());
+        $this->assertStringNotContainsString('grid-field--lazy-loadable', $gridField->extraClass());
     }
 
     public function testReadOnlyGetHTMLFragmentsNonLazy()
@@ -168,8 +168,8 @@ class GridFieldLazyLoaderTest extends SapphireTest
         $gridField = $this->makeGridFieldReadonly($this->getNonLazyGridField());
         $actual = $this->component->getHTMLFragments($gridField);
         $this->assertEmpty($actual, 'getHTMLFragments should always return an array');
-        $this->assertContains('grid-field--lazy-loaded', $gridField->extraClass());
-        $this->assertNotContains('grid-field--lazy-loadable', $gridField->extraClass());
+        $this->assertStringContainsString('grid-field--lazy-loaded', $gridField->extraClass());
+        $this->assertStringNotContainsString('grid-field--lazy-loadable', $gridField->extraClass());
     }
 
     /**

--- a/tests/php/Forms/GridField/GridFieldPaginatorTest.php
+++ b/tests/php/Forms/GridField/GridFieldPaginatorTest.php
@@ -49,7 +49,7 @@ class GridFieldPaginatorTest extends FunctionalTest
         Cheerleader::class,
     );
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->list = new DataList(Team::class);

--- a/tests/php/Forms/GridField/GridFieldPrintButtonTest.php
+++ b/tests/php/Forms/GridField/GridFieldPrintButtonTest.php
@@ -19,7 +19,7 @@ class GridFieldPrintButtonTest extends SapphireTest
         TestObject::class,
     );
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Forms/GridField/GridFieldSortableHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldSortableHeaderTest.php
@@ -47,23 +47,26 @@ class GridFieldSortableHeaderTest extends SapphireTest
         $htmlFragment = $compontent->getHTMLFragments($gridField);
 
         // Check that the output shows name and hat as sortable fields, but not city
-        $this->assertContains('<span class="non-sortable">City</span>', $htmlFragment['header']);
-        $this->assertContains(
+        $this->assertStringContainsString('<span class="non-sortable">City</span>', $htmlFragment['header']);
+        $this->assertStringContainsString(
             'value="Name" class="action grid-field__sort" id="action_SetOrderName"',
             $htmlFragment['header']
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'value="Cheerleader Hat" class="action grid-field__sort" id="action_SetOrderCheerleader-Hat-Colour"',
             $htmlFragment['header']
         );
 
         // Check inverse of above
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             'value="City" class="action grid-field__sort" id="action_SetOrderCity"',
             $htmlFragment['header']
         );
-        $this->assertNotContains('<span class="non-sortable">Name</span>', $htmlFragment['header']);
-        $this->assertNotContains('<span class="non-sortable">Cheerleader Hat</span>', $htmlFragment['header']);
+        $this->assertStringNotContainsString('<span class="non-sortable">Name</span>', $htmlFragment['header']);
+        $this->assertStringNotContainsString(
+            '<span class="non-sortable">Cheerleader Hat</span>',
+            $htmlFragment['header']
+        );
     }
 
     public function testGetManipulatedData()
@@ -145,20 +148,20 @@ class GridFieldSortableHeaderTest extends SapphireTest
         $relationListAsql = Convert::nl2os($relationListA->sql(), ' ');
 
         // Assert that all tables are joined properly
-        $this->assertContains('FROM "GridFieldSortableHeaderTest_Team"', $relationListAsql);
-        $this->assertContains(
+        $this->assertStringContainsString('FROM "GridFieldSortableHeaderTest_Team"', $relationListAsql);
+        $this->assertStringContainsString(
             'LEFT JOIN "GridFieldSortableHeaderTest_TeamGroup" '
             . 'ON "GridFieldSortableHeaderTest_TeamGroup"."ID" = "GridFieldSortableHeaderTest_Team"."ID"',
             $relationListAsql
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'LEFT JOIN "GridFieldSortableHeaderTest_Cheerleader" '
             . 'AS "cheerleader_GridFieldSortableHeaderTest_Cheerleader" '
             . 'ON "cheerleader_GridFieldSortableHeaderTest_Cheerleader"."ID" = '
             . '"GridFieldSortableHeaderTest_Team"."CheerleaderID"',
             $relationListAsql
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'LEFT JOIN "GridFieldSortableHeaderTest_CheerleaderHat" '
             . 'AS "cheerleader_hat_GridFieldSortableHeaderTest_CheerleaderHat" '
             . 'ON "cheerleader_hat_GridFieldSortableHeaderTest_CheerleaderHat"."ID" = '
@@ -185,15 +188,15 @@ class GridFieldSortableHeaderTest extends SapphireTest
         $relationListBsql = $relationListB->sql();
 
         // Assert that subclasses are included in the query
-        $this->assertContains('FROM "GridFieldSortableHeaderTest_Team"', $relationListBsql);
-        $this->assertContains(
+        $this->assertStringContainsString('FROM "GridFieldSortableHeaderTest_Team"', $relationListBsql);
+        $this->assertStringContainsString(
             'LEFT JOIN "GridFieldSortableHeaderTest_TeamGroup" '
             . 'ON "GridFieldSortableHeaderTest_TeamGroup"."ID" = "GridFieldSortableHeaderTest_Team"."ID"',
             $relationListBsql
         );
         // Joined tables are joined basetable first
         // Note: CheerLeader is base of Mom table, hence the alias
-        $this->assertContains(
+        $this->assertStringContainsString(
             'LEFT JOIN "GridFieldSortableHeaderTest_Cheerleader" '
             . 'AS "cheerleadersmom_GridFieldSortableHeaderTest_Cheerleader" '
             . 'ON "cheerleadersmom_GridFieldSortableHeaderTest_Cheerleader"."ID" = '
@@ -201,14 +204,14 @@ class GridFieldSortableHeaderTest extends SapphireTest
             $relationListBsql
         );
         // Then the basetable of the joined record is joined to the specific subtable
-        $this->assertContains(
+        $this->assertStringContainsString(
             'LEFT JOIN "GridFieldSortableHeaderTest_Mom" '
             . 'AS "cheerleadersmom_GridFieldSortableHeaderTest_Mom" '
             . 'ON "cheerleadersmom_GridFieldSortableHeaderTest_Cheerleader"."ID" = '
             . '"cheerleadersmom_GridFieldSortableHeaderTest_Mom"."ID"',
             $relationListBsql
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'LEFT JOIN "GridFieldSortableHeaderTest_CheerleaderHat" '
             . 'AS "cheerleadersmom_hat_GridFieldSortableHeaderTest_CheerleaderHat" '
             . 'ON "cheerleadersmom_hat_GridFieldSortableHeaderTest_CheerleaderHat"."ID" = '

--- a/tests/php/Forms/GridField/GridFieldTest.php
+++ b/tests/php/Forms/GridField/GridFieldTest.php
@@ -136,10 +136,10 @@ class GridFieldTest extends SapphireTest
     /**
      * @covers \SilverStripe\Forms\GridField\GridField::getModelClass
      *
-     * @expectedException \LogicException
      */
     public function testGridFieldModelClassThrowsException()
     {
+        $this->expectException(\LogicException::class);
         $obj = new GridField('testfield', 'testfield', ArrayList::create());
         $obj->getModelClass();
     }
@@ -261,15 +261,11 @@ class GridFieldTest extends SapphireTest
      * @skipUpgrade
      * @covers \SilverStripe\Forms\GridField\GridField::getColumnContent
      *
-     * @expectedException \InvalidArgumentException
      */
     public function testGetColumnContentBadArguments()
     {
-        $list = new ArrayList(
-            array(
-            new Member(array("ID" => 1, "Email" => "test@example.org"))
-            )
-        );
+        $this->expectException(\InvalidArgumentException::class);
+        $list = new ArrayList(array(new Member(array("ID" => 1, "Email" => "test@example.org"))));
         $obj = new GridField('testfield', 'testfield', $list);
         $obj->getColumnContent($list->first(), 'non-existing');
     }
@@ -308,31 +304,21 @@ class GridFieldTest extends SapphireTest
     /**
      * @covers \SilverStripe\Forms\GridField\GridField::getColumnAttributes
      *
-     * @expectedException \InvalidArgumentException
      */
     public function testGetColumnAttributesBadArguments()
     {
-        $list = new ArrayList(
-            array(
-            new Member(array("ID" => 1, "Email" => "test@example.org"))
-            )
-        );
-        $config = GridFieldConfig::create()->addComponent(new Component);
+        $this->expectException(\InvalidArgumentException::class);
+        $list = new ArrayList(array(new Member(array("ID" => 1, "Email" => "test@example.org"))));
+        $config = GridFieldConfig::create()->addComponent(new Component());
         $obj = new GridField('testfield', 'testfield', $list, $config);
         $obj->getColumnAttributes($list->first(), 'Non-existing');
     }
 
-    /**
-     * @expectedException \LogicException
-     */
     public function testGetColumnAttributesBadResponseFromComponent()
     {
-        $list = new ArrayList(
-            array(
-            new Member(array("ID" => 1, "Email" => "test@example.org"))
-            )
-        );
-        $config = GridFieldConfig::create()->addComponent(new Component);
+        $this->expectException(\LogicException::class);
+        $list = new ArrayList(array(new Member(array("ID" => 1, "Email" => "test@example.org"))));
+        $config = GridFieldConfig::create()->addComponent(new Component());
         $obj = new GridField('testfield', 'testfield', $list, $config);
         $obj->getColumnAttributes($list->first(), 'Surname');
     }
@@ -356,16 +342,12 @@ class GridFieldTest extends SapphireTest
     /**
      * @covers \SilverStripe\Forms\GridField\GridField::getColumnMetadata
      *
-     * @expectedException \LogicException
      */
     public function testGetColumnMetadataBadResponseFromComponent()
     {
-        $list = new ArrayList(
-            array(
-            new Member(array("ID" => 1, "Email" => "test@example.org"))
-            )
-        );
-        $config = GridFieldConfig::create()->addComponent(new Component);
+        $this->expectException(\LogicException::class);
+        $list = new ArrayList(array(new Member(array("ID" => 1, "Email" => "test@example.org"))));
+        $config = GridFieldConfig::create()->addComponent(new Component());
         $obj = new GridField('testfield', 'testfield', $list, $config);
         $obj->getColumnMetadata('Surname');
     }
@@ -373,10 +355,10 @@ class GridFieldTest extends SapphireTest
     /**
      * @covers \SilverStripe\Forms\GridField\GridField::getColumnMetadata
      *
-     * @expectedException \InvalidArgumentException
      */
     public function testGetColumnMetadataBadArguments()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $list = ArrayList::create();
         $config = GridFieldConfig::create()->addComponent(new Component);
         $obj = new GridField('testfield', 'testfield', $list, $config);
@@ -386,10 +368,10 @@ class GridFieldTest extends SapphireTest
     /**
      * @covers \SilverStripe\Forms\GridField\GridField::handleAction
      *
-     * @expectedException \InvalidArgumentException
      */
     public function testHandleActionBadArgument()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $obj = new GridField('testfield', 'testfield');
         $obj->handleAlterAction('prft', array(), array());
     }
@@ -482,7 +464,7 @@ class GridFieldTest extends SapphireTest
         $field = new GridField('testfield', 'testfield', ArrayList::create(), $config);
         $form = new Form(null, 'testform', new FieldList(array($field)), new FieldList());
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<div class=\"right\">rightone\nrighttwo</div><div class=\"left\">left</div>",
             $field->FieldHolder()
         );
@@ -518,7 +500,7 @@ class GridFieldTest extends SapphireTest
         $field = new GridField('testfield', 'testfield', ArrayList::create(), $config);
         $form = new Form(null, 'testform', new FieldList(array($field)), new FieldList());
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             "<div>first\n<strong>second</strong></div>",
             $field->FieldHolder()
         );
@@ -526,11 +508,10 @@ class GridFieldTest extends SapphireTest
 
     /**
      * Test that circular dependencies throw an exception
-     *
-     * @expectedException \LogicException
      */
     public function testGridFieldCustomFragmentsCircularDependencyThrowsException()
     {
+        $this->expectException(\LogicException::class);
         $config = GridFieldConfig::create()->addComponents(
             new HTMLFragments(
                 array(

--- a/tests/php/Forms/HTMLEditor/HTMLEditorConfigTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorConfigTest.php
@@ -18,7 +18,7 @@ use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 class HTMLEditorConfigTest extends SapphireTest
 {
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -140,7 +140,7 @@ class HTMLEditorConfigTest extends SapphireTest
         $this->assertNotContains('plugin1', array_keys($plugins));
         $this->assertNotContains('plugin2', array_keys($plugins));
     }
-    
+
     public function testRequireJSIncludesAllConfigs()
     {
         $a = HTMLEditorConfig::get('configA');

--- a/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
@@ -73,12 +73,12 @@ class HTMLEditorFieldTest extends FunctionalTest
         $inputText = "These are some unicodes: ä, ö, & ü";
         $field = new HTMLEditorField("Test", "Test");
         $field->setValue($inputText);
-        $this->assertContains('These are some unicodes: &auml;, &ouml;, &amp; &uuml;', $field->Field());
+        $this->assertStringContainsString('These are some unicodes: &auml;, &ouml;, &amp; &uuml;', $field->Field());
         // Test shortcodes
         $inputText = "Shortcode: [file_link id=4]";
         $field = new HTMLEditorField("Test", "Test");
         $field->setValue($inputText);
-        $this->assertContains('Shortcode: [file_link id=4]', $field->Field());
+        $this->assertStringContainsString('Shortcode: [file_link id=4]', $field->Field());
     }
 
     public function testBasicSaving()

--- a/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
@@ -25,7 +25,7 @@ class HTMLEditorFieldTest extends FunctionalTest
         TestObject::class,
     ];
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -55,7 +55,7 @@ class HTMLEditorFieldTest extends FunctionalTest
         }
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         TestAssetStore::reset();
         parent::tearDown();

--- a/tests/php/Forms/HTMLEditor/TinyMCECombinedGeneratorTest.php
+++ b/tests/php/Forms/HTMLEditor/TinyMCECombinedGeneratorTest.php
@@ -13,7 +13,7 @@ use SilverStripe\View\SSViewer;
 
 class TinyMCECombinedGeneratorTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -27,7 +27,7 @@ class TinyMCECombinedGeneratorTest extends SapphireTest
             ->set('editor_css', [ 'mycode/editor.css' ]);
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         parent::tearDown();
         // Flush test configs

--- a/tests/php/Forms/HTMLEditor/TinyMCECombinedGeneratorTest.php
+++ b/tests/php/Forms/HTMLEditor/TinyMCECombinedGeneratorTest.php
@@ -61,34 +61,34 @@ class TinyMCECombinedGeneratorTest extends SapphireTest
         $generator = Injector::inst()->create(TinyMCECombinedGenerator::class);
         $this->assertRegExp('#_tinymce/tinymce-testconfig-[0-9a-z]{10,10}#', $generator->generateFilename($c));
         $content = $generator->generateContent($c);
-        $this->assertContains(
+        $this->assertStringContainsString(
             "var baseURL = baseTag.length ? baseTag[0].baseURI : 'http://www.mysite.com/basedir/';\n",
             $content
         );
         // Main script file
-        $this->assertContains("/* tinymce.js */\n", $content);
+        $this->assertStringContainsString("/* tinymce.js */\n", $content);
         // Locale file
-        $this->assertContains("/* en.js */\n", $content);
+        $this->assertStringContainsString("/* en.js */\n", $content);
         // Local plugins
-        $this->assertContains("/* plugin1.js */\n", $content);
-        $this->assertContains("/* plugin4.min.js */\n", $content);
-        $this->assertContains("/* plugin4/langs/en.js */\n", $content);
-        $this->assertContains("/* plugin5.js */\n", $content);
-        $this->assertContains("/* plugin6.js */\n", $content);
+        $this->assertStringContainsString("/* plugin1.js */\n", $content);
+        $this->assertStringContainsString("/* plugin4.min.js */\n", $content);
+        $this->assertStringContainsString("/* plugin4/langs/en.js */\n", $content);
+        $this->assertStringContainsString("/* plugin5.js */\n", $content);
+        $this->assertStringContainsString("/* plugin6.js */\n", $content);
         // module-resource plugin
-        $this->assertContains("/* plugin8.js */\n", $content);
+        $this->assertStringContainsString("/* plugin8.js */\n", $content);
         // Exclude non-local plugins
-        $this->assertNotContains('plugin2.js', $content);
-        $this->assertNotContains('plugin3.js', $content);
+        $this->assertStringNotContainsString('plugin2.js', $content);
+        $this->assertStringNotContainsString('plugin3.js', $content);
         // Exclude missing file
-        $this->assertNotContains('plugin7.js', $content);
+        $this->assertStringNotContainsString('plugin7.js', $content);
 
         // Check themes
-        $this->assertContains("/* theme.js */\n", $content);
-        $this->assertContains("/* testtheme/langs/en.js */\n", $content);
+        $this->assertStringContainsString("/* theme.js */\n", $content);
+        $this->assertStringContainsString("/* testtheme/langs/en.js */\n", $content);
 
         // Check plugin links included
-        $this->assertContains(
+        $this->assertStringContainsString(
             'tinymce.each(\'tinymce/langs/en.js,mycode/plugin1.js,tinymce/plugins/plugin4/plugin.min.js,'
             . 'tinymce/plugins/plugin4/langs/en.js,tinymce/plugins/plugin5/plugin.js,mycode/plugin6.js,'
             . 'mycode/plugin8.js?m=',
@@ -96,7 +96,7 @@ class TinyMCECombinedGeneratorTest extends SapphireTest
         );
 
         // Check theme links included
-        $this->assertContains(
+        $this->assertStringContainsString(
             "tinymce/themes/testtheme/theme.js,tinymce/themes/testtheme/langs/en.js'.split(','),"
             . "function(f){tinymce.ScriptLoader.markDone(baseURL+f);});",
             $content

--- a/tests/php/Forms/LookupFieldTest.php
+++ b/tests/php/Forms/LookupFieldTest.php
@@ -18,8 +18,8 @@ class LookupFieldTest extends SapphireTest
         $field->setValue(null);
         $result = trim($field->Field()->getValue());
 
-        $this->assertContains('<span class="readonly" id="test"><i>(none)</i></span>', $result);
-        $this->assertContains('<input type="hidden" name="test" value="" />', $result);
+        $this->assertStringContainsString('<span class="readonly" id="test"><i>(none)</i></span>', $result);
+        $this->assertStringContainsString('<input type="hidden" name="test" value="" />', $result);
     }
 
     public function testStringValueWithNumericArraySource()
@@ -28,8 +28,8 @@ class LookupFieldTest extends SapphireTest
         $field = new LookupField('test', 'test', $source);
         $field->setValue(1);
         $result = trim($field->Field()->getValue());
-        $this->assertContains('<span class="readonly" id="test">one</span>', $result);
-        $this->assertContains('<input type="hidden" name="test" value="1" />', $result);
+        $this->assertStringContainsString('<span class="readonly" id="test">one</span>', $result);
+        $this->assertStringContainsString('<input type="hidden" name="test" value="1" />', $result);
     }
 
     public function testUnknownStringValueWithNumericArraySource()
@@ -39,8 +39,8 @@ class LookupFieldTest extends SapphireTest
         $field->setValue('w00t');
         $result = trim($field->Field()->getValue());
 
-        $this->assertContains('<span class="readonly" id="test">w00t</span>', $result);
-        $this->assertContains('<input type="hidden" name="test" value="" />', $result);
+        $this->assertStringContainsString('<span class="readonly" id="test">w00t</span>', $result);
+        $this->assertStringContainsString('<input type="hidden" name="test" value="" />', $result);
     }
 
     public function testArrayValueWithAssociativeArraySource()
@@ -51,8 +51,8 @@ class LookupFieldTest extends SapphireTest
         $field->setValue(array('one','two'));
         $result = trim($field->Field()->getValue());
 
-        $this->assertContains('<span class="readonly" id="test">one val, two val</span>', $result);
-        $this->assertContains('<input type="hidden" name="test" value="one, two" />', $result);
+        $this->assertStringContainsString('<span class="readonly" id="test">one val, two val</span>', $result);
+        $this->assertStringContainsString('<input type="hidden" name="test" value="one, two" />', $result);
     }
 
     public function testArrayValueWithNumericArraySource()
@@ -63,8 +63,8 @@ class LookupFieldTest extends SapphireTest
         $field->setValue(array(1,2));
         $result = trim($field->Field()->getValue());
 
-        $this->assertContains('<span class="readonly" id="test">one, two</span>', $result);
-        $this->assertContains('<input type="hidden" name="test" value="1, 2" />', $result);
+        $this->assertStringContainsString('<span class="readonly" id="test">one, two</span>', $result);
+        $this->assertStringContainsString('<input type="hidden" name="test" value="1, 2" />', $result);
     }
 
     public function testArrayValueWithSqlMapSource()
@@ -78,8 +78,8 @@ class LookupFieldTest extends SapphireTest
         $field->setValue(array($member1->ID, $member2->ID));
         $result = trim($field->Field()->getValue());
 
-        $this->assertContains('<span class="readonly" id="test">member1, member2</span>', $result);
-        $this->assertContains(sprintf(
+        $this->assertStringContainsString('<span class="readonly" id="test">member1, member2</span>', $result);
+        $this->assertStringContainsString(sprintf(
             '<input type="hidden" name="test" value="%s, %s" />',
             $member1->ID,
             $member2->ID
@@ -104,13 +104,13 @@ class LookupFieldTest extends SapphireTest
         $field->setValue(3);
         $result = trim($field->Field()->getValue());
 
-        $this->assertContains('<span class="readonly" id="test">Carrots</span>', $result);
-        $this->assertContains('<input type="hidden" name="test" value="3" />', $result);
+        $this->assertStringContainsString('<span class="readonly" id="test">Carrots</span>', $result);
+        $this->assertStringContainsString('<input type="hidden" name="test" value="3" />', $result);
 
         $field->setValue([3, 9]);
         $result = trim($field->Field()->getValue());
 
-        $this->assertContains('<span class="readonly" id="test">Carrots, Vegan</span>', $result);
-        $this->assertContains('<input type="hidden" name="test" value="3, 9" />', $result);
+        $this->assertStringContainsString('<span class="readonly" id="test">Carrots, Vegan</span>', $result);
+        $this->assertStringContainsString('<input type="hidden" name="test" value="3, 9" />', $result);
     }
 }

--- a/tests/php/Forms/NumericFieldTest.php
+++ b/tests/php/Forms/NumericFieldTest.php
@@ -112,8 +112,8 @@ class NumericFieldTest extends SapphireTest
         $field->setScale(2);
         $field->setValue(1001.3);
         $html = $field->performReadonlyTransformation()->Field()->forTemplate();
-        $this->assertContains('value="1.001,30"', $html);
-        $this->assertContains('readonly="readonly"', $html);
+        $this->assertStringContainsString('value="1.001,30"', $html);
+        $this->assertStringContainsString('readonly="readonly"', $html);
     }
 
     public function testNumberTypeOnInputHtml()
@@ -124,7 +124,7 @@ class NumericFieldTest extends SapphireTest
 
         // @todo - Revert to number one day when html5 number supports proper localisation
         // See https://github.com/silverstripe/silverstripe-framework/pull/4565
-        $this->assertContains('type="text"', $html, 'number type not set');
+        $this->assertStringContainsString('type="text"', $html, 'number type not set');
     }
 
     public function testNullSet()

--- a/tests/php/Forms/OptionsetFieldTest.php
+++ b/tests/php/Forms/OptionsetFieldTest.php
@@ -95,11 +95,11 @@ class OptionsetFieldTest extends SapphireTest
             )
         );
         $fieldHTML = (string)$field1->Field();
-        $this->assertContains('One', $fieldHTML);
-        $this->assertContains('Two &amp; Three', $fieldHTML);
-        $this->assertNotContains('Two & Three', $fieldHTML);
-        $this->assertContains('Four &amp; Five &amp; Six', $fieldHTML);
-        $this->assertNotContains('Four & Five & Six', $fieldHTML);
+        $this->assertStringContainsString('One', $fieldHTML);
+        $this->assertStringContainsString('Two &amp; Three', $fieldHTML);
+        $this->assertStringNotContainsString('Two & Three', $fieldHTML);
+        $this->assertStringContainsString('Four &amp; Five &amp; Six', $fieldHTML);
+        $this->assertStringNotContainsString('Four & Five & Six', $fieldHTML);
     }
 
     /**

--- a/tests/php/Forms/PrintableTransformationTabSetTest.php
+++ b/tests/php/Forms/PrintableTransformationTabSetTest.php
@@ -25,12 +25,12 @@ class PrintableTransformationTabSetTest extends SapphireTest
         $transformationTabSet = new PrintableTransformation_TabSet($tabs);
         $result = $transformationTabSet->FieldHolder();
 
-        $this->assertContains('<h1>Main</h1>', $result);
-        $this->assertContains('<h1>Secondary</h1>', $result);
+        $this->assertStringContainsString('<h1>Main</h1>', $result);
+        $this->assertStringContainsString('<h1>Secondary</h1>', $result);
 
         $transformationTabSet->setTabSet($optionsTabSet);
         $result = $transformationTabSet->FieldHolder();
 
-        $this->assertContains('<h2>Options</h2>', $result);
+        $this->assertStringContainsString('<h2>Options</h2>', $result);
     }
 }

--- a/tests/php/Forms/SelectionGroupTest.php
+++ b/tests/php/Forms/SelectionGroupTest.php
@@ -36,8 +36,8 @@ class SelectionGroupTest extends SapphireTest
         $this->assertEquals(' one title', (string)$listElOne->label[0]);
         $this->assertEquals(' two title', (string)$listElTwo->label[0]);
 
-        $this->assertContains('one view', (string)$listElOne->div);
-        $this->assertContains('two view', (string)$listElTwo->div);
+        $this->assertStringContainsString('one view', (string)$listElOne->div);
+        $this->assertStringContainsString('two view', (string)$listElTwo->div);
     }
 
     public function testSelectedFieldHolder()

--- a/tests/php/Forms/TextareaFieldTest.php
+++ b/tests/php/Forms/TextareaFieldTest.php
@@ -14,12 +14,12 @@ class TextareaFieldTest extends SapphireTest
         $inputText = "These are some unicodes: ä, ö, & ü";
         $field = new TextareaField("Test", "Test");
         $field->setValue($inputText);
-        $this->assertContains('These are some unicodes: &auml;, &ouml;, &amp; &uuml;', $field->Field());
+        $this->assertStringContainsString('These are some unicodes: &auml;, &ouml;, &amp; &uuml;', $field->Field());
         // Test shortcodes
         $inputText = "Shortcode: [file_link id=4]";
         $field = new TextareaField("Test", "Test");
         $field->setValue($inputText);
-        $this->assertContains('Shortcode: [file_link id=4]', $field->Field());
+        $this->assertStringContainsString('Shortcode: [file_link id=4]', $field->Field());
     }
 
     /**
@@ -31,7 +31,7 @@ class TextareaFieldTest extends SapphireTest
         $field = new TextareaField("Test", "Test");
         $field->setValue($inputText);
         $field = $field->performReadonlyTransformation();
-        $this->assertContains('These are some unicodes: äöü', $field->Field());
+        $this->assertStringContainsString('These are some unicodes: äöü', $field->Field());
     }
 
     /**
@@ -43,7 +43,7 @@ class TextareaFieldTest extends SapphireTest
         $field = new TextareaField("Test", "Test");
         $field = $field->performReadonlyTransformation();
         $field->setValue($inputText);
-        $this->assertContains(
+        $this->assertStringContainsString(
             'These are some special &lt;html&gt; chars including &#039;single&#039; &amp;'
             . ' &quot;double&quot; quotations',
             $field->Field()

--- a/tests/php/Forms/TimeFieldReadonlyTest.php
+++ b/tests/php/Forms/TimeFieldReadonlyTest.php
@@ -9,22 +9,22 @@ use SilverStripe\i18n\i18n;
 
 class TimeFieldReadonlyTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         i18n::set_locale('en_NZ');
     }
-    
+
     public function testPerformReadonly()
     {
         $field = new TimeField('Time', 'Time', '23:00:00');
         $roField = $field->performReadonlyTransformation();
         $this->assertInstanceOf(TimeField_Readonly::class, $roField);
-        
+
         $this->assertTrue($roField->isReadonly());
         $this->assertEquals($roField->dataValue(), '23:00:00');
     }
-    
+
     public function testSettingsCarryOver()
     {
         $field = new TimeField('Time', 'Time');
@@ -35,7 +35,7 @@ class TimeFieldReadonlyTest extends SapphireTest
             ->setLocale('en_US')
             ->setTimeLength(IntlDateFormatter::SHORT)
             ->setValue('23:00:00');
-        
+
         $roField = $field->performReadonlyTransformation();
         $this->assertFalse($roField->getHTML5());
         $this->assertEquals($roField->getTimeFormat(), 'KK:mma');

--- a/tests/php/Forms/TimeFieldTest.php
+++ b/tests/php/Forms/TimeFieldTest.php
@@ -11,7 +11,7 @@ use SilverStripe\i18n\i18n;
 
 class TimeFieldTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         i18n::set_locale('en_NZ');

--- a/tests/php/Forms/TimeFieldTest.php
+++ b/tests/php/Forms/TimeFieldTest.php
@@ -147,36 +147,30 @@ class TimeFieldTest extends SapphireTest
         $this->assertEquals($f->Value(), '23:59:00');
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessageRegExp /Please opt-out .* if using setTimeFormat/
-     */
     public function testHtml5WithCustomFormatThrowsException()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/Please opt-out .* if using setTimeFormat/');
         $f = new TimeField('Time', 'Time');
         $f->setValue('15:59:00');
         $f->setTimeFormat('mm:HH');
         $f->Value();
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessageRegExp /Please opt-out .* if using setTimeLength/
-     */
     public function testHtml5WithCustomDateLengthThrowsException()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/Please opt-out .* if using setTimeLength/');
         $f = new TimeField('Time', 'Time');
         $f->setValue('15:59:00');
         $f->setTimeLength(IntlDateFormatter::MEDIUM);
         $f->Value();
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessageRegExp /Please opt-out .* if using setLocale/
-     */
     public function testHtml5WithCustomLocaleThrowsException()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/Please opt-out .* if using setLocale/');
         $f = new TimeField('Time', 'Time');
         $f->setValue('15:59:00');
         $f->setLocale('de_DE');

--- a/tests/php/Forms/TipTest.php
+++ b/tests/php/Forms/TipTest.php
@@ -53,24 +53,23 @@ class TipTest extends SapphireTest
     /**
      * Ensure passing an invalid importance level to the constructor fails
      *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Provided importance level must be defined in Tip::IMPORTANCE_LEVELS
      */
     public function testInvalidImportanceLevelInConstructorCausesException()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Provided importance level must be defined in Tip::IMPORTANCE_LEVELS');
         $tip = new Tip('message', 'arbitrary-importance');
     }
 
     /**
      * Ensure setting an invalid importance level fails
      *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Provided importance level must be defined in Tip::IMPORTANCE_LEVELS
      */
     public function testInvalidImportanceLevelInSetterCausesException()
     {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Provided importance level must be defined in Tip::IMPORTANCE_LEVELS');
         $tip = new Tip('message');
-
         $tip->setImportanceLevel('arbitrary-importance');
     }
 }

--- a/tests/php/Forms/TreeDropdownFieldTest.php
+++ b/tests/php/Forms/TreeDropdownFieldTest.php
@@ -239,11 +239,11 @@ class TreeDropdownFieldTest extends SapphireTest
         $field->setValue($fileMock->ID);
         $readonlyField = $field->performReadonlyTransformation();
         $result = (string) $readonlyField->Field();
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<span class="readonly" id="TestTree">&lt;Special &amp; characters&gt;</span>',
             $result
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<input type="hidden" name="TestTree" value="' . $fileMock->ID . '" />',
             $result
         );

--- a/tests/php/Forms/TreeMultiselectFieldTest.php
+++ b/tests/php/Forms/TreeMultiselectFieldTest.php
@@ -133,38 +133,38 @@ class TreeMultiselectFieldTest extends SapphireTest
         $this->assertEquals($fieldId, sprintf('%s_%s', $this->formId, $this->fieldName));
 
         $schemaStateDefaults = $field->getSchemaStateDefaults();
-        $this->assertArrayHasKey('id', $schemaStateDefaults);
-        $this->assertEquals($fieldId, $schemaStateDefaults['id']);
-        $this->assertArrayHasKey('name', $schemaStateDefaults);
-        $this->assertEquals($this->fieldName, $schemaStateDefaults['name']);
-        $this->assertArrayHasKey('value', $schemaStateDefaults);
-        $this->assertNull($schemaStateDefaults['value']);
+        $this->assertArraySubset(
+            [
+                'id' => $fieldId,
+                'name' => $this->fieldName,
+                'value' => null
+            ],
+            $schemaStateDefaults,
+            true
+        );
 
         $schemaDataDefaults = $field->getSchemaDataDefaults();
-        $this->assertArrayHasKey('id', $schemaDataDefaults);
-        $this->assertEquals($fieldId, $schemaDataDefaults['id']);
-        $this->assertArrayHasKey('name', $schemaDataDefaults);
-        $this->assertEquals($this->fieldName, $schemaDataDefaults['name']);
-        $this->assertArrayHasKey('type', $schemaDataDefaults);
-        $this->assertEquals('text', $schemaDataDefaults['type']);
-        $this->assertArrayHasKey('schemaType', $schemaDataDefaults);
-        $this->assertEquals('SingleSelect', $schemaDataDefaults['schemaType']);
-        $this->assertArrayHasKey('component', $schemaDataDefaults);
-        $this->assertEquals('TreeDropdownField', $schemaDataDefaults['component']);
-        $this->assertArrayHasKey('holderId', $schemaDataDefaults);
-        $this->assertEquals(sprintf('%s_Holder', $fieldId), $schemaDataDefaults['holderId']);
-        $this->assertArrayHasKey('title', $schemaDataDefaults);
-        $this->assertEquals('Test tree', $schemaDataDefaults['title']);
-        $this->assertArrayHasKey('extraClass', $schemaDataDefaults);
-        $this->assertEquals('treemultiselect multiple searchable', $schemaDataDefaults['extraClass']);
-        $this->assertArrayHasKey('data', $schemaDataDefaults);
-        $this->assertEquals([
-            'urlTree' => 'field/TestTree/tree',
-            'showSearch' => true,
-            'emptyString' => '(Search or choose File)',
-            'hasEmptyDefault' => false,
-            'multiple' => true
-        ], $schemaDataDefaults['data']);
+        $this->assertArraySubset(
+            [
+                'id' => $fieldId,
+                'name' => $this->fieldName,
+                'type' => 'text',
+                'schemaType' => 'SingleSelect',
+                'component' => 'TreeDropdownField',
+                'holderId' => sprintf('%s_Holder', $fieldId),
+                'title' => 'Test tree',
+                'extraClass' => 'treemultiselect multiple searchable',
+                'data' => [
+                    'urlTree' => 'field/TestTree/tree',
+                    'showSearch' => true,
+                    'emptyString' => '(Search or choose File)',
+                    'hasEmptyDefault' => false,
+                    'multiple' => true
+                ]
+            ],
+            $schemaDataDefaults,
+            true
+        );
 
         $items = $field->getItems();
         $this->assertCount(0, $items, 'there must be no items selected');
@@ -184,12 +184,15 @@ class TreeMultiselectFieldTest extends SapphireTest
         $field->setValue($this->fieldValue);
 
         $schemaStateDefaults = $field->getSchemaStateDefaults();
-        $this->assertArrayHasKey('id', $schemaStateDefaults);
-        $this->assertEquals($field->ID(), $schemaStateDefaults['id']);
-        $this->assertArrayHasKey('name', $schemaStateDefaults);
-        $this->assertEquals('TestTree', $schemaStateDefaults['name']);
-        $this->assertArrayHasKey('value', $schemaStateDefaults);
-        $this->assertEquals($this->folderIds, $schemaStateDefaults['value']);
+        $this->assertArraySubset(
+            [
+                'id' => $field->ID(),
+                'name' => 'TestTree',
+                'value' => $this->folderIds
+            ],
+            $schemaStateDefaults,
+            true
+        );
 
         $items = $field->getItems();
         $this->assertCount(2, $items, 'there must be exactly 2 items selected');
@@ -207,38 +210,38 @@ class TreeMultiselectFieldTest extends SapphireTest
         $field = $this->field->performReadonlyTransformation();
 
         $schemaStateDefaults = $field->getSchemaStateDefaults();
-        $this->assertArrayHasKey('id', $schemaStateDefaults);
-        $this->assertEquals($field->ID(), $schemaStateDefaults['id']);
-        $this->assertArrayHasKey('name', $schemaStateDefaults);
-        $this->assertEquals('TestTree', $schemaStateDefaults['name']);
-        $this->assertArrayHasKey('value', $schemaStateDefaults);
-        $this->assertNull($schemaStateDefaults['value']);
+        $this->assertArraySubset(
+            [
+                'id' => $field->ID(),
+                'name' => 'TestTree',
+                'value' => null
+            ],
+            $schemaStateDefaults,
+            true
+        );
 
         $schemaDataDefaults = $field->getSchemaDataDefaults();
-        $this->assertArrayHasKey('id', $schemaDataDefaults);
-        $this->assertEquals($field->ID(), $schemaDataDefaults['id']);
-        $this->assertArrayHasKey('name', $schemaDataDefaults);
-        $this->assertEquals($this->fieldName, $schemaDataDefaults['name']);
-        $this->assertArrayHasKey('type', $schemaDataDefaults);
-        $this->assertEquals('text', $schemaDataDefaults['type']);
-        $this->assertArrayHasKey('schemaType', $schemaDataDefaults);
-        $this->assertEquals('SingleSelect', $schemaDataDefaults['schemaType']);
-        $this->assertArrayHasKey('component', $schemaDataDefaults);
-        $this->assertEquals('TreeDropdownField', $schemaDataDefaults['component']);
-        $this->assertArrayHasKey('holderId', $schemaDataDefaults);
-        $this->assertEquals(sprintf('%s_Holder', $field->ID()), $schemaDataDefaults['holderId']);
-        $this->assertArrayHasKey('title', $schemaDataDefaults);
-        $this->assertEquals('Test tree', $schemaDataDefaults['title']);
-        $this->assertArrayHasKey('extraClass', $schemaDataDefaults);
-        $this->assertEquals('treemultiselectfield_readonly multiple  searchable', $schemaDataDefaults['extraClass']);
-        $this->assertArrayHasKey('data', $schemaDataDefaults);
-        $this->assertEquals([
-            'urlTree' => 'field/TestTree/tree',
-            'showSearch' => true,
-            'emptyString' => '(Search or choose File)',
-            'hasEmptyDefault' => false,
-            'multiple' => true
-        ], $schemaDataDefaults['data']);
+        $this->assertArraySubset(
+            [
+                'id' => $field->ID(),
+                'name' => $this->fieldName,
+                'type' => 'text',
+                'schemaType' => 'SingleSelect',
+                'component' => 'TreeDropdownField',
+                'holderId' => sprintf('%s_Holder', $field->ID()),
+                'title' => 'Test tree',
+                'extraClass' => 'treemultiselectfield_readonly multiple  searchable',
+                'data' => [
+                    'urlTree' => 'field/TestTree/tree',
+                    'showSearch' => true,
+                    'emptyString' => '(Search or choose File)',
+                    'hasEmptyDefault' => false,
+                    'multiple' => true
+                ]
+            ],
+            $schemaDataDefaults,
+            true
+        );
 
         $items = $field->getItems();
         $this->assertCount(0, $items, 'there must be 0 selected items');
@@ -257,38 +260,38 @@ class TreeMultiselectFieldTest extends SapphireTest
         $field = $field->performReadonlyTransformation();
 
         $schemaStateDefaults = $field->getSchemaStateDefaults();
-        $this->assertArrayHasKey('id', $schemaStateDefaults);
-        $this->assertEquals($field->ID(), $schemaStateDefaults['id']);
-        $this->assertArrayHasKey('name', $schemaStateDefaults);
-        $this->assertEquals('TestTree', $schemaStateDefaults['name']);
-        $this->assertArrayHasKey('value', $schemaStateDefaults);
-        $this->assertEquals($this->folderIds, $schemaStateDefaults['value']);
+        $this->assertArraySubset(
+            [
+                'id' => $field->ID(),
+                'name' => 'TestTree',
+                'value' => $this->folderIds
+            ],
+            $schemaStateDefaults,
+            true
+        );
 
         $schemaDataDefaults = $field->getSchemaDataDefaults();
-        $this->assertArrayHasKey('id', $schemaDataDefaults);
-        $this->assertEquals($field->ID(), $schemaDataDefaults['id']);
-        $this->assertArrayHasKey('name', $schemaDataDefaults);
-        $this->assertEquals($this->fieldName, $schemaDataDefaults['name']);
-        $this->assertArrayHasKey('type', $schemaDataDefaults);
-        $this->assertEquals('text', $schemaDataDefaults['type']);
-        $this->assertArrayHasKey('schemaType', $schemaDataDefaults);
-        $this->assertEquals('SingleSelect', $schemaDataDefaults['schemaType']);
-        $this->assertArrayHasKey('component', $schemaDataDefaults);
-        $this->assertEquals('TreeDropdownField', $schemaDataDefaults['component']);
-        $this->assertArrayHasKey('holderId', $schemaDataDefaults);
-        $this->assertEquals(sprintf('%s_Holder', $field->ID()), $schemaDataDefaults['holderId']);
-        $this->assertArrayHasKey('title', $schemaDataDefaults);
-        $this->assertEquals('Test tree', $schemaDataDefaults['title']);
-        $this->assertArrayHasKey('extraClass', $schemaDataDefaults);
-        $this->assertEquals('treemultiselectfield_readonly multiple  searchable', $schemaDataDefaults['extraClass']);
-        $this->assertArrayHasKey('data', $schemaDataDefaults);
-        $this->assertEquals([
-            'urlTree' => 'field/TestTree/tree',
-            'showSearch' => true,
-            'emptyString' => '(Search or choose File)',
-            'hasEmptyDefault' => false,
-            'multiple' => true
-        ], $schemaDataDefaults['data']);
+        $this->assertArraySubset(
+            [
+                'id' => $field->ID(),
+                'name' => $this->fieldName,
+                'type' => 'text',
+                'schemaType' => 'SingleSelect',
+                'component' => 'TreeDropdownField',
+                'holderId' => sprintf('%s_Holder', $field->ID()),
+                'title' => 'Test tree',
+                'extraClass' => 'treemultiselectfield_readonly multiple  searchable',
+                'data' => [
+                    'urlTree' => 'field/TestTree/tree',
+                    'showSearch' => true,
+                    'emptyString' => '(Search or choose File)',
+                    'hasEmptyDefault' => false,
+                    'multiple' => true
+                ]
+            ],
+            $schemaDataDefaults,
+            true
+        );
 
         $items = $field->getItems();
         $this->assertCount(2, $items, 'there must be exactly 2 selected items');

--- a/tests/php/Forms/TreeMultiselectFieldTest.php
+++ b/tests/php/Forms/TreeMultiselectFieldTest.php
@@ -133,44 +133,44 @@ class TreeMultiselectFieldTest extends SapphireTest
         $this->assertEquals($fieldId, sprintf('%s_%s', $this->formId, $this->fieldName));
 
         $schemaStateDefaults = $field->getSchemaStateDefaults();
-        $this->assertArraySubset(
-            [
-                'id' => $fieldId,
-                'name' => $this->fieldName,
-                'value' => null
-            ],
-            $schemaStateDefaults,
-            true
-        );
+        $this->assertArrayHasKey('id', $schemaStateDefaults);
+        $this->assertEquals($fieldId, $schemaStateDefaults['id']);
+        $this->assertArrayHasKey('name', $schemaStateDefaults);
+        $this->assertEquals($this->fieldName, $schemaStateDefaults['name']);
+        $this->assertArrayHasKey('value', $schemaStateDefaults);
+        $this->assertNull($schemaStateDefaults['value']);
 
         $schemaDataDefaults = $field->getSchemaDataDefaults();
-        $this->assertArraySubset(
-            [
-                'id' => $fieldId,
-                'name' => $this->fieldName,
-                'type' => 'text',
-                'schemaType' => 'SingleSelect',
-                'component' => 'TreeDropdownField',
-                'holderId' => sprintf('%s_Holder', $fieldId),
-                'title' => 'Test tree',
-                'extraClass' => 'treemultiselect multiple searchable',
-                'data' => [
-                    'urlTree' => 'field/TestTree/tree',
-                    'showSearch' => true,
-                    'emptyString' => '(Search or choose File)',
-                    'hasEmptyDefault' => false,
-                    'multiple' => true
-                ]
-            ],
-            $schemaDataDefaults,
-            true
-        );
+        $this->assertArrayHasKey('id', $schemaDataDefaults);
+        $this->assertEquals($fieldId, $schemaDataDefaults['id']);
+        $this->assertArrayHasKey('name', $schemaDataDefaults);
+        $this->assertEquals($this->fieldName, $schemaDataDefaults['name']);
+        $this->assertArrayHasKey('type', $schemaDataDefaults);
+        $this->assertEquals('text', $schemaDataDefaults['type']);
+        $this->assertArrayHasKey('schemaType', $schemaDataDefaults);
+        $this->assertEquals('SingleSelect', $schemaDataDefaults['schemaType']);
+        $this->assertArrayHasKey('component', $schemaDataDefaults);
+        $this->assertEquals('TreeDropdownField', $schemaDataDefaults['component']);
+        $this->assertArrayHasKey('holderId', $schemaDataDefaults);
+        $this->assertEquals(sprintf('%s_Holder', $fieldId), $schemaDataDefaults['holderId']);
+        $this->assertArrayHasKey('title', $schemaDataDefaults);
+        $this->assertEquals('Test tree', $schemaDataDefaults['title']);
+        $this->assertArrayHasKey('extraClass', $schemaDataDefaults);
+        $this->assertEquals('treemultiselect multiple searchable', $schemaDataDefaults['extraClass']);
+        $this->assertArrayHasKey('data', $schemaDataDefaults);
+        $this->assertEquals([
+            'urlTree' => 'field/TestTree/tree',
+            'showSearch' => true,
+            'emptyString' => '(Search or choose File)',
+            'hasEmptyDefault' => false,
+            'multiple' => true
+        ], $schemaDataDefaults['data']);
 
         $items = $field->getItems();
         $this->assertCount(0, $items, 'there must be no items selected');
 
         $html = $field->Field();
-        $this->assertContains($field->ID(), $html);
+        $this->assertStringContainsString($field->ID(), $html);
     }
 
 
@@ -184,22 +184,19 @@ class TreeMultiselectFieldTest extends SapphireTest
         $field->setValue($this->fieldValue);
 
         $schemaStateDefaults = $field->getSchemaStateDefaults();
-        $this->assertArraySubset(
-            [
-                'id' => $field->ID(),
-                'name' => 'TestTree',
-                'value' => $this->folderIds
-            ],
-            $schemaStateDefaults,
-            true
-        );
+        $this->assertArrayHasKey('id', $schemaStateDefaults);
+        $this->assertEquals($field->ID(), $schemaStateDefaults['id']);
+        $this->assertArrayHasKey('name', $schemaStateDefaults);
+        $this->assertEquals('TestTree', $schemaStateDefaults['name']);
+        $this->assertArrayHasKey('value', $schemaStateDefaults);
+        $this->assertEquals($this->folderIds, $schemaStateDefaults['value']);
 
         $items = $field->getItems();
         $this->assertCount(2, $items, 'there must be exactly 2 items selected');
 
         $html = $field->Field();
-        $this->assertContains($field->ID(), $html);
-        $this->assertContains($this->fieldValue, $html);
+        $this->assertStringContainsString($field->ID(), $html);
+        $this->assertStringContainsString($this->fieldValue, $html);
     }
 
     /**
@@ -210,44 +207,44 @@ class TreeMultiselectFieldTest extends SapphireTest
         $field = $this->field->performReadonlyTransformation();
 
         $schemaStateDefaults = $field->getSchemaStateDefaults();
-        $this->assertArraySubset(
-            [
-                'id' => $field->ID(),
-                'name' => 'TestTree',
-                'value' => null
-            ],
-            $schemaStateDefaults,
-            true
-        );
+        $this->assertArrayHasKey('id', $schemaStateDefaults);
+        $this->assertEquals($field->ID(), $schemaStateDefaults['id']);
+        $this->assertArrayHasKey('name', $schemaStateDefaults);
+        $this->assertEquals('TestTree', $schemaStateDefaults['name']);
+        $this->assertArrayHasKey('value', $schemaStateDefaults);
+        $this->assertNull($schemaStateDefaults['value']);
 
         $schemaDataDefaults = $field->getSchemaDataDefaults();
-        $this->assertArraySubset(
-            [
-                'id' => $field->ID(),
-                'name' => $this->fieldName,
-                'type' => 'text',
-                'schemaType' => 'SingleSelect',
-                'component' => 'TreeDropdownField',
-                'holderId' => sprintf('%s_Holder', $field->ID()),
-                'title' => 'Test tree',
-                'extraClass' => 'treemultiselectfield_readonly multiple  searchable',
-                'data' => [
-                    'urlTree' => 'field/TestTree/tree',
-                    'showSearch' => true,
-                    'emptyString' => '(Search or choose File)',
-                    'hasEmptyDefault' => false,
-                    'multiple' => true
-                ]
-            ],
-            $schemaDataDefaults,
-            true
-        );
+        $this->assertArrayHasKey('id', $schemaDataDefaults);
+        $this->assertEquals($field->ID(), $schemaDataDefaults['id']);
+        $this->assertArrayHasKey('name', $schemaDataDefaults);
+        $this->assertEquals($this->fieldName, $schemaDataDefaults['name']);
+        $this->assertArrayHasKey('type', $schemaDataDefaults);
+        $this->assertEquals('text', $schemaDataDefaults['type']);
+        $this->assertArrayHasKey('schemaType', $schemaDataDefaults);
+        $this->assertEquals('SingleSelect', $schemaDataDefaults['schemaType']);
+        $this->assertArrayHasKey('component', $schemaDataDefaults);
+        $this->assertEquals('TreeDropdownField', $schemaDataDefaults['component']);
+        $this->assertArrayHasKey('holderId', $schemaDataDefaults);
+        $this->assertEquals(sprintf('%s_Holder', $field->ID()), $schemaDataDefaults['holderId']);
+        $this->assertArrayHasKey('title', $schemaDataDefaults);
+        $this->assertEquals('Test tree', $schemaDataDefaults['title']);
+        $this->assertArrayHasKey('extraClass', $schemaDataDefaults);
+        $this->assertEquals('treemultiselectfield_readonly multiple  searchable', $schemaDataDefaults['extraClass']);
+        $this->assertArrayHasKey('data', $schemaDataDefaults);
+        $this->assertEquals([
+            'urlTree' => 'field/TestTree/tree',
+            'showSearch' => true,
+            'emptyString' => '(Search or choose File)',
+            'hasEmptyDefault' => false,
+            'multiple' => true
+        ], $schemaDataDefaults['data']);
 
         $items = $field->getItems();
         $this->assertCount(0, $items, 'there must be 0 selected items');
 
         $html = $field->Field();
-        $this->assertContains($field->ID(), $html);
+        $this->assertStringContainsString($field->ID(), $html);
     }
 
     /**
@@ -260,44 +257,44 @@ class TreeMultiselectFieldTest extends SapphireTest
         $field = $field->performReadonlyTransformation();
 
         $schemaStateDefaults = $field->getSchemaStateDefaults();
-        $this->assertArraySubset(
-            [
-                'id' => $field->ID(),
-                'name' => 'TestTree',
-                'value' => $this->folderIds
-            ],
-            $schemaStateDefaults,
-            true
-        );
+        $this->assertArrayHasKey('id', $schemaStateDefaults);
+        $this->assertEquals($field->ID(), $schemaStateDefaults['id']);
+        $this->assertArrayHasKey('name', $schemaStateDefaults);
+        $this->assertEquals('TestTree', $schemaStateDefaults['name']);
+        $this->assertArrayHasKey('value', $schemaStateDefaults);
+        $this->assertEquals($this->folderIds, $schemaStateDefaults['value']);
 
         $schemaDataDefaults = $field->getSchemaDataDefaults();
-        $this->assertArraySubset(
-            [
-                'id' => $field->ID(),
-                'name' => $this->fieldName,
-                'type' => 'text',
-                'schemaType' => 'SingleSelect',
-                'component' => 'TreeDropdownField',
-                'holderId' => sprintf('%s_Holder', $field->ID()),
-                'title' => 'Test tree',
-                'extraClass' => 'treemultiselectfield_readonly multiple  searchable',
-                'data' => [
-                    'urlTree' => 'field/TestTree/tree',
-                    'showSearch' => true,
-                    'emptyString' => '(Search or choose File)',
-                    'hasEmptyDefault' => false,
-                    'multiple' => true
-                ]
-            ],
-            $schemaDataDefaults,
-            true
-        );
+        $this->assertArrayHasKey('id', $schemaDataDefaults);
+        $this->assertEquals($field->ID(), $schemaDataDefaults['id']);
+        $this->assertArrayHasKey('name', $schemaDataDefaults);
+        $this->assertEquals($this->fieldName, $schemaDataDefaults['name']);
+        $this->assertArrayHasKey('type', $schemaDataDefaults);
+        $this->assertEquals('text', $schemaDataDefaults['type']);
+        $this->assertArrayHasKey('schemaType', $schemaDataDefaults);
+        $this->assertEquals('SingleSelect', $schemaDataDefaults['schemaType']);
+        $this->assertArrayHasKey('component', $schemaDataDefaults);
+        $this->assertEquals('TreeDropdownField', $schemaDataDefaults['component']);
+        $this->assertArrayHasKey('holderId', $schemaDataDefaults);
+        $this->assertEquals(sprintf('%s_Holder', $field->ID()), $schemaDataDefaults['holderId']);
+        $this->assertArrayHasKey('title', $schemaDataDefaults);
+        $this->assertEquals('Test tree', $schemaDataDefaults['title']);
+        $this->assertArrayHasKey('extraClass', $schemaDataDefaults);
+        $this->assertEquals('treemultiselectfield_readonly multiple  searchable', $schemaDataDefaults['extraClass']);
+        $this->assertArrayHasKey('data', $schemaDataDefaults);
+        $this->assertEquals([
+            'urlTree' => 'field/TestTree/tree',
+            'showSearch' => true,
+            'emptyString' => '(Search or choose File)',
+            'hasEmptyDefault' => false,
+            'multiple' => true
+        ], $schemaDataDefaults['data']);
 
         $items = $field->getItems();
         $this->assertCount(2, $items, 'there must be exactly 2 selected items');
 
         $html = $field->Field();
-        $this->assertContains($field->ID(), $html);
-        $this->assertContains($this->fieldValue, $html);
+        $this->assertStringContainsString($field->ID(), $html);
+        $this->assertStringContainsString($this->fieldValue, $html);
     }
 }

--- a/tests/php/Forms/TreeMultiselectFieldTest.php
+++ b/tests/php/Forms/TreeMultiselectFieldTest.php
@@ -56,7 +56,7 @@ class TreeMultiselectFieldTest extends SapphireTest
      */
     protected $fieldValue;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Logging/DebugViewFriendlyErrorFormatterTest.php
+++ b/tests/php/Logging/DebugViewFriendlyErrorFormatterTest.php
@@ -11,7 +11,7 @@ use SilverStripe\Logging\DebugViewFriendlyErrorFormatter;
 
 class DebugViewFriendlyErrorFormatterTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         Email::config()->set('admin_email', 'testy@mctest.face');

--- a/tests/php/Logging/DetailedErrorFormatterTest.php
+++ b/tests/php/Logging/DetailedErrorFormatterTest.php
@@ -19,10 +19,10 @@ class DetailedErrorFormatterTest extends SapphireTest
         ]]);
 
         $base = __DIR__;
-        $this->assertContains('ERROR [Emergency]: Uncaught Exception: Error', $output);
-        $this->assertContains("Line 32 in $base/DetailedErrorFormatterTest/ErrorGenerator.php", $output);
-        $this->assertContains('* 32:                  throw new Exception(\'Error\');', $output);
-        $this->assertContains(
+        $this->assertStringContainsString('ERROR [Emergency]: Uncaught Exception: Error', $output);
+        $this->assertStringContainsString("Line 32 in $base/DetailedErrorFormatterTest/ErrorGenerator.php", $output);
+        $this->assertStringContainsString('* 32:                  throw new Exception(\'Error\');', $output);
+        $this->assertStringContainsString(
             'SilverStripe\\Logging\\Tests\\DetailedErrorFormatterTest\\ErrorGenerator->mockException(4)',
             $output
         );
@@ -40,10 +40,10 @@ class DetailedErrorFormatterTest extends SapphireTest
         $formatter = new DetailedErrorFormatter();
         $result = $formatter->format($record);
 
-        $this->assertContains('ERRNO 401', $result, 'Status code was not found in trace');
-        $this->assertContains('Denied', $result, 'Message was not found in trace');
-        $this->assertContains('Line 4 in index.php', $result, 'Line or filename were not found in trace');
-        $this->assertContains(self::class, $result, 'Backtrace doesn\'t show current test class');
+        $this->assertStringContainsString('ERRNO 401', $result, 'Status code was not found in trace');
+        $this->assertStringContainsString('Denied', $result, 'Message was not found in trace');
+        $this->assertStringContainsString('Line 4 in index.php', $result, 'Line or filename were not found in trace');
+        $this->assertStringContainsString(self::class, $result, 'Backtrace doesn\'t show current test class');
     }
 
     public function testFormatBatch()
@@ -66,9 +66,9 @@ class DetailedErrorFormatterTest extends SapphireTest
         $formatter = new DetailedErrorFormatter();
         $result = $formatter->formatBatch($records);
 
-        $this->assertContains('ERRNO 401', $result, 'First status code was not found in trace');
-        $this->assertContains('ERRNO 404', $result, 'Second status code was not found in trace');
-        $this->assertContains('Denied', $result, 'First message was not found in trace');
-        $this->assertContains('Not found', $result, 'Second message was not found in trace');
+        $this->assertStringContainsString('ERRNO 401', $result, 'First status code was not found in trace');
+        $this->assertStringContainsString('ERRNO 404', $result, 'Second status code was not found in trace');
+        $this->assertStringContainsString('Denied', $result, 'First message was not found in trace');
+        $this->assertStringContainsString('Not found', $result, 'Second message was not found in trace');
     }
 }

--- a/tests/php/Logging/HTTPOutputHandlerTest.php
+++ b/tests/php/Logging/HTTPOutputHandlerTest.php
@@ -12,7 +12,7 @@ use SilverStripe\Logging\HTTPOutputHandler;
 
 class HTTPOutputHandlerTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Logging/MonologErrorHandlerTest.php
+++ b/tests/php/Logging/MonologErrorHandlerTest.php
@@ -8,12 +8,10 @@ use SilverStripe\Logging\MonologErrorHandler;
 
 class MonologErrorHandlerTest extends SapphireTest
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessageRegExp /No Logger properties passed to MonologErrorHandler/
-     */
     public function testStartThrowsExceptionWithoutLoggerDefined()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/No Logger properties passed to MonologErrorHandler/');
         $handler = new MonologErrorHandler();
         $handler->start();
     }

--- a/tests/php/ORM/ArrayListTest.php
+++ b/tests/php/ORM/ArrayListTest.php
@@ -134,11 +134,9 @@ class ArrayListTest extends SapphireTest
         );
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\Error\Error
-     */
     public function testZeroLimit()
     {
+        $this->expectException(\PHPUnit\Framework\Error\Error::class);
         Deprecation::notification_version('4.3.0');
         $list = new ArrayList([
             ['Key' => 1],

--- a/tests/php/ORM/DBDateTest.php
+++ b/tests/php/ORM/DBDateTest.php
@@ -24,30 +24,6 @@ class DBDateTest extends SapphireTest
         i18n::set_locale('en_NZ');
     }
 
-    protected function tearDown() : void
-    {
-        $this->restoreNotices();
-        parent::tearDown();
-    }
-
-    /**
-     * Temporarily disable notices
-     */
-    protected function suppressNotices()
-    {
-        error_reporting(error_reporting() & ~E_USER_NOTICE);
-        Notice::$enabled = false;
-    }
-
-    /**
-     * Restore notices
-     */
-    protected function restoreNotices()
-    {
-        error_reporting($this->oldError);
-        Notice::$enabled = true;
-    }
-
     public function testNiceDate()
     {
         $this->assertEquals(
@@ -92,21 +68,17 @@ class DBDateTest extends SapphireTest
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid date: '3/16/2003'. Use y-MM-dd to prevent this error.
-     */
     public function testMDYConversion()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid date: \'3/16/2003\'. Use y-MM-dd to prevent this error.');
         DBField::create_field('Date', '3/16/2003');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid date: '03-03-04'. Use y-MM-dd to prevent this error.
-     */
     public function testY2kCorrection()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid date: \'03-03-04\'. Use y-MM-dd to prevent this error.');
         DBField::create_field('Date', '03-03-04');
     }
 

--- a/tests/php/ORM/DBDateTest.php
+++ b/tests/php/ORM/DBDateTest.php
@@ -15,7 +15,7 @@ class DBDateTest extends SapphireTest
 {
     protected $oldError = null;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->oldError = error_reporting();
@@ -24,7 +24,7 @@ class DBDateTest extends SapphireTest
         i18n::set_locale('en_NZ');
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         $this->restoreNotices();
         parent::tearDown();

--- a/tests/php/ORM/DBDatetimeTest.php
+++ b/tests/php/ORM/DBDatetimeTest.php
@@ -11,7 +11,7 @@ use SilverStripe\ORM\FieldType\DBDatetime;
  */
 class DBDatetimeTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         i18n::set_locale('en_NZ');

--- a/tests/php/ORM/DBHTMLTextTest.php
+++ b/tests/php/ORM/DBHTMLTextTest.php
@@ -17,7 +17,7 @@ class DBHTMLTextTest extends SapphireTest
 
     private $previousLocaleSetting = null;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -30,7 +30,7 @@ class DBHTMLTextTest extends SapphireTest
         ShortcodeParser::set_active('htmltest');
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
 
         // If a test sets the locale, reset it on teardown

--- a/tests/php/ORM/DBTextTest.php
+++ b/tests/php/ORM/DBTextTest.php
@@ -14,14 +14,14 @@ class DBTextTest extends SapphireTest
 
     private $previousLocaleSetting = null;
 
-    public function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         // clear the previous locale setting
         $this->previousLocaleSetting = null;
     }
 
-    public function tearDown()
+    protected function tearDown() : void
     {
         parent::tearDown();
         // If a test sets the locale, reset it on teardown

--- a/tests/php/ORM/DBTimeTest.php
+++ b/tests/php/ORM/DBTimeTest.php
@@ -10,7 +10,7 @@ use SilverStripe\Security\Member;
 
 class DBTimeTest extends SapphireTest
 {
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         i18n::set_locale('en_NZ');

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -90,11 +90,9 @@ class DataListTest extends SapphireTest
         $this->assertEquals(2, $newList->Count(), 'List should only contain two objects after subtraction');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSubtractBadDataclassThrowsException()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $teamsComments = TeamComment::get();
         $teams = Team::get();
         $teamsComments->subtract($teams);
@@ -153,21 +151,21 @@ class DataListTest extends SapphireTest
     public function testDistinct()
     {
         $list = TeamComment::get();
-        $this->assertContains(
+        $this->assertSQLContains(
             'SELECT DISTINCT',
             $list->dataQuery()->sql($params),
             'Query is set as distinct by default'
         );
 
         $list = $list->distinct(false);
-        $this->assertNotContains(
+        $this->assertSQLNotContains(
             'SELECT DISTINCT',
             $list->dataQuery()->sql($params),
             'Query does not contain distinct'
         );
 
         $list = $list->distinct(true);
-        $this->assertContains(
+        $this->assertSQLContains(
             'SELECT DISTINCT',
             $list->dataQuery()->sql($params),
             'Query contains distinct'
@@ -442,8 +440,8 @@ class DataListTest extends SapphireTest
 
         // Assert that filtering on ID searches by the base table, not the child table field
         $query = SubTeam::get()->filter('ID', 4)->sql($parameters);
-        $this->assertContains('WHERE ("DataObjectTest_Team"."ID" = ?)', $query);
-        $this->assertNotContains('WHERE ("DataObjectTest_SubTeam"."ID" = ?)', $query);
+        $this->assertSQLContains('WHERE ("DataObjectTest_Team"."ID" = ?)', $query);
+        $this->assertSQLNotContains('WHERE ("DataObjectTest_SubTeam"."ID" = ?)', $query);
     }
 
     public function testByIDs()
@@ -595,12 +593,12 @@ class DataListTest extends SapphireTest
         $this->assertEquals('Phil', $list->last()->Name);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Fans is not a linear relation on model SilverStripe\ORM\Tests\DataObjectTest\Player
-     */
     public function testSortInvalidParameters()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Fans is not a linear relation on model SilverStripe\\ORM\\Tests\\DataObjectTest\\Player'
+        );
         $list = Team::get();
         $list->sort('Founder.Fans.Surname'); // Can't sort on has_many
     }
@@ -763,12 +761,10 @@ class DataListTest extends SapphireTest
         $this->assertEquals('Bob', $list->first()->Name, 'First comment should be from Bob');
     }
 
-    /**
-     * @expectedException \SilverStripe\Core\Injector\InjectorNotFoundException
-     * @expectedExceptionMessage Class DataListFilter.Bogus does not exist
-     */
     public function testSimpleFilterWithNonExistingComparisator()
     {
+        $this->expectException(\SilverStripe\Core\Injector\InjectorNotFoundException::class);
+        $this->expectExceptionMessage('Class DataListFilter.Bogus does not exist');
         $list = TeamComment::get();
         $list->filter('Comment:Bogus', 'team comment');
     }
@@ -776,11 +772,11 @@ class DataListTest extends SapphireTest
     /**
      * Invalid modifiers are treated as failed filter construction
      *
-     * @expectedException \SilverStripe\Core\Injector\InjectorNotFoundException
-     * @expectedExceptionMessage Class DataListFilter.invalidmodifier does not exist
      */
     public function testInvalidModifier()
     {
+        $this->expectException(\SilverStripe\Core\Injector\InjectorNotFoundException::class);
+        $this->expectExceptionMessage('Class DataListFilter.invalidmodifier does not exist');
         $list = TeamComment::get();
         $list->filter('Comment:invalidmodifier', 'team comment');
     }
@@ -1104,12 +1100,12 @@ class DataListTest extends SapphireTest
         $this->assertEquals('007', $list->first()->ShirtNumber);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage MascotAnimal is not a relation on model SilverStripe\ORM\Tests\DataObjectTest\Team
-     */
     public function testFilterOnInvalidRelation()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'MascotAnimal is not a relation on model SilverStripe\\ORM\\Tests\\DataObjectTest\\Team'
+        );
         // Filter on missing relation 'MascotAnimal'
         Team::get()
             ->filter('MascotAnimal.Name', 'Richard')
@@ -1717,11 +1713,11 @@ class DataListTest extends SapphireTest
     /**
      * Test exact match filter with empty array items
      *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Cannot filter "DataObjectTest_TeamComment"."Name" against an empty set
      */
     public function testEmptyFilter()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot filter "DataObjectTest_TeamComment"."Name" against an empty set');
         $list = TeamComment::get();
         $list->exclude('Name', array());
     }

--- a/tests/php/ORM/DataObjectSchemaGenerationTest.php
+++ b/tests/php/ORM/DataObjectSchemaGenerationTest.php
@@ -20,7 +20,7 @@ class DataObjectSchemaGenerationTest extends SapphireTest
         SortedObject::class,
     );
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         // Start tests
         static::start();

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -63,7 +63,7 @@ class DataObjectTest extends SapphireTest
         DataObjectTest\TreeNode::class,
     );
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -1472,11 +1472,9 @@ class DataObjectTest extends SapphireTest
     }
 
 
-    /**
-     * @expectedException \SilverStripe\ORM\ValidationException
-     */
     public function testWritingInvalidDataObjectThrowsException()
     {
+        $this->expectException(\SilverStripe\ORM\ValidationException::class);
         $validatedObject = new DataObjectTest\ValidatedObject();
         $validatedObject->write();
     }
@@ -1626,29 +1624,23 @@ class DataObjectTest extends SapphireTest
         $this->assertEquals('Staff', $ceoObj->EmploymentType);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testValidateModelDefinitionsFailsWithArray()
     {
+        $this->expectException(\InvalidArgumentException::class);
         Config::modify()->merge(DataObjectTest\Team::class, 'has_one', array('NotValid' => array('NoArraysAllowed')));
         DataObject::getSchema()->hasOneComponent(DataObjectTest\Team::class, 'NotValid');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testValidateModelDefinitionsFailsWithIntKey()
     {
+        $this->expectException(\InvalidArgumentException::class);
         Config::modify()->set(DataObjectTest\Team::class, 'has_many', array(0 => DataObjectTest\Player::class));
         DataObject::getSchema()->hasManyComponent(DataObjectTest\Team::class, 0);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testValidateModelDefinitionsFailsWithIntValue()
     {
+        $this->expectException(\InvalidArgumentException::class);
         Config::modify()->merge(DataObjectTest\Team::class, 'many_many', array('Players' => 12));
         DataObject::getSchema()->manyManyComponent(DataObjectTest\Team::class, 'Players');
     }
@@ -1970,7 +1962,7 @@ class DataObjectTest extends SapphireTest
         $obj = new DataObjectTest\Fixture();
         $obj->write();
 
-        $this->assertInternalType("int", $obj->ID);
+        $this->assertIsInt($obj->ID);
     }
 
     /**
@@ -2250,11 +2242,9 @@ class DataObjectTest extends SapphireTest
         );
     }
 
-    /**
-     * @expectedException LogicException
-     */
     public function testInvalidate()
     {
+        $this->expectException(LogicException::class);
         $do = new DataObjectTest\Fixture();
         $do->write();
 
@@ -2375,11 +2365,9 @@ class DataObjectTest extends SapphireTest
         DataObjectTest\Player::get(null, "\"ID\" = 1");
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testBrokenLateStaticBindingStyle()
     {
+        $this->expectException(\InvalidArgumentException::class);
         // If you call DataObject::get() you have to pass a first argument
         DataObject::get();
     }

--- a/tests/php/ORM/DataObjectTest.yml
+++ b/tests/php/ORM/DataObjectTest.yml
@@ -49,7 +49,7 @@ SilverStripe\ORM\Tests\DataObjectTest\Player:
   captain1:
     FirstName: Captain
     Surname: Zookeeper
-    ShirtNumber: 007
+    ShirtNumber: '007'
     FavouriteTeam: =>SilverStripe\ORM\Tests\DataObjectTest\Team.team1
     Teams: =>SilverStripe\ORM\Tests\DataObjectTest\Team.team1
     FoundingTeams: =>SilverStripe\ORM\Tests\DataObjectTest\Team.team1

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -79,12 +79,12 @@ class DataQueryTest extends SapphireTest
         $dq = new DataQuery(DataQueryTest\ObjectB::class);
         $dq->applyRelation('TestC');
         $this->assertTrue($dq->query()->isJoinedTo('testc_DataQueryTest_C'));
-        $this->assertContains('"testc_DataQueryTest_C"."ID" = "DataQueryTest_B"."TestCID"', $dq->sql());
+        $this->assertSQLContains('"testc_DataQueryTest_C"."ID" = "DataQueryTest_B"."TestCID"', $dq->sql());
 
         $dq = new DataQuery(DataQueryTest\ObjectB::class);
         $dq->applyRelation('TestCTwo');
         $this->assertTrue($dq->query()->isJoinedTo('testctwo_DataQueryTest_C'));
-        $this->assertContains('"testctwo_DataQueryTest_C"."ID" = "DataQueryTest_B"."TestCTwoID"', $dq->sql());
+        $this->assertSQLContains('"testctwo_DataQueryTest_C"."ID" = "DataQueryTest_B"."TestCTwoID"', $dq->sql());
     }
 
     public function testApplyRelationDeepInheritance()
@@ -94,7 +94,7 @@ class DataQueryTest extends SapphireTest
         //apply a relation to a relation from an ancestor class
         $newDQ->applyRelation('TestA');
         $this->assertTrue($newDQ->query()->isJoinedTo('DataQueryTest_C'));
-        $this->assertContains('"testa_DataQueryTest_A"."ID" = "DataQueryTest_C"."TestAID"', $newDQ->sql($params));
+        $this->assertSQLContains('"testa_DataQueryTest_A"."ID" = "DataQueryTest_C"."TestAID"', $newDQ->sql($params));
 
         //test many_many relation
 
@@ -105,7 +105,7 @@ class DataQueryTest extends SapphireTest
         //check we are "joined" to the DataObject's table (there is no distinction between FROM or JOIN clauses)
         $this->assertTrue($newDQ->query()->isJoinedTo($baseDBTable));
         //check we are explicitly selecting "FROM" the DO's table
-        $this->assertContains("FROM \"$baseDBTable\"", $newDQ->sql());
+        $this->assertSQLContains("FROM \"$baseDBTable\"", $newDQ->sql());
 
         //test many_many with shared inheritance
         $newDQ = new DataQuery(DataQueryTest\ObjectE::class);
@@ -113,12 +113,12 @@ class DataQueryTest extends SapphireTest
         //check we are "joined" to the DataObject's table (there is no distinction between FROM or JOIN clauses)
         $this->assertTrue($newDQ->query()->isJoinedTo($baseDBTable));
         //check we are explicitly selecting "FROM" the DO's table
-        $this->assertContains("FROM \"$baseDBTable\"", $newDQ->sql(), 'The FROM clause is missing from the query');
+        $this->assertSQLContains("FROM \"$baseDBTable\"", $newDQ->sql(), 'The FROM clause is missing from the query');
         $newDQ->applyRelation('ManyTestGs');
         //confirm we are still joined to the base table
         $this->assertTrue($newDQ->query()->isJoinedTo($baseDBTable));
         //double check it is the "FROM" clause
-        $this->assertContains(
+        $this->assertSQLContains(
             "FROM \"$baseDBTable\"",
             $newDQ->sql(),
             'The FROM clause has been removed from the query'
@@ -260,7 +260,7 @@ class DataQueryTest extends SapphireTest
     {
         $dq = new DataQuery(SQLSelectTest\TestObject::class);
         $dq = $dq->sort('"Name" ASC, MID("Name", 8, 1) DESC');
-        $this->assertContains(
+        $this->assertSQLContains(
             'ORDER BY "SQLSelectTest_DO"."Name" ASC, "_SortColumn0" DESC',
             $dq->sql($parameters)
         );
@@ -276,13 +276,13 @@ class DataQueryTest extends SapphireTest
     public function testDistinct()
     {
         $query = new DataQuery(DataQueryTest\ObjectE::class);
-        $this->assertContains('SELECT DISTINCT', $query->sql($params), 'Query is set as distinct by default');
+        $this->assertSQLContains('SELECT DISTINCT', $query->sql($params), 'Query is set as distinct by default');
 
         $query = $query->distinct(false);
-        $this->assertNotContains('SELECT DISTINCT', $query->sql($params), 'Query does not contain distinct');
+        $this->assertSQLNotContains('SELECT DISTINCT', $query->sql($params), 'Query does not contain distinct');
 
         $query = $query->distinct(true);
-        $this->assertContains('SELECT DISTINCT', $query->sql($params), 'Query contains distinct');
+        $this->assertSQLContains('SELECT DISTINCT', $query->sql($params), 'Query contains distinct');
     }
 
     public function testComparisonClauseInt()

--- a/tests/php/ORM/DatabaseTest.php
+++ b/tests/php/ORM/DatabaseTest.php
@@ -209,21 +209,21 @@ class DatabaseTest extends SapphireTest
         )->record();
 
         // IDs and ints are returned as ints
-        $this->assertInternalType('int', $record['ID'], 'Primary key should be integer');
-        $this->assertInternalType('int', $record['MyInt'], 'DBInt fields should be integer');
+        $this->assertIsInt($record['ID'], 'Primary key should be integer');
+        $this->assertIsInt($record['MyInt'], 'DBInt fields should be integer');
 
-        $this->assertInternalType('float', $record['MyFloat'], 'DBFloat fields should be float');
-        $this->assertInternalType('float', $record['MyDecimal'], 'DBDecimal fields should be float');
+        $this->assertIsFloat($record['MyFloat'], 'DBFloat fields should be float');
+        $this->assertIsFloat($record['MyDecimal'], 'DBDecimal fields should be float');
 
         // Booleans are returned as ints – we follow MySQL's lead
-        $this->assertInternalType('int', $record['MyBoolean'], 'DBBoolean fields should be int');
+        $this->assertIsInt($record['MyBoolean'], 'DBBoolean fields should be int');
 
         // Strings and enums are returned as strings
-        $this->assertInternalType('string', $record['MyField'], 'DBVarchar fields should be string');
-        $this->assertInternalType('string', $record['ClassName'], 'DBEnum fields should be string');
+        $this->assertIsString($record['MyField'], 'DBVarchar fields should be string');
+        $this->assertIsString($record['ClassName'], 'DBEnum fields should be string');
 
         // Dates are returned as strings
-        $this->assertInternalType('string', $record['Created'], 'DBDatetime fields should be string');
+        $this->assertIsString($record['Created'], 'DBDatetime fields should be string');
 
 
         // Ensure that the same is true when calling a query a second time (cached prepared statement)
@@ -234,46 +234,46 @@ class DatabaseTest extends SapphireTest
         )->record();
 
         // IDs and ints are returned as ints
-        $this->assertInternalType('int', $record['ID'], 'Primary key should be integer (2nd call)');
-        $this->assertInternalType('int', $record['MyInt'], 'DBInt fields should be integer (2nd call)');
+        $this->assertIsInt($record['ID'], 'Primary key should be integer (2nd call)');
+        $this->assertIsInt($record['MyInt'], 'DBInt fields should be integer (2nd call)');
 
-        $this->assertInternalType('float', $record['MyFloat'], 'DBFloat fields should be float (2nd call)');
-        $this->assertInternalType('float', $record['MyDecimal'], 'DBDecimal fields should be float (2nd call)');
+        $this->assertIsFloat($record['MyFloat'], 'DBFloat fields should be float (2nd call)');
+        $this->assertIsFloat($record['MyDecimal'], 'DBDecimal fields should be float (2nd call)');
 
         // Booleans are returned as ints – we follow MySQL's lead
-        $this->assertInternalType('int', $record['MyBoolean'], 'DBBoolean fields should be int (2nd call)');
+        $this->assertIsInt($record['MyBoolean'], 'DBBoolean fields should be int (2nd call)');
 
         // Strings and enums are returned as strings
-        $this->assertInternalType('string', $record['MyField'], 'DBVarchar fields should be string (2nd call)');
-        $this->assertInternalType('string', $record['ClassName'], 'DBEnum fields should be string (2nd call)');
+        $this->assertIsString($record['MyField'], 'DBVarchar fields should be string (2nd call)');
+        $this->assertIsString($record['ClassName'], 'DBEnum fields should be string (2nd call)');
 
         // Dates are returned as strings
-        $this->assertInternalType('string', $record['Created'], 'DBDatetime fields should be string (2nd call)');
+        $this->assertIsString($record['Created'], 'DBDatetime fields should be string (2nd call)');
 
 
         // Ensure that the same is true when using non-prepared statements
         $record = DB::query('SELECT * FROM "DatabaseTest_MyObject" WHERE "ID" = ' . (int)$obj->ID)->record();
 
         // IDs and ints are returned as ints
-        $this->assertInternalType('int', $record['ID'], 'Primary key should be integer (non-prepared)');
-        $this->assertInternalType('int', $record['MyInt'], 'DBInt fields should be integer (non-prepared)');
+        $this->assertIsInt($record['ID'], 'Primary key should be integer (non-prepared)');
+        $this->assertIsInt($record['MyInt'], 'DBInt fields should be integer (non-prepared)');
 
-        $this->assertInternalType('float', $record['MyFloat'], 'DBFloat fields should be float (non-prepared)');
-        $this->assertInternalType('float', $record['MyDecimal'], 'DBDecimal fields should be float (non-prepared)');
+        $this->assertIsFloat($record['MyFloat'], 'DBFloat fields should be float (non-prepared)');
+        $this->assertIsFloat($record['MyDecimal'], 'DBDecimal fields should be float (non-prepared)');
 
         // Booleans are returned as ints – we follow MySQL's lead
-        $this->assertInternalType('int', $record['MyBoolean'], 'DBBoolean fields should be int (non-prepared)');
+        $this->assertIsInt($record['MyBoolean'], 'DBBoolean fields should be int (non-prepared)');
 
         // Strings and enums are returned as strings
-        $this->assertInternalType('string', $record['MyField'], 'DBVarchar fields should be string (non-prepared)');
-        $this->assertInternalType('string', $record['ClassName'], 'DBEnum fields should be string (non-prepared)');
+        $this->assertIsString($record['MyField'], 'DBVarchar fields should be string (non-prepared)');
+        $this->assertIsString($record['ClassName'], 'DBEnum fields should be string (non-prepared)');
 
         // Dates are returned as strings
-        $this->assertInternalType('string', $record['Created'], 'DBDatetime fields should be string (non-prepared)');
+        $this->assertIsString($record['Created'], 'DBDatetime fields should be string (non-prepared)');
 
         // Booleans selected directly are ints
         $result = DB::query('SELECT TRUE')->first();
-        $this->assertInternalType('int', reset($result));
+        $this->assertIsInt(reset($result));
     }
 
     /**

--- a/tests/php/ORM/DecimalTest.php
+++ b/tests/php/ORM/DecimalTest.php
@@ -19,7 +19,7 @@ class DecimalTest extends SapphireTest
         DecimalTest\TestObject::class
     );
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->testDataObject = $this->objFromFixture(DecimalTest\TestObject::class, 'test-dataobject');

--- a/tests/php/ORM/HierarchyCachingTest.php
+++ b/tests/php/ORM/HierarchyCachingTest.php
@@ -24,13 +24,13 @@ class HierachyCacheTest extends SapphireTest
         HideTestSubObject::class,
     );
 
-    public function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         TestObject::singleton()->flushCache();
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         parent::setUpBeforeClass();
         HideTestObject::config()->update(

--- a/tests/php/ORM/HierarchyTest.php
+++ b/tests/php/ORM/HierarchyTest.php
@@ -25,7 +25,7 @@ class HierarchyTest extends SapphireTest
         return [];
     }
 
-    public function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/ORM/ListDecoratorTest.php
+++ b/tests/php/ORM/ListDecoratorTest.php
@@ -23,7 +23,7 @@ class ListDecoratorTest extends SapphireTest
      */
     protected $decorator;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/ORM/ListDecoratorTest.php
+++ b/tests/php/ORM/ListDecoratorTest.php
@@ -108,12 +108,12 @@ class ListDecoratorTest extends SapphireTest
         $this->assertFalse($this->decorator->canFilterBy('Title'));
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage SS_Filterable::filterByCallback() passed callback must be callable, 'boolean' given
-     */
     public function testFilterByCallbackThrowsExceptionWhenGivenNonCallable()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(
+            'SS_Filterable::filterByCallback() passed callback must be callable, \'boolean\' given'
+        );
         $this->decorator->filterByCallback(true);
     }
 

--- a/tests/php/ORM/ManyManyThroughListTest.php
+++ b/tests/php/ORM/ManyManyThroughListTest.php
@@ -27,13 +27,13 @@ class ManyManyThroughListTest extends SapphireTest
         ManyManyThroughListTest\FallbackLocale::class,
     ];
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         DataObject::reset();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         DataObject::reset();
         parent::tearDown();

--- a/tests/php/ORM/ManyManyThroughListTest.php
+++ b/tests/php/ORM/ManyManyThroughListTest.php
@@ -193,10 +193,10 @@ class ManyManyThroughListTest extends SapphireTest
     /**
      * Test validation
      *
-     * @expectedException \InvalidArgumentException
      */
     public function testValidateModelValidatesJoinType()
     {
+        $this->expectException(\InvalidArgumentException::class);
         DataObject::reset();
         ManyManyThroughListTest\Item::config()->update(
             'db',

--- a/tests/php/ORM/MarkedSetTest.php
+++ b/tests/php/ORM/MarkedSetTest.php
@@ -31,7 +31,7 @@ class MarkedSetTest extends SapphireTest
         return [];
     }
 
-    public function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/ORM/PaginatedListTest.php
+++ b/tests/php/ORM/PaginatedListTest.php
@@ -326,7 +326,7 @@ class PaginatedListTest extends SapphireTest
     public function testFirstLink()
     {
         $list = new PaginatedList(new ArrayList());
-        $this->assertContains('start=0', $list->FirstLink());
+        $this->assertStringContainsString('start=0', $list->FirstLink());
     }
 
     public function testFirstLinkContainsCurrentGetParameters()
@@ -355,11 +355,11 @@ class PaginatedListTest extends SapphireTest
         $list = new PaginatedList(new ArrayList());
         $list->setPageLength(10);
         $list->setTotalItems(100);
-        $this->assertContains('start=90', $list->LastLink());
+        $this->assertStringContainsString('start=90', $list->LastLink());
 
         // Disable paging
         $list->setPageLength(0);
-        $this->assertContains('start=0', $list->LastLink());
+        $this->assertStringContainsString('start=0', $list->LastLink());
     }
 
     public function testLastLinkContainsCurrentGetParameters()
@@ -388,13 +388,13 @@ class PaginatedListTest extends SapphireTest
         $list = new PaginatedList(new ArrayList());
         $list->setTotalItems(50);
 
-        $this->assertContains('start=10', $list->NextLink());
+        $this->assertStringContainsString('start=10', $list->NextLink());
         $list->setCurrentPage(2);
-        $this->assertContains('start=20', $list->NextLink());
+        $this->assertStringContainsString('start=20', $list->NextLink());
         $list->setCurrentPage(3);
-        $this->assertContains('start=30', $list->NextLink());
+        $this->assertStringContainsString('start=30', $list->NextLink());
         $list->setCurrentPage(4);
-        $this->assertContains('start=40', $list->NextLink());
+        $this->assertStringContainsString('start=40', $list->NextLink());
         $list->setCurrentPage(5);
         $this->assertNull($list->NextLink());
 
@@ -432,11 +432,11 @@ class PaginatedListTest extends SapphireTest
 
         $this->assertNull($list->PrevLink());
         $list->setCurrentPage(2);
-        $this->assertContains('start=0', $list->PrevLink());
+        $this->assertStringContainsString('start=0', $list->PrevLink());
         $list->setCurrentPage(3);
-        $this->assertContains('start=10', $list->PrevLink());
+        $this->assertStringContainsString('start=10', $list->PrevLink());
         $list->setCurrentPage(5);
-        $this->assertContains('start=30', $list->PrevLink());
+        $this->assertStringContainsString('start=30', $list->PrevLink());
 
         // Disable paging
         $list->setPageLength(0);

--- a/tests/php/ORM/SQLSelectTest.php
+++ b/tests/php/ORM/SQLSelectTest.php
@@ -43,7 +43,7 @@ class SQLSelectTest extends SapphireTest
         $ids = $this->allFixtureIDs(SQLSelectTest\TestObject::class);
         $count = $qry->count('"SQLSelectTest_DO"."ID"');
         $this->assertEquals(count($ids), $count);
-        $this->assertInternalType("int", $count);
+        $this->assertIsInt($count);
         //test with `having`
         if (DB::get_conn() instanceof MySQLDatabase) {
             $qry->setSelect(array(
@@ -54,7 +54,7 @@ class SQLSelectTest extends SapphireTest
             $qry->setHaving('"Date" > 2012-02-01');
             $count = $qry->count('"SQLSelectTest_DO"."ID"');
             $this->assertEquals(1, $count);
-            $this->assertInternalType("int", $count);
+            $this->assertIsInt($count);
         }
     }
     public function testUnlimitedRowCount()
@@ -65,17 +65,17 @@ class SQLSelectTest extends SapphireTest
         $qry->setLimit(1);
         $count = $qry->unlimitedRowCount('"SQLSelectTest_DO"."ID"');
         $this->assertEquals(count($ids), $count);
-        $this->assertInternalType("int", $count);
+        $this->assertIsInt($count);
         // Test without column - SQLSelect has different logic for this
         $count = $qry->unlimitedRowCount();
         $this->assertEquals(2, $count);
-        $this->assertInternalType("int", $count);
+        $this->assertIsInt($count);
         //test with `having`
         if (DB::get_conn() instanceof MySQLDatabase) {
             $qry->setHaving('"Date" > 2012-02-01');
             $count = $qry->unlimitedRowCount('"SQLSelectTest_DO"."ID"');
             $this->assertEquals(1, $count);
-            $this->assertInternalType("int", $count);
+            $this->assertIsInt($count);
         }
     }
 
@@ -272,58 +272,48 @@ class SQLSelectTest extends SapphireTest
         );
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\Error\Error
-     */
     public function testZeroLimit()
     {
+        $this->expectException(\PHPUnit\Framework\Error\Error::class);
         Deprecation::notification_version('4.3.0');
         $query = new SQLSelect();
         $query->setFrom("MyTable");
         $query->setLimit(0);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\Error\Error
-     */
     public function testZeroLimitWithOffset()
     {
+        $this->expectException(\PHPUnit\Framework\Error\Error::class);
         Deprecation::notification_version('4.3.0');
-        if (!(DB::get_conn() instanceof MySQLDatabase
+        if (!(
+            DB::get_conn() instanceof MySQLDatabase
             || DB::get_conn() instanceof SQLite3Database
             || DB::get_conn() instanceof PostgreSQLDatabase
         )) {
             $this->markTestSkipped('This test requires either a MySQL, SQLite or PostgreSQL database');
         }
-
         $query = new SQLSelect();
         $query->setFrom("MyTable");
         $query->setLimit(0, 99);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testNegativeLimit()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $query = new SQLSelect();
         $query->setLimit(-10);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testNegativeOffset()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $query = new SQLSelect();
         $query->setLimit(1, -10);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testNegativeOffsetAndLimit()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $query = new SQLSelect();
         $query->setLimit(-10, -10);
     }

--- a/tests/php/ORM/SQLSelectTest.php
+++ b/tests/php/ORM/SQLSelectTest.php
@@ -23,13 +23,13 @@ class SQLSelectTest extends SapphireTest
 
     protected $oldDeprecation = null;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->oldDeprecation = Deprecation::dump_settings();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         Deprecation::restore_settings($this->oldDeprecation);
         parent::tearDown();

--- a/tests/php/ORM/Search/FulltextSearchableTest.php
+++ b/tests/php/ORM/Search/FulltextSearchableTest.php
@@ -12,7 +12,7 @@ use SilverStripe\ORM\Search\FulltextSearchable;
 class FulltextSearchableTest extends SapphireTest
 {
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -24,7 +24,7 @@ class FulltextSearchableTest extends SapphireTest
      * properly at the end of the test. This becomes apparent when a later test tries to
      * ALTER TABLE File and add fulltext indexes with the InnoDB table type.
      */
-    protected function tearDown()
+    protected function tearDown() : void
     {
         parent::tearDown();
 

--- a/tests/php/ORM/TransactionTest.php
+++ b/tests/php/ORM/TransactionTest.php
@@ -192,7 +192,7 @@ class TransactionTest extends SapphireTest
         $fail = DataObject::get_one(TestObject::class, "\"Title\"='Read only page failed'");
 
         //This page should be in the system
-        $this->assertInternalType('object', $success);
+        $this->assertIsObject($success);
         $this->assertTrue($success->exists());
 
         //This page should NOT exist, we had 'read only' permissions

--- a/tests/php/ORM/TransactionTest.php
+++ b/tests/php/ORM/TransactionTest.php
@@ -20,19 +20,19 @@ class TransactionTest extends SapphireTest
 
     private static $originalVersionInfo;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         self::$originalVersionInfo = Deprecation::dump_settings();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         Deprecation::restore_settings(self::$originalVersionInfo);
         parent::tearDown();
     }
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         parent::setUpBeforeClass();
         if (!DB::get_conn()->supportsTransactions()) {

--- a/tests/php/Security/BasicAuthTest.php
+++ b/tests/php/Security/BasicAuthTest.php
@@ -26,7 +26,7 @@ class BasicAuthTest extends FunctionalTest
         ControllerNotSecured::class,
     ];
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Security/GroupTest.php
+++ b/tests/php/Security/GroupTest.php
@@ -20,7 +20,7 @@ class GroupTest extends FunctionalTest
         TestMember::class
     ];
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
     }

--- a/tests/php/Security/InheritedPermissionsFlusherTest.php
+++ b/tests/php/Security/InheritedPermissionsFlusherTest.php
@@ -15,7 +15,7 @@ class InheritedPermissionsFlusherTest extends SapphireTest
 {
     protected static $fixture_file = 'InheritedPermissionsFlusherTest.yml';
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Security/InheritedPermissionsTest.php
+++ b/tests/php/Security/InheritedPermissionsTest.php
@@ -29,7 +29,7 @@ class InheritedPermissionsTest extends SapphireTest
      */
     protected $rootPermissions = null;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->rootPermissions = new TestDefaultPermissionChecker();
 
@@ -57,7 +57,7 @@ class InheritedPermissionsTest extends SapphireTest
         $permission2->clearCache();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         Injector::inst()->unregisterNamedObject(PermissionChecker::class . '.testpermissions');
         Injector::inst()->unregisterNamedObject(PermissionChecker::class . '.unstagedpermissions');

--- a/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.php
+++ b/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.php
@@ -15,7 +15,7 @@ class ChangePasswordHandlerTest extends SapphireTest
 {
     protected static $fixture_file = 'ChangePasswordHandlerTest.yml';
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.php
+++ b/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.php
@@ -42,8 +42,8 @@ class ChangePasswordHandlerTest extends SapphireTest
 
         $result = $handler->setRequest($request)->changepassword();
 
-        $this->assertInternalType('array', $result, 'An array is returned');
-        $this->assertContains('Security/lostpassword', $result['Content'], 'Lost password URL is included');
-        $this->assertContains('Security/login', $result['Content'], 'Login URL is included');
+        $this->assertIsArray($result, 'An array is returned');
+        $this->assertStringContainsString('Security/lostpassword', $result['Content'], 'Lost password URL is included');
+        $this->assertStringContainsString('Security/login', $result['Content'], 'Login URL is included');
     }
 }

--- a/tests/php/Security/MemberAuthenticatorTest.php
+++ b/tests/php/Security/MemberAuthenticatorTest.php
@@ -31,7 +31,7 @@ class MemberAuthenticatorTest extends SapphireTest
     protected $defaultUsername = null;
     protected $defaultPassword = null;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -50,7 +50,7 @@ class MemberAuthenticatorTest extends SapphireTest
             ->setTestNames([]);
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         DefaultAdminService::clearDefaultAdmin();
         if ($this->defaultUsername) {

--- a/tests/php/Security/MemberCsvBulkLoaderTest.php
+++ b/tests/php/Security/MemberCsvBulkLoaderTest.php
@@ -14,7 +14,7 @@ class MemberCsvBulkLoaderTest extends SapphireTest
 {
     protected static $fixture_file = 'MemberCsvBulkLoaderTest.yml';
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -38,7 +38,7 @@ class MemberTest extends FunctionalTest
         Member::class => '*',
     ];
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         parent::setUpBeforeClass();
 
@@ -62,7 +62,7 @@ class MemberTest extends FunctionalTest
     /**
      * @skipUpgrade
      */
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -103,11 +103,9 @@ class MemberTest extends FunctionalTest
         $m2->write();
     }
 
-    /**
-     * @expectedException \SilverStripe\ORM\ValidationException
-     */
     public function testWriteDoesntMergeExistingMemberOnIdentifierChange()
     {
+        $this->expectException(\SilverStripe\ORM\ValidationException::class);
         $m1 = new Member();
         $m1->Email = 'member@test.com';
         $m1->write();
@@ -259,7 +257,7 @@ class MemberTest extends FunctionalTest
         $this->assertEquals($response->getStatusCode(), 302);
 
         // We should get redirected to Security/passwordsent
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Security/lostpassword/passwordsent',
             urldecode($response->getHeader('Location'))
         );
@@ -1014,7 +1012,7 @@ class MemberTest extends FunctionalTest
                 array('name' => $m1->FirstName)
             )
         );
-        $this->assertContains($message, $response->getBody());
+        $this->assertStringContainsString($message, $response->getBody());
 
         $this->logOut();
 
@@ -1028,7 +1026,7 @@ class MemberTest extends FunctionalTest
                 'alc_device' => $firstHash->DeviceID
             )
         );
-        $this->assertNotContains($message, $response->getBody());
+        $this->assertStringNotContainsString($message, $response->getBody());
 
         $response = $this->get(
             'Security/login',
@@ -1039,7 +1037,7 @@ class MemberTest extends FunctionalTest
                 'alc_device' => str_rot13($firstHash->DeviceID)
             )
         );
-        $this->assertNotContains($message, $response->getBody());
+        $this->assertStringNotContainsString($message, $response->getBody());
 
         // Re-logging (ie 'alc_enc' has expired), and not checking the "Remember Me" option
         // should remove all previous hashes for this device
@@ -1057,7 +1055,7 @@ class MemberTest extends FunctionalTest
                 'alc_device' => $firstHash->DeviceID
             )
         );
-        $this->assertContains($message, $response->getBody());
+        $this->assertStringContainsString($message, $response->getBody());
         $this->assertEquals(RememberLoginHash::get()->filter('MemberID', $m1->ID)->count(), 0);
     }
 
@@ -1094,7 +1092,7 @@ class MemberTest extends FunctionalTest
                 array('name' => $m1->FirstName)
             )
         );
-        $this->assertContains($message, $response->getBody());
+        $this->assertStringContainsString($message, $response->getBody());
 
         $this->logOut();
 
@@ -1115,7 +1113,7 @@ class MemberTest extends FunctionalTest
                 'alc_device' => $firstHash->DeviceID
             )
         );
-        $this->assertNotContains($message, $response->getBody());
+        $this->assertStringNotContainsString($message, $response->getBody());
         $this->logOut();
         DBDatetime::clear_mock_now();
     }
@@ -1170,7 +1168,7 @@ class MemberTest extends FunctionalTest
                 array('name' => $m1->FirstName)
             )
         );
-        $this->assertContains($message, $response->getBody());
+        $this->assertStringContainsString($message, $response->getBody());
 
         // Test that removing session but not cookie keeps user
         /** @var SessionAuthenticationHandler $sessionHandler */
@@ -1188,7 +1186,7 @@ class MemberTest extends FunctionalTest
                 'alc_device' => $secondHash->DeviceID
             )
         );
-        $this->assertContains($message, $response->getBody());
+        $this->assertStringContainsString($message, $response->getBody());
 
         // Logging out from the second device - only one device being logged out
         RememberLoginHash::config()->update('logout_across_devices', false);

--- a/tests/php/Security/PasswordEncryptorTest.php
+++ b/tests/php/Security/PasswordEncryptorTest.php
@@ -12,7 +12,7 @@ use SilverStripe\Security\Tests\PasswordEncryptorTest\TestEncryptor;
 
 class PasswordEncryptorTest extends SapphireTest
 {
-    protected function tearDown()
+    protected function tearDown() : void
     {
         parent::tearDown();
         PasswordEncryptor_Blowfish::set_cost(10);

--- a/tests/php/Security/PasswordEncryptorTest.php
+++ b/tests/php/Security/PasswordEncryptorTest.php
@@ -29,11 +29,9 @@ class PasswordEncryptorTest extends SapphireTest
         $this->assertInstanceOf(TestEncryptor::class, $e);
     }
 
-    /**
-     * @expectedException \SilverStripe\Security\PasswordEncryptor_NotFoundException
-     */
     public function testCreateForCodeNotFound()
     {
+        $this->expectException(\SilverStripe\Security\PasswordEncryptor_NotFoundException::class);
         PasswordEncryptor::create_for_algorithm('unknown');
     }
 
@@ -47,7 +45,7 @@ class PasswordEncryptorTest extends SapphireTest
         $encryptors = PasswordEncryptor::get_encryptors();
         $this->assertContains('test', array_keys($encryptors));
         $encryptor = $encryptors['test'];
-        $this->assertContains(TestEncryptor::class, key($encryptor));
+        $this->assertStringContainsString(TestEncryptor::class, key($encryptor));
     }
 
     public function testEncryptorPHPHashWithArguments()

--- a/tests/php/Security/PasswordExpirationMiddlewareTest.php
+++ b/tests/php/Security/PasswordExpirationMiddlewareTest.php
@@ -14,7 +14,7 @@ class PasswordExpirationMiddlewareTest extends SapphireTest
 {
     use HttpRequestMockBuilder;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Security/PasswordValidatorTest.php
+++ b/tests/php/Security/PasswordValidatorTest.php
@@ -14,7 +14,7 @@ class PasswordValidatorTest extends SapphireTest
      */
     protected $usesDatabase = true;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 

--- a/tests/php/Security/PermissionCheckboxSetFieldTest.php
+++ b/tests/php/Security/PermissionCheckboxSetFieldTest.php
@@ -30,8 +30,8 @@ class PermissionCheckboxSetFieldTest extends SapphireTest
             $f->getHiddenPermissions(),
             array('NON-ADMIN')
         );
-        $this->assertContains('ADMIN', $f->Field());
-        $this->assertNotContains('NON-ADMIN', $f->Field());
+        $this->assertStringContainsString('ADMIN', $f->Field());
+        $this->assertStringNotContainsString('NON-ADMIN', $f->Field());
     }
 
     public function testSaveInto()

--- a/tests/php/Security/PermissionTest.php
+++ b/tests/php/Security/PermissionTest.php
@@ -148,14 +148,14 @@ class PermissionTest extends SapphireTest
             Permission::class,
             'GroupID'
         );
-        $this->assertContains('CMS_ACCESS_LeftAndMain', $permissionCheckboxSet->Field());
+        $this->assertStringContainsString('CMS_ACCESS_LeftAndMain', $permissionCheckboxSet->Field());
 
         Config::modify()->merge(Permission::class, 'hidden_permissions', array('CMS_ACCESS_LeftAndMain'));
 
-        $this->assertNotContains('CMS_ACCESS_LeftAndMain', $permissionCheckboxSet->Field());
+        $this->assertStringNotContainsString('CMS_ACCESS_LeftAndMain', $permissionCheckboxSet->Field());
 
         Config::inst()->remove(Permission::class, 'hidden_permissions');
-        $this->assertContains('CMS_ACCESS_LeftAndMain', $permissionCheckboxSet->Field());
+        $this->assertStringContainsString('CMS_ACCESS_LeftAndMain', $permissionCheckboxSet->Field());
     }
 
     public function testEmptyMemberFails()

--- a/tests/php/Security/SecurityDefaultAdminTest.php
+++ b/tests/php/Security/SecurityDefaultAdminTest.php
@@ -16,7 +16,7 @@ class SecurityDefaultAdminTest extends SapphireTest
 
     protected $defaultPassword = null;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
@@ -39,7 +39,7 @@ class SecurityDefaultAdminTest extends SapphireTest
         Permission::reset();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         DefaultAdminService::clearDefaultAdmin();
         if ($this->defaultUsername) {

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -42,7 +42,7 @@ class SecurityTest extends FunctionalTest
         SecurityTest\SecuredController::class,
     ];
 
-    protected function setUp()
+    protected function setUp() : void
     {
         // Set to an empty array of authenticators to enable the default
         Config::modify()

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -87,7 +87,7 @@ class SecurityTest extends FunctionalTest
 
         $response = $this->get('SecurityTest_SecuredController');
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertContains(
+        $this->assertStringContainsString(
             Config::inst()->get(Security::class, 'login_url'),
             $response->getHeader('Location')
         );
@@ -95,7 +95,7 @@ class SecurityTest extends FunctionalTest
         $this->logInWithPermission('ADMIN');
         $response = $this->get('SecurityTest_SecuredController');
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertContains('Success', $response->getBody());
+        $this->assertStringContainsString('Success', $response->getBody());
 
         $this->autoFollowRedirection = true;
     }
@@ -140,7 +140,7 @@ class SecurityTest extends FunctionalTest
             array('default' => 'default', 'alreadyLoggedIn' => 'You are already logged in!')
         );
         Security::permissionFailure($controller);
-        $this->assertContains(
+        $this->assertStringContainsString(
             'You are already logged in!',
             $controller->getResponse()->getBody(),
             'Custom permission failure message was ignored'
@@ -150,7 +150,7 @@ class SecurityTest extends FunctionalTest
             $controller,
             array('default' => 'default', 'alreadyLoggedIn' => 'One-off failure message')
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'One-off failure message',
             $controller->getResponse()->getBody(),
             "Message set passed to Security::permissionFailure() didn't override Config values"
@@ -161,7 +161,7 @@ class SecurityTest extends FunctionalTest
             $controller,
             DBField::create_field('HTMLFragment', '<p>Custom HTML &amp; Message</p>')
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<p>Custom HTML &amp; Message</p>',
             $controller->getResponse()->getBody()
         );
@@ -171,7 +171,7 @@ class SecurityTest extends FunctionalTest
             $controller,
             DBField::create_field('Text', 'Safely escaped & message')
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Safely escaped &amp; message',
             $controller->getResponse()->getBody()
         );
@@ -201,29 +201,32 @@ class SecurityTest extends FunctionalTest
             Security::setCurrentUser(null);
         }
         $response = $this->getRecursive('SecurityTest_SecuredController');
-        $this->assertContains(Convert::raw2xml("That page is secured."), $response->getBody());
-        $this->assertContains('<input type="submit" name="action_doLogin"', $response->getBody());
+        $this->assertStringContainsString(Convert::raw2xml("That page is secured."), $response->getBody());
+        $this->assertStringContainsString('<input type="submit" name="action_doLogin"', $response->getBody());
 
         // Non-logged in user should not be redirected, but instead shown the login form
         // No message/context is available as the user has not attempted to view the secured controller
         $response = $this->getRecursive('Security/login?BackURL=SecurityTest_SecuredController/');
-        $this->assertNotContains(Convert::raw2xml("That page is secured."), $response->getBody());
-        $this->assertNotContains(Convert::raw2xml("You don't have access to this page"), $response->getBody());
-        $this->assertContains('<input type="submit" name="action_doLogin"', $response->getBody());
+        $this->assertStringNotContainsString(Convert::raw2xml("That page is secured."), $response->getBody());
+        $this->assertStringNotContainsString(
+            Convert::raw2xml("You don't have access to this page"),
+            $response->getBody()
+        );
+        $this->assertStringContainsString('<input type="submit" name="action_doLogin"', $response->getBody());
 
         // BackURL with permission error (wrong permissions) should not redirect
         $this->logInAs('grouplessmember');
         $response = $this->getRecursive('SecurityTest_SecuredController');
-        $this->assertContains(Convert::raw2xml("You don't have access to this page"), $response->getBody());
-        $this->assertContains(
+        $this->assertStringContainsString(Convert::raw2xml("You don't have access to this page"), $response->getBody());
+        $this->assertStringContainsString(
             '<input type="submit" name="action_logout" value="Log in as someone else"',
             $response->getBody()
         );
 
         // Directly accessing this page should attempt to follow the BackURL, but stop when it encounters the error
         $response = $this->getRecursive('Security/login?BackURL=SecurityTest_SecuredController/');
-        $this->assertContains(Convert::raw2xml("You don't have access to this page"), $response->getBody());
-        $this->assertContains(
+        $this->assertStringContainsString(Convert::raw2xml("You don't have access to this page"), $response->getBody());
+        $this->assertStringContainsString(
             '<input type="submit" name="action_logout" value="Log in as someone else"',
             $response->getBody()
         );
@@ -231,11 +234,11 @@ class SecurityTest extends FunctionalTest
         // Check correctly logged in admin doesn't generate the same errors
         $this->logInAs('admin');
         $response = $this->getRecursive('SecurityTest_SecuredController');
-        $this->assertContains(Convert::raw2xml("Success"), $response->getBody());
+        $this->assertStringContainsString(Convert::raw2xml("Success"), $response->getBody());
 
         // Directly accessing this page should attempt to follow the BackURL and succeed
         $response = $this->getRecursive('Security/login?BackURL=SecurityTest_SecuredController/');
-        $this->assertContains(Convert::raw2xml("Success"), $response->getBody());
+        $this->assertStringContainsString(Convert::raw2xml("Success"), $response->getBody());
     }
 
     public function testLogInAsSomeoneElse()
@@ -722,7 +725,7 @@ class SecurityTest extends FunctionalTest
         $response = $this->get(Config::inst()->get(Security::class, 'login_url'));
         $robotsHeader = $response->getHeader('X-Robots-Tag');
         $this->assertNotNull($robotsHeader);
-        $this->assertContains('noindex', $robotsHeader);
+        $this->assertStringContainsString('noindex', $robotsHeader);
     }
 
     public function testDoNotSendEmptyRobotsHeaderIfNotDefined()

--- a/tests/php/View/Parsers/ShortcodeParserTest.php
+++ b/tests/php/View/Parsers/ShortcodeParserTest.php
@@ -322,9 +322,9 @@ class ShortcodeParserTest extends SapphireTest
     {
         $result = $this->parser->parse('<a href="[test_shortcode]?my-string=this&thing=2#my-anchor">Link</a>');
 
-        $this->assertContains('my-string=this', $result);
-        $this->assertContains('thing=2', $result);
-        $this->assertContains('my-anchor', $result);
+        $this->assertStringContainsString('my-string=this', $result);
+        $this->assertStringContainsString('thing=2', $result);
+        $this->assertStringContainsString('my-anchor', $result);
     }
 
     public function testNoParseAttemptIfNoCode()
@@ -352,7 +352,7 @@ class ShortcodeParserTest extends SapphireTest
 
         $result = $this->parser->parse('[img]');
 
-        $this->assertContains('http://example.com/image.jpg', $result);
+        $this->assertStringContainsString('http://example.com/image.jpg', $result);
     }
 
     // -----------------------------------------------------------------------------------------------------------------

--- a/tests/php/View/Parsers/ShortcodeParserTest.php
+++ b/tests/php/View/Parsers/ShortcodeParserTest.php
@@ -11,7 +11,7 @@ class ShortcodeParserTest extends SapphireTest
     protected $arguments, $contents, $tagName, $parser;
     protected $extra = array();
 
-    protected function setUp()
+    protected function setUp() : void
     {
         ShortcodeParser::get('test')->register('test_shortcode', array($this, 'shortcodeSaver'));
         $this->parser = ShortcodeParser::get('test');
@@ -19,7 +19,7 @@ class ShortcodeParserTest extends SapphireTest
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         ShortcodeParser::get('test')->unregister('test_shortcode');
 

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -67,14 +67,46 @@ class RequirementsTest extends SapphireTest
 
         $html = $backend->includeInHTML(self::$html_template);
 
-        $this->assertContains('http://www.mydomain.com/test.js', $html, 'Load external javascript URL');
-        $this->assertContains('https://www.mysecuredomain.com/test.js', $html, 'Load external secure javascript URL');
-        $this->assertContains('//scheme-relative.example.com/test.js', $html, 'Load external scheme-relative JS');
-        $this->assertContains('http://www.mydomain.com:3000/test.js', $html, 'Load external with port');
-        $this->assertContains('http://www.mydomain.com/test.css', $html, 'Load external CSS URL');
-        $this->assertContains('https://www.mysecuredomain.com/test.css', $html, 'Load external secure CSS URL');
-        $this->assertContains('//scheme-relative.example.com/test.css', $html, 'Load scheme-relative CSS URL');
-        $this->assertContains('http://www.mydomain.com:3000/test.css', $html, 'Load external with port');
+        $this->assertStringContainsString(
+            'http://www.mydomain.com/test.js',
+            $html,
+            'Load external javascript URL'
+        );
+        $this->assertStringContainsString(
+            'https://www.mysecuredomain.com/test.js',
+            $html,
+            'Load external secure javascript URL'
+        );
+        $this->assertStringContainsString(
+            '//scheme-relative.example.com/test.js',
+            $html,
+            'Load external scheme-relative JS'
+        );
+        $this->assertStringContainsString(
+            'http://www.mydomain.com:3000/test.js',
+            $html,
+            'Load external with port'
+        );
+        $this->assertStringContainsString(
+            'http://www.mydomain.com/test.css',
+            $html,
+            'Load external CSS URL'
+        );
+        $this->assertStringContainsString(
+            'https://www.mysecuredomain.com/test.css',
+            $html,
+            'Load external secure CSS URL'
+        );
+        $this->assertStringContainsString(
+            '//scheme-relative.example.com/test.css',
+            $html,
+            'Load scheme-relative CSS URL'
+        );
+        $this->assertStringContainsString(
+            'http://www.mydomain.com:3000/test.css',
+            $html,
+            'Load external with port'
+        );
     }
 
     /**
@@ -217,12 +249,12 @@ class RequirementsTest extends SapphireTest
         );
 
         /* COMBINED JAVASCRIPT HAS CORRECT CONTENT */
-        $this->assertContains(
+        $this->assertStringContainsString(
             "alert('b')",
             file_get_contents($combinedFilePath),
             'combined javascript has correct content'
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "alert('c')",
             file_get_contents($combinedFilePath),
             'combined javascript has correct content'
@@ -268,12 +300,12 @@ class RequirementsTest extends SapphireTest
         );
 
         /* COMBINED JAVASCRIPT HAS CORRECT CONTENT */
-        $this->assertContains(
+        $this->assertStringContainsString(
             "alert('b')",
             file_get_contents($combinedFilePath),
             'combined javascript has correct content'
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "alert('c')",
             file_get_contents($combinedFilePath),
             'combined javascript has correct content'
@@ -312,7 +344,7 @@ class RequirementsTest extends SapphireTest
         );
 
         /* DEFER IS NOT INCLUDED IN SCRIPT TAG */
-        $this->assertNotContains('defer', $html, 'defer is not included');
+        $this->assertStringNotContainsString('defer', $html, 'defer is not included');
 
         /* COMBINED JAVASCRIPT FILE EXISTS */
         clearstatcache(); // needed to get accurate file_exists() results
@@ -322,12 +354,12 @@ class RequirementsTest extends SapphireTest
         );
 
         /* COMBINED JAVASCRIPT HAS CORRECT CONTENT */
-        $this->assertContains(
+        $this->assertStringContainsString(
             "alert('b')",
             file_get_contents($combinedFilePath),
             'combined javascript has correct content'
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "alert('c')",
             file_get_contents($combinedFilePath),
             'combined javascript has correct content'
@@ -386,7 +418,7 @@ class RequirementsTest extends SapphireTest
         );
 
         /* ASYNC IS NOT INCLUDED IN SCRIPT TAG */
-        $this->assertNotContains('async', $html, 'async is not included');
+        $this->assertStringNotContainsString('async', $html, 'async is not included');
 
         /* COMBINED JAVASCRIPT FILE EXISTS */
         clearstatcache(); // needed to get accurate file_exists() results
@@ -396,12 +428,12 @@ class RequirementsTest extends SapphireTest
         );
 
         /* COMBINED JAVASCRIPT HAS CORRECT CONTENT */
-        $this->assertContains(
+        $this->assertStringContainsString(
             "alert('b')",
             file_get_contents($combinedFilePath),
             'combined javascript has correct content'
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "alert('c')",
             file_get_contents($combinedFilePath),
             'combined javascript has correct content'
@@ -467,12 +499,12 @@ class RequirementsTest extends SapphireTest
         );
 
         /* COMBINED JAVASCRIPT HAS CORRECT CONTENT */
-        $this->assertContains(
+        $this->assertStringContainsString(
             "alert('b')",
             file_get_contents($combinedFilePath),
             'combined javascript has correct content'
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "alert('c')",
             file_get_contents($combinedFilePath),
             'combined javascript has correct content'
@@ -609,7 +641,7 @@ class RequirementsTest extends SapphireTest
         clearstatcache(); // needed to get accurate file_exists() results
         $backend->includeInHTML(self::$html_template);
         $this->assertFileExists($combinedFilePath2);
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "alert('b')",
             file_get_contents($combinedFilePath2),
             'blocked uncombined files are not included'
@@ -822,12 +854,12 @@ class RequirementsTest extends SapphireTest
 
         $backend->setWriteJavascriptToBody(false);
         $html = $backend->includeInHTML($template);
-        $this->assertContains('<head><script', $html);
+        $this->assertStringContainsString('<head><script', $html);
 
         $backend->setWriteJavascriptToBody(true);
         $html = $backend->includeInHTML($template);
-        $this->assertNotContains('<head><script', $html);
-        $this->assertContains("</script>\n</body>", $html);
+        $this->assertStringNotContainsString('<head><script', $html);
+        $this->assertStringContainsString("</script>\n</body>", $html);
     }
 
     public function testIncludedJsIsNotCommentedOut()
@@ -840,7 +872,7 @@ class RequirementsTest extends SapphireTest
         $html = $backend->includeInHTML($template);
         //wiping out commented-out html
         $html = preg_replace('/<!--(.*)-->/Uis', '', $html);
-        $this->assertContains("RequirementsTest_a.js", $html);
+        $this->assertStringContainsString("RequirementsTest_a.js", $html);
     }
 
     public function testCommentedOutScriptTagIsIgnored()
@@ -959,7 +991,7 @@ EOS
 
         $urlGenerator->setNonceStyle(null);
         $html = $backend->includeInHTML($template);
-        $this->assertNotContains('RequirementsTest_a.js=', $html);
+        $this->assertStringNotContainsString('RequirementsTest_a.js=', $html);
         $this->assertNotRegExp('/RequirementsTest_a\.js\?m=[\d]*"/', $html);
         $this->assertNotRegExp('/RequirementsTest_b\.js\?foo=bar&amp;bla=blubb&amp;m=[\d]*"/', $html);
         $this->assertNotRegExp('/RequirementsTest_a\.css\?m=[\d]*"/', $html);

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -31,7 +31,7 @@ class RequirementsTest extends SapphireTest
 
     static $html_template = '<html><head></head><body></body></html>';
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         Director::config()->set('alternate_base_folder', __DIR__ . '/SSViewerTest');
@@ -43,7 +43,7 @@ class RequirementsTest extends SapphireTest
         $this->oldThemeResourceLoader = ThemeResourceLoader::inst();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         ThemeResourceLoader::set_instance($this->oldThemeResourceLoader);
         TestAssetStore::reset();

--- a/tests/php/View/SSViewerCacheBlockTest.php
+++ b/tests/php/View/SSViewerCacheBlockTest.php
@@ -422,11 +422,9 @@ class SSViewerCacheBlockTest extends SapphireTest
         $this->assertNotNull($this->_runtemplate('<% cached %><% with Foo %>$Bar<% end_with %><% end_cached %>'));
     }
 
-    /**
-     * @expectedException \SilverStripe\View\SSTemplateParseException
-     */
     public function testErrorMessageForCachedWithinControlWithinCached()
     {
+        $this->expectException(\SilverStripe\View\SSTemplateParseException::class);
         $this->_reset(true);
         $this->_runtemplate(
             '<% cached %><% with Foo %><% cached %>$Bar<% end_cached %><% end_with %><% end_cached %>'
@@ -443,20 +441,16 @@ class SSViewerCacheBlockTest extends SapphireTest
         );
     }
 
-    /**
-     * @expectedException \SilverStripe\View\SSTemplateParseException
-     */
     public function testErrorMessageForCachedWithinIf()
     {
+        $this->expectException(\SilverStripe\View\SSTemplateParseException::class);
         $this->_reset(true);
         $this->_runtemplate('<% cached %><% if Foo %><% cached %>$Bar<% end_cached %><% end_if %><% end_cached %>');
     }
 
-    /**
-     * @expectedException \SilverStripe\View\SSTemplateParseException
-     */
     public function testErrorMessageForInvalidConditional()
     {
+        $this->expectException(\SilverStripe\View\SSTemplateParseException::class);
         $this->_reset(true);
         $this->_runtemplate('<% cached Foo if %>$Bar<% end_cached %>');
     }

--- a/tests/php/View/SSViewerTest.php
+++ b/tests/php/View/SSViewerTest.php
@@ -50,7 +50,7 @@ class SSViewerTest extends SapphireTest
         SSViewerTest\TestObject::class,
     );
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         SSViewer::config()->update('source_file_comments', false);
@@ -59,7 +59,7 @@ class SSViewerTest extends SapphireTest
         $this->oldServer = $_SERVER;
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         $_SERVER = $this->oldServer;
         TestAssetStore::reset();

--- a/tests/php/View/SSViewerTest.php
+++ b/tests/php/View/SSViewerTest.php
@@ -259,14 +259,14 @@ class SSViewerTest extends SapphireTest
         $testBackend->processCombinedFiles();
         $js = array_keys($testBackend->getJavascript());
         $combinedTestFilePath = Director::publicFolder() . reset($js);
-        $this->assertContains('_combinedfiles/testRequirementsCombine-4c0e97a.js', $combinedTestFilePath);
+        $this->assertStringContainsString('_combinedfiles/testRequirementsCombine-4c0e97a.js', $combinedTestFilePath);
 
         // and make sure the combined content matches the input content, i.e. no loss of functionality
         if (!file_exists($combinedTestFilePath)) {
             $this->fail('No combined file was created at expected path: ' . $combinedTestFilePath);
         }
         $combinedTestFileContents = file_get_contents($combinedTestFilePath);
-        $this->assertContains($jsFileContents, $combinedTestFileContents);
+        $this->assertStringContainsString($jsFileContents, $combinedTestFileContents);
     }
 
     public function testRequirementsMinification()
@@ -1524,25 +1524,12 @@ after'
         );
     }
 
-    /**
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Up called when we're already at the top of the scope
-     */
     public function testTooManyUps()
     {
-        $data = new ArrayData([
-            'Foo' => new ArrayData([
-                'Name' => 'Foo',
-                'Bar' => new ArrayData([
-                    'Name' => 'Bar'
-                ])
-            ])
-        ]);
-
-        $this->assertEquals(
-            'Foo',
-            $this->render('<% with Foo.Bar %>{$Up.Up.Name}<% end_with %>', $data)
-        );
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Up called when we\'re already at the top of the scope');
+        $data = new ArrayData(['Foo' => new ArrayData(['Name' => 'Foo', 'Bar' => new ArrayData(['Name' => 'Bar'])])]);
+        $this->assertEquals('Foo', $this->render('<% with Foo.Bar %>{$Up.Up.Name}<% end_with %>', $data));
     }
 
     /**
@@ -1832,23 +1819,23 @@ after'
             '<a class="external-inserted" href="http://google.com#anchor">ExternalInsertedLink</a>'
         );
         $result = $tmpl->process($obj);
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<a class="inserted" href="' . $base . '#anchor">InsertedLink</a>',
             $result
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<a class="external-inserted" href="http://google.com#anchor">ExternalInsertedLink</a>',
             $result
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<a class="inline" href="' . $base . '#anchor">InlineLink</a>',
             $result
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<a class="external-inline" href="http://google.com#anchor">ExternalInlineLink</a>',
             $result
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<svg><use xlink:href="#sprite"></use></svg>',
             $result,
             'SSTemplateParser should only rewrite anchor hrefs'
@@ -1887,13 +1874,13 @@ after'
 
         $code = '<a class="inserted" href="<?php echo \SilverStripe\Core\Convert::raw2att(preg_replace("/^(\/)+/", "/",'
             . ' $_SERVER[\'REQUEST_URI\'])); ?>#anchor">InsertedLink</a>';
-        $this->assertContains($code, $result);
+        $this->assertStringContainsString($code, $result);
         // TODO Fix inline links in PHP mode
-        // $this->assertContains(
+        // $this->assertStringContainsString(
         //  '<a class="inline" href="<?php echo str_replace(',
         //  $result
         // );
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<svg><use xlink:href="#sprite"></use></svg>',
             $result,
             'SSTemplateParser should only rewrite anchor hrefs'

--- a/tests/php/View/ViewableDataTest.php
+++ b/tests/php/View/ViewableDataTest.php
@@ -215,7 +215,7 @@ class ViewableDataTest extends SapphireTest
         SSViewer::set_themes($themes);
 
         $data = new ViewableData();
-        $this->assertContains(
+        $this->assertStringContainsString(
             'tests/php/View/ViewableDataTest/testtheme',
             $data->ThemeDir()
         );

--- a/tests/php/i18n/i18nTest.php
+++ b/tests/php/i18n/i18nTest.php
@@ -17,13 +17,13 @@ class i18nTest extends SapphireTest
 {
     use i18nTestManifest;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->setupManifest();
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         $this->tearDownManifest();
         parent::tearDown();

--- a/tests/php/i18n/i18nTest.php
+++ b/tests/php/i18n/i18nTest.php
@@ -173,11 +173,11 @@ class i18nTest extends SapphireTest
         $parsedHtml = Convert::nl2os($viewer->process(new ArrayData([
             'TestProperty' => 'TestPropertyValue'
         ])));
-        $this->assertContains(
+        $this->assertStringContainsString(
             Convert::nl2os("Layout Template\n"),
             $parsedHtml
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             Convert::nl2os("Layout Template no namespace\n"),
             $parsedHtml
         );
@@ -202,42 +202,42 @@ class i18nTest extends SapphireTest
         i18n::set_locale('de_DE');
         $viewer = new SSViewer('i18nTestModule');
         $parsedHtml = Convert::nl2os($viewer->process(new ArrayData(array('TestProperty' => 'TestPropertyValue'))));
-        $this->assertContains(
+        $this->assertStringContainsString(
             Convert::nl2os("TRANS Main Template\n"),
             $parsedHtml
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             Convert::nl2os("TRANS Layout Template\n"),
             $parsedHtml
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             Convert::nl2os("TRANS Layout Template no namespace\n"),
             $parsedHtml
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             Convert::nl2os("TRANS My replacement: TestPropertyValue\n"),
             $parsedHtml
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             Convert::nl2os("TRANS Include Entity with Namespace\n"),
             $parsedHtml
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             Convert::nl2os("TRANS Include Entity without Namespace\n"),
             $parsedHtml
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             Convert::nl2os("TRANS My include replacement: TestPropertyValue\n"),
             $parsedHtml
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             Convert::nl2os("TRANS My include replacement no namespace: TestPropertyValue\n"),
             $parsedHtml
         );
         // Check plurals
-        $this->assertContains('Single: An item', $parsedHtml);
-        $this->assertContains('Multiple: 4 items', $parsedHtml);
-        $this->assertContains('None: 0 items', $parsedHtml);
+        $this->assertStringContainsString('Single: An item', $parsedHtml);
+        $this->assertStringContainsString('Multiple: 4 items', $parsedHtml);
+        $this->assertStringContainsString('None: 0 items', $parsedHtml);
 
         i18n::set_locale($oldLocale);
     }
@@ -264,7 +264,7 @@ class i18nTest extends SapphireTest
             $default,
             array("name"=>"Mark", "greeting"=>"welcome", "goodbye"=>"bye")
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "Hello Mark welcome. But it is late, bye",
             $translated,
             "Testing fallback to the translation default (but using the injection array)"
@@ -276,7 +276,7 @@ class i18nTest extends SapphireTest
             $default,
             ["name"=>"Paul", "greeting"=>"good you are here", "goodbye"=>"see you"]
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "TRANS Hello Paul good you are here. But it is late, see you",
             $translated,
             "Testing entity, default string and injection array"
@@ -289,7 +289,7 @@ class i18nTest extends SapphireTest
             "New context (this should be ignored)",
             ["name"=>"Steffen", "greeting"=>"willkommen", "goodbye"=>"wiedersehen"]
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "TRANS Hello Steffen willkommen. But it is late, wiedersehen",
             $translated,
             "Full test of translation, using default, context and injection array"
@@ -326,20 +326,20 @@ class i18nTest extends SapphireTest
 
         $viewer = new SSViewer('i18nTestModule');
         $parsedHtml = Convert::nl2os($viewer->process(new ArrayData(['TestProperty' => 'TestPropertyValue'])));
-        $this->assertContains(
+        $this->assertStringContainsString(
             Convert::nl2os("Hello Mark welcome. But it is late, bye\n"),
             $parsedHtml,
             "Testing fallback to the translation default (but using the injection array)"
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             Convert::nl2os("TRANS Hello Paul good you are here. But it is late, see you\n"),
             $parsedHtml,
             "Testing entity, default string and injection array"
         );
 
         //test injected calls
-        $this->assertContains(
+        $this->assertStringContainsString(
             Convert::nl2os(
                 "TRANS Hello " . Director::absoluteBaseURL() . " " . i18n::get_locale()
                 . ". But it is late, global calls\n"

--- a/tests/php/i18n/i18nTextCollectorTest.php
+++ b/tests/php/i18n/i18nTextCollectorTest.php
@@ -20,7 +20,7 @@ class i18nTextCollectorTest extends SapphireTest
      */
     protected $alternateBaseSavePath = null;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->setupManifest();
@@ -29,7 +29,7 @@ class i18nTextCollectorTest extends SapphireTest
         Filesystem::makeFolder($this->alternateBaseSavePath);
     }
 
-    protected function tearDown()
+    protected function tearDown() : void
     {
         if (is_dir($this->alternateBaseSavePath)) {
             Filesystem::removeFolder($this->alternateBaseSavePath);

--- a/tests/php/i18n/i18nTextCollectorTest.php
+++ b/tests/php/i18n/i18nTextCollectorTest.php
@@ -547,27 +547,27 @@ PHP;
         );
 
         $moduleLangFileContent = file_get_contents($moduleLangFile);
-        $this->assertContains(
+        $this->assertStringContainsString(
             "    ADDITION: Addition\n",
             $moduleLangFileContent
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "    ENTITY: 'Entity with \"Double Quotes\"'\n",
             $moduleLangFileContent
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "    MAINTEMPLATE: 'Main Template'\n",
             $moduleLangFileContent
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "    OTHERENTITY: 'Other Entity'\n",
             $moduleLangFileContent
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "    WITHNAMESPACE: 'Include Entity with Namespace'\n",
             $moduleLangFileContent
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "    NONAMESPACE: 'Include Entity without Namespace'\n",
             $moduleLangFileContent
         );
@@ -579,11 +579,11 @@ PHP;
             'Master language file can be written to modules /lang folder'
         );
         $otherModuleLangFileContent = file_get_contents($otherModuleLangFile);
-        $this->assertContains(
+        $this->assertStringContainsString(
             "    ENTITY: 'Other Module Entity'\n",
             $otherModuleLangFileContent
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "    MAINTEMPLATE: 'Main Template Other Module'\n",
             $otherModuleLangFileContent
         );


### PR DESCRIPTION
Moving PHPUnit to v8 as v7 is no longer supported and we need to fix some of our test failures by upgrading

Related:
- https://github.com/silverstripe/silverstripe-admin/pull/1023
- https://github.com/silverstripe/silverstripe-cms/pull/2532
- https://github.com/silverstripe/silverstripe-assets/pull/382
- https://github.com/silverstripe/silverstripe-testsession/pull/71
- https://github.com/silverstripe/silverstripe-versioned/pull/267
- https://github.com/silverstripe/silverstripe-graphql/pull/255