### PR TITLE
Update LostPasswordHandler.php

### DIFF
--- a/src/Security/MemberAuthenticator/LostPasswordHandler.php
+++ b/src/Security/MemberAuthenticator/LostPasswordHandler.php
@@ -218,8 +218,7 @@ class LostPasswordHandler extends RequestHandler
     protected function getMemberFromData(array $data)
     {
         if (!empty($data['Email'])) {
-            $uniqueIdentifier = Member::config()->get('unique_identifier_field');
-            return Member::get()->filter([$uniqueIdentifier => $data['Email']])->first();
+            return Member::get()->filter(['Email' => $data['Email']])->first();
         }
     }
 


### PR DESCRIPTION
[link](https://github.com/silverstripe/silverstripe-framework/pull/9475#issuecomment-617122506)

I did some changes to the SilverStripe code to fix the use of "unique_identifier_field" variabile.
Now you can set any variable name, which will be used for login and will also be set as the required field in Member_Validator

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
