### PR TITLE
DOC Add process for releasing individual module patches

### DIFF
--- a/docs/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
+++ b/docs/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
@@ -20,6 +20,28 @@ While this document is not normally applicable to normal silverstripe contributo
 it is still useful to have it available in a public location so that these users
 are aware of these processes.
 
+## Module releases
+
+Occasionally a fix to an individual module warrants a patch release outside of the standard quarterly release cycle. Rather than generating a full new recipe release, the following process should be followed to perform a patch release for an individual module:
+
+1. Check out the module locally
+1. Determine the new module version to be released (e.g. current version is 4.6.1, therefore new version will be 4.6.2)
+1. Generate a changelog using our standard changelog format and the current release + branch name:
+   ```
+   > git log --oneline --pretty=format:"* %s (%an) - %h" --no-merges 4.6.1...4.6
+   ```
+1. Draft a new Release in GitHub, targeting the correct branch, specifying the version to be released, and pasting the changelog in the description field.
+1. Publish the release, and ensure the new version becomes visible in Packagist.
+
+Projects wanting to pick up this individual patch will need to alias it in their `composer.json` file if they're using a recipe:
+
+```
+    "requirements": {
+        "silverstripe/recipe-cms": "^4.6.1",
+        "silverstripe/cms": "4.6.2 as 4.6.1"
+    }
+```
+
 ## First time setup
 
 As a core contributor it is necessary to have installed the following set of tools:

--- a/docs/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
+++ b/docs/en/05_Contributing/05_Making_A_SilverStripe_Core_Release.md
@@ -37,7 +37,7 @@ Projects wanting to pick up this individual patch will need to alias it in their
 
 ```
     "requirements": {
-        "silverstripe/recipe-cms": "^4.6.1",
+        "silverstripe/recipe-cms": "4.6.1",
         "silverstripe/cms": "4.6.2 as 4.6.1"
     }
 ```


### PR DESCRIPTION
We occasionally produce patch releases for individual core modules (and more frequently for non-core modules), but a standard process for this hasn't been documented previously. [Aiming to get Cow to perform the same operations](https://github.com/silverstripe/cow/issues/184) in the future to allow developers to consistently reference GitHub Releases for individual module patch notes.