### PR TITLE
[CVE-2024-32981] Disallow data:text/html in data attributes

### DIFF
--- a/src/Forms/HTMLEditor/HTMLEditorSanitiser.php
+++ b/src/Forms/HTMLEditor/HTMLEditorSanitiser.php
@@ -347,7 +347,7 @@ class HTMLEditorSanitiser
                 }
 
                 // Matches "javascript:" with any arbitrary linebreaks inbetween the characters.
-                $regex = '/^\s*' . implode('\s*', str_split('javascript:')) . '/i';
+                $regex = '#^\s*(' . implode('\s*', str_split('javascript:')) . '|' . implode('\s*', str_split('data:text/html;')) . ')#i';
                 // Strip out javascript execution in href or src attributes.
                 foreach (['src', 'href', 'data'] as $dangerAttribute) {
                     if ($el->hasAttribute($dangerAttribute)) {

--- a/tests/php/Forms/HTMLEditor/HTMLEditorSanitiserTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorSanitiserTest.php
@@ -120,7 +120,31 @@ class HTMLEditorSanitiserTest extends FunctionalTest
                 'object[data]',
                 '<object data=javascript:alert()>',
                 '<object></object>',
-                'Object with dangerous content in data attribute is completely removed'
+                'Object with dangerous javascript content in data attribute is completely removed'
+            ],
+            [
+                'object[data]',
+                '<object data="javascript:alert()">',
+                '<object></object>',
+                'Object with dangerous javascript content in data attribute with quotes is completely removed'
+            ],
+            [
+                'object[data]',
+                '<object data="data:text/html;base64,PHNjcmlwdD5hbGVydChkb2N1bWVudC5sb2NhdGlvbik8L3NjcmlwdD4=">',
+                '<object></object>',
+                'Object with dangerous html content in data attribute is completely removed'
+            ],
+            [
+                'object[data]',
+                '<object data="' . implode("\n", str_split(' DATA:TEXT/HTML;')) . 'base64,PHNjcmlwdD5hbGVydChkb2N1bWVudC5sb2NhdGlvbik8L3NjcmlwdD4=">',
+                '<object></object>',
+                'Object with split upper-case dangerous html content in data attribute is completely removed'
+            ],
+            [
+                'object[data]',
+                '<object data="data:text/xml;base64,PHNjcmlwdD5hbGVydChkb2N1bWVudC5sb2NhdGlvbik8L3NjcmlwdD4=">',
+                '<object data="data:text/xml;base64,PHNjcmlwdD5hbGVydChkb2N1bWVudC5sb2NhdGlvbik8L3NjcmlwdD4="></object>',
+                'Object with safe xml content in data attribute is retained'
             ],
             [
                 'img[src]',


### PR DESCRIPTION
This applies this vulnerability fix to the 4.13 branch:
https://github.com/advisories/GHSA-chx7-9x8h-r5mg
https://github.com/silverstripe/silverstripe-framework/pull/11307