### PR TITLE
FIX Update behat toast logic so it works with quotes

### DIFF
--- a/tests/behat/src/CmsUiContext.php
+++ b/tests/behat/src/CmsUiContext.php
@@ -85,7 +85,7 @@ class CmsUiContext implements Context
     }
 
     /**
-     * @Then /^I should see a "([^"]+)" (\w+) toast$/
+     * @Then /^I should see a "(.+)" (\w+) toast$/
      */
     public function iShouldSeeAToast($notice, $type)
     {
@@ -93,7 +93,7 @@ class CmsUiContext implements Context
     }
 
     /**
-     * @Then /^I should see a "([^"]+)" (\w+) toast with these actions: (.+)$/
+     * @Then /^I should see a "(.+)" (\w+) toast with these actions: (.+)$/
      */
     public function iShouldSeeAToastWithAction($notice, $type, $actions)
     {
@@ -110,7 +110,7 @@ class CmsUiContext implements Context
 
     /**
      * @param $action
-     * @When /^I click the "([^"]*)" toast action$/
+     * @When /^I click the "(.*)" toast action$/
      */
     public function stepIClickTheToastAction($action)
     {


### PR DESCRIPTION
Toast notification will often contain double quotes. This PR update our logic for testing toast notification in behat so it allows messages with double quotes.

* blocks https://github.com/silverstripe/silverstripe-campaign-admin/pull/177
* blocked by 4.7 release