### PR TITLE
FIX Short-array syntax for Enum

### DIFF
--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -396,13 +396,16 @@ abstract class DBSchemaManager
         // Create custom fields
         if ($fieldSchema) {
             foreach ($fieldSchema as $fieldName => $fieldSpec) {
+                $fieldSpec = $fieldSpec ??= '';
+                // convert Enum short array syntax to long array syntax to make parsing $arrayValue below easier
+                $fieldSpec = preg_replace('/^(enum\()\[(.*?)\]/i', '$1array($2)', $fieldSpec);
                 //Is this an array field?
                 $arrayValue = '';
-                if (strpos($fieldSpec ?? '', '[') !== false) {
+                $pos = strpos($fieldSpec, '[');
+                if ($pos !== false) {
                     //If so, remove it and store that info separately
-                    $pos = strpos($fieldSpec ?? '', '[');
-                    $arrayValue = substr($fieldSpec ?? '', $pos ?? 0);
-                    $fieldSpec = substr($fieldSpec ?? '', 0, $pos);
+                    $arrayValue = substr($fieldSpec, $pos);
+                    $fieldSpec = substr($fieldSpec, 0, $pos);
                 }
 
                 /** @var DBField $fieldObj */

--- a/tests/php/ORM/DBEnumTest.php
+++ b/tests/php/ORM/DBEnumTest.php
@@ -16,25 +16,67 @@ class DBEnumTest extends SapphireTest
 
     protected $usesDatabase = true;
 
-    public function testDefault()
+    /**
+     * @dataProvider provideParse
+     *
+     * nullifyEmpty is an option on DBString, which DBEnum extends
+     * Mainly used for testing that Enum short-array style syntax works while passing in options
+     */
+    public function testParse(?string $expectedDefault, bool $expectedNullifyEmpty, string $spec)
     {
-        /** @var DBEnum $enum1 */
-        $enum1 = DBField::create_field('Enum("A, B, C, D")', null);
-        /** @var DBEnum $enum2 */
-        $enum2 = DBField::create_field('Enum("A, B, C, D", "")', null);
-        /** @var DBEnum $enum3 */
-        $enum3 = DBField::create_field('Enum("A, B, C, D", null)', null);
-        /** @var DBEnum $enum4 */
-        $enum4 = DBField::create_field('Enum("A, B, C, D", 1)', null);
+        /** @var DBEnum $enum */
+        $enum = DBField::create_field($spec, null);
+        $this->assertEquals($expectedDefault, $enum->getDefaultValue());
+        $this->assertEquals($expectedDefault, $enum->getDefault());
+        $this->assertEquals($expectedNullifyEmpty, $enum->getNullifyEmpty());
+    }
 
-        $this->assertEquals('A', $enum1->getDefaultValue());
-        $this->assertEquals('A', $enum1->getDefault());
-        $this->assertEquals(null, $enum2->getDefaultValue());
-        $this->assertEquals(null, $enum2->getDefault());
-        $this->assertEquals(null, $enum3->getDefaultValue());
-        $this->assertEquals(null, $enum3->getDefault());
-        $this->assertEquals('B', $enum4->getDefaultValue());
-        $this->assertEquals('B', $enum4->getDefault());
+    public function provideParse()
+    {
+        return [
+            // standard syntax - double quotes
+            ['A', true, 'Enum("A, B, C, D")'],
+            ['B', true, 'Enum("A, B, C, D", "B")'],
+            ['C', true, 'Enum("A, B, C, D", 2)'],
+            [null, true, 'Enum("A, B, C, D", "")'],
+            [null, true, 'Enum("A, B, C, D", null)'],
+            ['B', false, 'Enum("A, B, C, D", "B", ["nullifyEmpty" => false])'],
+            // standard syntax - single quotes
+            ['A', true, "Enum('A, B, C, D')"],
+            ['B', true, "Enum('A, B, C, D', 'B')"],
+            ['C', true, "Enum('A, B, C, D', 2)"],
+            [null, true, "Enum('A, B, C, D', '')"],
+            [null, true, "Enum('A, B, C, D', null)"],
+            ['B', false, "Enum('A, B, C, D', 'B', ['nullifyEmpty' => false])"],
+            // long array syntax - double quotes
+            ['A', true, 'Enum(array("A", "B", "C", "D"))'],
+            ['B', true, 'Enum(array("A", "B", "C", "D"), "B")'],
+            ['C', true, 'Enum(array("A", "B", "C", "D"), 2)'],
+            [null, true, 'Enum(array("A", "B", "C", "D"), "")'],
+            [null, true, 'Enum(array("A", "B", "C", "D"), null)'],
+            ['B', false, 'Enum(array("A", "B", "C", "D"), "B", ["nullifyEmpty" => false])'],
+            // long array syntax - single quotes
+            ['A', true, "Enum(array('A', 'B', 'C', 'D'))"],
+            ['B', true, "Enum(array('A', 'B', 'C', 'D'), 'B')"],
+            ['C', true, "Enum(array('A', 'B', 'C', 'D'), 2)"],
+            [null, true, "Enum(array('A', 'B', 'C', 'D'), '')"],
+            [null, true, "Enum(array('A', 'B', 'C', 'D'), null)"],
+            ['B', false, "Enum(array('A', 'B', 'C', 'D'), 'B', ['nullifyEmpty' => false])"],
+            // short array syntax - double quotes
+            ['A', true, 'Enum(["A", "B", "C", "D"])'],
+            ['B', true, 'Enum(["A", "B", "C", "D"], "B")'],
+            ['C', true, 'Enum(["A", "B", "C", "D"], 2)'],
+            [null, true, 'Enum(["A", "B", "C", "D"], "")'],
+            [null, true, 'Enum(["A", "B", "C", "D"], null)'],
+            ['B', false, 'Enum(["A", "B", "C", "D"], "B", ["nullifyEmpty" => false])'],
+            // short array syntax - single quotes
+            ['A', true, "Enum(['A', 'B', 'C', 'D'])"],
+            ['B', true, "Enum(['A', 'B', 'C', 'D'], 'B')"],
+            ['C', true, "Enum(['A', 'B', 'C', 'D'], 2)"],
+            [null, true, "Enum(['A', 'B', 'C', 'D'], '')"],
+            [null, true, "Enum(['A', 'B', 'C', 'D'], null)"],
+            ['B', false, "Enum(['A', 'B', 'C', 'D'], 'B', ['nullifyEmpty' => false])"],
+        ];
     }
 
     public function testObsoleteValues()


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10435

Re the just deleting `$arrayValue` as noted in the original issue, it's used for specs such as `HTMLFragment(['whitelist' => ['meta', 'link']])` so we need to retain it