### PR TITLE
FIX Multi HTML entities in short codes

### DIFF
--- a/src/Forms/HTMLEditor/HTMLEditorField.php
+++ b/src/Forms/HTMLEditor/HTMLEditorField.php
@@ -190,4 +190,14 @@ class HTMLEditorField extends TextareaField
         $stateDefaults['data'] = $config->getConfigSchemaData();
         return $stateDefaults;
     }
+
+    /**
+     * Return value with all values encoded in html entities
+     *
+     * @return string Raw HTML
+     */
+    public function ValueEntities()
+    {
+        return htmlentities($this->Value() ?? '', ENT_COMPAT, 'UTF-8', false);
+    }
 }

--- a/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
@@ -208,4 +208,25 @@ EOS
             $readonlyContent->getValue()
         );
     }
+
+    public function testValueEntities()
+    {
+        $inputText = "The company &amp; partners";
+        $field = new HTMLEditorField("Content");
+        $field->setValue($inputText);
+
+        $this->assertEquals(
+            "The company &amp; partners",
+            $field->obj('ValueEntities')->forTemplate()
+        );
+
+        $inputText = "The company &amp;&amp; partners";
+        $field = new HTMLEditorField("Content");
+        $field->setValue($inputText);
+
+        $this->assertEquals(
+            "The company &amp;&amp; partners",
+            $field->obj('ValueEntities')->forTemplate()
+        );
+    }
 }


### PR DESCRIPTION
## Description
- Turn off double_encode for special characters in TextareaField.
## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10451