### PR TITLE
MINOR: make debug query easy-ish to parse

### DIFF
--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -267,7 +267,14 @@ abstract class Database
     protected function displayQuery($query, $endtime)
     {
         $queryCount = sprintf("%04d", $this->queryCount);
-        Debug::message("\n$queryCount: $query\n{$endtime}s\n", false);
+        Debug::message(
+            "
+                 \n|###|$queryCount:
+                 \n|##|$query
+                 \n|#|$endtime (seconds)
+             ",
+             false
+        );
     }
 
     /**


### PR DESCRIPTION
When you get 100s / 1000s of queries from ?&showqueries=backtrace and the like, it is great to have a way to, for example, find the slowest queries.  Having some characters to split the text into columns, etc... is useful here.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
