### PR TITLE
FIX Wrap deprecated config with no replacement

### DIFF
--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -704,7 +704,9 @@ class Director implements TemplateGlobalProvider
      */
     public static function publicDir()
     {
-        $alternate = self::config()->uninherited('alternate_public_dir');
+        $alternate = Deprecation::withNoReplacement(function () {
+            return self::config()->uninherited('alternate_public_dir');
+        });
         if (isset($alternate)) {
             return $alternate;
         }


### PR DESCRIPTION
We shouldn't see deprecation warnings for this config call unless we explicitly set `$showNoReplacementNotices` to true

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10703