### PR TITLE
BUGFIX: Remove LoginAttempt records

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -953,6 +953,10 @@ class Member extends DataObject
         // prevent orphaned records remaining in the DB
         $this->deletePasswordLogs();
         $this->Groups()->removeAll();
+
+        // remove (any) failed log in attempts
+        $idField = static::config()->get('unique_identifier_field');
+        LoginAttempt::getByEmail($this->{$idField})->removeAll();
     }
 
     /**


### PR DESCRIPTION
After a Member is deleted the LoginAttempt records are still preserved. I'm not sure this is intentional but it doesn't seem compliant with GDPR.

Any feedback welcome.