### PR TITLE
FIX Return null error solved for DBQueryBuilder::shouldBuildTraceComment

### DIFF
--- a/src/ORM/Connect/DBQueryBuilder.php
+++ b/src/ORM/Connect/DBQueryBuilder.php
@@ -86,7 +86,7 @@ class DBQueryBuilder
         if (Environment::hasEnv('SS_TRACE_DB_QUERY_ORIGIN')) {
             return (bool) Environment::getEnv('SS_TRACE_DB_QUERY_ORIGIN');
         }
-        return static::config()->get('trace_query_origin');
+        return static::config()->get('trace_query_origin') ?? false;
     }
 
     /**


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
Solves scenario where DBQueryBuilder::shouldBuildTraceComment returns null, causing a `TypeError`

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
- #11240 (Partial Solution)

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
