### PR TITLE
BUG Fix utf8 non-latin characters generating invalid encoding 

### DIFF
--- a/src/ORM/FieldType/DBHTMLText.php
+++ b/src/ORM/FieldType/DBHTMLText.php
@@ -228,7 +228,7 @@ class DBHTMLText extends DBText
         $text = strip_tags($text);
 
         // Implode >3 consecutive linebreaks into 2
-        $text = preg_replace('~(\R){2,}~', "\n\n", $text);
+        $text = preg_replace('~(\R){2,}~u', "\n\n", $text);
 
         // Decode HTML entities back to plain text
         return trim(Convert::xml2raw($text));

--- a/tests/php/ORM/DBHTMLTextTest.php
+++ b/tests/php/ORM/DBHTMLTextTest.php
@@ -265,7 +265,12 @@ class DBHTMLTextTest extends SapphireTest
             [
                 '<p>Collapses</p><p></p><p>Excessive<br/><br /><br>Newlines</p>',
                 "Collapses\n\nExcessive\n\nNewlines",
-            ]
+            ],
+            // non-latin characters
+            [
+                '<p>新西兰，奥特亚罗瓦&mdash;<br /><br /><br />&mdash;创新思维之乡</p>',
+                "新西兰，奥特亚罗瓦—\n\n—创新思维之乡"
+            ],
         ];
     }
 


### PR DESCRIPTION
Related to https://github.com/silverstripe/silverstripe-graphql/issues/318

I have tracked a text encoding issue where DBHTMLText::Plain() was mangling encoding of utf-8 non-latin text.

I have added a unit test, but I couldn't quite replicate the bug in the test without dumping the entire content area of my client's website (which, for confidentiality cases, obviously I can't push to github).

This fix replicates the same UTF-8 treatment in Convert::nl2os, which also adds this flag.

Without this fix, elemental module crashes the CMS when dealing with asian characters. I would put this at a high severity. :)