### PR TITLE
FIX Disallow negative values for FailedLoginCount

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -937,6 +937,11 @@ class Member extends DataObject
             $this->Locale = i18n::config()->get('default_locale');
         }
 
+        // Ensure FailedLoginCount is non-negative
+        if ($this->FailedLoginCount < 0) {
+            $this->FailedLoginCount = 0;
+        }
+
         parent::onBeforeWrite();
     }
 

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -1270,6 +1270,15 @@ class MemberTest extends FunctionalTest
         }
     }
 
+    public function testFailedLoginCountNegative()
+    {
+        /** @var Member $member */
+        $member = $this->objFromFixture(Member::class, 'test');
+        $member->FailedLoginCount = -1;
+        $member->write();
+        $this->assertSame(0, $member->FailedLoginCount);
+    }
+
     public function testMemberValidator()
     {
         // clear custom requirements for this test


### PR DESCRIPTION
Currently it's possible to set a FailedLoginCount to below zero.  There isn't a scenario where this is desirable.
