### PR TITLE
ENH Prepopulate version number cache for GridField canView checks

### DIFF
--- a/src/Forms/GridField/GridField.php
+++ b/src/Forms/GridField/GridField.php
@@ -688,6 +688,12 @@ class GridField extends FormField
         if ($total > 0) {
             $rows = [];
 
+            if (is_a($list, DataList::class)) {
+                // This will call Versioned::prepopulateVersionNumberCache() which reduces
+                // the number of database requests needed to do the canView() checks below
+                $list->prepopulateCaches();
+            }
+
             foreach ($list as $index => $record) {
                 if ($record->hasMethod('canView') && !$record->canView()) {
                     continue;


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/11743

When using frameworktest on /admin/test, removes 60 queries

```
Count: 30 - Query: SELECT "Version" FROM "Company_Live" WHERE "ID" = ?

Count: 30 - Query: SELECT "Version" FROM "Company" WHERE "ID" = ?
```

Replaces with

```
Count: 1 - Query: SELECT "ID", "Version" FROM "Company" WHERE "ID" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30)

Count: 1 - Query: SELECT "ID", "Version" FROM "Company_Live" WHERE "ID" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30)
```