### PR TITLE
ENH Refactor password reset to support SameSite=Strict

### DIFF
--- a/src/Security/MemberAuthenticator/ChangePasswordForm.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordForm.php
@@ -79,4 +79,14 @@ class ChangePasswordForm extends Form
 
         return $actions;
     }
+
+    /**
+     * Adds a hidden field to the form with the given autologin hash, to support the "forgot password" workflow.
+     */
+    public function addAutoLoginHash(string $hash): ChangePasswordForm
+    {
+        $this->fields->push(HiddenField::create('AutoLoginHash', 'AutoLoginHash', $hash));
+
+        return $this;
+    }
 }

--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -75,14 +75,6 @@ class ChangePasswordHandler extends RequestHandler
 
         // Check whether we are merely changing password, or resetting.
         if ($token !== null && $member && $member->validateAutoLoginToken($token)) {
-            $this->setSessionToken($member, $token);
-
-            // Redirect to myself, but without the hash in the URL
-            return $this->redirect($this->link);
-        }
-
-        $session = $this->getRequest()->getSession();
-        if ($session->get('AutoLoginHash')) {
             $message = DBField::create_field(
                 'HTMLFragment',
                 '<p>' . _t(
@@ -91,10 +83,12 @@ class ChangePasswordHandler extends RequestHandler
                 ) . '</p>'
             );
 
-            // Subsequent request after the "first load with hash" (see previous if clause).
+            $form = $this->changePasswordForm();
+            $form->addAutoLoginHash($member->encryptWithUserSettings($token));
+
             return [
                 'Content' => $message,
-                'Form'    => $this->changePasswordForm()
+                'Form'    => $form,
             ];
         }
 
@@ -110,7 +104,7 @@ class ChangePasswordHandler extends RequestHandler
 
             return [
                 'Content' => $message,
-                'Form'    => $this->changePasswordForm()
+                'Form'    => $this->changePasswordForm(),
             ];
         }
         // Show a friendly message saying the login token has expired
@@ -142,23 +136,6 @@ class ChangePasswordHandler extends RequestHandler
                 'You must be logged in in order to change your password!'
             )
         );
-    }
-
-
-    /**
-     * @param Member $member
-     * @param string $token
-     */
-    protected function setSessionToken($member, $token)
-    {
-        // if there is a current member, they should be logged out
-        if ($curMember = Security::getCurrentUser()) {
-            Injector::inst()->get(IdentityStore::class)->logOut();
-        }
-
-        $this->getRequest()->getSession()->regenerateSessionId();
-        // Store the hash for the change password form. Will be unset after reload within the ChangePasswordForm.
-        $this->getRequest()->getSession()->set('AutoLoginHash', $member->encryptWithUserSettings($token));
     }
 
     /**
@@ -215,16 +192,13 @@ class ChangePasswordHandler extends RequestHandler
             return $this->redirectBackToForm();
         }
 
-        $session = $this->getRequest()->getSession();
         if (!$member) {
-            if ($session->get('AutoLoginHash')) {
-                $member = Member::member_from_autologinhash($session->get('AutoLoginHash'));
+            if (isset($data['AutoLoginHash'])) {
+                $member = Member::member_from_autologinhash($data['AutoLoginHash']);
             }
 
-            // The user is not logged in and no valid auto login hash is available
+            // The user is not logged in and no valid token was provided
             if (!$member) {
-                $session->clear('AutoLoginHash');
-
                 return $this->redirect($this->addBackURLParam(Security::singleton()->Link('login')));
             }
         }
@@ -240,7 +214,7 @@ class ChangePasswordHandler extends RequestHandler
             );
 
             // redirect back to the form, instead of using redirectBack() which could send the user elsewhere.
-            return $this->redirectBackToForm();
+            return $this->redirectBackToForm($member->ID, $data['AutoLoginHash']);
         }
 
         // Fail if passwords do not match
@@ -254,7 +228,7 @@ class ChangePasswordHandler extends RequestHandler
             );
 
             // redirect back to the form, instead of using redirectBack() which could send the user elsewhere.
-            return $this->redirectBackToForm();
+            return $this->redirectBackToForm($member->ID, $data['AutoLoginHash']);
         }
 
         // Check if the new password is accepted
@@ -262,7 +236,7 @@ class ChangePasswordHandler extends RequestHandler
         if (!$validationResult->isValid()) {
             $form->setSessionValidationResult($validationResult);
 
-            return $this->redirectBackToForm();
+            return $this->redirectBackToForm($member->ID, $data['AutoLoginHash']);
         }
 
         // Clear locked out status
@@ -293,8 +267,6 @@ class ChangePasswordHandler extends RequestHandler
             $identityStore->logIn($member, false, $this->getRequest());
         }
 
-        $session->clear('AutoLoginHash');
-
         // Redirect to backurl
         $backURL = $this->getBackURL();
         if ($backURL
@@ -319,10 +291,18 @@ class ChangePasswordHandler extends RequestHandler
      *
      * @return HTTPResponse
      */
