### PR TITLE
NEW Add ORM abstraction for "WITH" clauses

### DIFF
--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -637,6 +637,17 @@ abstract class Database
     );
 
     /**
+     * Determines if this database supports Common Table Expression (aka WITH) clauses.
+     * By default it is assumed that it doesn't unless this method is explicitly overridden.
+     *
+     * @param bool $recursive if true, checks specifically if recursive CTEs are supported.
+     */
+    public function supportsCteQueries(bool $recursive = false): bool
+    {
+        return false;
+    }
+
+    /**
      * Determines if this database supports transactions
      *
      * @return boolean Flag indicating support for transactions
@@ -653,7 +664,6 @@ abstract class Database
     {
         return false;
     }
-
 
     /**
      * Determines if the used database supports given transactionMode as an argument to startTransaction()

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -6,16 +6,18 @@ use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\ORM\Tests\DataQueryTest\ObjectE;
 use SilverStripe\Security\Member;
 
 class DataQueryTest extends SapphireTest
 {
-
     protected static $fixture_file = 'DataQueryTest.yml';
 
     protected static $extra_dataobjects = [
         DataQueryTest\DataObjectAddsToQuery::class,
+        DataQueryTest\DateAndPriceObject::class,
         DataQueryTest\ObjectA::class,
         DataQueryTest\ObjectB::class,
         DataQueryTest\ObjectC::class,
@@ -25,6 +27,7 @@ class DataQueryTest extends SapphireTest
         DataQueryTest\ObjectG::class,
         DataQueryTest\ObjectH::class,
         DataQueryTest\ObjectI::class,
+        SQLSelectTest\CteRecursiveObject::class,
         SQLSelectTest\TestObject::class,
         SQLSelectTest\TestBase::class,
         SQLSelectTest\TestChild::class,
@@ -573,5 +576,281 @@ class DataQueryTest extends SapphireTest
             $query->limit(1, 9999)->exists(),
             'exist is false when a limit returns no results'
         );
+    }
+
+    public function provideWith()
+    {
+        return [
+            // Simple scenarios to test auto-join functionality
+            'naive CTE query with array join' => [
+                'dataClass' => DataQueryTest\DateAndPriceObject::class,
+                'name' => 'cte',
+                'query' => new SQLSelect(
+                    ['"DataQueryTest_DateAndPriceObject"."ID"'],
+                    '"DataQueryTest_DateAndPriceObject"',
+                    ['"DataQueryTest_DateAndPriceObject"."Price" > 200']
+                ),
+                'cteFields' => ['cte_id'],
+                'recursive' => false,
+                'extraManipulations' => [
+                    'innerJoin' => ['cte', '"DataQueryTest_DateAndPriceObject"."ID" = "cte"."cte_id"'],
+                ],
+                'expectedItems' => [
+                    'fixtures' => [
+                        'obj4',
+                        'obj5',
+                    ],
+                ],
+            ],
+            'naive CTE query with string join' => [
+                'dataClass' => DataQueryTest\DateAndPriceObject::class,
+                'name' => 'cte',
+                'query' => new SQLSelect('200'),
+                'cteFields' => ['value'],
+                'recursive' => false,
+                'extraManipulations' => [
+                    'innerJoin' => ['cte', '"DataQueryTest_DateAndPriceObject"."Price" < "cte"."value"'],
+                ],
+                'expectedItems' => [
+                    'fixtures' => [
+                        'nullobj',
+                        'obj1',
+                        'obj2',
+                    ]
+                ],
+            ],
+            // Simple scenario to test where the query is another DataQuery
+            'naive CTE query with DataQuery' => [
+                'dataClass' => DataQueryTest\DateAndPriceObject::class,
+                'name' => 'cte',
+                'query' => DataQueryTest\ObjectF::class,
+                'cteFields' => ['MyDate'],
+                'recursive' => false,
+                'extraManipulations' => [
+                    'innerJoin' => ['cte', '"DataQueryTest_DateAndPriceObject"."Date" = "cte"."MyDate"'],
+                ],
+                'expectedItems' => [
+                    'fixtures' => [
+                        'obj1',
+                        'obj2',
+                    ]
+                ],
+            ],
+            // Extrapolate missing data with a recursive query
+            // Missing data will be returned as records with no ID
+            'recursive CTE with extrapolated data' => [
+                'dataClass' => DataQueryTest\DateAndPriceObject::class,
+                'name' => 'dates',
+                'query' => (new SQLSelect(
+                    'MIN("DataQueryTest_DateAndPriceObject"."Date")',
+                    "DataQueryTest_DateAndPriceObject",
+                    '"DataQueryTest_DateAndPriceObject"."Date" IS NOT NULL'
+                ))->addUnion(
+                    new SQLSelect(
+                        'Date + INTERVAL 1 DAY',
+                        'dates',
+                        ['Date + INTERVAL 1 DAY <= (SELECT MAX("DataQueryTest_DateAndPriceObject"."Date") FROM "DataQueryTest_DateAndPriceObject")']
+                    ),
+                    SQLSelect::UNION_ALL
+                ),
+                'cteFields' => ['Date'],
+                'recursive' => true,
+                'extraManipulations' => [
+                    'selectField' => ['COALESCE("DataQueryTest_DateAndPriceObject"."Date", "dates"."Date")', 'Date'],
+                    'setAllowCollidingFieldStatements' => [true],
+                    'sort' => ['dates.Date'],
+                    'rightJoin' => ['dates', '"DataQueryTest_DateAndPriceObject"."Date" = "dates"."Date"'],
+                ],
+                'expectedItems' => [
+                    'data' => [
+                        ['fixtureName' => 'obj5'],
+                        ['fixtureName' => 'obj4'],
+                        ['Date' => '2023-01-06'],
+                        ['Date' => '2023-01-05'],
+                        ['fixtureName' => 'obj3'],
+                        ['Date' => '2023-01-03'],
+                        ['fixtureName' => 'obj2'],
+                        ['fixtureName' => 'obj1'],
+                    ]
+                ],
+            ],
+            // Get the ancestors of a given record with a recursive query
+            'complex hierarchical CTE with explicit columns' => [
+                'dataClass' => SQLSelectTest\CteRecursiveObject::class,
+                'name' => 'hierarchy',
+                'query' => (
+                    new SQLSelect(
+                        '"SQLSelectTestCteRecursive"."ParentID"',
+                        "SQLSelectTestCteRecursive",
+                        [['"SQLSelectTestCteRecursive"."ParentID" > 0 AND "SQLSelectTestCteRecursive"."Title" = ?' => 'child of child1']]
+                    )
+                )->addUnion(new SQLSelect(
+                    '"SQLSelectTestCteRecursive"."ParentID"',
+                    ['"hierarchy"', '"SQLSelectTestCteRecursive"'],
+                    ['"SQLSelectTestCteRecursive"."ParentID" > 0 AND "SQLSelectTestCteRecursive"."ID" = "hierarchy"."parent_id"']
+                )),
+                'cteFields' => ['parent_id'],
+                'recursive' => true,
+                'extraManipulations' => [
+                    'innerJoin' => ['hierarchy', '"SQLSelectTestCteRecursive"."ID" = "hierarchy"."parent_id"'],
+                ],
+                'expected' => [
+                    'fixtures' => [
+                        'grandparent',
+                        'parent',
+                        'child1',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideWith
+     */
+    public function testWith(
+        string $dataClass,
+        string $name,
+        string|SQLSelect $query,
+        array $cteFields,
+        bool $recursive,
+        array $extraManipulations,
+        array $expectedItems
+    ) {
+        if (!DB::get_conn()->supportsCteQueries()) {
+            $this->markTestSkipped('The current database does not support WITH clauses');
+        }
+        if ($recursive && !DB::get_conn()->supportsCteQueries(true)) {
+            $this->markTestSkipped('The current database does not support recursive WITH clauses');
+        }
+
+        // We can't instantiate a DataQuery in a provider method because it requires the injector, which isn't
+        // initialised that early. So we just pass the dataclass instead and instiate the query here.
+        if (is_string($query)) {
+            $query = new DataQuery($query);
+        }
+
+        $dataQuery = new DataQuery($dataClass);
+        $dataQuery->with($name, $query, $cteFields, $recursive);
+
+        foreach ($extraManipulations as $method => $args) {
+            $dataQuery->$method(...$args);
+        }
+
+        $expected = [];
+
+        if (isset($expectedItems['fixtures'])) {
+            foreach ($expectedItems['fixtures'] as $fixtureName) {
+                $expected[] = $this->idFromFixture($dataClass, $fixtureName);
+            }
+            $this->assertEquals($expected, $dataQuery->execute()->column('ID'));
+        }
+
+        if (isset($expectedItems['data'])) {
+            foreach ($expectedItems['data'] as $data) {
+                if (isset($data['fixtureName'])) {
+                    $data = $this->objFromFixture($dataClass, $data['fixtureName'])->toMap();
+                } else {
+                    $data['ClassName'] = null;
+                    $data['LastEdited'] = null;
+                    $data['Created'] = null;
+                    $data['Price'] = null;
+                    $data['ID'] = null;
+                }
+                $expected[] = $data;
+            }
+            $this->assertListEquals($expected, new ArrayList(iterator_to_array($dataQuery->execute(), true)));
+        }
+    }
+
+    /**
+     * tests the WITH clause, using a DataQuery as the CTE query
+     */
+    public function testWithUsingDataQuery()
+    {
+        if (!DB::get_conn()->supportsCteQueries(true)) {
+            $this->markTestSkipped('The current database does not support recursive WITH clauses');
+        }
+        $dataQuery = new DataQuery(SQLSelectTest\CteRecursiveObject::class);
+        $cteQuery = new DataQuery(SQLSelectTest\CteRecursiveObject::class);
+        $cteQuery->where([
+            '"SQLSelectTestCteRecursive"."ParentID" > 0',
+            '"SQLSelectTestCteRecursive"."Title" = ?' => 'child of child2'
+        ]);
+        $cteQuery->union(new SQLSelect(
+            '"SQLSelectTestCteRecursive"."ParentID"',
+            ['"hierarchy"', '"SQLSelectTestCteRecursive"'],
+            [
+                '"SQLSelectTestCteRecursive"."ParentID" > 0',
+                '"SQLSelectTestCteRecursive"."ID" = "hierarchy"."ParentID"'
+            ]
+        ));
+        $dataQuery->with('hierarchy', $cteQuery, ['ParentID'], true);
+        $dataQuery->innerJoin('hierarchy', '"SQLSelectTestCteRecursive"."ID" = "hierarchy"."ParentID"');
+
+        $expectedFixtures = [
+            'child2',
+            'parent',
+            'grandparent',
+        ];
+        $expectedData = [];
+        foreach ($expectedFixtures as $fixtureName) {
+            $expectedData[] = $this->objFromFixture(SQLSelectTest\CteRecursiveObject::class, $fixtureName)->toMap();
+        }
+        $this->assertListEquals($expectedData, new ArrayList(iterator_to_array($dataQuery->execute(), true)));
+    }
+
+    /**
+     * tests the WITH clause, using a DataQuery as the CTE query and as the unioned recursive query
+     */
+    public function testWithUsingOnlyDataQueries()
+    {
+        if (!DB::get_conn()->supportsCteQueries(true)) {
+            $this->markTestSkipped('The current database does not support recursive WITH clauses');
+        }
+        $dataQuery = new DataQuery(SQLSelectTest\CteRecursiveObject::class);
+        $cteQuery = new DataQuery(SQLSelectTest\CteRecursiveObject::class);
+        $cteQuery->where([
+            '"SQLSelectTestCteRecursive"."ParentID" > 0',
+            '"SQLSelectTestCteRecursive"."Title" = ?' => 'child of child2'
+        ]);
+        $cteQuery->union((new DataQuery(SQLSelectTest\CteRecursiveObject::class))
+            ->innerJoin('hierarchy', '"SQLSelectTestCteRecursive"."ID" = "hierarchy"."ParentID"')
+            ->where('"SQLSelectTestCteRecursive"."ParentID" > 0')
+            ->sort(null)
+            ->distinct(false));
+        // This test exists because previously when $cteFields was empty, it would cause an error with the above setup.
+        $dataQuery->with('hierarchy', $cteQuery, [], true);
+        $dataQuery->innerJoin('hierarchy', '"SQLSelectTestCteRecursive"."ID" = "hierarchy"."ParentID"');
+
+        $expectedFixtures = [
+            'child2',
+            'parent',
+            'grandparent',
+        ];
+        $expectedData = [];
+        foreach ($expectedFixtures as $fixtureName) {
+            $expectedData[] = $this->objFromFixture(SQLSelectTest\CteRecursiveObject::class, $fixtureName)->toMap();
+        }
+        $this->assertListEquals($expectedData, new ArrayList(iterator_to_array($dataQuery->execute(), true)));
+    }
+
+    /**
+     * Tests that CTE queries have appropriate JOINs for subclass tables etc.
+     * If `$query->query()->` was replaced with `$query->query->` in DataQuery::with(), this test would throw an exception.
+     * @doesNotPerformAssertions
+     */
+    public function testWithUsingDataQueryAppliesRelations()
+    {
+        if (!DB::get_conn()->supportsCteQueries()) {
+            $this->markTestSkipped('The current database does not support WITH clauses');
+        }
+        $dataQuery = new DataQuery(DataQueryTest\ObjectG::class);
+        $cteQuery = new DataQuery(DataQueryTest\ObjectG::class);
+        $cteQuery->where(['"DataQueryTest_G"."SubClassOnlyField" = ?' => 'This is the one']);
+        $dataQuery->with('test_implicit_joins', $cteQuery, ['ID']);
+        $dataQuery->innerJoin('test_implicit_joins', '"DataQueryTest_G"."ID" = "test_implicit_joins"."ID"');
+        // This will throw an exception if it fails - it passes if there's no exception.
+        $dataQuery->execute();
     }
 }

