### PR TITLE
fix: optional return value for paginator state

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -587,7 +587,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
     /**
      * Get the current paginator state
      */
-    private function getGridFieldPaginatorState(): GridState_Data
+    private function getGridFieldPaginatorState(): ?GridState_Data
     {
         $state = $this->getGridField()->getState(false);
         $gridStateStr = $this->getStateManager()->getStateFromRequest($this->gridField, $this->getRequest());


### PR DESCRIPTION
`$state->getData()->getData('GridFieldPaginator')` (line 598) returns null by default.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
