### PR TITLE
ENH spread MySQL ORM bind parameters

### DIFF
--- a/src/ORM/Connect/MySQLiConnector.php
+++ b/src/ORM/Connect/MySQLiConnector.php
@@ -278,16 +278,7 @@ class MySQLiConnector extends DBConnector
      */
     public function bindParameters(mysqli_stmt $statement, array $parameters)
     {
-        // Because mysqli_stmt::bind_param arguments must be passed by reference
-        // we need to do a bit of hackery
-        $boundNames = [];
-        $parametersCount = count($parameters ?? []);
-        for ($i = 0; $i < $parametersCount; $i++) {
-            $boundName = "param$i";
-            $$boundName = $parameters[$i];
-            $boundNames[] = &$$boundName;
-        }
-        $statement->bind_param(...$boundNames);
+        $statement->bind_param(...$parameters);
     }
 
     public function preparedQuery($sql, $parameters, $errorLevel = E_USER_ERROR)


### PR DESCRIPTION
Removing the rest of the "[bit of hackery][hackery-comment]" as it is now unnecessary.

The ORM rewrite supporting parameterised queries was [merged in July 2014][introduction-commit] and [released in October 2015][release-tag]. The official PHP support at the time was [5.3.2+][historical-requirements] which excluded the spread operator from being used (introduced in [PHP 5.6][spread-operator]), meaning all this variable shuffling had to happen due to the [PHP docs note][php-note] about using `call_user_func_array` [as this code did][old-call-style] (but has since been [made reudnant][first-refactor] by use of the spread operator in 437e53f2fec17bc778cc7bba39de322d43214441).

Ten years later none of this is relevant anymore, so we can save some useless data shuffling from every parameterised query by just directly using the spread operator.

[hackery-comment]: https://github.com/silverstripe/silverstripe-framework/blob/d8e9af8af8d59b3ee16f404f2f2b0a528d503022/model/connect/MySQLiConnector.php#L227
[introduction-commit]: https://github.com/silverstripe/silverstripe-framework/commit/d8e9af8af8d59b3ee16f404f2f2b0a528d503022
[release-tag]: https://github.com/silverstripe/silverstripe-framework/releases/tag/3.2.0
[historical-requirements]: https://web.archive.org/web/20140616033159/http://www.silverstripe.org/system-requirements
[spread-operator]: https://www.php.net/manual/en/migration56.new-features.php#migration56.new-features.splat
[php-note]: https://www.php.net/manual/en/mysqli-stmt.bind-param.php
[old-call-style]: https://github.com/silverstripe/silverstripe-framework/commit/d8e9af8af8d59b3ee16f404f2f2b0a528d503022#diff-3718b4ff71a03e1d4c0359a3d3da62f788bf8ccb0c08ede31b7f23a4dcddd61eR234
[first-refactor]: https://github.com/silverstripe/silverstripe-framework/commit/437e53f2fec17bc778cc7bba39de322d43214441#diff-9b2f2c197e0cd13a273016f609eebbf671ae5db75396ae73cba64635dd7b75baR257