### PR TITLE
Fixes getCMSFields TabSet example

### DIFF
--- a/docs/en/02_Developer_Guides/00_Model/11_Scaffolding.md
+++ b/docs/en/02_Developer_Guides/00_Model/11_Scaffolding.md
@@ -44,11 +44,13 @@ To fully customise your form fields, start with an empty FieldList.
 public function getCMSFields() 
 {
     $fields = FieldList::create(
-        TabSet::create("Root.Main",
-            CheckboxSetField::create('IsActive','Is active?'),
-            TextField::create('Title'),
-            TextareaField::create('Content')
-                ->setRows(5)
+        TabSet::create("Root",
+            Tab::create("Main",
+                CheckboxSetField::create('IsActive','Is active?'),
+                TextField::create('Title'),
+                TextareaField::create('Content')
+                    ->setRows(5)
+            )
         )
     );
     


### PR DESCRIPTION
Current example results in: "[Emergency] Uncaught InvalidArgumentException: TabSet can only contain instances of other Tab or Tabsets"

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
