### PR TITLE
ENH store tableList in cache

### DIFF
--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -46,3 +46,8 @@ SilverStripe\Core\Injector\Injector:
     factory: SilverStripe\Core\Cache\CacheFactory
     constructor:
       namespace: 'VersionProvider'
+  Psr\SimpleCache\CacheInterface.ClassInfo:
+    factory: SilverStripe\Core\Cache\CacheFactory
+    constructor:
+      namespace: "ClassInfo"
+      disable-container: true

--- a/src/Core/ClassInfo.php
+++ b/src/Core/ClassInfo.php
@@ -82,7 +82,8 @@ class ClassInfo
     public static function hasTable($tableName)
     {
         $cache = self::getCache();
-        $cacheKey = 'tableList';
+        $configData = serialize(DB::getConfig());
+        $cacheKey = 'tableList_' . md5($configData);
         $tableList = $cache->get($cacheKey) ?? [];
         if (empty($tableList) && DB::is_active()) {
             $tableList = DB::get_schema()->tableList();

--- a/src/Core/ClassInfo.php
+++ b/src/Core/ClassInfo.php
@@ -418,8 +418,7 @@ class ClassInfo
             $tokenName = is_array($token) ? $token[0] : $token;
 
             // Get the class name
-            if (
-                \defined('T_NAME_QUALIFIED') && is_array($token) &&
+            if (\defined('T_NAME_QUALIFIED') && is_array($token) &&
                 ($token[0] === T_NAME_QUALIFIED || $token[0] === T_NAME_FULLY_QUALIFIED)
             ) {
                 // PHP 8 exposes the FQCN as a single T_NAME_QUALIFIED or T_NAME_FULLY_QUALIFIED token
@@ -437,7 +436,7 @@ class ClassInfo
                 // Found another section of a namespaced class
                 $class .= $token[1];
                 $lastTokenWasNSSeparator = false;
-                // Get arguments
+            // Get arguments
             } elseif (is_array($token)) {
                 switch ($token[0]) {
                     case T_CONSTANT_ENCAPSED_STRING:
@@ -460,7 +459,7 @@ class ClassInfo
                         break;
 
                     case T_DNUMBER:
-                        $result = (float)$token[1];
+                        $result = (double)$token[1];
                         break;
 
                     case T_LNUMBER:

--- a/src/Core/ClassInfo.php
+++ b/src/Core/ClassInfo.php
@@ -4,14 +4,15 @@ namespace SilverStripe\Core;
 
 use Exception;
 use ReflectionClass;
-use SilverStripe\ORM\DB;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\Control\Director;
-use Psr\SimpleCache\CacheInterface;
-use SilverStripe\View\ViewableData;
 use SilverStripe\CMS\Model\SiteTree;
-use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Control\Director;
 use SilverStripe\Core\Manifest\ClassLoader;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\View\ViewableData;
+use Psr\SimpleCache\CacheInterface;
+use SilverStripe\Core\Flushable;
+use SilverStripe\Core\Injector\Injector;
 
 /**
  * Provides introspection information about the class tree.
@@ -20,7 +21,7 @@ use SilverStripe\Core\Manifest\ClassLoader;
  * class introspection heavily and without the caching it creates an unfortunate
  * performance hit.
  */
-class ClassInfo
+class ClassInfo implements Flushable
 {
     /**
      * @internal
@@ -76,6 +77,8 @@ class ClassInfo
     }
 
     /**
+     * Cached call to see if the table exists in the DB.
+     * For live queries, use DBSchemaManager::hasTable.
      * @param string $tableName
      * @return bool
      */
@@ -102,6 +105,11 @@ class ClassInfo
     {
         self::getCache()->clear();
         self::$_cache_ancestry = [];
+    }
+
+    public static function flush()
+    {
+        self::reset_db_cache();
     }
 
     /**


### PR DESCRIPTION
## Description
See issue for context

## Manual testing steps
With this new cache, no SHOW FULL TABLES WHERE Table_Type != 'VIEW' should appear in each request

## Issues
- https://github.com/silverstripe/silverstripe-framework/issues/11181

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
