### PR TITLE
Update URL in docs for ICU documentation

### DIFF
--- a/src/Forms/DateField.php
+++ b/src/Forms/DateField.php
@@ -42,7 +42,7 @@ use SilverStripe\ORM\ValidationResult;
  * # Formats
  *
  * All format strings should follow the CLDR standard as per
- * http://userguide.icu-project.org/formatparse/datetime. These will be converted
+ * https://unicode-org.github.io/icu/userguide/format_parse/datetime These will be converted
  * automatically to jquery UI format.
  *
  * The value of this field in PHP will be ISO 8601 standard (e.g. 2004-02-12), and
@@ -51,7 +51,7 @@ use SilverStripe\ORM\ValidationResult;
  * Note: Do NOT use php date format strings. Date format strings follow the date
  * field symbol table as below.
  *
- * @see http://userguide.icu-project.org/formatparse/datetime
+ * @see https://unicode-org.github.io/icu/userguide/format_parse/datetime
  * @see http://api.jqueryui.com/datepicker/#utility-formatDate
  */
 class DateField extends TextField
@@ -169,7 +169,7 @@ class DateField extends TextField
      * This can be set explicitly. If not, this will be generated from the current locale
      * with the current date length.
      *
-     * @see http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Field-Symbol-Table
+     * @see https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table
      */
     public function getDateFormat()
     {
@@ -190,7 +190,7 @@ class DateField extends TextField
      * Set date format in CLDR standard format.
      * Only applicable with {@link setHTML5(false)}.
      *
-     * @see http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Field-Symbol-Table
+     * @see https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table
      * @param string $format
      * @return $this
      */

--- a/src/Forms/DatetimeField.php
+++ b/src/Forms/DatetimeField.php
@@ -259,7 +259,7 @@ class DatetimeField extends TextField
      * This can be set explicitly. If not, this will be generated from the current locale
      * with the current date length.
      *
-     * @see http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Field-Symbol-Table
+     * @see https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table
      */
     public function getDatetimeFormat()
     {
@@ -275,7 +275,7 @@ class DatetimeField extends TextField
      * Set date format in CLDR standard format.
      * Only applicable with {@link setHTML5(false)}.
      *
-     * @see http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Field-Symbol-Table
+     * @see https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table
      * @param string $format
      * @return $this
      */

--- a/src/Forms/TimeField.php
+++ b/src/Forms/TimeField.php
@@ -91,7 +91,7 @@ class TimeField extends TextField
      * This can be set explicitly. If not, this will be generated from the current locale
      * with the current time length.
      *
-     * @see http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Field-Symbol-Table
+     * @see https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table
      */
     public function getTimeFormat()
     {
@@ -112,7 +112,7 @@ class TimeField extends TextField
      * Set time format in CLDR standard format.
      * Only applicable with {@link setHTML5(false)}.
      *
-     * @see http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Field-Symbol-Table
+     * @see https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table
      * @param string $format
      * @return $this
      */

--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -25,7 +25,7 @@ use SilverStripe\Security\Security;
  * </code>
  *
  * Date formats all follow CLDR standard format codes
- * @link http://userguide.icu-project.org/formatparse/datetime
+ * @link https://unicode-org.github.io/icu/userguide/format_parse/datetime
  */
 class DBDate extends DBField
 {
@@ -261,7 +261,7 @@ class DBDate extends DBField
      * Return the date using a particular formatting string. Use {o} to include an ordinal representation
      * for the day of the month ("1st", "2nd", "3rd" etc)
      *
-     * @param string $format Format code string. See http://userguide.icu-project.org/formatparse/datetime
+     * @param string $format Format code string. See https://unicode-org.github.io/icu/userguide/format_parse/datetime
      * @param string $locale Custom locale to use (add to signature in 5.0)
      * @return string The date in the requested format
      */

--- a/src/ORM/FieldType/DBTime.php
+++ b/src/ORM/FieldType/DBTime.php
@@ -114,7 +114,7 @@ class DBTime extends DBField
     /**
      * Return the time using a particular formatting string.
      *
-     * @param string $format Format code string. See http://userguide.icu-project.org/formatparse/datetime
+     * @param string $format Format code string. See https://unicode-org.github.io/icu/userguide/format_parse/datetime
      * @return string The time in the requested format
      */
     public function Format($format)


### PR DESCRIPTION
Update documentation that shows the link http://userguide.icu-project.org to the new location https://unicode-org.github.io/icu

![Screen Shot 2021-10-15 at 11 19 38 AM](https://user-images.githubusercontent.com/166450/137403522-5c25aa41-f44c-4f81-a041-7740c246ca74.png)

