### PR TITLE
DEP Remove unused league/flysystem requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "composer/installers": "~1.0",
         "embed/embed": "^3.0",
         "league/csv": "^8 || ^9",
-        "league/flysystem": "~1.0.12",
         "m1/env": "^2.1",
         "monolog/monolog": "~1.16",
         "nikic/php-parser": "^3 || ^4",

--- a/docs/en/04_Changelogs/4.7.0.md
+++ b/docs/en/04_Changelogs/4.7.0.md
@@ -5,6 +5,7 @@
 - [Experimental support for PHP 8](#experimental-support-for-php-8)
 - [Support for Symfony 4 Components](#support-for-symfony-4-components)
 - [Default MySQL collation updated](#default-mysql-collation-updated)
+- [Flysystem dependency shifted](#flysystem-dependency-shifted)
 
 ## New features
 
@@ -57,3 +58,17 @@ exceeding the maximum indexable size:
 You can rectify this by upgrading MySQL, enabling the `innodb_large_prefix` setting if present, or
 reducing the size of affected fields. If none of these solutions are currently suitable, you can
 remove the new collation configuration to default back to the previous default collation.
+
+### Flysystem dependency shifted
+
+Previously the Flysystem package was pulled in via the `silverstripe/framework` module, but only
+used in the `silverstripe/assets` module. To make this dependency clearer, it has been added to
+the `silverstripe/assets` module and removed from `silverstripe/framework`. Most developers should
+not notice any issues, but if you depend on Flysystem in your own project code, you should ensure
+that you have it specified in your `composer.json`.
+
+An edgecase exists where a project can update to `silverstripe/framework 4.7.0` but remain on
+`silverstripe/assets 1.6.x`, and lose the Flysystem dependency entirely. The best way to avoid this
+is by ensuring you update all core modules to the new minor release at once, ideally through a core
+recipe like `silverstripe/recipe-core`.
+

--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\View\Shortcodes;
 
 use Embed\Http\DispatcherInterface;
-use League\Flysystem\Exception;
 use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
 use SilverStripe\Core\Convert;


### PR DESCRIPTION
A bug in Flysystem was breaking the prefer-lowest build of silverstripe/assets, which led us to discover that the package isn't even used in framework. I've introduced a direct dependency on it in https://github.com/silverstripe/silverstripe-assets/pull/424.
