### PR TITLE
Adjust pretty name of closures on PHP 8.4

### DIFF
--- a/src/Dev/Deprecation.php
+++ b/src/Dev/Deprecation.php
@@ -139,7 +139,7 @@ class Deprecation
         $newLevel = $level;
         // handle closures inside withNoReplacement()
         if (self::$insideWithNoReplacement
-            && substr($backtrace[$newLevel]['function'], -strlen('{closure')) === '{closure'
+            && strpos($backtrace[$newLevel]['function'], '{closure') !== false
         ) {
             $newLevel = $newLevel + 2;
         }

--- a/src/Dev/Deprecation.php
+++ b/src/Dev/Deprecation.php
@@ -139,7 +139,7 @@ class Deprecation
         $newLevel = $level;
         // handle closures inside withNoReplacement()
         if (self::$insideWithNoReplacement
-            && substr($backtrace[$newLevel]['function'], -strlen('{closure}')) === '{closure}'
+            && substr($backtrace[$newLevel]['function'], -strlen('{closure')) === '{closure'
         ) {
             $newLevel = $newLevel + 2;
         }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description

related to https://github.com/php/php-src/pull/13550

see analog symfony change: https://github.com/symfony/symfony/pull/54614


<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
