### PR TITLE
DOCS fix broken link in changelog

### DIFF
--- a/docs/en/04_Changelogs/beta/4.6.0-beta1.md
+++ b/docs/en/04_Changelogs/beta/4.6.0-beta1.md
@@ -73,7 +73,7 @@ module, you should upgrade it as well.
 
 `silverstripe/mimevalidator` is now a core module and will ship by default on new projects. Projects referencing `silverstripe/recipe-core` will automatically install `silverstripe/mimevalidator` when they upgrade to 4.6.0.
 
-Read [Allowed file types](Developer_Guides/Files/Allowed_file_types) in the Silverstripe CMS doc for all the details.
+Read [Allowed file types](https://docs.silverstripe.org/en/4/developer_guides/files/allowed_file_types) in the Silverstripe CMS doc for all the details.
 
 <!--- Changes below this line will be automatically regenerated -->
 


### PR DESCRIPTION
The old link is broken because it tries: https://docs.silverstripe.org/en/4/changelogs/**beta**/Developer_Guides/Files/Allowed_file_types/