### PR TITLE
BUG: fix issue where default admin without valid email can not be saved

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -774,7 +774,7 @@ class Member extends DataObject
         if ((Director::isLive() || Injector::inst()->get(MailerInterface::class) instanceof TestMailer)
             && $this->isChanged('Password')
             && $this->record['Password']
-            && $this->Email
+            && Email::is_valid_address($this->Email ?? '')
             && static::config()->get('notify_password_change')
             && $this->isInDB()
         ) {


### PR DESCRIPTION
It is possible to have a default admin without a valid email. In this case, you can not save Member as it throws an error (email is tried being sent without a valid email address).

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10808
