### PR TITLE
FIX Problem with direct compare in SELECT statement causing incompatibility with SQL Server database

### DIFF
--- a/src/ORM/FieldType/DBForeignKey.php
+++ b/src/ORM/FieldType/DBForeignKey.php
@@ -96,11 +96,10 @@ class DBForeignKey extends DBInt
             // Remove distinct. Applying distinct shouldn't be required provided relations are not applied.
             $dataQuery->setDistinct(false);
 
-            $dataQuery->setSelect(['over_threshold' => 'count(*) > ' . (int) $threshold]);
+            $dataQuery->setSelect(['over_threshold' => '(CASE WHEN count(*) > ' . (int)$threshold . ' THEN 1 ELSE 0 END)']);
             $result = $dataQuery->execute()->column('over_threshold');
 
-            // Checking for 't' supports PostgreSQL before silverstripe/postgresql@2.2
-            $overThreshold = !empty($result) && ($result[0] === 't' ||  (int) $result[0] === 1);
+            $overThreshold = !empty($result) && ((int) $result[0] === 1);
 
             static::$foreignListCache[$hasOneClass] = [
                 'overThreshold' => $overThreshold,


### PR DESCRIPTION
Co-authored-by: Tomas Bilek

Basically the same PR as https://github.com/silverstripe/silverstripe-framework/pull/9210, though with a more recent version of framework that includes https://github.com/silverstripe/silverstripe-framework/blob/4/src/ORM/FieldType/DBDatetime.php#L220 which is required to get travis integration testing to pass
