### PR TITLE
FIX Retain custom sort on custom lists in GridFieldAddExistingAutoCompleter

### DIFF
--- a/tests/php/Forms/GridField/GridFieldAddExistingAutocompleterTest.php
+++ b/tests/php/Forms/GridField/GridFieldAddExistingAutocompleterTest.php
@@ -147,7 +147,12 @@ class GridFieldAddExistingAutocompleterTest extends FunctionalTest
         $result = json_decode($response->getBody(), true);
         $this->assertEquals(
             ['Team 1', 'Team 2', 'Team 3', 'Team 4'],
-            array_map(function ($item) { return $item['label']; }, $result)
+            array_map(
+                function ($item) {
+                    return $item['label'];
+                },
+                $result
+            )
         );
 
         $component->setSearchList(Team::get()->sort('Name', 'DESC'));
@@ -157,7 +162,12 @@ class GridFieldAddExistingAutocompleterTest extends FunctionalTest
         $result = json_decode($response->getBody(), true);
         $this->assertEquals(
             ['Team 4', 'Team 3', 'Team 2', 'Team 1'],
-            array_map(function ($item) { return $item['label']; }, $result)
+            array_map(
+                function ($item) {
+                    return $item['label'];
+                },
+                $result
+            )
         );
     }
 


### PR DESCRIPTION
Forcing sort by the first search field isn't always appropriate.
When a custom search list is used, we can set the expectation that custom sorting is intended as well.
As an example, this can be used to autocomplete based on FULLTEXT indexes,
and sort based on relevancy.