### PR TITLE
FIX Prevent infinite loops in Deprecation::notice()

### DIFF
--- a/src/Core/Config/Middleware/ExtensionMiddleware.php
+++ b/src/Core/Config/Middleware/ExtensionMiddleware.php
@@ -63,6 +63,11 @@ class ExtensionMiddleware implements Middleware
 
         $extensions = $extensionSourceConfig['extensions'];
         foreach ($extensions as $extension) {
+            // Allow removing extensions via yaml config by setting named extension config to null
+            if ($extension === null) {
+                continue;
+            }
+
             list($extensionClass, $extensionArgs) = ClassInfo::parse_class_spec($extension);
             // Strip service name specifier
             $extensionClass = strtok($extensionClass ?? '', '.');

--- a/src/Core/Extensible.php
+++ b/src/Core/Extensible.php
@@ -553,6 +553,11 @@ trait Extensible
 
             if ($extensions) {
                 foreach ($extensions as $extension) {
+                    // Allow removing extensions via yaml config by setting named extension config to null
+                    if ($extension === null) {
+                        continue;
+                    }
+
                     $name = $extension;
                     // Allow service names of the form "%$ServiceName"
                     if (substr($name ?? '', 0, 2) == '%$') {

--- a/src/Dev/Deprecation.php
+++ b/src/Dev/Deprecation.php
@@ -74,6 +74,11 @@ class Deprecation
     public static $notice_level = null;
 
     /**
+     * Used to prevent infinite call loops
+     */
+    protected static $inside_notice = false;
+
+    /**
      * Set the version that is used to check against the version passed to notice. If the ::notice version is
      * greater than or equal to this version, a message will be raised
      *
@@ -171,6 +176,10 @@ class Deprecation
      */
     public static function notice($atVersion, $string = '', $scope = Deprecation::SCOPE_METHOD)
     {
+        if (static::$inside_notice) {
+            return;
+        }
+        static::$inside_notice = true;
         if (!static::get_enabled()) {
             return;
         }
@@ -238,6 +247,7 @@ class Deprecation
                 user_error($string ?? '', $level ?? 0);
             }
         }
+        static::$inside_notice = false;
     }
 
     /**

--- a/src/Security/MemberAuthenticator/MemberAuthenticator.php
+++ b/src/Security/MemberAuthenticator/MemberAuthenticator.php
@@ -47,7 +47,7 @@ class MemberAuthenticator implements Authenticator
         // Optionally record every login attempt as a {@link LoginAttempt} object
         $this->recordLoginAttempt($data, $request, $member, $result->isValid());
 
-        if ($member) {
+        if ($member && $request->hasSession()) {
             $request->getSession()->clear('BackURL');
         }
 

--- a/tests/php/Core/ExtensionTest.php
+++ b/tests/php/Core/ExtensionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SilverStripe\Core\Tests;
+
+use BadMethodCallException;
+use ReflectionProperty;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Tests\ExtensionTest\NamedExtension;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObject;
+
+class ExtensionTest extends SapphireTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Reset extra_methods so that when we set NamedExtension to null it re-evaluates which methods are available
+        $reflectionProperty = new ReflectionProperty(DataObject::class, 'extra_methods');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue([]);
+        // Add named extension config like we would in yaml
+        Config::modify()->merge(DataObject::class, 'extensions', ['NamedExtension' => NamedExtension::class]);
+    }
+
+    public function testHasNamedExtension()
+    {
+        $this->assertTrue(DataObject::has_extension(NamedExtension::class));
+        $instance = new DataObject();
+        $this->assertTrue($instance->hasMethod('getTestValue'));
+        $this->assertSame('test', $instance->getTestValue());
+    }
+
+    public function testRemoveNamedExtension()
+    {
+        Config::modify()->merge(DataObject::class, 'extensions', ['NamedExtension' => null]);
+        $this->assertFalse(DataObject::has_extension(NamedExtension::class));
+        $instance = new DataObject();
+        $this->assertFalse($instance->hasMethod('getTestValue'));
+    }
+
+    public function testRemoveNamedExtensionException()
+    {
+        Config::modify()->merge(DataObject::class, 'extensions', ['NamedExtension' => null]);
+        $instance = new DataObject();
+        $this->expectException(BadMethodCallException::class);
+        $instance->getTestValue();
+    }
+}

--- a/tests/php/Core/ExtensionTest/NamedExtension.php
+++ b/tests/php/Core/ExtensionTest/NamedExtension.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\Core\Tests\ExtensionTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class NamedExtension extends Extension implements TestOnly
+{
+    public function getTestValue()
+    {
+        return 'test';
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10500

Prevent nested Deprecation::notice(), such as in the case of BaseKernel::getEnvironment(), from causing an infinite loop