### PR TITLE
MNT Remove unit test for removed method

### DIFF
--- a/tests/php/Security/RememberLoginHashTest.php
+++ b/tests/php/Security/RememberLoginHashTest.php
@@ -96,41 +96,4 @@ class RememberLoginHashTest extends SapphireTest
         RememberLoginHash::setLogoutAcrossDevices(false);
         $this->assertFalse(RememberLoginHash::getLogoutAcrossDevices());
     }
-
-    /**
-     * @param bool $replaceToken
-     */
-    #[DataProvider('provideRenew')]
-    public function testRenew($replaceToken)
-    {
-        // If session-manager module is installed it expects an active request during renewal
-        if (class_exists(LoginSession::class)) {
-            $this->markTestSkipped();
-        }
-
-        $member = $this->objFromFixture(Member::class, 'main');
-
-        $hash = RememberLoginHash::generate($member);
-        $oldToken = $hash->getToken();
-        $oldHash = $hash->Hash;
-
-        // Fetch the token from the DB - otherwise we still have the token from when this was originally created
-        $storedHash = RememberLoginHash::get()->find('ID', $hash->ID);
-
-        if ($replaceToken) {
-            $this->assertNotEquals($oldToken, $storedHash->getToken());
-            $this->assertNotEquals($oldHash, $storedHash->Hash);
-        } else {
-            $this->assertEmpty($storedHash->getToken());
-            $this->assertEquals($oldHash, $storedHash->Hash);
-        }
-    }
-
-    public static function provideRenew(): array
-    {
-        return [
-            [true],
-            [false],
-        ];
-    }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/357

The `renew()` method was removed in https://github.com/silverstripe/silverstripe-framework/commit/4e6b45469ece5dc8b2d420f141b7e613f1e05b69

This removes the corresponding unit test. This unit test will only run in silverstripe/recipe-core where the silverstripe/session-manager module (LoginSession class) is not installed e.g. https://github.com/silverstripe/recipe-core/actions/runs/12779274384/job/35623615435, hence why we took a long time to notice this