### PR TITLE
Update 04_Shortcodes.md

### DIFF
--- a/docs/en/02_Developer_Guides/05_Extending/04_Shortcodes.md
+++ b/docs/en/02_Developer_Guides/05_Extending/04_Shortcodes.md
@@ -63,7 +63,7 @@ class Page extends SiteTree
         'MyShortCodeMethod' => 'HTMLText'
     ];
 
-    public static function MyShortCodeMethod($arguments, $content = null, $parser = null, $tagName) 
+    public static function MyShortCodeMethod($arguments, $content = null, $parser = null, $tagName = null) 
     {
         return "<em>" . $tagName . "</em> " . $content . "; " . count($arguments) . " arguments.";
     }


### PR DESCRIPTION
Not Fixing anything just editing a Guide Page haven't found where this is built since it is in extending.
Optional Parameters need to be at the end with no non optional Tags after them. No Problem with php 7 but php 8 will throw a Fatal if the a non optional paramter is after optional Parameters i.e. "$tagName"
If $tagName is not optional then a reorder is in.. order :D
