### PR TITLE
FIX Allow subclasses of ManyMany lists in EagerLoadedList

### DIFF
--- a/src/ORM/EagerLoadedList.php
+++ b/src/ORM/EagerLoadedList.php
@@ -889,7 +889,7 @@ class EagerLoadedList extends ViewableData implements Relation, SS_List, Filtera
      */
     public function getExtraData($componentName, int|string $itemID): array
     {
-        if (!in_array(get_class($this->dataList), [ManyManyList::class, ManyManyThroughList::class])) {
+        if (!($this->dataList instanceof ManyManyList) && !($this->dataList instanceof ManyManyThroughList)) {
             throw new BadMethodCallException('Cannot have extra fields on this list type');
         }
 
@@ -926,7 +926,7 @@ class EagerLoadedList extends ViewableData implements Relation, SS_List, Filtera
      */
     public function getExtraFields(): array
     {
-        if (!in_array(get_class($this->dataList), [ManyManyList::class, ManyManyThroughList::class])) {
+        if (!($this->dataList instanceof ManyManyList) && !($this->dataList instanceof ManyManyThroughList)) {
             throw new BadMethodCallException('Cannot have extra fields on this list type');
         }
         return $this->extraFields;


### PR DESCRIPTION
Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/5786715302/job/15693254741
>  1) SilverStripe\ORM\Tests\EagerLoadedListTest::testGetExtraDataBadID
Failed asserting that exception of type "BadMethodCallException" matches expected exception "InvalidArgumentException". Message was: "Cannot have extra fields on this list type"

This failed because `silverstripe/auditor` module injects `AuditHookManyManyList` in place of `ManyManyList`.

## Issue
- https://github.com/silverstripe/.github/issues/87