### PR TITLE
ENH allow stacked messages on FormMessage

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -477,7 +477,8 @@ class Form extends ViewableData implements HasRequestHandler
 
     /**
      * Populate this form with messages from the given ValidationResult.
-     * Note: This will not clear any pre-existing messages
+     * Note: This will try not to clear any pre-existing messages, but will clear them
+     * if a new message has a different message type or cast than the existing ones.
      *
      * @param ValidationResult $result
      * @return $this
@@ -494,7 +495,7 @@ class Form extends ViewableData implements HasRequestHandler
                 $owner = $this;
             }
 
-            $owner->setMessage($message['message'], $message['messageType'], $message['messageCast']);
+            $owner->appendMessage($message['message'], $message['messageType'], $message['messageCast'], true);
         }
         return $this;
     }


### PR DESCRIPTION
Fixes #10270 

Adds a new method: `FormMessage::appendMessage()` which attempts to stack messages if it can, falling back to the current behaviour of setting the message if there's a mismatch.

<img width="863" alt="image" src="https://github.com/silverstripe/silverstripe-framework/assets/9702648/2056f057-2d37-4ad6-9be0-60c38f8805fb">
