### PR TITLE
MNT Fix broken unit tests

### DIFF
--- a/tests/php/Forms/HTMLEditor/HTMLEditorSanitiserTest.php
+++ b/tests/php/Forms/HTMLEditor/HTMLEditorSanitiserTest.php
@@ -218,8 +218,6 @@ class HTMLEditorSanitiserTest extends FunctionalTest
                 'validElements' => ['object' => ['attributes' => ['data' => true]]],
                 'input' => '<object data="' . HTMLEditorSanitiserTest::CHAR_BACKSPACE . 'javascript:alert()">',
                 'expected' => '<object></object>',
-
-                'object[data]',
             ],
             'remove text/html from data attribute' => [
                 'validElements' => ['object' => ['attributes' => ['data' => true]]],

--- a/tests/php/Forms/SearchableDropdownTraitTest.php
+++ b/tests/php/Forms/SearchableDropdownTraitTest.php
@@ -286,9 +286,8 @@ class SearchableDropdownTraitTest extends SapphireTest
      * Member has a method getTitle() that returns "Surname, FirstName"
      * The default label field on the field is "Title", which doesn't exist on the Member database table
      * It should fall back to using search context in this scenario
-     *
-     * @dataProvider provideSearchDataObjectWithMethodForLabelField
      */
+    #[DataProvider('provideSearchDataObjectWithMethodForLabelField')]
     public function testSearchDataObjectWithMethodForLabelField(string $term, string $expected): void
     {
         Member::config()->set('title_format', ['columns' => ['Surname', 'FirstName'], 'sep' => ', ']);

--- a/tests/php/Security/SecurityTest.php
+++ b/tests/php/Security/SecurityTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Security\Tests;
 
 use Page;
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
@@ -804,7 +805,7 @@ class SecurityTest extends FunctionalTest
         );
     }
 
-    public function provideWithMinimumExecutionTime(): array
+    public static function provideWithMinimumExecutionTime(): array
     {
         return [
             'check default is used' => [
@@ -818,9 +819,7 @@ class SecurityTest extends FunctionalTest
         ];
     }
 
-    /**
-     * @dataProvider provideWithMinimumExecutionTime
-     */
+    #[DataProvider('provideWithMinimumExecutionTime')]
     public function testWithMinimumExecutionTime(bool $useDefault, int $minExecution): void
     {
         if ($useDefault) {


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/actions/runs/14394349478/job/40367367280

```text
1) SilverStripe\Security\Tests\SecurityTest::testWithMinimumExecutionTime
The data provider specified for SilverStripe\Security\Tests\SecurityTest::testWithMinimumExecutionTime is invalid
Data Provider method SilverStripe\Security\Tests\SecurityTest::provideWithMinimumExecutionTime() is not static

1) Metadata found in doc-comment for method SilverStripe\Forms\Tests\SearchableDropdownTraitTest::testSearchDataObjectWithMethodForLabelField(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

2) Metadata found in doc-comment for method SilverStripe\Security\Tests\SecurityTest::testWithMinimumExecutionTime(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

1) SilverStripe\Forms\Tests\HTMLEditor\HTMLEditorSanitiserTest::testSanitise with data set "remove JS with backspace char from data attribute" ([[[true]]], Binary String: 0x3c6f626a65637...829223e, '<object></object>', 'object[data]')
Error: Cannot use positional argument after named argument during unpacking
```

## Issue
- https://github.com/silverstripe/.github/issues/389