### PR TITLE
FIX Respect explicit casting before casting arrays

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -521,13 +521,13 @@ class Form extends ViewableData implements HasRequestHandler
         return $this;
     }
 
-    public function castingHelper($field)
+    public function castingHelper($field, bool $useFallback = true)
     {
         // Override casting for field message
         if (strcasecmp($field ?? '', 'Message') === 0 && ($helper = $this->getMessageCastingHelper())) {
             return $helper;
         }
-        return parent::castingHelper($field);
+        return parent::castingHelper($field, $useFallback);
     }
 
     /**

--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -790,13 +790,13 @@ class FormField extends RequestHandler
         return $form->getSecurityToken()->isEnabled();
     }
 
-    public function castingHelper($field)
+    public function castingHelper($field, bool $useFallback = true)
     {
         // Override casting for field message
         if (strcasecmp($field ?? '', 'Message') === 0 && ($helper = $this->getMessageCastingHelper())) {
             return $helper;
         }
-        return parent::castingHelper($field);
+        return parent::castingHelper($field, $useFallback);
     }
 
     /**

--- a/src/Forms/ReadonlyField.php
+++ b/src/Forms/ReadonlyField.php
@@ -56,7 +56,7 @@ class ReadonlyField extends FormField
         return 'readonly';
     }
 
-    public function castingHelper($field)
+    public function castingHelper($field, bool $useFallback = true)
     {
         // Get dynamic cast for 'Value' field
         if (strcasecmp($field ?? '', 'Value') === 0) {
@@ -64,7 +64,7 @@ class ReadonlyField extends FormField
         }
 
         // Fall back to default casting
-        return parent::castingHelper($field);
+        return parent::castingHelper($field, $useFallback);
     }
 
     public function getSchemaStateDefaults()

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -2947,7 +2947,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     /**
      * {@inheritdoc}
      */
-    public function castingHelper($field)
+    public function castingHelper($field, bool $useFallback = true)
     {
         $fieldSpec = static::getSchema()->fieldSpec(static::class, $field);
         if ($fieldSpec) {
@@ -2965,7 +2965,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
             }
         }
 
-        return parent::castingHelper($field);
+        return parent::castingHelper($field, $useFallback);
     }
 
     /**

--- a/src/ORM/FieldType/DBComposite.php
+++ b/src/ORM/FieldType/DBComposite.php
@@ -319,14 +319,14 @@ abstract class DBComposite extends DBField
         return $fieldObject;
     }
 
-    public function castingHelper($field)
+    public function castingHelper($field, bool $useFallback = true)
     {
         $fields = $this->compositeDatabaseFields();
         if (isset($fields[$field])) {
             return $fields[$field];
         }
 
-        return parent::castingHelper($field);
+        return parent::castingHelper($field, $useFallback);
     }
 
     public function getIndexSpecs()

--- a/tests/php/View/ViewableDataTest.php
+++ b/tests/php/View/ViewableDataTest.php
@@ -6,6 +6,7 @@ use ReflectionMethod;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\FieldType\DBText;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
 use SilverStripe\View\Tests\ViewableDataTest\ViewableDataTestExtension;
@@ -59,6 +60,9 @@ class ViewableDataTest extends SapphireTest
 
         $this->assertInstanceOf(ViewableDataTest\RequiresCasting::class, $caster->obj('alwaysCasted'));
         $this->assertInstanceOf(ViewableDataTest\Caster::class, $caster->obj('noCastingInformation'));
+
+        $this->assertInstanceOf(DBText::class, $caster->obj('arrayOne'));
+        $this->assertInstanceOf(ArrayList::class, $caster->obj('arrayTwo'));
     }
 
     public function testFailoverRequiresCasting()

--- a/tests/php/View/ViewableDataTest/Castable.php
+++ b/tests/php/View/ViewableDataTest/Castable.php
@@ -7,13 +7,13 @@ use SilverStripe\View\ViewableData;
 
 class Castable extends ViewableData implements TestOnly
 {
-
     private static $default_cast = Caster::class;
 
     private static $casting = [
         'alwaysCasted' => RequiresCasting::class,
         'castedUnsafeXML' => UnescapedCaster::class,
         'test' => 'Text',
+        'arrayOne' => 'Text',
     ];
 
     public $test = 'test';
@@ -23,6 +23,16 @@ class Castable extends ViewableData implements TestOnly
     public function alwaysCasted()
     {
         return 'alwaysCasted';
+    }
+
+    public function arrayOne()
+    {
+        return ['value1', 'value2'];
+    }
+
+    public function arrayTwo()
+    {
+        return ['value1', 'value2'];
     }
 
     public function noCastingInformation()


### PR DESCRIPTION
Fixes https://github.com/symbiote/silverstripe-multivaluefield/actions/runs/9358332818/job/25759951695

>  1) Symbiote\MultiValueField\Tests\MultiValueFieldTest::testUpdate
BadMethodCallException: Object->__call(): the method 'getValues' does not exist on 'SilverStripe\ORM\ArrayList'

This was caused by https://github.com/silverstripe/silverstripe-framework/pull/11244 which didn't respect explicit pre-defined casting before casting arrays.

Needs https://github.com/silverstripe/silverstripe-cms/pull/2960 for CI to be happy.

## Issue
- https://github.com/silverstripe/.github/issues/266