### PR TITLE
Added onAfterBuild

### DIFF
--- a/src/ORM/DataExtension.php
+++ b/src/ORM/DataExtension.php
@@ -118,6 +118,15 @@ abstract class DataExtension extends Extension
     }
 
     /**
+     * Extend the owner's onAfterBuild() logic
+     *
+     * See {@link DataObject::onAfterBuild()} for context.
+     */
+    public function onAfterBuild()
+    {
+    }
+
+    /**
      * Influence the owner's can() permission check value to be disallowed (false),
      * allowed (true) if no other processed results are to disallow, or open (null) to not
      * affect the outcome.

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3543,6 +3543,17 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     }
 
     /**
+     * Invoked after every database build is complete (including after table creation and
+     * default record population).
+     *
+     * See {@link DatabaseAdmin::doBuild()} for context.
+     */
+    public function onAfterBuild()
+    {
+        $this->extend('onAfterBuild', $dummy);
+    }
+
+    /**
      * Get the default searchable fields for this object, as defined in the
      * $searchable_fields list. If searchable fields are not defined on the
      * data object, uses a default selection of summary fields.

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3550,7 +3550,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      */
     public function onAfterBuild()
     {
-        $this->extend('onAfterBuild', $dummy);
+        $this->extend('onAfterBuild');
     }
 
     /**

--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -401,6 +401,10 @@ class DatabaseAdmin extends Controller
             echo (Director::is_cli()) ? "\n Database build completed!\n\n" :"<p>Database build completed!</p>";
         }
 
+        foreach ($dataClasses as $dataClass) {
+            DataObject::singleton($dataClass)->onAfterBuild();
+        }
+
         ClassInfo::reset_db_cache();
     }
 


### PR DESCRIPTION
https://github.com/silverstripe/silverstripe-framework/issues/5206

DataObjects can now invoke logic after database build is complete, using `MyDataObject->onAfterBuild()` or `MyDataExtension->onAfterBuild()`

~No expected~ Minimal or circumstantial impact on existing behaviour. (🙏🏻 @michalkleiner)

