### PR TITLE
NEW Create composite indexes for default sort.

### DIFF
--- a/src/ORM/Connect/DBSchemaManager.php
+++ b/src/ORM/Connect/DBSchemaManager.php
@@ -589,6 +589,30 @@ abstract class DBSchemaManager
     }
 
     /**
+     * Like implodeColumnList() but allows for a direction to come after the quoted column for some index types.
+     */
+    protected function implodeIndexColumnList(array $columns, string $indexType): string
+    {
+        if (empty($columns)) {
+            return '';
+        }
+        if (!in_array($indexType, ['index', 'unique'])) {
+            return $this->implodeColumnList($columns);
+        }
+        $result = [];
+        foreach ($columns as $col) {
+            if (preg_match('/^(.*) (asc|desc)$/i', $col ?? '', $matches)) {
+                $column = trim($matches[1] ?? '');
+                $direction = strtoupper($matches[2] ?? '');
+                $result[] = "\"$column\" $direction";
+            } else {
+                $result[] = "\"$col\" ASC";
+            }
+        }
+        return implode(',', $result);
+    }
+
+    /**
      * Given an index specification in the form of a string ensure that each
      * column name is property quoted, stripping brackets and modifiers.
      * This index may also be in the form of a "CREATE INDEX..." sql fragment
@@ -650,7 +674,7 @@ abstract class DBSchemaManager
         }
 
         // Combine elements into standard string format
-        return sprintf('%s (%s)', $indexSpec['type'], $this->implodeColumnList($indexSpec['columns']));
+        return sprintf('%s (%s)', $indexSpec['type'], $this->implodeIndexColumnList($indexSpec['columns'], $indexSpec['type']));
     }
 
     /**

--- a/src/ORM/Connect/MySQLSchemaManager.php
+++ b/src/ORM/Connect/MySQLSchemaManager.php
@@ -301,9 +301,9 @@ class MySQLSchemaManager extends DBSchemaManager
     protected function getIndexSqlDefinition($indexName, $indexSpec)
     {
         if ($indexSpec['type'] == 'using') {
-            return sprintf('index "%s" using (%s)', $indexName, $this->implodeColumnList($indexSpec['columns']));
+            return sprintf('index "%s" using (%s)', $indexName, $this->implodeIndexColumnList($indexSpec['columns'], $indexSpec['type']));
         } else {
-            return sprintf('%s "%s" (%s)', $indexSpec['type'], $indexName, $this->implodeColumnList($indexSpec['columns']));
+            return sprintf('%s "%s" (%s)', $indexSpec['type'], $indexName, $this->implodeIndexColumnList($indexSpec['columns'], $indexSpec['type']));
         }
     }
 
@@ -315,7 +315,7 @@ class MySQLSchemaManager extends DBSchemaManager
             $tableName,
             $indexSpec['type'],
             $indexName,
-            $this->implodeColumnList($indexSpec['columns'])
+            $this->implodeIndexColumnList($indexSpec['columns'], $indexSpec['type'])
         ));
     }
 
@@ -332,7 +332,14 @@ class MySQLSchemaManager extends DBSchemaManager
         $indexList = [];
 
         foreach ($indexes as $index) {
-            $groupedIndexes[$index['Key_name']]['fields'][$index['Seq_in_index']] = $index['Column_name'];
+            $column = $index['Column_name'];
+            if (isset($index['Collation']) && $index['Collation'] !== 'NULL') {
+                $column .= match ($index['Collation']) {
+                    'A' => ' ASC',
+                    'D' => ' DESC',
+                };
+            }
+            $groupedIndexes[$index['Key_name']]['fields'][$index['Seq_in_index']] = $column;
 
             if ($index['Index_type'] == 'FULLTEXT') {
                 $groupedIndexes[$index['Key_name']]['type'] = 'fulltext';

--- a/src/ORM/DataObject.php
+++ b/src/ORM/DataObject.php
@@ -4373,6 +4373,13 @@ class DataObject extends ModelData implements DataObjectInterface, i18nEntityPro
     private static $default_sort = null;
 
     /**
+     * Determines whether to create indexes for the columns in the default_sort configuration value,
+     * and how many to create.
+     * See the SORT_INDEX_MODE_* constants on DataObjectSchema for options.
+     */
+    private static string $default_sort_index_mode = DataObjectSchema::SORT_INDEX_MODE_BOTH;
+
+    /**
      * Default list of fields that can be scaffolded by the ModelAdmin
      * search interface.
      *

--- a/src/ORM/DataObjectSchema.php
+++ b/src/ORM/DataObjectSchema.php
@@ -31,6 +31,30 @@ class DataObjectSchema
     public const HAS_ONE_MULTI_RELATIONAL = 'multirelational';
 
     /**
+     * Do not create any index for sort columns.
+     * You can also set the value to `null` to get this mode.
+     * Only select this mode if you intend to create your own indexes which cover sorting.
+     */
+    public const string SORT_INDEX_MODE_NONE = 'none';
+
+    /**
+     * Create an index for each individual column in the sort order.
+     * Do not create a composite index.
+     */
+    public const string SORT_INDEX_MODE_SINGLE = 'single';
+
+    /**
+     * Create a composite index with all columns in the sort order.
+     * Do not create individual indexes for each column.
+     */
+    public const string SORT_INDEX_MODE_COMPOSITE = 'composite';
+
+    /**
+     * Create both a composite index and a single index for each column in the sort order.
+     */
+    public const string SORT_INDEX_MODE_BOTH = 'both';
+
+    /**
      * Default separate for table namespaces. Can be set to any string for
      * databases that do not support some characters.
      *
@@ -642,27 +666,66 @@ class DataObjectSchema
 
     protected function buildSortDatabaseIndexes($class)
     {
+        $indexMode = $this->getSortIndexMode($class);
+        if ($indexMode === DataObjectSchema::SORT_INDEX_MODE_NONE) {
+            return [];
+        }
+
+        $shouldAddToComposite = in_array($indexMode, [DataObjectSchema::SORT_INDEX_MODE_BOTH, DataObjectSchema::SORT_INDEX_MODE_COMPOSITE]);
+        $shouldAddToSingle = in_array($indexMode, [DataObjectSchema::SORT_INDEX_MODE_BOTH, DataObjectSchema::SORT_INDEX_MODE_SINGLE]);
         $sort = Config::inst()->get($class, 'default_sort', Config::UNINHERITED);
         $indexes = [];
 
         if ($sort && is_string($sort)) {
             $sort = preg_split('/,(?![^()]*+\\))/', $sort ?? '');
+            $compositeCols = [];
             foreach ($sort as $value) {
                 try {
-                    list ($table, $column) = $this->parseSortColumn(trim($value ?? ''));
+                    list ($table, $column, $dir) = $this->parseSortColumn(trim($value ?? ''));
                     $table = trim($table ?? '', '"');
                     $column = trim($column ?? '', '"');
+                    // Skip and stop grabbing composite columns if the sort column is on a different table
                     if ($table && strtolower($table ?? '') !== strtolower(DataObjectSchema::tableName($class) ?? '')) {
+                        $shouldAddToComposite = false;
                         continue;
                     }
-                    if ($this->databaseField($class, $column, false)) {
+                    // ID is always the primary key, so we don't need a new index for it.
+                    if ($column === 'ID') {
+                        if ($shouldAddToComposite) {
+                            // We still need to include it in the composite index if it's part-way through
+                            $compositeCols[$column] = "$column $dir";
+                        }
+                        continue;
+                    }
+                    // Skip and stop grabbing composite columns if this isn't a column in the database.
+                    if (!$this->databaseField($class, $column, false)) {
+                        $shouldAddToComposite = false;
+                        continue;
+                    }
+                    // Add indexes as appropriate
+                    if ($shouldAddToSingle) {
                         $indexes[$column] = [
                             'type' => 'index',
                             'columns' => [$column],
                         ];
                     }
+                    if ($shouldAddToComposite) {
+                        $compositeCols[$column] = "$column $dir";
+                    }
                 } catch (InvalidArgumentException $e) {
                 }
+            }
+
+            // If ID is last, we can omit it since that gets implicitly added to all indexes
+            if (array_key_last($compositeCols) === 'ID') {
+                unset($compositeCols['ID']);
+            }
+            // Add a composite index if we either didn't already add a single column or have multiple columns.
+            if (!empty($compositeCols) && (!$shouldAddToSingle || count($compositeCols) > 1)) {
+                $indexes['default_sort_composite'] = [
+                    'type' => 'index',
+                    'columns' => array_values($compositeCols),
+                ];
             }
         }
         return $indexes;
@@ -673,19 +736,16 @@ class DataObjectSchema
      *
      * @param string $column String to parse containing the column name
      *
-     * @return array Resolved table and column.
+     * @return array Resolved table, column, and direction.
      */
     protected function parseSortColumn($column)
     {
         // Parse column specification, considering possible ansi sql quoting
         // Note that table prefix is allowed, but discarded
-        if (preg_match('/^("?(?<table>[^"\s]+)"?\\.)?"?(?<column>[^"\s]+)"?(\s+(?<direction>((asc)|(desc))(ending)?))?$/i', $column ?? '', $match)) {
-            $table = $match['table'];
-            $column = $match['column'];
-        } else {
+        if (!preg_match('/^("?(?<table>[^"\s]+)"?\\.)?"?(?<column>[^"\s]+)"?(\s+(?<direction>asc|desc)(ending)?)?$/i', $column ?? '', $match)) {
             throw new InvalidArgumentException("Invalid sort() column");
         }
-        return [$table, $column];
+        return [$match['table'], $match['column'], $match['direction'] ?? 'ASC'];
     }
 
     /**
@@ -1328,5 +1388,23 @@ class DataObjectSchema
                 . " which is not a subclass of " . DataObject::class
             );
         }
+    }
+
+    /**
+     * Get the mode that determines which indexes to create for default_sort.
+     */
+    private function getSortIndexMode(string $class): string
+    {
+        $mode = Config::inst()->get($class, 'default_sort_index_mode') ?? DataObjectSchema::SORT_INDEX_MODE_NONE;
+        $allowedModes = [
+            DataObjectSchema::SORT_INDEX_MODE_NONE,
+            DataObjectSchema::SORT_INDEX_MODE_SINGLE,
+            DataObjectSchema::SORT_INDEX_MODE_COMPOSITE,
+            DataObjectSchema::SORT_INDEX_MODE_BOTH,
+        ];
+        if (!in_array($mode, $allowedModes)) {
+            throw new LogicException("Invalid value for $class.default_sort_index_mode: '$mode'");
+        }
+        return $mode;
     }
 }

