### PR TITLE
FIX Do not use apostrophe in change password email

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -6,6 +6,7 @@ en:
     REMOVE: Remove
   SilverStripe\Control\ChangePasswordEmail_ss:
     CHANGEPASSWORDFOREMAIL: 'The password for account with email address {email} has been changed. If you didn\''t change your password please change your password using the link below'
+    CHANGEPASSWORDFOREMAIL2: 'The password for account with email address {email} has been changed. If you did not change your password please change your password using the link below'
     CHANGEPASSWORDTEXT1: 'You changed your password for'
     CHANGEPASSWORDTEXT3: 'Change password'
     HELLO: Hi

--- a/templates/SilverStripe/Control/Email/ChangePasswordEmail.ss
+++ b/templates/SilverStripe/Control/Email/ChangePasswordEmail.ss
@@ -2,6 +2,6 @@
 
 <p>
 	<%t SilverStripe\\Control\\ChangePasswordEmail_ss.CHANGEPASSWORDTEXT1 'You changed your password for' is 'for a url' %> $AbsoluteBaseURL.<br />
-	<%t SilverStripe\\Control\\ChangePasswordEmail_ss.CHANGEPASSWORDFOREMAIL 'The password for account with email address {email} has been changed. If you didn\'t change your password please change your password using the link below' email=$Email %><br />
+	<%t SilverStripe\\Control\\ChangePasswordEmail_ss.CHANGEPASSWORDFOREMAIL2 'The password for account with email address {email} has been changed. If you did not change your password please change your password using the link below' email=$Email %><br />
 	<a href="Security/changepassword"><%t SilverStripe\\Control\\ChangePasswordEmail_ss.CHANGEPASSWORDTEXT3 'Change password' %></a>
 </p>


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11514

I considered changing it to `&apos;`, though it looks pretty messy in the yml file, and it's probably easier for others to translate if we just use "did not" instead

Note that "Your password was changed" emails are only sent when the environment is in 'live' mode