### PR TITLE
DOCS: Remove links to common problems

### DIFF
--- a/docs/en/00_Getting_Started/index.md
+++ b/docs/en/00_Getting_Started/index.md
@@ -70,6 +70,6 @@ Webserver setup is covered in
 
 ## Troubleshooting
 
-If you run into trouble, see [common-problems](common_problems) or
+If you run into trouble, see [the Tips & Tricks forum](https://forum.silverstripe.org/c/tips) or
 check our [community help options](https://www.silverstripe.org/community/).
 

--- a/docs/en/01_Lessons/index.md
+++ b/docs/en/01_Lessons/index.md
@@ -29,5 +29,5 @@ icon: graduation-cap
 
 ## Help: If you get stuck
 
- * [Common Problems](/getting_started/common_problems): Review some existing solutions to common problems.
+ * [The Tips & Tricks forum](https://forum.silverstripe.org/c/tips): Review some existing solutions to common problems.
  * [SilverStripe Community](http://www.silverstripe.org/community/): Join our community chat via Slack, or ask a question on Stack Overflow.

--- a/docs/en/04_Changelogs/4.0.0.md
+++ b/docs/en/04_Changelogs/4.0.0.md
@@ -754,7 +754,7 @@ Public files have a "canonical URL" which doesn't change when file contents are 
 See our ["File Management" guide](/developer_guides/files/file_management) for more information.
 
 Depending on your server configuration, it may also be necessary to adjust your assets folder 
-permissions. Please see the [common installation problems](/getting_started/common_problems)
+permissions. Please see the [the Tips & Tricks forum](https://forum.silverstripe.org/c/tips)
 guide for configuration instruction.
 
 ### Image handling {#image-handling}
@@ -1091,8 +1091,8 @@ You will need to make sure that these files are writable via the web server, and
 configuration customisation is done via overriding these templates.
 
 Depending on your server configuration, it may also be necessary to adjust your assets folder 
-permissions. Please see the [common installation problems](/getting_started/common_problems)
-guide for configuration instruction.
+permissions. Please see the [the Tips & Tricks forum](https://forum.silverstripe.org/c/tips)
+for configuration instruction.
 
 If upgrading from an existing installation, make sure to invoke `?flush=all` at least once.
 


### PR DESCRIPTION
The whole Installation section was removed in this commit https://github.com/silverstripe/silverstripe-framework/commit/f93fcd66ef87402ae56f5459ac5c1600a0044819#diff-a30340582fcf3adb59c3cc4667f4910d