### PR TITLE
Fix error when `posix_getpwuid` returns false

### DIFF
--- a/src/Core/TempFolder.php
+++ b/src/Core/TempFolder.php
@@ -39,7 +39,7 @@ class TempFolder
         $user = '';
         if (function_exists('posix_getpwuid') && function_exists('posix_getuid')) {
             $userDetails = posix_getpwuid(posix_getuid());
-            $user = $userDetails['name'];
+            $user = $userDetails['name'] ?? false;
         }
         if (!$user) {
             $user = Environment::getEnv('APACHE_RUN_USER');


### PR DESCRIPTION
The posix_getpwuid function can return `false` if it fails (see [docs](https://www.php.net/manual/en/function.posix-getpwuid.php#:~:text=The%20function%20returns%20false%20on%20failure.)).

If this happens, it results in a notice output in the CMS/front-end and broken functionality.
`Notice: Trying to access array offset on value of type bool in ***/vendor/silverstripe/framework/src/Core/TempFolder.php on line 42`

<img width="2554" alt="Screen Shot 2022-05-04 at 8 24 30 AM" src="https://user-images.githubusercontent.com/415374/166566592-36eec35a-ae59-41b0-a70c-470d08414ea1.png">

Since there is a cascade in the `getTempFolderUsername()` function, I would assume it is safe to have `$user` set to `false` if it fails and to continue to look for another method to populate it successfully.

---
Observed in PHP 7.4.28 + PHP 7.4.29, macOS 12.3.1, M1 pro