### PR TITLE
FIX Type checking in objectForKey() to fix postgres bug

### DIFF
--- a/src/Forms/TreeDropdownField.php
+++ b/src/Forms/TreeDropdownField.php
@@ -812,10 +812,13 @@ class TreeDropdownField extends FormField
      * Get the object where the $keyField is equal to a certain value
      *
      * @param string|int $key
-     * @return DataObject
+     * @return DataObject|null
      */
     protected function objectForKey($key)
     {
+        if (!is_string($key) && !is_int($key)) {
+            return null;
+        }
         return DataObject::get($this->getSourceObject())
             ->filter($this->getKeyField(), $key)
             ->first();

--- a/src/Forms/TreeMultiselectField.php
+++ b/src/Forms/TreeMultiselectField.php
@@ -149,11 +149,15 @@ class TreeMultiselectField extends TreeDropdownField
 
         // Parse ids from value string / array
         $ids = [];
+
         if (is_string($value)) {
             $ids = preg_split("#\s*,\s*#", trim($value));
         } elseif (is_array($value)) {
             $ids = array_values($value);
         }
+
+        // Filter out empty strings
+        $ids = array_filter($ids);
 
         // No value
         if (empty($ids)) {

--- a/tests/php/Forms/TreeDropdownFieldTest.php
+++ b/tests/php/Forms/TreeDropdownFieldTest.php
@@ -8,7 +8,10 @@ use SilverStripe\Control\Session;
 use SilverStripe\Dev\CSSContentParser;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
 use SilverStripe\Forms\TreeDropdownField;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Tests\HierarchyTest\TestObject;
 
 class TreeDropdownFieldTest extends SapphireTest
@@ -245,5 +248,22 @@ class TreeDropdownFieldTest extends SapphireTest
             '<input type="hidden" name="TestTree" value="' . $fileMock->ID . '" />',
             $result
         );
+    }
+
+    /**
+     * This is to test setting $key to an Object in the protected function objectForKey()
+     * This is to fix an issue where postgres will not fail gracefully when you do this
+     */
+    public function testObjectForKeyObjectValue()
+    {
+        $form = Form::create();
+        $fieldList = FieldList::create();
+        $field = TreeDropdownField::create('TestTree', 'Test tree', File::class);
+        $fieldList->add($field);
+        $form->setFields($fieldList);
+        $field->setValue(DataObject::create());
+        // The following previously errored in postgres
+        $field->getSchemaStateDefaults();
+        $this->assertTrue(true);
     }
 }

--- a/tests/php/Forms/TreeMultiselectFieldTest.php
+++ b/tests/php/Forms/TreeMultiselectFieldTest.php
@@ -340,5 +340,12 @@ class TreeMultiselectFieldTest extends SapphireTest
             [],
             $field->getItems()
         );
+
+        // Andle empty string none value
+        $field->setValue('');
+        $this->assertListEquals(
+            [],
+            $field->getItems()
+        );
     }
 }


### PR DESCRIPTION
FIxes https://github.com/silverstripe/silverstripe-framework/issues/9802

Doing an inline check rather than modifying the function signature for semver

In the case referenced in the original issue, a ManyManyList is being passed into this function, which mysql can somehow handle gracefully but postgres cannot

I think returning null if it fails the typecheck is fine because DataList->first() will also return null so anything that calls this needs to be able to handle a null return value