### PR TITLE
HTML5 `<meta charset="utf-8">`

### DIFF
--- a/src/Control/HTTPResponse.php
+++ b/src/Control/HTTPResponse.php
@@ -117,7 +117,7 @@ class HTTPResponse
      * @var array
      */
     protected $headers = [
-        "content-type" => "text/html; charset=utf-8",
+        "charset" => "utf-8",
     ];
 
     /**

--- a/templates/BlankPage.ss
+++ b/templates/BlankPage.ss
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+<meta charset="utf-8">
 <title>$Title</title>
 <% base_tag %>
 </head>


### PR DESCRIPTION
## Description
`<meta charset="utf-8">` should be used exclusively, instead of `<meta http-equiv="Content-Type" content="text/html; charset=utf-8">` or both as it is not needed for HTML5. W3C Validator also flags self-closing tags as an issue. While Symfony has [reverted such a change](https://github.com/symfony/symfony/issues/53649), still it would make sense to remove those esp. in light of [PHP 8.4 DOM HTML5 parsing](https://wiki.php.net/rfc/domdocument_html5_parser). What is your opinion on handling self-closing tags?

## Manual testing steps
A [PR will follow in the CMS](https://github.com/silverstripe/silverstripe-cms/pull/3031) for ensuring HTML5 compliance. Additionally, simple theme should be updated to address this issue. Ultimately, only a single`<meta charset="utf-8">` should be used.

## Issues
https://github.com/silverstripe/silverstripe-framework/issues/7438

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
