### PR TITLE
FEAT optimize DataQuery::count for speed

### DIFF
--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -472,7 +472,6 @@ class DataQuery
     public function count()
     {
         $quotedColumn = DataObject::getSchema()->sqlColumnForField($this->dataClass(), 'ID');
-        return $this->getFinalisedQuery()->count("DISTINCT {$quotedColumn}");
         $finalisedQuery = $this->getFinalisedQuery();
         $countColumn = "DISTINCT {$quotedColumn}";
         // COUNT(DISTINCT ...) can be slower compared to COUNT(...) because it requires sorting and removing duplicates to find the unique values

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -473,14 +473,13 @@ class DataQuery
     {
         $quotedColumn = DataObject::getSchema()->sqlColumnForField($this->dataClass(), 'ID');
         $finalisedQuery = $this->getFinalisedQuery();
-        // The COUNT(DISTINCT ...) is added in case a join is added to the query (to apply a filter on related records)
-        $countColumn = "DISTINCT {$quotedColumn}";
         // COUNT(DISTINCT ...) can be slower compared to COUNT(...) because it requires sorting and removing duplicates to find the unique values
         // When using only one table and counting by ID (and since there are no NULL IDs), we can ignore DISTINCT
         if (count($finalisedQuery->getFrom()) === 1) {
-            $countColumn = "{$quotedColumn}";
+            return $finalisedQuery->count($quotedColumn);
         }
-        return $finalisedQuery->count($countColumn);
+        // The COUNT(DISTINCT ...) is added in case a join is added to the query (to apply a filter on related records)
+        return $finalisedQuery->count("DISTINCT {$quotedColumn}");
     }
 
     /**

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -473,6 +473,7 @@ class DataQuery
     {
         $quotedColumn = DataObject::getSchema()->sqlColumnForField($this->dataClass(), 'ID');
         $finalisedQuery = $this->getFinalisedQuery();
+        // The COUNT(DISTINCT ...) is added in case a join is added to the query (to apply a filter on related records)
         $countColumn = "DISTINCT {$quotedColumn}";
         // COUNT(DISTINCT ...) can be slower compared to COUNT(...) because it requires sorting and removing duplicates to find the unique values
         // When using only one table and counting by ID (and since there are no NULL IDs), we can ignore DISTINCT

--- a/src/ORM/DataQuery.php
+++ b/src/ORM/DataQuery.php
@@ -473,6 +473,14 @@ class DataQuery
     {
         $quotedColumn = DataObject::getSchema()->sqlColumnForField($this->dataClass(), 'ID');
         return $this->getFinalisedQuery()->count("DISTINCT {$quotedColumn}");
+        $finalisedQuery = $this->getFinalisedQuery();
+        $countColumn = "DISTINCT {$quotedColumn}";
+        // COUNT(DISTINCT ...) can be slower compared to COUNT(...) because it requires sorting and removing duplicates to find the unique values
+        // When using only one table and counting by ID (and since there are no NULL IDs), we can ignore DISTINCT
+        if (count($finalisedQuery->getFrom()) === 1) {
+            $countColumn = "{$quotedColumn}";
+        }
+        return $finalisedQuery->count($countColumn);
     }
 
     /**

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -466,7 +466,7 @@ class DataQueryTest extends SapphireTest
         $query->sort('"SortOrder"');
         $query->where(
             [
-            '"DataQueryTest_C"."Title" = ?' => ['First']
+                '"DataQueryTest_C"."Title" = ?' => ['First']
             ]
         );
         $result = $query->getFinalisedQuery(['Title']);
@@ -878,5 +878,51 @@ class DataQueryTest extends SapphireTest
         $dataQuery->innerJoin('test_implicit_joins', '"DataQueryTest_G"."ID" = "test_implicit_joins"."ID"');
         // This will throw an exception if it fails - it passes if there's no exception.
         $dataQuery->execute();
+    }
+
+    public function testDistinctCount()
+    {
+        // The COUNT(DISTINCT ...) is added in case a join is added to the query (to apply a filter on related records)
+        $distinct = new DataQueryTest\ObjectHasMultiRelationalHasMany();
+        $distinct->Name = 'Distinct';
+        $distinct->SortOrder =  2;
+        $distinct->write();
+
+        $otherDistinct = new DataQueryTest\ObjectHasMultiRelationalHasMany();
+        $otherDistinct->Name = 'OtherDistinct';
+        $otherDistinct->SortOrder =  1;
+        $otherDistinct->write();
+
+        $baseCount = DataQueryTest\ObjectHasMultiRelationalHasOne::get()->count();
+
+        $obj1 = new DataQueryTest\ObjectHasMultiRelationalHasOne();
+        $obj1->Name = 'sam';
+        $obj1->MultiRelationalID = $distinct->ID;
+        $obj1->write();
+
+        $obj2 = new DataQueryTest\ObjectHasMultiRelationalHasOne();
+        $obj2->Name = 'sam';
+        $obj2->MultiRelationalID = $distinct->ID;
+        $obj2->write();
+
+        $obj3 = new DataQueryTest\ObjectHasMultiRelationalHasOne();
+        $obj3->Name = 'john';
+        $obj3->MultiRelationalID = $otherDistinct->ID;
+        $obj3->write();
+
+        $newCount = DataQueryTest\ObjectHasMultiRelationalHasOne::get()->count();
+
+        $this->assertEquals($baseCount + 3, $newCount);
+
+        // This should return 1, not 2, even if we have two persons called 'sam' but only one 'Distinct' parent
+        $count = DataQueryTest\ObjectHasMultiRelationalHasMany::get()->filter('MultiRelational1.Name', 'sam')->count();
+        $this->assertEquals(1, $count);
+
+        // We have two 'sam' objects
+        $count = DataQueryTest\ObjectHasMultiRelationalHasOne::get()->filter('Name', 'sam')->count();
+        $this->assertEquals(2, $count);
+
+        $count = $distinct->MultiRelational1()->count();
+        $this->assertEquals(2, $count);
     }
 }

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -912,7 +912,7 @@ class DataQueryTest extends SapphireTest
 
         $this->assertEquals($baseCount + 3, $newCount);
 
-        // This should return 1, not 2. We have two persons called 'sam' but only one 'Distinct' parent
+        // This should return 1, not 2. We have two records in the "TestAs" relation called 'sam' but only one 'Distinct' ObjectC parent record
         $count = DataQueryTest\ObjectC::get()->filter("TestAs.Name", 'sam')->count();
         $this->assertEquals(1, $count);
 

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -883,46 +883,44 @@ class DataQueryTest extends SapphireTest
     public function testDistinctCount()
     {
         // The COUNT(DISTINCT ...) is added in case a join is added to the query (to apply a filter on related records)
-        $distinct = new DataQueryTest\ObjectHasMultiRelationalHasMany();
-        $distinct->Name = 'Distinct';
-        $distinct->SortOrder =  2;
+        $distinct = new DataQueryTest\ObjectC();
+        $distinct->Title = 'Distinct';
         $distinct->write();
 
-        $otherDistinct = new DataQueryTest\ObjectHasMultiRelationalHasMany();
-        $otherDistinct->Name = 'OtherDistinct';
-        $otherDistinct->SortOrder =  1;
+        $otherDistinct = new DataQueryTest\ObjectC();
+        $otherDistinct->Title = 'OtherDistinct';
         $otherDistinct->write();
 
-        $baseCount = DataQueryTest\ObjectHasMultiRelationalHasOne::get()->count();
+        $baseCount = DataQueryTest\ObjectA::get()->count();
 
-        $obj1 = new DataQueryTest\ObjectHasMultiRelationalHasOne();
+        $obj1 = new DataQueryTest\ObjectA();
         $obj1->Name = 'sam';
-        $obj1->MultiRelationalID = $distinct->ID;
+        $obj1->TestCID = $distinct->ID;
         $obj1->write();
 
-        $obj2 = new DataQueryTest\ObjectHasMultiRelationalHasOne();
+        $obj2 = new DataQueryTest\ObjectA();
         $obj2->Name = 'sam';
-        $obj2->MultiRelationalID = $distinct->ID;
+        $obj2->TestCID = $distinct->ID;
         $obj2->write();
 
-        $obj3 = new DataQueryTest\ObjectHasMultiRelationalHasOne();
+        $obj3 = new DataQueryTest\ObjectA();
         $obj3->Name = 'john';
-        $obj3->MultiRelationalID = $otherDistinct->ID;
+        $obj3->TestCID = $otherDistinct->ID;
         $obj3->write();
 
-        $newCount = DataQueryTest\ObjectHasMultiRelationalHasOne::get()->count();
+        $newCount = DataQueryTest\ObjectA::get()->count();
 
         $this->assertEquals($baseCount + 3, $newCount);
 
-        // This should return 1, not 2, even if we have two persons called 'sam' but only one 'Distinct' parent
-        $count = DataQueryTest\ObjectHasMultiRelationalHasMany::get()->filter('MultiRelational1.Name', 'sam')->count();
+        // This should return 1, not 2. We have two persons called 'sam' but only one 'Distinct' parent
+        $count = DataQueryTest\ObjectC::get()->filter("TestAs.Name", 'sam')->count();
         $this->assertEquals(1, $count);
 
         // We have two 'sam' objects
-        $count = DataQueryTest\ObjectHasMultiRelationalHasOne::get()->filter('Name', 'sam')->count();
+        $count = DataQueryTest\ObjectA::get()->filter('Name', 'sam')->count();
         $this->assertEquals(2, $count);
 
-        $count = $distinct->MultiRelational1()->count();
+        $count = $distinct->TestAs()->count();
         $this->assertEquals(2, $count);
     }
 }

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -882,36 +882,6 @@ class DataQueryTest extends SapphireTest
 
     public function testDistinctCount()
     {
-        // The COUNT(DISTINCT ...) is added in case a join is added to the query (to apply a filter on related records)
-        $distinct = new DataQueryTest\ObjectC();
-        $distinct->Title = 'Distinct';
-        $distinct->write();
-
-        $otherDistinct = new DataQueryTest\ObjectC();
-        $otherDistinct->Title = 'OtherDistinct';
-        $otherDistinct->write();
-
-        $baseCount = DataQueryTest\ObjectA::get()->count();
-
-        $obj1 = new DataQueryTest\ObjectA();
-        $obj1->Name = 'sam';
-        $obj1->TestCID = $distinct->ID;
-        $obj1->write();
-
-        $obj2 = new DataQueryTest\ObjectA();
-        $obj2->Name = 'sam';
-        $obj2->TestCID = $distinct->ID;
-        $obj2->write();
-
-        $obj3 = new DataQueryTest\ObjectA();
-        $obj3->Name = 'john';
-        $obj3->TestCID = $otherDistinct->ID;
-        $obj3->write();
-
-        $newCount = DataQueryTest\ObjectA::get()->count();
-
-        $this->assertEquals($baseCount + 3, $newCount);
-
         // This should return 1, not 2. We have two records in the "TestAs" relation called 'sam' but only one 'Distinct' ObjectC parent record
         $count = DataQueryTest\ObjectC::get()->filter("TestAs.Name", 'sam')->count();
         $this->assertEquals(1, $count);
@@ -920,6 +890,7 @@ class DataQueryTest extends SapphireTest
         $count = DataQueryTest\ObjectA::get()->filter('Name', 'sam')->count();
         $this->assertEquals(2, $count);
 
+        $distinct = $this->objFromFixture(DataQueryTest\ObjectC::class, 'distinct1');
         $count = $distinct->TestAs()->count();
         $this->assertEquals(2, $count);
     }

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -893,7 +893,7 @@ class DataQueryTest extends SapphireTest
         $this->assertEquals(2, $count);
 
         $distinct = $this->objFromFixture(DataQueryTest\ObjectJ::class, 'distinct1');
-        $count = $distinct->TestAs()->count();
+        $count = $distinct->TestKs()->count();
         $this->assertEquals(2, $count);
     }
 }

--- a/tests/php/ORM/DataQueryTest.php
+++ b/tests/php/ORM/DataQueryTest.php
@@ -27,6 +27,8 @@ class DataQueryTest extends SapphireTest
         DataQueryTest\ObjectG::class,
         DataQueryTest\ObjectH::class,
         DataQueryTest\ObjectI::class,
+        DataQueryTest\ObjectJ::class,
+        DataQueryTest\ObjectK::class,
         DataQueryTest\ObjectHasMultiRelationalHasOne::class,
         DataQueryTest\ObjectHasMultiRelationalHasMany::class,
         SQLSelectTest\CteRecursiveObject::class,
@@ -882,15 +884,15 @@ class DataQueryTest extends SapphireTest
 
     public function testDistinctCount()
     {
-        // This should return 1, not 2. We have two records in the "TestAs" relation called 'sam' but only one 'Distinct' ObjectC parent record
-        $count = DataQueryTest\ObjectC::get()->filter("TestAs.Name", 'sam')->count();
+        // This should return 1, not 2. We have two records in the "TestKs" relation called 'sam' but only one 'Distinct' ObjectJ parent record
+        $count = DataQueryTest\ObjectJ::get()->filter("TestKs.Name", 'sam')->count();
         $this->assertEquals(1, $count);
 
         // We have two 'sam' objects
-        $count = DataQueryTest\ObjectA::get()->filter('Name', 'sam')->count();
+        $count = DataQueryTest\ObjectK::get()->filter('Name', 'sam')->count();
         $this->assertEquals(2, $count);
 
-        $distinct = $this->objFromFixture(DataQueryTest\ObjectC::class, 'distinct1');
+        $distinct = $this->objFromFixture(DataQueryTest\ObjectJ::class, 'distinct1');
         $count = $distinct->TestAs()->count();
         $this->assertEquals(2, $count);
     }

--- a/tests/php/ORM/DataQueryTest.yml
+++ b/tests/php/ORM/DataQueryTest.yml
@@ -1,20 +1,3 @@
-SilverStripe\ORM\Tests\DataQueryTest\ObjectC:
-  distinct1:
-    Title: 'Distinct'
-  distinct2:
-    Title: 'OtherDistinct'
-
-SilverStripe\ORM\Tests\DataQueryTest\ObjectA:
-  sam1:
-    Title: 'sam'
-    TestC: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectC.distinct1
-  sam2:
-    Title: 'sam'
-    TestC: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectC.distinct1
-  john1:
-    Title: 'john'
-    TestC: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectC.distinct2
-
 SilverStripe\ORM\Tests\DataQueryTest\ObjectE:
   query1:
     Title: 'Last'
@@ -107,3 +90,20 @@ SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject:
   child-of-child2:
     Title: 'child of child2'
     Parent: =>SilverStripe\ORM\Tests\SQLSelectTest\CteRecursiveObject.child2
+
+SilverStripe\ORM\Tests\DataQueryTest\ObjectJ:
+  distinct1:
+    Title: 'Distinct'
+  distinct2:
+    Title: 'OtherDistinct'
+
+SilverStripe\ORM\Tests\DataQueryTest\ObjectK:
+  sam1:
+    Name: 'sam'
+    TestJ: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectJ.distinct1
+  sam2:
+    Name: 'sam'
+    TestJ: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectJ.distinct1
+  john1:
+    Name: 'john'
+    TestJ: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectJ.distinct2

--- a/tests/php/ORM/DataQueryTest.yml
+++ b/tests/php/ORM/DataQueryTest.yml
@@ -1,3 +1,20 @@
+SilverStripe\ORM\Tests\DataQueryTest\ObjectC:
+  distinct1:
+    Title: 'Distinct'
+  distinct2:
+    Title: 'OtherDistinct'
+
+SilverStripe\ORM\Tests\DataQueryTest\ObjectA:
+  sam1:
+    Title: 'sam'
+    TestC: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectC.distinct1
+  sam2:
+    Title: 'sam'
+    TestC: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectC.distinct1
+  john1:
+    Title: 'john'
+    TestC: =>SilverStripe\ORM\Tests\DataQueryTest\ObjectC.distinct2
+
 SilverStripe\ORM\Tests\DataQueryTest\ObjectE:
   query1:
     Title: 'Last'

--- a/tests/php/ORM/DataQueryTest/ObjectJ.php
+++ b/tests/php/ORM/DataQueryTest/ObjectJ.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataQueryTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class ObjectJ extends DataObject implements TestOnly
+{
+    private static $table_name = 'DataQueryTest_J';
+
+    private static $db = [
+        'Title' => 'Varchar'
+    ];
+
+    private static $has_one = [
+        'TestK' => ObjectK::class,
+    ];
+
+    private static $has_many = [
+        'TestKs' => ObjectK::class,
+    ];
+
+    private static $many_many = [
+        'ManyTestKs' => ObjectK::class,
+    ];
+}

--- a/tests/php/ORM/DataQueryTest/ObjectK.php
+++ b/tests/php/ORM/DataQueryTest/ObjectK.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\DataQueryTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class ObjectK extends DataObject implements TestOnly
+{
+    private static $table_name = 'DataQueryTest_K';
+
+    private static $db = [
+        'Name' => 'Varchar',
+    ];
+
+    private static $has_one = [
+        'TestI' => ObjectJ::class,
+    ];
+}

--- a/tests/php/ORM/DataQueryTest/ObjectK.php
+++ b/tests/php/ORM/DataQueryTest/ObjectK.php
@@ -14,6 +14,6 @@ class ObjectK extends DataObject implements TestOnly
     ];
 
     private static $has_one = [
-        'TestI' => ObjectJ::class,
+        'TestJ' => ObjectJ::class,
     ];
 }


### PR DESCRIPTION
## Description
See issue for context

## Manual testing steps
On a large table, when counting, see that the updated method performs much faster

## Issues
https://github.com/silverstripe/silverstripe-framework/issues/11640

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
