### PR TITLE
FIX Ensure getters and setters are respected

### DIFF
--- a/src/ORM/FieldType/DBBoolean.php
+++ b/src/ORM/FieldType/DBBoolean.php
@@ -46,7 +46,11 @@ class DBBoolean extends DBField
     {
         $fieldName = $this->name;
         if ($fieldName) {
-            $dataObject->setField($fieldName, $this->value ? 1 : 0);
+            if ($this->value instanceof DBField) {
+                $this->value->saveInto($dataObject);
+            } else {
+                $dataObject->__set($fieldName, $this->value ? 1 : 0);
+            }
         } else {
             $class = static::class;
             throw new \RuntimeException("DBField::saveInto() Called on a nameless '$class' object");

--- a/src/ORM/FieldType/DBComposite.php
+++ b/src/ORM/FieldType/DBComposite.php
@@ -221,8 +221,12 @@ abstract class DBComposite extends DBField
     {
         foreach ($this->compositeDatabaseFields() as $field => $spec) {
             // Save into record
-            $key = $this->getName() . $field;
-            $dataObject->setField($key, $this->getField($field));
+            if ($this->value instanceof DBField) {
+                $this->value->saveInto($dataObject);
+            } else {
+                $key = $this->getName() . $field;
+                $dataObject->__set($key, $this->getField($field));
+            }
         }
     }
 

--- a/src/ORM/FieldType/DBDecimal.php
+++ b/src/ORM/FieldType/DBDecimal.php
@@ -88,8 +88,12 @@ class DBDecimal extends DBField
         $fieldName = $this->name;
 
         if ($fieldName) {
-            $value = (float) preg_replace('/[^0-9.\-\+]/', '', $this->value ?? '');
-            $dataObject->setField($fieldName, $value);
+            if ($this->value instanceof DBField) {
+                $this->value->saveInto($dataObject);
+            } else {
+                $value = (float) preg_replace('/[^0-9.\-\+]/', '', $this->value ?? '');
+                $dataObject->__set($fieldName, $value);
+            }
         } else {
             throw new \UnexpectedValueException(
                 "DBField::saveInto() Called on a nameless '" . static::class . "' object"

--- a/src/ORM/FieldType/DBField.php
+++ b/src/ORM/FieldType/DBField.php
@@ -542,7 +542,11 @@ abstract class DBField extends ViewableData implements DBIndexable
                 "DBField::saveInto() Called on a nameless '" . static::class . "' object"
             );
         }
-        $dataObject->setField($fieldName, $this->value);
+        if ($this->value instanceof self) {
+            $this->value->saveInto($dataObject);
+        } else {
+            $dataObject->__set($fieldName, $this->value);
+        }
     }
 
     /**

--- a/src/ORM/FieldType/DBPercentage.php
+++ b/src/ORM/FieldType/DBPercentage.php
@@ -45,7 +45,7 @@ class DBPercentage extends DBDecimal
 
         $fieldName = $this->name;
         if ($fieldName && $dataObject->$fieldName > 1.0) {
-            $dataObject->setField($fieldName, 1.0);
+            $dataObject->__set($fieldName, 1.0);
         }
     }
 }

--- a/tests/php/ORM/DBFieldTest/TestDataObject.php
+++ b/tests/php/ORM/DBFieldTest/TestDataObject.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DBFieldTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class TestDataObject extends DataObject implements TestOnly
+{
+    private static $table_name = 'DBFieldTest_TestDataObject';
+
+    private static $db = [
+        'Title' => TestDbField::class,
+        'MyTestField' => TestDbField::class,
+    ];
+
+    public $setFieldCalledCount = 0;
+
+    public function setField($fieldName, $val)
+    {
+        $this->setFieldCalledCount++;
+        return parent::setField($fieldName, $val);
+    }
+
+    public function setMyTestField($val)
+    {
+        return $this->setField('MyTestField', strtolower($val));
+    }
+}

--- a/tests/php/ORM/DBFieldTest/TestDbField.php
+++ b/tests/php/ORM/DBFieldTest/TestDbField.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DBFieldTest;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\FieldType\DBField;
+
+class TestDbField extends DBField implements TestOnly
+{
+    public function requireField()
+    {
+        // Basically the same as DBVarchar but we don't want to test with DBVarchar in case something
+        // changes in that class eventually.
+        $charset = Config::inst()->get(MySQLDatabase::class, 'charset');
+        $collation = Config::inst()->get(MySQLDatabase::class, 'collation');
+
+        $parts = [
+            'datatype' => 'varchar',
+            'precision' => 255,
+            'character set' => $charset,
+            'collate' => $collation,
+            'arrayValue' => $this->arrayValue
+        ];
+
+        $values = [
+            'type' => 'varchar',
+            'parts' => $parts
+        ];
+
+        DB::require_field($this->tableName, $this->name, $values);
+    }
+
+    public $saveIntoCalledCount = 0;
+
+    public function saveInto($dataObject)
+    {
+        $this->saveIntoCalledCount++;
+        return parent::saveInto($dataObject);
+    }
+}

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -66,6 +66,7 @@ class DataObjectTest extends SapphireTest
         DataObjectTest\TreeNode::class,
         DataObjectTest\OverriddenDataObject::class,
         DataObjectTest\InjectedDataObject::class,
+        DataObjectTest\SettersAndGetters::class,
     ];
 
     protected function setUp(): void
@@ -2666,5 +2667,15 @@ class DataObjectTest extends SapphireTest
         // enum with dots in their values are also parsed correctly
         $vals = ['25.25', '50.00', '75.00', '100.50'];
         $this->assertSame(array_combine($vals ?? [], $vals ?? []), $obj->dbObject('MyEnumWithDots')->enumValues());
+    }
+
+    public function testSettersAndGettersAreRespected()
+    {
+        $obj = new DataObjectTest\SettersAndGetters();
+        $obj->MyTestField = 'Some Value';
+        // Setter overrides it with all lower case
+        $this->assertSame('some value', $obj->getField('MyTestField'));
+        // Getter overrides it with all upper case
+        $this->assertSame('SOME VALUE', $obj->MyTestField);
     }
 }

--- a/tests/php/ORM/DataObjectTest/SettersAndGetters.php
+++ b/tests/php/ORM/DataObjectTest/SettersAndGetters.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class SettersAndGetters extends DataObject implements TestOnly
+{
+    private static $table_name = 'DataObjectTest_SettersAndGetters';
+
+    private static $db = [
+        'MyTestField' => 'Varchar(255)',
+    ];
+
+    public function setMyTestField($val)
+    {
+        $this->setField('MyTestField', strtolower($val));
+    }
+
+    public function getMyTestField()
+    {
+        return strtoupper($this->getField('MyTestField'));
+    }
+}


### PR DESCRIPTION
Instances of `DBField` stopped using the `__set()` logic in https://github.com/silverstripe/silverstripe-framework/pull/10614 when `saveInto()` was called on them. This caused the regression in the issue.

This PR _explicitly_ uses the `__set()` logic, and includes tests to ensure it works as expected and we're not doing anything recursively.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10707