### PR TITLE
MNT Remove unexpected coupling with admin for test

### DIFF
--- a/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
@@ -8,6 +8,7 @@ use SilverStripe\Assets\FileNameFilter;
 use SilverStripe\Assets\Filesystem;
 use SilverStripe\Assets\Folder;
 use SilverStripe\Assets\Image;
+use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\CSSContentParser;
 use SilverStripe\Dev\FunctionalTest;
@@ -270,6 +271,15 @@ EOS
 
     public function testGetAttributes()
     {
+        // If silverstripe/admin isn't installed, we can't get TinyMCEConfig attributes
+        // unless we set up some expected config pointing to expected files.
+        if (!TinyMCEConfig::config()->get('base_dir')) {
+            // Copied from TinyMCECombinedGeneratorTest::setUp()
+            Director::config()->set('alternate_base_folder', __DIR__ . '/TinyMCECombinedGeneratorTest');
+            Director::config()->set('alternate_public_dir', '');
+            TinyMCEConfig::config()->set('base_dir', 'tinymce');
+            TinyMCEConfig::config()->set('editor_css', ['mycode/editor.css']);
+        }
         // Create an editor and set fixed_row_height to 0
         $editor = HTMLEditorField::create('Content');
         $editor->config()->set('fixed_row_height', 0);


### PR DESCRIPTION
This was introduced in https://github.com/silverstripe/silverstripe-framework/pull/11114 so I'm targetting `5.1`, even though the broken CI run was on `5`. I tested it in `5` and it does resolve that failure.

Fixes https://github.com/silverstripe/recipe-core/actions/runs/7854511547/job/21501300422
> ```
> 1) SilverStripe\Forms\Tests\HTMLEditor\HTMLEditorFieldTest::testGetAttributes
> Exception: If the silverstripe/admin module is not installed you must set the TinyMCE path in SilverStripe\Forms\HTMLEditor\TinyMCEConfig.base_dir
> ```

## Issue
- https://github.com/silverstripe/.github/issues/195