### PR TITLE
FIX HTMLEditorField::setRows with Elemental

### DIFF
--- a/src/Forms/HTMLEditor/HTMLEditorField.php
+++ b/src/Forms/HTMLEditor/HTMLEditorField.php
@@ -114,20 +114,10 @@ class HTMLEditorField extends TextareaField
 
     public function getAttributes()
     {
-        $config = $this->getEditorConfig();
-        // Fix CSS height based on rows
-        $rowHeight = $this->config()->get('fixed_row_height');
-        $attributes = [];
-        if ($rowHeight && ($config instanceof TinyMCEConfig)) {
-            $height = $this->getRows() * $rowHeight;
-            $attributes['style'] = sprintf('height: %dpx;', $height);
-            $config = clone $config;
-            $config->setOption('height', 'auto');
-        }
+        $config = $this->setEditorHeight($this->getEditorConfig());
 
         // Merge attributes
         return array_merge(
-            $attributes,
             parent::getAttributes(),
             $config->getAttributes()
         );
@@ -190,7 +180,7 @@ class HTMLEditorField extends TextareaField
     public function getSchemaStateDefaults()
     {
         $stateDefaults = parent::getSchemaStateDefaults();
-        $config = $this->getEditorConfig();
+        $config = $this->setEditorHeight($this->getEditorConfig());
         $stateDefaults['data'] = $config->getConfigSchemaData();
         return $stateDefaults;
     }
@@ -203,5 +193,24 @@ class HTMLEditorField extends TextareaField
     public function ValueEntities()
     {
         return htmlentities($this->Value() ?? '', ENT_COMPAT, 'UTF-8', false);
+    }
+
+    /**
+     * Set height of editor based on number of rows
+     */
+    private function setEditorHeight(HTMLEditorConfig $config): HTMLEditorConfig
+    {
+        $rowHeight = $this->config()->get('fixed_row_height');
+        if ($rowHeight && ($config instanceof TinyMCEConfig)) {
+            $rows = (int) $this->getRows();
+            $height = $rows * $rowHeight;
+            $config = clone $config;
+            if ($height) {
+                $config->setOption('height', 'auto');
+                $config->setOption('row_height', sprintf('%dpx', $height));
+            }
+        }
+
+        return $config;
     }
 }

--- a/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
@@ -267,4 +267,43 @@ EOS
         $editor->saveInto($obj);
         $this->assertEquals($htmlValue, $obj->Content, 'Table is removed');
     }
+
+    public function testGetAttributes()
+    {
+        // Create an editor and set fixed_row_height to 0
+        $editor = HTMLEditorField::create('Content');
+        $editor->config()->set('fixed_row_height', 0);
+        // Get the attributes and config from the editor
+        $attributes = $editor->getAttributes();
+        $data_config = json_decode($attributes['data-config'], true);
+        // If fixed_row_height is 0 then row_height and height config are not set
+        $this->assertArrayNotHasKey('height', $data_config, 'Config height should not be set');
+        $this->assertArrayNotHasKey('row_height', $data_config, 'Config row_height should not be set');
+        // Set the fixed_row_height back to 20px
+        $editor->config()->set('fixed_row_height', 20);
+        // Set the rows to 0
+        $editor->setRows(0);
+        // Get the attributes and config from the editor
+        $attributes = $editor->getAttributes();
+        $data_config = json_decode($attributes['data-config'], true);
+        // If rows is 0 then row_height and height config are not set
+        $this->assertArrayNotHasKey('height', $data_config, 'Config height should not be set');
+        $this->assertArrayNotHasKey('row_height', $data_config, 'Config row_height should not be set');
+        // Set the rows to 5
+        $editor->setRows(5);
+        // Get the attributes and config from the editor
+        $attributes = $editor->getAttributes();
+        $data_config = json_decode($attributes['data-config']);
+        // Check the height is set to auto and the row height is set to 100px (5 rows * 20px)
+        $this->assertEquals("auto", $data_config->height, 'Config height is not set');
+        $this->assertEquals("100px", $data_config->row_height, 'Config row_height is not set');
+        // Change the row height to 60px and set the rows to 3
+        $editor->setRows(3);
+        // Get the attributes and config from the editor
+        $attributes = $editor->getSchemaStateDefaults();
+        $data_config = json_decode($attributes['data']['attributes']['data-config']);
+        // Check the height is set to auto and the row height is set to 60px (3 rows * 20px)
+        $this->assertEquals("auto", $data_config->height, 'Config height is not set');
+        $this->assertEquals("60px", $data_config->row_height, 'Config row_height is not set');
+    }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

Additional modification for 

## Manual testing steps
- Modify Page.php
```php
class Page extends SiteTree
{
    private static array $db = [
        'Content' => 'HTMLText',
        'Content_2' => 'HTMLText',
    ];
    public function getCMSFields()
    {
        $fields = parent::getCMSFields();
        $fields->addFieldsToTab(
            'Root.Main',
            [
                HTMLEditorField::create('Content')
                ->setRows(4), //  HTMLEditorField should be 80px high 
                HTMLEditorField::create('Content_2'), //  HTMLEditorField should be 400px high by default
            ],
        );

        return $fields;
    }
}
```

- Add new Elemental block with the following code:
```php
<?php

namespace App\Blocks;

use DNADesign\Elemental\Models\BaseElement;
use SilverStripe\Forms\HTMLEditor\HTMLEditorField;

class LinksListBlock extends BaseElement
{

    private static array $db = [
        'Content' => 'HTMLText',
    ];

    private static string $icon = 'font-icon-block-file-list';

    private static string $table_name = 'TestContentBlock';

    private static string $singular_name = 'Test Content Block';

    private static string $plural_name = 'Test Content Blocks';

    private static bool $inline_editable = true;

    public function getType(): string
    {
        return _t(self::class . '.BlockType', 'Test Content Block');
    }

    public function getCMSFields()
    {
        $fields = parent::getCMSFields();

        $fields->addFieldsToTab(
            'Root.Main',
            [
                HTMLEditorField::create('Content', 'Content')
                ->setRows(3),
            ],
        );

        return $fields;
    }
}
```
- Create new Page and new Blocks Page in CMS.
- Test that all fields have either default `height = 400px;` or custom `height` is `setRows()` method was applied. 
- Test that the content of `HTMLEditorField` was saved. 

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-elemental/issues/1132

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
