### PR TITLE
avoid CMS coupling

### DIFF
--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -579,8 +579,13 @@ class Security extends Controller implements TemplateGlobalProvider
         $holderPage->URLSegment = 'Security';
         // Disable ID-based caching  of the log-in page by making it a random number
         $holderPage->ID = -1 * random_int(1, 10000000);
+        
+        if ($holderPage instanceof Controller) {
+            $controller = $holderPage;
+        } else {
+            $controller = ModelAsController::controller_for($holderPage);
+        }
 
-        $controller = ModelAsController::controller_for($holderPage);
         $controller->setRequest($this->getRequest());
         $controller->doInit();
 


### PR DESCRIPTION
In the current setup, we cannot use a custom security controller without the cms module. This changes allow setting another controller as "page_class".
