### PR TITLE
ENH Use guzzle for oembed

### DIFF
--- a/_config/oembed.yml
+++ b/_config/oembed.yml
@@ -4,6 +4,11 @@ Name: coreoembed
 SilverStripe\Core\Injector\Injector:
   SilverStripe\View\Embed\Embeddable:
     class: SilverStripe\View\Embed\EmbedContainer
+  Psr\Http\Client\ClientInterface.oembed:
+    class: GuzzleHttp\Client
+  Embed\Http\Crawler:
+    constructor:
+      - '%$Psr\Http\Client\ClientInterface.oembed'
   Embed\Embed:
     constructor:
       - '%$Embed\Http\Crawler'

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
     },
     "conflict": {
         "egulias/email-validator": "^2",
-        "phpunit/phpunit": "^6 || ^7 || ^8"
+        "phpunit/phpunit": "^6 || ^7 || ^8",
+        "cwp/cwp-core": "<2.11.0"
     },
     "provide": {
         "psr/container-implementation": "1.0.0"

--- a/docs/en/02_Developer_Guides/03_Forms/Field_types/03_HTMLEditorField.md
+++ b/docs/en/02_Developer_Guides/03_Forms/Field_types/03_HTMLEditorField.md
@@ -265,6 +265,19 @@ SilverStripe\AssetAdmin\Forms\RemoteFileFormFactory:
 HtmlEditorConfig::get('cms')->disablePlugins('ssembed');
 ```
 
+Use the following config if you need to send outbound requests through a proxy:
+
+```yaml
+---
+Name: myembed
+After: coreoembed
+---
+SilverStripe\Core\Injector\Injector:
+  Psr\Http\Client\ClientInterface.oembed:
+    constructor:
+      - proxy: '111.222.333.444:55'
+```
+
 ## Limiting oembed URLs
 
 HtmlEditorField can have whitelists set on both the scheme (default http & https) and domains allowed when

--- a/docs/en/04_Changelogs/4.11.0.md
+++ b/docs/en/04_Changelogs/4.11.0.md
@@ -102,6 +102,7 @@ This release includes a number of bug fixes to improve a broad range of areas. C
 
 - If `guzzlehttp/guzzle` is required, it must now be at least `7.3.0`. This was done to ensure that v2 of `guzzlehttp/psr7` is installed, which is used by `embed/embed` v4
 - `embed/embed` has been upgraded from v3 to v4. The internal implementation of the internal `Embeddable` interface has been changed from `EmbedResource` to `EmbedContainer`
+- `embed/embed` has been configured to use a guzzle client instead of the default curl client so that a proxy configuration value can be set if required
 
 <!--- Changes below this line will be automatically regenerated -->
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10305

Note: cwp-core 2.10.0 which has the [old curl config](https://github.com/silverstripe/cwp-core/blob/8487b6bf9fc78b446f1ec91478741c122ca1e91d/_config/oembed.yml#L12) has already been tagged as part of 4.11.0-beta1 release, so assumption is that we'd release the fix on cwp-core as a patch release 2.10.1.  Hence the composer conflict of `"cwp/cwp-core": "<2.10.1"`