### PR TITLE
FIX Parse Enums with dots in their values

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3150,7 +3150,10 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
             return $value;
         }
 
-        list($class, $spec) = explode('.', $helper);
+        $pos = strpos($helper, '.');
+        $class = substr($helper, 0, $pos);
+        $spec = substr($helper, $pos + 1);
+
         /** @var DBField $obj */
         $table = $schema->tableName($class);
         $obj = Injector::inst()->create($spec, $fieldName);

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -2622,4 +2622,15 @@ class DataObjectTest extends SapphireTest
             'Salary' => 50,
         ], DataObject::CREATE_HYDRATED);
     }
+
+    public function testDBObjectEnum()
+    {
+        $obj = new DataObjectTest\Fixture();
+        // enums are parsed correctly
+        $vals = ['25', '50', '75', '100'];
+        $this->assertSame(array_combine($vals, $vals), $obj->dbObject('MyEnum')->enumValues());
+        // enum with dots in their values are also parsed correctly
+        $vals = ['25.25', '50.00', '75.00', '100.50'];
+        $this->assertSame(array_combine($vals, $vals), $obj->dbObject('MyEnumWithDots')->enumValues());
+    }
 }

--- a/tests/php/ORM/DataObjectTest/Fixture.php
+++ b/tests/php/ORM/DataObjectTest/Fixture.php
@@ -25,6 +25,10 @@ class Fixture extends DataObject implements TestOnly
         'MyInt' => 'Int',
         'MyCurrency' => 'Currency',
         'MyDecimal'=> 'Decimal',
+
+        // Enums
+        'MyEnum' => 'Enum("25,50,75,100", "50")',
+        'MyEnumWithDots' => 'Enum("25.25,50.00,75.00,100.50", "50.00")',
     ];
 
     private static $defaults = [


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10000

Issue was that `$helper` would be `MyDataObject.Enum("25.25,50.00,75.00,100.50", "50.00")` and `explode('.', $helper)` would break it up into more than two pieces
