### PR TITLE
BUG Tweak shortcode parser so it properly parse empty attributes

### DIFF
--- a/src/View/Parsers/ShortcodeParser.php
+++ b/src/View/Parsers/ShortcodeParser.php
@@ -263,8 +263,8 @@ class ShortcodeParser
 		([^\s\/\'"=,]+)       # Name
 		\s* = \s*
 		(?:
-			(?:\'([^\']+)\') | # Value surrounded by \'
-			(?:"([^"]+)")    | # Value surrounded by "
+			(?:\'([^\']*)\') | # Value surrounded by \'
+			(?:"([^"]*)")    | # Value surrounded by "
 			([^\s,\]]+)          # Bare value
 		)
 ';

--- a/tests/php/View/Parsers/ShortcodeParserTest.php
+++ b/tests/php/View/Parsers/ShortcodeParserTest.php
@@ -79,37 +79,54 @@ class ShortcodeParserTest extends SapphireTest
         );
     }
 
-    public function testSimpleTag()
+    public function simpleTagDataProvider()
     {
-        $tests = [
-            '[test_shortcode]',
-            '[test_shortcode ]', '[test_shortcode,]', '[test_shortcode, ]' . '[test_shortcode/]', '[test_shortcode /]', '[test_shortcode,/]', '[test_shortcode, /]'
+        return [
+            ['[test_shortcode]'],
+            ['[test_shortcode ]'],
+            ['[test_shortcode,]'],
+            ['[test_shortcode, ][test_shortcode/]'],
+            ['[test_shortcode /]'],
+            ['[test_shortcode,/]'],
+            ['[test_shortcode, /]']
         ];
-
-        foreach ($tests as $test) {
-            $this->parser->parse($test);
-
-            $this->assertEquals([], $this->arguments, $test);
-            $this->assertEquals('', $this->contents, $test);
-            $this->assertEquals('test_shortcode', $this->tagName, $test);
-        }
     }
 
-    public function testOneArgument()
+    /**
+     * @dataProvider simpleTagDataProvider
+     */
+    public function testSimpleTag($test)
     {
-        $tests =  [
-            '[test_shortcode foo="bar"]', '[test_shortcode,foo="bar"]',
-            "[test_shortcode foo='bar']", "[test_shortcode,foo='bar']",
-            '[test_shortcode  foo  =  "bar"  /]', '[test_shortcode,  foo  =  "bar"  /]'
+        $this->parser->parse($test);
+        $this->assertEquals([], $this->arguments, $test);
+        $this->assertEquals('', $this->contents, $test);
+        $this->assertEquals('test_shortcode', $this->tagName, $test);
+    }
+
+    public function oneArgumentDataProvider()
+    {
+        return [
+            ['[test_shortcode foo="bar"]'],
+            ['[test_shortcode,foo="bar"]'],
+            ["[test_shortcode foo='bar']"],
+            ["[test_shortcode,foo='bar']"],
+            ["[test_shortcode foo=bar]"],
+            ["[test_shortcode,foo=bar]"],
+            ['[test_shortcode  foo  =  "bar"  /]'],
+            ['[test_shortcode,  foo  =  "bar"  /]']
         ];
+    }
 
-        foreach ($tests as $test) {
-            $this->parser->parse($test);
+    /**
+     * @dataProvider oneArgumentDataProvider
+     */
+    public function testOneArgument($test)
+    {
+        $this->parser->parse($test);
 
-            $this->assertEquals(['foo' => 'bar'], $this->arguments, $test);
-            $this->assertEquals('', $this->contents, $test);
-            $this->assertEquals('test_shortcode', $this->tagName, $test);
-        }
+        $this->assertEquals(['foo' => 'bar'], $this->arguments, $test);
+        $this->assertEquals('', $this->contents, $test);
+        $this->assertEquals('test_shortcode', $this->tagName, $test);
     }
 
     public function testMultipleArguments()
@@ -117,6 +134,26 @@ class ShortcodeParserTest extends SapphireTest
         $this->parser->parse('[test_shortcode foo = "bar",bar=\'foo\', baz="buz"]');
 
         $this->assertEquals(['foo' => 'bar', 'bar' => 'foo', 'baz' => 'buz'], $this->arguments);
+        $this->assertEquals('', $this->contents);
+        $this->assertEquals('test_shortcode', $this->tagName);
+    }
+
+    public function emptyArgumentsDataProvider()
+    {
+        return [
+            ['[test_shortcode foo=""]'],
+            ['[test_shortcode,foo=\'\']'],
+            ['[test_shortcode foo=""][/test_shortcode]'],
+        ];
+    }
+
+    /**
+     * @dataProvider emptyArgumentsDataProvider
+     */
+    public function testEmptyArguments($test)
+    {
+        $this->parser->parse($test);
+        $this->assertEquals(['foo' => ''], $this->arguments);
         $this->assertEquals('', $this->contents);
         $this->assertEquals('test_shortcode', $this->tagName);
     }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-assets/issues/435

Blocks https://github.com/silverstripe/silverstripe-assets/pull/436

Empty attributes are getting parsed as `""` or `''` instead of as a blank string. This fixes this problem
