### PR TITLE
FIX Class manifest is not caching enums

### DIFF
--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -597,7 +597,7 @@ class ClassManifest
             $classes = $data['classes'];
             $interfaces = $data['interfaces'];
             $traits = $data['traits'];
-            $enums = $data['enums'];
+            $enums = $data['enums'] ?? [];
         } else {
             $changed = true;
             // Build from php file parser
@@ -774,7 +774,7 @@ class ClassManifest
         if (!$data || !is_array($data)) {
             return false;
         }
-        foreach (['classes', 'interfaces', 'traits', 'enums'] as $key) {
+        foreach (['classes', 'interfaces', 'traits'] as $key) {
             // Must be set
             if (!isset($data[$key])) {
                 return false;

--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -597,7 +597,7 @@ class ClassManifest
             $classes = $data['classes'];
             $interfaces = $data['interfaces'];
             $traits = $data['traits'];
-            $enums = $data['enums'] ?? [];
+            $enums = $data['enums'];
         } else {
             $changed = true;
             // Build from php file parser
@@ -696,6 +696,7 @@ class ClassManifest
                 'classes' => $classes,
                 'interfaces' => $interfaces,
                 'traits' => $traits,
+                'enums' => $enums,
             ];
             $this->cache->set($key, $cache);
         }
@@ -774,7 +775,7 @@ class ClassManifest
         if (!$data || !is_array($data)) {
             return false;
         }
-        foreach (['classes', 'interfaces', 'traits'] as $key) {
+        foreach (['classes', 'interfaces', 'traits', 'enums'] as $key) {
             // Must be set
             if (!isset($data[$key])) {
                 return false;


### PR DESCRIPTION
## Description
Fix https://github.com/silverstripe/silverstripe-framework/issues/11531

Enums were not being added to cache, but validated and required

## Manual testing steps

See related issue

Basically, this will ensure that validateItemCache will actually return true
Currently it will always return false unless i've missed something somewhere...

## Issues
Fixes https://github.com/silverstripe/silverstripe-framework/issues/11531

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
