### PR TITLE
MNT Fix unit test providers

### DIFF
--- a/tests/php/Forms/GridField/GridFieldPrintButtonTest.php
+++ b/tests/php/Forms/GridField/GridFieldPrintButtonTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Forms\Tests\GridField;
 
 use LogicException;
 use ReflectionMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Control\Controller;
 use SilverStripe\Dev\CSSContentParser;
@@ -98,7 +99,7 @@ class GridFieldPrintButtonTest extends SapphireTest
         $this->assertSame($names, $foundNames);
     }
 
-    public function provideHandlePrintEscaping(): array
+    public static function provideHandlePrintEscaping(): array
     {
         return [
             // Without data columns component
@@ -193,9 +194,8 @@ class GridFieldPrintButtonTest extends SapphireTest
      * Explicitly tests that the following are both true:
      * - XML entities are not double-escaped
      * - XSS attack vectors are not introduced
-     *
-     * @dataProvider provideHandlePrintEscaping
      */
+    #[DataProvider('provideHandlePrintEscaping')]
     public function testHandlePrintEscaping(string|DBField $value, bool $useGridFieldDataColumns, string $expected): void
     {
         $component = new GridFieldPrintButton();

--- a/tests/php/ORM/DataObjectTest.php
+++ b/tests/php/ORM/DataObjectTest.php
@@ -2855,9 +2855,7 @@ class DataObjectTest extends SapphireTest
         ];
     }
 
-    /**
-     * @dataProvider provideProvideI18nEntities
-     */
+    #[DataProvider('provideProvideI18nEntities')]
     public function testProvideI18nEntities(?string $classDescription, bool $expected): void
     {
         $obj = new class extends DataObject {
@@ -2870,7 +2868,7 @@ class DataObjectTest extends SapphireTest
             {
                 return 'Clouds';
             }
-            public function classDescription()
+            public function classDescription(): ?string
             {
                 return $this->classDescription;
             }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/actions/runs/13299837085/job/37139181714?pr=11602

```text
1) SilverStripe\Forms\Tests\GridField\GridFieldPrintButtonTest::testHandlePrintEscaping
The data provider specified for SilverStripe\Forms\Tests\GridField\GridFieldPrintButtonTest::testHandlePrintEscaping is invalid
Data Provider method SilverStripe\Forms\Tests\GridField\GridFieldPrintButtonTest::provideHandlePrintEscaping() is not static

/home/runner/work/silverstripe-framework/silverstripe-framework/tests/php/Forms/GridField/GridFieldPrintButtonTest.php:199
```

```text
 There were 2 PHPUnit test runner deprecations:

1) Metadata found in doc-comment for method SilverStripe\Forms\Tests\GridField\GridFieldPrintButtonTest::testHandlePrintEscaping(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

2) Metadata found in doc-comment for method SilverStripe\ORM\Tests\DataObjectTest::testProvideI18nEntities(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.
```

And https://github.com/silverstripe/silverstripe-framework/actions/runs/13316490516/job/37191706970

```text
 PHP Fatal error:  Declaration of SilverStripe\ORM\DataObject@anonymous::classDescription() must be compatible with SilverStripe\ORM\DataObject::classDescription(): ?string in /home/runner/work/silverstripe-framework/silverstripe-framework/tests/php/ORM/DataObjectTest.php on line 2871
```

## Issue
- https://github.com/silverstripe/.github/issues/366