### PR TITLE
FIX Don't query to check case sensitivity more than once.

### DIFF
--- a/src/ORM/Filters/SearchFilter.php
+++ b/src/ORM/Filters/SearchFilter.php
@@ -488,7 +488,7 @@ abstract class SearchFilter
      */
     protected function getCaseSensitiveByCollation(): ?bool
     {
-        if (!SearchFilter::$caseSensitiveByCollation) {
+        if (SearchFilter::$caseSensitiveByCollation === null) {
             if (!DB::is_active()) {
                 return null;
             }


### PR DESCRIPTION
Found this while looking into our indexes - found this was being called multiple times - sometimes thousands of times in a single request.

It probably shouldn't be called that many times but I'll look into what was causing that separately.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11763