### PR TITLE
Add namespacing to YAML example

### DIFF
--- a/docs/en/02_Developer_Guides/02_Controllers/02_Routing.md
+++ b/docs/en/02_Developer_Guides/02_Controllers/02_Routing.md
@@ -256,7 +256,7 @@ class FeedController extends ContentController
 The YAML rule, in contrast, is simple. It needs to provide only enough information for the framework to choose the desired controller.
 
 ```yml
-Director:
+SilverStripe\Control\Director:
   rules:
     'feed': 'FeedController'
 ```


### PR DESCRIPTION
YAML code example is missing namespacing required for Silverstripe 4.