### PR TITLE
FIX: Invalid argument warning in backtrace

### DIFF
--- a/src/Dev/Backtrace.php
+++ b/src/Dev/Backtrace.php
@@ -122,7 +122,7 @@ class Backtrace
                 }
             }
             if ($match) {
-                foreach ($bt[$i]['args'] as $j => $arg) {
+                foreach ($bt[$i]['args'] ?? [] as $j => $arg) {
                     $bt[$i]['args'][$j] = '<filtered>';
                 }
             }


### PR DESCRIPTION
We log errors in [Sentry](https://sentry.io/), and for some reason whenever there’s a database connection error a second error is logged:

> E_WARNING: Invalid argument supplied for foreach() {"code":2,"message":"Invalid argument supplied for foreach()","file":"./vendor/silverstripe/framework/src/Dev/Backtrace.php","line":125} []

I’m not sure why the argument list is empty, but it clearly isn’t safe to assume arguments are always present in the backtrace 😄 