### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '20 14 * * 2'
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: CI

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -6,8 +6,12 @@ on:
     - cron: '50 10 4 * *'
   workflow_dispatch:
 
+permissions: {}
 jobs:
   keepalive:
+    permissions:
+      actions: write # to re-enable workflows
+
     name: Keepalive
     # Only run cron on the silverstripe account
     if: (github.event_name == 'schedule' && github.repository_owner == 'silverstripe') || (github.event_name != 'schedule')


### PR DESCRIPTION
Issue - https://github.com/silverstripe/silverstripe-framework/issues/10510

This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.