### PR TITLE
BUG Don't load SapphireTest in manifest

### DIFF
--- a/src/Core/Manifest/ClassLoader.php
+++ b/src/Core/Manifest/ClassLoader.php
@@ -112,6 +112,13 @@ class ClassLoader
                 break;
             }
         }
+
+        try {
+            $reflector = new \ReflectionClass($class);
+            return $reflector->getFileName();
+        } catch (\ReflectionException $ex) {
+        }
+
         return false;
     }
 

--- a/src/Core/Manifest/ManifestFileFinder.php
+++ b/src/Core/Manifest/ManifestFileFinder.php
@@ -251,4 +251,13 @@ class ManifestFileFinder extends FileFinder
 
         return false;
     }
+
+    protected function acceptFile($basename, $pathname, $depth)
+    {
+        if (preg_match('/^.+Test\.php$/', $basename) && preg_match('/^.+\/tests/', $pathname)) {
+            return false;
+        }
+
+        return parent::acceptFile($basename, $pathname, $depth);
+    }
 }


### PR DESCRIPTION
We're having some problems with our new PHPUnit 9 implementation.

Basically, when PHPUnit runs, the manifest attempts to discover every test class ... including some that have not been converted to be compatible with PHPUnit 9. This causes annoying errors and blocks us from running the unit tests.

This PRs attempts to bypass this problem with some ugly hack. I suspect there's a better way of doing this. Ideally, the manifest would be smart enough to only discover the test for the suite you are running.

But let's maybe start by seeing if this solves the problem ... then see if there's a better way to do it.
