### PR TITLE
FIX Correctly identify deprecated API in withNoReplacement

### DIFF
--- a/src/Dev/Deprecation.php
+++ b/src/Dev/Deprecation.php
@@ -177,6 +177,12 @@ class Deprecation
             $level = 1;
         }
         $newLevel = $level;
+        // handle closures inside withNoReplacement()
+        if (self::$insideWithNoReplacement
+            && substr($backtrace[$newLevel]['function'], -strlen('{closure}')) === '{closure}'
+        ) {
+            $newLevel = $newLevel + 2;
+        }
         // handle call_user_func
         if ($level === 4 && strpos($backtrace[2]['function'] ?? '', 'call_user_func') !== false) {
             $newLevel = 5;
@@ -277,10 +283,10 @@ class Deprecation
                     // Do not add to self::$userErrorMessageBuffer, as the backtrace is too expensive
                     return;
                 }
-    
+
                 // Getting a backtrace is slow, so we only do it if we need it
                 $backtrace = null;
-    
+
                 // Get the calling scope
                 if ($scope == Deprecation::SCOPE_METHOD) {
                     $backtrace = debug_backtrace(0);
@@ -291,7 +297,7 @@ class Deprecation
                 } else {
                     $caller = false;
                 }
-    
+
                 if (substr($string, -1) != '.') {
                     $string .= ".";
                 }

--- a/tests/php/Dev/DeprecationTest.php
+++ b/tests/php/Dev/DeprecationTest.php
@@ -151,6 +151,22 @@ class DeprecationTest extends SapphireTest
         Deprecation::outputNotices();
     }
 
+    public function testNoticeWithNoReplacementTrue()
+    {
+        $message = implode(' ', [
+            'SilverStripe\Dev\Tests\DeprecationTest->testNoticeWithNoReplacementTrue is deprecated.',
+            'My message.',
+            'Called from PHPUnit\Framework\TestCase->runTest.'
+        ]);
+        $this->expectDeprecation();
+        $this->expectDeprecationMessage($message);
+        Deprecation::enable(true);
+        Deprecation::withNoReplacement(function () {
+            Deprecation::notice('123', 'My message.');
+        });
+        Deprecation::outputNotices();
+    }
+
     public function testClassWithNoReplacement()
     {
         $message = implode(' ', [


### PR DESCRIPTION
## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10705