--- a/tests/php/ORM/DataQueryTest.yml
+++ b/tests/php/ORM/DataQueryTest.yml
@@ -9,6 +9,16 @@ SilverStripe\ORM\Tests\DataQueryTest\ObjectE:
     Title: 'Second'
     SortOrder: 2
 
+SilverStripe\ORM\Tests\DataQueryTest\ObjectF:
+  query1:
+    MyDate: '2023-06-01'
+  query2:
+    MyDate: '2023-01-01'
+  query3:
+    MyDate: '2023-01-02'
+  query4:
+    MyDate: '2023-06-02'
+
 SilverStripe\ORM\Tests\DataQueryTest\ObjectI:
   query1:
     Title: 'First'
@@ -41,3 +51,42 @@ SilverStripe\ORM\Tests\DataQueryTest\DataObjectAddsToQuery:
   obj1:
     FieldOne: 'This is a value'
     FieldTwo: 'This is also a value'
+
+SilverStripe\ORM\Tests\DataQueryTest\DateAndPriceObject:
+  nullobj:
+    Date: null
+    Price: null
+  obj1:
+    Price: 0
+    Date: '2023-01-01'
+  obj2:
+    Price: 100
+    Date: '2023-01-02'
+  obj3:
+    Price: 200
+    Date: '2023-01-04'
+  obj4:
+    Price: 300
+    Date: '2023-01-07'
+  obj5:
+    Price: 400
+    Date: '2023-01-08'
+
+SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject:
+  grandparent:
+    Title: 'grandparent'
+  parent:
+    Title: 'parent'
+    Parent: =>SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject.grandparent
+  child1:
+    Title: 'child1'
+    Parent: =>SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject.parent
+  child2:
+    Title: 'child2'
+    Parent: =>SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject.parent
+  child-of-child1:
+    Title: 'child of child1'
+    Parent: =>SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject.child1
+  child-of-child2:
+    Title: 'child of child2'
+    Parent: =>SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject.child2

