### PR TITLE
FIX Don't strip `<header>` tag from `HTMLValue`

### DIFF
--- a/src/View/Parsers/HTMLValue.php
+++ b/src/View/Parsers/HTMLValue.php
@@ -32,7 +32,7 @@ class HTMLValue extends ViewableData
      */
     public function setContent($content)
     {
-        $content = preg_replace('#</?(html|head|body)[^>]*>#si', '', $content);
+        $content = preg_replace('#</?(html|head(?!er)|body)[^>]*>#si', '', $content);
         $html5 = new HTML5(['disable_html_ns' => true]);
         $document = $html5->loadHTML(
             '<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head>' .

--- a/tests/php/View/Parsers/HTMLValueTest.php
+++ b/tests/php/View/Parsers/HTMLValueTest.php
@@ -160,4 +160,32 @@ class HTMLValueTest extends SapphireTest
             $this->assertEquals($noscript, $value->getContent(), 'Child tags are left untouched in noscript tags.');
         }
     }
+
+    public function provideOnlyStripIntendedTags(): array
+    {
+        return [
+            [
+                'input' => '<html><head></head><body><div><p>blahblah</p></div></body></html>',
+                'expected' => '<div><p>blahblah</p></div>',
+            ],
+            [
+                'input' => '<html><head></head><body><header></header><div><p>blahblah</p></div></body></html>',
+                'expected' => '<header></header><div><p>blahblah</p></div>',
+            ],
+            [
+                'input' => '<html some-attribute another-attribute="something"><head></head><body><div><p>blahblah</p></div></body></html>',
+                'expected' => '<div><p>blahblah</p></div>',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideOnlyStripIntendedTags
+     */
+    public function testOnlyStripIntendedTags(string $input, string $expected): void
+    {
+        $value = new HTMLValue();
+        $value->setContent($input);
+        $this->assertEquals($expected, $value->getContent(), 'Invalid HTML can be parsed');
+    }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Stops `HTMLValue` from stripping the `<header>` tag.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
See linked issue

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-framework/issues/11298
