### PR TITLE
Prevent infinite loop when getting table name for ComponentID

### DIFF
--- a/src/ORM/RelatedData/StandardRelatedDataService.php
+++ b/src/ORM/RelatedData/StandardRelatedDataService.php
@@ -162,7 +162,7 @@ class StandardRelatedDataService implements RelatedDataService
                 $tableName = $this->dataObjectSchema->tableName($candidateClass);
                 break;
             }
-            $candidateClass = get_parent_class($class ?? '');
+            $candidateClass = get_parent_class($candidateClass ?? '');
         }
         return $tableName;
     }


### PR DESCRIPTION
If the field isn't in the first 2 classes then would just continue to loop 
Fix means it will continue going to parent classes

Can be seen in the UsedOnTable in `admin` module if you have injected a new `Image` class that extends the built in one

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
