### PR TITLE
MNT Fix broken test caused by missing table

### DIFF
--- a/tests/php/ORM/HierarchyCachingTest.php
+++ b/tests/php/ORM/HierarchyCachingTest.php
@@ -9,6 +9,8 @@ use SilverStripe\Versioned\Versioned;
 use SilverStripe\ORM\Tests\HierarchyTest\TestObject;
 use SilverStripe\ORM\Tests\HierarchyTest\HideTestObject;
 use SilverStripe\ORM\Tests\HierarchyTest\HideTestSubObject;
+use SilverStripe\ORM\Tests\HierarchyTest\HierarchyOnSubclassTestObject;
+use SilverStripe\ORM\Tests\HierarchyTest\HierarchyOnSubclassTestSubObject;
 
 /**
  * @internal Only test the right values are returned, not that the cache is actually used.
@@ -22,6 +24,8 @@ class HierachyCacheTest extends SapphireTest
         TestObject::class,
         HideTestObject::class,
         HideTestSubObject::class,
+        HierarchyOnSubclassTestObject::class,
+        HierarchyOnSubclassTestSubObject::class
     ];
 
     public function setUp()


### PR DESCRIPTION
Fix [broken build](https://app.travis-ci.com/github/silverstripe/recipe-kitchen-sink/jobs/541011854) caused by https://github.com/silverstripe/silverstripe-framework/pull/10077


