### PR TITLE
FIX stabilise typed APIs

### DIFF
--- a/src/Control/Cookie.php
+++ b/src/Control/Cookie.php
@@ -14,6 +14,12 @@ class Cookie
 {
     use Configurable;
 
+    public const SAMESITE_LAX = 'Lax';
+
+    public const SAMESITE_STRICT = 'Strict';
+
+    public const SAMESITE_NONE = 'None';
+
     /**
      * @config
      *
@@ -25,7 +31,7 @@ class Cookie
      * Must be "Strict", "Lax", or "None"
      * @config
      */
-    private static string $default_samesite = 'Lax';
+    private static string $default_samesite = self::SAMESITE_LAX;
 
     /**
      * Fetch the current instance of the cookie backend.
@@ -110,14 +116,14 @@ class Cookie
     public static function validateSameSite(string $sameSite): void
     {
         $validValues = [
-            'Strict',
-            'Lax',
-            'None',
+            self::SAMESITE_STRICT,
+            self::SAMESITE_LAX,
+            self::SAMESITE_NONE,
         ];
         if (!in_array($sameSite, $validValues)) {
             throw new LogicException('Cookie samesite must be "Strict", "Lax", or "None"');
         }
-        if ($sameSite === 'None' && !Director::is_https(self::getRequest())) {
+        if ($sameSite === self::SAMESITE_NONE && !Director::is_https(self::getRequest())) {
             Injector::inst()->get(LoggerInterface::class)->warning('Cookie samesite cannot be "None" for non-https requests.');
         }
     }

--- a/src/Control/CookieJar.php
+++ b/src/Control/CookieJar.php
@@ -207,8 +207,8 @@ class CookieJar implements Cookie_Backend
     {
         Deprecation::notice('4.12.0', 'The relevant methods will include a `$sameSite` parameter instead.');
         if ($name === session_name()) {
-            return Session::config()->get('cookie_samesite');
+            return Session::config()->get('cookie_samesite') ?? Cookie::SAMESITE_LAX;
         }
-        return Cookie::config()->get('default_samesite');
+        return Cookie::config()->get('default_samesite') ?? Cookie::SAMESITE_LAX;
     }
 }

--- a/src/Control/Session.php
+++ b/src/Control/Session.php
@@ -139,7 +139,7 @@ class Session
      * Must be "Strict", "Lax", or "None".
      * @config
      */
-    private static string $cookie_samesite = 'Lax';
+    private static string $cookie_samesite = Cookie::SAMESITE_LAX;
 
     /**
      * Name of session cache limiter to use.
@@ -374,7 +374,7 @@ class Session
             }
         }
 
-        $sameSite = static::config()->get('cookie_samesite');
+        $sameSite = static::config()->get('cookie_samesite') ?? Cookie::SAMESITE_LAX;
         Cookie::validateSameSite($sameSite);
         $secure = $this->isCookieSecure($sameSite, Director::is_https($request));
 


### PR DESCRIPTION
Since 4.12 the use of typehints and return types has caused issues with values fetched directly from config without validation. This has lead to upgrade woes in a minor version with no immediate recourse other than manual system intervention.

To use types, we should ensure types, leaving a stable API that won't error on a bad value - or should give a thoughtful and directive error message if so.

resolves #10721 