### PR TITLE
FIX remove write from SearchableDropdownTrait

### DIFF
--- a/src/Forms/SearchableDropdownTrait.php
+++ b/src/Forms/SearchableDropdownTrait.php
@@ -397,7 +397,6 @@ trait SearchableDropdownTrait
                     $record->$classNameField = $ids ? $record->ClassName : '';
                 }
             }
-            $record->write();
         } else {
             // has_many / many_many field
             if (!method_exists($record, 'hasMethod')) {


### PR DESCRIPTION
## Description
SearchableDropdownTrait was calling `write()` on the underling DataObject.

## Manual testing steps

1. Create Model with multiple has_one relations
2. Save DataObject in ModelAdmin

## Issues
- #11284

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green

I don't have a full understanding on how and where SearchableDropdownTrait and the SearchableDropdown are used. So I'm not sure about test coverage for SearchableDropdownTrait.
