### PR TITLE
SS5: add trailing slash config and redirect

### DIFF
--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -400,13 +400,13 @@ class Director implements TemplateGlobalProvider
     {
         // Check if there is already a protocol given
         if (preg_match('/^http(s?):\/\//', $url ?? '')) {
-            return $url;
+            return Controller::normaliseTrailingSlash($url);
         }
 
         // Absolute urls without protocol are added
         // E.g. //google.com -> http://google.com
         if (strpos($url ?? '', '//') === 0) {
-            return self::protocol() . substr($url ?? '', 2);
+            return Controller::normaliseTrailingSlash(self::protocol() . substr($url ?? '', 2));
         }
 
         // Determine method for mapping the parent to this relative url
@@ -686,7 +686,7 @@ class Director implements TemplateGlobalProvider
         $url = preg_replace('#([^:])//#', '\\1/', trim($url ?? ''));
 
         // If using a real url, remove protocol / hostname / auth / port
-        if (preg_match('#^(?<protocol>https?:)?//(?<hostpart>[^/]*)(?<url>(/.*)?)$#i', $url ?? '', $matches)) {
+        if (preg_match('@^(?<protocol>https?:)?//(?<hostpart>[^/?#]*)(?<url>([/?#].*)?)$@i', $url ?? '', $matches)) {
             $url = $matches['url'];
         }
 
@@ -878,10 +878,11 @@ class Director implements TemplateGlobalProvider
      */
     public static function absoluteBaseURL()
     {
-        return self::absoluteURL(
+        $baseURL = self::absoluteURL(
             self::baseURL(),
             self::ROOT
         );
+        return Controller::normaliseTrailingSlash($baseURL);
     }
 
     /**

--- a/src/Control/HTTP.php
+++ b/src/Control/HTTP.php
@@ -172,7 +172,7 @@ class HTTP
         $isRelative = false;
         // We need absolute URLs for parse_url()
         if (Director::is_relative_url($uri)) {
-            $uri = Director::absoluteBaseURL() . $uri;
+            $uri = Controller::join_links(Director::absoluteBaseURL(), $uri);
             $isRelative = true;
         }
 
@@ -212,7 +212,7 @@ class HTTP
         $newUri = $scheme . '://' . $user . $host . $port . $path . $params . $fragment;
 
         if ($isRelative) {
-            return Director::baseURL() . Director::makeRelative($newUri);
+            return Controller::join_links(Director::baseURL(), Director::makeRelative($newUri));
         }
 
         return $newUri;

--- a/src/Control/RequestHandler.php
+++ b/src/Control/RequestHandler.php
@@ -561,7 +561,7 @@ class RequestHandler extends ViewableData
         // Check configured url_segment
         $url = $this->config()->get('url_segment');
         if ($url) {
-            $link = Controller::join_links($url, $action, '/');
+            $link = Controller::join_links($url, $action);
 
             // Give extensions the chance to modify by reference
             $this->extend('updateLink', $link, $action);

--- a/src/Dev/DebugView.php
+++ b/src/Dev/DebugView.php
@@ -135,8 +135,9 @@ class DebugView
         $pathLinks = [];
         foreach ($parts as $part) {
             if ($part != '') {
-                $pathPart .= "$part/";
-                $pathLinks[] = "<a href=\"$base$pathPart\">$part</a>";
+                $pathPart = Controller::join_links($pathPart, $part);
+                $href = Controller::join_links($base, $pathPart);
+                $pathLinks[] = "<a href=\"$href\">$part</a>";
             }
         }
         return implode('&nbsp;&rarr;&nbsp;', $pathLinks);

--- a/src/Dev/TaskRunner.php
+++ b/src/Dev/TaskRunner.php
@@ -76,7 +76,7 @@ class TaskRunner extends Controller
 
         foreach ($tasks as $task) {
             $list->push(ArrayData::create([
-                'TaskLink' => $baseUrl . 'dev/tasks/' . $task['segment'],
+                'TaskLink' => Controller::join_links($baseUrl, 'dev/tasks/', $task['segment']),
                 'Title' => $task['title'],
                 'Description' => $task['description'],
             ]));

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -651,7 +651,7 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
         $settings = $this->getSettings();
 
         // https://www.tiny.cloud/docs/tinymce/6/url-handling/#document_base_url
-        $settings['document_base_url'] = Director::absoluteBaseURL();
+        $settings['document_base_url'] = rtrim(Director::absoluteBaseURL(), '/') . '/';
 
         // https://www.tiny.cloud/docs/tinymce/6/apis/tinymce.root/#properties
         $baseResource = $this->getTinyMCEResource();

--- a/src/View/SSViewer.php
+++ b/src/View/SSViewer.php
@@ -825,7 +825,8 @@ PHP;
      */
     public static function get_base_tag($contentGeneratedSoFar)
     {
-        $base = Director::absoluteBaseURL();
+        // Base href should always have a trailing slash
+        $base = rtrim(Director::absoluteBaseURL(), '/') . '/';
 
         // Is the document XHTML?
         if (preg_match('/<!DOCTYPE[^>]+xhtml/i', $contentGeneratedSoFar ?? '')) {

--- a/tests/php/Control/HTTPTest.php
+++ b/tests/php/Control/HTTPTest.php
@@ -244,36 +244,41 @@ class HTTPTest extends FunctionalTest
      */
     public function testAbsoluteURLsCSS()
     {
-        $this->withBaseURL(
-            'http://www.silverstripe.org/',
-            function () {
+        foreach ([true, false] as $withTrailingSlash) {
+            // The results should be the same with both settings, since files should never have trailing slashes.
+            Controller::config()->set('add_trailing_slash', $withTrailingSlash);
 
-                // background-image
-                // Note that using /./ in urls is absolutely acceptable
-                $this->assertEquals(
-                    '<div style="background-image: url(\'http://www.silverstripe.org/./images/mybackground.gif\');">' . 'Content</div>',
-                    HTTP::absoluteURLs('<div style="background-image: url(\'./images/mybackground.gif\');">Content</div>')
-                );
+            $this->withBaseURL(
+                'http://www.silverstripe.org/',
+                function () {
 
-                // background
-                $this->assertEquals(
-                    '<div style="background: url(\'http://www.silverstripe.org/images/mybackground.gif\');">Content</div>',
-                    HTTP::absoluteURLs('<div style="background: url(\'images/mybackground.gif\');">Content</div>')
-                );
+                    // background-image
+                    // Note that using /./ in urls is absolutely acceptable
+                    $this->assertEquals(
+                        '<div style="background-image: url(\'http://www.silverstripe.org/./images/mybackground.gif\');">' . 'Content</div>',
+                        HTTP::absoluteURLs('<div style="background-image: url(\'./images/mybackground.gif\');">Content</div>')
+                    );
 
-                // list-style-image
-                $this->assertEquals(
-                    '<div style=\'background: url(http://www.silverstripe.org/list.png);\'>Content</div>',
-                    HTTP::absoluteURLs('<div style=\'background: url(list.png);\'>Content</div>')
-                );
+                    // background
+                    $this->assertEquals(
+                        '<div style="background: url(\'http://www.silverstripe.org/images/mybackground.gif\');">Content</div>',
+                        HTTP::absoluteURLs('<div style="background: url(\'images/mybackground.gif\');">Content</div>')
+                    );
 
-                // list-style
-                $this->assertEquals(
-                    '<div style=\'background: url("http://www.silverstripe.org/./assets/list.png");\'>Content</div>',
-                    HTTP::absoluteURLs('<div style=\'background: url("./assets/list.png");\'>Content</div>')
-                );
-            }
-        );
+                    // list-style-image
+                    $this->assertEquals(
+                        '<div style=\'background: url(http://www.silverstripe.org/list.png);\'>Content</div>',
+                        HTTP::absoluteURLs('<div style=\'background: url(list.png);\'>Content</div>')
+                    );
+
+                    // list-style
+                    $this->assertEquals(
+                        '<div style=\'background: url("http://www.silverstripe.org/./assets/list.png");\'>Content</div>',
+                        HTTP::absoluteURLs('<div style=\'background: url("./assets/list.png");\'>Content</div>')
+                    );
+                }
+            );
+        }
     }
 
     /**
@@ -281,70 +286,75 @@ class HTTPTest extends FunctionalTest
      */
     public function testAbsoluteURLsAttributes()
     {
-        $this->withBaseURL(
-            'http://www.silverstripe.org/',
-            function () {
-                //empty links
-                $this->assertEquals(
-                    '<a href="http://www.silverstripe.org/">test</a>',
-                    HTTP::absoluteURLs('<a href="">test</a>')
-                );
+        foreach ([true, false] as $withTrailingSlash) {
+            Controller::config()->set('add_trailing_slash', $withTrailingSlash);
+            $slash = $withTrailingSlash ? '/' : '';
 
-                $this->assertEquals(
-                    '<a href="http://www.silverstripe.org/">test</a>',
-                    HTTP::absoluteURLs('<a href="/">test</a>')
-                );
+            $this->withBaseURL(
+                'http://www.silverstripe.org/',
+                function () use ($slash) {
+                    //empty links
+                    $this->assertEquals(
+                        "<a href=\"http://www.silverstripe.org{$slash}\">test</a>",
+                        HTTP::absoluteURLs('<a href="">test</a>')
+                    );
 
-                //relative
-                $this->assertEquals(
-                    '<a href="http://www.silverstripe.org/">test</a>',
-                    HTTP::absoluteURLs('<a href="./">test</a>')
-                );
-                $this->assertEquals(
-                    '<a href="http://www.silverstripe.org/">test</a>',
-                    HTTP::absoluteURLs('<a href=".">test</a>')
-                );
+                    $this->assertEquals(
+                        "<a href=\"http://www.silverstripe.org{$slash}\">test</a>",
+                        HTTP::absoluteURLs('<a href="/">test</a>')
+                    );
 
-                // links
-                $this->assertEquals(
-                    '<a href=\'http://www.silverstripe.org/blog/\'>SS Blog</a>',
-                    HTTP::absoluteURLs('<a href=\'/blog/\'>SS Blog</a>')
-                );
+                    //relative
+                    $this->assertEquals(
+                        "<a href=\"http://www.silverstripe.org{$slash}\">test</a>",
+                        HTTP::absoluteURLs('<a href="./">test</a>')
+                    );
+                    $this->assertEquals(
+                        "<a href=\"http://www.silverstripe.org{$slash}\">test</a>",
+                        HTTP::absoluteURLs('<a href=".">test</a>')
+                    );
 
-                // background
-                // Note that using /./ in urls is absolutely acceptable
-                $this->assertEquals(
-                    '<div background="http://www.silverstripe.org/./themes/silverstripe/images/nav-bg-repeat-2.png">' . 'SS Blog</div>',
-                    HTTP::absoluteURLs('<div background="./themes/silverstripe/images/nav-bg-repeat-2.png">SS Blog</div>')
-                );
+                    // links
+                    $this->assertEquals(
+                        "<a href='http://www.silverstripe.org/blog{$slash}'>SS Blog</a>",
+                        HTTP::absoluteURLs('<a href=\'/blog/\'>SS Blog</a>')
+                    );
 
-                //check dot segments
-                // Assumption: dots are not removed
-                //if they were, the url should be: http://www.silverstripe.org/abc
-                $this->assertEquals(
-                    '<a href="http://www.silverstripe.org/test/page/../../abc">Test</a>',
-                    HTTP::absoluteURLs('<a href="test/page/../../abc">Test</a>')
-                );
+                    // background
+                    // Note that using /./ in urls is absolutely acceptable
+                    $this->assertEquals(
+                        '<div background="http://www.silverstripe.org/./themes/silverstripe/images/nav-bg-repeat-2.png">' . 'SS Blog</div>',
+                        HTTP::absoluteURLs('<div background="./themes/silverstripe/images/nav-bg-repeat-2.png">SS Blog</div>')
+                    );
 
-                // image
-                $this->assertEquals(
-                    '<img src=\'http://www.silverstripe.org/themes/silverstripe/images/logo-org.png\' />',
-                    HTTP::absoluteURLs('<img src=\'themes/silverstripe/images/logo-org.png\' />')
-                );
+                    //check dot segments
+                    // Assumption: dots are not removed
+                    //if they were, the url should be: http://www.silverstripe.org/abc
+                    $this->assertEquals(
+                        "<a href=\"http://www.silverstripe.org/test/page/../../abc{$slash}\">Test</a>",
+                        HTTP::absoluteURLs('<a href="test/page/../../abc">Test</a>')
+                    );
 
-                // link
-                $this->assertEquals(
-                    '<link href=http://www.silverstripe.org/base.css />',
-                    HTTP::absoluteURLs('<link href=base.css />')
-                );
+                    // image
+                    $this->assertEquals(
+                        '<img src=\'http://www.silverstripe.org/themes/silverstripe/images/logo-org.png\' />',
+                        HTTP::absoluteURLs('<img src=\'themes/silverstripe/images/logo-org.png\' />')
+                    );
 
-                // Test special characters are retained
-                $this->assertEquals(
-                    '<a href="http://www.silverstripe.org/Security/changepassword?m=3&amp;t=7214fdfde">password reset link</a>',
-                    HTTP::absoluteURLs('<a href="/Security/changepassword?m=3&amp;t=7214fdfde">password reset link</a>')
-                );
-            }
-        );
+                    // link
+                    $this->assertEquals(
+                        '<link href=http://www.silverstripe.org/base.css />',
+                        HTTP::absoluteURLs('<link href=base.css />')
+                    );
+
+                    // Test special characters are retained
+                    $this->assertEquals(
+                        "<a href=\"http://www.silverstripe.org/Security/changepassword{$slash}?m=3&amp;t=7214fdfde\">password reset link</a>",
+                        HTTP::absoluteURLs('<a href="/Security/changepassword?m=3&amp;t=7214fdfde">password reset link</a>')
+                    );
+                }
+            );
+        }
     }
 
     /**

--- a/tests/php/Control/Middleware/CanonicalURLMiddlewareTest.php
+++ b/tests/php/Control/Middleware/CanonicalURLMiddlewareTest.php
@@ -2,44 +2,28 @@
 
 namespace SilverStripe\Control\Tests\Middleware;
 
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Middleware\CanonicalURLMiddleware;
+use SilverStripe\Core\Environment;
 use SilverStripe\Dev\SapphireTest;
 
 class CanonicalURLMiddlewareTest extends SapphireTest
 {
-    /**
-     * Stub middleware class, partially mocked
-     *
-     * @var CanonicalURLMiddleware
-     */
-    protected $middleware;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        /** @var CanonicalURLMiddleware $middleware */
-        $this->middleware = $this->getMockBuilder(CanonicalURLMiddleware::class)
-            ->setMethods(['getRedirect'])
-            ->getMock();
-
-        $this->middleware->expects($this->any())->method('getRedirect')->willReturn(false);
-
-        $this->middleware->setForceBasicAuthToSSL(true);
-    }
 
     public function testHttpsIsForcedForBasicAuth()
     {
-        $this->middleware->expects($this->once())->method('getRedirect');
+        $middleware = $this->getMockedMiddleware();
+        $middleware->expects($this->once())->method('getRedirect');
 
         $request = new HTTPRequest('GET', '/');
+        $request->addHeader('host', 'www.example.com');
         $mockResponse = (new HTTPResponse)
             ->addHeader('WWW-Authenticate', 'basic')
             ->setStatusCode(401);
 
-        $result = $this->middleware->process($request, function () use ($mockResponse) {
+        $result = $middleware->process($request, function () use ($mockResponse) {
             return $mockResponse;
         });
 
@@ -50,15 +34,17 @@ class CanonicalURLMiddlewareTest extends SapphireTest
 
     public function testMiddlewareDelegateIsReturnedWhenBasicAuthRedirectIsDisabled()
     {
-        $this->middleware->expects($this->once())->method('getRedirect');
-        $this->middleware->setForceBasicAuthToSSL(false);
+        $middleware = $this->getMockedMiddleware();
+        $middleware->expects($this->once())->method('getRedirect');
+        $middleware->setForceBasicAuthToSSL(false);
 
         $request = new HTTPRequest('GET', '/');
+        $request->addHeader('host', 'www.example.com');
         $mockResponse = (new HTTPResponse)
             ->addHeader('WWW-Authenticate', 'basic')
             ->setStatusCode(401);
 
-        $result = $this->middleware->process($request, function () use ($mockResponse) {
+        $result = $middleware->process($request, function () use ($mockResponse) {
             return $mockResponse;
         });
         $this->assertSame($mockResponse, $result, 'Response returned verbatim with auto redirect disabled');
@@ -66,12 +52,14 @@ class CanonicalURLMiddlewareTest extends SapphireTest
 
     public function testMiddlewareDelegateIsReturnedWhenNoBasicAuthIsPresent()
     {
-        $this->middleware->expects($this->once())->method('getRedirect');
+        $middleware = $this->getMockedMiddleware();
+        $middleware->expects($this->once())->method('getRedirect');
 
         $request = new HTTPRequest('GET', '/');
+        $request->addHeader('host', 'www.example.com');
         $mockResponse = (new HTTPResponse)->addHeader('Foo', 'bar');
 
-        $result = $this->middleware->process($request, function () use ($mockResponse) {
+        $result = $middleware->process($request, function () use ($mockResponse) {
             return $mockResponse;
         });
 
@@ -80,19 +68,125 @@ class CanonicalURLMiddlewareTest extends SapphireTest
 
     public function testGetForceBasicAuthToSSL()
     {
-        $this->middleware->setForceBasicAuthToSSL(null);
+        $middleware = $this->getMockedMiddleware();
+        $middleware->setForceBasicAuthToSSL(null);
 
-        $this->middleware->setForceSSL(true);
-        $this->assertTrue($this->middleware->getForceBasicAuthToSSL(), 'Default falls over to forceSSL');
+        $middleware->setForceSSL(true);
+        $this->assertTrue($middleware->getForceBasicAuthToSSL(), 'Default falls over to forceSSL');
 
-        $this->middleware->setForceSSL(false);
-        $this->assertFalse($this->middleware->getForceBasicAuthToSSL(), 'Default falls over to forceSSL');
+        $middleware->setForceSSL(false);
+        $this->assertFalse($middleware->getForceBasicAuthToSSL(), 'Default falls over to forceSSL');
 
-        $this->middleware->setForceBasicAuthToSSL(true);
-        $this->assertTrue($this->middleware->getForceBasicAuthToSSL(), 'Explicitly set is returned');
+        $middleware->setForceBasicAuthToSSL(true);
+        $this->assertTrue($middleware->getForceBasicAuthToSSL(), 'Explicitly set is returned');
 
-        $this->middleware->setForceBasicAuthToSSL(false);
-        $this->middleware->setForceSSL(true);
-        $this->assertFalse($this->middleware->getForceBasicAuthToSSL(), 'Explicitly set is returned');
+        $middleware->setForceBasicAuthToSSL(false);
+        $middleware->setForceSSL(true);
+        $this->assertFalse($middleware->getForceBasicAuthToSSL(), 'Explicitly set is returned');
+    }
+
+    public function testRedirectTrailingSlash()
+    {
+        $testScenarios = [
+            [
+                'forceRedirect' => true,
+                'addTrailingSlash' => true,
+                'requestHasSlash' => true,
+            ],
+            [
+                'forceRedirect' => true,
+                'addTrailingSlash' => true,
+                'requestHasSlash' => false,
+            ],
+            [
+                'forceRedirect' => true,
+                'addTrailingSlash' => false,
+                'requestHasSlash' => true,
+            ],
+            [
+                'forceRedirect' => true,
+                'addTrailingSlash' => false,
+                'requestHasSlash' => false,
+            ],
+            [
+                'forceRedirect' => false,
+                'addTrailingSlash' => true,
+                'requestHasSlash' => true,
+            ],
+            [
+                'forceRedirect' => false,
+                'addTrailingSlash' => true,
+                'requestHasSlash' => false,
+            ],
+            [
+                'forceRedirect' => false,
+                'addTrailingSlash' => false,
+                'requestHasSlash' => true,
+            ],
+            [
+                'forceRedirect' => false,
+                'addTrailingSlash' => false,
+                'requestHasSlash' => false,
+            ],
+        ];
+        foreach ($testScenarios as $scenario) {
+            $forceRedirect = $scenario['forceRedirect'];
+            $addTrailingSlash = $scenario['addTrailingSlash'];
+            $requestHasSlash = $scenario['requestHasSlash'];
+
+            $middleware = $this->getMockedMiddleware(false);
+
+            $middleware->setEnforceTrailingSlashConfig($forceRedirect);
+            Controller::config()->set('add_trailing_slash', $addTrailingSlash);
+
+            $requestSlash = $requestHasSlash ? '/' : '';
+            $requestURL = "/about-us{$requestSlash}";
+
+            Environment::setEnv('REQUEST_URI', $requestURL);
+            $request = new HTTPRequest('GET', $requestURL);
+            $request->setScheme('https');
+            $request->addHeader('host', 'www.example.com');
+            $mockResponse = (new HTTPResponse)
+                ->setStatusCode(200);
+
+            $result = $middleware->process($request, function () use ($mockResponse) {
+                return $mockResponse;
+            });
+
+            $noRedirect = !$forceRedirect || ($addTrailingSlash && $requestHasSlash) || (!$addTrailingSlash && !$requestHasSlash);
+            if ($noRedirect) {
+                $this->assertNull($result->getHeader('Location'), 'No location header should be added');
+                $this->assertEquals(200, $result->getStatusCode(), 'No redirection should be made');
+            } else {
+                $this->assertEquals(301, $result->getStatusCode(), 'Responses should be redirected to include/omit trailing slash');
+                if ($addTrailingSlash) {
+                    $this->assertStringEndsWith('/', $result->getHeader('Location'), 'Trailing slash should be added');
+                } else {
+                    $this->assertStringEndsNotWith('/', $result->getHeader('Location'), 'Trailing slash should be removed');
+                }
+            }
+        }
+    }
+
+    private function getMockedMiddleware($mockGetRedirect = true): CanonicalURLMiddleware
+    {
+        $mockedMethods = ['isEnabled'];
+        if ($mockGetRedirect) {
+            $mockedMethods[] = 'getRedirect';
+        }
+
+        /** @var CanonicalURLMiddleware $middleware */
+        $middleware = $this->getMockBuilder(CanonicalURLMiddleware::class)
+            ->setMethods($mockedMethods)
+            ->getMock();
+
+        $middleware->expects($this->any())->method('isEnabled')->willReturn(true);
+        if ($mockGetRedirect) {
+            $middleware->expects($this->any())->method('getRedirect')->willReturn(false);
+        }
+
+        $middleware->setForceBasicAuthToSSL(true);
+
+        return $middleware;
     }
 }

--- a/tests/php/Control/RSS/RSSFeedTest.php
+++ b/tests/php/Control/RSS/RSSFeedTest.php
@@ -24,7 +24,7 @@ class RSSFeedTest extends SapphireTest
         $rssFeed = new RSSFeed($list, "http://www.example.com", "Test RSS Feed", "Test RSS Feed Description");
         $content = $rssFeed->outputToBrowser();
 
-        $this->assertStringContainsString('<link>http://www.example.org/item-a/</link>', $content);
+        $this->assertStringContainsString('<link>http://www.example.org/item-a</link>', $content);
         $this->assertStringContainsString('<link>http://www.example.com/item-b.html</link>', $content);
         $this->assertStringContainsString('<link>http://www.example.com/item-c.html</link>', $content);
 
@@ -60,9 +60,9 @@ class RSSFeedTest extends SapphireTest
     public function testLinkEncoding()
     {
         $list = new ArrayList();
-        $rssFeed = new RSSFeed($list, "http://www.example.com/?param1=true&param2=true", "Test RSS Feed");
+        $rssFeed = new RSSFeed($list, "http://www.example.com?param1=true&param2=true", "Test RSS Feed");
         $content = $rssFeed->outputToBrowser();
-        $this->assertStringContainsString('<link>http://www.example.com/?param1=true&amp;param2=true', $content);
+        $this->assertStringContainsString('<link>http://www.example.com?param1=true&amp;param2=true', $content);
     }
 
     public function testRSSFeedWithShortcode()

--- a/tests/php/Forms/FormFactoryTest.php
+++ b/tests/php/Forms/FormFactoryTest.php
@@ -56,7 +56,7 @@ class FormFactoryTest extends SapphireTest
         $previewLink = $form->Fields()->fieldByName('PreviewLink');
         $this->assertInstanceOf(LiteralField::class, $previewLink);
         $this->assertEquals(
-            '<a href="FormFactoryTest_TestController/preview/" rel="external" target="_blank">Preview</a>',
+            '<a href="FormFactoryTest_TestController/preview" rel="external" target="_blank">Preview</a>',
             $previewLink->getContent()
         );
 

--- a/tests/php/Forms/HTMLEditor/TinyMCECombinedGeneratorTest.php
+++ b/tests/php/Forms/HTMLEditor/TinyMCECombinedGeneratorTest.php
@@ -62,7 +62,7 @@ class TinyMCECombinedGeneratorTest extends SapphireTest
         $this->assertMatchesRegularExpression('#_tinymce/tinymce-testconfig-[0-9a-z]{10,10}#', $generator->generateFilename($c));
         $content = $generator->generateContent($c);
         $this->assertStringContainsString(
-            "var baseURL = baseTag.length ? baseTag[0].baseURI : 'http://www.mysite.com/basedir/';\n",
+            "var baseURL = baseTag.length ? baseTag[0].baseURI : 'http://www.mysite.com/basedir';\n",
             $content
         );
         // Main script file

--- a/tests/php/ORM/PaginatedListTest.php
+++ b/tests/php/ORM/PaginatedListTest.php
@@ -344,7 +344,8 @@ class PaginatedListTest extends SapphireTest
     public function testFirstLink()
     {
         $list = new PaginatedList(new ArrayList());
-        $this->assertStringContainsString('start=0', $list->FirstLink());
+        $link = $list->FirstLink();
+        $this->assertStringContainsString('start=0', $link);
     }
 
     public function testFirstLinkContainsCurrentGetParameters()

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -332,7 +332,7 @@ class SecurityTest extends FunctionalTest
         $this->get(
             Config::inst()->get(Security::class, 'logout_url'),
             null,
-            ['Referer' => Director::absoluteBaseURL() . 'testpage']
+            ['Referer' => Controller::join_links(Director::absoluteBaseURL(), 'testpage')]
         );
 
         /* Make sure the user is still logged in */
@@ -388,11 +388,11 @@ class SecurityTest extends FunctionalTest
         $response = $this->doTestLoginForm(
             'noexpiry@silverstripe.com',
             '1nitialPassword',
-            Director::absoluteBaseURL() . 'testpage'
+            Controller::join_links(Director::absoluteBaseURL(), 'testpage')
         );
         // for some reason the redirect happens to a relative URL
         $this->assertMatchesRegularExpression(
-            '/^' . preg_quote(Director::absoluteBaseURL() ?? '', '/') . 'testpage/',
+            '/^' . preg_quote(Controller::join_links(Director::absoluteBaseURL(), 'testpage'), '/') . '/',
             $response->getHeader('Location'),
             "Internal absolute BackURLs work when passed through to login form"
         );

--- a/tests/php/Security/SecurityTokenTest.php
+++ b/tests/php/Security/SecurityTokenTest.php
@@ -123,14 +123,14 @@ class SecurityTokenTest extends SapphireTest
     {
         $t = new SecurityToken();
 
-        $url = 'http://absolute.tld/action/';
+        $url = 'http://absolute.tld/action';
         $this->assertEquals(
             sprintf('%s?%s=%s', $url, $t->getName(), $t->getValue()),
             $t->addToUrl($url),
             'Urls without existing GET parameters'
         );
 
-        $url = 'http://absolute.tld/?getparam=1';
+        $url = 'http://absolute.tld?getparam=1';
         $this->assertEquals(
             sprintf('%s&%s=%s', $url, $t->getName(), $t->getValue()),
             $t->addToUrl($url),


### PR DESCRIPTION
This PR adds trailing slash configuration to `Controller` and extends `CanonicalURLMiddleware` to include the trailing slash redirect. 

This covers criteria 2-4 of the parent issue

## Parent issue
- https://github.com/silverstripe/silverstripe-cms/issues/2780
