### PR TITLE
Update Member_Validator.php

### DIFF
--- a/src/Security/Member_Validator.php
+++ b/src/Security/Member_Validator.php
@@ -54,6 +54,11 @@ class Member_Validator extends RequiredFields
 
         $required = array_merge($required, $this->customRequired);
 
+        $uniqueIdentifierFieldName = Member::config()->unique_identifier_field; 
+
+        if($uniqueIdentifierFieldName != 'Email') 
+            $required[] = $uniqueIdentifierFieldName; 
+
         // check for config API values and merge them in
         $config = $this->config()->customRequired;
         if (is_array($config)) {

--- a/src/Security/Member_Validator.php
+++ b/src/Security/Member_Validator.php
@@ -54,7 +54,7 @@ class Member_Validator extends RequiredFields
 
         $required = array_merge($required, $this->customRequired);
 
-        $uniqueIdentifierFieldName = Member::config()->unique_identifier_field; 
+        $uniqueIdentifierFieldName = Member::config()->get('unique_identifier_field'); 
 
         if($uniqueIdentifierFieldName != 'Email') 
             $required[] = $uniqueIdentifierFieldName; 
@@ -102,7 +102,7 @@ class Member_Validator extends RequiredFields
     {
         $valid = parent::php($data);
 
-        $identifierField = (string)Member::config()->unique_identifier_field;
+        $identifierField = (string)Member::config()->get('unique_identifier_field');
 
         // Only validate identifier field if it's actually set. This could be the case if
         // somebody removes `Email` from the list of required fields.


### PR DESCRIPTION
[link](https://github.com/silverstripe/silverstripe-framework/pull/9475#issuecomment-617122506)

I did some changes to the SilverStripe code to fix the use of "unique_identifier_field" variabile.
Now you can set any variable name, which will be used for login and will also be set as the required field in Member_Validator
