### PR TITLE
Use short array syntax across the framework's codebase

### DIFF
--- a/_register_database.php
+++ b/_register_database.php
@@ -6,7 +6,7 @@ use SilverStripe\Dev\Install\MySQLDatabaseConfigurationHelper;
 
 // Register MySQLi as a database adapter (listed as second option in Dev/Install/config-form.html)
 DatabaseAdapterRegistry::register(
-    array(
+    [
         /** @skipUpgrade */
         'class' => 'MySQLDatabase',
         'module' => 'framework',
@@ -17,12 +17,12 @@ DatabaseAdapterRegistry::register(
         'missingExtensionText' =>
             'The <a href="http://www.php.net/manual/en/book.mysqli.php">MySQLi</a>
 			PHP extension is not available. Please install or enable it and refresh this page.'
-    )
+    ]
 );
 
 // Register MySQL PDO as a database adapter (listed as first option in Dev/Install/config-form.html)
 DatabaseAdapterRegistry::register(
-    array(
+    [
         /** @skipUpgrade */
         'class' => 'MySQLPDODatabase',
         'module' => 'framework',
@@ -34,5 +34,5 @@ DatabaseAdapterRegistry::register(
             'Either the <a href="http://www.php.net/manual/en/book.pdo.php">PDO Extension</a> or
             the <a href="http://www.php.net/manual/en/ref.pdo-mysql.php">MySQL PDO Driver</a>
             are unavailable. Please install or enable these and refresh this page.'
-    )
+    ]
 );

--- a/docs/en/02_Developer_Guides/00_Model/01_Data_Model_and_ORM.md
+++ b/docs/en/02_Developer_Guides/00_Model/01_Data_Model_and_ORM.md
@@ -481,10 +481,10 @@ $players = Player::get()->exclude([
 `Exclude` follows the same pattern as filter, so for removing only Sam Minnée from the list:
 
 ```php
-$players = Player::get()->exclude(array(
+$players = Player::get()->exclude([
     'FirstName' => 'Sam',
     'Surname' => 'Minnée',
-));
+]);
 
 // SELECT * FROM Player WHERE (FirstName != 'Sam' OR LastName != 'Minnée')
 ```

--- a/docs/en/02_Developer_Guides/00_Model/02_Relations.md
+++ b/docs/en/02_Developer_Guides/00_Model/02_Relations.md
@@ -209,7 +209,7 @@ If you're using the default scaffolded form fields with multiple `has_one` relat
 public function getCMSFields()
 {
     $fields = parent::getCMSFields();
-    $fields->removeByName(array('ManagerID', 'CleanerID'));
+    $fields->removeByName(['ManagerID', 'CleanerID']);
     return $fields;
 }
 ```

--- a/docs/en/02_Developer_Guides/00_Model/03_Lists.md
+++ b/docs/en/02_Developer_Guides/00_Model/03_Lists.md
@@ -51,11 +51,11 @@ A map is an array where the array indexes contain data as well as the values. Yo
 ```php
 $members = Member::get()->map('ID', 'FirstName');
 
-// $members = array(
+// $members = [
 //    1 => 'Sam'
 //    2 => 'Sig'
 //    3 => 'Will'
-// );
+// ];
 ```
 
 This functionality is provided by the [Map](api:SilverStripe\ORM\Map) class, which can be used to build a map around any `SS_List`.
@@ -72,11 +72,11 @@ $members = Member::get();
 
 echo $members->column('Email');
 
-// returns array(
+// returns [
 //    'sam@silverstripe.com',
 //    'sig@silverstripe.com',
 //    'will@silverstripe.com'
-// );
+// ];
 ```
 
 ## ArrayList

--- a/docs/en/02_Developer_Guides/00_Model/04_Data_Types_and_Casting.md
+++ b/docs/en/02_Developer_Guides/00_Model/04_Data_Types_and_Casting.md
@@ -62,7 +62,7 @@ class Car extends DataObject
 {   
     private static $db = [
         'Wheels' => 'Int',
-        'Condition' => 'Enum(array("New","Fair","Junk"))'
+        'Condition' => 'Enum(["New","Fair","Junk"])'
     ];
     
     private static $defaults = [
@@ -93,7 +93,7 @@ class Car extends DataObject
 {   
     private static $db = [
         'Wheels' => 'Int(4)',
-        'Condition' => 'Enum(array("New","Fair","Junk"), "New")',
+        'Condition' => 'Enum(["New","Fair","Junk"], "New")',
         'Make' => 'Varchar(["default" => "Honda"])',
     );
 }
@@ -229,7 +229,7 @@ use SilverStripe\ORM\DataObject;
 class Player extends DataObject 
 {
     private static $db = [
-        "Status" => "Enum(array('Active', 'Injured', 'Retired'))"
+        "Status" => "Enum(['Active', 'Injured', 'Retired'])"
     ];
     
     public function getStatus() 

--- a/docs/en/02_Developer_Guides/00_Model/08_SQL_Select.md
+++ b/docs/en/02_Developer_Guides/00_Model/08_SQL_Select.md
@@ -147,10 +147,10 @@ API methods:
    but also supports SQL expressions as values if necessary
  * `setAssignments` - Replaces all existing assignments with the specified list
  * `getAssignments` - Returns all currently given assignments, as an associative array
-   in the format `array('Column' => array('SQL' => array('parameters)))`
+   in the format `['Column' => ['SQL' => ['parameters]]]`
  * `assign` - Singular form of addAssignments, but only assigns a single column value
  * `assignSQL` - Assigns a column the value of a specified SQL expression without parameters
-   `assignSQL('Column', 'SQL)` is shorthand for `assign('Column', array('SQL' => array()))`
+   `assignSQL('Column', 'SQL)` is shorthand for `assign('Column', ['SQL' => []])`
 
 SQLUpdate also includes the following API methods:
 
@@ -225,7 +225,7 @@ $insert->assign('"Content"', '<p>This is about us</p>');
 $insert->addRow(['"Title"' => 'Contact Us']);
 
 $columns = $insert->getColumns();
-// $columns will be array('"Title"', '"Content"', '"ClassName"');
+// $columns will be ['"Title"', '"Content"', '"ClassName"'];
 
 $insert->execute();
 ```

--- a/docs/en/02_Developer_Guides/08_Performance/00_Partial_Caching.md
+++ b/docs/en/02_Developer_Guides/08_Performance/00_Partial_Caching.md
@@ -93,7 +93,7 @@ If your caching logic is complex or re-usable, you can define a method on your c
 fragment.
 
 For example, a block that shows a collection of rotating slides needs to update whenever the relationship 
-`Page::$many_many = array('Slides' => 'Slide')` changes. In `PageController`:
+`Page::$many_many = ['Slides' => 'Slide']` changes. In `PageController`:
 
 
 ```php

--- a/docs/en/02_Developer_Guides/09_Security/00_Member.md
+++ b/docs/en/02_Developer_Guides/09_Security/00_Member.md
@@ -41,10 +41,10 @@ You can define subclasses of [Member](api:SilverStripe\Security\Member) to add e
 use SilverStripe\Security\Member;
 
 class MyMember extends Member {
-    private static $db = array(
+    private static $db = [
         "Age" => "Int",
         "Address" => "Text",
-    );
+    ];
 }
 ```
 

--- a/docs/en/02_Developer_Guides/18_Cookies_And_Sessions/02_Sessions.md
+++ b/docs/en/02_Developer_Guides/18_Cookies_And_Sessions/02_Sessions.md
@@ -72,7 +72,7 @@ echo $session->get('MyValue');
 // returns 6
 
 $data = $session->get('MyArrayOfValues'); 
-// $data = array(1,2,3)
+// $data = [1,2,3]
 
 $object = unserialize($session->get('MyObject', $object)); 
 // $object = Object()

--- a/docs/en/04_Changelogs/alpha/4.0.0-alpha1.md
+++ b/docs/en/04_Changelogs/alpha/4.0.0-alpha1.md
@@ -371,12 +371,12 @@ E.g.
 	:::php
 	class MyObject extends DataObject 
 	{
-		private static $has_one = array(
+		private static $has_one = [
 			"ImageObject" => "Image"
-		);
-		private static $db = array(
+		];
+		private static $db = [
 			"ImageField" => "DBFile('image/supported')"
-		);
+		];
 	}
 
 
@@ -518,12 +518,12 @@ The below describes the minimum amount of effort required to implement a composi
 	class MyAddressField extends DBComposite 
 	{
 
-		private static $composite_db = array(
+		private static $composite_db = [
 			'Street' => 'Varchar(200)',
 			'Suburb' => 'Varchar(100)',
 			'City' => 'Varchar(100)',
 			'Country' => 'Varchar(100)'
-		);
+		];
 
 		public function scaffoldFormField($title = null) 
 		{

--- a/src/Control/Email/Email.php
+++ b/src/Control/Email/Email.php
@@ -362,7 +362,7 @@ class Email extends ViewableData
      * Set recipient(s) of the email
      *
      * To send to many, pass an array:
-     * array('me@example.com' => 'My Name', 'other@example.com');
+     * ['me@example.com' => 'My Name', 'other@example.com'];
      *
      * @param string|array $address The message recipient(s) - if sending to multiple, use an array of address => name
      * @param string|null $name The name of the recipient (if one)

--- a/src/Dev/BulkLoader.php
+++ b/src/Dev/BulkLoader.php
@@ -57,19 +57,19 @@ abstract class BulkLoader extends ViewableData
      * <code>
      * <?php
      *  // simple example
-     *  array(
+     *  [
      *      'Title',
      *      'Birthday'
-     *  )
+     *  ]
      *
      * // complex example
-     *  array(
+     *  [
      *      'first name' => 'FirstName', // custom column name
      *      null, // ignored column
      *      'RegionID', // direct has_one/has_many ID setting
      *      'OrganisationTitle', // create has_one relation to existing record using $relationCallbacks
      *      'street' => 'Organisation.StreetName', // match an existing has_one or create one and write property.
-     *  );
+     *  ];
      * ?>
      * </code>
      *
@@ -82,12 +82,12 @@ abstract class BulkLoader extends ViewableData
      *
      * <code>
      * <?php
-     * array(
-     *      'OrganisationTitle' => array(
+     * [
+     *      'OrganisationTitle' => [
      *          'relationname' => 'Organisation', // relation accessor name
      *          'callback' => 'getOrganisationByTitle',
-     *      );
-     * );
+     *      ];
+     * ];
      * ?>
      * </code>
      *
@@ -111,12 +111,12 @@ abstract class BulkLoader extends ViewableData
      *
      *  <code>
      * <?php
-     * array(
+     * [
      *      'customernumber' => 'ID',
-     *      'phonenumber' => array(
+     *      'phonenumber' => [
      *          'callback' => 'getByImportedPhoneNumber'
-     *      )
-     * );
+     *      ]
+     * ];
      * ?>
      * </code>
      *
@@ -211,10 +211,10 @@ abstract class BulkLoader extends ViewableData
      *
      * Return Format:
      * <code>
-     * array(
-     *   'fields' => array('myFieldName'=>'myDescription'),
-     *   'relations' => array('myRelationName'=>'myDescription'),
-     * )
+     * [
+     *   'fields' => ['myFieldName'=>'myDescription'],
+     *   'relations' => ['myRelationName'=>'myDescription'],
+     * ]
      * </code>
      *
      * @todo Mix in custom column mappings

--- a/src/Dev/BulkLoader_Result.php
+++ b/src/Dev/BulkLoader_Result.php
@@ -30,7 +30,7 @@ class BulkLoader_Result implements \Countable
      *
      * Example:
      * <code>
-     * array(array('ID'=>1, 'ClassName'=>'Member', 'Message'=>'Updated existing record based on ParentID relation'))
+     * [['ID'=>1, 'ClassName'=>'Member', 'Message'=>'Updated existing record based on ParentID relation']]
      * </code>
      *
      * @var array

--- a/src/Forms/FileField.php
+++ b/src/Forms/FileField.php
@@ -31,7 +31,7 @@ use SilverStripe\ORM\DataObjectInterface;
  *      $actions = new FieldList(
  *          new FormAction('doUpload', 'Upload file')
  *      );
- *    $validator = new RequiredFields(array('MyName', 'MyFile'));
+ *    $validator = new RequiredFields(['MyName', 'MyFile']);
  *
  *      return new Form($this, 'Form', $fields, $actions, $validator);
  *  }

--- a/src/Forms/FileUploadReceiver.php
+++ b/src/Forms/FileUploadReceiver.php
@@ -44,7 +44,7 @@ trait FileUploadReceiver
     public $relationAutoSetting = true;
 
     /**
-     * Parent data record. Will be infered from parent form or controller if blank.
+     * Parent data record. Will be inferred from parent form or controller if blank.
      *
      * @var DataObject
      */

--- a/src/Forms/SelectionGroup.php
+++ b/src/Forms/SelectionGroup.php
@@ -13,7 +13,7 @@ use SilverStripe\View\HTML;
  * button is selected. Each item is defined through {@link SelectionGroup_Item}.
  *
  * @example <code>
- * $items = array(
+ * $items = [
  *  new SelectionGroup_Item(
  *      'one',
  *      new LiteralField('one', 'one view'),
@@ -24,7 +24,7 @@ use SilverStripe\View\HTML;
  *      new LiteralField('two', 'two view'),
  *      'two title'
  *  ),
- * );
+ * ];
  * $field = new SelectionGroup('MyGroup', $items);
  * </code>
  *

--- a/src/Forms/TextareaField.php
+++ b/src/Forms/TextareaField.php
@@ -26,7 +26,7 @@ class TextareaField extends FormField
      */
     private static $casting = [
         'Value' => 'Text',
-        'ValueEntities' => 'HTMLFragment(array(\'shortcodes\' => false))',
+        'ValueEntities' => 'HTMLFragment([\'shortcodes\' => false])',
     ];
 
     protected $schemaDataType = FormField::SCHEMA_DATA_TYPE_TEXT;

--- a/src/ORM/Connect/DBQueryBuilder.php
+++ b/src/ORM/Connect/DBQueryBuilder.php
@@ -122,7 +122,7 @@ class DBQueryBuilder
             foreach ($columns as $column) {
                 // Check if this column has a value for this row
                 if (isset($assignments[$column])) {
-                    // Assigment is a single item array, expand with a loop here
+                    // Assignment is a single item array, expand with a loop here
                     foreach ($assignments[$column] as $assignmentSQL => $assignmentParameters) {
                         $parts[] = $assignmentSQL;
                         $parameters = array_merge($parameters, $assignmentParameters);
@@ -220,7 +220,7 @@ class DBQueryBuilder
         // Join SET components together, considering parameters
         $parts = [];
         foreach ($query->getAssignments() as $column => $assignment) {
-            // Assigment is a single item array, expand with a loop here
+            // Assignment is a single item array, expand with a loop here
             foreach ($assignment as $assignmentSQL => $assignmentParameters) {
                 $parts[] = "$column = $assignmentSQL";
                 $parameters = array_merge($parameters, $assignmentParameters);

--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -345,7 +345,7 @@ abstract class DBSchemaManager
      * @param array $indexSchema A list of indexes to create. See {@link requireIndex()}
      * The values of the array can be one of:
      *   - true: Create a single column index on the field named the same as the index.
-     *   - array('fields' => array('A','B','C'), 'type' => 'index/unique/fulltext'): This gives you full
+     *   - ['fields' => ['A','B','C'], 'type' => 'index/unique/fulltext']: This gives you full
      *     control over the index.
      * @param boolean $hasAutoIncPK A flag indicating that the primary key on this table is an autoincrement type
      * @param array $options Create table options (ENGINE, etc.)
@@ -478,7 +478,7 @@ MESSAGE
      * The keys of the array are the names of the index.
      * The values of the array can be one of:
      *  - true: Create a single column index on the field named the same as the index.
-     *  - array('type' => 'index|unique|fulltext', 'value' => 'FieldA, FieldB'): This gives you full
+     *  - ['type' => 'index|unique|fulltext', 'value' => 'FieldA, FieldB']: This gives you full
      *    control over the index.
      *
      * @param string $table The table name.
@@ -536,7 +536,7 @@ MESSAGE
         $containedSpec = preg_replace('/(.*\(\s*)|(\s*\).*)/', '', $spec);
 
         // Split potentially quoted modifiers
-        // E.g. 'Title, "QuotedColumn"' => array('Title', 'QuotedColumn')
+        // E.g. 'Title, "QuotedColumn"' => ['Title', 'QuotedColumn']
         return preg_split('/"?\s*,\s*"?/', trim($containedSpec, '(") '));
     }
 

--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -729,7 +729,7 @@ class DataObjectSchema
      *
      * Standard many_many return type is:
      *
-     * array(
+     * [
      *  <manyManyClass>,        Name of class for relation. E.g. "Categories"
      *  <classname>,            The class that relation is defined in e.g. "Product"
      *  <candidateName>,        The target class of the relation e.g. "Category"
@@ -738,7 +738,7 @@ class DataObjectSchema
      *  <joinTableOrRelation>   The join table between the two classes e.g. "Product_Categories".
      *                          If the class name is 'ManyManyThroughList' then this is the name of the
      *                          has_many relation.
-     * )
+     * ]
      *
      * @param string $class Name of class to get component for
      * @param string $component The component name

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -38,12 +38,12 @@ class DataQuery
      * Map of all field names to an array of conflicting column SQL
      *
      * E.g.
-     * array(
-     *   'Title' => array(
+     * [
+     *   'Title' => [
      *     '"MyTable"."Title"',
      *     '"AnotherTable"."Title"',
-     *   )
-     * )
+     *   ]
+     * ]
      *
      * @var array
      */

--- a/src/ORM/FieldType/DBEnum.php
+++ b/src/ORM/FieldType/DBEnum.php
@@ -56,7 +56,7 @@ class DBEnum extends DBString
      *  "MyField" => "Enum('Val1, Val2, Val3')" // First item 'Val1' is default implicitly
      *  "MyField" => "Enum('Val1, Val2, Val3', 'Val2')" // 'Val2' is default explicitly
      *  "MyField" => "Enum('Val1, Val2, Val3', null)" // Force empty (no) default
-     *  "MyField" => "Enum(array('Val1', 'Val2', 'Val3'), 'Val1')" // Supports array notation as well
+     *  "MyField" => "Enum(['Val1', 'Val2', 'Val3'], 'Val1')" // Supports array notation as well
      * </code>
      *
      * @param string $name

--- a/src/ORM/FieldType/DBPercentage.php
+++ b/src/ORM/FieldType/DBPercentage.php
@@ -7,10 +7,10 @@ namespace SilverStripe\ORM\FieldType;
  *
  * Example instantiation in {@link DataObject::$db}:
  * <code>
- * static $db = array(
+ * static $db = [
  *  "SuccessRatio" => "Percentage",
  *  "ReallyAccurate" => "Percentage(6)",
- * );
+ * ];
  * </code>
  */
 class DBPercentage extends DBDecimal

--- a/src/ORM/Queries/SQLAssignmentRow.php
+++ b/src/ORM/Queries/SQLAssignmentRow.php
@@ -157,7 +157,7 @@ class SQLAssignmentRow
     /**
      * Retrieves the list of assignments in parameterised format
      *
-     * @return array List of assigments. The key of this array will be the
+     * @return array List of assignments. The key of this array will be the
      * column to assign, and the value a parameterised array in the format
      * ['SQL' => [parameters]];
      */

--- a/src/ORM/Queries/SQLAssignmentRow.php
+++ b/src/ORM/Queries/SQLAssignmentRow.php
@@ -14,12 +14,12 @@ class SQLAssignmentRow
      * List of field values to store for this query
      *
      * Each item in this array will be in the form of a single-length array
-     * in the format array('sql' => array($parameters)).
+     * in the format ['sql' => [$parameters]].
      * The field name is stored as the key
      *
      * E.g.
      *
-     * <code>$assignments['ID'] = array('?' => array(1));</code>
+     * <code>$assignments['ID'] = ['?' => [1]];</code>
      *
      * This allows for complex, parameterised updates, or explict field values set
      * without any prameters
@@ -45,7 +45,7 @@ class SQLAssignmentRow
      *
      * @param mixed $value Either a literal field value, or an array with
      * placeholder => parameter(s) as a pair
-     * @return array A single item array in the format array($sql => array($parameters))
+     * @return array A single item array in the format [$sql => [$parameters]]
      */
     protected function parseAssignment($value)
     {
@@ -57,7 +57,7 @@ class SQLAssignmentRow
 
         // If given as array then extract and check both the SQL as well as the parameter(s)
         // Note that there could be multiple parameters, e.g.
-        // array('MAX(?,?)' => array(1,2)) although the container should
+        // ['MAX(?,?)' => [1,2]] although the container should
         // have a single item
         if (count($value) == 1) {
             foreach ($value as $sql => $parameters) {
@@ -76,13 +76,13 @@ class SQLAssignmentRow
 
         throw new InvalidArgumentException(
             "Nested field assignments should be given as a single parameterised item array in "
-            . "array('?' => array('value')) format)"
+            . "['?' => ['value']] format)"
         );
     }
 
     /**
      * Given a list of assignments in any user-acceptible format, normalise the
-     * value to a common array('SQL' => array(parameters)) format
+     * value to a common ['SQL' => [parameters]] format
      *
      * @param array $assignments List of assignments.
      * The key of this array should be the field name, and the value the assigned
@@ -107,27 +107,27 @@ class SQLAssignmentRow
      * <code>
      *
      * // Basic assignments
-     * $query->addAssignments(array(
+     * $query->addAssignments([
      *      '"Object"."Title"' => 'Bob',
      *      '"Object"."Description"' => 'Bob was here'
-     * ))
+     * ])
      *
      * // Parameterised assignments
-     * $query->addAssignments(array(
-     *      '"Object"."Title"' => array('?' => 'Bob')),
-     *      '"Object"."Description"' => array('?' => null))
-     * ))
+     * $query->addAssignments([
+     *      '"Object"."Title"' => ['?' => 'Bob'],
+     *      '"Object"."Description"' => ['?' => null]
+     * ])
      *
      * // Complex parameters
-     * $query->addAssignments(array(
-     *      '"Object"."Score"' => array('MAX(?,?)' => array(1, 3))
-     * ));
+     * $query->addAssignments([
+     *      '"Object"."Score"' => ['MAX(?,?)' => [1, 3]]
+     * ]);
      *
-     * // Assigment of literal SQL for a field. The empty array is
+     * // Assignment of literal SQL for a field. The empty array is
      * // important to denote the zero-number paramater list
-     * $query->addAssignments(array(
-     *      '"Object"."Score"' => array('NOW()' => array())
-     * ));
+     * $query->addAssignments([
+     *      '"Object"."Score"' => ['NOW()' => []]
+     * ]);
      *
      * </code>
      *
@@ -159,7 +159,7 @@ class SQLAssignmentRow
      *
      * @return array List of assigments. The key of this array will be the
      * column to assign, and the value a parameterised array in the format
-     * array('SQL' => array(parameters));
+     * ['SQL' => [parameters]];
      */
     public function getAssignments()
     {
@@ -176,10 +176,10 @@ class SQLAssignmentRow
      * $query->assign('"Object"."Description"', 'lorum ipsum');
      *
      * // Single parameter
-     * $query->assign('"Object"."Title"', array('?' => 'Bob'));
+     * $query->assign('"Object"."Title"', ['?' => 'Bob']);
      *
      * // Complex parameters
-     * $query->assign('"Object"."Score"', array('MAX(?,?)' => array(1, 3));
+     * $query->assign('"Object"."Score"', ['MAX(?,?)' => [1, 3]]);
      * </code>
      *
      * @param string $field The field name to update

--- a/src/ORM/Queries/SQLInsert.php
+++ b/src/ORM/Queries/SQLInsert.php
@@ -194,7 +194,7 @@ class SQLInsert extends SQLExpression implements SQLWriteExpression
     }
 
     /**
-     * Clears all currently set assigment values on the current row
+     * Clears all currently set assignment values on the current row
      *
      * @return $this The self reference to this query
      */

--- a/src/ORM/Queries/SQLSelect.php
+++ b/src/ORM/Queries/SQLSelect.php
@@ -31,7 +31,7 @@ class SQLSelect extends SQLConditionalExpression
     /**
      * An array of having clauses.
      * Each item in this array will be in the form of a single-length array
-     * in the format array('predicate' => array($parameters))
+     * in the format ['predicate' => [$parameters]]
      *
      * @var array
      */
@@ -124,13 +124,13 @@ class SQLSelect extends SQLConditionalExpression
      *
      * <code>
      *  // pass fields to select as single parameter array
-     *  $query->setSelect(array('"Col1"', '"Col2"'))->setFrom('"MyTable"');
+     *  $query->setSelect(['"Col1"', '"Col2"'])->setFrom('"MyTable"');
      *
      *  // pass fields to select as multiple parameters
      *  $query->setSelect('"Col1"', '"Col2"')->setFrom('"MyTable"');
      *
      *  // Set a list of selected fields as aliases
-     *  $query->setSelect(array('Name' => '"Col1"', 'Details' => '"Col2"')->setFrom('"MyTable"');
+     *  $query->setSelect(['Name' => '"Col1"', 'Details' => '"Col2"'])->setFrom('"MyTable"');
      * </code>
      *
      * @param string|array $fields Field names should be ANSI SQL quoted. Array keys should be unquoted.
@@ -293,7 +293,7 @@ class SQLSelect extends SQLConditionalExpression
      * @example $sql->setOrderBy("Column DESC");
      * @example $sql->setOrderBy("Column DESC, ColumnTwo ASC");
      * @example $sql->setOrderBy("Column", "DESC");
-     * @example $sql->setOrderBy(array("Column" => "ASC", "ColumnTwo" => "DESC"));
+     * @example $sql->setOrderBy(["Column" => "ASC", "ColumnTwo" => "DESC"]);
      *
      * @param string|array $clauses Clauses to add (escaped SQL statement)
      * @param string $direction Sort direction, ASC or DESC
@@ -313,7 +313,7 @@ class SQLSelect extends SQLConditionalExpression
      * @example $sql->addOrderBy("Column DESC");
      * @example $sql->addOrderBy("Column DESC, ColumnTwo ASC");
      * @example $sql->addOrderBy("Column", "DESC");
-     * @example $sql->addOrderBy(array("Column" => "ASC", "ColumnTwo" => "DESC"));
+     * @example $sql->addOrderBy(["Column" => "ASC", "ColumnTwo" => "DESC"]);
      *
      * @param string|array $clauses Clauses to add (escaped SQL statements)
      * @param string $direction Sort direction, ASC or DESC
@@ -388,7 +388,7 @@ class SQLSelect extends SQLConditionalExpression
      *
      * @param string $value
      * @param string $defaultDirection
-     * @return array A two element array: array($column, $direction)
+     * @return array A two element array: [$column, $direction]
      */
     private function getDirectionFromString($value, $defaultDirection = null)
     {

--- a/src/ORM/Queries/SQLUpdate.php
+++ b/src/ORM/Queries/SQLUpdate.php
@@ -97,7 +97,7 @@ class SQLUpdate extends SQLConditionalExpression implements SQLWriteExpression
     }
 
     /**
-     * Clears all currently set assigment values
+     * Clears all currently set assignment values
      *
      * @return $this The self reference to this query
      */

--- a/src/ORM/Queries/SQLWriteExpression.php
+++ b/src/ORM/Queries/SQLWriteExpression.php
@@ -20,27 +20,27 @@ interface SQLWriteExpression
      * <code>
      *
      * // Basic assignments
-     * $query->addAssignments(array(
+     * $query->addAssignments([
      *      '"Object"."Title"' => 'Bob',
      *      '"Object"."Description"' => 'Bob was here'
-     * ))
+     * ])
      *
      * // Parameterised assignments
-     * $query->addAssignments(array(
-     *      '"Object"."Title"' => array('?' => 'Bob')),
-     *      '"Object"."Description"' => array('?' => null))
-     * ))
+     * $query->addAssignments([
+     *      '"Object"."Title"' => ['?' => 'Bob'],
+     *      '"Object"."Description"' => ['?' => null]
+     * ])
      *
      * // Complex parameters
-     * $query->addAssignments(array(
-     *      '"Object"."Score"' => array('MAX(?,?)' => array(1, 3))
-     * ));
+     * $query->addAssignments([
+     *      '"Object"."Score"' => ['MAX(?,?)' => [1, 3]]
+     * ]);
      *
-     * // Assigment of literal SQL for a field. The empty array is
+     * // Assignment of literal SQL for a field. The empty array is
      * // important to denote the zero-number paramater list
-     * $query->addAssignments(array(
-     *      '"Object"."Score"' => array('NOW()' => array())
-     * ));
+     * $query->addAssignments([
+     *      '"Object"."Score"' => ['NOW()' => []]
+     * ]);
      *
      * </code>
      *
@@ -68,7 +68,7 @@ interface SQLWriteExpression
      *
      * @return array List of assigments. The key of this array will be the
      * column to assign, and the value a parameterised array in the format
-     * array('SQL' => array(parameters));
+     * ['SQL' => [parameters]];
      */
     public function getAssignments();
 
@@ -84,10 +84,10 @@ interface SQLWriteExpression
      * $query->assign('"Object"."Description"', 'lorum ipsum'));
      *
      * // Single parameter
-     * $query->assign('"Object"."Title"', array('?' => 'Bob'));
+     * $query->assign('"Object"."Title"', ['?' => 'Bob']);
      *
      * // Complex parameters
-     * $query->assign('"Object"."Score"', array('MAX(?,?)' => array(1, 3));
+     * $query->assign('"Object"."Score"', ['MAX(?,?)' => [1, 3]]);
      * </code>
      *
      * @param string $field The field name to update

--- a/src/ORM/Queries/SQLWriteExpression.php
+++ b/src/ORM/Queries/SQLWriteExpression.php
@@ -66,7 +66,7 @@ interface SQLWriteExpression
      *
      * For multi-row objects returns assignments for the current row.
      *
-     * @return array List of assigments. The key of this array will be the
+     * @return array List of assignments. The key of this array will be the
      * column to assign, and the value a parameterised array in the format
      * ['SQL' => [parameters]];
      */

--- a/src/View/SSTemplateParser.peg
+++ b/src/View/SSTemplateParser.peg
@@ -84,30 +84,30 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /**
      * Stores the user-supplied closed block extension rules in the form:
-     * array(
+     * [
      *   'name' => function (&$res) {}
-     * )
+     * ]
      * See SSTemplateParser::ClosedBlock_Handle_Loop for an example of what the callable should look like
      * @var array
      */
-    protected $closedBlocks = array();
+    protected $closedBlocks = [];
 
     /**
      * Stores the user-supplied open block extension rules in the form:
-     * array(
+     * [
      *   'name' => function (&$res) {}
-     * )
+     * ]
      * See SSTemplateParser::OpenBlock_Handle_Base_tag for an example of what the callable should look like
      * @var array
      */
-    protected $openBlocks = array();
+    protected $openBlocks = [];
 
     /**
      * Allow the injection of new closed & open block callables
      * @param array $closedBlocks
      * @param array $openBlocks
      */
-    public function __construct($closedBlocks = array(), $openBlocks = array())
+    public function __construct($closedBlocks = [], $openBlocks = [])
     {
         parent::__construct(null);
         $this->setClosedBlocks($closedBlocks);
@@ -136,7 +136,7 @@ class SSTemplateParser extends Parser implements TemplateParser
      */
     public function setClosedBlocks($closedBlocks)
     {
-        $this->closedBlocks = array();
+        $this->closedBlocks = [];
         foreach ((array) $closedBlocks as $name => $callable) {
             $this->addClosedBlock($name, $callable);
         }
@@ -152,7 +152,7 @@ class SSTemplateParser extends Parser implements TemplateParser
      */
     public function setOpenBlocks($openBlocks)
     {
-        $this->openBlocks = array();
+        $this->openBlocks = [];
         foreach ((array) $openBlocks as $name => $callable) {
             $this->addOpenBlock($name, $callable);
         }
@@ -270,7 +270,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     function Lookup__construct(&$res)
     {
         $res['php'] = '$scope->locally()';
-        $res['LookupSteps'] = array();
+        $res['LookupSteps'] = [];
     }
 
     /**
@@ -285,7 +285,7 @@ class SSTemplateParser extends Parser implements TemplateParser
         $property = $sub['Call']['Method']['text'];
 
         if (isset($sub['Call']['CallArguments']) && $arguments = $sub['Call']['CallArguments']['php']) {
-            $res['php'] .= "->$method('$property', array($arguments), true)";
+            $res['php'] .= "->$method('$property', [$arguments], true)";
         } else {
             $res['php'] .= "->$method('$property', null, true)";
         }
@@ -346,7 +346,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     function InjectionVariables__construct(&$res)
     {
-        $res['php'] = "array(";
+        $res['php'] = "[";
     }
 
     function InjectionVariables_InjectionName(&$res, $sub)
@@ -364,7 +364,7 @@ class SSTemplateParser extends Parser implements TemplateParser
         if (substr($res['php'], -1) == ',') {
             $res['php'] = substr($res['php'], 0, -1); //remove last comma in the array
         }
-        $res['php'] .= ')';
+        $res['php'] .= ']';
     }
 
 
@@ -873,7 +873,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     */
     function Include__construct(&$res)
     {
-        $res['arguments'] = array();
+        $res['arguments'] = [];
     }
 
     function Include_Template(&$res, $sub)
@@ -892,8 +892,8 @@ class SSTemplateParser extends Parser implements TemplateParser
         $arguments = $res['arguments'];
 
         // Note: 'type' here is important to disable subTemplates in SSViewer::getSubtemplateFor()
-        $res['php'] = '$val .= \\SilverStripe\\View\\SSViewer::execute_template([["type" => "Includes", '.$template.'], '.$template.'], $scope->getItem(), array(' .
-            implode(',', $arguments)."), \$scope, true);\n";
+        $res['php'] = '$val .= \\SilverStripe\\View\\SSViewer::execute_template([["type" => "Includes", '.$template.'], '.$template.'], $scope->getItem(), [' .
+            implode(',', $arguments)."], \$scope, true);\n";
 
         if ($this->includeDebuggingComments) { // Add include filename comments on dev sites
             $res['php'] =
@@ -946,7 +946,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     function ClosedBlock_BlockArguments(&$res, $sub)
     {
         if (isset($sub['Argument']['ArgumentMode'])) {
-            $res['Arguments'] = array($sub['Argument']);
+            $res['Arguments'] = [$sub['Argument']];
             $res['ArgumentCount'] = 1;
         } else {
             $res['Arguments'] = $sub['Argument'];
@@ -1037,7 +1037,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     function OpenBlock_BlockArguments(&$res, $sub)
     {
         if (isset($sub['Argument']['ArgumentMode'])) {
-            $res['Arguments'] = array($sub['Argument']);
+            $res['Arguments'] = [$sub['Argument']];
             $res['ArgumentCount'] = 1;
         } else {
             $res['Arguments'] = $sub['Argument'];

--- a/src/View/SSTemplateParser.php
+++ b/src/View/SSTemplateParser.php
@@ -69,7 +69,7 @@ class SSTemplateParser extends Parser implements TemplateParser
      * See SSTemplateParser::ClosedBlock_Handle_Loop for an example of what the callable should look like
      * @var array
      */
-    protected $closedBlocks = array();
+    protected $closedBlocks = [];
 
     /**
      * Stores the user-supplied open block extension rules in the form:
@@ -79,14 +79,14 @@ class SSTemplateParser extends Parser implements TemplateParser
      * See SSTemplateParser::OpenBlock_Handle_Base_tag for an example of what the callable should look like
      * @var array
      */
-    protected $openBlocks = array();
+    protected $openBlocks = [];
 
     /**
      * Allow the injection of new closed & open block callables
      * @param array $closedBlocks
      * @param array $openBlocks
      */
-    public function __construct($closedBlocks = array(), $openBlocks = array())
+    public function __construct($closedBlocks = [], $openBlocks = [])
     {
         parent::__construct(null);
         $this->setClosedBlocks($closedBlocks);
@@ -115,7 +115,7 @@ class SSTemplateParser extends Parser implements TemplateParser
      */
     public function setClosedBlocks($closedBlocks)
     {
-        $this->closedBlocks = array();
+        $this->closedBlocks = [];
         foreach ((array) $closedBlocks as $name => $callable) {
             $this->addClosedBlock($name, $callable);
         }
@@ -131,7 +131,7 @@ class SSTemplateParser extends Parser implements TemplateParser
      */
     public function setOpenBlocks($openBlocks)
     {
-        $this->openBlocks = array();
+        $this->openBlocks = [];
         foreach ((array) $openBlocks as $name => $callable) {
             $this->addOpenBlock($name, $callable);
         }
@@ -190,8 +190,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* Template: (Comment | Translate | If | Require | CacheBlock | UncachedBlock | OldI18NTag | Include | ClosedBlock |
     OpenBlock | MalformedBlock | Injection | Text)+ */
-    protected $match_Template_typestack = array('Template');
-    function match_Template ($stack = array()) {
+    protected $match_Template_typestack = ['Template'];
+    function match_Template ($stack = []) {
     	$matchrule = "Template"; $result = $this->construct($matchrule, $matchrule, null);
     	$count = 0;
     	while (true) {
@@ -204,7 +204,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$res_0 = $result;
     				$pos_0 = $this->pos;
     				$matcher = 'match_'.'Comment'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres );
     					$_47 = TRUE; break;
@@ -216,7 +216,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$res_2 = $result;
     					$pos_2 = $this->pos;
     					$matcher = 'match_'.'Translate'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     						$_45 = TRUE; break;
@@ -228,7 +228,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     						$res_4 = $result;
     						$pos_4 = $this->pos;
     						$matcher = 'match_'.'If'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     							$_43 = TRUE; break;
@@ -240,7 +240,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     							$res_6 = $result;
     							$pos_6 = $this->pos;
     							$matcher = 'match_'.'Require'; $key = $matcher; $pos = $this->pos;
-    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     							if ($subres !== FALSE) {
     								$this->store( $result, $subres );
     								$_41 = TRUE; break;
@@ -252,7 +252,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     								$res_8 = $result;
     								$pos_8 = $this->pos;
     								$matcher = 'match_'.'CacheBlock'; $key = $matcher; $pos = $this->pos;
-    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     								if ($subres !== FALSE) {
     									$this->store( $result, $subres );
     									$_39 = TRUE; break;
@@ -264,7 +264,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     									$res_10 = $result;
     									$pos_10 = $this->pos;
     									$matcher = 'match_'.'UncachedBlock'; $key = $matcher; $pos = $this->pos;
-    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     									if ($subres !== FALSE) {
     										$this->store( $result, $subres );
     										$_37 = TRUE; break;
@@ -276,7 +276,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     										$res_12 = $result;
     										$pos_12 = $this->pos;
     										$matcher = 'match_'.'OldI18NTag'; $key = $matcher; $pos = $this->pos;
-    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     										if ($subres !== FALSE) {
     											$this->store( $result, $subres );
     											$_35 = TRUE; break;
@@ -288,7 +288,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     											$res_14 = $result;
     											$pos_14 = $this->pos;
     											$matcher = 'match_'.'Include'; $key = $matcher; $pos = $this->pos;
-    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     											if ($subres !== FALSE) {
     												$this->store( $result, $subres );
     												$_33 = TRUE; break;
@@ -300,7 +300,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     												$res_16 = $result;
     												$pos_16 = $this->pos;
     												$matcher = 'match_'.'ClosedBlock'; $key = $matcher; $pos = $this->pos;
-    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     												if ($subres !== FALSE) {
     													$this->store( $result, $subres );
     													$_31 = TRUE; break;
@@ -312,7 +312,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     													$res_18 = $result;
     													$pos_18 = $this->pos;
     													$matcher = 'match_'.'OpenBlock'; $key = $matcher; $pos = $this->pos;
-    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     													if ($subres !== FALSE) {
     														$this->store( $result, $subres );
     														$_29 = TRUE; break;
@@ -324,7 +324,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     														$res_20 = $result;
     														$pos_20 = $this->pos;
     														$matcher = 'match_'.'MalformedBlock'; $key = $matcher; $pos = $this->pos;
-    														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     														if ($subres !== FALSE) {
     															$this->store( $result, $subres );
     															$_27 = TRUE; break;
@@ -336,7 +336,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     															$res_22 = $result;
     															$pos_22 = $this->pos;
     															$matcher = 'match_'.'Injection'; $key = $matcher; $pos = $this->pos;
-    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     															if ($subres !== FALSE) {
     																$this->store( $result, $subres );
     																$_25 = TRUE; break;
@@ -344,7 +344,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     															$result = $res_22;
     															$this->pos = $pos_22;
     															$matcher = 'match_'.'Text'; $key = $matcher; $pos = $this->pos;
-    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     															if ($subres !== FALSE) {
     																$this->store( $result, $subres );
     																$_25 = TRUE; break;
@@ -445,8 +445,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* Word: / [A-Za-z_] [A-Za-z0-9_]* / */
-    protected $match_Word_typestack = array('Word');
-    function match_Word ($stack = array()) {
+    protected $match_Word_typestack = ['Word'];
+    function match_Word ($stack = []) {
     	$matchrule = "Word"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [A-Za-z_] [A-Za-z0-9_]* /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -457,8 +457,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* NamespacedWord: / [A-Za-z_\/\\] [A-Za-z0-9_\/\\]* / */
-    protected $match_NamespacedWord_typestack = array('NamespacedWord');
-    function match_NamespacedWord ($stack = array()) {
+    protected $match_NamespacedWord_typestack = ['NamespacedWord'];
+    function match_NamespacedWord ($stack = []) {
     	$matchrule = "NamespacedWord"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [A-Za-z_\/\\\\] [A-Za-z0-9_\/\\\\]* /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -469,8 +469,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Number: / [0-9]+ / */
-    protected $match_Number_typestack = array('Number');
-    function match_Number ($stack = array()) {
+    protected $match_Number_typestack = ['Number'];
+    function match_Number ($stack = []) {
     	$matchrule = "Number"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [0-9]+ /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -481,8 +481,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Value: / [A-Za-z0-9_]+ / */
-    protected $match_Value_typestack = array('Value');
-    function match_Value ($stack = array()) {
+    protected $match_Value_typestack = ['Value'];
+    function match_Value ($stack = []) {
     	$matchrule = "Value"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [A-Za-z0-9_]+ /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -493,13 +493,13 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* CallArguments: :Argument ( < "," < :Argument )* */
-    protected $match_CallArguments_typestack = array('CallArguments');
-    function match_CallArguments ($stack = array()) {
+    protected $match_CallArguments_typestack = ['CallArguments'];
+    function match_CallArguments ($stack = []) {
     	$matchrule = "CallArguments"; $result = $this->construct($matchrule, $matchrule, null);
     	$_62 = NULL;
     	do {
     		$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Argument" );
     		}
@@ -517,7 +517,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				else { $_60 = FALSE; break; }
     				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     				$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "Argument" );
     				}
@@ -558,13 +558,13 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* Call: Method:Word ( "(" < :CallArguments? > ")" )? */
-    protected $match_Call_typestack = array('Call');
-    function match_Call ($stack = array()) {
+    protected $match_Call_typestack = ['Call'];
+    function match_Call ($stack = []) {
     	$matchrule = "Call"; $result = $this->construct($matchrule, $matchrule, null);
     	$_72 = NULL;
     	do {
     		$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Method" );
     		}
@@ -582,7 +582,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$res_67 = $result;
     			$pos_67 = $this->pos;
     			$matcher = 'match_'.'CallArguments'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "CallArguments" );
     			}
@@ -616,13 +616,13 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* LookupStep: :Call &"." */
-    protected $match_LookupStep_typestack = array('LookupStep');
-    function match_LookupStep ($stack = array()) {
+    protected $match_LookupStep_typestack = ['LookupStep'];
+    function match_LookupStep ($stack = []) {
     	$matchrule = "LookupStep"; $result = $this->construct($matchrule, $matchrule, null);
     	$_76 = NULL;
     	do {
     		$matcher = 'match_'.'Call'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Call" );
     		}
@@ -649,11 +649,11 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* LastLookupStep: :Call */
-    protected $match_LastLookupStep_typestack = array('LastLookupStep');
-    function match_LastLookupStep ($stack = array()) {
+    protected $match_LastLookupStep_typestack = ['LastLookupStep'];
+    function match_LastLookupStep ($stack = []) {
     	$matchrule = "LastLookupStep"; $result = $this->construct($matchrule, $matchrule, null);
     	$matcher = 'match_'.'Call'; $key = $matcher; $pos = $this->pos;
-    	$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    	$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     	if ($subres !== FALSE) {
     		$this->store( $result, $subres, "Call" );
     		return $this->finalise($result);
@@ -663,8 +663,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Lookup: LookupStep ("." LookupStep)* "." LastLookupStep | LastLookupStep */
-    protected $match_Lookup_typestack = array('Lookup');
-    function match_Lookup ($stack = array()) {
+    protected $match_Lookup_typestack = ['Lookup'];
+    function match_Lookup ($stack = []) {
     	$matchrule = "Lookup"; $result = $this->construct($matchrule, $matchrule, null);
     	$_90 = NULL;
     	do {
@@ -673,7 +673,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_87 = NULL;
     		do {
     			$matcher = 'match_'.'LookupStep'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -689,7 +689,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					}
     					else { $_83 = FALSE; break; }
     					$matcher = 'match_'.'LookupStep'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     					}
@@ -711,7 +711,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			}
     			else { $_87 = FALSE; break; }
     			$matcher = 'match_'.'LastLookupStep'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -723,7 +723,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$result = $res_79;
     		$this->pos = $pos_79;
     		$matcher = 'match_'.'LastLookupStep'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_90 = TRUE; break;
@@ -743,7 +743,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     function Lookup__construct(&$res)
     {
         $res['php'] = '$scope->locally()';
-        $res['LookupSteps'] = array();
+        $res['LookupSteps'] = [];
     }
 
     /**
@@ -777,8 +777,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* Translate: "<%t" < Entity < (Default:QuotedString)? < (!("is" "=") < "is" < Context:QuotedString)? <
     (InjectionVariables)? > "%>" */
-    protected $match_Translate_typestack = array('Translate');
-    function match_Translate ($stack = array()) {
+    protected $match_Translate_typestack = ['Translate'];
+    function match_Translate ($stack = []) {
     	$matchrule = "Translate"; $result = $this->construct($matchrule, $matchrule, null);
     	$_116 = NULL;
     	do {
@@ -786,7 +786,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		else { $_116 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'Entity'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -797,7 +797,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_97 = NULL;
     		do {
     			$matcher = 'match_'.'QuotedString'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "Default" );
     			}
@@ -844,7 +844,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			else { $_108 = FALSE; break; }
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			$matcher = 'match_'.'QuotedString'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "Context" );
     			}
@@ -864,7 +864,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_112 = NULL;
     		do {
     			$matcher = 'match_'.'InjectionVariables'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -890,8 +890,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* InjectionVariables: (< InjectionName:Word "=" Argument)+ */
-    protected $match_InjectionVariables_typestack = array('InjectionVariables');
-    function match_InjectionVariables ($stack = array()) {
+    protected $match_InjectionVariables_typestack = ['InjectionVariables'];
+    function match_InjectionVariables ($stack = []) {
     	$matchrule = "InjectionVariables"; $result = $this->construct($matchrule, $matchrule, null);
     	$count = 0;
     	while (true) {
@@ -901,7 +901,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		do {
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "InjectionName" );
     			}
@@ -912,7 +912,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			}
     			else { $_122 = FALSE; break; }
     			$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -935,8 +935,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Entity: / [A-Za-z_\\] [\w\.\\]* / */
-    protected $match_Entity_typestack = array('Entity');
-    function match_Entity ($stack = array()) {
+    protected $match_Entity_typestack = ['Entity'];
+    function match_Entity ($stack = []) {
     	$matchrule = "Entity"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [A-Za-z_\\\\] [\w\.\\\\]* /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -1003,8 +1003,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* SimpleInjection: '$' :Lookup */
-    protected $match_SimpleInjection_typestack = array('SimpleInjection');
-    function match_SimpleInjection ($stack = array()) {
+    protected $match_SimpleInjection_typestack = ['SimpleInjection'];
+    function match_SimpleInjection ($stack = []) {
     	$matchrule = "SimpleInjection"; $result = $this->construct($matchrule, $matchrule, null);
     	$_127 = NULL;
     	do {
@@ -1014,7 +1014,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		}
     		else { $_127 = FALSE; break; }
     		$matcher = 'match_'.'Lookup'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Lookup" );
     		}
@@ -1028,15 +1028,15 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* BracketInjection: '{$' :Lookup "}" */
-    protected $match_BracketInjection_typestack = array('BracketInjection');
-    function match_BracketInjection ($stack = array()) {
+    protected $match_BracketInjection_typestack = ['BracketInjection'];
+    function match_BracketInjection ($stack = []) {
     	$matchrule = "BracketInjection"; $result = $this->construct($matchrule, $matchrule, null);
     	$_132 = NULL;
     	do {
     		if (( $subres = $this->literal( '{$' ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_132 = FALSE; break; }
     		$matcher = 'match_'.'Lookup'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Lookup" );
     		}
@@ -1055,15 +1055,15 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Injection: BracketInjection | SimpleInjection */
-    protected $match_Injection_typestack = array('Injection');
-    function match_Injection ($stack = array()) {
+    protected $match_Injection_typestack = ['Injection'];
+    function match_Injection ($stack = []) {
     	$matchrule = "Injection"; $result = $this->construct($matchrule, $matchrule, null);
     	$_137 = NULL;
     	do {
     		$res_134 = $result;
     		$pos_134 = $this->pos;
     		$matcher = 'match_'.'BracketInjection'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_137 = TRUE; break;
@@ -1071,7 +1071,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$result = $res_134;
     		$this->pos = $pos_134;
     		$matcher = 'match_'.'SimpleInjection'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_137 = TRUE; break;
@@ -1093,11 +1093,11 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* DollarMarkedLookup: SimpleInjection */
-    protected $match_DollarMarkedLookup_typestack = array('DollarMarkedLookup');
-    function match_DollarMarkedLookup ($stack = array()) {
+    protected $match_DollarMarkedLookup_typestack = ['DollarMarkedLookup'];
+    function match_DollarMarkedLookup ($stack = []) {
     	$matchrule = "DollarMarkedLookup"; $result = $this->construct($matchrule, $matchrule, null);
     	$matcher = 'match_'.'SimpleInjection'; $key = $matcher; $pos = $this->pos;
-    	$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    	$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     	if ($subres !== FALSE) {
     		$this->store( $result, $subres );
     		return $this->finalise($result);
@@ -1113,8 +1113,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* QuotedString: q:/['"]/   String:/ (\\\\ | \\. | [^$q\\])* /   '$q' */
-    protected $match_QuotedString_typestack = array('QuotedString');
-    function match_QuotedString ($stack = array()) {
+    protected $match_QuotedString_typestack = ['QuotedString'];
+    function match_QuotedString ($stack = []) {
     	$matchrule = "QuotedString"; $result = $this->construct($matchrule, $matchrule, null);
     	$_143 = NULL;
     	do {
@@ -1149,8 +1149,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* FreeString: /[^,)%!=><|&]+/ */
-    protected $match_FreeString_typestack = array('FreeString');
-    function match_FreeString ($stack = array()) {
+    protected $match_FreeString_typestack = ['FreeString'];
+    function match_FreeString ($stack = []) {
     	$matchrule = "FreeString"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/[^,)%!=><|&]+/' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -1165,15 +1165,15 @@ class SSTemplateParser extends Parser implements TemplateParser
     :QuotedString |
     :Lookup !(< FreeString)|
     :FreeString */
-    protected $match_Argument_typestack = array('Argument');
-    function match_Argument ($stack = array()) {
+    protected $match_Argument_typestack = ['Argument'];
+    function match_Argument ($stack = []) {
     	$matchrule = "Argument"; $result = $this->construct($matchrule, $matchrule, null);
     	$_163 = NULL;
     	do {
     		$res_146 = $result;
     		$pos_146 = $this->pos;
     		$matcher = 'match_'.'DollarMarkedLookup'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "DollarMarkedLookup" );
     			$_163 = TRUE; break;
@@ -1185,7 +1185,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$res_148 = $result;
     			$pos_148 = $this->pos;
     			$matcher = 'match_'.'QuotedString'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "QuotedString" );
     				$_161 = TRUE; break;
@@ -1199,7 +1199,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$_156 = NULL;
     				do {
     					$matcher = 'match_'.'Lookup'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres, "Lookup" );
     					}
@@ -1210,7 +1210,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					do {
     						if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     						$matcher = 'match_'.'FreeString'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     						}
@@ -1234,7 +1234,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$result = $res_150;
     				$this->pos = $pos_150;
     				$matcher = 'match_'.'FreeString'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "FreeString" );
     					$_159 = TRUE; break;
@@ -1308,8 +1308,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* ComparisonOperator: "!=" | "==" | ">=" | ">" | "<=" | "<" | "=" */
-    protected $match_ComparisonOperator_typestack = array('ComparisonOperator');
-    function match_ComparisonOperator ($stack = array()) {
+    protected $match_ComparisonOperator_typestack = ['ComparisonOperator'];
+    function match_ComparisonOperator ($stack = []) {
     	$matchrule = "ComparisonOperator"; $result = $this->construct($matchrule, $matchrule, null);
     	$_188 = NULL;
     	do {
@@ -1419,27 +1419,27 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Comparison: Argument < ComparisonOperator > Argument */
-    protected $match_Comparison_typestack = array('Comparison');
-    function match_Comparison ($stack = array()) {
+    protected $match_Comparison_typestack = ['Comparison'];
+    function match_Comparison ($stack = []) {
     	$matchrule = "Comparison"; $result = $this->construct($matchrule, $matchrule, null);
     	$_195 = NULL;
     	do {
     		$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
     		else { $_195 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'ComparisonOperator'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
     		else { $_195 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -1472,8 +1472,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* PresenceCheck: (Not:'not' <)? Argument */
-    protected $match_PresenceCheck_typestack = array('PresenceCheck');
-    function match_PresenceCheck ($stack = array()) {
+    protected $match_PresenceCheck_typestack = ['PresenceCheck'];
+    function match_PresenceCheck ($stack = []) {
     	$matchrule = "PresenceCheck"; $result = $this->construct($matchrule, $matchrule, null);
     	$_202 = NULL;
     	do {
@@ -1502,7 +1502,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			unset( $pos_200 );
     		}
     		$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -1534,15 +1534,15 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* IfArgumentPortion: Comparison | PresenceCheck */
-    protected $match_IfArgumentPortion_typestack = array('IfArgumentPortion');
-    function match_IfArgumentPortion ($stack = array()) {
+    protected $match_IfArgumentPortion_typestack = ['IfArgumentPortion'];
+    function match_IfArgumentPortion ($stack = []) {
     	$matchrule = "IfArgumentPortion"; $result = $this->construct($matchrule, $matchrule, null);
     	$_207 = NULL;
     	do {
     		$res_204 = $result;
     		$pos_204 = $this->pos;
     		$matcher = 'match_'.'Comparison'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_207 = TRUE; break;
@@ -1550,7 +1550,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$result = $res_204;
     		$this->pos = $pos_204;
     		$matcher = 'match_'.'PresenceCheck'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_207 = TRUE; break;
@@ -1572,8 +1572,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* BooleanOperator: "||" | "&&" */
-    protected $match_BooleanOperator_typestack = array('BooleanOperator');
-    function match_BooleanOperator ($stack = array()) {
+    protected $match_BooleanOperator_typestack = ['BooleanOperator'];
+    function match_BooleanOperator ($stack = []) {
     	$matchrule = "BooleanOperator"; $result = $this->construct($matchrule, $matchrule, null);
     	$_212 = NULL;
     	do {
@@ -1600,13 +1600,13 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* IfArgument: :IfArgumentPortion ( < :BooleanOperator < :IfArgumentPortion )* */
-    protected $match_IfArgument_typestack = array('IfArgument');
-    function match_IfArgument ($stack = array()) {
+    protected $match_IfArgument_typestack = ['IfArgument'];
+    function match_IfArgument ($stack = []) {
     	$matchrule = "IfArgument"; $result = $this->construct($matchrule, $matchrule, null);
     	$_221 = NULL;
     	do {
     		$matcher = 'match_'.'IfArgumentPortion'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "IfArgumentPortion" );
     		}
@@ -1618,14 +1618,14 @@ class SSTemplateParser extends Parser implements TemplateParser
     			do {
     				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     				$matcher = 'match_'.'BooleanOperator'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "BooleanOperator" );
     				}
     				else { $_219 = FALSE; break; }
     				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     				$matcher = 'match_'.'IfArgumentPortion'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "IfArgumentPortion" );
     				}
@@ -1661,8 +1661,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* IfPart: '<%' < 'if' [ :IfArgument > '%>' Template:$TemplateMatcher? */
-    protected $match_IfPart_typestack = array('IfPart');
-    function match_IfPart ($stack = array()) {
+    protected $match_IfPart_typestack = ['IfPart'];
+    function match_IfPart ($stack = []) {
     	$matchrule = "IfPart"; $result = $this->construct($matchrule, $matchrule, null);
     	$_231 = NULL;
     	do {
@@ -1674,7 +1674,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_231 = FALSE; break; }
     		$matcher = 'match_'.'IfArgument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "IfArgument" );
     		}
@@ -1685,7 +1685,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_230 = $result;
     		$pos_230 = $this->pos;
     		$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Template" );
     		}
@@ -1704,8 +1704,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* ElseIfPart: '<%' < 'else_if' [ :IfArgument > '%>' Template:$TemplateMatcher? */
-    protected $match_ElseIfPart_typestack = array('ElseIfPart');
-    function match_ElseIfPart ($stack = array()) {
+    protected $match_ElseIfPart_typestack = ['ElseIfPart'];
+    function match_ElseIfPart ($stack = []) {
     	$matchrule = "ElseIfPart"; $result = $this->construct($matchrule, $matchrule, null);
     	$_241 = NULL;
     	do {
@@ -1717,7 +1717,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_241 = FALSE; break; }
     		$matcher = 'match_'.'IfArgument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "IfArgument" );
     		}
@@ -1728,7 +1728,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_240 = $result;
     		$pos_240 = $this->pos;
     		$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Template" );
     		}
@@ -1747,8 +1747,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* ElsePart: '<%' < 'else' > '%>' Template:$TemplateMatcher? */
-    protected $match_ElsePart_typestack = array('ElsePart');
-    function match_ElsePart ($stack = array()) {
+    protected $match_ElsePart_typestack = ['ElsePart'];
+    function match_ElsePart ($stack = []) {
     	$matchrule = "ElsePart"; $result = $this->construct($matchrule, $matchrule, null);
     	$_249 = NULL;
     	do {
@@ -1763,7 +1763,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_248 = $result;
     		$pos_248 = $this->pos;
     		$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Template" );
     		}
@@ -1782,13 +1782,13 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* If: IfPart ElseIfPart* ElsePart? '<%' < 'end_if' > '%>' */
-    protected $match_If_typestack = array('If');
-    function match_If ($stack = array()) {
+    protected $match_If_typestack = ['If'];
+    function match_If ($stack = []) {
     	$matchrule = "If"; $result = $this->construct($matchrule, $matchrule, null);
     	$_259 = NULL;
     	do {
     		$matcher = 'match_'.'IfPart'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -1797,7 +1797,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$res_252 = $result;
     			$pos_252 = $this->pos;
     			$matcher = 'match_'.'ElseIfPart'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -1812,7 +1812,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_253 = $result;
     		$pos_253 = $this->pos;
     		$matcher = 'match_'.'ElsePart'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -1864,8 +1864,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* Require: '<%' < 'require' [ Call:(Method:Word "(" < :CallArguments  > ")") > '%>' */
-    protected $match_Require_typestack = array('Require');
-    function match_Require ($stack = array()) {
+    protected $match_Require_typestack = ['Require'];
+    function match_Require ($stack = []) {
     	$matchrule = "Require"; $result = $this->construct($matchrule, $matchrule, null);
     	$_275 = NULL;
     	do {
@@ -1880,7 +1880,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_271 = NULL;
     		do {
     			$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "Method" );
     			}
@@ -1892,7 +1892,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			else { $_271 = FALSE; break; }
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			$matcher = 'match_'.'CallArguments'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "CallArguments" );
     			}
@@ -1940,8 +1940,8 @@ class SSTemplateParser extends Parser implements TemplateParser
         :QuotedString |
         :Lookup
     ) */
-    protected $match_CacheBlockArgument_typestack = array('CacheBlockArgument');
-    function match_CacheBlockArgument ($stack = array()) {
+    protected $match_CacheBlockArgument_typestack = ['CacheBlockArgument'];
+    function match_CacheBlockArgument ($stack = []) {
     	$matchrule = "CacheBlockArgument"; $result = $this->construct($matchrule, $matchrule, null);
     	$_295 = NULL;
     	do {
@@ -1988,7 +1988,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$res_284 = $result;
     				$pos_284 = $this->pos;
     				$matcher = 'match_'.'DollarMarkedLookup'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "DollarMarkedLookup" );
     					$_291 = TRUE; break;
@@ -2000,7 +2000,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$res_286 = $result;
     					$pos_286 = $this->pos;
     					$matcher = 'match_'.'QuotedString'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres, "QuotedString" );
     						$_289 = TRUE; break;
@@ -2008,7 +2008,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$result = $res_286;
     					$this->pos = $pos_286;
     					$matcher = 'match_'.'Lookup'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres, "Lookup" );
     						$_289 = TRUE; break;
@@ -2054,13 +2054,13 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* CacheBlockArguments: CacheBlockArgument ( < "," < CacheBlockArgument )* */
-    protected $match_CacheBlockArguments_typestack = array('CacheBlockArguments');
-    function match_CacheBlockArguments ($stack = array()) {
+    protected $match_CacheBlockArguments_typestack = ['CacheBlockArguments'];
+    function match_CacheBlockArguments ($stack = []) {
     	$matchrule = "CacheBlockArguments"; $result = $this->construct($matchrule, $matchrule, null);
     	$_304 = NULL;
     	do {
     		$matcher = 'match_'.'CacheBlockArgument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -2078,7 +2078,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				else { $_302 = FALSE; break; }
     				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     				$matcher = 'match_'.'CacheBlockArgument'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres );
     				}
@@ -2116,9 +2116,9 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* CacheBlockTemplate: (Comment | Translate | If | Require |    OldI18NTag | Include | ClosedBlock |
     OpenBlock | MalformedBlock | Injection | Text)+ */
-    protected $match_CacheBlockTemplate_typestack = array('CacheBlockTemplate','Template');
-    function match_CacheBlockTemplate ($stack = array()) {
-    	$matchrule = "CacheBlockTemplate"; $result = $this->construct($matchrule, $matchrule, array('TemplateMatcher' => 'CacheRestrictedTemplate'));
+    protected $match_CacheBlockTemplate_typestack = ['CacheBlockTemplate','Template'];
+    function match_CacheBlockTemplate ($stack = []) {
+    	$matchrule = "CacheBlockTemplate"; $result = $this->construct($matchrule, $matchrule, ['TemplateMatcher' => 'CacheRestrictedTemplate']);
     	$count = 0;
     	while (true) {
     		$res_348 = $result;
@@ -2130,7 +2130,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$res_306 = $result;
     				$pos_306 = $this->pos;
     				$matcher = 'match_'.'Comment'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres );
     					$_345 = TRUE; break;
@@ -2142,7 +2142,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$res_308 = $result;
     					$pos_308 = $this->pos;
     					$matcher = 'match_'.'Translate'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     						$_343 = TRUE; break;
@@ -2154,7 +2154,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     						$res_310 = $result;
     						$pos_310 = $this->pos;
     						$matcher = 'match_'.'If'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     							$_341 = TRUE; break;
@@ -2166,7 +2166,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     							$res_312 = $result;
     							$pos_312 = $this->pos;
     							$matcher = 'match_'.'Require'; $key = $matcher; $pos = $this->pos;
-    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     							if ($subres !== FALSE) {
     								$this->store( $result, $subres );
     								$_339 = TRUE; break;
@@ -2178,7 +2178,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     								$res_314 = $result;
     								$pos_314 = $this->pos;
     								$matcher = 'match_'.'OldI18NTag'; $key = $matcher; $pos = $this->pos;
-    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     								if ($subres !== FALSE) {
     									$this->store( $result, $subres );
     									$_337 = TRUE; break;
@@ -2190,7 +2190,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     									$res_316 = $result;
     									$pos_316 = $this->pos;
     									$matcher = 'match_'.'Include'; $key = $matcher; $pos = $this->pos;
-    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     									if ($subres !== FALSE) {
     										$this->store( $result, $subres );
     										$_335 = TRUE; break;
@@ -2202,7 +2202,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     										$res_318 = $result;
     										$pos_318 = $this->pos;
     										$matcher = 'match_'.'ClosedBlock'; $key = $matcher; $pos = $this->pos;
-    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     										if ($subres !== FALSE) {
     											$this->store( $result, $subres );
     											$_333 = TRUE; break;
@@ -2214,7 +2214,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     											$res_320 = $result;
     											$pos_320 = $this->pos;
     											$matcher = 'match_'.'OpenBlock'; $key = $matcher; $pos = $this->pos;
-    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     											if ($subres !== FALSE) {
     												$this->store( $result, $subres );
     												$_331 = TRUE; break;
@@ -2226,7 +2226,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     												$res_322 = $result;
     												$pos_322 = $this->pos;
     												$matcher = 'match_'.'MalformedBlock'; $key = $matcher; $pos = $this->pos;
-    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     												if ($subres !== FALSE) {
     													$this->store( $result, $subres );
     													$_329 = TRUE; break;
@@ -2238,7 +2238,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     													$res_324 = $result;
     													$pos_324 = $this->pos;
     													$matcher = 'match_'.'Injection'; $key = $matcher; $pos = $this->pos;
-    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     													if ($subres !== FALSE) {
     														$this->store( $result, $subres );
     														$_327 = TRUE; break;
@@ -2246,7 +2246,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     													$result = $res_324;
     													$this->pos = $pos_324;
     													$matcher = 'match_'.'Text'; $key = $matcher; $pos = $this->pos;
-    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     													if ($subres !== FALSE) {
     														$this->store( $result, $subres );
     														$_327 = TRUE; break;
@@ -2334,8 +2334,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     '<%' < "uncached" < CacheBlockArguments? ( < Conditional:("if"|"unless") > Condition:IfArgument )? > '%>'
         Template:$TemplateMatcher?
         '<%' < 'end_' ("uncached"|"cached"|"cacheblock") > '%>' */
-    protected $match_UncachedBlock_typestack = array('UncachedBlock');
-    function match_UncachedBlock ($stack = array()) {
+    protected $match_UncachedBlock_typestack = ['UncachedBlock'];
+    function match_UncachedBlock ($stack = []) {
     	$matchrule = "UncachedBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_385 = NULL;
     	do {
@@ -2348,7 +2348,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_353 = $result;
     		$pos_353 = $this->pos;
     		$matcher = 'match_'.'CacheBlockArguments'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -2399,7 +2399,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			}
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			$matcher = 'match_'.'IfArgument'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "Condition" );
     			}
@@ -2419,7 +2419,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_368 = $result;
     		$pos_368 = $this->pos;
     		$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Template" );
     		}
@@ -2495,8 +2495,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* CacheRestrictedTemplate: (Comment | Translate | If | Require | CacheBlock | UncachedBlock | OldI18NTag | Include | ClosedBlock |
     OpenBlock | MalformedBlock | Injection | Text)+ */
-    protected $match_CacheRestrictedTemplate_typestack = array('CacheRestrictedTemplate','Template');
-    function match_CacheRestrictedTemplate ($stack = array()) {
+    protected $match_CacheRestrictedTemplate_typestack = ['CacheRestrictedTemplate','Template'];
+    function match_CacheRestrictedTemplate ($stack = []) {
     	$matchrule = "CacheRestrictedTemplate"; $result = $this->construct($matchrule, $matchrule, null);
     	$count = 0;
     	while (true) {
@@ -2509,7 +2509,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$res_387 = $result;
     				$pos_387 = $this->pos;
     				$matcher = 'match_'.'Comment'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres );
     					$_434 = TRUE; break;
@@ -2521,7 +2521,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$res_389 = $result;
     					$pos_389 = $this->pos;
     					$matcher = 'match_'.'Translate'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     						$_432 = TRUE; break;
@@ -2533,7 +2533,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     						$res_391 = $result;
     						$pos_391 = $this->pos;
     						$matcher = 'match_'.'If'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     							$_430 = TRUE; break;
@@ -2545,7 +2545,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     							$res_393 = $result;
     							$pos_393 = $this->pos;
     							$matcher = 'match_'.'Require'; $key = $matcher; $pos = $this->pos;
-    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     							if ($subres !== FALSE) {
     								$this->store( $result, $subres );
     								$_428 = TRUE; break;
@@ -2557,7 +2557,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     								$res_395 = $result;
     								$pos_395 = $this->pos;
     								$matcher = 'match_'.'CacheBlock'; $key = $matcher; $pos = $this->pos;
-    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     								if ($subres !== FALSE) {
     									$this->store( $result, $subres );
     									$_426 = TRUE; break;
@@ -2569,7 +2569,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     									$res_397 = $result;
     									$pos_397 = $this->pos;
     									$matcher = 'match_'.'UncachedBlock'; $key = $matcher; $pos = $this->pos;
-    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     									if ($subres !== FALSE) {
     										$this->store( $result, $subres );
     										$_424 = TRUE; break;
@@ -2581,7 +2581,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     										$res_399 = $result;
     										$pos_399 = $this->pos;
     										$matcher = 'match_'.'OldI18NTag'; $key = $matcher; $pos = $this->pos;
-    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     										if ($subres !== FALSE) {
     											$this->store( $result, $subres );
     											$_422 = TRUE; break;
@@ -2593,7 +2593,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     											$res_401 = $result;
     											$pos_401 = $this->pos;
     											$matcher = 'match_'.'Include'; $key = $matcher; $pos = $this->pos;
-    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     											if ($subres !== FALSE) {
     												$this->store( $result, $subres );
     												$_420 = TRUE; break;
@@ -2605,7 +2605,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     												$res_403 = $result;
     												$pos_403 = $this->pos;
     												$matcher = 'match_'.'ClosedBlock'; $key = $matcher; $pos = $this->pos;
-    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     												if ($subres !== FALSE) {
     													$this->store( $result, $subres );
     													$_418 = TRUE; break;
@@ -2617,7 +2617,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     													$res_405 = $result;
     													$pos_405 = $this->pos;
     													$matcher = 'match_'.'OpenBlock'; $key = $matcher; $pos = $this->pos;
-    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     													if ($subres !== FALSE) {
     														$this->store( $result, $subres );
     														$_416 = TRUE; break;
@@ -2629,7 +2629,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     														$res_407 = $result;
     														$pos_407 = $this->pos;
     														$matcher = 'match_'.'MalformedBlock'; $key = $matcher; $pos = $this->pos;
-    														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     														if ($subres !== FALSE) {
     															$this->store( $result, $subres );
     															$_414 = TRUE; break;
@@ -2641,7 +2641,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     															$res_409 = $result;
     															$pos_409 = $this->pos;
     															$matcher = 'match_'.'Injection'; $key = $matcher; $pos = $this->pos;
-    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     															if ($subres !== FALSE) {
     																$this->store( $result, $subres );
     																$_412 = TRUE; break;
@@ -2649,7 +2649,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     															$result = $res_409;
     															$this->pos = $pos_409;
     															$matcher = 'match_'.'Text'; $key = $matcher; $pos = $this->pos;
-    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     															if ($subres !== FALSE) {
     																$this->store( $result, $subres );
     																$_412 = TRUE; break;
@@ -2761,8 +2761,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     Condition:IfArgument )? > '%>'
         (CacheBlock | UncachedBlock | CacheBlockTemplate)*
     '<%' < 'end_' ("cached"|"uncached"|"cacheblock") > '%>' */
-    protected $match_CacheBlock_typestack = array('CacheBlock');
-    function match_CacheBlock ($stack = array()) {
+    protected $match_CacheBlock_typestack = ['CacheBlock'];
+    function match_CacheBlock ($stack = []) {
     	$matchrule = "CacheBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_492 = NULL;
     	do {
@@ -2809,7 +2809,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_449 = NULL;
     		do {
     			$matcher = 'match_'.'CacheBlockArguments'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -2864,7 +2864,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			}
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			$matcher = 'match_'.'IfArgument'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "Condition" );
     			}
@@ -2891,7 +2891,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$res_465 = $result;
     					$pos_465 = $this->pos;
     					$matcher = 'match_'.'CacheBlock'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     						$_472 = TRUE; break;
@@ -2903,7 +2903,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     						$res_467 = $result;
     						$pos_467 = $this->pos;
     						$matcher = 'match_'.'UncachedBlock'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     							$_470 = TRUE; break;
@@ -2911,7 +2911,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     						$result = $res_467;
     						$this->pos = $pos_467;
     						$matcher = 'match_'.'CacheBlockTemplate'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     							$_470 = TRUE; break;
@@ -3059,15 +3059,15 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* OldTPart: "_t" N "(" N QuotedString (N "," N CallArguments)? N ")" N (";")? */
-    protected $match_OldTPart_typestack = array('OldTPart');
-    function match_OldTPart ($stack = array()) {
+    protected $match_OldTPart_typestack = ['OldTPart'];
+    function match_OldTPart ($stack = []) {
     	$matchrule = "OldTPart"; $result = $this->construct($matchrule, $matchrule, null);
     	$_511 = NULL;
     	do {
     		if (( $subres = $this->literal( '_t' ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_511 = FALSE; break; }
     		$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3078,13 +3078,13 @@ class SSTemplateParser extends Parser implements TemplateParser
     		}
     		else { $_511 = FALSE; break; }
     		$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
     		else { $_511 = FALSE; break; }
     		$matcher = 'match_'.'QuotedString'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3094,7 +3094,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_503 = NULL;
     		do {
     			$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -3105,13 +3105,13 @@ class SSTemplateParser extends Parser implements TemplateParser
     			}
     			else { $_503 = FALSE; break; }
     			$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
     			else { $_503 = FALSE; break; }
     			$matcher = 'match_'.'CallArguments'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -3126,7 +3126,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			unset( $pos_504 );
     		}
     		$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3137,7 +3137,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		}
     		else { $_511 = FALSE; break; }
     		$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3169,8 +3169,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* N: / [\s\n]* / */
-    protected $match_N_typestack = array('N');
-    function match_N ($stack = array()) {
+    protected $match_N_typestack = ['N'];
+    function match_N ($stack = []) {
     	$matchrule = "N"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [\s\n]* /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -3207,8 +3207,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* OldTTag: "<%" < OldTPart > "%>" */
-    protected $match_OldTTag_typestack = array('OldTTag');
-    function match_OldTTag ($stack = array()) {
+    protected $match_OldTTag_typestack = ['OldTTag'];
+    function match_OldTTag ($stack = []) {
     	$matchrule = "OldTTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_519 = NULL;
     	do {
@@ -3216,7 +3216,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		else { $_519 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'OldTPart'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3239,8 +3239,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* OldSprintfTag: "<%" < "sprintf" < "(" < OldTPart < "," < CallArguments > ")" > "%>" */
-    protected $match_OldSprintfTag_typestack = array('OldSprintfTag');
-    function match_OldSprintfTag ($stack = array()) {
+    protected $match_OldSprintfTag_typestack = ['OldSprintfTag'];
+    function match_OldSprintfTag ($stack = []) {
     	$matchrule = "OldSprintfTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_536 = NULL;
     	do {
@@ -3257,7 +3257,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		else { $_536 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'OldTPart'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3270,7 +3270,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		else { $_536 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'CallArguments'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3309,15 +3309,15 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* OldI18NTag: OldSprintfTag | OldTTag */
-    protected $match_OldI18NTag_typestack = array('OldI18NTag');
-    function match_OldI18NTag ($stack = array()) {
+    protected $match_OldI18NTag_typestack = ['OldI18NTag'];
+    function match_OldI18NTag ($stack = []) {
     	$matchrule = "OldI18NTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_541 = NULL;
     	do {
     		$res_538 = $result;
     		$pos_538 = $this->pos;
     		$matcher = 'match_'.'OldSprintfTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_541 = TRUE; break;
@@ -3325,7 +3325,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$result = $res_538;
     		$this->pos = $pos_538;
     		$matcher = 'match_'.'OldTTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_541 = TRUE; break;
@@ -3347,13 +3347,13 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* NamedArgument: Name:Word "=" Value:Argument */
-    protected $match_NamedArgument_typestack = array('NamedArgument');
-    function match_NamedArgument ($stack = array()) {
+    protected $match_NamedArgument_typestack = ['NamedArgument'];
+    function match_NamedArgument ($stack = []) {
     	$matchrule = "NamedArgument"; $result = $this->construct($matchrule, $matchrule, null);
     	$_546 = NULL;
     	do {
     		$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Name" );
     		}
@@ -3364,7 +3364,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		}
     		else { $_546 = FALSE; break; }
     		$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Value" );
     		}
@@ -3401,8 +3401,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* Include: "<%" < "include" < Template:NamespacedWord < (NamedArgument ( < "," < NamedArgument )*)? > "%>" */
-    protected $match_Include_typestack = array('Include');
-    function match_Include ($stack = array()) {
+    protected $match_Include_typestack = ['Include'];
+    function match_Include ($stack = []) {
     	$matchrule = "Include"; $result = $this->construct($matchrule, $matchrule, null);
     	$_565 = NULL;
     	do {
@@ -3413,7 +3413,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		else { $_565 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'NamespacedWord'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Template" );
     		}
@@ -3424,7 +3424,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_561 = NULL;
     		do {
     			$matcher = 'match_'.'NamedArgument'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -3442,7 +3442,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					else { $_559 = FALSE; break; }
     					if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     					$matcher = 'match_'.'NamedArgument'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     					}
@@ -3481,7 +3481,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     function Include__construct(&$res)
     {
-        $res['arguments'] = array();
+        $res['arguments'] = [];
     }
 
     function Include_Template(&$res, $sub)
@@ -3512,13 +3512,13 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* BlockArguments: :Argument ( < "," < :Argument)* */
-    protected $match_BlockArguments_typestack = array('BlockArguments');
-    function match_BlockArguments ($stack = array()) {
+    protected $match_BlockArguments_typestack = ['BlockArguments'];
+    function match_BlockArguments ($stack = []) {
     	$matchrule = "BlockArguments"; $result = $this->construct($matchrule, $matchrule, null);
     	$_574 = NULL;
     	do {
     		$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Argument" );
     		}
@@ -3536,7 +3536,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				else { $_572 = FALSE; break; }
     				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     				$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "Argument" );
     				}
@@ -3561,8 +3561,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* NotBlockTag: "end_" | (("if" | "else_if" | "else" | "require" | "cached" | "uncached" | "cacheblock" | "include")]) */
-    protected $match_NotBlockTag_typestack = array('NotBlockTag');
-    function match_NotBlockTag ($stack = array()) {
+    protected $match_NotBlockTag_typestack = ['NotBlockTag'];
+    function match_NotBlockTag ($stack = []) {
     	$matchrule = "NotBlockTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_612 = NULL;
     	do {
@@ -3716,8 +3716,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* ClosedBlock: '<%' < !NotBlockTag BlockName:Word ( [ :BlockArguments ] )? > Zap:'%>' Template:$TemplateMatcher?
     '<%' < 'end_' '$BlockName' > '%>' */
-    protected $match_ClosedBlock_typestack = array('ClosedBlock');
-    function match_ClosedBlock ($stack = array()) {
+    protected $match_ClosedBlock_typestack = ['ClosedBlock'];
+    function match_ClosedBlock ($stack = []) {
     	$matchrule = "ClosedBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_632 = NULL;
     	do {
@@ -3727,7 +3727,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_616 = $result;
     		$pos_616 = $this->pos;
     		$matcher = 'match_'.'NotBlockTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$result = $res_616;
@@ -3739,7 +3739,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$this->pos = $pos_616;
     		}
     		$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "BlockName" );
     		}
@@ -3751,7 +3751,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			else { $_621 = FALSE; break; }
     			$matcher = 'match_'.'BlockArguments'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "BlockArguments" );
     			}
@@ -3781,7 +3781,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_625 = $result;
     		$pos_625 = $this->pos;
     		$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Template" );
     		}
@@ -3833,7 +3833,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     function ClosedBlock_BlockArguments(&$res, $sub)
     {
         if (isset($sub['Argument']['ArgumentMode'])) {
-            $res['Arguments'] = array($sub['Argument']);
+            $res['Arguments'] = [$sub['Argument']];
             $res['ArgumentCount'] = 1;
         } else {
             $res['Arguments'] = $sub['Argument'];
@@ -3910,8 +3910,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* OpenBlock: '<%' < !NotBlockTag BlockName:Word ( [ :BlockArguments ] )? > '%>' */
-    protected $match_OpenBlock_typestack = array('OpenBlock');
-    function match_OpenBlock ($stack = array()) {
+    protected $match_OpenBlock_typestack = ['OpenBlock'];
+    function match_OpenBlock ($stack = []) {
     	$matchrule = "OpenBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_645 = NULL;
     	do {
@@ -3921,7 +3921,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_636 = $result;
     		$pos_636 = $this->pos;
     		$matcher = 'match_'.'NotBlockTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$result = $res_636;
@@ -3933,7 +3933,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$this->pos = $pos_636;
     		}
     		$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "BlockName" );
     		}
@@ -3945,7 +3945,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			else { $_641 = FALSE; break; }
     			$matcher = 'match_'.'BlockArguments'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "BlockArguments" );
     			}
@@ -3981,7 +3981,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     function OpenBlock_BlockArguments(&$res, $sub)
     {
         if (isset($sub['Argument']['ArgumentMode'])) {
-            $res['Arguments'] = array($sub['Argument']);
+            $res['Arguments'] = [$sub['Argument']];
             $res['ArgumentCount'] = 1;
         } else {
             $res['Arguments'] = $sub['Argument'];
@@ -4048,8 +4048,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* MismatchedEndBlock: '<%' < 'end_' :Word > '%>' */
-    protected $match_MismatchedEndBlock_typestack = array('MismatchedEndBlock');
-    function match_MismatchedEndBlock ($stack = array()) {
+    protected $match_MismatchedEndBlock_typestack = ['MismatchedEndBlock'];
+    function match_MismatchedEndBlock ($stack = []) {
     	$matchrule = "MismatchedEndBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_653 = NULL;
     	do {
@@ -4059,7 +4059,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		if (( $subres = $this->literal( 'end_' ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_653 = FALSE; break; }
     		$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Word" );
     		}
@@ -4084,8 +4084,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* MalformedOpenTag: '<%' < !NotBlockTag Tag:Word  !( ( [ :BlockArguments ] )? > '%>' ) */
-    protected $match_MalformedOpenTag_typestack = array('MalformedOpenTag');
-    function match_MalformedOpenTag ($stack = array()) {
+    protected $match_MalformedOpenTag_typestack = ['MalformedOpenTag'];
+    function match_MalformedOpenTag ($stack = []) {
     	$matchrule = "MalformedOpenTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_668 = NULL;
     	do {
@@ -4095,7 +4095,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_657 = $result;
     		$pos_657 = $this->pos;
     		$matcher = 'match_'.'NotBlockTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$result = $res_657;
@@ -4107,7 +4107,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$this->pos = $pos_657;
     		}
     		$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Tag" );
     		}
@@ -4123,7 +4123,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     				else { $_662 = FALSE; break; }
     				$matcher = 'match_'.'BlockArguments'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "BlockArguments" );
     				}
@@ -4170,8 +4170,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* MalformedCloseTag: '<%' < Tag:('end_' :Word ) !( > '%>' ) */
-    protected $match_MalformedCloseTag_typestack = array('MalformedCloseTag');
-    function match_MalformedCloseTag ($stack = array()) {
+    protected $match_MalformedCloseTag_typestack = ['MalformedCloseTag'];
+    function match_MalformedCloseTag ($stack = []) {
     	$matchrule = "MalformedCloseTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_680 = NULL;
     	do {
@@ -4184,7 +4184,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			if (( $subres = $this->literal( 'end_' ) ) !== FALSE) { $result["text"] .= $subres; }
     			else { $_674 = FALSE; break; }
     			$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "Word" );
     			}
@@ -4236,15 +4236,15 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* MalformedBlock: MalformedOpenTag | MalformedCloseTag */
-    protected $match_MalformedBlock_typestack = array('MalformedBlock');
-    function match_MalformedBlock ($stack = array()) {
+    protected $match_MalformedBlock_typestack = ['MalformedBlock'];
+    function match_MalformedBlock ($stack = []) {
     	$matchrule = "MalformedBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_685 = NULL;
     	do {
     		$res_682 = $result;
     		$pos_682 = $this->pos;
     		$matcher = 'match_'.'MalformedOpenTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_685 = TRUE; break;
@@ -4252,7 +4252,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$result = $res_682;
     		$this->pos = $pos_682;
     		$matcher = 'match_'.'MalformedCloseTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_685 = TRUE; break;
@@ -4270,8 +4270,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Comment: "<%--" (!"--%>" /(?s)./)+ "--%>" */
-    protected $match_Comment_typestack = array('Comment');
-    function match_Comment ($stack = array()) {
+    protected $match_Comment_typestack = ['Comment'];
+    function match_Comment ($stack = []) {
     	$matchrule = "Comment"; $result = $this->construct($matchrule, $matchrule, null);
     	$_693 = NULL;
     	do {
@@ -4329,9 +4329,9 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* TopTemplate: (Comment | Translate | If | Require | CacheBlock | UncachedBlock | OldI18NTag | Include | ClosedBlock |
     OpenBlock |  MalformedBlock | MismatchedEndBlock  | Injection | Text)+ */
-    protected $match_TopTemplate_typestack = array('TopTemplate','Template');
-    function match_TopTemplate ($stack = array()) {
-    	$matchrule = "TopTemplate"; $result = $this->construct($matchrule, $matchrule, array('TemplateMatcher' => 'Template'));
+    protected $match_TopTemplate_typestack = ['TopTemplate','Template'];
+    function match_TopTemplate ($stack = []) {
+    	$matchrule = "TopTemplate"; $result = $this->construct($matchrule, $matchrule, ['TemplateMatcher' => 'Template']);
     	$count = 0;
     	while (true) {
     		$res_749 = $result;
@@ -4343,7 +4343,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$res_695 = $result;
     				$pos_695 = $this->pos;
     				$matcher = 'match_'.'Comment'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres );
     					$_746 = TRUE; break;
@@ -4355,7 +4355,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$res_697 = $result;
     					$pos_697 = $this->pos;
     					$matcher = 'match_'.'Translate'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     						$_744 = TRUE; break;
@@ -4367,7 +4367,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     						$res_699 = $result;
     						$pos_699 = $this->pos;
     						$matcher = 'match_'.'If'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     							$_742 = TRUE; break;
@@ -4379,7 +4379,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     							$res_701 = $result;
     							$pos_701 = $this->pos;
     							$matcher = 'match_'.'Require'; $key = $matcher; $pos = $this->pos;
-    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     							if ($subres !== FALSE) {
     								$this->store( $result, $subres );
     								$_740 = TRUE; break;
@@ -4391,7 +4391,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     								$res_703 = $result;
     								$pos_703 = $this->pos;
     								$matcher = 'match_'.'CacheBlock'; $key = $matcher; $pos = $this->pos;
-    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     								if ($subres !== FALSE) {
     									$this->store( $result, $subres );
     									$_738 = TRUE; break;
@@ -4403,7 +4403,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     									$res_705 = $result;
     									$pos_705 = $this->pos;
     									$matcher = 'match_'.'UncachedBlock'; $key = $matcher; $pos = $this->pos;
-    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     									if ($subres !== FALSE) {
     										$this->store( $result, $subres );
     										$_736 = TRUE; break;
@@ -4415,7 +4415,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     										$res_707 = $result;
     										$pos_707 = $this->pos;
     										$matcher = 'match_'.'OldI18NTag'; $key = $matcher; $pos = $this->pos;
-    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     										if ($subres !== FALSE) {
     											$this->store( $result, $subres );
     											$_734 = TRUE; break;
@@ -4427,7 +4427,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     											$res_709 = $result;
     											$pos_709 = $this->pos;
     											$matcher = 'match_'.'Include'; $key = $matcher; $pos = $this->pos;
-    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     											if ($subres !== FALSE) {
     												$this->store( $result, $subres );
     												$_732 = TRUE; break;
@@ -4439,7 +4439,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     												$res_711 = $result;
     												$pos_711 = $this->pos;
     												$matcher = 'match_'.'ClosedBlock'; $key = $matcher; $pos = $this->pos;
-    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     												if ($subres !== FALSE) {
     													$this->store( $result, $subres );
     													$_730 = TRUE; break;
@@ -4451,7 +4451,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     													$res_713 = $result;
     													$pos_713 = $this->pos;
     													$matcher = 'match_'.'OpenBlock'; $key = $matcher; $pos = $this->pos;
-    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     													if ($subres !== FALSE) {
     														$this->store( $result, $subres );
     														$_728 = TRUE; break;
@@ -4463,7 +4463,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     														$res_715 = $result;
     														$pos_715 = $this->pos;
     														$matcher = 'match_'.'MalformedBlock'; $key = $matcher; $pos = $this->pos;
-    														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     														if ($subres !== FALSE) {
     															$this->store( $result, $subres );
     															$_726 = TRUE; break;
@@ -4475,7 +4475,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     															$res_717 = $result;
     															$pos_717 = $this->pos;
     															$matcher = 'match_'.'MismatchedEndBlock'; $key = $matcher; $pos = $this->pos;
-    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     															if ($subres !== FALSE) {
     																$this->store( $result, $subres );
     																$_724 = TRUE; break;
@@ -4487,7 +4487,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     																$res_719 = $result;
     																$pos_719 = $this->pos;
     																$matcher = 'match_'.'Injection'; $key = $matcher; $pos = $this->pos;
-    																$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    																$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     																if ($subres !== FALSE) {
     																	$this->store( $result, $subres );
     																	$_722 = TRUE; break;
@@ -4495,7 +4495,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     																$result = $res_719;
     																$this->pos = $pos_719;
     																$matcher = 'match_'.'Text'; $key = $matcher; $pos = $this->pos;
-    																$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
+    																$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
     																if ($subres !== FALSE) {
     																	$this->store( $result, $subres );
     																	$_722 = TRUE; break;
@@ -4615,8 +4615,8 @@ class SSTemplateParser extends Parser implements TemplateParser
         '{' !'$' |
         '{$' !(/[A-Za-z_]/)
     )+ */
-    protected $match_Text_typestack = array('Text');
-    function match_Text ($stack = array()) {
+    protected $match_Text_typestack = ['Text'];
+    function match_Text ($stack = []) {
     	$matchrule = "Text"; $result = $this->construct($matchrule, $matchrule, null);
     	$count = 0;
     	while (true) {

--- a/src/View/SSTemplateParser.php
+++ b/src/View/SSTemplateParser.php
@@ -63,9 +63,9 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /**
      * Stores the user-supplied closed block extension rules in the form:
-     * array(
+     * [
      *   'name' => function (&$res) {}
-     * )
+     * ]
      * See SSTemplateParser::ClosedBlock_Handle_Loop for an example of what the callable should look like
      * @var array
      */
@@ -73,9 +73,9 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /**
      * Stores the user-supplied open block extension rules in the form:
-     * array(
+     * [
      *   'name' => function (&$res) {}
-     * )
+     * ]
      * See SSTemplateParser::OpenBlock_Handle_Base_tag for an example of what the callable should look like
      * @var array
      */
@@ -190,8 +190,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* Template: (Comment | Translate | If | Require | CacheBlock | UncachedBlock | OldI18NTag | Include | ClosedBlock |
     OpenBlock | MalformedBlock | Injection | Text)+ */
-    protected $match_Template_typestack = ['Template'];
-    function match_Template ($stack = []) {
+    protected $match_Template_typestack = array('Template');
+    function match_Template ($stack = array()) {
     	$matchrule = "Template"; $result = $this->construct($matchrule, $matchrule, null);
     	$count = 0;
     	while (true) {
@@ -204,7 +204,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$res_0 = $result;
     				$pos_0 = $this->pos;
     				$matcher = 'match_'.'Comment'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres );
     					$_47 = TRUE; break;
@@ -216,7 +216,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$res_2 = $result;
     					$pos_2 = $this->pos;
     					$matcher = 'match_'.'Translate'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     						$_45 = TRUE; break;
@@ -228,7 +228,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     						$res_4 = $result;
     						$pos_4 = $this->pos;
     						$matcher = 'match_'.'If'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     							$_43 = TRUE; break;
@@ -240,7 +240,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     							$res_6 = $result;
     							$pos_6 = $this->pos;
     							$matcher = 'match_'.'Require'; $key = $matcher; $pos = $this->pos;
-    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     							if ($subres !== FALSE) {
     								$this->store( $result, $subres );
     								$_41 = TRUE; break;
@@ -252,7 +252,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     								$res_8 = $result;
     								$pos_8 = $this->pos;
     								$matcher = 'match_'.'CacheBlock'; $key = $matcher; $pos = $this->pos;
-    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     								if ($subres !== FALSE) {
     									$this->store( $result, $subres );
     									$_39 = TRUE; break;
@@ -264,7 +264,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     									$res_10 = $result;
     									$pos_10 = $this->pos;
     									$matcher = 'match_'.'UncachedBlock'; $key = $matcher; $pos = $this->pos;
-    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     									if ($subres !== FALSE) {
     										$this->store( $result, $subres );
     										$_37 = TRUE; break;
@@ -276,7 +276,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     										$res_12 = $result;
     										$pos_12 = $this->pos;
     										$matcher = 'match_'.'OldI18NTag'; $key = $matcher; $pos = $this->pos;
-    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     										if ($subres !== FALSE) {
     											$this->store( $result, $subres );
     											$_35 = TRUE; break;
@@ -288,7 +288,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     											$res_14 = $result;
     											$pos_14 = $this->pos;
     											$matcher = 'match_'.'Include'; $key = $matcher; $pos = $this->pos;
-    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     											if ($subres !== FALSE) {
     												$this->store( $result, $subres );
     												$_33 = TRUE; break;
@@ -300,7 +300,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     												$res_16 = $result;
     												$pos_16 = $this->pos;
     												$matcher = 'match_'.'ClosedBlock'; $key = $matcher; $pos = $this->pos;
-    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     												if ($subres !== FALSE) {
     													$this->store( $result, $subres );
     													$_31 = TRUE; break;
@@ -312,7 +312,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     													$res_18 = $result;
     													$pos_18 = $this->pos;
     													$matcher = 'match_'.'OpenBlock'; $key = $matcher; $pos = $this->pos;
-    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     													if ($subres !== FALSE) {
     														$this->store( $result, $subres );
     														$_29 = TRUE; break;
@@ -324,7 +324,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     														$res_20 = $result;
     														$pos_20 = $this->pos;
     														$matcher = 'match_'.'MalformedBlock'; $key = $matcher; $pos = $this->pos;
-    														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     														if ($subres !== FALSE) {
     															$this->store( $result, $subres );
     															$_27 = TRUE; break;
@@ -336,7 +336,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     															$res_22 = $result;
     															$pos_22 = $this->pos;
     															$matcher = 'match_'.'Injection'; $key = $matcher; $pos = $this->pos;
-    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     															if ($subres !== FALSE) {
     																$this->store( $result, $subres );
     																$_25 = TRUE; break;
@@ -344,7 +344,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     															$result = $res_22;
     															$this->pos = $pos_22;
     															$matcher = 'match_'.'Text'; $key = $matcher; $pos = $this->pos;
-    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     															if ($subres !== FALSE) {
     																$this->store( $result, $subres );
     																$_25 = TRUE; break;
@@ -445,8 +445,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* Word: / [A-Za-z_] [A-Za-z0-9_]* / */
-    protected $match_Word_typestack = ['Word'];
-    function match_Word ($stack = []) {
+    protected $match_Word_typestack = array('Word');
+    function match_Word ($stack = array()) {
     	$matchrule = "Word"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [A-Za-z_] [A-Za-z0-9_]* /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -457,8 +457,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* NamespacedWord: / [A-Za-z_\/\\] [A-Za-z0-9_\/\\]* / */
-    protected $match_NamespacedWord_typestack = ['NamespacedWord'];
-    function match_NamespacedWord ($stack = []) {
+    protected $match_NamespacedWord_typestack = array('NamespacedWord');
+    function match_NamespacedWord ($stack = array()) {
     	$matchrule = "NamespacedWord"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [A-Za-z_\/\\\\] [A-Za-z0-9_\/\\\\]* /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -469,8 +469,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Number: / [0-9]+ / */
-    protected $match_Number_typestack = ['Number'];
-    function match_Number ($stack = []) {
+    protected $match_Number_typestack = array('Number');
+    function match_Number ($stack = array()) {
     	$matchrule = "Number"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [0-9]+ /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -481,8 +481,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Value: / [A-Za-z0-9_]+ / */
-    protected $match_Value_typestack = ['Value'];
-    function match_Value ($stack = []) {
+    protected $match_Value_typestack = array('Value');
+    function match_Value ($stack = array()) {
     	$matchrule = "Value"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [A-Za-z0-9_]+ /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -493,13 +493,13 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* CallArguments: :Argument ( < "," < :Argument )* */
-    protected $match_CallArguments_typestack = ['CallArguments'];
-    function match_CallArguments ($stack = []) {
+    protected $match_CallArguments_typestack = array('CallArguments');
+    function match_CallArguments ($stack = array()) {
     	$matchrule = "CallArguments"; $result = $this->construct($matchrule, $matchrule, null);
     	$_62 = NULL;
     	do {
     		$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Argument" );
     		}
@@ -517,7 +517,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				else { $_60 = FALSE; break; }
     				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     				$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "Argument" );
     				}
@@ -558,13 +558,13 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* Call: Method:Word ( "(" < :CallArguments? > ")" )? */
-    protected $match_Call_typestack = ['Call'];
-    function match_Call ($stack = []) {
+    protected $match_Call_typestack = array('Call');
+    function match_Call ($stack = array()) {
     	$matchrule = "Call"; $result = $this->construct($matchrule, $matchrule, null);
     	$_72 = NULL;
     	do {
     		$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Method" );
     		}
@@ -582,7 +582,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$res_67 = $result;
     			$pos_67 = $this->pos;
     			$matcher = 'match_'.'CallArguments'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "CallArguments" );
     			}
@@ -616,13 +616,13 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* LookupStep: :Call &"." */
-    protected $match_LookupStep_typestack = ['LookupStep'];
-    function match_LookupStep ($stack = []) {
+    protected $match_LookupStep_typestack = array('LookupStep');
+    function match_LookupStep ($stack = array()) {
     	$matchrule = "LookupStep"; $result = $this->construct($matchrule, $matchrule, null);
     	$_76 = NULL;
     	do {
     		$matcher = 'match_'.'Call'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Call" );
     		}
@@ -649,11 +649,11 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* LastLookupStep: :Call */
-    protected $match_LastLookupStep_typestack = ['LastLookupStep'];
-    function match_LastLookupStep ($stack = []) {
+    protected $match_LastLookupStep_typestack = array('LastLookupStep');
+    function match_LastLookupStep ($stack = array()) {
     	$matchrule = "LastLookupStep"; $result = $this->construct($matchrule, $matchrule, null);
     	$matcher = 'match_'.'Call'; $key = $matcher; $pos = $this->pos;
-    	$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    	$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     	if ($subres !== FALSE) {
     		$this->store( $result, $subres, "Call" );
     		return $this->finalise($result);
@@ -663,8 +663,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Lookup: LookupStep ("." LookupStep)* "." LastLookupStep | LastLookupStep */
-    protected $match_Lookup_typestack = ['Lookup'];
-    function match_Lookup ($stack = []) {
+    protected $match_Lookup_typestack = array('Lookup');
+    function match_Lookup ($stack = array()) {
     	$matchrule = "Lookup"; $result = $this->construct($matchrule, $matchrule, null);
     	$_90 = NULL;
     	do {
@@ -673,7 +673,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_87 = NULL;
     		do {
     			$matcher = 'match_'.'LookupStep'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -689,7 +689,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					}
     					else { $_83 = FALSE; break; }
     					$matcher = 'match_'.'LookupStep'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     					}
@@ -711,7 +711,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			}
     			else { $_87 = FALSE; break; }
     			$matcher = 'match_'.'LastLookupStep'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -723,7 +723,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$result = $res_79;
     		$this->pos = $pos_79;
     		$matcher = 'match_'.'LastLookupStep'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_90 = TRUE; break;
@@ -758,7 +758,7 @@ class SSTemplateParser extends Parser implements TemplateParser
         $property = $sub['Call']['Method']['text'];
 
         if (isset($sub['Call']['CallArguments']) && $arguments = $sub['Call']['CallArguments']['php']) {
-            $res['php'] .= "->$method('$property', array($arguments), true)";
+            $res['php'] .= "->$method('$property', [$arguments], true)";
         } else {
             $res['php'] .= "->$method('$property', null, true)";
         }
@@ -777,8 +777,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* Translate: "<%t" < Entity < (Default:QuotedString)? < (!("is" "=") < "is" < Context:QuotedString)? <
     (InjectionVariables)? > "%>" */
-    protected $match_Translate_typestack = ['Translate'];
-    function match_Translate ($stack = []) {
+    protected $match_Translate_typestack = array('Translate');
+    function match_Translate ($stack = array()) {
     	$matchrule = "Translate"; $result = $this->construct($matchrule, $matchrule, null);
     	$_116 = NULL;
     	do {
@@ -786,7 +786,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		else { $_116 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'Entity'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -797,7 +797,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_97 = NULL;
     		do {
     			$matcher = 'match_'.'QuotedString'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "Default" );
     			}
@@ -844,7 +844,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			else { $_108 = FALSE; break; }
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			$matcher = 'match_'.'QuotedString'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "Context" );
     			}
@@ -864,7 +864,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_112 = NULL;
     		do {
     			$matcher = 'match_'.'InjectionVariables'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -890,8 +890,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* InjectionVariables: (< InjectionName:Word "=" Argument)+ */
-    protected $match_InjectionVariables_typestack = ['InjectionVariables'];
-    function match_InjectionVariables ($stack = []) {
+    protected $match_InjectionVariables_typestack = array('InjectionVariables');
+    function match_InjectionVariables ($stack = array()) {
     	$matchrule = "InjectionVariables"; $result = $this->construct($matchrule, $matchrule, null);
     	$count = 0;
     	while (true) {
@@ -901,7 +901,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		do {
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "InjectionName" );
     			}
@@ -912,7 +912,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			}
     			else { $_122 = FALSE; break; }
     			$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -935,8 +935,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Entity: / [A-Za-z_\\] [\w\.\\]* / */
-    protected $match_Entity_typestack = ['Entity'];
-    function match_Entity ($stack = []) {
+    protected $match_Entity_typestack = array('Entity');
+    function match_Entity ($stack = array()) {
     	$matchrule = "Entity"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [A-Za-z_\\\\] [\w\.\\\\]* /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -980,7 +980,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     function InjectionVariables__construct(&$res)
     {
-        $res['php'] = "array(";
+        $res['php'] = "[";
     }
 
     function InjectionVariables_InjectionName(&$res, $sub)
@@ -998,13 +998,13 @@ class SSTemplateParser extends Parser implements TemplateParser
         if (substr($res['php'], -1) == ',') {
             $res['php'] = substr($res['php'], 0, -1); //remove last comma in the array
         }
-        $res['php'] .= ')';
+        $res['php'] .= ']';
     }
 
 
     /* SimpleInjection: '$' :Lookup */
-    protected $match_SimpleInjection_typestack = ['SimpleInjection'];
-    function match_SimpleInjection ($stack = []) {
+    protected $match_SimpleInjection_typestack = array('SimpleInjection');
+    function match_SimpleInjection ($stack = array()) {
     	$matchrule = "SimpleInjection"; $result = $this->construct($matchrule, $matchrule, null);
     	$_127 = NULL;
     	do {
@@ -1014,7 +1014,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		}
     		else { $_127 = FALSE; break; }
     		$matcher = 'match_'.'Lookup'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Lookup" );
     		}
@@ -1028,15 +1028,15 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* BracketInjection: '{$' :Lookup "}" */
-    protected $match_BracketInjection_typestack = ['BracketInjection'];
-    function match_BracketInjection ($stack = []) {
+    protected $match_BracketInjection_typestack = array('BracketInjection');
+    function match_BracketInjection ($stack = array()) {
     	$matchrule = "BracketInjection"; $result = $this->construct($matchrule, $matchrule, null);
     	$_132 = NULL;
     	do {
     		if (( $subres = $this->literal( '{$' ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_132 = FALSE; break; }
     		$matcher = 'match_'.'Lookup'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Lookup" );
     		}
@@ -1055,15 +1055,15 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Injection: BracketInjection | SimpleInjection */
-    protected $match_Injection_typestack = ['Injection'];
-    function match_Injection ($stack = []) {
+    protected $match_Injection_typestack = array('Injection');
+    function match_Injection ($stack = array()) {
     	$matchrule = "Injection"; $result = $this->construct($matchrule, $matchrule, null);
     	$_137 = NULL;
     	do {
     		$res_134 = $result;
     		$pos_134 = $this->pos;
     		$matcher = 'match_'.'BracketInjection'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_137 = TRUE; break;
@@ -1071,7 +1071,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$result = $res_134;
     		$this->pos = $pos_134;
     		$matcher = 'match_'.'SimpleInjection'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_137 = TRUE; break;
@@ -1093,11 +1093,11 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* DollarMarkedLookup: SimpleInjection */
-    protected $match_DollarMarkedLookup_typestack = ['DollarMarkedLookup'];
-    function match_DollarMarkedLookup ($stack = []) {
+    protected $match_DollarMarkedLookup_typestack = array('DollarMarkedLookup');
+    function match_DollarMarkedLookup ($stack = array()) {
     	$matchrule = "DollarMarkedLookup"; $result = $this->construct($matchrule, $matchrule, null);
     	$matcher = 'match_'.'SimpleInjection'; $key = $matcher; $pos = $this->pos;
-    	$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    	$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     	if ($subres !== FALSE) {
     		$this->store( $result, $subres );
     		return $this->finalise($result);
@@ -1113,12 +1113,12 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* QuotedString: q:/['"]/   String:/ (\\\\ | \\. | [^$q\\])* /   '$q' */
-    protected $match_QuotedString_typestack = ['QuotedString'];
-    function match_QuotedString ($stack = []) {
+    protected $match_QuotedString_typestack = array('QuotedString');
+    function match_QuotedString ($stack = array()) {
     	$matchrule = "QuotedString"; $result = $this->construct($matchrule, $matchrule, null);
     	$_143 = NULL;
     	do {
-    		$stack[] = $result; $result = $this->construct( $matchrule, "q" );
+    		$stack[] = $result; $result = $this->construct( $matchrule, "q" ); 
     		if (( $subres = $this->rx( '/[\'"]/' ) ) !== FALSE) {
     			$result["text"] .= $subres;
     			$subres = $result; $result = array_pop($stack);
@@ -1128,7 +1128,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$result = array_pop($stack);
     			$_143 = FALSE; break;
     		}
-    		$stack[] = $result; $result = $this->construct( $matchrule, "String" );
+    		$stack[] = $result; $result = $this->construct( $matchrule, "String" ); 
     		if (( $subres = $this->rx( '/ (\\\\\\\\ | \\\\. | [^'.$this->expression($result, $stack, 'q').'\\\\])* /' ) ) !== FALSE) {
     			$result["text"] .= $subres;
     			$subres = $result; $result = array_pop($stack);
@@ -1149,8 +1149,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* FreeString: /[^,)%!=><|&]+/ */
-    protected $match_FreeString_typestack = ['FreeString'];
-    function match_FreeString ($stack = []) {
+    protected $match_FreeString_typestack = array('FreeString');
+    function match_FreeString ($stack = array()) {
     	$matchrule = "FreeString"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/[^,)%!=><|&]+/' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -1165,15 +1165,15 @@ class SSTemplateParser extends Parser implements TemplateParser
     :QuotedString |
     :Lookup !(< FreeString)|
     :FreeString */
-    protected $match_Argument_typestack = ['Argument'];
-    function match_Argument ($stack = []) {
+    protected $match_Argument_typestack = array('Argument');
+    function match_Argument ($stack = array()) {
     	$matchrule = "Argument"; $result = $this->construct($matchrule, $matchrule, null);
     	$_163 = NULL;
     	do {
     		$res_146 = $result;
     		$pos_146 = $this->pos;
     		$matcher = 'match_'.'DollarMarkedLookup'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "DollarMarkedLookup" );
     			$_163 = TRUE; break;
@@ -1185,7 +1185,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$res_148 = $result;
     			$pos_148 = $this->pos;
     			$matcher = 'match_'.'QuotedString'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "QuotedString" );
     				$_161 = TRUE; break;
@@ -1199,7 +1199,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$_156 = NULL;
     				do {
     					$matcher = 'match_'.'Lookup'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres, "Lookup" );
     					}
@@ -1210,7 +1210,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					do {
     						if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     						$matcher = 'match_'.'FreeString'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     						}
@@ -1234,7 +1234,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$result = $res_150;
     				$this->pos = $pos_150;
     				$matcher = 'match_'.'FreeString'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "FreeString" );
     					$_159 = TRUE; break;
@@ -1308,8 +1308,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* ComparisonOperator: "!=" | "==" | ">=" | ">" | "<=" | "<" | "=" */
-    protected $match_ComparisonOperator_typestack = ['ComparisonOperator'];
-    function match_ComparisonOperator ($stack = []) {
+    protected $match_ComparisonOperator_typestack = array('ComparisonOperator');
+    function match_ComparisonOperator ($stack = array()) {
     	$matchrule = "ComparisonOperator"; $result = $this->construct($matchrule, $matchrule, null);
     	$_188 = NULL;
     	do {
@@ -1419,27 +1419,27 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Comparison: Argument < ComparisonOperator > Argument */
-    protected $match_Comparison_typestack = ['Comparison'];
-    function match_Comparison ($stack = []) {
+    protected $match_Comparison_typestack = array('Comparison');
+    function match_Comparison ($stack = array()) {
     	$matchrule = "Comparison"; $result = $this->construct($matchrule, $matchrule, null);
     	$_195 = NULL;
     	do {
     		$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
     		else { $_195 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'ComparisonOperator'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
     		else { $_195 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -1472,8 +1472,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* PresenceCheck: (Not:'not' <)? Argument */
-    protected $match_PresenceCheck_typestack = ['PresenceCheck'];
-    function match_PresenceCheck ($stack = []) {
+    protected $match_PresenceCheck_typestack = array('PresenceCheck');
+    function match_PresenceCheck ($stack = array()) {
     	$matchrule = "PresenceCheck"; $result = $this->construct($matchrule, $matchrule, null);
     	$_202 = NULL;
     	do {
@@ -1481,7 +1481,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$pos_200 = $this->pos;
     		$_199 = NULL;
     		do {
-    			$stack[] = $result; $result = $this->construct( $matchrule, "Not" );
+    			$stack[] = $result; $result = $this->construct( $matchrule, "Not" ); 
     			if (( $subres = $this->literal( 'not' ) ) !== FALSE) {
     				$result["text"] .= $subres;
     				$subres = $result; $result = array_pop($stack);
@@ -1502,7 +1502,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			unset( $pos_200 );
     		}
     		$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -1534,15 +1534,15 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* IfArgumentPortion: Comparison | PresenceCheck */
-    protected $match_IfArgumentPortion_typestack = ['IfArgumentPortion'];
-    function match_IfArgumentPortion ($stack = []) {
+    protected $match_IfArgumentPortion_typestack = array('IfArgumentPortion');
+    function match_IfArgumentPortion ($stack = array()) {
     	$matchrule = "IfArgumentPortion"; $result = $this->construct($matchrule, $matchrule, null);
     	$_207 = NULL;
     	do {
     		$res_204 = $result;
     		$pos_204 = $this->pos;
     		$matcher = 'match_'.'Comparison'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_207 = TRUE; break;
@@ -1550,7 +1550,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$result = $res_204;
     		$this->pos = $pos_204;
     		$matcher = 'match_'.'PresenceCheck'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_207 = TRUE; break;
@@ -1572,8 +1572,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* BooleanOperator: "||" | "&&" */
-    protected $match_BooleanOperator_typestack = ['BooleanOperator'];
-    function match_BooleanOperator ($stack = []) {
+    protected $match_BooleanOperator_typestack = array('BooleanOperator');
+    function match_BooleanOperator ($stack = array()) {
     	$matchrule = "BooleanOperator"; $result = $this->construct($matchrule, $matchrule, null);
     	$_212 = NULL;
     	do {
@@ -1600,13 +1600,13 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* IfArgument: :IfArgumentPortion ( < :BooleanOperator < :IfArgumentPortion )* */
-    protected $match_IfArgument_typestack = ['IfArgument'];
-    function match_IfArgument ($stack = []) {
+    protected $match_IfArgument_typestack = array('IfArgument');
+    function match_IfArgument ($stack = array()) {
     	$matchrule = "IfArgument"; $result = $this->construct($matchrule, $matchrule, null);
     	$_221 = NULL;
     	do {
     		$matcher = 'match_'.'IfArgumentPortion'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "IfArgumentPortion" );
     		}
@@ -1618,14 +1618,14 @@ class SSTemplateParser extends Parser implements TemplateParser
     			do {
     				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     				$matcher = 'match_'.'BooleanOperator'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "BooleanOperator" );
     				}
     				else { $_219 = FALSE; break; }
     				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     				$matcher = 'match_'.'IfArgumentPortion'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "IfArgumentPortion" );
     				}
@@ -1661,8 +1661,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* IfPart: '<%' < 'if' [ :IfArgument > '%>' Template:$TemplateMatcher? */
-    protected $match_IfPart_typestack = ['IfPart'];
-    function match_IfPart ($stack = []) {
+    protected $match_IfPart_typestack = array('IfPart');
+    function match_IfPart ($stack = array()) {
     	$matchrule = "IfPart"; $result = $this->construct($matchrule, $matchrule, null);
     	$_231 = NULL;
     	do {
@@ -1674,7 +1674,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_231 = FALSE; break; }
     		$matcher = 'match_'.'IfArgument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "IfArgument" );
     		}
@@ -1685,7 +1685,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_230 = $result;
     		$pos_230 = $this->pos;
     		$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Template" );
     		}
@@ -1704,8 +1704,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* ElseIfPart: '<%' < 'else_if' [ :IfArgument > '%>' Template:$TemplateMatcher? */
-    protected $match_ElseIfPart_typestack = ['ElseIfPart'];
-    function match_ElseIfPart ($stack = []) {
+    protected $match_ElseIfPart_typestack = array('ElseIfPart');
+    function match_ElseIfPart ($stack = array()) {
     	$matchrule = "ElseIfPart"; $result = $this->construct($matchrule, $matchrule, null);
     	$_241 = NULL;
     	do {
@@ -1717,7 +1717,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_241 = FALSE; break; }
     		$matcher = 'match_'.'IfArgument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "IfArgument" );
     		}
@@ -1728,7 +1728,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_240 = $result;
     		$pos_240 = $this->pos;
     		$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Template" );
     		}
@@ -1747,8 +1747,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* ElsePart: '<%' < 'else' > '%>' Template:$TemplateMatcher? */
-    protected $match_ElsePart_typestack = ['ElsePart'];
-    function match_ElsePart ($stack = []) {
+    protected $match_ElsePart_typestack = array('ElsePart');
+    function match_ElsePart ($stack = array()) {
     	$matchrule = "ElsePart"; $result = $this->construct($matchrule, $matchrule, null);
     	$_249 = NULL;
     	do {
@@ -1763,7 +1763,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_248 = $result;
     		$pos_248 = $this->pos;
     		$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Template" );
     		}
@@ -1782,13 +1782,13 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* If: IfPart ElseIfPart* ElsePart? '<%' < 'end_if' > '%>' */
-    protected $match_If_typestack = ['If'];
-    function match_If ($stack = []) {
+    protected $match_If_typestack = array('If');
+    function match_If ($stack = array()) {
     	$matchrule = "If"; $result = $this->construct($matchrule, $matchrule, null);
     	$_259 = NULL;
     	do {
     		$matcher = 'match_'.'IfPart'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -1797,7 +1797,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$res_252 = $result;
     			$pos_252 = $this->pos;
     			$matcher = 'match_'.'ElseIfPart'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -1812,7 +1812,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_253 = $result;
     		$pos_253 = $this->pos;
     		$matcher = 'match_'.'ElsePart'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -1864,8 +1864,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* Require: '<%' < 'require' [ Call:(Method:Word "(" < :CallArguments  > ")") > '%>' */
-    protected $match_Require_typestack = ['Require'];
-    function match_Require ($stack = []) {
+    protected $match_Require_typestack = array('Require');
+    function match_Require ($stack = array()) {
     	$matchrule = "Require"; $result = $this->construct($matchrule, $matchrule, null);
     	$_275 = NULL;
     	do {
@@ -1876,11 +1876,11 @@ class SSTemplateParser extends Parser implements TemplateParser
     		else { $_275 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_275 = FALSE; break; }
-    		$stack[] = $result; $result = $this->construct( $matchrule, "Call" );
+    		$stack[] = $result; $result = $this->construct( $matchrule, "Call" ); 
     		$_271 = NULL;
     		do {
     			$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "Method" );
     			}
@@ -1892,7 +1892,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			else { $_271 = FALSE; break; }
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			$matcher = 'match_'.'CallArguments'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "CallArguments" );
     			}
@@ -1940,8 +1940,8 @@ class SSTemplateParser extends Parser implements TemplateParser
         :QuotedString |
         :Lookup
     ) */
-    protected $match_CacheBlockArgument_typestack = ['CacheBlockArgument'];
-    function match_CacheBlockArgument ($stack = []) {
+    protected $match_CacheBlockArgument_typestack = array('CacheBlockArgument');
+    function match_CacheBlockArgument ($stack = array()) {
     	$matchrule = "CacheBlockArgument"; $result = $this->construct($matchrule, $matchrule, null);
     	$_295 = NULL;
     	do {
@@ -1988,7 +1988,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$res_284 = $result;
     				$pos_284 = $this->pos;
     				$matcher = 'match_'.'DollarMarkedLookup'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "DollarMarkedLookup" );
     					$_291 = TRUE; break;
@@ -2000,7 +2000,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$res_286 = $result;
     					$pos_286 = $this->pos;
     					$matcher = 'match_'.'QuotedString'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres, "QuotedString" );
     						$_289 = TRUE; break;
@@ -2008,7 +2008,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$result = $res_286;
     					$this->pos = $pos_286;
     					$matcher = 'match_'.'Lookup'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres, "Lookup" );
     						$_289 = TRUE; break;
@@ -2054,13 +2054,13 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* CacheBlockArguments: CacheBlockArgument ( < "," < CacheBlockArgument )* */
-    protected $match_CacheBlockArguments_typestack = ['CacheBlockArguments'];
-    function match_CacheBlockArguments ($stack = []) {
+    protected $match_CacheBlockArguments_typestack = array('CacheBlockArguments');
+    function match_CacheBlockArguments ($stack = array()) {
     	$matchrule = "CacheBlockArguments"; $result = $this->construct($matchrule, $matchrule, null);
     	$_304 = NULL;
     	do {
     		$matcher = 'match_'.'CacheBlockArgument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -2078,7 +2078,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				else { $_302 = FALSE; break; }
     				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     				$matcher = 'match_'.'CacheBlockArgument'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres );
     				}
@@ -2116,9 +2116,9 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* CacheBlockTemplate: (Comment | Translate | If | Require |    OldI18NTag | Include | ClosedBlock |
     OpenBlock | MalformedBlock | Injection | Text)+ */
-    protected $match_CacheBlockTemplate_typestack = ['CacheBlockTemplate','Template'];
-    function match_CacheBlockTemplate ($stack = []) {
-    	$matchrule = "CacheBlockTemplate"; $result = $this->construct($matchrule, $matchrule, ['TemplateMatcher' => 'CacheRestrictedTemplate']);
+    protected $match_CacheBlockTemplate_typestack = array('CacheBlockTemplate','Template');
+    function match_CacheBlockTemplate ($stack = array()) {
+    	$matchrule = "CacheBlockTemplate"; $result = $this->construct($matchrule, $matchrule, array('TemplateMatcher' => 'CacheRestrictedTemplate'));
     	$count = 0;
     	while (true) {
     		$res_348 = $result;
@@ -2130,7 +2130,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$res_306 = $result;
     				$pos_306 = $this->pos;
     				$matcher = 'match_'.'Comment'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres );
     					$_345 = TRUE; break;
@@ -2142,7 +2142,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$res_308 = $result;
     					$pos_308 = $this->pos;
     					$matcher = 'match_'.'Translate'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     						$_343 = TRUE; break;
@@ -2154,7 +2154,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     						$res_310 = $result;
     						$pos_310 = $this->pos;
     						$matcher = 'match_'.'If'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     							$_341 = TRUE; break;
@@ -2166,7 +2166,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     							$res_312 = $result;
     							$pos_312 = $this->pos;
     							$matcher = 'match_'.'Require'; $key = $matcher; $pos = $this->pos;
-    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     							if ($subres !== FALSE) {
     								$this->store( $result, $subres );
     								$_339 = TRUE; break;
@@ -2178,7 +2178,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     								$res_314 = $result;
     								$pos_314 = $this->pos;
     								$matcher = 'match_'.'OldI18NTag'; $key = $matcher; $pos = $this->pos;
-    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     								if ($subres !== FALSE) {
     									$this->store( $result, $subres );
     									$_337 = TRUE; break;
@@ -2190,7 +2190,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     									$res_316 = $result;
     									$pos_316 = $this->pos;
     									$matcher = 'match_'.'Include'; $key = $matcher; $pos = $this->pos;
-    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     									if ($subres !== FALSE) {
     										$this->store( $result, $subres );
     										$_335 = TRUE; break;
@@ -2202,7 +2202,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     										$res_318 = $result;
     										$pos_318 = $this->pos;
     										$matcher = 'match_'.'ClosedBlock'; $key = $matcher; $pos = $this->pos;
-    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     										if ($subres !== FALSE) {
     											$this->store( $result, $subres );
     											$_333 = TRUE; break;
@@ -2214,7 +2214,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     											$res_320 = $result;
     											$pos_320 = $this->pos;
     											$matcher = 'match_'.'OpenBlock'; $key = $matcher; $pos = $this->pos;
-    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     											if ($subres !== FALSE) {
     												$this->store( $result, $subres );
     												$_331 = TRUE; break;
@@ -2226,7 +2226,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     												$res_322 = $result;
     												$pos_322 = $this->pos;
     												$matcher = 'match_'.'MalformedBlock'; $key = $matcher; $pos = $this->pos;
-    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     												if ($subres !== FALSE) {
     													$this->store( $result, $subres );
     													$_329 = TRUE; break;
@@ -2238,7 +2238,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     													$res_324 = $result;
     													$pos_324 = $this->pos;
     													$matcher = 'match_'.'Injection'; $key = $matcher; $pos = $this->pos;
-    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     													if ($subres !== FALSE) {
     														$this->store( $result, $subres );
     														$_327 = TRUE; break;
@@ -2246,7 +2246,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     													$result = $res_324;
     													$this->pos = $pos_324;
     													$matcher = 'match_'.'Text'; $key = $matcher; $pos = $this->pos;
-    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     													if ($subres !== FALSE) {
     														$this->store( $result, $subres );
     														$_327 = TRUE; break;
@@ -2334,8 +2334,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     '<%' < "uncached" < CacheBlockArguments? ( < Conditional:("if"|"unless") > Condition:IfArgument )? > '%>'
         Template:$TemplateMatcher?
         '<%' < 'end_' ("uncached"|"cached"|"cacheblock") > '%>' */
-    protected $match_UncachedBlock_typestack = ['UncachedBlock'];
-    function match_UncachedBlock ($stack = []) {
+    protected $match_UncachedBlock_typestack = array('UncachedBlock');
+    function match_UncachedBlock ($stack = array()) {
     	$matchrule = "UncachedBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_385 = NULL;
     	do {
@@ -2348,7 +2348,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_353 = $result;
     		$pos_353 = $this->pos;
     		$matcher = 'match_'.'CacheBlockArguments'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -2363,7 +2363,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_364 = NULL;
     		do {
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-    			$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" );
+    			$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" ); 
     			$_360 = NULL;
     			do {
     				$_358 = NULL;
@@ -2399,7 +2399,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			}
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			$matcher = 'match_'.'IfArgument'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "Condition" );
     			}
@@ -2419,7 +2419,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_368 = $result;
     		$pos_368 = $this->pos;
     		$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Template" );
     		}
@@ -2495,8 +2495,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* CacheRestrictedTemplate: (Comment | Translate | If | Require | CacheBlock | UncachedBlock | OldI18NTag | Include | ClosedBlock |
     OpenBlock | MalformedBlock | Injection | Text)+ */
-    protected $match_CacheRestrictedTemplate_typestack = ['CacheRestrictedTemplate','Template'];
-    function match_CacheRestrictedTemplate ($stack = []) {
+    protected $match_CacheRestrictedTemplate_typestack = array('CacheRestrictedTemplate','Template');
+    function match_CacheRestrictedTemplate ($stack = array()) {
     	$matchrule = "CacheRestrictedTemplate"; $result = $this->construct($matchrule, $matchrule, null);
     	$count = 0;
     	while (true) {
@@ -2509,7 +2509,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$res_387 = $result;
     				$pos_387 = $this->pos;
     				$matcher = 'match_'.'Comment'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres );
     					$_434 = TRUE; break;
@@ -2521,7 +2521,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$res_389 = $result;
     					$pos_389 = $this->pos;
     					$matcher = 'match_'.'Translate'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     						$_432 = TRUE; break;
@@ -2533,7 +2533,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     						$res_391 = $result;
     						$pos_391 = $this->pos;
     						$matcher = 'match_'.'If'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     							$_430 = TRUE; break;
@@ -2545,7 +2545,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     							$res_393 = $result;
     							$pos_393 = $this->pos;
     							$matcher = 'match_'.'Require'; $key = $matcher; $pos = $this->pos;
-    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     							if ($subres !== FALSE) {
     								$this->store( $result, $subres );
     								$_428 = TRUE; break;
@@ -2557,7 +2557,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     								$res_395 = $result;
     								$pos_395 = $this->pos;
     								$matcher = 'match_'.'CacheBlock'; $key = $matcher; $pos = $this->pos;
-    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     								if ($subres !== FALSE) {
     									$this->store( $result, $subres );
     									$_426 = TRUE; break;
@@ -2569,7 +2569,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     									$res_397 = $result;
     									$pos_397 = $this->pos;
     									$matcher = 'match_'.'UncachedBlock'; $key = $matcher; $pos = $this->pos;
-    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     									if ($subres !== FALSE) {
     										$this->store( $result, $subres );
     										$_424 = TRUE; break;
@@ -2581,7 +2581,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     										$res_399 = $result;
     										$pos_399 = $this->pos;
     										$matcher = 'match_'.'OldI18NTag'; $key = $matcher; $pos = $this->pos;
-    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     										if ($subres !== FALSE) {
     											$this->store( $result, $subres );
     											$_422 = TRUE; break;
@@ -2593,7 +2593,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     											$res_401 = $result;
     											$pos_401 = $this->pos;
     											$matcher = 'match_'.'Include'; $key = $matcher; $pos = $this->pos;
-    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     											if ($subres !== FALSE) {
     												$this->store( $result, $subres );
     												$_420 = TRUE; break;
@@ -2605,7 +2605,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     												$res_403 = $result;
     												$pos_403 = $this->pos;
     												$matcher = 'match_'.'ClosedBlock'; $key = $matcher; $pos = $this->pos;
-    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     												if ($subres !== FALSE) {
     													$this->store( $result, $subres );
     													$_418 = TRUE; break;
@@ -2617,7 +2617,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     													$res_405 = $result;
     													$pos_405 = $this->pos;
     													$matcher = 'match_'.'OpenBlock'; $key = $matcher; $pos = $this->pos;
-    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     													if ($subres !== FALSE) {
     														$this->store( $result, $subres );
     														$_416 = TRUE; break;
@@ -2629,7 +2629,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     														$res_407 = $result;
     														$pos_407 = $this->pos;
     														$matcher = 'match_'.'MalformedBlock'; $key = $matcher; $pos = $this->pos;
-    														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     														if ($subres !== FALSE) {
     															$this->store( $result, $subres );
     															$_414 = TRUE; break;
@@ -2641,7 +2641,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     															$res_409 = $result;
     															$pos_409 = $this->pos;
     															$matcher = 'match_'.'Injection'; $key = $matcher; $pos = $this->pos;
-    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     															if ($subres !== FALSE) {
     																$this->store( $result, $subres );
     																$_412 = TRUE; break;
@@ -2649,7 +2649,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     															$result = $res_409;
     															$this->pos = $pos_409;
     															$matcher = 'match_'.'Text'; $key = $matcher; $pos = $this->pos;
-    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     															if ($subres !== FALSE) {
     																$this->store( $result, $subres );
     																$_412 = TRUE; break;
@@ -2761,15 +2761,15 @@ class SSTemplateParser extends Parser implements TemplateParser
     Condition:IfArgument )? > '%>'
         (CacheBlock | UncachedBlock | CacheBlockTemplate)*
     '<%' < 'end_' ("cached"|"uncached"|"cacheblock") > '%>' */
-    protected $match_CacheBlock_typestack = ['CacheBlock'];
-    function match_CacheBlock ($stack = []) {
+    protected $match_CacheBlock_typestack = array('CacheBlock');
+    function match_CacheBlock ($stack = array()) {
     	$matchrule = "CacheBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_492 = NULL;
     	do {
     		if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_492 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-    		$stack[] = $result; $result = $this->construct( $matchrule, "CacheTag" );
+    		$stack[] = $result; $result = $this->construct( $matchrule, "CacheTag" ); 
     		$_445 = NULL;
     		do {
     			$_443 = NULL;
@@ -2809,7 +2809,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_449 = NULL;
     		do {
     			$matcher = 'match_'.'CacheBlockArguments'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -2828,7 +2828,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_461 = NULL;
     		do {
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-    			$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" );
+    			$stack[] = $result; $result = $this->construct( $matchrule, "Conditional" ); 
     			$_457 = NULL;
     			do {
     				$_455 = NULL;
@@ -2864,7 +2864,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			}
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			$matcher = 'match_'.'IfArgument'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "Condition" );
     			}
@@ -2891,7 +2891,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$res_465 = $result;
     					$pos_465 = $this->pos;
     					$matcher = 'match_'.'CacheBlock'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     						$_472 = TRUE; break;
@@ -2903,7 +2903,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     						$res_467 = $result;
     						$pos_467 = $this->pos;
     						$matcher = 'match_'.'UncachedBlock'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     							$_470 = TRUE; break;
@@ -2911,7 +2911,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     						$result = $res_467;
     						$this->pos = $pos_467;
     						$matcher = 'match_'.'CacheBlockTemplate'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     							$_470 = TRUE; break;
@@ -3059,15 +3059,15 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* OldTPart: "_t" N "(" N QuotedString (N "," N CallArguments)? N ")" N (";")? */
-    protected $match_OldTPart_typestack = ['OldTPart'];
-    function match_OldTPart ($stack = []) {
+    protected $match_OldTPart_typestack = array('OldTPart');
+    function match_OldTPart ($stack = array()) {
     	$matchrule = "OldTPart"; $result = $this->construct($matchrule, $matchrule, null);
     	$_511 = NULL;
     	do {
     		if (( $subres = $this->literal( '_t' ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_511 = FALSE; break; }
     		$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3078,13 +3078,13 @@ class SSTemplateParser extends Parser implements TemplateParser
     		}
     		else { $_511 = FALSE; break; }
     		$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
     		else { $_511 = FALSE; break; }
     		$matcher = 'match_'.'QuotedString'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3094,7 +3094,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_503 = NULL;
     		do {
     			$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -3105,13 +3105,13 @@ class SSTemplateParser extends Parser implements TemplateParser
     			}
     			else { $_503 = FALSE; break; }
     			$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
     			else { $_503 = FALSE; break; }
     			$matcher = 'match_'.'CallArguments'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -3126,7 +3126,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			unset( $pos_504 );
     		}
     		$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3137,7 +3137,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		}
     		else { $_511 = FALSE; break; }
     		$matcher = 'match_'.'N'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3169,8 +3169,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* N: / [\s\n]* / */
-    protected $match_N_typestack = ['N'];
-    function match_N ($stack = []) {
+    protected $match_N_typestack = array('N');
+    function match_N ($stack = array()) {
     	$matchrule = "N"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [\s\n]* /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -3207,8 +3207,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* OldTTag: "<%" < OldTPart > "%>" */
-    protected $match_OldTTag_typestack = ['OldTTag'];
-    function match_OldTTag ($stack = []) {
+    protected $match_OldTTag_typestack = array('OldTTag');
+    function match_OldTTag ($stack = array()) {
     	$matchrule = "OldTTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_519 = NULL;
     	do {
@@ -3216,7 +3216,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		else { $_519 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'OldTPart'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3239,8 +3239,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* OldSprintfTag: "<%" < "sprintf" < "(" < OldTPart < "," < CallArguments > ")" > "%>" */
-    protected $match_OldSprintfTag_typestack = ['OldSprintfTag'];
-    function match_OldSprintfTag ($stack = []) {
+    protected $match_OldSprintfTag_typestack = array('OldSprintfTag');
+    function match_OldSprintfTag ($stack = array()) {
     	$matchrule = "OldSprintfTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_536 = NULL;
     	do {
@@ -3257,7 +3257,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		else { $_536 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'OldTPart'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3270,7 +3270,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		else { $_536 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'CallArguments'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     		}
@@ -3309,15 +3309,15 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* OldI18NTag: OldSprintfTag | OldTTag */
-    protected $match_OldI18NTag_typestack = ['OldI18NTag'];
-    function match_OldI18NTag ($stack = []) {
+    protected $match_OldI18NTag_typestack = array('OldI18NTag');
+    function match_OldI18NTag ($stack = array()) {
     	$matchrule = "OldI18NTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_541 = NULL;
     	do {
     		$res_538 = $result;
     		$pos_538 = $this->pos;
     		$matcher = 'match_'.'OldSprintfTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_541 = TRUE; break;
@@ -3325,7 +3325,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$result = $res_538;
     		$this->pos = $pos_538;
     		$matcher = 'match_'.'OldTTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_541 = TRUE; break;
@@ -3347,13 +3347,13 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* NamedArgument: Name:Word "=" Value:Argument */
-    protected $match_NamedArgument_typestack = ['NamedArgument'];
-    function match_NamedArgument ($stack = []) {
+    protected $match_NamedArgument_typestack = array('NamedArgument');
+    function match_NamedArgument ($stack = array()) {
     	$matchrule = "NamedArgument"; $result = $this->construct($matchrule, $matchrule, null);
     	$_546 = NULL;
     	do {
     		$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Name" );
     		}
@@ -3364,7 +3364,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		}
     		else { $_546 = FALSE; break; }
     		$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Value" );
     		}
@@ -3401,8 +3401,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* Include: "<%" < "include" < Template:NamespacedWord < (NamedArgument ( < "," < NamedArgument )*)? > "%>" */
-    protected $match_Include_typestack = ['Include'];
-    function match_Include ($stack = []) {
+    protected $match_Include_typestack = array('Include');
+    function match_Include ($stack = array()) {
     	$matchrule = "Include"; $result = $this->construct($matchrule, $matchrule, null);
     	$_565 = NULL;
     	do {
@@ -3413,7 +3413,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		else { $_565 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     		$matcher = 'match_'.'NamespacedWord'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Template" );
     		}
@@ -3424,7 +3424,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$_561 = NULL;
     		do {
     			$matcher = 'match_'.'NamedArgument'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres );
     			}
@@ -3442,7 +3442,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					else { $_559 = FALSE; break; }
     					if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     					$matcher = 'match_'.'NamedArgument'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     					}
@@ -3500,8 +3500,8 @@ class SSTemplateParser extends Parser implements TemplateParser
         $arguments = $res['arguments'];
 
         // Note: 'type' here is important to disable subTemplates in SSViewer::getSubtemplateFor()
-        $res['php'] = '$val .= \\SilverStripe\\View\\SSViewer::execute_template([["type" => "Includes", '.$template.'], '.$template.'], $scope->getItem(), array(' .
-            implode(',', $arguments)."), \$scope, true);\n";
+        $res['php'] = '$val .= \\SilverStripe\\View\\SSViewer::execute_template([["type" => "Includes", '.$template.'], '.$template.'], $scope->getItem(), [' .
+            implode(',', $arguments)."], \$scope, true);\n";
 
         if ($this->includeDebuggingComments) { // Add include filename comments on dev sites
             $res['php'] =
@@ -3512,13 +3512,13 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* BlockArguments: :Argument ( < "," < :Argument)* */
-    protected $match_BlockArguments_typestack = ['BlockArguments'];
-    function match_BlockArguments ($stack = []) {
+    protected $match_BlockArguments_typestack = array('BlockArguments');
+    function match_BlockArguments ($stack = array()) {
     	$matchrule = "BlockArguments"; $result = $this->construct($matchrule, $matchrule, null);
     	$_574 = NULL;
     	do {
     		$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Argument" );
     		}
@@ -3536,7 +3536,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				else { $_572 = FALSE; break; }
     				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     				$matcher = 'match_'.'Argument'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "Argument" );
     				}
@@ -3561,8 +3561,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* NotBlockTag: "end_" | (("if" | "else_if" | "else" | "require" | "cached" | "uncached" | "cacheblock" | "include")]) */
-    protected $match_NotBlockTag_typestack = ['NotBlockTag'];
-    function match_NotBlockTag ($stack = []) {
+    protected $match_NotBlockTag_typestack = array('NotBlockTag');
+    function match_NotBlockTag ($stack = array()) {
     	$matchrule = "NotBlockTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_612 = NULL;
     	do {
@@ -3716,8 +3716,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* ClosedBlock: '<%' < !NotBlockTag BlockName:Word ( [ :BlockArguments ] )? > Zap:'%>' Template:$TemplateMatcher?
     '<%' < 'end_' '$BlockName' > '%>' */
-    protected $match_ClosedBlock_typestack = ['ClosedBlock'];
-    function match_ClosedBlock ($stack = []) {
+    protected $match_ClosedBlock_typestack = array('ClosedBlock');
+    function match_ClosedBlock ($stack = array()) {
     	$matchrule = "ClosedBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_632 = NULL;
     	do {
@@ -3727,7 +3727,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_616 = $result;
     		$pos_616 = $this->pos;
     		$matcher = 'match_'.'NotBlockTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$result = $res_616;
@@ -3739,7 +3739,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$this->pos = $pos_616;
     		}
     		$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "BlockName" );
     		}
@@ -3751,7 +3751,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			else { $_621 = FALSE; break; }
     			$matcher = 'match_'.'BlockArguments'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "BlockArguments" );
     			}
@@ -3768,7 +3768,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			unset( $pos_622 );
     		}
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-    		$stack[] = $result; $result = $this->construct( $matchrule, "Zap" );
+    		$stack[] = $result; $result = $this->construct( $matchrule, "Zap" ); 
     		if (( $subres = $this->literal( '%>' ) ) !== FALSE) {
     			$result["text"] .= $subres;
     			$subres = $result; $result = array_pop($stack);
@@ -3781,7 +3781,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_625 = $result;
     		$pos_625 = $this->pos;
     		$matcher = 'match_'.$this->expression($result, $stack, 'TemplateMatcher'); $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Template" );
     		}
@@ -3910,8 +3910,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* OpenBlock: '<%' < !NotBlockTag BlockName:Word ( [ :BlockArguments ] )? > '%>' */
-    protected $match_OpenBlock_typestack = ['OpenBlock'];
-    function match_OpenBlock ($stack = []) {
+    protected $match_OpenBlock_typestack = array('OpenBlock');
+    function match_OpenBlock ($stack = array()) {
     	$matchrule = "OpenBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_645 = NULL;
     	do {
@@ -3921,7 +3921,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_636 = $result;
     		$pos_636 = $this->pos;
     		$matcher = 'match_'.'NotBlockTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$result = $res_636;
@@ -3933,7 +3933,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$this->pos = $pos_636;
     		}
     		$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "BlockName" );
     		}
@@ -3945,7 +3945,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     			else { $_641 = FALSE; break; }
     			$matcher = 'match_'.'BlockArguments'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "BlockArguments" );
     			}
@@ -4048,8 +4048,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* MismatchedEndBlock: '<%' < 'end_' :Word > '%>' */
-    protected $match_MismatchedEndBlock_typestack = ['MismatchedEndBlock'];
-    function match_MismatchedEndBlock ($stack = []) {
+    protected $match_MismatchedEndBlock_typestack = array('MismatchedEndBlock');
+    function match_MismatchedEndBlock ($stack = array()) {
     	$matchrule = "MismatchedEndBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_653 = NULL;
     	do {
@@ -4059,7 +4059,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		if (( $subres = $this->literal( 'end_' ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_653 = FALSE; break; }
     		$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Word" );
     		}
@@ -4084,8 +4084,8 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* MalformedOpenTag: '<%' < !NotBlockTag Tag:Word  !( ( [ :BlockArguments ] )? > '%>' ) */
-    protected $match_MalformedOpenTag_typestack = ['MalformedOpenTag'];
-    function match_MalformedOpenTag ($stack = []) {
+    protected $match_MalformedOpenTag_typestack = array('MalformedOpenTag');
+    function match_MalformedOpenTag ($stack = array()) {
     	$matchrule = "MalformedOpenTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_668 = NULL;
     	do {
@@ -4095,7 +4095,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$res_657 = $result;
     		$pos_657 = $this->pos;
     		$matcher = 'match_'.'NotBlockTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$result = $res_657;
@@ -4107,7 +4107,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     			$this->pos = $pos_657;
     		}
     		$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres, "Tag" );
     		}
@@ -4123,7 +4123,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
     				else { $_662 = FALSE; break; }
     				$matcher = 'match_'.'BlockArguments'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres, "BlockArguments" );
     				}
@@ -4170,21 +4170,21 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* MalformedCloseTag: '<%' < Tag:('end_' :Word ) !( > '%>' ) */
-    protected $match_MalformedCloseTag_typestack = ['MalformedCloseTag'];
-    function match_MalformedCloseTag ($stack = []) {
+    protected $match_MalformedCloseTag_typestack = array('MalformedCloseTag');
+    function match_MalformedCloseTag ($stack = array()) {
     	$matchrule = "MalformedCloseTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_680 = NULL;
     	do {
     		if (( $subres = $this->literal( '<%' ) ) !== FALSE) { $result["text"] .= $subres; }
     		else { $_680 = FALSE; break; }
     		if (( $subres = $this->whitespace(  ) ) !== FALSE) { $result["text"] .= $subres; }
-    		$stack[] = $result; $result = $this->construct( $matchrule, "Tag" );
+    		$stack[] = $result; $result = $this->construct( $matchrule, "Tag" ); 
     		$_674 = NULL;
     		do {
     			if (( $subres = $this->literal( 'end_' ) ) !== FALSE) { $result["text"] .= $subres; }
     			else { $_674 = FALSE; break; }
     			$matcher = 'match_'.'Word'; $key = $matcher; $pos = $this->pos;
-    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    			$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     			if ($subres !== FALSE) {
     				$this->store( $result, $subres, "Word" );
     			}
@@ -4236,15 +4236,15 @@ class SSTemplateParser extends Parser implements TemplateParser
     }
 
     /* MalformedBlock: MalformedOpenTag | MalformedCloseTag */
-    protected $match_MalformedBlock_typestack = ['MalformedBlock'];
-    function match_MalformedBlock ($stack = []) {
+    protected $match_MalformedBlock_typestack = array('MalformedBlock');
+    function match_MalformedBlock ($stack = array()) {
     	$matchrule = "MalformedBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_685 = NULL;
     	do {
     		$res_682 = $result;
     		$pos_682 = $this->pos;
     		$matcher = 'match_'.'MalformedOpenTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_685 = TRUE; break;
@@ -4252,7 +4252,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     		$result = $res_682;
     		$this->pos = $pos_682;
     		$matcher = 'match_'.'MalformedCloseTag'; $key = $matcher; $pos = $this->pos;
-    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    		$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     		if ($subres !== FALSE) {
     			$this->store( $result, $subres );
     			$_685 = TRUE; break;
@@ -4270,8 +4270,8 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
     /* Comment: "<%--" (!"--%>" /(?s)./)+ "--%>" */
-    protected $match_Comment_typestack = ['Comment'];
-    function match_Comment ($stack = []) {
+    protected $match_Comment_typestack = array('Comment');
+    function match_Comment ($stack = array()) {
     	$matchrule = "Comment"; $result = $this->construct($matchrule, $matchrule, null);
     	$_693 = NULL;
     	do {
@@ -4329,9 +4329,9 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* TopTemplate: (Comment | Translate | If | Require | CacheBlock | UncachedBlock | OldI18NTag | Include | ClosedBlock |
     OpenBlock |  MalformedBlock | MismatchedEndBlock  | Injection | Text)+ */
-    protected $match_TopTemplate_typestack = ['TopTemplate','Template'];
-    function match_TopTemplate ($stack = []) {
-    	$matchrule = "TopTemplate"; $result = $this->construct($matchrule, $matchrule, ['TemplateMatcher' => 'Template']);
+    protected $match_TopTemplate_typestack = array('TopTemplate','Template');
+    function match_TopTemplate ($stack = array()) {
+    	$matchrule = "TopTemplate"; $result = $this->construct($matchrule, $matchrule, array('TemplateMatcher' => 'Template'));
     	$count = 0;
     	while (true) {
     		$res_749 = $result;
@@ -4343,7 +4343,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     				$res_695 = $result;
     				$pos_695 = $this->pos;
     				$matcher = 'match_'.'Comment'; $key = $matcher; $pos = $this->pos;
-    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    				$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     				if ($subres !== FALSE) {
     					$this->store( $result, $subres );
     					$_746 = TRUE; break;
@@ -4355,7 +4355,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     					$res_697 = $result;
     					$pos_697 = $this->pos;
     					$matcher = 'match_'.'Translate'; $key = $matcher; $pos = $this->pos;
-    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    					$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     					if ($subres !== FALSE) {
     						$this->store( $result, $subres );
     						$_744 = TRUE; break;
@@ -4367,7 +4367,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     						$res_699 = $result;
     						$pos_699 = $this->pos;
     						$matcher = 'match_'.'If'; $key = $matcher; $pos = $this->pos;
-    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    						$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     						if ($subres !== FALSE) {
     							$this->store( $result, $subres );
     							$_742 = TRUE; break;
@@ -4379,7 +4379,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     							$res_701 = $result;
     							$pos_701 = $this->pos;
     							$matcher = 'match_'.'Require'; $key = $matcher; $pos = $this->pos;
-    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    							$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     							if ($subres !== FALSE) {
     								$this->store( $result, $subres );
     								$_740 = TRUE; break;
@@ -4391,7 +4391,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     								$res_703 = $result;
     								$pos_703 = $this->pos;
     								$matcher = 'match_'.'CacheBlock'; $key = $matcher; $pos = $this->pos;
-    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    								$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     								if ($subres !== FALSE) {
     									$this->store( $result, $subres );
     									$_738 = TRUE; break;
@@ -4403,7 +4403,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     									$res_705 = $result;
     									$pos_705 = $this->pos;
     									$matcher = 'match_'.'UncachedBlock'; $key = $matcher; $pos = $this->pos;
-    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    									$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     									if ($subres !== FALSE) {
     										$this->store( $result, $subres );
     										$_736 = TRUE; break;
@@ -4415,7 +4415,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     										$res_707 = $result;
     										$pos_707 = $this->pos;
     										$matcher = 'match_'.'OldI18NTag'; $key = $matcher; $pos = $this->pos;
-    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    										$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     										if ($subres !== FALSE) {
     											$this->store( $result, $subres );
     											$_734 = TRUE; break;
@@ -4427,7 +4427,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     											$res_709 = $result;
     											$pos_709 = $this->pos;
     											$matcher = 'match_'.'Include'; $key = $matcher; $pos = $this->pos;
-    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    											$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     											if ($subres !== FALSE) {
     												$this->store( $result, $subres );
     												$_732 = TRUE; break;
@@ -4439,7 +4439,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     												$res_711 = $result;
     												$pos_711 = $this->pos;
     												$matcher = 'match_'.'ClosedBlock'; $key = $matcher; $pos = $this->pos;
-    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    												$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     												if ($subres !== FALSE) {
     													$this->store( $result, $subres );
     													$_730 = TRUE; break;
@@ -4451,7 +4451,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     													$res_713 = $result;
     													$pos_713 = $this->pos;
     													$matcher = 'match_'.'OpenBlock'; $key = $matcher; $pos = $this->pos;
-    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    													$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     													if ($subres !== FALSE) {
     														$this->store( $result, $subres );
     														$_728 = TRUE; break;
@@ -4463,7 +4463,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     														$res_715 = $result;
     														$pos_715 = $this->pos;
     														$matcher = 'match_'.'MalformedBlock'; $key = $matcher; $pos = $this->pos;
-    														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    														$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     														if ($subres !== FALSE) {
     															$this->store( $result, $subres );
     															$_726 = TRUE; break;
@@ -4475,7 +4475,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     															$res_717 = $result;
     															$pos_717 = $this->pos;
     															$matcher = 'match_'.'MismatchedEndBlock'; $key = $matcher; $pos = $this->pos;
-    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    															$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     															if ($subres !== FALSE) {
     																$this->store( $result, $subres );
     																$_724 = TRUE; break;
@@ -4487,7 +4487,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     																$res_719 = $result;
     																$pos_719 = $this->pos;
     																$matcher = 'match_'.'Injection'; $key = $matcher; $pos = $this->pos;
-    																$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    																$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     																if ($subres !== FALSE) {
     																	$this->store( $result, $subres );
     																	$_722 = TRUE; break;
@@ -4495,7 +4495,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     																$result = $res_719;
     																$this->pos = $pos_719;
     																$matcher = 'match_'.'Text'; $key = $matcher; $pos = $this->pos;
-    																$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, [$result])) ) );
+    																$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
     																if ($subres !== FALSE) {
     																	$this->store( $result, $subres );
     																	$_722 = TRUE; break;
@@ -4615,8 +4615,8 @@ class SSTemplateParser extends Parser implements TemplateParser
         '{' !'$' |
         '{$' !(/[A-Za-z_]/)
     )+ */
-    protected $match_Text_typestack = ['Text'];
-    function match_Text ($stack = []) {
+    protected $match_Text_typestack = array('Text');
+    function match_Text ($stack = array()) {
     	$matchrule = "Text"; $result = $this->construct($matchrule, $matchrule, null);
     	$count = 0;
     	while (true) {

--- a/src/View/TemplateGlobalProvider.php
+++ b/src/View/TemplateGlobalProvider.php
@@ -27,7 +27,7 @@ interface TemplateGlobalProvider
      * @return array Returns an array of items. Each key => value pair is one of three forms:
      *  - template name (no key)
      *  - template name => method name
-     *  - template name => array(), where the array can contain these key => value pairs
+     *  - template name => [], where the array can contain these key => value pairs
      *     - "method" => method name
      *     - "casting" => casting class to use (i.e., Varchar, HTMLFragment, etc)
      */

--- a/tests/behat/travis-upload-artifacts.php
+++ b/tests/behat/travis-upload-artifacts.php
@@ -42,12 +42,12 @@ function checkenv($envs)
     return true;
 }
 
-$opts = getopt('', array(
+$opts = getopt('', [
     'artifacts-path:',
     'target-path:',
     'if-env:',
     'artifacts-base-url:',
-));
+]);
 
 // --if-env=BEHAT_TEST means that this script will only be executed if the given environment var is set
 if (empty($opts['if-env'])) {

--- a/tests/bootstrap/cli.php
+++ b/tests/bootstrap/cli.php
@@ -3,11 +3,11 @@
 // Fake the script name and base
 global $_SERVER;
 if (!$_SERVER) {
-    $_SERVER = array();
+    $_SERVER = [];
 }
 
 // We update the $_SERVER variable to contain data consistent with the rest of the application.
-$_SERVER = array_merge(array(
+$_SERVER = array_merge([
     'SERVER_PROTOCOL' => 'HTTP/1.1',
     'HTTP_ACCEPT' => 'text/plain;q=0.5',
     'HTTP_ACCEPT_LANGUAGE' => '*;q=0.5',
@@ -20,7 +20,7 @@ $_SERVER = array_merge(array(
     'REMOTE_ADDR' => '127.0.0.1',
     'REQUEST_METHOD' => 'GET',
     'HTTP_USER_AGENT' => 'CLI',
-), $_SERVER);
+], $_SERVER);
 
 $frameworkPath = dirname(dirname(__FILE__));
 $frameworkDir = basename($frameworkPath);
@@ -32,16 +32,16 @@ $_SERVER['SCRIPT_NAME'] = '.' . DIRECTORY_SEPARATOR . $frameworkDir . DIRECTORY_
 if (isset($_SERVER['argv'][2])) {
     $args = array_slice($_SERVER['argv'], 2);
     if (!isset($_GET)) {
-        $_GET = array();
+        $_GET = [];
     }
     if (!isset($_REQUEST)) {
-        $_REQUEST = array();
+        $_REQUEST = [];
     }
     foreach ($args as $arg) {
         if (strpos($arg, '=') == false) {
             $_GET['args'][] = $arg;
         } else {
-            $newItems = array();
+            $newItems = [];
             parse_str((substr($arg, 0, 2) == '--') ? substr($arg, 2) : $arg, $newItems);
             $_GET = array_merge($_GET, $newItems);
         }

--- a/tests/php/Control/ControllerTest/UnsecuredController.php
+++ b/tests/php/Control/ControllerTest/UnsecuredController.php
@@ -10,7 +10,7 @@ class UnsecuredController extends Controller implements TestOnly
     private static $url_segment = 'UnsecuredController';
 
     // Not defined, allow access to all
-    // static $allowed_actions = array();
+    // static $allowed_actions = [];
 
     // Granted for all
     public function method1()

--- a/tests/php/Core/ObjectTest.php
+++ b/tests/php/Core/ObjectTest.php
@@ -290,7 +290,7 @@ class ObjectTest extends SapphireTest
             $objectTest_ExtensionTest->hasExtension(ExtendTest3::class),
             "Extensions are detected with instance hasExtension() when added through add_extension()"
         );
-        
+
         // load in a custom implementation
         Injector::inst()->registerService(new ExtendTest5(), ExtendTest4::class);
         $this->assertTrue(

--- a/tests/php/Core/ObjectTest.php
+++ b/tests/php/Core/ObjectTest.php
@@ -441,7 +441,7 @@ class ObjectTest extends SapphireTest
         // True, false and null values
         $this->assertEquals(
             ['ClassName', ['string', true, ['string', false]]],
-            ClassInfo::parse_class_spec('ClassName("string", true, array("string", false))')
+            ClassInfo::parse_class_spec('ClassName("string", true, ["string", false])')
         );
         $this->assertEquals(
             ['ClassName', [true, false, null]],
@@ -451,7 +451,7 @@ class ObjectTest extends SapphireTest
         // Array
         $this->assertEquals(
             ['Enum', [['Accepted', 'Pending', 'Declined', 'Unsubmitted'], 'Unsubmitted']],
-            ClassInfo::parse_class_spec("Enum(array('Accepted', 'Pending', 'Declined', 'Unsubmitted'), 'Unsubmitted')")
+            ClassInfo::parse_class_spec("Enum(['Accepted', 'Pending', 'Declined', 'Unsubmitted'], 'Unsubmitted')")
         );
         // Nested array
         $this->assertEquals(
@@ -463,7 +463,7 @@ class ObjectTest extends SapphireTest
                 ]
             ],
             ClassInfo::parse_class_spec(
-                "Enum(array('Accepted', 'Pending', 'Declined', array('UnsubmittedA','UnsubmittedB')), 'Unsubmitted')"
+                "Enum(['Accepted', 'Pending', 'Declined', ['UnsubmittedA','UnsubmittedB']], 'Unsubmitted')"
             )
         );
         // 5.4 Shorthand Array
@@ -488,12 +488,12 @@ class ObjectTest extends SapphireTest
         // Associative array
         $this->assertEquals(
             ['Varchar', [255, ['nullifyEmpty' => false]]],
-            ClassInfo::parse_class_spec("Varchar(255, array('nullifyEmpty' => false))")
+            ClassInfo::parse_class_spec("Varchar(255, ['nullifyEmpty' => false])")
         );
         // Nested associative array
         $this->assertEquals(
             ['Test', ['string', ['nested' => ['foo' => 'bar']]]],
-            ClassInfo::parse_class_spec("Test('string', array('nested' => array('foo' => 'bar')))")
+            ClassInfo::parse_class_spec("Test('string', ['nested' => ['foo' => 'bar']])")
         );
         // 5.4 shorthand associative array
         $this->assertEquals(

--- a/tests/php/ORM/ArrayListTest.php
+++ b/tests/php/ORM/ArrayListTest.php
@@ -446,7 +446,7 @@ class ArrayListTest extends SapphireTest
             ['Name' => 'John'],
             ['Name' => 'bonny'],
             ['Name' => 'bonny1'],
-            //array('Name' => 'bonny10'),
+            //['Name' => 'bonny10'],
             ['Name' => 'bonny2'],
         ];
 
@@ -456,7 +456,7 @@ class ArrayListTest extends SapphireTest
             (object) ['Name' => 'Bob'],
             ['Name' => 'bonny'],
             ['Name' => 'bonny1'],
-            //array('Name' => 'bonny10'),
+            //['Name' => 'bonny10'],
             ['Name' => 'bonny2'],
             ['Name' => 'John'],
             ['Name' => 'Steve'],
@@ -756,7 +756,7 @@ class ArrayListTest extends SapphireTest
     }
 
     /**
-     * $list->filter('Name', array('Steve', 'John'); // Steve and John in list
+     * $list->filter('Name', ['Steve', 'John']; // Steve and John in list
      */
     public function testSimpleFilterWithMultiple()
     {
@@ -777,7 +777,7 @@ class ArrayListTest extends SapphireTest
     }
 
     /**
-     * $list->filter('Name', array('Steve', 'John'); // negative version
+     * $list->filter('Name', ['Steve', 'John']; // negative version
      */
     public function testSimpleFilterWithMultipleNoMatch()
     {
@@ -793,7 +793,7 @@ class ArrayListTest extends SapphireTest
     }
 
     /**
-     * $list->filter(array('Name'=>'bob, 'Age'=>21)); // bob with the Age 21 in list
+     * $list->filter(['Name'=>'bob, 'Age'=>21]); // bob with the Age 21 in list
      */
     public function testMultipleFilter()
     {
@@ -813,7 +813,7 @@ class ArrayListTest extends SapphireTest
     }
 
     /**
-     * $list->filter(array('Name'=>'bob, 'Age'=>21)); // negative version
+     * $list->filter(['Name'=>'bob, 'Age'=>21]); // negative version
      */
     public function testMultipleFilterNoMatch()
     {
@@ -829,7 +829,7 @@ class ArrayListTest extends SapphireTest
     }
 
     /**
-     * $list->filter(array('Name'=>'Steve', 'Age'=>array(21, 43))); // Steve with the Age 21 or 43
+     * $list->filter(['Name'=>'Steve', 'Age'=>[21, 43]]); // Steve with the Age 21 or 43
      */
     public function testMultipleWithArrayFilter()
     {
@@ -853,7 +853,7 @@ class ArrayListTest extends SapphireTest
     }
 
     /**
-     * $list->filter(array('Name'=>array('aziz','bob'), 'Age'=>array(21, 43)));
+     * $list->filter(['Name'=>['aziz','bob'], 'Age'=>[21, 43]]);
      */
     public function testMultipleWithArrayFilterAdvanced()
     {
@@ -900,7 +900,7 @@ class ArrayListTest extends SapphireTest
         $this->assertContains($bob, $filteredList);
 
         // azis or bob in the list
-        //$list = $list->filterAny('Name', array('aziz', 'bob');
+        //$list = $list->filterAny('Name', ['aziz', 'bob']);
         $filteredList = $list->filterAny('Name', ['Aziz', 'Bob'])->toArray();
         $this->assertCount(1, $filteredList);
         $this->assertContains($bob, $filteredList);
@@ -911,7 +911,7 @@ class ArrayListTest extends SapphireTest
         $this->assertContains($bob, $filteredList);
 
         // bob or anyone aged 21 in the list
-        //$list = $list->filterAny(array('Name'=>'bob, 'Age'=>21));
+        //$list = $list->filterAny(['Name'=>'bob, 'Age'=>21]);
         $filteredList = $list->filterAny(['Name' => 'Bob', 'Age' => 21])->toArray();
         $this->assertCount(4, $filteredList);
         $this->assertContains($bob, $filteredList);
@@ -920,7 +920,7 @@ class ArrayListTest extends SapphireTest
         $this->assertContains($phil, $filteredList);
 
         // bob or anyone aged 21 or 43 in the list
-        // $list = $list->filterAny(array('Name'=>'bob, 'Age'=>array(21, 43)));
+        // $list = $list->filterAny(['Name'=>'bob, 'Age'=>[21, 43]]);
         $filteredList = $list->filterAny(['Name' => 'Bob', 'Age' => [21, 43]])->toArray();
         $this->assertCount(5, $filteredList);
         $this->assertContains($bob, $filteredList);
@@ -930,7 +930,7 @@ class ArrayListTest extends SapphireTest
         $this->assertContains($phil, $filteredList);
 
         // all bobs, phils or anyone aged 21 or 43 in the list
-        //$list = $list->filterAny(array('Name'=>array('bob','phil'), 'Age'=>array(21, 43)));
+        //$list = $list->filterAny(['Name'=>['bob','phil'], 'Age'=>[21, 43]]);
         $filteredList = $list->filterAny(['Name' => ['Bob', 'Phil'], 'Age' => [21, 43]])->toArray();
         $this->assertCount(5, $filteredList);
         $this->assertContains($bob, $filteredList);

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -774,7 +774,7 @@ class DataListTest extends SapphireTest
     }
 
     /**
-     * $list->filter('Name', array('aziz', 'bob'); // aziz and bob in list
+     * $list->filter('Name', ['aziz', 'bob']); // aziz and bob in list
      */
     public function testSimpleFilterWithMultiple()
     {
@@ -794,7 +794,7 @@ class DataListTest extends SapphireTest
     }
 
     /**
-     *  $list->filter(array('Name'=>'bob, 'Age'=>21)); // bob with the age 21
+     *  $list->filter(['Name'=>'bob, 'Age'=>21]); // bob with the age 21
      */
     public function testFilterMultipleArray()
     {
@@ -833,7 +833,7 @@ class DataListTest extends SapphireTest
     }
 
     /**
-     * $list->filter(array('Name'=>array('aziz','bob'), 'Age'=>array(21, 43)));
+     * $list->filter(['Name'=>['aziz','bob'], 'Age'=>[21, 43]]);
      */
     public function testFilterArrayInArray()
     {
@@ -1499,7 +1499,7 @@ class DataListTest extends SapphireTest
     }
     //
     /**
-     * $list->exclude('Name', array('aziz', 'bob'); // exclude aziz and bob from list
+     * $list->exclude('Name', ['aziz', 'bob']); // exclude aziz and bob from list
      */
     public function testSimpleExcludeWithMultiple()
     {
@@ -1510,7 +1510,7 @@ class DataListTest extends SapphireTest
     }
 
     /**
-     * $list->exclude(array('Name'=>'bob, 'Age'=>21)); // negative version
+     * $list->exclude(['Name'=>'bob, 'Age'=>21]); // negative version
      */
     public function testMultipleExcludeWithMiss()
     {
@@ -1520,7 +1520,7 @@ class DataListTest extends SapphireTest
     }
 
     /**
-     * $list->exclude(array('Name'=>'bob, 'Age'=>21)); // exclude bob that has Age 21
+     * $list->exclude(['Name'=>'bob, 'Age'=>21]); // exclude bob that has Age 21
      */
     public function testMultipleExclude()
     {
@@ -1531,7 +1531,7 @@ class DataListTest extends SapphireTest
 
     /**
      * Test doesn't exclude if only matches one
-     * $list->exclude(array('Name'=>'bob, 'Age'=>21)); // exclude bob that has Age 21
+     * $list->exclude(['Name'=>'bob, 'Age'=>21]); // exclude bob that has Age 21
      */
     public function testMultipleExcludeMultipleMatches()
     {
@@ -1711,7 +1711,7 @@ class DataListTest extends SapphireTest
     }
 
     /**
-     * $list->exclude(array('Name'=>'bob, 'Age'=>array(21, 43))); // exclude bob with Age 21 or 43
+     * $list->exclude(['Name'=>'bob, 'Age'=>[21, 43]]); // exclude bob with Age 21 or 43
      */
     public function testMultipleExcludeWithMultipleThatCheersEitherTeam()
     {
@@ -1729,7 +1729,7 @@ class DataListTest extends SapphireTest
     }
 
     /**
-     * $list->exclude(array('Name'=>'bob, 'Age'=>array(21, 43))); // negative version
+     * $list->exclude(['Name'=>'bob, 'Age'=>[21, 43]]); // negative version
      */
     public function testMultipleExcludeWithMultipleThatCheersOnNonExistingTeam()
     {
@@ -1739,7 +1739,7 @@ class DataListTest extends SapphireTest
     }
 
     /**
-     * $list->exclude(array('Name'=>array('bob','phil'), 'Age'=>array(21, 43))); //negative version
+     * $list->exclude(['Name'=>['bob','phil'], 'Age'=>[21, 43]]); //negative version
      */
     public function testMultipleExcludeWithNoExclusion()
     {

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -173,7 +173,7 @@ class DataObjectTest extends SapphireTest
         );
 
         // assertEquals doesn't verify the order of array elements, so access keys manually to check order:
-        // expected: array('Name' => 'Varchar', 'Comment' => 'HTMLText')
+        // expected: ['Name' => 'Varchar', 'Comment' => 'HTMLText']
         $this->assertEquals(
             [
                 'Name',

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -594,7 +594,7 @@ class DataObjectTest extends SapphireTest
         // Test the IDs on the DataObjects are set correctly
         $this->assertListEquals($team1Comments, $team1->Comments());
 
-        // Test that has_many can be infered from the has_one via getNonReciprocalComponent
+        // Test that has_many can be inferred from the has_one via getNonReciprocalComponent
         $this->assertListEquals(
             $team1Comments,
             $team1->inferReciprocalComponent(DataObjectTest\TeamComment::class, 'Team')
@@ -1704,7 +1704,7 @@ class DataObjectTest extends SapphireTest
         $this->assertInstanceOf(ManyManyList::class, $teamWithoutSponsor->Sponsors());
         $this->assertEquals(0, $teamWithoutSponsor->Sponsors()->count());
 
-        // Test that belongs_many_many can be infered from with getNonReciprocalComponent
+        // Test that belongs_many_many can be inferred from with getNonReciprocalComponent
         $this->assertListEquals(
             [
                 ['Name' => 'Company corp'],
@@ -1713,7 +1713,7 @@ class DataObjectTest extends SapphireTest
             $team->inferReciprocalComponent(DataObjectTest\EquipmentCompany::class, 'SponsoredTeams')
         );
 
-        // Test that many_many can be infered from getNonReciprocalComponent
+        // Test that many_many can be inferred from getNonReciprocalComponent
         $this->assertListEquals(
             [
                 ['Title' => 'Team 1'],
@@ -2149,20 +2149,20 @@ class DataObjectTest extends SapphireTest
 
         $this->assertEquals($company->ID, $ceo->Company()->ID, 'belongs_to returns the right results.');
 
-        // Test belongs_to can be infered via getNonReciprocalComponent
+        // Test belongs_to can be inferred via getNonReciprocalComponent
         // Note: Will be returned as has_many since the belongs_to is ignored.
         $this->assertListEquals(
             [['Name' => 'New Company']],
             $ceo->inferReciprocalComponent(DataObjectTest\Company::class, 'CEO')
         );
 
-        // Test has_one to a belongs_to can be infered via getNonReciprocalComponent
+        // Test has_one to a belongs_to can be inferred via getNonReciprocalComponent
         $this->assertEquals(
             $ceo->ID,
             $company->inferReciprocalComponent(DataObjectTest\CEO::class, 'Company')->ID
         );
 
-        // Test automatic creation of class where no assigment exists
+        // Test automatic creation of class where no assignment exists
         $ceo = new DataObjectTest\CEO();
         $ceo->write();
 
@@ -2443,7 +2443,7 @@ class DataObjectTest extends SapphireTest
         $root->CycleID = $grandchild->ID;
         $root->write();
 
-        // Our count will have been set while loading our fixtures, let's reset eveything back to 0
+        // Our count will have been set while loading our fixtures, let's reset everything back to 0
         TreeNode::singleton()->resetCounts();
         $root = TreeNode::get()->byID($root->ID);
         $child = TreeNode::get()->byID($child->ID);
@@ -2487,7 +2487,7 @@ class DataObjectTest extends SapphireTest
         $root->CycleID = $grandchild->ID;
         $root->write();
 
-        // Our count will have been set while loading our fixtures, let's reset eveything back to 0
+        // Our count will have been set while loading our fixtures, let's reset everything back to 0
         TreeNode::singleton()->resetCounts();
         $root = TreeNode::get()->byID($root->ID);
         $child = TreeNode::get()->byID($child->ID);

--- a/tests/php/View/ViewableDataTest/CastingClass.php
+++ b/tests/php/View/ViewableDataTest/CastingClass.php
@@ -10,6 +10,6 @@ class CastingClass extends ViewableData implements TestOnly
     private static $casting = [
         'Field' => 'CastingType',
         'Argument' => 'ArgumentType(Argument)',
-        'ArrayArgument' => 'ArrayArgumentType(array(foo, bar))'
+        'ArrayArgument' => 'ArrayArgumentType([foo, bar])'
     ];
 }

--- a/tests/php/i18n/i18nTest/_fakewebroot/i18nothermodule/code/i18nTestModuleDecorator.php
+++ b/tests/php/i18n/i18nTest/_fakewebroot/i18nothermodule/code/i18nTestModuleDecorator.php
@@ -5,7 +5,7 @@ use SilverStripe\ORM\DataExtension;
 class i18nTestModuleExtension extends DataExtension
 {
 
-    public static $db = array(
+    public static $db = [
         'MyExtraField' => 'Varchar'
-    );
+    ];
 }

--- a/tests/php/i18n/i18nTest/_fakewebroot/i18ntestmodule/code/i18nTestModule.php
+++ b/tests/php/i18n/i18nTest/_fakewebroot/i18ntestmodule/code/i18nTestModule.php
@@ -5,9 +5,9 @@ use SilverStripe\Dev\TestOnly;
 
 class i18nTestModule extends DataObject implements TestOnly
 {
-    private static $db = array(
+    private static $db = [
         'MyField' => 'Varchar',
-    );
+    ];
 
     public function myMethod()
     {

--- a/tests/php/i18n/i18nTextCollectorTest.php
+++ b/tests/php/i18n/i18nTextCollectorTest.php
@@ -388,11 +388,11 @@ PHP;
         $php = <<<PHP
 _t('i18nTestModule.NEWMETHODSIG',"New _t method signature test");
 _t('i18nTestModule.INJECTIONS2', "Hello {name} {greeting}. But it is late, {goodbye}",
-	array("name"=>"Paul", "greeting"=>"good you are here", "goodbye"=>"see you"));
+	["name"=>"Paul", "greeting"=>"good you are here", "goodbye"=>"see you"]);
 _t("i18nTestModule.INJECTIONS3", "Hello {name} {greeting}. But it is late, {goodbye}",
 		"New context (this should be ignored)",
-		array("name"=>"Steffen", "greeting"=>"willkommen", "goodbye"=>"wiedersehen"));
-_t('i18nTestModule.INJECTIONS4', array("name"=>"Cat", "greeting"=>"meow", "goodbye"=>"meow"));
+		["name"=>"Steffen", "greeting"=>"willkommen", "goodbye"=>"wiedersehen"]);
+_t('i18nTestModule.INJECTIONS4', ["name"=>"Cat", "greeting"=>"meow", "goodbye"=>"meow"]);
 _t('i18nTestModule.INJECTIONS6', "Hello {name} {greeting}. But it is late, {goodbye}",
 	["name"=>"Paul", "greeting"=>"good you are here", "goodbye"=>"see you"]);
 _t("i18nTestModule.INJECTIONS7", "Hello {name} {greeting}. But it is late, {goodbye}",
@@ -429,7 +429,7 @@ PHP;
         $this->expectExceptionMessage('Missing localisation default for key i18nTestModule.INJECTIONS4');
 
         $php = <<<PHP
-_t('i18nTestModule.INJECTIONS4', array("name"=>"Cat", "greeting"=>"meow", "goodbye"=>"meow"));
+_t('i18nTestModule.INJECTIONS4', ["name"=>"Cat", "greeting"=>"meow", "goodbye"=>"meow"]);
 PHP;
         $c->setWarnOnEmptyDefault(true);
         $c->collectFromCode($php, null, $mymodule);

--- a/tests/phpcs_runner.php
+++ b/tests/phpcs_runner.php
@@ -10,12 +10,12 @@ if (!empty($_SERVER['argv'][1])) {
     die("Usage: php {$_SERVER['argv'][0]} <file>\n");
 }
 
-$result = array('comments' => array());
+$result = ['comments' => []];
 
 $extension = pathinfo($path, PATHINFO_EXTENSION);
 
 // Whitelist of extensions to check (default phpcs list)
-if (in_array($extension, array('php', 'js', 'inc', 'css'))) {
+if (in_array($extension, ['php', 'js', 'inc', 'css'])) {
     // Run each sniff
 
     // phpcs --encoding=utf-8 --standard=framework/tests/phpcs/tabs.xml
@@ -42,11 +42,11 @@ function run_sniff($standard, $path, array &$result, $extraFlags = '')
             $sanePath = str_replace('/', '_', $path);
             foreach ($errors as $error) {
                 $attributes = $error->attributes();
-                $result['comments'][] = array(
+                $result['comments'][] = [
                     'line' => (int)strval($attributes->line),
                     'id' => $standard . '-' . $sanePath . '-' . $attributes->line . '-' . $attributes->column,
                     'message' => strval($error)
-                );
+                ];
             }
         }
     }


### PR DESCRIPTION
Replaces #9472

This PR updates short array syntax that is used but in areas the linter doesn't check (comments, peg file, docs)