### PR TITLE
ENH Allow tag options for Requirements::customScript

### DIFF
--- a/src/View/Requirements.php
+++ b/src/View/Requirements.php
@@ -136,10 +136,13 @@ class Requirements implements Flushable
      *
      * @param string     $script       The script content as a string (without enclosing `<script>` tag)
      * @param string|int $uniquenessID A unique ID that ensures a piece of code is only added once
+     * @param array $options List of options. Available options include:
+     * - 'type' : Specifies the type of script
+     * - 'crossorigin' : Cross-origin policy for the resource
      */
-    public static function customScript($script, $uniquenessID = null)
+    public static function customScript($script, $uniquenessID = null, $options = [])
     {
-        self::backend()->customScript($script, $uniquenessID);
+        self::backend()->customScript($script, $uniquenessID, $options);
     }
 
     /**

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -491,8 +491,8 @@ class Requirements_Backend
      * @param string $script The script content as a string (without enclosing `<script>` tag)
      * @param string $uniquenessID A unique ID that ensures a piece of code is only added once
      * @param array $options List of options. Available options include:
-     * - 'provides' : List of scripts files included in this file
-     * - 'async' : Boolean value to set async attribute to script tag
+     * - 'type' : Specifies the type of script
+     * - 'crossorigin' : Cross-origin policy for the resource
      */
     public function customScript($script, $uniquenessID = null, $options = [])
     {

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -1403,6 +1403,7 @@ EOS
         $this->setupRequirements($backend);
 
         $backend->javascript('javascript/RequirementsTest_a.js', ['integrity' => 'abc', 'crossorigin' => 'use-credentials']);
+        $backend->customScript("//TEST", null, ['type' => 'module', 'crossorigin' => 'anonymous']);
         $backend->css('css/RequirementsTest_a.css', null, ['integrity' => 'def', 'crossorigin' => 'anonymous']);
         $html = $backend->includeInHTML(self::$html_template);
 
@@ -1411,6 +1412,13 @@ EOS
             '#<script type="application/javascript" src=".*/javascript/RequirementsTest_a.js.*" integrity="abc" crossorigin="use-credentials"#',
             $html,
             'javascript has correct sri attributes'
+        );
+
+        /* Custom Javascript has correct attribute */
+        $this->assertMatchesRegularExpression(
+            '#<script type="module" crossorigin="anonymous"#',
+            $html,
+            'custom javascript has correct sri attributes'
         );
 
         /* CSS has correct attributes */


### PR DESCRIPTION
Allows custom type and crossorigin attributes when using Requirements::customScript.

Resolves #11060 