### PR TITLE
API Deprecate broken and unnecessary Debug::require_developer_login()

### DIFF
--- a/src/Dev/Debug.php
+++ b/src/Dev/Debug.php
@@ -199,9 +199,11 @@ class Debug
     /**
      * Check if the user has permissions to run URL debug tools,
      * else redirect them to log in.
+     * @deprecated 5.4.0 Will be removed without equivalent functionality.
      */
     public static function require_developer_login()
     {
+        Deprecation::noticeWithNoReplacment('5.4.0');
         // Don't require login for dev mode
         if (Director::isDev()) {
             return;


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11666