### PR TITLE
ENH Create Requirements::customScriptWithAttributes

### DIFF
--- a/src/View/Requirements.php
+++ b/src/View/Requirements.php
@@ -149,9 +149,9 @@ class Requirements implements Flushable
      * @param array $options List of options. Available options include:
      * - 'type' : Specifies the type of script
      * - 'crossorigin' : Cross-origin policy for the resource
-     * @param string|int $uniquenessID A unique ID that ensures a piece of code is only added once
+     * @param string|int|null $uniquenessID A unique ID that ensures a piece of code is only added once
      */
-    public static function customScriptWithAttributes($script, $options = [], $uniquenessID = null)
+    public static function customScriptWithAttributes(string $script, array $options = [], string|int|null $uniquenessID = null)
     {
         self::backend()->customScriptWithAttributes($script, $options, $uniquenessID);
     }

--- a/src/View/Requirements.php
+++ b/src/View/Requirements.php
@@ -145,7 +145,7 @@ class Requirements implements Flushable
      * Register the given Javascript code into the list of requirements with optional tag
      * attributes.
      *
-     * @param string     $script       The script content as a string (without enclosing `<script>` tag)
+     * @param string $script The script content as a string (without enclosing `<script>` tag)
      * @param array $options List of options. Available options include:
      * - 'type' : Specifies the type of script
      * - 'crossorigin' : Cross-origin policy for the resource

--- a/src/View/Requirements.php
+++ b/src/View/Requirements.php
@@ -141,6 +141,7 @@ class Requirements implements Flushable
     {
         self::backend()->customScript($script, $uniquenessID);
     }
+
     /**
      * Register the given Javascript code into the list of requirements with optional tag
      * attributes.

--- a/src/View/Requirements.php
+++ b/src/View/Requirements.php
@@ -151,7 +151,8 @@ class Requirements implements Flushable
      * - 'crossorigin' : Cross-origin policy for the resource
      * @param string|int $uniquenessID A unique ID that ensures a piece of code is only added once
      */
-    public static function customScriptWithAttributes($script, $options = [], $uniquenessID = null){
+    public static function customScriptWithAttributes($script, $options = [], $uniquenessID = null)
+    {
         self::backend()->customScriptWithAttributes($script, $options, $uniquenessID);
     }
 

--- a/src/View/Requirements.php
+++ b/src/View/Requirements.php
@@ -141,6 +141,19 @@ class Requirements implements Flushable
     {
         self::backend()->customScript($script, $uniquenessID);
     }
+    /**
+     * Register the given Javascript code into the list of requirements with optional tag
+     * attributes.
+     *
+     * @param string     $script       The script content as a string (without enclosing `<script>` tag)
+     * @param array $options List of options. Available options include:
+     * - 'type' : Specifies the type of script
+     * - 'crossorigin' : Cross-origin policy for the resource
+     * @param string|int $uniquenessID A unique ID that ensures a piece of code is only added once
+     */
+    public static function customScriptWithAttributes($script, $options = [], $uniquenessID = null){
+        self::backend()->customScriptWithAttributes($script, $options, $uniquenessID);
+    }
 
     /**
      * Return all registered custom scripts

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -520,31 +520,20 @@ class Requirements_Backend
      */
     public function customScriptWithAttributes(string $script, array $attributes = [], string|int|null $uniquenessID = null)
     {
-        // Get type
-        $type = null;
-        if (isset($this->customScriptAttributes[$uniquenessID]['type'])) {
-            $type = $this->customScriptAttributes[$uniquenessID]['type'];
+        $attrs = [];
+        foreach (['type', 'crossorigin'] as $attrKey) {
+            if (isset($attributes[$attrKey])) {
+                $attrs[$attrKey] = strtolower($attributes[$attrKey]);
+            }
         }
-        if (isset($attributes['type'])) {
-            $type = strtolower($attributes['type']);
-        }
-
-        $crossorigin = $attributes['crossorigin'];
-        $crossorigin = isset($crossorigin) ? strtolower($crossorigin) : null;
-
         if ($uniquenessID) {
             $this->customScript[$uniquenessID] = $script;
-            $this->customScriptAttributess[$uniquenessID] = [
-                'type' => $type,
-                'crossorigin' => $crossorigin
-            ];
+            $this->customScriptAttributes[$uniquenessID] = $attrs;
         } else {
             $this->customScript[] = $script;
             $index = count($this->customScript) - 1;
-            $this->customScriptAttributes[$index] = [
-                'type' => $type,
-                'crossorigin' => $crossorigin
-            ];
+            $this->customScriptAttributes[$index] = $attrs;
+        }
         }
     }
 

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -504,7 +504,7 @@ class Requirements_Backend
         if ($uniquenessID) {
             $this->customScript[$uniquenessID]['content'] = $script;
         } else {
-            $this->customScript[]['content'] = $script;
+            $this->customScript[] = $script;
         }
     }
 
