### PR TITLE
Filter invalid fields taken from summaryFields

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3735,7 +3735,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
                     if ($schema->fieldSpec($this, $name)) {
                         $fields[] = $name;
                     } elseif ($this->relObject($spec)) {
-                        // Field does not always exist as a real db field (e.g. "Member.Title")
+                        // Check if it's real database field that we can query (e.g. NOT "Member.Title")
                         $parts = explode('.', $spec);
                         if (count($parts) === 2) {
                             $relObject = $this->relObject($parts[0]);

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3735,6 +3735,11 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
                     if ($schema->fieldSpec($this, $name)) {
                         $fields[] = $name;
                     } elseif ($this->relObject($spec)) {
+                        // Field does not always exist as a real db field (e.g. "Member.Title")
+                        $parts = explode(".", $spec);
+                        if (count($parts) == 2 && !$this->relObject($parts[0])->hasDatabaseField($parts[1])) {
+                            continue;
+                        }
                         $fields[] = $spec;
                     }
                 }

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3736,10 +3736,14 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
                         $fields[] = $name;
                     } elseif ($this->relObject($spec)) {
                         // Field does not always exist as a real db field (e.g. "Member.Title")
-                        $parts = explode(".", $spec);
-                        if (count($parts) == 2 && !$this->relObject($parts[0])->hasDatabaseField($parts[1])) {
-                            continue;
+                        $parts = explode('.', $spec);
+                        if (count($parts) === 2) {
+                            $relObject = $this->relObject($parts[0]);
+                            if (!$relObject || !$relObject->hasDatabaseField($parts[1])) {
+                                continue;
+                            }
                         }
+
                         $fields[] = $spec;
                     }
                 }

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -1394,6 +1394,11 @@ class DataObjectTest extends SapphireTest
             $fields,
             'Fields on related objects can be inherited from the $summary_fields static'
         );
+        $this->assertArrayNotHasKey(
+            'Captain.FavouriteTeam.MyTitle',
+            $fields,
+            'Fields from custom methods on related objects should not be inherited from the $summary_fields static'
+        );
 
         $testObj = new DataObjectTest\Fixture();
         $fields = $testObj->searchableFields();

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -1427,6 +1427,7 @@ class DataObjectTest extends SapphireTest
                 'Title.UpperCase' => 'Title',
                 'Captain.ShirtNumber' => 'Captain\'s shirt number',
                 'Captain.FavouriteTeam.Title' => 'Captain\'s favourite team',
+                'MyTitle' => 'MyTitle'
             ],
             $summaryFields
         );

--- a/tests/php/ORM/DataObjectTest/Team.php
+++ b/tests/php/ORM/DataObjectTest/Team.php
@@ -63,6 +63,7 @@ class Team extends DataObject implements TestOnly
 
     private static $summary_fields = [
         'Title', // Overridden by Team_Extension
+        'MyTitle', // We can use customMethods. It should NOT break scaffolded searchable_fields
         'Title.UpperCase' => 'Title',
         'Captain.ShirtNumber' => 'Captain\'s shirt number',
         'Captain.FavouriteTeam.Title' => 'Captain\'s favourite team'


### PR DESCRIPTION
This allows to prevent common errors like a summary_fields with Member.Title that would break some queries if no searchable_fields are provided.
While this PR fixes the issue, I think that the "relObject" probably deserve an additional parameter (like $dbFieldsOnly) and return only actual db fields. It could therefore be used in other places too. Or maybe have another method called relObjectField that would act as a simplified version of relObject.

More context here:
https://github.com/silverstripe/silverstripe-framework/issues/8792