### PR TITLE
MNT Fix unit test

### DIFF
--- a/tests/php/View/Embed/MockResponse.php
+++ b/tests/php/View/Embed/MockResponse.php
@@ -36,26 +36,32 @@ class MockResponse implements ResponseInterface
 
     public function getReasonPhrase()
     {
+        return '';
     }
 
     public function getProtocolVersion()
     {
+        return '';
     }
 
     public function getHeaders()
     {
+        return [];
     }
 
     public function getHeader($name)
     {
+        return '';
     }
 
     public function getHeaderLine($name)
     {
+        return '';
     }
 
     public function hasHeader($name)
     {
+        return false;
     }
 
     public function withHeader($name, $value)


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11473

MockResponse implements PSR ResponseInterface with extends MessageInterface

Those interfaces are both loosely typed, though their docblocks define expected return types

[This line](https://github.com/oscarotero/Embed/blob/master/src/Document.php#L30) is what's trigger the issue, it's expecting a string, though our mock response was return null. I've updated the mock response to return the expected types