### PR TITLE
API Deprecate PHPUnit 5.7 compatability hacks

### DIFF
--- a/src/Core/BaseKernel.php
+++ b/src/Core/BaseKernel.php
@@ -378,9 +378,11 @@ abstract class BaseKernel implements Kernel
      * The purpose of this method is to avoid loading PHPUnit test files with incompatible definitions.
      *
      * @return string[] List of CI types to ignore as defined by `Module`.
+     * @deprecated 5.0.0
      */
     protected function getIgnoredCIConfigs(): array
     {
+        Deprecation::notice('5.0.0', 'This method will be removed in CMS 5');
         return [];
     }
 

--- a/src/Core/Manifest/ClassLoader.php
+++ b/src/Core/Manifest/ClassLoader.php
@@ -124,6 +124,10 @@ class ClassLoader
      */
     public function init($includeTests = false, $forceRegen = false, array $ignoredCIConfigs = [])
     {
+        if (!empty($ignoredCIConfigs)) {
+            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
+        }
+
         foreach ($this->manifests as $manifest) {
             /** @var ClassManifest $instance */
             $instance = $manifest['instance'];

--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -11,6 +11,7 @@ use PhpParser\ParserFactory;
 use PhpParser\ErrorHandler\ErrorHandler;
 use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Cache\CacheFactory;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\TestOnly;
 
 /**
@@ -280,6 +281,10 @@ class ClassManifest
      */
     public function init($includeTests = false, $forceRegen = false, array $ignoredCIConfigs = [])
     {
+        if (!empty($ignoredCIConfigs)) {
+            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
+        }
+
         $this->cache = $this->buildCache($includeTests);
 
         // Check if cache is safe to use
@@ -543,6 +548,10 @@ class ClassManifest
      */
     public function regenerate($includeTests, array $ignoredCIConfigs = [])
     {
+        if (!empty($ignoredCIConfigs)) {
+            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
+        }
+
         // Reset the manifest so stale info doesn't cause errors.
         $this->loadState([]);
         $this->roots = [];

--- a/src/Core/Manifest/Module.php
+++ b/src/Core/Manifest/Module.php
@@ -331,9 +331,11 @@ class Module implements Serializable
      * that is observed is `PHP`
      * @return array List of configuration aspects e.g.: `['PHP' => 'CI_PHPUNIT_NINE']`
      * @internal
+     * @deprecated 5.0.0
      */
     public function getCIConfig(): array
     {
+        Deprecation::notice('5.0.0', 'This method will be removed in CMS 5');
         return [
             'PHP' => $this->getPhpCiConfig()
         ];

--- a/src/Core/Manifest/ModuleLoader.php
+++ b/src/Core/Manifest/ModuleLoader.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\Core\Manifest;
 
+use SilverStripe\Dev\Deprecation;
+
 /**
  * Module manifest holder
  */
@@ -95,6 +97,10 @@ class ModuleLoader
      */
     public function init($includeTests = false, $forceRegen = false, array $ignoredCIConfigs = [])
     {
+        if (!empty($ignoredCIConfigs)) {
+            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
+        }
+
         foreach ($this->manifests as $manifest) {
             $manifest->init($includeTests, $forceRegen, $ignoredCIConfigs);
         }

--- a/src/Core/Manifest/ModuleManifest.php
+++ b/src/Core/Manifest/ModuleManifest.php
@@ -7,6 +7,7 @@ use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Cache\CacheFactory;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * A utility class which builds a manifest of configuration items
@@ -125,6 +126,10 @@ class ModuleManifest
      */
     public function init($includeTests = false, $forceRegen = false, array $ignoredCIConfigs = [])
     {
+        if (!empty($ignoredCIConfigs)) {
+            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
+        }
+
         // build cache from factory
         if ($this->cacheFactory) {
             $this->cache = $this->cacheFactory->create(
@@ -167,6 +172,10 @@ class ModuleManifest
      */
     public function regenerate($includeTests = false, array $ignoredCIConfigs = [])
     {
+        if (!empty($ignoredCIConfigs)) {
+            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
+        }
+
         $this->modules = [];
 
         $finder = new ManifestFileFinder();

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -6,6 +6,7 @@ use PHPUnit_Framework_Constraint;
 use PHPUnit_Framework_ExpectationFailedException;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\SSListExporter;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\SS_List;
@@ -190,6 +191,8 @@ class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
 
     public function __construct($matches)
     {
+        Deprecation::notice('5.0.0', 'This class will be removed in CMS 5', Deprecation::SCOPE_CLASS);
+
         $this->exporter = new SSListExporter();
 
         $this->matches = $matches;

--- a/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
+++ b/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
@@ -6,6 +6,7 @@ use PHPUnit_Framework_Constraint;
 use PHPUnit_Framework_ExpectationFailedException;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\SSListExporter;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\SS_List;
@@ -135,6 +136,7 @@ class SSListContainsOnlyMatchingItems extends PHPUnit_Framework_Constraint imple
 
     public function __construct($match)
     {
+        Deprecation::notice('5.0.0', 'This class will be removed in CMS 5', Deprecation::SCOPE_CLASS);
         $this->exporter = new SSListExporter();
 
         $this->constraint = new ViewableDataContains($match);

--- a/src/Dev/Constraint/ViewableDataContains.php
+++ b/src/Dev/Constraint/ViewableDataContains.php
@@ -7,6 +7,7 @@ use PHPUnit_Framework_ExpectationFailedException;
 use PHPUnit_Util_InvalidArgumentHelper;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\View\ViewableData;
 use SilverStripe\Dev\SapphireTest;
@@ -141,6 +142,7 @@ class ViewableDataContains extends PHPUnit_Framework_Constraint implements TestO
      */
     public function __construct($match)
     {
+        Deprecation::notice('5.0.0', 'This class will be removed in CMS 5', Deprecation::SCOPE_CLASS);
         parent::__construct();
         if (!is_array($match)) {
             throw PHPUnit_Util_InvalidArgumentHelper::factory(

--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -546,6 +546,8 @@ class FunctionalTest extends SapphireTest implements TestOnly
 
     protected function setUp()
     {
+        Deprecation::notice('5.0.0', 'This class will be removed in CMS 5', Deprecation::SCOPE_CLASS);
+
         parent::setUp();
 
         // Skip calling FunctionalTest directly.

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -1619,6 +1619,8 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      */
     protected function setUp()
     {
+        Deprecation::notice('5.0.0', 'This class will be removed in CMS 5', Deprecation::SCOPE_CLASS);
+
         if (!defined('FRAMEWORK_PATH')) {
             trigger_error(
                 'Missing constants, did you remember to include the test bootstrap in your phpunit.xml file?',

--- a/src/Dev/TestKernel.php
+++ b/src/Dev/TestKernel.php
@@ -53,12 +53,16 @@ class TestKernel extends CoreKernel
      */
     public function setIgnoredCIConfigs(array $ciConfigs): self
     {
+        Deprecation::notice('5.0.0', 'This method will be removed in CMS 5');
+
         $this->ciConfigs = $ciConfigs;
         return $this;
     }
 
     protected function getIgnoredCIConfigs(): array
     {
+        Deprecation::notice('5.0.0', 'This method will be removed in CMS 5');
+
         return $this->ciConfigs;
     }
 

--- a/src/View/ThemeManifest.php
+++ b/src/View/ThemeManifest.php
@@ -6,6 +6,7 @@ use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Cache\CacheFactory;
 use SilverStripe\Core\Manifest\ManifestFileFinder;
 use SilverStripe\Core\Manifest\ModuleLoader;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * A class which builds a manifest of all themes (which is really just a directory called "templates")
@@ -77,6 +78,10 @@ class ThemeManifest implements ThemeList
      */
     public function init($includeTests = false, $forceRegen = false, array $ignoredCIConfigs = [])
     {
+        if (!empty($ignoredCIConfigs)) {
+            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
+        }
+
         // build cache from factory
         if ($this->cacheFactory) {
             $this->cache = $this->cacheFactory->create(
@@ -134,6 +139,10 @@ class ThemeManifest implements ThemeList
      */
     public function regenerate($includeTests = false, array $ignoredCIConfigs = [])
     {
+        if (!empty($ignoredCIConfigs)) {
+            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
+        }
+
         $finder = new ManifestFileFinder();
         $finder->setOptions([
             'include_themes' => false,


### PR DESCRIPTION
Deprecates API which is removed in https://github.com/silverstripe/silverstripe-framework/pull/10444
Follows https://docs.silverstripe.org/en/4/contributing/release_process/#deprecation - though note that there is no new API replacing the removed API in this case.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10398