### PR TITLE
FIX Ensure 'which' command detection across Linux distributions

### DIFF
--- a/sake
+++ b/sake
@@ -9,7 +9,7 @@ Executes a SilverStripe command"
 	exit 1
 fi
 
-if ! [ -x "$(command -v which)" ]; then
+if ! [ -x "$(type -P which)" ]; then
   echo "Error: sake requires the 'which' command to operate." >&2
   exit 1
 fi


### PR DESCRIPTION
## Description
This pull request addresses an issue with the `which` command detection in the `sake` script, which failed to accurately detect the presence of the `which` command across different operating systems. The previous implementation using `command -v which` functioned properly on Ubuntu-like distributions but not on others like Rocky Linux/RHEL or Fedora, where it sometimes returned only a command name or a function instead of the full path to the executable.

To ensure broader compatibility, especially with non-Debian-based Linux distributions, this fix modifies the command detection logic to use `type -P which`.

## Manual testing steps
On Linux inside Silverstripe project, run `vendor/bin/sake dev/build` and verify that it executes without the "which command" error.

## Issues
- #10682

## Pull request checklist
- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
