### PR TITLE
DOCS update typo

### DIFF
--- a/docs/en/04_Changelogs/3.7.4.md
+++ b/docs/en/04_Changelogs/3.7.4.md
@@ -1,4 +1,4 @@
-# 3.7.4 (unreleased)
+# 3.7.4
 
 * [Minor update to support PHP 7.4](https://github.com/silverstripe/silverstripe-framework/pull/9110)
 


### PR DESCRIPTION
According to packagist, 3.7.4 is already released! https://packagist.org/packages/silverstripe/framework#3.7.4

