### PR TITLE
Fix error when executing method SSViewer::templates() when $subTempla…

### DIFF
--- a/src/View/SSViewer.php
+++ b/src/View/SSViewer.php
@@ -167,7 +167,7 @@ class SSViewer implements Flushable
      *
      * @var array
      */
-    protected $subTemplates = null;
+    protected $subTemplates = [];
 
     /**
      * @var bool


### PR DESCRIPTION
…tes is still null

Without the fix this causes the framework to throw a 500 error:
`ERROR [Warning]: array_merge(): Expected parameter 2 to be an array, null given`

I noticed the error while doing a search with the `GridFieldAddExistingAutocompleter`. The error probably gets supressed on live environments.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
