### PR TITLE
Update 01_Upgrading_project.md

### DIFF
--- a/docs/en/03_Upgrading/01_Upgrading_project.md
+++ b/docs/en/03_Upgrading/01_Upgrading_project.md
@@ -467,7 +467,7 @@ For example, take the following `_ss_environment.php` file.
 <?php
 // Environment
 define('SS_ENVIRONMENT_TYPE', 'dev');
-define('SS_DEFAULT_ADMIN_USERNAME', 'admin');
+define('SS_DEFAULT_ADMIN_EMAIL', 'admin@email.here');
 define('SS_DEFAULT_ADMIN_PASSWORD', 'password');
 $_FILE_TO_URL_MAPPING[__DIR__] = 'http://localhost';
 
@@ -483,7 +483,7 @@ The equivalent `.env` file will look like this.
 ```bash
 ## Environment
 SS_ENVIRONMENT_TYPE="dev"
-SS_DEFAULT_ADMIN_USERNAME="admin"
+SS_DEFAULT_ADMIN_EMAIL="admin@email.here"
 SS_DEFAULT_ADMIN_PASSWORD="password"
 SS_BASE_URL="http://localhost/"
 


### PR DESCRIPTION
The value of SS_DEFAULT_ADMIN_USERNAME is registered in "Member->Email", so why is it called "SS_DEFAULT_ADMIN_USERNAME"?
I propose to name it to SS_DEFAULT_ADMIN_EMAIL for the default "unique_identifier_field" ('Email') and then we'll support different "unique_identifier_field" (like "Username" or other).

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
