### PR TITLE
Fix i18nTextCollector produces corrupt output / namespaces when running under PHP8.0

### DIFF
--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -571,20 +571,13 @@ class i18nTextCollector
             if (is_array($token)) {
                 list($id, $text) = $token;
 
-                // PHP 8 namespace tokens
-                if (\defined('T_NAME_QUALIFIED') && in_array($id, [T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED])) {
-                    $inNamespace = true;
-                    $currentClass[] = $text;
-                    continue;
-                }
-
                 // Check class
                 if ($id === T_NAMESPACE) {
                     $inNamespace = true;
                     $currentClass = [];
                     continue;
                 }
-                if ($inNamespace && $id === T_STRING) {
+                if ($inNamespace && ($id === T_STRING || (defined('T_NAME_QUALIFIED') && $id === T_NAME_QUALIFIED))) {
                     $currentClass[] = $text;
                     continue;
                 }

--- a/tests/php/i18n/i18nTextCollectorTest.php
+++ b/tests/php/i18n/i18nTextCollectorTest.php
@@ -300,9 +300,14 @@ PHP;
 <?php
 namespace SilverStripe\Framework\Core;
 
+use SilverStripe\ORM\DataObject;
+
 class MyClass extends Base implements SomeService {
     public function getNewLines(\$class) {
-        if (!is_subclass_of(\$class, DataObject::class) || !Object::has_extension(\$class, Versioned::class)) {
+        if (
+            !is_subclass_of(\$class, DataObject::class)
+            || !Object::has_extension(\$class, \SilverStripe\Versioned\Versioned::class)
+        ) {
             return null;
         }
         return _t(
@@ -331,6 +336,7 @@ class MyClass extends Base implements SomeService {
     }
 }
 PHP;
+
         $this->assertEquals(
             [
                 'SilverStripe\\Framework\\Core\\MyClass.NEWLINES' => "New Lines",


### PR DESCRIPTION
This PR fixes the buggy behaviour of the i18nTextCollector (#10227 ) when running under PHP8.0