### PR TITLE
ENH Update code to reflect changes in silverstripe/admin

### DIFF
--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -3,7 +3,7 @@
 namespace SilverStripe\Forms\GridField;
 
 use LogicException;
-use SilverStripe\Admin\LeftAndMain;
+use SilverStripe\Admin\FormSchemaController;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\ClassInfo;
@@ -425,7 +425,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
             return new HTTPResponse(_t(__CLASS__ . '.SearchFormFaliure', 'No search form could be generated'), 400);
         }
 
-        $parts = $gridField->getRequest()->getHeader(LeftAndMain::SCHEMA_HEADER);
+        $parts = $gridField->getRequest()->getHeader(FormSchemaController::SCHEMA_HEADER);
         $schemaID = $gridField->getRequest()->getURL();
         $data = FormSchema::singleton()
             ->getMultipartSchema($parts, $schemaID, $form);


### PR DESCRIPTION
May need https://github.com/silverstripe/silverstripe-admin/pull/1850 for CI to go green. Please merge that first.

Note that while we shouldn't have this coupling here, the coupling as _already_ here. Resolving that coupling issue is way out of scope and probably includes moving gridfield into its own separate module with its own css and js pulled out of silverstripe/admin.... a card for another day.

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1762