### PR TITLE
MINOR: Add noindex metatag to debugview

### DIFF
--- a/src/Dev/DebugView.php
+++ b/src/Dev/DebugView.php
@@ -223,6 +223,7 @@ class DebugView
             ->resolveURL('silverstripe/framework:client/styles/debug.css');
         $output = '<!DOCTYPE html><html><head><title>' . $url . '</title>';
         $output .= '<link rel="stylesheet" type="text/css" href="' . $debugCSS . '" />';
+        $output .= '<meta name="robots" content="noindex">';
         $output .= '</head>';
         $output .= '<body>';
 


### PR DESCRIPTION
No idea how common this was, but I just noticed that Google was crawling my /dev/ URLs. Not a security issue because they're throwing 403s, but we should have this as a fallback just in case someone accidentally leaves a production site in dev mode or something. 