### PR TITLE
API Deprecate Member::create_new_password()

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -828,9 +828,12 @@ class Member extends DataObject
      * filesystem.
      *
      * @return string Returns a random password.
+     *
+     * @deprecated 4.12.0 Will be removed without equivalent functionality to replace it
      */
     public static function create_new_password()
     {
+        Deprecation::notice('4.12.0', 'Will be removed without equivalent functionality to replace it');
         $words = Security::config()->uninherited('word_list');
 
         if ($words && file_exists($words ?? '')) {

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -88,6 +88,8 @@ class Security extends Controller implements TemplateGlobalProvider
      *
      * @config
      * @var string
+     *
+     * @deprecated 4.12 Will be removed without equivalent functionality to replace it
      */
     private static $word_list = './wordlist.txt';
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/8577

I did a string search in silverstripe/recipe-kitchen-sink for "create_new_password" and "word_list" - neither of these were used at all