### PR TITLE
Fix perform readonly transformation for lazyloaded searchabledropdown

### DIFF
--- a/src/Forms/SearchableDropdownTrait.php
+++ b/src/Forms/SearchableDropdownTrait.php
@@ -586,4 +586,18 @@ trait SearchableDropdownTrait
         }
         return $options;
     }
+
+    public function performReadonlyTransformation()
+    {
+        // This is calling a non-static method statically
+        // using call_user_func() here to prevent an IDE warning
+        // The reason we're calling FormField::castedCopy directly is to prevent an ancestor
+        // call to $this->getSource() which will load the entire DataList into memory which
+        // causes issues with very large datasets and isn't needed when the field is read-only
+        $field = call_user_func('SilverStripe\\Forms\\FormField::castedCopy', SearchableLookupField::class);
+        $field->setSource($this->sourceList);
+        $field->setReadonly(true);
+
+        return $field;
+    }
 }

--- a/src/Forms/SearchableLookupField.php
+++ b/src/Forms/SearchableLookupField.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SilverStripe\Forms;
+
+use SilverStripe\Core\Convert;
+use SilverStripe\ORM\ArrayLib;
+use SilverStripe\ORM\DataObjectInterface;
+use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataList;
+
+/**
+ * Read-only complement of {@link SearchableDropdownField} and {@link SearchableMultiDropdownField}.
+ *
+ * Shows the "human value" of the SearchableDropdownField for the currently selected
+ * values.
+ */
+class SearchableLookupField extends LookupField
+{
+    private ?DataList $sourceList = null;
+
+    /**
+     * To retain compatibility with ancestor getSource() this returns an array of only the selected values
+     */
+    public function getSource(): array
+    {
+        $values = $this->getValueArray();
+        if (empty($values) || $this->sourceList === null) {
+            $selectedValuesList = ArrayList::create();
+        } else {
+            $selectedValuesList = $this->sourceList->filterAny(['ID' => $values]);
+        }
+        return $this->getListMap($selectedValuesList);
+    }
+
+    /**
+     * @param mixed $source
+     */
+    public function setSource($source): static
+    {
+        // Setting to $this->sourceList instead of $this->source because SelectField.source
+        // docblock type is array|ArrayAccess i.e. does not allow DataList
+        if ($source instanceof DataList) {
+            $this->sourceList = $source;
+        } else {
+            $this->sourceList = null;
+        }
+        return $this;
+    }
+}


### PR DESCRIPTION
## Description
performReadonlyTransformation() on a SearchableDropdownField or SearchableMultiDropdownField, will convert the source DataList into an array, which requires pulling data for all records in the list from the database.

This is caused by the performReadonlyTransformation of the underlying SingleSelectField and MultiSelectField calling getSource. To circumvent this a new LazyLoadedLookupField is used. It has the same logic as SearchableDropdownTrait to use a Datalist internally for the Source.

This also contains the fix for #11294, since the wrong initial value of "Title" was messing up the control. 

**Please note:** This solution feels like quite a hack. I really don't like the fact, that getSource is not really returning the source. But I figured as long as SearchableDropdownTrait works this way the performReadonlyTransformation should be similar to it.

## Manual testing steps
Given ModelA has_one ModelB and ModelB has_many ModelA:

- Open ModelB in Model Admin
- Go to the ModelA Tab
- Click on Add new Model A
- A read only Field should be rendered and only one ModelB will be loaded from the Database

## Issues
- #11293
- #11294

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
