### PR TITLE
MNT Update unit test to expect loading attribute

### DIFF
--- a/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
@@ -180,7 +180,7 @@ class HTMLEditorFieldTest extends FunctionalTest
         $this->assertEquals(
             <<<EOS
 <span class="readonly typography" id="Content">
-	<img src="/assets/HTMLEditorFieldTest/f5c7c2f814/example__ResizedImageWzEwLDIwXQ.jpg" alt="" width="10" height="20">
+	<img src="/assets/HTMLEditorFieldTest/f5c7c2f814/example__ResizedImageWzEwLDIwXQ.jpg" alt="" width="10" height="20" loading="lazy">
 </span>
 
 
@@ -197,7 +197,7 @@ EOS
         $this->assertEquals(
             <<<EOS
 <span class="readonly typography" id="Content">
-	<img src="/assets/HTMLEditorFieldTest/f5c7c2f814/example__ResizedImageWzEwLDIwXQ.jpg" alt="" width="10" height="20">
+	<img src="/assets/HTMLEditorFieldTest/f5c7c2f814/example__ResizedImageWzEwLDIwXQ.jpg" alt="" width="10" height="20" loading="lazy">
 </span>
 
 	<input type="hidden" name="Content" value="[image src=&quot;/assets/HTMLEditorFieldTest/f5c7c2f814/example.jpg&quot; width=&quot;10&quot; height=&quot;20&quot; id=&quot;{$fileID}&quot;]" />


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10010

Note: One of the AC's on https://github.com/silverstripe/silverstripe-assets/issues/451 was `Ensure that when the image is loading in the CMS the image does not have the loading attribute`

The intention with that AC was to ensure images were always loaded when scroll down the editor for a better UX experience for content editors.  The benefits of lazy-loading such as SEO and saving mobile bandwidth aren't so relevant in a CMS editing context, so eager loading is generally going to be better

The readonly transformation is only for non-wysiwyg scenarios.  I'm not actually sure what these are.  The page history viewer will show the raw database value which is the shortcode, not the transformed HTML

The alternative to just updating the unit test would be to do something like the following in `HTMLEditorField_Readonly.php` (untested)

```php
public function getValue()
{
  return Config::withConfig(function () {
    Config::modify()->set(Image::class, 'lazy_loading_enabled', false);
    return $this->getValue();
  });
}
```

This doesn't seem like a particularly great thing to do

The downsides of lazy loading images are very small, and given I'm not even sure if the readonly HTMLEditor is used, I think we should just update the unit test
