### PR TITLE
ensure setCurrentUser gets a valid object

### DIFF
--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -440,7 +440,7 @@ class Security extends Controller implements TemplateGlobalProvider
     /**
      * @param null|Member $currentUser
      */
-    public static function setCurrentUser($currentUser = null)
+    public static function setCurrentUser(Member $currentUser = null)
     {
         self::$currentUser = $currentUser;
     }


### PR DESCRIPTION
Just ran into this recently, otherwise you could do something stupid like i did like Security::setCurrentUser('admin') and don't notice.