### PR TITLE
ENH More efficient hierarchy querying

### DIFF
--- a/src/Forms/TreeDropdownField.php
+++ b/src/Forms/TreeDropdownField.php
@@ -149,11 +149,11 @@ class TreeDropdownField extends FormField implements HasOneRelationFieldInterfac
     protected $baseID = 0;
 
     /**
-     * Default child method in Hierarchy->getChildrenAsUL
+     * Child method to use for Hierarchy->getChildrenAsUL - Hierarchy.default_children_method config
      *
      * @var string
      */
-    protected $childrenMethod = 'AllChildrenIncludingDeleted';
+    protected $childrenMethod = null;
 
     /**
      * Default child counting method in Hierarchy->getChildrenAsUL
@@ -392,7 +392,7 @@ class TreeDropdownField extends FormField implements HasOneRelationFieldInterfac
      */
     public function getChildrenMethod()
     {
-        return $this->childrenMethod;
+        return $this->childrenMethod ?: Hierarchy::config()->get('default_children_method');
     }
 
     /**

--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -14,12 +14,14 @@ use SilverStripe\Core\Extension;
 use SilverStripe\ORM\DB;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Core\Config\Config;
+use InvalidArgumentException;
 use SilverStripe\Core\Convert;
 use Exception;
 use SilverStripe\Model\ModelData;
 use SilverStripe\ORM\HiddenClass;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
+use SilverStripe\Core\Config\Configurable;
 
 /**
  * DataObjects that use the Hierarchy extension can be be organised as a hierarchy, with children and parents. The most
@@ -31,6 +33,8 @@ use SilverStripe\Security\Security;
  */
 class Hierarchy extends Extension
 {
+    use Configurable;
+
     /**
      * The name of the dedicated sort field, if there is one.
      * Will be null if there's no field for sorting this model.
@@ -128,6 +132,23 @@ class Hierarchy extends Extension
      * @var boolean
      */
     private static $prepopulate_numchildren_cache = true;
+
+    /**
+     * The default method called on the Hierarchy class to get children
+     */
+    private static string $default_children_method = 'getAllChildrenEvenIfDeleted';
+
+    /**
+     * Used to cache the children a node has in getAllChildrenEvenIfDeleted()
+     * @internal
+     */
+    private static array $all_children_child_ids_cache = [];
+
+    /**
+     * Used to cache child dataobjects in getAllChildrenEvenIfDeleted()
+     * @internal
+     */
+    private static array $all_children_obj_cache = [];
 
     /**
      * Prevent virtual page virtualising these fields
@@ -358,6 +379,121 @@ class Hierarchy extends Extension
         }
         $owner->extend("augmentAllChildrenIncludingDeleted", $stageChildren);
         return $stageChildren;
+    }
+
+    /**
+     * Return all children, including those that have been deleted but are still in live
+     *
+     * This achieves much the same result as AllChildrenIncludingDeleted(), and in intended to be far more
+     * performant, though there are some key differences:
+     * - Results will be cached in-memory to save on the number of database queries required
+     * - Database queries will be larger `WHERE "ID" IN (?, ?) style queries rather than many `WHERE "ID" = ?
+     * - While Hierarchy.node_threshold_total has not been exceeded, it will cache descendant record as
+     *   well to save future queries
+     * - It uses a totally different code path, e.g. it will not call stageChildren(), therefore some extension
+     *   hooks will not be fired
+     *
+     * Note that queries to retrieve data will only be done against the base data class, so any database fields defined
+     * on subclasses will be initially omitted, though these will be later fetched via DataObject::loadLazyFields() in separate inefficient DB queries
+     */
+    public function getAllChildrenEvenIfDeleted(): ArrayList
+    {
+        $owner = $this->getOwner();
+        $parentID = $owner->ID;
+        $dataClass = $owner->ClassName;
+        $baseDataClass = $owner->getSchema()->baseDataClass($dataClass);
+        Hierarchy::$all_children_child_ids_cache[$baseDataClass] ??= [];
+        Hierarchy::$all_children_obj_cache[$baseDataClass] ??= [];
+        if (!array_key_exists($parentID, Hierarchy::$all_children_obj_cache[$baseDataClass])) {
+            Hierarchy::$all_children_obj_cache[$baseDataClass][$parentID] = $owner;
+        }
+        $this->recursivelyCacheDescendants($baseDataClass, $parentID);
+        $childIDs = [];
+        if (array_key_exists($parentID, Hierarchy::$all_children_child_ids_cache[$baseDataClass])) {
+            $childIDs = Hierarchy::$all_children_child_ids_cache[$baseDataClass][$parentID];
+        }
+        $childNodes = [];
+        foreach ($childIDs as $childID) {
+            if (array_key_exists($childID, Hierarchy::$all_children_obj_cache[$baseDataClass])) {
+                $childNodes[] = Hierarchy::$all_children_obj_cache[$baseDataClass][$childID];
+            }
+        }
+        $children = ArrayList::create($childNodes);
+        $owner->extend('updateGetAllChildrenEvenIfDeleted', $children);
+        return $children;
+    }
+
+    /**
+     * Inner recursive method used by getAllChildrenEvenIfDeleted
+     * This will use a hierarchical query method where it will initially fetched from the "second level down"
+     * where the ParentID equals the single DataObject at the "top level" of the hierarchy
+     * It will then fetch from the "third level down" in the hierarchy where the ParentID is of the ParentIDs in
+     * the "second level down". In will continue querying like this until the total number of cached objects has
+     * exceeded the configured value `node_threshold_total`, or all object have been fetched
+     */
+    private function recursivelyCacheDescendants(
+        string $baseDataClass,
+        int|array $idOrIDs,
+    ): void {
+        if (!is_a($baseDataClass, DataObject::class, true)) {
+            throw new InvalidArgumentException("$baseDataClass is not a DataObject");
+        }
+        if (is_int($idOrIDs)) {
+            $parentIDs = [$idOrIDs];
+        } else {
+            $parentIDs = $idOrIDs;
+        }
+        $parentIDs = array_filter($parentIDs, function ($parentID) use ($baseDataClass) {
+            return !array_key_exists($parentID, Hierarchy::$all_children_child_ids_cache[$baseDataClass]);
+        });
+        if (empty($parentIDs)) {
+            return;
+        }
+        $config = $this->getOwner()->config();
+        $count = count(Hierarchy::$all_children_obj_cache[$baseDataClass]);
+        $threshold = $config->get('node_threshold_total');
+        if ($count >= $threshold) {
+            return;
+        }
+        $hideFromHierarchy = $config->get('hide_from_hierarchy');
+        $hideFromCMSTree = $config->get('hide_from_cms_tree');
+        $exclude = [];
+        if ($hideFromHierarchy) {
+            $exclude['ClassName'] = $hideFromHierarchy;
+        }
+        if ($hideFromCMSTree && $this->showingCMSTree()) {
+            $exclude['ClassName'] = $hideFromCMSTree;
+        }
+        $nextIDs = [];
+        /** @var DataList $children */
+        $children = $baseDataClass::get()->filter(['ParentID' => $parentIDs]);
+        if ($exclude) {
+            $children = $children->exclude($exclude);
+        }
+        if (class_exists(Versioned::class)) {
+            // This will also get Live records that are not on draft, so it's safe to save them
+            // to the same cache
+            // Though is an assumption that any children of a "live only" record
+            // should also be read and cached as "live only" records
+            $children = Versioned::updateListToAlsoIncludeDeleted($children);
+        }
+        foreach ($parentIDs as $parentID) {
+            Hierarchy::$all_children_child_ids_cache[$baseDataClass][$parentID] ??= [];
+        }
+        foreach ($children as $child) {
+            $childID = $child->ID;
+            $parentID = $child->ParentID;
+            Hierarchy::$all_children_child_ids_cache[$baseDataClass][$parentID][] = $childID;
+            Hierarchy::$all_children_obj_cache[$baseDataClass][$childID] = $child;
+            if (!array_key_exists($childID, Hierarchy::$all_children_child_ids_cache[$baseDataClass])
+                && !in_array($childID, $nextIDs)
+            ) {
+                $nextIDs[] = $childID;
+            }
+        }
+        if (count($nextIDs)) {
+            $this->recursivelyCacheDescendants($baseDataClass, $nextIDs);
+        }
     }
 
     /**

--- a/src/ORM/Hierarchy/MarkedSet.php
+++ b/src/ORM/Hierarchy/MarkedSet.php
@@ -52,7 +52,7 @@ class MarkedSet
     protected $rootNode = null;
 
     /**
-     * Method to use for getting children. Defaults to 'AllChildrenIncludingDeleted'
+     * Method to use for getting children. Defaults to Hierarchy.default_children_method config
      *
      * @var string
      */
@@ -180,7 +180,7 @@ class MarkedSet
      */
     public function getChildrenMethod()
     {
-        return $this->childrenMethod ?: 'AllChildrenIncludingDeleted';
+        return $this->childrenMethod ?: Hierarchy::config()->get('default_children_method');
     }
 
     /**

--- a/tests/php/ORM/HierarchyTest.php
+++ b/tests/php/ORM/HierarchyTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\ORM\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
+use ReflectionProperty;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Validation\ValidationException;
 use SilverStripe\Versioned\Versioned;
@@ -18,6 +19,7 @@ class HierarchyTest extends SapphireTest
 
     protected static $extra_dataobjects = [
         HierarchyTest\TestObject::class,
+        HierarchyTest\TestObjectHideFromHierarchy::class,
         HierarchyTest\HideTestObject::class,
         HierarchyTest\HideTestSubObject::class,
         HierarchyTest\HierarchyOnSubclassTestObject::class,
@@ -51,6 +53,15 @@ class HierarchyTest extends SapphireTest
         if (!class_exists(Versioned::class)) {
             $this->markTestSkipped('HierarchyTest requires the Versioned extension');
         }
+    }
+
+    protected function tearDown(): void
+    {
+        $reflA = new ReflectionProperty(Hierarchy::class, 'all_children_child_ids_cache');
+        $reflB = new ReflectionProperty(Hierarchy::class, 'all_children_obj_cache');
+        $reflA->setValue(null, []);
+        $reflB->setValue(null, []);
+        parent::tearDown();
     }
 
     /**
@@ -700,5 +711,120 @@ class HierarchyTest extends SapphireTest
         $group = new Group();
         $group->Title = '<b>My group</b>';
         $this->assertSame('<i>&lt;b&gt;My group&lt;/b&gt;</i>', $group->getTreeTitle());
+    }
+
+    public static function provideGetAllChildrenEvenIfDeleted(): array
+    {
+        return [
+            'threshold-5' => [
+                'threshold' => 5,
+                'hide' => true,
+                'expected' => [
+                    'Obj 3' => [
+                        'Obj 3a',
+                        'Obj 3b',
+                        'Obj 3c',
+                        'Obj 3d',
+                    ],
+                ]
+            ],
+            'threshold-6' => [
+                'threshold' => 6,
+                'hide' => true,
+                'expected' => [
+                    'Obj 3' => [
+                        'Obj 3a',
+                        'Obj 3b',
+                        'Obj 3c',
+                        'Obj 3d',
+                    ],
+                    'Obj 3a' => [
+                        'Obj 3aa',
+                        'Obj 3ab',
+                    ],
+                    'Obj 3b' => [
+                        'Obj 3ba',
+                        'Obj 3bb',
+                    ],
+                    'Obj 3c' => [
+                        'Obj 3ca'
+                    ],
+                    'Obj 3d' => [],
+                ]
+            ],
+            'threshold-50' => [
+                'threshold' => 50,
+                'hide' => true,
+                'expected' => [
+                    'Obj 3' => [
+                        'Obj 3a',
+                        'Obj 3b',
+                        'Obj 3c',
+                        'Obj 3d',
+                    ],
+                    'Obj 3a' => [
+                        'Obj 3aa',
+                        'Obj 3ab',
+                    ],
+                    'Obj 3b' => [
+                        'Obj 3ba',
+                        'Obj 3bb',
+                    ],
+                    'Obj 3c' => [
+                        'Obj 3ca'
+                    ],
+                    'Obj 3d' => [],
+                    'Obj 3aa' => [],
+                    'Obj 3ab' => [],
+                    'Obj 3ba' => [],
+                    'Obj 3bb' => [],
+                    'Obj 3ca' => [],
+                ]
+            ],
+            'show-hidden' => [
+                'threshold' => 6,
+                'hide' => false,
+                'expected' => [
+                    'Obj 3' => [
+                        'Obj 3a',
+                        'Obj 3b',
+                        'Obj 3c',
+                        'Obj 3d',
+                        'Obj 3HfH1',
+                    ],
+                ]
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetAllChildrenEvenIfDeleted')]
+    public function testGetAllChildrenEvenIfDeleted(int $threshold, bool $hide, array $expected): void
+    {
+        HierarchyTest\TestObject::config()->set('node_threshold_total', $threshold);
+        if ($hide) {
+            // Hierarchy::showingCMSTree() will always return false in this test, so
+            // hide_from_cms_tree is not tested
+            HierarchyTest\TestObject::config()->merge(
+                'hide_from_hierarchy',
+                [HierarchyTest\TestObjectHideFromHierarchy::class]
+            );
+        }
+        $dataClass = HierarchyTest\TestObject::class;
+        $obj3 = $this->objFromFixture($dataClass, 'obj3');
+        $children = $obj3->getAllChildrenEvenIfDeleted();
+        $this->assertSame($expected['Obj 3'], $children->column('Title'));
+        $reflA = new ReflectionProperty(Hierarchy::class, 'all_children_child_ids_cache');
+        $reflB = new ReflectionProperty(Hierarchy::class, 'all_children_obj_cache');
+        $cacheA = $reflA->getValue(null);
+        $cacheB = $reflB->getValue(null);
+        $actual = [];
+        foreach ($cacheA[$dataClass] as $id => $childIDs) {
+            $title = $cacheB[$dataClass][$id]->Title;
+            $actual[$title] = [];
+            foreach ($childIDs as $childID) {
+                $actual[$title][] = $cacheB[$dataClass][$childID]->Title;
+            }
+        }
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/php/ORM/HierarchyTest.yml
+++ b/tests/php/ORM/HierarchyTest.yml
@@ -43,7 +43,11 @@ SilverStripe\ORM\Tests\HierarchyTest\TestObject:
     Title: Obj 3bb
   obj3ca:
     Parent: =>SilverStripe\ORM\Tests\HierarchyTest\TestObject.obj3c
-    Title: Obj 3c
+    Title: Obj 3ca
+SilverStripe\ORM\Tests\HierarchyTest\TestObjectHideFromHierarchy:
+  obj3HfH1:
+    Parent: =>SilverStripe\ORM\Tests\HierarchyTest\TestObject.obj3
+    Title: Obj 3HfH1
 SilverStripe\ORM\Tests\HierarchyTest\HideTestObject:
   obj4:
     Title: Obj 4

--- a/tests/php/ORM/HierarchyTest/TestObjectHideFromHierarchy.php.php
+++ b/tests/php/ORM/HierarchyTest/TestObjectHideFromHierarchy.php.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\Hierarchy\Hierarchy;
+use SilverStripe\Versioned\Versioned;
+
+class TestObjectHideFromHierarchy extends TestObject implements TestOnly
+{
+    private static $table_name = 'HierarchyTest_ObjectHideFromHierarchy';
+
+    private static $db = [
+        'SomeField' => 'Varchar'
+    ];
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11703

Required for https://github.com/silverstripe/silverstripe-cms/pull/3076

This isn't intended to be merged, at this point it's just some exploratory work in to making the cms page site tree more db query efficient. On a site with 7 pages I was getting about 32 queries that were very similar, and this number will be substantially higher on sites with more pages

Currently the MarkedSet class will get children for one node at a time in a loop in `MarkedSet::markPartialTree()` which is a very inefficient query method. Instead what should happen is that a hierarchy of IDs is fetched ahead of time using a small number of `WHERE "ParentID" IN (?, ?, ?)` queries. Another option would be to fetch every ID + ParentID on the table in a single giant query, though there is some risk of running out of memory if doing this if the MarkedSet is on a non SiteTree DataObject will a huge number of rows.

However because of all the existing code in the class, including extension hooks, actually implementing this will be non-trivial

There will by a need to call InheritedPermissions::batchPermissionCheck(), which itself is upfront cachable if you give it a list of IDs

Question from Guy - could we do something similar to DataObject::get_one() which caches results, though instead do it for many i.e. DataObject::get_many()? (kind of applies to all PRs, not just this one)