### PR TITLE
FIX Remove unused action from allowed_actions

### DIFF
--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -42,7 +42,6 @@ class Security extends Controller implements TemplateGlobalProvider
         'login',
         'logout',
         'lostpassword',
-        'passwordsent',
         'ping',
     ];
 


### PR DESCRIPTION
This action was used in CMS 3, but has since been replaced with /Security/lostpassword/passwordsent which is a separate set of actions.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10671