### PR TITLE
API Deprecate Diff in favour of CMS5's HtmlDiff

### DIFF
--- a/src/View/Parsers/Diff.php
+++ b/src/View/Parsers/Diff.php
@@ -5,15 +5,27 @@ namespace SilverStripe\View\Parsers;
 use InvalidArgumentException;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\Deprecation;
 
 require_once 'difflib/difflib.php';
 
 /**
  * Class representing a 'diff' between two sequences of strings.
+ *
+ * @deprecated 4.13.0 Will be replaced with SilverStripe\View\Parsers\HtmlDiff
  */
 class Diff extends \Diff
 {
     public static $html_cleaner_class = null;
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct($from_lines, $to_lines)
+    {
+        Deprecation::notice('4.13.0', 'Will be replaced with SilverStripe\View\Parsers\HtmlDiff', Deprecation::SCOPE_CLASS);
+        parent::__construct($from_lines, $to_lines);
+    }
 
     /**
      *  Attempt to clean invalid HTML, which messes up diffs.
@@ -26,9 +38,12 @@ class Diff extends \Diff
      * @param HTMLCleaner $cleaner Optional instance of a HTMLCleaner class to
      *    use, overriding self::$html_cleaner_class
      * @return mixed|string
+     *
+     * @deprecated 4.13.0 Will be removed without equivalent functionality
      */
     public static function cleanHTML($content, $cleaner = null)
     {
+        Deprecation::notice('4.13.0', 'Will be removed without equivalent functionality');
         if (!$cleaner) {
             if (self::$html_cleaner_class && class_exists(self::$html_cleaner_class)) {
                 $cleaner = Injector::inst()->create(self::$html_cleaner_class);
@@ -57,9 +72,13 @@ class Diff extends \Diff
      * @param string $to
      * @param bool $escape
      * @return string
+     *
+     * @deprecated 4.13.0 Will be replaced with SilverStripe\View\Parsers\HtmlDiff::compareHTML()
      */
     public static function compareHTML($from, $to, $escape = false)
     {
+        Deprecation::notice('4.13.0', 'Will be replaced with SilverStripe\View\Parsers\HtmlDiff::compareHTML()');
+
         // First split up the content into words and tags
         $set1 = self::getHTMLChunks($from);
         $set2 = self::getHTMLChunks($to);
@@ -163,9 +182,13 @@ class Diff extends \Diff
     /**
      * @param string|bool|array $content If passed as an array, values will be concatenated with a comma.
      * @return array
+     *
+     * @deprecated 4.13.0 Will be removed without equivalent functionality
      */
     public static function getHTMLChunks($content)
     {
+        Deprecation::notice('4.13.0', 'Will be removed without equivalent functionality');
+
         if ($content && !is_string($content) && !is_array($content) && !is_numeric($content) && !is_bool($content)) {
             throw new InvalidArgumentException('$content parameter needs to be a string or array');
         }

--- a/tests/php/View/Parsers/DiffTest.php
+++ b/tests/php/View/Parsers/DiffTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\View\Tests\Parsers;
 
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\View\Parsers\Diff;
 
@@ -13,6 +14,10 @@ class DiffTest extends SapphireTest
      */
     public function testTableDiff()
     {
+        if (Deprecation::isEnabled()) {
+            $this->markTestSkipped('Test calls deprecated code');
+        }
+
         if (!class_exists('DOMDocument')) {
             $this->markTestSkipped('"DOMDocument" required');
             return;
@@ -47,7 +52,9 @@ class DiffTest extends SapphireTest
 		</table>";
 
         $expected = "<ins>" . $to . "</ins>" . "<del>" . $from . "</del>";
-        $compare = Diff::compareHTML($from, $to);
+        $compare = Deprecation::withNoReplacement(function () use ($from, $to) {
+            return Diff::compareHTML($from, $to);
+        });
 
         // Very hard to debug this way, wouldn't need to do this if PHP had an *actual* DOM parsing lib,
         // and not just the poor excuse that is DOMDocument
@@ -62,6 +69,10 @@ class DiffTest extends SapphireTest
      */
     public function testLegacyEachStatement()
     {
+        if (Deprecation::isEnabled()) {
+            $this->markTestSkipped('Test calls deprecated code');
+        }
+
         $sentenceOne =
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
         $sentenceTwo =
@@ -73,17 +84,25 @@ class DiffTest extends SapphireTest
         // We're cheating our test a little bit here, because depending on what HTML cleaner you have, you'll get
         // spaces added or not added around the tags.
         $expected = "/^ *<del>$sentenceOne<\/del> *$sentenceTwo *<ins>$sentenceOne<\/ins> *$/";
-        $actual = Diff::compareHTML($from, $to);
+        $actual = Deprecation::withNoReplacement(function () use ($from, $to) {
+            return Diff::compareHTML($from, $to);
+        });
 
         $this->assertMatchesRegularExpression($expected, $actual);
     }
 
     public function testDiffArray()
     {
+        if (Deprecation::isEnabled()) {
+            $this->markTestSkipped('Test calls deprecated code');
+        }
+
         $from = ['Lorem', ['array here please ignore'], 'ipsum dolor'];
         $to = 'Lorem,ipsum';
         $expected = "/^Lorem,ipsum *<del>dolor<\/del> *$/";
-        $actual = Diff::compareHTML($from, $to);
+        $actual = Deprecation::withNoReplacement(function () use ($from, $to) {
+            return Diff::compareHTML($from, $to);
+        });
 
         $this->assertMatchesRegularExpression($expected, $actual);
     }


### PR DESCRIPTION
Deprecates the `Diff` class in favour of the new `HtmlDiff` class in https://github.com/silverstripe/silverstripe-framework/pull/10641

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10640