--- a/tests/php/ORM/DataObjectSchemaGenerationTest.php
+++ b/tests/php/ORM/DataObjectSchemaGenerationTest.php
@@ -2,14 +2,16 @@
 
 namespace SilverStripe\ORM\Tests;
 
-use SilverStripe\Core\Config\Config;
+use PHPUnit\Framework\Attributes\DataProvider;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBEnum;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObjectSchema;
 use SilverStripe\ORM\Tests\DataObjectSchemaGenerationTest\SortedObject;
 use SilverStripe\ORM\Tests\DataObjectSchemaGenerationTest\TestIndexObject;
 use SilverStripe\ORM\Tests\DataObjectSchemaGenerationTest\TestObject;
+use SilverStripe\ORM\Tests\DataObjectSchemaTest\AllIndexes;
 
 class DataObjectSchemaGenerationTest extends SapphireTest
 {
@@ -17,6 +19,7 @@ class DataObjectSchemaGenerationTest extends SapphireTest
         TestObject::class,
         TestIndexObject::class,
         SortedObject::class,
+        AllIndexes::class,
     ];
 
     public static function setUpBeforeClass(): void
@@ -272,64 +275,265 @@ class DataObjectSchemaGenerationTest extends SapphireTest
         $item2->delete();
     }
 
