### PR TITLE
DOCS add 3.7.4 changelog to `4`

### DIFF
--- a/docs/en/04_Changelogs/3.7.4.md
+++ b/docs/en/04_Changelogs/3.7.4.md
@@ -1,0 +1,41 @@
+# 3.7.4
+
+* [Minor update to support PHP 7.4](https://github.com/silverstripe/silverstripe-framework/pull/9110)
+
+## Running SilverStripe 3.7 on PHP 7.4
+
+SilverStripe's standard test tools require `phpunit/phpunit-mock-objects` to run. This package has been deprecated and
+doesn't support PHP 7.4.
+
+SilverStripe is using a fork for its own PHP 7.3 unit tests: `sminnee/phpunit-mock-objects`.
+
+You can use this fork for your own project by running this command:
+```bash
+composer require --dev sminnee/phpunit-mock-objects:^3.4.7
+```
+
+This fork is not a supported module and SilverStripe does not commit to maintaining it.
+
+<!--- Changes below this line will be automatically regenerated -->
+
+## Change Log
+
+### Security
+
+ * 2019-09-16 [a86093fee](https://github.com/silverstripe/silverstripe-framework/commit/a86093fee6398881889d6d330a15f7042be25bff) Session fixation in "change password" form (Serge Latyntcev) - See [cve-2019-12203](https://www.silverstripe.org/download/security-releases/cve-2019-12203)
+ * 2019-01-10 [c44f06cdf](https://github.com/silverstripe/silverstripe-framework/commit/c44f06cdf10387a987e4efb096ff06b3bb4495ef) Patch SQL Injection vulnerability when arrays are assigned to DataObject Fields (Aaron Carlino) - See [ss-2018-021](https://www.silverstripe.org/download/security-releases/ss-2018-021)
+
+### Features and Enhancements
+
+ * 2019-03-13 [0bf03a3e7](https://github.com/silverstripe/silverstripe-framework/commit/0bf03a3e77304e242a81cca37ccbc02e35e3dbc6) Add PHP 7.4’s daily snapshot to the travis suite. (Sam Minnee)
+
+### Bugfixes
+
+ * 2019-08-26 [7d901a6d9](https://github.com/silverstripe/silverstripe-framework/commit/7d901a6d9b126ac057918f827e65aa0360231d1b) Member argument is now passed to LeftAndMain::alternateAccessCheck() (Robbie Averill)
+ * 2019-07-12 [b250e14ac](https://github.com/silverstripe/silverstripe-framework/commit/b250e14acea12493ee1bb7392cf3f18c5a1f5f8b) Require PHP7.4 compatible fork of phpunit-mock-objects (Maxime Rainville)
+ * 2019-04-15 [ad3c58f2d](https://github.com/silverstripe/silverstripe-framework/commit/ad3c58f2d875a0ac7a8a17372c7eca84abd1a2b3) Back-port https://github.com/silverstripe/silverstripe-admin/pull/769 to 3.7, fix parsererror issue (Damian Mooyman)
+ * 2019-02-26 [bd9296941](https://github.com/silverstripe/silverstripe-framework/commit/bd929694188dc7df7277d8430df5534dcb2b914a) Use a function common to MySQL, SQLite and PostgreSQL to test dynamic DBFIeld assigment (Maxime Rainville)
+ * 2019-02-25 [adbc560bd](https://github.com/silverstripe/silverstripe-framework/commit/adbc560bd70ba2e071f94a41a084768819196ee7) Address PR feedback. (Maxime Rainville)
+ * 2019-02-21 [4ec1a682c](https://github.com/silverstripe/silverstripe-framework/commit/4ec1a682cf354e2425ef4fd6598c7de8e807bcc7) Renable the ability to do dynamic assignment with DBField (Maxime Rainville)
+ * 2019-02-19 [ab5f09a9f](https://github.com/silverstripe/silverstripe-framework/commit/ab5f09a9f3ec12333c748dd68bfc504b5e509bfc) Updated unit test were targeting Float/Int which don't exist on PHP7 (#8810) (Maxime Rainville)
+<!--- Changes above this line will be automatically regenerated -->


### PR DESCRIPTION
Given that the changelog for 3.7.3 is in this branch, I'd say it's worth adding the latest 3.7.x version?

The alternative is we remove all 3.x changelogs from `4` and include a link to these in https://docs.silverstripe.org/en/4/changelogs/ to direct readers to the right place.

