### PR TITLE
API Make validator param nullable

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -114,9 +114,9 @@ class Form extends ModelData implements HasRequestHandler
     protected $name;
 
     /**
-     * @var Validator
+     * @var null|Validator
      */
-    protected $validator;
+    protected $validator = null;
 
     /**
      * @see setValidationResponseCallback()
@@ -635,7 +635,7 @@ class Form extends ModelData implements HasRequestHandler
 
     /**
      * Get the {@link Validator} attached to this form.
-     * @return Validator
+     * @return null|Validator
      */
     public function getValidator()
     {
@@ -644,10 +644,10 @@ class Form extends ModelData implements HasRequestHandler
 
     /**
      * Set the {@link Validator} on this form.
-     * @param Validator $validator
+     * @param null|Validator $validator
      * @return $this
      */
-    public function setValidator(Validator $validator)
+    public function setValidator(?Validator $validator)
     {
         if ($validator) {
             $this->validator = $validator;

--- a/tests/php/Forms/DropdownFieldTest.php
+++ b/tests/php/Forms/DropdownFieldTest.php
@@ -601,7 +601,7 @@ class DropdownFieldTest extends SapphireTest
         $this->assertTrue($field->validate()->isValid());
     }
 
-    public function provideGetDefaultValue(): array
+    public static function provideGetDefaultValue(): array
     {
         return [
             [
@@ -648,9 +648,7 @@ class DropdownFieldTest extends SapphireTest
         ];
     }
 
-    /**
-     * @dataProvider provideGetDefaultValue
-     */
+    #[DataProvider('provideGetDefaultValue')]
     public function testGetDefaultValue(mixed $value, bool $hasEmptyDefault, mixed $expected): void
     {
         $field = new DropdownField('MyField', source: ['one' => 'one', 'two' => 'two', '3' => 'three']);

--- a/tests/php/Forms/TreeDropdownFieldTest.php
+++ b/tests/php/Forms/TreeDropdownFieldTest.php
@@ -303,9 +303,9 @@ class TreeDropdownFieldTest extends SapphireTest
         $cssPath = 'ul.tree li#selector-TestTree-' . $subObject1->ID . ' li#selector-TestTree-' . $subObject1ChildB->ID . ' a';
         $firstResult = $parser->getBySelector($cssPath);
         $this->assertEquals(
-            $subObject1ChildB->Name,
+            $subObject1ChildB->Title,
             (string)$firstResult[0],
-            $subObject1ChildB->Name . ' is found, nested under ' . $subObject1->Name
+            $subObject1ChildB->Title . ' is found, nested under ' . $subObject1->Title
         );
 
         // other objects which don't contain the keyword 'SubObject' are not returned in search results


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/349

Two commits

API commit Fixes 

1) SilverStripe\Forms\Tests\GridField\GridFieldTest::testValidationMessageInOutput
TypeError: SilverStripe\Forms\Form::setValidator(): Argument 1 ($validator) must be of type SilverStripe\Forms\Validation\Validator, null given, called in /home/runner/work/silverstripe-installer/silverstripe-installer/vendor/silverstripe/framework/tests/php/Forms/GridField/GridFieldTest.php on line 554

MNT commit fixes

1) SilverStripe\Forms\Tests\DropdownFieldTest::testGetDefaultValue
The data provider specified for SilverStripe\Forms\Tests\DropdownFieldTest::testGetDefaultValue is invalid
Data Provider method SilverStripe\Forms\Tests\DropdownFieldTest::provideGetDefaultValue() is not static

and

1) SilverStripe\Forms\Tests\TreeDropdownFieldTest::testTreeSearchUsingSubObject
is found, nested under 
Failed asserting that 'Child B of Four SubObject' matches expected null.

