### PR TITLE
FIX Filter out E_USER_DEPRECATED unrelated to unit test

### DIFF
--- a/tests/php/Dev/DeprecationTest.php
+++ b/tests/php/Dev/DeprecationTest.php
@@ -24,12 +24,18 @@ class DeprecationTest extends SapphireTest
         //   https://github.com/laminas/laminas-di/pull/30#issuecomment-927585210
         parent::setup();
         $this->oldHandler = set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline) {
-            if (str_contains($errstr, 'SilverStripe\\Dev\\Tests\\DeprecationTest')) {
-                throw new Deprecated($errstr, $errno, '', 1);
+            if ($errno === E_USER_DEPRECATED) {
+                if (str_contains($errstr, 'SilverStripe\\Dev\\Tests\\DeprecationTest')) {
+                    throw new Deprecated($errstr, $errno, '', 1);
+                } else {
+                    // Surpress any E_USER_DEPRECATED unrelated to this unit-test
+                    return true;
+                }
             }
             if (is_callable($this->oldHandler)) {
                 return call_user_func($this->oldHandler, $errno, $errstr, $errfile, $errline);
             }
+            // Fallback to default PHP error handler
             return false;
         });
     }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-installer/issues/337

> Failed asserting that exception message 'Config SilverStripe\Control\HTTP.disable_http_cache is deprecated. Use HTTPCacheControlMiddleware.defaultState/.defaultForcingLevel instead.' contains 'SilverStripe\Dev\Tests\DeprecationTest->testNotice is deprecated. My message. Called from PHPUnit\Framework\TestCase->runTest.'.

Broken because of https://github.com/silverstripe/silverstripe-framework/pull/10559