### PR TITLE
FIX Don't error if template global is null

### DIFF
--- a/src/View/SSViewer_Scope.php
+++ b/src/View/SSViewer_Scope.php
@@ -177,6 +177,9 @@ class SSViewer_Scope
     public function getObj($name, $arguments = [], $cache = false, $cacheName = null)
     {
         $on = $this->itemIterator ? $this->itemIterator->current() : $this->item;
+        if ($on === null) {
+            return null;
+        }
         return $on->obj($name, $arguments, $cache, $cacheName);
     }
 

--- a/tests/php/View/SSViewerTest.php
+++ b/tests/php/View/SSViewerTest.php
@@ -364,6 +364,12 @@ SS;
         );
     }
 
+    public function testGlobalVariablesReturnNull()
+    {
+        $this->assertEquals('<p></p>', $this->render('<p>$SSViewerTest_GlobalReturnsNull</p>'));
+        $this->assertEquals('<p></p>', $this->render('<p>$SSViewerTest_GlobalReturnsNull.Chained.Properties</p>'));
+    }
+
     public function testCoreGlobalVariableCalls()
     {
         $this->assertEquals(

--- a/tests/php/View/SSViewerTest/TestGlobalProvider.php
+++ b/tests/php/View/SSViewerTest/TestGlobalProvider.php
@@ -18,8 +18,8 @@ class TestGlobalProvider implements TemplateGlobalProvider, TestOnly
             'SSViewerTest_GlobalReferencedByString' => 'get_reference',
             'SSViewerTest_GlobalReferencedInArray' => ['method' => 'get_reference'],
 
-            'SSViewerTest_GlobalThatTakesArguments' => ['method' => 'get_argmix', 'casting' => 'HTMLFragment']
-
+            'SSViewerTest_GlobalThatTakesArguments' => ['method' => 'get_argmix', 'casting' => 'HTMLFragment'],
+            'SSViewerTest_GlobalReturnsNull' => 'getNull',
         ];
     }
 
@@ -42,5 +42,10 @@ class TestGlobalProvider implements TemplateGlobalProvider, TestOnly
     {
         $args = func_get_args();
         return 'z' . implode(':', $args) . 'z';
+    }
+
+    public static function getNull()
+    {
+        return null;
     }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Fixes a bug where if template variables from a `TemplateGlobalProvider` return null and you chain off them, you'd get a null reference error.

The `getObj()` method is only ever called in one place, which sets the current item in scope - so if the current item in scope is null, we just keep null as the item in scope, which results in the behaviour we expect (i.e. nulls result in just not dumping anything to the template, are falsy in if statements, etc).

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
See reproduction steps in the issue description

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-framework/issues/11330

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] CI is green
