### PR TITLE
ENH Looping through arrays in templates

### DIFF
--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -127,7 +127,7 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
     public function getIterator(): Traversable
     {
         foreach ($this->items as $i => $item) {
-            if (is_array($item)) {
+            if (is_array($item) && !array_is_list($item)) {
                 yield new ArrayData($item);
             } else {
                 yield $item;

--- a/src/View/ArrayData.php
+++ b/src/View/ArrayData.php
@@ -77,7 +77,7 @@ class ArrayData extends ViewableData
     public function getField($field)
     {
         $value = $this->array[$field];
-        if (is_object($value) && !$value instanceof ViewableData) {
+        if (is_object($value) && !($value instanceof ViewableData) && !is_iterable($value)) {
             return new ArrayData($value);
         } elseif (ArrayLib::is_associative($value)) {
             return new ArrayData($value);

--- a/src/View/SSTemplateParser.php
+++ b/src/View/SSTemplateParser.php
@@ -1886,8 +1886,6 @@ class SSTemplateParser extends Parser implements TemplateParser
             $res['php'] .= '((bool)'.$sub['php'].')';
         } else {
             $php = ($sub['ArgumentMode'] == 'default' ? $sub['lookup_php'] : $sub['php']);
-            // TODO: kinda hacky - maybe we need a way to pass state down the parse chain so
-            // Lookup_LastLookupStep and Argument_BareWord can produce hasValue instead of XML_val
             $res['php'] .= str_replace('$$FINAL', 'hasValue', $php ?? '');
         }
     }
@@ -5292,8 +5290,6 @@ class SSTemplateParser extends Parser implements TemplateParser
         $text = stripslashes($text ?? '');
         $text = addcslashes($text ?? '', '\'\\');
 
-        // TODO: This is pretty ugly & gets applied on all files not just html. I wonder if we can make this
-        // non-dynamically calculated
         $code = <<<'EOC'
 (\SilverStripe\View\SSViewer::getRewriteHashLinksDefault()
     ? \SilverStripe\Core\Convert::raw2att( preg_replace("/^(\\/)+/", "/", $_SERVER['REQUEST_URI'] ) )
@@ -5332,8 +5328,7 @@ EOC;
 
             $this->includeDebuggingComments = $includeDebuggingComments;
 
-            // Ignore UTF8 BOM at beginning of string. TODO: Confirm this is needed, make sure SSViewer handles UTF
-            // (and other encodings) properly
+            // Ignore UTF8 BOM at beginning of string.
             if (substr($string ?? '', 0, 3) == pack("CCC", 0xef, 0xbb, 0xbf)) {
                 $this->pos = 3;
             }

--- a/src/View/SSViewer_Scope.php
+++ b/src/View/SSViewer_Scope.php
@@ -5,6 +5,7 @@ namespace SilverStripe\View;
 use ArrayIterator;
 use Countable;
 use Iterator;
+use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\FieldType\DBBoolean;
 use SilverStripe\ORM\FieldType\DBText;
 use SilverStripe\ORM\FieldType\DBFloat;
@@ -130,6 +131,12 @@ class SSViewer_Scope
         if (is_scalar($item)) {
             $item = $this->convertScalarToDBField($item);
         }
+
+        // Wrap list arrays in ViewableData so templates can handle them
+        if (is_array($item) && array_is_list($item)) {
+            $item = ArrayList::create($item);
+        }
+
         return $item;
     }
 
@@ -308,6 +315,8 @@ class SSViewer_Scope
             // Item may be an array or a regular IteratorAggregate
             if (is_array($this->item)) {
                 $this->itemIterator = new ArrayIterator($this->item);
+            } elseif ($this->item instanceof Iterator) {
+                $this->itemIterator = $this->item;
             } else {
                 $this->itemIterator = $this->item->getIterator();
 

--- a/tests/php/View/ViewableDataTest.php
+++ b/tests/php/View/ViewableDataTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\View\Tests;
 use ReflectionMethod;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ArrayList;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 use SilverStripe\View\Tests\ViewableDataTest\ViewableDataTestExtension;
@@ -277,5 +278,32 @@ class ViewableDataTest extends SapphireTest
         $this->assertTrue($viewableData->hasDynamicData('abc'));
         $this->assertSame($obj, $viewableData->getDynamicData('abc'));
         $this->assertSame($obj, $viewableData->abc);
+    }
+
+    public function provideWrapArrayInObj(): array
+    {
+        return [
+            'empty array' => [
+                'arr' => [],
+                'expectedClass' => ArrayList::class,
+            ],
+            'fully indexed array' => [
+                'arr' => [
+                    'value1',
+                    'value2',
+                ],
+                'expectedClass' => ArrayList::class,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideWrapArrayInObj
+     */
+    public function testWrapArrayInObj(array $arr, string $expectedClass): void
+    {
+        $viewableData = new ViewableData();
+        $viewableData->arr = $arr;
+        $this->assertInstanceOf($expectedClass, $viewableData->obj('arr'));
     }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Allows arrays to be passed into templates and iterated over.
Associative arrays are wrapped in `ArrayData` so their values can be accessed by key.
Indexed arrays are wrapped in ~~`ArrayIterator`~~ `ArrrayList` when fetched from `ViewableData::obj()` to respect the method signature.

~~Not wrapping in `ArrayList` because that currently throws exceptions if indexed arrays are passed in, and if we changed that it would silently fail if you try to call `Filter()` or `Sort()` or `Find()` etc.~~

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11237 