### PR TITLE
MNT Fix PHP linting in test class

### DIFF
--- a/tests/php/Forms/HTMLEditor/HTMLEditorConfigTest/NullEditorConfig.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorConfigTest/NullEditorConfig.php
@@ -49,5 +49,8 @@ class NullEditorConfig extends HTMLEditorConfig
         return [];
     }
 
-    public function init(): void {}
+    public function init(): void
+    {
+        // no-op
+    }
 }


### PR DESCRIPTION
Fixes linting problem in https://github.com/silverstripe/silverstripe-framework/actions/runs/13847305384/job/38748285260

```text
 FILE: ...ework/tests/php/Forms/HTMLEditor/HTMLEditorConfigTest/NullEditorConfig.php
--------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 1 LINE
--------------------------------------------------------------------------------
 52 | ERROR | [x] Opening brace should be on a new line
 52 | ERROR | [x] Closing brace must be on a line by itself
--------------------------------------------------------------------------------
```

## Issue
- https://github.com/silverstripe/.github/issues/377