### PR TITLE
ENH Remove code that doesn't belong here

### DIFF
--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -665,7 +665,6 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
 
         // Localise all permission categories
         $keys[__CLASS__ . '.AdminGroup'] = 'Administrator';
-        $keys[__CLASS__ . '.CMS_ACCESS_CATEGORY'] = 'CMS Access';
         $keys[__CLASS__ . '.CONTENT_CATEGORY'] = 'Content permissions';
         $keys[__CLASS__ . '.PERMISSIONS_CATEGORY'] = 'Roles and access permissions';
         return $keys;


### PR DESCRIPTION
This permission isn't added in framework, and doesn't exist if silverstripe/admin isn't installed. It doesn't belong here.
See https://github.com/silverstripe/silverstripe-admin/pull/1837#discussion_r1804062410

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2947