### PR TITLE
NEW Remove callbacks on relation lists

### DIFF
--- a/src/ORM/HasManyList.php
+++ b/src/ORM/HasManyList.php
@@ -136,5 +136,11 @@ class HasManyList extends RelationList
             $item->$foreignKey = null;
             $item->write();
         }
+
+        // Call removeCallback, if applicable
+        if ($this->removeCallback) {
+            $callback = $this->removeCallback;
+            $callback($this, [$item->ID]);
+        }
     }
 }

--- a/src/ORM/ManyManyThroughList.php
+++ b/src/ORM/ManyManyThroughList.php
@@ -130,12 +130,19 @@ class ManyManyThroughList extends RelationList
         // Find has_many row with a local key matching the given id
         $hasManyList = $this->manipulator->getParentRelationship($this->dataQuery());
         $records = $hasManyList->filter($this->manipulator->getLocalKey(), $itemID);
+        $affectedIds = [];
 
         // Rather than simple un-associating the record (as in has_many list)
         // Delete the actual mapping row as many_many deletions behave.
         /** @var DataObject $record */
         foreach ($records as $record) {
+            $affectedIds[] = $record->ID;
             $record->delete();
+        }
+
+        if ($this->removeCallback && $affectedIds) {
+            $callback = $this->removeCallback;
+            $callback($this, $affectedIds);
         }
     }
 
