### PR TITLE
DOCS Remove backticks from gatsby metadata in docs.

### DIFF
--- a/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/01_adding_dataobjects_to_the_schema.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/01_adding_dataobjects_to_the_schema.md
@@ -1,6 +1,6 @@
 ---
 title: Adding DataObjects to the schema
-summary: An overview of how the `DataObject` model can influence the creation of types, queries, and mutations
+summary: An overview of how the DataObject model can influence the creation of types, queries, and mutations
 ---
 
 # Working with DataObjects

--- a/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/02_query_plugins.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/02_query_plugins.md
@@ -1,6 +1,6 @@
 ---
-title: `DataObject` query plugins
-summary: Learn about some of the useful goodies that come pre-packaged with `DataObject` queries
+title: DataObject query plugins
+summary: Learn about some of the useful goodies that come pre-packaged with DataObject queries
 ---
 
 # Working with DataObjects

--- a/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/03_permissions.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/03_permissions.md
@@ -1,6 +1,6 @@
 ---
-title: `DataObject` operation permissions
-summary: A look at how permissions work for `DataObject` queries and mutations
+title: DataObject operation permissions
+summary: A look at how permissions work for DataObject queries and mutations
 ---
 
 # Working with DataObjects

--- a/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/04_inheritance.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/02_working_with_dataobjects/04_inheritance.md
@@ -1,6 +1,6 @@
 ---
-title: `DataObject` inheritance
-summary: Learn how inheritance is handled in `DataObject` types
+title: DataObject inheritance
+summary: Learn how inheritance is handled in DataObject types
 ---
 
 # Working with DataObjects

--- a/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/index.md
+++ b/docs/en/02_Developer_Guides/19_GraphQL/03_working_with_generic_types/index.md
@@ -1,6 +1,6 @@
 ---
 title: Working with generic types
-summary: Break away from the magic of `DataObject` models and build types and queries from scratch.
+summary: Break away from the magic of DataObject models and build types and queries from scratch.
 icon: clipboard
 ---
 


### PR DESCRIPTION
Gatsby can't handle backticks in the metadata (title, summary, etc) for docs and caused netlify builds to fail.

![image](https://user-images.githubusercontent.com/36352093/173699242-544c4f5a-5bce-4ead-ab85-f0a63d344b02.png)

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/554