### PR TITLE
API Don't publicly expose extension hook methods

### DIFF
--- a/src/Dev/Validation/DatabaseAdminExtension.php
+++ b/src/Dev/Validation/DatabaseAdminExtension.php
@@ -21,7 +21,7 @@ class DatabaseAdminExtension extends Extension
      * @param bool $testMode
      * @throws ReflectionException
      */
-    public function onAfterBuild(bool $quiet, bool $populate, bool $testMode): void
+    protected function onAfterBuild(bool $quiet, bool $populate, bool $testMode): void
     {
         $service = RelationValidationService::singleton();
 

--- a/src/ORM/DataExtension.php
+++ b/src/ORM/DataExtension.php
@@ -32,7 +32,7 @@ abstract class DataExtension extends Extension
      * @param ValidationResult $validationResult Local validation result
      * @throws ValidationException
      */
-    public function validate(ValidationResult $validationResult)
+    protected function validate(ValidationResult $validationResult)
     {
     }
 
@@ -42,7 +42,7 @@ abstract class DataExtension extends Extension
      * @param SQLSelect $query Query to augment.
      * @param DataQuery $dataQuery Container DataQuery for this SQLSelect
      */
-    public function augmentSQL(SQLSelect $query, DataQuery $dataQuery = null)
+    protected function augmentSQL(SQLSelect $query, DataQuery $dataQuery = null)
     {
     }
 
@@ -52,7 +52,7 @@ abstract class DataExtension extends Extension
      * When duplicating a table's structure, remember to duplicate the create options
      * as well. See {@link Versioned->augmentDatabase} for an example.
      */
-    public function augmentDatabase()
+    protected function augmentDatabase()
     {
     }
 
@@ -61,7 +61,7 @@ abstract class DataExtension extends Extension
      *
      * @param array $manipulation Array of operations to augment.
      */
-    public function augmentWrite(&$manipulation)
+    protected function augmentWrite(&$manipulation)
     {
     }
 
@@ -70,7 +70,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::onBeforeWrite()} for context.
      */
-    public function onBeforeWrite()
+    protected function onBeforeWrite()
     {
     }
 
@@ -79,7 +79,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::onAfterWrite()} for context.
      */
-    public function onAfterWrite()
+    protected function onAfterWrite()
     {
     }
 
@@ -88,7 +88,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::onBeforeDelete()} for context.
      */
-    public function onBeforeDelete()
+    protected function onBeforeDelete()
     {
     }
 
@@ -97,7 +97,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::onAfterDelete()} for context.
      */
-    public function onAfterDelete()
+    protected function onAfterDelete()
     {
     }
 
@@ -106,7 +106,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::requireDefaultRecords()} for context.
      */
-    public function requireDefaultRecords()
+    protected function requireDefaultRecords()
     {
     }
 
@@ -115,7 +115,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::populateDefaults()} for context.
      */
-    public function populateDefaults()
+    protected function populateDefaults()
     {
     }
 
@@ -124,7 +124,7 @@ abstract class DataExtension extends Extension
      *
      * See {@link DataObject::onAfterBuild()} for context.
      */
-    public function onAfterBuild()
+    protected function onAfterBuild()
     {
     }
 
@@ -138,7 +138,7 @@ abstract class DataExtension extends Extension
      * @param Member $member
      * @return bool|null
      */
-    public function can($member)
+    protected function can($member)
     {
     }
 
@@ -152,7 +152,7 @@ abstract class DataExtension extends Extension
      * @param Member $member
      * @return bool|null
      */
-    public function canEdit($member)
+    protected function canEdit($member)
     {
     }
 
@@ -166,7 +166,7 @@ abstract class DataExtension extends Extension
      * @param Member $member
      * @return bool|null
      */
-    public function canDelete($member)
+    protected function canDelete($member)
     {
     }
 
@@ -180,7 +180,7 @@ abstract class DataExtension extends Extension
      * @param Member $member
      * @return bool|null
      */
-    public function canCreate($member)
+    protected function canCreate($member)
     {
     }
 
@@ -195,7 +195,7 @@ abstract class DataExtension extends Extension
      * @return array Returns a map where the keys are db, has_one, etc, and
      *               the values are additional fields/relations to be defined.
      */
-    public function extraStatics($class = null, $extension = null)
+    protected function extraStatics($class = null, $extension = null)
     {
         return [];
     }
