### PR TITLE
NEW Enable ArrayList and EagerLoadedList to use search filters

### DIFF
--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -5,7 +5,11 @@ namespace SilverStripe\ORM;
 use ArrayIterator;
 use InvalidArgumentException;
 use LogicException;
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\Debug;
+use SilverStripe\ORM\Filters\SearchFilter;
+use SilverStripe\ORM\Filters\UsesSearchFilters;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\ViewableData;
 use Traversable;
@@ -26,6 +30,7 @@ use Traversable;
  */
 class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, Limitable
 {
+    use UsesSearchFilters;
 
     /**
      * Holds the items in the list
@@ -369,23 +374,6 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     }
 
     /**
-     * Find the first item of this list where the given key = value
-     *
-     * @param string $key
-     * @param string $value
-     * @return mixed
-     */
-    public function find($key, $value)
-    {
-        foreach ($this->items as $item) {
-            if ($this->extractValue($item, $key) == $value) {
-                return $item;
-            }
-        }
-        return null;
-    }
-
-    /**
      * Returns an array of a single field value for all items in the list.
      *
      * @param string $colName
@@ -587,6 +575,18 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     }
 
     /**
+     * Find the first item of this list where the given key = value
+     *
+     * @param string $key
+     * @param string $value
+     * @return mixed
+     */
+    public function find($key, $value)
+    {
+        return $this->filter($key, $value)->first();
+    }
+
+    /**
      * Filter the list to include items with these characteristics
      *
      * @return ArrayList
@@ -597,31 +597,15 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @example $list->filter(array('Name'=>'bob, 'Age'=>array(21, 43))); // bob with the Age 21 or 43
      * @example $list->filter(array('Name'=>array('aziz','bob'), 'Age'=>array(21, 43)));
      *          // aziz with the age 21 or 43 and bob with the Age 21 or 43
+     *
+     * Also supports SearchFilter syntax
+     * @example // include anyone with "sam" anywhere in their name
+     *          $list = $list->filter('Name:PartialMatch', 'sam');
      */
     public function filter()
     {
-
-        $keepUs = call_user_func_array([$this, 'normaliseFilterArgs'], func_get_args());
-
-        $itemsToKeep = [];
-        foreach ($this->items as $item) {
-            $keepItem = true;
-            foreach ($keepUs as $column => $value) {
-                if ((is_array($value) && !in_array($this->extractValue($item, $column), $value ?? []))
-                    || (!is_array($value) && $this->extractValue($item, $column) != $value)
-                ) {
-                    $keepItem = false;
-                    break;
-                }
-            }
-            if ($keepItem) {
-                $itemsToKeep[] = $item;
-            }
-        }
-
-        $list = clone $this;
-        $list->items = $itemsToKeep;
-        return $list;
+        $filters = call_user_func_array([$this, 'normaliseFilterArgs'], func_get_args());
+        return $this->filterOrExclude($filters);
     }
 
     /**
@@ -638,28 +622,102 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
      * @example // all bobs, phils or anyone aged 21 or 43 in the list
      *          $list = $list->filterAny(array('Name'=>array('bob','phil'), 'Age'=>array(21, 43)));
      *
+     * Also supports SearchFilter syntax
+     * @example // include anyone with "sam" anywhere in their name
+     *          $list = $list->filterAny('Name:PartialMatch', 'sam');
+     *
      * @param string|array See {@link filter()}
      * @return static
      */
     public function filterAny()
     {
-        $keepUs = $this->normaliseFilterArgs(...func_get_args());
+        $filters = call_user_func_array([$this, 'normaliseFilterArgs'], func_get_args());
+        return $this->filterOrExclude($filters, true, true);
+    }
 
+    /**
+     * Exclude the list to not contain items with these characteristics
+     *
+     * @return ArrayList
+     * @see SS_List::exclude()
+     * @example $list->exclude('Name', 'bob'); // exclude bob from list
+     * @example $list->exclude('Name', array('aziz', 'bob'); // exclude aziz and bob from list
+     * @example $list->exclude(array('Name'=>'bob, 'Age'=>21)); // exclude bob that has Age 21
+     * @example $list->exclude(array('Name'=>'bob, 'Age'=>array(21, 43))); // exclude bob with Age 21 or 43
+     * @example $list->exclude(array('Name'=>array('bob','phil'), 'Age'=>array(21, 43)));
+     *          // bob age 21 or 43, phil age 21 or 43 would be excluded
+     *
+     * Also supports SearchFilter syntax
+     * @example // everyone except anyone with "sam" anywhere in their name
+     *          $list = $list->exclude('Name:PartialMatch', 'sam');
+     */
+    public function exclude()
+    {
+        $filters = call_user_func_array([$this, 'normaliseFilterArgs'], func_get_args());
+        return $this->filterOrExclude($filters, false);
+    }
+
+    /**
+     * Return a copy of the list excluding any items that have any of these characteristics
+     *
+     * @example // everyone except bob in the list
+     *          $list = $list->excludeAny('Name', 'bob');
+     * @example // everyone except azis or bob in the list
+     *          $list = $list->excludeAny('Name', array('aziz', 'bob');
+     * @example // everyone except bob or anyone aged 21 in the list
+     *          $list = $list->excludeAny(array('Name'=>'bob, 'Age'=>21));
+     * @example // everyone except bob or anyone aged 21 or 43 in the list
+     *          $list = $list->excludeAny(array('Name'=>'bob, 'Age'=>array(21, 43)));
+     * @example // everyone except all bobs, phils or anyone aged 21 or 43 in the list
+     *          $list = $list->excludeAny(array('Name'=>array('bob','phil'), 'Age'=>array(21, 43)));
+     *
+     * Also supports SearchFilter syntax
+     * @example // everyone except anyone with "sam" anywhere in their name
+     *          $list = $list->excludeAny('Name:PartialMatch', 'sam');
+     *
+     * @param string|array See {@link filter()}
+     */
+    public function excludeAny(): static
+    {
+        $filters = call_user_func_array([$this, 'normaliseFilterArgs'], func_get_args());
+        return $this->filterOrExclude($filters, false, true);
+    }
+
+    /**
+     * Apply the appropriate filtering or excluding
+     */
+    protected function filterOrExclude(array $filters, bool $inclusive = true, bool $any = false): static
+    {
         $itemsToKeep = [];
+        $searchFilters = [];
+
+        foreach ($filters as $filterKey => $filterValue) {
+            $searchFilters[$filterKey] = $this->createSearchFilter($filterKey, $filterValue);
+        }
 
         foreach ($this->items as $item) {
-            foreach ($keepUs as $column => $value) {
-                $extractedValue = $this->extractValue($item, $column);
-                $matches = is_array($value) ? in_array($extractedValue, $value) : $extractedValue == $value;
-                if ($matches) {
-                    $itemsToKeep[] = $item;
+            $matches = [];
+            foreach ($filters as $filterKey => $filterValue) {
+                /** @var SearchFilter $searchFilter */
+                $searchFilter = $searchFilters[$filterKey];
+                $hasMatch = $searchFilter->matches($this->extractValue($item, $searchFilter->getFullName()));
+                $matches[$hasMatch] = 1;
+                // If this is excludeAny or filterAny and we have a match, we can stop looking for matches.
+                if ($any && $hasMatch) {
                     break;
                 }
+            }
+            // filterAny or excludeAny allow any true value to be a match; filter or exclude require any false value
+            // to be a mismatch.
+            $isMatch = $any ? isset($matches[true]) : !isset($matches[false]);
+            // If inclusive (filter) and we have a match, or exclusive (exclude) and there is NO match, keep the item.
+            if (($inclusive && $isMatch) || (!$inclusive && !$isMatch)) {
+                $itemsToKeep[] = $item;
             }
         }
 
         $list = clone $this;
-        $list->items = array_unique($itemsToKeep ?? [], SORT_REGULAR);
+        $list->items = $itemsToKeep;
         return $list;
     }
 
@@ -745,48 +803,6 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
         }
 
         return $output;
-    }
-
-    /**
-     * Exclude the list to not contain items with these characteristics
-     *
-     * @return ArrayList
-     * @see SS_List::exclude()
-     * @example $list->exclude('Name', 'bob'); // exclude bob from list
-     * @example $list->exclude('Name', array('aziz', 'bob'); // exclude aziz and bob from list
-     * @example $list->exclude(array('Name'=>'bob, 'Age'=>21)); // exclude bob that has Age 21
-     * @example $list->exclude(array('Name'=>'bob, 'Age'=>array(21, 43))); // exclude bob with Age 21 or 43
-     * @example $list->exclude(array('Name'=>array('bob','phil'), 'Age'=>array(21, 43)));
-     *          // bob age 21 or 43, phil age 21 or 43 would be excluded
-     */
-    public function exclude()
-    {
-        $removeUs = $this->normaliseFilterArgs(...func_get_args());
-
-        $hitsRequiredToRemove = count($removeUs ?? []);
-        $matches = [];
-        foreach ($removeUs as $column => $excludeValue) {
-            foreach ($this->items as $key => $item) {
-                if (!is_array($excludeValue) && $this->extractValue($item, $column) == $excludeValue) {
-                    $matches[$key] = isset($matches[$key]) ? $matches[$key] + 1 : 1;
-                } elseif (is_array($excludeValue) && in_array($this->extractValue($item, $column), $excludeValue ?? [])) {
-                    $matches[$key] = isset($matches[$key]) ? $matches[$key] + 1 : 1;
-                }
-            }
-        }
-
-        $keysToRemove = array_keys($matches ?? [], $hitsRequiredToRemove);
-
-        $itemsToKeep = [];
-        foreach ($this->items as $key => $value) {
-            if (!in_array($key, $keysToRemove ?? [])) {
-                $itemsToKeep[] = $value;
-            }
-        }
-
-        $list = clone $this;
-        $list->items = $itemsToKeep;
-        return $list;
     }
 
     protected function shouldExclude($item, $args)

--- a/src/ORM/EagerLoadedList.php
+++ b/src/ORM/EagerLoadedList.php
@@ -9,6 +9,7 @@ use SilverStripe\ORM\FieldType\DBField;
 use BadMethodCallException;
 use InvalidArgumentException;
 use LogicException;
+use SilverStripe\ORM\Filters\UsesSearchFilters;
 use Traversable;
 
 /**
@@ -23,6 +24,8 @@ use Traversable;
  */
 class EagerLoadedList extends ViewableData implements Relation, SS_List, Filterable, Sortable, Limitable
 {
+    use UsesSearchFilters;
+
     /**
      * List responsible for instantiating the actual DataObject objects from eager-loaded data
      */
@@ -545,9 +548,9 @@ class EagerLoadedList extends ViewableData implements Relation, SS_List, Filtera
                 throw new InvalidArgumentException("Incorrect number of arguments passed to $function");
         }
         foreach (array_keys($filter) as $column) {
-            if (!$this->canFilterBy($column)) {
-                throw new InvalidArgumentException("Can't filter by column '$column'");
-            }
+            // if (!$this->canFilterBy($column)) {
+            //     throw new InvalidArgumentException("Can't filter by column '$column'");
+            // }
         }
 
         return $filter;
@@ -561,12 +564,25 @@ class EagerLoadedList extends ViewableData implements Relation, SS_List, Filtera
     private function getMatches($filters, bool $any = false): array
     {
         $matches = [];
+        $searchFilters = [];
+
+        foreach ($filters as $filterKey => $filterValue) {
+            $searchFilters[$filterKey] = $this->createSearchFilter($filterKey, $filterValue);
+        }
+
         foreach ($this->rows as $id => $row) {
             $doesMatch = true;
             foreach ($filters as $column => $value) {
-                $extractedValue = $this->extractValue($row, $this->standardiseColumn($column));
-                $strict = $value === null || $extractedValue === null;
-                $doesMatch = $this->doesMatch($column, $value, $extractedValue, $strict);
+                // Throw exception for empty $value arrays to match ExactMatchFilter::manyFilter
+                if (is_array($value)) {
+                    if (empty($value)) {
+                        throw new InvalidArgumentException("Cannot filter $column against an empty set");
+                    }
+                }
+                /** @var SearchFilter $searchFilter */
+                $searchFilter = $searchFilters[$column];
+                $extractedValue = $this->extractValue($row, $this->standardiseColumn($searchFilter->getFullName()));
+                $doesMatch = $searchFilter->matches($extractedValue);
                 if (!$any && !$doesMatch) {
                     $doesMatch = false;
                     break;
@@ -580,23 +596,6 @@ class EagerLoadedList extends ViewableData implements Relation, SS_List, Filtera
             }
         }
         return $matches;
-    }
-
-    private function doesMatch(string $field, mixed $value1, mixed $value2, bool $strict): bool
-    {
-        if (is_array($value1)) {
-            if (empty($value1)) {
-                // mimics ExactMatchFilter::manyFilter
-                throw new InvalidArgumentException("Cannot filter $field against an empty set");
-            }
-            return in_array($value2, $value1, $strict);
-        }
-
-        if ($strict) {
-            return $value1 === $value2;
-        }
-
-        return $value1 == $value2;
     }
 
     /**

--- a/src/ORM/Filters/ComparisonFilter.php
+++ b/src/ORM/Filters/ComparisonFilter.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\ORM\Filters;
 
+use BadMethodCallException;
 use SilverStripe\ORM\DataQuery;
 
 /**
@@ -31,6 +32,68 @@ abstract class ComparisonFilter extends SearchFilter
      * @return string Inverse operator
      */
     abstract protected function getInverseOperator();
+
+    public function matches(mixed $toMatch): bool
+    {
+        // Match how MySQL handles null
+        if ($toMatch === null) {
+            return false;
+        }
+
+        $negated = in_array('not', $this->getModifiers());
+        $fieldMatches = false;
+
+        // can't just cast to array, because that will convert null into an empty array
+        $values = $this->getValue();
+        if (!is_array($values)) {
+            $values = [$values];
+        }
+
+        foreach ($values as $value) {
+            // Match how MySQL compares against null filters
+            if ($value === null) {
+                if ($this->isNumericNotString($toMatch)) {
+                    $value = 0;
+                } else {
+                    // Nothing else matches a null value, even when negated
+                    continue;
+                }
+            }
+            // Match how MySQL compares native numbers with strings
+            if ($this->isNumericNotString($value) && is_string($toMatch)) {
+                $toMatch = $this->coerceStringToNumber($toMatch);
+            }
+            if ($this->isNumericNotString($toMatch) && is_string($value)) {
+                $value = $this->coerceStringToNumber($value);
+            }
+            // Match how MySQL compares ints with floats
+            if (is_int($toMatch) && is_float($value)) {
+                $value = (int) $value;
+            }
+
+            $doesMatch = $this->match($toMatch, $value);
+
+            // Respect "not" modifier.
+            if ($negated) {
+                $doesMatch = !$doesMatch;
+            }
+            // If any value matches, then we consider the field to have matched.
+            if ($doesMatch) {
+                $fieldMatches = true;
+                break;
+            }
+        }
+
+        return $fieldMatches;
+    }
+
+    protected function match(int|float|string|null $objectValue, int|float|string|null $filterValue): bool
+    {
+        // We can't add an abstract method but we want to enforce the method signature for any subclasses
+        // which do implement this - therefore, throw an exception by default.
+        $actualClass = get_class($this);
+        throw new BadMethodCallException("matches is not implemented on $actualClass");
+    }
 
     /**
      * Applies a comparison filter to the query

--- a/src/ORM/Filters/EndsWithFilter.php
+++ b/src/ORM/Filters/EndsWithFilter.php
@@ -13,6 +13,7 @@ namespace SilverStripe\ORM\Filters;
  */
 class EndsWithFilter extends PartialMatchFilter
 {
+    protected static $matchesEndsWith = true;
 
     protected function getMatchPattern($value)
     {

--- a/src/ORM/Filters/GreaterThanFilter.php
+++ b/src/ORM/Filters/GreaterThanFilter.php
@@ -10,6 +10,21 @@ namespace SilverStripe\ORM\Filters;
  */
 class GreaterThanFilter extends ComparisonFilter
 {
+    protected function match(int|float|string|null $objectValue, int|float|string|null $filterValue): bool
+    {
+        if ($this->isNumericNotString($filterValue) && !is_numeric($objectValue)) {
+            return false;
+        }
+
+        // Match how MySQL compares against non-string numeric values
+        if ($this->isNumericNotString($objectValue) && $this->isNumericNotString($filterValue)) {
+            return $objectValue > $filterValue;
+        }
+
+        // Match how MySQL compares strings and numeric strings
+        $compared = strcasecmp($objectValue ?? '', $filterValue ?? '');
+        return $compared > 0;
+    }
 
     protected function getOperator()
     {

--- a/src/ORM/Filters/GreaterThanOrEqualFilter.php
+++ b/src/ORM/Filters/GreaterThanOrEqualFilter.php
@@ -10,6 +10,21 @@ namespace SilverStripe\ORM\Filters;
  */
 class GreaterThanOrEqualFilter extends ComparisonFilter
 {
+    protected function match(int|float|string|null $objectValue, int|float|string|null $filterValue): bool
+    {
+        if ($this->isNumericNotString($filterValue) && !is_numeric($objectValue)) {
+            return false;
+        }
+
+        // Match how MySQL compares against non-string numeric values
+        if ($this->isNumericNotString($objectValue) && $this->isNumericNotString($filterValue)) {
+            return $objectValue >= $filterValue;
+        }
+
+        // Match how MySQL compares strings and numeric strings
+        $compared = strcasecmp($objectValue ?? '', $filterValue ?? '');
+        return $compared >= 0;
+    }
 
     protected function getOperator()
     {

--- a/src/ORM/Filters/LessThanFilter.php
+++ b/src/ORM/Filters/LessThanFilter.php
@@ -10,6 +10,21 @@ namespace SilverStripe\ORM\Filters;
  */
 class LessThanFilter extends ComparisonFilter
 {
+    protected function match(int|float|string|null $objectValue, int|float|string|null $filterValue): bool
+    {
+        if ($this->isNumericNotString($filterValue) && !is_numeric($objectValue)) {
+            return true;
+        }
+
+        // Match how MySQL compares against non-string numeric values
+        if ($this->isNumericNotString($objectValue) && $this->isNumericNotString($filterValue)) {
+            return $objectValue < $filterValue;
+        }
+
+        // Match how MySQL compares strings and numeric strings
+        $compared = strcasecmp($objectValue ?? '', $filterValue ?? '');
+        return $compared < 0;
+    }
 
     protected function getOperator()
     {

--- a/src/ORM/Filters/LessThanOrEqualFilter.php
+++ b/src/ORM/Filters/LessThanOrEqualFilter.php
@@ -10,6 +10,21 @@ namespace SilverStripe\ORM\Filters;
  */
 class LessThanOrEqualFilter extends ComparisonFilter
 {
+    protected function match(int|float|string|null $objectValue, int|float|string|null $filterValue): bool
+    {
+        if ($this->isNumericNotString($filterValue) && !is_numeric($objectValue)) {
+            return true;
+        }
+
+        // Match how MySQL compares against non-string numeric values
+        if ($this->isNumericNotString($objectValue) && $this->isNumericNotString($filterValue)) {
+            return $objectValue <= $filterValue;
+        }
+
+        // Match how MySQL compares strings and numeric strings
+        $compared = strcasecmp($objectValue ?? '', $filterValue ?? '');
+        return $compared <= 0;
+    }
 
     protected function getOperator()
     {

--- a/src/ORM/Filters/StartsWithFilter.php
+++ b/src/ORM/Filters/StartsWithFilter.php
@@ -13,6 +13,7 @@ namespace SilverStripe\ORM\Filters;
  */
 class StartsWithFilter extends PartialMatchFilter
 {
+    protected static $matchesStartsWith = true;
 
     protected function getMatchPattern($value)
     {

--- a/src/ORM/Filters/UsesSearchFilters.php
+++ b/src/ORM/Filters/UsesSearchFilters.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SilverStripe\ORM\Filters;
+
+use SilverStripe\Core\Injector\Injector;
+
+trait UsesSearchFilters
+{
+    /**
+     * Given a filter expression and value construct a {@see SearchFilter} instance
+     *
+     * @param string $filter E.g. `Name:ExactMatch:not`, `Name:ExactMatch`, `Name:not`, `Name`
+     * @param mixed $value Value of the filter
+     * @return SearchFilter
+     */
+    protected function createSearchFilter($filter, $value)
+    {
+        // @TODO Handle the edge case where someone adds ArrayData with a field name "MyField:MoreFieldName" - the "MoreFieldName" should not be considered a searchfilter. (arraylist only)
+        // Field name is always the first component
+        $fieldArgs = explode(':', $filter);
+        $fieldName = array_shift($fieldArgs);
+        $default = 'DataListFilter.default';
+
+        // Inspect type of second argument to determine context
+        $secondArg = array_shift($fieldArgs);
+        $modifiers = $fieldArgs;
+        if (!$secondArg) {
+            // Use default SearchFilter if none specified. E.g. `->filter(['Name' => $myname])`
+            $filterServiceName = $default;
+        } else {
+            // The presence of a second argument is by default ambiguous; We need to query
+            // Whether this is a valid modifier on the default filter, or a filter itself.
+            /** @var SearchFilter $defaultFilterInstance */
+            $defaultFilterInstance = Injector::inst()->get($default);
+            if (in_array(strtolower($secondArg), $defaultFilterInstance->getSupportedModifiers() ?? [])) {
+                // Treat second (and any subsequent) argument as modifiers, using default filter
+                $filterServiceName = $default;
+                array_unshift($modifiers, $secondArg);
+            } else {
+                // Second argument isn't a valid modifier, so assume is filter identifier
+                $filterServiceName = "DataListFilter.{$secondArg}";
+            }
+        }
+
+        // Build instance
+        $filter = Injector::inst()->create($filterServiceName, $fieldName, $value, $modifiers);
+
+        return $filter;
+    }
+}

--- a/tests/php/ORM/Filters/EndsWithFilterTest.php
+++ b/tests/php/ORM/Filters/EndsWithFilterTest.php
@@ -2,208 +2,162 @@
 
 namespace SilverStripe\ORM\Tests\Filters;
 
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\ORM\Filters\ExactMatchFilter;
-use SilverStripe\ORM\Tests\Filters\ExactMatchFilterTest\Task;
-use SilverStripe\ORM\Tests\Filters\ExactMatchFilterTest\Project;
-use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\Filters\EndsWithFilter;
 use SilverStripe\View\ArrayData;
 
-class ExactMatchFilterTest extends SapphireTest
+class EndsWithFilterTest extends SapphireTest
 {
-    protected static $fixture_file = 'ExactMatchFilterTest.yml';
-
-    protected static $extra_dataobjects = [
-        Task::class,
-        Project::class,
-    ];
-
-    /**
-     * @dataProvider provideUsePlaceholders
-     */
-    public function testUsePlaceholders(?bool $expectedID, ?bool $expectedTitle, bool $config, callable $fn): void
-    {
-        Config::modify()->set(DataList::class, 'use_placeholders_for_integer_ids', $config);
-        [$idQueryUsesPlaceholders, $titleQueryUsesPlaceholders] = $this->usesPlaceholders($fn);
-        $this->assertSame($expectedID, $idQueryUsesPlaceholders);
-        $this->assertSame($expectedTitle, $titleQueryUsesPlaceholders);
-    }
-
-    public function provideUsePlaceholders(): array
-    {
-        $ids = [1, 2, 3];
-        $taskTitles = array_map(fn($i) => "Task $i", $ids);
-        return [
-            'primary key' => [
-                'expectedID' => false,
-                'expectedTitle' => null,
-                'config' => false,
-                'fn' => fn() => Task::get()->byIDs($ids)
-            ],
-            'primary key on relation' => [
-                'expectedID' => false,
-                'expectedTitle' => null,
-                'config' => false,
-                'fn' => fn() => Project::get()->filter('Tasks.ID', $ids)
-            ],
-            'foriegn key' => [
-                'expectedID' => false,
-                'expectedTitle' => null,
-                'config' => false,
-                'fn' => fn() => Task::get()->filter(['ProjectID' => $ids])
-            ],
-            'regular column' => [
-                'expectedID' => null,
-                'expectedTitle' => true,
-                'config' => false,
-                'fn' => fn() => Task::get()->filter(['Title' => $taskTitles])
-            ],
-            'primary key + regular column' => [
-                'expectedID' => false,
-                'expectedTitle' => true,
-                'config' => false,
-                'fn' => fn() => Task::get()->filter([
-                    'ID' => $ids,
-                    'Title' => $taskTitles
-                ])
-            ],
-            'primary key config enabled' => [
-                'expectedID' => true,
-                'expectedTitle' => null,
-                'config' => true,
-                'fn' => fn() => Task::get()->byIDs($ids)
-            ],
-            'non int values' => [
-                'expectedID' => true,
-                'expectedTitle' => null,
-                'config' => false,
-                'fn' => fn() => Task::get()->filter(['ID' => ['a', 'b', 'c']])
-            ],
-        ];
-    }
-
-    private function usesPlaceholders(callable $fn): array
-    {
-        // force showqueries on to view executed SQL via output-buffering
-        $list = $fn();
-        $sql = $list->dataQuery()->sql();
-        preg_match('#ID" IN \(([^\)]+)\)\)#', $sql, $matches);
-        $idQueryUsesPlaceholders = isset($matches[1]) ? $matches[1] === '?, ?, ?' : null;
-        preg_match('#"Title" IN \(([^\)]+)\)\)#', $sql, $matches);
-        $titleQueryUsesPlaceholders = isset($matches[1]) ? $matches[1] === '?, ?, ?' : null;
-        return [$idQueryUsesPlaceholders, $titleQueryUsesPlaceholders];
-    }
 
     public function provideMatches()
     {
         $scenarios = [
             // without modifiers
-            [
+            'null ends with null' => [
                 'filterValue' => null,
                 'objValue' => null,
                 'modifiers' => [],
                 'matches' => true,
             ],
-            [
+            'empty ends with null' => [
                 'filterValue' => null,
                 'objValue' => '',
                 'modifiers' => [],
-                'matches' => false,
+                'matches' => true,
             ],
-            [
+            'null ends with empty' => [
                 'filterValue' => '',
                 'objValue' => null,
                 'modifiers' => [],
-                'matches' => false,
+                'matches' => true,
             ],
-            [
+            'empty ends with empty' => [
                 'filterValue' => '',
                 'objValue' => '',
                 'modifiers' => [],
                 'matches' => true,
             ],
-            [
+            'empty ends with false' => [
                 'filterValue' => false,
                 'objValue' => '',
                 'modifiers' => [],
-                'matches' => false,
+                'matches' => true,
             ],
-            [
+            'true doesnt end with empty' => [
                 'filterValue' => true,
                 'objValue' => '',
                 'modifiers' => [],
                 'matches' => false,
             ],
-            [
+            'false doesnt end with empty' => [
                 'filterValue' => '',
                 'objValue' => false,
                 'modifiers' => [],
                 'matches' => false,
             ],
-            [
+            'true doesnt end with empty' => [
                 'filterValue' => '',
                 'objValue' => true,
                 'modifiers' => [],
                 'matches' => false,
             ],
-            [
+            'null ends with false' => [
                 'filterValue' => false,
                 'objValue' => null,
                 'modifiers' => [],
-                'matches' => false,
+                'matches' => true,
             ],
-            [
+            'false doesnt end with null' => [
                 'filterValue' => null,
                 'objValue' => false,
                 'modifiers' => [],
                 'matches' => false,
             ],
-            [
+            'false doesnt end with true' => [
                 'filterValue' => true,
                 'objValue' => false,
                 'modifiers' => [],
                 'matches' => false,
             ],
-            [
+            'true doesnt end with false' => [
+                'filterValue' => false,
+                'objValue' => true,
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            'false doesnt end with false' => [
                 'filterValue' => false,
                 'objValue' => false,
                 'modifiers' => [],
-                'matches' => true,
+                'matches' => false,
             ],
-            [
+            'true doesnt end with true' => [
                 'filterValue' => true,
                 'objValue' => true,
                 'modifiers' => [],
-                'matches' => true,
-            ],
-            [
-                'filterValue' => 'SomeValue',
-                'objValue' => 'SomeValue',
-                'modifiers' => [],
-                'matches' => true,
-            ],
-            [
-                'filterValue' => 'somevalue',
-                'objValue' => 'SomeValue',
-                'modifiers' => [],
                 'matches' => false,
             ],
-            [
+            'number is cast to string' => [
                 'filterValue' => 1,
                 'objValue' => '1',
                 'modifiers' => [],
-                'matches' => false,
+                'matches' => true,
             ],
-            [
+            '1 ends with 1' => [
                 'filterValue' => 1,
                 'objValue' => 1,
                 'modifiers' => [],
                 'matches' => true,
             ],
-            // test some values that are clearly not strings, since exact match
-            // is the default for ArrayList filtering which can have basically
-            // anything as its value
+            '100 doesnt end with 1' => [
+                'filterValue' => '1',
+                'objValue' => 100,
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            '100 ends with 0' => [
+                'filterValue' => '0',
+                'objValue' => 100,
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            '100 still ends with 0' => [
+                'filterValue' => 0,
+                'objValue' => 100,
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            'SomeValue ends with SomeValue' => [
+                'filterValue' => 'SomeValue',
+                'objValue' => 'SomeValue',
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            'SomeValue doesnt end with SomeValue' => [
+                'filterValue' => 'somevalue',
+                'objValue' => 'SomeValue',
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            'SomeValue doesnt end with meVal' => [
+                'filterValue' => 'meVal',
+                'objValue' => 'SomeValue',
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            'SomeValue ends with Value' => [
+                'filterValue' => 'Value',
+                'objValue' => 'SomeValue',
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            'SomeValue doesnt with vAlUe' => [
+                'filterValue' => 'vAlUe',
+                'objValue' => 'SomeValue',
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            // These will both evaluate to true because the __toString() method just returns the class name.
             [
                 'filterValue' => new ArrayData(['SomeField' => 'some value']),
                 'objValue' => new ArrayData(['SomeField' => 'some value']),
@@ -214,7 +168,7 @@ class ExactMatchFilterTest extends SapphireTest
                 'filterValue' => new ArrayData(['SomeField' => 'SoMe VaLuE']),
                 'objValue' => new ArrayData(['SomeField' => 'some value']),
                 'modifiers' => [],
-                'matches' => false,
+                'matches' => true,
             ],
             // case insensitive
             [
@@ -224,11 +178,24 @@ class ExactMatchFilterTest extends SapphireTest
                 'matches' => true,
             ],
             [
-                'filterValue' => 'some',
+                'filterValue' => 'vAlUe',
+                'objValue' => 'SomeValue',
+                'modifiers' => ['nocase'],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => 'meval',
                 'objValue' => 'SomeValue',
                 'modifiers' => ['nocase'],
                 'matches' => false,
             ],
+            [
+                'filterValue' => 'different',
+                'objValue' => 'SomeValue',
+                'modifiers' => ['nocase'],
+                'matches' => false,
+            ],
+            // These will both evaluate to true because the __toString() method just returns the class name.
             [
                 'filterValue' => new ArrayData(['SomeField' => 'SoMe VaLuE']),
                 'objValue' => new ArrayData(['SomeField' => 'some value']),
@@ -239,7 +206,7 @@ class ExactMatchFilterTest extends SapphireTest
                 'filterValue' => new ArrayData(['SomeField' => 'VaLuE']),
                 'objValue' => new ArrayData(['SomeField' => 'some value']),
                 'modifiers' => ['nocase'],
-                'matches' => false,
+                'matches' => true,
             ],
         ];
         // negated
@@ -261,11 +228,11 @@ class ExactMatchFilterTest extends SapphireTest
     /**
      * @dataProvider provideMatches
      */
-    public function testMatches(mixed $filterValue, mixed $objValue, array $modifiers, bool $matches)
+    public function testMatches(mixed $filterValue, mixed $matchValue, array $modifiers, bool $matches)
     {
-        $filter = new ExactMatchFilter();
+        $filter = new EndsWithFilter();
         $filter->setValue($filterValue);
         $filter->setModifiers($modifiers);
-        $this->assertSame($matches, $filter->matches($objValue));
+        $this->assertSame($matches, $filter->matches($matchValue));
     }
 }

--- a/tests/php/ORM/Filters/GreaterThanFilterTest.php
+++ b/tests/php/ORM/Filters/GreaterThanFilterTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Filters;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\Filters\GreaterThanFilter;
+use SilverStripe\View\ArrayData;
+
+class GreaterThanFilterTest extends SapphireTest
+{
+
+    public function provideMatches()
+    {
+        $scenarios = [
+            // without modifiers
+            [
+                'filterValue' => null,
+                'matchValue' => null,
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => '',
+                'matchValue' => null,
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => null,
+                'matchValue' => '',
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => '',
+                'matchValue' => '',
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => 'SomeValue',
+                'matchValue' => 'SomeValue',
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => 'SomeValue',
+                'matchValue' => 'somevalue',
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => '1',
+                'matchValue' => 1,
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => 1,
+                'matchValue' => 1,
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            // test some values that are clearly not strings, since exact match
+            // is the default for ArrayList filtering which can have basically
+            // anything as its value
+            [
+                'filterValue' => new ArrayData(['SomeField' => 'some value']),
+                'matchValue' => new ArrayData(['SomeField' => 'some value']),
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => new ArrayData(['SomeField' => 'some value']),
+                'matchValue' => new ArrayData(['SomeField' => 'SoMe VaLuE']),
+                'modifiers' => [],
+                'matches' => false,
+            ],
+        ];
+        // negated
+        foreach ($scenarios as $scenario) {
+            $scenario['modifiers'][] = 'not';
+            $scenario['matches'] = !$scenario['matches'];
+            $scenarios[] = $scenario;
+        }
+        return $scenarios;
+    }
+
+    /**
+     * @dataProvider provideMatches
+     */
+    public function testMatches(mixed $filterValue, mixed $matchValue, array $modifiers, bool $matches)
+    {
+        $filter = new GreaterThanFilter();
+        $filter->setValue($filterValue);
+        $filter->setModifiers($modifiers);
+        $this->assertSame($matches, $filter->matches($matchValue));
+    }
+}

--- a/tests/php/ORM/Filters/GreaterThanOrEqualFilterTest.php
+++ b/tests/php/ORM/Filters/GreaterThanOrEqualFilterTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Filters;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\Filters\GreaterThanOrEqualFilter;
+use SilverStripe\View\ArrayData;
+
+class GreaterThanOrEqualFilterTest extends SapphireTest
+{
+
+    public function provideMatches()
+    {
+        $scenarios = [
+            // without modifiers
+            [
+                'filterValue' => null,
+                'matchValue' => null,
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => '',
+                'matchValue' => null,
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => null,
+                'matchValue' => '',
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => '',
+                'matchValue' => '',
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => 'SomeValue',
+                'matchValue' => 'SomeValue',
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => 'SomeValue',
+                'matchValue' => 'somevalue',
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => '1',
+                'matchValue' => 1,
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => 1,
+                'matchValue' => 1,
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            // test some values that are clearly not strings, since exact match
+            // is the default for ArrayList filtering which can have basically
+            // anything as its value
+            [
+                'filterValue' => new ArrayData(['SomeField' => 'some value']),
+                'matchValue' => new ArrayData(['SomeField' => 'some value']),
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => new ArrayData(['SomeField' => 'some value']),
+                'matchValue' => new ArrayData(['SomeField' => 'SoMe VaLuE']),
+                'modifiers' => [],
+                'matches' => false,
+            ],
+        ];
+        // negated
+        foreach ($scenarios as $scenario) {
+            $scenario['modifiers'][] = 'not';
+            $scenario['matches'] = !$scenario['matches'];
+            $scenarios[] = $scenario;
+        }
+        return $scenarios;
+    }
+
+    /**
+     * @dataProvider provideMatches
+     */
+    public function testMatches(mixed $filterValue, mixed $matchValue, array $modifiers, bool $matches)
+    {
+        $filter = new GreaterThanOrEqualFilter();
+        $filter->setValue($filterValue);
+        $filter->setModifiers($modifiers);
+        $this->assertSame($matches, $filter->matches($matchValue));
+    }
+}

--- a/tests/php/ORM/Filters/LessThanFilterTest.php
+++ b/tests/php/ORM/Filters/LessThanFilterTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Filters;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\Filters\LessThanFilter;
+use SilverStripe\View\ArrayData;
+
+class LessThanFilterTest extends SapphireTest
+{
+
+    public function provideMatches()
+    {
+        $scenarios = [
+            // without modifiers
+            [
+                'filterValue' => null,
+                'matchValue' => null,
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => '',
+                'matchValue' => null,
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => null,
+                'matchValue' => '',
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => '',
+                'matchValue' => '',
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => 'SomeValue',
+                'matchValue' => 'SomeValue',
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => 'SomeValue',
+                'matchValue' => 'somevalue',
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => '1',
+                'matchValue' => 1,
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => 1,
+                'matchValue' => 1,
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            // test some values that are clearly not strings, since exact match
+            // is the default for ArrayList filtering which can have basically
+            // anything as its value
+            [
+                'filterValue' => new ArrayData(['SomeField' => 'some value']),
+                'matchValue' => new ArrayData(['SomeField' => 'some value']),
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => new ArrayData(['SomeField' => 'some value']),
+                'matchValue' => new ArrayData(['SomeField' => 'SoMe VaLuE']),
+                'modifiers' => [],
+                'matches' => false,
+            ],
+        ];
+        // negated
+        foreach ($scenarios as $scenario) {
+            $scenario['modifiers'][] = 'not';
+            $scenario['matches'] = !$scenario['matches'];
+            $scenarios[] = $scenario;
+        }
+        return $scenarios;
+    }
+
+    /**
+     * @dataProvider provideMatches
+     */
+    public function testMatches(mixed $filterValue, mixed $matchValue, array $modifiers, bool $matches)
+    {
+        $filter = new LessThanFilter();
+        $filter->setValue($filterValue);
+        $filter->setModifiers($modifiers);
+        $this->assertSame($matches, $filter->matches($matchValue));
+    }
+}

--- a/tests/php/ORM/Filters/LessThanOrEqualFilterTest.php
+++ b/tests/php/ORM/Filters/LessThanOrEqualFilterTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Filters;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\Filters\LessThanOrEqualFilter;
+use SilverStripe\View\ArrayData;
+
+class LessThanOrEqualFilterTest extends SapphireTest
+{
+
+    public function provideMatches()
+    {
+        $scenarios = [
+            // without modifiers
+            [
+                'filterValue' => null,
+                'matchValue' => null,
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => '',
+                'matchValue' => null,
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => null,
+                'matchValue' => '',
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => '',
+                'matchValue' => '',
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => 'SomeValue',
+                'matchValue' => 'SomeValue',
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => 'SomeValue',
+                'matchValue' => 'somevalue',
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => '1',
+                'matchValue' => 1,
+                'modifiers' => [],
+                'matches' => false,
+            ],
+            [
+                'filterValue' => 1,
+                'matchValue' => 1,
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            // test some values that are clearly not strings, since exact match
+            // is the default for ArrayList filtering which can have basically
+            // anything as its value
+            [
+                'filterValue' => new ArrayData(['SomeField' => 'some value']),
+                'matchValue' => new ArrayData(['SomeField' => 'some value']),
+                'modifiers' => [],
+                'matches' => true,
+            ],
+            [
+                'filterValue' => new ArrayData(['SomeField' => 'some value']),
+                'matchValue' => new ArrayData(['SomeField' => 'SoMe VaLuE']),
+                'modifiers' => [],
+                'matches' => false,
+            ],
+        ];
+        // negated
+        foreach ($scenarios as $scenario) {
+            $scenario['modifiers'][] = 'not';
+            $scenario['matches'] = !$scenario['matches'];
+            $scenarios[] = $scenario;
+        }
+        return $scenarios;
+    }
+
+    /**
+     * @dataProvider provideMatches
+     */
+    public function testMatches(mixed $filterValue, mixed $matchValue, array $modifiers, bool $matches)
+    {
+        $filter = new LessThanOrEqualFilter();
+        $filter->setValue($filterValue);
+        $filter->setModifiers($modifiers);
+        $this->assertSame($matches, $filter->matches($matchValue));
+    }
+}


### PR DESCRIPTION
Comparison logic is based on the way MySQL handles comparisons and coerces various types, for parity with `DataList`. This means the comparisons may behaviour slightly different for projects with other database drivers, but I think that's unavoidable without either:
a) abstracting this out so that we have something like `DB::matches()` which then calls some method on the `DBConnector` instance which means either a breaking change by introducing new methods on the interface or else checking if the method exists on the `DBConnector` implementation and if not, falling back to some default, OR
b) making DB queries which would be silly since that's what we're trying to avoid in the first place.

See https://dev.mysql.com/doc/refman/8.1/en/type-conversion.html for MySQL type conversion rules and https://dev.mysql.com/doc/refman/8.1/en/comparison-operators.html for MySQL comparison operator functionality - but it's not all documented and a lot of this has been found through trial and error. There are even more edge cases than what's covered here that I haven't even tried to cover, and you can see some failed CI where I'm still working on matching some weird MySQL behaviours.

## Options going forward
Now that I've been bashing my head against this for a bit, I'm thinking it's probably best to _not_ try matching the MySQL behaviour this closely. We can choose not to, because:

- This is new functionality, both for `ArrayList` and for `EagerLoadedList`, so we won't actually be making any breaking changes by _not_ explicitly matching the results of these filters when used in `DataList`.
- Matching MySQL behaviour specifically means we're likely to _not_ be matching behaviour for other database connectors like postgresql

Before I blow away a huge chunk of this PR though, I'd like to get at least one more opinion of it - the last thing I want is to change to a simpler implementation and then be told "no, go do what MySQL does"

### Option One: Don't try to match MySQL
We can provide the behaviour that seems most intuitive, and doesn't require all sorts of weird edge case handling.
For example, in exact match filter we can simply say: If it's not an exact match according to either `==` or `===` PHP comparison logic, then it isn't the same value (this is essentially what `ArrayList` currently does, so at least for that class we probably have to retain this behaviour).

However, _not_ MySQL behaviour means that filters on `EagerLoadedList` _may not_ provide the same results as if it was a regular `DataList` in some scenarios. Personally I think that's fine provided we clearly document that limitation - and it's only likely to happen in strange edge-cases anyway.
There's a decent likelyhood we'll provide the ability to pre-filter eager loaded lists anyway, which will further mitigate that limitation.

### Option Two: Try to match MySQL as much as we possibly can
This is what the PR is doing so far. However, there's a lot of stuff that MySQL does when matching stuff that doesn't seem intuitive - and it's resulting in a very complex implementation. It's hard to maintain, and if MySQL changes how it does things, we have to change how _we_ do things.

Matching MySQL behaviour specifically means we're likely to _not_ be matching behaviour for other database connectors like postgresql, so it's going to be obtuse to _someone_ either way.

However, matching MySQL behaviour (as closely as we can) means that filters on `EagerLoadedList` will provide the same results as if it was a regular `DataList`.

### Option Three: Try to match what _whatever the current database connector is_ does
This is basically Option Two above, but abstracted further so that it would be easy for maintainers of the postgres module to implement any weird postgres logic for this matching functionality.
To do this in a BC compatible way it means we'd need to have a `method_exists()` check on `DB::get_conn()`, and if the method _doesn't_ exist we'd have to have a fallback, which would probably have to be the MySQL implementation.

Personally this option is where it starts getting way too messy for my liking.


## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/5911