### PR TITLE
avoid multiple calls to records->count() In PermissionCheckboxSetField

### DIFF
--- a/src/Security/PermissionCheckboxSetField.php
+++ b/src/Security/PermissionCheckboxSetField.php
@@ -193,6 +193,7 @@ class PermissionCheckboxSetField extends FormField
             $privilegedPermissions = Permission::config()->privileged_permissions;
 
             // loop through all available categorized permissions and see if they're assigned for the given groups
+            $recordsCount = $this->records ? $this->records->Count() : 0;
             foreach ($this->source as $categoryName => $permissions) {
                 $options .= "<li><h5>$categoryName</h5></li>";
                 foreach ($permissions as $code => $permission) {
@@ -222,7 +223,7 @@ class PermissionCheckboxSetField extends FormField
                         // interface
                         $disabled = ' disabled="true"';
                         $inheritMessage = ' (' . join(', ', $inheritedCodes[$code]) . ')';
-                    } elseif ($this->records && $this->records->Count() > 1 && isset($uninheritedCodes[$code])) {
+                    } elseif ($this->records && $recordsCount > 1 && isset($uninheritedCodes[$code])) {
                         // If code assignments are collected from more than one "source group",
                         // show its origin automatically
                         $inheritMessage = ' (' . join(', ', $uninheritedCodes[$code]) . ')';

--- a/src/Security/PermissionCheckboxSetField.php
+++ b/src/Security/PermissionCheckboxSetField.php
@@ -223,7 +223,7 @@ class PermissionCheckboxSetField extends FormField
                         // interface
                         $disabled = ' disabled="true"';
                         $inheritMessage = ' (' . join(', ', $inheritedCodes[$code]) . ')';
-                    } elseif ($this->records && $recordsCount > 1 && isset($uninheritedCodes[$code])) {
+                    } elseif ($hasMultipleRecords && isset($uninheritedCodes[$code])) {
                         // If code assignments are collected from more than one "source group",
                         // show its origin automatically
                         $inheritMessage = ' (' . join(', ', $uninheritedCodes[$code]) . ')';

--- a/src/Security/PermissionCheckboxSetField.php
+++ b/src/Security/PermissionCheckboxSetField.php
@@ -193,7 +193,7 @@ class PermissionCheckboxSetField extends FormField
             $privilegedPermissions = Permission::config()->privileged_permissions;
 
             // loop through all available categorized permissions and see if they're assigned for the given groups
-            $recordsCount = $this->records ? $this->records->Count() : 0;
+            $hasMultipleRecords = $this->records?->count() > 1;
             foreach ($this->source as $categoryName => $permissions) {
                 $options .= "<li><h5>$categoryName</h5></li>";
                 foreach ($permissions as $code => $permission) {


### PR DESCRIPTION
these calls are not cached and lead to duplicate queries

example

<img width="1333" alt="image" src="https://github.com/silverstripe/silverstripe-framework/assets/250762/8106922d-c4f7-4b58-b724-f32c973c1740">

drops the number of queries from 50 to 18 in my project to display a typical member