### PR TITLE
DOC Remove "deprecated" note from PHPDoc for not-deprecated method

### DIFF
--- a/src/ORM/Connect/TransactionManager.php
+++ b/src/ORM/Connect/TransactionManager.php
@@ -16,8 +16,8 @@ interface TransactionManager
     /**
      * Start a prepared transaction
      *
-     * @param string|boolean $transactionMode Transaction mode, or false to ignore. Deprecated and will be removed in SS5.
-     * @param string|boolean $sessionCharacteristics Session characteristics, or false to ignore. Deprecated and will be removed in SS5.
+     * @param string|boolean $transactionMode Transaction mode, or false to ignore.
+     * @param string|boolean $sessionCharacteristics Session characteristics, or false to ignore.
      * @throws DatabaseException on failure
      * @return bool True on success
      */


### PR DESCRIPTION
This was added in https://github.com/silverstripe/silverstripe-framework/pull/8448 already deprecated. It's not super clear what the intention was with how to deal with removing this, and in https://github.com/silverstripe/silverstripe-framework/pull/10565 the actual deprecation notice from the method in `MySQLTransactionManager` was removed without any indication of why, but presumably due to that same lack of clarity.

Easiest conclusion is to just remove this part of the PHPDoc.

## Issue
- https://github.com/silverstripe/.github/issues/311