### PR TITLE
ENH Align ArrayList case sensitivity with other lists

### DIFF
--- a/src/Model/List/ArrayList.php
+++ b/src/Model/List/ArrayList.php
@@ -5,7 +5,6 @@ namespace SilverStripe\Model\List;
 use InvalidArgumentException;
 use LogicException;
 use SilverStripe\Dev\Debug;
-use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\Filters\ExactMatchFilter;
 use SilverStripe\ORM\Filters\SearchFilterable;
 use SilverStripe\Model\ArrayData;
@@ -32,14 +31,6 @@ use Traversable;
 class ArrayList extends ModelData implements SS_List
 {
     use SearchFilterable;
-
-    /**
-     * Whether filter and exclude calls should be case sensitive by default or not.
-     * This configuration property is here for backwards compatability.
-     *
-     * @deprecated 5.1.0 use SearchFilter.default_case_sensitive instead
-     */
-    private static bool $default_case_sensitive = true;
 
     /**
      * Holds the items in the list
@@ -690,17 +681,6 @@ class ArrayList extends ModelData implements SS_List
                 $hasNullFilter = true;
             }
             $searchFilter = $this->createSearchFilter($filterKey, $filterValue);
-
-            // Apply default case sensitivity for backwards compatability
-            if (!str_contains($filterKey, ':case') && !str_contains($filterKey, ':nocase')) {
-                $caseSensitive = Deprecation::withSuppressedNotice(fn() => static::config()->get('default_case_sensitive'));
-                if ($caseSensitive && in_array('case', $searchFilter->getSupportedModifiers())) {
-                    $searchFilter->setModifiers($searchFilter->getModifiers() + ['case']);
-                } elseif (!$caseSensitive && in_array('nocase', $searchFilter->getSupportedModifiers())) {
-                    $searchFilter->setModifiers($searchFilter->getModifiers() + ['nocase']);
-                }
-            }
-
             $searchFilters[$filterKey] = $searchFilter;
         }
 

--- a/tests/php/Model/List/ArrayListTest.php
+++ b/tests/php/Model/List/ArrayListTest.php
@@ -349,20 +349,20 @@ class ArrayListTest extends SapphireTest
         return [
             // test a couple of search filters
             // don't need to be as explicit as the filter tests, just check the syntax works
-            'exact match not case sensitive' => [
-                'args' => ['NoCase:nocase', 'case sensitive'],
+            'exact match case insensitive' => [
+                'args' => ['NoCase', 'case sensitive'],
                 'objects' => $objects,
                 'expected' => $objects[0],
             ],
             'startswith match' => [
                 'args' => ['StartsWithTest:StartsWith', 'test'],
                 'objects' => $objects,
-                'expected' => $objects[3],
-            ],
-            'startswith match no case' => [
-                'args' => ['StartsWithTest:StartsWith:nocase', 'test'],
-                'objects' => $objects,
                 'expected' => $objects[0],
+            ],
+            'startswith match case' => [
+                'args' => ['StartsWithTest:StartsWith:case', 'test'],
+                'objects' => $objects,
+                'expected' => $objects[3],
             ],
             'startswith match negated' => [
                 'args' => ['StartsWithTest:StartsWith:not', 'Test'],
@@ -1187,20 +1187,20 @@ class ArrayListTest extends SapphireTest
                 'expected' => [$objects[3], $objects[4]],
             ],
             // case sensitivity checks
-            'exact match case sensitive' => [
+            'exact match case insensitive' => [
                 'args' => [['NoCase' => 'case sensitive']],
                 'objects' => $objects,
-                'expected' => [$objects[1]],
-            ],
-            'exact match case insensitive' => [
-                'args' => ['NoCase:nocase', 'case sensitive'],
-                'objects' => $objects,
                 'expected' => [$objects[0], $objects[1]],
+            ],
+            'exact match case sensitive' => [
+                'args' => ['NoCase:case', 'case sensitive'],
+                'objects' => $objects,
+                'expected' => [$objects[1]],
             ],
             'exact match mixed case filters' => [
                 'args' => [[
                     'NoCase:nocase' => 'case sensitive',
-                    'CaseSensitive' => 'case sensitive',
+                    'CaseSensitive:case' => 'case sensitive',
                 ]],
                 'objects' => $objects,
                 'expected' => [$objects[1]],
@@ -1218,14 +1218,14 @@ class ArrayListTest extends SapphireTest
             ],
             // partialmatch filter
             'partial match' => [
-                'args' => ['StartsWithTest:PartialMatch', 'start'],
-                'objects' => $objects,
-                'expected' => [$objects[2]],
-            ],
-            'partial match with modifier' => [
-                'args' => [['StartsWithTest:PartialMatch:nocase' => 'start']],
+                'args' => [['StartsWithTest:PartialMatch' => 'start']],
                 'objects' => $objects,
                 'expected' => [$objects[1], $objects[2]],
+            ],
+            'partial match with modifier' => [
+                'args' => ['StartsWithTest:PartialMatch:case', 'start'],
+                'objects' => $objects,
+                'expected' => [$objects[2]],
             ],
             // greaterthan filter
             'greaterthan match' => [
@@ -1324,12 +1324,12 @@ class ArrayListTest extends SapphireTest
             'partial match' => [
                 'args' => ['StartsWithTest:PartialMatch', 'start'],
                 'objects' => $objects,
-                'expected' => [$objects[2]],
+                'expected' => [$objects[1], $objects[2]],
             ],
             'partial match with modifier' => [
-                'args' => ['StartsWithTest:PartialMatch:nocase', 'start'],
+                'args' => ['StartsWithTest:PartialMatch:case', 'start'],
                 'objects' => $objects,
-                'expected' => [$objects[1], $objects[2]],
+                'expected' => [$objects[2]],
             ],
             'greaterthan match' => [
                 'args' => ['GreaterThan100:GreaterThan', 100],


### PR DESCRIPTION
`SearchFilter` defaults to getting its case sensitivity from the database collation settings - this is true even when the list being used is `ArrayList`. `ArrayList` used to then _override_ that default with its own default, but that was only to preserve BC.

This change now aligns the default case sensitivity of `ArrayList` with other lists that use `SearchFilter` for their filtering functionality which provides a more consistent and predictable behaviour - calling `filter()` on a list which uses `SearchFilter` will now always have the same case sensitivity if no modifier is explicitly used.

## Issue
- https://github.com/silverstripe/.github/issues/311