### PR TITLE
FIX don't count records twice on a GridField if there is a GridFieldPaginator

### DIFF
--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -550,10 +550,7 @@ class GridField extends FormField
                 }
             }
             if ($item instanceof GridFieldPaginator) {
-                $parameters = $item->getTemplateParameters($this);
-                if ($parameters) {
-                    $total = $parameters->NumRecords;
-                }
+                $total = $item->getTotalItems();
             }
         }
 

--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -550,7 +550,10 @@ class GridField extends FormField
                 }
             }
             if ($item instanceof GridFieldPaginator) {
-                $total = $item->getTemplateParameters($this)->NumRecords;
+                $parameters = $item->getTemplateParameters($this);
+                if ($parameters) {
+                    $total = $parameters->NumRecords;
+                }
             }
         }
 

--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -524,6 +524,7 @@ class GridField extends FormField
         $columns = $this->getColumns();
 
         $list = $this->getManipulatedList();
+        $total = null; // can be populated by GridFieldPaginator
 
         $content = [
             'before' => '',
@@ -547,6 +548,9 @@ class GridField extends FormField
                         $content[$fragmentKey] .= $fragmentValue . "\n";
                     }
                 }
+            }
+            if ($item instanceof GridFieldPaginator) {
+                $total = $item->getTemplateParameters($this)->NumRecords;
             }
         }
 
@@ -630,7 +634,9 @@ class GridField extends FormField
             }
         }
 
-        $total = count($list ?? []);
+        if ($total === null) {
+            $total = count($list ?? []);
+        }
 
         if ($total > 0) {
             $rows = [];

--- a/src/Forms/GridField/GridFieldPaginator.php
+++ b/src/Forms/GridField/GridFieldPaginator.php
@@ -139,6 +139,11 @@ class GridFieldPaginator extends AbstractGridFieldComponent implements GridField
 
     protected $totalItems = 0;
 
+    public function getTotalItems(): int
+    {
+        return $this->totalItems;
+    }
+
     /**
      * Retrieves/Sets up the state object used to store and retrieve information
      * about the current paging details of this GridField


### PR DESCRIPTION
## Description
Fixes https://github.com/silverstripe/silverstripe-framework/issues/11592, see issue for context

## Manual testing steps
Check that no duplicate queries are being made to count records

## Issues
https://github.com/silverstripe/silverstripe-framework/issues/11592

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
