### PR TITLE
Allow better subclassing of MoneyField

### DIFF
--- a/src/Forms/MoneyField.php
+++ b/src/Forms/MoneyField.php
@@ -59,11 +59,7 @@ class MoneyField extends FormField
     public function __construct($name, $title = null, $value = "")
     {
         $this->setName($name);
-        $this->fieldAmount = NumericField::create(
-            "{$name}[Amount]",
-            _t('SilverStripe\\Forms\\MoneyField.FIELDLABELAMOUNT', 'Amount')
-        )
-            ->setScale(2);
+        $this->buildAmountField();
         $this->buildCurrencyField();
 
         parent::__construct($name, $title, $value);
@@ -73,6 +69,18 @@ class MoneyField extends FormField
     {
         $this->fieldAmount = clone $this->fieldAmount;
         $this->fieldCurrency = clone $this->fieldCurrency;
+    }
+
+    /**
+     * Builds a field to input the amount of money
+     */
+    protected function buildAmountField(): void
+    {
+        $this->fieldAmount = NumericField::create(
+            $this->name . '[Amount]',
+            _t('SilverStripe\\Forms\\MoneyField.FIELDLABELAMOUNT', 'Amount')
+        )
+            ->setScale(2);
     }
 
     /**

--- a/tests/php/Forms/MoneyFieldTest.php
+++ b/tests/php/Forms/MoneyFieldTest.php
@@ -2,9 +2,13 @@
 
 namespace SilverStripe\Forms\Tests;
 
+use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\HiddenField;
+use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\RequiredFields;
 use SilverStripe\Forms\Tests\MoneyFieldTest\CustomSetter_Object;
 use SilverStripe\Forms\Tests\MoneyFieldTest\TestObject;
+use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\FieldType\DBMoney;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\MoneyField;
@@ -126,5 +130,32 @@ class MoneyFieldTest extends SapphireTest
             'Amount' => 123
         ]);
         $this->assertFalse($field->validate($validator));
+    }
+
+    public function testGetCurrencyField(): void
+    {
+        $field = new MoneyField('Money');
+        $field->setAllowedCurrencies(['NZD', 'USD']);
+
+        $this->assertInstanceOf(DropdownField::class, $field->getCurrencyField());
+        $this->assertEquals('Money[Currency]', $field->getCurrencyField()->getName());
+
+        $field->setAllowedCurrencies(['USD']);
+
+        $this->assertInstanceOf(HiddenField::class, $field->getCurrencyField());
+        $this->assertEquals('Money[Currency]', $field->getCurrencyField()->getName());
+
+        $field->setAllowedCurrencies([]);
+
+        $this->assertInstanceOf(TextField::class, $field->getCurrencyField());
+        $this->assertEquals('Money[Currency]', $field->getCurrencyField()->getName());
+    }
+
+    public function testGetAmountField(): void
+    {
+        $field = new MoneyField('Money');
+        $this->assertInstanceOf(NumericField::class, $field->getAmountField());
+        $this->assertEquals(2, $field->getAmountField()->getScale());
+        $this->assertEquals('Money[Amount]', $field->getAmountField()->getName());
     }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Move generation of NumberField from constructor to method to allow override in subclass.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-framework/issues/11153

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
