### PR TITLE
FIX Save long decimal values into DBDecimal field correctly

### DIFF
--- a/src/ORM/FieldType/DBDecimal.php
+++ b/src/ORM/FieldType/DBDecimal.php
@@ -126,7 +126,7 @@ class DBDecimal extends DBField
             return 0;
         }
 
-        if (ctype_digit((string) $value)) {
+        if (abs((float) $value - (int) $value) < PHP_FLOAT_EPSILON) {
             return (int)$value;
         }
 

--- a/tests/php/ORM/DecimalTest.php
+++ b/tests/php/ORM/DecimalTest.php
@@ -61,6 +61,35 @@ class DecimalTest extends SapphireTest
         );
     }
 
+    public function testLongValueStoredCorrectly()
+    {
+        $this->assertEquals(
+            $this->testDataObject->MyDecimal5,
+            1.0,
+            'Long default long decimal value is rounded correctly'
+        );
+
+        $this->assertEqualsWithDelta(
+            $this->testDataObject->MyDecimal5,
+            0.99999999999999999999,
+            PHP_FLOAT_EPSILON,
+            'Long default long decimal value is correct within float epsilon'
+        );
+
+        $this->assertEquals(
+            $this->testDataObject->MyDecimal6,
+            8.0,
+            'Long decimal value with a default value is rounded correctly'
+        );
+
+        $this->assertEqualsWithDelta(
+            $this->testDataObject->MyDecimal6,
+            7.99999999999999999999,
+            PHP_FLOAT_EPSILON,
+            'Long decimal value is within epsilon if longer than allowed number of float digits'
+        );
+    }
+
     public function testScaffoldFormField()
     {
         /** @var DBDecimal $decimal */

--- a/tests/php/ORM/DecimalTest/TestObject.php
+++ b/tests/php/ORM/DecimalTest/TestObject.php
@@ -14,10 +14,13 @@ class TestObject extends DataObject implements TestOnly
         'MyDecimal1' => 'Decimal',
         'MyDecimal2' => 'Decimal(5,3,2.5)',
         'MyDecimal3' => 'Decimal(4,2,"Invalid default value")',
-        'MyDecimal4' => 'Decimal'
+        'MyDecimal4' => 'Decimal',
+        'MyDecimal5' => 'Decimal(20,18,0.99999999999999999999)',
+        'MyDecimal6' => 'Decimal',
     ];
 
     private static $defaults = [
-        'MyDecimal4' => 4
+        'MyDecimal4' => 4,
+        'MyDecimal6' => 7.99999999999999999999,
     ];
 }


### PR DESCRIPTION
When a decimal number is long and has more than the max number of 9s, it gets rounded to the nearest int.
The `ctype_digit` check was basically testing for not having the decimal point in it while converted to a string when it overflowed. In the PR I've used Stephen's suggestion from the issue of comparison using the epsilon constant.

## Parent issue
- #10592 