### PR TITLE
FIX Remove accidental deprecation warnings.

### DIFF
--- a/src/Core/Manifest/ClassLoader.php
+++ b/src/Core/Manifest/ClassLoader.php
@@ -123,10 +123,6 @@ class ClassLoader
      */
     public function init($includeTests = false, $forceRegen = false)
     {
-        if (!empty($ignoredCIConfigs)) {
-            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
-        }
-
         foreach ($this->manifests as $manifest) {
             /** @var ClassManifest $instance */
             $instance = $manifest['instance'];

--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -11,7 +11,6 @@ use PhpParser\ParserFactory;
 use PhpParser\ErrorHandler\ErrorHandler;
 use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Cache\CacheFactory;
-use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\TestOnly;
 
 /**
@@ -280,10 +279,6 @@ class ClassManifest
      */
     public function init($includeTests = false, $forceRegen = false)
     {
-        if (!empty($ignoredCIConfigs)) {
-            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
-        }
-
         $this->cache = $this->buildCache($includeTests);
 
         // Check if cache is safe to use
@@ -546,10 +541,6 @@ class ClassManifest
      */
     public function regenerate($includeTests)
     {
-        if (!empty($ignoredCIConfigs)) {
-            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
-        }
-
         // Reset the manifest so stale info doesn't cause errors.
         $this->loadState([]);
         $this->roots = [];

--- a/src/Core/Manifest/ModuleLoader.php
+++ b/src/Core/Manifest/ModuleLoader.php
@@ -2,8 +2,6 @@
 
 namespace SilverStripe\Core\Manifest;
 
-use SilverStripe\Dev\Deprecation;
-
 /**
  * Module manifest holder
  */
@@ -96,10 +94,6 @@ class ModuleLoader
      */
     public function init($includeTests = false, $forceRegen = false)
     {
-        if (!empty($ignoredCIConfigs)) {
-            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
-        }
-
         foreach ($this->manifests as $manifest) {
             $manifest->init($includeTests, $forceRegen);
         }

--- a/src/Core/Manifest/ModuleManifest.php
+++ b/src/Core/Manifest/ModuleManifest.php
@@ -7,7 +7,6 @@ use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Cache\CacheFactory;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Dev\Deprecation;
 
 /**
  * A utility class which builds a manifest of configuration items
@@ -125,10 +124,6 @@ class ModuleManifest
      */
     public function init($includeTests = false, $forceRegen = false)
     {
-        if (!empty($ignoredCIConfigs)) {
-            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
-        }
-
         // build cache from factory
         if ($this->cacheFactory) {
             $this->cache = $this->cacheFactory->create(
@@ -170,10 +165,6 @@ class ModuleManifest
      */
     public function regenerate($includeTests = false)
     {
-        if (!empty($ignoredCIConfigs)) {
-            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
-        }
-
         $this->modules = [];
 
         $finder = new ManifestFileFinder();

--- a/src/Dev/Constraint/SSListContains.php
+++ b/src/Dev/Constraint/SSListContains.php
@@ -4,7 +4,6 @@ namespace SilverStripe\Dev\Constraint;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
-use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\SSListExporter;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\SS_List;
@@ -30,8 +29,6 @@ class SSListContains extends Constraint implements TestOnly
 
     public function __construct(array $matches)
     {
-        Deprecation::notice('5.0.0', 'This class will be removed in CMS 5', Deprecation::SCOPE_CLASS);
-
         $this->exporter = new SSListExporter();
 
         $this->matches = $matches;

--- a/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
+++ b/src/Dev/Constraint/SSListContainsOnlyMatchingItems.php
@@ -4,7 +4,6 @@ namespace SilverStripe\Dev\Constraint;
 
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
-use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\SSListExporter;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\SS_List;
@@ -27,7 +26,6 @@ class SSListContainsOnlyMatchingItems extends Constraint implements TestOnly
 
     public function __construct($match)
     {
-        Deprecation::notice('5.0.0', 'This class will be removed in CMS 5', Deprecation::SCOPE_CLASS);
         $this->exporter = new SSListExporter();
 
         $this->constraint = new ViewableDataContains($match);

--- a/src/Dev/FunctionalTest.php
+++ b/src/Dev/FunctionalTest.php
@@ -83,8 +83,6 @@ abstract class FunctionalTest extends SapphireTest implements TestOnly
 
     protected function setUp(): void
     {
-        Deprecation::notice('5.0.0', 'This class will be removed in CMS 5', Deprecation::SCOPE_CLASS);
-
         parent::setUp();
 
         // Skip calling FunctionalTest directly.

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -264,8 +264,6 @@ abstract class SapphireTest extends TestCase implements TestOnly
      */
     protected function setUp(): void
     {
-        Deprecation::notice('5.0.0', 'This class will be removed in CMS 5', Deprecation::SCOPE_CLASS);
-
         if (!defined('FRAMEWORK_PATH')) {
             trigger_error(
                 'Missing constants, did you remember to include the test bootstrap in your phpunit.xml file?',

--- a/src/View/ThemeManifest.php
+++ b/src/View/ThemeManifest.php
@@ -6,7 +6,6 @@ use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Cache\CacheFactory;
 use SilverStripe\Core\Manifest\ManifestFileFinder;
 use SilverStripe\Core\Manifest\ModuleLoader;
-use SilverStripe\Dev\Deprecation;
 
 /**
  * A class which builds a manifest of all themes (which is really just a directory called "templates")
@@ -77,10 +76,6 @@ class ThemeManifest implements ThemeList
      */
     public function init($includeTests = false, $forceRegen = false)
     {
-        if (!empty($ignoredCIConfigs)) {
-            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
-        }
-
         // build cache from factory
         if ($this->cacheFactory) {
             $this->cache = $this->cacheFactory->create(
@@ -137,10 +132,6 @@ class ThemeManifest implements ThemeList
      */
     public function regenerate($includeTests = false)
     {
-        if (!empty($ignoredCIConfigs)) {
-            Deprecation::notice('5.0.0', 'The $ignoredCIConfigs parameter will be removed in CMS 5');
-        }
-
         $finder = new ManifestFileFinder();
         $finder->setOptions([
             'include_themes' => false,


### PR DESCRIPTION
These were erroneously added via a merge-up from 4 to 5 - see https://github.com/silverstripe/silverstripe-framework/commit/715415d5c8d2b0858a39470392f6fb5edc81ffe0
