### PR TITLE
API Create orderBy() method to handle raw SQL

### DIFF
--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -716,12 +716,17 @@ class DataQuery
     /**
      * Set the ORDER BY clause of this query
      *
+     * Note: while the similarly named DataList::sort() does not allow raw SQL, DataQuery::sort() does allow it
+     *
+     * Raw SQL can be vulnerable to SQL injection attacks if used incorrectly, so it's preferable not to use it
+     *
      * @see SQLSelect::orderby()
      *
      * @param string $sort Column to sort on (escaped SQL statement)
      * @param string $direction Direction ("ASC" or "DESC", escaped SQL statement)
      * @param bool $clear Clear existing values
      * @return $this
+     *
      */
     public function sort($sort = null, $direction = null, $clear = true)
     {

--- a/src/ORM/Search/SearchContext.php
+++ b/src/ORM/Search/SearchContext.php
@@ -204,8 +204,10 @@ class SearchContext
         } else {
             $query = $query->limit($limit);
         }
-
-        return $query->sort($sort);
+        if (!empty($sort) || is_null($sort)) {
+            $query = $query->sort($sort);
+        }
+        return $query;
     }
 
     /**

--- a/src/Security/InheritedPermissions.php
+++ b/src/Security/InheritedPermissions.php
@@ -393,7 +393,7 @@ class InheritedPermissions implements PermissionChecker, MemberCacheFlusher
         // of whether the user has permission to edit this object.
         $groupedByParent = [];
         $potentiallyInherited = $stageRecords->filter($typeField, self::INHERIT)
-            ->sort("\"{$baseTable}\".\"ID\"")
+            ->orderBy("\"{$baseTable}\".\"ID\"")
             ->dataQuery()
             ->query()
             ->setSelect([

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -1034,10 +1034,10 @@ class DataObjectTest extends SapphireTest
         $this->assertFalse($obj->isChanged());
 
         /* If we perform the same random query twice, it shouldn't return the same results */
-        $itemsA = DataObject::get(DataObjectTest\TeamComment::class, "", DB::get_conn()->random());
-        $itemsB = DataObject::get(DataObjectTest\TeamComment::class, "", DB::get_conn()->random());
-        $itemsC = DataObject::get(DataObjectTest\TeamComment::class, "", DB::get_conn()->random());
-        $itemsD = DataObject::get(DataObjectTest\TeamComment::class, "", DB::get_conn()->random());
+        $itemsA = DataObject::get(DataObjectTest\TeamComment::class, "")->orderBy(DB::get_conn()->random());
+        $itemsB = DataObject::get(DataObjectTest\TeamComment::class)->orderBy(DB::get_conn()->random());
+        $itemsC = DataObject::get(DataObjectTest\TeamComment::class)->orderBy(DB::get_conn()->random());
+        $itemsD = DataObject::get(DataObjectTest\TeamComment::class)->orderBy(DB::get_conn()->random());
         foreach ($itemsA as $item) {
             $keysA[] = $item->ID;
         }
@@ -1914,7 +1914,7 @@ class DataObjectTest extends SapphireTest
 
         // Check that ordering a many-many relation by an aggregate column doesn't fail
         $player = $this->objFromFixture(DataObjectTest\Player::class, 'player2');
