### PR TITLE
MNT Fix unit tests for kitchen-sink

### DIFF
--- a/tests/php/Control/DirectorTest.php
+++ b/tests/php/Control/DirectorTest.php
@@ -38,8 +38,10 @@ class DirectorTest extends SapphireTest
 
         // Ensure redirects enabled on all environments and global state doesn't affect the tests
         CanonicalURLMiddleware::singleton()
+            ->setForceSSL(null)
             ->setForceSSLDomain(null)
             ->setForceSSLPatterns([])
+            ->setForceWWW(null)
             ->setEnabledEnvs(true);
         $this->expectedRedirect = null;
     }
@@ -858,7 +860,10 @@ class DirectorTest extends SapphireTest
 
         $processor = new RequestProcessor([$filter]);
 
-        Injector::inst()->registerService($processor, RequestProcessor::class);
+        $middlewares = Director::singleton()->getMiddlewares();
+        $middlewares['RequestProcessorMiddleware'] = $processor;
+        Director::singleton()->setMiddlewares($middlewares);
+
         $response = Director::test('some-dummy-url');
         $this->assertEquals(404, $response->getStatusCode());
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10278

Should fix some of the travis errors in https://app.travis-ci.com/github/silverstripe/recipe-kitchen-sink/jobs/567740337 which only happen in recipe-kitchen-sink (not installer) due to interactions with other modules

