### PR TITLE
FIX Correctly clear table and reset auto increment

### DIFF
--- a/src/ORM/Connect/MySQLDatabase.php
+++ b/src/ORM/Connect/MySQLDatabase.php
@@ -569,23 +569,9 @@ class MySQLDatabase extends Database implements TransactionManager
         // Not simply using "TRUNCATE TABLE \"$table\"" because DELETE is a lot quicker
         // than TRUNCATE which is very relevant during unit testing. Using TRUNCATE will lead to an
         // approximately 50% increase it the total time of running unit tests.
-        //
-        // Using max(ID) to determine if the table should reset its auto-increment, rather than using
-        // SELECT "AUTO_INCREMENT" FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
-        // after deleting from the table, because in MySQL 8, under certain conditions, notably
-        // when running behat, sometimes the auto-increment was being reset to 2 for unknown reasons
-        $self = $this;
-        $fn = function () use ($self, $table) {
-            $maxID = $self->query("SELECT MAX(ID) FROM \"$table\"")->value();
-            $self->query("DELETE FROM \"$table\"");
-            if ($maxID > 0) {
-                $self->query("ALTER TABLE \"$table\" AUTO_INCREMENT = 1");
-            }
-        };
-        if ($this->supportsTransactions()) {
-            $this->withTransaction($fn);
-        } else {
-            $fn();
-        }
+        $this->query("DELETE FROM \"$table\"");
+        // Don't check the current AUTO_INCREMENT value first, because table stats are cached from
+        // MySQL 8.0 (for a full day by default) and will likely be out of date.
+        $this->query("ALTER TABLE \"$table\" AUTO_INCREMENT = 1")->value();
     }
 }


### PR DESCRIPTION
Follow-on from https://github.com/silverstripe/silverstripe-framework/pull/11309 and https://github.com/silverstripe/silverstripe-framework/pull/11319

We can't use the ID value as the existing implementation does, because if we created some records and then deleted them all, the max ID will be `0` or `null` (depending on how MySQL reads that), which means we won't reset the auto increment.

We also can't rely on fetching the current auto increment value like the original implementation did because that's cached in MySQL 8.0 which is what caused the original failure.

Instead, we just always reset the auto increment. It'll be faster than a truncate, and it's better than trying to mess with the cache settings for the table stats or running `ANALYZE TABLE` (which I did try but it caused other problems).

## Issue
- https://github.com/silverstripe/.github/issues/290