### PR TITLE
MNT Fix using treedropdownfield in behat

### DIFF
--- a/tests/behat/src/CmsFormsContext.php
+++ b/tests/behat/src/CmsFormsContext.php
@@ -304,13 +304,13 @@ JS;
         });
 
         $this->retryThrowable(function () use ($parentElement, $selector) {
-            $dropdown = $parentElement->find('css', '.Select-arrow');
+            $dropdown = $parentElement->find('css', '.treedropdownfield__dropdown-indicator');
             Assert::assertNotNull($dropdown, sprintf('Unable to find the dropdown in "%s"', $selector));
             $dropdown->click();
         });
 
         $this->retryThrowable(function () use ($text, $parentElement, $selector) {
-            $element = $parentElement->find('xpath', sprintf('//*[count(*)=0 and contains(.,"%s")]', $text));
+            $element = $parentElement->find('xpath', sprintf('//*[count(*)=0 and .="%s"]', $text));
             Assert::assertNotNull($element, sprintf('"%s" not found in "%s"', $text, $selector));
             $element->click();
         });
@@ -326,14 +326,14 @@ JS;
     {
         $locator = $this->fixStepArgument($locator);
         $page = $this->getSession()->getPage();
-        
+
         // Searching by name is usually good...
         $element = $page->find('css', 'textarea.htmleditor[name=\'' . $locator . '\']');
-        
+
         if ($element === null) {
             $element = $this->findInputByLabelContent($locator);
         }
-        
+
         Assert::assertNotNull($element, sprintf('HTML field "%s" not found', $locator));
         return $element;
     }


### PR DESCRIPTION
Fixes an error from https://github.com/silverstripe/silverstripe-cms/actions/runs/3726652553/jobs/6320241058
> Unable to find the dropdown in "#Form_AddForm_ParentID_Holder"

Also fixes a subsequent failure where an element that _contained_ the text (but wasn't the actual option) tried to get clicked instead. This is resolved by looking for the _exact_ text, rather than using _contains_.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/655