### PR TITLE
Rescue Master Branch PR: ENH Various changes via static analysis tooling

### DIFF
--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -563,7 +563,7 @@ class ClassManifest
             'ignore_files' => ['index.php', 'cli-script.php'],
             'ignore_tests' => !$includeTests,
             'ignored_ci_configs' => $ignoredCIConfigs,
-            'file_callback' => function ($basename, $pathname, $depth) use ($includeTests, $finder) {
+            'file_callback' => function ($basename, $pathname, $depth) use ($includeTests) {
                 $this->handleFile($basename, $pathname, $includeTests);
             },
         ]);

--- a/src/Forms/ConfirmedPasswordField.php
+++ b/src/Forms/ConfirmedPasswordField.php
@@ -123,7 +123,7 @@ class ConfirmedPasswordField extends FormField
      * @param string $name
      * @param string $title
      * @param mixed $value
-     * @param Form $form
+     * @param Form $form Ignored for ConfirmedPasswordField.
      * @param boolean $showOnClick
      * @param string $titleConfirmField Alternate title (not localizeable)
      */

--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -589,7 +589,7 @@ class FormField extends RequestHandler
         //
         // CSS class needs to be different from the one rendered through {@link FieldHolder()}.
         if ($this->getMessage()) {
-            $classes[] .= 'holder-' . $this->getMessageType();
+            $classes[] = 'holder-' . $this->getMessageType();
         }
 
         return implode(' ', $classes);

--- a/src/Forms/GridField/GridField_ActionMenuLink.php
+++ b/src/Forms/GridField/GridField_ActionMenuLink.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\Forms\GridField;
 
+use SilverStripe\ORM\DataObject;
+
 /**
  * Allows GridField_ActionMenuItem to act as a link
  */

--- a/src/Forms/NullableField.php
+++ b/src/Forms/NullableField.php
@@ -169,7 +169,7 @@ class NullableField extends FormField
     public function debug()
     {
         $result = sprintf(
-            '%s (%s: $s : <span style="color: red">%s</span>) = ',
+            '%s (%s: %s : <span style="color: red">%s</span>) = ',
             static::class,
             $this->name,
             $this->title,

--- a/src/ORM/Connect/MySQLDatabase.php
+++ b/src/ORM/Connect/MySQLDatabase.php
@@ -6,6 +6,7 @@ use SilverStripe\Assets\File;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Convert;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\PaginatedList;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\ArrayList;

--- a/src/ORM/Connect/MySQLSchemaManager.php
+++ b/src/ORM/Connect/MySQLSchemaManager.php
@@ -78,23 +78,23 @@ class MySQLSchemaManager extends DBSchemaManager
 
         if ($newFields) {
             foreach ($newFields as $k => $v) {
-                $alterList[] .= "ADD \"$k\" $v";
+                $alterList[] = "ADD \"$k\" $v";
             }
         }
         if ($newIndexes) {
             foreach ($newIndexes as $k => $v) {
-                $alterList[] .= "ADD " . $this->getIndexSqlDefinition($k, $v);
+                $alterList[] = "ADD " . $this->getIndexSqlDefinition($k, $v);
             }
         }
         if ($alteredFields) {
             foreach ($alteredFields as $k => $v) {
-                $alterList[] .= "CHANGE \"$k\" \"$k\" $v";
+                $alterList[] = "CHANGE \"$k\" \"$k\" $v";
             }
         }
         if ($alteredIndexes) {
             foreach ($alteredIndexes as $k => $v) {
-                $alterList[] .= "DROP INDEX \"$k\"";
-                $alterList[] .= "ADD " . $this->getIndexSqlDefinition($k, $v);
+                $alterList[] = "DROP INDEX \"$k\"";
+                $alterList[] = "ADD " . $this->getIndexSqlDefinition($k, $v);
             }
         }
 

--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -12,7 +12,6 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Manifest\ClassLoader;
 use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\DevelopmentAdmin;
-use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\Connect\DatabaseException;
 use SilverStripe\ORM\Connect\TableBuilder;
 use SilverStripe\ORM\FieldType\DBClassName;

--- a/src/View/Parsers/ShortcodeParser.php
+++ b/src/View/Parsers/ShortcodeParser.php
@@ -99,7 +99,7 @@ class ShortcodeParser
      *   - An associative array of extra information about the shortcode being parsed.
      *
      * @param string $shortcode The shortcode tag to map to the callback - normally in lowercase_underscore format.
-     * @param callback $callback The callback to replace the shortcode with.
+     * @param callable $callback The callback to replace the shortcode with.
      * @return $this
      */
     public function register($shortcode, $callback)

--- a/src/View/ThemeManifest.php
+++ b/src/View/ThemeManifest.php
@@ -124,7 +124,7 @@ class ThemeManifest implements ThemeList
     }
 
     /**
-     * @return \string[]
+     * @return string[]
      */
     public function getThemes()
     {


### PR DESCRIPTION
Rescues https://github.com/silverstripe/silverstripe-framework/pull/9039 which tidies up a bunch of code smells found through static analysis.

Targetting `4` because there's nothing that breaks API or changes any behaviour here - makes sense to merge into `4` and then merge up to `5` afterward so both lines can benefit.
Honestly this could even target `4.11` but I don't think it really materially fixes anything so not worth the extra effort involved with that.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350