### PR TITLE
DOCS add release announcement link to changelog

### DIFF
--- a/docs/en/04_Changelogs/4.9.0.md
+++ b/docs/en/04_Changelogs/4.9.0.md
@@ -92,6 +92,8 @@ A full list of module versions included in CMS Recipe 4.9.0 is provided below. W
 
 Upgrading to Silverstripe CMS Recipe 4.9.0 is recommended for all sites. This upgrade can be carried out by any development team familiar with Silverstripe.
 
+In addition to the below, have a read of the [CMS 4.9 release announcement](https://www.silverstripe.org/blog/cms-4-9-is-here/).
+
 - [Security considerations](#security-considerations)
 - [Security audit and regression test](#audit)
 - [For development teams of Common Web Platform projects](#cwp-end)
@@ -117,7 +119,6 @@ We have provided a high-level severity rating of the vulnerabilities below based
 ### Note for CVE-2021-28661 Default GraphQL permission checker not inherited by query subclass
 
 If your site has a custom GraphQL 3 ItemQuery/ListQuery Scaffolder implementation that relies on having no permission check, you will need to add a custom permission checker to bypass the `canView()` check.  See the [security announcement](https://www.silverstripe.org/download/security-releases/CVE-2021-28661) for implementation details.
-
 
 
 ## Regression test and Security audit{#audit}
@@ -210,6 +211,8 @@ Content authors can disable lazy loading on images added via the HTML editor fie
 
 Consult the [Insert images](https://userhelp.silverstripe.org/en/4/creating_pages_and_content/creating_and_editing_content/inserting_images/#lazy-loading)
 article in the Silverstripe CMS user help for detailed instructions.
+
+*Also note:* There is a [long-standing bug in Google Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=875403) that will prevent images that have not yet been in view (and loaded) from being included if a user chooses to print the page. This is something that site owners should be made aware of.
 
 ### Manage your CMS sessions across devices {#session-manager}
 


### PR DESCRIPTION
I've also suggested a note to an existing Chrome lazy-loading bug

