### PR TITLE
API Add new behat method for interacting with toasts

### DIFF
--- a/tests/behat/src/CmsUiContext.php
+++ b/tests/behat/src/CmsUiContext.php
@@ -81,7 +81,7 @@ class CmsUiContext implements Context
      */
     public function iShouldSeeANotice($notice)
     {
-        $this->getMainContext()->assertElementContains('.toast, .notice', $notice);
+        $this->getMainContext()->assertElementContains('.toast, .notice-wrap', $notice);
     }
 
     /**

--- a/tests/behat/src/CmsUiContext.php
+++ b/tests/behat/src/CmsUiContext.php
@@ -77,10 +77,49 @@ class CmsUiContext implements Context
 
     /**
      * @Then /^I should see a "([^"]*)" notice$/
+     * @deprecated 4.7.0 Use `iShouldSeeAToast` instead
      */
     public function iShouldSeeANotice($notice)
     {
-        $this->getMainContext()->assertElementContains('.notice-wrap', $notice);
+        $this->getMainContext()->assertElementContains('.toast, .notice', $notice);
+    }
+
+    /**
+     * @Then /^I should see a "([^"]+)" (\w+) toast$/
+     */
+    public function iShouldSeeAToast($notice, $type)
+    {
+        $this->getMainContext()->assertElementContains('.toast--' . $type, $notice);
+    }
+
+    /**
+     * @Then /^I should see a "([^"]+)" (\w+) toast with these actions: (.+)$/
+     */
+    public function iShouldSeeAToastWithAction($notice, $type, $actions)
+    {
+        $this->iShouldSeeAToast($notice, $type);
+
+        $actions = explode(',', $actions);
+        foreach($actions as $order => $action) {
+            $this->getMainContext()->assertElementContains(
+                sprintf('.toast--%s .toast__action:nth-child(%s)', $type, $order+1),
+                trim($action)
+            );
+        }
+    }
+
+    /**
+     * @param $action
+     * @When /^I click the "([^"]*)" toast action$/
+     */
+    public function stepIClickTheToastAction($action)
+    {
+        $page = $this->getMainContext()->getSession()->getPage();
+        $toasts = $page->find('css', '.toasts');
+        assertNotNull($toasts, "We have a toast container");
+        $toastAction = $toasts->find('named', ['link_or_button', "'{$action}'"]);
+        assertNotNull($toastAction, "We have a $action toast action");
+        $toastAction->click();
     }
 
     /**

--- a/tests/behat/src/CmsUiContext.php
+++ b/tests/behat/src/CmsUiContext.php
@@ -100,7 +100,7 @@ class CmsUiContext implements Context
         $this->iShouldSeeAToast($notice, $type);
 
         $actions = explode(',', $actions);
-        foreach($actions as $order => $action) {
+        foreach ($actions as $order => $action) {
             $this->getMainContext()->assertElementContains(
                 sprintf('.toast--%s .toast__action:nth-child(%s)', $type, $order+1),
                 trim($action)


### PR DESCRIPTION
This PR adds a couple extra method to allow behat to look for toast notifications and to click toast actions.

# Parent issue
* resolve https://github.com/silverstripe/silverstripe-admin/issues/504