### PR TITLE
BUG fieldNameError() references invalid $this->form

### DIFF
--- a/src/Forms/FieldList.php
+++ b/src/Forms/FieldList.php
@@ -155,11 +155,11 @@ class FieldList extends ArrayList
      */
     protected function fieldNameError(FormField $field, $functionName)
     {
-        if ($this->form) {
+        if ($field->getForm()) {
             $errorSuffix = sprintf(
                 " in your '%s' form called '%s'",
-                get_class($this->form),
-                $this->form->getName()
+                get_class($field->getForm()),
+                $field->getForm()->getName()
             );
         } else {
             $errorSuffix = '';


### PR DESCRIPTION
FieldList references `$this->form` which doesn't exist from what I can see. I presume this should have been `$field->getForm()`.

However, please note that I came across this when looking for something unrelated and haven't tested this PR.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
