### PR TITLE
DEP Conflict older versions of egulias/email-validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "phpstan/extension-installer": "^1.3"
     },
     "conflict": {
-        "egulias/email-validator": "^2",
+        "egulias/email-validator": "<3.2.1",
         "oscarotero/html-parser": "<0.1.7"
     },
     "provide": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11441

[3.2.1](https://github.com/egulias/EmailValidator/releases/tag/3.2.1) release includes fix

Message is [still happening](https://github.com/silverstripe/recipe-core/actions/runs/12797103580/job/35678285953#step:12:97) in recent CI runs of recipe-core - so we still need this PR