### PR TITLE
API Deprecate passing null paramters for Form and ValidationResult methods

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -1183,6 +1183,14 @@ class Form extends ViewableData implements HasRequestHandler
      */
     public function sessionMessage($message, $type = ValidationResult::TYPE_ERROR, $cast = ValidationResult::CAST_TEXT)
     {
+        if ($cast === null) {
+            Deprecation::notice(
+                '5.4.0',
+                'Passing $cast as null is deprecated. Pass a ValidationResult::CAST_* constant instead.',
+                Deprecation::SCOPE_GLOBAL
+            );
+            $cast = ValidationResult::CAST_TEXT;
+        }
         $this->setMessage($message, $type, $cast);
         $result = $this->getSessionValidationResult() ?: ValidationResult::create();
         $result->addMessage($message, $type, null, $cast);
@@ -1199,6 +1207,14 @@ class Form extends ViewableData implements HasRequestHandler
      */
     public function sessionError($message, $type = ValidationResult::TYPE_ERROR, $cast = ValidationResult::CAST_TEXT)
     {
+        if ($cast === null) {
+            Deprecation::notice(
+                '5.4.0',
+                'Passing $cast as null is deprecated. Pass a ValidationResult::CAST_* constant instead.',
+                Deprecation::SCOPE_GLOBAL
+            );
+            $cast = ValidationResult::CAST_TEXT;
+        }
         $this->setMessage($message, $type, $cast);
         $result = $this->getSessionValidationResult() ?: ValidationResult::create();
         $result->addError($message, $type, null, $cast);
@@ -1216,6 +1232,14 @@ class Form extends ViewableData implements HasRequestHandler
      */
     public function sessionFieldError($message, $fieldName, $type = ValidationResult::TYPE_ERROR, $cast = ValidationResult::CAST_TEXT)
     {
+        if ($cast === null) {
+            Deprecation::notice(
+                '5.4.0',
+                'Passing $cast as null is deprecated. Pass a ValidationResult::CAST_* constant instead.',
+                Deprecation::SCOPE_GLOBAL
+            );
+            $cast = ValidationResult::CAST_TEXT;
+        }
         $this->setMessage($message, $type, $cast);
         $result = $this->getSessionValidationResult() ?: ValidationResult::create();
         $result->addFieldMessage($fieldName, $message, $type, null, $cast);

--- a/src/ORM/ValidationResult.php
+++ b/src/ORM/ValidationResult.php
@@ -85,7 +85,23 @@ class ValidationResult
      */
     public function addError($message, $messageType = ValidationResult::TYPE_ERROR, $code = null, $cast = ValidationResult::CAST_TEXT)
     {
-        return $this->addFieldError(null, $message, $messageType, $code, $cast);
+        if ($code === null) {
+            Deprecation::notice(
+                '5.4.0',
+                'Passing $code as null is deprecated. Pass a blank string instead.',
+                Deprecation::SCOPE_GLOBAL
+            );
+            $code = '';
+        }
+        if ($cast === null) {
+            Deprecation::notice(
+                '5.4.0',
+                'Passing $cast as null is deprecated. Pass a ValidationResult::CAST_* constant instead.',
+                Deprecation::SCOPE_GLOBAL
+            );
+            $cast = ValidationResult::CAST_TEXT;
+        }
+        return $this->addFieldError('', $message, $messageType, $code, $cast);
     }
 
     /**
@@ -108,6 +124,22 @@ class ValidationResult
         $code = null,
         $cast = ValidationResult::CAST_TEXT
     ) {
+        if ($code === null) {
+            Deprecation::notice(
+                '5.4.0',
+                'Passing $code as null is deprecated. Pass a blank string instead.',
+                Deprecation::SCOPE_GLOBAL
+            );
+            $code = '';
+        }
+        if ($cast === null) {
+            Deprecation::notice(
+                '5.4.0',
+                'Passing $cast as null is deprecated. Pass a ValidationResult::CAST_* constant instead.',
+                Deprecation::SCOPE_GLOBAL
+            );
+            $cast = ValidationResult::CAST_TEXT;
+        }
         $this->isValid = false;
         return $this->addFieldMessage($fieldName, $message, $messageType, $code, $cast);
     }
@@ -126,6 +158,22 @@ class ValidationResult
      */
     public function addMessage($message, $messageType = ValidationResult::TYPE_ERROR, $code = null, $cast = ValidationResult::CAST_TEXT)
     {
+        if ($code === null) {
+            Deprecation::notice(
+                '5.4.0',
+                'Passing $code as null is deprecated. Pass a blank string instead.',
+                Deprecation::SCOPE_GLOBAL
+            );
+            $code = '';
+        }
+        if ($cast === null) {
+            Deprecation::notice(
+                '5.4.0',
+                'Passing $cast as null is deprecated. Pass a ValidationResult::CAST_* constant instead.',
+                Deprecation::SCOPE_GLOBAL
+            );
+            $cast = ValidationResult::CAST_TEXT;
+        }
         return $this->addFieldMessage(null, $message, $messageType, $code, $cast);
     }
 
@@ -149,6 +197,22 @@ class ValidationResult
         $code = null,
         $cast = ValidationResult::CAST_TEXT
     ) {
+        if ($code === null) {
+            Deprecation::notice(
+                '5.4.0',
+                'Passing $code as null is deprecated. Pass a blank string instead.',
+                Deprecation::SCOPE_GLOBAL
+            );
+            $code = '';
+        }
+        if ($cast === null) {
+            Deprecation::notice(
+                '5.4.0',
+                'Passing $cast as null is deprecated. Pass a ValidationResult::CAST_* constant instead.',
+                Deprecation::SCOPE_GLOBAL
+            );
+            $cast = ValidationResult::CAST_TEXT;
+        }
         if ($code && is_numeric($code)) {
             throw new InvalidArgumentException("Don't use a numeric code '$code'.  Use a string.");
         }

--- a/tests/php/Core/Validation/ConstraintValidatorTest.php
+++ b/tests/php/Core/Validation/ConstraintValidatorTest.php
@@ -354,7 +354,7 @@ class ConstraintValidatorTest extends SapphireTest
 
         $this->assertCount($countViolations, $violations);
         foreach ($violations as $violation) {
-            $this->assertSame($fieldName ?: null, $violation['fieldName']);
+            $this->assertSame($fieldName ?: '', $violation['fieldName']);
         }
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11423