### PR TITLE
Fixes warning if session is not active

### DIFF
--- a/security/Security.php
+++ b/security/Security.php
@@ -726,7 +726,7 @@ class Security extends Controller implements TemplateGlobalProvider {
 				$curMember->logOut();
 			}
 
-			if (!headers_sent()) {
+			if (!headers_sent() && session_status() == PHP_SESSION_ACTIVE) {
 				// To avoid a potential session fixation attack
 				// we're refreshing the session id so that it's
 				// always new and random for every authentication


### PR DESCRIPTION
Backport this change to SS3 https://github.com/silverstripe/silverstripe-framework/issues/9496

Recently got the issue on a old project

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
