### PR TITLE
ENH Add backwards-compatible aliases for "sake dev" and "sake dev/tasks"

### DIFF
--- a/src/Cli/Command/TasksCommand.php
+++ b/src/Cli/Command/TasksCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Note the description is blue so it stands out, to avoid developers missing it if they add a new
  * task and suddenly they don't see the tasks in their main commands list anymore.
  */
-#[AsCommand(name: 'tasks', description: '<fg=blue>See a list of build tasks to run</>')]
+#[AsCommand(name: 'tasks', description: '<fg=blue>See a list of build tasks to run</>', aliases: ['dev/tasks'])]
 class TasksCommand extends Command
 {
     private Command $listCommand;

--- a/src/Cli/Sake.php
+++ b/src/Cli/Sake.php
@@ -185,7 +185,7 @@ class Sake extends Application
                 $suggestions->suggestValue(new Suggestion($command->getName(), $command->getDescription()));
                 foreach ($command->getAliases() as $name) {
                     // Skip legacy dev aliases
-                    if (str_starts_with($name, 'dev/')) {
+                    if ($name === 'dev' || str_starts_with($name, 'dev/')) {
                         continue;
                     }
                     $suggestions->suggestValue(new Suggestion($name, $command->getDescription()));
@@ -204,7 +204,7 @@ class Sake extends Application
     {
         $name = $command->getName() ?? '';
         $nameUsedAs = $input->getFirstArgument() ?? '';
-        if (str_starts_with($nameUsedAs, 'dev/')) {
+        if ($nameUsedAs === 'dev' || str_starts_with($nameUsedAs, 'dev/')) {
             Deprecation::notice(
                 '6.0.0',
                 "Using the command with the name '$nameUsedAs' is deprecated. Use '$name' instead",
@@ -242,6 +242,10 @@ class Sake extends Application
         foreach ($commands as $command) {
             if (in_array(get_class($command), $toHide)) {
                 $command->setHidden(true);
+            }
+            // Add deprecated alias "sake dev" for backwards compatibility
+            if ($command instanceof ListCommand) {
+                $command->setAliases([...$command->getAliases(), 'dev']);
             }
         }
 

--- a/tests/php/Cli/SakeTest.php
+++ b/tests/php/Cli/SakeTest.php
@@ -248,23 +248,42 @@ class SakeTest extends SapphireTest
         $this->assertSame($versionProvider->getVersion(), $sake->getVersion());
     }
 
-    public function testLegacyDevCommands(): void
+    public static function provideLegacyDevCommands(): array
+    {
+        return [
+            [
+                'command' => 'dev',
+                'correctName' => 'list',
+            ],
+            [
+                'command' => 'dev/config',
+                'correctName' => 'config:dump',
+            ],
+            [
+                'command' => 'dev/tasks',
+                'correctName' => 'tasks',
+            ],
+            // NOTE: Do not run `dev/build` as that will manipulate the database in a way that causes subsequent tests to fail.
+        ];
+    }
+
+    #[DataProvider('provideLegacyDevCommands')]
+    public function testLegacyDevCommands(string $command, string $correctName): void
     {
         $sake = new Sake(Injector::inst()->get(Kernel::class));
         $sake->setAutoExit(false);
-        $input = new ArrayInput(['dev/config']);
+        $input = new ArrayInput([$command, '--quiet' => 1]);
         $input->setInteractive(false);
         $output = new BufferedOutput();
 
         $deprecationsWereEnabled = Deprecation::isEnabled();
         Deprecation::enable();
         $this->expectException(DeprecationTestException::class);
-        $expectedErrorString = 'Using the command with the name \'dev/config\' is deprecated. Use \'config:dump\' instead';
+        $expectedErrorString = "Using the command with the name '$command' is deprecated. Use '$correctName' instead";
         $this->expectExceptionMessage($expectedErrorString);
 
         $exitCode = $sake->run($input, $output);
         $this->assertSame(0, $exitCode, 'command should run successfully');
-        // $this->assertStringContainsString('abababa', $output->fetch());
 
         $this->allowCatchingDeprecations($expectedErrorString);
         try {


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11648#issuecomment-2749634881