### PR TITLE
DOC: fix code block not closed

### DIFF
--- a/docs/en/02_Developer_Guides/14_Files/07_File_Usage.md
+++ b/docs/en/02_Developer_Guides/14_Files/07_File_Usage.md
@@ -74,6 +74,7 @@ class UsedOnTableExtension extends Extension
         $ancestorDataObjects[] = $grandParentIWantToLink;
     }
 }
+```
 
 ### Example YML file:
 


### PR DESCRIPTION
This fixes an un-closed code block in the file usage docs, causing two code blocks (php & yml) to be joined.