### PR TITLE
API Add a way to check if a form or field has an extra css class.

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -1780,6 +1780,25 @@ class Form extends ViewableData implements HasRequestHandler
     }
 
     /**
+     * Check if a CSS-class has been added to the form container.
+     *
+     * @param string $class A string containing a classname or several class
+     * names delimited by a single space.
+     * @return boolean True if all of the classnames passed in have been added.
+     */
+    public function hasExtraClass($class)
+    {
+        //split at white space
+        $classes = preg_split('/\s+/', $class);
+        foreach ($classes as $class) {
+            if (!isset($this->extraClasses[$class])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Add a CSS-class to the form-container. If needed, multiple classes can
      * be added by delimiting a string with spaces.
      *

--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -603,6 +603,25 @@ class FormField extends RequestHandler
     }
 
     /**
+     * Check if a CSS-class has been added to the form container.
+     *
+     * @param string $class A string containing a classname or several class
+     * names delimited by a single space.
+     * @return boolean True if all of the classnames passed in have been added.
+     */
+    public function hasExtraClass($class)
+    {
+        //split at white space
+        $classes = preg_split('/\s+/', $class);
+        foreach ($classes as $class) {
+            if (!isset($this->extraClasses[$class])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Add one or more CSS-classes to the FormField container.
      *
      * Multiple class names should be space delimited.

--- a/tests/php/Forms/FormFieldTest.php
+++ b/tests/php/Forms/FormFieldTest.php
@@ -93,6 +93,19 @@ class FormFieldTest extends SapphireTest
         $this->assertStringEndsWith('class1 class2', $field->extraClass());
     }
 
+    public function testHasExtraClass()
+    {
+        $field = new FormField('MyField');
+        $field->addExtraClass('class1');
+        $field->addExtraClass('class2');
+        $this->assertTrue($field->hasExtraClass('class1'));
+        $this->assertTrue($field->hasExtraClass('class2'));
+        $this->assertTrue($field->hasExtraClass('class1 class2'));
+        $this->assertTrue($field->hasExtraClass('class2 class1'));
+        $this->assertFalse($field->hasExtraClass('class3'));
+        $this->assertFalse($field->hasExtraClass('class2 class3'));
+    }
+
     public function testRemoveExtraClass()
     {
         $field = new FormField('MyField');

--- a/tests/php/Forms/FormTest.php
+++ b/tests/php/Forms/FormTest.php
@@ -726,6 +726,19 @@ class FormTest extends FunctionalTest
         $this->assertStringEndsWith('class1 class2', $form->extraClass());
     }
 
+    public function testHasExtraClass()
+    {
+        $form = $this->getStubForm();
+        $form->addExtraClass('class1');
+        $form->addExtraClass('class2');
+        $this->assertTrue($form->hasExtraClass('class1'));
+        $this->assertTrue($form->hasExtraClass('class2'));
+        $this->assertTrue($form->hasExtraClass('class1 class2'));
+        $this->assertTrue($form->hasExtraClass('class2 class1'));
+        $this->assertFalse($form->hasExtraClass('class3'));
+        $this->assertFalse($form->hasExtraClass('class2 class3'));
+    }
+
     public function testRemoveExtraClass()
     {
         $form = $this->getStubForm();


### PR DESCRIPTION
Required for silverstripe/silverstripe-admin#1252
