### PR TITLE
MNT Skip test if Page class missing

### DIFF
--- a/tests/php/Dev/Validation/RelationValidationTest.php
+++ b/tests/php/Dev/Validation/RelationValidationTest.php
@@ -51,6 +51,9 @@ class RelationValidationTest extends SapphireTest
      */
     public function testIgnoredClass(string $class, ?string $relation, array $config, bool $expected): void
     {
+        if (!class_exists($class)) {
+            $this->markTestSkipped("This test requires the $class class");
+        }
         $service = RelationValidationService::singleton();
 
         foreach ($config as $name => $value) {


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Fix https://github.com/silverstripe/recipe-core/runs/7490756091?check_suite_focus=true#step:12:129
` 1) SilverStripe\Dev\Tests\Validation\RelationValidationTest::testIgnoredClass with data set "page should by included by default (empty namespace)" ('Page', null, array(), false)
ReflectionException: Class "Page" does not exist`

Page is defined in silverstripe/recipe-cms which is included by silverstripe/installer, which most modules will use.  recipe-core however will not include silverstripe/recipe-cms, hence the Page class is missing

This unit-test will be run in multiple other builds, so it's OK to skip for silverstripe/recipe-core