### PR TITLE
NEW Add abstraction for sql RIGHT JOIN

### DIFF
--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -832,6 +832,26 @@ class DataQuery
     }
 
     /**
+     * Add a RIGHT JOIN clause to this query.
+     *
+     * @param string $table The unquoted table to join to.
+     * @param string $onClause The filter for the join (escaped SQL statement).
+     * @param string $alias An optional alias name (unquoted)
+     * @param int $order A numerical index to control the order that joins are added to the query; lower order values
+     * will cause the query to appear first. The default is 20, and joins created automatically by the
+     * ORM have a value of 10.
+     * @param array $parameters Any additional parameters if the join is a parameterised subquery
+     * @return $this
+     */
+    public function rightJoin($table, $onClause, $alias = null, $order = 20, $parameters = [])
+    {
+        if ($table) {
+            $this->query->addRightJoin($table, $onClause, $alias, $order, $parameters);
+        }
+        return $this;
+    }
+
+    /**
      * Prefix of all joined table aliases. E.g. ->filter('Banner.Image.Title)'
      * Will join the Banner, and then Image relations
      * `$relationPrefx` will be `banner_image_`

--- a/src/ORM/Queries/SQLConditionalExpression.php
+++ b/src/ORM/Queries/SQLConditionalExpression.php
@@ -136,17 +136,25 @@ abstract class SQLConditionalExpression extends SQLExpression
      */
     public function addLeftJoin($table, $onPredicate, $tableAlias = '', $order = 20, $parameters = [])
     {
-        if (!$tableAlias) {
-            $tableAlias = $table;
-        }
-        $this->from[$tableAlias] = [
-            'type' => 'LEFT',
-            'table' => $table,
-            'filter' => [$onPredicate],
-            'order' => $order,
-            'parameters' => $parameters
-        ];
-        return $this;
+        return $this->addJoin($table, 'LEFT', $onPredicate, $tableAlias, $order, $parameters);
+    }
+
+    /**
+     * Add a RIGHT JOIN criteria to the tables list.
+     *
+     * @param string $table Unquoted table name
+     * @param string $onPredicate The "ON" SQL fragment in a "RIGHT JOIN ... AS ... ON ..." statement, Needs to be valid
+     *                            (quoted) SQL.
+     * @param string $tableAlias Optional alias which makes it easier to identify and replace joins later on
+     * @param int $order A numerical index to control the order that joins are added to the query; lower order values
+     *                   will cause the query to appear first. The default is 20, and joins created automatically by the
+     *                   ORM have a value of 10.
+     * @param array $parameters Any additional parameters if the join is a parameterized subquery
+     * @return $this Self reference
+     */
+    public function addRightJoin($table, $onPredicate, $tableAlias = '', $order = 20, $parameters = [])
+    {
+        return $this->addJoin($table, 'RIGHT', $onPredicate, $tableAlias, $order, $parameters);
     }
 
     /**
@@ -164,11 +172,19 @@ abstract class SQLConditionalExpression extends SQLExpression
      */
     public function addInnerJoin($table, $onPredicate, $tableAlias = null, $order = 20, $parameters = [])
     {
+        return $this->addJoin($table, 'INNER', $onPredicate, $tableAlias, $order, $parameters);
+    }
+
+    /**
+     * Add a JOIN criteria
+     */
+    private function addJoin($table, $type, $onPredicate, $tableAlias = null, $order = 20, $parameters = []): static
+    {
         if (!$tableAlias) {
             $tableAlias = $table;
         }
         $this->from[$tableAlias] = [
-            'type' => 'INNER',
+            'type' => $type,
             'table' => $table,
             'filter' => [$onPredicate],
             'order' => $order,

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -51,22 +51,33 @@ class DataQueryTest extends SapphireTest
         $this->assertEquals('Foo', $result['Title']);
     }
 
+    public function provideJoins()
+    {
+        return [
+            [
+                'joinMethod' => 'innerJoin',
+                'joinType' => 'INNER',
+            ],
+            [
+                'joinMethod' => 'leftJoin',
+                'joinType' => 'LEFT',
+            ],
+            [
+                'joinMethod' => 'rightJoin',
+                'joinType' => 'RIGHT',
+            ],
+        ];
+    }
+
     /**
-     * Test the leftJoin() and innerJoin method of the DataQuery object
+     * @dataProvider provideJoins
      */
-    public function testJoins()
+    public function testJoins($joinMethod, $joinType)
     {
         $dq = new DataQuery(Member::class);
-        $dq->innerJoin("Group_Members", "\"Group_Members\".\"MemberID\" = \"Member\".\"ID\"");
+        $dq->$joinMethod("Group_Members", "\"Group_Members\".\"MemberID\" = \"Member\".\"ID\"");
         $this->assertSQLContains(
-            "INNER JOIN \"Group_Members\" ON \"Group_Members\".\"MemberID\" = \"Member\".\"ID\"",
-            $dq->sql($parameters)
-        );
-
-        $dq = new DataQuery(Member::class);
-        $dq->leftJoin("Group_Members", "\"Group_Members\".\"MemberID\" = \"Member\".\"ID\"");
-        $this->assertSQLContains(
-            "LEFT JOIN \"Group_Members\" ON \"Group_Members\".\"MemberID\" = \"Member\".\"ID\"",
+            "$joinType JOIN \"Group_Members\" ON \"Group_Members\".\"MemberID\" = \"Member\".\"ID\"",
             $dq->sql($parameters)
         );
     }


### PR DESCRIPTION
Currently adding a RIGHT JOIN to a query, especially to a `DataQuery`, is quite difficult.
Right joins are really powerful in conjunction with Common Table Expressions (aka WITH clauses), so now is a good time to add this abstraction.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10902