### PR TITLE
FEAT: Add support for samesite attribute to session cookies

### DIFF
--- a/src/Control/Cookie.php
+++ b/src/Control/Cookie.php
@@ -42,7 +42,7 @@ class Cookie
      * @param bool $secure
      * @param bool $httpOnly
      *
-     * See http://php.net/set_session
+     * See http://php.net/setcookie
      */
     public static function set(
         $name,
@@ -51,9 +51,10 @@ class Cookie
         $path = null,
         $domain = null,
         $secure = false,
-        $httpOnly = true
+        $httpOnly = true,
+        $sameSite = null
     ) {
-        return self::get_inst()->set($name, $value, $expiry, $path, $domain, $secure, $httpOnly);
+        return self::get_inst()->set($name, $value, $expiry, $path, $domain, $secure, $httpOnly, $sameSite);
     }
 
     /**

--- a/src/Control/Cookie_Backend.php
+++ b/src/Control/Cookie_Backend.php
@@ -29,8 +29,19 @@ interface Cookie_Backend
      * @param string $domain The domain to make the cookie available on
      * @param boolean $secure Can the cookie only be sent over SSL?
      * @param boolean $httpOnly Prevent the cookie being accessible by JS
+     * @param string|null $sameSite One of 'None', 'Lax', 'Strict' or null to not pass a SameSite attribute. Note that
+     *                              this only works in PHP 7.3 or higher, and will be ignored in any earlier version.
      */
-    public function set($name, $value, $expiry = 90, $path = null, $domain = null, $secure = false, $httpOnly = true);
+    public function set(
+        $name,
+        $value,
+        $expiry = 90,
+        $path = null,
+        $domain = null,
+        $secure = false,
+        $httpOnly = true,
+        $sameSite = null
+    );
 
     /**
      * Get the cookie value by name

--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -329,10 +329,27 @@ class Session
 
                 session_start();
 
+                $sameSite = null;
+                $sessionParams = session_get_cookie_params();
+
+                // If samesite param is set, then we can pass it into the Cookie::set call below as we are on >= PHP 7.3
+                if (isset($sessionParams['samesite'])) {
+                    $sameSite = $sessionParams['samesite'];
+                }
+
                 // Session start emits a cookie, but only if there's no existing session. If there is a session timeout
                 // tied to this request, make sure the session is held for the entire timeout by refreshing the cookie age.
                 if ($timeout && $this->requestContainsSessionId($request)) {
-                    Cookie::set(session_name(), session_id(), $timeout / 86400, $path, $domain ?: null, $secure, true);
+                    Cookie::set(
+                        session_name(),
+                        session_id(),
+                        $timeout / 86400,
+                        $path,
+                        $domain ?: null,
+                        $secure,
+                        true,
+                        $sameSite
+                    );
                 }
             } else {
                 // If headers are sent then we can't have a session_cache_limiter otherwise we'll get a warning


### PR DESCRIPTION
Relates to #9440.

# Expected behaviour
Silverstripe CMS should support the new [SameSite cookie attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#SameSite) for all cookies, as well as session cookies.

# Observed behaviour
Silverstripe CMS doesn't properly support this attribute. There are two issues:

1. The `Cookie::set()` logic doesn't have support for the SameSite attribute.
2. Even if the above is fixed, Silverstripe CMS has some logic that sets the session cookie on every HTTP request, which means that until this fix is in place, you can set the samesite attribute via `ini_set()` but it only works for the very first `Set-Cookie` header - from then on the framework sets the cookie without the flag.

I **think** this fix is backwards compatible. It allows the attribute to be set, but only on PHP 7.3+ because it can't be set on older versions of PHP than that (without manually setting HTTP headers).

This doesn't take on any of the complexity that #9548 discussed, just the simplest possible thing to ensure that the samesite attribute is consistently set on session cookies.