### PR TITLE
API Remove deprecated CIConfig functionality

### DIFF
--- a/src/Core/Manifest/ClassLoader.php
+++ b/src/Core/Manifest/ClassLoader.php
@@ -2,9 +2,6 @@
 
 namespace SilverStripe\Core\Manifest;
 
-use SilverStripe\Core\ClassInfo;
-use SilverStripe\Dev\Deprecation;
-
 /**
  * A class that handles loading classes and interfaces from a class manifest
  * instance.
@@ -126,24 +123,9 @@ class ClassLoader
         foreach ($this->manifests as $manifest) {
             /** @var ClassManifest $instance */
             $instance = $manifest['instance'];
-            Deprecation::withNoReplacement(function () use ($instance, $includeTests, $forceRegen, $ignoredCIConfigs) {
-                $instance->init($includeTests, $forceRegen, $ignoredCIConfigs);
-            });
+            $instance->init($includeTests, $forceRegen);
         }
 
         $this->registerAutoloader();
-    }
-
-    /**
-     * Returns true if a class or interface name exists in the manifest.
-     *
-     * @param  string $class
-     * @return bool
-     * @deprecated 4.0.1 Use ClassInfo::exists() instead
-     */
-    public function classExists($class)
-    {
-        Deprecation::notice('4.0.1', 'Use ClassInfo::exists() instead');
-        return ClassInfo::exists($class);
     }
 }

--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -291,9 +291,7 @@ class ClassManifest
         }
 
         // Build
-        Deprecation::withNoReplacement(function () use ($includeTests, $ignoredCIConfigs) {
-            $this->regenerate($includeTests, $ignoredCIConfigs);
-        });
+        $this->regenerate($includeTests);
     }
 
     /**


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-framework/issues/10599

I've copy paste the raw version of 3x files from https://github.com/silverstripe/silverstripe-framework/pull/10594/files#diff-ae9e1d007682af983ba21d5d5d875ed1a1759a30246a0fbe941f342a6c174f0b so that we're able to dev/build flush=1 a regular CMS 5 install

The copy paste should mean there's no merge conflicts with the linked PR