### PR TITLE
API Remove deprecated template vars

### DIFF
--- a/src/View/SSViewer_BasicIteratorSupport.php
+++ b/src/View/SSViewer_BasicIteratorSupport.php
@@ -26,8 +26,6 @@ class SSViewer_BasicIteratorSupport implements TemplateIteratorProvider
         return [
             'IsFirst',
             'IsLast',
-            'First',
-            'Last',
             'FirstLast',
             'Middle',
             'MiddleString',


### PR DESCRIPTION
Remove deprecated template variables from `get_template_iterator_variables` The methods already removed from https://github.com/silverstripe/silverstripe-framework/pull/10594/