### PR TITLE
FIX Truncate table to clear table

### DIFF
--- a/src/ORM/Connect/MySQLDatabase.php
+++ b/src/ORM/Connect/MySQLDatabase.php
@@ -566,16 +566,6 @@ class MySQLDatabase extends Database implements TransactionManager
      */
     public function clearTable($table)
     {
-        $this->query("DELETE FROM \"$table\"");
-
-        // Check if resetting the auto-increment is needed
-        $autoIncrement = $this->preparedQuery(
-            'SELECT "AUTO_INCREMENT" FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?',
-            [ $this->getSelectedDatabase(), $table]
-        )->value();
-
-        if ($autoIncrement > 1) {
-            $this->query("ALTER TABLE \"$table\" AUTO_INCREMENT = 1");
-        }
+        $this->query("TRUNCATE TABLE \"$table\"");
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/278

For whatever reason MySQL 8 specifically would end up with an auto increment value of 2 instead of 1 which caused behat tests that rely on an ID to fail e.g. https://github.com/silverstripe/silverstripe-elemental/actions/runs/9986875108/job/27600180632?pr=1219

Truncating the table will correctly reset the auto increment

recipe-sink ci run with pr - https://github.com/creative-commoners/recipe-kitchen-sink/actions/runs/10005707377