### PR TITLE
FIX Escape user input from an HTML context.

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -567,13 +567,13 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
         $this->saveFormIntoRecord($data, $form);
 
         $link = '<a href="' . $this->Link('edit') . '">"'
-            . htmlspecialchars($this->record->Title ?? '', ENT_QUOTES)
+            . Convert::raw2xml($this->record->Title ?? '', ENT_QUOTES)
             . '"</a>';
         $message = _t(
             'SilverStripe\\Forms\\GridField\\GridFieldDetailForm.Saved',
             'Saved {name} {link}',
             [
-                'name' => $this->getModelName(),
+                'name' => Convert::raw2xml($this->getModelName()),
                 'link' => $link
             ]
         );
@@ -834,8 +834,8 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
             'SilverStripe\\Forms\\GridField\\GridFieldDetailForm.Deleted',
             'Deleted {type} "{name}"',
             [
-                'type' => $this->getModelName(),
-                'name' => $this->record->Title
+                'type' => Convert::raw2xml($this->getModelName()),
+                'name' => Convert::raw2xml($this->record->Title)
             ]
         );
 


### PR DESCRIPTION
There is no XSS vulnerability here due to other measures to mitigate one - but user input which includes HTML characters still might not render correctly without this fix.

## Issue
- https://github.com/silverstripeltd/product-issues/issues/890 (private issue)