### PR TITLE
ENH Various fixes for PHP 8.1 compatibility

### DIFF
--- a/src/ORM/Connect/MySQLiConnector.php
+++ b/src/ORM/Connect/MySQLiConnector.php
@@ -67,7 +67,8 @@ class MySQLiConnector extends DBConnector
         try {
             $success = $statement->prepare($sql);
         } catch (mysqli_sql_exception $e) {
-            throw new DatabaseException($e->getMessage());
+            $success = false;
+            $this->databaseError($e->getMessage(), E_USER_ERROR, $sql);
         }
         return $statement;
     }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10250

PHP 8.1 change the default behaviour of failed mysql statements from 'return false' to 'throw new mysqli_sql_exception()` https://php.watch/versions/8.1/mysqli-error-mode

Travis install failure on the `--prefer-lowest` job will be fixed by https://github.com/silverstripe/silverstripe-travis-shared/pull/36
