### PR TITLE
FIX Don't make queries if no custom config is set

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1705,6 +1705,12 @@ class Member extends DataObject
         $currentName = '';
         $currentPriority = 0;
 
+        // If we don't have a custom config, no need to look in all groups
+        $editorConfigMap = HTMLEditorConfig::get_available_configs_map();
+        if (count($editorConfigMap) === 1 && isset($editorConfigMap['cms'])) {
+            return 'cms';
+        }
+
         foreach ($this->Groups() as $group) {
             $configName = $group->HtmlEditorConfig;
             if ($configName) {

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -1707,8 +1707,12 @@ class Member extends DataObject
 
         // If we don't have a custom config, no need to look in all groups
         $editorConfigMap = HTMLEditorConfig::get_available_configs_map();
-        if (count($editorConfigMap) === 1 && isset($editorConfigMap['cms'])) {
+        $editorConfigCount = count($editorConfigMap);
+        if ($editorConfigCount === 0) {
             return 'cms';
+        }
+        if ($editorConfigCount === 1) {
+            return key($editorConfigMap);
         }
 
         foreach ($this->Groups() as $group) {


### PR DESCRIPTION
## Description
Fixes unecessary queries, see issue for context

## Manual testing steps
Check that no extra query is made on a fresh install

## Issues
https://github.com/silverstripe/silverstripe-framework/issues/11590

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
