### PR TITLE
BUG Fix wrong regex matching in case of multiple </head> (#9662)

### DIFF
--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -959,11 +959,17 @@ class Requirements_Backend
      */
     protected function insertTagsIntoHead($jsRequirements, $content)
     {
+        /**
+         * Negative lookahead regex to match the *last* case of "</head>"
+         *
+         * @see https://regex101.com/r/YlJxzh/1
+         */
         $content = preg_replace(
-            '/(<\/head>)/i',
+            '/(<\/head>)(?!.*\1)/si',
             $this->escapeReplacement($jsRequirements) . '\\1',
             $content
         );
+
         return $content;
     }
 


### PR DESCRIPTION
Hey,

Currently any page with multiple times the string `"</head>"` (which shouldn't exist, but do in some edge cases) end up with multiple JS requirements being inserted. This can lead to broken markup (see #9662).

This fix adds a negative lookahead in the regex matching the head-tag. It avoids multi-matching of `"</head>"` by limiting it the last match. As a result, the JS requirements will only be added once before the last closing head-tag. 

This fix resolved #9662.

Before merging it would be great if someone could test this further - I don't want to break stuff for many people!

Cheers,
Peter

