### PR TITLE
FIX Hardcode PasswordValidator config in VersionedMemberAuthenticatorTest

### DIFF
--- a/tests/php/Security/MemberAuthenticatorTest.php
+++ b/tests/php/Security/MemberAuthenticatorTest.php
@@ -46,6 +46,7 @@ class MemberAuthenticatorTest extends SapphireTest
         }
         DefaultAdminService::setDefaultAdmin('admin', 'password');
 
+        // Enforce dummy validation (this can otherwise be influenced by recipe config)
         PasswordValidator::singleton()
             ->setMinLength(0)
             ->setTestNames([]);

--- a/tests/php/Security/VersionedMemberAuthenticatorTest.php
+++ b/tests/php/Security/VersionedMemberAuthenticatorTest.php
@@ -44,6 +44,11 @@ class VersionedMemberAuthenticatorTest extends SapphireTest
             $this->markTestSkipped("Versioned is required");
             return;
         }
+
+        // Enforce dummy validation (this can otherwise be influenced by recipe config)
+        PasswordValidator::singleton()
+            ->setMinLength(0)
+            ->setTestNames([]);
     }
 
     protected function tearDown()


### PR DESCRIPTION
This was causing a failure in the CWP Kitchen Sink builds, which are influenced by the stricter `PasswordValidator` configuration in [cwp-core](https://github.com/silverstripe/cwp-core/blob/2/_config/security.yml).