### PR TITLE
ENH Cache result of GridFieldDetailForm_ItemRequest::getGridFieldItemAdjacencies()

### DIFF
--- a/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
+++ b/src/Forms/GridField/GridFieldDetailForm_ItemRequest.php
@@ -97,6 +97,11 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
     ];
 
     /**
+     * Used to cache the results of getGridFieldItemAdjacencies();
+     */
+    private array $cachedGridFieldItemAdjacencies = [];
+
+    /**
      *
      * @param GridField $gridField
      * @param GridFieldDetailForm $component
@@ -188,6 +193,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      */
     public function ItemEditForm()
     {
+        $this->resetAdjacenciesCache();
         $list = $this->gridField->getList();
 
         if (empty($this->record)) {
@@ -627,18 +633,30 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      */
     private function getGridFieldItemAdjacencies(): array
     {
-        $list = $this->getGridField()->getManipulatedList();
-        $paginator = $this->getGridFieldPaginatorState();
-        if (!$paginator) {
+        $paginatorState = $this->getGridFieldPaginatorState();
+        if (!$paginatorState) {
             return [];
         }
-        $currentPage = $paginator->getData('currentPage');
-        $itemsPerPage = $paginator->getData('itemsPerPage');
-
+        $keyStr = '';
+        $data = $this->getGridField()->getState()->toArray();
+        array_walk_recursive($data, function ($v, $k) use (&$keyStr) {
+            if (is_scalar($k) && is_scalar($v)) {
+                $keyStr .= $k . $v;
+            }
+        });
+        $key = md5($keyStr);
+        if (array_key_exists($key, $this->cachedGridFieldItemAdjacencies)) {
+            return $this->cachedGridFieldItemAdjacencies[$key];
+        }
+        $currentPage = $paginatorState->getData('currentPage');
+        $itemsPerPage = $paginatorState->getData('itemsPerPage');
         $limit = $itemsPerPage + 2;
-        $limitOffset = max(0, $itemsPerPage * ($currentPage-1) -1);
-
-        return $list->limit($limit, $limitOffset)->column('ID');
+        $limitOffset = max(0, $itemsPerPage * ($currentPage - 1) - 1);
+        $this->cachedGridFieldItemAdjacencies[$key] = $this->getGridField()
+            ->getManipulatedList()
+            ->limit($limit, $limitOffset)
+            ->column('ID');
+        return $this->cachedGridFieldItemAdjacencies[$key];
     }
 
     /**
@@ -736,6 +754,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      */
     public function getPreviousRecordID()
     {
+        $this->resetAdjacenciesCache();
         return $this->getAdjacentRecordID(-1);
     }
 
@@ -746,6 +765,7 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
      */
     public function getNextRecordID()
     {
+        $this->resetAdjacenciesCache();
         return $this->getAdjacentRecordID(1);
     }
 
@@ -1002,5 +1022,13 @@ class GridFieldDetailForm_ItemRequest extends RequestHandler
                 ]);
             }
         ], $this->getToplevelController()->getResponse());
+    }
+
+    /**
+     * Reset the cache used for getGridFieldItemAdjacencies()
+     */
+    private function resetAdjacenciesCache()
+    {
+        $this->cachedGridFieldItemAdjacencies = [];
     }
 }

--- a/tests/php/Forms/GridField/GridFieldDetailForm_ItemRequestTest.php
+++ b/tests/php/Forms/GridField/GridFieldDetailForm_ItemRequestTest.php
@@ -3,7 +3,10 @@
 namespace SilverStripe\Forms\Tests\GridField;
 
 use LogicException;
+use ReflectionMethod;
+use ReflectionProperty;
 use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_Base;
@@ -30,5 +33,40 @@ class GridFieldDetailForm_ItemRequestTest extends SapphireTest
         );
 
         $itemRequest->ItemEditForm();
+    }
+
+    public function testGetGridFieldItemAdjacencies(): void
+    {
+        $list = new ArrayList([
+            new ArrayData(['ID' => 101]),
+            new ArrayData(['ID' => 102]),
+            new ArrayData(['ID' => 103]),
+            new ArrayData(['ID' => 104]),
+            new ArrayData(['ID' => 105]),
+            new ArrayData(['ID' => 106]),
+            new ArrayData(['ID' => 107]),
+            new ArrayData(['ID' => 108]),
+            new ArrayData(['ID' => 109]),
+        ]);
+        $gridField = new GridField('dummy', 'dummy', $list, new GridFieldConfig_Base());
+        $modelClass = ArrayData::class;
+        $gridField->setModelClass($modelClass);
+        $itemRequest = new GridFieldDetailForm_ItemRequest($gridField, new GridFieldDetailForm(), new ArrayData(), new Controller(), '');
+        $request = new HTTPRequest('GET', '/', [
+            'gridState-dummy-0' => '{"GridFieldPaginator":{"currentPage":2,"itemsPerPage":3}}'
+        ]);
+        $itemRequest->setRequest($request);
+        // Assert method
+        $refl = new ReflectionMethod($itemRequest, 'getGridFieldItemAdjacencies');
+        $refl->setAccessible(true);
+        $expectedData = [103, 104, 105, 106, 107];
+        $this->assertSame($expectedData, $refl->invoke($itemRequest));
+        // Assert cache
+        $refl = new ReflectionProperty($itemRequest, 'cachedGridFieldItemAdjacencies');
+        $refl->setAccessible(true);
+        $this->assertSame(
+            ['9cffefcf339420d11129b3220eccf141' => $expectedData],
+            $refl->getValue($itemRequest)
+        );
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11703

This cuts down 10 queries to 2 when viewing a GridField managed record. This functionality being cached relates to the prev/next buttons in the bottom right of the CMS

When viewing a Member record in SecurityAdmin, the following queries each come up 5 times, have been reduced to 1 time each now

SELECT DISTINCT count(DISTINCT "Member"."ID") AS "Count" FROM "Member"
(from GridFieldPaginator::getManipulatedData():137 triggered by $this->getGridField()->getManipulatedList())

SELECT "Member"."ID", "Member"."Surname" AS "_SortColumn0", "Member"."FirstName" AS "_SortColumn1" FROM "Member" ORDER BY "_SortColumn0" ASC, "_SortColumn1" ASC LIMIT 32
(from the follow up call on the manipulated list i.e. ->column('ID'))