### PR TITLE
DOC Update the Query class doc to match the modern implementation.

### DIFF
--- a/src/ORM/Connect/Query.php
+++ b/src/ORM/Connect/Query.php
@@ -3,12 +3,18 @@
 namespace SilverStripe\ORM\Connect;
 
 use SilverStripe\Core\Convert;
-use Iterator;
 use Traversable;
 
 /**
- * Abstract query-result class. A query result provides an iterator that returns a map for each record of a query
- * result.
+ * Abstract query-result class. A query result is an iterable that returns a map for each record of a
+ * query result.
+ *
+ * This should be subclassed by an actual database implementation. It will only
+ * ever be constructed by a subclass of Database. The result of a database query - an iterable object
+ * that's returned by by various low-level ORM methods.
+ *
+ * Primarily, the Query class takes care of the iterator plumbing, letting the subclasses focusing
+ * on providing the specific data-access methods that are required.
  *
  * The map should be keyed by the column names, and the values should use the following types:
  *
@@ -18,15 +24,8 @@ use Traversable;
  *  - strings returned as strings
  *  - dates / datetimes returned as strings
  *
- * Note that until SilverStripe 4.3, bugs meant that strings were used for every column type.
- *
- * Once again, this should be subclassed by an actual database implementation.  It will only
- * ever be constructed by a subclass of SS_Database.  The result of a database query - an iteratable object
- * that's returned by DB::SS_Query
- *
- * Primarily, the Query class takes care of the iterator plumbing, letting the subclasses focusing
- * on providing the specific data-access methods that are required: {@link nextRecord()}, {@link numRecords()}
- * and {@link seek()}
+ * @see PostgreSQLQuery class on the silverstripe/postgresql module for an example of how to implement this
+ * class on a non-MySQL database.
  */
 abstract class Query implements \IteratorAggregate
 {


### PR DESCRIPTION
## Description
Refresh the PHPDoc for the Query class

## Issues
- https://github.com/silverstripe/silverstripe-framework/issues/11732

## Pull request checklist
- [x] The target branch is correct
#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
