### PR TITLE
DOCS changelog incorrectly includes security commit and references

### DIFF
--- a/docs/en/04_Changelogs/4.5.3.md
+++ b/docs/en/04_Changelogs/4.5.3.md
@@ -5,7 +5,6 @@
 This release contains security patches. Some of those patches might require some updates to your project.
 
 * [CVE-2020-9309 Script execution on protected files](https://www.silverstripe.org/download/security-releases/CVE-2020-9309)
-* [CVE-2019-19326 Web Cache Poisoning](https://www.silverstripe.org/download/security-releases/CVE-2019-19326)
 * [CVE-2020-6164 Information disclosure on /interactive URL path](https://www.silverstripe.org/download/security-releases/CVE-2020-6164)
 * [CVE-2020-6165 Limited queries break CanViewPermissionChecker](https://www.silverstripe.org/download/security-releases/CVE-2020-6165)
 
@@ -57,15 +56,6 @@ The `silverstripe/userforms` module now also includes `silverstripe/mimevalidato
 * 5.6.0 or later (requires CMS 4.6.0)
 
 Userforms that include a file upload field will automatically use the`MimeUploadValidator`. Beware that this will NOT change the default upload validator for other file upload fields in the CMS. You'll need to update your YML configuration for the `MimeUploadValidator` to be used everywhere.
-
-### CVE-2019-19326 Web Cache Poisoning {#CVE-2019-19326}
-
-Silverstripe sites using HTTP cache headers and HTTP caching proxies (e.g. CDNs) can be susceptible to web cache poisoning through the:
-* `X-Original-Url` HTTP header
-* `X-HTTP-Method-Override` HTTP header
-* `_method` POST variable.
-
-In order to remedy this vulnerability, Silverstripe Framework 4.5.3 removes native support for these features. While this is technically a semantic versioning breakage, these features are inherently insecure and date back to a time when browsers didn't natively support the full range of HTTP methods. Sites who still require these features will have highly unusual requirements that are best served by a tailored solution.
 
 ### Re-enabling the support for removed features
 
@@ -129,7 +119,6 @@ for more information on updating your GraphQL queries.
 ### Security
 
  * 2020-05-13 [cce2b1630](https://github.com/silverstripe/silverstripe-framework/commit/cce2b1630937895aa28c2914837651e7cd56d74b) Remove/deprecate unused controllers that can potentially give away some information about the underlying project. (Maxime Rainville) - See [cve-2020-6164](https://www.silverstripe.org/download/security-releases/cve-2020-6164)
- * 2020-05-11 [8518987cb](https://github.com/silverstripe/silverstripe-framework/commit/8518987cbd1eaca71b65dd4a4b35591db941509a) Stop honouring X-HTTP-Method-Override header, X-Original-Url header and _method POST variable. Add SS_HTTPRequest::setHttpMethod() (Maxime Rainville) - See [cve-2019-19326](https://www.silverstripe.org/download/security-releases/cve-2019-19326)
  * 2020-02-17 [d3968ad](https://github.com/silverstripe/silverstripe-asset-admin/commit/d3968adcbdb759cb20571865af3b6356c8922cde) Move the query resolution after the DataListQuery has been altered (Maxime Rainville) - See [cve-2020-6165](https://www.silverstripe.org/download/security-releases/cve-2020-6165)
  * 2020-02-11 [107e6c9](https://github.com/silverstripe/silverstripe-graphql/commit/107e6c918bb6a6a536dd9e3d8f5c74b4acdfd852) Ensure canView() check is run on items (Steve Boyd) - See [cve-2020-6165](https://www.silverstripe.org/download/security-releases/cve-2020-6165)
 


### PR DESCRIPTION
Changelog https://docs.silverstripe.org/en/4/changelogs/4.5.3/ claims CVE-2019-19326 has been fixed in that version, but in fact it was fixed only in 4.5.4, evidenced in:
* the "Version fixed" line in https://www.silverstripe.org/download/security-releases/CVE-2019-19326,
* by viewing the commit in tags directly: https://github.com/silverstripe/silverstripe-framework/commit/8518987cbd1eaca71b65dd4a4b35591db941509a

Note a content change is also needed on silverstripe.org to fix the reference to the 4.5.3 changelog here: https://www.silverstripe.org/download/security-releases/CVE-2019-19326 (which I'll take care of as well)