### PR TITLE
Fix #11289: Handle paths with spaces in Silverstripe's sake script

### DIFF
--- a/sake
+++ b/sake
@@ -42,7 +42,7 @@ fi
 
 # Find the PHP binary
 for candidatephp in php php5; do
-	if [ `which $candidatephp 2>/dev/null` -a -f `which $candidatephp 2>/dev/null` ]; then
+	if [ "`which $candidatephp 2>/dev/null`" -a -f "`which $candidatephp 2>/dev/null`" ]; then
 		php=`which $candidatephp 2>/dev/null`
 		break
 	fi
@@ -116,4 +116,4 @@ fi
 ################################################################################################
 ## Basic execution
 
-$php $framework/cli-script.php ${*}
+"$php" "$framework/cli-script.php" "${@}"


### PR DESCRIPTION
## Description

**Expected Behaviour:** `vendor/bin/sake` should function correctly regardless of where the PHP binary is located, even if the path includes spaces.

**Observed Behaviour:** If the path to the PHP interpreter contains spaces, the script fails with an error because the path isn’t wrapped in quotes, leading to incorrect parsing of the command.

This fix ensures that all paths in the `sake` script are properly quoted to handle spaces and other special characters that might appear in directory names.

## Manual Testing Steps

1. Place your PHP binary in a path with spaces and set up the environment variable or path accordingly.
2. Run `vendor/bin/sake build` to ensure it picks up the PHP binary and executes without errors.
3. Check other commands and scenarios where `sake` is used to ensure no other side effects are introduced by this change.

## Issues

- #11289 

## Pull Request Checklist

- [x] The target branch is correct. (Refer to [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version))
- [x] All commits are relevant to the purpose of the PR.
- [ ] Commit messages follow the [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages).
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/).
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/).
- [x] Changes are covered with tests, or tests are not necessary for this change.
- [x] Documentation is updated where necessary.
- [x] CI checks are green.

## Additional Notes

Please review the changes and provide feedback or merge if everything is in order.

Thank you!
