### PR TITLE
FIX 11577 performance issues with large list of groups

### DIFF
--- a/src/Security/Group.php
+++ b/src/Security/Group.php
@@ -23,6 +23,7 @@ use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
 use SilverStripe\Forms\ListboxField;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\RequiredFields;
+use SilverStripe\Forms\SearchableDropdownField;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
 use SilverStripe\Forms\TextareaField;
@@ -33,6 +34,7 @@ use SilverStripe\ORM\DataQuery;
 use SilverStripe\ORM\HasManyList;
 use SilverStripe\ORM\Hierarchy\Hierarchy;
 use SilverStripe\ORM\ManyManyList;
+use SilverStripe\ORM\Search\SearchContext;
 use SilverStripe\ORM\UnsavedRelationList;
 
 /**
@@ -91,6 +93,37 @@ class Group extends DataObject
         'Sort' => true,
     ];
 
+    /**
+     * Specify the limit from when groups should be lazyloaded for the SearchableDropdownField
+     *
+     * @var int
+     * @config
+     */
+    private static $dropdown_field_threshold = 100;
+
+    /**
+     * Create a search context which is used for the SearchableDropdownField
+     * in {@see Group::getCMSFields()} and {@see Member::getCMSFields()}
+     *
+     * @return SearchContext
+     */
+    public static function get_search_context_for_dropdown(): SearchContext
+    {
+        $group = Group::singleton();
+
+        return SearchContext::create(
+            Group::class,
+            FieldList::create(
+                TextField::create('Title', $group->fieldLabel('Title')),
+                TextField::create('Description', $group->fieldLabel('Description')),
+            ),
+            [
+                'Title' => 'PartialFilter',
+                'Description' => 'PartialFilter',
+            ]
+        );
+    }
+
     public function getAllChildren()
     {
         $doSet = new ArrayList();
@@ -122,6 +155,10 @@ class Group extends DataObject
      */
     public function getCMSFields()
     {
+        $groups = Group::get();
+        $threshold = Group::config()->get('dropdown_field_threshold');
+        $overThreshold = $groups->count() > $threshold;
+
         $fields = new FieldList(
             new TabSet(
                 "Root",
@@ -129,11 +166,23 @@ class Group extends DataObject
                     'Members',
                     _t(__CLASS__ . '.MEMBERS', 'Members'),
                     new TextField("Title", $this->fieldLabel('Title')),
-                    $parentidfield = DropdownField::create(
+                    $parentidfield = SearchableDropdownField::create(
                         'ParentID',
                         $this->fieldLabel('Parent'),
-                        $this->getDecodedBreadcrumbs()
-                    )->setEmptyString(' '),
+                        $groups,
+                        null,
+                        'BreadcrumbTitle'
+                    )
+                        ->setIsSearchable(true)
+                        ->setUseSearchContext(true)
+                        ->setSearchContext(Group::get_search_context_for_dropdown())
+                        ->setPlaceholder(_t(
+                            __CLASS__ . '.PARENT_GROUP_PLACEHOLDER',
+                            'Select parent group',
+                            'Placeholder text for a dropdown'
+                        ))
+                        ->setIsLazyLoaded($overThreshold)
+                        ->setLazyLoadLimit($threshold),
                     new TextareaField('Description', $this->fieldLabel('Description'))
                 ),
                 $permissionsTab = new Tab(
@@ -461,6 +510,16 @@ class Group extends DataObject
     }
 
     /**
+     * Label which can be used inside a SearchableDropdownField for example
+     *
+     * @return string
+     */
+    public function getBreadcrumbTitle(): string
+    {
+        return $this->getBreadcrumbs(' > ');
+    }
+
+    /**
      * @return string
      */
     public function getTreeTitle()
@@ -503,12 +562,12 @@ class Group extends DataObject
             }
         }
 
-        $currentGroups = Group::get()
-            ->filter('ID:not', $this->ID)
-            ->map('Code', 'Title')
-            ->toArray();
+        $hasGroupWithSameTitle = Group::get()
+            ->exclude('ID', $this->ID)
+            ->filter('Title', $this->Title)
+            ->exists();
 
-        if (in_array($this->Title, $currentGroups)) {
+        if ($hasGroupWithSameTitle) {
             $result->addError(
                 _t(
                     'SilverStripe\\Security\\Group.ValidationIdentifierAlreadyExists',
@@ -711,16 +770,21 @@ class Group extends DataObject
      */
     private function dedupeCode(): void
     {
-        $currentGroups = Group::get()
-            ->exclude('ID', $this->ID)
-            ->map('Code', 'Title')
-            ->toArray();
         $code = $this->Code;
         $count = 2;
-        while (isset($currentGroups[$code])) {
-            $code = $this->Code . '-' . $count;
-            $count++;
+
+        if ($code) {
+            while ($this->checkIfCodeExists($code)) {
+                $code = $this->Code . '-' . $count;
+                $count++;
+            }
+
+            $this->setField('Code', $code);
         }
-        $this->setField('Code', $code);
+    }
+
+    private function checkIfCodeExists(string $code): bool
+    {
+        return Group::get()->filter('Code', $code)->exclude('ID', $this->ID)->exists();
     }
 }

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -21,14 +21,17 @@ use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorConfig;
 use SilverStripe\Forms\ListboxField;
+use SilverStripe\Forms\SearchableMultiDropdownField;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
+use SilverStripe\Forms\TreeMultiselectField;
 use SilverStripe\i18n\i18n;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\ORM\FieldType\DBForeignKey;
 use SilverStripe\ORM\HasManyList;
 use SilverStripe\ORM\ManyManyList;
 use SilverStripe\ORM\Map;
@@ -1365,28 +1368,31 @@ class Member extends DataObject
             $fields->removeByName('RememberLoginHashes');
 
             if (Permission::check('EDIT_PERMISSIONS')) {
-                // Filter allowed groups
                 $groups = Group::get();
-                $disallowedGroupIDs = $this->disallowedGroups();
-                if ($disallowedGroupIDs) {
+
+                if ($disallowedGroupIDs = $this->disallowedGroups()) {
                     $groups = $groups->exclude('ID', $disallowedGroupIDs);
                 }
-                $groupsMap = [];
-                foreach ($groups as $group) {
-                    // Listboxfield values are escaped, use ASCII char instead of &raquo;
-                    $groupsMap[$group->ID] = $group->getBreadcrumbs(' > ');
-                }
-                asort($groupsMap);
+
+                $threshold = Group::config()->get('dropdown_field_threshold');
+                $overThreshold = $groups->count() > $threshold;
+
                 $fields->addFieldToTab(
                     'Root.Main',
-                    ListboxField::create('DirectGroups', Group::singleton()->i18n_plural_name())
-                        ->setSource($groupsMap)
-                        ->setAttribute(
-                            'data-placeholder',
-                            _t(__CLASS__ . '.ADDGROUP', 'Add group', 'Placeholder text for a dropdown')
-                        )
+                    SearchableMultiDropdownField::create(
+                        'DirectGroups',
+                        Group::singleton()->i18n_plural_name(),
+                        $groups,
+                        null,
+                        'BreadcrumbTitle'
+                    )
+                        ->setIsSearchable(true)
+                        ->setUseSearchContext(true)
+                        ->setSearchContext(Group::get_search_context_for_dropdown())
+                        ->setIsLazyLoaded($overThreshold)
+                        ->setLazyLoadLimit($threshold)
+                        ->setPlaceholder(_t(__CLASS__ . '.ADDGROUP', 'Add group', 'Placeholder text for a dropdown'))
                 );
-
 
                 // Add permission field (readonly to avoid complicated group assignment logic).
                 // This should only be available for existing records, as new records start


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

If you have many groups you can no longer edit a member in the admin.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

As this is a performance issue, I am not sure howto create a unittest for this. But here is a task to create a massive amount of groups:

```php
<?php

use SilverStripe\Dev\BuildTask;
use SilverStripe\ORM\DB;
use SilverStripe\Security\Group;

class GroupCreationTask extends BuildTask
{
    public function run($request): void
    {
        DB::query('TRUNCATE "Group"');
        DB::query('TRUNCATE "Permission"');

        Group::singleton()->requireDefaultRecords();

        $conn = DB::get_conn();
        $conn->transactionStart();

        $start = hrtime(true);

        for ($i = 0; $i < 3000; $i++) {
            if (($i % 100) == 0) {
                $conn->transactionEnd();
                $conn->transactionStart();

                $end = hrtime(true);
                $t = ($end - $start) / 1e9;

                printf("%d - %fs\n", $i, $t);

                $start = hrtime(true);
            }

            $parentGroup = Group::create();
            $parentGroup->Code = 'group_' . $i;
            $parentGroup->Title = 'Group ' . $i;
            $parentGroup->write();

            for ($j = 0; $j < 5; $j++) {
                $group = Group::create();
                $group->Code = 'group_' . $i . '_' . $j ;
                $group->Title = 'Group ' . $i . ' ' . $j;
                $group->ParentID = $parentGroup->ID;
                $group->write();
            }
        }

        $conn->transactionEnd();

        $end = hrtime(true);
        $t = ($end - $start) / 1e9;

        printf("%d - %fs\n", $i, $t);
    }
}
```

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-framework/issues/11577

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
