### PR TITLE
Update URLSegmentFilter default_replacement ordering

### DIFF
--- a/src/View/Parsers/URLSegmentFilter.php
+++ b/src/View/Parsers/URLSegmentFilter.php
@@ -35,8 +35,8 @@ class URLSegmentFilter implements FilterInterface
         '/&/u' => '-and-',
         '/\s|\+/u' => '-', // remove whitespace/plus
         '/[_.]+/u' => '-', // underscores and dots to dashes
-        '/[^A-Za-z0-9\-]+/u' => '', // remove non-ASCII chars, only allow alphanumeric and dashes
         '/[\/\?=#:]+/u' => '-', // remove forward slashes, question marks, equal signs, hashes and colons in case multibyte is allowed (and non-ASCII chars aren't removed)
+        '/[^A-Za-z0-9\-]+/u' => '', // remove non-ASCII chars, only allow alphanumeric and dashes
         '/[\-]{2,}/u' => '-', // remove duplicate dashes
         '/^[\-]+/u' => '', // Remove all leading dashes
         '/[\-]+$/u' => '' // Remove all trailing dashes


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11045

Forward slashes, question marks, equal signs, hashes and colons were never actually being replaced with hyphens due to the order of the `default_replacements` array.

The regex rule before it was always blasting it away.