### PR TITLE
FIX Check if blank method passed

### DIFF
--- a/src/Core/CustomMethods.php
+++ b/src/Core/CustomMethods.php
@@ -156,6 +156,9 @@ trait CustomMethods
      */
     protected function getExtraMethodConfig($method)
     {
+        if (empty($method)) {
+            return null;
+        }
         // Lazy define methods
         if (!isset(self::$extra_methods[static::class])) {
             $this->defineMethods();


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-cms/issues/2750

Checking for emtpy($method) protects against null being passed in for $method and later on triggering a deprecation warning in PHP 8.1 on strtolower($method);

Note: docblock params and return types are wrong because null is being passed in at least one instance (so not limited to string) and this function already returns null, so array return type is also incorrect.  There's a much wider issue with the docblock params and return type accuracy so not going to fix here.
