### PR TITLE
ENH Don't use the keyword "self"

### DIFF
--- a/src/Core/Environment.php
+++ b/src/Core/Environment.php
@@ -258,8 +258,8 @@ class Environment
      */
     public static function isCli()
     {
-        if (self::$isCliOverride !== null) {
-            return self::$isCliOverride;
+        if (Environment::$isCliOverride !== null) {
+            return Environment::$isCliOverride;
         }
         return in_array(strtolower(php_sapi_name() ?? ''), ['cli', 'phpdbg']);
     }


### PR DESCRIPTION
Wasn't included in https://github.com/silverstripe/silverstripe-framework/pull/11313 because this code is new in the `5` branch.

Fixes https://github.com/silverstripe/silverstripe-framework/actions/runs/10152021344/job/28072530978
> Can't use keyword 'self'. Use 'Environment' instead.

## Issue
- https://github.com/silverstripe/.github/issues/287