### PR TITLE
ENH Show friendly message if user takes too long changing password

### DIFF
--- a/src/Control/RequestHandler.php
+++ b/src/Control/RequestHandler.php
@@ -117,6 +117,14 @@ class RequestHandler extends ModelData
      */
     private static $allowed_actions = null;
 
+    /**
+     * If the request is handed off to a nested request handler, and that handler returns an array,
+     * by default this handler will be customised with that returned array.
+     * Setting this to true will return the array directly instead, which treats it as through this handler
+     * returned the array from an action method directly.
+     */
+    private static bool $customise_array_return_value = true;
+
     public function __construct()
     {
         $this->brokenOnConstruct = false;
@@ -223,7 +231,7 @@ class RequestHandler extends ModelData
             $returnValue = $result->handleRequest($request);
 
             // Array results can be used to handle
-            if (is_array($returnValue)) {
+            if (is_array($returnValue) && static::config()->get('customise_array_return_value')) {
                 $returnValue = $this->customise($returnValue);
             }
 

--- a/src/Security/MemberAuthenticator/ChangePasswordHandler.php
+++ b/src/Security/MemberAuthenticator/ChangePasswordHandler.php
@@ -47,6 +47,8 @@ class ChangePasswordHandler extends RequestHandler
         '' => 'changepassword',
     ];
 
+    private static bool $customise_array_return_value = false;
+
     /**
      * Keep track of whether a temporary hash is already generated during this request cycle.
      * @internal
@@ -282,15 +284,16 @@ class ChangePasswordHandler extends RequestHandler
         $session = $this->getRequest()->getSession();
         if (!$member) {
             $autoLoginHash = $session->get('AutoLoginHash');
-            if ($autoLoginHash) {
-                $member = Member::member_from_autologinhash($autoLoginHash);
+            if (!$autoLoginHash) {
+                // The user is not logged in and had no reset token, so give them a login form.
+                return $this->redirect($this->addBackURLParam(Security::singleton()->Link('login')));
             }
 
-            // The user is not logged in and no valid auto login hash is available
+            $member = Member::member_from_autologinhash($autoLoginHash);
             if (!$member) {
+                // Hash was invalid or expired
                 $session->clear('AutoLoginHash');
-
-                return $this->redirect($this->addBackURLParam(Security::singleton()->Link('login')));
+                return $this->getInvalidTokenResponse();
             }
         }
 


### PR DESCRIPTION
If a user's password reset token expires before they submit the form, they should get clear messaging instead of just being sent to the login form.

This was originally included as a second commit to https://github.com/silverstripe/silverstripe-framework/pull/11686. That PR must be merged before this one can be.

Note it already has product owner approval - it has only been split off for ease of reviewing.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11565