### PR TITLE
Fix DataQuery::exists() not working correctly

### DIFF
--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -485,7 +485,7 @@ class DataQuery
         $result = reset($row);
 
         // Checking for 't' supports PostgreSQL before silverstripe/postgresql@2.2
-        return $result === true || $result === 1 || $result === 't';
+        return $result === true || $result === 1 || $result === '1' || $result === 't';
     }
 
     /**


### PR DESCRIPTION
Fixes `DataQuery::exists()` not working correctly in some cases as discussed in #9809