### PR TITLE
ENH add support for expanded values on Time/DateField

### DIFF
--- a/src/Forms/DateField.php
+++ b/src/Forms/DateField.php
@@ -513,8 +513,8 @@ class DateField extends TextField
      * Convert frontend date to the internal representation (ISO 8601).
      * The frontend date is also in ISO 8601 when $html5=true.
      *
-     * @param string $date
-     * @return string The formatted date, or null if not a valid date
+     * @param ?string $date
+     * @return ?string The formatted date, or null if not a valid date
      */
     protected function frontendToInternal($date)
     {
@@ -524,6 +524,17 @@ class DateField extends TextField
         $fromFormatter = $this->getFrontendFormatter();
         $toFormatter = $this->getInternalFormatter();
         $timestamp = $fromFormatter->parse($date);
+
+        // Retry with expanded value
+        if ($timestamp === false) {
+            $zeroFormat = $fromFormatter->format(strtotime(date('Y-01-01 00:00:00')));
+            $expectedLength = strlen($zeroFormat);
+            if (strlen($date) < $expectedLength) {
+                $expandedValue = $date . substr($zeroFormat, strlen($date));
+                $timestamp = $fromFormatter->parse($expandedValue);
+            }
+        }
+        
         if ($timestamp === false) {
             return null;
         }

--- a/src/Forms/DatetimeField.php
+++ b/src/Forms/DatetimeField.php
@@ -179,8 +179,8 @@ class DatetimeField extends TextField
      * Assumes the value is in the defined {@link $timezone} (if one is set),
      * and adjusts for server timezone.
      *
-     * @param string $datetime
-     * @return string The formatted date, or null if not a valid date
+     * @param ?string $datetime
+     * @return ?string The formatted date, or null if not a valid date
      */
     public function frontendToInternal($datetime)
     {
@@ -192,6 +192,16 @@ class DatetimeField extends TextField
 
         // Try to parse time with seconds
         $timestamp = $fromFormatter->parse($datetime);
+
+        // Retry with expanded value
+        if ($timestamp === false) {
+            $zeroFormat = $fromFormatter->format(strtotime(date('Y-01-01 00:00:00')));
+            $expectedLength = strlen($zeroFormat);
+            if (strlen($datetime) < $expectedLength) {
+                $expandedValue = $datetime . substr($zeroFormat, strlen($datetime));
+                $timestamp = $fromFormatter->parse($expandedValue);
+            }
+        }
 
         // Try to parse time without seconds, since that's a valid HTML5 submission format
         // See https://html.spec.whatwg.org/multipage/infrastructure.html#times

--- a/src/Forms/TimeField.php
+++ b/src/Forms/TimeField.php
@@ -388,8 +388,8 @@ class TimeField extends TextField
      * Convert frontend time to the internal representation (ISO 8601).
      * The frontend time is also in ISO 8601 when $html5=true.
      *
-     * @param string $time
-     * @return string The formatted time, or null if not a valid time
+     * @param ?string $time
+     * @return ?string The formatted time, or null if not a valid time
      */
     protected function frontendToInternal($time)
     {
@@ -400,6 +400,16 @@ class TimeField extends TextField
         $toFormatter = $this->getInternalFormatter();
         $timestamp = $fromFormatter->parse($time);
 
+        // Retry with expanded value
+        if ($timestamp === false) {
+            $zeroFormat = $fromFormatter->format(strtotime(date('Y-01-01 00:00:00')));
+            $expectedLength = strlen($zeroFormat);
+            if (strlen($time) < $expectedLength) {
+                $expandedValue = $time . substr($zeroFormat, strlen($time));
+                $timestamp = $fromFormatter->parse($expandedValue);
+            }
+        }
+        
         // Try to parse time without seconds, since that's a valid HTML5 submission format
         // See https://html.spec.whatwg.org/multipage/infrastructure.html#times
         if ($timestamp === false && $this->getHTML5()) {


### PR DESCRIPTION
## Description

Currently, partial values in date/time field will results in null values. This is a bit annoying for time value (input 18:--:-- will be null) but is even more obvious on datetime field (inputing the date without the time results in null)

## Manual testing steps

Only input partial values, it still submit properly

## Issues

- https://github.com/silverstripe/silverstripe-framework/issues/11172

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
