### PR TITLE
switch to standard X-Forwarded-Proto instead of X-Forwarded-Protocol

### DIFF
--- a/docs/en/02_Developer_Guides/08_Performance/02_HTTP_Cache_Headers.md
+++ b/docs/en/02_Developer_Guides/08_Performance/02_HTTP_Cache_Headers.md
@@ -221,7 +221,7 @@ when calculating a cache key, usually in addition to the full URL.
 By default, SilverStripe will output a `Vary` header with the following content: 
 
 ```
-Vary: X-Forwarded-Protocol
+Vary: X-Forwarded-Proto
 ```
 
 To change the value of the `Vary` header, you can change this value by specifying the header in configuration.

--- a/docs/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
+++ b/docs/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
@@ -696,14 +696,14 @@ TrustedProxyMiddleware service:
 SilverStripe\Control\TrustedProxyMiddleware:
   properties:
     ProxyHostHeaders: X-Forwarded-Host
-    ProxySchemeHeaders: X-Forwarded-Protocol
+    ProxySchemeHeaders: X-Forwarded-Proto
     ProxyIPHeaders: X-Forwarded-Ip
 ```
 
 ```
 SS_TRUSTED_PROXY_HOST_HEADER="HTTP_X_FORWARDED_HOST"
 SS_TRUSTED_PROXY_IP_HEADER="HTTP_X_FORWARDED_FOR"
-SS_TRUSTED_PROXY_PROTOCOL_HEADER="HTTP_X_FORWARDED_PROTOCOL"
+SS_TRUSTED_PROXY_PROTOCOL_HEADER="HTTP_X_FORWARDED_PROTO"
 ```
 
 At the same time, you'll also need to define which headers you trust from these proxy IPs. Since there are multiple ways through which proxies can pass through HTTP information on the original hostname, IP and protocol, these values need to be adjusted for your specific proxy. The header names match their equivalent `$_SERVER` values.

--- a/src/Control/Middleware/HTTPCacheControlMiddleware.php
+++ b/src/Control/Middleware/HTTPCacheControlMiddleware.php
@@ -136,7 +136,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @var array
      */
     private static $defaultVary = [
-        "X-Forwarded-Protocol" => true,
+        "X-Forwarded-Proto" => true,
     ];
 
     /**

--- a/tests/php/Control/DirectorTest.php
+++ b/tests/php/Control/DirectorTest.php
@@ -757,11 +757,11 @@ class DirectorTest extends SapphireTest
 
         // nothing available
         $headers = [
-            'HTTP_X_FORWARDED_PROTOCOL', 'HTTPS', 'SSL'
+            'HTTP_X_FORWARDED_PROTO', 'HTTPS', 'SSL'
         ];
         foreach ($headers as $header) {
             if (isset($_SERVER[$header])) {
-                unset($_SERVER['HTTP_X_FORWARDED_PROTOCOL']);
+                unset($_SERVER['HTTP_X_FORWARDED_PROTO']);
             }
         }
 
@@ -778,7 +778,7 @@ class DirectorTest extends SapphireTest
                 null,
                 null,
                 null,
-                ['X-Forwarded-Protocol' => 'https']
+                ['X-Forwarded-Proto' => 'https']
             )->getBody()
         );
 
@@ -790,7 +790,7 @@ class DirectorTest extends SapphireTest
                 null,
                 null,
                 null,
-                ['X-Forwarded-Protocol' => 'http']
+                ['X-Forwarded-Proto' => 'http']
             )->getBody()
         );
 
@@ -802,7 +802,7 @@ class DirectorTest extends SapphireTest
                 null,
                 null,
                 null,
-                ['X-Forwarded-Protocol' => 'ftp']
+                ['X-Forwarded-Proto' => 'ftp']
             )->getBody()
         );
 

--- a/tests/php/Control/HTTPTest.php
+++ b/tests/php/Control/HTTPTest.php
@@ -88,12 +88,12 @@ class HTTPTest extends FunctionalTest
         $response = new HTTPResponse($body, 200);
         HTTPCacheControlMiddleware::singleton()
             ->setMaxAge(30)
-            ->setVary('X-Requested-With, X-Forwarded-Protocol');
+            ->setVary('X-Requested-With, X-Forwarded-Proto');
         $this->addCacheHeaders($response);
 
         // Vary set properly
         $v = $response->getHeader('Vary');
-        $this->assertContains("X-Forwarded-Protocol", $v);
+        $this->assertContains("X-Forwarded-Proto", $v);
         $this->assertContains("X-Requested-With", $v);
         $this->assertNotContains("Cookie", $v);
         $this->assertNotContains("User-Agent", $v);


### PR DESCRIPTION
Silverstripe currently uses the non-standard X-Forwarded-Protocol header. This PR changes that to X-Forwarded-Proto.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto.