### PR TITLE
FIX Allow repeated iterations of predicated query result

### DIFF
--- a/src/ORM/Connect/MySQLStatement.php
+++ b/src/ORM/Connect/MySQLStatement.php
@@ -116,6 +116,12 @@ class MySQLStatement extends Query
             }
             yield $row;
         }
+
+        // Check for the method first since $this->statement isn't strongly typed
+        if (method_exists($this->statement, 'data_seek')) {
+            // Reset so the query can be iterated over again
+            $this->statement->data_seek(0);
+        }
     }
 
     public function numRecords()


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10856