### PR TITLE
Move hasEmptySchema and emptyString to DataSchema on SingleSelectField

### DIFF
--- a/src/Forms/SingleSelectField.php
+++ b/src/Forms/SingleSelectField.php
@@ -34,11 +34,18 @@ abstract class SingleSelectField extends SelectField
     {
         $data = parent::getSchemaStateDefaults();
 
+        $data['value'] = $this->getDefaultValue();
+
+        return $data;
+    }
+
+    public function getSchemaDataDefaults()
+    {
+        $data = parent::getSchemaDataDefaults();
+
         // Add options to 'data'
         $data['data']['hasEmptyDefault'] = $this->getHasEmptyDefault();
         $data['data']['emptyString'] = $this->getHasEmptyDefault() ? $this->getEmptyString() : null;
-
-        $data['value'] = $this->getDefaultValue();
 
         return $data;
     }


### PR DESCRIPTION
Schema settings were being set in the state, but not in the Schema itself. Moving the `hasEmptySchema` and `emptyString` schema settings to a SchemaData ensures they are created with the FormBuilder while state still tracks current value.

Fixes: #8691 
