### PR TITLE
ENH Resolve relative paths in CSS files when combining

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "swiftmailer/swiftmailer": "^6.2",
         "symfony/cache": "^3.4 || ^4.0",
         "symfony/config": "^3.4 || ^4.0",
+        "symfony/filesystem": "^5.4 || ^6.0",
         "symfony/translation": "^3.4 || ^4.0",
         "symfony/yaml": "^3.4 || ^4.0",
         "php": "^7.4 || ^8.0",

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -55,8 +55,8 @@ class Requirements_Backend
     /**
      * Determine if relative urls in the combined files should be converted to absolute.
      *
-     * By default combined files will be parsed for relative urls to image/font assets and those
-     * utls will be changed to absolute to accomodate to the fact that the combined css is placed
+     * By default combined files will be parsed for relative URLs to image/font assets and those
+     * URLs will be changed to absolute to accomodate the fact that the combined css is placed
      * in a totally different folder than the source css files.
      *
      * Turn this off if you see some unexpected results.

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -1458,10 +1458,10 @@ MESSAGE
         $content = preg_replace_callback('#(url\([\n\r\s\'"]*)([^\s\)\?\'"]+)#i', function ($match) use ($fileUrlDir) {
             [ $fullMatch, $prefix, $relativePath ] = $match;
             if ($relativePath[0] === '/' || false !== strpos($relativePath, '://')) {
-                return $prefix . $relativePath;
+                return $fullMatch;
             }
-            $full = FilesystemPath::canonicalize(FilesystemPath::join($fileUrlDir, $relativePath));
-            return $prefix . $full;
+            $substitute = FilesystemPath::canonicalize(FilesystemPath::join($fileUrlDir, $relativePath));
+            return $prefix . $substitute;
         }, $content);
         return $content;
     }

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -65,7 +65,7 @@ class Requirements_Backend
      * @config
      * @var bool
      */
-    private static $resolve_relative_css_refs = true;
+    private static $resolve_relative_css_refs = false;
 
     /**
      * Paths to all required JavaScript files relative to docroot
@@ -1456,11 +1456,11 @@ MESSAGE
         $fileUrl = Injector::inst()->get(ResourceURLGenerator::class)->urlForResource($filePath);
         $fileUrlDir = dirname($fileUrl);
         $content = preg_replace_callback('#(url\([\n\r\s\'"]*)([^\s\)\?\'"]+)#i', function ($match) use ($fileUrlDir) {
-            [ $_, $prefix, $relativePath ] = $match;
+            [ $fullMatch, $prefix, $relativePath ] = $match;
             if ($relativePath[0] === '/' || false !== strpos($relativePath, '://')) {
                 return $prefix . $relativePath;
             }
-            $full = FilesystemPath::canonicalize($fileUrlDir . '/' . $relativePath);
+            $full = FilesystemPath::canonicalize(FilesystemPath::join($fileUrlDir, $relativePath));
             return $prefix . $full;
         }, $content);
         return $content;

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -13,6 +13,7 @@ use Silverstripe\Assets\Dev\TestAssetStore;
 use SilverStripe\View\Requirements_Backend;
 use SilverStripe\Core\Manifest\ResourceURLGenerator;
 use SilverStripe\Control\SimpleResourceURLGenerator;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\View\SSViewer;
 use SilverStripe\View\ThemeResourceLoader;
 
@@ -77,12 +78,12 @@ class RequirementsTest extends SapphireTest
         $this->assertStringContainsString('http://www.mydomain.com:3000/test.css', $html, 'Load external with port');
     }
 
-    public function testResolveCSSReferences()
+    public function testResolveCSSReferencesDisabled()
     {
         /** @var Requirements_Backend $backend */
         $backend = Injector::inst()->create(Requirements_Backend::class);
         $this->setupRequirements($backend);
