### PR TITLE
Cache results of _configure_database.php glob

### DIFF
--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -33,3 +33,7 @@ SilverStripe\Core\Injector\Injector:
     factory: SilverStripe\Core\Cache\CacheFactory
     constructor:
       namespace: 'ThemeResourceLoader'
+  Psr\SimpleCache\CacheInterface.DatabaseAdapterRegistry:
+    factory: SilverStripe\Core\Cache\CacheFactory
+    constructor:
+      namespace: 'DatabaseAdapterRegistry'


### PR DESCRIPTION
Removes a `glob` that searches for `/vendor/*/*/_configure_database.php` on every request

Looks like an ancient piece of code.  I couldn't find a single _configure_database.php in cwp/recipe-kitchen-sink

It's an expensive call that gets worse the more modules you add.  Using xhprof on vagrant (so it is going to be much slower then proper server, though it does provide a good illustration)

silverstripe/installer: 45ms
cwp/recipe-kitchen-sink: 517ms

Despite the file being in /Dev/Install, it gets called by CoreKernal->boot() which itself is called by HTTPApplication->execute() higher up in the call stack

