### PR TITLE
DOC fix urls in readme to be version independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and [installation from source](https://doc.silverstripe.org/framework/en/install
 ## Bugtracker ##
 
 Bugs are tracked on [github.com](https://github.com/silverstripe/silverstripe-framework/issues). 
-Please read our [issue reporting guidelines](https://docs.silverstripe.org/en/4/contributing/issues_and_bugs/).
+Please read our [issue reporting guidelines](https://docs.silverstripe.org/en/contributing/issues_and_bugs/).
 
 ## Development and Contribution ##
 
@@ -28,8 +28,8 @@ If you would like to make changes to the SilverStripe core codebase, we have an 
 
 ## Links ##
 
- * [Server Requirements](https://docs.silverstripe.org/en/4/getting_started/server_requirements/)
- * [Changelogs](https://docs.silverstripe.org/en/4/changelogs/)
+ * [Server Requirements](https://docs.silverstripe.org/en/getting_started/server_requirements/)
+ * [Changelogs](https://docs.silverstripe.org/en/changelogs/)
  * [Bugtracker: Framework](https://github.com/silverstripe/silverstripe-framework/issues)
  * [Bugtracker: CMS](https://github.com/silverstripe/silverstripe-cms/issues)
  * [Bugtracker: Installer](https://github.com/silverstripe/silverstripe-installer/issues)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you would like to make changes to the SilverStripe core codebase, we have an 
 
 ## Links ##
 
- * [Server Requirements](https://doc.silverstripe.org/framework/en/installation/server-requirements)
+ * [Server Requirements](https://docs.silverstripe.org/en/4/getting_started/server_requirements/)
  * [Changelogs](https://docs.silverstripe.org/en/4/changelogs/)
  * [Bugtracker: Framework](https://github.com/silverstripe/silverstripe-framework/issues)
  * [Bugtracker: CMS](https://github.com/silverstripe/silverstripe-cms/issues)


### PR DESCRIPTION
The existing url goes to a 404 in the documentation, I assume the structure of docs has changed since it was added.
