### PR TITLE
ENH - Ping function returns an HTTPResponse instead of an int

### DIFF
--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -499,7 +499,7 @@ class Security extends Controller implements TemplateGlobalProvider
     {
         HTTPCacheControlMiddleware::singleton()->disableCache();
         Requirements::clear();
-        return 1;
+        return HTTPResponse::create()->setBody('1');
     }
 
     /**


### PR DESCRIPTION
Discussion https://github.com/silverstripe/silverstripe-framework/pull/9744#issuecomment-715626767

`ping` is an `$allowed_actions` in `class Security extends Controller`

The ping function has no strict types including docblocks, so in theory it's OK to change the return type from `int` to `HTTPResponse`.

**Existing function:**
![image](https://user-images.githubusercontent.com/4809037/97093639-32f37700-16aa-11eb-96db-781a4687bc91.png)

Since it's an endpoint it should probably have returned an `HTTPResponse` to begin with

