### PR TITLE
MNT Don't change auto-increment for non mysql database in test

### DIFF
--- a/tests/php/ORM/DataListEagerLoadingTest.php
+++ b/tests/php/ORM/DataListEagerLoadingTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\ORM\Tests;
 use InvalidArgumentException;
 use LogicException;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\Connect\MySQLDatabase;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
@@ -78,6 +79,15 @@ class DataListEagerLoadingTest extends SapphireTest
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
+
+        // The AUTO_INCREMENT functionality isn't abstracted, and doesn't work with the same syntax in
+        // other database drivers. But for other drivers we don't care so much if there are overlapping
+        // IDs because avoiding them is only required to test the PHP logic, not the database driver
+        // compatibility.
+        if (!(DB::get_conn() instanceof MySQLDatabase)) {
+            return;
+        }
+
         // Set non-zero auto increment offset for each object type so we don't end up with the same IDs across
         // the board. If all of the IDs are 0, 1, 2 then we have no way of knowing if we're accidentally mixing
         // up relation ID lists between different relation lists for different classes.


### PR DESCRIPTION
Resolves failing CI builds for postgresql and sqlite3 which are caused by using `ALTER TABLE {table} AUTO_INCREMENT` where those database types don't support this syntax.

Note that if they fail or error on additional tests related to eager loading, that is out of scope for this PR, which aims to just get CI running again. Any failures beyond that are up to the community to resolve.

## Issue
- https://github.com/silverstripe/.github/issues/87