### PR TITLE
API Add new deprecation notices.

### DIFF
--- a/src/Core/Manifest/Module.php
+++ b/src/Core/Manifest/Module.php
@@ -23,16 +23,19 @@ class Module implements Serializable
 
     /**
      * Return value of getCIConfig() when module uses PHPUNit 9
+     * @deprecated 4.13.0 Will be removed without equivalent functionality
      */
     const CI_PHPUNIT_NINE = 'CI_PHPUNIT_NINE';
 
     /**
      * Return value of getCIConfig() when module uses PHPUNit 5
+     * @deprecated 4.13.0 Will be removed without equivalent functionality
      */
     const CI_PHPUNIT_FIVE = 'CI_PHPUNIT_FIVE';
 
     /**
      * Return value of getCIConfig() when module does not use any CI
+     * @deprecated 4.13.0 Will be removed without equivalent functionality
      */
     const CI_UNKNOWN = 'CI_UNKNOWN';
 

--- a/src/Dev/CSVParser.php
+++ b/src/Dev/CSVParser.php
@@ -31,6 +31,7 @@ use SilverStripe\Control\Director;
  *   $obj->write();
  * }
  * </code>
+ * @deprecated 4.13.0 Use League\Csv\Reader instead
  */
 class CSVParser implements Iterator
 {
@@ -115,7 +116,7 @@ class CSVParser implements Iterator
      */
     public function __construct($filename, $delimiter = ",", $enclosure = '"')
     {
-        Deprecation::notice('5.0', __CLASS__ . ' is deprecated, use ' . Reader::class . ' instead');
+        Deprecation::notice('4.13.0', 'Use ' . Reader::class . ' instead', Deprecation::SCOPE_CLASS);
         $filename = Director::getAbsFile($filename);
         $this->filename = $filename;
         $this->delimiter = $delimiter;

--- a/src/Dev/CsvBulkLoader.php
+++ b/src/Dev/CsvBulkLoader.php
@@ -254,11 +254,11 @@ class CsvBulkLoader extends BulkLoader
         Deprecation::notice('4.12.0', 'Process rows individually instead');
         $results = BulkLoader_Result::create();
 
-        $csv = new CSVParser(
-            $filepath,
-            $this->delimiter,
-            $this->enclosure
-        );
+        $delimiter = $this->delimiter;
+        $enclosure = $this->enclosure;
+        $csv = Deprecation::withNoReplacement(function () use ($filepath, $delimiter, $enclosure) {
+            return new CSVParser($filepath, $delimiter, $enclosure);
+        });
 
         // ColumnMap has two uses, depending on whether hasHeaderRow is set
         if ($this->columnMap) {

--- a/src/Dev/TestSession_STResponseWrapper.php
+++ b/src/Dev/TestSession_STResponseWrapper.php
@@ -6,6 +6,7 @@ use SilverStripe\Control\HTTPResponse;
 
 /**
  * Wrapper around HTTPResponse to make it look like a SimpleHTTPResposne
+ * @deprecated 4.13.0 Will be removed without equivalent functionality to replace it
  */
 class TestSession_STResponseWrapper
 {
@@ -17,6 +18,13 @@ class TestSession_STResponseWrapper
 
     public function __construct(HTTPResponse $response)
     {
+        Deprecation::withNoReplacement(function () {
+            Deprecation::notice(
+                '4.13.0',
+                'Will be removed without equivalent functionality to replace it',
+                Deprecation::SCOPE_CLASS
+            );
+        });
         $this->response = $response;
     }
 

--- a/tests/php/Dev/CSVParserTest.php
+++ b/tests/php/Dev/CSVParserTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Dev\Tests;
 
 use SilverStripe\Dev\CSVParser;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Dev\SapphireTest;
 
 class CSVParserTest extends SapphireTest
@@ -19,6 +20,9 @@ class CSVParserTest extends SapphireTest
     {
         parent::setUp();
         $this->csvPath = __DIR__ . '/CsvBulkLoaderTest/csv/';
+        if (Deprecation::isEnabled()) {
+            $this->markTestSkipped('Test calls deprecated code');
+        }
     }
 
     public function testParsingWithHeaders()


### PR DESCRIPTION
These are removed in CMS 5.

Note there have been so many new deprecations which we already haven't added to the CMS 4.13 changelog so there's no point manually adding this there, we're going to have to do some batch card to add all the ones we've missed anyway and we'll likely just automate that.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/674
