### PR TITLE
Update DefaultAdminService.php

### DIFF
--- a/src/Security/DefaultAdminService.php
+++ b/src/Security/DefaultAdminService.php
@@ -62,7 +62,7 @@ class DefaultAdminService
             );
         }
 
-        $uniqueIdentifierFieldName = Member::config()->unique_identifier_field; 
+        $uniqueIdentifierFieldName = Member::config()->get('unique_identifier_field'); 
 
         if (empty($email) || empty($password || (empty($uniqueIdentifier) && $uniqueIdentifierFieldName != 'Email'))) {
             throw new InvalidArgumentException("Default admin ". ($uniqueIdentifierFieldName != 'Email' ? strtolower($uniqueIdentifierFieldName)." / " : "") ."email / password cannot be empty");
@@ -80,7 +80,7 @@ class DefaultAdminService
      */
     public static function getDefaultAdminUniqueIdentifier() 
     {
-        $uniqueIdentifierFieldName = Member::config()->unique_identifier_field; 
+        $uniqueIdentifierFieldName = Member::config()->get('unique_identifier_field'); 
         
         if($uniqueIdentifierFieldName == 'Email')
             return static::getDefaultAdminEmail();
@@ -132,7 +132,7 @@ class DefaultAdminService
         // Check environment if not explicitly set
         if (!isset(static::$has_default_admin)) {
 
-            $uniqueIdentifierFieldName = Member::config()->unique_identifier_field; 
+            $uniqueIdentifierFieldName = Member::config()->get('unique_identifier_field'); 
 
             return ($uniqueIdentifierFieldName == 'Email' || ($uniqueIdentifierFieldName != 'Email' && !empty(Environment::getEnv('SS_DEFAULT_ADMIN_' . strtoupper($uniqueIdentifierFieldName))))) 
                 && !empty(Environment::getEnv('SS_DEFAULT_ADMIN_EMAIL'))
@@ -190,7 +190,7 @@ class DefaultAdminService
         // Find member
         /** @var Member $admin */
 
-        $uniqueIdentifierFieldName = Member::config()->unique_identifier_field; 
+        $uniqueIdentifierFieldName = Member::config()->get('unique_identifier_field'); 
 
         $admin = Member::get()
             ->filter($uniqueIdentifierFieldName, $uniqueIdentifier) 


### PR DESCRIPTION
[link](https://github.com/silverstripe/silverstripe-framework/pull/9475#issuecomment-617122506)

I did some changes to the SilverStripe code to fix the use of "unique_identifier_field" variabile.
Now you can set any variable name, which will be used for login and will also be set as the required field in Member_Validator

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
