### PR TITLE
FEAT Less cache fragmentation in ClassManifest

### DIFF
--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -55,14 +55,11 @@ class ClassManifest
 
     /**
      * In memory cache array for individually parsed files
-     * @var array|null
      */
     protected ?array $filesCache = null;
 
     /**
      * Key to use for files cache
-     *
-     * @var string
      */
     protected string $filesCacheKey;
 

--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -610,7 +610,7 @@ class ClassManifest
         // Note: $classes, $interfaces and $traits arrays have correct-case keys, not lowercase
         $changed = false;
         if ($this->cache
-            && ($data = $this->cache->get($key))
+            && ($data = $this->filesCache[$key] ?? null)
             && $this->validateItemCache($data)
         ) {
             $classes = $data['classes'];

--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -610,7 +610,7 @@ class ClassManifest
         // Note: $classes, $interfaces and $traits arrays have correct-case keys, not lowercase
         $changed = false;
         if ($this->cache
-            && ($data = $this->filesCache[$key] ?? null)
+            && ($data = ($this->filesCache[$key] ?? null))
             && $this->validateItemCache($data)
         ) {
             $classes = $data['classes'];

--- a/src/Core/Manifest/ClassManifest.php
+++ b/src/Core/Manifest/ClassManifest.php
@@ -54,6 +54,19 @@ class ClassManifest
     protected $cacheKey;
 
     /**
+     * In memory cache array for individually parsed files
+     * @var array|null
+     */
+    protected ?array $filesCache = null;
+
+    /**
+     * Key to use for files cache
+     *
+     * @var string
+     */
+    protected string $filesCacheKey;
+
+    /**
      * Array of properties to cache
      *
      * @var array
@@ -203,6 +216,7 @@ class ClassManifest
         $this->base = $base;
         $this->cacheFactory = $cacheFactory;
         $this->cacheKey = 'manifest';
+        $this->filesCacheKey = 'manifestFiles';
     }
 
     private function buildCache($includeTests = false)
@@ -563,6 +577,7 @@ class ClassManifest
 
         if ($this->cache) {
             $data = $this->getState();
+            $this->cache->set($this->filesCacheKey, $this->filesCache);
             $this->cache->set($this->cacheKey, $data);
             $this->cache->set('generated_at', time());
             $this->cache->delete('regenerate');
@@ -586,6 +601,10 @@ class ClassManifest
         // slow. A combination of the file name and file contents hash are used,
         // since just using the datetime lead to problems with upgrading.
         $key = preg_replace('/[^a-zA-Z0-9_]/', '_', $basename ?? '') . '_' . md5_file($pathname ?? '');
+
+        if ($this->cache && $this->filesCache === null) {
+            $this->filesCache = $this->cache->get($this->filesCacheKey);
+        }
 
         // Attempt to load from cache
         // Note: $classes, $interfaces and $traits arrays have correct-case keys, not lowercase
@@ -696,8 +715,10 @@ class ClassManifest
                 'classes' => $classes,
                 'interfaces' => $interfaces,
                 'traits' => $traits,
+                'enums' => $enums,
             ];
-            $this->cache->set($key, $cache);
+
+            $this->filesCache[$key] = $cache;
         }
     }
 


### PR DESCRIPTION
## Description
Reduce cache fragmentation by having only one entry for all cached files

## Manual testing steps

Check number of files being created

BEFORE: 2k files
![image](https://github.com/user-attachments/assets/928961ef-90bf-4292-bb05-ca7a4688a63a)

AFTER: 3 files
![image](https://github.com/user-attachments/assets/8a4f7699-a860-431c-81ed-62798288d21b)

## Issues

https://github.com/silverstripe/silverstripe-framework/issues/11525

## Questions

Should this target 6 ? for me, while this is technically a new "feature" it has only upsides and also "fixes" a performance issue

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
