### PR TITLE
Remove italics in headings

### DIFF
--- a/docs/en/00_Getting_Started/05_Recipes.md
+++ b/docs/en/00_Getting_Started/05_Recipes.md
@@ -14,7 +14,7 @@ Recipes are used to implement common broad feature sets by shipping a collection
 
 Before each version of a supported CMS recipe is released, it is comprehensively regression tested and passed to a third party for a security-focused audit, making sure that projects have a secure starting point or a safe and secure upgrade with each recipe release.
 
-## What's the difference between a *recipe* and a *module*?
+## What's the difference between a recipe and a module?
 
 Silverstripe CMS is powered by a system of components in the form of Composer packages. It consists of two types of package:
 


### PR DESCRIPTION
The italics in the heading appear to break the rendering of the page. Instead rendering the heading as "What's the difference between a".

![image (2)](https://user-images.githubusercontent.com/415374/149998114-8cf382b9-2a85-43fe-a176-e1f049becb36.png)


