### PR TITLE
ENH Ensure users are sent emails when passwords are changed by default

### DIFF
--- a/docs/en/04_Changelogs/4.11.0.md
+++ b/docs/en/04_Changelogs/4.11.0.md
@@ -8,6 +8,7 @@
   - [Upload and use WebP images in the CMS](#webp)
   - [Preview any DataObject in any admin section](#cms-preview)
   - [Allow-plugins configuration option in Composer versions 2.2.0 and up](#composer)
+  - [Users will recieve an email if their password is changed](#change-password-email)
   - [Other features](#other-features)
 - [Bugfixes](#bugfixes)
 - [Dependency and internal API changes](#dependency-internal-api-changes)
@@ -88,6 +89,21 @@ SilverStripe\CMS\Model\SiteTree:
     `silverstripe/vendor-plugin`
 New installations using `silverstripe/silverstripe-installer` and `silverstripe/recipe-kitchen-sink` from 4.11 onwards will have the above plugins added to the `allowed-plugins` configuration by default.
 - From July 2022 composer will no longer prompt to allow plugins when running `composer install`. This won't affect new installs using silverstripe/installer or silverstripe-recipe-kitchen-sink, but will affect other new projects, and existing projects where `allowed-plugins` hasn't yet been defined. In those cases developers will need to declare the allowed plugins manually in the project's `composer.json` file.
+
+### Users will recieve an email if their password is changed {#change-password-email}
+
+The `SilverStripe\Security\Member.notify_password_change` configuration has been set to `true` by default - it used to be `false`. This means when a user changes their password on a project in "live" mode, they will recieve an email alerting them that their password was changed. The email includes a link to change their password again, so that users can recover their account in the event that someone else changed their password without their knowledge.
+
+This change was made to improve the default security of your projects, but if you do not want this behaviour you can disable it by setting the configuration to false:
+
+```yml
+SilverStripe\Security\Member:
+  notify_password_change: false
+```
+
+The email content can also be changed by overriding the `SilverStripe\Control\Email\ChangePasswordEmail` template.
+
+Note that this configuration is already enabled by default in the `cwp/cwp-core` module. Projects which have that as a dependency won't experience any change in behaviour.
 
 ### Other new features {#other-features}
 

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -5,7 +5,7 @@ en:
     EDITINFO: 'Edit this file'
     REMOVE: Remove
   SilverStripe\Control\ChangePasswordEmail_ss:
-    CHANGEPASSWORDFOREMAIL: 'The password for account with email address {email} has been changed. If you didn\''t change your password please change your password using the link below'
+    CHANGEPASSWORDFOREMAIL: 'The password for account with email address {email} has been changed. If you didn''t change your password please change your password using the link below'
     CHANGEPASSWORDTEXT1: 'You changed your password for'
     CHANGEPASSWORDTEXT3: 'Change password'
     HELLO: Hi

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -106,7 +106,7 @@ class Member extends DataObject
      * @config
      * @var boolean
      */
-    private static $notify_password_change = false;
+    private static $notify_password_change = true;
 
     /**
      * All searchable database columns


### PR DESCRIPTION
Also a fix to remove the backslash that was being output in emails, and fixing some markdown linting issues in the changelog since I was already editing that file.

Note that each of the three commits has a different prefix for changelog purposes - no need to squash.

## Parent issue
- #10306