### PR TITLE
FIX Allow removing named extensions in yaml config

### DIFF
--- a/src/Core/Config/Middleware/ExtensionMiddleware.php
+++ b/src/Core/Config/Middleware/ExtensionMiddleware.php
@@ -63,6 +63,11 @@ class ExtensionMiddleware implements Middleware
 
         $extensions = $extensionSourceConfig['extensions'];
         foreach ($extensions as $extension) {
+            // Allow removing extensions via yaml config by setting named extension config to null
+            if ($extension === null) {
+                continue;
+            }
+
             list($extensionClass, $extensionArgs) = ClassInfo::parse_class_spec($extension);
             // Strip service name specifier
             $extensionClass = strtok($extensionClass ?? '', '.');

--- a/src/Core/Extensible.php
+++ b/src/Core/Extensible.php
@@ -553,6 +553,11 @@ trait Extensible
 
             if ($extensions) {
                 foreach ($extensions as $extension) {
+                    // Allow removing extensions via yaml config by setting named extension config to null
+                    if ($extension === null) {
+                        continue;
+                    }
+
                     $name = $extension;
                     // Allow service names of the form "%$ServiceName"
                     if (substr($name ?? '', 0, 2) == '%$') {

--- a/tests/php/Core/ExtensionTest.php
+++ b/tests/php/Core/ExtensionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SilverStripe\Core\Tests;
+
+use BadMethodCallException;
+use ReflectionProperty;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Tests\ExtensionTest\NamedExtension;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObject;
+
+class ExtensionTest extends SapphireTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Reset extra_methods so that when we set NamedExtension to null it re-evaluates which methods are available
+        $reflectionProperty = new ReflectionProperty(DataObject::class, 'extra_methods');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue([]);
+        // Add named extension config like we would in yaml
+        Config::modify()->merge(DataObject::class, 'extensions', ['NamedExtension' => NamedExtension::class]);
+    }
+
+    public function testHasNamedExtension()
+    {
+        $this->assertTrue(DataObject::has_extension(NamedExtension::class));
+        $instance = new DataObject();
+        $this->assertTrue($instance->hasMethod('getTestValue'));
+        $this->assertSame('test', $instance->getTestValue());
+    }
+
+    public function testRemoveNamedExtension()
+    {
+        Config::modify()->merge(DataObject::class, 'extensions', ['NamedExtension' => null]);
+        $this->assertFalse(DataObject::has_extension(NamedExtension::class));
+        $instance = new DataObject();
+        $this->assertFalse($instance->hasMethod('getTestValue'));
+    }
+
+    public function testRemoveNamedExtensionException()
+    {
+        Config::modify()->merge(DataObject::class, 'extensions', ['NamedExtension' => null]);
+        $instance = new DataObject();
+        $this->expectException(BadMethodCallException::class);
+        $instance->getTestValue();
+    }
+}

--- a/tests/php/Core/ExtensionTest/NamedExtension.php
+++ b/tests/php/Core/ExtensionTest/NamedExtension.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\Core\Tests\ExtensionTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class NamedExtension extends Extension implements TestOnly
+{
+    public function getTestValue()
+    {
+        return 'test';
+    }
+}


### PR DESCRIPTION
## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10511