### PR TITLE
FIX Don't try to access private properties/methods

### DIFF
--- a/tests/php/View/ViewableDataTest.php
+++ b/tests/php/View/ViewableDataTest.php
@@ -208,16 +208,47 @@ class ViewableDataTest extends SapphireTest
         $this->assertFalse($container->hasMethod('testMethod'), 'testMethod() incorrectly reported as existing');
     }
 
-    public function testIsPrivate()
+    public function testIsAccessibleMethod()
     {
-        $reflectionMethod = new ReflectionMethod(ViewableData::class, 'isPrivate');
+        $reflectionMethod = new ReflectionMethod(ViewableData::class, 'isAccessibleMethod');
         $reflectionMethod->setAccessible(true);
         $object = new ViewableDataTestObject();
-        
-        $output = $reflectionMethod->invokeArgs($object, [$object, 'privateMethod']);
-        $this->assertTrue($output, 'Method is not private');
-        
-        $output = $reflectionMethod->invokeArgs($object, [$object, 'publicMethod']);
-        $this->assertFalse($output, 'Method is private');
+
+        $output = $reflectionMethod->invokeArgs($object, ['privateMethod']);
+        $this->assertFalse($output, 'Method should not be accessible');
+
+        $output = $reflectionMethod->invokeArgs($object, ['protectedMethod']);
+        $this->assertTrue($output, 'Method should be accessible');
+
+        $output = $reflectionMethod->invokeArgs($object, ['publicMethod']);
+        $this->assertTrue($output, 'Method should be accessible');
+
+        $output = $reflectionMethod->invokeArgs($object, ['missingMethod']);
+        $this->assertFalse($output, 'Method should not be accessible');
+
+        $output = $reflectionMethod->invokeArgs(new ViewableData(), ['isAccessibleProperty']);
+        $this->assertTrue($output, 'Method should be accessible');
+    }
+
+    public function testIsAccessibleProperty()
+    {
+        $reflectionMethod = new ReflectionMethod(ViewableData::class, 'isAccessibleProperty');
+        $reflectionMethod->setAccessible(true);
+        $object = new ViewableDataTestObject();
+
+        $output = $reflectionMethod->invokeArgs($object, ['privateProperty']);
+        $this->assertFalse($output, 'Property should not be accessible');
+
+        $output = $reflectionMethod->invokeArgs($object, ['protectedProperty']);
+        $this->assertTrue($output, 'Property should be accessible');
+
+        $output = $reflectionMethod->invokeArgs($object, ['publicProperty']);
+        $this->assertTrue($output, 'Property should be accessible');
+
+        $output = $reflectionMethod->invokeArgs($object, ['missingProperty']);
+        $this->assertFalse($output, 'Property should not be accessible');
+
+        $output = $reflectionMethod->invokeArgs(new ViewableData(), ['objCache']);
+        $this->assertTrue($output, 'Property should be accessible');
     }
 }

--- a/tests/php/View/ViewableDataTestObject.php
+++ b/tests/php/View/ViewableDataTestObject.php
@@ -7,9 +7,20 @@ use SilverStripe\ORM\DataObject;
 
 class ViewableDataTestObject extends DataObject implements TestOnly
 {
+    private string $privateProperty = 'private property';
+
+    protected string $protectedProperty = 'protected property';
+
+    public string $publicProperty = 'public property';
+
     private function privateMethod(): string
     {
         return 'Private function';
+    }
+
+    protected function protectedMethod(): string
+    {
+        return 'Protected function';
     }
 
     public function publicMethod(): string


### PR DESCRIPTION
A partial solution for this was done in https://github.com/silverstripe/silverstripe-framework/pull/10637 - this PR makes that solution more robust and does the same for properties.

This also allows `ViewableData` to fall back to using the `$data` array if there are private properties instead of just noping out.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10669