### PR TITLE
Add buildtask and dev URL permissions

### DIFF
--- a/_config/requestprocessors.yml
+++ b/_config/requestprocessors.yml
@@ -87,7 +87,7 @@ SilverStripe\Core\Injector\Injector:
         DevUrlsConfirmationMiddleware: '%$DevUrlsConfirmationMiddleware'
 
   DevUrlsConfirmationMiddleware:
-    class: SilverStripe\Control\Middleware\PermissionAwareConfirmationMiddleware
+    class: SilverStripe\Control\Middleware\DevelopmentAdminConfirmationMiddleware
     constructor:
       - '%$SilverStripe\Control\Middleware\ConfirmationMiddleware\UrlPathStartswith("dev")'
     properties:
@@ -97,8 +97,6 @@ SilverStripe\Core\Injector\Injector:
         - '%$SilverStripe\Control\Middleware\ConfirmationMiddleware\CliBypass'
         - '%$SilverStripe\Control\Middleware\ConfirmationMiddleware\EnvironmentBypass("dev")'
       EnforceAuthentication: false
-      AffectedPermissions:
-        - ADMIN
 
 ---
 Name: dev_urls-confirmation-exceptions

--- a/_config/requestprocessors.yml
+++ b/_config/requestprocessors.yml
@@ -121,9 +121,6 @@ SilverStripe\Core\Injector\Injector:
   DevUrlsConfirmationMiddleware:
     properties:
       Bypasses:
-        # dev/build is covered by URLSpecialsMiddleware
-        - '%$SilverStripe\Control\Middleware\ConfirmationMiddleware\UrlPathStartswith("dev/build")'
-
         # The confirmation form is where people will be redirected for confirmation. We don't want to block it.
         - '%$SilverStripe\Control\Middleware\ConfirmationMiddleware\UrlPathStartswith("dev/confirm")'
 

--- a/src/Control/Middleware/DevelopmentAdminConfirmationMiddleware.php
+++ b/src/Control/Middleware/DevelopmentAdminConfirmationMiddleware.php
@@ -44,6 +44,11 @@ class DevelopmentAdminConfirmationMiddleware extends PermissionAwareConfirmation
         }
 
         $registeredRoutes = DevelopmentAdmin::config()->get('registered_controllers');
