### PR TITLE
MNT Explicitly test with blowfish

### DIFF
--- a/tests/php/Security/SecurityDefaultAdminTest.php
+++ b/tests/php/Security/SecurityDefaultAdminTest.php
@@ -7,6 +7,7 @@ use SilverStripe\Security\Member;
 use SilverStripe\Security\PasswordEncryptor;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\DefaultAdminService;
+use SilverStripe\Security\Security;
 
 class SecurityDefaultAdminTest extends SapphireTest
 {
@@ -35,6 +36,7 @@ class SecurityDefaultAdminTest extends SapphireTest
             $this->defaultUsername = null;
             $this->defaultPassword = null;
         }
+        Security::config()->set('password_encryption_algorithm', 'blowfish');
         DefaultAdminService::setDefaultAdmin('admin', 'password');
         Permission::reset();
     }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10574

Fix for https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/3429290339/jobs/5714714337

```
1) SilverStripe\Security\Tests\SecurityDefaultAdminTest::testFindAnAdministratorCreatesNewUser
Failed asserting that 'b74e431a911f29b48944a129f196028abb2b75497ad90c01668e3da397e1d4a8167e836471dedbe5d863cb0c3f00af61ca8c50fee27510b9ffb1103be4d54de4' starts with "$2y$10$".
```

Fails because of this commit https://github.com/silverstripe/silverstripe-framework/commit/a3c1cb0ddf2b95fb0dc149305a07a990538261d1 ONLY when run on sink because of this https://github.com/silverstripe/cwp-core/blob/2/_config/encryptors.yml#L11

```yml
# Enable SHA-512 via PBKDF2 by default, for NZISM compliance
SilverStripe\Security\Security:
  password_encryption_algorithm: pbkdf2_sha512
```