### PR TITLE
Prioritise posix_getuid() when attempting to create name for temp folder

### DIFF
--- a/src/Core/TempFolder.php
+++ b/src/Core/TempFolder.php
@@ -36,16 +36,19 @@ class TempFolder
      */
     public static function getTempFolderUsername()
     {
-        $user = Environment::getEnv('APACHE_RUN_USER');
+        $user = '';
+        if (function_exists('posix_getpwuid') && function_exists('posix_getuid')) {
+            $userDetails = posix_getpwuid(posix_getuid());
+            $user = $userDetails['name'];
+        }
+        if (!$user) {
+            $user = Environment::getEnv('APACHE_RUN_USER');
+        }
         if (!$user) {
             $user = Environment::getEnv('USER');
         }
         if (!$user) {
             $user = Environment::getEnv('USERNAME');
-        }
-        if (!$user && function_exists('posix_getpwuid') && function_exists('posix_getuid')) {
-            $userDetails = posix_getpwuid(posix_getuid());
-            $user = $userDetails['name'];
         }
         if (!$user) {
             $user = 'unknown';


### PR DESCRIPTION
I’m proposing this due to issues we’re having with Silverstripe creating a temp folder with the wrong name when running via CLI.

- `$_ENV['APACHE_RUN_USER']` doesn’t appear to be officially documented anywhere, and it’s Apache-specific
- `$_SERVER['USER']` and `$_SERVER['USERNAME']` are also undocumented AFAICT, and appear to give the current SSH username rather than the process owner

This change prioritises the actually documented `posix_getuid()`, but falls back to the other methods as the function may not exist in Windows environments. Note that this doesn’t affect filesystem permissions, only the name of the temp folder.

On our VPS, we see:
```
realuser@server ~ $ php -r "var_dump(\$_SERVER['USER']);"
string(5) "ssh-username"

realuser@server ~ $ php -r "var_dump(posix_getpwuid(posix_getuid())['name']);"
string(8) "realuser"
```

The current behaviour results in a different directory being created by CLI processes to Apache processes. In the example below, the first one (generated by Apache) is correct but the second one (created by a CLI `dev/build`) is created with the correct owner but wrong name:
```
realuser@server ~ $ cd silverstripe-cache && ls -al
total 28
drwxrwxrwx+  4 realuser www-data 4096 Nov  4 14:26 .
drwxr-xr-x   9 realuser www-data 4096 Nov  2 15:31 ..
drwxrwxr-x+ 16 realuser www-data 4096 Nov  4 14:29 realuser
drwxrwxr-x+ 17 realuser www-data 4096 Nov  4 14:27 ssh-username
```