### PR TITLE
FIX Ensure not passing null to mysql methods for PHP 8.1 compatibility

### DIFF
--- a/src/ORM/Connect/MySQLiConnector.php
+++ b/src/ORM/Connect/MySQLiConnector.php
@@ -151,7 +151,7 @@ class MySQLiConnector extends DBConnector
 
     public function escapeString($value)
     {
-        return $this->dbConn->real_escape_string($value);
+        return $this->dbConn->real_escape_string($value ?? '');
     }
 
     public function quoteString($value)
@@ -181,7 +181,7 @@ class MySQLiConnector extends DBConnector
         $this->beforeQuery($sql);
 
         // Benchmark query
-        $handle = $this->dbConn->query($sql, MYSQLI_STORE_RESULT);
+        $handle = $this->dbConn->query($sql ?? '', MYSQLI_STORE_RESULT);
 
         if (!$handle || $this->dbConn->error) {
             $this->databaseError($this->getLastError(), $errorLevel, $sql);
@@ -319,7 +319,7 @@ class MySQLiConnector extends DBConnector
 
     public function selectDatabase($name)
     {
-        if ($this->dbConn->select_db($name)) {
+        if ($this->dbConn->select_db($name ?? '')) {
             $this->databaseName = $name;
             return true;
         }


### PR DESCRIPTION
Fix for this type of error

`PHP Deprecated:  mysqli::real_escape_string(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/mysite/www/vendor/silverstripe/framework/src/ORM/Connect/MySQLiConnector.php on line 154`

Was missed during the initial round of adding ` ?? ''` to everything