### PR TITLE
ENH Cache $item->ID for eager loading

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -928,6 +928,8 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
 
     private function setDataObjectEagerLoadedData(DataObject $item): void
     {
+        // cache $item->ID at the top of this method to reduce calls to ViewableData::__get()
+        $itemID = $item->ID;
         foreach (array_keys($this->eagerLoadedData) as $eagerLoadRelation) {
             list($dataClasses, $relations) = $this->getEagerLoadVariables($eagerLoadRelation);
             $dataClass = $dataClasses[count($dataClasses) - 2];
@@ -935,7 +937,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
             foreach (array_keys($this->eagerLoadedData[$eagerLoadRelation]) as $eagerLoadID) {
                 $eagerLoadedData = $this->eagerLoadedData[$eagerLoadRelation][$eagerLoadID][$relation];
                 if ($dataClass === $dataClasses[0]) {
-                    if ($eagerLoadID === $item->ID) {
+                    if ($eagerLoadID === $itemID) {
                         $item->setEagerLoadedData($relation, $eagerLoadedData);
                     }
                 } elseif ($dataClass === $dataClasses[1]) {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-elemental/issues/1067

This small change makes a remarkably large difference to eager loading performance.

Every call to $item->ID in the loop will call ViewableData::__get(), which in turns ends up creating a new object via Injector.  While this is a fast operation, if you have a huge number of calls, such as in my case where I was working on the highly unoptimized cms site search, with 1000 pages and 5000 content blocks, this saved over a million calls per search.  All this PHP object creation was so bad it made enabling eager loading actually slower despite the drop in database calls.

This change makes it so that eager loading now faster in this particular operation, as would be expected
