### PR TITLE
ENH Let unit tests manipulate the DB before loading fixtures

### DIFF
--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -252,6 +252,14 @@ abstract class SapphireTest extends TestCase implements TestOnly
     }
 
     /**
+     * Called after the database is created, but before fixtures are loaded.
+     */
+    public function onBeforeLoadFixtures(): void
+    {
+        // no-op - this method is intended to be overridden by subclasses.
+    }
+
+    /**
      * Setup  the test.
      * Always sets up in order:
      *  - Reset php state

--- a/src/Dev/State/FixtureTestState.php
+++ b/src/Dev/State/FixtureTestState.php
@@ -63,6 +63,7 @@ class FixtureTestState implements TestState
                     $instance->augmentDefaultRecords();
                 }
             }
+            $test->onBeforeLoadFixtures();
             $this->loadFixtures($test);
         }
 


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Fixtures in unit tests can be set up using an explicit table name - but there's no way (that I can see) to actually create the table in the time between the test DB being created and fixtures being loaded.

This PR adds a way for tests to do that.

See https://github.com/silverstripe/silverstripe-linkfield/pull/253 for an example of how this works.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-linkfield/issues/229

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