-        $backend->setCombinedFilesFolder('_combinedfiles');
+        Config::forClass(get_class($backend))->set('resolve_relative_css_refs', false);
 
         $backend->combineFiles(
             'RequirementsTest_pc.css',
@@ -96,7 +97,59 @@ class RequirementsTest extends SapphireTest
 
         // we get the file path here
         $allCSS = $backend->getCSS();
-        $this->assertTrue(count($allCSS) == 1, 'only one combined file');
+        $this->assertCount(
+            1,
+            $allCSS,
+            'only one combined file'
+        );
+
+        $files = array_keys($allCSS);
+        $combinedFileName = $files[0];
+        $combinedFileName = str_replace('/' . ASSETS_DIR . '/', '/', $combinedFileName);
+
+        $combinedFilePath = TestAssetStore::base_path() . $combinedFileName;
+
+        $content = file_get_contents($combinedFilePath);
+
+        /* DISABLED COMBINED CSS URL RESOLVER IGNORED ONE DOT */
+        $this->assertStringContainsString(
+            ".p0 { background: url(./zero.gif); }",
+            $content,
+            'disabled combined css url resolver ignored one dot'
+        );
+
+        /* DISABLED COMBINED CSS URL RESOLVER IGNORED DOUBLE-DOT */
+        $this->assertStringContainsString(
+            ".p1 { background: url(../one.gif); }",
+            $content,
+            'disabled combined css url resolver ignored double-dot'
+        );
+    }
+
+    public function testResolveCSSReferences()
+    {
+        /** @var Requirements_Backend $backend */
+        $backend = Injector::inst()->create(Requirements_Backend::class);
+        $this->setupRequirements($backend);
+        Config::forClass(get_class($backend))->set('resolve_relative_css_refs', true);
+
+        $backend->combineFiles(
+            'RequirementsTest_pc.css',
+            [
+                'css/RequirementsTest_d.css',
+                'css/deep/deeper/RequirementsTest_p.css'
+            ]
+        );
+
+        $backend->includeInHTML(self::$html_template);
+
+        // we get the file path here
+        $allCSS = $backend->getCSS();
+        $this->assertCount(
+            1,
+            $allCSS,
+            'only one combined file'
+        );
         $files = array_keys($allCSS);
         $combinedFileName = $files[0];
         $combinedFileName = str_replace('/' . ASSETS_DIR . '/', '/', $combinedFileName);
@@ -111,39 +164,102 @@ class RequirementsTest extends SapphireTest
 
         $content = file_get_contents($combinedFilePath);
 
-        /* COMBINED CSS DECODED ONE DOT OKAY */
+        /* COMBINED CSS URL RESOLVER DECODED ONE DOT */
         $this->assertStringContainsString(
             ".p0 { background: url(/css/deep/deeper/zero.gif); }",
             $content,
-            'combined css decoded one dot okay'
+            'combined css url resolver decoded one dot'
         );
 
-        /* COMBINED CSS DECODED ONE DOUBLE-DOT OKAY */
+        /* COMBINED CSS URL RESOLVER DECODED ONE DOT WITH SINGLE QUOTES */
+        $this->assertStringContainsString(
+            ".p0sq { background: url('/css/deep/deeper/zero-sq.gif'); }",
+            $content,
+            'combined css url resolver decoded one dot with single quotes'
+        );
+
+        /* COMBINED CSS URL RESOLVER DECODED ONE DOT WITH DOUBLE QUOTES */
+        $this->assertStringContainsString(
+            ".p0dq { background: url(\"/css/deep/deeper/zero-dq.gif\"); }",
+            $content,
+            'combined css url resolver decoded one dot with double quotes'
+        );
+
+        /* COMBINED CSS URL RESOLVER DECODED ONE DOT WITH DOUBLE QUOTES AND SPACES NEW LINE */
+        $this->assertStringContainsString(
+            "\n  \"/css/deep/deeper/zero-dq-nls.gif\"\n",
+            $content,
+            'combined css url resolver decoded one dot with double quotes and spaces new line'
+        );
+
+        /* COMBINED CSS URL RESOLVER DECODED ONE DOT WITH DOUBLE QUOTES NEW LINE */
+        $this->assertStringContainsString(
+            "\"/css/deep/deeper/zero-dq-nl.gif\"",
+            $content,
+            'combined css url resolver decoded one dot with double quotes new line'
+        );
+
+        /* COMBINED CSS URL RESOLVER DECODED ONE DOT WITH DOUBLE QUOTES NEW LINE WITH SPACES */
+        $this->assertStringContainsString(
+            "\"/css/deep/deeper/zero-dq-nls.gif\"",
+            $content,
+            'combined css url resolver decoded one dot with double quotes new line with spaces'
+        );
+
+        /* COMBINED CSS URL RESOLVER DECODED 1 DOUBLE-DOT */
         $this->assertStringContainsString(
             ".p1 { background: url(/css/deep/one.gif); }",
             $content,
-            'combined css decoded 1 double-dot okay'
+            'combined css url resolver decoded 1 double-dot'
         );
 
-        /* COMBINED CSS DECODED 2 DOUBLE-DOT OKAY */
+        /* COMBINED CSS URL RESOLVER DECODED 2 DOUBLE-DOT */
         $this->assertStringContainsString(
             ".p2 { background: url(/css/two.gif); }",
             $content,
-            'combined css decoded 2 double-dot okay'
+            'combined css url resolver decoded 2 double-dot'
         );
 
-        /* COMBINED CSS DECODED 3 DOUBLE-DOT OKAY */
+        /* COMBINED CSS URL RESOLVER DECODED 2 DOUBLE-DOT SINGLE QUOTES */
+        $this->assertStringContainsString(
+            ".p2sq { background: url('/css/two-sq.gif'); }",
+            $content,
+            'combined css url resolver decoded 2 double-dot single quotes'
+        );
+
+        /* COMBINED CSS URL RESOLVER DECODED 2 DOUBLE-DOT DOUBLE QUOTES */
+        $this->assertStringContainsString(
+            ".p2dq { background: url(\"/css/two-dq.gif\"); }",
+            $content,
+            'combined css url resolver decoded 2 double-dot double quotes'
+        );
+
+        /* COMBINED CSS URL RESOLVER SHOULD NOT TOUCH ABSOLUTE PATH */
+        $this->assertStringContainsString(
+            ".p2abs { background: url(/foo/bar/../../two-abs.gif); }",
+            $content,
+            'combined css url resolver should not touch absolute path'
+        );
+
+        /* COMBINED CSS URL RESOLVER SHOULD NOT TOUCH ABSOLUTE PATH ON NEW LINE */
+        $this->assertStringContainsString(
+            "\n  /foo/bar/../../two-abs-ln.gif\n",
+            $content,
+            'combined css url resolver should not touch absolute path on new line'
+        );
+
+        /* COMBINED CSS URL RESOLVER DECODED 3 DOUBLE-DOT */
         $this->assertStringContainsString(
             ".p3 { background: url(/three.gif); }",
             $content,
-            'combined css decoded 3 double-dot okay'
+            'combined css url resolver decoded 3 double-dot'
         );
 
-        /* COMBINED CSS DECODED 4 DOUBLE-DOT OKAY */
+        /* COMBINED CSS URL RESOLVER DECODED 4 DOUBLE-DOT */
         $this->assertStringContainsString(
             ".p4 { background: url(/../four.gif); }",
             $content,
-            'combined css decoded 4 double-dot okay'
+            'combined css url resolver decoded 4 double-dot'
         );
     }
 

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -164,11 +164,32 @@ class RequirementsTest extends SapphireTest
 
         $content = file_get_contents($combinedFilePath);
 
