### PR TITLE
Fix #9641 DataList->column mutating underlying DataQuery

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1014,7 +1014,8 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      */
     public function column($colName = "ID")
     {
-        return $this->dataQuery->distinct(false)->column($colName);
+        $dataQuery = clone $this->dataQuery;
+        return $dataQuery->distinct(false)->column($colName);
     }
 
     /**


### PR DESCRIPTION
Fixes #9641

In DataList->column, clone the DataQuery before calling distinct(false), to avoid mutating it.