### PR TITLE
FIX Fix NavigateCommandTest and don't try to write null

### DIFF
--- a/src/Cli/Command/NavigateCommand.php
+++ b/src/Cli/Command/NavigateCommand.php
@@ -27,7 +27,7 @@ class NavigateCommand extends Command
 
         // Handle request and output resonse body
         $response = $app->handle($request);
-        $output->writeln($response->getBody(), OutputInterface::OUTPUT_RAW);
+        $output->writeln($response->getBody() ?? '', OutputInterface::OUTPUT_RAW);
 
         // Transform HTTP status code into sensible exit code
         $responseCode = $response->getStatusCode();

--- a/tests/php/Cli/Command/NavigateCommandTest.php
+++ b/tests/php/Cli/Command/NavigateCommandTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 
 class NavigateCommandTest extends SapphireTest
 {
-    protected $usesDatabase = false;
+    protected $usesDatabase = true;
 
     public static function provideExecute(): array
     {


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/actions/runs/11113727805/job/30878716554

```text
1) SilverStripe\Cli\Tests\Command\NavigateCommandTest::testExecute with data set #3 ('test-controller/errorResponse', [], 1, '')
SilverStripe\ORM\Connect\DatabaseException: Couldn't run query:
...
Table 'SS_mysite.SiteTree_Live' doesn't exist
```

## Issue
- https://github.com/silverstripe/.github/issues/313