### PR TITLE
ENH Do not require _config dir or _config.php for modules

### DIFF
--- a/src/Core/Manifest/ManifestFileFinder.php
+++ b/src/Core/Manifest/ManifestFileFinder.php
@@ -18,6 +18,11 @@ class ManifestFileFinder extends FileFinder
 
     const CONFIG_FILE = '_config.php';
     const CONFIG_DIR = '_config';
+    const COMPOSER_FILE = 'composer.json';
+    const COMPOSER_TYPES = [
+        'silverstripe-vendormodule',
+        'silverstripe-theme',
+    ];
     const EXCLUDE_FILE = '_manifest_exclude';
     const LANG_DIR = 'lang';
     const TESTS_DIR = 'tests';
@@ -177,6 +182,16 @@ class ManifestFileFinder extends FileFinder
         // True if config dir exists
         if (file_exists($pathname . '/' . ManifestFileFinder::CONFIG_DIR)) {
             return true;
+        }
+
+        // True if composer type
+        $path = $pathname . '/' . ManifestFileFinder::COMPOSER_FILE;
+        if (file_exists($path)) {
+            $composer = json_decode(file_get_contents($path), true);
+            $type = $composer['type'] ?? '';
+            if (in_array($type, ManifestFileFinder::COMPOSER_TYPES)) {
+                return true;
+            }
         }
 
         return false;

--- a/tests/php/Core/Manifest/ManifestFileFinderTest.php
+++ b/tests/php/Core/Manifest/ManifestFileFinderTest.php
@@ -120,4 +120,36 @@ class ManifestFileFinderTest extends SapphireTest
             ]
         );
     }
+
+    /**
+     * Note that this phpunit file is unable to use a dataProvider for some unknown reason
+     */
+    public function testIsDirectoryModule()
+    {
+        $provider = [
+            'vendormodule' => [
+                'silverstripe-vendormodule',
+                true,
+            ],
+            'theme' => [
+                'silverstripe-theme',
+                true,
+            ],
+            'somethingelse' => [
+                'silverstripe-somethingelse',
+                false,
+            ],
+            'notype' => [
+                'silverstripe-notype',
+                false,
+            ],
+        ];
+        foreach ($provider as $data) {
+            list($subdir, $expected) = $data;
+            $finder = new ManifestFileFinder();
+            $pathname = __DIR__ . '/fixtures/manifestfilefinder_rootconfigcomposer/' . $subdir;
+            $actual = $finder->isDirectoryModule('', $pathname, 0);
+            $this->assertSame($expected, $actual);
+        }
+    }
 }

--- a/tests/php/Core/Manifest/fixtures/manifestfilefinder_rootconfigcomposer/silverstripe-notype/composer.json
+++ b/tests/php/Core/Manifest/fixtures/manifestfilefinder_rootconfigcomposer/silverstripe-notype/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "silverstripe/manifestfilefindertest"
+}

--- a/tests/php/Core/Manifest/fixtures/manifestfilefinder_rootconfigcomposer/silverstripe-somethingelse/composer.json
+++ b/tests/php/Core/Manifest/fixtures/manifestfilefinder_rootconfigcomposer/silverstripe-somethingelse/composer.json
@@ -1,0 +1,4 @@
+{
+    "name": "silverstripe/manifestfilefindertest",
+    "type": "silverstripe-somethingelse"
+}

--- a/tests/php/Core/Manifest/fixtures/manifestfilefinder_rootconfigcomposer/silverstripe-theme/composer.json
+++ b/tests/php/Core/Manifest/fixtures/manifestfilefinder_rootconfigcomposer/silverstripe-theme/composer.json
@@ -1,0 +1,4 @@
+{
+    "name": "silverstripe/manifestfilefindertest",
+    "type": "silverstripe-theme"
+}

--- a/tests/php/Core/Manifest/fixtures/manifestfilefinder_rootconfigcomposer/silverstripe-vendormodule/composer.json
+++ b/tests/php/Core/Manifest/fixtures/manifestfilefinder_rootconfigcomposer/silverstripe-vendormodule/composer.json
@@ -1,0 +1,4 @@
+{
+    "name": "silverstripe/manifestfilefindertest",
+    "type": "silverstripe-vendormodule"
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11254

I think it makes sense to target CMS 6 with this rather than CMS 5, as there's a small chance that classes that aren't currently being included are suddently unintentionally included