### PR TITLE
Extensible allows extensions to be service definitions

### DIFF
--- a/docs/en/02_Developer_Guides/05_Extending/01_Extensions.md
+++ b/docs/en/02_Developer_Guides/05_Extending/01_Extensions.md
@@ -348,6 +348,8 @@ class CustomisedSomeExtension extends SomeExtension
 }
 ```
 
+You may also use [Injector service definitions](injector/) to define extensions such as `%$MyExtension.default`, which will be resolved by Injector before being applied.
+
 [notice]
 Please note that modifications such as this should be done in YAML configuration only. It is not recommended
 to use `Config::modify()->set()` to adjust the implementation class name of an extension after the configuration

--- a/src/Core/ClassInfo.php
+++ b/src/Core/ClassInfo.php
@@ -423,6 +423,12 @@ class ClassInfo
             return static::$_cache_parse[$classSpec];
         }
 
+        // Remove service class prefixes and append them later, ensuring PHP can still parse it
+        $serviceClassPrefix = substr($classSpec, 0, 2) === '%$';
+        if ($serviceClassPrefix) {
+            $classSpec = substr($classSpec, 2);
+        }
+
         $tokens = token_get_all("<?php $classSpec");
         $class = null;
         $args = array();
@@ -556,7 +562,12 @@ class ClassInfo
             }
         }
 
+        // Re-apply service class prefix
+        if ($serviceClassPrefix) {
+            $class = '%$' . $class;
+        }
         $result = [$class, $args];
+
         static::$_cache_parse[$classSpec] = $result;
         return $result;
     }

--- a/src/Core/Config/Middleware/ExtensionMiddleware.php
+++ b/src/Core/Config/Middleware/ExtensionMiddleware.php
@@ -10,6 +10,7 @@ use SilverStripe\Config\Middleware\MiddlewareCommon;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Extension;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataExtension;
 
 class ExtensionMiddleware implements Middleware
@@ -66,6 +67,9 @@ class ExtensionMiddleware implements Middleware
             list($extensionClass, $extensionArgs) = ClassInfo::parse_class_spec($extension);
             // Strip service name specifier
             $extensionClass = strtok($extensionClass, '.');
+            if ($extensionSpec = Injector::inst()->getServiceSpec($extensionClass)) {
+                $extensionClass = $extensionSpec['class'];
+            }
             if (!class_exists($extensionClass)) {
                 throw new InvalidArgumentException("$class references nonexistent $extensionClass in 'extensions'");
             }

--- a/src/Core/Config/Middleware/ExtensionMiddleware.php
+++ b/src/Core/Config/Middleware/ExtensionMiddleware.php
@@ -64,9 +64,8 @@ class ExtensionMiddleware implements Middleware
 
         $extensions = $extensionSourceConfig['extensions'];
         foreach ($extensions as $extension) {
-            list($extensionClass, $extensionArgs) = ClassInfo::parse_class_spec($extension);
-            // Strip service name specifier
-            $extensionClass = strtok($extensionClass, '.');
+            [$extensionClass, $extensionArgs] = ClassInfo::parse_class_spec($extension);
+
             if ($extensionSpec = Injector::inst()->getServiceSpec($extensionClass)) {
                 $extensionClass = $extensionSpec['class'];
             }

--- a/src/Core/Extensible.php
+++ b/src/Core/Extensible.php
@@ -178,10 +178,13 @@ trait Extensible
             $extension = $classOrExtension;
         }
 
-        if (!preg_match('/^([^(]*)/', $extension, $matches)) {
+        if (!preg_match('/^(%\$)?([^(]+)/', $extension, $matches)) {
             return false;
         }
-        $extensionClass = $matches[1];
+        $extensionClass = $matches[2];
+        if ($extensionSpec = Injector::inst()->getServiceSpec($extensionClass)) {
+            $extensionClass = $extensionSpec['class'];
+        }
         if (!class_exists($extensionClass)) {
             user_error(
                 sprintf('Object::add_extension() - Can\'t find extension class for "%s"', $extensionClass),
@@ -338,6 +341,10 @@ trait Extensible
             // Strip service name specifier
             $extensionClass = strtok($extensionClass, '.');
             $sources[] = $extensionClass;
+
+            if ($extensionSpec = Injector::inst()->getServiceSpec($extensionClass)) {
+                $extensionClass = $extensionSpec['class'];
+            }
 
             if (!class_exists($extensionClass)) {
                 throw new InvalidArgumentException("$class references nonexistent $extensionClass in \$extensions");

--- a/src/Core/Extensible.php
+++ b/src/Core/Extensible.php
@@ -564,7 +564,7 @@ trait Extensible
 
             foreach ($extensions as $extension) {
                 // Allow service names of the form "%$ServiceName" or "ServiceName.default"
-                [$extensionClass,] = ClassInfo::parse_class_spec($extension);
+                [$extensionClass] = ClassInfo::parse_class_spec($extension);
 
                 // If singletons have constructor dependencies they must be service references, and
                 // must be defined in Injector configuration

--- a/src/Core/Injector/Injector.php
+++ b/src/Core/Injector/Injector.php
@@ -1068,6 +1068,11 @@ class Injector implements ContainerInterface
             return $this->specs[$name];
         }
 
+        // Strip prefix
+        if (substr($name, 0, 2) === '%$') {
+            $name = substr($name, 2);
+        }
+
         // Lazy load
         $config = $this->configLocator->locateConfigFor($name);
         if ($config) {

--- a/tests/php/Core/ObjectTest.php
+++ b/tests/php/Core/ObjectTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Core\Tests;
 
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Extension;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Tests\ObjectTest\BaseObject;
@@ -13,6 +14,7 @@ use SilverStripe\Core\Tests\ObjectTest\ExtendTest3;
 use SilverStripe\Core\Tests\ObjectTest\ExtendTest4;
 use SilverStripe\Core\Tests\ObjectTest\ExtendTest5;
 use SilverStripe\Core\Tests\ObjectTest\ExtensionRemoveTest;
+use SilverStripe\Core\Tests\ObjectTest\ExtensionService;
 use SilverStripe\Core\Tests\ObjectTest\ExtensionTest;
 use SilverStripe\Core\Tests\ObjectTest\ExtensionTest2;
 use SilverStripe\Core\Tests\ObjectTest\ExtensionTest3;
@@ -545,5 +547,27 @@ class ObjectTest extends SapphireTest
         $this->assertInstanceOf($mockClass, $object->getExtensionInstance(TestExtension::class));
         $this->assertInstanceOf(TestExtension::class, $object->getExtensionInstance($mockClass));
         $this->assertInstanceOf($mockClass, $object->getExtensionInstance($mockClass));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testExtensionsAppliedViaANonExistentServiceAsAControl()
+    {
+        Config::modify()->set(BaseObject::class, 'extensions', ['NotAService']);
+        BaseObject::create();
+    }
+
+    public function testExtensionsCanBeAppliedViaInjectorServices()
+    {
+        $config = Config::modify();
+        $config->set(Injector::class, 'ATestService', [
+            'class' => ExtensionService::class,
+            'constructor' => ['nonsense'],
+        ]);
+        $config->set(BaseObject::class, 'extensions', ['ATestService']);
+
+        $nonsense = BaseObject::create();
+        $this->assertEquals('This extension is nonsense', $nonsense->aMethod());
     }
 }

--- a/tests/php/Core/ObjectTest/ExtensionService.php
+++ b/tests/php/Core/ObjectTest/ExtensionService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SilverStripe\Core\Tests\ObjectTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class ExtensionService extends Extension implements TestOnly
+{
+    private $property;
+
+    public function __construct($property)
+    {
+        $this->property = $property;
+    }
+
+    public function aMethod()
+    {
+        return 'This extension is ' . $this->property;
+    }
+}


### PR DESCRIPTION
This revives https://github.com/silverstripe/silverstripe-framework/pull/8444 which was closed due to  the target branch being routely deleted. This PR did a good job of enabling support for using service  classes that don't use `%$` prefixes, I've added that and a couple more tests.

Replacing an extension class with Injector is already possible in SilverStripe. This PR adds support   for using Injector service names/aliases for extension application - for example:

```yaml
SilverStripe\Core\Injector\Injector:
  MyExtension:
    class: MyRealExtension
  MyExtension.secondary:
    class: AnotherRealExtension
  MyExtension.tertiary: '%$AnotherRealExtension'

SilverStripe\CMS\Model\SiteTree:
  extensions:
    - '%$MyExtension'
    - '%$MyExtension.secondary'
    - MyExtension
    - MyExtension.secondary
    - MyExtension.tertiary
```

The Extensible code indicates that it expects to support service classes, perhaps that broke at some point. Even as a patch change, this PR does touch some pretty valuable parts of the framework, so I've targetted the next minor release.