### PR TITLE
BUG Nomalise boolean ORM filter in to 1/0

### DIFF
--- a/src/ORM/FieldType/DBBoolean.php
+++ b/src/ORM/FieldType/DBBoolean.php
@@ -96,4 +96,8 @@ class DBBoolean extends DBField
         }
         return $value ? 1 : 0;
     }
+
+    public function RAW() {
+        return $this->prepValueForDB($this->getValue());
+    }
 }

--- a/src/ORM/Filters/ExactMatchFilter.php
+++ b/src/ORM/Filters/ExactMatchFilter.php
@@ -53,7 +53,7 @@ class ExactMatchFilter extends SearchFilter
     {
         $this->model = $query->applyRelation($this->relation);
         $field = $this->getDbName();
-        $value = $this->getValue();
+        $value = $this->getDbFormattedValue();
 
         // Null comparison check
         if ($value === null) {
@@ -77,7 +77,7 @@ class ExactMatchFilter extends SearchFilter
         }
 
         $clause = [$where => $value];
-        
+
         return $this->aggregate ?
             $this->applyAggregate($query, $clause) :
             $query->where($clause);

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -793,6 +793,20 @@ class DataListTest extends SapphireTest
         $this->assertEquals(0, $list->count());
     }
 
+    public function testFilterByBoolean() {
+        $list = Player::get();
+        $list = $list->filter(['IsRetired' => false]);
+        $this->assertEquals(3, $list->count(), 'Some records have IsRetired set to false');
+        $allFalse = $list->column('IsRetired');
+        $this->assertNotContains(true, $allFalse, 'Filter false should filter all true values');
+
+        $list = Player::get();
+        $list = $list->filter(['IsRetired' => true]);
+        $this->assertEquals(1, $list->count(), 'One records has IsRetired set to true');
+        $allTrue = $list->column('IsRetired');
+        $this->assertNotContains(false, $allTrue, 'Filter true should filter all false values');
+    }
+
     /**
      *  $list->filter(['Name'=>'bob, 'Age'=>21]); // bob with the age 21
      */


### PR DESCRIPTION
I honestly don't know if this is a good idea. The parent issue is probably not worth fixing on it's own, but it does highlight that we don't currently have a good way to normalise filter values to specific DBField/DB-Drivers.

# Parent issue
- Fixes https://github.com/silverstripe/silverstripe-postgresql/issues/124
