### PR TITLE
ENH Replace record in Permission Table if GroupID already exist

### DIFF
--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -392,9 +392,16 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      */
     public static function grant($groupID, $code, $arg = "any")
     {
-        $perm = new Permission();
-        $perm->GroupID = $groupID;
-        $perm->Code = $code;
+        $permissions = Permission::get()->filter(['GroupID' => $groupID, 'Code' => $code]);
+        
+        if ($permissions && $permissions->count() > 0) {
+            $perm = $permissions->last();
+        } else {
+            $perm = new Permission();
+            $perm->GroupID = $groupID;
+            $perm->Code = $code;
+        }
+
         $perm->Type = self::GRANT_PERMISSION;
 
         // Arg component
@@ -427,9 +434,16 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      */
     public static function deny($groupID, $code, $arg = "any")
     {
-        $perm = new Permission();
-        $perm->GroupID = $groupID;
-        $perm->Code = $code;
+        $permissions = Permission::get()->filter(['GroupID' => $groupID, 'Code' => $code]);
+
+        if ($permissions && $permissions->count() > 0) {
+            $perm = $permissions->last();
+        } else {
+            $perm = new Permission();
+            $perm->GroupID = $groupID;
+            $perm->Code = $code;
+        }
+
         $perm->Type = self::DENY_PERMISSION;
 
         // Arg component

--- a/tests/php/Security/PermissionTest.yml
+++ b/tests/php/Security/PermissionTest.yml
@@ -33,6 +33,10 @@
     FirstName: Left
     Surname: AndMain
     Email: leftandmain@example.com
+  testcmseditormember:
+    FirstName: CMS
+    Surname: Editor
+    Email: testcmseditor@example.com
 
 'SilverStripe\Security\Group':
   author:
@@ -50,6 +54,14 @@
   leftandmain:
     Title: LeftAndMain
     Members: '=>SilverStripe\Security\Member.leftandmain'
+  cmsmaingroup:
+    Title: CMSMain
+    Members: '=>SilverStripe\Security\Member.testcmseditormember'
+  testpermissiongroup:
+    Title: TestPermissionGroup
+  testcmseditorgroup:
+    Title: TestCMSEditor
+    Members: '=>SilverStripe\Security\Member.testcmseditormember'
 
 'SilverStripe\Security\Permission':
   extra1:
@@ -61,3 +73,9 @@
   leftandmain:
     Code: CMS_ACCESS_LeftAndMain
     Group: '=>SilverStripe\Security\Group.leftandmain'
+  cmsmain:
+    Code: CMS_ACCESS_CMSMain
+    Group: '=>SilverStripe\Security\Group.cmsmaingroup'
+  testcmseditor:
+    Code: TEST_CMS_EDITOR
+    Group: '=>SilverStripe\Security\Group.testcmseditorgroup'


### PR DESCRIPTION
### Description
Duplicate Permission records are not created after calling Permission::grant
Override record if a provided GroupId with provided Code already exist in Permission table.
 
### Parent Issue
- #10147