+        while (!isset($registeredRoutes[$action]) && strpos($action, '/') !== false) {
+            // Check for the parent route if a specific route isn't found
+            $action = substr($action, 0, strrpos($action, '/'));
+        }
+
         if (isset($registeredRoutes[$action]['controller'])) {
             $initPermissions = Config::forClass($registeredRoutes[$action]['controller'])->get('init_permissions');
             foreach ($initPermissions as $permission) {

--- a/src/Control/Middleware/DevelopmentAdminConfirmationMiddleware.php
+++ b/src/Control/Middleware/DevelopmentAdminConfirmationMiddleware.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SilverStripe\Control\Middleware;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\DevelopmentAdmin;
+use SilverStripe\Security\Permission;
+
+/**
+ * Extends the PermissionAwareConfirmationMiddleware with checks for user permissions
+ *
+ * Respects users who don't have enough access and does not
+ * ask them for confirmation
+ *
+ * By default it enforces authentication by redirecting users to a login page.
+ *
+ * How it works:
+ *  - if user can bypass the middleware, then pass request further
+ *  - if there are no confirmation items, then pass request further
+ *  - if user is not authenticated and enforceAuthentication is false, then pass request further
+ *  - if user does not have at least one of the affected permissions, then pass request further
+ *  - otherwise, pass handling to the parent (ConfirmationMiddleware)
+ */
+class DevelopmentAdminConfirmationMiddleware extends PermissionAwareConfirmationMiddleware
+{
+
+    /**
+     * Check whether the user has permissions to perform the target operation
+     * Otherwise we may want to skip the confirmation dialog.
+     *
+     * WARNING! The user has to be authenticated beforehand
+     *
+     * @param HTTPRequest $request
+     *
+     * @return bool
+     */
+    public function hasAccess(HTTPRequest $request)
+    {
+        $action = $request->remaining();
+        if (empty($action)) {
+            return false;
+        }
+
+        $registeredRoutes = DevelopmentAdmin::config()->get('registered_controllers');
+        if (isset($registeredRoutes[$action]['controller'])) {
+            $initPermissions = Config::forClass($registeredRoutes[$action]['controller'])->get('init_permissions');
+            foreach ($initPermissions as $permission) {
+                if (Permission::check($permission)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Control/Middleware/URLSpecialsMiddleware.php
+++ b/src/Control/Middleware/URLSpecialsMiddleware.php
@@ -39,8 +39,7 @@ class URLSpecialsMiddleware extends PermissionAwareConfirmationMiddleware
         parent::__construct(
             new ConfirmationMiddleware\GetParameter("flush"),
             new ConfirmationMiddleware\GetParameter("isDev"),
-            new ConfirmationMiddleware\GetParameter("isTest"),
-            new ConfirmationMiddleware\UrlPathStartswith("dev/build")
+            new ConfirmationMiddleware\GetParameter("isTest")
         );
     }
 

--- a/src/Dev/DevBuildController.php
+++ b/src/Dev/DevBuildController.php
@@ -22,6 +22,12 @@ class DevBuildController extends Controller implements PermissionProvider
         'build'
     ];
 
+    private static $init_permissions = [
+        'ADMIN',
+        'ALL_DEV_ADMIN',
+        'CAN_DEV_BUILD',
+    ];
+
     protected function init(): void
     {
         parent::init();
@@ -59,7 +65,7 @@ class DevBuildController extends Controller implements PermissionProvider
             // We need to ensure that DevelopmentAdminTest can simulate permission failures when running
             // "dev/tasks" from CLI.
             || (Director::is_cli() && DevelopmentAdmin::config()->get('allow_all_cli'))
-            || Permission::check(['ADMIN', 'ALL_DEV_ADMIN', 'CAN_DEV_BUILD'])
+            || Permission::check(static::config()->get('init_permissions'))
         );
     }
     

--- a/src/Dev/DevConfigController.php
+++ b/src/Dev/DevConfigController.php
@@ -35,6 +35,12 @@ class DevConfigController extends Controller implements PermissionProvider
         'audit',
     ];
 
+    private static $init_permissions = [
+        'ADMIN',
+        'ALL_DEV_ADMIN',
+        'CAN_DEV_CONFIG',
+    ];
+
     protected function init(): void
     {
         parent::init();
@@ -148,7 +154,7 @@ class DevConfigController extends Controller implements PermissionProvider
             // We need to ensure that DevelopmentAdminTest can simulate permission failures when running
             // "dev/tasks" from CLI.
             || (Director::is_cli() && DevelopmentAdmin::config()->get('allow_all_cli'))
-            || Permission::check(['ADMIN', 'ALL_DEV_ADMIN', 'CAN_DEV_CONFIG'])
+            || Permission::check(static::config()->get('init_permissions'))
         );
     }
     

--- a/src/Dev/DevelopmentAdmin.php
+++ b/src/Dev/DevelopmentAdmin.php
@@ -2,17 +2,20 @@
 
 namespace SilverStripe\Dev;
 
-use SilverStripe\Core\Config\Config;
-use SilverStripe\Core\Injector\Injector;
+use Exception;
+use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\Control\Controller;
-use SilverStripe\Versioned\Versioned;
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\DatabaseAdmin;
 use SilverStripe\Security\Permission;
+use SilverStripe\Security\PermissionProvider;
 use SilverStripe\Security\Security;
-use Exception;
+use SilverStripe\Versioned\Versioned;
 
 /**
  * Base class for development tools.
@@ -25,7 +28,7 @@ use Exception;
  * @todo cleanup errors() it's not even an allowed action, so can go
  * @todo cleanup index() html building
  */
-class DevelopmentAdmin extends Controller
+class DevelopmentAdmin extends Controller implements PermissionProvider
 {
 
     private static $url_handlers = [
@@ -84,22 +87,8 @@ class DevelopmentAdmin extends Controller
         if (static::config()->get('deny_non_cli') && !Director::is_cli()) {
             return $this->httpError(404);
         }
-
-        // Special case for dev/build: Defer permission checks to DatabaseAdmin->init() (see #4957)
-        $requestedDevBuild = (stripos($this->getRequest()->getURL() ?? '', 'dev/build') === 0)
-            && (stripos($this->getRequest()->getURL() ?? '', 'dev/build/defaults') === false);
-
-        // We allow access to this controller regardless of live-status or ADMIN permission only
-        // if on CLI.  Access to this controller is always allowed in "dev-mode", or of the user is ADMIN.
-        $allowAllCLI = static::config()->get('allow_all_cli');
-        $canAccess = (
-            $requestedDevBuild
-            || Director::isDev()
-            || (Director::is_cli() && $allowAllCLI)
-            // Its important that we don't run this check if dev/build was requested
-            || Permission::check("ADMIN")
-        );
-        if (!$canAccess) {
+        
+        if (!$this->canViewAll() && empty($this->getLinks())) {
             Security::permissionFailure($this);
             return;
         }
@@ -114,6 +103,7 @@ class DevelopmentAdmin extends Controller
 
     public function index()
     {
+        $links = $this->getLinks();
         // Web mode
         if (!Director::is_cli()) {
             $renderer = DebugView::create();
@@ -123,7 +113,7 @@ class DevelopmentAdmin extends Controller
 
             echo '<div class="options"><ul>';
             $evenOdd = "odd";
-            foreach (self::get_links() as $action => $description) {
+            foreach ($links as $action => $description) {
                 echo "<li class=\"$evenOdd\"><a href=\"{$base}dev/$action\"><b>/dev/$action:</b>"
                     . " $description</a></li>\n";
                 $evenOdd = ($evenOdd == "odd") ? "even" : "odd";
@@ -135,7 +125,7 @@ class DevelopmentAdmin extends Controller
         } else {
             echo "SILVERSTRIPE DEVELOPMENT TOOLS\n--------------------------\n\n";
             echo "You can execute any of the following commands:\n\n";
-            foreach (self::get_links() as $action => $description) {
+            foreach ($links as $action => $description) {
                 echo "  sake dev/$action: $description\n";
             }
             echo "\n\n";
@@ -165,23 +155,49 @@ class DevelopmentAdmin extends Controller
         }
     }
 
-
-
-
     /*
      * Internal methods
      */
 
     /**
+     * @deprecated 5.2.0 use getLinks() instead to include permission checks
      * @return array of url => description
      */
     protected static function get_links()
     {
+        Deprecation::notice('5.2.0', 'Use getLinks() instead to include permission checks');
         $links = [];
 
         $reg = Config::inst()->get(static::class, 'registered_controllers');
         foreach ($reg as $registeredController) {
             if (isset($registeredController['links'])) {
+                foreach ($registeredController['links'] as $url => $desc) {
+                    $links[$url] = $desc;
+                }
+            }
+        }
+        return $links;
+    }
+
+    protected function getLinks(): array
+    {
+        $canViewAll = $this->canViewAll();
+        $links = [];
+        $reg = Config::inst()->get(static::class, 'registered_controllers');
+        foreach ($reg as $registeredController) {
+            if (isset($registeredController['links'])) {
+                if (!ClassInfo::exists($registeredController['controller'])) {
+                    continue;
+                }
+
+                if (!$canViewAll) {
+                    // Check access to controller
+                    $controllerSingleton = Injector::inst()->get($registeredController['controller']);
+                    if (!$controllerSingleton->hasMethod('canInit') || !$controllerSingleton->canInit()) {
+                        continue;
+                    }
+                }
+
                 foreach ($registeredController['links'] as $url => $desc) {
                     $links[$url] = $desc;
                 }
@@ -201,8 +217,6 @@ class DevelopmentAdmin extends Controller
 
         return null;
     }
-
-
 
 
     /*
@@ -257,5 +271,40 @@ TXT;
     public function errors()
     {
         $this->redirect("Debug_");
+    }
+
+    public function providePermissions(): array
+    {
+        return [
+            'ALL_DEV_ADMIN' => [
+                'name' => _t(__CLASS__ . '.ALL_DEV_ADMIN_DESCRIPTION', 'Can view and execute all /dev endpoints'),
+                'help' => _t(__CLASS__ . '.ALL_DEV_ADMIN_HELP', 'Can view and execute all /dev endpoints'),
+                'category' => static::permissionsCategory(),
+                'sort' => 50
+            ],
+        ];
+    }
+
+    public static function permissionsCategory(): string
+    {
+        return  _t(__CLASS__ . 'PERMISSIONS_CATEGORY', 'Dev permissions');
+    }
+
+    protected function canViewAll(): bool
+    {
+        // Special case for dev/build: Defer permission checks to DatabaseAdmin->init() (see #4957)
+        $requestedDevBuild = (stripos($this->getRequest()->getURL() ?? '', 'dev/build') === 0)
+            && (stripos($this->getRequest()->getURL() ?? '', 'dev/build/defaults') === false);
+
+        // We allow access to this controller regardless of live-status or ADMIN permission only
+        // if on CLI.  Access to this controller is always allowed in "dev-mode", or of the user is ADMIN.
+        $allowAllCLI = static::config()->get('allow_all_cli');
+        return (
+            $requestedDevBuild
+            || Director::isDev()
+            || (Director::is_cli() && $allowAllCLI)
+            // Its important that we don't run this check if dev/build was requested
+            || Permission::check(['ADMIN', 'ALL_DEV_ADMIN'])
+        );
     }
 }

--- a/src/Dev/TaskRunner.php
+++ b/src/Dev/TaskRunner.php
@@ -128,7 +128,7 @@ class TaskRunner extends Controller implements PermissionProvider
             }
         }
 
-        $message(sprintf('The build task "%s" could not be found', Convert::raw2xml($name)));
+        $message(sprintf('The build task "%s" could not be found, is disabled or you do not have sufficient permission to run it', Convert::raw2xml($name)));
     }
 
     /**

--- a/src/Dev/TaskRunner.php
+++ b/src/Dev/TaskRunner.php
@@ -33,6 +33,12 @@ class TaskRunner extends Controller implements PermissionProvider
         'runTask',
     ];
 
+    private static $init_permissions = [
+        'ADMIN',
+        'ALL_DEV_ADMIN',
+        'BUILDTASK_CAN_RUN',
+    ];
+
     /**
      * @var array
      */
@@ -206,7 +212,7 @@ class TaskRunner extends Controller implements PermissionProvider
             // We need to ensure that DevelopmentAdminTest can simulate permission failures when running
             // "dev/tasks" from CLI.
             || (Director::is_cli() && DevelopmentAdmin::config()->get('allow_all_cli'))
-            || Permission::check(['ADMIN', 'ALL_DEV_ADMIN', 'BUILDTASK_CAN_RUN'])
+            || Permission::check(static::config()->get('init_permissions'))
         );
     }
 

--- a/src/Dev/Tasks/CleanupTestDatabasesTask.php
+++ b/src/Dev/Tasks/CleanupTestDatabasesTask.php
@@ -23,6 +23,13 @@ class CleanupTestDatabasesTask extends BuildTask
 
     public function run($request)
     {
+        if (!$this->canView()) {
+            $response = Security::permissionFailure();
+            if ($response) {
+                $response->output();
+            }
+            die;
+        }
         TempDatabase::create()->deleteAll();
     }
 

--- a/src/Dev/Tasks/CleanupTestDatabasesTask.php
+++ b/src/Dev/Tasks/CleanupTestDatabasesTask.php
@@ -23,15 +23,11 @@ class CleanupTestDatabasesTask extends BuildTask
 
     public function run($request)
     {
-        if (!Permission::check('ADMIN') && !Director::is_cli()) {
-            $response = Security::permissionFailure();
-            if ($response) {
-                $response->output();
-            }
-            die;
-        }
-
-        // Delete all temp DBs
         TempDatabase::create()->deleteAll();
+    }
+
+    public function canView(): bool
+    {
+        return Permission::check('ADMIN') || Director::is_cli();
     }
 }

--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -61,23 +61,10 @@ class DatabaseAdmin extends Controller
     {
         parent::init();
 
-        // We allow access to this controller regardless of live-status or ADMIN permission only
-        // if on CLI or with the database not ready. The latter makes it less error-prone to do an
-        // initial schema build without requiring a default-admin login.
-        // Access to this controller is always allowed in "dev-mode", or of the user is ADMIN.
-        $allowAllCLI = DevelopmentAdmin::config()->get('allow_all_cli');
-        $canAccess = (
-            Director::isDev()
-            || !Security::database_is_ready()
-            // We need to ensure that DevelopmentAdminTest can simulate permission failures when running
-            // "dev/tests" from CLI.
-            || (Director::is_cli() && $allowAllCLI)
-            || Permission::check("ADMIN")
-        );
-        if (!$canAccess) {
+        if (!$this->canInit()) {
             Security::permissionFailure(
                 $this,
-                "This page is secured and you need administrator rights to access it. " .
+                "This page is secured and you need elevated permissions to access it. " .
                 "Enter your credentials below and we will send you right along."
             );
         }
@@ -365,6 +352,23 @@ class DatabaseAdmin extends Controller
         ClassInfo::reset_db_cache();
 
         $this->extend('onAfterBuild', $quiet, $populate, $testMode);
+    }
+
+    public function canInit(): bool
+    {
+        // We allow access to this controller regardless of live-status or ADMIN permission only
+        // if on CLI or with the database not ready. The latter makes it less error-prone to do an
+        // initial schema build without requiring a default-admin login.
+        // Access to this controller is always allowed in "dev-mode", or of the user is ADMIN.
+        $allowAllCLI = DevelopmentAdmin::config()->get('allow_all_cli');
+        return (
+            Director::isDev()
+            || !Security::database_is_ready()
+            // We need to ensure that DevelopmentAdminTest can simulate permission failures when running
+            // "dev/tests" from CLI.
+            || (Director::is_cli() && $allowAllCLI)
+            || Permission::check(['ADMIN', 'ALL_DEV_ADMIN', 'CAN_DEV_BUILD'])
+        );
     }
 
     /**

--- a/src/ORM/DatabaseAdmin.php
+++ b/src/ORM/DatabaseAdmin.php
@@ -10,6 +10,7 @@ use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Manifest\ClassLoader;
+use SilverStripe\Dev\DevBuildController;
 use SilverStripe\Dev\DevelopmentAdmin;
 use SilverStripe\ORM\Connect\DatabaseException;
 use SilverStripe\ORM\Connect\TableBuilder;
@@ -367,7 +368,7 @@ class DatabaseAdmin extends Controller
             // We need to ensure that DevelopmentAdminTest can simulate permission failures when running
             // "dev/tests" from CLI.
             || (Director::is_cli() && $allowAllCLI)
-            || Permission::check(['ADMIN', 'ALL_DEV_ADMIN', 'CAN_DEV_BUILD'])
+            || Permission::check(DevBuildController::config()->get('init_permissions'))
         );
     }
 

--- a/tests/php/Dev/DevAdminControllerTest/ControllerWithPermissions.php
+++ b/tests/php/Dev/DevAdminControllerTest/ControllerWithPermissions.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SilverStripe\Dev\Tests\DevAdminControllerTest;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Security\Permission;
+use SilverStripe\Security\PermissionProvider;
+
+class ControllerWithPermissions extends Controller implements PermissionProvider
+{
+
+    public const OK_MSG = 'DevAdminControllerTest_ControllerWithPermissions TEST OK';
+
+    private static $url_handlers = [
+        '' => 'index',
+    ];
+
+    private static $allowed_actions = [
+        'index',
+    ];
+
+
+    public function index()
+    {
+        echo self::OK_MSG;
+    }
+
+    public function canInit()
+    {
+        return Permission::check('DEV_ADMIN_TEST_PERMISSION');
+    }
+
+    public function providePermissions()
+    {
+        return [
+            'DEV_ADMIN_TEST_PERMISSION' => 'Dev admin test permission',
+        ];
+    }
+}


### PR DESCRIPTION
Introduces `canInit()` methods on Development admin controllers, and respects `canView()` permission checks on `BuildTask`s

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10852