### PR TITLE
MNT Resolve deprecation warnings in tests

### DIFF
--- a/tests/php/Core/EnvironmentTest.php
+++ b/tests/php/Core/EnvironmentTest.php
@@ -2,7 +2,7 @@
 
 namespace SilverStripe\Core\Tests;
 
-use ReflectionProperty;
+use ReflectionClass;
 use SilverStripe\Core\Environment;
 use SilverStripe\Dev\SapphireTest;
 
@@ -142,9 +142,8 @@ class EnvironmentTest extends SapphireTest
         $this->assertSame($expected, Environment::hasEnv($name));
 
         // unset the value
-        $reflectionEnv = new ReflectionProperty(Environment::class, 'env');
-        $reflectionEnv->setAccessible(true);
-        $reflectionEnv->setValue(array_diff($reflectionEnv->getValue(), [$name => $value]));
+        $reflectionEnv = new ReflectionClass(Environment::class);
+        $reflectionEnv->setStaticPropertyValue('env', array_diff($reflectionEnv->getStaticPropertyValue('env'), [$name => $value]));
         unset($_ENV[$name]);
         unset($_SERVER[$name]);
         putenv("$name");

--- a/tests/php/Core/ExtensionTest.php
+++ b/tests/php/Core/ExtensionTest.php
@@ -3,7 +3,7 @@
 namespace SilverStripe\Core\Tests;
 
 use BadMethodCallException;
-use ReflectionProperty;
+use ReflectionClass;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Tests\ExtensionTest\NamedExtension;
 use SilverStripe\Dev\SapphireTest;
@@ -15,9 +15,8 @@ class ExtensionTest extends SapphireTest
     {
         parent::setUp();
         // Reset extra_methods so that when we set NamedExtension to null it re-evaluates which methods are available
-        $reflectionProperty = new ReflectionProperty(DataObject::class, 'extra_methods');
-        $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue([]);
+        $reflectionClass = new ReflectionClass(DataObject::class);
+        $reflectionClass->setStaticPropertyValue('extra_methods', []);
         // Add named extension config like we would in yaml
         Config::modify()->merge(DataObject::class, 'extensions', ['NamedExtension' => NamedExtension::class]);
     }

--- a/tests/php/Logging/HTTPOutputHandlerTest.php
+++ b/tests/php/Logging/HTTPOutputHandlerTest.php
@@ -3,8 +3,8 @@
 namespace SilverStripe\Logging\Tests;
 
 use Monolog\Handler\HandlerInterface;
+use ReflectionClass;
 use ReflectionMethod;
-use ReflectionProperty;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\Deprecation;
@@ -156,8 +156,7 @@ class HTTPOutputHandlerTest extends SapphireTest
     ) {
         $reflectionShouldShow = new ReflectionMethod(HTTPOutputHandler::class, 'shouldShowError');
         $reflectionShouldShow->setAccessible(true);
-        $reflectionTriggeringError = new ReflectionProperty(Deprecation::class, 'isTriggeringError');
-        $reflectionTriggeringError->setAccessible(true);
+        $reflectionDeprecation = new ReflectionClass(Deprecation::class);
 
         $cliShouldShowOrig = Deprecation::shouldShowForCli();
         $httpShouldShowOrig = Deprecation::shouldShowForHttp();
@@ -171,7 +170,7 @@ class HTTPOutputHandlerTest extends SapphireTest
             Deprecation::setShouldShowForCli(true);
             Deprecation::setShouldShowForHttp($shouldShow);
         }
-        $reflectionTriggeringError->setValue($triggeringError);
+        $reflectionDeprecation->setStaticPropertyValue('isTriggeringError', $triggeringError);
 
         $mockHandler = $this->getMockBuilder(HTTPOutputHandler::class)->onlyMethods(['isCli'])->getMock();
         $mockHandler->method('isCli')->willReturn($isCli);
@@ -181,6 +180,6 @@ class HTTPOutputHandlerTest extends SapphireTest
 
         Deprecation::setShouldShowForCli($cliShouldShowOrig);
         Deprecation::setShouldShowForHttp($httpShouldShowOrig);
-        $reflectionTriggeringError->setValue($triggeringErrorOrig);
+        $reflectionDeprecation->setStaticPropertyValue('isTriggeringError', $triggeringErrorOrig);
     }
 }


### PR DESCRIPTION
See https://www.php.net/manual/en/migration83.deprecated.php about the deprecation
See https://www.php.net/manual/en/reflectionproperty.setvalue.php for the suggested solution

## Issues
- https://github.com/silverstripe/.github/issues/309