### PR TITLE
ENH Replace record in Permission Table if GroupID already exist

### DIFF
--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -392,10 +392,16 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      */
     public static function grant($groupID, $code, $arg = "any")
     {
-        $perm = new Permission();
-        $perm->GroupID = $groupID;
-        $perm->Code = $code;
-        $perm->Type = self::GRANT_PERMISSION;
+        $permissions = Permission::get()->filter(['GroupID' => $groupID, 'Code' => $code]);
+        
+        if ($permissions && $permissions->count() > 0) {
+            $perm = $permissions->first();
+        } else {
+            $perm = new Permission();
+            $perm->GroupID = $groupID;
+            $perm->Code = $code;
+            $perm->Type = self::GRANT_PERMISSION;
+        }
 
         // Arg component
         switch ($arg) {

--- a/tests/php/Security/PermissionTest.php
+++ b/tests/php/Security/PermissionTest.php
@@ -163,4 +163,37 @@ class PermissionTest extends SapphireTest
         $this->assertFalse(Permission::checkMember($member, 'ADMIN'));
         $this->assertFalse(Permission::checkMember($member, 'CMS_ACCESS_LeftAndMain'));
     }
+
+    public function testGrantPermission()
+    {
+        $id = rand(15, 20);
+
+        Permission::grant($id, 'CMS_ACCESS_CMSMain');
+        Permission::grant($id, 'CMS_ACCESS_AssetAdmin');
+        Permission::grant($id, 'CMS_ACCESS_ReportAdmin');
+
+        $groupPermission = Permission::get()->filter(['GroupID' => $id]);
+
+        $this->assertEquals(3, $groupPermission->count());
+        $this->assertEquals(0, $groupPermission->first()->Arg);
+
+
+        Permission::grant($id, 'CMS_ACCESS_CMSMain', 'all');
+        Permission::grant($id, 'CMS_ACCESS_AssetAdmin', 'all');
+        Permission::grant($id, 'CMS_ACCESS_ReportAdmin', 'all');
+
+        $groupPermission = Permission::get()->filter(['GroupID' => $id]);
+
+        $this->assertEquals(3, $groupPermission->count());
+        $this->assertEquals(-1, $groupPermission->first()->Arg);
+
+        Permission::grant($id, 'CMS_ACCESS_CMSMain', 'any');
+        Permission::grant($id, 'CMS_ACCESS_AssetAdmin', 'any');
+        Permission::grant($id, 'CMS_ACCESS_ReportAdmin', 'any');
+
+        $groupPermission = Permission::get()->filter(['GroupID' => $id]);
+
+        $this->assertEquals(3, $groupPermission->count());
+        $this->assertEquals(-1, $groupPermission->first()->Arg);
+    }
 }


### PR DESCRIPTION
### Description
Duplicate Permission records are not created after calling Permission::grant
Override record if a provided GroupId with provided Code already exist in Permission table.
 
### Parent Issue
- #10147