### PR TITLE
FIX: UnsavedRelationList first/last to return null if list is empty (fixes #11083)

### DIFF
--- a/src/ORM/UnsavedRelationList.php
+++ b/src/ORM/UnsavedRelationList.php
@@ -239,11 +239,11 @@ class UnsavedRelationList extends ArrayList implements Relation
      */
     public function first()
     {
-        $item = reset($this->items);
+        $item = reset($this->items) ?: null;
         if (is_numeric($item)) {
             $item = DataObject::get_by_id($this->dataClass, $item);
         }
-        if (!empty($this->extraFields[key($this->items)])) {
+        if ($item && !empty($this->extraFields[key($this->items)])) {
             $item->update($this->extraFields[key($this->items)]);
         }
         return $item;
@@ -256,8 +256,8 @@ class UnsavedRelationList extends ArrayList implements Relation
      */
     public function last()
     {
-        $item = end($this->items);
-        if (!empty($this->extraFields[key($this->items)])) {
+        $item = end($this->items) ?: null;
+        if ($item && !empty($this->extraFields[key($this->items)])) {
             $item->update($this->extraFields[key($this->items)]);
         }
         return $item;

--- a/src/ORM/UnsavedRelationList.php
+++ b/src/ORM/UnsavedRelationList.php
@@ -257,6 +257,9 @@ class UnsavedRelationList extends ArrayList implements Relation
     public function last()
     {
         $item = end($this->items) ?: null;
+        if (is_numeric($item)) {
+            $item = DataObject::get_by_id($this->dataClass, $item);
+        }
         if ($item && !empty($this->extraFields[key($this->items)])) {
             $item->update($this->extraFields[key($this->items)]);
         }

--- a/tests/php/ORM/UnsavedRelationListTest.php
+++ b/tests/php/ORM/UnsavedRelationListTest.php
@@ -310,4 +310,20 @@ class UnsavedRelationListTest extends SapphireTest
             ]
         );
     }
+
+    public function testFirstAndLast()
+    {
+        $object = new UnsavedRelationListTest\TestObject();
+        $children = $object->Children();
+
+        $this->assertNull($children->first(), 'Empty UnsavedRelationList should return null for first item.');
+        $this->assertNull($children->last(), 'Empty UnsavedRelationList should return null for last item.');
+
+        $children->add($firstChild = $this->objFromFixture(UnsavedRelationListTest\TestObject::class, 'ObjectA'));
+        $children->add($this->objFromFixture(UnsavedRelationListTest\TestObject::class, 'ObjectB'));
+        $children->add($lastChild = $this->objFromFixture(UnsavedRelationListTest\TestObject::class, 'ObjectC'));
+
+        $this->assertEquals($firstChild, $children->first(), 'Incorrect first item in UnsavedRelationList.');
+        $this->assertEquals($lastChild, $children->last(), 'Incorrect last item in UnsavedRelationList.');
+    }
 }


### PR DESCRIPTION
Issue #11083 