### PR TITLE
Smarter search for gridfield Proof-of-Concept

### DIFF
--- a/src/ORM/Filters/SummaryPartialMatchFilter.php
+++ b/src/ORM/Filters/SummaryPartialMatchFilter.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace SilverStripe\ORM\Filters;
+
+use SilverStripe\ORM\DataQuery;
+use SilverStripe\ORM\DB;
+use InvalidArgumentException;
+use SilverStripe\ORM\Queries\SQLConditionGroup;
+
+/**
+ * Matches textual content with a LIKE '%keyword%' construct.
+ */
+class SummaryPartialMatchFilter extends SearchFilter
+{
+    private $fieldlist = [];
+
+
+    public function __construct($fullName = null, $value = false, array $modifiers = [], array $fieldlist=[])
+    {
+        parent::__construct($fullName, $value, $modifiers);
+        $this->fieldlist = $fieldlist;
+    }
+
+    public function getSupportedModifiers()
+    {
+        return ['not', 'nocase', 'case'];
+    }
+
+    /**
+     * Apply the match filter to the given variable value
+     *
+     * @param string $value The raw value
+     * @return string
+     */
+    protected function getMatchPattern($value)
+    {
+        return "%$value%";
+    }
+
+    /**
+     * Apply filter criteria to a SQL query.
+     *
+     * @param DataQuery $query
+     * @return DataQuery
+     */
+    public function apply(DataQuery $query)
+    {
+        if ($this->aggregate) {
+            throw new InvalidArgumentException(sprintf(
+                'Aggregate functions can only be used with comparison filters. See %s',
+                $this->fullName
+            ));
+        }
+
+        return parent::apply($query);
+    }
+
+    protected function applyOne(DataQuery $query)
+    {
+        $this->model = $query->applyRelation($this->relation);
+
+        $fields = ['CEO', 'Name', 'Category'];
+        $value = $this->getValue();
+        $value = trim(preg_replace('!\s+!', ' ', $value));
+        $terms = explode(" ", $value);
+
+        foreach ($terms as $term) {
+            $clause = [];
+            foreach ($this->fieldlist as $field) {
+                $comparisonClause = DB::get_conn()->comparisonClause(
+                    $field,
+                    null,
+                    false, // exact?
+                    false, // negate?
+                    $this->getCaseSensitive(),
+                    true
+                );
+                $clause[$comparisonClause] = $this->getMatchPattern($term);
+            }
+            $query->whereAny($clause);
+        }
+
+        return $query;
+    }
+
+    protected function applyMany(DataQuery $query)
+    {
+        $this->model = $query->applyRelation($this->relation);
+        $whereClause = [];
+        $comparisonClause = DB::get_conn()->comparisonClause(
+            $this->getDbName(),
+            null,
+            false, // exact?
+            false, // negate?
+            $this->getCaseSensitive(),
+            true
+        );
+        foreach ($this->getValue() as $value) {
+            $whereClause[] = [$comparisonClause => $this->getMatchPattern($value)];
+        }
+        return $query->whereAny($whereClause);
+    }
+
+    protected function excludeOne(DataQuery $query)
+    {
+        $this->model = $query->applyRelation($this->relation);
+        $comparisonClause = DB::get_conn()->comparisonClause(
+            $this->getDbName(),
+            null,
+            false, // exact?
+            true, // negate?
+            $this->getCaseSensitive(),
+            true
+        );
+        return $query->where([
+            $comparisonClause => $this->getMatchPattern($this->getValue())
+        ]);
+    }
+
+    protected function excludeMany(DataQuery $query)
+    {
+        $this->model = $query->applyRelation($this->relation);
+        $values = $this->getValue();
+        $comparisonClause = DB::get_conn()->comparisonClause(
+            $this->getDbName(),
+            null,
+            false, // exact?
+            true, // negate?
+            $this->getCaseSensitive(),
+            true
+        );
+        $parameters = [];
+        foreach ($values as $value) {
+            $parameters[] = $this->getMatchPattern($value);
+        }
+        // Since query connective is ambiguous, use AND explicitly here
+        $count = count($values);
+        $predicate = implode(' AND ', array_fill(0, $count, $comparisonClause));
+        return $query->where([$predicate => $parameters]);
+    }
+
+    public function isEmpty()
+    {
+        return $this->getValue() === [] || $this->getValue() === null || $this->getValue() === '';
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-framework/issues/9356

This is a proof-of-concept to improve the default search set up for GridField.

NOT READY FOR PEER REVIEW.

The current Gridfield primary search has the default shortcomings:
- It only search against the first search field ... usually Name or Title.
- It requires the search term to appear as-is in the field. e.g. "Royal Shell Dutch" will not match "Royal Dutch Shell"
- The primary search is an alias for the matching advanced search filter field ... if you enter a search term and then open the "advanced filter" menu, you see your search term there, which is super confusing from a UX's perspective.
- It doesn't provide an obvious way to customise the primary search field.

This Proof-of-Concept improves on this by
- By splitting up the search expression into individual words and searching for each word across all searchable summary fields.
- By not mapping to a visible field in the "advanced filter" menu.

This works mostly out of the box and could reasonably be shipped in 4.8 without requiring DEV to change anything.

This video illustrates the problem and then switch to this PR to illustrate how it works: https://www.youtube.com/watch?v=Z6SuDeMCrdI