### PR TITLE
FIX Don't use $_SERVER superglobal when it's not needed

### DIFF
--- a/src/Control/HTTP.php
+++ b/src/Control/HTTP.php
@@ -132,9 +132,10 @@ class HTTP
 
     /**
      * Will try to include a GET parameter for an existing URL, preserving existing parameters and
-     * fragments. If no URL is given, falls back to $_SERVER['REQUEST_URI']. Uses parse_url() to
-     * dissect the URL, and http_build_query() to reconstruct it with the additional parameter.
-     * Converts any '&' (ampersand) URL parameter separators to the more XHTML compliant '&amp;'.
+     * fragments. If no URL is given, falls back to getting the URL from the current request.
+     * Uses parse_url() to dissect the URL, and http_build_query() to reconstruct it with the
+     * additional parameter. Converts any '&' (ampersand) URL parameter separators to the more
+     * XHTML compliant '&amp;'.
      *
      * CAUTION: If the URL is determined to be relative, it is prepended with Director::absoluteBaseURL().
      * This method will always return an absolute URL because Director::makeRelative() can lead to

--- a/src/Dev/Debug.php
+++ b/src/Dev/Debug.php
@@ -5,9 +5,6 @@ namespace SilverStripe\Dev;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\ORM\DB;
-use SilverStripe\Security\Permission;
-use SilverStripe\Security\Security;
 
 /**
  * Supports debugging and core error handling.
@@ -194,56 +191,5 @@ class Debug
             return true;
         }
         return false;
-    }
-
-    /**
-     * Check if the user has permissions to run URL debug tools,
-     * else redirect them to log in.
-     * @deprecated 5.4.0 Will be removed without equivalent functionality.
-     */
-    public static function require_developer_login()
-    {
-        Deprecation::noticeWithNoReplacment('5.4.0');
-        // Don't require login for dev mode
-        if (Director::isDev()) {
-            return;
-        }
-
-        if (isset($_SESSION['loggedInAs'])) {
-            // We have to do some raw SQL here, because this method is called in Object::defineMethods().
-            // This means we have to be careful about what objects we create, as we don't want Object::defineMethods()
-            // being called again.
-            // This basically calls Permission::checkMember($_SESSION['loggedInAs'], 'ADMIN');
-
-            $memberID = $_SESSION['loggedInAs'];
-            $permission = DB::prepared_query(
-                '
-				SELECT "ID" FROM "Permission"
-				INNER JOIN "Group_Members" ON "Permission"."GroupID" = "Group_Members"."GroupID"
-				WHERE "Permission"."Code" = ?
-				AND "Permission"."Type" = ?
-				AND "Group_Members"."MemberID" = ?',
-                [
-                    'ADMIN', // Code
-                    Permission::GRANT_PERMISSION, // Type
-                    $memberID // MemberID
-                ]
-            )->value();
-
-            if ($permission) {
-                return;
-            }
-        }
-
-        // This basically does the same as
-        // Security::permissionFailure(null, "You need to login with developer access to make use of debugging tools.")
-        // We have to do this because of how early this method is called in execution.
-        $_SESSION['SilverStripe\\Security\\Security']['Message']['message']
-            = "You need to login with developer access to make use of debugging tools.";
-        $_SESSION['SilverStripe\\Security\\Security']['Message']['type'] =  'warning';
-        $_SESSION['BackURL'] = $_SERVER['REQUEST_URI'];
-        header($_SERVER['SERVER_PROTOCOL'] . " 302 Found");
-        header("Location: " . Director::baseURL() . Security::login_url());
-        die();
     }
 }

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -408,11 +408,12 @@ class Security extends Controller implements TemplateGlobalProvider
         $message = $messageSet['default'];
 
         $request = $controller->getRequest();
+        $requestUrl = '/' . ltrim($request->getURL(true), '/');
         if ($request->hasSession()) {
             list($messageText, $messageCast) = $parseMessage($message);
             static::singleton()->setSessionMessage($messageText, ValidationResult::TYPE_WARNING, $messageCast);
 
-            $request->getSession()->set("BackURL", $_SERVER['REQUEST_URI']);
+            $request->getSession()->set('BackURL', $requestUrl);
         }
 
         // Audit logging hook
@@ -420,7 +421,7 @@ class Security extends Controller implements TemplateGlobalProvider
 
         return $controller->redirect(Controller::join_links(
             Security::config()->uninherited('login_url'),
-            "?BackURL=" . urlencode($_SERVER['REQUEST_URI'] ?? '')
+            "?BackURL=" . urlencode($requestUrl)
         ));
     }
 

