### PR TITLE
API Strongly type methods

### DIFF
--- a/src/Control/CLIRequestBuilder.php
+++ b/src/Control/CLIRequestBuilder.php
@@ -9,7 +9,7 @@ use SilverStripe\Core\Environment;
  */
 class CLIRequestBuilder extends HTTPRequestBuilder
 {
-    public static function cleanEnvironment(array $variables)
+    public static function cleanEnvironment(array $variables): array
     {
         // Create all blank vars
         foreach (['_REQUEST', '_GET', '_POST', '_SESSION', '_SERVER', '_COOKIE', '_ENV', '_FILES'] as $key) {
@@ -75,7 +75,7 @@ class CLIRequestBuilder extends HTTPRequestBuilder
      * @param string|null $url
      * @return HTTPRequest
      */
-    public static function createFromVariables(array $variables, $input, $url = null)
+    public static function createFromVariables(array $variables, string $input, $url = null): SilverStripe\Control\HTTPRequest
     {
         $request = parent::createFromVariables($variables, $input, $url);
         // unset scheme so that SS_BASE_URL can provide `is_https` information if required

--- a/src/Control/ContentNegotiator.php
+++ b/src/Control/ContentNegotiator.php
@@ -73,7 +73,7 @@ class ContentNegotiator
      * @param HTTPResponse $response
      * @return bool
      */
-    public static function enabled_for($response)
+    public static function enabled_for(SilverStripe\Control\HTTPResponse $response): bool
     {
         $contentType = $response->getHeader("Content-Type");
 
@@ -97,7 +97,7 @@ class ContentNegotiator
      *
      * @return bool
      */
-    public static function getEnabled()
+    public static function getEnabled(): bool
     {
         if (isset(static::$current_enabled)) {
             return static::$current_enabled;
@@ -110,7 +110,7 @@ class ContentNegotiator
      *
      * @param bool $enabled
      */
-    public static function setEnabled($enabled)
+    public static function setEnabled(bool $enabled): void
     {
         static::$current_enabled = $enabled;
     }
@@ -118,7 +118,7 @@ class ContentNegotiator
     /**
      * @param HTTPResponse $response
      */
-    public static function process(HTTPResponse $response)
+    public static function process(HTTPResponse $response): void
     {
         if (!self::enabled_for($response)) {
             return;
@@ -172,7 +172,7 @@ class ContentNegotiator
      *
      * @todo Search for more xhtml replacement
      */
-    public function xhtml(HTTPResponse $response)
+    public function xhtml(HTTPResponse $response): void
     {
         $content = $response->getBody();
         $encoding = Config::inst()->get('SilverStripe\\Control\\ContentNegotiator', 'encoding');
@@ -214,7 +214,7 @@ class ContentNegotiator
      *
      * @param HTTPResponse $response
      */
-    public function html(HTTPResponse $response)
+    public function html(HTTPResponse $response): void
     {
         $encoding = $this->config()->get('encoding');
         $contentType = $this->config()->get('content_type');

--- a/src/Control/Controller.php
+++ b/src/Control/Controller.php
@@ -100,7 +100,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @uses BasicAuth::requireLogin()
      */
-    protected function init()
+    protected function init(): void
     {
         // @todo This will be removed in 5.0 and will be controlled by middleware instead
         if ($this->basicAuthEnabled) {
@@ -117,7 +117,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * This should be called on all controllers before handling requests
      */
-    public function doInit()
+    public function doInit(): void
     {
         //extension hook
         $this->extend('onBeforeInit');
@@ -142,7 +142,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * Also set the URLParams
      */
-    public function setRequest($request)
+    public function setRequest(SilverStripe\Control\NullHTTPRequest $request): SilverStripe\CMS\Controllers\CMSMain
     {
         $return = parent::setRequest($request);
         $this->setURLParams($this->getRequest()->allParams());
@@ -157,7 +157,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @param HTTPRequest $request
      */
-    protected function beforeHandleRequest(HTTPRequest $request)
+    protected function beforeHandleRequest(HTTPRequest $request): void
     {
         //Set up the internal dependencies (request, response)
         $this->setRequest($request);
@@ -171,7 +171,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
     /**
      * Cleanup for the handleRequest method
      */
-    protected function afterHandleRequest()
+    protected function afterHandleRequest(): void
     {
         //Pop the current controller from the stack
         $this->popCurrent();
@@ -196,7 +196,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      * @param HTTPRequest $request
      * @return HTTPResponse
      */
-    public function handleRequest(HTTPRequest $request)
+    public function handleRequest(HTTPRequest $request): SilverStripe\Control\HTTPResponse
     {
         if (!$request) {
             throw new \RuntimeException('Controller::handleRequest() not passed a request!');
@@ -228,7 +228,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @param HTTPResponse|Object $response
      */
-    protected function prepareResponse($response)
+    protected function prepareResponse(string|SilverStripe\ORM\FieldType\DBHTMLText $response): void
     {
         if (!is_object($response)) {
             $this->getResponse()->setBody($response);
@@ -271,7 +271,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return DBHTMLText|HTTPResponse
      */
-    protected function handleAction($request, $action)
+    protected function handleAction(SilverStripe\Control\HTTPRequest $request, string $action): null|string|SilverStripe\Dev\DevBuildController
     {
         foreach ($request->latestParams() as $k => $v) {
             if ($v || !isset($this->urlParams[$k])) {
@@ -313,7 +313,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      * @param array $urlParams
      * @return $this
      */
-    public function setURLParams($urlParams)
+    public function setURLParams(array $urlParams): SilverStripe\CMS\Controllers\CMSMain
     {
         $this->urlParams = $urlParams;
         return $this;
@@ -324,7 +324,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return array
      */
-    public function getURLParams()
+    public function getURLParams(): array
     {
         return $this->urlParams;
     }
@@ -335,7 +335,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return HTTPResponse
      */
-    public function getResponse()
+    public function getResponse(): SilverStripe\Control\HTTPResponse
     {
         if (!$this->response) {
             $this->setResponse(new HTTPResponse());
@@ -350,7 +350,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return $this
      */
-    public function setResponse(HTTPResponse $response)
+    public function setResponse(HTTPResponse $response): SilverStripe\Dev\DevelopmentAdmin
     {
         $this->response = $response;
         return $this;
@@ -378,7 +378,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return string
      */
-    public function getAction()
+    public function getAction(): string
     {
         return $this->action;
     }
@@ -390,7 +390,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return SSViewer
      */
-    public function getViewer($action)
+    public function getViewer(string $action): SilverStripe\View\SSViewer
     {
         // Hard-coded templates
         if (isset($this->templates[$action]) && $this->templates[$action]) {
@@ -426,7 +426,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public function hasAction($action)
+    public function hasAction(string $action): bool
     {
         return parent::hasAction($action) || $this->hasActionTemplate($action);
     }
@@ -462,7 +462,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return string
      */
-    protected function definingClassForAction($action)
+    protected function definingClassForAction(string $action): string|null
     {
         $definingClass = parent::definingClassForAction($action);
         if ($definingClass) {
@@ -490,7 +490,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public function hasActionTemplate($action)
+    public function hasActionTemplate(string $action): bool
     {
         if (isset($this->templates[$action])) {
             return true;
@@ -514,7 +514,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return string
      */
-    public function render($params = null)
+    public function render($params = null): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $template = $this->getViewer($this->getAction());
 
@@ -550,7 +550,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return Controller
      */
-    public static function curr()
+    public static function curr(): SilverStripe\ErrorPage\ErrorPageController
     {
         if (Controller::$controller_stack) {
             return Controller::$controller_stack[0];
@@ -565,7 +565,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public static function has_curr()
+    public static function has_curr(): bool
     {
         return Controller::$controller_stack ? true : false;
     }
@@ -579,7 +579,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public function can($perm, $member = null)
+    public function can(array|string $perm, SilverStripe\Security\Member $member = null): bool
     {
         if (!$member) {
             $member = Security::getCurrentUser();
@@ -603,7 +603,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      * Note: Ensure this controller is assigned a request with a valid session before pushing
      * it to the stack.
      */
-    public function pushCurrent()
+    public function pushCurrent(): void
     {
         // Ensure this controller has a valid session
         $this->getRequest()->getSession();
@@ -613,7 +613,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
     /**
      * Pop this controller off the top of the stack.
      */
-    public function popCurrent()
+    public function popCurrent(): void
     {
         if ($this === self::$controller_stack[0]) {
             array_shift(self::$controller_stack);
@@ -633,7 +633,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      * @param int $code
      * @return HTTPResponse
      */
-    public function redirect($url, $code = 302)
+    public function redirect(string $url, int $code = 302): SilverStripe\Control\HTTPResponse
     {
         if ($this->getResponse()->getHeader('Location') && $this->getResponse()->getHeader('Location') != $url) {
             user_error("Already directed to " . $this->getResponse()->getHeader('Location')
@@ -651,7 +651,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      *
      * @return null|string
      */
-    public function redirectedTo()
+    public function redirectedTo(): bool
     {
         return $this->getResponse() && $this->getResponse()->getHeader('Location');
     }
@@ -666,7 +666,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      * @param string|array $arg One or more link segments, or list of link segments as an array
      * @return string
      */
-    public static function join_links($arg = null)
+    public static function join_links(string|array $arg = null): string
     {
         if (func_num_args() === 1 && is_array($arg)) {
             $args = $arg;
@@ -712,7 +712,7 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
     /**
      * @return array
      */
-    public static function get_template_global_variables()
+    public static function get_template_global_variables(): array
     {
         return [
             'CurrentPage' => 'curr',

--- a/src/Control/Cookie.php
+++ b/src/Control/Cookie.php
@@ -24,7 +24,7 @@ class Cookie
      *
      * @return Cookie_Backend
      */
-    public static function get_inst()
+    public static function get_inst(): SilverStripe\Control\CookieJar
     {
         return Injector::inst()->get('SilverStripe\\Control\\Cookie_Backend');
     }
@@ -45,14 +45,14 @@ class Cookie
      * See http://php.net/set_session
      */
     public static function set(
-        $name,
+        string $name,
         $value,
         $expiry = 90,
         $path = null,
         $domain = null,
         $secure = false,
         $httpOnly = true
-    ) {
+    ): null {
         return self::get_inst()->set($name, $value, $expiry, $path, $domain, $secure, $httpOnly);
     }
 
@@ -64,7 +64,7 @@ class Cookie
      *
      * @return null|string
      */
-    public static function get($name, $includeUnsent = true)
+    public static function get(string $name, bool $includeUnsent = true): null|string|int
     {
         return self::get_inst()->get($name, $includeUnsent);
     }
@@ -76,7 +76,7 @@ class Cookie
      *
      * @return array
      */
-    public static function get_all($includeUnsent = true)
+    public static function get_all(bool $includeUnsent = true): array
     {
         return self::get_inst()->getAll($includeUnsent);
     }
@@ -88,7 +88,7 @@ class Cookie
      * @param bool $secure
      * @param bool $httpOnly
      */
-    public static function force_expiry($name, $path = null, $domain = null, $secure = false, $httpOnly = true)
+    public static function force_expiry(string $name, string $path = null, $domain = null, bool $secure = false, bool $httpOnly = true): null
     {
         return self::get_inst()->forceExpiry($name, $path, $domain, $secure, $httpOnly);
     }

--- a/src/Control/CookieJar.php
+++ b/src/Control/CookieJar.php
@@ -51,7 +51,7 @@ class CookieJar implements Cookie_Backend
      * @param array $cookies The existing cookies to load into the cookie jar.
      * Omit this to default to $_COOKIE
      */
-    public function __construct($cookies = [])
+    public function __construct(array $cookies = []): void
     {
         $this->current = $this->existing = func_num_args()
             ? ($cookies ?: []) // Convert empty values to blank arrays
@@ -69,7 +69,7 @@ class CookieJar implements Cookie_Backend
      * @param boolean $secure Can the cookie only be sent over SSL?
      * @param boolean $httpOnly Prevent the cookie being accessible by JS
      */
-    public function set($name, $value, $expiry = 90, $path = null, $domain = null, $secure = false, $httpOnly = true)
+    public function set(string $name, string|bool|int $value, int|float $expiry = 90, string $path = null, string $domain = null, bool $secure = false, bool $httpOnly = true): void
     {
         //are we setting or clearing a cookie? false values are reserved for clearing cookies (see PHP manual)
         $clear = false;
@@ -105,7 +105,7 @@ class CookieJar implements Cookie_Backend
      *
      * @return string|null The cookie value or null if unset
      */
-    public function get($name, $includeUnsent = true)
+    public function get(string $name, bool $includeUnsent = true): null|string|int
     {
         $cookies = $includeUnsent ? $this->current : $this->existing;
         if (isset($cookies[$name])) {
@@ -126,7 +126,7 @@ class CookieJar implements Cookie_Backend
      * @param boolean $includeUnsent Include cookies we've yet to send
      * @return array All the cookies
      */
-    public function getAll($includeUnsent = true)
+    public function getAll(bool $includeUnsent = true): array
     {
         return $includeUnsent ? $this->current : $this->existing;
     }
@@ -140,7 +140,7 @@ class CookieJar implements Cookie_Backend
      * @param boolean $secure Can the cookie only be sent over SSL?
      * @param boolean $httpOnly Prevent the cookie being accessible by JS
      */
-    public function forceExpiry($name, $path = null, $domain = null, $secure = false, $httpOnly = true)
+    public function forceExpiry(string $name, string $path = null, $domain = null, bool $secure = false, bool $httpOnly = true): void
     {
         $this->set($name, false, -1, $path, $domain, $secure, $httpOnly);
     }
@@ -160,14 +160,14 @@ class CookieJar implements Cookie_Backend
      * @return boolean If the cookie was set or not; doesn't mean it's accepted by the browser
      */
     protected function outputCookie(
-        $name,
+        string $name,
         $value,
         $expiry = 90,
         $path = null,
         $domain = null,
         $secure = false,
         $httpOnly = true
-    ) {
+    ): bool {
         // if headers aren't sent, we can set the cookie
         if (!headers_sent($file, $line)) {
             return setcookie($name ?? '', $value ?? '', $expiry ?? 0, $path ?? '', $domain ?? '', $secure ?? false, $httpOnly ?? false);

--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -94,7 +94,7 @@ class Director implements TemplateGlobalProvider
      */
     private static $default_base_url = '`SS_BASE_URL`';
 
-    public function __construct()
+    public function __construct(): void
     {
     }
 
@@ -120,7 +120,7 @@ class Director implements TemplateGlobalProvider
      * @throws HTTPResponse_Exception
      */
     public static function test(
-        $url,
+        string $url,
         $postVars = [],
         $session = [],
         $httpMethod = null,
@@ -128,7 +128,7 @@ class Director implements TemplateGlobalProvider
         $headers = [],
         $cookies = [],
         &$request = null
-    ) {
+    ): SilverStripe\Control\HTTPResponse {
         return static::mockRequest(
             function (HTTPRequest $request) {
                 return Director::singleton()->handleRequest($request);
@@ -162,7 +162,7 @@ class Director implements TemplateGlobalProvider
      * @return mixed Result of callback
      */
     public static function mockRequest(
-        $callback,
+        callable $callback,
         $url,
         $postVars = [],
         $session = [],
@@ -171,7 +171,7 @@ class Director implements TemplateGlobalProvider
         $headers = [],
         $cookies = [],
         &$request = null
-    ) {
+    ): null|SilverStripe\Control\HTTPResponse {
         // Build list of cleanup promises
         $finally = [];
 
@@ -303,7 +303,7 @@ class Director implements TemplateGlobalProvider
      * @return HTTPResponse
      * @throws HTTPResponse_Exception
      */
-    public function handleRequest(HTTPRequest $request)
+    public function handleRequest(HTTPRequest $request): SilverStripe\Control\HTTPResponse
     {
         Injector::inst()->registerService($request, HTTPRequest::class);
 
@@ -388,7 +388,7 @@ class Director implements TemplateGlobalProvider
      *
      * @deprecated 5.0 Kernel::isFlushed to be used instead
      */
-    public static function isManifestFlushed()
+    public static function isManifestFlushed(): bool
     {
         $kernel = Injector::inst()->get(Kernel::class);
 
@@ -408,7 +408,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return SiteTree|Controller
      */
-    public static function get_current_page()
+    public static function get_current_page(): SilverStripe\ErrorPage\ErrorPage
     {
         return self::$current_page ? self::$current_page : Controller::curr();
     }
@@ -418,7 +418,7 @@ class Director implements TemplateGlobalProvider
      *
      * @param SiteTree $page
      */
-    public static function set_current_page($page)
+    public static function set_current_page(SilverStripe\ErrorPage\ErrorPage $page): void
     {
         self::$current_page = $page;
     }
@@ -437,7 +437,7 @@ class Director implements TemplateGlobalProvider
      * @param string $relativeParent Disambiguation method to use for evaluating relative paths
      * @return string The absolute url
      */
-    public static function absoluteURL($url, $relativeParent = self::BASE)
+    public static function absoluteURL(string $url, $relativeParent = self::BASE): string
     {
         if (is_bool($relativeParent)) {
             // Deprecate old boolean second parameter
@@ -484,7 +484,7 @@ class Director implements TemplateGlobalProvider
      * @param string $url
      * @return string|null Hostname, and optional port, or null if not a valid host
      */
-    protected static function parseHost($url)
+    protected static function parseHost(string $url): string|null
     {
         // Get base hostname
         $host = parse_url($url ?? '', PHP_URL_HOST);
@@ -507,7 +507,7 @@ class Director implements TemplateGlobalProvider
      * @param string $url
      * @return bool
      */
-    protected static function validateUserAndPass($url)
+    protected static function validateUserAndPass(string $url): bool
     {
         $parsedURL = parse_url($url ?? '');
 
@@ -535,7 +535,7 @@ class Director implements TemplateGlobalProvider
      * @param HTTPRequest $request
      * @return string Host name, including port (if present)
      */
-    public static function host(HTTPRequest $request = null)
+    public static function host(HTTPRequest $request = null): string
     {
         // Check if overridden by alternate_base_url
         if ($baseURL = self::config()->get('alternate_base_url')) {
@@ -577,7 +577,7 @@ class Director implements TemplateGlobalProvider
      * @param HTTPRequest $request
      * @return int|null
      */
-    public static function port(HTTPRequest $request = null)
+    public static function port(HTTPRequest $request = null): int
     {
         $host = static::host($request);
         return (int)parse_url($host ?? '', PHP_URL_PORT) ?: null;
@@ -589,7 +589,7 @@ class Director implements TemplateGlobalProvider
      * @param HTTPRequest|null $request
      * @return string|null
      */
-    public static function hostName(HTTPRequest $request = null)
+    public static function hostName(HTTPRequest $request = null): string
     {
         $host = static::host($request);
         return parse_url($host ?? '', PHP_URL_HOST) ?: null;
@@ -602,7 +602,7 @@ class Director implements TemplateGlobalProvider
      * @param HTTPRequest $request
      * @return bool|string
      */
-    public static function protocolAndHost(HTTPRequest $request = null)
+    public static function protocolAndHost(HTTPRequest $request = null): string
     {
         return static::protocol($request) . static::host($request);
     }
@@ -613,7 +613,7 @@ class Director implements TemplateGlobalProvider
      * @param HTTPRequest $request
      * @return string
      */
-    public static function protocol(HTTPRequest $request = null)
+    public static function protocol(HTTPRequest $request = null): string
     {
         return (self::is_https($request)) ? 'https://' : 'http://';
     }
@@ -624,7 +624,7 @@ class Director implements TemplateGlobalProvider
      * @param HTTPRequest $request
      * @return bool
      */
-    public static function is_https(HTTPRequest $request = null)
+    public static function is_https(HTTPRequest $request = null): bool
     {
         // Check override from alternate_base_url
         if ($baseURL = self::config()->uninherited('alternate_base_url')) {
@@ -658,7 +658,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return string Root-relative url with trailing slash.
      */
-    public static function baseURL()
+    public static function baseURL(): string
     {
         // Check override base_url
         $alternate = self::config()->get('alternate_base_url');
@@ -685,7 +685,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return string
      */
-    public static function baseFolder()
+    public static function baseFolder(): string
     {
         $alternate = Director::config()->uninherited('alternate_base_folder');
         return $alternate ?: BASE_PATH;
@@ -699,7 +699,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return string
      */
-    public static function publicDir()
+    public static function publicDir(): string
     {
         $alternate = self::config()->uninherited('alternate_public_dir');
         if (isset($alternate)) {
@@ -713,7 +713,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return string
      */
-    public static function publicFolder()
+    public static function publicFolder(): string
     {
         $folder = self::baseFolder();
         $publicDir = self::publicDir();
@@ -734,7 +734,7 @@ class Director implements TemplateGlobalProvider
      * @param string $url Accepts both a URL or a filesystem path.
      * @return string
      */
-    public static function makeRelative($url)
+    public static function makeRelative(string|bool $url): string
     {
         // Allow for the accidental inclusion whitespace and // in the URL
         $url = preg_replace('#([^:])//#', '\\1/', trim($url ?? ''));
@@ -769,7 +769,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public static function is_absolute($path)
+    public static function is_absolute(string $path): bool
     {
         if (empty($path)) {
             return false;
@@ -788,7 +788,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public static function is_root_relative_url($url)
+    public static function is_root_relative_url(string $url): bool
     {
         return strpos($url ?? '', '/') === 0 && strpos($url ?? '', '//') !== 0;
     }
@@ -807,7 +807,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public static function is_absolute_url($url)
+    public static function is_absolute_url(string $url): bool
     {
         // Strip off the query and fragment parts of the URL before checking
         if (($queryPosition = strpos($url ?? '', '?')) !== false) {
@@ -841,7 +841,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public static function is_relative_url($url)
+    public static function is_relative_url(string $url): bool
     {
         return !static::is_absolute_url($url);
     }
@@ -861,7 +861,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public static function is_site_url($url)
+    public static function is_site_url(string $url): bool
     {
         // Validate user and password
         if (!static::validateUserAndPass($url)) {
@@ -892,7 +892,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return string
      */
-    public static function getAbsFile($file)
+    public static function getAbsFile(string $file): string
     {
         // If already absolute
         if (self::is_absolute($file)) {
@@ -918,7 +918,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public static function fileExists($file)
+    public static function fileExists(string $file): bool
     {
         // replace any appended query-strings, e.g. /path/to/foo.php?bar=1 to /path/to/foo.php
         $file = preg_replace('/([^\?]*)?.*/', '$1', $file ?? '');
@@ -930,7 +930,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return string
      */
-    public static function absoluteBaseURL()
+    public static function absoluteBaseURL(): string
     {
         return self::absoluteURL(
             self::baseURL(),
@@ -1005,7 +1005,7 @@ class Director implements TemplateGlobalProvider
      * Can include port number.
      * @param HTTPRequest|null $request Request object to check
      */
-    public static function forceSSL($patterns = null, $secureDomain = null, HTTPRequest $request = null)
+    public static function forceSSL(array $patterns = null, string $secureDomain = null, HTTPRequest $request = null): void
     {
         $handler = CanonicalURLMiddleware::singleton()->setForceSSL(true);
         if ($patterns) {
@@ -1022,7 +1022,7 @@ class Director implements TemplateGlobalProvider
      *
      * @param HTTPRequest $request
      */
-    public static function forceWWW(HTTPRequest $request = null)
+    public static function forceWWW(HTTPRequest $request = null): void
     {
         $handler = CanonicalURLMiddleware::singleton()->setForceWWW(true);
         $handler->throwRedirectIfNeeded($request);
@@ -1038,7 +1038,7 @@ class Director implements TemplateGlobalProvider
      * @param HTTPRequest $request
      * @return bool
      */
-    public static function is_ajax(HTTPRequest $request = null)
+    public static function is_ajax(HTTPRequest $request = null): bool
     {
         $request = self::currentRequest($request);
         if ($request) {
@@ -1056,7 +1056,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public static function is_cli()
+    public static function is_cli(): bool
     {
         return Environment::isCli();
     }
@@ -1067,7 +1067,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return string
      */
-    public static function get_environment_type()
+    public static function get_environment_type(): string
     {
         /** @var Kernel $kernel */
         $kernel = Injector::inst()->get(Kernel::class);
@@ -1084,7 +1084,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return string|null null if not overridden, otherwise the actual value
      */
-    public static function get_session_environment_type(HTTPRequest $request = null)
+    public static function get_session_environment_type(HTTPRequest $request = null): void|null
     {
         $request = static::currentRequest($request);
 
@@ -1107,7 +1107,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public static function isLive()
+    public static function isLive(): bool
     {
         return self::get_environment_type() === 'live';
     }
@@ -1118,7 +1118,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public static function isDev()
+    public static function isDev(): bool
     {
         return self::get_environment_type() === 'dev';
     }
@@ -1129,7 +1129,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public static function isTest()
+    public static function isTest(): bool
     {
         return self::get_environment_type() === 'test';
     }
@@ -1140,7 +1140,7 @@ class Director implements TemplateGlobalProvider
      *
      * @return array
      */
-    public static function get_template_global_variables()
+    public static function get_template_global_variables(): array
     {
         return [
             'absoluteBaseURL',
@@ -1160,7 +1160,7 @@ class Director implements TemplateGlobalProvider
      * @param HTTPRequest $request
      * @return HTTPRequest Request object if one is both current and valid
      */
-    protected static function currentRequest(HTTPRequest $request = null)
+    protected static function currentRequest(HTTPRequest $request = null): null|SilverStripe\Control\HTTPRequest
     {
         // Ensure we only use a registered HTTPRequest and don't
         // incidentally construct a singleton

--- a/src/Control/Email/Email.php
+++ b/src/Control/Email/Email.php
@@ -101,7 +101,7 @@ class Email extends ViewableData
      *    This code is licensed under a Creative Commons Attribution-ShareAlike 2.5 License
      *    http://creativecommons.org/licenses/by-sa/2.5/
      */
-    public static function is_valid_address($address)
+    public static function is_valid_address(string|array $address): bool
     {
         $validator = new EmailValidator();
         return $validator->isValid($address, new RFCValidation());
@@ -112,7 +112,7 @@ class Email extends ViewableData
      *
      * @return array Keys are addresses, values are names
      */
-    public static function getSendAllEmailsTo()
+    public static function getSendAllEmailsTo(): array
     {
         return static::mergeConfiguredEmails('send_all_emails_to', 'SS_SEND_ALL_EMAILS_TO');
     }
@@ -122,7 +122,7 @@ class Email extends ViewableData
      *
      * @return array
      */
-    public static function getCCAllEmailsTo()
+    public static function getCCAllEmailsTo(): array
     {
         return static::mergeConfiguredEmails('cc_all_emails_to', 'SS_CC_ALL_EMAILS_TO');
     }
@@ -132,7 +132,7 @@ class Email extends ViewableData
      *
      * @return array
      */
-    public static function getBCCAllEmailsTo()
+    public static function getBCCAllEmailsTo(): array
     {
         return static::mergeConfiguredEmails('bcc_all_emails_to', 'SS_BCC_ALL_EMAILS_TO');
     }
@@ -142,7 +142,7 @@ class Email extends ViewableData
      *
      * @return array
      */
-    public static function getSendAllEmailsFrom()
+    public static function getSendAllEmailsFrom(): array
     {
         return static::mergeConfiguredEmails('send_all_emails_from', 'SS_SEND_ALL_EMAILS_FROM');
     }
@@ -154,7 +154,7 @@ class Email extends ViewableData
      * @param string $env Env variable key
      * @return array Array of email addresses
      */
-    protected static function mergeConfiguredEmails($config, $env)
+    protected static function mergeConfiguredEmails(string $config, string $env): array
     {
         // Normalise config list
         $normalised = [];
@@ -185,7 +185,7 @@ class Email extends ViewableData
      *    - 'hex': Hexadecimal URL-Encoding - useful for mailto: links
      * @return string
      */
-    public static function obfuscate($email, $method = 'visible')
+    public static function obfuscate(string $email, string $method = 'visible'): string
     {
         switch ($method) {
             case 'direction':
@@ -222,14 +222,14 @@ class Email extends ViewableData
      * @param string|null $returnPath
      */
     public function __construct(
-        $from = null,
+        string|array $from = null,
         $to = null,
         $subject = null,
         $body = null,
         $cc = null,
         $bcc = null,
         $returnPath = null
-    ) {
+    ): void {
         if ($from) {
             $this->setFrom($from);
         }
@@ -258,7 +258,7 @@ class Email extends ViewableData
     /**
      * @return Swift_Message
      */
-    public function getSwiftMessage()
+    public function getSwiftMessage(): Swift_Message
     {
         if (!$this->swiftMessage) {
             $message = new Swift_Message(null, null, 'text/html', 'utf-8');
@@ -275,7 +275,7 @@ class Email extends ViewableData
      *
      * @return $this
      */
-    public function setSwiftMessage($swiftMessage)
+    public function setSwiftMessage(Swift_Message $swiftMessage): SilverStripe\Control\Email\Email
     {
         $dateTime = new DateTime();
         $dateTime->setTimestamp(DBDatetime::now()->getTimestamp());
@@ -319,7 +319,7 @@ class Email extends ViewableData
     /**
      * @return string[]
      */
-    public function getFrom()
+    public function getFrom(): array
     {
         return $this->getSwiftMessage()->getFrom();
     }
@@ -328,7 +328,7 @@ class Email extends ViewableData
      * @param string|array $address
      * @return string|array
      */
-    private function sanitiseAddress($address)
+    private function sanitiseAddress(string|array $address): string|array
     {
         if (is_array($address)) {
             return array_map('trim', $address ?? []);
@@ -341,7 +341,7 @@ class Email extends ViewableData
      * @param string|null $name
      * @return $this
      */
-    public function setFrom($address, $name = null)
+    public function setFrom(string|array $address, $name = null): SilverStripe\Control\Email\Email
     {
         $address = $this->sanitiseAddress($address);
         $this->getSwiftMessage()->setFrom($address, $name);
@@ -354,7 +354,7 @@ class Email extends ViewableData
      * @param string|null $name
      * @return $this
      */
-    public function addFrom($address, $name = null)
+    public function addFrom(string $address, $name = null): SilverStripe\Control\Email\Email
     {
         $address = $this->sanitiseAddress($address);
         $this->getSwiftMessage()->addFrom($address, $name);
@@ -365,7 +365,7 @@ class Email extends ViewableData
     /**
      * @return string
      */
-    public function getSender()
+    public function getSender(): null|array
     {
         return $this->getSwiftMessage()->getSender();
     }
@@ -375,7 +375,7 @@ class Email extends ViewableData
      * @param string|null $name
      * @return $this
      */
-    public function setSender($address, $name = null)
+    public function setSender(string $address, string $name = null): SilverStripe\Control\Email\Email
     {
         $address = $this->sanitiseAddress($address);
         $this->getSwiftMessage()->setSender($address, $name);
@@ -386,7 +386,7 @@ class Email extends ViewableData
     /**
      * @return string
      */
-    public function getReturnPath()
+    public function getReturnPath(): string|null
     {
         return $this->getSwiftMessage()->getReturnPath();
     }
@@ -397,7 +397,7 @@ class Email extends ViewableData
      * @param string $address Email address where bounce notifications should be sent
      * @return $this
      */
-    public function setReturnPath($address)
+    public function setReturnPath(string $address): SilverStripe\Control\Email\Email
     {
         $address = $this->sanitiseAddress($address);
         $this->getSwiftMessage()->setReturnPath($address);
@@ -407,7 +407,7 @@ class Email extends ViewableData
     /**
      * @return array
      */
-    public function getTo()
+    public function getTo(): array|null
     {
         return $this->getSwiftMessage()->getTo();
     }
@@ -422,7 +422,7 @@ class Email extends ViewableData
      * @param string|null $name The name of the recipient (if one)
      * @return $this
      */
-    public function setTo($address, $name = null)
+    public function setTo(string|array $address, string $name = null): SilverStripe\Control\Email\Email
     {
         $address = $this->sanitiseAddress($address);
         $this->getSwiftMessage()->setTo($address, $name);
@@ -435,7 +435,7 @@ class Email extends ViewableData
      * @param string|null $name
      * @return $this
      */
-    public function addTo($address, $name = null)
+    public function addTo(string $address, $name = null): SilverStripe\Control\Email\Email
     {
         $address = $this->sanitiseAddress($address);
         $this->getSwiftMessage()->addTo($address, $name);
@@ -446,7 +446,7 @@ class Email extends ViewableData
     /**
      * @return array
      */
-    public function getCC()
+    public function getCC(): array
     {
         return $this->getSwiftMessage()->getCc();
     }
@@ -456,7 +456,7 @@ class Email extends ViewableData
      * @param string|null $name
      * @return $this
      */
-    public function setCC($address, $name = null)
+    public function setCC(string $address, string $name = null): SilverStripe\Control\Email\Email
     {
         $address = $this->sanitiseAddress($address);
         $this->getSwiftMessage()->setCc($address, $name);
@@ -469,7 +469,7 @@ class Email extends ViewableData
      * @param string|null $name
      * @return $this
      */
-    public function addCC($address, $name = null)
+    public function addCC(string $address, string $name = null): SilverStripe\Control\Email\Email
     {
         $address = $this->sanitiseAddress($address);
         $this->getSwiftMessage()->addCc($address, $name);
@@ -480,7 +480,7 @@ class Email extends ViewableData
     /**
      * @return array
      */
-    public function getBCC()
+    public function getBCC(): array
     {
         return $this->getSwiftMessage()->getBcc();
     }
@@ -490,7 +490,7 @@ class Email extends ViewableData
      * @param string|null $name
      * @return $this
      */
-    public function setBCC($address, $name = null)
+    public function setBCC(string $address, string $name = null): SilverStripe\Control\Email\Email
     {
         $address = $this->sanitiseAddress($address);
         $this->getSwiftMessage()->setBcc($address, $name);
@@ -503,7 +503,7 @@ class Email extends ViewableData
      * @param string|null $name
      * @return $this
      */
-    public function addBCC($address, $name = null)
+    public function addBCC(string $address, string $name = null): SilverStripe\Control\Email\Email
     {
         $address = $this->sanitiseAddress($address);
         $this->getSwiftMessage()->addBcc($address, $name);
@@ -514,7 +514,7 @@ class Email extends ViewableData
     /**
      * @return mixed
      */
-    public function getReplyTo()
+    public function getReplyTo(): null|array
     {
         return $this->getSwiftMessage()->getReplyTo();
     }
@@ -524,7 +524,7 @@ class Email extends ViewableData
      * @param string|null $name
      * @return $this
      */
-    public function setReplyTo($address, $name = null)
+    public function setReplyTo(string $address, string $name = null): SilverStripe\Control\Email\Email
     {
         $address = $this->sanitiseAddress($address);
         $this->getSwiftMessage()->setReplyTo($address, $name);
@@ -537,7 +537,7 @@ class Email extends ViewableData
      * @param string|null $name
      * @return $this
      */
-    public function addReplyTo($address, $name = null)
+    public function addReplyTo(string $address, $name = null): SilverStripe\Control\Email\Email
     {
         $address = $this->sanitiseAddress($address);
         $this->getSwiftMessage()->addReplyTo($address, $name);
@@ -548,7 +548,7 @@ class Email extends ViewableData
     /**
      * @return string
      */
-    public function getSubject()
+    public function getSubject(): string|null
     {
         return $this->getSwiftMessage()->getSubject();
     }
@@ -557,7 +557,7 @@ class Email extends ViewableData
      * @param string $subject The Subject line for the email
      * @return $this
      */
-    public function setSubject($subject)
+    public function setSubject(string $subject): SilverStripe\Control\Email\Email
     {
         $this->getSwiftMessage()->setSubject($subject);
 
@@ -567,7 +567,7 @@ class Email extends ViewableData
     /**
      * @return int
      */
-    public function getPriority()
+    public function getPriority(): string
     {
         return $this->getSwiftMessage()->getPriority();
     }
@@ -576,7 +576,7 @@ class Email extends ViewableData
      * @param int $priority
      * @return $this
      */
-    public function setPriority($priority)
+    public function setPriority(int $priority): SilverStripe\Control\Email\Email
     {
         $this->getSwiftMessage()->setPriority($priority);
 
@@ -589,7 +589,7 @@ class Email extends ViewableData
      * @param string $mime The mime type for the attachment
      * @return $this
      */
-    public function addAttachment($path, $alias = null, $mime = null)
+    public function addAttachment(string $path, $alias = null, string $mime = null): SilverStripe\Control\Email\Email
     {
         $attachment = \Swift_Attachment::fromPath($path);
         if ($alias) {
@@ -609,7 +609,7 @@ class Email extends ViewableData
      * @param string $mime
      * @return $this
      */
-    public function addAttachmentFromData($data, $name, $mime = null)
+    public function addAttachmentFromData(string $data, string $name, string $mime = null): SilverStripe\Control\Email\Email
     {
         $attachment = new \Swift_Attachment($data, $name);
         if ($mime) {
@@ -623,7 +623,7 @@ class Email extends ViewableData
     /**
      * @return array|ViewableData The template data
      */
-    public function getData()
+    public function getData(): SilverStripe\Security\Member|array
     {
         return $this->data;
     }
@@ -632,7 +632,7 @@ class Email extends ViewableData
      * @param array|ViewableData $data The template data to set
      * @return $this
      */
-    public function setData($data)
+    public function setData(SilverStripe\Security\Member|array $data): SilverStripe\Control\Email\Email
     {
         $this->data = $data;
         $this->invalidateBody();
@@ -645,7 +645,7 @@ class Email extends ViewableData
      * @param string|null $value The value of the data to add
      * @return $this
      */
-    public function addData($name, $value = null)
+    public function addData(string|array $name, string|bool|SilverStripe\Security\Member $value = null): SilverStripe\Control\Email\Email
     {
         if (is_array($name)) {
             $this->data = array_merge($this->data, $name);
@@ -666,7 +666,7 @@ class Email extends ViewableData
      * @param string $name
      * @return $this
      */
-    public function removeData($name)
+    public function removeData(string $name): SilverStripe\Control\Email\Email
     {
         if (is_array($this->data)) {
             unset($this->data[$name]);
@@ -682,7 +682,7 @@ class Email extends ViewableData
     /**
      * @return string
      */
-    public function getBody()
+    public function getBody(): string|null
     {
         return $this->getSwiftMessage()->getBody();
     }
@@ -691,7 +691,7 @@ class Email extends ViewableData
      * @param string $body The email body
      * @return $this
      */
-    public function setBody($body)
+    public function setBody(SilverStripe\ORM\FieldType\DBHTMLText|string $body): SilverStripe\Control\Email\Email
     {
         $plainPart = $this->findPlainPart();
         if ($plainPart) {
@@ -708,7 +708,7 @@ class Email extends ViewableData
     /**
      * @return $this
      */
-    public function invalidateBody()
+    public function invalidateBody(): SilverStripe\Control\Email\Email
     {
         $this->setBody(null);
 
@@ -739,7 +739,7 @@ class Email extends ViewableData
     /**
      * @return string
      */
-    public function getHTMLTemplate()
+    public function getHTMLTemplate(): string
     {
         if ($this->HTMLTemplate) {
             return $this->HTMLTemplate;
@@ -757,7 +757,7 @@ class Email extends ViewableData
      * @param string $template
      * @return $this
      */
-    public function setHTMLTemplate($template)
+    public function setHTMLTemplate(string $template): SilverStripe\Control\Email\Email
     {
         if (substr($template ?? '', -3) == '.ss') {
             $template = substr($template ?? '', 0, -3);
@@ -772,7 +772,7 @@ class Email extends ViewableData
      *
      * @return string
      */
-    public function getPlainTemplate()
+    public function getPlainTemplate(): null|string
     {
         return $this->plainTemplate;
     }
@@ -783,7 +783,7 @@ class Email extends ViewableData
      * @param string $template
      * @return $this
      */
-    public function setPlainTemplate($template)
+    public function setPlainTemplate(string $template): SilverStripe\Control\Email\Email
     {
         if (substr($template ?? '', -3) == '.ss') {
             $template = substr($template ?? '', 0, -3);
@@ -797,7 +797,7 @@ class Email extends ViewableData
      * @param array $recipients
      * @return $this
      */
-    public function setFailedRecipients($recipients)
+    public function setFailedRecipients(array $recipients): SilverStripe\Control\Email\Email
     {
         $this->failedRecipients = $recipients;
 
@@ -807,7 +807,7 @@ class Email extends ViewableData
     /**
      * @return array
      */
-    public function getFailedRecipients()
+    public function getFailedRecipients(): array
     {
         return $this->failedRecipients;
     }
@@ -817,7 +817,7 @@ class Email extends ViewableData
      *
      * @return bool
      */
-    public function IsEmail()
+    public function IsEmail(): bool
     {
         return true;
     }
@@ -827,7 +827,7 @@ class Email extends ViewableData
      *
      * @return bool true if successful or array of failed recipients
      */
-    public function send()
+    public function send(): bool
     {
         if (!$this->getBody()) {
             $this->render();
@@ -841,7 +841,7 @@ class Email extends ViewableData
     /**
      * @return array|bool
      */
-    public function sendPlain()
+    public function sendPlain(): bool
     {
         if (!$this->hasPlainPart()) {
             $this->render(true);
@@ -854,7 +854,7 @@ class Email extends ViewableData
      * @param bool $plainOnly Only render the message as plain text
      * @return $this
      */
-    public function render($plainOnly = false)
+    public function render(bool $plainOnly = false): SilverStripe\Control\Email\Email
     {
         if ($existingPlainPart = $this->findPlainPart()) {
             $this->getSwiftMessage()->detach($existingPlainPart);
@@ -922,7 +922,7 @@ class Email extends ViewableData
     /**
      * @return Swift_MimePart|false
      */
-    public function findPlainPart()
+    public function findPlainPart(): bool|Swift_MimePart
     {
         foreach ($this->getSwiftMessage()->getChildren() as $child) {
             if ($child instanceof Swift_MimePart && $child->getContentType() == 'text/plain') {
@@ -935,7 +935,7 @@ class Email extends ViewableData
     /**
      * @return bool
      */
-    public function hasPlainPart()
+    public function hasPlainPart(): bool
     {
         if ($this->getSwiftMessage()->getContentType() === 'text/plain') {
             return true;
@@ -948,7 +948,7 @@ class Email extends ViewableData
      *
      * @return $this
      */
-    public function generatePlainPartFromBody()
+    public function generatePlainPartFromBody(): SilverStripe\Control\Email\Email
     {
         $plainPart = $this->findPlainPart();
         if ($plainPart) {

--- a/src/Control/Email/SwiftMailer.php
+++ b/src/Control/Email/SwiftMailer.php
@@ -35,7 +35,7 @@ class SwiftMailer implements Mailer
      * @param Email $message
      * @return bool Whether the sending was "successful" or not
      */
-    public function send($message)
+    public function send(SilverStripe\Control\Email\Email $message): bool
     {
         $swiftMessage = $message->getSwiftMessage();
         $failedRecipients = [];
@@ -50,7 +50,7 @@ class SwiftMailer implements Mailer
      * @param array $failedRecipients
      * @return int
      */
-    protected function sendSwift($message, &$failedRecipients = null)
+    protected function sendSwift(Swift_Message $message, &$failedRecipients = null): int|null
     {
         return $this->getSwiftMailer()->send($message, $failedRecipients);
     }
@@ -58,7 +58,7 @@ class SwiftMailer implements Mailer
     /**
      * @return Swift_Mailer
      */
-    public function getSwiftMailer()
+    public function getSwiftMailer(): Swift_Mailer
     {
         return $this->swift;
     }
@@ -67,7 +67,7 @@ class SwiftMailer implements Mailer
      * @param Swift_Mailer $swift
      * @return $this
      */
-    public function setSwiftMailer($swift)
+    public function setSwiftMailer(Swift_Mailer $swift): SilverStripe\Control\Email\SwiftMailer
     {
         // register any required plugins
         foreach ($this->config()->get('swift_plugins') as $plugin) {

--- a/src/Control/Email/SwiftPlugin.php
+++ b/src/Control/Email/SwiftPlugin.php
@@ -9,7 +9,7 @@ class SwiftPlugin implements \Swift_Events_SendListener
      *
      * @param \Swift_Events_SendEvent $evt
      */
-    public function beforeSendPerformed(\Swift_Events_SendEvent $evt)
+    public function beforeSendPerformed(\Swift_Events_SendEvent $evt): void
     {
         /** @var \Swift_Message $message */
         $message = $evt->getMessage();
@@ -43,7 +43,7 @@ class SwiftPlugin implements \Swift_Events_SendListener
      * @param \Swift_Message $message
      * @param array|string $to
      */
-    protected function setTo($message, $to)
+    protected function setTo(Swift_Message $message, array $to): void
     {
         $headers = $message->getHeaders();
         $origTo = $message->getTo();
@@ -65,7 +65,7 @@ class SwiftPlugin implements \Swift_Events_SendListener
      * @param \Swift_Message $message
      * @param array|string $from
      */
-    protected function setFrom($message, $from)
+    protected function setFrom(Swift_Message $message, array $from): void
     {
         $headers = $message->getHeaders();
         $origFrom = $message->getFrom();
@@ -73,7 +73,7 @@ class SwiftPlugin implements \Swift_Events_SendListener
         $message->setFrom($from);
     }
 
-    public function sendPerformed(\Swift_Events_SendEvent $evt)
+    public function sendPerformed(\Swift_Events_SendEvent $evt): void
     {
         // noop
     }

--- a/src/Control/HTTP.php
+++ b/src/Control/HTTP.php
@@ -93,7 +93,7 @@ class HTTP
      * @param string $filename
      * @return string
      */
-    public static function filename2url($filename)
+    public static function filename2url(string $filename): string
     {
         $filename = realpath($filename ?? '');
         if (!$filename) {
@@ -118,7 +118,7 @@ class HTTP
      *
      * @return string
      */
-    public static function absoluteURLs($html)
+    public static function absoluteURLs(SilverStripe\ORM\FieldType\DBHTMLText|string $html): string
     {
         $html = str_replace('$CurrentPageURL', Controller::curr()->getRequest()->getURL() ?? '', $html ?? '');
         return HTTP::urlRewriter($html, function ($url) {
@@ -154,7 +154,7 @@ class HTTP
      *
      * @return string The content with all links rewritten as per the logic specified in $code.
      */
-    public static function urlRewriter($content, $code)
+    public static function urlRewriter(string $content, callable $code): string
     {
         if (!is_callable($code)) {
             throw new InvalidArgumentException(
@@ -217,7 +217,7 @@ class HTTP
      * @param string $separator Separator for http_build_query().
      * @return string
      */
-    public static function setGetVar($varname, $varvalue, $currentURL = null, $separator = '&')
+    public static function setGetVar(string $varname, int|string|float $varvalue, string $currentURL = null, $separator = '&'): string
     {
         if (!isset($currentURL)) {
             $request = Controller::curr()->getRequest();
@@ -296,7 +296,7 @@ class HTTP
      *
      * @return array
      */
-    public static function findByTagAndAttribute($content, $attributes)
+    public static function findByTagAndAttribute(string $content, array $attributes): null|array
     {
         $regexes = [];
 
@@ -323,7 +323,7 @@ class HTTP
      *
      * @return array
      */
-    public static function getLinksIn($content)
+    public static function getLinksIn(string $content): null|array
     {
         return self::findByTagAndAttribute($content, ["a" => "href"]);
     }
@@ -346,7 +346,7 @@ class HTTP
      * @param string $filename
      * @return string
      */
-    public static function get_mime_type($filename)
+    public static function get_mime_type(string $filename): string
     {
         // If the finfo module is compiled into PHP, use it.
         $path = BASE_PATH . DIRECTORY_SEPARATOR . $filename;
@@ -375,7 +375,7 @@ class HTTP
      * @deprecated 4.2.0:5.0.0 Use HTTPCacheControlMiddleware::singleton()->setMaxAge($age) instead
      * @param int $age
      */
-    public static function set_cache_age($age)
+    public static function set_cache_age(int $age): void
     {
         Deprecation::notice('5.0', 'Use HTTPCacheControlMiddleware::singleton()->setMaxAge($age) instead');
         self::$cache_age = $age;
@@ -428,7 +428,7 @@ class HTTP
      * @param HTTPResponse $response
      * @deprecated 4.2.0:5.0.0 Headers are added automatically by HTTPCacheControlMiddleware instead.
      */
-    public static function add_cache_headers($response = null)
+    public static function add_cache_headers(SilverStripe\Control\HTTPResponse $response = null): void
     {
         Deprecation::notice('5.0', 'Headers are added automatically by HTTPCacheControlMiddleware instead.');
 
@@ -478,7 +478,7 @@ class HTTP
      * @param HTTPRequest $request
      * @param HTTPResponse $response
      */
-    public static function augmentState(HTTPRequest $request, HTTPResponse $response)
+    public static function augmentState(HTTPRequest $request, HTTPResponse $response): void
     {
         // Skip if deprecated API is disabled
         $config = Config::forClass(HTTP::class);

--- a/src/Control/HTTPApplication.php
+++ b/src/Control/HTTPApplication.php
@@ -37,7 +37,7 @@ class HTTPApplication implements Application
      *
      * @param Kernel $kernel
      */
-    public function __construct(Kernel $kernel)
+    public function __construct(Kernel $kernel): void
     {
         $this->kernel = $kernel;
     }
@@ -62,7 +62,7 @@ class HTTPApplication implements Application
      *
      * @return FlushDiscoverer
      */
-    public function getFlushDiscoverer(HTTPRequest $request)
+    public function getFlushDiscoverer(HTTPRequest $request): SilverStripe\Core\Startup\CompositeFlushDiscoverer
     {
         if ($this->flushDiscoverer) {
             return $this->flushDiscoverer;
@@ -82,7 +82,7 @@ class HTTPApplication implements Application
      *
      * @return string
      */
-    protected function getEnvironmentType()
+    protected function getEnvironmentType(): string
     {
         $kernel_env = $this->kernel->getEnvironment();
         $server_env = Environment::getEnv('SS_ENVIRONMENT_TYPE');
@@ -97,7 +97,7 @@ class HTTPApplication implements Application
      *
      * @return Kernel
      */
-    public function getKernel()
+    public function getKernel(): SilverStripe\Core\CoreKernel
     {
         return $this->kernel;
     }
@@ -108,7 +108,7 @@ class HTTPApplication implements Application
      * @param HTTPRequest $request
      * @return HTTPResponse
      */
-    public function handle(HTTPRequest $request)
+    public function handle(HTTPRequest $request): SilverStripe\Control\HTTPResponse
     {
         $flush = (bool) $this->getFlushDiscoverer($request)->shouldFlush();
 
@@ -127,7 +127,7 @@ class HTTPApplication implements Application
      *
      * @return HTTPResponse
      */
-    public function execute(HTTPRequest $request, callable $callback, $flush = false)
+    public function execute(HTTPRequest $request, callable $callback, bool $flush = false): null|SilverStripe\Control\HTTPResponse
     {
         try {
             return $this->callMiddleware($request, function ($request) use ($callback, $flush) {

--- a/src/Control/HTTPRequest.php
+++ b/src/Control/HTTPRequest.php
@@ -151,7 +151,7 @@ class HTTPRequest implements ArrayAccess
      * @param array $postVars
      * @param string $body
      */
-    public function __construct($httpMethod, $url, $getVars = [], $postVars = [], $body = null)
+    public function __construct(string $httpMethod, string $url, array $getVars = [], array $postVars = [], string $body = null): void
     {
         $this->httpMethod = strtoupper($httpMethod ?? '');
         $this->setUrl($url);
@@ -170,7 +170,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $url The new URL
      * @return HTTPRequest The updated request
      */
-    public function setUrl($url)
+    public function setUrl(string $url): SilverStripe\Control\HTTPRequest
     {
         $this->url = $url;
 
@@ -194,7 +194,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return bool
      */
-    public function isGET()
+    public function isGET(): bool
     {
         return $this->httpMethod == 'GET';
     }
@@ -202,7 +202,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return bool
      */
-    public function isPOST()
+    public function isPOST(): bool
     {
         return $this->httpMethod == 'POST';
     }
@@ -210,7 +210,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return bool
      */
-    public function isPUT()
+    public function isPUT(): bool
     {
         return $this->httpMethod == 'PUT';
     }
@@ -218,7 +218,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return bool
      */
-    public function isDELETE()
+    public function isDELETE(): bool
     {
         return $this->httpMethod == 'DELETE';
     }
@@ -226,7 +226,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return bool
      */
-    public function isHEAD()
+    public function isHEAD(): bool
     {
         return $this->httpMethod == 'HEAD';
     }
@@ -235,7 +235,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $body
      * @return HTTPRequest $this
      */
-    public function setBody($body)
+    public function setBody(string $body): SilverStripe\Control\HTTPRequest
     {
         $this->body = $body;
         return $this;
@@ -244,7 +244,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return null|string
      */
-    public function getBody()
+    public function getBody(): string|null
     {
         return $this->body;
     }
@@ -252,7 +252,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return array
      */
-    public function getVars()
+    public function getVars(): array
     {
         return $this->getVars;
     }
@@ -260,7 +260,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return array
      */
-    public function postVars()
+    public function postVars(): array
     {
         return $this->postVars;
     }
@@ -272,7 +272,7 @@ class HTTPRequest implements ArrayAccess
      *
      * @return array
      */
-    public function requestVars()
+    public function requestVars(): array
     {
         return ArrayLib::array_merge_recursive($this->getVars, $this->postVars);
     }
@@ -281,7 +281,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $name
      * @return mixed
      */
-    public function getVar($name)
+    public function getVar(string $name): null|string|array|int
     {
         if (isset($this->getVars[$name])) {
             return $this->getVars[$name];
@@ -293,7 +293,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $name
      * @return mixed
      */
-    public function postVar($name)
+    public function postVar(string $name): null|array|string|int
     {
         if (isset($this->postVars[$name])) {
             return $this->postVars[$name];
@@ -305,7 +305,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $name
      * @return mixed
      */
-    public function requestVar($name)
+    public function requestVar(string $name): null|string|array|int|bool
     {
         if (isset($this->postVars[$name])) {
             return $this->postVars[$name];
@@ -324,7 +324,7 @@ class HTTPRequest implements ArrayAccess
      *
      * @return string
      */
-    public function getExtension()
+    public function getExtension(): null|string
     {
         return $this->extension;
     }
@@ -349,7 +349,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $header Example: "content-type"
      * @param string $value Example: "text/xml"
      */
-    public function addHeader($header, $value)
+    public function addHeader(string $header, string|bool $value): SilverStripe\Control\HTTPRequest
     {
         $header = strtolower($header ?? '');
         $this->headers[$header] = $value;
@@ -370,7 +370,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $header Name of the header (Insensitive to case as per <rfc2616 section 4.2 "Message Headers">)
      * @return mixed
      */
-    public function getHeader($header)
+    public function getHeader(string $header): null|string|bool
     {
         $header = strtolower($header ?? '');
         return (isset($this->headers[$header])) ? $this->headers[$header] : null;
@@ -383,7 +383,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $header
      * @return HTTPRequest $this
      */
-    public function removeHeader($header)
+    public function removeHeader(string $header): SilverStripe\Control\HTTPRequest
     {
         $header = strtolower($header ?? '');
         unset($this->headers[$header]);
@@ -396,7 +396,7 @@ class HTTPRequest implements ArrayAccess
      * @param bool $includeGetVars whether or not to include the get parameters
      * @return string
      */
-    public function getURL($includeGetVars = false)
+    public function getURL(bool $includeGetVars = false): string
     {
         $url = ($this->getExtension()) ? $this->url . '.' . $this->getExtension() : $this->url;
 
@@ -419,7 +419,7 @@ class HTTPRequest implements ArrayAccess
      *
      * @return boolean
      */
-    public function isAjax()
+    public function isAjax(): bool
     {
         return (
             $this->requestVar('ajax') ||
@@ -435,7 +435,7 @@ class HTTPRequest implements ArrayAccess
      * @return bool
      */
     #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists(string $offset): bool
     {
         return isset($this->postVars[$offset]) || isset($this->getVars[$offset]);
     }
@@ -447,19 +447,19 @@ class HTTPRequest implements ArrayAccess
      * @return mixed
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(string $offset): string
     {
         return $this->requestVar($offset);
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet(string $offset, string|int|array $value): void
     {
         $this->getVars[$offset] = $value;
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset(string $offset): void
     {
         unset($this->getVars[$offset]);
         unset($this->postVars[$offset]);
@@ -511,7 +511,7 @@ class HTTPRequest implements ArrayAccess
      * @param bool $shiftOnSuccess
      * @return array|bool
      */
-    public function match($pattern, $shiftOnSuccess = false)
+    public function match(string $pattern, bool $shiftOnSuccess = false): bool|array
     {
         // Check if a specific method is required
         if (preg_match('/^([A-Za-z]+) +(.*)$/', $pattern ?? '', $matches)) {
@@ -632,7 +632,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return array
      */
-    public function allParams()
+    public function allParams(): array
     {
         return $this->allParams;
     }
@@ -642,7 +642,7 @@ class HTTPRequest implements ArrayAccess
      *
      * @return string
      */
-    public function shiftAllParams()
+    public function shiftAllParams(): string
     {
         $keys    = array_keys($this->allParams ?? []);
         $values  = array_values($this->allParams ?? []);
@@ -663,7 +663,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return array
      */
-    public function latestParams()
+    public function latestParams(): array
     {
         return $this->latestParams;
     }
@@ -672,7 +672,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $name
      * @return string|null
      */
-    public function latestParam($name)
+    public function latestParam(string $name): null|string
     {
         if (isset($this->latestParams[$name])) {
             return $this->latestParams[$name];
@@ -693,7 +693,7 @@ class HTTPRequest implements ArrayAccess
      * @param $params
      * @return HTTPRequest $this
      */
-    public function setRouteParams($params)
+    public function setRouteParams(array $params): SilverStripe\Control\HTTPRequest
     {
         $this->routeParams = $params;
         return $this;
@@ -702,7 +702,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return array
      */
-    public function params()
+    public function params(): array
     {
         return array_merge($this->allParams, $this->routeParams);
     }
@@ -714,7 +714,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $name
      * @return string Value of the URL parameter (if found)
      */
-    public function param($name)
+    public function param(string $name): null|string|array|int
     {
         $params = $this->params();
         if (isset($params[$name])) {
@@ -731,7 +731,7 @@ class HTTPRequest implements ArrayAccess
      *
      * @return string Partial URL
      */
-    public function remaining()
+    public function remaining(): string
     {
         return implode("/", $this->dirParts);
     }
@@ -743,7 +743,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $pattern
      * @return bool
      */
-    public function isEmptyPattern($pattern)
+    public function isEmptyPattern(string $pattern): bool
     {
         if (preg_match('/^([A-Za-z]+) +(.*)$/', $pattern ?? '', $matches)) {
             $pattern = $matches[2];
@@ -762,7 +762,7 @@ class HTTPRequest implements ArrayAccess
      * @param int $count Shift Count
      * @return string|array
      */
-    public function shift($count = 1)
+    public function shift(int $count = 1): string|null|array
     {
         $return = [];
 
@@ -789,7 +789,7 @@ class HTTPRequest implements ArrayAccess
      *
      * @return bool
      */
-    public function allParsed()
+    public function allParsed(): bool
     {
         return sizeof($this->dirParts ?? []) <= $this->unshiftedButParsedParts;
     }
@@ -797,7 +797,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return string Return the host from the request
      */
-    public function getHost()
+    public function getHost(): null|string
     {
         return $this->getHeader('host');
     }
@@ -807,7 +807,7 @@ class HTTPRequest implements ArrayAccess
      *
      * @return string
      */
-    public function getIP()
+    public function getIP(): string|null
     {
         return $this->ip;
     }
@@ -819,7 +819,7 @@ class HTTPRequest implements ArrayAccess
      * @param $ip string
      * @return $this
      */
-    public function setIP($ip)
+    public function setIP(string $ip): SilverStripe\Control\HTTPRequest
     {
         if (!filter_var($ip, FILTER_VALIDATE_IP)) {
             throw new InvalidArgumentException("Invalid ip $ip");
@@ -836,7 +836,7 @@ class HTTPRequest implements ArrayAccess
      *                                (Default: false)
      * @return array
      */
-    public function getAcceptMimetypes($includeQuality = false)
+    public function getAcceptMimetypes(bool $includeQuality = false): array
     {
         $mimetypes = [];
         $mimetypesWithQuality = preg_split('#\s*,\s*#', $this->getHeader('accept') ?? '');
@@ -849,7 +849,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return string HTTP method (all uppercase)
      */
-    public function httpMethod()
+    public function httpMethod(): string
     {
         return $this->httpMethod;
     }
@@ -859,7 +859,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $method
      * @return $this
      */
-    public function setHttpMethod($method)
+    public function setHttpMethod(string $method): SilverStripe\Control\HTTPRequest
     {
         if (!self::isValidHttpMethod($method)) {
             throw new \InvalidArgumentException('HTTPRequest::setHttpMethod: Invalid HTTP method');
@@ -875,7 +875,7 @@ class HTTPRequest implements ArrayAccess
      *
      * @return string
      */
-    public function getScheme()
+    public function getScheme(): string
     {
         return $this->scheme;
     }
@@ -887,7 +887,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $scheme
      * @return $this
      */
-    public function setScheme($scheme)
+    public function setScheme(string $scheme): SilverStripe\Control\HTTPRequest
     {
         $this->scheme = $scheme;
         return $this;
@@ -897,7 +897,7 @@ class HTTPRequest implements ArrayAccess
      * @param string $method
      * @return bool
      */
-    private static function isValidHttpMethod($method)
+    private static function isValidHttpMethod(string $method): bool
     {
         return in_array(strtoupper($method ?? ''), ['GET','POST','PUT','DELETE','HEAD']);
     }
@@ -912,7 +912,7 @@ class HTTPRequest implements ArrayAccess
      * @return string HTTP method (all uppercase)
      * @deprecated 4.4.7
      */
-    public static function detect_method($origMethod, $postVars)
+    public static function detect_method(string $origMethod, array $postVars): string
     {
         if (isset($postVars['_method'])) {
             if (!self::isValidHttpMethod($postVars['_method'])) {
@@ -936,7 +936,7 @@ class HTTPRequest implements ArrayAccess
     /**
      * @return Session
      */
-    public function getSession()
+    public function getSession(): SilverStripe\Control\Session
     {
         if (!$this->hasSession()) {
             throw new BadMethodCallException("No session available for this HTTPRequest");
@@ -948,7 +948,7 @@ class HTTPRequest implements ArrayAccess
      * @param Session $session
      * @return $this
      */
-    public function setSession(Session $session)
+    public function setSession(Session $session): SilverStripe\Control\HTTPRequest
     {
         $this->session = $session;
         return $this;

--- a/src/Control/HTTPRequestBuilder.php
+++ b/src/Control/HTTPRequestBuilder.php
@@ -13,7 +13,7 @@ class HTTPRequestBuilder
      * @throws HTTPResponse_Exception
      * @return HTTPRequest
      */
-    public static function createFromEnvironment()
+    public static function createFromEnvironment(): SilverStripe\Control\HTTPRequest
     {
         // Clean and update live global variables
         $variables = static::cleanEnvironment(Environment::getVariables());
@@ -31,7 +31,7 @@ class HTTPRequestBuilder
      * @param string|null $url Provide specific url (relative to base)
      * @return HTTPRequest
      */
-    public static function createFromVariables(array $variables, $input, $url = null)
+    public static function createFromVariables(array $variables, string $input, string $url = null): SilverStripe\Control\HTTPRequest
     {
         // Infer URL from REQUEST_URI unless explicitly provided
         if (!isset($url)) {
@@ -84,7 +84,7 @@ class HTTPRequestBuilder
      *
      * @return array
      */
-    public static function extractRequestHeaders(array $server)
+    public static function extractRequestHeaders(array $server): array
     {
         $headers = [];
         foreach ($server as $key => $value) {
@@ -133,7 +133,7 @@ class HTTPRequestBuilder
      * @param array $variables
      * @return array Cleaned variables
      */
-    public static function cleanEnvironment(array $variables)
+    public static function cleanEnvironment(array $variables): array
     {
         // Merge $_FILES into $_POST
         $variables['_POST'] = array_merge((array)$variables['_POST'], (array)$variables['_FILES']);

--- a/src/Control/HTTPResponse.php
+++ b/src/Control/HTTPResponse.php
@@ -134,7 +134,7 @@ class HTTPResponse
      *  See {@link setStatusCode()} for more information.
      * @param string $protocolVersion
      */
-    public function __construct($body = null, $statusCode = null, $statusDescription = null, $protocolVersion = null)
+    public function __construct(string|SilverStripe\ORM\FieldType\DBHTMLText $body = null, int $statusCode = null, string $statusDescription = null, $protocolVersion = null): void
     {
         $this->setBody($body);
         if ($statusCode) {
@@ -157,7 +157,7 @@ class HTTPResponse
      *
      * @return $this
      */
-    public function setProtocolVersion($protocolVersion)
+    public function setProtocolVersion(string $protocolVersion): SilverStripe\Control\HTTPResponse
     {
         $this->protocolVersion = $protocolVersion;
         return $this;
@@ -172,7 +172,7 @@ class HTTPResponse
      *
      * @return $this
      */
-    public function setStatusCode($code, $description = null)
+    public function setStatusCode(int $code, string $description = null): SilverStripe\Control\HTTPResponse
     {
         if (isset(self::$status_codes[$code])) {
             $this->statusCode = $code;
@@ -196,7 +196,7 @@ class HTTPResponse
      *
      * @return $this
      */
-    public function setStatusDescription($description)
+    public function setStatusDescription(string $description): SilverStripe\Control\HTTPResponse
     {
         $this->statusDescription = $description;
         return $this;
@@ -213,7 +213,7 @@ class HTTPResponse
     /**
      * @return int
      */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->statusCode;
     }
@@ -221,7 +221,7 @@ class HTTPResponse
     /**
      * @return string Description for a HTTP status code
      */
-    public function getStatusDescription()
+    public function getStatusDescription(): string
     {
         return str_replace(["\r", "\n"], '', $this->statusDescription ?? '');
     }
@@ -231,7 +231,7 @@ class HTTPResponse
      *
      * @return bool
      */
-    public function isError()
+    public function isError(): bool
     {
         $statusCode = $this->getStatusCode();
         return $statusCode && ($statusCode < 200 || $statusCode > 399);
@@ -242,7 +242,7 @@ class HTTPResponse
      *
      * @return $this
      */
-    public function setBody($body)
+    public function setBody(SilverStripe\ORM\FieldType\DBHTMLText|string $body): SilverStripe\Control\HTTPResponse
     {
         $this->body = $body ? (string)$body : $body; // Don't type-cast false-ish values, eg null is null not ''
         return $this;
@@ -251,7 +251,7 @@ class HTTPResponse
     /**
      * @return string
      */
-    public function getBody()
+    public function getBody(): string|null
     {
         return $this->body;
     }
@@ -264,7 +264,7 @@ class HTTPResponse
      *
      * @return $this
      */
-    public function addHeader($header, $value)
+    public function addHeader(string $header, string|bool|int $value): SilverStripe\Control\HTTPResponse
     {
         $header = strtolower($header ?? '');
         $this->headers[$header] = $value;
@@ -278,7 +278,7 @@ class HTTPResponse
      *
      * @return string
      */
-    public function getHeader($header)
+    public function getHeader(string $header): null|string|int
     {
         $header = strtolower($header ?? '');
         if (isset($this->headers[$header])) {
@@ -290,7 +290,7 @@ class HTTPResponse
     /**
      * @return array
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
@@ -303,7 +303,7 @@ class HTTPResponse
      *
      * @return $this
      */
-    public function removeHeader($header)
+    public function removeHeader(string $header): SilverStripe\Control\HTTPResponse
     {
         $header = strtolower($header ?? '');
         unset($this->headers[$header]);
@@ -316,7 +316,7 @@ class HTTPResponse
      *
      * @return $this
      */
-    public function redirect($dest, $code = 302)
+    public function redirect(string $dest, int $code = 302): SilverStripe\Control\HTTPResponse
     {
         if (!in_array($code, self::$redirect_codes)) {
             trigger_error("Invalid HTTP redirect code {$code}", E_USER_WARNING);
@@ -330,7 +330,7 @@ class HTTPResponse
     /**
      * Send this HTTPResponse to the browser
      */
-    public function output()
+    public function output(): void
     {
         // Attach appropriate X-Include-JavaScript and X-Include-CSS headers
         if (Director::is_ajax()) {
@@ -371,7 +371,7 @@ EOT
     /**
      * Output HTTP headers to the browser
      */
-    protected function outputHeaders()
+    protected function outputHeaders(): void
     {
         $headersSent = headers_sent($file, $line);
         if (!$headersSent) {
@@ -402,7 +402,7 @@ EOT
     /**
      * Output body of this response to the browser
      */
-    protected function outputBody()
+    protected function outputBody(): void
     {
         // Only show error pages or generic "friendly" errors if the status code signifies
         // an error, and the response doesn't have any body yet that might contain
@@ -426,7 +426,7 @@ EOT
      *
      * @return bool
      */
-    public function isFinished()
+    public function isFinished(): bool
     {
         return $this->isRedirect() || $this->isError();
     }
@@ -436,7 +436,7 @@ EOT
      *
      * @return bool
      */
-    public function isRedirect()
+    public function isRedirect(): bool
     {
         return in_array($this->getStatusCode(), self::$redirect_codes);
     }

--- a/src/Control/HTTPResponse_Exception.php
+++ b/src/Control/HTTPResponse_Exception.php
@@ -28,7 +28,7 @@ class HTTPResponse_Exception extends Exception
      * @param string $statusDescription
      * @see HTTPResponse::__construct()
      */
-    public function __construct($body = null, $statusCode = null, $statusDescription = null)
+    public function __construct(string|SilverStripe\Control\HTTPResponse $body = null, int $statusCode = null, string $statusDescription = null): void
     {
         if ($body instanceof HTTPResponse) {
             // statusCode and statusDescription should override whatever is passed in the body
@@ -55,7 +55,7 @@ class HTTPResponse_Exception extends Exception
     /**
      * @return HTTPResponse
      */
-    public function getResponse()
+    public function getResponse(): SilverStripe\Control\HTTPResponse
     {
         return $this->response;
     }
@@ -63,7 +63,7 @@ class HTTPResponse_Exception extends Exception
     /**
      * @param HTTPResponse $response
      */
-    public function setResponse(HTTPResponse $response)
+    public function setResponse(HTTPResponse $response): void
     {
         $this->response = $response;
     }

--- a/src/Control/HTTPStreamResponse.php
+++ b/src/Control/HTTPStreamResponse.php
@@ -35,7 +35,7 @@ class HTTPStreamResponse extends HTTPResponse
      * @param int $statusCode The numeric status code - 200, 404, etc
      * @param string $statusDescription The text to be given alongside the status code.
      */
-    public function __construct($stream, $contentLength, $statusCode = null, $statusDescription = null)
+    public function __construct(resource $stream, int $contentLength, $statusCode = null, $statusDescription = null): void
     {
         parent::__construct(null, $statusCode, $statusDescription);
         $this->setStream($stream);
@@ -49,7 +49,7 @@ class HTTPStreamResponse extends HTTPResponse
      *
      * @return bool
      */
-    protected function isSeekable()
+    protected function isSeekable(): bool
     {
         $stream = $this->getStream();
         if (!$stream) {
@@ -62,7 +62,7 @@ class HTTPStreamResponse extends HTTPResponse
     /**
      * @return resource
      */
-    public function getStream()
+    public function getStream(): resource
     {
         return $this->stream;
     }
@@ -71,7 +71,7 @@ class HTTPStreamResponse extends HTTPResponse
      * @param resource $stream
      * @return $this
      */
-    public function setStream($stream)
+    public function setStream(resource $stream): SilverStripe\Control\HTTPStreamResponse
     {
         $this->setBody(null);
         $this->stream = $stream;
@@ -83,12 +83,12 @@ class HTTPStreamResponse extends HTTPResponse
      *
      * @return string
      */
-    public function getSavedBody()
+    public function getSavedBody(): null
     {
         return parent::getBody();
     }
 
-    public function getBody()
+    public function getBody(): string
     {
         $body = $this->getSavedBody();
         if (isset($body)) {
@@ -116,7 +116,7 @@ class HTTPStreamResponse extends HTTPResponse
      * @return mixed Result of $callback($stream) or null if no stream available
      * @throws BadMethodCallException Throws exception if stream can't be re-consumed
      */
-    protected function consumeStream($callback)
+    protected function consumeStream(callable $callback): null|string
     {
         // Load from stream
         $stream = $this->getStream();
@@ -142,7 +142,7 @@ class HTTPStreamResponse extends HTTPResponse
     /**
      * Output body of this response to the browser
      */
-    protected function outputBody()
+    protected function outputBody(): void
     {
         // If the output has been overwritten, or the stream is irreversible and has
         // already been consumed, return the cached body.

--- a/src/Control/Middleware/AllowedHostsMiddleware.php
+++ b/src/Control/Middleware/AllowedHostsMiddleware.php
@@ -21,7 +21,7 @@ class AllowedHostsMiddleware implements HTTPMiddleware
     /**
      * @return array List of allowed Host header values
      */
-    public function getAllowedHosts()
+    public function getAllowedHosts(): null
     {
         return $this->allowedHosts;
     }
@@ -33,7 +33,7 @@ class AllowedHostsMiddleware implements HTTPMiddleware
      * @param array|string $allowedHosts
      * @return $this
      */
-    public function setAllowedHosts($allowedHosts)
+    public function setAllowedHosts($allowedHosts): SilverStripe\Control\Middleware\AllowedHostsMiddleware
     {
         if (is_string($allowedHosts)) {
             $allowedHosts = preg_split('/ *, */', $allowedHosts ?? '');
@@ -45,7 +45,7 @@ class AllowedHostsMiddleware implements HTTPMiddleware
     /**
      * @inheritdoc
      */
-    public function process(HTTPRequest $request, callable $delegate)
+    public function process(HTTPRequest $request, callable $delegate): SilverStripe\Control\HTTPResponse
     {
         $allowedHosts = $this->getAllowedHosts();
 

--- a/src/Control/Middleware/CanonicalURLMiddleware.php
+++ b/src/Control/Middleware/CanonicalURLMiddleware.php
@@ -79,7 +79,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
     /**
      * @return array
      */
-    public function getForceSSLPatterns()
+    public function getForceSSLPatterns(): array
     {
         return $this->forceSSLPatterns ?: [];
     }
@@ -88,7 +88,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      * @param array $forceSSLPatterns
      * @return $this
      */
-    public function setForceSSLPatterns($forceSSLPatterns)
+    public function setForceSSLPatterns(array $forceSSLPatterns): SilverStripe\Control\Middleware\CanonicalURLMiddleware
     {
         $this->forceSSLPatterns = $forceSSLPatterns;
         return $this;
@@ -97,7 +97,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
     /**
      * @return string
      */
-    public function getForceSSLDomain()
+    public function getForceSSLDomain(): null|string
     {
         return $this->forceSSLDomain;
     }
@@ -106,7 +106,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      * @param string $forceSSLDomain
      * @return $this
      */
-    public function setForceSSLDomain($forceSSLDomain)
+    public function setForceSSLDomain(string $forceSSLDomain): SilverStripe\Control\Middleware\CanonicalURLMiddleware
     {
         $this->forceSSLDomain = $forceSSLDomain;
         return $this;
@@ -115,7 +115,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
     /**
      * @return bool
      */
-    public function getForceWWW()
+    public function getForceWWW(): bool|null
     {
         return $this->forceWWW;
     }
@@ -124,7 +124,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      * @param bool $forceWWW
      * @return $this
      */
-    public function setForceWWW($forceWWW)
+    public function setForceWWW(bool $forceWWW): SilverStripe\Control\Middleware\CanonicalURLMiddleware
     {
         $this->forceWWW = $forceWWW;
         return $this;
@@ -133,7 +133,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
     /**
      * @return bool
      */
-    public function getForceSSL()
+    public function getForceSSL(): bool|null
     {
         return $this->forceSSL;
     }
@@ -142,7 +142,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      * @param bool $forceSSL
      * @return $this
      */
-    public function setForceSSL($forceSSL)
+    public function setForceSSL(bool $forceSSL): SilverStripe\Control\Middleware\CanonicalURLMiddleware
     {
         $this->forceSSL = $forceSSL;
         return $this;
@@ -152,7 +152,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      * @param bool|null $forceBasicAuth
      * @return $this
      */
-    public function setForceBasicAuthToSSL($forceBasicAuth)
+    public function setForceBasicAuthToSSL(bool $forceBasicAuth): Mock_CanonicalURLMiddleware_0731bbb7
     {
         $this->forceBasicAuthToSSL = $forceBasicAuth;
         return $this;
@@ -161,7 +161,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
     /**
      * @return bool
      */
-    public function getForceBasicAuthToSSL()
+    public function getForceBasicAuthToSSL(): bool
     {
         // Check if explicitly set
         if (isset($this->forceBasicAuthToSSL)) {
@@ -178,7 +178,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      * @param callable $delegate
      * @return HTTPResponse
      */
-    public function process(HTTPRequest $request, callable $delegate)
+    public function process(HTTPRequest $request, callable $delegate): SilverStripe\Control\HTTPResponse
     {
         // Handle any redirects
         $redirect = $this->getRedirect($request);
@@ -204,7 +204,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      * @param HTTPRequest $request Pre-validated request object
      * @return HTTPResponse|null If a redirect is needed return the response
      */
-    protected function getRedirect(HTTPRequest $request)
+    protected function getRedirect(HTTPRequest $request): null|SilverStripe\Control\HTTPResponse
     {
         // Check global disable
         if (!$this->isEnabled()) {
@@ -244,7 +244,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      * @param HTTPRequest|null $request Allow HTTPRequest to be used for the base comparison
      * @throws HTTPResponse_Exception
      */
-    public function throwRedirectIfNeeded(HTTPRequest $request = null)
+    public function throwRedirectIfNeeded(HTTPRequest $request = null): void
     {
         $request = $this->getOrValidateRequest($request);
         if (!$request) {
@@ -262,7 +262,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      * @param HTTPRequest $request
      * @return HTTPRequest|null
      */
-    protected function getOrValidateRequest(HTTPRequest $request = null)
+    protected function getOrValidateRequest(HTTPRequest $request = null): SilverStripe\Control\HTTPRequest|null
     {
         if ($request instanceof HTTPRequest) {
             return $request;
@@ -279,7 +279,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      * @param HTTPRequest $request
      * @return bool
      */
-    protected function requiresSSL(HTTPRequest $request)
+    protected function requiresSSL(HTTPRequest $request): bool
     {
         // Check if force SSL is enabled
         if (!$this->getForceSSL()) {
@@ -312,7 +312,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
     /**
      * @return int
      */
-    public function getRedirectType()
+    public function getRedirectType(): int
     {
         return $this->redirectType;
     }
@@ -332,7 +332,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      *
      * @return array|bool
      */
-    public function getEnabledEnvs()
+    public function getEnabledEnvs(): bool
     {
         return $this->enabledEnvs;
     }
@@ -345,7 +345,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      * @param array|bool $enabledEnvs
      * @return $this
      */
-    public function setEnabledEnvs($enabledEnvs)
+    public function setEnabledEnvs(array|bool $enabledEnvs): SilverStripe\Control\Middleware\CanonicalURLMiddleware
     {
         $this->enabledEnvs = $enabledEnvs;
         return $this;
@@ -354,7 +354,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
     /**
      * Ensure this middleware is enabled
      */
-    protected function isEnabled()
+    protected function isEnabled(): bool
     {
         // At least one redirect must be enabled
         if (!$this->getForceWWW() && !$this->getForceSSL()) {
@@ -382,7 +382,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      * @param HTTPResponse $response
      * @return bool
      */
-    protected function hasBasicAuthPrompt(HTTPResponse $response = null)
+    protected function hasBasicAuthPrompt(HTTPResponse $response = null): bool
     {
         if (!$response) {
             return false;
@@ -398,7 +398,7 @@ class CanonicalURLMiddleware implements HTTPMiddleware
      * @param string $host
      * @return HTTPResponse
      */
-    protected function redirectToScheme(HTTPRequest $request, $scheme, $host = null)
+    protected function redirectToScheme(HTTPRequest $request, string $scheme, string $host = null): SilverStripe\Control\HTTPResponse
     {
         if (!$host) {
             $host = $request->getHost();

--- a/src/Control/Middleware/ChangeDetectionMiddleware.php
+++ b/src/Control/Middleware/ChangeDetectionMiddleware.php
@@ -22,7 +22,7 @@ class ChangeDetectionMiddleware implements HTTPMiddleware
      * @param callable $delegate
      * @return HTTPResponse
      */
-    public function process(HTTPRequest $request, callable $delegate)
+    public function process(HTTPRequest $request, callable $delegate): SilverStripe\Control\HTTPResponse
     {
         /** @var HTTPResponse $response */
         $response = $delegate($request);
@@ -62,7 +62,7 @@ class ChangeDetectionMiddleware implements HTTPMiddleware
      * @param HTTPResponse|string $response
      * @return string|false
      */
-    protected function generateETag(HTTPResponse $response)
+    protected function generateETag(HTTPResponse $response): bool
     {
         // Existing e-tag
         $etag = $response->getHeader('ETag');

--- a/src/Control/Middleware/ConfirmationMiddleware.php
+++ b/src/Control/Middleware/ConfirmationMiddleware.php
@@ -66,7 +66,7 @@ class ConfirmationMiddleware implements HTTPMiddleware
      *
      * @param ConfirmationMiddleware\Rule[] $rules Rules to check requests against
      */
-    public function __construct(...$rules)
+    public function __construct(...$rules): void
     {
         $this->rules = $rules;
         $this->declineUrl = Director::baseURL();
@@ -80,7 +80,7 @@ class ConfirmationMiddleware implements HTTPMiddleware
      *
      * @return string URL of the confirmation form
      */
-    protected function getConfirmationUrl(HTTPRequest $request, $confirmationStorageId)
+    protected function getConfirmationUrl(HTTPRequest $request, string $confirmationStorageId): string
     {
         $url = $this->confirmationFormUrl;
 
@@ -103,7 +103,7 @@ class ConfirmationMiddleware implements HTTPMiddleware
      *
      * @return string URL
      */
-    protected function generateDeclineUrlForRequest(HTTPRequest $request)
+    protected function generateDeclineUrlForRequest(HTTPRequest $request): string
     {
         return $this->declineUrl;
     }
@@ -129,7 +129,7 @@ class ConfirmationMiddleware implements HTTPMiddleware
      *
      * @return bool
      */
-    public function canBypass(HTTPRequest $request)
+    public function canBypass(HTTPRequest $request): bool
     {
         foreach ($this->bypasses as $bypass) {
             if ($bypass->checkRequestForBypass($request)) {
@@ -147,7 +147,7 @@ class ConfirmationMiddleware implements HTTPMiddleware
      *
      * @return Confirmation\Item[] list of confirmation items
      */
-    public function getConfirmationItems(HTTPRequest $request)
+    public function getConfirmationItems(HTTPRequest $request): array
     {
         $confirmationItems = [];
 
@@ -171,7 +171,7 @@ class ConfirmationMiddleware implements HTTPMiddleware
      *
      * @return HTTPResponse
      */
-    protected function buildConfirmationRedirect(HTTPRequest $request, Confirmation\Storage $storage, array $confirmationItems)
+    protected function buildConfirmationRedirect(HTTPRequest $request, Confirmation\Storage $storage, array $confirmationItems): SilverStripe\Control\HTTPResponse
     {
         $storage->cleanup();
 
@@ -199,7 +199,7 @@ class ConfirmationMiddleware implements HTTPMiddleware
      *
      * @return HTTPResponse
      */
-    protected function processItems(HTTPRequest $request, callable $delegate, $items)
+    protected function processItems(HTTPRequest $request, callable $delegate, array $items): SilverStripe\Control\HTTPResponse
     {
         $storage = Injector::inst()->createWithArgs(Confirmation\Storage::class, [$request->getSession(), $this->confirmationId, false]);
 
@@ -240,12 +240,12 @@ class ConfirmationMiddleware implements HTTPMiddleware
      *
      * @return null|HTTPResponse
      */
-    protected function confirmedEffect(HTTPRequest $request)
+    protected function confirmedEffect(HTTPRequest $request): null
     {
         return null;
     }
 
-    public function process(HTTPRequest $request, callable $delegate)
+    public function process(HTTPRequest $request, callable $delegate): null|SilverStripe\Control\HTTPResponse
     {
         if ($this->canBypass($request)) {
             if ($response = $this->confirmedEffect($request)) {
@@ -269,7 +269,7 @@ class ConfirmationMiddleware implements HTTPMiddleware
      *
      * @return $this
      */
-    public function setConfirmationStorageId($id)
+    public function setConfirmationStorageId(string $id): SilverStripe\Control\Middleware\URLSpecialsMiddleware
     {
         $this->confirmationId = $id;
         return $this;
@@ -282,7 +282,7 @@ class ConfirmationMiddleware implements HTTPMiddleware
      *
      * @return $this
      */
-    public function setConfirmationFormUrl($url)
+    public function setConfirmationFormUrl(string $url): SilverStripe\Control\Middleware\URLSpecialsMiddleware
     {
         $this->confirmationFormUrl = $url;
         return $this;
@@ -295,7 +295,7 @@ class ConfirmationMiddleware implements HTTPMiddleware
      *
      * @return $this
      */
-    public function setBypasses($bypasses)
+    public function setBypasses(array $bypasses): SilverStripe\Control\Middleware\URLSpecialsMiddleware
     {
         $this->bypasses = $bypasses;
         return $this;

--- a/src/Control/Middleware/ConfirmationMiddleware/AjaxBypass.php
+++ b/src/Control/Middleware/ConfirmationMiddleware/AjaxBypass.php
@@ -18,7 +18,7 @@ class AjaxBypass implements Bypass
      *
      * @return bool
      */
-    public function checkRequestForBypass(HTTPRequest $request)
+    public function checkRequestForBypass(HTTPRequest $request): bool
     {
         return $request->isAjax();
     }

--- a/src/Control/Middleware/ConfirmationMiddleware/CliBypass.php
+++ b/src/Control/Middleware/ConfirmationMiddleware/CliBypass.php
@@ -18,7 +18,7 @@ class CliBypass implements Bypass
      *
      * @return bool
      */
-    public function checkRequestForBypass(HTTPRequest $request)
+    public function checkRequestForBypass(HTTPRequest $request): bool
     {
         return Director::is_cli();
     }

--- a/src/Control/Middleware/ConfirmationMiddleware/EnvironmentBypass.php
+++ b/src/Control/Middleware/ConfirmationMiddleware/EnvironmentBypass.php
@@ -24,7 +24,7 @@ class EnvironmentBypass implements Bypass
      *
      * @param string[] ...$environments
      */
-    public function __construct(...$environments)
+    public function __construct(...$environments): void
     {
         $this->environments = $environments;
     }
@@ -61,7 +61,7 @@ class EnvironmentBypass implements Bypass
      *
      * @return bool
      */
-    public function checkRequestForBypass(HTTPRequest $request)
+    public function checkRequestForBypass(HTTPRequest $request): bool
     {
         return in_array(Director::get_environment_type(), $this->environments ?? [], true);
     }

--- a/src/Control/Middleware/ConfirmationMiddleware/GetParameter.php
+++ b/src/Control/Middleware/ConfirmationMiddleware/GetParameter.php
@@ -22,7 +22,7 @@ class GetParameter implements Rule, Bypass
      *
      * @param string $name
      */
-    public function __construct($name)
+    public function __construct(string $name): void
     {
         $this->setName($name);
     }
@@ -32,7 +32,7 @@ class GetParameter implements Rule, Bypass
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -44,7 +44,7 @@ class GetParameter implements Rule, Bypass
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName(string $name): SilverStripe\Control\Middleware\ConfirmationMiddleware\GetParameter
     {
         $this->name = $name;
         return $this;
@@ -58,7 +58,7 @@ class GetParameter implements Rule, Bypass
      *
      * @return Confirmation\Item
      */
-    protected function buildConfirmationItem($token, $value)
+    protected function buildConfirmationItem(string $token, string $value): SilverStripe\Security\Confirmation\Item
     {
         return new Confirmation\Item(
             $token,
@@ -75,7 +75,7 @@ class GetParameter implements Rule, Bypass
      *
      * @return string
      */
-    protected function generateToken($path, $value)
+    protected function generateToken(string $path, string $value): string
     {
         return sprintf('%s::%s?%s=%s', static::class, $path, $this->name, $value);
     }
@@ -87,17 +87,17 @@ class GetParameter implements Rule, Bypass
      *
      * @return bool
      */
-    protected function checkRequestHasParameter(HTTPRequest $request)
+    protected function checkRequestHasParameter(HTTPRequest $request): bool
     {
         return array_key_exists($this->name, $request->getVars() ?? []);
     }
 
-    public function checkRequestForBypass(HTTPRequest $request)
+    public function checkRequestForBypass(HTTPRequest $request): bool
     {
         return $this->checkRequestHasParameter($request);
     }
 
-    public function getRequestConfirmationItem(HTTPRequest $request)
+    public function getRequestConfirmationItem(HTTPRequest $request): null|SilverStripe\Security\Confirmation\Item
     {
         if (!$this->checkRequestHasParameter($request)) {
             return null;

--- a/src/Control/Middleware/ConfirmationMiddleware/HttpMethodBypass.php
+++ b/src/Control/Middleware/ConfirmationMiddleware/HttpMethodBypass.php
@@ -21,7 +21,7 @@ class HttpMethodBypass implements Bypass
      *
      * @param string[] ...$methods
      */
-    public function __construct(...$methods)
+    public function __construct(...$methods): void
     {
         $this->addMethods(...$methods);
     }
@@ -31,7 +31,7 @@ class HttpMethodBypass implements Bypass
      *
      * @return string[]
      */
-    public function getMethods()
+    public function getMethods(): array
     {
         return $this->methods;
     }
@@ -43,7 +43,7 @@ class HttpMethodBypass implements Bypass
      *
      * return $this
      */
-    public function addMethods(...$methods)
+    public function addMethods(...$methods): SilverStripe\Control\Middleware\ConfirmationMiddleware\HttpMethodBypass
     {
         // uppercase and exclude empties
         $methods = array_reduce(
@@ -74,7 +74,7 @@ class HttpMethodBypass implements Bypass
      *
      * @return bool
      */
-    public function checkRequestForBypass(HTTPRequest $request)
+    public function checkRequestForBypass(HTTPRequest $request): bool
     {
         return in_array($request->httpMethod(), $this->methods ?? [], true);
     }

--- a/src/Control/Middleware/ConfirmationMiddleware/Url.php
+++ b/src/Control/Middleware/ConfirmationMiddleware/Url.php
@@ -33,7 +33,7 @@ class Url implements Rule, Bypass
      * @param string[]|string|null $httpMethods to match against
      * @param string[]|null $params a list of GET parameters
      */
-    public function __construct($path, $httpMethods = null, $params = null)
+    public function __construct(string $path, array|string $httpMethods = null, array $params = null): void
     {
         $this->setPath($path);
         $this->setParams($params);
@@ -53,7 +53,7 @@ class Url implements Rule, Bypass
      *
      * @return $this
      */
-    public function addHttpMethods(...$methods)
+    public function addHttpMethods(...$methods): SilverStripe\Control\Middleware\ConfirmationMiddleware\Url
     {
         $this->httpMethods->addMethods(...$methods);
         return $this;
@@ -64,7 +64,7 @@ class Url implements Rule, Bypass
      *
      * @return string[]
      */
-    public function getHttpMethods()
+    public function getHttpMethods(): array
     {
         return $this->httpMethods->getMethods();
     }
@@ -84,18 +84,18 @@ class Url implements Rule, Bypass
      *
      * @return $this
      */
-    public function setParams($params = null)
+    public function setParams(array $params = null): SilverStripe\Control\Middleware\ConfirmationMiddleware\Url
     {
         $this->params = $params;
         return $this;
     }
 
-    public function checkRequestForBypass(HTTPRequest $request)
+    public function checkRequestForBypass(HTTPRequest $request): bool
     {
         return $this->checkRequest($request);
     }
 
-    public function getRequestConfirmationItem(HTTPRequest $request)
+    public function getRequestConfirmationItem(HTTPRequest $request): null|SilverStripe\Security\Confirmation\Item
     {
         if (!$this->checkRequest($request)) {
             return null;
@@ -114,7 +114,7 @@ class Url implements Rule, Bypass
      *
      * @return bool
      */
-    public function checkRequest(HTTPRequest $request)
+    public function checkRequest(HTTPRequest $request): bool
     {
         $httpMethods = $this->getHttpMethods();
 
@@ -161,7 +161,7 @@ class Url implements Rule, Bypass
      *
      * @return bool
      */
-    protected function checkPath($path)
+    protected function checkPath(string $path): bool
     {
         return $this->getPath() === $this->normalisePath($path);
     }
@@ -174,7 +174,7 @@ class Url implements Rule, Bypass
      *
      * @return Confirmation\Item
      */
-    protected function buildConfirmationItem($token, $url)
+    protected function buildConfirmationItem(string $token, string $url): SilverStripe\Security\Confirmation\Item
     {
         return new Confirmation\Item(
             $token,
@@ -191,7 +191,7 @@ class Url implements Rule, Bypass
      *
      * @return string
      */
-    protected function generateToken($httpMethod, $path)
+    protected function generateToken(string $httpMethod, string $path): string
     {
         return sprintf('%s::%s|%s', static::class, $httpMethod, $path);
     }

--- a/src/Control/Middleware/ConfirmationMiddleware/UrlPathStartswith.php
+++ b/src/Control/Middleware/ConfirmationMiddleware/UrlPathStartswith.php
@@ -17,7 +17,7 @@ class UrlPathStartswith implements Rule, Bypass
      *
      * @param string $path
      */
-    public function __construct($path)
+    public function __construct(string $path): void
     {
         $this->setPath($path);
     }
@@ -30,7 +30,7 @@ class UrlPathStartswith implements Rule, Bypass
      *
      * @return Confirmation\Item
      */
-    protected function buildConfirmationItem($token, $url)
+    protected function buildConfirmationItem(string $token, string $url): SilverStripe\Security\Confirmation\Item
     {
         return new Confirmation\Item(
             $token,
@@ -46,7 +46,7 @@ class UrlPathStartswith implements Rule, Bypass
      *
      * @return string
      */
-    protected function generateToken($path)
+    protected function generateToken(string $path): string
     {
         return sprintf('%s::%s', static::class, $path);
     }
@@ -59,18 +59,18 @@ class UrlPathStartswith implements Rule, Bypass
      *
      * @return bool
      */
-    protected function checkPath($path)
+    protected function checkPath(string $path): bool
     {
         $targetPath = $this->getPath();
         return strncmp($this->normalisePath($path) ?? '', $targetPath ?? '', strlen($targetPath ?? '')) === 0;
     }
 
-    public function checkRequestForBypass(HTTPRequest $request)
+    public function checkRequestForBypass(HTTPRequest $request): bool
     {
         return $this->checkPath($request->getURL());
     }
 
-    public function getRequestConfirmationItem(HTTPRequest $request)
+    public function getRequestConfirmationItem(HTTPRequest $request): SilverStripe\Security\Confirmation\Item|null
     {
         if (!$this->checkPath($request->getURL())) {
             return null;

--- a/src/Control/Middleware/ConfirmationMiddleware/UrlPathStartswithCaseInsensitive.php
+++ b/src/Control/Middleware/ConfirmationMiddleware/UrlPathStartswithCaseInsensitive.php
@@ -10,7 +10,7 @@ use SilverStripe\Security\Confirmation;
  */
 class UrlPathStartswithCaseInsensitive extends UrlPathStartswith
 {
-    protected function checkPath($path)
+    protected function checkPath(string $path): bool
     {
         $pattern = $this->getPath();
 

--- a/src/Control/Middleware/ExecMetricMiddleware.php
+++ b/src/Control/Middleware/ExecMetricMiddleware.php
@@ -14,7 +14,7 @@ use SilverStripe\Dev\Debug;
 class ExecMetricMiddleware implements HTTPMiddleware
 {
 
-    public function process(HTTPRequest $request, callable $delegate)
+    public function process(HTTPRequest $request, callable $delegate): SilverStripe\Control\HTTPResponse
     {
         if (!$this->showMetric($request)) {
             return $delegate($request);
@@ -41,7 +41,7 @@ class ExecMetricMiddleware implements HTTPMiddleware
      * @param HTTPRequest $request
      * @return bool
      */
-    private function showMetric(HTTPRequest $request)
+    private function showMetric(HTTPRequest $request): bool
     {
         return Director::isDev() && array_key_exists('execmetric', $request->getVars() ?? []);
     }

--- a/src/Control/Middleware/FlushMiddleware.php
+++ b/src/Control/Middleware/FlushMiddleware.php
@@ -12,7 +12,7 @@ use SilverStripe\Core\Flushable;
  */
 class FlushMiddleware implements HTTPMiddleware
 {
-    public function process(HTTPRequest $request, callable $delegate)
+    public function process(HTTPRequest $request, callable $delegate): SilverStripe\Control\HTTPResponse
     {
         if (Director::isManifestFlushed()) {
             // Disable cache when flushing

--- a/src/Control/Middleware/HTTPCacheControlMiddleware.php
+++ b/src/Control/Middleware/HTTPCacheControlMiddleware.php
@@ -36,7 +36,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @return HTTPResponse
      * @throws HTTPResponse_Exception
      */
-    public function process(HTTPRequest $request, callable $delegate)
+    public function process(HTTPRequest $request, callable $delegate): SilverStripe\Control\HTTPResponse
     {
         try {
             $response = $delegate($request);
@@ -198,7 +198,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      *
      * @return array
      */
-    public function getVary()
+    public function getVary(): array
     {
         // Explicitly set vary
         if (isset($this->vary)) {
@@ -216,7 +216,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param string|array $vary
      * @return $this
      */
-    public function addVary($vary)
+    public function addVary(string $vary): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         $combied = $this->combineVary($this->getVary(), $vary);
         $this->setVary($combied);
@@ -229,7 +229,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param array|string $vary
      * @return $this
      */
-    public function setVary($vary)
+    public function setVary(string|array $vary): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         $this->vary = $this->combineVary($vary);
         return $this;
@@ -241,7 +241,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param string|array[] $varies Each vary as a separate arg
      * @return array
      */
-    protected function combineVary(...$varies)
+    protected function combineVary(...$varies): array
     {
         $merged = [];
         foreach ($varies as $vary) {
@@ -278,7 +278,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param string $state
      * @return $this
      */
-    protected function setState($state)
+    protected function setState(string $state): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         if (!array_key_exists($state, $this->stateDirectives ?? [])) {
             throw new InvalidArgumentException("Invalid state {$state}");
@@ -292,7 +292,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      *
      * @return string
      */
-    public function getState()
+    public function getState(): string
     {
         return $this->state ?: $this->config()->get('defaultState');
     }
@@ -311,7 +311,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @return bool True if the given change is accepted, and that the internal
      * level threshold is updated (if necessary) to the new minimum level.
      */
-    protected function applyChangeLevel($level, $force)
+    protected function applyChangeLevel(int $level, bool $force): bool
     {
         $forcingLevel = $level + ($force ? self::LEVEL_FORCED : 0);
         if ($forcingLevel < $this->getForcingLevel()) {
@@ -332,7 +332,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * String or int value assign a specific value.
      * @return $this
      */
-    public function setStateDirective($states, $directive, $value = true)
+    public function setStateDirective(array $states, string $directive, int|bool|string $value = true): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         if ($value === null) {
             throw new InvalidArgumentException("Invalid directive value");
@@ -379,7 +379,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param string $directive
      * @return $this
      */
-    public function removeStateDirective($states, $directive)
+    public function removeStateDirective(array $states, string $directive): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         $this->setStateDirective($states, $directive, false);
         return $this;
@@ -392,7 +392,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param string $directive
      * @return bool
      */
-    public function hasStateDirective($state, $directive)
+    public function hasStateDirective(string $state, string $directive): bool
     {
         $directive = strtolower($directive ?? '');
         return isset($this->stateDirectives[$state][$directive]);
@@ -404,7 +404,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param string $directive
      * @return bool
      */
-    public function hasDirective($directive)
+    public function hasDirective(string $directive): bool
     {
         return $this->hasStateDirective($this->getState(), $directive);
     }
@@ -418,7 +418,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param string $directive
      * @return int|string|bool
      */
-    public function getStateDirective($state, $directive)
+    public function getStateDirective(string $state, string $directive): bool|int|string
     {
         $directive = strtolower($directive ?? '');
         if (isset($this->stateDirectives[$state][$directive])) {
@@ -433,7 +433,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param string $directive
      * @return bool|int|string
      */
-    public function getDirective($directive)
+    public function getDirective(string $directive): bool|int|string
     {
         return $this->getStateDirective($this->getState(), $directive);
     }
@@ -444,7 +444,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param string $state
      * @return array
      */
-    public function getStateDirectives($state)
+    public function getStateDirectives(string $state): array
     {
         return $this->stateDirectives[$state];
     }
@@ -454,7 +454,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      *
      * @return array
      */
-    public function getDirectives()
+    public function getDirectives(): array
     {
         return $this->getStateDirectives($this->getState());
     }
@@ -468,7 +468,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      *
      * @return $this
      */
-    public function setNoStore($noStore = true)
+    public function setNoStore(bool $noStore = true): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         // Affect all non-disabled states
         $applyTo = [self::STATE_ENABLED, self::STATE_PRIVATE, self::STATE_PUBLIC];
@@ -489,7 +489,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param bool $noCache
      * @return $this
      */
-    public function setNoCache($noCache = true)
+    public function setNoCache(bool $noCache = true): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         // Affect all non-disabled states
         $applyTo = [self::STATE_ENABLED, self::STATE_PRIVATE, self::STATE_PUBLIC];
@@ -512,7 +512,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param int $age
      * @return $this
      */
-    public function setMaxAge($age)
+    public function setMaxAge(int|string $age): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         // Affect all non-disabled states
         $applyTo = [self::STATE_ENABLED, self::STATE_PRIVATE, self::STATE_PUBLIC];
@@ -532,7 +532,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param int $age
      * @return $this
      */
-    public function setSharedMaxAge($age)
+    public function setSharedMaxAge(string $age): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         // Affect all non-disabled states
         $applyTo = [self::STATE_ENABLED, self::STATE_PRIVATE, self::STATE_PUBLIC];
@@ -551,7 +551,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param bool $mustRevalidate
      * @return $this
      */
-    public function setMustRevalidate($mustRevalidate = true)
+    public function setMustRevalidate($mustRevalidate = true): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         $applyTo = [self::STATE_ENABLED, self::STATE_PRIVATE, self::STATE_PUBLIC];
         $this->setStateDirective($applyTo, 'must-revalidate', $mustRevalidate);
@@ -572,7 +572,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param int $maxAge Shortcut for `setMaxAge()`, which is required to actually enable the cache.
      * @return $this
      */
-    public function enableCache($force = false, $maxAge = null)
+    public function enableCache(bool $force = false, int $maxAge = null): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         // Only execute this if its forcing level is high enough
         if ($this->applyChangeLevel(self::LEVEL_ENABLED, $force)) {
@@ -603,7 +603,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param bool $force Force the cache to disabled even if it's forced private or public
      * @return $this
      */
-    public function disableCache($force = false)
+    public function disableCache(bool $force = false): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         // Only execute this if its forcing level is high enough
         if ($this->applyChangeLevel(self::LEVEL_DISABLED, $force)) {
@@ -623,7 +623,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param bool $force Force the cache to private even if it's forced public
      * @return $this
      */
-    public function privateCache($force = false)
+    public function privateCache(bool $force = false): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         // Only execute this if its forcing level is high enough
         if ($this->applyChangeLevel(self::LEVEL_PRIVATE, $force)) {
@@ -644,7 +644,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param int $maxAge Shortcut for `setMaxAge()`, which is required to actually enable the cache.
      * @return $this
      */
-    public function publicCache($force = false, $maxAge = null)
+    public function publicCache(bool $force = false, int $maxAge = null): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         // Only execute this if its forcing level is high enough
         if ($this->applyChangeLevel(self::LEVEL_PUBLIC, $force)) {
@@ -665,7 +665,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      *
      * @return $this
      */
-    public function applyToResponse($response)
+    public function applyToResponse(SilverStripe\Control\HTTPResponse $response): SilverStripe\Control\Middleware\HTTPCacheControlMiddleware
     {
         $headers = $this->generateHeadersFor($response);
         foreach ($headers as $name => $value) {
@@ -681,7 +681,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      *
      * @return string
      */
-    protected function generateCacheHeader()
+    protected function generateCacheHeader(): string
     {
         $cacheControl = [];
         foreach ($this->getDirectives() as $directive => $value) {
@@ -700,7 +700,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param HTTPResponse $response
      * @return array
      */
-    public function generateHeadersFor(HTTPResponse $response)
+    public function generateHeadersFor(HTTPResponse $response): array
     {
         return array_filter([
             'Last-Modified' => $this->generateLastModifiedHeader(),
@@ -713,7 +713,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
     /**
      * Reset registered http cache control and force a fresh instance to be built
      */
-    public static function reset()
+    public static function reset(): void
     {
         Injector::inst()->unregisterNamedObject(__CLASS__);
     }
@@ -721,7 +721,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
     /**
      * @return int
      */
-    protected function getForcingLevel()
+    protected function getForcingLevel(): int
     {
         if (isset($this->forcingLevel)) {
             return $this->forcingLevel;
@@ -735,7 +735,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param HTTPResponse $response
      * @return string|null
      */
-    protected function generateVaryHeader(HTTPResponse $response)
+    protected function generateVaryHeader(HTTPResponse $response): string|null
     {
         // split the current vary header into it's parts and merge it with the config settings
         // to create a list of unique vary values
@@ -754,7 +754,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      *
      * @return string|null
      */
-    protected function generateLastModifiedHeader()
+    protected function generateLastModifiedHeader(): null
     {
         if (!$this->modificationDate) {
             return null;
@@ -767,7 +767,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      *
      * @return null|string
      */
-    protected function generateExpiresHeader()
+    protected function generateExpiresHeader(): null|string
     {
         $maxAge = $this->getDirective('max-age');
         if ($maxAge === false) {
@@ -785,7 +785,7 @@ class HTTPCacheControlMiddleware implements HTTPMiddleware, Resettable
      * @param HTTPRequest $request
      * @param HTTPResponse $response
      */
-    protected function augmentState(HTTPRequest $request, HTTPResponse $response)
+    protected function augmentState(HTTPRequest $request, HTTPResponse $response): void
     {
         // Errors disable cache (unless some errors are cached intentionally by usercode)
         if ($response->isError() || $response->isRedirect()) {

--- a/src/Control/Middleware/PermissionAwareConfirmationMiddleware.php
+++ b/src/Control/Middleware/PermissionAwareConfirmationMiddleware.php
@@ -63,7 +63,7 @@ class PermissionAwareConfirmationMiddleware extends ConfirmationMiddleware
      *
      * @return $this
      */
-    public function setAffectedPermissions($permissions)
+    public function setAffectedPermissions(array $permissions): SilverStripe\Control\Middleware\URLSpecialsMiddleware
     {
         $this->affectedPermissions = $permissions;
         return $this;
@@ -90,7 +90,7 @@ class PermissionAwareConfirmationMiddleware extends ConfirmationMiddleware
      *
      * @return $this
      */
-    public function setEnforceAuthentication($enforce)
+    public function setEnforceAuthentication(bool $enforce): SilverStripe\Control\Middleware\URLSpecialsMiddleware
     {
         $this->enforceAuthentication = $enforce;
         return $this;

--- a/src/Control/Middleware/RateLimitMiddleware.php
+++ b/src/Control/Middleware/RateLimitMiddleware.php
@@ -36,7 +36,7 @@ class RateLimitMiddleware implements HTTPMiddleware
      * @param callable $delegate
      * @return HTTPResponse
      */
-    public function process(HTTPRequest $request, callable $delegate)
+    public function process(HTTPRequest $request, callable $delegate): SilverStripe\Control\HTTPResponse
     {
         if (!$limiter = $this->getRateLimiter()) {
             $limiter = RateLimiter::create(
@@ -59,7 +59,7 @@ class RateLimitMiddleware implements HTTPMiddleware
      * @param HTTPRequest $request
      * @return string
      */
-    protected function getKeyFromRequest($request)
+    protected function getKeyFromRequest(SilverStripe\Control\HTTPRequest $request): string
     {
         $key = $this->getExtraKey() ? $this->getExtraKey() . '-' : '';
         $key .= $request->getHost() . '-';
@@ -74,7 +74,7 @@ class RateLimitMiddleware implements HTTPMiddleware
     /**
      * @return HTTPResponse
      */
-    protected function getErrorHTTPResponse()
+    protected function getErrorHTTPResponse(): SilverStripe\Control\HTTPResponse
     {
         return HTTPResponse::create('<h1>429 - Too many requests</h1>', 429);
     }
@@ -83,7 +83,7 @@ class RateLimitMiddleware implements HTTPMiddleware
      * @param HTTPResponse $response
      * @param RateLimiter $limiter
      */
-    protected function addHeadersToResponse($response, $limiter)
+    protected function addHeadersToResponse(SilverStripe\Control\HTTPResponse $response, SilverStripe\Core\Cache\RateLimiter $limiter): void
     {
         $response->addHeader('X-RateLimit-Limit', $limiter->getMaxAttempts());
         $response->addHeader('X-RateLimit-Remaining', $remaining = $limiter->getNumAttemptsRemaining());
@@ -98,7 +98,7 @@ class RateLimitMiddleware implements HTTPMiddleware
      * @param string $key
      * @return $this
      */
-    public function setExtraKey($key)
+    public function setExtraKey(string $key): SilverStripe\Control\Middleware\RateLimitMiddleware
     {
         $this->extraKey = $key;
         return $this;
@@ -107,7 +107,7 @@ class RateLimitMiddleware implements HTTPMiddleware
     /**
      * @return string
      */
-    public function getExtraKey()
+    public function getExtraKey(): string
     {
         return $this->extraKey;
     }
@@ -116,7 +116,7 @@ class RateLimitMiddleware implements HTTPMiddleware
      * @param int $maxAttempts
      * @return $this
      */
-    public function setMaxAttempts($maxAttempts)
+    public function setMaxAttempts(int $maxAttempts): SilverStripe\Control\Middleware\RateLimitMiddleware
     {
         $this->maxAttempts = $maxAttempts;
         return $this;
@@ -125,7 +125,7 @@ class RateLimitMiddleware implements HTTPMiddleware
     /**
      * @return int
      */
-    public function getMaxAttempts()
+    public function getMaxAttempts(): int
     {
         return $this->maxAttempts;
     }
@@ -134,7 +134,7 @@ class RateLimitMiddleware implements HTTPMiddleware
      * @param int $decay Time in minutes
      * @return $this
      */
-    public function setDecay($decay)
+    public function setDecay(int $decay): SilverStripe\Control\Middleware\RateLimitMiddleware
     {
         $this->decay = $decay;
         return $this;
@@ -143,7 +143,7 @@ class RateLimitMiddleware implements HTTPMiddleware
     /**
      * @return int
      */
-    public function getDecay()
+    public function getDecay(): int
     {
         return $this->decay;
     }
@@ -161,7 +161,7 @@ class RateLimitMiddleware implements HTTPMiddleware
     /**
      * @return RateLimiter|null
      */
-    public function getRateLimiter()
+    public function getRateLimiter(): null
     {
         return $this->rateLimiter;
     }

--- a/src/Control/Middleware/RequestHandlerMiddlewareAdapter.php
+++ b/src/Control/Middleware/RequestHandlerMiddlewareAdapter.php
@@ -18,7 +18,7 @@ class RequestHandlerMiddlewareAdapter extends RequestHandler
      */
     protected $requestHandler = null;
 
-    public function __construct(RequestHandler $handler = null)
+    public function __construct(RequestHandler $handler = null): void
     {
         if ($handler) {
             $this->setRequestHandler($handler);
@@ -34,7 +34,7 @@ class RequestHandlerMiddlewareAdapter extends RequestHandler
     /**
      * @return RequestHandler
      */
-    public function getRequestHandler()
+    public function getRequestHandler(): SilverStripe\Control\Tests\DirectorTest\TestController
     {
         return $this->requestHandler;
     }
@@ -43,13 +43,13 @@ class RequestHandlerMiddlewareAdapter extends RequestHandler
      * @param RequestHandler $requestHandler
      * @return $this
      */
-    public function setRequestHandler(RequestHandler $requestHandler)
+    public function setRequestHandler(RequestHandler $requestHandler): SilverStripe\Control\Middleware\RequestHandlerMiddlewareAdapter
     {
         $this->requestHandler = $requestHandler;
         return $this;
     }
 
-    public function handleRequest(HTTPRequest $request)
+    public function handleRequest(HTTPRequest $request): SilverStripe\Control\HTTPResponse
     {
         return $this->callMiddleware($request, function (HTTPRequest $request) {
             $this->setRequest($request);

--- a/src/Control/Middleware/TrustedProxyMiddleware.php
+++ b/src/Control/Middleware/TrustedProxyMiddleware.php
@@ -53,7 +53,7 @@ class TrustedProxyMiddleware implements HTTPMiddleware
      *
      * @return string
      */
-    public function getTrustedProxyIPs()
+    public function getTrustedProxyIPs(): string
     {
         return $this->trustedProxyIPs;
     }
@@ -65,7 +65,7 @@ class TrustedProxyMiddleware implements HTTPMiddleware
      * @param string $trustedProxyIPs
      * @return $this
      */
-    public function setTrustedProxyIPs($trustedProxyIPs)
+    public function setTrustedProxyIPs(string $trustedProxyIPs): SilverStripe\Control\Middleware\TrustedProxyMiddleware
     {
         $this->trustedProxyIPs = $trustedProxyIPs;
         return $this;
@@ -76,7 +76,7 @@ class TrustedProxyMiddleware implements HTTPMiddleware
      *
      * @return array
      */
-    public function getProxyHostHeaders()
+    public function getProxyHostHeaders(): array
     {
         return $this->proxyHostHeaders;
     }
@@ -120,7 +120,7 @@ class TrustedProxyMiddleware implements HTTPMiddleware
      *
      * @return array
      */
-    public function getProxySchemeHeaders()
+    public function getProxySchemeHeaders(): array
     {
         return $this->proxySchemeHeaders;
     }
@@ -138,7 +138,7 @@ class TrustedProxyMiddleware implements HTTPMiddleware
         return $this;
     }
 
-    public function process(HTTPRequest $request, callable $delegate)
+    public function process(HTTPRequest $request, callable $delegate): SilverStripe\Control\HTTPResponse
     {
         // If this is a trust proxy
         if ($this->isTrustedProxy($request)) {
@@ -182,7 +182,7 @@ class TrustedProxyMiddleware implements HTTPMiddleware
      * @param HTTPRequest $request
      * @return bool True if the request's source IP is a trusted proxy
      */
-    protected function isTrustedProxy(HTTPRequest $request)
+    protected function isTrustedProxy(HTTPRequest $request): bool
     {
         $trustedIPs = $this->getTrustedProxyIPs();
 
@@ -212,7 +212,7 @@ class TrustedProxyMiddleware implements HTTPMiddleware
      * @param string $headerValue The value from a trusted header
      * @return string The IP address
      */
-    protected function getIPFromHeaderValue($headerValue)
+    protected function getIPFromHeaderValue(string $headerValue): string
     {
         // Sometimes the IP from a load balancer could be "x.x.x.x, y.y.y.y, z.z.z.z"
         // so we need to find the most likely candidate

--- a/src/Control/Middleware/URLSpecialsMiddleware.php
+++ b/src/Control/Middleware/URLSpecialsMiddleware.php
@@ -34,7 +34,7 @@ class URLSpecialsMiddleware extends PermissionAwareConfirmationMiddleware
     /**
      * Initializes the middleware with the required rules
      */
-    public function __construct()
+    public function __construct(): void
     {
         parent::__construct(
             new ConfirmationMiddleware\GetParameter("flush"),
@@ -55,7 +55,7 @@ class URLSpecialsMiddleware extends PermissionAwareConfirmationMiddleware
      *
      * @return null|HTTPResponse redirect to the same url
      */
-    public function buildImpactRedirect(HTTPRequest $request)
+    public function buildImpactRedirect(HTTPRequest $request): void
     {
         $flush = $this->scheduleFlush($request);
         $env_type = $this->setSessionEnvType($request);
@@ -75,7 +75,7 @@ class URLSpecialsMiddleware extends PermissionAwareConfirmationMiddleware
         }
     }
 
-    protected function confirmedEffect(HTTPRequest $request)
+    protected function confirmedEffect(HTTPRequest $request): void
     {
         if ($response = $this->buildImpactRedirect($request)) {
             HTTPCacheControlMiddleware::singleton()->disableCache(true);

--- a/src/Control/NullHTTPRequest.php
+++ b/src/Control/NullHTTPRequest.php
@@ -10,7 +10,7 @@ namespace SilverStripe\Control;
 class NullHTTPRequest extends HTTPRequest
 {
 
-    public function __construct()
+    public function __construct(): void
     {
         parent::__construct(null, null);
     }

--- a/src/Control/PjaxResponseNegotiator.php
+++ b/src/Control/PjaxResponseNegotiator.php
@@ -41,13 +41,13 @@ class PjaxResponseNegotiator
      * @param array $callbacks
      * @param HTTPResponse $response An existing response to reuse (optional)
      */
-    public function __construct($callbacks = [], $response = null)
+    public function __construct(array $callbacks = [], SilverStripe\Control\HTTPResponse $response = null): void
     {
         $this->callbacks = $callbacks;
         $this->response = $response;
     }
 
-    public function getResponse()
+    public function getResponse(): SilverStripe\Control\HTTPResponse
     {
         if (!$this->response) {
             $this->response = new HTTPResponse();
@@ -71,7 +71,7 @@ class PjaxResponseNegotiator
      * @return HTTPResponse
      * @throws HTTPResponse_Exception
      */
-    public function respond(HTTPRequest $request, $extraCallbacks = [])
+    public function respond(HTTPRequest $request, array $extraCallbacks = []): SilverStripe\Control\HTTPResponse
     {
         // Prepare the default options and combine with the others
         $callbacks = array_merge($this->callbacks, $extraCallbacks);
@@ -112,7 +112,7 @@ class PjaxResponseNegotiator
      * @param string   $fragment
      * @param Callable $callback
      */
-    public function setCallback($fragment, $callback)
+    public function setCallback(string $fragment, callable $callback): void
     {
         $this->callbacks[$fragment] = $callback;
     }
@@ -123,7 +123,7 @@ class PjaxResponseNegotiator
      * @param array $fragments Fragments to insert.
      * @return $this
      */
-    public function setFragmentOverride($fragments)
+    public function setFragmentOverride(array $fragments): SilverStripe\Control\PjaxResponseNegotiator
     {
         if (!is_array($fragments)) {
             throw new InvalidArgumentException("fragments must be an array");

--- a/src/Control/RSS/RSSFeed.php
+++ b/src/Control/RSS/RSSFeed.php
@@ -132,7 +132,7 @@ class RSSFeed extends ViewableData
         $authorField = null,
         $lastModified = null,
         $etag = null
-    ) {
+    ): void {
         $this->entries = $entries;
         $this->link = $link;
         $this->description = $description;
@@ -154,7 +154,7 @@ class RSSFeed extends ViewableData
      * @param string $url URL of the feed
      * @param string $title Title to show
      */
-    public static function linkToFeed($url, $title = null)
+    public static function linkToFeed(string $url, string $title = null): void
     {
         $title = Convert::raw2xml($title);
         Requirements::insertHeadTags(
@@ -167,7 +167,7 @@ class RSSFeed extends ViewableData
      *
      * @return SS_List Returns the {@link RSSFeed_Entry} objects.
      */
-    public function Entries()
+    public function Entries(): SilverStripe\ORM\ArrayList
     {
         $output = new ArrayList();
 
@@ -186,7 +186,7 @@ class RSSFeed extends ViewableData
      *
      * @return string Returns the title of the feed.
      */
-    public function Title()
+    public function Title(): string
     {
         return $this->title;
     }
@@ -197,7 +197,7 @@ class RSSFeed extends ViewableData
      * @param string $action
      * @return string Returns the URL of the feed.
      */
-    public function Link($action = null)
+    public function Link($action = null): string
     {
         return Controller::join_links(Director::absoluteURL($this->link), $action);
     }
@@ -207,7 +207,7 @@ class RSSFeed extends ViewableData
      *
      * @return string Returns the description of the feed.
      */
-    public function Description()
+    public function Description(): null|string
     {
         return $this->description;
     }
@@ -219,7 +219,7 @@ class RSSFeed extends ViewableData
      *
      * @return DBHTMLText
      */
-    public function outputToBrowser()
+    public function outputToBrowser(): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $prevState = SSViewer::config()->uninherited('source_file_comments');
         SSViewer::config()->update('source_file_comments', false);
@@ -246,7 +246,7 @@ class RSSFeed extends ViewableData
      *
      * @param string $template
      */
-    public function setTemplate($template)
+    public function setTemplate(string $template): void
     {
         $this->template = $template;
     }
@@ -256,7 +256,7 @@ class RSSFeed extends ViewableData
      *
      * @return string
      */
-    public function getTemplate()
+    public function getTemplate(): null|string
     {
         return $this->template;
     }
@@ -267,7 +267,7 @@ class RSSFeed extends ViewableData
      *
      * @return array
      */
-    public function getTemplates()
+    public function getTemplates(): array
     {
         $templates = SSViewer::get_templates_by_class(static::class, '', __CLASS__);
         // Prefer any custom template

--- a/src/Control/RSS/RSSFeed_Entry.php
+++ b/src/Control/RSS/RSSFeed_Entry.php
@@ -52,7 +52,7 @@ class RSSFeed_Entry extends ViewableData
      * @param string $descriptionField
      * @param string $authorField
      */
-    public function __construct($entry, $titleField, $descriptionField, $authorField)
+    public function __construct(SilverStripe\Blog\Model\BlogPost $entry, string $titleField, string $descriptionField, string $authorField): void
     {
         $this->failover = $entry;
         $this->titleField = $titleField;
@@ -67,7 +67,7 @@ class RSSFeed_Entry extends ViewableData
      *
      * @return DBField Returns the description of the entry.
      */
-    public function Title()
+    public function Title(): SilverStripe\ORM\FieldType\DBVarchar
     {
         return $this->rssField($this->titleField);
     }
@@ -77,7 +77,7 @@ class RSSFeed_Entry extends ViewableData
      *
      * @return DBField Returns the description of the entry.
      */
-    public function Description()
+    public function Description(): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $description = $this->rssField($this->descriptionField);
 
@@ -94,7 +94,7 @@ class RSSFeed_Entry extends ViewableData
      *
      * @return DBField Returns the author of the entry.
      */
-    public function Author()
+    public function Author(): null|SilverStripe\ORM\FieldType\DBVarchar
     {
         return $this->rssField($this->authorField);
     }
@@ -105,7 +105,7 @@ class RSSFeed_Entry extends ViewableData
      * @param string $fieldName Name of field
      * @return DBField
      */
-    public function rssField($fieldName)
+    public function rssField(string $fieldName): null|SilverStripe\ORM\FieldType\DBVarchar
     {
         if ($fieldName) {
             return $this->failover->obj($fieldName);
@@ -119,7 +119,7 @@ class RSSFeed_Entry extends ViewableData
      * @return string Returns the URL of this entry
      * @throws BadMethodCallException
      */
-    public function AbsoluteLink()
+    public function AbsoluteLink(): string
     {
         if ($this->failover->hasMethod('AbsoluteLink')) {
             return $this->failover->AbsoluteLink();

--- a/src/Control/RequestHandler.php
+++ b/src/Control/RequestHandler.php
@@ -118,7 +118,7 @@ class RequestHandler extends ViewableData
      */
     private static $allowed_actions = null;
 
-    public function __construct()
+    public function __construct(): void
     {
         $this->brokenOnConstruct = false;
 
@@ -146,7 +146,7 @@ class RequestHandler extends ViewableData
      * @param HTTPRequest $request The object that is responsible for distributing URL parsing
      * @return HTTPResponse|RequestHandler|string|array
      */
-    public function handleRequest(HTTPRequest $request)
+    public function handleRequest(HTTPRequest $request): null|array|string|SilverStripe\ORM\FieldType\DBHTMLText
     {
         // $handlerClass is used to step up the class hierarchy to implement url_handlers inheritance
         if ($this->brokenOnConstruct) {
@@ -246,7 +246,7 @@ class RequestHandler extends ViewableData
      * @param HTTPRequest $request
      * @return array
      */
-    protected function findAction($request)
+    protected function findAction(SilverStripe\Control\HTTPRequest $request): array
     {
         $handlerClass = static::class;
 
@@ -288,7 +288,7 @@ class RequestHandler extends ViewableData
      * @param string $link
      * @return string
      */
-    protected function addBackURLParam($link)
+    protected function addBackURLParam(string $link): string
     {
         $backURL = $this->getBackURL();
         if ($backURL) {
@@ -307,7 +307,7 @@ class RequestHandler extends ViewableData
      * @param $action
      * @return HTTPResponse
      */
-    protected function handleAction($request, $action)
+    protected function handleAction(SilverStripe\Control\HTTPRequest $request, string $action): null|array|string|SilverStripe\Dev\DevBuildController
     {
         $classMessage = Director::isLive() ? 'on this handler' : 'on class ' . static::class;
 
@@ -342,7 +342,7 @@ class RequestHandler extends ViewableData
      * @param string $limitToClass
      * @return array|null
      */
-    public function allowedActions($limitToClass = null)
+    public function allowedActions(string $limitToClass = null): array|null
     {
         if ($limitToClass) {
             $actions = Config::forClass($limitToClass)->get('allowed_actions', true);
@@ -379,7 +379,7 @@ class RequestHandler extends ViewableData
      * @param string $action
      * @return bool
      */
-    public function hasAction($action)
+    public function hasAction(string $action): bool
     {
         if ($action == 'index') {
             return true;
@@ -428,7 +428,7 @@ class RequestHandler extends ViewableData
      * @param string $actionOrigCasing
      * @return string
      */
-    protected function definingClassForAction($actionOrigCasing)
+    protected function definingClassForAction(string $actionOrigCasing): string|null
     {
         $action = strtolower($actionOrigCasing ?? '');
 
@@ -453,7 +453,7 @@ class RequestHandler extends ViewableData
      * @return bool
      * @throws Exception
      */
-    public function checkAccessAction($action)
+    public function checkAccessAction(string $action): bool
     {
         $actionOrigCasing = $action;
         $action = strtolower($action ?? '');
@@ -513,7 +513,7 @@ class RequestHandler extends ViewableData
      * @uses HTTPResponse_Exception
      * @throws HTTPResponse_Exception
      */
-    public function httpError($errorCode, $errorMessage = null)
+    public function httpError(int $errorCode, string $errorMessage = null)
     {
         $request = $this->getRequest();
 
@@ -535,7 +535,7 @@ class RequestHandler extends ViewableData
      *
      * @return HTTPRequest
      */
-    public function getRequest()
+    public function getRequest(): SilverStripe\Control\NullHTTPRequest
     {
         return $this->request;
     }
@@ -547,7 +547,7 @@ class RequestHandler extends ViewableData
      * @param HTTPRequest $request
      * @return $this
      */
-    public function setRequest($request)
+    public function setRequest(SilverStripe\Control\NullHTTPRequest $request): SilverStripe\CMS\Controllers\CMSMain
     {
         $this->request = $request;
         return $this;
@@ -559,7 +559,7 @@ class RequestHandler extends ViewableData
      * @param string $action Optional action
      * @return string
      */
-    public function Link($action = null)
+    public function Link(bool|string $action = null): string
     {
         // Check configured url_segment
         $url = $this->config()->get('url_segment');
@@ -586,7 +586,7 @@ class RequestHandler extends ViewableData
      * @param int $code
      * @return HTTPResponse
      */
-    public function redirect($url, $code = 302)
+    public function redirect(string $url, int $code = 302): SilverStripe\Control\HTTPResponse
     {
         $url = Director::absoluteURL($url);
         $response = new HTTPResponse();
@@ -598,7 +598,7 @@ class RequestHandler extends ViewableData
      *
      * @return string
      */
-    public function getBackURL()
+    public function getBackURL(): null|string
     {
         $request = $this->getRequest();
         if (!$request) {
@@ -625,7 +625,7 @@ class RequestHandler extends ViewableData
      * @internal called from {@see Form::getValidationErrorResponse}
      * @return string|null
      */
-    public function getReturnReferer()
+    public function getReturnReferer(): null|string
     {
         $referer = $this->getReferer();
         if ($referer && Director::is_site_url($referer)) {
@@ -639,7 +639,7 @@ class RequestHandler extends ViewableData
      *
      * @return string
      */
-    public function getReferer()
+    public function getReferer(): null|string
     {
         $request = $this->getRequest();
         if (!$request) {
@@ -658,7 +658,7 @@ class RequestHandler extends ViewableData
      *
      * @return HTTPResponse
      */
-    public function redirectBack()
+    public function redirectBack(): SilverStripe\Control\HTTPResponse
     {
         // Prefer to redirect to ?BackURL, but fall back to Referer header
         // As a last resort redirect to base url

--- a/src/Control/RequestProcessor.php
+++ b/src/Control/RequestProcessor.php
@@ -27,7 +27,7 @@ class RequestProcessor implements HTTPMiddleware
      *
      * @param RequestFilter[] $filters
      */
-    public function __construct($filters = [])
+    public function __construct(array $filters = []): void
     {
         $this->filters = $filters;
     }
@@ -47,7 +47,7 @@ class RequestProcessor implements HTTPMiddleware
     /**
      * @inheritdoc
      */
-    public function process(HTTPRequest $request, callable $delegate)
+    public function process(HTTPRequest $request, callable $delegate): SilverStripe\Control\HTTPResponse
     {
         if ($this->filters) {
             Deprecation::notice(

--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -194,7 +194,7 @@ class Session
      * @param HTTPRequest $request
      * @return string
      */
-    protected function userAgent(HTTPRequest $request)
+    protected function userAgent(HTTPRequest $request): string|null
     {
         return $request->getHeader('User-Agent');
     }
@@ -205,7 +205,7 @@ class Session
      * @param array|null|Session $data Can be an array of data (such as $_SESSION) or another Session object to clone.
      * If null, this session is treated as unstarted.
      */
-    public function __construct($data)
+    public function __construct(array|SilverStripe\Control\Session $data): void
     {
         if ($data instanceof Session) {
             $data = $data->getAll();
@@ -223,7 +223,7 @@ class Session
      *
      * @param HTTPRequest $request
      */
-    public function init(HTTPRequest $request)
+    public function init(HTTPRequest $request): void
     {
         if (!$this->isStarted() && $this->requestContainsSessionId($request)) {
             $this->start($request);
@@ -243,7 +243,7 @@ class Session
      *
      * @param HTTPRequest $request
      */
-    public function restart(HTTPRequest $request)
+    public function restart(HTTPRequest $request): void
     {
         $this->destroy(true, $request);
         $this->start($request);
@@ -254,7 +254,7 @@ class Session
      *
      * @return bool
      */
-    public function isStarted()
+    public function isStarted(): bool
     {
         return $this->started;
     }
@@ -263,7 +263,7 @@ class Session
      * @param HTTPRequest $request
      * @return bool
      */
-    public function requestContainsSessionId(HTTPRequest $request)
+    public function requestContainsSessionId(HTTPRequest $request): bool
     {
         $secure = Director::is_https($request) && $this->config()->get('cookie_secure');
         $name = $secure ? $this->config()->get('cookie_name_secure') : session_name();
@@ -277,7 +277,7 @@ class Session
      *
      * @param HTTPRequest $request The request for which to start a session
      */
-    public function start(HTTPRequest $request)
+    public function start(HTTPRequest $request): void
     {
         if ($this->isStarted()) {
             throw new BadMethodCallException("Session has already started");
@@ -360,7 +360,7 @@ class Session
      * @param bool $removeCookie
      * @param HTTPRequest $request The request for which to destroy a session
      */
-    public function destroy($removeCookie = true, HTTPRequest $request = null)
+    public function destroy(bool $removeCookie = true, HTTPRequest $request = null): void
     {
         if (session_id()) {
             if ($removeCookie) {
@@ -388,7 +388,7 @@ class Session
      * @param mixed $val
      * @return $this
      */
-    public function set($name, $val)
+    public function set(string $name, string|int|bool|array|SilverStripe\MFA\Store\SessionStore $val): SilverStripe\Control\Session
     {
         $var = &$this->nestedValueRef($name, $this->data);
 
@@ -406,7 +406,7 @@ class Session
      * @internal
      * @param string $name
      */
-    protected function markChanged($name)
+    protected function markChanged(string $name): void
     {
         $diffVar = &$this->changedData;
         foreach (explode('.', $name ?? '') as $namePart) {
@@ -453,7 +453,7 @@ class Session
      * @param string $name
      * @return mixed
      */
-    public function get($name)
+    public function get(string $name): null|string|int|array|bool|SilverStripe\MFA\Store\SessionStore
     {
         return $this->nestedValue($name, $this->data);
     }
@@ -464,7 +464,7 @@ class Session
      * @param string $name
      * @return $this
      */
-    public function clear($name)
+    public function clear(string $name): SilverStripe\Control\Session
     {
         // Get var by path
         $var = $this->nestedValue($name, $this->data);
@@ -488,7 +488,7 @@ class Session
     /**
      * Clear all values
      */
-    public function clearAll()
+    public function clearAll(): void
     {
         if ($this->data && is_array($this->data)) {
             foreach (array_keys($this->data ?? []) as $key) {
@@ -502,7 +502,7 @@ class Session
      *
      * @return array|null
      */
-    public function getAll()
+    public function getAll(): array|null
     {
         return $this->data;
     }
@@ -512,7 +512,7 @@ class Session
      *
      * @param HTTPRequest $request
      */
-    public function finalize(HTTPRequest $request)
+    public function finalize(HTTPRequest $request): void
     {
         $this->set('HTTP_USER_AGENT', $this->userAgent($request));
     }
@@ -523,7 +523,7 @@ class Session
      *
      * @param HTTPRequest $request
      */
-    public function save(HTTPRequest $request)
+    public function save(HTTPRequest $request): void
     {
         if ($this->changedData) {
             $this->finalize($request);
@@ -545,7 +545,7 @@ class Session
      * @param array $data
      * @param array $dest
      */
-    protected function recursivelyApply($data, &$dest)
+    protected function recursivelyApply(array $data, &$dest): void
     {
         Deprecation::notice('5.0', 'Use recursivelyApplyChanges() instead');
         foreach ($data as $k => $v) {
@@ -565,7 +565,7 @@ class Session
      *
      * @return array
      */
-    public function changedData()
+    public function changedData(): array
     {
         return $this->changedData;
     }
@@ -579,7 +579,7 @@ class Session
      * @param array $source
      * @return mixed Reference to value in $source
      */
-    protected function &nestedValueRef($name, &$source)
+    protected function &nestedValueRef(string $name, &$source): null|int|string|array|bool|SilverStripe\ORM\FieldType\DBHTMLText
     {
         // Find var to change
         $var = &$source;
@@ -604,7 +604,7 @@ class Session
      * @param array $source
      * @return mixed Value in array in $source
      */
-    protected function nestedValue($name, $source)
+    protected function nestedValue(string $name, array $source): null|string|int|array|bool|SilverStripe\MFA\Store\SessionStore
     {
         // Find var to change
         $var = $source;
@@ -625,7 +625,7 @@ class Session
      * @param array $source
      * @param array $destination
      */
-    protected function recursivelyApplyChanges($changes, $source, &$destination)
+    protected function recursivelyApplyChanges(array $changes, array $source, &$destination): void
     {
         $source = $source ?: [];
         foreach ($changes as $key => $changed) {
@@ -650,7 +650,7 @@ class Session
      *
      * @internal This is for internal use only. Isn't a part of public API.
      */
-    public function regenerateSessionId()
+    public function regenerateSessionId(): void
     {
         if (!headers_sent() && session_status() === PHP_SESSION_ACTIVE) {
             session_regenerate_id(true);

--- a/src/Control/SimpleResourceURLGenerator.php
+++ b/src/Control/SimpleResourceURLGenerator.php
@@ -48,7 +48,7 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
      * @param string|null $nonceStyle The style of nonces to apply, or null to disable
      * @return $this
      */
-    public function setNonceStyle($nonceStyle)
+    public function setNonceStyle(string $nonceStyle): SilverStripe\Control\SimpleResourceURLGenerator
     {
         if ($nonceStyle && !in_array($nonceStyle, ['mtime', 'sha1', 'md5'])) {
             throw new InvalidArgumentException("NonceStyle '$nonceStyle' is not supported");
@@ -64,7 +64,7 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
      * @return string Doman-relative URL
      * @throws InvalidArgumentException If the resource doesn't exist
      */
-    public function urlForResource($relativePath)
+    public function urlForResource(SilverStripe\Core\Manifest\ModuleResource|string $relativePath): string
     {
         $query = '';
         if ($relativePath instanceof ModuleResource) {
@@ -134,7 +134,7 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
      * @param ModuleResource $resource
      * @return array List of [$exists, $absolutePath, $relativePath]
      */
-    protected function resolveModuleResource(ModuleResource $resource)
+    protected function resolveModuleResource(ModuleResource $resource): array
     {
         // Load from module resource
         $relativePath = $resource->getRelativePath();
@@ -163,7 +163,7 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
      * @param string $relativePath
      * @return array List of [$exists, $absolutePath, $relativePath]
      */
-    protected function resolveUnsecuredResource($relativePath)
+    protected function resolveUnsecuredResource(string $relativePath): array
     {
         // Check if the path requested is public-only, but we have no public folder
         $publicOnly = $this->inferPublicResourceRequired($relativePath);
@@ -193,7 +193,7 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
      * This prefix will be removed if exists. This path will also be normalised to match DIRECTORY_SEPARATOR
      * @return bool True if the resource must be a public resource
      */
-    protected function inferPublicResourceRequired(&$relativePath)
+    protected function inferPublicResourceRequired(string &$relativePath): bool
     {
         // Normalise path
         $relativePath = Path::normalise($relativePath, true);
@@ -213,7 +213,7 @@ class SimpleResourceURLGenerator implements ResourceURLGenerator
      * @param string $relativePath
      * @return array List of [$exists, $absolutePath, $relativePath]
      */
-    protected function resolvePublicResource($relativePath)
+    protected function resolvePublicResource(string $relativePath): array
     {
         // Determine if we should search both public and base resources, or only public
         $publicOnly = $this->inferPublicResourceRequired($relativePath);

--- a/src/Control/Util/IPUtils.php
+++ b/src/Control/Util/IPUtils.php
@@ -33,7 +33,7 @@ class IPUtils
      * @package framework
      * @subpackage core
      */
-    public static function checkIP($requestIP, $ips)
+    public static function checkIP(string $requestIP, string|array $ips): bool
     {
         if (!is_array($ips)) {
             $ips = [$ips];
@@ -58,7 +58,7 @@ class IPUtils
      *
      * @return bool Whether the request IP matches the IP, or whether the request IP is within the CIDR subnet
      */
-    public static function checkIP4($requestIP, $ip)
+    public static function checkIP4(string $requestIP, string $ip): bool|string
     {
         if (!filter_var($requestIP, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
             return false;
@@ -96,7 +96,7 @@ class IPUtils
      *
      * @throws \RuntimeException When IPV6 support is not enabled
      */
-    public static function checkIP6($requestIP, $ip)
+    public static function checkIP6(string $requestIP, string $ip): bool
     {
         if (!((extension_loaded('sockets') && defined('AF_INET6')) || @inet_pton('::1'))) {
             throw new \RuntimeException('Unable to check IPv6. Check that PHP was not compiled with option "disable-ipv6".');

--- a/src/Core/BaseKernel.php
+++ b/src/Core/BaseKernel.php
@@ -89,7 +89,7 @@ abstract class BaseKernel implements Kernel
      *
      * @param string $basePath Path to base dir for this application
      */
-    public function __construct($basePath)
+    public function __construct(string $basePath): void
     {
         $this->basePath = $basePath;
 
@@ -136,7 +136,7 @@ abstract class BaseKernel implements Kernel
     /**
      * Initialise PHP with default variables
      */
-    protected function bootPHP()
+    protected function bootPHP(): void
     {
         if ($this->getEnvironment() === self::LIVE) {
             // limited to fatal errors and warnings in live mode
@@ -177,7 +177,7 @@ abstract class BaseKernel implements Kernel
      *
      * @param bool $flush
      */
-    protected function bootManifests($flush)
+    protected function bootManifests(bool $flush): void
     {
         // Setup autoloader
         $this->getClassLoader()->init(
@@ -220,7 +220,7 @@ abstract class BaseKernel implements Kernel
     /**
      * Include all _config.php files
      */
-    protected function bootConfigs()
+    protected function bootConfigs(): void
     {
         global $project;
         $projectBefore = $project;
@@ -237,7 +237,7 @@ abstract class BaseKernel implements Kernel
      * Turn on error handling
      * @throws Exception
      */
-    protected function bootErrorHandling()
+    protected function bootErrorHandling(): void
     {
         // Register error handler
         $errorHandler = Injector::inst()->get(ErrorHandler::class);
@@ -262,7 +262,7 @@ abstract class BaseKernel implements Kernel
      *
      * @deprecated 5.0 use Director::get_environment_type() instead. Since 5.0 it should return only if kernel overrides. No checking SESSION or Environment.
      */
-    public function getEnvironment()
+    public function getEnvironment(): string
     {
         // Check set
         if ($this->enviroment) {
@@ -290,7 +290,7 @@ abstract class BaseKernel implements Kernel
      *
      * @deprecated 5.0 Use Director::get_session_environment_type() instead
      */
-    protected function sessionEnvironment()
+    protected function sessionEnvironment(): null
     {
         if (!$this->booted) {
             // session is not initialyzed yet, neither is manifest
@@ -364,7 +364,7 @@ abstract class BaseKernel implements Kernel
     /**
      * @return ManifestCacheFactory
      */
-    protected function buildManifestCacheFactory()
+    protected function buildManifestCacheFactory(): SilverStripe\Core\Cache\ManifestCacheFactory
     {
         return new ManifestCacheFactory([
             'namespace' => 'manifestcache',
@@ -387,7 +387,7 @@ abstract class BaseKernel implements Kernel
     /**
      * @return bool
      */
-    protected function getIncludeTests()
+    protected function getIncludeTests(): bool
     {
         return false;
     }
@@ -400,11 +400,11 @@ abstract class BaseKernel implements Kernel
         $this->booted = $bool;
     }
 
-    public function shutdown()
+    public function shutdown(): void
     {
     }
 
-    public function nest()
+    public function nest(): SilverStripe\Core\CoreKernel
     {
         // Clone this kernel, nesting config / injector manifest containers
         $kernel = clone $this;
@@ -414,7 +414,7 @@ abstract class BaseKernel implements Kernel
         return $kernel;
     }
 
-    public function activate()
+    public function activate(): SilverStripe\Core\CoreKernel
     {
         $this->configLoader->activate();
         $this->injectorLoader->activate();
@@ -426,7 +426,7 @@ abstract class BaseKernel implements Kernel
         return $this;
     }
 
-    public function getNestedFrom()
+    public function getNestedFrom(): SilverStripe\Dev\TestKernel
     {
         return $this->nestedFrom;
     }
@@ -436,7 +436,7 @@ abstract class BaseKernel implements Kernel
         return $this->getInjectorLoader()->getManifest();
     }
 
-    public function setInjectorLoader(InjectorLoader $injectorLoader)
+    public function setInjectorLoader(InjectorLoader $injectorLoader): SilverStripe\Core\CoreKernel
     {
         $this->injectorLoader = $injectorLoader;
         $injectorLoader
@@ -445,34 +445,34 @@ abstract class BaseKernel implements Kernel
         return $this;
     }
 
-    public function getInjectorLoader()
+    public function getInjectorLoader(): SilverStripe\Core\Injector\InjectorLoader
     {
         return $this->injectorLoader;
     }
 
-    public function getClassLoader()
+    public function getClassLoader(): SilverStripe\Core\Manifest\ClassLoader
     {
         return $this->classLoader;
     }
 
-    public function setClassLoader(ClassLoader $classLoader)
+    public function setClassLoader(ClassLoader $classLoader): SilverStripe\Core\CoreKernel
     {
         $this->classLoader = $classLoader;
         return $this;
     }
 
-    public function getModuleLoader()
+    public function getModuleLoader(): SilverStripe\Core\Manifest\ModuleLoader
     {
         return $this->moduleLoader;
     }
 
-    public function setModuleLoader(ModuleLoader $moduleLoader)
+    public function setModuleLoader(ModuleLoader $moduleLoader): SilverStripe\Core\CoreKernel
     {
         $this->moduleLoader = $moduleLoader;
         return $this;
     }
 
-    public function setEnvironment($environment)
+    public function setEnvironment(string $environment): SilverStripe\Dev\TestKernel
     {
         if (!in_array($environment, [self::DEV, self::TEST, self::LIVE, null])) {
             throw new InvalidArgumentException(
@@ -483,23 +483,23 @@ abstract class BaseKernel implements Kernel
         return $this;
     }
 
-    public function getConfigLoader()
+    public function getConfigLoader(): SilverStripe\Core\Config\ConfigLoader
     {
         return $this->configLoader;
     }
 
-    public function setConfigLoader($configLoader)
+    public function setConfigLoader(SilverStripe\Core\Config\ConfigLoader $configLoader): SilverStripe\Core\CoreKernel
     {
         $this->configLoader = $configLoader;
         return $this;
     }
 
-    public function getThemeResourceLoader()
+    public function getThemeResourceLoader(): SilverStripe\View\ThemeResourceLoader
     {
         return $this->themeResourceLoader;
     }
 
-    public function setThemeResourceLoader($themeResourceLoader)
+    public function setThemeResourceLoader(SilverStripe\View\ThemeResourceLoader $themeResourceLoader): SilverStripe\Core\CoreKernel
     {
         $this->themeResourceLoader = $themeResourceLoader;
         return $this;

--- a/src/Core/Cache/ApcuCacheFactory.php
+++ b/src/Core/Cache/ApcuCacheFactory.php
@@ -17,7 +17,7 @@ class ApcuCacheFactory implements CacheFactory
     /**
      * @param string $version
      */
-    public function __construct($version = null)
+    public function __construct(string $version = null): void
     {
         $this->version = $version;
     }
@@ -25,7 +25,7 @@ class ApcuCacheFactory implements CacheFactory
     /**
      * @inheritdoc
      */
-    public function create($service, array $params = [])
+    public function create(string $service, array $params = []): SilverStripe\Core\Tests\Cache\CacheTest\MockCache
     {
         $namespace = isset($params['namespace'])
             ? $params['namespace'] . '_' . md5(BASE_PATH)

--- a/src/Core/Cache/DefaultCacheFactory.php
+++ b/src/Core/Cache/DefaultCacheFactory.php
@@ -38,7 +38,7 @@ class DefaultCacheFactory implements CacheFactory
      * @param array $args List of global options to merge with args during create()
      * @param LoggerInterface $logger Logger instance to assign
      */
-    public function __construct($args = [], LoggerInterface $logger = null)
+    public function __construct(array $args = [], LoggerInterface $logger = null): void
     {
         $this->args = $args;
         $this->logger = $logger;
@@ -47,7 +47,7 @@ class DefaultCacheFactory implements CacheFactory
     /**
      * @inheritdoc
      */
-    public function create($service, array $args = [])
+    public function create(string $service, array $args = []): Symfony\Component\Cache\Simple\FilesystemCache
     {
         // merge args with default
         $args = array_merge($this->args, $args);
@@ -89,7 +89,7 @@ class DefaultCacheFactory implements CacheFactory
      *
      * @return bool
      */
-    protected function isAPCUSupported()
+    protected function isAPCUSupported(): bool
     {
         static $apcuSupported = null;
         if (null === $apcuSupported) {
@@ -104,7 +104,7 @@ class DefaultCacheFactory implements CacheFactory
      *
      * @return bool
      */
-    protected function isPHPFilesSupported()
+    protected function isPHPFilesSupported(): bool
     {
         static $phpFilesSupported = null;
         if (null === $phpFilesSupported) {
@@ -118,7 +118,7 @@ class DefaultCacheFactory implements CacheFactory
      * @param array $args
      * @return CacheInterface
      */
-    protected function createCache($class, $args)
+    protected function createCache(string $class, array $args): Symfony\Component\Cache\Simple\FilesystemCache
     {
         /** @var CacheInterface $cache */
         $cache = Injector::inst()->createWithArgs($class, $args);

--- a/src/Core/Cache/ManifestCacheFactory.php
+++ b/src/Core/Cache/ManifestCacheFactory.php
@@ -18,7 +18,7 @@ use SilverStripe\Core\Environment;
  */
 class ManifestCacheFactory extends DefaultCacheFactory
 {
-    public function __construct(array $args = [], LoggerInterface $logger = null)
+    public function __construct(array $args = [], LoggerInterface $logger = null): void
     {
         // Build default manifest logger
         if (!$logger) {
@@ -41,7 +41,7 @@ class ManifestCacheFactory extends DefaultCacheFactory
      * @param array $params The constructor parameters.
      * @return CacheInterface
      */
-    public function create($service, array $params = [])
+    public function create(string $service, array $params = []): Symfony\Component\Cache\Simple\FilesystemCache
     {
         // Override default cache generation with SS_MANIFESTCACHE
         $cacheClass = Environment::getEnv('SS_MANIFESTCACHE');
@@ -76,7 +76,7 @@ class ManifestCacheFactory extends DefaultCacheFactory
      * @param array $args
      * @return CacheInterface
      */
-    public function createCache($class, $args)
+    public function createCache(string $class, array $args): Symfony\Component\Cache\Simple\FilesystemCache
     {
         /** @var CacheInterface $cache */
         $reflection = new ReflectionClass($class);

--- a/src/Core/Cache/MemcachedCacheFactory.php
+++ b/src/Core/Cache/MemcachedCacheFactory.php
@@ -17,7 +17,7 @@ class MemcachedCacheFactory implements CacheFactory
     /**
      * @param Memcached $memcachedClient
      */
-    public function __construct(Memcached $memcachedClient = null)
+    public function __construct(Memcached $memcachedClient = null): void
     {
         $this->memcachedClient = $memcachedClient;
     }
@@ -25,7 +25,7 @@ class MemcachedCacheFactory implements CacheFactory
     /**
      * @inheritdoc
      */
-    public function create($service, array $params = [])
+    public function create(string $service, array $params = []): SilverStripe\Core\Tests\Cache\CacheTest\MockCache
     {
         $namespace = isset($params['namespace'])
             ? $params['namespace'] . '_' . md5(BASE_PATH)

--- a/src/Core/Cache/RateLimiter.php
+++ b/src/Core/Cache/RateLimiter.php
@@ -37,7 +37,7 @@ class RateLimiter
      * @param int $maxAttempts
      * @param int $decay
      */
-    public function __construct($identifier, $maxAttempts, $decay)
+    public function __construct(string $identifier, int $maxAttempts, int $decay): void
     {
         $this->setIdentifier($identifier);
         $this->setMaxAttempts($maxAttempts);
@@ -47,7 +47,7 @@ class RateLimiter
     /**
      * @return CacheInterface
      */
-    public function getCache()
+    public function getCache(): Symfony\Component\Cache\Simple\FilesystemCache
     {
         if (!$this->cache) {
             $this->setCache(Injector::inst()->create(CacheInterface::class . '.RateLimiter'));
@@ -60,7 +60,7 @@ class RateLimiter
      *
      * @return $this
      */
-    public function setCache($cache)
+    public function setCache(Symfony\Component\Cache\Simple\FilesystemCache $cache): SilverStripe\Core\Cache\RateLimiter
     {
         $this->cache = $cache;
         return $this;
@@ -69,7 +69,7 @@ class RateLimiter
     /**
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->identifier;
     }
@@ -78,7 +78,7 @@ class RateLimiter
      * @param string $identifier
      * @return $this
      */
-    public function setIdentifier($identifier)
+    public function setIdentifier(string $identifier): SilverStripe\Core\Cache\RateLimiter
     {
         $this->identifier = $identifier;
         return $this;
@@ -87,7 +87,7 @@ class RateLimiter
     /**
      * @return int
      */
-    public function getMaxAttempts()
+    public function getMaxAttempts(): int
     {
         return $this->maxAttempts;
     }
@@ -96,7 +96,7 @@ class RateLimiter
      * @param int $maxAttempts
      * @return $this
      */
-    public function setMaxAttempts($maxAttempts)
+    public function setMaxAttempts(int $maxAttempts): SilverStripe\Core\Cache\RateLimiter
     {
         $this->maxAttempts = $maxAttempts;
         return $this;
@@ -105,7 +105,7 @@ class RateLimiter
     /**
      * @return int
      */
-    public function getDecay()
+    public function getDecay(): int
     {
         return $this->decay;
     }
@@ -114,7 +114,7 @@ class RateLimiter
      * @param int $decay
      * @return $this
      */
-    public function setDecay($decay)
+    public function setDecay(int $decay): SilverStripe\Core\Cache\RateLimiter
     {
         $this->decay = $decay;
         return $this;
@@ -123,7 +123,7 @@ class RateLimiter
     /**
      * @return int
      */
-    public function getNumAttempts()
+    public function getNumAttempts(): int
     {
         return $this->getCache()->get($this->getIdentifier(), 0);
     }
@@ -131,7 +131,7 @@ class RateLimiter
     /**
      * @return int
      */
-    public function getNumAttemptsRemaining()
+    public function getNumAttemptsRemaining(): int
     {
         return max(0, $this->getMaxAttempts() - $this->getNumAttempts());
     }
@@ -139,7 +139,7 @@ class RateLimiter
     /**
      * @return int
      */
-    public function getTimeToReset()
+    public function getTimeToReset(): int
     {
         if ($expiry = $this->getCache()->get($this->getIdentifier() . '-timer')) {
             return $expiry - DBDatetime::now()->getTimestamp();
@@ -150,7 +150,7 @@ class RateLimiter
     /**
      * @return $this
      */
-    public function clearAttempts()
+    public function clearAttempts(): SilverStripe\Core\Cache\RateLimiter
     {
         $this->getCache()->delete($this->getIdentifier());
         return $this;
@@ -161,7 +161,7 @@ class RateLimiter
      *
      * @return $this
      */
-    public function hit()
+    public function hit(): SilverStripe\Core\Cache\RateLimiter
     {
         if (!$this->getCache()->has($this->getIdentifier())) {
             $ttl = $this->getDecay() * 60;
@@ -178,7 +178,7 @@ class RateLimiter
     /**
      * @return bool
      */
-    public function canAccess()
+    public function canAccess(): bool
     {
         if ($this->getNumAttempts() >= $this->getMaxAttempts()) {
             // if the timer cache item still exists then they are locked out

--- a/src/Core/ClassInfo.php
+++ b/src/Core/ClassInfo.php
@@ -64,7 +64,7 @@ class ClassInfo
      *
      * @return array List of all class names
      */
-    public static function allClasses()
+    public static function allClasses(): array
     {
         return ClassLoader::inst()->getManifest()->getClassNames();
     }
@@ -75,7 +75,7 @@ class ClassInfo
      * @param string $class
      * @return bool
      */
-    public static function exists($class)
+    public static function exists(string $class): bool
     {
         return class_exists($class ?? '', false)
             || interface_exists($class ?? '', false)
@@ -88,7 +88,7 @@ class ClassInfo
      * @param string $tableName
      * @return bool
      */
-    public static function hasTable($tableName)
+    public static function hasTable(string $tableName): bool
     {
         // Cache the list of all table names to reduce on DB traffic
         if (empty(self::$_cache_all_tables) && DB::is_active()) {
@@ -97,7 +97,7 @@ class ClassInfo
         return !empty(self::$_cache_all_tables[strtolower($tableName)]);
     }
 
-    public static function reset_db_cache()
+    public static function reset_db_cache(): void
     {
         self::$_cache_all_tables = null;
         self::$_cache_ancestry = [];
@@ -111,7 +111,7 @@ class ClassInfo
      * types that don't exist as implemented classes. By default these are excluded.
      * @return array List of subclasses
      */
-    public static function getValidSubClasses($class = SiteTree::class, $includeUnbacked = false)
+    public static function getValidSubClasses($class = SiteTree::class, $includeUnbacked = false): array
     {
         if (is_string($class) && !class_exists($class ?? '')) {
             return [];
@@ -136,7 +136,7 @@ class ClassInfo
      * @param string|object $nameOrObject Class or object instance
      * @return array
      */
-    public static function dataClassesFor($nameOrObject)
+    public static function dataClassesFor(string|DNADesign\Elemental\Tests\TopPage\TestContent $nameOrObject): array
     {
         if (is_string($nameOrObject) && !class_exists($nameOrObject ?? '')) {
             return [];
@@ -160,7 +160,7 @@ class ClassInfo
      * @param string $class
      * @return string
      */
-    public static function baseDataClass($class)
+    public static function baseDataClass(DNADesign\Elemental\Tests\Src\TestPage $class): string
     {
         Deprecation::notice('5.0', 'Use DataObject::getSchema()->baseDataClass()');
         return DataObject::getSchema()->baseDataClass($class);
@@ -187,7 +187,7 @@ class ClassInfo
      * @return array List of class names with lowercase keys and correct-case values
      * @throws \ReflectionException
      */
-    public static function subclassesFor($nameOrObject, $includeBaseClass = true)
+    public static function subclassesFor(string $nameOrObject, bool $includeBaseClass = true): array
     {
         if (is_string($nameOrObject) && !class_exists($nameOrObject ?? '')) {
             return [];
@@ -214,7 +214,7 @@ class ClassInfo
      * @throws \ReflectionException
      * @return string The normalised class name
      */
-    public static function class_name($nameOrObject)
+    public static function class_name(string|i18nTestModule|TractorCow\Fluent\Model\Locale $nameOrObject): string
     {
         if (is_object($nameOrObject)) {
             return get_class($nameOrObject);
@@ -244,7 +244,7 @@ class ClassInfo
      * @param bool $tablesOnly Only return classes that have a table in the db.
      * @return array List of class names with lowercase keys and correct-case values
      */
-    public static function ancestry($nameOrObject, $tablesOnly = false)
+    public static function ancestry(string|SilverStripe\CMS\Model\SiteTree $nameOrObject, bool $tablesOnly = false): array
     {
         if (is_string($nameOrObject) && !class_exists($nameOrObject ?? '')) {
             return [];
@@ -274,7 +274,7 @@ class ClassInfo
      * @return array A self-keyed array of class names with lowercase keys and correct-case values.
      * Note that this is only available with Silverstripe classes and not built-in PHP classes.
      */
-    public static function implementorsOf($interfaceName)
+    public static function implementorsOf(string $interfaceName): array
     {
         return ClassLoader::inst()->getManifest()->getImplementorsOf($interfaceName);
     }
@@ -286,7 +286,7 @@ class ClassInfo
      * @param string $interfaceName
      * @return bool
      */
-    public static function classImplements($className, $interfaceName)
+    public static function classImplements(string $className, string $interfaceName): bool
     {
         $lowerClassName = strtolower($className ?? '');
         $implementors = self::implementorsOf($interfaceName);
@@ -299,7 +299,7 @@ class ClassInfo
      * @param string $filePath Path to a PHP file (absolute or relative to webroot)
      * @return array Map of lowercase class names to correct class name
      */
-    public static function classes_for_file($filePath)
+    public static function classes_for_file(string $filePath): array
     {
         $absFilePath = Director::getAbsFile($filePath);
         $classManifest = ClassLoader::inst()->getManifest();
@@ -322,7 +322,7 @@ class ClassInfo
      * @param string $folderPath Relative or absolute folder path
      * @return array Map of lowercase class names to correct class name
      */
-    public static function classes_for_folder($folderPath)
+    public static function classes_for_folder(string $folderPath): array
     {
         $absFolderPath = Director::getAbsFile($folderPath);
         $classManifest = ClassLoader::inst()->getManifest();
@@ -347,7 +347,7 @@ class ClassInfo
      * @param string $compclass Parent class to test if this is the implementor
      * @return bool True if $class::$method is declared in $compclass
      */
-    public static function has_method_from($class, $method, $compclass)
+    public static function has_method_from(string $class, string $method, string $compclass): bool
     {
         $lClass = strtolower($class ?? '');
         $lMethod = strtolower($method ?? '');
@@ -385,7 +385,7 @@ class ClassInfo
      * @param string|object $nameOrObject Name of class, or instance
      * @return string Name of class without namespace
      */
-    public static function shortName($nameOrObject)
+    public static function shortName(string|i18nTestModule|SilverStripe\ORM\Tests\DataExtensionTest\MyObject $nameOrObject): string
     {
         $name = static::class_name($nameOrObject);
         $parts = explode('\\', $name ?? '');
@@ -399,7 +399,7 @@ class ClassInfo
      * @param string $method
      * @return bool
      */
-    public static function hasMethod($object, $method)
+    public static function hasMethod(string|int|array|SilverStripe\Core\Manifest\PrioritySorter $object, string $method): bool
     {
         if (empty($object) || (!is_object($object) && !is_string($object))) {
             return false;
@@ -418,7 +418,7 @@ class ClassInfo
      * @return array
      * @throws Exception
      */
-    public static function parse_class_spec($classSpec)
+    public static function parse_class_spec(string $classSpec): array
     {
         if (isset(static::$_cache_parse[$classSpec])) {
             return static::$_cache_parse[$classSpec];

--- a/src/Core/Config/Config.php
+++ b/src/Core/Config/Config.php
@@ -40,7 +40,7 @@ abstract class Config
      *
      * @return ConfigCollectionInterface
      */
-    public static function inst()
+    public static function inst(): SilverStripe\Config\Collections\CachedConfigCollection
     {
         return ConfigLoader::inst()->getManifest();
     }
@@ -50,7 +50,7 @@ abstract class Config
      *
      * @return MutableConfigCollectionInterface
      */
-    public static function modify()
+    public static function modify(): SilverStripe\Config\Collections\DeltaConfigCollection
     {
         $instance = static::inst();
         if ($instance instanceof MutableConfigCollectionInterface) {
@@ -76,7 +76,7 @@ abstract class Config
      *
      * @return ConfigCollectionInterface Active config
      */
-    public static function nest()
+    public static function nest(): SilverStripe\Config\Collections\DeltaConfigCollection
     {
         // Clone current config and nest
         $new = self::inst()->nest();
@@ -90,7 +90,7 @@ abstract class Config
      *
      * @return ConfigCollectionInterface
      */
-    public static function unnest()
+    public static function unnest(): SilverStripe\Config\Collections\DeltaConfigCollection
     {
         // Unnest unless we would be left at 0 manifests
         $loader = ConfigLoader::inst();
@@ -114,7 +114,7 @@ abstract class Config
      * @param string $class
      * @return Config_ForClass
      */
-    public static function forClass($class)
+    public static function forClass(string|Page $class): SilverStripe\Core\Config\Config_ForClass
     {
         return new Config_ForClass($class);
     }
@@ -126,7 +126,7 @@ abstract class Config
      * @param callable $callback Callback to run. Will be passed the nested config state as a parameter
      * @return mixed Result of callback
      */
-    public static function withConfig($callback)
+    public static function withConfig(callable $callback): null|string
     {
         static::nest();
         $config = static::modify();

--- a/src/Core/Config/ConfigLoader.php
+++ b/src/Core/Config/ConfigLoader.php
@@ -24,7 +24,7 @@ class ConfigLoader
     /**
      * @return self
      */
-    public static function inst()
+    public static function inst(): SilverStripe\Core\Config\ConfigLoader
     {
         return self::$instance ? self::$instance : self::$instance = new static();
     }
@@ -35,7 +35,7 @@ class ConfigLoader
      *
      * @return ConfigCollectionInterface
      */
-    public function getManifest()
+    public function getManifest(): SilverStripe\Config\Collections\CachedConfigCollection
     {
         if ($this !== self::$instance) {
             throw new BadMethodCallException(
@@ -63,7 +63,7 @@ class ConfigLoader
      *
      * @param ConfigCollectionInterface $manifest
      */
-    public function pushManifest(ConfigCollectionInterface $manifest)
+    public function pushManifest(ConfigCollectionInterface $manifest): void
     {
         $this->manifests[] = $manifest;
     }
@@ -71,7 +71,7 @@ class ConfigLoader
     /**
      * @return ConfigCollectionInterface
      */
-    public function popManifest()
+    public function popManifest(): SilverStripe\Config\Collections\DeltaConfigCollection
     {
         return array_pop($this->manifests);
     }
@@ -81,7 +81,7 @@ class ConfigLoader
      *
      * @return int
      */
-    public function countManifests()
+    public function countManifests(): int
     {
         return count($this->manifests ?? []);
     }
@@ -91,7 +91,7 @@ class ConfigLoader
      *
      * @return static
      */
-    public function nest()
+    public function nest(): SilverStripe\Core\Config\ConfigLoader
     {
         // Nest config
         $manifest = clone $this->getManifest();
@@ -109,7 +109,7 @@ class ConfigLoader
      *
      * @return $this
      */
-    public function activate()
+    public function activate(): SilverStripe\Core\Config\ConfigLoader
     {
         static::$instance = $this;
         return $this;

--- a/src/Core/Config/Config_ForClass.php
+++ b/src/Core/Config/Config_ForClass.php
@@ -14,7 +14,7 @@ class Config_ForClass
     /**
      * @param string|object $class
      */
-    public function __construct($class)
+    public function __construct(string|Page $class): void
     {
         $this->class = is_object($class) ? get_class($class) : $class;
     }
@@ -23,7 +23,7 @@ class Config_ForClass
      * @param string $name
      * @return mixed
      */
-    public function __get($name)
+    public function __get(string $name): bool|array|int|null|string
     {
         return $this->get($name);
     }
@@ -32,7 +32,7 @@ class Config_ForClass
      * @param string $name
      * @param mixed $val
      */
-    public function __set($name, $val)
+    public function __set(string $name, bool $val): void
     {
         $this->set($name, $val);
     }
@@ -44,7 +44,7 @@ class Config_ForClass
      * @param mixed $value
      * @return $this
      */
-    public function update($name, $value)
+    public function update(string $name, bool|string|array|int $value): SilverStripe\Core\Config\Config_ForClass
     {
         Deprecation::notice('5.0', 'Use merge() instead');
         return $this->merge($name, $value);
@@ -57,7 +57,7 @@ class Config_ForClass
      * @param mixed $value
      * @return $this
      */
-    public function merge($name, $value)
+    public function merge(string $name, bool|string|array|int $value): SilverStripe\Core\Config\Config_ForClass
     {
         Config::modify()->merge($this->class, $name, $value);
         return $this;
@@ -70,7 +70,7 @@ class Config_ForClass
      * @param mixed $value
      * @return $this
      */
-    public function set($name, $value)
+    public function set(string $name, array|bool|string|int $value): SilverStripe\Core\Config\Config_ForClass
     {
         Config::modify()->set($this->class, $name, $value);
         return $this;
@@ -80,7 +80,7 @@ class Config_ForClass
      * @param string $name
      * @return bool
      */
-    public function __isset($name)
+    public function __isset(string $name): bool
     {
         $val = $this->__get($name);
         return isset($val);
@@ -91,7 +91,7 @@ class Config_ForClass
      * @param mixed $options
      * @return mixed
      */
-    public function get($name, $options = 0)
+    public function get(string $name, int|bool $options = 0): array|string|null|bool|int|float
     {
         return Config::inst()->get($this->class, $name, $options);
     }
@@ -102,7 +102,7 @@ class Config_ForClass
      * @param string $name
      * @return $this
      */
-    public function remove($name)
+    public function remove(string $name): SilverStripe\Core\Config\Config_ForClass
     {
         Config::modify()->remove($this->class, $name);
         return $this;
@@ -124,7 +124,7 @@ class Config_ForClass
      * @param string $name Name of config
      * @return mixed
      */
-    public function uninherited($name)
+    public function uninherited(string $name): array|null|string|bool|int
     {
         return $this->get($name, Config::UNINHERITED);
     }

--- a/src/Core/Config/CoreConfigFactory.php
+++ b/src/Core/Config/CoreConfigFactory.php
@@ -33,7 +33,7 @@ class CoreConfigFactory
      *
      * @param CacheFactory $cacheFactory
      */
-    public function __construct(CacheFactory $cacheFactory = null)
+    public function __construct(CacheFactory $cacheFactory = null): void
     {
         $this->cacheFactory = $cacheFactory;
     }
@@ -45,7 +45,7 @@ class CoreConfigFactory
      *
      * @return CachedConfigCollection
      */
-    public function createRoot()
+    public function createRoot(): SilverStripe\Config\Collections\CachedConfigCollection
     {
         $instance = new CachedConfigCollection();
 
@@ -75,7 +75,7 @@ class CoreConfigFactory
      *
      * @return MemoryConfigCollection
      */
-    public function createCore()
+    public function createCore(): SilverStripe\Config\Collections\MemoryConfigCollection
     {
         $config = new MemoryConfigCollection();
 
@@ -97,7 +97,7 @@ class CoreConfigFactory
     /**
      * @return YamlTransformer
      */
-    protected function buildYamlTransformer()
+    protected function buildYamlTransformer(): SilverStripe\Config\Transformer\YamlTransformer
     {
         // Get all module dirs
         $modules = ModuleLoader::inst()->getManifest()->getModules();
@@ -116,7 +116,7 @@ class CoreConfigFactory
     /**
      * @return PrivateStaticTransformer
      */
-    public function buildStaticTransformer()
+    public function buildStaticTransformer(): SilverStripe\Config\Transformer\PrivateStaticTransformer
     {
         return new PrivateStaticTransformer(function () {
             return ClassLoader::inst()
@@ -129,7 +129,7 @@ class CoreConfigFactory
      * @param array|string $dirs Base dir to load from
      * @return YamlTransformer
      */
-    public function buildYamlTransformerForPath($dirs)
+    public function buildYamlTransformerForPath(array|string $dirs): SilverStripe\Config\Transformer\YamlTransformer
     {
         // Construct
         $transformer = YamlTransformer::create(

--- a/src/Core/Config/Middleware/ExtensionMiddleware.php
+++ b/src/Core/Config/Middleware/ExtensionMiddleware.php
@@ -16,7 +16,7 @@ class ExtensionMiddleware implements Middleware
 {
     use MiddlewareCommon;
 
-    public function __construct($disableFlag = 0)
+    public function __construct(int $disableFlag = 0): void
     {
         $this->setDisableFlag($disableFlag);
     }
@@ -29,7 +29,7 @@ class ExtensionMiddleware implements Middleware
      * @param callable $next Callback to next middleware
      * @return array Complete class config
      */
-    public function getClassConfig($class, $excludeMiddleware, $next)
+    public function getClassConfig(string $class, int $excludeMiddleware, callable $next): array
     {
         // Get base config
         $config = $next($class, $excludeMiddleware);
@@ -52,7 +52,7 @@ class ExtensionMiddleware implements Middleware
      * @param int $excludeMiddleware
      * @return Generator
      */
-    protected function getExtraConfig($class, $classConfig, $excludeMiddleware)
+    protected function getExtraConfig(string $class, array $classConfig, int $excludeMiddleware): void
     {
         // Note: 'extensions' config needs to come from it's own middleware call in case
         // applied by delta middleware (e.g. Object::add_extension)

--- a/src/Core/Config/Middleware/InheritanceMiddleware.php
+++ b/src/Core/Config/Middleware/InheritanceMiddleware.php
@@ -11,7 +11,7 @@ class InheritanceMiddleware implements Middleware
 {
     use MiddlewareCommon;
 
-    public function __construct($disableFlag = 0)
+    public function __construct(int $disableFlag = 0): void
     {
         $this->setDisableFlag($disableFlag);
     }
@@ -24,7 +24,7 @@ class InheritanceMiddleware implements Middleware
      * @param callable $next Callback to next middleware
      * @return array Complete class config
      */
-    public function getClassConfig($class, $excludeMiddleware, $next)
+    public function getClassConfig(string $class, int $excludeMiddleware, callable $next): array
     {
         // Skip if disabled
         $config = $next($class, $excludeMiddleware);

--- a/src/Core/Convert.php
+++ b/src/Core/Convert.php
@@ -36,7 +36,7 @@ class Convert
      * @param array|string $val String to escape, or array of strings
      * @return array|string
      */
-    public static function raw2att($val)
+    public static function raw2att(string|int|bool $val): string
     {
         return self::raw2xml($val);
     }
@@ -49,7 +49,7 @@ class Convert
      * @param string|array $val String to escape, or array of strings
      * @return array|string
      */
-    public static function raw2htmlatt($val)
+    public static function raw2htmlatt(string $val): string
     {
         return self::raw2att($val);
     }
@@ -66,7 +66,7 @@ class Convert
      *
      * @return array|string
      */
-    public static function raw2htmlname($val)
+    public static function raw2htmlname(string $val): string
     {
         if (is_array($val)) {
             foreach ($val as $k => $v) {
@@ -91,7 +91,7 @@ class Convert
      *
      * @return array|string
      */
-    public static function raw2htmlid($val)
+    public static function raw2htmlid(string|int $val): string
     {
         if (is_array($val)) {
             foreach ($val as $k => $v) {
@@ -120,7 +120,7 @@ class Convert
      * @param array|string $val String to escape, or array of strings
      * @return array|string
      */
-    public static function raw2xml($val)
+    public static function raw2xml(string|int|bool|array|float $val): string|array
     {
         if (is_array($val)) {
             foreach ($val as $k => $v) {
@@ -140,7 +140,7 @@ class Convert
      * @param array|string $val String to escape, or array of strings
      * @return array|string
      */
-    public static function raw2js($val)
+    public static function raw2js(string $val): string
     {
         if (is_array($val)) {
             foreach ($val as $k => $v) {
@@ -166,7 +166,7 @@ class Convert
      * @param  int   $options Optional bitmask of JSON constants
      * @return string           JSON encoded string
      */
-    public static function raw2json($val, $options = 0)
+    public static function raw2json(array|stdClass|string $val, int $options = 0): string
     {
         Deprecation::notice('4.4', 'Please use json_encode() instead.');
 
@@ -181,7 +181,7 @@ class Convert
      * @param  int    $options Optional bitmask of JSON constants
      * @return string          JSON encoded string
      */
-    public static function array2json($val, $options = 0)
+    public static function array2json(array $val, int $options = 0): string
     {
         Deprecation::notice('4.4', 'Please use json_encode() instead.');
 
@@ -200,7 +200,7 @@ class Convert
      * only escape the string (false).
      * @return string|array Safely encoded value in the same format as the input
      */
-    public static function raw2sql($val, $quoted = false)
+    public static function raw2sql(string|array|SilverStripe\ORM\FieldType\DBDatetime|int $val, bool $quoted = false): string|array
     {
         if (is_array($val)) {
             foreach ($val as $k => $v) {
@@ -226,7 +226,7 @@ class Convert
      * @param string $separator The string that delimits subsequent identifiers
      * @return string The escaped identifier. E.g. '"SiteTree"."Title"'
      */
-    public static function symbol2sql($identifier, $separator = '.')
+    public static function symbol2sql(string $identifier, $separator = '.'): string
     {
         return DB::get_conn()->escapeIdentifier($identifier, $separator);
     }
@@ -241,7 +241,7 @@ class Convert
      * @param mixed $val
      * @return array|string
      */
-    public static function xml2raw($val)
+    public static function xml2raw(string $val): string
     {
         if (is_array($val)) {
             foreach ($val as $k => $v) {
@@ -265,7 +265,7 @@ class Convert
      * @param string $val
      * @return object|boolean
      */
-    public static function json2obj($val)
+    public static function json2obj(string $val): stdClass
     {
         Deprecation::notice('4.4', 'Please use json_decode() instead.');
 
@@ -279,7 +279,7 @@ class Convert
      * @param string $val JSON string to convert
      * @return array|boolean
      */
-    public static function json2array($val)
+    public static function json2array(string $val): array
     {
         Deprecation::notice('4.4', 'Please use json_decode() instead.');
 
@@ -299,7 +299,7 @@ class Convert
      * @return array
      * @throws Exception
      */
-    public static function xml2array($val, $disableDoctypes = false, $disableExternals = false)
+    public static function xml2array(string $val, bool $disableDoctypes = false, $disableExternals = false): array
     {
         Deprecation::notice('4.10', 'Use a dedicated XML library instead');
 
@@ -332,7 +332,7 @@ class Convert
      *
      * @return mixed
      */
-    protected static function recursiveXMLToArray($xml)
+    protected static function recursiveXMLToArray(SimpleXMLElement|array|string $xml): string|array
     {
         $x = null;
         if ($xml instanceof SimpleXMLElement) {
@@ -387,7 +387,7 @@ class Convert
      * @param array $config
      * @return string
      */
-    public static function html2raw($data, $preserveLinks = false, $wordWrap = 0, $config = null)
+    public static function html2raw(string $data, bool $preserveLinks = false, int $wordWrap = 0, $config = null): string
     {
         $defaultConfig = [
             'PreserveLinks' => false,
@@ -486,7 +486,7 @@ class Convert
      * @param string $title
      * @return string
      */
-    public static function raw2url($title)
+    public static function raw2url(string $title): string
     {
         $f = URLSegmentFilter::create();
         return $f->filter($title);
@@ -501,7 +501,7 @@ class Convert
      * specified by the current OS
      * @return string
      */
-    public static function nl2os($data, $nl = PHP_EOL)
+    public static function nl2os(string|SilverStripe\ORM\FieldType\DBHTMLText $data, string $nl = PHP_EOL): string
     {
         return preg_replace('~\R~u', $nl ?? '', $data ?? '');
     }
@@ -513,7 +513,7 @@ class Convert
      * @param mixed $val Value to be encoded
      * @return string
      */
-    public static function base64url_encode($val)
+    public static function base64url_encode(array|string|float|bool $val): string
     {
         return rtrim(strtr(base64_encode(json_encode($val) ?? ''), '+/', '~_'), '=');
     }
@@ -524,7 +524,7 @@ class Convert
      * @param string $val Value to be decoded
      * @return mixed Original value
      */
-    public static function base64url_decode($val)
+    public static function base64url_decode(string $val): array|string|float|bool
     {
         return json_decode(
             base64_decode(str_pad(strtr($val ?? '', '~_', '+/'), strlen($val ?? '') % 4, '=', STR_PAD_RIGHT)) ?? '',
@@ -545,7 +545,7 @@ class Convert
      * @param $str
      * @return string
      */
-    public static function upperCamelToLowerCamel($str)
+    public static function upperCamelToLowerCamel(string $str): string
     {
         $return = null;
         $matches = null;
@@ -583,7 +583,7 @@ class Convert
      * @param string $memString A memory limit string, such as "64M"
      * @return int
      */
-    public static function memstring2bytes($memString)
+    public static function memstring2bytes(string|int $memString): int
     {
         // Remove  non-unit characters from the size
         $unit = preg_replace('/[^bkmgtpezy]/i', '', $memString ?? '');
@@ -604,7 +604,7 @@ class Convert
      * @param int $decimal decimal precision
      * @return string
      */
-    public static function bytes2memstring($bytes, $decimal = 0)
+    public static function bytes2memstring(int $bytes, $decimal = 0): string
     {
         $scales = ['B','K','M','G','T','P','E','Z','Y'];
         // Get scale
@@ -626,7 +626,7 @@ class Convert
      * @param bool $multiple Collapses multiple slashes or not
      * @return string
      */
-    public static function slashes($path, $separator = DIRECTORY_SEPARATOR, $multiple = true)
+    public static function slashes(string $path, string $separator = DIRECTORY_SEPARATOR, bool $multiple = true): string
     {
         if ($multiple) {
             return preg_replace('#[/\\\\]+#', $separator ?? '', $path ?? '');

--- a/src/Core/CoreKernel.php
+++ b/src/Core/CoreKernel.php
@@ -26,7 +26,7 @@ class CoreKernel extends BaseKernel
      * @throws HTTPResponse_Exception
      * @throws Exception
      */
-    public function boot($flush = false)
+    public function boot(bool $flush = false): void
     {
         $this->flush = $flush;
 
@@ -46,7 +46,7 @@ class CoreKernel extends BaseKernel
      *
      * @throws HTTPResponse_Exception
      */
-    protected function validateDatabase()
+    protected function validateDatabase(): void
     {
         $databaseConfig = DB::getConfig();
         // Gracefully fail if no DB is configured
@@ -61,7 +61,7 @@ class CoreKernel extends BaseKernel
     /**
      * Load default database configuration from the $database and $databaseConfig globals
      */
-    protected function bootDatabaseGlobals()
+    protected function bootDatabaseGlobals(): void
     {
         // Now that configs have been loaded, we can check global for database config
         global $databaseConfig;
@@ -93,7 +93,7 @@ class CoreKernel extends BaseKernel
     /**
      * Load default database configuration from environment variable
      */
-    protected function bootDatabaseEnvVars()
+    protected function bootDatabaseEnvVars(): void
     {
         // Set default database config
         $databaseConfig = $this->getDatabaseConfig();
@@ -106,7 +106,7 @@ class CoreKernel extends BaseKernel
      *
      * @return array
      */
-    protected function getDatabaseConfig()
+    protected function getDatabaseConfig(): array
     {
         /** @skipUpgrade */
         $databaseConfig = [
@@ -148,7 +148,7 @@ class CoreKernel extends BaseKernel
     /**
      * @return string
      */
-    protected function getDatabasePrefix()
+    protected function getDatabasePrefix(): string
     {
         return Environment::getEnv('SS_DATABASE_PREFIX') ?: '';
     }
@@ -156,7 +156,7 @@ class CoreKernel extends BaseKernel
     /**
      * @return string
      */
-    protected function getDatabaseSuffix()
+    protected function getDatabaseSuffix(): string
     {
         return Environment::getEnv('SS_DATABASE_SUFFIX') ?: '';
     }
@@ -166,7 +166,7 @@ class CoreKernel extends BaseKernel
      *
      * @return string
      */
-    protected function getDatabaseName()
+    protected function getDatabaseName(): string
     {
         // Check globals
         global $database;
@@ -223,7 +223,7 @@ class CoreKernel extends BaseKernel
      *
      * @return bool|null null if the kernel hasn't been booted yet
      */
-    public function isFlushed()
+    public function isFlushed(): bool
     {
         return $this->flush;
     }

--- a/src/Core/Environment.php
+++ b/src/Core/Environment.php
@@ -40,7 +40,7 @@ class Environment
      *
      * @return array List of all super globals
      */
-    public static function getVariables()
+    public static function getVariables(): array
     {
         // Suppress return by-ref
         $vars = [ 'env' => static::$env ];
@@ -57,7 +57,7 @@ class Environment
      *
      * @param array $vars
      */
-    public static function setVariables(array $vars)
+    public static function setVariables(array $vars): void
     {
         foreach ($vars as $varName => $varValue) {
             if ($varName === 'env') {
@@ -78,7 +78,7 @@ class Environment
      * @param string|float|int $memoryLimit A memory limit string, such as "64M".  If omitted, unlimited memory will be set.
      * @return bool true indicates a successful change, false a denied change.
      */
-    public static function increaseMemoryLimitTo($memoryLimit = -1)
+    public static function increaseMemoryLimitTo(string|int $memoryLimit = -1): bool
     {
         $memoryLimit = Convert::memstring2bytes($memoryLimit);
         $curLimit = Convert::memstring2bytes(ini_get('memory_limit'));
@@ -111,7 +111,7 @@ class Environment
      *
      * @param string|float $memoryLimit Memory limit string or float value
      */
-    static function setMemoryLimitMax($memoryLimit)
+    static function setMemoryLimitMax(int|string $memoryLimit): void
     {
         if (isset($memoryLimit) && !is_numeric($memoryLimit)) {
             $memoryLimit = Convert::memstring2bytes($memoryLimit);
@@ -122,7 +122,7 @@ class Environment
     /**
      * @return int Memory limit in bytes
      */
-    public static function getMemoryLimitMax()
+    public static function getMemoryLimitMax(): int
     {
         if (static::$memoryLimitMax === null) {
             return Convert::memstring2bytes(ini_get('memory_limit'));
@@ -138,7 +138,7 @@ class Environment
      * @param int $timeLimit The time limit in seconds.  If omitted, no time limit will be set.
      * @return Boolean TRUE indicates a successful change, FALSE a denied change.
      */
-    public static function increaseTimeLimitTo($timeLimit = null)
+    public static function increaseTimeLimitTo(int $timeLimit = null): bool
     {
         // Check vs max limit
         $max = static::getTimeLimitMax();
@@ -163,7 +163,7 @@ class Environment
      *
      * @param int $timeLimit Limit in seconds
      */
-    public static function setTimeLimitMax($timeLimit)
+    public static function setTimeLimitMax($timeLimit): void
     {
         static::$timeLimitMax = $timeLimit;
     }
@@ -171,7 +171,7 @@ class Environment
     /**
      * @return Int Limit in seconds
      */
-    public static function getTimeLimitMax()
+    public static function getTimeLimitMax(): null
     {
         return static::$timeLimitMax;
     }
@@ -182,7 +182,7 @@ class Environment
      * @param string $name
      * @return mixed Value of the environment variable, or false if not set
      */
-    public static function getEnv($name)
+    public static function getEnv(string $name): bool|string|int|null
     {
         switch (true) {
             case  is_array(static::$env) && array_key_exists($name, static::$env):
@@ -203,7 +203,7 @@ class Environment
      *
      * @param string $string Setting to assign in KEY=VALUE or KEY="VALUE" syntax
      */
-    public static function putEnv($string)
+    public static function putEnv(string $string): void
     {
         // Parse name-value pairs
         $envVars = parse_ini_string($string ?? '') ?: [];
@@ -218,7 +218,7 @@ class Environment
      * @param string $name
      * @param string $value
      */
-    public static function setEnv($name, $value)
+    public static function setEnv(string $name, string|bool|int $value): void
     {
         static::$env[$name] = $value;
     }
@@ -228,7 +228,7 @@ class Environment
      *
      * @return bool
      */
-    public static function isCli()
+    public static function isCli(): bool
     {
         return in_array(strtolower(php_sapi_name() ?? ''), ['cli', 'phpdbg']);
     }

--- a/src/Core/EnvironmentLoader.php
+++ b/src/Core/EnvironmentLoader.php
@@ -18,7 +18,7 @@ class EnvironmentLoader
      * @return array|null List of values parsed as an associative array, or null if not loaded
      * If overloading, this list will reflect the final state for all variables
      */
-    public function loadFile($path, $overload = false)
+    public function loadFile(string $path, bool $overload = false): array|null
     {
         // Not readable
         if (!file_exists($path ?? '') || !is_readable($path ?? '')) {

--- a/src/Core/Extension.php
+++ b/src/Core/Extension.php
@@ -36,7 +36,7 @@ abstract class Extension
      */
     private $ownerStack = [];
 
-    public function __construct()
+    public function __construct(): void
     {
     }
 
@@ -47,7 +47,7 @@ abstract class Extension
      * @param string $extensionClass
      * @param mixed $args
      */
-    public static function add_to_class($class, $extensionClass, $args = null)
+    public static function add_to_class(string $class, string $extensionClass, array $args = null): void
     {
         // NOP
     }
@@ -57,7 +57,7 @@ abstract class Extension
      *
      * @param object $owner The owner object
      */
-    public function setOwner($owner)
+    public function setOwner(i18nTestModule|SilverStripe\Control\Director $owner): void
     {
         $this->ownerStack[] = $this->owner;
         $this->owner = $owner;
@@ -84,7 +84,7 @@ abstract class Extension
     /**
      * Clear the current owner, and restore extension to the state prior to the last setOwner()
      */
-    public function clearOwner()
+    public function clearOwner(): void
     {
         if (empty($this->ownerStack)) {
             throw new BadMethodCallException("clearOwner() called more than setOwner()");
@@ -97,7 +97,7 @@ abstract class Extension
      *
      * @return Object
      */
-    public function getOwner()
+    public function getOwner(): null|Page
     {
         return $this->owner;
     }
@@ -110,7 +110,7 @@ abstract class Extension
      * @param string $extensionStr E.g. "Versioned('Stage','Live')"
      * @return string Extension classname, e.g. "Versioned"
      */
-    public static function get_classname_without_arguments($extensionStr)
+    public static function get_classname_without_arguments(string $extensionStr): string
     {
         // Split out both args and service name
         return strtok(strtok($extensionStr ?? '', '(') ?? '', '.');

--- a/src/Core/Injector/AopProxyService.php
+++ b/src/Core/Injector/AopProxyService.php
@@ -18,11 +18,11 @@ class AopProxyService
      * Because we don't know exactly how the proxied class is usually called,
      * provide a default constructor
      */
-    public function __construct()
+    public function __construct(): void
     {
     }
 
-    public function __call($method, $args)
+    public function __call(string $method, array $args): int|null
     {
         if (method_exists($this->proxied, $method ?? '')) {
             $continue = true;

--- a/src/Core/Injector/InjectionCreator.php
+++ b/src/Core/Injector/InjectionCreator.php
@@ -7,7 +7,7 @@ namespace SilverStripe\Core\Injector;
  */
 class InjectionCreator implements Factory
 {
-    public function create($class, array $params = [])
+    public function create(string $class, array $params = []): emteknetnz\TypeTransitioner\DevBuildExtension|i18nProviderClass|i18nTestModule|SilverStripe\Core\Manifest\PrioritySorter
     {
         if (!class_exists($class ?? '')) {
             throw new InjectorNotFoundException("Class {$class} does not exist");

--- a/src/Core/Injector/Injector.php
+++ b/src/Core/Injector/Injector.php
@@ -211,7 +211,7 @@ class Injector implements ContainerInterface
      * @param array $config
      *              Service configuration
      */
-    public function __construct($config = null)
+    public function __construct(array $config = null): void
     {
         $this->injectMap = [];
         $this->serviceCache = [
@@ -246,7 +246,7 @@ class Injector implements ContainerInterface
     /**
      * @return Injector
      */
-    public static function inst()
+    public static function inst(): SilverStripe\Core\Injector\Injector
     {
         return InjectorLoader::inst()->getManifest();
     }
@@ -261,7 +261,7 @@ class Injector implements ContainerInterface
      *
      * @return Injector Reference to new active Injector instance
      */
-    public static function nest()
+    public static function nest(): SilverStripe\Core\Injector\Injector
     {
         // Clone current injector and nest
         $new = clone self::inst();
@@ -275,7 +275,7 @@ class Injector implements ContainerInterface
      *
      * @return Injector Reference to restored active Injector instance
      */
-    public static function unnest()
+    public static function unnest(): SilverStripe\Core\Injector\Injector
     {
         // Unnest unless we would be left at 0 manifests
         $loader = InjectorLoader::inst();
@@ -295,7 +295,7 @@ class Injector implements ContainerInterface
      *
      * @param boolean $val
      */
-    public function setAutoScanProperties($val)
+    public function setAutoScanProperties(bool $val): void
     {
         $this->autoScanProperties = $val;
     }
@@ -305,7 +305,7 @@ class Injector implements ContainerInterface
      *
      * @param \SilverStripe\Core\Injector\Factory $obj
      */
-    public function setObjectCreator(Factory $obj)
+    public function setObjectCreator(Factory $obj): void
     {
         $this->objectCreator = $obj;
     }
@@ -313,7 +313,7 @@ class Injector implements ContainerInterface
     /**
      * @return Factory
      */
-    public function getObjectCreator()
+    public function getObjectCreator(): SilverStripe\Core\Injector\InjectionCreator
     {
         return $this->objectCreator;
     }
@@ -322,7 +322,7 @@ class Injector implements ContainerInterface
      * Set the configuration locator
      * @param ServiceConfigurationLocator $configLocator
      */
-    public function setConfigLocator($configLocator)
+    public function setConfigLocator(SilverStripe\Core\Injector\SilverStripeServiceConfigurationLocator $configLocator): void
     {
         $this->configLocator = $configLocator;
     }
@@ -331,7 +331,7 @@ class Injector implements ContainerInterface
      * Retrieve the configuration locator
      * @return ServiceConfigurationLocator
      */
-    public function getConfigLocator()
+    public function getConfigLocator(): SilverStripe\Core\Injector\SilverStripeServiceConfigurationLocator
     {
         return $this->configLocator;
     }
@@ -347,7 +347,7 @@ class Injector implements ContainerInterface
      * @param string $toInject The registered type that will be injected
      * @param string $injectVia Whether to inject by setting a property or calling a setter
      */
-    public function setInjectMapping($class, $property, $toInject, $injectVia = 'property')
+    public function setInjectMapping(string $class, string $property, string $toInject, string $injectVia = 'property'): void
     {
         $mapping = isset($this->injectMap[$class]) ? $this->injectMap[$class] : [];
 
@@ -370,7 +370,7 @@ class Injector implements ContainerInterface
      *                the object to be set
      * @return $this
      */
-    public function addAutoProperty($property, $object)
+    public function addAutoProperty(string $property, string $object): SilverStripe\Core\Injector\Injector
     {
         $this->autoProperties[$property] = $object;
         return $this;
@@ -382,7 +382,7 @@ class Injector implements ContainerInterface
      * @param array $config
      * @return $this
      */
-    public function load($config = [])
+    public function load(array $config = []): SilverStripe\Core\Injector\Injector
     {
         foreach ($config as $specId => $spec) {
             if (is_string($spec)) {
@@ -466,7 +466,7 @@ class Injector implements ContainerInterface
      * @param boolean $append
      *              Whether to append (the default) when the property is an array
      */
-    public function updateSpec($id, $property, $value, $append = true)
+    public function updateSpec(string $id, string $property, string $value, $append = true): void
     {
         if (isset($this->specs[$id]['properties'][$property])) {
             // by ref so we're updating the actual value
@@ -493,7 +493,7 @@ class Injector implements ContainerInterface
      * @param array $spec
      *          The class specification to update
      */
-    protected function updateSpecConstructor(&$spec)
+    protected function updateSpecConstructor(array &$spec): void
     {
         if (isset($spec['constructor'])) {
             $spec['constructor'] = $this->convertServiceProperty($spec['constructor']);
@@ -507,7 +507,7 @@ class Injector implements ContainerInterface
      * @param string $value
      * @return array|mixed|string
      */
-    public function convertServiceProperty($value)
+    public function convertServiceProperty(string|array|int|bool|float $value): string|array|null|int|bool|float|Monolog\Handler\SyslogHandler
     {
         if (is_array($value)) {
             $newVal = [];
@@ -584,7 +584,7 @@ class Injector implements ContainerInterface
      *                wants the object to be returned
      * @return object
      */
-    protected function instantiate($spec, $id = null, $type = null)
+    protected function instantiate(array $spec, string $id = null, string $type = null): emteknetnz\TypeTransitioner\DevBuildExtension|null|i18nProviderClass|i18nTestModule|SilverStripe\Core\Manifest\PrioritySorter
     {
         if (is_string($spec)) {
             $spec = ['class' => $spec];
@@ -651,7 +651,7 @@ class Injector implements ContainerInterface
      *              for a type is referenced correctly in case $object is no longer the same
      *              type as the loaded config specification had it as.
      */
-    public function inject($object, $asType = null)
+    public function inject(emteknetnz\TypeTransitioner\DevBuildExtension|i18nProviderClass|i18nTestModule|SilverStripe\Core\Manifest\PrioritySorter $object, string $asType = null): void
     {
         $objtype = $asType ? $asType : get_class($object);
         $mapping = isset($this->injectMap[$objtype]) ? $this->injectMap[$objtype] : null;
@@ -816,7 +816,7 @@ class Injector implements ContainerInterface
      * @param mixed $value
      *                  The value to set
      */
-    protected function setObjectProperty($object, $name, $value)
+    protected function setObjectProperty(SilverStripe\Core\Manifest\PrioritySorter $object, string $name, string|int|array|bool|SilverStripe\Logging\DetailedErrorFormatter $value): void
     {
         if (ClassInfo::hasMethod($object, 'set' . $name)) {
             $object->{'set' . $name}($value);
@@ -849,7 +849,7 @@ class Injector implements ContainerInterface
      * @param string $name
      * @return boolean
      */
-    public function has($name)
+    public function has(string $name): bool
     {
         return (bool)$this->getServiceName($name);
     }
@@ -866,7 +866,7 @@ class Injector implements ContainerInterface
      * @param string $name
      * @return string|null The name of the service (as it might be different from the one passed in)
      */
-    public function getServiceName($name)
+    public function getServiceName(string $name): string|null
     {
         // Lazy load in spec (disable inheritance to check exact service name)
         if ($this->getServiceSpec($name, false)) {
@@ -891,7 +891,7 @@ class Injector implements ContainerInterface
      * class name of the object to register)
      * @return $this
      */
-    public function registerService($service, $replace = null)
+    public function registerService(SilverStripe\Core\CoreKernel $service, string $replace = null): SilverStripe\Core\Injector\Injector
     {
         $registerAt = get_class($service);
         if ($replace !== null) {
@@ -910,7 +910,7 @@ class Injector implements ContainerInterface
      * @param string $name The name to unregister
      * @return $this
      */
-    public function unregisterNamedObject($name)
+    public function unregisterNamedObject(string $name): SilverStripe\Core\Injector\Injector
     {
         unset($this->serviceCache[$name]);
         unset($this->specs[$name]);
@@ -923,7 +923,7 @@ class Injector implements ContainerInterface
      * @param array|string $types Base class of object (not service name) to remove
      * @return $this
      */
-    public function unregisterObjects($types)
+    public function unregisterObjects(array|string $types): SilverStripe\Core\Injector\Injector
     {
         if (!is_array($types)) {
             $types = [ $types ];
@@ -965,7 +965,7 @@ class Injector implements ContainerInterface
      * @param array $constructorArgs Args to pass in to the constructor. Note: Ignored for singletons
      * @return mixed Instance of the specified object
      */
-    public function get($name, $asSingleton = true, $constructorArgs = [])
+    public function get(string|SilverStripe\Comments\Admin\CommentsGridFieldBulkAction\SpamHandler $name, bool $asSingleton = true, array $constructorArgs = []): emteknetnz\TypeTransitioner\DevBuildExtension|i18nProviderClass|i18nTestModule|SilverStripe\Core\CoreKernel
     {
         $object = $this->getNamedService($name, $asSingleton, $constructorArgs);
 
@@ -986,7 +986,7 @@ class Injector implements ContainerInterface
      * @param array $constructorArgs Args to pass in to the constructor. Note: Ignored for singletons
      * @return mixed Instance of the specified object
      */
-    protected function getNamedService($name, $asSingleton = true, $constructorArgs = [])
+    protected function getNamedService(string|SilverStripe\Comments\Admin\CommentsGridFieldBulkAction\SpamHandler $name, bool $asSingleton = true, array $constructorArgs = []): emteknetnz\TypeTransitioner\DevBuildExtension|null|i18nProviderClass|i18nTestModule|SilverStripe\Core\CoreKernel
     {
         // Normalise service / args
         list($name, $constructorArgs) = $this->normaliseArguments($name, $constructorArgs);
@@ -1026,7 +1026,7 @@ class Injector implements ContainerInterface
      * @param array $args
      * @return array Two items with name and new args
      */
-    protected function normaliseArguments($name, $args = [])
+    protected function normaliseArguments(string|SilverStripe\Comments\Admin\CommentsGridFieldBulkAction\SpamHandler $name, array $args = []): array
     {
         // Allow service names of the form "%$ServiceName"
         if (substr($name ?? '', 0, 2) == '%$') {
@@ -1052,7 +1052,7 @@ class Injector implements ContainerInterface
      * @param array $constructorArgs Optional constructor args
      * @return array
      */
-    protected function getServiceNamedSpec($name, $constructorArgs = [])
+    protected function getServiceNamedSpec(string $name, array $constructorArgs = []): array
     {
         $spec = $this->getServiceSpec($name);
         if ($spec) {
@@ -1077,7 +1077,7 @@ class Injector implements ContainerInterface
      * E.g. 'Psr/Log/LoggerInterface.custom' would fail over to 'Psr/Log/LoggerInterface'
      * @return mixed|object
      */
-    public function getServiceSpec($name, $inherit = true)
+    public function getServiceSpec(string $name, bool $inherit = true): array|null
     {
         if (isset($this->specs[$name])) {
             return $this->specs[$name];
@@ -1121,7 +1121,7 @@ class Injector implements ContainerInterface
      * @param mixed ...$argument arguments to pass to the constructor
      * @return mixed A new instance of the specified object
      */
-    public function create($name, $argument = null)
+    public function create(string $name, string|array|int|SilverStripe\ErrorPage\ErrorPage $argument = null): MySQLDatabase_ac19722
     {
         $constructorArgs = func_get_args();
         array_shift($constructorArgs);
@@ -1135,7 +1135,7 @@ class Injector implements ContainerInterface
      * @param array $constructorArgs Arguments to pass to the constructor
      * @return mixed
      */
-    public function createWithArgs($name, $constructorArgs)
+    public function createWithArgs(string $name, array $constructorArgs): SilverStripe\Core\Manifest\PrioritySorter
     {
         return $this->get($name, false, $constructorArgs);
     }

--- a/src/Core/Injector/InjectorLoader.php
+++ b/src/Core/Injector/InjectorLoader.php
@@ -23,7 +23,7 @@ class InjectorLoader
     /**
      * @return self
      */
-    public static function inst()
+    public static function inst(): SilverStripe\Core\Injector\InjectorLoader
     {
         return self::$instance ? self::$instance : self::$instance = new static();
     }
@@ -34,7 +34,7 @@ class InjectorLoader
      *
      * @return Injector
      */
-    public function getManifest()
+    public function getManifest(): SilverStripe\Core\Injector\Injector
     {
         if ($this !== self::$instance) {
             throw new BadMethodCallException(
@@ -62,7 +62,7 @@ class InjectorLoader
      *
      * @param Injector $manifest
      */
-    public function pushManifest(Injector $manifest)
+    public function pushManifest(Injector $manifest): void
     {
         $this->manifests[] = $manifest;
     }
@@ -70,7 +70,7 @@ class InjectorLoader
     /**
      * @return Injector
      */
-    public function popManifest()
+    public function popManifest(): SilverStripe\Core\Injector\Injector
     {
         return array_pop($this->manifests);
     }
@@ -80,7 +80,7 @@ class InjectorLoader
      *
      * @return int
      */
-    public function countManifests()
+    public function countManifests(): int
     {
         return count($this->manifests ?? []);
     }
@@ -90,7 +90,7 @@ class InjectorLoader
      *
      * @return static
      */
-    public function nest()
+    public function nest(): SilverStripe\Core\Injector\InjectorLoader
     {
         // Nest injector (note: Don't call getManifest()->nest() since that self-pushes a new manifest)
         $manifest = clone $this->getManifest();
@@ -109,7 +109,7 @@ class InjectorLoader
      *
      * @return $this
      */
-    public function activate()
+    public function activate(): SilverStripe\Core\Injector\InjectorLoader
     {
         static::$instance = $this;
         return $this;

--- a/src/Core/Injector/SilverStripeServiceConfigurationLocator.php
+++ b/src/Core/Injector/SilverStripeServiceConfigurationLocator.php
@@ -20,7 +20,7 @@ class SilverStripeServiceConfigurationLocator implements ServiceConfigurationLoc
      */
     protected $configs = [];
 
-    public function locateConfigFor($name)
+    public function locateConfigFor(string $name): array|null|string
     {
         // Check direct or cached result
         $config = $this->configFor($name);
@@ -44,7 +44,7 @@ class SilverStripeServiceConfigurationLocator implements ServiceConfigurationLoc
      * @param string $name Name of service
      * @return mixed Get config for this service
      */
-    protected function configFor($name)
+    protected function configFor(string $name): array|null|string
     {
         // Return cached result
         if (array_key_exists($name, $this->configs ?? [])) {

--- a/src/Core/Manifest/ClassContentRemover.php
+++ b/src/Core/Manifest/ClassContentRemover.php
@@ -19,7 +19,7 @@ class ClassContentRemover
      *
      * @return string
      */
-    public static function remove_class_content($filePath, $cutOffDepth = 1)
+    public static function remove_class_content(string $filePath, $cutOffDepth = 1): string
     {
 
         // Use PHP's built in method to strip comments and whitespace

--- a/src/Core/Manifest/ClassLoader.php
+++ b/src/Core/Manifest/ClassLoader.php
@@ -28,7 +28,7 @@ class ClassLoader
     /**
      * @return ClassLoader
      */
-    public static function inst()
+    public static function inst(): SilverStripe\Core\Manifest\ClassLoader
     {
         return self::$instance ? self::$instance : self::$instance = new static();
     }
@@ -39,7 +39,7 @@ class ClassLoader
      *
      * @return ClassManifest
      */
-    public function getManifest()
+    public function getManifest(): SilverStripe\Core\Manifest\ClassManifest
     {
         return $this->manifests[count($this->manifests) - 1]['instance'];
     }
@@ -59,7 +59,7 @@ class ClassLoader
      * @param bool $exclusive Marks the manifest as exclusive. If set to FALSE, will
      * look for classes in earlier manifests as well.
      */
-    public function pushManifest(ClassManifest $manifest, $exclusive = true)
+    public function pushManifest(ClassManifest $manifest, bool $exclusive = true): void
     {
         $this->manifests[] = ['exclusive' => $exclusive, 'instance' => $manifest];
     }
@@ -67,13 +67,13 @@ class ClassLoader
     /**
      * @return ClassManifest
      */
-    public function popManifest()
+    public function popManifest(): SilverStripe\Core\Manifest\ClassManifest
     {
         $manifest = array_pop($this->manifests);
         return $manifest['instance'];
     }
 
-    public function registerAutoloader()
+    public function registerAutoloader(): void
     {
         spl_autoload_register([$this, 'loadClass']);
     }
@@ -85,7 +85,7 @@ class ClassLoader
      * @param string $class
      * @return String
      */
-    public function loadClass($class)
+    public function loadClass(string $class): string|bool
     {
         if ($path = $this->getItemPath($class)) {
             require_once $path;
@@ -100,7 +100,7 @@ class ClassLoader
      * @param string $class
      * @return string|false
      */
-    public function getItemPath($class)
+    public function getItemPath(string $class): string|bool
     {
         foreach (array_reverse($this->manifests ?? []) as $manifest) {
             /** @var ClassManifest $manifestInst */
@@ -122,7 +122,7 @@ class ClassLoader
      * @param bool $forceRegen
      * @param string[] $ignoredCIConfigs
      */
-    public function init($includeTests = false, $forceRegen = false, array $ignoredCIConfigs = [])
+    public function init(bool $includeTests = false, bool $forceRegen = false, array $ignoredCIConfigs = []): void
     {
         foreach ($this->manifests as $manifest) {
             /** @var ClassManifest $instance */

--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -182,14 +182,14 @@ class ClassManifest
      * @param string $base The manifest base path.
      * @param CacheFactory $cacheFactory Optional cache to use. Set to null to not cache.
      */
-    public function __construct($base, CacheFactory $cacheFactory = null)
+    public function __construct(string $base, CacheFactory $cacheFactory = null): void
     {
         $this->base = $base;
         $this->cacheFactory = $cacheFactory;
         $this->cacheKey = 'manifest';
     }
 
-    private function buildCache($includeTests = false)
+    private function buildCache(bool $includeTests = false): null|Symfony\Component\Cache\Simple\FilesystemCache
     {
         if ($this->cache) {
             return $this->cache;
@@ -236,7 +236,7 @@ class ClassManifest
     /**
      * @internal This method is not a part of public API and will be deleted without a deprecation warning
      */
-    public function isFlushScheduled($includeTests = false)
+    public function isFlushScheduled($includeTests = false): null
     {
         $cache = $this->buildCache($includeTests);
 
@@ -262,7 +262,7 @@ class ClassManifest
      * @param bool $forceRegen
      * @param string[] $ignoredCIConfigs
      */
-    public function init($includeTests = false, $forceRegen = false, array $ignoredCIConfigs = [])
+    public function init(bool $includeTests = false, bool $forceRegen = false, array $ignoredCIConfigs = []): void
     {
         $this->cache = $this->buildCache($includeTests);
 
@@ -284,7 +284,7 @@ class ClassManifest
      *
      * @return Parser
      */
-    public function getParser()
+    public function getParser(): PhpParser\Parser\Multiple
     {
         if (!$this->parser) {
             $this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -298,7 +298,7 @@ class ClassManifest
      *
      * @return NodeTraverser
      */
-    public function getTraverser()
+    public function getTraverser(): PhpParser\NodeTraverser
     {
         if (!$this->traverser) {
             $this->traverser = new NodeTraverser;
@@ -314,7 +314,7 @@ class ClassManifest
      *
      * @return ClassManifestVisitor
      */
-    public function getVisitor()
+    public function getVisitor(): SilverStripe\Core\Manifest\ClassManifestVisitor
     {
         if (!$this->visitor) {
             $this->visitor = new ClassManifestVisitor;
@@ -330,7 +330,7 @@ class ClassManifest
      * @param  string $name
      * @return string|null
      */
-    public function getItemPath($name)
+    public function getItemPath(string $name): string|null
     {
         $lowerName = strtolower($name ?? '');
         foreach ([
@@ -351,7 +351,7 @@ class ClassManifest
      * @param string $name
      * @return string Correct case name
      */
-    public function getItemName($name)
+    public function getItemName(string $name): string|null
     {
         $lowerName = strtolower($name ?? '');
         foreach ([
@@ -371,7 +371,7 @@ class ClassManifest
      *
      * @return array
      */
-    public function getClasses()
+    public function getClasses(): array
     {
         return $this->classes;
     }
@@ -381,7 +381,7 @@ class ClassManifest
      *
      * @return array
      */
-    public function getClassNames()
+    public function getClassNames(): array
     {
         return $this->classNames;
     }
@@ -401,7 +401,7 @@ class ClassManifest
      *
      * @return array
      */
-    public function getTraitNames()
+    public function getTraitNames(): array
     {
         return $this->traitNames;
     }
@@ -411,7 +411,7 @@ class ClassManifest
      *
      * @return array
      */
-    public function getDescendants()
+    public function getDescendants(): array
     {
         return $this->descendants;
     }
@@ -423,7 +423,7 @@ class ClassManifest
      * @param  string|object $class
      * @return array
      */
-    public function getDescendantsOf($class)
+    public function getDescendantsOf(string $class): array
     {
         if (is_object($class)) {
             $class = get_class($class);
@@ -442,7 +442,7 @@ class ClassManifest
      *
      * @return array
      */
-    public function getInterfaces()
+    public function getInterfaces(): array
     {
         return $this->interfaces;
     }
@@ -463,7 +463,7 @@ class ClassManifest
      *
      * @return array
      */
-    public function getImplementors()
+    public function getImplementors(): array
     {
         return $this->implementors;
     }
@@ -475,7 +475,7 @@ class ClassManifest
      * @param string $interface
      * @return array
      */
-    public function getImplementorsOf($interface)
+    public function getImplementorsOf(string $interface): array
     {
         $lowerInterface = strtolower($interface ?? '');
         if (array_key_exists($lowerInterface, $this->implementors ?? [])) {
@@ -491,7 +491,7 @@ class ClassManifest
      * @param string $class Class name
      * @return Module
      */
-    public function getOwnerModule($class)
+    public function getOwnerModule(string $class): SilverStripe\Core\Manifest\Module
     {
         $path = $this->getItemPath($class);
         return ModuleLoader::inst()->getManifest()->getModuleByPath($path);
@@ -503,7 +503,7 @@ class ClassManifest
      * @param bool $includeTests
      * @param string[] $ignoredCIConfigs
      */
-    public function regenerate($includeTests, array $ignoredCIConfigs = [])
+    public function regenerate(bool $includeTests, array $ignoredCIConfigs = []): void
     {
         // Reset the manifest so stale info doesn't cause errors.
         $this->loadState([]);
@@ -544,7 +544,7 @@ class ClassManifest
      * @param bool $includeTests
      * @throws Exception
      */
-    public function handleFile($basename, $pathname, $includeTests)
+    public function handleFile(string $basename, string $pathname, bool $includeTests): void
     {
         // The results of individual file parses are cached, since only a few
         // files will have changed and TokenisedRegularExpression is quite
@@ -659,7 +659,7 @@ class ClassManifest
      * @param  string $class
      * @return array
      */
-    protected function coalesceDescendants($class)
+    protected function coalesceDescendants(string $class): array
     {
         // Reset descendents to immediate children initially
         $lowerClass = strtolower($class ?? '');
@@ -685,7 +685,7 @@ class ClassManifest
      * @param array $data
      * @return bool True if cache was valid and successfully loaded
      */
-    protected function loadState($data)
+    protected function loadState(array $data): bool
     {
         $success = true;
         foreach ($this->serialisedProperties as $property) {
@@ -705,7 +705,7 @@ class ClassManifest
      *
      * @return array
      */
-    protected function getState()
+    protected function getState(): array
     {
         $data = [];
         foreach ($this->serialisedProperties as $property) {
@@ -720,7 +720,7 @@ class ClassManifest
      * @param array $data
      * @return bool
      */
-    protected function validateItemCache($data)
+    protected function validateItemCache(array $data): bool
     {
         if (!$data || !is_array($data)) {
             return false;

--- a/src/Core/Manifest/ClassManifestErrorHandler.php
+++ b/src/Core/Manifest/ClassManifestErrorHandler.php
@@ -19,7 +19,7 @@ class ClassManifestErrorHandler implements ErrorHandler
     /**
      * @param string $pathname
      */
-    public function __construct($pathname)
+    public function __construct(string $pathname): void
     {
         $this->pathname = $pathname;
     }

--- a/src/Core/Manifest/ClassManifestVisitor.php
+++ b/src/Core/Manifest/ClassManifestVisitor.php
@@ -15,19 +15,19 @@ class ClassManifestVisitor extends NodeVisitorAbstract
 
     private $interfaces = [];
 
-    public function resetState()
+    public function resetState(): void
     {
         $this->classes = [];
         $this->traits = [];
         $this->interfaces = [];
     }
 
-    public function beforeTraverse(array $nodes)
+    public function beforeTraverse(array $nodes): void
     {
         $this->resetState();
     }
 
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): int|nothing
     {
         if ($node instanceof Node\Stmt\Class_) {
             $extends = [];
@@ -64,17 +64,17 @@ class ClassManifestVisitor extends NodeVisitorAbstract
         }
     }
 
-    public function getClasses()
+    public function getClasses(): array
     {
         return $this->classes;
     }
 
-    public function getTraits()
+    public function getTraits(): array
     {
         return $this->traits;
     }
 
-    public function getInterfaces()
+    public function getInterfaces(): array
     {
         return $this->interfaces;
     }

--- a/src/Core/Manifest/ManifestFileFinder.php
+++ b/src/Core/Manifest/ManifestFileFinder.php
@@ -38,7 +38,7 @@ class ManifestFileFinder extends FileFinder
         'ignored_ci_configs' => []
     ];
 
-    public function acceptDir($basename, $pathname, $depth)
+    public function acceptDir(string $basename, string $pathname, int $depth): bool
     {
         // Skip if ignored
         if ($this->isInsideIgnored($basename, $pathname, $depth)) {
@@ -95,7 +95,7 @@ class ManifestFileFinder extends FileFinder
      * @param int $depth
      * @return bool
      */
-    public function isInsideVendor($basename, $pathname, $depth)
+    public function isInsideVendor(string $basename, string $pathname, int $depth): bool
     {
         $base = basename($this->upLevels($pathname, $depth - 1) ?? '');
         return $base === self::VENDOR_DIR;
@@ -109,7 +109,7 @@ class ManifestFileFinder extends FileFinder
      * @param int $depth
      * @return bool
      */
-    public function isInsideThemes($basename, $pathname, $depth)
+    public function isInsideThemes(string $basename, string $pathname, int $depth): bool
     {
         $base = basename($this->upLevels($pathname, $depth - 1) ?? '');
         return $base === THEMES_DIR;
@@ -123,7 +123,7 @@ class ManifestFileFinder extends FileFinder
      * @param int $depth
      * @return bool
      */
-    public function isInsideIgnored($basename, $pathname, $depth)
+    public function isInsideIgnored(string $basename, string $pathname, int $depth): bool
     {
         return $this->anyParents($basename, $pathname, $depth, function ($basename, $pathname, $depth) {
             return $this->isDirectoryIgnored($basename, $pathname, $depth);
@@ -138,7 +138,7 @@ class ManifestFileFinder extends FileFinder
      * @param int $depth
      * @return bool
      */
-    public function isInsideModule($basename, $pathname, $depth)
+    public function isInsideModule(string $basename, string $pathname, int $depth): bool
     {
         return $this->anyParents($basename, $pathname, $depth, function ($basename, $pathname, $depth) {
             return $this->isDirectoryModule($basename, $pathname, $depth);
@@ -154,7 +154,7 @@ class ManifestFileFinder extends FileFinder
      * @param callable $callback
      * @return bool
      */
-    protected function anyParents($basename, $pathname, $depth, $callback)
+    protected function anyParents(string $basename, string $pathname, int $depth, callable $callback): bool
     {
         // Check all ignored dir up the path
         while ($depth >= 0) {
@@ -177,7 +177,7 @@ class ManifestFileFinder extends FileFinder
      * @param string $depth
      * @return bool
      */
-    public function isDirectoryModule($basename, $pathname, $depth)
+    public function isDirectoryModule(string $basename, string $pathname, int $depth): bool
     {
         // Depth can either be 0, 1, or 3 (if and only if inside vendor)
         $inVendor = $this->isInsideVendor($basename, $pathname, $depth);
@@ -205,7 +205,7 @@ class ManifestFileFinder extends FileFinder
      * @param int $depth Number of parents to rise
      * @return string
      */
-    protected function upLevels($pathname, $depth)
+    protected function upLevels(string $pathname, int $depth): string|null
     {
         if ($depth < 0) {
             return null;
@@ -221,7 +221,7 @@ class ManifestFileFinder extends FileFinder
      *
      * @return array
      */
-    protected function getIgnoredDirs()
+    protected function getIgnoredDirs(): array
     {
         $ignored = [self::LANG_DIR, 'node_modules'];
         if ($this->getOption('ignore_tests')) {
@@ -237,7 +237,7 @@ class ManifestFileFinder extends FileFinder
      * @param string $depth
      * @return bool
      */
-    public function isDirectoryIgnored($basename, $pathname, $depth)
+    public function isDirectoryIgnored(string $basename, string $pathname, int $depth): bool
     {
         // Don't ignore root
         if ($depth === 0) {

--- a/src/Core/Manifest/Module.php
+++ b/src/Core/Manifest/Module.php
@@ -72,7 +72,7 @@ class Module implements Serializable
      * @param string $path Absolute filesystem path to this module
      * @param string $basePath base path for the application this module is installed in
      */
-    public function __construct($path, $basePath)
+    public function __construct(string $path, string $basePath): void
     {
         $this->path = Path::normalise($path);
         $this->basePath = Path::normalise($basePath);
@@ -87,7 +87,7 @@ class Module implements Serializable
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->getComposerName() ?: $this->getShortName();
     }
@@ -97,7 +97,7 @@ class Module implements Serializable
      *
      * @return string|null
      */
-    public function getComposerName()
+    public function getComposerName(): null|string
     {
         if (isset($this->composerData['name'])) {
             return $this->composerData['name'];
@@ -126,7 +126,7 @@ class Module implements Serializable
      *
      * @return string
      */
-    public function getShortName()
+    public function getShortName(): string
     {
         // If installed in the root directory we need to infer from composer
         if ($this->path === $this->basePath && $this->composerData) {
@@ -154,7 +154,7 @@ class Module implements Serializable
      * Only applicable when reading the composer file for the main project.
      * @return string
      */
-    public function getResourcesDir()
+    public function getResourcesDir(): string
     {
         return isset($this->composerData['extra']['resources-dir'])
             ? $this->composerData['extra']['resources-dir']
@@ -166,7 +166,7 @@ class Module implements Serializable
      *
      * @return string Path with no trailing slash E.g. /var/www/module
      */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
@@ -177,7 +177,7 @@ class Module implements Serializable
      *
      * @return string Path with trimmed slashes. E.g. vendor/silverstripe/module.
      */
-    public function getRelativePath()
+    public function getRelativePath(): string
     {
         if ($this->path === $this->basePath) {
             return '';
@@ -230,7 +230,7 @@ class Module implements Serializable
     /**
      * Activate _config.php for this module, if one exists
      */
-    public function activate()
+    public function activate(): void
     {
         $config = "{$this->path}/_config.php";
         if (file_exists($config ?? '')) {
@@ -241,7 +241,7 @@ class Module implements Serializable
     /**
      * @throws Exception
      */
-    protected function loadComposer()
+    protected function loadComposer(): void
     {
         // Load composer data
         $path = "{$this->path}/composer.json";
@@ -262,7 +262,7 @@ class Module implements Serializable
      * @param string $path
      * @return ModuleResource
      */
-    public function getResource($path)
+    public function getResource(string $path): SilverStripe\Core\Manifest\ModuleResource
     {
         $path = Path::normalise($path, true);
         if (empty($path)) {
@@ -403,7 +403,7 @@ class Module implements Serializable
      * @param string[] $modules
      * @return false|string
      */
-    private function requireDevConstraint(array $modules)
+    private function requireDevConstraint(array $modules): string|bool
     {
         if (empty($this->composerData['require-dev']) || !is_array($this->composerData['require-dev'])) {
             return false;

--- a/src/Core/Manifest/ModuleLoader.php
+++ b/src/Core/Manifest/ModuleLoader.php
@@ -20,7 +20,7 @@ class ModuleLoader
     /**
      * @return self
      */
-    public static function inst()
+    public static function inst(): SilverStripe\Core\Manifest\ModuleLoader
     {
         return self::$instance ? self::$instance : self::$instance = new static();
     }
@@ -32,7 +32,7 @@ class ModuleLoader
      * @param string $module
      * @return Module
      */
-    public static function getModule($module)
+    public static function getModule(string $module): SilverStripe\Core\Manifest\Module
     {
         return static::inst()->getManifest()->getModule($module);
     }
@@ -43,7 +43,7 @@ class ModuleLoader
      *
      * @return ModuleManifest
      */
-    public function getManifest()
+    public function getManifest(): SilverStripe\Core\Manifest\ModuleManifest
     {
         return $this->manifests[count($this->manifests) - 1];
     }
@@ -63,7 +63,7 @@ class ModuleLoader
      *
      * @param ModuleManifest $manifest
      */
-    public function pushManifest(ModuleManifest $manifest)
+    public function pushManifest(ModuleManifest $manifest): void
     {
         $this->manifests[] = $manifest;
     }
@@ -71,7 +71,7 @@ class ModuleLoader
     /**
      * @return ModuleManifest
      */
-    public function popManifest()
+    public function popManifest(): SilverStripe\Core\Manifest\ModuleManifest
     {
         return array_pop($this->manifests);
     }
@@ -93,7 +93,7 @@ class ModuleLoader
      * @param bool $forceRegen
      * @param string[] $ignoredCIConfigs
      */
-    public function init($includeTests = false, $forceRegen = false, array $ignoredCIConfigs = [])
+    public function init(bool $includeTests = false, bool $forceRegen = false, array $ignoredCIConfigs = []): void
     {
         foreach ($this->manifests as $manifest) {
             $manifest->init($includeTests, $forceRegen, $ignoredCIConfigs);

--- a/src/Core/Manifest/ModuleManifest.php
+++ b/src/Core/Manifest/ModuleManifest.php
@@ -73,7 +73,7 @@ class ModuleManifest
      * @param string $base The project base path.
      * @param CacheFactory $cacheFactory Cache factory to use
      */
-    public function __construct($base, CacheFactory $cacheFactory = null)
+    public function __construct(string $base, CacheFactory $cacheFactory = null): void
     {
         $this->base = $base;
         $this->cacheKey = sha1($base ?? '') . '_modules';
@@ -85,7 +85,7 @@ class ModuleManifest
      *
      * @param string $path
      */
-    public function addModule($path)
+    public function addModule(string $path): void
     {
         $module = new Module($path, $this->base);
         $name = $module->getName();
@@ -112,7 +112,7 @@ class ModuleManifest
      * @param string $name Either full composer name or short name
      * @return bool
      */
-    public function moduleExists($name)
+    public function moduleExists(string $name): bool
     {
         $module = $this->getModule($name);
         return !empty($module);
@@ -123,7 +123,7 @@ class ModuleManifest
      * @param bool $forceRegen Force the manifest to be regenerated.
      * @param string[] $ignoredCIConfigs
      */
-    public function init($includeTests = false, $forceRegen = false, array $ignoredCIConfigs = [])
+    public function init(bool $includeTests = false, bool $forceRegen = false, array $ignoredCIConfigs = []): void
     {
         // build cache from factory
         if ($this->cacheFactory) {
@@ -145,7 +145,7 @@ class ModuleManifest
     /**
      * Includes all of the php _config.php files found by this manifest.
      */
-    public function activateConfig()
+    public function activateConfig(): void
     {
         $modules = $this->getModules();
         // Work in reverse priority, so the higher priority modules get later execution
@@ -165,7 +165,7 @@ class ModuleManifest
      * @param bool $includeTests
      * @param string[] $ignoredCIConfigs
      */
-    public function regenerate($includeTests = false, array $ignoredCIConfigs = [])
+    public function regenerate(bool $includeTests = false, array $ignoredCIConfigs = []): void
     {
         $this->modules = [];
 
@@ -198,7 +198,7 @@ class ModuleManifest
      * @param string $name
      * @return Module
      */
-    public function getModule($name)
+    public function getModule(string $name): SilverStripe\Core\Manifest\Module|null
     {
         // Optimised find
         if (isset($this->modules[$name])) {
@@ -222,7 +222,7 @@ class ModuleManifest
      *
      * @return Module[]
      */
-    public function getModules()
+    public function getModules(): array
     {
         return $this->modules;
     }
@@ -230,7 +230,7 @@ class ModuleManifest
     /**
      * Sort modules sorted by priority
      */
-    public function sort()
+    public function sort(): void
     {
         $order = static::config()->uninherited('module_priority');
         $project = static::config()->get('project');
@@ -257,7 +257,7 @@ class ModuleManifest
      * @param string $path Full filesystem path to the given file
      * @return Module The module, or null if not a path in any module
      */
-    public function getModuleByPath($path)
+    public function getModuleByPath(string $path): SilverStripe\Core\Manifest\Module|null
     {
         // Ensure path exists
         $path = realpath($path ?? '');

--- a/src/Core/Manifest/ModuleResource.php
+++ b/src/Core/Manifest/ModuleResource.php
@@ -37,7 +37,7 @@ class ModuleResource
      * @param Module $module
      * @param string $relativePath
      */
-    public function __construct(Module $module, $relativePath)
+    public function __construct(Module $module, string $relativePath): void
     {
         $this->module = $module;
         $this->relativePath = Path::normalise($relativePath, true);
@@ -54,7 +54,7 @@ class ModuleResource
      *
      * @return string Path with no trailing slash E.g. /var/www/module
      */
-    public function getPath()
+    public function getPath(): string
     {
         return Path::join($this->module->getPath(), $this->relativePath);
     }
@@ -67,7 +67,7 @@ class ModuleResource
      *
      * @return string Relative path (no leading /)
      */
-    public function getRelativePath()
+    public function getRelativePath(): string
     {
         // Root module
         $parent = $this->module->getRelativePath();
@@ -86,7 +86,7 @@ class ModuleResource
      *
      * @return string
      */
-    public function getURL()
+    public function getURL(): string
     {
         /** @var ResourceURLGenerator $generator */
         $generator = Injector::inst()->get(ResourceURLGenerator::class);
@@ -108,7 +108,7 @@ class ModuleResource
      *
      * @return bool
      */
-    public function exists()
+    public function exists(): bool
     {
         return file_exists($this->getPath() ?? '');
     }
@@ -126,7 +126,7 @@ class ModuleResource
     /**
      * @return Module
      */
-    public function getModule()
+    public function getModule(): SilverStripe\Core\Manifest\Module
     {
         return $this->module;
     }
@@ -138,7 +138,7 @@ class ModuleResource
      * @param string $path
      * @return ModuleResource
      */
-    public function getRelativeResource($path)
+    public function getRelativeResource(string $path): SilverStripe\Core\Manifest\ModuleResource
     {
         // Defer to parent module
         $relativeToModule = Path::join($this->relativePath, $path);

--- a/src/Core/Manifest/ModuleResourceLoader.php
+++ b/src/Core/Manifest/ModuleResourceLoader.php
@@ -21,7 +21,7 @@ class ModuleResourceLoader implements TemplateGlobalProvider
      * @param string $resource
      * @return string
      */
-    public function resolvePath($resource)
+    public function resolvePath(string $resource): string
     {
         // Skip blank resources
         if (empty($resource)) {
@@ -40,7 +40,7 @@ class ModuleResourceLoader implements TemplateGlobalProvider
      * @param string $resource
      * @return string
      */
-    public function resolveURL($resource)
+    public function resolveURL(string $resource): string
     {
         // Skip blank resources
         if (empty($resource)) {
@@ -62,7 +62,7 @@ class ModuleResourceLoader implements TemplateGlobalProvider
      * @param string $resource
      * @return string
      */
-    public static function resourcePath($resource)
+    public static function resourcePath(string $resource): string
     {
         return static::singleton()->resolvePath($resource);
     }
@@ -73,12 +73,12 @@ class ModuleResourceLoader implements TemplateGlobalProvider
      * @param string $resource
      * @return string
      */
-    public static function resourceURL($resource)
+    public static function resourceURL(string $resource): string
     {
         return static::singleton()->resolveURL($resource);
     }
 
-    public static function get_template_global_variables()
+    public static function get_template_global_variables(): array
     {
         return [
             'resourcePath',
@@ -93,7 +93,7 @@ class ModuleResourceLoader implements TemplateGlobalProvider
      * @param string $resource
      * @return ModuleResource|string The resource, or input string if not a module resource
      */
-    public function resolveResource($resource)
+    public function resolveResource(string $resource): string|SilverStripe\Core\Manifest\ModuleResource
     {
         // String of the form vendor/package:resource. Excludes "http://bla" as that's an absolute URL
         if (!preg_match('#^ *(?<module>[^/: ]+/[^/: ]+) *: *(?<resource>[^ ]*)$#', $resource ?? '', $matches)) {

--- a/src/Core/Manifest/PrioritySorter.php
+++ b/src/Core/Manifest/PrioritySorter.php
@@ -78,7 +78,7 @@ class PrioritySorter
      * @param array $items
      * @param array $priorities
      */
-    public function __construct(array $items = [], array $priorities = [])
+    public function __construct(array $items = [], array $priorities = []): void
     {
         $this->setItems($items);
         $this->priorities = $priorities;
@@ -89,7 +89,7 @@ class PrioritySorter
      *
      * @return array
      */
-    public function getSortedList()
+    public function getSortedList(): array
     {
         $this->addVariables();
 
@@ -116,7 +116,7 @@ class PrioritySorter
      * @param array $priorities An array of keys used in $this->items
      * @return $this
      */
-    public function setPriorities(array $priorities)
+    public function setPriorities(array $priorities): SilverStripe\Core\Manifest\PrioritySorter
     {
         $this->priorities = $priorities;
 
@@ -129,7 +129,7 @@ class PrioritySorter
      * @param array $items
      * @return $this
      */
-    public function setItems(array $items)
+    public function setItems(array $items): SilverStripe\Core\Manifest\PrioritySorter
     {
         $this->items = $items;
         $this->names = array_keys($items ?? []);
@@ -144,7 +144,7 @@ class PrioritySorter
      * @param $value
      * @return $this
      */
-    public function setVariable($name, $value)
+    public function setVariable(string $name, string $value): SilverStripe\Core\Manifest\PrioritySorter
     {
         $this->variables[$name] = $value;
 
@@ -157,7 +157,7 @@ class PrioritySorter
      * @param $key
      * @return $this
      */
-    public function setRestKey($key)
+    public function setRestKey(string $key): SilverStripe\Core\Manifest\PrioritySorter
     {
         $this->restKey = $key;
 
@@ -167,7 +167,7 @@ class PrioritySorter
     /**
      * If variables are defined, interpolate their values
      */
-    protected function addVariables()
+    protected function addVariables(): void
     {
         // Remove variables from the list
         $varValues = array_values($this->variables ?? []);
@@ -185,7 +185,7 @@ class PrioritySorter
      * If the "rest" key exists in the order array,
      * replace it by the unspecified items
      */
-    protected function includeRest(array $list)
+    protected function includeRest(array $list): void
     {
         $otherItemsIndex = false;
         if ($this->restKey) {
@@ -205,7 +205,7 @@ class PrioritySorter
      * @param $name
      * @return mixed
      */
-    protected function resolveValue($name)
+    protected function resolveValue(string $name): string
     {
         return isset($this->variables[$name]) ? $this->variables[$name] : $name;
     }

--- a/src/Core/Manifest/VersionProvider.php
+++ b/src/Core/Manifest/VersionProvider.php
@@ -42,7 +42,7 @@ class VersionProvider
      *
      * @return string
      */
-    public function getVersion()
+    public function getVersion(): string
     {
         $key = sprintf('%s-%s', $this->getComposerLockPath(), 'all');
         $version = $this->getCachedValue($key);
@@ -148,7 +148,7 @@ class VersionProvider
      * @param array $modules
      * @return array
      */
-    private function filterModules(array $modules)
+    private function filterModules(array $modules): array
     {
         $accountModule = [];
         foreach ($modules as $module => $value) {
@@ -171,7 +171,7 @@ class VersionProvider
      *
      * @return array
      */
-    public function getModules()
+    public function getModules(): array
     {
         $modules = Config::inst()->get(self::class, 'modules');
         return !empty($modules) ? $modules : ['silverstripe/framework' => 'Framework'];
@@ -183,7 +183,7 @@ class VersionProvider
      * @param array $modules
      * @return array
      */
-    public function getModuleVersionFromComposer($modules = [])
+    public function getModuleVersionFromComposer(array $modules = []): array
     {
         $versions = [];
         $lockData = $this->getComposerLock();
@@ -203,7 +203,7 @@ class VersionProvider
      * @param bool $cache
      * @return array
      */
-    protected function getComposerLock($cache = true)
+    protected function getComposerLock($cache = true): array
     {
         $composerLockPath = $this->getComposerLockPath();
         if (!file_exists($composerLockPath ?? '')) {

--- a/src/Core/Path.php
+++ b/src/Core/Path.php
@@ -22,7 +22,7 @@ class Path
      * @param array $parts
      * @return string Combined path, not including trailing slash (unless it's a single slash)
      */
-    public static function join(...$parts)
+    public static function join(...$parts): string
     {
         // In case $parts passed as an array in first parameter
         if (count($parts ?? []) === 1 && is_array($parts[0])) {
@@ -49,7 +49,7 @@ class Path
      * @param bool $relative
      * @return string Path with no trailing slash. If $relative is true, also trim leading slashes
      */
-    public static function normalise($path, $relative = false)
+    public static function normalise(string $path, bool $relative = false): string
     {
         $path = trim(Convert::slashes($path) ?? '');
         if ($relative) {

--- a/src/Core/Startup/CompositeFlushDiscoverer.php
+++ b/src/Core/Startup/CompositeFlushDiscoverer.php
@@ -9,7 +9,7 @@ namespace SilverStripe\Core\Startup;
  */
 class CompositeFlushDiscoverer extends \ArrayIterator implements FlushDiscoverer
 {
-    public function shouldFlush()
+    public function shouldFlush(): bool|nothing
     {
         foreach ($this as $discoverer) {
             $flush = $discoverer->shouldFlush();

--- a/src/Core/Startup/DeployFlushDiscoverer.php
+++ b/src/Core/Startup/DeployFlushDiscoverer.php
@@ -32,7 +32,7 @@ class DeployFlushDiscoverer implements FlushDiscoverer
      */
     protected $kernel;
 
-    public function __construct(Kernel $kernel)
+    public function __construct(Kernel $kernel): void
     {
         $this->kernel = $kernel;
     }
@@ -61,7 +61,7 @@ class DeployFlushDiscoverer implements FlushDiscoverer
      *
      * @return string|null returns the resource path or null if not set
      */
-    protected function getDeployResource()
+    protected function getDeployResource(): null
     {
         $resource = Environment::getEnv('SS_FLUSH_ON_DEPLOY');
 
@@ -100,7 +100,7 @@ class DeployFlushDiscoverer implements FlushDiscoverer
      *
      * {@inheritdoc}
      */
-    public function shouldFlush()
+    public function shouldFlush(): null
     {
         $resource = $this->getDeployResource();
 

--- a/src/Core/Startup/RequestFlushDiscoverer.php
+++ b/src/Core/Startup/RequestFlushDiscoverer.php
@@ -35,7 +35,7 @@ class RequestFlushDiscoverer implements FlushDiscoverer
      * @param HTTPRequest $request instance of the request (session is not initialized yet!)
      * @param string $env Environment type (dev, test or live)
      */
-    public function __construct(HTTPRequest $request, $env)
+    public function __construct(HTTPRequest $request, string $env): void
     {
         $this->env = $env;
         $this->request = $request;
@@ -47,7 +47,7 @@ class RequestFlushDiscoverer implements FlushDiscoverer
      *
      * @return null|bool flush or don't care
      */
-    protected function lookupRequest()
+    protected function lookupRequest(): bool|null
     {
         $request = $this->request;
 
@@ -68,7 +68,7 @@ class RequestFlushDiscoverer implements FlushDiscoverer
      *
      * @return bool|null true for allow, false for denying, or null if don't care
      */
-    protected function isAllowed()
+    protected function isAllowed(): bool
     {
         // WARNING!
         // We specifically return `null` and not `false` here so that
@@ -76,7 +76,7 @@ class RequestFlushDiscoverer implements FlushDiscoverer
         return (Environment::isCli() || $this->env === Kernel::DEV) ? true : null;
     }
 
-    public function shouldFlush()
+    public function shouldFlush(): bool|null
     {
         if (!$allowed = $this->isAllowed()) {
             return $allowed;

--- a/src/Core/Startup/ScheduledFlushDiscoverer.php
+++ b/src/Core/Startup/ScheduledFlushDiscoverer.php
@@ -17,7 +17,7 @@ class ScheduledFlushDiscoverer implements FlushDiscoverer
      */
     protected $kernel;
 
-    public function __construct(Kernel $kernel)
+    public function __construct(Kernel $kernel): void
     {
         $this->kernel = $kernel;
     }
@@ -28,7 +28,7 @@ class ScheduledFlushDiscoverer implements FlushDiscoverer
      *
      * @return bool unix timestamp
      */
-    protected function getFlush()
+    protected function getFlush(): bool
     {
         $classLoader = $this->kernel->getClassLoader();
         $classManifest = $classLoader->getManifest();
@@ -55,7 +55,7 @@ class ScheduledFlushDiscoverer implements FlushDiscoverer
         return false;
     }
 
-    public function shouldFlush()
+    public function shouldFlush(): null
     {
         if ($this->getFlush()) {
             return true;

--- a/src/Core/TempFolder.php
+++ b/src/Core/TempFolder.php
@@ -15,7 +15,7 @@ class TempFolder
      * @param string $base The base path to use for determining the temporary path
      * @return string Path to temp
      */
-    public static function getTempFolder($base)
+    public static function getTempFolder(string $base): string
     {
         $parent = static::getTempParentFolder($base);
 
@@ -34,7 +34,7 @@ class TempFolder
      *
      * @return string
      */
-    public static function getTempFolderUsername()
+    public static function getTempFolderUsername(): string
     {
         $user = '';
         if (function_exists('posix_getpwuid') && function_exists('posix_getuid')) {
@@ -66,7 +66,7 @@ class TempFolder
      * @return string
      * @throws Exception
      */
-    protected static function getTempParentFolder($base)
+    protected static function getTempParentFolder(string $base): string
     {
         // first, try finding a silverstripe-cache dir built off the base path
         $localPath = Path::join($base, 'silverstripe-cache');

--- a/src/Dev/Backtrace.php
+++ b/src/Dev/Backtrace.php
@@ -70,7 +70,7 @@ class Backtrace
      * @param null|array $ignoredFunctions List of extra functions to filter out
      * @return array
      */
-    public static function filter_backtrace($bt, $ignoredFunctions = null)
+    public static function filter_backtrace(array $bt, $ignoredFunctions = null): array
     {
         $defaultIgnoredFunctions = [
             'SilverStripe\\Logging\\Log::log',
@@ -160,7 +160,7 @@ class Backtrace
      * @param int $argCharLimit
      * @return string
      */
-    public static function full_func_name($item, $showArgs = false, $argCharLimit = 10000)
+    public static function full_func_name(array $item, bool $showArgs = false, int $argCharLimit = 10000): string
     {
         $funcName = '';
         if (isset($item['class'])) {
@@ -198,7 +198,7 @@ class Backtrace
      * @param array $ignoredFunctions List of functions that should be ignored. If not set, a default is provided
      * @return string The rendered backtrace
      */
-    public static function get_rendered_backtrace($bt, $plainText = false, $ignoredFunctions = null)
+    public static function get_rendered_backtrace(array $bt, bool $plainText = false, $ignoredFunctions = null): string
     {
         if (empty($bt)) {
             return '';

--- a/src/Dev/BehatFixtureFactory.php
+++ b/src/Dev/BehatFixtureFactory.php
@@ -6,7 +6,7 @@ use SilverStripe\Assets\File;
 
 class BehatFixtureFactory extends FixtureFactory
 {
-    public function createObject($name, $identifier, $data = null)
+    public function createObject(string $name, string $identifier, array $data = null): Page
     {
         if (!$data) {
             $data = [];

--- a/src/Dev/BuildTask.php
+++ b/src/Dev/BuildTask.php
@@ -20,7 +20,7 @@ abstract class BuildTask
     use Configurable;
     use Extensible;
 
-    public function __construct()
+    public function __construct(): void
     {
     }
 
@@ -62,7 +62,7 @@ abstract class BuildTask
     /**
      * @return bool
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return $this->enabled;
     }
@@ -70,7 +70,7 @@ abstract class BuildTask
     /**
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title ?: static::class;
     }
@@ -78,7 +78,7 @@ abstract class BuildTask
     /**
      * @return string HTML formatted description
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }

--- a/src/Dev/BulkLoader.php
+++ b/src/Dev/BulkLoader.php
@@ -129,7 +129,7 @@ abstract class BulkLoader extends ViewableData
      */
     public $deleteExistingRecords = false;
 
-    public function __construct($objectClass)
+    public function __construct(string $objectClass): void
     {
         $this->objectClass = $objectClass;
         parent::__construct();
@@ -141,7 +141,7 @@ abstract class BulkLoader extends ViewableData
      *
      * @return BulkLoader_Result See {@link self::processAll()}
      */
-    public function load($filepath)
+    public function load(string $filepath): SilverStripe\Dev\BulkLoader_Result
     {
         Environment::increaseTimeLimitTo(3600);
         Environment::increaseMemoryLimitTo('512M');
@@ -221,7 +221,7 @@ abstract class BulkLoader extends ViewableData
      *
      * @return array
      **/
-    public function getImportSpec()
+    public function getImportSpec(): array
     {
         $singleton = DataObject::singleton($this->objectClass);
 
@@ -260,7 +260,7 @@ abstract class BulkLoader extends ViewableData
      * @param string $fieldName Name of the field as specified in the array-values for {@link self::$columnMap}.
      * @return boolean
      */
-    protected function isNullValue($val, $fieldName = null)
+    protected function isNullValue(string $val, $fieldName = null): bool
     {
         return (empty($val) && $val !== '0');
     }

--- a/src/Dev/BulkLoader_Result.php
+++ b/src/Dev/BulkLoader_Result.php
@@ -63,7 +63,7 @@ class BulkLoader_Result implements \Countable
      * @return int
      */
     #[\ReturnTypeWillChange]
-    public function Count()
+    public function Count(): int
     {
         return count($this->created ?? []) + count($this->updated ?? []);
     }
@@ -71,7 +71,7 @@ class BulkLoader_Result implements \Countable
     /**
      * @return int
      */
-    public function CreatedCount()
+    public function CreatedCount(): int
     {
         return count($this->created ?? []);
     }
@@ -79,7 +79,7 @@ class BulkLoader_Result implements \Countable
     /**
      * @return int
      */
-    public function UpdatedCount()
+    public function UpdatedCount(): int
     {
         return count($this->updated ?? []);
     }
@@ -87,7 +87,7 @@ class BulkLoader_Result implements \Countable
     /**
      * @return int
      */
-    public function DeletedCount()
+    public function DeletedCount(): int
     {
         return count($this->deleted ?? []);
     }
@@ -98,7 +98,7 @@ class BulkLoader_Result implements \Countable
      *
      * @return ArrayList
      */
-    public function Created()
+    public function Created(): SilverStripe\ORM\ArrayList
     {
         return $this->mapToArrayList($this->created);
     }
@@ -106,7 +106,7 @@ class BulkLoader_Result implements \Countable
     /**
      * @return ArrayList
      */
-    public function Updated()
+    public function Updated(): SilverStripe\ORM\ArrayList
     {
         return $this->mapToArrayList($this->updated);
     }
@@ -114,7 +114,7 @@ class BulkLoader_Result implements \Countable
     /**
      * @return ArrayList
      */
-    public function Deleted()
+    public function Deleted(): SilverStripe\ORM\ArrayList
     {
         $set = new ArrayList();
         foreach ($this->deleted as $arrItem) {
@@ -137,7 +137,7 @@ class BulkLoader_Result implements \Countable
      * @param $obj DataObject
      * @param $message string
      */
-    public function addCreated($obj, $message = null)
+    public function addCreated(SilverStripe\Dev\Tests\BulkLoaderResultTest\Player $obj, string $message = null): void
     {
         $this->created[] = $this->lastChange = [
             'ID' => $obj->ID,
@@ -151,7 +151,7 @@ class BulkLoader_Result implements \Countable
      * @param $obj DataObject
      * @param $message string
      */
-    public function addUpdated($obj, $message = null)
+    public function addUpdated(SilverStripe\Dev\Tests\BulkLoaderResultTest\Player $obj, string $message = null): void
     {
         $this->updated[] = $this->lastChange = [
             'ID' => $obj->ID,
@@ -165,7 +165,7 @@ class BulkLoader_Result implements \Countable
      * @param $obj DataObject
      * @param $message string
      */
-    public function addDeleted($obj, $message = null)
+    public function addDeleted(SilverStripe\Dev\Tests\BulkLoaderResultTest\Player $obj, string $message = null): void
     {
         $data = $obj->toMap();
         $data['_BulkLoaderMessage'] = $message;
@@ -177,7 +177,7 @@ class BulkLoader_Result implements \Countable
      * @param array $arr containing ID and ClassName maps
      * @return ArrayList
      */
-    protected function mapToArrayList($arr)
+    protected function mapToArrayList(array $arr): SilverStripe\ORM\ArrayList
     {
         $set = new ArrayList();
         foreach ($arr as $arrItem) {

--- a/src/Dev/CLI.php
+++ b/src/Dev/CLI.php
@@ -11,7 +11,7 @@ class CLI
     /**
      * Returns true if the current STDOUT supports the use of colour control codes.
      */
-    public static function supports_colour()
+    public static function supports_colour(): bool
     {
         // Special case for buildbot
         if (isset($_ENV['_']) && strpos($_ENV['_'] ?? '', 'buildbot') !== false) {
@@ -35,7 +35,7 @@ class CLI
      * @param bool $bold A boolean variable - bold or not.
      * @return string
      */
-    public static function text($text, $fgColour = null, $bgColour = null, $bold = false)
+    public static function text(string $text, string $fgColour = null, $bgColour = null, bool $bold = false): string
     {
         if (!self::supports_colour()) {
             return $text;
@@ -60,7 +60,7 @@ class CLI
      * @param bool $bold A boolean variable - bold or not.
      * @return string
      */
-    public static function start_colour($fgColour = null, $bgColour = null, $bold = false)
+    public static function start_colour(string $fgColour = null, $bgColour = null, bool $bold = false): string
     {
         if (!self::supports_colour()) {
             return "";
@@ -96,7 +96,7 @@ class CLI
     /**
      * Send control codes for returning to normal colour
      */
-    public static function end_colour()
+    public static function end_colour(): string
     {
         return self::supports_colour() ? "\033[0m" : "";
     }

--- a/src/Dev/CSSContentParser.php
+++ b/src/Dev/CSSContentParser.php
@@ -30,7 +30,7 @@ class CSSContentParser
 
     protected $simpleXML = null;
 
-    public function __construct($content)
+    public function __construct(string|SilverStripe\ORM\FieldType\DBHTMLText $content): void
     {
         if (extension_loaded('tidy')) {
             // using the tidy php extension
@@ -80,7 +80,7 @@ class CSSContentParser
      * @param string $selector
      * @return SimpleXMLElement[]
      */
-    public function getBySelector($selector)
+    public function getBySelector(string $selector): array
     {
         $xpath = $this->selector2xpath($selector);
         return $this->getByXpath($xpath);
@@ -92,7 +92,7 @@ class CSSContentParser
      * @param string $xpath SimpleXML compatible XPATH statement
      * @return SimpleXMLElement[]
      */
-    public function getByXpath($xpath)
+    public function getByXpath(string $xpath): array
     {
         return $this->simpleXML->xpath($xpath);
     }
@@ -104,7 +104,7 @@ class CSSContentParser
      * @param string $selector See {@link getBySelector()}
      * @return String XPath expression
      */
-    public function selector2xpath($selector)
+    public function selector2xpath(string $selector): string
     {
         $parts = preg_split('/\\s+/', $selector ?? '');
         $xpath = "";

--- a/src/Dev/CSVParser.php
+++ b/src/Dev/CSVParser.php
@@ -113,7 +113,7 @@ class CSVParser implements Iterator
      * @param string $delimiter The character for separating columns
      * @param string $enclosure The character for quoting or enclosing columns
      */
-    public function __construct($filename, $delimiter = ",", $enclosure = '"')
+    public function __construct(string $filename, $delimiter = ",", $enclosure = '"'): void
     {
         Deprecation::notice('5.0', __CLASS__ . ' is deprecated, use ' . Reader::class . ' instead');
         $filename = Director::getAbsFile($filename);
@@ -136,7 +136,7 @@ class CSVParser implements Iterator
      *
      * @param array $columnMap
      */
-    public function mapColumns($columnMap)
+    public function mapColumns(array $columnMap): void
     {
         if ($columnMap) {
             $lowerColumnMap = [];
@@ -158,7 +158,7 @@ class CSVParser implements Iterator
      *
      * @param array $headerRow
      */
-    public function provideHeaderRow($headerRow)
+    public function provideHeaderRow(array $headerRow): void
     {
         $this->providedHeaderRow = $headerRow;
     }
@@ -166,7 +166,7 @@ class CSVParser implements Iterator
     /**
      * Open the CSV file for reading.
      */
-    protected function openFile()
+    protected function openFile(): void
     {
         $this->fileHandle = fopen($this->filename ?? '', 'r');
 
@@ -178,7 +178,7 @@ class CSVParser implements Iterator
     /**
      * Close the CSV file and re-set all of the internal variables.
      */
-    protected function closeFile()
+    protected function closeFile(): void
     {
         if ($this->fileHandle) {
             fclose($this->fileHandle);
@@ -194,7 +194,7 @@ class CSVParser implements Iterator
     /**
      * Get a header row from the CSV file.
      */
-    protected function fetchCSVHeader()
+    protected function fetchCSVHeader(): void
     {
         $srcRow = fgetcsv(
             $this->fileHandle,
@@ -213,7 +213,7 @@ class CSVParser implements Iterator
      *
      * @return array
      */
-    protected function remapHeader($header)
+    protected function remapHeader(array $header): array
     {
         $mappedHeader = [];
 
@@ -232,7 +232,7 @@ class CSVParser implements Iterator
      *
      * @return array
      */
-    protected function fetchCSVRow()
+    protected function fetchCSVRow(): array|null
     {
         if (!$this->fileHandle) {
             $this->openFile();
@@ -284,7 +284,7 @@ class CSVParser implements Iterator
     /**
      * @ignore
      */
-    public function __destruct()
+    public function __destruct(): void
     {
         $this->closeFile();
     }
@@ -295,7 +295,7 @@ class CSVParser implements Iterator
      * @ignore
      */
     #[\ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         $this->closeFile();
         $this->fetchCSVRow();
@@ -305,7 +305,7 @@ class CSVParser implements Iterator
      * @ignore
      */
     #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): array
     {
         return $this->currentRow;
     }
@@ -323,7 +323,7 @@ class CSVParser implements Iterator
      * @ignore
      */
     #[\ReturnTypeWillChange]
-    public function next()
+    public function next(): array|null
     {
         $this->fetchCSVRow();
 
@@ -334,7 +334,7 @@ class CSVParser implements Iterator
      * @ignore
      */
     #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return $this->currentRow ? true : false;
     }

--- a/src/Dev/CliDebugView.php
+++ b/src/Dev/CliDebugView.php
@@ -21,7 +21,7 @@ class CliDebugView extends DebugView
      * @param HTTPRequest $httpRequest
      * @return string
      */
-    public function renderHeader($httpRequest = null)
+    public function renderHeader($httpRequest = null): null
     {
         return null;
     }
@@ -29,7 +29,7 @@ class CliDebugView extends DebugView
     /**
      * Render HTML footer for development views
      */
-    public function renderFooter()
+    public function renderFooter(): void
     {
     }
 
@@ -43,7 +43,7 @@ class CliDebugView extends DebugView
      * @param int $errline
      * @return string
      */
-    public function renderError($httpRequest, $errno, $errstr, $errfile, $errline)
+    public function renderError(string $httpRequest, int $errno, string $errstr, string $errfile, int $errline): string
     {
         if (!isset(self::$error_types[$errno])) {
             $errorTypeTitle = "UNKNOWN TYPE, ERRNO $errno";
@@ -63,7 +63,7 @@ class CliDebugView extends DebugView
      * @param int $errline Index of the line in $lines which has the error
      * @return string
      */
-    public function renderSourceFragment($lines, $errline)
+    public function renderSourceFragment(array $lines, int $errline): string
     {
         $output = "Source\n======\n";
         foreach ($lines as $offset => $line) {
@@ -82,7 +82,7 @@ class CliDebugView extends DebugView
      * @param array $trace
      * @return string
      */
-    public function renderTrace($trace = null)
+    public function renderTrace(array $trace = null): string
     {
         $output = "Trace\n=====\n";
         $output .= Backtrace::get_rendered_backtrace($trace ? $trace : debug_backtrace(), true);
@@ -90,7 +90,7 @@ class CliDebugView extends DebugView
         return $output;
     }
 
-    public function renderParagraph($text)
+    public function renderParagraph(string $text): string
     {
         return wordwrap($text ?? '', self::config()->columns ?? 0) . "\n\n";
     }
@@ -103,7 +103,7 @@ class CliDebugView extends DebugView
      * @param string $description
      * @return string
      */
-    public function renderInfo($title, $subtitle, $description = null)
+    public function renderInfo(string $title, string $subtitle, string $description = null): string
     {
         $output = wordwrap(strtoupper($title ?? ''), self::config()->columns ?? 0) . "\n";
         $output .= wordwrap($subtitle ?? '', self::config()->columns ?? 0) . "\n";
@@ -140,7 +140,7 @@ class CliDebugView extends DebugView
      * @param bool $showHeader
      * @return string
      */
-    public function debugVariable($val, $caller, $showHeader = true)
+    public function debugVariable(string|array|SilverStripe\Dev\Tests\DebugViewTest\ObjectWithDebug $val, array $caller, $showHeader = true): string
     {
         $text = $this->debugVariableText($val);
         if ($showHeader) {
@@ -157,7 +157,7 @@ class CliDebugView extends DebugView
      * @param mixed $val
      * @return string
      */
-    public function debugVariableText($val)
+    public function debugVariableText(string|array|SilverStripe\Dev\Tests\DebugViewTest\ObjectWithDebug $val): string
     {
         // Check debug
         if (is_object($val) && ClassInfo::hasMethod($val, 'debug')) {

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -70,7 +70,7 @@ if (class_exists(Constraint::class)) {
          *
          * @throws PHPUnit_Framework_ExpectationFailedException
          */
-        public function evaluate($other, $description = '', $returnResult = false): ?bool
+        public function evaluate(SilverStripe\ORM\DataList $other, string $description = '', bool $returnResult = false): ?bool
         {
             $success = true;
 
@@ -213,7 +213,7 @@ class SSListContains extends PHPUnit_Framework_Constraint implements TestOnly
      *
      * @throws ExpectationFailedException
      */
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate(SilverStripe\ORM\DataList $other, string $description = '', bool $returnResult = false)
     {
         $success = true;
 

--- a/src/Dev/Constraint/SSListContainsOnly.php
+++ b/src/Dev/Constraint/SSListContainsOnly.php
@@ -53,7 +53,7 @@ class SSListContainsOnly extends SSListContains implements TestOnly
      *
      * @throws PHPUnit_Framework_ExpectationFailedException|ExpectationFailedException
      */
-    public function evaluate($other, $description = '', $returnResult = false): ?bool
+    public function evaluate(SilverStripe\ORM\ManyManyThroughList $other, string $description = '', bool $returnResult = false): ?bool
     {
         $success = true;
 

--- a/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
+++ b/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
@@ -42,7 +42,7 @@ if (class_exists(Constraint::class)) {
          */
         private $constraint;
 
-        public function __construct($match)
+        public function __construct(array $match)
         {
             $this->exporter = new SSListExporter();
 
@@ -68,7 +68,7 @@ if (class_exists(Constraint::class)) {
          *
          * @throws ExpectationFailedException
          */
-        public function evaluate($other, $description = '', $returnResult = false): ?bool
+        public function evaluate(SilverStripe\ORM\ArrayList $other, string $description = '', bool $returnResult = false): ?bool
         {
             $success = true;
 
@@ -133,7 +133,7 @@ class SSListContainsOnlyMatchingItems extends PHPUnit_Framework_Constraint imple
      */
     private $constraint;
 
-    public function __construct($match)
+    public function __construct(array $match)
     {
         $this->exporter = new SSListExporter();
 
@@ -159,7 +159,7 @@ class SSListContainsOnlyMatchingItems extends PHPUnit_Framework_Constraint imple
      *
      * @throws PHPUnit_Framework_ExpectationFailedException
      */
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate(SilverStripe\ORM\ArrayList $other, string $description = '', bool $returnResult = false)
     {
         $success = true;
 

--- a/src/Dev/Constraint/ViewableDataContains.php
+++ b/src/Dev/Constraint/ViewableDataContains.php
@@ -72,7 +72,7 @@ if (class_exists(Constraint::class)) {
          *
          * @throws ExpectationFailedException
          */
-        public function evaluate($other, $description = '', $returnResult = false): ?bool
+        public function evaluate(DNADesign\Elemental\Tests\Src\TestPage $other, string $description = '', bool $returnResult = false): ?bool
         {
             $success = true;
 
@@ -170,7 +170,7 @@ class ViewableDataContains extends PHPUnit_Framework_Constraint implements TestO
      *
      * @throws PHPUnit_Framework_ExpectationFailedException
      */
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate(DNADesign\Elemental\Tests\Src\TestPage $other, string $description = '', bool $returnResult = false)
     {
         $success = true;
 

--- a/src/Dev/CsvBulkLoader.php
+++ b/src/Dev/CsvBulkLoader.php
@@ -66,7 +66,7 @@ class CsvBulkLoader extends BulkLoader
      *
      * @return null|BulkLoader_Result
      */
-    protected function processAll($filepath, $preview = false)
+    protected function processAll(string $filepath, $preview = false): SilverStripe\Dev\BulkLoader_Result
     {
         $this->extend('onBeforeProcessAll', $filepath, $preview);
 
@@ -148,7 +148,7 @@ class CsvBulkLoader extends BulkLoader
         return $result;
     }
 
-    protected function getNormalisedColumnMap()
+    protected function getNormalisedColumnMap(): array
     {
         $map = [];
         foreach ($this->columnMap as $column => $newColumn) {
@@ -292,7 +292,7 @@ class CsvBulkLoader extends BulkLoader
      *
      * @return int
      */
-    protected function processRecord($record, $columnMap, &$results, $preview = false)
+    protected function processRecord(array $record, array $columnMap, &$results, bool $preview = false): int
     {
         $class = $this->objectClass;
 
@@ -417,7 +417,7 @@ class CsvBulkLoader extends BulkLoader
      * @param array $columnMap
      * @return DataObject
      */
-    public function findExistingObject($record, $columnMap = [])
+    public function findExistingObject(array $record, array $columnMap = []): bool|SilverStripe\Dev\Tests\CsvBulkLoaderTest\Player
     {
         $SNG_objectClass = singleton($this->objectClass);
         // checking for existing records (only if not already found)

--- a/src/Dev/Debug.php
+++ b/src/Dev/Debug.php
@@ -57,7 +57,7 @@ class Debug
      *
      * @return array
      */
-    public static function caller()
+    public static function caller(): array
     {
         $bt = debug_backtrace();
         $caller = isset($bt[2]) ? $bt[2] : [];
@@ -116,7 +116,7 @@ class Debug
      * @param HTTPRequest $request
      * @return string
      */
-    public static function text($val, HTTPRequest $request = null)
+    public static function text(SilverStripe\Forms\TextField $val, HTTPRequest $request = null): string
     {
         return static::create_debug_view($request)
             ->debugVariableText($val);
@@ -130,7 +130,7 @@ class Debug
      * @param bool $showHeader
      * @param HTTPRequest|null $request
      */
-    public static function message($message, $showHeader = true, HTTPRequest $request = null)
+    public static function message(string $message, $showHeader = true, HTTPRequest $request = null): void
     {
         // Don't show on live
         if (Director::isLive()) {
@@ -147,7 +147,7 @@ class Debug
      * @param HTTPRequest $request Optional request to target this view for
      * @return DebugView
      */
-    public static function create_debug_view(HTTPRequest $request = null)
+    public static function create_debug_view(HTTPRequest $request = null): SilverStripe\Dev\DebugView
     {
         $service = static::supportsHTML($request)
             ? DebugView::class
@@ -161,7 +161,7 @@ class Debug
      * @param HTTPRequest $request
      * @return bool
      */
-    protected static function supportsHTML(HTTPRequest $request = null)
+    protected static function supportsHTML(HTTPRequest $request = null): bool
     {
         // No HTML output in CLI
         if (Director::is_cli()) {

--- a/src/Dev/DebugView.php
+++ b/src/Dev/DebugView.php
@@ -122,7 +122,7 @@ class DebugView
      *
      * @return string
      */
-    public function Breadcrumbs()
+    public function Breadcrumbs(): string
     {
         $basePath = str_replace(Director::protocolAndHost() ?? '', '', Director::absoluteBaseURL() ?? '');
         $relPath = parse_url(
@@ -211,7 +211,7 @@ class DebugView
      * @param HTTPRequest $httpRequest
      * @return string
      */
-    public function renderHeader($httpRequest = null)
+    public function renderHeader($httpRequest = null): string
     {
         $url = htmlentities(
             $_SERVER['REQUEST_METHOD'] . ' ' . $_SERVER['REQUEST_URI'],
@@ -238,7 +238,7 @@ class DebugView
      * @param string|bool $description The description to show
      * @return string
      */
-    public function renderInfo($title, $subtitle, $description = false)
+    public function renderInfo(string $title, string $subtitle, $description = false): string
     {
         $output = '<div class="info header">';
         $output .= "<h1>" . Convert::raw2xml($title) . "</h1>";
@@ -259,7 +259,7 @@ class DebugView
      * Render HTML footer for development views
      * @return string
      */
-    public function renderFooter()
+    public function renderFooter(): string
     {
         return "</body></html>";
     }
@@ -274,7 +274,7 @@ class DebugView
      * @param int $errline The line number on which the error occurred
      * @return string
      */
-    public function renderError($httpRequest, $errno, $errstr, $errfile, $errline)
+    public function renderError(string $httpRequest, int $errno, string $errstr, string $errfile, int $errline): string
     {
         $errorType = isset(self::$error_types[$errno]) ? self::$error_types[$errno] : self::$unknown_error;
         $httpRequestEnt = htmlentities($httpRequest ?? '', ENT_COMPAT, 'UTF-8');
@@ -299,7 +299,7 @@ class DebugView
      * @param int $errline The line of the error
      * @return string
      */
-    public function renderSourceFragment($lines, $errline)
+    public function renderSourceFragment(array $lines, int $errline): string
     {
         $output = '<div class="info"><h3>Source</h3>';
         $output .= '<pre>';
@@ -322,7 +322,7 @@ class DebugView
      * @param  array $trace The debug_backtrace() array
      * @return string
      */
-    public function renderTrace($trace)
+    public function renderTrace(array $trace): string
     {
         $output = '<div class="info">';
         $output .= '<h3>Trace</h3>';
@@ -349,7 +349,7 @@ class DebugView
      * @param  array $caller
      * @return string
      */
-    protected function formatCaller($caller)
+    protected function formatCaller(array $caller): string
     {
         $return = basename($caller['file'] ?? '') . ":" . $caller['line'];
         if (!empty($caller['class']) && !empty($caller['function'])) {
@@ -379,7 +379,7 @@ class DebugView
         return $output;
     }
 
-    public function renderMessage($message, $caller, $showHeader = true)
+    public function renderMessage(string $message, array $caller, bool $showHeader = true): string
     {
         $header = '';
         if ($showHeader) {
@@ -398,7 +398,7 @@ class DebugView
      * @param bool $showHeader
      * @return string
      */
-    public function debugVariable($val, $caller, $showHeader = true)
+    public function debugVariable(string|array|SilverStripe\Dev\Tests\DebugViewTest\ObjectWithDebug $val, array $caller, $showHeader = true): string
     {
         $text = $this->debugVariableText($val);
 
@@ -419,7 +419,7 @@ class DebugView
      * @param mixed $val
      * @return string
      */
-    public function debugVariableText($val)
+    public function debugVariableText(string|array|SilverStripe\Dev\Tests\DebugViewTest\ObjectWithDebug $val): string
     {
         // Check debug
         if (is_object($val) && ClassInfo::hasMethod($val, 'debug')) {

--- a/src/Dev/Deprecation.php
+++ b/src/Dev/Deprecation.php
@@ -85,7 +85,7 @@ class Deprecation
      *    calls directly from this module rather than the global value
      * @return void
      */
-    public static function notification_version($ver, $forModule = null)
+    public static function notification_version(string $ver, string $forModule = null): void
     {
         if ($forModule) {
             self::$module_version_overrides[$forModule] = $ver;
@@ -101,7 +101,7 @@ class Deprecation
      * @param array $backtrace A backtrace as returned from debug_backtrace
      * @return Module The module being called
      */
-    protected static function get_calling_module_from_trace($backtrace)
+    protected static function get_calling_module_from_trace(array $backtrace): SilverStripe\Core\Manifest\Module|null
     {
         if (!isset($backtrace[1]['file'])) {
             return null;
@@ -120,7 +120,7 @@ class Deprecation
      * @param $level - 1 (default) will return immediate caller, 2 will return caller's caller, etc.
      * @return string - the name of the method
      */
-    protected static function get_called_method_from_trace($backtrace, $level = 1)
+    protected static function get_called_method_from_trace(array $backtrace, int $level = 1): string
     {
         $level = (int)$level;
         if (!$level) {
@@ -139,7 +139,7 @@ class Deprecation
      *
      * @return bool
      */
-    public static function get_enabled()
+    public static function get_enabled(): bool
     {
         // Deprecation is only available on dev
         if (!Director::isDev()) {
@@ -156,7 +156,7 @@ class Deprecation
      *
      * @param bool $enabled
      */
-    public static function set_enabled($enabled)
+    public static function set_enabled(bool $enabled): void
     {
         self::$enabled = $enabled;
     }
@@ -169,7 +169,7 @@ class Deprecation
      * @param string $string The notice to raise
      * @param int $scope Notice relates to the method or class context its called in.
      */
-    public static function notice($atVersion, $string = '', $scope = Deprecation::SCOPE_METHOD)
+    public static function notice(string $atVersion, string $string = '', $scope = Deprecation::SCOPE_METHOD): void
     {
         if (!static::get_enabled()) {
             return;
@@ -245,7 +245,7 @@ class Deprecation
      *
      * @return array Opaque array that should only be used to pass to {@see Deprecation::restore_settings()}
      */
-    public static function dump_settings()
+    public static function dump_settings(): array
     {
         return [
             'level' => self::$notice_level,
@@ -260,7 +260,7 @@ class Deprecation
      *
      * @param $settings array An array as returned by {@see Deprecation::dump_settings()}
      */
-    public static function restore_settings($settings)
+    public static function restore_settings(array $settings): void
     {
         self::$notice_level = $settings['level'];
         self::$version = $settings['version'];

--- a/src/Dev/DevBuildController.php
+++ b/src/Dev/DevBuildController.php
@@ -17,7 +17,7 @@ class DevBuildController extends Controller
         'build'
     ];
 
-    public function build($request)
+    public function build(SilverStripe\Control\HTTPRequest $request): SilverStripe\Control\HTTPResponse
     {
         if (Director::is_cli()) {
             $da = DatabaseAdmin::create();

--- a/src/Dev/DevelopmentAdmin.php
+++ b/src/Dev/DevelopmentAdmin.php
@@ -77,7 +77,7 @@ class DevelopmentAdmin extends Controller
      */
     private static $deny_non_cli = false;
 
-    protected function init()
+    protected function init(): void
     {
         parent::init();
 
@@ -142,7 +142,7 @@ class DevelopmentAdmin extends Controller
         }
     }
 
-    public function runRegisteredController(HTTPRequest $request)
+    public function runRegisteredController(HTTPRequest $request): SilverStripe\Dev\DevBuildController
     {
         $controllerClass = null;
 

--- a/src/Dev/FixtureBlueprint.php
+++ b/src/Dev/FixtureBlueprint.php
@@ -52,7 +52,7 @@ class FixtureBlueprint
      * @param string $class Defaults to $name
      * @param array $defaults
      */
-    public function __construct($name, $class = null, $defaults = [])
+    public function __construct(string $name, string $class = null, array $defaults = []): void
     {
         if (!$class) {
             $class = $name;
@@ -80,7 +80,7 @@ class FixtureBlueprint
      * @return DataObject
      * @throws Exception
      */
-    public function createObject($identifier, $data = null, $fixtures = null)
+    public function createObject(string|int $identifier, array $data = null, array $fixtures = null): DNADesign\Elemental\Models\ElementalArea
     {
         // We have to disable validation while we import the fixtures, as the order in
         // which they are imported doesnt guarantee valid relations until after the import is complete.
@@ -268,7 +268,7 @@ class FixtureBlueprint
     /**
      * @return string
      */
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }
@@ -280,7 +280,7 @@ class FixtureBlueprint
      * @param callable $callback
      * @return $this
      */
-    public function addCallback($type, $callback)
+    public function addCallback(string $type, callable $callback): SilverStripe\Dev\FixtureBlueprint
     {
         if (!array_key_exists($type, $this->callbacks ?? [])) {
             throw new InvalidArgumentException(sprintf('Invalid type "%s"', $type));
@@ -305,7 +305,7 @@ class FixtureBlueprint
         return $this;
     }
 
-    protected function invokeCallbacks($type, $args = [])
+    protected function invokeCallbacks(string $type, array $args = []): void
     {
         foreach ($this->callbacks[$type] as $callback) {
             call_user_func_array($callback, $args ?? []);
@@ -322,7 +322,7 @@ class FixtureBlueprint
      * will be given the value of that class's name
      * @return string Fixture database ID, or the original value
      */
-    protected function parseValue($value, $fixtures = null, &$class = null)
+    protected function parseValue(string|int|bool|float $value, $fixtures = null, &$class = null): string|int|null|bool|float
     {
         if (substr($value ?? '', 0, 2) == '=>') {
             // Parse a dictionary reference - used to set foreign keys
@@ -342,12 +342,12 @@ class FixtureBlueprint
         }
     }
 
-    protected function setValue($obj, $name, $value, $fixtures = null)
+    protected function setValue(DNADesign\Elemental\Models\ElementalArea $obj, string $name, string|int|bool|float $value, array $fixtures = null): void
     {
         $obj->$name = $this->parseValue($value, $fixtures);
     }
 
-    protected function overrideField($obj, $fieldName, $value, $fixtures = null)
+    protected function overrideField(SilverStripe\Dev\Tests\FixtureFactoryTest\TestDataObject $obj, string $fieldName, string $value, array $fixtures = null): void
     {
         $class = get_class($obj);
         $table = DataObject::getSchema()->tableForField($class, $fieldName);

--- a/src/Dev/FixtureFactory.php
+++ b/src/Dev/FixtureFactory.php
@@ -50,7 +50,7 @@ class FixtureFactory
      * @param array|FixtureBlueprint $defaults Array of default values, or a blueprint instance
      * @return $this
      */
-    public function define($name, $defaults = [])
+    public function define(string $name, SilverStripe\Dev\FixtureBlueprint|array $defaults = []): SilverStripe\Dev\BehatFixtureFactory
     {
         if ($defaults instanceof FixtureBlueprint) {
             $this->blueprints[$name] = $defaults;
@@ -76,7 +76,7 @@ class FixtureFactory
      * @param array $data Map of properties. Overrides default data.
      * @return DataObject
      */
-    public function createObject($name, $identifier, $data = null)
+    public function createObject(string $name, string|int $identifier, array $data = null): DNADesign\Elemental\Models\ElementalArea
     {
         if (!isset($this->blueprints[$name])) {
             $this->blueprints[$name] = new FixtureBlueprint($name);
@@ -102,7 +102,7 @@ class FixtureFactory
      * @param array $data Map of properties
      * @return int Database identifier
      */
-    public function createRaw($table, $identifier, $data)
+    public function createRaw(string $table, string $identifier, array $data): int
     {
         $fields = [];
         foreach ($data as $fieldName => $fieldVal) {
@@ -123,7 +123,7 @@ class FixtureFactory
      * @param string $identifier The identifier string, as provided in your fixture file
      * @return int
      */
-    public function getId($class, $identifier)
+    public function getId(string $class, string $identifier): int|bool
     {
         if (isset($this->fixtures[$class][$identifier])) {
             return $this->fixtures[$class][$identifier];
@@ -138,7 +138,7 @@ class FixtureFactory
      * @param string $class The data class or table name
      * @return array|false A map of fixture-identifier => object-id
      */
-    public function getIds($class)
+    public function getIds(string $class): array
     {
         if (isset($this->fixtures[$class])) {
             return $this->fixtures[$class];
@@ -153,7 +153,7 @@ class FixtureFactory
      * @param int $databaseId
      * @return $this
      */
-    public function setId($class, $identifier, $databaseId)
+    public function setId(string $class, string $identifier, int $databaseId): SilverStripe\Dev\FixtureFactory
     {
         $this->fixtures[$class][$identifier] = $databaseId;
         return $this;
@@ -166,7 +166,7 @@ class FixtureFactory
      * @param string $identifier The identifier string, as provided in your fixture file
      * @return DataObject
      */
-    public function get($class, $identifier)
+    public function get(string $class, string $identifier): null|DNADesign\Elemental\Models\ElementContent
     {
         $id = $this->getId($class, $identifier);
         if (!$id) {
@@ -190,7 +190,7 @@ class FixtureFactory
      * @return array Map of class names, containing a map of in-memory identifiers
      * mapped to database identifiers.
      */
-    public function getFixtures()
+    public function getFixtures(): array
     {
         return $this->fixtures;
     }
@@ -204,7 +204,7 @@ class FixtureFactory
      * @param bool $metadata Clear internal mapping as well as data.
      * Set to false by default since sometimes data is rolled back by translations.
      */
-    public function clear($limitToClass = null, $metadata = false)
+    public function clear(string $limitToClass = null, bool $metadata = false): void
     {
         $classes = ($limitToClass) ? [$limitToClass] : array_keys($this->fixtures ?? []);
         foreach ($classes as $class) {
@@ -242,7 +242,7 @@ class FixtureFactory
      * @param string $name
      * @return FixtureBlueprint|false
      */
-    public function getBlueprint($name)
+    public function getBlueprint(string $name): bool|SilverStripe\Dev\FixtureBlueprint
     {
         return (isset($this->blueprints[$name])) ? $this->blueprints[$name] : false;
     }
@@ -254,7 +254,7 @@ class FixtureFactory
      * @param string $value
      * @return string Fixture database ID, or the original value
      */
-    protected function parseValue($value)
+    protected function parseValue(string|int $value): int|string
     {
         if (substr($value ?? '', 0, 2) == '=>') {
             // Parse a dictionary reference - used to set foreign keys

--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -146,7 +146,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param string $url The base URL to use for this test
          * @param callable $callback The test to run
          */
-        protected function withBaseURL($url, $callback)
+        protected function withBaseURL(string $url, callable $callback)
         {
             $oldBase = Config::inst()->get(Director::class, 'alternate_base_url');
             Config::modify()->set(Director::class, 'alternate_base_url', $url);
@@ -159,7 +159,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param string $folder The base folder to use for this test
          * @param callable $callback The test to run
          */
-        protected function withBaseFolder($folder, $callback)
+        protected function withBaseFolder(string $folder, callable $callback)
         {
             $oldFolder = Config::inst()->get(Director::class, 'alternate_base_folder');
             Config::modify()->set(Director::class, 'alternate_base_folder', $folder);
@@ -177,7 +177,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param array $cookies
          * @return HTTPResponse
          */
-        public function get($url, $session = null, $headers = null, $cookies = null)
+        public function get(string $url, SilverStripe\Control\Session $session = null, array $headers = null, array $cookies = null)
         {
             $this->cssParser = null;
             $response = $this->mainSession->get($url, $session, $headers, $cookies);
@@ -199,7 +199,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param array $cookies
          * @return HTTPResponse
          */
-        public function post($url, $data, $headers = null, $session = null, $body = null, $cookies = null)
+        public function post(string $url, array $data, array $headers = null, SilverStripe\Control\Session $session = null, string $body = null, array $cookies = null)
         {
             $this->cssParser = null;
             $response = $this->mainSession->post($url, $data, $headers, $session, $body, $cookies);
@@ -228,7 +228,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param array $data Map of GET/POST data.
          * @return HTTPResponse
          */
-        public function submitForm($formID, $button = null, $data = [])
+        public function submitForm(string $formID, string $button = null, array $data = [])
         {
             $this->cssParser = null;
             $response = $this->mainSession->submitForm($formID, $button, $data);
@@ -290,7 +290,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param string $message
          * @throws AssertionFailedError
          */
-        public function assertPartialMatchBySelector($selector, $expectedMatches, $message = null)
+        public function assertPartialMatchBySelector(string $selector, array $expectedMatches, string $message = null)
         {
             if (is_string($expectedMatches)) {
                 $expectedMatches = [$expectedMatches];
@@ -585,8 +585,8 @@ class FunctionalTest extends SapphireTest implements TestOnly
 
     /**
      * Run a test while mocking the base url with the provided value
-     * @param string $url The base URL to use for this test
-     * @param callable $callback The test to run
+     * @param string string $url The base URL to use for this test
+     * @param callable callable $callback The test to run
      */
     protected function withBaseURL($url, $callback)
     {
@@ -598,8 +598,8 @@ class FunctionalTest extends SapphireTest implements TestOnly
 
     /**
      * Run a test while mocking the base folder with the provided value
-     * @param string $folder The base folder to use for this test
-     * @param callable $callback The test to run
+     * @param string string $folder The base folder to use for this test
+     * @param callable callable $callback The test to run
      */
     protected function withBaseFolder($folder, $callback)
     {
@@ -634,14 +634,14 @@ class FunctionalTest extends SapphireTest implements TestOnly
      *
      * @uses Director::test()
      * @param string $url
-     * @param array $data
+     * @param array array $data
      * @param array $headers
      * @param Session $session
      * @param string $body
      * @param array $cookies
      * @return HTTPResponse
      */
-    public function post($url, $data, $headers = null, $session = null, $body = null, $cookies = null)
+    public function post(string $url, $data, array $headers = null, SilverStripe\Control\Session $session = null, string $body = null, array $cookies = null)
     {
         $this->cssParser = null;
         $response = $this->mainSession->post($url, $data, $headers, $session, $body, $cookies);
@@ -728,11 +728,11 @@ class FunctionalTest extends SapphireTest implements TestOnly
      * Note: &nbsp; characters are stripped from the content; make sure that your assertions take this into account.
      *
      * @param string $selector A basic CSS selector, e.g. 'li.jobs h3'
-     * @param array|string $expectedMatches The content of at least one of the matched tags
+     * @param array|string array $expectedMatches The content of at least one of the matched tags
      * @param string $message
      * @throws PHPUnit_Framework_AssertionFailedError
      */
-    public function assertPartialMatchBySelector($selector, $expectedMatches, $message = null)
+    public function assertPartialMatchBySelector(string $selector, $expectedMatches, string $message = null)
     {
         if (is_string($expectedMatches)) {
             $expectedMatches = [$expectedMatches];

--- a/src/Dev/Install/DatabaseAdapterRegistry.php
+++ b/src/Dev/Install/DatabaseAdapterRegistry.php
@@ -139,7 +139,7 @@ class DatabaseAdapterRegistry implements Flushable
      * @param array $config Config to update. If not provided fall back to global $databaseConfig.
      * In 5.0.0 this will be mandatory and the global will be removed.
      */
-    public static function autoconfigure(&$config = null)
+    public static function autoconfigure(array &$config = null): void
     {
         if (!isset($config)) {
             Deprecation::notice('5.0', 'Configuration via global is deprecated');
@@ -197,7 +197,7 @@ class DatabaseAdapterRegistry implements Flushable
         return Injector::inst()->get(CacheInterface::class . '.DatabaseAdapterRegistry');
     }
 
-    public static function flush()
+    public static function flush(): void
     {
         static::getCache()->clear();
     }

--- a/src/Dev/Install/MySQLDatabaseConfigurationHelper.php
+++ b/src/Dev/Install/MySQLDatabaseConfigurationHelper.php
@@ -209,7 +209,7 @@ class MySQLDatabaseConfigurationHelper implements DatabaseConfigurationHelper
      * @param string $database Candidate database name
      * @return boolean
      */
-    public function checkValidDatabaseName($database)
+    public function checkValidDatabaseName(string $database): bool|int
     {
 
         // Reject filename unsafe characters (cross platform)
@@ -231,7 +231,7 @@ class MySQLDatabaseConfigurationHelper implements DatabaseConfigurationHelper
      * @param string $grant MySQL syntax grant to check within
      * @return boolean
      */
-    public function checkDatabasePermissionGrant($database, $permission, $grant)
+    public function checkDatabasePermissionGrant(string $database, string $permission, string $grant): int|bool
     {
         // Filter out invalid database names
         if (!$this->checkValidDatabaseName($database)) {

--- a/src/Dev/SSListExporter.php
+++ b/src/Dev/SSListExporter.php
@@ -23,7 +23,7 @@ class SSListExporter extends Exporter implements TestOnly
      * @return string
      * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
      */
-    protected function recursiveExport(&$value, $indentation, $processed = null)
+    protected function recursiveExport(array|string|int|SilverStripe\ORM\ArrayList &$value, int $indentation, SebastianBergmann\RecursionContext\Context $processed = null): string
     {
         if (!$processed) {
             $processed = new Context;
@@ -76,7 +76,7 @@ class SSListExporter extends Exporter implements TestOnly
      * @param ViewableData $object
      * @return array
      */
-    public function toMap(ViewableData $object)
+    public function toMap(ViewableData $object): array
     {
         return $object->hasMethod('toMap')
             ? $object->toMap()

--- a/src/Dev/SapphireInfo.php
+++ b/src/Dev/SapphireInfo.php
@@ -27,7 +27,7 @@ class SapphireInfo extends Controller
         }
     }
 
-    public function Version()
+    public function Version(): string
     {
         $sapphireVersion = file_get_contents(FRAMEWORK_PATH . '/silverstripe_version');
         if (!$sapphireVersion) {

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -253,7 +253,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          *
          * @param bool $bool
          */
-        protected static function set_is_running_test($bool)
+        protected static function set_is_running_test(bool $bool)
         {
             self::$is_running_test = $bool;
         }
@@ -379,7 +379,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param $fixtureFiles
          * @return bool
          */
-        protected function shouldSetupDatabaseForCurrentTest($fixtureFiles)
+        protected function shouldSetupDatabaseForCurrentTest(array $fixtureFiles)
         {
             $databaseEnabledByDefault = $fixtureFiles || $this->usesDatabase;
 
@@ -505,7 +505,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param string $identifier The identifier string, as provided in your fixture file
          * @return int
          */
-        protected function idFromFixture($className, $identifier)
+        protected function idFromFixture(string $className, string $identifier)
         {
             /** @var FixtureTestState $state */
             $state = static::$state->getStateByName('fixtures');
@@ -529,7 +529,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param string $className The data class or table name, as specified in your fixture file
          * @return array A map of fixture-identifier => object-id
          */
-        protected function allFixtureIDs($className)
+        protected function allFixtureIDs(string $className)
         {
             /** @var FixtureTestState $state */
             $state = static::$state->getStateByName('fixtures');
@@ -544,7 +544,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          *
          * @return DataObject
          */
-        protected function objFromFixture($className, $identifier)
+        protected function objFromFixture(string $className, string $identifier)
         {
             /** @var FixtureTestState $state */
             $state = static::$state->getStateByName('fixtures');
@@ -672,7 +672,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @return array|null Contains keys: 'Type', 'To', 'From', 'Subject', 'Content', 'PlainContent', 'AttachedFiles',
          *               'HtmlContent'
          */
-        public static function findEmail($to, $from = null, $subject = null, $content = null)
+        public static function findEmail(string $to, string $from = null, string $subject = null, string $content = null)
         {
             /** @var Mailer $mailer */
             $mailer = Injector::inst()->get(Mailer::class);
@@ -691,7 +691,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param string $subject
          * @param string $content
          */
-        public static function assertEmailSent($to, $from = null, $subject = null, $content = null)
+        public static function assertEmailSent(string $to, string $from = null, string $subject = null, string $content = null)
         {
             $found = (bool)static::findEmail($to, $from, $subject, $content);
 
@@ -741,7 +741,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          *         ['Email' => 'i...@example.com'],
          *      ], $members);
          */
-        public static function assertListContains($matches, SS_List $list, $message = '')
+        public static function assertListContains(array $matches, SS_List $list, string $message = '')
         {
             if (!is_array($matches)) {
                 throw self::createInvalidArgumentException(
@@ -765,7 +765,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @deprecated 4.0.0:5.0.0 Use assertListContains() instead
          *
          */
-        public function assertDOSContains($matches, $dataObjectSet)
+        public function assertDOSContains(array $matches, SilverStripe\ORM\ArrayList $dataObjectSet)
         {
             Deprecation::notice('5.0', 'Use assertListContains() instead');
             static::assertListContains($matches, $dataObjectSet);
@@ -791,7 +791,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          *          ['Email' => 'i...@example.com'],
          *      ], $members);
          */
-        public static function assertListNotContains($matches, SS_List $list, $message = '')
+        public static function assertListNotContains(array $matches, SS_List $list, string $message = '')
         {
             if (!is_array($matches)) {
                 throw self::createInvalidArgumentException(
@@ -843,7 +843,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param mixed $list The {@link SS_List} to test.
          * @param string $message
          */
-        public static function assertListEquals($matches, SS_List $list, $message = '')
+        public static function assertListEquals(array $matches, SS_List $list, string $message = '')
         {
             if (!is_array($matches)) {
                 throw self::createInvalidArgumentException(
@@ -867,7 +867,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @deprecated 4.0.0:5.0.0 Use assertListEquals() instead
          *
          */
-        public function assertDOSEquals($matches, $dataObjectSet)
+        public function assertDOSEquals(array $matches, SilverStripe\ORM\ArrayList $dataObjectSet)
         {
             Deprecation::notice('5.0', 'Use assertListEquals() instead');
             static::assertListEquals($matches, $dataObjectSet);
@@ -887,7 +887,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param mixed $list The {@link SS_List} to test.
          * @param string $message
          */
-        public static function assertListAllMatch($match, SS_List $list, $message = '')
+        public static function assertListAllMatch(array $match, SS_List $list, string $message = '')
         {
             if (!is_array($match)) {
                 throw self::createInvalidArgumentException(
@@ -924,7 +924,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param string $sql
          * @return string The cleaned and normalised SQL string
          */
-        protected static function normaliseSQL($sql)
+        protected static function normaliseSQL(string $sql)
         {
             return trim(preg_replace('/\s+/m', ' ', $sql ?? '') ?? '');
         }
@@ -937,7 +937,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param string $message
          */
         public static function assertSQLEquals(
-            $expectedSQL,
+            string $expectedSQL,
             $actualSQL,
             $message = ''
         ) {
@@ -956,7 +956,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param string $message
          */
         public static function assertSQLContains(
-            $needleSQL,
+            string $needleSQL,
             $haystackSQL,
             $message = ''
         ) {
@@ -979,7 +979,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param string $message
          */
         public static function assertSQLNotContains(
-            $needleSQL,
+            string $needleSQL,
             $haystackSQL,
             $message = ''
         ) {
@@ -1064,7 +1064,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param bool $includeExtraDataObjects If true, the extraDataObjects tables will also be included
          * @param bool $forceCreate Force DB to be created if it doesn't exist
          */
-        public static function resetDBSchema($includeExtraDataObjects = false, $forceCreate = false)
+        public static function resetDBSchema(bool $includeExtraDataObjects = false, bool $forceCreate = false)
         {
             if (!static::$tempDB) {
                 return;
@@ -1088,7 +1088,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param callable $callback
          * @return mixed
          */
-        public function actWithPermission($permCode, $callback)
+        public function actWithPermission(string $permCode, callable $callback)
         {
             return Member::actAs($this->createMemberWithPermission($permCode), $callback);
         }
@@ -1099,7 +1099,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param string|array $permCode
          * @return Member
          */
-        protected function createMemberWithPermission($permCode)
+        protected function createMemberWithPermission(string|array $permCode)
         {
             if (is_array($permCode)) {
                 $permArray = $permCode;
@@ -1156,7 +1156,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param string|array $permCode Either a permission, or list of permissions
          * @return int Member ID
          */
-        public function logInWithPermission($permCode = 'ADMIN')
+        public function logInWithPermission(string|array $permCode = 'ADMIN')
         {
             $member = $this->createMemberWithPermission($permCode);
             $this->logInAs($member);
@@ -1168,7 +1168,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          *
          * @param Member|int|string $member The ID, fixture codename, or Member object of the member that you want to log in
          */
-        public function logInAs($member)
+        public function logInAs(SilverStripe\Security\Member|string|int $member)
         {
             if (is_numeric($member)) {
                 $member = DataObject::get_by_id(Member::class, $member);
@@ -1201,7 +1201,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param callable $callback
          * @throws Exception
          */
-        protected function useTestTheme($themeBaseDir, $theme, $callback)
+        protected function useTestTheme(string string $themeBaseDir, $theme, callable $callback)
         {
             Config::nest();
             if (strpos($themeBaseDir ?? '', BASE_PATH) === 0) {
@@ -1261,7 +1261,7 @@ if (class_exists(IsEqualCanonicalizing::class)) {
          * @param string $fixtureFilePath
          * @return string
          */
-        protected function resolveFixturePath($fixtureFilePath)
+        protected function resolveFixturePath(string $fixtureFilePath)
         {
             // support loading via composer name path.
             if (strpos($fixtureFilePath ?? '', ':') !== false) {
@@ -1804,8 +1804,8 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
     /**
      * Get the ID of an object from the fixture.
      *
-     * @param string $className The data class or table name, as specified in your fixture file.  Parent classes won't work
-     * @param string $identifier The identifier string, as provided in your fixture file
+     * @param string string $className The data class or table name, as specified in your fixture file.  Parent classes won't work
+     * @param string string $identifier The identifier string, as provided in your fixture file
      * @return int
      */
     protected function idFromFixture($className, $identifier)
@@ -2420,7 +2420,7 @@ class SapphireTest extends PHPUnit_Framework_TestCase implements TestOnly
      * @param callable $callback
      * @return mixed
      */
-    public function actWithPermission($permCode, $callback)
+    public function actWithPermission(string|array $permCode, $callback)
     {
         return Member::actAs($this->createMemberWithPermission($permCode), $callback);
     }

--- a/src/Dev/State/ExtensionTestState.php
+++ b/src/Dev/State/ExtensionTestState.php
@@ -28,15 +28,15 @@ class ExtensionTestState implements TestState
      *
      * @param SapphireTest $test
      */
-    public function setUp(SapphireTest $test)
+    public function setUp(SapphireTest $test): void
     {
     }
 
-    public function tearDown(SapphireTest $test)
+    public function tearDown(SapphireTest $test): void
     {
     }
 
-    public function setUpOnce($class)
+    public function setUpOnce(string $class): void
     {
         // May be altered by another class
         $isAltered = false;
@@ -102,7 +102,7 @@ class ExtensionTestState implements TestState
         }
     }
 
-    public function tearDownOnce($class)
+    public function tearDownOnce(string $class): void
     {
         // @todo: This isn't strictly necessary to restore extensions, but only to ensure that
         // Object::$extra_methods is properly flushed. This should be replaced with a simple

--- a/src/Dev/State/FixtureTestState.php
+++ b/src/Dev/State/FixtureTestState.php
@@ -31,7 +31,7 @@ class FixtureTestState implements TestState
      *
      * @param SapphireTest $test
      */
-    public function setUp(SapphireTest $test)
+    public function setUp(SapphireTest $test): void
     {
         if (!$this->testNeedsDB($test)) {
             return;
@@ -77,7 +77,7 @@ class FixtureTestState implements TestState
      *
      * @param SapphireTest $test
      */
-    public function tearDown(SapphireTest $test)
+    public function tearDown(SapphireTest $test): void
     {
         if (!$this->testNeedsDB($test)) {
             return;
@@ -101,7 +101,7 @@ class FixtureTestState implements TestState
      *
      * @param string $class Class being setup
      */
-    public function setUpOnce($class)
+    public function setUpOnce(string $class): void
     {
         $this->resetFixtureFactory($class);
     }
@@ -111,7 +111,7 @@ class FixtureTestState implements TestState
      *
      * @param string $class Class being torn down
      */
-    public function tearDownOnce($class)
+    public function tearDownOnce(string $class): void
     {
         unset($this->fixtureFactories[strtolower($class)]);
         $class::tempDB()->clearAllData();
@@ -122,7 +122,7 @@ class FixtureTestState implements TestState
      *
      * @return bool|FixtureFactory
      */
-    public function getFixtureFactory($class)
+    public function getFixtureFactory(string $class): SilverStripe\Dev\FixtureFactory
     {
         $testClass = strtolower($class ?? '');
         if (array_key_exists($testClass, $this->fixtureFactories ?? [])) {
@@ -147,7 +147,7 @@ class FixtureTestState implements TestState
      *
      * @return array
      */
-    protected function getFixturePaths($fixtures, SapphireTest $test)
+    protected function getFixturePaths(array $fixtures, SapphireTest $test): array
     {
         return array_map(function ($fixtureFilePath) use ($test) {
             return $this->resolveFixturePath($fixtureFilePath, $test);
@@ -157,7 +157,7 @@ class FixtureTestState implements TestState
     /**
      * @param SapphireTest $test
      */
-    protected function loadFixtures(SapphireTest $test)
+    protected function loadFixtures(SapphireTest $test): void
     {
         $fixtures = $test::get_fixture_file();
         $fixtures = is_array($fixtures) ? $fixtures : [$fixtures];
@@ -173,7 +173,7 @@ class FixtureTestState implements TestState
      * @param string $fixtureFile
      * @param SapphireTest $test
      */
-    protected function loadFixture($fixtureFile, SapphireTest $test)
+    protected function loadFixture(string $fixtureFile, SapphireTest $test): void
     {
         /** @var YamlFixture $fixture */
         $fixture = Injector::inst()->create(YamlFixture::class, $fixtureFile);
@@ -188,7 +188,7 @@ class FixtureTestState implements TestState
      *
      * @return string
      */
-    protected function resolveFixturePath($fixtureFilePath, SapphireTest $test)
+    protected function resolveFixturePath(string $fixtureFilePath, SapphireTest $test): string
     {
         // Support fixture paths relative to the test class, rather than relative to webroot
         // String checking is faster than file_exists() calls.
@@ -213,7 +213,7 @@ class FixtureTestState implements TestState
      *
      * @return string Absolute path to current class.
      */
-    protected function getTestAbsolutePath(SapphireTest $test)
+    protected function getTestAbsolutePath(SapphireTest $test): string
     {
         $filename = ClassLoader::inst()->getItemPath(get_class($test));
         if (!$filename) {
@@ -228,7 +228,7 @@ class FixtureTestState implements TestState
      *
      * @return bool
      */
-    protected function testNeedsDB(SapphireTest $test)
+    protected function testNeedsDB(SapphireTest $test): bool
     {
         // test class explicitly enables DB
         if ($test->getUsesDatabase()) {
@@ -263,7 +263,7 @@ class FixtureTestState implements TestState
      *
      * @param string $class
      */
-    protected function resetFixtureFactory($class)
+    protected function resetFixtureFactory(string $class): void
     {
         $class = strtolower($class ?? '');
         $this->fixtureFactories[$class] = Injector::inst()->create(FixtureFactory::class);
@@ -276,7 +276,7 @@ class FixtureTestState implements TestState
      * @param string $class Name of test to check
      * @return bool
      */
-    protected function getIsLoaded($class)
+    protected function getIsLoaded(string $class): bool
     {
         return !empty($this->loaded[strtolower($class)]);
     }

--- a/src/Dev/State/FlushableTestState.php
+++ b/src/Dev/State/FlushableTestState.php
@@ -17,7 +17,7 @@ class FlushableTestState implements TestState
      */
     protected $flushed = false;
 
-    public function setUp(SapphireTest $test)
+    public function setUp(SapphireTest $test): void
     {
         // Reset all resettables
         /** @var Resettable $resettable */
@@ -26,11 +26,11 @@ class FlushableTestState implements TestState
         }
     }
 
-    public function tearDown(SapphireTest $test)
+    public function tearDown(SapphireTest $test): void
     {
     }
 
-    public function setUpOnce($class)
+    public function setUpOnce(string $class): void
     {
         if ($this->flushed) {
             return;
@@ -44,7 +44,7 @@ class FlushableTestState implements TestState
         }
     }
 
-    public function tearDownOnce($class)
+    public function tearDownOnce(string $class): void
     {
     }
 }

--- a/src/Dev/State/GlobalsTestState.php
+++ b/src/Dev/State/GlobalsTestState.php
@@ -23,22 +23,22 @@ class GlobalsTestState implements TestState
      */
     protected $vars = [];
 
-    public function setUp(SapphireTest $test)
+    public function setUp(SapphireTest $test): void
     {
         $this->vars = Environment::getVariables();
     }
 
-    public function tearDown(SapphireTest $test)
+    public function tearDown(SapphireTest $test): void
     {
         Environment::setVariables($this->vars);
     }
 
-    public function setUpOnce($class)
+    public function setUpOnce(string $class): void
     {
         $this->staticVars = Environment::getVariables();
     }
 
-    public function tearDownOnce($class)
+    public function tearDownOnce(string $class): void
     {
         Environment::setVariables($this->staticVars);
     }

--- a/src/Dev/State/KernelTestState.php
+++ b/src/Dev/State/KernelTestState.php
@@ -24,7 +24,7 @@ class KernelTestState implements TestState
      *
      * @return \SilverStripe\Dev\TestKernel
      */
-    protected function kernel()
+    protected function kernel(): SilverStripe\Dev\TestKernel
     {
         return end($this->kernels);
     }
@@ -34,7 +34,7 @@ class KernelTestState implements TestState
      *
      * @param SapphireTest $test
      */
-    public function setUp(SapphireTest $test)
+    public function setUp(SapphireTest $test): void
     {
         $this->nest();
     }
@@ -44,7 +44,7 @@ class KernelTestState implements TestState
      *
      * @param SapphireTest $test
      */
-    public function tearDown(SapphireTest $test)
+    public function tearDown(SapphireTest $test): void
     {
         $this->unnest();
     }
@@ -54,7 +54,7 @@ class KernelTestState implements TestState
      *
      * @param string $class Class being setup
      */
-    public function setUpOnce($class)
+    public function setUpOnce(string $class): void
     {
         // If first run, get initial kernel
         if (empty($this->kernels)) {
@@ -69,7 +69,7 @@ class KernelTestState implements TestState
      *
      * @param string $class Class being torn down
      */
-    public function tearDownOnce($class)
+    public function tearDownOnce(string $class): void
     {
         $this->unnest();
     }
@@ -77,14 +77,14 @@ class KernelTestState implements TestState
     /**
      * Nest the current kernel
      */
-    protected function nest()
+    protected function nest(): void
     {
         // Reset state
         $this->kernel()->reset();
         $this->kernels[] = $this->kernel()->nest();
     }
 
-    protected function unnest()
+    protected function unnest(): void
     {
         // Unnest and reset
         array_pop($this->kernels);

--- a/src/Dev/State/LoggerState.php
+++ b/src/Dev/State/LoggerState.php
@@ -16,7 +16,7 @@ use SilverStripe\Dev\SapphireTest;
  */
 class LoggerState implements TestState
 {
-    public function setUp(SapphireTest $test)
+    public function setUp(SapphireTest $test): void
     {
         /** @var Logger $userLogger */
         $userLogger = Injector::inst()->get(LoggerInterface::class);
@@ -25,17 +25,17 @@ class LoggerState implements TestState
         }
     }
 
-    public function tearDown(SapphireTest $test)
+    public function tearDown(SapphireTest $test): void
     {
         // noop
     }
 
-    public function setUpOnce($class)
+    public function setUpOnce(string $class): void
     {
         // noop
     }
 
-    public function tearDownOnce($class)
+    public function tearDownOnce(string $class): void
     {
         // noop
     }

--- a/src/Dev/State/SapphireTestState.php
+++ b/src/Dev/State/SapphireTestState.php
@@ -17,7 +17,7 @@ class SapphireTestState implements TestState
     /**
      * @return TestState[]
      */
-    public function getStates()
+    public function getStates(): array
     {
         return $this->states;
     }
@@ -27,7 +27,7 @@ class SapphireTestState implements TestState
      *
      * @return bool|TestState
      */
-    public function getStateByName($name)
+    public function getStateByName(string $name): SilverStripe\Dev\State\FixtureTestState
     {
         $states = $this->getStates();
         if (array_key_exists($name, $states ?? [])) {
@@ -56,20 +56,20 @@ class SapphireTestState implements TestState
      * @param TestState[] $states
      * @return $this
      */
-    public function setStates(array $states)
+    public function setStates(array $states): SilverStripe\Dev\State\SapphireTestState
     {
         $this->states = $states;
         return $this;
     }
 
-    public function setUp(SapphireTest $test)
+    public function setUp(SapphireTest $test): void
     {
         foreach ($this->states as $state) {
             $state->setUp($test);
         }
     }
 
-    public function tearDown(SapphireTest $test)
+    public function tearDown(SapphireTest $test): void
     {
         // Tear down in reverse order
         /** @var TestState $state */
@@ -78,7 +78,7 @@ class SapphireTestState implements TestState
         }
     }
 
-    public function setUpOnce($class)
+    public function setUpOnce(string $class): void
     {
         foreach ($this->states as $state) {
             $state->setUpOnce($class);
@@ -90,7 +90,7 @@ class SapphireTestState implements TestState
      *
      * @param string $class Class being torn down
      */
-    public function tearDownOnce($class)
+    public function tearDownOnce(string $class): void
     {
         // Tear down in reverse order
         /** @var TestState $state */

--- a/src/Dev/TaskRunner.php
+++ b/src/Dev/TaskRunner.php
@@ -39,7 +39,7 @@ class TaskRunner extends Controller
         'silverstripe/framework:client/styles/task-runner.css',
     ];
 
-    protected function init()
+    protected function init(): void
     {
         parent::init();
 
@@ -100,7 +100,7 @@ class TaskRunner extends Controller
      * Runs a BuildTask
      * @param HTTPRequest $request
      */
-    public function runTask($request)
+    public function runTask(SilverStripe\Control\HTTPRequest $request): void
     {
         $name = $request->param('TaskName');
         $tasks = $this->getTasks();
@@ -135,7 +135,7 @@ class TaskRunner extends Controller
     /**
      * @return array Array of associative arrays for each task (Keys: 'class', 'title', 'description')
      */
-    protected function getTasks()
+    protected function getTasks(): array
     {
         $availableTasks = [];
 
@@ -171,7 +171,7 @@ class TaskRunner extends Controller
      * @param string $class
      * @return boolean
      */
-    protected function taskEnabled($class)
+    protected function taskEnabled(string $class): bool
     {
         $reflectionClass = new ReflectionClass($class);
         if ($reflectionClass->isAbstract()) {

--- a/src/Dev/Tasks/MigrateFileTask.php
+++ b/src/Dev/Tasks/MigrateFileTask.php
@@ -258,7 +258,7 @@ class MigrateFileTask extends BuildTask
         $this->logger->info("Done!");
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return <<<TXT
 Imports all files referenced by File dataobjects into the new Asset Persistence Layer introduced in 4.0.
@@ -272,7 +272,7 @@ TXT;
     /**
      * @param LoggerInterface $logger
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): SilverStripe\Subsites\Tasks\SubsiteMigrateFileTask
     {
         $this->logger = $logger;
 

--- a/src/Dev/TestKernel.php
+++ b/src/Dev/TestKernel.php
@@ -14,7 +14,7 @@ class TestKernel extends CoreKernel
     private $ciConfigs = [];
 
 
-    public function __construct($basePath)
+    public function __construct(string $basePath): void
     {
         $this->setEnvironment(self::DEV);
         parent::__construct($basePath);
@@ -26,14 +26,14 @@ class TestKernel extends CoreKernel
      *
      * @return $this
      */
-    public function reset()
+    public function reset(): SilverStripe\Dev\TestKernel
     {
         $this->setEnvironment(self::DEV);
         $this->bootPHP();
         return $this;
     }
 
-    protected function bootPHP()
+    protected function bootPHP(): void
     {
         parent::bootPHP();
 
@@ -41,7 +41,7 @@ class TestKernel extends CoreKernel
         date_default_timezone_set('UTC');
     }
 
-    protected function getIncludeTests()
+    protected function getIncludeTests(): bool
     {
         return true;
     }
@@ -62,7 +62,7 @@ class TestKernel extends CoreKernel
         return $this->ciConfigs;
     }
 
-    protected function bootErrorHandling()
+    protected function bootErrorHandling(): void
     {
         // Leave phpunit to capture errors
         restore_error_handler();

--- a/src/Dev/TestMailer.php
+++ b/src/Dev/TestMailer.php
@@ -12,7 +12,7 @@ class TestMailer implements Mailer
      */
     protected $emailsSent = [];
 
-    public function send($email)
+    public function send(SilverStripe\Control\Email\Email $email): bool
     {
         // Detect body type
         $htmlContent = null;
@@ -68,7 +68,7 @@ class TestMailer implements Mailer
      *
      * @param array $data A map of information about the email
      */
-    protected function saveEmail($data)
+    protected function saveEmail(array $data): void
     {
         $this->emailsSent[] = $data;
     }
@@ -76,7 +76,7 @@ class TestMailer implements Mailer
     /**
      * Clear the log of emails sent
      */
-    public function clearEmails()
+    public function clearEmails(): void
     {
         $this->emailsSent = [];
     }
@@ -92,7 +92,7 @@ class TestMailer implements Mailer
      * @return array|null Contains keys: 'Type', 'To', 'From', 'Subject', 'Content', 'PlainContent', 'AttachedFiles',
      *               'HtmlContent'
      */
-    public function findEmail($to, $from = null, $subject = null, $content = null)
+    public function findEmail(string $to, string $from = null, string $subject = null, string $content = null): array|null
     {
         $compare = [
             'To' => $to,
@@ -133,7 +133,7 @@ class TestMailer implements Mailer
     /**
      * @param string $value
      */
-    private function normaliseSpaces(string $value)
+    private function normaliseSpaces(string $value): string
     {
         return str_replace([', ', '; '], [',', ';'], $value ?? '');
     }

--- a/src/Dev/TestSession.php
+++ b/src/Dev/TestSession.php
@@ -55,7 +55,7 @@ class TestSession
      */
     private $lastUrl;
 
-    public function __construct()
+    public function __construct(): void
     {
         $this->session = Injector::inst()->create(Session::class, []);
         $this->cookies = Injector::inst()->create(Cookie_Backend::class);
@@ -67,7 +67,7 @@ class TestSession
         $this->controller->doInit();
     }
 
-    public function __destruct()
+    public function __destruct(): void
     {
         // Shift off anything else that's on the stack.  This can happen if something throws
         // an exception that causes a premature TestSession::__destruct() call
@@ -90,7 +90,7 @@ class TestSession
      * @param array $cookies
      * @return HTTPResponse
      */
-    public function get($url, $session = null, $headers = null, $cookies = null)
+    public function get(string $url, SilverStripe\Control\Session $session = null, array $headers = null, array $cookies = null): SilverStripe\Control\HTTPResponse
     {
         $this->extend('updateGetURL', $url, $session, $headers, $cookies);
         $headers = (array) $headers;
@@ -126,7 +126,7 @@ class TestSession
      * @return HTTPResponse
      * @throws HTTPResponse_Exception
      */
-    public function post($url, $data, $headers = null, $session = null, $body = null, $cookies = null)
+    public function post(string $url, array $data, array $headers = null, SilverStripe\Control\Session $session = null, string $body = null, array $cookies = null): SilverStripe\Control\HTTPResponse
     {
         $this->extend('updatePostURL', $url, $data, $headers, $session, $body, $cookies);
         $headers = (array) $headers;
@@ -210,7 +210,7 @@ class TestSession
      * @return HTTPResponse
      * @throws Exception
      */
-    public function submitForm($formID, $button = null, $data = [])
+    public function submitForm(string $formID, string $button = null, array $data = []): SilverStripe\Control\HTTPResponse
     {
         $page = $this->lastPage();
         if ($page) {
@@ -248,7 +248,7 @@ class TestSession
      *
      * @return HTTPResponse The response given, or null if no redirect occurred
      */
-    public function followRedirection()
+    public function followRedirection(): SilverStripe\Control\HTTPResponse
     {
         if ($this->lastResponse->getHeader('Location')) {
             $url = Director::makeRelative($this->lastResponse->getHeader('Location'));
@@ -283,7 +283,7 @@ class TestSession
      *
      * @return string
      */
-    public function lastUrl()
+    public function lastUrl(): string
     {
         return $this->lastUrl;
     }
@@ -293,7 +293,7 @@ class TestSession
      *
      * @return string
      */
-    public function lastContent()
+    public function lastContent(): string
     {
         if (is_string($this->lastResponse)) {
             return $this->lastResponse;
@@ -317,7 +317,7 @@ class TestSession
      *
      * @return SimplePage The response if available
      */
-    public function lastPage()
+    public function lastPage(): SimplePage
     {
         require_once("simpletest/http.php");
         require_once("simpletest/page.php");
@@ -338,7 +338,7 @@ class TestSession
      *
      * @return Session
      */
-    public function session()
+    public function session(): SilverStripe\Control\Session
     {
         return $this->session;
     }

--- a/src/Dev/TestSession_STResponseWrapper.php
+++ b/src/Dev/TestSession_STResponseWrapper.php
@@ -15,7 +15,7 @@ class TestSession_STResponseWrapper
      */
     private $response;
 
-    public function __construct(HTTPResponse $response)
+    public function __construct(HTTPResponse $response): void
     {
         $this->response = $response;
     }
@@ -23,7 +23,7 @@ class TestSession_STResponseWrapper
     /**
      * @return string
      */
-    public function getContent()
+    public function getContent(): string
     {
         return $this->response->getBody();
     }
@@ -31,7 +31,7 @@ class TestSession_STResponseWrapper
     /**
      * @return string
      */
-    public function getError()
+    public function getError(): string
     {
         return "";
     }
@@ -39,7 +39,7 @@ class TestSession_STResponseWrapper
     /**
      * @return null
      */
-    public function getSent()
+    public function getSent(): null
     {
         return null;
     }
@@ -47,7 +47,7 @@ class TestSession_STResponseWrapper
     /**
      * @return string
      */
-    public function getHeaders()
+    public function getHeaders(): string
     {
         return "";
     }
@@ -55,7 +55,7 @@ class TestSession_STResponseWrapper
     /**
      * @return string 'GET'
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return "GET";
     }
@@ -63,7 +63,7 @@ class TestSession_STResponseWrapper
     /**
      * @return string
      */
-    public function getUrl()
+    public function getUrl(): string
     {
         return "";
     }
@@ -71,7 +71,7 @@ class TestSession_STResponseWrapper
     /**
      * @return null
      */
-    public function getRequestData()
+    public function getRequestData(): null
     {
         return null;
     }

--- a/src/Dev/Validation/RelationValidationService.php
+++ b/src/Dev/Validation/RelationValidationService.php
@@ -593,7 +593,7 @@ class RelationValidationService implements Resettable
      * @param array|string $relationData
      * @return string|null
      */
-    protected function parseManyManyRelation($relationData): ?string
+    protected function parseManyManyRelation(string|array $relationData): ?string
     {
         if (is_array($relationData)) {
             foreach (['through', 'to'] as $key) {
@@ -627,7 +627,7 @@ class RelationValidationService implements Resettable
      * @param string $relation
      * @param string $message
      */
-    protected function logError(string $class, string $relation, string $message)
+    protected function logError(string $class, string $relation, string $message): void
     {
         $classPrefix = $relation ? sprintf('%s / %s', $class, $relation) : $class;
         $this->errors[] = sprintf('%s : %s', $classPrefix, $message);

--- a/src/Dev/YamlFixture.php
+++ b/src/Dev/YamlFixture.php
@@ -89,7 +89,7 @@ class YamlFixture
     /**
      * @param string $fixture Absolute file path, or relative path to {@link Director::baseFolder()}
      */
-    public function __construct($fixture)
+    public function __construct(string $fixture): void
     {
         if (false !== strpos($fixture ?? '', "\n")) {
             $this->fixtureString = $fixture;
@@ -110,7 +110,7 @@ class YamlFixture
     /**
      * @return String Absolute file path
      */
-    public function getFixtureFile()
+    public function getFixtureFile(): string|null
     {
         return $this->fixtureFile;
     }
@@ -118,7 +118,7 @@ class YamlFixture
     /**
      * @return String Fixture string
      */
-    public function getFixtureString()
+    public function getFixtureString(): null|string
     {
         return $this->fixtureString;
     }
@@ -130,7 +130,7 @@ class YamlFixture
      *
      * @param  FixtureFactory $factory
      */
-    public function writeInto(FixtureFactory $factory)
+    public function writeInto(FixtureFactory $factory): void
     {
         $parser = new Parser();
         if (isset($this->fixtureString)) {

--- a/src/Forms/CheckboxField.php
+++ b/src/Forms/CheckboxField.php
@@ -10,23 +10,23 @@ class CheckboxField extends FormField
 
     protected $schemaDataType = FormField::SCHEMA_DATA_TYPE_BOOLEAN;
 
-    public function setValue($value, $data = null)
+    public function setValue(int|bool|float|string $value, array|DNADesign\Elemental\Models\ElementContent $data = null): SilverStripe\Forms\CheckboxField
     {
         $this->value = ($value) ? 1 : 0;
         return $this;
     }
 
-    public function dataValue()
+    public function dataValue(): null|int
     {
         return ($this->value) ? 1 : null;
     }
 
-    public function Value()
+    public function Value(): int
     {
         return ($this->value) ? 1 : 0;
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = parent::getAttributes();
         $attributes['value'] = 1;
@@ -48,7 +48,7 @@ class CheckboxField extends FormField
     /**
      * Returns a readonly version of this field
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\CheckboxField_Readonly
     {
         $field = new CheckboxField_Readonly($this->name, $this->title, $this->value);
         $field->setForm($this->form);

--- a/src/Forms/CheckboxField_Readonly.php
+++ b/src/Forms/CheckboxField_Readonly.php
@@ -8,19 +8,19 @@ namespace SilverStripe\Forms;
 class CheckboxField_Readonly extends ReadonlyField
 {
 
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\CheckboxField_Readonly
     {
         return clone $this;
     }
 
-    public function Value()
+    public function Value(): string
     {
         return $this->value ?
             _t('SilverStripe\\Forms\\CheckboxField.YESANSWER', 'Yes') :
             _t('SilverStripe\\Forms\\CheckboxField.NOANSWER', 'No');
     }
 
-    public function getValueCast()
+    public function getValueCast(): string
     {
         return 'Text';
     }

--- a/src/Forms/CheckboxSetField.php
+++ b/src/Forms/CheckboxSetField.php
@@ -54,7 +54,7 @@ class CheckboxSetField extends MultiSelectField
      * @param array $properties
      * @return DBHTMLText
      */
-    public function Field($properties = [])
+    public function Field($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $properties = array_merge($properties, [
             'Options' => $this->getOptions()
@@ -68,7 +68,7 @@ class CheckboxSetField extends MultiSelectField
      *
      * @return ArrayList
      */
-    public function getOptions()
+    public function getOptions(): SilverStripe\ORM\ArrayList
     {
         $selectedValues = $this->getValueArray();
         $defaultItems = $this->getDefaultItems();
@@ -102,12 +102,12 @@ class CheckboxSetField extends MultiSelectField
         return $options;
     }
 
-    public function Type()
+    public function Type(): string
     {
         return 'optionset checkboxset';
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = array_merge(
             parent::getAttributes(),

--- a/src/Forms/CompositeField.php
+++ b/src/Forms/CompositeField.php
@@ -53,7 +53,7 @@ class CompositeField extends FormField
     /** @skipUpgrade */
     protected $schemaComponent = 'CompositeField';
 
-    public function __construct($children = null)
+    public function __construct(array|string|SilverStripe\Forms\TextField $children = null): void
     {
         // Normalise $children to a FieldList
         if (!$children instanceof FieldList) {
@@ -71,7 +71,7 @@ class CompositeField extends FormField
     /**
      * Merge child field data into this form
      */
-    public function getSchemaDataDefaults()
+    public function getSchemaDataDefaults(): array
     {
         $defaults = parent::getSchemaDataDefaults();
         $children = $this->getChildren();
@@ -102,7 +102,7 @@ class CompositeField extends FormField
      *
      * @return FieldList
      */
-    public function FieldList()
+    public function FieldList(): SilverStripe\Forms\FieldList
     {
         return $this->children;
     }
@@ -112,7 +112,7 @@ class CompositeField extends FormField
      *
      * @return FieldList
      */
-    public function getChildren()
+    public function getChildren(): SilverStripe\Forms\FieldList
     {
         return $this->children;
     }
@@ -126,7 +126,7 @@ class CompositeField extends FormField
      *
      * @return String $name
      */
-    public function getName()
+    public function getName(): string
     {
         if ($this->name) {
             return $this->name;
@@ -153,7 +153,7 @@ class CompositeField extends FormField
      * @param FieldList $children
      * @return $this
      */
-    public function setChildren($children)
+    public function setChildren(SilverStripe\Forms\FieldList $children): SilverStripe\Forms\CompositeField
     {
         $this->children = $children;
         $children->setContainerField($this);
@@ -164,7 +164,7 @@ class CompositeField extends FormField
      * @param string $tag
      * @return $this
      */
-    public function setTag($tag)
+    public function setTag(string $tag): SilverStripe\Forms\CompositeField
     {
         $this->tag = $tag;
 
@@ -174,7 +174,7 @@ class CompositeField extends FormField
     /**
      * @return string
      */
-    public function getTag()
+    public function getTag(): string
     {
         return $this->tag;
     }
@@ -183,7 +183,7 @@ class CompositeField extends FormField
      * @param string $legend
      * @return $this
      */
-    public function setLegend($legend)
+    public function setLegend(string $legend): SilverStripe\Forms\CompositeField
     {
         $this->legend = $legend;
         return $this;
@@ -192,12 +192,12 @@ class CompositeField extends FormField
     /**
      * @return string
      */
-    public function getLegend()
+    public function getLegend(): null|string
     {
         return $this->legend;
     }
 
-    public function extraClass()
+    public function extraClass(): string
     {
         /** @skipUpgrade */
         $classes = ['field', 'CompositeField', parent::extraClass()];
@@ -208,7 +208,7 @@ class CompositeField extends FormField
         return implode(' ', $classes);
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return array_merge(
             parent::getAttributes(),
@@ -230,7 +230,7 @@ class CompositeField extends FormField
      * @param array $list
      * @param bool $saveableOnly
      */
-    public function collateDataFields(&$list, $saveableOnly = false)
+    public function collateDataFields(array &$list, bool $saveableOnly = false): void
     {
         foreach ($this->children as $field) {
             if (! $field instanceof FormField) {
@@ -263,7 +263,7 @@ class CompositeField extends FormField
         }
     }
 
-    public function setForm($form)
+    public function setForm(SilverStripe\Comments\Forms\CommentForm $form): SilverStripe\Forms\CompositeField
     {
         foreach ($this->getChildren() as $field) {
             if ($field instanceof FormField) {
@@ -277,7 +277,7 @@ class CompositeField extends FormField
 
 
 
-    public function setDisabled($disabled)
+    public function setDisabled(bool $disabled): SilverStripe\Forms\SelectionGroup_Item
     {
         parent::setDisabled($disabled);
         foreach ($this->getChildren() as $child) {
@@ -286,7 +286,7 @@ class CompositeField extends FormField
         return $this;
     }
 
-    public function setReadonly($readonly)
+    public function setReadonly(bool $readonly): SilverStripe\Forms\CompositeField
     {
         parent::setReadonly($readonly);
         foreach ($this->getChildren() as $child) {
@@ -295,28 +295,28 @@ class CompositeField extends FormField
         return $this;
     }
 
-    public function setColumnCount($columnCount)
+    public function setColumnCount(int $columnCount): SilverStripe\Forms\CompositeField
     {
         $this->columnCount = $columnCount;
         return $this;
     }
 
-    public function getColumnCount()
+    public function getColumnCount(): null
     {
         return $this->columnCount;
     }
 
-    public function isComposite()
+    public function isComposite(): bool
     {
         return true;
     }
 
-    public function hasData()
+    public function hasData(): bool
     {
         return false;
     }
 
-    public function fieldByName($name)
+    public function fieldByName(string $name): null|SilverStripe\Forms\Tab
     {
         return $this->children->fieldByName($name);
     }
@@ -326,7 +326,7 @@ class CompositeField extends FormField
      *
      * @param FormField $field
      */
-    public function push(FormField $field)
+    public function push(FormField $field): void
     {
         $this->children->push($field);
     }
@@ -336,7 +336,7 @@ class CompositeField extends FormField
      *
      * @param FormField $field
      */
-    public function unshift(FormField $field)
+    public function unshift(FormField $field): void
     {
         $this->children->unshift($field);
     }
@@ -349,7 +349,7 @@ class CompositeField extends FormField
      * @param bool $appendIfMissing
      * @return false|FormField
      */
-    public function insertBefore($insertBefore, $field, $appendIfMissing = true)
+    public function insertBefore(string $insertBefore, SilverStripe\Forms\DropdownField $field, bool $appendIfMissing = true): bool|SilverStripe\Forms\DropdownField
     {
         return $this->children->insertBefore($insertBefore, $field, $appendIfMissing);
     }
@@ -361,7 +361,7 @@ class CompositeField extends FormField
      * @param bool $appendIfMissing
      * @return false|FormField
      */
-    public function insertAfter($insertAfter, $field, $appendIfMissing = true)
+    public function insertAfter(string|SilverStripe\Forms\ReadonlyField $insertAfter, string|SilverStripe\AssetAdmin\Forms\UploadField $field, bool $appendIfMissing = true): bool|SilverStripe\AssetAdmin\Forms\UploadField
     {
         return $this->children->insertAfter($insertAfter, $field, $appendIfMissing);
     }
@@ -375,7 +375,7 @@ class CompositeField extends FormField
      * be removed if it's a data field.  Dataless fields, such as tabs, will
      * be left as-is.
      */
-    public function removeByName($fieldName, $dataFieldOnly = false)
+    public function removeByName(string $fieldName, bool $dataFieldOnly = false): void
     {
         $this->children->removeByName($fieldName, $dataFieldOnly);
     }
@@ -388,12 +388,12 @@ class CompositeField extends FormField
      * not be considered for replacement.
      * @return bool
      */
-    public function replaceField($fieldName, $newField, $dataFieldOnly = true)
+    public function replaceField(string $fieldName, DNADesign\Elemental\Forms\TextCheckboxGroupField $newField, $dataFieldOnly = true): bool
     {
         return $this->children->replaceField($fieldName, $newField, $dataFieldOnly);
     }
 
-    public function rootFieldList()
+    public function rootFieldList(): SilverStripe\Forms\FieldList
     {
         if (is_object($this->containerFieldList)) {
             return $this->containerFieldList->rootFieldList();
@@ -402,7 +402,7 @@ class CompositeField extends FormField
         }
     }
 
-    public function __clone()
+    public function __clone(): void
     {
         /** {@see FieldList::__clone(}} */
         $this->setChildren(clone $this->children);
@@ -414,7 +414,7 @@ class CompositeField extends FormField
      *
      * @return CompositeField
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\CompositeField
     {
         $newChildren = new FieldList();
         $clone = clone $this;
@@ -463,7 +463,7 @@ class CompositeField extends FormField
         return $clone;
     }
 
-    public function IsReadonly()
+    public function IsReadonly(): null|bool
     {
         return $this->readonly;
     }
@@ -476,7 +476,7 @@ class CompositeField extends FormField
      * @return int Position in children collection (first position starts with 0). Returns FALSE if the field can't
      *             be found.
      */
-    public function fieldPosition($field)
+    public function fieldPosition(string $field): int|bool
     {
         if (is_string($field)) {
             $field = $this->fieldByName($field);
@@ -503,7 +503,7 @@ class CompositeField extends FormField
      * @param string|FormField $field
      * @return bool
      */
-    public function makeFieldReadonly($field)
+    public function makeFieldReadonly(string|SilverStripe\Forms\TextField $field): bool
     {
         $fieldName = ($field instanceof FormField) ? $field->getName() : $field;
 
@@ -524,7 +524,7 @@ class CompositeField extends FormField
         return false;
     }
 
-    public function debug()
+    public function debug(): string
     {
         $class = static::class;
         $result = "$class ($this->name) <ul>";
@@ -541,7 +541,7 @@ class CompositeField extends FormField
      * @param Validator $validator
      * @return bool
      */
-    public function validate($validator)
+    public function validate(SilverStripe\UserForms\Extension\UserFormValidator $validator): bool
     {
         $valid = true;
         foreach ($this->children as $child) {

--- a/src/Forms/CompositeValidator.php
+++ b/src/Forms/CompositeValidator.php
@@ -47,7 +47,7 @@ class CompositeValidator extends Validator
      *
      * @param array|Validator[] $validators
      */
-    public function __construct(array $validators = [])
+    public function __construct(array $validators = []): void
     {
         $this->validators = array_values($validators ?? []);
 
@@ -60,7 +60,7 @@ class CompositeValidator extends Validator
      * @param Form $form
      * @return Validator
      */
-    public function setForm($form)
+    public function setForm(SilverStripe\Forms\Form $form): SilverStripe\Forms\CompositeValidator
     {
         foreach ($this->getValidators() as $validator) {
             $validator->setForm($form);
@@ -86,7 +86,7 @@ class CompositeValidator extends Validator
      *
      * @return ValidationResult
      */
-    public function validate()
+    public function validate(): SilverStripe\ORM\ValidationResult
     {
         $this->resetResult();
 
@@ -134,7 +134,7 @@ class CompositeValidator extends Validator
      *
      * @return bool
      */
-    public function fieldIsRequired($fieldName)
+    public function fieldIsRequired(string $fieldName): bool
     {
         foreach ($this->getValidators() as $validator) {
             if ($validator->fieldIsRequired($fieldName)) {

--- a/src/Forms/ConfirmedPasswordField.php
+++ b/src/Forms/ConfirmedPasswordField.php
@@ -128,13 +128,13 @@ class ConfirmedPasswordField extends FormField
      * @param string $titleConfirmField Alternate title (not localizeable)
      */
     public function __construct(
-        $name,
+        string $name,
         $title = null,
         $value = "",
         $form = null,
         $showOnClick = false,
         $titleConfirmField = null
-    ) {
+    ): void {
 
         // Set field title
         $title = isset($title) ? $title : _t('SilverStripe\\Security\\Member.PASSWORD', 'Password');
@@ -168,13 +168,13 @@ class ConfirmedPasswordField extends FormField
         $this->setValue($value);
     }
 
-    public function Title()
+    public function Title(): null
     {
         // Title is displayed on nested field, not on the top level field
         return null;
     }
 
-    public function setTitle($title)
+    public function setTitle(string $title): SilverStripe\Forms\ConfirmedPasswordField
     {
         $this->getPasswordField()->setTitle($title);
         return parent::setTitle($title);
@@ -185,7 +185,7 @@ class ConfirmedPasswordField extends FormField
      *
      * @return string
      */
-    public function Field($properties = [])
+    public function Field($properties = []): string
     {
         // Build inner content
         $fieldContent = '';
@@ -237,7 +237,7 @@ class ConfirmedPasswordField extends FormField
      * Returns the children of this field for use in templating.
      * @return FieldList
      */
-    public function getChildren()
+    public function getChildren(): SilverStripe\Forms\FieldList
     {
         return $this->children;
     }
@@ -252,7 +252,7 @@ class ConfirmedPasswordField extends FormField
      *
      * @return ConfirmedPasswordField
      */
-    public function setCanBeEmpty($value)
+    public function setCanBeEmpty(bool $value): SilverStripe\Forms\ConfirmedPasswordField
     {
         $this->canBeEmpty = (bool)$value;
 
@@ -278,7 +278,7 @@ class ConfirmedPasswordField extends FormField
     /**
      * @return string $title
      */
-    public function getShowOnClickTitle()
+    public function getShowOnClickTitle(): null
     {
         return $this->showOnClickTitle;
     }
@@ -288,7 +288,7 @@ class ConfirmedPasswordField extends FormField
      *
      * @return $this
      */
-    public function setRightTitle($title)
+    public function setRightTitle(string $title): SilverStripe\Forms\ConfirmedPasswordField
     {
         foreach ($this->getChildren() as $field) {
             /** @var FormField $field */
@@ -307,7 +307,7 @@ class ConfirmedPasswordField extends FormField
      * @param array $titles List of child titles
      * @return $this
      */
-    public function setChildrenTitles($titles)
+    public function setChildrenTitles(array $titles): SilverStripe\Forms\ConfirmedPasswordField
     {
         $expectedChildren = $this->getRequireExistingPassword() ? 3 : 2;
         if (is_array($titles) && count($titles ?? []) === $expectedChildren) {
@@ -332,7 +332,7 @@ class ConfirmedPasswordField extends FormField
      * @param mixed $data
      * @return $this
      */
-    public function setValue($value, $data = null)
+    public function setValue(string|array $value, SilverStripe\Security\Member|array $data = null): SilverStripe\Forms\ConfirmedPasswordField
     {
         // If $data is a DataObject, don't use the value, since it's a hashed value
         if ($data && $data instanceof DataObject) {
@@ -380,7 +380,7 @@ class ConfirmedPasswordField extends FormField
      * @param string $name new name to give to the field.
      * @return $this
      */
-    public function setName($name)
+    public function setName(string $name): SilverStripe\Forms\ConfirmedPasswordField
     {
         $this->getPasswordField()->setName($name . '[_Password]');
         $this->getConfirmPasswordField()->setName($name . '[_ConfirmPassword]');
@@ -398,7 +398,7 @@ class ConfirmedPasswordField extends FormField
      *
      * @return boolean
      */
-    public function isSaveable()
+    public function isSaveable(): bool
     {
         return !$this->showOnClick
             || ($this->showOnClick && $this->hiddenField && $this->hiddenField->Value());
@@ -410,7 +410,7 @@ class ConfirmedPasswordField extends FormField
      * @param Validator $validator
      * @return bool
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Security\Member_Validator $validator): bool
     {
         $name = $this->name;
 
@@ -556,7 +556,7 @@ class ConfirmedPasswordField extends FormField
      *
      * @param DataObjectInterface $record
      */
-    public function saveInto(DataObjectInterface $record)
+    public function saveInto(DataObjectInterface $record): void
     {
         if (!$this->isSaveable()) {
             return;
@@ -572,7 +572,7 @@ class ConfirmedPasswordField extends FormField
      *
      * @return ReadonlyField
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\ReadonlyField
     {
         /** @var ReadonlyField $field */
         $field = $this->castedCopy(ReadonlyField::class)
@@ -582,7 +582,7 @@ class ConfirmedPasswordField extends FormField
         return $field;
     }
 
-    public function performDisabledTransformation()
+    public function performDisabledTransformation(): SilverStripe\Forms\ReadonlyField
     {
         return $this->performReadonlyTransformation();
     }
@@ -592,7 +592,7 @@ class ConfirmedPasswordField extends FormField
      *
      * @return bool
      */
-    public function getRequireExistingPassword()
+    public function getRequireExistingPassword(): bool
     {
         return $this->requireExistingPassword;
     }
@@ -603,7 +603,7 @@ class ConfirmedPasswordField extends FormField
      * @param bool $show Flag to show or hide this field
      * @return $this
      */
-    public function setRequireExistingPassword($show)
+    public function setRequireExistingPassword(bool $show): SilverStripe\Forms\ConfirmedPasswordField
     {
         // Don't modify if already added / removed
         if ((bool)$show === $this->requireExistingPassword) {
@@ -624,7 +624,7 @@ class ConfirmedPasswordField extends FormField
     /**
      * @return PasswordField
      */
-    public function getPasswordField()
+    public function getPasswordField(): SilverStripe\Forms\PasswordField
     {
         return $this->passwordField;
     }
@@ -632,7 +632,7 @@ class ConfirmedPasswordField extends FormField
     /**
      * @return PasswordField
      */
-    public function getConfirmPasswordField()
+    public function getConfirmPasswordField(): SilverStripe\Forms\PasswordField
     {
         return $this->confirmPasswordfield;
     }
@@ -643,7 +643,7 @@ class ConfirmedPasswordField extends FormField
      * @param int $minLength
      * @return $this
      */
-    public function setMinLength($minLength)
+    public function setMinLength(int $minLength): SilverStripe\Forms\ConfirmedPasswordField
     {
         $this->minLength = (int) $minLength;
         return $this;
@@ -652,7 +652,7 @@ class ConfirmedPasswordField extends FormField
     /**
      * @return int
      */
-    public function getMinLength()
+    public function getMinLength(): null|int
     {
         return $this->minLength;
     }
@@ -663,7 +663,7 @@ class ConfirmedPasswordField extends FormField
      * @param int $maxLength
      * @return $this
      */
-    public function setMaxLength($maxLength)
+    public function setMaxLength(int $maxLength): SilverStripe\Forms\ConfirmedPasswordField
     {
         $this->maxLength = (int) $maxLength;
         return $this;
@@ -672,7 +672,7 @@ class ConfirmedPasswordField extends FormField
     /**
      * @return int
      */
-    public function getMaxLength()
+    public function getMaxLength(): null|int
     {
         return $this->maxLength;
     }
@@ -681,7 +681,7 @@ class ConfirmedPasswordField extends FormField
      * @param bool $requireStrongPassword
      * @return $this
      */
-    public function setRequireStrongPassword($requireStrongPassword)
+    public function setRequireStrongPassword(bool $requireStrongPassword): SilverStripe\Forms\ConfirmedPasswordField
     {
         $this->requireStrongPassword = (bool) $requireStrongPassword;
         return $this;
@@ -690,7 +690,7 @@ class ConfirmedPasswordField extends FormField
     /**
      * @return bool
      */
-    public function getRequireStrongPassword()
+    public function getRequireStrongPassword(): bool
     {
         return $this->requireStrongPassword;
     }

--- a/src/Forms/CurrencyField.php
+++ b/src/Forms/CurrencyField.php
@@ -22,7 +22,7 @@ class CurrencyField extends TextField
      * @param mixed $data
      * @return $this
      */
-    public function setValue($value, $data = null)
+    public function setValue(string|float $value, $data = null): SilverStripe\Forms\CurrencyField
     {
         if (!$value) {
             $value = 0.00;
@@ -35,7 +35,7 @@ class CurrencyField extends TextField
      * Overwrite the datavalue before saving to the db ;-)
      * return 0.00 if no value, or value is non-numeric
      */
-    public function dataValue()
+    public function dataValue(): string|float
     {
         if ($this->value) {
             return preg_replace('/[^0-9.\-]/', '', $this->value ?? '');
@@ -43,7 +43,7 @@ class CurrencyField extends TextField
         return 0.00;
     }
 
-    public function Type()
+    public function Type(): string
     {
         return 'currency text';
     }
@@ -51,12 +51,12 @@ class CurrencyField extends TextField
     /**
      * Create a new class for this field
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\CurrencyField_Readonly
     {
         return $this->castedCopy(CurrencyField_Readonly::class);
     }
 
-    public function validate($validator)
+    public function validate(SilverStripe\Forms\RequiredFields $validator): bool
     {
         $currencySymbol = preg_quote(DBCurrency::config()->uninherited('currency_symbol') ?? '');
         $regex = '/^\s*(\-?' . $currencySymbol . '?|' . $currencySymbol . '\-?)?(\d{1,3}(\,\d{3})*|(\d+))(\.\d{2})?\s*$/';
@@ -71,7 +71,7 @@ class CurrencyField extends TextField
         return true;
     }
 
-    public function getSchemaValidation()
+    public function getSchemaValidation(): array
     {
         $rules = parent::getSchemaValidation();
         $rules['currency'] = true;

--- a/src/Forms/CurrencyField_Disabled.php
+++ b/src/Forms/CurrencyField_Disabled.php
@@ -19,7 +19,7 @@ class CurrencyField_Disabled extends CurrencyField
      * @param array $properties
      * @return string
      */
-    public function Field($properties = [])
+    public function Field($properties = []): string
     {
         if ($this->value) {
             $val = Convert::raw2xml($this->value);

--- a/src/Forms/CurrencyField_Readonly.php
+++ b/src/Forms/CurrencyField_Readonly.php
@@ -17,7 +17,7 @@ class CurrencyField_Readonly extends ReadonlyField
      * @param array $properties
      * @return string
      */
-    public function Field($properties = [])
+    public function Field($properties = []): string
     {
         $currencySymbol = DBCurrency::config()->get('currency_symbol');
         if ($this->value) {
@@ -35,7 +35,7 @@ class CurrencyField_Readonly extends ReadonlyField
     /**
      * This already is a readonly field.
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\CurrencyField_Readonly
     {
         return clone $this;
     }

--- a/src/Forms/DatalessField.php
+++ b/src/Forms/DatalessField.php
@@ -20,12 +20,12 @@ class DatalessField extends FormField
      * function that returns whether this field contains data.
      * Always returns false.
      */
-    public function hasData()
+    public function hasData(): bool
     {
         return false;
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return array_merge(
             parent::getAttributes(),
@@ -42,7 +42,7 @@ class DatalessField extends FormField
      * @param array $properties
      * @return DBHTMLText
      */
-    public function FieldHolder($properties = [])
+    public function FieldHolder(array $properties = []): SilverStripe\ORM\FieldType\DBHTMLText|string
     {
         return $this->Field($properties);
     }
@@ -54,7 +54,7 @@ class DatalessField extends FormField
      * @param array $properties
      * @return DBHTMLText
      */
-    public function SmallFieldHolder($properties = [])
+    public function SmallFieldHolder(array $properties = []): string
     {
         return $this->Field($properties);
     }
@@ -62,7 +62,7 @@ class DatalessField extends FormField
     /**
      * Returns a readonly version of this field
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\HeaderField
     {
         $clone = clone $this;
         $clone->setReadonly(true);
@@ -73,7 +73,7 @@ class DatalessField extends FormField
      * @param bool $bool
      * @return $this
      */
-    public function setAllowHTML($bool)
+    public function setAllowHTML(bool $bool): SilverStripe\Forms\LiteralField
     {
         $this->allowHTML = $bool;
         return $this;
@@ -87,7 +87,7 @@ class DatalessField extends FormField
         return $this->allowHTML;
     }
 
-    public function Type()
+    public function Type(): string
     {
         return 'readonly';
     }

--- a/src/Forms/DateField.php
+++ b/src/Forms/DateField.php
@@ -114,7 +114,7 @@ class DateField extends TextField
     /**
      * @return bool
      */
-    public function getHTML5()
+    public function getHTML5(): bool
     {
         return $this->html5;
     }
@@ -123,7 +123,7 @@ class DateField extends TextField
      * @param boolean $bool
      * @return $this
      */
-    public function setHTML5($bool)
+    public function setHTML5(bool $bool): SilverStripe\Forms\DateField
     {
         $this->html5 = $bool;
         return $this;
@@ -140,7 +140,7 @@ class DateField extends TextField
      * @see http://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants
      * @return int
      */
-    public function getDateLength()
+    public function getDateLength(): int
     {
         if ($this->dateLength) {
             return $this->dateLength;
@@ -157,7 +157,7 @@ class DateField extends TextField
      * @param int $length
      * @return $this
      */
-    public function setDateLength($length)
+    public function setDateLength(int $length): SilverStripe\Forms\DateField
     {
         $this->dateLength = $length;
         return $this;
@@ -171,7 +171,7 @@ class DateField extends TextField
      *
      * @see https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table
      */
-    public function getDateFormat()
+    public function getDateFormat(): string
     {
         // Browsers expect ISO 8601 dates, localisation is handled on the client
         if ($this->getHTML5()) {
@@ -194,7 +194,7 @@ class DateField extends TextField
      * @param string $format
      * @return $this
      */
-    public function setDateFormat($format)
+    public function setDateFormat(string $format): SilverStripe\Forms\DateField
     {
         $this->dateFormat = $format;
         return $this;
@@ -206,7 +206,7 @@ class DateField extends TextField
      * @throws \LogicException
      * @return IntlDateFormatter
      */
-    protected function getFrontendFormatter()
+    protected function getFrontendFormatter(): IntlDateFormatter
     {
         if ($this->getHTML5() && $this->dateFormat && $this->dateFormat !== DBDate::ISO_DATE) {
             throw new \LogicException(
@@ -250,7 +250,7 @@ class DateField extends TextField
      *
      * @return IntlDateFormatter
      */
-    protected function getInternalFormatter()
+    protected function getInternalFormatter(): IntlDateFormatter
     {
         $formatter = IntlDateFormatter::create(
             DBDate::ISO_LOCALE,
@@ -263,7 +263,7 @@ class DateField extends TextField
         return $formatter;
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = parent::getAttributes();
 
@@ -279,7 +279,7 @@ class DateField extends TextField
         return $attributes;
     }
 
-    public function getSchemaDataDefaults()
+    public function getSchemaDataDefaults(): array
     {
         $defaults = parent::getSchemaDataDefaults();
         return array_merge($defaults, [
@@ -292,7 +292,7 @@ class DateField extends TextField
         ]);
     }
 
-    public function Type()
+    public function Type(): string
     {
         return 'date text';
     }
@@ -304,7 +304,7 @@ class DateField extends TextField
      * @param mixed $data
      * @return $this
      */
-    public function setSubmittedValue($value, $data = null)
+    public function setSubmittedValue(string|bool $value, array $data = null): SilverStripe\Forms\DateField
     {
         // Save raw value for later validation
         $this->rawValue = $value;
@@ -329,7 +329,7 @@ class DateField extends TextField
      * @param mixed $data
      * @return $this
      */
-    public function setValue($value, $data = null)
+    public function setValue(string|SilverStripe\Forms\GridField\GridState_Data $value, array|SilverStripe\SiteConfig\SiteConfig $data = null): SilverStripe\Forms\DateField
     {
         // Save raw value for later validation
         $this->rawValue = $value;
@@ -345,12 +345,12 @@ class DateField extends TextField
         return $this;
     }
 
-    public function Value()
+    public function Value(): null|string
     {
         return $this->internalToFrontend($this->value);
     }
 
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\DateField_Disabled
     {
         $field = $this
             ->castedCopy(DateField_Disabled::class)
@@ -365,7 +365,7 @@ class DateField extends TextField
      * @param Validator $validator
      * @return bool
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Forms\RequiredFields $validator): bool
     {
         // Don't validate empty fields
         if (empty($this->rawValue)) {
@@ -443,7 +443,7 @@ class DateField extends TextField
      *
      * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         // Use iso locale for html5
         if ($this->getHTML5()) {
@@ -460,13 +460,13 @@ class DateField extends TextField
      * @param string $locale
      * @return $this
      */
-    public function setLocale($locale)
+    public function setLocale(string $locale): SilverStripe\Forms\DateField
     {
         $this->locale = $locale;
         return $this;
     }
 
-    public function getSchemaValidation()
+    public function getSchemaValidation(): array
     {
         $rules = parent::getSchemaValidation();
         $rules['date'] = true;
@@ -476,7 +476,7 @@ class DateField extends TextField
     /**
      * @return string
      */
-    public function getMinDate()
+    public function getMinDate(): null|string
     {
         return $this->minDate;
     }
@@ -485,7 +485,7 @@ class DateField extends TextField
      * @param string $minDate
      * @return $this
      */
-    public function setMinDate($minDate)
+    public function setMinDate(string $minDate): SilverStripe\Forms\DateField
     {
         $this->minDate = $this->tidyInternal($minDate);
         return $this;
@@ -494,7 +494,7 @@ class DateField extends TextField
     /**
      * @return string
      */
-    public function getMaxDate()
+    public function getMaxDate(): null|string
     {
         return $this->maxDate;
     }
@@ -503,7 +503,7 @@ class DateField extends TextField
      * @param string $maxDate
      * @return $this
      */
-    public function setMaxDate($maxDate)
+    public function setMaxDate(string $maxDate): SilverStripe\Forms\DateField
     {
         $this->maxDate = $this->tidyInternal($maxDate);
         return $this;
@@ -516,7 +516,7 @@ class DateField extends TextField
      * @param string $date
      * @return string The formatted date, or null if not a valid date
      */
-    protected function frontendToInternal($date)
+    protected function frontendToInternal(string $date): string
     {
         if (!$date) {
             return null;
@@ -538,7 +538,7 @@ class DateField extends TextField
      * @param string $date
      * @return string The formatted date, or null if not a valid date
      */
-    protected function internalToFrontend($date)
+    protected function internalToFrontend(string $date): null|string
     {
         $date = $this->tidyInternal($date);
         if (!$date) {
@@ -560,7 +560,7 @@ class DateField extends TextField
      * @param string $date Date in ISO 8601 or approximate form
      * @return string ISO 8601 date, or null if not valid
      */
-    protected function tidyInternal($date)
+    protected function tidyInternal(SilverStripe\Forms\GridField\GridState_Data|string $date): null|string
     {
         if (!$date) {
             return null;

--- a/src/Forms/DateField_Disabled.php
+++ b/src/Forms/DateField_Disabled.php
@@ -14,7 +14,7 @@ class DateField_Disabled extends DateField
 
     protected $disabled = true;
 
-    public function Field($properties = [])
+    public function Field($properties = []): string
     {
         // Default display value
         $displayValue = '<i>(' . _t('SilverStripe\\Forms\\DateField.NOTSET', 'not set') . ')</i>';
@@ -51,12 +51,12 @@ class DateField_Disabled extends DateField
         );
     }
 
-    public function Type()
+    public function Type(): string
     {
         return "date_disabled readonly " . parent::Type();
     }
 
-    public function getHTML5()
+    public function getHTML5(): bool
     {
         // Always disable HTML5 feature when using the readonly field.
         return false;

--- a/src/Forms/DatetimeField.php
+++ b/src/Forms/DatetimeField.php
@@ -90,7 +90,7 @@ class DatetimeField extends TextField
      */
     protected $timezone = null;
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = parent::getAttributes();
 
@@ -109,7 +109,7 @@ class DatetimeField extends TextField
     /**
      * @inheritDoc
      */
-    public function getSchemaDataDefaults()
+    public function getSchemaDataDefaults(): array
     {
         $defaults = parent::getSchemaDataDefaults();
         return array_merge($defaults, [
@@ -125,7 +125,7 @@ class DatetimeField extends TextField
     /**
      * @inheritDoc
      */
-    public function Type()
+    public function Type(): string
     {
         return 'text datetime';
     }
@@ -133,7 +133,7 @@ class DatetimeField extends TextField
     /**
      * @return bool
      */
-    public function getHTML5()
+    public function getHTML5(): bool
     {
         return $this->html5;
     }
@@ -142,7 +142,7 @@ class DatetimeField extends TextField
      * @param $bool
      * @return $this
      */
-    public function setHTML5($bool)
+    public function setHTML5(bool $bool): SilverStripe\Forms\DatetimeField
     {
         $this->html5 = $bool;
         return $this;
@@ -156,7 +156,7 @@ class DatetimeField extends TextField
      * @param mixed $data
      * @return $this
      */
-    public function setSubmittedValue($value, $data = null)
+    public function setSubmittedValue(string|bool $value, array|SilverStripe\View\ArrayData $data = null): SilverStripe\Forms\DatetimeField
     {
         // Save raw value for later validation
         $this->rawValue = $value;
@@ -182,7 +182,7 @@ class DatetimeField extends TextField
      * @param string $datetime
      * @return string The formatted date, or null if not a valid date
      */
-    public function frontendToInternal($datetime)
+    public function frontendToInternal(string|bool $datetime): string|null
     {
         if (!$datetime) {
             return null;
@@ -212,7 +212,7 @@ class DatetimeField extends TextField
      * @throws \LogicException
      * @return IntlDateFormatter
      */
-    protected function getFrontendFormatter()
+    protected function getFrontendFormatter(): IntlDateFormatter
     {
         if ($this->getHTML5() && $this->datetimeFormat && $this->datetimeFormat !== DBDatetime::ISO_DATETIME_NORMALISED) {
             throw new \LogicException(
@@ -261,7 +261,7 @@ class DatetimeField extends TextField
      *
      * @see https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table
      */
-    public function getDatetimeFormat()
+    public function getDatetimeFormat(): string
     {
         if ($this->datetimeFormat) {
             return $this->datetimeFormat;
@@ -279,7 +279,7 @@ class DatetimeField extends TextField
      * @param string $format
      * @return $this
      */
-    public function setDatetimeFormat($format)
+    public function setDatetimeFormat(string $format): SilverStripe\Forms\DatetimeField
     {
         $this->datetimeFormat = $format;
         return $this;
@@ -291,7 +291,7 @@ class DatetimeField extends TextField
      * @param string $timezone Optional timezone identifier (defaults to server timezone)
      * @return IntlDateFormatter
      */
-    protected function getInternalFormatter($timezone = null)
+    protected function getInternalFormatter($timezone = null): IntlDateFormatter
     {
         if (!$timezone) {
             $timezone = date_default_timezone_get(); // Default to server timezone
@@ -322,7 +322,7 @@ class DatetimeField extends TextField
      * @param mixed $data
      * @return $this
      */
-    public function setValue($value, $data = null)
+    public function setValue(string|bool|SilverStripe\ORM\FieldType\DBDatetime $value, array|SilverStripe\Assets\File $data = null): SilverStripe\Forms\DatetimeField
     {
         // Save raw value for later validation
         $this->rawValue = $value;
@@ -365,7 +365,7 @@ class DatetimeField extends TextField
      *
      * @return string
      */
-    public function Value()
+    public function Value(): null|string
     {
         return $this->internalToFrontend($this->value);
     }
@@ -378,7 +378,7 @@ class DatetimeField extends TextField
      * @param string $datetime
      * @return string The formatted date and time, or null if not a valid date and time
      */
-    public function internalToFrontend($datetime)
+    public function internalToFrontend(string|bool $datetime): null|string
     {
         $datetime = $this->tidyInternal($datetime);
         if (!$datetime) {
@@ -401,7 +401,7 @@ class DatetimeField extends TextField
      * @param string $datetime Date in ISO 8601 or approximate form
      * @return string ISO 8601 date, or null if not valid
      */
-    public function tidyInternal($datetime)
+    public function tidyInternal(string|bool $datetime): null|string
     {
         if (!$datetime) {
             return null;
@@ -430,7 +430,7 @@ class DatetimeField extends TextField
      * @see http://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants
      * @return int
      */
-    public function getDateLength()
+    public function getDateLength(): int
     {
         if ($this->dateLength) {
             return $this->dateLength;
@@ -464,7 +464,7 @@ class DatetimeField extends TextField
      * @see http://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants
      * @return int
      */
-    public function getTimeLength()
+    public function getTimeLength(): int
     {
         if ($this->timeLength) {
             return $this->timeLength;
@@ -487,13 +487,13 @@ class DatetimeField extends TextField
         return $this;
     }
 
-    public function setDisabled($bool)
+    public function setDisabled(bool $bool): SilverStripe\Forms\DatetimeField
     {
         parent::setDisabled($bool);
         return $this;
     }
 
-    public function setReadonly($bool)
+    public function setReadonly(bool $bool): SilverStripe\Forms\DatetimeField
     {
         parent::setReadonly($bool);
         return $this;
@@ -505,7 +505,7 @@ class DatetimeField extends TextField
      * @param string $locale
      * @return $this
      */
-    public function setLocale($locale)
+    public function setLocale(string $locale): SilverStripe\Forms\DatetimeField
     {
         $this->locale = $locale;
         return $this;
@@ -516,7 +516,7 @@ class DatetimeField extends TextField
      *
      * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->locale ?: i18n::get_locale();
     }
@@ -524,7 +524,7 @@ class DatetimeField extends TextField
     /**
      * @return string Date in ISO 8601 format, in server timezone.
      */
-    public function getMinDatetime()
+    public function getMinDatetime(): null|string
     {
         return $this->minDatetime;
     }
@@ -533,7 +533,7 @@ class DatetimeField extends TextField
      * @param string $minDatetime A string in ISO 8601 format, in server timezone.
      * @return $this
      */
-    public function setMinDatetime($minDatetime)
+    public function setMinDatetime(string $minDatetime): SilverStripe\Forms\DatetimeField
     {
         $this->minDatetime = $this->tidyInternal($minDatetime);
         return $this;
@@ -542,7 +542,7 @@ class DatetimeField extends TextField
     /**
      * @return string Date in ISO 8601 format, in server timezone.
      */
-    public function getMaxDatetime()
+    public function getMaxDatetime(): null|string
     {
         return $this->maxDatetime;
     }
@@ -551,7 +551,7 @@ class DatetimeField extends TextField
      * @param string $maxDatetime A string in ISO 8601 format, in server timezone.
      * @return $this
      */
-    public function setMaxDatetime($maxDatetime)
+    public function setMaxDatetime(string $maxDatetime): SilverStripe\Forms\DatetimeField
     {
         $this->maxDatetime = $this->tidyInternal($maxDatetime);
         return $this;
@@ -561,7 +561,7 @@ class DatetimeField extends TextField
      * @param Validator $validator
      * @return bool
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Forms\RequiredFields $validator): bool
     {
         // Don't validate empty fields
         if (empty($this->rawValue)) {
@@ -634,7 +634,7 @@ class DatetimeField extends TextField
         return true;
     }
 
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\DatetimeField
     {
         $field = clone $this;
         $field->setReadonly(true);
@@ -644,7 +644,7 @@ class DatetimeField extends TextField
     /**
      * @return string
      */
-    public function getTimezone()
+    public function getTimezone(): null|string
     {
         return $this->timezone;
     }
@@ -653,7 +653,7 @@ class DatetimeField extends TextField
      * @param string $timezone
      * @return $this
      */
-    public function setTimezone($timezone)
+    public function setTimezone(string $timezone): SilverStripe\Forms\DatetimeField
     {
         if ($this->value && $timezone !== $this->timezone) {
             throw new \BadMethodCallException("Can't change timezone after setting a value");

--- a/src/Forms/DefaultFormFactory.php
+++ b/src/Forms/DefaultFormFactory.php
@@ -22,7 +22,7 @@ class DefaultFormFactory implements FormFactory
 {
     use Extensible;
 
-    public function __construct()
+    public function __construct(): void
     {
     }
 
@@ -33,7 +33,7 @@ class DefaultFormFactory implements FormFactory
      * @return Form
      * @throws InvalidArgumentException When required context is missing
      */
-    public function getForm(RequestHandler $controller = null, $name = FormFactory::DEFAULT_NAME, $context = [])
+    public function getForm(RequestHandler $controller = null, $name = FormFactory::DEFAULT_NAME, array $context = []): SilverStripe\Forms\Form
     {
         // Validate context
         foreach ($this->getRequiredContext() as $required) {
@@ -64,7 +64,7 @@ class DefaultFormFactory implements FormFactory
      * @param array $context
      * @return FieldList
      */
-    protected function getFormFields(RequestHandler $controller = null, $name, $context = [])
+    protected function getFormFields(RequestHandler $controller = null, string $name, array $context = []): SilverStripe\Forms\FieldList
     {
         // Fall back to standard "getCMSFields" which itself uses the FormScaffolder as a fallback
         // @todo Deprecate or formalise support for getCMSFields()
@@ -81,7 +81,7 @@ class DefaultFormFactory implements FormFactory
      * @param array $context
      * @return FieldList
      */
-    protected function getFormActions(RequestHandler $controller = null, $name, $context = [])
+    protected function getFormActions(RequestHandler $controller = null, string $name, array $context = []): SilverStripe\Forms\FieldList
     {
         // @todo Deprecate or formalise support for getCMSActions()
         $actions = $context['Record']->getCMSActions();
@@ -95,7 +95,7 @@ class DefaultFormFactory implements FormFactory
      * @param array $context
      * @return null|Validator
      */
-    protected function getFormValidator(RequestHandler $controller = null, $name, $context = [])
+    protected function getFormValidator(RequestHandler $controller = null, string $name, array $context = []): SilverStripe\Forms\CompositeValidator
     {
         if (!$context['Record'] instanceof DataObject) {
             return null;
@@ -119,7 +119,7 @@ class DefaultFormFactory implements FormFactory
      *
      * @return mixed
      */
-    public function getRequiredContext()
+    public function getRequiredContext(): array
     {
         return ['Record'];
     }

--- a/src/Forms/DisabledTransformation.php
+++ b/src/Forms/DisabledTransformation.php
@@ -7,7 +7,7 @@ namespace SilverStripe\Forms;
  */
 class DisabledTransformation extends FormTransformation
 {
-    public function transform(FormField $field)
+    public function transform(FormField $field): SilverStripe\Forms\TextField
     {
         return $field->performDisabledTransformation();
     }

--- a/src/Forms/DropdownField.php
+++ b/src/Forms/DropdownField.php
@@ -94,7 +94,7 @@ class DropdownField extends SingleSelectField
      * @param string $title Title of the option
      * @return ArrayData Field option
      */
-    protected function getFieldOption($value, $title)
+    protected function getFieldOption(int|string $value, string $title): SilverStripe\View\ArrayData
     {
         // Check selection
         $selected = $this->isSelectedValue($value, $this->Value());
@@ -119,7 +119,7 @@ class DropdownField extends SingleSelectField
      *
      * @return bool
      */
-    public function getHasEmptyDefault()
+    public function getHasEmptyDefault(): bool
     {
         return parent::getHasEmptyDefault() || $this->Required();
     }
@@ -128,7 +128,7 @@ class DropdownField extends SingleSelectField
      * @param array $properties
      * @return string
      */
-    public function Field($properties = [])
+    public function Field($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $options = [];
 

--- a/src/Forms/EmailField.php
+++ b/src/Forms/EmailField.php
@@ -12,7 +12,7 @@ class EmailField extends TextField
     /**
      * {@inheritdoc}
      */
-    public function Type()
+    public function Type(): string
     {
         return 'email text';
     }
@@ -27,7 +27,7 @@ class EmailField extends TextField
      *
      * @return string
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Forms\RequiredFields $validator): bool
     {
         $this->value = trim($this->value ?? '');
 

--- a/src/Forms/FieldGroup.php
+++ b/src/Forms/FieldGroup.php
@@ -73,7 +73,7 @@ class FieldGroup extends CompositeField
      * @param mixed $titleOrField Either the field title, list of fields, or first field
      * @param mixed ...$otherFields Subsequent fields or field list (if passing in title to $titleOrField)
      */
-    public function __construct($titleOrField = null, $otherFields = null)
+    public function __construct(string|array|SilverStripe\Forms\CompositeField $titleOrField = null, array|SilverStripe\Forms\GridField\GridField_FormAction $otherFields = null): void
     {
         $title = null;
         if (is_array($titleOrField) || $titleOrField instanceof FieldList) {
@@ -110,7 +110,7 @@ class FieldGroup extends CompositeField
      * TODO this is temporary, and should be removed when FormTemplateHelper is updated to handle ID
      *  for CompositeFields with no name
      */
-    public function getName()
+    public function getName(): string
     {
         if ($this->name) {
             return $this->name;
@@ -142,7 +142,7 @@ class FieldGroup extends CompositeField
     /**
      * @return string
      */
-    public function getZebra()
+    public function getZebra(): null
     {
         return $this->zebra;
     }
@@ -150,7 +150,7 @@ class FieldGroup extends CompositeField
     /**
      * @return string
      */
-    public function getMessage()
+    public function getMessage(): null|string
     {
         $dataFields = [];
         $this->collateDataFields($dataFields);
@@ -174,7 +174,7 @@ class FieldGroup extends CompositeField
     /**
      * @return string
      */
-    public function getMessageType()
+    public function getMessageType(): string
     {
         $dataFields = [];
         $this->collateDataFields($dataFields);
@@ -190,7 +190,7 @@ class FieldGroup extends CompositeField
         return null;
     }
 
-    public function getMessageCast()
+    public function getMessageCast(): string
     {
         return ValidationResult::CAST_HTML;
     }

--- a/src/Forms/FieldList.php
+++ b/src/Forms/FieldList.php
@@ -35,7 +35,7 @@ class FieldList extends ArrayList
      */
     protected $containerField;
 
-    public function __construct($items = [])
+    public function __construct(array|SilverStripe\Forms\TextField $items = []): void
     {
         if (!is_array($items) || func_num_args() > 1) {
             $items = func_get_args();
@@ -50,7 +50,7 @@ class FieldList extends ArrayList
         }
     }
 
-    public function __clone()
+    public function __clone(): void
     {
         // Clone all fields in this list
         foreach ($this->items as $key => $field) {
@@ -63,7 +63,7 @@ class FieldList extends ArrayList
      *
      * @param callable $callback
      */
-    public function recursiveWalk(callable $callback)
+    public function recursiveWalk(callable $callback): void
     {
         $stack = $this->toArray();
         while (!empty($stack)) {
@@ -81,7 +81,7 @@ class FieldList extends ArrayList
      *
      * @return static
      */
-    public function flattenFields()
+    public function flattenFields(): SilverStripe\Forms\FieldList
     {
         $fields = [];
         $this->recursiveWalk(function (FormField $field) use (&$fields) {
@@ -96,7 +96,7 @@ class FieldList extends ArrayList
      *
      * @return FormField[]
      */
-    public function dataFields()
+    public function dataFields(): array
     {
         if (empty($this->sequentialSet)) {
             $fields = [];
@@ -118,7 +118,7 @@ class FieldList extends ArrayList
     /**
      * @return FormField[]
      */
-    public function saveableFields()
+    public function saveableFields(): array
     {
         if (empty($this->sequentialSaveableSet)) {
             $fields = [];
@@ -142,7 +142,7 @@ class FieldList extends ArrayList
      *
      * @return array
      */
-    public function dataFieldNames()
+    public function dataFieldNames(): array
     {
         return array_keys($this->dataFields() ?? []);
     }
@@ -173,7 +173,7 @@ class FieldList extends ArrayList
         ));
     }
 
-    protected function flushFieldsCache()
+    protected function flushFieldsCache(): void
     {
         $this->sequentialSet = null;
         $this->sequentialSaveableSet = null;
@@ -230,7 +230,7 @@ class FieldList extends ArrayList
      *
      * @return $this
      */
-    public function addFieldToTab($tabName, $field, $insertBefore = null)
+    public function addFieldToTab(string $tabName, SilverStripe\Forms\NumericField $field, string $insertBefore = null): SilverStripe\Forms\FieldList
     {
         // This is a cache that must be flushed
         $this->flushFieldsCache();
@@ -259,7 +259,7 @@ class FieldList extends ArrayList
      *
      * @return $this
      */
-    public function addFieldsToTab($tabName, $fields, $insertBefore = null)
+    public function addFieldsToTab(string $tabName, array|SilverStripe\Forms\CompositeField $fields, string $insertBefore = null): SilverStripe\Forms\FieldList
     {
         $this->flushFieldsCache();
 
@@ -290,7 +290,7 @@ class FieldList extends ArrayList
      *
      * @return $this
      */
-    public function removeFieldFromTab($tabName, $fieldName)
+    public function removeFieldFromTab(string $tabName, string $fieldName): SilverStripe\Forms\FieldList
     {
         $this->flushFieldsCache();
 
@@ -311,7 +311,7 @@ class FieldList extends ArrayList
      *
      * @return $this
      */
-    public function removeFieldsFromTab($tabName, $fields)
+    public function removeFieldsFromTab(string $tabName, array $fields): SilverStripe\Forms\FieldList
     {
         $this->flushFieldsCache();
 
@@ -337,7 +337,7 @@ class FieldList extends ArrayList
      *
      * @return $this
      */
-    public function removeByName($fieldName, $dataFieldOnly = false)
+    public function removeByName(string|array $fieldName, bool $dataFieldOnly = false): SilverStripe\Forms\FieldList
     {
         if (!$fieldName) {
             user_error('FieldList::removeByName() was called with a blank field name.', E_USER_WARNING);
@@ -379,7 +379,7 @@ class FieldList extends ArrayList
      * @return bool TRUE field was successfully replaced
      *                   FALSE field wasn't found, nothing changed
      */
-    public function replaceField($fieldName, $newField, $dataFieldOnly = true)
+    public function replaceField(string $fieldName, DNADesign\Elemental\Forms\TextCheckboxGroupField $newField, bool $dataFieldOnly = true): bool
     {
         $this->flushFieldsCache();
         foreach ($this as $i => $field) {
@@ -402,7 +402,7 @@ class FieldList extends ArrayList
      * @param string $newFieldTitle New title of field
      * @return bool
      */
-    public function renameField($fieldName, $newFieldTitle)
+    public function renameField(string $fieldName, string $newFieldTitle): bool
     {
         $field = $this->dataFieldByName($fieldName);
         if (!$field) {
@@ -417,7 +417,7 @@ class FieldList extends ArrayList
     /**
      * @return bool
      */
-    public function hasTabSet()
+    public function hasTabSet(): bool
     {
         foreach ($this->items as $i => $field) {
             if (is_object($field) && $field instanceof TabSet) {
@@ -434,7 +434,7 @@ class FieldList extends ArrayList
      * @param string $tabName The tab to return, in the form "Tab.Subtab.Subsubtab".
      * @return Tab|null The found or null
      */
-    public function findTab($tabName)
+    public function findTab(string $tabName): null|SilverStripe\Forms\TabSet
     {
         $parts = explode('.', $tabName ?? '');
         $last_idx = count($parts ?? []) - 1;
@@ -463,7 +463,7 @@ class FieldList extends ArrayList
      *   The title is only changed if the tab doesn't exist already.
      * @return Tab The found or newly created Tab instance
      */
-    public function findOrMakeTab($tabName, $title = null)
+    public function findOrMakeTab(string $tabName, string $title = null): SilverStripe\Forms\Tab
     {
         $parts = explode('.', $tabName ?? '');
         $last_idx = count($parts ?? []) - 1;
@@ -509,7 +509,7 @@ class FieldList extends ArrayList
      * @param string $name
      * @return FormField|null
      */
-    public function fieldByName($name)
+    public function fieldByName(string $name): null|SilverStripe\Forms\HiddenField
     {
         $fullName = $name;
         if (strpos($name ?? '', '.') !== false) {
@@ -548,7 +548,7 @@ class FieldList extends ArrayList
      * @param string $name The name of the field to return
      * @return FormField|null
      */
-    public function dataFieldByName($name)
+    public function dataFieldByName(string $name): null|SilverStripe\Forms\EmailField
     {
         if ($dataFields = $this->dataFields()) {
             foreach ($dataFields as $child) {
@@ -569,7 +569,7 @@ class FieldList extends ArrayList
      * @param bool $appendIfMissing Append to the end of the list if $name isn't found
      * @return FormField|false Field if it was successfully inserted, false if not inserted
      */
-    public function insertBefore($name, $item, $appendIfMissing = true)
+    public function insertBefore(string|SilverStripe\Forms\DropdownField $name, string|SilverStripe\Forms\DropdownField $item, bool $appendIfMissing = true): bool|SilverStripe\Forms\DropdownField
     {
         // Backwards compatibility for order of arguments
         if ($name instanceof FormField) {
@@ -611,7 +611,7 @@ class FieldList extends ArrayList
      * @param bool $appendIfMissing Append to the end of the list if $name isn't found
      * @return FormField|false Field if it was successfully inserted, false if not inserted
      */
-    public function insertAfter($name, $item, $appendIfMissing = true)
+    public function insertAfter(string|SilverStripe\Forms\Tab $name, string|SilverStripe\AssetAdmin\Forms\UploadField $item, bool $appendIfMissing = true): bool|SilverStripe\AssetAdmin\Forms\UploadField
     {
         // Backwards compatibility for order of arguments
         if ($name instanceof FormField) {
@@ -649,7 +649,7 @@ class FieldList extends ArrayList
      *
      * @param FormField $item The FormField to add
      */
-    public function push($item)
+    public function push(SilverStripe\Forms\HiddenField $item): null
     {
         $this->onBeforeInsert($item);
         $item->setContainerFieldList($this);
@@ -662,7 +662,7 @@ class FieldList extends ArrayList
      *
      * @param FormField $item The FormField to add
      */
-    public function unshift($item)
+    public function unshift(SilverStripe\Forms\PasswordField $item): null
     {
         $this->onBeforeInsert($item);
         $item->setContainerFieldList($this);
@@ -675,7 +675,7 @@ class FieldList extends ArrayList
      *
      * @param FormField $item
      */
-    protected function onBeforeInsert($item)
+    protected function onBeforeInsert(SilverStripe\Forms\HiddenField $item): void
     {
         $this->flushFieldsCache();
 
@@ -691,7 +691,7 @@ class FieldList extends ArrayList
      * @param Form $form The form to set this FieldList to
      * @return $this
      */
-    public function setForm($form)
+    public function setForm(SilverStripe\CMS\Search\SearchForm $form): SilverStripe\Forms\FieldList
     {
         foreach ($this as $field) {
             $field->setForm($form);
@@ -724,7 +724,7 @@ class FieldList extends ArrayList
      *
      * @return FieldList
      */
-    public function HiddenFields()
+    public function HiddenFields(): SilverStripe\Forms\FieldList
     {
         $hiddenFields = new FieldList();
         $dataFields = $this->dataFields();
@@ -744,7 +744,7 @@ class FieldList extends ArrayList
      * Return all fields except for the hidden fields.
      * Useful when making your own simplified form layouts.
      */
-    public function VisibleFields()
+    public function VisibleFields(): SilverStripe\Forms\FieldList
     {
         $visibleFields = new FieldList();
 
@@ -764,7 +764,7 @@ class FieldList extends ArrayList
      * @param FormTransformation $trans
      * @return FieldList
      */
-    public function transform($trans)
+    public function transform(SilverStripe\Forms\ReadonlyTransformation $trans): SilverStripe\Forms\FieldList
     {
         $this->flushFieldsCache();
         $newFields = new FieldList();
@@ -779,7 +779,7 @@ class FieldList extends ArrayList
      *
      * @return FieldList|FormField
      */
-    public function rootFieldList()
+    public function rootFieldList(): SilverStripe\Forms\FieldList
     {
         if ($this->containerField) {
             return $this->containerField->rootFieldList();
@@ -791,7 +791,7 @@ class FieldList extends ArrayList
     /**
      * @return CompositeField|null
      */
-    public function getContainerField()
+    public function getContainerField(): null|SilverStripe\Forms\Tab
     {
         return $this->containerField;
     }
@@ -800,7 +800,7 @@ class FieldList extends ArrayList
      * @param CompositeField|null $field
      * @return $this
      */
-    public function setContainerField($field)
+    public function setContainerField(SilverStripe\Forms\CompositeField $field): SilverStripe\Forms\FieldList
     {
         $this->containerField = $field;
         return $this;
@@ -811,7 +811,7 @@ class FieldList extends ArrayList
      *
      * @return FieldList
      */
-    public function makeReadonly()
+    public function makeReadonly(): SilverStripe\Forms\FieldList
     {
         return $this->transform(new ReadonlyTransformation());
     }
@@ -821,7 +821,7 @@ class FieldList extends ArrayList
      *
      * @param string|array|FormField $field
      */
-    public function makeFieldReadonly($field)
+    public function makeFieldReadonly(string|SilverStripe\Forms\OptionsetField $field): void
     {
         if (!is_array($field)) {
             $field = [$field];
@@ -847,7 +847,7 @@ class FieldList extends ArrayList
      *
      * @param array $fieldNames Field names can be given as an array, or just as a list of arguments.
      */
-    public function changeFieldOrder($fieldNames)
+    public function changeFieldOrder(array|string $fieldNames): void
     {
         // Field names can be given as an array, or just as a list of arguments.
         if (!is_array($fieldNames)) {
@@ -888,7 +888,7 @@ class FieldList extends ArrayList
      * @return int Position in children collection (first position starts with 0).
      * Returns FALSE if the field can't be found.
      */
-    public function fieldPosition($field)
+    public function fieldPosition(string $field): int
     {
         if ($field instanceof FormField) {
             $field = $field->getName();
@@ -908,7 +908,7 @@ class FieldList extends ArrayList
     /**
      * Default template rendering of a FieldList will concatenate all FieldHolder values.
      */
-    public function forTemplate()
+    public function forTemplate(): string
     {
         $output = "";
         foreach ($this as $field) {

--- a/src/Forms/FileField.php
+++ b/src/Forms/FileField.php
@@ -67,7 +67,7 @@ class FileField extends FormField implements FileHandleField
      * @param string $title The field label.
      * @param int $value The value of the field.
      */
-    public function __construct($name, $title = null, $value = null)
+    public function __construct(string $name, bool|string $title = null, $value = null): void
     {
         $this->constructUploadReceiver();
         parent::__construct($name, $title, $value);
@@ -77,7 +77,7 @@ class FileField extends FormField implements FileHandleField
      * @param array $properties
      * @return string
      */
-    public function Field($properties = [])
+    public function Field($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $properties = array_merge($properties, [
             'MaxFileSize' => $this->getValidator()->getAllowedMaxFileSize()
@@ -86,7 +86,7 @@ class FileField extends FormField implements FileHandleField
         return parent::Field($properties);
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = parent::getAttributes();
 
@@ -103,7 +103,7 @@ class FileField extends FormField implements FileHandleField
      *
      * @return array
      */
-    protected function getAcceptFileTypes()
+    protected function getAcceptFileTypes(): array
     {
         $extensions = $this->getValidator()->getAllowedExtensions();
         if (!$extensions) {
@@ -170,12 +170,12 @@ class FileField extends FormField implements FileHandleField
         }
     }
 
-    public function Value()
+    public function Value(): null
     {
         return isset($_FILES[$this->getName()]) ? $_FILES[$this->getName()] : null;
     }
 
-    public function validate($validator)
+    public function validate(SilverStripe\Forms\RequiredFields $validator): bool
     {
         // FileField with the name multi_file_syntax[] or multi_file_syntax[key] will have the brackets trimmed in
         // $_FILES super-global so it will be stored as $_FILES['mutli_file_syntax']
@@ -214,7 +214,7 @@ class FileField extends FormField implements FileHandleField
      * @param array $fileData
      * @return bool
      */
-    private function validateFileData($validator, array $fileData): bool
+    private function validateFileData(SilverStripe\Forms\RequiredFields $validator, array $fileData): bool
     {
         $valid = $this->upload->validate($fileData);
         if (!$valid) {

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -285,7 +285,7 @@ class Form extends ViewableData implements HasRequestHandler
         FieldList $fields = null,
         FieldList $actions = null,
         Validator $validator = null
-    ) {
+    ): void {
         parent::__construct();
 
         $fields = $fields ? $fields : FieldList::create();
@@ -322,7 +322,7 @@ class Form extends ViewableData implements HasRequestHandler
     /**
      * @return bool
      */
-    public function getNotifyUnsavedChanges()
+    public function getNotifyUnsavedChanges(): bool
     {
         return $this->notifyUnsavedChanges;
     }
@@ -330,7 +330,7 @@ class Form extends ViewableData implements HasRequestHandler
     /**
      * @param bool $flag
      */
-    public function setNotifyUnsavedChanges($flag)
+    public function setNotifyUnsavedChanges(bool $flag): void
     {
         $this->notifyUnsavedChanges = $flag;
     }
@@ -340,7 +340,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return $this
      */
-    public function restoreFormState()
+    public function restoreFormState(): SilverStripe\CMS\Search\SearchForm
     {
         // Restore messages
         $result = $this->getSessionValidationResult();
@@ -361,7 +361,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return $this
      */
-    public function clearFormState()
+    public function clearFormState(): SilverStripe\CMS\Search\SearchForm
     {
         $this
             ->getSession()
@@ -375,7 +375,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return HTTPRequest
      */
-    protected function getRequest()
+    protected function getRequest(): SilverStripe\Control\HTTPRequest
     {
         // Check if current request handler has a request object
         $controller = $this->getController();
@@ -394,7 +394,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return Session
      */
-    protected function getSession()
+    protected function getSession(): SilverStripe\Control\Session
     {
         $request = $this->getRequest();
         if ($request) {
@@ -408,7 +408,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return array
      */
-    public function getSessionData()
+    public function getSessionData(): null|array
     {
         return $this->getSession()->get("FormInfo.{$this->FormName()}.data");
     }
@@ -419,7 +419,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param array $data
      * @return $this
      */
-    public function setSessionData($data)
+    public function setSessionData(array $data): SilverStripe\Forms\Form
     {
         $this->getSession()->set("FormInfo.{$this->FormName()}.data", $data);
         return $this;
@@ -430,7 +430,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return ValidationResult The ValidationResult object stored in the session
      */
-    public function getSessionValidationResult()
+    public function getSessionValidationResult(): null|SilverStripe\ORM\ValidationResult
     {
         $resultData = $this->getSession()->get("FormInfo.{$this->FormName()}.result");
         if (isset($resultData)) {
@@ -445,7 +445,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param bool $combineWithExisting If true, then this will be added to the existing result.
      * @return $this
      */
-    public function setSessionValidationResult(ValidationResult $result, $combineWithExisting = false)
+    public function setSessionValidationResult(ValidationResult $result, $combineWithExisting = false): SilverStripe\Forms\Form
     {
         // Combine with existing result
         if ($combineWithExisting) {
@@ -470,7 +470,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return $this
      */
-    public function clearMessage()
+    public function clearMessage(): SilverStripe\CMS\Search\SearchForm
     {
         $this->setMessage(null);
         $this->clearFormState();
@@ -484,7 +484,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param ValidationResult $result
      * @return $this
      */
-    public function loadMessagesFrom($result)
+    public function loadMessagesFrom(SilverStripe\ORM\ValidationResult $result): SilverStripe\Security\MemberAuthenticator\MemberLoginForm
     {
         // Set message on either a field or the parent form
         foreach ($result->getMessages() as $message) {
@@ -523,7 +523,7 @@ class Form extends ViewableData implements HasRequestHandler
         return $this;
     }
 
-    public function castingHelper($field)
+    public function castingHelper(string $field): string
     {
         // Override casting for field message
         if (strcasecmp($field ?? '', 'Message') === 0 && ($helper = $this->getMessageCastingHelper())) {
@@ -536,7 +536,7 @@ class Form extends ViewableData implements HasRequestHandler
      * set up the default classes for the form. This is done on construct so that the default classes can be removed
      * after instantiation
      */
-    protected function setupDefaultClasses()
+    protected function setupDefaultClasses(): void
     {
         $defaultClasses = self::config()->get('default_classes');
         if ($defaultClasses) {
@@ -549,7 +549,7 @@ class Form extends ViewableData implements HasRequestHandler
     /**
      * @return callable
      */
-    public function getValidationResponseCallback()
+    public function getValidationResponseCallback(): callable|null
     {
         return $this->validationResponseCallback;
     }
@@ -564,7 +564,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param $callback
      * @return self
      */
-    public function setValidationResponseCallback($callback)
+    public function setValidationResponseCallback(callable $callback): SilverStripe\Forms\Form
     {
         $this->validationResponseCallback = $callback;
 
@@ -576,7 +576,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return $this
      */
-    public function makeReadonly()
+    public function makeReadonly(): SilverStripe\Forms\Form
     {
         $this->transform(new ReadonlyTransformation());
         return $this;
@@ -590,7 +590,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param bool $bool Redirect to form on error?
      * @return $this
      */
-    public function setRedirectToFormOnValidationError($bool)
+    public function setRedirectToFormOnValidationError(bool $bool): SilverStripe\Comments\Forms\CommentForm
     {
         $this->redirectToFormOnValidationError = $bool;
         return $this;
@@ -602,7 +602,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return bool
      */
-    public function getRedirectToFormOnValidationError()
+    public function getRedirectToFormOnValidationError(): bool
     {
         return $this->redirectToFormOnValidationError;
     }
@@ -610,7 +610,7 @@ class Form extends ViewableData implements HasRequestHandler
     /**
      * @param FormTransformation $trans
      */
-    public function transform(FormTransformation $trans)
+    public function transform(FormTransformation $trans): void
     {
         $newFields = new FieldList();
         foreach ($this->fields as $field) {
@@ -635,7 +635,7 @@ class Form extends ViewableData implements HasRequestHandler
      * Get the {@link Validator} attached to this form.
      * @return Validator
      */
-    public function getValidator()
+    public function getValidator(): null|SilverStripe\Forms\RequiredFields
     {
         return $this->validator;
     }
@@ -645,7 +645,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param Validator $validator
      * @return $this
      */
-    public function setValidator(Validator $validator)
+    public function setValidator(Validator $validator): SilverStripe\Security\MemberAuthenticator\MemberLoginForm
     {
         if ($validator) {
             $this->validator = $validator;
@@ -657,7 +657,7 @@ class Form extends ViewableData implements HasRequestHandler
     /**
      * Remove the {@link Validator} from this from.
      */
-    public function unsetValidator()
+    public function unsetValidator(): SilverStripe\Forms\Form
     {
         $this->validator = null;
         return $this;
@@ -669,7 +669,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param array $actions
      * @return $this
      */
-    public function setValidationExemptActions($actions)
+    public function setValidationExemptActions(array $actions): SilverStripe\Forms\Form
     {
         $this->validationExemptActions = $actions;
         return $this;
@@ -680,7 +680,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return array
      */
-    public function getValidationExemptActions()
+    public function getValidationExemptActions(): array
     {
         return $this->validationExemptActions;
     }
@@ -691,7 +691,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param FormAction $action
      * @return bool
      */
-    public function actionIsValidationExempt($action)
+    public function actionIsValidationExempt(SilverStripe\Forms\FormAction $action): bool
     {
         // Non-actions don't bypass validation
         if (!$action) {
@@ -711,7 +711,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return FieldList
      */
-    public function getExtraFields()
+    public function getExtraFields(): SilverStripe\Forms\FieldList
     {
         $extraFields = new FieldList();
 
@@ -739,7 +739,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return FieldList The form fields
      */
-    public function Fields()
+    public function Fields(): null|SilverStripe\Forms\FieldList
     {
         foreach ($this->getExtraFields() as $field) {
             if (!$this->fields->fieldByName($field->getName())) {
@@ -777,7 +777,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param FieldList $fields
      * @return $this
      */
-    public function setFields($fields)
+    public function setFields(SilverStripe\Forms\FieldList $fields): SilverStripe\Forms\Form
     {
         $fields->setForm($this);
         $this->fields = $fields;
@@ -790,7 +790,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return FieldList The action list
      */
-    public function Actions()
+    public function Actions(): SilverStripe\Forms\FieldList
     {
         return $this->actions;
     }
@@ -801,7 +801,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param FieldList $actions
      * @return $this
      */
-    public function setActions($actions)
+    public function setActions(SilverStripe\Forms\FieldList $actions): SilverStripe\UserForms\Form\UserForm
     {
         $actions->setForm($this);
         $this->actions = $actions;
@@ -839,7 +839,7 @@ class Form extends ViewableData implements HasRequestHandler
         return $attrs;
     }
 
-    public function FormAttributes()
+    public function FormAttributes(): string
     {
         return $this->getAttributesHTML();
     }
@@ -861,7 +861,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return FormTemplateHelper
      */
-    public function getTemplateHelper()
+    public function getTemplateHelper(): SilverStripe\Forms\FormTemplateHelper
     {
         if ($this->templateHelper) {
             if (is_string($this->templateHelper)) {
@@ -907,7 +907,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param string|array $template The name of the template (without the .ss extension) or array form
      * @return $this
      */
-    public function setTemplate($template)
+    public function setTemplate(string|array $template): SilverStripe\CMS\Search\SearchForm
     {
         $this->template = $template;
         return $this;
@@ -918,7 +918,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return string|array
      */
-    public function getTemplate()
+    public function getTemplate(): string|null|array
     {
         return $this->template;
     }
@@ -930,7 +930,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return array
      */
-    public function getTemplates()
+    public function getTemplates(): array
     {
         $templates = SSViewer::get_templates_by_class(static::class, '', __CLASS__);
         // Prefer any custom template
@@ -947,7 +947,7 @@ class Form extends ViewableData implements HasRequestHandler
      * in which case multipart is used. You can also set the enc type using
      * {@link setEncType}.
      */
-    public function getEncType()
+    public function getEncType(): string
     {
         if ($this->encType) {
             return $this->encType;
@@ -971,7 +971,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param string $encType
      * @return $this
      */
-    public function setEncType($encType)
+    public function setEncType(string $encType): SilverStripe\Forms\Form
     {
         $this->encType = $encType;
         return $this;
@@ -989,7 +989,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return string HTTP method
      */
-    public function FormHttpMethod()
+    public function FormHttpMethod(): string
     {
         return $this->formMethod;
     }
@@ -1000,7 +1000,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return string Form HTTP method restricted to 'GET' or 'POST'
      */
-    public function FormMethod()
+    public function FormMethod(): string
     {
         if (in_array($this->formMethod, ['GET','POST'])) {
             return $this->formMethod;
@@ -1016,7 +1016,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param bool $strict If non-null, pass value to {@link setStrictFormMethodCheck()}.
      * @return $this
      */
-    public function setFormMethod($method, $strict = null)
+    public function setFormMethod(string $method, bool $strict = null): SilverStripe\CMS\Search\SearchForm
     {
         $this->formMethod = strtoupper($method ?? '');
         if ($strict !== null) {
@@ -1038,7 +1038,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param $bool boolean
      * @return $this
      */
-    public function setStrictFormMethodCheck($bool)
+    public function setStrictFormMethodCheck(bool $bool): SilverStripe\Security\MemberAuthenticator\MemberLoginForm
     {
         $this->strictFormMethodCheck = (bool)$bool;
         return $this;
@@ -1047,7 +1047,7 @@ class Form extends ViewableData implements HasRequestHandler
     /**
      * @return boolean
      */
-    public function getStrictFormMethodCheck()
+    public function getStrictFormMethodCheck(): bool
     {
         return $this->strictFormMethodCheck;
     }
@@ -1058,7 +1058,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return string
      */
-    public function FormAction()
+    public function FormAction(): string|null
     {
         if ($this->formActionPath) {
             return $this->formActionPath;
@@ -1078,7 +1078,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param string $path
      * @return $this
      */
-    public function setFormAction($path)
+    public function setFormAction(string $path): SilverStripe\CMS\Search\SearchForm
     {
         $this->formActionPath = $path;
 
@@ -1090,7 +1090,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return string
      */
-    public function FormName()
+    public function FormName(): string
     {
         return $this->getTemplateHelper()->generateFormID($this);
     }
@@ -1101,7 +1101,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param string $id
      * @return $this
      */
-    public function setHTMLID($id)
+    public function setHTMLID(string $id): SilverStripe\Forms\Form
     {
         $this->htmlID = $id;
 
@@ -1111,7 +1111,7 @@ class Form extends ViewableData implements HasRequestHandler
     /**
      * @return string
      */
-    public function getHTMLID()
+    public function getHTMLID(): null|string
     {
         return $this->htmlID;
     }
@@ -1121,7 +1121,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return RequestHandler
      */
-    public function getController()
+    public function getController(): null|SilverStripe\ErrorPage\ErrorPageController
     {
         return $this->controller;
     }
@@ -1132,7 +1132,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param RequestHandler $controller
      * @return $this
      */
-    public function setController(RequestHandler $controller = null)
+    public function setController(RequestHandler $controller = null): SilverStripe\CMS\Search\SearchForm
     {
         $this->controller = $controller;
         return $this;
@@ -1143,7 +1143,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string|null
     {
         return $this->name;
     }
@@ -1154,7 +1154,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param string $name
      * @return Form
      */
-    public function setName($name)
+    public function setName(string $name): SilverStripe\CMS\Search\SearchForm
     {
         $this->name = $name;
 
@@ -1182,7 +1182,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param string|bool $cast Cast type; One of the CAST_ constant definitions.
      * Bool values will be treated as plain text flag.
      */
-    public function sessionMessage($message, $type = ValidationResult::TYPE_ERROR, $cast = ValidationResult::CAST_TEXT)
+    public function sessionMessage(string $message, $type = ValidationResult::TYPE_ERROR, $cast = ValidationResult::CAST_TEXT): void
     {
         $this->setMessage($message, $type, $cast);
         $result = $this->getSessionValidationResult() ?: ValidationResult::create();
@@ -1198,7 +1198,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param string|bool $cast Cast type; One of the CAST_ constant definitions.
      * Bool values will be treated as plain text flag.
      */
-    public function sessionError($message, $type = ValidationResult::TYPE_ERROR, $cast = ValidationResult::CAST_TEXT)
+    public function sessionError(string $message, $type = ValidationResult::TYPE_ERROR, $cast = ValidationResult::CAST_TEXT): void
     {
         $this->setMessage($message, $type, $cast);
         $result = $this->getSessionValidationResult() ?: ValidationResult::create();
@@ -1229,7 +1229,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return DataObject
      */
-    public function getRecord()
+    public function getRecord(): null|SilverStripe\FrameworkTest\Elemental\Model\ElementalBehatTestObject
     {
         return $this->record;
     }
@@ -1240,7 +1240,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return string
      */
-    public function getLegend()
+    public function getLegend(): null
     {
         return $this->legend;
     }
@@ -1262,7 +1262,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return ValidationResult
      */
-    public function validationResult()
+    public function validationResult(): SilverStripe\ORM\ValidationResult
     {
         // Automatically pass if there is no validator, or the clicked button is exempt
         // Note: Soft support here for validation with absent request handler
@@ -1336,7 +1336,7 @@ class Form extends ViewableData implements HasRequestHandler
      * form that has some fields that save to one object, and some that save to another.
      * @return $this
      */
-    public function loadDataFrom($data, $mergeStrategy = 0, $fieldList = null)
+    public function loadDataFrom(array|DNADesign\Elemental\Models\ElementContent $data, bool|int $mergeStrategy = 0, array $fieldList = null): SilverStripe\Comments\Forms\CommentForm
     {
         if (!is_object($data) && !is_array($data)) {
             user_error("Form::loadDataFrom() not passed an array or an object", E_USER_WARNING);
@@ -1485,7 +1485,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param FieldList $fieldList An optional list of fields to process.  This can be useful when you have a
      * form that has some fields that save to one object, and some that save to another.
      */
-    public function saveInto(DataObjectInterface $dataObject, $fieldList = null)
+    public function saveInto(DataObjectInterface $dataObject, bool $fieldList = null): void
     {
         $dataFields = $this->fields->saveableFields();
         $lastField = null;
@@ -1521,7 +1521,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return array
      */
-    public function getData()
+    public function getData(): array
     {
         $dataFields = $this->fields->dataFields();
         $data = [];
@@ -1546,7 +1546,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return DBHTMLText
      */
-    public function forTemplate()
+    public function forTemplate(): SilverStripe\ORM\FieldType\DBHTMLText
     {
         if (!$this->canBeCached()) {
             HTTPCacheControlMiddleware::singleton()->disableCache();
@@ -1631,7 +1631,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return FormAction
      */
-    public function defaultAction()
+    public function defaultAction(): SilverStripe\Forms\FormAction
     {
         if ($this->hasDefaultAction && $this->actions) {
             return $this->actions->first();
@@ -1665,7 +1665,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return Form
      */
-    public function disableSecurityToken()
+    public function disableSecurityToken(): SilverStripe\CMS\Search\SearchForm
     {
         $this->securityToken = new NullSecurityToken();
 
@@ -1680,7 +1680,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return Form
      */
-    public function enableSecurityToken()
+    public function enableSecurityToken(): SilverStripe\Forms\Form
     {
         $this->securityToken = new SecurityToken();
 
@@ -1696,7 +1696,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return SecurityToken|null
      */
-    public function getSecurityToken()
+    public function getSecurityToken(): null|SilverStripe\Security\NullSecurityToken
     {
         return $this->securityToken;
     }
@@ -1706,7 +1706,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return string
      */
-    public function extraClass()
+    public function extraClass(): string
     {
         return implode(' ', array_unique($this->extraClasses ?? []));
     }
@@ -1718,7 +1718,7 @@ class Form extends ViewableData implements HasRequestHandler
      * names delimited by a single space.
      * @return boolean True if all of the classnames passed in have been added.
      */
-    public function hasExtraClass($class)
+    public function hasExtraClass(string $class): bool
     {
         //split at white space
         $classes = preg_split('/\s+/', $class ?? '');
@@ -1738,7 +1738,7 @@ class Form extends ViewableData implements HasRequestHandler
      *              names delimited by a single space.
      * @return $this
      */
-    public function addExtraClass($class)
+    public function addExtraClass(string $class): SilverStripe\Forms\Form
     {
         //split at white space
         $classes = preg_split('/\s+/', $class ?? '');
@@ -1756,7 +1756,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param string $class
      * @return $this
      */
-    public function removeExtraClass($class)
+    public function removeExtraClass(string $class): SilverStripe\Forms\Form
     {
         //split at white space
         $classes = preg_split('/\s+/', $class ?? '');
@@ -1797,7 +1797,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return FormRequestHandler
      */
-    public function getRequestHandler()
+    public function getRequestHandler(): SilverStripe\Forms\FormRequestHandler
     {
         if (!$this->requestHandler) {
             $this->requestHandler = $this->buildRequestHandler();
@@ -1811,7 +1811,7 @@ class Form extends ViewableData implements HasRequestHandler
      * @param FormRequestHandler $handler
      * @return $this
      */
-    public function setRequestHandler(FormRequestHandler $handler)
+    public function setRequestHandler(FormRequestHandler $handler): SilverStripe\Forms\Form
     {
         $this->requestHandler = $handler;
         return $this;
@@ -1822,7 +1822,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return FormRequestHandler
      */
-    protected function buildRequestHandler()
+    protected function buildRequestHandler(): SilverStripe\Forms\FormRequestHandler
     {
         return FormRequestHandler::create($this);
     }
@@ -1832,7 +1832,7 @@ class Form extends ViewableData implements HasRequestHandler
      *
      * @return bool
      */
-    protected function canBeCached()
+    protected function canBeCached(): bool
     {
         if ($this->getSecurityToken()->isEnabled()) {
             return false;

--- a/src/Forms/FormAction.php
+++ b/src/Forms/FormAction.php
@@ -77,7 +77,7 @@ class FormAction extends FormField
      * @param string $title The label on the button. This should be plain text, not escaped as HTML.
      * @param Form $form The parent form, auto-set when the field is placed inside a form
      */
-    public function __construct($action, $title = "", $form = null)
+    public function __construct(string $action, string|bool $title = "", $form = null): void
     {
         $this->action = "action_$action";
         $this->setForm($form);
@@ -88,7 +88,7 @@ class FormAction extends FormField
     /**
      * Add extra options to data
      */
-    public function getSchemaDataDefaults()
+    public function getSchemaDataDefaults(): array
     {
         $defaults = parent::getSchemaDataDefaults();
         $defaults['attributes']['type'] = $this->getUseButtonTag() ? 'button' : 'submit';
@@ -101,7 +101,7 @@ class FormAction extends FormField
      *
      * @return string
      */
-    public function getIcon()
+    public function getIcon(): string|null
     {
         return $this->icon;
     }
@@ -112,7 +112,7 @@ class FormAction extends FormField
      * @param string $icon Icon identifier (not path)
      * @return $this
      */
-    public function setIcon($icon)
+    public function setIcon(string $icon): SilverStripe\Forms\FormAction
     {
         $this->icon = $icon;
         return $this;
@@ -123,7 +123,7 @@ class FormAction extends FormField
      *
      * @return string
      */
-    public function actionName()
+    public function actionName(): string
     {
         return substr($this->name ?? '', 7);
     }
@@ -145,7 +145,7 @@ class FormAction extends FormField
      * @param array $properties
      * @return DBHTMLText
      */
-    public function Field($properties = [])
+    public function Field(array $properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $properties = array_merge(
             $properties,
@@ -163,17 +163,17 @@ class FormAction extends FormField
      * @param array $properties
      * @return DBHTMLText
      */
-    public function FieldHolder($properties = [])
+    public function FieldHolder($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         return $this->Field($properties);
     }
 
-    public function Type()
+    public function Type(): string
     {
         return 'action';
     }
 
-    public function getInputType()
+    public function getInputType(): string
     {
         if (isset($this->attributes['type'])) {
             return $this->attributes['type'];
@@ -182,7 +182,7 @@ class FormAction extends FormField
         }
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = array_merge(
             parent::getAttributes(),
@@ -217,7 +217,7 @@ class FormAction extends FormField
      *
      * @return string
      */
-    public function getButtonContent()
+    public function getButtonContent(): null
     {
         return $this->buttonContent;
     }
@@ -228,7 +228,7 @@ class FormAction extends FormField
      * @param boolean $bool
      * @return $this
      */
-    public function setUseButtonTag($bool)
+    public function setUseButtonTag(bool $bool): SilverStripe\Forms\FormAction
     {
         $this->useButtonTag = $bool;
         return $this;
@@ -239,7 +239,7 @@ class FormAction extends FormField
      *
      * @return boolean
      */
-    public function getUseButtonTag()
+    public function getUseButtonTag(): bool
     {
         return $this->useButtonTag;
     }
@@ -250,7 +250,7 @@ class FormAction extends FormField
      * @param bool $exempt
      * @return $this
      */
-    public function setValidationExempt($exempt = true)
+    public function setValidationExempt(bool $exempt = true): SilverStripe\Forms\FormAction
     {
         $this->validationExempt = $exempt;
         return $this;
@@ -261,7 +261,7 @@ class FormAction extends FormField
      *
      * @return bool
      */
-    public function getValidationExempt()
+    public function getValidationExempt(): bool
     {
         return $this->validationExempt;
     }
@@ -270,7 +270,7 @@ class FormAction extends FormField
      * Does not transform to readonly by purpose.
      * Globally disabled buttons would break the CMS.
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\FormAction
     {
         $clone = clone $this;
         $clone->setReadonly(true);

--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -299,7 +299,7 @@ class FormField extends RequestHandler
      *
      * @return string
      */
-    public static function name_to_label($fieldName)
+    public static function name_to_label(string $fieldName): string
     {
         // Handle dot delimiters
         if (strpos($fieldName ?? '', '.') !== false) {
@@ -331,7 +331,7 @@ class FormField extends RequestHandler
      * @param null|string|\SilverStripe\View\ViewableData $title The human-readable field label.
      * @param mixed $value The value of the field.
      */
-    public function __construct($name, $title = null, $value = null)
+    public function __construct(string $name, bool|string|int|SilverStripe\ORM\FieldType\DBHTMLText $title = null, string|bool|int|array|SilverStripe\Forms\GridField\GridState_Data $value = null): void
     {
         $this->setName($name);
 
@@ -354,7 +354,7 @@ class FormField extends RequestHandler
      * Set up the default classes for the form. This is done on construct so that the default classes can be removed
      * after instantiation
      */
-    protected function setupDefaultClasses()
+    protected function setupDefaultClasses(): void
     {
         $defaultClasses = $this->config()->get('default_classes');
         if ($defaultClasses) {
@@ -371,7 +371,7 @@ class FormField extends RequestHandler
      * @return string
      * @throws LogicException If no form is set yet
      */
-    public function Link($action = null)
+    public function Link(string $action = null): string
     {
         if (!$this->form) {
             throw new LogicException(
@@ -392,7 +392,7 @@ class FormField extends RequestHandler
      *
      * @return string
      */
-    public function ID()
+    public function ID(): string
     {
         return $this->getTemplateHelper()->generateFieldID($this);
     }
@@ -402,7 +402,7 @@ class FormField extends RequestHandler
      *
      * @return string
      */
-    public function HolderID()
+    public function HolderID(): string
     {
         return $this->getTemplateHelper()->generateFieldHolderID($this);
     }
@@ -416,7 +416,7 @@ class FormField extends RequestHandler
      *
      * @return FormTemplateHelper
      */
-    public function getTemplateHelper()
+    public function getTemplateHelper(): SilverStripe\Forms\FormTemplateHelper
     {
         if ($this->form) {
             return $this->form->getTemplateHelper();
@@ -430,7 +430,7 @@ class FormField extends RequestHandler
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string|null
     {
         return $this->name;
     }
@@ -440,7 +440,7 @@ class FormField extends RequestHandler
      *
      * @return string
      */
-    public function getInputType()
+    public function getInputType(): string|null
     {
         return $this->inputType;
     }
@@ -451,7 +451,7 @@ class FormField extends RequestHandler
      * @see FormField::setSubmittedValue()
      * @return mixed
      */
-    public function Value()
+    public function Value(): string|null|int|array|bool|DNADesign\Elemental\Models\ElementalArea
     {
         return $this->value;
     }
@@ -463,7 +463,7 @@ class FormField extends RequestHandler
      *
      * @param DataObject|DataObjectInterface $record DataObject to save data into
      */
-    public function saveInto(DataObjectInterface $record)
+    public function saveInto(DataObjectInterface $record): void
     {
         $component = $record;
         $fieldName = $this->name;
@@ -485,7 +485,7 @@ class FormField extends RequestHandler
      * @see Formfield::setValue()
      * @return mixed
      */
-    public function dataValue()
+    public function dataValue(): string|null|array|int|SilverStripe\Assets\File
     {
         return $this->value;
     }
@@ -495,7 +495,7 @@ class FormField extends RequestHandler
      *
      * @return string
      */
-    public function Title()
+    public function Title(): bool|string|SilverStripe\ORM\FieldType\DBHTMLText|int|null
     {
         return $this->title;
     }
@@ -507,7 +507,7 @@ class FormField extends RequestHandler
      * @param string $title Escaped HTML for title
      * @return $this
      */
-    public function setTitle($title)
+    public function setTitle(string|SilverStripe\ORM\FieldType\DBHTMLText|bool $title): SilverStripe\Forms\EmailField
     {
         $this->title = $title;
         return $this;
@@ -519,7 +519,7 @@ class FormField extends RequestHandler
      *
      * @return string Contextual label text
      */
-    public function RightTitle()
+    public function RightTitle(): null|string|SilverStripe\Forms\LiteralField
     {
         return $this->rightTitle;
     }
@@ -530,7 +530,7 @@ class FormField extends RequestHandler
      * @param string|DBField $rightTitle Plain text string, or a DBField with appropriately escaped HTML
      * @return $this
      */
-    public function setRightTitle($rightTitle)
+    public function setRightTitle(string|SilverStripe\Forms\LiteralField $rightTitle): SilverStripe\Forms\TextareaField
     {
         $this->rightTitle = $rightTitle;
         return $this;
@@ -539,7 +539,7 @@ class FormField extends RequestHandler
     /**
      * @return string
      */
-    public function LeftTitle()
+    public function LeftTitle(): null
     {
         return $this->leftTitle;
     }
@@ -549,7 +549,7 @@ class FormField extends RequestHandler
      *
      * @return $this
      */
-    public function setLeftTitle($leftTitle)
+    public function setLeftTitle($leftTitle): SilverStripe\Forms\CompositeField
     {
         $this->leftTitle = $leftTitle;
 
@@ -565,7 +565,7 @@ class FormField extends RequestHandler
      *
      * @return string
      */
-    public function extraClass()
+    public function extraClass(): string
     {
         $classes = [];
 
@@ -600,7 +600,7 @@ class FormField extends RequestHandler
      * names delimited by a single space.
      * @return boolean True if all of the classnames passed in have been added.
      */
-    public function hasExtraClass($class)
+    public function hasExtraClass(string $class): bool
     {
         //split at white space
         $classes = preg_split('/\s+/', $class ?? '');
@@ -621,7 +621,7 @@ class FormField extends RequestHandler
      *
      * @return $this
      */
-    public function addExtraClass($class)
+    public function addExtraClass(string $class): SilverStripe\Forms\CompositeField
     {
         $classes = preg_split('/\s+/', $class ?? '');
 
@@ -639,7 +639,7 @@ class FormField extends RequestHandler
      *
      * @return $this
      */
-    public function removeExtraClass($class)
+    public function removeExtraClass(string $class): SilverStripe\Forms\FormAction
     {
         $classes = preg_split('/\s+/', $class ?? '');
 
@@ -701,7 +701,7 @@ class FormField extends RequestHandler
      * @param array|DataObject $data {@see Form::loadDataFrom}
      * @return $this
      */
-    public function setValue($value, $data = null)
+    public function setValue(string|int|array|bool|float|DNADesign\Elemental\Models\ElementalArea $value, array|DNADesign\Elemental\Models\ElementContent $data = null): SilverStripe\Forms\TextField
     {
         $this->value = $value;
         return $this;
@@ -716,7 +716,7 @@ class FormField extends RequestHandler
      * @param array|DataObject $data
      * @return $this
      */
-    public function setSubmittedValue($value, $data = null)
+    public function setSubmittedValue(int|string|array|bool $value, array $data = null): SilverStripe\Forms\HiddenField
     {
         return $this->setValue($value, $data);
     }
@@ -728,7 +728,7 @@ class FormField extends RequestHandler
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName(string $name): SilverStripe\Forms\TextField
     {
         $this->name = $name;
 
@@ -742,7 +742,7 @@ class FormField extends RequestHandler
      *
      * @return $this
      */
-    public function setInputType($type)
+    public function setInputType(string $type): SilverStripe\Forms\TextField
     {
         $this->inputType = $type;
 
@@ -758,7 +758,7 @@ class FormField extends RequestHandler
      *
      * @return $this
      */
-    public function setForm($form)
+    public function setForm(SilverStripe\CMS\Search\SearchForm $form): SilverStripe\Forms\FormAction
     {
         $this->form = $form;
 
@@ -770,7 +770,7 @@ class FormField extends RequestHandler
      *
      * @return Form
      */
-    public function getForm()
+    public function getForm(): null|SilverStripe\Comments\Forms\CommentForm
     {
         return $this->form;
     }
@@ -780,7 +780,7 @@ class FormField extends RequestHandler
      *
      * @return bool
      */
-    public function securityTokenEnabled()
+    public function securityTokenEnabled(): bool
     {
         $form = $this->getForm();
 
@@ -791,7 +791,7 @@ class FormField extends RequestHandler
         return $form->getSecurityToken()->isEnabled();
     }
 
-    public function castingHelper($field)
+    public function castingHelper(string $field): string
     {
         // Override casting for field message
         if (strcasecmp($field ?? '', 'Message') === 0 && ($helper = $this->getMessageCastingHelper())) {
@@ -809,7 +809,7 @@ class FormField extends RequestHandler
      *
      * @return $this
      */
-    public function setCustomValidationMessage($customValidationMessage)
+    public function setCustomValidationMessage(string $customValidationMessage): SilverStripe\Forms\TextField
     {
         $this->customValidationMessage = $customValidationMessage;
 
@@ -822,7 +822,7 @@ class FormField extends RequestHandler
      *
      * @return string
      */
-    public function getCustomValidationMessage()
+    public function getCustomValidationMessage(): string
     {
         return $this->customValidationMessage;
     }
@@ -837,7 +837,7 @@ class FormField extends RequestHandler
      *
      * @return $this
      */
-    public function setTemplate($template)
+    public function setTemplate(string $template): DNADesign\Elemental\Forms\TextCheckboxGroupField
     {
         $this->template = $template;
 
@@ -847,7 +847,7 @@ class FormField extends RequestHandler
     /**
      * @return string
      */
-    public function getTemplate()
+    public function getTemplate(): null|string
     {
         return $this->template;
     }
@@ -855,7 +855,7 @@ class FormField extends RequestHandler
     /**
      * @return string
      */
-    public function getFieldHolderTemplate()
+    public function getFieldHolderTemplate(): null|string
     {
         return $this->fieldHolderTemplate;
     }
@@ -871,7 +871,7 @@ class FormField extends RequestHandler
      *
      * @return $this
      */
-    public function setFieldHolderTemplate($fieldHolderTemplate)
+    public function setFieldHolderTemplate(string $fieldHolderTemplate): SilverStripe\Forms\CompositeField
     {
         $this->fieldHolderTemplate = $fieldHolderTemplate;
 
@@ -881,7 +881,7 @@ class FormField extends RequestHandler
     /**
      * @return string
      */
-    public function getSmallFieldHolderTemplate()
+    public function getSmallFieldHolderTemplate(): null
     {
         return $this->smallFieldHolderTemplate;
     }
@@ -915,7 +915,7 @@ class FormField extends RequestHandler
      * @param array $properties
      * @return DBHTMLText
      */
-    public function Field($properties = [])
+    public function Field(array $properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $context = $this;
 
@@ -950,7 +950,7 @@ class FormField extends RequestHandler
      *
      * @return DBHTMLText
      */
-    public function FieldHolder($properties = [])
+    public function FieldHolder(array $properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $context = $this;
 
@@ -970,7 +970,7 @@ class FormField extends RequestHandler
      *
      * @return string
      */
-    public function SmallFieldHolder($properties = [])
+    public function SmallFieldHolder($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $context = $this;
 
@@ -986,7 +986,7 @@ class FormField extends RequestHandler
      *
      * @return array
      */
-    public function getTemplates()
+    public function getTemplates(): array
     {
         return $this->_templates($this->getTemplate());
     }
@@ -996,7 +996,7 @@ class FormField extends RequestHandler
      *
      * @return array
      */
-    public function getFieldHolderTemplates()
+    public function getFieldHolderTemplates(): array
     {
         return $this->_templates(
             $this->getFieldHolderTemplate(),
@@ -1009,7 +1009,7 @@ class FormField extends RequestHandler
      *
      * @return array
      */
-    public function getSmallFieldHolderTemplates()
+    public function getSmallFieldHolderTemplates(): array
     {
         return $this->_templates(
             $this->getSmallFieldHolderTemplate(),
@@ -1026,7 +1026,7 @@ class FormField extends RequestHandler
      *
      * @return array
      */
-    protected function _templates($customTemplate = null, $customTemplateSuffix = null)
+    protected function _templates(string $customTemplate = null, string $customTemplateSuffix = null): array
     {
         $templates = SSViewer::get_templates_by_class(static::class, $customTemplateSuffix, __CLASS__);
         // Prefer any custom template
@@ -1044,7 +1044,7 @@ class FormField extends RequestHandler
      *
      * @return bool
      */
-    public function isComposite()
+    public function isComposite(): bool
     {
         return false;
     }
@@ -1060,7 +1060,7 @@ class FormField extends RequestHandler
      *
      * @return bool
      */
-    public function hasData()
+    public function hasData(): bool
     {
         return true;
     }
@@ -1068,7 +1068,7 @@ class FormField extends RequestHandler
     /**
      * @return bool
      */
-    public function isReadonly()
+    public function isReadonly(): bool
     {
         return $this->readonly;
     }
@@ -1084,7 +1084,7 @@ class FormField extends RequestHandler
      *
      * @return $this
      */
-    public function setReadonly($readonly)
+    public function setReadonly(bool $readonly): SilverStripe\Forms\CompositeField
     {
         $this->readonly = $readonly;
         return $this;
@@ -1093,7 +1093,7 @@ class FormField extends RequestHandler
     /**
      * @return bool
      */
-    public function isDisabled()
+    public function isDisabled(): bool
     {
         return $this->disabled;
     }
@@ -1109,7 +1109,7 @@ class FormField extends RequestHandler
      *
      * @return $this
      */
-    public function setDisabled($disabled)
+    public function setDisabled(bool $disabled): SilverStripe\Forms\PasswordField
     {
         $this->disabled = $disabled;
 
@@ -1119,7 +1119,7 @@ class FormField extends RequestHandler
     /**
      * @return bool
      */
-    public function isAutofocus()
+    public function isAutofocus(): bool
     {
         return $this->autofocus;
     }
@@ -1141,7 +1141,7 @@ class FormField extends RequestHandler
      *
      * @return FormField
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\ReadonlyField
     {
         $readonlyClassName = static::class . '_Readonly';
 
@@ -1164,7 +1164,7 @@ class FormField extends RequestHandler
      *
      * @return FormField
      */
-    public function performDisabledTransformation()
+    public function performDisabledTransformation(): SilverStripe\Forms\ReadonlyField
     {
         $disabledClassName = static::class . '_Disabled';
 
@@ -1184,7 +1184,7 @@ class FormField extends RequestHandler
      *
      * @return mixed
      */
-    public function transform(FormTransformation $transformation)
+    public function transform(FormTransformation $transformation): SilverStripe\Forms\ReadonlyField
     {
         return $transformation->transform($this);
     }
@@ -1196,7 +1196,7 @@ class FormField extends RequestHandler
      *
      * @return bool
      */
-    public function hasClass($class)
+    public function hasClass(string $class): bool
     {
         $classes = explode(' ', strtolower($this->extraClass() ?? ''));
         return in_array(strtolower(trim($class ?? '')), $classes ?? []);
@@ -1213,7 +1213,7 @@ class FormField extends RequestHandler
      *
      * @return string
      */
-    public function Type()
+    public function Type(): string
     {
         $type = new ReflectionClass($this);
         return strtolower(preg_replace('/Field$/', '', $type->getShortName() ?? '') ?? '');
@@ -1228,7 +1228,7 @@ class FormField extends RequestHandler
      * @param Validator $validator
      * @return bool
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Forms\RequiredFields $validator): bool
     {
         return true;
     }
@@ -1242,7 +1242,7 @@ class FormField extends RequestHandler
      *
      * @return $this
      */
-    public function setDescription($description)
+    public function setDescription(string|SilverStripe\ORM\FieldType\DBHTMLText $description): SilverStripe\Forms\EmailField
     {
         $this->description = $description;
 
@@ -1252,7 +1252,7 @@ class FormField extends RequestHandler
     /**
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): null|string|SilverStripe\ORM\FieldType\DBHTMLText
     {
         return $this->description;
     }
@@ -1260,7 +1260,7 @@ class FormField extends RequestHandler
     /**
      * @return string
      */
-    public function debug()
+    public function debug(): string
     {
         $strValue = is_string($this->value) ? $this->value : print_r($this->value, true);
 
@@ -1280,7 +1280,7 @@ class FormField extends RequestHandler
      *
      * @return string
      */
-    public function forTemplate()
+    public function forTemplate(): SilverStripe\ORM\FieldType\DBHTMLText|string
     {
         return $this->Field();
     }
@@ -1288,7 +1288,7 @@ class FormField extends RequestHandler
     /**
      * @return bool
      */
-    public function Required()
+    public function Required(): bool
     {
         if ($this->form && ($validator = $this->form->getValidator())) {
             return $validator->fieldIsRequired($this->name);
@@ -1303,7 +1303,7 @@ class FormField extends RequestHandler
      * @param FieldList $containerFieldList
      * @return $this
      */
-    public function setContainerFieldList($containerFieldList)
+    public function setContainerFieldList(SilverStripe\Forms\FieldList $containerFieldList): SilverStripe\Forms\TextField
     {
         $this->containerFieldList = $containerFieldList;
         return $this;
@@ -1314,7 +1314,7 @@ class FormField extends RequestHandler
      *
      * @return FieldList
      */
-    public function getContainerFieldList()
+    public function getContainerFieldList(): SilverStripe\Forms\FieldList
     {
         return $this->containerFieldList;
     }
@@ -1322,7 +1322,7 @@ class FormField extends RequestHandler
     /**
      * @return null|FieldList
      */
-    public function rootFieldList()
+    public function rootFieldList(): SilverStripe\Forms\FieldList
     {
         if ($this->containerFieldList) {
             return $this->containerFieldList->rootFieldList();
@@ -1347,7 +1347,7 @@ class FormField extends RequestHandler
      *
      * @return FormField
      */
-    public function castedCopy($classOrCopy)
+    public function castedCopy(string|SilverStripe\Forms\TreeDropdownField_Readonly $classOrCopy): SilverStripe\Forms\CompositeField
     {
         $field = $classOrCopy;
 
@@ -1379,7 +1379,7 @@ class FormField extends RequestHandler
      *
      * @return bool
      */
-    public function canSubmitValue()
+    public function canSubmitValue(): bool
     {
         return $this->hasData() && !$this->isReadonly() && !$this->isDisabled();
     }
@@ -1390,7 +1390,7 @@ class FormField extends RequestHandler
      * @param string $componentType
      * @return FormField
      */
-    public function setSchemaComponent($componentType)
+    public function setSchemaComponent(string $componentType): SilverStripe\Forms\FieldGroup
     {
         $this->schemaComponent = $componentType;
         return $this;
@@ -1401,7 +1401,7 @@ class FormField extends RequestHandler
      *
      * @return string
      */
-    public function getSchemaComponent()
+    public function getSchemaComponent(): null|string
     {
         return $this->schemaComponent;
     }
@@ -1417,7 +1417,7 @@ class FormField extends RequestHandler
      *
      * @todo Add deep merging of arrays like `data` and `attributes`.
      */
-    public function setSchemaData($schemaData = [])
+    public function setSchemaData(array $schemaData = []): SilverStripe\Forms\FormAction
     {
         $defaults = $this->getSchemaData();
         $this->schemaData = array_merge($this->schemaData, array_intersect_key($schemaData ?? [], $defaults));
@@ -1429,7 +1429,7 @@ class FormField extends RequestHandler
      *
      * @return array
      */
-    public function getSchemaData()
+    public function getSchemaData(): array
     {
         $defaults = $this->getSchemaDataDefaults();
         return array_replace_recursive($defaults ?? [], array_intersect_key($this->schemaData ?? [], $defaults));
@@ -1440,7 +1440,7 @@ class FormField extends RequestHandler
      *
      * @return string
      */
-    public function getSchemaDataType()
+    public function getSchemaDataType(): null|string
     {
         return $this->schemaDataType;
     }
@@ -1452,7 +1452,7 @@ class FormField extends RequestHandler
      *
      * @return array
      */
-    public function getSchemaDataDefaults()
+    public function getSchemaDataDefaults(): array
     {
         $data = [
             'name' => $this->getName(),
@@ -1493,7 +1493,7 @@ class FormField extends RequestHandler
      *
      * @todo Add deep merging of arrays like `data` and `attributes`.
      */
-    public function setSchemaState($schemaState = [])
+    public function setSchemaState(array $schemaState = []): SilverStripe\Forms\TabSet
     {
         $defaults = $this->getSchemaState();
         $this->schemaState = array_merge($this->schemaState, array_intersect_key($schemaState ?? [], $defaults));
@@ -1505,7 +1505,7 @@ class FormField extends RequestHandler
      *
      * @return array
      */
-    public function getSchemaState()
+    public function getSchemaState(): array
     {
         $defaults = $this->getSchemaStateDefaults();
         return array_merge($defaults, array_intersect_key($this->schemaState ?? [], $defaults));
@@ -1521,7 +1521,7 @@ class FormField extends RequestHandler
      * @todo Make form / field messages not always stored as html; Store value / casting as separate values.
      * @return array
      */
-    public function getSchemaStateDefaults()
+    public function getSchemaStateDefaults(): array
     {
         $state = [
             'name' => $this->getName(),
@@ -1541,7 +1541,7 @@ class FormField extends RequestHandler
      *
      * @return array
      */
-    public function getSchemaValidation()
+    public function getSchemaValidation(): array
     {
         $validationList = [];
         if ($this->Required()) {

--- a/src/Forms/FormRequestHandler.php
+++ b/src/Forms/FormRequestHandler.php
@@ -55,7 +55,7 @@ class FormRequestHandler extends RequestHandler
      *
      * @param Form $form
      */
-    public function __construct(Form $form)
+    public function __construct(Form $form): void
     {
         $this->form = $form;
         parent::__construct();
@@ -74,7 +74,7 @@ class FormRequestHandler extends RequestHandler
      * @param string $action
      * @return string
      */
-    public function Link($action = null)
+    public function Link(string $action = null): string|null
     {
         // Forms without parent controller have no link;
         // E.g. Submission handled via graphql
@@ -106,7 +106,7 @@ class FormRequestHandler extends RequestHandler
      * @return HTTPResponse
      * @throws HTTPResponse_Exception
      */
-    public function httpSubmission($request)
+    public function httpSubmission(SilverStripe\Control\HTTPRequest $request): string|null|SilverStripe\Control\HTTPResponse
     {
         // Strict method check
         if ($this->form->getStrictFormMethodCheck()) {
@@ -268,7 +268,7 @@ class FormRequestHandler extends RequestHandler
      * @param string $action
      * @return bool
      */
-    public function checkAccessAction($action)
+    public function checkAccessAction(string $action): bool
     {
         if (parent::checkAccessAction($action)) {
             return true;
@@ -303,7 +303,7 @@ class FormRequestHandler extends RequestHandler
      * @param ValidationResult $result
      * @return HTTPResponse
      */
-    protected function getValidationErrorResponse(ValidationResult $result)
+    protected function getValidationErrorResponse(ValidationResult $result): SilverStripe\Control\HTTPResponse
     {
         // Check for custom handling mechanism
         $callback = $this->form->getValidationResponseCallback();
@@ -332,7 +332,7 @@ class FormRequestHandler extends RequestHandler
      *
      * @return HTTPResponse
      */
-    public function redirectBackToForm()
+    public function redirectBackToForm(): SilverStripe\Control\HTTPResponse
     {
         $pageURL = $this->getReturnReferer();
         if (!$pageURL) {
@@ -355,7 +355,7 @@ class FormRequestHandler extends RequestHandler
      * @param string $link
      * @return string
      */
-    protected function addBackURLParam($link)
+    protected function addBackURLParam(string $link): string
     {
         $backURL = $this->getBackURL();
         if ($backURL) {
@@ -371,7 +371,7 @@ class FormRequestHandler extends RequestHandler
      * @param ValidationResult $result
      * @return HTTPResponse
      */
-    protected function getAjaxErrorResponse(ValidationResult $result)
+    protected function getAjaxErrorResponse(ValidationResult $result): SilverStripe\Control\HTTPResponse
     {
         // Ajax form submissions accept json encoded errors by default
         $acceptType = $this->getRequest()->getHeader('Accept');
@@ -396,7 +396,7 @@ class FormRequestHandler extends RequestHandler
      * @param callable $funcName
      * @return FormField
      */
-    protected function checkFieldsForAction($fields, $funcName)
+    protected function checkFieldsForAction(SilverStripe\Forms\FieldList $fields, string $funcName): null|SilverStripe\Control\Tests\RequestHandlingTest\HandlingField
     {
         foreach ($fields as $field) {
             /** @skipUpgrade */
@@ -422,7 +422,7 @@ class FormRequestHandler extends RequestHandler
      * @param HTTPRequest $request
      * @return FormField
      */
-    public function handleField($request)
+    public function handleField(SilverStripe\Control\HTTPRequest $request): SilverStripe\Forms\GridField\GridField
     {
         $field = $this->form->Fields()->dataFieldByName($request->param('FieldName'));
 
@@ -440,7 +440,7 @@ class FormRequestHandler extends RequestHandler
      * @param callable $funcName The name of the action method that will be called.
      * @return $this
      */
-    public function setButtonClicked($funcName)
+    public function setButtonClicked(string $funcName): SilverStripe\Forms\FormRequestHandler
     {
         $this->buttonClickedFunc = $funcName;
         return $this;
@@ -451,7 +451,7 @@ class FormRequestHandler extends RequestHandler
      *
      * @return FormAction
      */
-    public function buttonClicked()
+    public function buttonClicked(): SilverStripe\Forms\FormAction|null
     {
         $actions = $this->getAllActions();
         foreach ($actions as $action) {
@@ -467,7 +467,7 @@ class FormRequestHandler extends RequestHandler
      *
      * @return array
      */
-    protected function getAllActions()
+    protected function getAllActions(): array
     {
         $fields = $this->form->Fields()->dataFields();
         $actions = $this->form->Actions()->dataFields();
@@ -524,7 +524,7 @@ class FormRequestHandler extends RequestHandler
      * @param array $vars
      * @return mixed
      */
-    private function invokeFormHandler($subject, string $funcName, HTTPRequest $request, array $vars)
+    private function invokeFormHandler(SilverStripe\MFA\Authenticator\LoginHandler $subject, string $funcName, HTTPRequest $request, array $vars): string|null|SilverStripe\Control\HTTPResponse
     {
         $this->extend('beforeCallFormHandler', $request, $funcName, $vars, $this->form, $subject);
         $result = $subject->$funcName($vars, $this->form, $request, $this);

--- a/src/Forms/FormScaffolder.php
+++ b/src/Forms/FormScaffolder.php
@@ -57,7 +57,7 @@ class FormScaffolder
     /**
      * @param DataObject $obj
      */
-    public function __construct($obj)
+    public function __construct(DNADesign\Elemental\Models\ElementContent $obj): void
     {
         $this->obj = $obj;
     }
@@ -70,7 +70,7 @@ class FormScaffolder
      *
      * @return FieldList
      */
-    public function getFieldList()
+    public function getFieldList(): SilverStripe\Forms\FieldList
     {
         $fields = new FieldList();
 
@@ -202,7 +202,7 @@ class FormScaffolder
         $overrideFieldClass,
         $tabbed,
         DataObject $dataObject
-    ) {
+    ): void {
         if ($tabbed) {
             $fields->findOrMakeTab(
                 "Root.$relationship",
@@ -234,7 +234,7 @@ class FormScaffolder
      *
      * @return array
      */
-    protected function getParamsArray()
+    protected function getParamsArray(): array
     {
         return [
             'tabbed' => $this->tabbed,

--- a/src/Forms/FormTemplateHelper.php
+++ b/src/Forms/FormTemplateHelper.php
@@ -32,7 +32,7 @@ class FormTemplateHelper
      *
      * @return string
      */
-    public function generateFormID($form)
+    public function generateFormID(SilverStripe\CMS\Search\SearchForm $form): string
     {
         if ($id = $form->getHTMLID()) {
             return Convert::raw2htmlid($id);
@@ -48,7 +48,7 @@ class FormTemplateHelper
      *
      * @return string
      */
-    public function generateFieldHolderID($field)
+    public function generateFieldHolderID(SilverStripe\Forms\CompositeField $field): string
     {
         return $this->generateFieldID($field) . '_Holder';
     }
@@ -59,7 +59,7 @@ class FormTemplateHelper
      * @param FormField $field
      * @return string
      */
-    public function generateFieldID($field)
+    public function generateFieldID(SilverStripe\Forms\CompositeField $field): string
     {
         // Don't include '.'s in IDs, they confused JavaScript
         $name = str_replace('.', '_', $field->getName() ?? '');

--- a/src/Forms/FormTransformation.php
+++ b/src/Forms/FormTransformation.php
@@ -26,11 +26,11 @@ class FormTransformation
     use Injectable;
     use Extensible;
 
-    public function __construct()
+    public function __construct(): void
     {
     }
 
-    public function transform(FormField $field)
+    public function transform(FormField $field): SilverStripe\Forms\ReadonlyField
     {
         // Look for a performXXTransformation() method on the field itself.
         // performReadonlyTransformation() is a pretty commonly applied method.

--- a/src/Forms/GridField/FormAction/AbstractRequestAwareStore.php
+++ b/src/Forms/GridField/FormAction/AbstractRequestAwareStore.php
@@ -9,7 +9,7 @@ abstract class AbstractRequestAwareStore implements StateStore
     /**
      * @return HTTPRequest
      */
-    public function getRequest()
+    public function getRequest(): SilverStripe\Control\HTTPRequest
     {
         // Replicating existing functionality from GridField_FormAction
         return Controller::curr()->getRequest();

--- a/src/Forms/GridField/FormAction/SessionStore.php
+++ b/src/Forms/GridField/FormAction/SessionStore.php
@@ -16,7 +16,7 @@ class SessionStore extends AbstractRequestAwareStore implements StateStore
      * @param array $state
      * @return array
      */
-    public function save($id, array $state)
+    public function save(string $id, array $state): array
     {
         $this->getRequest()->getSession()->set($id, $state);
 
@@ -30,7 +30,7 @@ class SessionStore extends AbstractRequestAwareStore implements StateStore
      * @param string $id
      * @return array
      */
-    public function load($id)
+    public function load(string $id): array
     {
         return (array) $this->getRequest()->getSession()->get($id);
     }

--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -149,7 +149,7 @@ class GridField extends FormField
      * @param SS_List $dataList
      * @param GridFieldConfig $config
      */
-    public function __construct($name, $title = null, SS_List $dataList = null, GridFieldConfig $config = null)
+    public function __construct(string $name, string|bool $title = null, SS_List $dataList = null, GridFieldConfig $config = null): void
     {
         parent::__construct($name, $title, null);
 
@@ -176,7 +176,7 @@ class GridField extends FormField
      *
      * @return string
      */
-    public function index($request)
+    public function index(SilverStripe\Control\HTTPRequest $request): string|SilverStripe\Control\HTTPResponse
     {
         return $this->gridFieldAlterAction([], $this->getForm(), $request);
     }
@@ -192,7 +192,7 @@ class GridField extends FormField
      *
      * @return $this
      */
-    public function setModelClass($modelClassName)
+    public function setModelClass(string $modelClassName): SilverStripe\Forms\GridField\GridField
     {
         $this->modelClassName = $modelClassName;
 
@@ -206,7 +206,7 @@ class GridField extends FormField
      *
      * @throws LogicException
      */
-    public function getModelClass()
+    public function getModelClass(): string
     {
         if ($this->modelClassName) {
             return $this->modelClassName;
@@ -232,7 +232,7 @@ class GridField extends FormField
      *
      * @param array $components an array map of component class references to whitelist for a readonly version.
      */
-    public function setReadonlyComponents(array $components)
+    public function setReadonlyComponents(array $components): void
     {
         $this->readonlyComponents = $components;
     }
@@ -242,7 +242,7 @@ class GridField extends FormField
      *
      * @return array a map of component classes.
      */
-    public function getReadonlyComponents()
+    public function getReadonlyComponents(): array
     {
         return $this->readonlyComponents;
     }
@@ -252,7 +252,7 @@ class GridField extends FormField
      *
      * @return GridField
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\GridField\GridField
     {
         $copy = clone $this;
         $copy->setReadonly(true);
@@ -293,7 +293,7 @@ class GridField extends FormField
     /**
      * @return GridFieldConfig
      */
-    public function getConfig()
+    public function getConfig(): DNADesign\Elemental\Forms\ElementalAreaConfig
     {
         return $this->config;
     }
@@ -303,7 +303,7 @@ class GridField extends FormField
      *
      * @return $this
      */
-    public function setConfig(GridFieldConfig $config)
+    public function setConfig(GridFieldConfig $config): SilverStripe\Forms\GridField\GridField
     {
         $this->config = $config;
 
@@ -319,7 +319,7 @@ class GridField extends FormField
      *
      * @return $this
      */
-    public function setReadonly($readonly)
+    public function setReadonly(bool $readonly): SilverStripe\Forms\GridField\GridField
     {
         parent::setReadonly($readonly);
         $this->getState()->Readonly = $readonly;
@@ -329,7 +329,7 @@ class GridField extends FormField
     /**
      * @return ArrayList
      */
-    public function getComponents()
+    public function getComponents(): SilverStripe\ORM\ArrayList
     {
         return $this->config->getComponents();
     }
@@ -344,7 +344,7 @@ class GridField extends FormField
      *
      * @return mixed
      */
-    public function getCastedValue($value, $castingDefinition)
+    public function getCastedValue(string $value, string|array $castingDefinition): null|string
     {
         $castingParams = [];
 
@@ -375,7 +375,7 @@ class GridField extends FormField
      *
      * @return $this
      */
-    public function setList(SS_List $list)
+    public function setList(SS_List $list): SilverStripe\Forms\GridField\GridField
     {
         $this->list = $list;
 
@@ -387,7 +387,7 @@ class GridField extends FormField
      *
      * @return SS_List
      */
-    public function getList()
+    public function getList(): null|SilverStripe\ORM\DataList
     {
         return $this->list;
     }
@@ -397,7 +397,7 @@ class GridField extends FormField
      *
      * @return SS_List
      */
-    public function getManipulatedList()
+    public function getManipulatedList(): SilverStripe\ORM\DataList
     {
         $list = $this->getList();
 
@@ -417,7 +417,7 @@ class GridField extends FormField
      *
      * @return GridState_Data|GridState
      */
-    public function getState($getData = true)
+    public function getState(bool $getData = true): SilverStripe\Forms\GridField\GridState_Data
     {
         // Initialise state on first call. This ensures it's evaluated after components have been added
         if (!$this->state) {
@@ -450,7 +450,7 @@ class GridField extends FormField
      * @param array $properties
      * @return string
      */
-    public function FieldHolder($properties = [])
+    public function FieldHolder($properties = []): string
     {
         $this->extend('onBeforeRenderHolder', $this, $properties);
 
@@ -697,7 +697,7 @@ class GridField extends FormField
      *
      * @return string
      */
-    protected function newCell($total, $index, $record, $attributes, $content)
+    protected function newCell(int $total, int $index, DNADesign\Elemental\Tests\Src\TestElement $record, array $attributes, string $content): string
     {
         return HTML::createTag(
             'td',
@@ -715,7 +715,7 @@ class GridField extends FormField
      *
      * @return string
      */
-    protected function newRow($total, $index, $record, $attributes, $content)
+    protected function newRow(int $total, int $index, DNADesign\Elemental\Tests\Src\TestElement $record, array $attributes, string $content): string
     {
         return HTML::createTag(
             'tr',
@@ -731,7 +731,7 @@ class GridField extends FormField
      *
      * @return array
      */
-    protected function getRowAttributes($total, $index, $record)
+    protected function getRowAttributes(int $total, int $index, DNADesign\Elemental\Tests\Src\TestElement $record): array
     {
         $rowClasses = $this->newRowClasses($total, $index, $record);
 
@@ -749,7 +749,7 @@ class GridField extends FormField
      *
      * @return array
      */
-    protected function newRowClasses($total, $index, $record)
+    protected function newRowClasses(int $total, int $index, DNADesign\Elemental\Tests\Src\TestElement $record): array
     {
         $classes = ['ss-gridfield-item'];
 
@@ -785,7 +785,7 @@ class GridField extends FormField
     /**
      * {@inheritdoc}
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return array_merge(
             parent::getAttributes(),
@@ -800,7 +800,7 @@ class GridField extends FormField
      *
      * @return array
      */
-    public function getColumns()
+    public function getColumns(): array
     {
         $columns = [];
 
@@ -823,7 +823,7 @@ class GridField extends FormField
      *
      * @throws InvalidArgumentException
      */
-    public function getColumnContent($record, $column)
+    public function getColumnContent(DNADesign\Elemental\Tests\Src\TestElement $record, string $column): string
     {
         if (!$this->columnDispatch) {
             $this->buildColumnDispatch();
@@ -854,7 +854,7 @@ class GridField extends FormField
      * @param array $fields a map of fieldname to callback. The callback will
      *                      be passed the record as an argument.
      */
-    public function addDataFields($fields)
+    public function addDataFields(array $fields): void
     {
         if ($this->customDataFields) {
             $this->customDataFields = array_merge($this->customDataFields, $fields);
@@ -874,7 +874,7 @@ class GridField extends FormField
      *
      * @return mixed
      */
-    public function getDataFieldValue($record, $fieldName)
+    public function getDataFieldValue(DNADesign\Elemental\Tests\Src\TestElement $record, string $fieldName): SilverStripe\ORM\FieldType\DBHTMLText|string|null|int|float
     {
         if (isset($this->customDataFields[$fieldName])) {
             $callback = $this->customDataFields[$fieldName];
@@ -904,7 +904,7 @@ class GridField extends FormField
      * @throws LogicException
      * @throws InvalidArgumentException
      */
-    public function getColumnAttributes($record, $column)
+    public function getColumnAttributes(DNADesign\Elemental\Tests\Src\TestElement $record, string $column): array
     {
         if (!$this->columnDispatch) {
             $this->buildColumnDispatch();
@@ -951,7 +951,7 @@ class GridField extends FormField
      * @throws LogicException
      * @throws InvalidArgumentException
      */
-    public function getColumnMetadata($column)
+    public function getColumnMetadata(string $column): array
     {
         if (!$this->columnDispatch) {
             $this->buildColumnDispatch();
@@ -991,7 +991,7 @@ class GridField extends FormField
      *
      * @return int
      */
-    public function getColumnCount()
+    public function getColumnCount(): int
     {
         if (!$this->columnDispatch) {
             $this->buildColumnDispatch();
@@ -1003,7 +1003,7 @@ class GridField extends FormField
     /**
      * Build an columnDispatch that maps a GridField_ColumnProvider to a column for reference later.
      */
-    protected function buildColumnDispatch()
+    protected function buildColumnDispatch(): void
     {
         $this->columnDispatch = [];
 
@@ -1027,7 +1027,7 @@ class GridField extends FormField
      *
      * @return string
      */
-    public function gridFieldAlterAction($data, $form, HTTPRequest $request)
+    public function gridFieldAlterAction(array $data, SilverStripe\Forms\Form $form, HTTPRequest $request): string|SilverStripe\Control\HTTPResponse
     {
         $data = $request->requestVars();
 
@@ -1102,7 +1102,7 @@ class GridField extends FormField
      *
      * @throws InvalidArgumentException
      */
-    public function handleAlterAction($actionName, $arguments, $data)
+    public function handleAlterAction(string $actionName, array|string $arguments, array $data): null|string|SilverStripe\Control\HTTPResponse
     {
         $actionName = strtolower($actionName ?? '');
 
@@ -1132,7 +1132,7 @@ class GridField extends FormField
      * @return array|RequestHandler|HTTPResponse|string
      * @throws HTTPResponse_Exception
      */
-    public function handleRequest(HTTPRequest $request)
+    public function handleRequest(HTTPRequest $request): string|SilverStripe\Control\HTTPResponse
     {
         if ($this->brokenOnConstruct) {
             user_error(
@@ -1231,7 +1231,7 @@ class GridField extends FormField
     /**
      * {@inheritdoc}
      */
-    public function saveInto(DataObjectInterface $record)
+    public function saveInto(DataObjectInterface $record): void
     {
         foreach ($this->getComponents() as $component) {
             if ($component instanceof GridField_SaveHandler) {
@@ -1245,7 +1245,7 @@ class GridField extends FormField
      *
      * @return string
      */
-    protected function getOptionalTableHeader(array $content)
+    protected function getOptionalTableHeader(array $content): string
     {
         if ($content['header']) {
             return HTML::createTag(
@@ -1263,7 +1263,7 @@ class GridField extends FormField
      *
      * @return string
      */
-    protected function getOptionalTableBody(array $content)
+    protected function getOptionalTableBody(array $content): string
     {
         if ($content['body']) {
             return HTML::createTag(
@@ -1281,7 +1281,7 @@ class GridField extends FormField
      *
      * @return string
      */
-    protected function getOptionalTableFooter($content)
+    protected function getOptionalTableFooter(array $content): string
     {
         if ($content['footer']) {
             return HTML::createTag(

--- a/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
+++ b/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
@@ -91,7 +91,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
      * @param string $targetFragment
      * @param array $searchFields Which fields on the object in the list should be searched
      */
-    public function __construct($targetFragment = 'before', $searchFields = null)
+    public function __construct(string $targetFragment = 'before', array $searchFields = null): void
     {
         $this->targetFragment = $targetFragment;
         $this->searchFields = (array)$searchFields;
@@ -102,7 +102,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
      * @param GridField $gridField
      * @return string[] - HTML
      */
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         $dataClass = $gridField->getModelClass();
 
@@ -158,7 +158,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
      * @param GridField $gridField
      * @return array
      */
-    public function getActions($gridField)
+    public function getActions(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return ['addto', 'find'];
     }
@@ -171,7 +171,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
      * @param array $arguments Arguments relevant for this
      * @param array $data All form data
      */
-    public function handleAction(GridField $gridField, $actionName, $arguments, $data)
+    public function handleAction(GridField $gridField, string $actionName, string $arguments, array $data): void
     {
         switch ($actionName) {
             case 'addto':
@@ -189,7 +189,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
      * @param SS_List $dataList
      * @return SS_List
      */
-    public function getManipulatedData(GridField $gridField, SS_List $dataList)
+    public function getManipulatedData(GridField $gridField, SS_List $dataList): SilverStripe\Auditor\AuditHookManyManyList
     {
         $objectID = $gridField->State->GridFieldAddRelation(null);
         if (empty($objectID)) {
@@ -208,7 +208,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
      * @param GridField $gridField
      * @return array
      */
-    public function getURLHandlers($gridField)
+    public function getURLHandlers(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return [
             'search' => 'doSearch',
@@ -222,7 +222,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
      * @param HTTPRequest $request
      * @return string
      */
-    public function doSearch($gridField, $request)
+    public function doSearch(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Control\HTTPRequest $request): SilverStripe\Control\HTTPResponse
     {
         $searchStr = $request->getVar('gridfield_relationsearch');
         $dataClass = $gridField->getModelClass();
@@ -283,7 +283,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
      *
      * @return $this
      */
-    public function setResultsFormat($format)
+    public function setResultsFormat(string $format): SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter
     {
         $this->resultsFormat = $format;
         return $this;
@@ -303,7 +303,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
      *
      * @param SS_List $list
      */
-    public function setSearchList(SS_List $list)
+    public function setSearchList(SS_List $list): SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter
     {
         $this->searchList = $list;
         return $this;
@@ -313,7 +313,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
      * @param array $fields
      * @return $this
      */
-    public function setSearchFields($fields)
+    public function setSearchFields(array $fields): SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter
     {
         $this->searchFields = $fields;
         return $this;
@@ -322,7 +322,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
     /**
      * @return array
      */
-    public function getSearchFields()
+    public function getSearchFields(): array
     {
         return $this->searchFields;
     }
@@ -335,7 +335,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
      * @param string $dataClass The class name
      * @return array|null names of the searchable fields
      */
-    public function scaffoldSearchFields($dataClass)
+    public function scaffoldSearchFields(string $dataClass): array
     {
         $obj = DataObject::singleton($dataClass);
         $fields = null;
@@ -385,7 +385,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
      *
      * @return string
      */
-    public function getPlaceholderText($dataClass)
+    public function getPlaceholderText(string $dataClass): string
     {
         $searchFields = ($this->getSearchFields())
             ? $this->getSearchFields()
@@ -436,7 +436,7 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
      *
      * @return int
      */
-    public function getResultsLimit()
+    public function getResultsLimit(): int
     {
         return $this->resultsLimit;
     }

--- a/src/Forms/GridField/GridFieldAddNewButton.php
+++ b/src/Forms/GridField/GridFieldAddNewButton.php
@@ -22,19 +22,19 @@ class GridFieldAddNewButton extends AbstractGridFieldComponent implements GridFi
 
     protected $buttonName;
 
-    public function setButtonName($name)
+    public function setButtonName(string $name): SilverStripe\Forms\GridField\GridFieldAddNewButton
     {
         $this->buttonName = $name;
 
         return $this;
     }
 
-    public function __construct($targetFragment = 'before')
+    public function __construct(string $targetFragment = 'before'): void
     {
         $this->targetFragment = $targetFragment;
     }
 
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         $singleton = singleton($gridField->getModelClass());
         $context = [];

--- a/src/Forms/GridField/GridFieldButtonRow.php
+++ b/src/Forms/GridField/GridFieldButtonRow.php
@@ -19,12 +19,12 @@ class GridFieldButtonRow extends AbstractGridFieldComponent implements GridField
 
     protected $targetFragment;
 
-    public function __construct($targetFragment = 'before')
+    public function __construct(string $targetFragment = 'before'): void
     {
         $this->targetFragment = $targetFragment;
     }
 
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         $data = new ArrayData([
             "TargetFragmentName" => $this->targetFragment,

--- a/src/Forms/GridField/GridFieldConfig.php
+++ b/src/Forms/GridField/GridFieldConfig.php
@@ -35,7 +35,7 @@ class GridFieldConfig
      */
     protected $components = null;
 
-    public function __construct()
+    public function __construct(): void
     {
         $this->components = new ArrayList();
     }
@@ -45,7 +45,7 @@ class GridFieldConfig
      * @param string $insertBefore The class of the component to insert this one before
      * @return $this
      */
-    public function addComponent(GridFieldComponent $component, $insertBefore = null)
+    public function addComponent(GridFieldComponent $component, string|SilverStripe\Forms\GridField\GridFieldEditButton $insertBefore = null): SilverStripe\Forms\GridField\GridFieldConfig_RelationEditor
     {
         if ($insertBefore) {
             $existingItems = $this->getComponents();
@@ -71,7 +71,7 @@ class GridFieldConfig
      * @param GridFieldComponent|GridFieldComponent[] ...$component One or more components, or an array of components
      * @return $this
      */
-    public function addComponents($component = null)
+    public function addComponents(array|Symbiote\GridFieldExtensions\GridFieldEditableColumns $component = null): SilverStripe\Comments\Admin\CommentsGridFieldConfig
     {
         $components = is_array($component) ? $component : func_get_args();
         foreach ($components as $component) {
@@ -84,7 +84,7 @@ class GridFieldConfig
      * @param GridFieldComponent $component
      * @return $this
      */
-    public function removeComponent(GridFieldComponent $component)
+    public function removeComponent(GridFieldComponent $component): SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor
     {
         $this->getComponents()->remove($component);
         return $this;
@@ -94,7 +94,7 @@ class GridFieldConfig
      * @param string|string[] $types Class name or interface, or an array of the same
      * @return $this
      */
-    public function removeComponentsByType($types)
+    public function removeComponentsByType(string|array $types): SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor
     {
         if (!is_array($types)) {
             $types = [$types];
@@ -113,7 +113,7 @@ class GridFieldConfig
     /**
      * @return ArrayList Of GridFieldComponent
      */
-    public function getComponents()
+    public function getComponents(): SilverStripe\ORM\ArrayList
     {
         if (!$this->components) {
             $this->components = new ArrayList();
@@ -127,7 +127,7 @@ class GridFieldConfig
      * @param string $type Class name or interface
      * @return ArrayList Of GridFieldComponent
      */
-    public function getComponentsByType($type)
+    public function getComponentsByType(string $type): SilverStripe\ORM\ArrayList
     {
         $components = new ArrayList();
         foreach ($this->components as $component) {
@@ -144,7 +144,7 @@ class GridFieldConfig
      * @param string $type ClassName
      * @return GridFieldComponent
      */
-    public function getComponentByType($type)
+    public function getComponentByType(string $type): null|Symbiote\GridFieldExtensions\GridFieldAddNewMultiClass
     {
         foreach ($this->components as $component) {
             if ($component instanceof $type) {

--- a/src/Forms/GridField/GridFieldConfig_Base.php
+++ b/src/Forms/GridField/GridFieldConfig_Base.php
@@ -12,7 +12,7 @@ class GridFieldConfig_Base extends GridFieldConfig
     /**
      * @param int $itemsPerPage - How many items per page should show up
      */
-    public function __construct($itemsPerPage = null)
+    public function __construct($itemsPerPage = null): void
     {
         parent::__construct();
         $this->addComponent(GridFieldToolbarHeader::create());

--- a/src/Forms/GridField/GridFieldConfig_RecordEditor.php
+++ b/src/Forms/GridField/GridFieldConfig_RecordEditor.php
@@ -13,7 +13,7 @@ class GridFieldConfig_RecordEditor extends GridFieldConfig
      * @param bool $showPagination Whether the `Previous` and `Next` buttons should display or not, leave as null to use default
      * @param bool $showAdd Whether the `Add` button should display or not, leave as null to use default
      */
-    public function __construct($itemsPerPage = null, $showPagination = null, $showAdd = null)
+    public function __construct(int $itemsPerPage = null, $showPagination = null, $showAdd = null): void
     {
         parent::__construct();
 

--- a/src/Forms/GridField/GridFieldConfig_RelationEditor.php
+++ b/src/Forms/GridField/GridFieldConfig_RelationEditor.php
@@ -25,7 +25,7 @@ class GridFieldConfig_RelationEditor extends GridFieldConfig
     /**
      * @param int $itemsPerPage - How many items per page should show up
      */
-    public function __construct($itemsPerPage = null)
+    public function __construct($itemsPerPage = null): void
     {
         parent::__construct();
 

--- a/src/Forms/GridField/GridFieldDataColumns.php
+++ b/src/Forms/GridField/GridFieldDataColumns.php
@@ -36,7 +36,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
      * @param GridField $gridField
      * @param array $columns List reference of all column names. (by reference)
      */
-    public function augmentColumns($gridField, &$columns)
+    public function augmentColumns(SilverStripe\Forms\GridField\GridField $gridField, &$columns): void
     {
         $baseColumns = array_keys($this->getDisplayFields($gridField) ?? []);
 
@@ -53,7 +53,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
      * @param GridField $gridField
      * @return array
      */
-    public function getColumnsHandled($gridField)
+    public function getColumnsHandled(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return array_keys($this->getDisplayFields($gridField) ?? []);
     }
@@ -66,7 +66,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
      * @param array $fields
      * @return $this
      */
-    public function setDisplayFields($fields)
+    public function setDisplayFields(array|stdClass $fields): SilverStripe\Forms\GridField\GridFieldDataColumns
     {
         if (!is_array($fields)) {
             throw new InvalidArgumentException(
@@ -84,7 +84,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
      * @return array
      * @see GridFieldDataColumns::setDisplayFields
      */
-    public function getDisplayFields($gridField)
+    public function getDisplayFields(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         if (!$this->displayFields) {
             return singleton($gridField->getModelClass())->summaryFields();
@@ -99,7 +99,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
      * @param array $casting
      * @return $this
      */
-    public function setFieldCasting($casting)
+    public function setFieldCasting(array $casting): SilverStripe\Forms\GridField\GridFieldDataColumns
     {
         $this->fieldCasting = $casting;
         return $this;
@@ -108,7 +108,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
     /**
      * @return array
      */
-    public function getFieldCasting()
+    public function getFieldCasting(): array
     {
         return $this->fieldCasting;
     }
@@ -128,7 +128,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
      * @param array $formatting
      * @return $this
      */
-    public function setFieldFormatting($formatting)
+    public function setFieldFormatting(array $formatting): SilverStripe\Forms\GridField\GridFieldDataColumns
     {
         $this->fieldFormatting = $formatting;
         return $this;
@@ -137,7 +137,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
     /**
      * @return array
      */
-    public function getFieldFormatting()
+    public function getFieldFormatting(): array
     {
         return $this->fieldFormatting;
     }
@@ -150,7 +150,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
      * @param string $columnName
      * @return string HTML for the column. Return NULL to skip.
      */
-    public function getColumnContent($gridField, $record, $columnName)
+    public function getColumnContent(SilverStripe\Forms\GridField\GridField $gridField, DNADesign\Elemental\Tests\Src\TestElement $record, string $columnName): string|null|SilverStripe\ORM\FieldType\DBHTMLText
     {
         // Find the data column for the given named column
         $columns = $this->getDisplayFields($gridField);
@@ -184,7 +184,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
      * @param  string $columnName
      * @return array
      */
-    public function getColumnAttributes($gridField, $record, $columnName)
+    public function getColumnAttributes(SilverStripe\Forms\GridField\GridField $gridField, DNADesign\Elemental\Tests\Src\TestElement $record, string $columnName): array
     {
         return ['class' => 'col-' . preg_replace('/[^\w]/', '-', $columnName ?? '')];
     }
@@ -197,7 +197,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
      * @param string $column
      * @return array Map of arbitrary metadata identifiers to their values.
      */
-    public function getColumnMetadata($gridField, $column)
+    public function getColumnMetadata(SilverStripe\Forms\GridField\GridField $gridField, string $column): array
     {
         $columns = $this->getDisplayFields($gridField);
 
@@ -244,7 +244,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
      * @param string $value
      * @return string
      */
-    protected function castValue($gridField, $fieldName, $value)
+    protected function castValue(SilverStripe\Forms\GridField\GridField $gridField, string $fieldName, SilverStripe\ORM\FieldType\DBHTMLText|string|int|float $value): string|null
     {
         // If a fieldCasting is specified, we assume the result is safe
         if (array_key_exists($fieldName, $this->fieldCasting ?? [])) {
@@ -274,7 +274,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
      * @param string $value
      * @return string
      */
-    protected function formatValue($gridField, $item, $fieldName, $value)
+    protected function formatValue(SilverStripe\Forms\GridField\GridField $gridField, DNADesign\Elemental\Tests\Src\TestElement $item, string $fieldName, string $value): string|null|SilverStripe\ORM\FieldType\DBHTMLText
     {
         if (!array_key_exists($fieldName, $this->fieldFormatting ?? [])) {
             return $value;
@@ -299,7 +299,7 @@ class GridFieldDataColumns extends AbstractGridFieldComponent implements GridFie
      * @param string $value
      * @return string
      */
-    protected function escapeValue($gridField, $value)
+    protected function escapeValue(SilverStripe\Forms\GridField\GridField $gridField, string|SilverStripe\ORM\FieldType\DBHTMLText $value): string|null|SilverStripe\ORM\FieldType\DBHTMLText
     {
         if (!$escape = $gridField->FieldEscape) {
             return $value;

--- a/src/Forms/GridField/GridFieldDeleteAction.php
+++ b/src/Forms/GridField/GridFieldDeleteAction.php
@@ -40,7 +40,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
      *
      * @param boolean $removeRelation - true if removing the item from the list, but not deleting it
      */
-    public function __construct($removeRelation = false)
+    public function __construct(bool $removeRelation = false): void
     {
         $this->setRemoveRelation($removeRelation);
     }
@@ -48,7 +48,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
     /**
      * @inheritdoc
      */
-    public function getTitle($gridField, $record, $columnName)
+    public function getTitle(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Security\Member $record, string $columnName): string
     {
         $field = $this->getRemoveAction($gridField, $record, $columnName);
 
@@ -62,7 +62,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
     /**
      * @inheritdoc
      */
-    public function getGroup($gridField, $record, $columnName)
+    public function getGroup(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Security\Member $record, string $columnName): null|string
     {
         $field = $this->getRemoveAction($gridField, $record, $columnName);
 
@@ -76,7 +76,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
      * @param string $columnName
      * @return string|null the attribles for the action
      */
-    public function getExtraData($gridField, $record, $columnName)
+    public function getExtraData(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Security\Member $record, string $columnName): array
     {
 
         $field = $this->getRemoveAction($gridField, $record, $columnName);
@@ -94,7 +94,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
      * @param GridField $gridField
      * @param array $columns
      */
-    public function augmentColumns($gridField, &$columns)
+    public function augmentColumns(SilverStripe\Forms\GridField\GridField $gridField, &$columns): void
     {
         if (!in_array('Actions', $columns ?? [])) {
             $columns[] = 'Actions';
@@ -109,7 +109,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
      * @param string $columnName
      * @return array
      */
-    public function getColumnAttributes($gridField, $record, $columnName)
+    public function getColumnAttributes(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\UserForms\Model\EditableFormField\EditableFormStep $record, string $columnName): array
     {
         return ['class' => 'grid-field__col-compact'];
     }
@@ -121,7 +121,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
      * @param string $columnName
      * @return array
      */
-    public function getColumnMetadata($gridField, $columnName)
+    public function getColumnMetadata(SilverStripe\Forms\GridField\GridField $gridField, string $columnName): array
     {
         if ($columnName == 'Actions') {
             return ['title' => ''];
@@ -134,7 +134,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
      * @param GridField $gridField
      * @return array
      */
-    public function getColumnsHandled($gridField)
+    public function getColumnsHandled(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return ['Actions'];
     }
@@ -145,7 +145,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
      * @param GridField $gridField
      * @return array
      */
-    public function getActions($gridField)
+    public function getActions(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return ['deleterecord', 'unlinkrelation'];
     }
@@ -157,7 +157,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
      * @param string $columnName
      * @return string|null the HTML for the column
      */
-    public function getColumnContent($gridField, $record, $columnName)
+    public function getColumnContent(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\UserForms\Model\EditableFormField\EditableFormStep $record, string $columnName): SilverStripe\ORM\FieldType\DBHTMLText|null
     {
         $field = $this->getRemoveAction($gridField, $record, $columnName);
 
@@ -177,7 +177,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
      * @param array $data Form data
      * @throws ValidationException
      */
-    public function handleAction(GridField $gridField, $actionName, $arguments, $data)
+    public function handleAction(GridField $gridField, string $actionName, array $arguments, array $data): void
     {
         if ($actionName == 'deleterecord' || $actionName == 'unlinkrelation') {
             /** @var DataObject $item */
@@ -213,7 +213,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
      * @param string $columnName
      * @return GridField_FormAction|null
      */
-    private function getRemoveAction($gridField, $record, $columnName)
+    private function getRemoveAction(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\UserForms\Model\EditableFormField\EditableFormStep $record, string $columnName): SilverStripe\Forms\GridField\GridField_FormAction|null
     {
         if ($this->getRemoveRelation()) {
             if (!$record->canEdit()) {
@@ -259,7 +259,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
      *
      * @return bool
      */
-    public function getRemoveRelation()
+    public function getRemoveRelation(): bool
     {
         return $this->removeRelation;
     }
@@ -269,7 +269,7 @@ class GridFieldDeleteAction extends AbstractGridFieldComponent implements GridFi
      * @param bool $removeRelation
      * @return $this
      */
-    public function setRemoveRelation($removeRelation)
+    public function setRemoveRelation(bool $removeRelation): SilverStripe\Forms\GridField\GridFieldDeleteAction
     {
         $this->removeRelation = (bool) $removeRelation;
         return $this;

--- a/src/Forms/GridField/GridFieldDetailForm.php
+++ b/src/Forms/GridField/GridFieldDetailForm.php
@@ -82,7 +82,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
      */
     protected $itemEditFormCallback;
 
-    public function getURLHandlers($gridField)
+    public function getURLHandlers(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return [
             'item/$ID' => 'handleItem'
@@ -101,7 +101,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
      * @param bool $showPagination Whether the `Previous` and `Next` buttons should display or not, leave as null to use default
      * @param bool $showAdd Whether the `Add` button should display or not, leave as null to use default
      */
-    public function __construct($name = null, $showPagination = null, $showAdd = null)
+    public function __construct(SilverStripe\Forms\Tests\GridField\GridFieldDetailFormTest\TestController $name = null, bool|string $showPagination = null, bool $showAdd = null): void
     {
         $this->setName($name ?: 'DetailForm');
         $this->setShowPagination($showPagination);
@@ -114,7 +114,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
      * @param HTTPRequest $request
      * @return HTTPResponse
      */
-    public function handleItem($gridField, $request)
+    public function handleItem(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Control\HTTPRequest $request): string|SilverStripe\ORM\FieldType\DBHTMLText
     {
         // Our getController could either give us a true Controller, if this is the top-level GridField.
         // It could also give us a RequestHandler in the form of GridFieldDetailForm_ItemRequest if this is a
@@ -220,7 +220,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
      * @param RequestHandler $requestHandler
      * @return GridFieldDetailForm_ItemRequest
      */
-    protected function getItemRequestHandler($gridField, $record, $requestHandler)
+    protected function getItemRequestHandler(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\FrameworkTest\Elemental\Model\ElementalBehatTestObject $record, SilverStripe\FrameworkTest\Elemental\Admin\ElementalBehatTestAdmin $requestHandler): SilverStripe\Versioned\VersionedGridFieldItemRequest
     {
         $class = $this->getItemRequestClass();
         $assignedClass = $this->itemRequestClass;
@@ -250,7 +250,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
     /**
      * @return String
      */
-    public function getTemplate()
+    public function getTemplate(): null
     {
         return $this->template;
     }
@@ -259,7 +259,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
      * @param string $name
      * @return $this
      */
-    public function setName($name)
+    public function setName(string|SilverStripe\Forms\Tests\GridField\GridFieldDetailFormTest\TestController $name): SilverStripe\Forms\GridField\GridFieldDetailForm
     {
         $this->name = $name;
         return $this;
@@ -298,7 +298,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
     /**
      * @return bool
      */
-    protected function getDefaultShowPagination()
+    protected function getDefaultShowPagination(): bool
     {
         $formActionsConfig = GridFieldDetailForm_ItemRequest::config()->get('formActions');
         return isset($formActionsConfig['showPagination']) ? (bool) $formActionsConfig['showPagination'] : false;
@@ -307,7 +307,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
     /**
      * @return bool
      */
-    public function getShowPagination()
+    public function getShowPagination(): bool
     {
         if ($this->showPagination === null) {
             return $this->getDefaultShowPagination();
@@ -320,7 +320,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
      * @param bool|null $showPagination
      * @return GridFieldDetailForm
      */
-    public function setShowPagination($showPagination)
+    public function setShowPagination(bool|string $showPagination): SilverStripe\Forms\GridField\GridFieldDetailForm
     {
         $this->showPagination = $showPagination;
         return $this;
@@ -329,7 +329,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
     /**
      * @return bool
      */
-    protected function getDefaultShowAdd()
+    protected function getDefaultShowAdd(): bool
     {
         $formActionsConfig = GridFieldDetailForm_ItemRequest::config()->get('formActions');
         return isset($formActionsConfig['showAdd']) ? (bool) $formActionsConfig['showAdd'] : false;
@@ -338,7 +338,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
     /**
      * @return bool
      */
-    public function getShowAdd()
+    public function getShowAdd(): bool
     {
         if ($this->showAdd === null) {
             return $this->getDefaultShowAdd();
@@ -351,7 +351,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
      * @param bool|null $showAdd
      * @return GridFieldDetailForm
      */
-    public function setShowAdd($showAdd)
+    public function setShowAdd(bool $showAdd): SilverStripe\Forms\GridField\GridFieldDetailForm
     {
         $this->showAdd = $showAdd;
         return $this;
@@ -361,7 +361,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
      * @param Validator $validator
      * @return $this
      */
-    public function setValidator(Validator $validator)
+    public function setValidator(Validator $validator): SilverStripe\Forms\GridField\GridFieldDetailForm
     {
         $this->validator = $validator;
         return $this;
@@ -370,7 +370,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
     /**
      * @return Validator
      */
-    public function getValidator()
+    public function getValidator(): null|SilverStripe\Forms\CompositeValidator
     {
         return $this->validator;
     }
@@ -379,7 +379,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
      * @param FieldList $fields
      * @return $this
      */
-    public function setFields(FieldList $fields)
+    public function setFields(FieldList $fields): SilverStripe\Forms\GridField\GridFieldDetailForm
     {
         $this->fields = $fields;
         return $this;
@@ -388,7 +388,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
     /**
      * @return FieldList
      */
-    public function getFields()
+    public function getFields(): null|SilverStripe\Forms\FieldList
     {
         return $this->fields;
     }
@@ -397,7 +397,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
      * @param string $class
      * @return $this
      */
-    public function setItemRequestClass($class)
+    public function setItemRequestClass(string $class): SilverStripe\Forms\GridField\GridFieldDetailForm
     {
         $this->itemRequestClass = $class;
         return $this;
@@ -406,7 +406,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
     /**
      * @return string name of {@see GridFieldDetailForm_ItemRequest} subclass
      */
-    public function getItemRequestClass()
+    public function getItemRequestClass(): string
     {
         if ($this->itemRequestClass) {
             return $this->itemRequestClass;
@@ -420,7 +420,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
      * @param Closure $cb Make changes on the edit form after constructing it.
      * @return $this
      */
-    public function setItemEditFormCallback(Closure $cb)
+    public function setItemEditFormCallback(Closure $cb): SilverStripe\Forms\GridField\GridFieldDetailForm
     {
         $this->itemEditFormCallback = $cb;
         return $this;
@@ -429,7 +429,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
     /**
      * @return Closure
      */
-    public function getItemEditFormCallback()
+    public function getItemEditFormCallback(): null|callable
     {
         return $this->itemEditFormCallback;
     }

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -97,7 +97,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      * @param RequestHandler $requestHandler
      * @param string $popupFormName
      */
-    public function __construct($gridField, $component, $record, $requestHandler, $popupFormName)
+    public function __construct(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Forms\GridField\GridFieldDetailForm $component, SilverStripe\FrameworkTest\Elemental\Model\ElementalBehatTestObject $record, SilverStripe\FrameworkTest\Elemental\Admin\ElementalBehatTestAdmin $requestHandler, string|SilverStripe\Forms\Tests\GridField\GridFieldDetailFormTest\TestController $popupFormName): void
     {
         $this->gridField = $gridField;
         $this->component = $component;
@@ -107,7 +107,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
         parent::__construct();
     }
 
-    public function Link($action = null)
+    public function Link(string $action = null): string
     {
         return Controller::join_links(
             $this->gridField->Link('item'),
@@ -120,7 +120,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      * @param HTTPRequest $request
      * @return mixed
      */
-    public function view($request)
+    public function view(SilverStripe\Control\HTTPRequest $request): SilverStripe\View\ViewableData_Customised
     {
         if (!$this->record->canView()) {
             $this->httpError(403, _t(
@@ -152,7 +152,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      * @param HTTPRequest $request
      * @return mixed
      */
-    public function edit($request)
+    public function edit(SilverStripe\Control\HTTPRequest $request): null|SilverStripe\ORM\FieldType\DBHTMLText
     {
         $controller = $this->getToplevelController();
         $form = $this->ItemEditForm();
@@ -183,7 +183,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      *
      * @return Form|HTTPResponse
      */
-    public function ItemEditForm()
+    public function ItemEditForm(): SilverStripe\Forms\Form
     {
         $list = $this->gridField->getList();
 
@@ -292,7 +292,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      *
      * @return array
      */
-    protected function getCreateContext()
+    protected function getCreateContext(): array
     {
         $gridField = $this->gridField;
         $context = [];
@@ -308,7 +308,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
     /**
      * @return CompositeField Returns the right aligned toolbar group field along with its FormAction's
      */
-    protected function getRightGroupField()
+    protected function getRightGroupField(): SilverStripe\Forms\CompositeField
     {
         $rightGroup = CompositeField::create()->setName('RightGroup');
         $rightGroup->addExtraClass('ml-auto');
@@ -380,7 +380,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      *
      * @return FieldList
      */
-    protected function getFormActions()
+    protected function getFormActions(): SilverStripe\Forms\FieldList
     {
         $manager = $this->getStateManager();
 
@@ -446,7 +446,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      *
      * @return Controller
      */
-    protected function getToplevelController()
+    protected function getToplevelController(): SilverStripe\FrameworkTest\Elemental\Admin\ElementalBehatTestAdmin
     {
         $c = $this->popupController;
         while ($c && $c instanceof GridFieldDetailForm_ItemRequest) {
@@ -455,7 +455,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
         return $c;
     }
 
-    protected function getBackLink()
+    protected function getBackLink(): string
     {
         // TODO Coupling with CMS
         $backlink = '';
@@ -488,7 +488,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      * @param SS_List $list
      * @return array List of data to write to the relation
      */
-    protected function getExtraSavedData($record, $list)
+    protected function getExtraSavedData(SilverStripe\FrameworkTest\Elemental\Model\ElementalBehatTestObject $record, SilverStripe\ORM\DataList $list): null|array
     {
         // Skip extra data if not ManyManyList
         if (!($list instanceof ManyManyList)) {
@@ -505,7 +505,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
         return $data;
     }
 
-    public function doSave($data, $form)
+    public function doSave(array $data, SilverStripe\Forms\Form $form): string|null|SilverStripe\ORM\FieldType\DBHTMLText
     {
         $isNewRecord = $this->record->ID == 0;
 
@@ -546,7 +546,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      * @param  int $id The ID of the record in the GridField
      * @return string
      */
-    public function getEditLink($id)
+    public function getEditLink(int $id): string
     {
         $link = Controller::join_links(
             $this->gridField->Link(),
@@ -561,7 +561,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      * @param int $offset The offset from the current record
      * @return int|bool
      */
-    private function getAdjacentRecordID($offset)
+    private function getAdjacentRecordID(int $offset): bool|int
     {
         $gridField = $this->getGridField();
         $list = $gridField->getManipulatedList();
@@ -592,7 +592,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      *
      * @return int
      */
-    public function getPreviousRecordID()
+    public function getPreviousRecordID(): bool|int
     {
         return $this->getAdjacentRecordID(-1);
     }
@@ -602,7 +602,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      *
      * @return int
      */
-    public function getNextRecordID()
+    public function getNextRecordID(): bool|int
     {
         return $this->getAdjacentRecordID(1);
     }
@@ -613,7 +613,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      * @param bool $isNewRecord True if this record was just created
      * @return HTTPResponse|DBHTMLText
      */
-    protected function redirectAfterSave($isNewRecord)
+    protected function redirectAfterSave(bool $isNewRecord): string|null|SilverStripe\ORM\FieldType\DBHTMLText
     {
         $controller = $this->getToplevelController();
         if ($isNewRecord) {
@@ -651,7 +651,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      * @throws ValidationException On error
      * @return DataObject Saved record
      */
-    protected function saveFormIntoRecord($data, $form)
+    protected function saveFormIntoRecord(array $data, SilverStripe\Forms\Form $form): SilverStripe\FrameworkTest\Elemental\Model\ElementalBehatTestObject
     {
         $list = $this->gridField->getList();
 
@@ -685,7 +685,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      * @return HTTPResponse
      * @throws ValidationException
      */
-    public function doDelete($data, $form)
+    public function doDelete(array $data, SilverStripe\Forms\Form $form): string
     {
         $title = $this->record->Title;
         if (!$this->record->canDelete()) {
@@ -723,7 +723,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      * @param string $template
      * @return $this
      */
-    public function setTemplate($template)
+    public function setTemplate($template): Symbiote\GridFieldExtensions\GridFieldAddNewMultiClassHandler
     {
         $this->template = $template;
         return $this;
@@ -732,7 +732,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
     /**
      * @return string
      */
-    public function getTemplate()
+    public function getTemplate(): null
     {
         return $this->template;
     }
@@ -742,7 +742,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      *
      * @return array
      */
-    public function getTemplates()
+    public function getTemplates(): array
     {
         $templates = SSViewer::get_templates_by_class($this, '', __CLASS__);
         // Prefer any custom template
@@ -755,7 +755,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
     /**
      * @return Controller
      */
-    public function getController()
+    public function getController(): SilverStripe\FrameworkTest\Elemental\Admin\ElementalBehatTestAdmin
     {
         return $this->popupController;
     }
@@ -763,7 +763,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
     /**
      * @return GridField
      */
-    public function getGridField()
+    public function getGridField(): SilverStripe\Forms\GridField\GridField
     {
         return $this->gridField;
     }
@@ -771,7 +771,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
     /**
      * @return DataObject
      */
-    public function getRecord()
+    public function getRecord(): SilverStripe\FrameworkTest\Elemental\Model\ElementalBehatTestObject
     {
         return $this->record;
     }
@@ -784,7 +784,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      * @param boolean $unlinked
      * @return ArrayList
      */
-    public function Breadcrumbs($unlinked = false)
+    public function Breadcrumbs(bool $unlinked = false): SilverStripe\ORM\ArrayList|null
     {
         if (!$this->popupController->hasMethod('Breadcrumbs')) {
             return null;

--- a/src/Forms/GridField/GridFieldEditButton.php
+++ b/src/Forms/GridField/GridFieldEditButton.php
@@ -36,7 +36,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
     /**
      * @inheritdoc
      */
-    public function getTitle($gridField, $record, $columnName)
+    public function getTitle(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Security\Member $record, string $columnName): string
     {
         return _t(__CLASS__ . '.EDIT', "Edit");
     }
@@ -44,7 +44,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
     /**
      * @inheritdoc
      */
-    public function getGroup($gridField, $record, $columnName)
+    public function getGroup(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Security\Member $record, string $columnName): string
     {
         return GridField_ActionMenuItem::DEFAULT_GROUP;
     }
@@ -52,7 +52,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
     /**
      * @inheritdoc
      */
-    public function getExtraData($gridField, $record, $columnName)
+    public function getExtraData(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Security\Member $record, string $columnName): array
     {
         return [
             "classNames" => "font-icon-edit action-detail edit-link"
@@ -62,7 +62,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
     /**
      * @inheritdoc
      */
-    public function getUrl($gridField, $record, $columnName, $addState = true)
+    public function getUrl(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\UserForms\Model\EditableFormField\EditableFormStep $record, string $columnName, bool $addState = true): string
     {
         $link = Controller::join_links(
             $gridField->Link('item'),
@@ -83,7 +83,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
      * @param GridField $gridField
      * @param array $columns
      */
-    public function augmentColumns($gridField, &$columns)
+    public function augmentColumns(SilverStripe\Forms\GridField\GridField $gridField, &$columns): void
     {
         if (!in_array('Actions', $columns ?? [])) {
             $columns[] = 'Actions';
@@ -98,7 +98,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
      * @param string $columnName
      * @return array
      */
-    public function getColumnAttributes($gridField, $record, $columnName)
+    public function getColumnAttributes(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\UserForms\Model\EditableFormField\EditableFormStep $record, string $columnName): array
     {
         return ['class' => 'grid-field__col-compact'];
     }
@@ -110,7 +110,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
      * @param string $columnName
      * @return array
      */
-    public function getColumnMetadata($gridField, $columnName)
+    public function getColumnMetadata(SilverStripe\Forms\GridField\GridField $gridField, string $columnName): array
     {
         if ($columnName == 'Actions') {
             return ['title' => ''];
@@ -124,7 +124,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
      * @param GridField $gridField
      * @return array
      */
-    public function getColumnsHandled($gridField)
+    public function getColumnsHandled(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return ['Actions'];
     }
@@ -135,7 +135,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
      * @param GridField $gridField
      * @return array
      */
-    public function getActions($gridField)
+    public function getActions(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return [];
     }
@@ -146,7 +146,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
      * @param string $columnName
      * @return string The HTML for the column
      */
-    public function getColumnContent($gridField, $record, $columnName)
+    public function getColumnContent(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\UserForms\Model\EditableFormField\EditableFormStep $record, string $columnName): SilverStripe\ORM\FieldType\DBHTMLText
     {
         // No permission checks, handled through GridFieldDetailForm,
         // which can make the form readonly if no edit permissions are available.
@@ -165,7 +165,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
      *
      * @return string
      */
-    public function getExtraClass()
+    public function getExtraClass(): string
     {
         return implode(' ', array_keys($this->extraClass ?? []));
     }
@@ -176,7 +176,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
      * @param string $class
      * @return $this
      */
-    public function addExtraClass($class)
+    public function addExtraClass(string $class): SilverStripe\Forms\GridField\GridFieldEditButton
     {
         $this->extraClass[$class] = true;
 
@@ -189,7 +189,7 @@ class GridFieldEditButton extends AbstractGridFieldComponent implements GridFiel
      * @param string $class
      * @return $this
      */
-    public function removeExtraClass($class)
+    public function removeExtraClass(string $class): SilverStripe\Forms\GridField\GridFieldEditButton
     {
         unset($this->extraClass[$class]);
 

--- a/src/Forms/GridField/GridFieldExportButton.php
+++ b/src/Forms/GridField/GridFieldExportButton.php
@@ -53,7 +53,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
      * @param string $targetFragment The HTML fragment to write the button into
      * @param array $exportColumns The columns to include in the export
      */
-    public function __construct($targetFragment = "after", $exportColumns = null)
+    public function __construct(string $targetFragment = "after", $exportColumns = null): void
     {
         $this->targetFragment = $targetFragment;
         $this->exportColumns = $exportColumns;
@@ -66,7 +66,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
      *
      * @return array
      */
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         $button = new GridField_FormAction(
             $gridField,
@@ -89,7 +89,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
      *
      * @return array
      */
-    public function getActions($gridField)
+    public function getActions(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return ['export'];
     }
@@ -109,7 +109,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
      *
      * @return array
      */
-    public function getURLHandlers($gridField)
+    public function getURLHandlers(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return [
             'export' => 'handleExport',
@@ -142,7 +142,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
      *
      * @return array
      */
-    protected function getExportColumnsForGridField(GridField $gridField)
+    protected function getExportColumnsForGridField(GridField $gridField): array
     {
         if ($this->exportColumns) {
             return $this->exportColumns;
@@ -164,7 +164,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
      *
      * @return string
      */
-    public function generateExportFileData($gridField)
+    public function generateExportFileData(SilverStripe\Forms\GridField\GridField $gridField): string
     {
         $csvColumns = $this->getExportColumnsForGridField($gridField);
 
@@ -275,7 +275,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
     /**
      * @return array
      */
-    public function getExportColumns()
+    public function getExportColumns(): array
     {
         return $this->exportColumns;
     }
@@ -285,7 +285,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
      *
      * @return $this
      */
-    public function setExportColumns($cols)
+    public function setExportColumns(array $cols): SilverStripe\Forms\GridField\GridFieldExportButton
     {
         $this->exportColumns = $cols;
         return $this;
@@ -294,7 +294,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
     /**
      * @return string
      */
-    public function getCsvSeparator()
+    public function getCsvSeparator(): string
     {
         return $this->csvSeparator;
     }
@@ -313,7 +313,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
     /**
      * @return string
      */
-    public function getCsvEnclosure()
+    public function getCsvEnclosure(): string
     {
         return $this->csvEnclosure;
     }
@@ -332,7 +332,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
     /**
      * @return boolean
      */
-    public function getCsvHasHeader()
+    public function getCsvHasHeader(): bool
     {
         return $this->csvHasHeader;
     }
@@ -342,7 +342,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
      *
      * @return $this
      */
-    public function setCsvHasHeader($bool)
+    public function setCsvHasHeader(bool $bool): SilverStripe\Forms\GridField\GridFieldExportButton
     {
         $this->csvHasHeader = $bool;
         return $this;

--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -79,7 +79,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
     /**
      * @inheritDoc
      */
-    public function getURLHandlers($gridField)
+    public function getURLHandlers(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return [
             'GET schema/SearchForm' => 'getSearchFormSchema'
@@ -92,10 +92,10 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
      * @param callable|null $updateSearchForm This will be removed in 5.0
      */
     public function __construct(
-        $useLegacy = false,
+        bool $useLegacy = false,
         callable $updateSearchContext = null,
         callable $updateSearchForm = null
-    ) {
+    ): void {
         $this->useLegacyFilterHeader = Config::inst()->get(self::class, 'force_legacy') || $useLegacy;
         $this->updateSearchContextCallback = $updateSearchContext;
         $this->updateSearchFormCallback = $updateSearchForm;
@@ -112,7 +112,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
      *
      * @param bool $throwExceptionOnBadDataType
      */
-    public function setThrowExceptionOnBadDataType($throwExceptionOnBadDataType)
+    public function setThrowExceptionOnBadDataType(bool $throwExceptionOnBadDataType): void
     {
         $this->throwExceptionOnBadDataType = $throwExceptionOnBadDataType;
     }
@@ -132,7 +132,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
      * @param SS_List $dataList
      * @return bool
      */
-    protected function checkDataType($dataList)
+    protected function checkDataType(SilverStripe\ORM\DataList $dataList): bool
     {
         if ($dataList instanceof Filterable) {
             return true;
@@ -152,7 +152,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
      * @param GridField $gridField
      * @return array
      */
-    public function getActions($gridField)
+    public function getActions(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         if (!$this->checkDataType($gridField->getList())) {
             return [];
@@ -169,7 +169,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
      * @param array $data
      * @return void
      */
-    public function handleAction(GridField $gridField, $actionName, $arguments, $data)
+    public function handleAction(GridField $gridField, string $actionName, array $arguments, array|string $data): void
     {
         if (!$this->checkDataType($gridField->getList())) {
             return;
@@ -205,7 +205,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
     /**
      * @inheritDoc
      */
-    public function getManipulatedData(GridField $gridField, SS_List $dataList)
+    public function getManipulatedData(GridField $gridField, SS_List $dataList): SilverStripe\ORM\DataList
     {
         if (!$this->checkDataType($dataList)) {
             return $dataList;
@@ -231,7 +231,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
      * @param GridField $gridField
      * @return boolean
      */
-    public function canFilterAnyColumns($gridField)
+    public function canFilterAnyColumns(SilverStripe\Forms\GridField\GridField $gridField): bool
     {
         $list = $gridField->getList();
 
@@ -259,7 +259,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
      * @param GridField $gridfield
      * @return \SilverStripe\ORM\Search\SearchContext
      */
-    public function getSearchContext(GridField $gridField)
+    public function getSearchContext(GridField $gridField): SilverStripe\ORM\Search\SearchContext
     {
         if (!$this->searchContext) {
             $this->searchContext = singleton($gridField->getModelClass())->getDefaultSearchContext();
@@ -278,7 +278,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
      * @param GridField $gridfield
      * @return string
      */
-    public function getSearchFieldSchema(GridField $gridField)
+    public function getSearchFieldSchema(GridField $gridField): string
     {
         $schemaUrl = Controller::join_links($gridField->Link(), 'schema/SearchForm');
 
@@ -328,7 +328,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
      * @param GridField $gridField
      * @return Form|null
      */
-    public function getSearchForm(GridField $gridField)
+    public function getSearchForm(GridField $gridField): null|SilverStripe\Forms\Form
     {
         $searchContext = $this->getSearchContext($gridField);
         $searchFields = $searchContext->getSearchFields();
@@ -393,7 +393,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
      * @param GridField $gridfield
      * @return HTTPResponse
      */
-    public function getSearchFormSchema(GridField $gridField)
+    public function getSearchFormSchema(GridField $gridField): SilverStripe\Control\HTTPResponse
     {
         $form = $this->getSearchForm($gridField);
 
@@ -419,7 +419,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
      * @param GridField $gridfield
      * @return ArrayList|null
      */
-    public function getLegacyFilterHeader(GridField $gridField)
+    public function getLegacyFilterHeader(GridField $gridField): SilverStripe\ORM\ArrayList
     {
         Deprecation::notice('5.0', 'Table row based filter header will be removed in favor of search field in 5.0');
 
@@ -494,7 +494,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
      * @param GridField $gridField
      * @return array|null
      */
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): array|null
     {
         $forTemplate = new ArrayData([]);
 

--- a/src/Forms/GridField/GridFieldFooter.php
+++ b/src/Forms/GridField/GridFieldFooter.php
@@ -40,7 +40,7 @@ class GridFieldFooter extends AbstractGridFieldComponent implements GridField_HT
      * @param string $message A message to display in the footer
      * @param bool $showrecordcount
      */
-    public function __construct($message = null, $showrecordcount = true)
+    public function __construct($message = null, $showrecordcount = true): void
     {
         if ($message) {
             $this->message = $message;
@@ -49,7 +49,7 @@ class GridFieldFooter extends AbstractGridFieldComponent implements GridField_HT
     }
 
 
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         $count = $gridField->getList()->count();
 

--- a/src/Forms/GridField/GridFieldGroupDeleteAction.php
+++ b/src/Forms/GridField/GridFieldGroupDeleteAction.php
@@ -20,7 +20,7 @@ class GridFieldGroupDeleteAction extends GridFieldDeleteAction
      */
     protected $groupID;
 
-    public function __construct($groupID)
+    public function __construct(int $groupID): void
     {
         $this->groupID = $groupID;
         parent::__construct(true);
@@ -33,7 +33,7 @@ class GridFieldGroupDeleteAction extends GridFieldDeleteAction
      * @param string $columnName
      * @return string the HTML for the column
      */
-    public function getColumnContent($gridField, $record, $columnName)
+    public function getColumnContent(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Security\Member $record, string $columnName): null|SilverStripe\ORM\FieldType\DBHTMLText
     {
         if ($this->canUnlink($record)) {
             return parent::getColumnContent($gridField, $record, $columnName);
@@ -48,7 +48,7 @@ class GridFieldGroupDeleteAction extends GridFieldDeleteAction
      * @param $columnName
      * @return null|string
      */
-    public function getGroup($gridField, $record, $columnName)
+    public function getGroup(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Security\Member $record, string $columnName): null|string
     {
         if (!$this->canUnlink($record)) {
             return null;
@@ -66,7 +66,7 @@ class GridFieldGroupDeleteAction extends GridFieldDeleteAction
      * @param array $data Form data
      * @throws ValidationException
      */
-    public function handleAction(GridField $gridField, $actionName, $arguments, $data)
+    public function handleAction(GridField $gridField, string $actionName, array $arguments, array $data): void
     {
         $record = $gridField->getList()->find('ID', $arguments['RecordID']);
 
@@ -84,7 +84,7 @@ class GridFieldGroupDeleteAction extends GridFieldDeleteAction
      * @param $record - the record of the User to unlink with
      * @return bool
      */
-    protected function canUnlink($record)
+    protected function canUnlink(SilverStripe\Security\Member $record): bool
     {
         $currentUser = Security::getCurrentUser();
         if ($currentUser

--- a/src/Forms/GridField/GridFieldImportButton.php
+++ b/src/Forms/GridField/GridFieldImportButton.php
@@ -35,7 +35,7 @@ class GridFieldImportButton extends AbstractGridFieldComponent implements GridFi
     /**
      * @param string $targetFragment The HTML fragment to write the button into
      */
-    public function __construct($targetFragment = "after")
+    public function __construct(string $targetFragment = "after"): void
     {
         $this->targetFragment = $targetFragment;
     }
@@ -46,7 +46,7 @@ class GridFieldImportButton extends AbstractGridFieldComponent implements GridFi
      * @param GridField $gridField
      * @return array
      */
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         $modalID = $gridField->ID() . '_ImportModal';
 
@@ -104,7 +104,7 @@ class GridFieldImportButton extends AbstractGridFieldComponent implements GridFi
     /**
      * @return string
      */
-    public function getModalTitle()
+    public function getModalTitle(): string
     {
         return $this->modalTitle;
     }
@@ -113,7 +113,7 @@ class GridFieldImportButton extends AbstractGridFieldComponent implements GridFi
      * @param string $modalTitle
      * @return $this
      */
-    public function setModalTitle($modalTitle)
+    public function setModalTitle(string $modalTitle): SilverStripe\Forms\GridField\GridFieldImportButton
     {
         $this->modalTitle = $modalTitle;
         return $this;
@@ -122,7 +122,7 @@ class GridFieldImportButton extends AbstractGridFieldComponent implements GridFi
     /**
      * @return Form
      */
-    public function getImportForm()
+    public function getImportForm(): SilverStripe\Forms\Form|null
     {
         return $this->importForm;
     }
@@ -131,7 +131,7 @@ class GridFieldImportButton extends AbstractGridFieldComponent implements GridFi
      * @param Form $importForm
      * @return $this
      */
-    public function setImportForm($importForm)
+    public function setImportForm(SilverStripe\Forms\Form|bool $importForm): SilverStripe\Forms\GridField\GridFieldImportButton
     {
         $this->importForm = $importForm;
         return $this;
@@ -140,7 +140,7 @@ class GridFieldImportButton extends AbstractGridFieldComponent implements GridFi
     /**
      * @return string
      */
-    public function getImportIframe()
+    public function getImportIframe(): null|string
     {
         return $this->importIframe;
     }
@@ -149,7 +149,7 @@ class GridFieldImportButton extends AbstractGridFieldComponent implements GridFi
      * @param string $importIframe
      * @return $this
      */
-    public function setImportIframe($importIframe)
+    public function setImportIframe(string $importIframe): SilverStripe\Forms\GridField\GridFieldImportButton
     {
         $this->importIframe = $importIframe;
         return $this;

--- a/src/Forms/GridField/GridFieldLazyLoader.php
+++ b/src/Forms/GridField/GridFieldLazyLoader.php
@@ -24,7 +24,7 @@ class GridFieldLazyLoader extends AbstractGridFieldComponent implements GridFiel
      * @param SS_List $dataList
      * @return SS_List
      */
-    public function getManipulatedData(GridField $gridField, SS_List $dataList)
+    public function getManipulatedData(GridField $gridField, SS_List $dataList): SilverStripe\ORM\ArrayList
     {
         // If we are lazy loading an empty the list
         if ($this->isLazy($gridField)) {
@@ -45,7 +45,7 @@ class GridFieldLazyLoader extends AbstractGridFieldComponent implements GridFiel
      * @param GridField $gridField
      * @return array
      */
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         $gridField->addExtraClass($this->isLazy($gridField) ?
             'grid-field--lazy-loadable' :
@@ -58,7 +58,7 @@ class GridFieldLazyLoader extends AbstractGridFieldComponent implements GridFiel
      * @param GridField $gridField
      * @return bool
      */
-    private function isLazy(GridField $gridField)
+    private function isLazy(GridField $gridField): bool
     {
         return
             $gridField->getRequest()->getHeader('X-Pjax') !== 'CurrentField' &&
@@ -70,7 +70,7 @@ class GridFieldLazyLoader extends AbstractGridFieldComponent implements GridFiel
      * @param FormField $field
      * @return bool
      */
-    private function isInTabSet(FormField $field)
+    private function isInTabSet(FormField $field): bool
     {
         $list = $field->getContainerFieldList();
         if ($list && $containerField = $list->getContainerField()) {

--- a/src/Forms/GridField/GridFieldPageCount.php
+++ b/src/Forms/GridField/GridFieldPageCount.php
@@ -24,7 +24,7 @@ class GridFieldPageCount extends AbstractGridFieldComponent implements GridField
     /**
      * @param string $targetFragment The fragment indicating the placement of this page count
      */
-    public function __construct($targetFragment = 'before')
+    public function __construct(string $targetFragment = 'before'): void
     {
         $this->targetFragment = $targetFragment;
     }
@@ -44,7 +44,7 @@ class GridFieldPageCount extends AbstractGridFieldComponent implements GridField
      * @return GridFieldPaginator The attached GridFieldPaginator, if found.
      * @throws LogicException
      */
-    protected function getPaginator($gridField)
+    protected function getPaginator(SilverStripe\Forms\GridField\GridField $gridField): SilverStripe\Forms\GridField\GridFieldPaginator
     {
         /** @var GridFieldPaginator $paginator */
         $paginator = $gridField->getConfig()->getComponentByType(GridFieldPaginator::class);
@@ -62,7 +62,7 @@ class GridFieldPageCount extends AbstractGridFieldComponent implements GridField
      * @param GridField $gridField
      * @return array
      */
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): null|array
     {
         // Retrieve paging parameters from the directing paginator component
         $paginator = $this->getPaginator($gridField);

--- a/src/Forms/GridField/GridFieldPaginator.php
+++ b/src/Forms/GridField/GridFieldPaginator.php
@@ -40,7 +40,7 @@ class GridFieldPaginator extends AbstractGridFieldComponent implements GridField
      *
      * @param int $itemsPerPage - How many items should be displayed per page
      */
-    public function __construct($itemsPerPage = null)
+    public function __construct(int $itemsPerPage = null): void
     {
         $this->itemsPerPage = $itemsPerPage
             ?: GridFieldPaginator::config()->uninherited('default_items_per_page');
@@ -58,7 +58,7 @@ class GridFieldPaginator extends AbstractGridFieldComponent implements GridField
      * @param bool $throwExceptionOnBadDataType
      * @return $this
      */
-    public function setThrowExceptionOnBadDataType($throwExceptionOnBadDataType)
+    public function setThrowExceptionOnBadDataType(bool $throwExceptionOnBadDataType): SilverStripe\Forms\GridField\GridFieldPaginator
     {
         $this->throwExceptionOnBadDataType = $throwExceptionOnBadDataType;
         return $this;
@@ -81,7 +81,7 @@ class GridFieldPaginator extends AbstractGridFieldComponent implements GridField
      * @param SS_List $dataList
      * @return bool
      */
-    protected function checkDataType($dataList)
+    protected function checkDataType(SilverStripe\ORM\DataList $dataList): bool
     {
         if ($dataList instanceof Limitable) {
             return true;
@@ -100,7 +100,7 @@ class GridFieldPaginator extends AbstractGridFieldComponent implements GridField
      * @param GridField $gridField
      * @return array
      */
-    public function getActions($gridField)
+    public function getActions(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         if (!$this->checkDataType($gridField->getList())) {
             return [];
@@ -138,7 +138,7 @@ class GridFieldPaginator extends AbstractGridFieldComponent implements GridField
      * @param GridField $gridField
      * @return GridState_Data
      */
-    protected function getGridPagerState(GridField $gridField)
+    protected function getGridPagerState(GridField $gridField): SilverStripe\Forms\GridField\GridState_Data
     {
         return $gridField->State->GridFieldPaginator;
     }
@@ -157,7 +157,7 @@ class GridFieldPaginator extends AbstractGridFieldComponent implements GridField
      * @param SS_List $dataList
      * @return SS_List
      */
-    public function getManipulatedData(GridField $gridField, SS_List $dataList)
+    public function getManipulatedData(GridField $gridField, SS_List $dataList): SilverStripe\ORM\DataList
     {
         if (!$this->checkDataType($dataList)) {
             return $dataList;
@@ -202,7 +202,7 @@ class GridFieldPaginator extends AbstractGridFieldComponent implements GridField
      *  <li>LastPage (optional):        GridField_FormAction - Button to go to last page</li>
      * </ul>
      */
-    public function getTemplateParameters(GridField $gridField)
+    public function getTemplateParameters(GridField $gridField): SilverStripe\View\ArrayData|null
     {
         if (!$this->checkDataType($gridField->getList())) {
             return null;
@@ -309,7 +309,7 @@ class GridFieldPaginator extends AbstractGridFieldComponent implements GridField
      * @param GridField $gridField
      * @return array
      */
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): array|null
     {
         $forTemplate = $this->getTemplateParameters($gridField);
         if (!$forTemplate) {
@@ -328,7 +328,7 @@ class GridFieldPaginator extends AbstractGridFieldComponent implements GridField
      * @param int $num
      * @return $this
      */
-    public function setItemsPerPage($num)
+    public function setItemsPerPage(int $num): SilverStripe\Forms\GridField\GridFieldPaginator
     {
         $this->itemsPerPage = $num;
         return $this;
@@ -337,7 +337,7 @@ class GridFieldPaginator extends AbstractGridFieldComponent implements GridField
     /**
      * @return Int
      */
-    public function getItemsPerPage()
+    public function getItemsPerPage(): int
     {
         return $this->itemsPerPage;
     }

--- a/src/Forms/GridField/GridFieldPrintButton.php
+++ b/src/Forms/GridField/GridFieldPrintButton.php
@@ -44,7 +44,7 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
      * @param string $targetFragment The HTML fragment to write the button into
      * @param array $printColumns The columns to include in the print view
      */
-    public function __construct($targetFragment = "after", $printColumns = null)
+    public function __construct(string $targetFragment = "after", $printColumns = null): void
     {
         $this->targetFragment = $targetFragment;
         $this->printColumns = $printColumns;
@@ -57,7 +57,7 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
      *
      * @return array
      */
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         $button = new GridField_FormAction(
             $gridField,
@@ -82,7 +82,7 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
      *
      * @return array
      */
-    public function getActions($gridField)
+    public function getActions(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return ['print'];
     }
@@ -96,7 +96,7 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
      * @param array $data
      * @return DBHTMLText
      */
-    public function handleAction(GridField $gridField, $actionName, $arguments, $data)
+    public function handleAction(GridField $gridField, string $actionName, array $arguments, array $data): SilverStripe\ORM\FieldType\DBHTMLText
     {
         if ($actionName == 'print') {
             return $this->handlePrint($gridField);
@@ -109,7 +109,7 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
      * @param GridField $gridField
      * @return array
      */
-    public function getURLHandlers($gridField)
+    public function getURLHandlers(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return [
             'print' => 'handlePrint',
@@ -123,7 +123,7 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
      * @param HTTPRequest $request
      * @return DBHTMLText
      */
-    public function handlePrint($gridField, $request = null)
+    public function handlePrint(SilverStripe\Forms\GridField\GridField $gridField, $request = null): SilverStripe\ORM\FieldType\DBHTMLText
     {
         set_time_limit(60);
         Requirements::clear();
@@ -149,7 +149,7 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
      *
      * @return array
      */
-    protected function getPrintColumnsForGridField(GridField $gridField)
+    protected function getPrintColumnsForGridField(GridField $gridField): array
     {
         if ($this->printColumns) {
             return $this->printColumns;
@@ -171,7 +171,7 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
      *
      * @return array
      */
-    public function getTitle(GridField $gridField)
+    public function getTitle(GridField $gridField): string
     {
         $form = $gridField->getForm();
         $currentController = $gridField->getForm()->getController();
@@ -204,7 +204,7 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
      * @param GridField $gridField
      * @return ArrayData
      */
-    public function generatePrintData(GridField $gridField)
+    public function generatePrintData(GridField $gridField): SilverStripe\View\ArrayData
     {
         $printColumns = $this->getPrintColumnsForGridField($gridField);
 
@@ -271,7 +271,7 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
      * @param array $cols
      * @return $this
      */
-    public function setPrintColumns($cols)
+    public function setPrintColumns(array $cols): SilverStripe\Forms\GridField\GridFieldPrintButton
     {
         $this->printColumns = $cols;
 
@@ -290,7 +290,7 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
      * @param bool $bool
      * @return $this
      */
-    public function setPrintHasHeader($bool)
+    public function setPrintHasHeader(bool $bool): SilverStripe\Forms\GridField\GridFieldPrintButton
     {
         $this->printHasHeader = $bool;
 

--- a/src/Forms/GridField/GridFieldSortableHeader.php
+++ b/src/Forms/GridField/GridFieldSortableHeader.php
@@ -45,7 +45,7 @@ class GridFieldSortableHeader extends AbstractGridFieldComponent implements Grid
      * @param bool $throwExceptionOnBadDataType
      * @return $this
      */
-    public function setThrowExceptionOnBadDataType($throwExceptionOnBadDataType)
+    public function setThrowExceptionOnBadDataType(bool $throwExceptionOnBadDataType): SilverStripe\Forms\GridField\GridFieldSortableHeader
     {
         $this->throwExceptionOnBadDataType = $throwExceptionOnBadDataType;
         return $this;
@@ -68,7 +68,7 @@ class GridFieldSortableHeader extends AbstractGridFieldComponent implements Grid
      * @param SS_List $dataList
      * @return bool
      */
-    protected function checkDataType($dataList)
+    protected function checkDataType(SilverStripe\ORM\DataList $dataList): bool
     {
         if ($dataList instanceof Sortable) {
             return true;
@@ -89,7 +89,7 @@ class GridFieldSortableHeader extends AbstractGridFieldComponent implements Grid
      * @param array $sorting
      * @return $this
      */
-    public function setFieldSorting($sorting)
+    public function setFieldSorting(array $sorting): SilverStripe\Forms\GridField\GridFieldSortableHeader
     {
         $this->fieldSorting = $sorting;
         return $this;
@@ -109,7 +109,7 @@ class GridFieldSortableHeader extends AbstractGridFieldComponent implements Grid
      * @param GridField $gridField
      * @return array
      */
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         $list = $gridField->getList();
         if (!$this->checkDataType($list)) {
@@ -221,7 +221,7 @@ class GridFieldSortableHeader extends AbstractGridFieldComponent implements Grid
      * @param GridField $gridField
      * @return array
      */
-    public function getActions($gridField)
+    public function getActions(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         if (!$this->checkDataType($gridField->getList())) {
             return [];
@@ -230,7 +230,7 @@ class GridFieldSortableHeader extends AbstractGridFieldComponent implements Grid
         return ['sortasc', 'sortdesc'];
     }
 
-    public function handleAction(GridField $gridField, $actionName, $arguments, $data)
+    public function handleAction(GridField $gridField, string $actionName, array $arguments, array $data): void
     {
         if (!$this->checkDataType($gridField->getList())) {
             return;
@@ -259,7 +259,7 @@ class GridFieldSortableHeader extends AbstractGridFieldComponent implements Grid
      * @param SS_List $dataList
      * @return SS_List
      */
-    public function getManipulatedData(GridField $gridField, SS_List $dataList)
+    public function getManipulatedData(GridField $gridField, SS_List $dataList): SilverStripe\ORM\DataList
     {
         if (!$this->checkDataType($dataList)) {
             return $dataList;

--- a/src/Forms/GridField/GridFieldToolbarHeader.php
+++ b/src/Forms/GridField/GridFieldToolbarHeader.php
@@ -17,7 +17,7 @@ class GridFieldToolbarHeader extends AbstractGridFieldComponent implements GridF
      * @param GridField $gridField
      * @return array
      */
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         $templates = SSViewer::get_templates_by_class($this, '', __CLASS__);
         return [

--- a/src/Forms/GridField/GridFieldViewButton.php
+++ b/src/Forms/GridField/GridFieldViewButton.php
@@ -16,7 +16,7 @@ class GridFieldViewButton extends AbstractGridFieldComponent implements GridFiel
     /**
      * @inheritdoc
      */
-    public function getTitle($gridField, $record, $columnName)
+    public function getTitle(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Forms\Tests\GridField\GridFieldDetailFormTest\Category $record, string $columnName): string
     {
         return _t(__CLASS__ . '.VIEW', "View");
     }
@@ -24,7 +24,7 @@ class GridFieldViewButton extends AbstractGridFieldComponent implements GridFiel
     /**
      * @inheritdoc
      */
-    public function getGroup($gridField, $record, $columnName)
+    public function getGroup(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Forms\Tests\GridField\GridFieldDetailFormTest\Category $record, string $columnName): string
     {
         return GridField_ActionMenuItem::DEFAULT_GROUP;
     }
@@ -32,7 +32,7 @@ class GridFieldViewButton extends AbstractGridFieldComponent implements GridFiel
     /**
      * @inheritdoc
      */
-    public function getExtraData($gridField, $record, $columnName)
+    public function getExtraData(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Forms\Tests\GridField\GridFieldDetailFormTest\Category $record, string $columnName): array
     {
         return [
             "classNames" => "font-icon-eye action-detail view-link"
@@ -42,24 +42,24 @@ class GridFieldViewButton extends AbstractGridFieldComponent implements GridFiel
     /**
      * @inheritdoc
      */
-    public function getUrl($gridField, $record, $columnName)
+    public function getUrl(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Forms\Tests\GridField\GridFieldDetailFormTest\Person $record, string $columnName): string
     {
         return Controller::join_links($gridField->Link('item'), $record->ID, 'view');
     }
 
-    public function augmentColumns($field, &$columns)
+    public function augmentColumns(SilverStripe\Comments\Admin\CommentsGridField $field, &$columns): void
     {
         if (!in_array('Actions', $columns ?? [])) {
             $columns[] = 'Actions';
         }
     }
 
-    public function getColumnsHandled($field)
+    public function getColumnsHandled(SilverStripe\Comments\Admin\CommentsGridField $field): array
     {
         return ['Actions'];
     }
 
-    public function getColumnContent($field, $record, $col)
+    public function getColumnContent(SilverStripe\Forms\GridField\GridField $field, SilverStripe\Forms\Tests\GridField\GridFieldDetailFormTest\Person $record, string $col): SilverStripe\ORM\FieldType\DBHTMLText
     {
         if (!$record->canView()) {
             return null;
@@ -71,12 +71,12 @@ class GridFieldViewButton extends AbstractGridFieldComponent implements GridFiel
         return $data->renderWith($template);
     }
 
-    public function getColumnAttributes($field, $record, $col)
+    public function getColumnAttributes(SilverStripe\Forms\GridField\GridField $field, SilverStripe\Forms\Tests\GridField\GridFieldDetailFormTest\Person $record, string $col): array
     {
         return ['class' => 'grid-field__col-compact'];
     }
 
-    public function getColumnMetadata($gridField, $col)
+    public function getColumnMetadata(SilverStripe\Comments\Admin\CommentsGridField $gridField, string $col): array
     {
         return ['title' => null];
     }

--- a/src/Forms/GridField/GridField_ActionMenu.php
+++ b/src/Forms/GridField/GridField_ActionMenu.php
@@ -10,19 +10,19 @@ use SilverStripe\View\SSViewer;
  */
 class GridField_ActionMenu extends AbstractGridFieldComponent implements GridField_ColumnProvider, GridField_ActionProvider
 {
-    public function augmentColumns($gridField, &$columns)
+    public function augmentColumns(SilverStripe\Forms\GridField\GridField $gridField, &$columns): void
     {
         if (!in_array('Actions', $columns ?? [])) {
             $columns[] = 'Actions';
         }
     }
 
-    public function getColumnsHandled($gridField)
+    public function getColumnsHandled(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return ['Actions'];
     }
 
-    public function getColumnContent($gridField, $record, $columnName)
+    public function getColumnContent(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Security\Member $record, string $columnName): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $items = $this->getItems($gridField);
 
@@ -55,17 +55,17 @@ class GridField_ActionMenu extends AbstractGridFieldComponent implements GridFie
         return $templateData->renderWith($template);
     }
 
-    public function getColumnAttributes($gridField, $record, $columnName)
+    public function getColumnAttributes(SilverStripe\Forms\GridField\GridField $gridField, SilverStripe\Security\Member $record, string $columnName): array
     {
         return ['class' => 'grid-field__col-compact action-menu'];
     }
 
-    public function getColumnMetadata($gridField, $columnName)
+    public function getColumnMetadata(SilverStripe\Forms\GridField\GridField $gridField, string $columnName): array
     {
         return ['title' => null];
     }
 
-    public function getActions($gridField)
+    public function getActions(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         $actions = [];
 
@@ -78,7 +78,7 @@ class GridField_ActionMenu extends AbstractGridFieldComponent implements GridFie
         return $actions;
     }
 
-    public function handleAction(GridField $gridField, $actionName, $arguments, $data)
+    public function handleAction(GridField $gridField, string $actionName, array $arguments, array $data): void
     {
         foreach ($this->getItems($gridField) as $item) {
             $actions = [];
@@ -97,7 +97,7 @@ class GridField_ActionMenu extends AbstractGridFieldComponent implements GridFie
      *
      * @return array
      */
-    public function getItems($gridfield)
+    public function getItems(SilverStripe\Forms\GridField\GridField $gridfield): array
     {
         $items = $gridfield->config->getComponentsByType(GridField_ActionMenuItem::class)->items;
 

--- a/src/Forms/GridField/GridField_FormAction.php
+++ b/src/Forms/GridField/GridField_FormAction.php
@@ -51,7 +51,7 @@ class GridField_FormAction extends FormAction
      * @param string $actionName
      * @param array $args
      */
-    public function __construct(GridField $gridField, $name, $title, $actionName, $args)
+    public function __construct(GridField $gridField, string $name, string|bool $title, string $actionName, array|string|int $args): void
     {
         $this->gridField = $gridField;
         $this->actionName = $actionName;
@@ -85,7 +85,7 @@ class GridField_FormAction extends FormAction
     /**
      * @return array
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         // Determine the state that goes with this action
         $state = [
@@ -124,7 +124,7 @@ class GridField_FormAction extends FormAction
      *
      * @return string
      */
-    protected function getNameFromParent()
+    protected function getNameFromParent(): string
     {
         $base = $this->gridField;
         $name = [];

--- a/src/Forms/GridField/GridState.php
+++ b/src/Forms/GridField/GridState.php
@@ -31,7 +31,7 @@ class GridState extends HiddenField
      * @param GridField $grid
      * @param string $value JSON encoded string
      */
-    public function __construct($grid, $value = null)
+    public function __construct(SilverStripe\Forms\GridField\GridField $grid, $value = null): void
     {
         $this->grid = $grid;
 
@@ -57,7 +57,7 @@ class GridState extends HiddenField
         return $d;
     }
 
-    public function setValue($value, $data = null)
+    public function setValue(string $value, $data = null): SilverStripe\Forms\GridField\GridState
     {
         // Apply the value on top of the existing defaults
         $data = json_decode($value ?? '', true);
@@ -82,7 +82,7 @@ class GridState extends HiddenField
     /**
      * @return GridState_Data
      */
-    public function getData()
+    public function getData(): SilverStripe\Forms\GridField\GridState_Data
     {
         if (!$this->data) {
             $this->data = new GridState_Data();
@@ -104,7 +104,7 @@ class GridState extends HiddenField
      *
      * @return string
      */
-    public function Value()
+    public function Value(): string
     {
         $data = $this->data ? $this->data->getChangesArray() : [];
         return json_encode($data, JSON_FORCE_OBJECT);

--- a/src/Forms/GridField/GridState_Component.php
+++ b/src/Forms/GridField/GridState_Component.php
@@ -8,7 +8,7 @@ namespace SilverStripe\Forms\GridField;
 class GridState_Component extends AbstractGridFieldComponent implements GridField_HTMLProvider
 {
 
-    public function getHTMLFragments($gridField)
+    public function getHTMLFragments(SilverStripe\Forms\GridField\GridField $gridField): array
     {
         return [
             'before' => $gridField->getState(false)->Field()

--- a/src/Forms/GridField/GridState_Data.php
+++ b/src/Forms/GridField/GridState_Data.php
@@ -18,17 +18,17 @@ class GridState_Data
 
     protected $defaults = [];
 
-    public function __construct($data = [])
+    public function __construct(array $data = []): void
     {
         $this->data = $data;
     }
 
-    public function __get($name)
+    public function __get(string $name): SilverStripe\Forms\GridField\GridState_Data|null|int|bool|string|float
     {
         return $this->getData($name, new self());
     }
 
-    public function __call($name, $arguments)
+    public function __call(string $name, array $arguments): null|string|int|bool|SilverStripe\Forms\GridField\GridState_Data
     {
         // Assume first parameter is default value
         if (empty($arguments)) {
@@ -61,7 +61,7 @@ class GridState_Data
      * @param mixed $default Default value to assign if not set. Note that this *will* be included in getChangesArray()
      * @return mixed The value associated with this key, or the value specified by $default if not set
      */
-    public function getData($name, $default = null)
+    public function getData(string $name, SilverStripe\Forms\GridField\GridState_Data|string|int|array|bool $default = null): SilverStripe\Forms\GridField\GridState_Data|null|string|int|array|bool|float
     {
         if (!array_key_exists($name, $this->data ?? [])) {
             $this->data[$name] = $default;
@@ -74,22 +74,22 @@ class GridState_Data
         return $this->data[$name];
     }
 
-    public function __set($name, $value)
+    public function __set(string $name, int|bool|array|string|float $value): void
     {
         $this->data[$name] = $value;
     }
 
-    public function __isset($name)
+    public function __isset(string $name): bool
     {
         return isset($this->data[$name]);
     }
 
-    public function __unset($name)
+    public function __unset(string $name): void
     {
         unset($this->data[$name]);
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         if (!$this->data) {
             return "";
@@ -101,7 +101,7 @@ class GridState_Data
     /**
      * Return all data, including defaults, as array
      */
-    public function toArray()
+    public function toArray(): array
     {
         $output = [];
 

--- a/src/Forms/GroupedDropdownField.php
+++ b/src/Forms/GroupedDropdownField.php
@@ -67,7 +67,7 @@ class GroupedDropdownField extends DropdownField
      * @param string|array $titleOrOptions Title of item, or options in grouip
      * @return ArrayData Data for this item
      */
-    protected function getFieldOption($valueOrGroup, $titleOrOptions)
+    protected function getFieldOption(string|int $valueOrGroup, string|array $titleOrOptions): SilverStripe\View\ArrayData
     {
         // Return flat option
         if (!is_array($titleOrOptions)) {
@@ -86,12 +86,12 @@ class GroupedDropdownField extends DropdownField
         ]);
     }
 
-    public function Type()
+    public function Type(): string
     {
         return 'groupeddropdown dropdown';
     }
 
-    public function getSourceValues()
+    public function getSourceValues(): array
     {
         // Flatten values
         $values = [];
@@ -109,7 +109,7 @@ class GroupedDropdownField extends DropdownField
     /**
      * @return SingleLookupField
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\SingleLookupField
     {
         $field = parent::performReadonlyTransformation();
         $field->setSource(ArrayLib::flatten($this->getSource()));

--- a/src/Forms/HTMLEditor/HTMLEditorConfig.php
+++ b/src/Forms/HTMLEditor/HTMLEditorConfig.php
@@ -75,7 +75,7 @@ abstract class HTMLEditorConfig
      * @return static The configuration object.
      * This will be created if it does not yet exist for that identifier
      */
-    public static function get($identifier = null)
+    public static function get(string $identifier = null): SilverStripe\Forms\HTMLEditor\TinyMCEConfig
     {
         if (!$identifier) {
             return static::get_active();
@@ -95,7 +95,7 @@ abstract class HTMLEditorConfig
      * @param HTMLEditorConfig $config Config to set, or null to clear
      * @return HTMLEditorConfig The assigned config
      */
-    public static function set_config($identifier, HTMLEditorConfig $config = null)
+    public static function set_config(string $identifier, HTMLEditorConfig $config = null): SilverStripe\Forms\HTMLEditor\TinyMCEConfig|null
     {
         if ($config) {
             self::$configs[$identifier] = $config;
@@ -110,7 +110,7 @@ abstract class HTMLEditorConfig
      * Gets the current themes, if it is not set this will fallback to config
      * @return array
      */
-    public static function getThemes()
+    public static function getThemes(): array
     {
         if (isset(static::$current_themes)) {
             return static::$current_themes;
@@ -123,7 +123,7 @@ abstract class HTMLEditorConfig
      *
      * @param array $themes
      */
-    public static function setThemes($themes)
+    public static function setThemes(array $themes): void
     {
         static::$current_themes = $themes;
     }
@@ -134,7 +134,7 @@ abstract class HTMLEditorConfig
      *
      * @param string $identifier The identifier for the config set
      */
-    public static function set_active_identifier($identifier)
+    public static function set_active_identifier(string $identifier): void
     {
         self::$current = $identifier;
     }
@@ -145,7 +145,7 @@ abstract class HTMLEditorConfig
      *
      * @return string The active configuration identifier
      */
-    public static function get_active_identifier()
+    public static function get_active_identifier(): string
     {
         $identifier = self::$current ?: static::config()->get('default_config');
         return $identifier;
@@ -156,7 +156,7 @@ abstract class HTMLEditorConfig
      *
      * @return HTMLEditorConfig The active configuration object
      */
-    public static function get_active()
+    public static function get_active(): SilverStripe\Forms\HTMLEditor\TinyMCEConfig
     {
         $identifier = self::get_active_identifier();
         return self::get($identifier);
@@ -168,7 +168,7 @@ abstract class HTMLEditorConfig
      * @param HTMLEditorConfig $config
      * @return HTMLEditorConfig The given config
      */
-    public static function set_active(HTMLEditorConfig $config)
+    public static function set_active(HTMLEditorConfig $config): SilverStripe\Forms\HTMLEditor\TinyMCEConfig
     {
         $identifier = static::get_active_identifier();
         return static::set_config($identifier, $config);
@@ -180,7 +180,7 @@ abstract class HTMLEditorConfig
      *
      * @return array
      */
-    public static function get_available_configs_map()
+    public static function get_available_configs_map(): array
     {
         $configs = [];
 
@@ -232,7 +232,7 @@ abstract class HTMLEditorConfig
      *
      * @return array
      */
-    public function getConfigSchemaData()
+    public function getConfigSchemaData(): array
     {
         return [
             'attributes' => $this->getAttributes(),

--- a/src/Forms/HTMLEditor/HTMLEditorField.php
+++ b/src/Forms/HTMLEditor/HTMLEditorField.php
@@ -69,7 +69,7 @@ class HTMLEditorField extends TextareaField
      *
      * @return HTMLEditorConfig
      */
-    public function getEditorConfig()
+    public function getEditorConfig(): SilverStripe\Forms\HTMLEditor\TinyMCEConfig
     {
         // Instance override
         if ($this->editorConfig instanceof HTMLEditorConfig) {
@@ -101,7 +101,7 @@ class HTMLEditorField extends TextareaField
      * @param mixed $value The value of the field.
      * @param string $config HTMLEditorConfig identifier to be used. Default to the active one.
      */
-    public function __construct($name, $title = null, $value = '', $config = null)
+    public function __construct(string $name, string|bool $title = null, string $value = '', $config = null): void
     {
         parent::__construct($name, $title, $value);
 
@@ -112,7 +112,7 @@ class HTMLEditorField extends TextareaField
         $this->setRows(HTMLEditorField::config()->default_rows);
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         // Fix CSS height based on rows
         $rowHeight = $this->config()->get('fixed_row_height');
@@ -134,7 +134,7 @@ class HTMLEditorField extends TextareaField
      * @param DataObject|DataObjectInterface $record
      * @throws Exception
      */
-    public function saveInto(DataObjectInterface $record)
+    public function saveInto(DataObjectInterface $record): void
     {
         if ($record->hasField($this->name) && $record->escapeTypeForField($this->name) != 'xml') {
             throw new Exception(
@@ -156,7 +156,7 @@ class HTMLEditorField extends TextareaField
         $record->{$this->name} = $htmlValue->getContent();
     }
 
-    public function setValue($value, $data = null)
+    public function setValue(string $value, array|DNADesign\Elemental\Models\ElementContent $data = null): SilverStripe\Forms\HTMLEditor\HTMLEditorField
     {
         // Regenerate links prior to preview, so that the editor can see them.
         $value = ImageShortcodeProvider::regenerate_html_links($value);
@@ -166,24 +166,24 @@ class HTMLEditorField extends TextareaField
     /**
      * @return HTMLEditorField_Readonly
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\HTMLEditor\HTMLEditorField_Readonly
     {
         return $this->castedCopy(HTMLEditorField_Readonly::class);
     }
 
-    public function performDisabledTransformation()
+    public function performDisabledTransformation(): SilverStripe\Forms\HTMLEditor\HTMLEditorField_Readonly
     {
         return $this->performReadonlyTransformation();
     }
 
-    public function Field($properties = [])
+    public function Field($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         // Include requirements
         $this->getEditorConfig()->init();
         return parent::Field($properties);
     }
 
-    public function getSchemaStateDefaults()
+    public function getSchemaStateDefaults(): array
     {
         $stateDefaults = parent::getSchemaStateDefaults();
         $config = $this->getEditorConfig();

--- a/src/Forms/HTMLEditor/HTMLEditorField_Readonly.php
+++ b/src/Forms/HTMLEditor/HTMLEditorField_Readonly.php
@@ -13,7 +13,7 @@ class HTMLEditorField_Readonly extends HTMLReadonlyField
         'Value' => 'HTMLText',
     ];
 
-    public function Type()
+    public function Type(): string
     {
         return 'htmleditorfield readonly';
     }

--- a/src/Forms/HTMLEditor/HTMLEditorSanitiser.php
+++ b/src/Forms/HTMLEditor/HTMLEditorSanitiser.php
@@ -49,7 +49,7 @@ class HTMLEditorSanitiser
      *
      * @param HTMLEditorConfig $config
      */
-    public function __construct(HTMLEditorConfig $config)
+    public function __construct(HTMLEditorConfig $config): void
     {
         $valid = $config->getOption('valid_elements');
         if ($valid) {
@@ -68,7 +68,7 @@ class HTMLEditorSanitiser
      * @param $str - The TinyMCE pattern
      * @return string - The equivalent regex
      */
-    protected function patternToRegex($str)
+    protected function patternToRegex(string $str): string
     {
         return '/^' . preg_replace('/([?+*])/', '.$1', $str ?? '') . '$/';
     }
@@ -81,7 +81,7 @@ class HTMLEditorSanitiser
      *
      * @param string $validElements - The valid_elements or extended_valid_elements string to add to the whitelist
      */
-    protected function addValidElements($validElements)
+    protected function addValidElements(string $validElements): void
     {
         $elementRuleRegExp = '/^([#+\-])?([^\[\/]+)(?:\/([^\[]+))?(?:\[([^\]]+)\])?$/';
         $attrRuleRegExp = '/^([!\-])?(\w+::\w+|[^=:<]+)?(?:([=:<])(.*))?$/';
@@ -186,7 +186,7 @@ class HTMLEditorSanitiser
      * @param string $tag The element tag
      * @return stdClass The element rule
      */
-    protected function getRuleForElement($tag)
+    protected function getRuleForElement(string $tag): stdClass|null
     {
         if (isset($this->elements[$tag])) {
             return $this->elements[$tag];
@@ -206,7 +206,7 @@ class HTMLEditorSanitiser
      * @param string $name The attribute name
      * @return stdClass The attribute rule
      */
-    protected function getRuleForAttribute($elementRule, $name)
+    protected function getRuleForAttribute(stdClass $elementRule, string $name): stdClass|null
     {
         if (isset($elementRule->attributes[$name])) {
             return $elementRule->attributes[$name];
@@ -225,7 +225,7 @@ class HTMLEditorSanitiser
      * @param stdClass $rule The rule to check against
      * @return bool True if the element passes (and so can be kept), false if it fails (and so needs stripping)
      */
-    protected function elementMatchesRule($element, $rule = null)
+    protected function elementMatchesRule(DOMElement $element, stdClass $rule = null): bool
     {
         // If the rule doesn't exist at all, the element isn't allowed
         if (!$rule) {
@@ -263,7 +263,7 @@ class HTMLEditorSanitiser
      * @param stdClass $rule - the rule to check against
      * @return bool - true if the attribute passes (and so can be kept), false if it fails (and so needs stripping)
      */
-    protected function attributeMatchesRule($attr, $rule = null)
+    protected function attributeMatchesRule(DOMAttr $attr, stdClass $rule = null): bool
     {
         // If the rule doesn't exist at all, the attribute isn't allowed
         if (!$rule) {
@@ -285,7 +285,7 @@ class HTMLEditorSanitiser
      *
      * @param HTMLValue $html - The HTMLValue to remove any non-whitelisted elements & attributes from
      */
-    public function sanitise(HTMLValue $html)
+    public function sanitise(HTMLValue $html): void
     {
         if (!$this->elements && !$this->elementPatterns) {
             return;
@@ -370,7 +370,7 @@ class HTMLEditorSanitiser
      * @param DOMElement $el
      * @param string|null $linkRelValue
      */
-    private function addRelValue(DOMElement $el, $linkRelValue)
+    private function addRelValue(DOMElement $el, string $linkRelValue): void
     {
         // user has checked the checkbox 'open link in new window'
         if ($el->getAttribute('target') && $el->getAttribute('rel') !== $linkRelValue) {

--- a/src/Forms/HTMLEditor/TinyMCECombinedGenerator.php
+++ b/src/Forms/HTMLEditor/TinyMCECombinedGenerator.php
@@ -37,7 +37,7 @@ class TinyMCECombinedGenerator implements TinyMCEScriptGenerator, Flushable
      * @param GeneratedAssetHandler $assetHandler
      * @return $this
      */
-    public function setAssetHandler(GeneratedAssetHandler $assetHandler)
+    public function setAssetHandler(GeneratedAssetHandler $assetHandler): SilverStripe\Forms\HTMLEditor\TinyMCECombinedGenerator
     {
         $this->assetHandler = $assetHandler;
         return $this;
@@ -47,7 +47,7 @@ class TinyMCECombinedGenerator implements TinyMCEScriptGenerator, Flushable
      * Get backend for assets
      * @return GeneratedAssetHandler
      */
-    public function getAssetHandler()
+    public function getAssetHandler(): SilverStripe\Assets\Flysystem\GeneratedAssets
     {
         return $this->assetHandler;
     }
@@ -58,7 +58,7 @@ class TinyMCECombinedGenerator implements TinyMCEScriptGenerator, Flushable
      * @param TinyMCEConfig $config
      * @return string
      */
-    public function getScriptURL(TinyMCEConfig $config)
+    public function getScriptURL(TinyMCEConfig $config): string
     {
         // Build URL for this config based on named config and hash of settings
         $url = $this->generateFilename($config);
@@ -75,7 +75,7 @@ class TinyMCECombinedGenerator implements TinyMCEScriptGenerator, Flushable
      * @param TinyMCEConfig $config
      * @return string
      */
-    public function generateContent(TinyMCEConfig $config)
+    public function generateContent(TinyMCEConfig $config): string
     {
         $tinymceDir = $config->getTinyMCEResource();
 
@@ -182,7 +182,7 @@ SCRIPT;
      * @param string|ModuleResource $file File to load.
      * @return string File contents or empty string if it doesn't exist.
      */
-    protected function getFileContents($file)
+    protected function getFileContents(SilverStripe\Core\Manifest\ModuleResource|string $file): string
     {
         if ($file instanceof ModuleResource) {
             $path = $file->getPath();
@@ -208,7 +208,7 @@ SCRIPT;
      * @param TinyMCEConfig $config
      * @return string
      */
-    protected function checkName(TinyMCEConfig $config)
+    protected function checkName(TinyMCEConfig $config): string
     {
         $configs = HTMLEditorConfig::get_available_configs_map();
         foreach ($configs as $id => $name) {
@@ -225,7 +225,7 @@ SCRIPT;
      * @param TinyMCEConfig $config
      * @return mixed
      */
-    public function generateFilename(TinyMCEConfig $config)
+    public function generateFilename(TinyMCEConfig $config): string
     {
         $hash = substr(sha1(json_encode($config->getAttributes()) ?? ''), 0, 10);
         $name = $this->checkName($config);
@@ -244,7 +244,7 @@ SCRIPT;
      *
      * @see FlushMiddleware
      */
-    public static function flush()
+    public static function flush(): void
     {
         $dir = dirname(static::config()->get('filename_base') ?? '');
         static::singleton()->getAssetHandler()->removeContent($dir);
@@ -257,7 +257,7 @@ SCRIPT;
      * @param string $resource
      * @return ModuleResource|string
      */
-    protected function resolveRelativeResource($base, $resource)
+    protected function resolveRelativeResource(SilverStripe\Core\Manifest\ModuleResource|string $base, string $resource): null|SilverStripe\Core\Manifest\ModuleResource|string
     {
         // Return resource path based on relative resource path
         foreach (['', '.min.js', '.js'] as $ext) {
@@ -281,7 +281,7 @@ SCRIPT;
      * @param string|ModuleResource $resource
      * @return bool
      */
-    protected function resourceExists($resource)
+    protected function resourceExists(SilverStripe\Core\Manifest\ModuleResource|string $resource): bool
     {
         if (!$resource) {
             return false;

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -311,7 +311,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      *
      * @return string
      */
-    public function getTheme()
+    public function getTheme(): string
     {
         return $this->theme;
     }
@@ -322,7 +322,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      * @param string $theme
      * @return $this
      */
-    public function setTheme($theme)
+    public function setTheme(string $theme): SilverStripe\Forms\HTMLEditor\TinyMCEConfig
     {
         $this->theme = $theme;
         return $this;
@@ -350,7 +350,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
         3 => []
     ];
 
-    public function getOption($key)
+    public function getOption(string $key): null|string
     {
         if (isset($this->settings[$key])) {
             return $this->settings[$key];
@@ -358,13 +358,13 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
         return null;
     }
 
-    public function setOption($key, $value)
+    public function setOption(string $key, string|array|bool $value): SilverStripe\Forms\HTMLEditor\TinyMCEConfig
     {
         $this->settings[$key] = $value;
         return $this;
     }
 
-    public function setOptions($options)
+    public function setOptions(array $options): SilverStripe\Forms\HTMLEditor\TinyMCEConfig
     {
         foreach ($options as $key => $value) {
             $this->settings[$key] = $value;
@@ -377,12 +377,12 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      *
      * @return array
      */
-    protected function getSettings()
+    protected function getSettings(): array
     {
         return $this->settings;
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return [
             'data-editor' => 'tinyMCE', // Register ss.editorWrappers.tinyMCE
@@ -411,7 +411,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      * @param string|array ...$plugin a string, or several strings, or a single array of strings - The plugins to enable
      * @return $this
      */
-    public function enablePlugins($plugin)
+    public function enablePlugins(array|string $plugin): SilverStripe\Forms\HTMLEditor\TinyMCEConfig
     {
         $plugins = func_get_args();
         if (is_array(current($plugins ?? []))) {
@@ -435,7 +435,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      * @param string|array ...$plugin a string, or several strings, or a single array of strings - The plugins to enable
      * @return $this
      */
-    public function disablePlugins($plugin)
+    public function disablePlugins(string|array $plugin): SilverStripe\Forms\HTMLEditor\TinyMCEConfig
     {
         $plugins = func_get_args();
         if (is_array(current($plugins ?? []))) {
@@ -454,7 +454,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      *
      * @return array
      */
-    public function getPlugins()
+    public function getPlugins(): array
     {
         return $this->plugins;
     }
@@ -466,7 +466,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      *
      * @return array
      */
-    public function getInternalPlugins()
+    public function getInternalPlugins(): array
     {
         // Return only plugins with no custom url
         $plugins = [];
@@ -483,7 +483,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      *
      * @return array
      */
-    public function getButtons()
+    public function getButtons(): array
     {
         return array_filter($this->buttons ?? []);
     }
@@ -513,7 +513,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      * The button names to add to this line
      * @return $this
      */
-    public function addButtonsToLine($line, $buttons)
+    public function addButtonsToLine(int $line, string $buttons): SilverStripe\Forms\HTMLEditor\TinyMCEConfig
     {
         if (func_num_args() > 2) {
             $buttons = func_get_args();
@@ -538,7 +538,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      * or null for no insertion
      * @return bool True if $name matched a button, false otherwise
      */
-    protected function modifyButtons($name, $offset, $del = 0, $add = null)
+    protected function modifyButtons(string $name, int $offset, int $del = 0, array $add = null): bool
     {
         foreach ($this->buttons as &$buttons) {
             if (($idx = array_search($name, $buttons ?? [])) !== false) {
@@ -560,7 +560,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      * The button names to insert before that button
      * @return bool True if insertion occurred, false if it did not (because the given button name was not found)
      */
-    public function insertButtonsBefore($before, $buttons)
+    public function insertButtonsBefore(string $before, string $buttons): bool
     {
         if (func_num_args() > 2) {
             $buttons = func_get_args();
@@ -579,7 +579,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      * The button names to insert after that button
      * @return bool True if insertion occurred, false if it did not (because the given button name was not found)
      */
-    public function insertButtonsAfter($after, $buttons)
+    public function insertButtonsAfter(string $after, string $buttons): bool
     {
         if (func_num_args() > 2) {
             $buttons = func_get_args();
@@ -595,7 +595,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      * Remove the first occurrence of buttons
      * @param string|string[] $buttons,... An array of strings, or one or more strings. The button names to remove.
      */
-    public function removeButtons($buttons)
+    public function removeButtons(string $buttons): void
     {
         if (func_num_args() > 1) {
             $buttons = func_get_args();
@@ -615,7 +615,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      *
      * @return array
      */
-    protected function getConfig()
+    protected function getConfig(): array
     {
         $settings = $this->getSettings();
 
@@ -719,7 +719,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      *
      * @return array
      */
-    protected function getEditorCSS()
+    protected function getEditorCSS(): array
     {
         $editor = [];
         $resourceLoader = ModuleResourceLoader::singleton();
@@ -737,7 +737,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      *
      * @return string[]
      */
-    public function getContentCSS()
+    public function getContentCSS(): array
     {
         // Prioritise instance specific content
         if (isset($this->contentCSS)) {
@@ -772,7 +772,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      * e.g. `silverstripe/admin:client/dist/styles/editor.css`
      * @return $this
      */
-    public function setContentCSS($css)
+    public function setContentCSS(array $css): SilverStripe\Forms\HTMLEditor\TinyMCEConfig
     {
         $this->contentCSS = $css;
         return $this;
@@ -786,20 +786,20 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      * @return string
      * @throws Exception
      */
-    public function getScriptURL()
+    public function getScriptURL(): string
     {
         /** @var TinyMCEScriptGenerator $generator */
         $generator = Injector::inst()->get(TinyMCEScriptGenerator::class);
         return $generator->getScriptURL($this);
     }
 
-    public function init()
+    public function init(): void
     {
         // include TinyMCE Javascript
         Requirements::javascript($this->getScriptURL());
     }
 
-    public function getConfigSchemaData()
+    public function getConfigSchemaData(): array
     {
         $data = parent::getConfigSchemaData();
         $data['editorjs'] = $this->getScriptURL();
@@ -811,7 +811,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      *
      * @return string Language
      */
-    public static function get_tinymce_lang()
+    public static function get_tinymce_lang(): string
     {
         $lang = static::config()->get('tinymce_lang');
         $locale = i18n::get_locale();
@@ -861,7 +861,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
      * @return ModuleResource|string
      * @throws Exception
      */
-    public function getTinyMCEResource()
+    public function getTinyMCEResource(): SilverStripe\Core\Manifest\ModuleResource|string
     {
         $configDir = static::config()->get('base_dir');
         if ($configDir) {
@@ -908,7 +908,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
         return $this;
     }
 
-    public function provideI18nEntities()
+    public function provideI18nEntities(): array
     {
         $entities = [
             self::class . '.PIXEL_WIDTH' => '{width} pixels',

--- a/src/Forms/HTMLReadonlyField.php
+++ b/src/Forms/HTMLReadonlyField.php
@@ -22,7 +22,7 @@ class HTMLReadonlyField extends ReadonlyField
      */
     protected $schemaComponent = 'HtmlReadonlyField';
 
-    public function Field($properties = [])
+    public function Field($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         return $this->renderWith($this->getTemplates());
     }
@@ -32,7 +32,7 @@ class HTMLReadonlyField extends ReadonlyField
      *
      * @return string Raw HTML
      */
-    public function ValueEntities()
+    public function ValueEntities(): string
     {
         return htmlentities($this->Value() ?? '', ENT_COMPAT, 'UTF-8');
     }

--- a/src/Forms/HeaderField.php
+++ b/src/Forms/HeaderField.php
@@ -30,7 +30,7 @@ class HeaderField extends DatalessField
      * @param string $title
      * @param int $headingLevel
      */
-    public function __construct($name, $title = null, $headingLevel = 2)
+    public function __construct(string $name, string|bool $title = null, int $headingLevel = 2): void
     {
         $this->setHeadingLevel($headingLevel);
         parent::__construct($name, $title);
@@ -39,7 +39,7 @@ class HeaderField extends DatalessField
     /**
      * @return int
      */
-    public function getHeadingLevel()
+    public function getHeadingLevel(): int
     {
         return $this->headingLevel;
     }
@@ -49,7 +49,7 @@ class HeaderField extends DatalessField
      *
      * @return $this
      */
-    public function setHeadingLevel($headingLevel)
+    public function setHeadingLevel(int $headingLevel): SilverStripe\Forms\HeaderField
     {
         $this->headingLevel = $headingLevel;
 
@@ -59,7 +59,7 @@ class HeaderField extends DatalessField
     /**
      * {@inheritdoc}
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return array_merge(
             parent::getAttributes(),
@@ -75,7 +75,7 @@ class HeaderField extends DatalessField
     /**
      * @return null
      */
-    public function Type()
+    public function Type(): null
     {
         return null;
     }
@@ -85,7 +85,7 @@ class HeaderField extends DatalessField
      *
      * @return array
      */
-    public function getSchemaStateDefaults()
+    public function getSchemaStateDefaults(): array
     {
         $state = parent::getSchemaStateDefaults();
 
@@ -99,7 +99,7 @@ class HeaderField extends DatalessField
      *
      * @return array
      */
-    public function getSchemaDataDefaults()
+    public function getSchemaDataDefaults(): array
     {
         $data = parent::getSchemaDataDefaults();
 

--- a/src/Forms/HiddenField.php
+++ b/src/Forms/HiddenField.php
@@ -16,7 +16,7 @@ class HiddenField extends FormField
      * @param array $properties
      * @return string
      */
-    public function FieldHolder($properties = [])
+    public function FieldHolder($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         return $this->Field($properties);
     }
@@ -24,7 +24,7 @@ class HiddenField extends FormField
     /**
      * @return static
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\HiddenField
     {
         $clone = clone $this;
 

--- a/src/Forms/LabelField.php
+++ b/src/Forms/LabelField.php
@@ -18,7 +18,7 @@ class LabelField extends DatalessField
      * @param string $name
      * @param null|string $title
      */
-    public function __construct($name, $title = null)
+    public function __construct(string $name, string $title = null): void
     {
         // legacy handling:
         // $title, $headingLevel...

--- a/src/Forms/ListboxField.php
+++ b/src/Forms/ListboxField.php
@@ -52,7 +52,7 @@ class ListboxField extends MultiSelectField
      * @param string|array|null $value You can pass an array of values or a single value like a drop down to be selected
      * @param int $size Optional size of the select element
      */
-    public function __construct($name, $title = '', $source = [], $value = null, $size = null)
+    public function __construct(string $name, string|bool $title = '', array|SilverStripe\ORM\Map $source = [], $value = null, $size = null): void
     {
         if ($size) {
             $this->setSize($size);
@@ -67,7 +67,7 @@ class ListboxField extends MultiSelectField
      * @param array $properties
      * @return string
      */
-    public function Field($properties = [])
+    public function Field($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $properties = array_merge($properties, [
             'Options' => $this->getOptions(),
@@ -81,7 +81,7 @@ class ListboxField extends MultiSelectField
      *
      * @return ArrayList
      */
-    public function getOptions()
+    public function getOptions(): SilverStripe\ORM\ArrayList
     {
         // Loop through and figure out which values were selected.
         $options = [];
@@ -104,7 +104,7 @@ class ListboxField extends MultiSelectField
         return $options;
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return array_merge(
             parent::getAttributes(),
@@ -121,7 +121,7 @@ class ListboxField extends MultiSelectField
      *
      * @return integer
      */
-    public function getSize()
+    public function getSize(): null
     {
         return $this->size;
     }
@@ -132,7 +132,7 @@ class ListboxField extends MultiSelectField
      * @param int $size The height in rows (e.g. 3)
      * @return $this Self reference
      */
-    public function setSize($size)
+    public function setSize(int $size): SilverStripe\Forms\ListboxField
     {
         $this->size = $size;
         return $this;
@@ -145,7 +145,7 @@ class ListboxField extends MultiSelectField
      * @param array $items Collection of array keys, as defined in the $source array
      * @return $this Self reference
      */
-    public function setDisabledItems($items)
+    public function setDisabledItems(array $items): SilverStripe\Forms\ListboxField
     {
         $this->disabledItems = $items;
         return $this;
@@ -154,7 +154,7 @@ class ListboxField extends MultiSelectField
     /**
      * @return array
      */
-    public function getDisabledItems()
+    public function getDisabledItems(): array
     {
         return $this->disabledItems;
     }

--- a/src/Forms/LiteralField.php
+++ b/src/Forms/LiteralField.php
@@ -38,7 +38,7 @@ class LiteralField extends DatalessField
      * @param string $name
      * @param string|FormField $content
      */
-    public function __construct($name, $content)
+    public function __construct(string $name, string|SilverStripe\ORM\FieldType\DBHTMLText|bool $content): void
     {
         $this->setContent($content);
 
@@ -50,7 +50,7 @@ class LiteralField extends DatalessField
      *
      * @return string
      */
-    public function FieldHolder($properties = [])
+    public function FieldHolder(array $properties = []): string|null
     {
         if ($this->content instanceof ViewableData) {
             $context = $this->content;
@@ -70,7 +70,7 @@ class LiteralField extends DatalessField
      *
      * @return string
      */
-    public function Field($properties = [])
+    public function Field($properties = []): string|null
     {
         return $this->FieldHolder($properties);
     }
@@ -82,7 +82,7 @@ class LiteralField extends DatalessField
      *
      * @return $this
      */
-    public function setContent($content)
+    public function setContent(string|SilverStripe\ORM\FieldType\DBHTMLText|bool $content): SilverStripe\Forms\LiteralField
     {
         $this->content = $content;
 
@@ -92,7 +92,7 @@ class LiteralField extends DatalessField
     /**
      * @return string
      */
-    public function getContent()
+    public function getContent(): string|SilverStripe\ORM\FieldType\DBHTMLText
     {
         return $this->content;
     }
@@ -114,7 +114,7 @@ class LiteralField extends DatalessField
     /**
      * @return static
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\LiteralField
     {
         $clone = clone $this;
 
@@ -128,7 +128,7 @@ class LiteralField extends DatalessField
      *
      * @return array
      */
-    public function getSchemaStateDefaults()
+    public function getSchemaStateDefaults(): array
     {
         $state = parent::getSchemaStateDefaults();
         $state['value'] = $this->FieldHolder();

--- a/src/Forms/LookupField.php
+++ b/src/Forms/LookupField.php
@@ -30,7 +30,7 @@ class LookupField extends MultiSelectField
      *
      * @return string
      */
-    public function Field($properties = [])
+    public function Field($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $source = ArrayLib::flatten($this->getSource());
         $values = $this->getValueArray();
@@ -72,7 +72,7 @@ class LookupField extends MultiSelectField
      * @param Validator $validator
      * @return bool
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Forms\RequiredFields $validator): bool
     {
         return true;
     }

--- a/src/Forms/MoneyField.php
+++ b/src/Forms/MoneyField.php
@@ -43,7 +43,7 @@ class MoneyField extends FormField
      *
      * @return FormField
      */
-    public function getCurrencyField()
+    public function getCurrencyField(): SilverStripe\Forms\TextField
     {
         return $this->fieldCurrency;
     }
@@ -53,12 +53,12 @@ class MoneyField extends FormField
      *
      * @return NumericField
      */
-    public function getAmountField()
+    public function getAmountField(): SilverStripe\Forms\NumericField
     {
         return $this->fieldAmount;
     }
 
-    public function __construct($name, $title = null, $value = "")
+    public function __construct(string $name, string $title = null, array|SilverStripe\ORM\FieldType\DBMoney $value = ""): void
     {
         $this->setName($name);
         $this->fieldAmount = NumericField::create(
@@ -71,7 +71,7 @@ class MoneyField extends FormField
         parent::__construct($name, $title, $value);
     }
 
-    public function __clone()
+    public function __clone(): void
     {
         $this->fieldAmount = clone $this->fieldAmount;
         $this->fieldCurrency = clone $this->fieldCurrency;
@@ -82,7 +82,7 @@ class MoneyField extends FormField
      *
      * @return FormField
      */
-    protected function buildCurrencyField()
+    protected function buildCurrencyField(): SilverStripe\Forms\TextField
     {
         $name = $this->getName();
 
@@ -118,7 +118,7 @@ class MoneyField extends FormField
         return $field;
     }
 
-    public function setSubmittedValue($value, $data = null)
+    public function setSubmittedValue(array $value, array $data = null): SilverStripe\Forms\MoneyField
     {
         if (empty($value)) {
             $this->value = null;
@@ -141,7 +141,7 @@ class MoneyField extends FormField
         return $this;
     }
 
-    public function setValue($value, $data = null)
+    public function setValue(array|SilverStripe\ORM\FieldType\DBMoney|string $value, array $data = null): SilverStripe\Forms\MoneyField
     {
         if (empty($value)) {
             $this->value = null;
@@ -181,7 +181,7 @@ class MoneyField extends FormField
      *
      * @return DBMoney
      */
-    protected function getDBMoney()
+    protected function getDBMoney(): SilverStripe\ORM\FieldType\DBMoney
     {
         return DBMoney::create_field('Money', [
             'Currency' => $this->fieldCurrency->dataValue(),
@@ -190,13 +190,13 @@ class MoneyField extends FormField
             ->setLocale($this->getLocale());
     }
 
-    public function dataValue()
+    public function dataValue(): string|float
     {
         // Non-localised money
         return $this->getDBMoney()->getValue();
     }
 
-    public function Value()
+    public function Value(): string
     {
         // Localised money
         return $this->getDBMoney()->Nice();
@@ -213,7 +213,7 @@ class MoneyField extends FormField
      *
      * @param DataObjectInterface|Object $dataObject
      */
-    public function saveInto(DataObjectInterface $dataObject)
+    public function saveInto(DataObjectInterface $dataObject): void
     {
         $fieldName = $this->getName();
         if ($dataObject->hasMethod("set$fieldName")) {
@@ -230,14 +230,14 @@ class MoneyField extends FormField
     /**
      * Returns a readonly version of this field.
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\MoneyField
     {
         $clone = clone $this;
         $clone->setReadonly(true);
         return $clone;
     }
 
-    public function setReadonly($bool)
+    public function setReadonly(bool $bool): SilverStripe\Forms\MoneyField
     {
         parent::setReadonly($bool);
 
@@ -247,7 +247,7 @@ class MoneyField extends FormField
         return $this;
     }
 
-    public function setDisabled($bool)
+    public function setDisabled(bool $bool): SilverStripe\Forms\MoneyField
     {
         parent::setDisabled($bool);
 
@@ -263,7 +263,7 @@ class MoneyField extends FormField
      * @param array $currencies
      * @return $this
      */
-    public function setAllowedCurrencies($currencies)
+    public function setAllowedCurrencies(array $currencies): SilverStripe\Forms\MoneyField
     {
         if (empty($currencies)) {
             $currencies = [];
@@ -287,7 +287,7 @@ class MoneyField extends FormField
     /**
      * @return array
      */
-    public function getAllowedCurrencies()
+    public function getAllowedCurrencies(): array
     {
         return $this->allowedCurrencies;
     }
@@ -298,7 +298,7 @@ class MoneyField extends FormField
      * @param string $locale
      * @return $this
      */
-    public function setLocale($locale)
+    public function setLocale(string $locale): SilverStripe\Forms\MoneyField
     {
         $this->fieldAmount->setLocale($locale);
         return $this;
@@ -310,7 +310,7 @@ class MoneyField extends FormField
      *
      * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->fieldAmount->getLocale();
     }
@@ -321,7 +321,7 @@ class MoneyField extends FormField
      * @param Validator $validator
      * @return bool
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Forms\RequiredFields $validator): bool
     {
         // Validate currency
         $currencies = $this->getAllowedCurrencies();
@@ -342,7 +342,7 @@ class MoneyField extends FormField
         return $this->fieldAmount->validate($validator) && $this->fieldCurrency->validate($validator);
     }
 
-    public function setForm($form)
+    public function setForm(SilverStripe\Forms\Form $form): SilverStripe\Forms\MoneyField
     {
         $this->fieldCurrency->setForm($form);
         $this->fieldAmount->setForm($form);

--- a/src/Forms/MultiSelectField.php
+++ b/src/Forms/MultiSelectField.php
@@ -29,7 +29,7 @@ abstract class MultiSelectField extends SelectField
      *
      * @return array List of values as an array
      */
-    public function getValueArray()
+    public function getValueArray(): array
     {
         return $this->getListValues($this->Value());
     }
@@ -42,7 +42,7 @@ abstract class MultiSelectField extends SelectField
      * @param array $items Collection of array keys, as defined in the $source array
      * @return $this Self reference
      */
-    public function setDefaultItems($items)
+    public function setDefaultItems(array $items): SilverStripe\Forms\CheckboxSetField
     {
         $this->defaultItems = $this->getListValues($items);
         return $this;
@@ -53,7 +53,7 @@ abstract class MultiSelectField extends SelectField
      *
      * @return array
      */
-    public function getDefaultItems()
+    public function getDefaultItems(): array
     {
         return $this->defaultItems;
     }
@@ -65,7 +65,7 @@ abstract class MultiSelectField extends SelectField
      * @param null|array|DataObject $obj {@see Form::loadDataFrom}
      * @return $this
      */
-    public function setValue($value, $obj = null)
+    public function setValue(array|string|int|bool|SilverStripe\Auditor\AuditHookManyManyList $value, array|SilverStripe\Security\Group $obj = null): SilverStripe\Forms\CheckboxSetField
     {
         // If we're not passed a value directly,
         // we can look for it in a relation method on the object passed as a second arg
@@ -82,7 +82,7 @@ abstract class MultiSelectField extends SelectField
      *
      * @param DataObject|DataObjectInterface $record
      */
-    public function loadFrom(DataObjectInterface $record)
+    public function loadFrom(DataObjectInterface $record): void
     {
         $fieldName = $this->getName();
         if (empty($fieldName) || empty($record)) {
@@ -121,7 +121,7 @@ abstract class MultiSelectField extends SelectField
      *
      * @param DataObject|DataObjectInterface $record The record to save into
      */
-    public function saveInto(DataObjectInterface $record)
+    public function saveInto(DataObjectInterface $record): void
     {
         $fieldName = $this->getName();
         if (empty($fieldName) || empty($record)) {
@@ -155,7 +155,7 @@ abstract class MultiSelectField extends SelectField
      * @param array $value
      * @return string|null
      */
-    public function stringEncode($value)
+    public function stringEncode(array $value): string|null
     {
         return $value
             ? json_encode(array_values($value))
@@ -168,7 +168,7 @@ abstract class MultiSelectField extends SelectField
      * @param string $value
      * @return array
      */
-    protected function stringDecode($value)
+    protected function stringDecode(string $value): array
     {
         // Handle empty case
         if (empty($value)) {
@@ -191,7 +191,7 @@ abstract class MultiSelectField extends SelectField
      * @param array $value
      * @return string|null
      */
-    protected function csvEncode($value)
+    protected function csvEncode(array $value): string
     {
         if (!$value) {
             return null;
@@ -214,7 +214,7 @@ abstract class MultiSelectField extends SelectField
      * @param string $value
      * @return array
      */
-    protected function csvDecode($value)
+    protected function csvDecode(string $value): array
     {
         if (!$value) {
             return [];
@@ -229,7 +229,7 @@ abstract class MultiSelectField extends SelectField
      * @param Validator $validator
      * @return bool
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Security\Member_Validator $validator): bool
     {
         $values = $this->getValueArray();
         $validValues = $this->getValidValues();
@@ -270,7 +270,7 @@ abstract class MultiSelectField extends SelectField
      *
      * @return ReadonlyField
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\LookupField
     {
         $field = $this->castedCopy('SilverStripe\\Forms\\LookupField');
         $field->setSource($this->getSource());

--- a/src/Forms/NullableField.php
+++ b/src/Forms/NullableField.php
@@ -48,7 +48,7 @@ class NullableField extends FormField
      * @param FormField $valueField
      * @param null|string $isNullLabel
      */
-    public function __construct(FormField $valueField, $isNullLabel = null)
+    public function __construct(FormField $valueField, $isNullLabel = null): void
     {
         $this->valueField = $valueField;
 
@@ -98,7 +98,7 @@ class NullableField extends FormField
      *
      * @return string
      */
-    public function getIsNullId()
+    public function getIsNullId(): string
     {
         return $this->getName() . "_IsNull";
     }
@@ -134,7 +134,7 @@ class NullableField extends FormField
      *
      * @return $this
      */
-    public function setValue($value, $data = null)
+    public function setValue(string $value, $data = null): SilverStripe\Forms\NullableField
     {
         $id = $this->getIsNullId();
 
@@ -154,7 +154,7 @@ class NullableField extends FormField
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName(string $name): SilverStripe\Forms\NullableField
     {
         $this->valueField->setName($name);
 

--- a/src/Forms/NumericField.php
+++ b/src/Forms/NumericField.php
@@ -53,7 +53,7 @@ class NumericField extends TextField
      *
      * @return NumberFormatter
      */
-    protected function getFormatter()
+    protected function getFormatter(): NumberFormatter
     {
         if ($this->getHTML5()) {
             // Locale-independent html5 number formatter
@@ -90,7 +90,7 @@ class NumericField extends TextField
      *
      * @return int
      */
-    protected function getNumberType()
+    protected function getNumberType(): int
     {
         $scale = $this->getScale();
         if ($scale === 0) {
@@ -101,7 +101,7 @@ class NumericField extends TextField
         return NumberFormatter::TYPE_DOUBLE;
     }
 
-    public function setSubmittedValue($value, $data = null)
+    public function setSubmittedValue(string|int|float $value, array $data = null): SilverStripe\Forms\NumericField
     {
         // Save original value in case parse fails
         $value = trim($value ?? '');
@@ -129,7 +129,7 @@ class NumericField extends TextField
      *
      * @return string
      */
-    public function Value()
+    public function Value(): string|null
     {
         // Show invalid value back to user in case of error
         if ($this->value === null || $this->value === false) {
@@ -139,7 +139,7 @@ class NumericField extends TextField
         return $formatter->format($this->value, $this->getNumberType());
     }
 
-    public function setValue($value, $data = null)
+    public function setValue(string|int|float $value, array|SilverStripe\Security\Member $data = null): SilverStripe\Forms\NumericField
     {
         $this->originalValue = $value;
         $this->value = $this->cast($value);
@@ -152,7 +152,7 @@ class NumericField extends TextField
      * @param string $value
      * @return float|int
      */
-    protected function cast($value)
+    protected function cast(string|int|float|bool $value): null|int|float
     {
         if (strlen($value ?? '') === 0) {
             return null;
@@ -166,12 +166,12 @@ class NumericField extends TextField
     /**
      * {@inheritdoc}
      */
-    public function Type()
+    public function Type(): string
     {
         return 'numeric text';
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = parent::getAttributes();
         if ($this->getHTML5()) {
@@ -189,7 +189,7 @@ class NumericField extends TextField
      * @param Validator $validator
      * @return bool
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Security\Member_Validator $validator): bool
     {
         // false signifies invalid value due to failed parse()
         if ($this->value !== false) {
@@ -207,7 +207,7 @@ class NumericField extends TextField
         return false;
     }
 
-    public function getSchemaValidation()
+    public function getSchemaValidation(): array
     {
         $rules = parent::getSchemaValidation();
         $rules['numeric'] = true;
@@ -219,7 +219,7 @@ class NumericField extends TextField
      *
      * @return int|float
      */
-    public function dataValue()
+    public function dataValue(): null|int|float
     {
         return $this->cast($this->value);
     }
@@ -229,7 +229,7 @@ class NumericField extends TextField
      *
      * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         if ($this->locale) {
             return $this->locale;
@@ -245,7 +245,7 @@ class NumericField extends TextField
      *
      * @return $this
      */
-    public function setLocale($locale)
+    public function setLocale(string $locale): SilverStripe\Forms\NumericField
     {
         $this->locale = $locale;
 
@@ -257,7 +257,7 @@ class NumericField extends TextField
      *
      * @return bool
      */
-    public function getHTML5()
+    public function getHTML5(): bool
     {
         return $this->html5;
     }
@@ -269,7 +269,7 @@ class NumericField extends TextField
      * @param bool $html5
      * @return $this
      */
-    public function setHTML5($html5)
+    public function setHTML5(bool $html5): SilverStripe\Forms\NumericField
     {
         $this->html5 = $html5;
         return $this;
@@ -299,7 +299,7 @@ class NumericField extends TextField
      *
      * @return int|null
      */
-    public function getScale()
+    public function getScale(): int|null
     {
         return $this->scale;
     }
@@ -311,13 +311,13 @@ class NumericField extends TextField
      * @param int|null $scale
      * @return $this
      */
-    public function setScale($scale)
+    public function setScale(int $scale): SilverStripe\Forms\NumericField
     {
         $this->scale = $scale;
         return $this;
     }
 
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\NumericField
     {
         $field = clone $this;
         $field->setReadonly(true);

--- a/src/Forms/OptionsetField.php
+++ b/src/Forms/OptionsetField.php
@@ -67,7 +67,7 @@ class OptionsetField extends SingleSelectField
      * @param boolean $odd True if this should be striped odd. Otherwise it should be striped even
      * @return ArrayData Field option
      */
-    protected function getFieldOption($value, $title, $odd)
+    protected function getFieldOption(int|string $value, string|SilverStripe\ORM\FieldType\DBHTMLText $title, bool $odd): SilverStripe\View\ArrayData
     {
         return new ArrayData([
             'ID' => $this->getOptionID($value),
@@ -87,7 +87,7 @@ class OptionsetField extends SingleSelectField
      * @param string $value
      * @return string
      */
-    protected function getOptionID($value)
+    protected function getOptionID(int|string $value): string
     {
         return $this->ID() . '_' . Convert::raw2htmlid($value);
     }
@@ -97,7 +97,7 @@ class OptionsetField extends SingleSelectField
      *
      * @return string
      */
-    protected function getOptionName()
+    protected function getOptionName(): string
     {
         return $this->getName();
     }
@@ -109,7 +109,7 @@ class OptionsetField extends SingleSelectField
      * @param bool $odd If this item is odd numbered in the list
      * @return string
      */
-    protected function getOptionClass($value, $odd)
+    protected function getOptionClass(int|string $value, bool $odd): string
     {
         $oddClass = $odd ? 'odd' : 'even';
         $valueClass = ' val' . Convert::raw2htmlid($value);
@@ -117,7 +117,7 @@ class OptionsetField extends SingleSelectField
     }
 
 
-    public function Field($properties = [])
+    public function Field($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $options = [];
         $odd = false;
@@ -138,7 +138,7 @@ class OptionsetField extends SingleSelectField
     /**
      * {@inheritdoc}
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Forms\RequiredFields $validator): bool
     {
         if (!$this->Value()) {
             return true;
@@ -147,7 +147,7 @@ class OptionsetField extends SingleSelectField
         return parent::validate($validator);
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = array_merge(
             parent::getAttributes(),

--- a/src/Forms/PasswordField.php
+++ b/src/Forms/PasswordField.php
@@ -32,7 +32,7 @@ class PasswordField extends TextField
      * @param null|string $title
      * @param string $value
      */
-    public function __construct($name, $title = null, $value = '')
+    public function __construct(string $name, string $title = null, string $value = ''): void
     {
         if (count(func_get_args()) > 3) {
             Deprecation::notice(
@@ -49,7 +49,7 @@ class PasswordField extends TextField
      * @param bool $bool
      * @return $this
      */
-    public function setAllowValuePostback($bool)
+    public function setAllowValuePostback(bool $bool): SilverStripe\Forms\PasswordField
     {
         $this->allowValuePostback = (bool) $bool;
 
@@ -59,7 +59,7 @@ class PasswordField extends TextField
     /**
      * @return bool
      */
-    public function getAllowValuePostback()
+    public function getAllowValuePostback(): bool
     {
         return $this->allowValuePostback;
     }
@@ -67,7 +67,7 @@ class PasswordField extends TextField
     /**
      * {@inheritdoc}
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = [];
 
@@ -106,7 +106,7 @@ class PasswordField extends TextField
     /**
      * {@inheritdoc}
      */
-    public function Type()
+    public function Type(): string
     {
         return 'text password';
     }

--- a/src/Forms/PopoverField.php
+++ b/src/Forms/PopoverField.php
@@ -52,7 +52,7 @@ class PopoverField extends FieldGroup
      *
      * @return string
      */
-    public function getPopoverTitle()
+    public function getPopoverTitle(): null|string
     {
         return $this->popoverTitle;
     }
@@ -63,7 +63,7 @@ class PopoverField extends FieldGroup
      * @param string $popoverTitle
      * @return $this
      */
-    public function setPopoverTitle($popoverTitle)
+    public function setPopoverTitle(string $popoverTitle): SilverStripe\Forms\PopoverField
     {
         $this->popoverTitle = $popoverTitle;
         return $this;
@@ -72,7 +72,7 @@ class PopoverField extends FieldGroup
     /**
      * @return string
      */
-    public function getButtonTooltip()
+    public function getButtonTooltip(): string|null
     {
         return $this->buttonTooltip;
     }
@@ -81,7 +81,7 @@ class PopoverField extends FieldGroup
      * @param string $text
      * @return $this
      */
-    public function setButtonTooltip($text)
+    public function setButtonTooltip(string $text): SilverStripe\Forms\PopoverField
     {
         $this->buttonTooltip = $text;
         return $this;
@@ -92,12 +92,12 @@ class PopoverField extends FieldGroup
      *
      * @return string
      */
-    public function getPlacement()
+    public function getPlacement(): string
     {
         return $this->placement;
     }
 
-    public function setPlacement($placement)
+    public function setPlacement(string $placement): SilverStripe\Forms\PopoverField
     {
         $valid = ['top', 'right', 'bottom', 'left'];
 
@@ -112,7 +112,7 @@ class PopoverField extends FieldGroup
         return $this;
     }
 
-    public function getSchemaDataDefaults()
+    public function getSchemaDataDefaults(): array
     {
         $schema = parent::getSchemaDataDefaults();
 

--- a/src/Forms/PrintableTransformation.php
+++ b/src/Forms/PrintableTransformation.php
@@ -13,7 +13,7 @@ class PrintableTransformation extends ReadonlyTransformation
      * @param TabSet $field
      * @return PrintableTransformation_TabSet
      */
-    public function transformTabSet($field)
+    public function transformTabSet(SilverStripe\Forms\TabSet $field): SilverStripe\Forms\PrintableTransformation_TabSet
     {
         $transformedField = new PrintableTransformation_TabSet($field->Tabs()->transform($this));
         $transformedField->Title = $field->Title();

--- a/src/Forms/PrintableTransformation_TabSet.php
+++ b/src/Forms/PrintableTransformation_TabSet.php
@@ -10,13 +10,13 @@ class PrintableTransformation_TabSet extends TabSet
     /**
      * @param array $tabs
      */
-    public function __construct($tabs)
+    public function __construct(array|SilverStripe\Forms\FieldList $tabs): void
     {
         $this->children = $tabs;
         CompositeField::__construct($tabs);
     }
 
-    public function FieldHolder($properties = [])
+    public function FieldHolder($properties = []): string
     {
         // This gives us support for sub-tabs.
         $tag = $this->getTabSet() ? 'h2>' : 'h1>';

--- a/src/Forms/ReadonlyField.php
+++ b/src/Forms/ReadonlyField.php
@@ -32,7 +32,7 @@ class ReadonlyField extends FormField
      * @param boolean $includeHiddenField
      * @return $this
      */
-    public function setIncludeHiddenField($includeHiddenField)
+    public function setIncludeHiddenField(bool $includeHiddenField): SilverStripe\Forms\HTMLEditor\HTMLEditorField_Readonly
     {
         $this->includeHiddenField = $includeHiddenField;
         return $this;
@@ -41,22 +41,22 @@ class ReadonlyField extends FormField
     /**
      * @return bool
      */
-    public function getIncludeHiddenField()
+    public function getIncludeHiddenField(): bool
     {
         return $this->includeHiddenField;
     }
 
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\ReadonlyField
     {
         return clone $this;
     }
 
-    public function Type()
+    public function Type(): string
     {
         return 'readonly';
     }
 
-    public function castingHelper($field)
+    public function castingHelper(string $field): string
     {
         // Get dynamic cast for 'Value' field
         if (strcasecmp($field ?? '', 'Value') === 0) {
@@ -67,7 +67,7 @@ class ReadonlyField extends FormField
         return parent::castingHelper($field);
     }
 
-    public function getSchemaStateDefaults()
+    public function getSchemaStateDefaults(): array
     {
         $state = parent::getSchemaStateDefaults();
         $state['value'] = $this->dataValue();
@@ -79,7 +79,7 @@ class ReadonlyField extends FormField
     /**
      * @return mixed|string
      */
-    public function Value()
+    public function Value(): string
     {
         // Get raw value
         $value = $this->dataValue();
@@ -97,7 +97,7 @@ class ReadonlyField extends FormField
      *
      * @return string
      */
-    public function getValueCast()
+    public function getValueCast(): string
     {
         // Casting class for 'none' text
         $value = $this->dataValue();

--- a/src/Forms/RequiredFields.php
+++ b/src/Forms/RequiredFields.php
@@ -26,7 +26,7 @@ class RequiredFields extends Validator
      * Pass each field to be validated as a separate argument to the constructor
      * of this object. (an array of elements are ok).
      */
-    public function __construct()
+    public function __construct(): void
     {
         $required = func_get_args();
         if (isset($required[0]) && is_array($required[0])) {
@@ -46,7 +46,7 @@ class RequiredFields extends Validator
      *
      * @return $this
      */
-    public function removeValidation()
+    public function removeValidation(): SilverStripe\Forms\RequiredFields
     {
         parent::removeValidation();
         $this->required = [];
@@ -81,7 +81,7 @@ class RequiredFields extends Validator
      *
      * @return boolean
      */
-    public function php($data)
+    public function php(array $data): bool
     {
         $valid = true;
         $fields = $this->form->Fields();
@@ -155,7 +155,7 @@ class RequiredFields extends Validator
      *
      * @return $this
      */
-    public function addRequiredField($field)
+    public function addRequiredField(string $field): SilverStripe\Forms\RequiredFields
     {
         $this->required[$field] = $field;
 
@@ -169,7 +169,7 @@ class RequiredFields extends Validator
      *
      * @return $this
      */
-    public function removeRequiredField($field)
+    public function removeRequiredField(string $field): SilverStripe\Forms\RequiredFields
     {
         unset($this->required[$field]);
 
@@ -182,7 +182,7 @@ class RequiredFields extends Validator
      * @param RequiredFields $requiredFields
      * @return $this
      */
-    public function appendRequiredFields($requiredFields)
+    public function appendRequiredFields(SilverStripe\Forms\RequiredFields $requiredFields): SilverStripe\Forms\RequiredFields
     {
         $this->required = $this->required + ArrayLib::valuekey(
             $requiredFields->getRequired()
@@ -201,7 +201,7 @@ class RequiredFields extends Validator
      *
      * @return boolean
      */
-    public function fieldIsRequired($fieldName)
+    public function fieldIsRequired(string $fieldName): bool
     {
         return isset($this->required[$fieldName]);
     }
@@ -211,7 +211,7 @@ class RequiredFields extends Validator
      *
      * @return array
      */
-    public function getRequired()
+    public function getRequired(): array
     {
         return array_values($this->required ?? []);
     }

--- a/src/Forms/Schema/FormSchema.php
+++ b/src/Forms/Schema/FormSchema.php
@@ -49,7 +49,7 @@ class FormSchema
      * @param ValidationResult $result Required for 'error' response
      * @return array
      */
-    public function getMultipartSchema($schemaParts, $schemaID, Form $form = null, ValidationResult $result = null)
+    public function getMultipartSchema(string $schemaParts, string $schemaID, Form $form = null, ValidationResult $result = null): array
     {
         if (!is_array($schemaParts)) {
             $schemaParts = preg_split('#\s*,\s*#', $schemaParts ?? '') ?: [];
@@ -89,7 +89,7 @@ class FormSchema
      * @param Form $form
      * @return array
      */
-    public function getSchema(Form $form)
+    public function getSchema(Form $form): array
     {
         $schema = [
             'name' => $form->getName(),
@@ -121,7 +121,7 @@ class FormSchema
      * @param Form $form
      * @return array
      */
-    public function getState(Form $form)
+    public function getState(Form $form): array
     {
         $state = [
             'id' => $form->FormName(),
@@ -176,7 +176,7 @@ class FormSchema
         ];
     }
 
-    protected function getFieldStates($fields)
+    protected function getFieldStates(SilverStripe\Forms\FieldList $fields): array
     {
         $states = [];
         /** @var FormField $field */

--- a/src/Forms/SelectField.php
+++ b/src/Forms/SelectField.php
@@ -35,7 +35,7 @@ abstract class SelectField extends FormField
      * @param array|ArrayAccess $source A map of the dropdown items
      * @param mixed $value The current value
      */
-    public function __construct($name, $title = null, $source = [], $value = null)
+    public function __construct(string $name, string|bool|SilverStripe\ORM\FieldType\DBHTMLText $title = null, array|SilverStripe\ORM\Map $source = [], string|int|array|SilverStripe\Auditor\AuditHookManyManyList $value = null): void
     {
         $this->setSource($source);
         if (!isset($title)) {
@@ -44,7 +44,7 @@ abstract class SelectField extends FormField
         parent::__construct($name, $title, $value);
     }
 
-    public function getSchemaStateDefaults()
+    public function getSchemaStateDefaults(): array
     {
         $data = parent::getSchemaStateDefaults();
         $disabled = $this->getDisabledItems();
@@ -73,7 +73,7 @@ abstract class SelectField extends FormField
      * @param array|SS_List $items Collection of values or items
      * @return $this
      */
-    public function setDisabledItems($items)
+    public function setDisabledItems(array $items): SilverStripe\Forms\DropdownField
     {
         $this->disabledItems = $this->getListValues($items);
         return $this;
@@ -84,7 +84,7 @@ abstract class SelectField extends FormField
      *
      * @return array
      */
-    public function getDisabledItems()
+    public function getDisabledItems(): array
     {
         return $this->disabledItems;
     }
@@ -95,7 +95,7 @@ abstract class SelectField extends FormField
      * @param string $value
      * @return bool
      */
-    protected function isDisabledValue($value)
+    protected function isDisabledValue(int|string $value): bool
     {
         if ($this->isDisabled()) {
             return true;
@@ -103,7 +103,7 @@ abstract class SelectField extends FormField
         return in_array($value, $this->getDisabledItems() ?? []);
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return array_merge(
             parent::getAttributes(),
@@ -116,7 +116,7 @@ abstract class SelectField extends FormField
      *
      * @return array
      */
-    protected function getSourceValues()
+    protected function getSourceValues(): array
     {
         return array_keys($this->getSource() ?? []);
     }
@@ -128,7 +128,7 @@ abstract class SelectField extends FormField
      *
      * @return array
      */
-    public function getValidValues()
+    public function getValidValues(): array
     {
         $valid = array_diff($this->getSourceValues() ?? [], $this->getDisabledItems());
         // Renumber indexes from 0
@@ -140,7 +140,7 @@ abstract class SelectField extends FormField
      *
      * @return array|ArrayAccess
      */
-    public function getSource()
+    public function getSource(): array
     {
         return $this->source;
     }
@@ -151,7 +151,7 @@ abstract class SelectField extends FormField
      * @param mixed $source
      * @return $this
      */
-    public function setSource($source)
+    public function setSource(array|SilverStripe\ORM\Map $source): SilverStripe\Forms\DropdownField
     {
         $this->source = $this->getListMap($source);
         return $this;
@@ -163,7 +163,7 @@ abstract class SelectField extends FormField
      * @param mixed $source
      * @return array Associative array of ids and titles
      */
-    protected function getListMap($source)
+    protected function getListMap(array|SilverStripe\ORM\Map $source): array
     {
         // Extract source as an array
         if ($source instanceof SS_List) {
@@ -186,7 +186,7 @@ abstract class SelectField extends FormField
      * @param mixed $values
      * @return array Non-associative list of values
      */
-    protected function getListValues($values)
+    protected function getListValues(array|int|string|bool $values): array
     {
         // Empty values
         if (empty($values)) {
@@ -213,7 +213,7 @@ abstract class SelectField extends FormField
      * @param mixed $userValue The value as submitted by the user
      * @return boolean True if the selected value matches the given option value
      */
-    public function isSelectedValue($dataValue, $userValue)
+    public function isSelectedValue(int|string $dataValue, SilverStripe\Forms\GridField\GridState_Data|string|int|bool|array $userValue): bool
     {
         if ($dataValue === $userValue) {
             return true;
@@ -248,7 +248,7 @@ abstract class SelectField extends FormField
         return $field;
     }
 
-    public function performDisabledTransformation()
+    public function performDisabledTransformation(): SilverStripe\Forms\CheckboxSetField
     {
         $clone = clone $this;
         $clone->setDisabled(true);
@@ -263,7 +263,7 @@ abstract class SelectField extends FormField
      * @param string $classOrCopy
      * @return FormField
      */
-    public function castedCopy($classOrCopy)
+    public function castedCopy(string $classOrCopy): SilverStripe\Forms\SingleLookupField
     {
         $field = parent::castedCopy($classOrCopy);
         if ($field instanceof SelectField) {

--- a/src/Forms/SelectionGroup.php
+++ b/src/Forms/SelectionGroup.php
@@ -41,7 +41,7 @@ class SelectionGroup extends CompositeField
      * @param array $items The list of {@link SelectionGroup_Item}
      * @param mixed $value
      */
-    public function __construct($name, $items, $value = null)
+    public function __construct(string $name, array $items, $value = null): void
     {
         if ($value !== null) {
             $this->setValue($value);
@@ -68,12 +68,12 @@ class SelectionGroup extends CompositeField
         $this->setName($name);
     }
 
-    public function FieldSet()
+    public function FieldSet(): SilverStripe\ORM\ArrayList
     {
         return $this->FieldList();
     }
 
-    public function FieldList()
+    public function FieldList(): SilverStripe\ORM\ArrayList
     {
         $items = parent::FieldList()->toArray();
         $count = 0;
@@ -113,12 +113,12 @@ class SelectionGroup extends CompositeField
         return new ArrayList($newItems);
     }
 
-    public function hasData()
+    public function hasData(): bool
     {
         return true;
     }
 
-    public function FieldHolder($properties = [])
+    public function FieldHolder($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         return parent::FieldHolder($properties);
     }

--- a/src/Forms/SelectionGroup_Item.php
+++ b/src/Forms/SelectionGroup_Item.php
@@ -20,7 +20,7 @@ class SelectionGroup_Item extends CompositeField
      * @param FormField|array $fields Contents of the option
      * @param string $title Title to show for the radio button option
      */
-    function __construct($value, $fields = null, $title = null)
+    function __construct(string $value, SilverStripe\Forms\TreeDropdownField $fields = null, string $title = null): void
     {
         $this->setValue($value);
         if ($fields && !is_array($fields)) {
@@ -32,23 +32,23 @@ class SelectionGroup_Item extends CompositeField
         $this->setTitle($title ?: $value);
     }
 
-    function getTitle()
+    function getTitle(): string
     {
         return $this->title;
     }
 
-    function setTitle($title)
+    function setTitle(string $title): SilverStripe\Forms\SelectionGroup_Item
     {
         $this->title = $title;
         return $this;
     }
 
-    function getValue()
+    function getValue(): string
     {
         return $this->value;
     }
 
-    function setValue($Value, $data = null)
+    function setValue(string $Value, $data = null): SilverStripe\Forms\SelectionGroup_Item
     {
         $this->value = $Value;
         return $this;

--- a/src/Forms/SingleLookupField.php
+++ b/src/Forms/SingleLookupField.php
@@ -23,7 +23,7 @@ class SingleLookupField extends SingleSelectField
     /**
      * @return mixed|null
      */
-    protected function valueToLabel()
+    protected function valueToLabel(): string|null
     {
         $value = $this->value;
         $source = $this->getSource();
@@ -42,7 +42,7 @@ class SingleLookupField extends SingleSelectField
      * @param Validator $validator
      * @return bool
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Security\Member_Validator $validator): bool
     {
         return true;
     }
@@ -77,7 +77,7 @@ class SingleLookupField extends SingleSelectField
     /**
      * @return string
      */
-    public function Type()
+    public function Type(): string
     {
         return 'single-lookup readonly';
     }
@@ -100,7 +100,7 @@ class SingleLookupField extends SingleSelectField
     /**
      * @return string
      */
-    public function getTemplate()
+    public function getTemplate(): string
     {
         // this field uses the same default template as LookupField
         return parent::getTemplate() ?: LookupField::class;
@@ -113,7 +113,7 @@ class SingleLookupField extends SingleSelectField
      *
      * @return string
      */
-    public function Field($properties = [])
+    public function Field($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $label = $this->valueToLabel();
         if (!is_null($label)) {

--- a/src/Forms/SingleSelectField.php
+++ b/src/Forms/SingleSelectField.php
@@ -30,7 +30,7 @@ abstract class SingleSelectField extends SelectField
 
     protected $schemaDataType = FormField::SCHEMA_DATA_TYPE_SINGLESELECT;
 
-    public function getSchemaStateDefaults()
+    public function getSchemaStateDefaults(): array
     {
         $data = parent::getSchemaStateDefaults();
 
@@ -39,7 +39,7 @@ abstract class SingleSelectField extends SelectField
         return $data;
     }
 
-    public function getSchemaDataDefaults()
+    public function getSchemaDataDefaults(): array
     {
         $data = parent::getSchemaDataDefaults();
 
@@ -50,7 +50,7 @@ abstract class SingleSelectField extends SelectField
         return $data;
     }
 
-    public function getDefaultValue()
+    public function getDefaultValue(): string|int
     {
         $value = $this->Value();
         // assign value to field, such as first option available
@@ -69,7 +69,7 @@ abstract class SingleSelectField extends SelectField
      * @param boolean $bool
      * @return self Self reference
      */
-    public function setHasEmptyDefault($bool)
+    public function setHasEmptyDefault(bool $bool): SilverStripe\Forms\DropdownField
     {
         $this->hasEmptyDefault = $bool;
         return $this;
@@ -78,7 +78,7 @@ abstract class SingleSelectField extends SelectField
     /**
      * @return bool
      */
-    public function getHasEmptyDefault()
+    public function getHasEmptyDefault(): bool
     {
         return $this->hasEmptyDefault;
     }
@@ -91,7 +91,7 @@ abstract class SingleSelectField extends SelectField
      * @param string $string
      * @return $this
      */
-    public function setEmptyString($string)
+    public function setEmptyString(string $string): SilverStripe\Forms\DropdownField
     {
         $this->setHasEmptyDefault(true);
         $this->emptyString = $string;
@@ -101,7 +101,7 @@ abstract class SingleSelectField extends SelectField
     /**
      * @return string
      */
-    public function getEmptyString()
+    public function getEmptyString(): string
     {
         return $this->emptyString;
     }
@@ -111,7 +111,7 @@ abstract class SingleSelectField extends SelectField
      *
      * @return array|ArrayAccess
      */
-    public function getSourceEmpty()
+    public function getSourceEmpty(): array
     {
         // Inject default option
         if ($this->getHasEmptyDefault()) {
@@ -127,7 +127,7 @@ abstract class SingleSelectField extends SelectField
      * @param Validator $validator
      * @return bool
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Security\Member_Validator $validator): bool
     {
         // Check if valid value is given
         $selected = $this->Value();
@@ -161,7 +161,7 @@ abstract class SingleSelectField extends SelectField
         return false;
     }
 
-    public function castedCopy($classOrCopy)
+    public function castedCopy(string $classOrCopy): SilverStripe\Forms\SingleLookupField
     {
         $field = parent::castedCopy($classOrCopy);
         if ($field instanceof SingleSelectField && $this->getHasEmptyDefault()) {
@@ -173,7 +173,7 @@ abstract class SingleSelectField extends SelectField
     /**
      * @return SingleLookupField
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\SingleLookupField
     {
         /** @var SingleLookupField $field */
         $field = $this->castedCopy(SingleLookupField::class);

--- a/src/Forms/Tab.php
+++ b/src/Forms/Tab.php
@@ -48,7 +48,7 @@ class Tab extends CompositeField
      * from the {@link $name} parameter.
      * @param FormField ...$fields All following parameters are inserted as children to this tab
      */
-    public function __construct($name, $titleOrField = null, $fields = null)
+    public function __construct(string $name, string|SilverStripe\Forms\TextField $titleOrField = null, SilverStripe\CMS\Forms\SiteTreeURLSegmentField $fields = null): void
     {
         if (!is_string($name)) {
             throw new InvalidArgumentException('Invalid string parameter for $name');
@@ -75,7 +75,7 @@ class Tab extends CompositeField
         $this->setID(Convert::raw2htmlid($name));
     }
 
-    public function ID()
+    public function ID(): string
     {
         if ($this->tabSet) {
             return $this->tabSet->ID() . '_' . $this->id;
@@ -90,7 +90,7 @@ class Tab extends CompositeField
      * @param string $id
      * @return $this
      */
-    public function setID($id)
+    public function setID(string $id): SilverStripe\Forms\Tab
     {
         $this->id = $id;
         return $this;
@@ -101,7 +101,7 @@ class Tab extends CompositeField
      *
      * @return FieldList
      */
-    public function Fields()
+    public function Fields(): SilverStripe\Forms\FieldList
     {
         return $this->children;
     }
@@ -112,7 +112,7 @@ class Tab extends CompositeField
      * @param TabSet $val
      * @return $this
      */
-    public function setTabSet($val)
+    public function setTabSet(SilverStripe\Forms\TabSet $val): SilverStripe\Forms\Tab
     {
         $this->tabSet = $val;
         return $this;
@@ -128,14 +128,14 @@ class Tab extends CompositeField
         return $this->tabSet;
     }
 
-    public function extraClass()
+    public function extraClass(): string
     {
         $classes = (array)$this->extraClasses;
 
         return implode(' ', $classes);
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = array_merge(
             $this->attributes,

--- a/src/Forms/TabSet.php
+++ b/src/Forms/TabSet.php
@@ -60,7 +60,7 @@ class TabSet extends CompositeField
      * from the {@link $name} parameter.
      * @param Tab|TabSet ...$tabs All further parameters are inserted as children into the TabSet
      */
-    public function __construct($name, $titleOrTab = null, $tabs = null)
+    public function __construct(string $name, array|string|SilverStripe\Forms\Tab $titleOrTab = null, SilverStripe\Forms\Tab $tabs = null): void
     {
         if (!is_string($name)) {
             throw new InvalidArgumentException('Invalid string parameter for $name');
@@ -102,7 +102,7 @@ class TabSet extends CompositeField
         $this->setID(Convert::raw2htmlid($name));
     }
 
-    public function ID()
+    public function ID(): string
     {
         if ($this->tabSet) {
             return $this->tabSet->ID() . '_' . $this->id . '_set';
@@ -116,7 +116,7 @@ class TabSet extends CompositeField
      * @param string $id
      * @return $this
      */
-    public function setID($id)
+    public function setID(string $id): SilverStripe\Forms\TabSet
     {
         $this->id = $id;
         return $this;
@@ -129,7 +129,7 @@ class TabSet extends CompositeField
      * @param array $properties
      * @return DBHTMLText|string
      */
-    public function FieldHolder($properties = [])
+    public function FieldHolder($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $obj = $properties ? $this->customise($properties) : $this;
 
@@ -141,7 +141,7 @@ class TabSet extends CompositeField
      *
      * @return FieldList
      */
-    public function Tabs()
+    public function Tabs(): SilverStripe\Forms\FieldList
     {
         return $this->children;
     }
@@ -160,7 +160,7 @@ class TabSet extends CompositeField
      * @param TabSet $val
      * @return $this
      */
-    public function setTabSet($val)
+    public function setTabSet(SilverStripe\Forms\TabSet $val): SilverStripe\Forms\TabSet
     {
         $this->tabSet = $val;
         return $this;
@@ -171,12 +171,12 @@ class TabSet extends CompositeField
      *
      * @return TabSet
      */
-    public function getTabSet()
+    public function getTabSet(): null|SilverStripe\Forms\TabSet
     {
         return $this->tabSet;
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = array_merge(
             $this->attributes,
@@ -196,7 +196,7 @@ class TabSet extends CompositeField
      *
      * @param FormField $field
      */
-    public function push(FormField $field)
+    public function push(FormField $field): void
     {
         if ($field instanceof Tab || $field instanceof TabSet) {
             $field->setTabSet($this);
@@ -209,7 +209,7 @@ class TabSet extends CompositeField
      *
      * @param FormField $field
      */
-    public function unshift(FormField $field)
+    public function unshift(FormField $field): void
     {
         if ($field instanceof Tab || $field instanceof TabSet) {
             $field->setTabSet($this);
@@ -225,7 +225,7 @@ class TabSet extends CompositeField
      * @param bool $appendIfMissing
      * @return FormField|null
      */
-    public function insertBefore($insertBefore, $field, $appendIfMissing = true)
+    public function insertBefore(string $insertBefore, SilverStripe\Forms\DropdownField $field, bool $appendIfMissing = true): SilverStripe\Forms\DropdownField
     {
         if ($field instanceof Tab || $field instanceof TabSet) {
             $field->setTabSet($this);
@@ -241,7 +241,7 @@ class TabSet extends CompositeField
      * @param bool $appendIfMissing
      * @return FormField|null
      */
-    public function insertAfter($insertAfter, $field, $appendIfMissing = true)
+    public function insertAfter(string $insertAfter, SilverStripe\AssetAdmin\Forms\UploadField $field, bool $appendIfMissing = true): bool|SilverStripe\AssetAdmin\Forms\UploadField
     {
         if ($field instanceof Tab || $field instanceof TabSet) {
             $field->setTabSet($this);
@@ -257,7 +257,7 @@ class TabSet extends CompositeField
      *
      * @return array
      */
-    public function getSchemaStateDefaults()
+    public function getSchemaStateDefaults(): array
     {
         $defaults = parent::getSchemaStateDefaults();
         $defaults['hideNav'] = false;

--- a/src/Forms/TextField.php
+++ b/src/Forms/TextField.php
@@ -32,7 +32,7 @@ class TextField extends FormField implements TippableFieldInterface
      * matching this size.
      * @param null|Form $form
      */
-    public function __construct($name, $title = null, $value = '', $maxLength = null, $form = null)
+    public function __construct(string $name, bool|string $title = null, string|SilverStripe\Forms\GridField\GridState_Data|int|bool $value = '', int $maxLength = null, SilverStripe\Security\MemberAuthenticator\MemberLoginForm $form = null): void
     {
         if ($maxLength) {
             $this->setMaxLength($maxLength);
@@ -49,7 +49,7 @@ class TextField extends FormField implements TippableFieldInterface
      * @param int $maxLength
      * @return $this
      */
-    public function setMaxLength($maxLength)
+    public function setMaxLength(int $maxLength): SilverStripe\Forms\TextField
     {
         $this->maxLength = $maxLength;
 
@@ -59,7 +59,7 @@ class TextField extends FormField implements TippableFieldInterface
     /**
      * @return null|int
      */
-    public function getMaxLength()
+    public function getMaxLength(): null|int
     {
         return $this->maxLength;
     }
@@ -90,7 +90,7 @@ class TextField extends FormField implements TippableFieldInterface
     /**
      * @return array
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $maxLength = $this->getMaxLength();
 
@@ -107,7 +107,7 @@ class TextField extends FormField implements TippableFieldInterface
         );
     }
 
-    public function getSchemaDataDefaults()
+    public function getSchemaDataDefaults(): array
     {
         $data = parent::getSchemaDataDefaults();
         $data['data']['maxlength'] =  $this->getMaxLength();
@@ -139,7 +139,7 @@ class TextField extends FormField implements TippableFieldInterface
      * @param Validator $validator
      * @return bool
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Forms\RequiredFields $validator): bool
     {
         if (!is_null($this->maxLength) && mb_strlen($this->value ?? '') > $this->maxLength) {
             $name = strip_tags($this->Title() ? $this->Title() : $this->getName());
@@ -157,7 +157,7 @@ class TextField extends FormField implements TippableFieldInterface
         return true;
     }
 
-    public function getSchemaValidation()
+    public function getSchemaValidation(): array
     {
         $rules = parent::getSchemaValidation();
         if ($this->getMaxLength()) {

--- a/src/Forms/TextareaField.php
+++ b/src/Forms/TextareaField.php
@@ -53,7 +53,7 @@ class TextareaField extends FormField
     /**
      * Set textarea specific schema data
      */
-    public function getSchemaDataDefaults()
+    public function getSchemaDataDefaults(): array
     {
         $data = parent::getSchemaDataDefaults();
         $data['data']['rows'] = $this->getRows();
@@ -69,7 +69,7 @@ class TextareaField extends FormField
      *
      * @return $this
      */
-    public function setRows($rows)
+    public function setRows(int $rows): SilverStripe\Forms\HTMLEditor\HTMLEditorField
     {
         $this->rows = $rows;
 
@@ -81,7 +81,7 @@ class TextareaField extends FormField
      *
      * @return int
      */
-    public function getRows()
+    public function getRows(): int
     {
         return $this->rows;
     }
@@ -105,7 +105,7 @@ class TextareaField extends FormField
      *
      * @return int
      */
-    public function getColumns()
+    public function getColumns(): int
     {
         return $this->cols;
     }
@@ -124,7 +124,7 @@ class TextareaField extends FormField
     /**
      * @return null|int
      */
-    public function getMaxLength()
+    public function getMaxLength(): null
     {
         return $this->maxLength;
     }
@@ -132,7 +132,7 @@ class TextareaField extends FormField
     /**
      * {@inheritdoc}
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = array_merge(
             parent::getAttributes(),
@@ -156,7 +156,7 @@ class TextareaField extends FormField
     /**
      * {@inheritdoc}
      */
-    public function Type()
+    public function Type(): string
     {
         $parent = parent::Type();
 
@@ -172,7 +172,7 @@ class TextareaField extends FormField
      *
      * @return string Raw HTML
      */
-    public function ValueEntities()
+    public function ValueEntities(): string
     {
         return htmlentities($this->Value() ?? '', ENT_COMPAT, 'UTF-8');
     }

--- a/src/Forms/TimeField.php
+++ b/src/Forms/TimeField.php
@@ -70,7 +70,7 @@ class TimeField extends TextField
     /**
      * @return bool
      */
-    public function getHTML5()
+    public function getHTML5(): bool
     {
         return $this->html5;
     }
@@ -79,7 +79,7 @@ class TimeField extends TextField
      * @param boolean $bool
      * @return $this
      */
-    public function setHTML5($bool)
+    public function setHTML5(bool $bool): SilverStripe\Forms\TimeField
     {
         $this->html5 = $bool;
         return $this;
@@ -93,7 +93,7 @@ class TimeField extends TextField
      *
      * @see https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table
      */
-    public function getTimeFormat()
+    public function getTimeFormat(): string
     {
         if ($this->getHTML5()) {
             // Browsers expect ISO 8601 times, localisation is handled on the client
@@ -116,7 +116,7 @@ class TimeField extends TextField
      * @param string $format
      * @return $this
      */
-    public function setTimeFormat($format)
+    public function setTimeFormat(string $format): SilverStripe\Forms\TimeField_Readonly
     {
         $this->timeFormat = $format;
         return $this;
@@ -133,7 +133,7 @@ class TimeField extends TextField
      * @see http://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants
      * @return int
      */
-    public function getTimeLength()
+    public function getTimeLength(): int
     {
         if ($this->timeLength) {
             return $this->timeLength;
@@ -150,7 +150,7 @@ class TimeField extends TextField
      * @param int $length
      * @return $this
      */
-    public function setTimeLength($length)
+    public function setTimeLength(int $length): SilverStripe\Forms\TimeField_Readonly
     {
         $this->timeLength = $length;
         return $this;
@@ -161,7 +161,7 @@ class TimeField extends TextField
      *
      * @return IntlDateFormatter
      */
-    protected function getFrontendFormatter()
+    protected function getFrontendFormatter(): IntlDateFormatter
     {
         if ($this->getHTML5() && $this->timeFormat && $this->timeFormat !== DBTime::ISO_TIME) {
             throw new \LogicException(
@@ -206,7 +206,7 @@ class TimeField extends TextField
      *
      * @return IntlDateFormatter
      */
-    protected function getInternalFormatter()
+    protected function getInternalFormatter(): IntlDateFormatter
     {
         $formatter = IntlDateFormatter::create(
             i18n::config()->uninherited('default_locale'),
@@ -256,7 +256,7 @@ class TimeField extends TextField
      * @param mixed $data
      * @return $this
      */
-    public function setSubmittedValue($value, $data = null)
+    public function setSubmittedValue(string $value, SilverStripe\View\ArrayData|array $data = null): SilverStripe\Forms\TimeField
     {
         // Save raw value for later validation
         $this->rawValue = $value;
@@ -273,7 +273,7 @@ class TimeField extends TextField
      * @param mixed $data
      * @return $this
      */
-    public function setValue($value, $data = null)
+    public function setValue(string|bool $value, array $data = null): SilverStripe\Forms\TimeField
     {
         // Save raw value for later validation
         $this->rawValue = $value;
@@ -289,7 +289,7 @@ class TimeField extends TextField
         return $this;
     }
 
-    public function Value()
+    public function Value(): string
     {
         $localised = $this->internalToFrontend($this->value);
         if ($localised) {
@@ -320,7 +320,7 @@ class TimeField extends TextField
      * @param Validator $validator
      * @return bool
      */
-    public function validate($validator)
+    public function validate(SilverStripe\Forms\RequiredFields $validator): bool
     {
         // Don't validate empty fields
         if (empty($this->rawValue)) {
@@ -345,7 +345,7 @@ class TimeField extends TextField
     /**
      * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->locale ?: i18n::get_locale();
     }
@@ -358,7 +358,7 @@ class TimeField extends TextField
      * @param string $locale
      * @return $this
      */
-    public function setLocale($locale)
+    public function setLocale(string $locale): SilverStripe\Forms\TimeField_Readonly
     {
         $this->locale = $locale;
         return $this;
@@ -369,7 +369,7 @@ class TimeField extends TextField
      *
      * @return TimeField_Readonly
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\TimeField_Readonly
     {
         /** @var TimeField_Readonly $result */
         $result = $this->castedCopy(TimeField_Readonly::class);
@@ -391,7 +391,7 @@ class TimeField extends TextField
      * @param string $time
      * @return string The formatted time, or null if not a valid time
      */
-    protected function frontendToInternal($time)
+    protected function frontendToInternal(string $time): string
     {
         if (!$time) {
             return null;
@@ -423,7 +423,7 @@ class TimeField extends TextField
      * @param string $time
      * @return string
      */
-    protected function internalToFrontend($time)
+    protected function internalToFrontend(string $time): string
     {
         $time = $this->tidyInternal($time);
         if (!$time) {
@@ -447,7 +447,7 @@ class TimeField extends TextField
      * @param string $time Time in ISO 8601 or approximate form
      * @return string ISO 8601 time, or null if not valid
      */
-    protected function tidyInternal($time)
+    protected function tidyInternal(string $time): string|null
     {
         if (!$time) {
             return null;
@@ -468,7 +468,7 @@ class TimeField extends TextField
     /**
      * @return string
      */
-    public function getTimezone()
+    public function getTimezone(): null|string
     {
         return $this->timezone;
     }
@@ -477,7 +477,7 @@ class TimeField extends TextField
      * @param string $timezone
      * @return $this
      */
-    public function setTimezone($timezone)
+    public function setTimezone(string $timezone): SilverStripe\Forms\TimeField_Readonly
     {
         if ($this->value && $timezone !== $this->timezone) {
             throw new \BadMethodCallException("Can't change timezone after setting a value");

--- a/src/Forms/ToggleCompositeField.php
+++ b/src/Forms/ToggleCompositeField.php
@@ -29,7 +29,7 @@ class ToggleCompositeField extends CompositeField
      * @param string $title
      * @param array|FieldList $children
      */
-    public function __construct($name, $title, $children)
+    public function __construct(string $name, string $title, array|SilverStripe\Forms\FieldList $children): void
     {
         parent::__construct($children);
         $this->setName($name);
@@ -42,7 +42,7 @@ class ToggleCompositeField extends CompositeField
      * @param array $properties
      * @return string
      */
-    public function FieldHolder($properties = [])
+    public function FieldHolder($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $context = $this;
 
@@ -58,7 +58,7 @@ class ToggleCompositeField extends CompositeField
      *
      * @return array
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = [
             'id' => $this->ID(),
@@ -80,7 +80,7 @@ class ToggleCompositeField extends CompositeField
     /**
      * @return bool
      */
-    public function getStartClosed()
+    public function getStartClosed(): bool
     {
         return $this->startClosed;
     }
@@ -102,7 +102,7 @@ class ToggleCompositeField extends CompositeField
     /**
      * @return int
      */
-    public function getHeadingLevel()
+    public function getHeadingLevel(): int
     {
         return $this->headingLevel;
     }
@@ -112,7 +112,7 @@ class ToggleCompositeField extends CompositeField
      *
      * @return $this
      */
-    public function setHeadingLevel($headingLevel)
+    public function setHeadingLevel(int $headingLevel): SilverStripe\Forms\ToggleCompositeField
     {
         $this->headingLevel = (int) $headingLevel;
 

--- a/src/Forms/TreeDropdownField.php
+++ b/src/Forms/TreeDropdownField.php
@@ -223,13 +223,13 @@ class TreeDropdownField extends FormField
      *      entering the text in the input field.
      */
     public function __construct(
-        $name,
+        string $name,
         $title = null,
         $sourceObject = null,
         $keyField = 'ID',
         $labelField = 'TreeTitle',
         $showSearch = true
-    ) {
+    ): void {
         if (!is_a($sourceObject, DataObject::class, true)) {
             throw new InvalidArgumentException("SourceObject must be a DataObject subclass");
         }
@@ -258,7 +258,7 @@ class TreeDropdownField extends FormField
      *
      * @return int
      */
-    public function getTreeBaseID()
+    public function getTreeBaseID(): int
     {
         return $this->baseID;
     }
@@ -270,7 +270,7 @@ class TreeDropdownField extends FormField
      * @param int $ID
      * @return $this
      */
-    public function setTreeBaseID($ID)
+    public function setTreeBaseID(int $ID): SilverStripe\Forms\TreeDropdownField
     {
         $this->baseID = (int) $ID;
         return $this;
@@ -282,7 +282,7 @@ class TreeDropdownField extends FormField
      *
      * @return callable
      */
-    public function getFilterFunction()
+    public function getFilterFunction(): null|callable
     {
         return $this->filterCallback;
     }
@@ -294,7 +294,7 @@ class TreeDropdownField extends FormField
      * @param callable $callback
      * @return $this
      */
-    public function setFilterFunction($callback)
+    public function setFilterFunction(callable $callback): SilverStripe\Forms\TreeDropdownField
     {
         if (!is_callable($callback, true)) {
             throw new InvalidArgumentException('TreeDropdownField->setFilterCallback(): not passed a valid callback');
@@ -309,7 +309,7 @@ class TreeDropdownField extends FormField
      *
      * @return callable
      */
-    public function getDisableFunction()
+    public function getDisableFunction(): null
     {
         return $this->disableCallback;
     }
@@ -336,7 +336,7 @@ class TreeDropdownField extends FormField
      *
      * @return callable
      */
-    public function getSearchFunction()
+    public function getSearchFunction(): null
     {
         return $this->searchCallback;
     }
@@ -348,7 +348,7 @@ class TreeDropdownField extends FormField
      * @param callable $callback
      * @return $this
      */
-    public function setSearchFunction($callback)
+    public function setSearchFunction(callable $callback): SilverStripe\Forms\TreeDropdownField
     {
         if (!is_callable($callback, true)) {
             throw new InvalidArgumentException('TreeDropdownField->setSearchFunction(): not passed a valid callback');
@@ -363,7 +363,7 @@ class TreeDropdownField extends FormField
      *
      * @return bool
      */
-    public function getShowSearch()
+    public function getShowSearch(): bool
     {
         return $this->showSearch;
     }
@@ -372,7 +372,7 @@ class TreeDropdownField extends FormField
      * @param bool $bool
      * @return $this
      */
-    public function setShowSearch($bool)
+    public function setShowSearch(bool $bool): SilverStripe\Forms\TreeDropdownField
     {
         $this->showSearch = $bool;
         return $this;
@@ -383,7 +383,7 @@ class TreeDropdownField extends FormField
      *
      * @return string
      */
-    public function getChildrenMethod()
+    public function getChildrenMethod(): string
     {
         return $this->childrenMethod;
     }
@@ -397,7 +397,7 @@ class TreeDropdownField extends FormField
      * See {@link Hierarchy} for a complete list of possible methods.
      * @return $this
      */
-    public function setChildrenMethod($method)
+    public function setChildrenMethod(string $method): SilverStripe\Forms\TreeDropdownField
     {
         $this->childrenMethod = $method;
         return $this;
@@ -408,7 +408,7 @@ class TreeDropdownField extends FormField
      *
      * @return string
      */
-    public function getNumChildrenMethod()
+    public function getNumChildrenMethod(): string
     {
         return $this->numChildrenMethod;
     }
@@ -419,13 +419,13 @@ class TreeDropdownField extends FormField
      *
      * @return $this
      */
-    public function setNumChildrenMethod($method)
+    public function setNumChildrenMethod(string $method): SilverStripe\Forms\TreeDropdownField
     {
         $this->numChildrenMethod = $method;
         return $this;
     }
 
-    public function extraClass()
+    public function extraClass(): string
     {
         return implode(' ', [parent::extraClass(), ($this->getShowSearch() ? "searchable" : null)]);
     }
@@ -437,7 +437,7 @@ class TreeDropdownField extends FormField
      * @return HTTPResponse
      * @throws Exception
      */
-    public function tree(HTTPRequest $request)
+    public function tree(HTTPRequest $request): SilverStripe\Control\HTTPResponse
     {
         // Regular source specification
         $isSubTree = false;
@@ -573,7 +573,7 @@ class TreeDropdownField extends FormField
      * @param DataObject $node
      * @return bool
      */
-    public function filterMarking($node)
+    public function filterMarking(Page $node): bool
     {
         $callback = $this->getFilterFunction();
         if ($callback && !call_user_func($callback, $node)) {
@@ -592,7 +592,7 @@ class TreeDropdownField extends FormField
      * @param $node
      * @return boolean
      */
-    public function nodeIsDisabled($node)
+    public function nodeIsDisabled(SilverStripe\CMS\Model\SiteTree $node): bool
     {
         $callback = $this->getDisableFunction();
         return $callback && call_user_func($callback, $node);
@@ -602,7 +602,7 @@ class TreeDropdownField extends FormField
      * Attributes to be given for this field type
      * @return array
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         $attributes = [
             'class' => $this->extraClass(),
@@ -625,7 +625,7 @@ class TreeDropdownField extends FormField
      * @param string $field
      * @return $this
      */
-    public function setLabelField($field)
+    public function setLabelField(string $field): SilverStripe\Forms\TreeDropdownField
     {
         $this->labelField = $field;
         return $this;
@@ -637,7 +637,7 @@ class TreeDropdownField extends FormField
      * @deprecated 4.0.0:5.0.0 Use getTitleField()
      * @return string
      */
-    public function getLabelField()
+    public function getLabelField(): string
     {
         return $this->labelField;
     }
@@ -647,7 +647,7 @@ class TreeDropdownField extends FormField
      *
      * @return string
      */
-    public function getTitleField()
+    public function getTitleField(): string
     {
         return $this->titleField;
     }
@@ -658,7 +658,7 @@ class TreeDropdownField extends FormField
      * @param string $field
      * @return $this
      */
-    public function setTitleField($field)
+    public function setTitleField(string $field): SilverStripe\Forms\TreeDropdownField
     {
         $this->titleField = $field;
         return $this;
@@ -668,7 +668,7 @@ class TreeDropdownField extends FormField
      * @param string $field
      * @return $this
      */
-    public function setKeyField($field)
+    public function setKeyField(string $field): SilverStripe\Forms\TreeDropdownField
     {
         $this->keyField = $field;
         return $this;
@@ -677,7 +677,7 @@ class TreeDropdownField extends FormField
     /**
      * @return string
      */
-    public function getKeyField()
+    public function getKeyField(): string
     {
         return $this->keyField;
     }
@@ -686,7 +686,7 @@ class TreeDropdownField extends FormField
      * @param string $class
      * @return $this
      */
-    public function setSourceObject($class)
+    public function setSourceObject(string $class): SilverStripe\Forms\TreeDropdownField
     {
         $this->sourceObject = $class;
         return $this;
@@ -697,7 +697,7 @@ class TreeDropdownField extends FormField
      *
      * @return string
      */
-    public function getSourceObject()
+    public function getSourceObject(): string
     {
         return $this->sourceObject;
     }
@@ -712,7 +712,7 @@ class TreeDropdownField extends FormField
      * @param array $parentTitles - a list of parent titles, which we use to construct the contextString
      * @return array - flattened list of children
      */
-    protected function flattenChildrenArray($children, $parentTitles = [])
+    protected function flattenChildrenArray(array $children, array $parentTitles = []): array
     {
         $output = [];
 
@@ -738,7 +738,7 @@ class TreeDropdownField extends FormField
      * Reverse-constructs the tree starting from the leaves. Initially taken from CMSSiteTreeFilter, but modified
      * with pluggable search function.
      */
-    protected function populateIDs()
+    protected function populateIDs(): void
     {
         // get all the leaves to be displayed
         $res = $this->getSearchResults();
@@ -778,7 +778,7 @@ class TreeDropdownField extends FormField
      *
      * @return DataList
      */
-    protected function getSearchResults()
+    protected function getSearchResults(): SilverStripe\ORM\DataList
     {
         $callback = $this->getSearchFunction();
         if ($callback) {
@@ -816,7 +816,7 @@ class TreeDropdownField extends FormField
      * @param string|int $key
      * @return DataObject|null
      */
-    protected function objectForKey($key)
+    protected function objectForKey(array|int|string|SilverStripe\Auditor\AuditHookManyManyList $key): null|SilverStripe\Assets\Folder
     {
         if (!is_string($key) && !is_int($key)) {
             return null;
@@ -829,7 +829,7 @@ class TreeDropdownField extends FormField
     /**
      * Changes this field to the readonly field.
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\TreeDropdownField_Readonly
     {
         /** @var TreeDropdownField_Readonly $copy */
         $copy = $this->castedCopy(TreeDropdownField_Readonly::class);
@@ -844,7 +844,7 @@ class TreeDropdownField extends FormField
      * @param string|FormField $classOrCopy
      * @return FormField
      */
-    public function castedCopy($classOrCopy)
+    public function castedCopy(string $classOrCopy): SilverStripe\Forms\TreeDropdownField_Readonly
     {
         $field = $classOrCopy;
 
@@ -855,7 +855,7 @@ class TreeDropdownField extends FormField
         return parent::castedCopy($field);
     }
 
-    public function getSchemaStateDefaults()
+    public function getSchemaStateDefaults(): array
     {
         $data = parent::getSchemaStateDefaults();
         /** @var Hierarchy|DataObject $record */
@@ -891,7 +891,7 @@ class TreeDropdownField extends FormField
      *
      * @return DBDatetime
      */
-    protected function getCacheKey()
+    protected function getCacheKey(): string|null
     {
         $target = $this->getSourceObject();
         if (!isset(self::$cacheKeyCache[$target])) {
@@ -900,7 +900,7 @@ class TreeDropdownField extends FormField
         return self::$cacheKeyCache[$target];
     }
 
-    public function getSchemaDataDefaults()
+    public function getSchemaDataDefaults(): array
     {
         $data = parent::getSchemaDataDefaults();
         $data['data'] = array_merge($data['data'], [
@@ -919,7 +919,7 @@ class TreeDropdownField extends FormField
      * @param boolean $bool
      * @return self Self reference
      */
-    public function setHasEmptyDefault($bool)
+    public function setHasEmptyDefault(bool $bool): SilverStripe\Forms\TreeDropdownField
     {
         $this->hasEmptyDefault = $bool;
         return $this;
@@ -928,7 +928,7 @@ class TreeDropdownField extends FormField
     /**
      * @return bool
      */
-    public function getHasEmptyDefault()
+    public function getHasEmptyDefault(): bool
     {
         return $this->hasEmptyDefault;
     }
@@ -941,7 +941,7 @@ class TreeDropdownField extends FormField
      * @param string $string
      * @return $this
      */
-    public function setEmptyString($string)
+    public function setEmptyString(string $string): SilverStripe\Forms\TreeDropdownField
     {
         $this->setHasEmptyDefault(true);
         $this->emptyString = $string;
@@ -951,7 +951,7 @@ class TreeDropdownField extends FormField
     /**
      * @return string
      */
-    public function getEmptyString()
+    public function getEmptyString(): string
     {
         if ($this->emptyString !== null) {
             return $this->emptyString;
@@ -969,7 +969,7 @@ class TreeDropdownField extends FormField
     /**
      * @return bool
      */
-    public function getShowSelectedPath()
+    public function getShowSelectedPath(): bool
     {
         return $this->showSelectedPath;
     }
@@ -978,7 +978,7 @@ class TreeDropdownField extends FormField
      * @param bool $showSelectedPath
      * @return TreeDropdownField
      */
-    public function setShowSelectedPath($showSelectedPath)
+    public function setShowSelectedPath(bool $showSelectedPath): SilverStripe\Forms\TreeDropdownField
     {
         $this->showSelectedPath = $showSelectedPath;
         return $this;

--- a/src/Forms/TreeDropdownField_Readonly.php
+++ b/src/Forms/TreeDropdownField_Readonly.php
@@ -6,7 +6,7 @@ class TreeDropdownField_Readonly extends TreeDropdownField
 {
     protected $readonly = true;
 
-    public function Field($properties = [])
+    public function Field($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $fieldName = $this->getTitleField();
         if ($this->value) {

--- a/src/Forms/TreeMultiselectField.php
+++ b/src/Forms/TreeMultiselectField.php
@@ -59,19 +59,19 @@ use SilverStripe\View\ViewableData;
 class TreeMultiselectField extends TreeDropdownField
 {
     public function __construct(
-        $name,
+        string $name,
         $title = null,
         $sourceObject = Group::class,
         $keyField = "ID",
         $labelField = "Title"
-    ) {
+    ): void {
         parent::__construct($name, $title, $sourceObject, $keyField, $labelField);
         $this->removeExtraClass('single');
         $this->addExtraClass('multiple');
         $this->value = 'unchanged';
     }
 
-    public function getSchemaDataDefaults()
+    public function getSchemaDataDefaults(): array
     {
         $data = parent::getSchemaDataDefaults();
 
@@ -82,7 +82,7 @@ class TreeMultiselectField extends TreeDropdownField
         return $data;
     }
 
-    public function getSchemaStateDefaults()
+    public function getSchemaStateDefaults(): array
     {
         $data = parent::getSchemaStateDefaults();
         unset($data['data']['valueObject']);
@@ -119,7 +119,7 @@ class TreeMultiselectField extends TreeDropdownField
      * Return this field's linked items
      * @return ArrayList|DataList $items
      */
-    public function getItems()
+    public function getItems(): SilverStripe\ORM\ArrayList
     {
         $value = $this->Value();
 
@@ -169,7 +169,7 @@ class TreeMultiselectField extends TreeDropdownField
             ->filter($this->getKeyField(), $ids);
     }
 
-    public function setValue($value, $source = null)
+    public function setValue(string|SilverStripe\Auditor\AuditHookManyManyList|array $value, array|SilverStripe\Assets\File $source = null): SilverStripe\Forms\TreeMultiselectField
     {
         // If loading from a dataobject, get items by relation
         if ($source instanceof DataObject) {
@@ -188,7 +188,7 @@ class TreeMultiselectField extends TreeDropdownField
         return parent::setValue($value);
     }
 
-    public function dataValue()
+    public function dataValue(): array
     {
         return $this->getItems()->column($this->getKeyField());
     }
@@ -200,7 +200,7 @@ class TreeMultiselectField extends TreeDropdownField
      * @param array $properties
      * @return DBHTMLText
      */
-    public function Field($properties = [])
+    public function Field($properties = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $value = '';
         $titleArray = [];
@@ -249,7 +249,7 @@ class TreeMultiselectField extends TreeDropdownField
      *
      * @param DataObjectInterface $record
      */
-    public function saveInto(DataObjectInterface $record)
+    public function saveInto(DataObjectInterface $record): void
     {
         $fieldName = $this->getName();
 
@@ -279,7 +279,7 @@ class TreeMultiselectField extends TreeDropdownField
     /**
      * Changes this field to the readonly field.
      */
-    public function performReadonlyTransformation()
+    public function performReadonlyTransformation(): SilverStripe\Forms\TreeMultiselectField_Readonly
     {
         /** @var TreeMultiselectField_Readonly $copy */
         $copy = $this->castedCopy(TreeMultiselectField_Readonly::class);
@@ -295,7 +295,7 @@ class TreeMultiselectField extends TreeDropdownField
      *
      * @internal To be removed in 5.0
      */
-    protected function objectForKey($key)
+    protected function objectForKey(SilverStripe\Auditor\AuditHookManyManyList|string $key): null
     {
         /**
          * Fixes https://github.com/silverstripe/silverstripe-framework/issues/8332

--- a/src/Forms/TreeMultiselectField_Readonly.php
+++ b/src/Forms/TreeMultiselectField_Readonly.php
@@ -7,7 +7,7 @@ class TreeMultiselectField_Readonly extends TreeMultiselectField
 
     protected $readonly = true;
 
-    public function Field($properties = [])
+    public function Field($properties = []): string
     {
         // Build list of titles
         $titleField = $this->getTitleField();

--- a/src/Forms/Validator.php
+++ b/src/Forms/Validator.php
@@ -18,7 +18,7 @@ abstract class Validator
     use Configurable;
     use Extensible;
 
-    public function __construct()
+    public function __construct(): void
     {
         $this->resetResult();
     }
@@ -42,7 +42,7 @@ abstract class Validator
      * @param Form $form
      * @return $this
      */
-    public function setForm($form)
+    public function setForm(SilverStripe\CMS\Search\SearchForm $form): SilverStripe\Forms\RequiredFields
     {
         $this->form = $form;
         return $this;
@@ -53,7 +53,7 @@ abstract class Validator
      *
      * @return ValidationResult
      */
-    public function validate()
+    public function validate(): SilverStripe\ORM\ValidationResult
     {
         $this->resetResult();
         if ($this->getEnabled()) {
@@ -78,11 +78,11 @@ abstract class Validator
      * @return $this
      */
     public function validationError(
-        $fieldName,
+        string $fieldName,
         $message,
         $messageType = ValidationResult::TYPE_ERROR,
         $cast = ValidationResult::CAST_TEXT
-    ) {
+    ): SilverStripe\Security\Member_Validator {
         $this->result->addFieldError($fieldName, $message, $messageType, null, $cast);
         return $this;
     }
@@ -102,7 +102,7 @@ abstract class Validator
      *
      * @return null|array
      */
-    public function getErrors()
+    public function getErrors(): array
     {
         if ($this->result) {
             return $this->result->getMessages();
@@ -115,7 +115,7 @@ abstract class Validator
      *
      * @return ValidationResult
      */
-    public function getResult()
+    public function getResult(): SilverStripe\ORM\ValidationResult
     {
         return $this->result;
     }
@@ -128,7 +128,7 @@ abstract class Validator
      *
      * @return bool
      */
-    public function fieldIsRequired($fieldName)
+    public function fieldIsRequired(string $fieldName): bool
     {
         return false;
     }
@@ -144,7 +144,7 @@ abstract class Validator
      * @param bool $enabled
      * @return $this
      */
-    public function setEnabled($enabled)
+    public function setEnabled(bool $enabled): SilverStripe\Forms\RequiredFields
     {
         $this->enabled = (bool)$enabled;
         return $this;
@@ -153,7 +153,7 @@ abstract class Validator
     /**
      * @return bool
      */
-    public function getEnabled()
+    public function getEnabled(): bool
     {
         return $this->enabled;
     }
@@ -161,7 +161,7 @@ abstract class Validator
     /**
      * @return $this
      */
-    public function removeValidation()
+    public function removeValidation(): SilverStripe\Forms\RequiredFields
     {
         $this->setEnabled(false);
         $this->resetResult();
@@ -185,7 +185,7 @@ abstract class Validator
      *
      * @return $this
      */
-    protected function resetResult()
+    protected function resetResult(): SilverStripe\Forms\RequiredFields
     {
         $this->result = ValidationResult::create();
         return $this;

--- a/src/Logging/DebugViewFriendlyErrorFormatter.php
+++ b/src/Logging/DebugViewFriendlyErrorFormatter.php
@@ -40,7 +40,7 @@ class DebugViewFriendlyErrorFormatter implements FormatterInterface
      *
      * @return int
      */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->statusCode;
     }
@@ -51,7 +51,7 @@ class DebugViewFriendlyErrorFormatter implements FormatterInterface
      * @param int $statusCode
      * @return $this
      */
-    public function setStatusCode($statusCode)
+    public function setStatusCode(int $statusCode): Mock_DebugViewFriendlyErrorFormatter_9dc3f595
     {
         $this->statusCode = $statusCode;
         return $this;
@@ -62,7 +62,7 @@ class DebugViewFriendlyErrorFormatter implements FormatterInterface
      *
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->friendlyErrorMessage;
     }
@@ -73,7 +73,7 @@ class DebugViewFriendlyErrorFormatter implements FormatterInterface
      * @param string $title
      * @return $this
      */
-    public function setTitle($title)
+    public function setTitle(string $title): SilverStripe\Logging\DebugViewFriendlyErrorFormatter
     {
         $this->friendlyErrorMessage = $title;
         return $this;
@@ -84,7 +84,7 @@ class DebugViewFriendlyErrorFormatter implements FormatterInterface
      *
      * @return string
      */
-    public function getBody()
+    public function getBody(): string
     {
         return $this->friendlyErrorDetail;
     }
@@ -95,20 +95,20 @@ class DebugViewFriendlyErrorFormatter implements FormatterInterface
      * @param string $body
      * @return $this
      */
-    public function setBody($body)
+    public function setBody(string $body): SilverStripe\Logging\DebugViewFriendlyErrorFormatter
     {
         $this->friendlyErrorDetail = $body;
         return $this;
     }
 
-    public function format(array $record)
+    public function format(array $record): string
     {
         // Get error code
         $code = empty($record['code']) ? $this->getStatusCode() : $record['code'];
         return $this->output($code);
     }
 
-    public function formatBatch(array $records)
+    public function formatBatch(array $records): string
     {
         $message = '';
         foreach ($records as $record) {
@@ -123,7 +123,7 @@ class DebugViewFriendlyErrorFormatter implements FormatterInterface
      * @param int $statusCode
      * @return string Content in an appropriate format for the current request
      */
-    public function output($statusCode)
+    public function output(int $statusCode): string
     {
         // TODO: Refactor into a content-type option
         if (Director::is_ajax()) {
@@ -147,7 +147,7 @@ class DebugViewFriendlyErrorFormatter implements FormatterInterface
      *
      * @return string|null
      */
-    private function addContactAdministratorInfo()
+    private function addContactAdministratorInfo(): string
     {
         if (!$adminEmail = Email::config()->admin_email) {
             return null;

--- a/src/Logging/DetailedErrorFormatter.php
+++ b/src/Logging/DetailedErrorFormatter.php
@@ -11,7 +11,7 @@ use Exception;
  */
 class DetailedErrorFormatter implements FormatterInterface
 {
-    public function format(array $record)
+    public function format(array $record): string
     {
         if (isset($record['context']['exception'])) {
             /** @var Exception $exception */
@@ -55,7 +55,7 @@ class DetailedErrorFormatter implements FormatterInterface
         );
     }
 
-    public function formatBatch(array $records)
+    public function formatBatch(array $records): string
     {
         return implode("\n", array_map([$this, 'format'], $records ?? []));
     }
@@ -67,7 +67,7 @@ class DetailedErrorFormatter implements FormatterInterface
      * @param string $line The line number to look for
      * @return int|null The matching row number, if found, or null if not found
      */
-    protected function findInTrace(array $trace, $file, $line)
+    protected function findInTrace(array $trace, string $file, int $line): int|null
     {
         foreach ($trace as $i => $call) {
             if (isset($call['file']) && isset($call['line']) && $call['file'] == $file && $call['line'] == $line) {
@@ -88,7 +88,7 @@ class DetailedErrorFormatter implements FormatterInterface
      * @param array $errcontext
      * @return string
      */
-    protected function output($errno, $errstr, $errfile, $errline, $errcontext)
+    protected function output(int $errno, string $errstr, string $errfile, int $errline, array $errcontext): string
     {
         $reporter = Debug::create_debug_view();
 

--- a/src/Logging/HTTPOutputHandler.php
+++ b/src/Logging/HTTPOutputHandler.php
@@ -35,7 +35,7 @@ class HTTPOutputHandler extends AbstractProcessingHandler
      *
      * @return string
      */
-    public function getContentType()
+    public function getContentType(): string
     {
         return $this->contentType;
     }
@@ -58,7 +58,7 @@ class HTTPOutputHandler extends AbstractProcessingHandler
      *
      * @return int
      */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->statusCode;
     }
@@ -82,7 +82,7 @@ class HTTPOutputHandler extends AbstractProcessingHandler
      * @param FormatterInterface $cliFormatter
      * @return HTTPOutputHandler Return $this to allow chainable calls
      */
-    public function setCLIFormatter(FormatterInterface $cliFormatter)
+    public function setCLIFormatter(FormatterInterface $cliFormatter): SilverStripe\Logging\HTTPOutputHandler
     {
         $this->cliFormatter = $cliFormatter;
 
@@ -95,7 +95,7 @@ class HTTPOutputHandler extends AbstractProcessingHandler
      *
      * @return FormatterInterface
      */
-    public function getCLIFormatter()
+    public function getCLIFormatter(): null|SilverStripe\Logging\DebugViewFriendlyErrorFormatter
     {
         return $this->cliFormatter;
     }
@@ -106,7 +106,7 @@ class HTTPOutputHandler extends AbstractProcessingHandler
      *
      * @return FormatterInterface
      */
-    public function getFormatter()
+    public function getFormatter(): SilverStripe\Logging\DetailedErrorFormatter
     {
         if (Director::is_cli() && ($cliFormatter = $this->getCLIFormatter())) {
             return $cliFormatter;
@@ -120,7 +120,7 @@ class HTTPOutputHandler extends AbstractProcessingHandler
      *
      * @return FormatterInterface
      */
-    public function getDefaultFormatter()
+    public function getDefaultFormatter(): SilverStripe\Logging\DetailedErrorFormatter
     {
         return parent::getFormatter();
     }
@@ -131,7 +131,7 @@ class HTTPOutputHandler extends AbstractProcessingHandler
      * @param FormatterInterface $formatter
      * @return $this
      */
-    public function setDefaultFormatter(FormatterInterface $formatter)
+    public function setDefaultFormatter(FormatterInterface $formatter): SilverStripe\Logging\HTTPOutputHandler
     {
         parent::setFormatter($formatter);
         return $this;
@@ -141,7 +141,7 @@ class HTTPOutputHandler extends AbstractProcessingHandler
      * @param array $record
      * @return bool
      */
-    protected function write(array $record)
+    protected function write(array $record): bool
     {
         ini_set('display_errors', 0);
 

--- a/src/Logging/MonologErrorHandler.php
+++ b/src/Logging/MonologErrorHandler.php
@@ -22,7 +22,7 @@ class MonologErrorHandler implements ErrorHandler
      * @param LoggerInterface $logger
      * @return $this
      */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): SilverStripe\Logging\MonologErrorHandler
     {
         Deprecation::notice('4.4.0', 'Please use pushLogger() instead');
 
@@ -49,7 +49,7 @@ class MonologErrorHandler implements ErrorHandler
      * @param LoggerInterface $logger
      * @return $this
      */
-    public function pushLogger(LoggerInterface $logger)
+    public function pushLogger(LoggerInterface $logger): SilverStripe\Logging\MonologErrorHandler
     {
         $this->loggers[] = $logger;
         return $this;
@@ -60,7 +60,7 @@ class MonologErrorHandler implements ErrorHandler
      *
      * @return LoggerInterface[]
      */
-    public function getLoggers()
+    public function getLoggers(): array
     {
         return $this->loggers;
     }
@@ -71,7 +71,7 @@ class MonologErrorHandler implements ErrorHandler
      * @param LoggerInterface[] $loggers
      * @return $this
      */
-    public function setLoggers(array $loggers)
+    public function setLoggers(array $loggers): SilverStripe\Logging\MonologErrorHandler
     {
         $this->loggers = $loggers;
         return $this;
@@ -82,7 +82,7 @@ class MonologErrorHandler implements ErrorHandler
      *
      * @throws InvalidArgumentException
      */
-    public function start()
+    public function start(): void
     {
         $loggers = $this->getLoggers();
         if (empty($loggers)) {

--- a/src/ORM/ArrayLib.php
+++ b/src/ORM/ArrayLib.php
@@ -46,7 +46,7 @@ class ArrayLib
      * @param array $arr
      * @return array
      */
-    public static function invert($arr)
+    public static function invert(array $arr): array
     {
         if (!$arr) {
             return [];
@@ -69,7 +69,7 @@ class ArrayLib
      * @param $arr array
      * @return array
      */
-    public static function valuekey($arr)
+    public static function valuekey(array $arr): array
     {
         return array_combine($arr ?? [], $arr ?? []);
     }
@@ -115,7 +115,7 @@ class ArrayLib
      *
      * @return boolean
      */
-    public static function is_associative($array)
+    public static function is_associative(array|string|bool|int|float|SilverStripe\ORM\ArrayList $array): bool
     {
         $isAssociative = !empty($array)
             && is_array($array)
@@ -164,7 +164,7 @@ class ArrayLib
      * @param $array array
      * @return array
      */
-    public static function array_map_recursive($f, $array)
+    public static function array_map_recursive(string $f, array $array): array
     {
         $applyOrRecurse = function ($v) use ($f) {
             return is_array($v) ? ArrayLib::array_map_recursive($f, $v) : call_user_func($f, $v);
@@ -185,7 +185,7 @@ class ArrayLib
      *
      * @return array
      */
-    public static function array_merge_recursive($array)
+    public static function array_merge_recursive(array $array): array
     {
         $arrays = func_get_args();
         $merged = [];
@@ -230,7 +230,7 @@ class ArrayLib
      *
      * @return array
      */
-    public static function flatten($array, $preserveKeys = true, &$out = [])
+    public static function flatten(array $array, $preserveKeys = true, &$out = []): array
     {
         array_walk_recursive(
             $array,
@@ -257,7 +257,7 @@ class ArrayLib
      * @param array $list
      * @return Generator
      */
-    public static function iterateVolatile(array &$list)
+    public static function iterateVolatile(array &$list): void
     {
         // Keyed by already-iterated items
         $iterated = [];

--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -38,7 +38,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @param array $items - an initial array to fill this object with
      */
-    public function __construct(array $items = [])
+    public function __construct(array $items = []): void
     {
         $this->items = array_values($items ?? []);
         parent::__construct();
@@ -56,7 +56,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @return string
      */
-    public function dataClass()
+    public function dataClass(): null|string
     {
         if ($this->dataClass) {
             return $this->dataClass;
@@ -73,7 +73,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param string $class
      * @return $this
      */
-    public function setDataClass($class)
+    public function setDataClass(string $class): SilverStripe\ORM\ArrayList
     {
         $this->dataClass = $class;
         return $this;
@@ -85,7 +85,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @return int
      */
     #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->items ?? []);
     }
@@ -95,7 +95,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @return bool
      */
-    public function exists()
+    public function exists(): bool
     {
         return !empty($this->items);
     }
@@ -107,7 +107,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @return ArrayIterator
      */
     #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         $items = array_map(
             function ($item) {
@@ -123,7 +123,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->items;
     }
@@ -134,7 +134,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param callable $callback
      * @return $this
      */
-    public function each($callback)
+    public function each(callable $callback): SilverStripe\ORM\ArrayList
     {
         foreach ($this as $item) {
             $callback($item);
@@ -157,7 +157,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @return array
      */
-    public function toNestedArray()
+    public function toNestedArray(): array
     {
         $result = [];
 
@@ -183,7 +183,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param int $offset
      * @return static
      */
-    public function limit($length, $offset = 0)
+    public function limit(int $length, int $offset = 0): SilverStripe\ORM\ArrayList
     {
         // Type checking: designed for consistency with DataList::limit()
         if (!is_numeric($length) || !is_numeric($offset)) {
@@ -222,7 +222,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @param mixed $item
      */
-    public function add($item)
+    public function add(array|stdClass|SilverStripe\Forms\GridField\GridField $item): void
     {
         $this->push($item);
     }
@@ -232,7 +232,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @param mixed $item
      */
-    public function remove($item)
+    public function remove(array|SilverStripe\Forms\GridField\GridFieldFilterHeader $item): void
     {
         $renumberKeys = false;
         foreach ($this->items as $key => $value) {
@@ -253,7 +253,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param array|object $with
      * @return void
      */
-    public function replace($item, $with)
+    public function replace(array|stdClass $item, array $with): void
     {
         foreach ($this->items as $key => $candidate) {
             if ($candidate === $item) {
@@ -269,7 +269,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @param array|object $with
      */
-    public function merge($with)
+    public function merge(array|SilverStripe\ORM\ArrayList $with): void
     {
         foreach ($with as $item) {
             $this->push($item);
@@ -283,7 +283,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param string $field
      * @return $this
      */
-    public function removeDuplicates($field = 'ID')
+    public function removeDuplicates(string $field = 'ID'): SilverStripe\ORM\ArrayList
     {
         $seen = [];
         $renumberKeys = false;
@@ -311,7 +311,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @param array|object $item
      */
-    public function push($item)
+    public function push(int|array|stdClass|SilverStripe\View\ArrayData $item): void
     {
         $this->items[] = $item;
     }
@@ -321,7 +321,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @return array|object
      */
-    public function pop()
+    public function pop(): array|SilverStripe\ORM\DataObject
     {
         return array_pop($this->items);
     }
@@ -331,7 +331,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @param array|object $item
      */
-    public function unshift($item)
+    public function unshift(array|SilverStripe\Forms\PasswordField $item): void
     {
         array_unshift($this->items, $item);
     }
@@ -341,7 +341,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @return array|object
      */
-    public function shift()
+    public function shift(): array|SilverStripe\View\ArrayData
     {
         return array_shift($this->items);
     }
@@ -351,7 +351,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @return mixed
      */
-    public function first()
+    public function first(): null|array|stdClass|SilverStripe\Forms\TextField
     {
         if (empty($this->items)) {
             return null;
@@ -365,7 +365,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @return mixed
      */
-    public function last()
+    public function last(): array|stdClass|SilverStripe\View\ArrayData
     {
         if (empty($this->items)) {
             return null;
@@ -381,7 +381,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param string $titlefield The value field of the result array
      * @return Map
      */
-    public function map($keyfield = 'ID', $titlefield = 'Title')
+    public function map(string $keyfield = 'ID', string $titlefield = 'Title'): SilverStripe\ORM\Map
     {
         $list = clone $this;
         return new Map($list, $keyfield, $titlefield);
@@ -394,7 +394,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param string $value
      * @return mixed
      */
-    public function find($key, $value)
+    public function find(string $key, string|int $value): null|stdClass|SilverStripe\View\ArrayData
     {
         foreach ($this->items as $item) {
             if ($this->extractValue($item, $key) == $value) {
@@ -410,7 +410,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param string $colName
      * @return array
      */
-    public function column($colName = 'ID')
+    public function column(string $colName = 'ID'): array
     {
         $result = [];
 
@@ -438,7 +438,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param string $by
      * @return bool
      */
-    public function canSortBy($by)
+    public function canSortBy(string $by): bool
     {
         return true;
     }
@@ -448,7 +448,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @return ArrayList
      */
-    public function reverse()
+    public function reverse(): SilverStripe\ORM\ArrayList
     {
         $list = clone $this;
         $list->items = array_reverse($this->items ?? []);
@@ -463,7 +463,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param mixed $direction Optional Additional argument which may contain the direction
      * @return array Sort specification in the form array("Column", SORT_ASC).
      */
-    protected function parseSortColumn($column, $direction = null)
+    protected function parseSortColumn(string|int $column, string $direction = null): array
     {
         // Substitute the direction for the column if column is a numeric index
         if ($direction && (empty($column) || is_numeric($column))) {
@@ -507,7 +507,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @example $list->sort('Name', 'ASC');
      * @example $list->sort(array('Name'=>'ASC,'Age'=>'DESC'));
      */
-    public function sort()
+    public function sort(): SilverStripe\ORM\UnsavedRelationList
     {
         $args = func_get_args();
 
@@ -579,7 +579,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @return $this
      */
-    public function shuffle()
+    public function shuffle(): SilverStripe\ORM\ArrayList
     {
         shuffle($this->items);
 
@@ -594,7 +594,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param string $by
      * @return bool
      */
-    public function canFilterBy($by)
+    public function canFilterBy(string $by): bool
     {
         if (empty($this->items)) {
             return false;
@@ -617,7 +617,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @example $list->filter(array('Name'=>array('aziz','bob'), 'Age'=>array(21, 43)));
      *          // aziz with the age 21 or 43 and bob with the Age 21 or 43
      */
-    public function filter()
+    public function filter(): SilverStripe\ORM\ArrayList
     {
 
         $keepUs = call_user_func_array([$this, 'normaliseFilterArgs'], func_get_args());
@@ -660,7 +660,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param string|array See {@link filter()}
      * @return static
      */
-    public function filterAny()
+    public function filterAny(): SilverStripe\ORM\UnsavedRelationList
     {
         $keepUs = $this->normaliseFilterArgs(...func_get_args());
 
@@ -691,7 +691,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      *
      * @return array The normalised keyed array
      */
-    protected function normaliseFilterArgs($column, $value = null)
+    protected function normaliseFilterArgs(string|array $column, int|bool|array|string $value = null): array
     {
         $args = func_get_args();
         if (count($args ?? []) > 2) {
@@ -722,13 +722,13 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param array $ids Array of integers, will be automatically cast/escaped.
      * @return ArrayList
      */
-    public function byIDs($ids)
+    public function byIDs(array $ids): SilverStripe\ORM\ArrayList
     {
         $ids = array_map('intval', $ids ?? []); // sanitize
         return $this->filter('ID', $ids);
     }
 
-    public function byID($id)
+    public function byID(int $id): array|null|SilverStripe\Versioned\Tests\VersionedTest\TestObject
     {
         $firstElement = $this->filter("ID", $id)->first();
 
@@ -746,7 +746,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param callable $callback
      * @return ArrayList
      */
-    public function filterByCallback($callback)
+    public function filterByCallback(callable $callback): SilverStripe\UserForms\FormField\UserFormsFieldList
     {
         if (!is_callable($callback)) {
             throw new LogicException(sprintf(
@@ -778,7 +778,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @example $list->exclude(array('Name'=>array('bob','phil'), 'Age'=>array(21, 43)));
      *          // bob age 21 or 43, phil age 21 or 43 would be excluded
      */
-    public function exclude()
+    public function exclude(): SilverStripe\ORM\ArrayList
     {
         $removeUs = $this->normaliseFilterArgs(...func_get_args());
 
@@ -820,7 +820,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @return bool
      */
     #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists(int|string $offset): bool
     {
         return array_key_exists($offset, $this->items ?? []);
     }
@@ -832,7 +832,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @return DataObject
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet(int|string $offset): array|stdClass|string|SilverStripe\View\ArrayData
     {
         if ($this->offsetExists($offset)) {
             return $this->items[$offset];
@@ -847,7 +847,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param mixed $value
      */
     #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet(string|int $offset, array|string|DNADesign\Elemental\Models\ElementalArea $value): void
     {
         if ($offset === null) {
             $this->items[] = $value;
@@ -862,7 +862,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param mixed $offset
      */
     #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset(int $offset): void
     {
         unset($this->items[$offset]);
     }
@@ -875,7 +875,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @param string $key
      * @return mixed
      */
-    protected function extractValue($item, $key)
+    protected function extractValue(array|stdClass|DNADesign\Elemental\Tests\Src\TestPage $item, string $key): int|string|null|bool|SilverStripe\ORM\FieldType\DBHTMLText
     {
         if (is_object($item)) {
             if (method_exists($item, 'hasMethod') && $item->hasMethod($key)) {

--- a/src/ORM/Connect/DBConnector.php
+++ b/src/ORM/Connect/DBConnector.php
@@ -44,7 +44,7 @@ abstract class DBConnector
      * @param array $parameters Parameters passed to the query
      * @throws DatabaseException
      */
-    protected function databaseError($msg, $errorLevel = E_USER_ERROR, $sql = null, $parameters = [])
+    protected function databaseError(string $msg, int $errorLevel = E_USER_ERROR, string $sql = null, array $parameters = [])
     {
         // Prevent errors when error checking is set at zero level
         if (empty($errorLevel)) {
@@ -88,7 +88,7 @@ abstract class DBConnector
      * @param string $sql
      * @return bool
      */
-    public function isQueryDDL($sql)
+    public function isQueryDDL(string $sql): bool
     {
         $operations = Config::inst()->get(static::class, 'ddl_operations');
         return $this->isQueryType($sql, $operations);
@@ -114,7 +114,7 @@ abstract class DBConnector
      * @param string|array $type Type or list of types (first word in the query). Must be lowercase
      * @return bool
      */
-    protected function isQueryType($sql, $type)
+    protected function isQueryType(string $sql, array $type): bool
     {
         if (!preg_match('/^(?<operation>\w+)\b/', $sql ?? '', $matches)) {
             return false;
@@ -132,7 +132,7 @@ abstract class DBConnector
      * @param array $parameters
      * @return array List of parameter values
      */
-    protected function parameterValues($parameters)
+    protected function parameterValues(array $parameters): array
     {
         $values = [];
         foreach ($parameters as $value) {

--- a/src/ORM/Connect/DBQueryBuilder.php
+++ b/src/ORM/Connect/DBQueryBuilder.php
@@ -21,7 +21,7 @@ class DBQueryBuilder
      *
      * @return string Non-empty whitespace character
      */
-    public function getSeparator()
+    public function getSeparator(): string
     {
         return "\n ";
     }
@@ -33,7 +33,7 @@ class DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string The resulting SQL as a string
      */
-    public function buildSQL(SQLExpression $query, &$parameters)
+    public function buildSQL(SQLExpression $query, &$parameters): string|null
     {
         $sql = null;
         $parameters = [];
@@ -66,7 +66,7 @@ class DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string Completed SQL string
      */
-    protected function buildSelectQuery(SQLSelect $query, array &$parameters)
+    protected function buildSelectQuery(SQLSelect $query, array &$parameters): string
     {
         $sql  = $this->buildSelectFragment($query, $parameters);
         $sql .= $this->buildFromFragment($query, $parameters);
@@ -85,7 +85,7 @@ class DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string Completed SQL string
      */
-    protected function buildDeleteQuery(SQLDelete $query, array &$parameters)
+    protected function buildDeleteQuery(SQLDelete $query, array &$parameters): string
     {
         $sql  = $this->buildDeleteFragment($query, $parameters);
         $sql .= $this->buildFromFragment($query, $parameters);
@@ -100,7 +100,7 @@ class DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string Completed SQL string
      */
-    protected function buildInsertQuery(SQLInsert $query, array &$parameters)
+    protected function buildInsertQuery(SQLInsert $query, array &$parameters): string
     {
         $nl = $this->getSeparator();
         $into = $query->getInto();
@@ -148,7 +148,7 @@ class DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string Completed SQL string
      */
-    protected function buildUpdateQuery(SQLUpdate $query, array &$parameters)
+    protected function buildUpdateQuery(SQLUpdate $query, array &$parameters): string
     {
         $sql  = $this->buildUpdateFragment($query, $parameters);
         $sql .= $this->buildWhereFragment($query, $parameters);
@@ -162,7 +162,7 @@ class DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string Completed select part of statement
      */
-    protected function buildSelectFragment(SQLSelect $query, array &$parameters)
+    protected function buildSelectFragment(SQLSelect $query, array &$parameters): string
     {
         $distinct = $query->getDistinct();
         $select = $query->getSelect();
@@ -192,7 +192,7 @@ class DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string Completed delete part of statement
      */
-    public function buildDeleteFragment(SQLDelete $query, array &$parameters)
+    public function buildDeleteFragment(SQLDelete $query, array &$parameters): string
     {
         $text = 'DELETE';
 
@@ -212,7 +212,7 @@ class DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string Completed from part of statement
      */
-    public function buildUpdateFragment(SQLUpdate $query, array &$parameters)
+    public function buildUpdateFragment(SQLUpdate $query, array &$parameters): string
     {
         $table = $query->getTable();
         $text = "UPDATE $table";
@@ -239,7 +239,7 @@ class DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string Completed from part of statement
      */
-    public function buildFromFragment(SQLConditionalExpression $query, array &$parameters)
+    public function buildFromFragment(SQLConditionalExpression $query, array &$parameters): string
     {
         $from = $query->getJoins($joinParameters);
         $parameters = array_merge($parameters, $joinParameters);
@@ -254,7 +254,7 @@ class DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string Completed where condition
      */
-    public function buildWhereFragment(SQLConditionalExpression $query, array &$parameters)
+    public function buildWhereFragment(SQLConditionalExpression $query, array &$parameters): string
     {
         // Get parameterised elements
         $where = $query->getWhereParameterised($whereParameters);
@@ -276,7 +276,7 @@ class DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string Completed order by part of statement
      */
-    public function buildOrderByFragment(SQLSelect $query, array &$parameters)
+    public function buildOrderByFragment(SQLSelect $query, array &$parameters): string
     {
         $orderBy = $query->getOrderBy();
         if (empty($orderBy)) {
@@ -300,7 +300,7 @@ class DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string Completed group part of statement
      */
-    public function buildGroupByFragment(SQLSelect $query, array &$parameters)
+    public function buildGroupByFragment(SQLSelect $query, array &$parameters): string
     {
         $groupBy = $query->getGroupBy();
         if (empty($groupBy)) {
@@ -318,7 +318,7 @@ class DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string
      */
-    public function buildHavingFragment(SQLSelect $query, array &$parameters)
+    public function buildHavingFragment(SQLSelect $query, array &$parameters): string
     {
         $having = $query->getHavingParameterised($havingParameters);
         if (empty($having)) {

--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -62,7 +62,7 @@ abstract class DBSchemaManager
      *
      * @deprecated 4.0.0:5.0.0
      */
-    public static function showTableNameWarning($table, $class)
+    public static function showTableNameWarning(string $table, string $class): void
     {
         static::$table_name_warnings[$table] = $class;
     }
@@ -72,7 +72,7 @@ abstract class DBSchemaManager
      *
      * @param Database $database
      */
-    public function setDatabase(Database $database)
+    public function setDatabase(Database $database): void
     {
         $this->database = $database;
     }
@@ -104,7 +104,7 @@ abstract class DBSchemaManager
      *
      * @param bool $quiet
      */
-    public function quiet($quiet = true)
+    public function quiet(bool $quiet = true): void
     {
         $this->supressOutput = $quiet;
     }
@@ -118,7 +118,7 @@ abstract class DBSchemaManager
      * @param int $errorLevel The level of error reporting to enable for the query
      * @return Query
      */
-    public function query($sql, $errorLevel = E_USER_ERROR)
+    public function query(string $sql, $errorLevel = E_USER_ERROR): SilverStripe\ORM\Connect\MySQLQuery
     {
         return $this->database->query($sql, $errorLevel);
     }
@@ -142,7 +142,7 @@ abstract class DBSchemaManager
      *
      * @param callable $callback
      */
-    public function schemaUpdate($callback)
+    public function schemaUpdate(callable $callback): void
     {
         // Begin schema update
         $this->schemaIsUpdating = true;
@@ -204,7 +204,7 @@ abstract class DBSchemaManager
     /**
      * Cancels the schema updates requested during (but not after) schemaUpdate() call.
      */
-    public function cancelSchemaUpdate()
+    public function cancelSchemaUpdate(): void
     {
         $this->schemaUpdateTransaction = null;
         $this->schemaIsUpdating = false;
@@ -215,7 +215,7 @@ abstract class DBSchemaManager
      *
      * @return boolean
      */
-    function isSchemaUpdating()
+    function isSchemaUpdating(): bool
     {
         return $this->schemaIsUpdating;
     }
@@ -225,7 +225,7 @@ abstract class DBSchemaManager
      *
      * @return boolean
      */
-    public function doesSchemaNeedUpdating()
+    public function doesSchemaNeedUpdating(): bool
     {
         return (bool) $this->schemaUpdateTransaction;
     }
@@ -239,7 +239,7 @@ abstract class DBSchemaManager
      * @param array $options Create table options (ENGINE, etc.)
      * @param array $advanced_options Advanced table creation options
      */
-    public function transCreateTable($table, $options = null, $advanced_options = null)
+    public function transCreateTable(string $table, array $options = null, bool $advanced_options = null): void
     {
         $this->schemaUpdateTransaction[$table] = [
             'command' => 'create',
@@ -271,7 +271,7 @@ abstract class DBSchemaManager
      * @param string $field Name of the field to create
      * @param string $schema Field specification as a string
      */
-    public function transCreateField($table, $field, $schema)
+    public function transCreateField(string $table, string $field, string $schema): void
     {
         $this->transInitTable($table);
         $this->schemaUpdateTransaction[$table]['newFields'][$field] = $schema;
@@ -284,7 +284,7 @@ abstract class DBSchemaManager
      * @param string $index Name of the index to create
      * @param array $schema Already parsed index specification
      */
-    public function transCreateIndex($table, $index, $schema)
+    public function transCreateIndex(string $table, string $index, array $schema): void
     {
         $this->transInitTable($table);
         $this->schemaUpdateTransaction[$table]['newIndexes'][$index] = $schema;
@@ -297,7 +297,7 @@ abstract class DBSchemaManager
      * @param string $field Name of the field to update
      * @param string $schema Field specification as a string
      */
-    public function transAlterField($table, $field, $schema)
+    public function transAlterField(string $table, string $field, string $schema): void
     {
         $this->transInitTable($table);
         $this->schemaUpdateTransaction[$table]['alteredFields'][$field] = $schema;
@@ -310,7 +310,7 @@ abstract class DBSchemaManager
      * @param string $index Name of the index to update
      * @param array $schema Already parsed index specification
      */
-    public function transAlterIndex($table, $index, $schema)
+    public function transAlterIndex(string $table, string $index, array $schema): void
     {
         $this->transInitTable($table);
         $this->schemaUpdateTransaction[$table]['alteredIndexes'][$index] = $schema;
@@ -322,7 +322,7 @@ abstract class DBSchemaManager
      *
      * @param string $table Name of the table to initialise
      */
-    protected function transInitTable($table)
+    protected function transInitTable(string $table): void
     {
         if (!isset($this->schemaUpdateTransaction[$table])) {
             $this->schemaUpdateTransaction[$table] = [
@@ -354,13 +354,13 @@ abstract class DBSchemaManager
      * @param array|bool $extensions List of extensions
      */
     public function requireTable(
-        $table,
+        string $table,
         $fieldSchema = null,
         $indexSchema = null,
         $hasAutoIncPK = true,
         $options = [],
         $extensions = false
-    ) {
+    ): void {
         if (!isset($this->tableList[strtolower($table)])) {
             $this->transCreateTable($table, $options, $extensions);
             $this->alterationMessage("Table $table: created", "created");
@@ -455,7 +455,7 @@ MESSAGE
      * If the given table exists, move it out of the way by renaming it to _obsolete_(tablename).
      * @param string $table The table name.
      */
-    public function dontRequireTable($table)
+    public function dontRequireTable(string $table): void
     {
         if (!isset($this->tableList[strtolower($table)])) {
             return;
@@ -488,7 +488,7 @@ MESSAGE
      * @param string|array|boolean $spec The specification of the index in any
      * loose format. See requireTable() for more information.
      */
-    public function requireIndex($table, $index, $spec)
+    public function requireIndex(string $table, string $index, array $spec): void
     {
         // Detect if adding to a new table
         $newTable = !isset($this->tableList[strtolower($table)]);
@@ -548,7 +548,7 @@ MESSAGE
      * @param array $columns List of columns to implode
      * @return string A properly quoted list of column names
      */
-    protected function implodeColumnList($columns)
+    protected function implodeColumnList(array $columns): string
     {
         if (empty($columns)) {
             return '';
@@ -600,7 +600,7 @@ MESSAGE
      * @param string|array $indexSpec
      * @return string
      */
-    protected function convertIndexSpec($indexSpec)
+    protected function convertIndexSpec(array $indexSpec): string
     {
         // Return already converted spec
         if (!is_array($indexSpec)
@@ -636,7 +636,7 @@ MESSAGE
      * @param string $fieldName - The field to check
      * @return bool - True if the table exists and the field exists on the table
      */
-    public function hasField($tableName, $fieldName)
+    public function hasField(string $tableName, string $fieldName): bool
     {
         if (!$this->hasTable($tableName)) {
             return false;
@@ -655,7 +655,7 @@ MESSAGE
      *  be prepared as a direct SQL framgment ready for insertion into ALTER TABLE. In this case you'll
      *  need to take care of database abstraction in your DBField subclass.
      */
-    public function requireField($table, $field, $spec)
+    public function requireField(string $table, string $field, string|array $spec): void
     {
         //TODO: this is starting to get extremely fragmented.
         //There are two different versions of $spec floating around, and their content changes depending
@@ -761,7 +761,7 @@ MESSAGE
      * @param string $table
      * @param string $fieldName
      */
-    public function dontRequireField($table, $fieldName)
+    public function dontRequireField(string $table, string $fieldName): void
     {
         $fieldList = $this->fieldList($table);
         if (array_key_exists($fieldName, $fieldList ?? [])) {
@@ -785,7 +785,7 @@ MESSAGE
      * @param string $message to display
      * @param string $type one of [created|changed|repaired|obsolete|deleted|error]
      */
-    public function alterationMessage($message, $type = "")
+    public function alterationMessage(string $message, string $type = ""): void
     {
         if (!$this->supressOutput) {
             if (Director::is_cli()) {
@@ -858,7 +858,7 @@ MESSAGE
      *
      * @param string $tableName Name of table in desired case
      */
-    public function fixTableCase($tableName)
+    public function fixTableCase(string $tableName): void
     {
         // Check if table exists
         $tables = $this->tableList();
@@ -1060,7 +1060,7 @@ MESSAGE
      * @param string $tableName
      * @return boolean
      */
-    public function clearCachedFieldlist($tableName = null)
+    public function clearCachedFieldlist($tableName = null): bool
     {
         return true;
     }

--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -64,7 +64,7 @@ abstract class Database
      *
      * @return DBConnector
      */
-    public function getConnector()
+    public function getConnector(): SilverStripe\ORM\Connect\MySQLiConnector
     {
         return $this->connector;
     }
@@ -74,7 +74,7 @@ abstract class Database
      *
      * @param DBConnector $connector
      */
-    public function setConnector(DBConnector $connector)
+    public function setConnector(DBConnector $connector): void
     {
         $this->connector = $connector;
     }
@@ -91,7 +91,7 @@ abstract class Database
      *
      * @return DBSchemaManager
      */
-    public function getSchemaManager()
+    public function getSchemaManager(): SilverStripe\ORM\Connect\MySQLSchemaManager
     {
         return $this->schemaManager;
     }
@@ -101,7 +101,7 @@ abstract class Database
      *
      * @param DBSchemaManager $schemaManager
      */
-    public function setSchemaManager(DBSchemaManager $schemaManager)
+    public function setSchemaManager(DBSchemaManager $schemaManager): void
     {
         $this->schemaManager = $schemaManager;
 
@@ -122,7 +122,7 @@ abstract class Database
      *
      * @return DBQueryBuilder
      */
-    public function getQueryBuilder()
+    public function getQueryBuilder(): SilverStripe\ORM\Connect\MySQLQueryBuilder
     {
         return $this->queryBuilder;
     }
@@ -132,7 +132,7 @@ abstract class Database
      *
      * @param DBQueryBuilder $queryBuilder
      */
-    public function setQueryBuilder(DBQueryBuilder $queryBuilder)
+    public function setQueryBuilder(DBQueryBuilder $queryBuilder): void
     {
         $this->queryBuilder = $queryBuilder;
     }
@@ -144,7 +144,7 @@ abstract class Database
      * @param int $errorLevel The level of error reporting to enable for the query
      * @return Query
      */
-    public function query($sql, $errorLevel = E_USER_ERROR)
+    public function query(string $sql, int $errorLevel = E_USER_ERROR): SilverStripe\ORM\Connect\MySQLQuery
     {
         // Check if we should only preview this query
         if ($this->previewWrite($sql)) {
@@ -170,7 +170,7 @@ abstract class Database
      * @param int $errorLevel The level of error reporting to enable for the query
      * @return Query
      */
-    public function preparedQuery($sql, $parameters, $errorLevel = E_USER_ERROR)
+    public function preparedQuery(string $sql, array $parameters, int $errorLevel = E_USER_ERROR): SilverStripe\ORM\Connect\MySQLQuery
     {
         // Check if we should only preview this query
         if ($this->previewWrite($sql)) {
@@ -197,7 +197,7 @@ abstract class Database
      * @param string $sql The query to be executed
      * @return boolean Flag indicating that the query was previewed
      */
-    protected function previewWrite($sql)
+    protected function previewWrite(string $sql): bool
     {
         // Only preview if previewWrite is set, we are in dev mode, and
         // the query is mutable
@@ -221,7 +221,7 @@ abstract class Database
      * @param array $parameters Parameters for any parameterised query
      * @return mixed Result of query
      */
-    protected function benchmarkQuery($sql, $callback, $parameters = [])
+    protected function benchmarkQuery(string $sql, callable $callback, array $parameters = []): SilverStripe\ORM\Connect\MySQLQuery
     {
         if (isset($_REQUEST['showqueries']) && Director::isDev()) {
             $displaySql = true;
@@ -296,7 +296,7 @@ abstract class Database
      * @param string $table The name of the table to get the generated ID for
      * @return integer the most recently generated ID for the specified table
      */
-    public function getGeneratedID($table)
+    public function getGeneratedID(string $table): int
     {
         return $this->connector->getGeneratedID($table);
     }
@@ -307,7 +307,7 @@ abstract class Database
      *
      * @return boolean Flag indicating that a valid database is connected
      */
-    public function isActive()
+    public function isActive(): bool
     {
         return $this->connector->isActive();
     }
@@ -319,7 +319,7 @@ abstract class Database
      * @param mixed $value Value to be prepared for database query
      * @return string Prepared string
      */
-    public function escapeString($value)
+    public function escapeString(string|SilverStripe\ORM\FieldType\DBDatetime|int $value): string
     {
         return $this->connector->escapeString($value);
     }
@@ -330,7 +330,7 @@ abstract class Database
      * @param mixed $value Value to be prepared for database query
      * @return string Prepared string
      */
-    public function quoteString($value)
+    public function quoteString(string|int|float $value): string
     {
         return $this->connector->quoteString($value);
     }
@@ -344,7 +344,7 @@ abstract class Database
      * @param string $separator Splitter for each component
      * @return string
      */
-    public function escapeIdentifier($value, $separator = '.')
+    public function escapeIdentifier(string $value, string $separator = '.'): string
     {
         // Split string into components
         if (!is_array($value)) {
@@ -361,7 +361,7 @@ abstract class Database
      * @param array $fieldValues
      * @return array List of field values with the keys as escaped column names
      */
-    protected function escapeColumnKeys($fieldValues)
+    protected function escapeColumnKeys(array $fieldValues): array
     {
         $out = [];
         foreach ($fieldValues as $field => $value) {
@@ -384,7 +384,7 @@ abstract class Database
      *
      * @param array $manipulation
      */
-    public function manipulate($manipulation)
+    public function manipulate(array $manipulation): void
     {
         if (empty($manipulation)) {
             return;
@@ -448,7 +448,7 @@ abstract class Database
     /**
      * Clear all data out of the database
      */
-    public function clearAllData()
+    public function clearAllData(): void
     {
         $tables = $this->getSchemaManager()->tableList();
         foreach ($tables as $table) {
@@ -473,7 +473,7 @@ abstract class Database
      * @param bool $isNull Whether to check for NULL or NOT NULL
      * @return string Non-parameterised null comparison clause
      */
-    public function nullCheckClause($field, $isNull)
+    public function nullCheckClause(string $field, bool $isNull): string
     {
         $clause = $isNull
             ? "%s IS NULL"
@@ -586,7 +586,7 @@ abstract class Database
      * Query for the version of the currently connected database
      * @return string Version of this database
      */
-    public function getVersion()
+    public function getVersion(): string
     {
         return $this->connector->getVersion();
     }
@@ -604,7 +604,7 @@ abstract class Database
      * Return the number of rows affected by the previous operation.
      * @return int
      */
-    public function affectedRows()
+    public function affectedRows(): int
     {
         return $this->connector->affectedRows();
     }
@@ -679,11 +679,11 @@ abstract class Database
      * @throws Exception
      */
     public function withTransaction(
-        $callback,
+        callable $callback,
         $errorCallback = null,
         $transactionMode = false,
         $errorIfTransactionsUnsupported = false
-    ) {
+    ): void {
         $supported = $this->supportsTransactions();
         if (!$supported && $errorIfTransactionsUnsupported) {
             throw new BadMethodCallException("Transactions not supported by this database.");
@@ -867,7 +867,7 @@ abstract class Database
      * @param string $name Name of the database to check for
      * @return bool Flag indicating whether this database exists
      */
-    public function databaseExists($name)
+    public function databaseExists(string $name): bool
     {
         return $this->schemaManager->databaseExists($name);
     }
@@ -894,7 +894,7 @@ abstract class Database
      * should be raised
      * @return bool Flag indicating success
      */
-    public function selectDatabase($name, $create = false, $errorLevel = E_USER_ERROR)
+    public function selectDatabase(string $name, bool $create = false, bool $errorLevel = E_USER_ERROR): bool
     {
         // In case our live environment is locked down, we can bypass a SHOW DATABASE check
         $canConnect = Config::inst()->get(static::class, 'optimistic_connect')
@@ -920,7 +920,7 @@ abstract class Database
      * Drop the database that this object is currently connected to.
      * Use with caution.
      */
-    public function dropSelectedDatabase()
+    public function dropSelectedDatabase(): void
     {
         $databaseName = $this->connector->getSelectedDatabase();
         if ($databaseName) {
@@ -934,7 +934,7 @@ abstract class Database
      *
      * @return string|null Name of the selected database, or null if none selected
      */
-    public function getSelectedDatabase()
+    public function getSelectedDatabase(): string|null
     {
         return $this->connector->getSelectedDatabase();
     }

--- a/src/ORM/Connect/DatabaseException.php
+++ b/src/ORM/Connect/DatabaseException.php
@@ -53,7 +53,7 @@ class DatabaseException extends Exception
      * @param string $sql The SQL executed for this query
      * @param array $parameters The parameters given for this query, if any
      */
-    public function __construct($message = '', $code = 0, $previous = null, $sql = null, $parameters = [])
+    public function __construct(string $message = '', int $code = 0, $previous = null, string $sql = null, array $parameters = []): void
     {
         parent::__construct($message, $code, $previous);
         $this->sql = $sql;

--- a/src/ORM/Connect/MySQLQuery.php
+++ b/src/ORM/Connect/MySQLQuery.php
@@ -30,7 +30,7 @@ class MySQLQuery extends Query
      * @param mixed $handle the internal mysql handle that is points to the resultset.
      * Non-mysqli_result values could be given for non-select queries (e.g. true)
      */
-    public function __construct($database, $handle)
+    public function __construct(SilverStripe\ORM\Connect\MySQLiConnector $database, bool|mysqli_result $handle): void
     {
         $this->handle = $handle;
         if (is_object($this->handle)) {
@@ -38,14 +38,14 @@ class MySQLQuery extends Query
         }
     }
 
-    public function __destruct()
+    public function __destruct(): void
     {
         if (is_object($this->handle)) {
             $this->handle->free();
         }
     }
 
-    public function seek($row)
+    public function seek(int $row): array
     {
         if (is_object($this->handle)) {
             // Fix for https://github.com/silverstripe/silverstripe-framework/issues/9097 without breaking the seek() API
@@ -57,7 +57,7 @@ class MySQLQuery extends Query
         return null;
     }
 
-    public function numRecords()
+    public function numRecords(): int
     {
         if (is_object($this->handle)) {
             return $this->handle->num_rows;
@@ -65,7 +65,7 @@ class MySQLQuery extends Query
         return null;
     }
 
-    public function nextRecord()
+    public function nextRecord(): array|bool
     {
         $floatTypes = [MYSQLI_TYPE_FLOAT, MYSQLI_TYPE_DOUBLE, MYSQLI_TYPE_DECIMAL, MYSQLI_TYPE_NEWDECIMAL];
 

--- a/src/ORM/Connect/MySQLQueryBuilder.php
+++ b/src/ORM/Connect/MySQLQueryBuilder.php
@@ -24,7 +24,7 @@ class MySQLQueryBuilder extends DBQueryBuilder
      * @param array $parameters Out parameter for the resulting query parameters
      * @return string The finalised limit SQL fragment
      */
-    public function buildLimitFragment(SQLSelect $query, array &$parameters)
+    public function buildLimitFragment(SQLSelect $query, array &$parameters): string
     {
         $nl = $this->getSeparator();
 

--- a/src/ORM/Connect/MySQLStatement.php
+++ b/src/ORM/Connect/MySQLStatement.php
@@ -59,7 +59,7 @@ class MySQLStatement extends Query
     /**
      * Binds this statement to the variables
      */
-    protected function bind()
+    protected function bind(): void
     {
         $variables = [];
 
@@ -87,7 +87,7 @@ class MySQLStatement extends Query
      * @param mysqli_stmt $statement The related statement, if present
      * @param mysqli_result $metadata The metadata for this statement
      */
-    public function __construct($statement, $metadata)
+    public function __construct(mysqli_stmt $statement, mysqli_result $metadata): void
     {
         $this->statement = $statement;
         $this->metadata = $metadata;
@@ -96,13 +96,13 @@ class MySQLStatement extends Query
         $this->bind();
     }
 
-    public function __destruct()
+    public function __destruct(): void
     {
         $this->statement->close();
         $this->currentRecord = false;
     }
 
-    public function seek($row)
+    public function seek(int $row): array
     {
         $this->rowNum = $row - 1;
 
@@ -113,12 +113,12 @@ class MySQLStatement extends Query
         return $result;
     }
 
-    public function numRecords()
+    public function numRecords(): int
     {
         return $this->statement->num_rows();
     }
 
-    public function nextRecord()
+    public function nextRecord(): bool|array
     {
         // Skip data if out of data
         if (!$this->statement->fetch()) {

--- a/src/ORM/Connect/MySQLTransactionManager.php
+++ b/src/ORM/Connect/MySQLTransactionManager.php
@@ -13,12 +13,12 @@ class MySQLTransactionManager implements TransactionManager
 
     protected $inTransaction = false;
 
-    public function __construct(Database $dbConn)
+    public function __construct(Database $dbConn): void
     {
         $this->dbConn = $dbConn;
     }
 
-    public function transactionStart($transactionMode = false, $sessionCharacteristics = false)
+    public function transactionStart(bool|string $transactionMode = false, bool $sessionCharacteristics = false): bool
     {
         if ($transactionMode || $sessionCharacteristics) {
             Deprecation::notice(
@@ -48,7 +48,7 @@ class MySQLTransactionManager implements TransactionManager
         return true;
     }
 
-    public function transactionEnd($chain = false)
+    public function transactionEnd($chain = false): bool
     {
         if (!$this->inTransaction) {
             throw new DatabaseException("Not in transaction, can't end.");
@@ -67,7 +67,7 @@ class MySQLTransactionManager implements TransactionManager
         return true;
     }
 
-    public function transactionRollback($savepoint = null)
+    public function transactionRollback(string $savepoint = null): bool
     {
         if (!$this->inTransaction) {
             throw new DatabaseException("Not in transaction, can't roll back.");
@@ -83,7 +83,7 @@ class MySQLTransactionManager implements TransactionManager
         return true;
     }
 
-    public function transactionSavepoint($savepoint)
+    public function transactionSavepoint(string $savepoint): void
     {
         $this->dbConn->query("SAVEPOINT $savepoint");
     }
@@ -93,7 +93,7 @@ class MySQLTransactionManager implements TransactionManager
         return (int)$this->inTransaction;
     }
 
-    public function supportsSavepoints()
+    public function supportsSavepoints(): bool
     {
         return true;
     }

--- a/src/ORM/Connect/MySQLiConnector.php
+++ b/src/ORM/Connect/MySQLiConnector.php
@@ -47,7 +47,7 @@ class MySQLiConnector extends DBConnector
      *
      * @param mysqli_stmt $statement
      */
-    protected function setLastStatement($statement)
+    protected function setLastStatement(mysqli_stmt $statement): void
     {
         $this->lastStatement = $statement;
     }
@@ -59,7 +59,7 @@ class MySQLiConnector extends DBConnector
      * @param boolean $success (by reference)
      * @return mysqli_stmt
      */
-    public function prepareStatement($sql, &$success)
+    public function prepareStatement(string $sql, &$success): mysqli_stmt
     {
         // Record last statement for error reporting
         $statement = $this->dbConn->stmt_init();
@@ -73,7 +73,7 @@ class MySQLiConnector extends DBConnector
         return $statement;
     }
 
-    public function connect($parameters, $selectDB = false)
+    public function connect(array $parameters, bool $selectDB = false): void
     {
         // Normally $selectDB is set to false by the MySQLDatabase controller, as per convention
         $selectedDB = ($selectDB && !empty($parameters['database'])) ? $parameters['database'] : null;
@@ -141,7 +141,7 @@ class MySQLiConnector extends DBConnector
         }
     }
 
-    public function __destruct()
+    public function __destruct(): void
     {
         if (is_resource($this->dbConn)) {
             mysqli_close($this->dbConn);
@@ -149,18 +149,18 @@ class MySQLiConnector extends DBConnector
         }
     }
 
-    public function escapeString($value)
+    public function escapeString(string|int|float|SilverStripe\ORM\FieldType\DBDatetime $value): string
     {
         return $this->dbConn->real_escape_string($value ?? '');
     }
 
-    public function quoteString($value)
+    public function quoteString(string|int|float $value): string
     {
         $value = $this->escapeString($value);
         return "'$value'";
     }
 
-    public function getVersion()
+    public function getVersion(): string
     {
         return $this->dbConn->server_info;
     }
@@ -170,13 +170,13 @@ class MySQLiConnector extends DBConnector
      *
      * @param string $sql
      */
-    protected function beforeQuery($sql)
+    protected function beforeQuery(string $sql): void
     {
         // Clear the last statement
         $this->setLastStatement(null);
     }
 
-    public function query($sql, $errorLevel = E_USER_ERROR)
+    public function query(string $sql, int $errorLevel = E_USER_ERROR): SilverStripe\ORM\Connect\MySQLQuery
     {
         $this->beforeQuery($sql);
 
@@ -199,7 +199,7 @@ class MySQLiConnector extends DBConnector
      * @param array $blobs Out parameter for list of blobs to bind separately (by reference)
      * @return array List of parameters appropriate for mysqli_stmt_bind_param function
      */
-    public function parsePreparedParameters($parameters, &$blobs)
+    public function parsePreparedParameters(array $parameters, &$blobs): array
     {
         $types = '';
         $values = [];
@@ -259,7 +259,7 @@ class MySQLiConnector extends DBConnector
      * @param mysqli_stmt $statement MySQLi statement
      * @param array $parameters List of parameters to pass to bind_param
      */
-    public function bindParameters(mysqli_stmt $statement, array $parameters)
+    public function bindParameters(mysqli_stmt $statement, array $parameters): void
     {
         // Because mysqli_stmt::bind_param arguments must be passed by reference
         // we need to do a bit of hackery
@@ -273,7 +273,7 @@ class MySQLiConnector extends DBConnector
         $statement->bind_param(...$boundNames);
     }
 
-    public function preparedQuery($sql, $parameters, $errorLevel = E_USER_ERROR)
+    public function preparedQuery(string $sql, array $parameters, int $errorLevel = E_USER_ERROR): SilverStripe\ORM\Connect\MySQLQuery
     {
         // Shortcut to basic query when not given parameters
         if (empty($parameters)) {
@@ -317,7 +317,7 @@ class MySQLiConnector extends DBConnector
         return new MySQLQuery($this, true);
     }
 
-    public function selectDatabase($name)
+    public function selectDatabase(string $name): bool
     {
         if ($this->dbConn->select_db($name ?? '')) {
             $this->databaseName = $name;
@@ -327,32 +327,32 @@ class MySQLiConnector extends DBConnector
         return false;
     }
 
-    public function getSelectedDatabase()
+    public function getSelectedDatabase(): string|null
     {
         return $this->databaseName;
     }
 
-    public function unloadDatabase()
+    public function unloadDatabase(): void
     {
         $this->databaseName = null;
     }
 
-    public function isActive()
+    public function isActive(): bool
     {
         return $this->databaseName && $this->dbConn && empty($this->dbConn->connect_error);
     }
 
-    public function affectedRows()
+    public function affectedRows(): int
     {
         return $this->dbConn->affected_rows;
     }
 
-    public function getGeneratedID($table)
+    public function getGeneratedID(string $table): int
     {
         return $this->dbConn->insert_id;
     }
 
-    public function getLastError()
+    public function getLastError(): string
     {
         // Check if a statement was used for the most recent query
         if ($this->lastStatement && $this->lastStatement->error) {

--- a/src/ORM/Connect/NestedTransactionManager.php
+++ b/src/ORM/Connect/NestedTransactionManager.php
@@ -34,7 +34,7 @@ class NestedTransactionManager implements TransactionManager
      * Create a NestedTransactionManager
      * @param TransactionManager $child The transaction manager that will handle the topmost transaction
      */
-    public function __construct(TransactionManager $child)
+    public function __construct(TransactionManager $child): void
     {
         $this->child = $child;
     }
@@ -44,7 +44,7 @@ class NestedTransactionManager implements TransactionManager
      * @throws DatabaseException on failure
      * @return bool True on success
      */
-    public function transactionStart($transactionMode = false, $sessionCharacteristics = false)
+    public function transactionStart(bool|string $transactionMode = false, bool $sessionCharacteristics = false): void
     {
         if ($this->transactionNesting <= 0) {
             $this->transactionNesting = 1;
@@ -57,7 +57,7 @@ class NestedTransactionManager implements TransactionManager
         }
     }
 
-    public function transactionEnd($chain = false)
+    public function transactionEnd($chain = false): void
     {
         if ($this->mustRollback) {
             throw new DatabaseException("Child transaction was rolled back, so parent can't be committed");
@@ -78,7 +78,7 @@ class NestedTransactionManager implements TransactionManager
         }
     }
 
-    public function transactionRollback($savepoint = null)
+    public function transactionRollback(bool $savepoint = null): void
     {
         if ($this->transactionNesting < 1) {
             throw new DatabaseException("Not within a transaction, so can't roll back");
@@ -110,7 +110,7 @@ class NestedTransactionManager implements TransactionManager
      *
      * @return int
      */
-    public function transactionDepth()
+    public function transactionDepth(): int
     {
         return $this->transactionNesting;
     }
@@ -120,7 +120,7 @@ class NestedTransactionManager implements TransactionManager
         return $this->child->transactionSavepoint($savepoint);
     }
 
-    public function supportsSavepoints()
+    public function supportsSavepoints(): bool
     {
         return $this->child->supportsSavepoints();
     }

--- a/src/ORM/Connect/PDOConnector.php
+++ b/src/ORM/Connect/PDOConnector.php
@@ -90,7 +90,7 @@ class PDOConnector extends DBConnector implements TransactionManager
     /**
      * Flush all prepared statements
      */
-    public function flushStatements()
+    public function flushStatements(): void
     {
         $this->cachedStatements = [];
     }
@@ -135,12 +135,12 @@ class PDOConnector extends DBConnector implements TransactionManager
      *
      * @return boolean
      */
-    public static function is_emulate_prepare()
+    public static function is_emulate_prepare(): bool
     {
         return self::config()->get('emulate_prepare');
     }
 
-    public function connect($parameters, $selectDB = false)
+    public function connect(array $parameters, $selectDB = false): void
     {
         Deprecation::notice('4.5', 'Use native database drivers in favour of PDO. '
             . 'https://github.com/silverstripe/silverstripe-framework/issues/8598');

--- a/src/ORM/Connect/Query.php
+++ b/src/ORM/Connect/Query.php
@@ -58,7 +58,7 @@ abstract class Query implements Iterator
      * @param string $column
      * @return array
      */
-    public function column($column = null)
+    public function column(string $column = null): array
     {
         $result = [];
 
@@ -94,7 +94,7 @@ abstract class Query implements Iterator
      *
      * @return array
      */
-    public function map()
+    public function map(): array
     {
         $column = [];
         foreach ($this as $record) {
@@ -110,7 +110,7 @@ abstract class Query implements Iterator
      *
      * @return array
      */
-    public function record()
+    public function record(): array|bool
     {
         return $this->next();
     }
@@ -120,7 +120,7 @@ abstract class Query implements Iterator
      *
      * @return string
      */
-    public function value()
+    public function value(): string|int|null|float
     {
         $record = $this->next();
         if ($record) {
@@ -171,7 +171,7 @@ abstract class Query implements Iterator
      * @return void
      */
     #[\ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         if ($this->queryHasBegun && $this->numRecords() > 0) {
             $this->queryHasBegun = false;
@@ -186,7 +186,7 @@ abstract class Query implements Iterator
      * @return array
      */
     #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): array|bool
     {
         if (!$this->currentRecord) {
             return $this->next();
@@ -200,7 +200,7 @@ abstract class Query implements Iterator
      *
      * @return array
      */
-    public function first()
+    public function first(): array|bool
     {
         $this->rewind();
         return $this->current();
@@ -212,7 +212,7 @@ abstract class Query implements Iterator
      * @return int
      */
     #[\ReturnTypeWillChange]
-    public function key()
+    public function key(): int
     {
         return $this->rowNum;
     }
@@ -224,7 +224,7 @@ abstract class Query implements Iterator
      * @return array
      */
     #[\ReturnTypeWillChange]
-    public function next()
+    public function next(): array|bool
     {
         $this->queryHasBegun = true;
         $this->currentRecord = $this->nextRecord();
@@ -238,7 +238,7 @@ abstract class Query implements Iterator
      * @return bool
      */
     #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         if (!$this->queryHasBegun) {
             $this->next();

--- a/src/ORM/Connect/TempDatabase.php
+++ b/src/ORM/Connect/TempDatabase.php
@@ -43,7 +43,7 @@ class TempDatabase
      *
      * @param string $name DB Connection name to use
      */
-    public function __construct($name = 'default')
+    public function __construct($name = 'default'): void
     {
         $this->name = $name;
     }
@@ -54,7 +54,7 @@ class TempDatabase
      * @param string $name
      * @return bool
      */
-    protected function isDBTemp($name)
+    protected function isDBTemp(string $name): bool
     {
         $prefix = Environment::getEnv('SS_DATABASE_PREFIX') ?: 'ss_';
         $result = preg_match(
@@ -67,7 +67,7 @@ class TempDatabase
     /**
      * @return Database
      */
-    protected function getConn()
+    protected function getConn(): MySQLDatabase_ac19722
     {
         return DB::get_conn($this->name);
     }
@@ -77,7 +77,7 @@ class TempDatabase
      *
      * @return bool
      */
-    public function isUsed()
+    public function isUsed(): bool
     {
         $selected = $this->getConn()->getSelectedDatabase();
         return $this->isDBTemp($selected);
@@ -94,7 +94,7 @@ class TempDatabase
     /**
      * Start a transaction for easy rollback after tests
      */
-    public function startTransaction()
+    public function startTransaction(): void
     {
         if (static::getConn()->supportsTransactions()) {
             static::getConn()->transactionStart();
@@ -109,7 +109,7 @@ class TempDatabase
      * is no transaction is counted as a failure, user code should either kill or flush the DB
      * as necessary
      */
-    public function rollbackTransaction()
+    public function rollbackTransaction(): bool
     {
         // Ensure a rollback can be performed
         $success = static::getConn()->supportsTransactions()
@@ -131,7 +131,7 @@ class TempDatabase
     /**
      * Destroy the current temp database
      */
-    public function kill()
+    public function kill(): void
     {
         // Nothing to kill
         if (!$this->isUsed()) {
@@ -163,7 +163,7 @@ class TempDatabase
     /**
      * Remove all content from the temporary database.
      */
-    public function clearAllData()
+    public function clearAllData(): void
     {
         if (!$this->isUsed()) {
             return;
@@ -190,7 +190,7 @@ class TempDatabase
      *
      * @return string DB name
      */
-    public function build()
+    public function build(): string
     {
         // Disable PHPUnit error handling
         $oldErrorHandler = set_error_handler(null);
@@ -229,7 +229,7 @@ class TempDatabase
      *
      * @param array $extraDataObjects
      */
-    protected function rebuildTables($extraDataObjects = [])
+    protected function rebuildTables(array $extraDataObjects = []): void
     {
         DataObject::reset();
 
@@ -297,7 +297,7 @@ class TempDatabase
      *
      * @param array $extraDataObjects List of extra dataobjects to build
      */
-    public function resetDBSchema(array $extraDataObjects = [])
+    public function resetDBSchema(array $extraDataObjects = []): void
     {
         // Skip if no DB
         if (!$this->isUsed()) {

--- a/src/ORM/DB.php
+++ b/src/ORM/DB.php
@@ -84,7 +84,7 @@ class DB
      * be accessed through DB::get_conn($name).  This is useful when you have an application that
      * needs to connect to more than one database.
      */
-    public static function set_conn(Database $connection, $name = 'default')
+    public static function set_conn(Database $connection, string $name = 'default'): void
     {
         self::$connections[$name] = $connection;
     }
@@ -96,7 +96,7 @@ class DB
      * the default connection is returned.
      * @return Database
      */
-    public static function get_conn($name = 'default')
+    public static function get_conn(string $name = 'default'): MySQLDatabase_ac19722
     {
         if (isset(self::$connections[$name])) {
             return self::$connections[$name];
@@ -128,7 +128,7 @@ class DB
      * the default connection is returned.
      * @return DBSchemaManager
      */
-    public static function get_schema($name = 'default')
+    public static function get_schema($name = 'default'): SilverStripe\ORM\Connect\MySQLSchemaManager
     {
         $connection = self::get_conn($name);
         if ($connection) {
@@ -146,7 +146,7 @@ class DB
      * the default connection is returned.
      * @return string The resulting SQL as a string
      */
-    public static function build_sql(SQLExpression $expression, &$parameters, $name = 'default')
+    public static function build_sql(SQLExpression $expression, &$parameters, $name = 'default'): string|null
     {
         $connection = self::get_conn($name);
         if ($connection) {
@@ -164,7 +164,7 @@ class DB
      * the default connection is returned.
      * @return DBConnector
      */
-    public static function get_connector($name = 'default')
+    public static function get_connector($name = 'default'): SilverStripe\ORM\Connect\MySQLiConnector
     {
         $connection = self::get_conn($name);
         if ($connection) {
@@ -224,7 +224,7 @@ class DB
      *
      * @return string|false Name of temp database, or false if not set
      */
-    public static function get_alternative_database_name()
+    public static function get_alternative_database_name(): bool|null
     {
         // Ignore if disabled
         if (!Config::inst()->get(static::class, 'alternative_database_enabled')) {
@@ -260,7 +260,7 @@ class DB
      * @param string $name
      * @return bool
      */
-    public static function valid_alternative_database_name($name)
+    public static function valid_alternative_database_name(string $name): bool
     {
         if (Director::isLive() || empty($name)) {
             return false;
@@ -282,7 +282,7 @@ class DB
      * @param string $label identifier for the connection
      * @return Database
      */
-    public static function connect($databaseConfig, $label = 'default')
+    public static function connect(array $databaseConfig, string $label = 'default'): MySQLDatabase_ac19722
     {
         // This is used by the "testsession" module to test up a test session using an alternative name
         if ($name = self::get_alternative_database_name()) {
@@ -312,7 +312,7 @@ class DB
      * @param array $databaseConfig
      * @param string $name
      */
-    public static function setConfig($databaseConfig, $name = 'default')
+    public static function setConfig(array $databaseConfig, $name = 'default'): void
     {
         static::$configs[$name] = $databaseConfig;
     }
@@ -323,7 +323,7 @@ class DB
      * @param string $name
      * @return mixed
      */
-    public static function getConfig($name = 'default')
+    public static function getConfig(string $name = 'default'): array
     {
         if (isset(static::$configs[$name])) {
             return static::$configs[$name];
@@ -346,7 +346,7 @@ class DB
      * @param int $errorLevel The level of error reporting to enable for the query
      * @return Query
      */
-    public static function query($sql, $errorLevel = E_USER_ERROR)
+    public static function query(string $sql, $errorLevel = E_USER_ERROR): SilverStripe\ORM\Connect\MySQLQuery
     {
         self::$lastQuery = $sql;
 
@@ -362,7 +362,7 @@ class DB
      * @param string $join The string to join each placeholder together with
      * @return string|null Either a list of placeholders, or null
      */
-    public static function placeholders($input, $join = ', ')
+    public static function placeholders(array $input, $join = ', '): string
     {
         if (is_array($input)) {
             $number = count($input ?? []);
@@ -438,7 +438,7 @@ class DB
      * @param int $errorLevel The level of error reporting to enable for the query
      * @return Query
      */
-    public static function prepared_query($sql, $parameters, $errorLevel = E_USER_ERROR)
+    public static function prepared_query(string $sql, array $parameters, $errorLevel = E_USER_ERROR): SilverStripe\ORM\Connect\MySQLQuery
     {
         self::$lastQuery = $sql;
 
@@ -487,7 +487,7 @@ class DB
      *
      * @param array $manipulation
      */
-    public static function manipulate($manipulation)
+    public static function manipulate(array $manipulation): void
     {
         self::$lastQuery = $manipulation;
         self::get_conn()->manipulate($manipulation);
@@ -499,7 +499,7 @@ class DB
      * @param string $table
      * @return int
      */
-    public static function get_generated_id($table)
+    public static function get_generated_id(string $table): int
     {
         return self::get_conn()->getGeneratedID($table);
     }
@@ -509,7 +509,7 @@ class DB
      *
      * @return boolean
      */
-    public static function is_active()
+    public static function is_active(): bool
     {
         return ($conn = self::get_conn()) && $conn->isActive();
     }
@@ -577,13 +577,13 @@ class DB
      * @param array $extensions List of extensions
      */
     public static function require_table(
-        $table,
+        string $table,
         $fieldSchema = null,
         $indexSchema = null,
         $hasAutoIncPK = true,
         $options = null,
         $extensions = null
-    ) {
+    ): void {
         self::get_schema()->requireTable($table, $fieldSchema, $indexSchema, $hasAutoIncPK, $options, $extensions);
     }
 
@@ -594,7 +594,7 @@ class DB
      * @param string $field The field name.
      * @param string $spec The field specification.
      */
-    public static function require_field($table, $field, $spec)
+    public static function require_field(string $table, string $field, string|array $spec): void
     {
         self::get_schema()->requireField($table, $field, $spec);
     }
@@ -616,7 +616,7 @@ class DB
      *
      * @param string $table The table name.
      */
-    public static function dont_require_table($table)
+    public static function dont_require_table(string $table): void
     {
         self::get_schema()->dontRequireTable($table);
     }
@@ -648,7 +648,7 @@ class DB
      *
      * @return integer The number of affected rows
      */
-    public static function affected_rows()
+    public static function affected_rows(): int
     {
         return self::get_conn()->affectedRows();
     }
@@ -659,7 +659,7 @@ class DB
      *
      * @return array The list of tables
      */
-    public static function table_list()
+    public static function table_list(): array
     {
         return self::get_schema()->tableList();
     }
@@ -671,7 +671,7 @@ class DB
      * @param string $table The table name.
      * @return array The list of fields
      */
-    public static function field_list($table)
+    public static function field_list(string $table): array
     {
         return self::get_schema()->fieldList($table);
     }
@@ -681,7 +681,7 @@ class DB
      *
      * @param bool $quiet
      */
-    public static function quiet($quiet = true)
+    public static function quiet(bool $quiet = true): void
     {
         self::get_schema()->quiet($quiet);
     }
@@ -692,7 +692,7 @@ class DB
      * @param string $message to display
      * @param string $type one of [created|changed|repaired|obsolete|deleted|error]
      */
-    public static function alteration_message($message, $type = "")
+    public static function alteration_message(string $message, string $type = ""): void
     {
         self::get_schema()->alterationMessage($message, $type);
     }

--- a/src/ORM/DataExtension.php
+++ b/src/ORM/DataExtension.php
@@ -32,7 +32,7 @@ abstract class DataExtension extends Extension
      * @param ValidationResult $validationResult Local validation result
      * @throws ValidationException
      */
-    public function validate(ValidationResult $validationResult)
+    public function validate(ValidationResult $validationResult): void
     {
     }
 
@@ -42,7 +42,7 @@ abstract class DataExtension extends Extension
      * @param SQLSelect $query Query to augment.
      * @param DataQuery $dataQuery Container DataQuery for this SQLSelect
      */
-    public function augmentSQL(SQLSelect $query, DataQuery $dataQuery = null)
+    public function augmentSQL(SQLSelect $query, DataQuery $dataQuery = null): void
     {
     }
 
@@ -52,7 +52,7 @@ abstract class DataExtension extends Extension
      * When duplicating a table's structure, remember to duplicate the create options
      * as well. See {@link Versioned->augmentDatabase} for an example.
      */
-    public function augmentDatabase()
+    public function augmentDatabase(): void
     {
     }
 
@@ -61,7 +61,7 @@ abstract class DataExtension extends Extension
      *
      * @param array $manipulation Array of operations to augment.
      */
-    public function augmentWrite(&$manipulation)
+    public function augmentWrite(array &$manipulation): void
     {
     }
 
@@ -70,7 +70,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::onBeforeWrite()} for context.
      */
-    public function onBeforeWrite()
+    public function onBeforeWrite(): void
     {
     }
 
@@ -79,7 +79,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::onAfterWrite()} for context.
      */
-    public function onAfterWrite()
+    public function onAfterWrite(): void
     {
     }
 
@@ -88,7 +88,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::onBeforeDelete()} for context.
      */
-    public function onBeforeDelete()
+    public function onBeforeDelete(): void
     {
     }
 
@@ -97,7 +97,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::onAfterDelete()} for context.
      */
-    public function onAfterDelete()
+    public function onAfterDelete(): void
     {
     }
 
@@ -106,7 +106,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::requireDefaultRecords()} for context.
      */
-    public function requireDefaultRecords()
+    public function requireDefaultRecords(): void
     {
     }
 
@@ -115,7 +115,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::populateDefaults()} for context.
      */
-    public function populateDefaults()
+    public function populateDefaults(): void
     {
     }
 
@@ -124,7 +124,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::onAfterBuild()} for context.
      */
-    public function onAfterBuild()
+    public function onAfterBuild(): void
     {
     }
 
@@ -138,7 +138,7 @@ abstract class DataExtension extends Extension
      * @param Member $member
      * @return bool|null
      */
-    public function can($member)
+    public function can(SilverStripe\Security\Member $member): void
     {
     }
 
@@ -152,7 +152,7 @@ abstract class DataExtension extends Extension
      * @param Member $member
      * @return bool|null
      */
-    public function canEdit($member)
+    public function canEdit(int|SilverStripe\Security\Member|bool $member): void
     {
     }
 
@@ -166,7 +166,7 @@ abstract class DataExtension extends Extension
      * @param Member $member
      * @return bool|null
      */
-    public function canDelete($member)
+    public function canDelete(SilverStripe\Security\Member $member): void
     {
     }
 
@@ -180,7 +180,7 @@ abstract class DataExtension extends Extension
      * @param Member $member
      * @return bool|null
      */
-    public function canCreate($member)
+    public function canCreate(SilverStripe\Security\Member $member): void
     {
     }
 
@@ -195,7 +195,7 @@ abstract class DataExtension extends Extension
      * @return array Returns a map where the keys are db, has_one, etc, and
      *               the values are additional fields/relations to be defined.
      */
-    public function extraStatics($class = null, $extension = null)
+    public function extraStatics($class = null, $extension = null): array
     {
         return [];
     }
@@ -213,7 +213,7 @@ abstract class DataExtension extends Extension
      *
      * @param FieldList $fields FieldList with a contained TabSet
      */
-    public function updateCMSFields(FieldList $fields)
+    public function updateCMSFields(FieldList $fields): void
     {
     }
 
@@ -236,7 +236,7 @@ abstract class DataExtension extends Extension
      *
      * @param FieldList $fields FieldList without TabSet nesting
      */
-    public function updateFrontEndFields(FieldList $fields)
+    public function updateFrontEndFields(FieldList $fields): void
     {
     }
 
@@ -246,7 +246,7 @@ abstract class DataExtension extends Extension
      *
      * @param FieldList $actions FieldList
      */
-    public function updateCMSActions(FieldList $actions)
+    public function updateCMSActions(FieldList $actions): void
     {
     }
 
@@ -258,7 +258,7 @@ abstract class DataExtension extends Extension
      *
      * @param array $fields Array of field names
      */
-    public function updateSummaryFields(&$fields)
+    public function updateSummaryFields(array &$fields): void
     {
         $summary_fields = Config::inst()->get(static::class, 'summary_fields');
         if ($summary_fields) {
@@ -281,7 +281,7 @@ abstract class DataExtension extends Extension
      *
      * @param array $labels Array of field labels
      */
-    public function updateFieldLabels(&$labels)
+    public function updateFieldLabels(array &$labels): void
     {
         $field_labels = Config::inst()->get(static::class, 'field_labels');
         if ($field_labels) {

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -55,7 +55,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @param string $dataClass - The DataObject class to query.
      */
-    public function __construct($dataClass)
+    public function __construct(string $dataClass): void
     {
         $this->dataClass = $dataClass;
         $this->dataQuery = new DataQuery($this->dataClass);
@@ -68,7 +68,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return string
      */
-    public function dataClass()
+    public function dataClass(): string
     {
         return $this->dataClass;
     }
@@ -76,7 +76,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
     /**
      * When cloning this object, clone the dataQuery object as well
      */
-    public function __clone()
+    public function __clone(): void
     {
         $this->dataQuery = clone $this->dataQuery;
     }
@@ -89,7 +89,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return DataQuery
      */
-    public function dataQuery()
+    public function dataQuery(): SilverStripe\ORM\DataQuery
     {
         return clone $this->dataQuery;
     }
@@ -115,7 +115,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @return static
      * @throws Exception
      */
-    public function alterDataQuery($callback)
+    public function alterDataQuery(callable|array $callback): SilverStripe\ORM\DataList
     {
         if ($this->inAlterDataQueryCall) {
             $list = $this;
@@ -151,7 +151,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param DataQuery $dataQuery
      * @return static
      */
-    public function setDataQuery(DataQuery $dataQuery)
+    public function setDataQuery(DataQuery $dataQuery): SilverStripe\ORM\DataList
     {
         $clone = clone $this;
         $clone->dataQuery = $dataQuery;
@@ -165,7 +165,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param mixed $val If $keyOrArray is not an array, this is the value to set
      * @return static
      */
-    public function setDataQueryParam($keyOrArray, $val = null)
+    public function setDataQueryParam(array|string $keyOrArray, bool|string $val = null): SilverStripe\ORM\ManyManyThroughList
     {
         $clone = clone $this;
 
@@ -186,7 +186,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param array $parameters Out variable for parameters required for this query
      * @return string The resulting SQL query (may be parameterised)
      */
-    public function sql(&$parameters = [])
+    public function sql(&$parameters = []): string
     {
         return $this->dataQuery->query()->sql($parameters);
     }
@@ -202,7 +202,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * paramaterised queries
      * @return static
      */
-    public function where($filter)
+    public function where(string|array $filter): SilverStripe\ORM\DataList
     {
         return $this->alterDataQuery(function (DataQuery $query) use ($filter) {
             $query->where($filter);
@@ -221,7 +221,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * paramaterised queries
      * @return static
      */
-    public function whereAny($filter)
+    public function whereAny(array $filter): SilverStripe\ORM\DataList
     {
         return $this->alterDataQuery(function (DataQuery $query) use ($filter) {
             $query->whereAny($filter);
@@ -236,7 +236,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string $fieldName
      * @return boolean
      */
-    public function canSortBy($fieldName)
+    public function canSortBy(string $fieldName): bool
     {
         return $this->dataQuery()->query()->canSortBy($fieldName);
     }
@@ -247,7 +247,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string $fieldName (May be a related field in dot notation like Member.FirstName)
      * @return boolean
      */
-    public function canFilterBy($fieldName)
+    public function canFilterBy(string $fieldName): bool
     {
         $model = singleton($this->dataClass);
         $relations = explode(".", $fieldName ?? '');
@@ -278,7 +278,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param int $offset
      * @return static
      */
-    public function limit($limit, $offset = 0)
+    public function limit(int|bool|string $limit, int|string $offset = 0): SilverStripe\ORM\DataList
     {
         return $this->alterDataQuery(function (DataQuery $query) use ($limit, $offset) {
             $query->limit($limit, $offset);
@@ -291,7 +291,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param bool $value
      * @return static
      */
-    public function distinct($value)
+    public function distinct(bool $value): SilverStripe\ORM\DataList
     {
         return $this->alterDataQuery(function (DataQuery $query) use ($value) {
             $query->distinct($value);
@@ -312,7 +312,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string|array Escaped SQL statement. If passed as array, all keys and values are assumed to be escaped.
      * @return static
      */
-    public function sort()
+    public function sort(): SilverStripe\ORM\DataList
     {
         $count = func_num_args();
 
@@ -383,7 +383,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string|array Escaped SQL statement. If passed as array, all keys and values will be escaped internally
      * @return $this
      */
-    public function filter()
+    public function filter(): SilverStripe\ORM\DataList
     {
         // Validate and process arguments
         $arguments = func_get_args();
@@ -409,7 +409,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param array $filterArray
      * @return $this
      */
-    public function addFilter($filterArray)
+    public function addFilter(array $filterArray): SilverStripe\ORM\DataList
     {
         $list = $this;
 
@@ -445,7 +445,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string|array See {@link filter()}
      * @return static
      */
-    public function filterAny()
+    public function filterAny(): SilverStripe\ORM\DataList
     {
         $numberFuncArgs = count(func_get_args());
         $whereArguments = [];
@@ -477,7 +477,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param callable $callback
      * @return ArrayList (this may change in future implementations)
      */
-    public function filterByCallback($callback)
+    public function filterByCallback(callable $callback): SilverStripe\ORM\ArrayList
     {
         if (!is_callable($callback)) {
             throw new LogicException(sprintf(
@@ -517,7 +517,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * if this relation will be used for sorting, and should not include duplicate rows.
      * @return $this DataList with this relation applied
      */
-    public function applyRelation($field, &$columnName = null, $linearOnly = false)
+    public function applyRelation(string $field, &$columnName = null, bool $linearOnly = false): SilverStripe\ORM\DataList
     {
         // If field is invalid, return it without modification
         if (!$this->isValidRelationName($field)) {
@@ -553,7 +553,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string $field
      * @return bool
      */
-    protected function isValidRelationName($field)
+    protected function isValidRelationName(string $field): int
     {
         return preg_match('/^[A-Z0-9._]+$/i', $field ?? '');
     }
@@ -565,7 +565,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param mixed $value Value of the filter
      * @return SearchFilter
      */
-    protected function createSearchFilter($filter, $value)
+    protected function createSearchFilter(string $filter, int|string|array|bool $value): SilverStripe\ORM\Filters\ExactMatchFilter
     {
         // Field name is always the first component
         $fieldArgs = explode(':', $filter ?? '');
@@ -613,7 +613,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return $this
      */
-    public function exclude()
+    public function exclude(): SilverStripe\ORM\DataList
     {
         $numberFuncArgs = count(func_get_args());
         $whereArguments = [];
@@ -651,7 +651,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return $this
      */
-    public function excludeAny()
+    public function excludeAny(): SilverStripe\ORM\DataList
     {
         $numberFuncArgs = count(func_get_args());
         $whereArguments = [];
@@ -682,7 +682,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @return static
      * @throws InvalidArgumentException
      */
-    public function subtract(DataList $list)
+    public function subtract(DataList $list): SilverStripe\ORM\DataList
     {
         if ($this->dataClass() != $list->dataClass()) {
             throw new InvalidArgumentException('The list passed must have the same dataclass as this class');
@@ -705,7 +705,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param array $parameters Any additional parameters if the join is a parameterised subquery
      * @return static
      */
-    public function innerJoin($table, $onClause, $alias = null, $order = 20, $parameters = [])
+    public function innerJoin(string $table, string $onClause, string $alias = null, int $order = 20, array $parameters = []): SilverStripe\ORM\DataList
     {
         return $this->alterDataQuery(function (DataQuery $query) use ($table, $onClause, $alias, $order, $parameters) {
             $query->innerJoin($table, $onClause, $alias, $order, $parameters);
@@ -724,7 +724,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param array $parameters Any additional parameters if the join is a parameterised subquery
      * @return static
      */
-    public function leftJoin($table, $onClause, $alias = null, $order = 20, $parameters = [])
+    public function leftJoin(string $table, string $onClause, string $alias = null, int $order = 20, array $parameters = []): SilverStripe\ORM\DataList
     {
         return $this->alterDataQuery(function (DataQuery $query) use ($table, $onClause, $alias, $order, $parameters) {
             $query->leftJoin($table, $onClause, $alias, $order, $parameters);
@@ -737,7 +737,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         $query = $this->dataQuery->query();
         $rows = $query->execute();
@@ -755,7 +755,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return array
      */
-    public function toNestedArray()
+    public function toNestedArray(): array
     {
         $result = [];
 
@@ -772,7 +772,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param callable $callback
      * @return $this
      */
-    public function each($callback)
+    public function each(callable $callback): SilverStripe\ORM\HasManyList
     {
         foreach ($this as $row) {
             $callback($row);
@@ -786,7 +786,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return \Generator&DataObject[]
      */
-    public function getGenerator()
+    public function getGenerator(): void
     {
         $query = $this->dataQuery->query()->execute();
 
@@ -812,7 +812,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string $titleField - the value field of the result array
      * @return Map
      */
-    public function map($keyField = 'ID', $titleField = 'Title')
+    public function map(string $keyField = 'ID', string $titleField = 'Title'): SilverStripe\ORM\Map
     {
         return new Map($this, $keyField, $titleField);
     }
@@ -824,7 +824,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param array $row
      * @return DataObject
      */
-    public function createDataObject($row)
+    public function createDataObject(array $row): SilverStripe\SiteConfig\SiteConfig
     {
         $class = $this->dataClass;
 
@@ -855,7 +855,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return array
      */
-    public function getQueryParams()
+    public function getQueryParams(): null|array
     {
         return $this->dataQuery()->getQueryParams();
     }
@@ -867,7 +867,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @return ArrayIterator
      */
     #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->toArray());
     }
@@ -878,7 +878,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @return int
      */
     #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return $this->dataQuery->count();
     }
@@ -889,7 +889,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string $fieldName
      * @return mixed
      */
-    public function max($fieldName)
+    public function max(string $fieldName): null|int|string
     {
         return $this->dataQuery->max($fieldName);
     }
@@ -900,7 +900,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string $fieldName
      * @return mixed
      */
-    public function min($fieldName)
+    public function min(string $fieldName): int|string|null
     {
         return $this->dataQuery->min($fieldName);
     }
@@ -911,7 +911,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string $fieldName
      * @return mixed
      */
-    public function avg($fieldName)
+    public function avg(string $fieldName): float
     {
         return $this->dataQuery->avg($fieldName);
     }
@@ -922,7 +922,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string $fieldName
      * @return mixed
      */
-    public function sum($fieldName)
+    public function sum(string $fieldName): float
     {
         return $this->dataQuery->sum($fieldName);
     }
@@ -935,7 +935,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return DataObject|null
      */
-    public function first()
+    public function first(): null|SilverStripe\SiteConfig\SiteConfig
     {
         foreach ($this->dataQuery->firstRow()->execute() as $row) {
             return $this->createDataObject($row);
@@ -950,7 +950,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return DataObject|null
      */
-    public function last()
+    public function last(): null|DNADesign\Elemental\Models\ElementContent
     {
         foreach ($this->dataQuery->lastRow()->execute() as $row) {
             return $this->createDataObject($row);
@@ -963,7 +963,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return bool
      */
-    public function exists()
+    public function exists(): bool
     {
         return $this->dataQuery->exists();
     }
@@ -977,7 +977,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string $value
      * @return DataObject|null
      */
-    public function find($key, $value)
+    public function find(string $key, string|int $value): null|SilverStripe\Security\Member
     {
         return $this->filter($key, $value)->first();
     }
@@ -988,7 +988,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param array $queriedColumns
      * @return static
      */
-    public function setQueriedColumns($queriedColumns)
+    public function setQueriedColumns(array $queriedColumns): SilverStripe\ORM\DataList
     {
         return $this->alterDataQuery(function (DataQuery $query) use ($queriedColumns) {
             $query->setQueriedColumns($queriedColumns);
@@ -1001,7 +1001,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param array $ids Array of integers
      * @return $this
      */
-    public function byIDs($ids)
+    public function byIDs(array $ids): SilverStripe\ORM\DataList
     {
         return $this->filter('ID', $ids);
     }
@@ -1014,7 +1014,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param int $id
      * @return DataObject|null
      */
-    public function byID($id)
+    public function byID(int|string $id): null|DNADesign\Elemental\Models\ElementalArea
     {
         return $this->filter('ID', $id)->first();
     }
@@ -1025,7 +1025,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string $colName
      * @return array
      */
-    public function column($colName = "ID")
+    public function column(string $colName = "ID"): array
     {
         $dataQuery = clone $this->dataQuery;
         return $dataQuery->distinct(false)->column($colName);
@@ -1037,7 +1037,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string $colName
      * @return array
      */
-    public function columnUnique($colName = "ID")
+    public function columnUnique(string $colName = "ID"): array
     {
         return $this->dataQuery->distinct(true)->column($colName);
     }
@@ -1050,7 +1050,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @param array $idList List of IDs.
      */
-    public function setByIDList($idList)
+    public function setByIDList(array $idList): void
     {
         $has = [];
 
@@ -1083,7 +1083,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return array
      */
-    public function getIDList()
+    public function getIDList(): array
     {
         $ids = $this->column("ID");
         return $ids ? array_combine($ids, $ids) : [];
@@ -1101,7 +1101,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param string $relationName
      * @return HasManyList|ManyManyList
      */
-    public function relation($relationName)
+    public function relation(string $relationName): SilverStripe\Auditor\AuditHookManyManyList
     {
         $ids = $this->column('ID');
         $singleton = DataObject::singleton($this->dataClass);
@@ -1121,7 +1121,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param array $items Items to add, as either DataObjects or IDs.
      * @return $this
      */
-    public function addMany($items)
+    public function addMany(SilverStripe\Auditor\AuditHookManyManyList $items): SilverStripe\Auditor\AuditHookManyManyList
     {
         foreach ($items as $item) {
             $this->add($item);
@@ -1135,7 +1135,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @param array $idList
      * @return $this
      */
-    public function removeMany($idList)
+    public function removeMany(array $idList): SilverStripe\ORM\ManyManyThroughList
     {
         foreach ($idList as $id) {
             $this->removeByID($id);
@@ -1162,7 +1162,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return $this
      */
-    public function shuffle()
+    public function shuffle(): SilverStripe\ORM\DataList
     {
         return $this->sort(DB::get_conn()->random());
     }
@@ -1172,7 +1172,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return $this
      */
-    public function removeAll()
+    public function removeAll(): SilverStripe\ORM\DataList
     {
         foreach ($this as $item) {
             $this->remove($item);
@@ -1186,7 +1186,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @param mixed $item
      */
-    public function add($item)
+    public function add(SilverStripe\FrameworkTest\Elemental\Model\ElementalBehatTestObject $item): void
     {
         // Nothing needs to happen by default
         // TO DO: If a filter is given to this data list then
@@ -1212,7 +1212,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @todo Allow for amendment of this behaviour - for example, we can remove an item from
      * an "ActiveItems" DataList by changing the status to inactive.
      */
-    public function remove($item)
+    public function remove(SilverStripe\Dev\Tests\CsvBulkLoaderTest\Player $item): void
     {
         // By default, we remove an item from a DataList by deleting it.
         $this->removeByID($item->ID);
@@ -1223,7 +1223,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @param int $itemID The primary ID
      */
-    public function removeByID($itemID)
+    public function removeByID(int $itemID): void
     {
         $item = $this->byID($itemID);
 
@@ -1237,7 +1237,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @return static
      */
-    public function reverse()
+    public function reverse(): SilverStripe\ORM\DataList
     {
         return $this->alterDataQuery(function (DataQuery $query) {
             $query->reverseSort();
@@ -1265,7 +1265,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      * @return DataObject
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($key)
+    public function offsetGet(int $key): SilverStripe\CMS\Model\SiteTree
     {
         return $this->limit(1, $key)->first();
     }

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -337,7 +337,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return DataObjectSchema
      */
-    public static function getSchema()
+    public static function getSchema(): SilverStripe\ORM\DataObjectSchema
     {
         return Injector::inst()->get(DataObjectSchema::class);
     }
@@ -351,7 +351,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *   left as the default by regular users.
      * @param array $queryParams List of DataQuery params necessary to lazy load, or load related objects.
      */
-    public function __construct($record = [], $creationType = self::CREATE_OBJECT, $queryParams = [])
+    public function __construct(array|stdClass $record = [], $creationType = self::CREATE_OBJECT, array $queryParams = []): void
     {
         parent::__construct();
 
@@ -442,7 +442,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param array $record
      * @param bool $mustHaveID If true, an exception will be thrown if $record doesn't have an ID.
      */
-    private function hydrate(array $record, bool $mustHaveID)
+    private function hydrate(array $record, bool $mustHaveID): void
     {
         if ($mustHaveID && empty($record['ID'])) {
             // CREATE_HYDRATED requires an ID to be included in the record
@@ -494,7 +494,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * Destroy all of this objects dependent objects and local caches.
      * You'll need to call this to get the memory of an object that has components or extensions freed.
      */
-    public function destroy()
+    public function destroy(): void
     {
         $this->flushCache(false);
     }
@@ -511,7 +511,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * Note: If using versioned, this will additionally failover to `owns` config.
      * @return static A duplicate of this node. The exact type will be the type of this node.
      */
-    public function duplicate($doWrite = true, $relations = null)
+    public function duplicate(bool $doWrite = true, string $relations = null): DNADesign\Elemental\Tests\Src\TestElement
     {
         // Handle legacy behaviour
         if (is_string($relations) || $relations === true) {
@@ -558,7 +558,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param DataObject $destinationObject the destination object to populate with the duplicated relations
      * @param array $relations List of relations
      */
-    protected function duplicateRelations($sourceObject, $destinationObject, $relations)
+    protected function duplicateRelations(DNADesign\Elemental\Models\ElementalArea $sourceObject, DNADesign\Elemental\Models\ElementalArea $destinationObject, array $relations): void
     {
         // Get list of duplicable relation types
         $manyMany = $sourceObject->manyMany();
@@ -627,7 +627,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param DataObject $destinationObject
      * @param string $relation
      */
-    protected function duplicateManyManyRelation($sourceObject, $destinationObject, $relation)
+    protected function duplicateManyManyRelation(DNADesign\Elemental\Tests\Src\TestElement $sourceObject, DNADesign\Elemental\Tests\Src\TestElement $destinationObject, string $relation): void
     {
         // Copy all components from source to destination
         $source = $sourceObject->getManyManyComponents($relation);
@@ -656,7 +656,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param DataObject $destinationObject
      * @param string $relation
      */
-    protected function duplicateHasManyRelation($sourceObject, $destinationObject, $relation)
+    protected function duplicateHasManyRelation(DNADesign\Elemental\Models\ElementalArea $sourceObject, DNADesign\Elemental\Models\ElementalArea $destinationObject, string $relation): void
     {
         // Copy all components from source to destination
         $source = $sourceObject->getComponents($relation);
@@ -680,7 +680,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param DataObject $destinationObject
      * @param string $relation
      */
-    protected function duplicateHasOneRelation($sourceObject, $destinationObject, $relation)
+    protected function duplicateHasOneRelation(DNADesign\Elemental\Tests\Src\TestPage $sourceObject, DNADesign\Elemental\Tests\Src\TestPage $destinationObject, string $relation): void
     {
         // Check if original object exists
         $item = $sourceObject->getComponent($relation);
@@ -700,7 +700,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param DataObject $destinationObject
      * @param string $relation
      */
-    protected function duplicateBelongsToRelation($sourceObject, $destinationObject, $relation)
+    protected function duplicateBelongsToRelation(SilverStripe\ORM\Tests\DataObjectDuplicationTest\Antelope $sourceObject, SilverStripe\ORM\Tests\DataObjectDuplicationTest\Antelope $destinationObject, string $relation): void
     {
         // Check if original object exists
         $item = $sourceObject->getComponent($relation);
@@ -721,7 +721,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return string
      */
-    public function getObsoleteClassName()
+    public function getObsoleteClassName(): null|string
     {
         $className = $this->getField("ClassName");
         if (!ClassInfo::exists($className)) {
@@ -735,7 +735,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return string
      */
-    public function getClassName()
+    public function getClassName(): string
     {
         $className = $this->getField("ClassName");
         if (!ClassInfo::exists($className)) {
@@ -754,7 +754,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $className The new ClassName attribute (a subclass of {@link DataObject})
      * @return $this
      */
-    public function setClassName($className)
+    public function setClassName(string $className): DNADesign\Elemental\Models\ElementalArea
     {
         $className = trim($className ?? '');
         if (!$className || !is_subclass_of($className, self::class)) {
@@ -782,7 +782,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return DataObject The new instance of the new class, The exact type will be of the class name provided.
      */
-    public function newClassInstance($newClassName)
+    public function newClassInstance(string $newClassName): SilverStripe\Assets\File
     {
         if (!is_subclass_of($newClassName, self::class)) {
             throw new InvalidArgumentException("$newClassName is not a valid subclass of DataObject");
@@ -807,7 +807,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * Adds methods from the extensions.
      * Called by Object::__construct() once per class.
      */
-    public function defineMethods()
+    public function defineMethods(): void
     {
         parent::defineMethods();
 
@@ -845,7 +845,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return boolean true if this object exists
      */
-    public function exists()
+    public function exists(): bool
     {
         return (isset($this->record['ID']) && $this->record['ID'] > 0);
     }
@@ -856,7 +856,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return boolean
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         $fixed = DataObject::config()->uninherited('fixed_fields');
         foreach ($this->toMap() as $field => $value) {
@@ -884,7 +884,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $count
      * @return string
      */
-    public function i18n_pluralise($count)
+    public function i18n_pluralise(int $count): string
     {
         $default = 'one ' . $this->i18n_singular_name() . '|{count} ' . $this->i18n_plural_name();
         return i18n::_t(
@@ -901,7 +901,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return string User friendly singular name of this DataObject
      */
-    public function singular_name()
+    public function singular_name(): string
     {
         $name = $this->config()->get('singular_name');
         if ($name) {
@@ -925,7 +925,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return string User friendly translated singular name of this DataObject
      */
-    public function i18n_singular_name()
+    public function i18n_singular_name(): string
     {
         return _t(static::class . '.SINGULARNAME', $this->singular_name());
     }
@@ -937,7 +937,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return string User friendly plural name of this DataObject
      */
-    public function plural_name()
+    public function plural_name(): string
     {
         if ($name = $this->config()->get('plural_name')) {
             return $name;
@@ -960,7 +960,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return string User friendly translated plural name of this DataObject
      */
-    public function i18n_plural_name()
+    public function i18n_plural_name(): string
     {
         return _t(static::class . '.PLURALNAME', $this->plural_name());
     }
@@ -982,7 +982,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string|null|int
     {
         $schema = static::getSchema();
         if ($schema->fieldSpec($this, 'Title')) {
@@ -1014,7 +1014,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return array The data as a map.
      */
-    public function toMap()
+    public function toMap(): array
     {
         $this->loadLazyFields();
         return array_filter($this->record ?? [], function ($val) {
@@ -1030,7 +1030,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return array The data as a map.
      */
-    public function getQueriedDatabaseFields()
+    public function getQueriedDatabaseFields(): array
     {
         return $this->record;
     }
@@ -1050,7 +1050,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param array $data A map of field name to data values to update.
      * @return DataObject $this
      */
-    public function update($data)
+    public function update(array $data): SilverStripe\SiteConfig\SiteConfig
     {
         foreach ($data as $key => $value) {
             // Implement dot syntax for updates
@@ -1140,7 +1140,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *                            Only applicable with $priority='right'. (optional)
      * @return Boolean
      */
-    public function merge($rightObj, $priority = 'right', $includeRelations = true, $overwriteWithEmpty = false)
+    public function merge(SilverStripe\ORM\Tests\DataObjectTest\SubTeam $rightObj, string $priority = 'right', bool $includeRelations = true, bool $overwriteWithEmpty = false): bool
     {
         $leftObj = $this;
 
@@ -1221,7 +1221,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return $this
      */
-    public function forceChange()
+    public function forceChange(): DNADesign\Elemental\Tests\Src\TestPage
     {
         // Ensure lazy fields loaded
         $this->loadLazyFields();
@@ -1253,7 +1253,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @see {@link ValidationResult}
      * @return ValidationResult
      */
-    public function validate()
+    public function validate(): SilverStripe\ORM\ValidationResult
     {
         $result = ValidationResult::create();
         $this->extend('validate', $result);
@@ -1265,7 +1265,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return ValidationResult
      */
-    public function doValidate()
+    public function doValidate(): SilverStripe\ORM\ValidationResult
     {
         Deprecation::notice('5.0', 'Use validate');
         return $this->validate();
@@ -1280,7 +1280,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @uses DataExtension::onBeforeWrite()
      */
-    protected function onBeforeWrite()
+    protected function onBeforeWrite(): void
     {
         $this->brokenOnWrite = false;
 
@@ -1296,7 +1296,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @uses DataExtension::onAfterWrite()
      */
-    protected function onAfterWrite()
+    protected function onAfterWrite(): void
     {
         $dummy = null;
         $this->extend('onAfterWrite', $dummy);
@@ -1313,7 +1313,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param ArrayList $list Optional list to add items to
      * @return ArrayList list of objects
      */
-    public function findCascadeDeletes($recursive = true, $list = null)
+    public function findCascadeDeletes(bool $recursive = true, $list = null): SilverStripe\ORM\ArrayList
     {
         // Find objects in these relationships
         return $this->findRelatedObjects('cascade_deletes', $recursive, $list);
@@ -1326,7 +1326,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @uses DataExtension::onBeforeDelete()
      */
-    protected function onBeforeDelete()
+    protected function onBeforeDelete(): void
     {
         $this->brokenOnDelete = false;
 
@@ -1340,7 +1340,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         }
     }
 
-    protected function onAfterDelete()
+    protected function onAfterDelete(): void
     {
         $this->extend('onAfterDelete');
     }
@@ -1353,7 +1353,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @uses DataExtension::populateDefaults()
      * @return DataObject $this
      */
-    public function populateDefaults()
+    public function populateDefaults(): SilverStripe\CMS\Model\SiteTree
     {
         $classes = array_reverse(ClassInfo::ancestry($this) ?? []);
 
@@ -1396,7 +1396,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return ValidationException Exception generated by this write, or null if valid
      */
-    protected function validateWrite()
+    protected function validateWrite(): null|SilverStripe\ORM\ValidationException
     {
         if ($this->ObsoleteClassName) {
             return new ValidationException(
@@ -1420,7 +1420,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @throws ValidationException
      */
-    protected function preWrite()
+    protected function preWrite(): void
     {
         // Validate this object
         if ($writeException = $this->validateWrite()) {
@@ -1446,7 +1446,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param bool $forceChanges If set to true, force all fields to be treated as changed
      * @return bool True if any changes are detected
      */
-    protected function updateChanges($forceChanges = false)
+    protected function updateChanges(bool $forceChanges = false): bool
     {
         if ($forceChanges) {
             // Force changes, but only for loaded fields
@@ -1467,7 +1467,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param array $manipulation Manipulation to write to
      * @param string $class Class of table to manipulate
      */
-    protected function prepareManipulationTable($baseTable, $now, $isNewRecord, &$manipulation, $class)
+    protected function prepareManipulationTable(string $baseTable, string $now, bool $isNewRecord, &$manipulation, string $class): void
     {
         $schema = $this->getSchema();
         $table = $schema->tableName($class);
@@ -1531,7 +1531,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $baseTable Base table
      * @param string $now Timestamp to use for the current time
      */
-    protected function writeBaseRecord($baseTable, $now)
+    protected function writeBaseRecord(string $baseTable, string $now): void
     {
         // Generate new ID if not specified
         if ($this->isInDB()) {
@@ -1555,7 +1555,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param bool $isNewRecord If this is a new record
      * @throws InvalidArgumentException
      */
-    protected function writeManipulation($baseTable, $now, $isNewRecord)
+    protected function writeManipulation(string $baseTable, string $now, bool $isNewRecord): void
     {
         // Generate database manipulations for each class
         $manipulation = [];
@@ -1614,7 +1614,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @return int The ID of the record
      * @throws ValidationException Exception that can be caught and handled by the calling function
      */
-    public function write($showDebug = false, $forceInsert = false, $forceWrite = false, $writeComponents = false)
+    public function write(bool $showDebug = false, bool $forceInsert = false, bool $forceWrite = false, bool|array $writeComponents = false): int
     {
         $now = DBDatetime::now()->Rfc2822();
 
@@ -1681,7 +1681,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     /**
      * Writes cached relation lists to the database, if possible
      */
-    public function writeRelations()
+    public function writeRelations(): void
     {
         if (!$this->isInDB()) {
             return;
@@ -1704,7 +1704,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param array $skip List of DataObject references to skip
      * @return DataObject $this
      */
-    public function writeComponents($recursive = false, $skip = [])
+    public function writeComponents(bool $recursive = false, array $skip = []): DNADesign\ElementalUserForms\Model\ElementForm
     {
         // Make sure we add our current object to the skip list
         $this->skipWriteComponents($recursive, $this, $skip);
@@ -1737,7 +1737,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param array $skip
      * @return bool Whether the target is already in the list
      */
-    private function skipWriteComponents($recursive, DataObject $target, array &$skip)
+    private function skipWriteComponents(bool $recursive, DataObject $target, array &$skip): bool
     {
         // skip writing component if it doesn't exist
         if (!$target->exists()) {
@@ -1776,7 +1776,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * Note that in Versioned objects, both Stage and Live will be deleted.
      * @uses DataExtension::augmentSQL()
      */
-    public function delete()
+    public function delete(): void
     {
         $this->brokenOnDelete = true;
         $this->onBeforeDelete();
@@ -1822,7 +1822,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $className The class name of the record to be deleted
      * @param int $id ID of record to be deleted
      */
-    public static function delete_by_id($className, $id)
+    public static function delete_by_id(string $className, int $id): void
     {
         $obj = DataObject::get_by_id($className, $id);
         if ($obj) {
@@ -1840,7 +1840,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return array Class ancestry
      */
-    public function getClassAncestry()
+    public function getClassAncestry(): array
     {
         return ClassInfo::ancestry(static::class);
     }
@@ -1854,7 +1854,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @return DataObject The component object. It's exact type will be that of the component.
      * @throws Exception
      */
-    public function getComponent($componentName)
+    public function getComponent(string $componentName): null|SilverStripe\CMS\Model\SiteTree
     {
         if (isset($this->components[$componentName])) {
             return $this->components[$componentName];
@@ -1939,7 +1939,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param DataObject|null $item
      * @return $this
      */
-    public function setComponent($componentName, $item)
+    public function setComponent(string $componentName, DNADesign\Elemental\Models\ElementalArea $item): DNADesign\Elemental\Tests\Src\TestPage
     {
         // Validate component
         $schema = static::getSchema();
@@ -1985,7 +1985,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param int|array $id Optional ID(s) for parent of this relation, if not the current record
      * @return HasManyList|UnsavedRelationList The components of the one-to-many relationship.
      */
-    public function getComponents($componentName, $id = null)
+    public function getComponents(string $componentName, array $id = null): SilverStripe\ORM\UnsavedRelationList
     {
         if (!isset($id)) {
             $id = $this->ID;
@@ -2031,7 +2031,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $relationName Relation name.
      * @return string Class name, or null if not found.
      */
-    public function getRelationClass($relationName)
+    public function getRelationClass(string $relationName): string|null
     {
         // Parse many_many
         $manyManyComponent = $this->getSchema()->manyManyComponent(static::class, $relationName);
@@ -2068,7 +2068,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $component Name of component
      * @return string has_one, has_many, many_many, belongs_many_many or belongs_to
      */
-    public function getRelationType($component)
+    public function getRelationType(string $component): string
     {
         $types = ['has_one', 'has_many', 'many_many', 'belongs_many_many', 'belongs_to'];
         $config = $this->config();
@@ -2098,7 +2098,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @throws BadMethodCallException
      * @throws InvalidArgumentException
      */
-    public function inferReciprocalComponent($remoteClass, $remoteRelation)
+    public function inferReciprocalComponent(string $remoteClass, string $remoteRelation): null|DNADesign\Elemental\Models\ElementalArea
     {
         $remote = DataObject::singleton($remoteClass);
         $class = $remote->getRelationClass($remoteRelation);
@@ -2202,7 +2202,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param int|array $id Optional ID for parent of this relation, if not the current record
      * @return ManyManyList|UnsavedRelationList The set of components
      */
-    public function getManyManyComponents($componentName, $id = null)
+    public function getManyManyComponents(string $componentName, array $id = null): SilverStripe\ORM\UnsavedRelationList
     {
         if (!isset($id)) {
             $id = $this->ID;
@@ -2270,7 +2270,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @return string|array The class of the one-to-one component, or an array of all one-to-one components and
      *                          their classes.
      */
-    public function hasOne()
+    public function hasOne(): array
     {
         return (array)$this->config()->get('has_one');
     }
@@ -2283,7 +2283,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *        the field data stripped off. It defaults to TRUE.
      * @return string|array
      */
-    public function belongsTo($classOnly = true)
+    public function belongsTo($classOnly = true): array
     {
         $belongsTo = (array)$this->config()->get('belongs_to');
         if ($belongsTo && $classOnly) {
@@ -2301,7 +2301,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *        the field data stripped off. It defaults to TRUE.
      * @return string|array|false
      */
-    public function hasMany($classOnly = true)
+    public function hasMany(bool $classOnly = true): array
     {
         $hasMany = (array)$this->config()->get('has_many');
         if ($hasMany && $classOnly) {
@@ -2319,7 +2319,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return array|null
      */
-    public function manyManyExtraFields()
+    public function manyManyExtraFields(): array
     {
         return $this->config()->get('many_many_extraFields');
     }
@@ -2332,7 +2332,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @see DataObjectSchema::manyManyComponent()
      * @return array|null An array of (parentclass, childclass), or an array of all many-many components
      */
-    public function manyMany()
+    public function manyMany(): array
     {
         $config = $this->config();
         $manyManys = (array)$config->get('many_many');
@@ -2349,7 +2349,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $class
      * @return array|false
      */
-    public function database_extensions($class)
+    public function database_extensions(string $class): bool
     {
         $extensions = Config::inst()->get($class, 'database_extensions', Config::UNINHERITED);
         if ($extensions) {
@@ -2365,7 +2365,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return SearchContext
      */
-    public function getDefaultSearchContext()
+    public function getDefaultSearchContext(): SilverStripe\ORM\Search\SearchContext
     {
         return SearchContext::create(
             static::class,
@@ -2389,7 +2389,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *   'restrictFields': Numeric array of a field name whitelist
      * @return FieldList
      */
-    public function scaffoldSearchFields($_params = null)
+    public function scaffoldSearchFields($_params = null): SilverStripe\Forms\FieldList
     {
         $params = array_merge(
             [
@@ -2464,7 +2464,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param array $_params Associative array passing through properties to {@link FormScaffolder}.
      * @return FieldList
      */
-    public function scaffoldFormFields($_params = null)
+    public function scaffoldFormFields(array $_params = null): SilverStripe\Forms\FieldList
     {
         $params = array_merge(
             [
@@ -2495,7 +2495,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @param callable $callback The callback to execute
      */
-    protected function beforeUpdateCMSFields($callback)
+    protected function beforeUpdateCMSFields(callable $callback): void
     {
         $this->beforeExtending('updateCMSFields', $callback);
     }
@@ -2506,7 +2506,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @param callable $callback The callback to execute
      */
-    protected function afterUpdateCMSFields(callable $callback)
+    protected function afterUpdateCMSFields(callable $callback): void
     {
         $this->afterExtending('updateCMSFields', $callback);
     }
@@ -2534,7 +2534,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return FieldList Returns a TabSet for usage within the CMS - don't use for frontend forms.
      */
-    public function getCMSFields()
+    public function getCMSFields(): SilverStripe\Forms\FieldList
     {
         $tabbedFields = $this->scaffoldFormFields([
             // Don't allow has_many/many_many relationship editing before the record is first saved
@@ -2554,7 +2554,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return FieldList an Empty FieldList(); need to be overload by solid subclass
      */
-    public function getCMSActions()
+    public function getCMSActions(): SilverStripe\Forms\FieldList
     {
         $actions = new FieldList();
         $this->extend('updateCMSActions', $actions);
@@ -2603,7 +2603,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param array $params See {@link scaffoldFormFields()}
      * @return FieldList Always returns a simple field collection without TabSet.
      */
-    public function getFrontEndFields($params = null)
+    public function getFrontEndFields($params = null): SilverStripe\Forms\FieldList
     {
         $untabbedFields = $this->scaffoldFormFields($params);
         $this->extend('updateFrontEndFields', $untabbedFields);
@@ -2611,7 +2611,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         return $untabbedFields;
     }
 
-    public function getViewerTemplates($suffix = '')
+    public function getViewerTemplates(string $suffix = ''): array
     {
         return SSViewer::get_templates_by_class(static::class, $suffix, $this->baseClass());
     }
@@ -2623,7 +2623,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $field The name of the field
      * @return mixed The field value
      */
-    public function getField($field)
+    public function getField(string $field): null|int|string|bool|float|array|SilverStripe\Assets\Storage\DBFile
     {
         // If we already have a value in $this->record, then we should just return that
         if (isset($this->record[$field])) {
@@ -2657,7 +2657,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * Not specifying a tableClass will load all lazy fields from all tables.
      * @return bool Flag if lazy loading succeeded
      */
-    protected function loadLazyFields($class = null)
+    protected function loadLazyFields(string $class = null): bool
     {
         if (!$this->isInDB() || !is_numeric($this->ID)) {
             return false;
@@ -2754,7 +2754,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param int $changeLevel The strictness of what is defined as change. Defaults to strict
      * @return array
      */
-    public function getChangedFields($databaseFieldsOnly = false, $changeLevel = self::CHANGE_STRICT)
+    public function getChangedFields(bool|array $databaseFieldsOnly = false, $changeLevel = self::CHANGE_STRICT): array
     {
         $changedFields = [];
 
@@ -2822,7 +2822,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param int $changeLevel See {@link getChangedFields()}
      * @return boolean
      */
-    public function isChanged($fieldName = null, $changeLevel = self::CHANGE_STRICT)
+    public function isChanged(string $fieldName = null, $changeLevel = self::CHANGE_STRICT): bool
     {
         $fields = $fieldName ? [$fieldName] : true;
         $changed = $this->getChangedFields($fields, $changeLevel);
@@ -2841,7 +2841,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param mixed $val New field value
      * @return $this
      */
-    public function setField($fieldName, $val)
+    public function setField(string $fieldName, bool|string|int|array|float|SilverStripe\RealMe\RealMeService $val): SilverStripe\CMS\Model\SiteTree
     {
         $this->objCacheClear();
         //if it's a has_one component, destroy the cache
@@ -2933,7 +2933,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param mixed $value New field value
      * @return $this
      */
-    public function setCastedField($fieldName, $value)
+    public function setCastedField(string $fieldName, string|int|SilverStripe\CKANRegistry\Model\Resource $value): SilverStripe\FrameworkTest\Elemental\Model\ElementalBehatTestObject
     {
         if (!$fieldName) {
             throw new InvalidArgumentException("DataObject::setCastedField: Called without a fieldName");
@@ -2951,7 +2951,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     /**
      * {@inheritdoc}
      */
-    public function castingHelper($field)
+    public function castingHelper(string $field): string
     {
         $fieldSpec = static::getSchema()->fieldSpec(static::class, $field);
         if ($fieldSpec) {
@@ -2980,7 +2980,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $field Name of the field
      * @return boolean True if the given field exists
      */
-    public function hasField($field)
+    public function hasField(string $field): bool
     {
         $schema = static::getSchema();
         return (
@@ -2999,7 +2999,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return boolean
      */
-    public function hasDatabaseField($field)
+    public function hasDatabaseField(string $field): bool
     {
         $spec = static::getSchema()->fieldSpec(static::class, $field, DataObjectSchema::DB_ONLY);
         return !empty($spec);
@@ -3060,7 +3060,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param array $context Optional context
      * @return boolean|null
      */
-    public function extendedCan($methodName, $member, $context = [])
+    public function extendedCan(string $methodName, SilverStripe\Security\Member|int|bool $member, array $context = []): null|bool
     {
         $results = $this->extend($methodName, $member, $context);
         if ($results && is_array($results)) {
@@ -3081,7 +3081,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param Member $member
      * @return boolean
      */
-    public function canView($member = null)
+    public function canView($member = null): bool
     {
         $extended = $this->extendedCan(__FUNCTION__, $member);
         if ($extended !== null) {
@@ -3094,7 +3094,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param Member $member
      * @return boolean
      */
-    public function canEdit($member = null)
+    public function canEdit($member = null): bool
     {
         $extended = $this->extendedCan(__FUNCTION__, $member);
         if ($extended !== null) {
@@ -3107,7 +3107,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param Member $member
      * @return boolean
      */
-    public function canDelete($member = null)
+    public function canDelete($member = null): bool
     {
         $extended = $this->extendedCan(__FUNCTION__, $member);
         if ($extended !== null) {
@@ -3122,7 +3122,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * affect whether (or where) this object could be created.
      * @return boolean
      */
-    public function canCreate($member = null, $context = [])
+    public function canCreate($member = null, $context = []): bool
     {
         $extended = $this->extendedCan(__FUNCTION__, $member, $context);
         if ($extended !== null) {
@@ -3159,7 +3159,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $fieldName Name of the field
      * @return DBField The field as a DBField object
      */
-    public function dbObject($fieldName)
+    public function dbObject(string $fieldName): null|SilverStripe\Assets\Storage\DBFile
     {
         // Check for field in DB
         $schema = static::getSchema();
@@ -3210,7 +3210,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @return mixed DBField of the field on the object or a DataList instance.
      * @throws LogicException If accessing invalid relations
      */
-    public function relObject($fieldPath)
+    public function relObject(string $fieldPath): null|bool|SilverStripe\ORM\FieldType\DBText
     {
         $object = null;
         $component = $this;
@@ -3248,7 +3248,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $fieldName string
      * @return mixed Will return null on a missing value
      */
-    public function relField($fieldName)
+    public function relField(string $fieldName): SilverStripe\ORM\FieldType\DBHTMLText|string|null|float|int
     {
         // Navigate to relative parent using relObject() if needed
         $component = $this;
@@ -3317,13 +3317,13 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @return DataList The objects matching the filter, in the class specified by $containerClass
      */
     public static function get(
-        $callerClass = null,
+        string $callerClass = null,
         $filter = "",
         $sort = "",
         $join = "",
         $limit = null,
         $containerClass = DataList::class
-    ) {
+    ): SilverStripe\ORM\DataList {
         // Validate arguments
         if ($callerClass == null) {
             $callerClass = get_called_class();
@@ -3381,7 +3381,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return DataObject|null The first item matching the query
      */
-    public static function get_one($callerClass, $filter = "", $cache = true, $orderby = "")
+    public static function get_one(string $callerClass, array|string $filter = "", bool $cache = true, string $orderby = ""): null|SilverStripe\SiteConfig\SiteConfig
     {
         /** @var DataObject $singleton */
         $singleton = singleton($callerClass);
@@ -3417,7 +3417,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *                            When false will just clear session-local cached data
      * @return DataObject $this
      */
-    public function flushCache($persistent = true)
+    public function flushCache(bool $persistent = true): SilverStripe\ORM\DataObject
     {
         if (static::class == self::class) {
             self::$_cache_get_one = [];
@@ -3440,7 +3440,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     /**
      * Flush the get_one global cache and destroy associated objects.
      */
-    public static function flush_and_destroy_cache()
+    public static function flush_and_destroy_cache(): void
     {
         if (self::$_cache_get_one) {
             foreach (self::$_cache_get_one as $class => $items) {
@@ -3459,7 +3459,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     /**
      * Reset all global caches associated with DataObject.
      */
-    public static function reset()
+    public static function reset(): void
     {
         // @todo Decouple these
         DBEnum::flushCache();
@@ -3483,7 +3483,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return static|null The element
      */
-    public static function get_by_id($classOrID, $idOrCache = null, $cache = true)
+    public static function get_by_id(string|int $classOrID, int|string $idOrCache = null, bool $cache = true): null|SilverStripe\SiteConfig\SiteConfig
     {
         // Shift arguments if passing id in first or second argument
         list ($class, $id, $cached) = is_numeric($classOrID)
@@ -3508,7 +3508,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return string
      */
-    public function baseTable()
+    public function baseTable(): string
     {
         return static::getSchema()->baseDataTable($this);
     }
@@ -3518,7 +3518,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return string
      */
-    public function baseClass()
+    public function baseClass(): string
     {
         return static::getSchema()->baseDataClass($this);
     }
@@ -3534,7 +3534,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @see $sourceQueryParams
      * @return array
      */
-    public function getSourceQueryParams()
+    public function getSourceQueryParams(): array|null
     {
         return $this->sourceQueryParams;
     }
@@ -3544,7 +3544,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return array
      */
-    public function getInheritableQueryParams()
+    public function getInheritableQueryParams(): array|null
     {
         $params = $this->getSourceQueryParams();
         $this->extend('updateInheritableQueryParams', $params);
@@ -3555,7 +3555,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @see $sourceQueryParams
      * @param array $array
      */
-    public function setSourceQueryParams($array)
+    public function setSourceQueryParams(array $array): void
     {
         $this->sourceQueryParams = $array;
     }
@@ -3565,7 +3565,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $key
      * @param string $value
      */
-    public function setSourceQueryParam($key, $value)
+    public function setSourceQueryParam(string $key, string $value): void
     {
         $this->sourceQueryParams[$key] = $value;
     }
@@ -3575,7 +3575,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $key
      * @return string
      */
-    public function getSourceQueryParam($key)
+    public function getSourceQueryParam(string $key): string|null
     {
         if (isset($this->sourceQueryParams[$key])) {
             return $this->sourceQueryParams[$key];
@@ -3590,7 +3590,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @uses DataExtension::augmentDatabase()
      */
-    public function requireTable()
+    public function requireTable(): void
     {
         // Only build the table if we've actually got fields
         $schema = static::getSchema();
@@ -3672,7 +3672,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @uses DataExtension::requireDefaultRecords()
      */
-    public function requireDefaultRecords()
+    public function requireDefaultRecords(): void
     {
         $defaultRecords = $this->config()->uninherited('default_records');
 
@@ -3698,7 +3698,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * See {@link DatabaseAdmin::doBuild()} for context.
      */
-    public function onAfterBuild()
+    public function onAfterBuild(): void
     {
         $this->extend('onAfterBuild');
     }
@@ -3710,7 +3710,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return array
      */
-    public function searchableFields()
+    public function searchableFields(): array
     {
         // can have mixed format, need to make consistent in most verbose form
         $fields = $this->config()->get('searchable_fields');
@@ -3813,7 +3813,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return array Array of all element labels
      */
-    public function fieldLabels($includerelations = true)
+    public function fieldLabels(bool $includerelations = true): array
     {
         $cacheKey = static::class . '_' . $includerelations;
 
@@ -3879,7 +3879,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $name Name of the field
      * @return string Label of the field
      */
-    public function fieldLabel($name)
+    public function fieldLabel(string $name): string
     {
         $labels = $this->fieldLabels();
         return (isset($labels[$name])) ? $labels[$name] : FormField::name_to_label($name);
@@ -3892,7 +3892,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return array
      */
-    public function summaryFields()
+    public function summaryFields(): array
     {
         $rawFields = $this->config()->get('summary_fields');
 
@@ -3951,7 +3951,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return array
      */
-    public function defaultSearchFilters()
+    public function defaultSearchFilters(): array
     {
         $filters = [];
 
@@ -3972,7 +3972,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     /**
      * @return boolean True if the object is in the database
      */
-    public function isInDB()
+    public function isInDB(): bool
     {
         return is_numeric($this->ID) && $this->ID > 0;
     }
@@ -4212,7 +4212,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      */
     private static $summary_fields = [];
 
-    public function provideI18nEntities()
+    public function provideI18nEntities(): array
     {
         // Note: see http://guides.rubyonrails.org/i18n.html#pluralization for rules
         // Best guess for a/an rule. Better guesses require overriding in subclasses
@@ -4238,7 +4238,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param bool $cache
      * @return boolean
      */
-    public function hasValue($field, $arguments = null, $cache = true)
+    public function hasValue(string $field, $arguments = null, bool $cache = true): bool
     {
         // has_one fields should not use dbObject to check if a value is given
         $hasOne = static::getSchema()->hasOneComponent(static::class, $field);
@@ -4254,7 +4254,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      *
      * @return DataObject
      */
-    public function getJoin()
+    public function getJoin(): null|SilverStripe\Assets\Shortcodes\FileLink
     {
         return $this->joinRecord;
     }
@@ -4266,7 +4266,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param string $alias Alias
      * @return $this
      */
-    public function setJoin(DataObject $object, $alias = null)
+    public function setJoin(DataObject $object, string $alias = null): SilverStripe\Assets\File
     {
         $this->joinRecord = $object;
         if ($alias) {
@@ -4289,7 +4289,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * instance of ArrayList will be constructed and returned
      * @return ArrayList The list of related objects
      */
-    public function findRelatedObjects($source, $recursive = true, $list = null)
+    public function findRelatedObjects(string $source, bool $recursive = true, SilverStripe\ORM\ArrayList $list = null): SilverStripe\ORM\ArrayList
     {
         if (!$list) {
             $list = new ArrayList();
@@ -4338,7 +4338,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param mixed $items List of new items to merge
      * @return ArrayList List of all newly added items that did not already exist in $list
      */
-    public function mergeRelatedObjects($list, $items)
+    public function mergeRelatedObjects(SilverStripe\ORM\ArrayList $list, SilverStripe\ORM\ManyManyThroughList $items): SilverStripe\ORM\ArrayList
     {
         $added = new ArrayList();
         if (!$items) {
@@ -4385,7 +4385,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      * @param ArrayList $added Additional list to insert into
      * @param DataObject $item Item to add
      */
-    protected function mergeRelatedObject($list, $added, $item)
+    protected function mergeRelatedObject(SilverStripe\ORM\ArrayList $list, SilverStripe\ORM\ArrayList $added, SilverStripe\Assets\Image $item): void
     {
         // Identify item
         $itemKey = get_class($item) . '/' . $item->ID;

--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -71,7 +71,7 @@ class DataObjectSchema
     /**
      * Clear cached table names
      */
-    public function reset()
+    public function reset(): void
     {
         $this->tableNames = [];
         $this->databaseFields = [];
@@ -85,7 +85,7 @@ class DataObjectSchema
      *
      * @return array
      */
-    public function getTableNames()
+    public function getTableNames(): array
     {
         $this->cacheTableNames();
         return $this->tableNames;
@@ -104,7 +104,7 @@ class DataObjectSchema
      *
      * @return string The SQL identifier string for the corresponding column for this field
      */
-    public function sqlColumnForField($class, $field, $tablePrefix = null)
+    public function sqlColumnForField(string|SilverStripe\ErrorPage\ErrorPage $class, string $field, string $tablePrefix = null): string
     {
         $table = $this->tableForField($class, $field);
         if (!$table) {
@@ -123,7 +123,7 @@ class DataObjectSchema
      *
      * @return string Returns the table name, or null if there is no table
      */
-    public function tableName($class)
+    public function tableName(string|SilverStripe\Assets\File $class): string
     {
         $tables = $this->getTableNames();
         $class = ClassInfo::class_name($class);
@@ -142,7 +142,7 @@ class DataObjectSchema
      * @return string
      * @throws InvalidArgumentException
      */
-    public function baseDataClass($class)
+    public function baseDataClass(string|TractorCow\Fluent\Model\Locale $class): string
     {
         $current = $class;
         while ($next = get_parent_class($current ?? '')) {
@@ -162,7 +162,7 @@ class DataObjectSchema
      *
      * @return string
      */
-    public function baseDataTable($class)
+    public function baseDataTable(string|TractorCow\Fluent\Model\Locale $class): string
     {
         return $this->tableName($this->baseDataClass($class));
     }
@@ -193,7 +193,7 @@ class DataObjectSchema
      *
      * @return array List of fields, where the key is the field name and the value is the field specification.
      */
-    public function fieldSpecs($classOrInstance, $options = 0)
+    public function fieldSpecs(string|SilverStripe\ErrorPage\ErrorPage $classOrInstance, int $options = 0): array
     {
         $class = ClassInfo::class_name($classOrInstance);
 
@@ -245,7 +245,7 @@ class DataObjectSchema
      * @return string|null Field will be a string in FieldClass(args) format, or
      * RecordClass.FieldClass(args) format if using INCLUDE_CLASS. Will be null if no field is found.
      */
-    public function fieldSpec($classOrInstance, $fieldName, $options = 0)
+    public function fieldSpec(string|SilverStripe\ErrorPage\ErrorPage $classOrInstance, string $fieldName, int $options = 0): null|string
     {
         $specs = $this->fieldSpecs($classOrInstance, $options);
         return isset($specs[$fieldName]) ? $specs[$fieldName] : null;
@@ -258,7 +258,7 @@ class DataObjectSchema
      *
      * @return string|null The FQN of the class, or null if not found
      */
-    public function tableClass($table)
+    public function tableClass(string $table): string|null
     {
         $tables = $this->getTableNames();
         $class = array_search($table, $tables ?? [], true);
@@ -281,7 +281,7 @@ class DataObjectSchema
     /**
      * Cache all table names if necessary
      */
-    protected function cacheTableNames()
+    protected function cacheTableNames(): void
     {
         if ($this->tableNames) {
             return;
@@ -314,7 +314,7 @@ class DataObjectSchema
      *
      * @return string
      */
-    protected function buildTableName($class)
+    protected function buildTableName(string $class): string
     {
         $table = Config::inst()->get($class, 'table_name', Config::UNINHERITED);
 
@@ -346,7 +346,7 @@ class DataObjectSchema
      *
      * @return array Map of fieldname to specification, similar to {@link DataObject::$db}.
      */
-    public function databaseFields($class, $aggregated = true)
+    public function databaseFields(string|TractorCow\Fluent\Model\Locale $class, bool $aggregated = true): array
     {
         $class = ClassInfo::class_name($class);
         if ($class === DataObject::class) {
@@ -373,7 +373,7 @@ class DataObjectSchema
      *
      * @return string|null Field specification, or null if not a field
      */
-    public function databaseField($class, $field, $aggregated = true)
+    public function databaseField(string $class, string $field, bool $aggregated = true): string|null
     {
         $fields = $this->databaseFields($class, $aggregated);
         return isset($fields[$field]) ? $fields[$field] : null;
@@ -385,7 +385,7 @@ class DataObjectSchema
      *
      * @return array
      */
-    public function databaseIndexes($class, $aggregated = true)
+    public function databaseIndexes(string $class, bool $aggregated = true): array
     {
         $class = ClassInfo::class_name($class);
         if ($class === DataObject::class) {
@@ -406,7 +406,7 @@ class DataObjectSchema
      *
      * @return bool
      */
-    public function classHasTable($class)
+    public function classHasTable(string $class): bool
     {
         if (!is_subclass_of($class, DataObject::class)) {
             return false;
@@ -430,7 +430,7 @@ class DataObjectSchema
      *
      * @return array List of composite fields and their class spec
      */
-    public function compositeFields($class, $aggregated = true)
+    public function compositeFields(string $class, bool $aggregated = true): array
     {
         $class = ClassInfo::class_name($class);
         if ($class === DataObject::class) {
@@ -458,7 +458,7 @@ class DataObjectSchema
      *
      * @return string|null Field specification, or null if not a field
      */
-    public function compositeField($class, $field, $aggregated = true)
+    public function compositeField(string $class, string $field, $aggregated = true): null|string
     {
         $fields = $this->compositeFields($class, $aggregated);
         return isset($fields[$field]) ? $fields[$field] : null;
@@ -470,7 +470,7 @@ class DataObjectSchema
      *
      * @param string $class Class name to cache
      */
-    protected function cacheDatabaseFields($class)
+    protected function cacheDatabaseFields(string $class): void
     {
         // Skip if already cached
         if (isset($this->databaseFields[$class]) && isset($this->compositeFields[$class])) {
@@ -534,7 +534,7 @@ class DataObjectSchema
      *
      * @param $class
      */
-    protected function cacheDatabaseIndexes($class)
+    protected function cacheDatabaseIndexes(string $class): void
     {
         if (!array_key_exists($class, $this->databaseIndexes ?? [])) {
             $this->databaseIndexes[$class] = array_merge(
@@ -552,7 +552,7 @@ class DataObjectSchema
      *
      * @return array
      */
-    protected function cacheDefaultDatabaseIndexes($class)
+    protected function cacheDefaultDatabaseIndexes(string $class): array
     {
         if (array_key_exists($class, $this->defaultDatabaseIndexes ?? [])) {
             return $this->defaultDatabaseIndexes[$class];
@@ -579,7 +579,7 @@ class DataObjectSchema
      * @throws InvalidArgumentException If an index already exists on the class
      * @throws InvalidArgumentException If a custom index format is not valid
      */
-    protected function buildCustomDatabaseIndexes($class)
+    protected function buildCustomDatabaseIndexes(string $class): array
     {
         $indexes = [];
         $classIndexes = Config::inst()->get($class, 'indexes', Config::UNINHERITED) ?: [];
@@ -621,7 +621,7 @@ class DataObjectSchema
         return $indexes;
     }
 
-    protected function buildSortDatabaseIndexes($class)
+    protected function buildSortDatabaseIndexes(string $class): array
     {
         $sort = Config::inst()->get($class, 'default_sort', Config::UNINHERITED);
         $indexes = [];
@@ -656,7 +656,7 @@ class DataObjectSchema
      *
      * @return array Resolved table and column.
      */
-    protected function parseSortColumn($column)
+    protected function parseSortColumn(string $column): array
     {
         // Parse column specification, considering possible ansi sql quoting
         // Note that table prefix is allowed, but discarded
@@ -679,7 +679,7 @@ class DataObjectSchema
      *
      * @return string
      */
-    public function tableForField($candidateClass, $fieldName)
+    public function tableForField(string|SilverStripe\ErrorPage\ErrorPage $candidateClass, string $fieldName): string|null
     {
         $class = $this->classForField($candidateClass, $fieldName);
         if ($class) {
@@ -698,7 +698,7 @@ class DataObjectSchema
      *
      * @return string
      */
-    public function classForField($candidateClass, $fieldName)
+    public function classForField(string|SilverStripe\ErrorPage\ErrorPage $candidateClass, string $fieldName): string|null
     {
         // normalise class name
         $candidateClass = ClassInfo::class_name($candidateClass);
@@ -745,7 +745,7 @@ class DataObjectSchema
      *
      * @return array|null
      */
-    public function manyManyComponent($class, $component)
+    public function manyManyComponent(string $class, string $component): array|null
     {
         $classes = ClassInfo::ancestry($class);
         foreach ($classes as $parentClass) {
@@ -792,7 +792,7 @@ class DataObjectSchema
      *
      * @return array Array with child class and relation name
      */
-    protected function parseBelongsManyManyComponent($parentClass, $component, $specification)
+    protected function parseBelongsManyManyComponent(string $parentClass, string $component, string $specification): array
     {
         $childClass = $specification;
         $relationName = null;
@@ -836,7 +836,7 @@ class DataObjectSchema
      *
      * @return array|null
      */
-    public function manyManyExtraFieldsForComponent($class, $component)
+    public function manyManyExtraFieldsForComponent(string $class, string $component): null|array
     {
         // Get directly declared many_many_extraFields
         $extraFields = Config::inst()->get($class, 'many_many_extraFields');
@@ -871,7 +871,7 @@ class DataObjectSchema
      *
      * @return string|null
      */
-    public function hasManyComponent($class, $component, $classOnly = true)
+    public function hasManyComponent(string $class, string|int $component, bool $classOnly = true): string|null
     {
         $hasMany = (array)Config::inst()->get($class, 'has_many');
         if (!isset($hasMany[$component])) {
@@ -895,7 +895,7 @@ class DataObjectSchema
      *
      * @return string|null
      */
-    public function hasOneComponent($class, $component)
+    public function hasOneComponent(string|DNADesign\Elemental\Models\BaseElement $class, string $component): null|string
     {
         $hasOnes = Config::forClass($class)->get('has_one');
         if (!isset($hasOnes[$component])) {
@@ -918,7 +918,7 @@ class DataObjectSchema
      *
      * @return string|null
      */
-    public function belongsToComponent($class, $component, $classOnly = true)
+    public function belongsToComponent(string $class, string $component, bool $classOnly = true): null|string
     {
         $belongsTo = (array)Config::forClass($class)->get('belongs_to');
         if (!isset($belongsTo[$component])) {
@@ -944,7 +944,7 @@ class DataObjectSchema
      *
      * @return string|null
      */
-    public function unaryComponent($class, $component)
+    public function unaryComponent(string $class, string $component): null|string
     {
         return $this->hasOneComponent($class, $component) ?: $this->belongsToComponent($class, $component);
     }
@@ -957,7 +957,7 @@ class DataObjectSchema
      *
      * @return array
      */
-    protected function parseManyManyComponent($parentClass, $component, $specification)
+    protected function parseManyManyComponent(string $parentClass, string $component, string|array|int $specification): array
     {
         // Check if this is many_many_through
         if (is_array($specification)) {
@@ -1007,7 +1007,7 @@ class DataObjectSchema
      *
      * @return string|null
      */
-    protected function getManyManyInverseRelationship($childClass, $parentClass)
+    protected function getManyManyInverseRelationship(string $childClass, string $parentClass): string
     {
         $otherManyMany = Config::inst()->get($childClass, 'many_many', Config::UNINHERITED);
         if (!$otherManyMany) {
@@ -1045,7 +1045,7 @@ class DataObjectSchema
      * @return string
      * @throws Exception
      */
-    public function getRemoteJoinField($class, $component, $type = 'has_many', &$polymorphic = false)
+    public function getRemoteJoinField(string $class, string $component, $type = 'has_many', &$polymorphic = false): string
     {
         // Extract relation from current object
         if ($type === 'has_many') {
@@ -1126,7 +1126,7 @@ class DataObjectSchema
      * @return string Class that matches the given relation
      * @throws InvalidArgumentException
      */
-    protected function checkManyManyFieldClass($parentClass, $component, $joinClass, $specification, $key)
+    protected function checkManyManyFieldClass(string $parentClass, string $component, string $joinClass, array $specification, string $key): string
     {
         // Ensure value for this key exists
         if (empty($specification[$key])) {
@@ -1187,7 +1187,7 @@ class DataObjectSchema
      *
      * @return string Name of join class
      */
-    protected function checkManyManyJoinClass($parentClass, $component, $specification)
+    protected function checkManyManyJoinClass(string $parentClass, string $component, array $specification): string
     {
         if (empty($specification['through'])) {
             throw new InvalidArgumentException(
@@ -1212,7 +1212,7 @@ class DataObjectSchema
      * @param string $relationClass Candidate class to check
      * @param string $type Relation type (e.g. has_one)
      */
-    protected function checkRelationClass($class, $component, $relationClass, $type)
+    protected function checkRelationClass(string|DNADesign\Elemental\Models\BaseElement $class, string|int $component, string|array|int $relationClass, string $type): void
     {
         if (!is_string($component) || is_numeric($component)) {
             throw new InvalidArgumentException(

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -73,7 +73,7 @@ class DataQuery
      *
      * @param string $dataClass The name of the DataObject class that you wish to query
      */
-    public function __construct($dataClass)
+    public function __construct(string $dataClass): void
     {
         $this->dataClass = $dataClass;
         $this->initialiseQuery();
@@ -82,7 +82,7 @@ class DataQuery
     /**
      * Clone this object
      */
-    public function __clone()
+    public function __clone(): void
     {
         $this->query = clone $this->query;
     }
@@ -92,7 +92,7 @@ class DataQuery
      *
      * @return string
      */
-    public function dataClass()
+    public function dataClass(): string
     {
         return $this->dataClass;
     }
@@ -103,7 +103,7 @@ class DataQuery
      *
      * @return SQLSelect
      */
-    public function query()
+    public function query(): SilverStripe\ORM\Queries\SQLSelect
     {
         return $this->getFinalisedQuery();
     }
@@ -117,7 +117,7 @@ class DataQuery
      * contained within any other predicate.
      * @return $this
      */
-    public function removeFilterOn($fieldExpression)
+    public function removeFilterOn(array|string $fieldExpression): SilverStripe\ORM\DataQuery
     {
         $matched = false;
 
@@ -162,7 +162,7 @@ class DataQuery
     /**
      * Set up the simplest initial query
      */
-    protected function initialiseQuery()
+    protected function initialiseQuery(): void
     {
         // Join on base table and let lazy loading join subtables
         $baseClass = DataObject::getSchema()->baseDataClass($this->dataClass());
@@ -189,7 +189,7 @@ class DataQuery
      * @param array $queriedColumns
      * @return $this
      */
-    public function setQueriedColumns($queriedColumns)
+    public function setQueriedColumns(array $queriedColumns): SilverStripe\ORM\DataQuery
     {
         $this->queriedColumns = $queriedColumns;
         return $this;
@@ -201,7 +201,7 @@ class DataQuery
      * @param array|null $queriedColumns Any columns to filter the query by
      * @return SQLSelect The finalised sql query
      */
-    public function getFinalisedQuery($queriedColumns = null)
+    public function getFinalisedQuery(array $queriedColumns = null): SilverStripe\ORM\Queries\SQLSelect
     {
         if (!$queriedColumns) {
             $queriedColumns = $this->queriedColumns;
@@ -353,7 +353,7 @@ class DataQuery
      * @param SQLSelect $query
      * @param array $originalSelect
      */
-    protected function ensureSelectContainsOrderbyColumns($query, $originalSelect = [])
+    protected function ensureSelectContainsOrderbyColumns(SilverStripe\ORM\Queries\SQLSelect $query, array $originalSelect = []): void
     {
         if ($orderby = $query->getOrderBy()) {
             $newOrderby = [];
@@ -430,7 +430,7 @@ class DataQuery
      *
      * @return Query
      */
-    public function execute()
+    public function execute(): SilverStripe\ORM\Connect\MySQLStatement
     {
         return $this->getFinalisedQuery()->execute();
     }
@@ -441,7 +441,7 @@ class DataQuery
      * @param array $parameters Out variable for parameters required for this query
      * @return string The resulting SQL query (may be paramaterised)
      */
-    public function sql(&$parameters = [])
+    public function sql(array &$parameters = []): string
     {
         return $this->getFinalisedQuery()->sql($parameters);
     }
@@ -452,7 +452,7 @@ class DataQuery
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         $quotedColumn = DataObject::getSchema()->sqlColumnForField($this->dataClass(), 'ID');
         return $this->getFinalisedQuery()->count("DISTINCT {$quotedColumn}");
@@ -499,7 +499,7 @@ class DataQuery
      * automatically so must not contain double quotes.
      * @return string
      */
-    public function max($field)
+    public function max(string $field): null|int|string
     {
         $table = DataObject::getSchema()->tableForField($this->dataClass, $field);
         if (!$table) {
@@ -515,7 +515,7 @@ class DataQuery
      * automatically so must not contain double quotes.
      * @return string
      */
-    public function min($field)
+    public function min(string $field): int|string|null
     {
         $table = DataObject::getSchema()->tableForField($this->dataClass, $field);
         if (!$table) {
@@ -531,7 +531,7 @@ class DataQuery
      * automatically so must not contain double quotes.
      * @return string
      */
-    public function avg($field)
+    public function avg(string $field): float
     {
         $table = DataObject::getSchema()->tableForField($this->dataClass, $field);
         if (!$table) {
@@ -547,7 +547,7 @@ class DataQuery
      * automatically so must not contain double quotes.
      * @return string
      */
-    public function sum($field)
+    public function sum(string $field): float
     {
         $table = DataObject::getSchema()->tableForField($this->dataClass, $field);
         if (!$table) {
@@ -563,7 +563,7 @@ class DataQuery
      * (as an escaped SQL statement)
      * @return string
      */
-    public function aggregate($expression)
+    public function aggregate(string $expression): null|int|string|float
     {
         return $this->getFinalisedQuery()->aggregate($expression)->execute()->value();
     }
@@ -574,7 +574,7 @@ class DataQuery
      *
      * @return SQLSelect
      */
-    public function firstRow()
+    public function firstRow(): SilverStripe\ORM\Queries\SQLSelect
     {
         return $this->getFinalisedQuery()->firstRow();
     }
@@ -585,7 +585,7 @@ class DataQuery
      *
      * @return SQLSelect
      */
-    public function lastRow()
+    public function lastRow(): SilverStripe\ORM\Queries\SQLSelect
     {
         return $this->getFinalisedQuery()->lastRow();
     }
@@ -597,7 +597,7 @@ class DataQuery
      * @param string $tableClass Class to select from
      * @param array $columns
      */
-    protected function selectColumnsFromTable(SQLSelect &$query, $tableClass, $columns = null)
+    protected function selectColumnsFromTable(SQLSelect &$query, string $tableClass, array $columns = null): void
     {
         // Add SQL for multi-value fields
         $schema = DataObject::getSchema();
@@ -635,7 +635,7 @@ class DataQuery
      * @param string $groupby Escaped SQL statement
      * @return $this
      */
-    public function groupby($groupby)
+    public function groupby(string $groupby): SilverStripe\ORM\DataQuery
     {
         $this->query->addGroupBy($groupby);
         return $this;
@@ -647,7 +647,7 @@ class DataQuery
      * @param mixed $having Predicate(s) to set, as escaped SQL statements or parameterised queries
      * @return $this
      */
-    public function having($having)
+    public function having(array $having): SilverStripe\ORM\DataQuery
     {
         $this->query->addHaving($having);
         return $this;
@@ -660,7 +660,7 @@ class DataQuery
      *
      * @return DataQuery_SubGroup
      */
-    public function disjunctiveGroup()
+    public function disjunctiveGroup(): SilverStripe\ORM\DataQuery_SubGroup
     {
         return new DataQuery_SubGroup($this, 'OR');
     }
@@ -672,7 +672,7 @@ class DataQuery
      *
      * @return DataQuery_SubGroup
      */
-    public function conjunctiveGroup()
+    public function conjunctiveGroup(): SilverStripe\ORM\DataQuery_SubGroup
     {
         return new DataQuery_SubGroup($this, 'AND');
     }
@@ -687,7 +687,7 @@ class DataQuery
      * paramaterised queries
      * @return $this
      */
-    public function where($filter)
+    public function where(string|array|SilverStripe\ORM\DataQuery_SubGroup $filter): SilverStripe\ORM\DataQuery
     {
         if ($filter) {
             $this->query->addWhere($filter);
@@ -705,7 +705,7 @@ class DataQuery
      * paramaterised queries
      * @return $this
      */
-    public function whereAny($filter)
+    public function whereAny(array $filter): SilverStripe\ORM\DataQuery
     {
         if ($filter) {
             $this->query->addWhereAny($filter);
@@ -723,7 +723,7 @@ class DataQuery
      * @param bool $clear Clear existing values
      * @return $this
      */
-    public function sort($sort = null, $direction = null, $clear = true)
+    public function sort(string|array $sort = null, string $direction = null, bool $clear = true): SilverStripe\ORM\DataQuery
     {
         if ($clear) {
             $this->query->setOrderBy($sort, $direction);
@@ -739,7 +739,7 @@ class DataQuery
      *
      * @return $this
      */
-    public function reverseSort()
+    public function reverseSort(): SilverStripe\ORM\DataQuery
     {
         $this->query->reverseOrderBy();
         return $this;
@@ -752,7 +752,7 @@ class DataQuery
      * @param int $offset
      * @return $this
      */
-    public function limit($limit, $offset = 0)
+    public function limit(int|bool|string $limit, int|string $offset = 0): SilverStripe\ORM\DataQuery
     {
         $this->query->setLimit($limit, $offset);
         return $this;
@@ -764,7 +764,7 @@ class DataQuery
      * @param bool $value
      * @return $this
      */
-    public function distinct($value)
+    public function distinct(bool $value): SilverStripe\ORM\DataQuery
     {
         $this->query->setDistinct($value);
         return $this;
@@ -782,7 +782,7 @@ class DataQuery
      * @param array $parameters Any additional parameters if the join is a parameterised subquery
      * @return $this
      */
-    public function innerJoin($table, $onClause, $alias = null, $order = 20, $parameters = [])
+    public function innerJoin(string $table, string $onClause, string $alias = null, int $order = 20, array $parameters = []): SilverStripe\ORM\DataQuery
     {
         if ($table) {
             $this->query->addInnerJoin($table, $onClause, $alias, $order, $parameters);
@@ -802,7 +802,7 @@ class DataQuery
      * @param array $parameters Any additional parameters if the join is a parameterised subquery
      * @return $this
      */
-    public function leftJoin($table, $onClause, $alias = null, $order = 20, $parameters = [])
+    public function leftJoin(string $table, string $onClause, string $alias = null, int $order = 20, array $parameters = []): SilverStripe\ORM\DataQuery
     {
         if ($table) {
             $this->query->addLeftJoin($table, $onClause, $alias, $order, $parameters);
@@ -823,7 +823,7 @@ class DataQuery
      * @param string|array $relation Relation in '.' delimited string, or array of parts
      * @return string Table prefix
      */
-    public static function applyRelationPrefix($relation)
+    public static function applyRelationPrefix(array $relation): null|string
     {
         if (!$relation) {
             return null;
@@ -847,7 +847,7 @@ class DataQuery
      * if this relation will be used for sorting, and should not include duplicate rows.
      * @return string The model class of the related item
      */
-    public function applyRelation($relation, $linearOnly = false)
+    public function applyRelation(array|string $relation, bool $linearOnly = false): string
     {
         // NO-OP
         if (!$relation) {
@@ -937,13 +937,13 @@ class DataQuery
      * @param string $type 'has_many' or 'belongs_to'
      */
     protected function joinHasManyRelation(
-        $localClass,
+        string $localClass,
         $localField,
         $foreignClass,
         $localPrefix = null,
         $foreignPrefix = null,
         $type = 'has_many'
-    ) {
+    ): void {
         if (!$foreignClass || $foreignClass === DataObject::class) {
             throw new InvalidArgumentException("Could not find a has_many relationship {$localField} on {$localClass}");
         }
@@ -1004,12 +1004,12 @@ class DataQuery
      * @param string $foreignPrefix Table prefix to use for joined table
      */
     protected function joinHasOneRelation(
-        $localClass,
+        string $localClass,
         $localField,
         $foreignClass,
         $localPrefix = null,
         $foreignPrefix = null
-    ) {
+    ): void {
         if (!$foreignClass) {
             throw new InvalidArgumentException("Could not find a has_one relationship {$localField} on {$localClass}");
         }
@@ -1069,7 +1069,7 @@ class DataQuery
      * @param string $componentPrefix Table prefix to use for both joined and mapping table
      */
     protected function joinManyManyRelationship(
-        $relationClass,
+        string $relationClass,
         $parentClass,
         $componentClass,
         $parentField,
@@ -1077,7 +1077,7 @@ class DataQuery
         $relationClassOrTable,
         $parentPrefix = null,
         $componentPrefix = null
-    ) {
+    ): void {
         $schema = DataObject::getSchema();
 
         if (class_exists($relationClassOrTable ?? '')) {
@@ -1139,7 +1139,7 @@ class DataQuery
      * @param string $field
      * @return $this
      */
-    public function subtract(DataQuery $subtractQuery, $field = 'ID')
+    public function subtract(DataQuery $subtractQuery, $field = 'ID'): SilverStripe\ORM\DataQuery
     {
         $fieldExpression = $subtractQuery->expressionForField($field);
         $subSelect = $subtractQuery->getFinalisedQuery();
@@ -1177,7 +1177,7 @@ class DataQuery
      * @param array $fields Database column names (will be escaped automatically)
      * @return $this
      */
-    public function addSelectFromTable($table, $fields)
+    public function addSelectFromTable(string $table, array $fields): SilverStripe\ORM\DataQuery
     {
         $fieldExpressions = array_map(function ($item) use ($table) {
             return Convert::symbol2sql("{$table}.{$item}");
@@ -1212,7 +1212,7 @@ class DataQuery
      * @return array List of column values for the specified column
      * @throws InvalidArgumentException
      */
-    public function column($field = 'ID')
+    public function column(string $field = 'ID'): array
     {
         $fieldExpression = $this->expressionForField($field);
         $query = $this->getFinalisedQuery([$field]);
@@ -1242,7 +1242,7 @@ class DataQuery
      * the full composite SQL statement, or the alias set through {@link SQLSelect->selectField()}.
      * @return string The expression used to query this field via this DataQuery
      */
-    protected function expressionForField($field)
+    protected function expressionForField(string $field): string|null
     {
         // Prepare query object for selecting this field
         $query = $this->getFinalisedQuery([$field]);
@@ -1266,7 +1266,7 @@ class DataQuery
      * @param string $fieldExpression String The field to select (escaped SQL statement)
      * @param string $alias String The alias of that field (escaped SQL statement)
      */
-    public function selectField($fieldExpression, $alias = null)
+    public function selectField(string $fieldExpression, string $alias = null): void
     {
         $this->query->selectField($fieldExpression, $alias);
     }
@@ -1286,7 +1286,7 @@ class DataQuery
      * @param string|array $value
      * @return $this
      */
-    public function setQueryParam($key, $value)
+    public function setQueryParam(string $key, string|bool|int|array $value): SilverStripe\ORM\DataQuery
     {
         $this->queryParams[$key] = $value;
         return $this;
@@ -1298,7 +1298,7 @@ class DataQuery
      * @param string $key
      * @return string
      */
-    public function getQueryParam($key)
+    public function getQueryParam(string $key): string|null|int|array|bool
     {
         if (isset($this->queryParams[$key])) {
             return $this->queryParams[$key];
@@ -1310,7 +1310,7 @@ class DataQuery
      * Returns all query parameters
      * @return array query parameters array
      */
-    public function getQueryParams()
+    public function getQueryParams(): null|array
     {
         return $this->queryParams;
     }
@@ -1320,7 +1320,7 @@ class DataQuery
      *
      * @return DataQueryManipulator[]
      */
-    public function getDataQueryManipulators()
+    public function getDataQueryManipulators(): array
     {
         return $this->dataQueryManipulators;
     }
@@ -1331,13 +1331,13 @@ class DataQuery
      * @param DataQueryManipulator $manipulator
      * @return $this
      */
-    public function pushQueryManipulator(DataQueryManipulator $manipulator)
+    public function pushQueryManipulator(DataQueryManipulator $manipulator): SilverStripe\ORM\DataQuery
     {
         $this->dataQueryManipulators[] = $manipulator;
         return $this;
     }
 
-    private function validateColumnField($field, SQLSelect $query)
+    private function validateColumnField(string $field, SQLSelect $query): bool
     {
         // standard column - nothing to process here
         if (strpos($field ?? '', '.') === false) {
@@ -1359,7 +1359,7 @@ class DataQuery
      * @param $table
      * @return mixed
      */
-    private function getJoinTableName($class, $table)
+    private function getJoinTableName(string $class, string $table): string
     {
         $updated = $table;
         $this->invokeWithExtensions('updateJoinTableName', $class, $table, $updated);

--- a/src/ORM/DataQuery_SubGroup.php
+++ b/src/ORM/DataQuery_SubGroup.php
@@ -21,7 +21,7 @@ class DataQuery_SubGroup extends DataQuery implements SQLConditionGroup
      */
     protected $whereQuery;
 
-    public function __construct(DataQuery $base, $connective)
+    public function __construct(DataQuery $base, string $connective): void
     {
         parent::__construct($base->dataClass);
         $this->query = $base->query;
@@ -31,7 +31,7 @@ class DataQuery_SubGroup extends DataQuery implements SQLConditionGroup
         $base->where($this);
     }
 
-    public function where($filter)
+    public function where(array|string|SilverStripe\ORM\DataQuery_SubGroup $filter): SilverStripe\ORM\DataQuery_SubGroup
     {
         if ($filter) {
             $this->whereQuery->addWhere($filter);
@@ -49,7 +49,7 @@ class DataQuery_SubGroup extends DataQuery implements SQLConditionGroup
         return $this;
     }
 
-    public function conditionSQL(&$parameters)
+    public function conditionSQL(array &$parameters): string|null
     {
         $parameters = [];
 

--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -58,7 +58,7 @@ class DatabaseAdmin extends Controller
      */
     private static $show_record_counts = true;
 
-    protected function init()
+    protected function init(): void
     {
         parent::init();
 
@@ -119,7 +119,7 @@ class DatabaseAdmin extends Controller
      * When we're called as /dev/build, that's actually the index. Do the same
      * as /dev/build/build.
      */
-    public function index()
+    public function index(): null
     {
         return $this->build();
     }
@@ -127,7 +127,7 @@ class DatabaseAdmin extends Controller
     /**
      * Updates the database schema, creating tables & fields as necessary.
      */
-    public function build()
+    public function build(): void
     {
         // The default time limit of 30 seconds is normally not enough
         Environment::increaseTimeLimitTo(600);
@@ -158,7 +158,7 @@ class DatabaseAdmin extends Controller
      *
      * @return string|null
      */
-    protected function getReturnURL()
+    protected function getReturnURL(): null
     {
         $url = $this->request->getVar('returnURL');
 
@@ -225,7 +225,7 @@ class DatabaseAdmin extends Controller
      * @param boolean $populate Populate the database, as well as setting up its schema
      * @param bool    $testMode
      */
-    public function doBuild($quiet = false, $populate = true, $testMode = false)
+    public function doBuild(bool $quiet = false, bool $populate = true, $testMode = false): void
     {
         $this->extend('onBeforeBuild', $quiet, $populate, $testMode);
 
@@ -430,7 +430,7 @@ class DatabaseAdmin extends Controller
      * @param string   $fieldName The field name to look in for obsolete class names
      * @param string[] $mapping   Map of old to new classnames
      */
-    protected function updateLegacyClassNameField($dataClass, $fieldName, $mapping)
+    protected function updateLegacyClassNameField(string $dataClass, string $fieldName, array $mapping): void
     {
         $schema = DataObject::getSchema();
         // Check first to ensure that the class has the specified field to update
@@ -501,7 +501,7 @@ class DatabaseAdmin extends Controller
      *
      * @return array[]
      */
-    protected function getClassNameRemappingFields()
+    protected function getClassNameRemappingFields(): array
     {
         $dataClasses = ClassInfo::getValidSubClasses(DataObject::class);
         $schema = DataObject::getSchema();
@@ -577,7 +577,7 @@ class DatabaseAdmin extends Controller
      *
      * @todo Migrate to separate build task
      */
-    protected function migrateClassNames()
+    protected function migrateClassNames(): void
     {
         $remappingConfig = $this->config()->get('classname_value_remapping');
         $remappingFields = $this->getClassNameRemappingFields();

--- a/src/ORM/FieldType/DBBigInt.php
+++ b/src/ORM/FieldType/DBBigInt.php
@@ -15,7 +15,7 @@ use SilverStripe\ORM\DB;
 class DBBigInt extends DBInt
 {
 
-    public function requireField()
+    public function requireField(): void
     {
         $parts = [
             'datatype' => 'bigint',

--- a/src/ORM/FieldType/DBBoolean.php
+++ b/src/ORM/FieldType/DBBoolean.php
@@ -11,14 +11,14 @@ use SilverStripe\ORM\DB;
  */
 class DBBoolean extends DBField
 {
-    public function __construct($name = null, $defaultVal = 0)
+    public function __construct(string|int $name = null, int|bool $defaultVal = 0): void
     {
         $this->defaultVal = ($defaultVal) ? 1 : 0;
 
         parent::__construct($name);
     }
 
-    public function requireField()
+    public function requireField(): void
     {
         $parts = [
             'datatype' => 'tinyint',
@@ -42,7 +42,7 @@ class DBBoolean extends DBField
         return ($this->value) ? 'true' : 'false';
     }
 
-    public function saveInto($dataObject)
+    public function saveInto(DNADesign\Elemental\Models\ElementContent $dataObject): void
     {
         $fieldName = $this->name;
         if ($fieldName) {
@@ -53,12 +53,12 @@ class DBBoolean extends DBField
         }
     }
 
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField($title = null, array $params = null): SilverStripe\Forms\CheckboxField
     {
         return CheckboxField::create($this->name, $title);
     }
 
-    public function scaffoldSearchField($title = null)
+    public function scaffoldSearchField($title = null): SilverStripe\Forms\DropdownField
     {
         $anyText = _t(__CLASS__ . '.ANY', 'Any');
         $source = [
@@ -71,12 +71,12 @@ class DBBoolean extends DBField
             ->setEmptyString($anyText);
     }
 
-    public function nullValue()
+    public function nullValue(): int
     {
         return 0;
     }
 
-    public function prepValueForDB($value)
+    public function prepValueForDB(bool|int|string|float|array $value): int
     {
         if (is_bool($value)) {
             return $value ? 1 : 0;

--- a/src/ORM/FieldType/DBClassName.php
+++ b/src/ORM/FieldType/DBClassName.php
@@ -49,7 +49,7 @@ class DBClassName extends DBEnum
      * @param string|null $baseClass Optional base class to limit selections
      * @param array       $options   Optional parameters for this DBField instance
      */
-    public function __construct($name = null, $baseClass = null, $options = [])
+    public function __construct(string $name = null, string $baseClass = null, array $options = []): void
     {
         $this->setBaseClass($baseClass);
         parent::__construct($name, null, null, $options);
@@ -58,7 +58,7 @@ class DBClassName extends DBEnum
     /**
      * @return void
      */
-    public function requireField()
+    public function requireField(): void
     {
         $parts = [
             'datatype' => 'enum',
@@ -83,7 +83,7 @@ class DBClassName extends DBEnum
      *
      * @return string
      */
-    public function getBaseClass()
+    public function getBaseClass(): string
     {
         // Use explicit base class
         if ($this->baseClass) {
@@ -109,7 +109,7 @@ class DBClassName extends DBEnum
      *
      * @return string|null
      */
-    public function getShortName()
+    public function getShortName(): string|null
     {
         $value = $this->getValue();
         if (empty($value) || !ClassInfo::exists($value)) {
@@ -124,7 +124,7 @@ class DBClassName extends DBEnum
      * @param string $baseClass
      * @return $this
      */
-    public function setBaseClass($baseClass)
+    public function setBaseClass(string $baseClass): SilverStripe\ORM\FieldType\DBClassName
     {
         $this->baseClass = $baseClass;
         return $this;
@@ -135,7 +135,7 @@ class DBClassName extends DBEnum
      *
      * @return array
      */
-    public function getEnum()
+    public function getEnum(): array
     {
         $classNames = ClassInfo::subclassesFor($this->getBaseClass());
         $dataobject = strtolower(DataObject::class);
@@ -143,7 +143,7 @@ class DBClassName extends DBEnum
         return array_values($classNames ?? []);
     }
 
-    public function setValue($value, $record = null, $markChanged = true)
+    public function setValue(string $value, SilverStripe\ErrorPage\ErrorPageController $record = null, bool $markChanged = true): void
     {
         parent::setValue($value, $record, $markChanged);
 
@@ -152,7 +152,7 @@ class DBClassName extends DBEnum
         }
     }
 
-    public function getDefault()
+    public function getDefault(): string
     {
         // Check for assigned default
         $default = parent::getDefault();

--- a/src/ORM/FieldType/DBComposite.php
+++ b/src/ORM/FieldType/DBComposite.php
@@ -49,7 +49,7 @@ abstract class DBComposite extends DBField
      */
     protected $record = [];
 
-    public function __set($property, $value)
+    public function __set(string $property, string|float $value): void
     {
         // Prevent failover / extensions from hijacking composite field setters
         // by intentionally avoiding hasMethod()
@@ -60,7 +60,7 @@ abstract class DBComposite extends DBField
         parent::__set($property, $value);
     }
 
-    public function __get($property)
+    public function __get(string $property): null|string|float
     {
         // Prevent failover / extensions from hijacking composite field getters
         // by intentionally avoiding hasMethod()
@@ -75,7 +75,7 @@ abstract class DBComposite extends DBField
      *
      * @param array $manipulation
      */
-    public function writeToManipulation(&$manipulation)
+    public function writeToManipulation(array &$manipulation): void
     {
         foreach ($this->compositeDatabaseFields() as $field => $spec) {
             // Write sub-manipulation
@@ -92,7 +92,7 @@ abstract class DBComposite extends DBField
      *
      * @param SQLSelect $query
      */
-    public function addToQuery(&$query)
+    public function addToQuery(SilverStripe\ORM\Queries\SQLSelect &$query): void
     {
         parent::addToQuery($query);
 
@@ -113,7 +113,7 @@ abstract class DBComposite extends DBField
      *
      * @return array
      */
-    public function compositeDatabaseFields()
+    public function compositeDatabaseFields(): array
     {
         return $this->config()->composite_db;
     }
@@ -123,7 +123,7 @@ abstract class DBComposite extends DBField
      * Returns true if this composite field has changed.
      * For fields bound to a DataObject, this will be cleared when the DataObject is written.
      */
-    public function isChanged()
+    public function isChanged(): bool
     {
         // When unbound, use the local changed flag
         if (!$this->record instanceof DataObject) {
@@ -157,7 +157,7 @@ abstract class DBComposite extends DBField
         return true;
     }
 
-    public function requireField()
+    public function requireField(): void
     {
         foreach ($this->compositeDatabaseFields() as $field => $spec) {
             $key = $this->getName() . $field;
@@ -177,7 +177,7 @@ abstract class DBComposite extends DBField
      * @param bool $markChanged
      * @return $this
      */
-    public function setValue($value, $record = null, $markChanged = true)
+    public function setValue(array|SilverStripe\ORM\FieldType\DBMoney $value, SilverStripe\Assets\Image $record = null, bool $markChanged = true): SilverStripe\Assets\Storage\DBFile
     {
         $this->isChanged = $markChanged;
 
@@ -211,12 +211,12 @@ abstract class DBComposite extends DBField
      *
      * @param DataObject $dataObject
      */
-    public function bindTo($dataObject)
+    public function bindTo(SilverStripe\Assets\Image $dataObject): void
     {
         $this->record = $dataObject;
     }
 
-    public function saveInto($dataObject)
+    public function saveInto(SilverStripe\ORM\Tests\DBMoneyTest\TestObject $dataObject): void
     {
         foreach ($this->compositeDatabaseFields() as $field => $spec) {
             // Save into record
@@ -231,7 +231,7 @@ abstract class DBComposite extends DBField
      * @param string $field
      * @return mixed
      */
-    public function getField($field)
+    public function getField(string $field): null|string|float|int
     {
         // Skip invalid fields
         $fields = $this->compositeDatabaseFields();
@@ -252,7 +252,7 @@ abstract class DBComposite extends DBField
         return null;
     }
 
-    public function hasField($field)
+    public function hasField(string $field): bool
     {
         $fields = $this->compositeDatabaseFields();
         return isset($fields[$field]);
@@ -266,7 +266,7 @@ abstract class DBComposite extends DBField
      * @param bool $markChanged
      * @return $this
      */
-    public function setField($field, $value, $markChanged = true)
+    public function setField(string $field, string|float|int $value, bool $markChanged = true): SilverStripe\Assets\Storage\DBFile
     {
         $this->objCacheClear();
 
@@ -300,7 +300,7 @@ abstract class DBComposite extends DBField
      * @param string $field Field name
      * @return DBField|null
      */
-    public function dbObject($field)
+    public function dbObject(string $field): SilverStripe\ORM\FieldType\DBVarchar
     {
         $fields = $this->compositeDatabaseFields();
         if (!isset($fields[$field])) {
@@ -316,7 +316,7 @@ abstract class DBComposite extends DBField
         return $fieldObject;
     }
 
-    public function castingHelper($field)
+    public function castingHelper(string $field): string
     {
         $fields = $this->compositeDatabaseFields();
         if (isset($fields[$field])) {
@@ -326,7 +326,7 @@ abstract class DBComposite extends DBField
         return parent::castingHelper($field);
     }
 
-    public function getIndexSpecs()
+    public function getIndexSpecs(): void|array
     {
         if ($type = $this->getIndexType()) {
             $columns = array_map(function ($name) {
@@ -340,7 +340,7 @@ abstract class DBComposite extends DBField
         }
     }
 
-    public function scalarValueOnly()
+    public function scalarValueOnly(): bool
     {
         return false;
     }

--- a/src/ORM/FieldType/DBCurrency.php
+++ b/src/ORM/FieldType/DBCurrency.php
@@ -25,7 +25,7 @@ class DBCurrency extends DBDecimal
      */
     private static $currency_symbol = '$';
 
-    public function __construct($name = null, $wholeSize = 9, $decimalSize = 2, $defaultValue = 0)
+    public function __construct(string $name = null, $wholeSize = 9, $decimalSize = 2, $defaultValue = 0): void
     {
         parent::__construct($name, $wholeSize, $decimalSize, $defaultValue);
     }
@@ -33,7 +33,7 @@ class DBCurrency extends DBDecimal
     /**
      * Returns the number as a currency, eg “$1,000.00”.
      */
-    public function Nice()
+    public function Nice(): string
     {
         $val = $this->config()->currency_symbol . number_format(abs($this->value ?? 0.0) ?? 0.0, 2);
         if ($this->value < 0) {
@@ -46,7 +46,7 @@ class DBCurrency extends DBDecimal
     /**
      * Returns the number as a whole-number currency, eg “$1,000”.
      */
-    public function Whole()
+    public function Whole(): string
     {
         $val = $this->config()->currency_symbol . number_format(abs($this->value ?? 0.0) ?? 0.0, 0);
         if ($this->value < 0) {
@@ -55,7 +55,7 @@ class DBCurrency extends DBDecimal
         return $val;
     }
 
-    public function setValue($value, $record = null, $markChanged = true)
+    public function setValue(string|int|float $value, SilverStripe\Dev\Tests\CsvBulkLoaderTest\PlayerContract $record = null, bool $markChanged = true): SilverStripe\ORM\FieldType\DBCurrency
     {
         $matches = null;
         if (is_numeric($value)) {
@@ -75,7 +75,7 @@ class DBCurrency extends DBDecimal
      *
      * @return CurrencyField
      */
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField($title = null, $params = null): SilverStripe\Forms\CurrencyField
     {
         return CurrencyField::create($this->getName(), $title);
     }

--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -40,7 +40,7 @@ class DBDate extends DBField
      */
     const ISO_LOCALE = 'en_US';
 
-    public function setValue($value, $record = null, $markChanged = true)
+    public function setValue(string|int|bool|array $value, SilverStripe\ErrorPage\ErrorPageController $record = null, bool $markChanged = true): SilverStripe\ORM\FieldType\DBDatetime
     {
         $value = $this->parseDate($value);
         if ($value === false) {
@@ -58,7 +58,7 @@ class DBDate extends DBField
      * @param mixed $value
      * @return string|null|false Formatted date, null if empty but valid, or false if invalid
      */
-    protected function parseDate($value)
+    protected function parseDate(string|int|bool|array $value): string|null
     {
         // Skip empty values
         if (empty($value) && !is_numeric($value)) {
@@ -92,7 +92,7 @@ class DBDate extends DBField
      *
      * @return string
      */
-    public function Nice()
+    public function Nice(): string
     {
         if (!$this->value) {
             return null;
@@ -106,7 +106,7 @@ class DBDate extends DBField
      *
      * @return string
      */
-    public function Year()
+    public function Year(): string
     {
         return $this->Format('y');
     }
@@ -116,7 +116,7 @@ class DBDate extends DBField
      *
      * @return string
      */
-    public function DayOfWeek()
+    public function DayOfWeek(): string
     {
         return $this->Format('cccc');
     }
@@ -126,7 +126,7 @@ class DBDate extends DBField
      *
      * @return string
      */
-    public function Month()
+    public function Month(): string
     {
         return $this->Format('LLLL');
     }
@@ -136,7 +136,7 @@ class DBDate extends DBField
      *
      * @return string
      */
-    public function ShortMonth()
+    public function ShortMonth(): string
     {
         return $this->Format('LLL');
     }
@@ -147,7 +147,7 @@ class DBDate extends DBField
      * @param bool $includeOrdinal Include ordinal suffix to day, e.g. "th" or "rd"
      * @return string
      */
-    public function DayOfMonth($includeOrdinal = false)
+    public function DayOfMonth(bool $includeOrdinal = false): string
     {
         $number = $this->Format('d');
         if ($includeOrdinal && $number) {
@@ -162,7 +162,7 @@ class DBDate extends DBField
      *
      * @return string
      */
-    public function Short()
+    public function Short(): string
     {
         if (!$this->value) {
             return null;
@@ -176,7 +176,7 @@ class DBDate extends DBField
      *
      * @return string
      */
-    public function Long()
+    public function Long(): string
     {
         if (!$this->value) {
             return null;
@@ -190,7 +190,7 @@ class DBDate extends DBField
      *
      * @return string
      */
-    public function Full()
+    public function Full(): string
     {
         if (!$this->value) {
             return null;
@@ -206,7 +206,7 @@ class DBDate extends DBField
      * @param int $timeLength
      * @return IntlDateFormatter
      */
-    public function getFormatter($dateLength = IntlDateFormatter::MEDIUM, $timeLength = IntlDateFormatter::NONE)
+    public function getFormatter($dateLength = IntlDateFormatter::MEDIUM, $timeLength = IntlDateFormatter::NONE): IntlDateFormatter
     {
         return $this->getCustomFormatter(null, null, $dateLength, $timeLength);
     }
@@ -221,11 +221,11 @@ class DBDate extends DBField
      * @return IntlDateFormatter
      */
     public function getCustomFormatter(
-        $locale = null,
+        string $locale = null,
         $pattern = null,
         $dateLength = IntlDateFormatter::MEDIUM,
         $timeLength = IntlDateFormatter::NONE
-    ) {
+    ): IntlDateFormatter {
         $locale = $locale ?: i18n::get_locale();
         $formatter = IntlDateFormatter::create($locale, $dateLength, $timeLength);
         if ($pattern) {
@@ -240,7 +240,7 @@ class DBDate extends DBField
      * @internal
      * @return IntlDateFormatter
      */
-    protected function getInternalFormatter()
+    protected function getInternalFormatter(): IntlDateFormatter
     {
         $formatter = $this->getCustomFormatter(DBDate::ISO_LOCALE, DBDate::ISO_DATE);
         $formatter->setLenient(false);
@@ -265,7 +265,7 @@ class DBDate extends DBField
      * @param string $locale Custom locale to use (add to signature in 5.0)
      * @return string The date in the requested format
      */
-    public function Format($format)
+    public function Format(string $format): string|null
     {
         // Note: soft-arg uses func_get_args() to respect semver. Add to signature in 5.0
         $locale = func_num_args() > 1 ? func_get_arg(1) : null;
@@ -288,7 +288,7 @@ class DBDate extends DBField
      *
      * @return int
      */
-    public function getTimestamp()
+    public function getTimestamp(): int
     {
         if ($this->value) {
             return strtotime($this->value ?? '');
@@ -324,7 +324,7 @@ class DBDate extends DBField
      * @param bool $includeOrdinals Include ordinal suffix to day, e.g. "th" or "rd"
      * @return string
      */
-    public function RangeString($otherDateObj, $includeOrdinals = false)
+    public function RangeString(SilverStripe\ORM\FieldType\DBDate $otherDateObj, bool $includeOrdinals = false): string
     {
         $d1 = $this->DayOfMonth($includeOrdinals);
         $d2 = $otherDateObj->DayOfMonth($includeOrdinals);
@@ -347,7 +347,7 @@ class DBDate extends DBField
      *
      * @return string
      */
-    public function Rfc822()
+    public function Rfc822(): string
     {
         if ($this->value) {
             return date('r', $this->getTimestamp());
@@ -360,7 +360,7 @@ class DBDate extends DBField
      *
      * @return string
      */
-    public function Rfc2822()
+    public function Rfc2822(): string
     {
         $formatter = $this->getInternalFormatter();
         $formatter->setPattern('y-MM-dd HH:mm:ss');
@@ -372,7 +372,7 @@ class DBDate extends DBField
      *
      * @return string
      */
-    public function Rfc3339()
+    public function Rfc3339(): string
     {
         return date('c', $this->getTimestamp());
     }
@@ -384,7 +384,7 @@ class DBDate extends DBField
      * @param int $significance Minimum significant value of X for "X units ago" to display
      * @return string
      */
-    public function Ago($includeSeconds = true, $significance = 2)
+    public function Ago(string|bool $includeSeconds = true, int $significance = 2): string|null
     {
         if (!$this->value) {
             return null;
@@ -412,7 +412,7 @@ class DBDate extends DBField
      * @param int $significance Minimum significant value of X for "X units ago" to display
      * @return string
      */
-    public function TimeDiff($includeSeconds = true, $significance = 2)
+    public function TimeDiff(string|bool $includeSeconds = true, int $significance = 2): string
     {
         if (!$this->value) {
             return false;
@@ -449,7 +449,7 @@ class DBDate extends DBField
      * 'seconds', 'minutes', 'hours', 'days', 'months', 'years'.
      * @return string The resulting formatted period
      */
-    public function TimeDiffIn($format)
+    public function TimeDiffIn(string $format): string
     {
         if (!$this->value) {
             return null;
@@ -512,7 +512,7 @@ class DBDate extends DBField
         }
     }
 
-    public function requireField()
+    public function requireField(): void
     {
         $parts = ['datatype' => 'date', 'arrayValue' => $this->arrayValue];
         $values = ['type' => 'date', 'parts' => $parts];
@@ -523,7 +523,7 @@ class DBDate extends DBField
      * Returns true if date is in the past.
      * @return boolean
      */
-    public function InPast()
+    public function InPast(): bool
     {
         return strtotime($this->value ?? '') < DBDatetime::now()->getTimestamp();
     }
@@ -532,7 +532,7 @@ class DBDate extends DBField
      * Returns true if date is in the future.
      * @return boolean
      */
-    public function InFuture()
+    public function InFuture(): bool
     {
         return strtotime($this->value ?? '') > DBDatetime::now()->getTimestamp();
     }
@@ -541,7 +541,7 @@ class DBDate extends DBField
      * Returns true if date is today.
      * @return boolean
      */
-    public function IsToday()
+    public function IsToday(): bool
     {
         return $this->Format(self::ISO_DATE) === DBDatetime::now()->Format(self::ISO_DATE);
     }
@@ -570,12 +570,12 @@ class DBDate extends DBField
      *
      * @return string
      */
-    public function URLDate()
+    public function URLDate(): string
     {
         return rawurlencode($this->Format(self::ISO_DATE, self::ISO_LOCALE) ?? '');
     }
 
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField($title = null, array $params = null): SilverStripe\Forms\DateField
     {
         $field = DateField::create($this->name, $title);
         $field->setHTML5(true);
@@ -589,7 +589,7 @@ class DBDate extends DBField
      * @param string $value
      * @return string
      */
-    protected function fixInputDate($value)
+    protected function fixInputDate(string $value): string|null
     {
         // split
         [$year, $month, $day, $time] = $this->explodeDateString($value);
@@ -614,7 +614,7 @@ class DBDate extends DBField
      * @param string $value
      * @return array
      */
-    protected function explodeDateString($value)
+    protected function explodeDateString(string $value): array
     {
         // split on known delimiters (. / -)
         if (!preg_match(

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -67,7 +67,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
         return $this;
     }
 
-    public function setValue($value, $record = null, $markChanged = true)
+    public function setValue(string|int|bool $value, SilverStripe\ErrorPage\ErrorPageController $record = null, bool $markChanged = true): SilverStripe\ORM\FieldType\DBDatetime
     {
         if ($this->immutable) {
             // This field is set as immutable so we have to create a new field instance
@@ -92,7 +92,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      *
      * @return string Formatted date.
      */
-    public function Date()
+    public function Date(): string
     {
         $formatter = $this->getFormatter(IntlDateFormatter::MEDIUM, IntlDateFormatter::NONE);
         return $formatter->format($this->getTimestamp());
@@ -103,7 +103,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      *
      * @return string Formatted time.
      */
-    public function Time()
+    public function Time(): string
     {
         $formatter = $this->getFormatter(IntlDateFormatter::NONE, IntlDateFormatter::MEDIUM);
         return $formatter->format($this->getTimestamp());
@@ -124,7 +124,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      *
      * @return string Formatted time.
      */
-    public function Time24()
+    public function Time24(): string
     {
         return $this->Format('H:mm');
     }
@@ -135,7 +135,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      * @param Member $member
      * @return boolean|string A time and date pair formatted as per user-defined settings.
      */
-    public function FormatFromSettings($member = null)
+    public function FormatFromSettings($member = null): null|string
     {
         if (!$member) {
             $member = Security::getCurrentUser();
@@ -153,7 +153,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
         return $this->Format($dateFormat . ' ' . $timeFormat, $member->getLocale());
     }
 
-    public function requireField()
+    public function requireField(): void
     {
         $parts = [
             'datatype' => 'datetime',
@@ -172,12 +172,12 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      *
      * @return string Formatted date and time.
      */
-    public function URLDatetime()
+    public function URLDatetime(): string
     {
         return rawurlencode($this->Format(self::ISO_DATETIME, self::ISO_LOCALE) ?? '');
     }
 
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField(string $title = null, array $params = null): SilverStripe\Forms\DatetimeField
     {
         $field = DatetimeField::create($this->name, $title);
         $dateTimeFormat = $field->getDatetimeFormat();
@@ -208,7 +208,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      *
      * @return static
      */
-    public static function now()
+    public static function now(): SilverStripe\ORM\FieldType\DBDatetime
     {
         $time = self::$mock_now ? self::$mock_now->Value : time();
 
@@ -226,7 +226,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      * @param DBDatetime|string $datetime Either in object format, or as a DBDatetime compatible string.
      * @throws Exception
      */
-    public static function set_mock_now($datetime)
+    public static function set_mock_now(string|int|SilverStripe\ORM\FieldType\DBDatetime $datetime): void
     {
         if (!$datetime instanceof DBDatetime) {
             $value = $datetime;
@@ -242,7 +242,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      * Clear any mocked date, which causes
      * {@link Now()} to return the current system date.
      */
-    public static function clear_mock_now()
+    public static function clear_mock_now(): void
     {
         self::$mock_now = null;
     }
@@ -255,7 +255,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      * @return mixed
      * @throws Exception
      */
-    public static function withFixedNow($time, $callback)
+    public static function withFixedNow(string $time, callable $callback): bool|null|SilverStripe\Security\Member
     {
         $original = self::$mock_now;
 
@@ -268,7 +268,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
         }
     }
 
-    public static function get_template_global_variables()
+    public static function get_template_global_variables(): array
     {
         return [
             'Now' => ['method' => 'now', 'casting' => 'Datetime'],
@@ -282,7 +282,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      * @param int $timeLength
      * @return IntlDateFormatter
      */
-    public function getFormatter($dateLength = IntlDateFormatter::MEDIUM, $timeLength = IntlDateFormatter::SHORT)
+    public function getFormatter($dateLength = IntlDateFormatter::MEDIUM, $timeLength = IntlDateFormatter::SHORT): IntlDateFormatter
     {
         return parent::getFormatter($dateLength, $timeLength);
     }
@@ -298,11 +298,11 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      * @return IntlDateFormatter
      */
     public function getCustomFormatter(
-        $locale = null,
+        string $locale = null,
         $pattern = null,
         $dateLength = IntlDateFormatter::MEDIUM,
         $timeLength = IntlDateFormatter::MEDIUM
-    ) {
+    ): IntlDateFormatter {
         return parent::getCustomFormatter($locale, $pattern, $dateLength, $timeLength);
     }
 
@@ -312,7 +312,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      * @internal
      * @return IntlDateFormatter
      */
-    protected function getInternalFormatter()
+    protected function getInternalFormatter(): IntlDateFormatter
     {
         $formatter = $this->getCustomFormatter(DBDate::ISO_LOCALE, DBDatetime::ISO_DATETIME);
         $formatter->setLenient(false);

--- a/src/ORM/FieldType/DBDecimal.php
+++ b/src/ORM/FieldType/DBDecimal.php
@@ -40,7 +40,7 @@ class DBDecimal extends DBField
      * @param int $decimalSize
      * @param float|int $defaultValue
      */
-    public function __construct($name = null, $wholeSize = 9, $decimalSize = 2, $defaultValue = 0)
+    public function __construct(string $name = null, int $wholeSize = 9, int $decimalSize = 2, int|float|string $defaultValue = 0): void
     {
         $this->wholeSize = is_int($wholeSize) ? $wholeSize : 9;
         $this->decimalSize = is_int($decimalSize) ? $decimalSize : 2;
@@ -66,7 +66,7 @@ class DBDecimal extends DBField
         return floor($this->value ?? 0.0);
     }
 
-    public function requireField()
+    public function requireField(): void
     {
         $parts = [
             'datatype' => 'decimal',
@@ -102,7 +102,7 @@ class DBDecimal extends DBField
      *
      * @return NumericField
      */
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField(string $title = null, $params = null): SilverStripe\Forms\NumericField
     {
         return NumericField::create($this->name, $title)
             ->setScale($this->decimalSize);
@@ -111,12 +111,12 @@ class DBDecimal extends DBField
     /**
      * @return float
      */
-    public function nullValue()
+    public function nullValue(): int
     {
         return 0;
     }
 
-    public function prepValueForDB($value)
+    public function prepValueForDB(string|float|int|bool|array $value): int|float
     {
         if ($value === true) {
             return 1;

--- a/src/ORM/FieldType/DBDouble.php
+++ b/src/ORM/FieldType/DBDouble.php
@@ -11,7 +11,7 @@ use SilverStripe\ORM\DB;
 class DBDouble extends DBFloat
 {
 
-    public function requireField()
+    public function requireField(): void
     {
         // HACK: MSSQL does not support double so we're using float instead
         // @todo This should go into MSSQLDatabase ideally somehow

--- a/src/ORM/FieldType/DBEnum.php
+++ b/src/ORM/FieldType/DBEnum.php
@@ -43,7 +43,7 @@ class DBEnum extends DBString
     /**
      * Clear all cached enum values.
      */
-    public static function flushCache()
+    public static function flushCache(): void
     {
         self::$enum_cache = [];
     }
@@ -67,7 +67,7 @@ class DBEnum extends DBString
      * Set to null or empty string to allow empty values
      * @param array  $options Optional parameters for this DB field
      */
-    public function __construct($name = null, $enum = null, $default = 0, $options = [])
+    public function __construct(string $name = null, string|array $enum = null, string|int $default = 0, array $options = []): void
     {
         if ($enum) {
             $this->setEnum($enum);
@@ -97,7 +97,7 @@ class DBEnum extends DBString
     /**
      * @return void
      */
-    public function requireField()
+    public function requireField(): void
     {
         $charset = Config::inst()->get(MySQLDatabase::class, 'charset');
         $collation = Config::inst()->get(MySQLDatabase::class, 'collation');
@@ -130,7 +130,7 @@ class DBEnum extends DBString
      * @param string $emptyString
      * @return DropdownField
      */
-    public function formField($title = null, $name = null, $hasEmpty = false, $value = '', $emptyString = null)
+    public function formField($title = null, $name = null, bool $hasEmpty = false, string $value = '', string $emptyString = null): SilverStripe\Forms\DropdownField
     {
 
         if (!$title) {
@@ -148,7 +148,7 @@ class DBEnum extends DBString
         return $field;
     }
 
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField($title = null, array $params = null): SilverStripe\Forms\DropdownField
     {
         return $this->formField($title);
     }
@@ -157,7 +157,7 @@ class DBEnum extends DBString
      * @param string $title
      * @return DropdownField
      */
-    public function scaffoldSearchField($title = null)
+    public function scaffoldSearchField($title = null): SilverStripe\Forms\DropdownField
     {
         $anyText = _t(__CLASS__ . '.ANY', 'Any');
         return $this->formField($title, null, true, '', "($anyText)");
@@ -171,7 +171,7 @@ class DBEnum extends DBString
      *
      * @return array
      */
-    public function enumValues($hasEmpty = false)
+    public function enumValues(bool $hasEmpty = false): array
     {
         return ($hasEmpty)
             ? array_merge(['' => ''], ArrayLib::valuekey($this->getEnum()))
@@ -183,7 +183,7 @@ class DBEnum extends DBString
      *
      * @return array
      */
-    public function getEnum()
+    public function getEnum(): array
     {
         return $this->enum;
     }
@@ -199,7 +199,7 @@ class DBEnum extends DBString
      *
      * @return array
      */
-    public function getEnumObsolete()
+    public function getEnumObsolete(): array
     {
         // Without a table or field specified, we can only retrieve known enum values
         $table = $this->getTable();
@@ -236,7 +236,7 @@ class DBEnum extends DBString
      * @param string|array $enum
      * @return $this
      */
-    public function setEnum($enum)
+    public function setEnum(string|array $enum): SilverStripe\ORM\FieldType\DBEnum
     {
         if (!is_array($enum)) {
             $enum = preg_split(
@@ -254,7 +254,7 @@ class DBEnum extends DBString
      *
      * @return string|null
      */
-    public function getDefault()
+    public function getDefault(): null|string
     {
         return $this->default;
     }
@@ -265,7 +265,7 @@ class DBEnum extends DBString
      * @param string $default
      * @return $this
      */
-    public function setDefault($default)
+    public function setDefault(string $default): SilverStripe\ORM\FieldType\DBEnum
     {
         $this->default = $default;
         $this->setDefaultValue($default);

--- a/src/ORM/FieldType/DBField.php
+++ b/src/ORM/FieldType/DBField.php
@@ -134,7 +134,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      * @param  array  $options
      * @throws InvalidArgumentException If $options was passed by not an array
      */
-    public function __construct($name = null, $options = [])
+    public function __construct(string|int $name = null, array $options = []): void
     {
         $this->name = $name;
 
@@ -161,7 +161,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      * Note: Will raise a warning if using both
      * @return static
      */
-    public static function create_field($spec, $value, $name = null, ...$args)
+    public static function create_field(string $spec, string|bool|int|SilverStripe\ORM\FieldType\DBHTMLText|array|float $value, $name = null, ...$args): SilverStripe\ORM\FieldType\DBHTMLText
     {
         // Raise warning if inconsistent with DataObject::dbObject() behaviour
         // This will cause spec args to be shifted down by the number of provided $args
@@ -189,7 +189,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName(string $name): SilverStripe\ORM\FieldType\DBHTMLText
     {
         if ($this->name && $this->name !== $name) {
             user_error("DBField::setName() shouldn't be called once a DBField already has a name."
@@ -206,7 +206,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string|null
     {
         return $this->name;
     }
@@ -216,7 +216,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return mixed
      */
-    public function getValue()
+    public function getValue(): string|null|bool|int|array|float|SilverStripe\ORM\FieldType\DBHTMLText
     {
         return $this->value;
     }
@@ -237,7 +237,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *  than setting a new value.
      * @return $this
      */
-    public function setValue($value, $record = null, $markChanged = true)
+    public function setValue(string|bool|int|array|float|SilverStripe\ORM\FieldType\DBHTMLText $value, SilverStripe\View\ArrayData $record = null, bool $markChanged = true): SilverStripe\ORM\FieldType\DBText
     {
         $this->value = $value;
         return $this;
@@ -248,7 +248,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return mixed
      */
-    public function getDefaultValue()
+    public function getDefaultValue(): string|null
     {
         return $this->defaultVal;
     }
@@ -259,7 +259,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      * @param mixed $defaultValue
      * @return $this
      */
-    public function setDefaultValue($defaultValue)
+    public function setDefaultValue(string $defaultValue): SilverStripe\ORM\FieldType\DBEnum
     {
         $this->defaultVal = $defaultValue;
         return $this;
@@ -271,7 +271,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      * @param array $options Array of options
      * @return $this
      */
-    public function setOptions(array $options = [])
+    public function setOptions(array $options = []): SilverStripe\ORM\FieldType\DBClassName
     {
         $this->options = $options;
         return $this;
@@ -301,7 +301,7 @@ abstract class DBField extends ViewableData implements DBIndexable
         return $this;
     }
 
-    public function getIndexType()
+    public function getIndexType(): bool|string
     {
         if (array_key_exists('index', $this->options ?? [])) {
             $type = $this->options['index'];
@@ -325,7 +325,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return boolean
      */
-    public function exists()
+    public function exists(): bool
     {
         return (bool)$this->value;
     }
@@ -338,7 +338,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      * @param mixed $value The value to check
      * @return mixed The raw value, or escaped parameterised details
      */
-    public function prepValueForDB($value)
+    public function prepValueForDB(string|array $value): string|null|array
     {
         if ($value === null ||
             $value === "" ||
@@ -363,7 +363,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @param array $manipulation
      */
-    public function writeToManipulation(&$manipulation)
+    public function writeToManipulation(array &$manipulation): void
     {
         $manipulation['fields'][$this->name] = $this->exists()
             ? $this->prepValueForDB($this->value) : $this->nullValue();
@@ -380,7 +380,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @param SQLSelect $query
      */
-    public function addToQuery(&$query)
+    public function addToQuery(SilverStripe\ORM\Queries\SQLSelect &$query): void
     {
     }
 
@@ -390,7 +390,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      * @param string $tableName
      * @return $this
      */
-    public function setTable($tableName)
+    public function setTable(string $tableName): SilverStripe\ORM\FieldType\DBPrimaryKey
     {
         $this->tableName = $tableName;
         return $this;
@@ -401,7 +401,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return string|null
      */
-    public function getTable()
+    public function getTable(): string|null
     {
         return $this->tableName;
     }
@@ -411,7 +411,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return string
      */
-    public function forTemplate()
+    public function forTemplate(): string
     {
         // Default to XML encoding
         return $this->XML();
@@ -422,7 +422,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return string
      */
-    public function HTMLATT()
+    public function HTMLATT(): string
     {
         return Convert::raw2htmlatt($this->RAW());
     }
@@ -432,7 +432,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return string
      */
-    public function URLATT()
+    public function URLATT(): string
     {
         return urlencode($this->RAW() ?? '');
     }
@@ -442,7 +442,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return string
      */
-    public function RAWURLATT()
+    public function RAWURLATT(): string
     {
         return rawurlencode($this->RAW() ?? '');
     }
@@ -452,7 +452,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return string
      */
-    public function ATT()
+    public function ATT(): string
     {
         return Convert::raw2att($this->RAW());
     }
@@ -463,7 +463,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return mixed
      */
-    public function RAW()
+    public function RAW(): string|null|bool|int|array|float
     {
         return $this->getValue();
     }
@@ -473,7 +473,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return string
      */
-    public function JS()
+    public function JS(): string
     {
         return Convert::raw2js($this->RAW());
     }
@@ -483,7 +483,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return string
      */
-    public function JSON()
+    public function JSON(): string
     {
         return json_encode($this->RAW());
     }
@@ -493,7 +493,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return string
      */
-    public function HTML()
+    public function HTML(): string
     {
         return $this->XML();
     }
@@ -503,7 +503,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return string
      */
-    public function XML()
+    public function XML(): string
     {
         return Convert::raw2xml($this->RAW());
     }
@@ -513,7 +513,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return string
      */
-    public function CDATA()
+    public function CDATA(): string
     {
         return $this->XML();
     }
@@ -524,7 +524,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @return mixed
      */
-    public function nullValue()
+    public function nullValue(): null
     {
         return null;
     }
@@ -534,7 +534,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      *
      * @param DataObject $dataObject
      */
-    public function saveInto($dataObject)
+    public function saveInto(DNADesign\Elemental\Models\ElementContent $dataObject): void
     {
         $fieldName = $this->name;
         if (empty($fieldName)) {
@@ -569,7 +569,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      * @param string $title Optional. Localized title of the generated instance
      * @return FormField
      */
-    public function scaffoldSearchField($title = null)
+    public function scaffoldSearchField($title = null): SilverStripe\Forms\TextField
     {
         return $this->scaffoldFormField($title);
     }
@@ -584,7 +584,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      * @param string $name Override name of this field
      * @return SearchFilter
      */
-    public function defaultSearchFilter($name = null)
+    public function defaultSearchFilter($name = null): SilverStripe\ORM\Filters\PartialMatchFilter
     {
         $name = ($name) ? $name : $this->name;
         $filterClass = $this->config()->get('default_search_filter_class');
@@ -607,7 +607,7 @@ abstract class DBField extends ViewableData implements DBIndexable
 DBG;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->forTemplate();
     }
@@ -624,7 +624,7 @@ DBG;
      * @param array $value
      * @return $this
      */
-    public function setArrayValue($value)
+    public function setArrayValue(string $value): SilverStripe\ORM\FieldType\DBPrimaryKey
     {
         $this->arrayValue = $value;
         return $this;
@@ -635,12 +635,12 @@ DBG;
      *
      * @return string|array Encoded string for use in formschema response
      */
-    public function getSchemaValue()
+    public function getSchemaValue(): string|null|bool|int
     {
         return $this->RAW();
     }
 
-    public function getIndexSpecs()
+    public function getIndexSpecs(): null|array
     {
         $type = $this->getIndexType();
         if ($type) {
@@ -658,7 +658,7 @@ DBG;
      * Composite DBFields can override this method and return `false` so they can accept arrays of values.
      * @return boolean
      */
-    public function scalarValueOnly()
+    public function scalarValueOnly(): bool
     {
         return true;
     }

--- a/src/ORM/FieldType/DBFloat.php
+++ b/src/ORM/FieldType/DBFloat.php
@@ -11,14 +11,14 @@ use SilverStripe\ORM\DB;
 class DBFloat extends DBField
 {
 
-    public function __construct($name = null, $defaultVal = 0)
+    public function __construct(string $name = null, $defaultVal = 0): void
     {
         $this->defaultVal = is_float($defaultVal) ? $defaultVal : (float) 0;
 
         parent::__construct($name);
     }
 
-    public function requireField()
+    public function requireField(): void
     {
         $parts = [
             'datatype' => 'float',
@@ -50,19 +50,19 @@ class DBFloat extends DBField
         return number_format(round($this->value ?? 0.0, $precision ?? 0), $precision ?? 0);
     }
 
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField($title = null, array $params = null): SilverStripe\Forms\NumericField
     {
         $field = NumericField::create($this->name, $title);
         $field->setScale(null); // remove no-decimal restriction
         return $field;
     }
 
-    public function nullValue()
+    public function nullValue(): int
     {
         return 0;
     }
 
-    public function prepValueForDB($value)
+    public function prepValueForDB(string|int|bool|array|float $value): string|int|float
     {
         if ($value === true) {
             return 1;

--- a/src/ORM/FieldType/DBForeignKey.php
+++ b/src/ORM/FieldType/DBForeignKey.php
@@ -50,13 +50,13 @@ class DBForeignKey extends DBInt
      */
     protected static $foreignListCache = [];
 
-    public function __construct($name, $object = null)
+    public function __construct(string $name, $object = null): void
     {
         $this->object = $object;
         parent::__construct($name);
     }
 
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField($title = null, array $params = null): SilverStripe\Forms\DropdownField
     {
         if (empty($this->object)) {
             return null;
@@ -126,7 +126,7 @@ class DBForeignKey extends DBInt
         return $field;
     }
 
-    public function setValue($value, $record = null, $markChanged = true)
+    public function setValue(int|string $value, DNADesign\Elemental\Models\ElementContent $record = null, bool $markChanged = true): void
     {
         if ($record instanceof DataObject) {
             $this->object = $record;

--- a/src/ORM/FieldType/DBHTMLText.php
+++ b/src/ORM/FieldType/DBHTMLText.php
@@ -47,7 +47,7 @@ class DBHTMLText extends DBText
      *
      * @return bool
      */
-    public function getProcessShortcodes()
+    public function getProcessShortcodes(): bool
     {
         return $this->processShortcodes;
     }
@@ -58,7 +58,7 @@ class DBHTMLText extends DBText
      * @param bool $process
      * @return $this
      */
-    public function setProcessShortcodes($process)
+    public function setProcessShortcodes(bool $process): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $this->processShortcodes = (bool)$process;
         return $this;
@@ -76,7 +76,7 @@ class DBHTMLText extends DBText
      *
      * @return array
      */
-    public function getWhitelist()
+    public function getWhitelist(): array
     {
         return $this->whitelist;
     }
@@ -87,7 +87,7 @@ class DBHTMLText extends DBText
      * @param array $whitelist
      * @return $this
      */
-    public function setWhitelist($whitelist)
+    public function setWhitelist(array|string $whitelist): SilverStripe\ORM\FieldType\DBHTMLText
     {
         if (!is_array($whitelist)) {
             $whitelist = preg_split('/\s*,\s*/', $whitelist ?? '');
@@ -113,7 +113,7 @@ class DBHTMLText extends DBText
      *
      * @return $this
      */
-    public function setOptions(array $options = [])
+    public function setOptions(array $options = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         if (array_key_exists("shortcodes", $options ?? [])) {
             $this->setProcessShortcodes(!!$options["shortcodes"]);
@@ -126,7 +126,7 @@ class DBHTMLText extends DBText
         return parent::setOptions($options);
     }
 
-    public function RAW()
+    public function RAW(): string|null|SilverStripe\ORM\FieldType\DBHTMLText
     {
         if ($this->processShortcodes) {
             return ShortcodeParser::get_active()->parse($this->value);
@@ -138,12 +138,12 @@ class DBHTMLText extends DBText
      * Return the value of the field with relative links converted to absolute urls (with placeholders parsed).
      * @return string
      */
-    public function AbsoluteLinks()
+    public function AbsoluteLinks(): string
     {
         return HTTP::absoluteURLs($this->forTemplate());
     }
 
-    public function forTemplate()
+    public function forTemplate(): string|null
     {
         // Suppress XML encoding for DBHtmlText
         return $this->RAW();
@@ -154,7 +154,7 @@ class DBHTMLText extends DBText
      *
      * @return string
      */
-    public function CDATA()
+    public function CDATA(): string
     {
         return sprintf(
             '<![CDATA[%s]]>',
@@ -162,7 +162,7 @@ class DBHTMLText extends DBText
         );
     }
 
-    public function prepValueForDB($value)
+    public function prepValueForDB(string|array $value): string|null
     {
         return parent::prepValueForDB($this->whitelistContent($value));
     }
@@ -173,7 +173,7 @@ class DBHTMLText extends DBText
      * @param string $value Input html content
      * @return string Value with all non-whitelisted content stripped (if applicable)
      */
-    public function whitelistContent($value)
+    public function whitelistContent(string|array $value): string|array
     {
         if ($this->whitelist) {
             $dom = HTMLValue::create($value);
@@ -199,12 +199,12 @@ class DBHTMLText extends DBText
         return $value;
     }
 
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField($title = null, array $params = null): SilverStripe\Forms\HTMLEditor\HTMLEditorField
     {
         return HTMLEditorField::create($this->name, $title);
     }
 
-    public function scaffoldSearchField($title = null)
+    public function scaffoldSearchField($title = null): SilverStripe\Forms\TextField
     {
         return new TextField($this->name, $title);
     }
@@ -214,7 +214,7 @@ class DBHTMLText extends DBText
      *
      * @return string
      */
-    public function Plain()
+    public function Plain(): string
     {
         // Preserve line breaks
         $text = preg_replace('/\<br(\s*)?\/?\>/i', "\n", $this->RAW() ?? '');
@@ -232,7 +232,7 @@ class DBHTMLText extends DBText
         return trim(Convert::xml2raw($text) ?? '');
     }
 
-    public function getSchemaValue()
+    public function getSchemaValue(): null|array
     {
         // Form schema format as HTML
         $value = $this->RAW();
@@ -242,7 +242,7 @@ class DBHTMLText extends DBText
         return null;
     }
 
-    public function exists()
+    public function exists(): bool
     {
         // Optimisation: don't process shortcode just for ->exists()
         $value = $this->getValue();

--- a/src/ORM/FieldType/DBHTMLVarchar.php
+++ b/src/ORM/FieldType/DBHTMLVarchar.php
@@ -36,7 +36,7 @@ class DBHTMLVarchar extends DBVarchar
      *
      * @return bool
      */
-    public function getProcessShortcodes()
+    public function getProcessShortcodes(): bool
     {
         return $this->processShortcodes;
     }
@@ -47,7 +47,7 @@ class DBHTMLVarchar extends DBVarchar
      * @param bool $process
      * @return $this
      */
-    public function setProcessShortcodes($process)
+    public function setProcessShortcodes(bool $process): SilverStripe\ORM\FieldType\DBHTMLVarchar
     {
         $this->processShortcodes = (bool)$process;
         return $this;
@@ -69,7 +69,7 @@ class DBHTMLVarchar extends DBVarchar
      *
      * @return $this
      */
-    public function setOptions(array $options = [])
+    public function setOptions(array $options = []): SilverStripe\ORM\FieldType\DBHTMLVarchar
     {
         if (array_key_exists("shortcodes", $options ?? [])) {
             $this->setProcessShortcodes(!!$options["shortcodes"]);
@@ -78,13 +78,13 @@ class DBHTMLVarchar extends DBVarchar
         return parent::setOptions($options);
     }
 
-    public function forTemplate()
+    public function forTemplate(): string
     {
         // Suppress XML encoding for DBHtmlText
         return $this->RAW();
     }
 
-    public function RAW()
+    public function RAW(): string
     {
         if ($this->processShortcodes) {
             return ShortcodeParser::get_active()->parse($this->value);
@@ -112,7 +112,7 @@ class DBHTMLVarchar extends DBVarchar
      *
      * @return string
      */
-    public function Plain()
+    public function Plain(): string
     {
         // Strip out HTML
         $text = strip_tags($this->RAW() ?? '');
@@ -141,7 +141,7 @@ class DBHTMLVarchar extends DBVarchar
         return null;
     }
 
-    public function exists()
+    public function exists(): bool
     {
         // Optimisation: don't process shortcode just for ->exists()
         $value = $this->getValue();

--- a/src/ORM/FieldType/DBInt.php
+++ b/src/ORM/FieldType/DBInt.php
@@ -13,7 +13,7 @@ use SilverStripe\View\ArrayData;
 class DBInt extends DBField
 {
 
-    public function __construct($name = null, $defaultVal = 0)
+    public function __construct(string $name = null, int $defaultVal = 0): void
     {
         $this->defaultVal = is_int($defaultVal) ? $defaultVal : 0;
 
@@ -24,7 +24,7 @@ class DBInt extends DBField
      * Ensure int values are always returned.
      * This is for mis-configured databases that return strings.
      */
-    public function getValue()
+    public function getValue(): int
     {
         return (int) $this->value;
     }
@@ -37,7 +37,7 @@ class DBInt extends DBField
         return number_format($this->value ?? 0.0);
     }
 
-    public function requireField()
+    public function requireField(): void
     {
         $parts = [
             'datatype' => 'int',
@@ -65,17 +65,17 @@ class DBInt extends DBField
         return sprintf('%d', $this->value);
     }
 
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField($title = null, array $params = null): SilverStripe\Forms\NumericField
     {
         return NumericField::create($this->name, $title);
     }
 
-    public function nullValue()
+    public function nullValue(): int
     {
         return 0;
     }
 
-    public function prepValueForDB($value)
+    public function prepValueForDB(int|string|bool|array $value): int
     {
         if ($value === true) {
             return 1;

--- a/src/ORM/FieldType/DBLocale.php
+++ b/src/ORM/FieldType/DBLocale.php
@@ -12,7 +12,7 @@ use SilverStripe\i18n\i18n;
 class DBLocale extends DBVarchar
 {
 
-    public function __construct($name = null, $size = 16)
+    public function __construct($name = null, $size = 16): void
     {
         parent::__construct($name, $size);
     }
@@ -24,7 +24,7 @@ class DBLocale extends DBVarchar
      *  field's locale value.
      * @return String
      */
-    public function Nice($showNative = false)
+    public function Nice(bool $showNative = false): string
     {
         if ($showNative) {
             return $this->getNativeName();
@@ -32,7 +32,7 @@ class DBLocale extends DBVarchar
         return $this->getShortName();
     }
 
-    public function RFC1766()
+    public function RFC1766(): string
     {
         return i18n::convert_rfc1766($this->value);
     }
@@ -43,7 +43,7 @@ class DBLocale extends DBVarchar
      *
      * @return string
      */
-    public function getShortName()
+    public function getShortName(): string
     {
         return i18n::getData()->languageName($this->value);
     }
@@ -51,7 +51,7 @@ class DBLocale extends DBVarchar
     /**
      * @return string
      */
-    public function getLongName()
+    public function getLongName(): string
     {
         return i18n::getData()->localeName($this->value);
     }
@@ -62,7 +62,7 @@ class DBLocale extends DBVarchar
      *
      * @return string
      */
-    public function getNativeName()
+    public function getNativeName(): string
     {
         $locale = $this->value;
         return i18n::with_locale($locale, function () {

--- a/src/ORM/FieldType/DBMoney.php
+++ b/src/ORM/FieldType/DBMoney.php
@@ -31,7 +31,7 @@ class DBMoney extends DBComposite
      *
      * @return NumberFormatter
      */
-    public function getFormatter()
+    public function getFormatter(): NumberFormatter
     {
         $locale = $this->getLocale();
         $currency = $this->getCurrency();
@@ -46,7 +46,7 @@ class DBMoney extends DBComposite
      *
      * @return string
      */
-    public function Nice()
+    public function Nice(): string
     {
         if (!$this->exists()) {
             return null;
@@ -69,7 +69,7 @@ class DBMoney extends DBComposite
      *
      * @return string
      */
-    public function getValue()
+    public function getValue(): string|float
     {
         if (!$this->exists()) {
             return null;
@@ -85,7 +85,7 @@ class DBMoney extends DBComposite
     /**
      * @return string
      */
-    public function getCurrency()
+    public function getCurrency(): string|null
     {
         return $this->getField('Currency');
     }
@@ -95,7 +95,7 @@ class DBMoney extends DBComposite
      * @param bool $markChanged
      * @return $this
      */
-    public function setCurrency($currency, $markChanged = true)
+    public function setCurrency(string $currency, $markChanged = true): SilverStripe\ORM\FieldType\DBMoney
     {
         $this->setField('Currency', $currency, $markChanged);
         return $this;
@@ -104,7 +104,7 @@ class DBMoney extends DBComposite
     /**
      * @return float
      */
-    public function getAmount()
+    public function getAmount(): float|null|int
     {
         return $this->getField('Amount');
     }
@@ -114,7 +114,7 @@ class DBMoney extends DBComposite
      * @param bool $markChanged
      * @return $this
      */
-    public function setAmount($amount, $markChanged = true)
+    public function setAmount(float|int $amount, $markChanged = true): SilverStripe\ORM\FieldType\DBMoney
     {
         // Retain nullability to mark this field as empty
         if (isset($amount)) {
@@ -127,7 +127,7 @@ class DBMoney extends DBComposite
     /**
      * @return boolean
      */
-    public function exists()
+    public function exists(): bool
     {
         return is_numeric($this->getAmount());
     }
@@ -137,7 +137,7 @@ class DBMoney extends DBComposite
      *
      * @return bool
      */
-    public function hasAmount()
+    public function hasAmount(): bool
     {
         $a = $this->getAmount();
         return (!empty($a) && is_numeric($a));
@@ -147,7 +147,7 @@ class DBMoney extends DBComposite
      * @param string $locale
      * @return $this
      */
-    public function setLocale($locale)
+    public function setLocale(string $locale): SilverStripe\ORM\FieldType\DBMoney
     {
         $this->locale = $locale;
         return $this;
@@ -156,7 +156,7 @@ class DBMoney extends DBComposite
     /**
      * @return string
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         return $this->locale ?: i18n::get_locale();
     }
@@ -166,7 +166,7 @@ class DBMoney extends DBComposite
      *
      * @return string
      */
-    public function getSymbol()
+    public function getSymbol(): string
     {
         return $this->getFormatter()->getSymbol(NumberFormatter::CURRENCY_SYMBOL);
     }

--- a/src/ORM/FieldType/DBMultiEnum.php
+++ b/src/ORM/FieldType/DBMultiEnum.php
@@ -12,7 +12,7 @@ use SilverStripe\ORM\DB;
  */
 class DBMultiEnum extends DBEnum
 {
-    public function __construct($name = null, $enum = null, $default = null)
+    public function __construct(string $name = null, string|array $enum = null, $default = null): void
     {
         // MultiEnum needs to take care of its own defaults
         parent::__construct($name, $enum, null);
@@ -33,7 +33,7 @@ class DBMultiEnum extends DBEnum
         }
     }
 
-    public function requireField()
+    public function requireField(): void
     {
         // @todo: Remove mysql-centric logic from this
         $charset = Config::inst()->get(MySQLDatabase::class, 'charset');

--- a/src/ORM/FieldType/DBPercentage.php
+++ b/src/ORM/FieldType/DBPercentage.php
@@ -22,7 +22,7 @@ class DBPercentage extends DBDecimal
      * @param string $name
      * @param int $precision
      */
-    public function __construct($name = null, $precision = 4)
+    public function __construct(string $name = null, int $precision = 4): void
     {
         if (!$precision) {
             $precision = 4;
@@ -34,7 +34,7 @@ class DBPercentage extends DBDecimal
     /**
      * Returns the number, expressed as a percentage. For example, “36.30%”
      */
-    public function Nice()
+    public function Nice(): string
     {
         return number_format($this->value * 100, $this->decimalSize - 2) . '%';
     }

--- a/src/ORM/FieldType/DBPolymorphicForeignKey.php
+++ b/src/ORM/FieldType/DBPolymorphicForeignKey.php
@@ -16,7 +16,7 @@ class DBPolymorphicForeignKey extends DBComposite
         'Class' => "DBClassName('" . DataObject::class . "', ['index' => false])"
     ];
 
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField($title = null, array $params = null): null
     {
         // Opt-out of form field generation - Scaffolding should be performed on
         // the has_many end, or set programmatically.
@@ -29,7 +29,7 @@ class DBPolymorphicForeignKey extends DBComposite
      *
      * @return string Name of a subclass of DataObject
      */
-    public function getClassValue()
+    public function getClassValue(): string
     {
         return $this->getField('Class');
     }
@@ -50,7 +50,7 @@ class DBPolymorphicForeignKey extends DBComposite
      *
      * @return integer
      */
-    public function getIDValue()
+    public function getIDValue(): int
     {
         return $this->getField('ID');
     }
@@ -66,7 +66,7 @@ class DBPolymorphicForeignKey extends DBComposite
         $this->setField('ID', $value, $markChanged);
     }
 
-    public function setValue($value, $record = null, $markChanged = true)
+    public function setValue($value, SilverStripe\Versioned\ChangeSetItem $record = null, bool $markChanged = true): void
     {
         // Map dataobject value to array
         if ($value instanceof DataObject) {
@@ -79,7 +79,7 @@ class DBPolymorphicForeignKey extends DBComposite
         parent::setValue($value, $record, $markChanged);
     }
 
-    public function getValue()
+    public function getValue(): SilverStripe\ORM\Tests\DataObjectTest\Team
     {
         $id = $this->getIDValue();
         $class = $this->getClassValue();

--- a/src/ORM/FieldType/DBPrimaryKey.php
+++ b/src/ORM/FieldType/DBPrimaryKey.php
@@ -24,18 +24,18 @@ class DBPrimaryKey extends DBInt
      */
     protected $autoIncrement = true;
 
-    public function setAutoIncrement($autoIncrement)
+    public function setAutoIncrement(bool $autoIncrement): SilverStripe\ORM\FieldType\DBPrimaryKey
     {
         $this->autoIncrement = $autoIncrement;
         return $this;
     }
 
-    public function getAutoIncrement()
+    public function getAutoIncrement(): bool
     {
         return $this->autoIncrement;
     }
 
-    public function requireField()
+    public function requireField(): void
     {
         $spec = DB::get_schema()->IdColumn(false, $this->getAutoIncrement());
         DB::require_field($this->getTable(), $this->getName(), $spec);
@@ -45,7 +45,7 @@ class DBPrimaryKey extends DBInt
      * @param string $name
      * @param DataObject $object The object that this is primary key for (should have a relation with $name)
      */
-    public function __construct($name, $object = null)
+    public function __construct(string $name, $object = null): void
     {
         $this->object = $object;
         parent::__construct($name);
@@ -56,12 +56,12 @@ class DBPrimaryKey extends DBInt
         return null;
     }
 
-    public function scaffoldSearchField($title = null)
+    public function scaffoldSearchField($title = null): void
     {
         parent::scaffoldFormField($title);
     }
 
-    public function setValue($value, $record = null, $markChanged = true)
+    public function setValue(int $value, DNADesign\Elemental\Models\BaseElement $record = null, bool $markChanged = true): void
     {
         parent::setValue($value, $record, $markChanged);
 

--- a/src/ORM/FieldType/DBString.php
+++ b/src/ORM/FieldType/DBString.php
@@ -24,7 +24,7 @@ abstract class DBString extends DBField
      *
      * {@inheritDoc}
      */
-    public function __construct($name = null, $options = [])
+    public function __construct(string|int $name = null, array $options = []): void
     {
         $this->options['nullifyEmpty'] = true;
         parent::__construct($name, $options);
@@ -42,7 +42,7 @@ abstract class DBString extends DBField
      *   </li></ul>
      * @return $this
      */
-    public function setOptions(array $options = [])
+    public function setOptions(array $options = []): SilverStripe\ORM\FieldType\DBClassName
     {
         parent::setOptions($options);
 
@@ -75,7 +75,7 @@ abstract class DBString extends DBField
      *
      * @return boolean True if empty strings are to be converted to null
      */
-    public function getNullifyEmpty()
+    public function getNullifyEmpty(): bool
     {
         return !empty($this->options['nullifyEmpty']);
     }
@@ -84,14 +84,14 @@ abstract class DBString extends DBField
      * (non-PHPdoc)
      * @see DBField::exists()
      */
-    public function exists()
+    public function exists(): bool
     {
         $value = $this->RAW();
         // All truthy values and non-empty strings exist ('0' but not (int)0)
         return $value || (is_string($value) && strlen($value ?? ''));
     }
 
-    public function prepValueForDB($value)
+    public function prepValueForDB(string|float|int|bool|array $value): string|null
     {
         // Cast non-empty value
         if (is_scalar($value) && strlen($value ?? '')) {
@@ -108,7 +108,7 @@ abstract class DBString extends DBField
     /**
      * @return string
      */
-    public function forTemplate()
+    public function forTemplate(): string
     {
         return nl2br(parent::forTemplate() ?? '');
     }
@@ -122,7 +122,7 @@ abstract class DBString extends DBField
      * @param string|false $add Ellipsis to add to the end of truncated string
      * @return string
      */
-    public function LimitCharacters($limit = 20, $add = false)
+    public function LimitCharacters(int $limit = 20, string $add = false): string
     {
         $value = $this->Plain();
         if (mb_strlen($value ?? '') <= $limit) {
@@ -140,7 +140,7 @@ abstract class DBString extends DBField
      * @param string|false $add Ellipsis to add to the end of truncated string
      * @return string Plain text value with limited characters
      */
-    public function LimitCharactersToClosestWord($limit = 20, $add = false)
+    public function LimitCharactersToClosestWord(int $limit = 20, string $add = false): string
     {
         // Safely convert to plain text
         $value = $this->Plain();
@@ -173,7 +173,7 @@ abstract class DBString extends DBField
      *
      * @return string
      */
-    public function LimitWordCount($numWords = 26, $add = false)
+    public function LimitWordCount(int $numWords = 26, string $add = false): string
     {
         $value = $this->Plain();
         $words = explode(' ', $value ?? '');
@@ -191,7 +191,7 @@ abstract class DBString extends DBField
      *
      * @return string Text with lowercase (HTML for some subclasses)
      */
-    public function LowerCase()
+    public function LowerCase(): string
     {
         return mb_strtolower($this->RAW() ?? '');
     }
@@ -201,7 +201,7 @@ abstract class DBString extends DBField
      *
      * @return string Text with uppercase (HTML for some subclasses)
      */
-    public function UpperCase()
+    public function UpperCase(): string
     {
         return mb_strtoupper($this->RAW() ?? '');
     }
@@ -211,7 +211,7 @@ abstract class DBString extends DBField
      *
      * @return string Plain text
      */
-    public function Plain()
+    public function Plain(): string
     {
         return trim($this->RAW() ?? '');
     }
@@ -222,7 +222,7 @@ abstract class DBString extends DBField
      * @param false|string $add
      * @return string
      */
-    private function addEllipsis(string $string, $add): string
+    private function addEllipsis(string $string, bool|string $add): string
     {
         if ($add === false) {
             $add = $this->defaultEllipsis();

--- a/src/ORM/FieldType/DBText.php
+++ b/src/ORM/FieldType/DBText.php
@@ -41,7 +41,7 @@ class DBText extends DBString
      * (non-PHPdoc)
      * @see DBField::requireField()
      */
-    public function requireField()
+    public function requireField(): void
     {
         $charset = Config::inst()->get(MySQLDatabase::class, 'charset');
         $collation = Config::inst()->get(MySQLDatabase::class, 'collation');
@@ -68,7 +68,7 @@ class DBText extends DBString
      * @param int $maxSentences The amount of sentences you want.
      * @return string
      */
-    public function LimitSentences($maxSentences = 2)
+    public function LimitSentences(int $maxSentences = 2): string
     {
         if (!is_numeric($maxSentences)) {
             throw new InvalidArgumentException("Text::LimitSentence() expects one numeric argument");
@@ -105,7 +105,7 @@ class DBText extends DBString
      *
      * @return string
      */
-    public function FirstSentence()
+    public function FirstSentence(): string
     {
         return $this->LimitSentences(1);
     }
@@ -117,7 +117,7 @@ class DBText extends DBString
      * @param string|false $add
      * @return string
      */
-    public function Summary($maxWords = 50, $add = false)
+    public function Summary(int $maxWords = 50, string|bool $add = false): string
     {
         // Get plain-text version
         $value = $this->Plain();
@@ -161,7 +161,7 @@ class DBText extends DBString
      *
      * @return string
      */
-    public function FirstParagraph()
+    public function FirstParagraph(): string
     {
         $value = $this->Plain();
         if (empty($value)) {
@@ -185,12 +185,12 @@ class DBText extends DBString
      * @return string HTML string with context
      */
     public function ContextSummary(
-        $characters = 500,
+        int $characters = 500,
         $keywords = null,
         $highlight = true,
         $prefix = false,
         $suffix = false
-    ) {
+    ): string {
 
         if (!$keywords) {
             // Use the default "Search" request variable (from SearchForm)
@@ -254,7 +254,7 @@ class DBText extends DBString
         return nl2br($summary ?? '');
     }
 
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField(string $title = null, array $params = null): SilverStripe\Forms\TextareaField
     {
         if (!$this->nullifyEmpty) {
             // Allow the user to select if it's null instead of automatically assuming empty string is
@@ -264,7 +264,7 @@ class DBText extends DBString
         return TextareaField::create($this->name, $title);
     }
 
-    public function scaffoldSearchField($title = null)
+    public function scaffoldSearchField($title = null): SilverStripe\Forms\TextField
     {
         return new TextField($this->name, $title);
     }

--- a/src/ORM/FieldType/DBTime.php
+++ b/src/ORM/FieldType/DBTime.php
@@ -27,7 +27,7 @@ class DBTime extends DBField
      */
     const ISO_TIME = 'HH:mm:ss';
 
-    public function setValue($value, $record = null, $markChanged = true)
+    public function setValue(string $value, BasicFieldsTestPage $record = null, bool $markChanged = true): SilverStripe\ORM\FieldType\DBTime
     {
         $value = $this->parseTime($value);
         if ($value === false) {
@@ -45,7 +45,7 @@ class DBTime extends DBField
      * @param mixed $value
      * @return string|null|false Formatted time, null if empty but valid, or false if invalid
      */
-    protected function parseTime($value)
+    protected function parseTime(string $value): null|string
     {
         // Skip empty values
         if (empty($value) && !is_numeric($value)) {
@@ -77,7 +77,7 @@ class DBTime extends DBField
      * @param int $timeLength
      * @return IntlDateFormatter
      */
-    public function getFormatter($timeLength = IntlDateFormatter::MEDIUM)
+    public function getFormatter($timeLength = IntlDateFormatter::MEDIUM): IntlDateFormatter
     {
         return IntlDateFormatter::create(i18n::get_locale(), IntlDateFormatter::NONE, $timeLength);
     }
@@ -87,7 +87,7 @@ class DBTime extends DBField
      *
      * @return string
      */
-    public function Short()
+    public function Short(): string
     {
         if (!$this->value) {
             return null;
@@ -102,7 +102,7 @@ class DBTime extends DBField
      *
      * @return string
      */
-    public function Nice()
+    public function Nice(): string
     {
         if (!$this->value) {
             return null;
@@ -127,7 +127,7 @@ class DBTime extends DBField
         return $formatter->format($this->getTimestamp());
     }
 
-    public function requireField()
+    public function requireField(): void
     {
         $parts = [
             'datatype' => 'time',
@@ -172,7 +172,7 @@ class DBTime extends DBField
      *
      * @return string
      */
-    public function getISOFormat()
+    public function getISOFormat(): string
     {
         return self::ISO_TIME;
     }
@@ -182,7 +182,7 @@ class DBTime extends DBField
      *
      * @return int
      */
-    public function getTimestamp()
+    public function getTimestamp(): int
     {
         if ($this->value) {
             return strtotime($this->value ?? '');

--- a/src/ORM/FieldType/DBVarchar.php
+++ b/src/ORM/FieldType/DBVarchar.php
@@ -38,7 +38,7 @@ class DBVarchar extends DBString
      * @param array $options Optional parameters, e.g. array("nullifyEmpty"=>false).
      *                       See {@link StringField::setOptions()} for information on the available options
      */
-    public function __construct($name = null, $size = 255, $options = [])
+    public function __construct(string|int $name = null, int $size = 255, array $options = []): void
     {
         $this->size = $size ? $size : 255;
         parent::__construct($name, $options);
@@ -53,7 +53,7 @@ class DBVarchar extends DBString
      *
      * @return int The size of the field
      */
-    public function getSize()
+    public function getSize(): int
     {
         return $this->size;
     }
@@ -62,7 +62,7 @@ class DBVarchar extends DBString
      * (non-PHPdoc)
      * @see DBField::requireField()
      */
-    public function requireField()
+    public function requireField(): void
     {
         $charset = Config::inst()->get(MySQLDatabase::class, 'charset');
         $collation = Config::inst()->get(MySQLDatabase::class, 'collation');
@@ -88,7 +88,7 @@ class DBVarchar extends DBString
      *
      * @return string
      */
-    public function Initial()
+    public function Initial(): string
     {
         if ($this->exists()) {
             $value = $this->RAW();
@@ -120,7 +120,7 @@ class DBVarchar extends DBString
         return str_replace("\n", '\par ', $this->RAW() ?? '');
     }
 
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField(string $title = null, array $params = null): SilverStripe\Forms\TextField
     {
         // Set field with appropriate size
         $field = TextField::create($this->name, $title);

--- a/src/ORM/FieldType/DBYear.php
+++ b/src/ORM/FieldType/DBYear.php
@@ -11,14 +11,14 @@ use SilverStripe\ORM\DB;
 class DBYear extends DBField
 {
 
-    public function requireField()
+    public function requireField(): void
     {
         $parts = ['datatype' => 'year', 'precision' => 4, 'arrayValue' => $this->arrayValue];
         $values = ['type' => 'year', 'parts' => $parts];
         DB::require_field($this->tableName, $this->name, $values);
     }
 
-    public function scaffoldFormField($title = null, $params = null)
+    public function scaffoldFormField(string $title = null, $params = null): SilverStripe\Forms\DropdownField
     {
         $selectBox = DropdownField::create($this->name, $title);
         $selectBox->setSource($this->getDefaultOptions());
@@ -35,7 +35,7 @@ class DBYear extends DBField
      * @param int|bool $end end date to count down to
      * @return array
      */
-    private function getDefaultOptions($start = null, $end = null)
+    private function getDefaultOptions($start = null, $end = null): array
     {
         if (!$start) {
             $start = (int)date('Y');

--- a/src/ORM/Filters/ComparisonFilter.php
+++ b/src/ORM/Filters/ComparisonFilter.php
@@ -39,7 +39,7 @@ abstract class ComparisonFilter extends SearchFilter
      * @param DataQuery $query
      * @return DataQuery
      */
-    protected function applyOne(DataQuery $query)
+    protected function applyOne(DataQuery $query): SilverStripe\ORM\DataQuery
     {
         $this->model = $query->applyRelation($this->relation);
 
@@ -58,7 +58,7 @@ abstract class ComparisonFilter extends SearchFilter
      * @param DataQuery $query
      * @return DataQuery
      */
-    protected function excludeOne(DataQuery $query)
+    protected function excludeOne(DataQuery $query): SilverStripe\ORM\DataQuery
     {
         $this->model = $query->applyRelation($this->relation);
 

--- a/src/ORM/Filters/EndsWithFilter.php
+++ b/src/ORM/Filters/EndsWithFilter.php
@@ -14,7 +14,7 @@ namespace SilverStripe\ORM\Filters;
 class EndsWithFilter extends PartialMatchFilter
 {
 
-    protected function getMatchPattern($value)
+    protected function getMatchPattern(string $value): string
     {
         return "%$value";
     }

--- a/src/ORM/Filters/ExactMatchFilter.php
+++ b/src/ORM/Filters/ExactMatchFilter.php
@@ -15,7 +15,7 @@ use InvalidArgumentException;
 class ExactMatchFilter extends SearchFilter
 {
 
-    public function getSupportedModifiers()
+    public function getSupportedModifiers(): array
     {
         return ['not', 'nocase', 'case'];
     }
@@ -26,7 +26,7 @@ class ExactMatchFilter extends SearchFilter
      * @param DataQuery $query
      * @return DataQuery
      */
-    protected function applyOne(DataQuery $query)
+    protected function applyOne(DataQuery $query): SilverStripe\ORM\DataQuery
     {
         return $this->oneFilter($query, true);
     }
@@ -37,7 +37,7 @@ class ExactMatchFilter extends SearchFilter
      * @param DataQuery $query
      * @return DataQuery
      */
-    protected function excludeOne(DataQuery $query)
+    protected function excludeOne(DataQuery $query): SilverStripe\ORM\DataQuery_SubGroup
     {
         return $this->oneFilter($query, false);
     }
@@ -49,7 +49,7 @@ class ExactMatchFilter extends SearchFilter
      * @param bool $inclusive True if this is inclusive, or false if exclusive
      * @return DataQuery
      */
-    protected function oneFilter(DataQuery $query, $inclusive)
+    protected function oneFilter(DataQuery $query, bool $inclusive): SilverStripe\ORM\DataQuery
     {
         $this->model = $query->applyRelation($this->relation);
         $field = $this->getDbName();
@@ -90,7 +90,7 @@ class ExactMatchFilter extends SearchFilter
      * @param DataQuery $query
      * @return DataQuery
      */
-    protected function applyMany(DataQuery $query)
+    protected function applyMany(DataQuery $query): SilverStripe\ORM\DataQuery
     {
         return $this->manyFilter($query, true);
     }
@@ -102,7 +102,7 @@ class ExactMatchFilter extends SearchFilter
      * @param DataQuery $query
      * @return DataQuery
      */
-    protected function excludeMany(DataQuery $query)
+    protected function excludeMany(DataQuery $query): SilverStripe\ORM\DataQuery
     {
         return $this->manyFilter($query, false);
     }
@@ -114,7 +114,7 @@ class ExactMatchFilter extends SearchFilter
      * @param bool $inclusive True if this is inclusive, or false if exclusive
      * @return DataQuery
      */
-    protected function manyFilter(DataQuery $query, $inclusive)
+    protected function manyFilter(DataQuery $query, bool $inclusive): SilverStripe\ORM\DataQuery
     {
         $this->model = $query->applyRelation($this->relation);
         $caseSensitive = $this->getCaseSensitive();
@@ -201,7 +201,7 @@ class ExactMatchFilter extends SearchFilter
             $query->where($clause);
     }
 
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return $this->getValue() === [] || $this->getValue() === null || $this->getValue() === '';
     }

--- a/src/ORM/Filters/FulltextFilter.php
+++ b/src/ORM/Filters/FulltextFilter.php
@@ -30,14 +30,14 @@ use Exception;
 class FulltextFilter extends SearchFilter
 {
 
-    protected function applyOne(DataQuery $query)
+    protected function applyOne(DataQuery $query): SilverStripe\ORM\DataQuery
     {
         $this->model = $query->applyRelation($this->relation);
         $predicate = sprintf("MATCH (%s) AGAINST (?)", $this->getDbName());
         return $query->where([$predicate => $this->getValue()]);
     }
 
-    protected function excludeOne(DataQuery $query)
+    protected function excludeOne(DataQuery $query): SilverStripe\ORM\DataQuery_SubGroup
     {
         $this->model = $query->applyRelation($this->relation);
         $predicate = sprintf("NOT MATCH (%s) AGAINST (?)", $this->getDbName());
@@ -61,7 +61,7 @@ class FulltextFilter extends SearchFilter
      * @throws Exception
      * @return string
     */
-    public function getDbName()
+    public function getDbName(): string
     {
         $indexes = DataObject::getSchema()->databaseIndexes($this->model);
         if (array_key_exists($this->getName(), $indexes ?? [])) {
@@ -87,7 +87,7 @@ class FulltextFilter extends SearchFilter
      * @param array $columns
      * @return string
      */
-    protected function prepareColumns($columns)
+    protected function prepareColumns(array $columns): string
     {
         $prefix = DataQuery::applyRelationPrefix($this->relation);
         $table = DataObject::getSchema()->tableForField($this->model, current($columns ?? []));

--- a/src/ORM/Filters/GreaterThanFilter.php
+++ b/src/ORM/Filters/GreaterThanFilter.php
@@ -11,12 +11,12 @@ namespace SilverStripe\ORM\Filters;
 class GreaterThanFilter extends ComparisonFilter
 {
 
-    protected function getOperator()
+    protected function getOperator(): string
     {
         return ">";
     }
 
-    protected function getInverseOperator()
+    protected function getInverseOperator(): string
     {
         return "<=";
     }

--- a/src/ORM/Filters/GreaterThanOrEqualFilter.php
+++ b/src/ORM/Filters/GreaterThanOrEqualFilter.php
@@ -11,7 +11,7 @@ namespace SilverStripe\ORM\Filters;
 class GreaterThanOrEqualFilter extends ComparisonFilter
 {
 
-    protected function getOperator()
+    protected function getOperator(): string
     {
         return ">=";
     }

--- a/src/ORM/Filters/LessThanFilter.php
+++ b/src/ORM/Filters/LessThanFilter.php
@@ -11,12 +11,12 @@ namespace SilverStripe\ORM\Filters;
 class LessThanFilter extends ComparisonFilter
 {
 
-    protected function getOperator()
+    protected function getOperator(): string
     {
         return "<";
     }
 
-    protected function getInverseOperator()
+    protected function getInverseOperator(): string
     {
         return ">=";
     }

--- a/src/ORM/Filters/LessThanOrEqualFilter.php
+++ b/src/ORM/Filters/LessThanOrEqualFilter.php
@@ -11,7 +11,7 @@ namespace SilverStripe\ORM\Filters;
 class LessThanOrEqualFilter extends ComparisonFilter
 {
 
-    protected function getOperator()
+    protected function getOperator(): string
     {
         return "<=";
     }

--- a/src/ORM/Filters/PartialMatchFilter.php
+++ b/src/ORM/Filters/PartialMatchFilter.php
@@ -12,7 +12,7 @@ use InvalidArgumentException;
 class PartialMatchFilter extends SearchFilter
 {
 
-    public function getSupportedModifiers()
+    public function getSupportedModifiers(): array
     {
         return ['not', 'nocase', 'case'];
     }
@@ -23,7 +23,7 @@ class PartialMatchFilter extends SearchFilter
      * @param string $value The raw value
      * @return string
      */
-    protected function getMatchPattern($value)
+    protected function getMatchPattern(string $value): string
     {
         return "%$value%";
     }
@@ -34,7 +34,7 @@ class PartialMatchFilter extends SearchFilter
      * @param DataQuery $query
      * @return DataQuery
      */
-    public function apply(DataQuery $query)
+    public function apply(DataQuery $query): SilverStripe\ORM\DataQuery_SubGroup
     {
         if ($this->aggregate) {
             throw new InvalidArgumentException(sprintf(
@@ -46,7 +46,7 @@ class PartialMatchFilter extends SearchFilter
         return parent::apply($query);
     }
 
-    protected function applyOne(DataQuery $query)
+    protected function applyOne(DataQuery $query): SilverStripe\ORM\DataQuery_SubGroup
     {
         $this->model = $query->applyRelation($this->relation);
         $comparisonClause = DB::get_conn()->comparisonClause(
@@ -65,7 +65,7 @@ class PartialMatchFilter extends SearchFilter
             $query->where($clause);
     }
 
-    protected function applyMany(DataQuery $query)
+    protected function applyMany(DataQuery $query): SilverStripe\ORM\DataQuery
     {
         $this->model = $query->applyRelation($this->relation);
         $whereClause = [];
@@ -83,7 +83,7 @@ class PartialMatchFilter extends SearchFilter
         return $query->whereAny($whereClause);
     }
 
-    protected function excludeOne(DataQuery $query)
+    protected function excludeOne(DataQuery $query): SilverStripe\ORM\DataQuery_SubGroup
     {
         $this->model = $query->applyRelation($this->relation);
         $comparisonClause = DB::get_conn()->comparisonClause(
@@ -121,7 +121,7 @@ class PartialMatchFilter extends SearchFilter
         return $query->where([$predicate => $parameters]);
     }
 
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return $this->getValue() === [] || $this->getValue() === null || $this->getValue() === '';
     }

--- a/src/ORM/Filters/SearchFilter.php
+++ b/src/ORM/Filters/SearchFilter.php
@@ -85,7 +85,7 @@ abstract class SearchFilter
      * @param mixed $value
      * @param array $modifiers
      */
-    public function __construct($fullName = null, $value = false, array $modifiers = [])
+    public function __construct(string $fullName = null, int|string|array|bool $value = false, array $modifiers = []): void
     {
         $this->fullName = $fullName;
 
@@ -102,7 +102,7 @@ abstract class SearchFilter
      *
      * @param string $name
      */
-    protected function addRelation($name)
+    protected function addRelation(string $name): void
     {
         if (strstr($name ?? '', '.')) {
             $parts = explode('.', $name ?? '');
@@ -118,7 +118,7 @@ abstract class SearchFilter
      *
      * @param string $name
      */
-    protected function addAggregate($name)
+    protected function addAggregate(string $name): void
     {
         if (!$this->relation) {
             return;
@@ -146,7 +146,7 @@ abstract class SearchFilter
      *
      * @param string|DataObject $className
      */
-    public function setModel($className)
+    public function setModel(string|SilverStripe\ORM\Tests\DataObjectTest\Team $className): void
     {
         $this->model = ClassInfo::class_name($className);
     }
@@ -156,7 +156,7 @@ abstract class SearchFilter
      *
      * @param string|array $value
      */
-    public function setValue($value)
+    public function setValue(string|array $value): void
     {
         $this->value = $value;
     }
@@ -166,7 +166,7 @@ abstract class SearchFilter
      *
      * @return string|array
      */
-    public function getValue()
+    public function getValue(): int|string|array|null|bool
     {
         return $this->value;
     }
@@ -176,7 +176,7 @@ abstract class SearchFilter
      *
      * @param array $modifiers
      */
-    public function setModifiers(array $modifiers)
+    public function setModifiers(array $modifiers): void
     {
         $modifiers = array_map('strtolower', $modifiers ?? []);
 
@@ -197,7 +197,7 @@ abstract class SearchFilter
      *
      * @return array
      */
-    public function getSupportedModifiers()
+    public function getSupportedModifiers(): array
     {
         // By default support 'not' as a modifier for all filters
         return ['not'];
@@ -208,7 +208,7 @@ abstract class SearchFilter
      *
      * @return array
      */
-    public function getModifiers()
+    public function getModifiers(): array
     {
         return $this->modifiers;
     }
@@ -218,7 +218,7 @@ abstract class SearchFilter
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -237,7 +237,7 @@ abstract class SearchFilter
      *
      * @return string
      */
-    public function getFullName()
+    public function getFullName(): string
     {
         return $this->fullName;
     }
@@ -255,7 +255,7 @@ abstract class SearchFilter
      *
      * @return string
      */
-    public function getDbName()
+    public function getDbName(): string
     {
         // Special handler for "NULL" relations
         if ($this->name === "NULL") {
@@ -314,7 +314,7 @@ abstract class SearchFilter
      *
      * @return string
      */
-    public function getDbFormattedValue()
+    public function getDbFormattedValue(): int|string
     {
         // SRM: This code finds the table where the field named $this->name lives
         // Todo: move to somewhere more appropriate, such as DataMapper, the magical class-to-be?
@@ -335,7 +335,7 @@ abstract class SearchFilter
      * @param  string    $having
      * @return DataQuery
      */
-    public function applyAggregate(DataQuery $query, $having)
+    public function applyAggregate(DataQuery $query, array $having): SilverStripe\ORM\DataQuery
     {
         $schema = DataObject::getSchema();
         $baseTable = $schema->baseDataTable($query->dataClass());
@@ -351,7 +351,7 @@ abstract class SearchFilter
      * @param DataQuery $query
      * @return DataQuery
      */
-    public function apply(DataQuery $query)
+    public function apply(DataQuery $query): SilverStripe\ORM\DataQuery
     {
         if (($key = array_search('not', $this->modifiers ?? [])) !== false) {
             unset($this->modifiers[$key]);
@@ -389,7 +389,7 @@ abstract class SearchFilter
      * @param DataQuery $query
      * @return DataQuery
      */
-    public function exclude(DataQuery $query)
+    public function exclude(DataQuery $query): SilverStripe\ORM\DataQuery_SubGroup
     {
         if (($key = array_search('not', $this->modifiers ?? [])) !== false) {
             unset($this->modifiers[$key]);
@@ -439,7 +439,7 @@ abstract class SearchFilter
      *
      * @return Mixed TRUE or FALSE to enforce sensitivity, NULL to use field collation.
      */
-    protected function getCaseSensitive()
+    protected function getCaseSensitive(): null|bool
     {
         $modifiers = $this->getModifiers();
         if (in_array('case', $modifiers ?? [])) {

--- a/src/ORM/Filters/StartsWithFilter.php
+++ b/src/ORM/Filters/StartsWithFilter.php
@@ -14,7 +14,7 @@ namespace SilverStripe\ORM\Filters;
 class StartsWithFilter extends PartialMatchFilter
 {
 
-    protected function getMatchPattern($value)
+    protected function getMatchPattern(string $value): string
     {
         return "$value%";
     }

--- a/src/ORM/GroupedList.php
+++ b/src/ORM/GroupedList.php
@@ -15,7 +15,7 @@ class GroupedList extends ListDecorator
      * @param  string $index
      * @return array
      */
-    public function groupBy($index)
+    public function groupBy(string $index): array
     {
         $result = [];
 
@@ -42,7 +42,7 @@ class GroupedList extends ListDecorator
      * @param  string $children Name of the control under which children can be iterated on
      * @return ArrayList
      */
-    public function GroupedBy($index, $children = 'Children')
+    public function GroupedBy(string $index, $children = 'Children'): SilverStripe\ORM\ArrayList
     {
         $grouped = $this->groupBy($index);
         $result  = new ArrayList();

--- a/src/ORM/HasManyList.php
+++ b/src/ORM/HasManyList.php
@@ -24,7 +24,7 @@ class HasManyList extends RelationList
      * @param string $dataClass The class of the DataObjects that this will list.
      * @param string $foreignKey The name of the foreign key field to set the ID filter against.
      */
-    public function __construct($dataClass, $foreignKey)
+    public function __construct(string $dataClass, string $foreignKey): void
     {
         parent::__construct($dataClass);
 
@@ -36,7 +36,7 @@ class HasManyList extends RelationList
      *
      * @return string
      */
-    public function getForeignKey()
+    public function getForeignKey(): string
     {
         return $this->foreignKey;
     }
@@ -45,7 +45,7 @@ class HasManyList extends RelationList
      * @param null|int|array|string $id
      * @return array
      */
-    protected function foreignIDFilter($id = null)
+    protected function foreignIDFilter(int|array $id = null): array
     {
         if ($id === null) {
             $id = $this->getForeignID();
@@ -69,7 +69,7 @@ class HasManyList extends RelationList
      *
      * @param DataObject|int $item The DataObject to be added, or its ID
      */
-    public function add($item)
+    public function add(int|SilverStripe\Versioned\ChangeSetItem $item): void
     {
         if (is_numeric($item)) {
             $item = DataObject::get_by_id($this->dataClass, $item);
@@ -106,7 +106,7 @@ class HasManyList extends RelationList
      *
      * @param int $itemID The ID of the item to be removed.
      */
-    public function removeByID($itemID)
+    public function removeByID(int $itemID): null
     {
         $item = $this->byID($itemID);
 
@@ -120,7 +120,7 @@ class HasManyList extends RelationList
      * @param DataObject $item The DataObject to be removed
      * @todo Maybe we should delete the object instead?
      */
-    public function remove($item)
+    public function remove(SilverStripe\ORM\Tests\DataObjectTest\TeamComment $item): void
     {
         if (!($item instanceof $this->dataClass)) {
             throw new InvalidArgumentException("HasManyList::remove() expecting a $this->dataClass object, or ID");

--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -104,7 +104,7 @@ class Hierarchy extends DataExtension
      */
     protected static $cache_numChildren = [];
 
-    public static function get_extra_config($class, $extension, $args)
+    public static function get_extra_config(string $class, string $extension, array $args): array
     {
         return [
             'has_one' => ['Parent' => $class]
@@ -116,7 +116,7 @@ class Hierarchy extends DataExtension
      *
      * @param ValidationResult $validationResult
      */
-    public function validate(ValidationResult $validationResult)
+    public function validate(ValidationResult $validationResult): void
     {
         // The object is new, won't be looping.
         /** @var DataObject|Hierarchy $owner */
@@ -160,7 +160,7 @@ class Hierarchy extends DataExtension
      *
      * @return int[]
      */
-    public function getDescendantIDList()
+    public function getDescendantIDList(): array
     {
         $idList = [];
         $this->loadDescendantIDListInto($idList);
@@ -173,7 +173,7 @@ class Hierarchy extends DataExtension
      * @param array $idList Array to put results in.
      * @param DataObject|Hierarchy $node
      */
-    protected function loadDescendantIDListInto(&$idList, $node = null)
+    protected function loadDescendantIDListInto(array &$idList, SilverStripe\ORM\Tests\HierarchyTest\TestObject $node = null): void
     {
         if (!$node) {
             $node = $this->owner;
@@ -192,7 +192,7 @@ class Hierarchy extends DataExtension
      *
      * @return SS_List
      */
-    public function Children()
+    public function Children(): SilverStripe\ORM\ArrayList
     {
         $children = $this->owner->_cache_children;
         if ($children) {
@@ -214,7 +214,7 @@ class Hierarchy extends DataExtension
      *
      * @return DataList
      */
-    public function AllChildren()
+    public function AllChildren(): SilverStripe\ORM\DataList
     {
         return $this->owner->stageChildren(true);
     }
@@ -228,7 +228,7 @@ class Hierarchy extends DataExtension
      *
      * @return ArrayList
      */
-    public function AllChildrenIncludingDeleted()
+    public function AllChildrenIncludingDeleted(): SilverStripe\ORM\ArrayList
     {
         /** @var DataObject|Hierarchy|Versioned $owner */
         $owner = $this->owner;
@@ -255,7 +255,7 @@ class Hierarchy extends DataExtension
      * @return DataList
      * @throws Exception
      */
-    public function AllHistoricalChildren()
+    public function AllHistoricalChildren(): SilverStripe\ORM\DataList
     {
         /** @var DataObject|Versioned|Hierarchy $owner */
         $owner = $this->owner;
@@ -279,7 +279,7 @@ class Hierarchy extends DataExtension
      *
      * @return int
      */
-    public function numHistoricalChildren()
+    public function numHistoricalChildren(): int
     {
         return $this->AllHistoricalChildren()->count();
     }
@@ -291,7 +291,7 @@ class Hierarchy extends DataExtension
      * @param bool $cache Whether to retrieve values from cache
      * @return int
      */
-    public function numChildren($cache = true)
+    public function numChildren(bool $cache = true): int
     {
 
         $baseClass = $this->owner->baseClass();
@@ -330,7 +330,7 @@ class Hierarchy extends DataExtension
      * @param array $options A map of hints about what should be cached. "numChildrenMethod" and
      *                       "childrenMethod" are allowed keys.
      */
-    public function prepopulateTreeDataCache($recordList = null, array $options = [])
+    public function prepopulateTreeDataCache(array $recordList = null, array $options = []): void
     {
         if (empty($options['numChildrenMethod']) || $options['numChildrenMethod'] === 'numChildren') {
             $idList = is_array($recordList) ? $recordList :
@@ -349,7 +349,7 @@ class Hierarchy extends DataExtension
      * @param string $baseClass
      * @param array $idList
      */
-    public static function prepopulate_numchildren_cache($baseClass, $idList = null)
+    public static function prepopulate_numchildren_cache(string $baseClass, array $idList = null): void
     {
         if (!Config::inst()->get(static::class, 'prepopulate_numchildren_cache')) {
             return;
@@ -433,7 +433,7 @@ class Hierarchy extends DataExtension
      * @param bool $skipParentIDFilter Set to true to suppress the ParentID and ID where statements.
      * @return DataList
      */
-    public function stageChildren($showAll = false, $skipParentIDFilter = false)
+    public function stageChildren(bool $showAll = false, bool $skipParentIDFilter = false): SilverStripe\ORM\DataList
     {
         /** @var DataObject|Hierarchy $owner */
         $owner = $this->owner;
@@ -480,7 +480,7 @@ class Hierarchy extends DataExtension
      * @return DataList
      * @throws Exception
      */
-    public function liveChildren($showAll = false, $onlyDeletedFromStage = false)
+    public function liveChildren(bool $showAll = false, bool $onlyDeletedFromStage = false): SilverStripe\ORM\DataList
     {
         /** @var Versioned|DataObject|Hierarchy $owner */
         $owner = $this->owner;
@@ -517,7 +517,7 @@ class Hierarchy extends DataExtension
      * @param string $filter
      * @return DataObject
      */
-    public function getParent($filter = null)
+    public function getParent($filter = null): null|SilverStripe\Assets\Folder
     {
         $parentID = $this->owner->ParentID;
         if (empty($parentID)) {
@@ -537,7 +537,7 @@ class Hierarchy extends DataExtension
      * @param bool $includeSelf
      * @return ArrayList
      */
-    public function getAncestors($includeSelf = false)
+    public function getAncestors(bool $includeSelf = false): SilverStripe\ORM\ArrayList
     {
         $ancestors = new ArrayList();
         $object = $this->owner;
@@ -558,7 +558,7 @@ class Hierarchy extends DataExtension
      * @param string $separator
      * @return string
      */
-    public function getBreadcrumbs($separator = ' &raquo; ')
+    public function getBreadcrumbs(string $separator = ' &raquo; '): string
     {
         $crumbs = [];
         $ancestors = array_reverse($this->owner->getAncestors()->toArray() ?? []);
@@ -575,7 +575,7 @@ class Hierarchy extends DataExtension
      * - Children (instance)
      * - NumChildren (instance)
      */
-    public function flushCache()
+    public function flushCache(): void
     {
         $this->owner->_cache_children = null;
         self::$cache_numChildren = [];

--- a/src/ORM/Hierarchy/MarkedSet.php
+++ b/src/ORM/Hierarchy/MarkedSet.php
@@ -102,7 +102,7 @@ class MarkedSet
         $numChildrenMethod = null,
         $nodeCountThreshold = null,
         $maxChildNodes = null
-    ) {
+    ): void {
         if (! $rootNode::has_extension(Hierarchy::class)) {
             throw new InvalidArgumentException(
                 get_class($rootNode) . " does not have the Hierarchy extension"
@@ -130,7 +130,7 @@ class MarkedSet
      *
      * @return int
      */
-    public function getNodeCountThreshold()
+    public function getNodeCountThreshold(): int
     {
         return $this->nodeCountThreshold
             ?: $this->rootNode->config()->get('node_threshold_total');
@@ -143,7 +143,7 @@ class MarkedSet
      *
      * @return int
      */
-    public function getMaxChildNodes()
+    public function getMaxChildNodes(): int
     {
         return $this->maxChildNodes
             ?: $this->rootNode->config()->get('node_threshold_leaf');
@@ -155,7 +155,7 @@ class MarkedSet
      * @param int $count
      * @return $this
      */
-    public function setMaxChildNodes($count)
+    public function setMaxChildNodes(int $count): SilverStripe\ORM\Hierarchy\MarkedSet
     {
         $this->maxChildNodes = $count;
         return $this;
@@ -167,7 +167,7 @@ class MarkedSet
      * @param int $total
      * @return $this
      */
-    public function setNodeCountThreshold($total)
+    public function setNodeCountThreshold(int $total): SilverStripe\ORM\Hierarchy\MarkedSet
     {
         $this->nodeCountThreshold = $total;
         return $this;
@@ -178,7 +178,7 @@ class MarkedSet
      *
      * @return string
      */
-    public function getChildrenMethod()
+    public function getChildrenMethod(): string
     {
         return $this->childrenMethod ?: 'AllChildrenIncludingDeleted';
     }
@@ -189,7 +189,7 @@ class MarkedSet
      * @param DataObject $node
      * @return SS_List
      */
-    protected function getChildren(DataObject $node)
+    protected function getChildren(DataObject $node): SilverStripe\ORM\ArrayList
     {
         $method = $this->getChildrenMethod();
         return $node->$method() ?: ArrayList::create();
@@ -202,7 +202,7 @@ class MarkedSet
      * @throws InvalidArgumentException
      * @return $this
      */
-    public function setChildrenMethod($method)
+    public function setChildrenMethod(string $method): SilverStripe\ORM\Hierarchy\MarkedSet
     {
         // Check method is valid
         if (!$this->rootNode->hasMethod($method)) {
@@ -221,7 +221,7 @@ class MarkedSet
      *
      * @return string
      */
-    public function getNumChildrenMethod()
+    public function getNumChildrenMethod(): string
     {
         return $this->numChildrenMethod ?: 'numChildren';
     }
@@ -232,7 +232,7 @@ class MarkedSet
      * @param DataObject $node
      * @return int
      */
-    protected function getNumChildren(DataObject $node)
+    protected function getNumChildren(DataObject $node): int
     {
         $method = $this->getNumChildrenMethod();
         return (int)$node->$method();
@@ -244,7 +244,7 @@ class MarkedSet
      * @param string $method
      * @return $this
      */
-    public function setNumChildrenMethod($method)
+    public function setNumChildrenMethod(string $method): SilverStripe\ORM\Hierarchy\MarkedSet
     {
         // Check method is valid
         if (!$this->rootNode->hasMethod($method)) {
@@ -268,9 +268,9 @@ class MarkedSet
      * @return string
      */
     public function renderChildren(
-        $template = null,
+        array|string $template = null,
         $context = []
-    ) {
+    ): string {
         // Default to HTML template
         if (!$template) {
             $template = [
@@ -291,7 +291,7 @@ class MarkedSet
      * replace the 'node' property at each point in the tree.
      * @return array
      */
-    public function getChildrenAsArray($serialiseEval = null)
+    public function getChildrenAsArray(callable $serialiseEval = null): array
     {
         if (!$serialiseEval) {
             $serialiseEval = function ($data) {
@@ -318,7 +318,7 @@ class MarkedSet
      * due to excessive line length. If callable, this will be executed with the current node dataobject
      * @return ArrayData Viewable object representing the root node. use getField('SubTree') to get HTML
      */
-    protected function renderSubtree($data, $template, $context = [])
+    protected function renderSubtree(array $data, array|string $template, callable|array $context = []): SilverStripe\View\ArrayData
     {
         // Render children
         $childNodes = new ArrayList();
@@ -357,7 +357,7 @@ class MarkedSet
      * replace the 'node' property at each point in the tree.
      * @return mixed|string
      */
-    protected function getSubtreeAsArray($data, $serialiseEval)
+    protected function getSubtreeAsArray(array $data, callable $serialiseEval): array
     {
         $output = $data;
 
@@ -399,7 +399,7 @@ class MarkedSet
      * @param int $depth
      * @return array|string
      */
-    protected function getSubtree($node, $depth = 0)
+    protected function getSubtree(SilverStripe\CMS\Model\SiteTree $node, int $depth = 0): array
     {
         // Check if this node is limited due to child count
         $numChildren = $this->getNumChildren($node);
@@ -448,7 +448,7 @@ class MarkedSet
      *
      * @return $this
      */
-    public function markPartialTree()
+    public function markPartialTree(): SilverStripe\ORM\Hierarchy\MarkedSet
     {
         $nodeCountThreshold = $this->getNodeCountThreshold();
 
@@ -497,7 +497,7 @@ class MarkedSet
      * @param callable $callback Callback to filter
      * @return $this
      */
-    public function setMarkingFilterFunction($callback)
+    public function setMarkingFilterFunction(callable $callback): SilverStripe\ORM\Hierarchy\MarkedSet
     {
         $this->markingFilter = [
             "func" => $callback,
@@ -511,7 +511,7 @@ class MarkedSet
      * @param DataObject $node Node to check
      * @return bool
      */
-    protected function markingFilterMatches(DataObject $node)
+    protected function markingFilterMatches(DataObject $node): bool
     {
         if (!$this->markingFilter) {
             return true;
@@ -544,7 +544,7 @@ class MarkedSet
      * @param DataObject $node Parent node
      * @return array List of children marked by this operation
      */
-    protected function markChildren(DataObject $node)
+    protected function markChildren(DataObject $node): array
     {
         $this->markExpanded($node);
 
@@ -587,7 +587,7 @@ class MarkedSet
      * @param DataObject $node
      * @return string
      */
-    protected function markingClasses($node)
+    protected function markingClasses(Page $node): string
     {
         $classes = [];
         if (!$this->isExpanded($node)) {
@@ -615,7 +615,7 @@ class MarkedSet
      * @param bool $open If this is true, mark the parent node as opened
      * @return bool
      */
-    public function markById($id, $open = false)
+    public function markById(int $id, bool $open = false): bool
     {
         if (isset($this->markedNodes[$id])) {
             $this->markChildren($this->markedNodes[$id]);
@@ -634,7 +634,7 @@ class MarkedSet
      * @param DataObject|Hierarchy $childObj
      * @return $this
      */
-    public function markToExpose(DataObject $childObj)
+    public function markToExpose(DataObject $childObj): SilverStripe\ORM\Hierarchy\MarkedSet
     {
         if (!$childObj) {
             return $this;
@@ -652,7 +652,7 @@ class MarkedSet
      * @refactor called from CMSMain
      * @return array
      */
-    public function markedNodeIDs()
+    public function markedNodeIDs(): array
     {
         return array_keys($this->markedNodes ?? []);
     }
@@ -672,7 +672,7 @@ class MarkedSet
     /**
      * Reset marked nodes
      */
-    public function clearMarks()
+    public function clearMarks(): void
     {
         $this->markedNodes = [];
         $this->expanded = [];
@@ -685,7 +685,7 @@ class MarkedSet
      * @param DataObject $node
      * @return $this
      */
-    public function markExpanded(DataObject $node)
+    public function markExpanded(DataObject $node): SilverStripe\ORM\Hierarchy\MarkedSet
     {
         $id = $node->ID ?: 0;
         $this->markedNodes[$id] = $node;
@@ -699,7 +699,7 @@ class MarkedSet
      * @param DataObject $node
      * @return $this
      */
-    public function markUnexpanded(DataObject $node)
+    public function markUnexpanded(DataObject $node): SilverStripe\ORM\Hierarchy\MarkedSet
     {
         $id = $node->ID ?: 0;
         $this->markedNodes[$id] = $node;
@@ -713,7 +713,7 @@ class MarkedSet
      * @param DataObject $node
      * @return $this
      */
-    public function markOpened(DataObject $node)
+    public function markOpened(DataObject $node): SilverStripe\ORM\Hierarchy\MarkedSet
     {
         $id = $node->ID ?: 0;
         $this->markedNodes[$id] = $node;
@@ -727,7 +727,7 @@ class MarkedSet
      * @param DataObject $node
      * @return $this
      */
-    public function markClosed(DataObject $node)
+    public function markClosed(DataObject $node): SilverStripe\ORM\Hierarchy\MarkedSet
     {
         $id = $node->ID ?: 0;
         $this->markedNodes[$id] = $node;
@@ -741,7 +741,7 @@ class MarkedSet
      * @param DataObject $node
      * @return bool
      */
-    public function isMarked(DataObject $node)
+    public function isMarked(DataObject $node): bool
     {
         $id = $node->ID ?: 0;
         return !empty($this->markedNodes[$id]);
@@ -754,7 +754,7 @@ class MarkedSet
      * @param DataObject $node
      * @return bool
      */
-    public function isExpanded(DataObject $node)
+    public function isExpanded(DataObject $node): bool
     {
         $id = $node->ID ?: 0;
         return !empty($this->expanded[$id]);
@@ -767,7 +767,7 @@ class MarkedSet
      * @param DataObject $node
      * @return bool
      */
-    public function isTreeOpened(DataObject $node)
+    public function isTreeOpened(DataObject $node): bool
     {
         $id = $node->ID ?: 0;
         return !empty($this->treeOpened[$id]);
@@ -780,7 +780,7 @@ class MarkedSet
      * @param int $count Children count (if already calculated)
      * @return bool
      */
-    protected function isNodeLimited(DataObject $node, $count = null)
+    protected function isNodeLimited(DataObject $node, int $count = null): bool
     {
         // Singleton root node isn't limited
         if (!$node->ID) {
@@ -805,7 +805,7 @@ class MarkedSet
      * @param bool $enabled
      * @return $this
      */
-    public function setLimitingEnabled($enabled)
+    public function setLimitingEnabled(bool $enabled): SilverStripe\ORM\Hierarchy\MarkedSet
     {
         $this->enableLimiting = $enabled;
         return $this;
@@ -816,7 +816,7 @@ class MarkedSet
      *
      * @return bool
      */
-    public function getLimitingEnabled()
+    public function getLimitingEnabled(): bool
     {
         return $this->enableLimiting;
     }

--- a/src/ORM/ListDecorator.php
+++ b/src/ORM/ListDecorator.php
@@ -18,7 +18,7 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
      */
     protected $list;
 
-    public function __construct(SS_List $list)
+    public function __construct(SS_List $list): void
     {
         $this->setList($list);
 
@@ -30,7 +30,7 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
      *
      * @return SS_List
      */
-    public function getList()
+    public function getList(): Mock_ArrayList_198b46e5
     {
         return $this->list;
     }
@@ -43,7 +43,7 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
      *
      * @return SS_List
      */
-    public function setList($list)
+    public function setList(SilverStripe\ORM\DataList $list): SilverStripe\ORM\PaginatedList
     {
         $this->list = $list;
         $this->failover = $this->list;
@@ -53,77 +53,77 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
     // PROXIED METHODS ---------------------------------------------------------
 
     #[\ReturnTypeWillChange]
-    public function offsetExists($key)
+    public function offsetExists(string $key): string
     {
         return $this->list->offsetExists($key);
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetGet($key)
+    public function offsetGet(int $key): string
     {
         return $this->list->offsetGet($key);
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetSet($key, $value)
+    public function offsetSet(string $key, string $value): void
     {
         $this->list->offsetSet($key, $value);
     }
 
     #[\ReturnTypeWillChange]
-    public function offsetUnset($key)
+    public function offsetUnset(string $key): void
     {
         $this->list->offsetUnset($key);
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         return $this->list->toArray();
     }
 
-    public function toNestedArray()
+    public function toNestedArray(): array
     {
         return $this->list->toNestedArray();
     }
 
-    public function add($item)
+    public function add(string $item): void
     {
         $this->list->add($item);
     }
 
-    public function remove($itemObject)
+    public function remove(SilverStripe\CMS\Model\SiteTree|string $itemObject): void
     {
         $this->list->remove($itemObject);
     }
 
     #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): string
     {
         return $this->list->getIterator();
     }
 
-    public function exists()
+    public function exists(): bool
     {
         return $this->list->exists();
     }
 
-    public function first()
+    public function first(): SilverStripe\CMS\Model\SiteTree|int
     {
         return $this->list->first();
     }
 
-    public function last()
+    public function last(): int
     {
         return $this->list->last();
     }
 
-    public function TotalItems()
+    public function TotalItems(): int
     {
         return $this->list->count();
     }
 
     #[\ReturnTypeWillChange]
-    public function Count()
+    public function Count(): int
     {
         return $this->list->count();
     }
@@ -133,37 +133,37 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
         return $this->list->forTemplate();
     }
 
-    public function map($index = 'ID', $titleField = 'Title')
+    public function map(string $index = 'ID', string $titleField = 'Title'): string
     {
         return $this->list->map($index, $titleField);
     }
 
-    public function find($key, $value)
+    public function find(string $key, string $value): string
     {
         return $this->list->find($key, $value);
     }
 
-    public function column($value = 'ID')
+    public function column(string $value = 'ID'): array|string
     {
         return $this->list->column($value);
     }
 
-    public function columnUnique($value = "ID")
+    public function columnUnique(string $value = "ID"): string
     {
         return $this->list->columnUnique($value);
     }
 
-    public function each($callback)
+    public function each(callable $callback): string
     {
         return $this->list->each($callback);
     }
 
-    public function canSortBy($by)
+    public function canSortBy(string $by): bool
     {
         return $this->list->canSortBy($by);
     }
 
-    public function reverse()
+    public function reverse(): string
     {
         return $this->list->reverse();
     }
@@ -177,12 +177,12 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
      * @example $list->sort('Name', 'ASC');
      * @example $list->sort(array('Name'=>'ASC,'Age'=>'DESC'));
      */
-    public function sort()
+    public function sort(): SilverStripe\ORM\DataList|string
     {
         return $this->list->sort(...func_get_args());
     }
 
-    public function canFilterBy($by)
+    public function canFilterBy(string $by): bool
     {
         return $this->list->canFilterBy($by);
     }
@@ -195,7 +195,7 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
      * @example $list->filter(array('Name'=>'bob, 'Age'=>21)); // bob or someone with Age 21
      * @example $list->filter(array('Name'=>'bob, 'Age'=>array(21, 43))); // bob or anyone with Age 21 or 43
      */
-    public function filter()
+    public function filter(): string
     {
         return $this->list->filter(...func_get_args());
     }
@@ -222,7 +222,7 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
      * @param string|array See {@link filter()}
      * @return DataList
      */
-    public function filterAny()
+    public function filterAny(): string
     {
         return $this->list->filterAny(...func_get_args());
     }
@@ -236,7 +236,7 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
      * @param callable $callback
      * @return ArrayList (this may change in future implementations)
      */
-    public function filterByCallback($callback)
+    public function filterByCallback(bool|callable $callback): SilverStripe\ORM\ArrayList
     {
         if (!is_callable($callback)) {
             throw new LogicException(sprintf(
@@ -253,7 +253,7 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
         return $output;
     }
 
-    public function limit($limit, $offset = 0)
+    public function limit(int $limit, int $offset = 0): string
     {
         return $this->list->limit($limit, $offset);
     }
@@ -264,7 +264,7 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
      * @param int $id
      * @return mixed
      */
-    public function byID($id)
+    public function byID(int $id): string
     {
         return $this->list->byID($id);
     }
@@ -275,7 +275,7 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
      * @param array $ids Array of integers
      * @return SS_List
      */
-    public function byIDs($ids)
+    public function byIDs(array $ids): string
     {
         return $this->list->byIDs($ids);
     }
@@ -288,12 +288,12 @@ abstract class ListDecorator extends ViewableData implements SS_List, Sortable, 
      * @example $list->exclude(array('Name'=>'bob, 'Age'=>21)); // exclude bob or someone with Age 21
      * @example $list->exclude(array('Name'=>'bob, 'Age'=>array(21, 43))); // exclude bob or anyone with Age 21 or 43
      */
-    public function exclude()
+    public function exclude(): string
     {
         return $this->list->exclude(...func_get_args());
     }
 
-    public function debug()
+    public function debug(): string
     {
         return $this->list->debug();
     }

--- a/src/ORM/ManyManyList.php
+++ b/src/ORM/ManyManyList.php
@@ -59,7 +59,7 @@ class ManyManyList extends RelationList
      *
      * @example new ManyManyList('Group','Group_Members', 'GroupID', 'MemberID');
      */
-    public function __construct($dataClass, $joinTable, $localKey, $foreignKey, $extraFields = [])
+    public function __construct(string $dataClass, string $joinTable, string $localKey, string $foreignKey, array $extraFields = []): void
     {
         parent::__construct($dataClass);
 
@@ -74,7 +74,7 @@ class ManyManyList extends RelationList
     /**
      * Setup the join between this dataobject and the necessary mapping table
      */
-    protected function linkJoinTable()
+    protected function linkJoinTable(): void
     {
         // Join to the many-many join table
         $dataClassIDColumn = DataObject::getSchema()->sqlColumnForField($this->dataClass(), 'ID');
@@ -95,7 +95,7 @@ class ManyManyList extends RelationList
      *
      * @return void
      */
-    protected function appendExtraFieldsToQuery()
+    protected function appendExtraFieldsToQuery(): void
     {
         $finalized = [];
 
@@ -127,7 +127,7 @@ class ManyManyList extends RelationList
      * @param array $row
      * @return DataObject
      */
-    public function createDataObject($row)
+    public function createDataObject(array $row): SilverStripe\Security\Group
     {
         // remove any composed fields
         $add = [];
@@ -169,7 +169,7 @@ class ManyManyList extends RelationList
      *
      * @return array
      */
-    protected function foreignIDFilter($id = null)
+    protected function foreignIDFilter(int|array $id = null): array
     {
         if ($id === null) {
             $id = $this->getForeignID();
@@ -197,7 +197,7 @@ class ManyManyList extends RelationList
      * as per getForeignID
      * @return array Condition In array(SQL => parameters format)
      */
-    protected function foreignIDWriteFilter($id = null)
+    protected function foreignIDWriteFilter(int $id = null): array
     {
         return $this->foreignIDFilter($id);
     }
@@ -218,7 +218,7 @@ class ManyManyList extends RelationList
      * Column names should be ANSI quoted.
      * @throws Exception
      */
-    public function add($item, $extraFields = [])
+    public function add(int|string|SilverStripe\Security\Member $item, array $extraFields = []): void
     {
         // Ensure nulls or empty strings are correctly treated as empty arrays
         if (empty($extraFields)) {
@@ -336,7 +336,7 @@ class ManyManyList extends RelationList
      *
      * @param DataObject $item
      */
-    public function remove($item)
+    public function remove(SilverStripe\Security\Member $item): null
     {
         if (!($item instanceof $this->dataClass)) {
             throw new InvalidArgumentException("ManyManyList::remove() expecting a $this->dataClass object");
@@ -355,7 +355,7 @@ class ManyManyList extends RelationList
      *
      * @param int $itemID The item ID
      */
-    public function removeByID($itemID)
+    public function removeByID(int $itemID): void
     {
         if (!is_numeric($itemID)) {
             throw new InvalidArgumentException("ManyManyList::removeById() expecting an ID");
@@ -387,7 +387,7 @@ class ManyManyList extends RelationList
      *
      * @return void
      */
-    public function removeAll()
+    public function removeAll(): void
     {
         // Remove the join to the join table to avoid MySQL row locking issues.
         $query = $this->dataQuery();
@@ -442,7 +442,7 @@ class ManyManyList extends RelationList
      *
      * @return array Map of fieldName => fieldValue
      */
-    public function getExtraData($componentName, $itemID)
+    public function getExtraData(string $componentName, int $itemID): array
     {
         $result = [];
 
@@ -484,7 +484,7 @@ class ManyManyList extends RelationList
      *
      * @return string the name of the table
      */
-    public function getJoinTable()
+    public function getJoinTable(): string
     {
         return $this->joinTable;
     }
@@ -494,7 +494,7 @@ class ManyManyList extends RelationList
      *
      * @return string the field name
      */
-    public function getLocalKey()
+    public function getLocalKey(): string
     {
         return $this->localKey;
     }
@@ -504,7 +504,7 @@ class ManyManyList extends RelationList
      *
      * @return string the field name
      */
-    public function getForeignKey()
+    public function getForeignKey(): string
     {
         return $this->foreignKey;
     }
@@ -514,7 +514,7 @@ class ManyManyList extends RelationList
      *
      * @return array a map of field names to types
      */
-    public function getExtraFields()
+    public function getExtraFields(): array
     {
         return $this->extraFields;
     }

--- a/src/ORM/ManyManyThroughList.php
+++ b/src/ORM/ManyManyThroughList.php
@@ -32,14 +32,14 @@ class ManyManyThroughList extends RelationList
      * @example new ManyManyThroughList('Banner', 'PageBanner', 'BannerID', 'PageID');
      */
     public function __construct(
-        $dataClass,
+        string $dataClass,
         $joinClass,
         $localKey,
         $foreignKey,
         $extraFields = [],
         $foreignClass = null,
         $parentClass = null
-    ) {
+    ): void {
         parent::__construct($dataClass);
 
         // Inject manipulator
@@ -60,13 +60,13 @@ class ManyManyThroughList extends RelationList
      * per getForeignID
      * @return array Condition In array(SQL => parameters format)
      */
-    protected function foreignIDFilter($id = null)
+    protected function foreignIDFilter(int $id = null): array
     {
         // foreignIDFilter is applied to the HasManyList via ManyManyThroughQueryManipulator, not here
         return [];
     }
 
-    public function createDataObject($row)
+    public function createDataObject(array $row): SilverStripe\Assets\File
     {
         // Add joined record
         $joinRow = [];
@@ -102,7 +102,7 @@ class ManyManyThroughList extends RelationList
      *
      * @param DataObject $item
      */
-    public function remove($item)
+    public function remove(SilverStripe\ORM\Tests\ManyManyThroughListTest\Item $item): void
     {
         if (!($item instanceof $this->dataClass)) {
             throw new InvalidArgumentException(
@@ -121,7 +121,7 @@ class ManyManyThroughList extends RelationList
      *
      * @param int $itemID The item ID
      */
-    public function removeByID($itemID)
+    public function removeByID(int $itemID): void
     {
         if (!is_numeric($itemID)) {
             throw new InvalidArgumentException("ManyManyThroughList::removeById() expecting an ID");
@@ -143,7 +143,7 @@ class ManyManyThroughList extends RelationList
         }
     }
 
-    public function removeAll()
+    public function removeAll(): void
     {
         // Get the IDs of records in the current list
         $affectedIds = $this->limit(null)->column('ID');
@@ -171,7 +171,7 @@ class ManyManyThroughList extends RelationList
      * @param mixed $item
      * @param array $extraFields
      */
-    public function add($item, $extraFields = [])
+    public function add(int|SilverStripe\ORM\Tests\ManyManyThroughListTest\Item $item, array $extraFields = []): void
     {
         // Ensure nulls or empty strings are correctly treated as empty arrays
         if (empty($extraFields)) {
@@ -264,7 +264,7 @@ class ManyManyThroughList extends RelationList
     /**
      * @return string
      */
-    public function getJoinTable()
+    public function getJoinTable(): string
     {
         $joinClass = $this->manipulator->getJoinClass();
         return DataObject::getSchema()->tableName($joinClass);

--- a/src/ORM/ManyManyThroughQueryManipulator.php
+++ b/src/ORM/ManyManyThroughQueryManipulator.php
@@ -61,7 +61,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
      * @param string $foreignClass the 'from' class name
      * @param string $parentClass Name of parent class. Subclass of $foreignClass
      */
-    public function __construct($joinClass, $localKey, $foreignKey, $foreignClass = null, $parentClass = null)
+    public function __construct(string $joinClass, string $localKey, string $foreignKey, string $foreignClass = null, string $parentClass = null): void
     {
         $this->setJoinClass($joinClass);
         $this->setLocalKey($localKey);
@@ -81,7 +81,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
     /**
      * @return string
      */
-    public function getJoinClass()
+    public function getJoinClass(): string
     {
         return $this->joinClass;
     }
@@ -90,7 +90,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
      * @param mixed $joinClass
      * @return $this
      */
-    public function setJoinClass($joinClass)
+    public function setJoinClass(string $joinClass): SilverStripe\ORM\ManyManyThroughQueryManipulator
     {
         $this->joinClass = $joinClass;
         return $this;
@@ -99,7 +99,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
     /**
      * @return string
      */
-    public function getLocalKey()
+    public function getLocalKey(): string
     {
         return $this->localKey;
     }
@@ -108,7 +108,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
      * @param string $localKey
      * @return $this
      */
-    public function setLocalKey($localKey)
+    public function setLocalKey(string $localKey): SilverStripe\ORM\ManyManyThroughQueryManipulator
     {
         $this->localKey = $localKey;
         return $this;
@@ -117,7 +117,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
     /**
      * @return string
      */
-    public function getForeignKey()
+    public function getForeignKey(): string
     {
         return $this->foreignKey;
     }
@@ -127,7 +127,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
      *
      * @return string
      */
-    public function getForeignIDKey()
+    public function getForeignIDKey(): string
     {
         $key = $this->getForeignKey();
         if ($this->getForeignClass() === DataObject::class) {
@@ -153,7 +153,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
      * @param string $foreignKey
      * @return $this
      */
-    public function setForeignKey($foreignKey)
+    public function setForeignKey(string $foreignKey): SilverStripe\ORM\ManyManyThroughQueryManipulator
     {
         $this->foreignKey = $foreignKey;
         return $this;
@@ -165,7 +165,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
      * @param DataQuery $query
      * @return HasManyList
      */
-    public function getParentRelationship(DataQuery $query)
+    public function getParentRelationship(DataQuery $query): SilverStripe\ORM\PolymorphicHasManyList
     {
         // Create has_many
         if ($this->getForeignClass() === DataObject::class) {
@@ -195,7 +195,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
      * @param DataQuery $query
      * @return mixed
      */
-    public function extractInheritableQueryParameters(DataQuery $query)
+    public function extractInheritableQueryParameters(DataQuery $query): array
     {
         $params = $query->getQueryParams();
 
@@ -218,7 +218,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
      *
      * @return string
      */
-    public function getJoinAlias()
+    public function getJoinAlias(): string
     {
         return DataObject::getSchema()->tableName($this->getJoinClass());
     }
@@ -230,7 +230,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
      * @param array $queriedColumns
      * @param SQLSelect $sqlSelect
      */
-    public function beforeGetFinalisedQuery(DataQuery $dataQuery, $queriedColumns, SQLSelect $sqlSelect)
+    public function beforeGetFinalisedQuery(DataQuery $dataQuery, array $queriedColumns, SQLSelect $sqlSelect): void
     {
         // Get metadata and SQL from join table
         $hasManyRelation = $this->getParentRelationship($dataQuery);
@@ -280,7 +280,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
      * @param array $queriedColumns
      * @param SQLSelect $sqlQuery
      */
-    public function afterGetFinalisedQuery(DataQuery $dataQuery, $queriedColumns, SQLSelect $sqlQuery)
+    public function afterGetFinalisedQuery(DataQuery $dataQuery, array $queriedColumns, SQLSelect $sqlQuery): void
     {
         // Inject final replacement after manipulation has been performed on the base dataquery
         $joinTableSQL = $dataQuery->getQueryParam('Foreign.JoinTableSQL');
@@ -293,7 +293,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
     /**
      * @return string
      */
-    public function getForeignClass()
+    public function getForeignClass(): string
     {
         return $this->foreignClass;
     }
@@ -302,7 +302,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
      * @param string $foreignClass
      * @return $this
      */
-    public function setForeignClass($foreignClass)
+    public function setForeignClass(string $foreignClass): SilverStripe\ORM\ManyManyThroughQueryManipulator
     {
         $this->foreignClass = $foreignClass;
         return $this;
@@ -311,7 +311,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
     /**
      * @return string
      */
-    public function getParentClass()
+    public function getParentClass(): string
     {
         return $this->parentClass;
     }
@@ -320,7 +320,7 @@ class ManyManyThroughQueryManipulator implements DataQueryManipulator
      * @param string $parentClass
      * @return ManyManyThroughQueryManipulator
      */
-    public function setParentClass($parentClass)
+    public function setParentClass(string $parentClass): SilverStripe\ORM\ManyManyThroughQueryManipulator
     {
         $this->parentClass = $parentClass;
         return $this;

--- a/src/ORM/Map.php
+++ b/src/ORM/Map.php
@@ -35,7 +35,7 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
      * @param string $keyField The field to use as the key of each map entry
      * @param string $valueField The field to use as the value of each map entry
      */
-    public function __construct(SS_List $list, $keyField = "ID", $valueField = "Title")
+    public function __construct(SS_List $list, string $keyField = "ID", string $valueField = "Title"): void
     {
         $this->list = $list;
         $this->keyField = $keyField;
@@ -47,7 +47,7 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
      *
      * @var string $keyField
      */
-    public function setKeyField($keyField)
+    public function setKeyField(string $keyField): void
     {
         $this->keyField = $keyField;
     }
@@ -57,7 +57,7 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
      *
      * @var string $valueField
      */
-    public function setValueField($valueField)
+    public function setValueField(string $valueField): void
     {
         $this->valueField = $valueField;
     }
@@ -67,7 +67,7 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         $array = [];
 
@@ -83,7 +83,7 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
      *
      * @return array
      */
-    public function keys()
+    public function keys(): array
     {
         return array_keys($this->toArray() ?? []);
     }
@@ -93,7 +93,7 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
      *
      * @return array
      */
-    public function values()
+    public function values(): array
     {
         return array_values($this->toArray() ?? []);
     }
@@ -107,7 +107,7 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
      * @var mixed $value
      * @return $this
      */
-    public function unshift($key, $value)
+    public function unshift(string|int $key, string $value): SilverStripe\ORM\Map
     {
         $oldItems = $this->firstItems;
         $this->firstItems = [
@@ -128,7 +128,7 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
      * @var mixed $value
      * @return $this
      */
-    public function push($key, $value)
+    public function push(string|int $key, string $value): SilverStripe\ORM\Map
     {
         $oldItems = $this->lastItems;
 
@@ -172,7 +172,7 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
      * @return mixed
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($key)
+    public function offsetGet(string|int $key): string|null|int
     {
         if (isset($this->firstItems[$key])) {
             return $this->firstItems[$key];
@@ -230,7 +230,7 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
      * @var mixed $value
      */
     #[\ReturnTypeWillChange]
-    public function offsetUnset($key)
+    public function offsetUnset(int $key): void
     {
         if (isset($this->firstItems[$key])) {
             unset($this->firstItems[$key]);
@@ -258,7 +258,7 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
      * @return Map_Iterator
      */
     #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): SilverStripe\ORM\Map_Iterator
     {
         return new Map_Iterator(
             $this->list->getIterator(),
@@ -276,7 +276,7 @@ class Map implements ArrayAccess, Countable, IteratorAggregate
      * @return int
      */
     #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return $this->list->count() +
             count($this->firstItems ?? []) +

--- a/src/ORM/Map_Iterator.php
+++ b/src/ORM/Map_Iterator.php
@@ -33,7 +33,7 @@ class Map_Iterator implements Iterator
      * @param array $firstItems An optional map of items to show first
      * @param array $lastItems An optional map of items to show last
      */
-    public function __construct(Iterator $items, $keyField, $titleField, $firstItems = null, $lastItems = null)
+    public function __construct(Iterator $items, string $keyField, string $titleField, array $firstItems = null, array $lastItems = null): void
     {
         $this->items = $items;
         $this->keyField = $keyField;
@@ -61,7 +61,7 @@ class Map_Iterator implements Iterator
      * @return mixed
      */
     #[\ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void|string
     {
         $this->firstItemIdx = 0;
         $this->endItemIdx = null;
@@ -89,7 +89,7 @@ class Map_Iterator implements Iterator
      * @return mixed
      */
     #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): string|null|int|Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered
     {
         if (($this->endItemIdx !== null) && isset($this->lastItems[$this->endItemIdx])) {
             return $this->lastItems[$this->endItemIdx][1];
@@ -109,7 +109,7 @@ class Map_Iterator implements Iterator
      * @param  string $key
      * @return mixed
      */
-    protected function extractValue($item, $key)
+    protected function extractValue(stdClass|DNADesign\Elemental\Models\ElementalArea $item, string $key): string|int|null|Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered
     {
         if (is_object($item)) {
             if (method_exists($item, 'hasMethod') && $item->hasMethod($key)) {
@@ -129,7 +129,7 @@ class Map_Iterator implements Iterator
      * @return string
      */
     #[\ReturnTypeWillChange]
-    public function key()
+    public function key(): int|string|null
     {
         if (($this->endItemIdx !== null) && isset($this->lastItems[$this->endItemIdx])) {
             return $this->lastItems[$this->endItemIdx][0];
@@ -148,7 +148,7 @@ class Map_Iterator implements Iterator
      * @return mixed
      */
     #[\ReturnTypeWillChange]
-    public function next()
+    public function next(): void|bool|array|string
     {
         $this->firstItemIdx++;
 
@@ -189,7 +189,7 @@ class Map_Iterator implements Iterator
      * @return boolean
      */
     #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return (
             (isset($this->firstItems[$this->firstItemIdx])) ||

--- a/src/ORM/PaginatedList.php
+++ b/src/ORM/PaginatedList.php
@@ -33,7 +33,7 @@ class PaginatedList extends ListDecorator
      *        request object that the pagination offset is read from.
      * @throws Exception
      */
-    public function __construct(SS_List $list, $request = [])
+    public function __construct(SS_List $list, SilverStripe\Control\HTTPRequest|array $request = []): void
     {
         if (!is_array($request) && !$request instanceof ArrayAccess) {
             throw new Exception('The request must be readable as an array.');
@@ -52,7 +52,7 @@ class PaginatedList extends ListDecorator
      *
      * @return string
      */
-    public function getPaginationGetVar()
+    public function getPaginationGetVar(): string
     {
         return $this->getVar;
     }
@@ -63,7 +63,7 @@ class PaginatedList extends ListDecorator
      * @param string $var
      * @return $this
      */
-    public function setPaginationGetVar($var)
+    public function setPaginationGetVar(string $var): SilverStripe\ORM\PaginatedList
     {
         $this->getVar = $var;
         return $this;
@@ -74,7 +74,7 @@ class PaginatedList extends ListDecorator
      *
      * @return int
      */
-    public function getPageLength()
+    public function getPageLength(): int
     {
         return $this->pageLength;
     }
@@ -85,7 +85,7 @@ class PaginatedList extends ListDecorator
      * @param int $length
      * @return $this
      */
-    public function setPageLength($length)
+    public function setPageLength(int $length): SilverStripe\ORM\PaginatedList
     {
         $this->pageLength = (int)$length;
         return $this;
@@ -97,7 +97,7 @@ class PaginatedList extends ListDecorator
      * @param int $page Page index beginning with 1
      * @return $this
      */
-    public function setCurrentPage($page)
+    public function setCurrentPage(int $page): SilverStripe\ORM\PaginatedList
     {
         $this->pageStart = ((int)$page - 1) * $this->getPageLength();
         return $this;
@@ -108,7 +108,7 @@ class PaginatedList extends ListDecorator
      *
      * @return int
      */
-    public function getPageStart()
+    public function getPageStart(): int
     {
         $request = $this->getRequest();
         if ($this->pageStart === null) {
@@ -132,7 +132,7 @@ class PaginatedList extends ListDecorator
      * @param int $start
      * @return $this
      */
-    public function setPageStart($start)
+    public function setPageStart(int $start): SilverStripe\ORM\PaginatedList
     {
         $this->pageStart = (int)$start;
         return $this;
@@ -143,7 +143,7 @@ class PaginatedList extends ListDecorator
      *
      * @return int
      */
-    public function getTotalItems()
+    public function getTotalItems(): int
     {
         if ($this->totalItems === null) {
             $this->totalItems = count($this->list ?? []);
@@ -159,7 +159,7 @@ class PaginatedList extends ListDecorator
      * @param int $items
      * @return $this
      */
-    public function setTotalItems($items)
+    public function setTotalItems(int $items): SilverStripe\ORM\PaginatedList
     {
         $this->totalItems = (int)$items;
         return $this;
@@ -172,7 +172,7 @@ class PaginatedList extends ListDecorator
      * @param SQLSelect $query
      * @return $this
      */
-    public function setPaginationFromQuery(SQLSelect $query)
+    public function setPaginationFromQuery(SQLSelect $query): SilverStripe\ORM\PaginatedList
     {
         if ($limit = $query->getLimit()) {
             $this->setPageLength($limit['limit']);
@@ -202,7 +202,7 @@ class PaginatedList extends ListDecorator
      * @param bool $limit
      * @return $this
      */
-    public function setLimitItems($limit)
+    public function setLimitItems(bool $limit): SilverStripe\ORM\PaginatedList
     {
         $this->limitItems = (bool)$limit;
         return $this;
@@ -212,7 +212,7 @@ class PaginatedList extends ListDecorator
      * @return IteratorIterator
      */
     #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): IteratorIterator
     {
         $pageLength = $this->getPageLength();
         if ($this->limitItems && $pageLength) {
@@ -236,7 +236,7 @@ class PaginatedList extends ListDecorator
      * @param  int $max
      * @return SS_List
      */
-    public function Pages($max = null)
+    public function Pages(int $max = null): SilverStripe\ORM\ArrayList
     {
         $result = new ArrayList();
 
@@ -308,7 +308,7 @@ class PaginatedList extends ListDecorator
      *         are displayed on either side of the current one.
      * @return SS_List
      */
-    public function PaginationSummary($context = 4)
+    public function PaginationSummary(int|string $context = 4): SilverStripe\ORM\ArrayList
     {
         $result = new ArrayList();
         $current = $this->CurrentPage();
@@ -368,7 +368,7 @@ class PaginatedList extends ListDecorator
     /**
      * @return int
      */
-    public function CurrentPage()
+    public function CurrentPage(): float|int
     {
         $pageLength = $this->getPageLength();
         return $pageLength
@@ -379,7 +379,7 @@ class PaginatedList extends ListDecorator
     /**
      * @return int
      */
-    public function TotalPages()
+    public function TotalPages(): float|int
     {
         $pageLength = $this->getPageLength();
         return $pageLength
@@ -390,7 +390,7 @@ class PaginatedList extends ListDecorator
     /**
      * @return bool
      */
-    public function MoreThanOnePage()
+    public function MoreThanOnePage(): bool
     {
         return $this->TotalPages() > 1;
     }
@@ -398,7 +398,7 @@ class PaginatedList extends ListDecorator
     /**
      * @return bool
      */
-    public function FirstPage()
+    public function FirstPage(): bool
     {
         return $this->CurrentPage() == 1;
     }
@@ -406,7 +406,7 @@ class PaginatedList extends ListDecorator
     /**
      * @return bool
      */
-    public function NotFirstPage()
+    public function NotFirstPage(): bool
     {
         return !$this->FirstPage();
     }
@@ -414,7 +414,7 @@ class PaginatedList extends ListDecorator
     /**
      * @return bool
      */
-    public function LastPage()
+    public function LastPage(): bool
     {
         return $this->CurrentPage() == $this->TotalPages();
     }
@@ -422,7 +422,7 @@ class PaginatedList extends ListDecorator
     /**
      * @return bool
      */
-    public function NotLastPage()
+    public function NotLastPage(): bool
     {
         return !$this->LastPage();
     }
@@ -433,7 +433,7 @@ class PaginatedList extends ListDecorator
      *
      * @return int
      */
-    public function FirstItem()
+    public function FirstItem(): int
     {
         return ($start = $this->getPageStart()) ? $start + 1 : 1;
     }
@@ -443,7 +443,7 @@ class PaginatedList extends ListDecorator
      *
      * @return int
      */
-    public function LastItem()
+    public function LastItem(): int
     {
         $pageLength = $this->getPageLength();
         if (!$pageLength) {
@@ -460,7 +460,7 @@ class PaginatedList extends ListDecorator
      *
      * @return string
      */
-    public function FirstLink()
+    public function FirstLink(): string
     {
         return HTTP::setGetVar(
             $this->getPaginationGetVar(),
@@ -474,7 +474,7 @@ class PaginatedList extends ListDecorator
      *
      * @return string
      */
-    public function LastLink()
+    public function LastLink(): string
     {
         return HTTP::setGetVar(
             $this->getPaginationGetVar(),
@@ -489,7 +489,7 @@ class PaginatedList extends ListDecorator
      *
      * @return string
      */
-    public function NextLink()
+    public function NextLink(): string|nothing
     {
         if ($this->NotLastPage()) {
             return HTTP::setGetVar(
@@ -506,7 +506,7 @@ class PaginatedList extends ListDecorator
      *
      * @return string
      */
-    public function PrevLink()
+    public function PrevLink(): void|string
     {
         if ($this->NotFirstPage()) {
             return HTTP::setGetVar(
@@ -530,7 +530,7 @@ class PaginatedList extends ListDecorator
      *
      * @param HTTPRequest|ArrayAccess $request
      */
-    public function setRequest($request)
+    public function setRequest(SilverStripe\Control\HTTPRequest|array $request): void
     {
         $this->request = $request;
     }
@@ -538,7 +538,7 @@ class PaginatedList extends ListDecorator
     /**
      * Get the request object for this list
      */
-    public function getRequest()
+    public function getRequest(): array|SilverStripe\Control\HTTPRequest
     {
         return $this->request;
     }

--- a/src/ORM/PolymorphicHasManyList.php
+++ b/src/ORM/PolymorphicHasManyList.php
@@ -24,7 +24,7 @@ class PolymorphicHasManyList extends HasManyList
      *
      * @return string
      */
-    public function getForeignClass()
+    public function getForeignClass(): string
     {
         return $this->dataQuery->getQueryParam('Foreign.Class');
     }
@@ -37,7 +37,7 @@ class PolymorphicHasManyList extends HasManyList
      * to generate the ID and Class foreign keys.
      * @param string $foreignClass Name of the class filter this relation is filtered against
      */
-    public function __construct($dataClass, $foreignField, $foreignClass)
+    public function __construct(string $dataClass, string $foreignField, string $foreignClass): void
     {
         // Set both id foreign key (as in HasManyList) and the class foreign key
         parent::__construct($dataClass, "{$foreignField}ID");
@@ -62,7 +62,7 @@ class PolymorphicHasManyList extends HasManyList
      *
      * @param DataObject|int $item The DataObject to be added, or its ID
      */
-    public function add($item)
+    public function add(int|SilverStripe\UserForms\Model\EditableFormField\EditableFormStep $item): void
     {
         if (is_numeric($item)) {
             $item = DataObject::get_by_id($this->dataClass, $item);
@@ -105,7 +105,7 @@ class PolymorphicHasManyList extends HasManyList
      * @param DataObject $item The DataObject to be removed
      * @todo Maybe we should delete the object instead?
      */
-    public function remove($item)
+    public function remove(SilverStripe\ORM\Tests\DataObjectTest\Fan $item): void
     {
         if (!($item instanceof $this->dataClass)) {
             throw new InvalidArgumentException(

--- a/src/ORM/Queries/SQLAssignmentRow.php
+++ b/src/ORM/Queries/SQLAssignmentRow.php
@@ -33,7 +33,7 @@ class SQLAssignmentRow
      *
      * @param array $values
      */
-    function __construct(array $values = [])
+    function __construct(array $values = []): void
     {
         $this->setAssignments($values);
     }
@@ -47,7 +47,7 @@ class SQLAssignmentRow
      * placeholder => parameter(s) as a pair
      * @return array A single item array in the format [$sql => [$parameters]]
      */
-    protected function parseAssignment($value)
+    protected function parseAssignment(string|int|array|float $value): array
     {
         // Assume string values (or values saved as customised array objects)
         // represent simple assignment
@@ -89,7 +89,7 @@ class SQLAssignmentRow
      * literal value, or an array with parameterised information.
      * @return array List of normalised assignments
      */
-    protected function normaliseAssignments(array $assignments)
+    protected function normaliseAssignments(array $assignments): array
     {
         $normalised = [];
         foreach ($assignments as $field => $value) {
@@ -134,7 +134,7 @@ class SQLAssignmentRow
      * @param array $assignments The list of fields to assign
      * @return $this The self reference to this row
      */
-    public function addAssignments(array $assignments)
+    public function addAssignments(array $assignments): SilverStripe\ORM\Queries\SQLAssignmentRow
     {
         $assignments = $this->normaliseAssignments($assignments);
         $this->assignments = array_merge($this->assignments, $assignments);
@@ -149,7 +149,7 @@ class SQLAssignmentRow
      * @param array $assignments
      * @return $this The self reference to this row
      */
-    public function setAssignments(array $assignments)
+    public function setAssignments(array $assignments): SilverStripe\ORM\Queries\SQLAssignmentRow
     {
         return $this->clear()->addAssignments($assignments);
     }
@@ -161,7 +161,7 @@ class SQLAssignmentRow
      * column to assign, and the value a parameterised array in the format
      * ['SQL' => [parameters]];
      */
-    public function getAssignments()
+    public function getAssignments(): array
     {
         return $this->assignments;
     }
@@ -188,7 +188,7 @@ class SQLAssignmentRow
      * or a single literal value.
      * @return $this The self reference to this row
      */
-    public function assign($field, $value)
+    public function assign(string $field, array|int|float|string $value): SilverStripe\ORM\Queries\SQLAssignmentRow
     {
         return $this->addAssignments([$field => $value]);
     }
@@ -201,7 +201,7 @@ class SQLAssignmentRow
      * @param string $sql The SQL to use for this update. E.g. "NOW()"
      * @return $this The self reference to this row
      */
-    public function assignSQL($field, $sql)
+    public function assignSQL(string $field, string $sql): SilverStripe\ORM\Queries\SQLAssignmentRow
     {
         return $this->assign($field, [$sql => []]);
     }
@@ -211,7 +211,7 @@ class SQLAssignmentRow
      *
      * @return boolean Flag indicating that this assignment is empty
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return empty($this->assignments);
     }
@@ -221,7 +221,7 @@ class SQLAssignmentRow
      *
      * @return array
      */
-    public function getColumns()
+    public function getColumns(): array
     {
         return array_keys($this->assignments ?? []);
     }
@@ -231,7 +231,7 @@ class SQLAssignmentRow
      *
      * @return $this The self reference to this row
      */
-    public function clear()
+    public function clear(): SilverStripe\ORM\Queries\SQLAssignmentRow
     {
         $this->assignments = [];
         return $this;

--- a/src/ORM/Queries/SQLConditionalExpression.php
+++ b/src/ORM/Queries/SQLConditionalExpression.php
@@ -48,7 +48,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param array|string $from An array of Tables (FROM clauses). The first one should be just the table name.
      * @param array $where An array of WHERE clauses.
      */
-    function __construct($from = [], $where = [])
+    function __construct(array|string $from = [], array|string $where = []): void
     {
         $this->setFrom($from);
         $this->setWhere($where);
@@ -62,7 +62,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param string|array $from Single, or list of, ANSI quoted table names
      * @return $this
      */
-    public function setFrom($from)
+    public function setFrom(array|string $from): SilverStripe\ORM\Queries\SQLSelect
     {
         $this->from = [];
         return $this->addFrom($from);
@@ -76,7 +76,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param string|array $from Single, or list of, ANSI quoted table names
      * @return $this Self reference
      */
-    public function addFrom($from)
+    public function addFrom(array|string $from): SilverStripe\ORM\Queries\SQLSelect
     {
         if (is_array($from)) {
             $this->from = array_merge($this->from, $from);
@@ -92,7 +92,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      *
      * @param string $value either 'AND' or 'OR'
      */
-    public function setConnective($value)
+    public function setConnective(string $value): void
     {
         $this->connective = $value;
     }
@@ -102,7 +102,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      *
      * @return string 'AND' or 'OR'
      */
-    public function getConnective()
+    public function getConnective(): string
     {
         return $this->connective;
     }
@@ -136,7 +136,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param array $parameters Any additional parameters if the join is a parameterized subquery
      * @return $this Self reference
      */
-    public function addLeftJoin($table, $onPredicate, $tableAlias = '', $order = 20, $parameters = [])
+    public function addLeftJoin(string $table, string $onPredicate, string $tableAlias = '', int $order = 20, array $parameters = []): SilverStripe\ORM\Queries\SQLSelect
     {
         if (!$tableAlias) {
             $tableAlias = $table;
@@ -164,7 +164,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param array $parameters Any additional parameters if the join is a parameterized subquery
      * @return $this Self reference
      */
-    public function addInnerJoin($table, $onPredicate, $tableAlias = null, $order = 20, $parameters = [])
+    public function addInnerJoin(string $table, string $onPredicate, string $tableAlias = null, int $order = 20, array $parameters = []): SilverStripe\ORM\Queries\SQLSelect
     {
         if (!$tableAlias) {
             $tableAlias = $table;
@@ -199,7 +199,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param string $filter The "ON" SQL fragment (escaped)
      * @return $this Self reference
      */
-    public function setJoinFilter($table, $filter)
+    public function setJoinFilter(string $table, string $filter): SilverStripe\ORM\Queries\SQLSelect
     {
         $this->from[$table]['filter'] = [$filter];
         return $this;
@@ -211,7 +211,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param string $tableAlias Table name
      * @return boolean
      */
-    public function isJoinedTo($tableAlias)
+    public function isJoinedTo(string $tableAlias): bool
     {
         return isset($this->from[$tableAlias]);
     }
@@ -221,7 +221,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      *
      * @return array Unquoted table names
      */
-    public function queriedTables()
+    public function queriedTables(): array
     {
         $tables = [];
 
@@ -250,7 +250,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      *
      * @return array
      */
-    public function getFrom()
+    public function getFrom(): array
     {
         return $this->from;
     }
@@ -263,7 +263,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param array $parameters Out variable for parameters required for this query
      * @return array List of joins as a mapping from array('Alias' => 'Join Expression')
      */
-    public function getJoins(&$parameters = [])
+    public function getJoins(&$parameters = []): array
     {
         if (func_num_args() == 0) {
             Deprecation::notice(
@@ -336,7 +336,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param $from array - in the format of $this->from
      * @return array - and reorderded list of selects
      */
-    protected function getOrderedJoins($from)
+    protected function getOrderedJoins(array $from): array
     {
         if (count($from ?? []) <= 1) {
             return $from;
@@ -377,7 +377,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param array $array The array to sort (by reference)
      * @param callable|string $cmpFunction The function to use for comparison
      */
-    protected function mergesort(&$array, $cmpFunction = 'strcmp')
+    protected function mergesort(array &$array, callable $cmpFunction = 'strcmp'): void
     {
         // Arrays of size < 2 require no action.
         if (count($array ?? []) < 2) {
@@ -429,7 +429,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param mixed ...$where Predicate(s) to set, as escaped SQL statements or parameterized queries
      * @return $this Self reference
      */
-    public function setWhere($where)
+    public function setWhere(array|string $where): SilverStripe\ORM\Queries\SQLSelect
     {
         $where = func_num_args() > 1 ? func_get_args() : $where;
         $this->where = [];
@@ -515,7 +515,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param mixed ...$where Predicate(s) to set, as escaped SQL statements or parameterized queries
      * @return $this Self reference
      */
-    public function addWhere($where)
+    public function addWhere(array|string|SilverStripe\ORM\DataQuery_SubGroup $where): SilverStripe\ORM\Queries\SQLSelect
     {
         $where = $this->normalisePredicates(func_get_args());
 
@@ -531,7 +531,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param mixed ...$filters Predicate(s) to set, as escaped SQL statements or parameterized queries
      * @return $this Self reference
      */
-    public function setWhereAny($filters)
+    public function setWhereAny(array $filters): SilverStripe\ORM\Queries\SQLSelect
     {
         $filters = func_num_args() > 1 ? func_get_args() : $filters;
         return $this
@@ -545,7 +545,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param mixed ...$filters Predicate(s) to set, as escaped SQL statements or parameterized queries
      * @return $this Self reference
      */
-    public function addWhereAny($filters)
+    public function addWhereAny(array $filters): SilverStripe\ORM\Queries\SQLSelect
     {
         // Parse and split predicates along with any parameters
         $filters = $this->normalisePredicates(func_get_args());
@@ -560,7 +560,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      *
      * @return array
      */
-    public function getWhere()
+    public function getWhere(): array
     {
         return $this->where;
     }
@@ -571,7 +571,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param array $parameters Out variable for parameters required for this query
      * @return array
      */
-    public function getWhereParameterised(&$parameters)
+    public function getWhereParameterised(&$parameters): array
     {
         $this->splitQueryParameters($this->where, $predicates, $parameters);
         return $predicates;
@@ -589,7 +589,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @return array|SQLConditionGroup A single item array in the format
      * array($predicate => array($parameters)), unless it's a SQLConditionGroup
      */
-    protected function parsePredicate($key, $value)
+    protected function parsePredicate(string|int $key, int|string|array|SilverStripe\ORM\DataQuery_SubGroup|bool $value): array|SilverStripe\ORM\DataQuery_SubGroup
     {
         // If a string key is given then presume this is a parameterized condition
         if ($value instanceof SQLConditionGroup) {
@@ -651,7 +651,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * one level more than for addWhere, as query expansion is not supported here.
      * @return array List of normalised predicates
      */
-    protected function normalisePredicates(array $predicates)
+    protected function normalisePredicates(array $predicates): array
     {
         // Since this function is called with func_get_args we should un-nest the single first parameter
         if (count($predicates ?? []) == 1) {
@@ -685,7 +685,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      * @param array $predicates Out parameter for the list of string predicates
      * @param array $parameters Out parameter for the list of parameters
      */
-    public function splitQueryParameters($conditions, &$predicates, &$parameters)
+    public function splitQueryParameters(array $conditions, &$predicates, &$parameters): void
     {
         // Merge all filters with parameterized queries
         $predicates = [];
@@ -714,7 +714,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      *
      * @return boolean
      */
-    public function filtersOnID()
+    public function filtersOnID(): bool
     {
         $regexp = '/^(.*\.)?("|`)?ID("|`)?\s?(=|IN)/';
 
@@ -734,7 +734,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      *
      * @return boolean
      */
-    public function filtersOnFK()
+    public function filtersOnFK(): bool
     {
         $regexp = '/^(.*\.)?("|`)?[a-zA-Z]+ID("|`)?\s?(=|IN)/';
 
@@ -748,7 +748,7 @@ abstract class SQLConditionalExpression extends SQLExpression
         return false;
     }
 
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return empty($this->from);
     }
@@ -770,7 +770,7 @@ abstract class SQLConditionalExpression extends SQLExpression
      *
      * @return SQLSelect
      */
-    public function toSelect()
+    public function toSelect(): SilverStripe\ORM\Queries\SQLSelect
     {
         $select = new SQLSelect();
         $this->copyTo($select);

--- a/src/ORM/Queries/SQLDelete.php
+++ b/src/ORM/Queries/SQLDelete.php
@@ -30,7 +30,7 @@ class SQLDelete extends SQLConditionalExpression
      * @param array|string $delete The table(s) to delete, if multiple tables are queried from
      * @return static
      */
-    public static function create($from = [], $where = [], $delete = [])
+    public static function create(string $from = [], array|string $where = [], $delete = []): SilverStripe\ORM\Queries\SQLDelete
     {
         return Injector::inst()->createWithArgs(__CLASS__, func_get_args());
     }
@@ -43,7 +43,7 @@ class SQLDelete extends SQLConditionalExpression
      * @param array $where An array of WHERE clauses.
      * @param array|string $delete The table(s) to delete, if multiple tables are queried from
      */
-    function __construct($from = [], $where = [], $delete = [])
+    function __construct(string $from = [], array|string $where = [], $delete = []): void
     {
         parent::__construct($from, $where);
         $this->setDelete($delete);
@@ -55,7 +55,7 @@ class SQLDelete extends SQLConditionalExpression
      *
      * @return array
      */
-    public function getDelete()
+    public function getDelete(): array
     {
         return $this->delete;
     }
@@ -67,7 +67,7 @@ class SQLDelete extends SQLConditionalExpression
      * @param string|array $tables Escaped SQL statement, usually an unquoted table name
      * @return $this Self reference
      */
-    public function setDelete($tables)
+    public function setDelete(array $tables): SilverStripe\ORM\Queries\SQLDelete
     {
         $this->delete = [];
         return $this->addDelete($tables);
@@ -80,7 +80,7 @@ class SQLDelete extends SQLConditionalExpression
      * @param string|array $tables Escaped SQL statement, usually an unquoted table name
      * @return $this Self reference
      */
-    public function addDelete($tables)
+    public function addDelete(array $tables): SilverStripe\ORM\Queries\SQLDelete
     {
         if (is_array($tables)) {
             $this->delete = array_merge($this->delete, $tables);

--- a/src/ORM/Queries/SQLExpression.php
+++ b/src/ORM/Queries/SQLExpression.php
@@ -36,7 +36,7 @@ abstract class SQLExpression
      * @param string $old The old text (escaped)
      * @param string $new The new text (escaped)
      */
-    public function replaceText($old, $new)
+    public function replaceText(string $old, string $new): void
     {
         $this->replacementsOld[] = $old;
         $this->replacementsNew[] = $new;
@@ -68,7 +68,7 @@ abstract class SQLExpression
      * @param string $old Name of the old table (unquoted, escaped)
      * @param string $new Name of the new table (unquoted, escaped)
      */
-    public function renameTable($old, $new)
+    public function renameTable(string $old, string $new): void
     {
         $this->replaceText("`$old`", "`$new`");
         $this->replaceText("\"$old\"", "\"$new\"");
@@ -88,7 +88,7 @@ abstract class SQLExpression
      * @param array $parameters Out variable for parameters required for this query
      * @return string The completed SQL query
      */
-    public function sql(&$parameters = [])
+    public function sql(array &$parameters = []): string|null
     {
         // Build each component as needed
         $sql = DB::build_sql($this, $parameters);
@@ -109,7 +109,7 @@ abstract class SQLExpression
      *
      * @return Query
      */
-    public function execute()
+    public function execute(): SilverStripe\ORM\Connect\MySQLQuery
     {
         $sql = $this->sql($parameters);
         return DB::prepared_query($sql, $parameters);
@@ -121,7 +121,7 @@ abstract class SQLExpression
      *
      * @param SQLExpression $object The object to copy properties to
      */
-    protected function copyTo(SQLExpression $object)
+    protected function copyTo(SQLExpression $object): void
     {
         $target = array_keys(get_object_vars($object));
         foreach (get_object_vars($this) as $variable => $value) {

--- a/src/ORM/Queries/SQLInsert.php
+++ b/src/ORM/Queries/SQLInsert.php
@@ -32,7 +32,7 @@ class SQLInsert extends SQLExpression implements SQLWriteExpression
      * @param array $assignments List of column assignments
      * @return static
      */
-    public static function create($into = null, $assignments = [])
+    public static function create(string $into = null, array $assignments = []): SilverStripe\ORM\Queries\SQLInsert
     {
         return Injector::inst()->createWithArgs(__CLASS__, func_get_args());
     }
@@ -43,7 +43,7 @@ class SQLInsert extends SQLExpression implements SQLWriteExpression
      * @param string $into Table name to insert into (ANSI quoted)
      * @param array $assignments List of column assignments
      */
-    function __construct($into = null, $assignments = [])
+    function __construct(string $into = null, array $assignments = []): void
     {
         $this->setInto($into);
         if (!empty($assignments)) {
@@ -57,7 +57,7 @@ class SQLInsert extends SQLExpression implements SQLWriteExpression
      * @param string $into Single table name (ANSI quoted)
      * @return $this The self reference to this query
      */
-    public function setInto($into)
+    public function setInto(string $into): SilverStripe\ORM\Queries\SQLInsert
     {
         $this->into = $into;
         return $this;
@@ -68,12 +68,12 @@ class SQLInsert extends SQLExpression implements SQLWriteExpression
      *
      * @return string Single table name
      */
-    public function getInto()
+    public function getInto(): string
     {
         return $this->into;
     }
 
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return empty($this->into) || empty($this->rows);
     }
@@ -84,7 +84,7 @@ class SQLInsert extends SQLExpression implements SQLWriteExpression
      * @param array|SQLAssignmentRow $data A list of data to include for this row
      * @return $this The self reference to this query
      */
-    public function addRow($data = null)
+    public function addRow(array $data = null): SilverStripe\ORM\Queries\SQLInsert
     {
         // Clear existing empty row
         if (($current = $this->currentRow()) && $current->isEmpty()) {
@@ -105,7 +105,7 @@ class SQLInsert extends SQLExpression implements SQLWriteExpression
      *
      * @return SQLAssignmentRow[]
      */
-    public function getRows()
+    public function getRows(): array
     {
         return $this->rows;
     }
@@ -115,7 +115,7 @@ class SQLInsert extends SQLExpression implements SQLWriteExpression
      *
      * @return array
      */
-    public function getColumns()
+    public function getColumns(): array
     {
         $columns = [];
         foreach ($this->getRows() as $row) {
@@ -155,7 +155,7 @@ class SQLInsert extends SQLExpression implements SQLWriteExpression
      * @param boolean $create Flag to indicate if a row should be created if none exists
      * @return SQLAssignmentRow|false The row, or false if none exists
      */
-    public function currentRow($create = false)
+    public function currentRow(bool $create = false): SilverStripe\ORM\Queries\SQLAssignmentRow|bool
     {
         $current = end($this->rows);
         if ($create && !$current) {
@@ -170,7 +170,7 @@ class SQLInsert extends SQLExpression implements SQLWriteExpression
         return $this;
     }
 
-    public function setAssignments(array $assignments)
+    public function setAssignments(array $assignments): SilverStripe\ORM\Queries\SQLInsert
     {
         $this->currentRow(true)->setAssignments($assignments);
         return $this;
@@ -181,7 +181,7 @@ class SQLInsert extends SQLExpression implements SQLWriteExpression
         return $this->currentRow(true)->getAssignments();
     }
 
-    public function assign($field, $value)
+    public function assign(string $field, string|int $value): SilverStripe\ORM\Queries\SQLInsert
     {
         $this->currentRow(true)->assign($field, $value);
         return $this;

--- a/src/ORM/Queries/SQLSelect.php
+++ b/src/ORM/Queries/SQLSelect.php
@@ -77,14 +77,14 @@ class SQLSelect extends SQLConditionalExpression
      * @return static
      */
     public static function create(
-        $select = "*",
+        string|array $select = "*",
         $from = [],
         $where = [],
         $orderby = [],
         $groupby = [],
         $having = [],
         $limit = []
-    ) {
+    ): SilverStripe\ORM\Queries\SQLSelect {
         return Injector::inst()->createWithArgs(__CLASS__, func_get_args());
     }
 
@@ -101,14 +101,14 @@ class SQLSelect extends SQLConditionalExpression
      * @param array|string $limit A LIMIT clause or array with limit and offset keys
      */
     public function __construct(
-        $select = "*",
+        array|string $select = "*",
         $from = [],
         $where = [],
         $orderby = [],
         $groupby = [],
         $having = [],
         $limit = []
-    ) {
+    ): void {
 
         parent::__construct($from, $where);
 
@@ -136,7 +136,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param string|array $fields Field names should be ANSI SQL quoted. Array keys should be unquoted.
      * @return $this Self reference
      */
-    public function setSelect($fields)
+    public function setSelect(array|string $fields): SilverStripe\ORM\Queries\SQLSelect
     {
         $this->select = [];
         if (func_num_args() > 1) {
@@ -155,7 +155,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param string|array $fields Field names should be ANSI SQL quoted. Array keys should be unquoted.
      * @return $this Self reference
      */
-    public function addSelect($fields)
+    public function addSelect(array|string $fields): SilverStripe\ORM\Queries\SQLSelect
     {
         if (func_num_args() > 1) {
             $fields = func_get_args();
@@ -177,7 +177,7 @@ class SQLSelect extends SQLConditionalExpression
      * Defaults to the unquoted column name of the $field parameter.
      * @return $this Self reference
      */
-    public function selectField($field, $alias = null)
+    public function selectField(string $field, string $alias = null): SilverStripe\ORM\Queries\SQLSelect
     {
         if (!$alias) {
             if (preg_match('/"([^"]+)"$/', $field ?? '', $matches)) {
@@ -198,7 +198,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param string $field
      * @return string
      */
-    public function expressionForField($field)
+    public function expressionForField(string $field): null|string
     {
         return isset($this->select[$field]) ? $this->select[$field] : null;
     }
@@ -209,7 +209,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param bool $value
      * @return $this Self reference
      */
-    public function setDistinct($value)
+    public function setDistinct(bool $value): SilverStripe\ORM\Queries\SQLSelect
     {
         $this->distinct = $value;
         return $this;
@@ -220,7 +220,7 @@ class SQLSelect extends SQLConditionalExpression
      *
      * @return bool
      */
-    public function getDistinct()
+    public function getDistinct(): bool
     {
         return $this->distinct;
     }
@@ -229,7 +229,7 @@ class SQLSelect extends SQLConditionalExpression
      * Get the limit property.
      * @return array
      */
-    public function getLimit()
+    public function getLimit(): array|null|bool|int
     {
         return $this->limit;
     }
@@ -244,7 +244,7 @@ class SQLSelect extends SQLConditionalExpression
      * @throws InvalidArgumentException
      * @return $this Self reference
      */
-    public function setLimit($limit, $offset = 0)
+    public function setLimit(array|int|bool|string $limit, int|string $offset = 0): SilverStripe\ORM\Queries\SQLSelect
     {
         if ((is_numeric($limit) && $limit < 0) || (is_numeric($offset) && $offset < 0)) {
             throw new InvalidArgumentException("SQLSelect::setLimit() only takes positive values");
@@ -300,7 +300,7 @@ class SQLSelect extends SQLConditionalExpression
      *
      * @return $this Self reference
      */
-    public function setOrderBy($clauses = null, $direction = null)
+    public function setOrderBy(array|string|bool $clauses = null, string $direction = null): SilverStripe\ORM\Queries\SQLSelect
     {
         $this->orderby = [];
         return $this->addOrderBy($clauses, $direction);
@@ -319,7 +319,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param string $direction Sort direction, ASC or DESC
      * @return $this Self reference
      */
-    public function addOrderBy($clauses = null, $direction = null)
+    public function addOrderBy(array|string|bool $clauses = null, string $direction = null): SilverStripe\ORM\Queries\SQLSelect
     {
         if (empty($clauses)) {
             return $this;
@@ -390,7 +390,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param string $defaultDirection
      * @return array A two element array: [$column, $direction]
      */
-    private function getDirectionFromString($value, $defaultDirection = null)
+    private function getDirectionFromString(string $value, string $defaultDirection = null): array
     {
         if (preg_match('/^(.*)(asc|desc)$/i', $value ?? '', $matches)) {
             $column = trim($matches[1] ?? '');
@@ -409,7 +409,7 @@ class SQLSelect extends SQLConditionalExpression
      *
      * @return array
      */
-    public function getOrderBy()
+    public function getOrderBy(): array
     {
         $orderby = $this->orderby;
         if (!$orderby) {
@@ -442,7 +442,7 @@ class SQLSelect extends SQLConditionalExpression
      *
      * @return $this Self reference
      */
-    public function reverseOrderBy()
+    public function reverseOrderBy(): SilverStripe\ORM\Queries\SQLSelect
     {
         $order = $this->getOrderBy();
         $this->orderby = [];
@@ -461,7 +461,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param string|array $groupby Escaped SQL statement
      * @return $this Self reference
      */
-    public function setGroupBy($groupby)
+    public function setGroupBy(array|string $groupby): SilverStripe\ORM\Queries\SQLSelect
     {
         $this->groupby = [];
         return $this->addGroupBy($groupby);
@@ -473,7 +473,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param string|array $groupby Escaped SQL statement
      * @return $this Self reference
      */
-    public function addGroupBy($groupby)
+    public function addGroupBy(array|string $groupby): SilverStripe\ORM\Queries\SQLSelect
     {
         if (is_array($groupby)) {
             $this->groupby = array_merge($this->groupby, $groupby);
@@ -492,7 +492,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param mixed ...$having Predicate(s) to set, as escaped SQL statements or parameterised queries
      * @return $this Self reference
      */
-    public function setHaving($having)
+    public function setHaving(array|string $having): SilverStripe\ORM\Queries\SQLSelect
     {
         $having = func_num_args() > 1 ? func_get_args() : $having;
         $this->having = [];
@@ -507,7 +507,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param mixed ...$having Predicate(s) to set, as escaped SQL statements or parameterised queries
      * @return $this Self reference
      */
-    public function addHaving($having)
+    public function addHaving(array|string $having): SilverStripe\ORM\Queries\SQLSelect
     {
         $having = $this->normalisePredicates(func_get_args());
 
@@ -521,7 +521,7 @@ class SQLSelect extends SQLConditionalExpression
      * Return a list of HAVING clauses used internally.
      * @return array
      */
-    public function getHaving()
+    public function getHaving(): array
     {
         return $this->having;
     }
@@ -532,7 +532,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param array $parameters Out variable for parameters required for this query
      * @return array
      */
-    public function getHavingParameterised(&$parameters)
+    public function getHavingParameterised(&$parameters): array
     {
         $this->splitQueryParameters($this->having, $conditions, $parameters);
         return $conditions;
@@ -543,7 +543,7 @@ class SQLSelect extends SQLConditionalExpression
      *
      * @return array
      */
-    public function getGroupBy()
+    public function getGroupBy(): array|null
     {
         return $this->groupby;
     }
@@ -556,7 +556,7 @@ class SQLSelect extends SQLConditionalExpression
      *
      * @return array
      */
-    public function getSelect()
+    public function getSelect(): array
     {
         return $this->select;
     }
@@ -569,7 +569,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param string $column
      * @return int
      */
-    public function unlimitedRowCount($column = null)
+    public function unlimitedRowCount(string $column = null): int
     {
         // we can't clear the select if we're relying on its output by a HAVING clause
         if (count($this->having ?? [])) {
@@ -608,7 +608,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param string $fieldName
      * @return bool
      */
-    public function canSortBy($fieldName)
+    public function canSortBy(string $fieldName): bool
     {
         $fieldName = preg_replace('/(\s+?)(A|DE)SC$/', '', $fieldName ?? '');
 
@@ -622,7 +622,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param string $column Quoted, escaped column name
      * @return int
      */
-    public function count($column = null)
+    public function count(string $column = null): int
     {
         // we can't clear the select if we're relying on its output by a HAVING clause
         if (!empty($this->having)) {
@@ -666,7 +666,7 @@ class SQLSelect extends SQLConditionalExpression
      * @param string $alias An optional alias for the aggregate column.
      * @return SQLSelect A clone of this object with the given aggregate function
      */
-    public function aggregate($column, $alias = null)
+    public function aggregate(string $column, string $alias = null): SilverStripe\ORM\Queries\SQLSelect
     {
 
         $clone = clone $this;
@@ -699,7 +699,7 @@ class SQLSelect extends SQLConditionalExpression
      *
      * @return SQLSelect A clone of this object with the first row only
      */
-    public function firstRow()
+    public function firstRow(): SilverStripe\ORM\Queries\SQLSelect
     {
         $query = clone $this;
         $offset = $this->limit ? $this->limit['start'] : 0;
@@ -712,7 +712,7 @@ class SQLSelect extends SQLConditionalExpression
      *
      * @return SQLSelect A clone of this object with the last row only
      */
-    public function lastRow()
+    public function lastRow(): SilverStripe\ORM\Queries\SQLSelect
     {
         $query = clone $this;
         $offset = $this->limit ? $this->limit['start'] : 0;

--- a/src/ORM/Queries/SQLUpdate.php
+++ b/src/ORM/Queries/SQLUpdate.php
@@ -26,7 +26,7 @@ class SQLUpdate extends SQLConditionalExpression implements SQLWriteExpression
      * @param array $where List of where clauses
      * @return static
      */
-    public static function create($table = null, $assignment = [], $where = [])
+    public static function create(string $table = null, array $assignment = [], array $where = []): SilverStripe\ORM\Queries\SQLUpdate
     {
         return Injector::inst()->createWithArgs(__CLASS__, func_get_args());
     }
@@ -38,7 +38,7 @@ class SQLUpdate extends SQLConditionalExpression implements SQLWriteExpression
      * @param array $assignment List of column assignments
      * @param array $where List of where clauses
      */
-    function __construct($table = null, $assignment = [], $where = [])
+    function __construct(string $table = null, array $assignment = [], array $where = []): void
     {
         parent::__construct(null, $where);
         $this->assignment = new SQLAssignmentRow();
@@ -52,7 +52,7 @@ class SQLUpdate extends SQLConditionalExpression implements SQLWriteExpression
      * @param string $table
      * @return $this Self reference
      */
-    public function setTable($table)
+    public function setTable(string $table): SilverStripe\ORM\Queries\SQLUpdate
     {
         return $this->setFrom($table);
     }
@@ -62,35 +62,35 @@ class SQLUpdate extends SQLConditionalExpression implements SQLWriteExpression
      *
      * @return string Name of the table
      */
-    public function getTable()
+    public function getTable(): string
     {
         return reset($this->from);
     }
 
-    public function addAssignments(array $assignments)
+    public function addAssignments(array $assignments): SilverStripe\ORM\Queries\SQLUpdate
     {
         $this->assignment->addAssignments($assignments);
         return $this;
     }
 
-    public function setAssignments(array $assignments)
+    public function setAssignments(array $assignments): SilverStripe\ORM\Queries\SQLUpdate
     {
         $this->assignment->setAssignments($assignments);
         return $this;
     }
 
-    public function getAssignments()
+    public function getAssignments(): array
     {
         return $this->assignment->getAssignments();
     }
 
-    public function assign($field, $value)
+    public function assign(string $field, int|float|string $value): SilverStripe\ORM\Queries\SQLUpdate
     {
         $this->assignment->assign($field, $value);
         return $this;
     }
 
-    public function assignSQL($field, $sql)
+    public function assignSQL(string $field, string $sql): SilverStripe\ORM\Queries\SQLUpdate
     {
         $this->assignment->assignSQL($field, $sql);
         return $this;
@@ -107,7 +107,7 @@ class SQLUpdate extends SQLConditionalExpression implements SQLWriteExpression
         return $this;
     }
 
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return empty($this->assignment) || $this->assignment->isEmpty() || parent::isEmpty();
     }

--- a/src/ORM/RelatedData/StandardRelatedDataService.php
+++ b/src/ORM/RelatedData/StandardRelatedDataService.php
@@ -412,7 +412,7 @@ class StandardRelatedDataService implements RelatedDataService
      * @param string[] $throughClasses
      * @return string
      */
-    private function updateComponentClass($componentClass, array &$throughClasses): string
+    private function updateComponentClass(array|string $componentClass, array &$throughClasses): string
     {
         if (!is_array($componentClass)) {
             return $componentClass;

--- a/src/ORM/RelationList.php
+++ b/src/ORM/RelationList.php
@@ -91,12 +91,12 @@ abstract class RelationList extends DataList implements Relation
      *
      * @return string|array|null
      */
-    public function getForeignID()
+    public function getForeignID(): int|array
     {
         return $this->dataQuery->getQueryParam('Foreign.ID');
     }
 
-    public function getQueryParams()
+    public function getQueryParams(): array
     {
         $params = parent::getQueryParams();
 
@@ -119,7 +119,7 @@ abstract class RelationList extends DataList implements Relation
      *
      * @return static
      */
-    public function forForeignID($id)
+    public function forForeignID(int|array $id): SilverStripe\Auditor\AuditHookMemberGroupSet
     {
         // Turn a 1-element array into a simple value
         if (is_array($id) && sizeof($id ?? []) == 1) {

--- a/src/ORM/Search/FulltextSearchable.php
+++ b/src/ORM/Search/FulltextSearchable.php
@@ -53,7 +53,7 @@ class FulltextSearchable extends DataExtension
      *  listed here. Default: {@link SiteTree} and {@link File}.
      * @throws Exception
      */
-    public static function enable($searchableClasses = [SiteTree::class, File::class])
+    public static function enable($searchableClasses = [SiteTree::class, File::class]): void
     {
         $defaultColumns = [
             SiteTree::class => ['Title','MenuTitle','Content','MetaDescription'],
@@ -86,7 +86,7 @@ class FulltextSearchable extends DataExtension
      * @param array|string $searchFields Comma-separated list (or array) of database column names
      *  that can be searched on. Used for generation of the database index definitions.
      */
-    public function __construct($searchFields = [])
+    public function __construct(string $searchFields = []): void
     {
         parent::__construct();
         if (is_array($searchFields)) {
@@ -99,7 +99,7 @@ class FulltextSearchable extends DataExtension
         }
     }
 
-    public static function get_extra_config($class, $extensionClass, $args)
+    public static function get_extra_config(string $class, string $extensionClass, array $args): array
     {
         return [
             'indexes' => [
@@ -117,7 +117,7 @@ class FulltextSearchable extends DataExtension
      *
      * @return array
      */
-    public static function get_searchable_classes()
+    public static function get_searchable_classes(): array
     {
         return self::$searchable_classes;
     }

--- a/src/ORM/Search/SearchContext.php
+++ b/src/ORM/Search/SearchContext.php
@@ -95,7 +95,7 @@ class SearchContext
      *                      {@link DataObject::scaffoldSearchFields()} if left blank.
      * @param array $filters Optional. Derived from modelclass if left blank
      */
-    public function __construct($modelClass, $fields = null, $filters = null)
+    public function __construct(string $modelClass, SilverStripe\Forms\FieldList $fields = null, array $filters = null): void
     {
         $this->modelClass = $modelClass;
         $this->fields = ($fields) ? $fields : new FieldList();
@@ -107,7 +107,7 @@ class SearchContext
      *
      * @return FieldList
      */
-    public function getSearchFields()
+    public function getSearchFields(): SilverStripe\Forms\FieldList
     {
         return ($this->fields) ? $this->fields : singleton($this->modelClass)->scaffoldSearchFields();
         // $this->fields is causing weirdness, so we ignore for now, using the default scaffolding
@@ -146,7 +146,7 @@ class SearchContext
      * @return DataList
      * @throws Exception
      */
-    public function getQuery($searchParams, $sort = false, $limit = false, $existingQuery = null)
+    public function getQuery(array $searchParams, bool|array $sort = false, bool|array $limit = false, SilverStripe\ORM\DataList $existingQuery = null): SilverStripe\ORM\DataList
     {
         if ($this->connective != "AND") {
             throw new Exception("SearchContext connective '$this->connective' not supported after ORM-rewrite.");
@@ -221,7 +221,7 @@ class SearchContext
      * @return DataList
      * @throws Exception
      */
-    public function getResults($searchParams, $sort = false, $limit = false)
+    public function getResults(array $searchParams, $sort = false, $limit = false): SilverStripe\ORM\DataList
     {
         $searchParams = array_filter((array)$searchParams, [$this, 'clearEmptySearchFields']);
 
@@ -236,7 +236,7 @@ class SearchContext
      * @param mixed $value
      * @return boolean
      */
-    public function clearEmptySearchFields($value)
+    public function clearEmptySearchFields(string|array $value): bool
     {
         return ($value != '');
     }
@@ -247,7 +247,7 @@ class SearchContext
      * @param string $name
      * @return SearchFilter
      */
-    public function getFilter($name)
+    public function getFilter(string $name): null|SilverStripe\ORM\Filters\PartialMatchFilter
     {
         if (isset($this->filters[$name])) {
             return $this->filters[$name];
@@ -261,7 +261,7 @@ class SearchContext
      *
      * @return SearchFilter[]
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return $this->filters;
     }
@@ -271,7 +271,7 @@ class SearchContext
      *
      * @param array $filters
      */
-    public function setFilters($filters)
+    public function setFilters($filters): void
     {
         $this->filters = $filters;
     }
@@ -281,7 +281,7 @@ class SearchContext
      *
      * @param SearchFilter $filter
      */
-    public function addFilter($filter)
+    public function addFilter(SilverStripe\ORM\Filters\FulltextFilter $filter): void
     {
         $this->filters[$filter->getFullName()] = $filter;
     }
@@ -301,7 +301,7 @@ class SearchContext
      *
      * @return FieldList
      */
-    public function getFields()
+    public function getFields(): SilverStripe\Forms\FieldList
     {
         return $this->fields;
     }
@@ -321,7 +321,7 @@ class SearchContext
      *
      * @param FormField $field
      */
-    public function addField($field)
+    public function addField(SilverStripe\Forms\TextField $field): void
     {
         $this->fields->push($field);
     }
@@ -342,7 +342,7 @@ class SearchContext
      * @param array|HTTPRequest $searchParams
      * @return $this
      */
-    public function setSearchParams($searchParams)
+    public function setSearchParams(array $searchParams): SilverStripe\ORM\Search\SearchContext
     {
         // hack to work with $searchParams when it's an Object
         if ($searchParams instanceof HTTPRequest) {
@@ -356,7 +356,7 @@ class SearchContext
     /**
      * @return array
      */
-    public function getSearchParams()
+    public function getSearchParams(): array
     {
         return $this->searchParams;
     }
@@ -368,7 +368,7 @@ class SearchContext
      *
      * @return ArrayList
      */
-    public function getSummary()
+    public function getSummary(): SilverStripe\ORM\ArrayList
     {
         $list = ArrayList::create();
         foreach ($this->searchParams as $searchField => $searchValue) {

--- a/src/ORM/UnsavedRelationList.php
+++ b/src/ORM/UnsavedRelationList.php
@@ -55,7 +55,7 @@ class UnsavedRelationList extends ArrayList implements Relation
      * @param string $relationName
      * @param string $dataClass The DataObject class used in the relation
      */
-    public function __construct($baseClass, $relationName, $dataClass)
+    public function __construct(string $baseClass, string $relationName, string $dataClass): void
     {
         $this->baseClass = $baseClass;
         $this->relationName = $relationName;
@@ -69,7 +69,7 @@ class UnsavedRelationList extends ArrayList implements Relation
      * @param mixed $item
      * @param array $extraFields A map of additional columns to insert into the joinTable in the case of a many_many relation
      */
-    public function add($item, $extraFields = null)
+    public function add(int|DNADesign\Elemental\Models\BaseElement $item, array $extraFields = null): void
     {
         $this->push($item, $extraFields);
     }
@@ -79,7 +79,7 @@ class UnsavedRelationList extends ArrayList implements Relation
      *
      * @param RelationList $list
      */
-    public function changeToList(RelationList $list)
+    public function changeToList(RelationList $list): void
     {
         foreach ($this->items as $key => $item) {
             $list->add($item, $this->extraFields[$key]);
@@ -92,7 +92,7 @@ class UnsavedRelationList extends ArrayList implements Relation
      * @param array|object $item
      * @param array $extraFields
      */
-    public function push($item, $extraFields = null)
+    public function push(int|DNADesign\Elemental\Models\BaseElement $item, array $extraFields = null): void
     {
         if ((is_object($item) && !$item instanceof $this->dataClass)
             || (!is_object($item) && !is_numeric($item))
@@ -113,7 +113,7 @@ class UnsavedRelationList extends ArrayList implements Relation
      *
      * @return string
      */
-    public function dataClass()
+    public function dataClass(): string
     {
         return $this->dataClass;
     }
@@ -124,7 +124,7 @@ class UnsavedRelationList extends ArrayList implements Relation
      * @return ArrayIterator
      */
     #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->toArray());
     }
@@ -135,7 +135,7 @@ class UnsavedRelationList extends ArrayList implements Relation
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         $items = [];
         foreach ($this->items as $key => $item) {
@@ -156,7 +156,7 @@ class UnsavedRelationList extends ArrayList implements Relation
      * @param array $items Items to add, as either DataObjects or IDs.
      * @return $this
      */
-    public function addMany($items)
+    public function addMany(array $items): SilverStripe\ORM\UnsavedRelationList
     {
         foreach ($items as $item) {
             $this->add($item);
@@ -167,7 +167,7 @@ class UnsavedRelationList extends ArrayList implements Relation
     /**
      * Remove all items from this relation.
      */
-    public function removeAll()
+    public function removeAll(): void
     {
         $this->items = [];
         $this->extraFields = [];
@@ -201,7 +201,7 @@ class UnsavedRelationList extends ArrayList implements Relation
      *
      * @param array $idList List of IDs.
      */
-    public function setByIDList($idList)
+    public function setByIDList(array $idList): void
     {
         $this->removeAll();
         $this->addMany($idList);
@@ -214,7 +214,7 @@ class UnsavedRelationList extends ArrayList implements Relation
      *
      * @return array
      */
-    public function getIDList()
+    public function getIDList(): array
     {
         // Get a list of IDs of our current items - if it's not a number then object then assume it's a DO.
         $ids = array_map(function ($obj) {
@@ -237,7 +237,7 @@ class UnsavedRelationList extends ArrayList implements Relation
      *
      * @return mixed
      */
-    public function first()
+    public function first(): SilverStripe\CKANRegistry\Model\ResourceField|bool
     {
         $item = reset($this->items);
         if (is_numeric($item)) {
@@ -269,7 +269,7 @@ class UnsavedRelationList extends ArrayList implements Relation
      * @param string $colName
      * @return array
      */
-    public function column($colName = 'ID')
+    public function column(string $colName = 'ID'): array
     {
         $list = new ArrayList($this->toArray());
         return $list->column($colName);

--- a/src/ORM/ValidationException.php
+++ b/src/ORM/ValidationException.php
@@ -29,7 +29,7 @@ class ValidationException extends Exception
      * failed result, or error message to build error from
      * @param integer $code The error code number
      */
-    public function __construct($result = null, $code = 0)
+    public function __construct(SilverStripe\ORM\ValidationResult|string $result = null, int $code = 0): void
     {
         // Catch legacy behaviour where second argument was not code
         if ($code && !is_numeric($code)) {
@@ -67,7 +67,7 @@ class ValidationException extends Exception
      *
      * @return ValidationResult
      */
-    public function getResult()
+    public function getResult(): SilverStripe\ORM\ValidationResult
     {
         return $this->result;
     }

--- a/src/ORM/ValidationResult.php
+++ b/src/ORM/ValidationResult.php
@@ -68,7 +68,7 @@ class ValidationResult implements Serializable
      * Create a new ValidationResult.
      * By default, it is a successful result.   Call $this->error() to record errors.
      */
-    public function __construct()
+    public function __construct(): void
     {
         if (func_num_args() > 0) {
             Deprecation::notice('3.2', '$valid parameter is deprecated please addError to mark the result as invalid', false);
@@ -92,7 +92,7 @@ class ValidationResult implements Serializable
      * Bool values will be treated as plain text flag.
      * @return $this
      */
-    public function addError($message, $messageType = self::TYPE_ERROR, $code = null, $cast = self::CAST_TEXT)
+    public function addError(string $message, $messageType = self::TYPE_ERROR, string $code = null, $cast = self::CAST_TEXT): SilverStripe\ORM\ValidationResult
     {
         return $this->addFieldError(null, $message, $messageType, $code, $cast);
     }
@@ -111,12 +111,12 @@ class ValidationResult implements Serializable
      * @return $this
      */
     public function addFieldError(
-        $fieldName,
+        string $fieldName,
         $message,
         $messageType = self::TYPE_ERROR,
         $code = null,
         $cast = self::CAST_TEXT
-    ) {
+    ): SilverStripe\ORM\ValidationResult {
         $this->isValid = false;
         return $this->addFieldMessage($fieldName, $message, $messageType, $code, $cast);
     }
@@ -133,7 +133,7 @@ class ValidationResult implements Serializable
      * Bool values will be treated as plain text flag.
      * @return $this
      */
-    public function addMessage($message, $messageType = self::TYPE_ERROR, $code = null, $cast = self::CAST_TEXT)
+    public function addMessage(string $message, $messageType = self::TYPE_ERROR, $code = null, $cast = self::CAST_TEXT): SilverStripe\ORM\ValidationResult
     {
         return $this->addFieldMessage(null, $message, $messageType, $code, $cast);
     }
@@ -152,12 +152,12 @@ class ValidationResult implements Serializable
      * @return $this
      */
     public function addFieldMessage(
-        $fieldName,
+        string $fieldName,
         $message,
         $messageType = self::TYPE_ERROR,
         $code = null,
         $cast = self::CAST_TEXT
-    ) {
+    ): SilverStripe\ORM\ValidationResult {
         if ($code && is_numeric($code)) {
             throw new InvalidArgumentException("Don't use a numeric code '$code'.  Use a string.");
         }
@@ -184,7 +184,7 @@ class ValidationResult implements Serializable
      * Returns true if the result is valid.
      * @return boolean
      */
-    public function isValid()
+    public function isValid(): bool
     {
         return $this->isValid;
     }
@@ -194,7 +194,7 @@ class ValidationResult implements Serializable
      *
      * @return array Array of messages, where each item is an array of data for that message.
      */
-    public function getMessages()
+    public function getMessages(): array
     {
         return $this->messages;
     }
@@ -207,7 +207,7 @@ class ValidationResult implements Serializable
      * @param ValidationResult $other the validation result object to combine
      * @return $this
      */
-    public function combineAnd(ValidationResult $other)
+    public function combineAnd(ValidationResult $other): SilverStripe\ORM\ValidationResult
     {
         $this->isValid = $this->isValid && $other->isValid();
         $this->messages = array_merge($this->messages, $other->getMessages());
@@ -234,7 +234,7 @@ class ValidationResult implements Serializable
      * @return string
      * @deprecated will be removed in 5.0
      */
-    public function serialize()
+    public function serialize(): string
     {
         return json_encode([$this->messages, $this->isValid]);
     }

--- a/src/Security/AuthenticationMiddleware.php
+++ b/src/Security/AuthenticationMiddleware.php
@@ -21,7 +21,7 @@ class AuthenticationMiddleware implements HTTPMiddleware
     /**
      * @return AuthenticationHandler
      */
-    public function getAuthenticationHandler()
+    public function getAuthenticationHandler(): SilverStripe\Security\RequestAuthenticationHandler
     {
         return $this->authenticationHandler;
     }
@@ -30,7 +30,7 @@ class AuthenticationMiddleware implements HTTPMiddleware
      * @param AuthenticationHandler $authenticationHandler
      * @return $this
      */
-    public function setAuthenticationHandler(AuthenticationHandler $authenticationHandler)
+    public function setAuthenticationHandler(AuthenticationHandler $authenticationHandler): SilverStripe\Security\AuthenticationMiddleware
     {
         $this->authenticationHandler = $authenticationHandler;
         return $this;
@@ -43,7 +43,7 @@ class AuthenticationMiddleware implements HTTPMiddleware
      * @param callable $delegate
      * @return HTTPResponse
      */
-    public function process(HTTPRequest $request, callable $delegate)
+    public function process(HTTPRequest $request, callable $delegate): SilverStripe\Control\HTTPResponse
     {
         try {
             $this

--- a/src/Security/BasicAuth.php
+++ b/src/Security/BasicAuth.php
@@ -87,7 +87,7 @@ class BasicAuth
         $realm,
         $permissionCode = null,
         $tryUsingSessionLogin = true
-    ) {
+    ): SilverStripe\Security\Member {
         if ((Director::is_cli() && static::config()->get('ignore_cli'))) {
             return true;
         }
@@ -188,7 +188,7 @@ class BasicAuth
      *  of the permission codes a user has.
      * @param string $message
      */
-    public static function protect_entire_site($protect = true, $code = self::AUTH_PERMISSION, $message = null)
+    public static function protect_entire_site(bool $protect = true, $code = self::AUTH_PERMISSION, $message = null): void
     {
         static::config()
             ->set('entire_site_protected', $protect)
@@ -208,7 +208,7 @@ class BasicAuth
      * @param HTTPRequest|null $request
      * @throws HTTPResponse_Exception
      */
-    public static function protect_site_if_necessary(HTTPRequest $request = null)
+    public static function protect_site_if_necessary(HTTPRequest $request = null): void
     {
         $config = static::config();
 

--- a/src/Security/BasicAuthMiddleware.php
+++ b/src/Security/BasicAuthMiddleware.php
@@ -37,7 +37,7 @@ class BasicAuthMiddleware implements HTTPMiddleware
      * @param callable $delegate
      * @return HTTPResponse
      */
-    public function process(HTTPRequest $request, callable $delegate)
+    public function process(HTTPRequest $request, callable $delegate): SilverStripe\Control\HTTPResponse
     {
         // Check if url matches any patterns
         $match = $this->checkMatchingURL($request);
@@ -73,7 +73,7 @@ class BasicAuthMiddleware implements HTTPMiddleware
      *
      * @return array
      */
-    public function getURLPatterns()
+    public function getURLPatterns(): array
     {
         return $this->urlPatterns ?: [];
     }
@@ -82,7 +82,7 @@ class BasicAuthMiddleware implements HTTPMiddleware
      * @param array $urlPatterns
      * @return $this
      */
-    public function setURLPatterns(array $urlPatterns)
+    public function setURLPatterns(array $urlPatterns): CWP\Core\Control\CwpBasicAuthMiddleware
     {
         $this->urlPatterns = $urlPatterns;
         return $this;
@@ -96,7 +96,7 @@ class BasicAuthMiddleware implements HTTPMiddleware
      * or null if should fall back to config value. Can also provide an explicit string / array of permission
      * codes to require for this requset.
      */
-    protected function checkMatchingURL(HTTPRequest $request)
+    protected function checkMatchingURL(HTTPRequest $request): null|string|bool
     {
         // Null if no permissions enabled
         $patterns = $this->getURLPatterns();

--- a/src/Security/CMSSecurity.php
+++ b/src/Security/CMSSecurity.php
@@ -32,7 +32,7 @@ class CMSSecurity extends Security
      */
     private static $reauth_enabled = true;
 
-    protected function init()
+    protected function init(): void
     {
         parent::init();
 
@@ -46,23 +46,23 @@ class CMSSecurity extends Security
         }
     }
 
-    public function login($request = null, $service = Authenticator::CMS_LOGIN)
+    public function login(SilverStripe\Control\HTTPRequest $request = null, $service = Authenticator::CMS_LOGIN): SilverStripe\ORM\FieldType\DBHTMLText
     {
         return parent::login($request, Authenticator::CMS_LOGIN);
     }
 
-    public function Link($action = null)
+    public function Link(string $action = null): string
     {
         /** @skipUpgrade */
         return Controller::join_links(Director::baseURL(), "CMSSecurity", $action);
     }
 
-    protected function getAuthenticator($name = 'cms')
+    protected function getAuthenticator(string $name = 'cms'): SilverStripe\Security\MemberAuthenticator\CMSMemberAuthenticator
     {
         return parent::getAuthenticator($name);
     }
 
-    public function getApplicableAuthenticators($service = Authenticator::CMS_LOGIN)
+    public function getApplicableAuthenticators($service = Authenticator::CMS_LOGIN): array
     {
         return parent::getApplicableAuthenticators($service);
     }
@@ -72,7 +72,7 @@ class CMSSecurity extends Security
      *
      * @return Member
      */
-    public function getTargetMember()
+    public function getTargetMember(): SilverStripe\Security\Member|null
     {
         $tempid = $this->getRequest()->requestVar('tempid');
         if ($tempid) {
@@ -82,13 +82,13 @@ class CMSSecurity extends Security
         return null;
     }
 
-    public function getResponseController($title)
+    public function getResponseController(string $title): SilverStripe\Security\CMSSecurity
     {
         // Use $this to prevent use of Page to render underlying templates
         return $this;
     }
 
-    protected function getSessionMessage(&$messageType = null)
+    protected function getSessionMessage(string &$messageType = null): string
     {
         $message =  parent::getSessionMessage($messageType);
         if ($message) {
@@ -117,7 +117,7 @@ class CMSSecurity extends Security
      *
      * @return HTTPResponse
      */
-    protected function redirectToExternalLogin()
+    protected function redirectToExternalLogin(): SilverStripe\Control\HTTPResponse
     {
         $loginURL = Security::create()->Link('login');
         $loginURLATT = Convert::raw2att($loginURL);
@@ -145,7 +145,7 @@ PHP
         return $response;
     }
 
-    protected function preLogin()
+    protected function preLogin(): null|SilverStripe\Control\HTTPResponse
     {
         // If no member has been previously logged in for this session, force a redirect to the main login page
         if (!$this->getTargetMember()) {
@@ -160,7 +160,7 @@ PHP
      *
      * @return bool
      */
-    public function enabled()
+    public function enabled(): bool
     {
         // Disable shortcut
         if (!static::config()->get('reauth_enabled')) {
@@ -175,7 +175,7 @@ PHP
      *
      * @return HTTPResponse|DBField
      */
-    public function success()
+    public function success(): SilverStripe\ORM\FieldType\DBHTMLText
     {
         // Ensure member is properly logged in
         if (!Security::getCurrentUser() || !class_exists(AdminRootController::class)) {

--- a/src/Security/Confirmation/Item.php
+++ b/src/Security/Confirmation/Item.php
@@ -45,7 +45,7 @@ class Item
      * @param string $name Human readable name of the item
      * @param string $description Human readable description of the item
      */
-    public function __construct($token, $name, $description)
+    public function __construct(string $token, string $name, string $description): void
     {
         $this->token = $token;
         $this->name = $name;
@@ -58,7 +58,7 @@ class Item
      *
      * @return string
      */
-    public function getToken()
+    public function getToken(): string
     {
         return $this->token;
     }
@@ -68,7 +68,7 @@ class Item
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -78,7 +78,7 @@ class Item
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
@@ -88,7 +88,7 @@ class Item
      *
      * @return bool
      */
-    public function isConfirmed()
+    public function isConfirmed(): bool
     {
         return $this->confirmed;
     }
@@ -96,7 +96,7 @@ class Item
     /**
      * Mark the item as confirmed
      */
-    public function confirm()
+    public function confirm(): void
     {
         $this->confirmed = true;
     }

--- a/src/Security/Confirmation/Storage.php
+++ b/src/Security/Confirmation/Storage.php
@@ -39,7 +39,7 @@ class Storage
      * @param string $id Unique storage identifier within the session
      * @param bool $new Cleanup the storage
      */
-    public function __construct(Session $session, $id, $new = true)
+    public function __construct(Session $session, string $id, bool $new = true): void
     {
         $id = trim((string) $id);
         if (!strlen($id ?? '')) {
@@ -58,7 +58,7 @@ class Storage
      * Remove all the data from the storage
      * Cleans up Session and Cookie related to this storage
      */
-    public function cleanup()
+    public function cleanup(): void
     {
         Cookie::force_expiry($this->getCookieKey());
         $this->session->clear($this->getNamespace());
@@ -72,7 +72,7 @@ class Storage
      *
      * @return bool whether all items have been confirmed
      */
-    public function confirm($data)
+    public function confirm(array $data): bool
     {
         foreach ($this->getItems() as $item) {
             $key = base64_encode($this->getTokenHash($item) ?? '');
@@ -100,7 +100,7 @@ class Storage
      *
      * @return array
      */
-    public function getHashedItems()
+    public function getHashedItems(): array
     {
         $items = [];
 
@@ -120,7 +120,7 @@ class Storage
      *
      * @return string
      */
-    public function getTokenHash(Item $item)
+    public function getTokenHash(Item $item): string
     {
         $token = $item->getToken();
         $salt = $this->getSessionSalt();
@@ -135,7 +135,7 @@ class Storage
      *
      * @return string
      */
-    public function getCookieKey()
+    public function getCookieKey(): string
     {
         $salt = $this->getSessionSalt();
 
@@ -159,7 +159,7 @@ class Storage
      *
      * @return string
      */
-    public function getSessionSalt()
+    public function getSessionSalt(): string
     {
         $key = $this->getNamespace('salt');
 
@@ -176,7 +176,7 @@ class Storage
      *
      * @return string
      */
-    protected function generateSalt()
+    protected function generateSalt(): string
     {
         return random_bytes(64);
     }
@@ -189,7 +189,7 @@ class Storage
      *
      * @return $this
      */
-    public function putItem(Item $item)
+    public function putItem(Item $item): SilverStripe\Security\Confirmation\Storage
     {
         $key = $this->getNamespace('items');
 
@@ -207,7 +207,7 @@ class Storage
      *
      * @return Item[]
      */
-    public function getItems()
+    public function getItems(): array
     {
         return $this->session->get($this->getNamespace('items')) ?: [];
     }
@@ -236,7 +236,7 @@ class Storage
      *
      * @return $this
      */
-    public function setSuccessRequest(HTTPRequest $request)
+    public function setSuccessRequest(HTTPRequest $request): void
     {
         $url = Controller::join_links(Director::baseURL(), $request->getURL(true));
         $this->setSuccessUrl($url);
@@ -290,7 +290,7 @@ class Storage
      *
      * @return string
      */
-    public function getHttpMethod()
+    public function getHttpMethod(): string
     {
         return $this->session->get($this->getNamespace('httpMethod'));
     }
@@ -361,7 +361,7 @@ class Storage
      *
      * @return $this
      */
-    public function setSuccessUrl($url)
+    public function setSuccessUrl(string $url): SilverStripe\Security\Confirmation\Storage
     {
         $this->session->set($this->getNamespace('successUrl'), $url);
         return $this;
@@ -372,7 +372,7 @@ class Storage
      *
      * @return string
      */
-    public function getSuccessUrl()
+    public function getSuccessUrl(): string
     {
         return $this->session->get($this->getNamespace('successUrl'));
     }
@@ -384,7 +384,7 @@ class Storage
      *
      * @return $this
      */
-    public function setFailureUrl($url)
+    public function setFailureUrl(string $url): SilverStripe\Security\Confirmation\Storage
     {
         $this->session->set($this->getNamespace('failureUrl'), $url);
         return $this;
@@ -407,7 +407,7 @@ class Storage
      *
      * @return bool
      */
-    public function check(array $items)
+    public function check(array $items): bool
     {
         foreach ($items as $itemToConfirm) {
             foreach ($this->getItems() as $item) {
@@ -435,7 +435,7 @@ class Storage
      *
      * @return string
      */
-    protected function getNamespace($key = null)
+    protected function getNamespace(string $key = null): string
     {
         return sprintf(
             '%s.%s%s',

--- a/src/Security/DefaultAdminService.php
+++ b/src/Security/DefaultAdminService.php
@@ -36,7 +36,7 @@ class DefaultAdminService
      */
     protected static $default_password = null;
 
-    public function __construct()
+    public function __construct(): void
     {
     }
 
@@ -46,7 +46,7 @@ class DefaultAdminService
      * @param string $username
      * @param string $password
      */
-    public static function setDefaultAdmin($username, $password)
+    public static function setDefaultAdmin(string $username, string $password): void
     {
         // don't overwrite if already set
         if (static::hasDefaultAdmin()) {
@@ -68,7 +68,7 @@ class DefaultAdminService
      * @return string The default admin username
      * @throws BadMethodCallException Throws exception if there is no default admin
      */
-    public static function getDefaultAdminUsername()
+    public static function getDefaultAdminUsername(): string
     {
         if (!static::hasDefaultAdmin()) {
             throw new BadMethodCallException(
@@ -82,7 +82,7 @@ class DefaultAdminService
      * @return string The default admin password
      * @throws BadMethodCallException Throws exception if there is no default admin
      */
-    public static function getDefaultAdminPassword()
+    public static function getDefaultAdminPassword(): string
     {
         if (!static::hasDefaultAdmin()) {
             throw new BadMethodCallException(
@@ -97,7 +97,7 @@ class DefaultAdminService
      *
      * @return bool
      */
-    public static function hasDefaultAdmin()
+    public static function hasDefaultAdmin(): bool
     {
         // Check environment if not explicitly set
         if (!isset(static::$has_default_admin)) {
@@ -110,7 +110,7 @@ class DefaultAdminService
     /**
      * Flush the default admin credentials.
      */
-    public static function clearDefaultAdmin()
+    public static function clearDefaultAdmin(): void
     {
         static::$has_default_admin = false;
         static::$default_username = null;
@@ -120,7 +120,7 @@ class DefaultAdminService
     /**
      * @return Member|null
      */
-    public function findOrCreateDefaultAdmin()
+    public function findOrCreateDefaultAdmin(): SilverStripe\Security\Member|null
     {
         $this->extend('beforeFindOrCreateDefaultAdmin');
 
@@ -148,7 +148,7 @@ class DefaultAdminService
      * @param string $name
      * @return Member
      */
-    public function findOrCreateAdmin($email, $name = null)
+    public function findOrCreateAdmin(string $email, string $name = null): SilverStripe\Security\Member
     {
         $this->extend('beforeFindOrCreateAdmin', $email, $name);
 
@@ -194,7 +194,7 @@ class DefaultAdminService
      *
      * @return Group
      */
-    protected function findOrCreateAdminGroup()
+    protected function findOrCreateAdminGroup(): SilverStripe\Security\Group
     {
         // Check pre-existing group
         $adminGroup = Permission::get_groups_by_permission('ADMIN')->first();
@@ -226,7 +226,7 @@ class DefaultAdminService
      * @param string $username
      * @return bool
      */
-    public static function isDefaultAdmin($username)
+    public static function isDefaultAdmin(string $username): bool
     {
         return static::hasDefaultAdmin()
             && $username
@@ -241,7 +241,7 @@ class DefaultAdminService
      * @param string $password
      * @return bool
      */
-    public static function isDefaultAdminCredentials($username, $password)
+    public static function isDefaultAdminCredentials(string $username, string $password): bool
     {
         return static::isDefaultAdmin($username)
             && $password

--- a/src/Security/Group.php
+++ b/src/Security/Group.php
@@ -91,7 +91,7 @@ class Group extends DataObject
         'Sort' => true,
     ];
 
-    public function getAllChildren()
+    public function getAllChildren(): SilverStripe\ORM\ArrayList
     {
         $doSet = new ArrayList();
 
@@ -105,7 +105,7 @@ class Group extends DataObject
         return $doSet;
     }
 
-    private function getDecodedBreadcrumbs()
+    private function getDecodedBreadcrumbs(): SilverStripe\ORM\ArrayList
     {
         $list = Group::get()->exclude('ID', $this->ID);
         $groups = ArrayList::create();
@@ -122,7 +122,7 @@ class Group extends DataObject
      * @skipUpgrade
      * @return FieldList
      */
-    public function getCMSFields()
+    public function getCMSFields(): SilverStripe\Forms\FieldList
     {
         $fields = new FieldList(
             new TabSet(
@@ -292,7 +292,7 @@ class Group extends DataObject
      * @return array
      * @skipUpgrade
      */
-    public function fieldLabels($includerelations = true)
+    public function fieldLabels($includerelations = true): array
     {
         $labels = parent::fieldLabels($includerelations);
         $labels['Title'] = _t(__CLASS__ . '.GROUPNAME', 'Group name');
@@ -317,7 +317,7 @@ class Group extends DataObject
      * @param string $filter
      * @return ManyManyList
      */
-    public function Members($filter = '')
+    public function Members($filter = ''): SilverStripe\Auditor\AuditHookManyManyList
     {
         // First get direct members as a base result
         $result = $this->DirectMembers();
@@ -347,7 +347,7 @@ class Group extends DataObject
     /**
      * Return only the members directly added to this group
      */
-    public function DirectMembers()
+    public function DirectMembers(): SilverStripe\Auditor\AuditHookManyManyList
     {
         return $this->getManyManyComponents('Members');
     }
@@ -358,7 +358,7 @@ class Group extends DataObject
      *
      * @return array
      */
-    public function collateFamilyIDs()
+    public function collateFamilyIDs(): array
     {
         if (!$this->exists()) {
             throw new \InvalidArgumentException("Cannot call collateFamilyIDs on unsaved Group.");
@@ -383,7 +383,7 @@ class Group extends DataObject
      *
      * @return array
      */
-    public function collateAncestorIDs()
+    public function collateAncestorIDs(): array
     {
         $parent = $this;
         $items = [];
@@ -400,7 +400,7 @@ class Group extends DataObject
      * @param string|int|Group $group Group instance, Group Code or ID
      * @return bool Returns TRUE if the Group is a child of the given group, otherwise FALSE
      */
-    public function inGroup($group)
+    public function inGroup(int|string|SilverStripe\Security\Group $group): bool
     {
         return in_array($this->identifierToGroupID($group), $this->collateAncestorIDs() ?? []);
     }
@@ -412,7 +412,7 @@ class Group extends DataObject
      * @param bool $requireAll set to TRUE if must be in ALL groups, or FALSE if must be in ANY
      * @return bool Returns TRUE if the Group is a child of any of the given groups, otherwise FALSE
      */
-    public function inGroups($groups, $requireAll = false)
+    public function inGroups(array $groups, bool $requireAll = false): bool
     {
         $ancestorIDs = $this->collateAncestorIDs();
         $candidateIDs = [];
@@ -440,7 +440,7 @@ class Group extends DataObject
      * @param string|int|Group $groupID Group instance, Group Code or ID
      * @return int|null the Group ID or NULL if not found
      */
-    protected function identifierToGroupID($groupID)
+    protected function identifierToGroupID(int|string|SilverStripe\Security\Group $groupID): int|null
     {
         if (is_numeric($groupID) && Group::get()->byID($groupID)) {
             return $groupID;
@@ -463,7 +463,7 @@ class Group extends DataObject
     /**
      * Override this so groups are ordered in the CMS
      */
-    public function stageChildren()
+    public function stageChildren(): SilverStripe\ORM\DataList
     {
         return Group::get()
             ->filter("ParentID", $this->ID)
@@ -474,7 +474,7 @@ class Group extends DataObject
     /**
      * @return string
      */
-    public function getTreeTitle()
+    public function getTreeTitle(): string
     {
         $title = htmlspecialchars($this->Title ?? '', ENT_QUOTES);
         $this->extend('updateTreeTitle', $title);
@@ -486,12 +486,12 @@ class Group extends DataObject
      *
      * @param string $val
      */
-    public function setCode($val)
+    public function setCode(string $val): void
     {
         $this->setField('Code', Convert::raw2url($val));
     }
 
-    public function validate()
+    public function validate(): SilverStripe\ORM\ValidationResult
     {
         $result = parent::validate();
 
@@ -543,7 +543,7 @@ class Group extends DataObject
         return $validator;
     }
 
-    public function onBeforeWrite()
+    public function onBeforeWrite(): void
     {
         parent::onBeforeWrite();
 
@@ -558,7 +558,7 @@ class Group extends DataObject
         $this->dedupeCode();
     }
 
-    public function onBeforeDelete()
+    public function onBeforeDelete(): void
     {
         parent::onBeforeDelete();
 
@@ -580,7 +580,7 @@ class Group extends DataObject
      * @param Member $member Member
      * @return boolean
      */
-    public function canEdit($member = null)
+    public function canEdit(SilverStripe\Security\Member $member = null): bool
     {
         if (!$member) {
             $member = Security::getCurrentUser();
@@ -616,7 +616,7 @@ class Group extends DataObject
      * @param Member $member
      * @return boolean
      */
-    public function canView($member = null)
+    public function canView($member = null): bool
     {
         if (!$member) {
             $member = Security::getCurrentUser();
@@ -638,7 +638,7 @@ class Group extends DataObject
         return false;
     }
 
-    public function canDelete($member = null)
+    public function canDelete($member = null): bool
     {
         if (!$member) {
             $member = Security::getCurrentUser();
@@ -661,7 +661,7 @@ class Group extends DataObject
      *
      * @return ArrayList
      */
-    public function AllChildrenIncludingDeleted()
+    public function AllChildrenIncludingDeleted(): SilverStripe\ORM\ArrayList
     {
         $children = parent::AllChildrenIncludingDeleted();
 
@@ -685,7 +685,7 @@ class Group extends DataObject
      * This function is called whenever the database is built, after the
      * database tables have all been created.
      */
-    public function requireDefaultRecords()
+    public function requireDefaultRecords(): void
     {
         parent::requireDefaultRecords();
 

--- a/src/Security/GroupCsvBulkLoader.php
+++ b/src/Security/GroupCsvBulkLoader.php
@@ -15,12 +15,12 @@ class GroupCsvBulkLoader extends CsvBulkLoader
         'Code' => 'Code',
     ];
 
-    public function __construct($objectClass = Group::class)
+    public function __construct($objectClass = Group::class): void
     {
         parent::__construct($objectClass);
     }
 
-    public function processRecord($record, $columnMap, &$results, $preview = false)
+    public function processRecord(array $record, array $columnMap, &$results, bool $preview = false): int
     {
         // We match by 'Code', the ID property is confusing the importer
         if (isset($record['ID'])) {

--- a/src/Security/InheritedPermissionFlusher.php
+++ b/src/Security/InheritedPermissionFlusher.php
@@ -18,7 +18,7 @@ class InheritedPermissionFlusher extends DataExtension implements Flushable
     /**
      * Flush all MemberCacheFlusher services
      */
-    public static function flush()
+    public static function flush(): void
     {
         singleton(__CLASS__)->flushCache();
     }
@@ -26,7 +26,7 @@ class InheritedPermissionFlusher extends DataExtension implements Flushable
     /**
      * @param DataObject $owner
      */
-    public function setOwner($owner)
+    public function setOwner(SilverStripe\Security\Group $owner): void
     {
         if (!$owner instanceof Member && !$owner instanceof Group) {
             throw new InvalidArgumentException(sprintf(
@@ -45,7 +45,7 @@ class InheritedPermissionFlusher extends DataExtension implements Flushable
      * @throws InvalidArgumentException
      * @return $this
      */
-    public function setServices($services)
+    public function setServices(array $services): SilverStripe\Security\InheritedPermissionFlusher
     {
         foreach ($services as $service) {
             if (!$service instanceof MemberCacheFlusher) {
@@ -66,7 +66,7 @@ class InheritedPermissionFlusher extends DataExtension implements Flushable
     /**
      * @return MemberCacheFlusher[]
      */
-    public function getServices()
+    public function getServices(): array
     {
         return $this->services;
     }
@@ -74,7 +74,7 @@ class InheritedPermissionFlusher extends DataExtension implements Flushable
     /**
      * Flushes all registered MemberCacheFlusher services
      */
-    public function flushCache()
+    public function flushCache(): void
     {
         $ids = $this->getMemberIDList();
         foreach ($this->getServices() as $service) {
@@ -87,7 +87,7 @@ class InheritedPermissionFlusher extends DataExtension implements Flushable
      *
      * @return array|null
      */
-    protected function getMemberIDList()
+    protected function getMemberIDList(): null|array
     {
         if (!$this->owner || !$this->owner->exists()) {
             return null;

--- a/src/Security/InheritedPermissions.php
+++ b/src/Security/InheritedPermissions.php
@@ -97,7 +97,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param string $baseClass Base class
      * @param CacheInterface $cache
      */
-    public function __construct($baseClass, CacheInterface $cache = null)
+    public function __construct(string $baseClass, CacheInterface $cache = null): SilverStripe\Security\InheritedPermissions
     {
         if (!is_a($baseClass, DataObject::class, true)) {
             throw new InvalidArgumentException('Invalid DataObject class: ' . $baseClass);
@@ -112,7 +112,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
     /**
      * Commits the cache
      */
-    public function __destruct()
+    public function __destruct(): void
     {
         // Ensure back-end cache is updated
         if (!empty($this->cachePermissions) && $this->cacheService) {
@@ -129,7 +129,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      *
      * @param array $memberIDs A list of member IDs
      */
-    public function flushMemberCache($memberIDs = null)
+    public function flushMemberCache(array|string $memberIDs = null): void
     {
         if (!$this->cacheService) {
             return;
@@ -154,7 +154,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param DefaultPermissionChecker $callback
      * @return $this
      */
-    public function setDefaultPermissions(DefaultPermissionChecker $callback)
+    public function setDefaultPermissions(DefaultPermissionChecker $callback): SilverStripe\Security\InheritedPermissions
     {
         $this->defaultPermissions = $callback;
         return $this;
@@ -166,7 +166,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param array $permissions
      * @return $this
      */
-    public function setGlobalEditPermissions($permissions)
+    public function setGlobalEditPermissions(array $permissions): SilverStripe\Security\InheritedPermissions
     {
         $this->globalEditPermissions = $permissions;
         return $this;
@@ -175,7 +175,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
     /**
      * @return array
      */
-    public function getGlobalEditPermissions()
+    public function getGlobalEditPermissions(): array
     {
         return $this->globalEditPermissions;
     }
@@ -185,7 +185,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      *
      * @return DefaultPermissionChecker|null
      */
-    public function getDefaultPermissions()
+    public function getDefaultPermissions(): null|SilverStripe\SiteConfig\SiteConfigPagePermissions
     {
         return $this->defaultPermissions;
     }
@@ -195,7 +195,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      *
      * @return string
      */
-    public function getBaseClass()
+    public function getBaseClass(): string
     {
         return $this->baseClass;
     }
@@ -206,7 +206,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param string $permission
      * @param array $ids
      */
-    public function prePopulatePermissionCache($permission = 'edit', $ids = [])
+    public function prePopulatePermissionCache(string $permission = 'edit', array $ids = []): void
     {
         switch ($permission) {
             case self::EDIT:
@@ -241,12 +241,12 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * ID keys to boolean values
      */
     protected function batchPermissionCheck(
-        $type,
+        string $type,
         $ids,
         Member $member = null,
         $globalPermission = [],
         $useCached = true
-    ) {
+    ): array {
         // Validate ids
         $ids = array_filter($ids ?? [], 'is_numeric');
         if (empty($ids)) {
@@ -343,12 +343,12 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @return array
      */
     protected function batchPermissionCheckForStage(
-        $type,
+        string $type,
         $globalPermission,
         DataList $stageRecords,
         $groupIDsSQLList,
         Member $member = null
-    ) {
+    ): array {
         // Initialise all IDs to false
         $result = array_fill_keys($stageRecords->column('ID') ?? [], false);
 
@@ -440,7 +440,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param bool $useCached
      * @return array
      */
-    public function canEditMultiple($ids, Member $member = null, $useCached = true)
+    public function canEditMultiple(array $ids, Member $member = null, bool $useCached = true): array
     {
         return $this->batchPermissionCheck(
             self::EDIT,
@@ -457,7 +457,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param bool $useCached
      * @return array
      */
-    public function canViewMultiple($ids, Member $member = null, $useCached = true)
+    public function canViewMultiple(array $ids, Member $member = null, $useCached = true): array
     {
         return $this->batchPermissionCheck(self::VIEW, $ids, $member, [], $useCached);
     }
@@ -468,7 +468,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param bool $useCached
      * @return array
      */
-    public function canDeleteMultiple($ids, Member $member = null, $useCached = true)
+    public function canDeleteMultiple(array $ids, Member $member = null, $useCached = true): array
     {
         // Validate ids
         $ids = array_filter($ids ?? [], 'is_numeric');
@@ -542,7 +542,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param Member|null $member
      * @return bool|mixed
      */
-    public function canDelete($id, Member $member = null)
+    public function canDelete(int $id, Member $member = null): bool
     {
         // No ID: Check default permission
         if (!$id) {
@@ -564,7 +564,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param Member|null $member
      * @return bool|mixed
      */
-    public function canEdit($id, Member $member = null)
+    public function canEdit(int $id, Member $member = null): bool
     {
         // No ID: Check default permission
         if (!$id) {
@@ -586,7 +586,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param Member|null $member
      * @return bool|mixed
      */
-    public function canView($id, Member $member = null)
+    public function canView(int $id, Member $member = null): bool
     {
         // No ID: Check default permission
         if (!$id) {
@@ -610,7 +610,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param string $type
      * @return string
      */
-    protected function getPermissionField($type)
+    protected function getPermissionField(string $type): string
     {
         switch ($type) {
             case self::DELETE:
@@ -631,7 +631,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param string $type
      * @return string
      */
-    protected function getJoinTable($type)
+    protected function getJoinTable(string $type): string
     {
         switch ($type) {
             case self::DELETE:
@@ -652,7 +652,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param Member $member
      * @return bool
      */
-    protected function checkDefaultPermissions($type, Member $member = null)
+    protected function checkDefaultPermissions(string $type, Member $member = null): bool
     {
         $defaultPermissions = $this->getDefaultPermissions();
         if (!$defaultPermissions) {
@@ -675,7 +675,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      *
      * @return bool
      */
-    protected function isVersioned()
+    protected function isVersioned(): bool
     {
         if (!class_exists(Versioned::class)) {
             return false;
@@ -688,7 +688,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
     /**
      * @return $this
      */
-    public function clearCache()
+    public function clearCache(): SilverStripe\Security\InheritedPermissions
     {
         $this->cachePermissions = [];
         return $this;
@@ -699,7 +699,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      *
      * @return string
      */
-    protected function getEditorGroupsTable()
+    protected function getEditorGroupsTable(): string
     {
         $table = DataObject::getSchema()->tableName($this->baseClass);
         return "{$table}_EditorGroups";
@@ -710,7 +710,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      *
      * @return string
      */
-    protected function getViewerGroupsTable()
+    protected function getViewerGroupsTable(): string
     {
         $table = DataObject::getSchema()->tableName($this->baseClass);
         return "{$table}_ViewerGroups";
@@ -722,7 +722,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param string $cacheKey
      * @return mixed
      */
-    protected function getCachePermissions($cacheKey)
+    protected function getCachePermissions(string $cacheKey): null|array
     {
         // Check local cache
         if (isset($this->cachePermissions[$cacheKey])) {
@@ -750,7 +750,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
      * @param int $memberID
      * @return string
      */
-    protected function generateCacheKey($type, $memberID)
+    protected function generateCacheKey(string $type, int $memberID): string
     {
         $classKey = str_replace('\\', '-', $this->baseClass ?? '');
         return "{$type}-{$classKey}-{$memberID}";

--- a/src/Security/LoginAttempt.php
+++ b/src/Security/LoginAttempt.php
@@ -74,7 +74,7 @@ class LoginAttempt extends DataObject
      * @param string $email
      * @return $this
      */
-    public function setEmail($email)
+    public function setEmail(string $email): SilverStripe\Security\LoginAttempt
     {
         // Store hashed email only
         $this->EmailHashed = sha1($email ?? '');
@@ -87,7 +87,7 @@ class LoginAttempt extends DataObject
      * @param string $email
      * @return DataList|LoginAttempt[]
      */
-    public static function getByEmail($email)
+    public static function getByEmail(string $email): SilverStripe\ORM\DataList
     {
         return static::get()->filterAny([
             'EmailHashed' => sha1($email ?? ''),

--- a/src/Security/LoginForm.php
+++ b/src/Security/LoginForm.php
@@ -36,7 +36,7 @@ abstract class LoginForm extends Form
      * @param string $class
      * @return $this
      */
-    public function setAuthenticatorClass($class)
+    public function setAuthenticatorClass(string $class): SilverStripe\Security\MemberAuthenticator\MemberLoginForm
     {
         $this->authenticatorClass = $class;
 
@@ -59,7 +59,7 @@ abstract class LoginForm extends Form
      *
      * @return string
      */
-    public function getAuthenticatorClass()
+    public function getAuthenticatorClass(): string
     {
         // B/C for deprecated authenticator_class property
         return $this->authenticator_class ?: $this->authenticatorClass;

--- a/src/Security/LogoutForm.php
+++ b/src/Security/LogoutForm.php
@@ -27,7 +27,7 @@ class LogoutForm extends Form
         FieldList $fields = null,
         FieldList $actions = null,
         Validator $validator = null
-    ) {
+    ): void {
         $this->setController($controller);
 
         if (!$fields) {
@@ -47,7 +47,7 @@ class LogoutForm extends Form
      *
      * @return FieldList
      */
-    protected function getFormFields()
+    protected function getFormFields(): SilverStripe\Forms\FieldList
     {
         $fields = FieldList::create();
 
@@ -70,7 +70,7 @@ class LogoutForm extends Form
      *
      * @return FieldList
      */
-    protected function getFormActions()
+    protected function getFormActions(): SilverStripe\Forms\FieldList
     {
         $actions = FieldList::create(
             FormAction::create('doLogout', _t('SilverStripe\\Security\\Member.BUTTONLOGOUT', "Log out"))

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -265,13 +265,13 @@ class Member extends DataObject
     /**
      * Ensure the locale is set to something sensible by default.
      */
-    public function populateDefaults()
+    public function populateDefaults(): void
     {
         parent::populateDefaults();
         $this->Locale = i18n::config()->get('default_locale');
     }
 
-    public function requireDefaultRecords()
+    public function requireDefaultRecords(): void
     {
         parent::requireDefaultRecords();
         // Default groups should've been built by Group->requireDefaultRecords() already
@@ -299,7 +299,7 @@ class Member extends DataObject
      * @param  string $password
      * @return ValidationResult
      */
-    public function checkPassword($password)
+    public function checkPassword(string $password): SilverStripe\ORM\ValidationResult
     {
         Deprecation::notice('5.0', 'Use Authenticator::checkPassword() instead');
 
@@ -330,7 +330,7 @@ class Member extends DataObject
      *
      * @return bool
      */
-    public function canLogin()
+    public function canLogin(): bool
     {
         return $this->validateCanLogin()->isValid();
     }
@@ -344,7 +344,7 @@ class Member extends DataObject
      * @param ValidationResult $result Optional result to add errors to
      * @return ValidationResult
      */
-    public function validateCanLogin(ValidationResult &$result = null)
+    public function validateCanLogin(ValidationResult &$result = null): SilverStripe\ORM\ValidationResult
     {
         $result = $result ?: ValidationResult::create();
         if ($this->isLockedOut()) {
@@ -369,7 +369,7 @@ class Member extends DataObject
      * @skipUpgrade
      * @return bool
      */
-    public function isLockedOut()
+    public function isLockedOut(): bool
     {
         /** @var DBDatetime $lockedOutUntilObj */
         $lockedOutUntilObj = $this->dbObject('LockedOutUntil');
@@ -414,7 +414,7 @@ class Member extends DataObject
      *
      * @param PasswordValidator $validator
      */
-    public static function set_password_validator(PasswordValidator $validator = null)
+    public static function set_password_validator(PasswordValidator $validator = null): void
     {
         // Override existing config
         Config::modify()->remove(Injector::class, PasswordValidator::class);
@@ -430,7 +430,7 @@ class Member extends DataObject
      *
      * @return PasswordValidator
      */
-    public static function password_validator()
+    public static function password_validator(): SilverStripe\Security\PasswordValidator
     {
         if (Injector::inst()->has(PasswordValidator::class)) {
             return Injector::inst()->get(PasswordValidator::class);
@@ -438,7 +438,7 @@ class Member extends DataObject
         return null;
     }
 
-    public function isPasswordExpired()
+    public function isPasswordExpired(): bool
     {
         if (!$this->PasswordExpiry) {
             return false;
@@ -451,7 +451,7 @@ class Member extends DataObject
      * @deprecated 5.0.0 Use Security::setCurrentUser() or IdentityStore::logIn()
      *
      */
-    public function logIn()
+    public function logIn(): void
     {
         Deprecation::notice(
             '5.0.0',
@@ -463,7 +463,7 @@ class Member extends DataObject
     /**
      * Called before a member is logged in via session/cookie/etc
      */
-    public function beforeMemberLoggedIn()
+    public function beforeMemberLoggedIn(): void
     {
         // @todo Move to middleware on the AuthenticationMiddleware IdentityStore
         $this->extend('beforeMemberLoggedIn');
@@ -472,7 +472,7 @@ class Member extends DataObject
     /**
      * Called after a member is logged in via session/cookie/etc
      */
-    public function afterMemberLoggedIn()
+    public function afterMemberLoggedIn(): void
     {
         // Clear the incorrect log-in count
         $this->registerSuccessfulLogin();
@@ -493,7 +493,7 @@ class Member extends DataObject
      * This should be performed any time the user presents their normal identification (normally Email)
      * and is successfully authenticated.
      */
-    public function regenerateTempID()
+    public function regenerateTempID(): void
     {
         $generator = new RandomGenerator();
         $lifetime = self::config()->get('temp_id_lifetime');
@@ -547,7 +547,7 @@ class Member extends DataObject
      *
      * @param HTTPRequest|null $request
      */
-    public function beforeMemberLoggedOut(HTTPRequest $request = null)
+    public function beforeMemberLoggedOut(HTTPRequest $request = null): void
     {
         $this->extend('beforeMemberLoggedOut', $request);
     }
@@ -557,7 +557,7 @@ class Member extends DataObject
      *
      * @param HTTPRequest|null $request
      */
-    public function afterMemberLoggedOut(HTTPRequest $request = null)
+    public function afterMemberLoggedOut(HTTPRequest $request = null): void
     {
         $this->extend('afterMemberLoggedOut', $request);
     }
@@ -569,7 +569,7 @@ class Member extends DataObject
      * @return string
      * @throws PasswordEncryptor_NotFoundException
      */
-    public function encryptWithUserSettings($string)
+    public function encryptWithUserSettings(string $string): string
     {
         if (!$string) {
             return null;
@@ -595,7 +595,7 @@ class Member extends DataObject
      *                           the Member.auto_login_token_lifetime config value
      * @return string Token that should be passed to the client (but NOT persisted).
      */
-    public function generateAutologinTokenAndStoreHash($lifetime = null)
+    public function generateAutologinTokenAndStoreHash($lifetime = null): string
     {
         if ($lifetime !== null) {
             Deprecation::notice(
@@ -632,7 +632,7 @@ class Member extends DataObject
      *
      * @returns bool Is token valid?
      */
-    public function validateAutoLoginToken($autologinToken)
+    public function validateAutoLoginToken(string $autologinToken): bool
     {
         $hash = $this->encryptWithUserSettings($autologinToken);
         $member = self::member_from_autologinhash($hash, false);
@@ -649,7 +649,7 @@ class Member extends DataObject
      * @return Member the matching member, if valid
      * @return Member
      */
-    public static function member_from_autologinhash($hash, $login = false)
+    public static function member_from_autologinhash(string $hash, bool $login = false): null|SilverStripe\Security\Member
     {
         /** @var Member $member */
         $member = static::get()->filter([
@@ -670,7 +670,7 @@ class Member extends DataObject
      * @param string $tempid
      * @return Member
      */
-    public static function member_from_tempid($tempid)
+    public static function member_from_tempid(string $tempid): SilverStripe\Security\Member|null
     {
         $members = static::get()
             ->filter('TempIDHash', $tempid);
@@ -719,7 +719,7 @@ class Member extends DataObject
      *
      * @return ConfirmedPasswordField
      */
-    public function getMemberPasswordField()
+    public function getMemberPasswordField(): SilverStripe\Forms\ConfirmedPasswordField
     {
         $editingPassword = $this->isInDB();
         $label = $editingPassword
@@ -756,7 +756,7 @@ class Member extends DataObject
      *
      * @return Member_Validator
      */
-    public function getValidator()
+    public function getValidator(): SilverStripe\Security\Member_Validator
     {
         $validator = Member_Validator::create();
         $validator->setForMember($this);
@@ -773,7 +773,7 @@ class Member extends DataObject
      *
      * @return Member
      */
-    public static function currentUser()
+    public static function currentUser(): SilverStripe\Security\Member|null
     {
         Deprecation::notice(
             '5.0.0',
@@ -799,7 +799,7 @@ class Member extends DataObject
      * @param callable $callback
      * @return mixed Result of $callback
      */
-    public static function actAs($member, $callback)
+    public static function actAs(SilverStripe\Security\Member $member, callable $callback): string|bool|null|SilverStripe\Control\HTTPResponse
     {
         $previousUser = Security::getCurrentUser();
 
@@ -823,7 +823,7 @@ class Member extends DataObject
      *
      * @return int Returns the ID of the current logged in user or 0.
      */
-    public static function currentUserID()
+    public static function currentUserID(): int
     {
         Deprecation::notice(
             '5.0.0',
@@ -869,7 +869,7 @@ class Member extends DataObject
     /**
      * Event handler called before writing to the database.
      */
-    public function onBeforeWrite()
+    public function onBeforeWrite(): void
     {
         // Remove any line-break or space characters accidentally added during a copy-paste operation
         if ($this->Email) {
@@ -947,7 +947,7 @@ class Member extends DataObject
         parent::onBeforeWrite();
     }
 
-    public function onAfterWrite()
+    public function onAfterWrite(): void
     {
         parent::onAfterWrite();
 
@@ -958,7 +958,7 @@ class Member extends DataObject
         }
     }
 
-    public function onAfterDelete()
+    public function onAfterDelete(): void
     {
         parent::onAfterDelete();
 
@@ -972,7 +972,7 @@ class Member extends DataObject
      *
      * @return $this
      */
-    protected function deletePasswordLogs()
+    protected function deletePasswordLogs(): SilverStripe\Security\Member
     {
         foreach ($this->LoggedPasswords() as $password) {
             $password->delete();
@@ -989,7 +989,7 @@ class Member extends DataObject
      * @param array $ids Database IDs of Group records
      * @return bool True if the change can be accepted
      */
-    public function onChangeGroups($ids)
+    public function onChangeGroups(array $ids): bool
     {
         // Ensure none of these match disallowed list
         $disallowedGroupIDs = $this->disallowedGroups();
@@ -1001,7 +1001,7 @@ class Member extends DataObject
      *
      * @return int[] List of group IDs
      */
-    protected function disallowedGroups()
+    protected function disallowedGroups(): array
     {
         // unless the current user is an admin already OR the logged in user is an admin
         if (Permission::check('ADMIN') || Permission::checkMember($this, 'ADMIN')) {
@@ -1020,7 +1020,7 @@ class Member extends DataObject
      * @param boolean $strict Only determine direct group membership if set to true (Default: false)
      * @return bool Returns TRUE if the member is in one of the given groups, otherwise FALSE.
      */
-    public function inGroups($groups, $strict = false)
+    public function inGroups(SilverStripe\Auditor\AuditHookManyManyList|array $groups, bool $strict = false): bool
     {
         if ($groups) {
             foreach ($groups as $group) {
@@ -1041,7 +1041,7 @@ class Member extends DataObject
      * @param boolean $strict Only determine direct group membership if set to TRUE (Default: FALSE)
      * @return bool Returns TRUE if the member is in the given group, otherwise FALSE.
      */
-    public function inGroup($group, $strict = false)
+    public function inGroup(SilverStripe\Security\Group|string $group, bool $strict = false): bool
     {
         if (is_numeric($group)) {
             $groupCheckObj = DataObject::get_by_id(Group::class, $group);
@@ -1078,7 +1078,7 @@ class Member extends DataObject
      * @param string $groupcode
      * @param string $title Title of the group
      */
-    public function addToGroupByCode($groupcode, $title = "")
+    public function addToGroupByCode(string $groupcode, string $title = ""): void
     {
         $group = DataObject::get_one(Group::class, [
             '"Group"."Code"' => $groupcode
@@ -1105,7 +1105,7 @@ class Member extends DataObject
      *
      * @param string $groupcode
      */
-    public function removeFromGroupByCode($groupcode)
+    public function removeFromGroupByCode(string $groupcode): void
     {
         $group = Group::get()->filter(['Code' => $groupcode])->first();
 
@@ -1140,7 +1140,7 @@ class Member extends DataObject
      *
      * @return string
      */
-    public function getLastName()
+    public function getLastName(): string
     {
         return $this->Surname;
     }
@@ -1155,7 +1155,7 @@ class Member extends DataObject
      * @return string Returns the first- and surname of the member. If the ID
      *  of the member is equal 0, only the surname is returned.
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         $format = static::config()->get('title_format');
         if ($format) {
@@ -1215,7 +1215,7 @@ class Member extends DataObject
      *
      * @return string Returns the first- and surname of the member.
      */
-    public function getName()
+    public function getName(): string|null
     {
         return ($this->Surname) ? trim($this->FirstName . ' ' . $this->Surname) : $this->FirstName;
     }
@@ -1229,7 +1229,7 @@ class Member extends DataObject
      *
      * @param string $name The name
      */
-    public function setName($name)
+    public function setName(string $name): void
     {
         $nameParts = explode(' ', $name ?? '');
         $this->Surname = array_pop($nameParts);
@@ -1254,7 +1254,7 @@ class Member extends DataObject
      *
      * @return string ISO date format
      */
-    public function getDateFormat()
+    public function getDateFormat(): string
     {
         $formatter = new IntlDateFormatter(
             $this->getLocale(),
@@ -1271,7 +1271,7 @@ class Member extends DataObject
     /**
      * Get user locale, falling back to the configured default locale
      */
-    public function getLocale()
+    public function getLocale(): string
     {
         $locale = $this->getField('Locale');
         if ($locale) {
@@ -1287,7 +1287,7 @@ class Member extends DataObject
      *
      * @return string ISO date format
      */
-    public function getTimeFormat()
+    public function getTimeFormat(): string
     {
         $formatter = new IntlDateFormatter(
             $this->getLocale(),
@@ -1312,7 +1312,7 @@ class Member extends DataObject
      * @todo Push all this logic into Member_GroupSet's getIterator()?
      * @return Member_Groupset
      */
-    public function Groups()
+    public function Groups(): SilverStripe\Auditor\AuditHookMemberGroupSet
     {
         $groups = Member_GroupSet::create(Group::class, 'Group_Members', 'GroupID', 'MemberID');
         $groups = $groups->forForeignID($this->ID);
@@ -1325,7 +1325,7 @@ class Member extends DataObject
     /**
      * @return ManyManyList|UnsavedRelationList
      */
-    public function DirectGroups()
+    public function DirectGroups(): SilverStripe\ORM\UnsavedRelationList
     {
         return $this->getManyManyComponents('Groups');
     }
@@ -1338,7 +1338,7 @@ class Member extends DataObject
      * @param mixed $groups - takes a SS_List, an array or a single Group.ID
      * @return Map Returns an Map that returns all Member data.
      */
-    public static function map_in_groups($groups = null)
+    public static function map_in_groups(int $groups = null): SilverStripe\ORM\Map
     {
         $groupIDList = [];
 
@@ -1475,7 +1475,7 @@ class Member extends DataObject
      * @return FieldList Return a FieldList of fields that would appropriate for
      *                   editing this member.
      */
-    public function getCMSFields()
+    public function getCMSFields(): SilverStripe\Forms\FieldList
     {
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
             /** @var TabSet $rootTabSet */
@@ -1562,7 +1562,7 @@ class Member extends DataObject
      * @param bool $includerelations Indicate if the labels returned include relation fields
      * @return array
      */
-    public function fieldLabels($includerelations = true)
+    public function fieldLabels(bool $includerelations = true): array
     {
         $labels = parent::fieldLabels($includerelations);
 
@@ -1597,7 +1597,7 @@ class Member extends DataObject
      * @param Member $member
      * @return bool
      */
-    public function canView($member = null)
+    public function canView($member = null): bool
     {
         //get member
         if (!$member) {
@@ -1629,7 +1629,7 @@ class Member extends DataObject
      * @param Member $member
      * @return bool
      */
-    public function canEdit($member = null)
+    public function canEdit(SilverStripe\Security\Member $member = null): bool
     {
         //get member
         if (!$member) {
@@ -1666,7 +1666,7 @@ class Member extends DataObject
      * @param Member $member
      * @return bool
      */
-    public function canDelete($member = null)
+    public function canDelete(SilverStripe\Security\Member $member = null): bool
     {
         if (!$member) {
             $member = Security::getCurrentUser();
@@ -1703,7 +1703,7 @@ class Member extends DataObject
     /**
      * Validate this member object.
      */
-    public function validate()
+    public function validate(): SilverStripe\ORM\ValidationResult
     {
         // If validation is disabled, skip this step
         if (!DataObject::config()->uninherited('validation_enabled')) {
@@ -1734,7 +1734,7 @@ class Member extends DataObject
      * @param bool $write Whether to write the member afterwards
      * @return ValidationResult
      */
-    public function changePassword($password, $write = true)
+    public function changePassword(string $password, bool $write = true): SilverStripe\ORM\ValidationResult
     {
         $this->Password = $password;
         $result = $this->validate();
@@ -1759,7 +1759,7 @@ class Member extends DataObject
      *
      * @return $this
      */
-    protected function encryptPassword()
+    protected function encryptPassword(): SilverStripe\Security\Member
     {
         // reset salt so that it gets regenerated - this will invalidate any persistent login cookies
         // or other information encrypted with this Member's settings (see self::encryptWithUserSettings)
@@ -1795,7 +1795,7 @@ class Member extends DataObject
      * Tell this member that someone made a failed attempt at logging in as them.
      * This can be used to lock the user out temporarily if too many failed attempts are made.
      */
-    public function registerFailedLogin()
+    public function registerFailedLogin(): void
     {
         $lockOutAfterCount = self::config()->get('lock_out_after_incorrect_logins');
         if ($lockOutAfterCount) {
@@ -1815,7 +1815,7 @@ class Member extends DataObject
     /**
      * Tell this member that a successful login has been made
      */
-    public function registerSuccessfulLogin()
+    public function registerSuccessfulLogin(): void
     {
         if (self::config()->get('lock_out_after_incorrect_logins')) {
             // Forgive all past login failures
@@ -1832,7 +1832,7 @@ class Member extends DataObject
      *
      * @return string
      */
-    public function getHtmlEditorConfigForCMS()
+    public function getHtmlEditorConfigForCMS(): string
     {
         $currentName = '';
         $currentPriority = 0;

--- a/src/Security/MemberAuthenticator/CMSLoginHandler.php
+++ b/src/Security/MemberAuthenticator/CMSLoginHandler.php
@@ -23,7 +23,7 @@ class CMSLoginHandler extends LoginHandler
      * @skipUpgrade
      * @return CMSMemberLoginForm
      */
-    public function loginForm()
+    public function loginForm(): SilverStripe\Security\MemberAuthenticator\CMSMemberLoginForm
     {
         return CMSMemberLoginForm::create(
             $this,
@@ -106,7 +106,7 @@ PHP
      *
      * @return HTTPResponse
      */
-    protected function redirectAfterSuccessfulLogin()
+    protected function redirectAfterSuccessfulLogin(): SilverStripe\Control\HTTPResponse
     {
         // Check password expiry
         if (Security::getCurrentUser()->isPasswordExpired()) {

--- a/src/Security/MemberAuthenticator/CMSMemberAuthenticator.php
+++ b/src/Security/MemberAuthenticator/CMSMemberAuthenticator.php
@@ -12,7 +12,7 @@ use SilverStripe\Security\Member;
 class CMSMemberAuthenticator extends MemberAuthenticator
 {
 
-    public function supportedServices()
+    public function supportedServices(): int
     {
         return BaseAuthenticator::CMS_LOGIN;
     }
@@ -24,7 +24,7 @@ class CMSMemberAuthenticator extends MemberAuthenticator
      * @param Member|null $member
      * @return Member
      */
-    protected function authenticateMember($data, ValidationResult &$result = null, Member $member = null)
+    protected function authenticateMember(array $data, ValidationResult &$result = null, Member $member = null): SilverStripe\Security\Member
     {
         // Attempt to identify by temporary ID
         if (!empty($data['tempid'])) {
@@ -42,7 +42,7 @@ class CMSMemberAuthenticator extends MemberAuthenticator
      * @param string $link
      * @return CMSLoginHandler
      */
-    public function getLoginHandler($link)
+    public function getLoginHandler(string $link): SilverStripe\Security\MemberAuthenticator\CMSLoginHandler
     {
         return CMSLoginHandler::create($link, $this);
     }

--- a/src/Security/MemberAuthenticator/CMSMemberLoginForm.php
+++ b/src/Security/MemberAuthenticator/CMSMemberLoginForm.php
@@ -26,7 +26,7 @@ class CMSMemberLoginForm extends MemberLoginForm
      * @param string $authenticatorClass
      * @param FieldList $name
      */
-    public function __construct(RequestHandler $controller, $authenticatorClass, $name)
+    public function __construct(RequestHandler $controller, string $authenticatorClass, string $name): void
     {
         $this->controller = $controller;
 
@@ -44,7 +44,7 @@ class CMSMemberLoginForm extends MemberLoginForm
     /**
      * @return FieldList
      */
-    public function getFormFields()
+    public function getFormFields(): SilverStripe\Forms\FieldList
     {
         // Set default fields
         $fields = FieldList::create([
@@ -81,7 +81,7 @@ class CMSMemberLoginForm extends MemberLoginForm
     /**
      * @return FieldList
      */
-    public function getFormActions()
+    public function getFormActions(): SilverStripe\Forms\FieldList
     {
         // Determine returnurl to redirect to parent page
         $logoutLink = $this->getExternalLink('logout');
@@ -120,7 +120,7 @@ class CMSMemberLoginForm extends MemberLoginForm
      * @param string $action Action
      * @return string
      */
-    public function getExternalLink($action = null)
+    public function getExternalLink(string $action = null): string
     {
         return Security::singleton()->Link($action);
     }

--- a/src/Security/MemberAuthenticator/ChangePasswordForm.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordForm.php
@@ -26,7 +26,7 @@ class ChangePasswordForm extends Form
      * {@link FormField} objects.
      * @param FieldList|FormAction $actions All of the action buttons in the form - a {@link FieldList} of
      */
-    public function __construct($controller, $name, $fields = null, $actions = null)
+    public function __construct(SilverStripe\MFA\Authenticator\ChangePasswordHandler $controller, string $name, $fields = null, $actions = null): void
     {
         $backURL = $controller->getBackURL()
             ?: $controller->getRequest()->getSession()->get('BackURL');
@@ -48,7 +48,7 @@ class ChangePasswordForm extends Form
     /**
      * @return FieldList
      */
-    protected function getFormFields()
+    protected function getFormFields(): SilverStripe\Forms\FieldList
     {
         $fields = FieldList::create();
 
@@ -68,7 +68,7 @@ class ChangePasswordForm extends Form
     /**
      * @return FieldList
      */
-    protected function getFormActions()
+    protected function getFormActions(): SilverStripe\Forms\FieldList
     {
         $actions = FieldList::create(
             FormAction::create(

--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -49,7 +49,7 @@ class ChangePasswordHandler extends RequestHandler
      * @param string $link The URL to recreate this request handler
      * @param MemberAuthenticator $authenticator
      */
-    public function __construct($link, MemberAuthenticator $authenticator)
+    public function __construct(string $link, MemberAuthenticator $authenticator): void
     {
         $this->link = $link;
         $this->authenticator = $authenticator;
@@ -62,7 +62,7 @@ class ChangePasswordHandler extends RequestHandler
      *
      * @return array|HTTPResponse
      */
-    public function changepassword()
+    public function changepassword(): SilverStripe\Control\HTTPResponse|array
     {
         $request = $this->getRequest();
 
@@ -150,7 +150,7 @@ class ChangePasswordHandler extends RequestHandler
      * @param Member $member
      * @param string $token
      */
-    protected function setSessionToken($member, $token)
+    protected function setSessionToken(SilverStripe\Security\Member $member, string $token): void
     {
         // if there is a current member, they should be logged out
         if ($curMember = Security::getCurrentUser()) {
@@ -170,7 +170,7 @@ class ChangePasswordHandler extends RequestHandler
      * @param string|null $action
      * @return string
      */
-    public function Link($action = null)
+    public function Link(string $action = null): string
     {
         $link = Controller::join_links($this->link, $action);
         $this->extend('updateLink', $link, $action);
@@ -183,7 +183,7 @@ class ChangePasswordHandler extends RequestHandler
      * @skipUpgrade
      * @return ChangePasswordForm Returns the lost password form
      */
-    public function changePasswordForm()
+    public function changePasswordForm(): SilverStripe\Security\MemberAuthenticator\ChangePasswordForm
     {
         return ChangePasswordForm::create(
             $this,
@@ -200,7 +200,7 @@ class ChangePasswordHandler extends RequestHandler
      * @throws ValidationException
      * @throws NotFoundExceptionInterface
      */
-    public function doChangePassword(array $data, $form)
+    public function doChangePassword(array $data, SilverStripe\Security\MemberAuthenticator\ChangePasswordForm $form): SilverStripe\Control\HTTPResponse
     {
         $member = Security::getCurrentUser();
         // The user was logged in, check the current password
@@ -308,7 +308,7 @@ class ChangePasswordHandler extends RequestHandler
      *
      * @return HTTPResponse
      */
-    public function redirectBackToForm()
+    public function redirectBackToForm(): SilverStripe\Control\HTTPResponse
     {
         // Redirect back to form
         $url = $this->addBackURLParam(Security::singleton()->Link('changepassword'));
@@ -323,7 +323,7 @@ class ChangePasswordHandler extends RequestHandler
      * @param string $password
      * @return bool
      */
-    protected function checkPassword($member, $password)
+    protected function checkPassword(SilverStripe\Security\Member $member, string $password): bool
     {
         if (empty($password)) {
             return false;

--- a/src/Security/MemberAuthenticator/CookieAuthenticationHandler.php
+++ b/src/Security/MemberAuthenticator/CookieAuthenticationHandler.php
@@ -42,7 +42,7 @@ class CookieAuthenticationHandler implements AuthenticationHandler
      *
      * @return string
      */
-    public function getDeviceCookieName()
+    public function getDeviceCookieName(): string
     {
         return $this->deviceCookieName;
     }
@@ -53,7 +53,7 @@ class CookieAuthenticationHandler implements AuthenticationHandler
      * @param string $deviceCookieName
      * @return $this
      */
-    public function setDeviceCookieName($deviceCookieName)
+    public function setDeviceCookieName(string $deviceCookieName): SilverStripe\Security\MemberAuthenticator\CookieAuthenticationHandler
     {
         $this->deviceCookieName = $deviceCookieName;
         return $this;
@@ -64,7 +64,7 @@ class CookieAuthenticationHandler implements AuthenticationHandler
      *
      * @return string
      */
-    public function getTokenCookieName()
+    public function getTokenCookieName(): string
     {
         return $this->tokenCookieName;
     }
@@ -75,7 +75,7 @@ class CookieAuthenticationHandler implements AuthenticationHandler
      * @param string $tokenCookieName
      * @return $this
      */
-    public function setTokenCookieName($tokenCookieName)
+    public function setTokenCookieName(string $tokenCookieName): SilverStripe\Security\MemberAuthenticator\CookieAuthenticationHandler
     {
         $this->tokenCookieName = $tokenCookieName;
         return $this;
@@ -86,7 +86,7 @@ class CookieAuthenticationHandler implements AuthenticationHandler
      *
      * @return string
      */
-    public function getTokenCookieSecure()
+    public function getTokenCookieSecure(): bool
     {
         return $this->tokenCookieSecure;
     }
@@ -119,7 +119,7 @@ class CookieAuthenticationHandler implements AuthenticationHandler
      * @param IdentityStore $cascadeInTo
      * @return $this
      */
-    public function setCascadeInTo(IdentityStore $cascadeInTo)
+    public function setCascadeInTo(IdentityStore $cascadeInTo): SilverStripe\Security\MemberAuthenticator\CookieAuthenticationHandler
     {
         $this->cascadeInTo = $cascadeInTo;
         return $this;
@@ -129,7 +129,7 @@ class CookieAuthenticationHandler implements AuthenticationHandler
      * @param HTTPRequest $request
      * @return Member
      */
-    public function authenticateRequest(HTTPRequest $request)
+    public function authenticateRequest(HTTPRequest $request): null|SilverStripe\Security\Member
     {
         $uidAndToken = Cookie::get($this->getTokenCookieName());
         $deviceID = Cookie::get($this->getDeviceCookieName());
@@ -204,7 +204,7 @@ class CookieAuthenticationHandler implements AuthenticationHandler
      * @param bool $persistent
      * @param HTTPRequest $request
      */
-    public function logIn(Member $member, $persistent = false, HTTPRequest $request = null)
+    public function logIn(Member $member, bool $persistent = false, HTTPRequest $request = null): void
     {
         // Cleans up any potential previous hash for this member on this device
         if ($alcDevice = Cookie::get($this->getDeviceCookieName())) {
@@ -244,7 +244,7 @@ class CookieAuthenticationHandler implements AuthenticationHandler
     /**
      * @param HTTPRequest $request
      */
-    public function logOut(HTTPRequest $request = null)
+    public function logOut(HTTPRequest $request = null): void
     {
         $member = Security::getCurrentUser();
         if ($member) {
@@ -262,7 +262,7 @@ class CookieAuthenticationHandler implements AuthenticationHandler
     /**
      * Clear the cookies set for the user
      */
-    protected function clearCookies()
+    protected function clearCookies(): void
     {
         $secure = $this->getTokenCookieSecure();
         Cookie::set($this->getTokenCookieName(), null, null, null, null, $secure);

--- a/src/Security/MemberAuthenticator/LoginHandler.php
+++ b/src/Security/MemberAuthenticator/LoginHandler.php
@@ -52,7 +52,7 @@ class LoginHandler extends RequestHandler
      * @param string $link The URL to recreate this request handler
      * @param MemberAuthenticator $authenticator The authenticator to use
      */
-    public function __construct($link, MemberAuthenticator $authenticator)
+    public function __construct(string $link, MemberAuthenticator $authenticator): void
     {
         $this->link = $link;
         $this->authenticator = $authenticator;
@@ -66,7 +66,7 @@ class LoginHandler extends RequestHandler
      * @param null|string $action
      * @return string
      */
-    public function Link($action = null)
+    public function Link(string $action = null): string
     {
         $link = Controller::join_links($this->link, $action);
         $this->extend('updateLink', $link, $action);
@@ -78,7 +78,7 @@ class LoginHandler extends RequestHandler
      *
      * @return array
      */
-    public function login()
+    public function login(): array
     {
         return [
             'Form' => $this->loginForm(),
@@ -91,7 +91,7 @@ class LoginHandler extends RequestHandler
      * @skipUpgrade
      * @return MemberLoginForm
      */
-    public function loginForm()
+    public function loginForm(): SilverStripe\Security\MemberAuthenticator\MemberLoginForm
     {
         return MemberLoginForm::create(
             $this,
@@ -110,7 +110,7 @@ class LoginHandler extends RequestHandler
      * @param HTTPRequest $request
      * @return HTTPResponse
      */
-    public function doLogin($data, MemberLoginForm $form, HTTPRequest $request)
+    public function doLogin(array $data, MemberLoginForm $form, HTTPRequest $request): SilverStripe\Control\HTTPResponse
     {
         $failureMessage = null;
 
@@ -152,7 +152,7 @@ class LoginHandler extends RequestHandler
         return $form->getRequestHandler()->redirectBackToForm();
     }
 
-    public function getReturnReferer()
+    public function getReturnReferer(): string
     {
         return $this->Link();
     }
@@ -171,7 +171,7 @@ class LoginHandler extends RequestHandler
      *
      * @return HTTPResponse
      */
-    protected function redirectAfterSuccessfulLogin()
+    protected function redirectAfterSuccessfulLogin(): SilverStripe\Control\HTTPResponse
     {
         $this
             ->getRequest()
@@ -220,7 +220,7 @@ class LoginHandler extends RequestHandler
      * @return Member Returns the member object on successful authentication
      *                or NULL on failure.
      */
-    public function checkLogin($data, HTTPRequest $request, ValidationResult &$result = null)
+    public function checkLogin(array $data, HTTPRequest $request, ValidationResult &$result = null): SilverStripe\Security\Member|null
     {
         $member = $this->authenticator->authenticate($data, $request, $result);
         if ($member instanceof Member) {
@@ -239,7 +239,7 @@ class LoginHandler extends RequestHandler
      * @return Member Returns the member object on successful authentication
      *                or NULL on failure.
      */
-    public function performLogin($member, $data, HTTPRequest $request)
+    public function performLogin(SilverStripe\Security\Member $member, array $data, HTTPRequest $request): SilverStripe\Security\Member
     {
         /** IdentityStore */
         $rememberMe = (isset($data['Remember']) && Security::config()->get('autologin_enabled'));
@@ -256,7 +256,7 @@ class LoginHandler extends RequestHandler
      * @skipUpgrade
      * @return HTTPResponse
      */
-    protected function redirectToChangePassword()
+    protected function redirectToChangePassword(): SilverStripe\Control\HTTPResponse
     {
         $cp = ChangePasswordForm::create($this, 'ChangePasswordForm');
         $cp->sessionMessage(

--- a/src/Security/MemberAuthenticator/LogoutHandler.php
+++ b/src/Security/MemberAuthenticator/LogoutHandler.php
@@ -48,7 +48,7 @@ class LogoutHandler extends RequestHandler
      *
      * @return array|HTTPResponse
      */
-    public function logout()
+    public function logout(): array|SilverStripe\Control\HTTPResponse
     {
         $member = Security::getCurrentUser();
 
@@ -74,7 +74,7 @@ class LogoutHandler extends RequestHandler
     /**
      * @return LogoutForm
      */
-    public function logoutForm()
+    public function logoutForm(): SilverStripe\Security\LogoutForm
     {
         return LogoutForm::create($this);
     }
@@ -83,7 +83,7 @@ class LogoutHandler extends RequestHandler
      * @param Member $member
      * @return HTTPResponse
      */
-    public function doLogOut($member)
+    public function doLogOut(SilverStripe\Security\Member $member): SilverStripe\Control\HTTPResponse
     {
         $this->extend('beforeLogout');
 
@@ -103,7 +103,7 @@ class LogoutHandler extends RequestHandler
     /**
      * @return HTTPResponse
      */
-    protected function redirectAfterLogout()
+    protected function redirectAfterLogout(): SilverStripe\Control\HTTPResponse
     {
         $backURL = $this->getBackURL();
         if ($backURL) {

--- a/src/Security/MemberAuthenticator/LostPasswordForm.php
+++ b/src/Security/MemberAuthenticator/LostPasswordForm.php
@@ -22,7 +22,7 @@ class LostPasswordForm extends MemberLoginForm
      * @skipUpgrade
      * @return FieldList
      */
-    public function getFormFields()
+    public function getFormFields(): SilverStripe\Forms\FieldList
     {
         return FieldList::create(
             EmailField::create('Email', _t('SilverStripe\\Security\\Member.EMAIL', 'Email'))
@@ -34,7 +34,7 @@ class LostPasswordForm extends MemberLoginForm
      *
      * @return FieldList
      */
-    public function getFormActions()
+    public function getFormActions(): SilverStripe\Forms\FieldList
     {
         return FieldList::create(
             FormAction::create(

--- a/src/Security/MemberAuthenticator/LostPasswordHandler.php
+++ b/src/Security/MemberAuthenticator/LostPasswordHandler.php
@@ -54,7 +54,7 @@ class LostPasswordHandler extends RequestHandler
     /**
      * @param string $link The URL to recreate this request handler
      */
-    public function __construct($link)
+    public function __construct(string $link): void
     {
         $this->link = $link;
         parent::__construct();
@@ -67,7 +67,7 @@ class LostPasswordHandler extends RequestHandler
      * @param string|null $action
      * @return string
      */
-    public function Link($action = null)
+    public function Link(string $action = null): string
     {
         $link = Controller::join_links($this->link, $action);
         $this->extend('updateLink', $link, $action);
@@ -79,7 +79,7 @@ class LostPasswordHandler extends RequestHandler
      *
      * @return array
      */
-    public function lostpassword()
+    public function lostpassword(): array
     {
 
         $message = _t(
@@ -99,7 +99,7 @@ class LostPasswordHandler extends RequestHandler
      *
      * @return array
      */
-    public function passwordsent()
+    public function passwordsent(): array
     {
         $message = _t(
             'SilverStripe\\Security\\Security.PASSWORDRESETSENTTEXT',
@@ -122,7 +122,7 @@ class LostPasswordHandler extends RequestHandler
      * @skipUpgrade
      * @return Form Returns the lost password form
      */
-    public function lostPasswordForm()
+    public function lostPasswordForm(): SilverStripe\Security\MemberAuthenticator\LostPasswordForm
     {
         return LostPasswordForm::create(
             $this,
@@ -159,7 +159,7 @@ class LostPasswordHandler extends RequestHandler
      * @param LostPasswordForm $form
      * @return HTTPResponse
      */
-    public function forgotPassword($data, $form)
+    public function forgotPassword(array $data, SilverStripe\Security\MemberAuthenticator\LostPasswordForm $form): SilverStripe\Control\HTTPResponse
     {
         // Run a first pass validation check on the data
         $dataValidation = $this->validateForgotPasswordData($data, $form);
@@ -194,7 +194,7 @@ class LostPasswordHandler extends RequestHandler
      * @param  LostPasswordForm $form
      * @return HTTPResponse|null
      */
-    protected function validateForgotPasswordData(array $data, LostPasswordForm $form)
+    protected function validateForgotPasswordData(array $data, LostPasswordForm $form): void
     {
         if (empty($data['Email'])) {
             $form->sessionMessage(
@@ -215,7 +215,7 @@ class LostPasswordHandler extends RequestHandler
      * @param  array $data
      * @return Member|null
      */
-    protected function getMemberFromData(array $data)
+    protected function getMemberFromData(array $data): SilverStripe\Security\Member
     {
         if (!empty($data['Email'])) {
             $uniqueIdentifier = Member::config()->get('unique_identifier_field');
@@ -229,7 +229,7 @@ class LostPasswordHandler extends RequestHandler
      * @param string $token
      * @return bool
      */
-    protected function sendEmail($member, $token)
+    protected function sendEmail(SilverStripe\Security\Member $member, string $token): bool
     {
         /** @var Email $email */
         $email = Email::create()
@@ -253,7 +253,7 @@ class LostPasswordHandler extends RequestHandler
      * @param array $data
      * @return HTTPResponse
      */
-    protected function redirectToSuccess(array $data)
+    protected function redirectToSuccess(array $data): SilverStripe\Control\HTTPResponse
     {
         $link = $this->link('passwordsent');
 

--- a/src/Security/MemberAuthenticator/MemberAuthenticator.php
+++ b/src/Security/MemberAuthenticator/MemberAuthenticator.php
@@ -24,14 +24,14 @@ class MemberAuthenticator implements Authenticator
 {
     use Extensible;
 
-    public function supportedServices()
+    public function supportedServices(): int
     {
         // Bitwise-OR of all the supported services in this Authenticator, to make a bitmask
         return Authenticator::LOGIN | Authenticator::LOGOUT | Authenticator::CHANGE_PASSWORD
             | Authenticator::RESET_PASSWORD | Authenticator::CHECK_PASSWORD;
     }
 
-    public function authenticate(array $data, HTTPRequest $request, ValidationResult &$result = null)
+    public function authenticate(array $data, HTTPRequest $request, ValidationResult &$result = null): SilverStripe\Security\Member|null
     {
         // Find authenticated member
         if (class_exists(Versioned::class)) {
@@ -63,7 +63,7 @@ class MemberAuthenticator implements Authenticator
      * @param Member $member This third parameter is used in the CMSAuthenticator(s)
      * @return Member Found member, regardless of successful login
      */
-    protected function authenticateMember($data, ValidationResult &$result = null, Member $member = null)
+    protected function authenticateMember(array $data, ValidationResult &$result = null, Member $member = null): SilverStripe\Security\Member|null
     {
         $email = !empty($data['Email']) ? $data['Email'] : null;
         $result = $result ?: ValidationResult::create();
@@ -137,7 +137,7 @@ class MemberAuthenticator implements Authenticator
      * @param ValidationResult $result
      * @return ValidationResult
      */
-    public function checkPassword(Member $member, $password, ValidationResult &$result = null)
+    public function checkPassword(Member $member, string $password, ValidationResult &$result = null): SilverStripe\ORM\ValidationResult
     {
         // Check if allowed to login
         $result = $member->validateCanLogin($result);
@@ -177,7 +177,7 @@ class MemberAuthenticator implements Authenticator
      * @param boolean $success
      * @return LoginAttempt|null
      */
-    protected function recordLoginAttempt($data, HTTPRequest $request, $member, $success)
+    protected function recordLoginAttempt(array $data, HTTPRequest $request, SilverStripe\Security\Member $member, bool $success): SilverStripe\Security\LoginAttempt
     {
         if (!Security::config()->get('login_recording')
             && !Member::config()->get('lock_out_after_incorrect_logins')
@@ -228,7 +228,7 @@ class MemberAuthenticator implements Authenticator
      * @param string $link
      * @return LostPasswordHandler
      */
-    public function getLostPasswordHandler($link)
+    public function getLostPasswordHandler(string $link): SilverStripe\Security\MemberAuthenticator\LostPasswordHandler
     {
         return LostPasswordHandler::create($link, $this);
     }
@@ -237,7 +237,7 @@ class MemberAuthenticator implements Authenticator
      * @param string $link
      * @return ChangePasswordHandler
      */
-    public function getChangePasswordHandler($link)
+    public function getChangePasswordHandler(string $link): SilverStripe\Security\MemberAuthenticator\ChangePasswordHandler
     {
         return ChangePasswordHandler::create($link, $this);
     }
@@ -246,7 +246,7 @@ class MemberAuthenticator implements Authenticator
      * @param string $link
      * @return LoginHandler
      */
-    public function getLoginHandler($link)
+    public function getLoginHandler(string $link): SilverStripe\Security\MemberAuthenticator\LoginHandler
     {
         return LoginHandler::create($link, $this);
     }
@@ -255,7 +255,7 @@ class MemberAuthenticator implements Authenticator
      * @param string $link
      * @return LogoutHandler
      */
-    public function getLogoutHandler($link)
+    public function getLogoutHandler(string $link): SilverStripe\Security\MemberAuthenticator\LogoutHandler
     {
         return LogoutHandler::create($link, $this);
     }

--- a/src/Security/MemberAuthenticator/MemberLoginForm.php
+++ b/src/Security/MemberAuthenticator/MemberLoginForm.php
@@ -69,13 +69,13 @@ class MemberLoginForm extends BaseLoginForm
      *                               so, only a logout button will be rendered
      */
     public function __construct(
-        $controller,
+        SilverStripe\MFA\Authenticator\LoginHandler $controller,
         $authenticatorClass,
         $name,
         $fields = null,
         $actions = null,
         $checkCurrentUser = true
-    ) {
+    ): void {
         $this->setController($controller);
         $this->setAuthenticatorClass($authenticatorClass);
 
@@ -122,7 +122,7 @@ class MemberLoginForm extends BaseLoginForm
      * @skipUpgrade
      * @return FieldList
      */
-    protected function getFormFields()
+    protected function getFormFields(): SilverStripe\Forms\FieldList
     {
         $request = $this->getRequest();
         if ($request->getVar('BackURL')) {
@@ -182,7 +182,7 @@ class MemberLoginForm extends BaseLoginForm
      *
      * @return FieldList
      */
-    protected function getFormActions()
+    protected function getFormActions(): SilverStripe\Forms\FieldList
     {
         $actions = FieldList::create(
             FormAction::create('doLogin', _t('SilverStripe\\Security\\Member.BUTTONLOGIN', "Log in")),
@@ -198,7 +198,7 @@ class MemberLoginForm extends BaseLoginForm
 
 
 
-    public function restoreFormState()
+    public function restoreFormState(): SilverStripe\Security\MemberAuthenticator\MemberLoginForm
     {
         parent::restoreFormState();
 

--- a/src/Security/MemberAuthenticator/SessionAuthenticationHandler.php
+++ b/src/Security/MemberAuthenticator/SessionAuthenticationHandler.php
@@ -24,7 +24,7 @@ class SessionAuthenticationHandler implements AuthenticationHandler
      *
      * @return string
      */
-    public function getSessionVariable()
+    public function getSessionVariable(): string|null
     {
         return $this->sessionVariable;
     }
@@ -34,7 +34,7 @@ class SessionAuthenticationHandler implements AuthenticationHandler
      *
      * @param string $sessionVariable
      */
-    public function setSessionVariable($sessionVariable)
+    public function setSessionVariable(string $sessionVariable): void
     {
         $this->sessionVariable = $sessionVariable;
     }
@@ -43,7 +43,7 @@ class SessionAuthenticationHandler implements AuthenticationHandler
      * @param HTTPRequest $request
      * @return Member
      */
-    public function authenticateRequest(HTTPRequest $request)
+    public function authenticateRequest(HTTPRequest $request): null|SilverStripe\Security\Member
     {
         $session = $request->getSession();
 
@@ -68,7 +68,7 @@ class SessionAuthenticationHandler implements AuthenticationHandler
      * @param bool $persistent
      * @param HTTPRequest $request
      */
-    public function logIn(Member $member, $persistent = false, HTTPRequest $request = null)
+    public function logIn(Member $member, bool $persistent = false, HTTPRequest $request = null): void
     {
         static::regenerateSessionId();
         $request = $request ?: Controller::curr()->getRequest();
@@ -84,7 +84,7 @@ class SessionAuthenticationHandler implements AuthenticationHandler
     /**
      * Regenerate the session_id.
      */
-    protected static function regenerateSessionId()
+    protected static function regenerateSessionId(): void
     {
         if (!Member::config()->get('session_regenerate_id')) {
             return;
@@ -109,7 +109,7 @@ class SessionAuthenticationHandler implements AuthenticationHandler
     /**
      * @param HTTPRequest $request
      */
-    public function logOut(HTTPRequest $request = null)
+    public function logOut(HTTPRequest $request = null): void
     {
         $request = $request ?: Controller::curr()->getRequest();
         $request->getSession()->destroy(true, $request);

--- a/src/Security/MemberCsvBulkLoader.php
+++ b/src/Security/MemberCsvBulkLoader.php
@@ -19,7 +19,7 @@ class MemberCsvBulkLoader extends CsvBulkLoader
      */
     protected $groups = [];
 
-    public function __construct($objectClass = null)
+    public function __construct($objectClass = null): void
     {
         if (!$objectClass) {
             $objectClass = 'SilverStripe\\Security\\Member';
@@ -36,7 +36,7 @@ class MemberCsvBulkLoader extends CsvBulkLoader
         'Email' => 'Email',
     ];
 
-    public function processRecord($record, $columnMap, &$results, $preview = false)
+    public function processRecord(array $record, array $columnMap, &$results, bool $preview = false): int
     {
         $objID = parent::processRecord($record, $columnMap, $results, $preview);
 
@@ -78,7 +78,7 @@ class MemberCsvBulkLoader extends CsvBulkLoader
     /**
      * @param array $groups
      */
-    public function setGroups($groups)
+    public function setGroups(array $groups): void
     {
         $this->groups = $groups;
     }

--- a/src/Security/MemberPassword.php
+++ b/src/Security/MemberPassword.php
@@ -33,7 +33,7 @@ class MemberPassword extends DataObject
      *
      * @param Member $member
      */
-    public static function log($member)
+    public static function log(SilverStripe\Security\Member $member): void
     {
         $record = new MemberPassword();
         $record->MemberID = $member->ID;
@@ -50,7 +50,7 @@ class MemberPassword extends DataObject
      * @param string $password Cleartext password
      * @return bool
      */
-    public function checkPassword($password)
+    public function checkPassword(string $password): bool
     {
         $encryptor = PasswordEncryptor::create_for_algorithm($this->PasswordEncryption);
         return $encryptor->check($this->Password ?? '', $password, $this->Salt, $this->Member());

--- a/src/Security/Member_GroupSet.php
+++ b/src/Security/Member_GroupSet.php
@@ -15,7 +15,7 @@ use SilverStripe\ORM\Queries\SQLSelect;
 class Member_GroupSet extends ManyManyList
 {
 
-    protected function linkJoinTable()
+    protected function linkJoinTable(): void
     {
         // Do not join the table directly
         if ($this->extraFields) {
@@ -33,7 +33,7 @@ class Member_GroupSet extends ManyManyList
      * ids as per getForeignID
      * @return array Condition In array(SQL => parameters format)
      */
-    public function foreignIDFilter($id = null)
+    public function foreignIDFilter(int $id = null): array
     {
         if ($id === null) {
             $id = $this->getForeignID();
@@ -61,14 +61,14 @@ class Member_GroupSet extends ManyManyList
         return ['"Group"."ID"' => 0];
     }
 
-    public function foreignIDWriteFilter($id = null)
+    public function foreignIDWriteFilter(int $id = null): array
     {
         // Use the ManyManyList::foreignIDFilter rather than the one
         // in this class, otherwise we end up selecting all inherited groups
         return parent::foreignIDFilter($id);
     }
 
-    public function add($item, $extraFields = null)
+    public function add(SilverStripe\Security\Group|int $item, $extraFields = null): void
     {
         // Get Group.ID
         $itemID = null;
@@ -86,7 +86,7 @@ class Member_GroupSet extends ManyManyList
         }
     }
 
-    public function removeAll()
+    public function removeAll(): void
     {
         // Remove the join to the join table to avoid MySQL row locking issues.
         $query = $this->dataQuery();
@@ -122,7 +122,7 @@ class Member_GroupSet extends ManyManyList
      * @param array $itemIDs
      * @return boolean
      */
-    protected function canAddGroups($itemIDs)
+    protected function canAddGroups(array $itemIDs): bool
     {
         if (empty($itemIDs)) {
             return true;
@@ -136,7 +136,7 @@ class Member_GroupSet extends ManyManyList
      *
      * @return Member
      */
-    protected function getMember()
+    protected function getMember(): SilverStripe\Security\Member
     {
         $id = $this->getForeignID();
         if ($id) {

--- a/src/Security/Member_Validator.php
+++ b/src/Security/Member_Validator.php
@@ -44,7 +44,7 @@ class Member_Validator extends RequiredFields
     /**
      * Constructor
      */
-    public function __construct()
+    public function __construct(): void
     {
         $required = func_get_args();
 
@@ -67,7 +67,7 @@ class Member_Validator extends RequiredFields
      * Get the member this validator applies to.
      * @return Member
      */
-    public function getForMember()
+    public function getForMember(): SilverStripe\Security\Member|null
     {
         return $this->forMember;
     }
@@ -77,7 +77,7 @@ class Member_Validator extends RequiredFields
      * @param Member $value
      * @return $this
      */
-    public function setForMember(Member $value)
+    public function setForMember(Member $value): SilverStripe\Security\Member_Validator
     {
         $this->forMember = $value;
         return $this;
@@ -93,7 +93,7 @@ class Member_Validator extends RequiredFields
      * @return bool Returns TRUE if the submitted data is valid, otherwise
      *              FALSE.
      */
-    public function php($data)
+    public function php(array $data): bool
     {
         $valid = parent::php($data);
 

--- a/src/Security/NullSecurityToken.php
+++ b/src/Security/NullSecurityToken.php
@@ -16,7 +16,7 @@ class NullSecurityToken extends SecurityToken
      * @param string $compare
      * @return bool
      */
-    public function check($compare)
+    public function check(string $compare): bool
     {
         return true;
     }
@@ -25,7 +25,7 @@ class NullSecurityToken extends SecurityToken
      * @param HTTPRequest $request
      * @return Boolean
      */
-    public function checkRequest($request)
+    public function checkRequest(SilverStripe\Control\HTTPRequest $request): bool
     {
         return true;
     }
@@ -34,7 +34,7 @@ class NullSecurityToken extends SecurityToken
      * @param FieldList $fieldset
      * @return false
      */
-    public function updateFieldSet(&$fieldset)
+    public function updateFieldSet(SilverStripe\Forms\FieldList &$fieldset): bool
     {
         // Remove, in case it was added beforehand
         $fieldset->removeByName($this->getName());
@@ -46,7 +46,7 @@ class NullSecurityToken extends SecurityToken
      * @param string $url
      * @return string
      */
-    public function addToUrl($url)
+    public function addToUrl(string $url): string
     {
         return $url;
     }
@@ -54,7 +54,7 @@ class NullSecurityToken extends SecurityToken
     /**
      * @return string
      */
-    public function getValue()
+    public function getValue(): null
     {
         return null;
     }

--- a/src/Security/PasswordEncryptor.php
+++ b/src/Security/PasswordEncryptor.php
@@ -26,7 +26,7 @@ abstract class PasswordEncryptor
     /**
      * @return array Map of encryptor code to the used class.
      */
-    public static function get_encryptors()
+    public static function get_encryptors(): array
     {
         return Config::inst()->get(self::class, 'encryptors');
     }
@@ -36,7 +36,7 @@ abstract class PasswordEncryptor
      * @return PasswordEncryptor
      * @throws PasswordEncryptor_NotFoundException
      */
-    public static function create_for_algorithm($algorithm)
+    public static function create_for_algorithm(string $algorithm): CWP\Core\PasswordEncryptor\PBKDF2
     {
         $encryptors = self::get_encryptors();
         if (!isset($encryptors[$algorithm])) {
@@ -81,7 +81,7 @@ abstract class PasswordEncryptor
      * @param Member $member (Optional)
      * @return string Maximum of 50 characters
      */
-    public function salt($password, $member = null)
+    public function salt(string $password, $member = null): string
     {
         $generator = new RandomGenerator();
         return substr($generator->randomToken('sha1') ?? '', 0, 50);
@@ -99,7 +99,7 @@ abstract class PasswordEncryptor
      * @param Member $member
      * @return bool
      */
-    public function check($hash, $password, $salt = null, $member = null)
+    public function check(string $hash, string $password, string $salt = null, SilverStripe\Security\Member $member = null): bool
     {
         return hash_equals($hash ?? '', $this->encrypt($password, $salt, $member) ?? '');
     }

--- a/src/Security/PasswordEncryptor_Blowfish.php
+++ b/src/Security/PasswordEncryptor_Blowfish.php
@@ -28,7 +28,7 @@ class PasswordEncryptor_Blowfish extends PasswordEncryptor
      *
      * @param int $cost range 4-31
      */
-    public static function set_cost($cost)
+    public static function set_cost(int $cost): void
     {
         self::$cost = max(min(31, $cost), 4);
     }
@@ -38,12 +38,12 @@ class PasswordEncryptor_Blowfish extends PasswordEncryptor
      *
      * @return int
      */
-    public static function get_cost()
+    public static function get_cost(): int
     {
         return self::$cost;
     }
 
-    public function encrypt($password, $salt = null, $member = null)
+    public function encrypt(string $password, string $salt = null, SilverStripe\Security\Member $member = null): string
     {
         // See: http://nz.php.net/security/crypt_blowfish.php
         // There are three version of the algorithm - y, a and x, in order
@@ -88,7 +88,7 @@ class PasswordEncryptor_Blowfish extends PasswordEncryptor
         return false;
     }
 
-    public function encryptY($password, $salt)
+    public function encryptY(string $password, string $salt): string
     {
         $methodAndSalt = '$2y$' . $salt;
         $encryptedPassword = crypt($password ?? '', $methodAndSalt ?? '');
@@ -131,7 +131,7 @@ class PasswordEncryptor_Blowfish extends PasswordEncryptor
      * version, depending on the version of PHP and the operating system,
      * so we need to test it.
      */
-    public function checkAEncryptionLevel()
+    public function checkAEncryptionLevel(): string
     {
         // Test hashes taken from
         // http://cvsweb.openwall.com/cgi/cvsweb.cgi/~checkout~/Owl/packages/glibc
@@ -159,13 +159,13 @@ class PasswordEncryptor_Blowfish extends PasswordEncryptor
      * @param Member $member
      * @return string
      */
-    public function salt($password, $member = null)
+    public function salt(string $password, $member = null): string
     {
         $generator = new RandomGenerator();
         return sprintf('%02d', self::$cost) . '$' . substr($generator->randomToken('sha1') ?? '', 0, 22);
     }
 
-    public function check($hash, $password, $salt = null, $member = null)
+    public function check(string $hash, string $password, string $salt = null, $member = null): bool
     {
         if (strpos($hash ?? '', '$2y$') === 0) {
             return $hash === $this->encryptY($password, $salt);

--- a/src/Security/PasswordEncryptor_LegacyPHPHash.php
+++ b/src/Security/PasswordEncryptor_LegacyPHPHash.php
@@ -11,7 +11,7 @@ namespace SilverStripe\Security;
  */
 class PasswordEncryptor_LegacyPHPHash extends PasswordEncryptor_PHPHash
 {
-    public function encrypt($password, $salt = null, $member = null)
+    public function encrypt(string $password, string $salt = null, SilverStripe\Security\Member $member = null): string
     {
         $password = parent::encrypt($password, $salt, $member);
 
@@ -23,7 +23,7 @@ class PasswordEncryptor_LegacyPHPHash extends PasswordEncryptor_PHPHash
         return substr(base_convert($password ?? '', 16, 36), 0, 64);
     }
 
-    public function check($hash, $password, $salt = null, $member = null)
+    public function check(string $hash, string $password, string $salt = null, SilverStripe\Security\Member $member = null): bool
     {
         // Due to flawed base_convert() floating point precision,
         // only the first 10 characters are consistently useful for comparisons.

--- a/src/Security/PasswordEncryptor_None.php
+++ b/src/Security/PasswordEncryptor_None.php
@@ -9,12 +9,12 @@ namespace SilverStripe\Security;
  */
 class PasswordEncryptor_None extends PasswordEncryptor
 {
-    public function encrypt($password, $salt = null, $member = null)
+    public function encrypt(string $password, bool $salt = null, SilverStripe\Security\Member $member = null): string|null
     {
         return $password;
     }
 
-    public function salt($password, $member = null)
+    public function salt(string $password, $member = null): bool
     {
         return false;
     }

--- a/src/Security/PasswordEncryptor_PHPHash.php
+++ b/src/Security/PasswordEncryptor_PHPHash.php
@@ -18,7 +18,7 @@ class PasswordEncryptor_PHPHash extends PasswordEncryptor
      * @param string $algorithm A PHP built-in hashing algorithm as defined by hash_algos()
      * @throws Exception
      */
-    public function __construct($algorithm)
+    public function __construct(string $algorithm): void
     {
         if (!in_array($algorithm, hash_algos())) {
             throw new Exception(
@@ -32,12 +32,12 @@ class PasswordEncryptor_PHPHash extends PasswordEncryptor
     /**
      * @return string
      */
-    public function getAlgorithm()
+    public function getAlgorithm(): string
     {
         return $this->algorithm;
     }
 
-    public function encrypt($password, $salt = null, $member = null)
+    public function encrypt(string $password, string $salt = null, SilverStripe\Security\Member $member = null): string
     {
         return hash($this->algorithm ?? '', $password . $salt);
     }

--- a/src/Security/PasswordValidator.php
+++ b/src/Security/PasswordValidator.php
@@ -127,7 +127,7 @@ class PasswordValidator
     /**
      * @return int
      */
-    public function getMinLength()
+    public function getMinLength(): int|null
     {
         if ($this->minLength !== null) {
             return $this->minLength;
@@ -139,7 +139,7 @@ class PasswordValidator
      * @param int $minLength
      * @return $this
      */
-    public function setMinLength($minLength)
+    public function setMinLength(int $minLength): SilverStripe\Security\PasswordValidator
     {
         $this->minLength = $minLength;
         return $this;
@@ -148,7 +148,7 @@ class PasswordValidator
     /**
      * @return integer
      */
-    public function getMinTestScore()
+    public function getMinTestScore(): int
     {
         if ($this->minScore !== null) {
             return $this->minScore;
@@ -160,7 +160,7 @@ class PasswordValidator
      * @param int $minScore
      * @return $this
      */
-    public function setMinTestScore($minScore)
+    public function setMinTestScore(int $minScore): SilverStripe\Security\PasswordValidator
     {
         $this->minScore = $minScore;
         return $this;
@@ -171,7 +171,7 @@ class PasswordValidator
      *
      * @return string[]
      */
-    public function getTestNames()
+    public function getTestNames(): array
     {
         if ($this->testNames !== null) {
             return $this->testNames;
@@ -185,7 +185,7 @@ class PasswordValidator
      * @param string[] $testNames
      * @return $this
      */
-    public function setTestNames($testNames)
+    public function setTestNames(array $testNames): SilverStripe\Security\PasswordValidator
     {
         $this->testNames = $testNames;
         return $this;
@@ -194,7 +194,7 @@ class PasswordValidator
     /**
      * @return int
      */
-    public function getHistoricCount()
+    public function getHistoricCount(): int|null
     {
         if ($this->historicalPasswordCount !== null) {
             return $this->historicalPasswordCount;
@@ -206,7 +206,7 @@ class PasswordValidator
      * @param int $count
      * @return $this
      */
-    public function setHistoricCount($count)
+    public function setHistoricCount(int $count): SilverStripe\Security\PasswordValidator
     {
         $this->historicalPasswordCount = $count;
         return $this;
@@ -217,7 +217,7 @@ class PasswordValidator
      *
      * @return array
      */
-    public function getTests()
+    public function getTests(): array
     {
         return $this->config()->get('character_strength_tests');
     }
@@ -227,7 +227,7 @@ class PasswordValidator
      * @param Member $member
      * @return ValidationResult
      */
-    public function validate($password, $member)
+    public function validate(string $password, SilverStripe\Security\Member $member): SilverStripe\ORM\ValidationResult
     {
         $valid = ValidationResult::create();
 

--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -130,7 +130,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      *  exists; FALSE otherwise. If "strict" checking is
      *  disabled, TRUE will be returned if the permission does not exist at all.
      */
-    public static function check($code, $arg = "any", $member = null, $strict = true)
+    public static function check(string|array $code, string $arg = "any", int|SilverStripe\Security\Member $member = null, $strict = true): bool
     {
         if (!$member) {
             if (!Security::getCurrentUser()) {
@@ -152,7 +152,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      * Flush the permission cache, for example if you have edited group membership or a permission record.
      * @todo Call this whenever Group_Members is added to or removed from
      */
-    public static function reset()
+    public static function reset(): void
     {
         self::$cache_permissions = [];
     }
@@ -170,7 +170,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      *  exists; FALSE otherwise. If "strict" checking is
      *  disabled, TRUE will be returned if the permission does not exist at all.
      */
-    public static function checkMember($member, $code, $arg = "any", $strict = true)
+    public static function checkMember(int|SilverStripe\Security\Member $member, string|array $code, string $arg = "any", bool $strict = true): bool
     {
         if (!$member) {
             $member = Security::getCurrentUser();
@@ -299,7 +299,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      * @param int $memberID
      * @return array
      */
-    public static function permissions_for_member($memberID)
+    public static function permissions_for_member(int $memberID): array
     {
         $groupList = self::groupList($memberID);
 
@@ -344,7 +344,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      * @return array Returns a list of group IDs to which the member belongs
      *               to or NULL.
      */
-    public static function groupList($memberID = null)
+    public static function groupList(int $memberID = null): array|null
     {
         // Default to current member, with session-caching
         if (!$memberID) {
@@ -390,7 +390,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      * @param string $arg Optional: The permission argument (e.g. a page ID).
      * @returns Permission Returns the new permission object.
      */
-    public static function grant($groupID, $code, $arg = "any")
+    public static function grant(int $groupID, string $code, $arg = "any"): SilverStripe\Security\Permission
     {
         $perm = new Permission();
         $perm->GroupID = $groupID;
@@ -425,7 +425,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      * @param string $arg Optional: The permission argument (e.g. a page ID).
      * @returns Permission Returns the new permission object.
      */
-    public static function deny($groupID, $code, $arg = "any")
+    public static function deny(int $groupID, string $code, $arg = "any"): SilverStripe\Security\Permission
     {
         $perm = new Permission();
         $perm->GroupID = $groupID;
@@ -458,7 +458,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      * @return SS_List Returns a set of member that have the specified
      *                       permission.
      */
-    public static function get_members_by_permission($code)
+    public static function get_members_by_permission(array|string $code): SilverStripe\ORM\DataList
     {
         $toplevelGroups = self::get_groups_by_permission($code);
         if (!$toplevelGroups) {
@@ -492,7 +492,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      * @param array|string $codes Either a single permission code, or an array of permission codes
      * @return SS_List The matching group objects
      */
-    public static function get_groups_by_permission($codes)
+    public static function get_groups_by_permission(string|array $codes): SilverStripe\ORM\DataList
     {
         $codeParams = is_array($codes) ? $codes : [$codes];
         $codeClause = DB::placeholders($codeParams);
@@ -523,7 +523,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      *  {@link Permission::check()}. The value is a description
      *  suitable for using in an interface.
      */
-    public static function get_codes($grouped = true)
+    public static function get_codes(bool $grouped = true): array
     {
         $classes = ClassInfo::implementorsOf('SilverStripe\\Security\\PermissionProvider');
 
@@ -631,7 +631,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      * @param array $b
      * @return int
      */
-    public static function sort_permissions($a, $b)
+    public static function sort_permissions(array $a, array $b): int
     {
         if ($a['sort'] == $b['sort']) {
             // Same sort value, do alpha instead
@@ -706,7 +706,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
         }
     }
 
-    public function onBeforeWrite()
+    public function onBeforeWrite(): void
     {
         parent::onBeforeWrite();
 
@@ -714,7 +714,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
         Permission::reset();
     }
 
-    public static function get_template_global_variables()
+    public static function get_template_global_variables(): array
     {
         return [
             'HasPerm' => 'check'

--- a/src/Security/PermissionCheckboxSetField.php
+++ b/src/Security/PermissionCheckboxSetField.php
@@ -48,7 +48,7 @@ class PermissionCheckboxSetField extends FormField
      *  Caution: saveInto() can only be used with a single record, all inherited permissions will be marked readonly.
      *  Setting multiple groups only makes sense in a readonly context. (Optional)
      */
-    public function __construct($name, $title, $managedClass, $filterField, $records = null)
+    public function __construct(string $name, bool|string $title, string $managedClass, string $filterField, SilverStripe\Security\Group $records = null): void
     {
         $this->filterField = $filterField;
         $this->managedClass = $managedClass;
@@ -72,7 +72,7 @@ class PermissionCheckboxSetField extends FormField
     /**
      * @param array $codes
      */
-    public function setHiddenPermissions($codes)
+    public function setHiddenPermissions(array $codes): void
     {
         $this->hiddenPermissions = $codes;
     }
@@ -80,7 +80,7 @@ class PermissionCheckboxSetField extends FormField
     /**
      * @return array
      */
-    public function getHiddenPermissions()
+    public function getHiddenPermissions(): array
     {
         return $this->hiddenPermissions;
     }
@@ -89,7 +89,7 @@ class PermissionCheckboxSetField extends FormField
      * @param array $properties
      * @return string
      */
-    public function Field($properties = [])
+    public function Field($properties = []): string
     {
         $uninheritedCodes = [];
         $inheritedCodes = [];
@@ -292,7 +292,7 @@ class PermissionCheckboxSetField extends FormField
      *
      * @param DataObjectInterface $record
      */
-    public function saveInto(DataObjectInterface $record)
+    public function saveInto(DataObjectInterface $record): void
     {
         $fieldname = $this->name;
         $managedClass = $this->managedClass;

--- a/src/Security/PermissionRole.php
+++ b/src/Security/PermissionRole.php
@@ -69,7 +69,7 @@ class PermissionRole extends DataObject
         return $fields;
     }
 
-    public function onAfterDelete()
+    public function onAfterDelete(): void
     {
         parent::onAfterDelete();
 
@@ -80,7 +80,7 @@ class PermissionRole extends DataObject
         }
     }
 
-    public function fieldLabels($includerelations = true)
+    public function fieldLabels(bool $includerelations = true): array
     {
         $labels = parent::fieldLabels($includerelations);
         $labels['Title'] = _t('SilverStripe\\Security\\PermissionRole.Title', 'Title');
@@ -93,12 +93,12 @@ class PermissionRole extends DataObject
         return $labels;
     }
 
-    public function canView($member = null)
+    public function canView($member = null): bool
     {
         return Permission::check('APPLY_ROLES', 'any', $member);
     }
 
-    public function canCreate($member = null, $context = [])
+    public function canCreate($member = null, array $context = []): bool
     {
         return Permission::check('APPLY_ROLES', 'any', $member);
     }

--- a/src/Security/PermissionRoleCode.php
+++ b/src/Security/PermissionRoleCode.php
@@ -28,7 +28,7 @@ class PermissionRoleCode extends DataObject
         "Code" => true,
     ];
 
-    public function validate()
+    public function validate(): SilverStripe\ORM\ValidationResult
     {
         $result = parent::validate();
 

--- a/src/Security/RandomGenerator.php
+++ b/src/Security/RandomGenerator.php
@@ -16,7 +16,7 @@ class RandomGenerator
      * @throws Exception If no suitable CSPRNG is installed
      * @deprecated 4.4.0:5.0.0
      */
-    public function generateEntropy()
+    public function generateEntropy(): string
     {
         Deprecation::notice('4.4', __METHOD__ . ' has been deprecated. Use random_bytes instead');
 
@@ -44,7 +44,7 @@ class RandomGenerator
      * @return string Returned length will depend on the used $algorithm
      * @throws Exception When there is no valid source of CSPRNG
      */
-    public function randomToken($algorithm = 'whirlpool')
+    public function randomToken(string $algorithm = 'whirlpool'): string
     {
         return hash($algorithm ?? '', random_bytes(64));
     }

--- a/src/Security/RememberLoginHash.php
+++ b/src/Security/RememberLoginHash.php
@@ -120,12 +120,12 @@ class RememberLoginHash extends DataObject
         static::$logoutAcrossDevices = $value;
     }
 
-    public function getToken()
+    public function getToken(): string
     {
         return $this->token;
     }
 
-    public function setToken($token)
+    public function setToken(string $token): void
     {
         $this->token = $token;
     }
@@ -134,7 +134,7 @@ class RememberLoginHash extends DataObject
      * Randomly generates a new ID used for the device
      * @return string A device ID
      */
-    protected function getNewDeviceID()
+    protected function getNewDeviceID(): string
     {
         $generator = new RandomGenerator();
         return $generator->randomToken('sha1');
@@ -146,7 +146,7 @@ class RememberLoginHash extends DataObject
      * @param Member $member The logged in user
      * @return string The hash to be stored in the database
      */
-    public function getNewHash(Member $member)
+    public function getNewHash(Member $member): string
     {
         $generator = new RandomGenerator();
         $this->setToken($generator->randomToken('sha1'));
@@ -161,7 +161,7 @@ class RememberLoginHash extends DataObject
      * @param Member $member The logged in user
      * @return RememberLoginHash The generated login hash
      */
-    public static function generate(Member $member)
+    public static function generate(Member $member): SilverStripe\Security\RememberLoginHash
     {
         if (!$member->exists()) {
             return null;
@@ -193,7 +193,7 @@ class RememberLoginHash extends DataObject
      *
      * @return RememberLoginHash
      */
-    public function renew()
+    public function renew(): SilverStripe\Security\RememberLoginHash
     {
         $hash = $this->getNewHash($this->Member());
         $this->Hash = $hash;
@@ -210,7 +210,7 @@ class RememberLoginHash extends DataObject
      * @param Member $member
      * @param string|null $alcDevice Null when logging out of non-persi-tien session
      */
-    public static function clear(Member $member, $alcDevice = null)
+    public static function clear(Member $member, string $alcDevice = null): void
     {
         if (!$member->exists()) {
             // If we don't have a valid user, we can't clear any "Remember me" tokens

--- a/src/Security/RequestAuthenticationHandler.php
+++ b/src/Security/RequestAuthenticationHandler.php
@@ -19,7 +19,7 @@ class RequestAuthenticationHandler implements AuthenticationHandler
      *
      * @return AuthenticationHandler[]
      */
-    protected function getHandlers()
+    protected function getHandlers(): array
     {
         return $this->handlers;
     }
@@ -30,13 +30,13 @@ class RequestAuthenticationHandler implements AuthenticationHandler
      * @param AuthenticationHandler[] $handlers
      * @return $this
      */
-    public function setHandlers(array $handlers)
+    public function setHandlers(array $handlers): SilverStripe\Security\RequestAuthenticationHandler
     {
         $this->handlers = $handlers;
         return $this;
     }
 
-    public function authenticateRequest(HTTPRequest $request)
+    public function authenticateRequest(HTTPRequest $request): void
     {
         /** @var AuthenticationHandler $handler */
         foreach ($this->getHandlers() as $name => $handler) {
@@ -55,7 +55,7 @@ class RequestAuthenticationHandler implements AuthenticationHandler
      * @param bool $persistent
      * @param HTTPRequest $request
      */
-    public function logIn(Member $member, $persistent = false, HTTPRequest $request = null)
+    public function logIn(Member $member, bool $persistent = false, HTTPRequest $request = null): void
     {
         $member->beforeMemberLoggedIn();
 
@@ -72,7 +72,7 @@ class RequestAuthenticationHandler implements AuthenticationHandler
      *
      * @param HTTPRequest $request
      */
-    public function logOut(HTTPRequest $request = null)
+    public function logOut(HTTPRequest $request = null): void
     {
         $member = Security::getCurrentUser();
         if ($member) {

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -200,7 +200,7 @@ class Security extends Controller implements TemplateGlobalProvider
     /**
      * @return Authenticator[]
      */
-    public function getAuthenticators()
+    public function getAuthenticators(): array
     {
         return array_filter($this->authenticators ?? []);
     }
@@ -208,12 +208,12 @@ class Security extends Controller implements TemplateGlobalProvider
     /**
      * @param Authenticator[] $authenticators
      */
-    public function setAuthenticators(array $authenticators)
+    public function setAuthenticators(array $authenticators): void
     {
         $this->authenticators = $authenticators;
     }
 
-    protected function init()
+    protected function init(): void
     {
         parent::init();
 
@@ -242,7 +242,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @return Authenticator Class name of Authenticator
      * @throws LogicException
      */
-    protected function getAuthenticator($name = 'default')
+    protected function getAuthenticator(string $name = 'default'): SilverStripe\MFA\Authenticator\MemberAuthenticator
     {
         $authenticators = $this->getAuthenticators();
 
@@ -259,7 +259,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @param int $service The type of service that is requested
      * @return Authenticator[] Return an array of Authenticator objects
      */
-    public function getApplicableAuthenticators($service = Authenticator::LOGIN)
+    public function getApplicableAuthenticators($service = Authenticator::LOGIN): array
     {
         $authenticators = $this->getAuthenticators();
 
@@ -284,7 +284,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @return bool Returns TRUE if the authenticator is registered, FALSE
      *              otherwise.
      */
-    public function hasAuthenticator($authenticator)
+    public function hasAuthenticator(string $authenticator): bool
     {
         $authenticators = $this->getAuthenticators();
 
@@ -316,7 +316,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * to log in.
      * @return HTTPResponse
      */
-    public static function permissionFailure($controller = null, $messageSet = null)
+    public static function permissionFailure(SilverStripe\CMS\Controllers\CMSPageEditController $controller = null, string|array|SilverStripe\ORM\FieldType\DBHTMLVarchar $messageSet = null): SilverStripe\Control\HTTPResponse|null
     {
         self::set_ignore_disallowed_actions(true);
 
@@ -448,7 +448,7 @@ class Security extends Controller implements TemplateGlobalProvider
      *
      * @param null|Member $currentUser
      */
-    public static function setCurrentUser($currentUser = null)
+    public static function setCurrentUser(SilverStripe\Security\Member $currentUser = null): void
     {
         self::$currentUser = $currentUser;
     }
@@ -456,7 +456,7 @@ class Security extends Controller implements TemplateGlobalProvider
     /**
      * @return null|Member
      */
-    public static function getCurrentUser()
+    public static function getCurrentUser(): null|SilverStripe\Security\Member
     {
         return self::$currentUser;
     }
@@ -491,7 +491,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @param string $action Name of the action
      * @return string Returns the link to the given action
      */
-    public function Link($action = null)
+    public function Link(string $action = null): string
     {
         /** @skipUpgrade */
         $link = Controller::join_links(Director::baseURL(), "Security", $action);
@@ -516,7 +516,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @return HTTPResponse Substitute response object if the login process should be circumvented.
      * Returns null if should proceed as normal.
      */
-    protected function preLogin()
+    protected function preLogin(): null|SilverStripe\Control\HTTPResponse
     {
         // Event handler for pre-login, with an option to let it break you out of the login form
         $eventResults = $this->extend('onBeforeSecurityLogin');
@@ -550,7 +550,7 @@ class Security extends Controller implements TemplateGlobalProvider
         return null;
     }
 
-    public function getRequest()
+    public function getRequest(): SilverStripe\Control\NullHTTPRequest
     {
         // Support Security::singleton() where a request isn't always injected
         $request = parent::getRequest();
@@ -571,7 +571,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @param string $title Title to use
      * @return Controller
      */
-    protected function getResponseController($title)
+    protected function getResponseController(string $title): SilverStripe\Security\Security
     {
         // Use the default setting for which Page to use to render the security page
         $pageClass = $this->config()->get('page_class');
@@ -622,7 +622,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @param string $messageType Type of message, if available, passed back to caller (by reference)
      * @return string Message in HTML format
      */
-    protected function getSessionMessage(&$messageType = null)
+    protected function getSessionMessage(string &$messageType = null): null|string
     {
         $session = $this->getRequest()->getSession();
         $message = $session->get('Security.Message.message');
@@ -648,10 +648,10 @@ class Security extends Controller implements TemplateGlobalProvider
      * @param string $messageCast Message cast. One of ValidationResult::CAST_*
      */
     public function setSessionMessage(
-        $message,
+        string|SilverStripe\ORM\FieldType\DBHTMLText $message,
         $messageType = ValidationResult::TYPE_WARNING,
         $messageCast = ValidationResult::CAST_TEXT
-    ) {
+    ): void {
         Controller::curr()
             ->getRequest()
             ->getSession()
@@ -663,7 +663,7 @@ class Security extends Controller implements TemplateGlobalProvider
     /**
      * Clear login message
      */
-    public static function clearSessionMessage()
+    public static function clearSessionMessage(): void
     {
         Controller::curr()
             ->getRequest()
@@ -682,7 +682,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @return HTTPResponse|string Returns the "login" page as HTML code.
      * @throws HTTPResponse_Exception
      */
-    public function login($request = null, $service = Authenticator::LOGIN)
+    public function login(SilverStripe\Control\HTTPRequest $request = null, $service = Authenticator::LOGIN): SilverStripe\ORM\FieldType\DBHTMLText
     {
         if ($request) {
             $this->setRequest($request);
@@ -727,7 +727,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @param int $service
      * @return HTTPResponse|string
      */
-    public function logout($request = null, $service = Authenticator::LOGOUT)
+    public function logout(SilverStripe\Control\HTTPRequest $request = null, $service = Authenticator::LOGOUT): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $authName = null;
 
@@ -762,7 +762,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @return array|Authenticator[]
      * @throws HTTPResponse_Exception
      */
-    protected function getServiceAuthenticatorsFromRequest($service, HTTPRequest $request)
+    protected function getServiceAuthenticatorsFromRequest(int $service, HTTPRequest $request): array
     {
         $authName = null;
 
@@ -877,7 +877,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @param callable $aggregator
      * @return array|HTTPResponse|RequestHandler|DBHTMLText|string
      */
-    protected function delegateToMultipleHandlers(array $handlers, $title, array $templates, callable $aggregator)
+    protected function delegateToMultipleHandlers(array $handlers, string $title, array $templates, callable $aggregator): SilverStripe\ORM\FieldType\DBHTMLText
     {
 
         // Simpler case for a single authenticator
@@ -911,7 +911,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @param array $templates
      * @return array|HTTPResponse|RequestHandler|DBHTMLText|string
      */
-    protected function delegateToHandler(RequestHandler $handler, $title, array $templates = [])
+    protected function delegateToHandler(RequestHandler $handler, string $title, array $templates = []): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $result = $handler->handleRequest($this->getRequest());
 
@@ -931,7 +931,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @param array $templates An array of templates to use for the render
      * @return HTTPResponse|DBHTMLText
      */
-    protected function renderWrappedController($title, array $fragments, array $templates)
+    protected function renderWrappedController(string $title, array $fragments, array $templates): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $controller = $this->getResponseController($title);
 
@@ -972,7 +972,7 @@ class Security extends Controller implements TemplateGlobalProvider
      *
      * @return string Returns the "lost password" page as HTML code.
      */
-    public function lostpassword()
+    public function lostpassword(): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $handlers = [];
         $authenticators = $this->getApplicableAuthenticators(Authenticator::RESET_PASSWORD);
@@ -1003,7 +1003,7 @@ class Security extends Controller implements TemplateGlobalProvider
      *
      * @return string|HTTPRequest Returns the "change password" page as HTML code, or a redirect response
      */
-    public function changepassword()
+    public function changepassword(): SilverStripe\Control\HTTPResponse
     {
         /** @var array|Authenticator[] $authenticators */
         $authenticators = $this->getApplicableAuthenticators(Authenticator::CHANGE_PASSWORD);
@@ -1031,7 +1031,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @param string $autologinToken The auto login token.
      * @return string
      */
-    public static function getPasswordResetLink($member, $autologinToken)
+    public static function getPasswordResetLink(SilverStripe\Security\Member $member, string $autologinToken): string
     {
         $autologinToken = urldecode($autologinToken ?? '');
 
@@ -1045,7 +1045,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @param string $action
      * @return array Template list
      */
-    public function getTemplatesFor($action)
+    public function getTemplatesFor(string $action): array
     {
         $templates = SSViewer::get_templates_by_class(static::class, "_{$action}", __CLASS__);
 
@@ -1201,7 +1201,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @throws PasswordEncryptor_NotFoundException
      * @see encrypt_passwords()
      */
-    public static function encrypt_password($password, $salt = null, $algorithm = null, $member = null)
+    public static function encrypt_password(string $password, string $salt = null, string $algorithm = null, SilverStripe\Security\Member $member = null): array
     {
         // Fall back to the default encryption algorithm
         if (!$algorithm) {
@@ -1227,7 +1227,7 @@ class Security extends Controller implements TemplateGlobalProvider
      *
      * @return bool
      */
-    public static function database_is_ready()
+    public static function database_is_ready(): bool
     {
         // Used for unit tests
         if (self::$force_database_is_ready !== null) {
@@ -1279,7 +1279,7 @@ class Security extends Controller implements TemplateGlobalProvider
     /**
      * Resets the database_is_ready cache
      */
-    public static function clear_database_is_ready()
+    public static function clear_database_is_ready(): void
     {
         self::$database_is_ready = null;
         self::$force_database_is_ready = null;
@@ -1290,7 +1290,7 @@ class Security extends Controller implements TemplateGlobalProvider
      *
      * @param bool $isReady
      */
-    public static function force_database_is_ready($isReady)
+    public static function force_database_is_ready(bool $isReady): void
     {
         self::$force_database_is_ready = $isReady;
     }
@@ -1319,7 +1319,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * Note that this is just a flag that other code needs to check with Security::ignore_disallowed_actions()
      * @param bool $flag True or false
      */
-    public static function set_ignore_disallowed_actions($flag)
+    public static function set_ignore_disallowed_actions(bool $flag): void
     {
         self::$ignore_disallowed_actions = $flag;
     }
@@ -1336,7 +1336,7 @@ class Security extends Controller implements TemplateGlobalProvider
      *
      * @return string
      */
-    public static function login_url()
+    public static function login_url(): string
     {
         return Controller::join_links(Director::baseURL(), self::config()->get('login_url'));
     }
@@ -1349,7 +1349,7 @@ class Security extends Controller implements TemplateGlobalProvider
      *
      * @return string
      */
-    public static function logout_url()
+    public static function logout_url(): string
     {
         $logoutUrl = Controller::join_links(Director::baseURL(), self::config()->get('logout_url'));
         return SecurityToken::inst()->addToUrl($logoutUrl);
@@ -1362,7 +1362,7 @@ class Security extends Controller implements TemplateGlobalProvider
      *
      * @return string
      */
-    public static function lost_password_url()
+    public static function lost_password_url(): string
     {
         return Controller::join_links(Director::baseURL(), self::config()->get('lost_password_url'));
     }
@@ -1372,7 +1372,7 @@ class Security extends Controller implements TemplateGlobalProvider
      *
      * @return array
      */
-    public static function get_template_global_variables()
+    public static function get_template_global_variables(): array
     {
         return [
             "LoginURL" => "login_url",

--- a/src/Security/SecurityToken.php
+++ b/src/Security/SecurityToken.php
@@ -65,7 +65,7 @@ class SecurityToken implements TemplateGlobalProvider
     /**
      * @param string $name
      */
-    public function __construct($name = null)
+    public function __construct(string $name = null): void
     {
         $this->name = $name ?: self::get_default_name();
     }
@@ -75,7 +75,7 @@ class SecurityToken implements TemplateGlobalProvider
      *
      * @return SecurityToken
      */
-    public static function inst()
+    public static function inst(): SilverStripe\Security\NullSecurityToken
     {
         if (!self::$inst) {
             self::$inst = new SecurityToken();
@@ -88,7 +88,7 @@ class SecurityToken implements TemplateGlobalProvider
      * Globally disable the token (override with {@link NullSecurityToken})
      * implementation. Note: Does not apply for
      */
-    public static function disable()
+    public static function disable(): void
     {
         self::$enabled = false;
         self::$inst = new NullSecurityToken();
@@ -97,7 +97,7 @@ class SecurityToken implements TemplateGlobalProvider
     /**
      * Globally enable tokens that have been previously disabled through {@link disable}.
      */
-    public static function enable()
+    public static function enable(): void
     {
         self::$enabled = true;
         self::$inst = new SecurityToken();
@@ -106,7 +106,7 @@ class SecurityToken implements TemplateGlobalProvider
     /**
      * @return boolean
      */
-    public static function is_enabled()
+    public static function is_enabled(): bool
     {
         return self::$enabled;
     }
@@ -114,7 +114,7 @@ class SecurityToken implements TemplateGlobalProvider
     /**
      * @return string
      */
-    public static function get_default_name()
+    public static function get_default_name(): string
     {
         return self::$default_name;
     }
@@ -123,7 +123,7 @@ class SecurityToken implements TemplateGlobalProvider
      * Returns the value of an the global SecurityToken in the current session
      * @return int
      */
-    public static function getSecurityID()
+    public static function getSecurityID(): string
     {
         $token = SecurityToken::inst();
         return $token->getValue();
@@ -142,7 +142,7 @@ class SecurityToken implements TemplateGlobalProvider
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -150,7 +150,7 @@ class SecurityToken implements TemplateGlobalProvider
     /**
      * @return string
      */
-    public function getValue()
+    public function getValue(): string
     {
         $session = $this->getSession();
         $value = $session->get($this->getName());
@@ -168,7 +168,7 @@ class SecurityToken implements TemplateGlobalProvider
      * @param string $val
      * @return $this
      */
-    public function setValue($val)
+    public function setValue(string $val): SilverStripe\Security\SecurityToken
     {
         $this->getSession()->set($this->getName(), $val);
         return $this;
@@ -180,7 +180,7 @@ class SecurityToken implements TemplateGlobalProvider
      * @return Session
      * @throws Exception If the HTTPRequest class hasn't been registered as a service and no controllers exist
      */
-    protected function getSession()
+    protected function getSession(): SilverStripe\Control\Session
     {
         $injector = Injector::inst();
         if ($injector->has(HTTPRequest::class)) {
@@ -194,7 +194,7 @@ class SecurityToken implements TemplateGlobalProvider
     /**
      * Reset the token to a new value.
      */
-    public function reset()
+    public function reset(): void
     {
         $this->setValue($this->generate());
     }
@@ -211,7 +211,7 @@ class SecurityToken implements TemplateGlobalProvider
      * @param string $compare
      * @return boolean
      */
-    public function check($compare)
+    public function check(string $compare): bool
     {
         return ($compare && $this->getValue() && $compare == $this->getValue());
     }
@@ -222,7 +222,7 @@ class SecurityToken implements TemplateGlobalProvider
      * @param HTTPRequest $request
      * @return bool
      */
-    public function checkRequest($request)
+    public function checkRequest(SilverStripe\Control\HTTPRequest $request): bool
     {
         $token = $this->getRequestToken($request);
         return $this->check($token);
@@ -234,7 +234,7 @@ class SecurityToken implements TemplateGlobalProvider
      * @param HTTPRequest $request
      * @return string
      */
-    protected function getRequestToken($request)
+    protected function getRequestToken(SilverStripe\Control\HTTPRequest $request): string|null
     {
         $name = $this->getName();
         $header = 'X-' . ucwords(strtolower($name ?? ''));
@@ -254,7 +254,7 @@ class SecurityToken implements TemplateGlobalProvider
      * @param FieldList $fieldset
      * @return HiddenField|false
      */
-    public function updateFieldSet(&$fieldset)
+    public function updateFieldSet(SilverStripe\Forms\FieldList &$fieldset): SilverStripe\Forms\HiddenField|bool
     {
         if (!$fieldset->fieldByName($this->getName())) {
             $field = new HiddenField($this->getName(), null, $this->getValue());
@@ -269,7 +269,7 @@ class SecurityToken implements TemplateGlobalProvider
      * @param string $url
      * @return string
      */
-    public function addToUrl($url)
+    public function addToUrl(string $url): string
     {
         return Controller::join_links($url, sprintf('?%s=%s', $this->getName(), $this->getValue()));
     }
@@ -284,7 +284,7 @@ class SecurityToken implements TemplateGlobalProvider
      *
      * @return boolean
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return !($this instanceof NullSecurityToken);
     }
@@ -294,13 +294,13 @@ class SecurityToken implements TemplateGlobalProvider
      *
      * @return string
      */
-    protected function generate()
+    protected function generate(): string
     {
         $generator = new RandomGenerator();
         return $generator->randomToken('sha1');
     }
 
-    public static function get_template_global_variables()
+    public static function get_template_global_variables(): array
     {
         return [
             'getSecurityID',

--- a/src/View/ArrayData.php
+++ b/src/View/ArrayData.php
@@ -29,7 +29,7 @@ class ArrayData extends ViewableData
      * @param object|array $value An associative array, or an object with simple properties.
      * Converts object properties to keys of an associative array.
      */
-    public function __construct($value = [])
+    public function __construct(array|stdClass|SilverStripe\Admin\CMSMenuItem $value = []): void
     {
         if (is_object($value)) {
             $this->array = get_object_vars($value);
@@ -55,7 +55,7 @@ class ArrayData extends ViewableData
      *
      * @return array
      */
-    public function toMap()
+    public function toMap(): array
     {
         return $this->array;
     }
@@ -74,7 +74,7 @@ class ArrayData extends ViewableData
      * @param string $field
      * @return mixed
      */
-    public function getField($field)
+    public function getField(string $field): string|bool|int|null|float|SilverStripe\ORM\ArrayList
     {
         $value = $this->array[$field];
         if (is_object($value) && !$value instanceof ViewableData) {
@@ -92,7 +92,7 @@ class ArrayData extends ViewableData
     * @param mixed $value
     * @return $this
     */
-    public function setField($field, $value)
+    public function setField(string $field, string|bool|SilverStripe\ORM\ArrayList $value): SilverStripe\View\ArrayData
     {
         $this->array[$field] = $value;
         return $this;
@@ -104,7 +104,7 @@ class ArrayData extends ViewableData
      * @param string $field Field Key
      * @return bool
      */
-    public function hasField($field)
+    public function hasField(string $field): bool
     {
         return isset($this->array[$field]);
     }
@@ -115,7 +115,7 @@ class ArrayData extends ViewableData
      * @param array $arr
      * @return stdClass $obj
      */
-    public static function array_to_object($arr = null)
+    public static function array_to_object(array $arr = null): stdClass
     {
         $obj = new stdClass();
         if ($arr) {

--- a/src/View/Dev/RequirementsTestState.php
+++ b/src/View/Dev/RequirementsTestState.php
@@ -18,22 +18,22 @@ class RequirementsTestState implements TestState
      */
     protected $backend = null;
 
-    public function setUp(SapphireTest $test)
+    public function setUp(SapphireTest $test): void
     {
         $this->backend = Requirements::backend();
         Requirements::set_backend(Requirements_Backend::create());
     }
 
-    public function tearDown(SapphireTest $test)
+    public function tearDown(SapphireTest $test): void
     {
         Requirements::set_backend($this->backend);
     }
 
-    public function setUpOnce($class)
+    public function setUpOnce(string $class): void
     {
     }
 
-    public function tearDownOnce($class)
+    public function tearDownOnce(string $class): void
     {
     }
 }

--- a/src/View/Dev/SSViewerTestState.php
+++ b/src/View/Dev/SSViewerTestState.php
@@ -9,22 +9,22 @@ use SilverStripe\View\SSViewer;
 
 class SSViewerTestState implements TestState
 {
-    public function setUp(SapphireTest $test)
+    public function setUp(SapphireTest $test): void
     {
         SSViewer::set_themes(null);
         SSViewer::setRewriteHashLinksDefault(null);
         ContentNegotiator::setEnabled(null);
     }
 
-    public function tearDown(SapphireTest $test)
+    public function tearDown(SapphireTest $test): void
     {
     }
 
-    public function setUpOnce($class)
+    public function setUpOnce(string $class): void
     {
     }
 
-    public function tearDownOnce($class)
+    public function tearDownOnce(string $class): void
     {
     }
 }

--- a/src/View/Embed/EmbedContainer.php
+++ b/src/View/Embed/EmbedContainer.php
@@ -27,7 +27,7 @@ class EmbedContainer implements Embeddable
 
     private array $options = [];
 
-    public function __construct(string $url)
+    public function __construct(string $url): void
     {
         $this->url = $url;
     }
@@ -35,7 +35,7 @@ class EmbedContainer implements Embeddable
     /**
      * @return int
      */
-    public function getWidth()
+    public function getWidth(): int
     {
         $code = $this->getExtractor()->code;
         return $code ? ($code->width ?: 100) : 100;
@@ -44,7 +44,7 @@ class EmbedContainer implements Embeddable
     /**
      * @return int
      */
-    public function getHeight()
+    public function getHeight(): int
     {
         $code = $this->getExtractor()->code;
         return $code ? ($code->height ?: 100) : 100;
@@ -53,7 +53,7 @@ class EmbedContainer implements Embeddable
     /**
      * @return string
      */
-    public function getPreviewURL()
+    public function getPreviewURL(): string
     {
         $extractor = $this->getExtractor();
 
@@ -71,7 +71,7 @@ class EmbedContainer implements Embeddable
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         $extractor = $this->getExtractor();
         if ($extractor->title) {
@@ -86,7 +86,7 @@ class EmbedContainer implements Embeddable
     /**
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         $html = $this->getExtractor()->code->html ?? '';
         if (strpos($html ?? '', '<video') !== false) {
@@ -109,7 +109,7 @@ class EmbedContainer implements Embeddable
     /**
      * @return bool
      */
-    public function validate()
+    public function validate(): bool
     {
         return !empty($this->getExtractor()->code->html ?? '');
     }

--- a/src/View/GenericTemplateGlobalProvider.php
+++ b/src/View/GenericTemplateGlobalProvider.php
@@ -8,7 +8,7 @@ use SilverStripe\ORM\DataList;
 class GenericTemplateGlobalProvider implements TemplateGlobalProvider
 {
 
-    public static function get_template_global_variables()
+    public static function get_template_global_variables(): array
     {
         return [
             'ModulePath',
@@ -21,7 +21,7 @@ class GenericTemplateGlobalProvider implements TemplateGlobalProvider
      * @param string $name Name of module to find path of
      * @return string
      */
-    public static function ModulePath($name)
+    public static function ModulePath(string $name): string
     {
         // BC for a couple of the key modules in the old syntax. Reduces merge brittleness but can
         // be removed before 4.0 stable

--- a/src/View/HTML.php
+++ b/src/View/HTML.php
@@ -57,7 +57,7 @@ class HTML
      * @param string $content Content to use between two tags. Not valid for void elements (e.g. link)
      * @return string
      */
-    public static function createTag($tag, $attributes, $content = null)
+    public static function createTag(string $tag, array $attributes, string $content = null): string
     {
         $tag = strtolower($tag ?? '');
 

--- a/src/View/Parsers/Diff.php
+++ b/src/View/Parsers/Diff.php
@@ -27,7 +27,7 @@ class Diff extends \Diff
      *    use, overriding self::$html_cleaner_class
      * @return mixed|string
      */
-    public static function cleanHTML($content, $cleaner = null)
+    public static function cleanHTML(string $content, $cleaner = null): string
     {
         if (!$cleaner) {
             if (self::$html_cleaner_class && class_exists(self::$html_cleaner_class)) {
@@ -58,7 +58,7 @@ class Diff extends \Diff
      * @param bool $escape
      * @return string
      */
-    public static function compareHTML($from, $to, $escape = false)
+    public static function compareHTML(string|array $from, string $to, bool $escape = false): string
     {
         // First split up the content into words and tags
         $set1 = self::getHTMLChunks($from);
@@ -164,7 +164,7 @@ class Diff extends \Diff
      * @param string|bool|array $content If passed as an array, values will be concatenated with a comma.
      * @return array
      */
-    public static function getHTMLChunks($content)
+    public static function getHTMLChunks(string|array $content): array
     {
         if ($content && !is_string($content) && !is_array($content) && !is_numeric($content) && !is_bool($content)) {
             throw new InvalidArgumentException('$content parameter needs to be a string or array');

--- a/src/View/Parsers/HTML4Value.php
+++ b/src/View/Parsers/HTML4Value.php
@@ -9,7 +9,7 @@ class HTML4Value extends HTMLValue
      * @param string $content
      * @return bool
      */
-    public function setContent($content)
+    public function setContent(string $content): bool
     {
         // Ensure that \r (carriage return) characters don't get replaced with "&#13;" entity by DOMDocument
         // This behaviour is apparently XML spec, but we don't want this because it messes up the HTML

--- a/src/View/Parsers/HTMLCleaner.php
+++ b/src/View/Parsers/HTMLCleaner.php
@@ -28,7 +28,7 @@ abstract class HTMLCleaner
     /**
      * @param array $config The configuration for the cleaner, if necessary
      */
-    public function __construct($config = null)
+    public function __construct($config = null): void
     {
         if ($config) {
             $config = array_merge($this->defaultConfig, $config);
@@ -41,7 +41,7 @@ abstract class HTMLCleaner
     /**
      * @param array $config
      */
-    public function setConfig($config)
+    public function setConfig(array $config): void
     {
         $this->config = $config;
     }
@@ -67,7 +67,7 @@ abstract class HTMLCleaner
      *
      * @return static
      */
-    public static function inst()
+    public static function inst(): SilverStripe\View\Parsers\TidyHTMLCleaner
     {
         if (class_exists('HTMLPurifier')) {
             return new PurifierHTMLCleaner();

--- a/src/View/Parsers/HTMLValue.php
+++ b/src/View/Parsers/HTMLValue.php
@@ -20,7 +20,7 @@ use DOMDocument;
 abstract class HTMLValue extends ViewableData
 {
 
-    public function __construct($fragment = null)
+    public function __construct(string $fragment = null): void
     {
         if ($fragment) {
             $this->setContent($fragment);
@@ -33,7 +33,7 @@ abstract class HTMLValue extends ViewableData
     /**
      * @return string
      */
-    public function getContent()
+    public function getContent(): string
     {
         $document = $this->getDocument();
         if (!$document) {
@@ -96,7 +96,7 @@ abstract class HTMLValue extends ViewableData
      * Get the DOMDocument for the passed content
      * @return DOMDocument | false - Return false if HTML not valid, the DOMDocument instance otherwise
      */
-    public function getDocument()
+    public function getDocument(): DOMDocument|bool
     {
         if (!$this->valid) {
             return false;
@@ -115,7 +115,7 @@ abstract class HTMLValue extends ViewableData
      * Is this HTMLValue in an errored state?
      * @return bool
      */
-    public function isValid()
+    public function isValid(): bool
     {
         return $this->valid;
     }
@@ -123,13 +123,13 @@ abstract class HTMLValue extends ViewableData
     /**
      * @param DOMDocument $document
      */
-    public function setDocument($document)
+    public function setDocument(DOMDocument $document): void
     {
         $this->document = $document;
         $this->valid = true;
     }
 
-    public function setInvalid()
+    public function setInvalid(): void
     {
         $this->document = $this->valid = false;
     }
@@ -142,7 +142,7 @@ abstract class HTMLValue extends ViewableData
      * @param array $arguments
      * @return mixed
      */
-    public function __call($method, $arguments)
+    public function __call(string $method, array $arguments): DOMNodeList|string
     {
         $doc = $this->getDocument();
 
@@ -157,7 +157,7 @@ abstract class HTMLValue extends ViewableData
      * Get the body element, or false if there isn't one (we haven't loaded any content
      * or this instance is in an invalid state)
      */
-    public function getBody()
+    public function getBody(): DOMElement
     {
         $doc = $this->getDocument();
         if (!$doc) {
@@ -178,7 +178,7 @@ abstract class HTMLValue extends ViewableData
      * @param string $query The xpath query string
      * @return DOMNodeList
      */
-    public function query($query)
+    public function query(string $query): DOMNodeList
     {
         $xp = new DOMXPath($this->getDocument());
         return $xp->query($query);

--- a/src/View/Parsers/SQLFormatter.php
+++ b/src/View/Parsers/SQLFormatter.php
@@ -32,7 +32,7 @@ class SQLFormatter
         'LIMIT',
     ];
 
-    public function formatPlain($sql)
+    public function formatPlain(string $sql): string
     {
         $sql = $this->addNewlines($sql, false);
 
@@ -55,7 +55,7 @@ class SQLFormatter
      * @param bool $useHtmlFormatting
      * @return string
      */
-    protected function addNewlines($sql, $useHtmlFormatting = false)
+    protected function addNewlines(string $sql, bool $useHtmlFormatting = false): string
     {
         $eol = PHP_EOL;
         foreach (self::$newline_before_tokens as $token) {

--- a/src/View/Parsers/ShortcodeParser.php
+++ b/src/View/Parsers/ShortcodeParser.php
@@ -24,7 +24,7 @@ class ShortcodeParser
     use Configurable;
     use Extensible;
 
-    public function __construct()
+    public function __construct(): void
     {
     }
 
@@ -56,7 +56,7 @@ class ShortcodeParser
      * @param string $identifier Defaults to "default".
      * @return ShortcodeParser
      */
-    public static function get($identifier = 'default')
+    public static function get(string $identifier = 'default'): SilverStripe\View\Parsers\ShortcodeParser
     {
         if (!array_key_exists($identifier, self::$instances)) {
             self::$instances[$identifier] = static::create();
@@ -70,7 +70,7 @@ class ShortcodeParser
      *
      * @return ShortcodeParser
      */
-    public static function get_active()
+    public static function get_active(): SilverStripe\View\Parsers\ShortcodeParser
     {
         return static::get(self::$active_instance);
     }
@@ -80,7 +80,7 @@ class ShortcodeParser
      *
      * @param string $identifier
      */
-    public static function set_active($identifier)
+    public static function set_active(string $identifier): void
     {
         self::$active_instance = (string) $identifier;
     }
@@ -102,7 +102,7 @@ class ShortcodeParser
      * @param callback $callback The callback to replace the shortcode with.
      * @return $this
      */
-    public function register($shortcode, $callback)
+    public function register(string $shortcode, array|callable $callback): SilverStripe\View\Parsers\ShortcodeParser
     {
         if (is_callable($callback)) {
             $this->shortcodes[$shortcode] = $callback;
@@ -118,7 +118,7 @@ class ShortcodeParser
      * @param string $shortcode
      * @return bool
      */
-    public function registered($shortcode)
+    public function registered(string $shortcode): bool
     {
         return array_key_exists($shortcode, $this->shortcodes ?? []);
     }
@@ -128,7 +128,7 @@ class ShortcodeParser
      *
      * @param string $shortcode
      */
-    public function unregister($shortcode)
+    public function unregister(string $shortcode): void
     {
         if ($this->registered($shortcode)) {
             unset($this->shortcodes[$shortcode]);
@@ -163,7 +163,7 @@ class ShortcodeParser
      * @param array $extra
      * @return mixed
      */
-    public function callShortcode($tag, $attributes, $content, $extra = [])
+    public function callShortcode(string $tag, array $attributes, string $content, array $extra = []): string|null|bool
     {
         if (!$tag || !isset($this->shortcodes[$tag])) {
             return false;
@@ -184,7 +184,7 @@ class ShortcodeParser
      *
      * @return bool|mixed|string
      */
-    public function getShortcodeReplacementText($tag, $extra = [], $isHTMLAllowed = true)
+    public function getShortcodeReplacementText(array $tag, array $extra = [], bool $isHTMLAllowed = true): string|null
     {
         $content = $this->callShortcode($tag['open'], $tag['attrs'], $tag['content'], $extra);
 
@@ -206,7 +206,7 @@ class ShortcodeParser
 
     // --------------------------------------------------------------------------------------------------------------
 
-    protected function removeNode($node)
+    protected function removeNode(DOMElement $node): void
     {
         $node->parentNode->removeChild($node);
     }
@@ -231,7 +231,7 @@ class ShortcodeParser
      * @param DOMNodeList $new
      * @param DOMElement $after
      */
-    protected function insertListAfter($new, $after)
+    protected function insertListAfter(DOMNodeList $new, DOMElement $after): void
     {
         $doc = $after->ownerDocument;
         $parent = $after->parentNode;
@@ -269,7 +269,7 @@ class ShortcodeParser
 		)
 ';
 
-    protected static function attrrx()
+    protected static function attrrx(): string
     {
         return '/' . self::$attrrx . '/xS';
     }
@@ -294,7 +294,7 @@ class ShortcodeParser
 		(?<cesc2>\]?)
 ';
 
-    protected static function tagrx()
+    protected static function tagrx(): string
     {
         return '/' . sprintf(self::$tagrx, self::$attrrx) . '/xS';
     }
@@ -317,7 +317,7 @@ class ShortcodeParser
      * @return array - The list of tags found. When using an open/close pair, only one item will be in the array,
      * with "content" set to the text between the tags
      */
-    public function extractTags($content)
+    public function extractTags(string $content): array
     {
         $tags = [];
 
@@ -429,7 +429,7 @@ class ShortcodeParser
      * @param callable $generator
      * @return string The HTML string with [tag] style shortcodes replaced by markers
      */
-    protected function replaceTagsWithText($content, $tags, $generator)
+    protected function replaceTagsWithText(string $content, array $tags, callable $generator): string
     {
         // The string with tags replaced with markers
         $str = '';
@@ -464,7 +464,7 @@ class ShortcodeParser
      *
      * @param HTMLValue $htmlvalue
      */
-    protected function replaceAttributeTagsWithContent($htmlvalue)
+    protected function replaceAttributeTagsWithContent(SilverStripe\HTML5\HTML5Value $htmlvalue): void
     {
         $attributes = $htmlvalue->query('//@*[contains(.,"[")][contains(.,"]")]');
         $parser = $this;
@@ -492,7 +492,7 @@ class ShortcodeParser
      * @param string $content
      * @return array
      */
-    protected function replaceElementTagsWithMarkers($content)
+    protected function replaceElementTagsWithMarkers(string $content): array
     {
         $tags = $this->extractTags($content);
 
@@ -511,7 +511,7 @@ class ShortcodeParser
      * @param DOMNodeList $nodes
      * @return array
      */
-    protected function findParentsForMarkers($nodes)
+    protected function findParentsForMarkers(DOMNodeList $nodes): array
     {
         $parents = [];
 
@@ -563,7 +563,7 @@ class ShortcodeParser
      * @param DOMElement $parent
      * @param int $location ShortcodeParser::BEFORE, ShortcodeParser::SPLIT or ShortcodeParser::INLINE
      */
-    protected function moveMarkerToCompliantHome($node, $parent, $location)
+    protected function moveMarkerToCompliantHome(DOMElement $node, DOMElement $parent, string $location): void
     {
         // Move before block parent
         if ($location == self::BEFORE) {
@@ -614,7 +614,7 @@ class ShortcodeParser
      * @param DOMElement $node
      * @param array $tag
      */
-    protected function replaceMarkerWithContent($node, $tag)
+    protected function replaceMarkerWithContent(DOMElement $node, array $tag): void
     {
         $content = $this->getShortcodeReplacementText($tag);
 
@@ -636,7 +636,7 @@ class ShortcodeParser
      * @param string $content
      * @return string
      */
-    public function parse($content)
+    public function parse(string $content): string|null
     {
         $this->extend('onBeforeParse', $content);
 

--- a/src/View/Parsers/TidyHTMLCleaner.php
+++ b/src/View/Parsers/TidyHTMLCleaner.php
@@ -21,7 +21,7 @@ class TidyHTMLCleaner extends HTMLCleaner
         'output-encoding' => 'utf8'
     ];
 
-    public function cleanHTML($content)
+    public function cleanHTML(string $content): string
     {
         $tidy = new tidy();
         $output = $tidy->repairString($content, $this->config);

--- a/src/View/Parsers/Transliterator.php
+++ b/src/View/Parsers/Transliterator.php
@@ -33,7 +33,7 @@ class Transliterator
      * @param string $source
      * @return string
      */
-    public function toASCII($source)
+    public function toASCII(string|int $source): string
     {
         if (function_exists('iconv') && $this->config()->use_iconv) {
             return $this->useIconv($source);
@@ -48,7 +48,7 @@ class Transliterator
      * @param string $source
      * @return string
      */
-    protected function useStrTr($source)
+    protected function useStrTr(string|int $source): string
     {
         $table = [
             'Š'=>'S', 'š'=>'s', 'Đ'=>'Dj', 'đ'=>'dj', 'Ž'=>'Z', 'ž'=>'z', 'Č'=>'C', 'č'=>'c', 'Ć'=>'C', 'ć'=>'c',

--- a/src/View/Parsers/URLSegmentFilter.php
+++ b/src/View/Parsers/URLSegmentFilter.php
@@ -75,7 +75,7 @@ class URLSegmentFilter implements FilterInterface
      * @param string $name URL path (without domain or query parameters), in utf8 encoding
      * @return string A filtered path compatible with RFC 3986
      */
-    public function filter($name)
+    public function filter(string|int $name): string
     {
         if (!$this->getAllowMultibyte()) {
             // Only transliterate when no multibyte support is requested
@@ -110,7 +110,7 @@ class URLSegmentFilter implements FilterInterface
      * @param string[] $replacements Map of find/replace used for preg_replace().
      * @return $this
      */
-    public function setReplacements($replacements)
+    public function setReplacements(array $replacements): SilverStripe\View\Parsers\URLSegmentFilter
     {
         $this->replacements = $replacements;
         return $this;
@@ -119,7 +119,7 @@ class URLSegmentFilter implements FilterInterface
     /**
      * @return string[]
      */
-    public function getReplacements()
+    public function getReplacements(): array
     {
         return $this->replacements ?: (array)$this->config()->get('default_replacements');
     }
@@ -127,7 +127,7 @@ class URLSegmentFilter implements FilterInterface
     /**
      * @return Transliterator|null
      */
-    public function getTransliterator()
+    public function getTransliterator(): SilverStripe\View\Parsers\Transliterator
     {
         if ($this->transliterator === null && $this->config()->get('default_use_transliterator')) {
             $this->transliterator = Transliterator::create();
@@ -148,7 +148,7 @@ class URLSegmentFilter implements FilterInterface
     /**
      * @param bool $bool
      */
-    public function setAllowMultibyte($bool)
+    public function setAllowMultibyte(bool $bool): void
     {
         $this->allowMultibyte = $bool;
     }
@@ -156,7 +156,7 @@ class URLSegmentFilter implements FilterInterface
     /**
      * @return boolean
      */
-    public function getAllowMultibyte()
+    public function getAllowMultibyte(): bool
     {
         return ($this->allowMultibyte !== null) ? $this->allowMultibyte : $this->config()->default_allow_multibyte;
     }

--- a/src/View/PublicThemes.php
+++ b/src/View/PublicThemes.php
@@ -4,7 +4,7 @@ namespace SilverStripe\View;
 
 class PublicThemes implements ThemeList
 {
-    public function getThemes()
+    public function getThemes(): array
     {
         return PUBLIC_DIR ? ['/' . PUBLIC_DIR] : [];
     }

--- a/src/View/Requirements.php
+++ b/src/View/Requirements.php
@@ -28,7 +28,7 @@ class Requirements implements Flushable
     /**
      * Triggered early in the request when a flush is requested
      */
-    public static function flush()
+    public static function flush(): void
     {
         $disabled = Config::inst()->get(static::class, 'disable_flush_combined');
         if (!$disabled) {
@@ -41,7 +41,7 @@ class Requirements implements Flushable
      *
      * @param bool $enable
      */
-    public static function set_combined_files_enabled($enable)
+    public static function set_combined_files_enabled(bool $enable): void
     {
         self::backend()->setCombinedFilesEnabled($enable);
     }
@@ -51,7 +51,7 @@ class Requirements implements Flushable
      *
      * @return bool
      */
-    public static function get_combined_files_enabled()
+    public static function get_combined_files_enabled(): bool
     {
         return self::backend()->getCombinedFilesEnabled();
     }
@@ -100,7 +100,7 @@ class Requirements implements Flushable
     /**
      * @return Requirements_Backend
      */
-    public static function backend()
+    public static function backend(): SilverStripe\View\Requirements_Backend
     {
         if (!self::$backend) {
             self::$backend = Requirements_Backend::create();
@@ -113,7 +113,7 @@ class Requirements implements Flushable
      *
      * @param Requirements_Backend $backend
      */
-    public static function set_backend(Requirements_Backend $backend)
+    public static function set_backend(Requirements_Backend $backend): void
     {
         self::$backend = $backend;
     }
@@ -127,7 +127,7 @@ class Requirements implements Flushable
      * - 'async' : Boolean value to set async attribute to script tag
      * - 'defer' : Boolean value to set defer attribute to script tag
      */
-    public static function javascript($file, $options = [])
+    public static function javascript(string $file, array $options = []): void
     {
         self::backend()->javascript($file, $options);
     }
@@ -138,7 +138,7 @@ class Requirements implements Flushable
      * @param string     $script       The script content as a string (without enclosing `<script>` tag)
      * @param string|int $uniquenessID A unique ID that ensures a piece of code is only added once
      */
-    public static function customScript($script, $uniquenessID = null)
+    public static function customScript(string $script, string $uniquenessID = null): void
     {
         self::backend()->customScript($script, $uniquenessID);
     }
@@ -159,7 +159,7 @@ class Requirements implements Flushable
      * @param string     $script       CSS selectors as a string (without enclosing `<style>` tag)
      * @param string|int $uniquenessID A unique ID that ensures a piece of code is only added once
      */
-    public static function customCSS($script, $uniquenessID = null)
+    public static function customCSS(string $script, string $uniquenessID = null): void
     {
         self::backend()->customCSS($script, $uniquenessID);
     }
@@ -170,7 +170,7 @@ class Requirements implements Flushable
      * @param string     $html         Custom HTML code
      * @param string|int $uniquenessID A unique ID that ensures a piece of code is only added once
      */
-    public static function insertHeadTags($html, $uniquenessID = null)
+    public static function insertHeadTags(string $html, $uniquenessID = null): void
     {
         self::backend()->insertHeadTags($html, $uniquenessID);
     }
@@ -198,7 +198,7 @@ class Requirements implements Flushable
      * - 'integrity' : SubResource Integrity hash
      * - 'crossorigin' : Cross-origin policy for the resource
      */
-    public static function css($file, $media = null, $options = [])
+    public static function css(string $file, string $media = null, array $options = []): void
     {
         self::backend()->css($file, $media, $options);
     }
@@ -214,7 +214,7 @@ class Requirements implements Flushable
      * @param string $media  Comma-separated list of media types to use in the link tag
      *                       (e.g. 'screen,projector')
      */
-    public static function themedCSS($name, $media = null)
+    public static function themedCSS(string $name, string $media = null): void
     {
         self::backend()->themedCSS($name, $media);
     }
@@ -230,7 +230,7 @@ class Requirements implements Flushable
      * @param string $type  Comma-separated list of types to use in the script tag
      *                       (e.g. 'text/javascript,text/ecmascript')
      */
-    public static function themedJavascript($name, $type = null)
+    public static function themedJavascript(string $name, $type = null): void
     {
         self::backend()->themedJavascript($name, $type);
     }
@@ -243,7 +243,7 @@ class Requirements implements Flushable
      *
      * @param string|int $fileOrID
      */
-    public static function clear($fileOrID = null)
+    public static function clear($fileOrID = null): void
     {
         self::backend()->clear($fileOrID);
     }
@@ -251,7 +251,7 @@ class Requirements implements Flushable
     /**
      * Restore requirements cleared by call to Requirements::clear
      */
-    public static function restore()
+    public static function restore(): void
     {
         self::backend()->restore();
     }
@@ -269,7 +269,7 @@ class Requirements implements Flushable
      *
      * @param string|int $fileOrID
      */
-    public static function block($fileOrID)
+    public static function block(string $fileOrID): void
     {
         self::backend()->block($fileOrID);
     }
@@ -301,7 +301,7 @@ class Requirements implements Flushable
      *                             through {@link SSViewer}
      * @return string HTML content augmented with the requirements tags
      */
-    public static function includeInHTML($content)
+    public static function includeInHTML(string $content): string
     {
         if (func_num_args() > 1) {
             Deprecation::notice(
@@ -320,7 +320,7 @@ class Requirements implements Flushable
      *
      * @param HTTPResponse $response
      */
-    public static function include_in_response(HTTPResponse $response)
+    public static function include_in_response(HTTPResponse $response): void
     {
         self::backend()->includeInResponse($response);
     }
@@ -338,7 +338,7 @@ class Requirements implements Flushable
      *
      * @return array
      */
-    public static function add_i18n_javascript($langDir, $return = false, $langOnly = false)
+    public static function add_i18n_javascript(string $langDir, bool $return = false, bool $langOnly = false): null
     {
         return self::backend()->add_i18n_javascript($langDir, $return);
     }
@@ -413,7 +413,7 @@ class Requirements implements Flushable
      * Deletes all generated combined files in the configured combined files directory,
      * but doesn't delete the directory itself
      */
-    public static function delete_all_combined_files()
+    public static function delete_all_combined_files(): void
     {
         self::backend()->deleteAllCombinedFiles();
     }
@@ -421,7 +421,7 @@ class Requirements implements Flushable
     /**
      * Re-sets the combined files definition. See {@link Requirements_Backend::clear_combined_files()}
      */
-    public static function clear_combined_files()
+    public static function clear_combined_files(): void
     {
         self::backend()->clearCombinedFiles();
     }

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -205,7 +205,7 @@ class Requirements_Backend
      *
      * @return GeneratedAssetHandler
      */
-    public function getAssetHandler()
+    public function getAssetHandler(): SilverStripe\Assets\Flysystem\GeneratedAssets
     {
         return $this->assetHandler;
     }
@@ -215,7 +215,7 @@ class Requirements_Backend
      *
      * @param GeneratedAssetHandler $handler
      */
-    public function setAssetHandler(GeneratedAssetHandler $handler)
+    public function setAssetHandler(GeneratedAssetHandler $handler): void
     {
         $this->assetHandler = $handler;
     }
@@ -236,7 +236,7 @@ class Requirements_Backend
      *
      * @param Requirements_Minifier $minifier
      */
-    public function setMinifier(Requirements_Minifier $minifier = null)
+    public function setMinifier(Requirements_Minifier $minifier = null): void
     {
         $this->minifier = $minifier;
     }
@@ -246,7 +246,7 @@ class Requirements_Backend
      *
      * @param bool $enable
      */
-    public function setCombinedFilesEnabled($enable)
+    public function setCombinedFilesEnabled(bool $enable): void
     {
         $this->combinedFilesEnabled = (bool)$enable;
     }
@@ -282,7 +282,7 @@ class Requirements_Backend
      *
      * @param string $folder
      */
-    public function setCombinedFilesFolder($folder)
+    public function setCombinedFilesFolder(string $folder): void
     {
         $this->combinedFilesFolder = $folder;
     }
@@ -292,7 +292,7 @@ class Requirements_Backend
      *
      * @return string
      */
-    public function getCombinedFilesFolder()
+    public function getCombinedFilesFolder(): string
     {
         if ($this->combinedFilesFolder) {
             return $this->combinedFilesFolder;
@@ -308,7 +308,7 @@ class Requirements_Backend
      *
      * @param bool $var
      */
-    public function setSuffixRequirements($var)
+    public function setSuffixRequirements(bool $var): void
     {
         $this->suffixRequirements = $var;
     }
@@ -330,7 +330,7 @@ class Requirements_Backend
      * @param bool $var
      * @return $this
      */
-    public function setWriteJavascriptToBody($var)
+    public function setWriteJavascriptToBody(bool $var): SilverStripe\View\Requirements_Backend
     {
         $this->writeJavascriptToBody = $var;
         return $this;
@@ -342,7 +342,7 @@ class Requirements_Backend
      *
      * @return bool
      */
-    public function getWriteJavascriptToBody()
+    public function getWriteJavascriptToBody(): bool
     {
         return $this->writeJavascriptToBody;
     }
@@ -353,7 +353,7 @@ class Requirements_Backend
      * @param bool $var
      * @return $this
      */
-    public function setForceJSToBottom($var)
+    public function setForceJSToBottom(bool $var): SilverStripe\View\Requirements_Backend
     {
         $this->forceJSToBottom = $var;
         return $this;
@@ -364,7 +364,7 @@ class Requirements_Backend
      *
      * @return bool
      */
-    public function getForceJSToBottom()
+    public function getForceJSToBottom(): bool
     {
         return $this->forceJSToBottom;
     }
@@ -374,7 +374,7 @@ class Requirements_Backend
      *
      * @return bool
      */
-    public function getMinifyCombinedFiles()
+    public function getMinifyCombinedFiles(): bool
     {
         return $this->minifyCombinedFiles;
     }
@@ -385,7 +385,7 @@ class Requirements_Backend
      * @param bool $minify
      * @return $this
      */
-    public function setMinifyCombinedFiles($minify)
+    public function setMinifyCombinedFiles(bool $minify): SilverStripe\View\Requirements_Backend
     {
         $this->minifyCombinedFiles = $minify;
         return $this;
@@ -403,7 +403,7 @@ class Requirements_Backend
      * - 'integrity' : SubResource Integrity hash
      * - 'crossorigin' : Cross-origin policy for the resource
      */
-    public function javascript($file, $options = [])
+    public function javascript(string $file, array $options = []): void
     {
         $file = ModuleResourceLoader::singleton()->resolvePath($file);
 
@@ -476,7 +476,7 @@ class Requirements_Backend
      *
      * @return array Array of provided files (map of $path => $path)
      */
-    public function getProvidedScripts()
+    public function getProvidedScripts(): array
     {
         $providedScripts = [];
         $includedScripts = [];
@@ -507,7 +507,7 @@ class Requirements_Backend
      *
      * @return array
      */
-    public function getJavascript()
+    public function getJavascript(): array
     {
         return array_diff_key(
             $this->javascript ?? [],
@@ -521,7 +521,7 @@ class Requirements_Backend
      *
      * @return array Indexed array of javascript files
      */
-    protected function getAllJavascript()
+    protected function getAllJavascript(): array
     {
         return $this->javascript;
     }
@@ -532,7 +532,7 @@ class Requirements_Backend
      * @param string $script The script content as a string (without enclosing `<script>` tag)
      * @param string $uniquenessID A unique ID that ensures a piece of code is only added once
      */
-    public function customScript($script, $uniquenessID = null)
+    public function customScript(string $script, string $uniquenessID = null): void
     {
         if ($uniquenessID) {
             $this->customScript[$uniquenessID] = $script;
@@ -546,7 +546,7 @@ class Requirements_Backend
      *
      * @return array
      */
-    public function getCustomScripts()
+    public function getCustomScripts(): array
     {
         return array_diff_key($this->customScript ?? [], $this->blocked);
     }
@@ -557,7 +557,7 @@ class Requirements_Backend
      * @param string $script CSS selectors as a string (without enclosing `<style>` tag)
      * @param string $uniquenessID A unique ID that ensures a piece of code is only added once
      */
-    public function customCSS($script, $uniquenessID = null)
+    public function customCSS(string $script, string $uniquenessID = null): void
     {
         if ($uniquenessID) {
             $this->customCSS[$uniquenessID] = $script;
@@ -571,7 +571,7 @@ class Requirements_Backend
      *
      * @return array
      */
-    public function getCustomCSS()
+    public function getCustomCSS(): array
     {
         return array_diff_key($this->customCSS ?? [], $this->blocked);
     }
@@ -582,7 +582,7 @@ class Requirements_Backend
      * @param string $html Custom HTML code
      * @param string $uniquenessID A unique ID that ensures a piece of code is only added once
      */
-    public function insertHeadTags($html, $uniquenessID = null)
+    public function insertHeadTags(string $html, $uniquenessID = null): void
     {
         if ($uniquenessID) {
             $this->customHeadTags[$uniquenessID] = $html;
@@ -596,7 +596,7 @@ class Requirements_Backend
      *
      * @return array
      */
-    public function getCustomHeadTags()
+    public function getCustomHeadTags(): array
     {
         return array_diff_key($this->customHeadTags ?? [], $this->blocked);
     }
@@ -642,7 +642,7 @@ class Requirements_Backend
      * - 'integrity' : SubResource Integrity hash
      * - 'crossorigin' : Cross-origin policy for the resource
      */
-    public function css($file, $media = null, $options = [])
+    public function css(string $file, string $media = null, array $options = []): void
     {
         $file = ModuleResourceLoader::singleton()->resolvePath($file);
 
@@ -671,7 +671,7 @@ class Requirements_Backend
      *
      * @return array Associative array of file to spec
      */
-    public function getCSS()
+    public function getCSS(): array
     {
         return array_diff_key($this->css ?? [], $this->blocked);
     }
@@ -681,7 +681,7 @@ class Requirements_Backend
      *
      * @return array Associative array of file to spec
      */
-    protected function getAllCSS()
+    protected function getAllCSS(): array
     {
         return $this->css;
     }
@@ -691,7 +691,7 @@ class Requirements_Backend
      *
      * @return array
      */
-    public function getBlocked()
+    public function getBlocked(): array
     {
         return $this->blocked;
     }
@@ -704,7 +704,7 @@ class Requirements_Backend
      *
      * @param string|int $fileOrID
      */
-    public function clear($fileOrID = null)
+    public function clear($fileOrID = null): void
     {
         $types = [
             'javascript',
@@ -730,7 +730,7 @@ class Requirements_Backend
     /**
      * Restore requirements cleared by call to Requirements::clear
      */
-    public function restore()
+    public function restore(): void
     {
         $types = [
             'javascript',
@@ -759,7 +759,7 @@ class Requirements_Backend
      * @param string|int $fileOrID Relative path from webroot, module resource reference or
      *                             requirement API ID
      */
-    public function block($fileOrID)
+    public function block(string $fileOrID): void
     {
         if (is_string($fileOrID)) {
             $fileOrID = ModuleResourceLoader::singleton()->resolvePath($fileOrID);
@@ -772,7 +772,7 @@ class Requirements_Backend
      *
      * @param string|int $fileOrID
      */
-    public function unblock($fileOrID)
+    public function unblock(string $fileOrID): void
     {
         unset($this->blocked[$fileOrID]);
     }
@@ -794,7 +794,7 @@ class Requirements_Backend
      *                             through {@link SSViewer}
      * @return string HTML content augmented with the requirements tags
      */
-    public function includeInHTML($content)
+    public function includeInHTML(string|bool $content): string
     {
         if (func_num_args() > 1) {
             Deprecation::notice(
@@ -901,7 +901,7 @@ class Requirements_Backend
      * @param string $content HTML body
      * @return string Merged HTML
      */
-    protected function insertScriptsAtBottom($jsRequirements, $content)
+    protected function insertScriptsAtBottom(string $jsRequirements, string $content): string
     {
         // Forcefully put the scripts at the bottom of the body instead of before the first
         // script tag.
@@ -920,7 +920,7 @@ class Requirements_Backend
      * @param string $content HTML body
      * @return string Merged HTML
      */
-    protected function insertScriptsIntoBody($jsRequirements, $content)
+    protected function insertScriptsIntoBody(string $jsRequirements, string $content): string
     {
         // If your template already has script tags in the body, then we try to put our script
         // tags just before those. Otherwise, we put it at the bottom.
@@ -957,7 +957,7 @@ class Requirements_Backend
      * @param string $content HTML body
      * @return string Merged HTML
      */
-    protected function insertTagsIntoHead($jsRequirements, $content)
+    protected function insertTagsIntoHead(string $jsRequirements, string $content): string
     {
         $content = preg_replace(
             '/(<\/head>)/i',
@@ -973,7 +973,7 @@ class Requirements_Backend
      * @param string $replacement
      * @return string
      */
-    protected function escapeReplacement($replacement)
+    protected function escapeReplacement(string $replacement): string
     {
         return addcslashes($replacement ?? '', '\\$');
     }
@@ -984,7 +984,7 @@ class Requirements_Backend
      *
      * @param HTTPResponse $response
      */
-    public function includeInResponse(HTTPResponse $response)
+    public function includeInResponse(HTTPResponse $response): void
     {
         $this->processCombinedFiles();
         $jsRequirements = [];
@@ -1026,7 +1026,7 @@ class Requirements_Backend
      *
      * @return array|null All relative files if $return is true, or null otherwise
      */
-    public function add_i18n_javascript($langDir, $return = false)
+    public function add_i18n_javascript(string $langDir, bool $return = false): null
     {
         $langDir = ModuleResourceLoader::singleton()->resolvePath($langDir);
 
@@ -1073,7 +1073,7 @@ class Requirements_Backend
      * @param string $fileOrUrl
      * @return string|bool
      */
-    protected function pathForFile($fileOrUrl)
+    protected function pathForFile(string $fileOrUrl): string
     {
         // Since combined urls could be root relative, treat them as urls here.
         if (preg_match('{^(//)|(http[s]?:)}', $fileOrUrl ?? '') || Director::is_root_relative_url($fileOrUrl)) {
@@ -1136,7 +1136,7 @@ class Requirements_Backend
      * - 'async' : If including JavaScript Files, boolean value to set async attribute to script tag
      * - 'defer' : If including JavaScript Files, boolean value to set defer attribute to script tag
      */
-    public function combineFiles($combinedFileName, $files, $options = [])
+    public function combineFiles(string $combinedFileName, array $files, array $options = []): void
     {
         if (is_string($options)) {
             Deprecation::notice('4.0', 'Parameter media is deprecated. Use options array instead.');
@@ -1201,7 +1201,7 @@ class Requirements_Backend
      * @param string|array $file Either a file path, or an array spec
      * @return array array with two elements, path and type of file
      */
-    protected function parseCombinedFile($file)
+    protected function parseCombinedFile(string $file): array
     {
         // Array with path and type keys
         if (is_array($file) && isset($file['path']) && isset($file['type'])) {
@@ -1243,7 +1243,7 @@ class Requirements_Backend
      *
      * @return array
      */
-    protected function getAllCombinedFiles()
+    protected function getAllCombinedFiles(): array
     {
         return $this->combinedFiles;
     }
@@ -1251,7 +1251,7 @@ class Requirements_Backend
     /**
      * Clears all combined files
      */
-    public function deleteAllCombinedFiles()
+    public function deleteAllCombinedFiles(): void
     {
         $combinedFolder = $this->getCombinedFilesFolder();
         if ($combinedFolder) {
@@ -1262,7 +1262,7 @@ class Requirements_Backend
     /**
      * Clear all registered CSS and JavaScript file combinations
      */
-    public function clearCombinedFiles()
+    public function clearCombinedFiles(): void
     {
         $this->combinedFiles = [];
     }
@@ -1270,7 +1270,7 @@ class Requirements_Backend
     /**
      * Do the heavy lifting involved in combining the combined files.
      */
-    public function processCombinedFiles()
+    public function processCombinedFiles(): void
     {
         // Check if combining is enabled
         if (!$this->getCombinedFilesEnabled()) {
@@ -1350,7 +1350,7 @@ class Requirements_Backend
      * @return string|null URL to this resource, if there are files to combine
      * @throws Exception
      */
-    protected function getCombinedFileURL($combinedFile, $fileList, $type)
+    protected function getCombinedFileURL(string $combinedFile, array $fileList, string $type): string|null
     {
         // Skip empty lists
         if (empty($fileList)) {
@@ -1428,7 +1428,7 @@ MESSAGE
      * @param array $fileList
      * @return string
      */
-    protected function hashedCombinedFilename($combinedFile, $fileList)
+    protected function hashedCombinedFilename(string $combinedFile, array $fileList): string
     {
         $name = pathinfo($combinedFile ?? '', PATHINFO_FILENAME);
         $hash = $this->hashOfFiles($fileList);
@@ -1441,7 +1441,7 @@ MESSAGE
      *
      * @return bool
      */
-    public function getCombinedFilesEnabled()
+    public function getCombinedFilesEnabled(): bool
     {
         if (isset($this->combinedFilesEnabled)) {
             return $this->combinedFilesEnabled;
@@ -1463,7 +1463,7 @@ MESSAGE
      * @param array $fileList List of files
      * @return string SHA1 bashed file hash
      */
-    protected function hashOfFiles($fileList)
+    protected function hashOfFiles(array $fileList): string
     {
         // Get hash based on hash of each file
         $hash = '';
@@ -1489,7 +1489,7 @@ MESSAGE
      * @param string $media Comma-separated list of media types to use in the link tag
      *                       (e.g. 'screen,projector')
      */
-    public function themedCSS($name, $media = null)
+    public function themedCSS(string $name, string $media = null): void
     {
         $path = ThemeResourceLoader::inst()->findThemedCSS($name, SSViewer::get_themes());
         if ($path) {
@@ -1513,7 +1513,7 @@ MESSAGE
      * @param string $type Comma-separated list of types to use in the script tag
      *                       (e.g. 'text/javascript,text/ecmascript')
      */
-    public function themedJavascript($name, $type = null)
+    public function themedJavascript(string $name, $type = null): void
     {
         $path = ThemeResourceLoader::inst()->findThemedJavascript($name, SSViewer::get_themes());
         if ($path) {

--- a/src/View/SSTemplateParseException.php
+++ b/src/View/SSTemplateParseException.php
@@ -17,7 +17,7 @@ class SSTemplateParseException extends Exception
      * @param string $message
      * @param SSTemplateParser $parser
      */
-    public function __construct($message, $parser)
+    public function __construct(string $message, SilverStripe\View\SSTemplateParser $parser): void
     {
         $prior = substr($parser->string ?? '', 0, $parser->pos);
 

--- a/src/View/SSTemplateParser.php
+++ b/src/View/SSTemplateParser.php
@@ -86,7 +86,7 @@ class SSTemplateParser extends Parser implements TemplateParser
      * @param array $closedBlocks
      * @param array $openBlocks
      */
-    public function __construct($closedBlocks = [], $openBlocks = [])
+    public function __construct($closedBlocks = [], $openBlocks = []): void
     {
         parent::__construct(null);
         $this->setClosedBlocks($closedBlocks);
@@ -96,7 +96,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     /**
      * Override the function that constructs the result arrays to also prepare a 'php' item in the array
      */
-    function construct($matchrule, $name, $arguments = null)
+    function construct(string $matchrule, string $name, array $arguments = null): array
     {
         $res = parent::construct($matchrule, $name, $arguments);
         if (!isset($res['php'])) {
@@ -113,7 +113,7 @@ class SSTemplateParser extends Parser implements TemplateParser
      * @param array $closedBlocks
      * @throws InvalidArgumentException
      */
-    public function setClosedBlocks($closedBlocks)
+    public function setClosedBlocks(array $closedBlocks): void
     {
         $this->closedBlocks = [];
         foreach ((array) $closedBlocks as $name => $callable) {
@@ -129,7 +129,7 @@ class SSTemplateParser extends Parser implements TemplateParser
      * @param array $openBlocks
      * @throws InvalidArgumentException
      */
-    public function setOpenBlocks($openBlocks)
+    public function setOpenBlocks(array $openBlocks): void
     {
         $this->openBlocks = [];
         foreach ((array) $openBlocks as $name => $callable) {
@@ -143,7 +143,7 @@ class SSTemplateParser extends Parser implements TemplateParser
      * @param callable $callable The function that modifies the generation of template code
      * @throws InvalidArgumentException
      */
-    public function addClosedBlock($name, $callable)
+    public function addClosedBlock(string $name, callable $callable): void
     {
         $this->validateExtensionBlock($name, $callable, 'Closed block');
         $this->closedBlocks[$name] = $callable;
@@ -155,7 +155,7 @@ class SSTemplateParser extends Parser implements TemplateParser
      * @param callable $callable The function that modifies the generation of template code
      * @throws InvalidArgumentException
      */
-    public function addOpenBlock($name, $callable)
+    public function addOpenBlock(string $name, callable $callable): void
     {
         $this->validateExtensionBlock($name, $callable, 'Open block');
         $this->openBlocks[$name] = $callable;
@@ -168,7 +168,7 @@ class SSTemplateParser extends Parser implements TemplateParser
      * @param $type
      * @throws InvalidArgumentException
      */
-    protected function validateExtensionBlock($name, $callable, $type)
+    protected function validateExtensionBlock(string $name, callable $callable, string $type): void
     {
         if (!is_string($name)) {
             throw new InvalidArgumentException(
@@ -191,7 +191,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     /* Template: (Comment | Translate | If | Require | CacheBlock | UncachedBlock | OldI18NTag | Include | ClosedBlock |
     OpenBlock | MalformedBlock | MalformedBracketInjection | Injection | Text)+ */
     protected $match_Template_typestack = array('Template');
-    function match_Template ($stack = array()) {
+    function match_Template ($stack = array()): array|bool {
     	$matchrule = "Template"; $result = $this->construct($matchrule, $matchrule, null);
     	$count = 0;
     	while (true) {
@@ -457,14 +457,14 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function Template_STR(&$res, $sub)
+    function Template_STR(array &$res, array $sub): void
     {
         $res['php'] .= $sub['php'] . PHP_EOL ;
     }
 
     /* Word: / [A-Za-z_] [A-Za-z0-9_]* / */
     protected $match_Word_typestack = array('Word');
-    function match_Word ($stack = array()) {
+    function match_Word ($stack = array()): array|bool {
     	$matchrule = "Word"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [A-Za-z_] [A-Za-z0-9_]* /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -476,7 +476,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* NamespacedWord: / [A-Za-z_\/\\] [A-Za-z0-9_\/\\]* / */
     protected $match_NamespacedWord_typestack = array('NamespacedWord');
-    function match_NamespacedWord ($stack = array()) {
+    function match_NamespacedWord ($stack = array()): array {
     	$matchrule = "NamespacedWord"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [A-Za-z_\/\\\\] [A-Za-z0-9_\/\\\\]* /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -512,7 +512,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* CallArguments: :Argument ( < "," < :Argument )* */
     protected $match_CallArguments_typestack = array('CallArguments');
-    function match_CallArguments ($stack = array()) {
+    function match_CallArguments ($stack = array()): array|bool {
     	$matchrule = "CallArguments"; $result = $this->construct($matchrule, $matchrule, null);
     	$_66 = NULL;
     	do {
@@ -565,7 +565,7 @@ class SSTemplateParser extends Parser implements TemplateParser
      * Values are bare words in templates, but strings in PHP. We rely on PHP's type conversion to back-convert
      * strings to numbers when needed.
      */
-    function CallArguments_Argument(&$res, $sub)
+    function CallArguments_Argument(array &$res, array $sub): void
     {
         if (!empty($res['php'])) {
             $res['php'] .= ', ';
@@ -577,7 +577,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* Call: Method:Word ( "(" < :CallArguments? > ")" )? */
     protected $match_Call_typestack = array('Call');
-    function match_Call ($stack = array()) {
+    function match_Call ($stack = array()): array|bool {
     	$matchrule = "Call"; $result = $this->construct($matchrule, $matchrule, null);
     	$_76 = NULL;
     	do {
@@ -635,7 +635,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* LookupStep: :Call &"." */
     protected $match_LookupStep_typestack = array('LookupStep');
-    function match_LookupStep ($stack = array()) {
+    function match_LookupStep ($stack = array()): bool|array {
     	$matchrule = "LookupStep"; $result = $this->construct($matchrule, $matchrule, null);
     	$_80 = NULL;
     	do {
@@ -668,7 +668,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* LastLookupStep: :Call */
     protected $match_LastLookupStep_typestack = array('LastLookupStep');
-    function match_LastLookupStep ($stack = array()) {
+    function match_LastLookupStep ($stack = array()): array|bool {
     	$matchrule = "LastLookupStep"; $result = $this->construct($matchrule, $matchrule, null);
     	$matcher = 'match_'.'Call'; $key = $matcher; $pos = $this->pos;
     	$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
@@ -682,7 +682,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* Lookup: LookupStep ("." LookupStep)* "." LastLookupStep | LastLookupStep */
     protected $match_Lookup_typestack = array('Lookup');
-    function match_Lookup ($stack = array()) {
+    function match_Lookup ($stack = array()): array|bool {
     	$matchrule = "Lookup"; $result = $this->construct($matchrule, $matchrule, null);
     	$_94 = NULL;
     	do {
@@ -758,7 +758,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function Lookup__construct(&$res)
+    function Lookup__construct(array &$res): void
     {
         $res['php'] = '$scope->locally()';
         $res['LookupSteps'] = [];
@@ -769,7 +769,7 @@ class SSTemplateParser extends Parser implements TemplateParser
      * get the next ViewableData in the sequence, and LastLookupStep calls different methods (XML_val, hasValue, obj)
      * depending on the context the lookup is used in.
      */
-    function Lookup_AddLookupStep(&$res, $sub, $method)
+    function Lookup_AddLookupStep(array &$res, array $sub, string $method): void
     {
         $res['LookupSteps'][] = $sub;
 
@@ -782,12 +782,12 @@ class SSTemplateParser extends Parser implements TemplateParser
         }
     }
 
-    function Lookup_LookupStep(&$res, $sub)
+    function Lookup_LookupStep(array &$res, array $sub): void
     {
         $this->Lookup_AddLookupStep($res, $sub, 'obj');
     }
 
-    function Lookup_LastLookupStep(&$res, $sub)
+    function Lookup_LastLookupStep(array &$res, array $sub): void
     {
         $this->Lookup_AddLookupStep($res, $sub, '$$FINAL');
     }
@@ -796,7 +796,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     /* Translate: "<%t" < Entity < (Default:QuotedString)? < (!("is" "=") < "is" < Context:QuotedString)? <
     (InjectionVariables)? > "%>" */
     protected $match_Translate_typestack = array('Translate');
-    function match_Translate ($stack = array()) {
+    function match_Translate ($stack = array()): bool|array {
     	$matchrule = "Translate"; $result = $this->construct($matchrule, $matchrule, null);
     	$_120 = NULL;
     	do {
@@ -909,7 +909,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* InjectionVariables: (< InjectionName:Word "=" Argument)+ */
     protected $match_InjectionVariables_typestack = array('InjectionVariables');
-    function match_InjectionVariables ($stack = array()) {
+    function match_InjectionVariables ($stack = array()): bool|array {
     	$matchrule = "InjectionVariables"; $result = $this->construct($matchrule, $matchrule, null);
     	$count = 0;
     	while (true) {
@@ -954,7 +954,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* Entity: / [A-Za-z_\\] [\w\.\\]* / */
     protected $match_Entity_typestack = array('Entity');
-    function match_Entity ($stack = array()) {
+    function match_Entity ($stack = array()): array {
     	$matchrule = "Entity"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [A-Za-z_\\\\] [\w\.\\\\]* /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -966,52 +966,52 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function Translate__construct(&$res)
+    function Translate__construct(array &$res): void
     {
         $res['php'] = '$val .= _t(';
     }
 
-    function Translate_Entity(&$res, $sub)
+    function Translate_Entity(array &$res, array $sub): void
     {
         $res['php'] .= "'$sub[text]'";
     }
 
-    function Translate_Default(&$res, $sub)
+    function Translate_Default(array &$res, array $sub): void
     {
         $res['php'] .= ",$sub[text]";
     }
 
-    function Translate_Context(&$res, $sub)
+    function Translate_Context(array &$res, array $sub): void
     {
         $res['php'] .= ",$sub[text]";
     }
 
-    function Translate_InjectionVariables(&$res, $sub)
+    function Translate_InjectionVariables(array &$res, array $sub): void
     {
         $res['php'] .= ",$sub[php]";
     }
 
-    function Translate__finalise(&$res)
+    function Translate__finalise(array &$res): void
     {
         $res['php'] .= ');';
     }
 
-    function InjectionVariables__construct(&$res)
+    function InjectionVariables__construct(array &$res): void
     {
         $res['php'] = "[";
     }
 
-    function InjectionVariables_InjectionName(&$res, $sub)
+    function InjectionVariables_InjectionName(array &$res, array $sub): void
     {
         $res['php'] .= "'$sub[text]'=>";
     }
 
-    function InjectionVariables_Argument(&$res, $sub)
+    function InjectionVariables_Argument(array &$res, array $sub): void
     {
         $res['php'] .= str_replace('$$FINAL', 'XML_val', $sub['php'] ?? '') . ',';
     }
 
-    function InjectionVariables__finalise(&$res)
+    function InjectionVariables__finalise(array &$res): void
     {
         if (substr($res['php'] ?? '', -1) == ',') {
             $res['php'] = substr($res['php'] ?? '', 0, -1); //remove last comma in the array
@@ -1021,7 +1021,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* MalformedBracketInjection: "{$" :Lookup !( "}" ) */
     protected $match_MalformedBracketInjection_typestack = array('MalformedBracketInjection');
-    function match_MalformedBracketInjection ($stack = array()) {
+    function match_MalformedBracketInjection ($stack = array()): bool {
     	$matchrule = "MalformedBracketInjection"; $result = $this->construct($matchrule, $matchrule, null);
     	$_134 = NULL;
     	do {
@@ -1063,7 +1063,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function MalformedBracketInjection__finalise(&$res)
+    function MalformedBracketInjection__finalise(array &$res)
     {
         $lookup = $res['text'];
         throw new SSTemplateParseException("Malformed bracket injection $lookup. Perhaps you have forgotten the " .
@@ -1072,7 +1072,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* SimpleInjection: '$' :Lookup */
     protected $match_SimpleInjection_typestack = array('SimpleInjection');
-    function match_SimpleInjection ($stack = array()) {
+    function match_SimpleInjection ($stack = array()): bool|array {
     	$matchrule = "SimpleInjection"; $result = $this->construct($matchrule, $matchrule, null);
     	$_138 = NULL;
     	do {
@@ -1097,7 +1097,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* BracketInjection: '{$' :Lookup "}" */
     protected $match_BracketInjection_typestack = array('BracketInjection');
-    function match_BracketInjection ($stack = array()) {
+    function match_BracketInjection ($stack = array()): bool|array {
     	$matchrule = "BracketInjection"; $result = $this->construct($matchrule, $matchrule, null);
     	$_143 = NULL;
     	do {
@@ -1124,7 +1124,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* Injection: BracketInjection | SimpleInjection */
     protected $match_Injection_typestack = array('Injection');
-    function match_Injection ($stack = array()) {
+    function match_Injection ($stack = array()): bool|array {
     	$matchrule = "Injection"; $result = $this->construct($matchrule, $matchrule, null);
     	$_148 = NULL;
     	do {
@@ -1155,14 +1155,14 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function Injection_STR(&$res, $sub)
+    function Injection_STR(array &$res, array $sub): void
     {
         $res['php'] = '$val .= '. str_replace('$$FINAL', 'XML_val', $sub['Lookup']['php'] ?? '') . ';';
     }
 
     /* DollarMarkedLookup: SimpleInjection */
     protected $match_DollarMarkedLookup_typestack = array('DollarMarkedLookup');
-    function match_DollarMarkedLookup ($stack = array()) {
+    function match_DollarMarkedLookup ($stack = array()): array|bool {
     	$matchrule = "DollarMarkedLookup"; $result = $this->construct($matchrule, $matchrule, null);
     	$matcher = 'match_'.'SimpleInjection'; $key = $matcher; $pos = $this->pos;
     	$subres = ( $this->packhas( $key, $pos ) ? $this->packread( $key, $pos ) : $this->packwrite( $key, $pos, $this->$matcher(array_merge($stack, array($result))) ) );
@@ -1175,14 +1175,14 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function DollarMarkedLookup_STR(&$res, $sub)
+    function DollarMarkedLookup_STR(array &$res, array $sub): void
     {
         $res['Lookup'] = $sub['Lookup'];
     }
 
     /* QuotedString: q:/['"]/   String:/ (\\\\ | \\. | [^$q\\])* /   '$q' */
     protected $match_QuotedString_typestack = array('QuotedString');
-    function match_QuotedString ($stack = array()) {
+    function match_QuotedString ($stack = array()): bool|array {
     	$matchrule = "QuotedString"; $result = $this->construct($matchrule, $matchrule, null);
     	$_154 = NULL;
     	do {
@@ -1218,7 +1218,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* FreeString: /[^,)%!=><|&]+/ */
     protected $match_FreeString_typestack = array('FreeString');
-    function match_FreeString ($stack = array()) {
+    function match_FreeString ($stack = array()): bool|array {
     	$matchrule = "FreeString"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/[^,)%!=><|&]+/' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -1234,7 +1234,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     :Lookup !(< FreeString)|
     :FreeString */
     protected $match_Argument_typestack = array('Argument');
-    function match_Argument ($stack = array()) {
+    function match_Argument ($stack = array()): array|bool {
     	$matchrule = "Argument"; $result = $this->construct($matchrule, $matchrule, null);
     	$_174 = NULL;
     	do {
@@ -1345,19 +1345,19 @@ class SSTemplateParser extends Parser implements TemplateParser
      * if the context indicates a string
      */
 
-    function Argument_DollarMarkedLookup(&$res, $sub)
+    function Argument_DollarMarkedLookup(array &$res, array $sub): void
     {
         $res['ArgumentMode'] = 'lookup';
         $res['php'] = $sub['Lookup']['php'];
     }
 
-    function Argument_QuotedString(&$res, $sub)
+    function Argument_QuotedString(array &$res, array $sub): void
     {
         $res['ArgumentMode'] = 'string';
         $res['php'] = "'" . str_replace("'", "\\'", $sub['String']['text'] ?? '') . "'";
     }
 
-    function Argument_Lookup(&$res, $sub)
+    function Argument_Lookup(array &$res, array $sub): void
     {
         if (count($sub['LookupSteps'] ?? []) == 1 && !isset($sub['LookupSteps'][0]['Call']['Arguments'])) {
             $res['ArgumentMode'] = 'default';
@@ -1369,7 +1369,7 @@ class SSTemplateParser extends Parser implements TemplateParser
         }
     }
 
-    function Argument_FreeString(&$res, $sub)
+    function Argument_FreeString(array &$res, array $sub): void
     {
         $res['ArgumentMode'] = 'string';
         $res['php'] = "'" . str_replace("'", "\\'", trim($sub['text'] ?? '')) . "'";
@@ -1377,7 +1377,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* ComparisonOperator: "!=" | "==" | ">=" | ">" | "<=" | "<" | "=" */
     protected $match_ComparisonOperator_typestack = array('ComparisonOperator');
-    function match_ComparisonOperator ($stack = array()) {
+    function match_ComparisonOperator ($stack = array()): bool|array {
     	$matchrule = "ComparisonOperator"; $result = $this->construct($matchrule, $matchrule, null);
     	$_199 = NULL;
     	do {
@@ -1488,7 +1488,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* Comparison: Argument < ComparisonOperator > Argument */
     protected $match_Comparison_typestack = array('Comparison');
-    function match_Comparison ($stack = array()) {
+    function match_Comparison ($stack = array()): bool|array {
     	$matchrule = "Comparison"; $result = $this->construct($matchrule, $matchrule, null);
     	$_206 = NULL;
     	do {
@@ -1521,7 +1521,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function Comparison_Argument(&$res, $sub)
+    function Comparison_Argument(array &$res, array $sub): void
     {
         if ($sub['ArgumentMode'] == 'default') {
             if (!empty($res['php'])) {
@@ -1534,14 +1534,14 @@ class SSTemplateParser extends Parser implements TemplateParser
         }
     }
 
-    function Comparison_ComparisonOperator(&$res, $sub)
+    function Comparison_ComparisonOperator(array &$res, array $sub): void
     {
         $res['php'] .= ($sub['text'] == '=' ? '==' : $sub['text']);
     }
 
     /* PresenceCheck: (Not:'not' <)? Argument */
     protected $match_PresenceCheck_typestack = array('PresenceCheck');
-    function match_PresenceCheck ($stack = array()) {
+    function match_PresenceCheck ($stack = array()): array|bool {
     	$matchrule = "PresenceCheck"; $result = $this->construct($matchrule, $matchrule, null);
     	$_213 = NULL;
     	do {
@@ -1584,12 +1584,12 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function PresenceCheck_Not(&$res, $sub)
+    function PresenceCheck_Not(array &$res, array $sub): void
     {
         $res['php'] = '!';
     }
 
-    function PresenceCheck_Argument(&$res, $sub)
+    function PresenceCheck_Argument(array &$res, array $sub): void
     {
         if ($sub['ArgumentMode'] == 'string') {
             $res['php'] .= '((bool)'.$sub['php'].')';
@@ -1603,7 +1603,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* IfArgumentPortion: Comparison | PresenceCheck */
     protected $match_IfArgumentPortion_typestack = array('IfArgumentPortion');
-    function match_IfArgumentPortion ($stack = array()) {
+    function match_IfArgumentPortion ($stack = array()): array|bool {
     	$matchrule = "IfArgumentPortion"; $result = $this->construct($matchrule, $matchrule, null);
     	$_218 = NULL;
     	do {
@@ -1634,14 +1634,14 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function IfArgumentPortion_STR(&$res, $sub)
+    function IfArgumentPortion_STR(array &$res, array $sub): void
     {
         $res['php'] = $sub['php'];
     }
 
     /* BooleanOperator: "||" | "&&" */
     protected $match_BooleanOperator_typestack = array('BooleanOperator');
-    function match_BooleanOperator ($stack = array()) {
+    function match_BooleanOperator ($stack = array()): bool|array {
     	$matchrule = "BooleanOperator"; $result = $this->construct($matchrule, $matchrule, null);
     	$_223 = NULL;
     	do {
@@ -1669,7 +1669,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* IfArgument: :IfArgumentPortion ( < :BooleanOperator < :IfArgumentPortion )* */
     protected $match_IfArgument_typestack = array('IfArgument');
-    function match_IfArgument ($stack = array()) {
+    function match_IfArgument ($stack = array()): array|bool {
     	$matchrule = "IfArgument"; $result = $this->construct($matchrule, $matchrule, null);
     	$_232 = NULL;
     	do {
@@ -1718,19 +1718,19 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function IfArgument_IfArgumentPortion(&$res, $sub)
+    function IfArgument_IfArgumentPortion(array &$res, array $sub): void
     {
         $res['php'] .= $sub['php'];
     }
 
-    function IfArgument_BooleanOperator(&$res, $sub)
+    function IfArgument_BooleanOperator(array &$res, array $sub): void
     {
         $res['php'] .= $sub['text'];
     }
 
     /* IfPart: '<%' < 'if' [ :IfArgument > '%>' Template:$TemplateMatcher? */
     protected $match_IfPart_typestack = array('IfPart');
-    function match_IfPart ($stack = array()) {
+    function match_IfPart ($stack = array()): bool|array {
     	$matchrule = "IfPart"; $result = $this->construct($matchrule, $matchrule, null);
     	$_242 = NULL;
     	do {
@@ -1773,7 +1773,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* ElseIfPart: '<%' < 'else_if' [ :IfArgument > '%>' Template:$TemplateMatcher? */
     protected $match_ElseIfPart_typestack = array('ElseIfPart');
-    function match_ElseIfPart ($stack = array()) {
+    function match_ElseIfPart ($stack = array()): bool|array {
     	$matchrule = "ElseIfPart"; $result = $this->construct($matchrule, $matchrule, null);
     	$_252 = NULL;
     	do {
@@ -1816,7 +1816,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* ElsePart: '<%' < 'else' > '%>' Template:$TemplateMatcher? */
     protected $match_ElsePart_typestack = array('ElsePart');
-    function match_ElsePart ($stack = array()) {
+    function match_ElsePart ($stack = array()): array|bool {
     	$matchrule = "ElsePart"; $result = $this->construct($matchrule, $matchrule, null);
     	$_260 = NULL;
     	do {
@@ -1851,7 +1851,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* If: IfPart ElseIfPart* ElsePart? '<%' < 'end_if' > '%>' */
     protected $match_If_typestack = array('If');
-    function match_If ($stack = array()) {
+    function match_If ($stack = array()): bool|array {
     	$matchrule = "If"; $result = $this->construct($matchrule, $matchrule, null);
     	$_270 = NULL;
     	do {
@@ -1907,7 +1907,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function If_IfPart(&$res, $sub)
+    function If_IfPart(array &$res, array $sub): void
     {
         $res['php'] =
             'if (' . $sub['IfArgument']['php'] . ') { ' . PHP_EOL .
@@ -1915,7 +1915,7 @@ class SSTemplateParser extends Parser implements TemplateParser
             '}';
     }
 
-    function If_ElseIfPart(&$res, $sub)
+    function If_ElseIfPart(array &$res, array $sub): void
     {
         $res['php'] .=
             'else if (' . $sub['IfArgument']['php'] . ') { ' . PHP_EOL .
@@ -1923,7 +1923,7 @@ class SSTemplateParser extends Parser implements TemplateParser
             '}';
     }
 
-    function If_ElsePart(&$res, $sub)
+    function If_ElsePart(array &$res, array $sub): void
     {
         $res['php'] .=
             'else { ' . PHP_EOL .
@@ -1933,7 +1933,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* Require: '<%' < 'require' [ Call:(Method:Word "(" < :CallArguments  > ")") > '%>' */
     protected $match_Require_typestack = array('Require');
-    function match_Require ($stack = array()) {
+    function match_Require ($stack = array()): bool|array {
     	$matchrule = "Require"; $result = $this->construct($matchrule, $matchrule, null);
     	$_286 = NULL;
     	do {
@@ -1994,7 +1994,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function Require_Call(&$res, $sub)
+    function Require_Call(array &$res, array $sub): void
     {
         $requirements = '\\SilverStripe\\View\\Requirements';
         $res['php'] = "{$requirements}::".$sub['Method']['text'].'('.$sub['CallArguments']['php'].');';
@@ -2009,7 +2009,7 @@ class SSTemplateParser extends Parser implements TemplateParser
         :Lookup
     ) */
     protected $match_CacheBlockArgument_typestack = array('CacheBlockArgument');
-    function match_CacheBlockArgument ($stack = array()) {
+    function match_CacheBlockArgument ($stack = array()): bool|array {
     	$matchrule = "CacheBlockArgument"; $result = $this->construct($matchrule, $matchrule, null);
     	$_306 = NULL;
     	do {
@@ -2111,19 +2111,19 @@ class SSTemplateParser extends Parser implements TemplateParser
         $res['php'] = $sub['Lookup']['php'];
     }
 
-    function CacheBlockArgument_QuotedString(&$res, $sub)
+    function CacheBlockArgument_QuotedString(array &$res, array $sub): void
     {
         $res['php'] = "'" . str_replace("'", "\\'", $sub['String']['text'] ?? '') . "'";
     }
 
-    function CacheBlockArgument_Lookup(&$res, $sub)
+    function CacheBlockArgument_Lookup(array &$res, array $sub): void
     {
         $res['php'] = $sub['php'];
     }
 
     /* CacheBlockArguments: CacheBlockArgument ( < "," < CacheBlockArgument )* */
     protected $match_CacheBlockArguments_typestack = array('CacheBlockArguments');
-    function match_CacheBlockArguments ($stack = array()) {
+    function match_CacheBlockArguments ($stack = array()): bool|array {
     	$matchrule = "CacheBlockArguments"; $result = $this->construct($matchrule, $matchrule, null);
     	$_315 = NULL;
     	do {
@@ -2171,7 +2171,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function CacheBlockArguments_CacheBlockArgument(&$res, $sub)
+    function CacheBlockArguments_CacheBlockArgument(array &$res, array $sub): void
     {
         if (!empty($res['php'])) {
             $res['php'] .= ".'_'.";
@@ -2185,7 +2185,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     /* CacheBlockTemplate: (Comment | Translate | If | Require |    OldI18NTag | Include | ClosedBlock |
     OpenBlock | MalformedBlock | MalformedBracketInjection | Injection | Text)+ */
     protected $match_CacheBlockTemplate_typestack = array('CacheBlockTemplate','Template');
-    function match_CacheBlockTemplate ($stack = array()) {
+    function match_CacheBlockTemplate ($stack = array()): bool|array {
     	$matchrule = "CacheBlockTemplate"; $result = $this->construct($matchrule, $matchrule, array('TemplateMatcher' => 'CacheRestrictedTemplate'));
     	$count = 0;
     	while (true) {
@@ -2421,7 +2421,7 @@ class SSTemplateParser extends Parser implements TemplateParser
         Template:$TemplateMatcher?
         '<%' < 'end_' ("uncached"|"cached"|"cacheblock") > '%>' */
     protected $match_UncachedBlock_typestack = array('UncachedBlock');
-    function match_UncachedBlock ($stack = array()) {
+    function match_UncachedBlock ($stack = array()): bool|array {
     	$matchrule = "UncachedBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_400 = NULL;
     	do {
@@ -2574,7 +2574,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function UncachedBlock_Template(&$res, $sub)
+    function UncachedBlock_Template(array &$res, array $sub): void
     {
         $res['php'] = $sub['php'];
     }
@@ -2582,7 +2582,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     /* CacheRestrictedTemplate: (Comment | Translate | If | Require | CacheBlock | UncachedBlock | OldI18NTag | Include | ClosedBlock |
     OpenBlock | MalformedBlock | MalformedBracketInjection | Injection | Text)+ */
     protected $match_CacheRestrictedTemplate_typestack = array('CacheRestrictedTemplate','Template');
-    function match_CacheRestrictedTemplate ($stack = array()) {
+    function match_CacheRestrictedTemplate ($stack = array()): array {
     	$matchrule = "CacheRestrictedTemplate"; $result = $this->construct($matchrule, $matchrule, null);
     	$count = 0;
     	while (true) {
@@ -2850,7 +2850,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function CacheRestrictedTemplate_CacheBlock(&$res, $sub)
+    function CacheRestrictedTemplate_CacheBlock(array &$res, array $sub)
     {
         throw new SSTemplateParseException('You cant have cache blocks nested within with, loop or control blocks ' .
             'that are within cache blocks', $this);
@@ -2868,7 +2868,7 @@ class SSTemplateParser extends Parser implements TemplateParser
         (CacheBlock | UncachedBlock | CacheBlockTemplate)*
     '<%' < 'end_' ("cached"|"uncached"|"cacheblock") > '%>' */
     protected $match_CacheBlock_typestack = array('CacheBlock');
-    function match_CacheBlock ($stack = array()) {
+    function match_CacheBlock ($stack = array()): bool|array {
     	$matchrule = "CacheBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_511 = NULL;
     	do {
@@ -3104,32 +3104,32 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function CacheBlock__construct(&$res)
+    function CacheBlock__construct(array &$res): void
     {
         $res['subblocks'] = 0;
     }
 
-    function CacheBlock_CacheBlockArguments(&$res, $sub)
+    function CacheBlock_CacheBlockArguments(array &$res, array $sub): void
     {
         $res['key'] = !empty($sub['php']) ? $sub['php'] : '';
     }
 
-    function CacheBlock_Condition(&$res, $sub)
+    function CacheBlock_Condition(array &$res, array $sub): void
     {
         $res['condition'] = ($res['Conditional']['text'] == 'if' ? '(' : '!(') . $sub['php'] . ') && ';
     }
 
-    function CacheBlock_CacheBlock(&$res, $sub)
+    function CacheBlock_CacheBlock(array &$res, array $sub): void
     {
         $res['php'] .= $sub['php'];
     }
 
-    function CacheBlock_UncachedBlock(&$res, $sub)
+    function CacheBlock_UncachedBlock(array &$res, array $sub): void
     {
         $res['php'] .= $sub['php'];
     }
 
-    function CacheBlock_CacheBlockTemplate(&$res, $sub)
+    function CacheBlock_CacheBlockTemplate(array &$res, array $sub): void
     {
         // Get the block counter
         $block = ++$res['subblocks'];
@@ -3166,7 +3166,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* OldTPart: "_t" N "(" N QuotedString (N "," N CallArguments)? N ")" N (";")? */
     protected $match_OldTPart_typestack = array('OldTPart');
-    function match_OldTPart ($stack = array()) {
+    function match_OldTPart ($stack = array()): bool|array {
     	$matchrule = "OldTPart"; $result = $this->construct($matchrule, $matchrule, null);
     	$_530 = NULL;
     	do {
@@ -3276,7 +3276,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* N: / [\s\n]* / */
     protected $match_N_typestack = array('N');
-    function match_N ($stack = array()) {
+    function match_N ($stack = array()): array {
     	$matchrule = "N"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->rx( '/ [\s\n]* /' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -3287,12 +3287,12 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function OldTPart__construct(&$res)
+    function OldTPart__construct(array &$res): void
     {
         $res['php'] = "_t(";
     }
 
-    function OldTPart_QuotedString(&$res, $sub)
+    function OldTPart_QuotedString(array &$res, array $sub): void
     {
         $entity = $sub['String']['text'];
         if (strpos($entity ?? '', '.') === false) {
@@ -3302,19 +3302,19 @@ class SSTemplateParser extends Parser implements TemplateParser
         }
     }
 
-    function OldTPart_CallArguments(&$res, $sub)
+    function OldTPart_CallArguments(array &$res, array $sub): void
     {
         $res['php'] .= ',' . $sub['php'];
     }
 
-    function OldTPart__finalise(&$res)
+    function OldTPart__finalise(array &$res): void
     {
         $res['php'] .= ')';
     }
 
     /* OldTTag: "<%" < OldTPart > "%>" */
     protected $match_OldTTag_typestack = array('OldTTag');
-    function match_OldTTag ($stack = array()) {
+    function match_OldTTag ($stack = array()): bool|array {
     	$matchrule = "OldTTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_538 = NULL;
     	do {
@@ -3339,14 +3339,14 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function OldTTag_OldTPart(&$res, $sub)
+    function OldTTag_OldTPart(array &$res, array $sub): void
     {
         $res['php'] = $sub['php'];
     }
 
     /* OldSprintfTag: "<%" < "sprintf" < "(" < OldTPart < "," < CallArguments > ")" > "%>" */
     protected $match_OldSprintfTag_typestack = array('OldSprintfTag');
-    function match_OldSprintfTag ($stack = array()) {
+    function match_OldSprintfTag ($stack = array()): bool {
     	$matchrule = "OldSprintfTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_555 = NULL;
     	do {
@@ -3399,7 +3399,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function OldSprintfTag__construct(&$res)
+    function OldSprintfTag__construct(array &$res): void
     {
         $res['php'] = "sprintf(";
     }
@@ -3416,7 +3416,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* OldI18NTag: OldSprintfTag | OldTTag */
     protected $match_OldI18NTag_typestack = array('OldI18NTag');
-    function match_OldI18NTag ($stack = array()) {
+    function match_OldI18NTag ($stack = array()): bool|array {
     	$matchrule = "OldI18NTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_560 = NULL;
     	do {
@@ -3447,14 +3447,14 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function OldI18NTag_STR(&$res, $sub)
+    function OldI18NTag_STR(array &$res, array $sub): void
     {
         $res['php'] = '$val .= ' . $sub['php'] . ';';
     }
 
     /* NamedArgument: Name:Word "=" Value:Argument */
     protected $match_NamedArgument_typestack = array('NamedArgument');
-    function match_NamedArgument ($stack = array()) {
+    function match_NamedArgument ($stack = array()): bool|array {
     	$matchrule = "NamedArgument"; $result = $this->construct($matchrule, $matchrule, null);
     	$_565 = NULL;
     	do {
@@ -3484,12 +3484,12 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function NamedArgument_Name(&$res, $sub)
+    function NamedArgument_Name(array &$res, array $sub): void
     {
         $res['php'] = "'" . $sub['text'] . "' => ";
     }
 
-    function NamedArgument_Value(&$res, $sub)
+    function NamedArgument_Value(array &$res, array $sub): void
     {
         switch ($sub['ArgumentMode']) {
             case 'string':
@@ -3508,7 +3508,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* Include: "<%" < "include" < Template:NamespacedWord < (NamedArgument ( < "," < NamedArgument )*)? > "%>" */
     protected $match_Include_typestack = array('Include');
-    function match_Include ($stack = array()) {
+    function match_Include ($stack = array()): bool|array {
     	$matchrule = "Include"; $result = $this->construct($matchrule, $matchrule, null);
     	$_584 = NULL;
     	do {
@@ -3585,22 +3585,22 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function Include__construct(&$res)
+    function Include__construct(array &$res): void
     {
         $res['arguments'] = [];
     }
 
-    function Include_Template(&$res, $sub)
+    function Include_Template(array &$res, array $sub): void
     {
         $res['template'] = "'" . $sub['text'] . "'";
     }
 
-    function Include_NamedArgument(&$res, $sub)
+    function Include_NamedArgument(array &$res, array $sub): void
     {
         $res['arguments'][] = $sub['php'];
     }
 
-    function Include__finalise(&$res)
+    function Include__finalise(array &$res): void
     {
         $template = $res['template'];
         $arguments = $res['arguments'];
@@ -3619,7 +3619,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* BlockArguments: :Argument ( < "," < :Argument)* */
     protected $match_BlockArguments_typestack = array('BlockArguments');
-    function match_BlockArguments ($stack = array()) {
+    function match_BlockArguments ($stack = array()): array|bool {
     	$matchrule = "BlockArguments"; $result = $this->construct($matchrule, $matchrule, null);
     	$_593 = NULL;
     	do {
@@ -3668,7 +3668,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* NotBlockTag: "end_" | (("if" | "else_if" | "else" | "require" | "cached" | "uncached" | "cacheblock" | "include")]) */
     protected $match_NotBlockTag_typestack = array('NotBlockTag');
-    function match_NotBlockTag ($stack = array()) {
+    function match_NotBlockTag ($stack = array()): bool|array {
     	$matchrule = "NotBlockTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_631 = NULL;
     	do {
@@ -3823,7 +3823,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     /* ClosedBlock: '<%' < !NotBlockTag BlockName:Word ( [ :BlockArguments ] )? > Zap:'%>' Template:$TemplateMatcher?
     '<%' < 'end_' '$BlockName' > '%>' */
     protected $match_ClosedBlock_typestack = array('ClosedBlock');
-    function match_ClosedBlock ($stack = array()) {
+    function match_ClosedBlock ($stack = array()): bool|array {
     	$matchrule = "ClosedBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_651 = NULL;
     	do {
@@ -3931,12 +3931,12 @@ class SSTemplateParser extends Parser implements TemplateParser
      * the php result of this block as it's return value, or throw an error if incorrect arguments were passed.
      */
 
-    function ClosedBlock__construct(&$res)
+    function ClosedBlock__construct(array &$res): void
     {
         $res['ArgumentCount'] = 0;
     }
 
-    function ClosedBlock_BlockArguments(&$res, $sub)
+    function ClosedBlock_BlockArguments(array &$res, array $sub): void
     {
         if (isset($sub['Argument']['ArgumentMode'])) {
             $res['Arguments'] = [$sub['Argument']];
@@ -3947,7 +3947,7 @@ class SSTemplateParser extends Parser implements TemplateParser
         }
     }
 
-    function ClosedBlock__finalise(&$res)
+    function ClosedBlock__finalise(array &$res): void
     {
         $blockname = $res['BlockName']['text'];
 
@@ -3965,7 +3965,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     /**
      * This is an example of a block handler function. This one handles the loop tag.
      */
-    function ClosedBlock_Handle_Loop(&$res)
+    function ClosedBlock_Handle_Loop(array &$res): string
     {
         if ($res['ArgumentCount'] > 1) {
             throw new SSTemplateParseException('Either no or too many arguments in control block. Must be one ' .
@@ -3996,7 +3996,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     /**
      * The closed block handler for with blocks
      */
-    function ClosedBlock_Handle_With(&$res)
+    function ClosedBlock_Handle_With(array &$res): string
     {
         if ($res['ArgumentCount'] != 1) {
             throw new SSTemplateParseException('Either no or too many arguments in with block. Must be one ' .
@@ -4017,7 +4017,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* OpenBlock: '<%' < !NotBlockTag BlockName:Word ( [ :BlockArguments ] )? > '%>' */
     protected $match_OpenBlock_typestack = array('OpenBlock');
-    function match_OpenBlock ($stack = array()) {
+    function match_OpenBlock ($stack = array()): bool|array {
     	$matchrule = "OpenBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_664 = NULL;
     	do {
@@ -4079,7 +4079,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function OpenBlock__construct(&$res)
+    function OpenBlock__construct(array &$res): void
     {
         $res['ArgumentCount'] = 0;
     }
@@ -4095,7 +4095,7 @@ class SSTemplateParser extends Parser implements TemplateParser
         }
     }
 
-    function OpenBlock__finalise(&$res)
+    function OpenBlock__finalise(array &$res): void
     {
         $blockname = $res['BlockName']['text'];
 
@@ -4134,7 +4134,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     /**
      * This is an open block handler, for the <% base_tag %> tag
      */
-    function OpenBlock_Handle_Base_tag(&$res)
+    function OpenBlock_Handle_Base_tag(array &$res): string
     {
         if ($res['ArgumentCount'] != 0) {
             throw new SSTemplateParseException('Base_tag takes no arguments', $this);
@@ -4155,7 +4155,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* MismatchedEndBlock: '<%' < 'end_' :Word > '%>' */
     protected $match_MismatchedEndBlock_typestack = array('MismatchedEndBlock');
-    function match_MismatchedEndBlock ($stack = array()) {
+    function match_MismatchedEndBlock ($stack = array()): bool {
     	$matchrule = "MismatchedEndBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_672 = NULL;
     	do {
@@ -4191,7 +4191,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* MalformedOpenTag: '<%' < !NotBlockTag Tag:Word  !( ( [ :BlockArguments ] )? > '%>' ) */
     protected $match_MalformedOpenTag_typestack = array('MalformedOpenTag');
-    function match_MalformedOpenTag ($stack = array()) {
+    function match_MalformedOpenTag ($stack = array()): bool {
     	$matchrule = "MalformedOpenTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_687 = NULL;
     	do {
@@ -4277,7 +4277,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* MalformedCloseTag: '<%' < Tag:('end_' :Word ) !( > '%>' ) */
     protected $match_MalformedCloseTag_typestack = array('MalformedCloseTag');
-    function match_MalformedCloseTag ($stack = array()) {
+    function match_MalformedCloseTag ($stack = array()): bool {
     	$matchrule = "MalformedCloseTag"; $result = $this->construct($matchrule, $matchrule, null);
     	$_699 = NULL;
     	do {
@@ -4343,7 +4343,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* MalformedBlock: MalformedOpenTag | MalformedCloseTag */
     protected $match_MalformedBlock_typestack = array('MalformedBlock');
-    function match_MalformedBlock ($stack = array()) {
+    function match_MalformedBlock ($stack = array()): bool {
     	$matchrule = "MalformedBlock"; $result = $this->construct($matchrule, $matchrule, null);
     	$_704 = NULL;
     	do {
@@ -4377,7 +4377,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* CommentWithContent: '<%--' ( !"--%>" /(?s)./ )+ '--%>' */
     protected $match_CommentWithContent_typestack = array('CommentWithContent');
-    function match_CommentWithContent ($stack = array()) {
+    function match_CommentWithContent ($stack = array()): bool|array {
     	$matchrule = "CommentWithContent"; $result = $this->construct($matchrule, $matchrule, null);
     	$_712 = NULL;
     	do {
@@ -4429,7 +4429,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* EmptyComment: '<%----%>' */
     protected $match_EmptyComment_typestack = array('EmptyComment');
-    function match_EmptyComment ($stack = array()) {
+    function match_EmptyComment ($stack = array()): bool|array {
     	$matchrule = "EmptyComment"; $result = $this->construct($matchrule, $matchrule, null);
     	if (( $subres = $this->literal( '<%----%>' ) ) !== FALSE) {
     		$result["text"] .= $subres;
@@ -4441,7 +4441,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     /* Comment: :EmptyComment | :CommentWithContent */
     protected $match_Comment_typestack = array('Comment');
-    function match_Comment ($stack = array()) {
+    function match_Comment ($stack = array()): bool|array {
     	$matchrule = "Comment"; $result = $this->construct($matchrule, $matchrule, null);
     	$_718 = NULL;
     	do {
@@ -4472,7 +4472,7 @@ class SSTemplateParser extends Parser implements TemplateParser
 
 
 
-    function Comment__construct(&$res)
+    function Comment__construct(array &$res): void
     {
         $res['php'] = '';
     }
@@ -4480,7 +4480,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     /* TopTemplate: (Comment | Translate | If | Require | CacheBlock | UncachedBlock | OldI18NTag | Include | ClosedBlock |
     OpenBlock |  MalformedBlock | MismatchedEndBlock  | MalformedBracketInjection | Injection | Text)+ */
     protected $match_TopTemplate_typestack = array('TopTemplate','Template');
-    function match_TopTemplate ($stack = array()) {
+    function match_TopTemplate ($stack = array()): array|bool {
     	$matchrule = "TopTemplate"; $result = $this->construct($matchrule, $matchrule, array('TemplateMatcher' => 'Template'));
     	$count = 0;
     	while (true) {
@@ -4772,7 +4772,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     /**
      * The TopTemplate also includes the opening stanza to start off the template
      */
-    function TopTemplate__construct(&$res)
+    function TopTemplate__construct(array &$res): void
     {
         $res['php'] = "<?php" . PHP_EOL;
     }
@@ -4786,7 +4786,7 @@ class SSTemplateParser extends Parser implements TemplateParser
         '{$' !(/[A-Za-z_]/)
     )+ */
     protected $match_Text_typestack = array('Text');
-    function match_Text ($stack = array()) {
+    function match_Text ($stack = array()): array|bool {
     	$matchrule = "Text"; $result = $this->construct($matchrule, $matchrule, null);
     	$count = 0;
     	while (true) {
@@ -4993,7 +4993,7 @@ class SSTemplateParser extends Parser implements TemplateParser
     /**
      * We convert text
      */
-    function Text__finalise(&$res)
+    function Text__finalise(array &$res): void
     {
         $text = $res['text'];
 
@@ -5032,7 +5032,7 @@ EOC;
      * @param bool $topTemplate True if this is a top template, false if it's just a template
      * @return mixed|string The php that, when executed (via include or exec) will behave as per the template source
      */
-    public function compileString($string, $templateName = "", $includeDebuggingComments = false, $topTemplate = true)
+    public function compileString(string|SilverStripe\ORM\FieldType\DBHTMLText $string, string $templateName = "", bool $includeDebuggingComments = false, bool $topTemplate = true): string
     {
         if (!trim($string ?? '')) {
             $code = '';
@@ -5074,7 +5074,7 @@ EOC;
      * @param string $templateName
      * @return string $code
      */
-    protected function includeDebuggingComments($code, $templateName)
+    protected function includeDebuggingComments(string $code, string $templateName): string
     {
         // If this template contains a doctype, put it right after it,
         // if not, put it after the <html> tag to avoid IE glitches

--- a/src/View/SSViewer.php
+++ b/src/View/SSViewer.php
@@ -193,7 +193,7 @@ class SSViewer implements Flushable
      *  </code>
      * @param TemplateParser $parser
      */
-    public function __construct($templates, TemplateParser $parser = null)
+    public function __construct(array|string $templates, TemplateParser $parser = null): void
     {
         if ($parser) {
             $this->setParser($parser);
@@ -219,7 +219,7 @@ class SSViewer implements Flushable
     /**
      * Triggered early in the request when someone requests a flush.
      */
-    public static function flush()
+    public static function flush(): void
     {
         self::flush_template_cache(true);
         self::flush_cacheblock_cache(true);
@@ -232,7 +232,7 @@ class SSViewer implements Flushable
      * @param bool|void $cacheTemplate Whether or not to cache the template from string
      * @return SSViewer
      */
-    public static function fromString($content, $cacheTemplate = null)
+    public static function fromString(string|SilverStripe\ORM\FieldType\DBHTMLText $content, bool $cacheTemplate = null): SilverStripe\View\SSViewer_FromString
     {
         $viewer = SSViewer_FromString::create($content);
         if ($cacheTemplate !== null) {
@@ -247,7 +247,7 @@ class SSViewer implements Flushable
      *
      * @param array $themes
      */
-    public static function set_themes($themes = [])
+    public static function set_themes(array $themes = []): void
     {
         static::$current_themes = $themes;
     }
@@ -257,7 +257,7 @@ class SSViewer implements Flushable
      *
      * @param array $themes
      */
-    public static function add_themes($themes = [])
+    public static function add_themes(array $themes = []): void
     {
         $currentThemes = SSViewer::get_themes();
         $finalThemes = array_merge($themes, $currentThemes);
@@ -270,7 +270,7 @@ class SSViewer implements Flushable
      *
      * @return array
      */
-    public static function get_themes()
+    public static function get_themes(): array
     {
         $default = [self::PUBLIC_THEME, self::DEFAULT_THEME];
 
@@ -316,7 +316,7 @@ class SSViewer implements Flushable
      * @param string $baseClass Class to halt ancestry search at
      * @return array
      */
-    public static function get_templates_by_class($classOrObject, $suffix = '', $baseClass = null)
+    public static function get_templates_by_class(string|SilverStripe\Forms\GridField\GridFieldButtonRow $classOrObject, string $suffix = '', string $baseClass = null): array
     {
         // Figure out the class name from the supplied context.
         if (!is_object($classOrObject) && !(
@@ -365,7 +365,7 @@ class SSViewer implements Flushable
      *
      * @return bool
      */
-    public function getRewriteHashLinks()
+    public function getRewriteHashLinks(): bool|string
     {
         if (isset($this->rewriteHashlinks)) {
             return $this->rewriteHashlinks;
@@ -390,7 +390,7 @@ class SSViewer implements Flushable
      *
      * @return bool
      */
-    public static function getRewriteHashLinksDefault()
+    public static function getRewriteHashLinksDefault(): bool|string
     {
         // Check if config overridden
         if (isset(static::$current_rewrite_hash_links)) {
@@ -404,7 +404,7 @@ class SSViewer implements Flushable
      *
      * @param bool $rewrite
      */
-    public static function setRewriteHashLinksDefault($rewrite)
+    public static function setRewriteHashLinksDefault(bool|string $rewrite): void
     {
         static::$current_rewrite_hash_links = $rewrite;
     }
@@ -412,7 +412,7 @@ class SSViewer implements Flushable
     /**
      * @param string|array $templates
      */
-    public function setTemplate($templates)
+    public function setTemplate(array|string $templates): void
     {
         $this->templates = $templates;
         $this->chosen = $this->chooseTemplate($templates);
@@ -425,7 +425,7 @@ class SSViewer implements Flushable
      * @param array|string $templates
      * @return string
      */
-    public static function chooseTemplate($templates)
+    public static function chooseTemplate(array|string $templates): string|null
     {
         return ThemeResourceLoader::inst()->findTemplate($templates, self::get_themes());
     }
@@ -435,7 +435,7 @@ class SSViewer implements Flushable
      *
      * @param TemplateParser $parser
      */
-    public function setParser(TemplateParser $parser)
+    public function setParser(TemplateParser $parser): void
     {
         $this->parser = $parser;
     }
@@ -445,7 +445,7 @@ class SSViewer implements Flushable
      *
      * @return TemplateParser
      */
-    public function getParser()
+    public function getParser(): SilverStripe\View\SSTemplateParser
     {
         if (!$this->parser) {
             $this->setParser(Injector::inst()->get('SilverStripe\\View\\SSTemplateParser'));
@@ -460,7 +460,7 @@ class SSViewer implements Flushable
      *
      * @return bool
      */
-    public static function hasTemplate($templates)
+    public static function hasTemplate(string|array $templates): bool
     {
         return (bool)ThemeResourceLoader::inst()->findTemplate($templates, self::get_themes());
     }
@@ -479,7 +479,7 @@ class SSViewer implements Flushable
     /**
      * @return string
      */
-    public function exists()
+    public function exists(): string|null
     {
         return $this->chosen;
     }
@@ -502,7 +502,7 @@ class SSViewer implements Flushable
      * @param bool $force Set this to true to force a re-flush. If left to false, flushing
      * may only be performed once a request.
      */
-    public static function flush_template_cache($force = false)
+    public static function flush_template_cache(bool $force = false): void
     {
         if (!self::$template_cache_flushed || $force) {
             $dir = dir(TEMP_PATH);
@@ -523,7 +523,7 @@ class SSViewer implements Flushable
      * @param bool $force Set this to true to force a re-flush. If left to false, flushing
      * may only be performed once a request.
      */
-    public static function flush_cacheblock_cache($force = false)
+    public static function flush_cacheblock_cache(bool $force = false): void
     {
         if (!self::$cacheblock_cache_flushed || $force) {
             $cache = Injector::inst()->get(CacheInterface::class . '.cacheblock');
@@ -549,7 +549,7 @@ class SSViewer implements Flushable
      *
      * @return CacheInterface
      */
-    public function getPartialCacheStore()
+    public function getPartialCacheStore(): SilverStripe\Versioned\Caching\VersionedCacheAdapter
     {
         if ($this->partialCacheStore) {
             return $this->partialCacheStore;
@@ -563,7 +563,7 @@ class SSViewer implements Flushable
      *
      * @param bool $incl
      */
-    public function includeRequirements($incl = true)
+    public function includeRequirements(bool $incl = true): void
     {
         $this->includeRequirements = $incl;
     }
@@ -581,7 +581,7 @@ class SSViewer implements Flushable
      * @param ViewableData $inheritedScope The current scope of a parent template including a sub-template
      * @return string The result of executing the template
      */
-    protected function includeGeneratedTemplate($cacheFile, $item, $overlay, $underlay, $inheritedScope = null)
+    protected function includeGeneratedTemplate(string $cacheFile, SilverStripe\View\ArrayData $item, array $overlay, array $underlay, SilverStripe\View\SSViewer_DataPresenter $inheritedScope = null): string
     {
         if (isset($_GET['showtemplate']) && $_GET['showtemplate'] && Permission::check('ADMIN')) {
             $lines = file($cacheFile ?? '');
@@ -620,7 +620,7 @@ class SSViewer implements Flushable
      * @param ViewableData $inheritedScope The current scope of a parent template including a sub-template
      * @return DBHTMLText Parsed template output.
      */
-    public function process($item, $arguments = null, $inheritedScope = null)
+    public function process(SilverStripe\View\ArrayData $item, array $arguments = null, SilverStripe\View\SSViewer_DataPresenter $inheritedScope = null): SilverStripe\ORM\FieldType\DBHTMLText
     {
         // Set hashlinks and temporarily modify global state
         $rewrite = $this->getRewriteHashLinks();
@@ -709,7 +709,7 @@ PHP;
      *
      * @return array|null
      */
-    protected function getSubtemplateFor($subtemplate)
+    protected function getSubtemplateFor(string $subtemplate): array|null
     {
         // Get explicit subtemplate name
         if (isset($this->subTemplates[$subtemplate])) {
@@ -749,7 +749,7 @@ PHP;
      *
      * @return string Evaluated result
      */
-    public static function execute_template($template, $data, $arguments = null, $scope = null, $globalRequirements = false)
+    public static function execute_template(array $template, SilverStripe\ErrorPage\ErrorPageController $data, array $arguments = null, SilverStripe\View\SSViewer_DataPresenter $scope = null, bool $globalRequirements = false): SilverStripe\ORM\FieldType\DBHTMLText
     {
         $v = SSViewer::create($template);
 
@@ -781,7 +781,7 @@ PHP;
      *
      * @return string Evaluated result
      */
-    public static function execute_string($content, $data, $arguments = null, $globalRequirements = false)
+    public static function execute_string(string|SilverStripe\ORM\FieldType\DBHTMLText $content, SilverStripe\View\Tests\SSViewerCacheBlockTest\TestModel $data, $arguments = null, $globalRequirements = false): string
     {
         $v = SSViewer::fromString($content);
 
@@ -808,7 +808,7 @@ PHP;
      * @param string $template The template file name
      * @return string
      */
-    public function parseTemplateContent($content, $template = "")
+    public function parseTemplateContent(string|SilverStripe\ORM\FieldType\DBHTMLText $content, string $template = ""): string
     {
         return $this->getParser()->compileString(
             $content,
@@ -823,7 +823,7 @@ PHP;
      *
      * @return array
      */
-    public function templates()
+    public function templates(): array
     {
         return array_merge(['main' => $this->chosen], $this->subTemplates);
     }
@@ -849,7 +849,7 @@ PHP;
      * the DOCTYPE declaration.
      * @return string
      */
-    public static function get_base_tag($contentGeneratedSoFar)
+    public static function get_base_tag(string $contentGeneratedSoFar): string
     {
         $base = Director::absoluteBaseURL();
 

--- a/src/View/SSViewer_BasicIteratorSupport.php
+++ b/src/View/SSViewer_BasicIteratorSupport.php
@@ -23,7 +23,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
     /**
      * @return array
      */
-    public static function get_template_iterator_variables()
+    public static function get_template_iterator_variables(): array
     {
         return [
             'IsFirst',
@@ -50,7 +50,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      * @param int $pos position in iterator
      * @param int $totalItems total number of items
      */
-    public function iteratorProperties($pos, $totalItems)
+    public function iteratorProperties(int $pos, int $totalItems): void
     {
         $this->iteratorPos = $pos;
         $this->iteratorTotalItems = $totalItems;
@@ -61,7 +61,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      *
      * @return bool
      */
-    public function IsFirst()
+    public function IsFirst(): bool
     {
         return $this->iteratorPos == 0;
     }
@@ -70,7 +70,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      * @deprecated 5.0.0 Use IsFirst() to avoid clashes with SS_Lists
      * @return bool
      */
-    public function First()
+    public function First(): bool
     {
         Deprecation::notice('5.0.0', 'Use IsFirst() to avoid clashes with SS_Lists');
         return $this->IsFirst();
@@ -81,7 +81,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      *
      * @return bool
      */
-    public function IsLast()
+    public function IsLast(): bool
     {
         return $this->iteratorPos == $this->iteratorTotalItems - 1;
     }
@@ -90,7 +90,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      * @deprecated 5.0.0 Use IsLast() to avoid clashes with SS_Lists
      * @return bool
      */
-    public function Last()
+    public function Last(): bool
     {
         Deprecation::notice('5.0.0', 'Use IsLast() to avoid clashes with SS_Lists');
         return $this->IsLast();
@@ -101,7 +101,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      *
      * @return string|null
      */
-    public function FirstLast()
+    public function FirstLast(): string|null
     {
         if ($this->IsFirst() && $this->IsLast()) {
             return 'first last';
@@ -120,7 +120,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      *
      * @return bool
      */
-    public function Middle()
+    public function Middle(): bool
     {
         return !$this->IsFirst() && !$this->IsLast();
     }
@@ -130,7 +130,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      *
      * @return string
      */
-    public function MiddleString()
+    public function MiddleString(): null|string
     {
         if ($this->Middle()) {
             return 'middle';
@@ -145,7 +145,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      * @param int $startIndex Number to start count from.
      * @return bool
      */
-    public function Even($startIndex = 1)
+    public function Even(int|string $startIndex = 1): bool
     {
         return !$this->Odd($startIndex);
     }
@@ -156,7 +156,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      * @param int $startIndex Number to start count from.
      * @return bool
      */
-    public function Odd($startIndex = 1)
+    public function Odd(int|string $startIndex = 1): bool
     {
         return (bool)(($this->iteratorPos + $startIndex) % 2);
     }
@@ -167,7 +167,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      * @param int $startIndex Number to start count from.
      * @return string
      */
-    public function EvenOdd($startIndex = 1)
+    public function EvenOdd($startIndex = 1): string
     {
         return ($this->Even($startIndex)) ? 'even' : 'odd';
     }
@@ -179,7 +179,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      * @param int $startIndex Number to start count from.
      * @return int
      */
-    public function Pos($startIndex = 1)
+    public function Pos(string $startIndex = 1): int
     {
         return $this->iteratorPos + $startIndex;
     }
@@ -191,7 +191,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      * @param int $endIndex Value of the last item
      * @return int
      */
-    public function FromEnd($endIndex = 1)
+    public function FromEnd(string $endIndex = 1): int
     {
         return $this->iteratorTotalItems - $this->iteratorPos + $endIndex - 1;
     }
@@ -201,7 +201,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      *
      * @return int
      */
-    public function TotalItems()
+    public function TotalItems(): int
     {
         return $this->iteratorTotalItems;
     }
@@ -214,7 +214,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      * @param int $startIndex Number to start count from.
      * @return int
      */
-    public function Modulus($mod, $startIndex = 1)
+    public function Modulus(string $mod, int|string $startIndex = 1): int
     {
         return ($this->iteratorPos + $startIndex) % $mod;
     }
@@ -228,7 +228,7 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
      * @param int $offset Number to start count from.
      * @return bool
      */
-    public function MultipleOf($factor, $offset = 1)
+    public function MultipleOf(string $factor, string $offset = 1): bool
     {
         return (bool)($this->Modulus($factor, $offset) == 0);
     }

--- a/src/View/SSViewer_DataPresenter.php
+++ b/src/View/SSViewer_DataPresenter.php
@@ -52,11 +52,11 @@ class SSViewer_DataPresenter extends SSViewer_Scope
      * @var SSViewer_Scope $inheritedScope
      */
     public function __construct(
-        $item,
+        SilverStripe\View\ArrayData $item,
         array $overlay = null,
         array $underlay = null,
         SSViewer_Scope $inheritedScope = null
-    ) {
+    ): void {
         parent::__construct($item, $inheritedScope);
 
         $this->overlay = $overlay ?: [];
@@ -69,7 +69,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope
     /**
      * Build cache of global properties
      */
-    protected function cacheGlobalProperties()
+    protected function cacheGlobalProperties(): void
     {
         if (self::$globalProperties !== null) {
             return;
@@ -84,7 +84,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope
     /**
      * Build cache of global iterator properties
      */
-    protected function cacheIteratorProperties()
+    protected function cacheIteratorProperties(): void
     {
         if (self::$iteratorProperties !== null) {
             return;
@@ -103,7 +103,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope
      * @var boolean $createObject
      * @return array
      */
-    protected function getPropertiesFromProvider($interfaceToQuery, $variableMethod, $createObject = false)
+    protected function getPropertiesFromProvider(string $interfaceToQuery, string $variableMethod, bool $createObject = false): array
     {
         $methods = [];
 
@@ -159,7 +159,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope
      * @param bool $cast If true, an object is always returned even if not an object.
      * @return array|null
      */
-    public function getInjectedValue($property, array $params, $cast = true)
+    public function getInjectedValue(string $property, array $params, $cast = true): null|array
     {
         // Get source for this value
         $source = $this->getValueSource($property);
@@ -196,7 +196,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope
      *
      * @return SSViewer_Scope
      */
-    public function pushScope()
+    public function pushScope(): SilverStripe\View\SSViewer_DataPresenter
     {
         $scope = parent::pushScope();
         $upIndex = $this->getUpIndex();
@@ -219,7 +219,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope
      *
      * @return SSViewer_Scope
      */
-    public function popScope()
+    public function popScope(): SilverStripe\View\SSViewer_DataPresenter
     {
         $upIndex = $this->getUpIndex();
 
@@ -241,7 +241,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope
      * @param string $cacheName
      * @return $this
      */
-    public function obj($name, $arguments = [], $cache = false, $cacheName = null)
+    public function obj(string $name, array $arguments = [], bool $cache = false, $cacheName = null): SilverStripe\View\SSViewer_DataPresenter
     {
         $overlayIndex = false;
 
@@ -273,7 +273,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope
     /**
      * {@inheritdoc}
      */
-    public function getObj($name, $arguments = [], $cache = false, $cacheName = null)
+    public function getObj(string $name, array $arguments = [], bool $cache = false, $cacheName = null): SilverStripe\ORM\ArrayList
     {
         $result = $this->getInjectedValue($name, (array)$arguments);
         if ($result) {
@@ -285,7 +285,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope
     /**
      * {@inheritdoc}
      */
-    public function __call($name, $arguments)
+    public function __call(string $name, array $arguments): string|bool|SilverStripe\ORM\FieldType\DBHTMLText|null
     {
         // Extract the method name and parameters
         $property = $arguments[0];  // The name of the public function being called
@@ -316,7 +316,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope
      * @param array $overrides List of overrides available
      * @return null|array Null if not provided, or array with 'value' or 'callable' key
      */
-    protected function processTemplateOverride($property, $overrides)
+    protected function processTemplateOverride(string $property, array $overrides): null|array
     {
         if (!isset($overrides[$property])) {
             return null;
@@ -344,7 +344,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope
      * @param string $property
      * @return array|null
      */
-    protected function getValueSource($property)
+    protected function getValueSource(string $property): null|array
     {
         // Check for a presenter-specific override
         $overlay = $this->processTemplateOverride($property, $this->overlay);
@@ -400,7 +400,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope
      * @param array $source
      * @return DBField
      */
-    protected function castValue($value, $source)
+    protected function castValue(string|bool|int|SilverStripe\ORM\FieldType\DBHTMLText $value, array $source): SilverStripe\ORM\FieldType\DBText
     {
         // Already cast
         if (is_object($value)) {

--- a/src/View/SSViewer_FromString.php
+++ b/src/View/SSViewer_FromString.php
@@ -35,7 +35,7 @@ class SSViewer_FromString extends SSViewer
      * @param string $content
      * @param TemplateParser $parser
      */
-    public function __construct($content, TemplateParser $parser = null)
+    public function __construct(string|SilverStripe\ORM\FieldType\DBHTMLText $content, TemplateParser $parser = null): void
     {
         if ($parser) {
             $this->setParser($parser);
@@ -47,7 +47,7 @@ class SSViewer_FromString extends SSViewer
     /**
      * {@inheritdoc}
      */
-    public function process($item, $arguments = null, $scope = null)
+    public function process(SilverStripe\Security\Member $item, $arguments = null, $scope = null): string
     {
         $hash = sha1($this->content ?? '');
         $cacheFile = TEMP_PATH . DIRECTORY_SEPARATOR . ".cache.$hash";
@@ -77,7 +77,7 @@ class SSViewer_FromString extends SSViewer
     /**
      * @param boolean $cacheTemplate
      */
-    public function setCacheTemplate($cacheTemplate)
+    public function setCacheTemplate(bool $cacheTemplate): void
     {
         $this->cacheTemplate = (bool)$cacheTemplate;
     }

--- a/src/View/SSViewer_Scope.php
+++ b/src/View/SSViewer_Scope.php
@@ -104,7 +104,7 @@ class SSViewer_Scope
      * @var object $item
      * @var SSViewer_Scope $inheritedScope
      */
-    public function __construct($item, SSViewer_Scope $inheritedScope = null)
+    public function __construct(SilverStripe\View\ArrayData $item, SSViewer_Scope $inheritedScope = null): void
     {
         $this->item = $item;
 
@@ -118,7 +118,7 @@ class SSViewer_Scope
      *
      * @return object
      */
-    public function getItem()
+    public function getItem(): SilverStripe\ErrorPage\ErrorPageController
     {
         return $this->itemIterator ? $this->itemIterator->current() : $this->item;
     }
@@ -128,7 +128,7 @@ class SSViewer_Scope
      *
      * @return self
      */
-    public function locally()
+    public function locally(): SilverStripe\View\SSViewer_DataPresenter
     {
         list(
             $this->item,
@@ -150,7 +150,7 @@ class SSViewer_Scope
      * Reset the local scope - restores saved state to the "global" item stack. Typically called after
      * a lookup chain has been completed
      */
-    public function resetLocalScope()
+    public function resetLocalScope(): void
     {
         // Restore previous un-completed lookup chain if set
         $previousLocalState = $this->localStack ? array_pop($this->localStack) : null;
@@ -173,7 +173,7 @@ class SSViewer_Scope
      * @param string $cacheName
      * @return mixed
      */
-    public function getObj($name, $arguments = [], $cache = false, $cacheName = null)
+    public function getObj(string $name, array $arguments = [], bool $cache = false, $cacheName = null): SilverStripe\ORM\ArrayList
     {
         $on = $this->itemIterator ? $this->itemIterator->current() : $this->item;
         return $on->obj($name, $arguments, $cache, $cacheName);
@@ -186,7 +186,7 @@ class SSViewer_Scope
      * @param string $cacheName
      * @return $this
      */
-    public function obj($name, $arguments = [], $cache = false, $cacheName = null)
+    public function obj(string $name, array $arguments = [], bool $cache = false, $cacheName = null): SilverStripe\View\SSViewer_DataPresenter
     {
         switch ($name) {
             case 'Up':
@@ -237,7 +237,7 @@ class SSViewer_Scope
      *
      * @return object
      */
-    public function self()
+    public function self(): SilverStripe\CKANRegistry\Page\CKANRegistryPageController
     {
         $result = $this->itemIterator ? $this->itemIterator->current() : $this->item;
         $this->resetLocalScope();
@@ -250,7 +250,7 @@ class SSViewer_Scope
      *
      * @return self
      */
-    public function pushScope()
+    public function pushScope(): SilverStripe\View\SSViewer_DataPresenter
     {
         $newLocalIndex = count($this->itemStack ?? []) - 1;
 
@@ -269,7 +269,7 @@ class SSViewer_Scope
      *
      * @return self
      */
-    public function popScope()
+    public function popScope(): SilverStripe\View\SSViewer_DataPresenter
     {
         $this->localIndex = $this->popIndex;
         $this->resetLocalScope();
@@ -282,7 +282,7 @@ class SSViewer_Scope
      *
      * @return mixed
      */
-    public function next()
+    public function next(): int|bool
     {
         if (!$this->item) {
             return false;
@@ -317,7 +317,7 @@ class SSViewer_Scope
      * @param array $arguments
      * @return mixed
      */
-    public function __call($name, $arguments)
+    public function __call(string $name, array $arguments): string|bool|SilverStripe\ORM\FieldType\DBHTMLText|null
     {
         $on = $this->itemIterator ? $this->itemIterator->current() : $this->item;
         $retval = $on ? $on->$name(...$arguments) : null;
@@ -329,7 +329,7 @@ class SSViewer_Scope
     /**
      * @return array
      */
-    protected function getItemStack()
+    protected function getItemStack(): array
     {
         return $this->itemStack;
     }
@@ -337,7 +337,7 @@ class SSViewer_Scope
     /**
      * @param array $stack
      */
-    protected function setItemStack(array $stack)
+    protected function setItemStack(array $stack): void
     {
         $this->itemStack = $stack;
     }
@@ -345,7 +345,7 @@ class SSViewer_Scope
     /**
      * @return int|null
      */
-    protected function getUpIndex()
+    protected function getUpIndex(): int|null
     {
         return $this->upIndex;
     }

--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -49,7 +49,7 @@ class EmbedShortcodeProvider implements ShortcodeHandler
      *
      * @return string
      */
-    public static function handle_shortcode($arguments, $content, $parser, $shortcode, $extra = [])
+    public static function handle_shortcode(array $arguments, string $content, SilverStripe\View\Parsers\ShortcodeParser $parser, string $shortcode, array $extra = []): string
     {
         // Get service URL
         if (!empty($content)) {
@@ -189,7 +189,7 @@ class EmbedShortcodeProvider implements ShortcodeHandler
      * @param string $content Raw HTML content
      * @return string
      */
-    protected static function videoEmbed($arguments, $content)
+    protected static function videoEmbed(array $arguments, string $content): string
     {
         // Ensure outer div has given width (but leave height auto)
         if (!empty($arguments['width'])) {
@@ -224,7 +224,7 @@ class EmbedShortcodeProvider implements ShortcodeHandler
      * @param string $title Default title
      * @return string
      */
-    protected static function linkEmbed($arguments, $href, $title)
+    protected static function linkEmbed(array $arguments, string $href, $title): string
     {
         $data = [
             'Arguments' => $arguments,

--- a/src/View/ThemeManifest.php
+++ b/src/View/ThemeManifest.php
@@ -63,7 +63,7 @@ class ThemeManifest implements ThemeList
      * @param string $project Path to application code
      * @param CacheFactory $cacheFactory Cache factory to generate backend cache with
      */
-    public function __construct($base, $project = null, CacheFactory $cacheFactory = null)
+    public function __construct(string $base, string $project = null, CacheFactory $cacheFactory = null): void
     {
         $this->base = $base;
         $this->project = $project;
@@ -75,7 +75,7 @@ class ThemeManifest implements ThemeList
      * @param bool $forceRegen Force the manifest to be regenerated.
      * @param string[] $ignoredCIConfigs
      */
-    public function init($includeTests = false, $forceRegen = false, array $ignoredCIConfigs = [])
+    public function init(bool $includeTests = false, bool $forceRegen = false, array $ignoredCIConfigs = []): void
     {
         // build cache from factory
         if ($this->cacheFactory) {
@@ -108,7 +108,7 @@ class ThemeManifest implements ThemeList
      * @param bool $includeTests
      * @return string
      */
-    public function getCacheKey($includeTests = false)
+    public function getCacheKey(bool $includeTests = false): string
     {
         return sha1(sprintf(
             "manifest-%s-%s-%u",
@@ -121,7 +121,7 @@ class ThemeManifest implements ThemeList
     /**
      * @return \string[]
      */
-    public function getThemes()
+    public function getThemes(): array
     {
         return $this->themes;
     }
@@ -132,7 +132,7 @@ class ThemeManifest implements ThemeList
      * @param bool $includeTests
      * @param string[] $ignoredCIConfigs
      */
-    public function regenerate($includeTests = false, array $ignoredCIConfigs = [])
+    public function regenerate(bool $includeTests = false, array $ignoredCIConfigs = []): void
     {
         $finder = new ManifestFileFinder();
         $finder->setOptions([
@@ -162,7 +162,7 @@ class ThemeManifest implements ThemeList
      * @param string $pathname
      * @param int $depth
      */
-    public function handleDirectory($basename, $pathname, $depth)
+    public function handleDirectory(string $basename, string $pathname, int $depth): void
     {
         if ($basename !== self::TEMPLATES_DIR) {
             return;
@@ -177,7 +177,7 @@ class ThemeManifest implements ThemeList
      * @param string $project
      * @return $this
      */
-    public function setProject($project)
+    public function setProject(string $project): SilverStripe\View\ThemeManifest
     {
         $this->project = $project;
 

--- a/src/View/ThemeResourceLoader.php
+++ b/src/View/ThemeResourceLoader.php
@@ -43,7 +43,7 @@ class ThemeResourceLoader implements Flushable
     /**
      * @return ThemeResourceLoader
      */
-    public static function inst()
+    public static function inst(): SilverStripe\View\ThemeResourceLoader
     {
         return self::$instance ? self::$instance : self::$instance = new self();
     }
@@ -53,12 +53,12 @@ class ThemeResourceLoader implements Flushable
      *
      * @param ThemeResourceLoader $instance
      */
-    public static function set_instance(ThemeResourceLoader $instance)
+    public static function set_instance(ThemeResourceLoader $instance): void
     {
         self::$instance = $instance;
     }
 
-    public function __construct($base = null)
+    public function __construct(string $base = null): void
     {
         $this->base = $base ? $base : BASE_PATH;
     }
@@ -69,7 +69,7 @@ class ThemeResourceLoader implements Flushable
      * @param string $set
      * @param ThemeList $manifest
      */
-    public function addSet($set, ThemeList $manifest)
+    public function addSet(string $set, ThemeList $manifest): void
     {
         $this->sets[$set] = $manifest;
     }
@@ -80,7 +80,7 @@ class ThemeResourceLoader implements Flushable
      * @param string $set
      * @return ThemeList
      */
-    public function getSet($set)
+    public function getSet(string $set): null|SilverStripe\View\ThemeManifest
     {
         if (isset($this->sets[$set])) {
             return $this->sets[$set];
@@ -102,7 +102,7 @@ class ThemeResourceLoader implements Flushable
      * @param string $identifier Theme identifier.
      * @return string Path from root, not including leading or trailing forward slash. E.g. themes/mytheme
      */
-    public function getPath($identifier)
+    public function getPath(string $identifier): string
     {
         $slashPos = strpos($identifier ?? '', '/');
         $parts = explode(':', $identifier ?? '', 2);
@@ -182,7 +182,7 @@ class ThemeResourceLoader implements Flushable
      * File location will be in the format themes/<theme>/templates/<directories>/<type>/<basename>.ss
      * Note that type (e.g. 'Layout') is not the root level directory under 'templates'.
      */
-    public function findTemplate($template, $themes = null)
+    public function findTemplate(array|string $template, array $themes = null): string|null
     {
         if ($themes === null) {
             $themes = SSViewer::get_themes();
@@ -260,7 +260,7 @@ class ThemeResourceLoader implements Flushable
      * @param array $themes List of themes, Defaults to {@see SSViewer::get_themes()}
      * @return string Path to resolved CSS file (relative to base dir)
      */
-    public function findThemedCSS($name, $themes = null)
+    public function findThemedCSS(string $name, array $themes = null): string|null
     {
         if ($themes === null) {
             $themes = SSViewer::get_themes();
@@ -289,7 +289,7 @@ class ThemeResourceLoader implements Flushable
      * @param array $themes List of themes, Defaults to {@see SSViewer::get_themes()}
      * @return string Path to resolved javascript file (relative to base dir)
      */
-    public function findThemedJavascript($name, $themes = null)
+    public function findThemedJavascript(string $name, array $themes = null): string|null
     {
         if ($themes === null) {
             $themes = SSViewer::get_themes();
@@ -316,7 +316,7 @@ class ThemeResourceLoader implements Flushable
      * @param array $themes An order listed of themes to search, Defaults to {@see SSViewer::get_themes()}
      * @return string
      */
-    public function findThemedResource($resource, $themes = null)
+    public function findThemedResource(string $resource, array $themes = null): null|string
     {
         if ($themes === null) {
             $themes = SSViewer::get_themes();
@@ -342,7 +342,7 @@ class ThemeResourceLoader implements Flushable
      * @param array $themes List of themes to resolve. Supports named theme sets. Defaults to {@see SSViewer::get_themes()}.
      * @return array List of root-relative folders in order of precedence.
      */
-    public function getThemePaths($themes = null)
+    public function getThemePaths(array $themes = null): array
     {
         if ($themes === null) {
             $themes = SSViewer::get_themes();
@@ -365,7 +365,7 @@ class ThemeResourceLoader implements Flushable
     /**
      * Flush any cached data
      */
-    public static function flush()
+    public static function flush(): void
     {
         self::inst()->getCache()->clear();
     }
@@ -373,7 +373,7 @@ class ThemeResourceLoader implements Flushable
     /**
      * @return CacheInterface
      */
-    public function getCache()
+    public function getCache(): SilverStripe\Versioned\Caching\VersionedCacheAdapter
     {
         if (!$this->cache) {
             $this->setCache(Injector::inst()->get(CacheInterface::class . '.ThemeResourceLoader'));
@@ -385,7 +385,7 @@ class ThemeResourceLoader implements Flushable
      * @param CacheInterface $cache
      * @return ThemeResourceLoader
      */
-    public function setCache(CacheInterface $cache)
+    public function setCache(CacheInterface $cache): SilverStripe\View\ThemeResourceLoader
     {
         $this->cache = $cache;
         return $this;

--- a/src/View/ViewableData.php
+++ b/src/View/ViewableData.php
@@ -87,7 +87,7 @@ class ViewableData implements IteratorAggregate
      */
     private $objCache = [];
 
-    public function __construct()
+    public function __construct(): void
     {
     }
 
@@ -103,7 +103,7 @@ class ViewableData implements IteratorAggregate
      * @param string $property
      * @return bool
      */
-    public function __isset($property)
+    public function __isset(string $property): bool
     {
         // getField() isn't a field-specific getter and shouldn't be treated as such
         if (strtolower($property ?? '') !== 'field' && $this->hasMethod($method = "get$property")) {
@@ -126,7 +126,7 @@ class ViewableData implements IteratorAggregate
      * @param string $property
      * @return mixed
      */
-    public function __get($property)
+    public function __get(string $property): string|null|int|bool|array|float|SilverStripe\CMS\Model\SiteTreeLinkTracking_Parser
     {
         // getField() isn't a field-specific getter and shouldn't be treated as such
         if (strtolower($property ?? '') !== 'field' && $this->hasMethod($method = "get$property")) {
@@ -149,7 +149,7 @@ class ViewableData implements IteratorAggregate
      * @param string $property
      * @param mixed $value
      */
-    public function __set($property, $value)
+    public function __set(string $property, bool|string|int|array|float|SilverStripe\RealMe\RealMeService $value): void
     {
         $this->objCacheClear();
         if ($this->hasMethod($method = "set$property")) {
@@ -164,7 +164,7 @@ class ViewableData implements IteratorAggregate
      *
      * @param ViewableData $failover
      */
-    public function setFailover(ViewableData $failover)
+    public function setFailover(ViewableData $failover): void
     {
         // Ensure cached methods from previous failover are removed
         if ($this->failover) {
@@ -180,7 +180,7 @@ class ViewableData implements IteratorAggregate
      *
      * @return ViewableData|null
      */
-    public function getFailover()
+    public function getFailover(): null|SilverStripe\ErrorPage\ErrorPage
     {
         return $this->failover;
     }
@@ -191,7 +191,7 @@ class ViewableData implements IteratorAggregate
      * @param string $field
      * @return bool
      */
-    public function hasField($field)
+    public function hasField(string $field): bool
     {
         return property_exists($this, $field ?? '');
     }
@@ -202,7 +202,7 @@ class ViewableData implements IteratorAggregate
      * @param string $field
      * @return mixed
      */
-    public function getField($field)
+    public function getField(string $field): string|array|int|SilverStripe\FrameworkTest\Elemental\Admin\ElementalBehatTestAdmin
     {
         return $this->$field;
     }
@@ -214,7 +214,7 @@ class ViewableData implements IteratorAggregate
      * @param mixed $value
      * @return $this
      */
-    public function setField($field, $value)
+    public function setField(string $field, string|int|array|bool|SilverStripe\ORM\ArrayList $value): SilverStripe\Reports\ReportAdmin
     {
         $this->objCacheClear();
         $this->$field = $value;
@@ -229,7 +229,7 @@ class ViewableData implements IteratorAggregate
      *
      * @throws LogicException
      */
-    public function defineMethods()
+    public function defineMethods(): void
     {
         if ($this->failover && !is_object($this->failover)) {
             throw new LogicException("ViewableData::\$failover set to a non-object");
@@ -255,7 +255,7 @@ class ViewableData implements IteratorAggregate
      * @param array|ViewableData $data
      * @return ViewableData_Customised
      */
-    public function customise($data)
+    public function customise(array|SilverStripe\View\ArrayData $data): SilverStripe\View\ViewableData_Customised
     {
         if (is_array($data) && (empty($data) || ArrayLib::is_associative($data))) {
             $data = new ArrayData($data);
@@ -278,7 +278,7 @@ class ViewableData implements IteratorAggregate
      *
      * @return bool
      */
-    public function exists()
+    public function exists(): bool
     {
         return true;
     }
@@ -286,7 +286,7 @@ class ViewableData implements IteratorAggregate
     /**
      * @return string the class name
      */
-    public function __toString()
+    public function __toString(): string
     {
         return static::class;
     }
@@ -294,7 +294,7 @@ class ViewableData implements IteratorAggregate
     /**
      * @return ViewableData
      */
-    public function getCustomisedObj()
+    public function getCustomisedObj(): null|SilverStripe\View\ViewableData_Customised
     {
         return $this->customisedObject;
     }
@@ -302,7 +302,7 @@ class ViewableData implements IteratorAggregate
     /**
      * @param ViewableData $object
      */
-    public function setCustomisedObj(ViewableData $object)
+    public function setCustomisedObj(ViewableData $object): void
     {
         $this->customisedObject = $object;
     }
@@ -317,7 +317,7 @@ class ViewableData implements IteratorAggregate
      * @return string Casting helper As a constructor pattern, and may include arguments.
      * @throws Exception
      */
-    public function castingHelper($field)
+    public function castingHelper(string $field): string
     {
         $specs = static::config()->get('casting');
         if (isset($specs[$field])) {
@@ -349,7 +349,7 @@ class ViewableData implements IteratorAggregate
      * @param string $field
      * @return string
      */
-    public function castingClass($field)
+    public function castingClass(string $field): string
     {
         // Strip arguments
         $spec = $this->castingHelper($field);
@@ -362,7 +362,7 @@ class ViewableData implements IteratorAggregate
      * @param string $field
      * @return string 'xml'|'raw'
      */
-    public function escapeTypeForField($field)
+    public function escapeTypeForField(string $field): string
     {
         $class = $this->castingClass($field) ?: $this->config()->get('default_cast');
 
@@ -386,7 +386,7 @@ class ViewableData implements IteratorAggregate
      * @param array $customFields fields to customise() the object with before rendering
      * @return DBHTMLText
      */
-    public function renderWith($template, $customFields = null)
+    public function renderWith(string|array|SilverStripe\View\SSViewer $template, array|SilverStripe\Security\Member $customFields = null): SilverStripe\ORM\FieldType\DBHTMLText|string
     {
         if (!is_object($template)) {
             $template = SSViewer::create($template);
@@ -413,7 +413,7 @@ class ViewableData implements IteratorAggregate
      * @param array $arguments List of optional arguments given
      * @return string
      */
-    protected function objCacheName($fieldName, $arguments)
+    protected function objCacheName(string $fieldName, array $arguments): string
     {
         return $arguments
             ? $fieldName . ":" . implode(',', $arguments)
@@ -426,7 +426,7 @@ class ViewableData implements IteratorAggregate
      * @param string $key Cache key
      * @return mixed
      */
-    protected function objCacheGet($key)
+    protected function objCacheGet(string|bool $key): null|SilverStripe\SiteConfig\SiteConfig
     {
         if (isset($this->objCache[$key])) {
             return $this->objCache[$key];
@@ -441,7 +441,7 @@ class ViewableData implements IteratorAggregate
      * @param mixed $value
      * @return $this
      */
-    protected function objCacheSet($key, $value)
+    protected function objCacheSet(string|bool $key, SilverStripe\ORM\ArrayList $value): SilverStripe\View\ArrayData
     {
         $this->objCache[$key] = $value;
         return $this;
@@ -452,7 +452,7 @@ class ViewableData implements IteratorAggregate
      *
      * @return $this
      */
-    protected function objCacheClear()
+    protected function objCacheClear(): SilverStripe\CMS\Model\SiteTree
     {
         $this->objCache = [];
         return $this;
@@ -468,7 +468,7 @@ class ViewableData implements IteratorAggregate
      * @param string $cacheName a custom cache name
      * @return Object|DBField
      */
-    public function obj($fieldName, $arguments = [], $cache = false, $cacheName = null)
+    public function obj(string $fieldName, array $arguments = [], bool $cache = false, bool $cacheName = null): SilverStripe\ORM\ArrayList
     {
         if (!$cacheName && $cache) {
             $cacheName = $this->objCacheName($fieldName, $arguments);
@@ -527,7 +527,7 @@ class ViewableData implements IteratorAggregate
      * @param bool $cache
      * @return bool
      */
-    public function hasValue($field, $arguments = [], $cache = true)
+    public function hasValue(string $field, array $arguments = [], bool $cache = true): bool
     {
         $result = $this->obj($field, $arguments, $cache);
         return $result->exists();
@@ -542,7 +542,7 @@ class ViewableData implements IteratorAggregate
      * @param bool $cache
      * @return string
      */
-    public function XML_val($field, $arguments = [], $cache = false)
+    public function XML_val(string $field, array $arguments = [], bool $cache = false): string|SilverStripe\ORM\FieldType\DBHTMLText|null
     {
         $result = $this->obj($field, $arguments, $cache);
         // Might contain additional formatting over ->XML(). E.g. parse shortcodes, nl2br()
@@ -577,7 +577,7 @@ class ViewableData implements IteratorAggregate
      * @return ArrayIterator
      */
     #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator([$this]);
     }
@@ -590,7 +590,7 @@ class ViewableData implements IteratorAggregate
      * @param string $suffix
      * @return array
      */
-    public function getViewerTemplates($suffix = '')
+    public function getViewerTemplates($suffix = ''): array
     {
         return SSViewer::get_templates_by_class(static::class, $suffix, self::class);
     }
@@ -601,7 +601,7 @@ class ViewableData implements IteratorAggregate
      *
      * @return ViewableData
      */
-    public function Me()
+    public function Me(): DNADesign\Elemental\Tests\Src\TestElementController
     {
         return $this;
     }
@@ -618,7 +618,7 @@ class ViewableData implements IteratorAggregate
      * @return string URL to the current theme
      * @deprecated 4.0.0:5.0.0 Use $resourcePath or $resourceURL template helpers instead
      */
-    public function ThemeDir()
+    public function ThemeDir(): string
     {
         Deprecation::notice('5.0', 'Use $resourcePath or $resourceURL template helpers instead');
         $themes = SSViewer::get_themes();
@@ -645,7 +645,7 @@ class ViewableData implements IteratorAggregate
      * @return string
      * @uses ClassInfo
      */
-    public function CSSClasses($stopAtClass = self::class)
+    public function CSSClasses($stopAtClass = self::class): string
     {
         $classes       = [];
         $classAncestry = array_reverse(ClassInfo::ancestry(static::class) ?? []);

--- a/src/View/ViewableData_Customised.php
+++ b/src/View/ViewableData_Customised.php
@@ -16,7 +16,7 @@ class ViewableData_Customised extends ViewableData
      * @param ViewableData $originalObject
      * @param ViewableData $customisedObject
      */
-    public function __construct(ViewableData $originalObject, ViewableData $customisedObject)
+    public function __construct(ViewableData $originalObject, ViewableData $customisedObject): void
     {
         $this->original = $originalObject;
         $this->customised = $customisedObject;
@@ -26,7 +26,7 @@ class ViewableData_Customised extends ViewableData
         parent::__construct();
     }
 
-    public function __call($method, $arguments)
+    public function __call(string $method, array $arguments): SilverStripe\View\SSViewer|string
     {
         if ($this->customised->hasMethod($method)) {
             return call_user_func_array([$this->customised, $method], $arguments ?? []);
@@ -35,7 +35,7 @@ class ViewableData_Customised extends ViewableData
         return call_user_func_array([$this->original, $method], $arguments ?? []);
     }
 
-    public function __get($property)
+    public function __get(string $property): string
     {
         if (isset($this->customised->$property)) {
             return $this->customised->$property;
@@ -49,12 +49,12 @@ class ViewableData_Customised extends ViewableData
         $this->customised->$property = $this->original->$property = $value;
     }
 
-    public function __isset($property)
+    public function __isset(string $property): bool
     {
         return isset($this->customised->$property) || isset($this->original->$property) || parent::__isset($property);
     }
 
-    public function hasMethod($method)
+    public function hasMethod(string $method): bool
     {
         return $this->customised->hasMethod($method) || $this->original->hasMethod($method);
     }
@@ -67,7 +67,7 @@ class ViewableData_Customised extends ViewableData
         return $this->original->cachedCall($field, $arguments, $identifier);
     }
 
-    public function obj($fieldName, $arguments = null, $cache = false, $cacheName = null)
+    public function obj(string $fieldName, array $arguments = null, bool $cache = false, $cacheName = null): SilverStripe\ORM\ArrayList
     {
         if ($this->customised->hasField($fieldName) || $this->customised->hasMethod($fieldName)) {
             return $this->customised->obj($fieldName, $arguments, $cache, $cacheName);

--- a/src/i18n/Data/Intl/IntlLocales.php
+++ b/src/i18n/Data/Intl/IntlLocales.php
@@ -25,7 +25,7 @@ class IntlLocales implements Locales, Resettable
     use Injectable;
     use Configurable;
 
-    public function __construct()
+    public function __construct(): void
     {
         if (!class_exists(Locale::class)) {
             throw new Exception("This backend requires the php-intl extension");
@@ -1397,7 +1397,7 @@ class IntlLocales implements Locales, Resettable
      * @param string $lang Short language code, e.g. "en"
      * @return string Long locale, e.g. "en_US"
      */
-    public function localeFromLang($lang)
+    public function localeFromLang(string $lang): string
     {
         $lang = Locale::canonicalize($lang);
 
@@ -1426,7 +1426,7 @@ class IntlLocales implements Locales, Resettable
      * @param string $locale E.g. "en_US"
      * @return string Short language code, e.g. "en"
      */
-    public function langFromLocale($locale)
+    public function langFromLocale(string $locale): string
     {
         return Locale::getPrimaryLanguage($locale);
     }
@@ -1443,7 +1443,7 @@ class IntlLocales implements Locales, Resettable
      *
      * @return array Map of locale code => name
      */
-    public function getLocales()
+    public function getLocales(): array
     {
         // Cache by locale
         $locale = i18n::get_locale();
@@ -1501,7 +1501,7 @@ class IntlLocales implements Locales, Resettable
      * @param string $locale
      * @return string
      */
-    public function localeName($locale)
+    public function localeName(string $locale): string
     {
         return Locale::getDisplayName($locale, i18n::get_locale());
     }
@@ -1512,7 +1512,7 @@ class IntlLocales implements Locales, Resettable
      * @param string $code
      * @return string
      */
-    public function languageName($code)
+    public function languageName(string $code): string
     {
         return Locale::getDisplayLanguage($code, i18n::get_locale());
     }
@@ -1529,7 +1529,7 @@ class IntlLocales implements Locales, Resettable
      *
      * @return array Map of country code => name
      */
-    public function getCountries()
+    public function getCountries(): array
     {
         // Cache by locale
         $locale = i18n::get_locale();
@@ -1557,7 +1557,7 @@ class IntlLocales implements Locales, Resettable
      * @param string $code ISO 3166-1 country code
      * @return string
      */
-    public function countryName($code)
+    public function countryName(string $code): string
     {
         return Locale::getDisplayRegion('-' . $code, i18n::get_locale());
     }
@@ -1568,7 +1568,7 @@ class IntlLocales implements Locales, Resettable
      * @param string $locale E.g. "en_US"
      * @return string Country code, e.g. "us"
      */
-    public function countryFromLocale($locale)
+    public function countryFromLocale(string $locale): string|null
     {
         return strtolower(Locale::getRegion($locale) ?? '') ?: null;
     }
@@ -1579,7 +1579,7 @@ class IntlLocales implements Locales, Resettable
      * @param string $locale
      * @return bool
      */
-    public function validate($locale)
+    public function validate(string $locale): bool
     {
         if (!$locale) {
             return false;
@@ -1609,7 +1609,7 @@ class IntlLocales implements Locales, Resettable
     /**
      * Reset the local cache of this object
      */
-    public static function reset()
+    public static function reset(): void
     {
         static::$cache_countries = [];
         static::$cache_languages = [];

--- a/src/i18n/Data/Sources.php
+++ b/src/i18n/Data/Sources.php
@@ -34,7 +34,7 @@ class Sources implements Resettable
      *
      * @return array Array of module names -> path
      */
-    public function getSortedModules()
+    public function getSortedModules(): array
     {
         $i18nOrder = Sources::config()->uninherited('module_priority');
         $sortedModules = [];
@@ -64,7 +64,7 @@ class Sources implements Resettable
      *
      * @return array
      */
-    public function getLangDirs()
+    public function getLangDirs(): array
     {
         if (static::$cache_lang_dirs) {
             return static::$cache_lang_dirs;
@@ -108,7 +108,7 @@ class Sources implements Resettable
      *
      * @return array Map of locale key => key of all distinct localisation file names
      */
-    protected function getLangFiles()
+    protected function getLangFiles(): array
     {
         if (static::$cache_lang_files) {
             return static::$cache_lang_files;
@@ -137,7 +137,7 @@ class Sources implements Resettable
      *
      * @return array Map of locale codes to names (localised)
      */
-    public function getKnownLocales()
+    public function getKnownLocales(): array
     {
         $localesData = i18n::getData();
         $allLocales = $localesData->getLocales();
@@ -157,7 +157,7 @@ class Sources implements Resettable
         return $locales;
     }
 
-    public static function reset()
+    public static function reset(): void
     {
         static::$cache_lang_files = [];
         static::$cache_lang_dirs = [];

--- a/src/i18n/Messages/Symfony/FlushInvalidatedResource.php
+++ b/src/i18n/Messages/Symfony/FlushInvalidatedResource.php
@@ -16,7 +16,7 @@ use Symfony\Component\Config\Resource\SelfCheckingResourceInterface;
 class FlushInvalidatedResource implements SelfCheckingResourceInterface, \Serializable, Flushable
 {
 
-    public function __toString()
+    public function __toString(): string
     {
         return md5(__CLASS__);
     }
@@ -27,7 +27,7 @@ class FlushInvalidatedResource implements SelfCheckingResourceInterface, \Serial
         return null;
     }
 
-    public function isFresh($timestamp)
+    public function isFresh(int $timestamp): bool
     {
         // Check mtime of canary
         $canary = static::canary();
@@ -74,7 +74,7 @@ class FlushInvalidatedResource implements SelfCheckingResourceInterface, \Serial
         // no-op
     }
 
-    public static function flush()
+    public static function flush(): void
     {
         // Mark canary as dirty
         static::touch();
@@ -85,7 +85,7 @@ class FlushInvalidatedResource implements SelfCheckingResourceInterface, \Serial
      *
      * @return string
      */
-    protected static function canary()
+    protected static function canary(): string
     {
         return TEMP_PATH . DIRECTORY_SEPARATOR . 'catalog.i18n_canary';
     }
@@ -93,7 +93,7 @@ class FlushInvalidatedResource implements SelfCheckingResourceInterface, \Serial
     /**
      * Touch the canary
      */
-    protected static function touch()
+    protected static function touch(): void
     {
         touch(static::canary() ?? '');
     }

--- a/src/i18n/Messages/Symfony/ModuleYamlLoader.php
+++ b/src/i18n/Messages/Symfony/ModuleYamlLoader.php
@@ -23,7 +23,7 @@ class ModuleYamlLoader extends ArrayLoader
      */
     protected $reader = null;
 
-    public function load($resource, $locale, $domain = 'messages')
+    public function load(array $resource, string $locale, string $domain = 'messages'): Symfony\Component\Translation\MessageCatalogue
     {
         $messages = [];
         foreach ($resource as $path) {
@@ -44,7 +44,7 @@ class ModuleYamlLoader extends ArrayLoader
     /**
      * @return Reader
      */
-    public function getReader()
+    public function getReader(): SilverStripe\i18n\Messages\YamlReader
     {
         return $this->reader;
     }
@@ -53,7 +53,7 @@ class ModuleYamlLoader extends ArrayLoader
      * @param Reader $reader
      * @return $this
      */
-    public function setReader(Reader $reader)
+    public function setReader(Reader $reader): SilverStripe\i18n\Messages\Symfony\ModuleYamlLoader
     {
         $this->reader = $reader;
         return $this;
@@ -67,7 +67,7 @@ class ModuleYamlLoader extends ArrayLoader
      * @param string $locale
      * @return array
      */
-    protected function loadMessages($path, $locale)
+    protected function loadMessages(string $path, string $locale): array
     {
         $filePath = $path . $locale . '.yml';
         $messages = $this->getReader()->read($locale, $filePath);
@@ -81,7 +81,7 @@ class ModuleYamlLoader extends ArrayLoader
      * @param string $locale
      * @return array Normalised messages
      */
-    protected function normaliseMessages($messages, $locale)
+    protected function normaliseMessages(array $messages, string $locale): array
     {
         foreach ($messages as $key => $value) {
             $messages[$key] = $this->normaliseMessage($key, $value, $locale);
@@ -101,7 +101,7 @@ class ModuleYamlLoader extends ArrayLoader
      * @param string $locale
      * @return string
      */
-    protected function normaliseMessage($key, $value, $locale)
+    protected function normaliseMessage(string $key, string|array $value, string $locale): string|null
     {
         if (!is_array($value)) {
             return $value;

--- a/src/i18n/Messages/Symfony/SymfonyMessageProvider.php
+++ b/src/i18n/Messages/Symfony/SymfonyMessageProvider.php
@@ -38,7 +38,7 @@ class SymfonyMessageProvider implements MessageProvider
     /**
      * @return Translator
      */
-    public function getTranslator()
+    public function getTranslator(): Symfony\Component\Translation\Translator
     {
         return $this->translator;
     }
@@ -47,7 +47,7 @@ class SymfonyMessageProvider implements MessageProvider
      * @param Translator $translator
      * @return $this
      */
-    public function setTranslator($translator)
+    public function setTranslator(Symfony\Component\Translation\Translator $translator): SilverStripe\i18n\Messages\Symfony\SymfonyMessageProvider
     {
         $this->translator = $translator;
         foreach ($translator->getFallbackLocales() as $locale) {
@@ -61,7 +61,7 @@ class SymfonyMessageProvider implements MessageProvider
      *
      * @param string $locale
      */
-    protected function load($locale)
+    protected function load(string $locale): void
     {
         if (isset($this->loadedLocales[$locale])) {
             return;
@@ -84,7 +84,7 @@ class SymfonyMessageProvider implements MessageProvider
         $this->loadedLocales[$locale] = true;
     }
 
-    public function translate($entity, $default, $injection)
+    public function translate(string $entity, string $default, array $injection): string
     {
         // Ensure localisation is ready
         $locale = i18n::get_locale();
@@ -104,7 +104,7 @@ class SymfonyMessageProvider implements MessageProvider
         return $result;
     }
 
-    public function pluralise($entity, $default, $injection, $count)
+    public function pluralise(string $entity, string $default, array $injection, int|float|string $count): string
     {
         if (is_array($default)) {
             $default = $this->normalisePlurals($default);
@@ -136,7 +136,7 @@ class SymfonyMessageProvider implements MessageProvider
      *
      * @return array
      */
-    public function getSourceDirs()
+    public function getSourceDirs(): array
     {
         if (!$this->sourceDirs) {
             $this->setSourceDirs(i18n::getSources()->getLangDirs());
@@ -150,7 +150,7 @@ class SymfonyMessageProvider implements MessageProvider
      * @param array $sourceDirs
      * @return $this
      */
-    public function setSourceDirs($sourceDirs)
+    public function setSourceDirs(array $sourceDirs): SilverStripe\i18n\Messages\Symfony\SymfonyMessageProvider
     {
         $this->sourceDirs = $sourceDirs;
         return $this;
@@ -162,7 +162,7 @@ class SymfonyMessageProvider implements MessageProvider
      * @param array $injection
      * @return array Injection array with all keys surrounded with {} placeholders
      */
-    protected function templateInjection($injection)
+    protected function templateInjection(array $injection): array
     {
         $injection = $injection ?: [];
         // Rewrite injection to {} surrounded placeholders

--- a/src/i18n/Messages/YamlReader.php
+++ b/src/i18n/Messages/YamlReader.php
@@ -17,7 +17,7 @@ class YamlReader implements Reader
     /**
      * @return Parser
      */
-    protected function getParser()
+    protected function getParser(): Symfony\Component\Yaml\Parser
     {
         if (!$this->parser) {
             $this->parser = new Parser();
@@ -25,7 +25,7 @@ class YamlReader implements Reader
         return $this->parser;
     }
 
-    public function read($locale, $path)
+    public function read(string $locale, string $path): array
     {
         try {
             if (!file_exists($path ?? '')) {
@@ -51,7 +51,7 @@ class YamlReader implements Reader
      * @param array $entities
      * @return mixed
      */
-    protected function normaliseMessages($entities)
+    protected function normaliseMessages(array $entities): array
     {
         $messages = [];
         // Squash second and third levels together (class.key)

--- a/src/i18n/Messages/YamlWriter.php
+++ b/src/i18n/Messages/YamlWriter.php
@@ -26,7 +26,7 @@ class YamlWriter implements Writer
     /**
      * @return Dumper
      */
-    protected function getDumper()
+    protected function getDumper(): Symfony\Component\Yaml\Dumper
     {
         if (!$this->dumper) {
             $this->dumper = new Dumper(2);
@@ -35,7 +35,7 @@ class YamlWriter implements Writer
     }
 
 
-    public function write($messages, $locale, $path)
+    public function write(array $messages, string $locale, string $path): void
     {
         // Skip empty entities
         if (empty($messages)) {
@@ -70,7 +70,7 @@ class YamlWriter implements Writer
      * @param array $messages
      * @return array
      */
-    protected function denormaliseMessages($messages)
+    protected function denormaliseMessages(array $messages): array
     {
         // Sort prior to denormalisation
         ksort($messages);
@@ -102,7 +102,7 @@ class YamlWriter implements Writer
      * @param array|string $value Input value
      * @return array|string denormalised value
      */
-    protected function denormaliseValue($value)
+    protected function denormaliseValue(string|array $value): string|array
     {
         // Check plural form
         $plurals = $this->getPluralForm($value);
@@ -130,7 +130,7 @@ class YamlWriter implements Writer
      * @param array|string $value
      * @return array List of plural forms, or empty array if not plural
      */
-    protected function getPluralForm($value)
+    protected function getPluralForm(string|array $value): array
     {
         // Strip non-plural keys away
         if (is_array($value)) {
@@ -151,7 +151,7 @@ class YamlWriter implements Writer
      * @param string $locale
      * @return string
      */
-    public function getYaml($messages, $locale)
+    public function getYaml(array $messages, string $locale): string
     {
         $entities = $this->denormaliseMessages($messages);
         $content = $this->getDumper()->dump([
@@ -166,7 +166,7 @@ class YamlWriter implements Writer
      * @param string $entity
      * @return array Two-length array with class and key as elements
      */
-    protected function getClassKey($entity)
+    protected function getClassKey(string $entity): array
     {
         $parts = explode('.', $entity ?? '');
         $class = array_shift($parts);

--- a/src/i18n/TextCollection/Parser.php
+++ b/src/i18n/TextCollection/Parser.php
@@ -42,7 +42,7 @@ class Parser extends SSTemplateParser
      * @param string $string
      * @param bool $warnIfEmpty
      */
-    public function __construct($string, $warnIfEmpty = true)
+    public function __construct(string $string, bool $warnIfEmpty = true): void
     {
         parent::__construct();
         $this->string = $string;
@@ -52,29 +52,29 @@ class Parser extends SSTemplateParser
         $this->warnIfEmpty = $warnIfEmpty;
     }
 
-    public function Translate__construct(&$res)
+    public function Translate__construct(array &$res): void
     {
         $this->currentEntity = [];
         $this->currentEntityKey = null;
     }
 
-    public function Translate_Entity(&$res, $sub)
+    public function Translate_Entity(array &$res, array $sub): void
     {
         // Collapse escaped slashes
         $this->currentEntityKey = str_replace('\\\\', '\\', $sub['text'] ?? ''); // key
     }
 
-    public function Translate_Default(&$res, $sub)
+    public function Translate_Default(array &$res, array $sub): void
     {
         $this->currentEntity['default'] = $sub['String']['text']; // default
     }
 
-    public function Translate_Context(&$res, $sub)
+    public function Translate_Context(array &$res, array $sub): void
     {
         $this->currentEntity['comment'] = $sub['String']['text']; //comment
     }
 
-    public function Translate__finalise(&$res)
+    public function Translate__finalise(array &$res): void
     {
         // Validate entity
         $entity = $this->currentEntity;
@@ -107,7 +107,7 @@ class Parser extends SSTemplateParser
      * @param bool $warnIfEmpty Show warnings if default omitted
      * @return array Map of keys -> values
      */
-    public static function getTranslatables($template, $warnIfEmpty = true)
+    public static function getTranslatables(string $template, bool $warnIfEmpty = true): array
     {
         // Run the parser and throw away the result
         $parser = new Parser($template, $warnIfEmpty);
@@ -121,7 +121,7 @@ class Parser extends SSTemplateParser
     /**
      * @return array
      */
-    public function getEntities()
+    public function getEntities(): array
     {
         return $this->entities;
     }

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -98,7 +98,7 @@ class i18nTextCollector
     /**
      * @param $locale
      */
-    public function __construct($locale = null)
+    public function __construct($locale = null): void
     {
         $this->defaultLocale = $locale
             ? $locale
@@ -114,7 +114,7 @@ class i18nTextCollector
      * @param Writer $writer
      * @return $this
      */
-    public function setWriter($writer)
+    public function setWriter(SilverStripe\i18n\Messages\YamlWriter $writer): SilverStripe\i18n\TextCollection\i18nTextCollector
     {
         $this->writer = $writer;
         return $this;
@@ -125,7 +125,7 @@ class i18nTextCollector
      *
      * @return Writer
      */
-    public function getWriter()
+    public function getWriter(): SilverStripe\i18n\Messages\YamlWriter
     {
         return $this->writer;
     }
@@ -135,7 +135,7 @@ class i18nTextCollector
      *
      * @return Reader
      */
-    public function getReader()
+    public function getReader(): SilverStripe\i18n\Messages\YamlReader
     {
         return $this->reader;
     }
@@ -146,7 +146,7 @@ class i18nTextCollector
      * @param Reader $reader
      * @return $this
      */
-    public function setReader(Reader $reader)
+    public function setReader(Reader $reader): SilverStripe\i18n\TextCollection\i18nTextCollector
     {
         $this->reader = $reader;
         return $this;
@@ -167,7 +167,7 @@ class i18nTextCollector
      * releases, because it allows "translation backports" to older releases
      * without removing strings these older releases still rely on.
      */
-    public function run($restrictToModules = null, $mergeWithExisting = false)
+    public function run($restrictToModules = null, $mergeWithExisting = false): void
     {
         $entitiesByModule = $this->collect($restrictToModules, $mergeWithExisting);
         if (empty($entitiesByModule)) {
@@ -195,7 +195,7 @@ class i18nTextCollector
      * @param bool $mergeWithExisting
      * @return array
      */
-    public function collect($restrictToModules = [], $mergeWithExisting = false)
+    public function collect($restrictToModules = [], bool $mergeWithExisting = false): array
     {
         $entitiesByModule = $this->getEntitiesByModule();
 
@@ -228,7 +228,7 @@ class i18nTextCollector
      * @param array $entitiesByModule List of all modules with keys
      * @return array Filtered listo of modules with duplicate keys unassigned
      */
-    protected function resolveDuplicateConflicts($entitiesByModule)
+    protected function resolveDuplicateConflicts(array $entitiesByModule): array
     {
         // Find all keys that exist across multiple modules
         $conflicts = $this->getConflicts($entitiesByModule);
@@ -255,7 +255,7 @@ class i18nTextCollector
      * @param array $entitiesByModule
      * @return array List of keys
      */
-    protected function getConflicts($entitiesByModule)
+    protected function getConflicts(array $entitiesByModule): array
     {
         $modules = array_keys($entitiesByModule ?? []);
         $allConflicts = [];
@@ -284,7 +284,7 @@ class i18nTextCollector
      * @param string $key
      * @return string Best module, if found
      */
-    protected function getBestModuleForKey($entitiesByModule, $key)
+    protected function getBestModuleForKey(array $entitiesByModule, string $key): string
     {
         // Check classes
         $class = current(explode('.', $key ?? ''));
@@ -325,7 +325,7 @@ class i18nTextCollector
      * @param string $class Either a FQN class name, or a non-qualified class name.
      * @return string Name of module
      */
-    protected function findModuleForClass($class)
+    protected function findModuleForClass(string $class): string
     {
         if (ClassInfo::exists($class)) {
             $module = ClassLoader::inst()
@@ -367,7 +367,7 @@ class i18nTextCollector
      * @param array $entitiesByModule
      * @return array
      */
-    protected function mergeWithExisting($entitiesByModule)
+    protected function mergeWithExisting(array $entitiesByModule): array
     {
         // For each module do a simple merge of the default yml with these strings
         foreach ($entitiesByModule as $module => $messages) {
@@ -392,7 +392,7 @@ class i18nTextCollector
      *
      * @return array
      */
-    protected function getEntitiesByModule()
+    protected function getEntitiesByModule(): array
     {
         // A master string tables array (one mst per module)
         $entitiesByModule = [];
@@ -452,7 +452,7 @@ class i18nTextCollector
      * @param array $entities
      * @return $this
      */
-    public function write(Module $module, $entities)
+    public function write(Module $module, array $entities): SilverStripe\i18n\TextCollection\i18nTextCollector
     {
         $this->getWriter()->write(
             $entities,
@@ -469,7 +469,7 @@ class i18nTextCollector
      * @param Module $module Module instance
      * @return array An array of entities found in the files that comprise the module
      */
-    protected function processModule(Module $module)
+    protected function processModule(Module $module): array
     {
         $entities = [];
 
@@ -506,7 +506,7 @@ class i18nTextCollector
      * @param Module $module Module instance
      * @return array List of files to parse
      */
-    protected function getFileListForModule(Module $module)
+    protected function getFileListForModule(Module $module): array
     {
         $modulePath = $module->getPath();
 
@@ -546,7 +546,7 @@ class i18nTextCollector
      * @param Module $module Module being collected
      * @return array Map of localised keys to default values provided for this code
      */
-    public function collectFromCode($content, $fileName, Module $module)
+    public function collectFromCode(string $content, string $fileName, Module $module): array
     {
         // Get namespace either from $fileName or $module fallback
         $namespace = $fileName ? basename($fileName) : $module->getName();
@@ -779,7 +779,7 @@ class i18nTextCollector
      * @param array $parsedFiles
      * @return array $entities An array of entities representing the extracted template function calls
      */
-    public function collectFromTemplate($content, $fileName, Module $module, &$parsedFiles = [])
+    public function collectFromTemplate(string $content, string $fileName, Module $module, &$parsedFiles = []): array
     {
         // Get namespace either from $fileName or $module fallback
         $namespace = $fileName ? basename($fileName) : $module->getName();
@@ -816,7 +816,7 @@ class i18nTextCollector
      * @param Module $module
      * @return array
      */
-    public function collectFromEntityProviders($filePath, Module $module = null)
+    public function collectFromEntityProviders(string $filePath, Module $module = null): array
     {
         $entities = [];
         $classes = ClassInfo::classes_for_file($filePath);
@@ -868,7 +868,7 @@ class i18nTextCollector
      * @param string $_namespace
      * @return string|boolean FALSE
      */
-    protected function normalizeEntity($fullName, $_namespace = null)
+    protected function normalizeEntity(string $fullName, string $_namespace = null): string
     {
         // split fullname into entity parts
         $entityParts = explode('.', $fullName ?? '');
@@ -905,7 +905,7 @@ class i18nTextCollector
      * @param string $folderExclude Regular expression matching folder names to exclude
      * @return array $fileList An array of files
      */
-    protected function getFilesRecursive($folder, $fileList = [], $type = null, $folderExclude = '/\/(tests)$/')
+    protected function getFilesRecursive(string $folder, array $fileList = [], string $type = null, $folderExclude = '/\/(tests): array$/'): array
     {
         if (!$fileList) {
             $fileList = [];
@@ -936,7 +936,7 @@ class i18nTextCollector
         return $fileList;
     }
 
-    public function getDefaultLocale()
+    public function getDefaultLocale(): string
     {
         return $this->defaultLocale;
     }
@@ -949,7 +949,7 @@ class i18nTextCollector
     /**
      * @return bool
      */
-    public function getWarnOnEmptyDefault()
+    public function getWarnOnEmptyDefault(): bool
     {
         return $this->warnOnEmptyDefault;
     }
@@ -958,7 +958,7 @@ class i18nTextCollector
      * @param bool $warnOnEmptyDefault
      * @return $this
      */
-    public function setWarnOnEmptyDefault($warnOnEmptyDefault)
+    public function setWarnOnEmptyDefault(bool $warnOnEmptyDefault): SilverStripe\i18n\TextCollection\i18nTextCollector
     {
         $this->warnOnEmptyDefault = $warnOnEmptyDefault;
         return $this;

--- a/src/i18n/i18n.php
+++ b/src/i18n/i18n.php
@@ -156,7 +156,7 @@ class i18n implements TemplateGlobalProvider
      *    injection parameter to pluralise.
      * @return string
      */
-    public static function _t($entity, $arg = null)
+    public static function _t(string $entity, string|array $arg = null): string
     {
         // Detect args
         $default = null;
@@ -236,7 +236,7 @@ class i18n implements TemplateGlobalProvider
      * @param string $string Input string
      * @return array List of plural forms, or empty array if not plural
      */
-    public static function parse_plurals($string)
+    public static function parse_plurals(string $string): array
     {
         if (strstr($string ?? '', '|') && strstr($string ?? '', '{count}')) {
             $keys = i18n::config()->uninherited('default_plurals');
@@ -255,7 +255,7 @@ class i18n implements TemplateGlobalProvider
      * @param array $plurals
      * @return string Delimited string, or null if not plurals
      */
-    public static function encode_plurals($plurals)
+    public static function encode_plurals(array $plurals): string
     {
         // Validate against global plural list
         $forms = i18n::config()->uninherited('plurals');
@@ -273,7 +273,7 @@ class i18n implements TemplateGlobalProvider
      * @param string $locale locale code
      * @return string Locale of closest available translation, if available
      */
-    public static function get_closest_translation($locale)
+    public static function get_closest_translation(string $locale): null|string
     {
         // Check if exact match
         $pool = self::getSources()->getKnownLocales();
@@ -301,7 +301,7 @@ class i18n implements TemplateGlobalProvider
      * @param string $locale
      * @return string
      */
-    public static function convert_rfc1766($locale)
+    public static function convert_rfc1766(string $locale): string
     {
         return str_replace('_', '-', $locale ?? '');
     }
@@ -317,7 +317,7 @@ class i18n implements TemplateGlobalProvider
      *                       http://unicode.org/cldr/data/diff/supplemental/languages_and_territories.html for a list
      *                       of possible locales.
      */
-    public static function set_locale($locale)
+    public static function set_locale(string $locale): void
     {
         if ($locale) {
             self::$current_locale = $locale;
@@ -331,7 +331,7 @@ class i18n implements TemplateGlobalProvider
      * @param callable $callback
      * @return mixed
      */
-    public static function with_locale($locale, $callback)
+    public static function with_locale(string $locale, callable $callback): string
     {
         $oldLocale = self::$current_locale;
         static::set_locale($locale);
@@ -348,7 +348,7 @@ class i18n implements TemplateGlobalProvider
      *
      * @return string Current locale in the system
      */
-    public static function get_locale()
+    public static function get_locale(): string
     {
         if (!self::$current_locale) {
             self::$current_locale = i18n::config()->uninherited('default_locale');
@@ -368,7 +368,7 @@ class i18n implements TemplateGlobalProvider
         return static::getData()->scriptDirection($locale);
     }
 
-    public static function get_template_global_variables()
+    public static function get_template_global_variables(): array
     {
         return [
             'i18nLocale' => 'get_locale',
@@ -380,7 +380,7 @@ class i18n implements TemplateGlobalProvider
     /**
      * @return MessageProvider
      */
-    public static function getMessageProvider()
+    public static function getMessageProvider(): SilverStripe\i18n\Messages\Symfony\SymfonyMessageProvider
     {
         return Injector::inst()->get(MessageProvider::class);
     }
@@ -390,7 +390,7 @@ class i18n implements TemplateGlobalProvider
      *
      * @return Locales
      */
-    public static function getData()
+    public static function getData(): SilverStripe\i18n\Data\Intl\IntlLocales
     {
         return Injector::inst()->get(Locales::class);
     }
@@ -400,7 +400,7 @@ class i18n implements TemplateGlobalProvider
      *
      * @return Sources
      */
-    public static function getSources()
+    public static function getSources(): SilverStripe\i18n\Data\Sources
     {
         return Injector::inst()->get(Sources::class);
     }


### PR DESCRIPTION
**DO NOT MERGE**

Issue https://github.com/silverstripe/silverstripe-framework/issues/10414

This is only a POC

It's automatic code-writing using https://github.com/emteknetnz/type-transitioner which is a 3-step process:

1. Code-writing to add trace statements `_a()` and `_r()` to all methods which are used for log trace results to a text file
2. Running ALL unit-test and behat tests in recipe-kitchen-sink to generate the trace text file
3. Using the results of the trace text file, code write in strongly type params and return types

This was done as a spike, so there's still plenty to do e.g. this code won't run, as you'll soon be greeted with the exception `
Fatal error: Declaration of SilverStripe\Control\HTTPRequest::offsetExists(string $offset) must be compatible with ArrayAccess::offsetExists(mixed $offset): bool in /var/www/vendor/silverstripe/framework/src/Control/HTTPRequest.php on line 438` - that's not a big deal, we'd just need to make the code writer more sophisticated.