### PR TITLE
FIX Allow __call() to trigger __call() in other classes

### DIFF
--- a/src/View/ViewLayerData.php
+++ b/src/View/ViewLayerData.php
@@ -255,7 +255,6 @@ class ViewLayerData implements IteratorAggregate, Stringable
 
     private function mustThrow(array $trace): bool
     {
-        $dataClass = get_class($this->data);
         foreach ($trace as $data) {
             $class = $data['class'] ?? '';
             $method = $data['function'] ?? '';
@@ -270,10 +269,6 @@ class ViewLayerData implements IteratorAggregate, Stringable
             // If we find a non __call method return true
             // This means our method exists, but it tried to call something else which doesn't
             if ($method !== '__call') {
-                return true;
-            }
-            // If we break class inheritance return true
-            if (!is_a($class, $dataClass, true) && !is_a($dataClass, $class, true)) {
                 return true;
             }
         }

--- a/tests/php/View/ViewLayerDataTest.php
+++ b/tests/php/View/ViewLayerDataTest.php
@@ -723,9 +723,11 @@ class ViewLayerDataTest extends SapphireTest
                 'method' => 'realMethod',
                 'exceptionCaught' => false,
             ],
+            // This happens if one class is used to wrap another, so it relies on calling
+            // methods on the wrapped class which may not share its class hierarchy.
             'exception thrown in __call() in a different class hierarchy' => [
                 'method' => 'anotherClass',
-                'exceptionCaught' => false,
+                'exceptionCaught' => true,
             ],
         ];
     }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-elemental/actions/runs/12128337221/job/33818161207 and many of the failures in https://github.com/silverstripe/silverstripe-cms/actions/runs/12128338043/
Basically `VirtualPage` couldn't be viewed at all, so that's easy to test.

If a class wraps another class, it may rely on calling methods in that other class. If that throws BadMethodCallException we should swallow that in ViewLayerData because it's the same as the method not existing on the object we're directly calling it on.

## Issue
- https://github.com/silverstripe/.github/issues/348