### PR TITLE
A few deprecation fixes

### DIFF
--- a/src/Dev/Deprecation.php
+++ b/src/Dev/Deprecation.php
@@ -157,6 +157,9 @@ class Deprecation
      */
     protected static function get_called_method_from_trace($backtrace, $level = 1)
     {
+        if ($backtrace === null) {
+            return '';
+        }
         $level = (int)$level;
         if (!$level) {
             $level = 1;
@@ -197,8 +200,11 @@ class Deprecation
         return $called;
     }
 
-    private static function isCalledFromSupportedCode(array $backtrace): bool
+    private static function isCalledFromSupportedCode(?array $backtrace): bool
     {
+        if ($backtrace === null) {
+            return false;
+        }
         $called = Deprecation::get_called_from_trace($backtrace, 1);
         $file = $called['file'] ?? '';
         if (!$file) {

--- a/src/View/SSTemplateParser.peg
+++ b/src/View/SSTemplateParser.peg
@@ -896,7 +896,9 @@ class SSTemplateParser extends Parser implements TemplateParser
     */
     function OldI18NTag_STR(&$res, $sub)
     {
-        $res['php'] = '$val .= ' . $sub['php'] . ';';
+        $res['php'] = '$val .= ' . $sub['php'] . ';' . Deprecation::class
+            . '::notice(\'5.4.0\', \'The <% _t() %> template syntax is deprecated. Use <%t %> instead.\', '
+            . Deprecation::class . '::SCOPE_GLOBAL);';
     }
 
     /*!*

--- a/src/View/SSTemplateParser.peg
+++ b/src/View/SSTemplateParser.peg
@@ -1155,7 +1155,9 @@ class SSTemplateParser extends Parser implements TemplateParser
         if ($res['ArgumentCount'] != 0) {
             throw new SSTemplateParseException('Base_tag takes no arguments', $this);
         }
-        return '$val .= \\SilverStripe\\View\\SSViewer::get_base_tag($val);';
+        $code = '$isXhtml = preg_match(\'/<!DOCTYPE[^>]+xhtml/i\', $val);';
+        $code .= PHP_EOL . '$val .= \\SilverStripe\\View\\SSViewer::getBaseTag($isXhtml);';
+        return $code;
     }
 
     /**

--- a/src/View/SSTemplateParser.php
+++ b/src/View/SSTemplateParser.php
@@ -4440,7 +4440,9 @@ class SSTemplateParser extends Parser implements TemplateParser
         if ($res['ArgumentCount'] != 0) {
             throw new SSTemplateParseException('Base_tag takes no arguments', $this);
         }
-        return '$val .= \\SilverStripe\\View\\SSViewer::get_base_tag($val);';
+        $code = '$isXhtml = preg_match(\'/<!DOCTYPE[^>]+xhtml/i\', $val);';
+        $code .= PHP_EOL . '$val .= \\SilverStripe\\View\\SSViewer::getBaseTag($isXhtml);';
+        return $code;
     }
 
     /**

--- a/src/View/SSTemplateParser.php
+++ b/src/View/SSTemplateParser.php
@@ -3748,7 +3748,9 @@ class SSTemplateParser extends Parser implements TemplateParser
 
     function OldI18NTag_STR(&$res, $sub)
     {
-        $res['php'] = '$val .= ' . $sub['php'] . ';';
+        $res['php'] = '$val .= ' . $sub['php'] . ';' . Deprecation::class
+            . '::notice(\'5.4.0\', \'The <% _t() %> template syntax is deprecated. Use <%t %> instead.\', '
+            . Deprecation::class . '::SCOPE_GLOBAL);';
     }
 
     /* NamedArgument: Name:Word "=" Value:Argument */


### PR DESCRIPTION
There's three distinct commits here. **DO NOT SQUASH**

1. Fixes error with deprecation notice - if there's no backtrace, it was throwing an error. This is the case with the new deprecation notice I've added in commit 2.
2. Add deprecation notice if the old i18n template syntax is used. No changelog entry required, it was already deprecated just had no notice.
3. Stop calling a deprecated static method from templates. This is the same code used in CMS 6 and avoids an unnecessary deprecation warning that would otherwise happen on every template render on the frontend.

## Issue
- https://github.com/silverstripe/.github/issues/311