### PR TITLE
FIX 'which' check in 'sake' now works for aliases

### DIFF
--- a/sake
+++ b/sake
@@ -9,10 +9,7 @@ Executes a SilverStripe command"
 	exit 1
 fi
 
-if ! [ -x "$(command -v which)" ]; then
-  echo "Error: sake requires the 'which' command to operate." >&2
-  exit 1
-fi
+command -v which >/dev/null 2>&1 || { echo >&2 "Error: sake requires the 'which' command to operate."; exit 1; }
 
 # find the silverstripe installation, looking first at sake
 # bin location, but falling back to current directory

--- a/sake
+++ b/sake
@@ -9,7 +9,10 @@ Executes a SilverStripe command"
 	exit 1
 fi
 
-command -v which >/dev/null 2>&1 || { echo >&2 "Error: sake requires the 'which' command to operate."; exit 1; }
+if ! command -v which >/dev/null 2>&1; then
+  echo "Error: sake requires the 'which' command to operate." >&2
+  exit 1
+fi
 
 # find the silverstripe installation, looking first at sake
 # bin location, but falling back to current directory

--- a/sake
+++ b/sake
@@ -9,7 +9,8 @@ Executes a SilverStripe command"
 	exit 1
 fi
 
-if ! command -v which >/dev/null 2>&1; then
+command -v which >/dev/null 2>&1
+if [ $? -ne 0 ]; then
   echo "Error: sake requires the 'which' command to operate." >&2
   exit 1
 fi


### PR DESCRIPTION
## Description

`sake` may wrongly exit early on its `which` check, since the current implementation does the following:

1. Retrieves via `command -v` information about the `which` executable
2. Tries to check the returned information string, if it is executable.

This solution is problematic since the returned information string may include alias information (and more),
which `test -x` can not interpret.

Additionally is the `test -x` check unnecessary  since `command -v` already only returns executable command or fails if the command can not be found.

Therefore, I changed the source to just check for the exit status of `command -v`.

## Manual testing steps

Run `vendor/bin/sake dev/build` on a POSIX compliant system, where `which` itself has been aliased.

## Issues

- https://github.com/silverstripe/silverstripe-framework/issues/10682


## Pull request checklist

- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
