### PR TITLE
add onBeforeFirstWrite and onAfterFirstWrite methods and test

### DIFF
--- a/src/ORM/DataExtension.php
+++ b/src/ORM/DataExtension.php
@@ -64,7 +64,15 @@ abstract class DataExtension extends Extension
     {
     }
 
+    public function onBeforeFirstWrite()
+    {
+    }
+
     public function onAfterWrite()
+    {
+    }
+
+    public function onAfterFirstWrite()
     {
     }
 

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -140,6 +140,12 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     private static $default_classname = null;
 
     /**
+     * Used by onAfterWrite() to track whether onAfterFirstWrite() needs to be called
+     * @var boolean
+     */
+    protected static $isFirstWrite = false;
+
+    /**
      * @deprecated 4.0.0:5.0.0
      * @var bool
      */
@@ -218,12 +224,6 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @var boolean
      */
     protected $brokenOnWrite = false;
-
-    /**
-     * Used by onAfterWrite() to track whether onAfterFirstWrite() needs to be called
-     * @var boolean
-     */
-    protected $isFirstWrite = false;
 
     /**
      * Should dataobjects be validated before they are written?
@@ -1211,7 +1211,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     protected function onBeforeFirstWrite()
     {
         $this->brokenOnWrite = false;
-        $this->isFirstWrite = true;
+        static::$isFirstWrite = true;
 
         $dummy = null;
         $this->extend('onBeforeFirstWrite', $dummy);

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -220,6 +220,12 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     protected $brokenOnWrite = false;
 
     /**
+     * Used by onAfterWrite() to track whether onAfterFirstWrite() needs to be called
+     * @var boolean
+     */
+    protected $isFirstWrite = false;
+
+    /**
      * Should dataobjects be validated before they are written?
      *
      * Caution: Validation can contain safeguards against invalid/malicious data,
@@ -1184,10 +1190,31 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      */
     protected function onBeforeWrite()
     {
+        if (!$this->exists()) {
+            $this->onBeforeFirstWrite();
+        }
         $this->brokenOnWrite = false;
 
         $dummy = null;
         $this->extend('onBeforeWrite', $dummy);
+    }
+
+    /**
+     * Event handler called before writing to the database for the first time
+     * You can overload this to clean up or otherwise process data before writing it to the
+     * database.  Don't forget to call parent::onBeforeFirstWrite(), though!
+     *
+     * This called after {@link $this->validate()}, so you can be sure that your data is valid.
+     *
+     * @uses DataExtension->onBeforeFirstWrite()
+     */
+    protected function onBeforeFirstWrite()
+    {
+        $this->brokenOnWrite = false;
+        $this->isFirstWrite = true;
+
+        $dummy = null;
+        $this->extend('onBeforeFirstWrite', $dummy);
     }
 
     /**
@@ -1200,8 +1227,25 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      */
     protected function onAfterWrite()
     {
+        if ($this->isFirstWrite) {
+            $this->onAfterFirstWrite();
+        }
         $dummy = null;
         $this->extend('onAfterWrite', $dummy);
+    }
+
+    /**
+     * Event handler called after writing to the database for the first time.
+     * You can overload this to act upon changes made to the data after it is written.
+     * $this->changed will have a record
+     * database.  Don't forget to call parent::onAfterFirstWrite(), though!
+     *
+     * @uses DataExtension->onAfterFirstWrite()
+     */
+    protected function onAfterFirstWrite()
+    {
+        $dummy = null;
+        $this->extend('onAfterFirstWrite', $dummy);
     }
 
     /**

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -875,16 +875,23 @@ class DataObjectTest extends SapphireTest
         $rookie->ChangeMeToForceWrites = 'Debut!';
         $rookie->write();
         $this->assertEquals(1, $rookie->CalledOnBeforeFirstWrite);
-        $this->assertEquals(1, $rookie->CalledOnBeforeWrite);
         $this->assertEquals(1, $rookie->CalledOnAfterFirstWrite);
-        $this->assertEquals(1, $rookie->CalledOnAfterWrite);
+
+        // Has to be done this way as onAfter and onBefore are called multiple times
+        $onBeforeCount = $rookie->CalledOnBeforeWrite;
+        $onAfterCount = $rookie->CalledOnAfterWrite;
+
+        $this->assertGreaterThanOrEqual(1, $onBeforeCount);
+        $this->assertGreaterThanOrEqual(1, $onAfterCount);
 
         $rookie->ChangeMeToForceWrites = 'Player of the match!';
         $rookie->write();
+
+        // Confirm these values haven't been updated the second time of asking
         $this->assertEquals(1, $rookie->CalledOnBeforeFirstWrite);
-        $this->assertEquals(2, $rookie->CalledOnBeforeWrite);
         $this->assertEquals(1, $rookie->CalledOnAfterFirstWrite);
-        $this->assertEquals(2, $rookie->CalledOnAfterWrite);
+        $this->assertGreaterThan($onBeforeCount, $rookie->CalledOnBeforeWrite);
+        $this->assertGreaterThan($onAfterCount, $rookie->CalledOnAfterWrite);
     }
 
     public function testForceChangeCantBeCancelledUntilWrite()

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -18,6 +18,7 @@ use SilverStripe\ORM\FieldType\DBPolymorphicForeignKey;
 use SilverStripe\ORM\FieldType\DBVarchar;
 use SilverStripe\ORM\ManyManyList;
 use SilverStripe\ORM\Tests\DataObjectTest\Company;
+use SilverStripe\ORM\Tests\DataObjectTest\FirstTimer;
 use SilverStripe\ORM\Tests\DataObjectTest\Player;
 use SilverStripe\ORM\Tests\DataObjectTest\TreeNode;
 use SilverStripe\Security\Member;
@@ -61,6 +62,7 @@ class DataObjectTest extends SapphireTest
         DataObjectTest\RelationChildSecond::class,
         DataObjectTest\MockDynamicAssignmentDataObject::class,
         DataObjectTest\TreeNode::class,
+        DataObjectTest\FirstTimer::class,
     );
 
     protected function setUp() : void
@@ -864,6 +866,25 @@ class DataObjectTest extends SapphireTest
             ),
             $obj->getChangedFields(true, DataObject::CHANGE_VALUE)
         );
+    }
+
+    public function testOnBeforeAndOnAfterFirstAndAnyWrite()
+    {
+        /** @var DataObjectTest\FirstTimer $rookie */
+        $rookie = $this->objFromFixture(DataObjectTest\FirstTimer::class, 'rookie');
+        $rookie->ChangeMeToForceWrites = 'Debut!';
+        $rookie->write();
+        $this->assertEquals(1, $rookie->CalledOnBeforeFirstWrite);
+        $this->assertEquals(1, $rookie->CalledOnBeforeWrite);
+        $this->assertEquals(1, $rookie->CalledOnAfterFirstWrite);
+        $this->assertEquals(1, $rookie->CalledOnAfterWrite);
+
+        $rookie->ChangeMeToForceWrites = 'Player of the match!';
+        $rookie->write();
+        $this->assertEquals(1, $rookie->CalledOnBeforeFirstWrite);
+        $this->assertEquals(2, $rookie->CalledOnBeforeWrite);
+        $this->assertEquals(1, $rookie->CalledOnAfterFirstWrite);
+        $this->assertEquals(2, $rookie->CalledOnAfterWrite);
     }
 
     public function testForceChangeCantBeCancelledUntilWrite()

