### PR TITLE
FIX Restrict incompatible version of symfony/translation-contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
     "bin": [
         "sake"
     ],
+    "conflict": {
+        "symfony/translation-contracts": ">=2.0"
+    },
     "require": {
         "bramus/monolog-colored-line-formatter": "~2.0",
         "composer/installers": "~1.0",


### PR DESCRIPTION
Fix for this issue https://github.com/symfony/symfony/issues/38537
