### PR TITLE
NEW Handle WithinRangeFilter in searchable_fields and SearchContext

### DIFF
--- a/src/Core/Validation/FieldValidation/BigIntFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/BigIntFieldValidator.php
@@ -23,6 +23,8 @@ class BigIntFieldValidator extends IntFieldValidator
             if ($bits === 32) {
                 throw new RunTimeException('Cannot use BigIntFieldValidator on a 32-bit system');
             }
+            $minValue ??= (int) DBBigInt::getMinValue();
+            $maxValue ??= (int) DBBigInt::getMaxValue();
         }
         $this->minValue = $minValue;
         $this->maxValue = $maxValue;

--- a/src/Core/Validation/FieldValidation/BigIntFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/BigIntFieldValidator.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Core\Validation\FieldValidation;
 
 use RunTimeException;
 use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\ORM\FieldType\DBBigInt;
 
 /**
  * A field validator for 64-bit integers
@@ -11,21 +12,6 @@ use SilverStripe\Core\Validation\ValidationResult;
  */
 class BigIntFieldValidator extends IntFieldValidator
 {
-    /**
-     * The minimum value for a signed 64-bit integer.
-     * Defined as string instead of int otherwise will end up as a float
-     * on 64-bit systems
-     *
-     * When this is cast to an int in IntFieldValidator::__construct()
-     * it will be properly cast to an int
-     */
-    protected const MIN_INT = '-9223372036854775808';
-
-    /**
-     * The maximum value for a signed 64-bit integer.
-     */
-    protected const MAX_INT = '9223372036854775807';
-
     public function __construct(
         string $name,
         mixed $value,
@@ -51,10 +37,10 @@ class BigIntFieldValidator extends IntFieldValidator
         // int values that are too large or too small will be cast to float
         // on 64-bit systems and will fail the validation in IntFieldValidator
         if (is_string($this->value)) {
-            if (!is_null($this->minValue) && bccomp($this->value, static::MIN_INT) === -1) {
+            if (!is_null($this->minValue) && bccomp($this->value, DBBigInt::getMinValue()) === -1) {
                 $result->addFieldError($this->name, $this->getTooSmallMessage());
             }
-            if (!is_null($this->maxValue) && bccomp($this->value, static::MAX_INT) === 1) {
+            if (!is_null($this->maxValue) && bccomp($this->value, DBBigInt::getMaxValue()) === 1) {
                 $result->addFieldError($this->name, $this->getTooLargeMessage());
             }
         }

--- a/src/Core/Validation/FieldValidation/IntFieldValidator.php
+++ b/src/Core/Validation/FieldValidation/IntFieldValidator.php
@@ -3,24 +3,13 @@
 namespace SilverStripe\Core\Validation\FieldValidation;
 
 use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\ORM\FieldType\DBInt;
 
 /**
  * Validates that a value is a 32-bit signed integer
  */
 class IntFieldValidator extends NumericNonStringFieldValidator
 {
-    /**
-     * The minimum value for a signed 32-bit integer.
-     * Defined as string instead of int because be cast to a float
-     * on 32-bit systems if defined as an int
-     */
-    protected const MIN_INT = '-2147483648';
-
-    /**
-     * The maximum value for a signed 32-bit integer.
-     */
-    protected const MAX_INT = '2147483647';
-
     public function __construct(
         string $name,
         mixed $value,
@@ -28,10 +17,10 @@ class IntFieldValidator extends NumericNonStringFieldValidator
         ?int $maxValue = null
     ) {
         if (is_null($minValue)) {
-            $minValue = (int) static::MIN_INT;
+            $minValue = (int) DBInt::getMinValue();
         }
         if (is_null($maxValue)) {
-            $maxValue = (int) static::MAX_INT;
+            $maxValue = (int) DBInt::getMaxValue();
         }
         parent::__construct($name, $value, $minValue, $maxValue);
     }

--- a/src/Forms/CurrencyField.php
+++ b/src/Forms/CurrencyField.php
@@ -30,6 +30,7 @@ class CurrencyField extends TextField
             . number_format((double)preg_replace('/[^0-9.\-]/', '', $value ?? ''), 2);
         return $this;
     }
+
     /**
      * Overwrite the datavalue before saving to the db ;-)
      * return 0.00 if no value, or value is non-numeric

--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -116,9 +116,13 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
         $state->Columns = [];
 
         if ($actionName === 'filter') {
-            if (isset($data['filter'][$gridField->getName()])) {
-                foreach ($data['filter'][$gridField->getName()] as $key => $filter) {
-                    $state->Columns->$key = $filter;
+            $filterValues = $data['filter'][$gridField->getName()] ?? null;
+            if ($filterValues !== null) {
+                $form = $this->getSearchForm($gridField);
+                $this->removeSearchPrefixFromFields($form->Fields());
+                $form->loadDataFrom($filterValues);
+                foreach ($filterValues as $fieldName => $rawFilterValue) {
+                    $state->Columns->$fieldName = $form->Fields()->dataFieldByName($fieldName)?->dataValue() ?? $rawFilterValue;
                 }
             }
         }
@@ -494,6 +498,16 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
             $field->setName('Search__' . $field->getName());
             if ($field instanceof CompositeField) {
                 $this->addSearchPrefixToFields($field->getChildren());
+            }
+        }
+    }
+
+    private function removeSearchPrefixFromFields(FieldList $fields): void
+    {
+        foreach ($fields as $field) {
+            $field->setName(str_replace('Search__', '', $field->getName()));
+            if ($field instanceof CompositeField) {
+                $this->removeSearchPrefixFromFields($field->getChildren());
             }
         }
     }

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -16,6 +16,7 @@ use SilverStripe\Core\Validation\ValidationInterface;
 use SilverStripe\Core\Validation\ValidationResult;
 use SilverStripe\Dev\Debug;
 use SilverStripe\Dev\Deprecation;
+use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\FormScaffolder;
@@ -46,6 +47,7 @@ use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
 use SilverStripe\View\SSViewer;
 use SilverStripe\Model\ModelData;
+use SilverStripe\ORM\Filters\WithinRangeFilter;
 use stdClass;
 
 /**
@@ -2438,40 +2440,7 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
                 continue;
             }
 
-            // If a custom fieldclass is provided as a string, use it
-            $field = null;
-            if ($params['fieldClasses'] && isset($params['fieldClasses'][$fieldName])) {
-                $fieldClass = $params['fieldClasses'][$fieldName];
-                $field = new $fieldClass($fieldName);
-            // If we explicitly set a field, then construct that
-            } elseif (isset($spec['field'])) {
-                // If it's a string, use it as a class name and construct
-                if (is_string($spec['field'])) {
-                    $fieldClass = $spec['field'];
-                    $field = new $fieldClass($fieldName);
-
-                // If it's a FormField object, then just use that object directly.
-                } elseif ($spec['field'] instanceof FormField) {
-                    $field = $spec['field'];
-
-                // Otherwise we have a bug
-                } else {
-                    user_error("Bad value for searchable_fields, 'field' value: "
-                        . var_export($spec['field'], true), E_USER_WARNING);
-                }
-
-            // Otherwise, use the database field's scaffolder
-            } elseif ($object = $this->relObject($fieldName)) {
-                if (is_object($object) && $object->hasMethod('scaffoldSearchField')) {
-                    $field = $object->scaffoldSearchField();
-                } else {
-                    throw new Exception(sprintf(
-                        "SearchField '%s' on '%s' does not return a valid DBField instance.",
-                        $fieldName,
-                        get_class($this)
-                    ));
-                }
-            }
+            $field = $this->scaffoldSingleSearchField($fieldName, $spec, $params);
 
             // Allow fields to opt out of search
             if (!$field) {
@@ -2482,6 +2451,24 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
                 $field->setName(str_replace('.', '__', $fieldName ?? ''));
             }
             $field->setTitle($spec['title']);
+
+            // If we're using a WithinRangeFilter, split the field into two separate fields (from and to)
+            if (is_a($spec['filter'] ?? '', WithinRangeFilter::class, true)) {
+                $fieldFrom = $field;
+                $fieldTo = clone $field;
+                $originalTitle = $field->Title();
+                $originalName = $field->getName();
+
+                $fieldFrom->setName($originalName . '_SearchFrom');
+                $fieldFrom->setTitle(_t(__CLASS__ . '.FILTER_WITHINRANGE_FROM', 'From'));
+                $fieldTo->setName($originalName . '_SearchTo');
+                $fieldTo->setTitle(_t(__CLASS__ . '.FILTER_WITHINRANGE_TO', 'To'));
+
+                $field = FieldGroup::create(
+                    $originalTitle,
+                    [$fieldFrom, $fieldTo]
+                )->setName($originalName)->addExtraClass('fieldgroup--fill-width');
+            }
 
             $fields->push($field);
         }
@@ -2496,6 +2483,56 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
         }
 
         return $fields;
+    }
+
+    /**
+     * Scaffold a single form field for use by the search context form.
+     */
+    private function scaffoldSingleSearchField(string $fieldName, array $spec, ?array $params): ?FormField
+    {
+        // If a custom fieldclass is provided as a string, use it
+        $field = null;
+        if ($params['fieldClasses'] && isset($params['fieldClasses'][$fieldName])) {
+            $fieldClass = $params['fieldClasses'][$fieldName];
+            $field = new $fieldClass($fieldName);
+        // If we explicitly set a field, then construct that
+        } elseif (isset($spec['field'])) {
+            // If it's a string, use it as a class name and construct
+            if (is_string($spec['field'])) {
+                $fieldClass = $spec['field'];
+                $field = new $fieldClass($fieldName);
+
+            // If it's a FormField object, then just use that object directly.
+            } elseif ($spec['field'] instanceof FormField) {
+                $field = $spec['field'];
+
+            // Otherwise we have a bug
+            } else {
+                user_error("Bad value for searchable_fields, 'field' value: "
+                    . var_export($spec['field'], true), E_USER_WARNING);
+            }
+        // Use the explicitly defined dataType if one was set
+        } elseif (isset($spec['dataType'])) {
+            $object = Injector::inst()->get($spec['dataType'], true);
+            $field = $this->scaffoldFieldFromObject($object, $fieldName);
+            $field->setName($fieldName);
+        // Otherwise, use the database field's scaffolder
+        } elseif ($object = $this->relObject($fieldName)) {
+            $field = $this->scaffoldFieldFromObject($object, $fieldName);
+        }
+        return $field;
+    }
+
+    private function scaffoldFieldFromObject(mixed $object, string $fieldName): FormField
+    {
+        if (!is_object($object) || !$object->hasMethod('scaffoldSearchField')) {
+            throw new LogicException(sprintf(
+                "SearchField '%s' on '%s' does not return a valid DBField instance.",
+                $fieldName,
+                get_class($this)
+            ));
+        }
+        return $object->scaffoldSearchField();
     }
 
     /**
@@ -3896,6 +3933,7 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
         $rewrite = [];
         foreach ($fields as $name => $specOrName) {
             $identifier = (is_int($name)) ? $specOrName : $name;
+            $relObject = isset($specOrName['match_any']) ? null : $this->relObject($identifier);
 
             if (is_int($name)) {
                 // Format: array('MyFieldName')
@@ -3903,14 +3941,22 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
             } elseif (is_array($specOrName) && (isset($specOrName['match_any']))) {
                 $rewrite[$identifier] = $fields[$identifier];
                 $rewrite[$identifier]['match_any'] = $specOrName['match_any'];
-            } elseif (is_array($specOrName) && ($relObject = $this->relObject($identifier))) {
+            } elseif (is_array($specOrName)) {
                 // Format: array('MyFieldName' => array(
                 //   'filter => 'ExactMatchFilter',
                 //   'field' => 'NumericField', // optional
                 //   'title' => 'My Title', // optional
+                //   'dataType' => DBInt::class // optional
+                // These two are only required if using WithinRangeFilter with a data type that doesn't
+                // inherently represent a date, time, or number
+                //   'rangeFromDefault' => PHP_INT_MIN
+                //   'rangeToDefault' => PHP_INT_MAX
                 // ))
                 $rewrite[$identifier] = array_merge(
-                    ['filter' => $relObject->config()->get('default_search_filter_class')],
+                    [
+                        'filter' => $relObject?->config()->get('default_search_filter_class'),
+                        'dataType' => $relObject ? get_class($relObject) : null,
+                    ],
                     (array)$specOrName
                 );
             } else {
@@ -3918,6 +3964,9 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
                 $rewrite[$identifier] = [
                     'filter' => $specOrName,
                 ];
+                if ($relObject !== null) {
+                    $rewrite[$identifier]['dataType'] ??= get_class($relObject);
+                }
             }
             if (!isset($rewrite[$identifier]['title'])) {
                 $rewrite[$identifier]['title'] = (isset($labels[$identifier]))
@@ -3925,6 +3974,33 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
             }
             if (!isset($rewrite[$identifier]['filter'])) {
                 $rewrite[$identifier]['filter'] = 'PartialMatchFilter';
+            }
+            // When using a WithinRangeFilter we need to know what the default from and to values
+            // should be, so that if a user only enters one of the two fields the other can be
+            // populated appropriately within the filter.
+            if (is_a($rewrite[$identifier]['filter'], WithinRangeFilter::class, true)) {
+                // The dataType requirement here is explicitly for WithinRangeFilter.
+                // DO NOT make it mandatory for other filters without first checking if this breaks
+                // anything for filtering a relation, where the class on the other end of the relation
+                // implements scaffoldSearchField().
+                $dataType = $rewrite[$identifier]['dataType'] ?? null;
+                if (!is_a($dataType ?? '', DBField::class, true)) {
+                    throw new LogicException("dataType must be set to a DBField class for '$identifier'");
+                }
+                if (!isset($rewrite[$identifier]['rangeFromDefault'])) {
+                    $fromDefault = $dataType::getMinValue();
+                    if ($fromDefault === null) {
+                        throw new LogicException("rangeFromDefault must be set for '$identifier'");
+                    }
+                    $rewrite[$identifier]['rangeFromDefault'] = $fromDefault;
+                }
+                if (!isset($rewrite[$identifier]['rangeToDefault'])) {
+                    $toDefault = $dataType::getMaxValue();
+                    if ($toDefault === null) {
+                        throw new LogicException("rangeToDefault must be set for '$identifier'");
+                    }
+                    $rewrite[$identifier]['rangeToDefault'] = $toDefault;
+                }
             }
         }
 

--- a/src/ORM/FieldType/DBBigInt.php
+++ b/src/ORM/FieldType/DBBigInt.php
@@ -14,6 +14,21 @@ use SilverStripe\ORM\DB;
  */
 class DBBigInt extends DBInt
 {
+    /**
+     * The minimum value for a signed 64-bit integer.
+     * Defined as string instead of int otherwise will end up as a float
+     * on 64-bit systems
+     *
+     * When this is cast to an int in IntFieldValidator::__construct()
+     * it will be properly cast to an int
+     */
+    protected const MIN_INT = '-9223372036854775808';
+
+    /**
+     * The maximum value for a signed 64-bit integer.
+     */
+    protected const MAX_INT = '9223372036854775807';
+
     private static array $field_validators = [
         // Remove parent validator and add BigIntValidator instead
         IntFieldValidator::class => null,

--- a/src/ORM/FieldType/DBCurrency.php
+++ b/src/ORM/FieldType/DBCurrency.php
@@ -4,6 +4,7 @@ namespace SilverStripe\ORM\FieldType;
 
 use SilverStripe\Forms\CurrencyField;
 use SilverStripe\Forms\FormField;
+use SilverStripe\Forms\NumericField;
 use SilverStripe\Model\ModelData;
 
 /**
@@ -67,5 +68,10 @@ class DBCurrency extends DBDecimal
     public function scaffoldFormField(?string $title = null, array $params = []): ?FormField
     {
         return CurrencyField::create($this->getName(), $title);
+    }
+
+    public function scaffoldSearchField(?string $title = null): ?FormField
+    {
+        return NumericField::create($this->getName(), $title);
     }
 }

--- a/src/ORM/FieldType/DBDate.php
+++ b/src/ORM/FieldType/DBDate.php
@@ -619,4 +619,14 @@ class DBDate extends DBField
         $parts[] = $matches['time'];
         return $parts;
     }
+
+    public static function getMinValue(): string
+    {
+        return '0000-00-00';
+    }
+
+    public static function getMaxValue(): string
+    {
+        return '9999-12-31';
+    }
 }

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -369,4 +369,14 @@ class DBDatetime extends DBDate implements TemplateGlobalProvider
     {
         return DBDatetime::ISO_DATETIME;
     }
+
+    public static function getMinValue(): string
+    {
+        return '0000-00-00 00:00:00';
+    }
+
+    public static function getMaxValue(): string
+    {
+        return '9999-12-31 23:59:59';
+    }
 }

--- a/src/ORM/FieldType/DBDatetime.php
+++ b/src/ORM/FieldType/DBDatetime.php
@@ -15,6 +15,7 @@ use SilverStripe\View\TemplateGlobalProvider;
 use SilverStripe\Model\ModelData;
 use SilverStripe\Core\Validation\FieldValidation\DateFieldValidator;
 use SilverStripe\Core\Validation\FieldValidation\DatetimeFieldValidator;
+use SilverStripe\ORM\Tests\Search\SearchContextTest\WithinRangeFilterModel;
 
 /**
  * Represents a date-time field.

--- a/src/ORM/FieldType/DBDecimal.php
+++ b/src/ORM/FieldType/DBDecimal.php
@@ -135,4 +135,14 @@ class DBDecimal extends DBField
 
         return (float) $value;
     }
+
+    public static function getMinValue(): float
+    {
+        return PHP_FLOAT_MIN;
+    }
+
+    public static function getMaxValue(): float
+    {
+        return PHP_FLOAT_MAX;
+    }
 }

--- a/src/ORM/FieldType/DBEmail.php
+++ b/src/ORM/FieldType/DBEmail.php
@@ -6,6 +6,7 @@ use SilverStripe\Forms\EmailField;
 use SilverStripe\ORM\FieldType\DBVarchar;
 use SilverStripe\Core\Validation\FieldValidation\EmailFieldValidator;
 use SilverStripe\Forms\FormField;
+use SilverStripe\Forms\TextField;
 
 class DBEmail extends DBVarchar
 {
@@ -18,5 +19,10 @@ class DBEmail extends DBVarchar
         $field = EmailField::create($this->name, $title);
         $field->setMaxLength($this->getSize());
         return $field;
+    }
+
+    public function scaffoldSearchField(?string $title = null): ?FormField
+    {
+        return TextField::create($this->getName(), $title);
     }
 }

--- a/src/ORM/FieldType/DBField.php
+++ b/src/ORM/FieldType/DBField.php
@@ -571,4 +571,20 @@ DBG;
     {
         return true;
     }
+
+    /**
+     * @return mixed The minimum value for comparisons with this field - or null if that's not determinable.
+     */
+    public static function getMinValue(): mixed
+    {
+        return null;
+    }
+
+    /**
+     * @return mixed The maximum value for comparisons with this field - or null if that's not determinable.
+     */
+    public static function getMaxValue(): mixed
+    {
+        return null;
+    }
 }

--- a/src/ORM/FieldType/DBFloat.php
+++ b/src/ORM/FieldType/DBFloat.php
@@ -89,4 +89,14 @@ class DBFloat extends DBField
 
         return $value;
     }
+
+    public static function getMinValue(): float
+    {
+        return PHP_FLOAT_MIN;
+    }
+
+    public static function getMaxValue(): float
+    {
+        return PHP_FLOAT_MAX;
+    }
 }

--- a/src/ORM/FieldType/DBForeignKey.php
+++ b/src/ORM/FieldType/DBForeignKey.php
@@ -2,14 +2,8 @@
 
 namespace SilverStripe\ORM\FieldType;
 
-use SilverStripe\Assets\File;
-use SilverStripe\Assets\Image;
-use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Validation\FieldValidation\IntFieldValidator;
-use SilverStripe\Forms\FileHandleField;
 use SilverStripe\Forms\FormField;
-use SilverStripe\Forms\SearchableDropdownField;
-use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Model\ModelData;
 
@@ -78,7 +72,7 @@ class DBForeignKey extends DBInt
         return parent::setValue($value, $record, $markChanged);
     }
 
-    public function getMinValue(): int
+    public static function getMinValue(): int
     {
         return 0;
     }

--- a/src/ORM/FieldType/DBHTMLText.php
+++ b/src/ORM/FieldType/DBHTMLText.php
@@ -186,7 +186,7 @@ class DBHTMLText extends DBText
 
     public function scaffoldSearchField(?string $title = null): ?FormField
     {
-        return new TextField($this->name, $title);
+        return TextField::create($this->name, $title);
     }
 
     /**

--- a/src/ORM/FieldType/DBInt.php
+++ b/src/ORM/FieldType/DBInt.php
@@ -13,6 +13,18 @@ use SilverStripe\Model\ModelData;
  */
 class DBInt extends DBField
 {
+    /**
+     * The minimum value for a signed 32-bit integer.
+     * Defined as string instead of int because be cast to a float
+     * on 32-bit systems if defined as an int
+     */
+    protected const MIN_INT = '-2147483648';
+
+    /**
+     * The maximum value for a signed 32-bit integer.
+     */
+    protected const MAX_INT = '2147483647';
+
     private static array $field_validators = [
         IntFieldValidator::class
     ];
@@ -88,5 +100,15 @@ class DBInt extends DBField
         }
 
         return (int)$value;
+    }
+
+    public static function getMinValue(): string|int
+    {
+        return static::MIN_INT;
+    }
+
+    public static function getMaxValue(): string|int
+    {
+        return static::MAX_INT;
     }
 }

