### PR TITLE
FIX Duplicate page keeps original pages canView and canEdit permission

### DIFF
--- a/src/Security/InheritedPermissionsExtension.php
+++ b/src/Security/InheritedPermissionsExtension.php
@@ -15,18 +15,23 @@ use SilverStripe\ORM\ManyManyList;
  */
 class InheritedPermissionsExtension extends DataExtension
 {
-    private static $db = [
+    private static array $db = [
         'CanViewType' => "Enum('Anyone, LoggedInUsers, OnlyTheseUsers, Inherit', 'Inherit')",
         'CanEditType' => "Enum('LoggedInUsers, OnlyTheseUsers, Inherit', 'Inherit')",
     ];
 
-    private static $many_many = [
+    private static array $many_many = [
         'ViewerGroups' => Group::class,
         'EditorGroups' => Group::class,
     ];
 
-    private static $defaults = [
+    private static array $defaults = [
         'CanViewType' => InheritedPermissions::INHERIT,
         'CanEditType' => InheritedPermissions::INHERIT,
+    ];
+
+    private static array $cascade_duplicates = [
+        'ViewerGroups',
+        'EditorGroups',
     ];
 }


### PR DESCRIPTION
## Description
- Add property `cascade_duplicates` to SiteTree class with specified relation names to duplicate and save against the new clone object. 

## Parent issue
- https://github.com/silverstripe/silverstripe-cms/issues/2609