### PR TITLE
FIX Apply raw2xml before extension hook

### DIFF
--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -808,8 +808,9 @@ class Hierarchy extends Extension
     {
         $owner = $this->getOwner();
         $title = $owner->MenuTitle ?: $owner->Title;
+        $title = Convert::raw2xml($title ?? '');
         $owner->extend('updateTreeTitle', $title);
-        return Convert::raw2xml($title ?? '');
+        return $title;
     }
 
     /**

--- a/tests/php/ORM/HierarchyTest.php
+++ b/tests/php/ORM/HierarchyTest.php
@@ -682,4 +682,14 @@ class HierarchyTest extends SapphireTest
 
         $this->assertSame($expected, $obj->defaultParent());
     }
+
+    /**
+     * Tests that HTML added by an extension is not escaped
+     */
+    public function testGetTreeTitleExtension()
+    {
+        HierarchyTest\TestObject::add_extension(HierarchyTest\TestTreeTitleExtension::class);
+        $obj = $this->objFromFixture(HierarchyTest\TestObject::class, 'obj1');
+        $this->assertSame('Obj 1', '<i>Obj 1</i>');
+    }
 }

--- a/tests/php/ORM/HierarchyTest/TestTreeTitleExtension.php
+++ b/tests/php/ORM/HierarchyTest/TestTreeTitleExtension.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Core\Extension;
+
+class TestTreeTitleExtension extends Extension implements TestOnly
+{
+    protected function updateTreeTitle(string &$title)
+    {
+        return "<i>$title</i>";
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/349

Fixes https://github.com/silverstripe/silverstripe-subsites/actions/runs/12342588552/job/34442723479#step:12:109

```
1) SilverStripe\Subsites\Tests\GroupSubsitesTest::testAlternateTreeTitle
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'The A Team <i>(global group)</i>'
+'The A Team &lt;i&gt;(global group)&lt;/i&gt;'
```