### PR TITLE
Remove useless requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "monolog/monolog": "~1.16",
         "nikic/php-parser": "^3 || ^4",
         "psr/container": "1.0.0",
-        "psr/container-implementation": "1.0.0",
         "silverstripe/config": "^1@dev",
         "silverstripe/assets": "^1@dev",
         "silverstripe/vendor-plugin": "^1.4",


### PR DESCRIPTION
It does not make sense to require a psr-container-implementation when the package is itself providing an implementation, as it fulfills its own requirement.

Refs https://github.com/composer/composer/issues/9316
