### PR TITLE
NEW: Mock sleep unit test utility.

### DIFF
--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -1359,6 +1359,22 @@ if (class_exists(IsEqualCanonicalizing::class)) {
                 $this->getName(false)
             );
         }
+
+        /**
+         * Test safe version of sleep()
+         *
+         * @param int $seconds
+         * @return DBDatetime
+         * @throws Exception
+         */
+        protected function mockSleep(int $seconds): DBDatetime
+        {
+            $now = DBDatetime::now();
+            $now->modify(sprintf('+ %d seconds', $seconds));
+            DBDatetime::set_mock_now($now);
+
+            return $now;
+        }
     }
 }
 
@@ -2654,5 +2670,21 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
             $rules[$route] = $class;
         }
         return $rules;
+    }
+
+    /**
+     * Test safe version of sleep()
+     *
+     * @param int $seconds
+     * @return DBDatetime
+     * @throws Exception
+     */
+    protected function mockSleep(int $seconds): DBDatetime
+    {
+        $now = DBDatetime::now();
+        $now->modify(sprintf('+ %d seconds', $seconds));
+        DBDatetime::set_mock_now($now);
+
+        return $now;
     }
 }

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -248,6 +248,22 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
     }
 
     /**
+     * Test safe version of sleep()
+     *
+     * @param int $seconds
+     * @return DBDatetime
+     * @throws Exception
+     */
+    public static function mockSleep(int $seconds): DBDatetime
+    {
+        $now = DBDatetime::now();
+        $now->modify(sprintf('+ %d seconds', $seconds));
+        DBDatetime::set_mock_now($now);
+
+        return $now;
+    }
+
+    /**
      * Run a callback with specific time, original mock value is retained after callback
      *
      * @param DBDatetime|string $time

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -248,22 +248,6 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
     }
 
     /**
-     * Test safe version of sleep()
-     *
-     * @param int $seconds
-     * @return DBDatetime
-     * @throws Exception
-     */
-    public static function mockSleep(int $seconds): DBDatetime
-    {
-        $now = DBDatetime::now();
-        $now->modify(sprintf('+ %d seconds', $seconds));
-        DBDatetime::set_mock_now($now);
-
-        return $now;
-    }
-
-    /**
      * Run a callback with specific time, original mock value is retained after callback
      *
      * @param DBDatetime|string $time

--- a/tests/php/ORM/DBDatetimeTest.php
+++ b/tests/php/ORM/DBDatetimeTest.php
@@ -58,6 +58,25 @@ class DBDatetimeTest extends SapphireTest
         });
     }
 
+    public function testMockSleep()
+    {
+        DBDatetime::set_mock_now('2010-01-01 10:00:00');
+
+        DBDatetime::mockSleep(1);
+        $this->assertEquals(
+            '2010-01-01 10:00:01',
+            DBDatetime::now()->Rfc2822(),
+            'We expect the time to move forward by 1 second'
+        );
+
+        DBDatetime::mockSleep(10);
+        $this->assertEquals(
+            '2010-01-01 10:00:11',
+            DBDatetime::now()->Rfc2822(),
+            'We expect the time to move forward by 10 seconds'
+        );
+    }
+
     public function testSetNullAndZeroValues()
     {
         $date = DBDatetime::create_field('Datetime', '');

--- a/tests/php/ORM/DBDatetimeTest.php
+++ b/tests/php/ORM/DBDatetimeTest.php
@@ -62,14 +62,14 @@ class DBDatetimeTest extends SapphireTest
     {
         DBDatetime::set_mock_now('2010-01-01 10:00:00');
 
-        DBDatetime::mockSleep(1);
+        $this->mockSleep(1);
         $this->assertEquals(
             '2010-01-01 10:00:01',
             DBDatetime::now()->Rfc2822(),
             'We expect the time to move forward by 1 second'
         );
 
-        DBDatetime::mockSleep(10);
+        $this->mockSleep(10);
         $this->assertEquals(
             '2010-01-01 10:00:11',
             DBDatetime::now()->Rfc2822(),


### PR DESCRIPTION
# NEW: Mock sleep unit test utility.

Simple utility function for unit tests. Use instead of `sleep()`. I found this quite handy is several projects, we might as well make the code reusable.