### PR TITLE
BUG Update DataQuery::exists to return false when limit causes no result to be returned

### DIFF
--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -468,7 +468,6 @@ class DataQuery
         // Clear limit, distinct, and order as it's not relevant for an exists query
         $statement->setDistinct(false);
         $statement->setOrderBy(null);
-        $statement->setLimit(null);
 
         // We can remove grouping if there's no "having" that might be relying on an aggregate
         // Additionally, the columns being selected no longer matter

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -465,7 +465,7 @@ class DataQuery
         // statement anyway
         $statement = $this->getFinalisedQuery();
 
-        // Clear limit, distinct, and order as it's not relevant for an exists query
+        // Clear distinct, and order as it's not relevant for an exists query
         $statement->setDistinct(false);
         $statement->setOrderBy(null);
 

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -466,8 +466,51 @@ class DataQueryTest extends SapphireTest
 
     public function testExistsCreatesFunctionalQueries()
     {
-        $this->assertTrue(ObjectE::get()->exists());
-        $this->assertFalse(ObjectE::get()->where(['"Title" = ?' => 'Foo'])->exists());
-        $this->assertTrue(ObjectE::get()->dataQuery()->groupby('"SortOrder"')->exists());
+        $this->assertTrue(
+            ObjectE::get()->exists(),
+            'Query for ObjectE exists because there\'s more than 1 record'
+        );
+        $this->assertFalse(
+            ObjectE::get()->where(['"Title" = ?' => 'Foo'])->exists(),
+            'Query for ObjectE with Title Foo does NOT exists because there\'s no matching record'
+        );
+        $this->assertTrue(
+            ObjectE::get()->dataQuery()->groupby('"SortOrder"')->exists(),
+            'Existence of query for ObjectE is not affected by group by'
+        );
+        $this->assertTrue(
+            ObjectE::get()->limit(1)->exists(),
+            'Existence of query for ObjectE is not affected by limit if records are returned'
+        );
+        $this->assertFalse(
+            ObjectE::get()->limit(4, 9999)->exists(),
+            'Existence of query for ObjectE is affected by limit if no records are returned'
+        );
+
+        $query = new DataQuery(ObjectE::class);
+        $this->assertTrue(
+            $query->exists(),
+            'exist returns true if query return results'
+        );
+        $query = new DataQuery(ObjectE::class);
+        $this->assertFalse(
+            $query->where(['"Title" = ?' => 'Foo'])->exists(),
+            'exist returns false if there\'s no results'
+        );
+        $query = new DataQuery(ObjectE::class);
+        $this->assertTrue(
+            $query->groupby('"SortOrder"')->exists(),
+            'exist is unaffected by group by'
+        );
+        $query = new DataQuery(ObjectE::class);
+        $this->assertTrue(
+            $query->limit(1)->exists(),
+            'exist is unaffected by limit as long as one recard is returned'
+        );
+        $this->assertFalse(
+            $query->limit(1, 9999)->exists(),
+            'exist is false when a limit returns no results'
+        );
     }
+
 }

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -512,5 +512,4 @@ class DataQueryTest extends SapphireTest
             'exist is false when a limit returns no results'
         );
     }
-
 }


### PR DESCRIPTION
This was raised by @mfendeksilverstripe.

While upgrading from 4.5 to 4.7, he discovered that DataList who are constrained by a limit into retuning 0 results, would still be considered "truthy" when a `if` statement was applied to them in an SS template:
```
4.5
<% if $Results %> <-- DataList which yields 0 results is treated as false
4.7
<% if $Results %> <-- DataList which yields 0 results is treated as true
```

