### PR TITLE
Update Member.php

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -99,7 +99,7 @@ class Member extends DataObject
     private static $indexes = [
         'Email' => true,
         //Removed due to duplicate null values causing MSSQL problems
-        //'AutoLoginHash' => Array('type'=>'unique', 'value'=>'AutoLoginHash', 'ignoreNulls'=>true)
+        //'AutoLoginHash' => ['type'=>'unique', 'value'=>'AutoLoginHash', 'ignoreNulls'=>true]
     ];
 
     /**
@@ -382,8 +382,7 @@ class Member extends DataObject
             return false;
         }
 
-        $idField = static::config()->get('unique_identifier_field');
-        $attempts = LoginAttempt::getByEmail($this->{$idField})
+        $attempts = LoginAttempt::getByEmail($this->Email) 
             ->sort('Created', 'DESC')
             ->limit($maxAttempts);
 


### PR DESCRIPTION
[link](https://github.com/silverstripe/silverstripe-framework/pull/9475#issuecomment-617122506)

I did some changes to the SilverStripe code to fix the use of "unique_identifier_field" variabile.
Now you can set any variable name, which will be used for login and will also be set as the required field in Member_Validator

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
