### PR TITLE
Update spaces in syntax, single quotes, early returns where possible

### DIFF
--- a/src/ORM/Connect/DBConnector.php
+++ b/src/ORM/Connect/DBConnector.php
@@ -122,9 +122,8 @@ abstract class DBConnector
         $operation = $matches['operation'];
         if (is_array($type)) {
             return in_array(strtolower($operation), $type);
-        } else {
-            return strcasecmp($sql, $type) === 0;
         }
+        return strcasecmp($sql, $type) === 0;
     }
 
     /**

--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -788,51 +788,45 @@ MESSAGE
         if (!$this->supressOutput) {
             if (Director::is_cli()) {
                 switch ($type) {
-                    case "created":
-                    case "changed":
-                    case "repaired":
-                        $sign = "+";
+                    case 'created':
+                    case 'changed':
+                    case 'repaired':
+                        $sign = '+';
                         break;
-                    case "obsolete":
-                    case "deleted":
+                    case 'obsolete':
+                    case 'deleted':
                         $sign = '-';
                         break;
-                    case "notice":
+                    case 'notice':
                         $sign = '*';
                         break;
-                    case "error":
-                        $sign = "!";
+                    case 'error':
+                        $sign = '!';
                         break;
                     default:
-                        $sign = " ";
+                        $sign = ' ';
                 }
                 $message = strip_tags($message);
                 echo "  $sign $message\n";
             } else {
                 switch ($type) {
-                    case "created":
-                        $class = "success";
+                    case 'created':
+                        $class = 'success';
                         break;
-                    case "obsolete":
-                        $class = "error";
+                    case 'obsolete':
+                    case 'error':
+                    case 'deleted':
+                        $class = 'error';
                         break;
-                    case "notice":
-                        $class = "warning";
+                    case 'notice':
+                        $class = 'warning';
                         break;
-                    case "error":
-                        $class = "error";
-                        break;
-                    case "deleted":
-                        $class = "error";
-                        break;
-                    case "changed":
-                        $class = "info";
-                        break;
-                    case "repaired":
-                        $class = "info";
+                    case 'changed':
+                    case 'repaired':
+                        $class = 'info';
                         break;
                     default:
-                        $class = "";
+                        $class = '';
                 }
                 echo "<li class=\"$class\">$message</li>";
             }
@@ -878,7 +872,7 @@ MESSAGE
 
         $this->alterationMessage(
             "Table $tableName: renamed from $currentName",
-            "repaired"
+            'repaired'
         );
 
         // Rename via temp table to avoid case-sensitivity issues

--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -254,9 +254,8 @@ abstract class Database
                 Backtrace::backtrace();
             }
             return $result;
-        } else {
-            return $callback($sql);
         }
+        return $callback($sql);
     }
 
     /**

--- a/src/ORM/Connect/DatabaseException.php
+++ b/src/ORM/Connect/DatabaseException.php
@@ -53,7 +53,7 @@ class DatabaseException extends Exception
      * @param string $sql The SQL executed for this query
      * @param array $parameters The parameters given for this query, if any
      */
