### PR TITLE
MNT Add merge-up action

### DIFF
--- a/.github/workflows/merge-up.yml
+++ b/.github/workflows/merge-up.yml
@@ -1,0 +1,16 @@
+name: Merge-up
+
+on:
+  # At 2:20 PM UTC, only on Friday and Saturday
+  schedule:
+    - cron: '20 14 * * 5,6'
+
+jobs:
+  merge-up:
+    name: Merge-up
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && github.repository_owner == 'silverstripe') || (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge-up
+        uses: silverstripe/gha-merge-up@v1


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/753

Requires https://github.com/silverstripe/gha-merge-up/pull/1 to be merged first

Unit test failures are unrelated