### PR TITLE
FIX Support pre tag

### DIFF
--- a/src/Forms/HTMLEditor/HTMLEditorField.php
+++ b/src/Forms/HTMLEditor/HTMLEditorField.php
@@ -191,7 +191,13 @@ class HTMLEditorField extends TextareaField
      */
     public function ValueEntities()
     {
-        return htmlentities($this->Value() ?? '', ENT_COMPAT, 'UTF-8', false);
+        $value = htmlentities($this->Value(), ENT_COMPAT, 'UTF-8', false);
+
+        $value = preg_replace_callback('/(?:&lt;pre.*?&gt;(?<replace>.*?)&lt;\/pre&gt;)/imsu', function ($matches) {
+            return str_replace($matches['replace'], htmlentities($matches['replace'], ENT_COMPAT, 'UTF-8', true), $matches[0]);
+        }, $value);
+
+        return $value;
     }
 
     /**

--- a/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorFieldTest.php
@@ -210,23 +210,34 @@ EOS
         );
     }
 
-    public function testValueEntities()
+    public function provideTestValueEntities()
     {
-        $inputText = "The company &amp; partners";
+        return [
+            "ampersand" => [
+                "The company &amp; partners",
+                "The company &amp; partners"
+            ],
+            "double ampersand" => [
+                "The company &amp;amp; partners",
+                "The company &amp;amp; partners"
+            ],
+            "left arrow and right arrow" => [
+                "<p><pre>&lt;strong&gt;The company and partners&lt;/strong&gt;</pre></p>",
+                "&lt;p&gt;&lt;pre&gt;&amp;lt;strong&amp;gt;The company and partners&amp;lt;/strong&amp;gt;&lt;/pre&gt;&lt;/p&gt;"
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestValueEntities
+     */
+    public function testValueEntities(string $input, string $result)
+    {
         $field = new HTMLEditorField("Content");
-        $field->setValue($inputText);
+        $field->setValue($input);
 
         $this->assertEquals(
-            "The company &amp; partners",
-            $field->obj('ValueEntities')->forTemplate()
-        );
-
-        $inputText = "The company &amp;&amp; partners";
-        $field = new HTMLEditorField("Content");
-        $field->setValue($inputText);
-
-        $this->assertEquals(
-            "The company &amp;&amp; partners",
+            $result,
             $field->obj('ValueEntities')->forTemplate()
         );
     }


### PR DESCRIPTION
## Description
POC: Another solution to support using "code" string in WYSIWYG. User can add code snippet wrapped in `<pre>` HTML tag. However, there is some difference in how the snippet code will be processed depending on how it was entered. If the snippet code was entered through Source Code, then all its contents will be processed and, for example, HTML tags will not be displayed in the text area. If the code is entered directly into the HTMLEDitor text field, then all internal tags will be displayed as text.

## Test steps
- Insert `<pre class="any"><div><strong>My test</strong>code snippet</div></pre>` into HTMLEditorField;
- Save;
- You should see `<div><strong>My test</strong>code snippet</div>` in HTMLEditorField;
- You should see `<div><strong>My test</strong>code snippet</div>` on Page;

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/11207
