### PR TITLE
Added a check for configured field name conflict with inherited methods

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3451,6 +3451,17 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
             );
         }
 
+        // Sanity check for fields that conflict with parent
+        foreach (array_keys($fields) as $fieldName) {
+            if (method_exists(get_parent_class($this), $fieldName)) {
+                throw new LogicException(sprintf(
+                    '\'%s\' has a $db field named "%s" that coincides with an inherited method of the same name.',
+                    static::class,
+                    $fieldName
+                ));
+            }
+        }
+
         if ($fields) {
             $hasAutoIncPK = get_parent_class($this) === self::class;
             DB::require_table(


### PR DESCRIPTION
https://github.com/silverstripe/silverstripe-framework/issues/6329

Added a sanity check which throws an error if a configured field has the same name as a method in the parent-level scope

![image](https://user-images.githubusercontent.com/1634995/84734140-4273fc80-aff4-11ea-8918-8cfd286eb602.png)

