### PR TITLE
NEW: Validate the Title on Group is not empty

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -217,6 +217,7 @@ en:
     GROUPNAME: 'Group name'
     GroupReminder: 'If you choose a parent group, this group will take all it''s roles'
     HierarchyPermsError: 'Can''t assign parent group "{group}" with privileged permissions (requires ADMIN access)'
+    ValidationIdentifierAlreadyExists: 'A Group ({group}) already exists with the same {identifier}'
     Locked: 'Locked?'
     MEMBERS: Members
     NEWGROUP: 'New Group'

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -1112,9 +1112,15 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
             $member = $this->cache_generatedMembers[$permCode];
         } else {
             // Generate group with these permissions
-            $group = Group::create();
-            $group->Title = "$permCode group";
-            $group->write();
+            $group = Group::get()->filterAny([
+                'Code' => "$permCode-group",
+                'Title' => "$permCode group",
+            ])->first();
+            if (!$group || !$group->exists()) {
+                $group = Group::create();
+                $group->Title = "$permCode group";
+                $group->write();
+            }
 
             // Create each individual permission
             foreach ($permArray as $permArrayItem) {

--- a/src/Security/Group.php
+++ b/src/Security/Group.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Security;
 
 use SilverStripe\Admin\SecurityAdmin;
 use SilverStripe\Core\Convert;
+use SilverStripe\Forms\CompositeValidator;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
@@ -21,6 +22,7 @@ use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
 use SilverStripe\Forms\ListboxField;
 use SilverStripe\Forms\LiteralField;
+use SilverStripe\Forms\RequiredFields;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
 use SilverStripe\Forms\TextareaField;
@@ -480,7 +482,16 @@ class Group extends DataObject
      */
     public function setCode($val)
     {
-        $this->setField("Code", Convert::raw2url($val));
+        $currentGroups = Group::get()
+            ->map('Code', 'Title')
+            ->toArray();
+        $code = Convert::raw2url($val);
+        $count = 2;
+        while (isset($currentGroups[$code])) {
+            $code = Convert::raw2url($val . '-' . $count);
+            $count++;
+        }
+        $this->setField("Code", $code);
     }
 
     public function validate()
@@ -506,7 +517,43 @@ class Group extends DataObject
             }
         }
 
+        $currentGroups = Group::get()
+            ->filter('ID:not', $this->ID)
+            ->map('Code', 'Title')
+            ->toArray();
+
+        if (isset($currentGroups[$this->Code])) {
+            $result->addError(
+                _t(
+                    'SilverStripe\\Security\\Group.ValidationIdentifierAlreadyExists',
+                    'A Group ({group}) already exists with the same {identifier}',
+                    ['group' => $this->Code, 'identifier' => 'Code']
+                )
+            );
+        }
+
+        if (in_array($this->Title, $currentGroups)) {
+            $result->addError(
+                _t(
+                    'SilverStripe\\Security\\Group.ValidationIdentifierAlreadyExists',
+                    'A Group ({group}) already exists with the same {identifier}',
+                    ['group' => $this->Title, 'identifier' => 'Title']
+                )
+            );
+        }
+
         return $result;
+    }
+
+    public function getCMSCompositeValidator(): CompositeValidator
+    {
+        $validator = parent::getCMSCompositeValidator();
+
+        $validator->addValidator(RequiredFields::create([
+            'Title'
+        ]));
+
+        return $validator;
     }
 
     public function onBeforeWrite()

--- a/tests/php/Security/GroupCsvBulkLoaderTest.php
+++ b/tests/php/Security/GroupCsvBulkLoaderTest.php
@@ -38,7 +38,7 @@ class GroupCsvBulkLoaderTest extends SapphireTest
 
         $updated = $results->Updated()->toArray();
         $this->assertEquals(count($updated), 1);
-        $this->assertEquals($updated[0]->Code, 'newgroup1');
+        $this->assertEquals($updated[0]->Code, 'newgroup1-2');
         $this->assertEquals($updated[0]->Title, 'New Group 1');
     }
 

--- a/tests/php/Security/GroupTest.yml
+++ b/tests/php/Security/GroupTest.yml
@@ -1,12 +1,16 @@
 'SilverStripe\Security\Group':
   admingroup:
+    Title: Admin Group
     Code: admingroup
   parentgroup:
+    Title: Parent Group
     Code: parentgroup
   childgroup:
+    Title: Child Group
     Code: childgroup
     Parent: '=>SilverStripe\Security\Group.parentgroup'
   grandchildgroup:
+    Title: Grandchild Group
     Code: grandchildgroup
     Parent: '=>SilverStripe\Security\Group.childgroup'
   group1:


### PR DESCRIPTION
You can currently create a new Group in the Security section of the CMS and leave the Title blank or fill it with only whitespace.

This pull requests adds some more validation on the Group DataObject as well as updating the GroupTest unit test.


