### PR TITLE
MNT Fix broken unit test

### DIFF
--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -168,7 +168,9 @@ class GridFieldFilterHeaderTest extends SapphireTest
     public function testCustomSearchField()
     {
         $searchSchema = json_decode($this->component->getSearchFieldSchema($this->gridField));
-        $this->assertEquals('Name', $searchSchema->name);
+        $modelClass = $this->gridField->getModelClass();
+        $obj = new $modelClass();
+        $this->assertEquals($obj->getGeneralSearchFieldName(), $searchSchema->name);
 
         Config::modify()->set(Team::class, 'general_search_field', 'CustomSearch');
         $searchSchema = json_decode($this->component->getSearchFieldSchema($this->gridField));


### PR DESCRIPTION
This test was introduced around the same time the general search field functionality was introduced, so the PR probably didn't include that functionality yet.

Fixes https://github.com/silverstripe/silverstripe-framework/runs/7643915707?check_suite_focus=true
> SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest::testCustomSearchField
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Name'
+'q'