### PR TITLE
BUG Make PasswordEncryptor::check more resistent to timing attacks

### DIFF
--- a/src/Security/PasswordEncryptor.php
+++ b/src/Security/PasswordEncryptor.php
@@ -100,6 +100,6 @@ abstract class PasswordEncryptor
      */
     public function check($hash, $password, $salt = null, $member = null)
     {
-        return $hash === $this->encrypt($password, $salt, $member);
+        return hash_equals($hash, $this->encrypt($password, $salt, $member));
     }
 }


### PR DESCRIPTION
This is a minor improvement to the logic we use to valid passwords. We're switching from a strict equality check to a php's native [`hash_equals`](https://www.php.net/manual/en/function.hash-equals.php) method which is more resistant to timing attack.


