### PR TITLE
ENH prevent default type in script tag

### DIFF
--- a/_config/mimetypes.yml
+++ b/_config/mimetypes.yml
@@ -362,7 +362,7 @@ SilverStripe\Control\HTTP:
     jpgm: video/jpm
     jpgv: video/jpeg
     jpm: video/jpm
-    js: application/javascript
+    js: text/javascript
     json: application/json
     jsonml: application/jsonml+json
     kar: audio/midi

--- a/src/Control/HTTPResponse.php
+++ b/src/Control/HTTPResponse.php
@@ -363,7 +363,7 @@ class HTTPResponse
         echo <<<EOT
 <p>Redirecting to <a href="{$urlATT}" title="Click this link if your browser does not redirect you">{$title}</a></p>
 <meta http-equiv="refresh" content="1; url={$urlATT}" />
-<script type="application/javascript">setTimeout(function(){
+<script>setTimeout(function(){
 	window.location.href = "{$urlJS}";
 }, 50);</script>
 EOT

--- a/src/Security/CMSSecurity.php
+++ b/src/Security/CMSSecurity.php
@@ -133,7 +133,7 @@ class CMSSecurity extends Security
 <!DOCTYPE html>
 <html><body>
 $message
-<script type="application/javascript">
+<script>
 setTimeout(function(){top.location.href = "$loginURLJS";}, 0);
 </script>
 </body></html>

--- a/src/Security/MemberAuthenticator/CMSLoginHandler.php
+++ b/src/Security/MemberAuthenticator/CMSLoginHandler.php
@@ -90,7 +90,7 @@ class CMSLoginHandler extends LoginHandler
 <!DOCTYPE html>
 <html><body>
 $message
-<script type="application/javascript">
+<script>
 setTimeout(function(){top.location.href = "$changePasswordURLJS";}, 0);
 </script>
 </body></html>

--- a/src/View/Requirements_Backend.php
+++ b/src/View/Requirements_Backend.php
@@ -810,7 +810,7 @@ class Requirements_Backend
         foreach ($this->getJavascript() as $file => $attributes) {
             // Build html attributes
             $htmlAttributes = [
-                'type' => isset($attributes['type']) ? $attributes['type'] : "application/javascript",
+                'type' => isset($attributes['type']) ? $attributes['type'] : null,
                 'src' => $this->pathForFile($file),
             ];
             if (!empty($attributes['async'])) {
@@ -832,7 +832,7 @@ class Requirements_Backend
         // Add all inline JavaScript *after* including external files they might rely on
         foreach ($this->getCustomScripts() as $key => $script) {
             // Build html attributes
-            $customHtmlAttributes = ['type' => 'application/javascript'];
+            $customHtmlAttributes = [];
             if (isset($this->customScriptAttributes[$key])) {
                 foreach ($this->customScriptAttributes[$key] as $attrKey => $attrValue) {
                     $customHtmlAttributes[$attrKey] = $attrValue;

--- a/tests/php/Core/ConvertTest.php
+++ b/tests/php/Core/ConvertTest.php
@@ -102,7 +102,7 @@ class ConvertTest extends SapphireTest
             'Strong tags with attributes are replaced with asterisks'
         );
 
-        $val3 = '<script type="application/javascript">Some really nasty javascript here</script>';
+        $val3 = '<script>Some really nasty javascript here</script>';
         $this->assertEquals(
             '',
             Convert::html2raw($val3),
@@ -116,7 +116,7 @@ class ConvertTest extends SapphireTest
             'Style tags are completely removed'
         );
 
-        $val5 = "<script type=\"application/javascript\">Some really nasty\nmultiline javascript here</script>";
+        $val5 = "<script>Some really nasty\nmultiline javascript here</script>";
         $this->assertEquals(
             '',
             Convert::html2raw($val5),

--- a/tests/php/View/RequirementsTest.php
+++ b/tests/php/View/RequirementsTest.php
@@ -392,7 +392,7 @@ class RequirementsTest extends SapphireTest
             $result
         );
         $this->assertMatchesRegularExpression(
-            '#<script type="application/javascript" src=".*/javascript/RequirementsTest_b.js#',
+            '#<script src=".*/javascript/RequirementsTest_b.js#',
             $result
         );
     }
@@ -1070,7 +1070,7 @@ class RequirementsTest extends SapphireTest
         $urlSrc = $urlGenerator->urlForResource($src);
         $this->assertEquals(
             '<html><head></head><body><!--<script>alert("commented out");</script>-->'
-            . '<h1>more content</h1><script type="application/javascript" src="' . $urlSrc
+            . '<h1>more content</h1><script src="' . $urlSrc
             . "\"></script>\n</body></html>",
             $html
         );
@@ -1094,8 +1094,8 @@ EOS
         $template = '<html><head></head><body><header>My header</header><p>Body<script></script></p></body></html>';
 
         // The expected outputs
-        $expectedScripts = "<script type=\"application/javascript\" src=\"http://www.mydomain.com/test.js\"></script>\n"
-            . "<script type=\"application/javascript\">//<![CDATA[\n"
+        $expectedScripts = "<script src=\"http://www.mydomain.com/test.js\"></script>\n"
+            . "<script>//<![CDATA[\n"
             . "var globalvar = {\n\tpattern: '\\\\\$custom\\\\1'\n};\n"
             . "//]]></script>\n";
         $JsInHead = "<html><head>$expectedScripts</head><body><header>My header</header><p>Body<script></script></p></body></html>";
@@ -1407,7 +1407,7 @@ EOS
 
         /* Javascript has correct attributes */
         $this->assertMatchesRegularExpression(
-            '#<script type="application/javascript" src=".*/javascript/RequirementsTest_a.js.*" integrity="abc" crossorigin="use-credentials"#',
+            '#<script src=".*/javascript/RequirementsTest_a.js.*" integrity="abc" crossorigin="use-credentials"#',
             $html,
             'javascript has correct sri attributes'
         );
@@ -1454,14 +1454,14 @@ EOS
         );
 
         $this->assertDoesNotMatchRegularExpression(
-            "#<script type=\"application/javascript\">//<!\[CDATA\[\s*Do Not Display\s*//\]\]></script>#s",
+            "#<script>//<!\[CDATA\[\s*Do Not Display\s*//\]\]></script>#s",
             $html,
             'customScript is correctly not displaying original write'
         );
 
         /* customScriptWithAttributes is overwritten by customScript */
         $this->assertMatchesRegularExpression(
-            "#<script type=\"application/javascript\">//<!\[CDATA\[\s*Override\s*//\]\]></script>#s",
+            "#<script>//<!\[CDATA\[\s*Override\s*//\]\]></script>#s",
             $html,
             'customScript is displaying latest write and clearing attributes'
         );


### PR DESCRIPTION
## Description
For 6 `application/javascript` should be gone in script tags. A refactored `Requirements_Backend`, that allows nonce (CSP) or flat attributes[], as suggested https://github.com/silverstripe/silverstripe-framework/issues/9910#issuecomment-822424329 would be preferable. Simply removing it is a minimal change, but improves the current situation.

## Manual testing steps
Check the HTML source; the type attribute should no longer be present on the <script> tags.
```
<script src="//code.jquery.com/jquery-3.7.1.min.js"></script>
<script src="/_resources/themes/simple/javascript/script.js?m=1718845897"></script>
```
instead of
```
<script type="application/javascript" src="//code.jquery.com/jquery-3.7.1.min.js"></script>
<script type="application/javascript" src="/_resources/themes/simple/javascript/script.js?m=1718845897"></script>
```
## Issues
- https://github.com/silverstripe/silverstripe-framework/issues/8221
- https://github.com/silverstripe/silverstripe-framework/issues/8710

## Pull request checklist
- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
