### PR TITLE
DOC: Fix page not found in Builtin Middlewares

### DIFF
--- a/docs/en/02_Developer_Guides/02_Controllers/06_Builtin_Middlewares.md
+++ b/docs/en/02_Developer_Guides/02_Controllers/06_Builtin_Middlewares.md
@@ -20,4 +20,4 @@ You may find them in the [SilverStripe\Control\Middleware](api:SilverStripe\Cont
 | [RateLimitMiddleware](api:SilverStripe\Control\Middleware\RateLimitMiddleware) | Access throttling, controls HTTP Retry-After header |
 | [SessionMiddleware](api:SilverStripe\Control\Middleware\SessionMiddleware) | PHP Session initialisation |
 | [TrustedProxyMiddleware](api:SilverStripe\Control\Middleware\TrustedProxyMiddleware) | Rewrites headers that provide IP and host details from upstream proxies |
-| [URLSpecialsMiddleware](api:SilverStripe\Control\Middleware\URLSpecialsMiddleware) | Controls some of the [URL special variables](../../debugging/url_variable_tools) |
+| [URLSpecialsMiddleware](api:SilverStripe\Control\Middleware\URLSpecialsMiddleware) | Controls some of the [URL special variables](../debugging/url_variable_tools) |


### PR DESCRIPTION
Updates the address to the URL special variables page

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