+        /* COMBINED CSS URL RESOLVER IGNORE FULL URLS */
+        $this->assertStringContainsString(
+            ".url { background: url(http://example.com/zero.gif); }",
+            $content,
+            'combined css url resolver ignore full urls'
+        );
+
         /* COMBINED CSS URL RESOLVER DECODED ONE DOT */
         $this->assertStringContainsString(
             ".p0 { background: url(/css/deep/deeper/zero.gif); }",
             $content,
             'combined css url resolver decoded one dot'
+        );
+
+        /* COMBINED CSS URL RESOLVER DECODED NO DOTS */
+        $this->assertStringContainsString(
+            ".p0-plain { background: url(/css/deep/deeper/zero.gif); }",
+            $content,
+            'combined css url resolver decoded no dots'
+        );
+
+        /* COMBINED CSS URL RESOLVER DAMAGED A QUERYSTRING */
+        $this->assertStringContainsString(
+            ".p0-qs { background: url(/css/deep/deeper/zero.gif?some=param); }",
+            $content,
+            'combined css url resolver damaged a querystring'
         );
 
         /* COMBINED CSS URL RESOLVER DECODED ONE DOT WITH SINGLE QUOTES */
@@ -255,11 +276,18 @@ class RequirementsTest extends SapphireTest
             'combined css url resolver decoded 3 double-dot'
         );
 
-        /* COMBINED CSS URL RESOLVER DECODED 4 DOUBLE-DOT */
+        /* COMBINED CSS URL RESOLVER DECODED 4 DOUBLE-DOT WHEN ONLY 3 LEVELS AVAILABLE*/
         $this->assertStringContainsString(
-            ".p4 { background: url(/../four.gif); }",
+            ".p4 { background: url(/four.gif); }",
             $content,
-            'combined css url resolver decoded 4 double-dot'
+            'combined css url resolver decoded 4 double-dot when only 4 levels available'
+        );
+
+        /* COMBINED CSS URL RESOLVER MODIFIED AN ARBITRARY VALUE */
+        $this->assertStringContainsString(
+            ".weird { content: \"./keepme.gif\"; }",
+            $content,
+            'combined css url resolver modified an arbitrary value'
         );
     }
 

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -280,7 +280,7 @@ class RequirementsTest extends SapphireTest
         $this->assertStringContainsString(
             ".p4 { background: url(/four.gif); }",
             $content,
-            'combined css url resolver decoded 4 double-dot when only 4 levels available'
+            'combined css url resolver decoded 4 double-dot when only 3 levels available'
         );
 
         /* COMBINED CSS URL RESOLVER MODIFIED AN ARBITRARY VALUE */

