### PR TITLE
MNT fix linting issues in 4.11.0 changelogs.

### DIFF
--- a/docs/en/04_Changelogs/4.11.0.md
+++ b/docs/en/04_Changelogs/4.11.0.md
@@ -7,15 +7,15 @@
 - [Features and enhancements](#features-and-enhancements)
   - [Upload and use WebP images in the CMS](#webp)
   - [Preview any DataObject in any admin section](#cms-preview)
+  - [Meta generator tag now shows framework version number](#meta-tag-version)
   - [Allow-plugins configuration option in Composer versions 2.2.0 and up](#composer)
   - [Other features](#other-features)
 - [Bugfixes](#bugfixes)
 - [Dependency and internal API changes](#dependency-internal-api-changes)
 
-
 ## Regression test and Security audit{#audit}
 
-This release has been comprehensively regression tested and passed to a third party for a security-focused audit. 
+This release has been comprehensively regression tested and passed to a third party for a security-focused audit.
 
 While it is still advised that you perform your own due diligence when upgrading your project, this work is performed to ensure a safe and secure upgrade with each recipe release.
 
@@ -27,7 +27,7 @@ In accordance with our [PHP support policy](/Getting_Started/Server_Requirements
 
 ### Upload and use WebP images {#webp}
 
-WebP is an alternative image format for displaying picture on websites. It provides generally better results in most use cases to JPEG and PNG. 
+WebP is an alternative image format for displaying picture on websites. It provides generally better results in most use cases to JPEG and PNG.
 
 Read [An image format for the Web](https://developers.google.com/speed/webp) for more information about WebP.
 
@@ -40,6 +40,7 @@ Until now, Silverstripe CMS would default to blocking content authors from uploa
 Once your project is upgraded to Silverstripe Recipe CMS 4.11, your content authors will automatically be able to upload WebP images and add them to web pages. We recommend you have a conversation with your users about the pros and cons of WebP so they can make an informed decisions about when to use this image format.
 
 If your website still caters to a significant number of visitors with browsers that do not support WebP, you can disable WebP image upload by adding this snippet to your YML config:
+
 ```yml
 ---
 Name: myproject-assetsfiletypes
@@ -60,9 +61,9 @@ This can be used to allow content authors to see the content they are creating i
 
 The [Preview Documentation](https://docs.silverstripe.org/en/4/developer_guides/customising_the_admin_interface/preview/) has been updated with code examples which show how to enable CMS preview on `DataObject`s in a couple of different scenarios.
 
-### Meta generator tag now shows framework version number
+### Meta generator tag now shows framework version number {#meta-tag-version}
 
-The meta generator tag, which can be seen in the meta tags when you view source on a regular page, now includes the framework version truncated to show just the major and minor version, e.g. 4.11. 
+The meta generator tag, which can be seen in the meta tags when you view source on a regular page, now includes the framework version truncated to show just the major and minor version, e.g. 4.11.
 
 This version number will provide aggregate installation numbers to the product team who maintain Silverstripe CMS which will be used to make informed product decisions.
 
@@ -79,6 +80,7 @@ The version portion of the metagenerator tag can be disabled via:
 SilverStripe\CMS\Model\SiteTree:
   show_meta_generator_version: false
 ```
+
 ### Allow-plugins configuration option in Composer versions 2.2.0 and up {#composer}
 
 - As of Composer 2.2.0, the [allow-plugins](https://getcomposer.org/doc/06-config.md#allow-plugins) option adds a layer of security. Developers will be prompted to allow plugins when running `composer install` for the first time on existing projects, or for any new projects not using `silverstripe/installer` or `silverstripe/recipe-kitchen-sink`.


### PR DESCRIPTION
Quick linting of the 4.11.0 changelogs plus adding a missing heading.