### PR TITLE
ENH Restore gridfield state from get vars (POC)

### DIFF
--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -4,10 +4,12 @@ namespace SilverStripe\Forms\GridField;
 
 use InvalidArgumentException;
 use LogicException;
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\HasRequestHandler;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\HTTPResponse_Exception;
+use SilverStripe\Control\NullHTTPRequest;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
@@ -45,6 +47,8 @@ use SilverStripe\View\HTML;
  */
 class GridField extends FormField
 {
+    use GridFieldStateAware;
+
     /**
      * @var array
      */
@@ -435,12 +439,40 @@ class GridField extends FormField
     {
         $this->state = new GridState($this);
 
+        $this->addStateFromRequest();
+
         $data = $this->state->getData();
 
         foreach ($this->getComponents() as $item) {
             if ($item instanceof GridField_StateProvider) {
                 $item->initDefaultState($data);
             }
+        }
+    }
+
+    /**
+     * Adds state for this gridfield from the request variables.
+     *
+     * If there is state already set on this GridField, that takes precedent
+     * over state from the request.
+     */
+    private function addStateFromRequest(): void
+    {
+        $request = $this->getRequest();
+        if (($request instanceof NullHTTPRequest) && Controller::has_curr()) {
+            $request = Controller::curr()->getRequest();
+        }
+        if ($request->params()['Action']) {
+            return;
+        }
+        $stateStr = $this->getStateManager()->getStateFromRequest($this, $request);
+        if ($stateStr) {
+            $oldState = $this->getState(false);
+            // Create a dummy state so that we can merge the current state with the request state.
+            $newState = new GridState($this, $stateStr);
+            // Put the current state on top of the request state.
+            $newState->setValue($oldState->Value());
+            $this->state = $newState;
         }
     }
 

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -481,7 +481,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
             $backlink = $toplevelController->Link();
         }
 
-        return $backlink;
+        return $this->gridField->addAllStateToUrl($backlink);
     }
 
     /**
@@ -815,6 +815,12 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
                 'Title' => _t('SilverStripe\\Forms\\GridField\\GridField.NewRecord', 'New {type}', ['type' => $this->record->i18n_singular_name()]),
                 'Link' => false
             ]));
+        }
+
+        foreach ($items as $item) {
+            if ($item->Link) {
+                $item->Link = $this->gridField->addAllStateToUrl($item->Link);
+            }
         }
 
         $this->extend('updateBreadcrumbs', $items);

--- a/src/Forms/GridField/GridFieldEditButton.php
+++ b/src/Forms/GridField/GridFieldEditButton.php
@@ -61,6 +61,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
 
     /**
      * @inheritdoc
+     * @param bool $addState DEPRECATED: Should be removed in major release
      */
     public function getUrl($gridField, $record, $columnName, $addState = true)
     {
@@ -70,11 +71,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
             'edit'
         );
 
-        if ($addState) {
-            $link = $this->getStateManager()->addStateToURL($gridField, $link);
-        }
-
-        return $link;
+        return $gridField->addAllStateToUrl($link, $addState);
     }
 
     /**

--- a/src/Forms/GridField/GridFieldViewButton.php
+++ b/src/Forms/GridField/GridFieldViewButton.php
@@ -44,7 +44,8 @@ class GridFieldViewButton extends AbstractGridFieldComponent implements GridFiel
      */
     public function getUrl($gridField, $record, $columnName)
     {
-        return Controller::join_links($gridField->Link('item'), $record->ID, 'view');
+        $link = Controller::join_links($gridField->Link('item'), $record->ID, 'view');
+        return $gridField->addAllStateToUrl($link);
     }
 
     public function augmentColumns($field, &$columns)

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest.php
@@ -341,10 +341,11 @@ class GridFieldDetailFormTest extends FunctionalTest
         );
         $this->assertEquals(
             sprintf(
-                'GridFieldDetailFormTest_GroupController/Form/field/testfield/item/%d/ItemEditForm/field/People'
-                . '/item/%d/edit',
+                '/GridFieldDetailFormTest_GroupController/Form/field/testfield/item/%d/ItemEditForm/field/People'
+                . '/item/%d/edit%s',
                 $group->ID,
-                $person->ID
+                $person->ID,
+                '?gridState-People-1=%7B%22GridFieldAddRelation%22%3Anull%7D'
             ),
             (string)$personEditLink[0]['href']
         );
@@ -359,11 +360,12 @@ class GridFieldDetailFormTest extends FunctionalTest
         );
         $this->assertEquals(
             sprintf(
-                'GridFieldDetailFormTest_GroupController/Form/field/testfield/item/%d/ItemEditForm/field/People'
-                . '/item/%d/ItemEditForm/field/Categories/item/%d/edit',
+                '/GridFieldDetailFormTest_GroupController/Form/field/testfield/item/%d/ItemEditForm/field/People'
+                . '/item/%d/ItemEditForm/field/Categories/item/%d/edit%s',
                 $group->ID,
                 $person->ID,
-                $category->ID
+                $category->ID,
+                '?gridState-Categories-2=%7B%22GridFieldAddRelation%22%3Anull%7D'
             ),
             (string)$categoryEditLink[0]['href']
         );


### PR DESCRIPTION
The `GridFieldDetailForm`'s item edit form adds the current gridfield state to the URL of the CMS breadcrumbs back button (not the browser back button).
This PR pulls that state back into the `GridField`, so that when a user clicks back they retain the pagination and filter options they had set.

## Parent Issue
- https://github.com/silverstripe/silverstripe-framework/issues/9380

## ~~Why this is draft~~
The `GridField` is a complicated beast, and apparently there are a few issues related to this one which ideally should be addressed in tandem. Also, trying to resolve this is taking a lot longer than I expected, so I'm parking this for now.
Note that this PR is not complete - for this functionality to be reliable we would need to make the following additional changes:
- [x] Add the state to the `GridFieldViewButton`'s URL
- [x] Check why sometimes the `GridFieldEditButton` doesn't include the state and decide if it _should_ do so
- [x] Add javascript to admin in `GridField.js` in the `onmatch` event to make the search filter visible if the state indicates that the field has been filtered
- [x] Consider using [`window.history.replaceState()`](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState) in admin javascript to add the gridfield state to the current history when the state changes (i.e. when paginating or filtering a gridfield)

## Related PR
- https://github.com/silverstripe/silverstripe-admin/pull/1326