### PR TITLE
BUG subTemplates should be an array

### DIFF
--- a/src/View/SSViewer.php
+++ b/src/View/SSViewer.php
@@ -167,7 +167,7 @@ class SSViewer implements Flushable
      *
      * @var array
      */
-    protected $subTemplates = null;
+    protected $subTemplates = [];
 
     /**
      * @var bool


### PR DESCRIPTION
See `SSViewer::templates()`and `SSViewer::setTemplateFile()` 

Methods assume this variable should be an array. If you call `setTemplateFile()` directly prior / instead of any `setTemplate` call then a PHP warning is generated `[Warning] array_merge(): Expected parameter 2 to be an array, null given`