### PR TITLE
MNT Fix unit tests

### DIFF
--- a/tests/php/Forms/DateFieldDisabledTest.php
+++ b/tests/php/Forms/DateFieldDisabledTest.php
@@ -12,7 +12,8 @@ class DateFieldDisabledTest extends SapphireTest
     protected function setUp(): void
     {
         parent::setUp();
-        i18n::set_locale('en_NZ');
+        // Set to an explicit locale so project-level locale swapping doesn't affect tests
+        i18n::set_locale('en_US');
         DBDatetime::set_mock_now('2011-02-01 8:34:00');
     }
 
@@ -22,7 +23,7 @@ class DateFieldDisabledTest extends SapphireTest
         $actual = DateField_Disabled::create('Test')
             ->setValue('2011-02-01')
             ->Field();
-        $expected = '<span class="readonly" id="Test">1/02/2011 (today)</span>';
+        $expected = '<span class="readonly" id="Test">Feb 1, 2011 (today)</span>';
         $this->assertEquals($expected, $actual);
 
         // Test today's date with time
@@ -38,14 +39,14 @@ class DateFieldDisabledTest extends SapphireTest
         $actual = DateField_Disabled::create('Test')
             ->setValue('2011-01-27')
             ->Field();
-        $expected = '<span class="readonly" id="Test">27/01/2011, 5 days ago</span>';
+        $expected = '<span class="readonly" id="Test">Jan 27, 2011, 5 days ago</span>';
         $this->assertEquals($expected, $actual);
 
         // Test future
         $actual = DateField_Disabled::create('Test')
             ->setValue('2011-02-06')
             ->Field();
-        $expected = '<span class="readonly" id="Test">6/02/2011, in 5 days</span>';
+        $expected = '<span class="readonly" id="Test">Feb 6, 2011, in 5 days</span>';
         $this->assertEquals($expected, $actual);
     }
 

--- a/tests/php/Forms/DatetimeFieldTest.php
+++ b/tests/php/Forms/DatetimeFieldTest.php
@@ -21,7 +21,8 @@ class DatetimeFieldTest extends SapphireTest
     protected function setUp(): void
     {
         parent::setUp();
-        i18n::set_locale('en_NZ');
+        // Set to an explicit locale so project-level locale swapping doesn't affect tests
+        i18n::set_locale('en_US');
         // Fix now to prevent race conditions
         DBDatetime::set_mock_now('2010-04-04');
         $this->timezone = date_default_timezone_get();
@@ -141,14 +142,14 @@ class DatetimeFieldTest extends SapphireTest
 
         $datetimeField
             ->setHTML5(false)
-            ->setLocale('en_NZ');
+            ->setLocale('de_DE');
 
-        $datetimeField->setSubmittedValue('29/03/2003 11:00:00 pm');
-        $this->assertEquals($datetimeField->dataValue(), '2003-03-29 23:00:00');
+        $datetimeField->setSubmittedValue('29/03/2003 23:00:00');
+        $this->assertEquals('2003-03-29 23:00:00', $datetimeField->dataValue());
 
         // Some localisation packages exclude the ',' in default medium format
         $this->assertMatchesRegularExpression(
-            '#29/03/2003(,)? 11:00:00 (PM|pm)#',
+            '#29.03.2003(,)? 23:00:00#',
             $datetimeField->Value(),
             'User value is formatted, and in user timezone'
         );

--- a/tests/php/ORM/DBDateTest.php
+++ b/tests/php/ORM/DBDateTest.php
@@ -20,7 +20,8 @@ class DBDateTest extends SapphireTest
         $this->oldError = error_reporting();
         // Validate setup
         assert(date_default_timezone_get() === 'UTC');
-        i18n::set_locale('en_NZ');
+        // Set to an explicit locale so project-level locale swapping doesn't affect tests
+        i18n::set_locale('en_US');
     }
 
     protected function tearDown(): void
