### PR TITLE
FIX HTMLEditorField::setRows minimal height

### DIFF
--- a/src/Forms/HTMLEditor/HTMLEditorField.php
+++ b/src/Forms/HTMLEditor/HTMLEditorField.php
@@ -114,19 +114,22 @@ class HTMLEditorField extends TextareaField
 
     public function getAttributes()
     {
+        $config = $this->getEditorConfig();
         // Fix CSS height based on rows
         $rowHeight = $this->config()->get('fixed_row_height');
         $attributes = [];
-        if ($rowHeight) {
+        if ($rowHeight && ($config instanceof TinyMCEConfig)) {
             $height = $this->getRows() * $rowHeight;
             $attributes['style'] = sprintf('height: %dpx;', $height);
+            $config = clone $config;
+            $config->setOption('height', 'auto');
         }
 
         // Merge attributes
         return array_merge(
             $attributes,
             parent::getAttributes(),
-            $this->getEditorConfig()->getAttributes()
+            $config->getAttributes()
         );
     }
 


### PR DESCRIPTION
## Description
The TinyMCE configuration introduces the `height => 'auto'` property, this will help set the height value for some nested elements. 
This `height` value will override the value specified in the `_config.php file`, if there is one.
Therefore, when using this `setRows` method, it is worth considering that the height specified in `_config.php` file will not be taken into account.

## Test steps

Update Page.php with the following code.

```php

use use SilverStripe\CMS\Model\SiteTree;
use SilverStripe\Forms\HTMLEditor\HTMLEditorField;

class Page extends SiteTree
{
  public function getCMSFields()
  {
      $fields = parent::getCMSFields();
      $fields->removeByName('Content');
      $fields->addFieldToTab('Root.Main', HTMLEditorField::create('OtherContent1')->setRows(2));
      $fields->addFieldToTab('Root.Main', HTMLEditorField::create('OtherContent2')->setRows(4));
      $fields->addFieldToTab('Root.Main', HTMLEditorField::create('OtherContent3')->setRows(5));
      $fields->addFieldToTab('Root.Main', HTMLEditorField::create('OtherContent4')->setRows(10));

      return $fields;
  }
}
```
- Fields should have height `20px` * `passed value to setRows`, E.g.  setRows(2) = 20px * 2 = 40px;
- Fields should be resizable.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10938
