### PR TITLE
MNT Spelling error in Maori language name

### DIFF
--- a/src/i18n/Data/Intl/IntlLocales.php
+++ b/src/i18n/Data/Intl/IntlLocales.php
@@ -1455,7 +1455,9 @@ class IntlLocales implements Locales, Resettable
         $locales = $this->config()->get('locales');
         $localised = [];
         foreach ($locales as $code => $default) {
-            $localised[$code] = $this->localeName($code);
+            // Fix spelling Maori language
+            $localeName = str_replace('Maori', 'Māori', $this->localeName($code));
+            $localised[$code] = $localeName;
         }
 
         // Save cache

--- a/tests/php/i18n/i18nTest.php
+++ b/tests/php/i18n/i18nTest.php
@@ -477,4 +477,9 @@ class i18nTest extends SapphireTest
             return i18n::getData()->languageName('de_CGN');
         }));
     }
+
+    public function testGetLocales()
+    {
+        $this->assertEquals('Māori (New Zealand)', i18n::getData()->getLocales()['mi_NZ']);
+    }
 }


### PR DESCRIPTION
## Parent issue
- https://github.com/silverstripe/.github/issues/111

## Note
I'm not quite sure that we need this, since It prevents user to find "Māori" without macrons.
