### PR TITLE
DOC Show beta changelogs on doc site

### DIFF
--- a/docs/en/04_Changelogs/index.md
+++ b/docs/en/04_Changelogs/index.md
@@ -15,7 +15,7 @@ As of Silverstripe CMS 4, these changelogs track **recipe** versions (`silverstr
 
 ---
 
-[CHILDREN Only="rc" includeFolders]
+[CHILDREN Only="rc,beta" includeFolders]
 
 ---
 


### PR DESCRIPTION
I want to show the beta changelog on the SIlverstripe doc site so I can link to the 4.6.0-beta1 changelog.