### PR TITLE
DOC: fix missing closing backtick for code display, add required alt attribute

### DIFF
--- a/docs/en/02_Developer_Guides/01_Templates/02_Common_Variables.md
+++ b/docs/en/02_Developer_Guides/01_Templates/02_Common_Variables.md
@@ -41,7 +41,7 @@ functionality may not be included.
 ```
 
 The `<% base_tag %>` placeholder is replaced with the HTML base element. Relative links within a document (such as `<img
-src="someimage.jpg" />) will become relative to the URI specified in the base tag. This ensures the browser knows where
+src="someimage.jpg" alt="">`) will become relative to the URI specified in the base tag. This ensures the browser knows where
 to locate your site’s images and css files.
 
 It renders in the template as `<base href="http://www.yoursite.com" /><!--[if lte IE 6]></base><![endif]-->`


### PR DESCRIPTION
Otherwise the code is output as html, and displays as a missing image. 

The alt attribute is required for image tags so should also be included. Self closing is no longer required in modern html.