### PR TITLE
WIP: NEW Add loading attribute to images and iframes

### DIFF
--- a/_config/requestprocessors.yml
+++ b/_config/requestprocessors.yml
@@ -14,6 +14,7 @@ SilverStripe\Core\Injector\Injector:
         ChangeDetectionMiddleware: '%$SilverStripe\Control\Middleware\ChangeDetectionMiddleware'
         HTTPCacheControleMiddleware: '%$SilverStripe\Control\Middleware\HTTPCacheControlMiddleware'
         CanonicalURLMiddleware: '%$SilverStripe\Control\Middleware\CanonicalURLMiddleware'
+        HTMLModificationMiddleware: '%$SilverStripe\Control\Middleware\HTMLModificationMiddleware'
   SilverStripe\Control\Middleware\AllowedHostsMiddleware:
     properties:
       AllowedHosts: '`SS_ALLOWED_HOSTS`'

--- a/src/Control/Middleware/HTMLModificationMiddleware.php
+++ b/src/Control/Middleware/HTMLModificationMiddleware.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SilverStripe\Control\Middleware;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\Config\Configurable;
+
+/**
+ * Mofifies HTML that is about to be sent to the browser
+ */
+class HTMLModificationMiddleware implements HTTPMiddleware
+{
+    use Configurable;
+
+    /**
+     * @var string
+     */
+    private static $img_loading_attr = 'lazy';
+
+    /**
+     * @var string
+     */
+    private static $iframe_loading_attr = 'lazy';
+
+    /**
+     * Generate response for the given request
+     *
+     * @param HTTPRequest $request
+     * @param callable $delegate
+     * @return HTTPResponse
+     */
+    public function process(HTTPRequest $request, callable $delegate)
+    {
+        /** HTTPResponse $response */
+        $response = $delegate($request);
+
+        // Only modify output if the response status code is 200
+        if ($response->getStatusCode() !== 200) {
+            return $response;
+        }
+
+        $this->addLoadingAttribute($response);
+
+        return $response;
+    }
+
+    /**
+     * Add an HTML loading attribute to `<img>` and `<iframe>` elements where:
+     * - there isn't already an existing loading attribute on the element
+     * - src, width and height attributes are all present on the element
+     *
+     * Example output:
+     * `<img loading="lazy" src="/my/image.jpg" width="150" height="100">`
+     *
+     * @param HTTPResponse $response
+     */
+    private function addLoadingAttribute(HTTPResponse $response): void
+    {
+        $body = $response->getBody();
+        $requiredAttrs = ['src', 'width', 'height'];
+        foreach (['img', 'iframe'] as $tag) {
+            $loadingAttr = $this->config()->get($tag . '_loading_attr');
+            if (array_key_exists($loadingAttr, ['lazy' => 1, 'eager' => 1, 'auto' => 1])) {
+                preg_match_all("#<$tag([^>]+)>#", $body, $matches);
+                for ($i = 0; $i < count($matches[0]); $i++) {
+                    $element = $matches[0][$i];
+                    $attrs = $matches[1][$i];
+                    // Skip if there is an existing loading attribute
+                    if (strpos($attrs, ' loading=') !== false) {
+                        continue;
+                    }
+                    // Ensure relevant attributes are present
+                    foreach ($requiredAttrs as $attr) {
+                        if (strpos($attrs, " $attr=") === false) {
+                            continue 2;
+                        }
+                    }
+                    // Add loading attr
+                    $replacement = str_replace("<$tag ", "<$tag loading=\"$loadingAttr\" ", $element);
+                    $body = str_replace($element, $replacement, $body);
+                }
+            }
+        }
+        $response->setBody($body);
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/silverstripeltd/product-issues/issues/354

[Google blog post](https://web.dev/browser-level-lazy-loading-for-cmss/) on the subject matter

Don't merge

This is currently a POC and discussion to agree upon an implementation

**Note on code placement**

There's a few central places identified where this sort of "across the board" code could be applied:
~~1. Controller::handleAction() - Where I placed this code for the POC.  It's a central location called only once per request right shortly before the final $html is a added to the $request that's sent back.  Downside is that custom code may override handleAction() and not called parent::handleAction.  There's also an extension hook right below where I added that code that could also be used.~~
~~2. SSViewer::process() - seems like a more appropriate location, however it's called multiple times because it's used to create html nested fragments, so there's a possibility that it will be called over the same HTML multiple times, though I may be wrong in this assumption~~
3. Middleware - we could parse the HTML on its way out to the browser.  This is my recommendation.
4. ImageShortcodeProvider.php in the assets module - will only apply the loading attribute to `<img>` and not `<iframe>` and really only to images inserted via tinymce.  I don't recommend this.

**Note on use of regex and str_replace**

I've gone with regex and str_replace() for performance reasons.  str_replace() is such a basic operation that I don't think there's much risk of creating messed up HTML output.  I'd strongly prefer not to use an XML parser because a) it'll run on every single request and b) it'll return null if the HTML output isn't parsable e.g. developer has some broken HTML in their template.

**Setup**

1. Install with silverstripe/installer using the simple theme
2. Upload and add a bunch of images via TinyMCE and save page
3. Copy paste themes\simple\images\blockquote.png and name it blockquote2.png and blockquote3.png
4. Add the following to themes\simple\templates\Includes\Footer.ss:

```
<img src="/_resources/themes/simple/images/blockquote.png" width="18" height="14">
<img src="/_resources/themes/simple/images/blockquote2.png" width="18" height="14" loading="eager">
<img src="/_resources/themes/simple/images/blockquote3.png">
```

**Outcome**

Viewing page source, images will have the loading="lazy" attribute added
```
<img loading="lazy" src="/assets/native-bird__ResizedImageWzYwMCwzNjBd.jpg"
    alt="" width="600" height="360" class="leftAlone ss-htmleditorfield-file image">
```

The footer will render as follows, with only the first img getting the loading="lazy" attribute applied
```
<img loading="lazy" src="/_resources/themes/simple/images/blockquote.png" width="18" height="14">
<img src="/_resources/themes/simple/images/blockquote2.png" width="18" height="14" loading="eager">
<img src="/_resources/themes/simple/images/blockquote3.png">
```

