### PR TITLE
Cosmetic change to italian translation

### DIFF
--- a/lang/it.yml
+++ b/lang/it.yml
@@ -72,7 +72,7 @@ it:
     VALIDATOR: Valiidatore
     VALIDCURRENCY: 'Inserisci una valuta valida'
   SilverStripe\Forms\FormField:
-    EXAMPLE: 'e.g. {format}'
+    EXAMPLE: 'per es. {format}'
     NONE: nessuno
   SilverStripe\Forms\FormScaffolder:
     TABMAIN: Principale


### PR DESCRIPTION
In italian we prefer the shortened locution "p. es." or "per es." ("per esempio", "for example") instead of the the english "e. g." ("exempli gratia", from latin, also correct in italian but less used in common form).

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
