### PR TITLE
API Move logic from silverstripe/cms into central place

### DIFF
--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -618,6 +618,30 @@ class Hierarchy extends Extension
     }
 
     /**
+     * Return the CSS classes to apply to this node in the CMS tree.
+     */
+    public function CMSTreeClasses(): string
+    {
+        $owner = $this->getOwner();
+        $classes = sprintf('class-%s', Convert::raw2htmlid(get_class($owner)));
+
+        if (!$owner->canAddChildren()) {
+            $classes .= " nochildren";
+        }
+
+        if (!$owner->canEdit() && !$owner->canAddChildren()) {
+            if (!$owner->canView()) {
+                $classes .= " disabled";
+            } else {
+                $classes .= " edit-disabled";
+            }
+        }
+
+        $owner->invokeWithExtensions('updateCMSTreeClasses', $classes);
+        return $classes;
+    }
+
+    /**
      * Find the first class in the inheritance chain that has Hierarchy extension applied
      *
      * @return string
@@ -775,6 +799,17 @@ class Hierarchy extends Extension
         }
         $crumbs[] = $this->owner->getTitle();
         return implode($separator ?? '', $crumbs);
+    }
+
+    /**
+     * Get the title that will be used in TreeDropdownField and other tree structures.
+     */
+    public function getTreeTitle(): string
+    {
+        $owner = $this->getOwner();
+        $title = $owner->MenuTitle ?: $owner->Title;
+        $owner->extend('updateTreeTitle', $title);
+        return Convert::raw2xml($title ?? '');
     }
 
     /**

--- a/src/Security/Group.php
+++ b/src/Security/Group.php
@@ -495,16 +495,6 @@ class Group extends DataObject
     }
 
     /**
-     * @return string
-     */
-    public function getTreeTitle()
-    {
-        $title = htmlspecialchars($this->Title ?? '', ENT_QUOTES);
-        $this->extend('updateTreeTitle', $title);
-        return $title;
-    }
-
-    /**
      * Overloaded to ensure the code is always descent.
      *
      * @param string $val

--- a/src/Security/PermissionCheckable.php
+++ b/src/Security/PermissionCheckable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\Security;
+
+/**
+ * Model with permissions that can be checked using PermissionChecker
+ */
+interface PermissionCheckable
+{
+    /**
+     * Get the permission checker for this model
+     */
+    public function getPermissionChecker(): PermissionChecker;
+}


### PR DESCRIPTION
Replaces https://github.com/silverstripe/silverstripe-framework/pull/11439

There's some API that `CMSMain` expects, because it's on `SiteTree`.

Some of that API is best placed in various places in this module.

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2947