### PR TITLE
FIX Use empty array as a fallback for preg_split within DBText summary

### DIFF
--- a/src/ORM/FieldType/DBText.php
+++ b/src/ORM/FieldType/DBText.php
@@ -80,7 +80,7 @@ class DBText extends DBString
         }
 
         // Do a word-search
-        $words = preg_split('/\s+/u', $value);
+        $words = preg_split('/\s+/u', $value) ?: [];
         $sentences = 0;
         foreach ($words as $i => $word) {
             if (preg_match('/(!|\?|\.)$/', $word) && !preg_match('/(Dr|Mr|Mrs|Ms|Miss|Sr|Jr|No)\.$/i', $word)) {
@@ -133,8 +133,8 @@ class DBText extends DBString
         // Split on sentences (don't remove period)
         $sentences = array_filter(array_map(function ($str) {
             return trim($str);
-        }, preg_split('@(?<=\.)@', $value)));
-        $wordCount = count(preg_split('#\s+#u', $sentences[0]));
+        }, preg_split('@(?<=\.)@', $value) ?: []));
+        $wordCount = count(preg_split('#\s+#u', $sentences[0]) ?: []);
 
         // if the first sentence is too long, show only the first $maxWords words
         if ($wordCount > $maxWords) {
@@ -149,7 +149,7 @@ class DBText extends DBString
 
             // If more sentences to process, count number of words
             if ($sentences) {
-                $wordCount += count(preg_split('#\s+#u', $sentences[0]));
+                $wordCount += count(preg_split('#\s+#u', $sentences[0]) ?: []);
             }
         } while ($wordCount < $maxWords && $sentences && trim($sentences[0]));
 
@@ -169,7 +169,7 @@ class DBText extends DBString
         }
 
         // Split paragraphs and return first
-        $paragraphs = preg_split('#\n{2,}#', $value);
+        $paragraphs = preg_split('#\n{2,}#', $value) ?: [];
         return reset($paragraphs);
     }
 

--- a/tests/php/ORM/DBTextTest.php
+++ b/tests/php/ORM/DBTextTest.php
@@ -114,7 +114,7 @@ class DBTextTest extends SapphireTest
             ['The little brown fox jumped over the lazy cow.', 3, 'The little brown…'],
             [' This text has white space around the ends ', 3, 'This text has…'],
 
-            // Words less than the limt word count don't get truncated, ellipsis not added
+            // Words less than the limit word count don't get truncated, ellipsis not added
             ['Two words', 3, 'Two words'],  // Two words shouldn't have an ellipsis
             ['These three words', 3, 'These three words'], // Three words shouldn't have an ellipsis
             ['One', 3, 'One'],  // Neither should one word
@@ -216,7 +216,7 @@ class DBTextTest extends SapphireTest
     }
 
     /**
-     * each test is in the format input, charactere limit, highlight, expected output
+     * each test is in the format input, character limit, highlight, expected output
      *
      * @return array
      */
@@ -268,7 +268,7 @@ class DBTextTest extends SapphireTest
                 'both schön and können have umlauts',
                 21,
                 '',
-                // check non existant search term
+                // check non-existent search term
                 'both schön and können…',
             ]
         ];
@@ -314,7 +314,7 @@ class DBTextTest extends SapphireTest
     /**
      * @dataProvider providerContextSummary
      * @param string $originalValue Input
-     * @param int    $limit         Numer of characters
+     * @param int    $limit         Number of characters
      * @param string $keywords      Keywords to highlight
      * @param string $expectedValue Expected output (XML encoded safely)
      */


### PR DESCRIPTION
If the content is invalid for whatever reason e.g. when instantiating a DBText field to get a summary of text through `DBField::create_field('Text', $content)->Summary(10)` from a UTF-malformed string, preg_split returns false and the rest of the code expects an array.

This fix ensures an array is always returned even when preg_split fails.