### PR TITLE
Fixed addFieldsToTab FieldList field is null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage/
 /vendor/
 composer.lock
 silverstripe-cache/
+.idea

--- a/src/Forms/FieldList.php
+++ b/src/Forms/FieldList.php
@@ -268,14 +268,17 @@ class FieldList extends ArrayList
 
         // Add the fields to the end of this set
         foreach ($fields as $field) {
-            // Check if a field by the same name exists in this tab
-            if ($insertBefore) {
-                $tab->insertBefore($insertBefore, $field);
-            } elseif (($name = $field->getName()) && $tab->fieldByName($name)) {
-                // It exists, so we need to replace the old one
-                $this->replaceField($field->getName(), $field);
-            } else {
-                $tab->push($field);
+            // Check if field is not null
+            if($field !== null) {
+                // Check if a field by the same name exists in this tab
+                if ($insertBefore) {
+                    $tab->insertBefore($insertBefore, $field);
+                } elseif (($name = $field->getName()) && $tab->fieldByName($name)) {
+                    // It exists, so we need to replace the old one
+                    $this->replaceField($field->getName(), $field);
+                } else {
+                    $tab->push($field);
+                }
             }
         }
 


### PR DESCRIPTION
I have found this error in CMS 4.13  while testing Redirector Page it prompts this error:

`error-log.ERROR: Uncaught Exception Error: "Call to a member function getName() on null`

This line of code is cause the issue  `} elseif (($name = $field->getName()) && $tab->fieldByName($name)) {`