### PR TITLE
BUG Tweak DBHTMLText::Plain to avoid treating some chinese characters…

### DIFF
--- a/src/ORM/FieldType/DBHTMLText.php
+++ b/src/ORM/FieldType/DBHTMLText.php
@@ -228,7 +228,7 @@ class DBHTMLText extends DBText
         $text = strip_tags($text);
 
         // Implode >3 consecutive linebreaks into 2
-        $text = preg_replace('~(\R){2,}~', "\n\n", $text);
+        $text = preg_replace('~(\R){2,}~u', "\n\n", $text);
 
         // Decode HTML entities back to plain text
         return trim(Convert::xml2raw($text));

--- a/tests/php/ORM/DBHTMLTextTest.php
+++ b/tests/php/ORM/DBHTMLTextTest.php
@@ -265,6 +265,10 @@ class DBHTMLTextTest extends SapphireTest
             [
                 '<p>Collapses</p><p></p><p>Excessive<br/><br /><br>Newlines</p>',
                 "Collapses\n\nExcessive\n\nNewlines",
+            ],
+            'Unicode character that could be confused for a line break' =>[
+                '充美好实的一天',
+                '充美好实的一天'
             ]
         ];
     }


### PR DESCRIPTION
The Plain method for DBHTMLText is meant to replace any sequence of more 3 line breaks or more with 2 line breaks.

The problem is that some unicode characters are getting confused for line breaks. Plain tries to replace them with 2 line break which completely mangles the unicode string and blow up the GraphQL response.

Adding the `u` flag to the regular expression turns on UTF8 functionality for the regex. Which avoid accidentally matching the wrong characters

# Parent issue
* https://github.com/dnadesign/silverstripe-elemental/issues/781