### PR TITLE
API Remove ALC renewal, tweak extension point

### DIFF
--- a/src/Security/MemberAuthenticator/CookieAuthenticationHandler.php
+++ b/src/Security/MemberAuthenticator/CookieAuthenticationHandler.php
@@ -175,22 +175,8 @@ class CookieAuthenticationHandler implements AuthenticationHandler
             $this->cascadeInTo->logIn($member, false, $request);
         }
 
-        // Renew the token
-        Deprecation::withSuppressedNotice(fn() => $rememberLoginHash->renew());
-
-        // Send the new token to the client if it was changed
-        if ($rememberLoginHash->getToken()) {
-            $tokenExpiryDays = RememberLoginHash::config()->uninherited('token_expiry_days');
-            Cookie::set(
-                $this->getTokenCookieName(),
-                $member->ID . ':' . $rememberLoginHash->getToken(),
-                $tokenExpiryDays,
-                null,
-                null,
-                false,
-                true
-            );
-        }
+        // Session renewal hook
+        $rememberLoginHash->extend('onAfterRenewSession');
 
         // Audit logging hook
         $member->extend('memberAutoLoggedIn');

--- a/src/Security/RememberLoginHash.php
+++ b/src/Security/RememberLoginHash.php
@@ -83,15 +83,6 @@ class RememberLoginHash extends DataObject
     private static $force_single_token = false;
 
     /**
-     * If true, the token will be replaced during session renewal. This can cause unexpected
-     * logouts if the new token does not reach the client (e.g. due to a network error).
-     *
-     * This can be disabled as of CMS 5.3, and renewal will be removed entirely in CMS 6.
-     * @deprecated 5.3.0 Will be removed without equivalent functionality
-     */
-    private static bool $replace_token_during_session_renewal = true;
-
-    /**
      * The token used for the hash. Only present during the lifetime of the request
      * that generates it, as the hash representation is stored in the database and
      * the token itself is sent to the client.
@@ -199,28 +190,6 @@ class RememberLoginHash extends DataObject
         $rememberLoginHash->extend('onAfterGenerateToken');
         $rememberLoginHash->write();
         return $rememberLoginHash;
-    }
-
-    /**
-     * Generates a new hash for this member but keeps the device ID intact
-     *
-     * @deprecated 5.3.0 Will be removed without equivalent functionality
-     * @return RememberLoginHash
-     */
-    public function renew()
-    {
-        // Only regenerate token if configured to do so
-        Deprecation::notice('5.3.0', 'Will be removed without equivalent functionality');
-        $replaceToken = RememberLoginHash::config()->get('replace_token_during_session_renewal');
-        if ($replaceToken) {
-            $hash = $this->getNewHash($this->Member());
-            $this->Hash = $hash;
-        }
-
-        $this->extend('onAfterRenewToken', $replaceToken);
-        $this->write();
-
-        return $this;
     }
 
     /**


### PR DESCRIPTION


<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description

The ALC token is no longer rotated during an active login. Also removed related `replace_token_during_session_renewal` config. The extension point that was previously provided in the `renew()` method has been renamed and is now triggered externally in the `CookieAuthenticationHandler::authenticateRequest()` method.

Co-dependent on related Login Session PR: silverstripe/silverstripe-session-manager#214

## Manual testing steps

Checkout this PR along with the Session Manager PR and validate that remember me functionality is intact.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11281

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
