### PR TITLE
DOCS incorrect php version reference

### DIFF
--- a/docs/en/00_Getting_Started/00_Server_Requirements.md
+++ b/docs/en/00_Getting_Started/00_Server_Requirements.md
@@ -257,7 +257,7 @@ table may be of use:
 | -------------------- | ----------- | ---------------- |
 | 3.0 - 3.5            | 5.3 - 5.6   | [requirements docs](https://docs.silverstripe.org/en/3.4/getting_started/server_requirements/)
 | 3.6                  | 5.3 - 7.1   | |
-| 3.7                  | 5.3 - 7.3   | [changelog](https://docs.silverstripe.org/en/3/changelogs/3.7.0/) |
+| 3.7                  | 5.3 - 7.4   | [changelog](https://docs.silverstripe.org/en/3/changelogs/3.7.4/) |
 | 4.0 - 4.4            | 5.6+        | |
 | 4.5+                 | 7.1+        | [blog post](https://www.silverstripe.org/blog/our-plan-for-ending-php-5-6-support-in-silverstripe-4/) |
 


### PR DESCRIPTION
v4 docs note that CMS 3.7 only supports up to 7.3 which is incorrect :) 