### PR TITLE
BUG Manually create singleton when building table

### DIFF
--- a/src/ORM/Connect/TableBuilder.php
+++ b/src/ORM/Connect/TableBuilder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SilverStripe\ORM\Connect;
+
+use SilverStripe\Control\Director;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+
+class TableBuilder
+{
+    use Injectable;
+
+    public function buildTables(DBSchemaManager $dbSchema, array $dataClasses, array $extraDataObjects = [], bool $quiet = false, bool $testMode = false, bool $showRecordCounts = false)
+    {
+        $dbSchema->schemaUpdate(function () use ($dataClasses, $extraDataObjects, $testMode, $quiet, $showRecordCounts) {
+            $dataObjectSchema = DataObject::getSchema();
+
+            foreach ($dataClasses as $dataClass) {
+                // Check if class exists before trying to instantiate - this sidesteps any manifest weirdness
+                if (!class_exists($dataClass)) {
+                    continue;
+                }
+
+                // Check if this class should be excluded as per testing conventions
+                /** @var DataObject $SNG */
+                $SNG = new $dataClass([], DataObject::CREATE_SINGLETON);
+                if (!$testMode && $SNG instanceof TestOnly) {
+                    continue;
+                }
+
+                // Log data
+                if (!$quiet) {
+                    $tableName = $dataObjectSchema->tableName($dataClass);
+                    if ($showRecordCounts && DB::get_schema()->hasTable($tableName)) {
+                        try {
+                            $count = DB::query("SELECT COUNT(*) FROM \"$tableName\"")->value();
+                            $countSuffix = " ($count records)";
+                        } catch (\Exception $e) {
+                            $countSuffix = " (error getting record count)";
+                        }
+                    } else {
+                        $countSuffix = "";
+                    }
+
+                    if (Director::is_cli()) {
+                        echo " * $tableName$countSuffix\n";
+                    } else {
+                        echo "<li>$tableName$countSuffix</li>\n";
+                    }
+                }
+
+                // Instruct the class to apply its schema to the database
+                $SNG->requireTable();
+            }
+
+            // If we have additional dataobjects which need schema (i.e. for tests), do so here:
+            if ($extraDataObjects) {
+                foreach ($extraDataObjects as $dataClass) {
+                    $SNG = new $dataClass([], DataObject::CREATE_SINGLETON);
+                    if ($SNG instanceof DataObject) {
+                        $SNG->requireTable();
+                    }
+                }
+            }
+        });
+    }
+}

--- a/src/ORM/Connect/TempDatabase.php
+++ b/src/ORM/Connect/TempDatabase.php
@@ -244,29 +244,9 @@ class TempDatabase
 
         $schema = $this->getConn()->getSchemaManager();
         $schema->quiet();
-        $schema->schemaUpdate(
-            function () use ($dataClasses, $extraDataObjects) {
-                foreach ($dataClasses as $dataClass) {
-                    // Check if class exists before trying to instantiate - this sidesteps any manifest weirdness
-                    if (class_exists($dataClass ?? '')) {
-                        $SNG = singleton($dataClass);
-                        if (!($SNG instanceof TestOnly)) {
-                            $SNG->requireTable();
-                        }
-                    }
-                }
 
-                // If we have additional dataobjects which need schema, do so here:
-                if ($extraDataObjects) {
-                    foreach ($extraDataObjects as $dataClass) {
-                        $SNG = singleton($dataClass);
-                        if (singleton($dataClass) instanceof DataObject) {
-                            $SNG->requireTable();
-                        }
-                    }
-                }
-            }
-        );
+        $tableBuilder = TableBuilder::singleton();
+        $tableBuilder->buildTables($schema, $dataClasses, $extraDataObjects, true);
 
         Config::modify()->set(DBSchemaManager::class, 'check_and_repair_on_build', $oldCheckAndRepairOnBuild);
 

--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -14,6 +14,7 @@ use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\DevelopmentAdmin;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\Connect\DatabaseException;
+use SilverStripe\ORM\Connect\TableBuilder;
 use SilverStripe\ORM\FieldType\DBClassName;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
@@ -304,46 +305,8 @@ class DatabaseAdmin extends Controller
 
         // Initiate schema update
         $dbSchema = DB::get_schema();
-        $dbSchema->schemaUpdate(function () use ($dataClasses, $testMode, $quiet, $showRecordCounts) {
-            $dataObjectSchema = DataObject::getSchema();
-
-            foreach ($dataClasses as $dataClass) {
-                // Check if class exists before trying to instantiate - this sidesteps any manifest weirdness
-                if (!class_exists($dataClass ?? '')) {
-                    continue;
-                }
-
-                // Check if this class should be excluded as per testing conventions
-                $SNG = new $dataClass([], DataObject::CREATE_SINGLETON);
-                if (!$testMode && $SNG instanceof TestOnly) {
-                    continue;
-                }
-                $tableName = $dataObjectSchema->tableName($dataClass);
-
-                // Log data
-                if (!$quiet) {
-                    if ($showRecordCounts && DB::get_schema()->hasTable($tableName)) {
-                        try {
-                            $count = DB::query("SELECT COUNT(*) FROM \"$tableName\"")->value();
-                            $countSuffix = " ($count records)";
-                        } catch (Exception $e) {
-                            $countSuffix = " (error getting record count)";
-                        }
-                    } else {
-                        $countSuffix = "";
-                    }
-
-                    if (Director::is_cli()) {
-                        echo " * $tableName$countSuffix\n";
-                    } else {
-                        echo "<li>$tableName$countSuffix</li>\n";
-                    }
-                }
-
-                // Instruct the class to apply its schema to the database
-                $SNG->requireTable();
-            }
-        });
+        $tableBuilder = TableBuilder::singleton();
+        $tableBuilder->buildTables($dbSchema, $dataClasses, [], $quiet, $testMode, $showRecordCounts);
         ClassInfo::reset_db_cache();
 
         if (!$quiet && !Director::is_cli()) {

--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -314,7 +314,7 @@ class DatabaseAdmin extends Controller
                 }
 
                 // Check if this class should be excluded as per testing conventions
-                $SNG = singleton($dataClass);
+                $SNG = new $dataClass([], DataObject::CREATE_SINGLETON);
                 if (!$testMode && $SNG instanceof TestOnly) {
                     continue;
                 }

--- a/tests/php/ORM/DataObjectTest/InjectedDataObject.php
+++ b/tests/php/ORM/DataObjectTest/InjectedDataObject.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class InjectedDataObject extends OverriddenDataObject implements TestOnly
+{
+    private static $db = [
+        'NewField' => 'Varchar',
+    ];
+}

--- a/tests/php/ORM/DataObjectTest/OverriddenDataObject.php
+++ b/tests/php/ORM/DataObjectTest/OverriddenDataObject.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class OverriddenDataObject extends DataObject implements TestOnly
+{
+    private static $table_name = 'DataObjectTest_OverriddenDataObject';
+
+    private static $db = [
+        'Salary' => 'BigInt',
+        'EmploymentType' => 'Varchar',
+    ];
+
+    private static $has_one = [
+        'CurrentCompany' => Company::class,
+    ];
+}


### PR DESCRIPTION
Because we use `singleton` to get class references when building table, if you try to inject over a class, it's table will never be created.

# Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/9950
