### PR TITLE
NEW Allow a single has_one to manage multiple reciprocal has_many

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -48,6 +48,8 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\ORM\FieldType\DBPercentage
   PolymorphicForeignKey:
     class: SilverStripe\ORM\FieldType\DBPolymorphicForeignKey
+  PolymorphicRelationAwareForeignKey:
+    class: SilverStripe\ORM\FieldType\DBPolymorphicRelationAwareForeignKey
   PrimaryKey:
     class: SilverStripe\ORM\FieldType\DBPrimaryKey
   Text:

--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -204,6 +204,14 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
                 $classKey = $list->getForeignClassKey();
                 $class = $list->getForeignClass();
                 $this->record->$classKey = $class;
+
+                // If the has_one relation storing the data can handle multiple reciprocal has_many relations,
+                // make sure we tell it which has_many relation this belongs to.
+                $relation = $list->getForeignRelation();
+                if ($relation) {
+                    $relationKey = $list->getForeignRelationKey();
+                    $this->record->$relationKey = $relation;
+                }
             }
         }
 

--- a/src/ORM/FieldType/DBPolymorphicRelationAwareForeignKey.php
+++ b/src/ORM/FieldType/DBPolymorphicRelationAwareForeignKey.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SilverStripe\ORM\FieldType;
+
+use InvalidArgumentException;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * A special polymorphic ForeignKey class that allows a single has_one relation to map to multiple has_many relations
+ */
+class DBPolymorphicRelationAwareForeignKey extends DBPolymorphicForeignKey
+{
+    private static array $composite_db = [
+        'Relation' => 'Varchar',
+    ];
+
+    /**
+     * Get the value of the "Relation" this key points to
+     *
+     * @return string Name of the has_many relation being stored
+     */
+    public function getRelationValue(): string
+    {
+        return $this->getField('Relation');
+    }
+
+    /**
+     * Set the value of the "Relation" this key points to
+     *
+     * @param string $value Name of the has_many relation being stored
+     * @param bool $markChanged Mark this field as changed?
+     */
+    public function setRelationValue(string $value, bool $markChanged = true): static
+    {
+        $this->setField('Relation', $value, $markChanged);
+        return $this;
+    }
+}