@@ -841,19 +841,22 @@ class Requirements_Backend
         // Add all inline JavaScript *after* including external files they might rely on
         foreach ($this->getCustomScripts() as $key => $script) {
             // Build html attributes
-            $curScriptAttributes = $this->customScriptAttributes[$key];
-            $htmlAttributes = [];
+            $curScriptAttributes = null;
+            if(array_key_exists($key, $this->customScriptAttributes)){
+                $curScriptAttributes = $this->customScriptAttributes[$key];
+            }
+            $customHtmlAttributes = [
+                'type' => 'application/javascript'
+            ];
             if (isset($curScriptAttributes)) {
-                $htmlAttributes = [
-                    'type' => $curScriptAttributes['type'] ?? "application/javascript"
-                ];
+                $customHtmlAttributes['type'] = $curScriptAttributes['type'];
                 if (!empty($curScriptAttributes['crossorigin'])) {
-                    $htmlAttributes['crossorigin'] = $curScriptAttributes['crossorigin'];
+                    $customHtmlAttributes['crossorigin'] = $curScriptAttributes['crossorigin'];
                 }
             }
             $jsRequirements .= HTML::createTag(
                 'script',
-                $htmlAttributes,
+                $customHtmlAttributes,
                 "//<![CDATA[\n{$script}\n//]]>"
             );
             $jsRequirements .= "\n";

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -502,6 +502,9 @@ class Requirements_Backend
     public function customScript($script, $uniquenessID = null)
     {
         if ($uniquenessID) {
+            if (isset($this->customScriptAttributes[$uniquenessID])) {
+                unset($this->customScriptAttributes[$uniquenessID]);
+            }
             $this->customScript[$uniquenessID] = $script;
         } else {
             $this->customScript[] = $script;

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -534,7 +534,6 @@ class Requirements_Backend
             $index = count($this->customScript) - 1;
             $this->customScriptAttributes[$index] = $attrs;
         }
-        }
     }
 
     /**

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -510,7 +510,8 @@ class Requirements_Backend
      * - 'crossorigin' : Cross-origin policy for the resource
      * @param string|int $uniquenessID A unique ID that ensures a piece of code is only added once
      */
