### PR TITLE
API Add deprecation

### DIFF
--- a/src/ORM/FieldType/DBBoolean.php
+++ b/src/ORM/FieldType/DBBoolean.php
@@ -13,7 +13,8 @@ class DBBoolean extends DBField
 {
     public function __construct($name = null, $defaultVal = 0)
     {
-        $this->defaultVal = ($defaultVal) ? 1 : 0;
+        $defaultValue = $defaultVal ? 1 : 0;
+        $this->setDefaultValue($defaultValue);
 
         parent::__construct($name);
     }
@@ -25,7 +26,7 @@ class DBBoolean extends DBField
             'precision' => 1,
             'sign' => 'unsigned',
             'null' => 'not null',
-            'default' => $this->defaultVal,
+            'default' => $this->getDefaultValue(),
             'arrayValue' => $this->arrayValue
         ];
         $values = ['type' => 'boolean', 'parts' => $parts];

--- a/src/ORM/FieldType/DBField.php
+++ b/src/ORM/FieldType/DBField.php
@@ -122,6 +122,7 @@ abstract class DBField extends ViewableData implements DBIndexable
      * @var $default mixed Default-value in the database.
      * Might be overridden on DataObject-level, but still useful for setting defaults on
      * already existing records after a db-build.
+     * @deprecated 5.4.0 Use getDefaultValue() and setDefaultValue() instead
      */
     protected $defaultVal;
 

--- a/src/ORM/FieldType/DBFloat.php
+++ b/src/ORM/FieldType/DBFloat.php
@@ -13,7 +13,8 @@ class DBFloat extends DBField
 
     public function __construct($name = null, $defaultVal = 0)
     {
-        $this->defaultVal = is_float($defaultVal) ? $defaultVal : (float) 0;
+        $defaultValue = is_float($defaultVal) ? $defaultVal : (float) 0;
+        $this->setDefaultValue($defaultValue);
 
         parent::__construct($name);
     }
@@ -23,7 +24,7 @@ class DBFloat extends DBField
         $parts = [
             'datatype' => 'float',
             'null' => 'not null',
-            'default' => $this->defaultVal,
+            'default' => $this->getDefaultValue(),
             'arrayValue' => $this->arrayValue
         ];
         $values = ['type' => 'float', 'parts' => $parts];

--- a/src/ORM/FieldType/DBInt.php
+++ b/src/ORM/FieldType/DBInt.php
@@ -15,7 +15,8 @@ class DBInt extends DBField
 
     public function __construct($name = null, $defaultVal = 0)
     {
-        $this->defaultVal = is_int($defaultVal) ? $defaultVal : 0;
+        $defaultValue = is_int($defaultVal) ? $defaultVal : 0;
+        $this->setDefaultValue($defaultValue);
 
         parent::__construct($name);
     }
@@ -43,7 +44,7 @@ class DBInt extends DBField
             'datatype' => 'int',
             'precision' => 11,
             'null' => 'not null',
-            'default' => $this->defaultVal,
+            'default' => $this->getDefaultValue(),
             'arrayValue' => $this->arrayValue
         ];
         $values = ['type' => 'int', 'parts' => $parts];


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11403

`DBField::getDefaultValue()` will simply return `DBField.defaultVal`

In the CMS 6 PR I've changed `protected $defaultVal;` to `private mixed $defaultValue = null;`