### PR TITLE
FIX Allow clearing lazyloaded SearchableDropdownField.

### DIFF
--- a/src/Forms/SearchableDropdownTrait.php
+++ b/src/Forms/SearchableDropdownTrait.php
@@ -29,7 +29,7 @@ trait SearchableDropdownTrait
         'search',
     ];
 
-    private bool $isClearable = false;
+    private bool $isClearable = true;
 
     private bool $isLazyLoaded = false;
 

--- a/src/Forms/SearchableMultiDropdownField.php
+++ b/src/Forms/SearchableMultiDropdownField.php
@@ -24,6 +24,5 @@ class SearchableMultiDropdownField extends MultiSelectField
         $this->setLabelField($labelField);
         $this->addExtraClass('ss-searchable-dropdown-field');
         $this->setIsMultiple(true);
-        $this->setIsClearable(true);
     }
 }

--- a/tests/php/Forms/SearchableDropdownTraitTest.php
+++ b/tests/php/Forms/SearchableDropdownTraitTest.php
@@ -205,16 +205,16 @@ class SearchableDropdownTraitTest extends SapphireTest
         $field->setForm($form);
         $schema = $field->getSchemaDataDefaults();
         $this->assertFalse($schema['lazyLoad']);
-        $this->assertFalse($schema['clearable']);
+        $this->assertTrue($schema['clearable']);
         $this->assertSame('Select or type to search...', $schema['placeholder']);
         $this->assertTrue($schema['searchable']);
         $field->setIsLazyLoaded(true);
-        $field->setIsClearable(true);
+        $field->setIsClearable(false);
         $field->setPlaceholder('My placeholder');
         $field->setIsSearchable(false);
         $schema = $field->getSchemaDataDefaults();
         $this->assertTrue($schema['lazyLoad']);
-        $this->assertTrue($schema['clearable']);
+        $this->assertFalse($schema['clearable']);
         $this->assertSame('My placeholder', $schema['placeholder']);
         $this->assertFalse($schema['searchable']);
     }


### PR DESCRIPTION
Considered doing this in a minor but the risk of regression is extremely small if not nil, and this is fixing a bug so `5.2` it is.

Checked the non-lazy-loaded field as well - I personally like having both there. It's subjective, but IMO it's good like this.

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1791