### PR TITLE
DOCS: Documenting the capability of 'envorconstant' to be checked against specific values

### DIFF
--- a/docs/en/02_Developer_Guides/04_Configuration/00_Configuration.md
+++ b/docs/en/02_Developer_Guides/04_Configuration/00_Configuration.md
@@ -334,15 +334,15 @@ rules contained match.
 
 You then list any of the following rules as sub-keys, with informational values as either a single value or a list.
 
-  - 'classexists', in which case the value(s) should be classes that must exist
-  - 'moduleexists', in which case the value(s) should be modules that must exist. This supports either folder
+  - `classexists`, in which case the value(s) should be classes that must exist
+  - `moduleexists`, in which case the value(s) should be modules that must exist. This supports either folder
     name or composer `vendor/name` format.
-  - 'environment', in which case the value(s) should be one of "live", "test" or "dev" to indicate the Silverstripe CMS
+  - `environment`, in which case the value(s) should be one of "live", "test" or "dev" to indicate the Silverstripe CMS
     mode the site must be in
-  - 'envvarset', in which case the value(s) should be environment variables that must be set
-  - 'constantdefined', in which case the value(s) should be constants that must be defined
-  - 'envorconstant' A variable which should be defined either via environment vars or constants
-  - 'extensionloaded', in which case the PHP extension(s) must be loaded
+  - `envvarset`, in which case the value(s) should be environment variables that must be set
+  - `constantdefined`, in which case the value(s) should be constants that must be defined
+  - `envorconstant`, a variable which should be defined either via environment vars or constants (and optionally be set to a specific value)
+  - `extensionloaded`, in which case the PHP extension(s) must be loaded
 
 For instance, to add a property to "foo" when a module exists, and "bar" otherwise, you could do this:
 
@@ -371,6 +371,18 @@ Only:
   moduleexists:
     - 'silverstripe/blog'
     - 'silverstripe/lumberjack'
+---
+```
+
+The `envorconstant` rule allows you to get even more specific by also directly comparing values of environment variables
+and constants. In this example, both `TEST_ENV` and `TEST_CONST` have to be defined _and_ set to certain values:
+
+```yaml
+---
+Only:
+  envorconstant:
+    TEST_ENV: 'example'
+    TEST_CONST: true
 ---
 ```
 


### PR DESCRIPTION
The documentation doesn't _fully_ explain how `envorconstant` can be used. Previously in SS v3 you could do the following:

```yaml
Only:
  ENV_VAR: 'value'
```

However, that schema has changed and it's still possible to do, but now circa SS v4 it's simply nested under the new `envorconstant` rule:

```yaml
Only:
  envorconstant:
    ENV_VAR: 'value'
```

However, it's not apparent that this is possible right now with the current documentation. I just went through a little trial and error to double check that this was possible, debugging/stepping through the code and this is indeed a first class capability in this chunk of code in `CoreConfigFactory`: https://github.com/silverstripe/silverstripe-framework/blob/4/src/Core/Config/CoreConfigFactory.php#L144-L162