### PR TITLE
FIX Add eagerloaded data to ALL relevant lists

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1372,7 +1372,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
                 if ($parentData->hasID($parentID)) {
                     $parentData->addEagerLoadedData($relationName, $parentID, $eagerLoadedData);
                     $added = true;
-                    break;
+                    // can't break here, because the parent might be in multiple relation lists
                 }
             } else {
                 throw new LogicException("Invalid parent for eager loading $relationType relation $relationName");

--- a/src/ORM/EagerLoadedList.php
+++ b/src/ORM/EagerLoadedList.php
@@ -940,7 +940,7 @@ class EagerLoadedList extends ViewableData implements Relation, SS_List, Filtera
 
     /**
      * Gets the final rows for this list after applying all transformations.
-     * Currently only limit is applied lazily, but others could be done this was as well.
+     * Currently only limit and sort are applied lazily, but filter could be done this was as well in the future.
      */
     private function getFinalisedRows(): array
     {


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
When a record belongs to multiple many_many (and maybe has_many) relations and you eagerload it and chained relations from it, you can end up in a scenario where the eagerloaded data doesn't get added to some of the relation lists it belongs to.
More details in the linked issue.

## Manual testing steps
1. Add a breakpoint on `DataList::getFinalisedQuery()`
2. Run this code
    ```php
    use SilverStripe\Security\Member;
    $list = Member::get()->eagerLoad('Groups.Permissions');
    foreach ($list as $member) {
        foreach ($member->DirectGroups() as $group) {
            foreach ($group->Permissions() as $perm) {
                echo '';
            }
        }
    }
    ```
3. Check the trace each time the breakpoint is hit. It should only be hit once directly from the above code.

You could also add a breakpoint in the above code itself, and check that each list being looped over (with exception for the top loop) is an instance of `EagerLoadedList`, not `DataList`.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-framework/issues/11138

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
