### PR TITLE
FIX BASE_PATH fallback assumed wrong file location

### DIFF
--- a/src/includes/constants.php
+++ b/src/includes/constants.php
@@ -58,9 +58,10 @@ if (!defined('BASE_PATH')) {
             }
         }
 
-        // Determine BASE_PATH by assuming that this file is framework/src/Core/Constants.php
-        //  we can then determine the base path
-        $candidateBasePath = rtrim(dirname(dirname(dirname(__DIR__))), DIRECTORY_SEPARATOR);
+        // Determine BASE_PATH by assuming that this file is vendor/silverstripe/framework/src/includes/constants.php
+        // we can then determine the base path
+        $candidateBasePath = rtrim(dirname(__DIR__, 5), DIRECTORY_SEPARATOR);
+
         // We can't have an empty BASE_PATH.  Making it / means that double-slashes occur in places but that's benign.
         // This likely only happens on chrooted environemnts
         return $candidateBasePath ?: DIRECTORY_SEPARATOR;


### PR DESCRIPTION
The file was moved back in 2017 with https://github.com/silverstripe/silverstripe-framework/commit/3873e4ba008cfc2af7e26ca86665affc289cd677#diff-8ce3f007bef0668c2c08320160362229abce9614025dc2a5b729d1b2b56ed3f7,
but the logic wasn't updated. That wasn't apparent since the fallback usually doesn't need to be triggered.
Whenever constants.php is included through the standard composer autoload, the debug_backtrace() logic took priority.

This is an important piece for using CoreKernel directly to boot Silverstripe,
which I'm currently attempting through a composer plugin (so a different autoloading path).
https://github.com/silverstripe/silverstripe-graphql-composer-plugin, context at https://github.com/silverstripe/silverstripe-graphql/issues/388

PR against minor release branch because its a bugfix, and we might rely on this being present in a 4.8.1 release for the composer graphql plugin rollout to early adopters.