### PR TITLE
FIX: Add check on model class to ensure its an instance of DataObject

### DIFF
--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -15,6 +15,7 @@ use SilverStripe\Forms\Form;
 use SilverStripe\Forms\Schema\FormSchema;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Filterable;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\View\ArrayData;
@@ -258,6 +259,12 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
             return false;
         }
         $modelClass = $gridField->getModelClass();
+
+        // Don't allow any model class if it's not a subclass of DataObject to avoid exceptions
+        if (!($modelClass::singleton() instanceof DataObject)) {
+            return false;
+        }
+
         // note: searchableFields() will return summary_fields if there are no searchable_fields on the model
         $searchableFields = array_keys($modelClass::singleton()->searchableFields());
         $summaryFields = array_keys($modelClass::singleton()->summaryFields());


### PR DESCRIPTION
- an exception might occur if model class is not a subclass of DataObject e.g. `ViewableData`. An additional check is needed to avoid this exception.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
