### PR TITLE
API Fix `@internal` phpdoc for config property

### DIFF
--- a/src/ORM/DB.php
+++ b/src/ORM/DB.php
@@ -83,7 +83,7 @@ class DB
 
     /**
      * The name of the last connection used. This is only used for unit-testing purposes.
-     * @interal
+     * @internal
      */
     private static string $lastConnectionName = '';
 


### PR DESCRIPTION
Found this while looking at another config in this class that got turned `@internal`. Will get approval from the product owner as this is technically a breaking change after the beta.

## Issue
- https://github.com/silverstripe/.github/issues/379