### PR TITLE
FEAT support variables as second and third argument

### DIFF
--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -618,9 +618,9 @@ class i18nTextCollector
         $potentialClassName = null;
         $currentUse = null;
         $currentUseAlias = null;
-        $inVar = null;
-        $inVarText = '';
-        $stringVariables = [];
+        $inVar = null; // Tracks string variables
+        $inVarText = ''; // Tracks the content of the current string variable
+        $stringVariables = []; // Store all string variables by name
         foreach ($tokens as $token) {
             // Shuffle last token to $lastToken
             $previousToken = $thisToken;

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -658,7 +658,7 @@ class i18nTextCollector
                         $inVarText = '';
                         continue;
                     }
-                    if ($id === T_CONSTANT_ENCAPSED_STRING && $inVar && $text) {
+                    if ($id === T_CONSTANT_ENCAPSED_STRING && $inVar !== null && $text !== null) {
                         // We need to call process strings because $text is like 'my' or 'string' or "my" or "string"
                         // This can be called multiple time, eg: $str = 'my' . 'string';
                         $inVarText .= $this->processString($text);

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -619,6 +619,7 @@ class i18nTextCollector
         $currentUse = null;
         $currentUseAlias = null;
         $inVar = null; // Tracks string variables
+        $inVarConcat =  false; // Track if we do things $x .= 'my str'
         $inVarText = ''; // Tracks the content of the current string variable
         $stringVariables = []; // Store all string variables by name
         foreach ($tokens as $token) {
@@ -629,11 +630,15 @@ class i18nTextCollector
             // Track string variables
             // Store when reaching end of statement if we have content
             if ($token === ";" && $inVar) {
-                if ($inVarText) {
-                    $stringVariables[$inVar] = $inVarText;
+                if (strlen($inVarText) > 0) {
+                    if ($inVarConcat && isset($stringVariables[$inVar])) {
+                        $stringVariables[$inVar] .= $inVarText;
+                    } else {
+                        $stringVariables[$inVar] = $inVarText;
+                    }
                 }
                 $inVar = null;
-                continue;
+                $inVarConcat = false;
             }
             // End track string variables
 
@@ -653,6 +658,9 @@ class i18nTextCollector
 
                 // Track string variables
                 if (!$inTransFn) {
+                    if ($id === T_CONCAT_EQUAL && $inVar) {
+                        $inVarConcat = true;
+                    }
                     if ($id === T_VARIABLE) {
                         $inVar = $text;
                         $inVarText = '';
@@ -785,7 +793,7 @@ class i18nTextCollector
                     $stringValue = $stringVariables[$text] ?? null;
 
                     // It has a default translation, continue
-                    if ($stringValue) {
+                    if ($stringValue !== null) {
                         $currentEntity[] = $stringValue;
                         continue;
                     }
@@ -877,16 +885,9 @@ class i18nTextCollector
                     // Ensure key is valid before saving
                     if (!empty($currentEntity[0])) {
                         $key = $currentEntity[0];
-                        $default = '';
-                        $comment = '';
-                        if (!empty($currentEntity[1])) {
-                            $default = $currentEntity[1];
-                            if (!empty($currentEntity[2])) {
-                                $comment = $currentEntity[2];
-                            }
-                        }
-                        // Save in appropriate format
-                        if ($default) {
+                        $default = $currentEntity[1] ?? '';
+                        $comment = $currentEntity[2] ?? '';
+                        if (strlen($default) > 0) {
                             $plurals = i18n::parse_plurals($default);
                             // Use array form if either plural or metadata is provided
                             if ($plurals) {

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -618,7 +618,6 @@ class i18nTextCollector
         $potentialClassName = null;
         $currentUse = null;
         $currentUseAlias = null;
-
         $inVar = null;
         $stringVariables = [];
         foreach ($tokens as $token) {

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -277,7 +277,7 @@ class i18nTextCollector
         // bubble-compare each group of modules
         for ($i = 0; $i < count($modules ?? []) - 1; $i++) {
             $left = array_keys($entitiesByModule[$modules[$i]] ?? []);
-            for ($j = $i+1; $j < count($modules ?? []); $j++) {
+            for ($j = $i + 1; $j < count($modules ?? []); $j++) {
                 $right = array_keys($entitiesByModule[$modules[$j]] ?? []);
                 $conflicts = array_intersect($left ?? [], $right);
                 $allConflicts = array_merge($allConflicts, $conflicts);
@@ -618,14 +618,40 @@ class i18nTextCollector
         $potentialClassName = null;
         $currentUse = null;
         $currentUseAlias = null;
+        $inVar = null;
+        $resetVar = false;
+        $stringVariables = [];
         foreach ($tokens as $token) {
             // Shuffle last token to $lastToken
             $previousToken = $thisToken;
             $thisToken = $token;
+
             if (is_array($token)) {
                 list($id, $text, $lineNo) = $token;
                 // minus 2 is used so the the line we get corresponds with what number token_get_all() returned
                 $line = $lines[$lineNo - 2] ?? '';
+
+                // Track string variables, store all $myString = 'my value'; into a temporary array
+                // This allows _t('Entity.Key', $str); syntax
+                // Does not support "my $var value", use "my {var} value" instead with proper context
+                if ($id === T_VARIABLE) {
+                    $inVar = $text;
+
+                    // Reset variable if redefined later in scope
+                    if (!empty($stringVariables[$inVar])) {
+                        $resetVar = true;
+                    }
+                }
+                if ($id === T_CONSTANT_ENCAPSED_STRING && $inVar && $text) {
+                    if (!isset($stringVariables[$inVar]) || $resetVar) {
+                        $stringVariables[$inVar] = '';
+                        $resetVar = false;
+                    }
+                    $stringVariables[$inVar] .= $this->processString($text);
+                }
+                if ($text === ';') {
+                    $inVar = null;
+                }
 
                 // Collect use statements so we can get fully qualified class names
                 // Note that T_USE will match both use statements and anonymous functions with the "use" keyword
@@ -733,8 +759,27 @@ class i18nTextCollector
                     continue;
                 }
 
+                // Allow _t(Entity.Key, 'translation', $var) and expand _t(Entity.Key, $var)
+                if ($id == T_VARIABLE && !empty($currentEntity)) {
+                    // We have a translation, eg: _t(Entity.Key, 'translation', $var)
+                    if (count($currentEntity) == 2) {
+                        continue;
+                    }
+
+                    // The variable is the second argument or present in the parameter
+                    // Try to find it _t(Entity.Key, $var)
+                    $stringValue = $stringVariables[$text] ?? null;
+
+                    // It's translated, continue
+                    if ($stringValue) {
+                        $currentEntity[] = $stringValue;
+                        continue;
+                    }
+                }
+
                 // If inside this translation, some elements might be unreachable
-                if (in_array($id, [T_VARIABLE, T_STATIC]) ||
+                if (
+                    in_array($id, [T_VARIABLE, T_STATIC]) ||
                     ($id === T_STRING && in_array($text, ['static', 'parent']))
                 ) {
                     // Un-collectable strings such as _t(static::class.'.KEY').
@@ -754,26 +799,7 @@ class i18nTextCollector
 
                 // Check text
                 if ($id == T_CONSTANT_ENCAPSED_STRING) {
-                    // Fixed quoting escapes, and remove leading/trailing quotes
-                    if (preg_match('/^\'(?<text>.*)\'$/s', $text ?? '', $matches)) {
-                        $text = preg_replace_callback(
-                            '/\\\\([\\\\\'])/s', // only \ and '
-                            function ($input) {
-                                return stripcslashes($input[0] ?? '');
-                            },
-                            $matches['text'] ?? ''
-                        );
-                    } elseif (preg_match('/^\"(?<text>.*)\"$/s', $text ?? '', $matches)) {
-                        $text = preg_replace_callback(
-                            '/\\\\([nrtvf\\\\$"]|[0-7]{1,3}|\x[0-9A-Fa-f]{1,2})/s', // rich replacement
-                            function ($input) {
-                                return stripcslashes($input[0] ?? '');
-                            },
-                            $matches['text'] ?? ''
-                        );
-                    } else {
-                        throw new LogicException("Invalid string escape: " . $text);
-                    }
+                    $text = $this->processString($text);
                 } elseif ($id === T_CLASS_C || $id === T_TRAIT_C) {
                     // Evaluate __CLASS__ . '.KEY' and i18nTextCollector::class concatenation
                     $text = implode('\\', $currentClass);
@@ -879,6 +905,31 @@ class i18nTextCollector
         ksort($entities);
 
         return $entities;
+    }
+
+    private function processString(string $text): string
+    {
+        // Fixed quoting escapes, and remove leading/trailing quotes
+        if (preg_match('/^\'(?<text>.*)\'$/s', $text ?? '', $matches)) {
+            $text = preg_replace_callback(
+                '/\\\\([\\\\\'])/s', // only \ and '
+                function ($input) {
+                    return stripcslashes($input[0] ?? '');
+                },
+                $matches['text'] ?? ''
+            );
+        } elseif (preg_match('/^\"(?<text>.*)\"$/s', $text ?? '', $matches)) {
+            $text = preg_replace_callback(
+                '/\\\\([nrtvf\\\\$"]|[0-7]{1,3}|\x[0-9A-Fa-f]{1,2})/s', // rich replacement
+                function ($input) {
+                    return stripcslashes($input[0] ?? '');
+                },
+                $matches['text'] ?? ''
+            );
+        } else {
+            throw new LogicException("Invalid string escape: " . $text);
+        }
+        return $text;
     }
 
     /**
@@ -1064,7 +1115,8 @@ class i18nTextCollector
 
             // Check if this extension is included
             $extension = pathinfo($path ?? '', PATHINFO_EXTENSION);
-            if (in_array($extension, $this->fileExtensions ?? [])
+            if (
+                in_array($extension, $this->fileExtensions ?? [])
                 && (!$type || $type === $extension)
             ) {
                 $fileList[$path] = $path;

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -773,9 +773,9 @@ class i18nTextCollector
                     continue;
                 }
 
-                // Allow _t(Entity.Key, 'translation', $var) and expand _t(Entity.Key, $var)
+                // Allow _t(Entity.Key, 'default text', $var) and expand _t(Entity.Key, $var)
                 if ($id == T_VARIABLE && !empty($currentEntity)) {
-                    // We have a default text, eg: _t(Entity.Key, 'translation', $var)
+                    // We have a default text, eg: _t(Entity.Key, 'default text', $var)
                     if (count($currentEntity) == 2) {
                         continue;
                     }
@@ -784,7 +784,7 @@ class i18nTextCollector
                     // Try to find it _t(Entity.Key, $var)
                     $stringValue = $stringVariables[$text] ?? null;
 
-                    // It's translated, continue
+                    // It has a default translation, continue
                     if ($stringValue) {
                         $currentEntity[] = $stringValue;
                         continue;

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -619,28 +619,53 @@ class i18nTextCollector
         $currentUse = null;
         $currentUseAlias = null;
         $inVar = null;
+        $inVarText = '';
         $stringVariables = [];
         foreach ($tokens as $token) {
             // Shuffle last token to $lastToken
             $previousToken = $thisToken;
             $thisToken = $token;
 
+            // Track string variables
+            // Store when reaching end of statement if we have content
+            if ($token === ";" && $inVar) {
+                if ($inVarText) {
+                    $stringVariables[$inVar] = $inVarText;
+                }
+                $inVar = null;
+                continue;
+            }
+            // End track string variables
+
+            // Not all tokens are returned as an array.
+            // If a token is not variable, but instead it is one particular constant string, it is returned as a string instead.
+            // You don't get a line number.
+            // This is the case for braces( "{", "}"), parentheses ("(", ")"), brackets ("[", "]"), comma (","), semi-colon (";")...
             if (is_array($token)) {
                 list($id, $text, $lineNo) = $token;
                 // minus 2 is used so the the line we get corresponds with what number token_get_all() returned
                 $line = $lines[$lineNo - 2] ?? '';
 
+                // Ignore whitespace
+                if ($id === T_WHITESPACE) {
+                    continue;
+                }
+
                 // Track string variables
-                if ($id === T_VARIABLE) {
-                    $inVar = $text;
+                if (!$inTransFn) {
+                    if ($id === T_VARIABLE) {
+                        $inVar = $text;
+                        $inVarText = '';
+                        continue;
+                    }
+                    if ($id === T_CONSTANT_ENCAPSED_STRING && $inVar && $text) {
+                        // We need to call process strings because $text is like 'my' or 'string' or "my" or "string"
+                        // This can be called multiple time, eg: $str = 'my' . 'string';
+                        $inVarText .= $this->processString($text);
+                        continue;
+                    }
                 }
-                if ($id === T_CONSTANT_ENCAPSED_STRING && $inVar && $text) {
-                    $stringVariables[$inVar] = $text;
-                    $inVar = null;
-                }
-                if ($text === ';') {
-                    $inVar = null;
-                }
+                // End track string variables
 
                 // Collect use statements so we can get fully qualified class names
                 // Note that T_USE will match both use statements and anonymous functions with the "use" keyword

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -924,9 +924,14 @@ class i18nTextCollector
         return $entities;
     }
 
+    /**
+     * Fixed quoting escapes, and remove leading/trailing quotes
+     * @throws LogicException if there is no single or double quotes
+     * @param string $text
+     * @return string
+     */
     private function processString(string $text): string
     {
-        // Fixed quoting escapes, and remove leading/trailing quotes
         if (preg_match('/^\'(?<text>.*)\'$/s', $text ?? '', $matches)) {
             $text = preg_replace_callback(
                 '/\\\\([\\\\\'])/s', // only \ and '

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -786,12 +786,8 @@ class i18nTextCollector
 
                     // It's translated, continue
                     if ($stringValue) {
-                        $stringValue = $this->processString($stringValue);
-                        // Deal with ''
-                        if ($stringValue) {
-                            $currentEntity[] = $stringValue;
-                            continue;
-                        }
+                        $currentEntity[] = $stringValue;
+                        continue;
                     }
                 }
 

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -775,7 +775,7 @@ class i18nTextCollector
 
                 // Allow _t(Entity.Key, 'translation', $var) and expand _t(Entity.Key, $var)
                 if ($id == T_VARIABLE && !empty($currentEntity)) {
-                    // We have a translation, eg: _t(Entity.Key, 'translation', $var)
+                    // We have a default text, eg: _t(Entity.Key, 'translation', $var)
                     if (count($currentEntity) == 2) {
                         continue;
                     }

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -618,8 +618,8 @@ class i18nTextCollector
         $potentialClassName = null;
         $currentUse = null;
         $currentUseAlias = null;
+
         $inVar = null;
-        $resetVar = false;
         $stringVariables = [];
         foreach ($tokens as $token) {
             // Shuffle last token to $lastToken
@@ -631,23 +631,13 @@ class i18nTextCollector
                 // minus 2 is used so the the line we get corresponds with what number token_get_all() returned
                 $line = $lines[$lineNo - 2] ?? '';
 
-                // Track string variables, store all $myString = 'my value'; into a temporary array
-                // This allows _t('Entity.Key', $str); syntax
-                // Does not support "my $var value", use "my {var} value" instead with proper context
+                // Track string variables
                 if ($id === T_VARIABLE) {
                     $inVar = $text;
-
-                    // Reset variable if redefined later in scope
-                    if (!empty($stringVariables[$inVar])) {
-                        $resetVar = true;
-                    }
                 }
                 if ($id === T_CONSTANT_ENCAPSED_STRING && $inVar && $text) {
-                    if (!isset($stringVariables[$inVar]) || $resetVar) {
-                        $stringVariables[$inVar] = '';
-                        $resetVar = false;
-                    }
-                    $stringVariables[$inVar] .= $this->processString($text);
+                    $stringVariables[$inVar] = $text;
+                    $inVar = null;
                 }
                 if ($text === ';') {
                     $inVar = null;
@@ -772,14 +762,17 @@ class i18nTextCollector
 
                     // It's translated, continue
                     if ($stringValue) {
-                        $currentEntity[] = $stringValue;
-                        continue;
+                        $stringValue = $this->processString($stringValue);
+                        // Deal with ''
+                        if ($stringValue) {
+                            $currentEntity[] = $stringValue;
+                            continue;
+                        }
                     }
                 }
 
                 // If inside this translation, some elements might be unreachable
-                if (
-                    in_array($id, [T_VARIABLE, T_STATIC]) ||
+                if (in_array($id, [T_VARIABLE, T_STATIC]) ||
                     ($id === T_STRING && in_array($text, ['static', 'parent']))
                 ) {
                     // Un-collectable strings such as _t(static::class.'.KEY').
@@ -1115,8 +1108,7 @@ class i18nTextCollector
 
             // Check if this extension is included
             $extension = pathinfo($path ?? '', PATHINFO_EXTENSION);
-            if (
-                in_array($extension, $this->fileExtensions ?? [])
+            if (in_array($extension, $this->fileExtensions ?? [])
                 && (!$type || $type === $extension)
             ) {
                 $fileList[$path] = $path;

--- a/tests/php/i18n/i18nTextCollectorTest.php
+++ b/tests/php/i18n/i18nTextCollectorTest.php
@@ -974,4 +974,50 @@ PHP;
         $this->assertArrayHasKey("{$otherRoot}/code/i18nTestModuleDecorator.php", $otherFiles);
         $this->assertArrayHasKey("{$otherRoot}/templates/i18nOtherModule.ss", $otherFiles);
     }
+
+    public function testItCanCollectVariables()
+    {
+        $c = i18nTextCollector::create();
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
+
+        $php = <<<'PHP'
+        $concatdouble = "t" . "est" . "";
+        $concat = 't' . 'e' . 's'
+            . 't' ;
+        $str = 'wrong';
+        $str = 'test';
+        _t('TestEntity.CONCATDBLKEY', $concatdouble);
+        _t('TestEntity.CONCATKEY', $concat);
+        _t('TestEntity.VARKEY', $str);
+        _t('TestEntity.REGULARKEY', 'test');
+PHP;
+
+        $collectedTranslatables = $c->collectFromCode($php, null, $mymodule);
+        $this->assertEquals([
+            'TestEntity.CONCATDBLKEY' => "test",
+            'TestEntity.CONCATKEY' => "test",
+            'TestEntity.VARKEY' => "test",
+            'TestEntity.REGULARKEY' => "test",
+        ], $collectedTranslatables);
+    }
+
+    public function testItCanUseVariableAsContext()
+    {
+        $c = i18nTextCollector::create();
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
+
+        $php = <<<'PHP'
+        $args = ['type' => 'var'];
+        _t('TestEntity.VARCONTEXT', 'test {type}', $args);
+        _t('TestEntity.VARIADICCONTEXT', 'test {type}', ...$args);
+        _t('TestEntity.REGULARCONTEXT', 'test {type}', ['type' => 'var']);
+PHP;
+
+        $collectedTranslatables = $c->collectFromCode($php, null, $mymodule);
+        $this->assertEquals([
+            'TestEntity.VARCONTEXT' => "test {type}",
+            'TestEntity.VARIADICCONTEXT' => "test {type}",
+            'TestEntity.REGULARCONTEXT' => "test {type}",
+        ], $collectedTranslatables);
+    }
 }

--- a/tests/php/i18n/i18nTextCollectorTest.php
+++ b/tests/php/i18n/i18nTextCollectorTest.php
@@ -981,11 +981,16 @@ PHP;
         $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
 
         $php = <<<'PHP'
+        $zeroval = "0"; // it can collect "falsy" values
+        $concatagain = "t";;;; // lots of semicolons shouldn't cause any issue
+        $concatagain .= "est";
         $concatdouble = "t" . "est" . "";
         $concat = 't' . 'e' . 's'
-            . 't' ;
+            . 't' ; // we can use concatenation for readibility
         $str = 'wrong';
-        $str = 'test';
+        $str = 'test'; // value can be overwritten later
+        _t('TestEntity.ZEROVAL', $zeroval);
+        _t('TestEntity.CONCATAGAIN', $concatagain);
         _t('TestEntity.CONCATDBLKEY', $concatdouble);
         _t('TestEntity.CONCATKEY', $concat);
         _t('TestEntity.VARKEY', $str);
@@ -994,6 +999,8 @@ PHP;
 
         $collectedTranslatables = $c->collectFromCode($php, null, $mymodule);
         $this->assertEquals([
+            'TestEntity.ZEROVAL' => "0",
+            'TestEntity.CONCATAGAIN' => "test",
             'TestEntity.CONCATDBLKEY' => "test",
             'TestEntity.CONCATKEY' => "test",
             'TestEntity.VARKEY' => "test",


### PR DESCRIPTION
## Description

This PR upgrades the text collector to support collecting arguments as variables for second and third argument (see examples below).

## Manual testing steps

```php
        // Should display last $str and support concatenation
        $str = 'Should NOT appear';
        $str = 'Lazy loading can increase perceived page performance by slightly delaying media loading. ' .
            'Eager loading will load files as soon as possible and can be used if the image is in view as the page ' .
            'loads (above or near the fold).';
        $titleTipContent = _t('DemoAdmin.LoadingTitleTip', $str);

        // Does not support variables, use {type}. This will improperly detect "test" as value for the translation
        $type = "test";
        $IDontHaveAValidSyntax = _t(__CLASS__ . '.CANNOT_DELETE', "Not allowed to delete '$type' records");

        // Support variable as third argument
        $var = ['some' => 'var'];
        $IWasNotCollected = _t('DemoAdmin.ImNOTCollected', 'test {some}', $var);

        // Support default case
        $ImCollected = _t('DemoAdmin.ImCollected', 'test {some}', ['some' => 'var']);
```

## Issues
- https://github.com/silverstripe/silverstripe-framework/issues/11268
- https://github.com/silverstripe/silverstripe-asset-admin/issues/1532

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