--- a/tests/php/Dev/Validation/Member.php
+++ b/tests/php/Dev/Validation/Member.php
@@ -43,6 +43,8 @@ class Member extends DataObject implements TestOnly
      */
     private static $has_many = [
         'TemporaryMembers' => Freelancer::class . '.TemporaryMember',
+        'ManyTeams' => Team::class . '.SingleMember',
+        'ManyMoreTeams' => Team::class . '.SingleMember',
     ];
 
     /**

--- a/tests/php/Dev/Validation/RelationValidationTest.php
+++ b/tests/php/Dev/Validation/RelationValidationTest.php
@@ -6,6 +6,8 @@ use Page;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\Validation\RelationValidationService;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DataObjectSchema;
 
 class RelationValidationTest extends SapphireTest
 {
@@ -107,6 +109,14 @@ class RelationValidationTest extends SapphireTest
                     'SilverStripe\Dev\Tests\Validation\Member / Hat : Back relation is ambiguous',
                 ],
             ],
+            'polymorphic has one' => [
+                Team::class,
+                'has_one',
+                [
+                    'SingleMember' => DataObject::class,
+                ],
+                [],
+            ],
             'invalid has one' => [
                 Member::class,
                 'has_one',
@@ -116,6 +126,45 @@ class RelationValidationTest extends SapphireTest
                 ],
                 [
                     'SilverStripe\Dev\Tests\Validation\Member / HomeTeam : Relation SilverStripe\Dev\Tests\Validation\Team.UnnecessaryRelation is not in the expected format (needs class only format).'
+                ],
+            ],
+            'has_one missing class in array config' => [
+                Team::class,
+                'has_one',
+                [
+                    'SingleMember' => [
+                        DataObjectSchema::HAS_ONE_MULTI_RELATIONAL => true,
+                    ],
+                ],
+                [
+                    'SilverStripe\Dev\Tests\Validation\Team / SingleMember : No class has been defined for this relation.'
+                ],
+            ],
+            'multi-relational has_one should be polymorphic' => [
+                Team::class,
+                'has_one',
+                [
+                    'SingleMember' => [
+                        'class' => Member::class,
+                        DataObjectSchema::HAS_ONE_MULTI_RELATIONAL => true,
+                    ],
+                ],
+                [
+                    'SilverStripe\Dev\Tests\Validation\Team / SingleMember : has_one relation that can handle multiple reciprocal has_many relations must be polymorphic.'
+                ],
+            ],
+            'has_one defines class in array config' => [
+                Team::class,
+                'has_one',
+                [
+                    'SingleMember' => [
+                        'class' => Member::class,
+                    ],
+                ],
+                // Note there's no message about the has_one class, which is technically correctly defined.
+                // The bad thing now is just that we still have multiple has_many relations pointing at it.
+                [
+                    'SilverStripe\Dev\Tests\Validation\Team / SingleMember : Back relation is ambiguous'
                 ],
             ],
             'ambiguous has_many - no relation name' => [

--- a/tests/php/Dev/Validation/Team.php
+++ b/tests/php/Dev/Validation/Team.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Dev\Tests\Validation;
 
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DataObjectSchema;
 use SilverStripe\ORM\HasManyList;
 use SilverStripe\ORM\ManyManyList;
 use SilverStripe\ORM\ManyManyThroughList;
@@ -29,6 +30,13 @@ class Team extends DataObject implements TestOnly
      */
     private static $db = [
         'Title' => 'Varchar(255)',
+    ];
+
+    private static array $has_one = [
+        'SingleMember' => [
+            'class' => DataObject::class,
+            DataObjectSchema::HAS_ONE_MULTI_RELATIONAL => true,
+        ],
     ];
 
     /**

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest/MultiReciprocalPeopleGroup.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest/MultiReciprocalPeopleGroup.php
@@ -7,16 +7,16 @@ use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_RelationEditor;
 use SilverStripe\ORM\DataObject;
 
-class PolymorphicPeopleGroup extends DataObject implements TestOnly
+class MultiRelationalPeopleGroup extends DataObject implements TestOnly
 {
-    private static $table_name = 'GridFieldDetailFormTest_PolymorphicPeopleGroup';
+    private static $table_name = 'GridFieldDetailFormTest_MultiRelationalPeopleGroup';
 
     private static $db = [
         'Name' => 'Varchar'
     ];
 
     private static $has_many = [
-        'People' => Person::class . '.PolymorphicGroup'
+        'People' => Person::class . '.MultiRelationalGroup'
     ];
 
     private static $default_sort = '"Name"';

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest/Person.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest/Person.php
@@ -7,6 +7,7 @@ use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_RelationEditor;
 use SilverStripe\Forms\RequiredFields;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DataObjectSchema;
 
 class Person extends DataObject implements TestOnly
 {
@@ -20,6 +21,10 @@ class Person extends DataObject implements TestOnly
     private static $has_one = [
         'Group' => PeopleGroup::class,
         'PolymorphicGroup' => DataObject::class,
+        'MultiRelationalGroup' => [
+            'class' => DataObject::class,
+            DataObjectSchema::HAS_ONE_MULTI_RELATIONAL => true,
+        ],
     ];
 
     private static $many_many = [

--- a/tests/php/ORM/DataObjectSchemaTest.php
+++ b/tests/php/ORM/DataObjectSchemaTest.php
@@ -159,68 +159,94 @@ class DataObjectSchemaTest extends SapphireTest
         );
     }
 
-    public function testFieldSpec()
+    /**
+     * @dataProvider provideFieldSpec
+     */
+    public function testFieldSpec(array $args, array $expected): void
     {
         $schema = DataObject::getSchema();
-        $this->assertEquals(
-            [
-                'ID' => 'PrimaryKey',
-                'ClassName' => 'DBClassName',
-                'LastEdited' => 'DBDatetime',
-                'Created' => 'DBDatetime',
-                'Title' => 'Varchar',
-                'Description' => 'Varchar',
-                'MoneyFieldCurrency' => 'Varchar(3)',
-                'MoneyFieldAmount' => 'Decimal(19,4)',
-                'MoneyField' => 'Money',
-            ],
-            $schema->fieldSpecs(HasFields::class)
-        );
-        $this->assertEquals(
-            [
-                'ID' => DataObjectSchemaTest\HasFields::class . '.PrimaryKey',
-                'ClassName' => DataObjectSchemaTest\BaseDataClass::class . '.DBClassName',
-                'LastEdited' => DataObjectSchemaTest\BaseDataClass::class . '.DBDatetime',
-                'Created' => DataObjectSchemaTest\BaseDataClass::class . '.DBDatetime',
-                'Title' => DataObjectSchemaTest\BaseDataClass::class . '.Varchar',
-                'Description' => DataObjectSchemaTest\HasFields::class . '.Varchar',
-                'MoneyFieldCurrency' => DataObjectSchemaTest\HasFields::class . '.Varchar(3)',
-                'MoneyFieldAmount' => DataObjectSchemaTest\HasFields::class . '.Decimal(19,4)',
-                'MoneyField' => DataObjectSchemaTest\HasFields::class . '.Money',
-            ],
-            $schema->fieldSpecs(HasFields::class, DataObjectSchema::INCLUDE_CLASS)
-        );
-        // DB_ONLY excludes composite field MoneyField
-        $this->assertEquals(
-            [
-                'ID' => DataObjectSchemaTest\HasFields::class . '.PrimaryKey',
-                'ClassName' => DataObjectSchemaTest\BaseDataClass::class . '.DBClassName',
-                'LastEdited' => DataObjectSchemaTest\BaseDataClass::class . '.DBDatetime',
-                'Created' => DataObjectSchemaTest\BaseDataClass::class . '.DBDatetime',
-                'Title' => DataObjectSchemaTest\BaseDataClass::class . '.Varchar',
-                'Description' => DataObjectSchemaTest\HasFields::class . '.Varchar',
-                'MoneyFieldCurrency' => DataObjectSchemaTest\HasFields::class . '.Varchar(3)',
-                'MoneyFieldAmount' => DataObjectSchemaTest\HasFields::class . '.Decimal(19,4)'
-            ],
-            $schema->fieldSpecs(
-                HasFields::class,
-                DataObjectSchema::INCLUDE_CLASS | DataObjectSchema::DB_ONLY
-            )
-        );
+        $this->assertEquals($expected, $schema->fieldSpecs(...$args));
+    }
 
