### PR TITLE
ENH Prepopulate version number cache

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -2061,4 +2061,17 @@ class DataList extends ModelData implements SS_List
             $currentChunk++;
         }
     }
+
+    /**
+     * Prepopulate any extension caches with the current dataclass and IDs of records
+     *
+     * Note that because this calls column() and may result in other database queries based on
+     * the IDs that returns, this should be called after all filtering, sorting, etc has already
+     * been set for this list.
+     */
+    public function prepopulateCaches(): void
+    {
+        $ids = $this->column('ID');
+        $this->extend('onPrepopulateCaches', $ids);
+    }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11703

Requires https://github.com/silverstripe/silverstripe-versioned/pull/500

Will combined lots of small SQL queries in to a large combined `WHERE "ID" IN` `canViewVersioned()` checks, triggered by calls to `canViewVersioned()`

Before
`SELECT "Version" FROM "SiteTree" WHERE "ID" = ?`

After
`SELECT "ID", "Version" FROM "SiteTree" WHERE "ID" IN (?, ?, ?)`

This can be seen when viewing pages in ArchiveAdmin, though there' probably plenty of scenarios when this happens