### PR TITLE
FIX Defensively copy mocked datetime

### DIFF
--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -173,7 +173,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
         /** @var DBDatetime $now */
         $now = null;
         if (self::$mock_now) {
-            $now = self::$mock_now;
+            $now = DBField::create_field('Datetime', self::$mock_now->Value);
         } else {
             $now = DBField::create_field('Datetime', time());
         }


### PR DESCRIPTION
`Datetime::now()` currently returns a reference to `self::$mock_now` if a mock time has been set. This means that if one calls `Datetime::now()->Modify(...)` the next time `Datetime::now()` is called it will return the modified datetime rather than the original. This PR has `Datetime::now()` return a defensive copy of `self::$mock_now` so that the mock time cannot be accidentally modified and can only be changed via `Datetime::set_mock_now()`
