### PR TITLE
FIX Don't load data up front for lazy-loaded searchable dropdown

### DIFF
--- a/src/Forms/SearchableDropdownField.php
+++ b/src/Forms/SearchableDropdownField.php
@@ -9,7 +9,7 @@ use SilverStripe\ORM\DataList;
 class SearchableDropdownField extends DropdownField
 {
     use SearchableDropdownTrait;
-    
+
     // This needs to be defined on the class, not the trait, otherwise there is a PHP error
     protected $schemaComponent = 'SearchableDropdownField';
 

--- a/src/Forms/SearchableDropdownTrait.php
+++ b/src/Forms/SearchableDropdownTrait.php
@@ -265,6 +265,13 @@ trait SearchableDropdownTrait
         return $this->getListMap($this->sourceList);
     }
 
+    public function Field($properties = [])
+    {
+        $context = $this;
+        $this->extend('onBeforeRender', $context, $properties);
+        return $context->customise($properties)->renderWith($context->getTemplates());
+    }
+
     /*
      * @param mixed $source
      */
@@ -450,9 +457,16 @@ trait SearchableDropdownTrait
 
     public function getSchemaStateDefaults(): array
     {
-        $data = parent::getSchemaStateDefaults();
-        $data = $this->updateDataForSchema($data);
-        return $data;
+        $state = [
+            'name' => $this->getName(),
+            'id' => $this->ID(),
+            'value' => $this->getDefaultSchemaValue(),
+            'message' => $this->getSchemaMessage(),
+            'data' => [],
+        ];
+
+        $state = $this->updateDataForSchema($state);
+        return $state;
     }
 
     /**
@@ -465,6 +479,14 @@ trait SearchableDropdownTrait
     {
         $this->isMultiple = $isMultiple;
         return $this;
+    }
+
+    private function getDefaultSchemaValue()
+    {
+        if (!$this->getIsLazyLoaded() && $this->hasMethod('getDefaultValue')) {
+            return $this->getDefaultValue();
+        }
+        return $this->Value();
     }
 
     private function getOptionsForSearchRequest(string $term): array


### PR DESCRIPTION
We replaced the auto-scaffolding of has_one form fields with this new thing, and we said it would be better because you don't need the `NumericField` fallback anymore - but the workaround in the linked issue is to manually replace the field with `NumericField` so we've obviously messed up there.

Ultimately `getSource()` should just return the `DataList` directly, but we can't do that in a minor much less a patch because the return type is strongly typed for that method.

In the meantime, the new logic avoids calling `getSource()` altogether as much as we can avoid it, since calling that method is usually not required.

I couldn't remove it being called from `castedCopy()` without copying a bunch of boilerplate from `FormField` - and it is a pretty messy method. Because of that, I also can't sensibly stop `performReadonlyTransformation()` from calling it, so readonly versions of the field will still suck when you have large datasets. If that specific scenario becomes a problem for someone we can look at dealing with it, but until someone complains about it I'm inclined to leave it alone for CMS 5.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11272