### PR TITLE
ENH Convert arrays displayed in templates to ViewableData

### DIFF
--- a/src/ORM/ArrayList.php
+++ b/src/ORM/ArrayList.php
@@ -64,6 +64,33 @@ class ArrayList extends ViewableData implements SS_List, Filterable, Sortable, L
         parent::__construct();
     }
 
+    public static function createFromArray(array $items): ArrayList|ArrayData
+    {
+        return self::recursiveCreateFromArray($items);
+    }
+
+    private static function recursiveCreateFromArray(mixed $itemOrItems): mixed
+    {
+        // $item
+        if (!is_array($itemOrItems)) {
+            return $itemOrItems;
+        }
+        // $items
+        if (array_is_list($itemOrItems)) {
+            $list = new ArrayList();
+            foreach ($itemOrItems as $item) {
+                $list->add(new ArrayData(['_index' => self::recursiveCreateFromArray($item)]));
+            }
+            return $list;
+        }
+        // assoc array
+        $data = [];
+        foreach ($itemOrItems as $key => $item) {
+            $data[$key] = self::recursiveCreateFromArray($item);
+        }
+        return new ArrayData($data);
+    }
+
     /**
      * Underlying type class for this list
      *

--- a/src/View/ViewableData.php
+++ b/src/View/ViewableData.php
@@ -25,6 +25,7 @@ use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\View\SSViewer;
 use Traversable;
 use UnexpectedValueException;
+use SilverStripe\ORM\ArrayList;
 
 /**
  * A ViewableData object is any object that can be rendered into a template/view.
@@ -558,6 +559,10 @@ class ViewableData implements IteratorAggregate
             $value = $this->$fieldName;
         }
 
+        if (is_array($value)) {
+            $value = ArrayList::createFromArray($value);
+        }
+
         // Cast object
         if (!is_object($value)) {
             // Force cast
@@ -676,6 +681,12 @@ class ViewableData implements IteratorAggregate
      */
     public function Me()
     {
+        if (is_a($this, ArrayData::class)) {
+            $keys = array_keys($this->toMap());
+            if (count($keys) === 1 && $keys[0] == '_index') {
+                return $this->_index;
+            }
+        }
         return $this;
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/pull/11244

Alternate solution to https://github.com/silverstripe/silverstripe-framework/pull/11244

Seems like it works?

**PageController.php**
```php
    public function ArrayListTest()
    {
        return new ArrayList(['a_list_1', 'a_list_2', 'a_list_3']);
    }

    public function NestedArrayListTest()
    {
        return new ArrayList([
            new ArrayList(['na_list_4', 'na_list_5', 'na_list_6']),
            new ArrayList(['na_list_7', 'na_list_8', 'na_list_9']),
        ]);
    }

    public function ArrayTest() {
        return ['arr_1', 'arr_2', 'arr_3'];
    }

    public function NestedArrayTest() {
        return [
            ['narr_1', 'narr_2', 'narr_3'],
            ['narr_4', 'narr_5', 'narr_6'],
        ];
    }

    public function AssocArrayTest() {
        return [
            'Key1' => 'aa_1',
        ];
    }

    public function NestedAssocArrayTest() {
        return [
            'Key1' => [
                'Key2' => 'naa_1',
            ],
        ];
    }
```

**Page.ss**
```html
		<% loop $ArrayListTest %>
			$Me<br>
		<% end_loop %>

		<% loop $NestedArrayListTest %>
			<% loop $Me %>
				$Me<br>
			<% end_loop %>
		<% end_loop %>

		<% loop $ArrayTest %>
			$Me<br>
		<% end_loop %>

		<% loop $NestedArrayTest %>
			<% loop $Me %>
				$Me<br>
			<% end_loop %>
		<% end_loop %>

		$AssocArrayTest.Key1<br>
		$NestedAssocArrayTest.Key1.Key2<br>
```