### PR TITLE
#3236 Added dev/config view

### DIFF
--- a/_config/dev.yml
+++ b/_config/dev.yml
@@ -13,3 +13,7 @@ SilverStripe\Dev\DevelopmentAdmin:
         tasks: 'See a list of build tasks to run'
     confirm:
       controller: SilverStripe\Dev\DevConfirmationController
+    config:
+      controller: Silverstripe\Dev\DevConfigController
+      links:
+        config: 'View the current config, useful for debugging'

--- a/docs/en/02_Developer_Guides/07_Debugging/02_URL_Variable_Tools.md
+++ b/docs/en/02_Developer_Guides/07_Debugging/02_URL_Variable_Tools.md
@@ -58,7 +58,7 @@ Redirections](/developer_guides/controllers/redirection) for more information an
  | ------------ | ------ | ----------- | 
  | BackURL      | URL    | Set to a relative URL string to use once Security Action is complete | 
 
-## Building and Publishing URLS
+## Building and Publishing URLs
 
  | Site URL                                      | Action | 
  | --------------------------------------------- | ------ | 
@@ -72,3 +72,9 @@ Redirections](/developer_guides/controllers/redirection) for more information an
  | quiet         | 1      | Don't show messages during build | 
  | dont_populate | 1      | Don't run **requireDefaultRecords()** on the models when building. This will build the table but not insert any records | 
 
+## Config diagnostic URLs
+
+ | Site URL                                      | Action | 
+ | --------------------------------------------- | ------ | 
+ | http://localhost**/dev/config**                | Output a simplified representation properties in the `Config` manifest | 
+ | http://localhost**/dev/config/audit**  | Audit `Config` properties and display any with missing PHP definitions |

--- a/src/Dev/DevConfigController.php
+++ b/src/Dev/DevConfigController.php
@@ -5,8 +5,10 @@ namespace SilverStripe\Dev;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use Symfony\Component\Yaml\Yaml;
+use SilverStripe\Core\Injector\Injector;
 
 /**
  * Class DevConfigController
@@ -20,6 +22,7 @@ class DevConfigController extends Controller
      * @var array
      */
     private static $url_handlers = [
+        'audit' => 'audit',
         '' => 'index'
     ];
 
@@ -27,7 +30,8 @@ class DevConfigController extends Controller
      * @var array
      */
     private static $allowed_actions = [
-        'index'
+        'index',
+        'audit',
     ];
 
     /**
@@ -38,16 +42,17 @@ class DevConfigController extends Controller
     public function index()
     {
         $body = '';
+        $subtitle = "Config manifest";
 
         if (Director::is_cli()) {
-            $body .= "\nCONFIG MANIFEST\n\n";
+            $body .= sprintf("\n%s\n\n", strtoupper($subtitle));
             $body .= Yaml::dump(Config::inst()->getAll(), 99, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
         } else {
             $renderer = DebugView::create();
             $body .= $renderer->renderHeader();
             $body .= $renderer->renderInfo("Configuration", Director::absoluteBaseURL());
             $body .= "<div class=\"options\">";
-            $body .= "<h2>Config manifest</h2>";
+            $body .= sprintf("<h2>%s</h2>", $subtitle);
             $body .= "<pre>";
             $body .= Yaml::dump(Config::inst()->getAll(), 99, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
             $body .= "</pre>";
@@ -56,5 +61,100 @@ class DevConfigController extends Controller
         }
 
         return $this->getResponse()->setBody($body);
+    }
+
+    /**
+     * Output the extraneous config properties which are defined in .yaml but not in a corresponding class
+     *
+     * @return string|HTTPResponse
+     */
+    public function audit()
+    {
+        $body = '';
+        $missing = [];
+        $subtitle = "Missing Config property definitions";
+
+        foreach ($this->array_keys_recursive(Config::inst()->getAll(), 2) as $className => $props) {
+            $props = array_keys($props);
+
+            if (!count($props)) {
+                // We can skip this entry
+                continue;
+            }
+
+            if ($className == strtolower(Injector::class)) {
+                // We don't want to check the injector config
+                continue;
+            }
+
+            foreach ($props as $prop) {
+                $defined = false;
+                // Check ancestry (private properties don't inherit natively)
+                foreach (ClassInfo::ancestry($className) as $cn) {
+                    if (property_exists($cn, $prop)) {
+                        $defined = true;
+                        break;
+                    }
+                }
+
+                if ($defined) {
+                    // No need to record this property
+                    continue;
+                }
+
+                $missing[] = sprintf("%s::$%s\n", $className, $prop);
+            }
+        }
+
+        $output = count($missing)
+            ? implode("\n", $missing)
+            : "All configured properties are defined\n";
+
+        if (Director::is_cli()) {
+            $body .= sprintf("\n%s\n\n", strtoupper($subtitle));
+            $body .= $output;
+        } else {
+            $renderer = DebugView::create();
+            $body .= $renderer->renderHeader();
+            $body .= $renderer->renderInfo(
+                "Configuration",
+                Director::absoluteBaseURL(),
+                "Config properties that are not defined (or inherited) by their respective classes"
+            );
+            $body .= "<div class=\"options\">";
+            $body .= sprintf("<h2>%s</h2>", $subtitle);
+            $body .= sprintf("<pre>%s</pre>", $output);
+            $body .= "</div>";
+            $body .= $renderer->renderFooter();
+        }
+
+        return $this->getResponse()->setBody($body);
+    }
+
+    /**
+     * Returns all the keys of a multi-dimensional array while maintining any nested structure
+     *
+     * @param array $array
+     * @param int $maxdepth
+     * @param int $depth
+     * @param array $arrayKeys
+     * @return array
+     */
+    protected function array_keys_recursive($array, $maxdepth = 20, $depth = 0, $arrayKeys = [])
+    {
+        if ($depth < $maxdepth) {
+            $depth++;
+            $keys = array_keys($array);
+
+            foreach ($keys as $key) {
+                if (!is_array($array[$key])) {
+                    continue;
+                }
+
+                $arrayKeys[$key] = $this->array_keys_recursive($array[$key], $maxdepth, $depth);
+            }
+        }
+
+        return $arrayKeys;
     }
 }

