### PR TITLE
NEW Add recipe-core to default VersionProvider module list

### DIFF
--- a/src/Core/Manifest/VersionProvider.php
+++ b/src/Core/Manifest/VersionProvider.php
@@ -31,7 +31,10 @@ class VersionProvider
     /**
      * @var array
      */
-    private static $modules = [];
+    private static $modules = [
+        'silverstripe/framework' => 'Framework',
+        'silverstripe/recipe-core' => 'Core Recipe',
+    ];
 
     /**
      * Gets a comma delimited string of package titles and versions


### PR DESCRIPTION
Follow up to #9628 and silverstripe/silverstripe-cms#2578.

Recipe versions are a more useful indicator than the framework module version, so if installed we want to show the recipe-core version. The cms module expands upon this to include recipe-cms.
