### PR TITLE
DEP Add guzzle 7 requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "bramus/monolog-colored-line-formatter": "^2",
         "composer/installers": "^1 || ^2",
         "composer/semver": "^1 || ^3",
+        "guzzlehttp/guzzle": "^7",
         "guzzlehttp/psr7": "^2",
         "embed/embed": "^4",
         "league/csv": "^8 || ^9",


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/542

Requirement should have been added in https://github.com/silverstripe/silverstripe-framework/pull/10311

Is causing failure in the graphql3 build of cms, while the graphql4 build which requires guzzle ^7.3 is passing - https://app.travis-ci.com/github/silverstripe/silverstripe-cms/builds/250729119

Tag 4.11.0-beta3 after merging