### PR TITLE
NEW Provide a standardised CMSEditLink method

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm.php
+++ b/src/Forms/GridField/GridFieldDetailForm.php
@@ -175,7 +175,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
 
     /**
      * Try and find another URL at which the given record can be edited.
-     * If redirectMissingRecords is true and the record has a CMSEditLink method, that value will be returned.
+     * If redirectMissingRecords is true and the record has a getCMSEditLink method, that value will be returned.
      * This only works when the list passed to the GridField is a {@link DataList}.
      *
      * @param $gridField The current GridField
@@ -203,9 +203,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
         }
 
         $existing = DataObject::get($list->dataClass())->byID($id);
-        if ($existing && $existing->hasMethod('CMSEditLink')) {
-            $link = $existing->CMSEditLink();
-        }
+        $link = $existing?->getCMSEditLink();
 
         if ($link && $link == $request->getURL()) {
             throw new \LogicException(sprintf(
@@ -282,7 +280,7 @@ class GridFieldDetailForm extends AbstractGridFieldComponent implements GridFiel
      * Enable redirection to missing records.
      *
      * If a GridField shows a filtered list, and the record is not in the list but exists in the
-     * database, and the record has a CMSEditLink method, then the system will redirect to the
+     * database, and the record has a getCMSEditLink method, then the system will redirect to the
      * URL returned by that method.
      */
     public function setRedirectMissingRecords(bool $redirectMissingRecords): GridFieldDetailForm

--- a/src/ORM/CMSPreviewable.php
+++ b/src/ORM/CMSPreviewable.php
@@ -32,9 +32,9 @@ interface CMSPreviewable
     public function getMimeType();
 
     /**
-     * @return string Link to the CMS-author view. Should point to a
+     * @return string|null Link to the CMS-author view. Should point to a
      * controller subclassing {@link LeftAndMain}. Example:
      * http://mysite.com/admin/edit/6
      */
-    public function CMSEditLink();
+    public function getCMSEditLink(): ?string;
 }

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -2693,6 +2693,25 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
     }
 
     /**
+     * Get the link for editing this record in the CMS.
+     */
+    public function getCMSEditLink(): ?string
+    {
+        $link = null;
+        $this->extend('updateCMSEditLink', $link);
+        return $link;
+    }
+
+    /**
+     * @deprecated 6.0.0 Use getCMSEditLink() instead
+     */
+    public function CMSEditLink()
+    {
+        Deprecation::notice('6.0.0', 'Use getCMSEditLink() instead');
+        return $this->getCMSEditLink();
+    }
+
+    /**
      * Gets the value of a field.
      * Called by {@link __get()} and any getFieldName() methods you might create.
      *
@@ -4143,6 +4162,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
      */
     private static $casting = [
         "Title" => 'Text',
+        'CMSEditLink' => 'Text',
     ];
 
     /**

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest/Person.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest/Person.php
@@ -75,7 +75,7 @@ class Person extends DataObject implements TestOnly
         );
     }
 
-    public function CMSEditLink()
+    public function getCMSEditLink(): ?string
     {
         return sprintf('my-admin/%d', $this->ID);
     }


### PR DESCRIPTION
Provides a standard implementation and method signature for the `CMSEditLink()` method which is used in various places. See related PRs.
This change allows us to convert the public `CMSEditLink()` method on `CMSEditLinkExtension` to instead be an appropriate protected `updateCMSEditLink()` extension hook. See https://github.com/silverstripe/silverstripe-admin/pull/1809

If we were doing this from scratch I'd call it `getEditLink()` - if you want that change, since this is a major release I can do that, but bear in mind that change introduces upgrade pain with probably 0 value added, so don't ask for it unless you can indicate some value it adds to offset the upgrade pain it'd introduce.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11258