### PR TITLE
FIX Provide a clear way to flush tests with phpunit 11

### DIFF
--- a/src/Core/Flushable.php
+++ b/src/Core/Flushable.php
@@ -4,7 +4,7 @@ namespace SilverStripe\Core;
 
 /**
  * Provides an interface for classes to implement their own flushing functionality
- * whenever flush=1 is requested.
+ * whenever a flush is requested in the kernel.
  */
 interface Flushable
 {

--- a/src/Dev/SapphireTest.php
+++ b/src/Dev/SapphireTest.php
@@ -46,6 +46,7 @@ use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mailer\Transport\NullTransport;
 use ReflectionMethod;
 use ReflectionClass;
+use SilverStripe\Core\Environment;
 use SilverStripe\Dev\Exceptions\ExpectedErrorException;
 use SilverStripe\Dev\Exceptions\ExpectedNoticeException;
 use SilverStripe\Dev\Exceptions\ExpectedWarningException;
@@ -566,7 +567,7 @@ abstract class SapphireTest extends TestCase implements TestOnly
         $filename = ClassLoader::inst()->getItemPath(static::class);
         if (!$filename) {
             throw new LogicException('getItemPath returned null for ' . static::class
-                . '. Try adding flush=1 to the test run.');
+                . '. Try setting the SS_PHPUNIT_FLUSH=1 environment variable.');
         }
         return dirname($filename ?? '');
     }
@@ -946,7 +947,7 @@ abstract class SapphireTest extends TestCase implements TestOnly
             $request = CLIRequestBuilder::createFromEnvironment();
 
             $app = new HTTPApplication($kernel);
-            $flush = array_key_exists('flush', $request->getVars() ?? []);
+            $flush = Environment::getEnv('SS_PHPUNIT_FLUSH') || array_key_exists('flush', $request->getVars() ?? []);
 
             // Custom application
             $res = $app->execute($request, function (HTTPRequest $request) {
@@ -969,10 +970,12 @@ abstract class SapphireTest extends TestCase implements TestOnly
             }
         } else {
             // Allow flush from the command line in the absence of HTTPApplication's special sauce
-            $flush = false;
-            foreach ($_SERVER['argv'] as $arg) {
-                if (preg_match('/^(--)?flush(=1)?$/', $arg ?? '')) {
-                    $flush = true;
+            $flush = Environment::getEnv('SS_PHPUNIT_FLUSH');
+            if (!$flush) {
+                foreach ($_SERVER['argv'] as $arg) {
+                    if (preg_match('/^(--)?flush(=1)?$/', $arg ?? '')) {
+                        $flush = true;
+                    }
                 }
             }
             $kernel->boot($flush);

--- a/src/Dev/State/FixtureTestState.php
+++ b/src/Dev/State/FixtureTestState.php
@@ -219,7 +219,7 @@ class FixtureTestState implements TestState
         $filename = ClassLoader::inst()->getItemPath($class);
         if (!$filename) {
             throw new LogicException('getItemPath returned null for ' . $class
-                . '. Try adding flush=1 to the test run.');
+                . '. Try setting the SS_PHPUNIT_FLUSH=1 environment variable.');
         }
         return dirname($filename ?? '');
     }

--- a/tests/bootstrap/cli.php
+++ b/tests/bootstrap/cli.php
@@ -26,6 +26,7 @@ $frameworkPath = dirname(dirname(__FILE__));
 $frameworkDir = basename($frameworkPath ?? '');
 
 // Copied from cli-script.php, to enable same behaviour through phpunit runner.
+// This is all legacy and should be removed in a future major release.
 if (isset($_SERVER['argv'][2])) {
     $args = array_slice($_SERVER['argv'] ?? [], 2);
     if (!isset($_GET)) {


### PR DESCRIPTION
The old way relied on an implementation detail of phpunit ignoring subsequent CLI arguments. This is more robust both now and for whatever changes PHPUnit makes in the future.

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11731