### PR TITLE
FIX: GRIDFIELD - fixing error interaction between limit and itemsPerPage

### DIFF
--- a/src/Forms/GridField/GridFieldPaginator.php
+++ b/src/Forms/GridField/GridFieldPaginator.php
@@ -177,6 +177,13 @@ class GridFieldPaginator extends AbstractGridFieldComponent implements GridField
 
         $startRow = $this->itemsPerPage * ($state->currentPage - 1);
 
+        // if the total list has less than the items per page you need to make sure that you set the items per page to be 
+        // the total number of items otherwise, you still get for example 20 items, in the gridfield, but the paginator info
+        // will say 1 of 1. Basically, the paginator override the limit, but should not do so if the limit is less than the items per page. 
+        if($this->totalItems < $this->itemsPerPage) {
+            $state->currentPage = 1;
+            $this->itemsPerPage = $this->totalItems;
+        }
         // Prevent visiting a page with an offset higher than the total number of items
         if ($startRow >= $this->totalItems) {
             $state->currentPage = 1;


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

If the total list has less than the items per page you need to make sure that you set the items per page to be the total number of items otherwise, you still get for example 20 items in the gridfield, but the paginator info will say 1 of 1. Basically, the paginator overrides the limit / total amount of items, but instead the paginator limit should be equal to the total number available in the full list (in this case). 

This is all the work I can do on this ticket. Please use the code if you like or, if not, someone else can pick up the ticket from here and make it their commit. 

![image](https://github.com/silverstripe/silverstripe-framework/assets/167154/d457b1db-6333-4774-80d1-3eb33e32f3e8)

![image](https://github.com/silverstripe/silverstripe-framework/assets/167154/3030cdd1-c43e-47f3-9677-bfb71e3e4226)


I understand that perhaps you should not be allowed to limit a list for ModelAdmin, but I feel there is value in doing so. I could be wrong. Maybe we could start with some feedback on this first. 

## Manual testing steps

 - Set up ModelAdmin with DataList
 - Limit the Datalist to 3 Items (using getList for example)
 - Review outcome in ModelAdmin

## Issues

See above


## Pull request checklist

I don't have time to double-check this.  This is a best effort approach.  Lets first consider if this is worthwhile at all. 

Also, as I have said before, if you find that I create more noise than help then just auto-delete any issues / commits I post.  I am very happy for you to do so as it would save me the effort of posting it at all. However, I do not have enough time to follow through on all of this (as no one pays me for this time and I still have to provide for my family) so it has to be a halfway house. 


- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
