### PR TITLE
Add config to allow dotenv override

### DIFF
--- a/src/includes/constants.php
+++ b/src/includes/constants.php
@@ -80,10 +80,13 @@ if (!defined('PUBLIC_PATH')) {
 if (!Environment::getEnv('SS_IGNORE_DOT_ENV')) {
     call_user_func(function () {
         $loader = new EnvironmentLoader();
+
+        $allowDotenvOverride = !!Environment::getEnv('SS_ALLOW_DOT_ENV_OVERRIDE');
+
         foreach ([BASE_PATH, dirname(BASE_PATH)] as $path) {
             // Stop searching after first `.env` file is loaded
             $dotEnvFile = $path . DIRECTORY_SEPARATOR . '.env';
-            if ($loader->loadFile($dotEnvFile)) {
+            if ($loader->loadFile($dotEnvFile, $allowDotenvOverride)) {
                 break;
             }
         }


### PR DESCRIPTION
This is a non-breaking workaround/fix for #10518.

Suppose you're running SilverStripe in a docker dev container that provides a default `SS_DATABASE_NAME: site` in the `docker-compose.yml`, but you want to temporarily use a different database. If you try to set it in the `.env` file it won't work, because the `EnvironmentLoader` won't load any variables that already exist.

This PR adds `SS_ALLOW_DOT_ENV_OVERRIDE` which if set allows `.env` values to override environment variables set on the system/process level.

In 5+ I would prefer this option to be inverted and allow `.env` overrides by default.