### PR TITLE
BUG Resolve issue where TreeMultiSelectField would error loading its value

### DIFF
--- a/src/Forms/TreeMultiselectField.php
+++ b/src/Forms/TreeMultiselectField.php
@@ -91,9 +91,9 @@ class TreeMultiselectField extends TreeDropdownField
         foreach ($items as $item) {
             if ($item instanceof DataObject) {
                 $values[] = [
-                    'id'        => $item->obj($this->getKeyField())->getValue(),
-                    'title'     => $item->obj($this->getTitleField())->getValue(),
-                    'parentid'  => $item->ParentID,
+                    'id' => $item->obj($this->getKeyField())->getValue(),
+                    'title' => $item->obj($this->getTitleField())->getValue(),
+                    'parentid' => $item->ParentID,
                     'treetitle' => $item->obj($this->getLabelField())->getSchemaValue(),
                 ];
             } else {
@@ -116,7 +116,7 @@ class TreeMultiselectField extends TreeDropdownField
 
     /**
      * Return this field's linked items
-     * @return SS_List $items
+     * @return ArrayList|DataList $items
      */
     public function getItems()
     {
@@ -164,9 +164,6 @@ class TreeMultiselectField extends TreeDropdownField
             ->filter($this->getKeyField(), $ids);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setValue($value, $source = null)
     {
         // If loading from a dataobject, get items by relation
@@ -225,10 +222,10 @@ class TreeMultiselectField extends TreeDropdownField
         $properties = array_merge(
             $properties,
             [
-                'Title'      => $title,
+                'Title' => $title,
                 'EmptyTitle' => $emptyTitle,
-                'Link'       => $dataUrlTree,
-                'Value'      => $value
+                'Link' => $dataUrlTree,
+                'Value' => $value
             ]
         );
         return FormField::Field($properties);

--- a/src/Forms/TreeMultiselectField.php
+++ b/src/Forms/TreeMultiselectField.php
@@ -76,7 +76,7 @@ class TreeMultiselectField extends TreeDropdownField
 
         $data['data'] = array_merge($data['data'], [
             'hasEmptyDefault' => false,
-            'multiple'        => true,
+            'multiple' => true,
         ]);
         return $data;
     }

--- a/src/Forms/TreeMultiselectField.php
+++ b/src/Forms/TreeMultiselectField.php
@@ -174,6 +174,12 @@ class TreeMultiselectField extends TreeDropdownField
             }
         }
 
+        // Handle legacy value; form-submitted `unchanged` implies empty set.
+        // See TreeDropdownField.js
+        if ($value === 'unchanged') {
+            $value = [];
+        }
+
         return parent::setValue($value);
     }
 

--- a/src/Forms/TreeMultiselectField.php
+++ b/src/Forms/TreeMultiselectField.php
@@ -149,7 +149,7 @@ class TreeMultiselectField extends TreeDropdownField
         // Parse ids from value string / array
         $ids = [];
         if (is_string($value)) {
-            $ids = explode(',', $value);
+            $ids = preg_split("#\s*,\s*#", trim($value));
         } elseif (is_array($value)) {
             $ids = array_values($value);
         }