--- a/src/Dev/DevConfigController.php
+++ b/src/Dev/DevConfigController.php
@@ -37,22 +37,24 @@ class DevConfigController extends Controller
      */
     public function index()
     {
+        $body = '';
+
         if (Director::is_cli()) {
-            echo "\nCONFIG MANIFEST\n\n";
-            echo Yaml::dump(Config::inst()->getAll(), 99, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+            $body .= "\nCONFIG MANIFEST\n\n";
+            $body .= Yaml::dump(Config::inst()->getAll(), 99, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
         } else {
             $renderer = DebugView::create();
-            echo $renderer->renderHeader();
-            echo $renderer->renderInfo("Configuration", Director::absoluteBaseURL());
-            echo "<div class=\"options\">";
-            echo "<h2>Config manifest</h2>";
-            echo "<pre>";
-            echo Yaml::dump(Config::inst()->getAll(), 99, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
-            echo "</pre>";
-            echo "</div>";
-            echo $renderer->renderFooter();
+            $body .= $renderer->renderHeader();
+            $body .= $renderer->renderInfo("Configuration", Director::absoluteBaseURL());
+            $body .= "<div class=\"options\">";
+            $body .= "<h2>Config manifest</h2>";
+            $body .= "<pre>";
+            $body .= Yaml::dump(Config::inst()->getAll(), 99, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+            $body .= "</pre>";
+            $body .= "</div>";
+            $body .= $renderer->renderFooter();
         }
 
-        return $this->getResponse();
+        return $this->getResponse()->setBody($body);
     }
 }

--- a/src/Dev/DevConfigController.php
+++ b/src/Dev/DevConfigController.php
@@ -11,9 +11,7 @@ use Symfony\Component\Yaml\Yaml;
 use SilverStripe\Core\Injector\Injector;
 
 /**
- * Class DevConfigController
- *
- * @package SilverStripe\Dev
+ * Outputs the full configuration.
  */
 class DevConfigController extends Controller
 {
@@ -140,7 +138,7 @@ class DevConfigController extends Controller
      * @param array $arrayKeys
      * @return array
      */
-    protected function array_keys_recursive($array, $maxdepth = 20, $depth = 0, $arrayKeys = [])
+    private function array_keys_recursive($array, $maxdepth = 20, $depth = 0, $arrayKeys = [])
     {
         if ($depth < $maxdepth) {
             $depth++;

--- a/src/Dev/DevConfigController.php
+++ b/src/Dev/DevConfigController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SilverStripe\Dev;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\Config\Config;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Class DevConfigController
+ *
+ * @package SilverStripe\Dev
+ */
+class DevConfigController extends Controller
+{
+
+    /**
+     * @var array
+     */
+    private static $url_handlers = [
+        '' => 'index'
+    ];
+
+    /**
+     * @var array
+     */
+    private static $allowed_actions = [
+        'index'
+    ];
+
+    /**
+     * Note: config() method is already defined, so let's just use index()
+     *
+     * @return string|HTTPResponse
+     */
+    public function index()
+    {
+        if (Director::is_cli()) {
+            echo "\nCONFIG MANIFEST\n\n";
+            echo Yaml::dump(Config::inst()->getAll(), 99, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+        } else {
+            $renderer = DebugView::create();
+            echo $renderer->renderHeader();
+            echo $renderer->renderInfo("Configuration", Director::absoluteBaseURL());
+            echo "<div class=\"options\">";
+            echo "<h2>Config manifest</h2>";
+            echo "<pre>";
+            echo Yaml::dump(Config::inst()->getAll(), 99, 2, Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+            echo "</pre>";
+            echo "</div>";
+            echo $renderer->renderFooter();
+        }
+
+        return $this->getResponse();
+    }
+}


### PR DESCRIPTION
Added a dev view to output the current config from `dev/config`

e.g `.vendor/silverstripe/framework/sake dev/config` or `/dev/config` in a browser

Output is a simple Yaml representation of the config manifest
![image](https://user-images.githubusercontent.com/1634995/84245935-eb84a800-ab59-11ea-8b2e-44f3fa368deb.png)

https://github.com/silverstripe/silverstripe-framework/issues/3236

UPDATE:

Added a dev view to output missing property definitions in the current config from `dev/config/audit`

![image](https://user-images.githubusercontent.com/1634995/84335021-f423bf80-abe7-11ea-8dad-20ce49388b55.png)

