### PR TITLE
default action should handle CompositeField

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -1617,7 +1617,11 @@ class Form extends ViewableData implements HasRequestHandler
     public function defaultAction()
     {
         if ($this->hasDefaultAction && $this->actions) {
-            return $this->actions->first();
+            $action = $this->actions->first();
+            if ($action instanceof CompositeField) {
+                return $action->getChildren()->first();
+            }
+            return $action;
         }
         return null;
     }


### PR DESCRIPTION
I was recently submitting Forms without an action_ value and realized that the code that handles the defaultAction doesn't deal with composite fields (which is the default in the admin, since we have the MajorActions group)

Currently, if you don't submit the actual action as action_doSave for instance, you would get

Uncaught BadMethodCallException: Object->__call(): the method 'actionName' does not exist on 'SilverStripe\Forms\CompositeField'

This PR makes sure that the defaultAction method works properly