### PR TITLE
Member updateName extension hook

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1217,7 +1217,9 @@ class Member extends DataObject
      */
     public function getName()
     {
-        return ($this->Surname) ? trim($this->FirstName . ' ' . $this->Surname) : $this->FirstName;
+        $name = ($this->Surname) ? trim($this->FirstName . ' ' . $this->Surname) : $this->FirstName;
+        $this->extend('updateName', $name);
+        return $name;
     }
 
 


### PR DESCRIPTION
Allow updating the member name from an extension.

When extending the Member object with fields like "Insertion" or "Initials", for example. It would be nice if we're able to change the result from the `getName` method so we can insert these new fields.
