### PR TITLE
ENH Use allowed view button for readonly GridField

### DIFF
--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -276,9 +276,18 @@ class GridField extends FormField
             }
         }
 
-        // If the edit button has been removed, replace it with a view button
+        // If the edit button has been removed, replace it with a view button if one is allowed
         if ($hadEditButton && !$copyConfig->getComponentByType(GridFieldViewButton::class)) {
-            $copyConfig->addComponent(GridFieldViewButton::create());
+            $viewButtonClass = null;
+            foreach ($allowedComponents as $componentClass) {
+                if (is_a($componentClass, GridFieldViewButton::class, true)) {
+                    $viewButtonClass = $componentClass;
+                    break;
+                }
+            }
+            if ($viewButtonClass) {
+                $copyConfig->addComponent($viewButtonClass::create());
+            }
         }
 
         $copy->extend('afterPerformReadonlyTransformation', $this);

--- a/tests/php/Forms/GridField/GridFieldReadonlyTest/GridFieldViewButtonReplacement.php
+++ b/tests/php/Forms/GridField/GridFieldReadonlyTest/GridFieldViewButtonReplacement.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\GridField\GridFieldReadonlyTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\GridField\GridFieldViewButton;
+
+class GridFieldViewButtonReplacement extends GridFieldViewButton implements TestOnly
+{
+
+}


### PR DESCRIPTION
The list of allowed readonly components is configurable. Developers might replace the `GridFieldViewButton` with their own implementation for a specific instance of a `GridField`. In that case, we want to make sure the correct component is used instead of the base `GridFieldViewButton` class.

## Issue
- https://github.com/silverstripe/silverstripe-lumberjack/issues/89