### PR TITLE
YamlReader should throw a meaningful exception message

### DIFF
--- a/src/i18n/Messages/YamlReader.php
+++ b/src/i18n/Messages/YamlReader.php
@@ -39,7 +39,7 @@ class YamlReader implements Reader
             // Normalise messages
             return $this->normaliseMessages($yaml[$locale]);
         } catch (ParseException $exception) {
-            throw new InvalidResourceException(sprintf('Error parsing YAML, invalid file "%s"', $path), 0, $exception);
+            throw new InvalidResourceException(sprintf('Error parsing YAML, invalid file "%s". Message: %s', $path, $exception->getMessage()), 0, $exception);
         }
     }
 

--- a/tests/php/i18n/YamlReaderTest.php
+++ b/tests/php/i18n/YamlReaderTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\i18n\Tests;
 
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\i18n\Messages\YamlReader;
+use Symfony\Component\Translation\Exception\InvalidResourceException;
 
 class YamlReaderTest extends SapphireTest
 {
@@ -37,5 +38,16 @@ class YamlReaderTest extends SapphireTest
             ],
         ];
         $this->assertEquals($expected, $output);
+    }
+
+
+    public function testThrowsMeaningfulExceptionWhenYmlIsCorrupted()
+    {
+        $path = __DIR__ . '/i18nTest/_fakewebroot/i18ntestmodule/lang/en_corrupt.yml';
+        $this->expectException(InvalidResourceException::class);
+        $regex_path = str_replace('.', '\.', $path);
+        $this->expectExceptionMessageRegExp('@^Error parsing YAML, invalid file "' . $regex_path . '"\. Message: ([\w ].*) line 5 @');
+        $reader = new YamlReader();
+        $reader->read('en', $path);
     }
 }

--- a/tests/php/i18n/i18nTest/_fakewebroot/i18ntestmodule/lang/en_corrupt.yml
+++ b/tests/php/i18n/i18nTest/_fakewebroot/i18ntestmodule/lang/en_corrupt.yml
@@ -1,0 +1,5 @@
+en:
+  NONAMESPACE: Include Entity without Namespace
+  Invalid: Foo
+    About: 'About us'
+    - Invalid # this should throw "A colon cannot be used in an unquoted mapping value at line 5"


### PR DESCRIPTION
when an parsing error occurs.

fixes #9690

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
