### PR TITLE
Update 05_Making_A_SilverStripe_Core_Release.md

### DIFF
--- a/docs/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
+++ b/docs/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
@@ -61,7 +61,7 @@ SS_DATABASE_PASSWORD=""
 SS_DATABASE_CHOOSE_NAME=1
 
 # So you can test releases
-SS_DEFAULT_ADMIN_USERNAME="admin"
+SS_DEFAULT_ADMIN_EMAIL="admin@email.here"
 SS_DEFAULT_ADMIN_PASSWORD="password"
 
 # Basic CLI request url default


### PR DESCRIPTION
The value of SS_DEFAULT_ADMIN_USERNAME is registered in "Member->Email", so why is it called "SS_DEFAULT_ADMIN_USERNAME"?
I propose to name it to SS_DEFAULT_ADMIN_EMAIL for the default "unique_identifier_field" ('Email') and then we'll support different "unique_identifier_field" (like "Username" or other).

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
