### PR TITLE
ENH Improve indexes for permission codes

### DIFF
--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -37,7 +37,10 @@ class Permission extends DataObject implements TemplateGlobalProvider, Resettabl
     ];
 
     private static $indexes = [
-        "Code" => true
+        'Code_GroupID' => [
+            'Code',
+            'GroupID',
+        ],
     ];
 
     private static $defaults = [

--- a/src/Security/PermissionRoleCode.php
+++ b/src/Security/PermissionRoleCode.php
@@ -28,9 +28,12 @@ class PermissionRoleCode extends DataObject
     private static bool $must_use_primary_db = true;
 
     private static bool $require_sudo_mode = true;
-    
+
     private static $indexes = [
-        "Code" => true,
+        'Code_RoleID' => [
+            'Code',
+            'RoleID',
+        ],
     ];
 
     public function validate(): ValidationResult


### PR DESCRIPTION
Very small improvement here. These are small tables so it won't really affect much I don't think - but at least on paper it's an improvement. There's queries that select `Code` and join or filter by the relation - so having those both in the same index means we can cover the whole query with a single index.

Anything that only needs the `Code` portion will still be able to use the index for that, so there's no need to keep the original single-column index.

## Issue

- https://github.com/silverstripe/.github/issues/415