### PR TITLE
ENH Provide onBeforeRenderHolder extension hook in GridField.

### DIFF
--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -438,6 +438,8 @@ class GridField extends FormField
      */
     public function FieldHolder($properties = [])
     {
+        $this->extend('onBeforeRenderHolder', $this, $properties);
+        
         $columns = $this->getColumns();
 
         $list = $this->getManipulatedList();


### PR DESCRIPTION
GridField has onBeforeRender in its Field method, but that hardly ever gets called.
This commit adds the onBeforeRenderHolder extension hook that is normally available via FormField::FieldHolder().