-        $player->Teams()->sort("count(DISTINCT \"DataObjectTest_Team_Players\".\"DataObjectTest_PlayerID\") DESC");
+        $player->Teams()->orderBy("count(DISTINCT \"DataObjectTest_Team_Players\".\"DataObjectTest_PlayerID\") DESC");
     }
 
     /**

--- a/tests/php/ORM/ManyManyThroughListTest.php
+++ b/tests/php/ORM/ManyManyThroughListTest.php
@@ -102,7 +102,7 @@ class ManyManyThroughListTest extends SapphireTest
 
         $items = $parent->Items();
         if ($sort) {
-            $items = $items->sort($sort);
+            $items = $items->orderBy($sort);
         }
         $this->assertSame($expected, $items->column('Title'));
     }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10449

Note: unit-tests won't pass until https://github.com/silverstripe/silverstripe-versioned/pull/385 is merged in - but this was run though an installer CI run: https://github.com/emteknetnz/silverstripe-installer/actions/runs/3617074332

I've only implemented this at the `DataList` level.  If we wanted to implement this deeper then for `sort()` we'd probably want to do this at the [SQLSelect::addOrderBy()](https://github.com/silverstripe/silverstripe-framework/blob/4.11/src/ORM/Queries/SQLSelect.php#L322) which is ultimately the only thing called by [DataQuery::sort()](https://github.com/silverstripe/silverstripe-framework/blob/4.11/src/ORM/DataQuery.php#L726) - however it feels as though there's going to be too much raw SQL flowing through there to make this practical given that Silverstripe loves to use `CASE WHEN` statements when constructing queries.  `SQLSelect::addOrderBy()` currently has a lot of logic to handle raw sql.  At some level we need to fully allow raw SQL because that's the language the database uses.

My assumption is that `DataList::sort()` is the entry point for SQL injection attacks because it's the abstraction used for interacting with the ORM i.e. `MyDataObject::get()->filter($filter)->sort($sort)->column('Title')` uses `DataList::sort()` - while DataQuery is one abstraction level below and SQLSelect is another abstraction below again.

The most recently disclosed SQL injection vulnerability was via DataList - https://github.com/silverstripe/silverstripe-framework/commit/4308a93cc81a75227bcbfc1abd4aaf5e21ef21ee

#### The following public methods on DataList do accept raw sql

##### sort()
- This PR tightens this up and splits off orderBy() which is the raw SQL version

##### `where()` and `whereAny()`
- I've split off a [new card](https://github.com/silverstripe/silverstripe-framework/issues/10601) to handle the following: 
- `var_dump(SiteTree::get()->where('MOD(ID,3) = 1')->column('ID'));`
- the major call to these is the $filter param in `public static DataObject::get($callerClass, $filter, ...)` and `get_one()`  - which will use call DataList::where() e.g. DataObject::get(MyDataObject::class, $rawSql). We should simply change the calls here from `->where()` to `->filter()` in CMS5 to tighten this up.
- `where() / whereAny()` are essentially the "raw" versions of 'filter() / filterAny()`, so this is similar to sort() / orderBy()
- `PartialMatchFilter::applyMany()` is the only call to `whereAny()` that needs further investigation
- Group::Member($filter = '') will call `where($filter)`

##### leftJoin() / - innerJoin()
- `var_dump(SiteTree::get()->leftJoin('Member', 'SiteTree.ID = Member.ID AND SiteTree.ID < 5 AND MOD(SiteTree.ID,3) = 1')->column('Member.Email'));`
- I've had a look through all the calls to `innerJoin()` and `leftJoin()` in core and there didn't look to be anything unsafe e.g. could be altered via a url parameter.
- I don't know if it's viable to filter out raw SQL since its includes a param for raw sql for the join clause.

#### The following public methods on DataList do not accept raw sql:

##### filter() / filterAny() / find() / exclude()
- `var_dump(SiteTree::get()->exclude(['MOD(ID,3)' => 1])->column('ID'));`
- Unknown column 'MOD(ID,3)' in 'where clause'
 
##### map()
- `var_dump(SiteTree::get()->map('ID', 'MOD(ID,3)')->toArray());`
- will simply iterate over the results of a database query and only return a value if key exists i.e. doesn't query database with MOD()

##### max() / min() / avg() / sum()
- `var_dump(SiteTree::get()->max('MOD(ID,3)'));`
- Unknown column 'MOD(ID,3)' in 'field list'

##### column() / columnUnique()
- `var_dump(SiteTree::get()->column('MOD(ID,3)'));`
- Invalid column name MOD(ID,3)

