### PR TITLE
FIX Don't use call_user_func in __call()

### DIFF
--- a/src/Core/Injector/AopProxyService.php
+++ b/src/Core/Injector/AopProxyService.php
@@ -47,7 +47,7 @@ class AopProxyService
             }
 
             if ($continue) {
-                $result = call_user_func_array([$this->proxied, $method], $args ?? []);
+                $result = $this->proxied->$method(...$args);
 
                 if (isset($this->afterCall[$method])) {
                     $methods = $this->afterCall[$method];

--- a/src/View/Parsers/HTMLValue.php
+++ b/src/View/Parsers/HTMLValue.php
@@ -160,7 +160,7 @@ class HTMLValue extends ModelData
         $doc = $this->getDocument();
 
         if ($doc && method_exists($doc, $method ?? '')) {
-            return call_user_func_array([$doc, $method], $arguments ?? []);
+            return $doc->$method(...$arguments);
         } else {
             return parent::__call($method, $arguments);
         }


### PR DESCRIPTION
These changes were made as a result of https://github.com/silverstripe/silverstripe-cms/pull/3034 - I took a look for any `__call()` implementations and these ones need updating.
These would cause problems if `ViewLayerData` hits them with a method that doesn't exist.

## Issue
- https://github.com/silverstripe/.github/issues/348