### PR TITLE
FIX Finish removing deprecated i18n functionality.

### DIFF
--- a/src/includes/functions.php
+++ b/src/includes/functions.php
@@ -60,6 +60,6 @@ function project()
  */
 function _t($entity, $arg = null)
 {
-    // Pass args directly to handle deprecation
+    // Pass args directly as we allow variable args.
     return call_user_func_array([i18n::class, '_t'], func_get_args());
 }


### PR DESCRIPTION
This functionality was deprecated in https://github.com/silverstripe/silverstripe-framework/pull/6558 and partially removed in #10594.

There's no chance anyone is still using the legacy `%s` in localisation strings today, as doing so would result in a hard error - so it's time to fully remove this legacy code.

## Issue
- https://github.com/silverstripe/.github/issues/311