### PR TITLE
FIX Add back missing SSL support for database connections

### DIFF
--- a/src/Core/CoreKernel.php
+++ b/src/Core/CoreKernel.php
@@ -6,6 +6,7 @@ use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Dev\Install\DatabaseAdapterRegistry;
 use SilverStripe\ORM\DB;
 use Exception;
+use LogicException;
 
 /**
  * Simple Kernel container
@@ -115,6 +116,29 @@ class CoreKernel extends BaseKernel
             "username" => Environment::getEnv('SS_DATABASE_USERNAME') ?: null,
             "password" => Environment::getEnv('SS_DATABASE_PASSWORD') ?: null,
         ];
+
+        // Only add SSL keys in the array if there is an actual value associated with them
+        $sslConf = [
+            'ssl_key' => 'SS_DATABASE_SSL_KEY',
+            'ssl_cert' => 'SS_DATABASE_SSL_CERT',
+            'ssl_ca' => 'SS_DATABASE_SSL_CA',
+            'ssl_cipher' => 'SS_DATABASE_SSL_CIPHER',
+        ];
+        foreach ($sslConf as $key => $envVar) {
+            $envValue = Environment::getEnv($envVar);
+            if ($envValue) {
+                $databaseConfig[$key] = $envValue;
+            }
+        }
+
+        // Having only the key or cert without the other is bad configuration.
+        if ((isset($databaseConfig['ssl_key']) && !isset($databaseConfig['ssl_cert']))
+            || (!isset($databaseConfig['ssl_key']) && isset($databaseConfig['ssl_cert']))
+        ) {
+            user_error('Database SSL cert and key must both be defined to use SSL in the database.', E_USER_WARNING);
+            unset($databaseConfig['ssl_key']);
+            unset($databaseConfig['ssl_cert']);
+        }
 
         // Set the port if called for
         $dbPort = Environment::getEnv('SS_DATABASE_PORT');

--- a/src/Dev/Install/MySQLDatabaseConfigurationHelper.php
+++ b/src/Dev/Install/MySQLDatabaseConfigurationHelper.php
@@ -35,15 +35,15 @@ class MySQLDatabaseConfigurationHelper implements DatabaseConfigurationHelper
                 case 'MySQLDatabase':
                     $conn = mysqli_init();
 
-                    // Set SSL parameters if they exist. All parameters are required.
-                    if (array_key_exists('ssl_key', $databaseConfig) &&
-                        array_key_exists('ssl_cert', $databaseConfig) &&
-                        array_key_exists('ssl_ca', $databaseConfig)
+                    // Set SSL parameters if they exist.
+                    // Must have both the SSL cert and key, or the common authority, or preferably all three.
+                    if ((array_key_exists('ssl_key', $databaseConfig) && array_key_exists('ssl_cert', $databaseConfig))
+                        || array_key_exists('ssl_ca', $databaseConfig)
                     ) {
                         $conn->ssl_set(
-                            $databaseConfig['ssl_key'],
-                            $databaseConfig['ssl_cert'],
-                            $databaseConfig['ssl_ca'],
+                            $databaseConfig['ssl_key'] ?? null,
+                            $databaseConfig['ssl_cert'] ?? null,
+                            $databaseConfig['ssl_ca'] ?? null,
                             dirname($databaseConfig['ssl_ca']),
                             array_key_exists('ssl_cipher', $databaseConfig)
                                 ? $databaseConfig['ssl_cipher']

--- a/src/ORM/Connect/MySQLiConnector.php
+++ b/src/ORM/Connect/MySQLiConnector.php
@@ -96,14 +96,15 @@ class MySQLiConnector extends DBConnector
             );
         }
 
-        // Set SSL parameters if they exist. All parameters are required.
-        if (array_key_exists('ssl_key', $parameters ?? []) &&
-            array_key_exists('ssl_cert', $parameters ?? []) &&
-            array_key_exists('ssl_ca', $parameters ?? [])) {
+        // Set SSL parameters if they exist.
+        // Must have both the SSL cert and key, or the common authority, or preferably all three.
+        if ((array_key_exists('ssl_key', $parameters ?? []) && array_key_exists('ssl_cert', $parameters ?? []))
+            || array_key_exists('ssl_ca', $parameters ?? [])
+        ) {
             $this->dbConn->ssl_set(
-                $parameters['ssl_key'],
-                $parameters['ssl_cert'],
-                $parameters['ssl_ca'],
+                $parameters['ssl_key'] ?? null,
+                $parameters['ssl_cert'] ?? null,
+                $parameters['ssl_ca'] ?? null,
                 dirname($parameters['ssl_ca'] ?? ''),
                 array_key_exists('ssl_cipher', $parameters ?? [])
                     ? $parameters['ssl_cipher']


### PR DESCRIPTION
Reinstates the SSL support for databases which was unintentionally partially removed at some stage.

## Note for testing
You'll need to set up SSL for mysql, obviously. The [official mysql docker image](https://hub.docker.com/_/mysql/) does already have SSL enabled, and has keys in the `/var/lib/mysql/` directory.
You can copy the relevant files out of the container to your host with the following commands:
```sh
docker cp CONTAINER_NAME:/var/lib/mysql/ca.pem ./ca.pem
docker cp CONTAINER_NAME:/var/lib/mysql/client-key.pem ./client-key.pem
docker cp CONTAINER_NAME:/var/lib/mysql/client-cert.pem ./client-cert.pem
```

Note that if you go that route, you will most likely run into this error:
> ERROR [Warning]: mysqli::real_connect(): Peer certificate CN='MySQL_Server_8.0.30_Auto_Generated_Server_Certificate' did not match expected CN='database-container'

This is because PHP is trying to validate that the server's SSL cert is correct, and in checking the [common name](https://www.ssl.com/faqs/common-name/) it finds that the common name which was set at the time the SSL cert was created doesn't match the host name your webserver docker container is using to access the database docker container.

You can bypass that validation for the purposes of testing this PR by making the following change in `vendor/silverstripe/framework/src/ORM/Connect/MySQLiConnector.php`:
```diff
  $this->dbConn->real_connect(
      $parameters['server'],
      $parameters['username'],
      $parameters['password'],
      $selectedDB,
-     !empty($parameters['port']) ? $parameters['port'] : ini_get("mysqli.default_port")
+     !empty($parameters['port']) ? $parameters['port'] : ini_get("mysqli.default_port"),
+     null,
+     MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT
  );
```
It says "don't verify server cert" but it actually only disables validating the common name.

You can, alternatively, either make it so that the host name your webserver is using to access the db container matches the common name of the existing cert, or go down the rabbit hole of creating new certs for the mysql instance to use.

### Checking if you have a working SSL connection

Put this somewhere, e.g. in a page controller or in `_config.php`:
```php
use SilverStripe\ORM\Connect\MySQLQuery;
use SilverStripe\ORM\DB;

/** @var MySQLQuery $result */
$result = DB::get_conn()->getConnector()->query("SELECT * FROM performance_schema.session_status WHERE VARIABLE_NAME IN ('Ssl_version','Ssl_cipher')");

echo '<pre>';
var_Dump($result->map());
echo '</pre>';
```

The output when not using SSL:
> array(2) {
  ["Ssl_cipher"]=>
  string(0) ""
  ["Ssl_version"]=>
  string(0) ""
}


The output when using SSL:
> array(2) {
  ["Ssl_cipher"]=>
  string(22) "TLS_AES_256_GCM_SHA384"
  ["Ssl_version"]=>
  string(7) "TLSv1.3"
}

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/8871

## Follow on issues created
- https://github.com/silverstripe/silverstripe-framework/issues/10787