### PR TITLE
DOC Add additional info to 4.9.0 changelog

### DIFF
--- a/docs/en/04_Changelogs/4.9.0.md
+++ b/docs/en/04_Changelogs/4.9.0.md
@@ -4,6 +4,7 @@
 
 - [Security audit and regression test](#audit)
 - [For development teams of Common Web Platform projects](#cwp-end)
+- [Dropping support for Internet Explorer 11](#ie11eol)
 - [Features and enhancements](#features-and-enhancements)
     - [Image lazy loading](#image-lazy-loading)
     - [Manage your CMS sessions across devices](#session-manager)
@@ -25,6 +26,14 @@ Review the [security audit report](INSERT-LINK-TO-AUDIT).
 This release marks the first release for Common Web Platform projects to eject out of managing projects in the CWP 2.x version line and to begin following the standard CMS 4.x version line, by adopting the CMS Recipe.
 
 More information and guidance on how to manage your project composer.json file will be published as part of the CMS 4.9.0 stable release and supporting documentation.
+
+## Dropping support for Internet Explorer 11{#ie11eol}
+
+Silverstripe CMS 4.9.0 is the last release of Silverstripe CMS that supports Internet Explorer 11. Silverstripe CMS 4.10.0 will not support Internet Explorer 11.
+
+[Microsoft has announced the end-of-life for Internet Explorer 11](https://blogs.windows.com/windowsexperience/2021/05/19/the-future-of-internet-explorer-on-windows-10-is-in-microsoft-edge/) on June 15, 2022. It has already dropped Internet Explorer support in many other products including Microsoft Teams and Microsoft 365. In this context, any development time dedicated to maintianing Internet Explorer support could be better use improving other areas of Silverstripe CMS.
+
+While the Silverstripe CMS UI might not allow content authors to manage content in Internet Explorer, this does not preclude Silverstripe CMS project from outputting an a frontend site that is compatible with Internet Explorer.
 
 ## Features and enhancements {#features-and-enhancements}
 

--- a/docs/en/04_Changelogs/4.9.0.md
+++ b/docs/en/04_Changelogs/4.9.0.md
@@ -2,13 +2,29 @@
 
 ## Overview
 
+- [Security audit and regression test](#audit)
+- [For development teams of Common Web Platform projects](#cwp-end)
 - [Features and enhancements](#features-and-enhancements)
     - [Image lazy loading](#image-lazy-loading)
     - [Manage your CMS sessions across devices](#session-manager)
     - [Default mail transport upgraded to sendmail](#sendmail)
+    - [Support for silverstripe/graphql v4](#graphqlv4)
     - [Other new features](#other-features)
 - [Bugfixes](#bugfixes)
 
+## Security audit and regression test{#audit}
+
+This release has gone through a regression test suite to identify any possible instability between modules.
+
+The release has also been audited by an independant security firm to identify possible security regressions.
+
+Review the [security audit report](INSERT-LINK-TO-AUDIT).
+
+## For development teams of Common Web Platform projects{#cwp-end}
+
+This release marks the first release for Common Web Platform projects to eject out of managing projects in the CWP 2.x version line and to begin following the standard CMS 4.x version line, by adopting the CMS Recipe.
+
+More information and guidance on how to manage your project composer.json file will be published as part of the CMS 4.9.0 stable release and supporting documentation.
 
 ## Features and enhancements {#features-and-enhancements}
 
@@ -88,6 +104,16 @@ Prior to 4.9.0, Silverstripe CMS 4 defaulted to using the built-in PHP `mail()` 
 Installations of Silverstripe CMS setup using silverstripe/installer 4.9.0 or greater default to using the more secure class `Swift_SendmailTransport` which uses a `sendmail` binary.
 
 It's highly recommended that existing Silverstripe CMS installation still using `Swift_MailTransport` upgrade to using `Swift_SendmailTransport` or another available transport, such as `Swift_SmtpTransport`. Details on how to use these classes are available in the [email section](https://docs.silverstripe.org/en/4/developer_guides/email/) of the developer docs.
+
+### Support for silverstripe/graphql v4 {#graphqlv4}
+
+The Silverstripe CMS 4.8.0 release added support for the experimental `silverstripe/graphql` v4 module. We made it easier for early adopters to run `silverstripe/graphql` v4 in this release:
+
+- Upgrade to the Silverstripe CMS 4.9.0 release.
+- Confirm your project `composer.json` file has a `"minimum-stability": "dev"` key.
+- Explicitely require `silverstripe/graphql` v4 by running `composer require silverstripe/graphql:^4`
+
+You don't need to inline any recipes anymore.
 
 ### Other new features
 

--- a/docs/en/04_Changelogs/4.9.0.md
+++ b/docs/en/04_Changelogs/4.9.0.md
@@ -2,6 +2,98 @@
 
 ## Overview
 
+A full list of module versions included in CMS Recipe {{ version }} is provided below. We recommend referencing recipes in your dependencies, rather than individual modules, to simplify version tracking. See [Recipes](/getting_started/).
+
+
+<details>
+<summary>Core module versions</summary>
+
+| Module | Version |
+| ------ | ------- |
+| silverstripe/admin | 1.9.0 |
+| silverstripe/asset-admin | 1.9.0 |
+| silverstripe/assets | 1.9.0 |
+| silverstripe/campaign-admin | 1.9.0 |
+| silverstripe/cms | 1.9.0 |
+| silverstripe/config | 1.2.0 |
+| silverstripe/errorpage | 1.9.0 |
+| silverstripe/framework | 4.9.0 |
+| silverstripe/graphql | 3.6.0 |
+| silverstripe/login-forms | 4.5.0 |
+| silverstripe/mimevalidator | 2.2.0 |
+| silverstripe/reports | 4.9.0 |
+| silverstripe/session-manager | 1.1.0 |
+| silverstripe/siteconfig | 4.9.0 |
+| silverstripe/versioned | 1.9.0 |
+| silverstripe/versioned-admin | 1.9.0 |
+</details>
+
+<details>
+<summary>Supported module versions</summary>
+
+| Module | Version |
+| ------ | ------- |
+| bringyourownideas/silverstripe-composer-update-checker | 2.0.3 |
+| bringyourownideas/silverstripe-maintenance | 2.3.1 |
+| cwp/agency-extensions | 2.5.0 |
+| cwp/cwp | 2.8.0 |
+| cwp/cwp-core | 2.8.0 |
+| cwp/cwp-pdfexport | 1.2.0 |
+| cwp/cwp-search | 1.5.0 |
+| cwp/starter-theme | 3.2.0 |
+| cwp/watea-theme | 3.1.0 |
+| dnadesign/silverstripe-elemental | 4.7.0 |
+| dnadesign/silverstripe-elemental-userforms | 3.0.0 |
+| silverstripe/akismet | 4.1.0 |
+| silverstripe/auditor | 2.3.0 |
+| silverstripe/blog | 3.8.0 |
+| silverstripe/ckan-registry | 1.3.0 |
+| silverstripe/comment-notifications | 2.1.0 |
+| silverstripe/comments | 3.6.0 |
+| silverstripe/content-widget | 2.2.0 |
+| silverstripe/contentreview | 4.3.0 |
+| silverstripe/controllerpolicy | 2.2.0 |
+| silverstripe/crontask | 2.3.0 |
+| silverstripe/documentconverter | 2.1.1 |
+| silverstripe/elemental-bannerblock | 2.3.0 |
+| silverstripe/elemental-fileblock | 2.2.0 |
+| silverstripe/environmentcheck | 2.3.0 |
+| silverstripe/externallinks | 2.1.1 |
+| silverstripe/fulltextsearch | 3.8.0 |
+| silverstripe/gridfieldqueuedexport | 2.5.0 |
+| silverstripe/html5 | 2.1.0 |
+| silverstripe/hybridsessions | 2.3.0 |
+| silverstripe/iframe | 2.1.0 |
+| silverstripe/ldap | 1.2.1 |
+| silverstripe/mfa | 4.4.0 |
+| silverstripe/realme | 4.1.1 |
+| silverstripe/registry | 2.3.0 |
+| silverstripe/restfulserver | 2.3.0 |
+| silverstripe/security-extensions | 4.1.0 |
+| silverstripe/securityreport | 2.3.0 |
+| silverstripe/segment-field | 2.4.0 |
+| silverstripe/sharedraftcontent | 2.5.0 |
+| silverstripe/sitewidecontent-report | 3.1.0 |
+| silverstripe/spamprotection | 3.1.0 |
+| silverstripe/spellcheck | 2.2.1 |
+| silverstripe/subsites | 2.4.0 |
+| silverstripe/tagfield | 2.7.0 |
+| silverstripe/taxonomy | 2.2.0 |
+| silverstripe/textextraction | 3.2.0 |
+| silverstripe/totp-authenticator | 4.2.0 |
+| silverstripe/userforms | 5.10.0 |
+| silverstripe/versionfeed | 2.1.0 |
+| silverstripe/webauthn-authenticator | 4.3.0 |
+| silverstripe/widgets | 2.1.1 |
+| symbiote/silverstripe-advancedworkflow | 5.5.0 |
+| symbiote/silverstripe-multivaluefield | 5.1.0 |
+| symbiote/silverstripe-queuedjobs | 4.8.0 |
+| tractorcow/silverstripe-fluent | 4.5.1 |
+
+</details>
+
+Upgrading to Recipe {{ version }} is recommended for all sites. This upgrade can be carried out by any development team familiar with Silverstripe.
+
 - [Security audit and regression test](#audit)
 - [For development teams of Common Web Platform projects](#cwp-end)
 - [Dropping support for Internet Explorer 11](#ie11eol)

--- a/docs/en/04_Changelogs/4.9.0.md
+++ b/docs/en/04_Changelogs/4.9.0.md
@@ -14,7 +14,7 @@ A full list of module versions included in CMS Recipe {{ version }} is provided 
 | silverstripe/asset-admin | 1.9.0 |
 | silverstripe/assets | 1.9.0 |
 | silverstripe/campaign-admin | 1.9.0 |
-| silverstripe/cms | 1.9.0 |
+| silverstripe/cms | 4.9.0 |
 | silverstripe/config | 1.2.0 |
 | silverstripe/errorpage | 1.9.0 |
 | silverstripe/framework | 4.9.0 |
@@ -105,13 +105,11 @@ Upgrading to Recipe {{ version }} is recommended for all sites. This upgrade can
     - [Other new features](#other-features)
 - [Bugfixes](#bugfixes)
 
-## Security audit and regression test{#audit}
+## Regression test and Security audit{#audit}
 
-This release has gone through a regression test suite to identify any possible instability between modules.
+This release has been comprehensively regression tested and passed to a third party for a security-focused audit. 
 
-The release has also been audited by an independant security firm to identify possible security regressions.
-
-Review the [security audit report](INSERT-LINK-TO-AUDIT).
+While it is still advised that you perform your own due diligence when upgrading your project, this work is performed to ensure a safe and secure upgrade with each recipe release.
 
 ## For development teams of Common Web Platform projects{#cwp-end}
 


### PR DESCRIPTION
This PR folds back some of the ad doc changelog tweaks we added to the 4.9.0-beta1 release. It also adds a bit to say that the release has been audited.
