### PR TITLE
NEW Validate DBFields

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -20,6 +20,8 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\ORM\FieldType\DBDecimal
   Double:
     class: SilverStripe\ORM\FieldType\DBDouble
+  Email:
+    class: SilverStripe\ORM\FieldType\DBEmail
   Enum:
     class: SilverStripe\ORM\FieldType\DBEnum
   Float:

--- a/src/Forms/EmailField.php
+++ b/src/Forms/EmailField.php
@@ -2,11 +2,18 @@
 
 namespace SilverStripe\Forms;
 
+use SilverStripe\Validation\EmailValidator;
+
 /**
- * Text input field with validation for correct email format according to RFC 2822.
+ * Text input field with validation for correct email format
  */
 class EmailField extends TextField
 {
+    private static array $field_validators = [
+        [
+            'class' => EmailValidator::class,
+        ],
+    ];
 
     protected $inputType = 'email';
     /**
@@ -15,39 +22,6 @@ class EmailField extends TextField
     public function Type()
     {
         return 'email text';
-    }
-
-    /**
-     * Validates for RFC 2822 compliant email addresses.
-     *
-     * @see http://www.regular-expressions.info/email.html
-     * @see http://www.ietf.org/rfc/rfc2822.txt
-     *
-     * @param Validator $validator
-     *
-     * @return string
-     */
-    public function validate($validator)
-    {
-        $result = true;
-        $this->value = trim($this->value ?? '');
-
-        $pattern = '^[a-z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$';
-
-        // Escape delimiter characters.
-        $safePattern = str_replace('/', '\\/', $pattern ?? '');
-
-        if ($this->value && !preg_match('/' . $safePattern . '/i', $this->value ?? '')) {
-            $validator->validationError(
-                $this->name,
-                _t('SilverStripe\\Forms\\EmailField.VALIDATION', 'Please enter an email address'),
-                'validation'
-            );
-
-            $result = false;
-        }
-
-        return $this->extendValidationResult($result, $validator);
     }
 
     public function getSchemaValidation()

--- a/src/Forms/TextField.php
+++ b/src/Forms/TextField.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\Forms;
 
+use SilverStripe\Validation\StringLengthValidator;
+
 /**
  * Text input field.
  */
@@ -13,6 +15,13 @@ class TextField extends FormField implements TippableFieldInterface
     protected $maxLength;
 
     protected $schemaDataType = FormField::SCHEMA_DATA_TYPE_TEXT;
+
+    private static array $field_validators = [
+        [
+            'class' => StringLengthValidator::class,
+            'argCalls' => [null, 'getMaxLength'],
+        ]
+    ];
 
     /**
      * @var Tip|null A tip to render beside the input
@@ -115,31 +124,6 @@ class TextField extends FormField implements TippableFieldInterface
         }
 
         return $data;
-    }
-
-    /**
-     * Validate this field
-     *
-     * @param Validator $validator
-     * @return bool
-     */
-    public function validate($validator)
-    {
-        $result = true;
-        if (!is_null($this->maxLength) && mb_strlen($this->value ?? '') > $this->maxLength) {
-            $name = strip_tags($this->Title() ? $this->Title() : $this->getName());
-            $validator->validationError(
-                $this->name,
-                _t(
-                    'SilverStripe\\Forms\\TextField.VALIDATEMAXLENGTH',
-                    'The value for {name} must not exceed {maxLength} characters in length',
-                    ['name' => $name, 'maxLength' => $this->maxLength]
-                ),
-                "validation"
-            );
-            $result = false;
-        }
-        return $this->extendValidationResult($result, $validator);
     }
 
     public function getSchemaValidation()

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -1230,6 +1230,15 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
     public function validate()
     {
         $result = ValidationResult::create();
+        // Call DBField::validate() on every DBField
+        $specs = static::getSchema()->fieldSpecs(static::class);
+        foreach (array_keys($specs) as $fieldName) {
+            $dbField = $this->dbObject($fieldName);
+            $validationResult = $dbField->validate();
+            if (!$validationResult->isValid()) {
+                $result->combineAnd($validationResult);
+            }
+        }
         $this->extend('updateValidate', $result);
         return $result;
     }

--- a/src/ORM/FieldType/DBEmail.php
+++ b/src/ORM/FieldType/DBEmail.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SilverStripe\ORM\FieldType;
+
+use SilverStripe\Forms\EmailField;
+use SilverStripe\ORM\FieldType\DBVarchar;
+use SilverStripe\Validation\EmailValidator;
+use SilverStripe\Forms\FormField;
+use SilverStripe\Forms\NullableField;
+
+class DBEmail extends DBVarchar
+{
+    private static array $field_validators = [
+        [
+            'class' => EmailValidator::class,
+        ],
+    ];
+
+    public function scaffoldFormField(?string $title = null, array $params = []): ?FormField
+    {
+        // Set field with appropriate size
+        $field = EmailField::create($this->name, $title);
+        $field->setMaxLength($this->getSize());
+
+        // Allow the user to select if it's null instead of automatically assuming empty string is
+        if (!$this->getNullifyEmpty()) {
+            return NullableField::create($field);
+        }
+        return $field;
+    }
+}

--- a/src/ORM/FieldType/DBVarchar.php
+++ b/src/ORM/FieldType/DBVarchar.php
@@ -8,6 +8,7 @@ use SilverStripe\Forms\NullableField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\Connect\MySQLDatabase;
 use SilverStripe\ORM\DB;
+use SilverStripe\Validation\StringLengthValidator;
 
 /**
  * Class Varchar represents a variable-length string of up to 255 characters, designed to store raw text
@@ -18,6 +19,13 @@ use SilverStripe\ORM\DB;
  */
 class DBVarchar extends DBString
 {
+    private static array $field_validators = [
+        [
+            'class' => StringLengthValidator::class,
+            'argCalls' => [null, 'getSize'],
+        ]
+    ];
+
     private static array $casting = [
         'Initial' => 'Text',
         'URL' => 'Text',

--- a/src/Validation/EmailValidator.php
+++ b/src/Validation/EmailValidator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SilverStripe\Validation;
+
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Validation\FieldValidator;
+use SilverStripe\Core\Validation\ConstraintValidator;
+use Symfony\Component\Validator\Constraints;
+use SilverStripe\Forms\FormField;
+use SilverStripe\ORM\FieldType\DBField;
+
+class EmailValidator extends FieldValidator
+{
+    protected function validateValue(ValidationResult $result): ValidationResult
+    {
+        $message = _t('SilverStripe\\Forms\\EmailField.VALIDATION', 'Please enter an email address');
+        $validationResult = ConstraintValidator::validate(
+            $this->value,
+            new Constraints\Email(message: $message),
+            $this->name
+        );
+        return $result->combineAnd($validationResult);
+    }
+}

--- a/src/Validation/FieldValidator.php
+++ b/src/Validation/FieldValidator.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SilverStripe\Validation;
+
+use RuntimeException;
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Forms\FormField;
+use SilverStripe\ORM\FieldType\DBField;
+use SilverStripe\Core\Injector\Injector;
+
+/**
+ * Abstract class that can be used as a validator for FormFields and DBFields
+ */
+abstract class FieldValidator
+{
+    protected string $name;
+    protected mixed $value;
+
+    public function __construct(string $name, mixed $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    public function validate(): ValidationResult
+    {
+        $result = ValidationResult::create();
+        $result = $this->validateValue($result);
+        return $result;
+    }
+
+    abstract protected function validateValue(ValidationResult $result): ValidationResult;
+
+    public static function createFieldValidatorsForField(
+        FormField|DBField $field,
+        string $name,
+        mixed $value
+    ): array {
+        $fieldValidators = [];
+        $config = $field->config()->get('field_validators');
+        foreach ($config as $spec) {
+            $class = $spec['class'];
+            $argCalls = $spec['argCalls'] ?? null;
+            if (!is_a($class, FieldValidator::class, true)) {
+                throw new RuntimeException("Class $class is not a FieldValidator");
+            }
+            $args = [$name, $value];
+            if (!is_null($argCalls)) {
+                if (!is_array($argCalls)) {
+                    throw new RuntimeException("argCalls for $class is not an array");
+                }
+                foreach ($argCalls as $i => $argCall) {
+                    if (!is_string($argCall) && !is_null($argCall)) {
+                        throw new RuntimeException("argCall $i for $class is not a string or null");
+                    }
+                    if ($argCall) {
+                        $args[] = call_user_func([$field, $argCall]);
+                    } else {
+                        $args[] = null;
+                    }
+                }
+            }
+            $fieldValidators[] = Injector::inst()->createWithArgs($class, $args);
+        }
+        return $fieldValidators;
+    }
+}

--- a/src/Validation/StringLengthValidator.php
+++ b/src/Validation/StringLengthValidator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SilverStripe\Validation;
+
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Validation\FieldValidator;
+
+class StringLengthValidator extends FieldValidator
+{
+    private ?int $minLength;
+    private ?int $maxLength;
+
+    public function __construct(string $name, mixed $value, ?int $minLength = null, ?int $maxLength = null)
+    {
+        parent::__construct($name, $value);
+        $this->minLength = $minLength;
+        $this->maxLength = $maxLength;
+    }
+
+    protected function validateValue(ValidationResult $result): ValidationResult
+    {
+        if (!is_null($this->maxLength) && mb_strlen($this->value ?? '') > $this->maxLength) {
+            $message = _t(
+                'SilverStripe\\Forms\\TextField.VALIDATEMAXLENGTH',
+                'The value for {name} must not exceed {maxLength} characters in length',
+                ['name' => $this->name, 'maxLength' => $this->maxLength]
+            );
+            $result->addFieldError($this->name, $message);
+        }
+        // TODO: minlength check
+        return $result;
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11391

All DBFields will be automatically validated on save

Creates a new FieldsValidator class that can be used in both FormField's and DBField's

Fields validators are defined for those classes via config on those classes

```php
private static array $field_validators = [
    [
        'class' => MyFieldValidator::class,
        'argCalls' => [null, 'getSomeValue'],
    ],
];
```

Where `argCalls` is an optional array of public methods to call on the $field to populate constructor args passed to the FieldValidator beyond the default $name + $value.

As they're a array defined in config, they are composable so subclasses can add additional FieldValidators

This is demonstrated with both:
- DBEmail extends DBVarchar extends DBField
- EmailField extends TextField extends FormField

Both DBEmail + Email field have an EmailValidator, and both DBVarchar and TextField have a StringLengthValidator

You can see this in action with `private static $db = [ 'MyEmail' => 'Email(7)' ]` which will create the new DBEmail field as a varchar(7) in the database.

If submit the form / make an API request, the email will be validated server side that it's both an email, and have a length less than or equal to 7 (JS validation will prevent entering a length greater than 7, though you can inspect the input element and change the value to bypass this).

This work is would go a long way to support future API work, where there's no form field validation and no JS to stop you from entering more than 7 characters. This new system would when making an API request would throw a ValidationException rather than allow you to save invalid emails that get truncated because they're too long.  Within a CMS context however it does mean that there's double validation on both the scaffolded EmailField, and the DBEmail, though I think this will have essentially no real world downside.

## Performance impact

As we are now validating all DBField's on DataObject::write(), most notably enforcing varchar limits, we need to be mindful of any performance impacts. Based on some quick testing it looks like the performance impact is tiny and not worth worrying about.

I tested on my laptop by putting a for loop of 1000 iterations around the DBField validation in DataObject::write() and timing it. I then created a DataObject with 10 varchars, and a model admin to manage it. I created and saved a new record, so while there were 10 new varchar fields, they had no data in them

0.1366 seconds / 14000 DBField validations

(4000 of those iterations will be from the ID/ClassName/LastEdited/Created fields

I then put in a value for the 10x varchar fields and saved again

0.2438 seconds / 14000 DBField validations

So even when bulk creating a large number of records, there isn't much performance impact. When saving a single record the performance impact won't be noticeable.

## MySQL strict mode and data truncation

MySQL behaves differently depending if strict mode is enabled or not, which means either `STRICT_TRANS_TABLES` or `STRICT_ALL_TABLES` is enabled. This can be seen by running `SELECT @@sql_mode;`

When I connect to mysql via terminal it's in strict mode - `STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION`

When I go `insert into MyDataObject (Email7) values ('123456789');` I get `ERROR 1406 (22001): Data too long for column 'Email7' at row 1`

When I run `DB::query('SELECT @@sql_mode')->value();` It's not in strict mode `REAL_AS_FLOAT,PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,ANSI`

When I go `MyDataObject::create(['Email7' => '1234567890'])->write();` it's created the record with Email7 truncated to "1234567"

We can't give any guarantees around whether a websites particular setup will have strict mode enabled or not, so it seems like we should be enforcing varchar limits in the ORM

## Config array

Re the config - I've gone with the kind of weird double array for maximum composability. Some other options:

```php
private static array $field_validators = [
    // A) no argCalls, int index
    MyFieldValidator::class,
    // B) no argCalls, string index. string index means you cannot have two of the same class
    MyFieldValidator::class => [], 
    // C) argCalls, string index
    MyFieldValidator::class => [null, 'getSomeValue'],
    // D) string index, no change of collision, looks ugly though
    __CLASS__ . '.' . MyFieldValidator::class => [],
]
```

The chance of collisions is probably really low, so changing it so instead we have both A) and C) is probably fine, or B) and C) meaning an 'argCalls' array must always be present for consistency

## Other notes

- I did not create the `private static array $required = [];` to replace RequiredFields in this PR, though I think that's worth doing separately
