### PR TITLE
FIX Don't make a count query when threshold = 0

### DIFF
--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -2525,8 +2525,10 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         $threshold = DBForeignKey::config()->get('dropdown_field_threshold');
         $overThreshold = $threshold === 0 || $list->count() > $threshold;
         $field = SearchableDropdownField::create($fieldName, $fieldTitle, $list, $ownerRecord->{$relationName . 'ID'}, $labelField)
-            ->setIsLazyLoaded($overThreshold)
-            ->setLazyLoadLimit($threshold);
+            ->setIsLazyLoaded($overThreshold);
+        if($threshold > 0) {
+            $field->setLazyLoadLimit($threshold);
+        }
         return $field;
     }
 

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -2526,7 +2526,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         $overThreshold = $threshold === 0 || $list->count() > $threshold;
         $field = SearchableDropdownField::create($fieldName, $fieldTitle, $list, $ownerRecord->{$relationName . 'ID'}, $labelField)
             ->setIsLazyLoaded($overThreshold);
-        if($threshold > 0) {
+        if ($threshold > 0) {
             $field->setLazyLoadLimit($threshold);
         }
         return $field;

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -2523,7 +2523,7 @@ class DataObject extends ViewableData implements DataObjectInterface, i18nEntity
         $labelField = $this->hasField('Title') ? 'Title' : 'Name';
         $list = DataList::create(static::class);
         $threshold = DBForeignKey::config()->get('dropdown_field_threshold');
-        $overThreshold = $list->count() > $threshold;
+        $overThreshold = $threshold === 0 || $list->count() > $threshold;
         $field = SearchableDropdownField::create($fieldName, $fieldTitle, $list, $ownerRecord->{$relationName . 'ID'}, $labelField)
             ->setIsLazyLoaded($overThreshold)
             ->setLazyLoadLimit($threshold);


### PR DESCRIPTION
This is a partial fix for https://github.com/silverstripe/silverstripe-framework/issues/11645

It avoids count queries when dropdown_field_threshold is set to 0

Everything will work the same as before, but with a very small difference: empty tables will now lazy load, but I think that's acceptable

It will also prevent setting a limit of 0

## Description
See issue for context

## Manual testing steps
Set the dropdown_field_threshold to 0
See that no more count queries are made during scaffolding

## Issues
https://github.com/silverstripe/silverstripe-framework/issues/11645

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
