### PR TITLE
Various changes to support refactoring CMS search filter functionality

### DIFF
--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -308,7 +308,9 @@ class Form extends ModelData implements HasRequestHandler, ValidationInterface
         }
 
         // Form error controls
-        $this->restoreFormState();
+        if ($controller) {
+            $this->restoreFormState();
+        }
 
         // Check if CSRF protection is enabled, either on the parent controller or from the default setting. Note that
         // method_exists() is used as some controllers (e.g. GroupTest) do not always extend from Object.
@@ -1788,6 +1790,21 @@ class Form extends ModelData implements HasRequestHandler, ValidationInterface
             unset($this->extraClasses[$class]);
         }
         return $this;
+    }
+
+    public function __clone(): void
+    {
+        $this->fields = clone $this->fields;
+        $this->actions = clone $this->actions;
+        if ($this->validator) {
+            $this->setValidator(clone $this->validator);
+        }
+        foreach ($this->fields as $field) {
+            $field->setForm($this);
+        }
+        foreach ($this->actions as $action) {
+            $action->setForm($this);
+        }
     }
 
     public function debug(): string

--- a/src/Forms/FormRequestHandler.php
+++ b/src/Forms/FormRequestHandler.php
@@ -4,16 +4,15 @@ namespace SilverStripe\Forms;
 
 use BadMethodCallException;
 use SilverStripe\Control\Controller;
-use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\ClassInfo;
-use SilverStripe\Core\Convert;
 use SilverStripe\Core\Validation\ValidationResult;
 use SilverStripe\Model\List\SS_List;
 use SilverStripe\Core\Validation\ValidationException;
