### PR TITLE
Bugfix: SSViewer check object exists before calling prop or method_exists

### DIFF
--- a/src/View/SSViewer_DataPresenter.php
+++ b/src/View/SSViewer_DataPresenter.php
@@ -355,7 +355,7 @@ class SSViewer_DataPresenter extends SSViewer_Scope
         // Check if the method to-be-called exists on the target object - if so, don't check any further
         // injection locations
         $on = $this->itemIterator ? $this->itemIterator->current() : $this->item;
-        if (isset($on->$property) || method_exists($on, $property ?? '')) {
+        if ($on && (isset($on->$property) || method_exists($on, $property ?? ''))) {
             return null;
         }
 


### PR DESCRIPTION
`$on` can be `null` (there is no property type enforcement for `item` in the `__construct()`), and when it is the `method_exists()` call will throw an error (as it expects `object or class` for the first param).

Another option could be do write it as `method_exists($on ?? '', $property ?? '')`, but I thought maybe this was a bit more descriptive.

My particular project comes across this issue when we use `SSViewerCacheBlockTest::_runtemplate()`, but there might be other situations where `item` is `null`.