### PR TITLE
NEW Provide clear UX validation errors when violating unique index

### DIFF
--- a/src/ORM/Connect/DBConnector.php
+++ b/src/ORM/Connect/DBConnector.php
@@ -52,7 +52,7 @@ abstract class DBConnector
 
         // Format query if given
         if (!empty($sql)) {
-            $formatter = new SQLFormatter();
+            $formatter = SQLFormatter::create();
             $formattedSQL = $formatter->formatPlain($sql);
             $msg = "Couldn't run query:\n\n{$formattedSQL}\n\n{$msg}";
         }
@@ -64,6 +64,23 @@ abstract class DBConnector
         } else {
             user_error($msg ?? '', $errorLevel ?? 0);
         }
+    }
+
+    protected function duplicateEntryError(
+        string $msg,
+        ?string $keyName,
+        ?string $duplicatedValue,
+        ?string $sql = null,
+        array $parameters = []
+    ): void {
+        // Format query if given
+        if (!empty($sql)) {
+            $formatter = SQLFormatter::create();
+            $formattedSQL = $formatter->formatPlain($sql);
+            $msg = "Couldn't run query:\n\n{$formattedSQL}\n\n{$msg}";
+        }
+
+        throw new DuplicateEntryException($msg, $keyName, $duplicatedValue, $sql, $parameters);
     }
 
     /**

--- a/src/ORM/Connect/DuplicateEntryException.php
+++ b/src/ORM/Connect/DuplicateEntryException.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SilverStripe\ORM\Connect;
+
+/**
+ * Exception for errors related to duplicate entries (e.g. violating a unique index)
+ */
+class DuplicateEntryException extends DatabaseException
+{
+    private ?string $keyName = null;
+
+    private ?string $duplicatedValue = null;
+
+    /**
+     * Constructs the database exception
+     *
+     * @param string $message The Exception message to throw.
+     * @param string|null $keyName The name of the key which the error is for (e.g. index name)
+     * @param string|null $duplicatedValue The value which was duplicated (e.g. combined value of multiple columns in index)
+     * @param string|null $sql The SQL executed for this query
+     * @param array $parameters The parameters given for this query, if any
+     */
+    public function __construct(
+        string $message = '',
+        ?string $keyName = null,
+        ?string $duplicatedValue = null,
+        ?string $sql = null,
+        array $parameters = []
+    ) {
+        parent::__construct($message, sql: $sql, parameters: $parameters);
+        $this->keyName = $keyName;
+        $this->duplicatedValue = $duplicatedValue;
+    }
+
+    /**
+     * Get the name of the key which the error is for (e.g. index name)
+     */
+    public function getKeyName(): ?string
+    {
+        return $this->keyName;
+    }
+
+    /**
+     * Get the value which was duplicated (e.g. combined value of multiple columns in index)
+     */
+    public function getDuplicatedValue(): ?string
+    {
+        return $this->duplicatedValue;
+    }
+}

--- a/tests/php/ORM/DataObjectTest/UniqueIndexObject.php
+++ b/tests/php/ORM/DataObjectTest/UniqueIndexObject.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataObjectTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class UniqueIndexObject extends DataObject implements TestOnly
+{
+    private static string $table_name = 'DataObjectTest_UniqueIndexObject';
+
+    private static array $db = [
+        'SingleField' => 'Varchar',
+        'Name' => 'Varchar',
+        'Code' => 'Varchar',
+    ];
+
+    private static array $indexes = [
+        'SingleFieldIndex' => [
+            'type' => 'unique',
+            'columns' => [
+                'SingleField',
+            ],
+        ],
+        'MultiFieldIndex' => [
+            'type' => 'unique',
+            'columns' => [
+                'Name',
+                'Code',
+            ],
+        ],
+    ];
+}


### PR DESCRIPTION
Tested locally with both MySQL and MariaDB

For an index with only a single column, it will show an error message next to the form field for that column:
![image](https://github.com/user-attachments/assets/67c64996-6798-47de-8577-c538dc01a940)

For an index with multiple columns, it will show a single error message at the top of the edit form:
![image](https://github.com/user-attachments/assets/c744d27f-65e1-425f-b8c1-4b2fa6374053)


## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10674