### PR TITLE
BUGFIX: Ensure realpath returns a string for stripos

### DIFF
--- a/src/Core/Manifest/ModuleManifest.php
+++ b/src/Core/Manifest/ModuleManifest.php
@@ -271,7 +271,8 @@ class ModuleManifest
         $modules = ModuleLoader::inst()->getManifest()->getModules();
         foreach ($modules as $module) {
             // Check if path is in module
-            if (stripos($path, realpath($module->getPath())) !== 0) {
+            $realPath = realpath($module->getPath());
+            if ($realPath && stripos($path, $realPath) !== 0) {
                 continue;
             }
 


### PR DESCRIPTION
I have this error appear in php 7.4;

```[Deprecated] stripos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior```

Updating the realpath to return a string fixes the issue.

Any feedback welcome.