### PR TITLE
FIX re-label forgot password for uniq id

### DIFF
--- a/src/Security/MemberAuthenticator/LostPasswordForm.php
+++ b/src/Security/MemberAuthenticator/LostPasswordForm.php
@@ -6,6 +6,8 @@ namespace SilverStripe\Security\MemberAuthenticator;
 use SilverStripe\Forms\EmailField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormAction;
+use SilverStripe\Forms\TextField;
+use SilverStripe\Security\Member;
 
 /**
  * Class LostPasswordForm handles the requests for lost password form generation
@@ -23,9 +25,15 @@ class LostPasswordForm extends MemberLoginForm
      */
     public function getFormFields()
     {
-        return FieldList::create(
-            EmailField::create('Email', _t('SilverStripe\\Security\\Member.EMAIL', 'Email'))
-        );
+        $uniqueIdentifier = Member::config()->get('unique_identifier_field');
+        $label = Member::singleton()->fieldLabel($uniqueIdentifier);
+        if ($uniqueIdentifier === 'Email') {
+            $emailField = EmailField::create('Email', $label);
+        } else {
+            // This field needs to still be called Email, but we can re-label it
+            $emailField = TextField::create('Email', $label);
+        }
+        return FieldList::create($emailField);
     }
 
     /**

--- a/tests/php/Security/MemberTest.php
+++ b/tests/php/Security/MemberTest.php
@@ -1030,7 +1030,7 @@ class MemberTest extends FunctionalTest
     public function testMap_in_groupsReturnsAll()
     {
         $members = Member::map_in_groups();
-        $this->assertEquals(17, $members->count(), 'There are 16 members in the mock plus a fake admin');
+        $this->assertEquals(18, $members->count(), 'There are 17 members in the mock plus a fake admin');
     }
 
     /**

--- a/tests/php/Security/MemberTest.yml
+++ b/tests/php/Security/MemberTest.yml
@@ -92,3 +92,6 @@
   delocalemember:
     Email: delocalemember@test.com
     Locale: de_DE
+  username-member:
+    Email: username@member.com
+    Username: username1234

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -485,6 +485,28 @@ class SecurityTest extends FunctionalTest
         $this->assertEquals($this->idFromFixture(Member::class, 'test'), $this->session()->get('loggedInAs'));
     }
 
+    public function testLostPasswordFormWithUniqueFieldIdentifier()
+    {
+        // override the unique identifier field
+        Member::config()->set('unique_identifier_field', 'Username');
+
+        /** @var Member $admin */
+        $member = $this->objFromFixture(Member::class, 'username-member');
+        $member->FailedLoginCount = 99;
+        $member->LockedOutUntil = DBDatetime::now()->getValue();
+        $member->write();
+
+        // load lostpassword form
+        $this->get('Security/lostpassword');
+        $labelElement = $this->cssParser()->getBySelector('#LostPasswordForm_lostPasswordForm_Email_Holder label');
+
+        $this->assertEquals(1, count($labelElement ?? []));
+        $this->assertStringContainsString(
+            '<label class="left" for="LostPasswordForm_lostPasswordForm_Email">Username</label>',
+            (string)$labelElement[0]->asXML()
+        );
+    }
+
     public function testChangePasswordFromLostPassword()
     {
         /** @var Member $admin */


### PR DESCRIPTION
## Description

 Defaults for non-Email unique identifier fields, including a TextField in the form and a sensible label.

## Manual testing steps

Set `unique_identifier_field` to something non-email.
See that it changes the field label.

## Issues

Fixes #11567 

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
