### PR TITLE
NEW Allow DataObject classes to define scaffolded relation formfields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "psr/http-message": "^1",
         "sebastian/diff": "^4.0",
         "silverstripe/config": "^2",
-        "silverstripe/assets": "^2.2",
+        "silverstripe/assets": "^2.3",
         "silverstripe/vendor-plugin": "^2",
         "sminnee/callbacklist": "^0.1.1",
         "symfony/cache": "^6.1",

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -18,7 +18,10 @@ use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\FormScaffolder;
 use SilverStripe\Forms\CompositeValidator;
 use SilverStripe\Forms\FieldsValidator;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig_RelationEditor;
 use SilverStripe\Forms\HiddenField;
+use SilverStripe\Forms\SearchableDropdownField;
 use SilverStripe\i18n\i18n;
 use SilverStripe\i18n\i18nEntityProvider;
 use SilverStripe\ORM\Connect\MySQLSchemaManager;
@@ -26,6 +29,7 @@ use SilverStripe\ORM\FieldType\DBComposite;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\FieldType\DBEnum;
 use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\FieldType\DBForeignKey;
 use SilverStripe\ORM\Filters\PartialMatchFilter;
 use SilverStripe\ORM\Filters\SearchFilter;
 use SilverStripe\ORM\Queries\SQLDelete;
@@ -2483,6 +2487,70 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         $this->extend('updateFormScaffolder', $fs, $this);
 
         return $fs->getFieldList();
