### PR TITLE
API Run some GridField manipulations after canview

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -570,7 +570,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      */
     private function getGridFieldItemAdjacencies(): array
     {
-        $list = $this->getGridField()->getManipulatedList();
+        $list = $this->getGridField()->getListForDisplay();
         $paginator = $this->getGridFieldPaginatorState();
         if (!$paginator) {
             return [];

--- a/src/Forms/GridField/GridFieldPrintButton.php
+++ b/src/Forms/GridField/GridFieldPrintButton.php
@@ -220,7 +220,10 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
             }
         }
 
-        $items = $gridField->getManipulatedList();
+        //Remove GridFieldPaginator as we're going to export the entire list.
+        $gridField->getConfig()->removeComponentsByType(GridFieldPaginator::class);
+
+        $items = $gridField->getListForDisplay();
         $itemRows = new ArrayList();
 
         /** @var GridFieldDataColumns $gridFieldColumnsComponent */

--- a/src/Forms/GridField/GridField_PostFilterDataManipulator.php
+++ b/src/Forms/GridField/GridField_PostFilterDataManipulator.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\Forms\GridField;
+
+use SilverStripe\ORM\SS_List;
+
+/**
+ * Can modify the data list.
+ *
+ * For example, a paginating component can apply a limit, or a sorting
+ * component can apply a sort.
+ *
+ * Generally, the data manipulator will make use of to {@link GridState}
+ * variables to decide how to modify the {@link SS_List}.
+ *
+ * This manipulation is done after the canView check - this is useful for things
+ * like pagination.
+ */
+interface GridField_PostFilterDataManipulator extends GridFieldComponent
+{
+    /**
+     * Manipulate the {@link SS_List} as needed by this grid modifier after filtering with a canView check.
+     */
+    public function getManipulatedDataPostFilter(GridField $gridField, SS_List $dataList): SS_List;
+}

--- a/tests/php/Forms/GridField/GridFieldPaginatorTest.php
+++ b/tests/php/Forms/GridField/GridFieldPaginatorTest.php
@@ -12,6 +12,7 @@ use SilverStripe\Forms\GridField\GridFieldConfig;
 use SilverStripe\Forms\GridField\GridFieldPageCount;
 use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\Forms\GridField\GridFieldToolbarHeader;
+use SilverStripe\Forms\Tests\GridField\GridFieldPaginatorTest\CanViewCheckObject;
 use SilverStripe\Forms\Tests\GridField\GridFieldTest\Cheerleader;
 use SilverStripe\Forms\Tests\GridField\GridFieldTest\Player;
 use SilverStripe\Forms\Tests\GridField\GridFieldTest\Team;
@@ -47,6 +48,7 @@ class GridFieldPaginatorTest extends FunctionalTest
         Team::class,
         Player::class,
         Cheerleader::class,
+        CanViewCheckObject::class,
     ];
 
     protected function setUp(): void
@@ -126,5 +128,92 @@ class GridFieldPaginatorTest extends FunctionalTest
         // Assert that the paginator state has been corrected and the list contains items
         $this->assertEquals(1, $grid->State->GridFieldPaginator->currentPage);
         $this->assertEquals($perPage, $list->count());
