### PR TITLE
4.7 add samesite support

### DIFF
--- a/src/Control/Cookie.php
+++ b/src/Control/Cookie.php
@@ -121,7 +121,7 @@ class Cookie
     public static function get_valid_samesite_value(string $sameSite = null, bool $allowEmpty = true): string
     {
         $sameSite = trim($sameSite ?? '');
-        if ('' === $sameSite && $allowEmpty) {
+        if ('' === $sameSite) {
             return $allowEmpty ? '' : self::SAMESITE_DEFAULT;
         }
 

--- a/src/Control/Cookie.php
+++ b/src/Control/Cookie.php
@@ -5,6 +5,11 @@ namespace SilverStripe\Control;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injector;
 
+use function in_array;
+use function strtolower;
+use function trim;
+use function ucfirst;
+
 /**
  * A set of static methods for manipulating cookies.
  */
@@ -18,6 +23,17 @@ class Cookie
      * @var bool
      */
     private static $report_errors = true;
+
+    /**
+     * @config
+     * @var string One of 'Strict', 'Lax', 'None', ''
+     */
+    private static $samesite = '';
+
+    /*
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#lax
+     */
+    private const SAMESITE_DEFAULT = 'Lax';
 
     /**
      * Fetch the current instance of the cookie backend.
@@ -91,5 +107,29 @@ class Cookie
     public static function force_expiry($name, $path = null, $domain = null, $secure = false, $httpOnly = true)
     {
         return self::get_inst()->forceExpiry($name, $path, $domain, $secure, $httpOnly);
+    }
+
+    /**
+     * Get a valid SameSite atribute value
+     *
+     * @internal Not part of public api: for internal use only
+     *
+     * @param string|null $sameSite
+     * @param bool $allowEmpty Alow returning an empty string
+     * @return string
+     */
+    public static function get_valid_samesite_value(string $sameSite = null, bool $allowEmpty = true): string
+    {
+        $sameSite = trim($sameSite ?? '');
+        if ('' === $sameSite && $allowEmpty) {
+            return $allowEmpty ? '' : self::SAMESITE_DEFAULT;
+        }
+
+        $sameSite = ucfirst(strtolower($sameSite));
+        if (in_array($sameSite, ['Strict', 'Lax', 'None'], true)) {
+            return $sameSite;
+        }
+
+        return $allowEmpty ? '' : self::SAMESITE_DEFAULT;
     }
 }

--- a/src/Control/CookieJar.php
+++ b/src/Control/CookieJar.php
@@ -5,6 +5,8 @@ namespace SilverStripe\Control;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use LogicException;
 
+use const PHP_VERSION_ID;
+
 /**
  * A default backend for the setting and getting of cookies
  *
@@ -179,7 +181,7 @@ class CookieJar implements Cookie_Backend
                 $secure = true;
             }
 
-            if (PHP_VERSION_ID < 70300 || '' === $sameSite) {
+            if (PHP_VERSION_ID < 70300) {
                 if ('' !== $sameSite) {
                     $path = $path ?: '/'; // we must have a value for path to esploit the php bug for PHP<7.3
                     $path = "{$path}; SameSite={$sameSite}";

--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -329,7 +329,7 @@ class Session
                     $secure = true;
                 }
 
-                if (PHP_VERSION_ID < 70300 || '' === $sameSite) {
+                if (PHP_VERSION_ID < 70300) {
                     if ('' !== $sameSite) {
                         $path = "{$path}; SameSite={$sameSite}";
                     }


### PR DESCRIPTION
This PR aims to add backward compatible support for the SameSite cookie attribute in generic cookies and session cookies.
It is deactivated by default, to enable it use configuration:
```php
// e.g. src/app/_config.php
//...
use SilverStripe\Control\Cookie;
use SilverStripe\Control\Session;
//...

Cookie::config()->set('samesite', 'Lax'); // new configuration property for Cookie
Session::config()->set('cookie_samesite', 'Lax'); // new configuration property for Session
```
When enabled, the SameSite attribute is set either by injecting its value into the Path attribute (thanks to a php bug) for PHP<7.3 and using the new PHP7.3+ signatures for `setcookie` ad `session_set_cookie_params`  functions.

The core classes (`Cookie`, `Session`) method signatures have not been changed in order to avoid BC issues. The attribute value to add to cookies is only set via configuration.

An helper static method was added to the Cookie class to obtain a valid or empty or default SameSite value.

The `CookieJar::outputCookie()` argument `$expiry` was renamed to `$expires` as hinted in `setcookie`, in order to avoid confusion about its meaning. In `CookieJar::set()` `$expiry` means `days`, while in `CookieJar::outputCookie()` its used as the actual expiring date unix-timestamp. Thus the default value 90 here means 90 seconds after the UNIX-Epoch which would make the cookie expire. I changed to 0 (browser session). Being an internal method only called once this change should be safe in any case.

This is basically how I patched my 2.4 to 4.x silverstripe installations. We could also use `header` instead of `setcookie`, but the patch for session cookie params and php<7.3 would still require using the path attribute... 

Notes:
- need to add unit tests (once I'll have figured out why even the stable repo fails locally :-) )
- build succeded in my repo: https://travis-ci.com/github/pine3ree/silverstripe-framework/builds/223786017 


