### PR TITLE
FIX TinyMCEConfig image size presets handle incorrect values

### DIFF
--- a/_config/html.yml
+++ b/_config/html.yml
@@ -16,7 +16,7 @@ SilverStripe\Core\Injector\Injector:
 
 SilverStripe\Forms\HTMLEditor\TinyMCEConfig:
   image_size_presets:
-    - width: 600,
+    - width: 600
       i18n: SilverStripe\Forms\HTMLEditor\TinyMCEConfig.BEST_FIT
       text: Best fit
       name: bestfit

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -694,6 +694,10 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
         }
 
         foreach ($settings['image_size_presets'] as &$preset) {
+            if (isset($preset['width'])) {
+                $preset['width'] = (int) $preset['width'];
+            }
+
             if (isset($preset['i18n'])) {
                 $preset['text'] = _t(
                     $preset['i18n'],


### PR DESCRIPTION
Currently the config passes incorrect (string) values to the frontend "as is", which breaks the image size preset buttons in the editor.

Related - https://github.com/silverstripe/silverstripe-asset-admin/pull/1143
Related - https://github.com/silverstripe/silverstripe-asset-admin/pull/1144

This issue fixes the Behat tests of `asset-admin`: https://travis-ci.org/github/silverstripe/silverstripe-asset-admin/builds/729491726