### PR TITLE
FIX Don't generate table alias for "from" statement that are not column names

### DIFF
--- a/src/ORM/Queries/SQLConditionalExpression.php
+++ b/src/ORM/Queries/SQLConditionalExpression.php
@@ -78,7 +78,18 @@ abstract class SQLConditionalExpression extends SQLExpression
         if (is_array($from)) {
             $this->from = array_merge($this->from, $from);
         } elseif (!empty($from)) {
-            $this->from[str_replace(['"','`'], '', $from)] = $from;
+            // Check if the from clause looks like a regular table name
+            // Table name most be an uninterrupted string, with no spaces.
+            // It may be padded with spaces. e.g. ` TableName ` will be
+            // treated as Table Name, but not ` Table Name `.
+            if (preg_match('/^\s*[^\s]+\s*$/', $from)) {
+                // Add an alias for the table name, stripping any quotes
+                $this->from[str_replace(['"','`'], '', $from)] = $from;
+            } else {
+                // Add from clause without an alias - this is probably a full
+                // sub-select with its own explicit alias.
+                $this->from[] = $from;
+            }
         }
 
         return $this;


### PR DESCRIPTION


## Manual testing steps
This is updating a low level API that is widely use across tho codebase. There's not really any manual steps that could be taken ... aside from using the system.

## Issues
- #11276

## Pull request checklist
- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
