### PR TITLE
deprecate First and Last in order to disambiguate for array lists

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/01_Syntax.md
+++ b/docs/en/02_Developer_Guides/01_Templates/01_Syntax.md
@@ -358,6 +358,8 @@ iteration.
  * `$Even`, `$Odd`: Returns boolean, handy for zebra striping.
  * `$EvenOdd`: Returns a string, either 'even' or 'odd'. Useful for CSS classes.
  * `$First`, `$Last`, `$Middle`: Booleans about the position in the list.
+    * Note: as of CMS 4.7.0 `$IsFirst` and `$IsLast` will be preferred. The original
+    syntax will continue to work, but will be deprecated in a future release.
  * `$FirstLast`: Returns a string, "first", "last", "first last" (if both), or "". Useful for CSS classes.
  * `$Pos`: The current position in the list (integer).
    Will start at 1, but can take a starting index as a parameter.

--- a/src/View/SSViewer_BasicIteratorSupport.php
+++ b/src/View/SSViewer_BasicIteratorSupport.php
@@ -67,12 +67,12 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
     }
 
     /**
-     * @deprecated
+     * @deprecated 4.7.0 Use isFirst() to avoid clashes with SS_Lists
      * @return bool
      */
     public function First()
     {
-        Deprecation::notice("5.0.0 please use isFirst() to avoid clashes with SS_Lists");
+        Deprecation::notice('4.7.0', 'Use isFirst() to avoid clashes with SS_Lists');
         return $this->isFirst();
     }
 
@@ -87,12 +87,12 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
     }
 
     /**
-     * @deprecated
+     * @deprecated 4.7.0 Use isLast() to avoid clashes with SS_Lists
      * @return bool
      */
     public function Last()
     {
-        Deprecation::notice("5.0.0 please use isLast() to avoid clashes with SS_Lists");
+        Deprecation::notice('4.7.0', 'Use isLast() to avoid clashes with SS_Lists');
         return $this->isLast();
     }
 

--- a/src/View/SSViewer_BasicIteratorSupport.php
+++ b/src/View/SSViewer_BasicIteratorSupport.php
@@ -72,7 +72,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      */
     public function First()
     {
-        Deprecation::notice('5.0', 'Use IsFirst() to avoid clashes with SS_Lists');
+        Deprecation::notice('5.0.0', 'Use IsFirst() to avoid clashes with SS_Lists');
         return $this->IsFirst();
     }
 

--- a/src/View/SSViewer_BasicIteratorSupport.php
+++ b/src/View/SSViewer_BasicIteratorSupport.php
@@ -67,7 +67,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
     }
 
     /**
-     * @deprecated 5.0 Use IsFirst() to avoid clashes with SS_Lists
+     * @deprecated 5.0.0 Use IsFirst() to avoid clashes with SS_Lists
      * @return bool
      */
     public function First()
@@ -87,12 +87,12 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
     }
 
     /**
-     * @deprecated 5.0 Use IsLast() to avoid clashes with SS_Lists
+     * @deprecated 5.0.0 Use IsLast() to avoid clashes with SS_Lists
      * @return bool
      */
     public function Last()
     {
-        Deprecation::notice('5.0', 'Use IsLast() to avoid clashes with SS_Lists');
+        Deprecation::notice('5.0.0', 'Use IsLast() to avoid clashes with SS_Lists');
         return $this->IsLast();
     }
 

