### PR TITLE
FIX Don't try to use empty backtrace

### DIFF
--- a/src/Dev/Deprecation.php
+++ b/src/Dev/Deprecation.php
@@ -144,7 +144,7 @@ class Deprecation
      */
     protected static function get_called_method_from_trace($backtrace, $level = 1)
     {
-        if ($backtrace === null) {
+        if (empty($backtrace)) {
             return '';
         }
         $level = (int)$level;
@@ -193,7 +193,7 @@ class Deprecation
 
     private static function isCalledFromSupportedCode(?array $backtrace): bool
     {
-        if ($backtrace === null) {
+        if (empty($backtrace)) {
             return false;
         }
         $called = Deprecation::get_called_from_trace($backtrace, 1);


### PR DESCRIPTION

In CMS 5 the `$backtrace` variable was initialised as `null` but now it's initialised as an empty array - but the methods that use it weren't updated to handle that.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11698
