### PR TITLE
FIX Remove legacy filter icon

### DIFF
--- a/src/Forms/GridField/GridFieldSortableHeader.php
+++ b/src/Forms/GridField/GridFieldSortableHeader.php
@@ -188,25 +188,7 @@ class GridFieldSortableHeader extends AbstractGridFieldComponent implements Grid
                     }
                 }
             } else {
-                if ($currentColumn == count($columns ?? [])) {
-                    $filter = $gridField->getConfig()->getComponentByType(GridFieldFilterHeader::class);
-
-                    if ($filter && $filter->canFilterAnyColumns($gridField)) {
-                        $field = new LiteralField(
-                            $fieldName,
-                            sprintf(
-                                '<button type="button" name="showFilter" aria-label="%s" title="%s"' .
-                                ' class="btn btn-secondary font-icon-search btn--no-text btn--icon-large grid-field__filter-open"></button>',
-                                _t('SilverStripe\\Forms\\GridField\\GridField.OpenFilter', "Open search and filter"),
-                                _t('SilverStripe\\Forms\\GridField\\GridField.OpenFilter', "Open search and filter")
-                            )
-                        );
-                    } else {
-                        $field = new LiteralField($fieldName, '<span class="non-sortable">' . $title . '</span>');
-                    }
-                } else {
-                    $field = new LiteralField($fieldName, '<span class="non-sortable">' . $title . '</span>');
-                }
+                $field = new LiteralField($fieldName, '<span class="non-sortable">' . $title . '</span>');
             }
             $forTemplate->Fields->push($field);
         }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/1478

Deleting the old code block because it's purely for the previously and now deprecated `$filter->useLegacyFilterHeader`
https://github.com/silverstripe/silverstripe-framework/blob/4/src/Forms/GridField/GridFieldSortableHeader.php#L194

The "normal" filter icon (the one we want to retain) is set in GridFieldFilterHeader for both `4` and `5` - https://github.com/silverstripe/silverstripe-framework/blob/4.13/src/Forms/GridField/GridFieldFilterHeader.php#L542