### PR TITLE
ENH Make SudoModeService extensible

### DIFF
--- a/src/Security/SudoMode/SudoModeService.php
+++ b/src/Security/SudoMode/SudoModeService.php
@@ -4,11 +4,13 @@ namespace SilverStripe\Security\SudoMode;
 
 use SilverStripe\Control\Session;
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Extensible;
 use SilverStripe\ORM\FieldType\DBDatetime;
 
 class SudoModeService implements SudoModeServiceInterface
 {
     use Configurable;
+    use Extensible;
 
     /**
      * The lifetime that sudo mode authorization lasts for, in minutes.


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/368

This is a fairly strange PR to fix behat tests in recip-kitchen-sink for totp-authenticator and session-manager.  Both of the module did not recieve new minor releases as part of CMS 5.4, though they did receive PR's [here](https://github.com/silverstripe/silverstripe-totp-authenticator/pull/185) and [here](https://github.com/silverstripe/silverstripe-session-manager/pull/235) to their `5` branches to fix behat as part of the recipet sudo mode work

Backport those behat PR's to the current minor branches for totp-authenticator + session manager do not work, because they will still correctly use installer 5.3 and thus framework 5.3 in CI, however the SudoModeService in framework 5.3 does not have the Extensible trait, so you cannot run `Given I add an extension "SilverStripe\BehatExtension\Extensions\ActivateSudoModeServiceExtension" to the "SilverStripe\Security\SudoMode\SudoModeService" class` in behat.

We *could* release beta2 which specifcally releases new versions of totp-authenticator + session-manager who each bump their requirement of framework to 5.4, though I think it's much better to just make SudoModeService be Extensible in 5.3 instead.