### PR TITLE
FIX Loop over current scope when no argument passed to loop block

### DIFF
--- a/src/View/SSTemplateParser.peg
+++ b/src/View/SSTemplateParser.peg
@@ -1031,13 +1031,13 @@ class SSTemplateParser extends Parser implements TemplateParser
     function ClosedBlock_Handle_Loop(&$res)
     {
         if ($res['ArgumentCount'] > 1) {
-            throw new SSTemplateParseException('Either no or too many arguments in control block. Must be one ' .
-                'argument only.', $this);
+            throw new SSTemplateParseException('Too many arguments in control block. Must be one or no' .
+                'arguments only.', $this);
         }
 
         //loop without arguments loops on the current scope
         if ($res['ArgumentCount'] == 0) {
-            $on = '$scope->obj(\'Up\', null)->obj(\'Foo\', null)';
+            $on = '$scope->locally()->obj(\'Me\', null, true)';
         } else {    //loop in the normal way
             $arg = $res['Arguments'][0];
             if ($arg['ArgumentMode'] == 'string') {

--- a/tests/php/View/SSViewerTest.php
+++ b/tests/php/View/SSViewerTest.php
@@ -500,6 +500,15 @@ SS;
         );
     }
 
+    public function testCurrentScopeLoop(): void
+    {
+        $data = new ArrayList([['Val' => 'one'], ['Val' => 'two'], ['Val' => 'three']]);
+        $this->assertEqualIgnoringWhitespace(
+            'one two three',
+            $this->render('<% loop %>$Val<% end_loop %>', $data)
+        );
+    }
+
     public function testCurrentScopeLoopWith()
     {
         // Data to run the loop tests on - one sequence of three items, each with a subitem


### PR DESCRIPTION
Finishes a feature that was sitting there in a broken state for a while - looping through the current item in scope.

This is kinda a mix between a fix and a new feature - I'm calling it a fix in the commit because the current state is simply broken, but I'm targeting `5` because if someone somehow has a `<% loop %>` sitting in a template right now (which will be silently failing) they'll get unexpected results after pulling this into their project.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11250