### PR TITLE
NEW: Add/remove callbacks for relation lists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "silverstripe/config": "^1@dev",
         "silverstripe/assets": "^1@dev",
         "silverstripe/vendor-plugin": "^1.4",
+        "sminnee/callbacklist": "^0.1",
         "swiftmailer/swiftmailer": "~5.4",
         "symfony/cache": "^3.3@dev",
         "symfony/config": "^3.2",

--- a/src/ORM/HasManyList.php
+++ b/src/ORM/HasManyList.php
@@ -93,6 +93,10 @@ class HasManyList extends RelationList
         $item->$foreignKey = $foreignID;
 
         $item->write();
+
+        if ($this->addCallbacks) {
+            $this->addCallbacks->call($this, $item, []);
+        }
     }
 
     /**
@@ -135,6 +139,10 @@ class HasManyList extends RelationList
         ) {
             $item->$foreignKey = null;
             $item->write();
+        }
+
+        if ($this->removeCallbacks) {
+            $this->removeCallbacks->call($this, [$item->ID]);
         }
     }
 }

--- a/src/ORM/RelationList.php
+++ b/src/ORM/RelationList.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\ORM;
 
 use Exception;
+use Sminnee\CallbackList\CallbackList;
 
 /**
  * A DataList that represents a relation.
@@ -11,6 +12,79 @@ use Exception;
  */
 abstract class RelationList extends DataList implements Relation
 {
+    /**
+     * @var CallbackList|null
+     */
+    protected $addCallbacks;
+
+    /**
+     * @var CallbackList|null
+     */
+    protected $removeCallbacks;
+
+    /**
+     * Manage callbacks which are called after the add() action is completed.
+     * Each callback will be passed (RelationList $this, DataObject|int $item, array $extraFields).
+     * If a relation methods is manually defined, this can be called to adjust the behaviour
+     * when adding records to this list.
+     *
+     * Needs to be defined through an overloaded relationship getter
+     * to ensure it is set consistently. These getters return a new object
+     * every time they're called.
+     *
+     * Note that subclasses of RelationList must implement the callback for it to function
+     *
+     * @return this
+     */
+    public function addCallbacks(): CallbackList
+    {
+        if (!$this->addCallbacks) {
+            $this->addCallbacks = new CallbackList();
+        }
+
+        return $this->addCallbacks;
+    }
+
+    /**
+     * Manage callbacks which are called after the remove() action is completed.
+     * Each Callback will be passed (RelationList $this, [int] $removedIds).
+     *
+     * Needs to be defined through an overloaded relationship getter
+     * to ensure it is set consistently. These getters return a new object
+     * every time they're called. Example:
+     *
+     * ```php
+     * class MyObject extends DataObject()
+     * {
+     *   private static $many_many = [
+     *     'MyRelationship' => '...',
+     *   ];
+     *   public function MyRelationship()
+     *   {
+     *     $list = $this->getManyManyComponents('MyRelationship');
+     *     $list->removeCallbacks()->add(function ($removedIds) {
+     *       // ...
+     *     });
+     *     return $list;
+     *   }
+     * }
+     * ```
+     *
+     * If a relation methods is manually defined, this can be called to adjust the behaviour
+     * when adding records to this list.
+     *
+     * Subclasses of RelationList must implement the callback for it to function
+     *
+     * @return this
+     */
+    public function removeCallbacks(): CallbackList
+    {
+        if (!$this->removeCallbacks) {
+            $this->removeCallbacks = new CallbackList();
+        }
+
+        return $this->removeCallbacks;
+    }
 
     /**
      * Any number of foreign keys to apply to this list


### PR DESCRIPTION
This provides a mechanism for adjusting the behaviour of these
relations when building more complex data models.

For example the following example has a status field incorporates a
Status field into the relationship:

```php
function MyRelation() {
  $rel = $this->getManyManyComponents(‘MyRelation’);
  $rel = $rel->filter(‘Status’, ‘Active’);

  $rel->setAddCallback(function ($relation, $item, $extra) {
    $item->Status = ‘Active’;
    $item->write();
  });

  return $rel;
}
```

## to do

 * [x] refactor to allow multiple callbacks via sminnee/callbacklist