### PR TITLE
API Deprecate API that will be removed in CMS 6

### DIFF
--- a/src/Forms/HTMLEditor/HTMLEditorField.php
+++ b/src/Forms/HTMLEditor/HTMLEditorField.php
@@ -54,6 +54,7 @@ class HTMLEditorField extends TextareaField
      * Extra height per row
      *
      * @var int
+     * @deprecated 5.4.0 Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorConfig.fixed_row_height
      */
     private static $fixed_row_height = 20;
 

--- a/src/Forms/HTMLEditor/HTMLEditorSanitiser.php
+++ b/src/Forms/HTMLEditor/HTMLEditorSanitiser.php
@@ -7,6 +7,7 @@ use DOMElement;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\XssSanitiser;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\View\Parsers\HTMLValue;
 use stdClass;
 
@@ -34,12 +35,22 @@ class HTMLEditorSanitiser
      */
     private static $link_rel_value = 'noopener noreferrer';
 
-    /** @var stdClass - $element => $rule hash for whitelist element rules where the element name isn't a pattern */
+    /**
+     * @var stdClass - $element => $rule hash for whitelist element rules where the element name isn't a pattern
+     * @deprecated 5.4.0 Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorRuleSet
+     */
     protected $elements = [];
-    /** @var stdClass - Sequential list of whitelist element rules where the element name is a pattern */
+
+    /**
+     * @var stdClass - Sequential list of whitelist element rules where the element name is a pattern
+     * @deprecated 5.4.0 Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorRuleSet
+     */
     protected $elementPatterns = [];
 
-    /** @var stdClass - The list of attributes that apply to all further whitelisted elements added */
+    /**
+     * @var stdClass - The list of attributes that apply to all further whitelisted elements added
+     * @deprecated 5.4.0 Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorRuleSet
+     */
     protected $globalAttributes = [];
 
     /**
@@ -68,9 +79,14 @@ class HTMLEditorSanitiser
      *
      * @param $str - The TinyMCE pattern
      * @return string - The equivalent regex
+     * @deprecated 5.4.0 Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorRuleSet::patternToRegex()
      */
     protected function patternToRegex($str)
     {
+        Deprecation::noticeWithNoReplacment(
+            '5.4.0',
+            'Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorRuleSet::patternToRegex()'
+        );
         return '/^' . preg_replace('/([?+*])/', '.$1', $str ?? '') . '$/';
     }
 
@@ -81,9 +97,14 @@ class HTMLEditorSanitiser
      * Logic based heavily on javascript version from tiny_mce_src.js
      *
      * @param string $validElements - The valid_elements or extended_valid_elements string to add to the whitelist
