### PR TITLE
[CVE-2023-49783] Allow permission checks in BulkLoader

### DIFF
--- a/src/Dev/BulkLoader.php
+++ b/src/Dev/BulkLoader.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Dev;
 
+use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Core\Environment;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\View\ViewableData;
@@ -21,6 +22,7 @@ use SilverStripe\View\ViewableData;
  */
 abstract class BulkLoader extends ViewableData
 {
+    private bool $checkPermissions = false;
 
     /**
      * Each row in the imported dataset should map to one instance
@@ -135,6 +137,23 @@ abstract class BulkLoader extends ViewableData
         parent::__construct();
     }
 
+    /**
+     * If true, this bulk loader will respect create/edit/delete permissions.
+     */
+    public function getCheckPermissions(): bool
+    {
+        return $this->checkPermissions;
+    }
+
+    /**
+     * Determine whether this bulk loader should respect create/edit/delete permissions.
+     */
+    public function setCheckPermissions(bool $value): self
+    {
+        $this->checkPermissions = $value;
+        return $this;
+    }
+
     /*
      * Load the given file via {@link self::processAll()} and {@link self::processRecord()}.
      * Optionally truncates (clear) the table before it imports.
@@ -148,6 +167,21 @@ abstract class BulkLoader extends ViewableData
 
         //get all instances of the to be imported data object
         if ($this->deleteExistingRecords) {
+            if ($this->getCheckPermissions()) {
+                // We need to check each record, in case there's some fancy conditional logic in the canDelete method.
+                // If we can't delete even a single record, we should bail because otherwise the result would not be
+                // what the user expects.
+                /** @var DataObject $record */
+                foreach (DataObject::get($this->objectClass) as $record) {
+                    if (!$record->canDelete()) {
+                        $type = $record->i18n_singular_name();
+                        throw new HTTPResponse_Exception(
+                            _t(__CLASS__ . '.CANNOT_DELETE', "Not allowed to delete '$type' records"),
+                            403
+                        );
+                    }
+                }
+            }
             DataObject::get($this->objectClass)->removeAll();
         }
 

--- a/src/Security/GroupCsvBulkLoader.php
+++ b/src/Security/GroupCsvBulkLoader.php
@@ -12,6 +12,7 @@ class GroupCsvBulkLoader extends CsvBulkLoader
 {
 
     public $duplicateChecks = [
+        'ID' => 'ID',
         'Code' => 'Code',
     ];
 

--- a/src/Security/MemberCsvBulkLoader.php
+++ b/src/Security/MemberCsvBulkLoader.php
@@ -33,6 +33,7 @@ class MemberCsvBulkLoader extends CsvBulkLoader
      * @var array
      */
     public $duplicateChecks = [
+        'ID' => 'ID',
         'Email' => 'Email',
     ];
 

--- a/tests/php/Dev/CsvBulkLoaderTest.yml
+++ b/tests/php/Dev/CsvBulkLoaderTest.yml
@@ -1,3 +1,19 @@
 SilverStripe\Dev\Tests\CsvBulkLoaderTest\Team:
    team1:
       Title: My Team
+
+SilverStripe\Dev\Tests\CsvBulkLoaderTest\CantDeleteModel:
+  model1:
+    Title: Record 1
+  model2:
+    Title: Record 2
+  model3:
+    Title: Record 3
+
+SilverStripe\Dev\Tests\CsvBulkLoaderTest\CantEditModel:
+  model1:
+    Title: Record 1
+  model2:
+    Title: Record 2
+  model3:
+    Title: Record 3

--- a/tests/php/Dev/CsvBulkLoaderTest/CanModifyModel.php
+++ b/tests/php/Dev/CsvBulkLoaderTest/CanModifyModel.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SilverStripe\Dev\Tests\CsvBulkLoaderTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class CanModifyModel extends DataObject implements TestOnly
+{
+    private static $table_name = 'CsvBulkLoaderTest_CanModifyModel';
+
+    private static array $db = [
+        'Title' => 'Varchar',
+        'AnotherField' => 'Varchar',
+    ];
+
+    public function canCreate($member = null, $context = [])
+    {
+        return true;
+    }
+
+    public function canEdit($member = null)
+    {
+        return true;
+    }
+
+    public function canDelete($member = null)
+    {
+        return true;
+    }
+}

--- a/tests/php/Dev/CsvBulkLoaderTest/CantCreateModel.php
+++ b/tests/php/Dev/CsvBulkLoaderTest/CantCreateModel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Dev\Tests\CsvBulkLoaderTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class CantCreateModel extends CanModifyModel implements TestOnly
+{
+    public function canCreate($member = null, $context = [])
+    {
+        return false;
+    }
+}

--- a/tests/php/Dev/CsvBulkLoaderTest/CantDeleteModel.php
+++ b/tests/php/Dev/CsvBulkLoaderTest/CantDeleteModel.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SilverStripe\Dev\Tests\CsvBulkLoaderTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class CantDeleteModel extends DataObject implements TestOnly
+{
+    private static $table_name = 'CsvBulkLoaderTest_CantDeleteModel';
+
+    private static array $db = [
+        'Title' => 'Varchar',
+        'AnotherField' => 'Varchar',
+    ];
+
+    public function canCreate($member = null, $context = [])
+    {
+        return true;
+    }
+
+    public function canEdit($member = null)
+    {
+        return true;
+    }
+
+    public function canDelete($member = null)
+    {
+        return false;
+    }
+}

--- a/tests/php/Dev/CsvBulkLoaderTest/CantEditModel.php
+++ b/tests/php/Dev/CsvBulkLoaderTest/CantEditModel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Dev\Tests\CsvBulkLoaderTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class CantEditModel extends CanModifyModel implements TestOnly
+{
+    public function canEdit($member = null)
+    {
+        return false;
+    }
+}

--- a/tests/php/Dev/CsvBulkLoaderTest/csv/PermissionCheck.csv
+++ b/tests/php/Dev/CsvBulkLoaderTest/csv/PermissionCheck.csv
@@ -1,0 +1,4 @@
+Title, AnotherField
+Record 1, value 1
+Record 2, value 2
+Record 3, value 3


### PR DESCRIPTION
This should match https://github.com/silverstripe-security/silverstripe-framework/pull/130 exactly.

CI has already passed in the security repository. Any CI failures that are present there are expected and accounted for. This can be merged safely without waiting for CI to run again. CI will run after merging anyway, and is a safeguard prior to patching.

## Issue
- https://github.com/silverstripeltd/product-issues/issues/832
- https://github.com/silverstripe-security/security-issues/issues/177