### PR TITLE
FIX default_sort has no associated index

### DIFF
--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -103,6 +103,11 @@ class Member extends DataObject
 
     private static $indexes = [
         'Email' => true,
+        // Helps queries using default_sort
+        'SortedName'=> [
+            'type' => 'index',
+            'columns' => ['Surname', 'FirstName'],
+        ],
         //Removed due to duplicate null values causing MSSQL problems
         //'AutoLoginHash' => Array('type'=>'unique', 'value'=>'AutoLoginHash', 'ignoreNulls'=>true)
     ];


### PR DESCRIPTION
## Description
See issue for context

This PR adds a new index that matches the default_sort

This index should help many queries, also when filtering by surname/firstname (eg: in autocomplete scenarios). With this index, it means it actually better to filter against Surname/FirstName rather than just Surname

## Manual testing steps

Simply use `Member::get()->first()`
without the index, the db engine may be using filesort due to default_sort being used

```sql
EXPLAIN SELECT * FROM Member ORDER BY Surname ASC, FirstName ASC LIMIT 1
```

would show "using filesort" on all records of the table

with the index, it shouldn't, and it will fetch the first record from the index directly

for filters, queries like

```sql
EXPLAIN SELECT * FROM Member 
WHERE Surname LIKE 'test%' AND FirstName LIKE 'test%'
ORDER BY Surname ASC, FirstName ASC LIMIT 1

# or even
EXPLAIN SELECT * FROM Member 
WHERE Surname LIKE 'test%'
ORDER BY Surname ASC, FirstName ASC LIMIT 1
```

will now be using the index as well resulting in much faster queries

## Issues
https://github.com/silverstripe/silverstripe-framework/issues/11674

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
