### PR TITLE
ENH Faster method for creating injected instances

### DIFF
--- a/src/Core/Injector/InjectionCreator.php
+++ b/src/Core/Injector/InjectionCreator.php
@@ -2,29 +2,18 @@
 
 namespace SilverStripe\Core\Injector;
 
-use ReflectionClass;
-use ReflectionException;
-
 /**
  * A class for creating new objects by the injector.
  */
 class InjectionCreator implements Factory
 {
-
     public function create($class, array $params = [])
     {
-        try {
-            $reflector = new ReflectionClass($class);
-        } catch (ReflectionException $e) {
-            throw new InjectorNotFoundException($e);
+        if (!class_exists($class)) {
+            throw new InjectorNotFoundException("Class {$class} does not exist");
         }
-
-        if (count($params)) {
-            // Remove named keys to ensure that PHP7 and PHP8 interpret these the same way
-            $params = array_values($params);
-            return $reflector->newInstanceArgs($params);
-        }
-
-        return $reflector->newInstance();
+        // Ensure there are no string keys as they cannot be unpacked with the `...` operator
+        $values = array_values($params);
+        return new $class(...$values);
     }
 }


### PR DESCRIPTION
~17% faster method for instantiating things via injector

I validated the performance using the following code in my projects `PageController`

```php
<?php

use SilverStripe\Admin\ModalController;
use SilverStripe\CMS\Controllers\ContentController;

class PageController extends ContentController
{
    protected function init()
    {
        parent::init();

        $time_pre = microtime(true);
        for($i=0;$i<100000;$i++) {
            //$this->injectOld(); // This took 0.2139 seconds 
            $this->injectNew(); // This took 0.1776 seconds 
        }
        $time_post = microtime(true);
        $exec_time = $time_post - $time_pre;
        echo sprintf("This took %.4f seconds", $exec_time);

    }

    private function injectOld()
    {
        $class = ModalController::class;
        $params = ['MyController', 'MyName'];
        $reflector = new ReflectionClass($class);
        return $reflector->newInstanceArgs($params);
    }

    private function injectNew()
    {
        $class = ModalController::class;
        $params = ['MyController', 'MyName'];
        return new $class(...array_values($params));
    }
}

```