### PR TITLE
DOCS add note to changelog for Solr changes

### DIFF
--- a/docs/en/04_Changelogs/4.6.0.md
+++ b/docs/en/04_Changelogs/4.6.0.md
@@ -5,6 +5,7 @@
  * [MySQL tables are auto-converted from MyISAM to InnoDB](#myisam)
  * [Editing files directly in the insert-media modal](#in-modal-editing)
  * [MIME Type validation now a core module](#mime-validator)
+ * [Solr no longer indexes draft/restricted content](#solr-updates)
 
 ## MySQL tables are auto-converted from MyISAM to InnoDB {#myisam}
 
@@ -86,6 +87,18 @@ install `silverstripe/mimevalidator` when they upgrade to 4.6.0.
 Read [Allowed file types](Developer_Guides/Files/Allowed_file_types) in the
 Silverstripe CMS doc for all the details.
 
+## Solr no longer indexes draft/restricted content {#solr-updates}
+
+At the time of this release a new version of the popular [silverstripe/fulltextsearch module](https://github.com/silverstripe/silverstripe-fulltextsearch) is also available, introducing more secure defaults. Most notably, draft and restricted content will no longer be indexed by default, due to a `canView()` check being performed against an anonymous user prior to (re)indexing. Restricted content means that it has a permission level of either 'Logged-in users' or 'Only these groups'.
+
+If your project uses this module, after upgrading your website, ensure that you run the `Solr_Reindex` task on your production environment to remove previously indexed content that should no longer be there.
+
+If your website requires draft or restricted content to be indexed, you can opt-out of the new secure defaults on a per-model basis.
+
+This is a great opportunity to make sure that any custom indexes/search controllers in your project are correctly filtering results based on permissions and search visibility, which you can now achieve via a unified method (see `SilverStripe\FullTextSearch\Search\ServicesSearchableService::isSearchable()`.)
+
+The [silverstripe/fulltextsearch module readme provides additional information](https://github.com/silverstripe/silverstripe-fulltextsearch).
+
 
 ## Regressions
 
@@ -95,4 +108,3 @@ Silverstripe CMS doc for all the details.
 <!--- Changes below this line will be automatically regenerated -->
 
 <!--- Changes above this line will be automatically regenerated -->
-

--- a/docs/en/04_Changelogs/4.6.0.md
+++ b/docs/en/04_Changelogs/4.6.0.md
@@ -95,7 +95,7 @@ If your project uses this module, after upgrading your website, ensure that you 
 
 If your website requires draft or restricted content to be indexed, you can opt-out of the new secure defaults on a per-model basis.
 
-This is a great opportunity to make sure that any custom indexes/search controllers in your project are correctly filtering results based on permissions and search visibility, which you can now achieve via a unified method (see `SilverStripe\FullTextSearch\Search\ServicesSearchableService::isSearchable()`.)
+This is a great opportunity to make sure that any custom indexes/search controllers in your project are correctly filtering results based on permissions and search visibility, which you can now achieve via a unified method (see `SilverStripe\FullTextSearch\Search\Services\SearchableService::isSearchable()`.)
 
 The [silverstripe/fulltextsearch module readme provides additional information](https://github.com/silverstripe/silverstripe-fulltextsearch).
 


### PR DESCRIPTION
I know we haven't quite landed on an approach for capturing information of non-core modules in changelogs, but I think this one is really worth including. Addons has the fulltextsearch module downloads at 158,435 and given the changes, I think it's better to be safe than sorry?
