### PR TITLE
FIX Revert adding extension hook

### DIFF
--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -470,7 +470,6 @@ class Director implements TemplateGlobalProvider
             // Default to respecting site base_url
             $parent = self::absoluteBaseURL();
         }
-        static::singleton()->extend('updateAbsoluteURLParent', $parent);
 
         // Map empty urls to relative slash and join to base
         if (empty($url) || $url === '.' || $url === './') {


### PR DESCRIPTION
Revert https://github.com/silverstripe/silverstripe-framework/pull/10168/files

This hasn't been tagged, so we can remove the API

Adding this extension hook caused a [number of strange issues](https://app.travis-ci.com/github/silverstripe/recipe-kitchen-sink/jobs/557690846) when running unit tests in CI when there was a module present, namely `cwp/cwp`, which contains an old fashioned [_config.php](https://github.com/silverstripe/cwp/blob/2/_config.php#L25) file that calls `Director::absoluteBaseURL()`

This ends up causing the manifest to be created twice, which normally wouldn't be a problem, but the manifest cache (an array property on a class) is not respected as there are 2 'surrounding classes' so there ends up being two sets of service classes (`%$` references) being created, which is clearly wrong since they are supposed to be singletons.

I don't think this PR was inherently wrong, I think it's more an underlying fragility in the Silverstripe test harness.

