### PR TITLE
Allow setting sql_mode via config

### DIFF
--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -1,7 +1,7 @@
 ---
 title: Server Requirements
 icon: server
-summary: What you will need to run Silverstripe CMS on a web server 
+summary: What you will need to run Silverstripe CMS on a web server
 ---
 
 
@@ -27,7 +27,11 @@ Use [phpinfo()](http://php.net/manual/en/function.phpinfo.php) to inspect your c
  * PostgreSQL ([third party module](https://addons.silverstripe.org/add-ons/silverstripe/postgresql), community supported)
  * SQL Server ([third party module](https://addons.silverstripe.org/add-ons/silverstripe/mssql), community supported)
  * SQLite ([third party module](https://addons.silverstripe.org/add-ons/silverstripe/sqlite3), community supported)
- 
+
+ ### Connection mode (sql_mode) when using MySQL server >=5.7.5
+
+ MySQL versions >=5.7.5 the `ANSI` sql_mode setting behaves differently and includes the `ONLY_FULL_GROUP_BY` setting. In most cases it is recommended to leave this setting as-is because it results in deterministic SQL. However for some advanced cases the sql_mode can be configured on the database connection via the configuration API.
+
 ## Webserver Configuration
 
 ### Overview
@@ -138,14 +142,14 @@ See [silverstripe/vendor-plugin](https://github.com/silverstripe/vendor-plugin) 
 The default installation includes [silverstripe/errorpage](https://addons.silverstripe.org/add-ons/silverstripe/errorpage),
 which generates static error pages that bypass PHP execution when those pages are published in the CMS.
 Once published, the static files are located in `public/assets/error-404.html` and `public/assets/error-500.html`.
-The default `public/.htaccess` file is configured to have Apache serve those pages based on their HTTP status code. 
+The default `public/.htaccess` file is configured to have Apache serve those pages based on their HTTP status code.
 
 ### Other webservers (Nginx, IIS, Lighttpd)
 
 Serving through webservers other than Apache requires more manual configuration,
 since the defaults configured through `.htaccess` don't apply.
 Please apply the considerations above to your webserver to ensure a secure hosting environment.
-In particular, configure protected assets correctly to avoid exposing draft or protected files uploaded through the CMS. 
+In particular, configure protected assets correctly to avoid exposing draft or protected files uploaded through the CMS.
 
 There are various community supported installation instructions for different environments.
 Nginx is a popular choice, see [Nginx webserver configuration](https://forum.silverstripe.org/t/nginx-webserver-configuration/2246).
@@ -182,9 +186,9 @@ SilverStripe's PHP support has changed over time and if you are looking to upgra
 SilverStripe CMS supports the following web browsers:
 * Google Chrome
 * Internet Explorer 11
-* Microsoft Edge 
+* Microsoft Edge
 * Mozilla Firefox
- 
+
 We aim to provide satisfactory experiences in Apple Safari. SilverStripe CMS works well across Windows, Linux, and Mac operating systems.
 
 ## End user requirements

--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -30,7 +30,7 @@ Use [phpinfo()](http://php.net/manual/en/function.phpinfo.php) to inspect your c
 
  ### Connection mode (sql_mode) when using MySQL server >=5.7.5
 
- MySQL versions >=5.7.5 the `ANSI` sql_mode setting behaves differently and includes the `ONLY_FULL_GROUP_BY` setting. In most cases it is recommended to leave this setting as-is because it results in deterministic SQL. However for some advanced cases the sql_mode can be configured on the database connection via the configuration API.
+In MySQL versions >=5.7.5, the `ANSI` sql_mode setting behaves differently and includes the `ONLY_FULL_GROUP_BY` setting. It is generally recommended to leave this setting as-is because it results in deterministic SQL. However, for some advanced cases, the sql_mode can be configured on the database connection via the configuration API (see `MySQLDatabase::$sql_mode` for more details.) This setting is only available in Silverstripe CMS 4.7 and later.
 
 ## Webserver Configuration
 

--- a/docs/en/04_Changelogs/4.7.0.md
+++ b/docs/en/04_Changelogs/4.7.0.md
@@ -62,7 +62,7 @@ remove the new collation configuration to default back to the previous default c
 
 ### MySQL connection mode now configurable
 
-MySQL versions >=5.7.5 the `ANSI` sql_mode setting behaves differently and includes the `ONLY_FULL_GROUP_BY` setting. In most cases it is recommended to leave this setting as-is because it results in deterministic SQL. However for some advanced cases the sql_mode can be configured on the database connection via the configuration API.
+In MySQL versions >=5.7.5, the `ANSI` sql_mode setting behaves differently and includes the `ONLY_FULL_GROUP_BY` setting. It is generally recommended to leave this setting as-is because it results in deterministic SQL. However, for some advanced cases, the sql_mode can now be configured on the database connection via the configuration API (see `MySQLDatabase::$sql_mode` for more details.)
 
 ### Flysystem dependency shifted
 
@@ -76,4 +76,3 @@ An edgecase exists where a project can update to `silverstripe/framework 4.7.0` 
 `silverstripe/assets 1.6.x`, and lose the Flysystem dependency entirely. The best way to avoid this
 is by ensuring you update all core modules to the new minor release at once, ideally through a core
 recipe like `silverstripe/recipe-core`.
-

--- a/docs/en/04_Changelogs/4.7.0.md
+++ b/docs/en/04_Changelogs/4.7.0.md
@@ -5,6 +5,7 @@
 - [Experimental support for PHP 8](#experimental-support-for-php-8)
 - [Support for Symfony 4 Components](#support-for-symfony-4-components)
 - [Default MySQL collation updated](#default-mysql-collation-updated)
+- [MySQL connection mode configurable](#mysql-connection-mode-now-configurable)
 - [Flysystem dependency shifted](#flysystem-dependency-shifted)
 
 ## New features
@@ -58,6 +59,10 @@ exceeding the maximum indexable size:
 You can rectify this by upgrading MySQL, enabling the `innodb_large_prefix` setting if present, or
 reducing the size of affected fields. If none of these solutions are currently suitable, you can
 remove the new collation configuration to default back to the previous default collation.
+
+### MySQL connection mode now configurable
+
+MySQL versions >=5.7.5 the `ANSI` sql_mode setting behaves differently and includes the `ONLY_FULL_GROUP_BY` setting. In most cases it is recommended to leave this setting as-is because it results in deterministic SQL. However for some advanced cases the sql_mode can be configured on the database connection via the configuration API.
 
 ### Flysystem dependency shifted
 

--- a/src/ORM/Connect/MySQLDatabase.php
+++ b/src/ORM/Connect/MySQLDatabase.php
@@ -50,6 +50,14 @@ class MySQLDatabase extends Database implements TransactionManager
     private static $charset = 'utf8';
 
     /**
+     * Default sql_mode
+     *
+     * @config
+     * @var string
+     */
+    private static $sql_mode = 'ANSI';
+
+    /**
      * Cache for getTransactionManager()
      *
      * @var TransactionManager
@@ -84,8 +92,8 @@ class MySQLDatabase extends Database implements TransactionManager
         // Notify connector of parameters
         $this->connector->connect($parameters);
 
-        // This is important!
-        $this->setSQLMode('ANSI');
+        // Set sql_mode
+        $this->setSQLMode(static::config()->get('sql_mode'));
 
         if (isset($parameters['timezone'])) {
             $this->selectTimezone($parameters['timezone']);

--- a/src/ORM/Connect/MySQLDatabase.php
+++ b/src/ORM/Connect/MySQLDatabase.php
@@ -50,7 +50,8 @@ class MySQLDatabase extends Database implements TransactionManager
     private static $charset = 'utf8';
 
     /**
-     * Default sql_mode
+     * SQL Mode used on connections to MySQL. Defaults to ANSI. For basic ORM
+     * compatibility, this setting must always include ANSI or ANSI_QUOTES.
      *
      * @config
      * @var string


### PR DESCRIPTION
MYSQL >=5.7.5 introduced a change to the `ANSI` alias for the `sql_mode` setting. Namely, it now includes `ONLY_FULL_GROUP_BY`. While this may be more correct SQL it can cause problems eg:
- https://github.com/silverstripe/silverstripe-framework/issues/5451
- https://github.com/tractorcow-farm/silverstripe-fluent/issues/257

Projects built to 5.6 will have a few surprises when upgrading to 5.7 as there is no warning on the current behaviour.

And there have been a few attempts to fix it outside of framework eg:
- https://github.com/tractorcow-farm/silverstripe-fluent/pull/617
- https://github.com/SpliffSplendor/silverstripe-mysqlfixer
- https://github.com/sunnysideup/silverstripe-mysql-5-7-fix/

So i'm proposing we make this a config option and those who need to/know what they're after can change the connection mode.
