### PR TITLE
FIX Prevent backslash in CSS class name

### DIFF
--- a/src/Security/PermissionCheckboxSetField.php
+++ b/src/Security/PermissionCheckboxSetField.php
@@ -207,7 +207,7 @@ class PermissionCheckboxSetField extends FormField
 
                     $odd = ($odd + 1) % 2;
                     $extraClass = $odd ? 'odd' : 'even';
-                    $extraClass .= ' val' . str_replace(' ', '', $code ?? '');
+                    $extraClass .= ' val' . str_replace([' ', '\\'], ['', '-'], $code ?? '');
                     $itemID = $this->ID() . '_' . preg_replace('/[^a-zA-Z0-9]+/', '', $code ?? '');
                     $disabled = $inheritMessage = '';
                     $checked = (isset($uninheritedCodes[$code]) || isset($inheritedCodes[$code]))


### PR DESCRIPTION
since the default code is using get_called_class, you can end up with \ in the class name which is an escape character for css selectors this update convert for example

even valCMS_ACCESS_SilverStripe\VersionedAdmin\ArchiveAdmin to
even valCMS_ACCESS_SilverStripe-VersionedAdmin-ArchiveAdmin

ArchiveAdmin class should probably implement     private static $required_permission_codes = 'CMS_ACCESS_ArchiveAdmin '; also

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
