### PR TITLE
FIX PHP 8.1 support in MySQLiConnector::query errors

### DIFF
--- a/src/ORM/Connect/MySQLiConnector.php
+++ b/src/ORM/Connect/MySQLiConnector.php
@@ -180,12 +180,19 @@ class MySQLiConnector extends DBConnector
     {
         $this->beforeQuery($sql);
 
-        // Benchmark query
-        $handle = $this->dbConn->query($sql ?? '', MYSQLI_STORE_RESULT);
+        $error = null;
+        $handle = null;
 
-        if (!$handle || $this->dbConn->error) {
-            $this->databaseError($this->getLastError(), $errorLevel, $sql);
-            return null;
+        try {
+            // Benchmark query
+            $handle = $this->dbConn->query($sql ?? '', MYSQLI_STORE_RESULT);
+        } catch (mysqli_sql_exception $e) {
+            $error = $e->getMessage();
+        } finally {
+            if (!$handle || $this->dbConn->error) {
+                $this->databaseError($error ?? $this->getLastError(), $errorLevel, $sql);
+                return null;
+            }
         }
 
         // Some non-select queries return true on success

--- a/tests/php/ORM/MySQLiConnectorTest.php
+++ b/tests/php/ORM/MySQLiConnectorTest.php
@@ -15,13 +15,12 @@ use SilverStripe\Tests\ORM\Utf8\Utf8TestHelper;
  */
 class MySQLiConnectorTest extends SapphireTest implements TestOnly
 {
+    /** @var array project database settings configuration */
+    private $config = [];
+
     private function getConnector(?string $charset = null, ?string $collation = null, bool $selectDb = false)
     {
-        $config = DB::getConfig();
-
-        if (strtolower(substr($config['type'] ?? '', 0, 5)) !== 'mysql') {
-            return $this->markTestSkipped('The test only relevant for MySQL');
-        }
+        $config = $this->config;
 
         if ($charset) {
             $config['charset'] = $charset;
@@ -36,6 +35,19 @@ class MySQLiConnectorTest extends SapphireTest implements TestOnly
         $connector->connect($config, $selectDb);
 
         return $connector;
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $config = DB::getConfig();
+
+        if (strtolower(substr($config['type'] ?? '', 0, 5)) !== 'mysql') {
+            $this->markTestSkipped("The test only relevant for MySQL - but $config[type] is in use");
+        }
+
+        $this->config = $config;
     }
 
     /**

--- a/tests/php/ORM/MySQLiConnectorTest.php
+++ b/tests/php/ORM/MySQLiConnectorTest.php
@@ -2,10 +2,12 @@
 
 namespace SilverStripe\ORM\Tests;
 
+use mysqli_driver;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
-use SilverStripe\ORM\Tests\MySQLiConnectorTest\MySQLiConnector;
+use SilverStripe\ORM\Connect\DatabaseException;
 use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Tests\MySQLiConnectorTest\MySQLiConnector;
 use SilverStripe\Tests\ORM\Utf8\Utf8TestHelper;
 
 /**
@@ -13,21 +15,35 @@ use SilverStripe\Tests\ORM\Utf8\Utf8TestHelper;
  */
 class MySQLiConnectorTest extends SapphireTest implements TestOnly
 {
-    /**
-     * @dataProvider charsetProvider
-     */
-    public function testConnectionCharsetControl($charset, $defaultCollation)
+    private function getConnector(?string $charset = null, ?string $collation = null, bool $selectDb = false)
     {
         $config = DB::getConfig();
-        $config['charset'] = $charset;
-        $config['database'] = 'information_schema';
 
         if (strtolower(substr($config['type'] ?? '', 0, 5)) !== 'mysql') {
             return $this->markTestSkipped('The test only relevant for MySQL');
         }
 
+        if ($charset) {
+            $config['charset'] = $charset;
+        }
+        if ($collation) {
+            $config['collation'] = $collation;
+        }
+
+        $config['database'] = 'information_schema';
+
         $connector = new MySQLiConnector();
-        $connector->connect($config);
+        $connector->connect($config, $selectDb);
+
+        return $connector;
+    }
+
+    /**
+     * @dataProvider charsetProvider
+     */
+    public function testConnectionCharsetControl($charset, $defaultCollation)
+    {
+        $connector = $this->getConnector($charset);
         $connection = $connector->getMysqliConnection();
 
         $cset = $connection->get_charset();
@@ -47,17 +63,7 @@ class MySQLiConnectorTest extends SapphireTest implements TestOnly
      */
     public function testConnectionCollationControl($charset, $defaultCollation, $customCollation)
     {
-        $config = DB::getConfig();
-        $config['charset'] = $charset;
-        $config['collation'] = $customCollation;
-        $config['database'] = 'information_schema';
-
-        if (strtolower(substr($config['type'] ?? '', 0, 5)) !== 'mysql') {
-            return $this->markTestSkipped('The test only relevant for MySQL');
-        }
-
-        $connector = new MySQLiConnector();
-        $connector->connect($config);
+        $connector = $this->getConnector($charset, $customCollation);
         $connection = $connector->getMysqliConnection();
 
         $cset = $connection->get_charset();
@@ -101,20 +107,7 @@ class MySQLiConnectorTest extends SapphireTest implements TestOnly
 
     public function testUtf8mb4GeneralCollation()
     {
-        $charset = 'utf8mb4';
-        $collation = 'utf8mb4_general_ci';
-
-        $config = DB::getConfig();
-        $config['charset'] = $charset;
-        $config['collation'] = $collation;
-        $config['database'] = 'information_schema';
-
-        if (strtolower(substr($config['type'] ?? '', 0, 5)) !== 'mysql') {
-            return $this->markTestSkipped('The test only relevant for MySQL');
-        }
-
-        $connector = new MySQLiConnector();
-        $connector->connect($config, true);
+        $connector = $this->getConnector('utf8mb4', 'utf8mb4_general_ci', true);
         $connection = $connector->getMysqliConnection();
 
         $result = $connection->query(
@@ -127,20 +120,7 @@ class MySQLiConnectorTest extends SapphireTest implements TestOnly
 
     public function testUtf8mb4UnicodeCollation()
     {
-        $charset = 'utf8mb4';
-        $collation = 'utf8mb4_unicode_ci';
-
-        $config = DB::getConfig();
-        $config['charset'] = $charset;
-        $config['collation'] = $collation;
-        $config['database'] = 'information_schema';
-
-        if (strtolower(substr($config['type'] ?? '', 0, 5)) !== 'mysql') {
-            return $this->markTestSkipped('The test only relevant for MySQL');
-        }
-
-        $connector = new MySQLiConnector();
-        $connector->connect($config, true);
+        $connector = $this->getConnector('utf8mb4', 'utf8mb4_unicode_ci', true);
         $connection = $connector->getMysqliConnection();
 
         $result = $connection->query(
@@ -150,5 +130,26 @@ class MySQLiConnectorTest extends SapphireTest implements TestOnly
         $this->assertCount(2, $result, '`utf8mb4_unicode_ci` must recognise "rst" and "rßt" as different values');
         $this->assertEquals('rßt', $result[0][0]);
         $this->assertEquals('rst', $result[1][0]);
+    }
+
+    public function testQueryThrowsDatabaseErrorOnMySQLiError()
+    {
+        $connector = $this->getConnector();
+        $driver = new mysqli_driver();
+        // The default with PHP >= 8.0
+        $driver->report_mode = MYSQLI_REPORT_OFF;
+        $this->expectException(DatabaseException::class);
+        $connector = $this->getConnector(null, null, true);
+        $connector->query('force an error with invalid SQL');
+    }
+
+    public function testQueryThrowsDatabaseErrorOnMySQLiException()
+    {
+        $driver = new mysqli_driver();
+        // The default since PHP 8.1 - https://www.php.net/manual/en/mysqli-driver.report-mode.php
+        $driver->report_mode = MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT;
+        $this->expectException(DatabaseException::class);
+        $connector = $this->getConnector(null, null, true);
+        $connector->query('force an error with invalid SQL');
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10613

The default error reporting mode in PHP 8.1 has changed from using errors reported on the connection handle to throwing mysqli_sql_exception. query() makes no allowance for this, and functions up the call stack expect to catch
Silverstripe\ORM\Connect\DatabaseException instead - resulting in the MySQLi exception going all the way up to halt the system.

We can use a try, catch, and finally to retain backwards compatibility, no matter which setting (e.g. PHP version default) someone has enabled.

C.f. https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.mysqli