### PR TITLE
FIX Treat value not in SingleSelectField options as blank

### DIFF
--- a/src/Forms/SingleSelectField.php
+++ b/src/Forms/SingleSelectField.php
@@ -53,12 +53,13 @@ abstract class SingleSelectField extends SelectField
     public function getDefaultValue()
     {
         $value = $this->Value();
+        $validValues = $this->getValidValues();
         // assign value to field, such as first option available
-        if ($value === null) {
+        if ($value === null || !in_array($value, $validValues)) {
             if ($this->getHasEmptyDefault()) {
                 $value = '';
             } else {
-                $values = $this->getValidValues();
+                $values = $validValues;
                 $value = array_shift($values);
             }
         }

--- a/tests/php/Forms/DropdownFieldTest.php
+++ b/tests/php/Forms/DropdownFieldTest.php
@@ -170,7 +170,7 @@ class DropdownFieldTest extends SapphireTest
 
         $form->method('getHTMLID')
             ->willReturn($formName);
-        
+
         $source = [
             'first' => 'value',
             0 => 'otherValue'
@@ -608,5 +608,63 @@ class DropdownFieldTest extends SapphireTest
         $v = new RequiredFields();
         $field->validate($v);
         $this->assertTrue($v->getResult()->isValid());
+    }
+
+    public function provideGetDefaultValue(): array
+    {
+        return [
+            [
+                'value' => null,
+                'hasEmptyDefault' => true,
+                'expected' => '',
+            ],
+            [
+                'value' => null,
+                'hasEmptyDefault' => false,
+                'expected' => 'one',
+            ],
+            [
+                'value' => 'four',
+                'hasEmptyDefault' => true,
+                'expected' => '',
+            ],
+            [
+                'value' => 'four',
+                'hasEmptyDefault' => false,
+                'expected' => 'one',
+            ],
+            [
+                'value' => 'two',
+                'hasEmptyDefault' => true,
+                'expected' => 'two',
+            ],
+            [
+                'value' => 'two',
+                'hasEmptyDefault' => false,
+                'expected' => 'two',
+            ],
+            [
+                // Note this is an int, but matches against the string key
+                'value' => 3,
+                'hasEmptyDefault' => true,
+                'expected' => 3,
+            ],
+            [
+                'value' => 3,
+                'hasEmptyDefault' => false,
+                'expected' => 3,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideGetDefaultValue
+     */
+    public function testGetDefaultValue(mixed $value, bool $hasEmptyDefault, mixed $expected): void
+    {
+        $field = new DropdownField('MyField', source: ['one' => 'one', 'two' => 'two', '3' => 'three']);
+        $field->setHasEmptyDefault($hasEmptyDefault);
+        $field->setValue($value);
+        $this->assertSame($expected, $field->getDefaultValue());
     }
 }


### PR DESCRIPTION
Replaces https://github.com/silverstripe/silverstripe-admin/pull/1872

This makes the react dropdown fields behave more like the entwine ones when the DB value is not in the set of dropdown options.

Note that the reproduction steps in the issue rely on the DB field being `Int` (or perhaps other numeric fields as well - but specifically not a string type). This is because its default value is `0`, while the default for `Varchar` for example is `null` which wouldn't exhibit the bug.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11502