--- a/src/View/SSViewer.php
+++ b/src/View/SSViewer.php
@@ -11,6 +11,8 @@ use SilverStripe\Control\Director;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Injector\Injector;
 
 /**
@@ -336,17 +338,7 @@ class SSViewer
 
         // If we have our crazy base tag, then fix # links referencing the current page.
         if ($rewrite) {
-            if (strpos($output ?? '', '<base') !== false) {
-                if ($rewrite === 'php') {
-                    $thisURLRelativeToBase = <<<PHP
-<?php echo \\SilverStripe\\Core\\Convert::raw2att(preg_replace("/^(\\\\/)+/", "/", \$_SERVER['REQUEST_URI'])); ?>
-PHP;
-                } else {
-                    $thisURLRelativeToBase = Convert::raw2att(preg_replace("/^(\\/)+/", "/", $_SERVER['REQUEST_URI'] ?? ''));
-                }
-
-                $output = preg_replace('/(<a[^>]+href *= *)"#/i', '\\1"' . $thisURLRelativeToBase . '#', $output ?? '');
-            }
+            $output = $this->rewriteHashLinks($output, $rewrite === 'php');
         }
 
         // Wrap the HTML in a `DBHTMLText`. We use `HTMLFragment` here because shortcodes should
@@ -357,6 +349,32 @@ PHP;
         // Reset global state
         static::setRewriteHashLinksDefault($origRewriteDefault);
         return $html;
+    }
+
+    private function rewriteHashLinks(string $output, bool $rewritePHP) : string
+    {
+        if (!Injector::inst()->has(HTTPRequest::class)) {
+            Injector::inst()->get(LoggerInterface::class)->warning('No HTTPRequest is available to get the path for rewriting hash links.');
+            return $output;
+        }
+        $request = Injector::inst()->get(HTTPRequest::class);
+        $url = '/' . $request->getURL(true);
+        if (strpos($output ?? '', '<base') !== false) {
+            if ($rewritePHP) {
+                $thisURLRelativeToBase = <<<PHP
+                <?php echo \\SilverStripe\\Core\\Convert::raw2att(preg_replace(
+                    "/^(\\\\/)+/",
+                    "/",
+                    \$_SERVER['REQUEST_URI'] ?? SilverStripe\\Control\\Controller::curr()?->getRequest()?->getURL(true) ?? '$url'
+                )); ?>
+                PHP;
+            } else {
+                $thisURLRelativeToBase = Convert::raw2att($url);
+            }
+
+            $output = preg_replace('/(<a[^>]+href *= *)"#/i', '\\1"' . $thisURLRelativeToBase . '#', $output ?? '');
+        }
+        return $output;
     }
 
     /**

--- a/tests/php/View/SSViewerTest.php
+++ b/tests/php/View/SSViewerTest.php
@@ -3,7 +3,9 @@
 namespace SilverStripe\View\Tests;
 
 use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Convert;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\View\Requirements;
@@ -142,7 +144,13 @@ class SSViewerTest extends SapphireTest
         $oldServerVars = $_SERVER;
 
         try {
-            $_SERVER['REQUEST_URI'] = '//file.com?foo"onclick="alert(\'xss\')""';
+            $origRequest = Injector::inst()->has(HTTPRequest::class)
+                ? Injector::inst()->get(HTTPRequest::class)
+                : null;
+            Injector::inst()->registerService(
+                new HTTPRequest('GET', '//file.com?foo"onclick="alert(\'xss\')""'),
+                HTTPRequest::class
+            );
 
             // Note that leading double slashes have been rewritten to prevent these being mis-interepreted
             // as protocol-less absolute urls
@@ -187,6 +195,11 @@ class SSViewerTest extends SapphireTest
             );
         } finally {
             $_SERVER = $oldServerVars;
+            if ($origRequest) {
+                Injector::inst()->registerService($origRequest, HTTPRequest::class);
+            } else {
+                Injector::inst()->unregisterNamedObject(HTTPRequest::class);
+            }
         }
     }
 
@@ -206,7 +219,23 @@ class SSViewerTest extends SapphireTest
             </html>'
         );
         $tmpl = new SSViewer([], $engine);
-        $result = $tmpl->process('pretend this is a model');
+
+        try {
+            $origRequest = Injector::inst()->has(HTTPRequest::class)
+                ? Injector::inst()->get(HTTPRequest::class)
+                : null;
+            Injector::inst()->registerService(
+                new HTTPRequest('GET', 'about-us'),
+                HTTPRequest::class
+            );
+            $result = $tmpl->process('pretend this is a model');
+        } finally {
+            if ($origRequest) {
+                Injector::inst()->registerService($origRequest, HTTPRequest::class);
+            } else {
+                Injector::inst()->unregisterNamedObject(HTTPRequest::class);
+            }
+        }
 
         $code = <<<'EOC'
         <a class="inserted" href="<?php echo \SilverStripe\Core\Convert::raw2att(preg_replace(

--- a/tests/php/View/SSViewerTest.php
+++ b/tests/php/View/SSViewerTest.php
@@ -209,8 +209,12 @@ class SSViewerTest extends SapphireTest
         $result = $tmpl->process('pretend this is a model');
 
         $code = <<<'EOC'
-<a class="inserted" href="<?php echo \SilverStripe\Core\Convert::raw2att(preg_replace("/^(\/)+/", "/", $_SERVER['REQUEST_URI'])); ?>#anchor">InsertedLink</a>
-EOC;
+        <a class="inserted" href="<?php echo \SilverStripe\Core\Convert::raw2att(preg_replace(
+            "/^(\/)+/",
+            "/",
+            $_SERVER['REQUEST_URI'] ?? SilverStripe\Control\Controller::curr()?->getRequest()?->getURL(true) ?? '/about-us'
+        )); ?>#anchor">InsertedLink</a>
+        EOC;
         $this->assertStringContainsString($code, $result);
         $this->assertStringContainsString(
             '<svg><use xlink:href="#sprite"></use></svg>',


### PR DESCRIPTION
This doesn't get populated the same way when running CLI commands. Notably staticpublishqueue creates a `HTTPRequest` but doesn't populate the superglobal in its queued job.

The second commit here is a breaking API change and will need the product owner's approval.
Note that `Debug::require_developer_login()` isn't called from anywhere in our code and doesn't actually work. If you're logged in you get an error, and if you're logged out you get redirected to `security/login` (note, NOT to a relative URL in your domain - the host is completely missing. It's broken as hell)

I'll raise a separate PR to deprecate `Debug::require_developer_login()` for CMS 5.4 shortly.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11666