### PR TITLE
DEP Conflict with symfony/process if not PHP 8.1 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
     },
     "conflict": {
         "egulias/email-validator": "^2",
-        "oscarotero/html-parser": "<0.1.7"
+        "oscarotero/html-parser": "<0.1.7",
+        "symfony/process": "<5.3.7"
     },
     "provide": {
         "psr/container-implementation": "1.0.0"


### PR DESCRIPTION
Fixes https://github.com/silverstripe/recipe-reporting-tools/actions/runs/4815390328/jobs/8574047765
> PHP Fatal error:  During inheritance of IteratorAggregate: Uncaught Return type of Symfony\Component\Process\Process::getIterator($flags = 0) should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

If `symfony/process` is installed, it cannot be one of the versions that has deprecation warnings in PHP 8.1

## Parent issue
- https://github.com/silverstripe/.github/issues/42