### PR TITLE
DEP Bump masterminds/html5 to 2.7.6 to fix deperaction warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "embed/embed": "^4.4.7",
         "league/csv": "^9.8.0",
         "m1/env": "^2.2.0",
-        "masterminds/html5": "^2.7",
+        "masterminds/html5": "^2.7.6",
         "monolog/monolog": "^3.2.0",
         "nikic/php-parser": "^4.15.0",
         "psr/container": "^1.1 || ^2.0",


### PR DESCRIPTION
Current constraint is causing deprecation warning on `--prefer-lowest` builds.

## Parent issue
- https://github.com/silverstripe/silverstripe-sqlite3/issues/68