### PR TITLE
FIX Don't replace config manifest for nested kernels

### DIFF
--- a/src/Core/BaseKernel.php
+++ b/src/Core/BaseKernel.php
@@ -115,11 +115,13 @@ abstract class BaseKernel implements Kernel
         $this->setModuleLoader($moduleLoader);
 
         // Config loader
-        // @todo refactor CoreConfigFactory
-        $configFactory = new CoreConfigFactory($manifestCacheFactory);
-        $configManifest = $configFactory->createRoot();
         $configLoader = ConfigLoader::inst();
-        $configLoader->pushManifest($configManifest);
+        // If nesting kernels, don't create a new config manifest as that will reset config deltas
+        if (!$configLoader->hasManifest()) {
+            $configFactory = new CoreConfigFactory($manifestCacheFactory);
+            $configManifest = $configFactory->createRoot();
+            $configLoader->pushManifest($configManifest);
+        }
         $this->setConfigLoader($configLoader);
 
         // Load template manifest


### PR DESCRIPTION
If nesting kernels, the same instance of `ConfigLoader` is used for _both_ kernels. The result is that if there were any runtime changes to configuration (i.e. `MyClass::config()->set()`), these changes are discarded _for both kernels_.

For production scenarios this isn't likely to cause problems, because runtime configuration changes are probably made inside `_config.php` files which are _also_ re-executed, but for unit tests this can cause problems as seen in https://github.com/silverstripe/silverstripe-staticpublishqueue/pull/178

## Issue
- https://github.com/silverstripe/silverstripe-staticpublishqueue/issues/172