### PR TITLE
MNT Expand Composer requirements to support PHP 8, Update Behat config to support Symfony 4

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -9,7 +9,7 @@ default:
   suites:
     framework:
       paths:
-        - %paths.modules.admin%/tests/behat/features
+        - '%paths.modules.admin%/tests/behat/features'
       contexts:
         - SilverStripe\Framework\Tests\Behaviour\FeatureContext
         - SilverStripe\Framework\Tests\Behaviour\CmsFormsContext
@@ -19,7 +19,7 @@ default:
         - SilverStripe\BehatExtension\Context\LoginContext
         -
           SilverStripe\BehatExtension\Context\FixtureContext:
-            - %paths.modules.admin%/tests/behat/features/files/
+            - '%paths.modules.admin%/tests/behat/features/files/'
 
   extensions:
     SilverStripe\BehatExtension\MinkExtension:
@@ -30,5 +30,5 @@ default:
         wd_host: "http://127.0.0.1:9515" #chromedriver port
 
     SilverStripe\BehatExtension\Extension:
-      screenshot_path: %paths.base%/artifacts/screenshots
+      screenshot_path: '%paths.base%/artifacts/screenshots'
       bootstrap_file: "tests/behat/serve-bootstrap.php"

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "symfony/config": "^3.2 || ^4",
         "symfony/translation": "^2.8 || ^3 || ^4",
         "symfony/yaml": "^3.2 || ^4",
-        "php": ">=7.1.0",
+        "php": "^7.1 || ^8",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-hash": "*",


### PR DESCRIPTION
PHP 8 support has been merged here and throughout the rest of core (barring the recipes themselves), so we're ready to flag this module as compatible with it. This PR also includes a tweak to Behat config to support `symfony/yaml ^4`.