### PR TITLE
FIX Make deprecation enabled check faster

### DIFF
--- a/src/Dev/Deprecation.php
+++ b/src/Dev/Deprecation.php
@@ -234,12 +234,12 @@ class Deprecation
 
     public static function isEnabled(): bool
     {
-        if (!Director::isDev()) {
-            return false;
-        }
         if (Environment::hasEnv('SS_DEPRECATION_ENABLED')) {
             $envVar = Environment::getEnv('SS_DEPRECATION_ENABLED');
             return self::varAsBoolean($envVar);
+        }
+        if (!Director::isDev()) {
+            return false;
         }
         return static::$currentlyEnabled;
     }


### PR DESCRIPTION
The dev environment check in CMS 4 is slow, since it checks the session before checking environment variables. We should skip that outright if deprecations are explicitly disabled.

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1622