### PR TITLE
FIX Default GridField search fields with an index of 0 to use StartWithFilter

### DIFF
--- a/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
+++ b/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
@@ -12,10 +12,10 @@ use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\Filters\SearchFilter;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 use LogicException;
-use SilverStripe\ORM\Filters\SearchFilter;
 
 /**
  * This class is is responsible for adding objects to another object's has_many
@@ -347,7 +347,7 @@ class GridFieldAddExistingAutocompleter implements GridField_HTMLProvider, GridF
                     // so we need to check the original setting.
                     // If the field is defined $searchable_fields = array('MyField'),
                     // then default to StartsWith filter, which makes more sense in this context.
-                    if (!$customSearchableFields || array_search($name, $customSearchableFields)) {
+                    if (!$customSearchableFields || array_search($name, $customSearchableFields) !== false) {
                         $filter = 'StartsWith';
                     } else {
                         $filterName = $spec['filter'];

--- a/tests/php/Forms/GridField/GridFieldAddExistingAutocompleterTest.php
+++ b/tests/php/Forms/GridField/GridFieldAddExistingAutocompleterTest.php
@@ -14,6 +14,7 @@ use SilverStripe\Forms\Tests\GridField\GridFieldAddExistingAutocompleterTest\Tes
 use SilverStripe\Forms\Tests\GridField\GridFieldTest\Cheerleader;
 use SilverStripe\Forms\Tests\GridField\GridFieldTest\Permissions;
 use SilverStripe\Forms\Tests\GridField\GridFieldTest\Player;
+use SilverStripe\Forms\Tests\GridField\GridFieldTest\Stadium;
 use SilverStripe\Forms\Tests\GridField\GridFieldTest\Team;
 use SilverStripe\ORM\ArrayList;
 
@@ -29,7 +30,8 @@ class GridFieldAddExistingAutocompleterTest extends FunctionalTest
         Team::class,
         Cheerleader::class,
         Player::class,
-        Permissions::class
+        Permissions::class,
+        Stadium::class,
     ];
 
     protected static $extra_controllers = [
@@ -41,15 +43,12 @@ class GridFieldAddExistingAutocompleterTest extends FunctionalTest
         $autoCompleter = new GridFieldAddExistingAutocompleter($targetFragment = 'before', ['Test']);
         $this->assertEquals(
             [
-                'Name:PartialMatch',
-                'City:StartsWith',
-                'Cheerleaders.Name:StartsWith'
+                'Name:StartsWith',
+                'City:EndsWith',
+                'Country:ExactMatch',
+                'Type:Fulltext'
             ],
-            $autoCompleter->scaffoldSearchFields(Team::class)
-        );
-        $this->assertEquals(
-            [ 'Name:StartsWith' ],
-            $autoCompleter->scaffoldSearchFields(Cheerleader::class)
+            $autoCompleter->scaffoldSearchFields(Stadium::class)
         );
     }
 

--- a/tests/php/Forms/GridField/GridFieldTest/Stadium.php
+++ b/tests/php/Forms/GridField/GridFieldTest/Stadium.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\GridField\GridFieldTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\Filters\EndsWithFilter;
+
+class Stadium extends DataObject implements TestOnly
+{
+    private static $table_name = 'GridFieldTest_Stadium';
+
+    private static $db = [
+        'Name' => 'Varchar',
+        'City' => 'Varchar',
+        'Country' => 'Varchar',
+        'Type' => 'Varchar'
+    ];
+
+    private static $searchable_fields = [
+        'Name',
+        'City' => [
+            'filter' => EndsWithFilter::class
+        ],
+        'Country' => [
+            'filter' => 'ExactMatchFilter'
+        ],
+    ];
+
+    private static $extensions = [
+        StadiumExtension::class,
+    ];
+}

--- a/tests/php/Forms/GridField/GridFieldTest/StadiumExtension.php
+++ b/tests/php/Forms/GridField/GridFieldTest/StadiumExtension.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\GridField\GridFieldTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\Filters\FulltextFilter;
+use SilverStripe\Forms\Tests\GridField\GridFieldTest\StadiumExtension;
+
+class StadiumExtension extends DataExtension implements TestOnly
+{
+    public function updateSearchableFields(&$fields)
+    {
+        $fields['Type']['filter'] = new FulltextFilter();
+    }
+}


### PR DESCRIPTION
array_search will return 0 if it matched the first value in an array

Also add a unit test for https://github.com/silverstripe/silverstripe-framework/pull/9991