### PR TITLE
FIX Use DataColumns content when available in CSV export

### DIFF
--- a/src/Forms/GridField/GridFieldExportButton.php
+++ b/src/Forms/GridField/GridFieldExportButton.php
@@ -234,7 +234,7 @@ class GridFieldExportButton implements GridField_HTMLProvider, GridField_ActionP
                         }
 
                         $value = $columnHeader($relObj);
-                    } elseif ($gridFieldColumnsComponent && array_key_exists($columnSource, $columnsHandled)) {
+                    } elseif ($gridFieldColumnsComponent && in_array($columnSource, $columnsHandled)) {
                         $value = strip_tags(
                             $gridFieldColumnsComponent->getColumnContent($gridField, $item, $columnSource)
                         );


### PR DESCRIPTION
Fix #9248 broke #9173 by accidentally checking for a string key in a numerically indexed array. Change the check to search the array instead (fixes #10308)

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
