### PR TITLE
ENH More efficient hierarchy querying

### DIFF
--- a/src/Forms/TreeDropdownField.php
+++ b/src/Forms/TreeDropdownField.php
@@ -149,11 +149,12 @@ class TreeDropdownField extends FormField implements HasOneRelationFieldInterfac
     protected $baseID = 0;
 
     /**
-     * Default child method in Hierarchy->getChildrenAsUL
+     * Child method to use for Hierarchy->getChildrenAsUL
+     * If null will use config Hierarchy.tree_children_method
      *
      * @var string
      */
-    protected $childrenMethod = 'AllChildrenIncludingDeleted';
+    protected $childrenMethod = null;
 
     /**
      * Default child counting method in Hierarchy->getChildrenAsUL
@@ -392,7 +393,14 @@ class TreeDropdownField extends FormField implements HasOneRelationFieldInterfac
      */
     public function getChildrenMethod()
     {
-        return $this->childrenMethod;
+        if ($this->childrenMethod) {
+            return $this->childrenMethod;
+        }
+        $sourceClass = $this->getSourceObject();
+        /* @var DataObject&Hierarchy $obj */
+        $obj = DataObject::singleton($sourceClass);
+        $baseClass = $obj->getHierarchyBaseClass();
+        return $baseClass::config()->get('tree_children_method');
     }
 
     /**

--- a/src/ORM/Hierarchy/Hierarchy.php
+++ b/src/ORM/Hierarchy/Hierarchy.php
@@ -20,6 +20,7 @@ use SilverStripe\Model\ModelData;
 use SilverStripe\ORM\HiddenClass;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * DataObjects that use the Hierarchy extension can be be organised as a hierarchy, with children and parents. The most
@@ -128,6 +129,28 @@ class Hierarchy extends Extension
      * @var boolean
      */
     private static $prepopulate_numchildren_cache = true;
+
+    /**
+     * The default method called on the Hierarchy class to get children
+     * This can be overriden on classes that use the Hierarchy extension, though it should only be
+     * defined on the base class that has the hierarchy extension applied to it. For instance:
+     * - MyBaseClass has the Hierarchy extension applied
+     * - MySubClass extends MyBaseClass
+     * Only define the tree_children_method on MyBaseClass
+     */
+    private static string $tree_children_method = 'getChildrenForTree';
+
+    /**
+     * Used to cache the children a node has in getChildrenForTree()
+     * @internal
+     */
+    private static array $children_for_tree_ids_cache = [];
+
+    /**
+     * Used to cache child dataobjects in getChildrenForTree()
+     * @internal
+     */
+    private static array $children_for_tree_obj_cache = [];
 
     /**
      * Prevent virtual page virtualising these fields
@@ -338,9 +361,11 @@ class Hierarchy extends Extension
      * - Everything else has "SameOnStage" set, as an indicator that this information has been looked up.
      *
      * @return ArrayList<DataObject&static>
+     * @deprecated 6.0.0 Use getChildrenForTree() instead.
      */
     public function AllChildrenIncludingDeleted()
     {
+        Deprecation::notice('6.0.0', 'Use getChildrenForTree() instead');
         /** @var DataObject|Hierarchy|Versioned $owner */
         $owner = $this->owner;
         $stageChildren = $owner->stageChildren(true);
@@ -358,6 +383,97 @@ class Hierarchy extends Extension
         }
         $owner->extend("augmentAllChildrenIncludingDeleted", $stageChildren);
         return $stageChildren;
