### PR TITLE
FIX handle non breakable spaces

### DIFF
--- a/src/Forms/NumericField.php
+++ b/src/Forms/NumericField.php
@@ -101,10 +101,20 @@ class NumericField extends TextField
         return NumberFormatter::TYPE_DOUBLE;
     }
 
+    /**
+     * In some cases and locales, validation expects non-breaking spaces.
+     * This homogenises regular, narrow and thin non-breaking spaces to a regular space character.
+     *
+     */
+    private function clean(?string $value): string
+    {
+        return trim(str_replace(["\u{00A0}", "\u{202F}", "\u{2009}"], ' ', $value ?? ''));
+    }
+
     public function setSubmittedValue($value, $data = null)
     {
         // Save original value in case parse fails
-        $value = trim($value ?? '');
+        $value = $this->clean($value);
         $this->originalValue = $value;
 
         // Empty string is no-number (not 0)

--- a/tests/php/Forms/NumericFieldTest.php
+++ b/tests/php/Forms/NumericFieldTest.php
@@ -12,27 +12,6 @@ class NumericFieldTest extends SapphireTest
     protected $usesDatabase = false;
 
     /**
-     * In some cases and locales, validation expects non-breaking spaces.
-     * This homogenises narrow and regular NBSPs to a regular space character
-     *
-     * Duplicates non-public NumericField::clean method
-     *
-     * @param  string $input
-     * @return string The input value, with all non-breaking spaces replaced with spaces
-     */
-    protected function clean($input)
-    {
-        return str_replace(
-            [
-                html_entity_decode('&nbsp;', 0, 'UTF-8'),
-                html_entity_decode('&#8239;', 0, 'UTF-8'), // narrow non-breaking space
-            ],
-            ' ',
-            trim($input ?? '')
-        );
-    }
-
-    /**
      * Test that data loaded in via Form::loadDataFrom(DataObject) will populate the field correctly,
      * and can format the database value appropriately for the frontend
      *
@@ -64,8 +43,8 @@ class NumericFieldTest extends SapphireTest
 
         // Test expected formatted value
         $this->assertEquals(
-            $this->clean($output),
-            $this->clean($field->Value()),
+            (string) $output,
+            $field->Value(),
             "Expected $input to be formatted as $output in locale $locale"
         );
 
@@ -92,11 +71,11 @@ class NumericFieldTest extends SapphireTest
             ['nl_NL', null, '12.1', '12,1'],
             ['nl_NL', 1, '14000.5', "14.000,5"],
             // fr
-            ['fr_FR', 0, '13000', "13 000"],
+            ['fr_FR', 0, '13000', "13 000"], // With a narrow non breaking space
             ['fr_FR', 0, '15', '15'],
             ['fr_FR', null, '12.0', '12,0'],
             ['fr_FR', null, '12.1', '12,1'],
-            ['fr_FR', 1, '14000.5', "14 000,5"],
+            ['fr_FR', 1, '14000.5', "14 000,5"], // With a narrow non breaking space
             // us
             ['en_US', 0, '13000', "13,000"],
             ['en_US', 0, '15', '15'],
@@ -175,15 +154,15 @@ class NumericFieldTest extends SapphireTest
             ['nl_NL', 1, '15,000.5', false],
 
             // fr
-            ['fr_FR', 0, '13000', 13000, '13 000'],
+            ['fr_FR', 0, '13000', 13000, '13 000'], // With a narrow non breaking space
             ['fr_FR', 2, '12,00', 12.0],
             ['fr_FR', 2, '12.00', false],
-            ['fr_FR', 1, '11 000', 11000, '11 000,0'],
-            ['fr_FR', 0, '11.000', 11000, '11 000'],
+            ['fr_FR', 1, '11 000', 11000, '11 000,0'], // With a narrow non breaking space
+            ['fr_FR', 0, '11.000', 11000, '11 000'], // With a narrow non breaking space
             ['fr_FR', null, '11,000', 11.000, '11,0'],
-            ['fr_FR', 1, '15 000,5', 15000.5],
+            ['fr_FR', 1, '15 000,5', 15000.5, '15 000,5'], // With a narrow non breaking space
             ['fr_FR', 1, '15 000.5', false],
-            ['fr_FR', 1, '15.000,5', 15000.5, '15 000,5'],
+            ['fr_FR', 1, '15.000,5', 15000.5, '15 000,5'], // With a narrow non breaking space
             ['fr_FR', 1, '15,000.5', false],
             // us
             ['en_US', 0, '13000', 13000, '13,000'],
@@ -260,8 +239,8 @@ class NumericFieldTest extends SapphireTest
             $cleanedInput = $submittedValue;
         }
         $this->assertEquals(
-            $this->clean($cleanedInput),
-            $this->clean($field->Value()),
+            $cleanedInput,
+            $field->Value(),
             "Expected input $submittedValue to be cleaned up as $cleanedInput in locale $locale"
         );
     }


### PR DESCRIPTION
Fixes issue https://github.com/silverstripe/silverstripe-framework/issues/11162
and very likely will also deal with https://github.com/silverstripe/silverstripe-framework/issues/10626

I've targeted this to 5.1 but it probably also apply to 4.x but i don't know if it's worth it to apply the patch there as well

## Description

See relevant issue

## Manual testing steps

See relevant issue

## Issues

- https://github.com/silverstripe/silverstripe-framework/issues/11162
- https://github.com/silverstripe/silverstripe-framework/issues/10626

## Related

also see https://www.php.net/manual/en/class.numberformatter.php#129192

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
