### PR TITLE
FIX: OutOfBoundsException when recipe-core isn't installed (fixes #11197)

### DIFF
--- a/src/Core/Manifest/VersionProvider.php
+++ b/src/Core/Manifest/VersionProvider.php
@@ -189,6 +189,9 @@ class VersionProvider
     {
         $versions = [];
         foreach ($modules as $module) {
+            if (!InstalledVersions::isInstalled($module)) {
+                continue;
+            }
             $versions[$module] = InstalledVersions::getPrettyVersion($module);
         }
         return $versions;


### PR DESCRIPTION
## Issues
- #11197

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
