### PR TITLE
FIX Reset nonce style to prevent affecting other unit tests

### DIFF
--- a/tests/php/Control/SimpleResourceURLGeneratorTest.php
+++ b/tests/php/Control/SimpleResourceURLGeneratorTest.php
@@ -73,6 +73,7 @@ class SimpleResourceURLGeneratorTest extends SapphireTest
     {
         /** @var SimpleResourceURLGenerator $generator */
         $generator = Injector::inst()->get(ResourceURLGenerator::class);
+        $generator->setNonceStyle('mtime');
         $mtime = filemtime(
             __DIR__ . '/SimpleResourceURLGeneratorTest/_fakewebroot/vendor/silverstripe/mymodule/client/style.css'
         );
@@ -86,6 +87,7 @@ class SimpleResourceURLGeneratorTest extends SapphireTest
     {
         /** @var SimpleResourceURLGenerator $generator */
         $generator = Injector::inst()->get(ResourceURLGenerator::class);
+        $generator->setNonceStyle('mtime');
         $mtime = filemtime(
             __DIR__ . '/SimpleResourceURLGeneratorTest/_fakewebroot/public/basemodule/css/style.css'
         );
@@ -109,6 +111,7 @@ class SimpleResourceURLGeneratorTest extends SapphireTest
     {
         /** @var SimpleResourceURLGenerator $generator */
         $generator = Injector::inst()->get(ResourceURLGenerator::class);
+        $generator->setNonceStyle('mtime');
         $module = new Module(
             __DIR__ . '/SimpleResourceURLGeneratorTest/_fakewebroot/vendor/silverstripe/mymodule/',
             __DIR__ . '/SimpleResourceURLGeneratorTest/_fakewebroot/'

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -642,6 +642,9 @@ class RequirementsTest extends SapphireTest
         $backend = Injector::inst()->create(Requirements_Backend::class);
         $this->setupRequirements($backend);
 
+        $generator = Injector::inst()->get(ResourceURLGenerator::class);
+        $generator->setNonceStyle('mtime');
+
         $backend->javascript('javascript/RequirementsTest_a.js?test=1&test=2&test=3');
         $backend->css('css/RequirementsTest_a.css?test=1&test=2&test=3');
         $html = $backend->includeInHTML(self::$html_template);


### PR DESCRIPTION
[Recent merged PR](https://github.com/silverstripe/silverstripe-framework/pull/9509) caused breakage on cwp-recipe-kitchen-sink travis integration test
https://travis-ci.org/github/creative-commoners/cwp-recipe-kitchen-sink/jobs/686362008

Travis cwp-recipe-kitchen-sink with code patch **(make sure this is green before merging)**:
https://travis-ci.org/github/creative-commoners/cwp-recipe-kitchen-sink/jobs/686414264
