### PR TITLE
destroy session on logout instead of restarting it

### DIFF
--- a/src/Security/MemberAuthenticator/SessionAuthenticationHandler.php
+++ b/src/Security/MemberAuthenticator/SessionAuthenticationHandler.php
@@ -112,6 +112,6 @@ class SessionAuthenticationHandler implements AuthenticationHandler
     public function logOut(HTTPRequest $request = null)
     {
         $request = $request ?: Controller::curr()->getRequest();
-        $request->getSession()->restart($request);
+        $request->getSession()->destroy();
     }
 }


### PR DESCRIPTION
IMHO there is no reason to keep the session around after logout? When you visit a public page the session is not started either, so there is no reason to keep a session around after logout.