### PR TITLE
FIX Ensure PHP 8.1 compatible version of oscarotero/html-parser is installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
         "squizlabs/php_codesniffer": "^3.7"
     },
     "conflict": {
-        "egulias/email-validator": "^2"
+        "egulias/email-validator": "^2",
+        "oscarotero/html-parser": "<0.1.5"
     },
     "provide": {
         "psr/container-implementation": "1.0.0"


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10349

Fix https://github.com/silverstripe/silverstripe-framework/runs/7756886656?check_suite_focus=true#step:12:116
`Function libxml_disable_entity_loader() is deprecated`

PHP 8.1 support was added in 0.1.5 https://github.com/oscarotero/html-parser/blob/v0.1.5/CHANGELOG.md