### PR TITLE
Update SwiftMailer from v5 to v6

### DIFF
--- a/_config/email.yml
+++ b/_config/email.yml
@@ -2,7 +2,7 @@
 Name: emailconfig
 ---
 SilverStripe\Core\Injector\Injector:
-  Swift_Transport: Swift_MailTransport
+  Swift_Transport: Swift_SendmailTransport
   Swift_Mailer:
     constructor:
       - '%$Swift_Transport'

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "silverstripe/assets": "^1@dev",
         "silverstripe/vendor-plugin": "^1.4",
         "sminnee/callbacklist": "^0.1",
-        "swiftmailer/swiftmailer": "~5.4",
+        "swiftmailer/swiftmailer": "^6.2",
         "symfony/cache": "^3.3 || ^4",
         "symfony/config": "^3.2 || ^4",
         "symfony/translation": "^2.8 || ^3 || ^4",

--- a/docs/en/02_Developer_Guides/10_Email/index.md
+++ b/docs/en/02_Developer_Guides/10_Email/index.md
@@ -14,7 +14,7 @@ covers how to create an `Email` instance, customise it with a HTML template, the
 SilverStripe provides an API over the top of the [SwiftMailer](http://swiftmailer.org/) PHP library which comes with an
 extensive list of "transports" for sending mail via different services. 
 
-Out of the box, SilverStripe will use the built-in PHP `mail()` command via the `Swift_MailTransport` class. If you'd
+Out of the box, SilverStripe will use the built-in PHP `mail()` command via the `Swift_SendmailTransport` class. If you'd
 like to use a more robust transport to send mail you can swap out the transport used by the `Mailer` via config:
 
 ```yml

--- a/src/Control/Email/Email.php
+++ b/src/Control/Email/Email.php
@@ -2,12 +2,14 @@
 
 namespace SilverStripe\Control\Email;
 
+use DateTime;
+use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\RFCValidation;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTP;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\View\Requirements;
@@ -99,7 +101,8 @@ class Email extends ViewableData
      */
     public static function is_valid_address($address)
     {
-        return \Swift_Validate::email($address);
+        $validator = new EmailValidator();
+        return $validator->isValid($address, new RFCValidation());
     }
 
     /**
@@ -269,7 +272,7 @@ class Email extends ViewableData
      */
     public function setSwiftMessage($swiftMessage)
     {
-        $swiftMessage->setDate(DBDatetime::now()->getTimestamp());
+        $swiftMessage->setDate(new DateTime());
         if (!$swiftMessage->getFrom() && ($defaultFrom = $this->config()->get('admin_email'))) {
             $swiftMessage->setFrom($defaultFrom);
         }
@@ -610,7 +613,7 @@ class Email extends ViewableData
         }
 
         $this->invalidateBody();
-        
+
         return $this;
     }
 

--- a/src/Control/Email/SwiftPlugin.php
+++ b/src/Control/Email/SwiftPlugin.php
@@ -40,7 +40,7 @@ class SwiftPlugin implements \Swift_Events_SendListener
     }
 
     /**
-     * @param \Swift_Mime_Message $message
+     * @param \Swift_Mime_SimpleMessage $message
      * @param array|string $to
      */
     protected function setTo($message, $to)
@@ -62,7 +62,7 @@ class SwiftPlugin implements \Swift_Events_SendListener
     }
 
     /**
-     * @param \Swift_Mime_Message $message
+     * @param \Swift_Mime_SimpleMessage $message
      * @param array|string $from
      */
     protected function setFrom($message, $from)

--- a/tests/php/Control/Email/EmailTest.php
+++ b/tests/php/Control/Email/EmailTest.php
@@ -269,9 +269,11 @@ class EmailTest extends SapphireTest
         $email = new Email();
         $swiftMessage = new Swift_Message();
         $email->setSwiftMessage($swiftMessage);
+        // When swiftmessage is created, it uses DateTime() to set the date, which does not implement mock_now
+        $email->getSwiftMessage()->setDate(new \DateTime(DBDatetime::now()));
         $this->assertCount(1, $email->getFrom());
         $this->assertContains('admin@example.com', array_keys($swiftMessage->getFrom()));
-        $this->assertEquals(strtotime('2017-01-01 07:00:00'), $swiftMessage->getDate());
+        $this->assertEquals(strtotime('2017-01-01 07:00:00'), $swiftMessage->getDate()->getTimestamp());
         $this->assertEquals($swiftMessage, $email->getSwiftMessage());
 
         // check from field is retained

--- a/tests/php/Control/Email/SwiftMailerTest.php
+++ b/tests/php/Control/Email/SwiftMailerTest.php
@@ -6,7 +6,8 @@ use SilverStripe\Control\Email\Email;
 use SilverStripe\Control\Email\SwiftMailer;
 use SilverStripe\Dev\SapphireTest;
 use Swift_Mailer;
-use Swift_MailTransport;
+use Swift_Mime_SimpleMessage;
+use Swift_SendmailTransport;
 use Swift_Message;
 use Swift_NullTransport;
 use Swift_Plugins_AntiFloodPlugin;
@@ -23,8 +24,8 @@ class SwiftMailerTest extends SapphireTest
         SwiftMailer::config()->remove('swift_plugins');
         SwiftMailer::config()->update('swift_plugins', [Swift_Plugins_AntiFloodPlugin::class]);
 
-        /** @var Swift_MailTransport $transport */
-        $transport = $this->getMockBuilder(Swift_MailTransport::class)->getMock();
+        /** @var Swift_SendmailTransport $transport */
+        $transport = $this->getMockBuilder(Swift_SendmailTransport::class)->getMock();
         $transport
             ->expects($this->once())
             ->method('registerPlugin')
@@ -55,7 +56,7 @@ class SwiftMailerTest extends SapphireTest
             ->setMethods(['sendSwift'])
             ->getMock();
         $mailer->expects($this->once())->method('sendSwift')->with(
-            $this->isInstanceOf(Swift_Message::class)
+            $this->isInstanceOf(Swift_Mime_SimpleMessage::class)
         );
 
         $mailer->send($email);


### PR DESCRIPTION
Parent issue https://github.com/silverstripe/silverstripe-framework/issues/9834

## Issues addressed

- #9834
- #9796
- #9801

We noticed issues with SwiftMailer v5 and encrypted file attachments. We implemented a fork successfully with our (WIP) SMIME encryption module.

## Configuration updates

Default `Swift_Transport` changed from `Swift_MailTransport` to `Swift_SendmailTransport`. No configuration changes are required in project code—it is assumed that any variation on configuration in the affected area is by using an alternative SwiftMailer transport class (eg, `Swift_SmtpTransport`) which does not use a new classname. The docs have been updated to reflect this change.

## Release version

Since this is a major version change for Swiftmailer and includes a configuration update, I would suggest this to be a minor release.

## Deprecation notes

I did not find any additional deprecation notices across PHP 7.4 and 7.3, and will rely on CI to catch other notices.