-    public function customScriptWithAttributes($script, $options = [], $uniquenessID = null){
+    public function customScriptWithAttributes($script, $options = [], $uniquenessID = null)
+    {
         // Get type
         $type = null;
         if (isset($this->customScript[$uniquenessID]['type'])) {

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -830,18 +830,9 @@ class Requirements_Backend
         // Add all inline JavaScript *after* including external files they might rely on
         foreach ($this->getCustomScripts() as $key => $script) {
             // Build html attributes
-            $curScriptAttributes = null;
-            if (array_key_exists($key, $this->customScriptAttributes)) {
-                $curScriptAttributes = $this->customScriptAttributes[$key];
-            }
-            $customHtmlAttributes = [
-                'type' => 'application/javascript'
-            ];
-            if (isset($curScriptAttributes)) {
-                $customHtmlAttributes['type'] = $curScriptAttributes['type'];
-                if (!empty($curScriptAttributes['crossorigin'])) {
-                    $customHtmlAttributes['crossorigin'] = $curScriptAttributes['crossorigin'];
-                }
+            $customHtmlAttributes = ['type' => 'application/javascript'];
+            foreach ($this->customScriptAttributes[$key] as $attrKey => $attrValue) {
+                $customHtmlAttributes[$attrKey] = $attrValue;
             }
             $jsRequirements .= HTML::createTag(
                 'script',

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -494,9 +494,46 @@ class Requirements_Backend
     public function customScript($script, $uniquenessID = null)
     {
         if ($uniquenessID) {
-            $this->customScript[$uniquenessID] = $script;
+            $this->customScript[$uniquenessID]['content'] = $script;
         } else {
-            $this->customScript[] = $script;
+            $this->customScript[]['content'] = $script;
+        }
+    }
+
+    /**
+     * Register the given Javascript code into the list of requirements with optional tag
+     * attributes.
+     *
+     * @param string     $script       The script content as a string (without enclosing `<script>` tag)
+     * @param array $options List of options. Available options include:
+     * - 'type' : Specifies the type of script
+     * - 'crossorigin' : Cross-origin policy for the resource
+     * @param string|int $uniquenessID A unique ID that ensures a piece of code is only added once
+     */
+    public function customScriptWithAttributes($script, $options = [], $uniquenessID = null){
+        // Get type
+        $type = null;
+        if (isset($this->customScript[$uniquenessID]['type'])) {
+            $type = $this->customScript[$uniquenessID]['type'];
+        }
+        if (isset($options['type'])) {
+            $type = $options['type'];
+        }
+
+        $crossorigin = $options['crossorigin'] ?? null;
+
+        if ($uniquenessID) {
+            $this->customScript[$uniquenessID] = [
+                'content' => $script,
+                'type' => $type,
+                'crossorigin' => $crossorigin
+            ];
+        } else {
+            $this->customScript[] = [
+                'content' => $script,
+                'type' => $type,
+                'crossorigin' => $crossorigin
+            ];
         }
     }
 
@@ -792,10 +829,17 @@ class Requirements_Backend
 
         // Add all inline JavaScript *after* including external files they might rely on
         foreach ($this->getCustomScripts() as $script) {
+            // Build html attributes
+            $htmlAttributes = [
+                'type' => isset($script['type']) ? $script['type'] : "application/javascript"
+            ];
+            if (!empty($script['crossorigin'])) {
+                $htmlAttributes['crossorigin'] = $script['crossorigin'];
+            }
             $jsRequirements .= HTML::createTag(
                 'script',
-                [ 'type' => 'application/javascript' ],
-                "//<![CDATA[\n{$script}\n//]]>"
+                $htmlAttributes,
+                "//<![CDATA[\n{$script['content']}\n//]]>"
             );
             $jsRequirements .= "\n";
         }

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -502,7 +502,7 @@ class Requirements_Backend
     public function customScript($script, $uniquenessID = null)
     {
         if ($uniquenessID) {
-            $this->customScript[$uniquenessID]['content'] = $script;
+            $this->customScript[$uniquenessID] = $script;
         } else {
             $this->customScript[] = $script;
         }

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -842,7 +842,7 @@ class Requirements_Backend
         foreach ($this->getCustomScripts() as $key => $script) {
             // Build html attributes
             $curScriptAttributes = null;
-            if(array_key_exists($key, $this->customScriptAttributes)){
+            if (array_key_exists($key, $this->customScriptAttributes)) {
                 $curScriptAttributes = $this->customScriptAttributes[$key];
             }
             $customHtmlAttributes = [

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -512,7 +512,7 @@ class Requirements_Backend
      * Register the given Javascript code into the list of requirements with optional tag
      * attributes.
      *
-     * @param string     $script       The script content as a string (without enclosing `<script>` tag)
+     * @param string $script The script content as a string (without enclosing `<script>` tag)
      * @param array $options List of options. Available options include:
      * - 'type' : Specifies the type of script
      * - 'crossorigin' : Cross-origin policy for the resource

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -830,8 +830,10 @@ class Requirements_Backend
         foreach ($this->getCustomScripts() as $key => $script) {
             // Build html attributes
             $customHtmlAttributes = ['type' => 'application/javascript'];
-            foreach ($this->customScriptAttributes[$key] as $attrKey => $attrValue) {
-                $customHtmlAttributes[$attrKey] = $attrValue;
+            if (isset($this->customScriptAttributes[$key])) {
+                foreach ($this->customScriptAttributes[$key] as $attrKey => $attrValue) {
+                    $customHtmlAttributes[$attrKey] = $attrValue;
+                }
             }
             $jsRequirements .= HTML::createTag(
                 'script',

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -1403,6 +1403,7 @@ EOS
         $this->setupRequirements($backend);
 
         $backend->javascript('javascript/RequirementsTest_a.js', ['integrity' => 'abc', 'crossorigin' => 'use-credentials']);
+        $backend->customScriptWithAttributes("//TEST", ['type' => 'module', 'crossorigin' => 'anonymous']);
         $backend->css('css/RequirementsTest_a.css', null, ['integrity' => 'def', 'crossorigin' => 'anonymous']);
         $html = $backend->includeInHTML(self::$html_template);
 
@@ -1412,6 +1413,14 @@ EOS
             $html,
             'javascript has correct sri attributes'
         );
+
+        /* Custom Javascript has correct attribute */
+        $this->assertMatchesRegularExpression(
+            '#<script type="module" crossorigin="anonymous"#',
+            $html,
+            'custom javascript has correct sri attributes'
+        );
+
 
         /* CSS has correct attributes */
         $this->assertMatchesRegularExpression(

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -1429,7 +1429,7 @@ EOS
         );
     }
 
-    public function testUniquenessID(){
+    public function testUniquenessID() {
         /** @var Requirements_Backend $backend */
         $backend = Injector::inst()->create(Requirements_Backend::class);
         $this->setupRequirements($backend);

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -1429,7 +1429,8 @@ EOS
         );
     }
 
-    public function testUniquenessID() {
+    public function testUniquenessID()
+    {
         /** @var Requirements_Backend $backend */
         $backend = Injector::inst()->create(Requirements_Backend::class);
         $this->setupRequirements($backend);

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -1437,11 +1437,13 @@ EOS
 
         // Create requirements that are to be overwritten
         $backend->customScript("Do Not Display", 42);
+        $backend->customScriptWithAttributes("Do Not Display", ['type' => 'module', 'crossorigin' => 'use-credentials'], 84);
         $backend->customCSS("Do Not Display", 42);
         $backend->insertHeadTags("<span>Do Not Display</span>", 42);
 
         // Override
         $backend->customScriptWithAttributes("Override", ['type' => 'module', 'crossorigin' => 'use-credentials'], 42);
+        $backend->customScript("Override", 84);
         $backend->customCSS("Override", 42);
         $backend->insertHeadTags("<span>Override</span>", 42);
 
@@ -1458,6 +1460,19 @@ EOS
             "#<script type=\"application/javascript\">//<!\[CDATA\[\s*Do Not Display\s*//\]\]></script>#s",
             $html,
             'customScript is correctly not displaying original write'
+        );
+
+        /* customScriptWithAttributes is overwritten by customScript */
+        $this->assertMatchesRegularExpression(
+            "#<script type=\"application/javascript\">//<!\[CDATA\[\s*Override\s*//\]\]></script>#s",
+            $html,
+            'customScript is displaying latest write and clearing attributes'
+        );
+
+        $this->assertDoesNotMatchRegularExpression(
+            "#<script type=\"module\" crossorigin=\"use-credentials\">//<!\[CDATA\[\s*Do Not Display\s*//\]\]></script>#s",
+            $html,
+            'customScript is displaying latest write'
         );
 
         /* customCSS is overwritten */

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -1421,8 +1421,6 @@ EOS
             $html,
             'custom javascript has correct sri attributes'
         );
-
-
         /* CSS has correct attributes */
         $this->assertMatchesRegularExpression(
             '#<link .*href=".*/RequirementsTest_a\.css.*" integrity="def" crossorigin="anonymous"#',

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -1403,7 +1403,8 @@ EOS
         $this->setupRequirements($backend);
 
         $backend->javascript('javascript/RequirementsTest_a.js', ['integrity' => 'abc', 'crossorigin' => 'use-credentials']);
-        $backend->customScriptWithAttributes("//TEST", ['type' => 'module', 'crossorigin' => 'anonymous']);
+        // Tests attribute appending AND lowercase string conversion
+        $backend->customScriptWithAttributes("//TEST", ['type' => 'module', 'crossorigin' => 'Anonymous']);
         $backend->css('css/RequirementsTest_a.css', null, ['integrity' => 'def', 'crossorigin' => 'anonymous']);
         $html = $backend->includeInHTML(self::$html_template);
 


### PR DESCRIPTION
Allows custom type and crossorigin attributes when using the new method Requirements::customScriptWithAttributes, as suggested here: https://github.com/silverstripe/silverstripe-framework/pull/11061#discussion_r1402892340/.

Resolves #11060 