### PR TITLE
ENH Do not use placeholders by default for foreignIDFilter()

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -38,6 +38,11 @@ use SilverStripe\ORM\ArrayList;
  */
 class DataList extends ViewableData implements SS_List, Filterable, Sortable, Limitable
 {
+    /**
+     * Whether to use placeholders for integer IDs on Primary and Foriegn keys during a WHERE IN query
+     * It is significantly faster to not use placeholders
+     */
+    private static bool $use_placeholders_for_integer_ids = false;
 
     /**
      * The DataObject class name that this data list is querying

--- a/src/ORM/Filters/ExactMatchFilter.php
+++ b/src/ORM/Filters/ExactMatchFilter.php
@@ -4,11 +4,11 @@ namespace SilverStripe\ORM\Filters;
 
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\DB;
-use SilverStripe\Core\Config\Configurable;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\FieldType\DBPrimaryKey;
 use SilverStripe\ORM\FieldType\DBForeignKey;
+use SilverStripe\ORM\DataList;
 
 /**
  * Selects textual content with an exact match between columnname and keyword.
@@ -18,9 +18,6 @@ use SilverStripe\ORM\FieldType\DBForeignKey;
  */
 class ExactMatchFilter extends SearchFilter
 {
-    use Configurable;
-
-    private static bool $use_placeholders_for_integer_ids = false;
 
     public function getSupportedModifiers()
     {
@@ -229,12 +226,12 @@ class ExactMatchFilter extends SearchFilter
      * - The values being filtered are all either integers or valid integer strings
      * - Using placeholders for integer ids has been configured off
      *
-     * Putting IDs directly into a where clause instead of using placehodlers was measured to be significantly
+     * Putting IDs directly into a where clause instead of using placeholders was measured to be significantly
      * faster when querying a large number of IDs e.g. over 1000
      */
     private function usePlaceholders(string $column, array $values): bool
     {
-        if ($this->config()->get('use_placeholders_for_integer_ids')) {
+        if (DataList::config()->get('use_placeholders_for_integer_ids')) {
             return true;
         }
         // Ensure that the $column was created in the "Table"."Column" format

--- a/src/ORM/HasManyList.php
+++ b/src/ORM/HasManyList.php
@@ -50,11 +50,12 @@ class HasManyList extends RelationList
         if ($id === null) {
             $id = $this->getForeignID();
         }
-
         // Apply relation filter
         $key = DataObject::getSchema()->sqlColumnForField($this->dataClass(), $this->getForeignKey());
         if (is_array($id)) {
-            return ["$key IN (" . DB::placeholders($id) . ")"  => $id];
+            $in = $this->prepareForeignIDsForWhereInClause($id);
+            $vals = str_contains($in, '?') ? $id : [];
+            return ["$key IN ($in)" => $vals];
         }
         if ($id !== null) {
             return [$key => $id];

--- a/src/ORM/ManyManyList.php
+++ b/src/ORM/ManyManyList.php
@@ -177,7 +177,9 @@ class ManyManyList extends RelationList
         // Apply relation filter
         $key = "\"{$this->joinTable}\".\"{$this->foreignKey}\"";
         if (is_array($id)) {
-            return ["$key IN (" . DB::placeholders($id) . ")"  => $id];
+            $in = $this->prepareForeignIDsForWhereInClause($id);
+            $vals = str_contains($in, '?') ? $id : [];
+            return ["$key IN ($in)" => $vals];
         }
         if ($id !== null) {
             return [$key => $id];

--- a/src/Security/Member_GroupSet.php
+++ b/src/Security/Member_GroupSet.php
@@ -54,8 +54,9 @@ class Member_GroupSet extends ManyManyList
 
         // Add a filter to this DataList
         if (!empty($allGroupIDs)) {
-            $allGroupIDsPlaceholders = DB::placeholders($allGroupIDs);
-            return ["\"Group\".\"ID\" IN ($allGroupIDsPlaceholders)" => $allGroupIDs];
+            $in = $this->prepareForeignIDsForWhereInClause($allGroupIDs);
+            $vals = str_contains($in, '?') ? $allGroupIDs : [];
+            return ["\"Group\".\"ID\" IN ($in)" => $vals];
         }
 
         return ['"Group"."ID"' => 0];

--- a/tests/php/ORM/Filters/ExactMatchFilterTest.php
+++ b/tests/php/ORM/Filters/ExactMatchFilterTest.php
@@ -7,6 +7,7 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\Filters\ExactMatchFilter;
 use SilverStripe\ORM\Tests\Filters\ExactMatchFilterTest\Task;
 use SilverStripe\ORM\Tests\Filters\ExactMatchFilterTest\Project;
+use SilverStripe\ORM\DataList;
 
 class ExactMatchFilterTest extends SapphireTest
 {
@@ -22,7 +23,7 @@ class ExactMatchFilterTest extends SapphireTest
      */
     public function testUsePlaceholders(?bool $expectedID, ?bool $expectedTitle, bool $config, callable $fn): void
     {
-        Config::modify()->set(ExactMatchFilter::class, 'use_placeholders_for_integer_ids', $config);
+        Config::modify()->set(DataList::class, 'use_placeholders_for_integer_ids', $config);
         [$idQueryUsesPlaceholders, $titleQueryUsesPlaceholders] = $this->usesPlaceholders($fn);
         $this->assertSame($expectedID, $idQueryUsesPlaceholders);
         $this->assertSame($expectedTitle, $titleQueryUsesPlaceholders);

--- a/tests/php/Security/Member_GroupSetTest.php
+++ b/tests/php/Security/Member_GroupSetTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SilverStripe\Security\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Security\Tests\GroupTest\TestMember;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\ORM\DataList;
+
+class Member_GroupSetTest extends SapphireTest
+{
+    protected static $fixture_file = 'GroupTest.yml';
+
+    protected static $extra_dataobjects = [
+        TestMember::class
+    ];
+
+    /**
+     * @dataProvider provideForForeignIDPlaceholders
+     */
+    public function testForForeignIDPlaceholders(bool $config, bool $useInt, bool $expected): void
+    {
+        Config::modify()->set(DataList::class, 'use_placeholders_for_integer_ids', $config);
+        $member1 = $this->objFromFixture(TestMember::class, 'parentgroupuser');
+        $member2 = $this->objFromFixture(TestMember::class, 'allgroupuser');
+        $groups1 = $member1->Groups();
+        $groups2 = $member2->Groups();
+        $ids = $useInt ? [$member1->ID, $member2->ID] : ['Lorem', 'Ipsum'];
+        $newGroupList = $groups1->forForeignID($ids);
+        $sql = $newGroupList->dataQuery()->sql();
+        preg_match('#ID" IN \(([^\)]+)\)\)#', $sql, $matches);
+        $usesPlaceholders = ($matches[1] ?? '') === '?, ?, ?, ?, ?' || str_contains($sql, '"Group"."ID" = ?');
+        $this->assertSame($expected, $usesPlaceholders);
+        $expectedIDs = $useInt
+            ? array_unique(array_merge($groups1->column('ID'), $groups2->column('ID')))
+            : [];
+        $this->assertEqualsCanonicalizing($expectedIDs, $newGroupList->column('ID'));
+    }
+
+    public function provideForForeignIDPlaceholders(): array
+    {
+        return [
+            'config false' => [
+                'config' => false,
+                'useInt' => true,
+                'expected' => false,
+            ],
+            'config false non-int' => [
+                'config' => false,
+                'useInt' => false,
+                'expected' => true,
+            ],
+            'config true' => [
+                'config' => true,
+                'useInt' => true,
+                'expected' => true,
+            ],
+            'config true non-int' => [
+                'config' => true,
+                'useInt' => false,
+                'expected' => true,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10887

## Performance tests:

10,000 records

I didn't test `Member_GroupSet` due to not wanting to truncate my `Member` and `Group` tables, though it's logical to expect that there would be performance gain since there was clearly a gain for all the others lists

### HasManyList

**placeholders on - avg 0.3304s**
0.3144
0.3712
0.3279
0.3091
0.3295

**placeholders off - avg 0.1584s**
0.1558
0.1545
0.1551
0.1634
0.1632
 
### ManyManyList

**placeholders on - avg 0.3119s**
0.3105
0.3118
0.3066
0.3130
0.3178

**placeholders off - avg 0.1529s**
0.1511
0.1478
0.1563
0.1565
0.1526

### ManyManyThroughList

**placeholders on - avg 0.8766s**
0.9052
0.8893
0.8608
0.8687
0.8588

**placeholders off - avg 0.6901s**
0.6974
0.6993
0.6881
0.6811
0.6844

## Test setup:

**MyDataObject.php**
```php
<?php

use SilverStripe\ORM\DataObject;

class MyDataObject extends DataObject
{
    private static $table_name = 'MyDataObject';

    private static $db = [
        'Title' => 'Varchar'
    ];

    private static $has_many = [
        'MySubDataObjects' => MySubDataObject::class
    ];

    private static $many_many = [
        'MyManyDataObjects' => MyManyDataObject::class,
        'MyManyThroughDataObjects' => MyManyThroughDataObject::class
    ];
}
```

**MySubDataObject.php**
```php
<?php

use SilverStripe\ORM\DataObject;

class MySubDataObject extends DataObject
{
    private static $table_name = 'MySubDataObject';

    private static $db = [
        'Title' => 'Varchar'
    ];

    private static $has_one = [
        'MyDataObject' => MyDataObject::class
    ];
}
```

**MyManyDataObject.php**
```php
<?php

use SilverStripe\ORM\DataObject;

class MyManyDataObject extends DataObject
{
    private static $table_name = 'MyManyDataObject';

    private static $db = [
        'Title' => 'Varchar'
    ];

    private static $belongs_many_many = [
        'MyDataObject' => MyDataObject::class
    ];
}
```

**MyManyThroughDataObject.php**
```php
<?php

use SilverStripe\ORM\DataObject;

class MyManyThroughDataObject extends DataObject
{
    private static $table_name = 'MyManyThroughDataObject';

    private static $db = [
        'Title' => 'Varchar'
    ];
}
```

**MyThroughDataObject.php**
```php
<?php

use SilverStripe\ORM\DataObject;

class MyThroughDataObject extends DataObject
{
    private static $table_name = 'MyThroughDataObject';

    private static $has_one = [
        'MyDataObject' => MyDataObject::class,
        'MyManyThroughDataObject' => MyManyThroughDataObject::class,
    ];
}
```

**PageController.php**
```php
<?php

use SilverStripe\Core\Config\Config;
use SilverStripe\Versioned\Versioned;
use SilverStripe\ORM\DB;
use SilverStripe\CMS\Controllers\ContentController;
use SilverStripe\ORM\DataList;

class PageController extends ContentController
{
    protected function init()
    {
        parent::init();
        //
        DB::query('truncate MyDataObject');
        DB::query('truncate MySubDataObject');
        DB::query('truncate MyManyDataObject');
        DB::query('truncate MyDataObject_MyManyDataObjects');
        DB::query('truncate MyManyThroughDataObject');
        DB::query('truncate MyThroughDataObject');
        $a = [];
        $b = [];
        $c = [];
        $d = [];
        $e = [];
        $f = [];
        for ($i = 1; $i <= 10000; $i++) {
            $a[] = "('Title $i')";
            $b[] = "('$i', 'Title $i')";
            $c[] = "('Title $i')";
            $d[] = "('$i', '$i')";
            $e[] = "('Title $i')";
            $f[] = "('$i', '$i')";
        }
        $as = implode(',', $a);
        $bs = implode(',', $b);
        $cs = implode(',', $c);
        $ds = implode(',', $d);
        $es = implode(',', $e);
        $fs = implode(',', $f);
        DB::query("insert into MyDataObject (Title) values $as");
        DB::query("insert into MySubDataObject (MyDataObjectID, Title) values $bs");
        DB::query("insert into MyManyDataObject (Title) values $cs");
        DB::query("insert into MyDataObject_MyManyDataObjects (MyDataObjectID, MyManyDataObjectID) values $ds");
        DB::query("insert into MyManyThroughDataObject (Title) values $es");
        DB::query("insert into MyThroughDataObject (MyDataObjectID, MyManyThroughDataObjectID) values $fs");
        //
        Versioned::set_reading_mode('Stage.Stage');
        $ids = MyDataObject::get()->column('ID');

        Config::modify()->set(DataList::class, 'use_placeholders_for_integer_ids', false);
        // $list = MyDataObject::get()->first()->MySubDataObjects();
        // $list = MyDataObject::get()->first()->MyManyDataObjects();
        $list = MyDataObject::get()->first()->MyManyThroughDataObjects();

        $s = microtime(true);
        $newList = $list->forForeignID($ids);
        $newList->toArray();
        $t = microtime(true) - $s;
        printf('%0.4f', $t);
        echo "<br>";
        $sql = $newList->dataQuery()->sql();
        echo $sql;
        die;
    }
}
```