### PR TITLE
NEW: Allow different search filters on TreeDropdownField

### DIFF
--- a/src/Forms/TreeDropdownField.php
+++ b/src/Forms/TreeDropdownField.php
@@ -61,6 +61,8 @@ class TreeDropdownField extends FormField
 
     protected $schemaComponent = 'TreeDropdownField';
 
+    private static $search_filter = 'PartialMatch';
+
     private static $url_handlers = [
         '$Action!/$ID' => '$Action'
     ];
@@ -791,9 +793,11 @@ class TreeDropdownField extends FormField
             'Title',
             'Name'
         ]);
+
+        $searchFilter = $this->config()->get('search_filter') ?? 'PartialMatch';
         foreach ($candidates as $candidate) {
             if ($sourceObjectInstance->hasDatabaseField($candidate)) {
-                $filters["{$candidate}:PartialMatch"] = $this->search;
+                $filters["{$candidate}:{$searchFilter}"] = $this->search;
             }
         }
 

--- a/tests/php/Forms/TreeDropdownFieldTest.php
+++ b/tests/php/Forms/TreeDropdownFieldTest.php
@@ -363,4 +363,47 @@ class TreeDropdownFieldTest extends SapphireTest
             'TreeBaseId is included in the default schema data'
         );
     }
+
+    public function testSearchFilter()
+    {
+        $field = new TreeDropdownField('TestTree', 'Test tree', TestObject::class);
+
+        // case-insensitive search against keyword 'zero' for pages
+        $request = new HTTPRequest('GET', 'url', ['search' => 'zero', 'format' => 'json', 'flatList' => '1' ]);
+        $request->setSession(new Session([]));
+        $response = $field->tree($request);
+        $tree = $response->getBody();
+        $json = json_decode($tree);
+        $children1Before = count($json->children);
+        $this->assertEquals($children1Before, 4, 'PartialMatch search for zero has 4 results in fixture');
+
+        TreeDropdownField::config()->set('search_filter', 'StartsWith');
+        $request = new HTTPRequest('GET', 'url', ['search' => 'zero', 'format' => 'json', 'flatList' => '1' ]);
+        $request->setSession(new Session([]));
+        $response = $field->tree($request);
+        $tree = $response->getBody();
+        $json = json_decode($tree);
+        $children1After = count($json->children);
+        $this->assertEquals($children1After, 1, 'StartsWith search for zero has 1 result in fixture');
+
+        //change search_filter back and repeat the test
+        TreeDropdownField::config()->set('search_filter', 'PartialMatch');
+        // case-insensitive search against keyword 'child' for pages
+        $request = new HTTPRequest('GET', 'url', ['search' => 'child', 'format' => 'json', 'flatList' => '1' ]);
+        $request->setSession(new Session([]));
+        $response = $field->tree($request);
+        $tree = $response->getBody();
+        $json = json_decode($tree);
+        $children2Before = count($json->children);
+        $this->assertEquals($children2Before, 9, 'PartialMatch search for child has 9 results in fixture');
+
+        TreeDropdownField::config()->set('search_filter', 'StartsWith');
+        $request = new HTTPRequest('GET', 'url', ['search' => 'child', 'format' => 'json', 'flatList' => '1' ]);
+        $request->setSession(new Session([]));
+        $response = $field->tree($request);
+        $tree = $response->getBody();
+        $json = json_decode($tree);
+        $children2After = count($json->children);
+        $this->assertEquals($children2After, 8, 'PartialMatch search for child has 8 results in fixture (excludes grandchild)');
+    }
 }

--- a/tests/php/Forms/TreeDropdownFieldTest.php
+++ b/tests/php/Forms/TreeDropdownFieldTest.php
@@ -404,6 +404,6 @@ class TreeDropdownFieldTest extends SapphireTest
         $tree = $response->getBody();
         $json = json_decode($tree);
         $children2After = count($json->children);
-        $this->assertEquals($children2After, 8, 'PartialMatch search for child has 8 results in fixture (excludes grandchild)');
+        $this->assertEquals($children2After, 8, 'StartsWith search for child has 8 results in fixture (excludes grandchild)');
     }
 }


### PR DESCRIPTION
This pull request comes about when encountering performance issues on the `tree` method when searching on a large dataset. 

I have a site with >20K SiteTree records. The client love the Insert Link feature on the WYSIWYG, and starts enthusiastically searching for Titles containing "tra". The offending link can be reproduced after logging into the CMS and visiting `admin/Modals/editorInternalLink/field/PageID/tree?search=tra&flatList=1&format=json`.  Unfortunately, this kicks off some really inefficient queries to the backend, exacerbated by the following issues:

1. Lots of records, not much we can do about that
2. We're searching on Title and MenuTitle by default, which is not indexed, because...
3. It's using PartialMatch, so an index on those columns would be ineffective

To address this, I propose replacing the hardcoded PartialMatch filter with a configuration variable, to allow developers to modify the search behaviour.  In my case, I added `indexes` on SiteTree for MenuTitle and Title.  After changing the filter to StartsWith the query responds in ~6s vs the 30+ (usually an execution_limit error) it was taking previously, albeit at the expense of fewer results.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
