### PR TITLE
ENH allow mysql index length declaration

### DIFF
--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -551,7 +551,16 @@ MESSAGE
         if (empty($columns)) {
             return '';
         }
-        return '"' . implode('","', $columns) . '"';
+        $columns = array_map([$this, 'quoteIndexColumn'], $columns);
+        return implode(',', $columns);
+    }
+
+    public function quoteIndexColumn($column)
+    {
+        if (preg_match('/^(\w+)\((\d+)\)$/', $column, $matches)) {
+            return sprintf('"%s"(%d)', $matches[1], $matches[2]);
+        }
+        return sprintf('"%s"', $column);
     }
 
     /**

--- a/src/ORM/Connect/MySQLSchemaManager.php
+++ b/src/ORM/Connect/MySQLSchemaManager.php
@@ -344,7 +344,11 @@ class MySQLSchemaManager extends DBSchemaManager
         $indexList = [];
 
         foreach ($indexes as $index) {
-            $groupedIndexes[$index['Key_name']]['fields'][$index['Seq_in_index']] = $index['Column_name'];
+            $columnDeclaration = $index['Column_name'];
+            if ($index['Sub_part']) {
+                $columnDeclaration .= '(' . $index['Sub_part'] . ')';
+            }
+            $groupedIndexes[$index['Key_name']]['fields'][$index['Seq_in_index']] = $columnDeclaration;
 
             if ($index['Index_type'] == 'FULLTEXT') {
                 $groupedIndexes[$index['Key_name']]['type'] = 'fulltext';


### PR DESCRIPTION
Mysql Demands the Text indexes to have length specified. Setting aside the sanity of using the large fields in indexes, this is possible and can sometimes be needed.

Example:
```php
class MyObject extends DataObject
{
    public static $table_name="MyObject";
    public static $db=[
        "Title" => "Varchar",
        "LongColumn" => "Text",
    ];
    public static $indexes=[
        "MyIndex" => [
            "type" => "index",
            "columns" => [
                "LongColumn(123)",
            ]
        ]
    ];
}
```
for the following DataObject I expected the SQL query for that looks like this:
```sql
ALTER TABLE "MyObject" ADD INDEX "MyIndex" ( "LongColumn" (123) )
```

However, `DBSchemaManager` quotes the full column name and produces this:
```sql
ALTER TABLE "MyObject" ADD INDEX "MyIndex" ( "LongColumn(123)" )
```
 which results in "column not found" error.

This PR may solve the problem, though.
I'd like the maintainers' input on the Idea before moving forward with polishing the PR.
Thank you!

- [x] Actual code
- [ ] Tests
- [ ] Add/change phpdoc blocks
- [ ] Add note to the documentation (maybe)