### PR TITLE
FIX Unexpected message issue

### DIFF
--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -362,7 +362,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
         }
 
         foreach ($searchFields->getIterator() as $field) {
-            $field->addExtraClass('stacked');
+            $field->addExtraClass('stacked no-change-track');
         }
 
         $name = $gridField->Title ?: singleton($gridField->getModelClass())->i18n_plural_name();

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -139,4 +139,21 @@ class GridFieldFilterHeaderTest extends SapphireTest
             'GridFieldFilterHeader::handleAction resets the gridstate filter when the user resets the search.'
         );
     }
+
+    public function testGetSearchForm()
+    {
+        $searchForm = $this->component->getSearchForm($this->gridField);
+
+        $this->assertTrue($searchForm instanceof Form);
+        $this->assertEquals('Search__Name', $searchForm->fields[0]->Name);
+        $this->assertEquals('Search__City', $searchForm->fields[1]->Name);
+        $this->assertEquals('Search__Cheerleader__Hat__Colour', $searchForm->fields[2]->Name);
+        $this->assertEquals('TeamsSearchForm', $searchForm->Name);
+        $this->assertEquals('cms-search-form', $searchForm->extraClasses['cms-search-form']);
+
+        foreach ($searchForm->fields as $field) {
+            $this->assertEquals('stacked', $field->extraClasses['stacked']);
+            $this->assertEquals('no-change-track', $field->extraClasses['no-change-track']);
+        }
+    }
 }


### PR DESCRIPTION
### Description
Additional class name '.no-change-track' was appended to search field in GridFieldFilterHeader to avoid check any changes that user does in search field.

### Parent issue
 - [x] https://github.com/silverstripe/silverstripe-admin/issues/1313
