### PR TITLE
DOC Remove reference to being able to test GraphQL v4 without inlining recipes and tweak swiftmailer doc

### DIFF
--- a/docs/en/04_Changelogs/4.9.0.md
+++ b/docs/en/04_Changelogs/4.9.0.md
@@ -100,8 +100,7 @@ Upgrading to Recipe {{ version }} is recommended for all sites. This upgrade can
 - [Features and enhancements](#features-and-enhancements)
     - [Image lazy loading](#image-lazy-loading)
     - [Manage your CMS sessions across devices](#session-manager)
-    - [Default mail transport upgraded to sendmail](#sendmail)
-    - [Support for silverstripe/graphql v4](#graphqlv4)
+    - [Upgrade to Swiftmailer version 6](#swiftmailer)
     - [Other new features](#other-features)
 - [Bugfixes](#bugfixes)
 
@@ -194,25 +193,20 @@ Functional tests should use `$this->logInAs($member)` and `$this->logOut()` when
 
 Review the [Functional Testing developer documentation](/developer_guides/testing/functional_testing/#loginas) for more details on `logInAs()` and `logOut()`.
 
-### Default mail transport upgraded to sendmail {#sendmail}
+### Upgrade to Swiftmailer version 6 {#swiftmailer}
 
-Silverstripe CMS provides an API over the top of the [SwiftMailer](http://swiftmailer.org/) PHP library which comes with an extensive list of "transports" for sending mail via different services. 
+Silverstripe CMS provides an API over the top of the [SwiftMailer](http://swiftmailer.org/) PHP library which comes with an extensive list of "transports" for sending mail via different services. Silverstripe CMS 4.9.0 upgrades to Swiftmailer version 6 from version 5.
 
-Prior to 4.9.0, Silverstripe CMS 4 defaulted to using the built-in PHP `mail()` command via a deprecated class `Swift_MailTransport`. However, using this layer is less secure and is strongly discouraged.
+#### Moving away from _Swift_MailTransport_ 
+Prior to 4.9.0, Silverstripe CMS 4 defaulted to using the built-in PHP `mail()` command via a deprecated class `Swift_MailTransport`. However, the Swiftmailer maintainers have decided to remove this class because of some inherent security flaw in the way the PHP mail function handles the `from` header.
 
-Installations of Silverstripe CMS setup using silverstripe/installer 4.9.0 or greater default to using the more secure class `Swift_SendmailTransport` which uses a `sendmail` binary.
+Read this [GitHub comment by a SwiftMailer maintainer](https://github.com/swiftmailer/swiftmailer/issues/866#issuecomment-289291228) for a detailed explanation of the weakness of the PHP mail function.  
 
-It's highly recommended that existing Silverstripe CMS installation still using `Swift_MailTransport` upgrade to using `Swift_SendmailTransport` or another available transport, such as `Swift_SmtpTransport`. Details on how to use these classes are available in the [email section](https://docs.silverstripe.org/en/4/developer_guides/email/) of the developer docs.
+We have included the deprecated `Swift_MailTransport` class in the `silverstripe/framework` codebase to ensure backward compatibility for project upgrading to Silverstripe Recipe CMS 4.9.0. However, using this layer is less secure and is strongly discouraged.
 
-### Support for silverstripe/graphql v4 {#graphqlv4}
+New Silverstripe CMS project created from `silverstripe/installer` 4.9.0 or greater will default to using the more secure class `Swift_SendmailTransport` which uses a `sendmail` binary.
 
-The Silverstripe CMS 4.8.0 release added support for the experimental `silverstripe/graphql` v4 module. We made it easier for early adopters to run `silverstripe/graphql` v4 in this release:
-
-- Upgrade to the Silverstripe CMS 4.9.0 release.
-- Confirm your project `composer.json` file has a `"minimum-stability": "dev"` key.
-- Explicitely require `silverstripe/graphql` v4 by running `composer require silverstripe/graphql:^4`
-
-You don't need to inline any recipes anymore.
+It's highly recommended that existing Silverstripe CMS installation using `Swift_MailTransport` upgrade to `Swift_SendmailTransport` or another available transport, such as `Swift_SmtpTransport`. Details on how to use these classes are available in the [email section](https://docs.silverstripe.org/en/4/developer_guides/email/) of the developer docs.
 
 ### Other new features
 


### PR DESCRIPTION
This PR removes the bit about allowing to install GraphQL v4 without inlining recipes. My dumb brain realised after the fact that this would cause projects to upgrade to GraphQL v4 once it got tag stable which would be a pretty bad and confusing.

I also a bit more info about the Swiftmailer upgrade