--- a/src/ORM/FieldType/DBPercentage.php
+++ b/src/ORM/FieldType/DBPercentage.php
@@ -39,12 +39,12 @@ class DBPercentage extends DBDecimal
         parent::__construct($name, $precision + 1, $precision);
     }
 
-    public function getMinValue(): float
+    public static function getMinValue(): float
     {
         return 0.0;
     }
 
-    public function getMaxValue(): float
+    public static function getMaxValue(): float
     {
         return 1.0;
     }

--- a/src/ORM/FieldType/DBTime.php
+++ b/src/ORM/FieldType/DBTime.php
@@ -181,4 +181,14 @@ class DBTime extends DBField
         }
         return 0;
     }
+
+    public static function getMinValue(): string
+    {
+        return '00:00:00';
+    }
+
+    public static function getMaxValue(): string
+    {
+        return '23:59:59';
+    }
 }

--- a/src/ORM/FieldType/DBUrl.php
+++ b/src/ORM/FieldType/DBUrl.php
@@ -5,6 +5,7 @@ namespace SilverStripe\ORM\FieldType;
 use SilverStripe\ORM\FieldType\DBVarchar;
 use SilverStripe\Core\Validation\FieldValidation\UrlFieldValidator;
 use SilverStripe\Forms\FormField;
