### PR TITLE
FIX Allow custom SELECT to be used for sorting in DataQuery::column()

### DIFF
--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -395,7 +395,12 @@ class DataQuery
                     // format internally; then this check can be part of selectField()
                     $selects = $query->getSelect();
                     if (!isset($selects[$col]) && !in_array($qualCol, $selects)) {
-                        $query->selectField($qualCol);
+                        // Use the original select if possible.
+                        if (array_key_exists($col, $originalSelect)) {
+                            $query->selectField($originalSelect[$col], $col);
+                        } else {
+                            $query->selectField($qualCol);
+                        }
                     }
                 } else {
                     $qualCol = '"' . implode('"."', $parts) . '"';

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -326,6 +326,21 @@ class DataQueryTest extends SapphireTest
         );
     }
 
+    public function testCustomFieldWithAliasSort()
+    {
+        $query = new DataQuery(DataQueryTest\ObjectE::class);
+        $query->selectField(sprintf(
+            '(case when "Title" = %s then 1 else 0 end)',
+            DB::get_conn()->quoteString('Second')
+        ), 'CustomColumn');
+        $query->sort('CustomColumn', 'DESC', true);
+        $query->sort('SortOrder', 'ASC', false);
+        $this->assertEquals(
+            ['Second', 'First', 'Last'],
+            $query->column('Title')
+        );
+    }
+
     public function testComparisonClauseDateStartsWith()
     {
         DB::query("INSERT INTO \"DataQueryTest_F\" (\"MyDate\") VALUES ('1988-03-04 06:30')");


### PR DESCRIPTION
If a custom select clause (using special features such as `CASE`) is used, and it was added using `SQLSelect::selectField`, the custom select clause should be retained when calling DataQuery::column().

I know that using `SQLSelect::addOrderBy` to add the select clause is handled correctly, but that's because it uses a special alias. If I want to use a specific alias, I can't rely on that.