@@ -143,7 +150,13 @@ class ManyManyThroughList extends RelationList
     {
         // Empty has_many table matching the current foreign key
         $hasManyList = $this->manipulator->getParentRelationship($this->dataQuery());
+        $affectedIds = $hasManyList->column('ID');
         $hasManyList->removeAll();
+
+        if ($this->removeCallback && $affectedIds) {
+            $callback = $this->removeCallback;
+            $callback($this, $affectedIds);
+        }
     }
 
     /**

--- a/src/ORM/RelationList.php
+++ b/src/ORM/RelationList.php
@@ -13,6 +13,49 @@ abstract class RelationList extends DataList implements Relation
 {
 
     /**
+     * @var Callable
+     */
+    protected $removeCallback;
+
+    /**
+     * Set a callback that is called after the remove() action is completed.
+     * Callback will be passed ($this, $removedIds).
+     *
+     * Needs to be defined through an overloaded relationship getter
+     * to ensure it is set consistently. These getters return a new object
+     * every time they're called. Example:
+     *
+     * ```php
+     * class MyObject extends DataObject()
+     * {
+     *   private static $many_many = [
+     *     'MyRelationship' => '...',
+     *   ];
+     *   public function MyRelationship()
+     *   {
+     *     $list = $this->getManyManyComponents('MyRelationship');
+     *     $list->setRemoveCallback(function ($removedIds) {
+     *       // ...
+     *     });
+     *     return $list;
+     *   }
+     * }
+     * ```
+     *
+     * If a relation methods is manually defined, this can be called to adjust the behaviour
+     * when adding records to this list.
+     *
+     * Subclasses of RelationList must implement the callback for it to function
+     *
+     * @return this
+     */
+    public function setRemoveCallback($callback): self
+    {
+        $this->removeCallback = $callback;
+        return $this;
+    }
+
+    /**
      * Any number of foreign keys to apply to this list
      *
      * @return string|array|null

--- a/tests/php/ORM/HasManyListTest.php
+++ b/tests/php/ORM/HasManyListTest.php
@@ -113,4 +113,36 @@ class HasManyListTest extends SapphireTest
             ['Model' => 'F40'],
         ], $company->CompanyCars()->sort('"Model" ASC'));
     }
+
+    public function testRemoveCallbackOnRemove()
+    {
+        $removedIds = [];
+
+        $base = $this->objFromFixture(Company::class, 'silverstripe');
+        $relation = $base->Employees();
+        $remove = $relation->First();
+
+        $relation->setRemoveCallback(function ($list, $ids) use (&$removedIds) {
+            $removedIds = $ids;
+        });
+
+        $relation->remove($remove);
+        $this->assertEquals([$remove->ID], $removedIds);
+    }
+
+    public function testRemoveCallbackOnRemoveById()
+    {
+        $removedIds = [];
+
+        $base = $this->objFromFixture(Company::class, 'silverstripe');
+        $relation = $base->Employees();
+        $remove = $relation->First();
+
+        $relation->setRemoveCallback(function ($list, $ids) use (&$removedIds) {
+            $removedIds = $ids;
+        });
+
+        $relation->removeByID($remove->ID);
+        $this->assertEquals([$remove->ID], $removedIds);
+    }
 }

--- a/tests/php/ORM/ManyManyListTest.php
+++ b/tests/php/ORM/ManyManyListTest.php
@@ -457,4 +457,52 @@ class ManyManyListTest extends SapphireTest
             'ManyManyDynamicField' => false,
         ]);
     }
+
+    public function testRemoveCallbackOnRemove()
+    {
+        $removedIds = [];
+
+        $base = $this->objFromFixture(Team::class, 'team1');
+        $relation = $base->Players();
+        $remove = $relation->First();
+
+        $relation->setRemoveCallback(function ($list, $ids) use (&$removedIds) {
+            $removedIds = $ids;
+        });
+
+        $relation->remove($remove);
+        $this->assertEquals([$remove->ID], $removedIds);
+    }
+
+    public function testRemoveCallbackOnRemoveById()
+    {
+        $removedIds = [];
+
+        $base = $this->objFromFixture(Team::class, 'team1');
+        $relation = $base->Players();
+        $remove = $relation->First();
+
+        $relation->setRemoveCallback(function ($list, $ids) use (&$removedIds) {
+            $removedIds = $ids;
+        });
+
+        $relation->removeByID($remove->ID);
+        $this->assertEquals([$remove->ID], $removedIds);
+    }
+
+    public function testRemoveCallbackOnRemoveAll()
+    {
+        $removedIds = [];
+
+        $base = $this->objFromFixture(Team::class, 'team1');
+        $relation = $base->Players();
+        $remove = $relation->column('ID');
+
+        $relation->setRemoveCallback(function ($list, $ids) use (&$removedIds) {
+            $removedIds = $ids;
+        });
+
+        $relation->removeAll();
+        $this->assertEquals(sort($remove), sort($removedIds));
+    }
 }

--- a/tests/php/ORM/ManyManyThroughListTest.php
+++ b/tests/php/ORM/ManyManyThroughListTest.php
@@ -362,4 +362,52 @@ class ManyManyThroughListTest extends SapphireTest
         $this->assertSame('International', $firstReverse->Title);
         $this->assertSame('Argentina', $secondReverse->Title);
     }
+
+    public function testRemoveCallbackOnRemove()
+    {
+        $removedIds = [];
+
+        $base = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
+        $relation = $base->Items();
+        $remove = $relation->First();
+
+        $relation->setRemoveCallback(function ($list, $ids) use (&$removedIds) {
+            $removedIds = $ids;
+        });
+
+        $relation->remove($remove);
+        $this->assertEquals([$remove->ID], $removedIds);
+    }
+
+    public function testRemoveCallbackOnRemoveById()
+    {
+        $removedIds = [];
+
+        $base = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
+        $relation = $base->Items();
+        $remove = $relation->First();
+
+        $relation->setRemoveCallback(function ($list, $ids) use (&$removedIds) {
+            $removedIds = $ids;
+        });
+
+        $relation->removeByID($remove->ID);
+        $this->assertEquals([$remove->ID], $removedIds);
+    }
+
+    public function testRemoveCallbackOnRemoveAll()
+    {
+        $removedIds = [];
+
+        $base = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
+        $relation = $base->Items();
+        $remove = $relation->column('ID');
+
+        $relation->setRemoveCallback(function ($list, $ids) use (&$removedIds) {
+            $removedIds = $ids;
+        });
+
+        $relation->removeAll();
+        $this->assertEquals(sort($remove), sort($removedIds));
+    }
 }


### PR DESCRIPTION
Complements addCallback in https://github.com/silverstripe/silverstripe-framework/pull/9572.

Note that both the existing addCallback and this new removeCallback
rely on the list identity staying the same, which limits where you
can set this callback (only in an overloaded getter).