### PR TITLE
FIX Get ApcuCacheFactory and MemcachedCacheFactory working again

### DIFF
--- a/src/Core/Cache/ApcuCacheFactory.php
+++ b/src/Core/Cache/ApcuCacheFactory.php
@@ -3,12 +3,11 @@
 namespace SilverStripe\Core\Cache;
 
 use SilverStripe\Core\Injector\Injector;
-use Symfony\Component\Cache\Simple\ApcuCache;
-use Memcached;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Cache\Psr16Cache;
 
 class ApcuCacheFactory implements CacheFactory
 {
-
     /**
      * @var string
      */
@@ -31,10 +30,11 @@ class ApcuCacheFactory implements CacheFactory
             ? $params['namespace'] . '_' . md5(BASE_PATH)
             : md5(BASE_PATH);
         $defaultLifetime = isset($params['defaultLifetime']) ? $params['defaultLifetime'] : 0;
-        return Injector::inst()->createWithArgs(ApcuCache::class, [
+        $psr6Cache = Injector::inst()->createWithArgs(ApcuAdapter::class, [
             $namespace,
             $defaultLifetime,
             $this->version
         ]);
+        return Injector::inst()->createWithArgs(Psr16Cache::class, [$psr6Cache]);
     }
 }

--- a/src/Core/Cache/MemcachedCacheFactory.php
+++ b/src/Core/Cache/MemcachedCacheFactory.php
@@ -3,7 +3,8 @@
 namespace SilverStripe\Core\Cache;
 
 use SilverStripe\Core\Injector\Injector;
-use Symfony\Component\Cache\Simple\MemcachedCache;
+use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+use Symfony\Component\Cache\Psr16Cache;
 use Memcached;
 
 class MemcachedCacheFactory implements CacheFactory
@@ -31,10 +32,11 @@ class MemcachedCacheFactory implements CacheFactory
             ? $params['namespace'] . '_' . md5(BASE_PATH)
             : md5(BASE_PATH);
         $defaultLifetime = isset($params['defaultLifetime']) ? $params['defaultLifetime'] : 0;
-        return Injector::inst()->createWithArgs(MemcachedCache::class, [
+        $psr6Cache = Injector::inst()->createWithArgs(MemcachedAdapter::class, [
             $this->memcachedClient,
             $namespace,
             $defaultLifetime
         ]);
+        return Injector::inst()->createWithArgs(Psr16Cache::class, [$psr6Cache]);
     }
 }

--- a/tests/php/Core/Cache/CacheTest.php
+++ b/tests/php/Core/Cache/CacheTest.php
@@ -2,14 +2,17 @@
 
 namespace SilverStripe\Core\Tests\Cache;
 
+use Behat\Gherkin\Cache\MemoryCache;
 use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Cache\ApcuCacheFactory;
 use SilverStripe\Core\Cache\MemcachedCacheFactory;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Tests\Cache\CacheTest\MockCache;
 use SilverStripe\Dev\SapphireTest;
-use Symfony\Component\Cache\Simple\ApcuCache;
-use Symfony\Component\Cache\Simple\MemcachedCache;
+use Symfony\Component\Cache\Psr16Cache;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+use Memcached;
 
 class CacheTest extends SapphireTest
 {
@@ -22,7 +25,10 @@ class CacheTest extends SapphireTest
                 ApcuCacheFactory::class => [
                     'constructor' => [ 'version' => 'ss40test' ]
                 ],
-                MemcachedCacheFactory::class => MemcachedCacheFactory::class,
+                'MemcachedClient' => Memcached::class,
+                MemcachedCacheFactory::class => [
+                    'constructor' => [ 'memcachedClient' => '%$MemcachedClient' ]
+                ],
                 CacheInterface::class . '.TestApcuCache' =>  [
                     'factory' => ApcuCacheFactory::class,
                     'constructor' => [
@@ -37,42 +43,42 @@ class CacheTest extends SapphireTest
                         'defaultLifetime' => 5600,
                     ],
                 ],
-                ApcuCache::class => MockCache::class,
-                MemcachedCache::class => MockCache::class,
+                Psr16Cache::class => MockCache::class,
+                ApcuAdapter::class => MockCache::class,
+                MemcachedAdapter::class => MockCache::class,
             ]);
     }
 
     public function testApcuCacheFactory()
     {
-        $cache = Injector::inst()->get(CacheInterface::class . '.TestApcuCache');
-        $this->assertInstanceOf(
-            MockCache::class,
-            $cache
-        );
+        $psr16Cache = Injector::inst()->get(CacheInterface::class . '.TestApcuCache');
+        $this->assertInstanceOf(MockCache::class, $psr16Cache);
+        $this->assertEquals(MockCache::class, get_class($psr16Cache->getArgs()[0]));
         $this->assertEquals(
             [
                 'TestApcuCache_' . md5(BASE_PATH),
                 2600,
                 'ss40test'
             ],
-            $cache->getArgs()
+            $psr16Cache->getArgs()[0]->getArgs()
         );
     }
 
     public function testMemCacheFactory()
     {
-        $cache = Injector::inst()->get(CacheInterface::class . '.TestMemcache');
-        $this->assertInstanceOf(
-            MockCache::class,
-            $cache
-        );
+        if (!class_exists(Memcached::class)) {
+            $this->markTestSkipped('Memcached is not installed');
+        }
+        $psr16Cache = Injector::inst()->get(CacheInterface::class . '.TestMemcache');
+        $this->assertInstanceOf(MockCache::class, $psr16Cache);
+        $this->assertEquals(MockCache::class, get_class($psr16Cache->getArgs()[0]));
         $this->assertEquals(
             [
-                null,
+                new MemCached(),
                 'TestMemCache_' . md5(BASE_PATH),
                 5600
             ],
-            $cache->getArgs()
+            $psr16Cache->getArgs()[0]->getArgs()
         );
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10770

All that was required was to follow the same pattern of using the new symfony PSR6 'Adapters' and wrapping them in a PSR16 cache similar to [FilesystemCacheFactory](https://github.com/silverstripe/silverstripe-framework/blob/5.0/src/Core/Cache/FilesystemCacheFactory.php#L29)

## How to get apcu working locally:

Ensure the acpu php extension is installed, e.g. `sudo apt install -y php-apcu`
(note: simply have the apcu extension installed is enough by itself is enough for [apcu + filesystem cache] to be used via `ChainAdapter` in [DefaultCacheFactory](https://github.com/silverstripe/silverstripe-framework/blob/5/src/Core/Cache/DefaultCacheFactory.php#L96))

To get the ApcuCacheFactory to be used for CacheFactory instead of DefaultCacheFactory:

**mycache.yml**
```yml
---
Name: mycache
After: '*'
---
SilverStripe\Core\Injector\Injector:
  ApcuCacheFactory:
    class: 'SilverStripe\Core\Cache\ApcuCacheFactory'
  SilverStripe\Core\Cache\CacheFactory: '%$ApcuCacheFactory'
```

## How to get memcached working locally:

Ensure the memcached php extension is installed e.g. `sudo apt install -y php-memcached`

Ensure the memcached server is running locally:
`sudo apt install -y memcached libmemcached-tools`
`service memcached restart`
Ensure that it's running locally:
`echo stats | nc 127.0.0.1 11211`

To get the MemcachedCacheFactory to be used for CacheFactory instead of DefaultCacheFactory:

**mycache.yml**
```yml
---
Name: mycache
After: '*'
---
SilverStripe\Core\Injector\Injector:
  MemcachedClient:
    class: 'Memcached'
    calls:
      - [ addServer, [ 'localhost', 11211 ] ]
  MemcachedCacheFactory:
    class: 'SilverStripe\Core\Cache\MemcachedCacheFactory'
    constructor:
      client: '%$MemcachedClient'
  SilverStripe\Core\Cache\CacheFactory: '%$MemcachedCacheFactory'
```


