### PR TITLE
ENH Do not use placeholders for int ID filters

### DIFF
--- a/tests/php/ORM/Filters/ExactMatchFilterTest.php
+++ b/tests/php/ORM/Filters/ExactMatchFilterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Filters;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\Filters\ExactMatchFilter;
+use SilverStripe\ORM\Tests\Filters\ExactMatchFilterTest\Task;
+use SilverStripe\ORM\Tests\Filters\ExactMatchFilterTest\Project;
+
+class ExactMatchFilterTest extends SapphireTest
+{
+    protected static $fixture_file = 'ExactMatchFilterTest.yml';
+
+    protected static $extra_dataobjects = [
+        Task::class,
+        Project::class,
+    ];
+
+    /**
+     * @dataProvider provideUsePlaceholders
+     */
+    public function testUsePlaceholders(?bool $expectedID, ?bool $expectedTitle, bool $config, callable $fn): void
+    {
+        Config::modify()->set(ExactMatchFilter::class, 'use_placeholders_for_integer_ids', $config);
+        [$idQueryUsesPlaceholders, $titleQueryUsesPlaceholders] = $this->usesPlaceholders($fn);
+        $this->assertSame($expectedID, $idQueryUsesPlaceholders);
+        $this->assertSame($expectedTitle, $titleQueryUsesPlaceholders);
+    }
+
+    public function provideUsePlaceholders(): array
+    {
+        $ids = [1, 2, 3];
+        $taskTitles = array_map(fn($i) => "Task $i", $ids);
+        return [
+            'primary key' => [
+                'expectedID' => false,
+                'expectedTitle' => null,
+                'config' => false,
+                'fn' => fn() => Task::get()->byIDs($ids)
+            ],
+            'primary key on relation' => [
+                'expectedID' => false,
+                'expectedTitle' => null,
+                'config' => false,
+                'fn' => fn() => Project::get()->filter('Tasks.ID', $ids)
+            ],
+            'foriegn key' => [
+                'expectedID' => false,
+                'expectedTitle' => null,
+                'config' => false,
+                'fn' => fn() => Task::get()->filter(['ProjectID' => $ids])
+            ],
+            'regular column' => [
+                'expectedID' => null,
+                'expectedTitle' => true,
+                'config' => false,
+                'fn' => fn() => Task::get()->filter(['Title' => $taskTitles])
+            ],
+            'primary key + regular column' => [
+                'expectedID' => false,
+                'expectedTitle' => true,
+                'config' => false,
+                'fn' => fn() => Task::get()->filter([
+                    'ID' => $ids,
+                    'Title' => $taskTitles
+                ])
+            ],
+            'primary key config enabled' => [
+                'expectedID' => true,
+                'expectedTitle' => null,
+                'config' => true,
+                'fn' => fn() => Task::get()->byIDs($ids)
+            ],
+            'non int values' => [
+                'expectedID' => true,
+                'expectedTitle' => null,
+                'config' => false,
+                'fn' => fn() => Task::get()->filter(['ID' => ['a', 'b', 'c']])
+            ],
+        ];
+    }
+
+    private function usesPlaceholders(callable $fn): array
+    {
+        // force showqueries on to view executed SQL via output-buffering
+        $list = $fn();
+        $sql = $list->dataQuery()->sql();
+        preg_match('#ID" IN \(([^\)]+)\)\)#', $sql, $matches);
+        $idQueryUsesPlaceholders = isset($matches[1]) ? $matches[1] === '?, ?, ?' : null;
+        preg_match('#"Title" IN \(([^\)]+)\)\)#', $sql, $matches);
+        $titleQueryUsesPlaceholders = isset($matches[1]) ? $matches[1] === '?, ?, ?' : null;
+        return [$idQueryUsesPlaceholders, $titleQueryUsesPlaceholders];
+    }
+}

--- a/tests/php/ORM/Filters/ExactMatchFilterTest.yml
+++ b/tests/php/ORM/Filters/ExactMatchFilterTest.yml
@@ -1,0 +1,17 @@
+SilverStripe\ORM\Tests\Filters\ExactMatchFilterTest\Project:
+  project1:
+    Title: 'Project 1'
+  project2:
+    Title: 'Project 2'
+  project3:
+    Title: 'Project 3'
+SilverStripe\ORM\Tests\Filters\ExactMatchFilterTest\Task:
+  task1:
+    Title: 'Task 1'
+    Project: =>SilverStripe\ORM\Tests\Filters\ExactMatchFilterTest\Project.project1
+  task2:
+    Title: 'Task 2'
+    Project: =>SilverStripe\ORM\Tests\Filters\ExactMatchFilterTest\Project.project2
+  task3:
+    Title: 'Task 3'
+    Project: =>SilverStripe\ORM\Tests\Filters\ExactMatchFilterTest\Project.project3

--- a/tests/php/ORM/Filters/ExactMatchFilterTest/Project.php
+++ b/tests/php/ORM/Filters/ExactMatchFilterTest/Project.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Filters\ExactMatchFilterTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class Project extends DataObject implements TestOnly
+{
+    private static $table_name = 'ExactMatchFilterTest_Project';
+
+    private static $db = [
+        'Title' => 'Varchar(255)',
+    ];
+
+    private static $has_many = [
+        'Tasks' => Task::class,
+    ];
+}

--- a/tests/php/ORM/Filters/ExactMatchFilterTest/Task.php
+++ b/tests/php/ORM/Filters/ExactMatchFilterTest/Task.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Filters\ExactMatchFilterTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class Task extends DataObject implements TestOnly
+{
+    private static $table_name = 'ExactMatchFilterTest_Task';
+
+    private static $db = [
+        'Title' => 'Varchar(255)',
+    ];
+
+    private static $has_one = [
+        'Project' => Project::class,
+    ];
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10860

Quering time on SC hosting doing a `->filter['ID' => $ids]` with 10,000 records - pretty consistent with initial laptop testing in parent issue where it's roughly 3x faster with placeholders turned off

**Placeholders on - avg 0.1175s**

0.1378s
0.0884s
0.1123s
0.1408s
0.1080s 

**Placesholders off - avg 0.0348s**

0.0498s 
0.0232s 
0.0259s
0.0550s
0.0202s 
