### PR TITLE
DEP Use symfony for IPUtils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "symfony/config": "^6.1",
         "symfony/dom-crawler": "^6.1",
         "symfony/filesystem": "^6.1",
+        "symfony/http-foundation": "^6.1",
         "symfony/mailer": "^6.1",
         "symfony/mime": "^6.1",
         "symfony/translation": "^6.1",

--- a/src/Control/Middleware/TrustedProxyMiddleware.php
+++ b/src/Control/Middleware/TrustedProxyMiddleware.php
@@ -3,7 +3,7 @@
 namespace SilverStripe\Control\Middleware;
 
 use SilverStripe\Control\HTTPRequest;
-use SilverStripe\Control\Util\IPUtils;
+use Symfony\Component\HttpFoundation\IpUtils;
 
 /**
  * This middleware will rewrite headers that provide IP and host details from an upstream proxy.

--- a/src/Control/Util/IPUtils.php
+++ b/src/Control/Util/IPUtils.php
@@ -11,10 +11,13 @@
 
 namespace SilverStripe\Control\Util;
 
+use SilverStripe\Dev\Deprecation;
+
 /**
  * Http utility functions.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @deprecated 5.3.0 Use Symfony\Component\HttpFoundation\IpUtils instead
  */
 class IPUtils
 {
@@ -37,6 +40,7 @@ class IPUtils
      */
     public static function checkIP($requestIP, $ips)
     {
+        Deprecation::notice('5.3.0', 'Use Symfony\Component\HttpFoundation\IpUtils::checkIP() instead');
         if (!is_array($ips)) {
             $ips = [$ips];
         }
@@ -62,6 +66,7 @@ class IPUtils
      */
     public static function checkIP4($requestIP, $ip)
     {
+        Deprecation::notice('5.3.0', 'Use Symfony\Component\HttpFoundation\IpUtils::checkIP4() instead');
         if (!filter_var($requestIP, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
             return false;
         }
@@ -100,6 +105,7 @@ class IPUtils
      */
     public static function checkIP6($requestIP, $ip)
     {
+        Deprecation::notice('5.3.0', 'Use Symfony\Component\HttpFoundation\IpUtils::checkIP6() instead');
         if (!((extension_loaded('sockets') && defined('AF_INET6')) || @inet_pton('::1'))) {
             throw new \RuntimeException('Unable to check IPv6. Check that PHP was not compiled with option "disable-ipv6".');
         }
@@ -141,6 +147,7 @@ class IPUtils
      */
     public static function anonymize(string $ip): string
     {
+        Deprecation::notice('5.3.0', 'Use Symfony\Component\HttpFoundation\IpUtils::anonymize() instead');
         $wrappedIPv6 = false;
         if (str_starts_with($ip, '[') && str_ends_with($ip, ']')) {
             $wrappedIPv6 = true;

--- a/tests/php/Control/IPUtilsTest.php
+++ b/tests/php/Control/IPUtilsTest.php
@@ -13,6 +13,7 @@ namespace SilverStripe\Control\Tests;
  */
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Control\Util\IPUtils;
+use SilverStripe\Dev\Deprecation;
 
 class IPUtilsTest extends SapphireTest
 {
@@ -21,7 +22,9 @@ class IPUtilsTest extends SapphireTest
      */
     public function testIPv4($matches, $remoteAddr, $cidr)
     {
-        $this->assertSame($matches, IPUtils::checkIP($remoteAddr, $cidr));
+        Deprecation::withNoReplacement(function () use ($matches, $remoteAddr, $cidr) {
+            $this->assertSame($matches, IPUtils::checkIP($remoteAddr, $cidr));
+        });
     }
 
     public function iPv4Provider()
@@ -51,7 +54,9 @@ class IPUtilsTest extends SapphireTest
             $this->markTestSkipped('Only works when PHP is compiled without the option "disable-ipv6".');
         }
 
-        $this->assertSame($matches, IPUtils::checkIP($remoteAddr, $cidr));
+        Deprecation::withNoReplacement(function () use ($matches, $remoteAddr, $cidr) {
+            $this->assertSame($matches, IPUtils::checkIP($remoteAddr, $cidr));
+        });
     }
 
     public function iPv6Provider()
@@ -80,6 +85,8 @@ class IPUtilsTest extends SapphireTest
             $this->markTestSkipped('Only works when PHP is compiled with the option "disable-ipv6".');
         }
 
-        IPUtils::checkIP('2a01:198:603:0:396e:4789:8e99:890f', '2a01:198:603:0::/65');
+        Deprecation::withNoReplacement(function () {
+            IPUtils::checkIP('2a01:198:603:0:396e:4789:8e99:890f', '2a01:198:603:0::/65');
+        });
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10846

IPUtilsTest will still pass if you simply swap out the Silverstripe import of IPUtils for the Symfony one
