### PR TITLE
Use field editorconfig when sanitising content

### DIFF
--- a/src/Forms/HTMLEditor/HTMLEditorField.php
+++ b/src/Forms/HTMLEditor/HTMLEditorField.php
@@ -145,7 +145,8 @@ class HTMLEditorField extends TextareaField
         // Sanitise if requested
         $htmlValue = HTMLValue::create($this->Value());
         if (HTMLEditorField::config()->sanitise_server_side) {
-            $santiser = HTMLEditorSanitiser::create(HTMLEditorConfig::get_active());
+            $config = $this->getEditorConfig();
+            $santiser = HTMLEditorSanitiser::create($config);
             $santiser->sanitise($htmlValue);
         }
 


### PR DESCRIPTION
see https://github.com/silverstripe/silverstripe-framework/issues/10975 for the original issue
This changes to using the field configured HTMLEditorConfig instance when sanitising content for saving. It will fall back to the active config if none is defined on the field. 

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10975