### PR TITLE
NEW: Add method to check if a class is ready for db queries.

### DIFF
--- a/src/ORM/DB.php
+++ b/src/ORM/DB.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\ORM;
 
-use BadMethodCallException;
 use InvalidArgumentException;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
@@ -59,8 +58,6 @@ class DB
      * @var array List of configs each in the $databaseConfig format
      */
     protected static $configs = [];
-
-
 
     /**
      * The last SQL query run.


### PR DESCRIPTION
This effectively makes the functionality from `Security::database_is_ready()` reusable for any arbitrary `DataObject`
subclass.

Replaces #10041

## Parent issue
- #10332
