### PR TITLE
MNT Rename test class to conform with standard naming convention

### DIFF
--- a/tests/php/Forms/NullableFieldTest.php
+++ b/tests/php/Forms/NullableFieldTest.php
@@ -11,7 +11,7 @@ use SilverStripe\Forms\NullableField;
  *
  * @author Pete Bacon Darwin
  */
-class NullableFieldTests extends SapphireTest
+class NullableFieldTest extends SapphireTest
 {
 
     /**


### PR DESCRIPTION
This is currently a hardcoded exception to removing tests in our travis config because the file name isn't following the convention.
Moving to github actions, we don't want to have such hardcoded exceptions.

## Parent issue
- https://github.com/silverstripe/github-actions-ci-cd/issues/36