### PR TITLE
Bug Fix - Ensure DataQuery::exists() SQL is both valid MySQL and T-SQL

### DIFF
--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -479,7 +479,7 @@ class DataQuery
         }
 
         // Wrap the whole thing in an "EXISTS"
-        $sql = 'SELECT EXISTS(' . $statement->sql($params) . ')';
+        $sql = 'SELECT CASE WHEN EXISTS(' . $statement->sql($params) . ') THEN 1 ELSE 0 END';
         $result = DB::prepared_query($sql, $params);
         $row = $result->first();
         $result = reset($row);


### PR DESCRIPTION
The original SQL statement for checking at the DB level if a DataQuery result set has any rows (implemented in #8915) is not valid T-SQL for use with SQL Server.

This pull request aims to tweak that SQL so that it is valid MySQL **and** T-SQL. 

Note that I am not familiar with any other supported DB backends such as SQLite or PostgreSQL so someone with knowledge of these should review this change for compatibility with those please

I have made a more detailed reference to the errors this fixes in #9809  
