### PR TITLE
ENH: Add extension hooks to core emails

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -914,7 +914,7 @@ class Member extends DataObject
             && static::config()->get('notify_password_change')
             && $this->isInDB()
         ) {
-            Email::create()
+            $email = Email::create()
                 ->setHTMLTemplate('SilverStripe\\Control\\Email\\ChangePasswordEmail')
                 ->setData($this)
                 ->setTo($this->Email)
@@ -922,8 +922,10 @@ class Member extends DataObject
                     __CLASS__ . '.SUBJECTPASSWORDCHANGED',
                     "Your password has been changed",
                     'Email subject'
-                ))
-                ->send();
+                ));
+
+            $this->extend('updateChangedPasswordEmail', $email);
+            $email->send();
         }
 
         // The test on $this->ID is used for when records are initially created. Note that this only works with

--- a/src/Security/MemberAuthenticator/LostPasswordHandler.php
+++ b/src/Security/MemberAuthenticator/LostPasswordHandler.php
@@ -242,6 +242,8 @@ class LostPasswordHandler extends RequestHandler
             ))
             ->addData('PasswordResetLink', Security::getPasswordResetLink($member, $token))
             ->setTo($member->Email);
+
+        $member->extend('updateForgotPasswordEmail', $email);
         return $email->send();
     }
 


### PR DESCRIPTION
A (sorta) follow up to https://github.com/silverstripe/silverstripe-framework/pull/10313.

Extension hooks here make it possible to adjust the email contents with much more flexibility than just a single template, or even rebuild the entire email from scratch:

```php
public function updateChangedPasswordEmail(&$email)
{
    $email = new MyCustomEmailClass();
    // ... etc
}
```