@@ -213,7 +213,7 @@ abstract class DataExtension extends Extension
      *
      * @param FieldList $fields FieldList with a contained TabSet
      */
-    public function updateCMSFields(FieldList $fields)
+    protected function updateCMSFields(FieldList $fields)
     {
     }
 
@@ -224,7 +224,7 @@ abstract class DataExtension extends Extension
      *
      * @param CompositeValidator $compositeValidator
      */
-    public function updateCMSCompositeValidator(CompositeValidator $compositeValidator): void
+    protected function updateCMSCompositeValidator(CompositeValidator $compositeValidator): void
     {
     }
 
@@ -236,7 +236,7 @@ abstract class DataExtension extends Extension
      *
      * @param FieldList $fields FieldList without TabSet nesting
      */
-    public function updateFrontEndFields(FieldList $fields)
+    protected function updateFrontEndFields(FieldList $fields)
     {
     }
 
@@ -246,7 +246,7 @@ abstract class DataExtension extends Extension
      *
      * @param FieldList $actions FieldList
      */
-    public function updateCMSActions(FieldList $actions)
+    protected function updateCMSActions(FieldList $actions)
     {
     }
 
@@ -258,7 +258,7 @@ abstract class DataExtension extends Extension
      *
      * @param array $fields Array of field names
      */
