### PR TITLE
MNT Update utf8 aliases for mysql 8 and mariadb 10.6

### DIFF
--- a/tests/php/ORM/MySQLPDOConnectorTest.php
+++ b/tests/php/ORM/MySQLPDOConnectorTest.php
@@ -9,6 +9,7 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\Tests\MySQLPDOConnectorTest\PDOConnector;
 use SilverStripe\ORM\DB;
+use SilverStripe\Tests\ORM\Utf8\Utf8TestHelper;
 
 /**
  * @requires extension PDO
@@ -38,8 +39,9 @@ class MySQLPDOConnectorTest extends SapphireTest implements TestOnly
         $cset = $connection->query('show variables like "character_set_connection"')->fetch(PDO::FETCH_NUM)[1];
         $collation = $connection->query('show variables like "collation_connection"')->fetch(PDO::FETCH_NUM)[1];
 
-        $this->assertEquals($charset, $cset);
-        $this->assertEquals($defaultCollation, $collation);
+        $helper = new Utf8TestHelper();
+        $this->assertEquals($helper->getUpdatedUtfCharsetForCurrentDB($charset), $cset);
+        $this->assertEquals($helper->getUpdatedUtfCollationForCurrentDB($defaultCollation), $collation);
 
         unset($cset, $connection, $connector, $config);
     }
@@ -66,8 +68,9 @@ class MySQLPDOConnectorTest extends SapphireTest implements TestOnly
         $cset = $connection->query('show variables like "character_set_connection"')->fetch(PDO::FETCH_NUM)[1];
         $collation = $connection->query('show variables like "collation_connection"')->fetch(PDO::FETCH_NUM)[1];
 
-        $this->assertEquals($charset, $cset);
-        $this->assertEquals($customCollation, $collation);
+        $helper = new Utf8TestHelper();
+        $this->assertEquals($helper->getUpdatedUtfCharsetForCurrentDB($charset), $cset);
+        $this->assertEquals($helper->getUpdatedUtfCollationForCurrentDB($customCollation), $collation);
 
         unset($cset, $connection, $connector, $config);
     }

--- a/tests/php/ORM/Utf8/Utf8TestHelper.php
+++ b/tests/php/ORM/Utf8/Utf8TestHelper.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SilverStripe\Tests\ORM\Utf8;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DB;
+
+class Utf8TestHelper implements TestOnly
+{
+    private ?string $dbVersion = null;
+
+    public function getUpdatedUtfCharsetForCurrentDB(string $charset): string
+    {
+        if ($charset !== 'utf8') {
+            return $charset;
+        }
+        return $this->isMySqlGte80() || $this->isMariaDBGte106() ? 'utf8mb3' : 'utf8';
+    }
+
+    public function getUpdatedUtfCollationForCurrentDB(string $collation): string
+    {
+        if ($collation === 'utf8_general_ci') {
+            return $this->isMariaDBGte106() ? 'utf8mb3_general_ci' : 'utf8_general_ci';
+        }
+        if ($collation === 'utf8_unicode_520_ci') {
+            return $this->isMariaDBGte106() ? 'utf8mb3_unicode_520_ci' : 'utf8_unicode_520_ci';
+        }
+        return $collation;
+    }
+
+    /**
+     * MySQL has used utf8 as an alias for utf8mb3
+     * Beginning with MySQL 8.0.28, utf8mb3 is used
+     * https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8mb3.html
+     */
+    private function isMySqlGte80(): bool
+    {
+        // Example MySQL version: 8.0.29
+        if (preg_match('#^([0-9]+)\.[0-9]+\.[0-9]+$#', $this->getDBVersion(), $m)) {
+            return (int) $m[1] >= 8;
+        }
+        return false;
+    }
+
+    /**
+     * Until MariaDB 10.5, utf8mb3 was an alias for utf8.
+     * From MariaDB 10.6, utf8 is by default an alias for utf8mb3
+     * https://mariadb.com/kb/en/unicode/
+     */
+    private function isMariaDBGte106(): bool
+    {
+        // Example mariadb version: 5.5.5-10.6.8-mariadb-1:10.6.8+maria~focal
+        if (preg_match('#([0-9]+)\.([0-9]+)\.[0-9]+-mariadb#', $this->getDBVersion(), $m)) {
+            return (int) $m[1] >= 11 || ((int) $m[1] >= 10 && (int) $m[2] >= 6);
+        }
+        return false;
+    }
+
+    private function getDBVersion(): string
+    {
+        if (is_null($this->dbVersion)) {
+            $this->dbVersion = strtolower(DB::get_conn()->getVersion());
+        }
+        return $this->dbVersion;
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/github-actions-ci-cd/issues/33

MySQL 8.0+ and MariaDB 10.6+ self-report 'utf8mb3' instead of 'utf8'

Example of failure on mysql 8.0 https://github.com/emteknetnz/silverstripe-framework/runs/6584854634?check_suite_focus=true#step:12:111

Have tested locally on mysql 5.7, mysql 8.0, mariadb 10.5, mariadb 10.6

Passing with mysql 5.7 + mysql 8.0 in ci - https://github.com/emteknetnz/silverstripe-framework/actions/runs/2382366944
