### PR TITLE
DOC: fix accidentally nested info box

### DIFF
--- a/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/03_building_the_schema.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/03_building_the_schema.md
@@ -35,11 +35,11 @@ The task that generates the schema code is `build-schema`. It takes a parameter 
 
 Keep in mind that many of your changes will be in YAML, which also requires a flush.
 
-`$ vendor/bin/sake dev/graphql/build schema=default flush=1
+`$ vendor/bin/sake dev/graphql/build schema=default flush=1`
 
 [info]
 If you do not provide a `schema` parameter, the task will build all schemas.
-[/info]`
+[/info]
 
 ### Building on dev/build
 


### PR DESCRIPTION
The code block was closed on the wrong side of the info box, causing it to not render correctly.