### PR TITLE
PHP 8.2 compatibility fixes

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -65,6 +65,7 @@ use SilverStripe\View\ViewableData;
  * For example, the "URLSegment" field in a standard CMS form would be
  * accessible through "admin/EditForm/field/URLSegment/FieldHolder".
  */
+#[\AllowDynamicProperties]
 class Form extends ViewableData implements HasRequestHandler
 {
     use AttributesHTML;

--- a/src/ORM/Connect/MySQLDatabase.php
+++ b/src/ORM/Connect/MySQLDatabase.php
@@ -22,6 +22,7 @@ use Exception;
  * You are advised to backup your tables if changing settings on an existing database
  * `connection_charset` and `charset` should be equal, similarly so should `connection_collation` and `collation`
  */
+#[\AllowDynamicProperties]
 class MySQLDatabase extends Database implements TransactionManager
 {
     use Configurable;

--- a/thirdparty/php-peg/Parser.php
+++ b/thirdparty/php-peg/Parser.php
@@ -8,6 +8,7 @@
  *  Of course, the next regex might be outside that bracket - after the bracket if other matches have progressed beyond the match position, or before
  *  the bracket if a failed match + restore has moved the current position backwards - so we have to check that too.
  */
+#[\AllowDynamicProperties]
 class ParserRegexp {
 	function __construct( $parser, $rx ) {
 		$this->parser = $parser ;
@@ -44,6 +45,7 @@ class ParserRegexp {
  * - some abstraction of code that would otherwise be repeated many times in a compiled grammer, mostly related to calling user functions
  *   for result construction and building
  */
+#[\AllowDynamicProperties]
 class Parser {
     /**
      * @var string
@@ -202,6 +204,7 @@ class Parser {
  *
  * @author Hamish Friedlander
  */
+#[\AllowDynamicProperties]
 class Packrat extends Parser {
 	function __construct( $string ) {
 		parent::__construct( $string ) ;
@@ -254,6 +257,7 @@ class Packrat extends Parser {
  *
  * @author Hamish Friedlander
  */
+#[\AllowDynamicProperties]
 class FalseOnlyPackrat extends Parser {
 	function __construct( $string ) {
 		parent::__construct( $string ) ;
@@ -288,6 +292,7 @@ class FalseOnlyPackrat extends Parser {
  *
  * @author Hamish Friedlander
  */
+#[\AllowDynamicProperties]
 class ConservativePackrat extends Parser {
 	function packhas( $key, $pos ) {
 		return isset( $this->packres[$key] ) && $this->packres[$key] !== NULL ;


### PR DESCRIPTION
Currently framework code in version 4 triggers a lot of deprecation errors, because of setting dynamic properties on some classes. This can be easily fixed by declaring these properties on the classes, and should have no impact on the code otherwise.

The reason for fixing this is to be able to fix deprecation errors with PHP 8.2 in Silverstripe modules without these errors getting buried in all the deprecation errors from framework, not to have version 4 of Silverstripe officially support PHP 8.2.