### PR TITLE
FIX Handle polymorphic relationships that use Owner instead of Parent

### DIFF
--- a/src/ORM/RelatedData/StandardRelatedDataService.php
+++ b/src/ORM/RelatedData/StandardRelatedDataService.php
@@ -313,9 +313,10 @@ class StandardRelatedDataService implements RelatedDataService
         $tableName = $this->dataObjectSchema->tableName($class);
         $where = sprintf('"%s" = %u', $componentIDField, $record->ID);
 
-        // Polymorphic
-        if ($componentIDField === 'ParentID' && isset($dbFields['ParentClass'])) {
-            $where .= sprintf(' AND "ParentClass" = %s', $this->prepareClassNameLiteral(get_class($record)));
+        // Polymorphic - if $component is "Parent" or "Owner" then usually it will be polymorphic
+        $isPolymorphic = DataObject::getSchema()->hasOneComponent($class, $component) === DataObject::class;
+        if ($isPolymorphic) {
+            $where .= sprintf(' AND "' . $component . 'Class" = %s', $this->prepareClassNameLiteral(get_class($record)));
         }
 
         // Example SQL:


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-linkfield/issues/9

Duplicate file links were showing on the used on table due to the Link using 'Owner' instead of 'Parent'

While this is by no means a complete solution for the used on table, I don't want to do a full refactor given the context here is only to get the used on table working correctly for LinkField