--- a/tests/php/ORM/DataObjectTest.yml
+++ b/tests/php/ORM/DataObjectTest.yml
@@ -189,3 +189,11 @@ SilverStripe\ORM\Tests\DataObjectTest\TreeNode:
   grandchild:
     Title: GrandChildren
     Parent: =>SilverStripe\ORM\Tests\DataObjectTest\TreeNode.child
+
+SilverStripe\ORM\Tests\DataObjectTest\FirstTimer:
+  rookie:
+    ChangeMeToForceWrites: rookie
+    CalledOnBeforeFirstWrite: 0
+    CalledOnBeforeWrite: 0
+    CalledOnAfterFirstWrite: 0
+    CalledOnAfterWrite: 0

--- a/tests/php/ORM/DataObjectTest/FirstTimer.php
+++ b/tests/php/ORM/DataObjectTest/FirstTimer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * Class FirstTimer
+ *
+ * @package SilverStripe\ORM\Tests\DataObjectTest
+ * @property string ChangeMeToForceWrites
+ * @property integer CalledOnBeforeFirstWrite
+ * @property integer CalledOnBeforeWrite
+ * @property integer CalledOnAfterFirstWrite
+ * @property integer CalledOnAfterWrite
+ */
+class FirstTimer extends DataObject implements TestOnly
+{
+    private static $table_name = 'DataObjectTest_FirstTimer';
+
+    private static $db = [
+        'ChangeMeToForceWrites' => 'Varchar',
+        'CalledOnBeforeFirstWrite' => 'Int',
+        'CalledOnBeforeWrite' => 'Int',
+        'CalledOnAfterFirstWrite' => 'Int',
+        'CalledOnAfterWrite' => 'Int',
+    ];
+
+    public function onBeforeFirstWrite()
+    {
+        $this->increment('CalledOnBeforeFirstWrite');
+        parent::onBeforeFirstWrite();
+    }
+
+    public function onBeforeWrite()
+    {
+        $this->increment('CalledOnBeforeWrite');
+        parent::onBeforeWrite();
+    }
+
+    public function onAfterFirstWrite()
+    {
+        $this->increment('CalledOnAfterFirstWrite');
+        parent::onAfterFirstWrite();
+    }
+
+    public function onAfterWrite()
+    {
+        $this->increment('CalledOnAfterWrite');
+        parent::onAfterWrite();
+    }
+
+    private function increment($field)
+    {
+        $this->setField($field, $this->getField($field) + 1);
+    }
+}


### PR DESCRIPTION
Not sure that `master` is the best destination but happy to rebase.

Came from a recurrence of the "onBeforeWrite was called lots of times" problem - I think this pattern comes up reasonably often and this method is designed to catch that occurrence.

Allows use of `onBeforeFirstWrite()` and `onAfterFirstWrite()` which are reasonably self-explanatory.