### PR TITLE
FIX Defensively copy $mock_now in Datetime::now()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ import:
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION="4.x-dev"
-    - REQUIRE_RECIPE="4.x-dev"
+    - REQUIRE_RECIPE="4.8.x-dev"
 
 # Using a manual matrix to exlude PHPUNIT_COVERAGE_TEST for now because it was causing some strange issues
 # e.g. https://travis-ci.com/github/silverstripe/silverstripe-framework/jobs/457096837

--- a/docs/en/04_Changelogs/rc/4.8.0-rc1.md
+++ b/docs/en/04_Changelogs/rc/4.8.0-rc1.md
@@ -1,0 +1,436 @@
+# 4.8.0-rc1
+
+## Overview
+
+- [Support for silverstripe/graphql v4](#graphql-v4)
+- [Improvements to the login form template and signed in period](#default-period)
+- [Other new features](#features)
+- [Bugfixes](#bugfixes)
+
+A full list of module versions included in CMS Recipe 4.8.0-rc1 is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/).
+
+<details>
+<summary>Included module versions</summary>
+
+| Module | Version |
+| ------ | ------- |
+| silverstripe/admin | 1.8.0-rc1 |
+| silverstripe/asset-admin | 1.8.0-rc1 |
+| silverstripe/assets | 1.8.0-rc1 |
+| silverstripe/campaign-admin | 1.8.0-rc1 |
+| silverstripe/cms | 1.8.0-rc1 |
+| silverstripe/config | 1.1.0 |
+| silverstripe/errorpage | 1.8.0-rc1 |
+| silverstripe/framework | 4.8.0-rc1 |
+| silverstripe/graphql | 3.5.0-rc1 |
+| silverstripe/login-forms | 4.4.1 |
+| silverstripe/mimevalidator | 2.1.1 |
+| silverstripe/reports | 4.8.0-rc1 |
+| silverstripe/siteconfig | 4.8.0-rc1 |
+| silverstripe/versioned | 1.8.0-rc1 |
+| silverstripe/versioned-admin | 1.8.0-rc1 |
+
+</details>
+
+### Support for silverstripe/graphql v4 {#graphql-v4}
+
+The [silverstripe/graphql](http://github.com/silverstripe/silverstripe-graphql/issues) module is used
+to drive various parts of the CMS UI, as well as building your own GraphQL APIs in Silverstripe projects.
+
+The CMS currently ships with `silverstripe/graphql:^3`, which is stable but slow for larger schemas.
+The module was rewritten from scratch with performance in mind
+(see [goals](https://github.com/silverstripe/silverstripe-framework/issues/8824) and [pull request](https://github.com/silverstripe/silverstripe-graphql/pulls)).
+The resulting`silverstripe/graphql:^4` release is currently in a alpha stage.
+We encourage everyone to get started, read our new [GraphQL documentation](https://docs.silverstripe.org/en/4/developer_guides/graphql/), 
+provide [feedback](https://github.com/silverstripe/silverstripe-graphql/issues) and help us stabilise the module.
+
+In order to facilitate the new module release, most GraphQL helper classes to drive the CMS UI
+have been marked as deprecated, and moved to `GraphQL/_legacy` folders within core modules.
+The GraphQL schema under `admin/graphql` has been altered slightly to enable forwards compatibility,
+with lower-camelcase field names, and a different filter argument structure.
+In the unlikely case that you are relying on those classes or queries directly,
+consider upgrading to `silverstripe/graphql:^4`.
+Your own GraphQL schemas outside of `admin/graphql` should not be affected by the changes
+if you choose to stay on `silverstripe/graphql:^3` for the time being.
+
+We are planning to require the use of `silverstripe/graphql:^4` in a future CMS 4.x release.
+
+If your project uses `silverstripe/recipe-cms`, please note that it is still locked to use `silverstripe/graphql:^3`.  If you'd like to now use `silverstripe/graphql:^4` then you'll need remove `silverstripe/recipe-cms` from your root composer.json, and instead copy the contents of the composer.json in silverstripe/recipe-cms to your root composer.json and change `silverstripe/graphql` to `^4`.
+
+#### GraphQL 3 code moved to _legacy folder
+
+You will notice that many of the core modules now have a `_legacy` directory in their root.
+This is a temporary fix that we have applied to satisfy the competing interests of semver and
+PSR-4 autoloading.
+
+Because the semver contract precludes changing the fully-qualified names of any classes,
+we need to keep GraphQL 3 code untouched. But GraphQL 4 code often contains classes of similar
+or identical names, e.g. "ReadFilesResolver", or something to that effect. Further, this 
+backward compatibility creates a common demand for the canonical namespace "GraphQL.", e.g.
+`SilverStripe\AssetAdmin\GraphQL`. It didn't seem appropriate to put _old_ code in the "GraphQL"
+space, and _new_ code in a less obvious place, like `SilverStripe\AssetAdmin\GraphQL4`.
+
+A simple fix would have been to stuff all the GraphQL 3 code into `code/GraphQL/_legacy` and use `classmap` to shim the PSR-4 autoloader, but this is [no longer supported](https://blog.packagist.com/composer-2-0-is-now-available/#3-backwards-compatibility-breaks) in Composer 2.0.
+
+Thus, we ended up with the "least bad" solution, which was to create a parallel path resolution
+for GraphQL 3 code in the `_legacy` folder, alongside `code/` / `src/`.
+
+It is likely that in the future, we will mandate the use of GraphQL 4 in Silverstripe CMS, and
+remove this shim. We expect this happen within just one minor release, making `_legacy/` a very short-lived workaround.
+
+## Enhancements
+
+### Improvements to the login form template and signed in period {#default-period}
+
+We’ve reduced the time period of the “Keep me signed in” checkbox on the login form from
+90 to 30 days. This time period is now also visible in the label. This value is configurable via `SilverStripe\Security\RememberLoginHash::token_expiry_days`.
+
+This change has been made to more accurately reflect what action will be taken, and give the reader more information to make a safe and secure decision. In addition to this, the [login-forms](https://addons.silverstripe.org/add-ons/silverstripe/login-forms) module includes a new popover intended to provide further information to support using the "Keep me signed in" option safely.
+
+## Other new features {#features}
+
+* [Added a `chunkedFetch()` method to `DataList`](/Developer_Guides/Model/Lists#chunkedFetch) to avoid loading large result sets in memory all at once. 
+
+## Bugfixes {#bugfixes}
+
+This release includes a number of bug fixes to improve a broad range of areas. Check the change logs for full details of these fixes split by module. Thank you to the community members that helped contribute these fixes as part of the release!
+
+
+## Change Log
+
+
+### Features and Enhancements
+
+
+ * silverstripe/installer (4.7.3 -&gt; 4.8.0-rc1)
+    * 2021-04-30 [4e1fa26](https://github.com/silverstripe/silverstripe-installer/commit/4e1fa260eee067442e9510eecbf033205febe563) Add login-forms to changelog template (Steve Boyd)
+
+ * silverstripe/framework (4.7.3 -&gt; 4.8.0-rc1)
+    * 2021-04-15 [d9e8dd42c](https://github.com/silverstripe/silverstripe-framework/commit/d9e8dd42c08b7639caec471acfca1ce6e7672044) Update keep me signed in tooltip text (Steve Boyd)
+    * 2021-04-06 [1c7fd287a](https://github.com/silverstripe/silverstripe-framework/commit/1c7fd287a1e638992bb7f90abc504e225bb5351c) Reduce default token period from 90 to 30 days (Steve Boyd)
+    * 2021-02-11 [095a3b70f](https://github.com/silverstripe/silverstripe-framework/commit/095a3b70f86d8c72da4be8e2f49c8a740a7e6e3d) Provide helpers for isDev/isTest/isLive in templates (Loz Calver)
+    * 2020-10-22 [eedad00eb](https://github.com/silverstripe/silverstripe-framework/commit/eedad00ebef73c0e6841fd8dd93232dbc4c67ce0) Expose TreeDropdownField root node ID in schema (Loz Calver)
+
+ * silverstripe/admin (1.7.3 -&gt; 1.8.0-rc1)
+    * 2021-02-16 [50188c4](https://github.com/silverstripe/silverstripe-admin/commit/50188c44f8d6cc34adfd138f08c90a7e42d9e61b) New event handler for schema transcribe (Aaron Carlino)
+    * 2020-11-12 [6bd63f8](https://github.com/silverstripe/silverstripe-admin/commit/6bd63f835b67de8dcb7e7a174f84db2d486d96f9) GraphQL 4 Compatibility (#1148) (Aaron Carlino)
+
+ * silverstripe/asset-admin (1.7.1 -&gt; 1.8.0-rc1)
+    * 2020-12-01 [d8070f00](https://github.com/silverstripe/silverstripe-asset-admin/commit/d8070f0088f51b6e798e4ed80401548046bcaa77) Compliance with new SchemaConfig API (#1164) (Aaron Carlino)
+    * 2020-11-13 [6751560a](https://github.com/silverstripe/silverstripe-asset-admin/commit/6751560a28d03ca1f81e0e90cf52de1773f1c616) GraphQL 4 compatibility  (#1154) (Aaron Carlino)
+
+ * silverstripe/versioned-admin (1.7.2 -&gt; 1.8.0-rc1)
+    * 2021-02-26 [a7e0205](https://github.com/silverstripe/silverstripe-versioned-admin/commit/a7e020500d9bdd3e21cfadd7d0c1bdf6618b2b62) Update Versioned Admin menu title to &amp;quot;Archive&amp;quot;. Fixes #156 (#175) (Chris Penny)
+    * 2020-11-12 [721403f](https://github.com/silverstripe/silverstripe-versioned-admin/commit/721403f24bc134baa0645c332bdc47379048dc72) GraphQL 4 Compatibility (#184) (Aaron Carlino)
+
+ * silverstripe/cms (4.7.1 -&gt; 4.8.0-rc1)
+    * 2020-12-01 [36a6fb00](https://github.com/silverstripe/silverstripe-cms/commit/36a6fb002e8c15679ac718233aa411a7cad6db27) Compliance with new SchemaConfig API (#2617) (Aaron Carlino)
+    * 2020-11-13 [5ab1ff3e](https://github.com/silverstripe/silverstripe-cms/commit/5ab1ff3e69bb41f7025db3f6202bbc65355332f2) GraphQL Compatibility (#2607) (Aaron Carlino)
+
+ * silverstripe/versioned (1.7.2 -&gt; 1.8.0-rc1)
+    * 2021-02-26 [3995209](https://github.com/silverstripe/silverstripe-versioned/commit/3995209857b06f8a11d5eded47bbd9c77cdee43b) Update Versioned Admin menu title to &amp;quot;Archive&amp;quot; (#302) (Chris Penny)
+    * 2020-12-01 [1ac859e](https://github.com/silverstripe/silverstripe-versioned/commit/1ac859e6261607ae7a0f4aba601811494f91a8d8) Compliance with new SchemaConfig API (#315) (Aaron Carlino)
+    * 2020-11-19 [68cbd4f](https://github.com/silverstripe/silverstripe-versioned/commit/68cbd4fdb11d498071911562109b8a41f4697d23) compatibility with new stateless plugins (Aaron Carlino)
+    * 2020-11-13 [4a42ca7](https://github.com/silverstripe/silverstripe-versioned/commit/4a42ca707e37e7fd5beae8ae2894c65c65d5fe81) GraphQL 4 Compatibility (#308) (Aaron Carlino)
+
+ * silverstripe/graphql (3.4.1 -&gt; 3.5.0-rc1)
+    * 2020-11-13 [25f654c](https://github.com/silverstripe/silverstripe-graphql/commit/25f654c9fd33327b6107158868a636a6090d4d13) Field formatting API, forward compatibility (#313) (Aaron Carlino)
+
+ * silverstripe/login-forms (4.3.0 -&gt; 4.4.1)
+    * 2021-04-14 [5ebdbff](https://github.com/silverstripe/silverstripe-login-forms/commit/5ebdbff9e4d57ccca04a6e230e9bf62d54515e7a) Use popover for help icon (Steve Boyd)
+    * 2021-01-21 [1449aac](https://github.com/silverstripe/silverstripe-login-forms/commit/1449aac66db602b032dca50c90b6d04cd6aff3e2) Updating Silverstripe logo to new logo (#75) (3Dgoo)
+
+    
+### Bugfixes
+
+
+ * silverstripe/assets (1.7.0 -&gt; 1.8.0-rc1)
+    * 2021-03-19 [6dd8559](https://github.com/silverstripe/silverstripe-assets/commit/6dd8559313d33260ce098fbbac5f7629c8788575) Ensure remove folder removes all exepcted files/folders/links (#430) (Adrian Humphreys)
+    * 2021-03-12 [756be6f](https://github.com/silverstripe/silverstripe-assets/commit/756be6fd7a8e750a7695922d9c233ea8d41e6fe3) Remove disabled extensions from allowed_extensions (#439) (Andrew Aitken-Fincham)
+    * 2021-03-01 [4018329](https://github.com/silverstripe/silverstripe-assets/commit/40183293f1d2e4454fd8404d5a2d096b0c8b9a2a) Cast image dimensions from shortcode as int to avoid exception when dimensions are not numeric (#436) (Michael van Schaik)
+
+ * silverstripe/framework (4.7.3 -&gt; 4.8.0-rc1)
+    * 2021-04-20 [12a6f7bd0](https://github.com/silverstripe/silverstripe-framework/commit/12a6f7bd0faf8094e9844c44d08fb514a01bebf0) fix typo in core constants phpdoc block (maks)
+    * 2021-03-30 [66fa597b3](https://github.com/silverstripe/silverstripe-framework/commit/66fa597b3be882c735ea7afc4e90725083b4acea) Better handling of remember me token when login across devices is disabled (#9895) (Maxime Rainville)
+    * 2021-03-03 [d2fa64b48](https://github.com/silverstripe/silverstripe-framework/commit/d2fa64b48928fdb051e956f3ec4dbf772691d708) Allow Email to re-render when data changes (#9876) (Nik)
+    * 2021-02-25 [028c4fdaa](https://github.com/silverstripe/silverstripe-framework/commit/028c4fdaa1b2bc2fff9df0f21e9c45ce3d628216) Tweak shortcode parser so it properly parse empty attributes (Maxime Rainville)
+    * 2021-02-08 [33365b92f](https://github.com/silverstripe/silverstripe-framework/commit/33365b92f3529ae353af64b90251e3f515adc0ea) Bug Fix - Ensure DataQuery::exists() SQL is both valid MySQL and T-SQL (Joe Harvey)
+    * 2021-01-21 [0dd59a1e7](https://github.com/silverstripe/silverstripe-framework/commit/0dd59a1e7b0fca36950313c4216fbb7f403cbbbf) Reset GridFieldFilterHeader grid state when search is cleared (#9829) (Maxime Rainville)
+    * 2021-01-07 [2f64667bd](https://github.com/silverstripe/silverstripe-framework/commit/2f64667bd68c7c61c32d9180adab1db5b2d96a0c) DBComposite getIndexSpecs method using self API to get the list of db fields (Serge Latyntcev)
+    * 2020-12-29 [3b74c2596](https://github.com/silverstripe/silverstripe-framework/commit/3b74c2596fc37aa68b8e173a9e7f07b355fc99a1) Fix DataQuery::exists() not working correctly (3Dgoo)
+    * 2020-12-28 [157d426d3](https://github.com/silverstripe/silverstripe-framework/commit/157d426d39b03d408fa73a4885de824e894b3f9d) URL to Symfony cache adapters (Patrick Nelson)
+    * 2020-12-22 [43777d1df](https://github.com/silverstripe/silverstripe-framework/commit/43777d1df2b5fd14eb3283bb48b5ffc2484c5b89) Update .gitattributes and some http:// links (#9805) (William Desportes)
+    * 2020-12-21 [c932d7e7f](https://github.com/silverstripe/silverstripe-framework/commit/c932d7e7fbcc11d3248e53f319964b474a36e6a5) Fix the phpdoc blocks (William Desportes)
+    * 2020-12-15 [5be045f9a](https://github.com/silverstripe/silverstripe-framework/commit/5be045f9a2e0bf8e4b1e99e3604ceb59e0553b49) Bug when specifying 0 in ArrayList::offsetSet (Steve Boyd)
+    * 2020-12-07 [61afab2ed](https://github.com/silverstripe/silverstripe-framework/commit/61afab2ed89a6cf3e5b010464bd515dc7baf21ee) fix indentation (Lukas)
+    * 2020-08-17 [5226d961e](https://github.com/silverstripe/silverstripe-framework/commit/5226d961e80a2bf5e9bd1403dfebf4be9e64494c) Fix unit test (Maxime Rainville)
+
+ * silverstripe/admin (1.7.3 -&gt; 1.8.0-rc1)
+    * 2021-05-11 [4793b9f](https://github.com/silverstripe/silverstripe-admin/commit/4793b9fc054521dfe386a391ce540e3d611cb323) Fix TreeDropDownField no longer displaying dropdown options (#1196) (Andre Kiste)
+    * 2021-02-25 [036bc9e](https://github.com/silverstripe/silverstripe-admin/commit/036bc9ea97e40d50207d06680366c572f6fb85dc) Fix merge conflict from merge-up (Steve Boyd)
+    * 2021-02-14 [9a4bf89](https://github.com/silverstripe/silverstripe-admin/commit/9a4bf8971864378b67dae6ad727f5218d31c1a25) Allow external link anchor fiel to work even if the user provides a hash mark (Maxime Rainville)
+    * 2021-01-26 [095b773](https://github.com/silverstripe/silverstripe-admin/commit/095b7737a8cfa3ff9fc250264282dad514fd7475) Clean up old life cycle methods and fix serach filter compenent state (Maxime Rainville)
+    * 2020-12-02 [bc9457b](https://github.com/silverstripe/silverstripe-admin/commit/bc9457bdedef3a566e3252403176e7cb414973ed) Fix inforrect modelConfig (Aaron Carlino)
+    * 2020-10-22 [397fa06](https://github.com/silverstripe/silverstripe-admin/commit/397fa06894d685ac72757e7d83c17793c1ddf876) TreeDropdownField wouldn&amp;#039;t render children when using TreeBaseID (fixes #954) (Loz Calver)
+    * 2020-08-28 [7594ef2](https://github.com/silverstripe/silverstripe-admin/commit/7594ef2a5cb842a0ac260a1c85f2826e3ef60030) Do not override grid state with search parameters (Maxime Rainville)
+
+ * silverstripe/asset-admin (1.7.1 -&gt; 1.8.0-rc1)
+    * 2021-03-11 [cd68c693](https://github.com/silverstripe/silverstripe-asset-admin/commit/cd68c6933c9d1d0b47469b174605558e6302af29) Set folder gallery item display to flex to allow it to scale with browser zoom level (Maxime Rainville)
+    * 2021-02-10 [516a3b5e](https://github.com/silverstripe/silverstripe-asset-admin/commit/516a3b5e9d7e75f62cf5e8735e74ad7e87a1831e) Remove file history preview (Steve Boyd)
+    * 2021-02-09 [6ee29644](https://github.com/silverstripe/silverstripe-asset-admin/commit/6ee29644d08cbc7656b86ea31a101d32cb259904) Remove duplicate url dependency in package.json (Scott Hutchinson)
+
+ * silverstripe/campaign-admin (1.7.1 -&gt; 1.8.0-rc1)
+    * 2020-09-16 [1a9af45](https://github.com/silverstripe/silverstripe-campaign-admin/commit/1a9af4503fb3fcebbfb4f55fa65db558bc7f39f2) Display a notification after publishing a campaign (Maxime Rainville)
+
+ * silverstripe/versioned-admin (1.7.2 -&gt; 1.8.0-rc1)
+    * 2020-11-17 [5b42dc8](https://github.com/silverstripe/silverstripe-versioned-admin/commit/5b42dc8ec596f4cfb8cb394015490b71778fd6f2) don&amp;#039;t disable bundle.js / bundle.css with no-cms install (Damian Mooyman)
+    * 2020-10-23 [efdf83c](https://github.com/silverstripe/silverstripe-versioned-admin/commit/efdf83ca768dafe820b9559fb8618fe53b789d1b) Fix issue with composer warning about PSR-4 paths (Damian Mooyman)
+    * 2020-08-26 [424d4db](https://github.com/silverstripe/silverstripe-versioned-admin/commit/424d4dbe22bdff333cc074f747f0ac019627e1a6) Allow use of ArchiveAdmin on unstaged objects. (Sam Minnee)
+
+ * silverstripe/cms (4.7.1 -&gt; 4.8.0-rc1)
+    * 2021-03-05 [db7efad6](https://github.com/silverstripe/silverstripe-cms/commit/db7efad6ca5cf9e60eb99fb0c270b640f836a8fa) undefined variable inChangeSets (Will Rossiter)
+
+ * silverstripe/versioned (1.7.2 -&gt; 1.8.0-rc1)
+    * 2021-02-24 [1685b88](https://github.com/silverstripe/silverstripe-versioned/commit/1685b887329339a326339e3fdd41c84d01ee116e) Unset subquery sort in unlinkDisownedRelationship to avoid exception on DB Drivers that disallow sub query sort (#325) (Klemen Dolinsek)
+    * 2021-02-16 [36bfe43](https://github.com/silverstripe/silverstripe-versioned/commit/36bfe439767b10fbbc8cbb7e89c1e4370228d011) GraphQL tests based on latest refactoring (Ingo Schommer)
+    * 2021-02-16 [e33dd28](https://github.com/silverstripe/silverstripe-versioned/commit/e33dd2812ceee919b12ae1866044d147f61b4af8) Apply version filtering on read correctly (Ingo Schommer)
+
+ * silverstripe/login-forms (4.3.0 -&gt; 4.4.1)
+    * 2021-04-12 [a44bd51](https://github.com/silverstripe/silverstripe-login-forms/commit/a44bd511d9b3a24ac1c8982a5d10bffe1a665007) Fix checkbox alignment (André Kiste)
+    * 2021-04-12 [08b5eac](https://github.com/silverstripe/silverstripe-login-forms/commit/08b5eacf84e3e2703300600a62074800e4baf441) Fix checkbox field rendering tooltip twice (André Kiste)
+    * 2021-02-15 [c618b63](https://github.com/silverstripe/silverstripe-login-forms/commit/c618b63529730fb989f4d04179b222745129f54f) Avoid clipping of the Silverstripe CMS logo (Maxime Rainville)
+    * 2021-01-21 [1ac3429](https://github.com/silverstripe/silverstripe-login-forms/commit/1ac342993dc40a48ecfd8b566efa18eea9372573) Allow title and form to resize independently (#81) (Garion Herman)
+
+    
+### API Changes
+
+
+ * silverstripe/framework (4.7.3 -&gt; 4.8.0-rc1)
+    * 2021-04-19 [bcccc63d3](https://github.com/silverstripe/silverstripe-framework/commit/bcccc63d33485b6ff434f8ce8e4cbc4e3b099e8c) Methods to override logout_accross_devices (Steve Boyd)
+    * 2021-01-21 [9ca33950a](https://github.com/silverstripe/silverstripe-framework/commit/9ca33950a276747d0dc4f40b62c1df307e3c572a) Add a CREATE_MEMORY_HYDRATED option to DataObject constructor (#9767) (Maxime Rainville)
+    * 2019-08-23 [70ffb3297](https://github.com/silverstripe/silverstripe-framework/commit/70ffb3297acd1e281d8246bb26878a2e35d530fe) Only include gridfield state value that differ from the expected default (Maxime Rainville)
+
+ * silverstripe/asset-admin (1.7.1 -&gt; 1.8.0-rc1)
+    * 2021-05-10 [0ea08159](https://github.com/silverstripe/silverstripe-asset-admin/commit/0ea081594cf3fc2f6e0bef38b761f30cd31c3cf7) Require graphl 3.5 or greater (Maxime Rainville)
+    * 2020-09-02 [5fc57048](https://github.com/silverstripe/silverstripe-asset-admin/commit/5fc570488037624e39023df04426111307645ddd) Add an option to disabled cache busting when showing image thumbnail for people using S3 as their asset store (Maxime Rainville)
+
+ * silverstripe/versioned-admin (1.7.2 -&gt; 1.8.0-rc1)
+    * 2021-05-10 [6748fc9](https://github.com/silverstripe/silverstripe-versioned-admin/commit/6748fc9842fd7f7d92b8f17aaa4e4f0358ac41ae) Bump requirement no GraphQL 3.5 (Maxime Rainville)
+
+ * silverstripe/graphql (3.4.1 -&gt; 3.5.0-rc1)
+    * 2021-05-10 [f8ac3f7](https://github.com/silverstripe/silverstripe-graphql/commit/f8ac3f757b055a8ec8327fddf77db3dee1afae62) Block older version module from using this minor (#379) (Maxime Rainville)
+
+    
+### Dependencies
+
+
+ * silverstripe/admin (1.7.3 -&gt; 1.8.0-rc1)
+    * 2020-11-16 [fc76297](https://github.com/silverstripe/silverstripe-admin/commit/fc7629708604c0cc60a35ac901ca4f686ed1e9bb) Rebuild assets after node-sass update (Garion Herman)
+    * 2020-09-04 [9d6ac18](https://github.com/silverstripe/silverstripe-admin/commit/9d6ac18900c972f9b5333ed46bdaa45345a06ce3) Bump node-sass from 4.13.0 to 4.14.1 (dependabot[bot])
+
+ * silverstripe/campaign-admin (1.7.1 -&gt; 1.8.0-rc1)
+    * 2021-04-20 [ab208b2](https://github.com/silverstripe/silverstripe-campaign-admin/commit/ab208b2fdc671a51b5dff1a85229ff56c33630f2) Bump handlebars from 4.5.1 to 4.7.7 (dependabot[bot])
+    * 2021-04-19 [36d70c5](https://github.com/silverstripe/silverstripe-campaign-admin/commit/36d70c5dec94927f2f0a8f3917be461b4640bc27) Bump ssri from 6.0.1 to 6.0.2 (dependabot[bot])
+    * 2020-12-11 [d4bc8da](https://github.com/silverstripe/silverstripe-campaign-admin/commit/d4bc8da0ba2673af1d50e36da0cb77ce1d1be074) Bump ini from 1.3.5 to 1.3.7 (dependabot[bot])
+
+ * silverstripe/versioned-admin (1.7.2 -&gt; 1.8.0-rc1)
+    * 2020-12-11 [c769bab](https://github.com/silverstripe/silverstripe-versioned-admin/commit/c769bab8a826411b74eab32120ae43011067622e) Bump ini from 1.3.5 to 1.3.7 (dependabot[bot])
+    * 2020-11-16 [5dc919d](https://github.com/silverstripe/silverstripe-versioned-admin/commit/5dc919d213d71937560da2dbc5a1840c5f8a07d9) Rebuild assets after node-sass update (Garion Herman)
+    * 2020-11-13 [e070cdd](https://github.com/silverstripe/silverstripe-versioned-admin/commit/e070cdd6e04d84cac70835d20582b6b062665133) Bump dot-prop from 4.2.0 to 4.2.1 (dependabot[bot])
+    * 2020-09-07 [8828557](https://github.com/silverstripe/silverstripe-versioned-admin/commit/8828557a9422bc263843bde70a2b4b78595ebeb0) Bump node-sass from 4.13.0 to 4.14.1 (dependabot[bot])
+
+ * silverstripe/cms (4.7.1 -&gt; 4.8.0-rc1)
+    * 2020-12-11 [9136c8a5](https://github.com/silverstripe/silverstripe-cms/commit/9136c8a55fed5748fbcc09afa0ab8f9043cc5873) Bump ini from 1.3.5 to 1.3.7 (dependabot[bot])
+
+ * silverstripe/login-forms (4.3.0 -&gt; 4.4.1)
+    * 2020-12-11 [9e097f4](https://github.com/silverstripe/silverstripe-login-forms/commit/9e097f45c815b606a6936a6cb23b47cd206231f1) Bump ini from 1.3.5 to 1.3.7 (dependabot[bot])
+    * 2020-11-12 [c06130e](https://github.com/silverstripe/silverstripe-login-forms/commit/c06130e613fcf02c8a64fee37dc323c1766ec1b9) Bump dot-prop from 4.2.0 to 4.2.1 (dependabot[bot])
+
+    
+### Documentation
+
+
+ * silverstripe/framework (4.7.3 -&gt; 4.8.0-rc1)
+    * 2021-03-18 [9e766dbaa](https://github.com/silverstripe/silverstripe-framework/commit/9e766dbaade9a23a6601c93816e3344d6a4faf26) Fix incorrect CSRF graphql documentation (Aaron Carlino)
+    * 2021-03-10 [4ee92da6b](https://github.com/silverstripe/silverstripe-framework/commit/4ee92da6b570e4fbc93a4e4620f9adc941ab100c) Clarify return value for CompositeValidator::getValidatorsByType() (Maxime Rainville)
+    * 2021-02-24 [34bc08051](https://github.com/silverstripe/silverstripe-framework/commit/34bc080515ca12975ab129d8e490bebd564b25a3) Add guide on new MySQL collation to Server Reqs (Garion Herman)
+    * 2021-02-23 [07dea64bf](https://github.com/silverstripe/silverstripe-framework/commit/07dea64bf6e906cfd4511af335e6cf2e7ca74539) Document removal of exclude directive (Aaron Carlino)
+    * 2021-02-19 [5a4641d80](https://github.com/silverstripe/silverstripe-framework/commit/5a4641d806a0a4d9d9ed17286e70dacbc4d252e8) Disable versioning on GraphQL (#9769) (Ingo Schommer)
+    * 2021-02-16 [68eeef60d](https://github.com/silverstripe/silverstripe-framework/commit/68eeef60d5f207d6c2b176aecf3280eb9a670853) GraphQL build requirement changes (Ingo Schommer)
+    * 2021-02-15 [eca656ffe](https://github.com/silverstripe/silverstripe-framework/commit/eca656ffeb43ec2de904583378954faa1606406f) fix accidentally nested info box (Ed Wilde)
+    * 2021-02-15 [7d67760a6](https://github.com/silverstripe/silverstripe-framework/commit/7d67760a69bb204f93104c93708a85f88e02898e) fix link syntax (Ed Wilde)
+    * 2021-02-15 [8a8f5e6ba](https://github.com/silverstripe/silverstripe-framework/commit/8a8f5e6baad23ed0d7c3dc0a2c4abf4075fc6844) fix code block not closed (Ed Wilde)
+    * 2021-02-14 [e60a25cfb](https://github.com/silverstripe/silverstripe-framework/commit/e60a25cfbd98d58d9278b4120e9c314dfa73acdf) fix typo (Ed Wilde)
+    * 2021-02-14 [01eedff4a](https://github.com/silverstripe/silverstripe-framework/commit/01eedff4a498c201cbec3ddb7e3520e8bd013946) fix api link syntax and a couple of typos (Ed Wilde)
+    * 2021-02-14 [3a214a2ed](https://github.com/silverstripe/silverstripe-framework/commit/3a214a2ed3586f07383fb13a05b0af4c2be53804) fix broken heading (Ed Wilde)
+    * 2021-02-12 [da56fa785](https://github.com/silverstripe/silverstripe-framework/commit/da56fa785b591b1ddefc120d1d9da104039739f5) fix invalid syntax on link (Ed Wilde)
+    * 2021-02-10 [cf50aa71b](https://github.com/silverstripe/silverstripe-framework/commit/cf50aa71b57a8d2643416971b581f453a5a27614) fix missing closing backtick for code display, add required alt attribute (Ed Wilde)
+    * 2021-02-10 [c3499d20e](https://github.com/silverstripe/silverstripe-framework/commit/c3499d20e5a8827d22eaf933f08863ad9864a70d) add a callout to the deprecation notice (Ed Wilde)
+    * 2021-02-10 [95a142a9d](https://github.com/silverstripe/silverstripe-framework/commit/95a142a9deae8fbb931fb164a0ef7174f8827fb3) complete first sentence describing middleware (Ed Wilde)
+    * 2021-02-04 [1be5f471d](https://github.com/silverstripe/silverstripe-framework/commit/1be5f471de7bce661f1db18c78bbcf9371dfefa5) Resolver signature and context provider examples (Ingo Schommer)
+    * 2021-02-01 [ac90ec7d4](https://github.com/silverstripe/silverstripe-framework/commit/ac90ec7d400e7e57e4339e58c55758d14e5ca7c5) remove the version number from docs urls (Ed Wilde)
+    * 2021-01-31 [296e41768](https://github.com/silverstripe/silverstripe-framework/commit/296e41768a6183716b61e0364a0da817c39bed31) fix the &amp;#039;Server Requirements&amp;#039; url (Ed Wilde)
+    * 2021-01-30 [062656d92](https://github.com/silverstripe/silverstripe-framework/commit/062656d923d1dc5aab26241079c69e78717b6212) Add &amp;quot;Defining the ModelAdmin models&amp;quot; section (Maxime Rainville)
+    * 2021-01-27 [24ca17053](https://github.com/silverstripe/silverstripe-framework/commit/24ca17053d5863f3cf68382e099f95e594b6eb49) Docs for GraphQL 4 changes (Aaron Carlino)
+    * 2021-01-26 [fd99d50b3](https://github.com/silverstripe/silverstripe-framework/commit/fd99d50b3007220db01ba0822e794dfb2356b5e5) Maintainer Guidelines updates (Serge Latyntcev)
+    * 2021-01-19 [caa224e37](https://github.com/silverstripe/silverstripe-framework/commit/caa224e37b7936872f3e48cbf4b613858db310d2) Remove BuildState documentation (Aaron Carlino)
+    * 2021-01-14 [c82f5eeb7](https://github.com/silverstripe/silverstripe-framework/commit/c82f5eeb7fbadc4022fb0e9f6f2eea0069fee8ca) Add Maintainer Guidelines to the Contributing section (Serge Latyntcev)
+    * 2021-01-13 [d308bb022](https://github.com/silverstripe/silverstripe-framework/commit/d308bb022cf4b50f6f80b3f9aefce38116dd853e) GraphQL blacklisted fields (#9768) (Ingo Schommer)
+    * 2021-01-12 [99b15ce6d](https://github.com/silverstripe/silverstripe-framework/commit/99b15ce6d30dddf19eec9b3617b239a969249e82) New &amp;quot;Triage&amp;quot; role for Silverstripe Core (Ingo Schommer)
+    * 2021-01-12 [676353011](https://github.com/silverstripe/silverstripe-framework/commit/67635301179f35e35edecb50cba15ca72389fe60) Clarified Core vs. Supported Modules (Ingo Schommer)
+    * 2020-12-22 [869aaa79a](https://github.com/silverstripe/silverstripe-framework/commit/869aaa79abaae938c091977dee33aee3d8313e7f) Fix `FlysystemAssetStore` reference (#9807) (Martin D)
+    * 2020-12-08 [835284fdf](https://github.com/silverstripe/silverstripe-framework/commit/835284fdfe6c3500123547d5431d864c7bce7a4e) GraphQL filter plugin (Ingo Schommer)
+    * 2020-12-01 [fe972d62d](https://github.com/silverstripe/silverstripe-framework/commit/fe972d62d57e8477838c39611b54f8bef7d619ab) Document new schema config, change to resolver discovery pattern (#9781) (Aaron Carlino)
+    * 2020-11-25 [40d19d04e](https://github.com/silverstripe/silverstripe-framework/commit/40d19d04ecd8681db3c19204ba1e76638ac80ea4) Filesystem capacity issue potential on caches (Ingo Schommer)
+    * 2020-11-19 [154fb7046](https://github.com/silverstripe/silverstripe-framework/commit/154fb7046855f55c10f1e28a6d92c85e9b77ed79) replace broken Director link to Routing (Christopher Darling)
+    * 2020-11-19 [e69cfd152](https://github.com/silverstripe/silverstripe-framework/commit/e69cfd152eb6ed290cd9318289dbc5eb675fa5b6) Document new stateless plugins (Aaron Carlino)
+    * 2020-11-16 [bdb2deb3f](https://github.com/silverstripe/silverstripe-framework/commit/bdb2deb3f55970fcd198a99128cffc4e21ef4545) Update HistoryViewerField to require javascript more consistently (#9773) (Scott Hutchinson)
+    * 2020-11-15 [b6e4747b7](https://github.com/silverstripe/silverstripe-framework/commit/b6e4747b7489422ddaf949781b9ce8fecd66bc91) Add blurb about _legacy to changelog (Aaron Carlino)
+    * 2020-11-15 [f673996aa](https://github.com/silverstripe/silverstripe-framework/commit/f673996aa059b245f55c163130a62cb0cd2d0da8) Fix classname reference in SearchContext docs (#9771) (wernerkrauss)
+    * 2020-11-11 [e02540c76](https://github.com/silverstripe/silverstripe-framework/commit/e02540c7696dbac0ffd76ebe1ae568098a8385e9) GraphQL v4 changelog note (#9762) (Ingo Schommer)
+    * 2020-11-03 [bf6a52b9c](https://github.com/silverstripe/silverstripe-framework/commit/bf6a52b9c0d8d73fe0dc3db9105761fe76f63f6f) Add some extra details to the changelog about toast notification and DataObject hydration (#9754) (Maxime Rainville)
+    * 2020-10-15 [fee31c2c6](https://github.com/silverstripe/silverstripe-framework/commit/fee31c2c6cf09b8108d546340b663dd5101fd4b5) Recommend moving .protected out of webroot (Ingo Schommer)
+
+    
+### Other changes
+
+
+ * silverstripe/installer (4.7.3 -&gt; 4.8.0-rc1)
+    * 2021-01-21 [da876a8](https://github.com/silverstripe/silverstripe-installer/commit/da876a829c8b45163ef7c976dae2c90e4c899a20) Update build status badge (Steve Boyd)
+
+ * silverstripe/recipe-cms (4.7.3 -&gt; 4.8.0-rc1)
+    * 2021-01-21 [3e7ecaa](https://github.com/silverstripe/recipe-cms/commit/3e7ecaaaccf718535222343e96925ce571e96935) Update README.md (Steve Boyd)
+    * 2020-12-27 [959e61b](https://github.com/silverstripe/recipe-cms/commit/959e61b9e5af5ac505302b801f020333f903d68f) Upgrade silverstripe/recipe-plugin to support composer 2.0 (Tony Air)
+    * 2020-11-13 [d69f89d](https://github.com/silverstripe/recipe-cms/commit/d69f89d972c46f4728900b50b18f8a790c421f69) Allow graphql 4 (#41) (Aaron Carlino)
+
+ * silverstripe/recipe-core (4.7.3 -&gt; 4.8.0-rc1)
+    * 2021-01-21 [d897a30](https://github.com/silverstripe/recipe-core/commit/d897a30a934c77dbe6fee1437be050a428ebd667) Removed status badge, there are no tests (Ingo Schommer)
+    * 2021-01-21 [8d6752f](https://github.com/silverstripe/recipe-core/commit/8d6752f5578246d2c824bb48432b52175f5a5dfe) Update build status badge (Steve Boyd)
+
+ * silverstripe/assets (1.7.0 -&gt; 1.8.0-rc1)
+    * 2021-01-28 [f0761f7](https://github.com/silverstripe/silverstripe-assets/commit/f0761f7c15d15b8ed316bfeaf49fa96c6e280fe7) 426: Ensure cache key doesn&amp;#039;t contain invalid characters (Adrian Humphreys)
+    * 2021-01-28 [b1cec43](https://github.com/silverstripe/silverstripe-assets/commit/b1cec437d2d476f29f7660b07eba8bc40afdef0e) Check if Versioned is available (Ralph Slooten)
+    * 2021-01-21 [6e28ee6](https://github.com/silverstripe/silverstripe-assets/commit/6e28ee688ce48a498388342334348e79b148f93a) Update build status badge (Steve Boyd)
+
+ * silverstripe/framework (4.7.3 -&gt; 4.8.0-rc1)
+    * 2021-05-16 [dde1e7a5c](https://github.com/silverstripe/silverstripe-framework/commit/dde1e7a5c2df2d0859c46c1f8c02fbce5ebfd7b4) Update translations (Steve Boyd)
+    * 2021-04-13 [6fc25e4e9](https://github.com/silverstripe/silverstripe-framework/commit/6fc25e4e9619b001abb4ed223e54cc11758f9695) RFC Add chunk method to DataList to iterate over large dataset (#8940) (Maxime Rainville)
+    * 2021-04-13 [e2777ded8](https://github.com/silverstripe/silverstripe-framework/commit/e2777ded8e7800550c6e0c89e3c0782eca678cfc) • Add missing string (André Kiste)
+    * 2021-04-13 [31c5ab206](https://github.com/silverstripe/silverstripe-framework/commit/31c5ab20693a59570fe4f9d169fa3e5917a161e1) [BUGFIX] Prevent call getHeader() on null HTTPRequest object (Kunal Hari)
+    * 2021-04-11 [bbcc187c0](https://github.com/silverstripe/silverstripe-framework/commit/bbcc187c025d42d24e7dc00f81da96c666bfde42) Update conflicting translations. (André Kiste)
+    * 2021-04-08 [8692aabe9](https://github.com/silverstripe/silverstripe-framework/commit/8692aabe9b0bf391b580218a6771d354c17e969e) Use new designs (André Kiste)
+    * 2021-04-05 [b75860b19](https://github.com/silverstripe/silverstripe-framework/commit/b75860b195516f1c950f2f46439538f2d525883d) PATCH: fix param in docblock ... add \ to FormField::__construct (Nicolaas)
+    * 2021-04-01 [2ecd8b34e](https://github.com/silverstripe/silverstripe-framework/commit/2ecd8b34eeed3d828a77b5145cd8abd5c8241109) adding use SilverStripe\Security\Member; to make sure linting works (Nicolaas)
+    * 2021-03-30 [44fae4497](https://github.com/silverstripe/silverstripe-framework/commit/44fae4497b3f141721ec144cded938cbfd081bea) Better describe the &amp;#039;keep me signed in&amp;#039; checkbox (André Kiste)
+    * 2021-03-23 [504e20320](https://github.com/silverstripe/silverstripe-framework/commit/504e20320e7a180ef88c817a73342eb8c1d78abf) Update DBBoolean.php (#9893) (Nicolaas)
+    * 2021-03-22 [daa9060c1](https://github.com/silverstripe/silverstripe-framework/commit/daa9060c1a5155e6686abe2186c1a0cf953ef977) remove unused class import Convert (Christopher Darling)
+    * 2021-03-22 [fc40e0b98](https://github.com/silverstripe/silverstripe-framework/commit/fc40e0b98a4342b08c35e970a4076ae757982198) Test that email is trimmed (Thomas Portelange)
+    * 2021-03-22 [22b2d58b5](https://github.com/silverstripe/silverstripe-framework/commit/22b2d58b5addb44b897c694001d2d475bfc62dd9) Update src/Security/Member.php (Thomas Portelange)
+    * 2021-03-19 [0586c55e6](https://github.com/silverstripe/silverstripe-framework/commit/0586c55e62c4a393bd9766fb63d1ff87da919067) prevent spaces in emails (Thomas Portelange)
+    * 2021-03-04 [9f9ff0151](https://github.com/silverstripe/silverstripe-framework/commit/9f9ff0151e6628e4a1abe42babaa6fcb7c8211b6) Update 02_cors.md (Joe Chenevey)
+    * 2021-02-16 [d023f4613](https://github.com/silverstripe/silverstripe-framework/commit/d023f461377bc71b0e82cfc18b6c0763494835b3) Update upgrading docs to refactoring (Aaron Carlino)
+    * 2021-02-09 [77ecbd854](https://github.com/silverstripe/silverstripe-framework/commit/77ecbd854dc8b0969e3e2b16880da056dab2d2fa) Updated TreeDropdownField.php documentation (Antony Thorpe)
+    * 2021-02-03 [8c2a9ba07](https://github.com/silverstripe/silverstripe-framework/commit/8c2a9ba07a5394c53f7c3a303be38e6692f94de0) Document edge case for non-assets install (Aaron Carlino)
+    * 2021-01-26 [452f50700](https://github.com/silverstripe/silverstripe-framework/commit/452f50700f7b5d2cf273297f218e4c37967040db) Update docs/en/05_Contributing/16_Maintainer_Guidelines.md (Serge Latyntsev)
+    * 2021-01-21 [d5eb3216b](https://github.com/silverstripe/silverstripe-framework/commit/d5eb3216b353d47b137ed69082f48c6c0bb8fc6c) Update docs/en/05_Contributing/16_Maintainer_Guidelines.md (Ingo Schommer)
+    * 2021-01-21 [7a1a1dc13](https://github.com/silverstripe/silverstripe-framework/commit/7a1a1dc132446425d1961e54a6484d22e3e72f82) Update index.md (Lars Prakken)
+    * 2021-01-21 [a2d7dd081](https://github.com/silverstripe/silverstripe-framework/commit/a2d7dd081d354c9becee2c11304ecde191eb76c2) Update build status badge (Steve Boyd)
+    * 2021-01-13 [fe2027e48](https://github.com/silverstripe/silverstripe-framework/commit/fe2027e4867bd0bf8d5df964f1b4cd47c9876378) PHPDoc in PEG parser (Ingo Schommer)
+    * 2020-11-27 [e908b68bf](https://github.com/silverstripe/silverstripe-framework/commit/e908b68bfa2f18aeb02587276472825ad0e29855) Revert &amp;quot;Update 09_Core_committers.md&amp;quot; (Scott Hutchinson)
+    * 2020-11-26 [ddd8e6da3](https://github.com/silverstripe/silverstripe-framework/commit/ddd8e6da313e95af677f2ba0b8e1c17431335410) Revert translation updates (Steve Boyd)
+    * 2020-11-25 [2a99b8295](https://github.com/silverstripe/silverstripe-framework/commit/2a99b8295cf9926163fa8a96880d3578ff3d87d8) Fixing links (Patrick Nelson)
+    * 2020-11-09 [1e87528fa](https://github.com/silverstripe/silverstripe-framework/commit/1e87528fa8216c41c99e8e05c38053f0b556edc9) Update 14_PHP_Coding_Conventions.md (Andrew Aitken-Fincham)
+    * 2020-11-09 [924d0ccb9](https://github.com/silverstripe/silverstripe-framework/commit/924d0ccb9ee8a616c4d88708155f28b9acd8370e) Link to the PHPCS standard used for framework (Andrew Aitken-Fincham)
+    * 2020-11-06 [37a5c9af1](https://github.com/silverstripe/silverstripe-framework/commit/37a5c9af1573debedc304f42381d6d22b956820e) 01_Error_Handling: % wrapped in quotes (James Cocker)
+    * 2020-10-22 [bc92b52c1](https://github.com/silverstripe/silverstripe-framework/commit/bc92b52c1cde5073d37ab544fce3f3dc98d25814) Remove useless requirement (Christophe Coevoet)
+    * 2020-08-17 [a43414ded](https://github.com/silverstripe/silverstripe-framework/commit/a43414dedbd746acc7906203b0c60b959785dc0e) Make sure GridState always outputs a JSON Object string (Maxime Rainville)
+    * 2020-07-08 [34f5004b2](https://github.com/silverstripe/silverstripe-framework/commit/34f5004b2662f06ba55fedbe9c9512c03ced02e1) Update 04_Rendering_Templates.md (scttw)
+
+ * silverstripe/admin (1.7.3 -&gt; 1.8.0-rc1)
+    * 2021-05-16 [bdc8576](https://github.com/silverstripe/silverstripe-admin/commit/bdc8576b2486fcdd73b1f4c36feee4aae8f7ebbd) Update translations (Steve Boyd)
+    * 2021-02-22 [1f17a3c](https://github.com/silverstripe/silverstripe-admin/commit/1f17a3cb386f65d16f37176faaf35a671cc74d85) BUGFIX: remove null request due to urls.reverse() (Aaron Carlino)
+    * 2021-02-19 [7b84013](https://github.com/silverstripe/silverstripe-admin/commit/7b840133e52ac7271914510cae474c231dde741a) BUGFIX: Incorrect fragment url (Aaron Carlino)
+    * 2021-02-17 [c4dc092](https://github.com/silverstripe/silverstripe-admin/commit/c4dc0928182190b643fd498ebd9e09a12e805288) BUGFIX: Replace GraphQL3 fragment urls, rely on legacy document state (Aaron Carlino)
+    * 2021-02-16 [5490584](https://github.com/silverstripe/silverstripe-admin/commit/5490584dc722bb60b6f2cfb64613767b575a10d4) Correct GraphQL admin types path (Ingo Schommer)
+    * 2021-01-27 [195b510](https://github.com/silverstripe/silverstripe-admin/commit/195b510ecb8a8cddf2022531cd94068df049e4ab) Compatibility with GraphQL 4 changes (Aaron Carlino)
+    * 2021-01-21 [a1498ac](https://github.com/silverstripe/silverstripe-admin/commit/a1498aca6b0f0c5f28187a4773a2b520aa53606d) Update build status badge (Steve Boyd)
+    * 2020-11-16 [13a1232](https://github.com/silverstripe/silverstripe-admin/commit/13a12327e822d4e1e1580f8ff30e024d1ad469d7) GraphQL BACKWARD_COMPAT flag fix (#1157) (Ingo Schommer)
+    * 2020-11-13 [9202c18](https://github.com/silverstripe/silverstripe-admin/commit/9202c182eea27b952546336a0e24c80b102d16ae) Move graphql legacy code to _legacy for PSR-4 compat (Aaron Carlino)
+
+ * silverstripe/asset-admin (1.7.1 -&gt; 1.8.0-rc1)
+    * 2021-05-16 [d56f0330](https://github.com/silverstripe/silverstripe-asset-admin/commit/d56f033088dcee34d9719478a795df91a68cb32d) Update translations (Steve Boyd)
+    * 2021-02-17 [d303bd90](https://github.com/silverstripe/silverstripe-asset-admin/commit/d303bd90411fff950d78eb2e3d2a03568e63f3e1) Linting (Aaron Carlino)
+    * 2021-02-16 [af73cf28](https://github.com/silverstripe/silverstripe-asset-admin/commit/af73cf28682c51d359ac3b42b60ee01cb9e99ed6) Remove redundant event handler (Aaron Carlino)
+    * 2021-02-16 [1d94a222](https://github.com/silverstripe/silverstripe-asset-admin/commit/1d94a222bb21327f451e7ccb4ec4b0b74ee69677) Reinstate GraphQL type transcriber config (Ingo Schommer)
+    * 2021-01-27 [c7472e29](https://github.com/silverstripe/silverstripe-asset-admin/commit/c7472e2931f76659ffabdcf8804d852218d1607a) Compatibility with GraphQL 4 changes (Aaron Carlino)
+    * 2021-01-21 [d1d76212](https://github.com/silverstripe/silverstripe-asset-admin/commit/d1d76212cf633e3fa8fc475fc5b5b6e08d47216b) Update build status badge (Steve Boyd)
+    * 2021-01-19 [1539dfef](https://github.com/silverstripe/silverstripe-asset-admin/commit/1539dfefb8945b87bfd7c883355f660b92178305) Compatibility with new context providers (Aaron Carlino)
+    * 2020-11-16 [4d09b012](https://github.com/silverstripe/silverstripe-asset-admin/commit/4d09b0120d2ef40752a72a6f24c74629193471f8) GraphQL BACKWARD_COMPAT flag fix (#1162) (Ingo Schommer)
+    * 2020-11-13 [3a96166a](https://github.com/silverstripe/silverstripe-asset-admin/commit/3a96166acea3b24f2602a794f6a2675ec05d10c7) Move graphql legacy code to _legacy for PSR-4 compat (Aaron Carlino)
+
+ * silverstripe/campaign-admin (1.7.1 -&gt; 1.8.0-rc1)
+    * 2021-05-16 [713a250](https://github.com/silverstripe/silverstripe-campaign-admin/commit/713a250826cf7222961b4bd90ce655840376c920) Update translations (Steve Boyd)
+    * 2021-03-18 [9c18955](https://github.com/silverstripe/silverstripe-campaign-admin/commit/9c18955b68f13ea7032a08f972b5e5703a24b4c8) BUGFIX: fix behat test (Aaron Carlino)
+    * 2021-01-21 [d16122f](https://github.com/silverstripe/silverstripe-campaign-admin/commit/d16122f55c267b90defc438ef6ee43bd14093f86) Update build status badge (Steve Boyd)
+
+ * silverstripe/versioned-admin (1.7.2 -&gt; 1.8.0-rc1)
+    * 2021-05-16 [066d9ac](https://github.com/silverstripe/silverstripe-versioned-admin/commit/066d9ac4112429c7061646a5ba32c23a73b244bf) Update translations (Steve Boyd)
+    * 2021-05-10 [84bba8b](https://github.com/silverstripe/silverstripe-versioned-admin/commit/84bba8be158efefd7de61b076731254f35a93a0b) Update composer.json (Maxime Rainville)
+    * 2021-01-21 [d941d44](https://github.com/silverstripe/silverstripe-versioned-admin/commit/d941d4491653b4026d282f5ded990dfe0605069d) Update build status badge (Steve Boyd)
+    * 2020-11-16 [e1ce901](https://github.com/silverstripe/silverstripe-versioned-admin/commit/e1ce901c49121a397778fb88eb72bf10f9c5ab93) GraphQL BACKWARD_COMPAT flag fix (Ingo Schommer)
+    * 2020-11-13 [cae464f](https://github.com/silverstripe/silverstripe-versioned-admin/commit/cae464fd25494e24d1e05d863c7bc1d4221d8d57) Allow graphql 4 (Aaron Carlino)
+    * 2020-08-26 [9b9e88a](https://github.com/silverstripe/silverstripe-versioned-admin/commit/9b9e88a5fbba61eb62e486dc44e4b05044e04f63) MINOR: Add tests for single-stage ArchiveAdmin (Sam Minnee)
+
+ * silverstripe/cms (4.7.1 -&gt; 4.8.0-rc1)
+    * 2021-05-16 [8c151627](https://github.com/silverstripe/silverstripe-cms/commit/8c1516270a59dd47b57406e7eb67069c8e35fbf1) Update translations (Steve Boyd)
+    * 2021-05-07 [67bfdf0f](https://github.com/silverstripe/silverstripe-cms/commit/67bfdf0ff1de0f4a0cb2f4be85c974c54b292415) BUGFIX: Ensure SiteTree is always available in the CMS, along with ancestors (Aaron Carlino)
+    * 2021-01-21 [f9b6d582](https://github.com/silverstripe/silverstripe-cms/commit/f9b6d582956e6052c4cdc0a65df20459ab86fcb6) Update build status badge (Steve Boyd)
+    * 2020-12-08 [e22fda3f](https://github.com/silverstripe/silverstripe-cms/commit/e22fda3fed9ff677607bb477a4e5c3edd301cfc1) Remove duplicate injector entry (Aaron Carlino)
+    * 2020-12-07 [e415d418](https://github.com/silverstripe/silverstripe-cms/commit/e415d41856d4b201fa9f9651dac8fc225447afef) BUGFIX: Restore, refactor getByLink plugin (Aaron Carlino)
+    * 2020-11-13 [ee3e51e5](https://github.com/silverstripe/silverstripe-cms/commit/ee3e51e5e51cf3ad8a104b1c331c1a0d7490c982) Move graphql legacy code to _legacy for PSR-4 compat (Aaron Carlino)
+
+ * silverstripe/errorpage (1.7.0 -&gt; 1.8.0-rc1)
+    * 2021-05-16 [e004bd5](https://github.com/silverstripe/silverstripe-errorpage/commit/e004bd582198f8b04bbf6402f8ce86c99e03104f) Update translations (Steve Boyd)
+    * 2021-01-21 [dbf8d18](https://github.com/silverstripe/silverstripe-errorpage/commit/dbf8d189cfdbbd48ee4d649e20df52259d11fa69) Update build status badge (Steve Boyd)
+
+ * silverstripe/reports (4.7.0 -&gt; 4.8.0-rc1)
+    * 2021-05-16 [27288dc5](https://github.com/silverstripe/silverstripe-reports/commit/27288dc50864c5a5f6f5fbd2cc52f781101dfa06) Update translations (Steve Boyd)
+    * 2021-01-21 [e101f1e0](https://github.com/silverstripe/silverstripe-reports/commit/e101f1e0341935001b86568542f65d3de557a5d8) Update build status badge (Steve Boyd)
+
+ * silverstripe/siteconfig (4.7.0 -&gt; 4.8.0-rc1)
+    * 2021-05-16 [1656cfb8](https://github.com/silverstripe/silverstripe-siteconfig/commit/1656cfb86f28791a07e6792865291eed10fe5786) Update translations (Steve Boyd)
+    * 2021-01-21 [1ff64fcd](https://github.com/silverstripe/silverstripe-siteconfig/commit/1ff64fcdb838ea524c191f5968e1a2353925361f) Update build status badge (Steve Boyd)
+
+ * silverstripe/versioned (1.7.2 -&gt; 1.8.0-rc1)
+    * 2021-05-16 [afa9e64](https://github.com/silverstripe/silverstripe-versioned/commit/afa9e64f81c03dc41b8a599bcce095d0fda83099) Update translations (Steve Boyd)
+    * 2021-03-15 [41ff068](https://github.com/silverstripe/silverstripe-versioned/commit/41ff06867649194a9b3c59e21b3c95d646b17e1d) MINOR: fix incorrect variable (Aaron Carlino)
+    * 2021-03-12 [a566639](https://github.com/silverstripe/silverstripe-versioned/commit/a566639741662e3e475d77e085fb45bd31fb3c18) MINOR: applyToReadingState should not throw. Allow graceful failure to make implementation simpler (resolveVersionedRead) (#329) (Aaron Carlino)
+    * 2021-03-11 [f0701e5](https://github.com/silverstripe/silverstripe-versioned/commit/f0701e5eaa9aa968d6047a2514973ff5aca3ca2f) BUGFIX: replace versions pagination, sort to fix versioned-admin (#326) (Aaron Carlino)
+    * 2021-02-17 [9e451a2](https://github.com/silverstripe/silverstripe-versioned/commit/9e451a20b26273bf7b15a5204f72cb6f3b3308e2) BUGFIX: use correct createStorableSchema method (Aaron Carlino)
+    * 2021-02-15 [821494e](https://github.com/silverstripe/silverstripe-versioned/commit/821494e085e6b90d1985ce88aac3208c8182b2d4) Apply versioning only to reading state, and not to nested queries anymore (Aaron Carlino)
+    * 2021-01-27 [b6cab40](https://github.com/silverstripe/silverstripe-versioned/commit/b6cab4040cdfb6e2676d97aa115a539f23e99150) Compatibility with GraphQL 4 changes (Aaron Carlino)
+    * 2021-01-21 [fbe05df](https://github.com/silverstripe/silverstripe-versioned/commit/fbe05dfc2ce9b2ef94d1c85803ab71b9f8e4042e) Update README.md (Steve Boyd)
+    * 2021-01-19 [ebb4c8f](https://github.com/silverstripe/silverstripe-versioned/commit/ebb4c8f3b75481fbd8067116f38561a81f29e5d9) Compatibility with new context providers (Aaron Carlino)
+    * 2020-12-02 [33a5e56](https://github.com/silverstripe/silverstripe-versioned/commit/33a5e56150e69cb55a83209b0cc3615aee2659a1) Get tests passing (Aaron Carlino)
+    * 2020-12-02 [b7aad04](https://github.com/silverstripe/silverstripe-versioned/commit/b7aad04d0709ed5c49d3349b433da39b20885475) BUGFIX: move modelConfig to correct location (Aaron Carlino)
+    * 2020-11-16 [fbd9637](https://github.com/silverstripe/silverstripe-versioned/commit/fbd96379357448a6a44307242abeae54ffba10a3) Fixed implicit GraphQL dependency (#312) (Ingo Schommer)
+    * 2020-11-16 [dd5a031](https://github.com/silverstripe/silverstripe-versioned/commit/dd5a0319e77d81c90a060e2224c0e304f4ff18eb) Check existence of ResolveInfo (Aaron Carlino)
+    * 2020-11-15 [6404194](https://github.com/silverstripe/silverstripe-versioned/commit/6404194544ac91743b48370b20d59a3941c266e5) Remove classmap (Aaron Carlino)
+    * 2020-11-13 [d3b7709](https://github.com/silverstripe/silverstripe-versioned/commit/d3b7709dbafea3227277929f5f52ce2b33238600) Move graphql legacy code to _legacy for PSR-4 compat (Aaron Carlino)
+
+ * silverstripe/graphql (3.4.1 -&gt; 3.5.0-rc1)
+    * 2021-01-21 [2f000b6](https://github.com/silverstripe/silverstripe-graphql/commit/2f000b61c22f41bd1b887749ad8f26fc4c589332) Update build status badge (Steve Boyd)
+    * 2020-12-10 [c1db445](https://github.com/silverstripe/silverstripe-graphql/commit/c1db44582bc5fe864a5df9f0236f15625fffe165) Removed non-functional scrutinizer badge (Ingo Schommer)
+
+ * silverstripe/login-forms (4.3.0 -&gt; 4.4.1)
+    * 2021-04-13 [370c3ca](https://github.com/silverstripe/silverstripe-login-forms/commit/370c3ca0f87261c0807d4851766dee116ea008bd) Display tooltip when title is set (André Kiste)
+    * 2021-04-13 [4554bc5](https://github.com/silverstripe/silverstripe-login-forms/commit/4554bc5712ba9af5e747cde37aff594967002737) • Move attribute to login-forms (André Kiste)
+    * 2021-04-12 [a73d0e7](https://github.com/silverstripe/silverstripe-login-forms/commit/a73d0e7caecfbeacf860b7d889e4d3c71a9c0e0e) Move bootstrap to npm (André Kiste)
+    * 2021-04-08 [51432f9](https://github.com/silverstripe/silverstripe-login-forms/commit/51432f92cb045d4ed632472433ee2f8924ca458e) Use new designs (André Kiste)
+    * 2021-03-30 [effb664](https://github.com/silverstripe/silverstripe-login-forms/commit/effb664f46e66d5417203c46218e0726159687c9) Better describe the &amp;#039;keep me signed in&amp;#039; option (André Kiste)
+    * 2021-01-21 [f38beb9](https://github.com/silverstripe/silverstripe-login-forms/commit/f38beb964af88a277bec05f5a57da39c726e4541) Update build status badge (Steve Boyd)
+    * 2020-11-06 [127532c](https://github.com/silverstripe/silverstripe-login-forms/commit/127532cdf67e21d6ff6ba492717dc849f55add4c) Setting form max width (Michael Nowina-Krowicki)
+
+    
+
+<!--- Changes above this line will be automatically regenerated -->

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -173,7 +173,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
         /** @var DBDatetime $now */
         $now = null;
         if (self::$mock_now) {
-            $now = self::$mock_now;
+            $now = DBField::create_field('Datetime', self::$mock_now->Value);
         } else {
             $now = DBField::create_field('Datetime', time());
         }


### PR DESCRIPTION
<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
`Datetime::now()` currently returns a reference to `self::$mock_now` if a mock time has been set. This means that if one calls `Datetime::now()->Modify(...)` the next time `Datetime::now()` is called it will return the modified datetime rather than the original. This PR has `Datetime::now()` return a defensive copy of `self::$mock_now` so that the mock time cannot be accidentally modified and can only be changed via `Datetime::set_mock_now()`
