### PR TITLE
FIX remove placeholder search text on readonly field

### DIFF
--- a/src/Forms/SearchableDropdownTrait.php
+++ b/src/Forms/SearchableDropdownTrait.php
@@ -139,7 +139,6 @@ trait SearchableDropdownTrait
                 return $emptyString;
             }
         }
-        $name = $this->getName();
         if ($this->getUseDynamicPlaceholder()) {
             if ($this->getIsSearchable()) {
                 if (!$this->getIsLazyLoaded()) {
@@ -597,6 +596,9 @@ trait SearchableDropdownTrait
         $field = call_user_func('SilverStripe\\Forms\\FormField::castedCopy', SearchableLookupField::class);
         $field->setSource($this->sourceList);
         $field->setReadonly(true);
+
+        // Remove the text "Type to search..." on a read-only field
+        $field->setPlaceholder('');
 
         return $field;
     }

--- a/src/Forms/SearchableDropdownTrait.php
+++ b/src/Forms/SearchableDropdownTrait.php
@@ -598,7 +598,7 @@ trait SearchableDropdownTrait
         $field->setReadonly(true);
 
         // Remove the text "Type to search..." on a read-only field
-        $field->setPlaceholder('');
+        // $field->setPlaceholder('');
 
         return $field;
     }

--- a/tests/php/Forms/SearchableDropdownTraitTest.php
+++ b/tests/php/Forms/SearchableDropdownTraitTest.php
@@ -73,6 +73,8 @@ class SearchableDropdownTraitTest extends SapphireTest
         $this->assertSame('My empty string', $field->getPlaceholder());
         $field->setPlaceholder('My placeholder');
         $this->assertSame('My placeholder', $field->getPlaceholder());
+        $readonlyField = $field->performReadonlyTransformation();
+        $this->assertSame('', $readonlyField->getPlaceholder());
     }
 
     public function testSeachContext(): void


### PR DESCRIPTION
## Description

Sets the placeholder text to an empty string on a readonly, "searchable" dropdown.

Also removes a line that sets a `$name` variable as it is unused in the method

## Issues

- #11398 

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
