### PR TITLE
FIX Ensure null is not passed to strip_tags()

### DIFF
--- a/src/Forms/GridField/GridFieldPrintButton.php
+++ b/src/Forms/GridField/GridFieldPrintButton.php
@@ -241,7 +241,7 @@ class GridFieldPrintButton extends AbstractGridFieldComponent implements GridFie
 
                 foreach ($printColumns as $field => $label) {
                     $value = $gridFieldColumnsComponent
-                        ? strip_tags($gridFieldColumnsComponent->getColumnContent($gridField, $item, $field))
+                        ? strip_tags($gridFieldColumnsComponent->getColumnContent($gridField, $item, $field) ?? '')
                         : $gridField->getDataFieldValue($item, $field);
 
                     $itemRow->push(new ArrayData([


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11665

I considered updating the return of GridFieldDataColumns::getColumnContent() to that it would return empty string if $value was null, however this would not fix any subclasses of GridFieldDataColumns that overrode getColumnContent().   If we were to do that approach I think strong typing the return would be required