### PR TITLE
DOC Clarify inline comment

### DIFF
--- a/src/Dev/Deprecation.php
+++ b/src/Dev/Deprecation.php
@@ -379,8 +379,8 @@ class Deprecation
         try {
             $data = null;
             if ($scope === Deprecation::SCOPE_CONFIG) {
-                // Deprecated config set via yaml will only be shown in the browser when using ?flush=1
-                // It will not show in CLI when running dev/build flush=1
+                // Deprecated config set via yaml will only be shown in the CLI when using flush=1
+                // It will not show in the browser with ?flush=1
                 $data = [
                     'key' => sha1($string),
                     'message' => $string,


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11699

When deprecations are enabled via .env file, deprecated config only seems to show in CLI rather than via HTTP, regardless if monolog logging is setup or not

```php
// app/src/Page.php
use SilverStripe\CMS\Model\SiteTree;

class Page extends SiteTree
{
    /**
     * @deprecated 1.2.3 Lorem ipsum
     */
    private static $my_depr_config = 'abc';

    public function requireDefaultRecords()
    {
        static::config()->get('my_depr_config');
    }
}
```

```yml
---
Name: mylogging
---
SilverStripe\Core\Injector\Injector:
  Psr\Log\LoggerInterface:
    calls:
      LogFileHandler: [ pushHandler, [ '%$LogFileHandler' ] ]
  LogFileHandler:
    class: Monolog\Handler\StreamHandler
    constructor:
      - "/var/www/silverstripe.log"
      - "info"
```