### PR TITLE
FEATURE: Added new middleware to rewrite the hash links and disabled SSViewer's rewriting by default

### DIFF
--- a/_config/requestprocessors.yml
+++ b/_config/requestprocessors.yml
@@ -14,6 +14,7 @@ SilverStripe\Core\Injector\Injector:
         ChangeDetectionMiddleware: '%$SilverStripe\Control\Middleware\ChangeDetectionMiddleware'
         HTTPCacheControleMiddleware: '%$SilverStripe\Control\Middleware\HTTPCacheControlMiddleware'
         CanonicalURLMiddleware: '%$SilverStripe\Control\Middleware\CanonicalURLMiddleware'
+        RewriteHashLinksMiddleware: '%$SilverStripe\Control\Middleware\RewriteHashLinksMiddleware'
   SilverStripe\Control\Middleware\AllowedHostsMiddleware:
     properties:
       AllowedHosts: '`SS_ALLOWED_HOSTS`'

--- a/src/Control/Middleware/RewriteHashLinksMiddleware.php
+++ b/src/Control/Middleware/RewriteHashLinksMiddleware.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SilverStripe\Control\Middleware;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\Middleware\HTTPMiddleware;
+use SilverStripe\Core\Convert;
+use SilverStripe\Core\Config\Configurable;
+
+class RewriteHashLinksMiddleware implements HTTPMiddleware
+{
+    use Configurable;
+
+    /**
+     * Mime types to be handled by this middleware
+     * @var string
+     * @config SilverStripe\Control\Middleware\RewriteHashLinksMiddleware.handled_mime_types
+     */
+    private static $handled_mime_types = [
+        'text/html',
+        'application/xhtml+xml',
+    ];
+
+
+    /**
+     * Rewrites hash links in html responses
+     * @param HTTPRequest $request
+     * @param callable $delegate
+     * @return \SilverStripe\Control\HTTPResponse
+     */
+    public function process(HTTPRequest $request, callable $delegate)
+    {
+        /** @var \SilverStripe\Control\HTTPResponse $response **/
+        $response = $delegate($request);
+
+
+        $contentType = explode(';', $response->getHeader('content-type'));
+        $contentType = strtolower(trim(array_shift($contentType)));
+        if (in_array($contentType, $this->config()->handled_mime_types)) {
+            $body = $response->getBody();
+
+            if (strpos($body, '<base') !== false) {
+                $body = preg_replace('/(<a[^>]+href *= *)"#/i', '\\1"' . Convert::raw2att(preg_replace("/^(\\/)+/", "/", $_SERVER['REQUEST_URI'])) . '#', $body);
+                $response->setBody($body);
+            }
+        }
+
+
+        return $response;
+    }
+}

--- a/src/Control/Middleware/RewriteHashLinksMiddleware.php
+++ b/src/Control/Middleware/RewriteHashLinksMiddleware.php
@@ -2,8 +2,6 @@
 
 namespace SilverStripe\Control\Middleware;
 
-use SilverStripe\Control\Director;
-use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Middleware\HTTPMiddleware;
 use SilverStripe\Core\Convert;

--- a/src/View/SSViewer.php
+++ b/src/View/SSViewer.php
@@ -112,7 +112,7 @@ class SSViewer implements Flushable
      * @config
      * @var bool
      */
