### PR TITLE
NEW: Improved task runner UI.

### DIFF
--- a/client/styles/task-runner.css
+++ b/client/styles/task-runner.css
@@ -53,6 +53,7 @@
 }
 
 .task__button:focus,
-.task__button:hover {
+.task__button:hover,
+.task__button:focus {
   background-color: #ced5e1;
 }

--- a/client/styles/task-runner.css
+++ b/client/styles/task-runner.css
@@ -1,0 +1,51 @@
+/* This file is manually maintained, it is not generated from SCSS sources */
+
+.task__panel {
+  margin: 15px;
+}
+
+.task__list {
+  border-left: 1px solid #000000;
+  border-top: 1px solid #000000;
+  display: grid;
+  grid-template-columns: 1fr;
+  margin-top: 15px;
+}
+
+@media (min-width:992px) {
+  .task__list {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.task__item {
+  border-bottom: 1px solid #000000;
+  border-right: 1px solid #000000;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 15px;
+  transition: background-color 0.2s;
+}
+
+.task__item:hover {
+  background-color: #ffffff;
+}
+
+.task__item .description {
+  margin-bottom: 25px;
+}
+
+.task__button {
+  border: 1px solid #000000;
+  border-radius: 5px;
+  background-color: #f6f7f8;
+  display: inline-block;
+  padding: 10px 15px;
+  text-decoration: none;
+  transition: background-color 0.2s;
+}
+
+.task__button--warning:hover {
+  background-color: #ffebeb;
+}

--- a/client/styles/task-runner.css
+++ b/client/styles/task-runner.css
@@ -10,10 +10,8 @@
 
 @media (min-width:992px) {
   .task__list {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+    columns: 2;
     column-gap: 100px;
-    row-gap: 30px;
   }
 }
 
@@ -23,12 +21,9 @@
 
 @media (min-width:992px) {
   .task__item {
-    padding-bottom: 0;
+    display: inline-block;
+    width: 100%;
   }
-}
-
-.task__item:last-child {
-  padding-bottom: 0;
 }
 
 .task__title {

--- a/client/styles/task-runner.css
+++ b/client/styles/task-runner.css
@@ -28,12 +28,12 @@
 
 .task__title {
   color: #303b4d;
+  margin: 0 0 8px;
 }
 
 .task__description {
   color: #43536d;
-  margin-bottom: 20px;
-  margin-top: 15px;
+  margin-bottom: 12px;
 }
 
 .task__button {

--- a/client/styles/task-runner.css
+++ b/client/styles/task-runner.css
@@ -38,6 +38,7 @@
 .task__description {
   color: #43536d;
   margin-bottom: 20px;
+  margin-top: 15px;
 }
 
 .task__button {
@@ -56,6 +57,7 @@
   margin-right: 0;
 }
 
+.task__button:focus,
 .task__button:hover {
   background-color: #ced5e1;
 }

--- a/client/styles/task-runner.css
+++ b/client/styles/task-runner.css
@@ -1,55 +1,61 @@
 /* This file is manually maintained, it is not generated from SCSS sources */
 
+.task {
+  padding-top: 20px;
+}
+
 .task__panel {
-  margin-top: 10px;
-}
-
-.task__intro {
-  margin: 0 15px;
-}
-
-.task__list {
-  border-left: 1px solid #000000;
-  border-top: 1px solid #000000;
-  display: grid;
-  grid-template-columns: 1fr;
-  margin-top: 15px;
+  padding: 0 15px 15px 15px;
 }
 
 @media (min-width:992px) {
   .task__list {
+    display: grid;
     grid-template-columns: 1fr 1fr;
+    column-gap: 100px;
+    row-gap: 30px;
   }
 }
 
 .task__item {
-  border-bottom: 1px solid #000000;
-  border-right: 1px solid #000000;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding: 8px;
-  transition: background-color 0.2s;
+  padding-bottom: 30px;
 }
 
-.task__item:hover {
-  background-color: #ffffff;
+@media (min-width:992px) {
+  .task__item {
+    padding-bottom: 0;
+  }
 }
 
-.task__item .description {
-  margin-bottom: 10px;
+.task__item:last-child {
+  padding-bottom: 0;
+}
+
+.task__title {
+  color: #303b4d;
+}
+
+.task__description {
+  color: #43536d;
+  margin-bottom: 20px;
 }
 
 .task__button {
-  border: 1px solid #000000;
+  border: 1px solid #ced5e1;
   border-radius: 5px;
   background-color: #f6f7f8;
+  color: #43536d;
   display: inline-block;
-  padding: 5px 8px;
+  margin-right: 10px;
+  padding: 6px 10px;
   text-decoration: none;
   transition: background-color 0.2s;
 }
 
-.task__button--warning:hover {
-  background-color: #ffebeb;
+.task__button:last-child {
+  margin-right: 0;
+}
+
+.task__button:hover {
+  background-color: #ced5e1;
 }

--- a/client/styles/task-runner.css
+++ b/client/styles/task-runner.css
@@ -1,7 +1,11 @@
 /* This file is manually maintained, it is not generated from SCSS sources */
 
 .task__panel {
-  margin: 15px;
+  margin-top: 10px;
+}
+
+.task__intro {
+  margin: 0 15px;
 }
 
 .task__list {
@@ -24,7 +28,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: 15px;
+  padding: 8px;
   transition: background-color 0.2s;
 }
 
@@ -33,7 +37,7 @@
 }
 
 .task__item .description {
-  margin-bottom: 25px;
+  margin-bottom: 10px;
 }
 
 .task__button {
@@ -41,7 +45,7 @@
   border-radius: 5px;
   background-color: #f6f7f8;
   display: inline-block;
-  padding: 10px 15px;
+  padding: 5px 8px;
   text-decoration: none;
   transition: background-color 0.2s;
 }

--- a/client/styles/task-runner.css
+++ b/client/styles/task-runner.css
@@ -53,7 +53,6 @@
 }
 
 .task__button:focus,
-.task__button:hover,
-.task__button:focus {
+.task__button:hover {
   background-color: #ced5e1;
 }

--- a/src/Dev/TaskRunner.php
+++ b/src/Dev/TaskRunner.php
@@ -145,10 +145,12 @@ class TaskRunner extends Controller
             }
 
             $singleton = BuildTask::singleton($class);
+            $description = $singleton->getDescription();
+            $description = trim($description);
 
             $desc = (Director::is_cli())
-                ? Convert::html2raw($singleton->getDescription())
-                : $singleton->getDescription();
+                ? Convert::html2raw($description)
+                : $description;
 
             $availableTasks[] = [
                 'class' => $class,

--- a/templates/SilverStripe/Dev/TaskRunner.ss
+++ b/templates/SilverStripe/Dev/TaskRunner.ss
@@ -1,0 +1,26 @@
+$Header.RAW
+$Info.RAW
+
+<div class="task">
+    <div class="task__panel">
+        <h2>Tasks</h2>
+        <p>These tasks can be run immediately.</p>
+        <% if $Tasks.Count > 0 %>
+            <div class="task__list">
+                <% loop $Tasks %>
+                    <div class="task__item">
+                        <div>
+                            <h3>$Title</h3>
+                            <p class="description">$Description</p>
+                        </div>
+                        <div>
+                            <a href="{$TaskLink.ATT}" class="task__button task__button--warning">Run immediately</a>
+                        </div>
+                    </div>
+                <% end_loop %>
+            </div>
+        <% end_if %>
+    </div>
+</div>
+
+$Footer.RAW

--- a/templates/SilverStripe/Dev/TaskRunner.ss
+++ b/templates/SilverStripe/Dev/TaskRunner.ss
@@ -3,20 +3,16 @@ $Info.RAW
 
 <div class="task">
     <div class="task__panel">
-        <div class="task__intro">
-            <h2>Tasks</h2>
-            <p>These tasks can be run immediately.</p>
-        </div>
         <% if $Tasks.Count > 0 %>
             <div class="task__list">
                 <% loop $Tasks %>
                     <div class="task__item">
                         <div>
-                            <h3>$Title</h3>
-                            <p class="description">$Description</p>
+                            <h3 class="task__title">$Title</h3>
+                            <p class="task__description">$Description</p>
                         </div>
                         <div>
-                            <a href="{$TaskLink.ATT}" class="task__button task__button--warning">Run immediately</a>
+                            <a href="{$TaskLink.ATT}" class="task__button">Run task</a>
                         </div>
                     </div>
                 <% end_loop %>

--- a/templates/SilverStripe/Dev/TaskRunner.ss
+++ b/templates/SilverStripe/Dev/TaskRunner.ss
@@ -9,7 +9,7 @@ $Info.RAW
                     <div class="task__item">
                         <div>
                             <h3 class="task__title">$Title</h3>
-                            <p class="task__description">$Description</p>
+                            <div class="task__description">$Description</div>
                         </div>
                         <div>
                             <a href="{$TaskLink.ATT}" class="task__button">Run task</a>

--- a/templates/SilverStripe/Dev/TaskRunner.ss
+++ b/templates/SilverStripe/Dev/TaskRunner.ss
@@ -3,8 +3,10 @@ $Info.RAW
 
 <div class="task">
     <div class="task__panel">
-        <h2>Tasks</h2>
-        <p>These tasks can be run immediately.</p>
+        <div class="task__intro">
+            <h2>Tasks</h2>
+            <p>These tasks can be run immediately.</p>
+        </div>
         <% if $Tasks.Count > 0 %>
             <div class="task__list">
                 <% loop $Tasks %>


### PR DESCRIPTION
# Task runner better UI

Simple UI changes which improve usability of the task runner. Lightweight CSS (no build chain or JS required).

## Problem

* it takes time to find the dev task you want to run especially if you don't know the exact task name
* links which execute dev tasks are tiny, mis-click error can happen
* current UI is cluttered with too many dev tasks and the space is used inefficiently
* rendering component of the task runner is messy (combines backend and frontend logic)
* overriding frontend display requires subclassing

### Current UI
![Screen Shot 2020-06-09 at 11 14 27 AM](https://user-images.githubusercontent.com/26395487/84089251-91dd8a00-aa42-11ea-8f87-bb50cdf0cfea.png)

## Solution

* move the task into grid-style list so the screen is less cluttered
* visually separate the dev tasks
* visually separate the action buttons and make them much more visible
* split the rendering into backend (populate data) and a template (render), this allows the template to be overridden without subclassing

### Proposed UI
![Screen Shot 2020-06-09 at 11 20 22 AM](https://user-images.githubusercontent.com/26395487/84089617-876fc000-aa43-11ea-9eaa-6789316660d5.png)

## Related issues
https://github.com/silverstripe/silverstripe-framework/issues/9541

## Related Pull requests
https://github.com/symbiote/silverstripe-queuedjobs/pull/301