### PR TITLE
NEW: Expose TreeDropdownField root node ID in schema

### DIFF
--- a/src/Forms/TreeDropdownField.php
+++ b/src/Forms/TreeDropdownField.php
@@ -901,6 +901,7 @@ class TreeDropdownField extends FormField
         $data['data'] = array_merge($data['data'], [
             'urlTree' => $this->Link('tree'),
             'showSearch' => $this->getShowSearch(),
+            'treeBaseId' => $this->getTreeBaseID(),
             'emptyString' => $this->getEmptyString(),
             'hasEmptyDefault' => $this->getHasEmptyDefault(),
             'multiple' => false,

--- a/tests/php/Forms/TreeDropdownFieldTest.php
+++ b/tests/php/Forms/TreeDropdownFieldTest.php
@@ -8,6 +8,8 @@ use SilverStripe\Control\Session;
 use SilverStripe\Dev\CSSContentParser;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\ORM\Tests\HierarchyTest\TestObject;
 
@@ -244,6 +246,35 @@ class TreeDropdownFieldTest extends SapphireTest
         $this->assertContains(
             '<input type="hidden" name="TestTree" value="' . $fileMock->ID . '" />',
             $result
+        );
+    }
+
+    public function testTreeBaseID()
+    {
+        $treeBaseID = $this->idFromFixture(Folder::class, 'folder1');
+        $field = new TreeDropdownField('TestTree', 'Test tree', Folder::class);
+
+        // getSchemaDataDefaults needs the field to be attach to a form
+        new Form(
+            null,
+            'mock',
+            new FieldList($field)
+        );
+
+        $this->assertEmpty($field->getTreeBaseID(), 'TreeBaseId does not have an initial value');
+
+        $field->setTreeBaseID($treeBaseID);
+        $this->assertEquals(
+            $treeBaseID,
+            $field->getTreeBaseID(),
+            'Value passed to setTreeBaseID is returned by getTreeBaseID'
+        );
+
+        $schema = $field->getSchemaDataDefaults();
+        $this->assertEquals(
+            $treeBaseID,
+            $schema['data']['treeBaseId'],
+            'TreeBaseId is included in the default schema data'
         );
     }
 }


### PR DESCRIPTION
Forms part of a fix for silverstripe/silverstripe-admin#954

Merge with https://github.com/silverstripe/silverstripe-admin/pull/1144