### PR TITLE
FIX/API Always set polymorphic class name in gridfield on new records.

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -18,6 +18,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\ORM\HasManyList;
 use SilverStripe\ORM\ManyManyList;
+use SilverStripe\ORM\PolymorphicHasManyList;
 use SilverStripe\ORM\RelationList;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\ValidationException;
@@ -201,6 +202,12 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
             $key = $list->getForeignKey();
             $id = $list->getForeignID();
             $this->record->$key = $id;
+            // If the list is polymorphic, add the foreign class as well.
+            if ($list instanceof PolymorphicHasManyList) {
+                $classKey = $list->getForeignClassKey();
+                $class = $list->getForeignClass();
+                $this->record->$classKey = $class;
+            }
         }
 
         if (!$this->record->canView()) {

--- a/src/ORM/PolymorphicHasManyList.php
+++ b/src/ORM/PolymorphicHasManyList.php
@@ -30,6 +30,14 @@ class PolymorphicHasManyList extends HasManyList
     }
 
     /**
+     * Gets the field name which holds the related object class.
+     */
+    public function getForeignClassKey(): string
+    {
+        return $this->classForeignKey;
+    }
+
+    /**
      * Create a new PolymorphicHasManyList relation list.
      *
      * @param string $dataClass The class of the DataObjects that this will list.

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest/Person.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest/Person.php
@@ -18,7 +18,8 @@ class Person extends DataObject implements TestOnly
     ];
 
     private static $has_one = [
-        'Group' => PeopleGroup::class
+        'Group' => PeopleGroup::class,
+        'PolymorphicGroup' => DataObject::class,
     ];
 
     private static $many_many = [

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest/PolymorphicPeopleGroup.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest/PolymorphicPeopleGroup.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\GridField\GridFieldDetailFormTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig_RelationEditor;
+use SilverStripe\ORM\DataObject;
+
+class PolymorphicPeopleGroup extends DataObject implements TestOnly
+{
+    private static $table_name = 'GridFieldDetailFormTest_PolymorphicPeopleGroup';
+
+    private static $db = [
+        'Name' => 'Varchar'
+    ];
+
+    private static $has_many = [
+        'People' => Person::class
+    ];
+
+    private static $default_sort = '"Name"';
+
+    public function getCMSFields()
+    {
+        $fields = parent::getCMSFields();
+        $fields->replaceField(
+            'People',
+            GridField::create(
+                'People',
+                'People',
+                $this->People(),
+                GridFieldConfig_RelationEditor::create()
+            )
+        );
+        return $fields;
+    }
+}

--- a/tests/php/ORM/PolymorphicHasManyListTest.php
+++ b/tests/php/ORM/PolymorphicHasManyListTest.php
@@ -110,4 +110,11 @@ class PolymorphicHasManyListTest extends SapphireTest
         $this->assertEmpty($subteam1fan->FavouriteID);
         $this->assertEmpty($subteam1fan->FavouriteClass);
     }
+
+    public function testGetForeignClassKey(): void
+    {
+        $team = $this->objFromFixture(DataObjectTest\Team::class, 'team1');
+        $list = $team->Fans();
+        $this->assertSame('FavouriteClass', $list->getForeignClassKey());
+    }
 }


### PR DESCRIPTION
When creating a new record in a gridfield item edit form and polymorphic `has_one` relations have the ID set, but not the class. In polymorphic relations the ID is useless without the class.

This has caused at least one known issue (see parent issue below) where a relation is relied on for canX permissions but ultimately the relation only exists _after_ the record has been created.

## Parent issue
- silverstripe/silverstripe-userforms#1103