### PR TITLE
DOCS Adjust 4.7.0 collation docs to describe opt-in issue

### DIFF
--- a/docs/en/04_Changelogs/4.7.0.md
+++ b/docs/en/04_Changelogs/4.7.0.md
@@ -86,9 +86,14 @@ If you'd rather retain the previous YAML parser for the time being, you can run
 
 ### Default MySQL collation updated
 
-New projects based on `silverstripe/installer` will default to the `utf8mb4_unicode_ci` collation.
-This change will not affect existing projects, but developers are encouraged to adopt this collation
-as it provides better support for multi-byte characters such as emojis.
+New projects based on Recipe 4.7.0 will default to using the `utf8mb4_unicode_ci` collation. This
+collation provides better support for multi-byte characters such as emojis, and developers are
+encouraged to adopt this collation across all projects where possible.
+
+When upgrading to Recipe 4.7.0, this configuration change will also incorrectly apply to existing
+projects. _This is unintended_, and in Recipe 4.7.1 and later the change will be opt-in. If you
+wish to opt out of the new collation during an upgrade to Recipe 4.7.0, remove the
+`app/_config/database.yml` configuration file that is added during the Composer update process.
 
 Depending on the version of MySQL you are running, you may encounter issues with `Varchar` fields
 exceeding the maximum indexable size:


### PR DESCRIPTION
Documents an issue where a default MySQL collation adjustment, originally intended as an opt-in change for existing projects, shipped as an opt-out change in Recipe 4.7.0. This will become opt-in when Recipe 4.7.1 ships (see https://github.com/silverstripe/recipe-core/pull/64.)

Related: https://github.com/silverstripe/silverstripe-framework/issues/9811