### PR TITLE
Update 04_Rendering_Templates.md

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/04_Rendering_Templates.md
+++ b/docs/en/02_Developer_Guides/01_Templates/04_Rendering_Templates.md
@@ -35,6 +35,19 @@ echo $arrayData->renderWith('Coach_Message');
 // returns "<strong>John</strong> is the Head Coach on our team."
 
 ```
+If your template is a Layout template that needs to be rendered into the main Page template (to include a header and footer, for example), you need to render your Layout template into a string, and pass that as the Layout parameter to the Page template.
+
+```php
+$data = [
+    'Title' => 'Message from the Head Coach'
+];
+
+return $this->customise([
+    'Layout' => $this
+                ->customise($data)
+                ->renderWith(['Template\Path\From\templates\Layout\Coach_Message'])
+])->renderWith(['Page']);
+```
 
 [info]
 Most classes in SilverStripe you want in your template extend `ViewableData` and allow you to call `renderWith`. This 


### PR DESCRIPTION
The method of including a Layout template into a full template file isn't well documented, and isn't intuitive especially if you have come from the SS3 way of doing it via $this->customise($data)->renderWith(['MyCustomTemplate', 'Page']);  Adding this as an example will help people add layout templates to Controller actions, and form responses where a custom layout needs to inherit it's parent template.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