-    function __construct($message = '', $code = 0, $previous = null, $sql = null, $parameters = [])
+    public function __construct($message = '', $code = 0, $previous = null, $sql = null, $parameters = [])
     {
         parent::__construct($message, $code, $previous);
         $this->sql = $sql;

--- a/src/ORM/FieldType/DBBoolean.php
+++ b/src/ORM/FieldType/DBBoolean.php
@@ -11,7 +11,6 @@ use SilverStripe\ORM\DB;
  */
 class DBBoolean extends DBField
 {
-
     public function __construct($name = null, $defaultVal = 0)
     {
         $this->defaultVal = ($defaultVal) ? 1 : 0;
@@ -21,15 +20,15 @@ class DBBoolean extends DBField
 
     public function requireField()
     {
-        $parts=[
-            'datatype'=>'tinyint',
-            'precision'=>1,
-            'sign'=>'unsigned',
-            'null'=>'not null',
-            'default'=>$this->defaultVal,
-            'arrayValue'=>$this->arrayValue
+        $parts = [
+            'datatype' => 'tinyint',
+            'precision' => 1,
+            'sign' => 'unsigned',
+            'null' => 'not null',
+            'default' => $this->defaultVal,
+            'arrayValue' => $this->arrayValue
         ];
-        $values=['type'=>'boolean', 'parts'=>$parts];
+        $values = ['type' => 'boolean', 'parts' => $parts];
         DB::require_field($this->tableName, $this->name, $values);
     }
 
@@ -81,9 +80,11 @@ class DBBoolean extends DBField
     {
         if (is_bool($value)) {
             return $value ? 1 : 0;
-        } elseif (empty($value)) {
+        }
+        if (empty($value)) {
             return 0;
-        } elseif (is_string($value)) {
+        }
+        if (is_string($value)) {
             switch (strtolower($value)) {
                 case 'false':
                 case 'f':

--- a/src/ORM/FieldType/DBClassName.php
+++ b/src/ORM/FieldType/DBClassName.php
@@ -4,9 +4,9 @@ namespace SilverStripe\ORM\FieldType;
 
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
-use SilverStripe\Dev\Deprecation;
 
 /**
  * Represents a classname selector, which respects obsolete clasess.

--- a/src/ORM/FieldType/DBComposite.php
+++ b/src/ORM/FieldType/DBComposite.php
@@ -126,7 +126,7 @@ abstract class DBComposite extends DBField
     public function isChanged()
     {
         // When unbound, use the local changed flag
-        if (! ($this->record instanceof DataObject)) {
+        if (!$this->record instanceof DataObject) {
             return $this->isChanged;
         }
 

--- a/src/ORM/FieldType/DBCurrency.php
+++ b/src/ORM/FieldType/DBCurrency.php
@@ -35,7 +35,6 @@ class DBCurrency extends DBDecimal
      */
     public function Nice()
     {
-        // return "<span title=\"$this->value\">$" . number_format($this->value, 2) . '</span>';
         $val = $this->config()->currency_symbol . number_format(abs($this->value), 2);
         if ($this->value < 0) {
             return "($val)";

--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -335,11 +335,11 @@ class DBDate extends DBField
 
         if ($y1 != $y2) {
             return "$d1 $m1 $y1 - $d2 $m2 $y2";
-        } elseif ($m1 != $m2) {
-            return "$d1 $m1 - $d2 $m2 $y1";
-        } else {
-            return "$d1 - $d2 $m1 $y1";
         }
+        if ($m1 != $m2) {
+            return "$d1 $m1 - $d2 $m2 $y1";
+        }
+        return "$d1 - $d2 $m1 $y1";
     }
 
     /**
@@ -393,19 +393,18 @@ class DBDate extends DBField
         $now = DBDatetime::now()->getTimestamp();
         if ($timestamp <= $now) {
             return _t(
-                'SilverStripe\\ORM\\FieldType\\DBDate.TIMEDIFFAGO',
+                __CLASS__ . '.TIMEDIFFAGO',
                 "{difference} ago",
                 'Natural language time difference, e.g. 2 hours ago',
                 ['difference' => $this->TimeDiff($includeSeconds, $significance)]
             );
-        } else {
-            return _t(
-                'SilverStripe\\ORM\\FieldType\\DBDate.TIMEDIFFIN',
-                "in {difference}",
-                'Natural language time difference, e.g. in 2 hours',
-                ['difference' => $this->TimeDiff($includeSeconds, $significance)]
-            );
         }
+        return _t(
+            __CLASS__ . '.TIMEDIFFIN',
+            "in {difference}",
+            'Natural language time difference, e.g. in 2 hours',
+            ['difference' => $this->TimeDiff($includeSeconds, $significance)]
+        );
     }
 
     /**
@@ -423,20 +422,24 @@ class DBDate extends DBField
         $time = $this->getTimestamp();
         $ago = abs($time - $now);
         if ($ago < 60 && !$includeSeconds) {
-            return _t('SilverStripe\\ORM\\FieldType\\DBDate.LessThanMinuteAgo', 'less than a minute');
-        } elseif ($ago < $significance * 60 && $includeSeconds) {
-            return $this->TimeDiffIn('seconds');
-        } elseif ($ago < $significance * 3600) {
-            return $this->TimeDiffIn('minutes');
-        } elseif ($ago < $significance * 86400) {
-            return $this->TimeDiffIn('hours');
-        } elseif ($ago < $significance * 86400 * 30) {
-            return $this->TimeDiffIn('days');
-        } elseif ($ago < $significance * 86400 * 365) {
-            return $this->TimeDiffIn('months');
-        } else {
-            return $this->TimeDiffIn('years');
+            return _t(__CLASS__ . '.LessThanMinuteAgo', 'less than a minute');
         }
+        if ($ago < $significance * 60 && $includeSeconds) {
+            return $this->TimeDiffIn('seconds');
+        }
+        if ($ago < $significance * 3600) {
+            return $this->TimeDiffIn('minutes');
+        }
+        if ($ago < $significance * 86400) {
+            return $this->TimeDiffIn('hours');
+        }
+        if ($ago < $significance * 86400 * 30) {
+            return $this->TimeDiffIn('days');
+        }
+        if ($ago < $significance * 86400 * 365) {
+            return $this->TimeDiffIn('months');
+        }
+        return $this->TimeDiffIn('years');
     }
 
     /**
@@ -456,7 +459,7 @@ class DBDate extends DBField
         $time = $this->getTimestamp();
         $ago = abs($time - $now);
         switch ($format) {
-            case "seconds":
+            case 'seconds':
                 $span = $ago;
                 return _t(
                     __CLASS__ . '.SECONDS_SHORT_PLURALS',
@@ -464,7 +467,7 @@ class DBDate extends DBField
                     ['count' => $span]
                 );
 
-            case "minutes":
+            case 'minutes':
                 $span = round($ago / 60);
                 return _t(
                     __CLASS__ . '.MINUTES_SHORT_PLURALS',
@@ -472,7 +475,7 @@ class DBDate extends DBField
                     ['count' => $span]
                 );
 
-            case "hours":
+            case 'hours':
                 $span = round($ago / 3600);
                 return _t(
                     __CLASS__ . '.HOURS_SHORT_PLURALS',
@@ -480,7 +483,7 @@ class DBDate extends DBField
                     ['count' => $span]
                 );
 
-            case "days":
+            case 'days':
                 $span = round($ago / 86400);
                 return _t(
                     __CLASS__ . '.DAYS_SHORT_PLURALS',
@@ -488,7 +491,7 @@ class DBDate extends DBField
                     ['count' => $span]
                 );
 
-            case "months":
+            case 'months':
                 $span = round($ago / 86400 / 30);
                 return _t(
                     __CLASS__ . '.MONTHS_SHORT_PLURALS',
@@ -496,7 +499,7 @@ class DBDate extends DBField
                     ['count' => $span]
                 );
 
-            case "years":
+            case 'years':
                 $span = round($ago / 86400 / 365);
                 return _t(
                     __CLASS__ . '.YEARS_SHORT_PLURALS',
@@ -554,6 +557,7 @@ class DBDate extends DBField
      * </code>
      *
      * @param string $adjustment PHP strtotime style
+     * @return $this
      */
     public function modify(string $adjustment): self
     {
@@ -588,7 +592,7 @@ class DBDate extends DBField
     protected function fixInputDate($value)
     {
         // split
-        list($year, $month, $day, $time) = $this->explodeDateString($value);
+        [$year, $month, $day, $time] = $this->explodeDateString($value);
 
         if ((int)$year === 0 && (int)$month === 0 && (int)$day === 0) {
             return null;

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -93,7 +93,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      * Return a date and time formatted as per a CMS user's settings.
      *
      * @param Member $member
-     * @return boolean | string A time and date pair formatted as per user-defined settings.
+     * @return boolean|string A time and date pair formatted as per user-defined settings.
      */
     public function FormatFromSettings($member = null)
     {
@@ -150,7 +150,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
                 'SilverStripe\\Forms\\FormField.EXAMPLE',
                 'e.g. {format}',
                 'Example format',
-                [ 'format' => $date ]
+                ['format' => $date]
             ))
             ->setAttribute('placeholder', $dateTimeFormat);
 

--- a/src/ORM/FieldType/DBDecimal.php
+++ b/src/ORM/FieldType/DBDecimal.php
@@ -2,8 +2,8 @@
 
 namespace SilverStripe\ORM\FieldType;
 
-use SilverStripe\ORM\DB;
 use SilverStripe\Forms\NumericField;
+use SilverStripe\ORM\DB;
 
 /**
  * Represents a Decimal field.

--- a/src/ORM/FieldType/DBDouble.php
+++ b/src/ORM/FieldType/DBDouble.php
@@ -2,8 +2,8 @@
 
 namespace SilverStripe\ORM\FieldType;
 
-use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Connect\MySQLDatabase;
+use SilverStripe\ORM\DB;
 
 /**
  * Supports double precision DB types

--- a/src/ORM/FieldType/DBEnum.php
+++ b/src/ORM/FieldType/DBEnum.php
@@ -130,7 +130,7 @@ class DBEnum extends DBString
      * @param string $emptyString
      * @return DropdownField
      */
-    public function formField($title = null, $name = null, $hasEmpty = false, $value = "", $emptyString = null)
+    public function formField($title = null, $name = null, $hasEmpty = false, $value = '', $emptyString = null)
     {
 
         if (!$title) {
@@ -154,13 +154,12 @@ class DBEnum extends DBString
     }
 
     /**
-     * @param string
-     *
+     * @param string $title
      * @return DropdownField
      */
     public function scaffoldSearchField($title = null)
     {
-        $anyText = _t('SilverStripe\\ORM\\FieldType\\DBEnum.ANY', 'Any');
+        $anyText = _t(__CLASS__ . '.ANY', 'Any');
         return $this->formField($title, null, true, '', "($anyText)");
     }
 

--- a/src/ORM/FieldType/DBField.php
+++ b/src/ORM/FieldType/DBField.php
@@ -232,7 +232,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @param mixed $value
      * @param DataObject|array $record An array or object that this field is part of
-     * @param bool $markChanged Indicate wether this field should be marked changed.
+     * @param bool $markChanged Indicate whether this field should be marked changed.
      *  Set to FALSE if you are initializing this field after construction, rather
      *  than setting a new value.
      * @return $this
@@ -335,7 +335,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      * will be escaped automatically by the prepared query processor, so it
      * should not be escaped or quoted at all.
      *
-     * @param $value mixed The value to check
+     * @param mixed $value The value to check
      * @return mixed The raw value, or escaped parameterised details
      */
     public function prepValueForDB($value)

--- a/src/ORM/FieldType/DBFloat.php
+++ b/src/ORM/FieldType/DBFloat.php
@@ -21,12 +21,12 @@ class DBFloat extends DBField
     public function requireField()
     {
         $parts = [
-            'datatype'=>'float',
-            'null'=>'not null',
-            'default'=>$this->defaultVal,
-            'arrayValue'=>$this->arrayValue
+            'datatype' => 'float',
+            'null' => 'not null',
+            'default' => $this->defaultVal,
+            'arrayValue' => $this->arrayValue
         ];
-        $values = ['type'=>'float', 'parts'=>$parts];
+        $values = ['type' => 'float', 'parts' => $parts];
         DB::require_field($this->tableName, $this->name, $values);
     }
 
@@ -66,7 +66,9 @@ class DBFloat extends DBField
     {
         if ($value === true) {
             return 1;
-        } elseif (empty($value) || !is_numeric($value)) {
+        }
+
+        if (empty($value) || !is_numeric($value)) {
             return 0;
         }
 

--- a/src/ORM/FieldType/DBForeignKey.php
+++ b/src/ORM/FieldType/DBForeignKey.php
@@ -79,7 +79,7 @@ class DBForeignKey extends DBInt
         }
 
         // Build selector / numeric field
-        $titleField = $hasOneSingleton->hasField('Title') ? "Title" : "Name";
+        $titleField = $hasOneSingleton->hasField('Title') ? 'Title' : 'Name';
         $list = DataList::create($hasOneClass);
         // Don't scaffold a dropdown for large tables, as making the list concrete
         // might exceed the available PHP memory in creating too many DataObject instances
@@ -118,7 +118,10 @@ class DBForeignKey extends DBInt
             $field->setEmptyString(' ');
         } else {
             $field = new NumericField($this->name, $title);
-            $field->setRightTitle(_t(self::class . '.DROPDOWN_THRESHOLD_FALLBACK_MESSAGE', 'Too many related objects; fallback field in use'));
+            $field->setRightTitle(_t(
+                self::class . '.DROPDOWN_THRESHOLD_FALLBACK_MESSAGE',
+                'Too many related objects; fallback field in use'
+            ));
         }
         return $field;
     }

--- a/src/ORM/FieldType/DBHTMLText.php
+++ b/src/ORM/FieldType/DBHTMLText.php
@@ -2,11 +2,10 @@
 
 namespace SilverStripe\ORM\FieldType;
 
-use SilverStripe\Core\Convert;
-use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Control\HTTP;
-use SilverStripe\Forms\TextField;
+use SilverStripe\Core\Convert;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
+use SilverStripe\Forms\TextField;
 use SilverStripe\View\Parsers\HTMLValue;
 use SilverStripe\View\Parsers\ShortcodeParser;
 
@@ -131,9 +130,8 @@ class DBHTMLText extends DBText
     {
         if ($this->processShortcodes) {
             return ShortcodeParser::get_active()->parse($this->value);
-        } else {
-            return $this->value;
         }
+        return $this->value;
     }
 
     /**

--- a/src/ORM/FieldType/DBHTMLVarchar.php
+++ b/src/ORM/FieldType/DBHTMLVarchar.php
@@ -3,8 +3,8 @@
 namespace SilverStripe\ORM\FieldType;
 
 use SilverStripe\Core\Convert;
-use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
+use SilverStripe\Forms\TextField;
 use SilverStripe\View\Parsers\ShortcodeParser;
 
 /**
@@ -88,9 +88,8 @@ class DBHTMLVarchar extends DBVarchar
     {
         if ($this->processShortcodes) {
             return ShortcodeParser::get_active()->parse($this->value);
-        } else {
-            return $this->value;
         }
+        return $this->value;
     }
 
     /**

--- a/src/ORM/FieldType/DBIndexable.php
+++ b/src/ORM/FieldType/DBIndexable.php
@@ -30,7 +30,7 @@ interface DBIndexable
      * @param string|bool $indexType Either of the types listed in {@link SilverStripe\ORM\FieldType\DBIndexable}, or
      *                               boolean true to indicate that the default index type should be used.
      * @return $this
-     * @throws InvalidArgumentException If $type is not one of TYPE_INDEX, TYPE_UNIQUE or TYPE_FULLTEXT
+     * @throws \InvalidArgumentException If $type is not one of TYPE_INDEX, TYPE_UNIQUE or TYPE_FULLTEXT
      */
     public function setIndexType($type);
 

--- a/src/ORM/FieldType/DBInt.php
+++ b/src/ORM/FieldType/DBInt.php
@@ -3,8 +3,8 @@
 namespace SilverStripe\ORM\FieldType;
 
 use SilverStripe\Forms\NumericField;
-use SilverStripe\ORM\DB;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DB;
 use SilverStripe\View\ArrayData;
 
 /**
@@ -45,7 +45,7 @@ class DBInt extends DBField
     {
         $output = new ArrayList();
         for ($i = 0; $i < $this->value; $i++) {
-            $output->push(new ArrayData([ 'Number' => $i + 1 ]));
+            $output->push(ArrayData::create(['Number' => $i + 1]));
         }
 
         return $output;

--- a/src/ORM/FieldType/DBLocale.php
+++ b/src/ORM/FieldType/DBLocale.php
@@ -65,7 +65,7 @@ class DBLocale extends DBVarchar
     public function getNativeName()
     {
         $locale = $this->value;
-        return i18n::with_locale($locale, function () use ($locale) {
+        return i18n::with_locale($locale, function () {
             return $this->getShortName();
         });
     }

--- a/src/ORM/FieldType/DBMoney.php
+++ b/src/ORM/FieldType/DBMoney.php
@@ -22,8 +22,8 @@ class DBMoney extends DBComposite
      * @param array
      */
     private static $composite_db = [
-        "Currency" => "Varchar(3)",
-        "Amount" => 'Decimal(19,4)'
+        'Currency' => 'Varchar(3)',
+        'Amount' => 'Decimal(19,4)'
     ];
 
     /**

--- a/src/ORM/FieldType/DBMultiEnum.php
+++ b/src/ORM/FieldType/DBMultiEnum.php
@@ -3,9 +3,9 @@
 namespace SilverStripe\ORM\FieldType;
 
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Forms\CheckboxSetField;
 use SilverStripe\ORM\Connect\MySQLDatabase;
 use SilverStripe\ORM\DB;
-use SilverStripe\Forms\CheckboxSetField;
 
 /**
  * Represents an multi-select enumeration field.
@@ -25,7 +25,7 @@ class DBMultiEnum extends DBEnum
                 if (!in_array($thisDefault, $this->enum)) {
                     throw new \InvalidArgumentException(
                         "Enum::__construct() The default value '$thisDefault' does not match "
-                        . "any item in the enumeration"
+                        . 'any item in the enumeration'
                     );
                 }
             }
@@ -38,16 +38,16 @@ class DBMultiEnum extends DBEnum
         // @todo: Remove mysql-centric logic from this
         $charset = Config::inst()->get(MySQLDatabase::class, 'charset');
         $collation = Config::inst()->get(MySQLDatabase::class, 'collation');
-        $values=[
-            'type'=>'set',
-            'parts'=>[
-                'enums'=>$this->enum,
-                'character set'=> $charset,
-                'collate'=> $collation,
-                'default'=> $this->default,
-                'table'=>$this->tableName,
-                'arrayValue'=>$this->arrayValue
-            ]
+        $values = [
+            'type' => 'set',
+            'parts' => [
+                'enums' => $this->enum,
+                'character set' => $charset,
+                'collate' => $collation,
+                'default' => $this->default,
+                'table' => $this->tableName,
+                'arrayValue' => $this->arrayValue,
+            ],
         ];
 
         DB::require_field($this->tableName, $this->name, $values);
@@ -64,7 +64,7 @@ class DBMultiEnum extends DBEnum
      * @param string $emptyString
      * @return CheckboxSetField
      */
-    public function formField($title = null, $name = null, $hasEmpty = false, $value = "", $emptyString = null)
+    public function formField($title = null, $name = null, $hasEmpty = false, $value = '', $emptyString = null)
     {
 
         if (!$title) {
@@ -74,8 +74,6 @@ class DBMultiEnum extends DBEnum
             $name = $this->name;
         }
 
-        $field = new CheckboxSetField($name, $title, $this->enumValues($hasEmpty), $value);
-
-        return $field;
+        return new CheckboxSetField($name, $title, $this->enumValues($hasEmpty), $value);
     }
 }

--- a/src/ORM/FieldType/DBPolymorphicForeignKey.php
+++ b/src/ORM/FieldType/DBPolymorphicForeignKey.php
@@ -83,7 +83,7 @@ class DBPolymorphicForeignKey extends DBComposite
     {
         $id = $this->getIDValue();
         $class = $this->getClassValue();
-        if ($id && $class && is_subclass_of($class, 'SilverStripe\ORM\DataObject')) {
+        if ($id && $class && is_subclass_of($class, DataObject::class)) {
             return DataObject::get_by_id($class, $id);
         }
         return null;

--- a/src/ORM/FieldType/DBPrimaryKey.php
+++ b/src/ORM/FieldType/DBPrimaryKey.php
@@ -2,8 +2,8 @@
 
 namespace SilverStripe\ORM\FieldType;
 
-use SilverStripe\ORM\DB;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
 
 /**
  * A special type Int field used for primary keys.

--- a/src/ORM/FieldType/DBString.php
+++ b/src/ORM/FieldType/DBString.php
@@ -11,12 +11,12 @@ abstract class DBString extends DBField
      * @var array
      */
     private static $casting = [
-        "LimitCharacters" => "Text",
-        "LimitCharactersToClosestWord" => "Text",
-        "LimitWordCount" => "Text",
-        "LowerCase" => "Text",
-        "UpperCase" => "Text",
-        "Plain" => "Text",
+        'LimitCharacters' => 'Text',
+        'LimitCharactersToClosestWord' => 'Text',
+        'LimitWordCount' => 'Text',
+        'LowerCase' => 'Text',
+        'UpperCase' => 'Text',
+        'Plain' => 'Text',
     ];
 
     /**

--- a/src/ORM/FieldType/DBText.php
+++ b/src/ORM/FieldType/DBText.php
@@ -2,14 +2,14 @@
 
 namespace SilverStripe\ORM\FieldType;
 
+use InvalidArgumentException;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
-use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Forms\TextareaField;
 use SilverStripe\Forms\NullableField;
+use SilverStripe\Forms\TextareaField;
 use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\Connect\MySQLDatabase;
 use SilverStripe\ORM\DB;
-use InvalidArgumentException;
 
 /**
  * Represents a variable-length string of up to 16 megabytes, designed to store raw text
@@ -29,12 +29,12 @@ class DBText extends DBString
 {
 
     private static $casting = [
-        "BigSummary" => "Text",
-        "ContextSummary" => "HTMLFragment", // Always returns HTML as it contains formatting and highlighting
-        "FirstParagraph" => "Text",
-        "FirstSentence" => "Text",
-        "LimitSentences" => "Text",
-        "Summary" => "Text",
+        'BigSummary' => 'Text',
+        'ContextSummary' => 'HTMLFragment', // Always returns HTML as it contains formatting and highlighting
+        'FirstParagraph' => 'Text',
+        'FirstSentence' => 'Text',
+        'LimitSentences' => 'Text',
+        'Summary' => 'Text',
     ];
 
     /**
@@ -43,8 +43,8 @@ class DBText extends DBString
      */
     public function requireField()
     {
-        $charset = Config::inst()->get('SilverStripe\ORM\Connect\MySQLDatabase', 'charset');
-        $collation = Config::inst()->get('SilverStripe\ORM\Connect\MySQLDatabase', 'collation');
+        $charset = Config::inst()->get(MySQLDatabase::class, 'charset');
+        $collation = Config::inst()->get(MySQLDatabase::class, 'collation');
 
         $parts = [
             'datatype' => 'mediumtext',
@@ -76,7 +76,7 @@ class DBText extends DBString
 
         $value = $this->Plain();
         if (!$value) {
-            return "";
+            return '';
         }
 
         // Do a word-search
@@ -94,10 +94,9 @@ class DBText extends DBString
         // Failing to find the number of sentences requested, fallback to a logical default
         if ($maxSentences > 1) {
             return $value;
-        } else {
-            // If searching for a single sentence (and there are none) just do a text summary
-            return $this->Summary(20);
         }
+        // If searching for a single sentence (and there are none) just do a text summary
+        return $this->Summary(20);
     }
 
 
@@ -260,10 +259,9 @@ class DBText extends DBString
         if (!$this->nullifyEmpty) {
             // Allow the user to select if it's null instead of automatically assuming empty string is
             return NullableField::create(TextareaField::create($this->name, $title));
-        } else {
-            // Automatically determine null (empty string)
-            return TextareaField::create($this->name, $title);
         }
+        // Automatically determine null (empty string)
+        return TextareaField::create($this->name, $title);
     }
 
     public function scaffoldSearchField($title = null)

--- a/src/ORM/FieldType/DBTime.php
+++ b/src/ORM/FieldType/DBTime.php
@@ -32,7 +32,7 @@ class DBTime extends DBField
         $value = $this->parseTime($value);
         if ($value === false) {
             throw new InvalidArgumentException(
-                "Invalid date passed. Use " . $this->getISOFormat() . " to prevent this error."
+                'Invalid date passed. Use ' . $this->getISOFormat() . ' to prevent this error.'
             );
         }
         $this->value = $value;

--- a/src/ORM/FieldType/DBVarchar.php
+++ b/src/ORM/FieldType/DBVarchar.php
@@ -19,8 +19,8 @@ class DBVarchar extends DBString
 {
 
     private static $casting = [
-        "Initial" => "Text",
-        "URL" => "Text",
+        'Initial' => 'Text',
+        'URL' => 'Text',
     ];
 
     /**
@@ -68,11 +68,11 @@ class DBVarchar extends DBString
         $collation = Config::inst()->get(MySQLDatabase::class, 'collation');
 
         $parts = [
-            'datatype'=>'varchar',
-            'precision'=>$this->size,
-            'character set'=> $charset,
-            'collate'=> $collation,
-            'arrayValue'=>$this->arrayValue
+            'datatype' => 'varchar',
+            'precision' => $this->size,
+            'character set' => $charset,
+            'collate' => $collation,
+            'arrayValue' => $this->arrayValue
         ];
 
         $values = [
@@ -107,9 +107,8 @@ class DBVarchar extends DBString
         $value = $this->RAW();
         if (preg_match('#^[a-zA-Z]+://#', $value)) {
             return $value;
-        } else {
-            return "http://" . $value;
         }
+        return 'http://' . $value;
     }
 
     /**

--- a/src/ORM/FieldType/DBYear.php
+++ b/src/ORM/FieldType/DBYear.php
@@ -13,8 +13,8 @@ class DBYear extends DBField
 
     public function requireField()
     {
-        $parts=['datatype'=>'year', 'precision'=>4, 'arrayValue'=>$this->arrayValue];
-        $values=['type'=>'year', 'parts'=>$parts];
+        $parts = ['datatype' => 'year', 'precision' => 4, 'arrayValue' => $this->arrayValue];
+        $values = ['type' => 'year', 'parts' => $parts];
         DB::require_field($this->tableName, $this->name, $values);
     }
 
@@ -44,7 +44,7 @@ class DBYear extends DBField
             $end = 1900;
         }
         $years = [];
-        for ($i=$start; $i>=$end; $i--) {
+        for ($i = $start; $i >= $end; $i--) {
             $years[$i] = $i;
         }
         return $years;


### PR DESCRIPTION
* Adding spaces in syntax like `['foo'=>'bar']`
* Use single quotes over double
* Early returns where possible
* Some phpdoc fixes
* Some minor logic tidy ups

It's a reasonably small PR because I don't want it to be overwhelming to review.