### PR TITLE
FIX: Group visibility for SITETREE_GRANT_ACCESS permissions

### DIFF
--- a/src/Security/Group.php
+++ b/src/Security/Group.php
@@ -635,6 +635,11 @@ class Group extends DataObject
             return true;
         }
 
+        // if user can grant access for specific groups, they need to be able to see the groups
+        if (Permission::checkMember($member, "SITETREE_GRANT_ACCESS")) {
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
Make groups visible if member has SITETREE_GRANT_ACCESS permissions, otherwise the dropdown for selecting the group is empty

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
