### PR TITLE
MINOR: adding filter variable for dev/tasks

### DIFF
--- a/src/Dev/TaskRunner.php
+++ b/src/Dev/TaskRunner.php
@@ -42,9 +42,28 @@ class TaskRunner extends Controller
         }
     }
 
-    public function index()
+    /**
+     * list of options - can be filtered by adding the `q` request variable (e.g. `/dev/tasks/?q=test` OR `vendor/bin/sake dev/tasks q=test`)
+     * @param  HTTPRequest $index
+     * @return DBHTMLText|string - depends on whether it is `Director::is_cli()` request (returns string) or not (returns DBHTMLText)
+     */
+    public function index($request = null)
     {
+        $baseUrl = Director::absoluteBaseURL();
         $tasks = $this->getTasks();
+        $filter = (string) trim($request->requestVar('q'));
+        if($filter) {
+            $tasks = array_filter(
+                $tasks,
+                function ($v) use ($filter) {
+                    $t = $v['title'] ?? '';
+                    $d = $v['description'] ?? '';
+                    return
+                        stripos((string) $t, $filter) !== false &&
+                        stripos((string) $d, $filter) !== false;
+                }
+            );
+        }
 
         // Web mode
         if (!Director::is_cli()) {

--- a/src/Dev/TaskRunner.php
+++ b/src/Dev/TaskRunner.php
@@ -52,15 +52,15 @@ class TaskRunner extends Controller
         $baseUrl = Director::absoluteBaseURL();
         $tasks = $this->getTasks();
         $filter = (string) trim($request->requestVar('q'));
-        if($filter) {
+        if ($filter) {
             $tasks = array_filter(
                 $tasks,
-                function ($v) use ($filter) {
-                    $t = $v['title'] ?? '';
-                    $d = $v['description'] ?? '';
+                function ($arrayItem) use ($filter) {
+                    $title = $arrayItem['title'] ?? '';
+                    $description = $arrayItem['description'] ?? '';
                     return
-                        stripos((string) $t, $filter) !== false &&
-                        stripos((string) $d, $filter) !== false;
+                        stripos((string) $title, $filter) !== false &&
+                        stripos((string) $description, $filter) !== false;
                 }
             );
         }
@@ -73,6 +73,7 @@ class TaskRunner extends Controller
             $base = Director::absoluteBaseURL();
 
             echo "<div class=\"options\">";
+            echo "<p>use /dev/tasks/?q=anyfilter in the url to filter this list.</p>";
             echo "<ul>";
             foreach ($tasks as $task) {
                 echo "<li><p>";
@@ -86,6 +87,7 @@ class TaskRunner extends Controller
         // CLI mode
         } else {
             echo "SILVERSTRIPE DEVELOPMENT TOOLS: Tasks\n--------------------------\n\n";
+            echo "- use vendor/bin/sake dev/tasks q=anyfilter to filter this list.\n\n";
             foreach ($tasks as $task) {
                 echo " * $task[title]: sake dev/tasks/" . $task['segment'] . "\n";
             }


### PR DESCRIPTION
Long overdue change to find tasks easily. 

Tasks can be filtered by adding the `q` request variable (e.g. `/dev/tasks/?q=test` OR `vendor/bin/sake dev/tasks q=test`)