### PR TITLE
DOCS: Fixing links in translation documentation page

### DIFF
--- a/docs/en/05_Contributing/08_Translation_Process.md
+++ b/docs/en/05_Contributing/08_Translation_Process.md
@@ -18,10 +18,10 @@ task. See [i18n](../developer_guides/i18n#collecting-text) for more details.
 
 ### Import master files
 
-If you don't have an account on transifex.com yet, [create a free account now](http://www.transifex.com/signup). After 
+If you don't have an account on transifex.com yet, [create a free account now](https://www.transifex.com/signup/). After 
 creating a new project, you have to upload the `en.yml` master file as a new "Resource". While you can do this through 
 the web interface, there's a convenient 
-[commandline client](http://support.transifex.com/customer/portal/topics/440187-transifex-client/articles) for this 
+[commandline client](https://docs.transifex.com/client/introduction) for this 
 purpose. In order to use it, set up a new `.tx/config` file in your module folder:
 
 ```yaml
@@ -42,12 +42,12 @@ sign up, and they can create languages and translations as required.
 ### Import existing translations
 
 In case you have existing translations in YML format, there's a "New language" option in the web interface. 
-Alternatively, use the [commandline client](http://support.transifex.com/customer/portal/topics/440187-transifex-client/articles).
+Alternatively, use the [commandline client](https://docs.transifex.com/client/introduction).
 
 ### Export existing translations
 
 You can download new translations in YML format through the web interface, but that can get quite tedious for more than 
-a handful of translations. Again, the [commandline client](http://support.transifex.com/customer/portal/topics/440187-transifex-client/articles)
+a handful of translations. Again, the [commandline client](https://docs.transifex.com/client/introduction)
 provides a more convenient interface here with the `tx pull` command, downloading all translations as a batch.
 
 ### Merge back existing translations
@@ -67,9 +67,9 @@ The conversion from PHP format to YML is taken care of by a module called
 
 ## Download Translations from Transifex.com
 
-We are managing our translations through a tool called [transifex.com](http://transifex.com). Most modules are handled 
+We are managing our translations through a tool called [transifex.com](https://www.transifex.com). Most modules are handled 
 under the "silverstripe" user, see 
-[list of translatable modules](https://www.transifex.com/accounts/profile/silverstripe/).
+[list of translatable modules](https://www.transifex.com/user/profile/silverstripe/).
 
 Translations need to be reviewed before being committed, which is a process that happens roughly once per month. We're 
 merging back translations into all supported release branches as well as the `master` branch. The following script 
@@ -124,7 +124,7 @@ type = KEYVALUEJSON
 
 Then you can upload the source files via a normal `tx push`. Once translations come in, you need to convert the source 
 files back into the JS files SilverStripe can actually read. This requires an installation of our 
-[buildtools](https://github.com/silverstripe/silverstripe-buildtools).
+[buildtools](https://github.com/silverstripe-archive/silverstripe-buildtools).
 
 ```
 tx pull
@@ -138,4 +138,4 @@ git commit -m "Updated javascript translations"
  * [i18n](/developer_guides/i18n/): Developer-level documentation of Silverstripe's i18n capabilities
  * [Contributing Translations](/contributing/translations): Information for translators looking to contribute translations of the SilverStripe UI.
  * [translatable](https://github.com/silverstripe/silverstripe-translatable): DataObject-interface powering the website-content translations
- * `["Translatable ModelAdmin" module](http://silverstripe.org/translatablemodeladmin-module/)`: An extension which allows translations of DataObjects inside ModelAdmin
+ * ["Translatable ModelAdmin" module](https://github.com/silverstripe-archive/silverstripe-translatablemodeladmin): An extension which allows translations of DataObjects inside ModelAdmin


### PR DESCRIPTION
Best effort in fixing outdated links that are either pointing to old/invalid domains and also ensuring each are using `https://` (since all linked sites support it), particularly the sign up page.

