### PR TITLE
ENH Allow disabling/dropping indexes via config

### DIFF
--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -351,8 +351,9 @@ abstract class DBSchemaManager
      * @param array $indexSchema A list of indexes to create. See {@link requireIndex()}
      * The values of the array can be one of:
      *   - true: Create a single column index on the field named the same as the index.
-     *   - ['fields' => ['A','B','C'], 'type' => 'index/unique/fulltext']: This gives you full
+     *   - ['columns' => ['A','B','C'], 'type' => 'index/unique/fulltext']: This gives you full
      *     control over the index.
+     *   - false to drop the index
      * @param boolean $hasAutoIncPK A flag indicating that the primary key on this table is an autoincrement type
      * @param array $options Create table options (ENGINE, etc.)
      * @param array|bool $extensions List of extensions
@@ -431,7 +432,11 @@ abstract class DBSchemaManager
         // Create custom indexes
         if ($indexSchema) {
             foreach ($indexSchema as $indexName => $indexSpec) {
-                $this->requireIndex($table, $indexName, $indexSpec);
+                if ($indexSpec === false) {
+                    $this->dontRequireIndex($table, $indexName);
+                } else {
+                    $this->requireIndex($table, $indexName, $indexSpec);
+                }
             }
         }
 
@@ -525,6 +530,28 @@ abstract class DBSchemaManager
             $this->alterationMessage(
                 "Index $table.$index: changed to $specString <i class=\"build-info-before\">(from $oldSpecString)</i>",
                 "changed"
+            );
+        }
+    }
+
+    public function dontRequireIndex(string $table, string $index): void
+    {
+        // Skip if this is a new table, since it just won't have that index
+        $newTable = !isset($this->tableList[strtolower($table)]);
+        if ($newTable) {
+            return;
+        }
+
+        $indexKey = $this->indexKey($table, $index, []);
+        $indexList = $this->indexList($table);
+        // Drop the index if it exists
+        if (isset($indexList[$indexKey])) {
+            $oldSpec = $indexList[$indexKey];
+            $oldSpecString = $this->convertIndexSpec($oldSpec);
+            $this->transAlterIndex($table, $index, ['drop' => true]);
+            $this->alterationMessage(
+                "Index $table.$index: dropped <i class=\"build-info-before\">(from $oldSpecString)</i>",
+                "deleted"
             );
         }
     }

--- a/src/ORM/Connect/MySQLSchemaManager.php
+++ b/src/ORM/Connect/MySQLSchemaManager.php
@@ -93,7 +93,9 @@ class MySQLSchemaManager extends DBSchemaManager
         if ($alteredIndexes) {
             foreach ($alteredIndexes as $k => $v) {
                 $alterList[] = "DROP INDEX \"$k\"";
-                $alterList[] = "ADD " . $this->getIndexSqlDefinition($k, $v);
+                if (!array_key_exists('drop', $v) || !$v['drop']) {
+                    $alterList[] = "ADD " . $this->getIndexSqlDefinition($k, $v);
+                }
             }
         }
 

--- a/src/ORM/DB.php
+++ b/src/ORM/DB.php
@@ -676,8 +676,9 @@ class DB
      * @param string $indexSchema A list of indexes to create.  The keys of the array are the names of the index.
      * The values of the array can be one of:
      *   - true: Create a single column index on the field named the same as the index.
-     *   - array('fields' => array('A','B','C'), 'type' => 'index/unique/fulltext'): This gives you full
+     *   - ['columns' => ['A','B','C'], 'type' => 'index/unique/fulltext']: This gives you full
      *     control over the index.
+     *   - false to drop the index
      * @param boolean $hasAutoIncPK A flag indicating that the primary key on this table is an autoincrement type
      * @param string $options SQL statement to append to the CREATE TABLE call.
      * @param array $extensions List of extensions

--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -629,7 +629,7 @@ class DataObjectSchema
                         var_export($indexSpec['columns'], true)
                     ));
                 }
-            } else {
+            } elseif ($indexSpec !== false) {
                 $indexSpec = [
                     'type' => 'index',
                     'columns' => [$indexName],

--- a/src/ORM/Filters/FulltextFilter.php
+++ b/src/ORM/Filters/FulltextFilter.php
@@ -62,9 +62,10 @@ class FulltextFilter extends SearchFilter
     */
     public function getDbName()
     {
+        $name = $this->getName();
         $indexes = DataObject::getSchema()->databaseIndexes($this->model);
-        if (array_key_exists($this->getName(), $indexes ?? [])) {
-            $index = $indexes[$this->getName()];
+        if (array_key_exists($name, $indexes) && $indexes[$name] !== false) {
+            $index = $indexes[$name];
         } else {
             return parent::getDbName();
         }
@@ -73,7 +74,7 @@ class FulltextFilter extends SearchFilter
         } else {
             throw new Exception(sprintf(
                 "Invalid fulltext index format for '%s' on '%s'",
-                var_export($this->getName(), true),
+                var_export($name, true),
                 var_export($this->model, true)
             ));
         }

--- a/tests/php/ORM/DataObjectSchemaGenerationTest.php
+++ b/tests/php/ORM/DataObjectSchemaGenerationTest.php
@@ -188,6 +188,23 @@ class DataObjectSchemaGenerationTest extends SapphireTest
         );
     }
 
+    public function testIndexGetsDropped(): void
+    {
+        $table = DataObject::getSchema()->tableName(TestIndexObject::class);
+        $schema = DB::get_schema();
+        DB::quiet();
+        $originalIndexes = $schema->indexList($table);
+        $this->assertArrayHasKey('SearchFields', $originalIndexes);
+
+        TestIndexObject::config()->merge('indexes', ['SearchFields' => false]);
+        $schema->schemaUpdate(function () {
+            $obj = new TestIndexObject();
+            $obj->requireTable();
+        });
+        $currentIndexes = $schema->indexList($table);
+        $this->assertArrayNotHasKey('SearchFields', $currentIndexes);
+    }
+
     /**
      * Tests the generation of the ClassName spec and ensure it's not unnecessarily influenced
      * by the order of classnames of existing records

--- a/tests/php/ORM/DataObjectSchemaTest.php
+++ b/tests/php/ORM/DataObjectSchemaTest.php
@@ -324,6 +324,29 @@ class DataObjectSchemaTest extends SapphireTest
         $this->assertArrayNotHasKey('PolymorpheusClass', $indexes);
     }
 
+    public static function provideIndexCanBeDropped(): array
+    {
+        return [
+            [
+                'class' => AllIndexes::class,
+                'index' => 'Content',
+            ],
+            [
+                'class' => HasComposites::class,
+                'index' => 'Polymorpheus',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideIndexCanBeDropped')]
+    public function testIndexCanBeDropped(string $class, string $index): void
+    {
+        $class::config()->merge('indexes', [$index => false]);
+        $indexes = DataObject::getSchema()->databaseIndexes($class);
+        $this->assertArrayHasKey($index, $indexes);
+        $this->assertFalse($indexes[$index]);
+    }
+
     public function testCompositeFieldsCanBeIndexedByDefaultConfiguration()
     {
         Config::modify()->set(DBMoney::class, 'index', true);


### PR DESCRIPTION
Note that this is the _only_ way to get the ORM to automatically drop old indexes, it won't drop an index if you just remove it from `indexes` config.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/9901