### PR TITLE
FIX Match multi-line JOIN statements

### DIFF
--- a/src/ORM/Queries/SQLConditionalExpression.php
+++ b/src/ORM/Queries/SQLConditionalExpression.php
@@ -802,6 +802,6 @@ abstract class SQLConditionalExpression extends SQLExpression
      */
     public static function getJoinRegex(): string
     {
-        return '/JOIN +.*? +(AS|ON|USING\(?) +/i';
+        return '/JOIN\s+.*?\s+(AS|ON|USING\(?)\s+/is';
     }
 }

--- a/tests/php/ORM/DBQueryBuilderTest.php
+++ b/tests/php/ORM/DBQueryBuilderTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SilverStripe\ORM\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\Connect\DBQueryBuilder;
+use SilverStripe\ORM\Queries\SQLSelect;
+
+class DBQueryBuilderTest extends SapphireTest
+{
+    protected $usesDatabase = false;
+
+    public function testMultilineJoin()
+    {
+        $join = <<<JOIN
+        INNER JOIN
+        (SELECT DISTINCT "SiteTreeLink"."ClassName", "SiteTreeLink"."LastEdited", "SiteTreeLink"."Created", "SiteTreeLink"."LinkedID",
+        "SiteTreeLink"."ParentID", "SiteTreeLink"."ParentClass", "SiteTreeLink"."ID" FROM "SiteTreeLink")
+        AS "SiteTreeLink" ON "SiteTreeLink"."LinkedID" = "SiteTree"."ID"
+        JOIN;
+        $select = new SQLSelect('*', ['SomeTable', $join]);
+        $builder = new DBQueryBuilder();
+
+        $params = [];
+        $this->assertSame('FROM SomeTable ' . $join, trim($builder->buildFromFragment($select, $params)));
+    }
+}


### PR DESCRIPTION
This bug was introduced in https://github.com/silverstripe/silverstripe-framework/pull/10953
The error was caused by not accounting for JOIN clauses that span multiple lines - so the query builder thought the JOIN was actually a table name.

Because this was causing failure in multiple modules, I've created a full installer CI run:
https://github.com/creative-commoners/silverstripe-installer/actions/runs/6304821057

## Issue
- https://github.com/silverstripe/.github/issues/118