### PR TITLE
Update 03_Authentication.md

### DIFF
--- a/docs/en/02_Developer_Guides/09_Security/03_Authentication.md
+++ b/docs/en/02_Developer_Guides/09_Security/03_Authentication.md
@@ -60,7 +60,7 @@ SS_DEFAULT_ADMIN_EMAIL="admin@email.here"
 SS_DEFAULT_ADMIN_PASSWORD="password"
 ```
 
-When a user logs in with these credentials, then a [Member](api:SilverStripe\Security\Member) with the Email 'admin' will be generated in
+When a user logs in with these credentials, then a [Member](api:SilverStripe\Security\Member) with the Email 'admin@email.here' will be generated in
 the database, but without any password information. This means that the password can be reset or changed by simply
 updating the `.env` file.
 

--- a/docs/en/02_Developer_Guides/09_Security/03_Authentication.md
+++ b/docs/en/02_Developer_Guides/09_Security/03_Authentication.md
@@ -56,7 +56,7 @@ It is advisable to configure this user in your `.env` file inside of the web roo
 
 ```
 # Configure a default username and password to access the CMS on all sites in this environment.
-SS_DEFAULT_ADMIN_USERNAME="admin"
+SS_DEFAULT_ADMIN_EMAIL="admin@email.here"
 SS_DEFAULT_ADMIN_PASSWORD="password"
 ```
 


### PR DESCRIPTION
The value of SS_DEFAULT_ADMIN_USERNAME is registered in "Member->Email", so why is it called "SS_DEFAULT_ADMIN_USERNAME"?
I propose to name it to SS_DEFAULT_ADMIN_EMAIL for the default "unique_identifier_field" ('Email') and then we'll support different "unique_identifier_field" (like "Username" or other).

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
