### PR TITLE
allow null state for GridFieldPaginator

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -587,7 +587,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
     /**
      * Get the current paginator state
      */
-    private function getGridFieldPaginatorState(): GridState_Data
+    private function getGridFieldPaginatorState(): ?GridState_Data
     {
         $state = $this->getGridField()->getState(false);
         $gridStateStr = $this->getStateManager()->getStateFromRequest($this->gridField, $this->getRequest());


### PR DESCRIPTION
Fix Uncaught TypeError: SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest::getGridFieldPaginatorState(): Return value must be of type SilverStripe\Forms\GridField\GridState_Data, null returned

It can already be null in the code, for example

        $paginator = $this->getGridFieldPaginatorState();
        if (!$paginator) {
            return [];
        }

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
