### PR TITLE
Fix broken tests

### DIFF
--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -1108,9 +1108,15 @@ if (class_exists(IsEqualCanonicalizing::class)) {
                 $member = $this->cache_generatedMembers[$permCode];
             } else {
                 // Generate group with these permissions
-                $group = Group::create();
-                $group->Title = "$permCode group";
-                $group->write();
+                $group = Group::get()->filterAny([
+                    'Code' => "$permCode-group",
+                    'Title' => "$permCode group",
+                ])->first();
+                if (!$group || !$group->exists()) {
+                    $group = Group::create();
+                    $group->Title = "$permCode group";
+                    $group->write();
+                }
 
                 // Create each individual permission
                 foreach ($permArray as $permArrayItem) {


### PR DESCRIPTION
This update was missing from https://github.com/silverstripe/silverstripe-framework/pull/10113. The diff on that PR shows at as being added to lines 1115 - 1123, but it was [actually added to 2437 - 2445](https://github.com/silverstripe/silverstripe-framework/commit/b8d37f9ae43b971890ae311d8bdcfaf5c32927ae). I think that’s probably because the PHPUnit 9 changes (which effectively duplicate the `SapphireTest` class) were merged after that PR was open, and for some reason Github’s UI was showing the changes in the wrong place.

Either way, it needs to be added to _both_ copies of `SapphireTest`.