### PR TITLE
prevent spaces in emails

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -872,7 +872,7 @@ class Member extends DataObject
     public function onBeforeWrite()
     {
         // Prevent spaces in emails
-        if($this->Email) {
+        if ($this->Email) {
             $this->Email = trim($this->Email);
         }
         

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -871,7 +871,7 @@ class Member extends DataObject
      */
     public function onBeforeWrite()
     {
-        // Prevent spaces in emails
+        // Remove any line-break or space characters accidentally added during a copy-paste operation
         if ($this->Email) {
             $this->Email = trim($this->Email);
         }

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -871,6 +871,11 @@ class Member extends DataObject
      */
     public function onBeforeWrite()
     {
+        // Prevent spaces in emails
+        if($this->Email) {
+            $this->Email = trim($this->Email);
+        }
+        
         // If a member with the same "unique identifier" already exists with a different ID, don't allow merging.
         // Note: This does not a full replacement for safeguards in the controller layer (e.g. in a registration form),
         // but rather a last line of defense against data inconsistencies.

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -1593,4 +1593,12 @@ class MemberTest extends FunctionalTest
 
         $this->assertSame('Johnson', $member->getLastName(), 'getLastName should proxy to Surname');
     }
+    
+    public function testEmailIsTrimmed()
+    {
+        $member = new Member();
+        $member->Email = " trimmed@test.com\r\n";
+        $member->write();
+        $this->assertNotNull(Member::get()->find('Email', 'trimmed@test.com'));
+    }
 }


### PR DESCRIPTION
so this is not the first time a customer of mine is just copy pasting stuff in emails fields and somehow, a space at the end skips validation. this update ensure there is no space before or after the email, it would probably save a lot of time for everyone to have this build in.
it's probably better to fix it here rather than at form level because this also happens for csv imports etc