### PR TITLE
DBField Documentation correction

### DIFF
--- a/src/ORM/FieldType/DBField.php
+++ b/src/ORM/FieldType/DBField.php
@@ -37,7 +37,7 @@ use SilverStripe\View\ViewableData;
  * <code>
  * class Blob extends DBField {
  *  function requireField() {
- *      DB::requireField($this->tableName, $this->name, "blob");
+ *      DB::require_field($this->tableName, $this->name, "blob");
  *  }
  * }
  * </code>


### PR DESCRIPTION
Hello,
the method requiredField in the line 40 of the API documentation doesn't exist in the class DB.

I think that it should be DB::require_field($this->tableName, $this->name, "blob");