-    private static $rewrite_hash_links = true;
+    private static $rewrite_hash_links = false;
 
     /**
      * Overridden value of rewrite_hash_links config

--- a/tests/php/Control/Middleware/RewriteHashLinksMiddlewareTest.php
+++ b/tests/php/Control/Middleware/RewriteHashLinksMiddlewareTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace SilverStripe\Control\Tests\Middleware;
+
+use SilverStripe\Control\Middleware\RewriteHashLinksMiddleware;
+use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\Convert;
+use SilverStripe\Dev\SapphireTest;
+
+class RewriteHashLinksMiddlewareTest extends SapphireTest
+{
+    /**
+     * Tests rewriting of HTML content types to ensure that it's properly rewriting anchors when the base tag is present
+     */
+    public function testRewriteHTMLWithBase()
+    {
+        $_SERVER['HTTP_HOST'] = 'www.mysite.com';
+        $_SERVER['REQUEST_URI'] = '//file.com?foo"onclick="alert(\'xss\')""';
+
+        $base = Convert::raw2att('/file.com?foo"onclick="alert(\'xss\')""');
+
+
+        $body = '<!DOCTYPE html>
+        <html>
+            <head><base href="' . Director::absoluteBaseURL() . '"><!--[if lte IE 6]></base><![endif]--></head>
+            <body>
+                <a class="external-inline" href="http://google.com#anchor">ExternalInlineLink</a>
+                <a class="inline" href="#anchor">InlineLink</a>
+                <svg><use xlink:href="#sprite"></use></svg>
+            </body>
+        </html>';
+
+
+        //Mock a request
+        $request = new HTTPRequest('GET', $_SERVER['REQUEST_URI']);
+
+
+        //Hand through the Middleware to be "processed"
+        $middleware = new RewriteHashLinksMiddleware();
+        $result = $middleware->process($request, function (HTTPRequest $request) use ($body) {
+            return HTTPResponse::create($body);
+        })->getBody();
+
+
+        $this->assertContains(
+            '<a class="inline" href="' . $base . '#anchor">InlineLink</a>',
+            $result
+        );
+
+        $this->assertContains(
+            '<a class="external-inline" href="http://google.com#anchor">ExternalInlineLink</a>',
+            $result
+        );
+
+        $this->assertContains(
+            '<svg><use xlink:href="#sprite"></use></svg>',
+            $result,
+            'RewriteHashLinksMiddleware should only rewrite anchor hrefs'
+        );
+    }
+
+    /**
+     * Tests rewriting of HTML content types to ensure that it's not rewriting anchors when the base tag is not present
+     */
+    public function testRewriteHTMLWithoutBase()
+    {
+        $_SERVER['HTTP_HOST'] = 'www.mysite.com';
+        $_SERVER['REQUEST_URI'] = '//file.com?foo"onclick="alert(\'xss\')""';
+
+        $base = Convert::raw2att('/file.com?foo"onclick="alert(\'xss\')""');
+
+
+        $body = '<!DOCTYPE html>
+        <html>
+            <head></head>
+            <body>
+                <a class="external-inline" href="http://google.com#anchor">ExternalInlineLink</a>
+                <a class="inline" href="#anchor">InlineLink</a>
+                <svg><use xlink:href="#sprite"></use></svg>
+            </body>
+        </html>';
+
+
+        //Mock a request
+        $request = new HTTPRequest('GET', $_SERVER['REQUEST_URI']);
+
+
+        //Hand through the Middleware to be "processed"
+        $middleware = new RewriteHashLinksMiddleware();
+        $result = $middleware->process($request, function (HTTPRequest $request) use ($body) {
+            return HTTPResponse::create($body);
+        })->getBody();
+
+
+        $this->assertNotContains(
+            '<a class="inline" href="' . $base . '#anchor">InlineLink</a>',
+            $result
+        );
+
+        $this->assertContains(
+            '<a class="external-inline" href="http://google.com#anchor">ExternalInlineLink</a>',
+            $result
+        );
+
+        $this->assertContains(
+            '<svg><use xlink:href="#sprite"></use></svg>',
+            $result,
+            'RewriteHashLinksMiddleware should only rewrite anchor hrefs'
+        );
+    }
+
+    /**
+     * Tests rewriting of JSON content type to ensure that it's not rewriting anchors
+     */
+    public function testRewriteJSONWithBase()
+    {
+        $_SERVER['HTTP_HOST'] = 'www.mysite.com';
+        $_SERVER['REQUEST_URI'] = '//file.com?foo"onclick="alert(\'xss\')""';
+
+        $base = Convert::raw2att('/file.com?foo"onclick="alert(\'xss\')""');
+
+
+        $body = json_encode(['test' => '<!DOCTYPE html>
+        <html>
+            <head><base href="' . Director::absoluteBaseURL() . '"><!--[if lte IE 6]></base><![endif]--></head>
+            <body>
+                <a class="external-inline" href="http://google.com#anchor">ExternalInlineLink</a>
+                <a class="inline" href="#anchor">InlineLink</a>
+                <svg><use xlink:href="#sprite"></use></svg>
+            </body>
+        </html>']);
+
+
+        //Mock a request
+        $request = new HTTPRequest('GET', $_SERVER['REQUEST_URI']);
+
+
+        //Hand through the Middleware to be "processed"
+        $middleware = new RewriteHashLinksMiddleware();
+        $result = $middleware->process($request, function (HTTPRequest $request) use ($body) {
+            return HTTPResponse::create($body)->addHeader('content-type', 'application/json; charset=utf-8');
+        })->getBody();
+
+
+        $this->assertNotContains(
+            '<a class=\\"inline\\" href=\\"' . $base . '#anchor\\">InlineLink<\\/a>',
+            $result
+        );
+
+        $this->assertContains(
+            '<a class=\\"external-inline\\" href=\\"http:\\/\\/google.com#anchor\\">ExternalInlineLink<\\/a>',
+            $result
+        );
+
+        $this->assertContains(
+            '<svg><use xlink:href=\\"#sprite\\"><\\/use><\\/svg>',
+            $result,
+            'RewriteHashLinksMiddleware should only rewrite anchor hrefs'
+        );
+    }
+}

--- a/tests/php/Control/Middleware/RewriteHashLinksMiddlewareTest.php
+++ b/tests/php/Control/Middleware/RewriteHashLinksMiddlewareTest.php
@@ -21,7 +21,6 @@ class RewriteHashLinksMiddlewareTest extends SapphireTest
 
         $base = Convert::raw2att('/file.com?foo"onclick="alert(\'xss\')""');
 
-
         $body = '<!DOCTYPE html>
         <html>
             <head><base href="' . Director::absoluteBaseURL() . '"><!--[if lte IE 6]></base><![endif]--></head>
@@ -32,17 +31,14 @@ class RewriteHashLinksMiddlewareTest extends SapphireTest
             </body>
         </html>';
 
-
         //Mock a request
         $request = new HTTPRequest('GET', $_SERVER['REQUEST_URI']);
-
 
         //Hand through the Middleware to be "processed"
         $middleware = new RewriteHashLinksMiddleware();
         $result = $middleware->process($request, function (HTTPRequest $request) use ($body) {
             return HTTPResponse::create($body);
         })->getBody();
-
 
         $this->assertContains(
             '<a class="inline" href="' . $base . '#anchor">InlineLink</a>',
@@ -71,7 +67,6 @@ class RewriteHashLinksMiddlewareTest extends SapphireTest
 
         $base = Convert::raw2att('/file.com?foo"onclick="alert(\'xss\')""');
 
-
         $body = '<!DOCTYPE html>
         <html>
             <head></head>
@@ -82,17 +77,14 @@ class RewriteHashLinksMiddlewareTest extends SapphireTest
             </body>
         </html>';
 
-
         //Mock a request
         $request = new HTTPRequest('GET', $_SERVER['REQUEST_URI']);
-
 
         //Hand through the Middleware to be "processed"
         $middleware = new RewriteHashLinksMiddleware();
         $result = $middleware->process($request, function (HTTPRequest $request) use ($body) {
             return HTTPResponse::create($body);
         })->getBody();
-
 
         $this->assertNotContains(
             '<a class="inline" href="' . $base . '#anchor">InlineLink</a>',
@@ -121,7 +113,6 @@ class RewriteHashLinksMiddlewareTest extends SapphireTest
 
         $base = Convert::raw2att('/file.com?foo"onclick="alert(\'xss\')""');
 
-
         $body = json_encode(['test' => '<!DOCTYPE html>
         <html>
             <head><base href="' . Director::absoluteBaseURL() . '"><!--[if lte IE 6]></base><![endif]--></head>
@@ -136,13 +127,11 @@ class RewriteHashLinksMiddlewareTest extends SapphireTest
         //Mock a request
         $request = new HTTPRequest('GET', $_SERVER['REQUEST_URI']);
 
-
         //Hand through the Middleware to be "processed"
         $middleware = new RewriteHashLinksMiddleware();
         $result = $middleware->process($request, function (HTTPRequest $request) use ($body) {
             return HTTPResponse::create($body)->addHeader('content-type', 'application/json; charset=utf-8');
         })->getBody();
-
 
         $this->assertNotContains(
             '<a class=\\"inline\\" href=\\"' . $base . '#anchor\\">InlineLink<\\/a>',

--- a/tests/php/Control/Middleware/RewriteHashLinksMiddlewareTest.php
+++ b/tests/php/Control/Middleware/RewriteHashLinksMiddlewareTest.php
@@ -30,6 +30,8 @@ class RewriteHashLinksMiddlewareTest extends SapphireTest
      */
     protected function tearDown()
     {
+        parent::tearDown();
+        
         if ($this->currentHost === false) {
             unset($_SERVER['HTTP_HOST']);
         } else {

--- a/tests/php/Control/Middleware/RewriteHashLinksMiddlewareTest.php
+++ b/tests/php/Control/Middleware/RewriteHashLinksMiddlewareTest.php
@@ -2,15 +2,47 @@
 
 namespace SilverStripe\Control\Tests\Middleware;
 
-use SilverStripe\Control\Middleware\RewriteHashLinksMiddleware;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\Middleware\RewriteHashLinksMiddleware;
 use SilverStripe\Core\Convert;
 use SilverStripe\Dev\SapphireTest;
 
 class RewriteHashLinksMiddlewareTest extends SapphireTest
 {
+    protected $currentHost;
+    protected $currentURI;
+
+    /**
+     * Setup the test
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->currentHost = (isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : false);
+        $this->currentURI = (isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : false);
+    }
+
+    /**
+     * Clean up the test
+     */
+    protected function tearDown()
+    {
+        if ($this->currentHost === false) {
+            unset($_SERVER['HTTP_HOST']);
+        } else {
+            $_SERVER['HTTP_HOST'] = $this->currentHost;
+        }
+
+        if ($this->currentURI === false) {
+            unset($_SERVER['REQUEST_URI']);
+        } else {
+            $_SERVER['REQUEST_URI'] = $this->currentURI;
+        }
+    }
+
     /**
      * Tests rewriting of HTML content types to ensure that it's properly rewriting anchors when the base tag is present
      */


### PR DESCRIPTION
While attempting to fix #8986 in pull #9044 I realized that the changes in that pull request don't work in all scenarios (see my comments there for my discoveries). This pull request introduces a new HTTP middleware that basically moves the hash rewriting from SSViewer which prevents the cache blocks from capturing the hash rewriting and exposing parameters in the url at the time of caching. If accepted I think the SSViewer hash rewriting should probably be fully deprecated and removed in 5 if this is (or something similar) is used in Silverstripe 5.

@emteknetnz Per our discussion here is the changes I was talking about, I am/Webbuilders Group is currently using this code on a couple sites with no known issues (so far) and it does seem to have corrected the issue for us.