### PR TITLE
DOC GraphQL src must always be an array.

### DIFF
--- a/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/02_configuring_your_schema.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/02_configuring_your_schema.md
@@ -78,13 +78,17 @@ relative to the project root.
 SilverStripe\GraphQL\Schema\Schema:
   schemas:
     default:
-      src: app/_graphql
+      src: 
+        - app/_graphql
 ```
 
+Your `src` must be an array. This allows further source files to be merged into your schema. 
+This feature can be use to extend the schema of third party modules.
+
 [info]
-It is recommended that you define your sources as an array so that further source files are merged.
- Otherwise, another config file could completely override part of your schema definition.
+Your directory can also be a module reference, e.g. `somevendor/somemodule: _graphql`
 [/info]
+
 
 **app/_config/graphql.yml**
 ```yml
@@ -94,11 +98,11 @@ SilverStripe\GraphQL\Schema\Schema:
       src:
         - app/_graphql
         - module/_graphql
+        # The next line would map to an exposed folder e.g.: vendor/somevendor/somemodule/_graphql
+        - somevendor/somemodule: _graphql
 ```
 
-[info]
-Your directory can also be a module reference, e.g. `somevendor/somemodule: _graphql`
-[/info]
+
 
 Now, in our `app/_graphql` file, we can create YAML file definitions.
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/02_configuring_your_schema.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/02_configuring_your_schema.md
@@ -98,8 +98,8 @@ SilverStripe\GraphQL\Schema\Schema:
       src:
         - app/_graphql
         - module/_graphql
-        # The next line would map to an exposed folder e.g.: vendor/somevendor/somemodule/_graphql
-        - somevendor/somemodule: _graphql
+        # The next line would map to `vendor/somevendor/somemodule/_graphql`
+        - 'somevendor/somemodule: _graphql'
 ```
 
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/05_adding_pagination.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/05_adding_pagination.md
@@ -102,7 +102,7 @@ query {
     nodes {
       name
     }
-    }
+  }
 } 
 ```
 


### PR DESCRIPTION
Some minor update to the new GraphQL doc