+    }
+
+    public function providePaginationInteractionWithCanview()
+    {
+        return [
+            'defaults to paginate before canView' => [
+                'defaultCanview' => null,
+                'instanceCanview' => null,
+                // 30 items total because the canview check hadn't been run when the pagination was generated
+                'recordsNumber' => 'View 1–5 of 30',
+                // The manipulated list has been limited to the first page aka 5 items
+                'manipulatedListCount' => 5,
+                // Canview is run after pagination, so the list is limited to one page of 5 items and then 2 are
+                // removed for failing the canView check.
+                'listForDisplayCount' => 3,
+            ],
+            'property overrides config' => [
+                'defaultCanview' => true,
+                'instanceCanview' => false,
+                'recordsNumber' => 'View 1–5 of 30',
+                'manipulatedListCount' => 5,
+                'listForDisplayCount' => 3,
+            ],
+            'paginate after canView via config' => [
+                'defaultCanview' => true,
+                'instanceCanview' => null,
+                // 15 items total because the canview fails for every second item
+                'recordsNumber' => 'View 1–5 of 15',
+                // The manipulated list has not yet been limited to the first page, so still shows the total
+                'manipulatedListCount' => 30,
+                // The display list shows the first page, which is 5 items that can be viewed
+                'listForDisplayCount' => 5,
+            ],
+            'paginate after canView via property' => [
+                'defaultCanview' => false,
+                'instanceCanview' => true,
+                'recordsNumber' => 'View 1–5 of 15',
+                'manipulatedListCount' => 30,
+                'listForDisplayCount' => 5,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providePaginationInteractionWithCanview
+     */
+    public function testPaginationInteractionWithCanview(
+        ?bool $defaultCanview,
+        ?bool $instanceCanview,
+        string $recordsNumber,
+        int $manipulatedListCount,
+        int $listForDisplayCount
+    ) {
+        if ($defaultCanview !== null) {
+            GridFieldPaginator::config()->set('default_paginate_after_canview', $defaultCanview);
+        }
+        $gridField = $this->getCanViewTestGridField();
+        if ($instanceCanview !== null) {
+            $gridField->getConfig()->getComponentByType(GridFieldPaginator::class)->setFilterAfterCanview($instanceCanview);
+        }
+        $fieldHolder = $gridField->FieldHolder();
+        $content = new CSSContentParser($fieldHolder);
+
+        $this->assertSame($recordsNumber, $content->getBySelector('.pagination-records-number')[0]->__toString());
+        $this->assertCount($manipulatedListCount, $gridField->getManipulatedList());
+        $this->assertCount($listForDisplayCount, $gridField->getListForDisplay());
+    }
+
+    private function getCanViewTestGridField(): GridField
+    {
+        // 30 items
+        for ($i = 1; $i <= 30; $i++) {
+            $obj = new CanViewCheckObject();
+            $obj->Name = "Object {$i}";
+            $obj->write();
+        }
+
+        $list = CanViewCheckObject::get();
+        $config = GridFieldConfig::create()->addComponents(
+            new GridFieldToolbarHeader(), // Required to support pagecount
+            new GridFieldPaginator(5),
+            new GridFieldPageCount('toolbar-header-right')
+        );
+        $gridField = new GridField('testfield', 'testfield', $list, $config);
+        new Form(null, 'mockform', new FieldList([$gridField]), new FieldList());
+
+        return $gridField;
     }
 }

--- a/tests/php/Forms/GridField/GridFieldPaginatorTest/CanViewCheckObject.php
+++ b/tests/php/Forms/GridField/GridFieldPaginatorTest/CanViewCheckObject.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\GridField\GridFieldPaginatorTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class CanViewCheckObject extends DataObject implements TestOnly
+{
+    private static $table_name = 'GridFieldPaginatorTest_CanViewCheckObject';
+
+    private static $db = [
+        'Name' => 'Varchar'
+    ];
+
+    public static bool $canView = true;
+
+    public function canView($member = null)
+    {
+        static::$canView = !static::$canView;
+        return static::$canView;
+    }
+}

--- a/tests/php/Forms/GridField/GridFieldPrintButtonTest/TestObject.php
+++ b/tests/php/Forms/GridField/GridFieldPrintButtonTest/TestObject.php
@@ -12,4 +12,9 @@ class TestObject extends DataObject implements TestOnly
     private static $db = [
         'Name' => 'Varchar'
     ];
+
+    public function canView($member = null)
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Allows optionally having a less performant but more correct pagination by running canView checks before paginating.
I think this is as close as we're going to get to a fix for this without a massive rethink about how we handle permissions.

I opted to have this disabled by default to avoid causing problems for projects with large datasets - but having the option here means anyone who finds this is a problem for them can make a judgment call as to whether the correct pagination is worth the performance hit (and they can make that call on a per-gridfield basis if they really want).

Note that the new `GridField::getListForDisplay()` method has been added to give people a clear API for getting the manipulated list that is ready to be displayed. This is in contrast to `getManipulatedList()` which hasn't been checked for view permissions _and_ may not have had some of its data manipulated yet.
I've replaced calls to `getManipulatedList()` with calls to the new `getListForDisplay()` wherever we actually need the final list which will be displayed (or used for other end-use purposes such as exporting to csv).

Note also that I have opted for filtering every record, not only the "first [num per page] records" as suggested in a comment on the parent issue, because:
- The total number of pages would still be incorrect if we did that - which would give you links to pages which will never have records
- That's way more complicated
- This approach is more general and gives us the opportunity to run _other_ data manipulations after canview checks in the future, if we want.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/5995