### PR TITLE
FIX: Stop ManyManyThroughList join records incorrectly showing as changed (fixes #10821)

### DIFF
--- a/src/ORM/ManyManyThroughList.php
+++ b/src/ORM/ManyManyThroughList.php
@@ -87,7 +87,8 @@ class ManyManyThroughList extends RelationList
         if ($joinRow) {
             $joinClass = $this->manipulator->getJoinClass();
             $joinQueryParams = $this->manipulator->extractInheritableQueryParameters($this->dataQuery);
-            $joinRecord = Injector::inst()->create($joinClass, $joinRow, false, $joinQueryParams);
+            $creationType = empty($joinRow['ID']) ? DataObject::CREATE_OBJECT : DataObject::CREATE_HYDRATED;
+            $joinRecord = Injector::inst()->create($joinClass, $joinRow, $creationType, $joinQueryParams);
             $record->setJoin($joinRecord, $joinAlias);
         }
 

--- a/tests/php/ORM/ManyManyThroughListTest.php
+++ b/tests/php/ORM/ManyManyThroughListTest.php
@@ -514,4 +514,19 @@ class ManyManyThroughListTest extends SapphireTest
         $relation->removeAll();
         $this->assertEquals(sort($remove), sort($removedIds));
     }
+
+    public function testChangedFields()
+    {
+        /** @var ManyManyThroughListTest\TestObject $parent */
+        $parent = $this->objFromFixture(ManyManyThroughListTest\TestObject::class, 'parent1');
+        $item1 = $parent->Items()->first();
+
+        // Nothing has changed yet
+        $this->assertEmpty($item1->getChangedFields());
+        $this->assertFalse($item1->isChanged('Title'));
+
+        // Change a field, ensure change is flagged
+        $item1->Title = 'a test title';
+        $this->assertTrue($item1->isChanged('Title'));
+    }
 }


### PR DESCRIPTION
Issue: #10821 