### PR TITLE
DOCS: address broken code samples

### DIFF
--- a/docs/en/02_Developer_Guides/02_Controllers/05_Middlewares.md
+++ b/docs/en/02_Developer_Guides/02_Controllers/05_Middlewares.md
@@ -26,6 +26,7 @@ will deliberately return a different response, e.g. an error response or a redir
 ```php
 use SilverStripe\Control\Middleware\HTTPMiddleware;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
 
 class CustomMiddleware implements HTTPMiddleware
 {
@@ -75,7 +76,7 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Control\Director:
     properties:
       Middlewares:
-        CustomMiddleware: %$CustomMiddleware
+        CustomMiddleware: '%$CustomMiddleware'
 ```
 
 
@@ -89,7 +90,7 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Control\Director:
     properties:
       Middlewares:
-        CustomMiddleware: %$ConfiguredMiddleware
+        CustomMiddleware: '%$ConfiguredMiddleware'
   ConfiguredMiddleware:
    class: 'CustomMiddleware'
    properties:
@@ -111,14 +112,14 @@ SilverStripe\Core\Injector\Injector:
   SpecialRouteMiddleware:
     class: SilverStripe\Control\Middleware\RequestHandlerMiddlewareAdapter
     properties:
-      RequestHandler: %$MyController
+      RequestHandler: '%$MyController'
       Middlewares:
-        - %$CustomMiddleware
-        - %$AnotherMiddleware
+        - '%$CustomMiddleware'
+        - '%$AnotherMiddleware'
 SilverStripe\Control\Director:
   rules:
-    special\section:
-      Controller: %$SpecialRouteMiddleware
+    special/section:
+      Controller: '%$SpecialRouteMiddleware'
 ```
 
 ## Application middleware


### PR DESCRIPTION
<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->

Added a missing use-statement and fixed YAML-syntax errors for the [HTTP-Middleware docs](https://docs.silverstripe.org/en/4/developer_guides/controllers/middlewares/)