### PR TITLE
MINOR: specify export fields on Model itself

### DIFF
--- a/src/Forms/GridField/GridFieldExportButton.php
+++ b/src/Forms/GridField/GridFieldExportButton.php
@@ -144,6 +144,10 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
      */
     protected function getExportColumnsForGridField(GridField $gridField)
     {
+        $singleton = DataObject::singleton($gridField->getModelClass());
+        if($singleton->hasMethod('getModelAdminExportFields')) {
+            return $singleton->getModelAdminExportFields();
+        }
         if ($this->exportColumns) {
             return $this->exportColumns;
         }
@@ -154,7 +158,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
             return $dataCols->getDisplayFields($gridField);
         }
 
-        return DataObject::singleton($gridField->getModelClass())->summaryFields();
+        return $singleton->summaryFields();
     }
 
     /**


### PR DESCRIPTION
I would like to propose this change as it allows you to set export fields directtly on the model rather than relying on `summary_fields` or `the gridfield display fields`. I have never liked the way these two purposes were linked and this allows us to separate them. 

In other words, you may want to export more / different fields than just the ones displayed in the summary list in the gridfield. 

If you like it then I can also add the documentation to go with it. 
