### PR TITLE
DEP Remove unnecessary bramus/monolog-colored-line-formatter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     ],
     "require": {
         "php": "^8.1",
-        "bramus/monolog-colored-line-formatter": "^2.0.3",
         "composer/installers": "^2.2",
         "guzzlehttp/guzzle": "^7.5.0",
         "guzzlehttp/psr7": "^2.4.0",


### PR DESCRIPTION
This dependency was only ever used by [MigrateFileTask](https://github.com/silverstripe/silverstripe-framework/blob/4/src/Dev/Tasks/MigrateFileTask.php) which has been removed.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10486