### PR TITLE
DBComposite::writeToManipulation() is never called

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -1491,7 +1491,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
             $specification = $schema->fieldSpec(
                 $class,
                 $fieldName,
-                DataObjectSchema::DB_ONLY | DataObjectSchema::UNINHERITED
+                DataObjectSchema::UNINHERITED
             );
             if (!$specification) {
                 continue;

--- a/tests/php/ORM/DBCompositeTest.php
+++ b/tests/php/ORM/DBCompositeTest.php
@@ -114,19 +114,6 @@ class DBCompositeTest extends SapphireTest
         $this->assertEquals('DBCompositeTest_SubclassedDBFieldObject', $object2->dbObject('OverriddenMoney')->getTable());
     }
 
-    /* Uncomment this for SS5
-    public function testSetFieldDynamicPropertyException()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(implode(' ', [
-            'Field abc does not exist.',
-            'If this was accessed via a dynamic property then call setDynamicData() instead.'
-        ]));
-        $object = new DBCompositeTest\TestObject();
-        $object->MyMoney->abc = 'def';
-    }
-    */
-
     public function testWriteToManipuationIsCalledWhenWritingDataObject()
     {
         $obj = DBCompositeTest\TestObject::create();

--- a/tests/php/ORM/DBCompositeTest.php
+++ b/tests/php/ORM/DBCompositeTest.php
@@ -53,7 +53,8 @@ class DBCompositeTest extends SapphireTest
         $this->assertEquals(
             [
                 'MyMoney' => 'Money',
-                'OverriddenMoney' => 'Money'
+                'OverriddenMoney' => 'Money',
+                'DoubleMoney' => DBCompositeTest\DBDoubleMoney::class
             ],
             $schema->compositeFields(DBCompositeTest\TestObject::class)
         );
@@ -68,6 +69,7 @@ class DBCompositeTest extends SapphireTest
                 'MyMoney' => 'Money',
                 'OtherMoney' => 'Money',
                 'OverriddenMoney' => 'Money',
+                'DoubleMoney' => DBCompositeTest\DBDoubleMoney::class
             ],
             $schema->compositeFields(DBCompositeTest\SubclassedDBFieldObject::class)
         );
@@ -110,5 +112,34 @@ class DBCompositeTest extends SapphireTest
         $this->assertEquals('DBCompositeTest_DataObject', $object2->dbObject('MyMoney')->getTable());
         $this->assertEquals('DBCompositeTest_SubclassedDBFieldObject', $object2->dbObject('OtherMoney')->getTable());
         $this->assertEquals('DBCompositeTest_SubclassedDBFieldObject', $object2->dbObject('OverriddenMoney')->getTable());
+    }
+
+    public function testSetFieldDynamicPropertyException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(implode(' ', [
+            'Field abc does not exist.',
+            'If this was accessed via a dynamic property then call setDynamicData() instead.'
+        ]));
+        $object = new DBCompositeTest\TestObject();
+        $object->MyMoney->abc = 'def';
+    }
+
+    public function testWriteToManipuationIsCalledWhenWritingDataObject()
+    {
+        $obj = DBCompositeTest\TestObject::create();
+        $obj->DoubleMoney = ['Amount' => 10, 'Currency' => 'CAD'];
+        $moneyField = $obj->dbObject('DoubleMoney');
+        $this->assertEquals(10, $moneyField->getAmount());
+
+        $obj->write();
+
+        // Custom money class should double the amount before writing
+        $this->assertEquals(20, $moneyField->getAmount());
+
+        // Note: these would fail since dbObject will return a new instance
+        // of the DoubleMoney field based on the initial values
+        // $this->assertSame($moneyField, $obj->dbObject('DoubleMoney'));
+        // $this->assertEquals(20, $obj->dbObject('DoubleMoney')->getAmount());
     }
 }

--- a/tests/php/ORM/DBCompositeTest.php
+++ b/tests/php/ORM/DBCompositeTest.php
@@ -114,6 +114,7 @@ class DBCompositeTest extends SapphireTest
         $this->assertEquals('DBCompositeTest_SubclassedDBFieldObject', $object2->dbObject('OverriddenMoney')->getTable());
     }
 
+    /* Uncomment this for SS5
     public function testSetFieldDynamicPropertyException()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -124,6 +125,7 @@ class DBCompositeTest extends SapphireTest
         $object = new DBCompositeTest\TestObject();
         $object->MyMoney->abc = 'def';
     }
+    */
 
     public function testWriteToManipuationIsCalledWhenWritingDataObject()
     {

--- a/tests/php/ORM/DBCompositeTest/DBDoubleMoney.php
+++ b/tests/php/ORM/DBCompositeTest/DBDoubleMoney.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DBCompositeTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\FieldType\DBMoney;
+
+class DBDoubleMoney extends DBMoney implements TestOnly
+{
+    public function writeToManipulation(&$manipulation)
+    {
+        // Duplicate the amount before writing
+        $this->setAmount($this->getAmount() * 2);
+
+        parent::writeToManipulation($manipulation);
+    }
+}

--- a/tests/php/ORM/DBCompositeTest/TestObject.php
+++ b/tests/php/ORM/DBCompositeTest/TestObject.php
@@ -12,6 +12,7 @@ class TestObject extends DataObject implements TestOnly
     private static $db = [
         'Title' => 'Text',
         'MyMoney' => 'Money',
-        'OverriddenMoney' => 'Money'
+        'OverriddenMoney' => 'Money',
+        'DoubleMoney' => DBDoubleMoney::class,
     ];
 }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/8800

Credits to https://github.com/silverstripe/silverstripe-framework/pull/9182