### PR TITLE
BUGFIX: ensure template file exists

### DIFF
--- a/src/View/SSViewer.php
+++ b/src/View/SSViewer.php
@@ -633,7 +633,7 @@ class SSViewer implements Flushable
 
         $cacheFile = TEMP_PATH . DIRECTORY_SEPARATOR . '.cache'
             . str_replace(['\\','/',':'], '.', Director::makeRelative(realpath($template)));
-        $lastEdited = filemtime($template);
+        $lastEdited = file_exists($template) ? filemtime($template) : false;
 
         if (!file_exists($cacheFile) || filemtime($cacheFile) < $lastEdited) {
             $content = file_get_contents($template);


### PR DESCRIPTION
When a .ss file is removed from the theme and the cache is not cleared then I receive the error; `filemtime(): stat failed for MyTemplate.ss` ref SSViewer.php on line 636.

Does it make sense to check if the file exists before running `filemtime` to avoid the problem again?

Any feedback welcome.