### PR TITLE
MINOR: one standard way to get Anchors for SiteTree and  BaseElement et al.

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -25,6 +25,7 @@ use SilverStripe\ORM\FieldType\DBComposite;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\FieldType\DBEnum;
 use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\FieldType\DBHTMLText
 use SilverStripe\ORM\Filters\PartialMatchFilter;
 use SilverStripe\ORM\Filters\SearchFilter;
 use SilverStripe\ORM\Queries\SQLDelete;
@@ -991,6 +992,22 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         return array_filter($this->record ?? [], function ($val) {
             return $val !== null;
         });
+    }
+
+    public function getAnchorsInHtml() : array
+    {
+        $anchors = [];
+        $allFields = DataObject::getSchema()->fieldSpecs($this);
+        foreach ($allFields as $field => $fieldSpec) {
+            $fieldObj = $this->dbObject($field);
+            if ($fieldObj instanceof DBHTMLText) {
+                $anchors = array_merge($anchors, $fieldObj->getAnchors());
+            }
+        }
+        $anchors = array_unique($anchors);
+
+        $this->extend('getAnchorsInHtml', $anchors);        
+        return $anchors;
     }
 
     /**

--- a/src/ORM/FieldType/DBHTMLText.php
+++ b/src/ORM/FieldType/DBHTMLText.php
@@ -134,6 +134,24 @@ class DBHTMLText extends DBText
         return $this->value;
     }
 
+    public function getAnchors() : array
+    {
+        $parseSuccess = preg_match_all(
+            "/\\s+(name|id)\\s*=\\s*([\"'])([^\\2\\s>]*?)\\2|\\s+(name|id)\\s*=\\s*([^\"']+)[\\s +>]/im",
+            $this->value ?? '',
+            $matches
+        );
+
+        $anchors = [];
+        if ($parseSuccess >= 1) {
+            $anchors = array_values(array_unique(array_filter(
+                array_merge($matches[3], $matches[5])
+            )));
+        }
+        
+        return $anchors;
+    }
+    
     /**
      * Return the value of the field with relative links converted to absolute urls (with placeholders parsed).
      * @return string


### PR DESCRIPTION
Both SiteTree and BaseElement have their own way to extract anchors from HTML Content. This  would make this more unified.


This is just a bit of an idea at the moment. I can see BaseElement and SiteTree both doing their own thing extactings IDs from HTML.  This should probably go somewhere else. 

https://github.com/silverstripe/silverstripe-elemental/blob/5/src/Models/BaseElement.php#L765

https://github.com/silverstripe/silverstripe-cms/blob/5/code/Model/SiteTree.php#L3370