### PR TITLE
FEAT add sortByField and remove mysql specific code from DataList

### DIFF
--- a/src/ORM/Connect/Database.php
+++ b/src/ORM/Connect/Database.php
@@ -954,4 +954,26 @@ abstract class Database
      * @return string Expression for a random value
      */
     abstract public function random();
+
+    /**
+     * Generate SQL for sorting by a specific field using CASE logic.
+     *
+     * Subclasses can override this method to provide optimized implementations
+     * (e.g., using MySQL's FIELD method).
+     *
+     * @param string $field The name of the field to sort by.
+     * @param array $values The values to order by.
+     * @return string SQL snippet for ordering.
+     */
+    public function sortByField(string $field, array $values): string
+    {
+        $caseStatements = [];
+        foreach ($values as $index => $value) {
+            $escaped = is_int($value) ? $value : "'" . addslashes($value) . "'";
+            $caseStatements[] = "CASE {$field} = {$escaped} THEN {$index}";
+        }
+        $count = count($caseStatements);
+        $sqlCase = implode(' ', $caseStatements);
+        return "CASE {$sqlCase} ELSE {$count} END";
+    }
 }

--- a/src/ORM/Connect/MySQLDatabase.php
+++ b/src/ORM/Connect/MySQLDatabase.php
@@ -586,4 +586,22 @@ class MySQLDatabase extends Database implements TransactionManager
             $this->query("ALTER TABLE \"$table\" AUTO_INCREMENT = 1");
         }
     }
+
+    /**
+     * Generate SQL for sorting by a specific field using MySQL's FIELD function.
+     *
+     * @param string $field The name of the field to sort by.
+     * @param array $values The values to order by.
+     * @return string SQL snippet for ordering.
+     */
+    public function sortByField(string $field, array $values): string
+    {
+        $escapedValues = [];
+        foreach ($values as $value) {
+            $escaped = is_int($value) ? $value : "'" . addslashes($value) . "'";
+            $escapedValues[] = $escaped;
+        }
+        $sqlIds = implode(',', $escapedValues);
+        return "FIELD({$field}, {$sqlIds})";
+    }
 }

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1374,16 +1374,21 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
         // Note that $joinRows also holds extra fields data
         $joinRows = [];
         if (!empty($parentIDs) && !empty($fetchedIDs)) {
-            $fetchedIDsAsString = implode(',', $fetchedIDs);
-            $joinRows = DB::query(
+            // Use sortByField to generate the ORDER BY clause
+            $orderByClause = DB::get_conn()->sortByField($childIDField, $fetchedIDs);
+
+            $joinQuery = DB::query(
                 'SELECT * FROM "' . $joinTable
                 // Only get joins relevant for the parent list
                 . '" WHERE "' . $parentIDField . '" IN (' . implode(',', $parentIDs) . ')'
                 // Exclude any children that got filtered out
-                . ' AND ' . $childIDField . ' IN (' . $fetchedIDsAsString . ')'
+                . ' AND ' . $childIDField . ' IN (' . implode(',', $fetchedIDs) . ')'
                 // Respect sort order of fetched items
-                . ' ORDER BY FIELD(' . $childIDField . ', ' . $fetchedIDsAsString . ')'
+                . ' ORDER BY ' . $orderByClause
             );
+
+            // Execute the query
+            $joinRows = DB::query($joinQuery);
         }
 
         // Store the children in an EagerLoadedList against the correct parent

--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -1377,15 +1377,14 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
             // Use sortByField to generate the ORDER BY clause
             $orderByClause = DB::get_conn()->sortByField($childIDField, $fetchedIDs);
 
-            $joinQuery = DB::query(
-                'SELECT * FROM "' . $joinTable
+            // Build the query with the order clause
+            $joinQuery = 'SELECT * FROM "' . $joinTable
                 // Only get joins relevant for the parent list
                 . '" WHERE "' . $parentIDField . '" IN (' . implode(',', $parentIDs) . ')'
                 // Exclude any children that got filtered out
                 . ' AND ' . $childIDField . ' IN (' . implode(',', $fetchedIDs) . ')'
                 // Respect sort order of fetched items
-                . ' ORDER BY ' . $orderByClause
-            );
+                . ' ORDER BY ' . $orderByClause;
 
             // Execute the query
             $joinRows = DB::query($joinQuery);


### PR DESCRIPTION
## Description
This is an alternative proposal to https://github.com/silverstripe/silverstripe-framework/pull/11509

This is based on the work of @LennyObez with some improvements (avoid hardcoded 999, don't escape integer)

## Manual testing steps
Create and populate two DataObjects that have a many_many relation between them
Perform an eagerLoad on DataObject::get() and convert the result to an array
Observe that the new sortByField method is used

## Issues
https://github.com/silverstripe/silverstripe-framework/issues/11503

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
