### PR TITLE
ENH Search all summary fields and split words

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -16,6 +16,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\FormScaffolder;
 use SilverStripe\Forms\CompositeValidator;
+use SilverStripe\Forms\HiddenField;
 use SilverStripe\i18n\i18n;
 use SilverStripe\i18n\i18nEntityProvider;
 use SilverStripe\ORM\Connect\MySQLSchemaManager;
@@ -2378,6 +2379,12 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
             (array)$_params
         );
         $fields = new FieldList();
+
+        // Adds a 'search all summary fields' field to be used as the default search field
+        // The gridfield search simply picks the first field from the list
+        // See GridFieldFilterHeader.php and SearchContext.php
+        $fields->push(HiddenField::create('summary_fields', 'Summary fields search'));
+
         foreach ($this->searchableFields() as $fieldName => $spec) {
             if ($params['restrictFields'] && !in_array($fieldName, $params['restrictFields'])) {
                 continue;


### PR DESCRIPTION
POC, don't merge

Issue https://github.com/silverstripe/silverstripe-framework/issues/9356

1) Searches all summary_fields (or searchable_fields if available e.g. Member table)
2) Splits words on spaces

In both cases it does a `WHERE .. OR` on things

I think that 1) is good, I'm not entirely sure if 2) is entirely good because it won't put the most relevant search results at the top e.g. if searching on 3 words and it matches all 3, it won't necessarily put that as the top search result.  Weight is the same something that partially matched on a single word.  This might be considered OK though.

I'd prefer we don't attempt to go too far with this at this stage, we're not trying to build a fully fledged search engine :-)  I think what we have here is a significant improvement.

Should probably point to the `4` branch because it's a behaviour change

Some front end changes are probably required within the admin module to tidy up the UX when using the advanced filter, possibly disable the 'summary_fields' field and remove the placeholder text