### PR TITLE
API Do not raise user_error from Controller::curr()

### DIFF
--- a/src/Control/Controller.php
+++ b/src/Control/Controller.php
@@ -527,30 +527,10 @@ class Controller extends RequestHandler implements TemplateGlobalProvider
 
     /**
      * Returns the current controller.
-     *
-     * @return Controller
      */
-    public static function curr()
+    public static function curr(): ?Controller
     {
-        if (Controller::$controller_stack) {
-            return Controller::$controller_stack[0];
-        }
-        // This user_error() will be removed in the next major version of Silverstripe CMS
-        user_error("No current controller available", E_USER_WARNING);
-        return null;
-    }
-
-    /**
-     * Tests whether we have a currently active controller or not. True if there is at least 1
-     * controller in the stack.
-     *
-     * @return bool
-     * @deprecated 5.4.0 Will be removed without equivalent functionality to replace it
-     */
-    public static function has_curr()
-    {
-        Deprecation::noticeWithNoReplacment('5.4.0');
-        return Controller::$controller_stack ? true : false;
+        return Controller::$controller_stack[0] ?? null;
     }
 
     /**

--- a/src/Control/Cookie.php
+++ b/src/Control/Cookie.php
@@ -133,10 +133,7 @@ class Cookie
      */
     private static function getRequest(): ?HTTPRequest
     {
-        $request = null;
-        if (Controller::has_curr()) {
-            $request = Controller::curr()->getRequest();
-        }
+        $request = Controller::curr()?->getRequest();
         // NullHTTPRequest always has a scheme of http - set to null so we can fallback on default_base_url
         return ($request instanceof NullHTTPRequest) ? null : $request;
     }

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -597,7 +597,7 @@ abstract class SapphireTest extends TestCase implements TestOnly
         // Note: Ideally a clean Controller should be created for each test.
         // Now all tests executed in a batch share the same controller.
         if (class_exists(Controller::class)) {
-            $controller = Controller::has_curr() ? Controller::curr() : null;
+            $controller = Controller::curr();
             if ($controller && ($response = $controller->getResponse()) && $response->getHeader('Location')) {
                 $response->setStatusCode(200);
                 $response->removeHeader('Location');

--- a/src/Dev/TestSession.php
+++ b/src/Dev/TestSession.php
@@ -71,11 +71,11 @@ class TestSession
     {
         // Shift off anything else that's on the stack.  This can happen if something throws
         // an exception that causes a premature TestSession::__destruct() call
-        while (Controller::has_curr() && Controller::curr() !== $this->controller) {
+        while (Controller::curr() && Controller::curr() !== $this->controller) {
             Controller::curr()->popCurrent();
         }
 
-        if (Controller::has_curr()) {
+        if (Controller::curr()) {
             $this->controller->popCurrent();
         }
     }

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -384,7 +384,7 @@ class Form extends ModelData implements HasRequestHandler, ValidationInterface
             return $controller->getRequest();
         }
         // Fall back to current controller
-        if (Controller::has_curr() && !(Controller::curr()->getRequest() instanceof NullHTTPRequest)) {
+        if (Controller::curr() && !(Controller::curr()->getRequest() instanceof NullHTTPRequest)) {
             return Controller::curr()->getRequest();
         }
         return null;

--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -475,7 +475,7 @@ class GridField extends FormField
     private function addStateFromRequest(): void
     {
         $request = $this->getRequest();
-        if (($request instanceof NullHTTPRequest) && Controller::has_curr()) {
+        if (($request instanceof NullHTTPRequest) && Controller::curr()) {
             $request = Controller::curr()->getRequest();
         }
 

--- a/src/Logging/ErrorOutputHandler.php
+++ b/src/Logging/ErrorOutputHandler.php
@@ -169,7 +169,7 @@ class ErrorOutputHandler extends AbstractProcessingHandler
             return;
         }
 
-        if (Controller::has_curr()) {
+        if (Controller::curr()) {
             $response = Controller::curr()->getResponse();
         } else {
             $response = new HTTPResponse();

--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -609,10 +609,10 @@ class Hierarchy extends Extension
      */
     public function showingCMSTree()
     {
-        if (!Controller::has_curr() || !class_exists(LeftAndMain::class)) {
+        $controller = Controller::curr();
+        if (!$controller || !class_exists(LeftAndMain::class)) {
             return false;
         }
-        $controller = Controller::curr();
         return $controller instanceof LeftAndMain
             && in_array($controller->getAction(), ["treeview", "listview", "getsubtree"]);
     }

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -326,7 +326,7 @@ class Security extends Controller implements TemplateGlobalProvider
             ];
         };
 
-        if (!$controller && Controller::has_curr()) {
+        if (!$controller && Controller::curr()) {
             $controller = Controller::curr();
         }
 
@@ -526,8 +526,9 @@ class Security extends Controller implements TemplateGlobalProvider
             return $request;
         }
 
-        if (Controller::has_curr() && Controller::curr() !== $this) {
-            return Controller::curr()->getRequest();
+        $controller = Controller::curr();
+        if ($controller && $controller !== $this) {
+            return $controller->getRequest();
         }
 
         return null;

--- a/src/Security/SecurityToken.php
+++ b/src/Security/SecurityToken.php
@@ -184,7 +184,7 @@ class SecurityToken implements TemplateGlobalProvider
         $injector = Injector::inst();
         if ($injector->has(HTTPRequest::class)) {
             return $injector->get(HTTPRequest::class)->getSession();
-        } elseif (Controller::has_curr()) {
+        } elseif (Controller::curr()) {
             return Controller::curr()->getRequest()->getSession();
         }
         throw new Exception('No HTTPRequest object or controller available yet!');

--- a/tests/php/Control/ControllerTest/TestController.php
+++ b/tests/php/Control/ControllerTest/TestController.php
@@ -13,8 +13,9 @@ class TestController extends Controller implements TestOnly
     public function __construct()
     {
         parent::__construct();
-        if (Controller::has_curr()) {
-            $this->setRequest(Controller::curr()->getRequest());
+        $controller = Controller::curr();
+        if ($controller) {
+            $this->setRequest($controller->getRequest());
         }
     }
 

--- a/tests/php/Control/DirectorTest/TestController.php
+++ b/tests/php/Control/DirectorTest/TestController.php
@@ -11,8 +11,9 @@ class TestController extends Controller implements TestOnly
     public function __construct()
     {
         parent::__construct();
-        if (Controller::has_curr()) {
-            $this->setRequest(Controller::curr()->getRequest());
+        $controller = Controller::curr();
+        if ($controller) {
+            $this->setRequest($controller->getRequest());
         }
     }
 

--- a/tests/php/Control/RequestHandlingTest/TestController.php
+++ b/tests/php/Control/RequestHandlingTest/TestController.php
@@ -42,8 +42,9 @@ class TestController extends Controller implements TestOnly
     {
         $this->failover = new ControllerFailover();
         parent::__construct();
-        if (Controller::has_curr()) {
-            $this->setRequest(Controller::curr()->getRequest());
+        $controller = Controller::curr();
+        if ($controller) {
+            $this->setRequest($controller->getRequest());
         }
     }
 

--- a/tests/php/Forms/EmailFieldTest/TestController.php
+++ b/tests/php/Forms/EmailFieldTest/TestController.php
@@ -17,8 +17,9 @@ class TestController extends Controller implements TestOnly
     public function __construct()
     {
         parent::__construct();
-        if (Controller::has_curr()) {
-            $this->setRequest(Controller::curr()->getRequest());
+        $controller = Controller::curr();
+        if ($controller) {
+            $this->setRequest($controller->getRequest());
         }
     }
 

--- a/tests/php/Forms/FormFactoryTest/TestController.php
+++ b/tests/php/Forms/FormFactoryTest/TestController.php
@@ -15,8 +15,9 @@ class TestController extends Controller
     public function __construct()
     {
         parent::__construct();
-        if (Controller::has_curr()) {
-            $this->setRequest(Controller::curr()->getRequest());
+        $controller = Controller::curr();
+        if ($controller) {
+            $this->setRequest($controller->getRequest());
         }
     }
 

--- a/tests/php/Forms/FormTest/ControllerWithSpecialSubmittedValueFields.php
+++ b/tests/php/Forms/FormTest/ControllerWithSpecialSubmittedValueFields.php
@@ -23,8 +23,9 @@ class ControllerWithSpecialSubmittedValueFields extends Controller implements Te
     public function __construct()
     {
         parent::__construct();
-        if (Controller::has_curr()) {
-            $this->setRequest(Controller::curr()->getRequest());
+        $controller = Controller::curr();
+        if ($controller) {
+            $this->setRequest($controller->getRequest());
         }
     }
 

--- a/tests/php/Forms/FormTest/TestController.php
+++ b/tests/php/Forms/FormTest/TestController.php
@@ -22,8 +22,9 @@ class TestController extends Controller implements TestOnly
     public function __construct()
     {
         parent::__construct();
-        if (Controller::has_curr()) {
-            $this->setRequest(Controller::curr()->getRequest());
+        $controller = Controller::curr();
+        if ($controller) {
+            $this->setRequest($controller->getRequest());
         }
     }
 

--- a/tests/php/Forms/GridField/GridFieldAddExistingAutocompleterTest/TestController.php
+++ b/tests/php/Forms/GridField/GridFieldAddExistingAutocompleterTest/TestController.php
@@ -17,8 +17,9 @@ class TestController extends Controller implements TestOnly
     public function __construct()
     {
         parent::__construct();
-        if (Controller::has_curr()) {
-            $this->setRequest(Controller::curr()->getRequest());
+        $controller = Controller::curr();
+        if ($controller) {
+            $this->setRequest($controller->getRequest());
         }
     }
 

--- a/tests/php/Forms/GridField/GridFieldDetailFormTest/TestController.php
+++ b/tests/php/Forms/GridField/GridFieldDetailFormTest/TestController.php
@@ -20,8 +20,9 @@ class TestController extends Controller implements TestOnly
     public function __construct()
     {
         parent::__construct();
-        if (Controller::has_curr()) {
-            $this->setRequest(Controller::curr()->getRequest());
+        $controller = Controller::curr();
+        if ($controller) {
+            $this->setRequest($controller->getRequest());
         }
     }
 

--- a/tests/php/Forms/GridField/GridField_URLHandlerTest/TestController.php
+++ b/tests/php/Forms/GridField/GridField_URLHandlerTest/TestController.php
@@ -15,8 +15,9 @@ class TestController extends Controller implements TestOnly
     public function __construct()
     {
         parent::__construct();
-        if (Controller::has_curr()) {
-            $this->setRequest(Controller::curr()->getRequest());
+        $controller = Controller::curr();
+        if ($controller) {
+            $this->setRequest($controller->getRequest());
         }
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11386

This PR also removes `Controller::has_curr()` as it's no longer needed since `Controller::curr()` will now return `null` which can be tested against