### PR TITLE
FIX property_exists() parameters mixup

### DIFF
--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -604,7 +604,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
 
         $firstRecord = $this->first();
 
-        return is_array($firstRecord) ? array_key_exists($by, $firstRecord) : property_exists($firstRecord ?? '', $by);
+        return is_array($firstRecord) ? array_key_exists($by, $firstRecord) : property_exists($firstRecord, $by ?? '');
     }
 
     /**

--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -604,7 +604,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
 
         $firstRecord = $this->first();
 
-        return is_array($firstRecord) ? array_key_exists($by, $firstRecord) : property_exists($by, $firstRecord ?? '');
+        return is_array($firstRecord) ? array_key_exists($by, $firstRecord) : property_exists($firstRecord ?? '', $by);
     }
 
     /**


### PR DESCRIPTION
property_exists() has first parameter "object_or_class" and second is a property to check

It could be related to this https://github.com/silverstripe/silverstripe-framework/issues/10428? Not sure.
