### PR TITLE
NEW Set action button state on form validation fail

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -476,6 +476,47 @@ class Form extends ViewableData implements HasRequestHandler
     }
 
     /**
+     * Set the state of an action button to dirty or pristine if the button exists
+     *
+     * @param string $actionButton - "save" or "publish"
+     * @param string $state - "pristine" or "dirty"
+     */
+    public function setActionButtonState(string $actionButton, string $state): void
+    {
+        /** @var CompositeField $majorActions */
+        /** @var FormAction $action */
+        $oppositeState = $state === 'dirty' ? 'pristine' : 'dirty';
+        $classes = [
+            'save' => [
+                'dirty' => 'btn-primary font-icon-save',
+                'pristine' => 'btn-outline-primary font-icon-tick',
+            ],
+            'publish' => [
+                'dirty' => 'btn-primary font-icon-rocket',
+                'pristine' => 'btn-outline-primary font-icon-tick',
+            ]
+        ];
+        // action_save and action_publish are used by SiteTree
+        // action_doSave and action_doPublish are used by GridFieldDetailForm_ItemRequest
+        $names = [
+            'save' => ['action_save', 'action_doSave'],
+            'publish' => ['action_publish', 'action_doPublish'],
+        ];
+        $this->extend('updateActionButtonState', $classes, $names);
+        $majorActions = $this->Actions()->fieldByName('MajorActions');
+        if (!$majorActions) {
+            return;
+        }
+        foreach ($majorActions->getChildren() as $action) {
+            if (!in_array($action->getName(), $names[$actionButton])) {
+                continue;
+            }
+            $action->removeExtraClass($classes[$actionButton][$oppositeState]);
+            $action->addExtraClass($classes[$actionButton][$state]);
+        }
+    }
+
+    /**
      * Populate this form with messages from the given ValidationResult.
      * Note: This will not clear any pre-existing messages
      *

--- a/src/Forms/FormRequestHandler.php
+++ b/src/Forms/FormRequestHandler.php
@@ -220,6 +220,8 @@ class FormRequestHandler extends RequestHandler
             // Or we can use the Validator attached to the form
             $result = $this->form->validationResult();
             if (!$result->isValid()) {
+                $this->form->setActionButtonState('save', 'dirty');
+                $this->form->setActionButtonState('publish', 'dirty');
                 return $this->getValidationErrorResponse($result);
             }
 
@@ -250,6 +252,8 @@ class FormRequestHandler extends RequestHandler
             // The ValidationResult contains all the relevant metadata
             $result = $e->getResult();
             $this->form->loadMessagesFrom($result);
+            $this->form->setActionButtonState('save', 'dirty');
+            $this->form->setActionButtonState('publish', 'dirty');
             return $this->getValidationErrorResponse($result);
         }
 

--- a/tests/php/Forms/FormRequestHandlerTest.php
+++ b/tests/php/Forms/FormRequestHandlerTest.php
@@ -6,10 +6,13 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Session;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\FormRequestHandler;
 use SilverStripe\Forms\PasswordField;
+use SilverStripe\Forms\RequiredFields;
 use SilverStripe\Forms\Tests\FormRequestHandlerTest\TestForm;
 use SilverStripe\Forms\Tests\FormRequestHandlerTest\TestFormRequestHandler;
 use SilverStripe\Forms\TextField;
@@ -49,5 +52,42 @@ class FormRequestHandlerTest extends SapphireTest
         $request->setSession(new Session([]));
         $response = $handler->httpSubmission($request);
         $this->assertFalse($response->isError());
+    }
+
+    public function testValidationButtonState()
+    {
+        /** @var FormAction $action */
+        // Save button classes
+        $saveButtonDirtyClass = 'btn-primary font-icon-save';
+        $saveButtonPristineClass = 'btn-outline-primary font-icon-tick';
+
+        // Create a form and handler
+        $majorActions = new CompositeField([
+            new FormAction('doSave', 'Save')
+        ]);
+        $majorActions->setName('MajorActions');
+        $form = new Form(
+            new FormTest\TestController(),
+            'Form',
+            new FieldList(new TextField('MyField')),
+            new FieldList($majorActions)
+        );
+        $validator = new RequiredFields('MyField');
+        $form->setValidator($validator);
+        $form->disableSecurityToken();
+        $handler = new FormRequestHandler($form);
+
+        // Set the save button to a pristine state
+        $action = $form->Actions()->fieldByName('MajorActions')->getChildren()[0];
+        $action->removeExtraClass($saveButtonDirtyClass);
+        $action->addExtraClass($saveButtonPristineClass);
+
+        // Submit the form with the required field not filled in
+        // Validate that save button has a dirty class because the form failed validation
+        $request = new HTTPRequest('POST', '/', null, ['MyField' => '', 'action_doSave' => 1]);
+        $request->setSession(new Session([]));
+        $handler->httpSubmission($request);
+        $this->assertTrue(strpos($action->extraClass(), $saveButtonDirtyClass) !== false);
+        $this->assertTrue(strpos($action->extraClass(), $saveButtonPristineClass) === false);
     }
 }

