### PR TITLE
Update index.md

### DIFF
--- a/docs/en/00_Getting_Started/index.md
+++ b/docs/en/00_Getting_Started/index.md
@@ -39,7 +39,7 @@ SS_DATABASE_NAME="<database>"
 SS_DATABASE_SERVER="localhost"
 SS_DATABASE_USERNAME="<user>"
 SS_DATABASE_PASSWORD="<password>"
-SS_DEFAULT_ADMIN_USERNAME="admin"
+SS_DEFAULT_ADMIN_EMAIL="admin@email.here"
 SS_DEFAULT_ADMIN_PASSWORD="password"
 SS_ENVIRONMENT_TYPE="<dev|test|live>"
 ```


### PR DESCRIPTION
The value of SS_DEFAULT_ADMIN_USERNAME is registered in "Member->Email", so why is it called "SS_DEFAULT_ADMIN_USERNAME"?
I propose to name it to SS_DEFAULT_ADMIN_EMAIL for the default "unique_identifier_field" ('Email') and then we'll support different "unique_identifier_field" (like "Username" or other).


<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
