### PR TITLE
FIX DBComposite getIndexSpecs method

### DIFF
--- a/src/ORM/FieldType/DBComposite.php
+++ b/src/ORM/FieldType/DBComposite.php
@@ -331,7 +331,7 @@ abstract class DBComposite extends DBField
         if ($type = $this->getIndexType()) {
             $columns = array_map(function ($name) {
                 return $this->getName() . $name;
-            }, array_keys((array) static::config()->get('composite_db')));
+            }, array_keys((array) $this->compositeDatabaseFields()));
 
             return [
                 'type' => $type,


### PR DESCRIPTION
`getIndexSpecs` implementation should rely on the class own public API to define the list of the composite db fields.
Currently overriding `compositeDatabaseFields` in children won't affect the index spec