### PR TITLE
MNT Switch to get() style config notation

### DIFF
--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -298,7 +298,7 @@ class DatabaseAdmin extends Controller
             }
         }
 
-        $showRecordCounts = (boolean)$this->config()->show_record_counts;
+        $showRecordCounts = (boolean)$this->config()->get('show_record_counts');
 
         // Initiate schema update
         $dbSchema = DB::get_schema();

--- a/src/ORM/FieldType/DBComposite.php
+++ b/src/ORM/FieldType/DBComposite.php
@@ -115,7 +115,7 @@ abstract class DBComposite extends DBField
      */
     public function compositeDatabaseFields()
     {
-        return $this->config()->composite_db;
+        return $this->config()->get('composite_db');
     }
 
 

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -606,7 +606,7 @@ class Member extends DataObject
             );
             $lifetime = (86400 * $lifetime); // Method argument is days, convert to seconds
         } else {
-            $lifetime = $this->config()->auto_login_token_lifetime;
+            $lifetime = $this->config()->get('auto_login_token_lifetime');
         }
 
         do {

--- a/src/Security/Member_Validator.php
+++ b/src/Security/Member_Validator.php
@@ -55,7 +55,7 @@ class Member_Validator extends RequiredFields
         $required = array_merge($required, $this->customRequired);
 
         // check for config API values and merge them in
-        $config = $this->config()->customRequired;
+        $config = $this->config()->get('customRequired');
         if (is_array($config)) {
             $required = array_merge($required, $config);
         }

--- a/src/View/Parsers/URLSegmentFilter.php
+++ b/src/View/Parsers/URLSegmentFilter.php
@@ -158,6 +158,7 @@ class URLSegmentFilter implements FilterInterface
      */
     public function getAllowMultibyte()
     {
-        return ($this->allowMultibyte !== null) ? $this->allowMultibyte : $this->config()->default_allow_multibyte;
+        return ($this->allowMultibyte !== null) ? $this->allowMultibyte
+            : $this->config()->get('default_allow_multibyte');
     }
 }


### PR DESCRIPTION
Refactor magic_method notation to the far more standard get() notation for retrieving config values

I recently spent several minutes confused when I first saw this notation while merging a pull-request.  I ended up debugging to confirm that the magic_method does in fact work

To avoid future confusion I think it's far better just refactor it to the far more standard way of retrieving values

I found all the instances of this by doing "find in files" in phpstorm and searching on the regex

`\$this->config\(\)->[A-Za-z0-9\_]+;`