### PR TITLE
Add custom setForm() method for ConfirmedPasswordField

### DIFF
--- a/src/Forms/ConfirmedPasswordField.php
+++ b/src/Forms/ConfirmedPasswordField.php
@@ -706,10 +706,10 @@ class ConfirmedPasswordField extends FormField
      */
     public function setForm($form)
     {
-        $this->form = $form;
-        $this->getPasswordField()->form = $form;
-        $this->getConfirmPasswordField()->form = $form;
-
+        $this->getPasswordField()->setForm($form);
+        $this->getConfirmPasswordField()->setForm($form);
+        
+        parent::setForm($form);
         return $this;
     }
 }

--- a/src/Forms/ConfirmedPasswordField.php
+++ b/src/Forms/ConfirmedPasswordField.php
@@ -694,4 +694,22 @@ class ConfirmedPasswordField extends FormField
     {
         return $this->requireStrongPassword;
     }
+    
+    /**
+     * Set the container form.
+     *
+     * This is called automatically when fields are added to forms.
+     *
+     * @param Form $form
+     *
+     * @return $this
+     */
+    public function setForm($form)
+    {
+        $this->form = $form;
+        $this->getPasswordField()->form = $form;
+        $this->getConfirmPasswordField()->form = $form;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Fixes bug that makes it impossible to set a ConfirmedPasswordField as "required" due to the two child fields not getting a form assigned to them.

# Issue
Adding the names of a `ConfirmedPasswordField` field to a `RequiredFields` form validator would have no effect. e.g. The fields would not be marked as `required`.

This is because the standard `setForm()` method in `FormField` sets the form on the parent `ConfirmedPasswordField` but not on either the two child `PasswordField`s.

# Fix
This PR adds a custom `setForm()` method to `ConfirmedPasswordField` which sets the form on the child fields as well as the parent. So the following validator will now work as expected:
````php
$required = new RequiredFields('Password[_Password]', 'Password[_ConfirmPassword]');`
```` 