### PR TITLE
Fix link typo in 01_Caching.md

### DIFF
--- a/docs/en/02_Developer_Guides/08_Performance/01_Caching.md
+++ b/docs/en/02_Developer_Guides/08_Performance/01_Caching.md
@@ -38,7 +38,7 @@ Note that this library describes usage of [PSR-6](http://www.php-fig.org/psr/psr
 but also exposes caches following the PSR-16 interface. 
 
 Cache objects are configured via YAML
-and SilverStripe's [dependency injection](/developer-guides/extending/injector) system. 
+and SilverStripe's [dependency injection](/developer_guides/extending/injector) system. 
 
 
 ```yml


### PR DESCRIPTION
Fix broken link to  dependency injection documentation (`developer-guides` -> `developer_guides`)