### PR TITLE
Reduce calls to Cache creation for class manifest

### DIFF
--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -210,13 +210,13 @@ class ClassManifest
      */
     public function getManifestTimestamp($includeTests = false)
     {
-        $cache = $this->buildCache($includeTests);
+        $this->cache = $this->buildCache($includeTests);
 
-        if (!$cache) {
+        if (!$this->cache) {
             return null;
         }
 
-        return $cache->get('generated_at');
+        return $this->cache->get('generated_at');
     }
 
     /**
@@ -224,13 +224,13 @@ class ClassManifest
      */
     public function scheduleFlush($includeTests = false)
     {
-        $cache = $this->buildCache($includeTests);
+        $this->cache = $this->buildCache($includeTests);
 
-        if (!$cache) {
+        if (!$this->cache) {
             return null;
         }
 
-        $cache->set('regenerate', true);
+        $this->cache->set('regenerate', true);
     }
 
     /**
@@ -238,13 +238,13 @@ class ClassManifest
      */
     public function isFlushScheduled($includeTests = false)
     {
-        $cache = $this->buildCache($includeTests);
+        $this->cache = $this->buildCache($includeTests);
 
-        if (!$cache) {
+        if (!$this->cache) {
             return null;
         }
 
-        return $cache->get('regenerate');
+        return $this->cache->get('regenerate');
     }
 
     /**


### PR DESCRIPTION
## Overview

Reduce calls to ClassManifest's cache factory `create` by using existing private cache.

### Changes

 - Update methods using classmanifest cache to save results to `$this->cache`.

### Normal requests to application via HTTP requests creates cache multiple times.

1. **HTTP Application checks for flush.**

`HTTPApplication->handle` method calls `shouldFlush` through the flush discoverer. This ends up calling `scheduleFlush` on `ClassManifest` which does not utilize the private class cache `$this->cache`. This causes the creation of a cache (which is expected during the first call to `buildCache`, however the result is never saved to `$this->cache`.

1. **Kernel boot generates classmanifest through `init`**

`CoreKernel->bootManifest` method calls `init` directory on `ClassManifest`. This method also uses `buildCache`, however as the previously call did not cache the results, it is generated again and stored to `$this->cache`.



