### PR TITLE
ENH Cache result of GridFieldDetailForm_ItemRequest::getGridFieldItemAdjacencies()

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -98,6 +98,11 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
     ];
 
     /**
+     * Used to cache the results of getGridFieldItemAdjacencies();
+     */
+    private array $cachedGridFieldItemAdjacencies;
+
+    /**
      *
      * @param GridField $gridField
      * @param GridFieldDetailForm $component
@@ -628,18 +633,22 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      */
     private function getGridFieldItemAdjacencies(): array
     {
-        $list = $this->getGridField()->getManipulatedList();
-        $paginator = $this->getGridFieldPaginatorState();
-        if (!$paginator) {
-            return [];
+        if (!isset($this->cachedGridFieldItemAdjacencies)) {
+            $paginator = $this->getGridFieldPaginatorState();
+            if (!$paginator) {
+                $this->cachedGridFieldItemAdjacencies = [];
+            } else {
+                $currentPage = $paginator->getData('currentPage');
+                $itemsPerPage = $paginator->getData('itemsPerPage');
+                $limit = $itemsPerPage + 2;
+                $limitOffset = max(0, $itemsPerPage * ($currentPage - 1) -1);
+                $this->cachedGridFieldItemAdjacencies = $this->getGridField()
+                    ->getManipulatedList()
+                    ->limit($limit, $limitOffset)
+                    ->column('ID');
+            }
         }
-        $currentPage = $paginator->getData('currentPage');
-        $itemsPerPage = $paginator->getData('itemsPerPage');
-
-        $limit = $itemsPerPage + 2;
-        $limitOffset = max(0, $itemsPerPage * ($currentPage-1) -1);
-
-        return $list->limit($limit, $limitOffset)->column('ID');
+        return $this->cachedGridFieldItemAdjacencies;
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11703

**Do not merge, this should probably target 5.4 instead of 6**

This cuts down 10 queries to 2 when viewing a GridField managed record. This functionality being cached relates to the prev/next buttons in the bottom right of the CMS

When viewing a Member record in SecurityAdmin, the following queries each come up 5 times, have been reduced to 1 time each now

SELECT DISTINCT count(DISTINCT "Member"."ID") AS "Count" FROM "Member"
(from GridFieldPaginator::getManipulatedData():137 triggered by $this->getGridField()->getManipulatedList())

SELECT "Member"."ID", "Member"."Surname" AS "_SortColumn0", "Member"."FirstName" AS "_SortColumn1" FROM "Member" ORDER BY "_SortColumn0" ASC, "_SortColumn1" ASC LIMIT 32
(from the follow up call on the manipulated list i.e. ->column('ID'))