### PR TITLE
BUG Readonly version of GroupedDropdownField

### DIFF
--- a/src/Forms/GroupedDropdownField.php
+++ b/src/Forms/GroupedDropdownField.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms;
 
+use SilverStripe\ORM\ArrayLib;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\View\ArrayData;
 
@@ -103,5 +104,15 @@ class GroupedDropdownField extends DropdownField
             }
         );
         return $values;
+    }
+
+    /**
+     * @return SingleLookupField
+     */
+    public function performReadonlyTransformation()
+    {
+        $field = parent::performReadonlyTransformation();
+        $field->setSource(ArrayLib::flatten($this->getSource()));
+        return $field;
     }
 }

--- a/tests/php/Forms/GroupedDropdownFieldTest.php
+++ b/tests/php/Forms/GroupedDropdownFieldTest.php
@@ -129,4 +129,39 @@ class GroupedDropdownFieldTest extends SapphireTest
             preg_replace('/\s+/', ' ', (string)$field->Field())
         );
     }
+
+    /**
+     * Test that readonly version of GroupedDropdownField displays all values
+     */
+    public function testReadonlyValue()
+    {
+        $field = GroupedDropdownField::create(
+            'Test',
+            'Testing',
+            [
+                "1" => "One",
+                "Group One" => [
+                    "2" => "Two",
+                    "3" => "Three"
+                ],
+                "Group Two" => [
+                    "4" => "Four"
+                ],
+            ]
+        );
+
+        // value on first level
+        $field->setValue("1");
+        $this->assertRegExp(
+            '/<span class="readonly" id="Test">One<\/span><input type="hidden" name="Test" value="1" \/>/',
+            (string)$field->performReadonlyTransformation()->Field()
+        );
+
+        // value on first level
+        $field->setValue("2");
+        $this->assertRegExp(
+            '/<span class="readonly" id="Test">Two<\/span><input type="hidden" name="Test" value="2" \/>/',
+            (string)$field->performReadonlyTransformation()->Field()
+        );
+    }
 }


### PR DESCRIPTION
GroupedDropdownField was showing empty values in Readonly mode due to not correctly handling the hierarchical source array.
Uses flattened source now in GroupedDropdownField->performReadonlyTransformation()
