### PR TITLE
Added mention of Session.timeout to secure_coding docs

### DIFF
--- a/docs/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
+++ b/docs/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
@@ -617,6 +617,7 @@ In addition, you can tighten password security with the following configuration 
     the user is blocked from further attempts for the timespan defined in `$lock_out_delay_mins`
  * `Member.lock_out_delay_mins`: Minutes of enforced lockout after incorrect password attempts. Only applies if `lock_out_after_incorrect_logins` is greater than 0.
  * `Security.remember_username`: Set to false to disable autocomplete on login form
+ * `Session.timeout`: Set timeout to attenuate the risk of active sessions being exploited
 
 ## Clickjacking: Prevent iframe Inclusion
 


### PR DESCRIPTION
https://github.com/silverstripe/silverstripe-framework/issues/5860

Just a brief mention of `Session.timeout`, no expected changes to existing behaviour.