### PR TITLE
FIX Set tableName on DBField before calling addToQuery

### DIFF
--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -603,6 +603,7 @@ class DataQuery
         $schema = DataObject::getSchema();
         $databaseFields = $schema->databaseFields($tableClass, false);
         $compositeFields = $schema->compositeFields($tableClass, false);
+        $tableName = $schema->tableName($tableClass);
         unset($databaseFields['ID']);
         foreach ($databaseFields as $k => $v) {
             if ((is_null($columns) || in_array($k, $columns ?? [])) && !isset($compositeFields[$k])) {
@@ -618,12 +619,12 @@ class DataQuery
                     $query->selectField($quotedField, $k);
                 }
                 $dbO = Injector::inst()->create($v, $k);
+                $dbO->setTable($tableName);
                 $dbO->addToQuery($query);
             }
         }
         foreach ($compositeFields as $k => $v) {
             if ((is_null($columns) || in_array($k, $columns ?? [])) && $v) {
-                $tableName = $schema->tableName($tableClass);
                 $dbO = Injector::inst()->create($v, $k);
                 $dbO->setTable($tableName);
                 $dbO->addToQuery($query);

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -387,8 +387,9 @@ class DataQueryTest extends SapphireTest
         // Including filter on parent table only doesn't pull in second
         $query = new DataQuery(DataQueryTest\DataObjectAddsToQuery::class);
         $result = $query->getFinalisedQuery();
-        // The `DBFieldAddsToQuery` test field removes itself from the select query
-        $this->assertArrayNotHasKey('FieldTwo', $result->getSelect());
+        // The `DBFieldAddsToQuery` test field adds a new field to the select query
+        $this->assertArrayHasKey('FieldTwo2', $result->getSelect());
+        $this->assertSame('"DataQueryTest_AddsToQuery"."FieldTwo"', $result->getSelect()['FieldTwo2']);
     }
 
     /**

--- a/tests/php/ORM/DataQueryTest/DBFieldAddsToQuery.php
+++ b/tests/php/ORM/DataQueryTest/DBFieldAddsToQuery.php
@@ -4,13 +4,14 @@ namespace SilverStripe\ORM\Tests\DataQueryTest;
 
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\FieldType\DBText;
+use SilverStripe\ORM\Queries\SQLSelect;
 
 class DBFieldAddsToQuery extends DBText implements TestOnly
 {
     public function addToQuery(&$query)
     {
-        $select = $query->getSelect();
-        unset($select[$this->name]);
-        $query->setSelect($select);
+        // Add a new item, to validate that tableName and name are set correctly.
+        /** @var SQLSelect $query */
+        $query->addSelect([$this->name . '2' => '"' . $this->tableName . '"."' . $this->name . '"']);
     }
 }


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10945