### PR TITLE
FIX: Fix invalid yaml string

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -7,7 +7,7 @@ en:
     EDITINFO: 'Edit this file'
     REMOVE: Remove
   SilverStripe\Control\ChangePasswordEmail_ss:
-    CHANGEPASSWORDFOREMAIL: 'The password for account with email address {email} has been changed. If you didn\''t change your password please change your password using the link below'
+    CHANGEPASSWORDFOREMAIL: "The password for account with email address {email} has been changed. If you didn't change your password please change your password using the link below"
     CHANGEPASSWORDTEXT1: 'You changed your password for'
     CHANGEPASSWORDTEXT3: 'Change password'
     HELLO: Hi


### PR DESCRIPTION
Necessary to work with the latest version of symfony/yaml:4 (4.4.17)