### PR TITLE
NEW Validate DBFields

### DIFF
--- a/_config/model.yml
+++ b/_config/model.yml
@@ -20,6 +20,8 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\ORM\FieldType\DBDecimal
   Double:
     class: SilverStripe\ORM\FieldType\DBDouble
+  Email:
+    class: SilverStripe\ORM\FieldType\DBEmail
   Enum:
     class: SilverStripe\ORM\FieldType\DBEnum
   Float:
@@ -36,6 +38,8 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\ORM\FieldType\DBHTMLVarchar
   Int:
     class: SilverStripe\ORM\FieldType\DBInt
+  IP:
+    class: SilverStripe\ORM\FieldType\DBIp
   BigInt:
     class: SilverStripe\ORM\FieldType\DBBigInt
   Locale:
@@ -58,6 +62,8 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\ORM\FieldType\DBText
   Time:
     class: SilverStripe\ORM\FieldType\DBTime
+  URL:
+    class: SilverStripe\ORM\FieldType\DBUrl
   Varchar:
     class: SilverStripe\ORM\FieldType\DBVarchar
   Year:

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "symfony/dom-crawler": "^7.0",
         "symfony/filesystem": "^7.0",
         "symfony/http-foundation": "^7.0",
+        "symfony/intl": "^7.0",
         "symfony/mailer": "^7.0",
         "symfony/mime": "^7.0",
         "symfony/translation": "^7.0",

--- a/src/Core/Validation/FieldValidation/BigIntFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/BigIntFieldValidator.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use RunTimeException;
+use SilverStripe\Core\Validation\FieldValidation\IntFieldValidator;
+use SilverStripe\Core\Validation\ValidationResult;
+
+/**
+ * A field validator for 64-bit integers
+ * Will throw a RunTimeException if used on a 32-bit system
+ */
+class BigIntFieldValidator extends IntFieldValidator
+{
+    /**
+     * The minimum value for a signed 64-bit integer.
+     * Defined as string instead of int otherwise will end up as a float
+     * on 64-bit systems
+     *
+     * When this is cast to an int in IntFieldValidator::__construct()
+     * it will be properly cast to an int
+     */
+    protected const MIN_INT = '-9223372036854775808';
+
+    /**
+     * The maximum value for a signed 64-bit integer.
+     */
+    protected const MAX_INT = '9223372036854775807';
+
+    public function __construct(
+        string $name,
+        mixed $value,
+        ?int $minValue = null,
+        ?int $maxValue = null
+    ) {
+        if (is_null($minValue) || is_null($maxValue)) {
+            $bits = strlen(decbin(~0));
+            if ($bits === 32) {
+                throw new RunTimeException('Cannot use BigIntFieldValidator on a 32-bit system');
+            }
+        }
+        $this->minValue = $minValue;
+        $this->maxValue = $maxValue;
+        parent::__construct($name, $value, $minValue, $maxValue);
+    }
+
+    protected function validateValue(): ValidationResult
+    {
+        $result = ValidationResult::create();
+        // Validate string values that are too large or too small
+        // Only testing for string values here as that's all bccomp can take as arguments
+        // int values that are too large or too small will be cast to float
+        // on 64-bit systems and will fail the validation in IntFieldValidator
+        if (is_string($this->value)) {
+            if (!is_null($this->minValue) && bccomp($this->value, static::MIN_INT) === -1) {
+                $result->addFieldError($this->name, $this->getTooSmallMessage());
+            }
+            if (!is_null($this->maxValue) && bccomp($this->value, static::MAX_INT) === 1) {
+                $result->addFieldError($this->name, $this->getTooLargeMessage());
+            }
+        }
+        $result->combineAnd(parent::validateValue());
+        return $result;
+    }
+}

--- a/src/Core/Validation/FieldValidation/BooleanFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/BooleanFieldValidator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Core\Validation\FieldValidation\FieldValidator;
+
+/**
+ * Validates that a value is a boolean
+ */
+class BooleanFieldValidator extends FieldValidator
+{
+    protected function validateValue(): ValidationResult
+    {
+        $result = ValidationResult::create();
+        if (!is_bool($this->value)) {
+            $message = _t(__CLASS__ . '.INVALID', 'Invalid value');
+            $result->addFieldError($this->name, $message);
+        }
+        return $result;
+    }
+}

--- a/src/Core/Validation/FieldValidation/CompositeFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/CompositeFieldValidator.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use InvalidArgumentException;
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Core\Validation\FieldValidation\FieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\FieldValidationInterface;
+
+/**
+ * A field validator used to validate DBComposite fields
+ */
+class CompositeFieldValidator extends FieldValidator
+{
+    /**
+     * @param mixed $value - an iterable list of FieldValidators
+     */
+    public function __construct(string $name, mixed $value)
+    {
+        parent::__construct($name, $value);
+        if (!is_iterable($value)) {
+            throw new InvalidArgumentException('Value must be iterable');
+        }
+        foreach ($value as $child) {
+            if (!is_a($child, FieldValidationInterface::class)) {
+                throw new InvalidArgumentException('Child is not a' . FieldValidationInterface::class);
+            }
+        }
+    }
+
+    protected function validateValue(): ValidationResult
+    {
+        $result = ValidationResult::create();
+        foreach ($this->value as $child) {
+            $result->combineAnd($child->validate());
+        }
+        return $result;
+    }
+}

--- a/src/Core/Validation/FieldValidation/DateFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/DateFieldValidator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use SilverStripe\Core\Validation\FieldValidation\FieldValidator;
+use SilverStripe\Core\Validation\ValidationResult;
+
+/**
+ * Validates that a value is a valid date, which means that it follows the equivalent formats:
+ * - PHP date format Y-m-d
+ * - SO format y-MM-dd i.e. DBDate::ISO_DATE
+ *
+ * Blank string values are allowed
+ */
+class DateFieldValidator extends FieldValidator
+{
+    protected function validateValue(): ValidationResult
+    {
+        $result = ValidationResult::create();
+        // Allow empty strings
+        if ($this->value === '') {
+            return $result;
+        }
+        // Not using symfony/validator because it was allowing d-m-Y format strings
+        $date = date_parse_from_format($this->getFormat(), $this->value ?? '');
+        if ($date === false || $date['error_count'] > 0 || $date['warning_count'] > 0) {
+            $result->addFieldError($this->name, $this->getMessage());
+        }
+        return $result;
+    }
+
+    protected function getFormat(): string
+    {
+        return 'Y-m-d';
+    }
+
+    protected function getMessage(): string
+    {
+        return _t(__CLASS__ . '.INVALID', 'Invalid date');
+    }
+}

--- a/src/Core/Validation/FieldValidation/DatetimeFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/DatetimeFieldValidator.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use SilverStripe\Core\Validation\FieldValidation\DateFieldValidator;
+
+/**
+ * Validates that a value is a valid date/time, which means that it follows the equivalent formats:
+ * - PHP date format Y-m-d H:i:s
+ * - ISO format 'y-MM-dd HH:mm:ss' i.e. DBDateTime::ISO_DATETIME
+ *
+ * Blank string values are allowed
+ */
+class DatetimeFieldValidator extends DateFieldValidator
+{
+    protected function getFormat(): string
+    {
+        return 'Y-m-d H:i:s';
+    }
+
+    protected function getMessage(): string
+    {
+        return _t(__CLASS__ . '.INVALID', 'Invalid date/time');
+    }
+}

--- a/src/Core/Validation/FieldValidation/DecimalFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/DecimalFieldValidator.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Core\Validation\FieldValidation\NumericFieldValidator;
+
+/**
+ * Validates that a value is a valid decimal
+ * This intended for use when validating that a value can be stored in a database as a decimal
+ *
+ * Example of how digits are stored in the database
+ * Decimal(5,2) is allowed a total of 5 digits, and will always round to 2 decimal places
+ * This means it has a maximum 3 digits before the decimal point
+ *
+ * Valid
+ * 123.99
+ * 999.99
+ * -999.99
+ * 123.999 - will round to 124.00
+ *
+ * Not valid
+ * 1234.9 - 4 digits the before the decimal point
+ * 999.999 - would be rounded to 1000.00 which exceeds 5 total digits
+ */
+class DecimalFieldValidator extends NumericFieldValidator
+{
+    /**
+     * Whole number size e.g. For Decimal(9,2) this would be 9
+     */
+    private int $wholeSize;
+
+    /**
+     * Decimal size e.g. For Decimal(5,2) this would be 2
+     */
+    private int $decimalSize;
+
+    public function __construct(
+        string $name,
+        mixed $value,
+        int $wholeSize,
+        int $decimalSize,
+        int $minValue = null,
+        int $maxValue = null,
+    ) {
+        parent::__construct($name, $value, $minValue, $maxValue);
+        $this->wholeSize = $wholeSize;
+        $this->decimalSize = $decimalSize;
+    }
+
+    protected function validateValue(): ValidationResult
+    {
+        $result = parent::validateValue();
+        if (!$result->isValid()) {
+            return $result;
+        }
+        // Convert to absolute value - the minus sign is not relevant for validation
+        $absValue = abs($this->value);
+        // Round to the decimal size which is what the database will do
+        $rounded = round($absValue, $this->decimalSize);
+        // Get formatted as a string, which will right pad with zeros to the decimal size
+        $rounded = number_format($rounded, $this->decimalSize, thousands_separator: '');
+        // Count this number of digits - the minus 1 is for the decimal point
+        $digitCount = strlen((string) $rounded) - 1;
+        if ($digitCount > $this->wholeSize) {
+            $message = _t(
+                __CLASS__ . '.TOOLARGE',
+                'Cannot have more than {wholeSize} digits which includes {decimalSize} decimal places',
+                [
+                    'wholeSize' => $this->wholeSize,
+                    'decimalSize' => $this->decimalSize
+                ]
+            );
+            $result->addFieldError($this->name, $message);
+        }
+        return $result;
+    }
+}

--- a/src/Core/Validation/FieldValidation/EmailFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/EmailFieldValidator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Email;
+use SilverStripe\Core\Validation\FieldValidation\StringFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\SymfonyFieldValidatorTrait;
+use SilverStripe\Core\Validation\FieldValidation\SymfonyFieldValidatorInterface;
+
+/**
+ * Validates that a value is a valid email address
+ * Uses Symfony's Email constraint to validate
+ */
+class EmailFieldValidator extends StringFieldValidator implements SymfonyFieldValidatorInterface
+{
+    use SymfonyFieldValidatorTrait;
+
+    public function getConstraint(): Constraint|array
+    {
+        $message =  _t(__CLASS__ . '.INVALID', 'Invalid email address');
+        return new Email(message: $message);
+    }
+}

--- a/src/Core/Validation/FieldValidation/FieldValidationInterface.php
+++ b/src/Core/Validation/FieldValidation/FieldValidationInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use SilverStripe\Core\Validation\ValidationInterface;
+
+/**
+ * Interface for fields e.g. a DBField or FormField, that can use FieldValidator's
+ * Intended for use on classes that have the FieldValidationTrait applied
+ */
+interface FieldValidationInterface extends ValidationInterface
+{
+    public function getName(): string;
+
+    public function getValue(): mixed;
+
+    public function getValueForValidation(): mixed;
+}

--- a/src/Core/Validation/FieldValidation/FieldValidationTrait.php
+++ b/src/Core/Validation/FieldValidation/FieldValidationTrait.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use RuntimeException;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Validation\FieldValidation\FieldValidationInterface;
+use SilverStripe\Core\Validation\ValidationResult;
+
+/**
+ * Trait to add FieldValidator validation to a field, e.g. a DBField or FormField
+ * The field must implement FieldValidationInterface
+ */
+trait FieldValidationTrait
+{
+    use Configurable;
+
+    /**
+     * FieldValidators configuration for the field
+     *
+     * Each item in the array can be one of the following
+     * a) MyFieldValidator::class,
+     * b) MyFieldValidator::class => [null, 'getSomething'],
+     * c) MyFieldValidator::class => null,
+     *
+     * a) Will create a MyFieldValidator and pass the name and value of the field as args to the constructor
+     * b) Will create a MyFieldValidator and pass the name, value, and pass additional args, where each null values
+     *    will be passed as null, and non-null values will call a method on the field e.g. will pass null for the first
+     *    additional arg and call $field->getSomething() to get a value for the second additional arg
+     * c) Will disable a previously set MyFieldValidator. This is useful to disable a FieldValidator that was set
+     *    on a parent class
+     *
+     * You may only have a single instance of a given FieldValidator class per field, e.g. you can't have two
+     * instances of a `MyFieldValidator` class for the same field.
+     */
+    private static array $field_validators = [];
+
+    /**
+     * Validate this field using FieldValidators
+     */
+    public function validate(): ValidationResult
+    {
+        $result = ValidationResult::create();
+        $fieldValidators = $this->getFieldValidators();
+        foreach ($fieldValidators as $fieldValidator) {
+            $result->combineAnd($fieldValidator->validate());
+        }
+        return $result;
+    }
+
+    /**
+     * Get instantiated FieldValidators based on `field_validators` configuration
+     */
+    private function getFieldValidators(): array
+    {
+        $fieldValidators = [];
+        // Used to disable a validator that was previously set with an int index
+        if (!is_a($this, FieldValidationInterface::class)) {
+            $message = get_class($this) . ' must implement interface ' . FieldValidationInterface::class;
+            throw new RuntimeException($message);
+        }
+        /** @var FieldValidationInterface|Configurable $this */
+        $name = $this->getName();
+        $value = $this->getValueForValidation();
+        // Field name is required for FieldValidators when called ValidationResult::addFieldMessage()
+        if ($name === '') {
+            throw new RuntimeException('Field name is blank');
+        }
+        $classes = $this->getClassesFromConfig();
+        foreach ($classes as $class => $argCalls) {
+            $args = [$name, $value];
+            foreach ($argCalls as $i => $argCall) {
+                if (is_null($argCall)) {
+                    $args[] = null;
+                    continue;
+                }
+                if (!is_string($argCall)) {
+                    throw new RuntimeException("argCall $i for FieldValidator $class is not a string or null");
+                }
+                if (!$this->hasMethod($argCall)) {
+                    throw new RuntimeException("Method $argCall does not exist on " . get_class($this));
+                }
+                $args[] = call_user_func([$this, $argCall]);
+            }
+            $fieldValidators[] = Injector::inst()->createWithArgs($class, $args);
+        }
+        return $fieldValidators;
+    }
+
+    /**
+     * Get FieldValidator classes based on `field_validators` configuration
+     */
+    private function getClassesFromConfig(): array
+    {
+        $classes = [];
+        $disabledClasses = [];
+        $config = static::config()->get('field_validators');
+        foreach ($config as $indexOrClass => $classOrArgCallsOrDisable) {
+            $class = '';
+            $argCalls = [];
+            $disable = false;
+            if (is_int($indexOrClass)) {
+                $class = $classOrArgCallsOrDisable;
+            } else {
+                $class = $indexOrClass;
+                $argCalls = $classOrArgCallsOrDisable;
+                $disable = $classOrArgCallsOrDisable === null;
+            }
+            if ($disable) {
+                // Disabling a class that was previously defined
+                $disabledClasses[$class] = true;
+                continue;
+            } else {
+                if (isset($disabledClasses[$class])) {
+                    unset($disabledClasses[$class]);
+                }
+            }
+            if (!is_a($class, FieldValidator::class, true)) {
+                throw new RuntimeException("Class $class is not a FieldValidator");
+            }
+            if (!is_array($argCalls)) {
+                throw new RuntimeException("argCalls for FieldValidator $class is not an array");
+            }
+            // array_unique() is used to dedupe any cases where a subclass defines the same FieldValidator
+            // this config can happens when a subclass defines a FieldValidator that was already defined on a parent
+            // class, though it calls different methods
+            $argCalls = array_unique($argCalls);
+            $classes[$class] = $argCalls;
+        }
+        foreach (array_keys($disabledClasses) as $class) {
+            unset($classes[$class]);
+        }
+        return $classes;
+    }
+}

