### PR TITLE
Rescue Master Branch PR: Fix SQLConditionalExpression::getJoins so it always adds explicit aliases

### DIFF
--- a/src/ORM/Queries/SQLConditionalExpression.php
+++ b/src/ORM/Queries/SQLConditionalExpression.php
@@ -287,14 +287,7 @@ abstract class SQLConditionalExpression extends SQLExpression
                     continue;
                 }
 
-                if (preg_match('/AS\s+(?:"[^"]+"|[A-Z0-9_]+)\s*$/i', $join ?? '')) {
-                    // custom aliases override the ones defined through array keys
-                    // this is only meant to keep backward compatibility with SS <= 4.3,
-                    // to be removed in SS5
-                    continue;
-                }
-
-                $trimmedAlias = trim($alias ?? '', '"');
+                $trimmedAlias = trim($alias, '"');
 
                 if ($trimmedAlias !== trim($join ?? '', '"')) {
                     $joins[$alias] = "{$join} AS \"{$trimmedAlias}\"";

--- a/tests/php/ORM/SQLSelectTest.php
+++ b/tests/php/ORM/SQLSelectTest.php
@@ -814,15 +814,18 @@ class SQLSelectTest extends SapphireTest
             $sql
         );
 
+        // This feature is a bug that used to exist in SS4 and was removed in SS5
+        // so now we test it does not exist and we end up with incorrect SQL because of that
+        // In SS4 the "explicitAlias" would be ignored
         $query = SQLSelect::create('*', [
             'MyTableAlias' => '"MyTable"',
-            'ignoredAlias' => ', (SELECT * FROM "MyTable" where "something" = "whatever") as "CrossJoin"'
+            'explicitAlias' => ', (SELECT * FROM "MyTable" where "something" = "whatever") as "CrossJoin"'
         ]);
         $sql = $query->sql();
 
         $this->assertSQLEquals(
             'SELECT * FROM "MyTable" AS "MyTableAlias" , ' .
-            '(SELECT * FROM "MyTable" where "something" = "whatever") as "CrossJoin"',
+            '(SELECT * FROM "MyTable" where "something" = "whatever") as "CrossJoin" AS "explicitAlias"',
             $sql
         );
     }


### PR DESCRIPTION
Rescues https://github.com/silverstripe/silverstripe-framework/pull/8966
This is a revert of https://github.com/silverstripe/silverstripe-framework/pull/8956 which was always intended to be temporary.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350