### PR TITLE
MNT Handle LogicExceptions when calling setI18nLocale()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
         "phpstan/extension-installer": "^1.3"
     },
     "conflict": {
+        "silverstripe/behat-extension": "<5.5",
         "egulias/email-validator": "^2",
         "oscarotero/html-parser": "<0.1.7",
         "symfony/process": "<5.3.7"

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -65,6 +65,13 @@ abstract class SapphireTest extends TestCase implements TestOnly
     protected static $fixture_file = null;
 
     /**
+     * Whether to set the i18n locale to en_US for supported modules before running the test.
+     * This should only be set to false if calling setI18nLocale() causes the test to
+     * throw an exception as part of calling setI18nLocale()
+     */
+    protected bool $doSetSupportedModuleLocaleToUS = true;
+
+    /**
      * @var Boolean If set to TRUE, this will force a test database to be generated
      * in {@link setUp()}. Note that this flag is overruled by the presence of a
      * {@link $fixture_file}, which always forces a database build.
@@ -1239,6 +1246,10 @@ abstract class SapphireTest extends TestCase implements TestOnly
      */
     private function setI18nLocale(): void
     {
+        if (!$this->doSetSupportedModuleLocaleToUS) {
+            $this->setLocaleToDefault();
+            return;
+        }
         $path = $this->getCurrentRelativePath();
         $packagistName = '';
         if (preg_match('#(^|/)vendor/([^/]+/[^/]+)/.+#', $path, $matches)) {
@@ -1261,9 +1272,16 @@ abstract class SapphireTest extends TestCase implements TestOnly
             i18n::config()->set('default_locale', 'en_US');
             i18n::set_locale('en_US');
         } else {
-            // Set the locale to the default_locale, which may have been set at project level to a
-            // non-en_US locale and the project unit tests expect that locale to be set
-            i18n::set_locale(i18n::config()->get('default_locale'));
+            $this->setLocaleToDefault();
         }
+    }
+
+    /**
+     * Set the locale to the default_locale, which may have been set at project level to a
+     * non-en_US locale and the project unit tests expect that locale to be set
+     */
+    private function setLocaleToDefault(): void
+    {
+        i18n::set_locale(i18n::config()->get('default_locale'));
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/357

Fixes https://github.com/silverstripe/silverstripe-behat-extension/actions/runs/12938868907/job/36089987699?pr=295#step:12:101

`1) SilverStripe\BehatExtension\Tests\SilverStripeContextTest::testGetRegionObjThrowsExceptionOnUnknownSelector
LogicException: getItemPath returned null for SilverStripe\BehatExtension\Tests\SilverStripeContextTest.`

[SilverStripeContextTest](https://github.com/silverstripe/silverstripe-behat-extension/blob/5/tests/php/SilverStripeContextTest.php) does some weird stuff with mocking.  In these sorts of scenarios I'm assuming the type of unit testing that we're running won't be reliant upon having to set the en_US locale in order to get the test to always pass. 

[Kitchen sink CI run](https://github.com/creative-commoners/recipe-kitchen-sink/actions/runs/12979001917) with this [PR](https://github.com/silverstripe/silverstripe-behat-extension/pull/296) - https://github.com/creative-commoners/recipe-kitchen-sink/actions/runs/12979001917