### PR TITLE
MNT Tweak some test to account for slightly different sorting logic in PostgreSQL

### DIFF
--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -1958,8 +1958,6 @@ class DataListTest extends SapphireTest
     /**
      * Test passing scalar values to sort()
      *
-     * Explicity tests that sort(null) will wipe any existing sort on a DataList
-     *
      * @dataProvider provideSortScalarValues
      */
     public function testSortScalarValues(mixed $emtpyValue, string $type): void
@@ -1992,10 +1990,7 @@ class DataListTest extends SapphireTest
     }
 
     /**
-     * Test passing scalar values to sort()
-     *
      * Explicity tests that sort(null) will wipe any existing sort on a DataList
-     *
      */
     public function testSortNull(): void
     {

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -1831,7 +1831,7 @@ class MemberTest extends FunctionalTest
         $result = Member::mapInCMSGroups($groups);
         $this->assertInstanceOf(Map::class, $result);
 
-        $this->assertSame($expectedUsers, $result->keys());
+        $this->assertEqualsCanonicalizing($expectedUsers, $result->keys());
     }
 
     public function provideMapInCMSGroups()


### PR DESCRIPTION
Queries without a ORDER BY clause in PostgreSQL are return in a slightly different order. This leads to somewhat different results in some context.

## Parent issue
https://github.com/silverstripe/silverstripe-postgresql/issues/143