### PR TITLE
MNT Update Utf8TestHelper for MySQL 8.0.30

### DIFF
--- a/tests/php/ORM/Utf8/Utf8TestHelper.php
+++ b/tests/php/ORM/Utf8/Utf8TestHelper.php
@@ -23,10 +23,12 @@ class Utf8TestHelper implements TestOnly
     public function getUpdatedUtfCollationForCurrentDB(string $collation): string
     {
         if ($collation === 'utf8_general_ci') {
-            return $this->isMariaDBGte106() ? 'utf8mb3_general_ci' : 'utf8_general_ci';
+            return $this->isMariaDBGte106() || $this->isMySqlGte8030()
+                ? 'utf8mb3_general_ci' : 'utf8_general_ci';
         }
         if ($collation === 'utf8_unicode_520_ci') {
-            return $this->isMariaDBGte106() ? 'utf8mb3_unicode_520_ci' : 'utf8_unicode_520_ci';
+            return $this->isMariaDBGte106() || $this->isMySqlGte8030()
+                ? 'utf8mb3_unicode_520_ci' : 'utf8_unicode_520_ci';
         }
         return $collation;
     }
@@ -44,6 +46,28 @@ class Utf8TestHelper implements TestOnly
         }
         return false;
     }
+
+    /**
+     * Starting with 8.0.30, utf8mb3 is reported for the collation as well
+     * https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-30.html
+     */
+    private function isMySqlGte8030(): bool
+    {
+        // Example MySQL version: 8.0.29
+        if (preg_match('#^([0-9]+)\.([0-9]+)\.([0-9]+)$#', $this->getDBVersion(), $m)) {
+            if ((int) $m[1] >= 8) {
+                if ((int) $m[2] === 0) {
+                    if ((int) $m[3] >= 30) {
+                        return true;
+                    }
+                } else {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
 
     /**
      * Until MariaDB 10.5, utf8mb3 was an alias for utf8.


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Fix https://github.com/silverstripe/silverstripe-installer/runs/7551400211?check_suite_focus=true#step:12:113
```
--- Expected
+++ Actual
@@ @@
-'utf8_general_ci'
+'utf8mb3_general_ci'
```

MySQL 8.0.30 changed the reported collations to mb3 - https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-30.html#mysqld-8-0-30-charset
