### PR TITLE
Revert "FIX Change password form when cookie samesite is strict"

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -70,18 +70,12 @@ class Member extends DataObject
     private static $db = [
         'FirstName' => 'Varchar',
         'Surname' => 'Varchar',
-        // See RFC 5321, Section 4.5.3.1.3. (256 minus the < and > character)
-        'Email' => 'Varchar(254)',
-        // Temporary id used for cms re-authentication
-        'TempIDHash' => 'Varchar(160)',
-        // Expiry of temp login
-        'TempIDExpired' => 'Datetime',
+        'Email' => 'Varchar(254)', // See RFC 5321, Section 4.5.3.1.3. (256 minus the < and > character)
+        'TempIDHash' => 'Varchar(160)', // Temporary id used for cms re-authentication
+        'TempIDExpired' => 'Datetime', // Expiry of temp login
         'Password' => 'Varchar(160)',
-        // Used to auto-login the user on password reset
-        'AutoLoginHash' => 'Varchar(160)',
+        'AutoLoginHash' => 'Varchar(160)', // Used to auto-login the user on password reset
         'AutoLoginExpired' => 'Datetime',
-        // Temporary hash used for auto-login to prevent leaking AutoLoginHash on redirect
-        'AutoLoginTempHash' => 'Varchar(64)',
         // This is an arbitrary code pointing to a PasswordEncryptor instance,
         // not an actual encryption algorithm.
         // Warning: Never change this field after its the first password hashing without
@@ -163,7 +157,6 @@ class Member extends DataObject
     private static $hidden_fields = [
         'AutoLoginHash',
         'AutoLoginExpired',
-        'AutoLoginTempHash',
         'PasswordEncryption',
         'PasswordExpiry',
         'LockedOutUntil',

--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -16,8 +16,6 @@ use SilverStripe\Security\IdentityStore;
 use SilverStripe\Security\LoginAttempt;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
-use SilverStripe\Dev\Deprecation;
-use SilverStripe\Security\RandomGenerator;
 
 class ChangePasswordHandler extends RequestHandler
 {
@@ -68,46 +66,21 @@ class ChangePasswordHandler extends RequestHandler
     {
         $request = $this->getRequest();
 
-        // Check is we're resetting via a token in URL i.e. reset password email link
+        // Extract the member from the URL.
         $member = null;
         if ($request->getVar('m') !== null) {
             $member = Member::get()->filter(['ID' => (int)$request->getVar('m')])->first();
         }
         $token = $request->getVar('t');
+
+        // Check whether we are merely changing password, or resetting.
         if ($token !== null && $member && $member->validateAutoLoginToken($token)) {
-            // Redirect to current url, though with a temporary hash in the URL
-            // This will ensure that that the member ID and token will not appear in browser history
-            // Instead only a harmless temporary hash will appear in the browser history
-            // We do this instead of setting the session value at this point because if
-            // cookie SameSite is set to Strict, then  when clicking a password reset link via a
-            // webmail client, then the redirect will be treated as cross-origin request and value
-            // of the session cookie will not be accessible
-            $autoLoginTempHash = $this->createAutoLoginTempHash();
-            $member->AutoLoginTempHash = $autoLoginTempHash;
-            $member->write();
-            $response = $this->redirect($this->link . '?th=' . $autoLoginTempHash);
-            return $response;
+            $this->setSessionToken($member, $token);
+
+            // Redirect to myself, but without the hash in the URL
+            return $this->redirect($this->link);
         }
 
-        // Check the if we're processing a temp token redirect
-        $tempToken = $request->getVar('th');
-        if ($tempToken !== null) {
-            $member = Member::get()->find('AutoLoginTempHash', $tempToken);
-            if ($member) {
-                // Delete the temp token from the member so that it cannot be used again
-                // This prevents the browser history from being used to access the change password form
-                $member->AutoLoginTempHash = '';
-                $member->write();
-                // Add the token to the session so that the change password form can be submitted
-                // with the token in the session, instead of the URL
-                $encryptedToken = $member->AutoLoginHash;
-                $this->setSessionTokenShared($member, $encryptedToken, false);
-            }
-        }
-
-        // If there is AutoLoginHash in the session, then create a form
-        // If the token is valid then Member will be automatically logined in
-        // as part of doChangePassword() which is the form action handler of the change password form
         $session = $this->getRequest()->getSession();
         if ($session->get('AutoLoginHash')) {
             $message = DBField::create_field(
@@ -171,17 +144,21 @@ class ChangePasswordHandler extends RequestHandler
         );
     }
 
+
     /**
-     * Set the session token for the member with a token that has not been encrypted
-     *
      * @param Member $member
      * @param string $token
-     * @deprecated 5.4.0 Will be removed without equivalent functionality to replace it
      */
     protected function setSessionToken($member, $token)
     {
-        Deprecation::noticeWithNoReplacment('5.4.0');
-        $this->setSessionTokenShared($member, $token, true);
+        // if there is a current member, they should be logged out
+        if ($curMember = Security::getCurrentUser()) {
+            Injector::inst()->get(IdentityStore::class)->logOut();
+        }
+
+        $this->getRequest()->getSession()->regenerateSessionId();
+        // Store the hash for the change password form. Will be unset after reload within the ChangePasswordForm.
+        $this->getRequest()->getSession()->set('AutoLoginHash', $member->encryptWithUserSettings($token));
     }
 
     /**
@@ -240,9 +217,8 @@ class ChangePasswordHandler extends RequestHandler
 
         $session = $this->getRequest()->getSession();
         if (!$member) {
-            $autoLoginHash = $session->get('AutoLoginHash');
-            if ($autoLoginHash) {
-                $member = Member::member_from_autologinhash($autoLoginHash);
+            if ($session->get('AutoLoginHash')) {
+                $member = Member::member_from_autologinhash($session->get('AutoLoginHash'));
             }
 
             // The user is not logged in and no valid auto login hash is available
@@ -371,38 +347,5 @@ class ChangePasswordHandler extends RequestHandler
             }
         }
         return true;
-    }
-
-    /**
-     * Generate a temporary auto login hash for the member
-     */
-    private function createAutoLoginTempHash(): string
-    {
-        $member = null;
-        $autoLoginTempHash = '';
-        do {
-            $autoLoginTempHash = Injector::inst()->get(RandomGenerator::class)->randomToken('sha256');
-            $member = Member::get()->find('AutoLoginTempHash', $autoLoginTempHash);
-        } while ($member !== null);
-        return $autoLoginTempHash;
-    }
-
-    /**
-     * Shared function to set the session token
-     */
-    private function setSessionTokenShared(Member $member, string $token, bool $encrypt): void
-    {
-        // if there is a current member, they should be logged out
-        if (Security::getCurrentUser()) {
-            Injector::inst()->get(IdentityStore::class)->logOut();
-        }
-        $this->getRequest()->getSession()->regenerateSessionId();
-        // Store the hash for the change password form. Will be unset after reload within the ChangePasswordForm.
-        if ($encrypt) {
-            $autoLoginHash = $member->encryptWithUserSettings($token);
-        } else {
-            $autoLoginHash = $token;
-        }
-        $this->getRequest()->getSession()->set('AutoLoginHash', $autoLoginHash);
     }
 }

--- a/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.php
+++ b/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.php
@@ -3,131 +3,47 @@
 namespace SilverStripe\Security\Tests\MemberAuthenticator;
 
 use SilverStripe\Control\HTTPRequest;
-use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Session;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Security\Member;
-use SilverStripe\Security\MemberAuthenticator\ChangePasswordForm;
 use SilverStripe\Security\MemberAuthenticator\ChangePasswordHandler;
 use SilverStripe\Security\MemberAuthenticator\MemberAuthenticator;
 use SilverStripe\Security\Security;
-use SilverStripe\Control\Director;
-use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Security\RandomGenerator;
 
 class ChangePasswordHandlerTest extends SapphireTest
 {
     protected static $fixture_file = 'ChangePasswordHandlerTest.yml';
 
-    private ChangePasswordHandler $handler;
-
     protected function setUp(): void
     {
         parent::setUp();
+
         Config::modify()
             ->set(Security::class, 'login_url', 'Security/login')
             ->set(Security::class, 'lost_password_url', 'Security/lostpassword');
 
         $this->logOut();
-        $this->handler = new ChangePasswordHandler('/Security/changepassword', new MemberAuthenticator());
-        $generator = new class() extends RandomGenerator {
-            public function randomToken($algorithm = 'whirlpool')
-            {
-                return 'temporary-hash';
-            }
-        };
-        Injector::inst()->registerService($generator, RandomGenerator::class);
-        // Hash members AutoLoginHash and set AutoLoginExpired
-        $member = $this->objFromFixture(Member::class, 'sarah');
-        $member->AutoLoginHash = $member->encryptWithUserSettings($member->AutoLoginHash);
-        $member->AutoLoginExpired = date('Y-m-d H:i:s', strtotime('+7 days'));
-        $member->write();
-    }
-
-    public function testValidUrlParamsRedirectsWithTemporaryHash()
-    {
-        $request = $this->createRequest([
-            'm' => $this->idFromFixture(Member::class, 'sarah'),
-            't' => 'foobar',
-        ]);
-        $result = $this->handler->setRequest($request)->changepassword();
-        $this->assertTrue(is_a($result, HTTPResponse::class));
-        $this->assertSame(302, $result->getStatusCode());
-        $location = '/Security/changepassword?th=temporary-hash';
-        $this->assertSame(Director::absoluteURL($location), $result->getHeader('Location'));
     }
 
     public function testExpiredOrInvalidTokenProvidesLostPasswordAndLoginLink()
     {
-        $request = $this->createRequest([
+        $request = new HTTPRequest('GET', '/Security/changepassword', [
             'm' => $this->idFromFixture(Member::class, 'sarah'),
             't' => 'an-old-or-expired-hash',
         ]);
-        $result = $this->handler->setRequest($request)->changepassword();
-        $this->assertIsArray($result);
-        $this->assertSame(['Content'], array_keys($result));
-        $this->assertStringContainsString('Security/lostpassword', $result['Content']);
-        $this->assertStringContainsString('Security/login', $result['Content']);
-    }
-
-    public function testTemporaryHashInUrlRendersForm()
-    {
-        $this->setMemberAutoLoginTempHash();
-        $request = $this->createRequest([
-            'th' => 'temporary-hash'
-        ]);
-        $result = $this->handler->setRequest($request)->changepassword();
-        $this->assertIsArray($result);
-        $this->assertSame(['Content', 'Form'], array_keys($result));
-        $this->assertTrue(is_a($result['Form'], ChangePasswordForm::class));
-    }
-
-    public function testSubsequentTemporaryHashRedirectsToLoginForm()
-    {
-        $this->setMemberAutoLoginTempHash();
-        $request = $this->createRequest([
-            'th' => 'temporary-hash'
-        ]);
-        $this->handler->setRequest($request)->changepassword();
-        $request = $this->createRequest([
-            'th' => 'temporary-hash'
-        ]);
-        $result = $this->handler->setRequest($request)->changepassword();
-        $this->assertTrue(is_a($result, HTTPResponse::class));
-        $this->assertSame(302, $result->getStatusCode());
-        $location = '/Security/login';
-        $this->assertStringContainsString($location, $result->getHeader('Location'));
-    }
-
-    public function testIncorrectTemporaryHashInUrlRendersLoginForm()
-    {
-        $this->setMemberAutoLoginTempHash();
-        $request = $this->createRequest([
-            'th' => 'wrong-hash'
-        ]);
-        $result = $this->handler->setRequest($request)->changepassword();
-        $this->assertTrue(is_a($result, HTTPResponse::class));
-        $this->assertSame(302, $result->getStatusCode());
-        $location = '/Security/login';
-        $this->assertStringContainsString($location, $result->getHeader('Location'));
-    }
-
-    private function createRequest(array $params = []): HTTPRequest
-    {
-        $request = new HTTPRequest('POST', '/Security/changepassword', $params);
         $request->setSession(new Session([]));
-        return $request;
-    }
 
-    /**
-     * Set the AutoLoginTempHash to 'temporary-hash for the member
-     * This is used to simulate the second stage of the change password process
-     */
-    private function setMemberAutoLoginTempHash(): void
-    {
-        $member = $this->objFromFixture(Member::class, 'sarah');
-        $member->AutoLoginTempHash = 'temporary-hash';
-        $member->write();
+        /** @var ChangePasswordHandler $handler */
+        $handler = $this->getMockBuilder(ChangePasswordHandler::class)
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $result = $handler->setRequest($request)->changepassword();
+
+        $this->assertIsArray($result, 'An array is returned');
+        $this->assertStringContainsString('Security/lostpassword', $result['Content'], 'Lost password URL is included');
+        $this->assertStringContainsString('Security/login', $result['Content'], 'Login URL is included');
     }
 }

--- a/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.yml
+++ b/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.yml
@@ -2,4 +2,4 @@ SilverStripe\Security\Member:
   sarah:
     FirstName: Sarah
     Surname: Smith
-    AutoLoginHash: foobar
+    AutoLoginToken: foobar

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -533,12 +533,12 @@ class SecurityTest extends FunctionalTest
         // Check.
         $response = $this->get('Security/changepassword/?m=' . $admin->ID . '&t=' . $token);
         $this->assertEquals(302, $response->getStatusCode());
-        $location = (string) $response->getHeader('Location');
-        $this->assertStringStartsWith(
-            Director::absoluteURL('Security/changepassword?th='),
-            Director::absoluteURL($location)
+        $this->assertEquals(
+            Director::absoluteURL('Security/changepassword'),
+            Director::absoluteURL((string) $response->getHeader('Location'))
         );
-        $this->get($location);
+        // Follow redirection to form without hash in GET parameter
+        $this->get('Security/changepassword');
         $this->doTestChangepasswordForm('1nitialPassword', 'changedPassword#123');
         $this->assertEquals($this->idFromFixture(Member::class, 'test'), $this->session()->get('loggedInAs'));
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11565

Reverts https://github.com/silverstripe/silverstripe-framework/commit/b2d53a6f01d995c970f51f4c915769022f7c65ba

This PR caused a phpunit test failure with silverstripe-mfa which will override the changepassword() method. What the test failure caught was that the mfa form was being bypassed after clicking the change password email link