### PR TITLE
FIX Throw DatabaseException, not mysqli_sql_exception

### DIFF
--- a/src/ORM/Connect/MySQLiConnector.php
+++ b/src/ORM/Connect/MySQLiConnector.php
@@ -306,7 +306,12 @@ class MySQLiConnector extends DBConnector
             }
 
             // Safely execute the statement
-            $statement->execute();
+            try {
+                $statement->execute();
+            } catch (mysqli_sql_exception $e) {
+                $success = false;
+                $this->databaseError($e->getMessage(), E_USER_ERROR, $sql, $parameters);
+            }
         }
 
         if (!$success || $statement->error) {


### PR DESCRIPTION
If a unique index is used and that uniqueness is violated, a `mysqli_sql_exception` is thrown and never caught.
Other `mysqli_sql_exception`s that get thrown are caught and converted into `DatabaseException`.

See https://github.com/silverstripe/silverstripe-framework/pull/10570 

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10674