### PR TITLE
MNT Update phpunit xml file for phpunit 11

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,38 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-Standard module phpunit configuration.
-Requires PHPUnit ^9
--->
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
-    <testsuites>
-        <testsuite name="Default">
-            <directory>tests/php</directory>
-        </testsuite>
-        <!-- Framework ORM tests are split up to run in parallel -->
-        <testsuite name="framework-core">
-            <directory>tests/php</directory>
-            <exclude>
-                <directory>tests/php/ORM</directory>
-            </exclude>
-        </testsuite>
-        <testsuite name="framework-orm">
-            <directory>tests/php/ORM</directory>
-        </testsuite>
-        <testsuite name="cms">
-            <directory>vendor/silverstripe/cms/tests</directory>
-        </testsuite>
-        <!-- Cache suite is separate so it only runs what it needs to run. Intentionally also included in core above. -->
-        <testsuite name="framework-cache-only">
-            <directory>tests/php/Core/Cache</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">.</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-                <directory suffix=".php">thirdparty/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd">
+  <testsuites>
+    <testsuite name="Default">
+      <directory>tests/php</directory>
+    </testsuite>
+    <!-- Framework ORM tests are split up to run in parallel in github actions CI -->
+    <testsuite name="framework-core">
+      <!-- Will be run in github actions CI with option exclude-filter /ORM/ -->
+      <directory>tests/php</directory>
+    </testsuite>
+    <testsuite name="framework-orm">
+      <!-- Will be run in github actions CI with option filter /ORM/ -->
+      <directory>tests/php</directory>
+    </testsuite>
+    <!-- Cache suite is separate so it only runs what it needs to run -->
+    <testsuite name="framework-cache-only">
+      <directory>tests/php/Core/Cache</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">.</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">tests/</directory>
+      <directory suffix=".php">thirdparty/</directory>
+    </exclude>
+  </source>
 </phpunit>


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11406

Needs https://github.com/silverstripe/gha-run-tests/pull/40 merged and tagged first

phpunit xml file needs to be different for phpunit 11. Notably `<exclude>` can no longer be in `<directory>`

I tried this novel approach to mimic exclude, though it doesn't work

```
      <directory>tests/php</directory>
      <!-- Exclude ORM tests from core suite by requiring PHP version 99 or above -->
      <directory phpVersion="99.0.0" phpVersionOperator=">=">tests/php/ORM</directory>
```

Since there's no way to actually exclude a subdirectory anymore via the xml file, I think we need to filter the testsuites in github actions. The other option is to move ORM tests into a totally different location, though I don't want to do that

I also ran the `--migrate-configuration` flag when running phpunit 11 to automatically fix another xml issue. Note that when running this it adds a `cacheDirectory=".phpunit.cache"` attribute which we do not want as this causes a cache dir in the root folder to be added which we don't want, so delete this attribute if running this on other modules. The xml file is valid without the cacheDirectory attribute

