### PR TITLE
FIX Ensure tmpItem has a value before calling method_exists on it

### DIFF
--- a/src/Forms/GridField/GridFieldSortableHeader.php
+++ b/src/Forms/GridField/GridFieldSortableHeader.php
@@ -146,7 +146,7 @@ class GridFieldSortableHeader implements GridField_HTMLProvider, GridField_DataM
                     if ($tmpItem instanceof SS_List) {
                         // It's impossible to sort on a HasManyList/ManyManyList
                         break;
-                    } elseif (method_exists($tmpItem, 'hasMethod') && $tmpItem->hasMethod($methodName)) {
+                    } elseif ($tmpItem && method_exists($tmpItem, 'hasMethod') && $tmpItem->hasMethod($methodName)) {
                         // The part is a relation name, so get the object/list from it
                         $tmpItem = $tmpItem->$methodName();
                     } elseif ($tmpItem instanceof DataObject


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/492

PHP8 Travis breaking https://app.travis-ci.com/github/silverstripe/silverstripe-blog/jobs/549475178#L1422

PHP8 now breaks calling which passing `null` to `method_exists(null, 'myMethod');`

https://bugs.php.net/bug.php?id=77627
https://www.php.net/ChangeLog-8.php

This change ensure we don't pass `null` to `method_exists()`