### PR TITLE
FIX Trigger eagerloading for first() and last()

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1408,8 +1408,13 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      */
     public function first()
     {
-        foreach ($this->dataQuery->firstRow()->execute() as $row) {
-            return $this->createDataObject($row);
+        // We need to trigger eager loading by iterating over the list, rather than just fetching
+        // the first row from the dataQuery.
+        // This limit and offset logic mimics that $this->dataQuery->firstRow() would ultimately do.
+        $limitOffset = $this->dataQuery->query()->getLimit() ?? [];
+        $offset =  array_key_exists('start', $limitOffset) ? $limitOffset['start'] : 0;
+        foreach ($this->limit(1, $offset) as $record) {
+            return $record;
         }
         return null;
     }
@@ -1423,8 +1428,14 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
      */
     public function last()
     {
-        foreach ($this->dataQuery->lastRow()->execute() as $row) {
-            return $this->createDataObject($row);
+        // We need to trigger eager loading by iterating over the list, rather than just fetching
+        // the last row from the dataQuery.
+        // This limit and offset logic mimics that $this->dataQuery->lastRow() would ultimately do.
+        $limitOffset = $this->dataQuery->query()->getLimit() ?? [];
+        $offset =  array_key_exists('start', $limitOffset) ? $limitOffset['start'] : 0;
+        $index = max($this->count() + $offset - 1, 0);
+        foreach ($this->limit(1, $index) as $record) {
+            return $record;
         }
         return null;
     }

--- a/tests/php/ORM/DataListEagerLoadingTest.php
+++ b/tests/php/ORM/DataListEagerLoadingTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\ORM\Tests;
 
 use InvalidArgumentException;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
@@ -1114,5 +1115,23 @@ class DataListEagerLoadingTest extends SapphireTest
                 'ManyManyThroughEagerLoadObjects.ManyManyThroughSubEagerLoadObjects',
             ],
         ];
+    }
+
+    public function testFirstHasEagerloadedRelation()
+    {
+        $record = EagerLoadObject::create(['Title' => 'My obj']);
+        $record->write();
+        $record->HasManyEagerLoadObjects()->add(HasManyEagerLoadObject::create(['Title' => 'My related obj']));
+        $obj = EagerLoadObject::get()->eagerLoad('HasManyEagerLoadObjects')->first();
+        $this->assertInstanceOf(ArrayList::class, $obj->HasManyEagerLoadObjects());
+    }
+
+    public function testLastHasEagerloadedRelation()
+    {
+        $record = EagerLoadObject::create(['Title' => 'My obj']);
+        $record->write();
+        $record->HasManyEagerLoadObjects()->add(HasManyEagerLoadObject::create(['Title' => 'My related obj']));
+        $obj = EagerLoadObject::get()->eagerLoad('HasManyEagerLoadObjects')->last();
+        $this->assertInstanceOf(ArrayList::class, $obj->HasManyEagerLoadObjects());
     }
 }

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -2081,6 +2081,28 @@ class DataListTest extends SapphireTest
         ], $productTitles);
     }
 
+    public function testFirst()
+    {
+        $list = Sortable::get()->sort('Sort');
+        $this->assertGreaterThanOrEqual(
+            3,
+            $list->count(),
+            'We must have at least 3 items for this test to be valid'
+        );
+        $this->assertSame('Steve', $list->first()->Name);
+    }
+
+    public function testLast()
+    {
+        $list = Sortable::get()->sort('Sort');
+        $this->assertGreaterThanOrEqual(
+            3,
+            $list->count(),
+            'We must have at least 3 items for this test to be valid'
+        );
+        $this->assertSame('John', $list->last()->Name);
+    }
+
     public function testChunkedFetch()
     {
         $expectedIDs = Team::get()->map('ID', 'ID')->toArray();


### PR DESCRIPTION
The new logic is directly pulled from `SQLSelect::firstRow()` and `SQLSelect::lastRow()` which is was ultimately was powering these methods - tracing those, you can see that this limited query (limit 1) was always being run, and the result (which was necessarily an array of size one) was returned from the database - and then just the first and last rows respectively were pulled out from there in PHP.

So the logic is unchanged, I'm just pulling it up to this level so we can _also_ trigger eager loading - and only trigger it once. i.e. calling `first()` then `last()` and then iterating over the same list won't trigger multiple db queries.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10876