### PR TITLE
FIX PDO transaction in PHP 8, add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  # Every Tuesday at 2:20pm UTC
+  schedule:
+    - cron: '20 14 * * 2'
+
+jobs:
+  ci:
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
+    with:
+      # Turn phpcoverage off because it causes a segfault
+      phpcoverage_force_off: true
+      # There is a strange behat.yml file in framework that runs behat tests in the admin module
+      endtoend: false

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,15 @@
+name: Keepalive
+
+on:
+  # The 4th of every month at 10:50am UTC
+  schedule:
+    - cron: '50 10 4 * *'
+  workflow_dispatch:
+
+jobs:
+  keepalive:
+    name: Keepalive
+    runs-on: ubuntu-latest
+    steps:
+      - name: Keepalive
+        uses: silverstripe/gha-keepalive@v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Silverstripe Framework
 
-[![Build Status](https://api.travis-ci.com/silverstripe/silverstripe-framework.svg?branch=4)](https://travis-ci.com/silverstripe/silverstripe-framework)
+[![CI](https://github.com/silverstripe/silverstripe-framework/actions/workflows/ci.yml/badge.svg)](https://github.com/silverstripe/silverstripe-framework/actions/workflows/ci.yml)
 [![Build Docs](https://github.com/silverstripe/silverstripe-framework/workflows/Build%20Docs/badge.svg)](https://docs.silverstripe.org/)
 [![Latest Stable Version](https://poser.pugx.org/silverstripe/framework/version.svg)](https://www.silverstripe.org/stable-download/)
 [![Latest Unstable Version](https://poser.pugx.org/silverstripe/framework/v/unstable.svg)](https://packagist.org/packages/silverstripe/framework)

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "psr/container": "^1",
         "silverstripe/config": "^1@dev",
         "silverstripe/assets": "^1@dev",
-        "silverstripe/vendor-plugin": "^1.4",
+        "silverstripe/vendor-plugin": "^1.6",
         "sminnee/callbacklist": "^0.1",
         "swiftmailer/swiftmailer": "^6.2",
         "symfony/cache": "^3.4 || ^4.0",


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

The update of silverstripe/vendor-plugin to ^1.6 is a corresponding update to https://github.com/silverstripe/gha-ci/pull/21

PDO issue is to fix `PDOException: There is no active transaction` e.g. https://github.com/silverstripe/silverstripe-framework/runs/7014940963?check_suite_focus=true#step:12:127