### PR TITLE
DOC Clarify that Silverstripe CMS does not have a bug bounty program

### DIFF
--- a/docs/en/05_Contributing/00_Issues_and_Bugs.md
+++ b/docs/en/05_Contributing/00_Issues_and_Bugs.md
@@ -58,6 +58,8 @@ Report security issues to [security@silverstripe.org](mailto:security@silverstri
 See our "[Release Process](/contributing/release_process/#security-releases)" documentation for more info, and 
 read our guide on [how to write secure code](/developer_guides/security/secure_coding/).
 
+Silverstripe CMS does not operate a *bug bounty* program.
+
 ## Sharing your Opinion
 
 * [forum.silverstripe.org](http://forum.silverstripe.org): Forums on silverstripe.org

--- a/docs/en/05_Contributing/04_Release_Process.md
+++ b/docs/en/05_Contributing/04_Release_Process.md
@@ -214,6 +214,8 @@ Report security issues in our [commercially supported modules](https://www.silve
 to [security@silverstripe.org](mailto:security@silverstripe.org). 
 Please don't file security issues in our [bugtracker](issues_and_bugs). 
 
+Silverstripe CMS does not operate a *bug bounty* program.
+
 ### Acknowledgment and disclosure
 
 In the event of a confirmed vulnerability in our


### PR DESCRIPTION
We're getting low quality vulnerability reports from people who are only looking to make a quick buck. Hopefully by explicitly stating that we don't operate a bug bounty program, they'll move along to something else.
