### PR TITLE
ENH: Avoid "new" keyword to instantiate CompositeValidator

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -2547,7 +2547,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      */
     public function getCMSCompositeValidator(): CompositeValidator
     {
-        $compositeValidator = new CompositeValidator();
+        $compositeValidator = CompositeValidator::create();
 
         // Support for the old method during the deprecation period
         if ($this->hasMethod('getCMSValidator')) {


### PR DESCRIPTION
The CompositeValidator is Injectable, so we should allow project code to replace it here via the Injector.