+use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\UrlField;
 
 class DBUrl extends DBVarchar
@@ -18,5 +19,10 @@ class DBUrl extends DBVarchar
         $field = UrlField::create($this->name, $title);
         $field->setMaxLength($this->getSize());
         return $field;
+    }
+
+    public function scaffoldSearchField(?string $title = null): ?FormField
+    {
+        return TextField::create($this->getName(), $title);
     }
 }

--- a/src/ORM/FieldType/DBYear.php
+++ b/src/ORM/FieldType/DBYear.php
@@ -21,8 +21,8 @@ class DBYear extends DBField
 
     private static $field_validators = [
         YearFieldValidator::class => [
-            'minValue' => 'getMinYear',
-            'maxValue' => 'getMaxYear'
+            'minValue' => 'getMinValue',
+            'maxValue' => 'getMaxValue'
         ],
     ];
 
@@ -70,12 +70,12 @@ class DBYear extends DBField
         return $this;
     }
 
-    public function getMinYear(): int
+    public static function getMinValue(): int
     {
         return DBYear::MIN_YEAR;
     }
 
-    public function getMaxYear(): int
+    public static function getMaxValue(): int
     {
         return DBYear::MAX_YEAR;
     }

--- a/src/ORM/Filters/WithinRangeFilter.php
+++ b/src/ORM/Filters/WithinRangeFilter.php
@@ -6,18 +6,27 @@ use SilverStripe\ORM\DataQuery;
 
 class WithinRangeFilter extends SearchFilter
 {
+    private mixed $min = null;
+    private mixed $max = null;
 
-    private $min;
-    private $max;
-
-    public function setMin($min)
+    public function setMin(mixed $min)
     {
         $this->min = $min;
     }
 
-    public function setMax($max)
+    public function getMin(): mixed
+    {
+        return $this->min;
+    }
+
+    public function setMax(mixed $max)
     {
         $this->max = $max;
+    }
+
+    public function getMax(): mixed
+    {
+        return $this->max;
     }
 
     protected function applyOne(DataQuery $query)

--- a/src/ORM/Search/SearchContext.php
+++ b/src/ORM/Search/SearchContext.php
@@ -19,7 +19,10 @@ use InvalidArgumentException;
 use Exception;
 use LogicException;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Forms\DateField;
 use SilverStripe\ORM\DataQuery;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\ORM\Filters\WithinRangeFilter;
 
 /**
  * Manages searching of properties on one or more {@link DataObject}
@@ -77,6 +80,13 @@ class SearchContext
      * @var array
      */
     protected $searchParams = [];
+
+    /**
+     * A list of fields that use WithinRangeFilter that have already been included in the query.
+     * This prevents the "from" and "to" fields from both independently affecting the query since they
+     * have to be paired together in the same filter.
+     */
+    protected $withinRangeFieldsChecked = [];
 
     /**
      * A key value pair of values that should be searched for.
@@ -161,6 +171,7 @@ class SearchContext
      */
     private function search(DataList $query): DataList
     {
+        $this->withinRangeFieldsChecked = [];
         /** @var DataObject $modelObj */
         $modelObj = Injector::inst()->create($this->modelClass);
         $searchableFields = $modelObj->searchableFields();
@@ -296,8 +307,35 @@ class SearchContext
             return $query;
         }
         $filter->setModel($this->modelClass);
-        $filter->setValue($searchPhrase);
-        $searchableFieldSpec = $searchableFields[$searchField] ?? [];
+        // WithinRangeFilter needs a bit of help knowing what its "from" and "to" values are
+        if ($filter instanceof WithinRangeFilter) {
+            $baseName = preg_replace('/_Search(From|To)$/', '', $searchField);
+            if (array_key_exists($baseName, $this->withinRangeFieldsChecked)) {
+                return $query;
+            }
+            $allSearchParams = $this->getSearchParams();
+            $searchableFieldSpec = $searchableFields[$baseName] ?? [];
+            $from = $allSearchParams[$baseName . '_SearchFrom'] ?? $searchableFieldSpec['rangeFromDefault'];
+            $to = $allSearchParams[$baseName . '_SearchTo'] ?? $searchableFieldSpec['rangeToDefault'];
+            // If we're using DateField for a DBDateTime, set "from" to the start of the day, and "to" to the end of the day.
+            // Though if we're using the default values, we don't need to add this as it should already be there.
+            if (is_a($searchableFieldSpec['dataType'] ?? '', DBDatetime::class, true)
+                && is_a($searchableFieldSpec['field'] ?? '', DateField::class, true)
+            ) {
+                if ($from !== $searchableFieldSpec['rangeFromDefault']) {
+                    $from .= ' 00:00:00';
+                }
+                if ($to !== $searchableFieldSpec['rangeToDefault']) {
+                    $to .= ' 23:59:59';
+                }
+            }
+            $filter->setMin($from);
+            $filter->setMax($to);
+            $this->withinRangeFieldsChecked[$baseName] = true;
+        } else {
+            $filter->setValue($searchPhrase);
+            $searchableFieldSpec = $searchableFields[$searchField] ?? [];
+        }
         return $query->alterDataQuery(function ($dataQuery) use ($filter, $searchableFieldSpec) {
             $this->applyFilter($filter, $dataQuery, $searchableFieldSpec);
         });
@@ -318,9 +356,13 @@ class SearchContext
             $modifiers = $filter->getModifiers();
             $subGroup = $dataQuery->disjunctiveGroup();
             foreach ($searchFields as $matchField) {
-                /** @var SearchFilter $filter */
-                $filter = Injector::inst()->create($filterClass, $matchField, $value, $modifiers);
-                $filter->apply($subGroup);
+                /** @var SearchFilter $subFilter */
+                $subFilter = Injector::inst()->create($filterClass, $matchField, $value, $modifiers);
+                if ($subFilter instanceof WithinRangeFilter) {
+                    $subFilter->setMin($filter->getMin());
+                    $subFilter->setMax($filter->getMax());
+                }
+                $subFilter->apply($subGroup);
             }
         } else {
             $filter->apply($dataQuery);
@@ -364,11 +406,8 @@ class SearchContext
      */
     public function getFilter($name)
     {
-        if (isset($this->filters[$name])) {
-            return $this->filters[$name];
-        } else {
-            return null;
-        }
+        $withinRangeFilterCheck = preg_replace('/_Search(From|To)$/', '', $name);
+        return $this->filters[$name] ?? $this->filters[$withinRangeFilterCheck] ?? null;
     }
 
     /**

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -15,6 +15,7 @@ use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridFieldFilterHeader;
 use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\Cheerleader;
 use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\CheerleaderHat;
+use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\ModelWithBadSearchableFields;
 use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\Mom;
 use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\NonDataObject;
 use SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\Team;
@@ -59,6 +60,7 @@ class GridFieldFilterHeaderTest extends SapphireTest
         Cheerleader::class,
         CheerleaderHat::class,
         Mom::class,
+        ModelWithBadSearchableFields::class,
     ];
 
     protected function setUp(): void
@@ -222,15 +224,16 @@ class GridFieldFilterHeaderTest extends SapphireTest
         Config::modify()->set(Team::class, 'searchable_fields', ['Name']);
         $this->assertTrue($filterHeader->canFilterAnyColumns($gridField));
 
-        // test that you can filterBy if searchable_fields even if it is not a legit field
-        // this is because we're making a blind assumption it will be filterable later in a SearchContext
-        Config::modify()->set(Team::class, 'searchable_fields', ['WhatIsThis']);
-        $this->assertTrue($filterHeader->canFilterAnyColumns($gridField));
-
         // test that you cannot filter by non-db field when it falls back to summary_fields
         Config::modify()->remove(Team::class, 'searchable_fields');
         Config::modify()->set(Team::class, 'summary_fields', ['MySummaryField']);
         $this->assertFalse($filterHeader->canFilterAnyColumns($gridField));
+
+        // test that you can filterBy even if searchableFields() includes a non-db field
+        // this is because we're making a blind assumption it will be filterable in a custom SearchContext
+        $gridField->setList(ModelWithBadSearchableFields::get());
+        $gridField->setModelClass(ModelWithBadSearchableFields::class);
+        $this->assertTrue($filterHeader->canFilterAnyColumns($gridField));
     }
 
     public function testCanFilterAnyColumnsNonDataObject()

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.yml
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.yml
@@ -74,3 +74,7 @@ SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\TeamGroup:
     City: Melbourne
     Cheerleader: =>SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\Cheerleader.cheerleader1
     CheerleadersMom: =>SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\Mom.mom1
+
+SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest\ModelWithBadSearchableFields:
+  record1:
+    Name: Record 1

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest/ModelWithBadSearchableFields.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest/ModelWithBadSearchableFields.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\DataObject;
+
+class ModelWithBadSearchableFields extends DataObject implements TestOnly
+{
+    private static $table_name = 'GridFieldFilterHeaderTest_ModelWithBadSearchableFields';
+
+    private static $db = [
+        'Name' => 'Varchar',
+    ];
+
+    private static $summary_fields = [
+        'Name' => 'Name',
+    ];
+
+    // Explicitly empty
+    private static $searchable_fields = [];
+
+    public function searchableFields()
+    {
+        // Explicitly only include this custom field
+        return [
+            'WhatIsThis' => [
+                'field' => TextField::class,
+                'title' => $this->fieldLabel('WhatIsThis'),
+            ],
+        ];
+    }
+}

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -27,6 +27,17 @@ use SilverStripe\Core\Validation\ValidationException;
 use SilverStripe\Security\Member;
 use SilverStripe\Model\ModelData;
 use ReflectionMethod;
+use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\CompositeField;
+use SilverStripe\Forms\DatalessField;
+use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\HiddenField;
+use SilverStripe\Forms\LiteralField;
+use SilverStripe\Forms\NumericField;
+use SilverStripe\Forms\TextareaField;
+use SilverStripe\Forms\TextField;
+use SilverStripe\ORM\FieldType\DBInt;
+use SilverStripe\ORM\Filters\WithinRangeFilter;
 use stdClass;
 
 class DataObjectTest extends SapphireTest
@@ -1417,6 +1428,241 @@ class DataObjectTest extends SapphireTest
         $testObj = new DataObjectTest\Fixture();
         $fields = $testObj->searchableFields();
         $this->assertEmpty($fields);
+    }
+
+    public static function provideSearchableFieldsForWithinRangeFilter(): array
+    {
+        return [
+            'invalid field in general' => [
+                'config' => [
+                    'NotARealField' => [
+                        'filter' => WithinRangeFilter::class,
+                        'rangeFromDefault' => 'some value',
+                        'rangeToDefault' => 'another value',
+                    ],
+                ],
+                'exceptionMessage' => 'NotARealField is not a relation/field on ' . DataObjectTest\Team::class,
+                'expected' => null,
+            ],
+            'cannot filter by relation with WithinRangeFilter' => [
+                'config' => [
+                    'Captain' => [
+                        'filter' => WithinRangeFilter::class,
+                    ],
+                ],
+                'exceptionMessage' => "dataType must be set to a DBField class for 'Captain'",
+                'expected' => null,
+            ],
+            'missing default "from"' => [
+                'config' => [
+                    'Title' => ['filter' => WithinRangeFilter::class],
+                ],
+                'exceptionMessage' => "rangeFromDefault must be set for 'Title'",
+                'expected' => null,
+            ],
+            'missing default "to"' => [
+                'config' => [
+                    'Title' => [
+                        'filter' => WithinRangeFilter::class,
+                        'rangeFromDefault' => 'some value',
+                    ],
+                ],
+                'exceptionMessage' => "rangeToDefault must be set for 'Title'",
+                'expected' => null,
+            ],
+            'fully valid config' => [
+                'config' => [
+                    'Title' => [
+                        'filter' => WithinRangeFilter::class,
+                        'rangeFromDefault' => 'some value',
+                        'rangeToDefault' => 'another value',
+                    ],
+                ],
+                'exceptionMessage' => null,
+                'expected' => [
+                    'Title' => [
+                        'filter' => WithinRangeFilter::class,
+                        'dataType' => DBVarchar::class,
+                        'rangeFromDefault' => 'some value',
+                        'rangeToDefault' => 'another value',
+                        'title' => 'Title',
+                    ],
+                ],
+            ],
+            'fully valid config inferred from datatype' => [
+                'config' => [
+                    'Title' => [
+                        'filter' => WithinRangeFilter::class,
+                        'dataType' => DBInt::class,
+                    ],
+                ],
+                'exceptionMessage' => null,
+                'expected' => [
+                    'Title' => [
+                        'filter' => WithinRangeFilter::class,
+                        'dataType' => DBInt::class,
+                        'title' => 'Title',
+                        'rangeFromDefault' => DBInt::getMinValue(),
+                        'rangeToDefault' => DBInt::getMaxValue(),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideSearchableFieldsForWithinRangeFilter')]
+    public function testSearchableFieldsForWithinRangeFilter(array $config, ?string $exceptionMessage, ?array $expected): void
+    {
+        DataObjectTest\Team::config()->set('searchable_fields', $config);
+        $team = $this->objFromFixture(DataObjectTest\Team::class, 'team1');
+
+        if ($exceptionMessage !== null) {
+            $this->expectException(LogicException::class);
+            $this->expectExceptionMessage($exceptionMessage);
+        }
+
+        $fields = $team->searchableFields();
+        if ($expected !== null) {
+            $this->assertSame($expected, $fields);
+        }
+    }
+
+    public static function provideScaffoldSearchFields(): array
+    {
+        return [
+            'inferred from simple config' => [
+                'config' => [
+                    'Title',
+                    'DatabaseField',
+                    'NumericField',
+                    'Captain.IsRetired' => [
+                        'Title' => 'Captain is retired',
+                    ],
+                ],
+                'generalSearchFieldName' => '',
+                'expected' => [
+                    'Title' => TextField::class,
+                    'DatabaseField' => TextField::class,
+                    'NumericField' => NumericField::class,
+                    'Captain__IsRetired' => DropdownField::class,
+                ],
+            ],
+            'inferred from simple config (with general field)' => [
+                'config' => [
+                    'Title',
+                    'DatabaseField',
+                    'NumericField',
+                    'Captain.IsRetired' => [
+                        'Title' => 'Captain is retired',
+                    ],
+                ],
+                'generalSearchFieldName' => 'gen',
+                'expected' => [
+                    'gen' => HiddenField::class,
+                    'Title' => TextField::class,
+                    'DatabaseField' => TextField::class,
+                    'NumericField' => NumericField::class,
+                    'Captain__IsRetired' => DropdownField::class,
+                ],
+            ],
+            'field specified in config' => [
+                'config' => [
+                    'Title' => [
+                        'field' => DatalessField::class,
+                    ],
+                ],
+                'generalSearchFieldName' => 'gen',
+                'expected' => [
+                    'gen' => HiddenField::class,
+                    'Title' => DatalessField::class,
+                ],
+            ],
+            'no searchable fields' => [
+                'config' => [],
+                'generalSearchFieldName' => 'gen',
+                'expected' => [],
+            ],
+            'within range duplicates field' => [
+                'config' => [
+                    'NumericField' => WithinRangeFilter::class,
+                ],
+                'generalSearchFieldName' => '',
+                'expected' => [
+                    'NumericField_SearchFrom' => NumericField::class,
+                    'NumericField_SearchTo' => NumericField::class,
+                ],
+            ],
+            'search against relation (with method implemented)' => [
+                'config' => [
+                    'Captain',
+                ],
+                'generalSearchFieldName' => '',
+                'expected' => [
+                    'Captain.ID' => DropdownField::class,
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideScaffoldSearchFields')]
+    public function testScaffoldSearchFields(array $config, string $generalSearchFieldName, array $expected): void
+    {
+        DataObjectTest\Team::config()->set('searchable_fields', $config);
+        DataObjectTest\Team::config()->set('general_search_field_name', $generalSearchFieldName);
+        $team = $this->objFromFixture(DataObjectTest\Team::class, 'team1');
+
+        $fields = $team->scaffoldSearchFields();
+        $fieldMap = [];
+        foreach ($fields as $field) {
+            if ($field instanceof CompositeField) {
+                foreach ($field->getChildren() as $childField) {
+                    $fieldMap[$childField->getName()] = get_class($childField);
+                }
+                continue;
+            }
+            $fieldMap[$field->getName()] = get_class($field);
+        }
+        $this->assertSame($expected, $fieldMap);
+    }
+
+    public function testScaffoldSearchFieldsWithArg(): void
+    {
+        $config = [
+            'Title',
+            'DatabaseField' => [
+                // This will get overridden by fieldClasses arg
+                'field' => DatalessField::class,
+            ],
+            'NumericField',
+            'Captain.IsRetired' => [
+                'Title' => 'Captain is retired',
+            ],
+        ];
+        $args = [
+            'fieldClasses' => [
+                'DatabaseField' => NumericField::class,
+            ],
+            'restrictFields' => [
+                'DatabaseField',
+                'Captain.IsRetired'
+            ],
+        ];
+        $expected = [
+            'DatabaseField' => NumericField::class,
+            'Captain__IsRetired' => DropdownField::class,
+        ];
+
+
+        DataObjectTest\Team::config()->set('searchable_fields', $config);
+        DataObjectTest\Team::config()->set('general_search_field_name', '');
+        $team = $this->objFromFixture(DataObjectTest\Team::class, 'team1');
+
+        $fields = $team->scaffoldSearchFields($args);
+        $fieldMap = [];
+        foreach ($fields as $field) {
+            $fieldMap[$field->getName()] = get_class($field);
+        }
+        $this->assertSame($expected, $fieldMap);
     }
 
     public function testCastingHelper()

--- a/tests/php/ORM/DataObjectTest/Player.php
+++ b/tests/php/ORM/DataObjectTest/Player.php
@@ -3,6 +3,8 @@
 namespace SilverStripe\ORM\Tests\DataObjectTest;
 
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\FormField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectSchema;
 use SilverStripe\ORM\Tests\DataObjectTest;
@@ -47,5 +49,13 @@ class Player extends Member implements TestOnly
     public function ReturnsNull()
     {
         return null;
+    }
+
+    public function scaffoldSearchField(): FormField
+    {
+        // This is a weird scenario, given you have to explicitly say the relation name here.
+        // This is just here to ensure we don't break this in a minor or patch. There's no
+        // reason not to break this in a major (or else improve it so the relation name is passed in)
+        return DropdownField::create('Captain.ID', null, Player::get()->map());
     }
 }

--- a/tests/php/ORM/Search/BasicSearchContextTest.php
+++ b/tests/php/ORM/Search/BasicSearchContextTest.php
@@ -15,6 +15,7 @@ use SilverStripe\ORM\Filters\StartsWithFilter;
 use SilverStripe\ORM\Search\BasicSearchContext;
 use SilverStripe\Model\ArrayData;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
 
 class BasicSearchContextTest extends SapphireTest
 {
@@ -22,6 +23,7 @@ class BasicSearchContextTest extends SapphireTest
 
     protected static $extra_dataobjects = [
         SearchContextTest\GeneralSearch::class,
+        SearchContextTest\WithinRangeFilterModel::class,
     ];
 
     private function getList(): ArrayList
@@ -338,5 +340,25 @@ class BasicSearchContextTest extends SapphireTest
         $results = $context->getQuery([$generalField => $general1->ExcludeThisField], existingQuery: $list);
         $this->assertNotEmpty($general1->ExcludeThisField);
         $this->assertCount(0, $results);
+    }
+
+
+    #[DataProviderExternal(SearchContextTest::class, 'provideQueryWithinRangeFilter')]
+    public function testQueryWithinRangeFilter(array $params, array $expectedFixtureNames): void
+    {
+        $model = SearchContextTest\WithinRangeFilterModel::singleton();
+        $context = $model->getDefaultSearchContext();
+        $results = $context->getResults($params)->column('ID');
+
+        $found = [];
+        foreach ($expectedFixtureNames as $fixtureName) {
+            $id = $this->idFromFixture(SearchContextTest\WithinRangeFilterModel::class, $fixtureName);
+            if (in_array($id, $results)) {
+                $found[] = $fixtureName;
+            }
+        }
+
+        $this->assertSame($expectedFixtureNames, $found);
+        $this->assertCount(count($expectedFixtureNames), $results, 'More results found than expected');
     }
 }

--- a/tests/php/ORM/Search/BasicSearchContextTest.yml
+++ b/tests/php/ORM/Search/BasicSearchContextTest.yml
@@ -26,3 +26,41 @@ SilverStripe\ORM\Tests\Search\SearchContextTest\GeneralSearch:
     PartialMatchField: MatchNothing
     MatchAny1: MatchNothing
     MatchAny2: MatchNothing
+
+SilverStripe\ORM\Tests\Search\SearchContextTest\WithinRangeFilterModel:
+  lowrange:
+    DateOnly: '1912-05-03'
+    Datetime: '1912-05-03 01:23:45'
+    DatetimeWithDateField: '1912-05-03 01:23:45'
+    TimeOnly: '01:23:45'
+    IntRange: 13
+    DecimalRange: 1.234
+    FloatRange: 1.234
+    PercentageRange: 0.05
+    YearRange: 1912
+    CurrencyRange: 1.23
+    VarcharRangeWithConfig: 'c'
+  midrange:
+    DateOnly: '2005-04-06'
+    Datetime: '2005-04-06 12:34:56'
+    DatetimeWithDateField: '2005-04-06 12:34:56'
+    TimeOnly: '12:34:56'
+    IntRange: 500
+    DecimalRange: 12.34
+    FloatRange: 12.34
+    PercentageRange: 0.53
+    YearRange: 2005
+    CurrencyRange: 12.34
+    VarcharRangeWithConfig: 'l'
+  highrange:
+    DateOnly: '2123-03-07'
+    Datetime: '2123-03-07 23:45:47'
+    DatetimeWithDateField: '2123-03-07 23:45:47'
+    TimeOnly: '23:45:47'
+    IntRange: 1234
+    DecimalRange: 123.4
+    FloatRange: 123.4
+    PercentageRange: 0.95
+    YearRange: 2123
+    CurrencyRange: 123.4
+    VarcharRangeWithConfig: 'x'

--- a/tests/php/ORM/Search/SearchContextTest.php
+++ b/tests/php/ORM/Search/SearchContextTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\ORM\Tests\Search;
 
 use LogicException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionMethod;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
@@ -22,7 +23,6 @@ use SilverStripe\Model\ArrayData;
 
 class SearchContextTest extends SapphireTest
 {
-
     protected static $fixture_file = 'SearchContextTest.yml';
 
     protected static $extra_dataobjects = [
@@ -34,6 +34,7 @@ class SearchContextTest extends SapphireTest
         SearchContextTest\Deadline::class,
         SearchContextTest\Action::class,
         SearchContextTest\AllFilterTypes::class,
+        SearchContextTest\WithinRangeFilterModel::class,
         SearchContextTest\Customer::class,
         SearchContextTest\Address::class,
         SearchContextTest\Order::class,
@@ -176,6 +177,279 @@ class SearchContextTest extends SapphireTest
             "Get RSS feeds working",
             $project->Actions()->find('ID', $action3->ID)->Description
         );
+    }
+
+    public static function provideQueryWithinRangeFilter(): array
+    {
+        return [
+            // DBDate
+            'date mid range' => [
+                'params' => [
+                    'DateOnly_SearchFrom' => '1990-01-01',
+                    'DateOnly_SearchTo' => '2100-12-24',
+                ],
+                'expectedFixtureNames' => ['midrange'],
+            ],
+            'date from only' => [
+                'params' => [
+                    'DateOnly_SearchFrom' => '1990-01-01',
+                ],
+                'expectedFixtureNames' => ['midrange', 'highrange'],
+            ],
+            'date to only' => [
+                'params' => [
+                    'DateOnly_SearchTo' => '2100-12-24',
+                ],
+                'expectedFixtureNames' => ['lowrange', 'midrange'],
+            ],
+            // DBDatetime
+            'datetime mid range' => [
+                'params' => [
+                    'Datetime_SearchFrom' => '1990-01-01 12:23:15',
+                    'Datetime_SearchTo' => '2100-12-24 12:23:15',
+                ],
+                'expectedFixtureNames' => ['midrange'],
+            ],
+            'datetime from only' => [
+                'params' => [
+                    'Datetime_SearchFrom' => '1990-01-01 12:23:15',
+                ],
+                'expectedFixtureNames' => ['midrange', 'highrange'],
+            ],
+            'datetime to only' => [
+                'params' => [
+                    'Datetime_SearchTo' => '2100-12-24 12:23:15',
+                ],
+                'expectedFixtureNames' => ['lowrange', 'midrange'],
+            ],
+            'datetime mid range date only' => [
+                'params' => [
+                    'DatetimeWithDateField_SearchFrom' => '1990-01-01',
+                    'DatetimeWithDateField_SearchTo' => '2100-12-24',
+                ],
+                'expectedFixtureNames' => ['midrange'],
+            ],
+            'datetime from only date only' => [
+                'params' => [
+                    'DatetimeWithDateField_SearchFrom' => '1990-01-01',
+                ],
+                'expectedFixtureNames' => ['midrange', 'highrange'],
+            ],
+            'datetime to only date only' => [
+                'params' => [
+                    'DatetimeWithDateField_SearchTo' => '2100-12-24',
+                ],
+                'expectedFixtureNames' => ['lowrange', 'midrange'],
+            ],
+            'datetime mid range date only exact day' => [
+                'params' => [
+                    // The from time should end up being 00:00:00
+                    'DatetimeWithDateField_SearchFrom' => '2005-04-06',
+                    // The to time should end up being 24:59:59
+                    'DatetimeWithDateField_SearchTo' => '2005-04-06',
+                ],
+                'expectedFixtureNames' => ['midrange'],
+            ],
+            // DBTime
+            'time mid range' => [
+                'params' => [
+                    'TimeOnly_SearchFrom' => '05:23:45',
+                    'TimeOnly_SearchTo' => '17:01:23',
+                ],
+                'expectedFixtureNames' => ['midrange'],
+            ],
+            'time from only' => [
+                'params' => [
+                    'TimeOnly_SearchFrom' => '05:23:45',
+                ],
+                'expectedFixtureNames' => ['midrange', 'highrange'],
+            ],
+            'time to only' => [
+                'params' => [
+                    'TimeOnly_SearchTo' => '17:01:23',
+                ],
+                'expectedFixtureNames' => ['lowrange', 'midrange'],
+            ],
+            // DBInt
+            'int mid range' => [
+                'params' => [
+                    'IntRange_SearchFrom' => '53',
+                    'IntRange_SearchTo' => '623',
+                ],
+                'expectedFixtureNames' => ['midrange'],
+            ],
+            'int from only' => [
+                'params' => [
+                    'IntRange_SearchFrom' => '53',
+                ],
+                'expectedFixtureNames' => ['midrange', 'highrange'],
+            ],
+            'int to only' => [
+                'params' => [
+                    'IntRange_SearchTo' => '623',
+                ],
+                'expectedFixtureNames' => ['lowrange', 'midrange'],
+            ],
+            // DBDecimal
+            'decimal mid range' => [
+                'params' => [
+                    'DecimalRange_SearchFrom' => '2.0',
+                    'DecimalRange_SearchTo' => '63.125',
+                ],
+                'expectedFixtureNames' => ['midrange'],
+            ],
+            'decimal from only' => [
+                'params' => [
+                    'DecimalRange_SearchFrom' => '2.0',
+                ],
+                'expectedFixtureNames' => ['midrange', 'highrange'],
+            ],
+            'decimal to only' => [
+                'params' => [
+                    'DecimalRange_SearchTo' => '63.125',
+                ],
+                'expectedFixtureNames' => ['lowrange', 'midrange'],
+            ],
+            // DBFloat
+            'float mid range' => [
+                'params' => [
+                    'FloatRange_SearchFrom' => '2.0',
+                    'FloatRange_SearchTo' => '63.125',
+                ],
+                'expectedFixtureNames' => ['midrange'],
+            ],
+            'float from only' => [
+                'params' => [
+                    'FloatRange_SearchFrom' => '2.0',
+                ],
+                'expectedFixtureNames' => ['midrange', 'highrange'],
+            ],
+            'float to only' => [
+                'params' => [
+                    'FloatRange_SearchTo' => '63.125',
+                ],
+                'expectedFixtureNames' => ['lowrange', 'midrange'],
+            ],
+            // DBPercentage
+            'percentage mid range' => [
+                'params' => [
+                    'PercentageRange_SearchFrom' => '0.12',
+                    'PercentageRange_SearchTo' => '0.75',
+                ],
+                'expectedFixtureNames' => ['midrange'],
+            ],
+            'percentage from only' => [
+                'params' => [
+                    'PercentageRange_SearchFrom' => '0.12',
+                ],
+                'expectedFixtureNames' => ['midrange', 'highrange'],
+            ],
+            'percentage to only' => [
+                'params' => [
+                    'PercentageRange_SearchTo' => '0.75',
+                ],
+                'expectedFixtureNames' => ['lowrange', 'midrange'],
+            ],
+            // DBYear
+            'year mid range' => [
+                'params' => [
+                    'YearRange_SearchFrom' => '1990',
+                    'YearRange_SearchTo' => '2100',
+                ],
+                'expectedFixtureNames' => ['midrange'],
+            ],
+            'year from only' => [
+                'params' => [
+                    'YearRange_SearchFrom' => '1990',
+                ],
+                'expectedFixtureNames' => ['midrange', 'highrange'],
+            ],
+            'year to only' => [
+                'params' => [
+                    'YearRange_SearchTo' => '2100',
+                ],
+                'expectedFixtureNames' => ['lowrange', 'midrange'],
+            ],
+            // DBCurrency
+            'currency mid range' => [
+                'params' => [
+                    'CurrencyRange_SearchFrom' => '2.0',
+                    'CurrencyRange_SearchTo' => '63.125',
+                ],
+                'expectedFixtureNames' => ['midrange'],
+            ],
+            'currency from only' => [
+                'params' => [
+                    'CurrencyRange_SearchFrom' => '2.0',
+                ],
+                'expectedFixtureNames' => ['midrange', 'highrange'],
+            ],
+            'currency to only' => [
+                'params' => [
+                    'CurrencyRange_SearchTo' => '63.125',
+                ],
+                'expectedFixtureNames' => ['lowrange', 'midrange'],
+            ],
+            // Special match_any config
+            'match_any mid range' => [
+                'params' => [
+                    'MatchAnyRange_SearchFrom' => '2.0',
+                    'MatchAnyRange_SearchTo' => '63.125',
+                ],
+                'expectedFixtureNames' => ['midrange'],
+            ],
+            'match_any from only' => [
+                'params' => [
+                    'MatchAnyRange_SearchFrom' => '2.0',
+                ],
+                'expectedFixtureNames' => ['midrange', 'highrange'],
+            ],
+            'match_any to only' => [
+                'params' => [
+                    'MatchAnyRange_SearchTo' => '63.125',
+                ],
+                'expectedFixtureNames' => ['lowrange', 'midrange'],
+            ],
+            // DBVarchar
+            'varchar mid range' => [
+                'params' => [
+                    'VarcharRangeWithConfig_SearchFrom' => 'e',
+                    'VarcharRangeWithConfig_SearchTo' => 's',
+                ],
+                'expectedFixtureNames' => ['midrange'],
+            ],
+            'varchar from only' => [
+                'params' => [
+                    'VarcharRangeWithConfig_SearchFrom' => 'e',
+                ],
+                'expectedFixtureNames' => ['midrange', 'highrange'],
+            ],
+            'varchar to only' => [
+                'params' => [
+                    'VarcharRangeWithConfig_SearchTo' => 's',
+                ],
+                'expectedFixtureNames' => ['lowrange', 'midrange'],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideQueryWithinRangeFilter')]
+    public function testQueryWithinRangeFilter(array $params, array $expectedFixtureNames): void
+    {
+        $model = SearchContextTest\WithinRangeFilterModel::singleton();
+        $context = $model->getDefaultSearchContext();
+        $results = $context->getResults($params)->column('ID');
+
+        $found = [];
+        foreach ($expectedFixtureNames as $fixtureName) {
+            $id = $this->idFromFixture(SearchContextTest\WithinRangeFilterModel::class, $fixtureName);
+            if (in_array($id, $results)) {
+                $found[] = $fixtureName;
+            }
+        }
+
+        $this->assertSame($expectedFixtureNames, $found);
+        $this->assertCount(count($expectedFixtureNames), $results, 'More results found than expected');
     }
 
     public function testCanGenerateQueryUsingAllFilterTypes()

--- a/tests/php/ORM/Search/SearchContextTest.yml
+++ b/tests/php/ORM/Search/SearchContextTest.yml
@@ -71,6 +71,44 @@ SilverStripe\ORM\Tests\Search\SearchContextTest\AllFilterTypes:
     EndsWith: abcd-efgh-ijkl
     FulltextField: one two three
 
+SilverStripe\ORM\Tests\Search\SearchContextTest\WithinRangeFilterModel:
+  lowrange:
+    DateOnly: '1912-05-03'
+    Datetime: '1912-05-03 01:23:45'
+    DatetimeWithDateField: '1912-05-03 01:23:45'
+    TimeOnly: '01:23:45'
+    IntRange: 13
+    DecimalRange: 1.234
+    FloatRange: 1.234
+    PercentageRange: 0.05
+    YearRange: 1912
+    CurrencyRange: 1.23
+    VarcharRangeWithConfig: 'c'
+  midrange:
+    DateOnly: '2005-04-06'
+    Datetime: '2005-04-06 12:34:56'
+    DatetimeWithDateField: '2005-04-06 12:34:56'
+    TimeOnly: '12:34:56'
+    IntRange: 500
+    DecimalRange: 12.34
+    FloatRange: 12.34
+    PercentageRange: 0.53
+    YearRange: 2005
+    CurrencyRange: 12.34
+    VarcharRangeWithConfig: 'l'
+  highrange:
+    DateOnly: '2123-03-07'
+    Datetime: '2123-03-07 23:45:47'
+    DatetimeWithDateField: '2123-03-07 23:45:47'
+    TimeOnly: '23:45:47'
+    IntRange: 1234
+    DecimalRange: 123.4
+    FloatRange: 123.4
+    PercentageRange: 0.95
+    YearRange: 2123
+    CurrencyRange: 123.4
+    VarcharRangeWithConfig: 'x'
+
 SilverStripe\ORM\Tests\Search\SearchContextTest\Customer:
   customer1:
     FirstName: Bill

--- a/tests/php/ORM/Search/SearchContextTest/AllFilterTypes.php
+++ b/tests/php/ORM/Search/SearchContextTest/AllFilterTypes.php
@@ -5,6 +5,9 @@ namespace SilverStripe\ORM\Tests\Search\SearchContextTest;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
 
+/**
+ * Note this model intentionally omits WithinRangeFilter because that will be tested separately.
+ */
 class AllFilterTypes extends DataObject implements TestOnly
 {
     private static $table_name = 'SearchContextTest_AllFilterTypes';

--- a/tests/php/ORM/Search/SearchContextTest/WithinRangeFilterModel.php
+++ b/tests/php/ORM/Search/SearchContextTest/WithinRangeFilterModel.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\Search\SearchContextTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\DateField;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\FieldType\DBDecimal;
+use SilverStripe\ORM\Filters\WithinRangeFilter;
+
+class WithinRangeFilterModel extends DataObject implements TestOnly
+{
+    private static $table_name = 'SearchContextTest_WithinRangeFilterModel';
+
+    private static $db = [
+        // All date, time, and numeric fields are supported automatically
+        'DateOnly' => 'Date',
+        'Datetime' => 'Datetime',
+        'DatetimeWithDateField' => 'Datetime',
+        'TimeOnly' => 'Time',
+        'IntRange' => 'Int',
+        'DecimalRange' => 'Decimal',
+        'FloatRange' => 'Float',
+        'PercentageRange' => 'Percentage',
+        'YearRange' => 'Year',
+        'CurrencyRange' => 'Currency',
+        // Other field types require additional configuration but can work
+        'VarcharRangeWithConfig' => 'Varchar',
+    ];
+
+    private static $searchable_fields = [
+        'DateOnly' => WithinRangeFilter::class,
+        'Datetime' => WithinRangeFilter::class,
+        'DatetimeWithDateField' => [
+            'filter' => WithinRangeFilter::class,
+            'field' => DateField::class,
+        ],
+        'TimeOnly' => WithinRangeFilter::class,
+        'IntRange' => WithinRangeFilter::class,
+        'DecimalRange' => WithinRangeFilter::class,
+        'FloatRange' => WithinRangeFilter::class,
+        'PercentageRange' => WithinRangeFilter::class,
+        'YearRange' => WithinRangeFilter::class,
+        'CurrencyRange' => WithinRangeFilter::class,
+        // Special "match_any" config can also work with this filter
+        'MatchAnyRange' => [
+            'filter' => WithinRangeFilter::class,
+            'dataType' => DBDecimal::class,
+            'match_any' => [
+                'DecimalRange',
+                'FloatRange',
+                'CurrencyRange',
+            ],
+        ],
+        // Note the addition of rangeFromDefault and rangeToDefault here
+        'VarcharRangeWithConfig' => [
+            'filter' => WithinRangeFilter::class,
+            'rangeFromDefault' => 'a',
+            'rangeToDefault' => 'z',
+        ],
+    ];
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR has multiple commits. Do not squash - or if you do, use the second commit's message

This PR enables using `WithinRangeFilter` to filter by numeric, date, and time fields in `searchable_fields`. It can also be used with other field types (see the varchar unit test scenario) if some additional config is provided.

This PR is required so that the current `SiteTree` filter on `LastEdited` can be performed using a `SearchContext` instead of using the current custom weird filter it uses.

Note that this PR does _not_ include any updates to the css e.g. to make date fields look nicer - that will come in https://github.com/silverstripe/silverstripe-admin/pull/1897. For now we're adding just the functionality itself.

See the docs or unit tests for configuration that you can use to test locally.

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2949