### PR TITLE
API Deprecate ViewableData::Me()

### DIFF
--- a/src/View/ViewableData.php
+++ b/src/View/ViewableData.php
@@ -673,9 +673,13 @@ class ViewableData implements IteratorAggregate
      * access to itself.
      *
      * @return ViewableData
+     * @deprecated 5.3.0 Will be replaced with special handling in templates.
      */
     public function Me()
     {
+        Deprecation::withNoReplacement(
+            fn () => Deprecation::notice('5.3.0', 'Will be replaced with special handling in templates.')
+        );
         return $this;
     }
 


### PR DESCRIPTION
`$Me` will still work in templates, but the method in `ViewableData` is being removed. See https://github.com/silverstripe/silverstripe-framework/pull/11244 for details.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11237