### PR TITLE
FIX Apply raw2xml before extension hook

### DIFF
--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -808,8 +808,9 @@ class Hierarchy extends Extension
     {
         $owner = $this->getOwner();
         $title = $owner->MenuTitle ?: $owner->Title;
+        $title = Convert::raw2xml($title ?? '');
         $owner->extend('updateTreeTitle', $title);
-        return Convert::raw2xml($title ?? '');
+        return $title;
     }
 
     /**

--- a/tests/php/ORM/HierarchyTest.php
+++ b/tests/php/ORM/HierarchyTest.php
@@ -9,6 +9,8 @@ use SilverStripe\Core\Validation\ValidationException;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\Hierarchy\Hierarchy;
+use SilverStripe\Security\Group;
+use SilverStripe\ORM\Tests\HierarchyTest\TestTreeTitleExtension;
 
 class HierarchyTest extends SapphireTest
 {
@@ -681,5 +683,16 @@ class HierarchyTest extends SapphireTest
         $obj = new $class();
 
         $this->assertSame($expected, $obj->defaultParent());
+    }
+
+    /**
+     * Tests that HTML added by an extension is not escaped, though HTML in the base Title still is
+     */
+    public function testGetTreeTitleExtension()
+    {
+        Group::add_extension(TestTreeTitleExtension::class);
+        $group = new Group();
+        $group->Title = '<b>My group</b>';
+        $this->assertSame('<i>&lt;b&gt;My group&lt;/b&gt;</i>', $group->getTreeTitle());
     }
 }

--- a/tests/php/ORM/HierarchyTest/TestTreeTitleExtension.php
+++ b/tests/php/ORM/HierarchyTest/TestTreeTitleExtension.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Core\Extension;
+
+class TestTreeTitleExtension extends Extension implements TestOnly
+{
+    protected function updateTreeTitle(string &$title)
+    {
+        $title = "<i>$title</i>";
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/349

Fixes https://github.com/silverstripe/silverstripe-subsites/actions/runs/12342588552/job/34442723479#step:12:109

```
1) SilverStripe\Subsites\Tests\GroupSubsitesTest::testAlternateTreeTitle
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'The A Team <i>(global group)</i>'
+'The A Team &lt;i&gt;(global group)&lt;/i&gt;'
```