### PR TITLE
API Improve type safety for Controller::join_links()

### DIFF
--- a/src/Control/Controller.php
+++ b/src/Control/Controller.php
@@ -627,9 +627,8 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
      * Caution: All parameters are expected to be URI-encoded already.
      *
      * @param string|array $arg One or more link segments, or list of link segments as an array
-     * @return string
      */
-    public static function join_links($arg = null)
+    public static function join_links($arg = null): string
     {
         if (func_num_args() === 1 && is_array($arg)) {
             $args = $arg;


### PR DESCRIPTION
Allows methods that call `Controller::join_links()` to introduce strongly typed return types.
e.g. `AdminRootController::admin_url()` in https://github.com/silverstripe/silverstripe-admin/pull/1836

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1761