--- a/tests/php/Forms/FormTest.php
+++ b/tests/php/Forms/FormTest.php
@@ -7,6 +7,7 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Session;
 use SilverStripe\Dev\CSSContentParser;
 use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\DateField;
 use SilverStripe\Forms\DatetimeField;
 use SilverStripe\Forms\FieldList;
@@ -1107,5 +1108,49 @@ class FormTest extends FunctionalTest
             ),
             new FieldList()
         );
+    }
+
+    public function testSetActionButtonState()
+    {
+        /** @var FormAction $action */
+        $classes = [
+            'save' => [
+                'dirty' => 'btn-primary font-icon-save',
+                'pristine' => 'btn-outline-primary font-icon-tick',
+            ],
+            'publish' => [
+                'dirty' => 'btn-primary font-icon-rocket',
+                'pristine' => 'btn-outline-primary font-icon-tick',
+            ]
+        ];
+        $majorActions = new CompositeField([
+            new FormAction('doSave', 'Save'),
+            new FormAction('doPublish', 'Publish')
+        ]);
+        $majorActions->setName('MajorActions');
+        $form = new Form(
+            new FormTest\TestController(),
+            'Form',
+            new FieldList(new TextField('MyField')),
+            new FieldList($majorActions)
+        );
+
+        // save button
+        $action = $form->Actions()->fieldByName('MajorActions')->getChildren()[0];
+        $form->setActionButtonState('save', 'dirty');
+        $this->assertTrue(strpos($action->extraClass(), $classes['save']['dirty']) !== false);
+        $this->assertTrue(strpos($action->extraClass(), $classes['save']['pristine']) === false);
+        $form->setActionButtonState('save', 'pristine');
+        $this->assertTrue(strpos($action->extraClass(), $classes['save']['dirty']) === false);
+        $this->assertTrue(strpos($action->extraClass(), $classes['save']['pristine']) !== false);
+
+        // publish button
+        $action = $form->Actions()->fieldByName('MajorActions')->getChildren()[1];
+        $form->setActionButtonState('publish', 'dirty');
+        $this->assertTrue(strpos($action->extraClass(), $classes['publish']['dirty']) !== false);
+        $this->assertTrue(strpos($action->extraClass(), $classes['publish']['pristine']) === false);
+        $form->setActionButtonState('publish', 'pristine');
+        $this->assertTrue(strpos($action->extraClass(), $classes['publish']['dirty']) === false);
+        $this->assertTrue(strpos($action->extraClass(), $classes['publish']['pristine']) !== false);
     }
 }


### PR DESCRIPTION
Fix for https://github.com/silverstripe/silverstripe-admin/issues/1110

I'll admit it does seem a little wrong:
- Setting hardcoded button classes in Form.php
- Using hardcoded action names e.g. "action_save", "action_doPublish"

However:
- Hardcoded button classes are already [used all over the place](https://github.com/silverstripe/silverstripe-admin/issues/1110#issuecomment-695867148) so I don't think a "clean" solution is realistic here
- I think the hardcoded action names are fine given how little these will change (never?).  I've added an extension hook just in case a module somewhere adds a new button.
- This does seem like the most central place to set button state for both validation errors for both SiteTree and GridField Forms

Open to moving this code somewhere else or doing it a little cleaner if someone can show me where and how.
