### PR TITLE
Set all Dutch translations to informal 'Je' instead of 'U'

### DIFF
--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -8,7 +8,7 @@ nl:
     REMOVE: Verwijder
   SilverStripe\Control\ChangePasswordEmail_ss:
     CHANGEPASSWORDFOREMAIL: 'Het wachtwoord voor het account met e-mailadres {email} is zojuist aangepast. Heb je geen wachtwoord aangepast, gebruik van onderstaande knop om uit veiligheidsoverwegingen je wachtwoord opnieuw in te stellen.'
-    CHANGEPASSWORDTEXT1: 'U heeft het wachtwoord veranderd voor'
+    CHANGEPASSWORDTEXT1: 'Je hebt het wachtwoord veranderd voor'
     CHANGEPASSWORDTEXT3: 'Wachtwoord opnieuw instellen'
     HELLO: Hallo
   SilverStripe\Control\Email\ForgotPasswordEmail_ss:
@@ -119,7 +119,7 @@ nl:
     Search: 'Zoek naar "{name}"'
     SearchFormFaliure: 'Er kon geen zoekformulier worden aangemaakt'
   SilverStripe\Forms\GridField\GridFieldGroupDeleteAction:
-    UnlinkSelfFailure: 'U kunt uzelf niet verwijderen van deze groep, omdat u dan geen admin-rechten meer heeft.'
+    UnlinkSelfFailure: 'Je kunt jezelf niet verwijderen van deze groep, omdat je dan geen admin-rechten meer hebt.'
   SilverStripe\Forms\GridField\GridFieldPaginator:
     OF: van
     Page: Pagina
@@ -203,7 +203,7 @@ nl:
     LOGIN_MESSAGE: '<p>De browsersessie is verlopen wegens inactiviteit</p>'
     LOGIN_TITLE: 'Log opnieuw in om verder te gaan.'
     SUCCESS: Succes
-    SUCCESSCONTENT: '<p>U bent ingelogd. <a target="_top" href="{link}">Klik hier</a> als u niet automatisch wordt doorgestuurd.</p>'
+    SUCCESSCONTENT: '<p>Je bent ingelogd. <a target="_top" href="{link}">Klik hier</a> als je niet automatisch wordt doorgestuurd.</p>'
     SUCCESS_TITLE: 'Inloggen is gelukt'
   SilverStripe\Security\Confirmation\Form:
     CONFIRM: Uitvoeren
@@ -220,8 +220,8 @@ nl:
     DefaultGroupTitleContentAuthors: 'Inhoud Auteurs'
     Description: 'Omschrijving '
     GROUPNAME: 'Groep naam'
-    GroupReminder: 'Als u de bovenliggende groep selecteert, neemt deze groep alle rollen over'
-    HierarchyPermsError: 'U moet (ADMIN) rechten hebben om de bovenliggende groep "{group}" toe te kennen'
+    GroupReminder: 'Als je de bovenliggende groep selecteert, neemt deze groep alle rollen over'
+    HierarchyPermsError: 'Je moet (ADMIN) rechten hebben om de bovenliggende groep "{group}" toe te kennen'
     Locked: 'Gesloten?'
     MEMBERS: Leden
     NEWGROUP: 'Nieuwe groep'
@@ -290,7 +290,7 @@ nl:
     INTERFACELANG: 'Interface taal'
     KEEP_ME_SIGNED_IN: 'Ingelogd blijven gedurende {count} dagen'
     KEEP_ME_SIGNED_IN_TOOLTIP: 'Onthoud gedurende {count} dagen de inloggegevens op dit apparaat. Gebruik dit alleen op vertrouwde apparaten.'
-    LOGGEDINAS: 'U bent ingelogd als {name}.'
+    LOGGEDINAS: 'Je bent ingelogd als {name}.'
     NEWPASSWORD: 'Nieuw wachtwoord'
     PASSWORD: Wachtwoord
     PASSWORDEXPIRED: 'Je wachtwoord is verlopen. Kies een nieuw wachtwoord.'
@@ -379,7 +379,7 @@ nl:
     PLURALS:
       one: 'Een permissiecode'
       other: '{count} permissiecodes'
-    PermsError: 'U moet (ADMIN) rechten hebben om de code "{code}" toe te kennen'
+    PermsError: 'Je moet (ADMIN) rechten hebben om de code "{code}" toe te kennen'
     SINGULARNAME: Permissiecode
     db_Code: Code
     has_one_Role: Rol
@@ -392,9 +392,9 @@ nl:
     has_one_LoginSession: inlogsessie
     has_one_Member: Lid
   SilverStripe\Security\Security:
-    ALREADYLOGGEDIN: 'U hebt geen toegang tot deze pagina.  Als u een andere account met de nodige rechten hebt, kan u hieronder opnieuw inloggen.'
+    ALREADYLOGGEDIN: 'Je hebt geen toegang tot deze pagina.  Als je een ander account met de nodige rechten hebt, kun je hieronder opnieuw inloggen.'
     BUTTONSEND: 'Nieuw wachtwoord aanmaken'
-    CHANGEPASSWORDBELOW: 'Je kan hieronder het wachtwoord veranderen.'
+    CHANGEPASSWORDBELOW: 'Je kunt hieronder het wachtwoord veranderen.'
     CHANGEPASSWORDHEADER: 'Wachtwoord veranderen'
     CONFIRMLOGOUT: 'Klik op onderstaande knop om uit te loggen.'
     ENTERNEWPASSWORD: 'Voer een nieuw wachtwoord in.'
@@ -402,7 +402,7 @@ nl:
     LOGIN: Inloggen
     LOGOUT: Uitloggen
     LOSTPASSWORDHEADER: 'Wachtwoord vergeten'
-    NOTEPAGESECURED: 'Deze pagina is beveiligd. Voer uw gegevens in en u wordt automatisch doorgestuurd.'
+    NOTEPAGESECURED: 'Deze pagina is beveiligd. Voer je gegevens in en je wordt automatisch doorgestuurd.'
     NOTERESETLINKINVALID: '<p>De reset link is ongeldig of verlopen.</p><p>Je kan <a href="{link1}">hier</a> een nieuwe link aanvragen of het wachtwoord veranderen nadat je bent <a href="{link2}">ingelogd</a>.</p>'
     NOTERESETPASSWORD: 'Voer je e-mailadres in en we sturen een link waarmee je een nieuw wachtwoord kunt instellen.'
     PASSWORDRESETSENTHEADER: Verzonden


### PR DESCRIPTION
The dutch language file uses a inconsistent mix of formal ('U') and informal ('Je') salutations. In this change, all 'U' words are set to the informal version 'Je'.

<!--
Thanks for contributing, you're awesome! :star:
Please describe expected and observed behaviour, and what you're fixing.
For visual fixes, please include tested browsers and screenshots.
Search for related existing issues and link to them if possible.
Please read https://docs.silverstripe.org/en/contributing/code/
-->
