### PR TITLE
MINOR: adding link to BuildTask

### DIFF
--- a/src/Dev/BuildTask.php
+++ b/src/Dev/BuildTask.php
@@ -6,6 +6,7 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Control\Director;
 
 /**
  * Interface for a generic build task. Does not support dependencies. This will simply
@@ -82,4 +83,16 @@ abstract class BuildTask
     {
         return $this->description;
     }
+    
+    /**
+     * @return string  e.g. /dev/tasks/MyTask-In-Full
+     */
+    public function Link() : string
+    {
+        $link = $this->Config()->get('segment');
+        if (! $link) {
+            $link = str_replace('\\', '-', static::class);
+        }
+        return Director::absoluteUrl('dev/tasks/') . $link;
+    }    
 }


### PR DESCRIPTION
This makes it easier to access dev/tasks from various places in, for example, the CMS.  

In further commits, this can also be used in other places so that there is one source of truth for the link for a BuildTask.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
