### PR TITLE
FIX Handle __TRAIT__ in i18nTextCollector

### DIFF
--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -625,14 +625,14 @@ class i18nTextCollector
                     }
                 }
 
-                // Check class
-                if ($id === T_CLASS) {
+                // Check class and trait
+                if ($id === T_CLASS || $id === T_TRAIT) {
                     // Skip if previous token was '::'. E.g. 'Object::class'
                     if (is_array($previousToken) && $previousToken[0] === T_DOUBLE_COLON) {
                         if ($inSelf) {
                             // Handle self::class by allowing logic further down
-                            // for __CLASS__ to handle an array of class parts
-                            $id = T_CLASS_C;
+                            // for __CLASS__/__TRAIT__ to handle an array of class parts
+                            $id = $id === T_TRAIT ? T_TRAIT_C : T_CLASS_C;
                             $inSelf = false;
                         } elseif ($potentialClassName) {
                             $id = T_CONSTANT_ENCAPSED_STRING;
@@ -722,7 +722,7 @@ class i18nTextCollector
                     } else {
                         throw new LogicException("Invalid string escape: " . $text);
                     }
-                } elseif ($id === T_CLASS_C) {
+                } elseif ($id === T_CLASS_C || $id === T_TRAIT_C) {
                     // Evaluate __CLASS__ . '.KEY' and self::class concatenation
                     $text = implode('\\', $currentClass);
                 } else {

--- a/tests/php/i18n/i18nTextCollectorTest.php
+++ b/tests/php/i18n/i18nTextCollectorTest.php
@@ -407,6 +407,39 @@ PHP;
         );
     }
 
+    public function testCollectFromTrait()
+    {
+        $c = i18nTextCollector::create();
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
+        $php = <<<PHP
+<?php
+namespace SilverStripe\Framework\Core;
+
+use SilverStripe\ORM\DataObject;
+
+class MyTrait extends Base implements SomeService {
+    public function getNewLines(\$class) {
+        if (
+            !is_subclass_of(\$class, DataObject::class)
+            || !Object::has_extension(\$class, \SilverStripe\Versioned\Versioned::class)
+        ) {
+            return null;
+        }
+        return _t(
+            __TRAIT__.'.NEWLINES',
+            'New Lines'
+        );
+    }
+}
+PHP;
+        $this->assertEquals(
+            [
+                'SilverStripe\\Framework\\Core\\MyTrait.NEWLINES' => "New Lines",
+            ],
+            $c->collectFromCode($php, null, $mymodule)
+        );
+    }
+
     public function testNewlinesInEntityValues()
     {
         $c = i18nTextCollector::create();


### PR DESCRIPTION
Applies fix committed to v5 to v4.13. Addresses issue identified in https://github.com/tractorcow-farm/silverstripe-fluent/issues/823 and https://github.com/tractorcow-farm/silverstripe-fluent/pull/824

Original PR: https://github.com/silverstripe/silverstripe-framework/pull/10813

Attn: @GuySartorelli 