### PR TITLE
FIX Image in summaryfields breaks search

### DIFF
--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -269,7 +269,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
             sort($searchableFields);
             sort($summaryFields);
             // searchable_fields has been explictily defined i.e. searchableFields() is not falling back to summary_fields
-            if ($searchableFields !== $summaryFields) {
+            if (!empty($searchableFields) && ($searchableFields !== $summaryFields)) {
                 return true;
             }
             // we have fallen back to summary_fields, check they are filterable

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -3724,6 +3724,52 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         $this->extend('onAfterBuild');
     }
 
+    private function getDatabaseBackedField(string $fieldPath): ?string
+    {
+        $component = $this;
+        $fieldParts = [];
+        $parts = explode('.', $fieldPath ?? '');
+
+        foreach ($parts as $nextPart) {
+            if (!$component) {
+                return null;
+            }
+            $fieldParts[] = $nextPart;
+            
+            if ($component instanceof Relation || $component instanceof DataList) {
+                if ($component->hasMethod($nextPart)) {
+                    // If the next part is a method, we don't have a database-backed field.
+                    return null;
+                }
+                // The next part could either be a field, or another relation
+                $singleton = DataObject::singleton($component->dataClass());
+                if ($singleton->dbObject($nextPart) instanceof DBField) {
+                    // If the next part is a DBField, we've found the database-backed field.
+                    break;
+                }
+                $component = $component->relation($nextPart);
+                array_shift($parts);
+            } elseif ($component instanceof DataObject && ($component->dbObject($nextPart) instanceof DBField)) {
+                // If the next part is a DBField, we've found the database-backed field.
+                break;
+            } elseif ($component instanceof DataObject && $component->getRelationType($nextPart) !== null) {
+                // If it's a last part or only one elemnt of a relation, we don't have a database-backed field.
+                if (count($parts) === 1) {
+                    return null;
+                }
+                $component = $component->$nextPart();
+                array_shift($parts);
+            } elseif (ClassInfo::hasMethod($component, $nextPart)) {
+                // If the next part is a method, we don't have a database-backed field.
+                return null;
+            } else {
+                return null;
+            }
+        }
+
+        return implode('.', $fieldParts) ?: null;
+    }
+
     /**
      * Get the default searchable fields for this object, as defined in the
      * $searchable_fields list. If searchable fields are not defined on the
@@ -3742,21 +3788,10 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
             $summaryFields = array_keys($this->summaryFields() ?? []);
             $fields = [];
 
-            // remove the custom getters as the search should not include them
-            $schema = static::getSchema();
             if ($summaryFields) {
-                foreach ($summaryFields as $key => $name) {
-                    $spec = $name;
-
-                    // Extract field name in case this is a method called on a field (e.g. "Date.Nice")
-                    if (($fieldPos = strpos($name ?? '', '.')) !== false) {
-                        $name = substr($name ?? '', 0, $fieldPos);
-                    }
-
-                    if ($schema->fieldSpec($this, $name)) {
-                        $fields[] = $name;
-                    } elseif ($this->relObject($spec)) {
-                        $fields[] = $spec;
+                foreach ($summaryFields as $name) {
+                    if ($field = $this->getDatabaseBackedField($name)) {
+                        $fields[] = $field;
                     }
                 }
             }

--- a/tests/php/ORM/DataObjectTest/Player.php
+++ b/tests/php/ORM/DataObjectTest/Player.php
@@ -37,4 +37,9 @@ class Player extends Member implements TestOnly
         'IsRetired',
         'ShirtNumber'
     ];
+
+    public function ReturnsNull()
+    {
+        return null;
+    }
 }

--- a/tests/php/ORM/Search/SearchContextTest.php
+++ b/tests/php/ORM/Search/SearchContextTest.php
@@ -58,13 +58,22 @@ class SearchContextTest extends SapphireTest
         $obj = new SearchContextTest\NoSearchableFields();
         $summaryFields = $obj->summaryFields();
         $expected = [];
-        foreach ($summaryFields as $field => $label) {
+
+        $expectedSearchableFields = [
+            'Name',
+            'Customer.FirstName',
+            'HairColor',
+            'EyeColor',
+        ];
+
+        foreach ($expectedSearchableFields as $field) {
             $expected[$field] = [
                 'title' => $obj->fieldLabel($field),
                 'filter' => 'PartialMatchFilter',
             ];
         }
         $this->assertEquals($expected, $obj->searchableFields());
+        $this->assertNotEquals($summaryFields, $obj->searchableFields());
     }
 
     public function testSummaryIncludesDefaultFieldsIfNotDefined()

--- a/tests/php/ORM/Search/SearchContextTest/NoSearchableFields.php
+++ b/tests/php/ORM/Search/SearchContextTest/NoSearchableFields.php
@@ -4,6 +4,7 @@ namespace SilverStripe\ORM\Tests\Search\SearchContextTest;
 
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Assets\Image;
 
 class NoSearchableFields extends DataObject implements TestOnly
 {
@@ -18,12 +19,34 @@ class NoSearchableFields extends DataObject implements TestOnly
 
     private static $has_one = [
         'Customer' => Customer::class,
+        'Image' => Image::class,
     ];
 
     private static $summary_fields = [
         'Name' => 'Custom Label',
+        'Customer' => 'Customer',
         'Customer.FirstName' => 'Customer',
+        'Image.CMSThumbnail' => 'Image',
+        'Image.BackLinks' => 'Backlinks',
+        'Image.BackLinks.Count' => 'Backlinks',
         'HairColor',
         'EyeColor',
+        'ReturnsNull',
+        'DynamicField'
     ];
+
+    public function MyName()
+    {
+        return 'Class ' . $this->Name;
+    }
+
+    public function getDynamicField()
+    {
+        return 'dynamicfield';
+    }
+
+    public function ReturnsNull()
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
## Description
Fields that pass validation on `hasMethod()` check, but do not have a corresponding field or relations in the DB are excluded from `searchable_fields`.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10761
