### PR TITLE
ENH Default DB settings to use 4 bytes to store UTF8 characters

### DIFF
--- a/src/ORM/Connect/MySQLDatabase.php
+++ b/src/ORM/Connect/MySQLDatabase.php
@@ -10,7 +10,6 @@ use SilverStripe\Model\List\PaginatedList;
 use SilverStripe\ORM\DataList;
 use SilverStripe\Model\List\ArrayList;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\Queries\SQLSelect;
 use Exception;
 
 /**
@@ -31,7 +30,7 @@ class MySQLDatabase extends Database implements TransactionManager
      * @config
      * @var String
      */
-    private static $connection_charset = 'utf8';
+    private static $connection_charset = 'utf8mb4';
 
     /**
      * Default connection collation
@@ -39,7 +38,7 @@ class MySQLDatabase extends Database implements TransactionManager
      * @config
      * @var string
      */
-    private static $connection_collation = 'utf8_general_ci';
+    private static $connection_collation = 'utf8mb4_unicode_ci';
 
     /**
      * Default charset
@@ -47,7 +46,7 @@ class MySQLDatabase extends Database implements TransactionManager
      * @config
      * @var string
      */
-    private static $charset = 'utf8';
+    private static $charset = 'utf8mb4';
 
     /**
      * SQL Mode used on connections to MySQL. Defaults to ANSI. For basic ORM
@@ -73,7 +72,7 @@ class MySQLDatabase extends Database implements TransactionManager
      * @config
      * @var string
      */
-    private static $collation = 'utf8_general_ci';
+    private static $collation = 'utf8mb4_unicode_ci';
 
     public function connect($parameters)
     {


### PR DESCRIPTION
## Description
Default DB settings to use 4 bytes to store UTF8 characters

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
- https://github.com/silverstripe/silverstripe-framework/issues/11336

## Related PR
- https://github.com/silverstripe/recipe-core/pull/102
- https://github.com/silverstripe/developer-docs/pull/602

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
