### PR TITLE
BUGFIX: Incorrect type used for `Swift_Mime_SimpleMessage::setDate()`

### DIFF
--- a/src/Control/Email/Email.php
+++ b/src/Control/Email/Email.php
@@ -269,7 +269,6 @@ class Email extends ViewableData
      */
     public function setSwiftMessage($swiftMessage)
     {
-        $swiftMessage->setDate(DBDatetime::now()->getTimestamp());
         if (!$swiftMessage->getFrom() && ($defaultFrom = $this->config()->get('admin_email'))) {
             $swiftMessage->setFrom($defaultFrom);
         }


### PR DESCRIPTION
I'm receiving the error;

```Argument 1 passed to Swift_Mime_SimpleMessage::setDate() must implement interface DateTimeInterface, int given, called in /var/www/vendor/silverstripe/framework/src/Control/Email/Email.php on line 272```

I'm also not sure why the Date needs to be set explicitly. Any feedback welcome.