### PR TITLE
FIX Ensure extra classes are copied over to readonly/disabled fields

### DIFF
--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -1355,13 +1355,14 @@ class FormField extends RequestHandler
             $field = $classOrCopy::create($this->name);
         }
 
+        $extraClasses = $this->extraClasses ? array_values($this->extraClasses) : [];
         $field
             ->setValue($this->value)
             ->setForm($this->form)
             ->setTitle($this->Title())
             ->setLeftTitle($this->LeftTitle())
             ->setRightTitle($this->RightTitle())
-            ->addExtraClass($this->extraClass) // Don't use extraClass(), since this merges calculated values
+            ->addExtraClass(implode(' ', $extraClasses)) // Don't use extraClass(), since this merges calculated values
             ->setDescription($this->getDescription());
 
         // Only include built-in attributes, ignore anything set through getAttributes().

--- a/tests/php/Forms/FormFieldTest.php
+++ b/tests/php/Forms/FormFieldTest.php
@@ -259,6 +259,14 @@ class FormFieldTest extends SapphireTest
         $this->assertStringNotContainsString('readonly="readonly"', $field->getAttributesHTML());
     }
 
+    public function testReadonlyPreservesExtraClass()
+    {
+        $field = new FormField('MyField');
+        $field->addExtraClass('myextraclass1')->addExtraClass('myextraclass2');
+        $field->setReadonly(true);
+        $this->assertStringContainsString('myextraclass1 myextraclass2', $field->getAttributesHTML());
+    }
+
     public function testDisabled()
     {
         $field = new FormField('MyField');

--- a/tests/php/Forms/TreeMultiselectFieldTest.php
+++ b/tests/php/Forms/TreeMultiselectFieldTest.php
@@ -203,7 +203,7 @@ class TreeMultiselectFieldTest extends SapphireTest
         $this->assertSame('TreeDropdownField', $schemaDataDefaults['component']);
         $this->assertSame(sprintf('%s_Holder', $field->ID()), $schemaDataDefaults['holderId']);
         $this->assertSame('Test tree', $schemaDataDefaults['title']);
-        $this->assertSame('treemultiselectfield_readonly multiple  searchable', $schemaDataDefaults['extraClass']);
+        $this->assertSame('treemultiselectfield_readonly multiple searchable', $schemaDataDefaults['extraClass']);
         $this->assertSame('field/TestTree/tree', $schemaDataDefaults['data']['urlTree']);
         $this->assertSame(true, $schemaDataDefaults['data']['showSearch']);
         $this->assertSame('(Search or choose File)', $schemaDataDefaults['data']['emptyString']);
@@ -239,7 +239,7 @@ class TreeMultiselectFieldTest extends SapphireTest
         $this->assertSame('TreeDropdownField', $schemaDataDefaults['component']);
         $this->assertSame(sprintf('%s_Holder', $field->ID()), $schemaDataDefaults['holderId']);
         $this->assertSame('Test tree', $schemaDataDefaults['title']);
-        $this->assertSame('treemultiselectfield_readonly multiple  searchable', $schemaDataDefaults['extraClass']);
+        $this->assertSame('treemultiselectfield_readonly multiple searchable', $schemaDataDefaults['extraClass']);
         $this->assertSame('field/TestTree/tree', $schemaDataDefaults['data']['urlTree']);
         $this->assertSame(true, $schemaDataDefaults['data']['showSearch']);
         $this->assertSame('(Search or choose File)', $schemaDataDefaults['data']['emptyString']);


### PR DESCRIPTION
Currently calling `->performReadonlyTransformation()` loses all extra classes, because `$this->extraClass` is always `null` (I don’t even know why it still exists)