### PR TITLE
FIX Don't set session value in endpoint accessed from mail link.

### DIFF
--- a/src/Control/RequestHandler.php
+++ b/src/Control/RequestHandler.php
@@ -91,7 +91,6 @@ class RequestHandler extends ModelData
         '$Action' => '$Action',
     ];
 
-
     /**
      * Define a list of action handling methods that are allowed to be called directly by URLs.
      * The variable should be an array of action names. This sample shows the different values that it can contain:

--- a/src/Security/Member.php
+++ b/src/Security/Member.php
@@ -75,12 +75,18 @@ class Member extends DataObject
     private static $db = [
         'FirstName' => 'Varchar',
         'Surname' => 'Varchar',
-        'Email' => 'Varchar(254)', // See RFC 5321, Section 4.5.3.1.3. (256 minus the < and > character)
-        'TempIDHash' => 'Varchar(160)', // Temporary id used for cms re-authentication
-        'TempIDExpired' => 'Datetime', // Expiry of temp login
+        // See RFC 5321, Section 4.5.3.1.3. (256 minus the < and > character)
+        'Email' => 'Varchar(254)',
+        // Temporary id used for cms re-authentication
+        'TempIDHash' => 'Varchar(160)',
+        // Expiry of temp login
+        'TempIDExpired' => 'Datetime',
         'Password' => 'Varchar(160)',
-        'AutoLoginHash' => 'Varchar(160)', // Used to auto-login the user on password reset
+        // Used to auto-login the user on password reset
+        'AutoLoginHash' => 'Varchar(160)',
         'AutoLoginExpired' => 'Datetime',
+        // Temporary hash used for auto-login to prevent leaking AutoLoginHash on redirect
+        'AutoLoginTempHash' => 'Varchar(64)',
         // This is an arbitrary code pointing to a PasswordEncryptor instance,
         // not an actual encryption algorithm.
         // Warning: Never change this field after its the first password hashing without
@@ -164,6 +170,7 @@ class Member extends DataObject
     private static $hidden_fields = [
         'AutoLoginHash',
         'AutoLoginExpired',
+        'AutoLoginTempHash',
         'PasswordEncryption',
         'PasswordExpiry',
         'LockedOutUntil',

--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -15,6 +15,7 @@ use SilverStripe\Security\Authenticator;
 use SilverStripe\Security\IdentityStore;
 use SilverStripe\Security\LoginAttempt;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\RandomGenerator;
 use SilverStripe\Security\Security;
 
 class ChangePasswordHandler extends RequestHandler
@@ -47,6 +48,18 @@ class ChangePasswordHandler extends RequestHandler
     ];
 
     /**
+     * Keep track of whether a temporary hash is already generated during this request cycle.
+     * @internal
+     */
+    private static bool $tempHashAlreadyGenerated = false;
+
+    /**
+     * Keep track of whether a temporary hash has already been processed during this request cycle.
+     * @internal
+     */
+    private static bool $tempHashAlreadyProcessed = false;
+
+    /**
      * @param string $link The URL to recreate this request handler
      * @param MemberAuthenticator $authenticator
      */
