### PR TITLE
Warn on database misconfiguration in test runs

### DIFF
--- a/src/Core/CoreKernel.php
+++ b/src/Core/CoreKernel.php
@@ -270,7 +270,7 @@ class CoreKernel implements Kernel
         $databaseConfig = DB::getConfig();
         // Gracefully fail if no DB is configured
         if (empty($databaseConfig['database'])) {
-            $msg = 'SilverStripe Framework requires a "database" key in DB::getConfig(). ' .
+            $msg = 'Silverstripe Framework requires a "database" key in DB::getConfig(). ' .
                 'Did you forget to set SS_DATABASE_NAME or SS_DATABASE_CHOOSE_NAME in your environment?';
             $this->detectLegacyEnvironment();
             $this->redirectToInstaller($msg);

--- a/src/Core/CoreKernel.php
+++ b/src/Core/CoreKernel.php
@@ -270,8 +270,10 @@ class CoreKernel implements Kernel
         $databaseConfig = DB::getConfig();
         // Gracefully fail if no DB is configured
         if (empty($databaseConfig['database'])) {
+            $msg = 'SilverStripe Framework requires a "database" key in DB::getConfig(). ' .
+                'Did you forget to set SS_DATABASE_NAME or SS_DATABASE_CHOOSE_NAME in your environment?';
             $this->detectLegacyEnvironment();
-            $this->redirectToInstaller();
+            $this->redirectToInstaller($msg);
         }
     }
 
@@ -311,14 +313,17 @@ class CoreKernel implements Kernel
     }
 
     /**
-     * If missing configuration, redirect to install.php
+     * If missing configuration, redirect to install.php if it exists.
+     * Otherwise show a server error to the user.
+     *
+     * @param string $msg Optional message to show to the user on an installed project (install.php missing).
      */
-    protected function redirectToInstaller()
+    protected function redirectToInstaller($msg = '')
     {
         // Error if installer not available
         if (!file_exists(Director::publicFolder() . '/install.php')) {
             throw new HTTPResponse_Exception(
-                'SilverStripe Framework requires database configuration defined via .env',
+                $msg,
                 500
             );
         }

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -1023,7 +1023,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
             $flush = array_key_exists('flush', $request->getVars());
 
             // Custom application
-            $app->execute($request, function (HTTPRequest $request) {
+            $res = $app->execute($request, function (HTTPRequest $request) {
                 // Start session and execute
                 $request->getSession()->init($request);
 
@@ -1037,6 +1037,10 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
                 $controller->pushCurrent();
                 $controller->doInit();
             }, $flush);
+
+            if ($res && $res->isError()) {
+                throw new LogicException($res->getBody());
+            }
         } else {
             // Allow flush from the command line in the absence of HTTPApplication's special sauce
             $flush = false;


### PR DESCRIPTION
Fixes the weirdest bug I've seen in a while:
`vendor/bin/phpunit` fails with "no current controller" locally, but works in Travis:

```
No current controller available
/Users/ingo/Sites/4.x-dev/vendor/silverstripe/framework/src/Control/Controller.php:558
/Users/ingo/Sites/4.x-dev/vendor/silverstripe/framework/src/Security/MemberAuthenticator/SessionAuthenticationHandler.php:74
/Users/ingo/Sites/4.x-dev/vendor/silverstripe/framework/src/Security/RequestAuthenticationHandler.php:63
/Users/ingo/Sites/4.x-dev/vendor/silverstripe/framework/src/Dev/SapphireTest.php:1167
/Users/ingo/Sites/4.x-dev/vendor/silverstripe/framework/src/Dev/SapphireTest.php:1151
/Users/ingo/Sites/4.x-dev/vendor/silverstripe/versioned/tests/php/ChangeSetItemTest.php:18
/Users/ingo/Sites/4.x-dev/vendor/sminnee/phpunit/phpunit:52
```

Root cause: 

1. `$app->execute()` in `SapphireTest` swallows server errors
2. The error it swallows is "SilverStripe Framework requires database configuration defined via .env". Which is also incorrect - it does have an `.env`, but hasn’t detected a `database` value
3. This is due to configuring `.env`, but not setting `SS_DATABASE_CHOOSE_NAME`

Aaaaand this doesn’t happen on Travis because there it doesn’t have a .env, so `bootstrap/environment.php` auto-sets `SS_DATABASE_CHOOSE_NAME`. You could argue that this logic is a bit flawed around this, or that neither `SS_DATABASE_NAME` nor `SS_DATABASE_CHOOSE_NAME` should be needed for unit test exec (which creates its own database). But most importantly, *you should not swallow errors*, which this PR fixes.