### PR TITLE
Check for component before saving, fallback to full form field name

### DIFF
--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -475,8 +475,10 @@ class FormField extends RequestHandler
             $component = $record->relObject($relation);
         }
 
-        if ($fieldName) {
+        if ($fieldName && $component) {
             $component->setCastedField($fieldName, $this->dataValue());
+        } else {
+            $record->setCastedField($this->name, $this->dataValue());
         }
     }
 


### PR DESCRIPTION
Closes #10188 

### Summary
Prevents `Call to a member function setCastedField() on null` error when using dot syntax for has_many components. This **does not** save has_many components by itself.

### Additional notes
We have custom code that handles the saving of has_many components with dot syntax. [This change](https://github.com/silverstripe/silverstripe-framework/commit/02fb7c3b178f85b75365b0efb46ae8b25a204590) breaks that functionality. This simply checks for a valid component before calling `setCastedField`. If the component does not exist, this will fallback to the original `setCastedField` procedure.