### PR TITLE
array_key_exists() on objects is deprecated

### DIFF
--- a/model/ArrayList.php
+++ b/model/ArrayList.php
@@ -475,7 +475,7 @@ class ArrayList extends ViewableData implements SS_List, SS_Filterable, SS_Sorta
 			return false;
 		}
 
-		return array_key_exists($by, $firstRecord);
+        return is_array($firstRecord) ? array_key_exists($by, $firstRecord) : property_exists($by, $firstRecord);
 	}
 
 	/**


### PR DESCRIPTION
Fix for array_key_exists() in PHP 7.4.
In GridFieldFilterHeader, the ArrayList::canFilterBy() method is called. E.g. for the method SiteTree::DependentPages this functionality is used. Link to an internal page in the CMS, save, go to the other page, you will get the deprecation notice.

Fix same as in 4.6.0
https://github.com/silverstripe/silverstripe-framework/commit/ec6a35354383cc18db9562af7b25841bfb2cd673