--- a/src/View/SSViewer_BasicIteratorSupport.php
+++ b/src/View/SSViewer_BasicIteratorSupport.php
@@ -26,8 +26,8 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
     public static function get_template_iterator_variables()
     {
         return [
-            'isFirst',
-            'isLast',
+            'IsFirst',
+            'IsLast',
             'First',
             'Last',
             'FirstLast',
@@ -61,19 +61,19 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      *
      * @return bool
      */
-    public function isFirst()
+    public function IsFirst()
     {
         return $this->iteratorPos == 0;
     }
 
     /**
-     * @deprecated 4.7.0 Use isFirst() to avoid clashes with SS_Lists
+     * @deprecated 5.0 Use IsFirst() to avoid clashes with SS_Lists
      * @return bool
      */
     public function First()
     {
-        Deprecation::notice('4.7.0', 'Use isFirst() to avoid clashes with SS_Lists');
-        return $this->isFirst();
+        Deprecation::notice('5.0', 'Use IsFirst() to avoid clashes with SS_Lists');
+        return $this->IsFirst();
     }
 
     /**
@@ -81,19 +81,19 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      *
      * @return bool
      */
-    public function isLast()
+    public function IsLast()
     {
         return $this->iteratorPos == $this->iteratorTotalItems - 1;
     }
 
     /**
-     * @deprecated 4.7.0 Use isLast() to avoid clashes with SS_Lists
+     * @deprecated 5.0 Use IsLast() to avoid clashes with SS_Lists
      * @return bool
      */
     public function Last()
     {
-        Deprecation::notice('4.7.0', 'Use isLast() to avoid clashes with SS_Lists');
-        return $this->isLast();
+        Deprecation::notice('5.0', 'Use IsLast() to avoid clashes with SS_Lists');
+        return $this->IsLast();
     }
 
     /**
@@ -103,13 +103,13 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      */
     public function FirstLast()
     {
-        if ($this->isFirst() && $this->isLast()) {
+        if ($this->IsFirst() && $this->IsLast()) {
             return 'first last';
         }
-        if ($this->isFirst()) {
+        if ($this->IsFirst()) {
             return 'first';
         }
-        if ($this->isLast()) {
+        if ($this->IsLast()) {
             return 'last';
         }
         return null;
@@ -122,7 +122,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      */
     public function Middle()
     {
-        return !$this->isFirst() && !$this->isLast();
+        return !$this->IsFirst() && !$this->IsLast();
     }
 
     /**

--- a/src/View/SSViewer_BasicIteratorSupport.php
+++ b/src/View/SSViewer_BasicIteratorSupport.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\View;
 
+use SilverStripe\Dev\Deprecation;
+
 /**
  * Defines an extra set of basic methods that can be used in templates
  * that are not defined on sub-classes of {@link ViewableData}.
@@ -24,6 +26,8 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
     public static function get_template_iterator_variables()
     {
         return [
+            'isFirst',
+            'isLast',
             'First',
             'Last',
             'FirstLast',
@@ -57,9 +61,19 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      *
      * @return bool
      */
-    public function First()
+    public function isFirst()
     {
         return $this->iteratorPos == 0;
+    }
+
+    /**
+     * @deprecated
+     * @return bool
+     */
+    public function First()
+    {
+        Deprecation::notice("5.0.0 please use isFirst() to avoid clashes with SS_Lists");
+        return $this->isFirst();
     }
 
     /**
@@ -67,9 +81,19 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      *
      * @return bool
      */
-    public function Last()
+    public function isLast()
     {
         return $this->iteratorPos == $this->iteratorTotalItems - 1;
+    }
+
+    /**
+     * @deprecated
+     * @return bool
+     */
+    public function Last()
+    {
+        Deprecation::notice("5.0.0 please use isLast() to avoid clashes with SS_Lists");
+        return $this->isLast();
     }
 
     /**
@@ -79,13 +103,13 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      */
     public function FirstLast()
     {
-        if ($this->First() && $this->Last()) {
+        if ($this->isFirst() && $this->isLast()) {
             return 'first last';
         }
-        if ($this->First()) {
+        if ($this->isFirst()) {
             return 'first';
         }
-        if ($this->Last()) {
+        if ($this->isLast()) {
             return 'last';
         }
         return null;
@@ -98,7 +122,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      */
     public function Middle()
     {
-        return !$this->First() && !$this->Last();
+        return !$this->isFirst() && !$this->isLast();
     }
 
     /**


### PR DESCRIPTION
Comes from a conversation on Slack - if you have a `ArrayList` of `ArrayList`s in a template, calling `$First` in a loop in a template will always return true, as it calls the `->first()` method on the `ArrayList` instead of the `->First()` method from `SSViewer_BasicIteratorSupport`.

This PR deprecates those methods in favour of boolean-indicating `$isFirst` and the counterpart `$isLast`.

Not sure I've done the deprecation right so happy to adjust based on feedback - or rename.