### PR TITLE
FIX Respect SS_BASE_URL scheme in CLI environment

### DIFF
--- a/src/Control/CLIRequestBuilder.php
+++ b/src/Control/CLIRequestBuilder.php
@@ -64,6 +64,13 @@ class CLIRequestBuilder extends HTTPRequestBuilder
             $variables['_GET']['url'] = $variables['_SERVER']['argv'][1];
             $variables['_SERVER']['REQUEST_URI'] = $variables['_SERVER']['argv'][1];
         }
+        
+        // Set 'HTTPS' and 'SSL' flag for CLI depending on SS_BASE_URL scheme value.
+        $scheme = parse_url(Environment::getEnv('SS_BASE_URL') ?? '', PHP_URL_SCHEME);
+        if ($scheme == 'https') {
+            $variables['_SERVER']['HTTPS'] = 'on';
+            $variables['_SERVER']['SSL'] = true;
+        }
 
         // Parse rest of variables as standard
         return parent::cleanEnvironment($variables);


### PR DESCRIPTION
Additionally set _SERVER variables for HTTPS and SSL to respect SS_BASE_URL scheme when executing builds and tasks through CLI. This should solve base tags not being provided with the correct HTTP scheme. This is important to resolve mixed content issues and insecure requests.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10615