### PR TITLE
Add admin_email config recommendation to 4.9.0 upgrade

### DIFF
--- a/docs/en/04_Changelogs/4.9.0.md
+++ b/docs/en/04_Changelogs/4.9.0.md
@@ -249,6 +249,8 @@ New Silverstripe CMS project created from `silverstripe/installer` 4.9.0 or grea
 
 It's highly recommended that existing Silverstripe CMS installation using `Swift_MailTransport` upgrade to `Swift_SendmailTransport` or another available transport, such as `Swift_SmtpTransport`. Details on how to use these classes are available in the [email section](https://docs.silverstripe.org/en/4/developer_guides/email/) of the developer docs.
 
+It is also crucial to ensure that you have a `From:` address properly configured, as changing from `mail()` to `sendmail` will mean that any existing fallback configuration will no longer apply. You can [set this in your yaml config](https://docs.silverstripe.org/en/4/developer_guides/email/#administrator-emails) which will mean that password reset emails and others continue to send.
+
 ### Other new features
 
 * [New title tip component](https://silverstripe.github.io/silverstripe-pattern-lib/?knob-Content=Example%20tip%20contents&selectedKind=Admin%2FTip&selectedStory=Title%20tip&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Fnotes%2Fpanel) allowing you to provide extra context on the purpose of a field

--- a/docs/en/04_Changelogs/4.9.0.md
+++ b/docs/en/04_Changelogs/4.9.0.md
@@ -238,7 +238,8 @@ Review the [Functional Testing developer documentation](/developer_guides/testin
 
 Silverstripe CMS provides an API over the top of the [SwiftMailer](http://swiftmailer.org/) PHP library which comes with an extensive list of "transports" for sending mail via different services. Silverstripe CMS 4.9.0 upgrades to Swiftmailer version 6 from version 5.
 
-#### Moving away from _Swift_MailTransport_ 
+#### Moving away from Swift_MailTransport
+
 Prior to 4.9.0, Silverstripe CMS 4 defaulted to using the built-in PHP `mail()` command via a deprecated class `Swift_MailTransport`. However, the Swiftmailer maintainers have decided to remove this class because of some inherent security flaw in the way the PHP mail function handles the `from` header.
 
 Read this [GitHub comment by a SwiftMailer maintainer](https://github.com/swiftmailer/swiftmailer/issues/866#issuecomment-289291228) for a detailed explanation of the weakness of the PHP mail function.


### PR DESCRIPTION
Seen a lot of sites get tripped up by this (on SCPS-CCL in particular) so would be good to clarify.