### PR TITLE
ENH Set the default resources dir to "_resources"

### DIFF
--- a/src/Core/Manifest/ManifestFileFinder.php
+++ b/src/Core/Manifest/ManifestFileFinder.php
@@ -25,11 +25,6 @@ class ManifestFileFinder extends FileFinder
     const TESTS_DIR = 'tests';
     const VENDOR_DIR = 'vendor';
 
-    /**
-     * @deprecated 4.4.0:5.0.0 Use global `RESOURCES_DIR` instead.
-     */
-    const RESOURCES_DIR = RESOURCES_DIR;
-
     protected static $default_options = [
         'include_themes' => false,
         'ignore_tests' => true,

--- a/src/includes/constants.php
+++ b/src/includes/constants.php
@@ -219,7 +219,7 @@ if (!defined('TEMP_FOLDER')) {
 // Define the resource dir constant that will be use to exposed vendor assets
 if (!defined('RESOURCES_DIR')) {
     $project = new SilverStripe\Core\Manifest\Module(BASE_PATH, BASE_PATH);
-    $resourcesDir = $project->getResourcesDir() ?: 'resources';
+    $resourcesDir = $project->getResourcesDir() ?: '_resources';
     if (preg_match('/^[_\-a-z0-9]+$/i', $resourcesDir ?? '')) {
         define('RESOURCES_DIR', $resourcesDir);
     } else {


### PR DESCRIPTION
**DO NOT SQUASH** - the two commits have distinct changelog implications.

## BC breaking changes
- Removed deprecated `ManifestFileFinder::RESOURCES_DIR`
- Changed default for `RESOURCES_DIR` const to "_resources"

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10399