### PR TITLE
FIX Don't swallow relevant BadMethodCallExceptions from ViewLayerData

### DIFF
--- a/src/Model/ModelDataCustomised.php
+++ b/src/Model/ModelDataCustomised.php
@@ -24,10 +24,10 @@ class ModelDataCustomised extends ModelData
     public function __call($method, $arguments)
     {
         if ($this->customised->hasMethod($method)) {
-            return call_user_func_array([$this->customised, $method], $arguments ?? []);
+            return $this->customised->$method(...$arguments);
         }
 
-        return call_user_func_array([$this->original, $method], $arguments ?? []);
+        return $this->original->$method(...$arguments);
     }
 
     public function __get(string $property): mixed

--- a/tests/php/View/ViewLayerDataTest/TestBadMethodCallObject.php
+++ b/tests/php/View/ViewLayerDataTest/TestBadMethodCallObject.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\View\Tests\ViewLayerDataTest;
+
+use BadMethodCallException;
+use SilverStripe\Dev\TestOnly;
+
+class TestBadMethodCallObject implements TestOnly
+{
+    public function __call(string $name, array $arguments): void
+    {
+        throw new BadMethodCallException('This exception should be caught by ViewLayerData');
+    }
+}

--- a/tests/php/View/ViewLayerDataTest/TestBadMethodCallObjectSubclass.php
+++ b/tests/php/View/ViewLayerDataTest/TestBadMethodCallObjectSubclass.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SilverStripe\View\Tests\ViewLayerDataTest;
+
+use BadMethodCallException;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Model\ModelData;
+
+class TestBadMethodCallObjectSubclass extends TestBadMethodCallObject implements TestOnly
+{
+    public function __call(string $name, array $arguments): void
+    {
+        if ($name === 'directMethod') {
+            throw new BadMethodCallException('This exception should be caught by ViewLayerData');
+        }
+        if ($name === 'realMethod') {
+            $this->throwException();
+        }
+        if ($name === 'anotherClass') {
+            $data = new ModelData();
+            $data->thisMethodDoesntExist();
+        }
+        parent::__call($name, $arguments);
+    }
+
+    public function throwException(): void
+    {
+        throw new BadMethodCallException('This exception should NOT be caught by ViewLayerData');
+    }
+}


### PR DESCRIPTION
Without this PR, scenarios "exception thrown outside __call()" and "exception thrown in __call() in a different class hierarchy" would fail.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11481