### PR TITLE
FIX Allow public extension getter methods to work

### DIFF
--- a/src/Core/CustomMethods.php
+++ b/src/Core/CustomMethods.php
@@ -147,7 +147,15 @@ trait CustomMethods
      */
     public function hasMethod($method)
     {
-        return method_exists($this, $method ?? '') || $this->getExtraMethodConfig($method);
+        return method_exists($this, $method ?? '') || $this->hasCustomMethod($method);
+    }
+
+    /**
+     * Determines if a custom method with this name is defined.
+     */
+    protected function hasCustomMethod($method): bool
+    {
+        return $this->getExtraMethodConfig($method) !== null;
     }
 
     /**

--- a/src/View/ViewableData.php
+++ b/src/View/ViewableData.php
@@ -247,11 +247,14 @@ class ViewableData implements IteratorAggregate
     private function isAccessibleMethod(string $method): bool
     {
         if (!method_exists($this, $method)) {
-            return false;
+            // Methods added via extensions are accessible
+            return $this->hasCustomMethod($method);
         }
+        // All methods defined on ViewableData are accessible to ViewableData
         if (static::class === self::class) {
             return true;
         }
+        // Private methods defined on subclasses are not accessible to ViewableData
         $reflectionMethod = new ReflectionMethod($this, $method);
         return !$reflectionMethod->isPrivate();
     }

--- a/tests/php/View/ViewableDataTest.php
+++ b/tests/php/View/ViewableDataTest.php
@@ -7,8 +7,9 @@ use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
+use SilverStripe\View\Tests\ViewableDataTest\ViewableDataTestExtension;
+use SilverStripe\View\Tests\ViewableDataTest\ViewableDataTestObject;
 use SilverStripe\View\ViewableData;
-use SilverStripe\View\Tests\ViewableDataTestObject;
 
 /**
  * See {@link SSViewerTest->testCastingHelpers()} for more tests related to casting and ViewableData behaviour,
@@ -16,6 +17,11 @@ use SilverStripe\View\Tests\ViewableDataTestObject;
  */
 class ViewableDataTest extends SapphireTest
 {
+    protected static $required_extensions = [
+        ViewableDataTestObject::class => [
+            ViewableDataTestExtension::class,
+        ],
+    ];
 
     public function testCasting()
     {
@@ -213,6 +219,7 @@ class ViewableDataTest extends SapphireTest
         $reflectionMethod = new ReflectionMethod(ViewableData::class, 'isAccessibleMethod');
         $reflectionMethod->setAccessible(true);
         $object = new ViewableDataTestObject();
+        $viewableData = new ViewableData();
 
         $output = $reflectionMethod->invokeArgs($object, ['privateMethod']);
         $this->assertFalse($output, 'Method should not be accessible');
@@ -226,8 +233,17 @@ class ViewableDataTest extends SapphireTest
         $output = $reflectionMethod->invokeArgs($object, ['missingMethod']);
         $this->assertFalse($output, 'Method should not be accessible');
 
-        $output = $reflectionMethod->invokeArgs(new ViewableData(), ['isAccessibleProperty']);
+        $output = $reflectionMethod->invokeArgs($viewableData, ['isAccessibleProperty']);
         $this->assertTrue($output, 'Method should be accessible');
+
+        $output = $reflectionMethod->invokeArgs($object, ['publicMethodFromExtension']);
+        $this->assertTrue($output, 'Method should be accessible');
+
+        $output = $reflectionMethod->invokeArgs($object, ['protectedMethodFromExtension']);
+        $this->assertFalse($output, 'Method should not be accessible');
+
+        $output = $reflectionMethod->invokeArgs($object, ['privateMethodFromExtension']);
+        $this->assertFalse($output, 'Method should not be accessible');
     }
 
     public function testIsAccessibleProperty()

--- a/tests/php/View/ViewableDataTest/ViewableDataTestObject.php
+++ b/tests/php/View/ViewableDataTest/ViewableDataTestObject.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverStripe\View\Tests;
+namespace SilverStripe\View\Tests\ViewableDataTest;
 
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;

--- a/tests/php/View/ViewableDataTest/ViewableDataTextExtension.php
+++ b/tests/php/View/ViewableDataTest/ViewableDataTextExtension.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SilverStripe\View\Tests\ViewableDataTest;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+
+class ViewableDataTestExtension extends Extension implements TestOnly
+{
+    private function privateMethodFromExtension(): string
+    {
+        return 'Private function';
+    }
+
+    protected function protectedMethodFromExtension(): string
+    {
+        return 'Protected function';
+    }
+
+    public function publicMethodFromExtension(): string
+    {
+        return 'Public function';
+    }
+}


### PR DESCRIPTION
This was accidentally broken in #10670. `isAccessibleMethod` now accounts for public methods added via extensions.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10669