### PR TITLE
API Add strong-typing to SearchContext::getQuery() $limit param

### DIFF
--- a/src/ORM/Search/BasicSearchContext.php
+++ b/src/ORM/Search/BasicSearchContext.php
@@ -33,26 +33,14 @@ class BasicSearchContext extends SearchContext
      *  If a filter is applied to a relationship in dot notation,
      *  the parameter name should have the dots replaced with double underscores,
      *  for example "Comments__Name" instead of the filter name "Comments.Name".
-     * @param array|bool|string $sort Field to sort on.
+     * @param array|false|string $sort Field to sort on.
      * @param int|array|null $limit
      * @param SS_List $existingQuery
      */
-    public function getQuery($searchParams, $sort = false, $limit = false, $existingQuery = null): SS_List
+    public function getQuery($searchParams, $sort = false, int|array|null $limit = null, $existingQuery = null): SS_List
     {
         if (!$existingQuery || !is_a($existingQuery, SS_List::class)) {
             throw new InvalidArgumentException('getQuery requires a pre-existing SS_List list to be passed as $existingQuery.');
-        }
-
-        if ((count(func_get_args()) >= 3) && (!in_array(gettype($limit), ['array', 'NULL', 'integer']))) {
-            Deprecation::notice(
-                '5.1.0',
-                '$limit should be type of int|array|null'
-            );
-            if (is_string($limit) && is_numeric($limit)) {
-                $limit = (int) $limit;
-            } else {
-                $limit = null;
-            }
         }
 
         $searchParams = $this->applySearchFilters($this->normaliseSearchParams($searchParams));

--- a/src/ORM/Search/SearchContext.php
+++ b/src/ORM/Search/SearchContext.php
@@ -142,22 +142,15 @@ class SearchContext
      *  If a filter is applied to a relationship in dot notation,
      *  the parameter name should have the dots replaced with double underscores,
      *  for example "Comments__Name" instead of the filter name "Comments.Name".
-     * @param array|bool|string $sort Database column to sort on.
+     * @param array|false|string $sort Database column to sort on.
      *  Falls back to {@link DataObject::$default_sort} if not provided.
      * @param int|array|null $limit
      * @param DataList $existingQuery
      * @return DataList<T>
      * @throws Exception
      */
-    public function getQuery($searchParams, $sort = false, $limit = false, $existingQuery = null)
+    public function getQuery($searchParams, $sort = false, int|array|null $limit = null, $existingQuery = null)
     {
-        if ((count(func_get_args()) >= 3) && (!in_array(gettype($limit), ['integer', 'array', 'NULL']))) {
-            Deprecation::notice(
-                '5.1.0',
-                '$limit should be type of int|array|null'
-            );
-            $limit = null;
-        }
         $this->setSearchParams($searchParams);
         $query = $this->prepareQuery($sort, $limit, $existingQuery);
         return $this->search($query);
@@ -197,9 +190,6 @@ class SearchContext
         }
         $query = null;
         if ($existingQuery) {
-            if (!($existingQuery instanceof DataList)) {
-                throw new InvalidArgumentException("existingQuery must be DataList");
-            }
             if ($existingQuery->dataClass() != $this->modelClass) {
                 throw new InvalidArgumentException("existingQuery's dataClass is " . $existingQuery->dataClass()
                     . ", $this->modelClass expected.");

--- a/tests/php/ORM/Search/BasicSearchContextTest.php
+++ b/tests/php/ORM/Search/BasicSearchContextTest.php
@@ -266,26 +266,6 @@ class BasicSearchContextTest extends SapphireTest
                     'Sara',
                 ],
             ],
-            'limit numeric string' => [
-                'limit' => '4',
-                'expected' => [
-                    'James',
-                    'John',
-                    'Jane',
-                    'Hemi',
-                ],
-            ],
-            'limit invalid string' => [
-                'limit' => 'blah',
-                'expected' => [
-                    'James',
-                    'John',
-                    'Jane',
-                    'Hemi',
-                    'Sara',
-                    'MatchNothing',
-                ],
-            ],
         ];
     }
 


### PR DESCRIPTION
Seems the two search context implementations had different ideas about what was correct for the limit parameter, and the basic one wasn't even handling the values correctly.

## Issue
- https://github.com/silverstripe/.github/issues/311