### PR TITLE
FIX HTMLEditorField is not able to show html or xml code examples

### DIFF
--- a/src/Forms/HTMLEditor/HTMLEditorField.php
+++ b/src/Forms/HTMLEditor/HTMLEditorField.php
@@ -191,7 +191,19 @@ class HTMLEditorField extends TextareaField
      */
     public function ValueEntities()
     {
-        return htmlentities($this->Value() ?? '', ENT_COMPAT, 'UTF-8', false);
+        $entities = get_html_translation_table(HTML_ENTITIES);
+
+        foreach ($entities as $key => $value) {
+            $entities[$key] = "/" . $value . "/";
+        }
+
+        $value = preg_replace_callback($entities, function ($matches) {
+            // Don't apply double encoding to ampersand
+            $doubleEncoding = $matches[0] != '&amp;';
+            return htmlentities($matches[0], ENT_COMPAT, 'UTF-8', $doubleEncoding);
+        }, $this->Value() ?? '');
+
+        return $value;
     }
 
     /**

--- a/src/View/Shortcodes/EmbedShortcodeProvider.php
+++ b/src/View/Shortcodes/EmbedShortcodeProvider.php
@@ -171,6 +171,10 @@ class EmbedShortcodeProvider implements ShortcodeHandler
             $arguments['style'] = 'width: ' . intval($arguments['width']) . 'px;';
         }
 
+        if (!empty($arguments['caption'])) {
+            $arguments['caption'] = htmlentities($arguments['caption'], ENT_QUOTES, 'UTF-8', false);
+        }
+
         // override iframe dimension attributes provided by webservice with ones specified in shortcode arguments
         foreach (['width', 'height'] as $attr) {
             if (!($value = $arguments[$attr] ?? false)) {

--- a/templates/SilverStripe/View/Shortcodes/EmbedShortcodeProvider_video.ss
+++ b/templates/SilverStripe/View/Shortcodes/EmbedShortcodeProvider_video.ss
@@ -3,6 +3,6 @@
 >
     {$Content}
     <% if $Arguments.caption %>
-        <p class="caption">{$Arguments.caption}</p>
+        <p class="caption">{$Arguments.caption.RAW}</p>
     <% end_if %>
 </div>

--- a/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
@@ -74,7 +74,7 @@ class HTMLEditorFieldTest extends FunctionalTest
         $inputText = "These are some unicodes: ä, ö, & ü";
         $field = new HTMLEditorField("Test", "Test");
         $field->setValue($inputText);
-        $this->assertStringContainsString('These are some unicodes: &auml;, &ouml;, &amp; &uuml;', $field->Field());
+        $this->assertStringContainsString('These are some unicodes: ä, ö, & ü', $field->Field());
         // Test shortcodes
         $inputText = "Shortcode: [file_link id=4]";
         $field = new HTMLEditorField("Test", "Test");
@@ -210,23 +210,34 @@ EOS
         );
     }
 
-    public function testValueEntities()
+    public function provideTestValueEntities()
     {
-        $inputText = "The company &amp; partners";
+        return [
+            "ampersand" => [
+                "The company &amp; partners",
+                "The company &amp; partners"
+            ],
+            "double ampersand" => [
+                "The company &amp;amp; partners",
+                "The company &amp;amp; partners"
+            ],
+            "left arrow and right arrow" => [
+                "<p>&lt;strong&gt;The company &amp;amp; partners&lt;/strong&gt;</p>",
+                "<p>&amp;lt;strong&amp;gt;The company &amp;amp; partners&amp;lt;/strong&amp;gt;</p>"
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestValueEntities
+     */
+    public function testValueEntities(string $input, string $result)
+    {
         $field = new HTMLEditorField("Content");
-        $field->setValue($inputText);
+        $field->setValue($input);
 
         $this->assertEquals(
-            "The company &amp; partners",
-            $field->obj('ValueEntities')->forTemplate()
-        );
-
-        $inputText = "The company &amp;&amp; partners";
-        $field = new HTMLEditorField("Content");
-        $field->setValue($inputText);
-
-        $this->assertEquals(
-            "The company &amp;&amp; partners",
+            $result,
             $field->obj('ValueEntities')->forTemplate()
         );
     }


### PR DESCRIPTION
## Description
Additional condition to avoid double ampersand encoding. 

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/11207
