### PR TITLE
API Move logic from silverstripe/cms into central place

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -32,6 +32,7 @@ use SilverStripe\Model\ArrayData;
 use SilverStripe\View\HTML;
 use SilverStripe\View\SSViewer;
 use SilverStripe\Model\ModelData;
+use SilverStripe\ORM\FieldType\DBField;
 
 class GridFieldDetailForm_ItemRequest extends RequestHandler
 {
@@ -930,11 +931,13 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
         $items = $this->popupController->Breadcrumbs($unlinked);
 
         if (!$items) {
+            /** @var ArrayList<ArrayData> $items */
             $items = ArrayList::create();
         }
 
-        if ($this->record && $this->record->ID) {
-            $title = ($this->record->Title) ? $this->record->Title : "#{$this->record->ID}";
+        $record = $this->getRecord();
+        if ($record && $record->ID) {
+            $title = ($record->Title) ? $record->Title : "#{$record->ID}";
             $items->push(ArrayData::create([
                 'Title' => $title,
                 'Link' => $this->Link()
@@ -950,6 +953,11 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
             if ($item->Link) {
                 $item->Link = $this->gridField->addAllStateToUrl($item->Link);
             }
+        }
+
+        $statusFlags = $record->getStatusFlagMarkup('badge--breadcrumbs');
+        if ($statusFlags) {
+            $items->last()->setField('Extra', DBField::create_field('HTMLFragment', $statusFlags));
         }
 
         $this->extend('updateBreadcrumbs', $items);

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -116,17 +116,13 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
 {
     /**
      * Human-readable singular name.
-     * @var string
-     * @config
      */
-    private static $singular_name = null;
+    private static ?string $singular_name = null;
 
     /**
      * Human-readable plural name
-     * @var string
-     * @config
      */
-    private static $plural_name = null;
+    private static ?string $plural_name = null;
 
     /**
      * Description of the class.
@@ -150,7 +146,6 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
      * @var string
      */
     private static $default_classname = null;
-
     /**
      * Whether this DataObject class must only use the primary database and not a read-only replica
      * Note that this will be only be enforced when using DataQuery::execute() or
@@ -957,40 +952,23 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
 
     /**
      * Get description for this class
-     * @return null|string
      */
-    public function classDescription()
+    public function classDescription(): ?string
     {
         return static::config()->get('class_description', Config::UNINHERITED);
     }
 
     /**
      * Get localised description for this class
-     * @return null|string
      */
-    public function i18n_classDescription()
+    public function i18n_classDescription(): ?string
     {
         $notDefined = 'NOT_DEFINED';
-        $baseDescription = $this->classDescription() ?? $notDefined;
-
-        // Check the new i18n key first
-        $description = _t(static::class . '.CLASS_DESCRIPTION', $baseDescription);
-        if ($description !== $baseDescription) {
-            return $description;
-        }
-
-        // Fall back on the deprecated localisation key
-        $legacyI18n = _t(static::class . '.DESCRIPTION', $baseDescription);
-        if ($legacyI18n !== $baseDescription) {
-            return $legacyI18n;
-        }
-
-        // If there was no description available in config nor in i18n, return null
-        if ($baseDescription === $notDefined) {
+        $description = _t(static::class.'.CLASS_DESCRIPTION', $this->classDescription() ?? $notDefined);
+        if ($description === $notDefined) {
             return null;
         }
-        // Return raw description
-        return $baseDescription;
+        return $description;
     }
 
     /**
@@ -3562,14 +3540,14 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
     }
 
     /**
-     * Flush the cached results for all relations (has_one, has_many, many_many)
-     * Also clears any cached aggregate data.
+     * @inheritDoc
      *
-     * @param boolean $persistent When true will also clear persistent data stored in the Cache system.
+     * Also flush the cached results for all relations (has_one, has_many, many_many)
+     *
+     * @param bool $persistent When true will also clear persistent data stored in the Cache system.
      *                            When false will just clear session-local cached data
-     * @return static $this
      */
-    public function flushCache($persistent = true)
+    public function flushCache(bool $persistent = true): static
     {
         if (static::class == DataObject::class) {
             DataObject::$_cache_get_one = [];
@@ -3583,11 +3561,9 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
             }
         }
 
-        $this->extend('onFlushCache');
-
         $this->components = [];
         $this->eagerLoadedData = [];
-        return $this;
+        return parent::flushCache();
     }
 
     /**

--- a/src/ORM/FieldType/DBEnum.php
+++ b/src/ORM/FieldType/DBEnum.php
@@ -5,7 +5,6 @@ namespace SilverStripe\ORM\FieldType;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Validation\FieldValidation\OptionFieldValidator;
 use SilverStripe\Core\Resettable;
-use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\SelectField;
@@ -42,16 +41,6 @@ class DBEnum extends DBString implements Resettable
      * nested arrays with keys mapped to field names. The values of the lowest level array are the enum values
      */
     protected static array $enum_cache = [];
-
-    /**
-     * Clear all cached enum values.
-     * @deprecated 5.4.0 Use reset() instead.
-     */
-    public static function flushCache(): void
-    {
-        Deprecation::notice('5.4.0', 'Use reset() instead.');
-        static::reset();
-    }
 
     public static function reset(): void
     {

--- a/tests/php/Forms/GridField/GridFieldDataColumnsTest/TestStatusFlagsObject.php
+++ b/tests/php/Forms/GridField/GridFieldDataColumnsTest/TestStatusFlagsObject.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\GridField\GridFieldDataColumnsTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Model\ModelData;
+
+class TestStatusFlagsObject extends ModelData implements TestOnly
+{
+    public function getTitle()
+    {
+        return 'My test object';
+    }
+
+    public function getAnotherField()
+    {
+        return 'Another test field';
+    }
+
+    public function getStatusFlags(bool $cached = true): array
+    {
+        $flags = parent::getStatusFlags($cached);
+        $flags['f1'] = [
+            'title' => 'a flag',
+            'text' => 'flag1',
+        ];
+        $flags['f2'] = 'flag2';
+        return $flags;
+    }
+}

--- a/tests/php/Forms/GridField/GridFieldDetailFormItemRequestTest/TestBreadcrumbsController.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormItemRequestTest/TestBreadcrumbsController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\GridField\GridFieldDetailFormItemRequestTest;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Model\ArrayData;
+use SilverStripe\Model\List\ArrayList;
+
+class TestBreadcrumbsController extends Controller implements TestOnly
+{
+    public function Breadcrumbs()
+    {
+        return new ArrayList([new ArrayData(['Title' => 'My Controller', 'Link' => 'my-link'])]);
+    }
+}

--- a/tests/php/Forms/GridField/GridFieldDetailFormItemRequestTest/TestStatusFlagsObject.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormItemRequestTest/TestStatusFlagsObject.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\GridField\GridFieldDetailFormItemRequestTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Model\ModelData;
+
+class TestStatusFlagsObject extends ModelData implements TestOnly
+{
+    public function getTitle()
+    {
+        return 'My test object';
+    }
+
+    public function getAnotherField()
+    {
+        return 'Another test field';
+    }
+
+    public function getStatusFlags(bool $cached = true): array
+    {
+        $flags = parent::getStatusFlags($cached);
+        $flags['f1'] = [
+            'title' => 'a flag',
+            'text' => 'flag1',
+        ];
+        $flags['f2'] = 'flag2';
+        return $flags;
+    }
+}

--- a/tests/php/Forms/GridField/GridFieldDetailForm_ItemRequestTest.php
+++ b/tests/php/Forms/GridField/GridFieldDetailForm_ItemRequestTest.php
@@ -4,13 +4,17 @@ namespace SilverStripe\Forms\Tests\GridField;
 
 use LogicException;
 use SilverStripe\Control\Controller;
+use SilverStripe\Dev\CSSContentParser;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_Base;
 use SilverStripe\Forms\GridField\GridFieldDetailForm;
 use SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest;
+use SilverStripe\Forms\Tests\GridField\GridFieldDetailFormItemRequestTest\TestBreadcrumbsController;
+use SilverStripe\Forms\Tests\GridField\GridFieldDetailFormItemRequestTest\TestStatusFlagsObject;
 use SilverStripe\Model\List\ArrayList;
 use SilverStripe\Model\ArrayData;
+use SilverStripe\ORM\FieldType\DBHTMLText;
 
 class GridFieldDetailForm_ItemRequestTest extends SapphireTest
 {
@@ -30,5 +34,30 @@ class GridFieldDetailForm_ItemRequestTest extends SapphireTest
         );
 
         $itemRequest->ItemEditForm();
+    }
+
+    public function testBreadcrumbs(): void
+    {
+        $record = new TestStatusFlagsObject();
+        $gridField = new GridField('dummy', 'dummy', new ArrayList([$record]), new GridFieldConfig_Base());
+        $modelClass = ArrayData::class;
+        $gridField->setModelClass($modelClass);
+        $itemRequest = new GridFieldDetailForm_ItemRequest($gridField, new GridFieldDetailForm(), $record, new TestBreadcrumbsController(), '');
+
+        $crumbs = $itemRequest->Breadcrumbs();
+        $this->assertCount(2, $crumbs);
+        $this->assertTrue($crumbs->last()->hasField('Extra'));
+        $crumbFlags = $crumbs->last()->getField('Extra');
+        $statusFlagMarkup = $record->getStatusFlagMarkup('badge--breadcrumbs');
+
+        // Check status flags are in the right spot
+        $this->assertInstanceOf(DBHTMLText::class, $crumbFlags);
+        $this->assertSame($statusFlagMarkup, $crumbFlags->__toString());
+
+        // Check crumbs are as expected
+        $this->assertSame('My Controller', $crumbs->first()->Title);
+        $this->assertSame('my-link', $crumbs->first()->Link);
+        $this->assertSame('New TestStatusFlagsObject', $crumbs->last()->Title);
+        $this->assertSame(false, $crumbs->last()->Link);
     }
 }

--- a/tests/php/Forms/GridField/GridFieldReadonlyTest.php
+++ b/tests/php/Forms/GridField/GridFieldReadonlyTest.php
@@ -22,7 +22,6 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldViewButton;
 use SilverStripe\Forms\Tests\GridField\GridFieldReadonlyTest\GridFieldViewButtonReplacement;
-use SilverStripe\Versioned\VersionedGridFieldState\VersionedGridFieldState;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 class GridFieldReadonlyTest extends SapphireTest
@@ -77,7 +76,6 @@ class GridFieldReadonlyTest extends SapphireTest
         $gridConfig->addComponent($pagination = new GridFieldPaginator(2));
         $gridConfig->addComponent(new GridFieldDetailForm());
         $gridConfig->addComponent(new GridFieldDeleteAction());
-        $gridConfig->addComponent(new VersionedGridFieldState());
 
         $gridField = GridField::create(
             'Cheerleaders',

--- a/tests/php/Forms/GridField/GridFieldTest.php
+++ b/tests/php/Forms/GridField/GridFieldTest.php
@@ -13,8 +13,6 @@ use SilverStripe\Forms\Form;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldButtonRow;
 use SilverStripe\Forms\GridField\GridFieldConfig;
-use SilverStripe\Forms\GridField\GridFieldConfig_Base;
-use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
 use SilverStripe\Forms\GridField\GridFieldFilterHeader;
 use SilverStripe\Forms\GridField\GridFieldPageCount;
@@ -37,7 +35,6 @@ use SilverStripe\Model\List\ArrayList;
 use SilverStripe\Core\Validation\ValidationResult;
 use SilverStripe\Security\Group;
 use SilverStripe\Security\Member;
-use SilverStripe\Versioned\VersionedGridFieldStateExtension;
 
 class GridFieldTest extends SapphireTest
 {
@@ -46,15 +43,6 @@ class GridFieldTest extends SapphireTest
         Cheerleader::class,
         Player::class,
         Team::class,
-    ];
-
-    protected static $illegal_extensions = [
-        GridFieldConfig_RecordEditor::class => [
-            VersionedGridFieldStateExtension::class,
-        ],
-        GridFieldConfig_Base::class => [
-            VersionedGridFieldStateExtension::class,
-        ],
     ];
 
     public function testGridField()

--- a/tests/php/Model/ModelDataTest.php
+++ b/tests/php/Model/ModelDataTest.php
@@ -398,4 +398,35 @@ class ModelDataTest extends SapphireTest
         $modelData->arr = $arr;
         $this->assertInstanceOf($expectedClass, $modelData->obj('arr'));
     }
+
+    public function testGetStatusFlags(): void
+    {
+        // no flags by default
+        $modelData = new ModelData();
+        $this->assertSame([], $modelData->getStatusFlags());
+
+        // test updateStatusFlags extension hook
+        $modelData = new ModelDataTestObject();
+        $this->assertSame([
+            'myKey1' => 'some flag',
+            'myKey2' => [
+                'text' => 'another flag',
+                'title' => 'title attr',
+            ],
+        ], $modelData->getStatusFlags());
+    }
+
+    public function testGetStatusFlagMarkup(): void
+    {
+        // no flags means no markup by default
+        $modelData = new ModelData();
+        $this->assertSame('', $modelData->getStatusFlagMarkup('my-css-class'));
+
+        // test updateStatusFlags extension hook
+        $modelData = new ModelDataTestObject();
+        $this->assertSame(
+            '<span class="badge status-myKey1 my-css-class">some flag</span><span class="badge status-myKey2 my-css-class" title="title attr">another flag</span>',
+            $modelData->getStatusFlagMarkup('my-css-class')
+        );
+    }
 }

--- a/tests/php/Model/ModelDataTest/ViewableDataTextExtension.php
+++ b/tests/php/Model/ModelDataTest/ViewableDataTextExtension.php
@@ -21,4 +21,13 @@ class ModelDataTestExtension extends Extension implements TestOnly
     {
         return 'Public function';
     }
+
+    public function updateStatusFlags(array &$flags): void
+    {
+        $flags['myKey1'] = 'some flag';
+        $flags['myKey2'] = [
+            'text' => 'another flag',
+            'title' => 'title attr',
+        ];
+    }
 }

--- a/tests/php/ORM/HierarchyTest.yml
+++ b/tests/php/ORM/HierarchyTest.yml
@@ -70,3 +70,6 @@ SilverStripe\ORM\Tests\HierarchyTest\HierarchyOnSubclassTestSubObject:
   obj5ba:
     Parent: =>SilverStripe\ORM\Tests\HierarchyTest\HierarchyOnSubclassTestSubObject.obj5b
     Title: Obj 5ba
+SilverStripe\ORM\Tests\HierarchyTest\NoEditTestObject:
+  no-edit1:
+    Title: Obj no-edit 1

--- a/tests/php/ORM/HierarchyTest/HierarchyModel.php
+++ b/tests/php/ORM/HierarchyTest/HierarchyModel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\Hierarchy\Hierarchy;
+
+/**
+ * @mixin Hierarchy
+ */
+class HierarchyModel extends DataObject implements TestOnly
+{
+    private static $table_name = 'HierarchyTest_HierarchyModel';
+
+    private static $db = [
+        'Title' => 'Varchar'
+    ];
+
+    private static $extensions = [
+        Hierarchy::class,
+    ];
+}

--- a/tests/php/ORM/HierarchyTest/NoEditTestObject.php
+++ b/tests/php/ORM/HierarchyTest/NoEditTestObject.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+class NoEditTestObject extends TestObject
+{
+    private static $table_name = 'HierarchyHideTest_NoEditTestObject';
+
+    public function canEdit($member = null)
+    {
+        return false;
+    }
+}

--- a/tests/php/ORM/HierarchyTest/SortableHierarchyModel.php
+++ b/tests/php/ORM/HierarchyTest/SortableHierarchyModel.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\Hierarchy\Hierarchy;
+
+/**
+ * @mixin Hierarchy
+ */
+class SortableHierarchyModel extends DataObject implements TestOnly
+{
+    private static $table_name = 'HierarchyTest_SortableHierarchyModel';
+
+    private static $db = [
+        'Title' => 'Varchar',
+        'Sort' => 'Int'
+    ];
+
+    private static $extensions = [
+        Hierarchy::class,
+    ];
+
+    private static $default_sort = 'Sort';
+
+    private static $sort_field = 'Sort';
+}

--- a/tests/php/ORM/HierarchyTest/TestAllowedChildrenA.php
+++ b/tests/php/ORM/HierarchyTest/TestAllowedChildrenA.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class TestAllowedChildrenA extends HierarchyModel implements TestOnly
+{
+    private static $table_name = 'HierarchyTest_TestAllowedChildrenA';
+
+    private static $allowed_children = [
+        TestAllowedChildrenB::class,
+    ];
+}

--- a/tests/php/ORM/HierarchyTest/TestAllowedChildrenB.php
+++ b/tests/php/ORM/HierarchyTest/TestAllowedChildrenB.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class TestAllowedChildrenB extends HierarchyModel implements TestOnly
+{
+    private static $table_name = 'HierarchyTest_TestAllowedChildrenB';
+
+    // Also allowed subclasses
+    private static $allowed_children = [
+        TestAllowedChildrenC::class,
+    ];
+}

--- a/tests/php/ORM/HierarchyTest/TestAllowedChildrenC.php
+++ b/tests/php/ORM/HierarchyTest/TestAllowedChildrenC.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class TestAllowedChildrenC extends HierarchyModel implements TestOnly
+{
+    private static $table_name = 'HierarchyTest_TestAllowedChildrenC';
+
+    private static $allowed_children = [
+        TestAllowedChildrenA::class,
+        TestAllowedChildrenD::class,
+    ];
+}

--- a/tests/php/ORM/HierarchyTest/TestAllowedChildrenCext.php
+++ b/tests/php/ORM/HierarchyTest/TestAllowedChildrenCext.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class TestAllowedChildrenCext extends TestAllowedChildrenC implements TestOnly
+{
+    private static $table_name = 'HierarchyTest_TestAllowedChildrenCext';
+
+    // Override TestAllowedChildrenC definitions
+    private static $allowed_children = [
+        TestAllowedChildrenB::class,
+    ];
+}

--- a/tests/php/ORM/HierarchyTest/TestAllowedChildrenD.php
+++ b/tests/php/ORM/HierarchyTest/TestAllowedChildrenD.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class TestAllowedChildrenD extends HierarchyModel implements TestOnly
+{
+    private static $table_name = 'HierarchyTest_TestAllowedChildrenD';
+
+    // Only allows this class, no children classes
+    private static $allowed_children = [
+        '*' . TestAllowedChildrenC::class,
+    ];
+}

--- a/tests/php/ORM/HierarchyTest/TestAllowedChildrenE.php
+++ b/tests/php/ORM/HierarchyTest/TestAllowedChildrenE.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+use SilverStripe\Dev\TestOnly;
+
+class TestAllowedChildrenE extends HierarchyModel implements TestOnly
+{
+    private static $table_name = 'HierarchyTest_TestAllowedChildrenE';
+
+    // Only allows nothing
+    private static $allowed_children = 'none';
+}

--- a/tests/php/ORM/HierarchyTest/TestAllowedChildrenHidden.php
+++ b/tests/php/ORM/HierarchyTest/TestAllowedChildrenHidden.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\HiddenClass;
+
+class TestAllowedChildrenHidden extends HierarchyModel implements TestOnly, HiddenClass
+{
+    private static $table_name = 'HierarchyTest_TestAllowedChildrenHidden';
+}


### PR DESCRIPTION
This logic is used by `CMSMain` but needs to be callable on any hierarchical model.

In some cases this logic is generic enough it could be on any model or any `DataObject`.

See the [corresponding CMS PR](https://github.com/silverstripe/silverstripe-cms/pull/3022) to see where this code came from.

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2947