-    public function testSortFieldBecomeIndexes()
+    public static function provideSortFieldBecomeIndexes(): array
     {
+        return [
+            'single field' => [
+                'defaultSort' => 'Sort',
+                'expectedIndexes' => [
+                    'Sort' => [
+                        'type' => 'index',
+                        'columns' => ['Sort'],
+                    ],
+                ],
+            ],
+            'single field with direction' => [
+                'defaultSort' => 'Sort ASC',
+                'expectedIndexes' => [
+                    'Sort' => [
+                        'type' => 'index',
+                        'columns' => ['Sort'],
+                    ],
+                ],
+            ],
+            'single field opposite direction' => [
+                'defaultSort' => 'Sort DESC',
+                'expectedIndexes' => [
+                    'Sort' => [
+                        'type' => 'index',
+                        'columns' => ['Sort'],
+                    ],
+                ],
+            ],
+            'single field quoted' => [
+                'defaultSort' => '"Sort" DESC',
+                'expectedIndexes' => [
+                    'Sort' => [
+                        'type' => 'index',
+                        'columns' => ['Sort'],
+                    ],
+                ],
+            ],
+            'single field with table name' => [
+                'defaultSort' => '"DataObjectSchemaGenerationTest_SortedObject"."Sort" ASC',
+                'expectedIndexes' => [
+                    'Sort' => [
+                        'type' => 'index',
+                        'columns' => ['Sort'],
+                    ],
+                ],
+            ],
+            'multiple fields' => [
+                'defaultSort' => 'Sort, Title',
+                'expectedIndexes' => [
+                    'Sort' => [
+                        'type' => 'index',
+                        'columns' => ['Sort'],
+                    ],
+                    'Title' => [
+                        'type' => 'index',
+                        'columns' => ['Title'],
+                    ],
+                    'default_sort_composite' => [
+                        'type' => 'index',
+                        'columns' => ['Sort ASC', 'Title ASC'],
+                    ],
+                ],
+            ],
+            'multiple fields with directions' => [
+                'defaultSort' => '"Sort" DESC, "Title" ASC',
+                'expectedIndexes' => [
+                    'Sort' => [
+                        'type' => 'index',
+                        'columns' => ['Sort'],
+                    ],
+                    'Title' => [
+                        'type' => 'index',
+                        'columns' => ['Title'],
+                    ],
+                    'default_sort_composite' => [
+                        'type' => 'index',
+                        'columns' => ['Sort DESC', 'Title ASC'],
+                    ],
+                ],
+            ],
+            'multiple fields, ID in middle' => [
+                'defaultSort' => '"Sort" DESC, ID, "Title" ASC',
+                'expectedIndexes' => [
+                    'Sort' => [
+                        'type' => 'index',
+                        'columns' => ['Sort'],
+                    ],
+                    'Title' => [
+                        'type' => 'index',
+                        'columns' => ['Title'],
+                    ],
+                    'default_sort_composite' => [
+                        'type' => 'index',
+                        'columns' => ['Sort DESC', 'ID ASC', 'Title ASC'],
+                    ],
+                ],
+            ],
+            'multiple fields, ID at end' => [
+                'defaultSort' => '"Sort" DESC, "Title" ASC, ID',
+                'expectedIndexes' => [
+                    'Sort' => [
+                        'type' => 'index',
+                        'columns' => ['Sort'],
+                    ],
+                    'Title' => [
+                        'type' => 'index',
+                        'columns' => ['Title'],
+                    ],
+                    'default_sort_composite' => [
+                        'type' => 'index',
+                        'columns' => ['Sort DESC', 'Title ASC'],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideSortFieldBecomeIndexes')]
+    public function testSortFieldBecomeIndexes(string $defaultSort, array $expectedIndexes): void
+    {
+        // Check the default index is what we expect and then reset to prep the test
         $indexes = DataObject::getSchema()->databaseIndexes(SortedObject::class);
         $this->assertContains([
             'type' => 'index',
             'columns' => ['Sort'],
         ], $indexes);
         DataObject::getSchema()->reset();
-        Config::inst()->set(SortedObject::class, 'default_sort', 'Sort ASC');
+
+        // Set the test sort value and check the indexes match expected values
+        SortedObject::config()->set('default_sort', $defaultSort);
+        $indexes = DataObject::getSchema()->databaseIndexes(SortedObject::class);
+        foreach ($expectedIndexes as $index => $spec) {
+            $this->assertArrayHasKey($index, $indexes);
+            $this->assertSame($spec, $indexes[$index]);
+        }
+    }
+
+    public static function provideSortFieldIndexMode(): array
+    {
+        return [
+            [
+                'mode' => DataObjectSchema::SORT_INDEX_MODE_NONE,
+                'expectedIndexes' => [
+                    'Sort' => null,
+                    'Title' => null,
+                    'default_sort_composite' => null,
+                ],
+            ],
+            [
+                'mode' => DataObjectSchema::SORT_INDEX_MODE_BOTH,
+                'expectedIndexes' => [
+                    'Sort' => [
+                        'type' => 'index',
+                        'columns' => ['Sort'],
+                    ],
+                    'Title' => [
+                        'type' => 'index',
+                        'columns' => ['Title'],
+                    ],
+                    'default_sort_composite' => [
+                        'type' => 'index',
+                        'columns' => ['Sort DESC', 'Title ASC'],
+                    ],
+                ],
+            ],
+            [
+                'mode' => DataObjectSchema::SORT_INDEX_MODE_COMPOSITE,
+                'expectedIndexes' => [
+                    'Sort' => null,
+                    'Title' => null,
+                    'default_sort_composite' => [
+                        'type' => 'index',
+                        'columns' => ['Sort DESC', 'Title ASC'],
+                    ],
+                ],
+            ],
+            [
+                'mode' => DataObjectSchema::SORT_INDEX_MODE_SINGLE,
+                'expectedIndexes' => [
+                    'Sort' => [
+                        'type' => 'index',
+                        'columns' => ['Sort'],
+                    ],
+                    'Title' => [
+                        'type' => 'index',
+                        'columns' => ['Title'],
+                    ],
+                    'default_sort_composite' => null,
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('provideSortFieldIndexMode')]
+    public function testSortFieldIndexMode(string $mode, array $expectedIndexes): void
+    {
+        // Check the default index is what we expect and then reset to prep the test
         $indexes = DataObject::getSchema()->databaseIndexes(SortedObject::class);
         $this->assertContains([
             'type' => 'index',
             'columns' => ['Sort'],
         ], $indexes);
         DataObject::getSchema()->reset();
-        Config::inst()->set(SortedObject::class, 'default_sort', 'Sort DESC');
+
+        // Set the test configuration and check the indexes match expected values
+        SortedObject::config()->set('default_sort', 'Sort DESC, Title');
+        SortedObject::config()->set('default_sort_index_mode', $mode);
+        $indexes = DataObject::getSchema()->databaseIndexes(SortedObject::class);
+        foreach ($expectedIndexes as $index => $spec) {
+            if ($spec === null) {
+                $this->assertArrayNotHasKey($index, $indexes);
+            } else {
+                $this->assertArrayHasKey($index, $indexes);
+                $this->assertSame($spec, $indexes[$index]);
+            }
+        }
+    }
+
+    public function testOverrideSortIndex(): void
+    {
+        // Check the default index is what we expect and then reset to prep the test
         $indexes = DataObject::getSchema()->databaseIndexes(SortedObject::class);
         $this->assertContains([
             'type' => 'index',
             'columns' => ['Sort'],
         ], $indexes);
         DataObject::getSchema()->reset();
-        Config::inst()->set(SortedObject::class, 'default_sort', '"Sort" DESC');
-        $indexes = DataObject::getSchema()->databaseIndexes(SortedObject::class);
-        $this->assertContains([
-            'type' => 'index',
-            'columns' => ['Sort'],
-        ], $indexes);
-        DataObject::getSchema()->reset();
-        Config::inst()->set(SortedObject::class, 'default_sort', '"DataObjectSchemaGenerationTest_SortedObject"."Sort" ASC');
-        $indexes = DataObject::getSchema()->databaseIndexes(SortedObject::class);
-        $this->assertContains([
-            'type' => 'index',
-            'columns' => ['Sort'],
-        ], $indexes);
-        DataObject::getSchema()->reset();
-        Config::inst()->set(SortedObject::class, 'default_sort', '"Sort" DESC, "Title" ASC');
-        $indexes = DataObject::getSchema()->databaseIndexes(SortedObject::class);
-        $this->assertContains([
-            'type' => 'index',
-            'columns' => ['Sort'],
-        ], $indexes);
-        $this->assertContains([
-            'type' => 'index',
-            'columns' => ['Title'],
-        ], $indexes);
-        DataObject::getSchema()->reset();
-        // make sure that specific indexes aren't overwritten
-        Config::inst()->merge(SortedObject::class, 'indexes', [
+
+        // Set the test index config and check the index matches expected values
+        SortedObject::config()->merge('indexes', [
             'Sort' => [
                 'type' => 'unique',
                 'columns' => ['Sort'],
             ],
         ]);
         $indexes = DataObject::getSchema()->databaseIndexes(SortedObject::class);
-        $this->assertContains([
+        $this->assertArrayHasKey('Sort', $indexes);
+        $this->assertSame([
             'type' => 'unique',
             'columns' => ['Sort'],
-        ], $indexes);
+        ], $indexes['Sort']);
+    }
+
+    public function testIndexesDirectionIsRespected(): void
+    {
+        $table = DataObject::getSchema()->tableName(AllIndexes::class);
+        $schema = [
+            'type' => 'index',
+            'columns' => ['Title DESC'],
+        ];
+        $indexSchema = DataObject::getSchema()->databaseIndexes(AllIndexes::class);
+        $this->assertEquals($schema, $indexSchema['IndexDesc']);
+
+        $schema['name'] = 'IndexDesc';
+        $actualSchema = DB::get_schema()->indexList($table);
+        // Use assertEqualsCanonicalizing because the order doesn't matter
+        // and the indexes in the `columns` array are different.
+        $this->assertEqualsCanonicalizing($schema, $actualSchema['IndexDesc']);
     }
 }

--- a/tests/php/ORM/DataObjectSchemaTest.php
+++ b/tests/php/ORM/DataObjectSchemaTest.php
@@ -35,7 +35,7 @@ class DataObjectSchemaTest extends SapphireTest
         BaseDataClass::class,
         ChildClass::class,
         GrandChildClass::class,
-        HasFields::Class,
+        HasFields::class,
         NoFields::class,
         WithCustomTable::class,
         WithRelation::class,
@@ -272,7 +272,7 @@ class DataObjectSchemaTest extends SapphireTest
     public function testDatabaseIndexes()
     {
         $indexes = DataObject::getSchema()->databaseIndexes(AllIndexes::class);
-        $this->assertCount(5, $indexes);
+        $this->assertCount(6, $indexes);
         $this->assertArrayHasKey('ClassName', $indexes);
         $this->assertEquals([
             'type' => 'index',
@@ -302,6 +302,12 @@ class DataObjectSchemaTest extends SapphireTest
             'type' => 'index',
             'columns' => ['Title'],
         ], $indexes['IndexNormal']);
+
+        $this->assertArrayHasKey('IndexDesc', $indexes);
+        $this->assertEquals([
+            'type' => 'index',
+            'columns' => ['Title DESC'],
+        ], $indexes['IndexDesc']);
     }
 
     public function testCompositeDatabaseFieldIndexes()
@@ -425,7 +431,6 @@ class DataObjectSchemaTest extends SapphireTest
     }
 
     #[DataProvider('provideHasOneComponent')]
-
     public function testHasOneComponent(string $class, string $component, string $expected): void
     {
         $this->assertSame($expected, DataObject::getSchema()->hasOneComponent($class, $component));

--- a/tests/php/ORM/DataObjectSchemaTest/AllIndexes.php
+++ b/tests/php/ORM/DataObjectSchemaTest/AllIndexes.php
@@ -30,5 +30,8 @@ class AllIndexes extends DataObject implements TestOnly
         'IndexNormal' => [
             'columns' => ['Title'],
         ],
+        'IndexDesc' => [
+            'columns' => ['Title DESC'],
+        ],
     ];
 }


### PR DESCRIPTION
Also adds explicitly directionality to indexes, and provides configuration options to choose whether indexes should be created for default sort columns or not.

## Why use a composite index?

_tl;dr: the database will have to do _some_ (if not all) manual sorting without it._

When sorting on multiple columns, if there is no composite index that covers all of those columns, the best the database will be able to do is pick an index of _one_ of the columns (usually the first column), and then manually sort after that. Sometimes (as with the example below) it won't even use a single column index for composite order.

To test this:

1. make sure you have around 100 records in the `Member` table (in my case I used the records created by silverstripe/frameworktest)
2. in the mysql CLI shell, run:

```mysql
DROP INDEX default_sort_composite ON Member;
```

_You can alternatively set `Member.default_sort_index_mode` to 'single' but you'll need to drop your db or have a fresh installation - Silverstripe CMS won't drop the index for you if you already built it_

3. Then run:

```mysql
EXPLAIN SELECT * FROM Member ORDER BY Surname, FirstName LIMIT 10;
```

```text
+------+-------------+--------+------+---------------+------+---------+------+------+----------------+
| id   | select_type | table  | type | possible_keys | key  | key_len | ref  | rows | Extra          |
+------+-------------+--------+------+---------------+------+---------+------+------+----------------+
|    1 | SIMPLE      | Member | ALL  | NULL          | NULL | NULL    | NULL | 93   | Using filesort |
+------+-------------+--------+------+---------------+------+---------+------+------+----------------+
```

Note that in this case the database chose to not use _any_ index, and just used filesort for everything. In some cases it might choose to use the `Surname` index if it thinks that will be faster. But that's still worse than using a composite index which covers the whole sort operation.

## Why keep individual indexes?

_tl;dr: They may improve performance for specific queries, and they're already there._

With arguable exception of the first column in the composite index (see https://github.com/silverstripe/silverstripe-framework/pull/11747#discussion_r2115040448), the individual column indexes may be useful in queries that don't use the default sort (e.g. sorting by column in a gridfield), or may be chosen over the composite key for highly selective queries (filtering by `WHERE FirstName = <some-value>`).

Because of that, and because those indexes were already being created, I think it's best to keep those indexes there by default - but provide configuration to opt-out of them for those who are fine-tuning their indexes.

Note that even with the new `default_sort_index_mode` configuration set to 'none' or 'composite', the existing indexes _will not be automatically removed_ by Silverstripe CMS, and this PR _will not change that_. https://github.com/silverstripe/silverstripe-framework/issues/9901 will provide a way to explicitly drop specifically named indexes, though if there is a desire to automatically drop indexes that wouldn't be created if the table was new, a separate issue should be created to discuss that.

## Why add directionality?

_tl;dr: Without it, the index won't be used or will only be partially used if directions differ between more than one column in the sort order._

Directionality is important with composite indexes which are used for sorting.
Consider for example the default sort `Surname ASC, FirstName DESC`.

If the index was just using the default `ASC` order for both columns, it could only use half the index, or may not use the index at all.

To test this:
1. make sure you have around 100 records in the `Member` table (in my case I used the records created by silverstripe/frameworktest)
4. add the following YAML
5. do a `db:build`

```yaml
SilverStripe\Security\Member:
  default_sort: 'Surname ASC, FirstName DESC'
```

6. Then in the `mysql` CLI shell, run:

```mysql
EXPLAIN SELECT * FROM Member ORDER BY Surname ASC, FirstName DESC LIMIT 10;
```

```text
+------+-------------+--------+-------+---------------+------------------------+---------+------+------+-------+
| id   | select_type | table  | type  | possible_keys | key                    | key_len | ref  | rows | Extra |
+------+-------------+--------+-------+---------------+------------------------+---------+------+------+-------+
|    1 | SIMPLE      | Member | index | NULL          | default_sort_composite | 2046    | NULL | 10   |       |
+------+-------------+--------+-------+---------------+------------------------+---------+------+------+-------+
```

_I'm using MariaDB so your output may differ slightly._

7. Then run this - note the only change is the order of the second column in the sort:

```mysql
EXPLAIN SELECT * FROM Member ORDER BY Surname ASC, FirstName ASC LIMIT 10;
```

```text
+------+-------------+--------+------+---------------+------+---------+------+------+----------------+
| id   | select_type | table  | type | possible_keys | key  | key_len | ref  | rows | Extra          |
+------+-------------+--------+------+---------------+------+---------+------+------+----------------+
|    1 | SIMPLE      | Member | ALL  | NULL          | NULL | NULL    | NULL | 93   | Using filesort |
+------+-------------+--------+------+---------------+------+---------+------+------+----------------+
```

Note that it isn't using an index (nothing under `key`), had to traverse the whole table (`rows` is 93 (the whole table) instead of 10), and used filesort since it wasn't using the index to sort.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11674