### PR TITLE
ENH Return PJAX responses from gridfield edit forms

### DIFF
--- a/src/Control/RequestHandler.php
+++ b/src/Control/RequestHandler.php
@@ -678,4 +678,15 @@ class RequestHandler extends ViewableData
         $url = Director::absoluteURL((string) $url);
         return $this->redirect($url);
     }
+
+    /**
+     * Convert an array of data to JSON and wrap it in an HTML tag as pjax is used and jQuery will parse this
+     * as an element on the client side in LeftAndMain.js handleAjaxResponse()
+     * The attribute type="application/json" denotes this is a data block and won't be processed by a browser
+     * https://html.spec.whatwg.org/#the-script-element
+     */
+    protected function prepareDataForPjax(array $data): string
+    {
+        return '<script type="application/json">' . json_encode($data) . '</script>';
+    }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Adds a PJAX response negotiator to `GridFieldDetailForm_ItemRequest` so that javascript which is expecting PJAX responses will get what it's expecting.

Note there's a kitchen sink CI run linked in the main issue

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
1. Add [`silverstripe/frameworktest`](https://github.com/silverstripe/silverstripe-frameworktest) to a project and make sure all of the operations work as expected for companies (which are versioned) and employees (which are not versioned) in "Test ModelAdmin"
2. Add an elemental area to the `Company` class (yml config snippet below), add a block with an upload field (e.g [`silverstripe/elemental-fileblock`](https://github.com/silverstripe/silverstripe-elemental-fileblock/)) and make sure you can upload a file to the block and save with the page save button.

```yml
SilverStripe\FrameworkTest\Model\Company:
  extensions:
    - DNADesign\Elemental\Extensions\ElementalAreasExtension
  has_one:
    ElementalArea: 'DNADesign\Elemental\Models\ElementalArea'
  owns:
    - 'ElementalArea'
  cascade_duplicates:
    - 'ElementalArea'
```

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-elemental/issues/1156

