### PR TITLE
ENH Make all GridField components injectable.

### DIFF
--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -259,7 +259,7 @@ class GridField extends FormField
 
         // If the edit button has been removed, replace it with a view button
         if ($hadEditButton && !$copyConfig->getComponentByType(GridFieldViewButton::class)) {
-            $copyConfig->addComponent(new GridFieldViewButton);
+            $copyConfig->addComponent(GridFieldViewButton::create());
         }
 
         return $copy;
@@ -295,7 +295,7 @@ class GridField extends FormField
         $this->config = $config;
 
         if (!$this->config->getComponentByType(GridState_Component::class)) {
-            $this->config->addComponent(new GridState_Component());
+            $this->config->addComponent(GridState_Component::create());
         }
 
         return $this;
@@ -440,7 +440,7 @@ class GridField extends FormField
     public function FieldHolder($properties = [])
     {
         $this->extend('onBeforeRenderHolder', $this, $properties);
-        
+
         $columns = $this->getColumns();
 
         $list = $this->getManipulatedList();
@@ -655,7 +655,7 @@ class GridField extends FormField
             $tableAttributes,
             $header . "\n" . $footer . "\n" . $body
         );
-        
+
         $message = Convert::raw2xml($this->getMessage());
         if (is_array($message)) {
             $message = $message['message'];

--- a/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
+++ b/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
@@ -15,6 +15,7 @@ use SilverStripe\ORM\DataList;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 use LogicException;
+use SilverStripe\Core\Injector\Injectable;
 
 /**
  * This class is is responsible for adding objects to another object's has_many
@@ -34,6 +35,7 @@ use LogicException;
  */
 class GridFieldAddExistingAutocompleter implements GridField_HTMLProvider, GridField_ActionProvider, GridField_DataManipulator, GridField_URLHandler
 {
+    use Injectable;
 
     /**
      * The HTML fragment to write this component into

--- a/src/Forms/GridField/GridFieldAddNewButton.php
+++ b/src/Forms/GridField/GridFieldAddNewButton.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Forms\GridField;
 
 use SilverStripe\Control\Controller;
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\RelationList;
 use SilverStripe\View\ArrayData;
@@ -17,6 +18,7 @@ use SilverStripe\View\SSViewer;
  */
 class GridFieldAddNewButton implements GridField_HTMLProvider
 {
+    use Injectable;
 
     protected $targetFragment;
 

--- a/src/Forms/GridField/GridFieldButtonRow.php
+++ b/src/Forms/GridField/GridFieldButtonRow.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms\GridField;
 
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 
@@ -16,6 +17,7 @@ use SilverStripe\View\SSViewer;
  */
 class GridFieldButtonRow implements GridField_HTMLProvider
 {
+    use Injectable;
 
     protected $targetFragment;
 

--- a/src/Forms/GridField/GridFieldConfig_Base.php
+++ b/src/Forms/GridField/GridFieldConfig_Base.php
@@ -15,13 +15,13 @@ class GridFieldConfig_Base extends GridFieldConfig
     public function __construct($itemsPerPage = null)
     {
         parent::__construct();
-        $this->addComponent(new GridFieldToolbarHeader());
-        $this->addComponent(new GridFieldButtonRow('before'));
-        $this->addComponent($sort = new GridFieldSortableHeader());
-        $this->addComponent($filter = new GridFieldFilterHeader());
-        $this->addComponent(new GridFieldDataColumns());
-        $this->addComponent(new GridFieldPageCount('toolbar-header-right'));
-        $this->addComponent($pagination = new GridFieldPaginator($itemsPerPage));
+        $this->addComponent(GridFieldToolbarHeader::create());
+        $this->addComponent(GridFieldButtonRow::create('before'));
+        $this->addComponent($sort = GridFieldSortableHeader::create());
+        $this->addComponent($filter = GridFieldFilterHeader::create());
+        $this->addComponent(GridFieldDataColumns::create());
+        $this->addComponent(GridFieldPageCount::create('toolbar-header-right'));
+        $this->addComponent($pagination = GridFieldPaginator::create($itemsPerPage));
 
         $sort->setThrowExceptionOnBadDataType(false);
         $filter->setThrowExceptionOnBadDataType(false);

--- a/src/Forms/GridField/GridFieldConfig_RecordEditor.php
+++ b/src/Forms/GridField/GridFieldConfig_RecordEditor.php
@@ -17,18 +17,18 @@ class GridFieldConfig_RecordEditor extends GridFieldConfig
     {
         parent::__construct();
 
-        $this->addComponent(new GridFieldButtonRow('before'));
-        $this->addComponent(new GridFieldAddNewButton('buttons-before-left'));
-        $this->addComponent(new GridFieldToolbarHeader());
-        $this->addComponent($sort = new GridFieldSortableHeader());
-        $this->addComponent($filter = new GridFieldFilterHeader());
-        $this->addComponent(new GridFieldDataColumns());
-        $this->addComponent(new GridFieldEditButton());
-        $this->addComponent(new GridFieldDeleteAction());
-        $this->addComponent(new GridField_ActionMenu());
-        $this->addComponent(new GridFieldPageCount('toolbar-header-right'));
-        $this->addComponent($pagination = new GridFieldPaginator($itemsPerPage));
-        $this->addComponent(new GridFieldDetailForm(null, $showPagination, $showAdd));
+        $this->addComponent(GridFieldButtonRow::create('before'));
+        $this->addComponent(GridFieldAddNewButton::create('buttons-before-left'));
+        $this->addComponent(GridFieldToolbarHeader::create());
+        $this->addComponent($sort = GridFieldSortableHeader::create());
+        $this->addComponent($filter = GridFieldFilterHeader::create());
+        $this->addComponent(GridFieldDataColumns::create());
+        $this->addComponent(GridFieldEditButton::create());
+        $this->addComponent(GridFieldDeleteAction::create());
+        $this->addComponent(GridField_ActionMenu::create());
+        $this->addComponent(GridFieldPageCount::create('toolbar-header-right'));
+        $this->addComponent($pagination = GridFieldPaginator::create($itemsPerPage));
+        $this->addComponent(GridFieldDetailForm::create(null, $showPagination, $showAdd));
 
         $sort->setThrowExceptionOnBadDataType(false);
         $filter->setThrowExceptionOnBadDataType(false);

--- a/src/Forms/GridField/GridFieldConfig_RecordViewer.php
+++ b/src/Forms/GridField/GridFieldConfig_RecordViewer.php
@@ -12,8 +12,8 @@ class GridFieldConfig_RecordViewer extends GridFieldConfig_Base
     {
         parent::__construct($itemsPerPage);
 
-        $this->addComponent(new GridFieldViewButton());
-        $this->addComponent(new GridFieldDetailForm());
+        $this->addComponent(GridFieldViewButton::create());
+        $this->addComponent(GridFieldDetailForm::create());
         $this->removeComponentsByType(GridFieldFilterHeader::class);
 
         $this->extend('updateConfig');

--- a/src/Forms/GridField/GridFieldConfig_RelationEditor.php
+++ b/src/Forms/GridField/GridFieldConfig_RelationEditor.php
@@ -29,19 +29,19 @@ class GridFieldConfig_RelationEditor extends GridFieldConfig
     {
         parent::__construct();
 
-        $this->addComponent(new GridFieldButtonRow('before'));
-        $this->addComponent(new GridFieldAddNewButton('buttons-before-left'));
-        $this->addComponent(new GridFieldAddExistingAutocompleter('buttons-before-right'));
-        $this->addComponent(new GridFieldToolbarHeader());
-        $this->addComponent($sort = new GridFieldSortableHeader());
-        $this->addComponent($filter = new GridFieldFilterHeader());
-        $this->addComponent(new GridFieldDataColumns());
-        $this->addComponent(new GridFieldEditButton());
-        $this->addComponent(new GridFieldDeleteAction(true));
-        $this->addComponent(new GridField_ActionMenu());
-        $this->addComponent(new GridFieldPageCount('toolbar-header-right'));
-        $this->addComponent($pagination = new GridFieldPaginator($itemsPerPage));
-        $this->addComponent(new GridFieldDetailForm());
+        $this->addComponent(GridFieldButtonRow::create('before'));
+        $this->addComponent(GridFieldAddNewButton::create('buttons-before-left'));
+        $this->addComponent(GridFieldAddExistingAutocompleter::create('buttons-before-right'));
+        $this->addComponent(GridFieldToolbarHeader::create());
+        $this->addComponent($sort = GridFieldSortableHeader::create());
+        $this->addComponent($filter = GridFieldFilterHeader::create());
+        $this->addComponent(GridFieldDataColumns::create());
+        $this->addComponent(GridFieldEditButton::create());
+        $this->addComponent(GridFieldDeleteAction::create(true));
+        $this->addComponent(GridField_ActionMenu::create());
+        $this->addComponent(GridFieldPageCount::create('toolbar-header-right'));
+        $this->addComponent($pagination = GridFieldPaginator::create($itemsPerPage));
+        $this->addComponent(GridFieldDetailForm::create());
 
         $sort->setThrowExceptionOnBadDataType(false);
         $filter->setThrowExceptionOnBadDataType(false);

--- a/src/Forms/GridField/GridFieldDataColumns.php
+++ b/src/Forms/GridField/GridFieldDataColumns.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Forms\GridField;
 
 use SilverStripe\Core\Convert;
 use InvalidArgumentException;
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\DataObject;
 
 /**
@@ -11,6 +12,7 @@ use SilverStripe\ORM\DataObject;
  */
 class GridFieldDataColumns implements GridField_ColumnProvider
 {
+    use Injectable;
 
     /**
      * @var array

--- a/src/Forms/GridField/GridFieldDeleteAction.php
+++ b/src/Forms/GridField/GridFieldDeleteAction.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Forms\GridField;
 
 use SilverStripe\Control\Controller;
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ValidationException;
 
@@ -16,14 +17,15 @@ use SilverStripe\ORM\ValidationException;
  * Use the {@link $removeRelation} property set in the constructor.
  *
  * <code>
- * $action = new GridFieldDeleteAction(); // delete objects permanently
+ * $action = GridFieldDeleteAction::create(); // delete objects permanently
  *
  * // removes the relation to object instead of deleting
- * $action = new GridFieldDeleteAction(true);
+ * $action = GridFieldDeleteAction::create(true);
  * </code>
  */
 class GridFieldDeleteAction implements GridField_ColumnProvider, GridField_ActionProvider, GridField_ActionMenuItem
 {
+    use Injectable;
 
     /**
      * If this is set to true, this {@link GridField_ActionProvider} will

--- a/src/Forms/GridField/GridFieldExportButton.php
+++ b/src/Forms/GridField/GridFieldExportButton.php
@@ -6,6 +6,7 @@ use League\Csv\Writer;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\DataObject;
 
 /**
@@ -13,6 +14,8 @@ use SilverStripe\ORM\DataObject;
  */
 class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionProvider, GridField_URLHandler
 {
+    use Injectable;
+
     /**
      * @var array Map of a property name on the exported objects, with values being the column title in the CSV file.
      * Note that titles are only used when {@link $csvHasHeader} is set to TRUE.

--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -8,6 +8,7 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\FieldList;
@@ -28,6 +29,8 @@ use SilverStripe\View\SSViewer;
  */
 class GridFieldFilterHeader implements GridField_URLHandler, GridField_HTMLProvider, GridField_DataManipulator, GridField_ActionProvider, GridField_StateProvider
 {
+    use Injectable;
+
     /**
      * See {@link setThrowExceptionOnBadDataType()}
      *

--- a/src/Forms/GridField/GridFieldFooter.php
+++ b/src/Forms/GridField/GridFieldFooter.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms\GridField;
 
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 
@@ -20,6 +21,7 @@ use SilverStripe\View\SSViewer;
  */
 class GridFieldFooter implements GridField_HTMLProvider
 {
+    use Injectable;
 
     /**
      * A message to display in the footer

--- a/src/Forms/GridField/GridFieldLazyLoader.php
+++ b/src/Forms/GridField/GridFieldLazyLoader.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms\GridField;
 
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\TabSet;
 use SilverStripe\ORM\ArrayList;
@@ -16,6 +17,7 @@ use SilverStripe\ORM\SS_List;
  */
 class GridFieldLazyLoader implements GridField_DataManipulator, GridField_HTMLProvider
 {
+    use Injectable;
 
     /**
      * Empty $datalist if the current request should be lazy loadable.

--- a/src/Forms/GridField/GridFieldPageCount.php
+++ b/src/Forms/GridField/GridFieldPageCount.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Forms\GridField;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\View\SSViewer;
 use LogicException;
+use SilverStripe\Core\Injector\Injectable;
 
 /**
  * GridFieldPage displays a simple current page count summary.
@@ -14,7 +15,7 @@ use LogicException;
  */
 class GridFieldPageCount implements GridField_HTMLProvider
 {
-    use Configurable;
+    use Configurable, Injectable;
 
     /**
      * @var string placement indicator for this control

--- a/src/Forms/GridField/GridFieldPaginator.php
+++ b/src/Forms/GridField/GridFieldPaginator.php
@@ -9,6 +9,7 @@ use SilverStripe\ORM\UnsavedRelationList;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 use LogicException;
+use SilverStripe\Core\Injector\Injectable;
 
 /**
  * GridFieldPaginator paginates the {@link GridField} list and adds controls
@@ -16,7 +17,7 @@ use LogicException;
  */
 class GridFieldPaginator implements GridField_HTMLProvider, GridField_DataManipulator, GridField_ActionProvider, GridField_StateProvider
 {
-    use Configurable;
+    use Configurable, Injectable;
 
     /**
      * Specifies default items per page

--- a/src/Forms/GridField/GridFieldPrintButton.php
+++ b/src/Forms/GridField/GridFieldPrintButton.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Forms\GridField;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Extensible;
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
@@ -18,7 +19,7 @@ use SilverStripe\View\Requirements;
  */
 class GridFieldPrintButton implements GridField_HTMLProvider, GridField_ActionProvider, GridField_URLHandler
 {
-    use Extensible;
+    use Extensible, Injectable;
 
     /**
      * @var array Map of a property name on the printed objects, with values

--- a/src/Forms/GridField/GridFieldSortableHeader.php
+++ b/src/Forms/GridField/GridFieldSortableHeader.php
@@ -11,6 +11,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 use LogicException;
+use SilverStripe\Core\Injector\Injectable;
 
 /**
  * GridFieldSortableHeader adds column headers to a {@link GridField} that can
@@ -20,6 +21,7 @@ use LogicException;
  */
 class GridFieldSortableHeader implements GridField_HTMLProvider, GridField_DataManipulator, GridField_ActionProvider, GridField_StateProvider
 {
+    use Injectable;
 
     /**
      * See {@link setThrowExceptionOnBadDataType()}

--- a/src/Forms/GridField/GridFieldStateManager.php
+++ b/src/Forms/GridField/GridFieldStateManager.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Forms\GridField;
 
 use SilverStripe\Control\HTTP;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Injector\Injectable;
 
 /**
  * Creates a unique key for the gridfield, and uses that to write to and retrieve
@@ -12,6 +13,8 @@ use SilverStripe\Control\HTTPRequest;
  */
 class GridFieldStateManager implements GridFieldStateManagerInterface
 {
+    use Injectable;
+
     /**
      * @param GridField $gridField
      * @return string

--- a/src/Forms/GridField/GridFieldToolbarHeader.php
+++ b/src/Forms/GridField/GridFieldToolbarHeader.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms\GridField;
 
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\View\SSViewer;
 
 /**
@@ -12,6 +13,7 @@ use SilverStripe\View\SSViewer;
  */
 class GridFieldToolbarHeader implements GridField_HTMLProvider
 {
+    use Injectable;
 
     /**
      * @param GridField $gridField

--- a/src/Forms/GridField/GridFieldViewButton.php
+++ b/src/Forms/GridField/GridFieldViewButton.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Forms\GridField;
 
 use SilverStripe\Control\Controller;
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 
@@ -13,6 +14,8 @@ use SilverStripe\View\SSViewer;
  */
 class GridFieldViewButton implements GridField_ColumnProvider, GridField_ActionMenuLink
 {
+    use Injectable;
+
     /**
      * @inheritdoc
      */

--- a/src/Forms/GridField/GridField_ActionMenu.php
+++ b/src/Forms/GridField/GridField_ActionMenu.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms\GridField;
 
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 
@@ -10,6 +11,8 @@ use SilverStripe\View\SSViewer;
  */
 class GridField_ActionMenu implements GridField_ColumnProvider, GridField_ActionProvider
 {
+    use Injectable;
+
     public function augmentColumns($gridField, &$columns)
     {
         if (!in_array('Actions', $columns)) {

--- a/src/Forms/GridField/GridState_Component.php
+++ b/src/Forms/GridField/GridState_Component.php
@@ -2,11 +2,14 @@
 
 namespace SilverStripe\Forms\GridField;
 
+use SilverStripe\Core\Injector\Injectable;
+
 /**
  * @see GridState
  */
 class GridState_Component implements GridField_HTMLProvider
 {
+    use Injectable;
 
     public function getHTMLFragments($gridField)
     {

--- a/src/Security/Group.php
+++ b/src/Security/Group.php
@@ -153,11 +153,11 @@ class Group extends DataObject
         if ($this->ID) {
             $group = $this;
             $config = GridFieldConfig_RelationEditor::create();
-            $config->addComponent(new GridFieldButtonRow('after'));
-            $config->addComponents(new GridFieldExportButton('buttons-after-left'));
-            $config->addComponents(new GridFieldPrintButton('buttons-after-left'));
+            $config->addComponent(GridFieldButtonRow::create('after'));
+            $config->addComponents(GridFieldExportButton::create('buttons-after-left'));
+            $config->addComponents(GridFieldPrintButton::create('buttons-after-left'));
             $config->removeComponentsByType(GridFieldDeleteAction::class);
-            $config->addComponent(new GridFieldGroupDeleteAction($this->ID), GridFieldPageCount::class);
+            $config->addComponent(GridFieldGroupDeleteAction::create($this->ID), GridFieldPageCount::class);
 
             /** @var GridFieldAddExistingAutocompleter $autocompleter */
             $autocompleter = $config->getComponentByType(GridFieldAddExistingAutocompleter::class);


### PR DESCRIPTION
Some components were already injectable, but all GridField components shipped in silverstripe should be injectable.
This makes it a LOT easier to make global project-specific changes to a given component.

Separate pull requests will need to be made to other silverstripe core modules to replace use of the `new` keyword to take advantage of this - I'll work on that as time permits if this PR gets approved.
