### PR TITLE
BACKPORT - Handle MySQL exception

### DIFF
--- a/src/ORM/Connect/MySQLiConnector.php
+++ b/src/ORM/Connect/MySQLiConnector.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\ORM\Connect;
 
 use mysqli;
+use mysqli_sql_exception;
 use mysqli_stmt;
 use SilverStripe\Core\Config\Config;
 
@@ -63,7 +64,12 @@ class MySQLiConnector extends DBConnector
         // Record last statement for error reporting
         $statement = $this->dbConn->stmt_init();
         $this->setLastStatement($statement);
-        $success = $statement->prepare($sql);
+        try {
+            $success = $statement->prepare($sql);
+        } catch (mysqli_sql_exception $e) {
+            $success = false;
+            $this->databaseError($e->getMessage(), E_USER_ERROR, $sql);
+        }
         return $statement;
     }
 


### PR DESCRIPTION
Backport of
https://github.com/silverstripe/silverstripe-framework/commit/511b3bb060cb2962e79e6a034eea818b6c890ba4#diff-9b2f2c197e0cd13a273016f609eebbf671ae5db75396ae73cba64635dd7b75baR67
and
https://github.com/silverstripe/silverstripe-framework/commit/337c6e583cced016582e6367b9db8b44e9dd0b5e

To convert mysql exceptions to DatabaseError in php 8.1 - https://php.watch/versions/8.1/mysqli-error-mode

Even though 4.10 isn't php 8.1 compatible, in practice we run github actions CI 4.10 branches against 8.1 a lot due to a lack of minor branch to installer-version / php version detection e.g. https://github.com/silverstripe/cwp/runs/7351123074?check_suite_focus=true