### PR TITLE
ENH: Scaffold GridFieldFilterHeader filters for ArrayList based GridFields.

### DIFF
--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -11,7 +11,7 @@ use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\Schema\FormSchema;
-use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\Filterable;
 use SilverStripe\ORM\Filters\PartialMatchFilter;
 use SilverStripe\ORM\Search\BasicSearchContext;
@@ -290,10 +290,9 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
             $list = $gridField->getList();
             $searchContext = $singleton->getDefaultSearchContext();
 
-            // In case we are working with an ArrayList we need to convert the search context into a basic search context
-            // This is because the scaffolded filters are intended to use ORM for data searching,
-            // they rely on DataList functionality which is not available on an ArrayList
-            if ($list instanceof ArrayList) {
+            // In case we are working with a list not backed by the database we need to convert the search context into a BasicSearchContext
+            // This is because the scaffolded filters use the ORM for data searching
+            if (!$list instanceof DataList) {
                 $searchContext = $this->getBasicSearchContext($gridField, $searchContext);
             }
 
@@ -507,11 +506,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
     }
 
     /**
-     * Transform search context into basic search context (preserve all relevant search settings)
-     *
-     * @param GridField $gridField
-     * @param SearchContext $searchContext
-     * @return BasicSearchContext
+     * Transform search context into BasicSearchContext (preserves all relevant search settings)
      */
     private function getBasicSearchContext(GridField $gridField, SearchContext $searchContext): BasicSearchContext
     {
@@ -524,10 +519,10 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
         $basicSearchContext = BasicSearchContext::create($list->dataClass());
         $basicSearchContext->setFields($defaultSearchFields);
 
-        // Carry over filter configuration (make changes to filter classes so they work with ArrayList data)
+        // Carry over filter configuration (make changes to filter classes so they work with this list)
         foreach ($defaultFilters as $defaultFilter) {
             $fieldFilter = PartialMatchFilter::create(
-            // Use name instead of full name as this plain filter doesn't understand relations
+                // Use name instead of full name as this plain filter doesn't understand relations
                 $defaultFilter->getName(),
                 $defaultFilter->getValue(),
                 $defaultFilter->getModifiers(),

--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -516,7 +516,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
         $list = $gridField->getList();
 
         // Carry over any search form settings
-        $basicSearchContext = BasicSearchContext::create($list->dataClass());
+        $basicSearchContext = BasicSearchContext::create($gridField->getModelClass());
         $basicSearchContext->setFields($defaultSearchFields);
 
         // Carry over filter configuration (make changes to filter classes so they work with this list)

--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -290,9 +290,9 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
             $list = $gridField->getList();
             $searchContext = $singleton->getDefaultSearchContext();
 
-            // In case we are working with an ArrayList we need to conver the search context into a basic search context
-            // This is because the scaffolded filters are inteded to use ORM for data searching,
-            // they rely on DataList functionality which is not avaialble on an ArayList
+            // In case we are working with an ArrayList we need to convert the search context into a basic search context
+            // This is because the scaffolded filters are intended to use ORM for data searching,
+            // they rely on DataList functionality which is not available on an ArrayList
             if ($list instanceof ArrayList) {
                 $searchContext = $this->getBasicSearchContext($gridField, $searchContext);
             }
@@ -507,7 +507,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
     }
 
     /**
-     * Transform search contex into basic search context (preserve all releavnt search settings)
+     * Transform search context into basic search context (preserve all relevant search settings)
      *
      * @param GridField $gridField
      * @param SearchContext $searchContext

--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -11,7 +11,10 @@ use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\Schema\FormSchema;
+use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\Filterable;
+use SilverStripe\ORM\Filters\PartialMatchFilter;
+use SilverStripe\ORM\Search\BasicSearchContext;
 use SilverStripe\ORM\Search\SearchContext;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\View\ArrayData;
@@ -283,7 +286,18 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
                     . " or implement a getDefaultSearchContext() method on $modelClass"
                 );
             }
-            $this->searchContext = $singleton->getDefaultSearchContext();
+
+            $list = $gridField->getList();
+            $searchContext = $singleton->getDefaultSearchContext();
+
+            // In case we are working with an ArrayList we need to conver the search context into a basic search context
+            // This is because the scaffolded filters are inteded to use ORM for data searching,
+            // they rely on DataList functionality which is not avaialble on an ArayList
+            if ($list instanceof ArrayList) {
+                $searchContext = $this->getBasicSearchContext($gridField, $searchContext);
+            }
+
+            $this->searchContext = $searchContext;
         }
 
         return $this->searchContext;
@@ -490,5 +504,37 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
         }
 
         return ClassInfo::shortName($inst);
+    }
+
+    /**
+     * Transform search contex into basic search context (preserve all releavnt search settings)
+     *
+     * @param GridField $gridField
+     * @param SearchContext $searchContext
+     * @return BasicSearchContext
+     */
+    private function getBasicSearchContext(GridField $gridField, SearchContext $searchContext): BasicSearchContext
+    {
+        // Retrieve filters settings as these can be carried over as is
+        $defaultSearchFields = $searchContext->getSearchFields();
+        $defaultFilters = $searchContext->getFilters();
+        $list = $gridField->getList();
+
+        // Carry over any search form settings
+        $basicSearchContext = BasicSearchContext::create($list->dataClass());
+        $basicSearchContext->setFields($defaultSearchFields);
+
+        // Carry over filter configuration (make changes to filter classes so they work with ArrayList data)
+        foreach ($defaultFilters as $defaultFilter) {
+            $fieldFilter = PartialMatchFilter::create(
+            // Use name instead of full name as this plain filter doesn't understand relations
+                $defaultFilter->getName(),
+                $defaultFilter->getValue(),
+                $defaultFilter->getModifiers(),
+            );
+            $basicSearchContext->addFilter($fieldFilter);
+        }
+
+        return $basicSearchContext;
     }
 }

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -288,13 +288,13 @@ class GridFieldFilterHeaderTest extends SapphireTest
         $this->assertInstanceOf(
             BasicSearchContext::class,
             $arrayListSearchContext,
-            'We expect a basic search context as our GridField list is provied via ArrayList'
+            'We expect a basic search context as our GridField list is provided via ArrayList'
         );
 
         $this->assertNotInstanceOf(
             BasicSearchContext::class,
             $dataListSearchContext,
-            'We expect a regular search context as our GridField list is provied via DataList'
+            'We expect a regular search context as our GridField list is provided via DataList'
         );
 
         $arrayListSearchFields = $arrayListSearchContext

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -22,6 +22,7 @@ use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\TeamGroup;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\Filters\PartialMatchFilter;
 use SilverStripe\ORM\Filters\SearchFilter;
 use SilverStripe\ORM\Search\BasicSearchContext;
 use SilverStripe\ORM\Search\SearchContext;
@@ -332,14 +333,15 @@ class GridFieldFilterHeaderTest extends SapphireTest
             return $filter::class;
         };
         $arrayListSearchFilterTypes = array_map($getFilterType, $arrayListFilters);
