### PR TITLE
ENH Add disabled attribute to SelectionGroup

### DIFF
--- a/src/Forms/SelectionGroup.php
+++ b/src/Forms/SelectionGroup.php
@@ -101,6 +101,7 @@ class SelectionGroup extends CompositeField
                         'name' => $this->name,
                         'value' => $item->getValue(),
                         'checked' => $checked,
+                        'disabled' => $item->isDisabled()
                     ]
                 )),
                 "RadioLabel" => $item->getTitle(),


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-cms/issues/2396

Unblocks https://github.com/silverstripe/silverstripe-cms/pull/2604

If `$item->isDisabled()` is false, then the attribute won't render on the frontend
