### PR TITLE
Added return type to ArraySubset constraint to be compatible with PHPUnit 9

### DIFF
--- a/src/Dev/Constraint/ArraySubset.php
+++ b/src/Dev/Constraint/ArraySubset.php
@@ -56,7 +56,7 @@ final class ArraySubset extends Constraint
      * @throws ExpectationFailedException
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
-    public function evaluate($other, string $description = '', bool $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {
         //type cast $other & $this->subset as an array to allow
         //support in standard array functions.


### PR DESCRIPTION
PHPUnit 9 has added the `?bool` return type to `Constraint@evaluate`, without this test suites running on phpunit 9 fail