### PR TITLE
MNT Fix unit test when running without silverstripe/admin installed

### DIFF
--- a/tests/php/Forms/ConfirmedPasswordFieldTest.php
+++ b/tests/php/Forms/ConfirmedPasswordFieldTest.php
@@ -442,7 +442,9 @@ class ConfirmedPasswordFieldTest extends SapphireTest
         // CWP front-end templates break this logic - but there's no easy fix for that.
         // For the most part we are interested in ensuring this works in the CMS with default templates.
         $originalThemes = SSViewer::get_themes();
-        SSViewer::set_themes(LeftAndMain::config()->uninherited('admin_themes'));
+        if (class_exists(LeftAndMain::class)) {
+            SSViewer::set_themes(LeftAndMain::config()->uninherited('admin_themes'));
+        }
         try {
             $form = new Form();
             $field = new ConfirmedPasswordField('Test');


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/188

Fixes when running as silverstripe/recipe-core which won't install silverstripe/admin - https://github.com/silverstripe/recipe-core/actions/runs/7667349016/job/20896992238