### PR TITLE
MNT Ensure composer/semver installed or skip test

### DIFF
--- a/tests/php/Core/Manifest/VersionProviderTest.php
+++ b/tests/php/Core/Manifest/VersionProviderTest.php
@@ -65,7 +65,7 @@ class VersionProviderTest extends SapphireTest
     public function testGetModuleVersionFromComposer()
     {
         Config::modify()->set(VersionProvider::class, 'modules', [
-            'silverstripe/siteconfig' => 'SiteConfig',
+            'silverstripe/config' => 'Config',
             'silverstripe/framework' => 'Framework',
         ]);
 
@@ -77,17 +77,20 @@ class VersionProviderTest extends SapphireTest
     public function testGetVersion()
     {
         Config::modify()->set(VersionProvider::class, 'modules', [
-            'silverstripe/siteconfig' => 'SiteConfig',
+            'silverstripe/config' => 'Config',
             'silverstripe/framework' => 'Framework'
         ]);
         $result = $this->getProvider()->getVersion();
-        $this->assertStringNotContainsString('SiteConfig: ', $result);
+        $this->assertStringNotContainsString('Config: ', $result);
         $this->assertStringContainsString('Framework: ', $result);
         $this->assertStringNotContainsString(', ', $result);
     }
 
     public function testGetModuleVersion()
     {
+        if (!class_exists(VersionParser::class)) {
+            $this->markTestSkipped('This test requires composer/semver to be installed');
+        }
         $provider = $this->getProvider();
         Config::modify()->set(VersionProvider::class, 'modules', [
             'silverstripe/framework' => 'Framework',


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/207

Fixes https://github.com/silverstripe/silverstripe-installer/actions/runs/8131709640/job/22225347023

`1) SilverStripe\Core\Tests\Manifest\VersionProviderTest::testGetModuleVersion
Error: Class "Composer\Semver\VersionParser" not found`

`composer/semver` was originally added as `require-dev` in https://github.com/silverstripe/silverstripe-framework/pull/11157

Also fixes https://github.com/silverstripe/recipe-core/actions/runs/8110522366/job/22167949864#step:12:162

`1) SilverStripe\Core\Tests\Manifest\VersionProviderTest::testGetVersion
OutOfBoundsException: Package "silverstripe/siteconfig" is not installed`

Which breaks in silverstripe/recipe-core because silverstripe/siteconfig isn't installed - presumably it was erroneously passing before
