### PR TITLE
BUG: Datetime now() should be immutable

### DIFF
--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -562,11 +562,7 @@ class DBDate extends DBField
     public function modify(string $adjustment): self
     {
         $modifiedTime = strtotime($adjustment, $this->getTimestamp());
-
-        // Return a clone of this field so this modification doesn't apply to any other object references
-        $field = clone $this;
-
-        return $field->setValue($modifiedTime);
+        return $this->setValue($modifiedTime);
     }
 
     /**

--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -562,7 +562,11 @@ class DBDate extends DBField
     public function modify(string $adjustment): self
     {
         $modifiedTime = strtotime($adjustment, $this->getTimestamp());
-        return $this->setValue($modifiedTime);
+
+        // Return a clone of this field so this modification doesn't apply to any other object references
+        $field = clone $this;
+
+        return $field->setValue($modifiedTime);
     }
 
     /**

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -215,8 +215,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
         /** @var DBDatetime $now */
         $now = DBField::create_field('Datetime', $time);
 
-        // Make this field immutable, so future modifications don't apply to any other object references
-        return $now->setImmutable(true);
+        return $now;
     }
 
     /**

--- a/tests/php/Forms/DatetimeFieldTest.php
+++ b/tests/php/Forms/DatetimeFieldTest.php
@@ -507,7 +507,8 @@ class DatetimeFieldTest extends SapphireTest
         DBDatetime::set_mock_now($globalStateNow);
 
         // Suppose we need to know the current time in our feature, we store it in a variable
-        $now = DBDatetime::now();
+        // Make this field immutable, so future modifications don't apply to any other object references
+        $now = DBDatetime::now()->setImmutable(true);
 
         // Later in the code we want to know the time value for 10 days later, we can reuse our $now variable
         $later = $now->modify('+ 10 days')->Rfc2822();

--- a/tests/php/Forms/DatetimeFieldTest.php
+++ b/tests/php/Forms/DatetimeFieldTest.php
@@ -501,6 +501,23 @@ class DatetimeFieldTest extends SapphireTest
         $field->setTimezone('Pacific/Auckland');
     }
 
+    public function testModifyReturnNewField(): void
+    {
+        $globalStateNow = '2020-01-01 00:00:00';
+        DBDatetime::set_mock_now($globalStateNow);
+
+        // Suppose we need to know the current time in our feature, we store it in a variable
+        $now = DBDatetime::now();
+
+        // Later in the code we want to know the time value for 10 days later, we can reuse our $now variable
+        $later = $now->modify('+ 10 days')->Rfc2822();
+
+        // Our expectation is that this code should not apply the change to our
+        // $now variable declared earlier in the code
+        $this->assertSame('2020-01-11 00:00:00', $later, 'We expect to get a future datetime');
+        $this->assertSame($globalStateNow, $now->Rfc2822(), 'We expect to get the current datetime');
+    }
+
     protected function getMockForm()
     {
         /** @skipUpgrade */


### PR DESCRIPTION
# BUG: Datetime now() should be immutable

I noticed that `DBDate::now()->modify()` doesn't return a new field instance. This can cause an unintended side-effects and waste time of developers figuring out what the issue is.

This change-set ensures that the `now()` returns an immutable field instance so any existing references to the old field are still pointing to the old value.

I included a unit test to showcase this behaviour.

## Notes

Unit tests failure is an upstream issue not related to this change-set.

## Related issues

https://github.com/silverstripe/silverstripe-framework/issues/10126