### PR TITLE
DOC Remove simple theme reference from PHPDoc comment

### DIFF
--- a/src/View/ThemeList.php
+++ b/src/View/ThemeList.php
@@ -15,7 +15,7 @@ interface ThemeList
      *     '/mysite',
      *     'vendor/module:themename',
      *     '/framework/admin'
-     *     'simple'
+     *     'my-theme'
      *   ]
      * </code>
      *


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/startup-theme/issues/7