### PR TITLE
API rescue master-branch PR: Shorten auto-generated table names #7621

### DIFF
--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -59,8 +59,6 @@ abstract class DBSchemaManager
     /**
      * @param string $table
      * @param string $class
-     *
-     * @deprecated 4.0.0:5.0.0
      */
     public static function showTableNameWarning($table, $class)
     {
@@ -436,11 +434,10 @@ abstract class DBSchemaManager
             if (!$table_name_info_sent) {
                 $this->alterationMessage(
                     <<<'MESSAGE'
-<strong>Please note:</strong> It is strongly recommended to define a
-table_name for all namespaced models. Not defining a table_name may cause generated table
-names to be too long and may not be supported by your current database engine. The generated
-naming scheme will also change when upgrading to SilverStripe 5.0 and potentially break.
-MESSAGE
+                    <strong>Please note:</strong> It is strongly recommended to define a
+                    table_name for all namespaced models. Not defining a table_name may cause generated table
+                    names to be too long and may not be supported by your current database engine.
+                    MESSAGE
                     ,
                     'error'
                 );

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3623,11 +3623,32 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         $fields = $schema->databaseFields(static::class, false);
         $indexes = $schema->databaseIndexes(static::class, false);
         $extensions = self::database_extensions(static::class);
+        $legacyTables = $schema->getLegacyTableNames(static::class);
 
         if (empty($table)) {
             throw new LogicException(
                 "Class " . static::class . " not loaded by manifest, or no database table configured"
             );
+        }
+
+        if ($legacyTables) {
+            $ignore = Config::inst()->get(static::class, 'ignored_legacy_tables') ?: [];
+            $renameTables = array_diff(
+                array_intersect($legacyTables, DB::table_list()),
+                $ignore
+            );
+            if (count($renameTables) > 1) {
+                $class = static::class;
+                $legacyList = implode(', ', $renameTables);
+                trigger_error(
+                    "Class $class has multiple legacy tables: $legacyList",
+                    E_USER_NOTICE
+                );
+            }
+            if (count($renameTables) === 1) {
+                $dbSchema = DB::get_schema();
+                $dbSchema->renameTable($renameTables[0], $table);
+            }
         }
 
         if ($fields) {

--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -318,23 +318,47 @@ class DataObjectSchema
     {
         $table = Config::inst()->get($class, 'table_name', Config::UNINHERITED);
 
-        // Generate default table name
+        // Return table name if configured
         if ($table) {
             return $table;
         }
 
+        // Use classname directly if not namespaced
         if (strpos($class ?? '', '\\') === false) {
             return $class;
         }
 
-        $separator = DataObjectSchema::config()->uninherited('table_namespace_separator');
-        $table = str_replace('\\', $separator ?? '', trim($class ?? '', '\\'));
+        // Attempt to generate a nice table name
+        $separator = DataObjectSchema::config()->uninherited('table_namespace_separator') ?? '';
+        $parts = explode('\\', trim($class ?? '', '\\'));
+        $vendor = array_slice($parts, 0, 1)[0];
+        $base = array_slice($parts, -1, 1)[0];
+        if ($vendor && $base && $vendor !== $base) {
+            $table = "{$vendor}{$separator}{$base}";
+        } elseif ($base) {
+            $table = $base;
+        } else {
+            throw new InvalidArgumentException("Unable to build a table name for class '$class'. Define a table_name for this class.");
+        }
 
+        // Display a warning about namespaced classes producing long table names
         if (!ClassInfo::classImplements($class, TestOnly::class) && $this->classHasTable($class)) {
             DBSchemaManager::showTableNameWarning($table, $class);
         }
 
         return $table;
+    }
+
+    /**
+     * @param $class
+     * @return array
+     */
+    public function getLegacyTableNames($class)
+    {
+        $separator = DataObjectSchema::config()->uninherited('table_namespace_separator');
+        $names[] = str_replace('\\', $separator, trim($class, '\\'));
+
+        return $names;
     }
 
     /**

--- a/tests/php/ORM/DataObjectSchemaTest.php
+++ b/tests/php/ORM/DataObjectSchemaTest.php
@@ -58,9 +58,9 @@ class DataObjectSchemaTest extends SapphireTest
             'DOSTWithCustomTable',
             $schema->tableName(WithCustomTable::class)
         );
-        // Default table name is FQN
+        // Default table name is Vendor plus base class
         $this->assertEquals(
-            'SilverStripe_ORM_Tests_DataObjectSchemaTest_DefaultTableName',
+            'SilverStripe_DefaultTableName',
             $schema->tableName(DefaultTableName::class)
         );
     }


### PR DESCRIPTION
Rescues PR #7621 from the master branch.

Note that I have also added a commit on top of it which un-deprecates the warning for `DataObject` classes which are missing a `table_name` (added in #7620 as a companion to #7621) as I believe it promotes best practices and still protects against table names that may still be too long.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350