-        $dataListSearchFilterTypes = array_map($getFilterType, $dataListFilters);
-        $arrayListSearchFilterTypes = array_values($arrayListSearchFilterTypes);
-        $dataListSearchFilterTypes = array_values($dataListSearchFilterTypes);
+        $arrayListSearchFilterTypes = array_unique($arrayListSearchFilterTypes);
 
-        $this->assertNotSame(
-            $arrayListSearchFilterTypes,
-            $dataListSearchFilterTypes,
-            'We expect the search filters to be different as the filtering is different based on how data is provided to the GridField'
+        $this->assertCount(1, $arrayListSearchFilterTypes, 'We expect all filters to be of the same type');
+        $arrayListSearchFilterType = array_shift($arrayListSearchFilterTypes);
+
+        $this->assertEquals(
+            PartialMatchFilter::class,
+            $arrayListSearchFilterType,
+            'We expect partial match filters'
         );
     }
 }

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -22,6 +22,9 @@ use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\TeamGroup;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\Filters\SearchFilter;
+use SilverStripe\ORM\Search\BasicSearchContext;
+use SilverStripe\ORM\Search\SearchContext;
 use SilverStripe\View\ArrayData;
 
 class GridFieldFilterHeaderTest extends SapphireTest
@@ -267,5 +270,76 @@ class GridFieldFilterHeaderTest extends SapphireTest
         );
 
         $component->getSearchContext($gridField);
