### PR TITLE
FIX Cache duplicate embeds separately

### DIFF
--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -61,9 +61,13 @@ class EmbedShortcodeProvider implements ShortcodeHandler
             return '';
         }
 
+        $class = $arguments['class'] ?? '';
+        $width = $arguments['width'] ?? '';
+        $height = $arguments['height'] ?? '';
+
         // Try to use cached result
         $cache = static::getCache();
-        $key = static::deriveCacheKey($serviceURL);
+        $key = static::deriveCacheKey($serviceURL, $class, $width, $height);
         try {
             if ($cache->has($key)) {
                 return $cache->get($key);
@@ -273,11 +277,14 @@ class EmbedShortcodeProvider implements ShortcodeHandler
             if (!isset($tag['open']) || $tag['open'] != 'embed') {
                 continue;
             }
-            $url = $tag['content'] ?? $tag['attrs']['url'] ?? null;
+            $url = $tag['content'] ?? $tag['attrs']['url'] ?? '';
+            $class = $tag['attrs']['class'] ?? '';
+            $width = $tag['attrs']['width'] ?? '';
+            $height = $tag['attrs']['height'] ?? '';
             if (!$url) {
                 continue;
             }
-            $key = static::deriveCacheKey($url);
+            $key = static::deriveCacheKey($url, $class, $width, $height);
             try {
                 if (!$cache->has($key)) {
                     continue;
@@ -301,9 +308,23 @@ class EmbedShortcodeProvider implements ShortcodeHandler
      * @param string $url
      * @return string
      */
-    private static function deriveCacheKey(string $url): string
+    private static function deriveCacheKey(string $url, string $class, string $width, string $height): string
     {
-        $key = 'embed-shortcode-' . preg_replace('/[^a-zA-Z0-9\-]/', '', $url);
-        return $key;
+        return implode('-', array_filter([
+            'embed-shortcode',
+            self::cleanKeySegment($url),
+            self::cleanKeySegment($class),
+            self::cleanKeySegment($width),
+            self::cleanKeySegment($height)
+        ]));
+    }
+
+    /**
+     * @param string $str
+     * @return string
+     */
+    private static function cleanKeySegment(string $str): string
+    {
+        return preg_replace('/[^a-zA-Z0-9\-]/', '', $str);
     }
 }

--- a/tests/php/View/Shortcodes/EmbedShortcodeProviderTest.php
+++ b/tests/php/View/Shortcodes/EmbedShortcodeProviderTest.php
@@ -139,10 +139,13 @@ EOS
         $cache = $method->invokeArgs($provider, []);
         $method = $reflector->getMethod('deriveCacheKey');
         $method->setAccessible(true);
-        $key = $method->invokeArgs($provider, [$url]);
+        $class = 'leftAlone ss-htmleditorfield-file embed';
+        $width = '480';
+        $height = '270';
+        $key = $method->invokeArgs($provider, [$url, $class, $width, $height]);
 
         // assertions
-        $this->assertEquals('embed-shortcode-httpwwwtest-servicecomabc123', $key);
+        $this->assertEquals('embed-shortcode-httpwwwtest-servicecomabc123-leftAloness-htmleditorfield-fileembed-480-270', $key);
         $cache->set($key, $embedHtml);
         $this->assertTrue($cache->has($key));
         EmbedShortcodeProvider::flushCachedShortcodes($parser, $content);


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/1199

Note: while 'caption' is part of the shortcode, its HTML is rendered separately from the rest of the embed and is not cached, so no need to add it to the cache key

Unit tests are expected to fail - it's because the .travis file in framework will run some cms tests - this corresponding PR should be merged after this PR https://github.com/silverstripe/silverstripe-cms/pull/2672