### PR TITLE
FIX Ensure schema data includes attributes

### DIFF
--- a/src/Forms/FormField.php
+++ b/src/Forms/FormField.php
@@ -1493,6 +1493,16 @@ class FormField extends RequestHandler
         if ($titleTip instanceof Tip) {
             $data['titleTip'] = $titleTip->getTipSchema();
         }
+        $attributes = $this->getAttributes();
+        // Remove value from attributes because otherwise it breaks react fields
+        unset($attributes['value']);
+        // Remove above attributes from attributes list to avoid double-ups
+        foreach (array_keys($data) as $key) {
+            // HTML attributes are always lowercase so we need to make sure to transform our js key names
+            // to lowercase before unsetting them.
+            unset($attributes[strtolower($key)]);
+        }
+        $data['attributes'] = $attributes;
         return $data;
     }
 
@@ -1560,6 +1570,18 @@ class FormField extends RequestHandler
         }
         $this->extend('updateSchemaValidation', $validationList);
         return $validationList;
+    }
+
+    /**
+     * Gets the data-schema and data-state attributes for the input element.
+     * Can't be included in getAttributesHtml because that would result in
+     * an infinite loop.
+     */
+    public function getSchemaAttributesHtml(): DBHTMLText
+    {
+        $content = 'data-schema="' . htmlspecialchars(json_encode($this->getSchemaData()))
+            . '" data-state="' . htmlspecialchars(json_encode($this->getSchemaState())) . '"';
+        return DBHTMLText::create()->setValue($content);
     }
 
     /**

--- a/src/Forms/SearchableDropdownTrait.php
+++ b/src/Forms/SearchableDropdownTrait.php
@@ -312,7 +312,6 @@ trait SearchableDropdownTrait
             parent::getAttributes(),
             [
                 'name' => $name,
-                'data-schema' => json_encode($this->getSchemaData()),
             ]
         );
     }

--- a/src/Forms/TreeDropdownField.php
+++ b/src/Forms/TreeDropdownField.php
@@ -620,8 +620,6 @@ class TreeDropdownField extends FormField implements HasOneRelationFieldInterfac
         $attributes = [
             'class' => $this->extraClass(),
             'id' => $this->ID(),
-            'data-schema' => json_encode($this->getSchemaData()),
-            'data-state' => json_encode($this->getSchemaState()),
         ];
 
         $attributes = array_merge($attributes, $this->attributes);

--- a/templates/SilverStripe/Forms/TreeDropdownField.ss
+++ b/templates/SilverStripe/Forms/TreeDropdownField.ss
@@ -1,6 +1,6 @@
 <div
 	class="TreeDropdownField<% if $extraClass %> $extraClass<% end_if %><% if $ShowSearch %> searchable<% end_if %>"
-	$AttributesHTML('class')
+	$AttributesHTML('class') $SchemaAttributesHtml
 	<% if $Metadata %>data-metadata="$Metadata.ATT"<% end_if %>
 >
 	<input id="$ID" type="hidden" name="$Name.ATT" value="$Value.ATT" />

--- a/tests/php/Forms/FormFieldTest.php
+++ b/tests/php/Forms/FormFieldTest.php
@@ -414,6 +414,16 @@ class FormFieldTest extends SapphireTest
         $this->assertSame('Test tip', $schema['titleTip']['content']);
     }
 
+    public function testGetSchemaDataDefaultsAttributes()
+    {
+        $field = new FormField('MyField');
+        $field->setAttribute('foo', 'bar');
+        $this->assertEquals('bar', $field->getAttribute('foo'));
+        $schema = $field->getSchemaDataDefaults();
+        $this->assertArrayHasKey('foo', $schema['attributes']);
+        $this->assertEquals('bar', $schema['attributes']['foo']);
+    }
+
     public function testGetSchemaData()
     {
         $field = new FormField('MyField');

--- a/tests/php/Forms/FormSchemaTest/testGetNestedSchema.json
+++ b/tests/php/Forms/FormSchemaTest/testGetNestedSchema.json
@@ -30,7 +30,9 @@
       "disabled": false,
       "autoFocus": false,
       "customValidationMessage": "",
-      "attributes": [],
+      "attributes": {
+        "class": "text"
+      },
       "data": {
         "maxlength": null
       },
@@ -53,7 +55,9 @@
       "disabled": false,
       "autoFocus": false,
       "customValidationMessage": "",
-      "attributes": [],
+      "attributes": {
+        "class": "hidden"
+      },
       "data": [],
       "validation": []
     }
@@ -77,7 +81,8 @@
       "autoFocus": false,
       "customValidationMessage": "",
       "attributes": {
-        "type": "submit"
+        "type": "submit",
+        "class": "action"
       },
       "data": {
         "icon": "save"
@@ -102,7 +107,8 @@
       "autoFocus": false,
       "customValidationMessage": "",
       "attributes": {
-        "type": "button"
+        "type": "button",
+        "class": "action"
       },
       "data": {
         "icon": null
@@ -126,7 +132,10 @@
       "disabled": false,
       "autoFocus": false,
       "customValidationMessage": "",
-      "attributes": [],
+      "attributes": {
+        "class": "field CompositeField popover",
+        "tabindex": null
+      },
       "data": {
         "popoverTitle": null,
         "placement": "bottom",
@@ -159,7 +168,8 @@
           "autoFocus": false,
           "customValidationMessage": "",
           "attributes": {
-            "type": "submit"
+            "type": "submit",
+            "class": "action"
           },
           "data": {
             "icon": null
@@ -184,7 +194,8 @@
           "autoFocus": false,
           "customValidationMessage": "",
           "attributes": {
-            "type": "submit"
+            "type": "submit",
+            "class": "action"
           },
           "data": {
             "icon": null

--- a/tests/php/Forms/FormSchemaTest/testGetSchema.json
+++ b/tests/php/Forms/FormSchemaTest/testGetSchema.json
@@ -30,7 +30,9 @@
             "disabled": false,
             "autoFocus": false,
             "customValidationMessage": "",
-            "attributes": [],
+            "attributes": {
+              "class": "hidden"
+            },
             "data": [],
             "validation": []
         }

--- a/tests/php/Forms/FormSchemaTest/testSchemaValidation.json
+++ b/tests/php/Forms/FormSchemaTest/testSchemaValidation.json
@@ -36,7 +36,13 @@
                     "length": 40
                 }
             },
-            "attributes": [],
+            "attributes": {
+              "class": "text",
+              "required": "required",
+              "aria-required": "true",
+              "maxLength": 40,
+              "size": 30
+            },
             "data": {
               "maxlength": 40
             }
@@ -62,7 +68,12 @@
             "validation": {
                 "date": true
             },
-            "attributes": [],
+            "attributes": {
+              "class": "date text",
+              "lang": "en-US",
+              "min": null,
+              "max": null
+            },
             "data": {
                 "html5": true,
                 "min": null,
@@ -90,7 +101,9 @@
             "validation": {
                 "numeric": true
             },
-            "attributes": [],
+            "attributes": {
+              "class": "numeric text"
+            },
             "data": {
                 "maxlength": null
             }
@@ -115,7 +128,9 @@
             "validation": {
                 "currency": true
             },
-            "attributes": [],
+            "attributes": {
+              "class": "currency text"
+            },
             "data": {
                 "maxlength": null
             }
@@ -138,7 +153,9 @@
             "autoFocus": false,
             "customValidationMessage": "",
             "validation": [],
-            "attributes": [],
+            "attributes": {
+              "class": "hidden"
+            },
             "data": []
         }
     ],


### PR DESCRIPTION
Includes attributes in `getSchemaDataDefaults()` (excluding any duplicates and the `value` attribute, which would have caused problems).

## To test

Assuming you have `silverstripe/frameworktest` installed:

1. Add this code to the `Company` class
    
    ```php
    public function scaffoldSearchFields($_params = null)
    {
        $fields = parent::scaffoldSearchFields($_params);
        foreach ($fields as $field) {
            if ($field->getName() === 'Name') {
                $field->setAttribute('placeholder', 'this is my placeholder');
            }
        }
        return $fields;
    }
    ```
    
1. Go to the "Test ModelAdmin" section (`/admin/test`)
1. Click the magnifying glass in the top right, then expand "search options" - the "Name" field should have some placeholder text.

Also check that you can set up and use the formfields which were specifically changed.


## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/9124