### PR TITLE
BUG Update RelatedDataService to properly escape ClassName in Polymorphic relations

### DIFF
--- a/src/ORM/RelatedData/StandardRelatedDataService.php
+++ b/src/ORM/RelatedData/StandardRelatedDataService.php
@@ -394,14 +394,7 @@ class StandardRelatedDataService implements RelatedDataService
      */
     private function prepareClassNameLiteral(string $value): string
     {
-        $c = chr(92);
-        $escaped = str_replace($c ?? '', "{$c}{$c}", $value ?? '');
-        // postgres
-        if (stripos(get_class(DB::get_conn()), 'postgres') !== false) {
-            return "E'{$escaped}'";
-        }
-        // mysql
-        return "'{$escaped}'";
+        return DB::get_conn()->quoteString($value);
     }
 
     /**


### PR DESCRIPTION
`StandardRelatedDataService` escapes ClassName in its query using some hackish logic instead of asking DB to do it for it.

This breaks alternative DB adapters like SQLite.


## Parent issue
- https://github.com/silverstripe/silverstripe-sqlite3/issues/68