### PR TITLE
DOC Update old pre-namespaces PHPDoc

### DIFF
--- a/src/Core/Injector/Injectable.php
+++ b/src/Core/Injector/Injectable.php
@@ -17,7 +17,7 @@ trait Injectable
      * This can be called in one of two ways - either calling via the class directly,
      * or calling on Object and passing the class name as the first parameter. The following
      * are equivalent:
-     *    $list = DataList::create('SiteTree');
+     *    $list = DataList::create(SiteTree::class);
      *    $list = SiteTree::get();
      *
      * @param array $args


### PR DESCRIPTION
The code in the original PHPDoc would have produced an error if used.
