### PR TITLE
ENH Reduce duplication of code in GridField view and edit buttons.

### DIFF
--- a/src/Forms/GridField/GridFieldEditButton.php
+++ b/src/Forms/GridField/GridFieldEditButton.php
@@ -63,7 +63,7 @@ class GridFieldEditButton implements GridField_ColumnProvider, GridField_ActionP
     /**
      * @inheritdoc
      */
-    public function getUrl($gridField, $record, $columnName)
+    public function getUrl($gridField, $record, $columnName, $addState = true)
     {
         $link = Controller::join_links(
             $gridField->Link('item'),
@@ -71,7 +71,11 @@ class GridFieldEditButton implements GridField_ColumnProvider, GridField_ActionP
             'edit'
         );
 
-        return $this->getStateManager()->addStateToURL($gridField, $link);
+        if ($addState) {
+            $link = $this->getStateManager()->addStateToURL($gridField, $link);
+        }
+
+        return $link;
     }
 
     /**
@@ -149,7 +153,7 @@ class GridFieldEditButton implements GridField_ColumnProvider, GridField_ActionP
         // which can make the form readonly if no edit permissions are available.
 
         $data = new ArrayData([
-            'Link' => Controller::join_links($gridField->Link('item'), $record->ID, 'edit'),
+            'Link' => $this->getURL($gridField, $record, $columnName, false),
             'ExtraClass' => $this->getExtraClass()
         ]);
 

--- a/src/Forms/GridField/GridFieldViewButton.php
+++ b/src/Forms/GridField/GridFieldViewButton.php
@@ -65,7 +65,7 @@ class GridFieldViewButton implements GridField_ColumnProvider, GridField_ActionM
             return null;
         }
         $data = new ArrayData([
-            'Link' => Controller::join_links($field->Link('item'), $record->ID, 'view')
+            'Link' => $this->getURL($field, $record, $col);
         ]);
         $template = SSViewer::get_templates_by_class($this, '', __CLASS__);
         return $data->renderWith($template);

--- a/src/Forms/GridField/GridFieldViewButton.php
+++ b/src/Forms/GridField/GridFieldViewButton.php
@@ -65,7 +65,7 @@ class GridFieldViewButton implements GridField_ColumnProvider, GridField_ActionM
             return null;
         }
         $data = new ArrayData([
-            'Link' => $this->getURL($field, $record, $col);
+            'Link' => $this->getURL($field, $record, $col),
         ]);
         $template = SSViewer::get_templates_by_class($this, '', __CLASS__);
         return $data->renderWith($template);


### PR DESCRIPTION
Reduces duplication of URL generation code in the `GridFieldEditButton` and `GridFieldViewButton` classes.
This makes the behaviour of these classes a little more predictable when subclassing them, as you only have to override the `getURL` method to change the URL in all cases.
