### PR TITLE
Fix GridField CSV export value escaping

### DIFF
--- a/src/Forms/GridField/GridFieldExportButton.php
+++ b/src/Forms/GridField/GridFieldExportButton.php
@@ -244,7 +244,10 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
                         $value = $columnHeader($relObj);
                     } elseif ($gridFieldColumnsComponent && in_array($columnSource, $columnsHandled ?? [])) {
                         $value = strip_tags(
-                            $gridFieldColumnsComponent->getColumnContent($gridField, $item, $columnSource) ?? ''
+                            html_entity_decode(
+                                $gridFieldColumnsComponent->getColumnContent($gridField, $item, $columnSource),
+                                ENT_QUOTES
+                            ) ?? ''
                         );
                     } else {
                         $value = $gridField->getDataFieldValue($item, $columnSource);


### PR DESCRIPTION
This PR fixes CSV exports from the GridField when export columns are also defined in the `$summary_fields`.

Any CSV export column that is also included in the model's `$summary_fields` gets incorrectly escaped with htmlentities. This PR uses `htmlentities_decode()` to ensure characters such as `'` and `"` remain intact, and are thus correctly encoded in the CSV file.

Please see #10657 for further details.