### PR TITLE
MNT Fix unit test

### DIFF
--- a/tests/php/View/Embed/MockResponse.php
+++ b/tests/php/View/Embed/MockResponse.php
@@ -56,6 +56,9 @@ class MockResponse implements ResponseInterface
 
     public function getHeaderLine($name)
     {
+        if (strtolower($name) === 'content-type') {
+            return 'text/html; charset=utf-8';
+        }
         return '';
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/349

Fixes https://github.com/silverstripe/silverstripe-framework/actions/runs/12286468439/job/34286763680#step:12:154

`1) SilverStripe\View\Tests\Embed\EmbedContainerTest::testGetDimensions
TypeError: mb_encoding_aliases(): Argument #1 ($encoding) must be of type string, null given`