+    }
+
+    /**
+     * Scaffold a form field for selecting records of this model type in a has_one relation.
+     *
+     * @param string $fieldName The name we usually expect the field to have. This is often the has_one relation
+     * name with "ID" suffixed to it.
+     * @param string $relationName The name of the actual has_one relation, without "ID" suffixed to it.
+     * Some form fields such as UploadField use this instead of the usual field name.
+     */
+    public function scaffoldFormFieldForHasOne(
+        string $fieldName,
+        ?string $fieldTitle,
+        string $relationName,
+        DataObject $ownerRecord
+    ): FormField {
+        $labelField = $this->hasField('Title') ? 'Title' : 'Name';
+        $list = DataList::create(static::class);
+        $threshold = DBForeignKey::config()->get('dropdown_field_threshold');
+        $overThreshold = $list->count() > $threshold;
+        $field = SearchableDropdownField::create($fieldName, $fieldTitle, $list, $labelField)
+            ->setIsLazyLoaded($overThreshold)
+            ->setLazyLoadLimit($threshold);
+        return $field;
+    }
+
+    /**
+     * Scaffold a form field for selecting records of this model type in a has_many relation.
+     *
+     * @param bool &$includeInTab Set this to true if the field should be in its own tab. False otherwise.
+     */
+    public function scaffoldFormFieldForHasMany(
+        string $relationName,
+        ?string $fieldTitle,
+        DataObject $ownerRecord,
+        bool &$includeInOwnTab
+    ): FormField {
+        $includeInOwnTab = true;
+        return GridField::create(
+            $relationName,
+            $fieldTitle,
+            $ownerRecord->$relationName(),
+            GridFieldConfig_RelationEditor::create()
+        );
+    }
+
+    /**
+     * Scaffold a form field for selecting records of this model type in a many_many relation.
+     *
+     * @param bool &$includeInTab Set this to true if the field should be in its own tab. False otherwise.
+     */
+    public function scaffoldFormFieldForManyMany(
+        string $relationName,
+        ?string $fieldTitle,
+        DataObject $ownerRecord,
+        bool &$includeInOwnTab
+    ): FormField {
+        $includeInOwnTab = true;
+        return GridField::create(
+            $relationName,
+            $fieldTitle,
+            $ownerRecord->$relationName(),
+            GridFieldConfig_RelationEditor::create()
+        );
     }
 
     /**

--- a/src/ORM/FieldType/DBForeignKey.php
+++ b/src/ORM/FieldType/DBForeignKey.php
@@ -28,7 +28,8 @@ class DBForeignKey extends DBInt
     protected $object;
 
     /**
-     * Number of related objects to show in a dropdown before it switches to using lazyloading
+     * Number of related objects to show in a scaffolded searchable dropdown field before it
+     * switches to using lazyloading.
      * This will also be used as the lazy load limit
      *
      * @config
@@ -65,23 +66,7 @@ class DBForeignKey extends DBInt
             return null;
         }
         $hasOneSingleton = singleton($hasOneClass);
-        if ($hasOneSingleton instanceof File) {
-            $field = Injector::inst()->create(FileHandleField::class, $relationName, $title);
-            if ($hasOneSingleton instanceof Image) {
-                $field->setAllowedFileCategories('image/supported');
-            }
-            if ($field->hasMethod('setAllowedMaxFileNumber')) {
-                $field->setAllowedMaxFileNumber(1);
-            }
-            return $field;
-        }
-        $labelField = $hasOneSingleton->hasField('Title') ? 'Title' : 'Name';
-        $list = DataList::create($hasOneClass);
-        $threshold = self::config()->get('dropdown_field_threshold');
-        $overThreshold = $list->count() > $threshold;
-        $field = SearchableDropdownField::create($this->name, $title, $list, $labelField)
-            ->setIsLazyLoaded($overThreshold)
-            ->setLazyLoadLimit($threshold);
+        $field = $hasOneSingleton->scaffoldFormFieldForHasOne($this->name, $title, $relationName, $this->object);
         return $field;
     }
 

--- a/tests/php/Forms/FormScaffolderTest.yml
+++ b/tests/php/Forms/FormScaffolderTest.yml
@@ -10,3 +10,6 @@ SilverStripe\Forms\Tests\FormScaffolderTest\Author:
   author1:
     FirstName: Author 1
     Tags: =>SilverStripe\Forms\Tests\FormScaffolderTest\Article.article1
+SilverStripe\Forms\Tests\FormScaffolderTest\ParentModel:
+  parent1:
+    Title: Parent 1

--- a/tests/php/Forms/FormScaffolderTest/Child.php
+++ b/tests/php/Forms/FormScaffolderTest/Child.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\FormScaffolderTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\CurrencyField;
+use SilverStripe\Forms\DateField;
+use SilverStripe\Forms\FormField;
+use SilverStripe\Forms\TimeField;
+use SilverStripe\ORM\DataObject;
+
+class Child extends DataObject implements TestOnly
+{
+    private static $table_name = 'FormScaffolderTest_Child';
+
+    private static $db = [
+        'Title' => 'Varchar',
+    ];
+
+    private static $has_one = [
+        'Parent' => ParentModel::class,
+    ];
+
+    public static bool $includeInOwnTab = true;
+
+    public function scaffoldFormFieldForHasOne(
+        string $fieldName,
+        ?string $fieldTitle,
+        string $relationName,
+        DataObject $ownerRecord
+    ): FormField {
+        // Intentionally return a field that is unlikely to be used by default in the future.
+        return DateField::create($fieldName, $fieldTitle);
+    }
+
+    public function scaffoldFormFieldForHasMany(
+        string $relationName,
+        ?string $fieldTitle,
+        DataObject $ownerRecord,
+        bool &$includeInOwnTab
+    ): FormField {
+        $includeInOwnTab = static::$includeInOwnTab;
+        // Intentionally return a field that is unlikely to be used by default in the future.
+        return CurrencyField::create($relationName, $fieldTitle);
+    }
+
+    public function scaffoldFormFieldForManyMany(
+        string $relationName,
+        ?string $fieldTitle,
+        DataObject $ownerRecord,
+        bool &$includeInOwnTab
+    ): FormField {
+        $includeInOwnTab = static::$includeInOwnTab;
+        // Intentionally return a field that is unlikely to be used by default in the future.
+        return TimeField::create($relationName, $fieldTitle);
+    }
+}

--- a/tests/php/Forms/FormScaffolderTest/ParentChildJoin.php
+++ b/tests/php/Forms/FormScaffolderTest/ParentChildJoin.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\FormScaffolderTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class ParentChildJoin extends DataObject implements TestOnly
+{
+    private static $table_name = 'FormScaffolderTest_ParentChildJoin';
+
+    private static $db = [
+        'Title' => 'Varchar',
+    ];
+
+    private static $has_one = [
+        'Parent' => ParentModel::class,
+        'Child' => Child::class,
+    ];
+}

--- a/tests/php/Forms/FormScaffolderTest/ParentModel.php
+++ b/tests/php/Forms/FormScaffolderTest/ParentModel.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\FormScaffolderTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class ParentModel extends DataObject implements TestOnly
+{
+    private static $table_name = 'FormScaffolderTest_ParentModel';
+
+    private static $db = [
+        'Title' => 'Varchar',
+    ];
+
+    private static $has_one = [
+        'Child' => Child::class,
+        'ChildPolymorphic' => DataObject::class,
+    ];
+
+    private static $has_many = [
+        'ChildrenHasMany' => Child::class . '.Parent',
+    ];
+
+    private static $many_many = [
+        'ChildrenManyMany' => Child::class,
+        'ChildrenManyManyThrough' => [
+            'through' => ParentChildJoin::class,
+            'from' => 'Parent',
+            'to' => 'Child',
+        ]
+    ];
+}


### PR DESCRIPTION
Implements new API for scaffolding `has_one`, `has_many`, and `many_many` relations.

Needs https://github.com/silverstripe/silverstripe-assets/pull/613 to ensure file and image has_one relations are scaffolded with the same logic they were before, hence the bump in dependency.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11079