### PR TITLE
FIX Mitigate continue; warning when run on PHP 7.3+ (fixes #9826)

### DIFF
--- a/parsers/HTML/HTMLBBCodeParser.php
+++ b/parsers/HTML/HTMLBBCodeParser.php
@@ -502,7 +502,8 @@ class SSHTMLBBCodeParser
 				{
 					if (trim($tag['text']) == '') {
 						//just an empty indentation or newline without value?
-						continue;
+						//skip this iteration of the foreach loop
+						continue 2;
 					}
 					$newTagArray[] = $child;
 					$openTags[] = $child['tag'];


### PR DESCRIPTION
PHP 7.3+ issues a warning when continue; is used inside a switch statement, as it has the same behaviour as break; HTMLBBCodeParser.php had such a continue; statement that is intended to skip to the the next record of the foreach that the switch sits inside. continue 2; needs to be used here.

**Steps to duplicate issue:**

1. Install Silverstripe 3.7.5 on server running PHP 5.6 with display_errors=on
2. Load website, observe no warning
3. Switch server to PHP 7.3 (or 7.4)
4. Load website, observe warning **Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"** on every page load.

**Reason**

Line 505 of /framework/parsers/HTML/HTMLBBCodeParser.php has a continue; statement inside a switch block. In turn this switch block is within a foreach block. The line is intended to skip to the next item in the foreach block, but PHP 7.3+ is warning that it will be acting as break; for the switch block.

**Search for other instances**

I looked at 179 occurrences of continue; inside /framework. None were nested inside switch statements. There were two other files where they were inside foreach blocks, which were in turn inside switch blocks. But these shouldn't be an issue since the parent block for the continue statements are foreach, not switch. Would appreciate if someone could confirm my thinking there.

https://github.com/muppsy007/silverstripe-framework/blob/3.7/model/Versioned.php
https://github.com/muppsy007/silverstripe-framework/blob/3.7/thirdparty/Zend/Locale/Data.php

Please see https://github.com/silverstripe/silverstripe-framework/issues/9826 for more discussion from kinglozzer and sminnee.