### PR TITLE
FIX Correctly remove relations with ManyManyThroughList::removeall

### DIFF
--- a/src/ORM/ManyManyList.php
+++ b/src/ORM/ManyManyList.php
@@ -389,7 +389,6 @@ class ManyManyList extends RelationList
      */
     public function removeAll()
     {
-
         // Remove the join to the join table to avoid MySQL row locking issues.
         $query = $this->dataQuery();
         $foreignFilter = $query->getQueryParam('Foreign.Filter');

--- a/src/ORM/ManyManyThroughQueryManipulator.php
+++ b/src/ORM/ManyManyThroughQueryManipulator.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\ORM;
 
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\Deprecation;

--- a/tests/php/ORM/ManyManyThroughListTest.php
+++ b/tests/php/ORM/ManyManyThroughListTest.php
@@ -202,6 +202,64 @@ class ManyManyThroughListTest extends SapphireTest
         );
     }
 
+    public function testRemoveAll()
+    {
+        $first = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
+        $first->Items()->add($this->objFromFixture(ManyManyThroughListTest\Item::class, 'child0'));
+        $second = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent2');
+
+        $firstItems = $first->Items();
+        $secondItems = $second->Items();
+        $initialJoins = ManyManyThroughListTest\JoinObject::get()->count();
+        $initialItems = ManyManyThroughListTest\Item::get()->count();
+        $initialRelations = $firstItems->count();
+        $initialSecondListRelations = $secondItems->count();
+
+        $firstItems->removeAll();
+
+        // Validate all items were removed from the first list, but none were removed from the second list
+        $this->assertEquals(0, count($firstItems));
+        $this->assertEquals($initialSecondListRelations, count($secondItems));
+
+        // Validate that the JoinObjects were actually removed from the database
+        $this->assertEquals($initialJoins - $initialRelations, ManyManyThroughListTest\JoinObject::get()->count());
+
+        // Confirm Item objects were not removed from the database
+        $this->assertEquals($initialItems, ManyManyThroughListTest\Item::get()->count());
+    }
+
+    public function testRemoveAllIgnoresLimit()
+    {
+        $parent = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
+        $parent->Items()->add($this->objFromFixture(ManyManyThroughListTest\Item::class, 'child0'));
+        $initialJoins = ManyManyThroughListTest\JoinObject::get()->count();
+        // Validate there are enough items in the relation for this test
+        $this->assertTrue($initialJoins > 1);
+
+        $items = $parent->Items()->Limit(1);
+        $items->removeAll();
+
+        // Validate all items were removed from the list - not only one
+        $this->assertEquals(0, count($items));
+    }
+
+    public function testFilteredRemoveAll()
+    {
+        $parent = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
+        $parent->Items()->add($this->objFromFixture(ManyManyThroughListTest\Item::class, 'child0'));
+        $items = $parent->Items();
+        $initialJoins = ManyManyThroughListTest\JoinObject::get()->count();
+        $initialRelations = $items->count();
+
+        $items->filter('Title:not', 'not filtered')->removeAll();
+
+        // Validate only the filtered items were removed
+        $this->assertEquals(1, $items->count());
+
+        // Validate the list only contains the correct remaining item
+        $this->assertEquals(['not filtered'], $items->column('Title'));
+    }
+
     /**
      * Test validation
      *

--- a/tests/php/ORM/ManyManyThroughListTest.yml
+++ b/tests/php/ORM/ManyManyThroughListTest.yml
@@ -1,7 +1,12 @@
 SilverStripe\ORM\Tests\ManyManyThroughListTest\TestObject:
   parent1:
     Title: 'my object'
+  parent2:
+    Title: 'my object2'
 SilverStripe\ORM\Tests\ManyManyThroughListTest\Item:
+  # Having this one first means the IDs of records aren't the same as the IDs of the join objects.
+  child0:
+    Title: 'not filtered'
   child1:
     Title: 'item 1'
   child2:
@@ -16,6 +21,14 @@ SilverStripe\ORM\Tests\ManyManyThroughListTest\JoinObject:
     Title: 'join 2'
     Sort: 2
     Parent: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\TestObject.parent1
+    Child: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\Item.child2
+  join3:
+    Title: 'join 3'
+    Parent: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\TestObject.parent2
+    Child: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\Item.child1
+  join4:
+    Title: 'join 4'
+    Parent: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\TestObject.parent2
     Child: =>SilverStripe\ORM\Tests\ManyManyThroughListTest\Item.child2
 SilverStripe\ORM\Tests\ManyManyThroughListTest\PolyObjectA:
   obja1:


### PR DESCRIPTION
Instead of just setting one side of the relation to null in the through table, remove the rows entirely.
Remove only the relations which match the filters that have already been set on the list.
This is consistent with the way `ManyManyList` works - in fact much of the code for the tests are taken straight from that class.

The issue was ultimately caused by the `HasManyList` which is being used as an intermediary not having and of the 'where' clause (i.e. filter/exclude) of the underlying dataquery of the `ManyManyThroughList`. Changing that without causing regressions seemed like a bit of a tricky way to handle this - and even then if we still relied on using `removeAll()` from that `HasManyList` we would have still seen the rows in the through table being updated with null IDs on one side of the relationship instead of those rows being deleted outright.

Also some small tidy-up (removing an unnecessary line break and an unused "use" statement)

## Parent Issue
- fixes #10104 
