### PR TITLE
Revert "Use field editorconfig when sanitising content"

### DIFF
--- a/src/Forms/HTMLEditor/HTMLEditorField.php
+++ b/src/Forms/HTMLEditor/HTMLEditorField.php
@@ -145,8 +145,7 @@ class HTMLEditorField extends TextareaField
         // Sanitise if requested
         $htmlValue = HTMLValue::create($this->Value());
         if (HTMLEditorField::config()->sanitise_server_side) {
-            $config = $this->getEditorConfig();
-            $santiser = HTMLEditorSanitiser::create($config);
+            $santiser = HTMLEditorSanitiser::create(HTMLEditorConfig::get_active());
             $santiser->sanitise($htmlValue);
         }
 

--- a/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
@@ -11,7 +11,6 @@ use SilverStripe\Assets\Image;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\CSSContentParser;
 use SilverStripe\Dev\FunctionalTest;
-use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
 use SilverStripe\Forms\HTMLReadonlyField;
@@ -229,42 +228,5 @@ EOS
             "The company &amp;&amp; partners",
             $field->obj('ValueEntities')->forTemplate()
         );
-    }
-
-    public function testFieldConfigSanitization()
-    {
-        $obj = TestObject::create();
-        $editor = HTMLEditorField::create('Content');
-        $defaultValidElements = [
-            '@[id|class|style|title|data*]',
-            'a[id|rel|dir|tabindex|accesskey|type|name|href|target|title|class]',
-            '-strong/-b[class]',
-            '-em/-i[class]',
-            '-ol[class]',
-            '#p[id|dir|class|align|style]',
-            '-li[class]',
-            'br',
-            '-span[class|align|style]',
-            '-ul[class]',
-            '-h3[id|dir|class|align|style]',
-            '-h2[id|dir|class|align|style]',
-            'hr[class]',
-        ];
-        $restrictedConfig = HTMLEditorConfig::get('restricted');
-        $restrictedConfig->setOption('valid_elements', implode(',', $defaultValidElements));
-        $editor->setEditorConfig($restrictedConfig);
-
-        $expectedHtmlString = '<p>standard text</p>Header';
-        $htmlValue = '<p>standard text</p><table><tbody><tr><th></th></tr><tr><td>Header</td></tr></tbody><tbody></tbody></table>';
-        $editor->setValue($htmlValue);
-        $editor->saveInto($obj);
-        $this->assertEquals($expectedHtmlString, $obj->Content, 'Table is not removed');
-
-        $defaultConfig = HTMLEditorConfig::get('default');
-        $editor->setEditorConfig($defaultConfig);
-
-        $editor->setValue($htmlValue);
-        $editor->saveInto($obj);
-        $this->assertEquals($htmlValue, $obj->Content, 'Table is removed');
     }
 }


### PR DESCRIPTION
This reverts https://github.com/silverstripe/silverstripe-framework/pull/10977

<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Reverts a bugfix which caused unexpected flow-on effects.
It will be reinstated with flow-on effects managed appropriately in https://github.com/silverstripe/silverstripe-framework/issues/11141

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-framework/issues/11179

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release (not needed)
- [x] CI is green
