### PR TITLE
ENH Use text field's title for validation messages.

### DIFF
--- a/src/Forms/TextField.php
+++ b/src/Forms/TextField.php
@@ -142,12 +142,13 @@ class TextField extends FormField implements TippableFieldInterface
     public function validate($validator)
     {
         if (!is_null($this->maxLength) && mb_strlen($this->value) > $this->maxLength) {
+            $name = strip_tags($this->Title() ? $this->Title() : $this->getName());
             $validator->validationError(
                 $this->name,
                 _t(
                     'SilverStripe\\Forms\\TextField.VALIDATEMAXLENGTH',
                     'The value for {name} must not exceed {maxLength} characters in length',
-                    ['name' => $this->getName(), 'maxLength' => $this->maxLength]
+                    ['name' => $name, 'maxLength' => $this->maxLength]
                 ),
                 "validation"
             );


### PR DESCRIPTION
Where a field has a title, this is preferred over the field name in validation messages, as that is the "name" of the field as presented to the user.