### PR TITLE
ENH Allow selecting multiple (or no) tables

### DIFF
--- a/src/ORM/Connect/DBQueryBuilder.php
+++ b/src/ORM/Connect/DBQueryBuilder.php
@@ -242,9 +242,25 @@ class DBQueryBuilder
     public function buildFromFragment(SQLConditionalExpression $query, array &$parameters)
     {
         $from = $query->getJoins($joinParameters);
+        $tables = [];
+        $joins = [];
+
+        // E.g. a naive "Select 1" statement is valid SQL
+        if (empty($from)) {
+            return '';
+        }
+
+        foreach ($from as $joinOrTable) {
+            if (preg_match(SQLConditionalExpression::getJoinRegex(), $joinOrTable)) {
+                $joins[] = $joinOrTable;
+            } else {
+                $tables[] = $joinOrTable;
+            }
+        }
+
         $parameters = array_merge($parameters, $joinParameters);
         $nl = $this->getSeparator();
-        return  "{$nl}FROM " . implode(' ', $from);
+        return  "{$nl}FROM " . implode(', ', $tables) . ' ' . implode(' ', $joins);
     }
 
     /**

--- a/src/ORM/Queries/SQLConditionalExpression.php
+++ b/src/ORM/Queries/SQLConditionalExpression.php
@@ -8,7 +8,6 @@ namespace SilverStripe\ORM\Queries;
  */
 abstract class SQLConditionalExpression extends SQLExpression
 {
-
     /**
      * An array of WHERE clauses.
      *
@@ -226,7 +225,7 @@ abstract class SQLConditionalExpression extends SQLExpression
         foreach ($this->from as $key => $tableClause) {
             if (is_array($tableClause)) {
                 $table = '"' . $tableClause['table'] . '"';
-            } elseif (is_string($tableClause) && preg_match('/JOIN +("[^"]+") +(AS|ON) +/i', $tableClause ?? '', $matches)) {
+            } elseif (is_string($tableClause) && preg_match(self::getJoinRegex(), $tableClause ?? '', $matches)) {
                 $table = $matches[1];
             } else {
                 $table = $tableClause;
@@ -325,11 +324,16 @@ abstract class SQLConditionalExpression extends SQLExpression
             return $from;
         }
 
-        // shift the first FROM table out from so we only deal with the JOINs
-        reset($from);
-        $baseFromAlias = key($from ?? []);
-        $baseFrom = array_shift($from);
+        // Remove the regular FROM tables out so we only deal with the JOINs
+        $regularTables = [];
+        foreach ($from as $alias => $tableClause) {
+            if (is_string($tableClause) && !preg_match(self::getJoinRegex(), $tableClause)) {
+                $regularTables[$alias] = $tableClause;
+                unset($from[$alias]);
+            }
+        }
 
+        // Sort the joins
         $this->mergesort($from, function ($firstJoin, $secondJoin) {
             if (!is_array($firstJoin)
                 || !is_array($secondJoin)
@@ -341,11 +345,14 @@ abstract class SQLConditionalExpression extends SQLExpression
             }
         });
 
-        // Put the first FROM table back into the results
-        if (!empty($baseFromAlias) && !is_numeric($baseFromAlias)) {
-            $from = array_merge([$baseFromAlias => $baseFrom], $from);
-        } else {
-            array_unshift($from, $baseFrom);
+        // Put the regular FROM tables back into the results
+        $regularTables = array_reverse($regularTables, true);
+        foreach ($regularTables as $alias => $tableName) {
+            if (!empty($alias) && !is_numeric($alias)) {
+                $from = array_merge([$alias => $tableName], $from);
+            } else {
+                array_unshift($from, $tableName);
+            }
         }
 
         return $from;
@@ -772,5 +779,13 @@ abstract class SQLConditionalExpression extends SQLExpression
         $update = new SQLUpdate();
         $this->copyTo($update);
         return $update;
+    }
+
+    /**
+     * Get the regular expression pattern used to identify JOIN statements
+     */
+    public static function getJoinRegex(): string
+    {
+        return '/JOIN +.*? +(AS|ON|USING\(?) +/i';
     }
 }

--- a/src/ORM/Queries/SQLSelect.php
+++ b/src/ORM/Queries/SQLSelect.php
@@ -162,6 +162,9 @@ class SQLSelect extends SQLConditionalExpression
             $fields = [$fields];
         }
         foreach ($fields as $idx => $field) {
+            if ($field === '') {
+                continue;
+            }
             $this->selectField($field, is_numeric($idx) ? null : $idx);
         }
 
@@ -712,5 +715,11 @@ class SQLSelect extends SQLConditionalExpression
         $index = max($this->count() + $offset - 1, 0);
         $query->setLimit(1, $index);
         return $query;
+    }
+
+    public function isEmpty()
+    {
+        // Empty if there's no select, or we're trying to select '*' but there's no FROM clause
+        return empty($this->select) || (empty($this->from) && array_key_exists('*', $this->select));
     }
 }


### PR DESCRIPTION
Currently to select multiple tables in an SQLSelect query, you need to explicitly add a comma to subsequent tables in the FROM clause. This is a pretty bad smell, isn't intuitive or documented, and will make it harder to use Common Table Expressions (aka WITH clauses) once those are implemented - so this seems like a good time to remove that limitation.

Also allows selecting NO tables, e.g. `SELECT 1;` is a perfectly valid SQL select statement. These can be useful in testing things like unions, but are also sometimes useful in Common Table Expressions.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10902