### PR TITLE
  FIX: pass correct column name parameter instead of numeric index

### DIFF
--- a/src/Forms/GridField/GridFieldExportButton.php
+++ b/src/Forms/GridField/GridFieldExportButton.php
@@ -236,7 +236,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
                         $value = $columnHeader($relObj);
                     } elseif ($gridFieldColumnsComponent && array_key_exists($columnSource, $columnsHandled)) {
                         $value = strip_tags(
-                            $gridFieldColumnsComponent->getColumnContent($gridField, $item, $columnSource)
+                            $gridFieldColumnsComponent->getColumnContent($gridField, $item, $columnsHandled[$columnSource])
                         );
                     } else {
                         $value = $gridField->getDataFieldValue($item, $columnSource);


### PR DESCRIPTION
<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
Fix issue described [here](https://github.com/silverstripe/silverstripe-framework/issues/9244#issuecomment-806723331)