### PR TITLE
Enhancements required for linkfield migration

### DIFF
--- a/src/Core/Environment.php
+++ b/src/Core/Environment.php
@@ -36,6 +36,13 @@ class Environment
     protected static $env = [];
 
     /**
+     * Used by unit tests to override `isCli()`
+     * This is not config. Use reflection to change the value
+     * @internal
+     */
+    private static ?bool $isCliOverride = null;
+
+    /**
      * Extract env vars prior to modification
      *
      * @return array List of all super globals
@@ -251,6 +258,9 @@ class Environment
      */
     public static function isCli()
     {
+        if (self::$isCliOverride !== null) {
+            return self::$isCliOverride;
+        }
         return in_array(strtolower(php_sapi_name() ?? ''), ['cli', 'phpdbg']);
     }
 }

--- a/tests/php/ORM/SQLUpdateTest.yml
+++ b/tests/php/ORM/SQLUpdateTest.yml
@@ -10,3 +10,7 @@ SilverStripe\ORM\Tests\SQLUpdateTest\TestChild:
     Title: 'Object 3'
     Description: 'Description 3'
     Details: 'Details 3'
+SilverStripe\ORM\Tests\SQLUpdateTest\TestOther:
+  test3:
+    Title: 'Object 2 mirror'
+    Description: 'Description 2'

--- a/tests/php/ORM/SQLUpdateTest/TestOther.php
+++ b/tests/php/ORM/SQLUpdateTest/TestOther.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\SQLUpdateTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class TestOther extends DataObject implements TestOnly
+{
+    private static $table_name = 'SQLUpdateTestOther';
+
+    private static $db = [
+        'Title' => 'Varchar(255)',
+        'Description' => 'Text'
+    ];
+}


### PR DESCRIPTION
Commit 1: Adds a test utility. Required for a test in https://github.com/silverstripe/silverstripe-linkfield/pull/244
Commit 2: Adds JOIN support for `SQLUpdate`. Required for migrating owners in https://github.com/silverstripe/silverstripe-linkfield/pull/244

## Issue
- https://github.com/silverstripe/silverstripe-linkfield/issues/228