### PR TITLE
MINOR: allow dev/tasks to be filtered

### DIFF
--- a/src/Dev/TaskRunner.php
+++ b/src/Dev/TaskRunner.php
@@ -56,11 +56,28 @@ class TaskRunner extends Controller
         }
     }
 
-    public function index()
+    /**
+     * list of options - can be filtered by adding the `q` request variable (e.g. `/dev/tasks/?q=test` OR `vendor/bin/sake dev/tasks q=test`)
+     * @param  HTTPRequest $index
+     * @return DBHTMLText|string - depends on whether it is `Director::is_cli()` request (returns string) or not (returns DBHTMLText)
+     */
+    public function index($request = null)
     {
         $baseUrl = Director::absoluteBaseURL();
         $tasks = $this->getTasks();
-
+        $filter = (string) trim($request->requestVar('q'));
+        if($filter) {
+            $tasks = array_filter(
+                $tasks,
+                function ($v) use ($filter) {
+                    $t = $v['title'] ?? '';
+                    $d = $v['description'] ?? '';
+                    return
+                        stripos((string) $t, $filter) !== false &&
+                        stripos((string) $d, $filter) !== false;
+                }
+            );
+        }
         if (Director::is_cli()) {
             // CLI mode
             $output = 'SILVERSTRIPE DEVELOPMENT TOOLS: Tasks' . PHP_EOL . '--------------------------' . PHP_EOL . PHP_EOL;


### PR DESCRIPTION
This change is long overdue.

Often, you can find yourself spending ages trying to find the right dev/task task.  This change will allow you to type

```shell
vendor/bin/sake dev/tasks q=delete
```
In the command line to find the delete tasks. 

AND:

https://foo.bar.com.eu/dev/tasks/?q=delete

in the browser address bar to find the same.

