### PR TITLE
FIX Only send email if email address set

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -910,6 +910,7 @@ class Member extends DataObject
         if ((Director::isLive() || Injector::inst()->get(Mailer::class) instanceof TestMailer)
             && $this->isChanged('Password')
             && $this->record['Password']
+            && $this->Email
             && static::config()->get('notify_password_change')
             && $this->isInDB()
         ) {


### PR DESCRIPTION
With the upgrade to SwiftMailer v6 there is additional validation done on email address

If a blank email address is set, it now fails validation
`Swift_RfcComplianceException: Address in mailbox given [] does not comply with RFC 2822, 3.6.2.`
https://app.travis-ci.com/github/silverstripe/recipe-kitchen-sink/jobs/535666659

This is basically an edge case that should only happen in unit testing.  When a `Member` object is created without an Email address.  It shows up in unit testing on recipe-kitchen-sink but not regular framework tests because cwp-core sets `notify_password_change` to `true` https://github.com/silverstripe/cwp-core/blob/2/_config/config.yml#L21.  It defaults to `false` https://github.com/silverstripe/silverstripe-framework/blob/4/src/Security/Member.php#L109

