### PR TITLE
ENH: saveFormIntoRecord() new extension points.

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -1487,16 +1487,21 @@ class Form extends ViewableData implements HasRequestHandler
      */
     public function saveInto(DataObjectInterface $dataObject, $fieldList = null)
     {
+        $form = $this;
+        $dataObject->invokeWithExtensions('onBeforeFormSaveInto', $form, $fieldList);
+
         $dataFields = $this->fields->saveableFields();
         $lastField = null;
+
         if ($dataFields) {
             foreach ($dataFields as $field) {
-            // Skip fields that have been excluded
+                // Skip fields that have been excluded
                 if ($fieldList && is_array($fieldList) && !in_array($field->getName(), $fieldList ?? [])) {
                     continue;
                 }
 
                 $saveMethod = "save{$field->getName()}";
+
                 if ($field->getName() == "ClassName") {
                     $lastField = $field;
                 } elseif ($dataObject->hasMethod($saveMethod)) {
@@ -1506,9 +1511,12 @@ class Form extends ViewableData implements HasRequestHandler
                 }
             }
         }
+
         if ($lastField) {
             $lastField->saveInto($dataObject);
         }
+
+        $dataObject->invokeWithExtensions('onAfterFormSaveInto', $form, $fieldList);
     }
 
     /**

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -753,9 +753,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
 
         // Save form and any extra saved data into this dataobject.
         // Set writeComponents = true to write has-one relations / join records
-        $this->extend('onBeforeSaveInto', $this->record, $data, $form);
         $form->saveInto($this->record);
-        $this->extend('onAfterSaveInto', $this->record, $data, $form);
         // https://github.com/silverstripe/silverstripe-assets/issues/365
         $this->record->write();
         $this->extend('onAfterSave', $this->record);

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -753,7 +753,9 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
 
         // Save form and any extra saved data into this dataobject.
         // Set writeComponents = true to write has-one relations / join records
+        $this->extend('onBeforeSaveInto', $this->record, $data, $form);
         $form->saveInto($this->record);
+        $this->extend('onAfterSaveInto', $this->record, $data, $form);
         // https://github.com/silverstripe/silverstripe-assets/issues/365
         $this->record->write();
         $this->extend('onAfterSave', $this->record);


### PR DESCRIPTION
# ENH: saveFormIntoRecord() new extension points

Added new extension points for data manipulation when saving form into record. This is useful for cases where advanced form field logic is present such as:

* dependent fields - one field value changes valid values of another field (value needs to be sanitised instead of throwing a validation error)
* composite fields - set of fields are used to collect a composite value which is saved into a relation or serialised data

This can already be done via `onBeforeWrite()` but this approach is too generic and such logic needs to handle the cases when `write()` is called outside of Form controller context.

The new extension points allow a more suitable place for such code.