### PR TITLE
DOC: fix broken heading

### DIFF
--- a/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
+++ b/docs/en/02_Developer_Guides/00_Model/10_Versioning.md
@@ -114,7 +114,7 @@ It is possible for an item to be included both implicitly and explicitly in a ch
 
 This section explains how to take a regular DataObject and add versioning to it.
 
-### Applying the `Versioned` extension to your DataObject
+### Applying the Versioned extension to your DataObject
 
 ```php
 <?php


### PR DESCRIPTION
It appears there may be a bug in gatsby which causes code blocks in headings to not be output. I can't find a specific issue in their project to link this to, so it might be best to simply remove the code block here allowing the header to display correctly.