### PR TITLE
Update CORs example in readme adding a colon so that the example config works. 

### DIFF
--- a/docs/en/02_Developer_Guides/19_GraphQL/04_security_and_best_practices/02_cors.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/04_security_and_best_practices/02_cors.md
@@ -143,7 +143,7 @@ SilverStripe\GraphQL\Controller:
 ```yaml
 ## CORS Config
 SilverStripe\Core\Injector\Injector:
-  SilverStripe\GraphQL\Controller.default
+  SilverStripe\GraphQL\Controller.default:
     properties:
       corsConfig:
         Enabled: false


### PR DESCRIPTION
CORs example was missing a colon.  

Without the colon the corsConfig isn't applied to the controller.   With the colon the corsConfig is applied and the CORs config works as expected. 

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
