### PR TITLE
HistoryViewer: explain "magic names"

### DIFF
--- a/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
+++ b/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
@@ -1243,6 +1243,22 @@ window.document.addEventListener('DOMContentLoaded', () => {
   );
 });
 ```
+[hint]
+GraphQL scaffolding derives the names for the schema from the first part of the namespace and the classname, while in
+the Injector the database table name is used. So in the case of
+```php
+namespace Foo\Bar;
+// …
+class MyVersionedObject extends DataObject
+{
+    private static $table_name = 'FBVersionedObject';
+    // …
+}
+```
+you would have to use `readOneFooMyVersionedObject`, `rollbackFooMyVersionedObject` and
+`HistoryViewerToolbar.VersionedAdmin.HistoryViewer.FBVersionedObject.HistoryViewerVersionDetail` respectively
+[/hint]
+
 
 For more information, see [ReactJS, Redux and GraphQL](../../customising_the_admin_interface/react_redux_and_graphql).
 

--- a/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
+++ b/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
@@ -1256,7 +1256,7 @@ class MyVersionedObject extends DataObject
 }
 ```
 you would have to use `readOneFooMyVersionedObject`, `rollbackFooMyVersionedObject` and
-`HistoryViewerToolbar.VersionedAdmin.HistoryViewer.FBVersionedObject.HistoryViewerVersionDetail` respectively
+`HistoryViewerToolbar.VersionedAdmin.HistoryViewer.MyTableName.HistoryViewerVersionDetail` respectively
 [/hint]
 
 

--- a/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
+++ b/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
@@ -1251,7 +1251,7 @@ namespace Foo\Bar;
 // …
 class MyVersionedObject extends DataObject
 {
-    private static $table_name = 'FBVersionedObject';
+    private static $table_name = 'MyTableName';
     // …
 }
 ```


### PR DESCRIPTION
GraphQL scaffolding uses names consisting of the first part of the namespace and the classname, but to inject it to the HistoryViewer field you need to use the database table name.

Took me hours to find out why the boilerplate doesn't work for me…