### PR TITLE
FIX: Include missing security page titles when CMS not installed (fixes #9648)

### DIFF
--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -939,6 +939,8 @@ class Security extends Controller implements TemplateGlobalProvider
         // We've displayed the message in the form output, so reset it for the next run.
         static::clearSessionMessage();
 
+        // Ensure title is present - in case getResponseController() didn't return a page controller
+        $fragments = array_merge($fragments, ['Title' => $title]);
         if ($message) {
             $messageResult = [
                 'Content'     => DBField::create_field('HTMLFragment', $message),


### PR DESCRIPTION
Proposed fix for #9648

---

Resolves #9648 