### PR TITLE
FIX Remove attempt to update

### DIFF
--- a/src/Control/HTTP.php
+++ b/src/Control/HTTP.php
@@ -57,7 +57,6 @@ class HTTP
      */
     public static function absoluteURLs($html)
     {
-        $html = str_replace('$CurrentPageURL', Controller::curr()->getRequest()->getURL() ?? '', $html ?? '');
         return HTTP::urlRewriter($html, function ($url) {
             //no need to rewrite, if uri has a protocol (determined here by existence of reserved URI character ":")
             if (preg_match('/^\w+:/', $url ?? '')) {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11678

This line is also in CMS 5 https://github.com/silverstripe/silverstripe-framework/blob/5/src/Control/HTTP.php#L68

I cannot find any reference to anything in CMS 5/6 sink actually using `CurrentPageURL`, in a template.  There is also no corresponding `getCurrentPageURL()` method / call anywhere, and no reference in the docs

Rather than attempt to try and work out what the current url is in CLI context (which is nonsensical) I think we should just delete this line in CMS 6

Unit test failures are unrelated
