### PR TITLE
ENH Provide hook for updating absoluteBaseURL

### DIFF
--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -470,6 +470,7 @@ class Director implements TemplateGlobalProvider
             // Default to respecting site base_url
             $parent = self::absoluteBaseURL();
         }
+        static::singleton()->extend('updateAbsoluteURLParent', $parent);
 
         // Map empty urls to relative slash and join to base
         if (empty($url) || $url === '.' || $url === './') {


### PR DESCRIPTION
Reinstates #10168 which had to be reverted in #10291 because of #10292

Once #10292 is fixed, this can be merged in.