### PR TITLE
FIX Update dataclass when setting dataquery into datalist

### DIFF
--- a/src/ORM/DataList.php
+++ b/src/ORM/DataList.php
@@ -199,6 +199,7 @@ class DataList extends ViewableData implements SS_List, Filterable, Sortable, Li
     {
         $clone = clone $this;
         $clone->dataQuery = $dataQuery;
+        $clone->dataClass = $dataQuery->dataClass();
         return $clone;
     }
 

--- a/tests/php/ORM/DataListTest.php
+++ b/tests/php/ORM/DataListTest.php
@@ -180,6 +180,22 @@ class DataListTest extends SapphireTest
         $teamsComments->subtract($teams);
     }
 
+    public function testSetDataQuery(): void
+    {
+        $list = Team::get();
+        $numTeams = $list->count();
+        $numTeamComments = TeamComment::get()->count();
+        $this->assertNotSame($numTeams, $numTeamComments, 'If these are the same, we need to update the test');
+
+        $newList = $list->setDataQuery(new DataQuery(TeamComment::class));
+        // Original list unaffected
+        $this->assertNotSame($list, $newList);
+        $this->assertSame(Team::class, $list->dataClass());
+        // New list is using the new data query
+        $this->assertSame(TeamComment::class, $newList->dataClass());
+        $this->assertSame($numTeamComments, $newList->count());
+    }
+
     public function testListCreationSortAndLimit()
     {
         // By default, a DataList will contain all items of that class


### PR DESCRIPTION
Without this fix, you get into weird situations where the underlying data is for one class, but gets populated into objects instantiated from a different class.

When caching is added (see linked issue) the problem will be exacerbated.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767