### PR TITLE
NEW Search across multiple searchable fields by default

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -148,6 +148,7 @@ en:
       one: 'A Data Object'
       other: '{count} Data Objects'
     SINGULARNAME: 'Data Object'
+    GENERALSEARCH: 'General Search'
   SilverStripe\ORM\FieldType\DBBoolean:
     ANY: Any
     NOANSWER: 'No'

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -4237,6 +4237,14 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     private static string $general_search_field_filter = PartialMatchFilter::class;
 
     /**
+     * If true, the search phrase is split into individual terms, and checks all searchable fields for each search term.
+     * If false, all fields are checked for the entire search phrase as a whole.
+     *
+     * Note that splitting terms may cause unexpected resuls if using an ExactMatchFilter.
+     */
+    private static bool $general_search_split_terms = true;
+
+    /**
      * User defined labels for searchable_fields, used to override
      * default display in the search form.
      * @config

--- a/src/ORM/Filters/PartialMatchFilter.php
+++ b/src/ORM/Filters/PartialMatchFilter.php
@@ -59,7 +59,7 @@ class PartialMatchFilter extends SearchFilter
         );
 
         $clause = [$comparisonClause => $this->getMatchPattern($this->getValue())];
-        
+
         return $this->aggregate ?
             $this->applyAggregate($query, $clause) :
             $query->where($clause);

--- a/src/ORM/Search/SearchContext.php
+++ b/src/ORM/Search/SearchContext.php
@@ -17,6 +17,7 @@ use SilverStripe\Forms\SelectField;
 use SilverStripe\Forms\CheckboxField;
 use InvalidArgumentException;
 use Exception;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\DataQuery;
 
 /**
@@ -110,8 +111,6 @@ class SearchContext
     public function getSearchFields()
     {
         return ($this->fields) ? $this->fields : singleton($this->modelClass)->scaffoldSearchFields();
-        // $this->fields is causing weirdness, so we ignore for now, using the default scaffolding
-        //return singleton($this->modelClass)->scaffoldSearchFields();
     }
 
     /**
@@ -151,8 +150,38 @@ class SearchContext
         if ($this->connective != "AND") {
             throw new Exception("SearchContext connective '$this->connective' not supported after ORM-rewrite.");
         }
+        $this->setSearchParams($searchParams);
+        $query = $this->prepareQuery($sort, $limit, $existingQuery);
+        return $this->search($query);
+    }
 
-        /** DataList $query */
+    /**
+     * Perform a search on the passed DataList based on $this->searchParams.
+     */
+    private function search(DataList $query): DataList
+    {
+        /** @var DataObject $modelObj */
+        $modelObj = Injector::inst()->create($this->modelClass);
+        $searchableFields = $modelObj->searchableFields();
+        foreach ($this->searchParams as $searchField => $searchPhrase) {
+            $searchField = str_replace('__', '.', $searchField ?? '');
+            if ($searchField !== '' && $searchField === $modelObj->getGeneralSearchFieldName()) {
+                $query = $this->generalFieldSearch($query, $searchableFields, $searchPhrase);
+            } else {
+                $query = $this->individualFieldSearch($query, $searchableFields, $searchField, $searchPhrase);
+            }
+        }
+        return $query;
+    }
+
+    /**
+     * Prepare the query to begin searching
+     *
+     * @param array|bool|string $sort Database column to sort on.
+     * @param array|bool|string $limit
+     */
+    private function prepareQuery($sort, $limit, ?DataList $existingQuery): DataList
+    {
         $query = null;
         if ($existingQuery) {
             if (!($existingQuery instanceof DataList)) {
@@ -176,38 +205,90 @@ class SearchContext
             $query = $query->limit($limit);
         }
 
-        /** @var DataList $query */
-        $query = $query->sort($sort);
-        $this->setSearchParams($searchParams);
+        return $query->sort($sort);
+    }
 
-        $modelObj = Injector::inst()->create($this->modelClass);
-        $searchableFields = $modelObj->searchableFields();
-        foreach ($this->searchParams as $key => $value) {
-            $key = str_replace('__', '.', $key ?? '');
-            if ($filter = $this->getFilter($key)) {
-                $filter->setModel($this->modelClass);
-                $filter->setValue($value);
-                if (!$filter->isEmpty()) {
-                    if (isset($searchableFields[$key]['match_any'])) {
-                        $searchFields = $searchableFields[$key]['match_any'];
-                        $filterClass = get_class($filter);
-                        $modifiers = $filter->getModifiers();
-                        $query = $query->alterDataQuery(function (DataQuery $dataQuery) use ($searchFields, $filterClass, $modifiers, $value) {
-                            $subGroup = $dataQuery->disjunctiveGroup();
-                            foreach ($searchFields as $matchField) {
-                                /** @var SearchFilter $filterClass */
-                                $filter = new $filterClass($matchField, $value, $modifiers);
-                                $filter->apply($subGroup);
-                            }
-                        });
-                    } else {
-                        $query = $query->alterDataQuery([$filter, 'apply']);
-                    }
+    /**
+     * Use the global general search for searching across multiple fields.
+     * Results in a where clause that looks like "WHERE (field1 LIKE %lorem ipsum% OR field2 LIKE %lorem ipsum%)"
+     *
+     * @param string|array $searchPhrase
+     */
+    private function generalFieldSearch(DataList $query, array $searchableFields, $searchPhrase): DataList
+    {
+        return $query->alterDataQuery(function (DataQuery $dataQuery) use ($searchableFields, $searchPhrase) {
+            $formFields = $this->getSearchFields();
+            $subGroup = $dataQuery->disjunctiveGroup();
+            foreach ($searchableFields as $field => $spec) {
+                $formFieldName = str_replace('.', '__', $field);
+                $filter = $this->getGeneralSearchFilter($this->modelClass, $field);
+                // Only apply filter if the field is allowed to be general and is backed by a form field.
+                // Otherwise we could be dealing with, for example, a DataObject which implements scaffoldSearchField
+                // to provide some unexpected field name, where the below would result in a DatabaseException.
+                if ((!isset($spec['general']) || $spec['general'])
+                    && ($formFields->fieldByName($formFieldName) || $formFields->dataFieldByName($formFieldName))
+                    && $filter !== null
+                ) {
+                    $filter->setModel($this->modelClass);
+                    $filter->setValue($searchPhrase);
+                    $this->applyFilter($filter, $subGroup, $spec);
                 }
             }
-        }
+        });
+    }
 
-        return $query;
+    /**
+     * Get the search filter for the given fieldname when searched from the general search field.
+     */
+    private function getGeneralSearchFilter(string $modelClass, string $fieldName): ?SearchFilter
+    {
+        if ($filterClass = Config::inst()->get($modelClass, 'general_search_field_filter')) {
+            return Injector::inst()->create($filterClass, $fieldName);
+        }
+        return $this->getFilter($fieldName);
+    }
+
+    /**
+     * Search against a single field
+     *
+     * @param string|array $searchPhrase
+     */
+    private function individualFieldSearch(DataList $query, array $searchableFields, string $searchField, $searchPhrase): DataList
+    {
+        $filter = $this->getFilter($searchField);
+        if (!$filter) {
+            return $query;
+        }
+        $filter->setModel($this->modelClass);
+        $filter->setValue($searchPhrase);
+        $searchableFieldSpec = $searchableFields[$searchField] ?? [];
+        return $query->alterDataQuery(function ($dataQuery) use ($filter, $searchableFieldSpec) {
+            $this->applyFilter($filter, $dataQuery, $searchableFieldSpec);
+        });
+    }
+
+    /**
+     * Apply a SearchFilter to a DataQuery for a given field's specifications
+     */
+    private function applyFilter(SearchFilter $filter, DataQuery $dataQuery, array $searchableFieldSpec): void
+    {
+        if ($filter->isEmpty()) {
+            return;
+        }
+        if (isset($searchableFieldSpec['match_any'])) {
+            $searchFields = $searchableFieldSpec['match_any'];
+            $filterClass = get_class($filter);
+            $value = $filter->getValue();
+            $modifiers = $filter->getModifiers();
+            $subGroup = $dataQuery->disjunctiveGroup();
+            foreach ($searchFields as $matchField) {
+                /** @var SearchFilter $filter */
+                $filter = Injector::inst()->create($filterClass, $matchField, $value, $modifiers);
+                $filter->apply($subGroup);
+            }
+        } else {
+            $filter->apply($dataQuery);
+        }
     }
 
     /**

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -14,8 +14,8 @@ use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\CheerleaderHat;
 use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\Mom;
 use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\Team;
 use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\TeamGroup;
-use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\TestController;
 use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\DataObject;
 
 class GridFieldFilterHeaderTest extends SapphireTest
 {
@@ -89,9 +89,12 @@ class GridFieldFilterHeaderTest extends SapphireTest
     public function testSearchFieldSchema()
     {
         $searchSchema = json_decode($this->component->getSearchFieldSchema($this->gridField) ?? '');
+        $modelClass = $this->gridField->getModelClass();
+        /** @var DataObject $obj */
+        $obj = new $modelClass();
 
         $this->assertEquals('field/testfield/schema/SearchForm', $searchSchema->formSchemaUrl);
-        $this->assertEquals('Name', $searchSchema->name);
+        $this->assertEquals($obj->getGeneralSearchFieldName(), $searchSchema->name);
         $this->assertEquals('Search "Teams"', $searchSchema->placeholder);
         $this->assertEquals(new \stdClass, $searchSchema->filters);
 
@@ -110,9 +113,12 @@ class GridFieldFilterHeaderTest extends SapphireTest
         );
         $this->gridField->setRequest($request);
         $searchSchema = json_decode($this->component->getSearchFieldSchema($this->gridField) ?? '');
+        $modelClass = $this->gridField->getModelClass();
+        /** @var DataObject $obj */
+        $obj = new $modelClass();
 
         $this->assertEquals('field/testfield/schema/SearchForm', $searchSchema->formSchemaUrl);
-        $this->assertEquals('Name', $searchSchema->name);
+        $this->assertEquals($obj->getGeneralSearchFieldName(), $searchSchema->name);
         $this->assertEquals('Search "Teams"', $searchSchema->placeholder);
         $this->assertEquals('test', $searchSchema->filters->Search__Name);
         $this->assertEquals('place', $searchSchema->filters->Search__City);
@@ -145,9 +151,10 @@ class GridFieldFilterHeaderTest extends SapphireTest
         $searchForm = $this->component->getSearchForm($this->gridField);
 
         $this->assertTrue($searchForm instanceof Form);
-        $this->assertEquals('Search__Name', $searchForm->fields[0]->Name);
-        $this->assertEquals('Search__City', $searchForm->fields[1]->Name);
-        $this->assertEquals('Search__Cheerleader__Hat__Colour', $searchForm->fields[2]->Name);
+        $this->assertEquals('Search__q', $searchForm->fields[0]->Name);
+        $this->assertEquals('Search__Name', $searchForm->fields[1]->Name);
+        $this->assertEquals('Search__City', $searchForm->fields[2]->Name);
+        $this->assertEquals('Search__Cheerleader__Hat__Colour', $searchForm->fields[3]->Name);
         $this->assertEquals('TeamsSearchForm', $searchForm->Name);
         $this->assertEquals('cms-search-form', $searchForm->extraClasses['cms-search-form']);
 

--- a/tests/php/ORM/Search/SearchContextTest.yml
+++ b/tests/php/ORM/Search/SearchContextTest.yml
@@ -74,6 +74,7 @@ SilverStripe\ORM\Tests\Search\SearchContextTest\AllFilterTypes:
 SilverStripe\ORM\Tests\Search\SearchContextTest\Customer:
   customer1:
     FirstName: Bill
+    MatchAny: Some arbitrary Value
   customer2:
     FirstName: Bailey
   customer3:
@@ -100,3 +101,34 @@ SilverStripe\ORM\Tests\Search\SearchContextTest\Order:
     Name: 'Jack'
     Customer: =>SilverStripe\ORM\Tests\Search\SearchContextTest\Customer.customer3
     ShippingAddress: =>SilverStripe\ORM\Tests\Search\SearchContextTest\Address.address3
+
+SilverStripe\ORM\Tests\Search\SearchContextTest\GeneralSearch:
+  general0:
+    Name: General Zero
+    DoNotUseThisField: omitted
+    HairColor: blue
+    ExcludeThisField: excluded
+    ExactMatchField: Some specific value here
+    PartialMatchField: A partial match is allowed for this field
+    MatchAny1: Some match any field
+    MatchAny2: Another match any field
+    Customer: =>SilverStripe\ORM\Tests\Search\SearchContextTest\Customer.customer2
+  general1:
+    Name: General One
+    DoNotUseThisField: omitted
+    HairColor: brown
+    ExcludeThisField: excluded
+    ExactMatchField: This requires an exact match
+    PartialMatchField: This explicitly allows partial matches
+    MatchAny1: first match
+    MatchAny2: second match
+    Customer: =>SilverStripe\ORM\Tests\Search\SearchContextTest\Customer.customer1
+  general2:
+    Name: MatchNothing
+    DoNotUseThisField: MatchNothing
+    HairColor: MatchNothing
+    ExcludeThisField: MatchNothing
+    ExactMatchField: MatchNothing
+    PartialMatchField: MatchNothing
+    MatchAny1: MatchNothing
+    MatchAny2: MatchNothing

--- a/tests/php/ORM/Search/SearchContextTest/Customer.php
+++ b/tests/php/ORM/Search/SearchContextTest/Customer.php
@@ -10,6 +10,7 @@ class Customer extends DataObject implements TestOnly
     private static $table_name = 'SearchContextTest_Customer';
 
     private static $db = [
-        'FirstName' => 'Text'
+        'FirstName' => 'Text',
+        'MatchAny' => 'Varchar',
     ];
 }

--- a/tests/php/ORM/Search/SearchContextTest/GeneralSearch.php
+++ b/tests/php/ORM/Search/SearchContextTest/GeneralSearch.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Search\SearchContextTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\DataObject;
+
+class GeneralSearch extends DataObject implements TestOnly
+{
+    private static $table_name = 'SearchContextTest_GeneralSearch';
+
+    private static $db = [
+        'Name' => 'Varchar',
+        'DoNotUseThisField' => 'Varchar',
+        'HairColor' => 'Varchar',
+        'ExcludeThisField' => 'Varchar',
+        'ExactMatchField' => 'Varchar',
+        'PartialMatchField' => 'Varchar',
+        'MatchAny1' => 'Varchar',
+        'MatchAny2' => 'Varchar',
+    ];
+
+    private static $has_one = [
+        'Customer' => Customer::class,
+        'ShippingAddress' => Address::class,
+    ];
+
+    private static $searchable_fields = [
+        'Name',
+        'HairColor',
+        'ExcludeThisField' => [
+            'general' => false,
+        ],
+        'ExactMatchField' => [
+            'filter' => 'ExactMatchFilter',
+        ],
+        'PartialMatchField' => [
+            'filter' => 'PartialMatchFilter',
+        ],
+        'MatchAny' => [
+            'field' => TextField::class,
+            'match_any' => [
+                'MatchAny1',
+                'MatchAny2',
+                'Customer.MatchAny',
+            ]
+        ]
+    ];
+}

--- a/tests/php/ORM/Search/SearchContextTest/NoSearchableFields.php
+++ b/tests/php/ORM/Search/SearchContextTest/NoSearchableFields.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Search\SearchContextTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class NoSearchableFields extends DataObject implements TestOnly
+{
+    private static $table_name = 'SearchContextTest_NoSearchableFields';
+
+    private static $db = [
+        'Name' => 'Varchar',
+        'Email' => 'Varchar',
+        'HairColor' => 'Varchar',
+        'EyeColor' => 'Varchar'
+    ];
+
+    private static $has_one = [
+        'Customer' => Customer::class,
+    ];
+
+    private static $summary_fields = [
+        'Name' => 'Custom Label',
+        'Customer.FirstName' => 'Customer',
+        'HairColor',
+        'EyeColor',
+    ];
+}


### PR DESCRIPTION
Changes the default field for gridfield filters from being the first `$searchable_field` to searching instead across _all_ `$searchable_fields` by default.

Includes a way to fall back to the old way (use the first field), which may be useful for projects that already have their own custom implementation of this feature or which implement some other specific behaviour instead.

An alternative approach, similar to what Max did in #9836, would be to split the search query up into whitespace-delimited terms and pass those as the value for the filters - this would then result in using `applyMany` instead of `applyOne` in the filter. I'd be open to implementing that either as a thing to _always_ do or a configuration option if someone thinks it would be a significant enough improvement over this approach - but bear in mind it comes at the cost of a more complex query. It would be easy enough to implement that after the fact however so I've opted for the simpler approach for now.

Also refactored `SearchContext` somewhat to be easier to override specific parts of the process - e.g. override `prepareQuery()` to change the query before the searching starts, or override `search()` to override the search behaviour (such as to use solr/algolia/etc instead of DB queries), or override `individualFieldSearch()` to change the way individual fields get searched against.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/9356