### PR TITLE
Allow classes to be passed into Injector::inst()->load()

### DIFF
--- a/src/Core/Injector/InjectionCreator.php
+++ b/src/Core/Injector/InjectionCreator.php
@@ -9,30 +9,17 @@ class InjectionCreator implements Factory
 {
     public function create($class, array $params = [])
     {
+        // Ensure there are no string keys as they cannot be unpacked with the `...` operator
+        $values = array_values($params ?? []);
+
         // Allow anonymous classes or other classes to pass without ReflectionClass
         if (is_object($class)) {
-            $values = $this->removeStringKeys($params);
-
             return new $class(...$values);
         }
         elseif(!class_exists($class ?? '')) {
             throw new InjectorNotFoundException("Class {$class} does not exist");
         }
 
-        $values = $this->removeStringKeys($params);
-
         return new $class(...$values);
-    }
-
-    /**
-     * @param $params
-     *
-     * Ensure there are no string keys as they cannot be unpacked with the `...` operator
-     *
-     * @return array
-     */
-    private function removeStringKeys($params): array
-    {
-        return array_values($params ?? []);
     }
 }

--- a/src/Core/Injector/InjectionCreator.php
+++ b/src/Core/Injector/InjectionCreator.php
@@ -9,11 +9,30 @@ class InjectionCreator implements Factory
 {
     public function create($class, array $params = [])
     {
-        if (!class_exists($class ?? '')) {
+        // Allow anonymous classes or other classes to pass without ReflectionClass
+        if (is_object($class)) {
+            $values = $this->removeStringKeys($params);
+
+            return new $class(...$values);
+        }
+        elseif(!class_exists($class ?? '')) {
             throw new InjectorNotFoundException("Class {$class} does not exist");
         }
-        // Ensure there are no string keys as they cannot be unpacked with the `...` operator
-        $values = array_values($params ?? []);
+
+        $values = $this->removeStringKeys($params);
+
         return new $class(...$values);
+    }
+
+    /**
+     * @param $params
+     *
+     * Ensure there are no string keys as they cannot be unpacked with the `...` operator
+     *
+     * @return array
+     */
+    private function removeStringKeys($params): array
+    {
+        return array_values($params ?? []);
     }
 }

--- a/src/Core/Injector/InjectionCreator.php
+++ b/src/Core/Injector/InjectionCreator.php
@@ -9,16 +9,16 @@ class InjectionCreator implements Factory
 {
     public function create($class, array $params = [])
     {
-        // Ensure there are no string keys as they cannot be unpacked with the `...` operator
-        $values = array_values($params ?? []);
-
         // Allow anonymous classes or other classes to pass without ReflectionClass
         if (is_object($class)) {
-            return new $class(...$values);
+            return $class;
         }
         elseif(!class_exists($class ?? '')) {
             throw new InjectorNotFoundException("Class {$class} does not exist");
         }
+
+        // Ensure there are no string keys as they cannot be unpacked with the `...` operator
+        $values = array_values($params ?? []);
 
         return new $class(...$values);
     }

--- a/src/Core/Injector/InjectionCreator.php
+++ b/src/Core/Injector/InjectionCreator.php
@@ -12,8 +12,8 @@ class InjectionCreator implements Factory
         // Allow anonymous classes or other classes to pass without ReflectionClass
         if (is_object($class)) {
             return $class;
-        }
-        elseif (!class_exists($class ?? '')) { 
+        } 
+        elseif (!class_exists($class ?? '')) {
             throw new InjectorNotFoundException("Class {$class} does not exist");
         }
 

--- a/src/Core/Injector/InjectionCreator.php
+++ b/src/Core/Injector/InjectionCreator.php
@@ -13,7 +13,7 @@ class InjectionCreator implements Factory
         if (is_object($class)) {
             return $class;
         }
-        elseif(!class_exists($class ?? '')) {
+        elseif (!class_exists($class ?? '')) { 
             throw new InjectorNotFoundException("Class {$class} does not exist");
         }
 

--- a/tests/php/Core/Injector/InjectorTest.php
+++ b/tests/php/Core/Injector/InjectorTest.php
@@ -22,11 +22,10 @@ use SilverStripe\Core\Tests\Injector\InjectorTest\NewRequirementsBackend;
 use SilverStripe\Core\Tests\Injector\InjectorTest\OriginalRequirementsBackend;
 use SilverStripe\Core\Tests\Injector\InjectorTest\OtherTestObject;
 use SilverStripe\Core\Tests\Injector\InjectorTest\TestObject;
+use SilverStripe\Core\Tests\Injector\InjectorTest\TestObjectTwo;
 use SilverStripe\Core\Tests\Injector\InjectorTest\TestSetterInjections;
 use SilverStripe\Core\Tests\Injector\InjectorTest\TestStaticInjections;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Dev\TestOnly;
-use stdClass;
 
 define('TEST_SERVICES', __DIR__ . '/AopProxyServiceTest');
 
@@ -1064,5 +1063,28 @@ class InjectorTest extends SapphireTest
         // Return to nestingLevel 0
         Injector::unnest();
         $this->nestingLevel--;
+    }
+
+    public function testAnonymousClass()
+    {
+        // load a mock & method override via Injector
+        Injector::inst()->load([
+            TestObject::class => [
+                'class' => new class {
+                    public function foo(): string
+                    {
+                        return TestObject::TEST_BAZ;
+                    }
+                },
+            ],
+        ]);
+
+        $myObject = new TestObjectTwo();
+
+        $this->assertEquals(
+            TestObject::TEST_BAZ,
+            $myObject->fooViaTestObject(),
+            'Function return does not match what was mocked above'
+        );
     }
 }

--- a/tests/php/Core/Injector/InjectorTest/TestObject.php
+++ b/tests/php/Core/Injector/InjectorTest/TestObject.php
@@ -2,10 +2,15 @@
 
 namespace SilverStripe\Core\Tests\Injector\InjectorTest;
 
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Dev\TestOnly;
 
 class TestObject implements TestOnly
 {
+    use Injectable;
+
+    const TEST_BAR = 'bar';
+    const TEST_BAZ = 'baz';
 
     public $sampleService;
 
@@ -29,5 +34,10 @@ class TestObject implements TestOnly
     protected function protectedMethod()
     {
         $this->methodCalls[] = 'protectedMethod called';
+    }
+
+    public function foo(): string
+    {
+        return self::TEST_BAR;
     }
 }

--- a/tests/php/Core/Injector/InjectorTest/TestObjectTwo.php
+++ b/tests/php/Core/Injector/InjectorTest/TestObjectTwo.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Injector\InjectorTest;
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Dev\TestOnly;
+
+class TestObjectTwo implements TestOnly
+{
+    public function fooViaTestObject(): string
+    {
+        $obj1 = TestObject::create();
+
+        return $obj1->foo();
+    }
+}


### PR DESCRIPTION
## Issue:
Progress on #10533 

## Summary:
> It appears there was a breaking change in https://github.com/silverstripe/silverstripe-framework/pull/10265 that prevents anonymous classes (to override specific functions in tests) being passed into `Injector::inst()->load()`.
> 
> Thus this is a breaking change from 4.10 to 4.11


## Objective
This PR's purpose is to bring back this functionality, whilst keeping any speed gains from #10265 

Spurred off @kinglozzer comments there, and conversation with @GuySartorelli in SS Users slack.


I have tested this locally with business logic, and this resolves the original issue.


## Comments
As this adds another path through InjectionCreator it needs some unit tests.
I am not sure where is would be best to add this, doesn't appear to be a dedicated TestInjectionCreator file or anything.

Happy for someone else to write the tests or point me in the right direction.


## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10533
