### PR TITLE
Remove unused lines in `findTab()`

### DIFF
--- a/src/Forms/FieldList.php
+++ b/src/Forms/FieldList.php
@@ -400,7 +400,6 @@ class FieldList extends ArrayList
         $currentPointer = $this;
 
         foreach ($parts as $k => $part) {
-            $parentPointer = $currentPointer;
             /** @var FormField $currentPointer */
             $currentPointer = $currentPointer->fieldByName($part);
         }

--- a/src/Forms/FieldList.php
+++ b/src/Forms/FieldList.php
@@ -395,7 +395,6 @@ class FieldList extends ArrayList
     public function findTab($tabName)
     {
         $parts = explode('.', $tabName ?? '');
-        $last_idx = count($parts ?? []) - 1;
 
         $currentPointer = $this;
 


### PR DESCRIPTION
Fixes #11090

These lines don't appear to be of any use...likely copied over from `findOrMakeTab()` below.