### PR TITLE
Allow extension of getAttributes for Tab and TabSet

### DIFF
--- a/src/Forms/Tab.php
+++ b/src/Forms/Tab.php
@@ -137,12 +137,16 @@ class Tab extends CompositeField
 
     public function getAttributes()
     {
-        return array_merge(
+        $attributes = array_merge(
             $this->attributes,
             [
                 'id' => $this->ID(),
                 'class' => 'tab ' . $this->extraClass()
             ]
         );
+
+        $this->extend('updateAttributes', $attributes);
+
+        return $attributes;
     }
 }

--- a/src/Forms/TabSet.php
+++ b/src/Forms/TabSet.php
@@ -178,13 +178,17 @@ class TabSet extends CompositeField
 
     public function getAttributes()
     {
-        return array_merge(
+        $attributes = array_merge(
             $this->attributes,
             [
                 'id' => $this->ID(),
                 'class' => $this->extraClass()
             ]
         );
+
+        $this->extend('updateAttributes', $attributes);
+
+        return $attributes;
     }
 
     /**


### PR DESCRIPTION
because getAttributes are overriden, extensions cannot update the tabs attributes

this is an issue, and more specifically because injector is not used to create tabset (therefore, extending the class doesn't help)

i don't see any negative effects of this. the alternative is to use injector (TabSet::create instead of new TabSet) in the code to allow for custom classes.