### PR TITLE
FIX Allow double dots in path when not attempting directory traversal

### DIFF
--- a/src/Core/Path.php
+++ b/src/Core/Path.php
@@ -34,7 +34,7 @@ class Path
         $fullPath = static::normalise(implode(DIRECTORY_SEPARATOR, $parts));
 
         // Protect against directory traversal vulnerability (OTG-AUTHZ-001)
-        if (strpos($fullPath ?? '', '..') !== false) {
+        if ($fullPath === '..' || str_ends_with($fullPath, '/..') || str_contains($fullPath, '../')) {
             throw new InvalidArgumentException('Can not collapse relative folders');
         }
 

--- a/tests/php/Core/PathTest.php
+++ b/tests/php/Core/PathTest.php
@@ -48,6 +48,8 @@ class PathTest extends SapphireTest
             [['\\', '', '/root', '/', ' ', '/', '\\'], '/root'],
             // join blocks of paths
             [['/root/dir', 'another/path\\to/join'], '/root/dir/another/path/to/join'],
+            // Double dot is fine if it's not attempting directory traversal
+            [['/root/my..name/', 'another/path\\to/join'], '/root/my..name/another/path/to/join'],
         ];
 
         // Rewrite tests for other filesystems (output arg only)
@@ -79,6 +81,8 @@ class PathTest extends SapphireTest
             [['/base', '../passwd'], 'Can not collapse relative folders'],
             [['/base/../', 'passwd/path'], 'Can not collapse relative folders'],
             [['../', 'passwd/path'], 'Can not collapse relative folders'],
+            [['..', 'passwd/path'], 'Can not collapse relative folders'],
+            [['base/..', 'passwd/path'], 'Can not collapse relative folders'],
         ];
     }
 


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Doesn't throw an exception for `..` in a filename in scenarios that can't trigger directory traversal.

This allows, for example, images with `..` in the filename to be uploaded.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-framework/issues/11216