### PR TITLE
Remove waring about typos

### DIFF
--- a/docs/en/04_Changelogs/4.11.0.md
+++ b/docs/en/04_Changelogs/4.11.0.md
@@ -45,8 +45,6 @@ This release includes a number of bug fixes to improve a broad range of areas. C
 
 - If `guzzlehttp/guzzle` is required, it must now be at least `7.3.0`. This was done to ensure that v2 of `guzzlehttp/psr7` is installed, which is used by `embed/embed` v4
 - `embed/embed` has been upgraded from v3 to v4. The internal implementation of the internal `Embeddable` interface has been changed from `EmbedResource` to `EmbedContainer`
-- Fixed typo in `SilverStripe\Core\CoreKernel` protected variable `$enviroment`, now `$environment`.  
-   If you've extended CoreKernel and not using the appropriate getter/setter methods, please update your code.
 
 <!--- Changes below this line will be automatically regenerated -->
 


### PR DESCRIPTION
This change was undone by the NullDatabase PR and probably should not have been made in the first places since its a semver breakage.
