### PR TITLE
FIX remove Upload type from setUpload for Injections

### DIFF
--- a/src/Forms/UploadReceiver.php
+++ b/src/Forms/UploadReceiver.php
@@ -61,10 +61,10 @@ trait UploadReceiver
     /**
      * Sets the upload handler
      *
-     * @param Upload $upload
+     * @param $upload
      * @return $this Self reference
      */
-    public function setUpload(Upload $upload)
+    public function setUpload($upload)
     {
         $this->upload = $upload;
         return $this;


### PR DESCRIPTION
## Description
When Injecting "SilverStripe\Assets\Upload" with a custom class, the UploadReceiver.php trait throws an "Uncaught TypeError", at setUpload(). 

## Issues
This is happening due to the "Upload" type defined in docblocks and params. Removing this type allows the Upload Class to be properly injected.


## Pull request checklist
- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
    - I have not used the correct commit message type as I have not checked before creating the PR
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
