### PR TITLE
FIX Call Textarea validation extension

### DIFF
--- a/src/Forms/TextareaField.php
+++ b/src/Forms/TextareaField.php
@@ -174,6 +174,7 @@ class TextareaField extends FormField
      */
     public function validate($validator)
     {
+        $result = true;
         if (!is_null($this->maxLength) && mb_strlen($this->value ?? '') > $this->maxLength) {
             $name = strip_tags($this->Title() ? $this->Title() : $this->getName());
             $validator->validationError(
@@ -185,9 +186,9 @@ class TextareaField extends FormField
                 ),
                 "validation"
             );
-            return false;
+            $result = false;
         }
-        return true;
+        return $this->extendValidationResult($result, $validator);
     }
 
     public function getSchemaValidation()


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/108

Fixes https://github.com/silverstripe/silverstripe-framework/actions/runs/6058877214/job/16441418587#step:12:236
`1) SilverStripe\Forms\Tests\FormFieldTest::testValidationExtensionHooksAreCalledOnFormFieldSubclasses
Expectation failed for 'SilverStripe\Forms\TextareaField' class: Method was expected to be called 1 times, actually called 0 times.`

Caused by [this PR](https://github.com/silverstripe/silverstripe-framework/pull/10931) to 4.13 being merged up to 5.0 and not being compatible with [this PR](https://github.com/silverstripe/silverstripe-framework/pull/10569) that introduced new API that targetted 5.0