### PR TITLE
FIX Use TransportFactory to prevent infinite config loop

### DIFF
--- a/_config/mailer.yml
+++ b/_config/mailer.yml
@@ -11,18 +11,7 @@ SilverStripe\Core\Injector\Injector:
     calls:
       - [addSubscriber, ['%$SilverStripe\Control\Email\MailerSubscriber']]
   Symfony\Component\Mailer\Transport\TransportInterface:
-    factory: Symfony\Component\Mailer\Transport
-    factory_method: fromDsn
+    factory: SilverStripe\Control\Email\TransportFactory
     constructor:
       dsn: 'sendmail://default'
       dispatcher: '%$Symfony\Component\EventDispatcher\EventDispatcherInterface.mailer'
----
-Name: mailer-dsn-env
-After: '*'
-Only:
-  envvarset: MAILER_DSN
----
-SilverStripe\Core\Injector\Injector:
-  Symfony\Component\Mailer\Transport\TransportInterface:
-    constructor:
-      dsn: '`MAILER_DSN`'

--- a/src/Control/Email/TransportFactory.php
+++ b/src/Control/Email/TransportFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SilverStripe\Control\Email;
+
+use SilverStripe\Core\Environment;
+use SilverStripe\Core\Injector\Factory;
+use Symfony\Component\Mailer\Transport;
+
+/**
+ * Creates an email transport from a DSN string
+ * A DSN defined in an environment variable has priority over a DSN defined in yml config file
+ */
+class TransportFactory implements Factory
+{
+    public function create($service, array $params = [])
+    {
+        $dsn = Environment::getEnv('MAILER_DSN') ?: $params['dsn'];
+        $dispatcher = $params['dispatcher'];
+        return Transport::fromDsn($dsn, $dispatcher);
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10888

Existing documentation for setting a DSN via yml config still works - https://docs.silverstripe.org/en/5/developer_guides/email/#email

i.e. 
```yml
SilverStripe\Core\Injector\Injector:
  Symfony\Component\Mailer\Transport\TransportInterface:
    constructor:
      dsn: '<my-dsn>'
```