### PR TITLE
FIX: Add missing casting for Form::getAttributesHTML (fixes #10386)

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -232,7 +232,8 @@ class Form extends ViewableData implements HasRequestHandler
      * @var array
      */
     private static $casting = [
-        'AttributesHTML' => 'HTMLFragment',
+        'AttributesHTML' => 'HTMLFragment', // property $AttributesHTML version
+        'getAttributesHTML' => 'HTMLFragment', // method $getAttributesHTML($arg) version
         'FormAttributes' => 'HTMLFragment',
         'FormName' => 'Text',
         'Legend' => 'HTMLFragment',


### PR DESCRIPTION
Fixes #10386

Comments are copied from `FormField::$casting`, I think they’re necessary in case someone in future spots this and thinks the two values are duplicates