### PR TITLE
[CVE-2023-48714] Don't show or add records the member isn't allowed to

### DIFF
--- a/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
+++ b/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
@@ -16,6 +16,7 @@ use SilverStripe\ORM\Filters\SearchFilter;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 use LogicException;
+use SilverStripe\Control\HTTPResponse_Exception;
 
 /**
  * This class is is responsible for adding objects to another object's has_many
@@ -195,11 +196,14 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
         if (empty($objectID)) {
             return $dataList;
         }
+        $gridField->State->GridFieldAddRelation = null;
         $object = DataObject::get_by_id($gridField->getModelClass(), $objectID);
         if ($object) {
+            if (!$object->canView()) {
+                throw new HTTPResponse_Exception(null, 403);
+            }
             $dataList->add($object);
         }
-        $gridField->State->GridFieldAddRelation = null;
         return $dataList;
     }
 
@@ -265,6 +269,9 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
         SSViewer::config()->set('source_file_comments', false);
         $viewer = SSViewer::fromString($this->resultsFormat);
         foreach ($results as $result) {
+            if (!$result->canView()) {
+                continue;
+            }
             $title = Convert::html2raw($viewer->process($result));
             $json[] = [
                 'label' => $title,


### PR DESCRIPTION
This should match https://github.com/silverstripe-security/silverstripe-framework/pull/129 exactly

CI has already passed in the security repository. Any CI failures that are present there are expected and accounted for. This can be merged safely without waiting for CI to run again. CI will run after merging anyway, and is a safeguard prior to patching.

## Issues
- https://github.com/silverstripeltd/product-issues/issues/832
- https://github.com/silverstripe-security/security-issues/issues/176