### PR TITLE
NEW: Add onBeforeRender extension hook to Form

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -1552,10 +1552,13 @@ class Form extends ViewableData implements HasRequestHandler
             HTTPCacheControlMiddleware::singleton()->disableCache();
         }
 
-        $return = $this->renderWith($this->getTemplates());
+        $context = $this;
+        $this->extend('onBeforeRender', $context);
+
+        $return = $context->renderWith($this->getTemplates());
 
         // Now that we're rendered, clear message
-        $this->clearMessage();
+        $context->clearMessage();
 
         return $return;
     }

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -1555,7 +1555,7 @@ class Form extends ViewableData implements HasRequestHandler
         $context = $this;
         $this->extend('onBeforeRender', $context);
 
-        $return = $context->renderWith($this->getTemplates());
+        $return = $context->renderWith($context->getTemplates());
 
         // Now that we're rendered, clear message
         $context->clearMessage();

--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -927,7 +927,7 @@ class FormField extends RequestHandler
             $context = $context->customise($properties);
         }
 
-        $result = $context->renderWith($this->getTemplates());
+        $result = $context->renderWith($context->getTemplates());
 
         // Trim whitespace from the result, so that trailing newlines are suppressed. Works for strings and HTMLText values
         if (is_string($result)) {
@@ -962,7 +962,7 @@ class FormField extends RequestHandler
             $context = $context->customise($properties);
         }
 
-        return $context->renderWith($this->getFieldHolderTemplates());
+        return $context->renderWith($context->getFieldHolderTemplates());
     }
 
     /**

--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -959,7 +959,7 @@ class FormField extends RequestHandler
         $this->extend('onBeforeRenderHolder', $context, $properties);
 
         if (count($properties ?? [])) {
-            $context = $this->customise($properties);
+            $context = $context->customise($properties);
         }
 
         return $context->renderWith($this->getFieldHolderTemplates());


### PR DESCRIPTION
This hook would be _really_ useful for computing things as late as possible before rendering forms - we have this hook for fields, but not the form itself. I copied the approach in `FormField::Field()`:

https://github.com/silverstripe/silverstripe-framework/blob/e454db6dc9c218185f07b298cbe218a65f03dd61/src/Forms/FormField.php#L922-L930

I believe the hook was originally set up like this to allow developers to completely overwrite the `$context` variable by adding pass-by-ref (`&$context`) to their extension if needed, so to keep it consistent I added the same.

For the “fix” commit, I’m just bringing `FormField::FieldHolder()` in line with `FormField::Field()`, I think this was just overlooked when the extension hook was initially added. If a developer overwrites `$context` as described above, this would then be re-overwritten with the original `FormField` object, so this fixes that.