### PR TITLE
Update installation links in the readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Requires a [`silverstripe-installer`](https://github.com/silverstripe/silverstri
 
 ## Installation ##
 
-See [installation on different platforms](https://doc.silverstripe.org/framework/en/installation/),
-and [installation from source](https://doc.silverstripe.org/framework/en/installation/from-source).
+See [getting started](https://docs.silverstripe.org/en/4/getting_started/),
+for instructions on how to start the installation process.
 
 ## Bugtracker ##
 


### PR DESCRIPTION
Changed the installation links to getting started as there are no installation pages in the docs for v4. Logically this would be the best place to start when looking for instructions on how to install for new starters. There are still links to the lessons and server requirements for further details. 

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
