### PR TITLE
FIX Use correct contructor for HTTPOutputHandler

### DIFF
--- a/src/Logging/HTTPOutputHandler.php
+++ b/src/Logging/HTTPOutputHandler.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Logging;
 
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Level;
 use Monolog\LogRecord;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
@@ -34,9 +35,9 @@ class HTTPOutputHandler extends AbstractProcessingHandler
      */
     private $cliFormatter = null;
 
-    public function __construct()
+    public function __construct(int|string|Level $level = Level::Debug, bool $bubble = true)
     {
-        parent::__construct();
+        parent::__construct($level, $bubble);
         Deprecation::withNoReplacement(function () {
             Deprecation::notice(
                 '5.4.0',


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/305

Causes a [mass of output](https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/10915320005/job/30295436301) on graphql unit tests which call $logger->info() alot, because instead of passing the [injected 'notice' level](https://github.com/silverstripe/silverstripe-framework/blob/5/_config/logging.yml#L57), it uses the default 'debug' level instead.