### PR TITLE
FIX Reduce array method calls

### DIFF
--- a/src/Dev/Deprecation.php
+++ b/src/Dev/Deprecation.php
@@ -237,8 +237,8 @@ class Deprecation
         if (!Director::isDev()) {
             return false;
         }
-        $envVar = Environment::getEnv('SS_DEPRECATION_ENABLED');
         if (Environment::hasEnv('SS_DEPRECATION_ENABLED')) {
+            $envVar = Environment::getEnv('SS_DEPRECATION_ENABLED');
             return self::varAsBoolean($envVar);
         }
         return static::$currentlyEnabled;
@@ -293,8 +293,8 @@ class Deprecation
      */
     public static function shouldShowForHttp(): bool
     {
-        $envVar = Environment::getEnv('SS_DEPRECATION_SHOW_HTTP');
         if (Environment::hasEnv('SS_DEPRECATION_SHOW_HTTP')) {
+            $envVar = Environment::getEnv('SS_DEPRECATION_SHOW_HTTP');
             return self::varAsBoolean($envVar);
         }
         return self::$shouldShowForHttp;
@@ -306,8 +306,8 @@ class Deprecation
      */
     public static function shouldShowForCli(): bool
     {
-        $envVar = Environment::getEnv('SS_DEPRECATION_SHOW_CLI');
         if (Environment::hasEnv('SS_DEPRECATION_SHOW_CLI')) {
+            $envVar = Environment::getEnv('SS_DEPRECATION_SHOW_CLI');
             return self::varAsBoolean($envVar);
         }
         return self::$shouldShowForCli;

--- a/tests/php/Core/EnvironmentTest.php
+++ b/tests/php/Core/EnvironmentTest.php
@@ -79,7 +79,6 @@ class EnvironmentTest extends SapphireTest
         $valueOptions = [
             true,
             false,
-            null,
             0,
             1,
             1.75,
@@ -97,6 +96,12 @@ class EnvironmentTest extends SapphireTest
                 ];
             }
         }
+        // `null` isn't a supported value outside of using the `.env` option.
+        $scenarios[] = [
+            'setAs' => '.env',
+            'value' => null,
+            'expected' => true,
+        ];
         $scenarios[] = [
             'setAs' => null,
             'value' => null,


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/29

This is to fix an extremely strange issue where PHP is timing out in CI - it seems like it's being related to too many array lookup operations causing PHP to start going very slowly. Deprecation::isEnabled() is called an extremely large amount in 4.13.  For whatever reason this was only causing issues in the MFA testsuite within recipe-kitchen-sink, normally during a WebAuthn test. Possibly it managed to go a threshold of calls to Deprecation::isEnabled()

Example failure - https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/4427766962/jobs/7765874165#step:12:63

This PR:
- Uses less array methods, opting for [isset()](https://www.php.net/manual/en/function.isset.php) where possible
- Ensures that getEnv() is only called after hasEnv(), which logically is how it should have been all along

**recipe-kitchen-sink run with this branch**
**- https://github.com/emteknetnz/recipe-kitchen-sink/actions/runs/4474834608** - note I'm not sure why red phplinting + endtoend jobs were created for this run, in normal CI runs those jobs aren't created. In this case they can be ignored