@@ -64,73 +77,120 @@ class ChangePasswordHandler extends RequestHandler
      */
     public function changepassword()
     {
+        $ret = $this->processChangePasswordUrlVars();
+        if ($ret) {
+            return $ret;
+        }
+        return $this->createChangePasswordResponse();
+    }
+
+    /**
+     * Process the get URL variables for a change password request.
+     * If additional action is required, return a response for that action.
+     * Otherwise, return null which indicates the change password form should be presented.
+     */
+    protected function processChangePasswordUrlVars(): array|HTTPResponse|null
+    {
         $request = $this->getRequest();
 
-        // Extract the member from the URL.
+        // Check if we're resetting via a token in URL i.e. reset password email link
         $member = null;
         if ($request->getVar('m') !== null) {
             $member = Member::get()->filter(['ID' => (int)$request->getVar('m')])->first();
         }
+
+        // If we have a token and a member, a user is trying to reset their password.
+        // We'll set a temp token and redirect back here for the next round of processing.
         $token = $request->getVar('t');
-
-        // Check whether we are merely changing password, or resetting.
-        if ($token !== null && $member && $member->validateAutoLoginToken($token)) {
-            $this->setSessionToken($member, $token);
-
-            // Redirect to myself, but without the hash in the URL
-            return $this->redirect($this->link);
+        if ($token !== null && $member !== null) {
+            if (!$member->validateAutoLoginToken($token)) {
+                return $this->getInvalidTokenResponse();
+            }
+            // Redirect to current url, though with a temporary hash in the URL.
+            // This will ensure that that the member ID and token will not appear in browser history.
+            // Instead only a harmless temporary hash will appear in the browser history.
+            // We do this instead of setting the session value at this point because if
+            // cookie SameSite is set to Strict, then when clicking a password reset link via a
+            // webmail client the redirect will be treated as cross-origin request and value
+            // of the session cookie will not be accessible, so we have to set the session variable
+            // AFTER the redirect.
+            $autoLoginTempHash = $this->createAutoLoginTempHash($member);
+            $member->AutoLoginTempHash = $autoLoginTempHash;
+            $member->write();
+            $response = $this->redirect(Controller::join_links($this->link, '?th=' . $autoLoginTempHash));
+            return $response;
         }
 
+        // If a member or password reset token was included on its own, the URL was invalid.
+        if ($token !== null || $member !== null) {
+            return $this->getInvalidTokenResponse();
+        }
+
+        // If this request was a redirect which includes the temp token, set the session token.
+        $tempToken = $request->getVar('th');
+        if ($tempToken !== null && !ChangePasswordHandler::$tempHashAlreadyProcessed) {
+            $member = Member::get()->find('AutoLoginTempHash', $tempToken);
+            if (!$member) {
+                return $this->getInvalidTokenResponse();
+            }
+            // Delete the temp token from the member so that it cannot be used again
+            // This prevents the browser history from being used to access the change password form
+            $member->AutoLoginTempHash = '';
+            $member->write();
+            // Add the token to the session so that the change password form can be submitted
+            // with the token in the session, instead of the URL
+            $encryptedToken = $member->AutoLoginHash;
+            $this->setSessionToken($member, $encryptedToken, true);
+            ChangePasswordHandler::$tempHashAlreadyProcessed = true;
+        }
+
+        // If we get here, either the token is valid and we've just set it to the session,
+        // or a logged in user is changing their password with this form.
+        return null;
+    }
+
+    /**
+     * Get a response which either includes the change password form or a permission failure
+     * for when a user is trying to reset or change their password.
+     */
+    protected function createChangePasswordResponse(): array|HTTPResponse
+    {
+        // If there is AutoLoginHash in the session, then create a form.
+        // If the token is valid then Member will be automatically logined in
+        // as part of doChangePassword() which is the form action handler of the change password form.
         $session = $this->getRequest()->getSession();
-        if ($session->get('AutoLoginHash')) {
+        $hash = $session->get('AutoLoginHash');
+        if ($hash) {
+            if (!Member::get()->filter(['AutoLoginHash' => $hash])) {
+                return $this->getInvalidTokenResponse();
+            }
             $message = DBField::create_field(
                 'HTMLFragment',
                 '<p>' . _t(
-                    'SilverStripe\\Security\\Security.ENTERNEWPASSWORD',
+                    Security::class . '.ENTERNEWPASSWORD',
                     'Please enter a new password.'
                 ) . '</p>'
             );
 
-            // Subsequent request after the "first load with hash" (see previous if clause).
             return [
                 'Content' => $message,
-                'Form'    => $this->changePasswordForm()
+                'Form' => $this->changePasswordForm()
             ];
         }
 
+        // Logged in user requested a password change form.
         if (Security::getCurrentUser()) {
-            // Logged in user requested a password change form.
             $message = DBField::create_field(
                 'HTMLFragment',
                 '<p>' . _t(
-                    'SilverStripe\\Security\\Security.CHANGEPASSWORDBELOW',
+                    Security::class . '.CHANGEPASSWORDBELOW',
                     'You can change your password below.'
                 ) . '</p>'
             );
 
             return [
                 'Content' => $message,
-                'Form'    => $this->changePasswordForm()
-            ];
-        }
-        // Show a friendly message saying the login token has expired
-        if ($token !== null && $member && !$member->validateAutoLoginToken($token)) {
-            $message = DBField::create_field(
-                'HTMLFragment',
-                _t(
-                    'SilverStripe\\Security\\Security.NOTERESETLINKINVALID',
-                    '<p>The password reset link is invalid or expired.</p>'
-                    . '<p>You can request a new one <a href="{link1}">here</a> or change your password after'
-                    . ' you <a href="{link2}">log in</a>.</p>',
-                    [
-                        'link1' => Security::lost_password_url(),
-                        'link2' => Security::login_url(),
-                    ]
-                )
-            );
-
-            return [
-                'Content' => $message,
+                'Form' => $this->changePasswordForm()
             ];
         }
 
@@ -138,27 +198,31 @@ class ChangePasswordHandler extends RequestHandler
         return Security::permissionFailure(
             Controller::curr(),
             _t(
-                'SilverStripe\\Security\\Security.ERRORPASSWORDPERMISSION',
+                Security::class . '.ERRORPASSWORDPERMISSION',
                 'You must be logged in in order to change your password!'
             )
         );
     }
 
-
     /**
-     * @param Member $member
-     * @param string $token
+     * Set the encrypted session token for the member.
      */
-    protected function setSessionToken($member, $token)
+    protected function setSessionToken(Member $member, string $token, bool $alreadyEncrypted = false): void
     {
         // if there is a current member, they should be logged out
-        if ($curMember = Security::getCurrentUser()) {
+        if (Security::getCurrentUser()) {
             Injector::inst()->get(IdentityStore::class)->logOut();
         }
-
         $this->getRequest()->getSession()->regenerateSessionId();
+
+        if ($alreadyEncrypted) {
+            $autoLoginHash = $token;
+        } else {
+            $autoLoginHash = $member->encryptWithUserSettings($token);
+        }
+
         // Store the hash for the change password form. Will be unset after reload within the ChangePasswordForm.
-        $this->getRequest()->getSession()->set('AutoLoginHash', $member->encryptWithUserSettings($token));
+        $this->getRequest()->getSession()->set('AutoLoginHash', $autoLoginHash);
     }
 
     /**
@@ -217,8 +281,9 @@ class ChangePasswordHandler extends RequestHandler
 
         $session = $this->getRequest()->getSession();
         if (!$member) {
-            if ($session->get('AutoLoginHash')) {
-                $member = Member::member_from_autologinhash($session->get('AutoLoginHash'));
+            $autoLoginHash = $session->get('AutoLoginHash');
+            if ($autoLoginHash) {
+                $member = Member::member_from_autologinhash($autoLoginHash);
             }
 
             // The user is not logged in and no valid auto login hash is available
@@ -347,5 +412,50 @@ class ChangePasswordHandler extends RequestHandler
             }
         }
         return true;
+    }
+
+    /**
+     * Generate a temporary auto login hash for the member
+     */
+    private function createAutoLoginTempHash(Member $member): string
+    {
+        // If a second authenticator wants to set the temp hash, we should just use the existing hash.
+        if (ChangePasswordHandler::$tempHashAlreadyGenerated) {
+            return $member->AutoLoginTempHash;
+        }
+        // Generate a new random token. We do this instead of re-hashing the regular token
+        // because there is a slim edge-case that the member doesn't have a salt or hashing algorithm set
+        // (e.g. the member was created in code without a password) which would result in reusing the
+        // token in plain text.
+        $foundMember = null;
+        $autoLoginTempHash = '';
+        do {
+            $autoLoginTempHash = Injector::inst()->get(RandomGenerator::class)->randomToken('sha256');
+            $foundMember = Member::get()->find('AutoLoginTempHash', $autoLoginTempHash);
+        } while ($foundMember !== null);
+        ChangePasswordHandler::$tempHashAlreadyGenerated = true;
+        return $autoLoginTempHash;
+    }
+
+    /**
+     * Prepare a friendly message for if the login token is invalid or expired.
+     */
+    private function getInvalidTokenResponse(): array
+    {
+        return [
+            'Content' => DBField::create_field(
+                'HTMLFragment',
+                _t(
+                    Security::class . '.NOTERESETLINKINVALID',
+                    '<p>The password reset link is invalid or expired.</p>'
+                    . '<p>You can request a new one <a href="{link1}">here</a> or change your password after'
+                    . ' you <a href="{link2}">log in</a>.</p>',
+                    [
+                        'link1' => Security::lost_password_url(),
+                        'link2' => Security::login_url(),
+                    ]
+                )
+            ),
+        ];
     }
 }

--- a/src/Security/Security.php
+++ b/src/Security/Security.php
@@ -655,7 +655,7 @@ class Security extends Controller implements TemplateGlobalProvider
      *
      * @param null|HTTPRequest $request
      * @param int $service
-     * @return HTTPResponse|string Returns the "login" page as HTML code.
+     * @return HTTPResponse|RequestHandler|DBHTMLText|string Returns the "login" page as HTML code.
      * @throws HTTPResponse_Exception
      */
     public function login($request = null, $service = Authenticator::LOGIN)
@@ -701,7 +701,7 @@ class Security extends Controller implements TemplateGlobalProvider
      *
      * @param null|HTTPRequest $request
      * @param int $service
-     * @return HTTPResponse|string
+     * @return HTTPResponse|RequestHandler|DBHTMLText|string
      */
     public function logout($request = null, $service = Authenticator::LOGOUT)
     {
@@ -850,7 +850,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @param string $title The title of the form
      * @param array $templates
      * @param callable $aggregator
-     * @return array|HTTPResponse|RequestHandler|DBHTMLText|string
+     * @return HTTPResponse|RequestHandler|DBHTMLText|string
      */
     protected function delegateToMultipleHandlers(array $handlers, $title, array $templates, callable $aggregator)
     {
@@ -884,7 +884,7 @@ class Security extends Controller implements TemplateGlobalProvider
      * @param RequestHandler $handler
      * @param string $title The title of the form
      * @param array $templates
-     * @return array|HTTPResponse|RequestHandler|DBHTMLText|string
+     * @return HTTPResponse|RequestHandler|DBHTMLText|string
      */
     protected function delegateToHandler(RequestHandler $handler, $title, array $templates = [])
     {
@@ -945,7 +945,7 @@ class Security extends Controller implements TemplateGlobalProvider
     /**
      * Show the "lost password" page
      *
-     * @return string Returns the "lost password" page as HTML code.
+     * @return HTTPResponse|RequestHandler|DBHTMLText|string Returns the "lost password" page as HTML code.
      */
     public function lostpassword()
     {
@@ -975,7 +975,7 @@ class Security extends Controller implements TemplateGlobalProvider
      *
      * @see ChangePasswordForm
      *
-     * @return string|HTTPRequest Returns the "change password" page as HTML code, or a redirect response
+     * @return HTTPResponse|RequestHandler|DBHTMLText|string Returns the "change password" page as HTML code, or a redirect response
      */
     public function changepassword()
     {

--- a/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.php
+++ b/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.php
@@ -2,50 +2,152 @@
 
 namespace SilverStripe\Security\Tests\MemberAuthenticator;
 
+use ReflectionClass;
+use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\Session;
-use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\MemberAuthenticator\ChangePasswordForm;
 use SilverStripe\Security\MemberAuthenticator\ChangePasswordHandler;
 use SilverStripe\Security\MemberAuthenticator\MemberAuthenticator;
+use SilverStripe\Security\RandomGenerator;
 use SilverStripe\Security\Security;
 
 class ChangePasswordHandlerTest extends SapphireTest
 {
     protected static $fixture_file = 'ChangePasswordHandlerTest.yml';
 
+    private ChangePasswordHandler $handler;
+
     protected function setUp(): void
     {
         parent::setUp();
-
-        Config::modify()
-            ->set(Security::class, 'login_url', 'Security/login')
-            ->set(Security::class, 'lost_password_url', 'Security/lostpassword');
-
         $this->logOut();
+
+        $this->handler = new ChangePasswordHandler('/Security/changepassword', new MemberAuthenticator());
+        $generator = new class() extends RandomGenerator {
+            public function randomToken($algorithm = 'whirlpool')
+            {
+                return 'temporary-hash';
+            }
+        };
+        Injector::inst()->registerService($generator, RandomGenerator::class);
+        // These values need to be set dynamically rather than as static fixture values.
+        $member = $this->objFromFixture(Member::class, 'sarah');
+        $member->AutoLoginHash = $member->encryptWithUserSettings($member->AutoLoginHash);
+        $member->AutoLoginExpired = date('Y-m-d H:i:s', strtotime('+7 days'));
+        $member->write();
     }
 
-    public function testExpiredOrInvalidTokenProvidesLostPasswordAndLoginLink()
+    protected function tearDown(): void
     {
-        $request = new HTTPRequest('GET', '/Security/changepassword', [
+        $handlerReflection = new ReflectionClass(ChangePasswordHandler::class);
+        $handlerReflection->setStaticPropertyValue('tempHashAlreadyGenerated', false);
+        $handlerReflection->setStaticPropertyValue('tempHashAlreadyProcessed', false);
+    }
+
+    public function testValidUrlParamsRedirectsWithTemporaryHash()
+    {
+        $request = $this->createRequest([
+            'm' => $this->idFromFixture(Member::class, 'sarah'),
+            't' => 'foobar',
+        ]);
+        $result = $this->handler->setRequest($request)->changepassword();
+        $this->assertInstanceOf(HTTPResponse::class, $result);
+        $this->assertSame(302, $result->getStatusCode());
+        $location = Director::absoluteURL('/Security/changepassword?th=temporary-hash');
+        $this->assertSame($location, $result->getHeader('Location'));
+    }
+
+    public function testExpiredOrInvalidToken()
+    {
+        $request = $this->createRequest([
             'm' => $this->idFromFixture(Member::class, 'sarah'),
             't' => 'an-old-or-expired-hash',
         ]);
+        $result = $this->handler->setRequest($request)->changepassword();
+        $this->assertIsArray($result);
+        $this->assertSame(['Content'], array_keys($result));
+        $this->assertSame($this->getInvalidTokenString(), $result['Content']->getValue());
+    }
+
+    public function testTemporaryHashInUrlRendersForm()
+    {
+        $this->setMemberAutoLoginTempHash();
+        $request = $this->createRequest([
+            'th' => 'temporary-hash'
+        ]);
+        $result = $this->handler->setRequest($request)->changepassword();
+        $this->assertIsArray($result);
+        $this->assertSame(['Content', 'Form'], array_keys($result));
+        $this->assertInstanceOf(ChangePasswordForm::class, $result['Form']);
+        $this->assertNotSame($this->getInvalidTokenString(), $result['Content']->getValue());
+    }
+
+    public function testSubsequentTemporaryHash()
+    {
+        $this->setMemberAutoLoginTempHash();
+        $request = $this->createRequest([
+            'th' => 'temporary-hash'
+        ]);
+        $this->handler->setRequest($request)->changepassword();
+        // Simulate starting a fresh request cycle
+        $handlerReflection = new ReflectionClass(ChangePasswordHandler::class);
+        $handlerReflection->setStaticPropertyValue('tempHashAlreadyGenerated', false);
+        $handlerReflection->setStaticPropertyValue('tempHashAlreadyProcessed', false);
+        $request = $this->createRequest([
+            'th' => 'temporary-hash'
+        ]);
+        $this->handler->setRequest($request);
+        $result = $this->handler->changepassword();
+        $this->assertIsArray($result);
+        $this->assertInstanceOf(DBHTMLText::class, $result['Content'] ?? null);
+        $this->assertSame($this->getInvalidTokenString(), $result['Content']->getValue());
+    }
+
+    public function testIncorrectTemporaryHashInUrl()
+    {
+        $this->setMemberAutoLoginTempHash();
+        $request = $this->createRequest([
+            'th' => 'wrong-hash'
+        ]);
+        $result = $this->handler->setRequest($request)->changepassword();
+        $this->assertIsArray($result);
+        $this->assertInstanceOf(DBHTMLText::class, $result['Content'] ?? null);
+        $this->assertSame($this->getInvalidTokenString(), $result['Content']->getValue());
+    }
+
+    /**
+     * Create a HTTPRequest for testing with.
+     */
+    private function createRequest(array $params = []): HTTPRequest
+    {
+        $request = new HTTPRequest('POST', '/Security/changepassword', $params);
         $request->setSession(new Session([]));
+        return $request;
+    }
 
-        // not using a phpunit mock otherwise get the error
-        // Error: Typed property MockObject_ChangePasswordHandler_12f49d86::$__phpunit_state
-        // must not be accessed before initialization
-        $handler = new class() extends ChangePasswordHandler {
-            public function __construct()
-            {
-            }
-        };
+    /**
+     * Set the AutoLoginTempHash to 'temporary-hash' for the test member.
+     * This is used to simulate the second stage of the change password process.
+     */
+    private function setMemberAutoLoginTempHash(): void
+    {
+        $member = $this->objFromFixture(Member::class, 'sarah');
+        $member->AutoLoginTempHash = 'temporary-hash';
+        $member->write();
+    }
 
-        $result = $handler->setRequest($request)->changepassword();
-        $this->assertIsArray($result, 'An array is returned');
-        $this->assertStringContainsString('Security/lostpassword', $result['Content'], 'Lost password URL is included');
-        $this->assertStringContainsString('Security/login', $result['Content'], 'Login URL is included');
+    private function getInvalidTokenString(): string
+    {
+        $link1 = Security::lost_password_url();
+        $link2 = Security::login_url();
+        return '<p>The password reset link is invalid or expired.</p>'
+        . "<p>You can request a new one <a href=\"{$link1}\">here</a> or change your password after"
+        . " you <a href=\"{$link2}\">log in</a>.</p>";
     }
 }

--- a/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.yml
+++ b/tests/php/Security/MemberAuthenticator/ChangePasswordHandlerTest.yml
@@ -2,4 +2,4 @@ SilverStripe\Security\Member:
   sarah:
     FirstName: Sarah
     Surname: Smith
-    AutoLoginToken: foobar
+    AutoLoginHash: foobar

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Security\Tests;
 
 use Page;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
@@ -20,8 +21,10 @@ use SilverStripe\ORM\FieldType\DBEnum;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Security\LoginAttempt;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\MemberAuthenticator\ChangePasswordHandler;
 use SilverStripe\Security\MemberAuthenticator\MemberAuthenticator;
 use SilverStripe\Security\Security;
 use SilverStripe\Security\SecurityToken;
@@ -65,6 +68,14 @@ class SecurityTest extends FunctionalTest
         parent::setUp();
 
         Director::config()->set('alternate_base_url', '/');
+    }
+
+    protected function tearDown(): void
+    {
+        $handlerReflection = new ReflectionClass(ChangePasswordHandler::class);
+        $handlerReflection->setStaticPropertyValue('tempHashAlreadyGenerated', false);
+        $handlerReflection->setStaticPropertyValue('tempHashAlreadyProcessed', false);
+        parent::tearDown();
     }
 
     public function testAccessingAuthenticatedPageRedirectsToLoginForm()
@@ -528,12 +539,13 @@ class SecurityTest extends FunctionalTest
         // Check.
         $response = $this->get('Security/changepassword/?m=' . $admin->ID . '&t=' . $token);
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals(
-            Director::absoluteURL('Security/changepassword'),
-            Director::absoluteURL((string) $response->getHeader('Location'))
+        $location = (string) $response->getHeader('Location');
+        $this->assertStringStartsWith(
+            Director::absoluteURL('Security/changepassword?th='),
+            Director::absoluteURL($location)
         );
-        // Follow redirection to form without hash in GET parameter
-        $this->get('Security/changepassword');
+        // Follow redirection
+        $this->get($location);
         $this->doTestChangepasswordForm('1nitialPassword', 'changedPassword#123');
         $this->assertEquals($this->idFromFixture(Member::class, 'test'), $this->session()->get('loggedInAs'));
 
@@ -546,6 +558,80 @@ class SecurityTest extends FunctionalTest
         $admin = DataObject::get_by_id(Member::class, $admin->ID, false);
         $this->assertNull($admin->LockedOutUntil);
         $this->assertEquals(0, $admin->FailedLoginCount);
+    }
+
+    public function testChangePasswordMultipleAuthenticators()
+    {
+        // Prepare member
+        $member = $this->objFromFixture(Member::class, 'test');
+        $member->AutoLoginHash = $member->encryptWithUserSettings('some-token');
+        $member->AutoLoginExpired = date('Y-m-d H:i:s', strtotime('+7 days'));
+        $member->write();
+
+        // Prepare dummy authenticator
+        $secondaryPasswordHandlerClass = get_class(
+            // Note we have to pass arguments into the constructor here - we can't just make an
+            // anonymous class without instantiating it unfortunately.
+            new class('', new MemberAuthenticator()) extends ChangePasswordHandler {
+                private static $allowed_actions = [
+                    'changepassword',
+                ];
+                protected function createChangePasswordResponse(): array|HTTPResponse
+                {
+                    // This is an invalid response, and is included to validate that the valid handler will be used
+                    // even if there's an invalid one in the group
+                    return [];
+                }
+            }
+        );
+        $secondaryAuthenticator = new class($secondaryPasswordHandlerClass) extends MemberAuthenticator {
+            public function __construct(private string $handlerClass)
+            {
+            }
+            public function getChangePasswordHandler($link)
+            {
+                return $this->handlerClass::create($link, $this);
+            }
+        };
+        $security = Security::singleton();
+        try {
+            // Add the dummy authenticator and prep request
+            $authenticators = $security->getAuthenticators();
+            $authenticators['test-auth'] = $secondaryAuthenticator;
+            $security->setAuthenticators($authenticators);
+            $params = [
+                't' => 'some-token',
+                'm' => $member->ID,
+            ];
+            // Don't include "/Security" because that would have been routed out by Security admin by now
+            $request = new HTTPRequest('GET', '/changepassword', $params);
+            $request->setSession(new Session([]));
+            $security->setRequest($request);
+
+            // Initial request should redirect to the form with a new temp hash
+            $response = $security->changepassword();
+            $this->assertInstanceOf(HTTPResponse::class, $response);
+            $this->assertSame(302, $response->getStatusCode());
+            $locationPrefix = Director::absoluteURL('/Security/changepassword?th=');
+            $actualLocation = $response->getHeader('Location');
+            $this->assertStringStartsWith($locationPrefix, $actualLocation);
+
+            // Second request should return the form
+            $params = [
+                'th' => str_replace($locationPrefix, '', $actualLocation),
+            ];
+            $request = new HTTPRequest('GET', '/changepassword', $params);
+            $request->setSession(new Session([]));
+            $security->setRequest($request);
+            $response = $security->changepassword();
+            $this->assertInstanceOf(DBHTMLText::class, $response);
+            $this->assertStringNotContainsString('The password reset link is invalid or expired', $response->getValue());
+            $this->assertStringContainsString('Please enter a new password', $response->getValue());
+        } finally {
+            $authenticators = $security->getAuthenticators();
+            unset($authenticators['test-auth']);
+            $security->setAuthenticators($authenticators);
+        }
     }
 
     public function testRepeatedLoginAttemptsLockingPeopleOut()


### PR DESCRIPTION
With the session cookie's "SameSite" value set to "Strict", we can't set session values when a request is the result of clicking a link from another website.
When a user clicks the reset password link from an email within a web client (e.g. Gmail), this results in not being able to reset their password.

This change sets the session value _after_ the redirect, while avoiding putting the reset token into the browser history which could allow a bad actor to access it.

This change also allows that flow to work for silverstripe/mfa which needs to alter the second part of the flow, but detects that currently using the session value's presence or absence.

This PR is based off https://github.com/silverstripe/silverstripe-framework/pull/11668 and https://github.com/silverstripe/silverstripe-framework/pull/11676 though it does have some differences.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11565