### PR TITLE
MNT Use correct branch of installer for travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ version: ~> 1.0
 import:
   - silverstripe/silverstripe-travis-shared:config/provision/standard.yml
 
+env:
+  global:
+    - REQUIRE_RECIPE="4.10.x-dev"
+
 # Using a manual matrix to exlude PHPUNIT_COVERAGE_TEST for now because it was causing some strange issues
 # e.g. https://travis-ci.com/github/silverstripe/silverstripe-framework/jobs/457096837
 jobs:


### PR DESCRIPTION
Travis has a hardcoded workaround to use the current minor branch of installer unless otherwise specified. That's 4.11 now that we're in beta, which is breaking builds for 4.10