### PR TITLE
NEW Record deprecated config

### DIFF
--- a/tests/php/Dev/DeprecationTest.php
+++ b/tests/php/Dev/DeprecationTest.php
@@ -2,16 +2,43 @@
 
 namespace SilverStripe\Dev\Tests;
 
+use PHPUnit\Framework\Error\Deprecated;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Dev\Tests\DeprecationTest\TestDeprecation;
+use SilverStripe\Dev\Tests\DeprecationTest\DeprecationTestObject;
 
 class DeprecationTest extends SapphireTest
 {
+    protected static $extra_dataobjects = [
+        DeprecationTestObject::class,
+    ];
+
+    private $oldHandler = null;
+
+    protected function setup(): void
+    {
+        // Use custom error handler for two reasons:
+        // - Filter out errors for deprecated class properities unrelated to this unit test
+        // - Allow the use of expectDeprecation(), which doesn't work with E_USER_DEPRECATION by default
+        //   https://github.com/laminas/laminas-di/pull/30#issuecomment-927585210
+        parent::setup();
+        $this->oldHandler = set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline) {
+            if (str_contains($errstr, 'SilverStripe\\Dev\\Tests\\DeprecationTest')) {
+                throw new Deprecated($errstr, $errno, '', 1);
+            }
+            if (is_callable($this->oldHandler)) {
+                return call_user_func($this->oldHandler, $errno, $errstr, $errfile, $errline);
+            }
+            return false;
+        });
+    }
+
     protected function tearDown(): void
     {
-        Deprecation::$notice_level = E_USER_DEPRECATED;
         Deprecation::disable();
+        set_error_handler($this->oldHandler);
+        $this->oldHandler = null;
         parent::tearDown();
     }
 
@@ -22,9 +49,8 @@ class DeprecationTest extends SapphireTest
             'My message.',
             'Called from PHPUnit\Framework\TestCase->runTest.'
         ]);
-        $this->expectError();
-        $this->expectErrorMessage($message);
-        Deprecation::$notice_level = E_USER_NOTICE;
+        $this->expectDeprecation();
+        $this->expectDeprecationMessage($message);
         Deprecation::enable();
         Deprecation::notice('1.2.3', 'My message');
     }
@@ -34,8 +60,71 @@ class DeprecationTest extends SapphireTest
      */
     public function testDisabled()
     {
-        Deprecation::$notice_level = E_USER_NOTICE;
         // test that no error error is raised because by default Deprecation is disabled
         Deprecation::notice('4.5.6', 'My message');
+    }
+
+    // The following tests would be better to put in the silverstripe/config module, however this is not
+    // possible to do in a clean way as the config for the DeprecationTestObject will not load if it
+    // is inside the silverstripe/config directory, as there is no _config.php file or _config folder.
+    // Adding a _config.php file will break existing unit-tests within silverstripe/config
+    // It is possible to put DeprecationTestObject in framework and the unit tests in config, however
+    // that's probably messier then just having everything within framework
+
+    public function testConfigGetFirst()
+    {
+        $message = implode(' ', [
+            'Config SilverStripe\Dev\Tests\DeprecationTest\DeprecationTestObject.first_config is deprecated.',
+            'My first config message.'
+        ]);
+        $this->expectDeprecation();
+        $this->expectDeprecationMessage($message);
+        Deprecation::enable();
+        Config::inst()->get(DeprecationTestObject::class, 'first_config');
+    }
+
+    public function testConfigGetSecond()
+    {
+        $message = implode(' ', [
+            'Config SilverStripe\Dev\Tests\DeprecationTest\DeprecationTestObject.second_config is deprecated.',
+            'My second config message.'
+        ]);
+        $this->expectDeprecation();
+        $this->expectDeprecationMessage($message);
+        Deprecation::enable();
+        Config::inst()->get(DeprecationTestObject::class, 'second_config');
+    }
+
+    public function testConfigGetThird()
+    {
+        $message = 'Config SilverStripe\Dev\Tests\DeprecationTest\DeprecationTestObject.third_config is deprecated.';
+        $this->expectDeprecation();
+        $this->expectDeprecationMessage($message);
+        Deprecation::enable();
+        Config::inst()->get(DeprecationTestObject::class, 'third_config');
+    }
+
+    public function testConfigSet()
+    {
+        $message = implode(' ', [
+            'Config SilverStripe\Dev\Tests\DeprecationTest\DeprecationTestObject.first_config is deprecated.',
+            'My first config message.'
+        ]);
+        $this->expectDeprecation();
+        $this->expectDeprecationMessage($message);
+        Deprecation::enable();
+        Config::modify()->set(DeprecationTestObject::class, 'first_config', 'abc');
+    }
+
+    public function testConfigMerge()
+    {
+        $message = implode(' ', [
+            'Config SilverStripe\Dev\Tests\DeprecationTest\DeprecationTestObject.array_config is deprecated.',
+            'My array config message.'
+        ]);
+        $this->expectDeprecation();
+        $this->expectDeprecationMessage($message);
+        Deprecation::enable();
+        Config::modify()->merge(DeprecationTestObject::class, 'array_config', ['abc']);
     }
 }

--- a/tests/php/Dev/DeprecationTest/DeprecationTestObject.php
+++ b/tests/php/Dev/DeprecationTest/DeprecationTestObject.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SilverStripe\Dev\Tests\DeprecationTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class DeprecationTestObject extends DataObject implements TestOnly
+{
+    private static $db = [
+        "Name" => "Varchar"
+    ];
+
+    private static $table_name = 'DeprecatedTestObject';
+
+    /**
+     * @deprecated 1.2.3 My first config message
+     */
+    private static $first_config = 'ABC';
+
+    /**
+     * @deprecated My second config message
+     */
+    private static $second_config = 'DEF';
+
+    /**
+     * @deprecated
+     */
+    private static $third_config = 'XYZ';
+
+    /**
+     * @deprecated 1.2.3 My array config message
+     */
+    private static $array_config = ['lorem', 'ipsum'];
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10543

Note reliant on another PR linked the main issue - CI is green when run together https://github.com/emteknetnz/silverstripe-installer/actions/runs/3342348741

I also ended up doing some refactoring in this PR
- Changed DeprecationTest unit tests to from expectNotice() to expectDeprecation() - came about because of the custom error handle which was required to get unit-testing working
- Deprecated Deprecation::notice_level as it's no longer needed as we have the custom error handler
- Changed the new protected static properties to private static marked with `@internal` (I didn't realize this was an option when the original PR was done)