### PR TITLE
FIX Tidy extension and cli fix for tests

### DIFF
--- a/src/Dev/CSSContentParser.php
+++ b/src/Dev/CSSContentParser.php
@@ -38,7 +38,7 @@ class CSSContentParser
                 [
                     'output-xhtml' => true,
                     'numeric-entities' => true,
-                    'wrap' => 0, // We need this to be consistent for functional test string comparisons
+                    'wrap' => 99999, // We need this to be consistent for functional test string comparisons
                 ],
                 'utf8'
             );
@@ -48,7 +48,7 @@ class CSSContentParser
         } elseif (@shell_exec('which tidy')) {
             // using tiny through cli
             $CLI_content = escapeshellarg($content);
-            $tidy = `echo $CLI_content | tidy --force-output 1 -n -q -utf8 -asxhtml -w 0 2> /dev/null`;
+            $tidy = `echo $CLI_content | tidy --force-output 1 -n -q -utf8 -asxhtml -w 99999 2> /dev/null`;
             $tidy = str_replace('xmlns="http://www.w3.org/1999/xhtml"', '', $tidy);
             $tidy = str_replace('&#160;', '', $tidy);
         } else {


### PR DESCRIPTION
Wrap doesn't actually wrap in the tidy extension.
This causes tests to be flakey, for example some of `FormTest` fails
if you happen to have `ext-tidy` installed (which is the default on most systems).
This happened to me on PHP 7.4.19 with tidy 5.6.0 (OSX Homebrew).
Note that the tests aren't failing in Travis right now.

You'd expect `wrap => 0` to be honoured. It's documented as an integer
in the tidy docs: https://api.html-tidy.org/tidy/quickref_5.6.0.html#wrap.

Even tracked this down to the PHP source which appears to be doing the right thing:
https://github.com/php/php-src/blob/master/ext/tidy/tidy.c#L300

There's a bug from 2018 against PHP 7.2.8 which was closed as "not a bug" without comment:
https://bugs.php.net/bug.php?id=76683

You can see the behaviour in action in the following test.

```
<?php
$html = '<p>a really long string which should not be wrapped</p>';

echo "## With tidy extension" . PHP_EOL;
$tidy = new tidy();
$tidy->parseString(
    $html,
    [
        'output-xhtml' => true,
        'numeric-entities' => true,
        'wrap' => 0,
    ],
    'utf8'
);
$tidy->cleanRepair();
echo $tidy . PHP_EOL;

echo "## With tidy cli" . PHP_EOL;
$cmd = sprintf("echo " . escapeshellarg($html) . " | tidy --force-output 1 -n -q -utf8 -asxhtml -w 0 2> /dev/null");
echo shell_exec($cmd);
```

Long story short, setting it to 99999 fixes the issue.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
