### PR TITLE
NEW: Add GridFieldDetailForm::setRedirectMissingRecords()

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -623,6 +623,11 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
             // to the same URL (it assumes that its content is already current, and doesn't reload)
             return $this->edit($controller->getRequest());
         } else {
+            // We might be able to redirect to open the record in a different view
+            if ($redirectDest = $this->component->getLostRecordRedirection($this->gridField, $controller->getRequest(), $this->record->ID)) {
+                return $controller->redirect($redirectDest, 302);
+            }
+
             // Changes to the record properties might've excluded the record from
             // a filtered list, so return back to the main view if it can't be found
             $url = $controller->getRequest()->getURL();

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest.php
@@ -207,7 +207,7 @@ class GridFieldDetailFormTest extends FunctionalTest
         );
         $this->assertFalse($response->isError());
 
-        $person = Person::get()->sort('FirstName')->First();
+        $person = $this->objFromFixture(Person::class, 'jane');
         $favouriteGroup = $person->FavouriteGroups()->first();
 
         $this->assertInstanceOf(PeopleGroup::class, $favouriteGroup);
@@ -248,7 +248,7 @@ class GridFieldDetailFormTest extends FunctionalTest
             ]
         );
         $this->assertFalse($response->isError());
-        $person = Person::get()->sort('FirstName')->First();
+        $person = $this->objFromFixture(Person::class, 'jane');
         $category = $person->Categories()->filter(['Name' => 'Updated Category'])->First();
         $this->assertEquals(
             [
@@ -271,7 +271,7 @@ class GridFieldDetailFormTest extends FunctionalTest
         );
         $this->assertFalse($response->isError());
 
-        $person = Person::get()->sort('FirstName')->First();
+        $person = $this->objFromFixture(Person::class, 'jane');
         $category = $person->Categories()->filter(['Name' => 'Updated Category'])->First();
         $this->assertEquals(
             [
@@ -404,5 +404,35 @@ class GridFieldDetailFormTest extends FunctionalTest
 
         $this->assertEquals($group->Name, (string) $title[0]);
         $this->assertEquals($group->ID, (string) $id[0]['value']);
+    }
+
+    public function testRedirectMissingRecords()
+    {
+        $origAutoFollow = $this->autoFollowRedirection;
+        $this->autoFollowRedirection = false;
+
+        // GridField is filtered people in "My Group", which does't include "jack"
+        $included = $this->objFromFixture(Person::class, 'joe');
+        $excluded = $this->objFromFixture(Person::class, 'jack');
+
+        $response = $this->get(sprintf(
+            'GridFieldDetailFormTest_Controller/Form/field/testfield/item/%d/edit',
+            $included->ID
+        ));
+        $this->assertFalse(
+            $response->isRedirect(),
+            'Existing records are not redirected'
+        );
+
+        $response = $this->get(sprintf(
+            'GridFieldDetailFormTest_Controller/Form/field/testfield/item/%d/edit',
+            $excluded->ID
+        ));
+        $this->assertTrue(
+            $response->isRedirect(),
+            'Non-existing records are redirected'
+        );
+
+        $this->autoFollowRedirection = $origAutoFollow;
     }
 }

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest.yml
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest.yml
@@ -5,6 +5,9 @@ SilverStripe\Forms\Tests\GridField\GridFieldDetailFormTest\Person:
   jane:
     FirstName: Jane
     Surname: Doe
+  jack:
+    FirstName: Jack
+    Surname: Doe
 
 SilverStripe\Forms\Tests\GridField\GridFieldDetailFormTest\PeopleGroup:
   group:

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest/CategoryController.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest/CategoryController.php
@@ -31,7 +31,7 @@ class CategoryController extends Controller implements TestOnly
     public function Form()
     {
         // GridField lists categories for a specific person
-        $person = Person::get()->sort('FirstName')->First();
+        $person = Person::get()->filter('FirstName', 'Jane')->First();
         $detailFields = singleton(Category::class)->getCMSFields();
         $detailFields->addFieldsToTab(
             'Root.Main',

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest/Person.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest/Person.php
@@ -69,4 +69,9 @@ class Person extends DataObject implements TestOnly
             ]
         );
     }
+
+    public function CMSEditLink()
+    {
+        return sprintf('my-admin/%d', $this->ID);
+    }
 }

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest/TestController.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest/TestController.php
@@ -48,7 +48,9 @@ class TestController extends Controller implements TestOnly
         $field->getConfig()->addComponent(new GridFieldViewButton());
         $field->getConfig()->addComponent(new GridFieldEditButton());
         /** @skipUpgrade */
-        $field->getConfig()->addComponent($gridFieldForm = new GridFieldDetailForm($this, 'Form'));
+        $gridFieldForm = new GridFieldDetailForm($this, 'Form');
+        $gridFieldForm->setRedirectMissingRecords(true);
+        $field->getConfig()->addComponent($gridFieldForm);
         $field->getConfig()->addComponent(new GridFieldEditButton());
         /** @skipUpgrade */
         return new Form($this, 'Form', new FieldList($field), new FieldList());


### PR DESCRIPTION
This new opt-in setting will let grid field detail forms redirect to the
“Correct” URL of a GridField if it’s not found in the current list.

This works by:
 * Looking for the item in the database
 * If it exists, check for a CMSEditLink() method that returns a value
 * If so, redirect to that

This is useful if you have a number of grid fields that each show a
partial list of records, and it’s possible for the user to make changes
such the item no longer appears in the list, but does appear in another
list.

It’s an opt-in feature as I think all changes like this should be
opt-in, based on previous experiences improving GridField and in turn
breaking SecurityAdmin and slowing versioned-data-browsing down. ;-)

Fixes #9067