### PR TITLE
ENH Add samesite attribute to cookies.

### DIFF
--- a/docs/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
+++ b/docs/en/02_Developer_Guides/09_Security/04_Secure_Coding.md
@@ -762,11 +762,15 @@ disable this behaviour using `CanonicalURLMiddleware::singleton()->setForceBasic
 configuration in YAML.
 
 We also want to ensure cookies are not shared between secure and non-secure sessions, so we must tell Silverstripe CMS to 
-use a [secure session](https://docs.silverstripe.org/en/3/developer_guides/cookies_and_sessions/sessions/#secure-session-cookie). 
-To do this, you may set the `cookie_secure` parameter to `true` in your `config.yml` for `Session`
+use a [secure session](/developer_guides/cookies_and_sessions/sessions/#secure-session-cookie).
+To do this, you may set the `cookie_secure` parameter to `true` in your `config.yml` for `Session`.
+
+It is also a good idea to set the `samesite` attribute for the session cookie to `Strict` unless you have a specific use case for
+sharing the session cookie across domains.
 
 ```yml
 SilverStripe\Control\Session:
+  cookie_samesite: 'Strict'
   cookie_secure: true
 ```
 
@@ -783,6 +787,11 @@ SilverStripe\Core\Injector\Injector:
     properties:
       TokenCookieSecure: true
 ```
+
+[info]
+There is not currently an easy way to pass a `samesite` attribute value for setting this cookie - but you can set the
+default value for the attribute for all cookies. See [the main cookies documentation](/developer_guides/cookies_and_sessions/cookies#samesite-attribute) for more information.
+[/info]
 
 For other cookies set by your application we should also ensure the users are provided with secure cookies by setting 
 the "Secure" and "HTTPOnly" flags. These flags prevent them from being stolen by an attacker through javascript. 

--- a/docs/en/02_Developer_Guides/18_Cookies_And_Sessions/01_Cookies.md
+++ b/docs/en/02_Developer_Guides/18_Cookies_And_Sessions/01_Cookies.md
@@ -5,6 +5,10 @@ icon: cookie-bite
 ---
 
 # Cookies
+
+Note that cookies can have security implications - before setting your own cookies, make sure to read through the
+[secure coding](/developer_guides/security/secure_coding#secure-sessions-cookies-and-tls-https) documentation.
+
 ## Accessing and Manipulating Cookies
 
 Cookies are a mechanism for storing data in the remote browser and thus tracking or identifying return users. 
@@ -51,6 +55,20 @@ Cookie::force_expiry($name, $path = null, $domain = null);
 
 // Cookie::force_expiry('MyApplicationPreference')
 ```
+
+### Samesite attribute
+
+The `samesite` attribute is set on all cookies with a default value of `Lax`. You can change the default value by setting the `default_samesite` value on the
+[Cookie](api:SilverStripe\Control\Cookie) class:
+
+```yml
+SilverStripe\Control\Cookie:
+  default_samesite: 'Strict'
+```
+
+[info]
+Note that this _doesn't_ apply for the session cookie, which is handled separately. See [Sessions](/developer_guides/cookies_and_sessions/sessions#samesite-attribute).
+[/info]
 
 ## Cookie_Backend
 

--- a/docs/en/02_Developer_Guides/18_Cookies_And_Sessions/02_Sessions.md
+++ b/docs/en/02_Developer_Guides/18_Cookies_And_Sessions/02_Sessions.md
@@ -101,7 +101,19 @@ including form and page comment information. None of this is vital but `clear_al
 $session->clearAll();
 ```
 
-## Secure Session Cookie
+## Cookies
+
+### Samesite attribute
+
+The session cookie is handled slightly differently than most cookies on the site, which provides the opportunity to handle the samesite attribute separately from other cookies.
+You can change the `samesite` attribute for session cookies like so:
+
+```yml
+SilverStripe\Control\Session:
+  cookie_samesite: 'Strict'
+```
+
+### Secure Session Cookie
 
 In certain circumstances, you may want to use a different `session_name` cookie when using the `https` protocol for security purposes. To do this, you may set the `cookie_secure` parameter to `true` on your `config.yml`
 
@@ -112,6 +124,8 @@ SilverStripe\Control\Session:
 ```
 
 This uses the session_name `SECSESSID` for `https` connections instead of the default `PHPSESSID`. Doing so adds an extra layer of security to your session cookie since you no longer share `http` and `https` sessions.
+
+Note that if you set `cookie_samesite` to `None` (which is _strongly_ discouraged), the `cookie_secure` value will _always_ be `true`.
 
 ## Relaxing checks around user agent strings
 

--- a/docs/en/04_Changelogs/4.12.0.md
+++ b/docs/en/04_Changelogs/4.12.0.md
@@ -1,0 +1,55 @@
+---
+title: 4.12.0 (unreleased)
+---
+
+# 4.12.0 (unreleased)
+
+## Overview
+
+- [Regression test and Security audit](#audit)
+- [Features and enhancements](#features-and-enhancements)
+  - [Samesite attribute on cookies](#cookies-samesite)
+  - [Other features](#other-features)
+- [Bugfixes](#bugfixes)
+
+## Regression test and Security audit{#audit}
+
+This release has been comprehensively regression tested and passed to a third party for a security-focused audit.
+
+While it is still advised that you perform your own due diligence when upgrading your project, this work is performed to ensure a safe and secure upgrade with each recipe release.
+
+## Features and enhancements {#features-and-enhancements}
+
+### Samesite attribute on cookies {#cookies-samesite}
+
+The `samesite` attribute is now set on all cookies. To avoid backward compatability issues, the `Lax` value has been set by default, but we recommend reviewing the requirements of your project and setting an appropriate value.
+
+The default value can be set for all cookies (except for the session cookie) in yaml configuration like so:
+
+```yml
+SilverStripe\Control\Cookie:
+  default_samesite: 'Strict'
+```
+
+Check out the [cookies documentation](/developer_guides/cookies_and_sessions/cookies#samesite-attribute) for more information.
+
+The session cookie is handled separately. You can configure it like so:
+
+```yml
+SilverStripe\Control\Session:
+  cookie_samesite: 'Strict'
+```
+
+Note that if you set the `samesite` attribute to `None`, the `secure` is automatically set to `true` as required by the specification.
+
+For more information about the `samesite` attribute check out https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+
+### Other new features {#other-features}
+
+## Bugfixes {#bugfixes}
+
+This release includes a number of bug fixes to improve a broad range of areas. Check the change logs for full details of these fixes split by module. Thank you to the community members that helped contribute these fixes as part of the release!
+
+<!--- Changes below this line will be automatically regenerated -->
+
+<!--- Changes above this line will be automatically regenerated -->


### PR DESCRIPTION
Sets a default `samesite` attribute on all cookies. Using the `Lax` value means that we're just setting an explicit value that is identical to the implicit value that was already being used.

This PR provides a way to configure both the default value for all cookies and for session cookies separately, as well as giving an extension hook if a specific value is desired for a given cookie.

The extension hook should be removed in the next major in favour of adding a new parameter like what was proposed in #9842 - I've avoided doing that here because the cookie backend is explicitly extensible (with an interface and docs and everything) so adding new parameters here would constitute a breaking change.

The following links may be useful background:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
https://www.php.net/manual/en/function.setcookie.php
https://www.php.net/manual/en/function.session-set-cookie-params.php

## Parent issue:
- https://github.com/silverstripe/silverstripe-framework/issues/9440

## Related issue:
- tractorcow-farm/silverstripe-fluent#651
