### PR TITLE
FIX: Respect limit when filtering by callback

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -487,9 +487,17 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
         }
         /** @var ArrayList $output */
         $output = ArrayList::create();
+        $limit = $this->dataQuery->query()->getLimit();
+        $count = 0;
         foreach ($this as $item) {
+            // Respect the limit.
+            if ($count >= $limit) {
+                break;
+            }
+            // Perform the actual callback filtering.
             if (call_user_func($callback, $item, $this)) {
                 $output->push($item);
+                $count++;
             }
         }
         return $output;

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -1480,6 +1480,34 @@ class DataListTest extends SapphireTest
         $this->assertTrue($list instanceof Filterable, 'The List should be of type SS_Filterable');
     }
 
+    public function testFilterByCallbackWithLimits()
+    {
+        // Limit 0 contains 0 items.
+        $team1ID = $this->idFromFixture(DataObjectTest\Team::class, 'team1');
+        $list = TeamComment::get();
+        $list = $list->limit(0);
+        $list = $list->filterByCallback(
+            function ($item) use ($team1ID) {
+                return $item->TeamID == $team1ID;
+            }
+        );
+        $this->assertEquals(0, $list->count());
+
+        // Limit 1 contains 1 item.
+        $team1ID = $this->idFromFixture(DataObjectTest\Team::class, 'team1');
+        $list = TeamComment::get();
+        $list = $list->limit(1);
+        $list = $list->filterByCallback(
+            function ($item) use ($team1ID) {
+                return $item->TeamID == $team1ID;
+            }
+        );
+        $result = $list->column('Name');
+        $expected = array_intersect($result, ['Bob']);
+        $this->assertEquals(1, $list->count());
+        $this->assertEquals($expected, $result, 'List should only contain one comment from Team 1 (Bob)');
+    }
+
     /**
      * $list->exclude('Name', 'bob'); // exclude bob from list
      */


### PR DESCRIPTION
While a limit can be set afterwards on the `ArrayList`, currently if a limit is set prior to calling `filterByCallback` it will never be applied. This applies the limit in a way that doesn't require instantiating every item.

Note that this _could_ have BC concerns for anyone who expects a non-limited list after calling `filterByCallback` on a `DataList` and isn't aware that `limit` is called on that list earlier up the chain - but in my opinion they are actually relying on a bug.

Targeting 4 because it wasn't until I started writing this PR message that I realised it is technically a bug - happy to retarget and change the commit message, but I'll wait to see if others agree first.