### PR TITLE
TestMailer - Add Headers attribute in order for tests to asserts its   contents

### DIFF
--- a/src/Dev/TestMailer.php
+++ b/src/Dev/TestMailer.php
@@ -48,7 +48,8 @@ class TestMailer implements Mailer
             'From' => implode(';', array_keys($email->getFrom() ?: [])),
             'Subject' => $email->getSubject(),
             'Content' => $email->getBody(),
-            'AttachedFiles' => $attachedFiles
+            'AttachedFiles' => $attachedFiles,
+            'Headers' => $email->getSwiftMessage()->getHeaders(),
         ];
         if ($plainContent) {
             $serialised['PlainContent'] = $plainContent;


### PR DESCRIPTION
When running tests and finding that an email has been sent, in SS3 we are able to assert if the emails sent contains Cc/Bcc using customHeaders attribute. This pull request re-adds that feature using Headers attribute.

Reference: https://github.com/silverstripe/silverstripe-framework/blob/88a4e69de6928c5e771831a55c043c57960198e2/tests/email/EmailTest.php#L213