-    public function redirectBackToForm()
+    public function redirectBackToForm(?int $withMemberID = null, ?string $withToken = null)
     {
         // Redirect back to form
-        $url = $this->addBackURLParam(Security::singleton()->Link('changepassword'));
+        $url = Security::singleton()->Link('changepassword');
+
+        // Include token data if performing an unauthenticated password reset
+        if ($withMemberID && $withToken) {
+            $url = Controller::join_links($url, "?m={$withMemberID}&t={$withToken}");
+        }
+
+        // Add Back URL if available
+        $url = $this->addBackURLParam($url);
 
         return $this->redirect($url);
     }

--- a/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.php
+++ b/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.php
@@ -10,8 +10,9 @@ use SilverStripe\Security\Member;
 use SilverStripe\Security\MemberAuthenticator\ChangePasswordHandler;
 use SilverStripe\Security\MemberAuthenticator\MemberAuthenticator;
 use SilverStripe\Security\Security;
+use SilverStripe\Dev\FunctionalTest;
 
-class ChangePasswordHandlerTest extends SapphireTest
+class ChangePasswordHandlerTest extends FunctionalTest
 {
     protected static $fixture_file = 'ChangePasswordHandlerTest.yml';
 
@@ -45,5 +46,51 @@ class ChangePasswordHandlerTest extends SapphireTest
         $this->assertIsArray($result, 'An array is returned');
         $this->assertStringContainsString('Security/lostpassword', $result['Content'], 'Lost password URL is included');
         $this->assertStringContainsString('Security/login', $result['Content'], 'Login URL is included');
+    }
+
+    public function testLegitimateTokenLoadsChangePasswordForm()
+    {
+        $member = $this->objFromFixture(Member::class, 'sarah');
+        $token = $member->generateAutologinTokenAndStoreHash();
+        $hash = $member->AutoLoginHash;
+
+        $request = new HTTPRequest('GET', '/Security/changepassword', [
+            'm' => $member->ID,
+            't' => $token,
+        ]);
+        $request->setSession(new Session([]));
+
+        /** @var ChangePasswordHandler $handler */
+        $handler = $this->getMockBuilder(ChangePasswordHandler::class)
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $result = $handler->setRequest($request)->changepassword();
+
+        $this->assertIsArray($result, 'An array is returned');
+        $this->assertArrayHasKey('Form', $result, 'Form is included');
+
+        $hashField = $result['Form']->HiddenFields()->dataFieldByName('AutoLoginHash') ?? null;
+        $this->assertIsObject($hashField, 'AutoLoginHash field is included');
+        $this->assertEquals($hashField->value, $hash, 'AutoLoginHash field value is correct');
+    }
+
+    public function testSubmittingChangePasswordFormSucceedsWithValidToken()
+    {
+        $member = $this->objFromFixture(Member::class, 'sarah');
+        $hash = $member->generateAutologinTokenAndStoreHash();
+
+        $this->get("/Security/changepassword?m={$member->ID}&t={$hash}");
+        $result = $this->submitForm('ChangePasswordForm_ChangePasswordForm', null, [
+            'NewPassword1' => 'newpassword',
+            'NewPassword2' => 'newpassword',
+        ]);
+
+        $this->assertStringContainsString(
+            'You&#039;re logged in',
+            $result->getBody(),
+            'User is logged in'
+        );
     }
 }

--- a/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.yml
+++ b/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.yml
@@ -2,4 +2,3 @@ SilverStripe\Security\Member:
   sarah:
     FirstName: Sarah
     Surname: Smith
-    AutoLoginToken: foobar

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -510,13 +510,7 @@ class SecurityTest extends FunctionalTest
 
         // Check.
         $response = $this->get('Security/changepassword/?m=' . $admin->ID . '&t=' . $token);
-        $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals(
-            Director::absoluteURL('Security/changepassword'),
-            Director::absoluteURL((string) $response->getHeader('Location'))
-        );
-        // Follow redirection to form without hash in GET parameter
-        $this->get('Security/changepassword');
+        $this->assertEquals(200, $response->getStatusCode());
         $this->doTestChangepasswordForm('1nitialPassword', 'changedPassword#123');
         $this->assertEquals($this->idFromFixture(Member::class, 'test'), $this->session()->get('loggedInAs'));
 


### PR DESCRIPTION


<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description

Performing an immediate redirect on a request from an external website, such as a web-based email client, causes the new request to be treated as external, and when the session cookie is set to Samesite=Strict, this prevents the cookie from being sent by the browser, triggering a fresh session. This meant that the existing password reset mechanism would not function in this mode, as the AutoLoginHash was being stored in the session and immediately lost, triggering a redirect to the login form.

This change refactors the change password handler to instead push the AutoLoginHash value into the change password form as a hidden field, ensuring it can be read during submission.

It also includes broader test coverage of the change password handler, though this remains incomplete due to time constraints.

## Manual testing steps

Enable SameSite=Strict on session cookies:

```yml
SilverStripe\Control\Session:
  cookie_samesite: 'Strict'
```

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #11565 

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
