### PR TITLE
Adjust isEnabled method 

### DIFF
--- a/_config/dev.yml
+++ b/_config/dev.yml
@@ -1,6 +1,9 @@
 ---
 Name: DevelopmentAdmin
 ---
+SilverStripe\Dev\BuildTask:
+  default_enabled: true
+
 SilverStripe\Dev\DevelopmentAdmin:
   registered_controllers:
     build:

--- a/_config/dev.yml
+++ b/_config/dev.yml
@@ -1,9 +1,6 @@
 ---
 Name: DevelopmentAdmin
 ---
-SilverStripe\Dev\BuildTask:
-  default_enabled: true
-
 SilverStripe\Dev\DevelopmentAdmin:
   registered_controllers:
     build:

--- a/src/Dev/BuildTask.php
+++ b/src/Dev/BuildTask.php
@@ -34,7 +34,7 @@ abstract class BuildTask
     private static $segment = null;
 
     /**
-     * change this to `bool` in CMS6
+     * Make this non-nullable and change this to `bool` in CMS6 with a value of `true`
      * @var bool|null
      */
     private static ?bool $is_enabled = null;
@@ -42,7 +42,7 @@ abstract class BuildTask
     /**
      * @var bool $enabled If set to FALSE, keep it from showing in the list
      * and from being executable through URL or CLI.
-     * @deprecated - remove in CMS6
+     * @deprecated - remove in CMS 6 and rely on $is_enabled instead
      */
     protected $enabled = true;
 
@@ -70,15 +70,12 @@ abstract class BuildTask
     /**
      * @return bool
      */
-    public function isEnabled(): bool
+    public function isEnabled()
     {
-        $isEnabled = $this->config()->get('enabled');
-        $isDefaultEnabled = Config::inst()->get(__CLASS__, 'default_enabled');
+        $isEnabled = $this->config()->get('is_enabled');
 
         if ($isEnabled === null) {
-            Deprecation::notice('6.0', 'Null values not allowed in CMS6 ...');
-
-            return static::$enabled ?? $isDefaultEnabled;
+            return static::$enabled ?? true;
         }
         return $isEnabled;
     }

--- a/src/Dev/BuildTask.php
+++ b/src/Dev/BuildTask.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Dev;
 
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
@@ -33,8 +34,15 @@ abstract class BuildTask
     private static $segment = null;
 
     /**
+     * change this to `bool` in CMS6
+     * @var bool|null
+     */
+    private static ?bool $is_enabled = null;
+
+    /**
      * @var bool $enabled If set to FALSE, keep it from showing in the list
      * and from being executable through URL or CLI.
+     * @deprecated - remove in CMS6
      */
     protected $enabled = true;
 
@@ -62,9 +70,17 @@ abstract class BuildTask
     /**
      * @return bool
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
-        return $this->enabled;
+        $isEnabled = $this->config()->get('enabled');
+        $isDefaultEnabled = Config::inst()->get(__CLASS__, 'default_enabled');
+
+        if ($isEnabled === null) {
+            Deprecation::notice('6.0', 'Null values not allowed in CMS6 ...');
+
+            return static::$enabled ?? $isDefaultEnabled;
+        }
+        return $isEnabled;
     }
 
     /**

--- a/src/Dev/BuildTask.php
+++ b/src/Dev/BuildTask.php
@@ -75,7 +75,7 @@ abstract class BuildTask
         $isEnabled = $this->config()->get('is_enabled');
 
         if ($isEnabled === null) {
-            return static::$enabled ?? true;
+            return $this->enabled;
         }
         return $isEnabled;
     }


### PR DESCRIPTION
[Issue](https://github.com/silverstripe/silverstripe-framework/issues/10799)

I added a way to be able to use a config yaml file to be able to disable certain, or all, tasks with a simple config. 

There also is a new config to set the default behaviour. This has been added to the dev.yml
```yml
SilverStripe\Dev\BuildTask:
    default_enabled: true
```

To use these changes, you can create your own yml config, example:
```yml
SilverStripe\Dev\BuildTask:
  default_enabled: false
DevTasks\ExampleTask:
  enabled: true
```

This would disable all tasks, besides the ExampleTask.

I also added the suggestion from [this](https://github.com/silverstripe/silverstripe-framework/issues/10799#issuecomment-1579554726) comment to add a deprecation notice.

Let me know if something needs to be adjusted.