### PR TITLE
DEP Explicitly require psr/http-message ^1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "monolog/monolog": "^1.16",
         "nikic/php-parser": "^4.10.5",
         "psr/container": "^1",
+        "psr/http-message": "^1",
         "silverstripe/config": "^1@dev",
         "silverstripe/assets": "^1@dev",
         "silverstripe/vendor-plugin": "^1.6",


### PR DESCRIPTION
Issue - https://github.com/silverstripe/.github/issues/48

4.12 version of https://github.com/silverstripe/silverstripe-framework/pull/10794 - think this may have been accidentally reverted on merge-up