### PR TITLE
DOCS: Remove unnecessary `return`

### DIFF
--- a/src/Security/Confirmation/Handler.php
+++ b/src/Security/Confirmation/Handler.php
@@ -50,7 +50,6 @@ class Handler extends RequestHandler
             'Title' => _t(__CLASS__ . '.FORM_TITLE', 'Confirm potentially dangerous action'),
             'Form' => $this->Form()
         ];
-        return $this;
     }
 
     /**


### PR DESCRIPTION
Remove unnecessary `return` as `return` specified on the previous line.