### PR TITLE
ENH Use updated league/csv api

### DIFF
--- a/src/Forms/GridField/GridFieldExportButton.php
+++ b/src/Forms/GridField/GridFieldExportButton.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms\GridField;
 
+use League\Csv\Bom;
 use League\Csv\Writer;
 use LogicException;
 use SilverStripe\Control\HTTPRequest;
@@ -180,8 +181,8 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
         $csvWriter = Writer::createFromFileObject(new \SplTempFileObject());
         $csvWriter->setDelimiter($this->getCsvSeparator());
         $csvWriter->setEnclosure($this->getCsvEnclosure());
-        $csvWriter->setNewline("\r\n"); //use windows line endings for compatibility with some csv libraries
-        $csvWriter->setOutputBOM(Writer::BOM_UTF8);
+        $csvWriter->setEndOfLine("\r\n"); //use windows line endings for compatibility with some csv libraries
+        $csvWriter->setOutputBOM(Bom::Utf8);
 
         if (!Config::inst()->get(get_class($this), 'xls_export_disabled')) {
             $csvWriter->addFormatter(function (array $row) {
@@ -269,11 +270,7 @@ class GridFieldExportButton extends AbstractGridFieldComponent implements GridFi
             }
         }
 
-        if (method_exists($csvWriter, 'getContent')) {
-            return $csvWriter->getContent();
-        }
-
-        return (string)$csvWriter;
+        return $csvWriter->toString();
     }
 
     /**

--- a/tests/php/Forms/GridField/GridFieldExportButtonTest.php
+++ b/tests/php/Forms/GridField/GridFieldExportButtonTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Forms\Tests\GridField;
 
+use League\Csv\Bom;
 use League\Csv\Reader;
 use LogicException;
 use ReflectionMethod;
@@ -64,7 +65,7 @@ class GridFieldExportButtonTest extends SapphireTest
 
         $this->assertEquals(
             "$bom\"My Name\"\r\n",
-            (string) $csvReader
+            (string) $csvReader->toString()
         );
     }
 
@@ -78,7 +79,7 @@ class GridFieldExportButtonTest extends SapphireTest
 
         $this->assertEquals(
             $bom . '"My Name"' . "\r\n" . 'Test' . "\r\n" . 'Test2' . "\r\n",
-            (string) $csvReader
+            $csvReader->toString()
         );
     }
 
@@ -98,7 +99,7 @@ class GridFieldExportButtonTest extends SapphireTest
 
         $this->assertEquals(
             "$bom\"My Name\"\r\n\"\t=SUM(1, 2)\"\r\nTest\r\nTest2\r\n",
-            (string) $csvReader
+            $csvReader->toString()
         );
     }
 
@@ -117,7 +118,7 @@ class GridFieldExportButtonTest extends SapphireTest
 
         $this->assertEquals(
             $bom . 'Name,City' . "\r\n" . 'Test,"City city"' . "\r\n" . 'Test2,"Quoted ""City"" 2 city"' . "\r\n",
-            (string) $csvReader
+            $csvReader->toString()
         );
     }
 
@@ -134,7 +135,7 @@ class GridFieldExportButtonTest extends SapphireTest
 
         $this->assertEquals(
             $bom . 'Name,strtolower' . "\r\n" . 'Test,City' . "\r\n" . 'Test2,"Quoted ""City"" 2"' . "\r\n",
-            (string) $csvReader
+            $csvReader->toString()
         );
     }
 
@@ -152,7 +153,7 @@ class GridFieldExportButtonTest extends SapphireTest
 
         $this->assertEquals(
             $bom . 'Test,City' . "\r\n" . 'Test2,"Quoted ""City"" 2"' . "\r\n",
-            (string) $csvReader
+            $csvReader->toString()
         );
     }
 
@@ -179,7 +180,7 @@ class GridFieldExportButtonTest extends SapphireTest
 
         $this->assertEquals(
             $bom . "ID\r\n" . "1\r\n" . "2\r\n" . "3\r\n" . "4\r\n" . "5\r\n" . "6\r\n" . "7\r\n" . "8\r\n" . "9\r\n" . "10\r\n" . "11\r\n" . "12\r\n" . "13\r\n" . "14\r\n" . "15\r\n" . "16\r\n",
-            (string) $csvReader
+            $csvReader->toString()
         );
     }
 
@@ -195,7 +196,7 @@ class GridFieldExportButtonTest extends SapphireTest
 
         $this->assertEquals(
             "$bom\"Rugby Team Number\"\r\n2\r\n0\r\n",
-            (string) $csvReader
+            $csvReader->toString()
         );
     }
 
@@ -224,7 +225,7 @@ class GridFieldExportButtonTest extends SapphireTest
 
         // Explicitly set the output BOM in league/csv 9
         if (method_exists($reader, 'getContent')) {
-            $reader->setOutputBOM(Reader::BOM_UTF8);
+            $reader->setOutputBOM(Bom::Utf8);
         }
 
         return $reader;


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/349

https://github.com/silverstripe/silverstripe-framework/pull/11507 being merged and merged up to fix the broken unit tests, this just fixes deprecation warnings

Fixes https://github.com/silverstripe/silverstripe-framework/actions/runs/12270153106/job/34283940618#step:12:125

Deprecation notices only happen on php 8.4

```
PHP Deprecated:  Method League\Csv\Writer::setNewline() is deprecated since league/csv:9.8.0, use League\Csv\Writer::setEndOfLine() in /home/runner/work/silverstripe-framework/silverstripe-framework/src/Forms/GridField/GridFieldExportButton.php on line 183
PHP Deprecated:  Constant League\Csv\ByteSequence::BOM_UTF8 is deprecated since league/csv:9.16.0, use League\Csv\Bom:Utf8 instead in /home/runner/work/silverstripe-framework/silverstripe-framework/src/Forms/GridField/GridFieldExportButton.php on line 184
PHP Deprecated:  Method League\Csv\AbstractCsv::getContent() is deprecated since league/csv:9.7.0, use League\Csv\AbstractCsv::toString() instead in /home/runner/work/silverstripe-framework/silverstripe-framework/src/Forms/GridField/GridFieldExportButton.php on line 273
PHP Deprecated:  Constant League\Csv\ByteSequence::BOM_UTF8 is deprecated since league/csv:9.16.0, use League\Csv\Bom:Utf8 instead in /home/runner/work/silverstripe-framework/silverstripe-framework/tests/php/Forms/GridField/GridFieldExportButtonTest.php on line 227
PHP Deprecated:  Method League\Csv\AbstractCsv::__toString() is deprecated since league/csv:9.1.0, use League\Csv\AbstractCsv::toString() instead in /home/runner/work/silverstripe-framework/silverstripe-framework/tests/php/Forms/GridField/GridFieldExportButtonTest.php on line 67
```