### PR TITLE
ENH Provide hook for updating absoluteBaseURL

### DIFF
--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -470,6 +470,7 @@ class Director implements TemplateGlobalProvider
             // Default to respecting site base_url
             $parent = self::absoluteBaseURL();
         }
+        static::singleton()->extend('updateAbsoluteURLParent', $parent);
 
         // Map empty urls to relative slash and join to base
         if (empty($url) || $url === '.' || $url === './') {


### PR DESCRIPTION
One use case for this that I've run into a few times is for sending emails using a queued job from the CLI.

Calling `setBody` on an email uses `Director::absoluteURL` which ultimately uses `Director::baseURL` to make email links absolute. This can often result in the host being the server name rather than the actual website host name.

Providing this as an extension makes it easy to configure for a variety of possible situations that could result in needing dynamic control of the absolute base URL - such as using subsites.
