### PR TITLE
DOCS fix incorrect Injector YAML examples

### DIFF
--- a/docs/en/02_Developer_Guides/05_Extending/05_Injector.md
+++ b/docs/en/02_Developer_Guides/05_Extending/05_Injector.md
@@ -110,10 +110,10 @@ The [Configuration YAML](../configuration) does the hard work of configuring tho
 **app/_config/app.yml**
 
 ```yml
-Injector:
+SilverStripe\Core\Injector\Injector:
   PermissionService:
     class: MyCustomPermissionService
-  MyController
+  MyController:
     properties:
       textProperty: 'My Text Value'
 ```
@@ -249,7 +249,7 @@ SilverStripe\Core\Injector\Injector:
     class: RestrictivePermissionService
     properties:
       database: %$MySQLDatabase
-  MySQLDatabase
+  MySQLDatabase:
     constructor:
       0: 'dbusername'
       1: 'dbpassword'


### PR DESCRIPTION
Adds missing namespace and colons