### PR TITLE
MINOR: add filterable and sortable field indexes

### DIFF
--- a/src/Security/Group.php
+++ b/src/Security/Group.php
@@ -84,6 +84,12 @@ class Group extends DataObject
     ];
 
     private static $table_name = "Group";
+    
+    private static $indexes = [
+        'Title' => true,
+        'Code' => true,
+        'Sort' => true,
+    ];
 
     public function getAllChildren()
     {


### PR DESCRIPTION
Fields that are regularly used for filter and sort should be indexed, this should probably be reviewed for all DataObjects. 
