### PR TITLE
Fix email failure bugs

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -290,6 +290,7 @@ en:
     CURRENT_PASSWORD: 'Current Password'
     EDIT_PASSWORD: 'New Password'
     EMAIL: Email
+    EMAIL_FAILED: 'There was an error when trying to email you a password reset link.'
     EMPTYNEWPASSWORD: "The new password can't be empty, please try again"
     ENTEREMAIL: 'Please enter an email address to get a password reset link.'
     ERRORLOCKEDOUT2: 'Your account has been temporarily disabled because of too many failed attempts at logging in. Please try again in {count} minutes.'

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Security;
 
 use IntlDateFormatter;
 use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
 use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\Control\Director;
@@ -34,7 +35,9 @@ use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\UnsavedRelationList;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\ORM\ValidationResult;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Exception\RfcComplianceException;
 
 /**
  * The member class which represents the users of the system
@@ -772,18 +775,24 @@ class Member extends DataObject
             && static::config()->get('notify_password_change')
             && $this->isInDB()
         ) {
-            $email = Email::create()
-                ->setHTMLTemplate('SilverStripe\\Control\\Email\\ChangePasswordEmail')
-                ->setData($this)
-                ->setTo($this->Email)
-                ->setSubject(_t(
-                    __CLASS__ . '.SUBJECTPASSWORDCHANGED',
-                    "Your password has been changed",
-                    'Email subject'
-                ));
+            try {
+                $email = Email::create()
+                    ->setHTMLTemplate('SilverStripe\\Control\\Email\\ChangePasswordEmail')
+                    ->setData($this)
+                    ->setTo($this->Email)
+                    ->setSubject(_t(
+                        __CLASS__ . '.SUBJECTPASSWORDCHANGED',
+                        "Your password has been changed",
+                        'Email subject'
+                    ));
 
-            $this->extend('updateChangedPasswordEmail', $email);
-            $email->send();
+                $this->extend('updateChangedPasswordEmail', $email);
+                $email->send();
+            } catch (TransportExceptionInterface | RfcComplianceException $e) {
+                /** @var LoggerInterface $logger */
+                $logger = Injector::inst()->get(LoggerInterface::class . '.errorhandler');
+                $logger->error('Error sending email in ' . __FILE__ . ' line ' . __LINE__ . ": {$e->getMessage()}");
+            }
         }
 
         // The test on $this->ID is used for when records are initially created. Note that this only works with


### PR DESCRIPTION
This PR fixes two related bugs.

For both bugs, this PR logs the error, but lets code execution continue
Note that there are two ways this exception can occur:
1. `admin_url` is not a valid email address, so `RfcComplianceException` is thrown
2. Something fails in symfony mailer while actually sending the email, so `TransportExceptionInterface` is thrown

## Bug one
- https://github.com/silverstripe/silverstripe-framework/issues/11034

If there's an exception thrown when trying to send an email to a user in live mode when their password has been changed, the new password does not get saved.

## Bug two
No issue open

When using the password recovery functionality ("I've lost my password"), if an exception is thrown when trying to send the recovery email, the whole page just breaks.

Instead of that, the user should be given a user-friendly error message, and the cause of the error should be logged.

## Notes
- With bug one specifically, there is [some weird side-effect](https://github.com/silverstripe/silverstripe-admin/issues/1634) to logging the error which causes the success toast to be red (so it looks like a failure toast), and the page doesn't reload. But the new password _is_ saved, so I'm raising a separate issue to look into that side effect. The bug this PR fixes is about saving the password value, and that bug is fixed with this PR.