### PR TITLE
MNT Add void return to EmailTest setup

### DIFF
--- a/tests/php/Control/Email/EmailTest.php
+++ b/tests/php/Control/Email/EmailTest.php
@@ -24,8 +24,7 @@ use Swift_RfcComplianceException;
 
 class EmailTest extends SapphireTest
 {
-
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         Director::config()->set('alternate_base_url', 'http://www.mysite.com/');


### PR DESCRIPTION
[Pull-request](https://github.com/silverstripe/silverstripe-framework/pull/10236) to 4.9 that was recently merged up failed to account for phpunit 9.5 return type
