### PR TITLE
FIX Sort without specifying a table name

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -323,6 +323,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      *
      * @param string|array $args
      * @example $list = $list->sort('Name'); // default ASC sorting
+     * @example $list = $list->sort('"Name"'); // field names can have double quotes around them
      * @example $list = $list->sort('Name ASC, Age DESC');
      * @example $list = $list->sort('Name', 'ASC');
      * @example $list = $list->sort(['Name' => 'ASC', 'Age' => 'DESC']);

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1188,15 +1188,15 @@ class Member extends DataObject
      *
      * If no groups are passed, all groups with CMS permissions will be used.
      *
-     * @param array $groups Groups to consider or NULL to use all groups with
+     * @param SS_List|array|null $groups Groups to consider or NULL to use all groups with
      *                      CMS permissions.
      * @return Map Returns a map of all members in the groups given that
      *                have CMS permissions.
      */
-    public static function mapInCMSGroups($groups = null)
+    public static function mapInCMSGroups(SS_List|array|null $groups = null): Map
     {
         // non-countable $groups will issue a warning when using count() in PHP 7.2+
-        if (!$groups) {
+        if ($groups === null) {
             $groups = [];
         }
 
@@ -1205,7 +1205,7 @@ class Member extends DataObject
             return ArrayList::create()->map();
         }
 
-        if (count($groups ?? []) == 0) {
+        if (count($groups) === 0) {
             $perms = ['ADMIN', 'CMS_ACCESS_AssetAdmin'];
 
             if (class_exists(CMSMain::class)) {
@@ -1246,7 +1246,7 @@ class Member extends DataObject
             ]);
         }
 
-        return $members->sort('"Member"."Surname", "Member"."FirstName"')->map();
+        return $members->sort('"Surname", "FirstName"')->map();
     }
 
 

--- a/tests/php/Security/MemberTest.yml
+++ b/tests/php/Security/MemberTest.yml
@@ -58,6 +58,8 @@
     Email: noexpiry@silverstripe.com
     Password: 1nitialPassword
   staffmember:
+    FirstName: Staff
+    Surname: User
     Email: staffmember@test.com
     Groups: '=>SilverStripe\Security\Group.staffgroup'
   managementmember:


### PR DESCRIPTION
Using a table name in sort() is not allowed in CMS 5. We could use orderBy() here but member is the table it will sort on by default anyway so there's no need.

Also added unit tests, which should have caught this ages ago.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/644#event-8403907821