### PR TITLE
MINOR: faster checking if record exists

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -924,15 +924,8 @@ class Member extends DataObject
         }
 
         $groupCandidateObjs = ($strict) ? $this->getManyManyComponents("Groups") : $this->Groups();
-        if ($groupCandidateObjs) {
-            foreach ($groupCandidateObjs as $groupCandidateObj) {
-                if ($groupCandidateObj->ID == $groupCheckObj->ID) {
-                    return true;
-                }
-            }
-        }
 
-        return false;
+        return $groupCandidateObjs->filter(['ID' => $groupCheckObj->ID])->exists();
     }
 
     /**


### PR DESCRIPTION
Rather than using a loop through each object, we just filter for it in the SQL query.  This is likely to speed up the code and also make it more legible.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
