### PR TITLE
Test ci.yml from 4.11 pull-request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is a test, do not merge
+
 ## Silverstripe Framework
 
 [![Build Status](https://api.travis-ci.com/silverstripe/silverstripe-framework.svg?branch=4)](https://travis-ci.com/silverstripe/silverstripe-framework)


### PR DESCRIPTION
Do not merge

Testing that a pull-request targetting `4.11` which does not have ci.yml will trigger a workflow from the `4` branch which does have ci.yml