-        // Use all options at once
-        $this->assertEquals(
-            [
-                'ID' => DataObjectSchemaTest\HasFields::class . '.PrimaryKey',
-                'Description' => DataObjectSchemaTest\HasFields::class . '.Varchar',
-                'MoneyFieldCurrency' => DataObjectSchemaTest\HasFields::class . '.Varchar(3)',
-                'MoneyFieldAmount' => DataObjectSchemaTest\HasFields::class . '.Decimal(19,4)',
+    public function provideFieldSpec(): array
+    {
+        return [
+            'just pass a class' => [
+                'args' => [HasFields::class],
+                'expected' => [
+                    'ID' => 'PrimaryKey',
+                    'ClassName' => 'DBClassName',
+                    'LastEdited' => 'DBDatetime',
+                    'Created' => 'DBDatetime',
+                    'Title' => 'Varchar',
+                    'Description' => 'Varchar',
+                    'MoneyFieldCurrency' => 'Varchar(3)',
+                    'MoneyFieldAmount' => 'Decimal(19,4)',
+                    'MoneyField' => 'Money',
+                ],
             ],
-            $schema->fieldSpecs(
-                HasFields::class,
-                DataObjectSchema::INCLUDE_CLASS | DataObjectSchema::DB_ONLY | DataObjectSchema::UNINHERITED
-            )
-        );
+            'prefix with classname' => [
+                'args' => [HasFields::class, DataObjectSchema::INCLUDE_CLASS],
+                'expected' => [
+                    'ID' => DataObjectSchemaTest\HasFields::class . '.PrimaryKey',
+                    'ClassName' => DataObjectSchemaTest\BaseDataClass::class . '.DBClassName',
+                    'LastEdited' => DataObjectSchemaTest\BaseDataClass::class . '.DBDatetime',
+                    'Created' => DataObjectSchemaTest\BaseDataClass::class . '.DBDatetime',
+                    'Title' => DataObjectSchemaTest\BaseDataClass::class . '.Varchar',
+                    'Description' => DataObjectSchemaTest\HasFields::class . '.Varchar',
+                    'MoneyFieldCurrency' => DataObjectSchemaTest\HasFields::class . '.Varchar(3)',
+                    'MoneyFieldAmount' => DataObjectSchemaTest\HasFields::class . '.Decimal(19,4)',
+                    'MoneyField' => DataObjectSchemaTest\HasFields::class . '.Money',
+                ],
+            ],
+            'DB_ONLY excludes composite field MoneyField' => [
+                'args' => [
+                    HasFields::class,
+                    DataObjectSchema::INCLUDE_CLASS | DataObjectSchema::DB_ONLY,
+                ],
+                'expected' => [
+                    'ID' => DataObjectSchemaTest\HasFields::class . '.PrimaryKey',
+                    'ClassName' => DataObjectSchemaTest\BaseDataClass::class . '.DBClassName',
+                    'LastEdited' => DataObjectSchemaTest\BaseDataClass::class . '.DBDatetime',
+                    'Created' => DataObjectSchemaTest\BaseDataClass::class . '.DBDatetime',
+                    'Title' => DataObjectSchemaTest\BaseDataClass::class . '.Varchar',
+                    'Description' => DataObjectSchemaTest\HasFields::class . '.Varchar',
+                    'MoneyFieldCurrency' => DataObjectSchemaTest\HasFields::class . '.Varchar(3)',
+                    'MoneyFieldAmount' => DataObjectSchemaTest\HasFields::class . '.Decimal(19,4)'
+                ],
+            ],
+            'Use all options at once' => [
+                'args' => [
+                    HasFields::class,
+                    DataObjectSchema::INCLUDE_CLASS | DataObjectSchema::DB_ONLY | DataObjectSchema::UNINHERITED
+                ],
+                'expected' => [
+                    'ID' => DataObjectSchemaTest\HasFields::class . '.PrimaryKey',
+                    'Description' => DataObjectSchemaTest\HasFields::class . '.Varchar',
+                    'MoneyFieldCurrency' => DataObjectSchemaTest\HasFields::class . '.Varchar(3)',
+                    'MoneyFieldAmount' => DataObjectSchemaTest\HasFields::class . '.Decimal(19,4)',
+                ],
+            ],
+            'has_one relations are returned correctly' => [
+                'args' => [WithRelation::class],
+                'expected' => [
+                    'ID' => 'PrimaryKey',
+                    'ClassName' => 'DBClassName',
+                    'LastEdited' => 'DBDatetime',
+                    'Created' => 'DBDatetime',
+                    'Title' => 'Varchar',
+                    'RelationID' => 'ForeignKey',
+                    'PolymorphicRelationID' => 'Int',
+                    'PolymorphicRelationClass' => "DBClassName('SilverStripe\ORM\DataObject', ['index' => false])",
+                    'MultiRelationalRelationID' => 'Int',
+                    'MultiRelationalRelationClass' => "DBClassName('SilverStripe\ORM\DataObject', ['index' => false])",
+                    'MultiRelationalRelationRelation' => 'Varchar',
+                    'PolymorphicRelation' => 'PolymorphicForeignKey',
+                    'MultiRelationalRelation' => 'PolymorphicRelationAwareForeignKey',
+                    'ArraySyntaxRelationID' => 'ForeignKey',
+                ],
+            ],
+        ];
     }
 
     /**
@@ -372,5 +398,77 @@ class DataObjectSchemaTest extends SapphireTest
             ],
             AllIndexes::get()
         );
+    }
+
+    /**
+     * @dataProvider provideHasOneComponent
+     */
+
+    public function testHasOneComponent(string $class, string $component, string $expected): void
+    {
+        $this->assertSame($expected, DataObject::getSchema()->hasOneComponent($class, $component));
+    }
+
+    public function provideHasOneComponent(): array
+    {
+        return [
+            [
+                'class' => WithRelation::class,
+                'component' => 'Relation',
+                'expected' => HasFields::class,
+            ],
+            [
+                'class' => WithRelation::class,
+                'component' => 'PolymorphicRelation',
+                'expected' => DataObject::class,
+            ],
+            [
+                'class' => WithRelation::class,
+                'component' => 'ArraySyntaxRelation',
+                'expected' => HasFields::class,
+            ],
+            [
+                'class' => WithRelation::class,
+                'component' => 'MultiRelationalRelation',
+                'expected' => DataObject::class,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideHasOneComponentHandlesMultipleRelations
+     */
+    public function testHasOneComponentHandlesMultipleRelations(string $class, string $component, bool $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            DataObject::getSchema()->hasOneComponentHandlesMultipleRelations($class, $component)
+        );
+    }
+
+    public function provideHasOneComponentHandlesMultipleRelations(): array
+    {
+        return [
+            [
+                'class' => WithRelation::class,
+                'component' => 'Relation',
+                'expected' => false,
+            ],
+            [
+                'class' => WithRelation::class,
+                'component' => 'PolymorphicRelation',
+                'expected' => false,
+            ],
+            [
+                'class' => WithRelation::class,
+                'component' => 'ArraySyntaxRelation',
+                'expected' => false,
+            ],
+            [
+                'class' => WithRelation::class,
+                'component' => 'MultiRelationalRelation',
+                'expected' => true,
+            ],
+        ];
     }
 }

--- a/tests/php/ORM/DataObjectSchemaTest/WithRelation.php
+++ b/tests/php/ORM/DataObjectSchemaTest/WithRelation.php
@@ -2,11 +2,22 @@
 
 namespace SilverStripe\ORM\Tests\DataObjectSchemaTest;
 
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DataObjectSchema;
+
 class WithRelation extends NoFields
 {
     private static $table_name = 'DataObjectSchemaTest_WithRelation';
 
     private static $has_one = [
-        'Relation' => HasFields::Class
+        'Relation' => HasFields::class,
+        'PolymorphicRelation' => DataObject::class,
+        'MultiRelationalRelation' => [
+            'class' => DataObject::class,
+            DataObjectSchema::HAS_ONE_MULTI_RELATIONAL => true,
+        ],
+        'ArraySyntaxRelation' => [
+            'class' => HasFields::class,
+        ],
     ];
 }

--- a/tests/php/ORM/DataObjectTest/Player.php
+++ b/tests/php/ORM/DataObjectTest/Player.php
@@ -3,6 +3,8 @@
 namespace SilverStripe\ORM\Tests\DataObjectTest;
 
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DataObjectSchema;
 use SilverStripe\ORM\Tests\DataObjectTest;
 use SilverStripe\Security\Member;
 
@@ -17,6 +19,10 @@ class Player extends Member implements TestOnly
 
     private static $has_one = [
         'FavouriteTeam' => DataObjectTest\Team::class,
+        'MultiRelational' => [
+            'class' => DataObject::class,
+            DataObjectSchema::HAS_ONE_MULTI_RELATIONAL => true,
+        ],
     ];
 
     private static $belongs_many_many = [

--- a/tests/php/ORM/DataObjectTest/Team.php
+++ b/tests/php/ORM/DataObjectTest/Team.php
@@ -44,7 +44,10 @@ class Team extends DataObject implements TestOnly
         'SubTeams' => SubTeam::class,
         'Comments' => TeamComment::class,
         'Fans' => Fan::class . '.Favourite', // Polymorphic - Team fans
-        'PlayerFans' => Player::class . '.FavouriteTeam'
+        'PlayerFans' => Player::class . '.FavouriteTeam',
+        // multi-relational relation:
+        'ManyPlayers1' => Player::class . '.MultiRelational',
+        'ManyPlayers2' => Player::class . '.MultiRelational',
     ];
 
     private static $many_many = [

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -27,6 +27,8 @@ class DataQueryTest extends SapphireTest
         DataQueryTest\ObjectG::class,
         DataQueryTest\ObjectH::class,
         DataQueryTest\ObjectI::class,
+        DataQueryTest\ObjectHasMultiRelationalHasOne::class,
+        DataQueryTest\ObjectHasMultiRelationalHasMany::class,
         SQLSelectTest\CteRecursiveObject::class,
         SQLSelectTest\TestObject::class,
         SQLSelectTest\TestBase::class,
@@ -97,6 +99,33 @@ class DataQueryTest extends SapphireTest
         $dq->applyRelation('TestCTwo');
         $this->assertTrue($dq->query()->isJoinedTo('testctwo_DataQueryTest_C'));
         $this->assertStringContainsString('"testctwo_DataQueryTest_C"."ID" = "DataQueryTest_B"."TestCTwoID"', $dq->sql());
+    }
+
+    /**
+     * @dataProvider provideApplyRelationMultiRelational
+     */
+    public function testApplyRelationMultiRelational(string $relation): void
+    {
+        $dq = new DataQuery(DataQueryTest\ObjectHasMultiRelationalHasMany::class);
+        $dq->applyRelation($relation);
+        $joinAlias = strtolower($relation) . '_DataQueryTest_ObjectHasMultiRelationalHasOne';
+        $joinAliasWithQuotes = '"' . $joinAlias . '"';
+        $this->assertTrue($dq->query()->isJoinedTo($joinAlias));
+        $this->assertStringContainsString($joinAliasWithQuotes . '."MultiRelationalID" = "DataQueryTest_ObjectHasMultiRelationalHasMany"."ID"', $dq->sql());
+        $this->assertStringContainsString($joinAliasWithQuotes . '."MultiRelationalRelation" = ' . $relation, $dq->sql());
+        $this->assertStringContainsString($joinAliasWithQuotes . '."MultiRelationalClass" = "DataQueryTest_ObjectHasMultiRelationalHasMany"."ClassName"', $dq->sql());
+    }
+
+    public function provideApplyRelationMultiRelational(): array
+    {
+        return [
+            'relation1' => [
+                'relation' => 'MultiRelational1',
+            ],
+            'relation2' => [
+                'relation' => 'MultiRelational2',
+            ],
+        ];
     }
 
     public function testApplyRelationDeepInheritance()

--- a/tests/php/ORM/DataQueryTest/ObjectHasMultiReciprocalHasMany.php
+++ b/tests/php/ORM/DataQueryTest/ObjectHasMultiReciprocalHasMany.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataQueryTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class ObjectHasMultiRelationalHasMany extends DataObject implements TestOnly
+{
+    private static string $table_name = 'DataQueryTest_ObjectHasMultiRelationalHasMany';
+
+    private static array $db = [
+        'Name' => 'Varchar',
+        'SortOrder' => 'Int',
+    ];
+
+    private static array $has_many = [
+        'MultiRelational1' => ObjectHasMultiRelationalHasOne::class . '.MultiRelational',
+        'MultiRelational2' => ObjectHasMultiRelationalHasOne::class . '.MultiRelational',
+    ];
+}

--- a/tests/php/ORM/DataQueryTest/ObjectHasMultiReciprocalHasOne.php
+++ b/tests/php/ORM/DataQueryTest/ObjectHasMultiReciprocalHasOne.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataQueryTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DataObjectSchema;
+
+class ObjectHasMultiRelationalHasOne extends DataObject implements TestOnly
+{
+    private static string $table_name = 'DataQueryTest_ObjectHasMultiRelationalHasOne';
+
+    private static array $db = [
+        'Name' => 'Varchar',
+        'SortOrder' => 'Int',
+    ];
+
+    private static array $has_one = [
+        'MultiRelational' => [
+            'class' => DataObject::class,
+            DataObjectSchema::HAS_ONE_MULTI_RELATIONAL => true,
+        ],
+    ];
+}

--- a/tests/php/ORM/PolymorphicHasManyListTest.php
+++ b/tests/php/ORM/PolymorphicHasManyListTest.php
@@ -15,7 +15,10 @@ class PolymorphicHasManyListTest extends SapphireTest
 {
 
     // Borrow the model from DataObjectTest
-    protected static $fixture_file = 'DataObjectTest.yml';
+    protected static $fixture_file = [
+        'DataObjectTest.yml',
+        'PolymorphicHasManyListTest.yml',
+    ];
 
     public static function getExtraDataObjects()
     {
@@ -33,6 +36,30 @@ class PolymorphicHasManyListTest extends SapphireTest
     }
 
     /**
+     * Validates that multiple has_many relations can point to a single multi-relational
+     * has_one relation and still be separate
+     */
+    public function testMultiRelationalRelations(): void
+    {
+        $team = $this->objFromFixture(Team::class, 'multiRelationalTeam');
+        $playersList1 = $team->ManyPlayers1();
+        $playersList2 = $team->ManyPlayers2();
+
+        // Lists are separate
+        $this->assertSame(
+            ['MultiRelational Player 1', 'MultiRelational Player 2', 'MultiRelational Player 6'],
+            $playersList1->sort('FirstName')->column('FirstName')
+        );
+        $this->assertSame(
+            ['MultiRelational Player 3', 'MultiRelational Player 4', 'MultiRelational Player 5'],
+            $playersList2->sort('FirstName')->column('FirstName')
+        );
+        // The relation is saved on the has_one side of the relationship
+        $this->assertSame('ManyPlayers1', $playersList1->first()->MultiRelationalRelation);
+        $this->assertSame('ManyPlayers2', $playersList2->first()->MultiRelationalRelation);
+    }
+
+    /**
      * Test that DataList::relation works with PolymorphicHasManyList
      */
     public function testFilterRelation()
@@ -40,7 +67,7 @@ class PolymorphicHasManyListTest extends SapphireTest
         // Check that expected teams exist
         $list = Team::get();
         $this->assertEquals(
-            ['Subteam 1', 'Subteam 2', 'Subteam 3', 'Team 1', 'Team 2', 'Team 3'],
+            ['MultiRelational team', 'Subteam 1', 'Subteam 2', 'Subteam 3', 'Team 1', 'Team 2', 'Team 3'],
             $list->sort('Title')->column('Title')
         );
 
@@ -66,15 +93,59 @@ class PolymorphicHasManyListTest extends SapphireTest
     }
 
     /**
+     * The same as testFilterRelation but for multi-relational relationships
+     */
+    public function testFilterMultiRelationalRelation(): void
+    {
+        $list = Team::get();
+
+        $players1 = $list->relation('ManyPlayers1')->sort('FirstName')->column('FirstName');
+        $players2 = $list->relation('ManyPlayers2')->sort('FirstName')->column('FirstName');
+        // Test that each relation has the expected players
+        $this->assertSame(
+            ['MultiRelational Player 1', 'MultiRelational Player 2', 'MultiRelational Player 6'],
+            $players1
+        );
+        $this->assertSame(
+            ['MultiRelational Player 3', 'MultiRelational Player 4', 'MultiRelational Player 5'],
+            $players2
+        );
+
+        // Modify list of fans
+        $team = $this->objFromFixture(DataObjectTest\Team::class, 'multiRelationalTeam');
+        $newPlayer1 = new DataObjectTest\Player(['FirstName' => 'New player 1']);
+        $team->ManyPlayers1()->add($newPlayer1);
+        $this->assertSame('ManyPlayers1', $newPlayer1->MultiRelationalRelation);
+        $this->assertSame(Team::class, $newPlayer1->MultiRelationalClass);
+        $this->assertSame($team->ID, $newPlayer1->MultiRelationalID);
+        $newPlayer2 = new DataObjectTest\Player(['FirstName' => 'New player 2']);
+        $team->ManyPlayers2()->add($newPlayer2);
+        $this->assertSame('ManyPlayers2', $newPlayer2->MultiRelationalRelation);
+        $this->assertSame(Team::class, $newPlayer2->MultiRelationalClass);
+        $this->assertSame($team->ID, $newPlayer2->MultiRelationalID);
+
+        // and retest
+        $players1 = $list->relation('ManyPlayers1')->sort('FirstName')->column('FirstName');
+        $players2 = $list->relation('ManyPlayers2')->sort('FirstName')->column('FirstName');
+        $this->assertSame(
+            ['MultiRelational Player 1', 'MultiRelational Player 2', 'MultiRelational Player 6', 'New player 1'],
+            $players1
+        );
+        $this->assertSame(
+            ['MultiRelational Player 3', 'MultiRelational Player 4', 'MultiRelational Player 5', 'New player 2'],
+            $players2
+        );
+    }
+
+    /**
      * Test that related objects can be removed from a relation
      */
     public function testRemoveRelation()
     {
-
         // Check that expected teams exist
         $list = Team::get();
         $this->assertEquals(
-            ['Subteam 1', 'Subteam 2', 'Subteam 3', 'Team 1', 'Team 2', 'Team 3'],
+            ['MultiRelational team', 'Subteam 1', 'Subteam 2', 'Subteam 3', 'Team 1', 'Team 2', 'Team 3'],
             $list->sort('Title')->column('Title')
         );
 
@@ -109,10 +180,57 @@ class PolymorphicHasManyListTest extends SapphireTest
         $this->assertEmpty($subteam1fan->FavouriteClass);
     }
 
+    /**
+     * The same as testRemoveRelation but for multi-relational relationships
+     */
+    public function testRemoveMultiRelationalRelation(): void
+    {
+        $team = $this->objFromFixture(DataObjectTest\Team::class, 'multiRelationalTeam');
+        $originalPlayers1 = $team->ManyPlayers1()->sort('FirstName')->column('FirstName');
+        $originalPlayers2 = $team->ManyPlayers2()->sort('FirstName')->column('FirstName');
+
+        // Test that each relation has the expected players as a baseline
+        $this->assertSame(
+            ['MultiRelational Player 1', 'MultiRelational Player 2', 'MultiRelational Player 6'],
+            $originalPlayers1
+        );
+        $this->assertSame(
+            ['MultiRelational Player 3', 'MultiRelational Player 4', 'MultiRelational Player 5'],
+            $originalPlayers2
+        );
+
+        // Test that you can't remove items from relations they're not in
+        $playerFromGroup1 = $this->objFromFixture(DataObjectTest\Player::class, 'multiRelationalPlayer2');
+        $team->ManyPlayers2()->remove($playerFromGroup1);
+        $this->assertSame($originalPlayers1, $team->ManyPlayers1()->sort('FirstName')->column('FirstName'));
+        $this->assertSame($originalPlayers2, $team->ManyPlayers2()->sort('FirstName')->column('FirstName'));
+        $this->assertSame('ManyPlayers1', $playerFromGroup1->MultiRelationalRelation);
+        $this->assertSame(Team::class, $playerFromGroup1->MultiRelationalClass);
+        $this->assertSame($team->ID, $playerFromGroup1->MultiRelationalID);
+
+        // Test that you *can* remove items from relations they *are* in
+        $team->ManyPlayers1()->remove($playerFromGroup1);
+        $this->assertSame(
+            ['MultiRelational Player 1', 'MultiRelational Player 6'],
+            $team->ManyPlayers1()->sort('FirstName')->column('FirstName')
+        );
+        $this->assertSame($originalPlayers2, $team->ManyPlayers2()->sort('FirstName')->column('FirstName'));
+        $this->assertEmpty($playerFromGroup1->MultiRelationalRelation);
+        $this->assertEmpty($playerFromGroup1->MultiRelationalClass);
+        $this->assertEmpty($playerFromGroup1->MultiRelationalID);
+    }
+
     public function testGetForeignClassKey(): void
     {
         $team = $this->objFromFixture(DataObjectTest\Team::class, 'team1');
         $list = $team->Fans();
         $this->assertSame('FavouriteClass', $list->getForeignClassKey());
+    }
+
+    public function getGetForeignRelationKey(): void
+    {
+        $team = $this->objFromFixture(DataObjectTest\Team::class, 'team1');
+        $list = $team->Fans();
+        $this->assertSame('FavouriteRelation', $list->getForeignRelationKey());
     }
 }

--- a/tests/php/ORM/PolymorphicHasManyListTest.yml
+++ b/tests/php/ORM/PolymorphicHasManyListTest.yml
@@ -1,0 +1,25 @@
+SilverStripe\ORM\Tests\DataObjectTest\Player:
+  multiRelationalPlayer1:
+    FirstName: MultiRelational Player 1
+  multiRelationalPlayer2:
+    FirstName: MultiRelational Player 2
+  multiRelationalPlayer3:
+    FirstName: MultiRelational Player 3
+  multiRelationalPlayer4:
+    FirstName: MultiRelational Player 4
+  multiRelationalPlayer5:
+    FirstName: MultiRelational Player 5
+  multiRelationalPlayer6:
+    FirstName: MultiRelational Player 6
+
+SilverStripe\ORM\Tests\DataObjectTest\Team:
+  multiRelationalTeam:
+    Title: MultiRelational team
+    ManyPlayers1:
+      - =>SilverStripe\ORM\Tests\DataObjectTest\Player.multiRelationalPlayer1
+      - =>SilverStripe\ORM\Tests\DataObjectTest\Player.multiRelationalPlayer2
+      - =>SilverStripe\ORM\Tests\DataObjectTest\Player.multiRelationalPlayer6
+    ManyPlayers2:
+      - =>SilverStripe\ORM\Tests\DataObjectTest\Player.multiRelationalPlayer3
+      - =>SilverStripe\ORM\Tests\DataObjectTest\Player.multiRelationalPlayer4
+      - =>SilverStripe\ORM\Tests\DataObjectTest\Player.multiRelationalPlayer5


### PR DESCRIPTION
This PR provides a new has_one syntax that allows for a single has_one relation to be pointed at by multiple has_many relations - and each will correctly retain only their own items, without bleeding between them.

Without this PR, if you wanted multiple has_many relations on class A all pointing at class B, you would need to have a separate has_one relation on class B for each of the has_many relations.

## Issue
- https://github.com/silverstripe/silverstripe-linkfield/issues/5