### PR TITLE
API Remove deprecation notice from method we're not removing

### DIFF
--- a/src/Forms/SearchableDropdownField.php
+++ b/src/Forms/SearchableDropdownField.php
@@ -26,16 +26,4 @@ class SearchableDropdownField extends DropdownField implements HasOneRelationFie
         $this->addExtraClass('ss-searchable-dropdown-field');
         $this->setHasEmptyDefault(true);
     }
-
-    /**
-     * @param string $string
-     * @return $this
-     *
-     * @deprecated 5.2.0 Use setPlaceholder() instead
-     */
-    public function setEmptyString($string)
-    {
-        Deprecation::notice('5.2.0', 'Use setPlaceholder() instead');
-        return parent::setEmptyString($string);
-    }
 }

--- a/src/Forms/SearchableDropdownTrait.php
+++ b/src/Forms/SearchableDropdownTrait.php
@@ -159,8 +159,7 @@ trait SearchableDropdownTrait
      * Calling this will also call setHasEmptyDefault(true), if the method exists on the class,
      * which is required for the placeholder functionality to work on SearchableDropdownField
      *
-     * In the case of SearchableDropField this method should be used instead of setEmptyString() which
-     * will be remvoved in a future version
+     * In the case of SearchableDropField this method should be used instead of setEmptyString()
      */
     public function setPlaceholder(string $placeholder): static
     {


### PR DESCRIPTION
We can't remove this method, because it will still be inherited from SingleSelectField.

If the empty string has been set, it is used by `getPlaceholder()` - so I think just keeping the method with no deprecation is ultimately fine. We prefer people to use `setPlaceholder()` but if they use `setEmptyString()` instead it'll be handled appropriately.

## Issue
- https://github.com/silverstripe/.github/issues/311