### PR TITLE
API Rescue Master Branch PR: Allow dataobject get_one without passing a class

### DIFF
--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -436,6 +436,12 @@ class DataObjectTest extends SapphireTest
         $this->assertEquals('Bob', $comment->Name);
         $comment = DataObject::get_one(DataObjectTest\TeamComment::class, '', true, '"Name" DESC');
         $this->assertEquals('Phil', $comment->Name);
+
+        // Test get_one() without passing classname
+        $this->assertEquals(
+            DataObjectTest\TeamComment::get_one(),
+            DataObject::get_one(DataObjectTest\TeamComment::class)
+        );
     }
 
     public function testGetByIDCallerClass()


### PR DESCRIPTION
Rescues https://github.com/silverstripe/silverstripe-framework/pull/8480

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350