### PR TITLE
FIX Call defineMethods if lower method is missing

### DIFF
--- a/src/Core/CustomMethods.php
+++ b/src/Core/CustomMethods.php
@@ -171,11 +171,14 @@ trait CustomMethods
         }
         // Lazy define methods
         $lowerClass = strtolower(static::class);
-        if (!isset(self::class::$extra_methods[$lowerClass])) {
+        $lowerMethod = strtolower($method);
+        if (!array_key_exists($lowerClass, self::class::$extra_methods)
+            || !array_key_exists($lowerMethod, self::class::$extra_methods[$lowerClass])
+        ) {
             $this->defineMethods();
         }
 
-        return self::class::$extra_methods[$lowerClass][strtolower($method)] ?? null;
+        return self::class::$extra_methods[$lowerClass][$lowerMethod] ?? null;
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/320

Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/11393429390/job/31701681778

`1) SilverStripe\Security\Tests\VersionedMemberAuthenticatorTest::testAuthenticateAgainstLiveStage
BadMethodCallException: Object->__call(): the method 'publishSingle' does not exist on 'SilverStripe\Security\Member'`

This is a hard to reproduce issue where if you run VersionedMemberAuthenticatorTest AND another test that includes `$usesDatabase = true` or a fixture file, and you're using kitchen-sink, you'll get the above error.  However if you only run VersionedMemberAuthenticatorTest it'll be fine.