### PR TITLE
ENH Create fallback email from address

### DIFF
--- a/src/Control/Email/Email.php
+++ b/src/Control/Email/Email.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Control\Email;
 
 use DateTime;
+use RuntimeException;
 use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\RFCValidation;
 use SilverStripe\Control\Director;
@@ -25,7 +26,6 @@ use Swift_MimePart;
  */
 class Email extends ViewableData
 {
-
     /**
      * @var array
      * @config
@@ -276,12 +276,28 @@ class Email extends ViewableData
         $dateTime = new DateTime();
         $dateTime->setTimestamp(DBDatetime::now()->getTimestamp());
         $swiftMessage->setDate($dateTime);
-        if (!$swiftMessage->getFrom() && ($defaultFrom = $this->config()->get('admin_email'))) {
-            $swiftMessage->setFrom($defaultFrom);
+        if (!$swiftMessage->getFrom()) {
+            $swiftMessage->setFrom($this->getDefaultFrom());
         }
         $this->swiftMessage = $swiftMessage;
 
         return $this;
+    }
+
+    /**
+     * @return string
+     */
+    private function getDefaultFrom(): string
+    {
+        $defaultFrom = $this->config()->get('admin_email');
+        if (!$defaultFrom) {
+            $host = Director::host();
+            if (empty($host)) {
+                throw new RuntimeException('Host not defined');
+            }
+            $defaultFrom = sprintf('no-reply@%s', $host);
+        }
+        return $defaultFrom;
     }
 
     /**

--- a/tests/php/Control/Email/EmailTest.php
+++ b/tests/php/Control/Email/EmailTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Control\Tests\Email;
 
 use DateTime;
 use PHPUnit_Framework_MockObject_MockObject;
+use SilverStripe\Control\Director;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Control\Email\Mailer;
 use SilverStripe\Control\Email\SwiftMailer;
@@ -23,6 +24,12 @@ use Swift_RfcComplianceException;
 
 class EmailTest extends SapphireTest
 {
+
+    protected function setUp()
+    {
+        parent::setUp();
+        Director::config()->set('alternate_base_url', 'http://www.mysite.com/');
+    }
 
     public function testAddAttachment()
     {
@@ -660,6 +667,21 @@ class EmailTest extends SapphireTest
         /** @var \Swift_MimePart $plainPart */
         $plainPart = reset($children);
         $this->assertContains('Test', $plainPart->getBody());
+    }
+
+    public function testGetDefaultFrom()
+    {
+        $email = new Email();
+        $class = new \ReflectionClass(Email::class);
+        $method = $class->getMethod('getDefaultFrom');
+        $method->setAccessible(true);
+
+        // default to no-reply@mydomain.com if admin_email config not set
+        $this->assertSame('no-reply@www.mysite.com', $method->invokeArgs($email, []));
+
+        // use admin_email config
+        Email::config()->set('admin_email', 'myadmin@somewhere.com');
+        $this->assertSame('myadmin@somewhere.com', $method->invokeArgs($email, []));
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10217

Fallback email address is `no-reply@mydomain.com` which matches what happened pre 4.9 using the `mail()` function without a from address defined

Internal chat about strangeness on CCL [here](https://silverstripeltd.slack.com/archives/CEYE6K29Y/p1645080163552139) 
