### PR TITLE
FIX Use ORM functions to perform eager loading instead of raw query

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -5,6 +5,7 @@ namespace SilverStripe\ORM;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\Debug;
 use SilverStripe\ORM\Queries\SQLConditionGroup;
+use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\View\ViewableData;
 use Exception;
 use InvalidArgumentException;
@@ -1349,6 +1350,10 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
         $fetchList = $relationList->forForeignID($parentIDs);
         $fetchList = $this->manipulateEagerLoadingQuery($fetchList, $relationChain, $relationType);
         $fetchedRows = $fetchList->getFinalisedQuery();
+        $query = $fetchList->dataQuery()->query();
+        $fetchedOrderBy = $query->getOrderBy();
+        $childTables = $query->queriedTables();
+        $childTable = reset($childTables);
 
         foreach ($fetchedRows as $row) {
             $fetchedRowsArray[$row['ID']] = $row;
@@ -1361,15 +1366,18 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
         $joinRows = [];
         if (!empty($parentIDs) && !empty($fetchedIDs)) {
             $fetchedIDsAsString = implode(',', $fetchedIDs);
-            $joinRows = DB::query(
-                'SELECT * FROM "' . $joinTable
+            $joinRows = SQLSelect::create()
+                // Only select join columns to avoid ambiguity with joined child table columns
+                ->setSelect('"' . $joinTable . '".' . "*")
+                ->setFrom('"' . $joinTable . '"')
                 // Only get joins relevant for the parent list
-                . '" WHERE "' . $parentIDField . '" IN (' . implode(',', $parentIDs) . ')'
-                // Exclude any children that got filtered out
-                . ' AND ' . $childIDField . ' IN (' . $fetchedIDsAsString . ')'
-                // Respect sort order of fetched items
-                . ' ORDER BY FIELD(' . $childIDField . ', ' . $fetchedIDsAsString . ')'
-            );
+                ->addWhere('"' . $joinTable . '"."' . $parentIDField . '" IN (' . implode(',', $parentIDs) . ')')
+                // Exclude children that got filtered out
+                ->addWhere('"' . $joinTable . '"."' . $childIDField . '" IN (' . $fetchedIDsAsString . ')')
+                // Respect sort order of fetched children by joining child table and using its order by clause
+                ->addLeftJoin($childTable, "$childTable.ID = $joinTable.$childIDField")
+                ->setOrderBy($fetchedOrderBy)
+                ->execute();
         }
 
         // Store the children in an EagerLoadedList against the correct parent


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
The original query was a hardcoded and a rather hacky way of retaining the ordering of the child objects while fetching from a many_many table. The method used to retain this order was 'FIELD', which is a MySQL exclusive feature and breaks in other sql engines. This change converts the query to properly make use of the ORM functions and use the ordering used in the original query directly.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
1. Create and populate two DataObjects that have a many_many relation between them
2. Perform an eagerLoad on DataObject::get() and convert the result to an array
3. Observe that the new SQLSelect query is performed correctly
4. Observe that grabbing the first relation entry from the first array object is the expected DataObject and does not perform another query


## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11503

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