+    }
+
+    public function testGetBasicSearchContext(): void
+    {
+        $arrayList = new ArrayList();
+        $arrayList->setDataClass(Team::class);
+        $arrayListFilter = new GridFieldFilterHeader();
+        $arrayListGridField = new GridField('dummy', 'dummy', $arrayList);
+        $arrayListSearchContext = $arrayListFilter->getSearchContext($arrayListGridField);
+
+        $dataList = Team::get();
+        $dataListFilter = new GridFieldFilterHeader();
+        $dataListGridField = new GridField('dummy', 'dummy', $dataList);
+        $dataListSearchContext = $dataListFilter->getSearchContext($dataListGridField);
+
+        $this->assertInstanceOf(
+            BasicSearchContext::class,
+            $arrayListSearchContext,
+            'We expect a basic search context as our GridField list is provied via ArrayList'
+        );
+
+        $this->assertNotInstanceOf(
+            BasicSearchContext::class,
+            $dataListSearchContext,
+            'We expect a regular search context as our GridField list is provied via DataList'
+        );
+
+        $arrayListSearchFields = $arrayListSearchContext
+            ->getSearchFields()
+            ->column('Name');
+
+        $dataListSearchFields = $dataListSearchContext
+            ->getSearchFields()
+            ->column('Name');
+
+        $this->assertSame(
+            $arrayListSearchFields,
+            $dataListSearchFields,
+            'We expect the search fields to be the same regardless of how data is provided to the GridField'
+        );
+
+        $arrayListFilters = $arrayListSearchContext->getFilters();
+        $dataListFilters = $dataListSearchContext->getFilters();
+
+        $getFilterName = static function (SearchFilter $filter): string {
+            return $filter->getName();
+        };
+        $arrayListSearchFilterNames = array_map($getFilterName, $arrayListFilters);
+        $dataListSearchFilterNames = array_map($getFilterName, $dataListFilters);
+        $arrayListSearchFilterNames = array_values($arrayListSearchFilterNames);
+        $dataListSearchFilterNames = array_values($dataListSearchFilterNames);
+
+        $this->assertSame(
+            $arrayListSearchFilterNames,
+            $dataListSearchFilterNames,
+            'We expect the search filters to be the same regardless of how data is provided to the GridField'
+        );
+
+        $getFilterType = static function (SearchFilter $filter): string {
+            return $filter::class;
+        };
+        $arrayListSearchFilterTypes = array_map($getFilterType, $arrayListFilters);
+        $dataListSearchFilterTypes = array_map($getFilterType, $dataListFilters);
+        $arrayListSearchFilterTypes = array_values($arrayListSearchFilterTypes);
+        $dataListSearchFilterTypes = array_values($dataListSearchFilterTypes);
+
+        $this->assertNotSame(
+            $arrayListSearchFilterTypes,
+            $dataListSearchFilterTypes,
+            'We expect the search filters to be different as the filtering is different based on how data is provided to the GridField'
+        );
     }
 }


### PR DESCRIPTION
## Description

Enables filtering capability for cases where GirdField data is stored in an `ArrayList`. This wasn't working before because pre CMS 5 such feature was not supported. With CMS 5 it's possible so we should enable it.

## Issues

- https://github.com/silverstripe/silverstripe-framework/issues/10654
- https://github.com/tractorcow-farm/silverstripe-fluent/issues/924

Likely replaces https://github.com/tractorcow-farm/silverstripe-fluent/pull/922

## Pull request checklist

- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
