### PR TITLE
FIX Handle getting HasOneRelationFieldInterface passed as an array

### DIFF
--- a/src/Forms/RequiredFields.php
+++ b/src/Forms/RequiredFields.php
@@ -113,7 +113,12 @@ class RequiredFields extends Validator
                 if ($formField instanceof FileField && isset($value['error']) && $value['error']) {
                     $error = true;
                 } else {
-                    $error = (count($value ?? [])) ? false : true;
+                    if (is_a($formField, HasOneRelationFieldInterface::class) && isset($value['value'])) {
+                        $stringValue = (string) $value['value'];
+                        $error = in_array($stringValue, ['0', '']);
+                    } else {
+                        $error = (count($value ?? [])) ? false : true;
+                    }
                 }
             } else {
                 $stringValue = (string) $value;

--- a/src/Forms/SearchableDropdownField.php
+++ b/src/Forms/SearchableDropdownField.php
@@ -5,8 +5,9 @@ namespace SilverStripe\Forms;
 use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\ORM\DataList;
+use SilverStripe\Forms\HasOneRelationFieldInterface;
 
-class SearchableDropdownField extends DropdownField
+class SearchableDropdownField extends DropdownField implements HasOneRelationFieldInterface
 {
     use SearchableDropdownTrait;
     

--- a/tests/php/Forms/RequiredFieldsTest.php
+++ b/tests/php/Forms/RequiredFieldsTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Forms\Tests;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\RequiredFields;
 use SilverStripe\Forms\Form;
+use SilverStripe\Forms\SearchableDropdownField;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\Security\Group;
 
@@ -289,16 +290,35 @@ class RequiredFieldsTest extends SapphireTest
         );
     }
 
-    public function testTreedropFieldValidation()
+    public function provideHasOneRelationFieldInterfaceValidation(): array
+    {
+        return [
+            [
+                'className' => TreeDropdownField::class,
+            ],
+            [
+                'className' => SearchableDropdownField::class,
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider provideHasOneRelationFieldInterfaceValidation
+     */
+    public function testHasOneRelationFieldInterfaceValidation(string $className)
     {
         $form = new Form();
-        $field = new TreeDropdownField('TestField', 'TestField', Group::class);
+        $param = $className === TreeDropdownField::class ? Group::class : Group::get();
+        $field = new $className('TestField', 'TestField', $param);
         $form->Fields()->push($field);
         $validator = new RequiredFields('TestField');
         $validator->setForm($form);
-        // blank string and '0' are fail required field validation
+        // blank string and 0 and '0' and array with value of 0 fail required field validation
         $this->assertFalse($validator->php(['TestField' => '']));
+        $this->assertFalse($validator->php(['TestField' => 0]));
         $this->assertFalse($validator->php(['TestField' => '0']));
+        $this->assertFalse($validator->php(['TestField' => ['value' => 0]]));
+        $this->assertFalse($validator->php(['TestField' => ['value' => '0']]));
         // '1' passes required field validation
         $this->assertTrue($validator->php(['TestField' => '1']));
     }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-elemental/issues/1155

This fixes bugs with autoscaffolded SearchableDropdownField for has_one SiteTree relations

Replication steps

- Create a non-inline editable elemental content block
- Add a has_one relation to a 'MySiteTree' => SiteTree::class
- Add include the validation php block below

```php
    public function getCMSCompositeValidator(): CompositeValidator
    {
        return CompositeValidator::create([RequiredFields::create(['MySiteTreeID'])]);
    }
```

You can leave the field blank and submit and the required fields validation won't trigger
