### PR TITLE
Scalar fixes

### DIFF
--- a/src/Control/Controller.php
+++ b/src/Control/Controller.php
@@ -230,7 +230,9 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      */
     protected function prepareResponse($response)
     {
-        if ($response instanceof HTTPResponse) {
+        if (!is_object($response)) {
+            $this->getResponse()->setBody($response);
+        } elseif ($response instanceof HTTPResponse) {
             if (isset($_REQUEST['debug_request'])) {
                 $class = static::class;
                 Debug::message(

--- a/src/Core/ClassInfo.php
+++ b/src/Core/ClassInfo.php
@@ -400,7 +400,7 @@ class ClassInfo
      */
     public static function hasMethod($object, $method)
     {
-        if (empty($object)) {
+        if (empty($object) || (!is_object($object) && !is_string($object))) {
             return false;
         }
         if (method_exists($object, $method)) {

--- a/tests/php/Core/ClassInfoTest.php
+++ b/tests/php/Core/ClassInfoTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Core\Tests;
 
+use DateTime;
 use ReflectionException;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Tests\ClassInfoTest\BaseClass;
@@ -15,6 +16,7 @@ use SilverStripe\Core\Tests\ClassInfoTest\ExtensionTest1;
 use SilverStripe\Core\Tests\ClassInfoTest\ExtensionTest2;
 use SilverStripe\Core\Tests\ClassInfoTest\GrandChildClass;
 use SilverStripe\Core\Tests\ClassInfoTest\HasFields;
+use SilverStripe\Core\Tests\ClassInfoTest\HasMethod;
 use SilverStripe\Core\Tests\ClassInfoTest\NoFields;
 use SilverStripe\Core\Tests\ClassInfoTest\WithCustomTable;
 use SilverStripe\Core\Tests\ClassInfoTest\WithRelation;
@@ -266,9 +268,57 @@ class ClassInfoTest extends SapphireTest
         );
     }
 
-    /**
-     * @dataProvider provideClassSpecCases
-     */
+    /** @dataProvider provideHasMethodCases */
+    public function testHasMethod($object, $method, $output)
+    {
+        $this->assertEquals(
+            $output,
+            ClassInfo::hasMethod($object, $method)
+        );
+    }
+
+    public function provideHasMethodCases()
+    {
+        return [
+            'Basic object' => [
+                new DateTime(),
+                'format',
+                true,
+            ],
+            'CustomMethod object' => [
+                new HasMethod(),
+                'example',
+                true,
+            ],
+            'Class Name' => [
+                'DateTime',
+                'format',
+                true,
+            ],
+            'FQCN' => [
+                '\DateTime',
+                'format',
+                true,
+            ],
+            'Invalid FQCN' => [
+                '--GreatTime',
+                'format',
+                false,
+            ],
+            'Integer' => [
+                1,
+                'format',
+                false,
+            ],
+            'Array' => [
+                ['\DateTime'],
+                'format',
+                false,
+            ],
+        ];
+    }
+
+    /** @dataProvider provideClassSpecCases */
     public function testParseClassSpec($input, $output)
     {
         $this->assertEquals(

--- a/tests/php/Core/ClassInfoTest/HasMethod.php
+++ b/tests/php/Core/ClassInfoTest/HasMethod.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\Core\Tests\ClassInfoTest;
+
+use SilverStripe\Core\CustomMethods;
+use SilverStripe\Dev\TestOnly;
+
+/**
+ * Example of class with hasMethod() implementation
+ */
+class HasMethod implements TestOnly
+{
+    use CustomMethods;
+
+    public function example()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
PHP 8 limits `method_exists()` to accepting strings and objects, which was in particular impacting the `/Security/ping` endpoint (which returns an integer.)

I've included two changes:

- A minor improvement to `Controller::prepareResponse()` that handles scalar values directly, rather than passing them through checks only relevant to objects
- A fix to `ClassInfo::hasMethod()` that will enforce a `false` outcome if the provided value isn't a valid argument for `method_exists()`. I initially considered putting the same blanket `is_scalar()` check in place here, but that changes the behaviour when passing in FQCNs, which may be relied upon (despite the docblock clearly calling for an object.)