### PR TITLE
DEP Set minimum version of symfony/cache to 7.1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "silverstripe/template-engine": "^1",
         "silverstripe/vendor-plugin": "^2",
         "sminnee/callbacklist": "^0.1.1",
-        "symfony/cache": "^7.0",
+        "symfony/cache": "^7.1.5",
         "symfony/config": "^7.0",
         "symfony/console": "^7.0",
         "symfony/dom-crawler": "^7.0",

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\ORM\Tests;
 
 use InvalidArgumentException;
 use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
@@ -27,7 +28,6 @@ use SilverStripe\Security\Member;
 use SilverStripe\Model\ModelData;
 use ReflectionMethod;
 use stdClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 class DataObjectTest extends SapphireTest
 {
@@ -1913,7 +1913,7 @@ class DataObjectTest extends SapphireTest
         $this->assertEquals(2, $player->Teams()->dataQuery()->query()->unlimitedRowCount());
     }
 
-    public function provideSingularName(): array
+    public static function provideSingularName(): array
     {
         return [
             [
@@ -1933,8 +1933,8 @@ class DataObjectTest extends SapphireTest
 
     /**
      * Tests that singular_name() generates sensible defaults.
-     * @dataProvider provideSingularName
      */
+    #[DataProvider('provideSingularName')]
     public function testSingularName(string $class, string $expected): void
     {
         i18n::set_locale('en_NZ');
@@ -1952,7 +1952,7 @@ class DataObjectTest extends SapphireTest
         );
     }
 
-    public function providePluralName(): array
+    public static function providePluralName(): array
     {
         return [
             [
@@ -1984,8 +1984,8 @@ class DataObjectTest extends SapphireTest
 
     /**
      * Tests that plural_name() generates sensible defaults.
-     * @dataProvider providePluralName
      */
+    #[DataProvider('providePluralName')]
     public function testPluralName(string $class, string $expected): void
     {
         i18n::set_locale('en_NZ');
@@ -2003,7 +2003,7 @@ class DataObjectTest extends SapphireTest
         );
     }
 
-    public function provideClassDescription(): array
+    public static function provideClassDescription(): array
     {
         return [
             'no description by default' => [
@@ -2021,9 +2021,7 @@ class DataObjectTest extends SapphireTest
         ];
     }
 
-    /**
-     * @dataProvider provideClassDescription
-     */
+    #[DataProvider('provideClassDescription')]
     public function testClassDescription(string $class, ?string $expected): void
     {
         i18n::set_locale('en_NZ');


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/328

Two commits, so don't squash merge

## 1
Require https://github.com/symfony/cache/releases/tag/v7.1.5 which has a fix to work with newer versions of redis

Fixes --prefer-lowest build https://github.com/silverstripe/silverstripe-framework/actions/runs/11826436315/job/32952439907

`PHP Fatal error:  Declaration of Symfony\Component\Cache\Traits\Redis6Proxy::hSet($key, $member, $value): Redis|int|false must be compatible with Redis::hSet(string $key, mixed ...$fields_and_vals): Redis|int|false in /home/runner/work/silverstripe-framework/silverstripe-framework/vendor/symfony/cache/Traits/Redis6Proxy.php on line 519`

## 2
Fix DataProviders in unit test after merge-up from 5