+    }
+
+    /**
+     * Return direct children in the hierarchy for creating a tree
+     *
+     * This does much the same result as AllChildrenIncludingDeleted() and is far more performant,
+     * though there are some key differences:
+     * - Results will be cached in-memory to save on the number of database queries required
+     * - Database queries will be larger `WHERE "ID" IN (?, ?) style queries rather than many `WHERE "ID" = ?
+     * - While Hierarchy.node_threshold_total has not been exceeded, it will cache descendant record as
+     *   well to save future queries
+     * - Does not included deleted records, which could be done via Versioned::updateListToAlsoIncludeDeleted($children)
+     */
+    public function getChildrenForTree(): ArrayList
+    {
+        /** @var DataObject&Hierarchy */
+        $owner = $this->getOwner();
+        $parentID = $owner->ID;
+        $baseClass = $owner->getHierarchyBaseClass();
+        Hierarchy::$children_for_tree_ids_cache[$baseClass] ??= [];
+        Hierarchy::$children_for_tree_obj_cache[$baseClass] ??= [];
+        if (!array_key_exists($parentID, Hierarchy::$children_for_tree_obj_cache[$baseClass])) {
+            Hierarchy::$children_for_tree_obj_cache[$baseClass][$parentID] = $owner;
+        }
+        $this->recursivelyCacheDescendantsForTree($baseClass, [$parentID]);
+        $childIDs = [];
+        if (array_key_exists($parentID, Hierarchy::$children_for_tree_ids_cache[$baseClass])) {
+            $childIDs = Hierarchy::$children_for_tree_ids_cache[$baseClass][$parentID];
+        }
+        $childNodes = [];
+        foreach ($childIDs as $childID) {
+            if (array_key_exists($childID, Hierarchy::$children_for_tree_obj_cache[$baseClass])) {
+                $childNodes[] = Hierarchy::$children_for_tree_obj_cache[$baseClass][$childID];
+            }
+        }
+        $children = ArrayList::create($childNodes);
+        $owner->extend('updateGetChildrenForTree', $includeDeleted, $children);
+        return $children;
+    }
+
+    /**
+     * Inner recursive method used by getChildrenForTree()
+     */
+    private function recursivelyCacheDescendantsForTree(string $baseClass, array $parentIDs): void
+    {
+        // Only query records which have not be previously cached
+        $parentIDs = array_filter($parentIDs, function ($parentID) use ($baseClass) {
+            return !array_key_exists($parentID, Hierarchy::$children_for_tree_ids_cache[$baseClass]);
+        });
+        if (empty($parentIDs)) {
+            return;
+        }
+        $config = $this->getOwner()->config();
+        $count = count(Hierarchy::$children_for_tree_obj_cache[$baseClass]);
+        $threshold = $config->get('node_threshold_total');
+        if ($count > $threshold) {
+            return;
+        }
+        $nextIDs = [];
+        // This will use a hierarchical query method where it will initially fetched from the "second level down"
+        // where the ParentID equals the single DataObject at the "top level" of the hierarchy
+        // It will then fetch from the "third level down" in the hierarchy where the ParentID is of the ParentIDs in
+        // the "second level down". In will continue querying like this until the total number of cached objects has
+        // exceeded the configured value `node_threshold_total`, or all object have been fetched
+        /** @var DataList $children */
+        $children = $baseClass::get()->filter(['ParentID' => $parentIDs]);
+        $hideFromHierarchy = $config->get('hide_from_hierarchy');
+        $hideFromCMSTree = $config->get('hide_from_cms_tree');
+        if ($hideFromHierarchy) {
+            $children = $children->exclude(['ClassName' => $hideFromHierarchy]);
+        }
+        if ($hideFromCMSTree && $this->showingCMSTree()) {
+            $children = $children->exclude(['ClassName' => $hideFromCMSTree]);
+        }
+        foreach ($parentIDs as $parentID) {
+            Hierarchy::$children_for_tree_ids_cache[$baseClass][$parentID] = [];
+        }
+        foreach ($children as $child) {
+            $childID = $child->ID;
+            $parentID = $child->ParentID;
+            Hierarchy::$children_for_tree_ids_cache[$baseClass][$parentID][] = $childID;
+            Hierarchy::$children_for_tree_obj_cache[$baseClass][$childID] = $child;
+            if (!array_key_exists($childID, Hierarchy::$children_for_tree_ids_cache[$baseClass])
+                && !in_array($childID, $nextIDs)
+            ) {
+                $nextIDs[] = $childID;
+            }
+        }
+        if (count($nextIDs)) {
+            $this->recursivelyCacheDescendantsForTree($baseClass, $nextIDs);
+        }
     }
 
     /**
@@ -505,6 +621,14 @@ class Hierarchy extends Extension
     }
 
     /**
+     * Whether the internal Hierarchy::$cache_numChildren cache has been populated for $baseClass
+     */
+    public static function numChildrenCacheIsPopulated(string $baseClass): bool
+    {
+        return Hierarchy::$cache_numChildren[$baseClass]['numChildren']['_complete'] ?? false;
+    }
+
+    /**
      * Returns the class name of the default class for children of this page.
      * Note that this is intended for use with CMSMain and may not be respected with other model management methods.
      */