--- a/tests/php/View/SSViewerTest/public/css/deep/deeper/RequirementsTest_p.css
+++ b/tests/php/View/SSViewerTest/public/css/deep/deeper/RequirementsTest_p.css
@@ -1,4 +1,7 @@
+.url { background: url(http://example.com/zero.gif); } /* don't touch this */
 .p0 { background: url(./zero.gif); }
+.p0-plain { background: url(zero.gif); }
+.p0-qs { background: url(./zero.gif?some=param); } /* keep the query string */
 .p0-nl { background: url(
   ./zero-nl.gif );
 }
@@ -20,3 +23,4 @@
 .p2dq { background: url("../../two-dq.gif"); }
 .p3 { background: url(../../../three.gif); }
 .p4 { background: url(../../../../four.gif); }
+.weird { content: "./keepme.gif"; }

--- a/tests/php/View/SSViewerTest/public/css/deep/deeper/RequirementsTest_p.css
+++ b/tests/php/View/SSViewerTest/public/css/deep/deeper/RequirementsTest_p.css
@@ -1,0 +1,5 @@
+.p0 { background: url(./zero.gif); }
+.p1 { background: url(../one.gif); }
+.p2 { background: url(../../two.gif); }
+.p3 { background: url(../../../three.gif); }
+.p4 { background: url(../../../../four.gif); }

--- a/tests/php/View/SSViewerTest/public/css/deep/deeper/RequirementsTest_p.css
+++ b/tests/php/View/SSViewerTest/public/css/deep/deeper/RequirementsTest_p.css
@@ -1,5 +1,22 @@
 .p0 { background: url(./zero.gif); }
+.p0-nl { background: url(
+  ./zero-nl.gif );
+}
+.p0sq { background: url('./zero-sq.gif'); }
+.p0dq { background: url("./zero-dq.gif"); }
+.p0dq-nl { background: url(
+"./zero-dq-nl.gif"
+); }
+.p0dq-nls { background: url(
+  "./zero-dq-nls.gif"
+); }
 .p1 { background: url(../one.gif); }
 .p2 { background: url(../../two.gif); }
+.p2abs { background: url(/foo/bar/../../two-abs.gif); } /* don't touch this */
+.p2abs-ln { background: url(
+  /foo/bar/../../two-abs-ln.gif
+); } /* don't touch this */
+.p2sq { background: url('../../two-sq.gif'); }
+.p2dq { background: url("../../two-dq.gif"); }
 .p3 { background: url(../../../three.gif); }
 .p4 { background: url(../../../../four.gif); }


### PR DESCRIPTION
When combining CSS from a complex directory structure, especially when using some third-party libraries, they may refer to other files (i.e. FontAwesome refers to the font files) and the combines result doesn't seem to taking the paths of the original files into account. This results in broken themes when running SilverStripe in LIVE mode.

i.e.
I have included `themes/simple/vendors/fontawesome-pro-5/css/all.css` into `Requirements::combine_files()` call and while doing good in DEV mode (when no actual combining happening) it breaks when switching to LIVE because the source file contains references like `../webfonts/some-font.ttf` and the combined file is located in `/assets/_combinedfiles/`.

Here I'm suggesting to resolve the paths to such additional assets like this:
Consider file is located in `/_resources/themes/simple/some/folders/main.css`.

### Valid cases
| from | to |
| ---- | ---- |
| `./zero.gif` | `/_resources/themes/simple/some/folders/zero.gif` |
| `../one.gif` | `/_resources/themes/simple/some/one.gif` |
| `../../two.gif` | `/_resources/themes/simple/two.gif` |
| `../../../three.gif` | `/_resources/themes/three.gif` |

### Invalid cases
This is to demonstrate what happens if we try to escape the allowed directories or use `.../` in a path.
| from | to |
| ---- | ---- |
| `../../../../../../../../../../../../too-many.gif` | `/too-many.gif` |
| `.../invalid.gif` | `./_resources/themes/simple/some/invalid.gif` |



