### PR TITLE
FIX Ensure dir exists before scanning it

### DIFF
--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -472,8 +472,11 @@ class i18nTextCollector
         if (!$this->modulesAndThemes) {
             $modules = ModuleLoader::inst()->getManifest()->getModules();
             // load themes as modules
-            $themes = array_diff(scandir(THEMES_PATH), ['..', '.']);
-            if ($themes) {
+            $themes = [];
+            if (is_dir(THEMES_PATH)) {
+                $themes = array_diff(scandir(THEMES_PATH), ['..', '.']);
+            }
+            if (!empty($themes)) {
                 foreach ($themes as $theme) {
                     if (is_dir(Path::join(THEMES_PATH, $theme))) {
                         $modules[self::THEME_PREFIX . $theme] = new Module(Path::join(THEMES_PATH, $theme), BASE_PATH);


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/56

Fixes https://github.com/silverstripe/recipe-core/actions/runs/4958218552/jobs/8870822705#step:12:133

```
1) SilverStripe\i18n\Tests\i18nTextCollectorTest::testCollectMergesWithExisting
scandir(/home/runner/work/recipe-core/recipe-core/themes): Failed to open directory: No such file or directory

/home/runner/work/recipe-core/recipe-core/vendor/silverstripe/framework/src/i18n/TextCollection/i18nTextCollector.php:475
```

Regression happened when this PR was merged https://github.com/silverstripe/silverstripe-framework/pull/10685/files#diff-12d1ba6d0696b4faf367da9b56489de26ab1261e4bf3e310d3730f2c8a1ba72fR475