### PR TITLE
DEP Revert change to dependency that was made during a merge-up

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "swiftmailer/swiftmailer": "^6.3.0",
         "symfony/cache": "^4.4.44",
         "symfony/config": "^4.4.44",
-        "symfony/filesystem": "^6.0",
+        "symfony/filesystem": "^5.4 || ^6.0",
         "symfony/translation": "^4.4.44",
         "symfony/yaml": "^4.4.44",
         "ext-ctype": "*",


### PR DESCRIPTION
This dependency was introduced in https://github.com/silverstripe/silverstripe-framework/commit/6975815513caa81dce15134fe9a3b5c5d12d60e8 and changed to match our no-dual-support standard for CMS 5 during merge-up in https://github.com/creative-commoners/silverstripe-framework/commit/715415d5c8d2b0858a39470392f6fb5edc81ffe0

Removing dual support for this has caused a dependency mismatch between framework and assets. To allow CI builds to run we are reverting this change temporarily. It will be addressed more fully in https://github.com/silverstripe/silverstripe-framework/issues/10389