### PR TITLE
DOCS Remove pre-release warnings from GraphQL docs.

### DIFF
--- a/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/01_activating_the_server.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/01_activating_the_server.md
@@ -8,13 +8,11 @@ icon: rocket
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Activating the default GraphQL server
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/02_configuring_your_schema.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/02_configuring_your_schema.md
@@ -8,13 +8,11 @@ icon: code
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Configuring your schema
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/03_building_the_schema.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/03_building_the_schema.md
@@ -8,13 +8,11 @@ icon: hammer
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Building the schema
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/04_using_procedural_code.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/04_using_procedural_code.md
@@ -8,13 +8,11 @@ icon: tools
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Building a schema with procedural code
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/05_deploying_the_schema.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/05_deploying_the_schema.md
@@ -8,13 +8,11 @@ icon: rocket
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql).
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Deploying the schema
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/index.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/01_getting_started/index.md
@@ -9,12 +9,10 @@ icon: rocket
 This section of the documentation will give you an overview of how to get a simple GraphQL API
 up and running with some `DataObject` content.
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 [CHILDREN]

--- a/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/01_adding_dataobjects_to_the_schema.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/01_adding_dataobjects_to_the_schema.md
@@ -7,13 +7,11 @@ summary: An overview of how the `DataObject` model can influence the creation of
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## The `DataObject` model type
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/02_query_plugins.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/02_query_plugins.md
@@ -7,13 +7,11 @@ summary: Learn about some of the useful goodies that come pre-packaged with `Dat
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## `DataObject` query plugins
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/03_permissions.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/03_permissions.md
@@ -7,13 +7,11 @@ summary: A look at how permissions work for `DataObject` queries and mutations
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## `DataObject` operation permissions
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/04_inheritance.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/04_inheritance.md
@@ -7,13 +7,11 @@ summary: Learn how inheritance is handled in `DataObject` types
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## `DataObject` inheritance
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/05_versioning.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/05_versioning.md
@@ -7,13 +7,11 @@ summary: A guide on how DataObjects with the Versioned extension behave in Graph
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Versioned content
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/06_property_mapping.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/06_property_mapping.md
@@ -7,13 +7,11 @@ summary: Learn how to customise field names, use dot syntax, and use aggregate f
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Property mapping and dot syntax
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/07_nested_definitions.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/07_nested_definitions.md
@@ -6,13 +6,11 @@ summary: Define dependent types inline with a parent type
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Nested type definitions
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/index.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/index.md
@@ -11,12 +11,10 @@ and adding read/write operations. We'll also look at some of the plugins that ar
 like [sorting, filtering, and pagination](query_plugins), as well as some more advanced concepts like
 [permissions](permissions), [inheritance](inheritance) and [property mapping](property_mapping).
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql).
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 [CHILDREN]

--- a/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/01_creating_a_generic_type.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/01_creating_a_generic_type.md
@@ -7,13 +7,11 @@ summary: Creating a type that doesn't map to a DataObject
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Creating a generic type
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/02_building_a_custom_query.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/02_building_a_custom_query.md
@@ -6,13 +6,11 @@ summary: Add a custom query for any type of data
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Building a custom query
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/03_resolver_discovery.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/03_resolver_discovery.md
@@ -7,13 +7,11 @@ summary: How you can opt out of mapping fields to resolvers by adhering to namin
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## The resolver discovery pattern
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/04_adding_arguments.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/04_adding_arguments.md
@@ -7,13 +7,11 @@ summary: Add arguments to your fields, queries, and mutations
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Adding arguments
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/05_adding_pagination.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/05_adding_pagination.md
@@ -6,13 +6,11 @@ summary: Add the pagination plugin to a generic query
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Adding pagination
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/06_adding_descriptions.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/06_adding_descriptions.md
@@ -6,13 +6,11 @@ summary: Add descriptions to just about anything in your schema to improve your 
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Adding descriptions
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/07_enums_unions_and_interfaces.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/07_enums_unions_and_interfaces.md
@@ -6,13 +6,11 @@ summary: Add some non-object types to your schema
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Enums, unions, and interfaces
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/index.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/index.md
@@ -17,12 +17,10 @@ declare `DataObject` classes as generic types. You would lose a lot of the benef
 in doing so, but this lower level API may suit your needs for very specific use cases.
 [/info]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 [CHILDREN]

--- a/docs/en/02_Developer_Guides/19_GraphQL/04_security_and_best_practices/01_authentication.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/04_security_and_best_practices/01_authentication.md
@@ -8,13 +8,11 @@ icon: user-lock
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Authentication
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/04_security_and_best_practices/02_cors.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/04_security_and_best_practices/02_cors.md
@@ -7,13 +7,11 @@ summary: Ensure that requests to your API come from a whitelist of origins
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Cross-Origin Resource Sharing (CORS)
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/04_security_and_best_practices/03_csrf_protection.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/04_security_and_best_practices/03_csrf_protection.md
@@ -6,13 +6,11 @@ summary: Protect destructive actions from cross-site request forgery
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## CSRF tokens (required for mutations)
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/04_security_and_best_practices/04_http_method_checking.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/04_security_and_best_practices/04_http_method_checking.md
@@ -7,13 +7,11 @@ summary: Ensure requests are GET or POST
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Strict HTTP Method Checking
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/04_security_and_best_practices/index.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/04_security_and_best_practices/index.md
@@ -9,12 +9,10 @@ icon: user-lock
 In this section we'll cover several options you have for keeping your GraphQL API secure and compliant
 with best practices. Some of these tools require configuration, while others come pre-installed.
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 [CHILDREN]

--- a/docs/en/02_Developer_Guides/19_GraphQL/05_plugins/01_overview.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/05_plugins/01_overview.md
@@ -7,13 +7,11 @@ summary: An overview of how plugins work with the GraphQL schema
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## What are plugins?
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/05_plugins/02_writing_a_simple_plugin.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/05_plugins/02_writing_a_simple_plugin.md
@@ -7,13 +7,11 @@ summary: In this tutorial, we add a simple plugin for string fields
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Writing a simple plugin
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/05_plugins/03_writing_a_complex_plugin.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/05_plugins/03_writing_a_complex_plugin.md
@@ -6,13 +6,11 @@ summary: In this tutorial, we'll create a plugin that affects models, queries, a
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Writing a complex plugin
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/05_plugins/index.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/05_plugins/index.md
@@ -10,12 +10,10 @@ Plugins play a critical role in distributing reusable functionality across your 
 everything loaded into the schema, including types, fields, queries, mutations, and even specifically to model types
 and their fields and operations.
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 [CHILDREN]

--- a/docs/en/02_Developer_Guides/19_GraphQL/06_extending/adding_a_custom_model.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/06_extending/adding_a_custom_model.md
@@ -6,13 +6,11 @@ summary: Add a new class-backed type beyond DataObject
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Adding a custom model
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/06_extending/adding_a_custom_operation.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/06_extending/adding_a_custom_operation.md
@@ -6,13 +6,11 @@ summary: Add a new operation for model types
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Adding a custom operation
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/06_extending/adding_middleware.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/06_extending/adding_middleware.md
@@ -6,13 +6,11 @@ summary: Add middleware to to extend query execution
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## Adding middleware
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/06_extending/global_schema.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/06_extending/global_schema.md
@@ -7,13 +7,11 @@ summary: How to push modifications to every schema in the project
 
 [CHILDREN asList]
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 ## The global schema
 

--- a/docs/en/02_Developer_Guides/19_GraphQL/06_extending/index.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/06_extending/index.md
@@ -8,12 +8,10 @@ In this section of the documentation, we'll look at some advanced
 features for developers who want to extend their GraphQL server
 using custom models, middleware, and new operations.
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 [CHILDREN]

--- a/docs/en/02_Developer_Guides/19_GraphQL/07_tips_and_tricks.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/07_tips_and_tricks.md
@@ -5,13 +5,11 @@ summary: Miscellaneous useful tips for working with your GraphQL schema
 
 # Tips & Tricks
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 
 ## Debugging the generated code

--- a/docs/en/02_Developer_Guides/19_GraphQL/index.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/index.md
@@ -6,12 +6,10 @@ system.
 
 For more information on GraphQL in general, visit its [documentation site](https://graphql.org).
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql). 
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 [CHILDREN includeFolders]

--- a/docs/en/03_Upgrading/06_Upgrading_to_GraphQL_4.md
+++ b/docs/en/03_Upgrading/06_Upgrading_to_GraphQL_4.md
@@ -5,13 +5,11 @@ summary: Upgrade your Silverstripe CMS project to use graphQL version 4
 
 # Upgrading to GraphQL 4
 
-[alert]
-You are viewing docs for a pre-release version of silverstripe/graphql (4.x).
-Help us improve it by joining #graphql on the [Community Slack](https://www.silverstripe.org/blog/community-slack-channel/),
-and report any issues at [github.com/silverstripe/silverstripe-graphql](https://github.com/silverstripe/silverstripe-graphql).
-Docs for the current stable version (3.x) can be found
-[here](https://github.com/silverstripe/silverstripe-graphql/tree/3)
-[/alert]
+[info]
+You are viewing docs for silverstripe/graphql 4.x.
+If you are using 3.x, documentation can be found
+[in the github repository](https://github.com/silverstripe/silverstripe-graphql/tree/3)
+[/info]
 
 The 4.0 release of `silverstripe/graphql` underwent a massive set of changes representing an
 entire rewrite of the module. This was done as part of a year-long plan to improve performance. While


### PR DESCRIPTION
Removing pre-release warnings in preparation for the stable 4.0.0 release of silverstripe/graphql.

## IMPORTANT
Do not merge this until we are close to a stable release for 4.11.0 (which includes a stable release of silverstripe/graphql 4.0.0)

## Parent Issue
- https://github.com/silverstripe/silverstripe-graphql/issues/438