### PR TITLE
Loads default TinyMCE config instead of empty one

### DIFF
--- a/src/Forms/HTMLEditor/HTMLEditorField.php
+++ b/src/Forms/HTMLEditor/HTMLEditorField.php
@@ -145,7 +145,7 @@ class HTMLEditorField extends TextareaField
         // Sanitise if requested
         $htmlValue = HTMLValue::create($this->Value());
         if (HTMLEditorField::config()->sanitise_server_side) {
-            $config = $this->getEditorConfig();
+            $config = HTMLEditorConfig::get(HTMLEditorConfig::config()->get('default_config'));
             $santiser = HTMLEditorSanitiser::create($config);
             $santiser->sanitise($htmlValue);
         }


### PR DESCRIPTION
## Description
v4.13.30 introduced a bug where a custom TinyMCE config would start from an empty config rather than the default config. 

## Manual testing steps

Define an extended valid elements value for a custom TinyMCE config in _config.php.

```php
TinyMCEConfig::get('CustomConfi')
    ->setOptions(['extended_valid_elements' => 'small']);
```

Add a custom field using this config in Page.php

```php
        private static $db = [
            'RichTextField' => 'HTMLText'
        ];

        public function getCMSFields()
        {
            $fields = parent::getCMSFields();
            $fields->addFieldToTab('Root.Main', HTMLEditorField::create('RichTextField', 'RichTextField', $this->RichTextField, 'CustomConfig'));
            return $fields;
        }
```

Open a TinyMCE editor in the CMS and enter paragraph breaks, links, h3 tags, and, via the source code option a `<small>` tag.

Prior to this fix all except the small tag will be stripped on save. After this fix, all the markup will save as expected.

## Issues
- #11141

## Pull request checklist
- [X] The target branch is correct
- [X] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
- [X] The commit messages follow our [commit message guidelines]
- [X] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [X] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [X] This change is covered with tests (or tests aren't necessary for this change)
- [X] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green

## Additional Comments

- I do not know the reason for the change in 4.13.30, I suspect it was to prevent loading the "active" config, which presumably may or may not be the default. If loading the default was _not_ the desired outcome, this PR may conflict with the reasoning behind that change. However, for my purposes, 4.13.30 was a breaking change.
- The change in 4.13.30 was also applied in 5.x. It may be necessary to cherry-pick the change there as well, though I have not tested in 5.x.
