### PR TITLE
ENH Make DataObject::exists() an alias of DataObject::isInDB()

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -847,7 +847,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      */
     public function exists()
     {
-        return (isset($this->record['ID']) && $this->record['ID'] > 0);
+        return $this->isInDB();
     }
 
     /**


### PR DESCRIPTION
For most `DataObject`s, `exists()` is the same as `isInDB()`, so it doesn't make sense to implement them separately/differently.
Note that the `isset()` check in `exists()` is unnecessary, since the `'ID'` key is always added to the `record` on instantiation (either as the actual ID of the record, or defaulted to 0).

Keeping both methods is sensible, as they are semantically different. `isInDB()` is explicitly checking only if the record is stored in the database, while `exists()` has a broader meaning and is overridden in some cases, such as `File::exists()` which checks both `parent::exists()` (i.e. `isInDB()`) _and_ if the actual file exists in the filesystem. So we can't remove `exists()`, but a lot of the time developers want to explicitly only test if a record is in the database (e.g. `onBeforeWrite()` hooks which should only affect the first write of a record)

## Parent issue:
- closes https://github.com/silverstripe/silverstripe-framework/issues/9352