### PR TITLE
API Rescue Master Branch PR: Remove isDev / isTest querystring arguments

### DIFF
--- a/src/Core/BaseKernel.php
+++ b/src/Core/BaseKernel.php
@@ -269,35 +269,12 @@ abstract class BaseKernel implements Kernel
             return $this->enviroment;
         }
 
-        // Check saved session
-        $env = $this->sessionEnvironment();
-        if ($env) {
-            return $env;
-        }
-
         // Check getenv
         if ($env = Environment::getEnv('SS_ENVIRONMENT_TYPE')) {
             return $env;
         }
 
         return self::LIVE;
-    }
-
-    /**
-     * Check or update any temporary environment specified in the session.
-     *
-     * @return null|string
-     *
-     * @deprecated 5.0 Use Director::get_session_environment_type() instead
-     */
-    protected function sessionEnvironment()
-    {
-        if (!$this->booted) {
-            // session is not initialyzed yet, neither is manifest
-            return null;
-        }
-
-        return Director::get_session_environment_type();
     }
 
     abstract public function boot($flush = false);

--- a/src/Core/Startup/ErrorControlChainMiddleware.php
+++ b/src/Core/Startup/ErrorControlChainMiddleware.php
@@ -53,10 +53,7 @@ class ErrorControlChainMiddleware implements HTTPMiddleware
     {
         $chain = new ConfirmationTokenChain();
         $chain->pushToken(new URLConfirmationToken('dev/build', $request));
-
-        foreach (['isTest', 'isDev', 'flush'] as $parameter) {
-            $chain->pushToken(new ParameterConfirmationToken($parameter, $request));
-        }
+        $chain->pushToken(new ParameterConfirmationToken('flush', $request));
 
         return $chain;
     }

--- a/src/Core/Startup/ParameterConfirmationToken.php
+++ b/src/Core/Startup/ParameterConfirmationToken.php
@@ -129,7 +129,6 @@ class ParameterConfirmationToken extends AbstractConfirmationToken
 
     public function suppress()
     {
-        unset($_GET[$this->parameterName]);
         $this->request->offsetUnset($this->parameterName);
     }
 


### PR DESCRIPTION
Rescues https://github.com/silverstripe/silverstripe-framework/commit/215d93c375ea0002bd6650536293a60f4c6eb448
Refers to https://www.silverstripe.org/download/security-releases/SS-2018-005

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350