### PR TITLE
NEW Make CMSFields scaffolding configurable, plus new options

### DIFF
--- a/src/Forms/FieldList.php
+++ b/src/Forms/FieldList.php
@@ -407,6 +407,9 @@ class FieldList extends ArrayList
         $currentPointer = $this;
 
         foreach ($parts as $k => $part) {
+            if ($currentPointer === null) {
+                return null;
+            }
             $currentPointer = $currentPointer->fieldByName($part);
         }
 

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -290,6 +290,15 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     private static $table_name = null;
 
     /**
+     * Settings used by the FormScaffolder that scaffolds fields for getCMSFields()
+     */
+    private static array $scaffold_cms_fields_settings = [
+        'includeRelations' => true,
+        'tabbed' => true,
+        'ajaxSafe' => true,
+    ];
+
+    /**
      * Non-static relationship cache, indexed by component name.
      *
      * @var DataObject[]
@@ -2469,8 +2478,12 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         $params = array_merge(
             [
                 'tabbed' => false,
+                'mainTabOnly' => false,
                 'includeRelations' => false,
+                'restrictRelations' => [],
+                'ignoreRelations' => [],
                 'restrictFields' => false,
+                'ignoreFields' => [],
                 'fieldClasses' => false,
                 'ajaxSafe' => false
             ],
@@ -2479,8 +2492,12 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
 
         $fs = FormScaffolder::create($this);
         $fs->tabbed = $params['tabbed'];
+        $fs->mainTabOnly = $params['mainTabOnly'];
         $fs->includeRelations = $params['includeRelations'];
+        $fs->restrictRelations = $params['restrictRelations'];
+        $fs->ignoreRelations = $params['ignoreRelations'];
         $fs->restrictFields = $params['restrictFields'];
+        $fs->ignoreFields = $params['ignoreFields'];
         $fs->fieldClasses = $params['fieldClasses'];
         $fs->ajaxSafe = $params['ajaxSafe'];
 
@@ -2600,12 +2617,12 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      */
     public function getCMSFields()
     {
-        $tabbedFields = $this->scaffoldFormFields([
-            // Don't allow has_many/many_many relationship editing before the record is first saved
-            'includeRelations' => ($this->ID > 0),
-            'tabbed' => true,
-            'ajaxSafe' => true
-        ]);
+        $scaffoldOptions = static::config()->get('scaffold_cms_fields_settings');
+        // Don't allow has_many/many_many relationship editing before the record is first saved
+        if (!$this->isInDB()) {
+            $scaffoldOptions['includeRelations'] = false;
+        }
+        $tabbedFields = $this->scaffoldFormFields($scaffoldOptions);
 
         $this->extend('updateCMSFields', $tabbedFields);
 

--- a/tests/php/Forms/FieldListTest.php
+++ b/tests/php/Forms/FieldListTest.php
@@ -259,6 +259,8 @@ class FieldListTest extends SapphireTest
         $this->assertNull($fields->findTab('More'));
         $this->assertEquals($fields->findTab('Root.More'), $more);
         $this->assertEquals($fields->findTab('Root.More.Tab4'), $tab4);
+
+        $this->assertNull($fields->findTab('This.Doesnt.Exist'));
     }
 
     /**


### PR DESCRIPTION
Doing this to support the CMS 6 changes - but there's no reason for this new feature to wait until April since it's not BC breaking.

- Adds three new options for `FormScaffolder`:
    - `tabsOnly`: Only return the `Root.Main` tab in the FieldList (effectively don't scaffold anything).
        - This isn't strictly necessary, but it does make it easier to follow best practice (calling `parent::getCMSFields()`) even in scenarios where you want to build all your form fields from scratch.
    - `ignoreFields`: Array of field names in $db or relations in $has_one which should not be scaffolded.
    - `ignoreRelations`: Array of relations in $has_many or $many_many which should not be scaffolded.
    - `restrictRelations`: Array of relation names to use as an allow list. Similar to the existing `restrictFields`
- Makes the options used to scaffold fields in `getCMSFields()` configurable.

> [!NOTE]
> `ignoreFields` includes $has_one to match the behaviour of both `restrictFields` (includes $has_one) and `includeRelations` (for $has_many and $many_many only)


## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2767