### PR TITLE
ENH Enable allowing collisions for field statements

### DIFF
--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -172,6 +172,33 @@ class DataQueryTest extends SapphireTest
         $this->assertTrue(true);
     }
 
+    public function provideFieldCollision()
+    {
+        return [
+            'allow collisions' => [true],
+            'disallow collisions' => [false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFieldCollision
+     */
+    public function testFieldCollision($allowCollisions)
+    {
+        $dataQuery = new DataQuery(DataQueryTest\ObjectB::class);
+        $dataQuery->selectField('COALESCE(NULL, 1) AS "Title"');
+        $dataQuery->setAllowCollidingFieldStatements($allowCollisions);
+
+        if ($allowCollisions) {
+            $this->assertSQLContains('THEN "DataQueryTest_B"."Title" WHEN COALESCE(NULL, 1) AS "Title" IS NOT NULL THEN COALESCE(NULL, 1) AS "Title" ELSE NULL END AS "Title"', $dataQuery->sql());
+        } else {
+            $this->expectError();
+            $this->expectErrorMessageMatches('/^Bad collision item /');
+        }
+
+        $dataQuery->getFinalisedQuery();
+    }
+
     public function testDisjunctiveGroup()
     {
         $dq = new DataQuery(DataQueryTest\ObjectA::class);


### PR DESCRIPTION
This one's a bit abstract as its own PR, but it makes sense in conjunction with the unit tests being added to https://github.com/silverstripe/silverstripe-framework/pull/10943 - specifically the "recursive CTE with extrapolated data" test scenario in `DataQueryTest`. That test (and indeed that entire query scenario) is not possible without allowing this, or something _like_ this. Note that test uses an old name for the method - I'll update that once this and all other related PRs are merged.

It would probably be better to instead have a "coallesce" method, but the problem with that is we don't have a clean way to define the _order_ of coalescence because a lot of fields aren't added until the query is finalised, so that method would be highly un-intuitive unless we made some breaking changes.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10902