### PR TITLE
Doc Update Formatting and Casting SS_DateTime to DBDateTime

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/09_Casting.md
+++ b/docs/en/02_Developer_Guides/01_Templates/09_Casting.md
@@ -20,7 +20,7 @@ $Content.FirstParagraph
 <!-- returns the result of HtmlText::FirstParagragh() -->
 
 $LastEdited.Format("d/m/Y")
-<!-- returns the result of SS_Datetime::Format("d/m/Y") -->
+<!-- returns the result of DBDatetime::Format("d/m/Y") -->
 ```
 
 Any public method from the object in scope can be called within the template. If that method returns another 


### PR DESCRIPTION
Changed SS_DateTime to DBDatetime as SS_DateTime was changed to DBDateTime in version 4.0

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