+use SilverStripe\Forms\Schema\FormSchema;
 
 class FormRequestHandler extends RequestHandler
 {
@@ -27,6 +26,7 @@ class FormRequestHandler extends RequestHandler
      * @var array
      */
     private static $allowed_actions = [
+        'getSchema',
         'handleField',
         'httpSubmission',
         'forTemplate',
@@ -37,6 +37,7 @@ class FormRequestHandler extends RequestHandler
      * @var array
      */
     private static $url_handlers = [
+        'GET schema' => 'getSchema',
         'field/$FieldName!' => 'handleField',
         'POST ' => 'httpSubmission',
         'GET ' => 'httpSubmission',
@@ -67,6 +68,18 @@ class FormRequestHandler extends RequestHandler
         }
     }
 
+    /**
+     * Gets a JSON schema representing a form.
+     */
+    public function getSchema(HTTPRequest $request): HTTPResponse
+    {
+        $schemaID = $request->getURL();
+        $parts = $request->getHeader(FormSchema::SCHEMA_HEADER);
+        $data = FormSchema::singleton()->getMultipartSchema($parts, $schemaID, $this->form);
+        $response = HTTPResponse::create(json_encode($data));
+        $response->addHeader('Content-Type', 'application/json');
+        return $response;
+    }
 
     /**
      * Get link for this form

--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -275,8 +275,8 @@ class GridField extends FormField
         $hadEditButton = $copyConfig->getComponentByType(GridFieldEditButton::class) !== null;
 
         // get the whitelist for allowable readonly components
-        $allowedComponents = $this->getReadonlyComponents();
-        foreach ($this->getConfig()->getComponents() as $component) {
+        $allowedComponents = $copy->getReadonlyComponents();
+        foreach ($copy->getConfig()->getComponents() as $component) {
             // if a component doesn't exist, remove it from the readonly version.
             if (!in_array(get_class($component), $allowedComponents ?? [])) {
                 $copyConfig->removeComponent($component);
@@ -297,7 +297,7 @@ class GridField extends FormField
             }
         }
 
-        $copy->extend('afterPerformReadonlyTransformation', $this);
+        $copy->extend('afterPerformReadonlyTransformation', $copy);
 
         return $copy;
     }
@@ -1344,6 +1344,11 @@ class GridField extends FormField
                 $component->handleSave($this, $record);
             }
         }
+    }
+
+    public function __clone(): void
+    {
+        $this->config = clone $this->config;
     }
 
     /**

--- a/src/Forms/GridField/GridFieldConfig.php
+++ b/src/Forms/GridField/GridFieldConfig.php
@@ -155,4 +155,13 @@ class GridFieldConfig
         }
         return null;
     }
+
+    public function __clone(): void
+    {
+        $components = $this->components;
+        $this->components = ArrayList::create();
+        foreach ($components as $component) {
+            $this->components->add(clone $component);
+        }
+    }
 }

--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -3,22 +3,14 @@
 namespace SilverStripe\Forms\GridField;
 
 use LogicException;
-use SilverStripe\Admin\FormSchemaController;
-use SilverStripe\Control\Controller;
-use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\ClassInfo;
-use SilverStripe\Dev\Deprecation;
-use SilverStripe\Forms\CompositeField;
-use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
-use SilverStripe\Forms\Schema\FormSchema;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\Filters\PartialMatchFilter;
 use SilverStripe\ORM\Search\BasicSearchContext;
 use SilverStripe\ORM\Search\SearchContext;
 use SilverStripe\Model\List\SS_List;
-use SilverStripe\Model\ArrayData;
-use SilverStripe\View\SSViewer;
+use SilverStripe\ORM\Search\SearchContextForm;
 
 /**
  * GridFieldFilterHeader alters the {@link GridField} with some filtering
@@ -52,7 +44,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
     public function getURLHandlers($gridField)
     {
         return [
-            'GET schema/SearchForm' => 'getSearchFormSchema'
+            'GET SearchForm' => 'getSearchForm',
         ];
     }
 
@@ -119,11 +111,8 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
         if ($actionName === 'filter') {
             $filterValues = $data['filter'][$gridField->getName()] ?? null;
             if ($filterValues !== null) {
-                $form = $this->getSearchForm($gridField);
-                $this->removeSearchPrefixFromFields($form->Fields());
-                $form->loadDataFrom($filterValues);
-                foreach ($filterValues as $fieldName => $rawFilterValue) {
-                    $state->Columns->$fieldName = $form->Fields()->dataFieldByName($fieldName)?->dataValue() ?? $rawFilterValue;
+                foreach ($filterValues as $fieldName => $value) {
+                    $state->Columns->$fieldName = $value;
                 }
             }
         }
@@ -158,6 +147,9 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
         if (empty($filterArguments)) {
             return $dataList;
         }
+
+        $form = $this->getSearchForm($gridField);
+        $filterArguments = $form->prepareValuesForSearchContext($filterArguments);
 
         $dataListClone = clone($dataList);
         $results = $this->getSearchContext($gridField)
@@ -276,144 +268,23 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
     }
 
     /**
-     * Returns the search field schema for the component
-     *
-     * @param GridField $gridfield
-     * @return string
-     * @deprecated 5.4.0 Will be replaced with SilverStripe\ORM\Search\SearchContextForm::getSchemaData()
+     * Returns the search form for the component if relevant
      */
-    public function getSearchFieldSchema(GridField $gridField)
+    public function getSearchForm(GridField $gridField): ?SearchContextForm
     {
-        Deprecation::noticeWithNoReplacment(
-            '5.4.0',
-            'Will be replaced with SilverStripe\ORM\Search\SearchContextForm::getSchemaData()'
-        );
-        $schemaUrl = Controller::join_links($gridField->Link(), 'schema/SearchForm');
-        $inst = singleton($gridField->getModelClass());
-        $context = $this->getSearchContext($gridField);
-        $params = $gridField->getRequest()->postVar('filter') ?: [];
-        if (array_key_exists($gridField->getName(), $params ?? [])) {
-            $params = $params[$gridField->getName()];
-        }
-        if ($context->getSearchParams()) {
-            $params = array_merge($context->getSearchParams(), $params);
-        }
-        $context->setSearchParams($params);
+        if (!$this->searchForm) {
+            $searchContext = $this->getSearchContext($gridField);
 
-        $searchField = $this->getSearchField() ?: $inst->config()->get('general_search_field');
-        if (!$searchField) {
-            $searchField = $context->getSearchFields()->first();
-            $searchField = $searchField && property_exists($searchField, 'name') ? $searchField->name : null;
-        }
-
-        // Prefix "Search__" onto the filters to match the field names in the actual form
-        $filters = $context->getSearchParams();
-        if (!empty($filters)) {
-            $filters = array_combine(array_map(function ($key) {
-                return 'Search__' . $key;
-            }, array_keys($filters ?? [])), $filters ?? []);
-        }
-
-        $searchAction = GridField_FormAction::create($gridField, 'filter', false, 'filter', null);
-        $clearAction = GridField_FormAction::create($gridField, 'reset', false, 'reset', null);
-        $schema = [
-            'formSchemaUrl' => $schemaUrl,
-            'name' => $searchField,
-            'placeholder' => $this->getPlaceHolder($inst),
-            'filters' => $filters ?: new \stdClass, // stdClass maps to empty json object '{}'
-            'gridfield' => $gridField->getName(),
-            'searchAction' => $searchAction->getAttribute('name'),
-            'searchActionState' => $searchAction->getAttribute('data-action-state'),
-            'clearAction' => $clearAction->getAttribute('name'),
-            'clearActionState' => $clearAction->getAttribute('data-action-state'),
-        ];
-
-        return json_encode($schema);
-    }
-
-    /**
-     * Returns the search form for the component
-     *
-     * @param GridField $gridField
-     * @return Form|null
-     */
-    public function getSearchForm(GridField $gridField)
-    {
-        $searchContext = $this->getSearchContext($gridField);
-        $searchFields = $searchContext->getSearchFields();
-
-        if ($searchFields->count() === 0) {
-            return null;
-        }
-
-        if ($this->searchForm) {
-            return $this->searchForm;
-        }
-
-        $this->addSearchPrefixToFields($searchFields);
-
-        // Update field titles to match column titles
-        $columns = $gridField->getColumns();
-        foreach ($columns as $columnField) {
-            $metadata = $gridField->getColumnMetadata($columnField);
-            // Get the field name, without any modifications
-            $name = explode('.', $columnField ?? '');
-            $title = $metadata['title'];
-            $field = $searchFields->fieldByName($name[0]);
-
-            if ($field) {
-                $field->setTitle($title);
+            if ($searchContext->getSearchFields()->count() === 0) {
+                return null;
             }
+
+            $this->searchForm = SearchContextForm::create($gridField, $searchContext);
+            $this->searchForm->setHTMLID('GridField_' . $gridField->getName() . '_SearchForm');
+            $this->searchForm->addExtraClass('form--no-dividers');
         }
-
-        $this->updateFieldClasses($searchFields);
-
-        $name = $this->getTitle(singleton($gridField->getModelClass()));
-
-        $this->searchForm = $form = new Form(
-            $gridField,
-            $name . "SearchForm",
-            $searchFields,
-            new FieldList()
-        );
-
-        $form->setFormMethod('get');
-        $form->setFormAction($gridField->Link());
-        $form->addExtraClass('cms-search-form form--no-dividers');
-        $form->disableSecurityToken(); // This form is not tied to session so we disable this
-        $form->loadDataFrom($searchContext->getSearchParams());
 
         return $this->searchForm;
-    }
-
-    /**
-     * Returns the search form schema for the component
-     *
-     * @param GridField $gridfield
-     * @return HTTPResponse
-     * @deprecated 5.4.0 Will be replaced with SilverStripe\Forms\FormRequestHandler::getSchema()
-     */
-    public function getSearchFormSchema(GridField $gridField)
-    {
-        Deprecation::noticeWithNoReplacment(
-            '5.4.0',
-            'Will be replaced with SilverStripe\Forms\FormRequestHandler::getSchema()'
-        );
-        $form = $this->getSearchForm($gridField);
-
-        // If there are no filterable fields, return a 400 response
-        if (!$form) {
-            return new HTTPResponse(_t(__CLASS__ . '.SearchFormFaliure', 'No search form could be generated'), 400);
-        }
-
-        $parts = $gridField->getRequest()->getHeader(FormSchema::SCHEMA_HEADER);
-        $schemaID = $gridField->getRequest()->getURL();
-        $data = FormSchema::singleton()
-            ->getMultipartSchema($parts, $schemaID, $form);
-
-        $response = new HTTPResponse(json_encode($data));
-        $response->addHeader('Content-Type', 'application/json');
-        return $response;
     }
 
     /**
@@ -424,52 +295,17 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
      */
     public function getHTMLFragments($gridField)
     {
-        $forTemplate = new ArrayData([]);
-
         if (!$this->canFilterAnyColumns($gridField)) {
             return null;
         }
 
-        $fieldSchema = $this->getSearchFieldSchema($gridField);
-        $forTemplate->SearchFieldSchema = $fieldSchema;
-        $searchTemplates = SSViewer::get_templates_by_class($this, '_Search', __CLASS__);
+        $form = $this->getSearchForm($gridField);
+        $isFiltered = !empty($this->getSearchContext($gridField)->getSearchParams());
+
         return [
-            'before' => $forTemplate->renderWith($searchTemplates),
-            'buttons-before-right' => sprintf(
-                '<button type="button" name="showFilter" aria-label="%s" title="%s"' .
-                ' class="btn btn-secondary font-icon-search btn--no-text btn--icon-large grid-field__filter-open"></button>',
-                _t('SilverStripe\\Forms\\GridField\\GridField.OpenFilter', "Open search and filter"),
-                _t('SilverStripe\\Forms\\GridField\\GridField.OpenFilter', "Open search and filter")
-            )
+            'before' => $form->getPlaceHolder($isFiltered),
+            'buttons-before-right' => $form->getFilterButton($isFiltered),
         ];
-    }
-
-    /**
-     * Get the text that will be used as a placeholder in the search field.
-     *
-     * @param object $obj An instance of the class that will be searched against.
-     * If getPlaceHolderText is empty, this object will be used to build the placeholder
-     * e.g. 'Search "My Data Object"'
-     */
-    private function getPlaceHolder(object $obj): string
-    {
-        $placeholder = $this->getPlaceHolderText();
-        if (!empty($placeholder)) {
-            return $placeholder;
-        }
-        if ($obj) {
-            return _t(__CLASS__ . '.Search', 'Search "{name}"', ['name' => $this->getTitle($obj)]);
-        }
-        return _t(__CLASS__ . '.Search_Default', 'Search');
-    }
-
-    private function getTitle(object $inst): string
-    {
-        if (ClassInfo::hasMethod($inst, 'i18n_plural_name')) {
-            return $inst->i18n_plural_name();
-        }
-
-        return ClassInfo::shortName($inst);
     }
 
     /**
@@ -480,7 +316,6 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
         // Retrieve filters settings as these can be carried over as is
         $defaultSearchFields = $searchContext->getSearchFields();
         $defaultFilters = $searchContext->getFilters();
-        $list = $gridField->getList();
 
         // Carry over any search form settings
         $basicSearchContext = BasicSearchContext::create($gridField->getModelClass());
@@ -498,41 +333,5 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
         }
 
         return $basicSearchContext;
-    }
-
-    /*
-     * Append a prefix to search field names to prevent conflicts with other fields in the search form
-     */
-    private function addSearchPrefixToFields(FieldList $fields): void
-    {
-        foreach ($fields as $field) {
-            $field->setName('Search__' . $field->getName());
-            if ($field instanceof CompositeField) {
-                $this->addSearchPrefixToFields($field->getChildren());
-            }
-        }
-    }
-
-    private function removeSearchPrefixFromFields(FieldList $fields): void
-    {
-        foreach ($fields as $field) {
-            $field->setName(str_replace('Search__', '', $field->getName()));
-            if ($field instanceof CompositeField) {
-                $this->removeSearchPrefixFromFields($field->getChildren());
-            }
-        }
-    }
-
-    /**
-     * Update CSS classes for form fields, including nested inside composite fields
-     */
-    private function updateFieldClasses(FieldList $fields): void
-    {
-        foreach ($fields as $field) {
-            $field->addExtraClass('stacked no-change-track');
-            if ($field instanceof CompositeField) {
-                $this->updateFieldClasses($field->getChildren());
-            }
-        }
     }
 }

--- a/src/Forms/Validation/CompositeValidator.php
+++ b/src/Forms/Validation/CompositeValidator.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Forms\Validation;
 
 use InvalidArgumentException;
 use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Forms\Form;
 
 /**
  * CompositeValidator can contain between 0 and many different types of Validators. Each Validator is itself still
@@ -51,11 +52,8 @@ class CompositeValidator extends Validator
 
     /**
      * Set the provided Form to the CompositeValidator and each Validator that has been added.
-     *
-     * @param Form $form
-     * @return Validator
      */
-    public function setForm($form)
+    public function setForm(Form $form): static
     {
         foreach ($this->getValidators() as $validator) {
             $validator->setForm($form);
@@ -203,6 +201,13 @@ class CompositeValidator extends Validator
         }
 
         return true;
+    }
+
+    public function __clone(): void
+    {
+        foreach ($this->validators as $key => $validator) {
+            $this->validators[$key] = clone $validator;
+        }
     }
 
     /**

--- a/src/Forms/Validation/Validator.php
+++ b/src/Forms/Validation/Validator.php
@@ -6,6 +6,7 @@ use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Forms\Form;
 
 /**
  * This validation class handles all form and custom form validation through the use of Required
@@ -23,10 +24,7 @@ abstract class Validator
         $this->resetResult();
     }
 
-    /**
-     * @var Form $form
-     */
-    protected $form;
+    protected Form $form;
 
     /**
      * @var ValidationResult $result
@@ -38,14 +36,15 @@ abstract class Validator
      */
     private $enabled = true;
 
-    /**
-     * @param Form $form
-     * @return $this
-     */
-    public function setForm($form)
+    public function setForm(Form $form): static
     {
         $this->form = $form;
         return $this;
+    }
+
+    public function getForm(): Form
+    {
+        return $this->form;
     }
 
     /**

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -4176,15 +4176,15 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
      * it is constructed here. Otherwise, the default filter specified in
      * {@link DBField} is used.
      *
-     * @return array
+     * @return SearchFilter[]
      */
-    public function defaultSearchFilters()
+    public function defaultSearchFilters(): array
     {
         $filters = [];
 
         foreach ($this->searchableFields() as $name => $spec) {
             if (empty($spec['filter'])) {
-                $filters[$name] = 'PartialMatchFilter';
+                $filters[$name] = Injector::inst()->create('PartialMatchFilter', $name);
             } elseif ($spec['filter'] instanceof SearchFilter) {
                 $filters[$name] = $spec['filter'];
             } else {

--- a/src/ORM/Search/SearchContext.php
+++ b/src/ORM/Search/SearchContext.php
@@ -18,6 +18,7 @@ use SilverStripe\Forms\CheckboxField;
 use InvalidArgumentException;
 use Exception;
 use LogicException;
+use SilverStripe\Control\Controller;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\DateField;
 use SilverStripe\ORM\DataQuery;
@@ -225,10 +226,8 @@ class SearchContext
 
     /**
      * Takes a search phrase or search term and searches for it across all searchable fields.
-     *
-     * @param string|array $searchPhrase
      */
-    private function generalSearchAcrossFields($searchPhrase, DataQuery $subGroup, array $searchableFields): void
+    protected function generalSearchAcrossFields(string|array $searchPhrase, DataQuery $subGroup, array $searchableFields): void
     {
         $formFields = $this->getSearchFields();
         foreach ($searchableFields as $field => $spec) {
@@ -300,7 +299,7 @@ class SearchContext
      * @param string|array $searchPhrase
      * @return DataList<T>
      */
-    private function individualFieldSearch(DataList $query, array $searchableFields, string $searchField, $searchPhrase): DataList
+    protected function individualFieldSearch(DataList $query, array $searchableFields, string $searchField, $searchPhrase): DataList
     {
         $filter = $this->getFilter($searchField);
         if (!$filter) {
@@ -344,7 +343,7 @@ class SearchContext
     /**
      * Apply a SearchFilter to a DataQuery for a given field's specifications
      */
-    private function applyFilter(SearchFilter $filter, DataQuery $dataQuery, array $searchableFieldSpec): void
+    protected function applyFilter(SearchFilter $filter, DataQuery $dataQuery, array $searchableFieldSpec): void
     {
         if ($filter->isEmpty()) {
             return;
@@ -513,6 +512,11 @@ class SearchContext
     public function getSearchParams()
     {
         return $this->searchParams;
+    }
+
+    public function getModelClass(): string
+    {
+        return $this->modelClass;
     }
 
     /**

--- a/src/ORM/Search/SearchContextForm.php
+++ b/src/ORM/Search/SearchContextForm.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace SilverStripe\ORM\Search;
+
+use SilverStripe\Control\RequestHandler;
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Forms\CompositeField;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridField_FormAction;
+use SilverStripe\Forms\GridField\GridFieldFilterHeader;
+use SilverStripe\ORM\FieldType\DBHTMLText;
+use SilverStripe\View\SSViewer;
+
+/**
+ * A form for using a search context in the CMS.
+ *
+ * Note that the form submission goes through to the index action of the controller by default,
+ * and is intended to return the same markup you would ordinarily get for that controller but with
+ * the results filtered appropriately.
+ */
+class SearchContextForm extends Form
+{
+    private SearchContext $searchContext;
+
+    private ?string $searchField = null;
+
+    private static $casting = [
+        'SchemaData' => 'Text',
+        'getSchemaData' => 'Text',
+    ];
+
+    public function __construct(RequestHandler $controller, SearchContext $searchContext, $name = 'SearchForm')
+    {
+        $this->searchContext = $searchContext;
+        // Need to clone the fields so when we update their names we don't alter the search context fields.
+        $searchFields = clone $searchContext->getSearchFields();
+        $this->setDefaultSearchField($searchFields, $controller);
+        $this->prepareSearchFieldsForCMS($searchFields);
+        parent::__construct($controller, $name, $searchFields);
+        $this->setHTMLID(ClassInfo::shortName($controller) . '_' . $name);
+        // This form is not tied to session so we disable the CSRF token
+        $this->disableSecurityToken();
+        $this->setFormMethod('GET');
+        $this->setFormAction($controller->Link());
+        $this->addExtraClass('cms-search-form');
+
+        // Load the form with previously set search data if any
+        $this->loadDataFrom($searchContext->getSearchParams());
+    }
+
+    public function setSearchField(string $fieldName): static
+    {
+        $this->searchField = $fieldName;
+        return $this;
+    }
+
+    public function getSearchField(): string
+    {
+        return $this->searchField;
+    }
+
+    /**
+     * Get the schema for this search context for use in the CMS search filter form.
+     * Note that this is not the same as the form schema (i.e. it includes no information about form fields).
+     */
+    public function getSchemaData(): array
+    {
+        $formSchemaUrl = $this->getRequestHandler()->Link('schema');
+        $singleton = singleton($this->searchContext->getModelClass());
+
+        // Prefix "Search__" onto the search params to match the field names in the actual form
+        $searchParams = $this->searchContext->getSearchParams();
+        if (!empty($searchParams)) {
+            $searchParams = array_combine(array_map(function ($key) {
+                return 'Search__' . $key;
+            }, array_keys($searchParams ?? [])), $searchParams ?? []);
+        }
+
+        $schema = [
+            'formSchemaUrl' => $formSchemaUrl,
+            'name' => $this->getSearchField(),
+            // stdClass will map to empty json object '{}' when encoded
+            'filters' => $searchParams ?: new \stdClass()
+        ];
+
+        // GridField has some special requirements to ensure the "state" of the filter header is updated
+        $parentRequestHandler = $this->getController();
+        if ($parentRequestHandler instanceof GridField) {
+            $searchAction = GridField_FormAction::create($parentRequestHandler, 'filter', false, 'filter', null);
+            $clearAction = GridField_FormAction::create($parentRequestHandler, 'reset', false, 'reset', null);
+            $schema = array_merge($schema, [
+                'gridfield' => $parentRequestHandler->getName(),
+                'searchAction' => $searchAction->getAttribute('name'),
+                'clearAction' => $clearAction->getAttribute('name'),
+            ]);
+            $filterHeader = $parentRequestHandler->getConfig()->getComponentByType(GridFieldFilterHeader::class);
+            if ($filterHeader) {
+                $placeholder = $filterHeader->getPlaceHolderText();
+                if ($placeholder) {
+                    $schema['placeholder'] = $placeholder;
+                }
+            }
+        }
+
+        if (!isset($schema['placeholder'])) {
+            $schema['placeholder'] = _t(
+                __CLASS__ . '.FILTERLABELTEXT',
+                'Search "{model}"',
+                ['model' => ClassInfo::hasMethod($singleton, 'i18n_plural_name') ? $singleton->i18n_plural_name() : ClassInfo::shortName($singleton)]
+            );
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Get the rendered placeholder with schema data required for generating the search filter form in the CMS
+     */
+    public function getPlaceHolder(bool $isFiltered): DBHTMLText
+    {
+        $templateCandidates = SSViewer::get_templates_by_class(static::class, '_Placeholder', __CLASS__);
+        return $this->renderWith($templateCandidates, ['IsFiltered' => $isFiltered]);
+    }
+
+    /**
+     * Get the rendered search filter button which toggles display of the search filter form in the CMS
+     */
+    public function getFilterButton(bool $isFiltered): DBHTMLText
+    {
+        $templateCandidates = SSViewer::get_templates_by_class(static::class, '_Button', __CLASS__);
+        return $this->renderWith($templateCandidates, ['IsFiltered' => $isFiltered]);
+    }
+
+    /**
+     * Takes raw values submitted e.g. via AJAX and pulls them through FormField instances.
+     * This allows form fields such as CurrencyField to make any relevant adjustments prior to using
+     * the values in the SearchContext database comparisons.
+     */
+    public function prepareValuesForSearchContext(array $values): array
+    {
+        // Use a close so we don't alter the value of fields in the current form
+        $form = clone $this;
+        $this->removeSearchPrefixFromFields($form->Fields());
+        $form->loadDataFrom($values);
+
+        // Get the values from the form where possible, as form fields may transform the value for DB comparisons
+        foreach ($values as $fieldName => $rawFilterValue) {
+            $values[$fieldName] = $form->Fields()->dataFieldByName($fieldName)?->dataValue() ?? $rawFilterValue;
+        }
+
+        return $values;
+    }
+
+    /**
+     * Sets the default general_search_field based on configuration or the first available form field.
+     * Must be called before prepareSearchFieldsForCMS() which alters the field names.
+     */
+    private function setDefaultSearchField(FieldList $fields, RequestHandler $controller): void
+    {
+        $searchField = null;
+        if ($controller instanceof GridField) {
+            // Check for a specific search field via gridfield
+            $filterHeader = $controller->getConfig()->getComponentByType(GridFieldFilterHeader::class);
+            if ($filterHeader) {
+                $searchField = $filterHeader->getSearchField();
+            }
+        }
+        if (!$searchField) {
+            // Check for a general search field on the model
+            $modelClass = $this->searchContext->getModelClass();
+            $searchField = $modelClass::config()->get('general_search_field');
+        }
+        if (!$searchField) {
+            // Fall back on the first defined FormField
+            $searchField = $fields->first();
+            $searchField = $searchField && property_exists($searchField, 'name') ? $searchField->name : '';
+        }
+        $this->setSearchField($searchField ?? '');
+    }
+
+    /**
+     * Prepares search fields for use in the CMS.
+     *
+     * - Appends a prefix to search field names to prevent conflicts with other fields in the search form
+     * - Adds appropriate CSS classes
+     */
+    private function prepareSearchFieldsForCMS(FieldList $fields): void
+    {
+        foreach ($fields as $field) {
+            $field->addExtraClass('stacked');
+            $field->setName('Search__' . $field->getName());
+            if ($field instanceof CompositeField) {
+                $this->prepareSearchFieldsForCMS($field->getChildren());
+            }
+        }
+    }
+
+    /**
+     * Remove the Search__ prefix from form field names so we can match them directly with submitted fields.
+     */
+    private function removeSearchPrefixFromFields(FieldList $fields): void
+    {
+        foreach ($fields as $field) {
+            $field->setName(str_replace('Search__', '', $field->getName()));
+            if ($field instanceof CompositeField) {
+                $this->removeSearchPrefixFromFields($field->getChildren());
+            }
+        }
+    }
+}

--- a/templates/SilverStripe/Forms/GridField/GridFieldFilterHeader_Row.ss
+++ b/templates/SilverStripe/Forms/GridField/GridFieldFilterHeader_Row.ss
@@ -1,7 +1,0 @@
-<% if $Fields %>
-    <tr class="grid-field__filter-header grid-field__search-holder--hidden">
-	   <% loop $Fields %>
-	       <th class="extra">$Field</th>
-	   <% end_loop %>
-    </tr>
-<% end_if %>

--- a/templates/SilverStripe/Forms/GridField/GridFieldFilterHeader_Search.ss
+++ b/templates/SilverStripe/Forms/GridField/GridFieldFilterHeader_Search.ss
@@ -1,1 +1,0 @@
-<div class="search-holder grid-field__search-holder grid-field__search-holder--hidden" data-schema="$SearchFieldSchema"></div>

--- a/templates/SilverStripe/ORM/Search/SearchContextForm_Button.ss
+++ b/templates/SilverStripe/ORM/Search/SearchContextForm_Button.ss
@@ -1,0 +1,9 @@
+<div class="view-controls">
+    <% if not $IsFiltered %>
+        <button type="button" name="showFilter" aria-controls="$HTMLID"
+            class="btn btn-secondary icon-button font-icon-search btn--icon-large btn--no-text"
+            title="<%t SilverStripe\ORM\Search\SearchContextForm.OpenFilter 'Open search and filter' %>"
+            aria-label="<%t SilverStripe\ORM\Search\SearchContextForm.OpenFilter 'Open search and filter' %>"
+        ></button>
+    <% end_if %>
+</div>

--- a/templates/SilverStripe/ORM/Search/SearchContextForm_Placeholder.ss
+++ b/templates/SilverStripe/ORM/Search/SearchContextForm_Placeholder.ss
@@ -1,0 +1,3 @@
+<div id="$HTMLID" class="cms-content-filters<% if not $IsFiltered %> cms-content-filters--hidden<% end_if %>">
+    <div class="search-holder search-holder--cms" data-schema="$SchemaData.JSON"></div>
+</div>

--- a/tests/php/Forms/FormTest.php
+++ b/tests/php/Forms/FormTest.php
@@ -39,9 +39,12 @@ use SilverStripe\Forms\GridField\GridFieldDetailForm;
 use SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest;
 use SilverStripe\Security\MemberAuthenticator\LostPasswordHandler;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\SudoModePasswordField;
 use SilverStripe\Security\SudoMode\SudoModeServiceInterface;
 use SilverStripe\Forms\ReadonlyField;
+use SilverStripe\Forms\Validation\CompositeValidator;
+use SilverStripe\Forms\Validation\RequiredFieldsValidator;
 
 class FormTest extends FunctionalTest
 {
@@ -1420,5 +1423,221 @@ class FormTest extends FunctionalTest
         } else {
             $this->assertNotEmpty($messages);
         }
+    }
+
+    /**
+     * Test cloning a form deep clones all its fields, actions, and validators.
+     */
+    public function testClone()
+    {
+        $fields = new FieldList([
+            $field1 = new CompositeField([
+                $field2 = new TextField('my-text-field', value: '123'),
+            ]),
+            $field3 = new LiteralField('literal-test', 'some content'),
+        ]);
+        $actions = new FieldList([
+            $action1 = new FormAction('some-action', 'action name'),
+        ]);
+        $validator = new CompositeValidator([
+            $childValidator1 = new RequiredFieldsValidator(['Field1', 'FieldTwo']),
+            $childValidator2 = new CompositeValidator([
+                $childValidator3 = new RequiredFieldsValidator(['Field3', 'FieldFour']),
+            ]),
+        ]);
+        $form = new Form(fields: $fields, actions: $actions, validator: $validator);
+
+        $clone = clone $form;
+
+        // Ensure clones look the same but aren't the same object
+        $this->assertNotSame($clone, $form);
+        $originalFormValues = [
+            $form->getName(),
+            $form->getAttributes(),
+            $form->extraClass(),
+        ];
+        $this->assertSame(
+            $originalFormValues,
+            [
+                $clone->getName(),
+                $clone->getAttributes(),
+                $clone->extraClass(),
+            ]
+        );
+        // Test fields
+        $cloneFields = $clone->Fields();
+        $this->assertNotSame($fields, $cloneFields);
+        $cloneField1 = $cloneFields->first();
+        $cloneField2 = $cloneField1->getChildren()->first();
+        $cloneField3 = $cloneFields->last();
+        $this->assertNotSame($field1, $cloneField1);
+        $this->assertNotSame($field2, $cloneField2);
+        $this->assertNotSame($field3, $cloneField3);
+        // Test actions
+        $cloneActions = $clone->Actions();
+        $this->assertNotSame($actions, $cloneActions);
+        $cloneAction1 = $cloneActions->first();
+        $this->assertNotSame($action1, $cloneAction1);
+        // Test validators
+        /** @var CompositeValidator $cloneValidator */
+        $cloneValidator = $clone->getValidator();
+        $cloneChildValidator1 = $cloneValidator->getValidators()[0];
+        $cloneChildValidator2 = $cloneValidator->getValidators()[1];
+        $cloneChildValidator3 = $cloneChildValidator2->getValidators()[0];
+        $this->assertNotSame($validator, $cloneValidator);
+        $this->assertNotSame($childValidator1, $cloneChildValidator1);
+        $this->assertNotSame($childValidator2, $cloneChildValidator2);
+        $this->assertNotSame($childValidator3, $cloneChildValidator3);
+        $this->assertSame(
+            [
+                $childValidator1->getRequired(),
+                $childValidator3->getRequired(),
+            ],
+            [
+                $cloneChildValidator1->getRequired(),
+                $cloneChildValidator3->getRequired(),
+            ]
+        );
+
+        // Ensure everything belongs to the right form
+        // Note FieldList doesn't have a concept of belonging to a form
+        $items = [
+            'orig' => [
+                $field1,
+                $field2,
+                $field3,
+                $action1,
+                $validator,
+                $childValidator1,
+                $childValidator2,
+                $childValidator3,
+            ],
+            'clone' => [
+                $cloneField1,
+                $cloneField2,
+                $cloneField3,
+                $cloneAction1,
+                $cloneValidator,
+                $cloneChildValidator1,
+                $cloneChildValidator2,
+                $cloneChildValidator3,
+            ],
+        ];
+        foreach ($items as $type => $list) {
+            $owner = $type === 'orig' ? $form : $clone;
+            foreach ($list as $item) {
+                $this->assertSame($owner, $item->getForm());
+            }
+        }
+
+        // Ensure changes don't affect original
+        $clone->removeExtraClass('booger')
+            ->addExtraClass('wigwam')
+            ->setName('my-form')
+            ->setAttribute('data-test', 'value2');
+        $this->assertSame(
+            $originalFormValues,
+            [
+                $form->getName(),
+                $form->getAttributes(),
+                $form->extraClass(),
+            ],
+        );
+        $this->assertSame(
+            [
+                'my-form',
+                array_merge(
+                    $form->getAttributes(),
+                    [
+                        'id' => 'Form_my-form',
+                        'class' => 'wigwam',
+                        'data-test' => 'value2',
+                    ]
+                ),
+                'wigwam',
+            ],
+            [
+                $clone->getName(),
+                $clone->getAttributes(),
+                $clone->extraClass(),
+            ]
+        );
+        // Test fields
+        $cloneField2->setValue('abba')->setName('text-field-clone');
+        $cloneField3->setContent('My literal content');
+        $this->assertSame(
+            [
+                'my-text-field',
+                '123',
+                'some content',
+            ],
+            [
+                $field2->getName(),
+                $field2->getValue(),
+                $field3->getContent(),
+            ]
+        );
+        $this->assertSame(
+            [
+                'text-field-clone',
+                'abba',
+                'My literal content',
+            ],
+            [
+                $cloneField2->getName(),
+                $cloneField2->getValue(),
+                $cloneField3->getContent(),
+            ]
+        );
+        // Test actions
+        $cloneAction1->setName('my-new-name')->setTitle('another name');
+        $this->assertSame(
+            [
+                'action_some-action',
+                'action name',
+            ],
+            [
+                $action1->getName(),
+                $action1->Title(),
+            ]
+        );
+        $this->assertSame(
+            [
+                'my-new-name',
+                'another name',
+            ],
+            [
+                $cloneAction1->getName(),
+                $cloneAction1->Title(),
+            ]
+        );
+        // Test validators
+        $cloneValidator->removeValidatorsByType(RequiredFieldsValidator::class);
+        $cloneChildValidator3->removeRequiredField('FieldFour')->addRequiredField('Field5');
+        $this->assertSame(
+            [
+                $childValidator1,
+                $childValidator2,
+            ],
+            $validator->getValidators()
+        );
+        $this->assertSame(
+            [1 => $cloneChildValidator2],
+            $cloneValidator->getValidators()
+        );
+        $this->assertSame(
+            [
+                'Field3',
+                'FieldFour',
+            ],
+            $childValidator3->getRequired()
+        );
+        $this->assertSame(
+            [
+                'Field3',
+                'Field5',
+            ],
+            $cloneChildValidator3->getRequired()
+        );
     }
 }

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -4,8 +4,10 @@ namespace SilverStripe\Forms\Tests\GridField;
 
 use LogicException;
 use ReflectionMethod;
+use ReflectionProperty;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\CSSContentParser;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
@@ -78,73 +80,15 @@ class GridFieldFilterHeaderTest extends SapphireTest
      */
     public function testRenderHeaders()
     {
-        $htmlFragment = $this->component->getHTMLFragments($this->gridField);
+        $htmlFragments = $this->component->getHTMLFragments($this->gridField);
+        $beforeParser = new CSSContentParser($htmlFragments['before']);
+        // Just check some key elements are there - the rest of the details we entrust to the SearchContextForm.
+        $this->assertNotEmpty($beforeParser->getBySelector('#GridField_testfield_SearchForm'));
+        $this->assertNotEmpty($beforeParser->getBySelector('.search-holder'));
 
-        // Check that the output is the new search field
-        $this->assertStringContainsString('<div class="search-holder grid-field__search-holder grid-field__search-holder--hidden"', $htmlFragment['before']);
-        $this->assertStringContainsString('Open search and filter', $htmlFragment['buttons-before-right']);
-    }
 
-    public function testSearchFieldSchema()
-    {
-        $searchSchema = json_decode($this->component->getSearchFieldSchema($this->gridField) ?? '');
-        $modelClass = $this->gridField->getModelClass();
-        /** @var DataObject $obj */
-        $obj = new $modelClass();
-
-        $this->assertEquals('field/testfield/schema/SearchForm', $searchSchema->formSchemaUrl);
-        $this->assertEquals($obj->getGeneralSearchFieldName(), $searchSchema->name);
-        $this->assertEquals('Search "Teams"', $searchSchema->placeholder);
-        $this->assertEquals(new \stdClass, $searchSchema->filters);
-
-        $request = new HTTPRequest(
-            'POST',
-            'field/testfield',
-            [],
-            [
-                'filter' => [
-                    'testfield' => [
-                        'Name' => 'test',
-                        'City' => 'place'
-                    ]
-                ],
-            ]
-        );
-        $this->gridField->setRequest($request);
-        $searchSchema = json_decode($this->component->getSearchFieldSchema($this->gridField) ?? '');
-        $modelClass = $this->gridField->getModelClass();
-        /** @var DataObject $obj */
-        $obj = new $modelClass();
-
-        $this->assertEquals('field/testfield/schema/SearchForm', $searchSchema->formSchemaUrl);
-        $this->assertEquals($obj->getGeneralSearchFieldName(), $searchSchema->name);
-        $this->assertEquals('Search "Teams"', $searchSchema->placeholder);
-        $this->assertEquals('test', $searchSchema->filters->Search__Name);
-        $this->assertEquals('place', $searchSchema->filters->Search__City);
-        $this->assertEquals('testfield', $searchSchema->gridfield);
-    }
-
-    /**
-     * Tests the private method that returns the placeholder for the search field
-     */
-    public function testGetPlaceHolder()
-    {
-        $gridField = new GridField('test');
-        $filterHeader = new GridFieldFilterHeader();
-        $reflectionGetPlaceHolder = new ReflectionMethod($filterHeader, 'getPlaceHolder');
-        $reflectionGetPlaceHolder->setAccessible(true);
-
-        // No explicit placeholder or model i18n_plural_name method
-        $this->assertSame('Search "ArrayData"', $reflectionGetPlaceHolder->invoke($filterHeader, new ArrayData()));
-
-        // No explicit placeholder, but model has i18n_plural_name method
-        $model = new DataObject();
-        $this->assertSame('Search "' . $model->i18n_plural_name() . '"', $reflectionGetPlaceHolder->invoke($filterHeader, $model));
-
-        // Explicit placeholder is set, which overrides both of the above cases
-        $filterHeader->setPlaceHolderText('This is the text');
-        $this->assertSame('This is the text', $reflectionGetPlaceHolder->invoke($filterHeader, $model));
-        $this->assertSame('This is the text', $reflectionGetPlaceHolder->invoke($filterHeader, new ArrayData()));
+        $beforeRightParser = new CSSContentParser($htmlFragments['buttons-before-right']);
+        $this->assertNotEmpty($beforeRightParser->getBySelector('.view-controls button["showFilter"]'));
     }
 
     public function testHandleActionReset()
@@ -183,28 +127,33 @@ class GridFieldFilterHeaderTest extends SapphireTest
         $this->assertEquals('Search__TestCompositeNested', $fields[7]->Name);
         // Make sure there aren't additional fields we're not testing for
         $this->assertCount(8, $fields);
-        $this->assertEquals('TeamsSearchForm', $searchForm->Name);
+        $this->assertEquals('GridField_testfield_SearchForm', $searchForm->getHTMLID());
         $this->assertTrue($searchForm->hasExtraClass('cms-search-form'));
         foreach ($fields as $field) {
             $this->assertTrue($field->hasExtraClass('stacked'));
-            $this->assertTrue($field->hasExtraClass('no-change-track'));
         }
     }
 
     public function testCustomSearchField()
     {
-        $searchSchema = json_decode($this->component->getSearchFieldSchema($this->gridField));
+        $reflectionForm = new ReflectionProperty($this->component, 'searchForm');
+        $form = $this->component->getSearchForm($this->gridField);
+        $searchSchema = $form->getSchemaData();
         $modelClass = $this->gridField->getModelClass();
         $obj = new $modelClass();
-        $this->assertEquals($obj->getGeneralSearchFieldName(), $searchSchema->name);
+        $this->assertEquals($obj->getGeneralSearchFieldName(), $searchSchema['name']);
 
         Config::modify()->set(Team::class, 'general_search_field', 'CustomSearch');
-        $searchSchema = json_decode($this->component->getSearchFieldSchema($this->gridField));
-        $this->assertEquals('CustomSearch', $searchSchema->name);
+        $reflectionForm->setValue($this->component, null);
+        $form = $this->component->getSearchForm($this->gridField);
+        $searchSchema = $form->getSchemaData();
+        $this->assertEquals('CustomSearch', $searchSchema['name']);
 
         $this->component->setSearchField('ReallyCustomSearch');
-        $searchSchema = json_decode($this->component->getSearchFieldSchema($this->gridField));
-        $this->assertEquals('ReallyCustomSearch', $searchSchema->name);
+        $reflectionForm->setValue($this->component, null);
+        $form = $this->component->getSearchForm($this->gridField);
+        $searchSchema = $form->getSchemaData();
+        $this->assertEquals('ReallyCustomSearch', $searchSchema['name']);
 
         $this->assertEquals('ReallyCustomSearch', $this->component->getSearchField());
     }

--- a/tests/php/Forms/GridField/GridFieldReadonlyTest.php
+++ b/tests/php/Forms/GridField/GridFieldReadonlyTest.php
@@ -110,7 +110,8 @@ class GridFieldReadonlyTest extends SapphireTest
 
         // assert that all the components in the readonly version are present in the whitelist.
         foreach ($readonlyGridField->getConfig()->getComponents() as $component) {
-            $this->assertTrue(in_array(get_class($component), $readonlyComponents ?? []));
+            $componentClass = get_class($component);
+            $this->assertTrue(in_array($componentClass, $readonlyComponents), 'should have ' . $componentClass);
         }
     }
 }

--- a/tests/php/Forms/GridField/GridFieldTest.php
+++ b/tests/php/Forms/GridField/GridFieldTest.php
@@ -33,6 +33,7 @@ use SilverStripe\Forms\Tests\GridField\GridFieldTest\Team;
 use SilverStripe\Forms\Tests\ValidatorTest\TestValidator;
 use SilverStripe\Model\List\ArrayList;
 use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Forms\GridField\GridFieldConfig_Base;
 use SilverStripe\Security\Group;
 use SilverStripe\Security\Member;
 
@@ -618,5 +619,21 @@ class GridFieldTest extends SapphireTest
             $gridField->addAllStateToUrl($link),
             '/class-name/item/1?gridState-Test%5BState%5D%5BColumn%5D=Name'
         );
+    }
+
+    /**
+     * Test that cloning a GridField deep clones the components
+     */
+    public function testClone()
+    {
+        $config = new GridFieldConfig_Base();
+        $gridField = new GridField('my-gridfield', config: $config);
+        $clone = clone $gridField;
+
+        $this->assertNotSame($gridField, $clone);
+        $this->assertNotSame($config, $clone->getConfig());
+        foreach ($config->getComponents() as $component) {
+            $this->assertNotSame($component, $clone->getConfig()->getComponentsByType(get_class($component)));
+        }
     }
 }

--- a/tests/php/Forms/ValidatorTest/TestValidator.php
+++ b/tests/php/Forms/ValidatorTest/TestValidator.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\Forms\Tests\ValidatorTest;
 
 use SilverStripe\Dev\TestOnly;
-use SilverStripe\Forms\Form;
 use SilverStripe\Forms\Validation\Validator;
 
 class TestValidator extends Validator implements TestOnly
@@ -22,15 +21,5 @@ class TestValidator extends Validator implements TestOnly
         }
 
         return null;
-    }
-
-    /**
-     * Allow us to access the form for test purposes.
-     *
-     * @return Form|null
-     */
-    public function getForm(): ?Form
-    {
-        return $this->form;
     }
 }

--- a/tests/php/ORM/Search/SearchContextFormTest/TestController.php
+++ b/tests/php/ORM/Search/SearchContextFormTest/TestController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Search\SearchContextFormTest;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Dev\TestOnly;
+
+class TestController extends Controller implements TestOnly
+{
+    private static $url_segment = 'my-path';
+}

--- a/tests/php/ORM/Search/SearchContextFormText.php
+++ b/tests/php/ORM/Search/SearchContextFormText.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Search;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridField_FormAction;
+use SilverStripe\Forms\GridField\GridFieldConfig_Base;
+use SilverStripe\Forms\GridField\GridFieldFilterHeader;
+use SilverStripe\ORM\Search\SearchContext;
+use SilverStripe\ORM\Search\SearchContextForm;
+use SilverStripe\ORM\Tests\Search\SearchContextTest;
+use SilverStripe\ORM\Tests\Search\SearchContextFormTest\TestController;
+
+class SearchContextFormText extends SapphireTest
+{
+    protected static $extra_dataobjects = [
+        SearchContextTest\Action::class,
+    ];
+
+    public static function provideGetSchemaData(): array
+    {
+        return [
+            'standard controller' => [
+                'controllerClass' => TestController::class,
+                'modelClass' => SearchContextTest\Action::class,
+                // Note placeholder can only be customised with gridfields
+                'placeholder' => null,
+                'expected' => [
+                    'formSchemaUrl' => 'my-path/SearchForm/schema',
+                    'name' => 'q',
+                    'filters' => new \stdClass,
+                    'placeholder' => 'Search "Actions"',
+                ],
+            ],
+            'standard controller - no general search' => [
+                'controllerClass' => TestController::class,
+                'modelClass' => SearchContextTest\Book::class,
+                'placeholder' => null,
+                'expected' => [
+                    'formSchemaUrl' => 'my-path/SearchForm/schema',
+                    'name' => 'Title',
+                    'filters' => new \stdClass,
+                    'placeholder' => 'Search "Books"',
+                ],
+            ],
+            'gridfield as controller' => [
+                'controllerClass' => GridField::class,
+                'modelClass' => SearchContextTest\Action::class,
+                'placeholder' => null,
+                'expected' => [
+                    'formSchemaUrl' => 'field/my-field/SearchForm/schema',
+                    'name' => 'q',
+                    'filters' => new \stdClass,
+                    'placeholder' => 'Search "Actions"',
+                    'gridfield' => 'my-field',
+                    // Action values are dynamic and will be set in the test below.
+                    'searchAction' => '',
+                    'clearAction' => '',
+                ],
+            ],
+            'gridfield as controller - no general search with custom placeholder' => [
+                'controllerClass' => GridField::class,
+                'modelClass' => SearchContextTest\Book::class,
+                'placeholder' => 'My custom placeholder',
+                'expected' => [
+                    'formSchemaUrl' => 'field/my-field/SearchForm/schema',
+                    'name' => 'Title',
+                    'filters' => new \stdClass,
+                    'placeholder' => 'My custom placeholder',
+                    'gridfield' => 'my-field',
+                    // Action values are dynamic and will be set in the test below.
+                    'searchAction' => '',
+                    'clearAction' => '',
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetSchemaData')]
+    public function testGetSchemaData(string $controllerClass, string $modelClass, ?string $placeholder, array $expected): void
+    {
+        if ($controllerClass === GridField::class) {
+            $controller = new GridField('my-field', config: new GridFieldConfig_Base());
+            $form = new Form();
+            $controller->setForm($form);
+            $searchAction = new GridField_FormAction($controller, 'filter', false, 'filter', null);
+            $clearAction = new GridField_FormAction($controller, 'reset', false, 'reset', null);
+            $expected['searchAction'] = $searchAction->getAttribute('name');
+            $expected['clearAction'] = $clearAction->getAttribute('name');
+            if ($placeholder) {
+                $controller->getConfig()->getComponentByType(GridFieldFilterHeader::class)->setPlaceHolderText($placeholder);
+            }
+        } else {
+            $controller = new $controllerClass();
+        }
+        $form = new SearchContextForm($controller, new SearchContext($modelClass));
+        $searchSchema = $form->getSchemaData();
+
+        $this->assertEquals($expected, $searchSchema);
+    }
+
+    public function testGetSchemaDataIncludesFilters(): void
+    {
+        $context = new SearchContext(SearchContextTest\Action::class);
+        $context->setSearchParams(['q' => 'test', 'Title' => 'some title']);
+        $form = new SearchContextForm(new TestController(), $context);
+        $searchSchema = $form->getSchemaData();
+
+        $this->assertEquals(
+            [
+                'formSchemaUrl' => 'my-path/SearchForm/schema',
+                'name' => 'q',
+                'filters' => ['Search__q' => 'test', 'Search__Title' => 'some title'],
+                'placeholder' => 'Search "Actions"',
+            ],
+            $searchSchema,
+        );
+    }
+}

--- a/tests/php/ORM/Search/SearchContextTest/Book.php
+++ b/tests/php/ORM/Search/SearchContextTest/Book.php
@@ -13,4 +13,6 @@ class Book extends DataObject implements TestOnly
         'Title' => 'Varchar',
         'Summary' => 'Varchar'
     ];
+
+    private static string $general_search_field_name = '';
 }


### PR DESCRIPTION
CMSMain had different search filter code paths than the grid field search filter, and there was a lot of duplication of code. This commit works alongside the PR in silverstripe/silverstripe-cms to unify those code paths

## Issue

- https://github.com/silverstripe/silverstripe-cms/issues/2949