### PR TITLE
Add support for braille format files

### DIFF
--- a/_config/mimetypes.yml
+++ b/_config/mimetypes.yml
@@ -67,6 +67,7 @@ SilverStripe\Control\HTTP:
     box: application/vnd.previewsystems.box
     boz: application/x-bzip2
     bpk: application/octet-stream
+    brf: text/plain
     btif: image/prs.btif
     bz: application/x-bzip
     bz2: application/x-bzip2


### PR DESCRIPTION
This adds support for the [Braille ASCII file format](https://en.wikipedia.org/wiki/Braille_ASCII). 

This is increasingly requested by clients in the public sector.

*Possible caveat:* It seems, there is disagreement on what mime type `brf` files should be: datatypes.net says it should be `application/octet-stream` ([ref](https://datatypes.net/open-brf-files)), but apache says it should be text/plain ([ref](https://bz.apache.org/bugzilla/show_bug.cgi?id=41240)). In custom configurations we typically add both.

In this case I believe the apache decision pre-dates datetypes.net (I only see May 2022 in the [wayback machine](https://web.archive.org/web/20230000000000*/https://datatypes.net/open-brf-files)) and makes more sense given the type of content within the file.

## Issue
- https://github.com/silverstripe/silverstripe-assets/issues/573