### PR TITLE
DOCS Add Recipes section, add module version breakdown to 4.5.2

### DIFF
--- a/docs/en/00_Getting_Started/05_Recipes.md
+++ b/docs/en/00_Getting_Started/05_Recipes.md
@@ -1,0 +1,20 @@
+---
+title: Recipes
+summary: What Recipes are, and how they are used in Silverstripe CMS
+icon: clipboard
+---
+
+# Recipes
+
+Silverstripe CMS is powered by a system of components in the form of Composer packages. It consists of two types of package:
+
+- **Modules**, which provide pieces of functionality (such as `silverstripe/cms` and `silverstripe/framework`)
+- **Recipes**, which group related Modules together to make them easier to install and release.
+
+When we announce a new version of Silverstripe CMS and publish a changelog for it, we refer to a new set of _Recipe_ versions, which include new versions of some or all of their associated Modules. The easiest way to keep up to date with new Silverstripe CMS releases is to depend on one of the core Recipes:
+
+- [`silverstripe/recipe-core`](https://packagist.org/packages/silverstripe/recipe-core): Contains only the base framework, without the admin UI or CMS features.
+- [`silverstripe/recipe-cms`](https://packagist.org/packages/silverstripe/recipe-cms): Includes `recipe-core`, and adds the admin UI and CMS features. We recommend specifying this recipe in your dependencies.
+- [`silverstripe/installer`](https://packagist.org/packages/silverstripe/installer): Includes `recipe-cms`, and adds a default theme for the front-end of your site. We recommend creating new projects based on this recipe (via `composer create-project silverstripe/installer myproject ^4`)
+
+When determining whether you are running the latest version of Silverstripe CMS, it is easier to refer to the Recipe version than the individual Module versions, which may not align with Recipe versions. You can use Packagist to find detailed information on what versions of individual modules are contained in each Recipe release.

--- a/docs/en/04_Changelogs/4.5.2.md
+++ b/docs/en/04_Changelogs/4.5.2.md
@@ -11,7 +11,6 @@ CVE-2019-12245 patch which was released in September 2019.
 * [Read the CVE-2019-12245 security disclosure](https://www.silverstripe.org/download/security-releases/CVE-2019-12245)
   from September 2019
 
-
 **Simply applying the patch might NOT be enough.** Some files that were uploaded
 or created prior to the application of the CVE-2020-9280/CVE-2019-12245 patches
 may be left exposed to the public. You may need to run some additional file
@@ -23,6 +22,29 @@ upgrading as soon as convenient.
 
 If your project was migrated from Silverstripe CMS 3, you need to run the new
 `migrate-folders` task.
+
+As this release is a hotfix, it only includes updates to a subset of core modules. A full list of module versions included in Recipe 4.5.2 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/recipes) for more information.
+
+<details>
+<summary>Included module versions</summary>
++--------+---------+
+| Module | Version |
++--------+---------+
+| silverstripe/admin | 1.5.1 |
+| silverstripe/asset-admin | 1.5.1 |
+| silverstripe/assets | 4.5.2 |
+| silverstripe/campaign-admin | 1.5.1 |
+| silverstripe/cms | 4.5.1 |
+| silverstripe/config | 1.0.18 |
+| silverstripe/errorpage | 1.5.1 |
+| silverstripe/framework | 4.5.3 |
+| silverstripe/graphql | 3.2.3 |
+| silverstripe/reports | 4.5.1 |
+| silverstripe/siteconfig | 4.5.1 |
+| silverstripe/versioned | 1.5.1 |
+| silverstripe/versioned-admin | 1.3.1 |
++--------+---------+
+</details>
 
 ## What does this release fix?
 

--- a/docs/en/04_Changelogs/index.md
+++ b/docs/en/04_Changelogs/index.md
@@ -1,5 +1,7 @@
+---
 title: Changelogs
 introduction: Key information on new features and improvements in each version.
+---
 
 Keep up to date with new releases by reading [SilverStripe Forums](https://forum.silverstripe.org/c/releases),
 and our [blog posts](http://silverstripe.org/blog/tag/release).
@@ -8,4 +10,12 @@ We also keep an overview of [security-related releases](http://silverstripe.org/
 
 For information on how to upgrade to newer versions consult the [upgrading](/upgrading) guide.
 
-[CHILDREN]
+As of Silverstripe CMS 4, these changelogs track **recipe** versions (`silverstripe/installer`, `silverstripe/recipe-core`, and `silverstripe/recipe-cms`), rather than versions of individual modules like `framework` or `cms`, which can vary from the recipe version and from each other. We recommend referencing recipes in your Composer dependencies, rather than individual modules. See [Recipes](/getting_started/recipes) for more information.
+
+---
+
+[CHILDREN Only="rc" includeFolders]
+
+---
+
+[CHILDREN reverse]


### PR DESCRIPTION
This PR:

- Introduces a section to the documentation covering what recipes are, how they differ from modules, and what our core recipes entail.
- Adds a message to the changelog index page explaining that changelogs relate to recipe versions as of Silverstripe CMS 4.
- Adds a breakdown of the module versions included in 4.5.2.

These changes are intended to alleviate some confusion we've been seeing in the community around version information recently, as the 4.5.2 hotfix release diverges module versions significantly (some modules stayed at `4.5.1`, whilst framework was already ahead a patch and shifted to `4.5.3`). Other work is also underway to put more emphasis on prioritising display of recipe versions [within the CMS](https://github.com/silverstripe/silverstripe-installer/issues/276) and related tooling, in order to make it easier to determine whether projects are safely running the latest release.

Feedback on the structure and wording of these changes is most welcome 🙂