### PR TITLE
FIX Use valid values for APCu version

### DIFF
--- a/src/Core/Cache/ApcuCacheFactory.php
+++ b/src/Core/Cache/ApcuCacheFactory.php
@@ -40,6 +40,9 @@ class ApcuCacheFactory extends AbstractCacheFactory implements InMemoryCacheFact
         $defaultLifetime = isset($params['defaultLifetime']) ? $params['defaultLifetime'] : 0;
         // $version is optional - defaults to null.
         $version = isset($params['version']) ? $params['version'] : Environment::getEnv('SS_APCU_VERSION');
+        if ($version === false) {
+            $version = null;
+        }
         $useInjector = isset($params['useInjector']) ? $params['useInjector'] : true;
 
         return $this->instantiateCache(


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/actions/runs/9900395403/job/27351105826
> Symfony\Component\Cache\Exception\InvalidArgumentException: Cache key length must be greater than zero.

I thought `Environment::getEnv()` returned `null` if there's no value set - but it turns out it's `false`. We need a string or `null`.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11145