### PR TITLE
FIX Call addToQuery on all DBFields

### DIFF
--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -617,6 +617,8 @@ class DataQuery
                 } else {
                     $query->selectField($quotedField, $k);
                 }
+                $dbO = Injector::inst()->create($v, $k);
+                $dbO->addToQuery($query);
             }
         }
         foreach ($compositeFields as $k => $v) {

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -18,6 +18,7 @@ class DataQueryTest extends SapphireTest
     protected static $fixture_file = 'DataQueryTest.yml';
 
     protected static $extra_dataobjects = [
+        DataQueryTest\DataObjectAddsToQuery::class,
         DataQueryTest\ObjectA::class,
         DataQueryTest\ObjectB::class,
         DataQueryTest\ObjectC::class,
@@ -379,6 +380,15 @@ class DataQueryTest extends SapphireTest
         $query2->where(DB::get_conn()->comparisonClause('"MyString"', 'helloworld', false, false, true));
         $this->assertEquals(0, $query2->count(), "Found mystring. Shouldn't be able too.");
         static::resetDBSchema(true);
+    }
+
+    public function testAddToQueryIsCalled()
+    {
+        // Including filter on parent table only doesn't pull in second
+        $query = new DataQuery(DataQueryTest\DataObjectAddsToQuery::class);
+        $result = $query->getFinalisedQuery();
+        // The `DBFieldAddsToQuery` test field removes itself from the select query
+        $this->assertArrayNotHasKey('FieldTwo', $result->getSelect());
     }
 
     /**

--- a/tests/php/ORM/DataQueryTest.yml
+++ b/tests/php/ORM/DataQueryTest.yml
@@ -36,3 +36,8 @@ SilverStripe\ORM\Tests\DataQueryTest\ObjectH:
     SortOrder: 2
     ManyTestEs: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectE.query2
     ManyTestIs: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectI.query3
+
+SilverStripe\ORM\Tests\DataQueryTest\DataObjectAddsToQuery:
+  obj1:
+    FieldOne: 'This is a value'
+    FieldTwo: 'This is also a value'

--- a/tests/php/ORM/DataQueryTest/DBFieldAddsToQuery.php
+++ b/tests/php/ORM/DataQueryTest/DBFieldAddsToQuery.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataQueryTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\FieldType\DBText;
+
+class DBFieldAddsToQuery extends DBText implements TestOnly
+{
+    public function addToQuery(&$query)
+    {
+        $select = $query->getSelect();
+        unset($select[$this->name]);
+        $query->setSelect($select);
+    }
+}

--- a/tests/php/ORM/DataQueryTest/DataObjectAddsToQuery.php
+++ b/tests/php/ORM/DataQueryTest/DataObjectAddsToQuery.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataQueryTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class DataObjectAddsToQuery extends DataObject implements TestOnly
+{
+    private static $table_name = 'DataQueryTest_AddsToQuery';
+
+    private static $db = [
+        'FieldOne' => 'Text',
+        'FieldTwo' => DBFieldAddsToQuery::class,
+    ];
+}


### PR DESCRIPTION
This is a bug fix with no new API so I'm targetting `4.13`, but if there are any regression concerns I can happily retarget to `5`.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10140