### PR TITLE
API Allow array style email addresses

### DIFF
--- a/src/Control/Email/Email.php
+++ b/src/Control/Email/Email.php
@@ -162,12 +162,12 @@ class Email extends SymfonyEmail
     }
 
     public function __construct(
-        string $from = '',
-        string $to = '',
+        string|array $from = '',
+        string|array $to = '',
         string $subject = '',
         string $body = '',
-        string $cc = '',
-        string $bcc = '',
+        string|array $cc = '',
+        string|array $bcc = '',
         string $returnPath = ''
     ) {
         parent::__construct();
@@ -197,13 +197,14 @@ class Email extends SymfonyEmail
         $this->data = ViewableData::create();
     }
 
-    private function getDefaultFrom(): string
+    private function getDefaultFrom(): string|array
     {
         // admin_email can have a string or an array config
         // https://docs.silverstripe.org/en/4/developer_guides/email/#administrator-emails
         $adminEmail = $this->config()->get('admin_email');
         if (is_array($adminEmail) && count($adminEmail ?? []) > 0) {
-            $defaultFrom = array_keys($adminEmail)[0];
+            $email = array_keys($adminEmail)[0];
+            $defaultFrom = [$email => $adminEmail[$email]];
         } else {
             if (is_string($adminEmail)) {
                 $defaultFrom = $adminEmail;
@@ -238,8 +239,9 @@ class Email extends SymfonyEmail
     /**
      * The following arguments combinations are valid
      * a) $address = 'my@email.com', $name = 'My name'
-     * b) $address = ['my@email.com' => 'My name', 'other@email.com' => 'My other name']
-     * c) $address = ['my@email.com' => 'My name', 'other@email.com']
+     * b) $address = ['my@email.com' => 'My name']
+     * c) $address = ['my@email.com' => 'My name', 'other@email.com' => 'My other name']
+     * d) $address = ['my@email.com' => 'My name', 'other@email.com']
      */
     private function createAddressArray(string|array $address, $name = ''): array
     {
@@ -266,7 +268,7 @@ class Email extends SymfonyEmail
     /**
      * @see createAddressArray()
      */
-    public function setTo(string|array $address, $name = ''): static
+    public function setTo(string|array $address, string $name = ''): static
     {
         return $this->to(...$this->createAddressArray($address, $name));
     }

--- a/tests/php/Control/Email/EmailTest.php
+++ b/tests/php/Control/Email/EmailTest.php
@@ -272,6 +272,47 @@ class EmailTest extends SapphireTest
         $this->assertEquals('bounce@example.com', $email->getReturnPath()->getAddress());
     }
 
+    public function testConstructorArray(): void
+    {
+        $email = new Email(
+            ['from@example.com' => 'From name'],
+            ['a@example.com' => "A", 'b@example.com' => "B", 'c@example.com', 'd@example.com'],
+            'subject',
+            '<p>body</p>',
+            ['cca@example.com' => 'CCA', 'ccb@example.com' => "CCB", 'ccc@example.com', 'ccd@example.com'],
+            ['bcca@example.com' => 'BCCA', 'bccb@example.com' => "BCCB", 'bccc@example.com', 'bccd@example.com'],
+            'bounce@example.com'
+        );
+        $this->assertCount(1, $email->getFrom());
+        $this->assertSame('from@example.com', $email->getFrom()[0]->getAddress());
+        $this->assertSame('From name', $email->getFrom()[0]->getName());
+        $this->assertCount(4, $email->getTo());
+        $this->assertSame('a@example.com', $email->getTo()[0]->getAddress());
+        $this->assertSame('A', $email->getTo()[0]->getName());
+        $this->assertSame('b@example.com', $email->getTo()[1]->getAddress());
+        $this->assertSame('B', $email->getTo()[1]->getName());
+        $this->assertSame('c@example.com', $email->getTo()[2]->getAddress());
+        $this->assertSame('', $email->getTo()[2]->getName());
+        $this->assertCount(4, $email->getCC());
+        $this->assertEquals('cca@example.com', $email->getCC()[0]->getAddress());
+        $this->assertEquals('CCA', $email->getCC()[0]->getName());
+        $this->assertEquals('ccb@example.com', $email->getCC()[1]->getAddress());
+        $this->assertEquals('CCB', $email->getCC()[1]->getName());
+        $this->assertEquals('ccc@example.com', $email->getCC()[2]->getAddress());
+        $this->assertEquals('', $email->getCC()[2]->getName());
+        $this->assertEquals('ccd@example.com', $email->getCC()[3]->getAddress());
+        $this->assertEquals('', $email->getCC()[2]->getName());
+        $this->assertCount(4, $email->getBCC());
+        $this->assertEquals('bcca@example.com', $email->getBCC()[0]->getAddress());
+        $this->assertEquals('BCCA', $email->getBCC()[0]->getName());
+        $this->assertEquals('bccb@example.com', $email->getBCC()[1]->getAddress());
+        $this->assertEquals('BCCB', $email->getBCC()[1]->getName());
+        $this->assertEquals('bccc@example.com', $email->getBCC()[2]->getAddress());
+        $this->assertEquals('', $email->getBCC()[2]->getName());
+        $this->assertEquals('bccd@example.com', $email->getBCC()[3]->getAddress());
+        $this->assertEquals('', $email->getBCC()[2]->getName());
+    }
+
     public function testSetBody(): void
     {
         $email = new Email();
@@ -490,7 +531,10 @@ class EmailTest extends SapphireTest
 
         // use admin_email config array syntax
         Email::config()->set('admin_email', ['anotheradmin@somewhere.com' => 'Admin-email']);
-        $this->assertSame('anotheradmin@somewhere.com', $method->invokeArgs($email, []));
+        $this->assertSame(
+            ['anotheradmin@somewhere.com' => 'Admin-email'],
+            $method->invokeArgs($email, [])
+        );
         $this->assertTrue(true);
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10618

Background - https://github.com/symbiote/silverstripe-queuedjobs/pull/395

Array style email addresses - https://docs.silverstripe.org/en/4/developer_guides/email/#administrator-emails