### PR TITLE
FIX Remove non-readonly components from sudo mode gridfield

### DIFF
--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -548,7 +548,8 @@ class GridField extends FormField
                 if ($session) {
                     $service = Injector::inst()->get(SudoModeServiceInterface::class);
                     if (!$service->check($session)) {
-                        $this->performReadonlyTransformation();
+                        $copy = $this->performReadonlyTransformation();
+                        $this->setConfig($copy->getConfig());
                         $this->setReadonly(true);
                         $this->addSudoModeComponent();
                         $sudoModeTransformation = true;


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/378

Kitchen sink run to validate it fixes the issue in admin - https://github.com/creative-commoners/recipe-kitchen-sink/actions/runs/13959002995

6.0 fixed up some referencing stuff in GridField::performReadonlyTransformation() - https://github.com/silverstripe/silverstripe-framework/commit/fd5c4657af848bb00fbcdaac0b251b41afccf536#diff-c5907f790efc160f18abbccf8d6d3de8e13eff90e5b3a6119e1447da06f70c40R278-L300

This code changes accounts for that