--- a/src/Core/Validation/FieldValidation/FieldValidator.php
+++ b/src/Core/Validation/FieldValidation/FieldValidator.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Core\Validation\ValidationInterface;
+
+/**
+ * Abstract class that can be used as a FieldValidator for FormFields and DBFields
+ */
+abstract class FieldValidator implements ValidationInterface
+{
+    /**
+     * The name of the field being validated
+     */
+    protected string $name;
+
+    /**
+     * The value to validate
+     */
+    protected mixed $value;
+
+    /**
+     * Whether null is considered a valid value
+     */
+    protected bool $allowNull = true;
+
+    public function __construct(string $name, mixed $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    /**
+     * Validate the value
+     */
+    public function validate(): ValidationResult
+    {
+        $result = ValidationResult::create();
+        if (is_null($this->value) && $this->allowNull) {
+            return $result;
+        }
+        $result->combineAnd($this->validateValue());
+        return $result;
+    }
+
+    /**
+     * Inner validation method that performs the actual validation logic
+     */
+    abstract protected function validateValue(): ValidationResult;
+}

--- a/src/Core/Validation/FieldValidation/IntFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/IntFieldValidator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Core\Validation\FieldValidation\NumericFieldValidator;
+
+/**
+ * Validates that a value is a 32-bit signed integer
+ */
+class IntFieldValidator extends NumericFieldValidator
+{
+    /**
+     * The minimum value for a signed 32-bit integer.
+     * Defined as string instead of int because be cast to a float
+     * on 32-bit systems if defined as an int
+     */
+    protected const MIN_INT = '-2147483648';
+
+    /**
+     * The maximum value for a signed 32-bit integer.
+     */
+    protected const MAX_INT = '2147483647';
+
+    public function __construct(
+        string $name,
+        mixed $value,
+        ?int $minValue = null,
+        ?int $maxValue = null
+    ) {
+        if (is_null($minValue)) {
+            $minValue = (int) static::MIN_INT;
+        }
+        if (is_null($maxValue)) {
+            $maxValue = (int) static::MAX_INT;
+        }
+        parent::__construct($name, $value, $minValue, $maxValue);
+    }
+
+    protected function validateValue(): ValidationResult
+    {
+        $result = ValidationResult::create();
+        if (!is_int($this->value)) {
+            $message = _t(__CLASS__ . '.WRONGTYPE', 'Must be an integer');
+            $result->addFieldError($this->name, $message);
+        }
+        if (!$result->isValid()) {
+            return $result;
+        }
+        $result->combineAnd(parent::validateValue());
+        return $result;
+    }
+}

--- a/src/Core/Validation/FieldValidation/IpFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/IpFieldValidator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Ip;
+use SilverStripe\Core\Validation\FieldValidation\StringFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\SymfonyFieldValidatorTrait;
+use SilverStripe\Core\Validation\FieldValidation\SymfonyFieldValidatorInterface;
+
+/**
+ * Validates that a value is a valid IP address
+ * Uses Symfony's Ip constraint to validate
+ */
+class IpFieldValidator extends StringFieldValidator implements SymfonyFieldValidatorInterface
+{
+    use SymfonyFieldValidatorTrait;
+
+    public function getConstraint(): Constraint|array
+    {
+        $message =  _t(__CLASS__ . '.INVALID', 'Invalid IP address');
+        return new Ip(
+            version: Ip::ALL,
+            message: $message
+        );
+    }
+}

--- a/src/Core/Validation/FieldValidation/LocaleFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/LocaleFieldValidator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Locale;
+use SilverStripe\Core\Validation\FieldValidation\StringFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\SymfonyFieldValidatorTrait;
+use SilverStripe\Core\Validation\FieldValidation\SymfonyFieldValidatorInterface;
+
+/**
+ * Validates that a value is a valid locale
+ * Uses Symfony's Locale constraint to validate
+ */
+class LocaleFieldValidator extends StringFieldValidator implements SymfonyFieldValidatorInterface
+{
+    use SymfonyFieldValidatorTrait;
+
+    public function getConstraint(): Constraint|array
+    {
+        $message =  _t(__CLASS__ . '.INVALID', 'Invalid locale');
+        return new Locale(message: $message, canonicalize: false);
+    }
+}

--- a/src/Core/Validation/FieldValidation/MultiOptionFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/MultiOptionFieldValidator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use InvalidArgumentException;
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Core\Validation\FieldValidation\OptionFieldValidator;
+
+/**
+ * Validates that that all values are one of a set of options
+ */
+class MultiOptionFieldValidator extends OptionFieldValidator
+{
+    /**
+     * @param mixed $value - an array of values to be validated
+     */
+    public function __construct(string $name, mixed $value, array $options)
+    {
+        if (!is_iterable($value) && !is_null($value)) {
+            throw new InvalidArgumentException('Value must be iterable');
+        }
+        parent::__construct($name, $value, $options);
+    }
+
+    protected function validateValue(): ValidationResult
+    {
+        $result = ValidationResult::create();
+        foreach ($this->value as $value) {
+            $this->checkValueInOptions($value, $result);
+        }
+        return $result;
+    }
+}

--- a/src/Core/Validation/FieldValidation/NumericFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/NumericFieldValidator.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Core\Validation\FieldValidation\FieldValidator;
+use InvalidArgumentException;
+
+/**
+ * Validates that a value is a numeric value
+ * Optionally, can also check that the value is within a certain range
+ */
+class NumericFieldValidator extends FieldValidator
+{
+    /**
+     * Minimum size of the number
+     */
+    protected ?int $minValue;
+
+    /**
+     * Maximum size of the number
+     */
+    protected ?int $maxValue;
+
+    public function __construct(
+        string $name,
+        mixed $value,
+        ?int $minValue = null,
+        ?int $maxValue = null
+    ) {
+        if (!is_null($minValue) && !is_null($maxValue) && $maxValue < $minValue) {
+            throw new InvalidArgumentException('maxValue cannot be less than minValue');
+        }
+        $this->minValue = $minValue;
+        $this->maxValue = $maxValue;
+        parent::__construct($name, $value);
+    }
+
+    protected function validateValue(): ValidationResult
+    {
+        $result = ValidationResult::create();
+        if (!is_numeric($this->value) || is_string($this->value)) {
+            // Must be a numeric value, though not as a numeric string
+            $message = _t(__CLASS__ . '.WRONGTYPE', 'Must be numeric, and not a string');
+            $result->addFieldError($this->name, $message);
+        } elseif (!is_null($this->minValue) && $this->value < $this->minValue) {
+            $result->addFieldError($this->name, $this->getTooSmallMessage());
+        } elseif (!is_null($this->maxValue) && $this->value > $this->maxValue) {
+            $result->addFieldError($this->name, $this->getTooLargeMessage());
+        }
+        return $result;
+    }
+
+    protected function getTooSmallMessage(): string
+    {
+        return _t(
+            __CLASS__ . '.TOOSMALL',
+            'Value cannot be less than {minValue}',
+            ['minValue' => $this->minValue]
+        );
+    }
+
+    protected function getTooLargeMessage(): string
+    {
+        return _t(
+            __CLASS__ . '.TOOLARGE',
+            'Value cannot be greater than {maxValue}',
+            ['maxValue' => $this->maxValue]
+        );
+    }
+}

--- a/src/Core/Validation/FieldValidation/OptionFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/OptionFieldValidator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Core\Validation\FieldValidation\FieldValidator;
+
+/**
+ * Validates that a value is one of a set of options
+ */
+class OptionFieldValidator extends FieldValidator
+{
+    /**
+     * A list of allowed values
+     */
+    protected array $options;
+
+    public function __construct(string $name, mixed $value, array $options)
+    {
+        parent::__construct($name, $value);
+        $this->options = $options;
+    }
+
+    protected function validateValue(): ValidationResult
+    {
+        $result = ValidationResult::create();
+        $this->checkValueInOptions($this->value, $result);
+        return $result;
+    }
+
+    protected function checkValueInOptions(mixed $value, ValidationResult $result): void
+    {
+        if (!in_array($value, $this->options, true)) {
+            $message = _t(__CLASS__ . '.NOTALLOWED', 'Not an allowed value');
+            $result->addFieldError($this->name, $message);
+        }
+    }
+}

--- a/src/Core/Validation/FieldValidation/StringFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/StringFieldValidator.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use InvalidArgumentException;
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Core\Validation\FieldValidation\FieldValidator;
+
+/**
+ * Validates that a value is a string and optionally checks its multi-byte length.
+ */
+class StringFieldValidator extends FieldValidator
+{
+    /**
+     * The minimum length of the string
+     */
+    private ?int $minLength;
+
+    /**
+     * The maximum length of the string
+     */
+    private ?int $maxLength;
+
+    public function __construct(
+        string $name,
+        mixed $value,
+        ?int $minLength = null,
+        ?int $maxLength = null
+    ) {
+        parent::__construct($name, $value);
+        if (!is_null($minLength) && $minLength < 0) {
+            throw new InvalidArgumentException('minLength must be greater than or equal to 0');
+        }
+        if (!is_null($maxLength) && $maxLength < 0) {
+            throw new InvalidArgumentException('maxLength must be greater than or equal to 0');
+        }
+        if (!is_null($minLength) && !is_null($maxLength) && $maxLength < $minLength) {
+            throw new InvalidArgumentException('maxLength must be greater than or equal to minLength');
+        }
+        $this->minLength = $minLength;
+        $this->maxLength = $maxLength;
+    }
+
+    protected function validateValue(): ValidationResult
+    {
+        $result = ValidationResult::create();
+        if (!is_string($this->value)) {
+            $message = _t(__CLASS__ . '.WRONGTYPE', 'Must be a string');
+            $result->addFieldError($this->name, $message);
+            return $result;
+        }
+        $len = mb_strlen($this->value);
+        if (!is_null($this->minLength) && $len < $this->minLength) {
+            $message = _t(
+                __CLASS__ . '.TOOSHORT',
+                'Must have at least {minLength} characters',
+                ['minLength' => $this->minLength]
+            );
+            $result->addFieldError($this->name, $message);
+        }
+        if (!is_null($this->maxLength) && $len > $this->maxLength) {
+            $message = _t(
+                __CLASS__ . '.TOOLONG',
+                'Can not have more than {maxLength} characters',
+                ['maxLength' => $this->maxLength]
+            );
+            $result->addFieldError($this->name, $message);
+        }
+        return $result;
+    }
+}

--- a/src/Core/Validation/FieldValidation/SymfonyFieldValidatorInterface.php
+++ b/src/Core/Validation/FieldValidation/SymfonyFieldValidatorInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Interface for FieldValidators which validate using Symfony constraints
+ */
+interface SymfonyFieldValidatorInterface
+{
+    /**
+     * Get the Symfony constraint to validate against
+     * Can return either a single constraint or an array of constraints
+     */
+    public function getConstraint(): Constraint|array;
+}

--- a/src/Core/Validation/FieldValidation/SymfonyFieldValidatorTrait.php
+++ b/src/Core/Validation/FieldValidation/SymfonyFieldValidatorTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use LogicException;
+use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Core\Validation\ConstraintValidator;
+use SilverStripe\Core\Validation\FieldValidation\SymfonyFieldValidatorInterface;
+
+/**
+ * Trait for FieldValidators which validate using Symfony constraints
+ */
+trait SymfonyFieldValidatorTrait
+{
+    protected function validateValue(): ValidationResult
+    {
+        if (!is_a($this, SymfonyFieldValidatorInterface::class)) {
+            $message = 'Classes using SymfonyFieldValidatorTrait must implement SymfonyFieldValidatorInterface';
+            throw new LogicException($message);
+        }
+        $result = parent::validateValue();
+        if (!$result->isValid()) {
+            return $result;
+        }
+        $constraint = $this->getConstraint();
+        $validationResult = ConstraintValidator::validate($this->value, $constraint, $this->name);
+        return $result->combineAnd($validationResult);
+    }
+}

--- a/src/Core/Validation/FieldValidation/TimeFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/TimeFieldValidator.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use SilverStripe\Core\Validation\FieldValidation\DateFieldValidator;
+
+/**
+ * Validates that a value is a valid time, which means that it follows the equivalent formats:
+ * - PHP date format H:i:s
+ * - ISO format 'HH:mm:ss' i.e. DBTime::ISO_TIME
+ *
+ * Blank string values are allowed
+ */
+class TimeFieldValidator extends DateFieldValidator
+{
+    protected function getFormat(): string
+    {
+        return 'H:i:s';
+    }
+
+    protected function getMessage(): string
+    {
+        return _t(__CLASS__ . '.INVALID', 'Invalid time');
+    }
+}

--- a/src/Core/Validation/FieldValidation/UrlFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/UrlFieldValidator.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Url;
+use SilverStripe\Core\Validation\FieldValidation\StringFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\SymfonyFieldValidatorTrait;
+use SilverStripe\Core\Validation\FieldValidation\SymfonyFieldValidatorInterface;
+
+/**
+ * Validates that a value is a valid URL
+ * Uses Symfony's Url constraint to validate
+ */
+class UrlFieldValidator extends StringFieldValidator implements SymfonyFieldValidatorInterface
+{
+    use SymfonyFieldValidatorTrait;
+
+    public function getConstraint(): Constraint|array
+    {
+        $message =  _t(__CLASS__ . '.INVALID', 'Invalid URL');
+        return new Url(message: $message);
+    }
+}

--- a/src/Core/Validation/FieldValidation/YearFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/YearFieldValidator.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\Core\Validation\FieldValidation;
+
+use SilverStripe\Core\Validation\ValidationResult;
+
+/**
+ * Validates a value in DBYear field
+ * This FieldValidator is not intended to be used in fields other than DBYear
+ */
+class YearFieldValidator extends IntFieldValidator
+{
+    /**
+     * Special year value which is less than DBYear::MIN_YEAR and is considered valid
+     */
+    private const SPECIAL_YEAR = 0;
+
+    protected function validateValue(): ValidationResult
+    {
+        if ($this->value === YearFieldValidator::SPECIAL_YEAR) {
+            return ValidationResult::create();
+        }
+        return parent::validateValue();
+    }
+}

--- a/src/Core/Validation/ValidationInterface.php
+++ b/src/Core/Validation/ValidationInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\Core\Validation;
+
+use SilverStripe\Core\Validation\ValidationResult;
+
+/**
+ * Interface for classes that can be validated.
+ */
+interface ValidationInterface
+{
+    public function validate(): ValidationResult;
+}

--- a/src/Core/Validation/ValidationResult.php
+++ b/src/Core/Validation/ValidationResult.php
@@ -73,8 +73,12 @@ class ValidationResult
      * Bool values will be treated as plain text flag.
      * @return $this
      */
-    public function addError($message, $messageType = ValidationResult::TYPE_ERROR, $code = null, $cast = ValidationResult::CAST_TEXT)
-    {
+    public function addError(
+        $message,
+        $messageType = ValidationResult::TYPE_ERROR,
+        $code = null,
+        $cast = ValidationResult::CAST_TEXT,
+    ) {
         return $this->addFieldError(null, $message, $messageType, $code, $cast);
     }
 
@@ -96,7 +100,7 @@ class ValidationResult
         $message,
         $messageType = ValidationResult::TYPE_ERROR,
         $code = null,
-        $cast = ValidationResult::CAST_TEXT
+        $cast = ValidationResult::CAST_TEXT,
     ) {
         $this->isValid = false;
         return $this->addFieldMessage($fieldName, $message, $messageType, $code, $cast);
@@ -114,8 +118,12 @@ class ValidationResult
      * Bool values will be treated as plain text flag.
      * @return $this
      */
-    public function addMessage($message, $messageType = ValidationResult::TYPE_ERROR, $code = null, $cast = ValidationResult::CAST_TEXT)
-    {
+    public function addMessage(
+        $message,
+        $messageType = ValidationResult::TYPE_ERROR,
+        $code = null,
+        $cast = ValidationResult::CAST_TEXT,
+    ) {
         return $this->addFieldMessage(null, $message, $messageType, $code, $cast);
     }
 
@@ -137,7 +145,7 @@ class ValidationResult
         $message,
         $messageType = ValidationResult::TYPE_ERROR,
         $code = null,
-        $cast = ValidationResult::CAST_TEXT
+        $cast = ValidationResult::CAST_TEXT,
     ) {
         if ($code && is_numeric($code)) {
             throw new InvalidArgumentException("Don't use a numeric code '$code'.  Use a string.");
@@ -151,7 +159,6 @@ class ValidationResult
             'messageType' => $messageType,
             'messageCast' => $cast,
         ];
-
         if ($code) {
             $this->messages[$code] = $metadata;
         } else {

--- a/src/Forms/CompositeField.php
+++ b/src/Forms/CompositeField.php
@@ -119,8 +119,6 @@ class CompositeField extends FormField
      * Returns the name (ID) for the element.
      * If the CompositeField doesn't have a name, but we still want the ID/name to be set.
      * This code generates the ID from the nested children.
-     *
-     * @return String $name
      */
     public function getName()
     {

--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -427,8 +427,6 @@ class FormField extends RequestHandler
 
     /**
      * Returns the field name.
-     *
-     * @return string
      */
     public function getName()
     {

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -1235,6 +1235,12 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
     public function validate()
     {
         $result = ValidationResult::create();
+        // Call DBField::validate() on every DBField
+        $specs = DataObject::getSchema()->fieldSpecs(static::class);
+        foreach (array_keys($specs) as $fieldName) {
+            $dbField = $this->dbObject($fieldName);
+            $result->combineAnd($dbField->validate());
+        }
         $this->extend('updateValidate', $result);
         return $result;
     }

--- a/src/ORM/FieldType/DBBigInt.php
+++ b/src/ORM/FieldType/DBBigInt.php
@@ -2,18 +2,23 @@
 
 namespace SilverStripe\ORM\FieldType;
 
+use SilverStripe\Core\Validation\FieldValidation\IntFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\BigIntFieldValidator;
 use SilverStripe\ORM\DB;
 
 /**
- * Represents a signed 8 byte integer field. Do note PHP running as 32-bit might not work with Bigint properly, as it
- * would convert the value to a float when queried from the database since the value is a 64-bit one.
+ * Represents a signed 8 byte integer field with a range between -9223372036854775808 and 9223372036854775807
  *
- * @package framework
- * @subpackage model
- * @see Int
+ * Do note PHP running as 32-bit might not work with Bigint properly, as it
+ * would convert the value to a float when queried from the database since the value is a 64-bit one.
  */
 class DBBigInt extends DBInt
 {
+    private static array $field_validators = [
+        // Remove parent validator and add BigIntValidator instead
+        IntFieldValidator::class => null,
+        BigIntFieldValidator::class,
+    ];
 
     public function requireField(): void
     {
@@ -24,7 +29,6 @@ class DBBigInt extends DBInt
             'default' => $this->defaultVal,
             'arrayValue' => $this->arrayValue
         ];
-
         $values = ['type' => 'bigint', 'parts' => $parts];
         DB::require_field($this->tableName, $this->name, $values);
     }

--- a/src/ORM/FieldType/DBBoolean.php
+++ b/src/ORM/FieldType/DBBoolean.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\ORM\FieldType;
 
+use SilverStripe\Core\Validation\FieldValidation\BooleanFieldValidator;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FormField;
@@ -9,15 +10,18 @@ use SilverStripe\ORM\DB;
 use SilverStripe\Model\ModelData;
 
 /**
- * Represents a boolean field.
+ * Represents a boolean field
+ * Values are stored in the database as tinyint i.e. 1 or 0
  */
 class DBBoolean extends DBField
 {
-    public function __construct(?string $name = null, bool|int $defaultVal = 0)
-    {
-        $defaultValue = $defaultVal ? 1 : 0;
-        $this->setDefaultValue($defaultValue);
+    private static array $field_validators = [
+        BooleanFieldValidator::class,
+    ];
 
+    public function __construct(?string $name = null, bool|int $defaultVal = false)
+    {
+        $this->setDefaultValue($defaultVal);
         parent::__construct($name);
     }
 
@@ -28,11 +32,24 @@ class DBBoolean extends DBField
             'precision' => 1,
             'sign' => 'unsigned',
             'null' => 'not null',
-            'default' => $this->getDefaultValue(),
+            'default' => (int) $this->getDefaultValue(),
             'arrayValue' => $this->arrayValue
         ];
         $values = ['type' => 'boolean', 'parts' => $parts];
         DB::require_field($this->tableName, $this->name, $values);
+    }
+
+    public function setDefaultValue(mixed $defaultValue): static
+    {
+        $value = (int) $this->convertBooleanLikeValue($defaultValue);
+        return parent::setDefaultValue($value);
+    }
+
+    public function setValue(mixed $value, null|array|ModelData $record = null, bool $markChanged = true): static
+    {
+        $value = $this->convertBooleanLikeValue($value);
+        parent::setValue($value, $record, $markChanged);
+        return $this;
     }
 
     public function Nice(): string
@@ -52,7 +69,7 @@ class DBBoolean extends DBField
             if ($this->value instanceof DBField) {
                 $this->value->saveInto($dataObject);
             } else {
-                $dataObject->__set($fieldName, $this->value ? 1 : 0);
+                $dataObject->__set($fieldName, (bool) $this->value);
             }
         } else {
             $class = static::class;
@@ -70,8 +87,8 @@ class DBBoolean extends DBField
         $anyText = _t(__CLASS__ . '.ANY', 'Any');
         $source = [
             '' => $anyText,
-            1 => _t(__CLASS__ . '.YESANSWER', 'Yes'),
-            0 => _t(__CLASS__ . '.NOANSWER', 'No')
+            '1' => _t(__CLASS__ . '.YESANSWER', 'Yes'),
+            '0' => _t(__CLASS__ . '.NOANSWER', 'No')
         ];
 
         return DropdownField::create($this->name, $title, $source)
@@ -85,22 +102,35 @@ class DBBoolean extends DBField
 
     public function prepValueForDB(mixed $value): array|int|null
     {
-        if (is_bool($value)) {
-            return $value ? 1 : 0;
-        }
-        if (empty($value)) {
-            return 0;
-        }
+        $bool = $this->convertBooleanLikeValue($value);
+        // Ensure a tiny int is returned no matter what e.g. value is an
+        return $bool ? 1 : 0;
+    }
+
+    /**
+     * Convert boolean-like values to boolean
+     * Does not convert non-boolean-like values e.g. array - will be handled by the FieldValidator
+     */
+    private function convertBooleanLikeValue(mixed $value): mixed
+    {
         if (is_string($value)) {
-            switch (strtolower($value ?? '')) {
+            switch (strtolower($value)) {
                 case 'false':
                 case 'f':
-                    return 0;
+                case '0':
+                    return false;
                 case 'true':
                 case 't':
-                    return 1;
+                case '1':
+                    return true;
             }
         }
-        return $value ? 1 : 0;
+        if ($value === 0) {
+            return false;
+        }
+        if ($value === 1) {
+            return true;
+        }
+        return $value;
     }
 }

--- a/src/ORM/FieldType/DBClassNameVarchar.php
+++ b/src/ORM/FieldType/DBClassNameVarchar.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\ORM\FieldType;
 
 use SilverStripe\ORM\FieldType\DBVarchar;
+use SilverStripe\Core\Validation\FieldValidation\OptionFieldValidator;
 
 /**
  * An alternative to DBClassName that stores the class name as a varchar instead of an enum
@@ -24,4 +25,8 @@ use SilverStripe\ORM\FieldType\DBVarchar;
 class DBClassNameVarchar extends DBVarchar
 {
     use DBClassNameTrait;
+
+    private static array $field_validators = [
+        OptionFieldValidator::class => ['getEnum'],
+    ];
 }

--- a/src/ORM/FieldType/DBComposite.php
+++ b/src/ORM/FieldType/DBComposite.php
@@ -8,6 +8,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\Model\ModelData;
+use SilverStripe\Core\Validation\FieldValidation\CompositeFieldValidator;
 
 /**
  * Extend this class when designing a {@link DBField} that doesn't have a 1-1 mapping with a database field.
@@ -25,6 +26,10 @@ use SilverStripe\Model\ModelData;
  */
 abstract class DBComposite extends DBField
 {
+    private static array $field_validators = [
+        CompositeFieldValidator::class,
+    ];
+
     /**
      * Similar to {@link DataObject::$db},
      * holds an array of composite field names.
@@ -188,6 +193,15 @@ abstract class DBComposite extends DBField
             }
         }
         return $this;
+    }
+
+    public function getValueForValidation(): mixed
+    {
+        $fields = [];
+        foreach (array_keys($this->compositeDatabaseFields()) as $fieldName) {
+            $fields[] = $this->dbObject($fieldName);
+        }
+        return $fields;
     }
 
     /**

--- a/src/ORM/FieldType/DBCurrency.php
+++ b/src/ORM/FieldType/DBCurrency.php
@@ -53,15 +53,14 @@ class DBCurrency extends DBDecimal
 
     public function setValue(mixed $value, null|array|ModelData $record = null, bool $markChanged = true): static
     {
-        $matches = null;
-        if (is_numeric($value)) {
-            $this->value = $value;
-        } elseif (preg_match('/-?\$?[0-9,]+(.[0-9]+)?([Ee][0-9]+)?/', $value ?? '', $matches)) {
-            $this->value = str_replace(['$', ',', static::config()->get('currency_symbol')], '', $matches[0] ?? '');
-        } else {
-            $this->value = 0;
+        if (is_string($value)) {
+            $symbol = static::config()->get('currency_symbol');
+            $val = str_replace(['$', ',', $symbol], '', $value);
+            if (is_numeric($val)) {
+                $value = (float) $val;
+            }
         }
-
+        parent::setValue($value, $record, $markChanged);
         return $this;
     }
 

--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -12,6 +12,7 @@ use SilverStripe\ORM\DB;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 use SilverStripe\Model\ModelData;
+use SilverStripe\Core\Validation\FieldValidation\DateFieldValidator;
 
 /**
  * Represents a date field.
@@ -33,6 +34,7 @@ class DBDate extends DBField
 {
     /**
      * Standard ISO format string for date in CLDR standard format
+     * This is equivalent to php date format "Y-m-d" e.g. 2024-08-31
      */
     public const ISO_DATE = 'y-MM-dd';
 
@@ -41,6 +43,10 @@ class DBDate extends DBField
      * locale-specific numeric localisation breaking internal date strings.
      */
     public const ISO_LOCALE = 'en_US';
+
+    private static array $field_validators = [
+        DateFieldValidator::class,
+    ];
 
     public function setValue(mixed $value, null|array|ModelData $record = null, bool $markChanged = true): static
     {

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -13,6 +13,8 @@ use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 use SilverStripe\View\TemplateGlobalProvider;
 use SilverStripe\Model\ModelData;
+use SilverStripe\Core\Validation\FieldValidation\DateFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\DatetimeFieldValidator;
 
 /**
  * Represents a date-time field.
@@ -39,6 +41,7 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
     /**
      * Standard ISO format string for date and time in CLDR standard format,
      * with a whitespace separating date and time (common database representation, e.g. in MySQL).
+     * This is equivalent to php date format "Y-m-d H:i:s" e.g. 2024-08-31 09:30:00
      */
     public const ISO_DATETIME = 'y-MM-dd HH:mm:ss';
 
@@ -47,6 +50,13 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
      * with a "T" separator between date and time (W3C standard, e.g. for HTML5 datetime-local fields).
      */
     public const ISO_DATETIME_NORMALISED = 'y-MM-dd\'T\'HH:mm:ss';
+
+    private static array $field_validators = [
+        // Remove parent validator
+        DateFieldValidator::class => null,
+        // Add datetime validator
+        DatetimeFieldValidator::class,
+    ];
 
     /**
      * Flag idicating if this field is considered immutable

--- a/src/ORM/FieldType/DBEmail.php
+++ b/src/ORM/FieldType/DBEmail.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SilverStripe\ORM\FieldType;
+
+use SilverStripe\Forms\EmailField;
+use SilverStripe\ORM\FieldType\DBVarchar;
+use SilverStripe\Core\Validation\FieldValidation\EmailFieldValidator;
+use SilverStripe\Forms\FormField;
+
+class DBEmail extends DBVarchar
+{
+    private static array $field_validators = [
+        EmailFieldValidator::class,
+    ];
+
+    public function scaffoldFormField(?string $title = null, array $params = []): ?FormField
+    {
+        $field = EmailField::create($this->name, $title);
+        $field->setMaxLength($this->getSize());
+        return $field;
+    }
+}

--- a/src/ORM/FieldType/DBEnum.php
+++ b/src/ORM/FieldType/DBEnum.php
@@ -3,12 +3,14 @@
 namespace SilverStripe\ORM\FieldType;
 
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Validation\FieldValidation\OptionFieldValidator;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\SelectField;
 use SilverStripe\Core\ArrayLib;
 use SilverStripe\ORM\Connect\MySQLDatabase;
 use SilverStripe\ORM\DB;
+use SilverStripe\Model\ModelData;
 
 /**
  * Class Enum represents an enumeration of a set of strings.
@@ -17,6 +19,10 @@ use SilverStripe\ORM\DB;
  */
 class DBEnum extends DBString
 {
+    private static array $field_validators = [
+        OptionFieldValidator::class => ['getEnum'],
+    ];
+
     /**
      * List of enum values
      */
@@ -73,14 +79,14 @@ class DBEnum extends DBString
 
             // If there's a default, then use this
             if ($default && !is_int($default)) {
-                if (in_array($default, $enum ?? [])) {
+                if (in_array($default, $enum)) {
                     $this->setDefault($default);
                 } else {
                     throw new \InvalidArgumentException(
                         "Enum::__construct() The default value '$default' does not match any item in the enumeration"
                     );
                 }
-            } elseif (is_int($default) && $default < count($enum ?? [])) {
+            } elseif (is_int($default) && $default < count($enum)) {
                 // Set to specified index if given
                 $this->setDefault($enum[$default]);
             } else {

--- a/src/ORM/FieldType/DBFloat.php
+++ b/src/ORM/FieldType/DBFloat.php
@@ -2,20 +2,24 @@
 
 namespace SilverStripe\ORM\FieldType;
 
+use SilverStripe\Core\Validation\FieldValidation\NumericFieldValidator;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\ORM\DB;
+use SilverStripe\Model\ModelData;
 
 /**
  * Represents a floating point field.
  */
 class DBFloat extends DBField
 {
+    private static array $field_validators = [
+        NumericFieldValidator::class,
+    ];
+
     public function __construct(?string $name = null, float|int $defaultVal = 0)
     {
-        $defaultValue = is_float($defaultVal) ? $defaultVal : (float) 0;
-        $this->setDefaultValue($defaultValue);
-
+        $this->setDefaultValue((float) $defaultVal);
         parent::__construct($name);
     }
 
@@ -29,6 +33,16 @@ class DBFloat extends DBField
         ];
         $values = ['type' => 'float', 'parts' => $parts];
         DB::require_field($this->tableName, $this->name, $values);
+    }
+
+    public function setValue(mixed $value, null|array|ModelData $record = null, bool $markChanged = true): static
+    {
+        // Cast ints and numeric strings to floats
+        if (is_int($value) || (is_string($value) && is_numeric($value))) {
+            $value = (float) $value;
+        }
+        parent::setValue($value, $record, $markChanged);
+        return $this;
     }
 
     /**
@@ -58,9 +72,9 @@ class DBFloat extends DBField
         return $field;
     }
 
-    public function nullValue(): ?int
+    public function nullValue(): ?float
     {
-        return 0;
+        return 0.0;
     }
 
     public function prepValueForDB(mixed $value): array|float|int|null

--- a/src/ORM/FieldType/DBForeignKey.php
+++ b/src/ORM/FieldType/DBForeignKey.php
@@ -5,6 +5,7 @@ namespace SilverStripe\ORM\FieldType;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Image;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\Validation\FieldValidation\IntFieldValidator;
 use SilverStripe\Forms\FileHandleField;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\SearchableDropdownField;
@@ -25,6 +26,10 @@ use SilverStripe\Model\ModelData;
 class DBForeignKey extends DBInt
 {
     protected ?DataObject $object;
+
+    private static array $field_validators = [
+        IntFieldValidator::class => ['getMinValue'],
+    ];
 
     /**
      * Number of related objects to show in a scaffolded searchable dropdown field before it
@@ -63,6 +68,16 @@ class DBForeignKey extends DBInt
         if ($record instanceof DataObject) {
             $this->object = $record;
         }
+        // Convert blank string to 0, this is sometimes required when calling DataObject::setCastedValue()
+        // after a form submission where the value is a blank string when no value is selected
+        if ($value === '') {
+            $value = 0;
+        }
         return parent::setValue($value, $record, $markChanged);
+    }
+
+    public function getMinValue(): int
+    {
+        return 0;
     }
 }

--- a/src/ORM/FieldType/DBIp.php
+++ b/src/ORM/FieldType/DBIp.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\ORM\FieldType;
+
+use SilverStripe\ORM\FieldType\DBVarchar;
+use SilverStripe\Core\Validation\FieldValidation\IpFieldValidator;
+
+class DBIp extends DBVarchar
+{
+    private static array $field_validators = [
+        IpFieldValidator::class,
+    ];
+}

--- a/src/ORM/FieldType/DBLocale.php
+++ b/src/ORM/FieldType/DBLocale.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\ORM\FieldType;
 
+use SilverStripe\Core\Validation\FieldValidation\LocaleFieldValidator;
 use SilverStripe\i18n\i18n;
 
 /**
@@ -9,6 +10,10 @@ use SilverStripe\i18n\i18n;
  */
 class DBLocale extends DBVarchar
 {
+    private static array $field_validators = [
+        LocaleFieldValidator::class,
+    ];
+
     public function __construct(?string $name = null, int $size = 16)
     {
         parent::__construct($name, $size);

--- a/src/ORM/FieldType/DBMultiEnum.php
+++ b/src/ORM/FieldType/DBMultiEnum.php
@@ -3,6 +3,9 @@
 namespace SilverStripe\ORM\FieldType;
 
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Validation\FieldValidation\OptionFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\MultiOptionFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\StringFieldValidator;
 use SilverStripe\Forms\CheckboxSetField;
 use SilverStripe\Forms\MultiSelectField;
 use SilverStripe\ORM\Connect\MySQLDatabase;
@@ -13,6 +16,14 @@ use SilverStripe\ORM\DB;
  */
 class DBMultiEnum extends DBEnum
 {
+    private static array $field_validators = [
+        // disable parent field validators
+        StringFieldValidator::class => null,
+        OptionFieldValidator::class => null,
+        // enable multi enum field validator
+        MultiOptionFieldValidator::class => ['getEnum'],
+    ];
+
     public function __construct($name = null, $enum = null, $default = null)
     {
         // MultiEnum needs to take care of its own defaults
@@ -32,6 +43,18 @@ class DBMultiEnum extends DBEnum
             }
             $this->default = implode(',', $defaults);
         }
+    }
+
+    public function getValueForValidation(): mixed
+    {
+        $value = parent::getValueForValidation();
+        if (is_iterable($value)) {
+            return $value;
+        }
+        if (is_string($value)) {
+            return explode(',', $value);
+        }
+        return $value;
     }
 
     public function requireField(): void

--- a/src/ORM/FieldType/DBPercentage.php
+++ b/src/ORM/FieldType/DBPercentage.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\ORM\FieldType;
 
 use SilverStripe\Model\ModelData;
+use SilverStripe\Core\Validation\FieldValidation\DecimalFieldValidator;
 
 /**
  * Represents a decimal field from 0-1 containing a percentage value.
@@ -17,6 +18,10 @@ use SilverStripe\Model\ModelData;
  */
 class DBPercentage extends DBDecimal
 {
+    private static array $field_validators = [
+        DecimalFieldValidator::class => ['getWholeSize', 'getDecimalSize', 'getMinValue', 'getMaxValue'],
+    ];
+
     /**
      * Create a new Decimal field.
      */
@@ -27,6 +32,16 @@ class DBPercentage extends DBDecimal
         }
 
         parent::__construct($name, $precision + 1, $precision);
+    }
+
+    public function getMinValue(): float
+    {
+        return 0.0;
+    }
+
+    public function getMaxValue(): float
+    {
+        return 1.0;
     }
 
     /**

--- a/src/ORM/FieldType/DBString.php
+++ b/src/ORM/FieldType/DBString.php
@@ -2,11 +2,18 @@
 
 namespace SilverStripe\ORM\FieldType;
 
+use SilverStripe\Model\ModelData;
+use SilverStripe\Core\Validation\FieldValidation\StringFieldValidator;
+
 /**
  * An abstract base class for the string field types (i.e. Varchar and Text)
  */
 abstract class DBString extends DBField
 {
+    private static array $field_validators = [
+        StringFieldValidator::class,
+    ];
+
     private static array $casting = [
         'LimitCharacters' => 'Text',
         'LimitCharactersToClosestWord' => 'Text',
@@ -17,13 +24,14 @@ abstract class DBString extends DBField
     ];
 
     /**
-     * Set the default value for "nullify empty"
+     * Set the default value for "nullify empty" and 'default'
      *
      * {@inheritDoc}
      */
     public function __construct($name = null, $options = [])
     {
         $this->options['nullifyEmpty'] = true;
+        $this->options['default'] = '';
         parent::__construct($name, $options);
     }
 

--- a/src/ORM/FieldType/DBTime.php
+++ b/src/ORM/FieldType/DBTime.php
@@ -11,6 +11,7 @@ use SilverStripe\ORM\DB;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
 use SilverStripe\Model\ModelData;
+use SilverStripe\Core\Validation\FieldValidation\TimeFieldValidator;
 
 /**
  * Represents a column in the database with the type 'Time'.
@@ -26,8 +27,13 @@ class DBTime extends DBField
 {
     /**
      * Standard ISO format string for time in CLDR standard format
+     * This is equivalent to php date format "H:i:s" e.g. 09:30:00
      */
     public const ISO_TIME = 'HH:mm:ss';
+
+    private static array $field_validators = [
+        TimeFieldValidator::class,
+    ];
 
     public function setValue(mixed $value, null|array|ModelData $record = null, bool $markChanged = true): static
     {

--- a/src/ORM/FieldType/DBUrl.php
+++ b/src/ORM/FieldType/DBUrl.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SilverStripe\ORM\FieldType;
+
+use SilverStripe\ORM\FieldType\DBVarchar;
+use SilverStripe\Core\Validation\FieldValidation\UrlFieldValidator;
+use SilverStripe\Forms\FormField;
+use SilverStripe\Forms\UrlField;
+
+class DBUrl extends DBVarchar
+{
+    private static array $field_validators = [
+        UrlFieldValidator::class,
+    ];
+
+    public function scaffoldFormField(?string $title = null, array $params = []): ?FormField
+    {
+        $field = UrlField::create($this->name, $title);
+        $field->setMaxLength($this->getSize());
+        return $field;
+    }
+}

--- a/src/ORM/FieldType/DBVarchar.php
+++ b/src/ORM/FieldType/DBVarchar.php
@@ -8,6 +8,7 @@ use SilverStripe\Forms\NullableField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\Connect\MySQLDatabase;
 use SilverStripe\ORM\DB;
+use SilverStripe\Core\Validation\FieldValidation\StringFieldValidator;
 
 /**
  * Class Varchar represents a variable-length string of up to 255 characters, designed to store raw text
@@ -18,6 +19,10 @@ use SilverStripe\ORM\DB;
  */
 class DBVarchar extends DBString
 {
+    private static array $field_validators = [
+        StringFieldValidator::class => [null, 'getSize'],
+    ];
+
     private static array $casting = [
         'Initial' => 'Text',
         'URL' => 'Text',

--- a/src/ORM/FieldType/DBYear.php
+++ b/src/ORM/FieldType/DBYear.php
@@ -5,12 +5,24 @@ namespace SilverStripe\ORM\FieldType;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FormField;
 use SilverStripe\ORM\DB;
+use SilverStripe\Model\ModelData;
+use SilverStripe\Core\Validation\FieldValidation\YearFieldValidator;
 
 /**
- * Represents a single year field.
+ * Represents a single year field
+ * This field is only intended to be used with a MySQL database and the year datatype
  */
 class DBYear extends DBField
 {
+    // MySQL year datatype supports years between 1901 and 2155
+    // https://dev.mysql.com/doc/refman/8.0/en/year.html
+    public const MIN_YEAR = 1901;
+    public const MAX_YEAR = 2155;
+
+    private static $field_validators = [
+        YearFieldValidator::class => ['getMinYear', 'getMaxYear'],
+    ];
+
     public function requireField(): void
     {
         $parts = ['datatype' => 'year', 'precision' => 4, 'arrayValue' => $this->arrayValue];
@@ -25,11 +37,51 @@ class DBYear extends DBField
         return $selectBox;
     }
 
+    public function setValue(mixed $value, null|array|ModelData $record = null, bool $markChanged = true): static
+    {
+        parent::setValue($value, $record, $markChanged);
+        // 0 is used to represent a null value, which will be stored as 0000 in MySQL
+        if ($this->value === '0000') {
+            $this->value = 0;
+        }
+        // shorthand for 2000 in MySQL
+        if ($this->value === '00') {
+            $this->value = 2000;
+        }
+        // convert string int to int
+        // string int and int are both valid in MySQL, though only use int internally
+        if (is_string($this->value) && preg_match('#^\d+$#', (string) $this->value)) {
+            $this->value = (int) $this->value;
+        }
+        if (!is_int($this->value)) {
+            return $this;
+        }
+        // shorthand for 2001-2069 in MySQL
+        if ($this->value >= 1 && $this->value <= 69) {
+            $this->value = 2000 + $this->value;
+        }
+        // shorthand for 1970-1999 in MySQL
+        if ($this->value >= 70 && $this->value <= 99) {
+            $this->value = 1900 + $this->value;
+        }
+        return $this;
+    }
+
+    public function getMinYear(): int
+    {
+        return DBYear::MIN_YEAR;
+    }
+
+    public function getMaxYear(): int
+    {
+        return DBYear::MAX_YEAR;
+    }
+
     /**
      * Returns a list of default options that can
      * be used to populate a select box, or compare against
      * input values. Starts by default at the current year,
-     * and counts back to 1900.
+     * and counts back to 1901.
      *
      * @param int|null $start starting date to count down from
      * @param int|null $end end date to count down to
@@ -37,10 +89,10 @@ class DBYear extends DBField
     private function getDefaultOptions(?int $start = null, ?int $end = null): array
     {
         if (!$start) {
-            $start = (int)date('Y');
+            $start = (int) date('Y');
         }
         if (!$end) {
-            $end = 1900;
+            $end = DBYear::MIN_YEAR;
         }
         $years = [];
         for ($i = $start; $i >= $end; $i--) {

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -444,7 +444,6 @@ class Member extends DataObject
         if (!$this->PasswordExpiry) {
             return false;
         }
-
         return strtotime(date('Y-m-d')) >= strtotime($this->PasswordExpiry ?? '');
     }
 

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -1063,6 +1063,12 @@ class Security extends Controller implements TemplateGlobalProvider
         // New salts will only need to be generated if the password is hashed for the first time
         $salt = ($salt) ? $salt : $encryptor->salt($password);
 
+        // PasswordEncryptors may return false, though the Member.db ['Salt'] field is
+        // a Varchar so we need to ensure it's returned as a string
+        if ($salt === false) {
+            $salt = '';
+        }
+
         return [
             'password'  => $encryptor->encrypt($password, $salt, $member),
             'salt' => $salt,

--- a/tests/behat/src/CmsUiContext.php
+++ b/tests/behat/src/CmsUiContext.php
@@ -12,6 +12,7 @@ use Behat\Mink\Session;
 use PHPUnit\Framework\Assert;
 use SilverStripe\BehatExtension\Context\MainContextAwareTrait;
 use SilverStripe\BehatExtension\Utility\StepHelper;
+use Facebook\WebDriver\Exception\ElementNotInteractableException;
 
 /**
  * CmsUiContext

--- a/tests/php/Core/Validation/FieldValidation/BigIntFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/BigIntFieldValidatorTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\BigIntFieldValidator;
+
+class BigIntFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        return [
+            'valid-int' => [
+                'value' => 123,
+                'expected' => true,
+            ],
+            'valid-zero' => [
+                'value' => 0,
+                'expected' => true,
+            ],
+            'valid-negative-int' => [
+                'value' => -123,
+                'expected' => true,
+            ],
+            'valid-max-int' => [
+                'value' => 9223372036854775807,
+                'expected' => true,
+            ],
+            'valid-min-int' => [
+                'value' => '-9223372036854775808',
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'expected' => true,
+            ],
+            'invalid-too-large-int' => [
+                'value' => 9223372036854775808,
+                'expected' => false,
+            ],
+            'invalid-too-small-int' => [
+                'value' => -9223372036854775809,
+                'expected' => false,
+            ],
+            'invalid-too-large-string' => [
+                'value' => '9223372036854775808',
+                'expected' => false,
+            ],
+            'invalid-too-small-string' => [
+                'value' => '-9223372036854775809',
+                'expected' => false,
+            ],
+            'invalid-string-int' => [
+                'value' => '123',
+                'expected' => false,
+            ],
+            'invalid-float' => [
+                'value' => 123.45,
+                'expected' => false,
+            ],
+            'invalid-array' => [
+                'value' => [123],
+                'expected' => false,
+            ],
+            'invalid-true' => [
+                'value' => true,
+                'expected' => false,
+            ],
+            'invalid-false' => [
+                'value' => false,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, bool $expected): void
+    {
+        // On 64-bit systems, -9223372036854775808 will end up as a float
+        // however it works correctly when cast to an int
+        if ($value === '-9223372036854775808') {
+            $value = (int) $value;
+        }
+        $validator = new BigIntFieldValidator('MyField', $value);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/BooleanFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/BooleanFieldValidatorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\BooleanFieldValidator;
+
+class BooleanFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        return [
+            'valid-true' => [
+                'value' => true,
+                'expected' => true,
+            ],
+            'valid-false' => [
+                'value' => false,
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'expected' => true,
+            ],
+            'invalid-int-1' => [
+                'value' => 1,
+                'expected' => false,
+            ],
+            'invalid-int-0' => [
+                'value' => 0,
+                'expected' => false,
+            ],
+            'invalid-string-1' => [
+                'value' => '1',
+                'expected' => false,
+            ],
+            'invalid-string-0' => [
+                'value' => '0',
+                'expected' => false,
+            ],
+            'invalid-string-true' => [
+                'value' => 'true',
+                'expected' => false,
+            ],
+            'invalid-string-false' => [
+                'value' => 'false',
+                'expected' => false,
+            ],
+            'invalid-string' => [
+                'value' => 'abc',
+                'expected' => false,
+            ],
+            'invalid-int' => [
+                'value' => 123,
+                'expected' => false,
+            ],
+            'invalid-array' => [
+                'value' => [],
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, bool $expected): void
+    {
+        $validator = new BooleanFieldValidator('MyField', $value);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/CompositeFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/CompositeFieldValidatorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use InvalidArgumentException;
+use stdClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Core\Validation\FieldValidation\CompositeFieldValidator;
+use SilverStripe\ORM\FieldType\DBBoolean;
+use SilverStripe\ORM\FieldType\DBVarchar;
+
+class CompositeFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        return [
+            'valid' => [
+                'valueBoolean' => true,
+                'valueString' => 'fish',
+                'valueIsNull' => false,
+                'exception' => null,
+                'expected' => true,
+            ],
+            'exception-not-iterable' => [
+                'valueBoolean' => true,
+                'valueString' => 'not-iterable',
+                'valueIsNull' => false,
+                'exception' => InvalidArgumentException::class,
+                'expected' => true,
+            ],
+            'exception-not-field-validator' => [
+                'valueBoolean' => true,
+                'valueString' => 'no-field-validation',
+                'valueIsNull' => false,
+                'exception' => InvalidArgumentException::class,
+                'expected' => true,
+            ],
+            'exception-do-not-skip-null' => [
+                'valueBoolean' => true,
+                'valueString' => 'fish',
+                'valueIsNull' => true,
+                'exception' => InvalidArgumentException::class,
+                'expected' => true,
+            ],
+            'invalid-bool-field' => [
+                'valueBoolean' => 'dog',
+                'valueString' => 'fish',
+                'valueIsNull' => false,
+                'exception' => null,
+                'expected' => false,
+            ],
+            'invalid-string-field' => [
+                'valueBoolean' => true,
+                'valueString' => 456.789,
+                'valueIsNull' => false,
+                'exception' => null,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(
+        mixed $valueBoolean,
+        mixed $valueString,
+        bool $valueIsNull,
+        ?string $exception,
+        bool $expected
+    ): void {
+        if ($exception) {
+            $this->expectException($exception);
+        }
+        if ($valueIsNull) {
+            $iterable = null;
+        } else {
+            $booleanField = new DBBoolean('BooleanField');
+            $booleanField->setValue($valueBoolean);
+            if ($exception && $valueString === 'no-field-validation') {
+                $stringField = new stdClass();
+            } else {
+                $stringField = new DBVarchar('StringField');
+                $stringField->setValue($valueString);
+            }
+            if ($exception && $valueString === 'not-iterable') {
+                $iterable = 'banana';
+            } else {
+                $iterable = [$booleanField, $stringField];
+            }
+        }
+        $validator = new CompositeFieldValidator('MyField', $iterable);
+        $result = $validator->validate();
+        if (!$exception) {
+            $this->assertSame($expected, $result->isValid());
+        }
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/DateFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/DateFieldValidatorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\DateFieldValidator;
+
+class DateFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        return [
+            'valid' => [
+                'value' => '2020-09-15',
+                'expected' => true,
+            ],
+            'valid-blank-string' => [
+                'value' => '',
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'expected' => true,
+            ],
+            'invalid' => [
+                'value' => '2020-02-30',
+                'expected' => false,
+            ],
+            'invalid-wrong-format' => [
+                'value' => '15-09-2020',
+                'expected' => false,
+            ],
+            'invalid-date-time' => [
+                'value' => '2020-09-15 13:34:56',
+                'expected' => false,
+            ],
+            'invalid-time' => [
+                'value' => '13:34:56',
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, bool $expected): void
+    {
+        $validator = new DateFieldValidator('MyField', $value);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/DatetimeFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/DatetimeFieldValidatorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\DatetimeFieldValidator;
+
+class DatetimeFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        return [
+            'valid' => [
+                'value' => '2020-09-15 13:34:56',
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'expected' => true,
+            ],
+            'invalid-date' => [
+                'value' => '2020-02-30 13:34:56',
+                'expected' => false,
+            ],
+            'invalid-time' => [
+                'value' => '2020-02-15 13:99:56',
+                'expected' => false,
+            ],
+            'invalid-wrong-format' => [
+                'value' => '15-09-2020 13:34:56',
+                'expected' => false,
+            ],
+            'invalid-date-only' => [
+                'value' => '2020-09-15',
+                'expected' => false,
+            ],
+            'invalid-time-only' => [
+                'value' => '13:34:56',
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, bool $expected): void
+    {
+        $validator = new DatetimeFieldValidator('MyField', $value);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/DecimalFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/DecimalFieldValidatorTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\DecimalFieldValidator;
+
+class DecimalFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        return [
+            'valid' => [
+                'value' => 123.45,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => true,
+            ],
+            'valid-negative' => [
+                'value' => -123.45,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => true,
+            ],
+            'valid-zero' => [
+                'value' => 0,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => true,
+            ],
+            'valid-rounded-dp' => [
+                'value' => 123.456,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => true,
+            ],
+            'valid-rounded-up' => [
+                'value' => 123.999,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => true,
+            ],
+            'valid-int' => [
+                'value' => 123,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => true,
+            ],
+            'valid-negative-int' => [
+                'value' => -123,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => true,
+            ],
+            'valid-max' => [
+                'value' => 999.99,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => true,
+            ],
+            'valid-max-negative' => [
+                'value' => -999.99,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => true,
+            ],
+            'valid-in-range' => [
+                'value' => 5.0,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => 1.0,
+                'maxValue' => 10.0,
+                'expected' => true,
+            ],
+            'invalid-below-min' => [
+                'value' => 0.5,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => 1.0,
+                'maxValue' => 10.0,
+                'expected' => false,
+            ],
+            'invalid-above-max' => [
+                'value' => 15.0,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => 1.0,
+                'maxValue' => 10.0,
+                'expected' => false,
+            ],
+            'invalid-rounded-to-6-digts' => [
+                'value' => 999.999,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => false,
+            ],
+            'invalid-too-long' => [
+                'value' => 1234.56,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => false,
+            ],
+            'invalid-too-long-3dp' => [
+                'value' => 123.456,
+                'wholeSize' => 5,
+                'decimalSize' => 3,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => false,
+            ],
+            'invalid-too-long-1dp' => [
+                'value' => 123.4,
+                'wholeSize' => 5,
+                'decimalSize' => 3,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => false,
+            ],
+            'invalid-too-long-int' => [
+                'value' => 123,
+                'wholeSize' => 5,
+                'decimalSize' => 3,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => false,
+            ],
+            'invalid-string' => [
+                'value' => '123.45',
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => false,
+            ],
+            'invalid-true' => [
+                'value' => true,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => false,
+            ],
+            'invalid-false' => [
+                'value' => false,
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => false,
+            ],
+            'invalid-array' => [
+                'value' => [123.45],
+                'wholeSize' => 5,
+                'decimalSize' => 2,
+                'minValue' => null,
+                'maxValue' => null,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(
+        mixed $value,
+        int $wholeSize,
+        int $decimalSize,
+        ?float $minValue,
+        ?float $maxValue,
+        bool $expected,
+    ): void {
+        $validator = new DecimalFieldValidator('MyField', $value, $wholeSize, $decimalSize, $minValue, $maxValue);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/EmailFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/EmailFieldValidatorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\EmailFieldValidator;
+
+class EmailFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        // Using symfony/validator for implementation so only smoke testing
+        return [
+            'valid' => [
+                'value' => 'test@example.com',
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'expected' => true,
+            ],
+            'invalid' => [
+                'value' => 'fish',
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, bool $expected): void
+    {
+        $validator = new EmailFieldValidator('MyField', $value);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/IntFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/IntFieldValidatorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\IntFieldValidator;
+
+class IntFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        return [
+            'valid-int' => [
+                'value' => 123,
+                'expected' => true,
+            ],
+            'valid-zero' => [
+                'value' => 0,
+                'expected' => true,
+            ],
+            'valid-negative-int' => [
+                'value' => -123,
+                'expected' => true,
+            ],
+            'valid-max-int' => [
+                'value' => 2147483647,
+                'expected' => true,
+            ],
+            'valid-min-int' => [
+                'value' => -2147483648,
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'expected' => true,
+            ],
+            'invalid-out-of-bounds' => [
+                'value' => 2147483648,
+                'expected' => false,
+            ],
+            'invalid-out-of-negative-bounds' => [
+                'value' => -2147483649,
+                'expected' => false,
+            ],
+            'invalid-string-int' => [
+                'value' => '123',
+                'expected' => false,
+            ],
+            'invalid-float' => [
+                'value' => 123.45,
+                'expected' => false,
+            ],
+            'invalid-array' => [
+                'value' => [123],
+                'expected' => false,
+            ],
+            'invalid-true' => [
+                'value' => true,
+                'expected' => false,
+            ],
+            'invalid-false' => [
+                'value' => false,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, bool $expected): void
+    {
+        $validator = new IntFieldValidator('MyField', $value);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/IpFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/IpFieldValidatorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\IpFieldValidator;
+
+class IpFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        // Using symfony/validator for implementation so only smoke testing
+        return [
+            'valid-ipv4' => [
+                'value' => '127.0.0.1',
+                'expected' => true,
+            ],
+            'valid-ipv6' => [
+                'value' => '0:0:0:0:0:0:0:1',
+                'expected' => true,
+            ],
+            'valid-ipv6-short' => [
+                'value' => '::1',
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'expected' => true,
+            ],
+            'invalid' => [
+                'value' => '12345',
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, bool $expected): void
+    {
+        $validator = new IpFieldValidator('MyField', $value);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/LocaleFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/LocaleFieldValidatorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\LocaleFieldValidator;
+
+class LocaleFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        // Using symfony/validator for implementation so only smoke testing
+        return [
+            'valid' => [
+                'value' => 'de_DE',
+                'expected' => true,
+            ],
+            'valid-short' => [
+                'value' => 'de',
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'expected' => true,
+            ],
+            'invalid-dash' => [
+                'value' => 'de-DE',
+                'expected' => false,
+            ],
+            'invalid-not-canonicalize' => [
+                'value' => 'DE_de',
+                'expected' => false,
+            ],
+            'invalid' => [
+                'value' => 'zz_ZZ',
+                'expected' => false,
+            ],
+            'invalid-short' => [
+                'value' => 'zz',
+                'expected' => false,
+            ],
+            'invalid-underscores' => [
+                'value' => '_____',
+                'expected' => false,
+            ],
+            'invalid-donut' => [
+                'value' => 'donut',
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, bool $expected): void
+    {
+        $validator = new LocaleFieldValidator('MyField', $value);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/MultiOptionFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/MultiOptionFieldValidatorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use InvalidArgumentException;
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\MultiOptionFieldValidator;
+
+class MultiOptionFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        return [
+            'valid-string' => [
+                'value' => ['cat'],
+                'allowedValues' => ['cat', 'dog'],
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-multi-string' => [
+                'value' => ['cat', 'dog'],
+                'allowedValues' => ['cat', 'dog'],
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-none' => [
+                'value' => [],
+                'allowedValues' => ['cat', 'dog'],
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-int' => [
+                'value' => [123],
+                'allowedValues' => [123, 456],
+                'exception' => false,
+                'expected' => true,
+            ],
+            'exception-not-array' => [
+                'value' => 'cat,dog',
+                'allowedValues' => ['cat', 'dog'],
+                'exception' => true,
+                'expected' => false,
+            ],
+            'invalid' => [
+                'value' => ['fish'],
+                'allowedValues' => ['cat', 'dog'],
+                'exception' => false,
+                'expected' => false,
+            ],
+            'invalid-null' => [
+                'value' => [null],
+                'allowedValues' => ['cat', 'dog'],
+                'exception' => false,
+                'expected' => false,
+            ],
+            'invalid-multi' => [
+                'value' => ['dog', 'fish'],
+                'allowedValues' => ['cat', 'dog'],
+                'exception' => false,
+                'expected' => false,
+            ],
+            'invalid-strict' => [
+                'value' => ['123'],
+                'allowedValues' => [123, 456],
+                'exception' => false,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, array $allowedValues, bool $exception, bool $expected): void
+    {
+        if ($exception) {
+            $this->expectException(InvalidArgumentException::class);
+        }
+        $validator = new MultiOptionFieldValidator('MyField', $value, $allowedValues);
+        $result = $validator->validate();
+        if (!$exception) {
+            $this->assertSame($expected, $result->isValid());
+        }
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/NumericFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/NumericFieldValidatorTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\NumericFieldValidator;
+use InvalidArgumentException;
+
+class NumericFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidateType(): array
+    {
+        return [
+            'valid-int' => [
+                'value' => 123,
+                'expected' => true,
+            ],
+            'valid-zero' => [
+                'value' => 0,
+                'expected' => true,
+            ],
+            'valid-negative-int' => [
+                'value' => -123,
+                'expected' => true,
+            ],
+            'valid-float' => [
+                'value' => 123.45,
+                'expected' => true,
+            ],
+            'valid-negative-float' => [
+                'value' => -123.45,
+                'expected' => true,
+            ],
+            'valid-max-int' => [
+                'value' => PHP_INT_MAX,
+                'expected' => true,
+            ],
+            'valid-min-int' => [
+                'value' => PHP_INT_MIN,
+                'expected' => true,
+            ],
+            'valid-max-float' => [
+                'value' => PHP_FLOAT_MAX,
+                'expected' => true,
+            ],
+            'valid-min-float' => [
+                'value' => PHP_FLOAT_MIN,
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'expected' => true,
+            ],
+            'invalid-string' => [
+                'value' => '123',
+                'expected' => false,
+            ],
+            'invalid-array' => [
+                'value' => [123],
+                'expected' => false,
+            ],
+            'invalid-true' => [
+                'value' => true,
+                'expected' => false,
+            ],
+            'invalid-false' => [
+                'value' => false,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidateType')]
+    public function testValidateType(mixed $value, bool $expected): void
+    {
+        $validator = new NumericFieldValidator('MyField', $value);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+
+    public static function provideValidate(): array
+    {
+        return [
+            'valid' => [
+                'value' => 10,
+                'minValue' => null,
+                'maxValue' => null,
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-min' => [
+                'value' => 15,
+                'minValue' => 10,
+                'maxValue' => null,
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-min-equal' => [
+                'value' => 10,
+                'minValue' => 10,
+                'maxValue' => null,
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-max' => [
+                'value' => 5,
+                'minValue' => null,
+                'maxValue' => 10,
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-max-equal' => [
+                'value' => 10,
+                'minValue' => null,
+                'maxValue' => 10,
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-min-max-between' => [
+                'value' => 15,
+                'minValue' => 10,
+                'maxValue' => 20,
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-min-max-equal' => [
+                'value' => 10,
+                'minValue' => 10,
+                'maxValue' => 10,
+                'exception' => false,
+                'expected' => true,
+            ],
+            'exception-min-above-max' => [
+                'value' => 15,
+                'minValue' => 20,
+                'maxValue' => 10,
+                'exception' => true,
+                'expected' => false,
+            ],
+            'invalid-below-min' => [
+                'value' => 5,
+                'minValue' => 10,
+                'maxValue' => 20,
+                'exception' => false,
+                'expected' => false,
+            ],
+            'invalid-above-max' => [
+                'value' => 25,
+                'minValue' => 10,
+                'maxValue' => 20,
+                'exception' => false,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(int $value, ?int $minValue, ?int $maxValue, bool $exception, bool $expected): void
+    {
+        if ($exception) {
+            $this->expectException(InvalidArgumentException::class);
+        }
+        $validator = new NumericFieldValidator('MyField', $value, $minValue, $maxValue);
+        $result = $validator->validate();
+        if (!$exception) {
+            $this->assertSame($expected, $result->isValid());
+        }
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/OptionFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/OptionFieldValidatorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\OptionFieldValidator;
+
+class OptionFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        return [
+            'valid-string' => [
+                'value' => 'cat',
+                'allowedValues' => ['cat', 'dog'],
+                'expected' => true,
+            ],
+            'valid-int' => [
+                'value' => 123,
+                'allowedValues' => [123, 456],
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'allowedValues' => ['cat', 'dog'],
+                'expected' => true,
+            ],
+            'invalid' => [
+                'value' => 'fish',
+                'allowedValues' => ['cat', 'dog'],
+                'expected' => false,
+            ],
+            'valid-empty-string' => [
+                'value' => '',
+                'allowedValues' => ['cat', 'dog'],
+                'expected' => false,
+            ],
+            'invalid-strict' => [
+                'value' => '123',
+                'allowedValues' => [123, 456],
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, array $allowedValues, bool $expected): void
+    {
+        $validator = new OptionFieldValidator('MyField', $value, $allowedValues);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/StringFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/StringFieldValidatorTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\StringFieldValidator;
+use SilverStripe\Dev\SapphireTest;
+
+class StringFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        return [
+            'valid-no-limit' => [
+                'value' => 'fish',
+                'minLength' => null,
+                'maxLength' => null,
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-blank' => [
+                'value' => '',
+                'minLength' => null,
+                'maxLength' => null,
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-max' => [
+                'value' => 'fish',
+                'minLength' => 0,
+                'maxLength' => 4,
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-less-than-max-null-min' => [
+                'value' => 'fish',
+                'minLength' => null,
+                'maxLength' => 4,
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-less-than-max-unicode' => [
+                'value' => '☕☕☕☕',
+                'minLength' => 0,
+                'maxLength' => 4,
+                'exception' => false,
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'minLength' => null,
+                'maxLength' => null,
+                'exception' => false,
+                'expected' => true,
+            ],
+            'exception-negative-min' => [
+                'value' => 'fish',
+                'minLength' => -1,
+                'maxLength' => null,
+                'exception' => true,
+                'expected' => false,
+            ],
+            'exception-negative-max' => [
+                'value' => 'fish',
+                'minLength' => null,
+                'maxLength' => -1,
+                'exception' => true,
+                'expected' => false,
+            ],
+            'exception-max-below-min' => [
+                'value' => 'fish',
+                'minLength' => 20,
+                'maxLength' => 10,
+                'exception' => true,
+                'expected' => false,
+            ],
+            'invalid-below-min' => [
+                'value' => 'fish',
+                'minLength' => 5,
+                'maxLength' => null,
+                'exception' => false,
+                'expected' => false,
+            ],
+            'invalid-below-min-unicode' => [
+                'value' => '☕☕☕☕',
+                'minLength' => 5,
+                'maxLength' => null,
+                'exception' => false,
+                'expected' => false,
+            ],
+            'invalid-blank-with-min' => [
+                'value' => '',
+                'minLength' => 5,
+                'maxLength' => null,
+                'exception' => false,
+                'expected' => false,
+            ],
+            'invalid-above-min' => [
+                'value' => 'fish',
+                'minLength' => 0,
+                'maxLength' => 3,
+                'exception' => false,
+                'expected' => false,
+            ],
+            'invalid-above-min-unicode' => [
+                'value' => '☕☕☕☕',
+                'minLength' => 0,
+                'maxLength' => 3,
+                'exception' => false,
+                'expected' => false,
+            ],
+            'invalid-int' => [
+                'value' => 123,
+                'minLength' => null,
+                'maxLength' => null,
+                'exception' => false,
+                'expected' => false,
+            ],
+            'invalid-float' => [
+                'value' => 123.56,
+                'minLength' => null,
+                'maxLength' => null,
+                'exception' => false,
+                'expected' => false,
+            ],
+            'invalid-true' => [
+                'value' => true,
+                'minLength' => null,
+                'maxLength' => null,
+                'exception' => false,
+                'expected' => false,
+            ],
+            'invalid-false' => [
+                'value' => false,
+                'minLength' => null,
+                'maxLength' => null,
+                'exception' => false,
+                'expected' => false,
+            ],
+            'invalid-array' => [
+                'value' => ['fish'],
+                'minLength' => null,
+                'maxLength' => null,
+                'exception' => false,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, ?int $minLength, ?int $maxLength, bool $exception, bool $expected): void
+    {
+        if ($exception) {
+            $this->expectException(InvalidArgumentException::class);
+        }
+        $validator = new StringFieldValidator('MyField', $value, $minLength, $maxLength);
+        $result = $validator->validate();
+        if (!$exception) {
+            $this->assertSame($expected, $result->isValid());
+        }
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/TimeFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/TimeFieldValidatorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\TimeFieldValidator;
+
+class TimeFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        return [
+            'valid' => [
+                'value' => '13:34:56',
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'expected' => true,
+            ],
+            'invalid' => [
+                'value' => '13:99:56',
+                'expected' => false,
+            ],
+            'invalid-wrong-format' => [
+                'value' => '13-34-56',
+                'expected' => false,
+            ],
+            'invalid-date-time' => [
+                'value' => '2020-09-15 13:34:56',
+                'expected' => false,
+            ],
+            'invalid-date' => [
+                'value' => '2020-09-15',
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, bool $expected): void
+    {
+        $validator = new TimeFieldValidator('MyField', $value);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/UrlFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/UrlFieldValidatorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\UrlFieldValidator;
+
+class UrlFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        // Using symfony/validator for implementation so only smoke testing
+        return [
+            'valid-https' => [
+                'value' => 'https://www.example.com',
+                'expected' => true,
+            ],
+            'valid-http' => [
+                'value' => 'https://www.example.com',
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'expected' => true,
+            ],
+            'invalid-ftp' => [
+                'value' => 'ftp://www.example.com',
+                'expected' => false,
+            ],
+            'invalid-no-scheme' => [
+                'value' => 'www.example.com',
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, bool $expected): void
+    {
+        $validator = new UrlFieldValidator('MyField', $value);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+}

--- a/tests/php/Core/Validation/FieldValidation/YearFieldValidatorTest.php
+++ b/tests/php/Core/Validation/FieldValidation/YearFieldValidatorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SilverStripe\Core\Tests\Validation\FieldValidation;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\Validation\FieldValidation\YearFieldValidator;
+use SilverStripe\ORM\FieldType\DBYear;
+
+class YearFieldValidatorTest extends SapphireTest
+{
+    public static function provideValidate(): array
+    {
+        // YearFieldValidator extends IntFieldValidator so only testing a subset
+        // of possible values here
+        return [
+            'valid-int' => [
+                'value' => 2021,
+                'expected' => true,
+            ],
+            'valid-zero' => [
+                'value' => 0,
+                'expected' => true,
+            ],
+            'valid-null' => [
+                'value' => null,
+                'expected' => true,
+            ],
+            'invalid-out-of-range-low' => [
+                'value' => 1850,
+                'expected' => false,
+            ],
+            'invalid-out-of-range-high' => [
+                'value' => 3000,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, bool $expected): void
+    {
+        $validator = new YearFieldValidator('MyField', $value, DBYear::MIN_YEAR, DBYear::MAX_YEAR);
+        $result = $validator->validate();
+        $this->assertSame($expected, $result->isValid());
+    }
+}

--- a/tests/php/Dev/CsvBulkLoaderTest.php
+++ b/tests/php/Dev/CsvBulkLoaderTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\Dev\Tests;
 use League\Csv\Writer;
 use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Dev\Tests\CsvBulkLoaderTest\CustomLoader;
+use SilverStripe\Dev\Tests\CsvBulkLoaderTest\Biscuit;
 use SilverStripe\Dev\Tests\CsvBulkLoaderTest\Player;
 use SilverStripe\Dev\Tests\CsvBulkLoaderTest\PlayerContract;
 use SilverStripe\Dev\Tests\CsvBulkLoaderTest\Team;
@@ -21,10 +22,10 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 class CsvBulkLoaderTest extends SapphireTest
 {
-
     protected static $fixture_file = 'CsvBulkLoaderTest.yml';
 
     protected static $extra_dataobjects = [
+        Biscuit::class,
         Team::class,
         Player::class,
         PlayerContract::class,
@@ -322,6 +323,22 @@ class CsvBulkLoaderTest extends SapphireTest
             ['FirstName' => 'Järg', 'Birthday' => '1982-06-30'],
             ['FirstName' => 'Jacob', 'Birthday' => '2000-04-30'],
         ], $players);
+    }
+
+    public function testLoadNumericTypes()
+    {
+        $loader = new CsvBulkLoader(Biscuit::class);
+        $loader->load($this->csvPath . 'Biscuits.csv');
+        $biscuits = Biscuit::get();
+        $this->assertCount(1, $biscuits);
+        $this->assertListContains([
+            [
+                'Title' => 'lorem',
+                'MyInt' => 12345,
+                'MyFloat' => 12.345,
+                'MyDecimal' => 123.45,
+            ],
+        ], $biscuits);
     }
 
     protected function getLineCount(&$file)

--- a/tests/php/Dev/CsvBulkLoaderTest/Biscuit.php
+++ b/tests/php/Dev/CsvBulkLoaderTest/Biscuit.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SilverStripe\Dev\Tests\CsvBulkLoaderTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class Biscuit extends DataObject implements TestOnly
+{
+    private static $db = [
+        'Title' => 'Varchar(255)',
+        'MyInt' => 'Int',
+        'MyFloat' => 'Float',
+        'MyDecimal' => 'Decimal',
+    ];
+
+    private static $table_name = 'CsvBulkLoaderTest_Biscuit';
+}

--- a/tests/php/Dev/CsvBulkLoaderTest/csv/Biscuits.csv
+++ b/tests/php/Dev/CsvBulkLoaderTest/csv/Biscuits.csv
@@ -1,0 +1,2 @@
+Title,MyInt,MyFloat,MyDecimal
+lorem,12345,12.345,123.45

--- a/tests/php/Forms/FormFieldTest.php
+++ b/tests/php/Forms/FormFieldTest.php
@@ -39,6 +39,7 @@ use SilverStripe\Security\PermissionCheckboxSetField_Readonly;
 use SilverStripe\Forms\SearchableMultiDropdownField;
 use SilverStripe\Forms\SearchableDropdownField;
 use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\ORM\FieldType\DBInt;
 
 class FormFieldTest extends SapphireTest
 {

--- a/tests/php/ORM/DBBigIntTest.php
+++ b/tests/php/ORM/DBBigIntTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SilverStripe\ORM\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\FieldType\DBBigInt;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class DBBigIntTest extends SapphireTest
+{
+    public static function provideSetValue(): array
+    {
+        return [
+            'int' => [
+                'value' => 3,
+                'expected' => 3,
+            ],
+            'string-int' => [
+                'value' => '3',
+                'expected' => 3,
+            ],
+            'string-int-max' => [
+                'value' => '9223372036854775807',
+                // note: need to cast string to int rather than use defined int or it will turn into a float
+                'expected' => (int) '9223372036854775807',
+            ],
+            'string-int-min' => [
+                'value' => '-9223372036854775808',
+                // note: need to cast string to int rather than use defined int or it will turn into a float
+                'expected' => (int) '-9223372036854775808',
+            ],
+            'string-int-too-large' => [
+                'value' => '9223372036854775808',
+                'expected' => '9223372036854775808',
+            ],
+            'string-int-too-small' => [
+                'value' => '-9223372036854775809',
+                'expected' => '-9223372036854775809',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideSetValue')]
+    public function testSetValue(mixed $value, mixed $expected): void
+    {
+        $field = new DBBigInt('MyField');
+        $field->setValue($value);
+        $this->assertSame($expected, $field->getValue());
+    }
+}

--- a/tests/php/ORM/DBBooleanTest.php
+++ b/tests/php/ORM/DBBooleanTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SilverStripe\ORM\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\ORM\FieldType\DBBoolean;
+
+class DBBooleanTest extends SapphireTest
+{
+    public function testDefaultValue(): void
+    {
+        $field = new DBBoolean('MyField');
+        $this->assertSame(false, $field->getValue());
+    }
+
+    public static function provideSetValue(): array
+    {
+        return [
+            'true' => [
+                'value' => true,
+                'expected' => true,
+            ],
+            'false' => [
+                'value' => false,
+                'expected' => false,
+            ],
+            '1-int' => [
+                'value' => 1,
+                'expected' => true,
+            ],
+            '1-string' => [
+                'value' => '1',
+                'expected' => true,
+            ],
+            '0-int' => [
+                'value' => 0,
+                'expected' => false,
+            ],
+            '0-string' => [
+                'value' => '0',
+                'expected' => false,
+            ],
+            't' => [
+                'value' => 't',
+                'expected' => true,
+            ],
+            'f' => [
+                'value' => 'f',
+                'expected' => false,
+            ],
+            'T' => [
+                'value' => 'T',
+                'expected' => true,
+            ],
+            'F' => [
+                'value' => 'F',
+                'expected' => false,
+            ],
+            'true-string' => [
+                'value' => 'true',
+                'expected' => true,
+            ],
+            'false-string' => [
+                'value' => 'false',
+                'expected' => false,
+            ],
+            '2-int' => [
+                'value' => 2,
+                'expected' => 2,
+            ],
+            '0.0' => [
+                'value' => 0.0,
+                'expected' => 0.0,
+            ],
+            '1.0' => [
+                'value' => 1.0,
+                'expected' => 1.0,
+            ],
+            'null' => [
+                'value' => null,
+                'expected' => null,
+            ],
+            'array' => [
+                'value' => [],
+                'expected' => [],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideSetValue')]
+    public function testSetValue(mixed $value, mixed $expected): void
+    {
+        $field = new DBBoolean('MyField');
+        $field->setValue($value);
+        $this->assertSame($expected, $field->getValue());
+    }
+}

--- a/tests/php/ORM/DBCompositeTest.php
+++ b/tests/php/ORM/DBCompositeTest.php
@@ -6,6 +6,9 @@ use SilverStripe\ORM\FieldType\DBMoney;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\SapphireTest;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\ORM\FieldType\DBVarchar;
+use SilverStripe\ORM\FieldType\DBDecimal;
 
 class DBCompositeTest extends SapphireTest
 {
@@ -139,5 +142,13 @@ class DBCompositeTest extends SapphireTest
         // of the DoubleMoney field based on the initial values
         // $this->assertSame($moneyField, $obj->dbObject('DoubleMoney'));
         // $this->assertEquals(20, $obj->dbObject('DoubleMoney')->getAmount());
+    }
+
+    public function testGetValueForValidation(): void
+    {
+        $obj = DBCompositeTest\DBDoubleMoney::create();
+        $expected = [DBVarchar::class, DBDecimal::class];
+        $actual = array_map('get_class', $obj->getValueForValidation());
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/php/ORM/DBCurrencyTest.php
+++ b/tests/php/ORM/DBCurrencyTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\ORM\Tests;
 use SilverStripe\Forms\CurrencyField;
 use SilverStripe\ORM\FieldType\DBCurrency;
 use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DBCurrencyTest extends SapphireTest
 {
@@ -14,11 +15,6 @@ class DBCurrencyTest extends SapphireTest
         $tests = [
             // Test basic operation
             '$50.00' => ['$50.00', '$50'],
-
-            // Test removal of junk text
-            'this is -50.29 dollars' => ['($50.29)', '($50)'],
-            'this is -50.79 dollars' => ['($50.79)', '($51)'],
-            'this is 50.79 dollars' => ['$50.79', '$51'],
 
             // Test negative numbers
             '-1000' => ['($1,000.00)','($1,000)'],
@@ -30,9 +26,6 @@ class DBCurrencyTest extends SapphireTest
             // Test scientific notation
             '5.68434188608E-14' => ['$0.00', '$0'],
             '5.68434188608E7' => ['$56,843,418.86', '$56,843,419'],
-            "Sometimes Es are still bad: 51 dollars, even though they\'re used in scientific notation"
-                => ['$51.00', '$51'],
-            "What about 5.68434188608E7 in the middle of a string" => ['$56,843,418.86', '$56,843,419'],
         ];
 
         foreach ($tests as $value => $niceValues) {
@@ -50,5 +43,76 @@ class DBCurrencyTest extends SapphireTest
         $scaffoldedField = $currencyDbField->scaffoldFormField();
 
         $this->assertInstanceOf(CurrencyField::class, $scaffoldedField);
+    }
+
+    public static function provideSetValue(): array
+    {
+        // Most test cases covered by DBCurrencyTest, only testing a subset here
+        return [
+            'currency' => [
+                'value' => '$1.23',
+                'expected' => 1.23,
+            ],
+            'negative-currency' => [
+                'value' => "-$1.23",
+                'expected' => -1.23,
+            ],
+            'scientific-1' => [
+                'value' => 5.68434188608E-14,
+                'expected' => 5.68434188608E-14,
+            ],
+            'scientific-2' => [
+                'value' => 5.68434188608E7,
+                'expected' => 56843418.8608,
+            ],
+            'scientific-1-string' => [
+                'value' => '5.68434188608E-14',
+                'expected' => 5.68434188608E-14,
+            ],
+            'scientific-2-string' => [
+                'value' => '5.68434188608E7',
+                'expected' => 56843418.8608,
+            ],
+            'int' => [
+                'value' => 1,
+                'expected' => 1.0,
+            ],
+            'string-int' => [
+                'value' => "1",
+                'expected' => 1.0,
+            ],
+            'string-float' => [
+                'value' => '1.2',
+                'expected' => 1.2,
+            ],
+            'value-in-string' => [
+                'value' => 'this is 50.29 dollars',
+                'expected' => 'this is 50.29 dollars',
+            ],
+            'scientific-value-in-string' => [
+                'value' => '5.68434188608E7 a string',
+                'expected' => '5.68434188608E7 a string',
+            ],
+            'value-in-brackets' => [
+                'value' => '(100)',
+                'expected' => '(100)',
+            ],
+            'non-numeric' => [
+                'value' => 'fish',
+                'expected' => 'fish',
+            ],
+            'null' => [
+                'value' => null,
+                'expected' => null,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideSetValue')]
+    public function testSetValue(mixed $value, mixed $expected): void
+    {
+        $field = new DBCurrency('MyField');
+        $field->setValue($value);
+        $this->assertSame($expected, $field->getValue());
     }
 }

--- a/tests/php/ORM/DBDecimalTest.php
+++ b/tests/php/ORM/DBDecimalTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SilverStripe\ORM\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\FieldType\DBInt;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\ORM\FieldType\DBDecimal;
+
+class DBDecimalTest extends SapphireTest
+{
+    public function testDefaultValue(): void
+    {
+        $field = new DBDecimal('MyField');
+        $this->assertSame(0.0, $field->getValue());
+    }
+
+    public static function provideSetValue(): array
+    {
+        return [
+            'float' => [
+                'value' => 9.123,
+                'expected' => 9.123,
+            ],
+            'negative-float' => [
+                'value' => -9.123,
+                'expected' => -9.123,
+            ],
+            'string-float' => [
+                'value' => '9.123',
+                'expected' => 9.123,
+            ],
+            'string-negative-float' => [
+                'value' => '-9.123',
+                'expected' => -9.123,
+            ],
+            'zero' => [
+                'value' => 0,
+                'expected' => 0.0,
+            ],
+            'int' => [
+                'value' => 3,
+                'expected' => 3.0,
+            ],
+            'negative-int' => [
+                'value' => -3,
+                'expected' => -3.0,
+            ],
+            'string-int' => [
+                'value' => '3',
+                'expected' => 3.0,
+            ],
+            'negative-string-int' => [
+                'value' => '-3',
+                'expected' => -3.0,
+            ],
+            'string' => [
+                'value' => 'fish',
+                'expected' => 'fish',
+            ],
+            'array' => [
+                'value' => [],
+                'expected' => [],
+            ],
+            'null' => [
+                'value' => null,
+                'expected' => null,
+            ],
+            'true' => [
+                'value' => true,
+                'expected' => true,
+            ],
+            'false' => [
+                'value' => false,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideSetValue')]
+    public function testSetValue(mixed $value, mixed $expected): void
+    {
+        $field = new DBDecimal('MyField');
+        $field->setValue($value);
+        $this->assertSame($expected, $field->getValue());
+    }
+}

--- a/tests/php/ORM/DBEnumTest.php
+++ b/tests/php/ORM/DBEnumTest.php
@@ -118,7 +118,7 @@ class DBEnumTest extends SapphireTest
 
         $obj2 = new FieldType\DBEnumTestObject();
         $obj2->Colour = 'Purple';
-        $obj2->write();
+        $obj2->write(skipValidation: true);
 
         $this->assertEquals(
             ['Purple', 'Red'],
@@ -140,5 +140,57 @@ class DBEnumTest extends SapphireTest
             ['Blue', 'Green'],
             $colourField->getEnumObsolete()
         );
+    }
+
+    public static function provideSetValue(): array
+    {
+        return [
+            'string' => [
+                'value' => 'green',
+                'expected' => 'green',
+            ],
+            'string-not-in-set' => [
+                'value' => 'purple',
+                'expected' => 'purple',
+            ],
+            'int' => [
+                'value' => 123,
+                'expected' => 123,
+            ],
+            'empty-string' => [
+                'value' => '',
+                'expected' => '',
+            ],
+            'null' => [
+                'value' => null,
+                'expected' => null,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideSetValue')]
+    public function testSetValue(mixed $value, mixed $expected): void
+    {
+        $field = new DBEnum('TestField', ['red', 'green', 'blue'], 'blue');
+        $field->setValue($value);
+        $this->assertSame($expected, $field->getValue());
+    }
+
+    public function testSaveDefaultValue()
+    {
+        $obj = new FieldType\DBEnumTestObject();
+        $id = $obj->write();
+        // Fetch the object from the database
+        $obj = FieldType\DBEnumTestObject::get()->byID($id);
+        $this->assertEquals('Red', $obj->Colour);
+        $this->assertEquals('Blue', $obj->ColourWithDefault);
+        // Set value to null and save
+        $obj->Colour = null;
+        $obj->ColourWithDefault = null;
+        $obj->write();
+        // Fetch the object from the database
+        $obj = FieldType\DBEnumTestObject::get()->byID($id);
+        $this->assertEquals(null, $obj->Colour);
+        $this->assertEquals(null, $obj->ColourWithDefault);
     }
 }

--- a/tests/php/ORM/DBFieldTest.php
+++ b/tests/php/ORM/DBFieldTest.php
@@ -2,7 +2,7 @@
 
 namespace SilverStripe\ORM\Tests;
 
-use SilverStripe\Assets\Image;
+use Exception;
 use SilverStripe\ORM\FieldType\DBBigInt;
 use SilverStripe\ORM\FieldType\DBBoolean;
 use SilverStripe\ORM\FieldType\DBCurrency;
@@ -30,6 +30,33 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBYear;
 use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Core\ClassInfo;
+use ReflectionClass;
+use SilverStripe\Core\Validation\FieldValidation\BooleanFieldValidator;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Core\Validation\FieldValidation\BigIntFieldValidator;
+use SilverStripe\ORM\FieldType\DBClassName;
+use ReflectionMethod;
+use SilverStripe\Core\Validation\FieldValidation\CompositeFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\DateFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\DecimalFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\EmailFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\OptionFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\IntFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\IpFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\LocaleFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\MultiOptionFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\StringFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\TimeFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\UrlFieldValidator;
+use SilverStripe\Core\Validation\FieldValidation\YearFieldValidator;
+use SilverStripe\ORM\FieldType\DBUrl;
+use SilverStripe\ORM\FieldType\DBPolymorphicRelationAwareForeignKey;
+use SilverStripe\ORM\FieldType\DBIp;
+use SilverStripe\ORM\FieldType\DBEmail;
+use SilverStripe\Core\Validation\FieldValidation\DatetimeFieldValidator;
+use SilverStripe\ORM\FieldType\DBClassNameVarchar;
+use SilverStripe\Core\Validation\FieldValidation\NumericFieldValidator;
 
 /**
  * Tests for DBField objects.
@@ -391,5 +418,170 @@ class DBFieldTest extends SapphireTest
         $obj->MyTestField = $field;
 
         $this->assertEquals('new value', $obj->getField('MyTestField'));
+    }
+
+    public function testDefaultValues(): void
+    {
+        $expectedBaseDefault = null;
+        $expectedDefaults = [
+            DBBoolean::class => false,
+            DBDecimal::class => 0.0,
+            DBInt::class => 0,
+            DBFloat::class => 0.0,
+        ];
+        $count = 0;
+        $classes = ClassInfo::subclassesFor(DBField::class);
+        foreach ($classes as $class) {
+            if (is_a($class, TestOnly::class, true)) {
+                continue;
+            }
+            if (!str_starts_with($class, 'SilverStripe\ORM\FieldType')) {
+                continue;
+            }
+            $reflector = new ReflectionClass($class);
+            if ($reflector->isAbstract()) {
+                continue;
+            }
+            $expected = $expectedBaseDefault;
+            foreach ($expectedDefaults as $baseClass => $default) {
+                if ($class === $baseClass || is_subclass_of($class, $baseClass)) {
+                    $expected = $default;
+                    break;
+                }
+            }
+            $field = new $class('TestField');
+            $this->assertSame($expected, $field->getValue(), $class);
+            $count++;
+        }
+        // Assert that we have tested all classes e.g. namespace wasn't changed, no new classes were added
+        // that haven't been tested
+        $this->assertSame(29, $count);
+    }
+
+    public function testFieldValidatorConfig(): void
+    {
+        $expectedFieldValidators = [
+            DBBigInt::class => [
+                BigIntFieldValidator::class,
+            ],
+            DBBoolean::class => [
+                BooleanFieldValidator::class,
+            ],
+            DBClassName::class => [
+                StringFieldValidator::class,
+                OptionFieldValidator::class,
+            ],
+            DBClassNameVarchar::class => [
+                StringFieldValidator::class,
+                OptionFieldValidator::class,
+            ],
+            DBCurrency::class => [
+                DecimalFieldValidator::class,
+            ],
+            DBDate::class => [
+                DateFieldValidator::class,
+            ],
+            DBDatetime::class => [
+                DatetimeFieldValidator::class,
+            ],
+            DBDecimal::class => [
+                DecimalFieldValidator::class,
+            ],
+            DBDouble::class => [
+                NumericFieldValidator::class,
+            ],
+            DBEmail::class => [
+                StringFieldValidator::class,
+                EmailFieldValidator::class,
+            ],
+            DBEnum::class => [
+                StringFieldValidator::class,
+                OptionFieldValidator::class,
+            ],
+            DBFloat::class => [
+                NumericFieldValidator::class,
+            ],
+            DBForeignKey::class => [
+                IntFieldValidator::class,
+            ],
+            DBHTMLText::class => [
+                StringFieldValidator::class,
+            ],
+            DBHTMLVarchar::class => [
+                StringFieldValidator::class,
+            ],
+            DBInt::class => [
+                IntFieldValidator::class,
+            ],
+            DBIp::class => [
+                StringFieldValidator::class,
+                IpFieldValidator::class,
+            ],
+            DBLocale::class => [
+                StringFieldValidator::class,
+                LocaleFieldValidator::class,
+            ],
+            DBMoney::class => [
+                CompositeFieldValidator::class,
+            ],
+            DBMultiEnum::class => [
+                MultiOptionFieldValidator::class,
+            ],
+            DBPercentage::class => [
+                DecimalFieldValidator::class,
+            ],
+            DBPolymorphicForeignKey::class => [
+                CompositeFieldValidator::class,
+            ],
+            DBPolymorphicRelationAwareForeignKey::class => [
+                CompositeFieldValidator::class,
+            ],
+            DBPrimaryKey::class => [
+                IntFieldValidator::class,
+            ],
+            DBText::class => [
+                StringFieldValidator::class,
+            ],
+            DBTime::class => [
+                TimeFieldValidator::class,
+            ],
+            DBUrl::class => [
+                StringFieldValidator::class,
+                UrlFieldValidator::class,
+            ],
+            DBVarchar::class => [
+                StringFieldValidator::class,
+            ],
+            DBYear::class => [
+                YearFieldValidator::class,
+            ],
+        ];
+        $count = 0;
+        $classes = ClassInfo::subclassesFor(DBField::class);
+        foreach ($classes as $class) {
+            if (is_a($class, TestOnly::class, true)) {
+                continue;
+            }
+            if (!str_starts_with($class, 'SilverStripe\ORM\FieldType')) {
+                continue;
+            }
+            $reflector = new ReflectionClass($class);
+            if ($reflector->isAbstract()) {
+                continue;
+            }
+            if (!array_key_exists($class, $expectedFieldValidators)) {
+                throw new Exception("No field validator config found for $class");
+            }
+            $expected = $expectedFieldValidators[$class];
+            $method = new ReflectionMethod($class, 'getFieldValidators');
+            $method->setAccessible(true);
+            $obj = new $class('MyField');
+            $actual = array_map('get_class', $method->invoke($obj));
+            $this->assertSame($expected, $actual, $class);
+            $count++;
+        }
+        // Assert that we have tested all classes e.g. namespace wasn't changed, no new classes were added
+        // that haven't been tested
+        $this->assertSame(29, $count);
     }
 }

--- a/tests/php/ORM/DBFloatTest.php
+++ b/tests/php/ORM/DBFloatTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace SilverStripe\ORM\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\ORM\FieldType\DBFloat;
+
+class DBFloatTest extends SapphireTest
+{
+    public function testDefaultValue(): void
+    {
+        $field = new DBFloat('MyField');
+        $this->assertSame(0.0, $field->getValue());
+    }
+
+    public static function provideSetValue(): array
+    {
+        return [
+            'float' => [
+                'value' => 9.123,
+                'expected' => 9.123,
+            ],
+            'negative-float' => [
+                'value' => -9.123,
+                'expected' => -9.123,
+            ],
+            'string-float' => [
+                'value' => '9.123',
+                'expected' => 9.123,
+            ],
+            'string-negative-float' => [
+                'value' => '-9.123',
+                'expected' => -9.123,
+            ],
+            'zero' => [
+                'value' => 0,
+                'expected' => 0.0,
+            ],
+            'int' => [
+                'value' => 3,
+                'expected' => 3.0,
+            ],
+            'negative-int' => [
+                'value' => -3,
+                'expected' => -3.0,
+            ],
+            'string-int' => [
+                'value' => '3',
+                'expected' => 3.0,
+            ],
+            'negative-string-int' => [
+                'value' => '-3',
+                'expected' => -3.0,
+            ],
+            'string' => [
+                'value' => 'fish',
+                'expected' => 'fish',
+            ],
+            'array' => [
+                'value' => [],
+                'expected' => [],
+            ],
+            'null' => [
+                'value' => null,
+                'expected' => null,
+            ],
+            'true' => [
+                'value' => true,
+                'expected' => true,
+            ],
+            'false' => [
+                'value' => false,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideSetValue')]
+    public function testSetValue(mixed $value, mixed $expected): void
+    {
+        $field = new DBFloat('MyField');
+        $field->setValue($value);
+        $this->assertSame($expected, $field->getValue());
+    }
+}

--- a/tests/php/ORM/DBForiegnKeyTest.php
+++ b/tests/php/ORM/DBForiegnKeyTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SilverStripe\ORM\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\ORM\FieldType\DBForeignKey;
+
+class DBForiegnKeyTest extends SapphireTest
+{
+    public static function provideSetValue(): array
+    {
+        return [
+            'int' => [
+                'value' => 2,
+                'expected' => 2,
+            ],
+            'string' => [
+                'value' => '2',
+                'expected' => 2,
+            ],
+            'zero' => [
+                'value' => 0,
+                'expected' => 0,
+            ],
+            'blank-string' => [
+                'value' => '',
+                'expected' => 0,
+            ],
+            'null' => [
+                'value' => null,
+                'expected' => null,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideSetValue')]
+    public function testSetValue(mixed $value, mixed $expected): void
+    {
+        $field = new DBForeignKey('TestField');
+        $field->setValue($value);
+        $this->assertSame($expected, $field->getValue());
+    }
+}

--- a/tests/php/ORM/DBIntTest.php
+++ b/tests/php/ORM/DBIntTest.php
@@ -4,15 +4,82 @@ namespace SilverStripe\ORM\Tests;
 
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\FieldType\DBInt;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DBIntTest extends SapphireTest
 {
-    public function testGetValueCastToInt()
+    public function testDefaultValue(): void
     {
-        $field = DBInt::create('MyField');
-        $field->setValue(3);
-        $this->assertSame(3, $field->getValue());
-        $field->setValue('3');
-        $this->assertSame(3, $field->getValue());
+        $field = new DBInt('MyField');
+        $this->assertSame(0, $field->getValue());
+    }
+
+    public static function provideSetValue(): array
+    {
+        return [
+            'int' => [
+                'value' => 3,
+                'expected' => 3,
+            ],
+            'string-int' => [
+                'value' => '3',
+                'expected' => 3,
+            ],
+            'negative-int' => [
+                'value' => -3,
+                'expected' => -3,
+            ],
+            'negative-string-int' => [
+                'value' => '-3',
+                'expected' => -3,
+            ],
+            'float' => [
+                'value' => 3.5,
+                'expected' => 3.5,
+            ],
+            'string' => [
+                'value' => 'fish',
+                'expected' => 'fish',
+            ],
+            'array' => [
+                'value' => [],
+                'expected' => [],
+            ],
+            'null' => [
+                'value' => null,
+                'expected' => null,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideSetValue')]
+    public function testSetValue(mixed $value, mixed $expected): void
+    {
+        $field = new DBInt('MyField');
+        $field->setValue($value);
+        $this->assertSame($expected, $field->getValue());
+    }
+
+    public static function provideValidate(): array
+    {
+        return [
+            'valid' => [
+                'value' => 123,
+                'expected' => true,
+            ],
+            'invalid' => [
+                'value' => 'abc',
+                'expected' => false,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideValidate')]
+    public function testValidate(mixed $value, bool $expected): void
+    {
+        $field = new DBInt('MyField');
+        $field->setValue($value);
+        $result = $field->validate();
+        $this->assertSame($expected, $result->isValid());
     }
 }

--- a/tests/php/ORM/DBMultiEnumTest.php
+++ b/tests/php/ORM/DBMultiEnumTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SilverStripe\ORM\Tests;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\FieldType\DBMultiEnum;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class DBMultiEnumTest extends SapphireTest
+{
+    public static function provideGetValueForValidation(): array
+    {
+        return [
+            'array' => [
+                'value' => ['Red', 'Green'],
+                'expected' => ['Red', 'Green'],
+            ],
+            'string' => [
+                'value' => 'Red,Green',
+                'expected' => ['Red', 'Green'],
+            ],
+            'string-non-existant-value' => [
+                'value' => 'Red,Green,Purple',
+                'expected' => ['Red', 'Green', 'Purple'],
+            ],
+            'empty-string' => [
+                'value' => '',
+                'expected' => [''],
+            ],
+            'null' => [
+                'value' => null,
+                'expected' => null,
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetValueForValidation')]
+    public function testGetValueForValidation(mixed $value, mixed $expected): void
+    {
+        $obj = new DBMultiEnum('TestField', ['Red', 'Green', 'Blue']);
+        $obj->setValue($value);
+        $this->assertSame($expected, $obj->getValueForValidation());
+    }
+}

--- a/tests/php/ORM/DBStringTest.php
+++ b/tests/php/ORM/DBStringTest.php
@@ -7,6 +7,7 @@ use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBString;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\Tests\DBStringTest\MyStringField;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DBStringTest extends SapphireTest
 {

--- a/tests/php/ORM/DBYearTest.php
+++ b/tests/php/ORM/DBYearTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\ORM\Tests;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\ORM\FieldType\DBYear;
 use SilverStripe\Dev\SapphireTest;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DBYearTest extends SapphireTest
 {
@@ -18,15 +19,15 @@ class DBYearTest extends SapphireTest
         $field = $year->scaffoldFormField("YearTest");
         $this->assertEquals(DropdownField::class, get_class($field));
 
-        //This should be a list of years from the current one, counting down to 1900
+        //This should be a list of years from the current one, counting down to 1901
         $source = $field->getSource();
 
         $lastValue = end($source);
         $lastKey = key($source ?? []);
 
-        //Keys and values should be the same - and the last one should be 1900
-        $this->assertEquals(1900, $lastValue);
-        $this->assertEquals(1900, $lastKey);
+        //Keys and values should be the same - and the last one should be 1901
+        $this->assertEquals(1901, $lastValue);
+        $this->assertEquals(1901, $lastKey);
     }
 
     public function testScaffoldFormFieldLast()
@@ -42,5 +43,99 @@ class DBYearTest extends SapphireTest
 
         $this->assertEquals($currentYear, $firstValue);
         $this->assertEquals($currentYear, $firstKey);
+    }
+
+    public static function provideSetValue(): array
+    {
+        return [
+            '4-int' => [
+                'value' => 2024,
+                'expected' => 2024,
+            ],
+            '2-int' => [
+                'value' => 24,
+                'expected' => 2024,
+            ],
+            '0-int' => [
+                'value' => 0,
+                'expected' => 0,
+            ],
+            '4-string' => [
+                'value' => '2024',
+                'expected' => 2024,
+            ],
+            '2-string' => [
+                'value' => '24',
+                'expected' => 2024,
+            ],
+            '0-string' => [
+                'value' => '0',
+                'expected' => 0,
+            ],
+            '00-string' => [
+                'value' => '00',
+                'expected' => 2000,
+            ],
+            '0000-string' => [
+                'value' => '0000',
+                'expected' => 0,
+            ],
+            '4-int-low' => [
+                'value' => 1900,
+                'expected' => 1900,
+            ],
+            '4-int-low' => [
+                'value' => 2156,
+                'expected' => 2156,
+            ],
+            '4-string-low' => [
+                'value' => '1900',
+                'expected' => 1900,
+            ],
+            '4-string-low' => [
+                'value' => '2156',
+                'expected' => 2156,
+            ],
+            'int-negative' => [
+                'value' => -2024,
+                'expected' => -2024,
+            ],
+            'string-negative' => [
+                'value' => '-2024',
+                'expected' => '-2024',
+            ],
+            'float' => [
+                'value' => 2024.0,
+                'expected' => 2024.0,
+            ],
+            'string-float' => [
+                'value' => '2024.0',
+                'expected' => '2024.0',
+            ],
+            'null' => [
+                'value' => null,
+                'expected' => null,
+            ],
+            'true' => [
+                'value' => true,
+                'expected' => true,
+            ],
+            'false' => [
+                'value' => false,
+                'expected' => false,
+            ],
+            'array' => [
+                'value' => [],
+                'expected' => [],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideSetValue')]
+    public function testSetValue(mixed $value, mixed $expected): void
+    {
+        $field = new DBYear('MyField');
+        $result = $field->setValue($value);
+        $this->assertSame($expected, $field->getValue());
     }
 }

--- a/tests/php/ORM/DecimalTest.php
+++ b/tests/php/ORM/DecimalTest.php
@@ -24,22 +24,23 @@ class DecimalTest extends SapphireTest
     {
         parent::setUp();
         $this->testDataObject = $this->objFromFixture(DecimalTest\TestObject::class, 'test-dataobject');
+        $x=1;
     }
 
     public function testDefaultValue()
     {
-        $this->assertEquals(
+        $this->assertSame(
+            0.0,
             $this->testDataObject->MyDecimal1,
-            0,
-            'Database default for Decimal type is 0'
+            'Database default for Decimal type is 0.0'
         );
     }
 
     public function testSpecifiedDefaultValue()
     {
-        $this->assertEquals(
-            $this->testDataObject->MyDecimal2,
+        $this->assertSame(
             2.5,
+            $this->testDataObject->MyDecimal2,
             'Default value for Decimal type is set to 2.5'
         );
     }
@@ -52,37 +53,37 @@ class DecimalTest extends SapphireTest
 
     public function testSpecifiedDefaultValueInDefaultsArray()
     {
-        $this->assertEquals(
+        $this->assertSame(
             $this->testDataObject->MyDecimal4,
-            4,
+            4.0,
             'Default value for Decimal type is set to 4'
         );
     }
 
     public function testLongValueStoredCorrectly()
     {
-        $this->assertEquals(
-            $this->testDataObject->MyDecimal5,
+        $this->assertSame(
             1.0,
+            $this->testDataObject->MyDecimal5,
             'Long default long decimal value is rounded correctly'
         );
 
         $this->assertEqualsWithDelta(
-            $this->testDataObject->MyDecimal5,
             0.99999999999999999999,
+            $this->testDataObject->MyDecimal5,
             PHP_FLOAT_EPSILON,
             'Long default long decimal value is correct within float epsilon'
         );
 
-        $this->assertEquals(
-            $this->testDataObject->MyDecimal6,
+        $this->assertSame(
             8.0,
+            $this->testDataObject->MyDecimal6,
             'Long decimal value with a default value is rounded correctly'
         );
 
         $this->assertEqualsWithDelta(
-            $this->testDataObject->MyDecimal6,
             7.99999999999999999999,
+            $this->testDataObject->MyDecimal6,
             PHP_FLOAT_EPSILON,
             'Long decimal value is within epsilon if longer than allowed number of float digits'
         );

--- a/tests/php/ORM/FieldType/DBEnumTestObject.php
+++ b/tests/php/ORM/FieldType/DBEnumTestObject.php
@@ -11,5 +11,6 @@ class DBEnumTestObject extends DataObject
 
     private static $db = [
         'Colour' => 'Enum("Red,Blue,Green")',
+        'ColourWithDefault' => 'Enum("Red,Blue,Green","Blue")',
     ];
 }

--- a/tests/php/View/CastingServiceTest.php
+++ b/tests/php/View/CastingServiceTest.php
@@ -67,7 +67,7 @@ class CastingServiceTest extends SapphireTest
                 'expected' => DBHTMLText::class,
             ],
             [
-                'data' => '12.35',
+                'data' => 12.35,
                 'source' => TestDataObject::class,
                 'fieldName' => 'OverrideCastingHelper',
                 'expected' => DBCurrency::class,


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11403

- Adds the new FieldValiator class and multple subclasses
- Adds a mechanism for adding FieldValidators to DBFields and FormFields, and calling them when appropriate
- Updates some setValue() methods on DBField subclasses to convert values e.g. string integers to integers. This is mainly done to soften some of the upgrade pain now that just about everything is being validated.
- Adds new DBField types - DBEmail, DBIp, DBUrl
- ~~Adds a $value param to ValidationResult. This is mainly to make debugging easier.~~

~Note that while this PR adds support to FormField for FieldValidators, I haven't actually added the FieldValidators to the FormField's in this PR, as too much would be changing at once and many things would break in CI. Instead I've split off a [separate issue](https://github.com/silverstripe/silverstripe-framework/issues/11422) for that to be done after this has been merged~ Have removed FormField changes

There is some type conversion going on in `DBField::setValue()`, which happens before validation, though I'm trying to not be too permissive as this PR is essentially adding strict typing to DBFields.  Some examples:

- DBBoolean allows a wide range of values for backwards compatibility e.g. `'t'` will get converted to `true`
- DBInt will convert numeric ints to int. One reason for allow this is because HTTP form field submissions are strings, so it's required when doing things like $form->saveInto($dataObject);
- DBDecimal will convert int to float, because not allowing $obj->MyDecimal = 5; is pointlessly annoying as we're not loosing any precision. Note the opposite is not allowed i.e. there is no conversion when going $obj->MyInt = 5.1, as this would truncate the decimal place. This will trigger a validation exception instead.

A few things that we might want to consider changing (easiest done as follow up cards):
- ~DBBoolean should possibly stop accepting values such as 't'~ will retain backward compatibility
- ~DBDate currently accepts a range of dates and attempts to fix things. Changes were made in this PR, though one not unexpected and not great side effect is that a value that previously threw an error during `DBDate::setValue()` "03-03-04" now gets turned into "2003-03-04". The existing behaviour of turning "0" into "1970-01-01" remain. Perhaps we should be stricter and only allow 'Y-m-d' style inputs.~ Have reverted changes, now behaves like CMS 5
- DBTime::parseTime() uses strtotime() so will parse things like "23.02.56" and "11:02 pm". We should consider forcing "H:i:s" format for all inputted strings
- DBString subclasses e.g. DBVarchar will not convert int/float to string. The intention here is a user may mistakenly be assigning ints/floats to a Varchar field and then later attempt numeric operation e.g. adding, subtraction.  Argument could be made that we should convert here. (opposite of above points, i.e. be "more helpful" rather than "more strict")

Also to answer the question "why are we even doing this when you can just get the database to do this?". It's because we cannot give any guarantees is MySQL is set in strict mode (will complain and not update value when invalid) vs not in strict mode (will truncate and insert). Also, FieldValidator is an abstract class that will be shared with FormField validation, which doesn't even touch the database. Also, things like EmailFieldValidator can't be validated by MySQL.