### PR TITLE
ENH Do not rely on flush variable

### DIFF
--- a/src/Control/Middleware/URLSpecialsMiddleware/FlushScheduler.php
+++ b/src/Control/Middleware/URLSpecialsMiddleware/FlushScheduler.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Control\Middleware\URLSpecialsMiddleware;
 
-use SilverStripe\Core\BaseKernel;
 use SilverStripe\Core\Kernel;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Startup\ScheduledFlushDiscoverer;
@@ -28,15 +27,13 @@ trait FlushScheduler
      */
     public function scheduleFlush(HTTPRequest $request)
     {
-        $flush = array_key_exists('flush', $request->getVars() ?? []) || ($request->getURL() === 'dev/build');
-
-        $kernel = Injector::inst()->get(Kernel::class);
-        if (!$flush || (method_exists($kernel, 'isFlushed') && $kernel->isFlushed())) {
-            return false;
+        if ($request->getURL() === 'dev/build') {
+            $kernel = Injector::inst()->get(Kernel::class);
+            if (!$kernel->isFlushed()) {
+                ScheduledFlushDiscoverer::scheduleFlush($kernel);
+                return true;
+            }
         }
-
-        ScheduledFlushDiscoverer::scheduleFlush($kernel);
-
-        return true;
+        return false;
     }
 }

--- a/src/Core/Startup/RequestFlushDiscoverer.php
+++ b/src/Core/Startup/RequestFlushDiscoverer.php
@@ -44,7 +44,6 @@ class RequestFlushDiscoverer implements FlushDiscoverer
     /**
      * Checks whether the request contains any flush indicators
      *
-     *
      * @return null|bool flush or don't care
      */
     protected function lookupRequest()

--- a/src/Dev/Install/DatabaseAdapterRegistry.php
+++ b/src/Dev/Install/DatabaseAdapterRegistry.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Flushable;
+use SilverStripe\Core\Kernel;
 
 /**
  * This class keeps track of the available database adapters
@@ -155,8 +156,8 @@ class DatabaseAdapterRegistry implements Flushable
      */
     protected static function getConfigureDatabasePaths(): array
     {
-        // autoconfigure() will get called before flush() on ?flush, so manually flush just to ensure no weirdness
-        if (isset($_GET['flush'])) {
+        // autoconfigure() will get called before flush() on flush, so manually flush just to ensure no weirdness
+        if (Injector::inst()->get(Kernel::class)->isFlushed()) {
             static::flush();
         }
         try {

--- a/src/View/SSViewer_FromString.php
+++ b/src/View/SSViewer_FromString.php
@@ -5,6 +5,8 @@ namespace SilverStripe\View;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Dev\Deprecation;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Core\Kernel;
 
 /**
  * Special SSViewer that will process a template passed as a string, rather than a filename.
@@ -60,7 +62,7 @@ class SSViewer_FromString extends SSViewer
         $hash = sha1($this->content ?? '');
         $cacheFile = TEMP_PATH . DIRECTORY_SEPARATOR . ".cache.$hash";
 
-        if (!file_exists($cacheFile ?? '') || isset($_GET['flush'])) {
+        if (!file_exists($cacheFile ?? '') || Injector::inst()->get(Kernel::class)->isFlushed()) {
             $content = $this->parseTemplateContent($this->content, "string sha1=$hash");
             $fh = fopen($cacheFile ?? '', 'w');
             fwrite($fh, $content ?? '');


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/324

Notes on a couple of places where `$request->getVar('flush')` is used that were not changed:

[RequestFlushDiscover::lookupRequest()](https://github.com/silverstripe/silverstripe-framework/blob/5/src/Core/Startup/RequestFlushDiscoverer.php#L54) - not changed because it's the central place that checks `$request->getVar('flush')`, somewhere has to do it after all

[SapphireTest::start()](https://github.com/silverstripe/silverstripe-framework/blob/5/src/Dev/SapphireTest.php#L889) - unlike the new sake, it still uses `CLIRequestBuilder::createFromEnvironment()` which returns an `HTTPRequest`. Without significant refactoring it needs to stay this way as you need to be able to use without sake e.g. `vendor/bin/phpunit path/to/something`
