### PR TITLE
DEP Allow psr/container ^1.1 or ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "m1/env": "^2.2.0",
         "monolog/monolog": "^3.2.0",
         "nikic/php-parser": "^4.15.0",
-        "psr/container": "^2.0",
+        "psr/container": "^1.1 || ^2.0",
         "silverstripe/config": "^2",
         "silverstripe/assets": "^2",
         "silverstripe/vendor-plugin": "^2",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10402

Related conversation https://github.com/silverstripe/silverstripe-ldap/pull/46/files#r1071095574

tl;dr - we can use either psr/container v1 or v2, we upgraded to v2 because it was the latest, without realising at the time it would create a conflict with a dependency in the ldap module.  I've confirmed locally that v1 works just fine.

This PR does dual support for v1 and v2, as both of them work.  v2 will install for most people, though there's the option for anyone who wants to install silverstripe/ldap.  I think dual support is preferable to locking it to v1, because I think it's pretty likely that in the future a different dependency that is more likely to be installed that silverstripe/ldap will require psr/container v2

When using v1, we don't need to change the method signature on CMS 5 [Injector::has()](https://github.com/silverstripe/silverstripe-framework/blob/5/src/Core/Injector/Injector.php#L864) - we can keep the `: bool` return type despite the fact it implements psr/container v1 ContainerInterface::has() which has no strong return type (unlike v2 which has a `: bool` return type).

This is because PHP [covariance](https://www.php.net/manual/en/language.oop5.variance.php) allows us to specify more specific return types on child classes (including class implementors of interfaces, surprisingly).  We need keep the strong return type so that psr/container v2 still works

Note ^1.1 is required because [1.1.0](https://github.com/php-fig/container/blob/1.1.0/src/ContainerInterface.php#L35) strongly types the `$id` param, whereas [1.0.0](https://github.com/php-fig/container/blob/1.0.0/src/ContainerInterface.php#L35) does not