### PR TITLE
MNT Fix unit test

### DIFF
--- a/tests/php/ORM/HierarchyTest.php
+++ b/tests/php/ORM/HierarchyTest.php
@@ -690,6 +690,12 @@ class HierarchyTest extends SapphireTest
      */
     public function testGetTreeTitleExtension()
     {
+        // Ensure no other extensions are applied which would change the expected result
+        foreach (Group::get_extensions() as $extension) {
+            if ($extension !== Hierarchy::class) {
+                Group::remove_extension($extension);
+            }
+        }
         Group::add_extension(TestTreeTitleExtension::class);
         $group = new Group();
         $group->Title = '<b>My group</b>';


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/349

Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/12402183570/job/34623193042#step:12:142

Happens when subsites extension is applied

```
 1) SilverStripe\ORM\Tests\HierarchyTest::testGetTreeTitleExtension
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'<i>&lt;b&gt;My group&lt;/b&gt;</i>'
+'<i>&lt;b&gt;My group&lt;/b&gt; <i>(global group)</i></i>'
```