--- a/tests/php/Forms/TreeMultiselectFieldTest.php
+++ b/tests/php/Forms/TreeMultiselectFieldTest.php
@@ -135,8 +135,8 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaStateDefaults = $field->getSchemaStateDefaults();
         $this->assertArraySubset(
             [
-                'id' => $fieldId,
-                'name' => $this->fieldName,
+                'id'    => $fieldId,
+                'name'  => $this->fieldName,
                 'value' => 'unchanged'
             ],
             $schemaStateDefaults,
@@ -146,20 +146,20 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaDataDefaults = $field->getSchemaDataDefaults();
         $this->assertArraySubset(
             [
-                'id' => $fieldId,
-                'name' => $this->fieldName,
-                'type' => 'text',
+                'id'         => $fieldId,
+                'name'       => $this->fieldName,
+                'type'       => 'text',
                 'schemaType' => 'SingleSelect',
-                'component' => 'TreeDropdownField',
-                'holderId' => sprintf('%s_Holder', $fieldId),
-                'title' => 'Test tree',
+                'component'  => 'TreeDropdownField',
+                'holderId'   => sprintf('%s_Holder', $fieldId),
+                'title'      => 'Test tree',
                 'extraClass' => 'treemultiselect multiple searchable',
-                'data' => [
-                    'urlTree' => 'field/TestTree/tree',
-                    'showSearch' => true,
-                    'emptyString' => '(Search or choose File)',
+                'data'       => [
+                    'urlTree'         => 'field/TestTree/tree',
+                    'showSearch'      => true,
+                    'emptyString'     => '(Search or choose File)',
                     'hasEmptyDefault' => false,
-                    'multiple' => true
+                    'multiple'        => true
                 ]
             ],
             $schemaDataDefaults,
@@ -187,8 +187,8 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaStateDefaults = $field->getSchemaStateDefaults();
         $this->assertArraySubset(
             [
-                'id' => $field->ID(),
-                'name' => 'TestTree',
+                'id'    => $field->ID(),
+                'name'  => 'TestTree',
                 'value' => $this->folderIds
             ],
             $schemaStateDefaults,
@@ -213,8 +213,8 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaStateDefaults = $field->getSchemaStateDefaults();
         $this->assertArraySubset(
             [
-                'id' => $field->ID(),
-                'name' => 'TestTree',
+                'id'    => $field->ID(),
+                'name'  => 'TestTree',
                 'value' => 'unchanged'
             ],
             $schemaStateDefaults,
@@ -224,20 +224,20 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaDataDefaults = $field->getSchemaDataDefaults();
         $this->assertArraySubset(
             [
-                'id' => $field->ID(),
-                'name' => $this->fieldName,
-                'type' => 'text',
+                'id'         => $field->ID(),
+                'name'       => $this->fieldName,
+                'type'       => 'text',
                 'schemaType' => 'SingleSelect',
-                'component' => 'TreeDropdownField',
-                'holderId' => sprintf('%s_Holder', $field->ID()),
-                'title' => 'Test tree',
+                'component'  => 'TreeDropdownField',
+                'holderId'   => sprintf('%s_Holder', $field->ID()),
+                'title'      => 'Test tree',
                 'extraClass' => 'treemultiselectfield_readonly multiple  searchable',
-                'data' => [
-                    'urlTree' => 'field/TestTree/tree',
-                    'showSearch' => true,
-                    'emptyString' => '(Search or choose File)',
+                'data'       => [
+                    'urlTree'         => 'field/TestTree/tree',
+                    'showSearch'      => true,
+                    'emptyString'     => '(Search or choose File)',
                     'hasEmptyDefault' => false,
-                    'multiple' => true
+                    'multiple'        => true
                 ]
             ],
             $schemaDataDefaults,
@@ -263,8 +263,8 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaStateDefaults = $field->getSchemaStateDefaults();
         $this->assertArraySubset(
             [
-                'id' => $field->ID(),
-                'name' => 'TestTree',
+                'id'    => $field->ID(),
+                'name'  => 'TestTree',
                 'value' => $this->folderIds
             ],
             $schemaStateDefaults,
@@ -274,20 +274,20 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaDataDefaults = $field->getSchemaDataDefaults();
         $this->assertArraySubset(
             [
-                'id' => $field->ID(),
-                'name' => $this->fieldName,
-                'type' => 'text',
+                'id'         => $field->ID(),
+                'name'       => $this->fieldName,
+                'type'       => 'text',
                 'schemaType' => 'SingleSelect',
-                'component' => 'TreeDropdownField',
-                'holderId' => sprintf('%s_Holder', $field->ID()),
-                'title' => 'Test tree',
+                'component'  => 'TreeDropdownField',
+                'holderId'   => sprintf('%s_Holder', $field->ID()),
+                'title'      => 'Test tree',
                 'extraClass' => 'treemultiselectfield_readonly multiple  searchable',
-                'data' => [
-                    'urlTree' => 'field/TestTree/tree',
-                    'showSearch' => true,
-                    'emptyString' => '(Search or choose File)',
+                'data'       => [
+                    'urlTree'         => 'field/TestTree/tree',
+                    'showSearch'      => true,
+                    'emptyString'     => '(Search or choose File)',
                     'hasEmptyDefault' => false,
-                    'multiple' => true
+                    'multiple'        => true
                 ]
             ],
             $schemaDataDefaults,
@@ -300,5 +300,30 @@ class TreeMultiselectFieldTest extends SapphireTest
         $html = $field->Field();
         $this->assertContains($field->ID(), $html);
         $this->assertContains($this->fieldValue, $html);
+    }
+
+    public function testGetItems()
+    {
+        // Default items scaffolded from 'unchanged' value (empty)
+        $field = $this->field;
+        $this->assertListEquals(
+            [],
+            $field->getItems()
+        );
+
+
+        // Set list of items by array of ids
+        $field->setValue($this->folderIds);
+        $this->assertListEquals(
+            $this->loadFolders(),
+            $field->getItems()
+        );
+
+        // Set list of items by comma separated ids
+        $field->satValue($this->fieldValue);
+        $this->assertListEquals(
+            $this->loadFolders(),
+            $field->getItems()
+        );
     }
 }

--- a/tests/php/Forms/TreeMultiselectFieldTest.php
+++ b/tests/php/Forms/TreeMultiselectFieldTest.php
@@ -135,8 +135,8 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaStateDefaults = $field->getSchemaStateDefaults();
         $this->assertArraySubset(
             [
-                'id'    => $fieldId,
-                'name'  => $this->fieldName,
+                'id' => $fieldId,
+                'name' => $this->fieldName,
                 'value' => 'unchanged'
             ],
             $schemaStateDefaults,
@@ -146,20 +146,20 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaDataDefaults = $field->getSchemaDataDefaults();
         $this->assertArraySubset(
             [
-                'id'         => $fieldId,
-                'name'       => $this->fieldName,
-                'type'       => 'text',
+                'id' => $fieldId,
+                'name' => $this->fieldName,
+                'type' => 'text',
                 'schemaType' => 'SingleSelect',
-                'component'  => 'TreeDropdownField',
-                'holderId'   => sprintf('%s_Holder', $fieldId),
-                'title'      => 'Test tree',
+                'component' => 'TreeDropdownField',
+                'holderId' => sprintf('%s_Holder', $fieldId),
+                'title' => 'Test tree',
                 'extraClass' => 'treemultiselect multiple searchable',
-                'data'       => [
-                    'urlTree'         => 'field/TestTree/tree',
-                    'showSearch'      => true,
-                    'emptyString'     => '(Search or choose File)',
+                'data' => [
+                    'urlTree' => 'field/TestTree/tree',
+                    'showSearch' => true,
+                    'emptyString' => '(Search or choose File)',
                     'hasEmptyDefault' => false,
-                    'multiple'        => true
+                    'multiple' => true
                 ]
             ],
             $schemaDataDefaults,
@@ -187,8 +187,8 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaStateDefaults = $field->getSchemaStateDefaults();
         $this->assertArraySubset(
             [
-                'id'    => $field->ID(),
-                'name'  => 'TestTree',
+                'id' => $field->ID(),
+                'name' => 'TestTree',
                 'value' => $this->folderIds
             ],
             $schemaStateDefaults,
@@ -213,8 +213,8 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaStateDefaults = $field->getSchemaStateDefaults();
         $this->assertArraySubset(
             [
-                'id'    => $field->ID(),
-                'name'  => 'TestTree',
+                'id' => $field->ID(),
+                'name' => 'TestTree',
                 'value' => 'unchanged'
             ],
             $schemaStateDefaults,
@@ -224,20 +224,20 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaDataDefaults = $field->getSchemaDataDefaults();
         $this->assertArraySubset(
             [
-                'id'         => $field->ID(),
-                'name'       => $this->fieldName,
-                'type'       => 'text',
+                'id' => $field->ID(),
+                'name' => $this->fieldName,
+                'type' => 'text',
                 'schemaType' => 'SingleSelect',
-                'component'  => 'TreeDropdownField',
-                'holderId'   => sprintf('%s_Holder', $field->ID()),
-                'title'      => 'Test tree',
+                'component' => 'TreeDropdownField',
+                'holderId' => sprintf('%s_Holder', $field->ID()),
+                'title' => 'Test tree',
                 'extraClass' => 'treemultiselectfield_readonly multiple  searchable',
-                'data'       => [
-                    'urlTree'         => 'field/TestTree/tree',
-                    'showSearch'      => true,
-                    'emptyString'     => '(Search or choose File)',
+                'data' => [
+                    'urlTree' => 'field/TestTree/tree',
+                    'showSearch' => true,
+                    'emptyString' => '(Search or choose File)',
                     'hasEmptyDefault' => false,
-                    'multiple'        => true
+                    'multiple' => true
                 ]
             ],
             $schemaDataDefaults,
@@ -263,8 +263,8 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaStateDefaults = $field->getSchemaStateDefaults();
         $this->assertArraySubset(
             [
-                'id'    => $field->ID(),
-                'name'  => 'TestTree',
+                'id' => $field->ID(),
+                'name' => 'TestTree',
                 'value' => $this->folderIds
             ],
             $schemaStateDefaults,
@@ -274,20 +274,20 @@ class TreeMultiselectFieldTest extends SapphireTest
         $schemaDataDefaults = $field->getSchemaDataDefaults();
         $this->assertArraySubset(
             [
-                'id'         => $field->ID(),
-                'name'       => $this->fieldName,
-                'type'       => 'text',
+                'id' => $field->ID(),
+                'name' => $this->fieldName,
+                'type' => 'text',
                 'schemaType' => 'SingleSelect',
-                'component'  => 'TreeDropdownField',
-                'holderId'   => sprintf('%s_Holder', $field->ID()),
-                'title'      => 'Test tree',
+                'component' => 'TreeDropdownField',
+                'holderId' => sprintf('%s_Holder', $field->ID()),
+                'title' => 'Test tree',
                 'extraClass' => 'treemultiselectfield_readonly multiple  searchable',
-                'data'       => [
-                    'urlTree'         => 'field/TestTree/tree',
-                    'showSearch'      => true,
-                    'emptyString'     => '(Search or choose File)',
+                'data' => [
+                    'urlTree' => 'field/TestTree/tree',
+                    'showSearch' => true,
+                    'emptyString' => '(Search or choose File)',
                     'hasEmptyDefault' => false,
-                    'multiple'        => true
+                    'multiple' => true
                 ]
             ],
             $schemaDataDefaults,

--- a/tests/php/Forms/TreeMultiselectFieldTest.php
+++ b/tests/php/Forms/TreeMultiselectFieldTest.php
@@ -311,18 +311,26 @@ class TreeMultiselectFieldTest extends SapphireTest
             $field->getItems()
         );
 
+        $expectedItem = array_map(
+            function ($folder) {
+                return [
+                    'Filename' => $folder->Filename,
+                ];
+            },
+            $this->loadFolders()
+        );
 
         // Set list of items by array of ids
         $field->setValue($this->folderIds);
         $this->assertListEquals(
-            $this->loadFolders(),
+            $expectedItem,
             $field->getItems()
         );
 
         // Set list of items by comma separated ids
-        $field->satValue($this->fieldValue);
+        $field->setValue($this->fieldValue);
         $this->assertListEquals(
-            $this->loadFolders(),
+            $expectedItem,
             $field->getItems()
         );
     }

--- a/tests/php/Forms/TreeMultiselectFieldTest.php
+++ b/tests/php/Forms/TreeMultiselectFieldTest.php
@@ -333,5 +333,12 @@ class TreeMultiselectFieldTest extends SapphireTest
             $expectedItem,
             $field->getItems()
         );
+
+        // Handle legacy empty value (form submits 'unchanged')
+        $field->setValue('unchanged');
+        $this->assertListEquals(
+            [],
+            $field->getItems()
+        );
     }
 }


### PR DESCRIPTION
Related to https://github.com/dnadesign/silverstripe-elemental/issues/812 where multiselect would error in elemental.

Elemental aliases all field names, causing TreeMultiSelectField to occasionally error when loading values.

Normally the field would work in other forms, but it would query the base record quite frequently.

This change addresses this issue by ensuring that setValue() records the ids of any assigned value safely, and does not fail over to calling the parent method {$name}() on the form record unless necessary.

Main functionality addresses consistency of the getItems() method, which have been unit tested to ensure each value type is safely considered.