### PR TITLE
MINOR: adding SpelledOut method in DBInt

### DIFF
--- a/src/ORM/FieldType/DBInt.php
+++ b/src/ORM/FieldType/DBInt.php
@@ -64,7 +64,13 @@ class DBInt extends DBField
     {
         return sprintf('%d', $this->value);
     }
-
+    
+    public function SpelledOut()
+    {
+        $v = $this->prepValueForDB($this->value);
+        return (new NumberFormatter(i18n::get_locale(), NumberFormatter::SPELLOUT))->format($v);
+    }
+    
     public function scaffoldFormField($title = null, $params = null)
     {
         return NumericField::create($this->name, $title);


### PR DESCRIPTION
This is just an idea, be curious to see if this would be acceptable.  

You can then write in your template:

```ss
$MyInt  = $MyInt.SpelledOut 
```

Which outputs:
```html
7 = seven
```