### PR TITLE
IMPR: Allow to customize autocomplete attribute

### DIFF
--- a/src/Forms/PasswordField.php
+++ b/src/Forms/PasswordField.php
@@ -84,8 +84,8 @@ class PasswordField extends TextField
         }
 
         return array_merge(
-            parent::getAttributes(),
-            $attributes
+            $attributes,
+            parent::getAttributes()
         );
     }
 


### PR DESCRIPTION
Accordingly to https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
I'd like to set autocompleate="current-password"

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
