### PR TITLE
MNT Ignore narrow no-break space in regex in tests

### DIFF
--- a/tests/php/Forms/DatetimeFieldTest.php
+++ b/tests/php/Forms/DatetimeFieldTest.php
@@ -148,7 +148,7 @@ class DatetimeFieldTest extends SapphireTest
 
         // Some localisation packages exclude the ',' in default medium format
         $this->assertMatchesRegularExpression(
-            '#29/03/2003(,)? 11:00:00 (PM|pm)#',
+            '#29/03/2003(,)?\h11:00:00\h(PM|pm)#u',
             $datetimeField->Value(),
             'User value is formatted, and in user timezone'
         );

--- a/tests/php/ORM/DBDatetimeTest.php
+++ b/tests/php/ORM/DBDatetimeTest.php
@@ -127,10 +127,10 @@ class DBDatetimeTest extends SapphireTest
 
         // note: Some localisation packages exclude the ',' in default medium format
         i18n::set_locale('en_NZ');
-        $this->assertMatchesRegularExpression('#11/12/2001(,)? 10:10 PM#i', $date->Nice());
+        $this->assertMatchesRegularExpression('#11/12/2001(,)?\h10:10\hPM#iu', $date->Nice());
 
         i18n::set_locale('en_US');
-        $this->assertMatchesRegularExpression('#Dec 11(,)? 2001(,)? 10:10 PM#i', $date->Nice());
+        $this->assertMatchesRegularExpression('#Dec\h11(,)?\h2001(,)?\h10:10\hPM#iu', $date->Nice());
     }
 
     public function testDate()
@@ -142,7 +142,7 @@ class DBDatetimeTest extends SapphireTest
     public function testTime()
     {
         $date = DBDatetime::create_field('Datetime', '2001-12-31 22:10:59');
-        $this->assertMatchesRegularExpression('#10:10:59 PM#i', $date->Time());
+        $this->assertMatchesRegularExpression('#10:10:59\hPM#iu', $date->Time());
     }
 
     public function testTime24()

--- a/tests/php/ORM/DBTimeTest.php
+++ b/tests/php/ORM/DBTimeTest.php
@@ -48,12 +48,12 @@ class DBTimeTest extends SapphireTest
     public function testNice()
     {
         $time = DBTime::create_field('Time', '17:15:55');
-        $this->assertMatchesRegularExpression('#5:15:55 PM#i', $time->Nice());
+        $this->assertMatchesRegularExpression('#5:15:55\hPM#iu', $time->Nice());
     }
 
     public function testShort()
     {
         $time = DBTime::create_field('Time', '17:15:55');
-        $this->assertMatchesRegularExpression('#5:15 PM#i', $time->Short());
+        $this->assertMatchesRegularExpression('#5:15\hPM#iu', $time->Short());
     }
 }


### PR DESCRIPTION
I ran framework's unit tests locally with MariaDB 11.4, and got some failures. The failures were a result of having `U+202F` instead of a regular space in the result. The tests I've updated don't really care what kind of space is used, so replacing the space with `\h` and allowing unicode matches resolves these problems.

Didn't see any repeats of [this problem](https://github.com/silverstripe/.github/issues/202), so fingers crossed we don't see that in CI either once we make the change there.

## Issue
- https://github.com/silverstripe/gha-generate-matrix/issues/85