@@ -646,7 +770,7 @@ class Hierarchy extends Extension
      *
      * @return string
      */
-    private function getHierarchyBaseClass(): string
+    public function getHierarchyBaseClass(): string
     {
         $ancestry = ClassInfo::ancestry($this->owner);
         $ancestorClass = array_shift($ancestry);

--- a/src/ORM/Hierarchy/MarkedSet.php
+++ b/src/ORM/Hierarchy/MarkedSet.php
@@ -11,6 +11,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Model\List\SS_List;
 use SilverStripe\Model\ArrayData;
+use SilverStripe\ORM\Hierarchy\Hierarchy;
 
 /**
  * Contains a set of hierarchical objects generated from a marking compilation run.
@@ -47,12 +48,12 @@ class MarkedSet
     public $markingFilter;
 
     /**
-     * @var DataObject
+     * @var DataObject&Hierarchy
      */
     protected $rootNode = null;
 
     /**
-     * Method to use for getting children. Defaults to 'AllChildrenIncludingDeleted'
+     * Method to use for getting children. Defaults to Hierarchy.tree_children_method config
      *
      * @var string
      */
@@ -180,7 +181,11 @@ class MarkedSet
      */
     public function getChildrenMethod()
     {
-        return $this->childrenMethod ?: 'AllChildrenIncludingDeleted';
+        if ($this->childrenMethod) {
+            return $this->childrenMethod;
+        }
+        $baseClass = $this->rootNode->getHierarchyBaseClass();
+        return $baseClass::config()->get('tree_children_method');
     }
 
     /**
@@ -453,9 +458,18 @@ class MarkedSet
         $nodeCountThreshold = $this->getNodeCountThreshold();
 
         // Add root node, not-expanded by default
+        /** @var DataObject&Hierarchy $rootNode */
         $rootNode = $this->rootNode;
         $this->clearMarks();
         $this->markUnexpanded($rootNode);
+
+        $baseClass = $rootNode->getHierarchyBaseClass();
+        if (!Hierarchy::numChildrenCacheIsPopulated($baseClass)) {
+            $rootNode->prepopulateTreeDataCache(null, [
+                'childrenMethod' => $this->getChildrenMethod(),
+                'numChildMethod' => $this->getNumChildrenMethod(),
+            ]);
+        }
 
         // Build markedNodes for this subtree until we reach the threshold
         // foreach can't handle an ever-growing $nodes list

--- a/tests/php/Forms/TreeDropdownFieldTest.php
+++ b/tests/php/Forms/TreeDropdownFieldTest.php
@@ -16,6 +16,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Tests\HierarchyTest\HierarchyOnSubclassTestObject;
 use SilverStripe\ORM\Tests\HierarchyTest\HierarchyOnSubclassTestSubObject;
 use SilverStripe\ORM\Tests\HierarchyTest\TestObject;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TreeDropdownFieldTest extends SapphireTest
 {
@@ -422,5 +423,41 @@ class TreeDropdownFieldTest extends SapphireTest
         $json = json_decode($tree);
         $children2After = count($json->children);
         $this->assertEquals($children2After, 8, 'StartsWith search for child has 8 results in fixture (excludes grandchild)');
+    }
+
+    public static function provideGetChildrenMethod(): array
+    {
+        return [
+            'set-method' => [
+                'childrenMethod' => true,
+                'baseClassConfig' => true,
+                'expected' => 'mySetMethod',
+            ],
+            'base-class-config' => [
+                'childrenMethod' => false,
+                'baseClassConfig' => true,
+                'expected' => 'myBaseClassMethod',
+            ],
+            'extension-config' => [
+                'childrenMethod' => false,
+                'baseClassConfig' => false,
+                'expected' => 'getChildrenForTree',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetChildrenMethod')]
+    public function testGetChildrenMethod(bool $childrenMethod, bool $baseClassConfig, string $expected): void
+    {
+        $baseClass = TestObject::class;
+        $field = new TreeDropdownField('Test', sourceObject: $baseClass);
+        if ($childrenMethod) {
+            $field->setChildrenMethod('mySetMethod');
+        }
+        if ($baseClassConfig) {
+            $baseClass::config()->set('tree_children_method', 'myBaseClassMethod');
+        }
+        $actual = $field->getChildrenMethod();
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/php/ORM/HierarchyTest.php
+++ b/tests/php/ORM/HierarchyTest.php
@@ -4,6 +4,7 @@ namespace SilverStripe\ORM\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
+use ReflectionProperty;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Validation\ValidationException;
 use SilverStripe\Versioned\Versioned;
@@ -18,6 +19,7 @@ class HierarchyTest extends SapphireTest
 
     protected static $extra_dataobjects = [
         HierarchyTest\TestObject::class,
+        HierarchyTest\TestObjectHideFromHierarchy::class,
         HierarchyTest\HideTestObject::class,
         HierarchyTest\HideTestSubObject::class,
         HierarchyTest\HierarchyOnSubclassTestObject::class,
@@ -51,6 +53,15 @@ class HierarchyTest extends SapphireTest
         if (!class_exists(Versioned::class)) {
             $this->markTestSkipped('HierarchyTest requires the Versioned extension');
         }
+    }
+
+    protected function tearDown(): void
+    {
+        $reflA = new ReflectionProperty(Hierarchy::class, 'children_for_tree_ids_cache');
+        $reflB = new ReflectionProperty(Hierarchy::class, 'children_for_tree_obj_cache');
+        $reflA->setValue(null, []);
+        $reflB->setValue(null, []);
+        parent::tearDown();
     }
 
     /**
@@ -112,12 +123,12 @@ class HierarchyTest extends SapphireTest
 
         // Check that all obj 3 children are returned
         $this->assertEquals(
-            ["Obj 3a", "Obj 3b", "Obj 3c", "Obj 3d"],
+            ["Obj 3a", "Obj 3b", "Obj 3c", "Obj 3d", "Obj 3HfH1"],
             $obj3->AllHistoricalChildren()->column('Title')
         );
 
         // Check numHistoricalChildren
-        $this->assertEquals(4, $obj3->numHistoricalChildren());
+        $this->assertEquals(5, $obj3->numHistoricalChildren());
     }
 
     public function testNumChildren()
@@ -139,7 +150,7 @@ class HierarchyTest extends SapphireTest
 
         $this->assertEquals(0, $obj1->numChildren());
         $this->assertEquals(2, $obj2->numChildren());
-        $this->assertEquals(4, $obj3->numChildren());
+        $this->assertEquals(5, $obj3->numChildren());
         $this->assertEquals(2, $obj2a->numChildren());
         $this->assertEquals(0, $obj2b->numChildren());
         $this->assertEquals(2, $obj3a->numChildren());
@@ -700,5 +711,156 @@ class HierarchyTest extends SapphireTest
         $group = new Group();
         $group->Title = '<b>My group</b>';
         $this->assertSame('<i>&lt;b&gt;My group&lt;/b&gt;</i>', $group->getTreeTitle());
+    }
+
+    public static function provideGetChildrenForTree(): array
+    {
+        return [
+            'threshold-1' => [
+                'threshold' => 1,
+                'hide' => true,
+                'expected' => [
+                    'Obj 3' => [
+                        'Obj 3a',
+                        'Obj 3b',
+                        'Obj 3c',
+                        'Obj 3d',
+                    ],
+                ]
+            ],
+            'threshold-4' => [
+                'threshold' => 4,
+                'hide' => true,
+                'expected' => [
+                    'Obj 3' => [
+                        'Obj 3a',
+                        'Obj 3b',
+                        'Obj 3c',
+                        'Obj 3d',
+                    ],
+                ]
+            ],
+            'threshold-5' => [
+                'threshold' => 5,
+                'hide' => true,
+                'expected' => [
+                    'Obj 3' => [
+                        'Obj 3a',
+                        'Obj 3b',
+                        'Obj 3c',
+                        'Obj 3d',
+                    ],
+                    'Obj 3a' => [
+                        'Obj 3aa',
+                        'Obj 3ab',
+                    ],
+                    'Obj 3b' => [
+                        'Obj 3ba',
+                        'Obj 3bb',
+                    ],
+                    'Obj 3c' => [
+                        'Obj 3ca'
+                    ],
+                    'Obj 3d' => [],
+                ]
+            ],
+            'threshold-6' => [
+                'threshold' => 6,
+                'hide' => true,
+                'expected' => [
+                    'Obj 3' => [
+                        'Obj 3a',
+                        'Obj 3b',
+                        'Obj 3c',
+                        'Obj 3d',
+                    ],
+                    'Obj 3a' => [
+                        'Obj 3aa',
+                        'Obj 3ab',
+                    ],
+                    'Obj 3b' => [
+                        'Obj 3ba',
+                        'Obj 3bb',
+                    ],
+                    'Obj 3c' => [
+                        'Obj 3ca'
+                    ],
+                    'Obj 3d' => [],
+                ]
+            ],
+            'threshold-50' => [
+                'threshold' => 50,
+                'hide' => true,
+                'expected' => [
+                    'Obj 3' => [
+                        'Obj 3a',
+                        'Obj 3b',
+                        'Obj 3c',
+                        'Obj 3d',
+                    ],
+                    'Obj 3a' => [
+                        'Obj 3aa',
+                        'Obj 3ab',
+                    ],
+                    'Obj 3b' => [
+                        'Obj 3ba',
+                        'Obj 3bb',
+                    ],
+                    'Obj 3c' => [
+                        'Obj 3ca'
+                    ],
+                    'Obj 3d' => [],
+                    'Obj 3aa' => [],
+                    'Obj 3ab' => [],
+                    'Obj 3ba' => [],
+                    'Obj 3bb' => [],
+                    'Obj 3ca' => [],
+                ]
+            ],
+            'show-hidden' => [
+                'threshold' => 5,
+                'hide' => false,
+                'expected' => [
+                    'Obj 3' => [
+                        'Obj 3a',
+                        'Obj 3b',
+                        'Obj 3c',
+                        'Obj 3d',
+                        'Obj 3HfH1',
+                    ],
+                ]
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetChildrenForTree')]
+    public function testGetChildrenForTree(int $threshold, bool $hide, array $expected): void
+    {
+        HierarchyTest\TestObject::config()->set('node_threshold_total', $threshold);
+        if ($hide) {
+            // Hierarchy::showingCMSTree() will always return false in this test, so
+            // hide_from_cms_tree is not tested
+            HierarchyTest\TestObject::config()->merge(
+                'hide_from_hierarchy',
+                [HierarchyTest\TestObjectHideFromHierarchy::class]
+            );
+        }
+        $dataClass = HierarchyTest\TestObject::class;
+        $obj3 = $this->objFromFixture($dataClass, 'obj3');
+        $children = $obj3->getChildrenForTree();
+        $this->assertSame($expected['Obj 3'], $children->column('Title'));
+        $reflA = new ReflectionProperty(Hierarchy::class, 'children_for_tree_ids_cache');
+        $reflB = new ReflectionProperty(Hierarchy::class, 'children_for_tree_obj_cache');
+        $cacheA = $reflA->getValue(null);
+        $cacheB = $reflB->getValue(null);
+        $actual = [];
+        foreach ($cacheA[$dataClass] as $id => $childIDs) {
+            $title = $cacheB[$dataClass][$id]->Title;
+            $actual[$title] = [];
+            foreach ($childIDs as $childID) {
+                $actual[$title][] = $cacheB[$dataClass][$childID]->Title;
+            }
+        }
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/php/ORM/HierarchyTest.yml
+++ b/tests/php/ORM/HierarchyTest.yml
@@ -43,7 +43,11 @@ SilverStripe\ORM\Tests\HierarchyTest\TestObject:
     Title: Obj 3bb
   obj3ca:
     Parent: =>SilverStripe\ORM\Tests\HierarchyTest\TestObject.obj3c
-    Title: Obj 3c
+    Title: Obj 3ca
+SilverStripe\ORM\Tests\HierarchyTest\TestObjectHideFromHierarchy:
+  obj3HfH1:
+    Parent: =>SilverStripe\ORM\Tests\HierarchyTest\TestObject.obj3
+    Title: Obj 3HfH1
 SilverStripe\ORM\Tests\HierarchyTest\HideTestObject:
   obj4:
     Title: Obj 4

--- a/tests/php/ORM/HierarchyTest/TestObjectHideFromHierarchy.php.php
+++ b/tests/php/ORM/HierarchyTest/TestObjectHideFromHierarchy.php.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SilverStripe\ORM\Tests\HierarchyTest;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\Hierarchy\Hierarchy;
+use SilverStripe\Versioned\Versioned;
+
+class TestObjectHideFromHierarchy extends TestObject implements TestOnly
+{
+    private static $table_name = 'HierarchyTest_ObjectHideFromHierarchy';
+}

--- a/tests/php/ORM/MarkedSetTest.php
+++ b/tests/php/ORM/MarkedSetTest.php
@@ -8,6 +8,7 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Hierarchy\MarkedSet;
 use SilverStripe\Versioned\Versioned;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Test set of marked Hierarchy-extended DataObjects
@@ -18,6 +19,8 @@ class MarkedSetTest extends SapphireTest
 
     protected static $extra_dataobjects = [
         HierarchyTest\TestObject::class,
+        HierarchyTest\HierarchyOnSubclassTestObject::class,
+        HierarchyTest\HierarchyOnSubclassTestSubObject::class,
         HierarchyTest\HideTestObject::class,
         HierarchyTest\HideTestSubObject::class,
     ];
@@ -105,11 +108,13 @@ class MarkedSetTest extends SapphireTest
     </li>
     <li>Obj 3c
         <ul>
-            <li>Obj 3c
+            <li>Obj 3ca
             </li>
         </ul>
     </li>
     <li>Obj 3d
+    </li>
+    <li>Obj 3HfH1
     </li>
 </ul>
 
@@ -437,5 +442,42 @@ EOT;
         $expected = implode("\n", array_filter(array_map('trim', explode("\n", $expected ?? ''))));
         $actual = implode("\n", array_filter(array_map('trim', explode("\n", $actual ?? ''))));
         $this->assertXmlStringEqualsXmlString($expected, $actual, $message);
+    }
+
+    public static function provideGetChildrenMethod(): array
+    {
+        return [
+            'set-method' => [
+                'childrenMethod' => true,
+                'baseClassConfig' => true,
+                'expected' => 'getUniqueKey',
+            ],
+            'base-class-config' => [
+                'childrenMethod' => false,
+                'baseClassConfig' => true,
+                'expected' => 'myBaseClassMethod',
+            ],
+            'extension-config' => [
+                'childrenMethod' => false,
+                'baseClassConfig' => false,
+                'expected' => 'getChildrenForTree',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetChildrenMethod')]
+    public function testGetChildrenMethod(bool $childrenMethod, bool $baseClassConfig, string $expected): void
+    {
+        $baseClass = HierarchyTest\TestObject::class;
+        $markedSet = new MarkedSet($baseClass::singleton());
+        if ($childrenMethod) {
+            // This needs to be a method that actually exists, it's just a random method from DataObject
+            $markedSet->setChildrenMethod('getUniqueKey');
+        }
+        if ($baseClassConfig) {
+            $baseClass::config()->set('tree_children_method', 'myBaseClassMethod');
+        }
+        $actual = $markedSet->getChildrenMethod();
+        $this->assertSame($expected, $actual);
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11703

Required for https://github.com/silverstripe/silverstripe-cms/pull/3077

This will greatly reduce the number of queries when viewing the site tree 

With 16006 pages testing on silverstripe/installer with https://github.com/emteknetnz/silverstripe-db-query-counter and https://github.com/emteknetnz/silverstripe-data-generator (and the silverstripe/cms PR)

I've pointed out the individual queries with the biggest reductions

Note that the before and after were both counted with https://github.com/silverstripe/silverstripe-cms/pull/3077/files#r2078854671 implemented, including on the "before" tests, so that queries from the redundant XHR request to /tree were not included

I ran flush before logging to ensure that caches were clear

**/admin/pages:**

**_Before_**
Total queries: 46

`Count: 12 - Query: SELECT DISTINCT "SiteTree"."ClassName", "SiteTree"."LastEdited" ... FROM "SiteTree" WHERE ("SiteTree"."ParentID" <> "SiteTree"."ID") AND ("SiteTree"."ParentID" = ?) ORDER BY "SiteTree"."Sort" ASC`
+
`Count: 12 - Query: SELECT DISTINCT "SiteTree_Live"."ClassName", "SiteTree_Live"."LastEdited"... WHERE ("SiteTree_Live"."ParentID" = ?) AND (("SiteTree_Live"."ID" != ? OR "SiteTree_Live"."ID" IS NULL)) AND ("SiteTree_Live"."ID" NOT IN (SELECT "ID" FROM "SiteTree")) ORDER BY "SiteTree_Live"."Sort" ASC FROM "SiteTree")) ORDER BY "SiteTree_Live"."Sort" ASC`

**_After:_**
Total queries: 24

`Count: 1 - Query: SELECT DISTINCT "SiteTree"."ClassName", "SiteTree"."LastEdited"... FROM "SiteTree" WHERE ("SiteTree"."ParentID" IN (0)) ORDER BY "SiteTree"."Sort" ASC`
+
`Count: 1 - Query: SELECT DISTINCT "SiteTree"."ClassName", "SiteTree"."LastEdited"... FROM "SiteTree" WHERE ("SiteTree"."ParentID" IN (7, 4112, 8217, 12322, 828, 4933, 9038, 13143, 1649, 5754, 9859, 13964, 2470, 6575, 10680, 14785, 3291, 7396, 11501, 15606, 1, 2, 3, 4, 5, 6)) ORDER BY "SiteTree"."Sort" ASC`

**/pages/edit/show/9 - page that is 3 levels deep**

The difference is much more pronounced for nested pages

**_Before_**
Total queries: 386

`Count: 95 - Query: SELECT DISTINCT "SiteTree"."ClassName", "SiteTree"."LastEdited"... FROM "SiteTree" WHERE ("SiteTree"."ParentID" <> "SiteTree"."ID") AND ("SiteTree"."ParentID" = ?) ORDER BY "SiteTree"."Sort" ASC`
+
`Count: 95 - Query: SELECT DISTINCT "SiteTree_Live"."ClassName", "SiteTree_Live"."LastEdited"... FROM "SiteTree_Live" WHERE ("SiteTree_Live"."ParentID" = ?) AND (("SiteTree_Live"."ID" != ? OR "SiteTree_Live"."ID" IS NULL)) AND ("SiteTree_Live"."ID" NOT IN (SELECT "ID" FROM "SiteTree")) ORDER BY "SiteTree_Live"."Sort" ASC`

**_After:_**
Total queries: 150

`Count: 1 - Query: SELECT DISTINCT "SiteTree"."ClassName", "SiteTree"."LastEdited"... FROM "SiteTree" WHERE ("SiteTree"."ParentID" IN (0)) ORDER BY "SiteTree"."Sort" ASC`
+
`Count: 1 - Query: SELECT DISTINCT "SiteTree"."ClassName", "SiteTree"."LastEdited"... FROM "SiteTree" WHERE ("SiteTree"."ParentID" IN (7, 4112, 8217, 12322, 828, 4933, 9038, 13143, 1649, 5754, 9859, 13964, 2470, 6575, 10680, 14785, 3291, 7396, 11501, 15606, 1, 2, 3, 4, 5, 6)) ORDER BY "SiteTree"."Sort" ASC`