### PR TITLE
MNT Fix unit test

### DIFF
--- a/tests/php/Security/VersionedMemberAuthenticatorTest.php
+++ b/tests/php/Security/VersionedMemberAuthenticatorTest.php
@@ -42,6 +42,14 @@ class VersionedMemberAuthenticatorTest extends SapphireTest
             return;
         }
 
+        // Explicity add the Versioned extension to Member, even though it's already in $required_extensions.
+        // This is done to call `unset(self::class::$extra_methods[strtolower($subclass)]);` in
+        // Extensible::add_extension() so when CustomMethods::getExtraMethodConfig() updates the $extra_methods
+        // it will include methods of Versioned such as publishSingle()
+        // This issue will only occur when running subsequent unit test classes in the same process, rather than this
+        // this unit test class in isolation
+        Member::add_extension(Versioned::class);
+
         // Enforce dummy validation (this can otherwise be influenced by recipe config)
         PasswordValidator::singleton()
             ->setMinLength(0)


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/320

Note that while this doesn't show up in CI until CMS 6, it can be replicated on a CMS 5.3 sink install with `--testsuite framework-core --filter="SecurityDefaultAdminTest|VersionedMemberAuthenticatorTest"`

Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/11393429390/job/31701681778

`1) SilverStripe\Security\Tests\VersionedMemberAuthenticatorTest::testAuthenticateAgainstLiveStage BadMethodCallException: Object->__call(): the method 'publishSingle' does not exist on 'SilverStripe\Security\Member'`

This is a hard to reproduce issue where if you run VersionedMemberAuthenticatorTest AND another test that includes $usesDatabase = true or a fixture file, and you're using kitchen-sink, you'll get the above error. However if you only run VersionedMemberAuthenticatorTest it'll be fine.

CI failure is unrelated and will be fixed in https://github.com/silverstripe/gha-ci/pull/158