### PR TITLE
FIX Don't search against non-general fields in gridfield

### DIFF
--- a/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
+++ b/src/Forms/GridField/GridFieldAddExistingAutocompleter.php
@@ -375,30 +375,37 @@ class GridFieldAddExistingAutocompleter extends AbstractGridFieldComponent imple
         if ($fieldSpecs = $obj->searchableFields()) {
             $customSearchableFields = $obj->config()->get('searchable_fields');
             foreach ($fieldSpecs as $name => $spec) {
-                if (is_array($spec) && array_key_exists('filter', $spec ?? [])) {
-                    // The searchableFields() spec defaults to PartialMatch,
-                    // so we need to check the original setting.
-                    // If the field is defined $searchable_fields = array('MyField'),
-                    // then default to StartsWith filter, which makes more sense in this context.
-                    if (!$customSearchableFields || array_search($name, $customSearchableFields ?? []) !== false) {
-                        $filter = 'StartsWith';
-                    } else {
-                        $filterName = $spec['filter'];
-                        // It can be an instance
-                        if ($filterName instanceof SearchFilter) {
-                            $filterName = get_class($filterName);
-                        }
-                        // It can be a fully qualified class name
-                        if (strpos($filterName ?? '', '\\') !== false) {
-                            $filterNameParts = explode("\\", $filterName ?? '');
-                            // We expect an alias matching the class name without namespace, see #coresearchaliases
-                            $filterName = array_pop($filterNameParts);
-                        }
-                        $filter = preg_replace('/Filter$/', '', $filterName ?? '');
+                if (is_array($spec)) {
+                    // Skip fields that shouldn't be used in a general search
+                    if (array_key_exists('general', $spec) && !$spec['general']) {
+                        continue;
                     }
-                    $fields[] = "{$name}:{$filter}";
-                } else {
-                    $fields[] = $name;
+                    // Set an appropriate filter
+                    if (array_key_exists('filter', $spec)) {
+                        // The searchableFields() spec defaults to PartialMatch,
+                        // so we need to check the original setting.
+                        // If the field is defined $searchable_fields = array('MyField'),
+                        // then default to StartsWith filter, which makes more sense in this context.
+                        if (!$customSearchableFields || array_search($name, $customSearchableFields ?? []) !== false) {
+                            $filter = 'StartsWith';
+                        } else {
+                            $filterName = $spec['filter'];
+                            // It can be an instance
+                            if ($filterName instanceof SearchFilter) {
+                                $filterName = get_class($filterName);
+                            }
+                            // It can be a fully qualified class name
+                            if (strpos($filterName ?? '', '\\') !== false) {
+                                $filterNameParts = explode("\\", $filterName ?? '');
+                                // We expect an alias matching the class name without namespace, see #coresearchaliases
+                                $filterName = array_pop($filterNameParts);
+                            }
+                            $filter = preg_replace('/Filter$/', '', $filterName ?? '');
+                        }
+                        $fields[] = "{$name}:{$filter}";
+                    } else {
+                        $fields[] = $name;
+                    }
                 }
             }
         }

--- a/tests/php/Forms/GridField/GridFieldTest/Stadium.php
+++ b/tests/php/Forms/GridField/GridFieldTest/Stadium.php
@@ -14,7 +14,8 @@ class Stadium extends DataObject implements TestOnly
         'Name' => 'Varchar',
         'City' => 'Varchar',
         'Country' => 'Varchar',
-        'Type' => 'Varchar'
+        'Type' => 'Varchar',
+        'IgnoreMe' => 'Varchar',
     ];
 
     private static $searchable_fields = [
@@ -24,6 +25,9 @@ class Stadium extends DataObject implements TestOnly
         ],
         'Country' => [
             'filter' => 'ExactMatchFilter'
+        ],
+        'IgnoreMe' => [
+            'general' => false,
         ],
     ];
 


### PR DESCRIPTION
The `GridFieldAddExistingAutocompleter` only allows searching by a search term, and currently does so against all fields in the searchable fields configuration, even if they're explicitly configured to not be used in a general single-field search.

This should probably have been done as part of https://github.com/silverstripe/silverstripe-framework/pull/10382 and is arguably a fix that could be done in `5.4` - but since it's not actually causing problems there I'd prefer to keep this targetting `6.0` where it is causing problems. This reduces the chance of unexpected regressions in 5.4 if we did target there.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11739