### PR TITLE
FIX Don't redirect admin URLs regardless of trailing slash

### DIFF
--- a/src/Control/Middleware/CanonicalURLMiddleware.php
+++ b/src/Control/Middleware/CanonicalURLMiddleware.php
@@ -412,7 +412,10 @@ class CanonicalURLMiddleware implements HTTPMiddleware
         $paths = (array) $this->getEnforceTrailingSlashConfigIgnorePaths();
         if (!empty($paths)) {
             foreach ($paths as $path) {
-                if (str_starts_with(trim($path, '/'), trim($requestPath, '/'))) {
+                if (str_starts_with(
+                    $this->trailingSlashForComparison($requestPath),
+                    $this->trailingSlashForComparison($path)
+                )) {
                     return false;
                 }
             }
@@ -437,6 +440,15 @@ class CanonicalURLMiddleware implements HTTPMiddleware
         }
 
         return true;
+    }
+
+    /**
+     * Ensure a string has a trailing slash to that we can use str_starts_with and compare
+     * paths like admin/ with administration/ and get a correct result.
+     */
+    private function trailingSlashForComparison(string $path): string
+    {
+        return trim($path, '/') . '/';
     }
 
     /**


### PR DESCRIPTION
The `str_starts_with()` arguments were the wrong way around, and there weren't any unit tests to check if this was working. In addition, there was a scenario where a route `/administration/` would have skipped redirection even though it isn't one of the paths in `enforceTrailingSlashConfigIgnorePaths`.

I've fixed the above problems, as well as tidied up the existing trailing slash redirect unit test.

Note that as per the issue, this is only reproducible in live mode or by changing config so that the middleware is active in another mode.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10775