### PR TITLE
FIX EmailField::validate returns bool

### DIFF
--- a/src/Forms/EmailField.php
+++ b/src/Forms/EmailField.php
@@ -24,8 +24,7 @@ class EmailField extends TextField
      * @see http://www.ietf.org/rfc/rfc2822.txt
      *
      * @param Validator $validator
-     *
-     * @return string
+     * @return bool
      */
     public function validate($validator)
     {


### PR DESCRIPTION
## Description
Just a minor phpdoc update i noticed while working with phpstan

## Manual testing steps
extendValidationResult returns bool, so does this

## Issues
i'm not sure an issue is required for this :)

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
