### PR TITLE
API Make the public directory mandatory

### DIFF
--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -76,15 +76,6 @@ class Director implements TemplateGlobalProvider
     private static $alternate_base_folder;
 
     /**
-     * Override PUBLIC_DIR. Set to a non-null value to override.
-     * Setting to an empty string will disable public dir.
-     *
-     * @config
-     * @var bool|null
-     */
-    private static $alternate_public_dir = null;
-
-    /**
      * Base url to populate if cannot be determined otherwise.
      * Supports back-ticked vars; E.g. '`SS_BASE_URL`'
      *
@@ -654,19 +645,12 @@ class Director implements TemplateGlobalProvider
     }
 
     /**
-     * Check if using a separate public dir, and if so return this directory
-     * name.
-     *
-     * This will be removed in 5.0 and fixed to 'public'
+     * The name of the public directory
      *
      * @return string
      */
     public static function publicDir()
     {
-        $alternate = self::config()->uninherited('alternate_public_dir');
-        if (isset($alternate)) {
-            return $alternate;
-        }
         return PUBLIC_DIR;
     }
 

--- a/src/View/PublicThemes.php
+++ b/src/View/PublicThemes.php
@@ -6,6 +6,6 @@ class PublicThemes implements ThemeList
 {
     public function getThemes()
     {
-        return PUBLIC_DIR ? ['/' . PUBLIC_DIR] : [];
+        return ['/' . PUBLIC_DIR];
     }
 }

--- a/src/includes/constants.php
+++ b/src/includes/constants.php
@@ -24,7 +24,7 @@ use SilverStripe\Core\TempFolder;
  * - THEMES_PATH: Absolute filepath, e.g. "/var/www/my-webroot/themes"
  * - FRAMEWORK_DIR: Path relative to webroot, e.g. "framework"
  * - FRAMEWORK_PATH:Absolute filepath, e.g. "/var/www/my-webroot/framework"
- * - PUBLIC_DIR: Webroot path relative to project root, e.g. "public" or ""
+ * - PUBLIC_DIR: Webroot path relative to project root - always evaluates to "public"
  * - PUBLIC_PATH: Absolute path to webroot, e.g. "/var/www/project/public"
  * - THIRDPARTY_DIR: Path relative to webroot, e.g. "framework/thirdparty"
  * - THIRDPARTY_PATH: Absolute filepath, e.g. "/var/www/my-webroot/framework/thirdparty"
@@ -70,10 +70,10 @@ if (!defined('BASE_PATH')) {
 
 // Set public webroot dir / path
 if (!defined('PUBLIC_DIR')) {
-    define('PUBLIC_DIR', is_dir(BASE_PATH . DIRECTORY_SEPARATOR . 'public') ? 'public' : '');
+    define('PUBLIC_DIR', 'public');
 }
 if (!defined('PUBLIC_PATH')) {
-    define('PUBLIC_PATH', PUBLIC_DIR ? BASE_PATH . DIRECTORY_SEPARATOR . PUBLIC_DIR : BASE_PATH);
+    define('PUBLIC_PATH', BASE_PATH . DIRECTORY_SEPARATOR . PUBLIC_DIR);
 }
 
 // Allow a first class env var to be set that disables .env file loading
@@ -183,7 +183,7 @@ if (!defined('ASSETS_PATH')) {
     call_user_func(function () {
         $paths = [
             BASE_PATH,
-            (PUBLIC_DIR ? PUBLIC_DIR : null),
+            PUBLIC_DIR,
             ASSETS_DIR
         ];
         define('ASSETS_PATH', implode(DIRECTORY_SEPARATOR, array_filter($paths ?? [])));

--- a/tests/php/Forms/HTMLEditor/TinyMCECombinedGeneratorTest.php
+++ b/tests/php/Forms/HTMLEditor/TinyMCECombinedGeneratorTest.php
@@ -90,7 +90,7 @@ class TinyMCECombinedGeneratorTest extends SapphireTest
         // Check plugin links included
         $this->assertStringContainsString(
             <<<EOS
-tinymce.each('tinymce/langs/en.js,mycode/plugin1.js,tinymce/plugins/plugin4/plugin.min.js,tinymce/plugins/plugin4/langs/en.js,tinymce/plugins/plugin5/plugin.js,mycode/plugin6.js,mycode/plugin8.js?m=
+tinymce.each('tinymce/langs/en.js,mycode/plugin1.js,tinymce/plugins/plugin4/plugin.min.js,tinymce/plugins/plugin4/langs/en.js,tinymce/plugins/plugin5/plugin.js,mycode/plugin6.js,_resources/mycode/plugin8.js?m=
 EOS
             ,
             $content


### PR DESCRIPTION
The `public/` directory is mandatory in CMS 5 (some of the functionality had already been explicitly deprecated in CMS 4 and so it has been removed in CMS 5) - but if the `public/` dir didn't exist yet, framework was still pointing at the project root.
This has been causing our behat tests to fail in CI for most modules.

## Note
Any deprecations required in CMS 4 or updates to documentation will be done separately - the primary purpose of this PR is to get builds passing again.

## Related RFC
https://github.com/silverstripe/silverstripe-framework/issues/8168

## Parent Issue
- https://github.com/silverstripeltd/product-issues/issues/642