### PR TITLE
FIX More context for GridFieldDataColumns callbacks

### DIFF
--- a/src/Forms/GridField/GridFieldDataColumns.php
+++ b/src/Forms/GridField/GridFieldDataColumns.php
@@ -159,7 +159,7 @@ class GridFieldDataColumns implements GridField_ColumnProvider
         // Allow callbacks
         if (is_array($columnInfo) && isset($columnInfo['callback'])) {
             $method = $columnInfo['callback'];
-            $value = $method($record);
+            $value = $method($record, $columnName, $gridField);
 
         // This supports simple FieldName syntax
         } else {


### PR DESCRIPTION
This emulates the callback signature from
GridFieldEditableColumns in the symbiote/silverstripe-gridfieldextensions module, which extends GridFieldDataColumns. In case canEdit() fails, this component passes control back to the parent (rendering a standard column content rather than a formfield). Which can become an issue if you've defined custom 'callback' handlers on setDisplayFields() - GridFieldDataColumns passes in only one arg (`$record`), while GridFieldEditableColumns passes in three (`$record`, `$col` and `$grid`).

While you could argue that this is a bug in the other module,
I think this additional context is beneficial for the main
GridFieldDataColumns use case as well, and it just happens to fix that bug.

In terms of backwards compat, PHP won't complain if you pass in *more* arguments to a method.