### PR TITLE
FIX Generate salt if needed

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -520,18 +520,11 @@ class Member extends DataObject
 
         // If the algorithm or salt is not available, it means we are operating
         // on legacy account with unhashed password. Do not hash the string.
-        if (!$this->PasswordEncryption) {
+        if (!$this->PasswordEncryption || !$this->Salt) {
             return $string;
         }
 
         $e = PasswordEncryptor::create_for_algorithm($this->PasswordEncryption);
-
-        // If we don't have a salt, don't allow invalid calls to encrypt method
-        if (!$this->Salt) {
-            $this->Salt = $e->salt($string, $this);
-            $this->write();
-        }
-
         return $e->encrypt($string, $this->Salt);
     }
 

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -524,8 +524,13 @@ class Member extends DataObject
             return $string;
         }
 
-        // We assume we have PasswordEncryption and Salt available here.
         $e = PasswordEncryptor::create_for_algorithm($this->PasswordEncryption);
+
+        // If we don't have a salt, don't allow invalid calls to encrypt method
+        if (!$this->Salt) {
+            $this->Salt = $e->salt($string, $this);
+            $this->write();
+        }
 
         return $e->encrypt($string, $this->Salt);
     }


### PR DESCRIPTION
## Description

Some Members may not have a Salt defined. Yet, it's possible to call `encryptWithUserSettings` nonetheless and the framework will assume a Salt exist. This is not correct, since it will fail to encrypt things properly.
I don't see any reason to assume anything and not generate a Salt if needed.

Alternative option if we don't want to generate a salt: at least throw a proper exception explaining that you cannot encrypt with an empty salt instead of assuming there is a valid value there.

## Manual testing steps
- On a Member without a password, but with a PasswordEncryption
- Call $member->encryptWithUserSettings('somestring')
- You get a blowfish exception because it could not encrypt with an empty salt

## Issues

https://github.com/silverstripe/silverstripe-framework/issues/11159

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
