### PR TITLE
API Add an AttributesHTML trait

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -20,6 +20,7 @@ use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Security\NullSecurityToken;
 use SilverStripe\Security\SecurityToken;
+use SilverStripe\View\AttributesHTML;
 use SilverStripe\View\SSViewer;
 use SilverStripe\View\ViewableData;
 
@@ -66,10 +67,10 @@ use SilverStripe\View\ViewableData;
  */
 class Form extends ViewableData implements HasRequestHandler
 {
+    use AttributesHTML;
     use FormMessage;
 
     /**
-     * Default form Name property
      */
     const DEFAULT_NAME = 'Form';
 
@@ -816,33 +817,7 @@ class Form extends ViewableData implements HasRequestHandler
         return $this;
     }
 
-    /**
-     * @param string $name
-     * @param string $value
-     * @return $this
-     */
-    public function setAttribute($name, $value)
-    {
-        $this->attributes[$name] = $value;
-        return $this;
-    }
-
-    /**
-     * @param string $name
-     * @return string
-     */
-    public function getAttribute($name)
-    {
-        if (isset($this->attributes[$name])) {
-            return $this->attributes[$name];
-        }
-        return null;
-    }
-
-    /**
-     * @return array
-     */
-    public function getAttributes()
+    protected function getDefaultAttributes(): array
     {
         $attrs = [
             'id' => $this->FormName(),
@@ -860,51 +835,7 @@ class Form extends ViewableData implements HasRequestHandler
             $attrs['class'] .= ' validationerror';
         }
 
-        $attrs = array_merge($attrs, $this->attributes);
-
         return $attrs;
-    }
-
-    /**
-     * Return the attributes of the form tag - used by the templates.
-     *
-     * @param array $attrs Custom attributes to process. Falls back to {@link getAttributes()}.
-     * If at least one argument is passed as a string, all arguments act as excludes by name.
-     *
-     * @return string HTML attributes, ready for insertion into an HTML tag
-     */
-    public function getAttributesHTML($attrs = null)
-    {
-        $exclude = (is_string($attrs)) ? func_get_args() : null;
-
-        $attrs = $this->getAttributes();
-
-        // Remove empty
-        $attrs = array_filter((array)$attrs, function ($value) {
-            return ($value || $value === 0);
-        });
-
-        // Remove excluded
-        if ($exclude) {
-            $attrs = array_diff_key($attrs, array_flip($exclude));
-        }
-
-        // Prepare HTML-friendly 'method' attribute (lower-case)
-        if (isset($attrs['method'])) {
-            $attrs['method'] = strtolower($attrs['method']);
-        }
-
-        // Create markup
-        $parts = [];
-        foreach ($attrs as $name => $value) {
-            if ($value === true) {
-                $value = $name;
-            }
-
-            $parts[] = sprintf('%s="%s"', Convert::raw2att($name), Convert::raw2att($value));
-        }
-
-        return implode(' ', $parts);
     }
 
     public function FormAttributes()

--- a/src/View/AttributesHTML.php
+++ b/src/View/AttributesHTML.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace SilverStripe\View;
+
+use SilverStripe\Core\Convert;
+
+/**
+ * This trait can be applied to a ViewableData class to add the logic to render attributes in an SS template.
+ *
+ * When applying this trait to a class, you also need to add the following casting configuration.
+ * ```
+ * private static $casting = [
+ *     'AttributesHTML' => 'HTMLFragment',
+ *     'getAttributesHTML' => 'HTMLFragment',
+ * ];
+ * ```
+ */
+trait AttributesHTML
+{
+
+    /**
+     * List of attributes to render on the frontend
+     * @var array
+     */
+    protected $attributes = [];
+
+    /**
+     * Set an HTML attribute
+     * @param $name
+     * @param $value
+     * @return $this
+     */
+    public function setAttribute($name, $value)
+    {
+        $this->attributes[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Retrieve the value of an HTML attribute
+     * @param string $name
+     * @return mixed|null
+     */
+    public function getAttribute($name)
+    {
+        $attributes = $this->getAttributes();
+
+        if (isset($attributes[$name])) {
+            return $attributes[$name];
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the default attributes when rendering this object.
+     *
+     * Called by `getAttributes()`
+     *
+     * @return array
+     */
+    abstract protected function getDefaultAttributes(): array;
+
+    /**
+     * Allows customization through an 'updateAttributes' hook on the base class.
+     * Existing attributes are passed in as the first argument and can be manipulated,
+     * but any attributes added through a subclass implementation won't be included.
+     *
+     * @return array
+     */
+    public function getAttributes()
+    {
+        $defaultAttributes = $this->getDefaultAttributes();
+
+        $attributes = array_merge($defaultAttributes, $this->attributes);
+
+        if (method_exists($this, 'extend')) {
+            $this->extend('updateAttributes', $attributes);
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Custom attributes to process. Falls back to {@link getAttributes()}.
+     *
+     * If at least one argument is passed as a string, all arguments act as excludes, by name.
+     *
+     * @param array $attributes
+     *
+     * @return string
+     */
+    public function getAttributesHTML($attributes = null)
+    {
+        $exclude = null;
+
+        if (is_string($attributes)) {
+            $exclude = func_get_args();
+        }
+
+        if (!$attributes || is_string($attributes)) {
+            $attributes = $this->getAttributes();
+        }
+
+        $attributes = (array) $attributes;
+
+        $attributes = array_filter($attributes, function ($v) {
+            return ($v || $v === 0 || $v === '0');
+        });
+
+        if ($exclude) {
+            $attributes = array_diff_key(
+                $attributes,
+                array_flip($exclude)
+            );
+        }
+
+        // Create markup
+        $parts = [];
+
+        foreach ($attributes as $name => $value) {
+            if ($value === true) {
+                $value = $name;
+            } else {
+                if (is_scalar($value)) {
+                    $value = (string) $value;
+                } else {
+                    $value = json_encode($value);
+                }
+            }
+
+            $parts[] = sprintf('%s="%s"', Convert::raw2att($name), Convert::raw2att($value));
+        }
+
+        return implode(' ', $parts);
+    }
+}


### PR DESCRIPTION
This idea emerged out https://github.com/silverstripe/silverstripe-assets/pull/458#discussion_r663646460

The idea is that we would extract common pattern into trait to make them re-usable and reduce code duplication.

# Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10032
