### PR TITLE
API Deprecate API which will be removed in CMS 6

### DIFF
--- a/src/Control/Director.php
+++ b/src/Control/Director.php
@@ -12,6 +12,7 @@ use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Kernel;
 use SilverStripe\Core\Path;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\Requirements;
 use SilverStripe\View\Requirements_Backend;
@@ -1037,9 +1038,11 @@ class Director implements TemplateGlobalProvider
      * @param HTTPRequest $request
      *
      * @return string|null null if not overridden, otherwise the actual value
+     * @deprecated 5.4.0 Use get_environment_type() instead.
      */
     public static function get_session_environment_type(HTTPRequest $request = null)
     {
+        Deprecation::notice('5.4.0', 'Use get_environment_type() instead.');
         $request = static::currentRequest($request);
 
         if (!$request) {

--- a/src/Control/HTTPApplication.php
+++ b/src/Control/HTTPApplication.php
@@ -12,6 +12,7 @@ use SilverStripe\Core\Startup\CallbackFlushDiscoverer;
 use SilverStripe\Core\Startup\RequestFlushDiscoverer;
 use SilverStripe\Core\Startup\ScheduledFlushDiscoverer;
 use SilverStripe\Core\Startup\DeployFlushDiscoverer;
+use SilverStripe\Dev\Deprecation;
 
 class HTTPApplication implements Application
 {
@@ -165,6 +166,8 @@ class HTTPApplication implements Application
      */
     private function warnAboutDeprecatedSetups()
     {
-        // noop
+        if (defined('CUSTOM_INCLUDE_PATH')) {
+            Deprecation::notice('5.4.0', 'Use of the "CUSTOM_INCLUDE_PATH" constant is deprecated.', Deprecation::SCOPE_GLOBAL);
+        }
     }
 }

--- a/src/Control/Middleware/URLSpecialsMiddleware/SessionEnvTypeSwitcher.php
+++ b/src/Control/Middleware/URLSpecialsMiddleware/SessionEnvTypeSwitcher.php
@@ -8,6 +8,7 @@ use SilverStripe\Control\HTTPRequest;
 
 /**
  * Implements switching user session into Test and Dev environment types
+ * @deprecated 5.4.0 Will be removed without equivalent functionality to replace it.
  */
 trait SessionEnvTypeSwitcher
 {

--- a/src/Core/Manifest/VersionProvider.php
+++ b/src/Core/Manifest/VersionProvider.php
@@ -239,9 +239,11 @@ class VersionProvider
 
     /**
      * @return string
+     * @deprecated 5.4.0 Will be removed without equivalent functionality to replace it.
      */
     protected function getComposerLockPath(): string
     {
+        Deprecation::noticeWithNoReplacment('5.4.0');
         return BASE_PATH . '/composer.lock';
     }
 }

--- a/src/i18n/Messages/Symfony/FlushInvalidatedResource.php
+++ b/src/i18n/Messages/Symfony/FlushInvalidatedResource.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\i18n\Messages\Symfony;
 
 use SilverStripe\Core\Flushable;
+use SilverStripe\Dev\Deprecation;
 use Symfony\Component\Config\Resource\SelfCheckingResourceInterface;
 
 /**
@@ -20,9 +21,12 @@ class FlushInvalidatedResource implements SelfCheckingResourceInterface, Flushab
         return md5(__CLASS__);
     }
 
+    /**
+     * @deprecated 5.4.0 Will be removed without equivalent functionality to replace it.
+     */
     public function getResource()
     {
-        // @deprecated at 3.0, do nothing
+        Deprecation::noticeWithNoReplacment('5.4.0');
         return null;
     }
 


### PR DESCRIPTION
All of this was either incorrectly deprecated already or should have already been removed in CMS 5.
See comments in https://github.com/silverstripe/silverstripe-framework/pull/11524

## Issues
- https://github.com/silverstripe/.github/issues/311