@@ -48,42 +49,42 @@ class DBDateTest extends SapphireTest
     public function testNiceDate()
     {
         $this->assertEquals(
-            '31/03/2008',
+            'Mar 31, 2008',
             DBField::create_field('Date', 1206968400)->Nice(),
             "Date->Nice() works with timestamp integers"
         );
         $this->assertEquals(
-            '30/03/2008',
+            'Mar 30, 2008',
             DBField::create_field('Date', 1206882000)->Nice(),
             "Date->Nice() works with timestamp integers"
         );
         $this->assertEquals(
-            '31/03/2008',
+            'Mar 31, 2008',
             DBField::create_field('Date', '1206968400')->Nice(),
             "Date->Nice() works with timestamp strings"
         );
         $this->assertEquals(
-            '30/03/2008',
+            'Mar 30, 2008',
             DBField::create_field('Date', '1206882000')->Nice(),
             "Date->Nice() works with timestamp strings"
         );
         $this->assertEquals(
-            '4/03/2003',
+            'Mar 4, 2003',
             DBField::create_field('Date', '4.3.2003')->Nice(),
             "Date->Nice() works with D.M.YYYY format"
         );
         $this->assertEquals(
-            '4/03/2003',
+            'Mar 4, 2003',
             DBField::create_field('Date', '04.03.2003')->Nice(),
             "Date->Nice() works with DD.MM.YYYY format"
         );
         $this->assertEquals(
-            '4/03/2003',
+            'Mar 4, 2003',
             DBField::create_field('Date', '2003-3-4')->Nice(),
             "Date->Nice() works with YYYY-M-D format"
         );
         $this->assertEquals(
-            '4/03/2003',
+            'Mar 4, 2003',
             DBField::create_field('Date', '2003-03-04')->Nice(),
             "Date->Nice() works with YYYY-MM-DD format"
         );
@@ -107,7 +108,7 @@ class DBDateTest extends SapphireTest
     {
         // iso8601 expects year first, but support year last
         $this->assertEquals(
-            '4/03/2003',
+            'Mar 4, 2003',
             DBField::create_field('Date', '04-03-2003')->Nice(),
             "Date->Nice() works with DD-MM-YYYY format"
         );
@@ -152,32 +153,32 @@ class DBDateTest extends SapphireTest
     public function testLongDate()
     {
         $this->assertEquals(
-            '31 March 2008',
+            'March 31, 2008',
             DBField::create_field('Date', 1206968400)->Long(),
             "Date->Long() works with numeric timestamp"
         );
         $this->assertEquals(
-            '31 March 2008',
+            'March 31, 2008',
             DBField::create_field('Date', '1206968400')->Long(),
             "Date->Long() works with string timestamp"
         );
         $this->assertEquals(
-            '30 March 2008',
+            'March 30, 2008',
             DBField::create_field('Date', 1206882000)->Long(),
             "Date->Long() works with numeric timestamp"
         );
         $this->assertEquals(
-            '30 March 2008',
+            'March 30, 2008',
             DBField::create_field('Date', '1206882000')->Long(),
             "Date->Long() works with numeric timestamp"
         );
         $this->assertEquals(
-            '3 April 2003',
+            'April 3, 2003',
             DBField::create_field('Date', '2003-4-3')->Long(),
             "Date->Long() works with YYYY-M-D"
         );
         $this->assertEquals(
-            '3 April 2003',
+            'April 3, 2003',
             DBField::create_field('Date', '3.4.2003')->Long(),
             "Date->Long() works with D.M.YYYY"
         );
@@ -186,7 +187,7 @@ class DBDateTest extends SapphireTest
     public function testFull()
     {
         $this->assertEquals(
-            'Monday, 31 March 2008',
+            'Monday, March 31, 2008',
             DBField::create_field('Date', 1206968400)->Full(),
             "Date->Full() works with timestamp integers"
         );

--- a/tests/php/ORM/DBDatetimeTest.php
+++ b/tests/php/ORM/DBDatetimeTest.php
@@ -14,7 +14,8 @@ class DBDatetimeTest extends SapphireTest
     protected function setUp(): void
     {
         parent::setUp();
-        i18n::set_locale('en_NZ');
+        // Set to an explicit locale so project-level locale swapping doesn't affect tests
+        i18n::set_locale('en_US');
     }
 
     public function testNowWithSystemDate()
@@ -126,23 +127,23 @@ class DBDatetimeTest extends SapphireTest
         $date = DBDatetime::create_field('Datetime', '2001-12-11 22:10:59');
 
         // note: Some localisation packages exclude the ',' in default medium format
-        i18n::set_locale('en_NZ');
-        $this->assertMatchesRegularExpression('#11/12/2001(,)? 10:10 PM#i', $date->Nice());
+        i18n::set_locale('de_DE');
+        $this->assertMatchesRegularExpression('#11.12.2001(,)? 22:10#i', $date->Nice());
 
         i18n::set_locale('en_US');
-        $this->assertMatchesRegularExpression('#Dec 11(,)? 2001(,)? 10:10 PM#i', $date->Nice());
+        $this->assertMatchesRegularExpression('#Dec 11(,)? 2001(,)? 10:10\hPM#iu', $date->Nice());
     }
 
     public function testDate()
     {
         $date = DBDatetime::create_field('Datetime', '2001-12-31 22:10:59');
-        $this->assertEquals('31/12/2001', $date->Date());
+        $this->assertEquals('Dec 31, 2001', $date->Date());
     }
 
     public function testTime()
     {
         $date = DBDatetime::create_field('Datetime', '2001-12-31 22:10:59');
-        $this->assertMatchesRegularExpression('#10:10:59 PM#i', $date->Time());
+        $this->assertMatchesRegularExpression('#10:10:59\hPM#iu', $date->Time());
     }
 
     public function testTime24()

--- a/tests/php/ORM/DBTimeTest.php
+++ b/tests/php/ORM/DBTimeTest.php
@@ -48,12 +48,12 @@ class DBTimeTest extends SapphireTest
     public function testNice()
     {
         $time = DBTime::create_field('Time', '17:15:55');
-        $this->assertMatchesRegularExpression('#5:15:55 PM#i', $time->Nice());
+        $this->assertMatchesRegularExpression('#5:15:55\hPM#iu', $time->Nice());
     }
 
     public function testShort()
     {
         $time = DBTime::create_field('Time', '17:15:55');
-        $this->assertMatchesRegularExpression('#5:15 PM#i', $time->Short());
+        $this->assertMatchesRegularExpression('#5:15\hPM#iu', $time->Short());
     }
 }


### PR DESCRIPTION
Fixes various date formatting failures in https://github.com/silverstripe/silverstripe-framework/actions/runs/11091228469/job/30830628977

Two main causes:
1. https://github.com/php/php-src/issues/16127
    - Bug in upstream dependency results in some "medium" dates being returned as "short" dates for `en_NZ` locale. We shouldn't try to pre-fix the bug, nor should we attempt to revert to the buggy behaviour. Solution is to test against a locale that didn't exhibit the bug.
2. https://github.com/php/php-src/issues/11600
    - Intentional change in upstream dependency results in "narrow non-breaking spaces" in some formatted dates where a regular space used to be. Solution is to update tests to not care what the space looks like so long as it's there.

## Issue
- https://github.com/silverstripe/.github/issues/313