### PR TITLE
FIX: Make IsFirst and IsLast work as expected for PaginatedList (fixes #11465)

### DIFF
--- a/tests/php/View/SSViewerTest.php
+++ b/tests/php/View/SSViewerTest.php
@@ -1480,6 +1480,37 @@ after'
         $this->assertEquals("", $result, "Only numbers that are multiples of 11 are returned. I.e. nothing returned");
     }
 
+    public function testSSViewerBasicIteratorSupportWithPaginatedList()
+    {
+        $list = new ArrayList([
+            ['Val' => 1],
+            ['Val' => 2],
+            ['Val' => 3],
+            ['Val' => 4],
+            ['Val' => 5],
+            ['Val' => 6],
+        ]);
+        $paginatedList = new PaginatedList($list);
+        $paginatedList->setPageLength(2);
+        $data = new ArrayData([
+            'PaginatedList' => $paginatedList
+        ]);
+
+        $result = $this->render('<% loop PaginatedList %><% if $IsFirst %>$Val<% end_if %><% end_loop %>', $data);
+        $this->assertEquals("1", $result, "Only the first item on the first page is rendered");
+
+        $result = $this->render('<% loop PaginatedList %><% if $IsLast %>$Val<% end_if %><% end_loop %>', $data);
+        $this->assertEquals("2", $result, "Only the last item on the first page is rendered");
+
+        $paginatedList->setCurrentPage(2);
+
+        $result = $this->render('<% loop PaginatedList %><% if $IsFirst %>$Val<% end_if %><% end_loop %>', $data);
+        $this->assertEquals("3", $result, "Only the first item on the second page is rendered");
+
+        $result = $this->render('<% loop PaginatedList %><% if $IsLast %>$Val<% end_if %><% end_loop %>', $data);
+        $this->assertEquals("4", $result, "Only the last item on the second page is rendered");
+    }
+
     /**
      * Test $Up works when the scope $Up refers to was entered with a "with" block
      */


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
Adds a fix for #11465 in CMS 5 that doesn’t risk a BC-break. 

## Manual testing steps
Set up a paginated list (e.g. in your `Page` class):
```php
public function getPaginatedList()
{
    $items = [
        ['Val' => 1],
        ['Val' => 2],
        ['Val' => 3],
        ['Val' => 4],
        ['Val' => 5],
        ['Val' => 6],
        ['Val' => 7],
        ['Val' => 8],
        ['Val' => 9],
        ['Val' => 10],
    ];
    $list = new ArrayList($items);
    $paginated = new PaginatedList($list);
    $paginated->setPageLength(3);
    $paginated->setCurrentPage(2);
    return $paginated;
}
```

In a template, iterate through that paginated list:
```text
<ul>
    <% loop $PaginatedList %>
    <li>$FirstLast $Val</li>
    <% end_loop %>
</ul>
```

Verify that the output is:
```text
    first 4
    5
    last 6
```

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11465

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
