### PR TITLE
ENH: CookieJar, Increase method visibility for implementors

### DIFF
--- a/src/Control/CookieJar.php
+++ b/src/Control/CookieJar.php
@@ -148,7 +148,7 @@ class CookieJar implements Cookie_Backend
     /**
      * The function that actually sets the cookie using PHP
      *
-     * @see http://uk3.php.net/manual/en/function.setcookie.php
+     * @see https://php.net/manual/en/function.setcookie.php
      *
      * @param string $name The name of the cookie
      * @param string|array $value The value for the cookie to hold
@@ -193,7 +193,7 @@ class CookieJar implements Cookie_Backend
     /**
      * Cookies must be secure if samesite is "None"
      */
-    private function cookieIsSecure(string $sameSite, bool $secure): bool
+    protected function cookieIsSecure(string $sameSite, bool $secure): bool
     {
         return $sameSite === 'None' ? true : $secure;
     }
@@ -201,7 +201,7 @@ class CookieJar implements Cookie_Backend
     /**
      * Get the correct samesite value - Session cookies use a different configuration variable.
      */
-    private function getSameSite(string $name): string
+    protected function getSameSite(string $name): string
     {
         if ($name === session_name()) {
             return Session::config()->get('cookie_samesite');


### PR DESCRIPTION
Changed `::getSameSite()` and `::cookieIsSecure()` to protected for implementors.

`::getSameSite()` may go soon but it's a pain having these private since I expect it's a common pattern to inject a custom `CookieJar` given the documentation on it.

No method reordering needed as these are the only private methods in the file. Also updated a link to the PHP docs to be region generic and to use TLS.