### PR TITLE
Better handling of remember me token when login across devices is disabled

### DIFF
--- a/src/Security/RememberLoginHash.php
+++ b/src/Security/RememberLoginHash.php
@@ -189,8 +189,5 @@ class RememberLoginHash extends DataObject
                 'DeviceID' => $alcDevice
             ])->removeAll();
         }
-
-        // We've logged in without checking the "Remember me" checkbox and `logout_across_devices` is disable ...
-        // so we don't have any RememberLoginHash to clear
     }
 }

--- a/tests/php/Security/RememberLoginHashTest.php
+++ b/tests/php/Security/RememberLoginHashTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace SilverStripe\Security\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\RememberLoginHash;
+
+class RememberLoginHashTest extends SapphireTest
+{
+    protected static $fixture_file = 'RememberLoginHashTest.yml';
+
+    /** @var RememberLoginHash[]  */
+    private $loginHash = [];
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        /** @var Member $main */
+        $main = $this->objFromFixture(Member::class, 'main');
+
+        /** @var Member $secondary */
+        $secondary = $this->objFromFixture(Member::class, 'secondary');
+
+        $this->loginHash = [
+            'current' => RememberLoginHash::generate($main),
+            'other' => RememberLoginHash::generate($main),
+            'secondary' => RememberLoginHash::generate($secondary),
+        ];
+    }
+
+    public function clearScenarios()
+    {
+        return [
+            'logout across devices' => [true, 'current', ['secondary'], ['current', 'other']],
+            'logout across devices on non-persistent session' => [true, false, ['secondary'], ['current', 'other']],
+            'logout single device' => [false, 'current', ['secondary', 'other'], ['current']],
+            'logout single device on non-persistent session' => [false, false, ['secondary', 'current', 'other'], []],
+        ];
+    }
+
+    /**
+     * @param bool $logoutAcrossDevices
+     * @param string $deviceId
+     * @param array $expected
+     * @param array $unexpected
+     * @dataProvider clearScenarios
+     */
+    public function testClear(bool $logoutAcrossDevices, string $deviceId, array $expected, array $unexpected)
+    {
+        RememberLoginHash::config()->set('logout_across_devices', $logoutAcrossDevices);
+
+        RememberLoginHash::clear(
+            $this->objFromFixture(Member::class, 'main'),
+            $deviceId ? $this->loginHash[$deviceId]->DeviceID : null
+        );
+
+        foreach ($expected as $key) {
+            $ID = $this->loginHash[$key]->ID;
+            $this->assertNotEmpty(
+                RememberLoginHash::get()->byID($ID),
+                "$key $ID RememberLoginHash is found"
+            );
+        }
+
+        foreach ($unexpected as $key) {
+            $ID = $this->loginHash[$key]->ID;
+            $this->assertEmpty(
+                RememberLoginHash::get()->byID($ID),
+                "$key RememberLoginHash has been removed"
+            );
+        }
+    }
+}

--- a/tests/php/Security/RememberLoginHashTest.yml
+++ b/tests/php/Security/RememberLoginHashTest.yml
@@ -1,0 +1,7 @@
+'SilverStripe\Security\Member':
+  main:
+    FirstName: Main
+    Surname: Test Subject
+  secondary:
+    FirstName: Secondary
+    Surname: Test Subject


### PR DESCRIPTION
The specific bug addressed by this fix is that when you logged out from a non-persistent session (you did NOT check the remember checkbox) and `login across devices` is disabled, you will not the less invalidate all remember me token for this user.

# Parent issue
Fixes #9794