### PR TITLE
Docs/SearchContext: $this->class is null

### DIFF
--- a/docs/en/02_Developer_Guides/12_Search/01_Searchcontext.md
+++ b/docs/en/02_Developer_Guides/12_Search/01_Searchcontext.md
@@ -69,7 +69,7 @@ class MyDataObject extends DataObject
         ];
 
         return new SearchContext(
-            $this->class, 
+            static::class, 
             $fields, 
             $filters
         );


### PR DESCRIPTION
it works for me with `static::class` instead; this is also used by `DataObject::getDefaultSearchContext()`.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
