### PR TITLE
Permission::groupList is never cached

### DIFF
--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -347,9 +347,9 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
      */
     public static function groupList($memberID = null)
     {
+        $member = Security::getCurrentUser();
         // Default to current member, with session-caching
-        if (!$memberID) {
-            $member = Security::getCurrentUser();
+        if (!$memberID || ($member && $member->ID == $memberID)) {
             if ($member && isset($_SESSION['Permission_groupList'][$member->ID])) {
                 return $_SESSION['Permission_groupList'][$member->ID];
             }
@@ -373,9 +373,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
 
 
             // Session caching
-            if (!$memberID) {
-                $_SESSION['Permission_groupList'][$member->ID] = $groupList;
-            }
+            $_SESSION['Permission_groupList'][$member->ID] = $groupList;
 
             return isset($groupList) ? $groupList : null;
         }

--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -12,6 +12,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\View\TemplateGlobalProvider;
+use SilverStripe\Security\Member;
 
 /**
  * Represents a permission assigned to a group.
@@ -354,7 +355,7 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
                 return $_SESSION['Permission_groupList'][$member->ID];
             }
         } else {
-            $member = DataObject::get_by_id("SilverStripe\\Security\\Member", $memberID);
+            $member = DataObject::get_by_id(Member::class, $memberID);
         }
 
         if ($member) {

--- a/tests/php/Security/PermissionTest.php
+++ b/tests/php/Security/PermissionTest.php
@@ -104,6 +104,17 @@ class PermissionTest extends SapphireTest
         $this->assertFalse(in_array('CMS_ACCESS_MyAdmin', $permissions ?? []));
     }
 
+    public function testPermissionsGroupList()
+    {
+        $member = $this->objFromFixture(Member::class, 'access');
+
+        $this->assertTrue(!isset($_SESSION['Permission_groupList']));
+
+        $permissions = Permission::groupList($member->ID);
+
+        $this->assertNotEmpty($_SESSION['Permission_groupList'][$member->ID]);
+    }
+
     public function testRolesAndPermissionsFromParentGroupsAreInherited()
     {
         $member = $this->objFromFixture(Member::class, 'globalauthor');


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/10835

I did minimal changes to make it work

Ideally, logic should be rewritten better and avoid usage of $_SESSION