### PR TITLE
MNT Run ORM tests in parallel to other tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,8 +8,15 @@ Requires PHPUnit ^9
         <testsuite name="Default">
             <directory>tests/php</directory>
         </testsuite>
-        <testsuite name="framework">
+        <!-- Framework ORM tests are split up to run in parallel -->
+        <testsuite name="framework-core">
             <directory>tests/php</directory>
+            <exclude>
+                <directory>tests/php/ORM</directory>
+            </exclude>
+        </testsuite>
+        <testsuite name="framework-orm">
+            <directory>tests/php/ORM</directory>
         </testsuite>
         <testsuite name="cms">
             <directory>vendor/silverstripe/cms/tests</directory>


### PR DESCRIPTION
Note that [the CI run for this PR](https://github.com/silverstripe/silverstripe-framework/actions/runs/5757426723) was ~5 minutes (~30%) faster than the [last CI run on the 4.13 branch](https://github.com/silverstripe/silverstripe-framework/actions/runs/5746191915)

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10900