### PR TITLE
FIX Prevent invalid i18n sources from being collected

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -4429,8 +4429,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         $pluralName = $this->plural_name();
         $singularName = $this->singular_name();
         $conjunction = preg_match('/^[aeiou]/i', $singularName ?? '') ? 'An ' : 'A ';
-        return [
-            static::class . '.CLASS_DESCRIPTION' => $this->classDescription(),
+        $entities = [
             static::class . '.SINGULARNAME' => $singularName,
             static::class . '.PLURALNAME' => $pluralName,
             static::class . '.PLURALS' => [
@@ -4438,6 +4437,11 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
                 'other' => '{count} ' . $pluralName
             ]
         ];
+        $classDescription = $this->classDescription();
+        if ($classDescription) {
+            $entities[static::class . '.CLASS_DESCRIPTION'] = $classDescription;
+        }
+        return $entities;
     }
 
     /**

--- a/src/i18n/TextCollection/i18nTextCollector.php
+++ b/src/i18n/TextCollection/i18nTextCollector.php
@@ -883,7 +883,7 @@ class i18nTextCollector
                     $inTransFn = false;
                     $inConcat = false;
                     // Ensure key is valid before saving
-                    if (!empty($currentEntity[0])) {
+                    if (!empty($currentEntity[0]) && !str_ends_with($currentEntity[0], '.')) {
                         $key = $currentEntity[0];
                         $default = $currentEntity[1] ?? '';
                         $comment = $currentEntity[2] ?? '';

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -2840,4 +2840,56 @@ class DataObjectTest extends SapphireTest
         $this->expectExceptionMessage($expectedMessage);
         $record2->write();
     }
+
+    public static function provideProvideI18nEntities(): array
+    {
+        return [
+            'has-class-description' => [
+                'classDescription' => 'A fluffy cloud',
+                'expected' => true,
+            ],
+            'no-class-description' => [
+                'classDescription' => null,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideProvideI18nEntities
+     */
+    public function testProvideI18nEntities(?string $classDescription, bool $expected): void
+    {
+        $obj = new class extends DataObject {
+            public $classDescription;
+            public function singular_name()
+            {
+                return 'Cloud';
+            }
+            public function plural_name()
+            {
+                return 'Clouds';
+            }
+            public function classDescription()
+            {
+                return $this->classDescription;
+            }
+        };
+        $obj->classDescription = $classDescription;
+        $entities = $obj->provideI18nEntities();
+        // Fix up anonymous class keys
+        foreach ($entities as $key => $entity) {
+            unset($entities[$key]);
+            $newKey = preg_replace('#^.+?\.([A-Z_]+)$#', '$1', $key);
+            $entities[$newKey] = $entity;
+        }
+        $this->assertSame('Cloud', $entities['SINGULARNAME']);
+        $this->assertSame('Clouds', $entities['PLURALNAME']);
+        $this->assertSame(['one' => 'A Cloud', 'other' => '{count} Clouds'], $entities['PLURALS']);
+        if ($expected) {
+            $this->assertSame('A fluffy cloud', $entities['CLASS_DESCRIPTION']);
+        } else {
+            $this->assertFalse(array_key_exists('CLASS_DESCRIPTION', $entities));
+        }
+    }
 }

--- a/tests/php/i18n/i18nTextCollectorTest.php
+++ b/tests/php/i18n/i18nTextCollectorTest.php
@@ -1028,4 +1028,26 @@ PHP;
             'TestEntity.REGULARCONTEXT' => "test {type}",
         ], $collectedTranslatables);
     }
+
+    public function testDoesNotCollectInvalidKeys()
+    {
+        // From the code below this will previously collect `'.' => 'generic'`
+        // Code was added to i18nTextCollector::collectFromCode() to ignore keys
+        // that end with "."
+        $c = i18nTextCollector::create();
+        $mymodule = ModuleLoader::inst()->getManifest()->getModule('i18ntestmodule');
+        $php = <<<'PHP'
+        $data = [
+            $foo,
+            static::get_something($foo),
+            'generic'
+        ];
+        _t(
+            __CLASS__ . '.' . ucfirst($foo) . 'Type',
+            $hello[$foo]
+        );
+        PHP;
+        $collectedTranslatables = $c->collectFromCode($php, null, $mymodule);
+        $this->assertEmpty($collectedTranslatables);
+    }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/365

Fixes a couple of bugs that showed up when running the text collector:
- In assets File.php, an invalid key ending with "." with a value of "generic" was being collected
- There were lots of invalid `CLASS_DESCRIPTION: null` being collected in multiple modules