### PR TITLE
ENH Set PasswordEncryption on default admin

### DIFF
--- a/src/Security/DefaultAdminService.php
+++ b/src/Security/DefaultAdminService.php
@@ -171,7 +171,7 @@ class DefaultAdminService
             $admin = Member::create();
             $admin->FirstName = $name ?: $email;
             $admin->Email = $email;
-            $admin->PasswordEncryption = 'none';
+            $admin->PasswordEncryption = Security::config()->get('password_encryption_algorithm');
             $admin->write();
         }
 

--- a/tests/php/Security/SecurityDefaultAdminTest.php
+++ b/tests/php/Security/SecurityDefaultAdminTest.php
@@ -77,7 +77,7 @@ class SecurityDefaultAdminTest extends SapphireTest
         $this->assertTrue(Permission::checkMember($admin, 'ADMIN'));
         $this->assertEquals($admin->Email, DefaultAdminService::getDefaultAdminUsername());
         $this->assertTrue(DefaultAdminService::isDefaultAdmin($admin->Email));
-        $this->assertNull($admin->Password);
+        $this->assertStringStartsWith('$2y$10$', $admin->Password);
         $this->assertArrayHasKey($admin->PasswordEncryption, PasswordEncryptor::get_encryptors());
     }
 
@@ -92,7 +92,7 @@ class SecurityDefaultAdminTest extends SapphireTest
         $this->assertTrue(Permission::checkMember($admin, 'ADMIN'));
         $this->assertEquals('newadmin@example.com', $admin->Email);
         $this->assertEquals('Admin Name', $admin->FirstName);
-        $this->assertNull($admin->Password);
+        $this->assertStringStartsWith('$2y$10$', $admin->Password);
     }
 
     public function testFindAnAdministratorWithoutDefaultAdmin()
@@ -112,9 +112,8 @@ class SecurityDefaultAdminTest extends SapphireTest
         $admin = $service->findOrCreateDefaultAdmin();
         $this->assertTrue(Permission::checkMember($admin, 'ADMIN'));
 
-        // User should have Email but no Password
         $this->assertEquals('admin', $admin->Email);
-        $this->assertEmpty($admin->Password);
+        $this->assertStringStartsWith('$2y$10$', $admin->Password);
     }
 
     public function testDefaultAdmin()
@@ -127,6 +126,6 @@ class SecurityDefaultAdminTest extends SapphireTest
         $this->assertTrue(Permission::checkMember($admin, 'ADMIN'));
         $this->assertEquals($admin->Email, DefaultAdminService::getDefaultAdminUsername());
         $this->assertTrue(DefaultAdminService::isDefaultAdmin($admin->Email));
-        $this->assertNull($admin->Password);
+        $this->assertStringStartsWith('$2y$10$', $admin->Password);
     }
 }


### PR DESCRIPTION
Ensures `RememberLoginHash` gets encrypted for the default admin

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/610