### PR TITLE
[DOCS] Member::logInAs is not a valid example

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -790,7 +790,7 @@ class Member extends DataObject
      *
      * E.g.
      * <code>
-     * Member::logInAs(Security::findAnAdministrator(), function() {
+     * Member::actAs(Security::findAnAdministrator(), function() {
      *     $record->write();
      * });
      * </code>


### PR DESCRIPTION
Member::logInAs doesn't exist as a static function.

Additionally, `logInAs` does exist as a function in SapphireTest.php, so, should this be updated to also use `Member::actAs` for consistency?