+     * @deprecated 5.4.0 Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorRuleSet
      */
     protected function addValidElements($validElements)
     {
+        Deprecation::noticeWithNoReplacment(
+            '5.4.0',
+            'Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorRuleSet'
+        );
         $elementRuleRegExp = '/^([#+\-])?([^\[\/]+)(?:\/([^\[]+))?(?:\[([^\]]+)\])?$/';
         $attrRuleRegExp = '/^([!\-])?(\w+::\w+|[^=:<]+)?(?:([=:<])(.*))?$/';
         $hasPatternsRegExp = '/[*?+]/';
@@ -186,9 +207,14 @@ class HTMLEditorSanitiser
      * Given an element tag, return the rule structure for that element
      * @param string $tag The element tag
      * @return stdClass The element rule
+     * @deprecated 5.4.0 Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorRuleSet::getRuleForElement()
      */
     protected function getRuleForElement($tag)
     {
+        Deprecation::noticeWithNoReplacment(
+            '5.4.0',
+            'Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorRuleSet::getRuleForElement()'
+        );
         if (isset($this->elements[$tag])) {
             return $this->elements[$tag];
         }
@@ -206,9 +232,14 @@ class HTMLEditorSanitiser
      * @param object $elementRule
      * @param string $name The attribute name
      * @return stdClass The attribute rule
+     * @deprecated 5.4.0 Will be replaced with logic in SilverStripe\Forms\HTMLEditor\HTMLEditorElementRule
      */
     protected function getRuleForAttribute($elementRule, $name)
     {
+        Deprecation::noticeWithNoReplacment(
+            '5.4.0',
+            'Will be replaced with logic in SilverStripe\Forms\HTMLEditor\HTMLEditorElementRule'
+        );
         if (isset($elementRule->attributes[$name])) {
             return $elementRule->attributes[$name];
         }
@@ -225,9 +256,14 @@ class HTMLEditorSanitiser
      * @param DOMElement $element The element to check
      * @param stdClass $rule The rule to check against
      * @return bool True if the element passes (and so can be kept), false if it fails (and so needs stripping)
+     * @deprecated 5.4.0 Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorRuleSet::isElementAllowed()
      */
     protected function elementMatchesRule($element, $rule = null)
     {
+        Deprecation::noticeWithNoReplacment(
+            '5.4.0',
+            'Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorRuleSet::isElementAllowed()'
+        );
         // If the rule doesn't exist at all, the element isn't allowed
         if (!$rule) {
             return false;
@@ -263,9 +299,14 @@ class HTMLEditorSanitiser
      * @param DOMAttr $attr - the attribute to check
      * @param stdClass $rule - the rule to check against
      * @return bool - true if the attribute passes (and so can be kept), false if it fails (and so needs stripping)
+     * @deprecated 5.4.0 Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorElementRule::isAttributeAllowed()
      */
     protected function attributeMatchesRule($attr, $rule = null)
     {
+        Deprecation::noticeWithNoReplacment(
+            '5.4.0',
+            'Will be replaced with SilverStripe\Forms\HTMLEditor\HTMLEditorElementRule::isAttributeAllowed()'
+        );
         // If the rule doesn't exist at all, the attribute isn't allowed
         if (!$rule) {
             return false;

--- a/src/Forms/HTMLEditor/TinyMCECombinedGenerator.php
+++ b/src/Forms/HTMLEditor/TinyMCECombinedGenerator.php
@@ -9,10 +9,12 @@ use SilverStripe\Core\Convert;
 use SilverStripe\Core\Flushable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Manifest\ModuleResource;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * Generates tinymce config using a combined file generated via a standard
  * SilverStripe {@link GeneratedAssetHandler}
+ * @deprecated 5.4.0 Will be replaced with SilverStripe\TinyMCE\TinyMCECombinedGenerator
  */
 class TinyMCECombinedGenerator implements TinyMCEScriptGenerator, Flushable
 {
@@ -30,6 +32,15 @@ class TinyMCECombinedGenerator implements TinyMCEScriptGenerator, Flushable
      * @var GeneratedAssetHandler
      */
     protected $assetHandler = null;
+
+    public function __construct()
+    {
+        Deprecation::noticeWithNoReplacment(
+            '5.4.0',
+            'Will be replaced with SilverStripe\TinyMCE\TinyMCECombinedGenerator',
+            Deprecation::SCOPE_CLASS
+        );
+    }
 
     /**
      * Assign backend store for generated assets

--- a/src/Forms/HTMLEditor/TinyMCEConfig.php
+++ b/src/Forms/HTMLEditor/TinyMCEConfig.php
@@ -9,6 +9,7 @@ use SilverStripe\Control\Director;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Manifest\ModuleResource;
 use SilverStripe\Core\Manifest\ModuleResourceLoader;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\i18n\i18n;
 use SilverStripe\i18n\i18nEntityProvider;
 use SilverStripe\View\Requirements;
@@ -17,6 +18,7 @@ use SilverStripe\View\ThemeResourceLoader;
 
 /**
  * Default configuration for HtmlEditor specific to tinymce
+ * @deprecated 5.4.0 Will be replaced with SilverStripe\TinyMCE\TinyMCEConfig
  */
 class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
 {
@@ -354,6 +356,11 @@ class TinyMCEConfig extends HTMLEditorConfig implements i18nEntityProvider
 
     public function __construct()
     {
+        Deprecation::noticeWithNoReplacment(
+            '5.4.0',
+            'Will be replaced with SilverStripe\TinyMCE\TinyMCEConfig',
+            Deprecation::SCOPE_CLASS
+        );
         $this->settings = static::config()->get('default_options');
     }
 

--- a/src/Forms/HTMLEditor/TinyMCEScriptGenerator.php
+++ b/src/Forms/HTMLEditor/TinyMCEScriptGenerator.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Forms\HTMLEditor;
 
 /**
  * Declares a service which can generate a script URL for a given HTMLEditor config
+ * @deprecated 5.4.0 Will be replaced with SilverStripe\TinyMCE\TinyMCEScriptGenerator
  */
 interface TinyMCEScriptGenerator
 {


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/silverstripe-htmleditor-tinymce/issues/2