### PR TITLE
ENH Rescue Master Branch Commits: CSV BOM stripping is now handled internally by league/csv

### DIFF
--- a/src/Dev/CsvBulkLoader.php
+++ b/src/Dev/CsvBulkLoader.php
@@ -76,14 +76,7 @@ class CsvBulkLoader extends BulkLoader
             $filepath = Director::getAbsFile($filepath);
             $csvReader = Reader::createFromPath($filepath, 'r');
             $csvReader->setDelimiter($this->delimiter);
-
-            // league/csv 9
-            if (method_exists($csvReader, 'skipInputBOM')) {
-                $csvReader->skipInputBOM();
-            // league/csv 8
-            } else {
-                $csvReader->stripBom(true);
-            }
+            $csvReader->skipInputBOM();
 
             $tabExtractor = function ($row, $rowOffset) {
                 foreach ($row as &$item) {


### PR DESCRIPTION
Effectively rescues https://github.com/silverstripe/silverstripe-framework/pull/9442/commits/a88553aad2c1e01c546305b0495d57978f835d3a and https://github.com/silverstripe/silverstripe-framework/pull/9443/commits/427bc5443f0e8ab3a54ae44b8d4ca62cc5067f18
We don't support league/csv 8 anymore.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350