--- a/tests/php/ORM/DataQueryTest/DateAndPriceObject.php
+++ b/tests/php/ORM/DataQueryTest/DateAndPriceObject.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataQueryTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class DateAndPriceObject extends DataObject implements TestOnly
+{
+    private static $table_name = 'DataQueryTest_DateAndPriceObject';
+
+    private static $db = [
+        'Date' => 'Date',
+        'Price' => 'Int',
+    ];
+}

--- a/tests/php/ORM/DataQueryTest/ObjectG.php
+++ b/tests/php/ORM/DataQueryTest/ObjectG.php
@@ -8,6 +8,10 @@ class ObjectG extends ObjectC implements TestOnly
 {
     private static $table_name = 'DataQueryTest_G';
 
+    private static $db = [
+        'SubClassOnlyField' => 'Text',
+    ];
+
     private static $belongs_many_many = [
         'ManyTestEs' => ObjectE::class,
     ];

--- a/tests/php/ORM/MySQLDatabaseTest.php
+++ b/tests/php/ORM/MySQLDatabaseTest.php
@@ -8,6 +8,8 @@ use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Connect\MySQLiConnector;
 use SilverStripe\ORM\Queries\SQLUpdate;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\Connect\MySQLDatabase;
+use SilverStripe\ORM\Tests\MySQLSchemaManagerTest\MySQLDBDummy;
 
 class MySQLDatabaseTest extends SapphireTest
 {
@@ -109,5 +111,106 @@ class MySQLDatabaseTest extends SapphireTest
         $result = $query->execute();
         $this->assertInstanceOf(MySQLQuery::class, $result);
         $this->assertEquals(1, DB::affected_rows());
+    }
+
+    public function provideSupportsCte()
+    {
+        return [
+            // mysql unsupported
+            [
+                'version' => '1.1.1',
+                'expected' => false,
+                'expectedRecursive' => false,
+            ],
+            [
+                'version' => '5.9999.9999',
+                'expected' => false,
+                'expectedRecursive' => false,
+            ],
+            [
+                'version' => '8.0.0',
+                'expected' => false,
+                'expectedRecursive' => false,
+            ],
+            // mysql supported
+            [
+                'version' => '8.0.1',
+                'expected' => true,
+                'expectedRecursive' => true,
+            ],
+            [
+                'version' => '10.2.0',
+                'expected' => true,
+                'expectedRecursive' => true,
+            ],
+            [
+                'version' => '999.999.999',
+                'expected' => true,
+                'expectedRecursive' => true,
+            ],
+            // mariaDB unsupported (various formats)
+            [
+                'version' => '5.5.5-10.2.0-mariadb-1:10.6.8+maria~focal',
+                'expected' => false,
+                'expectedRecursive' => false,
+            ],
+            [
+                'version' => '10.2.0-mariadb-1:10.6.8+maria~jammy',
+                'expected' => false,
+                'expectedRecursive' => false,
+            ],
+            [
+                'version' => '10.2.0-mariadb-1:10.2.0+maria~focal',
+                'expected' => false,
+                'expectedRecursive' => false,
+            ],
+            // mariadb supported (various formats)
+            [
+                'version' => '5.5.5-10.2.1-mariadb-1:10.6.8+maria~focal',
+                'expected' => true,
+                'expectedRecursive' => false,
+            ],
+            [
+                'version' => '10.2.1-mariadb-1:10.6.8+maria~jammy',
+                'expected' => true,
+                'expectedRecursive' => false,
+            ],
+            [
+                'version' => '10.2.1-mariadb-1:10.2.1+maria~focal',
+                'expected' => true,
+                'expectedRecursive' => false,
+            ],
+            [
+                'version' => '10.2.2-mariadb-1:10.2.2+maria~jammy',
+                'expected' => true,
+                'expectedRecursive' => true,
+            ],
+            [
+                'version' => '5.5.5-10.2.2-mariadb-1:10.2.2+maria~jammy',
+                'expected' => true,
+                'expectedRecursive' => true,
+            ],
+            [
+                'version' => '5.5.5-999.999.999-mariadb-1:10.2.2+maria~jammy',
+                'expected' => true,
+                'expectedRecursive' => true,
+            ],
+            // completely invalid versions
+            [
+                'version' => '999.999.999-some-random-string',
+                'expected' => false,
+                'expectedRecursive' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideSupportsCte
+     */
+    public function testSupportsCte(string $version, bool $expected, bool $expectedRecursive)
+    {
+        $database = new MySQLDBDummy($version);
+        $this->assertSame($expected, $database->supportsCteQueries());
+        $this->assertSame($expectedRecursive, $database->supportsCteQueries(true));
     }
 }

--- a/tests/php/ORM/SQLSelectTest.yml
+++ b/tests/php/ORM/SQLSelectTest.yml
@@ -9,3 +9,36 @@ SilverStripe\ORM\Tests\SQLSelectTest\TestObject:
     Meta: 'Details 2'
     Date: 2012-05-01 09:00:00
     Common: 'Common Value'
+
+SilverStripe\ORM\Tests\SQLSelectTest\CteDatesObject:
+  dates1:
+    Date: '2017-01-03'
+    Price: 300
+  dates2:
+    Date: '2017-01-06'
+    Price: 50
+  dates3:
+    Date: '2017-01-08'
+    Price: 180
+  dates4:
+    Date: '2017-01-10'
+    Price: 5
+
+SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject:
+  recursive1:
+    Title: 'grandparent'
+  recursive2:
+    Title: 'parent'
+    Parent: =>SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject.recursive1
+  recursive3:
+    Title: 'child1'
+    Parent: =>SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject.recursive2
+  recursive4:
+    Title: 'child2'
+    Parent: =>SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject.recursive2
+  recursive5:
+    Title: 'child of child1'
+    Parent: =>SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject.recursive3
+  recursive6:
+    Title: 'child of child2'
+    Parent: =>SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject.recursive5

--- a/tests/php/ORM/SQLSelectTest/CteDatesObject.php
+++ b/tests/php/ORM/SQLSelectTest/CteDatesObject.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\SQLSelectTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class CteDatesObject extends DataObject implements TestOnly
+{
+    private static $table_name = 'SQLSelectTestCteDates';
+
+    private static $db = [
+        'Date' => 'Date',
+        'Price' => 'Int',
+    ];
+}

--- a/tests/php/ORM/SQLSelectTest/CteRecursiveObject.php
+++ b/tests/php/ORM/SQLSelectTest/CteRecursiveObject.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\SQLSelectTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class CteRecursiveObject extends DataObject implements TestOnly
+{
+    private static $table_name = 'SQLSelectTestCteRecursive';
+
+    private static $db = [
+        'Title' => 'Varchar',
+    ];
+
+    private static $has_one = [
+        'Parent' => self::class,
+    ];
+
+    private static $has_many = [
+        'Children' => self::class . '.Parent',
+    ];
+}


### PR DESCRIPTION
Note that several times the code or comments in this PR refer to "CTE" - that stands for "Common Table Expression" and is a very very common way to refer to a `WITH` statement in SQL, making it a lot easier to find with a text search since "with" is such a common word.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10902