### PR TITLE
Backport fix to GroupedDropdownFieldTest

### DIFF
--- a/tests/php/Forms/GroupedDropdownFieldTest.php
+++ b/tests/php/Forms/GroupedDropdownFieldTest.php
@@ -153,14 +153,14 @@ class GroupedDropdownFieldTest extends SapphireTest
         // value on first level
         $field->setValue("1");
         $this->assertRegExp(
-            '/<span class="readonly" id="Test">One<\/span><input type="hidden" name="Test" value="1" \/>/',
+            '#<span class="readonly" id="Test">One</span>\n?<input type="hidden" name="Test" value="1" />#',
             (string)$field->performReadonlyTransformation()->Field()
         );
 
         // value on first level
         $field->setValue("2");
         $this->assertRegExp(
-            '/<span class="readonly" id="Test">Two<\/span><input type="hidden" name="Test" value="2" \/>/',
+            '#<span class="readonly" id="Test">Two</span>\n?<input type="hidden" name="Test" value="2" />#',
             (string)$field->performReadonlyTransformation()->Field()
         );
     }


### PR DESCRIPTION
Backport of https://github.com/silverstripe/silverstripe-framework/pull/9637 which I think was merged into `4` instead of `4.6` possibly by accident?

Fixes https://travis-ci.org/github/silverstripe/cwp-recipe-kitchen-sink/jobs/718825822