### PR TITLE
FIX Ensure parent class exists before retrieving database fields for it

### DIFF
--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -360,7 +360,8 @@ class DataObjectSchema
         }
 
         // Recursively merge
-        $parentFields = $this->databaseFields(get_parent_class($class));
+        $parentClass = get_parent_class($class);
+        $parentFields = $parentClass ? $this->databaseFields($parentClass) : [];
         return array_merge($fields, array_diff_key($parentFields, $fields));
     }
 


### PR DESCRIPTION
This is just some defensive programming for an edge case

Part of https://github.com/silverstripe/silverstripe-admin/issues/1098

If for whatever reason you pass in a something that you perhaps shouldn't like a DataExtension e.g.  SilverStripe\Assets\Shortcodes\FileLinkTracking, this stops an error from being thrown.
