### PR TITLE
TLN Update translations

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -132,6 +132,7 @@ en:
   SilverStripe\Forms\GridField\GridFieldFilterHeader:
     Search: 'Search "{name}"'
     SearchFormFaliure: 'No search form could be generated'
+    Search_Default: Search
   SilverStripe\Forms\GridField\GridFieldGroupDeleteAction:
     UnlinkSelfFailure: 'Cannot remove yourself from this group, you will lose admin rights'
   SilverStripe\Forms\GridField\GridFieldPaginator:
@@ -198,6 +199,25 @@ en:
     TIMEDIFFIN: 'in {difference}'
     YEARS_SHORT_PLURALS:
       one: '{count} year'
+      other: '{count} years'
+  SilverStripe\ORM\FieldType\DBDatetime:
+    nDays:
+      one: 'one day'
+      other: '{count} days'
+    nHours:
+      one: 'one hour'
+      other: '{count} hours'
+    nMinutes:
+      one: 'one minute'
+      other: '{count} minutes'
+    nMonths:
+      one: 'one month'
+      other: '{count} months'
+    nSeconds:
+      one: 'one second'
+      other: '{count} seconds'
+    nYears:
+      one: 'one year'
       other: '{count} years'
   SilverStripe\ORM\FieldType\DBEnum:
     ANY: Any

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -242,19 +242,16 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
                 ['count' => $diff->i]
             );
         }
+        $message = _t(
+            __CLASS__ . '.nSeconds',
+            'one second|{count} seconds',
+            ['count' => $diff->s ?? 0]
+        );
         if ($diff->s) {
-            $result[] = _t(
-                __CLASS__ . '.nSeconds',
-                'one second|{count} seconds',
-                ['count' => $diff->s]
-            );
+            $result[] = $message;
         }
         if (empty($result)) {
-            return _t(
-                __CLASS__ . '.nSeconds',
-                '{count} seconds',
-                ['count' => 0]
-            );
+            return $message;
         }
         return implode(', ', $result);
     }


### PR DESCRIPTION
Automated translations update generated using [silverstripe/tx-translator](https://github.com/silverstripe/silverstripe-tx-translator)

This PR includes a "fix" to ensure the that text collector does not mistakenly use '{count} seconds' for the translation source value instead of the correct 'one second|{count} seconds',
                