### PR TITLE
FIX Do not load source in SearchableDropdownTrait when lazy-loading

### DIFF
--- a/src/Forms/SearchableDropdownTrait.php
+++ b/src/Forms/SearchableDropdownTrait.php
@@ -262,6 +262,10 @@ trait SearchableDropdownTrait
      */
     public function getSource(): array
     {
+        // Source will be unused when lazy-loading so just return an empty array
+        if ($this->getIsLazyLoaded()) {
+            return [];
+        }
         return $this->getListMap($this->sourceList);
     }
 

--- a/tests/php/Forms/SearchableDropdownTraitTest.php
+++ b/tests/php/Forms/SearchableDropdownTraitTest.php
@@ -217,4 +217,28 @@ class SearchableDropdownTraitTest extends SapphireTest
         $this->assertSame('My placeholder', $schema['placeholder']);
         $this->assertFalse($schema['searchable']);
     }
+
+    public function provideGetSource(): array
+    {
+        return [
+            'lazyLoad' => [
+                'isLazyLoaded' => true,
+                'expected' => 0,
+            ],
+            'not lazyLoad' => [
+                'isLazyLoaded' => false,
+                'expected' => 3,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideGetSource
+     */
+    public function testGetSource(bool $isLazyLoaded, int $expected): void
+    {
+        $field = new SearchableDropdownField('MyField', 'MyField', Team::get());
+        $field->setIsLazyLoaded($isLazyLoaded);
+        $this->assertCount($expected, $field->getSource());
+    }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11272

silverstripe/installer ci run with pr - https://github.com/emteknetnz/silverstripe-installer/actions/runs/9473993800 (includes admin behat) (green)

Note the SearchableDropDownField seems like it's broken in an elemental context, I've created a [new card](https://github.com/silverstripe/silverstripe-admin/issues/1778) for this

Test setup:

**MyDataObject.php**
```php
<?php

use SilverStripe\ORM\DataObject;

class MyDataObject extends DataObject
{
    private static $table_name = 'MyDataObject';

    private static $db = [
        'Title' => 'Varchar'
    ];

    private static $has_one = [
        'MySubDataObject' => MySubDataObject::class
    ];
}
```

**MySubDataObject**
```php
<?php

use SilverStripe\ORM\DataObject;

class MySubDataObject extends DataObject
{
    private static $table_name = 'MySubDataObject';

    private static $db = [
        'Title' => 'Varchar'
    ];

    private static $has_many = [
        'MyDataObject' => MyDataObject::class
    ];
}
```

**ModelAdmin.php**
```php
<?php

use SilverStripe\Admin\ModelAdmin;

class MyModelAdmin extends ModelAdmin
{
    private static $url_segment = 'MyModelAdmin';

    private static $menu_title = 'My model admin';

    private static $managed_models = [
        MyDataObject::class,
    ];
}
```

**MySubModelAdmin.php**
```php
<?php

use SilverStripe\Admin\ModelAdmin;

class MySubModelAdmin extends ModelAdmin
{
    private static $url_segment = 'MySubModelAdmin';

    private static $menu_title = 'My sub admin';

    private static $managed_models = [
        MySubDataObject::class,
    ];
}
```