-    public function updateSummaryFields(&$fields)
+    protected function updateSummaryFields(&$fields)
     {
         $summary_fields = Config::inst()->get(static::class, 'summary_fields');
         if ($summary_fields) {
@@ -281,7 +281,7 @@ abstract class DataExtension extends Extension
      *
      * @param array $labels Array of field labels
      */
-    public function updateFieldLabels(&$labels)
+    protected function updateFieldLabels(&$labels)
     {
         $field_labels = Config::inst()->get(static::class, 'field_labels');
         if ($field_labels) {

--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -116,7 +116,7 @@ class Hierarchy extends DataExtension
      *
      * @param ValidationResult $validationResult
      */
-    public function validate(ValidationResult $validationResult)
+    protected function validate(ValidationResult $validationResult)
     {
         // The object is new, won't be looping.
         /** @var DataObject|Hierarchy $owner */

--- a/tests/php/Control/RequestHandlingTest/ControllerExtension.php
+++ b/tests/php/Control/RequestHandlingTest/ControllerExtension.php
@@ -25,7 +25,7 @@ class ControllerExtension extends Extension implements TestOnly
     /**
      * Called whenever there is an HTTP error
      */
-    public function onBeforeHTTPError()
+    protected function onBeforeHTTPError()
     {
         self::$called_error = true;
     }
@@ -33,7 +33,7 @@ class ControllerExtension extends Extension implements TestOnly
     /**
      * Called whenever there is an 404 error
      */
-    public function onBeforeHTTPError404()
+    protected function onBeforeHTTPError404()
     {
         self::$called_404_error = true;
     }

--- a/tests/php/Core/ObjectTest/ExtendTest1.php
+++ b/tests/php/Core/ObjectTest/ExtendTest1.php
@@ -7,7 +7,7 @@ use SilverStripe\Dev\TestOnly;
 
 class ExtendTest1 extends Extension implements TestOnly
 {
-    public function extendableMethod(&$argument = null)
+    protected function extendableMethod(&$argument = null)
     {
         if ($argument) {
             $argument = 'modified';

--- a/tests/php/Core/ObjectTest/ExtendTest2.php
+++ b/tests/php/Core/ObjectTest/ExtendTest2.php
@@ -15,7 +15,7 @@ class ExtendTest2 extends Extension implements TestOnly
         $this->constructorArgs = func_get_args();
     }
 
-    public function extendableMethod($argument = null)
+    protected function extendableMethod($argument = null)
     {
         $args = implode(',', array_filter(func_get_args()));
         return "ExtendTest2($args)";

--- a/tests/php/Core/ObjectTest/ExtendTest3.php
+++ b/tests/php/Core/ObjectTest/ExtendTest3.php
@@ -15,7 +15,7 @@ class ExtendTest3 extends Extension implements TestOnly
         $this->constructorArgs = func_get_args();
     }
 
-    public function extendableMethod($argument = null)
+    protected function extendableMethod($argument = null)
     {
         return "ExtendTest3($argument)";
     }

--- a/tests/php/Forms/FormFactoryTest/ControllerExtension.php
+++ b/tests/php/Forms/FormFactoryTest/ControllerExtension.php
@@ -35,7 +35,7 @@ class ControllerExtension extends Extension
      * @param string     $name
      * @param array      $context
      */
-    public function updateFormActions(FieldList &$actions, Controller $controller, $name, $context = [])
+    protected function updateFormActions(FieldList &$actions, Controller $controller, $name, $context = [])
     {
         // Add publish button if record is versioned
         if (empty($context['Record'])) {
@@ -56,7 +56,7 @@ class ControllerExtension extends Extension
      * @param string     $name
      * @param array      $context
      */
-    public function updateFormFields(FieldList &$fields, Controller $controller, $name, $context = [])
+    protected function updateFormFields(FieldList &$fields, Controller $controller, $name, $context = [])
     {
         // Add preview link
         if (empty($context['Record'])) {

--- a/tests/php/Forms/FormFieldTest/TestExtension.php
+++ b/tests/php/Forms/FormFieldTest/TestExtension.php
@@ -8,7 +8,7 @@ use SilverStripe\Dev\TestOnly;
 class TestExtension extends Extension implements TestOnly
 {
 
-    public function updateAttributes(&$attrs)
+    protected function updateAttributes(&$attrs)
     {
         $attrs['extended'] = true;
     }

--- a/tests/php/Forms/FormScaffolderTest/ArticleExtension.php
+++ b/tests/php/Forms/FormScaffolderTest/ArticleExtension.php
@@ -13,7 +13,7 @@ class ArticleExtension extends DataExtension implements TestOnly
         'ExtendedField' => 'Varchar'
     ];
 
-    public function updateCMSFields(FieldList $fields)
+    protected function updateCMSFields(FieldList $fields)
     {
         $fields->addFieldToTab(
             'Root.Main',

--- a/tests/php/Forms/GridField/GridFieldTest/StadiumExtension.php
+++ b/tests/php/Forms/GridField/GridFieldTest/StadiumExtension.php
@@ -9,7 +9,7 @@ use SilverStripe\Forms\Tests\GridField\GridFieldTest\StadiumExtension;
 
 class StadiumExtension extends DataExtension implements TestOnly
 {
-    public function updateSearchableFields(&$fields)
+    protected function updateSearchableFields(&$fields)
     {
         $fields['Type']['filter'] = new FulltextFilter();
     }

--- a/tests/php/ORM/DataExtensionTest/CMSFieldsBaseExtension.php
+++ b/tests/php/ORM/DataExtensionTest/CMSFieldsBaseExtension.php
@@ -17,7 +17,7 @@ class CMSFieldsBaseExtension extends DataExtension implements TestOnly
         'ExtendedFieldRemove' => 'Varchar(255)'
     ];
 
-    public function updateCMSFields(FieldList $fields)
+    protected function updateCMSFields(FieldList $fields)
     {
         $fields->addFieldToTab('Root.Test', new TextField('ExtendedFieldRemove'));
         $fields->addFieldToTab('Root.Test', new TextField('ExtendedFieldKeep'));

--- a/tests/php/ORM/DataExtensionTest/Extension1.php
+++ b/tests/php/ORM/DataExtensionTest/Extension1.php
@@ -8,17 +8,17 @@ use SilverStripe\ORM\DataExtension;
 class Extension1 extends DataExtension implements TestOnly
 {
 
-    public function canOne($member = null)
+    protected function canOne($member = null)
     {
         return true;
     }
 
-    public function canTwo($member = null)
+    protected function canTwo($member = null)
     {
         return false;
     }
 
-    public function canThree($member = null)
+    protected function canThree($member = null)
     {
     }
 }

--- a/tests/php/ORM/DataExtensionTest/Extension2.php
+++ b/tests/php/ORM/DataExtensionTest/Extension2.php
@@ -8,17 +8,17 @@ use SilverStripe\ORM\DataExtension;
 class Extension2 extends DataExtension implements TestOnly
 {
 
-    public function canOne($member = null)
+    protected function canOne($member = null)
     {
         return true;
     }
 
-    public function canTwo($member = null)
+    protected function canTwo($member = null)
     {
         return true;
     }
 
-    public function canThree($member = null)
+    protected function canThree($member = null)
     {
     }
 }

--- a/tests/php/ORM/DataObjectTest/Team_Extension.php
+++ b/tests/php/ORM/DataObjectTest/Team_Extension.php
@@ -24,7 +24,7 @@ class Team_Extension extends DataExtension implements TestOnly
         return "extended dynamic field";
     }
 
-    public function augmentHydrateFields()
+    protected function augmentHydrateFields()
     {
         return [
             'CustomHydratedField' => true,

--- a/tests/php/Security/MemberTest/AlwaysFailExtension.php
+++ b/tests/php/Security/MemberTest/AlwaysFailExtension.php
@@ -10,7 +10,7 @@ use SilverStripe\ORM\DataExtension;
  */
 class AlwaysFailExtension extends DataExtension implements TestOnly
 {
-    public function updatePHP($data, $form)
+    protected function updatePHP($data, $form)
     {
         return false;
     }

--- a/tests/php/Security/MemberTest/EditingAllowedDeletingDeniedExtension.php
+++ b/tests/php/Security/MemberTest/EditingAllowedDeletingDeniedExtension.php
@@ -8,17 +8,17 @@ use SilverStripe\ORM\DataExtension;
 class EditingAllowedDeletingDeniedExtension extends DataExtension implements TestOnly
 {
 
-    public function canView($member = null)
+    protected function canView($member = null)
     {
         return true;
     }
 
-    public function canEdit($member = null)
+    protected function canEdit($member = null)
     {
         return true;
     }
 
-    public function canDelete($member = null)
+    protected function canDelete($member = null)
     {
         return false;
     }

--- a/tests/php/Security/MemberTest/ExtendedChangePasswordExtension.php
+++ b/tests/php/Security/MemberTest/ExtendedChangePasswordExtension.php
@@ -11,7 +11,7 @@ use SilverStripe\ORM\ValidationResult;
  */
 class ExtendedChangePasswordExtension extends DataExtension implements TestOnly
 {
-    public function onBeforeChangePassword($newPassword, $valid)
+    protected function onBeforeChangePassword($newPassword, $valid)
     {
         $valid->addError('Extension failed to handle Mary changing her password');
     }

--- a/tests/php/Security/MemberTest/FieldsExtension.php
+++ b/tests/php/Security/MemberTest/FieldsExtension.php
@@ -9,7 +9,7 @@ use SilverStripe\ORM\DataExtension;
 
 class FieldsExtension extends DataExtension implements TestOnly
 {
-    public function updateCMSFields(FieldList $fields)
+    protected function updateCMSFields(FieldList $fields)
     {
         $fields->addFieldToTab('Root.Main', new TextField('TestMemberField', 'Test'));
     }

--- a/tests/php/Security/MemberTest/SurnameMustMatchFirstNameExtension.php
+++ b/tests/php/Security/MemberTest/SurnameMustMatchFirstNameExtension.php
@@ -10,7 +10,7 @@ use SilverStripe\ORM\DataExtension;
  */
 class SurnameMustMatchFirstNameExtension extends DataExtension implements TestOnly
 {
-    public function updatePHP($data, $form)
+    protected function updatePHP($data, $form)
     {
         return $data['FirstName'] == $data['Surname'];
     }

--- a/tests/php/Security/MemberTest/ViewingAllowedExtension.php
+++ b/tests/php/Security/MemberTest/ViewingAllowedExtension.php
@@ -8,7 +8,7 @@ use SilverStripe\ORM\DataExtension;
 class ViewingAllowedExtension extends DataExtension implements TestOnly
 {
 
-    public function canView($member = null)
+    protected function canView($member = null)
     {
         return true;
     }

--- a/tests/php/Security/MemberTest/ViewingDeniedExtension.php
+++ b/tests/php/Security/MemberTest/ViewingDeniedExtension.php
@@ -8,7 +8,7 @@ use SilverStripe\ORM\DataExtension;
 class ViewingDeniedExtension extends DataExtension implements TestOnly
 {
 
-    public function canView($member = null)
+    protected function canView($member = null)
     {
         return false;
     }


### PR DESCRIPTION
Extension hook methods should be protected - this should be best practices for CMS 5 now that it is a possibility as it reduces the public API surface extensions introduce.

## Parent Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10514