### PR TITLE
BUGFIX: Ensure $items isn't null in GridFieldDetailForm_ItemRequest->…

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -786,17 +786,19 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
         /** @var ArrayList $items */
         $items = $this->popupController->Breadcrumbs($unlinked);
 
-        if ($this->record && $this->record->ID) {
-            $title = ($this->record->Title) ? $this->record->Title : "#{$this->record->ID}";
-            $items->push(new ArrayData([
-                'Title' => $title,
-                'Link' => $this->Link()
-            ]));
-        } else {
-            $items->push(new ArrayData([
-                'Title' => _t('SilverStripe\\Forms\\GridField\\GridField.NewRecord', 'New {type}', ['type' => $this->record->i18n_singular_name()]),
-                'Link' => false
-            ]));
+        if ($items) {
+            if ($this->record && $this->record->ID) {
+                $title = ($this->record->Title) ? $this->record->Title : "#{$this->record->ID}";
+                $items->push(new ArrayData([
+                    'Title' => $title,
+                    'Link' => $this->Link()
+                ]));
+            } else {
+                $items->push(new ArrayData([
+                    'Title' => _t('SilverStripe\\Forms\\GridField\\GridField.NewRecord', 'New {type}', ['type' => $this->record->i18n_singular_name()]),
+                    'Link' => false
+                ]));
+            }
         }
 
         $this->extend('updateBreadcrumbs', $items);

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -464,8 +464,10 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
             if ($toplevelController->hasMethod('Backlink')) {
                 $backlink = $toplevelController->Backlink();
             } elseif ($this->popupController->hasMethod('Breadcrumbs')) {
-                $parents = $this->popupController->Breadcrumbs(false)->items;
-                $backlink = array_pop($parents)->Link;
+                $parents = $this->popupController->Breadcrumbs(false);
+                if ($parents && $parents = $parents->items) {
+                    $backlink = array_pop($parents)->Link;
+                }
             }
         }
         if (!$backlink) {
@@ -786,19 +788,21 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
         /** @var ArrayList $items */
         $items = $this->popupController->Breadcrumbs($unlinked);
 
-        if ($items) {
-            if ($this->record && $this->record->ID) {
-                $title = ($this->record->Title) ? $this->record->Title : "#{$this->record->ID}";
-                $items->push(new ArrayData([
-                    'Title' => $title,
-                    'Link' => $this->Link()
-                ]));
-            } else {
-                $items->push(new ArrayData([
-                    'Title' => _t('SilverStripe\\Forms\\GridField\\GridField.NewRecord', 'New {type}', ['type' => $this->record->i18n_singular_name()]),
-                    'Link' => false
-                ]));
-            }
+        if (!$items) {
+            $items = new ArrayList();
+        }
+
+        if ($this->record && $this->record->ID) {
+            $title = ($this->record->Title) ? $this->record->Title : "#{$this->record->ID}";
+            $items->push(new ArrayData([
+                'Title' => $title,
+                'Link' => $this->Link()
+            ]));
+        } else {
+            $items->push(new ArrayData([
+                'Title' => _t('SilverStripe\\Forms\\GridField\\GridField.NewRecord', 'New {type}', ['type' => $this->record->i18n_singular_name()]),
+                'Link' => false
+            ]));
         }
 
         $this->extend('updateBreadcrumbs', $items);


### PR DESCRIPTION
…Breadcrumbs() prior to performing operations on it.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
