### PR TITLE
Add a basic ContentLocale method to controller

### DIFF
--- a/src/Control/Controller.php
+++ b/src/Control/Controller.php
@@ -660,8 +660,8 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
     /**
      * Returns an RFC1766 compliant locale string, e.g. 'fr-CA'.
      *
-     * Suitable for insertion into lang= and xml:lang=
-     * attributes in HTML or XHTML output.
+     * Note: The method is overloaded in {@link ContentController} where it takes into account
+     * the current data record (@link SiteTree) and adds support for {@link Translatable}.
      *
      * @return string
      */

--- a/src/Control/Controller.php
+++ b/src/Control/Controller.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Control;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Dev\Debug;
 use SilverStripe\Dev\Deprecation;
+use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Security\BasicAuth;
 use SilverStripe\Security\BasicAuthMiddleware;
@@ -654,6 +655,20 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
     public function redirectedTo()
     {
         return $this->getResponse() && $this->getResponse()->getHeader('Location');
+    }
+    
+    /**
+     * Returns an RFC1766 compliant locale string, e.g. 'fr-CA'.
+     *
+     * Suitable for insertion into lang= and xml:lang=
+     * attributes in HTML or XHTML output.
+     *
+     * @return string
+     */
+    public function ContentLocale()
+    {
+        $locale = i18n::get_locale();
+        return i18n::convert_rfc1766($locale);
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10080

Add a basic ContentLocale method to controller that doesn't check a dataRecord.
