### PR TITLE
DOC Add details about ModelAdmin and Login Forms to 4.6 changelogs

### DIFF
--- a/docs/en/04_Changelogs/4.6.0.md
+++ b/docs/en/04_Changelogs/4.6.0.md
@@ -1,4 +1,4 @@
-# 4.6.0 (Unreleased)
+# 4.6.0
 
 ## Overview {#overview}
 
@@ -6,42 +6,46 @@
  * [Editing files directly in the insert-media modal](#in-modal-editing)
  * [MIME Type validation now a core module](#mime-validator)
  * [Solr no longer indexes draft/restricted content](#solr-updates)
+ * [Simplify customisation of ModelAdmin](#modeladmin-customisation)
+ * [Login forms module ships with installer](#loginforms)
 
 ## MySQL tables are auto-converted from MyISAM to InnoDB {#myisam}
 
 Beginning with [4.4.0](https://docs.silverstripe.org/en/4/changelogs/4.4.0/),
-our minimum requirement for MySQL is 5.6 (since MySQL 5.5 end of life reached in
-December 2018). Starting with MySQL 5.6, [InnoDB](https://dev.mysql.com/doc/refman/5.6/en/innodb-introduction.html)
-is the new default storage engine, replacing the older [MyISAM](https://dev.mysql.com/doc/refman/5.6/en/myisam-storage-engine.html)
-engine.
+our minimum requirement for MySQL is 5.6 (since MySQL 5.5 end of life reached in December 2018).
+Starting with MySQL 5.6, [InnoDB](https://dev.mysql.com/doc/refman/5.6/en/innodb-introduction.html)
+is the new default storage engine,
+replacing the older [MyISAM](https://dev.mysql.com/doc/refman/5.6/en/myisam-storage-engine.html) engine.
 
-Silverstripe CMS already creates InnoDB tables by default, mainly in order to
-benefit from their better support for database transactions. Before MySQL 5.6,
-InnoDB didn't have a `FULLTEXT` search index, requiring us to enforce the MyISAM
-engine when devs opted into this index type in their particular setup. There are
-a few ways in which this opt-in can happen:
+Silverstripe CMS already creates InnoDB tables by default,
+mainly in order to benefit from their better support for database transactions.
+Before MySQL 5.6, InnoDB didn't have a `FULLTEXT` search index,
+requiring us to enforce the MyISAM engine when devs opted into this index type
+in their particular setup. There are a few ways in which this opt-in can happen:
 
  * Adding the [FulltextSearchable](https://github.com/silverstripe/silverstripe-framework/blob/4/src/ORM/Search/FulltextSearchable.php)
-   extension to a DataObject, as described in our [search docs](https://docs.silverstripe.org/en/4/developer_guides/search/fulltextsearch/)
+   extension to a DataObject, as described in our
+   [search docs](https://docs.silverstripe.org/en/4/developer_guides/search/fulltextsearch/)
  * Defining `'type' => 'fulltext'` in `DataObject::$db` column definitions
  * Implementing [DBIndexable](https://github.com/silverstripe/silverstripe-framework/blob/4/src/ORM/FieldType/DBIndexable.php)
    on a custom `DBField` subclass.
  * Setting `'ENGINE=MyISAM'` in `DataObject::$create_table_options`
 
-This search index is not required to enable simple text search in the "Pages"
-section of the CMS, or any ModelAdmin implementations. We generally recommend
-choosing a more powerful [search addon](https://addons.silverstripe.org/add-ons?search=fulltext&type=&sort=downloads)
+This search index is not required to enable simple text search
+in the "Pages" section of the CMS, or any ModelAdmin implementations.
+We generally recommend to choose a more powerful
+[search addon](https://addons.silverstripe.org/add-ons?search=fulltext&type=&sort=downloads)
 (e.g. based on Solr or ElasticSearch) for website frontend search use cases.
 
 As of 4.6.0, a `dev/build` will automatically switch MyISAM tables to InnoDB,
 which automatically recreates any indexes required. If you have large indexes,
-this can extend the duration of this task. As usual, back up your database
-before upgrading, and test upgrades on non-production systems first. Our tests
-indicate that indexes with thousands of records and screen pages worth of
-content (15MB index size) are converted in a few seconds.
+this can extend the duration if this task. As usual, back up your database
+before upgrading, and test upgrades on non-production systems first.
+Our tests indicate that indexes with thousands of records and screen pages
+worth of content (15MB index size) are converted in a few seconds.
 
-In order to opt out of this change, you can set the engine explicitly for your
-DataObject implementations:
+In order to opt out of this change, you can set the engine explicitly
+for your DataObject implementations:
 
 ```php
 use SilverStripe\ORM\Connect\MySQLSchemaManager;
@@ -55,37 +59,35 @@ class MyDataObject extends DataObject
 }
 ```
 
-## Editing files directly in the Insert Media modal {#in-modal-editing}
+## Editing files directly in the insert-media modal{#in-modal-editing}
 
-Authors can now directly edit file details when selecting a file in an
-`UploadField` or when inserting media in a `HTMLEditorField`. The "image
-placement" and "file link" forms that show when inserting an image or a link in
-an `HTMLEditorField` have been simplified.
+Editors can now directly edit file details when selecting a file in an UploadField or when inserting media in a
+HTMLEditorField. The "image placement" and "file link" forms that show when inserting an image or a link in an
+HTMLEditorField have been simplified.
 
-If you have customised the fields in the asset administration UI or Insert Media
-modal, you will need to do some regression testing when upgrading, and will
-likely need to make some minor adjustments to your code.
+This does mean that the order and structure of fields have changed somewhat. If you have customised the forms in the
+asset administration area or in the "Insert Media Modal", you should do some regression testing when upgrading to
+make sure your customisations still work as expected.
 
-Implementing the new Edit Details UI required filtering the fields generated in
-`File::getCMSFields()` into two `Form`s. The implementation in 4.6.0 does not
-expose a clear API to custom fields for differentiating between the `Form`s, and
-by default any fields added via an extension will appear in both views. For the
-time being, a simple way to resolve this is to check for the presence of the
-`Editor.Details.Title` field and add your field based on this. See the community
-module [jonom/focuspoint](https://github.com/jonom/silverstripe-focuspoint/pull/78/files#diff-cc697eb8345aa25a5f88c89d1a87ff6aR27-R34)
-for an example implementation, and ensure you update this module during your
-upgrade to 4.6.0 if you have it installed.
-
-We intend to improve this pattern in a future release of Silverstripe CMS.
+If your project uses the popular [jonom/focuspoint](https://github.com/jonom/silverstripe-focuspoint) community
+module, you should upgrade it as well.
 
 ## MIME Type validation now a core module {#mime-validator}
 
-`silverstripe/mimevalidator` is now a core module and will ship by default on
-new projects. Projects referencing `silverstripe/recipe-core` will automatically
-install `silverstripe/mimevalidator` when they upgrade to 4.6.0.
+`silverstripe/mimevalidator` is now a core module and will ship by default on new projects. Projects referencing `silverstripe/recipe-core` will automatically install `silverstripe/mimevalidator` when they upgrade to 4.6.0.
 
-Read [Allowed file types](Developer_Guides/Files/Allowed_file_types) in the
-Silverstripe CMS doc for all the details.
+Read [Allowed file types](Developer_Guides/Files/Allowed_file_types) in the Silverstripe CMS doc for all the details.
+
+## File status icons in the file manager
+
+![File status icons](https://raw.githubusercontent.com/silverstripe/silverstripe-framework/blob/4/docs/en/04_Changelogs/_images/file-status-icons.png "A screenshot of file status icons being displayed in the file manager")
+
+Files and folders with permissions of either "Logged in users" or "Only these groups (choose from list)" now show
+a "Restricted access" icon in the file manager.  These permissions can either be directly on the DataObject or
+they can be inherited from the parent folder.
+
+Websites with the optional [UserForms](https://github.com/silverstripe/silverstripe-userforms) module installed will
+show a "Form submission" icon on files uploaded through a UserForm.  UserForm uploaded files without a "Restricted access" icon show a "Form submission, unrestricted access" icon instead.
 
 ## Solr no longer indexes draft/restricted content {#solr-updates}
 
@@ -99,11 +101,28 @@ This is a great opportunity to make sure that any custom indexes/search controll
 
 The [silverstripe/fulltextsearch module readme provides additional information](https://github.com/silverstripe/silverstripe-fulltextsearch).
 
+## Simplify customisation of ModelAdmin {#modeladmin-customisation}
 
-## Regressions
+`ModelAdmin::getEditForm()` has been split into smaller more discrete protected methods:
+* `getGridField()`
+* `getGridFieldConfig()`.
 
- - [File section, icons broken until page is refreshed](https://github.com/silverstripe/silverstripe-admin/issues/1064)
+Two matching extension hooks have been added as well:
+* `updateGridField()`
+* `updateGridFieldConfig()`.
 
+This will make it easier for developers to customise GridFields in their ModelAdmins.
+
+Learn how to [alter the ModelAdmin GridField or Form](/developer_guides/customising_the_admin_interface/modeladmin/#altering-the-modeladmin-gridfield-or-form)
+
+## Login forms module ships with installer {#loginforms}
+
+The `silverstripe/login-forms` module is now part of the default installer. This alters the login form to provide
+consistent styling and behaviour that's independent from the specifics in your project. Only new projects will
+get the new login form. Older projects can manually require the `silverstripe/login-forms` module to get the new
+login form.
+
+View the [Silverstripe Login Forms readme](https://github.com/silverstripe/silverstripe-login-forms) on Github for more details.
 
 <!--- Changes below this line will be automatically regenerated -->
 


### PR DESCRIPTION
After some reflection I concluded that the ModelAdmin API change and the login form change are worth highlighting in the 4.6.0 changelog.
