### PR TITLE
FIX Handle composite fields in GridFIeldFilterHeader

### DIFF
--- a/src/Forms/GridField/GridFieldFilterHeader.php
+++ b/src/Forms/GridField/GridFieldFilterHeader.php
@@ -8,6 +8,7 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Dev\Deprecation;
+use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\Schema\FormSchema;
@@ -305,7 +306,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
             $searchField = $searchField && property_exists($searchField, 'name') ? $searchField->name : null;
         }
 
-        // Prefix "Search__" onto the filters for the React component
+        // Prefix "Search__" onto the filters to match the field names in the actual form
         $filters = $context->getSearchParams();
         if (!empty($filters)) {
             $filters = array_combine(array_map(function ($key) {
@@ -362,14 +363,10 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
             return $this->searchForm;
         }
 
-        // Append a prefix to search field names to prevent conflicts with other fields in the search form
-        foreach ($searchFields as $field) {
-            $field->setName('Search__' . $field->getName());
-        }
-
-        $columns = $gridField->getColumns();
+        $this->addSearchPrefixToFields($searchFields);
 
         // Update field titles to match column titles
+        $columns = $gridField->getColumns();
         foreach ($columns as $columnField) {
             $metadata = $gridField->getColumnMetadata($columnField);
             // Get the field name, without any modifications
@@ -382,9 +379,7 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
             }
         }
 
-        foreach ($searchFields->getIterator() as $field) {
-            $field->addExtraClass('stacked no-change-track');
-        }
+        $this->updateFieldClasses($searchFields);
 
         $name = $this->getTitle($gridField, singleton($gridField->getModelClass()));
 
@@ -455,5 +450,31 @@ class GridFieldFilterHeader extends AbstractGridFieldComponent implements GridFi
                 _t('SilverStripe\\Forms\\GridField\\GridField.OpenFilter', "Open search and filter")
             )
         ];
+    }
+
+    /**
+     * Append a prefix to search field names to prevent conflicts with other fields in the search form
+     */
+    private function addSearchPrefixToFields(FieldList $fields): void
+    {
+        foreach ($fields as $field) {
+            $field->setName('Search__' . $field->getName());
+            if ($field instanceof CompositeField) {
+                $this->addSearchPrefixToFields($field->getChildren());
+            }
+        }
+    }
+
+    /**
+     * Update CSS classes for form fields, including nested inside composite fields
+     */
+    private function updateFieldClasses(FieldList $fields): void
+    {
+        foreach ($fields as $field) {
+            $field->addExtraClass('stacked no-change-track');
+            if ($field instanceof CompositeField) {
+                $this->updateFieldClasses($field->getChildren());
+            }
+        }
     }
 }

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest.php
@@ -143,11 +143,17 @@ class GridFieldFilterHeaderTest extends SapphireTest
     {
         $searchForm = $this->component->getSearchForm($this->gridField);
         $this->assertTrue($searchForm instanceof Form);
-        $fields = $searchForm->Fields()->toArray();
+        $fields = $searchForm->Fields()->flattenFields()->toArray();
         $this->assertEquals('Search__q', $fields[0]->Name);
         $this->assertEquals('Search__Name', $fields[1]->Name);
         $this->assertEquals('Search__City', $fields[2]->Name);
         $this->assertEquals('Search__Cheerleader__Hat__Colour', $fields[3]->Name);
+        $this->assertEquals('Search__TestCompositeSingleTestCompositeNestedGroup', $fields[4]->Name);
+        $this->assertEquals('Search__TestCompositeSingle', $fields[5]->Name);
+        $this->assertEquals('Search__TestCompositeNestedGroup', $fields[6]->Name);
+        $this->assertEquals('Search__TestCompositeNested', $fields[7]->Name);
+        // Make sure there aren't additional fields we're not testing for
+        $this->assertCount(8, $fields);
         $this->assertEquals('TeamsSearchForm', $searchForm->Name);
         $this->assertTrue($searchForm->hasExtraClass('cms-search-form'));
         foreach ($fields as $field) {

--- a/tests/php/Forms/GridField/GridFieldFilterHeaderTest/Team.php
+++ b/tests/php/Forms/GridField/GridFieldFilterHeaderTest/Team.php
@@ -3,6 +3,8 @@
 namespace SilverStripe\Forms\Tests\GridField\GridFieldFilterHeaderTest;
 
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\CompositeField;
+use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\DataObject;
 
 class Team extends DataObject implements TestOnly
@@ -28,5 +30,17 @@ class Team extends DataObject implements TestOnly
     public function getMySummaryField()
     {
         return 'MY SUMMARY FIELD';
+    }
+
+    public function scaffoldSearchFields($_params = null)
+    {
+        $fields = parent::scaffoldSearchFields($_params);
+        $fields->add(new CompositeField([
+            new TextField('TestCompositeSingle'),
+            new CompositeField([
+                new TextField('TestCompositeNested'),
+            ])
+        ]));
+        return $fields;
     }
 }


### PR DESCRIPTION
In the CMS search filter, composite fields would always appear empty after submitting the form (even though it applies the filter) because their prefix was missing. That could also introduce conflicts if a same-named field was in the main edit form.

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2949